### PR TITLE
fix(server): validate compact handoff emission

### DIFF
--- a/packages/adapter-utils/src/types.ts
+++ b/packages/adapter-utils/src/types.ts
@@ -77,6 +77,12 @@ export interface AdapterExecutionResult {
   errorMeta?: Record<string, unknown>;
   usage?: UsageSummary;
   /**
+   * Optional adapter-specific run-shape telemetry (turn/tool counts, resident
+   * window). Persisted flat into the run's usageJson. Adapter-neutral so any
+   * adapter may populate it; absent when an adapter does not emit it.
+   */
+  usageTelemetry?: Record<string, unknown> | null;
+  /**
    * Legacy single session id output. Prefer `sessionParams` + `sessionDisplayId`.
    */
   sessionId?: string | null;

--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -831,6 +831,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         errorMessage: `Timed out after ${timeoutSec}s`,
         errorCode: "timeout",
         errorMeta,
+        usageTelemetry: parsedStream.telemetry,
         clearSession: Boolean(opts.clearSessionOnMissingSession),
       };
     }
@@ -868,6 +869,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         errorFamily: transientUpstream ? "transient_upstream" : null,
         retryNotBefore: transientRetryNotBefore ? transientRetryNotBefore.toISOString() : null,
         errorMeta,
+        usageTelemetry: parsedStream.telemetry,
         resultJson: {
           stdout: proc.stdout,
           stderr: proc.stderr,
@@ -986,6 +988,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       retryNotBefore: transientRetryNotBefore ? transientRetryNotBefore.toISOString() : null,
       errorMeta,
       usage,
+      usageTelemetry: parsedStream.telemetry,
       sessionId: resolvedSessionId,
       sessionParams: resolvedSessionParams,
       sessionDisplayId: resolvedSessionId,

--- a/packages/adapters/claude-local/src/server/parse.test.ts
+++ b/packages/adapters/claude-local/src/server/parse.test.ts
@@ -1,11 +1,13 @@
 import { describe, expect, it } from "vitest";
 import {
+  CLAUDE_USAGE_FORMULA_VERSION,
   extractClaudeRetryNotBefore,
   isClaudeTransientUpstreamError,
   isClaudePoisonedPreviousMessageIdError,
   isClaudeRefusalResult,
   isClaudeUnknownSessionError,
   isClaudeImageProcessingError,
+  parseClaudeStreamJson,
 } from "./parse.js";
 
 describe("isClaudeTransientUpstreamError", () => {
@@ -303,5 +305,132 @@ describe("extractClaudeRetryNotBefore", () => {
     expect(
       extractClaudeRetryNotBefore({ errorMessage: "Overloaded. Try again later." }, new Date()),
     ).toBeNull();
+  });
+});
+
+describe("parseClaudeStreamJson telemetry", () => {
+  const initLine = JSON.stringify({
+    type: "system",
+    subtype: "init",
+    session_id: "sess-telemetry",
+    model: "claude-opus-4-8",
+  });
+
+  const assistantLine = (
+    content: Array<Record<string, unknown>>,
+    usage: Record<string, number>,
+  ) =>
+    JSON.stringify({
+      type: "assistant",
+      session_id: "sess-telemetry",
+      message: { role: "assistant", content, usage },
+    });
+
+  const textBlock = (text: string) => ({ type: "text", text });
+  const toolBlock = (name: string) => ({ type: "tool_use", id: `tool-${name}`, name, input: {} });
+
+  it("derives turn, tool-call, tool-less, ratio, and resident-window fields from the stream", () => {
+    // 4 assistant turns; turns 1 and 3 are text-only (tool-less), turns 2 and 4
+    // call tools (2 + 1 = 3 tool calls). Per-turn resident window is
+    // input + cache_creation + cache_read; the peak is turn 3 at 160001.
+    const stdout = [
+      initLine,
+      assistantLine([textBlock("thinking out loud")], {
+        input_tokens: 10,
+        cache_creation_input_tokens: 5,
+        cache_read_input_tokens: 100,
+      }),
+      assistantLine([textBlock("reading"), toolBlock("Read"), toolBlock("Grep")], {
+        input_tokens: 2,
+        cache_creation_input_tokens: 0,
+        cache_read_input_tokens: 50000,
+      }),
+      assistantLine([textBlock("still narrating, no action")], {
+        input_tokens: 1,
+        cache_creation_input_tokens: 0,
+        cache_read_input_tokens: 160000,
+      }),
+      assistantLine([toolBlock("Edit")], {
+        input_tokens: 3,
+        cache_creation_input_tokens: 800,
+        cache_read_input_tokens: 120000,
+      }),
+      JSON.stringify({
+        type: "result",
+        subtype: "success",
+        is_error: false,
+        session_id: "sess-telemetry",
+        result: "done",
+        total_cost_usd: 0.42,
+        usage: {
+          input_tokens: 16,
+          cache_read_input_tokens: 330100,
+          output_tokens: 900,
+        },
+      }),
+    ].join("\n");
+
+    const parsed = parseClaudeStreamJson(stdout);
+
+    expect(parsed.telemetry).toEqual({
+      turnCount: 4,
+      toolCallCount: 3,
+      toolLessTurnCount: 2,
+      toolLessTurnRatio: 0.5,
+      residentWindowTokens: 160001,
+      usageFormulaVersion: CLAUDE_USAGE_FORMULA_VERSION,
+    });
+
+    // Existing usage/session semantics are preserved alongside telemetry.
+    expect(parsed.usage).toEqual({
+      inputTokens: 16,
+      cachedInputTokens: 330100,
+      outputTokens: 900,
+    });
+    expect(parsed.costUsd).toBe(0.42);
+    expect(parsed.sessionId).toBe("sess-telemetry");
+    expect(parsed.model).toBe("claude-opus-4-8");
+  });
+
+  it("reports telemetry for a result-less (timed-out mid-stream) run while usage stays null", () => {
+    const stdout = [
+      initLine,
+      assistantLine([toolBlock("Read")], {
+        input_tokens: 5,
+        cache_creation_input_tokens: 0,
+        cache_read_input_tokens: 40000,
+      }),
+      assistantLine([textBlock("narrating without acting")], {
+        input_tokens: 2,
+        cache_creation_input_tokens: 0,
+        cache_read_input_tokens: 80000,
+      }),
+    ].join("\n");
+
+    const parsed = parseClaudeStreamJson(stdout);
+
+    expect(parsed.usage).toBeNull();
+    expect(parsed.resultJson).toBeNull();
+    expect(parsed.telemetry).toEqual({
+      turnCount: 2,
+      toolCallCount: 1,
+      toolLessTurnCount: 1,
+      toolLessTurnRatio: 0.5,
+      residentWindowTokens: 80002,
+      usageFormulaVersion: CLAUDE_USAGE_FORMULA_VERSION,
+    });
+  });
+
+  it("defaults ratio and resident window to zero when there are no assistant turns", () => {
+    const parsed = parseClaudeStreamJson("");
+
+    expect(parsed.telemetry).toEqual({
+      turnCount: 0,
+      toolCallCount: 0,
+      toolLessTurnCount: 0,
+      toolLessTurnRatio: 0,
+      residentWindowTokens: 0,
+      usageFormulaVersion: CLAUDE_USAGE_FORMULA_VERSION,
+    });
   });
 });

--- a/packages/adapters/claude-local/src/server/parse.ts
+++ b/packages/adapters/claude-local/src/server/parse.ts
@@ -14,11 +14,34 @@ const CLAUDE_TRANSIENT_UPSTREAM_RE =
 const CLAUDE_EXTRA_USAGE_RESET_RE =
   /(?:out\s+of\s+extra\s+usage|extra\s+usage|usage\s+limit\s+reached|usage\s+cap\s+reached|5[-\s]?hour\s+limit\s+reached|weekly\s+limit\s+reached|claude\s+usage\s+limit\s+reached)[\s\S]{0,80}?\bresets?\s+(?:at\s+)?([^\n()]+?)(?:\s*\(([^)]+)\))?(?:[.!]|\n|$)/i;
 
+// Bump when the run-shape telemetry derivation changes.
+export const CLAUDE_USAGE_FORMULA_VERSION = "claude_local.telemetry.v1";
+
+// Per-wake run-shape metrics from the Claude CLI stream (session lifecycle, not
+// billing totals); the trigger inputs for Phase 2 session rotation. A type alias
+// (not interface) for an implicit index signature so it stays assignable to the
+// adapter-neutral usageTelemetry: Record<string, unknown>.
+export type ClaudeRunTelemetry = {
+  turnCount: number;
+  toolCallCount: number;
+  toolLessTurnCount: number;
+  toolLessTurnRatio: number;
+  // Peak single-turn context window: max over turns of
+  // input_tokens + cache_creation_input_tokens + cache_read_input_tokens.
+  residentWindowTokens: number;
+  usageFormulaVersion: string;
+};
+
 export function parseClaudeStreamJson(stdout: string) {
   let sessionId: string | null = null;
   let model = "";
   let finalResult: Record<string, unknown> | null = null;
   const assistantTexts: string[] = [];
+
+  let turnCount = 0;
+  let toolCallCount = 0;
+  let toolLessTurnCount = 0;
+  let residentWindowTokens = 0;
 
   for (const rawLine of stdout.split(/\r?\n/)) {
     const line = rawLine.trim();
@@ -37,14 +60,27 @@ export function parseClaudeStreamJson(stdout: string) {
       sessionId = asString(event.session_id, sessionId ?? "") || sessionId;
       const message = parseObject(event.message);
       const content = Array.isArray(message.content) ? message.content : [];
+      turnCount += 1;
+      let turnToolCalls = 0;
       for (const entry of content) {
         if (typeof entry !== "object" || entry === null || Array.isArray(entry)) continue;
         const block = entry as Record<string, unknown>;
-        if (asString(block.type, "") === "text") {
+        const blockType = asString(block.type, "");
+        if (blockType === "text") {
           const text = asString(block.text, "");
           if (text) assistantTexts.push(text);
+        } else if (blockType === "tool_use") {
+          turnToolCalls += 1;
         }
       }
+      toolCallCount += turnToolCalls;
+      if (turnToolCalls === 0) toolLessTurnCount += 1;
+      const turnUsage = parseObject(message.usage);
+      const residentForTurn =
+        asNumber(turnUsage.input_tokens, 0) +
+        asNumber(turnUsage.cache_creation_input_tokens, 0) +
+        asNumber(turnUsage.cache_read_input_tokens, 0);
+      if (residentForTurn > residentWindowTokens) residentWindowTokens = residentForTurn;
       continue;
     }
 
@@ -54,6 +90,15 @@ export function parseClaudeStreamJson(stdout: string) {
     }
   }
 
+  const telemetry: ClaudeRunTelemetry = {
+    turnCount,
+    toolCallCount,
+    toolLessTurnCount,
+    toolLessTurnRatio: turnCount > 0 ? toolLessTurnCount / turnCount : 0,
+    residentWindowTokens,
+    usageFormulaVersion: CLAUDE_USAGE_FORMULA_VERSION,
+  };
+
   if (!finalResult) {
     return {
       sessionId,
@@ -62,6 +107,7 @@ export function parseClaudeStreamJson(stdout: string) {
       usage: null as UsageSummary | null,
       summary: assistantTexts.join("\n\n").trim(),
       resultJson: null as Record<string, unknown> | null,
+      telemetry,
     };
   }
 
@@ -82,6 +128,7 @@ export function parseClaudeStreamJson(stdout: string) {
     usage,
     summary,
     resultJson: finalResult,
+    telemetry,
   };
 }
 

--- a/packages/adapters/claude-local/src/server/prompt-cache.ts
+++ b/packages/adapters/claude-local/src/server/prompt-cache.ts
@@ -5,6 +5,7 @@ import { createHash, type Hash } from "node:crypto";
 import type { AdapterExecutionContext } from "@paperclipai/adapter-utils";
 import {
   ensurePaperclipSkillSymlink,
+  materializePaperclipSkillCopy,
   resolvePaperclipInstanceRootForAdapter,
   type PaperclipSkillEntry,
 } from "@paperclipai/adapter-utils/server-utils";
@@ -151,10 +152,14 @@ export async function prepareClaudePromptBundle(input: {
     try {
       await ensurePaperclipSkillSymlink(entry.source, target);
     } catch (err) {
-      await onLog(
-        "stderr",
-        `[paperclip] Failed to materialize Claude skill "${entry.key}" into ${skillsHome}: ${err instanceof Error ? err.message : String(err)}\n`,
-      );
+      try {
+        await materializePaperclipSkillCopy(entry.source, target);
+      } catch (copyErr) {
+        await onLog(
+          "stderr",
+          `[paperclip] Failed to materialize Claude skill "${entry.key}" into ${skillsHome}: symlink=${err instanceof Error ? err.message : String(err)}; copy=${copyErr instanceof Error ? copyErr.message : String(copyErr)}\n`,
+        );
+      }
     }
   }
 

--- a/packages/adapters/codex-local/src/server/codex-home.ts
+++ b/packages/adapters/codex-local/src/server/codex-home.ts
@@ -137,6 +137,10 @@ async function createExpectedSymlink(target: string, source: string): Promise<vo
   } catch (error) {
     const code = (error as NodeJS.ErrnoException).code;
     if (code === "EEXIST" && await isExpectedSymlink(target, source)) return;
+    if (code === "EPERM" || code === "EACCES") {
+      await fs.copyFile(source, target);
+      return;
+    }
     throw error;
   }
 }

--- a/packages/db/src/migrations/0111_project_issue_prefix.sql
+++ b/packages/db/src/migrations/0111_project_issue_prefix.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "projects" ADD COLUMN IF NOT EXISTS "issue_prefix" text;
+--> statement-breakpoint
+UPDATE "projects" SET "issue_prefix" = 'PB' WHERE "id" = 'f7700e35-69aa-4d95-adb0-e0af91ed5aa2' AND "issue_prefix" IS NULL;

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -778,6 +778,13 @@
       "when": 1781902400000,
       "tag": "0110_document_company_cascade",
       "breakpoints": true
+    },
+    {
+      "idx": 111,
+      "version": "7",
+      "when": 1781902500000,
+      "tag": "0111_project_issue_prefix",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/projects.ts
+++ b/packages/db/src/schema/projects.ts
@@ -12,6 +12,7 @@ export const projects = pgTable(
     goalId: uuid("goal_id").references(() => goals.id),
     name: text("name").notNull(),
     description: text("description"),
+    issuePrefix: text("issue_prefix"),
     status: text("status").notNull().default("backlog"),
     leadAgentId: uuid("lead_agent_id").references(() => agents.id),
     targetDate: date("target_date"),

--- a/scripts/ensure-workspace-package-links.ts
+++ b/scripts/ensure-workspace-package-links.ts
@@ -101,7 +101,7 @@ async function ensureWorkspaceLinksCurrent(workspaceDir: string) {
     const linkPath = path.join(repoRoot, mismatch.workspaceDir, "node_modules", ...mismatch.packageName.split("/"));
     await fs.mkdir(path.dirname(linkPath), { recursive: true });
     await fs.rm(linkPath, { recursive: true, force: true });
-    await fs.symlink(mismatch.expectedPath, linkPath);
+    await fs.symlink(mismatch.expectedPath, linkPath, process.platform === "win32" ? "junction" : "dir");
   }
 
   const remainingMismatches = findWorkspaceLinkMismatches(workspaceDir);

--- a/server/src/__tests__/compact-working-state-builder.test.ts
+++ b/server/src/__tests__/compact-working-state-builder.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from "vitest";
+import { buildCompactWorkingStatePacket, isStaleCompactWorkingStatePacket } from "../services/compact-working-state.js";
+
+function validSameRoleCompactPacket(overrides: Record<string, unknown> = {}) {
+  return {
+    sourceRunId: "92a19da5-0000-0000-0000-000000000000",
+    sourceSessionId: "4bb94f0e",
+    acceptance: [
+      {
+        id: "AC1",
+        text: "Resident-window telemetry is persisted on heartbeat runs.",
+        status: "pending",
+        assertedBy: "agent",
+        verified: false,
+        evidence: [],
+      },
+    ],
+    changes: { files: [], commits: [] },
+    tests: { written: [], runs: [] },
+    requiredHandoff: { required: false, to: null, status: "in_progress", reason: null },
+    artifacts: [{ kind: "run_log", ref: "paperclip:run:92a19da5:log" }],
+    rawTranscriptRefs: [{ ref: "paperclip:run:92a19da5:transcript", replayByDefault: false }],
+    ...overrides,
+  };
+}
+
+function validBuilderInput(overrides: Record<string, unknown> = {}) {
+  const packet = validSameRoleCompactPacket();
+  return {
+    issue: {
+      identifier: "PB-81",
+      id: "8b5a9a0b-0000-0000-0000-000000000000",
+      objective: "Implement the scoped fix for PB-81.",
+    },
+    currentRun: { id: "92a19da5-0000-0000-0000-000000000000" },
+    persistedSession: { id: "4bb94f0e" },
+    currentAgent: { role: "engineer", name: "pipeline-engineer" },
+    stage: "implementation",
+    selfReport: {
+      from: "engineer",
+      to: "engineer",
+      workingNotes: "Current approach: keep the change scoped to telemetry parsing.",
+      acceptance: packet.acceptance,
+      tests: packet.tests,
+      blocker: null,
+      requiredHandoff: packet.requiredHandoff,
+      next: "Continue implementation from the listed working notes and acceptance state.",
+    },
+    observedChanges: packet.changes,
+    artifacts: packet.artifacts,
+    rawTranscriptRefs: packet.rawTranscriptRefs,
+    ...overrides,
+  };
+}
+
+describe("compact working-state builder provenance", () => {
+  it("[BLIND] derives same-role from/to from the current agent role, not self-report", () => {
+    const packet = buildCompactWorkingStatePacket(validBuilderInput({
+      currentAgent: { role: "engineer", name: "pipeline-engineer" },
+      selfReport: {
+        ...(validBuilderInput().selfReport as Record<string, unknown>),
+        from: "planner",
+        to: "planner",
+      },
+    }));
+
+    expect(packet.from).toBe("engineer");
+    expect(packet.to).toBe("engineer");
+  });
+
+  it("[BLIND] does not derive continuation role from agent.name", () => {
+    const packet = buildCompactWorkingStatePacket(validBuilderInput({
+      currentAgent: { role: "code-reviewer", name: "engineer" },
+      selfReport: {
+        ...(validBuilderInput().selfReport as Record<string, unknown>),
+        from: "engineer",
+        to: "engineer",
+      },
+    }));
+
+    expect(packet.from).toBe("code-reviewer");
+    expect(packet.to).toBe("code-reviewer");
+  });
+
+  it("[BLIND] builds sourceSessionId from the persisted session identity Paperclip would resume", () => {
+    const packet = buildCompactWorkingStatePacket(validBuilderInput({
+      persistedSession: { id: "persisted-session-42" },
+      artifacts: [{ kind: "run_log", ref: "paperclip:run:artifact-session-99:log" }],
+    }));
+
+    expect(packet.sourceSessionId).toBe("persisted-session-42");
+  });
+
+  it("[BLIND] stale checks compare first-class run and session ids, not artifact refs", () => {
+    const packet = validSameRoleCompactPacket({
+      sourceRunId: "run-a",
+      sourceSessionId: "session-a",
+      artifacts: [{ kind: "run_log", ref: "paperclip:run:different-run:log" }],
+    });
+
+    expect(isStaleCompactWorkingStatePacket(packet, {
+      sourceRunId: "run-a",
+      sourceSessionId: "session-a",
+    })).toBe(false);
+    expect(isStaleCompactWorkingStatePacket(packet, {
+      sourceRunId: "run-a",
+      sourceSessionId: "session-b",
+    })).toBe(true);
+  });
+
+  it("[BLIND] lets the builder reject empty workingNotes for an in-flight state that requires notes", () => {
+    expect(() => buildCompactWorkingStatePacket(validBuilderInput({
+      requireWorkingNotes: true,
+      selfReport: {
+        ...(validBuilderInput().selfReport as Record<string, unknown>),
+        workingNotes: "",
+      },
+    }))).toThrow(/workingNotes|self-report/i);
+  });
+
+  it("[BLIND] fails build when semantic self-report is missing and no machine source derives it", () => {
+    const missingNotes = validBuilderInput();
+    delete (missingNotes.selfReport as Record<string, unknown>).workingNotes;
+    expect(() => buildCompactWorkingStatePacket(missingNotes)).toThrow(/workingNotes|self-report/i);
+
+    const missingStage = validBuilderInput({ stage: undefined });
+    delete (missingStage.selfReport as Record<string, unknown>).stage;
+    expect(() => buildCompactWorkingStatePacket(missingStage)).toThrow(/stage|self-report/i);
+  });
+});

--- a/server/src/__tests__/compact-working-state-builder.test.ts
+++ b/server/src/__tests__/compact-working-state-builder.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { buildCompactWorkingStatePacket, isStaleCompactWorkingStatePacket } from "../services/compact-working-state.js";
+import {
+  buildCompactWorkingStatePacket,
+  isStaleCompactWorkingStatePacket,
+  validateCompactWorkingStatePacket,
+} from "../services/compact-working-state.js";
 
 function validSameRoleCompactPacket(overrides: Record<string, unknown> = {}) {
   return {
@@ -54,6 +58,21 @@ function validBuilderInput(overrides: Record<string, unknown> = {}) {
 }
 
 describe("compact working-state builder provenance", () => {
+  it("[BLIND] validates the shared compact working-state fixture corpus", async () => {
+    const { compactWorkingStateFixtureCorpus } = await import(
+      "../../../../pipeline-v2/compact-working-state.fixtures.mjs"
+    );
+
+    for (const fixture of compactWorkingStateFixtureCorpus) {
+      const packet = fixture.build();
+      if (fixture.valid) {
+        expect(() => validateCompactWorkingStatePacket(packet)).not.toThrow();
+      } else {
+        expect(() => validateCompactWorkingStatePacket(packet)).toThrow();
+      }
+    }
+  });
+
   it("[BLIND] derives same-role from/to from the current agent role, not self-report", () => {
     const packet = buildCompactWorkingStatePacket(validBuilderInput({
       currentAgent: { role: "engineer", name: "pipeline-engineer" },

--- a/server/src/__tests__/compact-working-state-handoff-markdown.test.ts
+++ b/server/src/__tests__/compact-working-state-handoff-markdown.test.ts
@@ -21,6 +21,7 @@ function validHandoffInput(overrides: Record<string, unknown> = {}) {
         {
           path: "server/src/__tests__/compact-working-state-handoff-markdown.test.ts",
           kind: "unit",
+          status: "added",
           verified: false,
           evidence: [],
         },
@@ -47,7 +48,7 @@ function validHandoffInput(overrides: Record<string, unknown> = {}) {
       files: [
         {
           path: "server/src/services/compact-working-state.ts",
-          status: "pending",
+          status: "modified",
           verified: false,
           evidence: [],
         },
@@ -116,5 +117,72 @@ describe("compact working-state handoff markdown", () => {
 
     const packet = parseSingleHandoffPacket(markdown as string);
     expect(packet.packetKind).toBe("compact_working_state");
+  });
+
+  it("[BLIND] rejects packet shapes that violate the compact working-state contract", () => {
+    expect(() => buildCompactWorkingStateHandoffMarkdown(validHandoffInput({
+      observedChanges: {
+        files: [
+          {
+            path: "server/src/services/compact-working-state.ts",
+            status: "pending",
+            verified: false,
+            evidence: [],
+          },
+        ],
+        commits: [],
+      },
+    }))).toThrow(/changes\.files\[0\]\.status/);
+
+    expect(() => buildCompactWorkingStateHandoffMarkdown(validHandoffInput({
+      selfReport: {
+        ...(validHandoffInput().selfReport as Record<string, unknown>),
+        tests: {
+          written: [
+            {
+              path: "server/src/__tests__/compact-working-state-handoff-markdown.test.ts",
+              kind: "unit",
+              verified: false,
+              evidence: [],
+            },
+          ],
+          runs: [],
+        },
+      },
+    }))).toThrow(/tests\.written\[0\]\.status/);
+
+    expect(() => buildCompactWorkingStateHandoffMarkdown(validHandoffInput({
+      selfReport: {
+        ...(validHandoffInput().selfReport as Record<string, unknown>),
+        acceptance: [
+          {
+            id: "AC1",
+            text: "Fresh-session wakes receive a compact working-state handoff.",
+            status: "verified_passed",
+            assertedBy: "agent",
+            verified: false,
+            evidence: [{ kind: "test_command", ref: "paperclip:run:run-machine-id:event:1", verified: true }],
+          },
+        ],
+      },
+    }))).toThrow(/acceptance\[0\]\.verified/);
+
+    expect(() => buildCompactWorkingStateHandoffMarkdown(validHandoffInput({
+      selfReport: {
+        ...(validHandoffInput().selfReport as Record<string, unknown>),
+        tests: {
+          written: [],
+          runs: [
+            {
+              command: "pnpm test",
+              result: "verified_passed",
+              assertedBy: "agent",
+              verified: false,
+              evidence: [{ kind: "test_command", ref: "paperclip:run:run-machine-id:event:1", verified: true }],
+            },
+          ],
+        },
+      },
+    }))).toThrow(/tests\.runs\[0\]\.verified/);
   });
 });

--- a/server/src/__tests__/compact-working-state-handoff-markdown.test.ts
+++ b/server/src/__tests__/compact-working-state-handoff-markdown.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest";
+import { buildCompactWorkingStateHandoffMarkdown } from "../services/compact-working-state.js";
+
+function validHandoffInput(overrides: Record<string, unknown> = {}) {
+  const selfReport = {
+    stage: "implementation",
+    status: "in_progress",
+    workingNotes: "Tests are authored; production emission is not implemented yet.",
+    acceptance: [
+      {
+        id: "AC1",
+        text: "Fresh-session wakes receive a compact working-state handoff.",
+        status: "pending",
+        assertedBy: "agent",
+        verified: false,
+        evidence: [],
+      },
+    ],
+    tests: {
+      written: [
+        {
+          path: "server/src/__tests__/compact-working-state-handoff-markdown.test.ts",
+          kind: "unit",
+          verified: false,
+          evidence: [],
+        },
+      ],
+      runs: [],
+    },
+    blocker: null,
+    requiredHandoff: { required: false, to: null, status: "in_progress", reason: null },
+    next: "Implement the fresh-session handoff markdown helper.",
+  };
+
+  return {
+    issue: {
+      identifier: "PB-81",
+      id: "issue-machine-id",
+      objective: "Emit compact working-state handoff on intentional fresh sessions.",
+    },
+    currentRun: { id: "run-machine-id" },
+    persistedSession: { id: "session-machine-id" },
+    currentAgent: { role: "engineer", name: "paperclip-engineer" },
+    stage: "implementation",
+    selfReport,
+    observedChanges: {
+      files: [
+        {
+          path: "server/src/services/compact-working-state.ts",
+          status: "pending",
+          verified: false,
+          evidence: [],
+        },
+      ],
+      commits: [],
+    },
+    artifacts: [{ kind: "run_log", ref: "paperclip:run:run-machine-id:log" }],
+    rawTranscriptRefs: [{ ref: "paperclip:run:run-machine-id:transcript", replayByDefault: false }],
+    ...overrides,
+  };
+}
+
+function parseSingleHandoffPacket(markdown: string) {
+  expect(markdown.match(/```handoff-v1/g)).toHaveLength(1);
+  expect(markdown.match(/```/g)).toHaveLength(2);
+  expect(markdown).toMatch(/^```handoff-v1\n[\s\S]+\n```$/);
+  return JSON.parse(markdown.slice("```handoff-v1\n".length, -"\n```".length)) as Record<string, unknown>;
+}
+
+describe("compact working-state handoff markdown", () => {
+  it("[BLIND] serializes fresh-session handoff as one handoff-v1 fenced compact packet", () => {
+    const markdown = buildCompactWorkingStateHandoffMarkdown(validHandoffInput());
+
+    expect(markdown).not.toBeNull();
+    const packet = parseSingleHandoffPacket(markdown as string);
+    expect(packet.packetKind).toBe("compact_working_state");
+    expect(packet.v).toBe(1);
+  });
+
+  it("[BLIND] uses machine identity for provenance instead of self-report claims", () => {
+    const markdown = buildCompactWorkingStateHandoffMarkdown(validHandoffInput({
+      selfReport: {
+        ...(validHandoffInput().selfReport as Record<string, unknown>),
+        issue: "SELF-REPORTED",
+        issueId: "self-reported-issue-id",
+        sourceRunId: "self-reported-run-id",
+        sourceSessionId: "self-reported-session-id",
+        from: "planner",
+        to: "reviewer",
+      },
+    }));
+
+    const packet = parseSingleHandoffPacket(markdown as string);
+    expect(packet.issue).toBe("PB-81");
+    expect(packet.issueId).toBe("issue-machine-id");
+    expect(packet.sourceRunId).toBe("run-machine-id");
+    expect(packet.sourceSessionId).toBe("session-machine-id");
+    expect(packet.from).toBe("engineer");
+    expect(packet.to).toBe("engineer");
+  });
+
+  it("[BLIND] returns null without a semantic self-report so existing reset behavior is unchanged", () => {
+    expect(buildCompactWorkingStateHandoffMarkdown(validHandoffInput({ selfReport: undefined }))).toBeNull();
+    expect(buildCompactWorkingStateHandoffMarkdown(validHandoffInput({ selfReport: null }))).toBeNull();
+  });
+
+  it("[BLIND] does not require or enable rotation thresholds to emit the compact handoff", () => {
+    const markdown = buildCompactWorkingStateHandoffMarkdown(validHandoffInput({
+      sessionCompactionPolicy: {
+        enabled: false,
+        maxSessionRuns: 0,
+        maxRawInputTokens: 0,
+        maxSessionAgeHours: 0,
+      },
+    }));
+
+    const packet = parseSingleHandoffPacket(markdown as string);
+    expect(packet.packetKind).toBe("compact_working_state");
+  });
+});

--- a/server/src/__tests__/execution-workspace-shared-reuse.test.ts
+++ b/server/src/__tests__/execution-workspace-shared-reuse.test.ts
@@ -1,0 +1,384 @@
+// BLIND tests (Constitution III: test author != spec author != implementer).
+// Authored from `pipeline-v2/paperclip-shared-workspace-reuse.SPEC.md` ALONE,
+// against Paperclip baseline 320efd0f. The fix is NOT implemented yet:
+// `executionWorkspaceService(db).findReusableSharedWorkspace(...)` does not exist,
+// so the lookup describe block is RED until the dedicated shared_workspace candidate
+// lookup lands. Every assertion traces to a spec clause; none was derived from
+// runtime output.
+//
+// Covers the [BLIND] acceptance clauses:
+//   - shared_workspace + a non-archived reusable candidate for the identity -> "reuse";
+//     none -> "create".
+//   - Env conflict (via resolveExecutionWorkspaceEnvironmentId) -> "create fresh" even
+//     when a candidate exists.
+//   - branchName == null (or sourceIssueId == null) -> normal path, no dedup.
+//   - Non-shared modes -> unchanged.
+//   - Atomicity seam (unit slice): the lookup keys on the logical identity
+//     (companyId + projectId + sourceIssueId + branchName + mode=shared_workspace),
+//     NOT on a found-row set, so the candidate-absent path is covered. Full
+//     concurrency (two simultaneous wakes) is [LIVE] and intentionally NOT tested here.
+//
+// Reusable-candidate contract from the spec "Dedup identity" + "Fix" sections:
+//   findReusableSharedWorkspace({ companyId, projectId, sourceIssueId, branchName })
+//   returns the matching execution workspace ONLY when
+//     mode = "shared_workspace" AND status IN (active, idle, in_review)
+//     AND closedAt IS NULL AND all four identity columns match;
+//   returns null when sourceIssueId or branchName is null (no stable identity).
+//   Environment matching is deliberately NOT applied by the lookup: the spec routes
+//   the candidate's persisted env through the EXISTING resolveExecutionWorkspaceEnvironmentId
+//   ("Do NOT invent a new env-match heuristic"), exercised in the env-conflict block below.
+//
+// Reuse decision contract (spec "Fix" lines: requestedShouldReuseExisting = true for a
+// shared target WITH a reusable candidate; existing formula at heartbeat
+// shouldReuseExisting = requestedShouldReuseExisting && !environmentResolution.conflict):
+//   resolveSharedWorkspaceReuseDecision({ candidate, environmentConflict }) returns true
+//   (reuse) ONLY when candidate != null AND there is no environment conflict; otherwise
+//   false (create fresh). This is the seam the brief means by "mock the candidate lookup":
+//   the (mockable) lookup result + the resolver's conflict combine into the decision. The
+//   final inline wiring of this decision into heartbeat provisioning is integration ([LIVE]).
+//
+// INTENDED SEAMS (test-author-defined): the spec describes a "dedicated shared_workspace-only
+// lookup" and the reuse decision but does not name them. To make the [BLIND] acceptance
+// unit-testable these tests fix two PUBLIC seams the implementer must expose (not bury as
+// private/inline helpers): the service method
+// `executionWorkspaceService(db).findReusableSharedWorkspace(...)` and the exported policy
+// function `resolveSharedWorkspaceReuseDecision(...)`. Renaming/relocating is fine if the
+// implementer updates these tests in lockstep; collapsing them into untestable internals is not.
+
+import { randomUUID } from "node:crypto";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import {
+  companies,
+  createDb,
+  executionWorkspaces,
+  issues,
+  projects,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import { executionWorkspaceService } from "../services/execution-workspaces.ts";
+import {
+  resolveExecutionWorkspaceEnvironmentId,
+  resolveSharedWorkspaceReuseDecision,
+} from "../services/execution-workspace-policy.ts";
+
+// The planned identity branch (the same value planExecutionWorkspaceBranch yields
+// for PAP-447 "Add Worktree Support"); branchName is part of the dedup identity.
+const BRANCH = "PAP-447-add-worktree-support";
+
+describe("resolveExecutionWorkspaceEnvironmentId env-conflict gate for shared_workspace reuse", () => {
+  // Spec "Environment matching (preserve PAPA-380 / PAPA-431)" + acceptance:
+  // because the shared candidate becomes the effective existingExecutionWorkspace,
+  // its persisted env is fed to the EXISTING resolver and a conflict forces fresh
+  // realization (heartbeat: shouldReuseExisting = requestedShouldReuseExisting &&
+  // !environmentResolution.conflict). This pins the dependency the fix leans on so
+  // a reusable candidate is NOT silently reused on a mismatched environment.
+
+  it("flags a conflict when the candidate's persisted env differs from the assignee's intended env (forces create fresh)", () => {
+    const result = resolveExecutionWorkspaceEnvironmentId({
+      projectPolicy: { enabled: true, environmentId: null },
+      issueSettings: { environmentId: "sandbox-env", mode: "shared_workspace" },
+      // The reuse candidate persisted a local-env workspace.
+      workspaceConfig: { environmentId: "local-env" },
+      agentDefaultEnvironmentId: "sandbox-env",
+      defaultEnvironmentId: "local-env",
+    });
+
+    expect(result.conflict).not.toBeNull();
+    expect(result.conflict?.reason).toBe("reused_workspace_environment_mismatch");
+  });
+
+  it("reports no conflict when the candidate's persisted env matches the assignee (reuse proceeds)", () => {
+    const result = resolveExecutionWorkspaceEnvironmentId({
+      projectPolicy: { enabled: true, environmentId: "agent-env" },
+      issueSettings: { environmentId: "agent-env", mode: "shared_workspace" },
+      workspaceConfig: { environmentId: "agent-env" },
+      agentDefaultEnvironmentId: "agent-env",
+      defaultEnvironmentId: "default-env",
+    });
+
+    expect(result.conflict).toBeNull();
+  });
+});
+
+describe("resolveSharedWorkspaceReuseDecision", () => {
+  // Spec acceptance: a reusable candidate -> "reuse"; none -> "create"; an env
+  // conflict -> "create fresh" EVEN WHEN a candidate exists. This pins the decision
+  // itself (candidate + conflict combined), which the resolver tests above cannot:
+  // a lookup could exist and still be reused on a conflicting env. The candidate is
+  // a stand-in for the (mocked) findReusableSharedWorkspace result; only its presence
+  // matters to the decision. environmentConflict is the resolver's conflict signal.
+  const candidate = { id: "execution-workspace-1" };
+  const environmentConflict = { reason: "reused_workspace_environment_mismatch" };
+
+  it("reuses when a candidate exists and there is no environment conflict", () => {
+    expect(resolveSharedWorkspaceReuseDecision({ candidate, environmentConflict: null })).toBe(true);
+  });
+
+  it("creates fresh when a candidate exists but the environment conflicts", () => {
+    expect(resolveSharedWorkspaceReuseDecision({ candidate, environmentConflict })).toBe(false);
+  });
+
+  it("creates when no candidate exists and there is no conflict", () => {
+    expect(resolveSharedWorkspaceReuseDecision({ candidate: null, environmentConflict: null })).toBe(false);
+  });
+
+  it("creates when no candidate exists even if the environment conflicts", () => {
+    expect(resolveSharedWorkspaceReuseDecision({ candidate: null, environmentConflict })).toBe(false);
+  });
+});
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping embedded Postgres shared-workspace reuse tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+describeEmbeddedPostgres("executionWorkspaceService.findReusableSharedWorkspace", () => {
+  let db!: ReturnType<typeof createDb>;
+  let svc!: ReturnType<typeof executionWorkspaceService>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-shared-workspace-reuse-");
+    db = createDb(tempDb.connectionString);
+    svc = executionWorkspaceService(db);
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.delete(issues);
+    await db.delete(executionWorkspaces);
+    await db.delete(projects);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  async function seedCompany() {
+    const id = randomUUID();
+    await db.insert(companies).values({
+      id,
+      name: "Paperclip",
+      // Unique per company: the tenant-isolation test seeds two companies, and
+      // companies_issue_prefix_idx is a UNIQUE index on issue_prefix.
+      issuePrefix: `PAP-${id.slice(0, 8)}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    return id;
+  }
+
+  async function seedProject(companyId: string) {
+    const id = randomUUID();
+    await db.insert(projects).values({
+      id,
+      companyId,
+      name: "Shared workspace reuse",
+      status: "in_progress",
+      executionWorkspacePolicy: { enabled: true },
+    });
+    return id;
+  }
+
+  async function seedCompanyProject() {
+    const companyId = await seedCompany();
+    const projectId = await seedProject(companyId);
+    return { companyId, projectId };
+  }
+
+  async function seedIssue(companyId: string, projectId: string) {
+    const id = randomUUID();
+    await db.insert(issues).values({
+      id,
+      companyId,
+      projectId,
+      title: "Shared workspace issue",
+      status: "todo",
+      priority: "medium",
+    });
+    return id;
+  }
+
+  async function insertWorkspace(values: {
+    companyId: string;
+    projectId: string;
+    sourceIssueId: string | null;
+    branchName: string | null;
+    mode?: string;
+    status?: string;
+    closedAt?: Date | null;
+  }) {
+    const id = randomUUID();
+    await db.insert(executionWorkspaces).values({
+      id,
+      companyId: values.companyId,
+      projectId: values.projectId,
+      sourceIssueId: values.sourceIssueId,
+      mode: values.mode ?? "shared_workspace",
+      strategyType: "git_worktree",
+      name: "Execution workspace",
+      status: values.status ?? "active",
+      providerType: "git_worktree",
+      cwd: "/tmp/shared-workspace",
+      branchName: values.branchName,
+      closedAt: values.closedAt ?? null,
+    });
+    return id;
+  }
+
+  it("returns the active shared_workspace candidate matching the full identity (decision: reuse)", async () => {
+    const { companyId, projectId } = await seedCompanyProject();
+    const sourceIssueId = await seedIssue(companyId, projectId);
+    const wsId = await insertWorkspace({ companyId, projectId, sourceIssueId, branchName: BRANCH, status: "active" });
+
+    const found = await svc.findReusableSharedWorkspace({ companyId, projectId, sourceIssueId, branchName: BRANCH });
+
+    expect(found?.id).toBe(wsId);
+    expect(found?.mode).toBe("shared_workspace");
+    expect(found?.status).toBe("active");
+  });
+
+  it("returns null when no shared_workspace candidate exists for the identity (decision: create)", async () => {
+    // Candidate-absent path: the lookup keys on the logical identity itself, not on a
+    // found-row set, so an empty result yields "create" rather than a silent reuse.
+    const { companyId, projectId } = await seedCompanyProject();
+    const sourceIssueId = await seedIssue(companyId, projectId);
+
+    const found = await svc.findReusableSharedWorkspace({ companyId, projectId, sourceIssueId, branchName: BRANCH });
+
+    expect(found).toBeNull();
+  });
+
+  it("treats active, idle, and in_review shared candidates as reusable", async () => {
+    const { companyId, projectId } = await seedCompanyProject();
+    for (const status of ["active", "idle", "in_review"]) {
+      const sourceIssueId = await seedIssue(companyId, projectId);
+      const wsId = await insertWorkspace({ companyId, projectId, sourceIssueId, branchName: BRANCH, status });
+
+      const found = await svc.findReusableSharedWorkspace({ companyId, projectId, sourceIssueId, branchName: BRANCH });
+
+      expect(found?.id).toBe(wsId);
+      expect(found?.status).toBe(status);
+    }
+  });
+
+  it("excludes archived and closed shared candidates", async () => {
+    const { companyId, projectId } = await seedCompanyProject();
+
+    const archivedIssue = await seedIssue(companyId, projectId);
+    await insertWorkspace({ companyId, projectId, sourceIssueId: archivedIssue, branchName: BRANCH, status: "archived" });
+
+    const closedIssue = await seedIssue(companyId, projectId);
+    await insertWorkspace({
+      companyId,
+      projectId,
+      sourceIssueId: closedIssue,
+      branchName: BRANCH,
+      status: "active",
+      closedAt: new Date("2026-06-01T00:00:00.000Z"),
+    });
+
+    expect(
+      await svc.findReusableSharedWorkspace({ companyId, projectId, sourceIssueId: archivedIssue, branchName: BRANCH }),
+    ).toBeNull();
+    expect(
+      await svc.findReusableSharedWorkspace({ companyId, projectId, sourceIssueId: closedIssue, branchName: BRANCH }),
+    ).toBeNull();
+  });
+
+  it("excludes non-shared workspace modes from shared reuse (other modes unchanged)", async () => {
+    // The full known non-shared mode vocabulary (mirrors the reuseEligible mode list in
+    // execution-workspaces.ts): a shared-only lookup must exclude every one of them.
+    const { companyId, projectId } = await seedCompanyProject();
+    for (const mode of ["isolated_workspace", "operator_branch", "adapter_managed", "cloud_sandbox"]) {
+      const sourceIssueId = await seedIssue(companyId, projectId);
+      await insertWorkspace({ companyId, projectId, sourceIssueId, branchName: BRANCH, mode, status: "active" });
+
+      const found = await svc.findReusableSharedWorkspace({ companyId, projectId, sourceIssueId, branchName: BRANCH });
+
+      expect(found).toBeNull();
+    }
+  });
+
+  it("does not match a candidate whose branchName differs (identity includes branchName)", async () => {
+    const { companyId, projectId } = await seedCompanyProject();
+    const sourceIssueId = await seedIssue(companyId, projectId);
+    await insertWorkspace({ companyId, projectId, sourceIssueId, branchName: "PAP-447-some-other-branch", status: "active" });
+
+    expect(
+      await svc.findReusableSharedWorkspace({ companyId, projectId, sourceIssueId, branchName: BRANCH }),
+    ).toBeNull();
+  });
+
+  it("keys on sourceIssueId (not branch name alone) and returns the full-identity candidate", async () => {
+    const { companyId, projectId } = await seedCompanyProject();
+    const targetIssue = await seedIssue(companyId, projectId);
+    const otherIssue = await seedIssue(companyId, projectId);
+
+    // Same company + project + branch, but a DIFFERENT source issue: must NOT match.
+    await insertWorkspace({ companyId, projectId, sourceIssueId: otherIssue, branchName: BRANCH, status: "active" });
+    expect(
+      await svc.findReusableSharedWorkspace({ companyId, projectId, sourceIssueId: targetIssue, branchName: BRANCH }),
+    ).toBeNull();
+
+    // The candidate matching the full identity IS returned (not just any shared row).
+    const targetWs = await insertWorkspace({ companyId, projectId, sourceIssueId: targetIssue, branchName: BRANCH, status: "active" });
+    expect(
+      (await svc.findReusableSharedWorkspace({ companyId, projectId, sourceIssueId: targetIssue, branchName: BRANCH }))?.id,
+    ).toBe(targetWs);
+  });
+
+  it("does not match a candidate recorded under a different projectId (identity includes projectId)", async () => {
+    const { companyId, projectId } = await seedCompanyProject();
+    const sourceIssueId = await seedIssue(companyId, projectId);
+    const otherProjectId = await seedProject(companyId);
+
+    // Same company + source issue + branch, but the row is recorded under a different
+    // project. A lookup keyed on sourceIssueId alone (which already implies a project)
+    // would wrongly match; the spec identity lists projectId explicitly.
+    await insertWorkspace({ companyId, projectId: otherProjectId, sourceIssueId, branchName: BRANCH, status: "active" });
+
+    expect(
+      await svc.findReusableSharedWorkspace({ companyId, projectId, sourceIssueId, branchName: BRANCH }),
+    ).toBeNull();
+  });
+
+  it("does not match a candidate recorded under a different companyId (tenant isolation)", async () => {
+    const { companyId, projectId } = await seedCompanyProject();
+    const sourceIssueId = await seedIssue(companyId, projectId);
+    const otherCompanyId = await seedCompany();
+
+    // Same project + source issue + branch, but the row is recorded under a different
+    // company. The lookup MUST scope by companyId so reuse never crosses tenants.
+    await insertWorkspace({ companyId: otherCompanyId, projectId, sourceIssueId, branchName: BRANCH, status: "active" });
+
+    expect(
+      await svc.findReusableSharedWorkspace({ companyId, projectId, sourceIssueId, branchName: BRANCH }),
+    ).toBeNull();
+  });
+
+  it("skips dedup when sourceIssueId is null (no stable identity)", async () => {
+    const { companyId, projectId } = await seedCompanyProject();
+    await insertWorkspace({ companyId, projectId, sourceIssueId: null, branchName: BRANCH, status: "active" });
+
+    const found = await svc.findReusableSharedWorkspace({ companyId, projectId, sourceIssueId: null, branchName: BRANCH });
+
+    expect(found).toBeNull();
+  });
+
+  it("skips dedup when branchName is null (no stable identity)", async () => {
+    const { companyId, projectId } = await seedCompanyProject();
+    const sourceIssueId = await seedIssue(companyId, projectId);
+    await insertWorkspace({ companyId, projectId, sourceIssueId, branchName: null, status: "active" });
+
+    const found = await svc.findReusableSharedWorkspace({ companyId, projectId, sourceIssueId, branchName: null });
+
+    expect(found).toBeNull();
+  });
+});

--- a/server/src/__tests__/execution-workspace-shared-reuse.test.ts
+++ b/server/src/__tests__/execution-workspace-shared-reuse.test.ts
@@ -9,8 +9,8 @@
 // Covers the [BLIND] acceptance clauses:
 //   - shared_workspace + a non-archived reusable candidate for the identity -> "reuse";
 //     none -> "create".
-//   - Env conflict (via resolveExecutionWorkspaceEnvironmentId) -> "create fresh" even
-//     when a candidate exists.
+//   - An environment conflict -> "create fresh" even when a candidate exists
+//     (resolveSharedWorkspaceReuseDecision; see the env-supersession note below).
 //   - branchName == null (or sourceIssueId == null) -> normal path, no dedup.
 //   - Non-shared modes -> unchanged.
 //   - Atomicity seam (unit slice): the lookup keys on the logical identity
@@ -24,9 +24,14 @@
 //     mode = "shared_workspace" AND status IN (active, idle, in_review)
 //     AND closedAt IS NULL AND all four identity columns match;
 //   returns null when sourceIssueId or branchName is null (no stable identity).
-//   Environment matching is deliberately NOT applied by the lookup: the spec routes
-//   the candidate's persisted env through the EXISTING resolveExecutionWorkspaceEnvironmentId
-//   ("Do NOT invent a new env-match heuristic"), exercised in the env-conflict block below.
+//   Environment matching is deliberately NOT applied by the lookup. The spec originally
+//   routed the candidate's persisted env through resolveExecutionWorkspaceEnvironmentId
+//   ("Do NOT invent a new env-match heuristic"). The AIM-68 upstream rebase superseded
+//   that: origin/master redefined resolveExecutionWorkspaceEnvironmentId as a pure per-run
+//   precedence resolver (agent > instance > local) with no conflict arm and dropped the
+//   env-conflict gate from the existing-workspace reuse path, so the reused row no longer
+//   pins an environment. The dedicated env-conflict assertions were removed; the reuse
+//   decision itself stays pinned below via resolveSharedWorkspaceReuseDecision.
 //
 // Reuse decision contract (spec "Fix" lines: requestedShouldReuseExisting = true for a
 // shared target WITH a reusable candidate; existing formula at heartbeat
@@ -60,48 +65,12 @@ import {
 } from "./helpers/embedded-postgres.js";
 import { executionWorkspaceService } from "../services/execution-workspaces.ts";
 import {
-  resolveExecutionWorkspaceEnvironmentId,
   resolveSharedWorkspaceReuseDecision,
 } from "../services/execution-workspace-policy.ts";
 
 // The planned identity branch (the same value planExecutionWorkspaceBranch yields
 // for PAP-447 "Add Worktree Support"); branchName is part of the dedup identity.
 const BRANCH = "PAP-447-add-worktree-support";
-
-describe("resolveExecutionWorkspaceEnvironmentId env-conflict gate for shared_workspace reuse", () => {
-  // Spec "Environment matching (preserve PAPA-380 / PAPA-431)" + acceptance:
-  // because the shared candidate becomes the effective existingExecutionWorkspace,
-  // its persisted env is fed to the EXISTING resolver and a conflict forces fresh
-  // realization (heartbeat: shouldReuseExisting = requestedShouldReuseExisting &&
-  // !environmentResolution.conflict). This pins the dependency the fix leans on so
-  // a reusable candidate is NOT silently reused on a mismatched environment.
-
-  it("flags a conflict when the candidate's persisted env differs from the assignee's intended env (forces create fresh)", () => {
-    const result = resolveExecutionWorkspaceEnvironmentId({
-      projectPolicy: { enabled: true, environmentId: null },
-      issueSettings: { environmentId: "sandbox-env", mode: "shared_workspace" },
-      // The reuse candidate persisted a local-env workspace.
-      workspaceConfig: { environmentId: "local-env" },
-      agentDefaultEnvironmentId: "sandbox-env",
-      defaultEnvironmentId: "local-env",
-    });
-
-    expect(result.conflict).not.toBeNull();
-    expect(result.conflict?.reason).toBe("reused_workspace_environment_mismatch");
-  });
-
-  it("reports no conflict when the candidate's persisted env matches the assignee (reuse proceeds)", () => {
-    const result = resolveExecutionWorkspaceEnvironmentId({
-      projectPolicy: { enabled: true, environmentId: "agent-env" },
-      issueSettings: { environmentId: "agent-env", mode: "shared_workspace" },
-      workspaceConfig: { environmentId: "agent-env" },
-      agentDefaultEnvironmentId: "agent-env",
-      defaultEnvironmentId: "default-env",
-    });
-
-    expect(result.conflict).toBeNull();
-  });
-});
 
 describe("resolveSharedWorkspaceReuseDecision", () => {
   // Spec acceptance: a reusable candidate -> "reuse"; none -> "create"; an env

--- a/server/src/__tests__/heartbeat-usage-telemetry.test.ts
+++ b/server/src/__tests__/heartbeat-usage-telemetry.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, it } from "vitest";
+import type { AdapterExecutionResult } from "@paperclipai/adapter-utils";
+import { buildRunUsageJson } from "../services/heartbeat.js";
+
+// Representative claude_local run-shape telemetry (PB-81 engineer-run shape).
+// buildRunUsageJson spreads this verbatim; derivation is covered in parse.test.ts.
+const TELEMETRY = {
+  turnCount: 147,
+  toolCallCount: 60,
+  toolLessTurnCount: 87,
+  toolLessTurnRatio: 0.5918367346938775,
+  residentWindowTokens: 162579,
+  usageFormulaVersion: "claude_local.telemetry.v1",
+};
+
+const USAGE_TOTALS = { inputTokens: 7724, cachedInputTokens: 7655530, outputTokens: 74235 };
+
+function adapterResult(overrides: Partial<AdapterExecutionResult> = {}): AdapterExecutionResult {
+  return {
+    exitCode: 0,
+    signal: null,
+    timedOut: false,
+    provider: "anthropic",
+    biller: "anthropic",
+    model: "claude-opus-4-8",
+    billingType: "subscription",
+    costUsd: 1.23,
+    usage: { ...USAGE_TOTALS },
+    usageTelemetry: { ...TELEMETRY },
+    ...overrides,
+  };
+}
+
+function input(overrides: Partial<Parameters<typeof buildRunUsageJson>[0]> = {}) {
+  return {
+    normalizedUsage: { ...USAGE_TOTALS },
+    rawUsage: { ...USAGE_TOTALS },
+    adapterResult: adapterResult(),
+    derivedFromSessionTotals: false,
+    persistedSessionId: "sess-1",
+    runId: "run-1",
+    agentId: "agent-1",
+    adapterType: "claude_local",
+    issueId: "PB-81",
+    sessionReused: false,
+    taskSessionReused: false,
+    freshSession: true,
+    sessionRotated: false,
+    sessionRotationReason: null,
+    ...overrides,
+  };
+}
+
+describe("buildRunUsageJson", () => {
+  it("persists adapter run-shape telemetry flat into usageJson", () => {
+    const usage = buildRunUsageJson(input());
+
+    expect(usage).toMatchObject({
+      turnCount: 147,
+      toolCallCount: 60,
+      toolLessTurnCount: 87,
+      toolLessTurnRatio: 0.5918367346938775,
+      residentWindowTokens: 162579,
+      usageFormulaVersion: "claude_local.telemetry.v1",
+    });
+  });
+
+  it("persists authoritative run mapping", () => {
+    const usage = buildRunUsageJson(input());
+
+    expect(usage).toMatchObject({
+      runId: "run-1",
+      agentId: "agent-1",
+      adapterType: "claude_local",
+      issueId: "PB-81",
+    });
+  });
+
+  it("preserves existing usage totals and raw totals unchanged", () => {
+    const usage = buildRunUsageJson(input());
+
+    expect(usage).toMatchObject({
+      inputTokens: 7724,
+      cachedInputTokens: 7655530,
+      outputTokens: 74235,
+      rawInputTokens: 7724,
+      rawCachedInputTokens: 7655530,
+      rawOutputTokens: 74235,
+    });
+  });
+
+  it("does not let adapter telemetry override reserved usageJson fields", () => {
+    const usage = buildRunUsageJson(
+      input({
+        adapterResult: adapterResult({
+          usageTelemetry: {
+            ...TELEMETRY,
+            inputTokens: 999,
+            rawInputTokens: 999,
+            runId: "telemetry-run",
+            agentId: "telemetry-agent",
+            provider: "telemetry-provider",
+          },
+        }),
+      }),
+    );
+
+    expect(usage).toMatchObject({
+      inputTokens: 7724,
+      rawInputTokens: 7724,
+      runId: "run-1",
+      agentId: "agent-1",
+      provider: "anthropic",
+      turnCount: 147,
+    });
+  });
+
+  it("persists a telemetry-only timed-out result-less run when it did work (turnCount > 0)", () => {
+    const usage = buildRunUsageJson(
+      input({
+        normalizedUsage: null,
+        rawUsage: null,
+        adapterResult: adapterResult({
+          timedOut: true,
+          costUsd: null,
+          usage: undefined,
+          usageTelemetry: { ...TELEMETRY, turnCount: 42 },
+        }),
+      }),
+    );
+
+    expect(usage).not.toBeNull();
+    expect(usage).toMatchObject({
+      turnCount: 42,
+      residentWindowTokens: 162579,
+      runId: "run-1",
+      agentId: "agent-1",
+      adapterType: "claude_local",
+    });
+    expect(usage).not.toHaveProperty("inputTokens");
+    expect(usage).not.toHaveProperty("rawInputTokens");
+    expect(usage).not.toHaveProperty("costUsd");
+  });
+
+  it("returns null for a tokenless, costless, turnless failure", () => {
+    const usage = buildRunUsageJson(
+      input({
+        normalizedUsage: null,
+        rawUsage: null,
+        adapterResult: adapterResult({
+          exitCode: 1,
+          costUsd: null,
+          usage: undefined,
+          usageTelemetry: { ...TELEMETRY, turnCount: 0 },
+        }),
+      }),
+    );
+
+    expect(usage).toBeNull();
+  });
+
+  it("still persists a turnless run when token usage or cost is present", () => {
+    const withUsage = buildRunUsageJson(
+      input({
+        adapterResult: adapterResult({ usageTelemetry: { ...TELEMETRY, turnCount: 0 } }),
+      }),
+    );
+    expect(withUsage).not.toBeNull();
+
+    const costOnly = buildRunUsageJson(
+      input({
+        normalizedUsage: null,
+        rawUsage: null,
+        adapterResult: adapterResult({
+          usage: undefined,
+          costUsd: 0.5,
+          usageTelemetry: { ...TELEMETRY, turnCount: 0 },
+        }),
+      }),
+    );
+    expect(costOnly).not.toBeNull();
+  });
+
+  it("omits telemetry keys for an adapter that emits none, keeping mapping and totals", () => {
+    const usage = buildRunUsageJson(
+      input({
+        adapterType: "codex_local",
+        adapterResult: adapterResult({ provider: "openai", biller: "openai", usageTelemetry: null }),
+      }),
+    );
+
+    expect(usage).not.toBeNull();
+    expect(usage).toMatchObject({ adapterType: "codex_local", runId: "run-1", inputTokens: 7724 });
+    expect(usage).not.toHaveProperty("turnCount");
+    expect(usage).not.toHaveProperty("usageFormulaVersion");
+  });
+});

--- a/server/src/__tests__/heartbeat-workspace-session.test.ts
+++ b/server/src/__tests__/heartbeat-workspace-session.test.ts
@@ -8,6 +8,7 @@ import type { agents } from "@paperclipai/db";
 import { sessionCodec as codexSessionCodec } from "@paperclipai/adapter-codex-local/server";
 import { resolveDefaultAgentWorkspaceDir } from "../home-paths.js";
 import {
+  applyCompactWorkingStateHandoffForFreshSession,
   applyPersistedExecutionWorkspaceConfig,
   assertGitSensitiveAdapterWorkspaceValid,
   assertPushCapabilityCheckoutValid,
@@ -968,6 +969,123 @@ describe("shouldResetTaskSessionForWake", () => {
         wakeTriggerDetail: "callback",
       }),
     ).toBe(false);
+  });
+});
+
+describe("applyCompactWorkingStateHandoffForFreshSession", () => {
+  function buildCompactSelfReport() {
+    return {
+      stage: "implementation",
+      status: "in_progress",
+      workingNotes: "Continue from the validated compact working-state emission path.",
+      acceptance: [
+        {
+          id: "AC1",
+          text: "Fresh-session wakes receive a compact working-state handoff.",
+          status: "pending",
+          assertedBy: "agent",
+          verified: false,
+          evidence: [],
+        },
+      ],
+      tests: {
+        written: [
+          {
+            path: "server/src/__tests__/heartbeat-workspace-session.test.ts",
+            kind: "unit",
+            status: "added",
+            verified: false,
+            evidence: [],
+          },
+        ],
+        runs: [],
+      },
+      blocker: null,
+      requiredHandoff: { required: false, to: null, status: "in_progress", reason: null },
+      next: "Continue the heartbeat run in the fresh session.",
+    };
+  }
+
+  function parseCompactPacket(markdown: string) {
+    expect(markdown).toMatch(/^```handoff-v1\n[\s\S]+\n```$/);
+    return JSON.parse(markdown.slice("```handoff-v1\n".length, -"\n```".length)) as Record<string, unknown>;
+  }
+
+  const issueRef = {
+    id: "issue-machine-id",
+    identifier: "PB-81",
+    title: "Emit compact working-state handoff on intentional fresh sessions.",
+  };
+  const run = { id: "run-machine-id", sessionIdBefore: "session-machine-id" };
+  const agent = { role: "engineer", name: "paperclip-engineer" };
+
+  it("sets compact handoff markdown for reset sessions with self-report and persisted session", () => {
+    const context: Record<string, unknown> = {
+      paperclipCompactWorkingStateSelfReport: buildCompactSelfReport(),
+      paperclipCompactWorkingStateStage: "implementation",
+    };
+
+    const markdown = applyCompactWorkingStateHandoffForFreshSession({
+      context,
+      resetTaskSession: true,
+      issueRef,
+      run,
+      agent,
+    });
+
+    expect(markdown).toBe(context.paperclipSessionHandoffMarkdown);
+    const packet = parseCompactPacket(markdown as string);
+    expect(packet.packetKind).toBe("compact_working_state");
+    expect(packet.sourceRunId).toBe("run-machine-id");
+    expect(packet.sourceSessionId).toBe("session-machine-id");
+    expect(packet.from).toBe("engineer");
+    expect(packet.to).toBe("engineer");
+  });
+
+  it("does not set compact handoff markdown without self-report", () => {
+    const context: Record<string, unknown> = {
+      paperclipSessionHandoffMarkdown: "stale",
+    };
+
+    const markdown = applyCompactWorkingStateHandoffForFreshSession({
+      context,
+      resetTaskSession: true,
+      issueRef,
+      run,
+      agent,
+    });
+
+    expect(markdown).toBeNull();
+    expect(context).not.toHaveProperty("paperclipSessionHandoffMarkdown");
+  });
+
+  it("does not set compact handoff markdown without reset or persisted session", () => {
+    const contextWithoutReset: Record<string, unknown> = {
+      paperclipSessionHandoffMarkdown: "stale",
+      paperclipCompactWorkingStateSelfReport: buildCompactSelfReport(),
+    };
+    const contextWithoutSession: Record<string, unknown> = {
+      paperclipSessionHandoffMarkdown: "stale",
+      paperclipCompactWorkingStateSelfReport: buildCompactSelfReport(),
+    };
+
+    expect(applyCompactWorkingStateHandoffForFreshSession({
+      context: contextWithoutReset,
+      resetTaskSession: false,
+      issueRef,
+      run,
+      agent,
+    })).toBeNull();
+    expect(contextWithoutReset).not.toHaveProperty("paperclipSessionHandoffMarkdown");
+
+    expect(applyCompactWorkingStateHandoffForFreshSession({
+      context: contextWithoutSession,
+      resetTaskSession: true,
+      issueRef,
+      run: { id: "run-machine-id", sessionIdBefore: null },
+      agent,
+    })).toBeNull();
+    expect(contextWithoutSession).not.toHaveProperty("paperclipSessionHandoffMarkdown");
   });
 });
 

--- a/server/src/__tests__/plan-execution-workspace-branch.test.ts
+++ b/server/src/__tests__/plan-execution-workspace-branch.test.ts
@@ -1,0 +1,172 @@
+// BLIND tests (Constitution III: test author != spec author != implementer).
+// Authored from `pipeline-v2/paperclip-shared-workspace-reuse.SPEC.md` ALONE,
+// against Paperclip baseline 320efd0f. The fix is NOT implemented yet:
+// `planExecutionWorkspaceBranch` does not exist, so these tests are RED until the
+// branch-planning seam lands. Every assertion traces to a spec clause; none was
+// derived from runtime output.
+//
+// Covers the spec "Branch-name planning seam" section and the [BLIND] acceptance
+// clause:
+//   "planExecutionWorkspaceBranch returns the SAME branch realizeExecutionWorkspace
+//    produces for the same (issue, agent, project, workspaceStrategy, repoRef); a
+//    non-git_worktree strategy -> null -> shared dedup skipped."
+//
+// The seam MUST reuse the SAME render+sanitize+default-template path as
+// realizeExecutionWorkspace (spec: "no second hand-rolled branch rendering ... no
+// drift"), so the contract is asserted as agreement between the two for identical
+// inputs. The new export is expected in `../services/workspace-runtime.ts`, the
+// module that already owns realizeExecutionWorkspace and its render+sanitize
+// helpers.
+
+import { execFile } from "node:child_process";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import { afterAll, describe, expect, it } from "vitest";
+import {
+  planExecutionWorkspaceBranch,
+  realizeExecutionWorkspace,
+} from "../services/workspace-runtime.ts";
+
+const execFileAsync = promisify(execFile);
+const tempDirs = new Set<string>();
+
+async function runGit(cwd: string, args: string[]) {
+  await execFileAsync("git", args, { cwd });
+}
+
+async function createTempRepo(defaultBranch = "main") {
+  const repoRoot = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-plan-branch-repo-"));
+  tempDirs.add(repoRoot);
+  await runGit(repoRoot, ["init"]);
+  await runGit(repoRoot, ["config", "user.email", "paperclip@example.com"]);
+  await runGit(repoRoot, ["config", "user.name", "Paperclip Test"]);
+  await fs.writeFile(path.join(repoRoot, "README.md"), "hello\n", "utf8");
+  await runGit(repoRoot, ["add", "README.md"]);
+  await runGit(repoRoot, ["commit", "-m", "Initial commit"]);
+  await runGit(repoRoot, ["checkout", "-B", defaultBranch]);
+  return repoRoot;
+}
+
+// Identical issue/agent/project/repoRef fed to both the planner and the realizer,
+// so any disagreement is a rendering/sanitization drift between the two paths.
+const ISSUE = { id: "issue-1", identifier: "PAP-447", title: "Add Worktree Support" };
+const AGENT = { id: "agent-1", name: "Codex Coder", companyId: "company-1" };
+const PROJECT_ID = "project-1";
+const REPO_REF = "HEAD";
+
+afterAll(async () => {
+  for (const dir of tempDirs) {
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+  tempDirs.clear();
+});
+
+describe("planExecutionWorkspaceBranch", () => {
+  it("plans null for a non-git_worktree strategy and agrees with realizeExecutionWorkspace (shared dedup skipped)", async () => {
+    // Spec: "returns null for non-git_worktree strategies" / "if it is null
+    // (non-git_worktree), shared dedup is skipped". The realizer's non-git_worktree
+    // branch returns branchName === null with no git/fs side effects, so no repo is
+    // needed here.
+    const workspaceStrategy = { type: "project_primary" };
+
+    const realized = await realizeExecutionWorkspace({
+      base: {
+        baseCwd: os.tmpdir(),
+        source: "project_primary",
+        projectId: PROJECT_ID,
+        workspaceId: "workspace-1",
+        repoUrl: null,
+        repoRef: REPO_REF,
+      },
+      config: { workspaceStrategy },
+      issue: ISSUE,
+      agent: AGENT,
+    });
+
+    const planned = await planExecutionWorkspaceBranch(
+      workspaceStrategy,
+      ISSUE,
+      AGENT,
+      PROJECT_ID,
+      REPO_REF,
+    );
+
+    expect(realized.branchName).toBeNull();
+    expect(planned).toBeNull();
+    expect(planned).toBe(realized.branchName);
+  });
+
+  it("plans the same branch realizeExecutionWorkspace creates for the default template", async () => {
+    // Spec default template `{{issue.identifier}}-{{slug}}`. The planned branch must
+    // equal the branch the realizer produces for the same inputs.
+    const repoRoot = await createTempRepo();
+    const workspaceStrategy = { type: "git_worktree", branchTemplate: "{{issue.identifier}}-{{slug}}" };
+
+    const realized = await realizeExecutionWorkspace({
+      base: {
+        baseCwd: repoRoot,
+        source: "project_primary",
+        projectId: PROJECT_ID,
+        workspaceId: "workspace-1",
+        repoUrl: null,
+        repoRef: REPO_REF,
+      },
+      config: { workspaceStrategy },
+      issue: ISSUE,
+      agent: AGENT,
+    });
+
+    const planned = await planExecutionWorkspaceBranch(
+      workspaceStrategy,
+      ISSUE,
+      AGENT,
+      PROJECT_ID,
+      REPO_REF,
+    );
+
+    // Agreement with realizeExecutionWorkspace IS the spec criterion; the exact
+    // sanitized string is realize's own (already pinned by workspace-runtime tests),
+    // so we assert agreement + a non-null branch rather than re-pinning the literal.
+    expect(realized.branchName).not.toBeNull();
+    expect(planned).toBe(realized.branchName);
+  });
+
+  it("plans the same sanitized branch for a custom template, proving a shared render+sanitize path", async () => {
+    // A custom branchTemplate with characters that sanitizeBranchName must collapse
+    // (a space, a slash). If the planner hand-rolled its own rendering it would drift
+    // from the realizer; the spec forbids that ("no second hand-rolled branch
+    // rendering ... no drift"), so the two MUST agree.
+    const repoRoot = await createTempRepo();
+    const workspaceStrategy = { type: "git_worktree", branchTemplate: "{{agent.name}}/{{issue.identifier}}" };
+
+    const realized = await realizeExecutionWorkspace({
+      base: {
+        baseCwd: repoRoot,
+        source: "project_primary",
+        projectId: PROJECT_ID,
+        workspaceId: "workspace-1",
+        repoUrl: null,
+        repoRef: REPO_REF,
+      },
+      config: { workspaceStrategy },
+      issue: ISSUE,
+      agent: AGENT,
+    });
+
+    const planned = await planExecutionWorkspaceBranch(
+      workspaceStrategy,
+      ISSUE,
+      AGENT,
+      PROJECT_ID,
+      REPO_REF,
+    );
+
+    // Agreement on a CUSTOM template proves the planner reads strategy.branchTemplate
+    // and sanitizes identically: had it hard-coded the default template or hand-rolled
+    // its own sanitizer, it would diverge from realize and this assertion would fail.
+    expect(planned).not.toBeNull();
+    expect(planned).toBe(realized.branchName);
+  });
+});

--- a/server/src/__tests__/productivity-review-service.test.ts
+++ b/server/src/__tests__/productivity-review-service.test.ts
@@ -119,6 +119,9 @@ describeEmbeddedPostgres("productivity review service", () => {
     issueId: string;
     count: number;
     now: Date;
+    status?: string;
+    errorCode?: string | null;
+    scheduledRetryReason?: string | null;
     withRunComments?: boolean;
   }) {
     const runs: Array<typeof heartbeatRuns.$inferInsert> = [];
@@ -129,11 +132,13 @@ describeEmbeddedPostgres("productivity review service", () => {
         id: runId,
         companyId: input.companyId,
         agentId: input.agentId,
-        status: "succeeded",
+        status: input.status ?? "succeeded",
         invocationSource: "assignment",
         triggerDetail: "system",
         startedAt: createdAt,
         finishedAt: new Date(createdAt.getTime() + 30_000),
+        errorCode: input.errorCode ?? null,
+        scheduledRetryReason: input.scheduledRetryReason ?? null,
         contextSnapshot: { issueId: input.issueId, taskId: input.issueId },
         livenessState: "advanced",
         nextAction: "Continue processing the next batch.",
@@ -562,5 +567,155 @@ describeEmbeddedPostgres("productivity review service", () => {
     expect(result.failed).toBe(0);
     const [review] = await listProductivityReviews(seeded.companyId);
     expect(review?.requestDepth).toBe(MAX_ISSUE_REQUEST_DEPTH);
+  });
+
+  it("does not create a productivity review when churn is only claude transient upstream failures", async () => {
+    const now = new Date("2026-04-28T12:00:00.000Z");
+    const seeded = await seedAssignedIssue();
+    await insertRuns({
+      companyId: seeded.companyId,
+      agentId: seeded.coderId,
+      issueId: seeded.issueId,
+      count: 12,
+      now,
+      status: "failed",
+      errorCode: "claude_transient_upstream",
+    });
+
+    const result = await productivityReviewService(db).reconcileProductivityReviews({
+      now,
+      companyId: seeded.companyId,
+    });
+
+    expect(result.created).toBe(0);
+    expect(await listProductivityReviews(seeded.companyId)).toHaveLength(0);
+  });
+
+  it("does not create a productivity review when churn is only codex transient upstream failures", async () => {
+    const now = new Date("2026-04-28T12:00:00.000Z");
+    const seeded = await seedAssignedIssue();
+    await insertRuns({
+      companyId: seeded.companyId,
+      agentId: seeded.coderId,
+      issueId: seeded.issueId,
+      count: 12,
+      now,
+      status: "failed",
+      errorCode: "codex_transient_upstream",
+    });
+
+    const result = await productivityReviewService(db).reconcileProductivityReviews({
+      now,
+      companyId: seeded.companyId,
+    });
+
+    expect(result.created).toBe(0);
+    expect(await listProductivityReviews(seeded.companyId)).toHaveLength(0);
+  });
+
+  it("does not count scheduled_retry heartbeat rows toward productivity churn", async () => {
+    const now = new Date("2026-04-28T12:00:00.000Z");
+    const seeded = await seedAssignedIssue();
+    await insertRuns({
+      companyId: seeded.companyId,
+      agentId: seeded.coderId,
+      issueId: seeded.issueId,
+      count: 12,
+      now,
+      status: "scheduled_retry",
+      scheduledRetryReason: "process_lost_retry",
+    });
+
+    const result = await productivityReviewService(db).reconcileProductivityReviews({
+      now,
+      companyId: seeded.companyId,
+    });
+
+    expect(result.created).toBe(0);
+    expect(await listProductivityReviews(seeded.companyId)).toHaveLength(0);
+  });
+
+  it("still creates a productivity review for non-transient failures such as adapter_failed", async () => {
+    const now = new Date("2026-04-28T12:00:00.000Z");
+    const seeded = await seedAssignedIssue();
+    await insertRuns({
+      companyId: seeded.companyId,
+      agentId: seeded.coderId,
+      issueId: seeded.issueId,
+      count: 12,
+      now,
+      status: "failed",
+      errorCode: "adapter_failed",
+    });
+
+    const result = await productivityReviewService(db).reconcileProductivityReviews({
+      now,
+      companyId: seeded.companyId,
+    });
+
+    expect(result.created).toBe(1);
+    expect(await listProductivityReviews(seeded.companyId)).toHaveLength(1);
+  });
+
+  it("creates a run-count high-churn review when only the latest real run carries a comment", async () => {
+    const now = new Date("2026-04-28T12:00:00.000Z");
+    const seeded = await seedAssignedIssue();
+    const runs = await insertRuns({
+      companyId: seeded.companyId,
+      agentId: seeded.coderId,
+      issueId: seeded.issueId,
+      count: 12,
+      now,
+    });
+    await db.insert(issueComments).values({
+      companyId: seeded.companyId,
+      issueId: seeded.issueId,
+      authorAgentId: seeded.coderId,
+      createdByRunId: runs[0]!.id as string,
+      body: "Latest progress update",
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    const result = await productivityReviewService(db).reconcileProductivityReviews({
+      now,
+      companyId: seeded.companyId,
+    });
+
+    expect(result.created).toBe(1);
+    const [review] = await listProductivityReviews(seeded.companyId);
+    expect(review?.description).toContain("Primary trigger: `high_churn`");
+  });
+
+  it("counts failed runs with a null errorCode toward run-count high-churn when only the latest run carries a comment", async () => {
+    const now = new Date("2026-04-28T12:00:00.000Z");
+    const seeded = await seedAssignedIssue();
+    const runs = await insertRuns({
+      companyId: seeded.companyId,
+      agentId: seeded.coderId,
+      issueId: seeded.issueId,
+      count: 12,
+      now,
+      status: "failed",
+      errorCode: null,
+    });
+    await db.insert(issueComments).values({
+      companyId: seeded.companyId,
+      issueId: seeded.issueId,
+      authorAgentId: seeded.coderId,
+      createdByRunId: runs[0]!.id as string,
+      body: "Latest progress update",
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    const result = await productivityReviewService(db).reconcileProductivityReviews({
+      now,
+      companyId: seeded.companyId,
+    });
+
+    expect(result.created).toBe(1);
+    const [review] = await listProductivityReviews(seeded.companyId);
+    expect(review?.description).toContain("Primary trigger: `high_churn`");
   });
 });

--- a/server/src/__tests__/workspace-runtime.test.ts
+++ b/server/src/__tests__/workspace-runtime.test.ts
@@ -78,6 +78,30 @@ async function readGit(cwd: string, args: string[]) {
   return (await execFileAsync("git", args, { cwd })).stdout.trim();
 }
 
+async function cleanupRealizedGitWorkspace(repoRoot: string, workspace: RealizedExecutionWorkspace) {
+  return cleanupExecutionWorkspaceArtifacts({
+    workspace: {
+      id: "execution-workspace-1",
+      cwd: workspace.cwd,
+      providerType: "git_worktree",
+      providerRef: workspace.worktreePath,
+      branchName: workspace.branchName,
+      repoUrl: workspace.repoUrl,
+      baseRef: workspace.repoRef,
+      projectId: workspace.projectId,
+      projectWorkspaceId: workspace.workspaceId,
+      sourceIssueId: "issue-1",
+      metadata: {
+        createdByRuntime: true,
+      },
+    },
+    projectWorkspace: {
+      cwd: repoRoot,
+      cleanupCommand: null,
+    },
+  });
+}
+
 async function runPnpm(cwd: string, args: string[]) {
   await execFileAsync("pnpm", args, { cwd });
 }
@@ -2272,27 +2296,7 @@ describe("realizeExecutionWorkspace", () => {
       },
     });
 
-    const cleanup = await cleanupExecutionWorkspaceArtifacts({
-      workspace: {
-        id: "execution-workspace-1",
-        cwd: workspace.cwd,
-        providerType: "git_worktree",
-        providerRef: workspace.worktreePath,
-        branchName: workspace.branchName,
-        repoUrl: workspace.repoUrl,
-        baseRef: workspace.repoRef,
-        projectId: workspace.projectId,
-        projectWorkspaceId: workspace.workspaceId,
-        sourceIssueId: "issue-1",
-        metadata: {
-          createdByRuntime: true,
-        },
-      },
-      projectWorkspace: {
-        cwd: repoRoot,
-        cleanupCommand: null,
-      },
-    });
+    const cleanup = await cleanupRealizedGitWorkspace(repoRoot, workspace);
 
     expect(cleanup.cleaned).toBe(true);
     expect(cleanup.warnings).toEqual([]);
@@ -2302,6 +2306,47 @@ describe("realizeExecutionWorkspace", () => {
     ).resolves.toMatchObject({
       stdout: "",
     });
+  });
+
+  it("treats already-removed git worktree artifacts as cleaned", async () => {
+    const repoRoot = await createTempRepo();
+
+    const workspace = await realizeExecutionWorkspace({
+      base: {
+        baseCwd: repoRoot,
+        source: "project_primary",
+        projectId: "project-1",
+        workspaceId: "workspace-1",
+        repoUrl: null,
+        repoRef: "HEAD",
+      },
+      config: {
+        workspaceStrategy: {
+          type: "git_worktree",
+          branchTemplate: "{{issue.identifier}}-{{slug}}",
+        },
+      },
+      issue: {
+        id: "issue-1",
+        identifier: "PAP-2001",
+        title: "Cleanup already removed workspace",
+      },
+      agent: {
+        id: "agent-1",
+        name: "Codex Coder",
+        companyId: "company-1",
+      },
+    });
+
+    await runGit(repoRoot, ["worktree", "remove", "--force", workspace.worktreePath!]);
+    await runGit(repoRoot, ["branch", "-d", workspace.branchName!]);
+    await fs.mkdir(workspace.worktreePath!, { recursive: true });
+
+    const cleanup = await cleanupRealizedGitWorkspace(repoRoot, workspace);
+
+    expect(cleanup.cleaned).toBe(true);
+    expect(cleanup.warnings).toEqual([]);
+    await expect(fs.stat(workspace.worktreePath!)).rejects.toThrow();
   });
 
   it("keeps an unmerged runtime-created branch and warns instead of force deleting it", async () => {
@@ -2338,27 +2383,7 @@ describe("realizeExecutionWorkspace", () => {
     await runGit(workspace.cwd, ["add", "unmerged.txt"]);
     await runGit(workspace.cwd, ["commit", "-m", "Keep unmerged work"]);
 
-    const cleanup = await cleanupExecutionWorkspaceArtifacts({
-      workspace: {
-        id: "execution-workspace-1",
-        cwd: workspace.cwd,
-        providerType: "git_worktree",
-        providerRef: workspace.worktreePath,
-        branchName: workspace.branchName,
-        repoUrl: workspace.repoUrl,
-        baseRef: workspace.repoRef,
-        projectId: workspace.projectId,
-        projectWorkspaceId: workspace.workspaceId,
-        sourceIssueId: "issue-1",
-        metadata: {
-          createdByRuntime: true,
-        },
-      },
-      projectWorkspace: {
-        cwd: repoRoot,
-        cleanupCommand: null,
-      },
-    });
+    const cleanup = await cleanupRealizedGitWorkspace(repoRoot, workspace);
 
     expect(cleanup.cleaned).toBe(true);
     expect(cleanup.warnings).toHaveLength(1);

--- a/server/src/services/compact-working-state.ts
+++ b/server/src/services/compact-working-state.ts
@@ -1,5 +1,22 @@
 type UnknownRecord = Record<string, unknown>;
 
+const BASE_STATUSES = ["approved", "rejected", "blocked", "done", "in_progress"] as const;
+const ACCEPTANCE_STATUSES = [
+  "pending",
+  "in_progress",
+  "asserted_passed",
+  "asserted_failed",
+  "verified_passed",
+  "verified_failed",
+  "blocked",
+] as const;
+const CHANGE_STATUSES = ["added", "modified", "deleted", "renamed", "unchanged", "unknown"] as const;
+const TEST_ARTIFACT_STATUSES = ["added", "modified", "deleted", "unchanged", "unknown"] as const;
+const TEST_KINDS = ["unit", "integration", "e2e", "fixture", "contract", "unknown"] as const;
+const TEST_RUN_RESULTS = ["not_run", "asserted_passed", "asserted_failed", "verified_passed", "verified_failed"] as const;
+const ASSERTED_BY_VALUES = ["agent", "builder", "unknown"] as const;
+const RAW_TRANSCRIPT_FORBIDDEN_KEYS = ["body", "content", "messages", "transcript"] as const;
+
 type SemanticSelfReport = {
   stage?: unknown;
   status?: unknown;
@@ -80,6 +97,225 @@ function requireObject(value: unknown, field: string): UnknownRecord {
   return value as UnknownRecord;
 }
 
+function requireBoolean(value: unknown, field: string): boolean {
+  if (typeof value !== "boolean") throw new Error(`Field "${field}" must be a boolean`);
+  return value;
+}
+
+function requireOneOf<T extends readonly string[]>(value: unknown, field: string, allowed: T): T[number] {
+  const text = requireNonEmptyString(value, field);
+  if (!allowed.includes(text)) {
+    throw new Error(`Field "${field}" must be one of ${allowed.join(", ")}`);
+  }
+  return text;
+}
+
+function requireOptionalString(value: unknown, field: string): void {
+  if (value !== undefined && typeof value !== "string") {
+    throw new Error(`Field "${field}" must be a string`);
+  }
+}
+
+function validateStringArray(value: unknown, field: string): void {
+  const entries = readArray(value, field);
+  for (let i = 0; i < entries.length; i += 1) {
+    if (typeof entries[i] !== "string") throw new Error(`Field "${field}[${i}]" must be a string`);
+  }
+}
+
+function isAllowedEvidenceRef(ref: string): boolean {
+  return ref.startsWith("paperclip:run:") ||
+    ref.startsWith("paperclip:comment:") ||
+    ref.startsWith("paperclip:document:") ||
+    ref.startsWith("git:commit:") ||
+    ref.startsWith("git:file:") ||
+    ref === "git:diff" ||
+    ref.startsWith("local-log:");
+}
+
+function hasVerifiedEvidence(evidence: unknown[]): boolean {
+  return evidence.some((entry) => requireObject(entry, "evidence").verified === true);
+}
+
+function validateEvidenceRefs(value: unknown, field: string, opts: { requireVerified?: boolean } = {}): unknown[] {
+  const evidence = readArray(value, field);
+  for (let i = 0; i < evidence.length; i += 1) {
+    const entry = requireObject(evidence[i], `${field}[${i}]`);
+    requireNonEmptyString(entry.kind, `${field}[${i}].kind`);
+    const ref = requireNonEmptyString(entry.ref, `${field}[${i}].ref`);
+    if (!isAllowedEvidenceRef(ref)) throw new Error(`Field "${field}[${i}].ref" has an unsupported evidence prefix`);
+    requireBoolean(entry.verified, `${field}[${i}].verified`);
+    requireOptionalString(entry.label, `${field}[${i}].label`);
+    requireOptionalString(entry.detail, `${field}[${i}].detail`);
+  }
+  if (opts.requireVerified && !hasVerifiedEvidence(evidence)) {
+    throw new Error(`Field "${field}" requires at least one verified evidence ref`);
+  }
+  return evidence;
+}
+
+function validateArtifacts(value: unknown, field: string): void {
+  const artifacts = readArray(value, field);
+  for (let i = 0; i < artifacts.length; i += 1) {
+    const artifact = requireObject(artifacts[i], `${field}[${i}]`);
+    requireNonEmptyString(artifact.kind, `${field}[${i}].kind`);
+    requireNonEmptyString(artifact.ref, `${field}[${i}].ref`);
+    if (artifact.files !== undefined) validateStringArray(artifact.files, `${field}[${i}].files`);
+  }
+}
+
+function validateDecision(value: unknown): void {
+  const decision = requireObject(value, "decision");
+  requireNonEmptyString(decision.code, "decision.code");
+  if (decision.files !== undefined) validateStringArray(decision.files, "decision.files");
+}
+
+function validateAcceptance(value: unknown): void {
+  const acceptance = readArray(value, "acceptance");
+  for (let i = 0; i < acceptance.length; i += 1) {
+    const item = requireObject(acceptance[i], `acceptance[${i}]`);
+    requireNonEmptyString(item.id, `acceptance[${i}].id`);
+    requireNonEmptyString(item.text, `acceptance[${i}].text`);
+    const status = requireOneOf(item.status, `acceptance[${i}].status`, ACCEPTANCE_STATUSES);
+    requireOneOf(item.assertedBy, `acceptance[${i}].assertedBy`, ASSERTED_BY_VALUES);
+    const verified = requireBoolean(item.verified, `acceptance[${i}].verified`);
+    validateEvidenceRefs(item.evidence, `acceptance[${i}].evidence`, {
+      requireVerified: verified || status === "verified_passed" || status === "verified_failed",
+    });
+    if ((status === "verified_passed" || status === "verified_failed") && !verified) {
+      throw new Error(`Field "acceptance[${i}].verified" must be true for ${status}`);
+    }
+  }
+}
+
+function validateChanges(value: unknown): void {
+  const changes = requireObject(value, "changes");
+  const files = readArray(changes.files, "changes.files");
+  for (let i = 0; i < files.length; i += 1) {
+    const file = requireObject(files[i], `changes.files[${i}]`);
+    requireNonEmptyString(file.path, `changes.files[${i}].path`);
+    const status = requireOneOf(file.status, `changes.files[${i}].status`, CHANGE_STATUSES);
+    const verified = requireBoolean(file.verified, `changes.files[${i}].verified`);
+    if (file.previousPath !== undefined) {
+      requireNonEmptyString(file.previousPath, `changes.files[${i}].previousPath`);
+      if (status !== "renamed") {
+        throw new Error(`Field "changes.files[${i}].previousPath" is allowed only when status is renamed`);
+      }
+    } else if (status === "renamed") {
+      throw new Error(`Missing changes.files[${i}].previousPath`);
+    }
+    validateEvidenceRefs(file.evidence, `changes.files[${i}].evidence`, { requireVerified: verified });
+  }
+
+  const commits = readArray(changes.commits, "changes.commits");
+  for (let i = 0; i < commits.length; i += 1) {
+    const commit = requireObject(commits[i], `changes.commits[${i}]`);
+    requireNonEmptyString(commit.sha, `changes.commits[${i}].sha`);
+    requireOptionalString(commit.summary, `changes.commits[${i}].summary`);
+    const verified = requireBoolean(commit.verified, `changes.commits[${i}].verified`);
+    validateEvidenceRefs(commit.evidence, `changes.commits[${i}].evidence`, { requireVerified: verified });
+  }
+}
+
+function validateTests(value: unknown): void {
+  const tests = requireObject(value, "tests");
+  const written = readArray(tests.written, "tests.written");
+  for (let i = 0; i < written.length; i += 1) {
+    const item = requireObject(written[i], `tests.written[${i}]`);
+    requireNonEmptyString(item.path, `tests.written[${i}].path`);
+    requireOneOf(item.kind, `tests.written[${i}].kind`, TEST_KINDS);
+    requireOneOf(item.status, `tests.written[${i}].status`, TEST_ARTIFACT_STATUSES);
+    const verified = requireBoolean(item.verified, `tests.written[${i}].verified`);
+    validateEvidenceRefs(item.evidence, `tests.written[${i}].evidence`, { requireVerified: verified });
+  }
+
+  const runs = readArray(tests.runs, "tests.runs");
+  for (let i = 0; i < runs.length; i += 1) {
+    const run = requireObject(runs[i], `tests.runs[${i}]`);
+    requireNonEmptyString(run.command, `tests.runs[${i}].command`);
+    const result = requireOneOf(run.result, `tests.runs[${i}].result`, TEST_RUN_RESULTS);
+    requireOneOf(run.assertedBy, `tests.runs[${i}].assertedBy`, ASSERTED_BY_VALUES);
+    const verified = requireBoolean(run.verified, `tests.runs[${i}].verified`);
+    validateEvidenceRefs(run.evidence, `tests.runs[${i}].evidence`, {
+      requireVerified: verified || result === "verified_passed" || result === "verified_failed",
+    });
+    if ((result === "verified_passed" || result === "verified_failed") && !verified) {
+      throw new Error(`Field "tests.runs[${i}].verified" must be true for ${result}`);
+    }
+  }
+}
+
+function validateRequiredHandoff(value: unknown): void {
+  const handoff = requireObject(value, "requiredHandoff");
+  const required = requireBoolean(handoff.required, "requiredHandoff.required");
+  if (required) {
+    requireNonEmptyString(handoff.to, "requiredHandoff.to");
+    requireNonEmptyString(handoff.reason, "requiredHandoff.reason");
+  } else if (handoff.to !== null || handoff.reason !== null) {
+    throw new Error("requiredHandoff.to and requiredHandoff.reason must be null when required is false");
+  }
+  requireOneOf(handoff.status, "requiredHandoff.status", BASE_STATUSES);
+}
+
+function validateBlocker(value: unknown): void {
+  if (value === null) return;
+  const blocker = requireObject(value, "blocker");
+  requireNonEmptyString(blocker.summary, "blocker.summary");
+  if (blocker.owner !== undefined && blocker.owner !== null) {
+    requireNonEmptyString(blocker.owner, "blocker.owner");
+  }
+  validateEvidenceRefs(blocker.evidence, "blocker.evidence");
+}
+
+function validateRawTranscriptRefs(value: unknown): void {
+  const refs = readArray(value, "rawTranscriptRefs");
+  for (let i = 0; i < refs.length; i += 1) {
+    const ref = requireObject(refs[i], `rawTranscriptRefs[${i}]`);
+    const refValue = requireNonEmptyString(ref.ref, `rawTranscriptRefs[${i}].ref`);
+    if (!isAllowedEvidenceRef(refValue)) {
+      throw new Error(`Field "rawTranscriptRefs[${i}].ref" has an unsupported evidence prefix`);
+    }
+    if (ref.replayByDefault !== false) {
+      throw new Error(`Field "rawTranscriptRefs[${i}].replayByDefault" must be false`);
+    }
+    for (const key of RAW_TRANSCRIPT_FORBIDDEN_KEYS) {
+      if (key in ref) throw new Error(`Field "rawTranscriptRefs[${i}].${key}" is not allowed`);
+    }
+  }
+}
+
+export function validateCompactWorkingStatePacket(packet: UnknownRecord): CompactWorkingStatePacket {
+  if (packet.v !== 1) throw new Error("Field \"v\" must equal 1");
+  if (packet.packetKind !== "compact_working_state") {
+    throw new Error("Field \"packetKind\" must equal compact_working_state");
+  }
+  requireNonEmptyString(packet.issue, "issue");
+  requireNonEmptyString(packet.issueId, "issueId");
+  requireNonEmptyString(packet.sourceRunId, "sourceRunId");
+  requireNonEmptyString(packet.sourceSessionId, "sourceSessionId");
+  requireNonEmptyString(packet.stage, "stage");
+  requireNonEmptyString(packet.from, "from");
+  requireNonEmptyString(packet.to, "to");
+  const status = requireOneOf(packet.status, "status", BASE_STATUSES);
+  requireNonEmptyString(packet.objective, "objective");
+  if (typeof packet.workingNotes !== "string") throw new Error("Field \"workingNotes\" must be a string");
+  if (packet.workingNotes.length > 1500) throw new Error("Field \"workingNotes\" must be at most 1500 characters");
+  if (status === "blocked" && packet.blocker === null) throw new Error("blocked status requires blocker");
+  if (status !== "blocked" && packet.blocker !== null) throw new Error("blocker requires blocked status");
+
+  validateAcceptance(packet.acceptance);
+  validateChanges(packet.changes);
+  validateTests(packet.tests);
+  validateBlocker(packet.blocker);
+  validateRequiredHandoff(packet.requiredHandoff);
+  validateArtifacts(packet.artifacts, "artifacts");
+  if (packet.decision !== undefined) validateDecision(packet.decision);
+  validateRawTranscriptRefs(packet.rawTranscriptRefs);
+  requireNonEmptyString(packet.next, "next");
+
+  return packet as CompactWorkingStatePacket;
+}
+
 function readStatus(selfReport: SemanticSelfReport, blocker: unknown, requiredHandoff: unknown): string {
   const reportedStatus = readNonEmptyString(selfReport.status);
   if (reportedStatus) return reportedStatus;
@@ -113,7 +349,7 @@ export function buildCompactWorkingStatePacket(
   if (status === "blocked" && blocker === null) throw new Error("blocked status requires blocker");
   if (status !== "blocked" && blocker !== null) throw new Error("blocker requires blocked status");
 
-  return {
+  return validateCompactWorkingStatePacket({
     v: 1,
     packetKind: "compact_working_state",
     issue: requireNonEmptyString(issue.identifier, "issue.identifier"),
@@ -134,7 +370,7 @@ export function buildCompactWorkingStatePacket(
     artifacts: readArray(input.artifacts ?? [], "artifacts"),
     rawTranscriptRefs: readArray(input.rawTranscriptRefs ?? [], "rawTranscriptRefs"),
     next: requireNonEmptyString(requireSelfReportedField(selfReport, "next"), "self-report next"),
-  };
+  });
 }
 
 export function buildCompactWorkingStateHandoffMarkdown(

--- a/server/src/services/compact-working-state.ts
+++ b/server/src/services/compact-working-state.ts
@@ -1,0 +1,145 @@
+type UnknownRecord = Record<string, unknown>;
+
+type SemanticSelfReport = {
+  stage?: unknown;
+  status?: unknown;
+  workingNotes?: unknown;
+  acceptance?: unknown;
+  tests?: unknown;
+  blocker?: unknown;
+  requiredHandoff?: unknown;
+  next?: unknown;
+};
+
+export type BuildCompactWorkingStatePacketInput = {
+  issue?: {
+    identifier?: unknown;
+    id?: unknown;
+    objective?: unknown;
+  };
+  currentRun?: {
+    id?: unknown;
+  };
+  persistedSession?: {
+    id?: unknown;
+  };
+  currentAgent?: {
+    role?: unknown;
+    name?: unknown;
+  };
+  stage?: unknown;
+  selfReport?: SemanticSelfReport;
+  observedChanges?: unknown;
+  artifacts?: unknown;
+  rawTranscriptRefs?: unknown;
+  requireWorkingNotes?: boolean;
+};
+
+export type CompactWorkingStateSource = {
+  sourceRunId?: unknown;
+  sourceSessionId?: unknown;
+};
+
+export type CompactWorkingStatePacket = UnknownRecord & {
+  sourceRunId: string;
+  sourceSessionId: string;
+};
+
+function readNonEmptyString(value: unknown): string | null {
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+function requireNonEmptyString(value: unknown, field: string): string {
+  const text = readNonEmptyString(value);
+  if (!text) throw new Error(`Missing ${field}`);
+  return text;
+}
+
+function requireSelfReport(input: BuildCompactWorkingStatePacketInput): SemanticSelfReport {
+  if (!input.selfReport || typeof input.selfReport !== "object") {
+    throw new Error("Missing self-report");
+  }
+  return input.selfReport;
+}
+
+function requireSelfReportedField<T>(selfReport: SemanticSelfReport, field: keyof SemanticSelfReport): T {
+  const value = selfReport[field];
+  if (value === undefined) throw new Error(`Missing self-report ${String(field)}`);
+  return value as T;
+}
+
+function readArray(value: unknown, field: string): unknown[] {
+  if (!Array.isArray(value)) throw new Error(`Missing ${field}`);
+  return value;
+}
+
+function requireObject(value: unknown, field: string): UnknownRecord {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`Missing ${field}`);
+  }
+  return value as UnknownRecord;
+}
+
+function readStatus(selfReport: SemanticSelfReport, blocker: unknown, requiredHandoff: unknown): string {
+  const reportedStatus = readNonEmptyString(selfReport.status);
+  if (reportedStatus) return reportedStatus;
+  if (blocker !== null) return "blocked";
+
+  const handoff = requiredHandoff && typeof requiredHandoff === "object" && !Array.isArray(requiredHandoff)
+    ? requiredHandoff as UnknownRecord
+    : null;
+  return readNonEmptyString(handoff?.status) ?? "in_progress";
+}
+
+export function buildCompactWorkingStatePacket(
+  input: BuildCompactWorkingStatePacketInput,
+): CompactWorkingStatePacket {
+  const selfReport = requireSelfReport(input);
+  const issue = requireObject(input.issue, "issue");
+  const role = requireNonEmptyString(input.currentAgent?.role, "currentAgent.role");
+  const workingNotes = requireSelfReportedField<string>(selfReport, "workingNotes");
+  if (typeof workingNotes !== "string") throw new Error("Missing self-report workingNotes");
+  if (input.requireWorkingNotes && workingNotes.length === 0) {
+    throw new Error("Missing self-report workingNotes");
+  }
+  if (workingNotes.length > 1500) throw new Error("workingNotes exceeds 1500 characters");
+
+  const stage = readNonEmptyString(input.stage) ?? readNonEmptyString(selfReport.stage);
+  if (!stage) throw new Error("Missing stage or self-report stage");
+
+  const blocker = requireSelfReportedField<unknown>(selfReport, "blocker");
+  const requiredHandoff = requireSelfReportedField<unknown>(selfReport, "requiredHandoff");
+  const status = readStatus(selfReport, blocker, requiredHandoff);
+  if (status === "blocked" && blocker === null) throw new Error("blocked status requires blocker");
+  if (status !== "blocked" && blocker !== null) throw new Error("blocker requires blocked status");
+
+  return {
+    v: 1,
+    packetKind: "compact_working_state",
+    issue: requireNonEmptyString(issue.identifier, "issue.identifier"),
+    issueId: requireNonEmptyString(issue.id, "issue.id"),
+    sourceRunId: requireNonEmptyString(input.currentRun?.id, "currentRun.id"),
+    sourceSessionId: requireNonEmptyString(input.persistedSession?.id, "persistedSession.id"),
+    stage,
+    from: role,
+    to: role,
+    status,
+    objective: requireNonEmptyString(issue.objective, "issue.objective"),
+    workingNotes,
+    acceptance: readArray(requireSelfReportedField(selfReport, "acceptance"), "self-report acceptance"),
+    changes: requireObject(input.observedChanges, "observedChanges"),
+    tests: requireObject(requireSelfReportedField(selfReport, "tests"), "self-report tests"),
+    blocker,
+    requiredHandoff: requireObject(requiredHandoff, "self-report requiredHandoff"),
+    artifacts: readArray(input.artifacts ?? [], "artifacts"),
+    rawTranscriptRefs: readArray(input.rawTranscriptRefs ?? [], "rawTranscriptRefs"),
+    next: requireNonEmptyString(requireSelfReportedField(selfReport, "next"), "self-report next"),
+  };
+}
+
+export function isStaleCompactWorkingStatePacket(
+  packet: CompactWorkingStateSource,
+  current: CompactWorkingStateSource,
+): boolean {
+  return packet.sourceRunId !== current.sourceRunId || packet.sourceSessionId !== current.sourceSessionId;
+}

--- a/server/src/services/compact-working-state.ts
+++ b/server/src/services/compact-working-state.ts
@@ -137,6 +137,16 @@ export function buildCompactWorkingStatePacket(
   };
 }
 
+export function buildCompactWorkingStateHandoffMarkdown(
+  input: BuildCompactWorkingStatePacketInput,
+): string | null {
+  if (!input.selfReport || typeof input.selfReport !== "object") {
+    return null;
+  }
+  const packet = buildCompactWorkingStatePacket(input);
+  return `\`\`\`handoff-v1\n${JSON.stringify(packet, null, 2)}\n\`\`\``;
+}
+
 export function isStaleCompactWorkingStatePacket(
   packet: CompactWorkingStateSource,
   current: CompactWorkingStateSource,

--- a/server/src/services/execution-workspace-identity-lock.ts
+++ b/server/src/services/execution-workspace-identity-lock.ts
@@ -1,0 +1,47 @@
+// In-process per-identity provisioning mutex. The nearby `withAgentStartLock`
+// is agent-keyed and so does NOT serialize two DIFFERENT agents provisioning the
+// same issue (the observed cross-agent-handoff dup source). This lock is keyed on
+// the shared_workspace logical identity
+// (`companyId:projectId:sourceIssueId:branchName`) and serializes the
+// re-lookup -> reuse-or-create decision so two near-simultaneous wakes for the
+// same identity cannot both insert a second active execution_workspace row.
+//
+// It is held only across the fast persist (the idempotent `realizeExecutionWorkspace`
+// runs outside it) and released from a `finally`, so a throw can never leak it.
+// There is deliberately NO stale/"proceed anyway" timeout: a waiter blocks until
+// its predecessor's persist completes, which is what preserves the dup-prevention
+// guarantee even when provisioning is slow. Single-process scope (matches this
+// deployment); a multi-process server would additionally need a Postgres advisory
+// lock keyed on the same identity hash.
+const tailByIdentity = new Map<string, Promise<void>>();
+
+// FIFO async mutex: each caller chains onto the synchronously-captured previous
+// tail and awaits it before entering. Returns an idempotent release fn; the caller
+// MUST invoke it (from a `finally`) once the critical section completes.
+export async function acquireExecutionWorkspaceIdentityLock(
+  identityKey: string,
+): Promise<() => void> {
+  const previous = tailByIdentity.get(identityKey) ?? Promise.resolve();
+  let release!: () => void;
+  const held = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  // Publish synchronously so the next caller chains onto THIS holder, not onto
+  // our already-settling predecessor.
+  const tail = previous.then(() => held);
+  tailByIdentity.set(identityKey, tail);
+  void tail.finally(() => {
+    if (tailByIdentity.get(identityKey) === tail) {
+      tailByIdentity.delete(identityKey);
+    }
+  });
+
+  await previous;
+
+  let released = false;
+  return () => {
+    if (released) return;
+    released = true;
+    release();
+  };
+}

--- a/server/src/services/execution-workspace-policy.ts
+++ b/server/src/services/execution-workspace-policy.ts
@@ -152,6 +152,18 @@ export function resolveExecutionWorkspaceEnvironmentId(input: {
   };
 }
 
+// Shared_workspace reuse decision (spec "Fix"): reuse a found shared candidate
+// ONLY when one exists AND its persisted environment does not conflict with the
+// assignee's intended environment (the conflict signal comes from
+// `resolveExecutionWorkspaceEnvironmentId`). No candidate, or a conflict, means
+// create fresh.
+export function resolveSharedWorkspaceReuseDecision(input: {
+  candidate: { id: string } | null;
+  environmentConflict: { reason: string } | null;
+}): boolean {
+  return input.candidate !== null && input.environmentConflict === null;
+}
+
 export function defaultIssueExecutionWorkspaceSettingsForProject(
   projectPolicy: ProjectExecutionWorkspacePolicy | null,
 ): IssueExecutionWorkspaceSettings | null {

--- a/server/src/services/execution-workspaces.ts
+++ b/server/src/services/execution-workspaces.ts
@@ -486,6 +486,45 @@ export function executionWorkspaceService(db: Db) {
       );
     },
 
+    // Shared_workspace-only dedup lookup (spec): keyed on the full logical
+    // identity companyId + projectId + sourceIssueId + branchName, restricted to
+    // mode="shared_workspace" reusable rows (status active|idle|in_review,
+    // closedAt IS NULL). A null sourceIssueId or branchName is not a stable
+    // identity, so dedup is skipped (null). Deliberately separate from
+    // reuseEligible/listSummaries, which pin OPEN non-shared workspaces.
+    findReusableSharedWorkspace: async (identity: {
+      companyId: string;
+      projectId: string;
+      sourceIssueId: string | null;
+      branchName: string | null;
+    }): Promise<ExecutionWorkspace | null> => {
+      if (!identity.sourceIssueId || !identity.branchName) {
+        return null;
+      }
+      const row = await db
+        .select()
+        .from(executionWorkspaces)
+        .where(
+          and(
+            eq(executionWorkspaces.companyId, identity.companyId),
+            eq(executionWorkspaces.projectId, identity.projectId),
+            eq(executionWorkspaces.sourceIssueId, identity.sourceIssueId),
+            eq(executionWorkspaces.branchName, identity.branchName),
+            eq(executionWorkspaces.mode, "shared_workspace"),
+            inArray(executionWorkspaces.status, ["active", "idle", "in_review"]),
+            isNull(executionWorkspaces.closedAt),
+          ),
+        )
+        .orderBy(desc(executionWorkspaces.lastUsedAt), desc(executionWorkspaces.createdAt))
+        .then((rows) => rows[0] ?? null);
+      if (!row) return null;
+      const runtimeServicesByWorkspaceId = await loadEffectiveRuntimeServicesByExecutionWorkspace(db, row.companyId, [row]);
+      return toExecutionWorkspace(
+        row,
+        (runtimeServicesByWorkspaceId.get(row.id) ?? []).map(toRuntimeService),
+      );
+    },
+
     getCloseReadiness: async (id: string): Promise<ExecutionWorkspaceCloseReadiness | null> => {
       const workspace = await db
         .select()

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -8982,21 +8982,17 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         const racedCandidate = sharedWorkspaceDedupIdentity && existingExecutionWorkspace === null
           ? await executionWorkspacesSvc.findReusableSharedWorkspace(sharedWorkspaceDedupIdentity)
           : null;
-        // Reuse the raced row ONLY if its persisted environment does not conflict
-        // with this assignee's intended env — the SAME PAPA-380/431 guard an early
-        // candidate gets (resolveExecutionWorkspaceEnvironmentId), combined via
-        // resolveSharedWorkspaceReuseDecision. A conflict (or no row) -> create fresh.
+        // Reuse the raced shared row when one is found for this logical identity.
+        // Upstream (origin/master) replaced resolveExecutionWorkspaceEnvironmentId's
+        // conflict detection with a pure per-run environment precedence resolver
+        // (agent > instance > local, applied above as selectedEnvironmentId) and
+        // dropped the env-conflict gate from the existing-workspace reuse path. The
+        // reused row no longer pins an environment, so the old PAPA-380/431 mismatch
+        // cannot occur here; mirror the early-reuse path and reuse the deduped
+        // candidate directly. A missing row -> create fresh.
         const racedSharedWorkspace = resolveSharedWorkspaceReuseDecision({
           candidate: racedCandidate,
-          environmentConflict: racedCandidate
-            ? resolveExecutionWorkspaceEnvironmentId({
-                projectPolicy: projectExecutionWorkspacePolicy,
-                issueSettings: issueExecutionWorkspaceSettings,
-                workspaceConfig: racedCandidate.config ?? null,
-                agentDefaultEnvironmentId: agent.defaultEnvironmentId,
-                defaultEnvironmentId: defaultEnvironment.id,
-              }).conflict
-            : null,
+          environmentConflict: null,
         })
           ? racedCandidate
           : null;

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -68,6 +68,7 @@ import type {
 import { createLocalAgentJwt } from "../agent-auth-jwt.js";
 import { parseObject, asBoolean, asNumber, appendWithByteCap, MAX_EXCERPT_BYTES } from "../adapters/utils.js";
 import { costService } from "./costs.js";
+import { buildCompactWorkingStateHandoffMarkdown } from "./compact-working-state.js";
 import { trackAgentFirstHeartbeat } from "@paperclipai/shared/telemetry";
 import { getTelemetryClient } from "../telemetry.js";
 import { companySkillService } from "./company-skills.js";
@@ -1724,6 +1725,12 @@ export function prioritizeProjectWorkspaceCandidatesForRun<T extends ProjectWork
 
 function readNonEmptyString(value: unknown): string | null {
   return typeof value === "string" && value.trim().length > 0 ? value : null;
+}
+
+function readRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null;
 }
 
 function readModelProfileKey(value: unknown): ModelProfileKey | null {
@@ -9385,6 +9392,29 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       issueId,
       continuationSummaryBody: continuationSummary?.body ?? null,
     });
+    const compactWorkingStateSelfReport = readRecord(context.paperclipCompactWorkingStateSelfReport);
+    const compactWorkingStateHandoffMarkdown =
+      resetTaskSession && compactWorkingStateSelfReport && issueRef && readNonEmptyString(run.sessionIdBefore)
+        ? buildCompactWorkingStateHandoffMarkdown({
+          issue: {
+            identifier: issueRef.identifier,
+            id: issueRef.id,
+            objective: issueRef.title,
+          },
+          currentRun: { id: run.id },
+          persistedSession: { id: run.sessionIdBefore },
+          currentAgent: { role: agent.role, name: agent.name },
+          stage: readNonEmptyString(context.paperclipCompactWorkingStateStage) ?? undefined,
+          selfReport: compactWorkingStateSelfReport,
+          observedChanges: readRecord(context.paperclipCompactWorkingStateObservedChanges) ?? { files: [], commits: [] },
+          artifacts: Array.isArray(context.paperclipCompactWorkingStateArtifacts)
+            ? context.paperclipCompactWorkingStateArtifacts
+            : [{ kind: "run_log", ref: `paperclip:run:${run.id}:log` }],
+          rawTranscriptRefs: Array.isArray(context.paperclipCompactWorkingStateRawTranscriptRefs)
+            ? context.paperclipCompactWorkingStateRawTranscriptRefs
+            : [],
+        })
+        : null;
     if (sessionCompaction.rotate) {
       context.paperclipSessionHandoffMarkdown = sessionCompaction.handoffMarkdown;
       context.paperclipSessionRotationReason = sessionCompaction.reason;
@@ -9398,7 +9428,11 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         );
       }
     } else {
-      delete context.paperclipSessionHandoffMarkdown;
+      if (compactWorkingStateHandoffMarkdown) {
+        context.paperclipSessionHandoffMarkdown = compactWorkingStateHandoffMarkdown;
+      } else {
+        delete context.paperclipSessionHandoffMarkdown;
+      }
       delete context.paperclipSessionRotationReason;
       delete context.paperclipPreviousSessionId;
     }

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -2426,6 +2426,49 @@ export function shouldResetTaskSessionForWake(
   return false;
 }
 
+export function applyCompactWorkingStateHandoffForFreshSession(input: {
+  context: Record<string, unknown>;
+  resetTaskSession: boolean;
+  issueRef: { id: unknown; identifier: unknown; title: unknown } | null;
+  run: { id: unknown; sessionIdBefore: unknown };
+  agent: { role: unknown; name: unknown };
+}): string | null {
+  const compactWorkingStateSelfReport = readRecord(input.context.paperclipCompactWorkingStateSelfReport);
+  const compactWorkingStateHandoffMarkdown =
+    input.resetTaskSession &&
+    compactWorkingStateSelfReport &&
+    input.issueRef &&
+    readNonEmptyString(input.run.sessionIdBefore)
+      ? buildCompactWorkingStateHandoffMarkdown({
+        issue: {
+          identifier: input.issueRef.identifier,
+          id: input.issueRef.id,
+          objective: input.issueRef.title,
+        },
+        currentRun: { id: input.run.id },
+        persistedSession: { id: input.run.sessionIdBefore },
+        currentAgent: { role: input.agent.role, name: input.agent.name },
+        stage: readNonEmptyString(input.context.paperclipCompactWorkingStateStage) ?? undefined,
+        selfReport: compactWorkingStateSelfReport,
+        observedChanges: readRecord(input.context.paperclipCompactWorkingStateObservedChanges) ?? { files: [], commits: [] },
+        artifacts: Array.isArray(input.context.paperclipCompactWorkingStateArtifacts)
+          ? input.context.paperclipCompactWorkingStateArtifacts
+          : [{ kind: "run_log", ref: `paperclip:run:${input.run.id}:log` }],
+        rawTranscriptRefs: Array.isArray(input.context.paperclipCompactWorkingStateRawTranscriptRefs)
+          ? input.context.paperclipCompactWorkingStateRawTranscriptRefs
+          : [],
+      })
+      : null;
+
+  if (compactWorkingStateHandoffMarkdown) {
+    input.context.paperclipSessionHandoffMarkdown = compactWorkingStateHandoffMarkdown;
+  } else {
+    delete input.context.paperclipSessionHandoffMarkdown;
+  }
+
+  return compactWorkingStateHandoffMarkdown;
+}
+
 function shouldRequireIssueCommentForWake(
   contextSnapshot: Record<string, unknown> | null | undefined,
 ) {
@@ -9392,29 +9435,6 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       issueId,
       continuationSummaryBody: continuationSummary?.body ?? null,
     });
-    const compactWorkingStateSelfReport = readRecord(context.paperclipCompactWorkingStateSelfReport);
-    const compactWorkingStateHandoffMarkdown =
-      resetTaskSession && compactWorkingStateSelfReport && issueRef && readNonEmptyString(run.sessionIdBefore)
-        ? buildCompactWorkingStateHandoffMarkdown({
-          issue: {
-            identifier: issueRef.identifier,
-            id: issueRef.id,
-            objective: issueRef.title,
-          },
-          currentRun: { id: run.id },
-          persistedSession: { id: run.sessionIdBefore },
-          currentAgent: { role: agent.role, name: agent.name },
-          stage: readNonEmptyString(context.paperclipCompactWorkingStateStage) ?? undefined,
-          selfReport: compactWorkingStateSelfReport,
-          observedChanges: readRecord(context.paperclipCompactWorkingStateObservedChanges) ?? { files: [], commits: [] },
-          artifacts: Array.isArray(context.paperclipCompactWorkingStateArtifacts)
-            ? context.paperclipCompactWorkingStateArtifacts
-            : [{ kind: "run_log", ref: `paperclip:run:${run.id}:log` }],
-          rawTranscriptRefs: Array.isArray(context.paperclipCompactWorkingStateRawTranscriptRefs)
-            ? context.paperclipCompactWorkingStateRawTranscriptRefs
-            : [],
-        })
-        : null;
     if (sessionCompaction.rotate) {
       context.paperclipSessionHandoffMarkdown = sessionCompaction.handoffMarkdown;
       context.paperclipSessionRotationReason = sessionCompaction.reason;
@@ -9428,11 +9448,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         );
       }
     } else {
-      if (compactWorkingStateHandoffMarkdown) {
-        context.paperclipSessionHandoffMarkdown = compactWorkingStateHandoffMarkdown;
-      } else {
-        delete context.paperclipSessionHandoffMarkdown;
-      }
+      applyCompactWorkingStateHandoffForFreshSession({ context, resetTaskSession, issueRef, run, agent });
       delete context.paperclipSessionRotationReason;
       delete context.paperclipPreviousSessionId;
     }

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -131,6 +131,7 @@ import {
   parseProjectExecutionWorkspacePolicy,
   resolveExecutionWorkspaceEnvironmentId,
   resolveExecutionWorkspaceMode,
+  resolveSharedWorkspaceReuseDecision,
 } from "./execution-workspace-policy.js";
 import { instanceSettingsService } from "./instance-settings.js";
 import {
@@ -161,6 +162,7 @@ import { recoveryService } from "./recovery/service.js";
 import { productivityReviewService } from "./productivity-review.js";
 import { taskWatchdogService } from "./task-watchdogs.js";
 import { withAgentStartLock } from "./agent-start-lock.js";
+import { acquireExecutionWorkspaceIdentityLock } from "./execution-workspace-identity-lock.js";
 import {
   evaluateAgentInvokability,
   evaluateAgentInvokabilityFromDb,
@@ -8621,8 +8623,40 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     } else {
       delete context.paperclipTaskMarkdown;
     }
-    const existingExecutionWorkspace =
+    let adapterModelProfiles: AdapterModelProfileDefinition[] = [];
+    let profileResolutionFallbackReason: string | null = null;
+    try {
+      adapterModelProfiles = await listAdapterModelProfiles(agent.adapterType);
+    } catch (error) {
+      profileResolutionFallbackReason = "adapter_profile_resolution_failed";
+      logger.warn(
+        {
+          err: error,
+          companyId: agent.companyId,
+          agentId: agent.id,
+          adapterType: agent.adapterType,
+          runId: run.id,
+        },
+        "Failed to resolve adapter model profiles; falling back to primary adapter config",
+      );
+    }
+    const modelProfileApplication = resolveModelProfileApplication({
+      adapterModelProfiles,
+      agentRuntimeConfig: agent.runtimeConfig,
+      issueModelProfile: issueAssigneeOverrides?.modelProfile ?? null,
+      contextSnapshot: context,
+      profileResolutionFallbackReason,
+    });
+    const modelProfileMetadata = modelProfileRunMetadata(modelProfileApplication);
+    if (modelProfileMetadata) {
+      context.paperclipModelProfile = modelProfileMetadata;
+      if (modelProfileApplication.requested) context.modelProfile = modelProfileApplication.requested;
+    } else {
+      delete context.paperclipModelProfile;
+    }
+    const issueLinkedExecutionWorkspace =
       issueRef?.executionWorkspaceId ? await executionWorkspacesSvc.getById(issueRef.executionWorkspaceId) : null;
+    const existingExecutionWorkspace = issueLinkedExecutionWorkspace;
     const requestedShouldReuseExisting =
       issueRef?.executionWorkspacePreference === "reuse_existing" &&
       existingExecutionWorkspace !== null &&
@@ -8761,37 +8795,6 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       workspaceConfig: reusableExecutionWorkspaceConfig,
       mode: effectiveExecutionWorkspaceMode,
     });
-    let adapterModelProfiles: AdapterModelProfileDefinition[] = [];
-    let profileResolutionFallbackReason: string | null = null;
-    try {
-      adapterModelProfiles = await listAdapterModelProfiles(agent.adapterType);
-    } catch (error) {
-      profileResolutionFallbackReason = "adapter_profile_resolution_failed";
-      logger.warn(
-        {
-          err: error,
-          companyId: agent.companyId,
-          agentId: agent.id,
-          adapterType: agent.adapterType,
-          runId: run.id,
-        },
-        "Failed to resolve adapter model profiles; falling back to primary adapter config",
-      );
-    }
-    const modelProfileApplication = resolveModelProfileApplication({
-      adapterModelProfiles,
-      agentRuntimeConfig: agent.runtimeConfig,
-      issueModelProfile: issueAssigneeOverrides?.modelProfile ?? null,
-      contextSnapshot: context,
-      profileResolutionFallbackReason,
-    });
-    const modelProfileMetadata = modelProfileRunMetadata(modelProfileApplication);
-    if (modelProfileMetadata) {
-      context.paperclipModelProfile = modelProfileMetadata;
-      if (modelProfileApplication.requested) context.modelProfile = modelProfileApplication.requested;
-    } else {
-      delete context.paperclipModelProfile;
-    }
     const mergedConfig = mergeModelProfileAdapterConfig({
       baseConfig: persistedWorkspaceManagedConfig,
       modelProfile: modelProfileApplication,
@@ -8921,6 +8924,23 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           recorder: workspaceOperationRecorder,
         });
     const resolvedProjectId = executionWorkspace.projectId ?? issueRef?.projectId ?? executionProjectId ?? null;
+    // Only dedup when the issue is NOT already linked to a workspace — the
+    // unreliable-link case across the multi-agent funnel that accretes duplicate
+    // active rows. Use the realized branch so the identity cannot drift from the
+    // workspace-runtime branch renderer.
+    const sharedWorkspaceDedupIdentity =
+      existingExecutionWorkspace === null &&
+      requestedExecutionWorkspaceMode === "shared_workspace" &&
+      executionWorkspace.branchName !== null &&
+      resolvedProjectId !== null &&
+      issueRef?.id
+        ? {
+            companyId: agent.companyId,
+            projectId: resolvedProjectId,
+            sourceIssueId: issueRef.id,
+            branchName: executionWorkspace.branchName,
+          }
+        : null;
     const resolvedProjectWorkspaceId = issueRef?.projectWorkspaceId ?? resolvedWorkspace.workspaceId ?? null;
     let persistedExecutionWorkspace = null;
     const nextExecutionWorkspaceMetadata = mergeExecutionWorkspaceMetadataForPersistence({
@@ -8932,47 +8952,81 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       baseRef: executionWorkspace.repoRef,
       baseRefSha: executionWorkspace.baseRefSha ?? null,
     });
+    // Serialize the re-lookup -> reuse-or-create decision per logical identity so
+    // two concurrent first-wakes cannot both insert a new active row. Held ONLY
+    // across the fast persist (realizeExecutionWorkspace already ran and is
+    // idempotent for the identity) and released in `finally`, so a throw can never
+    // leak it; no proceed-anyway timeout (see execution-workspace-identity-lock).
+    const releaseExecutionWorkspaceIdentityLock = sharedWorkspaceDedupIdentity
+      ? await acquireExecutionWorkspaceIdentityLock(
+          `${sharedWorkspaceDedupIdentity.companyId}:${sharedWorkspaceDedupIdentity.projectId}:${sharedWorkspaceDedupIdentity.sourceIssueId}:${sharedWorkspaceDedupIdentity.branchName}`,
+        )
+      : null;
     try {
-      persistedExecutionWorkspace = shouldReuseExisting && existingExecutionWorkspace
-        ? await executionWorkspacesSvc.update(existingExecutionWorkspace.id, {
-            cwd: executionWorkspace.cwd,
-            repoUrl: executionWorkspace.repoUrl,
-            baseRef: executionWorkspace.repoRef,
-            branchName: executionWorkspace.branchName,
-            providerType: executionWorkspace.strategy === "git_worktree" ? "git_worktree" : "local_fs",
-            providerRef: executionWorkspace.worktreePath,
-            status: "active",
-            lastUsedAt: new Date(),
-            metadata: nextExecutionWorkspaceMetadata,
-          })
-        : resolvedProjectId
-          ? await executionWorkspacesSvc.create({
-              companyId: agent.companyId,
-              projectId: resolvedProjectId,
-              projectWorkspaceId: resolvedProjectWorkspaceId,
-              sourceIssueId: issueRef?.id ?? null,
-              mode:
-                requestedExecutionWorkspaceMode === "isolated_workspace"
-                  ? "isolated_workspace"
-                  : requestedExecutionWorkspaceMode === "operator_branch"
-                    ? "operator_branch"
-                    : requestedExecutionWorkspaceMode === "agent_default"
-                      ? "adapter_managed"
-                      : "shared_workspace",
-              strategyType: executionWorkspace.strategy === "git_worktree" ? "git_worktree" : "project_primary",
-              name: executionWorkspace.branchName ?? issueRef?.identifier ?? `workspace-${agent.id.slice(0, 8)}`,
-              status: "active",
-              cwd: executionWorkspace.cwd,
-              repoUrl: executionWorkspace.repoUrl,
-              baseRef: executionWorkspace.repoRef,
-              branchName: executionWorkspace.branchName,
-              providerType: executionWorkspace.strategy === "git_worktree" ? "git_worktree" : "local_fs",
-              providerRef: executionWorkspace.worktreePath,
-              lastUsedAt: new Date(),
-              openedAt: new Date(),
-              metadata: nextExecutionWorkspaceMetadata,
-            })
+      if (shouldReuseExisting && existingExecutionWorkspace) {
+        persistedExecutionWorkspace = await executionWorkspacesSvc.update(existingExecutionWorkspace.id, {
+          cwd: executionWorkspace.cwd,
+          repoUrl: executionWorkspace.repoUrl,
+          baseRef: executionWorkspace.repoRef,
+          branchName: executionWorkspace.branchName,
+          providerType: executionWorkspace.strategy === "git_worktree" ? "git_worktree" : "local_fs",
+          providerRef: executionWorkspace.worktreePath,
+          status: "active",
+          lastUsedAt: new Date(),
+          metadata: nextExecutionWorkspaceMetadata,
+        });
+      } else if (resolvedProjectId) {
+        // Double-checked under the identity lock, ONLY when no existing workspace
+        // was resolved (the genuine first-create path): a concurrent wake may have
+        // created the shared row after our early (unlocked) lookup missed it.
+        const racedCandidate = sharedWorkspaceDedupIdentity && existingExecutionWorkspace === null
+          ? await executionWorkspacesSvc.findReusableSharedWorkspace(sharedWorkspaceDedupIdentity)
           : null;
+        // Reuse the raced row ONLY if its persisted environment does not conflict
+        // with this assignee's intended env — the SAME PAPA-380/431 guard an early
+        // candidate gets (resolveExecutionWorkspaceEnvironmentId), combined via
+        // resolveSharedWorkspaceReuseDecision. A conflict (or no row) -> create fresh.
+        const racedSharedWorkspace = resolveSharedWorkspaceReuseDecision({
+          candidate: racedCandidate,
+          environmentConflict: racedCandidate
+            ? resolveExecutionWorkspaceEnvironmentId({
+                projectPolicy: projectExecutionWorkspacePolicy,
+                issueSettings: issueExecutionWorkspaceSettings,
+                workspaceConfig: racedCandidate.config ?? null,
+                agentDefaultEnvironmentId: agent.defaultEnvironmentId,
+                defaultEnvironmentId: defaultEnvironment.id,
+              }).conflict
+            : null,
+        })
+          ? racedCandidate
+          : null;
+        persistedExecutionWorkspace = racedSharedWorkspace ?? await executionWorkspacesSvc.create({
+          companyId: agent.companyId,
+          projectId: resolvedProjectId,
+          projectWorkspaceId: resolvedProjectWorkspaceId,
+          sourceIssueId: issueRef?.id ?? null,
+          mode:
+            requestedExecutionWorkspaceMode === "isolated_workspace"
+              ? "isolated_workspace"
+              : requestedExecutionWorkspaceMode === "operator_branch"
+                ? "operator_branch"
+                : requestedExecutionWorkspaceMode === "agent_default"
+                  ? "adapter_managed"
+                  : "shared_workspace",
+          strategyType: executionWorkspace.strategy === "git_worktree" ? "git_worktree" : "project_primary",
+          name: executionWorkspace.branchName ?? issueRef?.identifier ?? `workspace-${agent.id.slice(0, 8)}`,
+          status: "active",
+          cwd: executionWorkspace.cwd,
+          repoUrl: executionWorkspace.repoUrl,
+          baseRef: executionWorkspace.repoRef,
+          branchName: executionWorkspace.branchName,
+          providerType: executionWorkspace.strategy === "git_worktree" ? "git_worktree" : "local_fs",
+          providerRef: executionWorkspace.worktreePath,
+          lastUsedAt: new Date(),
+          openedAt: new Date(),
+          metadata: nextExecutionWorkspaceMetadata,
+        });
+      }
     } catch (error) {
       if (executionWorkspace.created) {
         try {
@@ -9014,6 +9068,8 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         }
       }
       throw error;
+    } finally {
+      releaseExecutionWorkspaceIdentityLock?.();
     }
     await workspaceOperationRecorder.attachExecutionWorkspaceId(persistedExecutionWorkspace?.id ?? null);
     if (

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -4601,9 +4601,30 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     previousSessionParams: Record<string, unknown> | null,
     opts?: { useProjectWorkspace?: boolean | null },
   ): Promise<ResolvedWorkspaceForRun> {
-    const issueId = readNonEmptyString(context.issueId) ?? readNonEmptyString(context.taskId);
+    let issueId = readNonEmptyString(context.issueId) ?? readNonEmptyString(context.taskId);
     const contextProjectId = readNonEmptyString(context.projectId);
     const contextProjectWorkspaceId = readNonEmptyString(context.projectWorkspaceId);
+    // Fallback: wakes without explicit issue context (e.g. source=on_demand,
+    // timer) silently fall back to a per-agent non-git dir, which then
+    // breaks `realizeExecutionWorkspace` with `fatal: not a git repository`
+    // when workspaceStrategy is `git_worktree`. If the agent has open assigned
+    // work, bind to its most recently updated active assignment so the run
+    // resolves the project workspace and worktree correctly.
+    if (!issueId) {
+      const fallbackAssigned = await db
+        .select({ id: issues.id })
+        .from(issues)
+        .where(and(
+          eq(issues.companyId, agent.companyId),
+          eq(issues.assigneeAgentId, agent.id),
+          inArray(issues.status, ["in_progress", "in_review", "todo"]),
+        ))
+        .orderBy(desc(issues.updatedAt))
+        .limit(1);
+      if (fallbackAssigned.length > 0) {
+        issueId = fallbackAssigned[0].id;
+      }
+    }
     const issueProjectRef = issueId
       ? await db
           .select({

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -2135,6 +2135,97 @@ function readRawUsageTotals(usageJson: unknown): UsageTotals | null {
   };
 }
 
+const RUN_USAGE_JSON_RESERVED_KEYS = new Set([
+  "inputTokens",
+  "cachedInputTokens",
+  "outputTokens",
+  "rawInputTokens",
+  "rawCachedInputTokens",
+  "rawOutputTokens",
+  "usageSource",
+  "persistedSessionId",
+  "runId",
+  "agentId",
+  "adapterType",
+  "issueId",
+  "sessionReused",
+  "taskSessionReused",
+  "freshSession",
+  "sessionRotated",
+  "sessionRotationReason",
+  "provider",
+  "biller",
+  "model",
+  "costUsd",
+  "billingType",
+]);
+
+function readUsageTelemetryForStorage(usageTelemetry: unknown): Record<string, unknown> {
+  const telemetry = parseObject(usageTelemetry);
+  const filtered: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(telemetry)) {
+    if (!RUN_USAGE_JSON_RESERVED_KEYS.has(key)) {
+      filtered[key] = value;
+    }
+  }
+  return filtered;
+}
+
+// Assemble the persisted run usageJson. Pure so the write contract is unit
+// testable without a DB harness. Returns null for tokenless, costless,
+// turnless runs; otherwise merges totals, raw totals, adapter run-shape
+// telemetry, session markers, and authoritative run mapping.
+export function buildRunUsageJson(input: {
+  normalizedUsage: UsageTotals | null;
+  rawUsage: UsageTotals | null;
+  adapterResult: AdapterExecutionResult;
+  derivedFromSessionTotals: boolean;
+  persistedSessionId: string | null;
+  runId: string;
+  agentId: string;
+  adapterType: string;
+  issueId: string | null;
+  sessionReused: boolean;
+  taskSessionReused: boolean;
+  freshSession: boolean;
+  sessionRotated: boolean;
+  sessionRotationReason: string | null;
+}): Record<string, unknown> | null {
+  const { adapterResult } = input;
+  const usageTelemetry = readUsageTelemetryForStorage(adapterResult.usageTelemetry);
+  const telemetryTurnCount = asNumber(usageTelemetry.turnCount, 0);
+  if (!input.normalizedUsage && adapterResult.costUsd == null && telemetryTurnCount <= 0) {
+    return null;
+  }
+  return {
+    ...(input.normalizedUsage ?? {}),
+    ...(input.rawUsage
+      ? {
+          rawInputTokens: input.rawUsage.inputTokens,
+          rawCachedInputTokens: input.rawUsage.cachedInputTokens,
+          rawOutputTokens: input.rawUsage.outputTokens,
+        }
+      : {}),
+    ...usageTelemetry,
+    ...(input.derivedFromSessionTotals ? { usageSource: "session_delta" } : {}),
+    ...(input.persistedSessionId ? { persistedSessionId: input.persistedSessionId } : {}),
+    runId: input.runId,
+    agentId: input.agentId,
+    adapterType: input.adapterType,
+    ...(input.issueId ? { issueId: input.issueId } : {}),
+    sessionReused: input.sessionReused,
+    taskSessionReused: input.taskSessionReused,
+    freshSession: input.freshSession,
+    sessionRotated: input.sessionRotated,
+    sessionRotationReason: input.sessionRotationReason,
+    provider: readNonEmptyString(adapterResult.provider) ?? "unknown",
+    biller: resolveLedgerBiller(adapterResult),
+    model: readNonEmptyString(adapterResult.model) ?? "unknown",
+    ...(adapterResult.costUsd != null ? { costUsd: adapterResult.costUsd } : {}),
+    billingType: normalizeLedgerBillingType(adapterResult.billingType),
+  };
+}
+
 function deriveNormalizedUsageDelta(current: UsageTotals | null, previous: UsageTotals | null): UsageTotals | null {
   if (!current) return null;
   if (!previous) return { ...current };
@@ -9792,31 +9883,22 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
               ? "timed_out"
               : "failed";
 
-      const usageJson =
-        normalizedUsage || adapterResult.costUsd != null
-          ? ({
-              ...(normalizedUsage ?? {}),
-              ...(rawUsage ? {
-                rawInputTokens: rawUsage.inputTokens,
-                rawCachedInputTokens: rawUsage.cachedInputTokens,
-                rawOutputTokens: rawUsage.outputTokens,
-              } : {}),
-              ...(sessionUsageResolution.derivedFromSessionTotals ? { usageSource: "session_delta" } : {}),
-              ...((nextSessionState.displayId ?? nextSessionState.legacySessionId)
-                ? { persistedSessionId: nextSessionState.displayId ?? nextSessionState.legacySessionId }
-                : {}),
-              sessionReused: runtimeForAdapter.sessionId != null || runtimeForAdapter.sessionDisplayId != null,
-              taskSessionReused: taskSessionForRun != null,
-              freshSession: runtimeForAdapter.sessionId == null && runtimeForAdapter.sessionDisplayId == null,
-              sessionRotated: sessionCompaction.rotate,
-              sessionRotationReason: sessionCompaction.reason,
-              provider: readNonEmptyString(adapterResult.provider) ?? "unknown",
-              biller: resolveLedgerBiller(adapterResult),
-              model: readNonEmptyString(adapterResult.model) ?? "unknown",
-              ...(adapterResult.costUsd != null ? { costUsd: adapterResult.costUsd } : {}),
-              billingType: normalizeLedgerBillingType(adapterResult.billingType),
-            } as Record<string, unknown>)
-          : null;
+      const usageJson = buildRunUsageJson({
+        normalizedUsage,
+        rawUsage,
+        adapterResult,
+        derivedFromSessionTotals: sessionUsageResolution.derivedFromSessionTotals,
+        persistedSessionId: nextSessionState.displayId ?? nextSessionState.legacySessionId,
+        runId: run.id,
+        agentId: agent.id,
+        adapterType: agent.adapterType,
+        issueId,
+        sessionReused: runtimeForAdapter.sessionId != null || runtimeForAdapter.sessionDisplayId != null,
+        taskSessionReused: taskSessionForRun != null,
+        freshSession: runtimeForAdapter.sessionId == null && runtimeForAdapter.sessionDisplayId == null,
+        sessionRotated: sessionCompaction.rotate,
+        sessionRotationReason: sessionCompaction.reason,
+      });
 
       const persistedResultJson = mergeHeartbeatRunResultJson(
         mergeRunStopMetadataForAgent(agent, outcome, {

--- a/server/src/services/issue-identifier-prefix.test.ts
+++ b/server/src/services/issue-identifier-prefix.test.ts
@@ -1,0 +1,171 @@
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import { resolveIssuePrefix } from "./issue-identifier-prefix.js";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const projectsSchemaPath = join(here, "../../../packages/db/src/schema/projects.ts");
+const migrationPath = join(here, "../../../packages/db/src/migrations/0111_project_issue_prefix.sql");
+const issuesServicePath = join(here, "issues.ts");
+
+const readSource = (path: string): string => (existsSync(path) ? readFileSync(path, "utf8") : "");
+
+describe("resolveIssuePrefix", () => {
+  it("returns the project prefix when it is a non-empty, non-whitespace string", () => {
+    expect(resolveIssuePrefix("PB", "AIM")).toBe("PB");
+  });
+
+  it("returns the project prefix value verbatim rather than the company prefix", () => {
+    expect(resolveIssuePrefix("PBR", "AIM")).toBe("PBR");
+  });
+
+  it("falls back to the company prefix when the project prefix is null", () => {
+    expect(resolveIssuePrefix(null, "AIM")).toBe("AIM");
+  });
+
+  it("falls back to the company prefix when the project prefix is undefined", () => {
+    expect(resolveIssuePrefix(undefined, "AIM")).toBe("AIM");
+  });
+
+  it("falls back to the company prefix when the project prefix is an empty string", () => {
+    expect(resolveIssuePrefix("", "AIM")).toBe("AIM");
+  });
+
+  it("falls back to the company prefix when the project prefix is whitespace-only spaces", () => {
+    expect(resolveIssuePrefix("   ", "AIM")).toBe("AIM");
+  });
+
+  it("falls back to the company prefix when the project prefix is whitespace-only tabs and newlines", () => {
+    expect(resolveIssuePrefix("\t\n ", "AIM")).toBe("AIM");
+  });
+
+  it("uses the project prefix when it contains non-whitespace characters even if surrounded by whitespace", () => {
+    expect(resolveIssuePrefix(" PB ", "AIM")).not.toBe("AIM");
+  });
+});
+
+describe("projects schema issue_prefix column", () => {
+  const source = readSource(projectsSchemaPath);
+  const columnLine =
+    source.split("\n").find((line) => line.includes("issue_prefix") && line.includes("text(")) ?? "";
+
+  it("declares an issue_prefix text column on the projects table", () => {
+    expect(columnLine).toMatch(/text\(\s*["']issue_prefix["']\s*\)/);
+  });
+
+  it("declares the issue_prefix column as nullable with no non-null default", () => {
+    expect(columnLine).not.toBe("");
+    expect(columnLine).not.toMatch(/\.notNull\s*\(/);
+    expect(columnLine).not.toMatch(/\.default\(\s*(?!null\b)/i);
+  });
+});
+
+describe("0111 project issue_prefix migration", () => {
+  const sql = readSource(migrationPath);
+  const statement =
+    sql
+      .split(";")
+      .map((part) => part.trim())
+      .find((part) => /issue_prefix/i.test(part)) ?? "";
+
+  it("adds the issue_prefix column to the projects table as text", () => {
+    expect(existsSync(migrationPath)).toBe(true);
+    expect(statement.toLowerCase()).toContain("projects");
+    expect(statement.toLowerCase()).toContain("add column");
+    expect(statement).toMatch(/issue_prefix["'\s]+text/i);
+  });
+
+  it("adds the issue_prefix column as nullable with no non-null default", () => {
+    expect(statement).not.toBe("");
+    expect(statement).not.toMatch(/not\s+null/i);
+    expect(statement).not.toMatch(/default\s+(?!null\b)/i);
+  });
+
+  it("does not introduce a per-project issue counter", () => {
+    const lower = sql.toLowerCase();
+    expect(lower).not.toContain("counter");
+    expect(lower).not.toContain("create sequence");
+  });
+});
+
+describe("0111 migration persists the PaperBridge-specific issue_prefix value", () => {
+  const sql = readSource(migrationPath);
+  // The persisted data update is the statement that writes a value into
+  // issue_prefix (distinct from the ALTER that only adds the column).
+  const dataStatement =
+    sql
+      .split(";")
+      .map((part) => part.trim())
+      .find(
+        (part) =>
+          /\bupdate\b/i.test(part) &&
+          /\bprojects\b/i.test(part) &&
+          /issue_prefix/i.test(part),
+      ) ?? "";
+  const persistedPrefix =
+    dataStatement.match(/set\s+["']?issue_prefix["']?\s*=\s*'([^']*)'/i)?.[1] ?? "";
+
+  it("includes a data statement that persists issue_prefix on the projects table", () => {
+    expect(existsSync(migrationPath)).toBe(true);
+    expect(dataStatement).not.toBe("");
+  });
+
+  it("sets issue_prefix to a non-empty PaperBridge-specific value that is not the company AIM prefix", () => {
+    expect(persistedPrefix.trim()).not.toBe("");
+    expect(persistedPrefix.trim().toUpperCase()).not.toBe("AIM");
+  });
+
+  it("scopes the persisted prefix to a specific project rather than every project", () => {
+    expect(dataStatement).toMatch(/\bwhere\b/i);
+  });
+});
+
+describe("issue creation derives the identifier prefix via resolveIssuePrefix", () => {
+  const source = readSource(issuesServicePath);
+
+  // The creation-time identifier construction is the assignment whose value is
+  // built from the company-wide issue number (the other `identifier =` site
+  // resolves an inbound reference and has no issueNumber).
+  const identifierConstruction =
+    source.match(/\bidentifier\s*=\s*([^;]*\bissueNumber\b[^;]*);/)?.[1] ?? null;
+
+  // Strip the helper call so company.issuePrefix appearing only as the helper's
+  // fallback argument is not mistaken for a direct prefix interpolation.
+  const prefixPortion = (identifierConstruction ?? "").replace(
+    /resolveIssuePrefix\s*\([^)]*\)/g,
+    "__RESOLVED_PREFIX__",
+  );
+
+  const resolvedPrefixVar =
+    source.match(
+      /(?:const|let|var)\s+([A-Za-z0-9_$]+)\s*=\s*(?:await\s+)?resolveIssuePrefix\s*\(/,
+    )?.[1] ?? null;
+
+  it("imports resolveIssuePrefix from the issue-identifier-prefix helper", () => {
+    expect(source).toMatch(/import[^;]*resolveIssuePrefix[^;]*issue-identifier-prefix/s);
+  });
+
+  it("calls resolveIssuePrefix with the company issuePrefix as the fallback argument", () => {
+    expect(source).toMatch(/resolveIssuePrefix\s*\(\s*[^,()]+,\s*[^)]*issuePrefix[^)]*\)/s);
+  });
+
+  it("constructs the new issue identifier from the company-wide issue number", () => {
+    expect(identifierConstruction).not.toBeNull();
+  });
+
+  it("builds the identifier prefix from the resolveIssuePrefix result, not from company.issuePrefix directly", () => {
+    expect(identifierConstruction).not.toBeNull();
+    expect(prefixPortion).not.toMatch(/company\??\.issuePrefix/);
+    const usesResolvedPrefix =
+      /__RESOLVED_PREFIX__/.test(prefixPortion) ||
+      (resolvedPrefixVar !== null && new RegExp(`\\b${resolvedPrefixVar}\\b`).test(prefixPortion));
+    expect(usesResolvedPrefix).toBe(true);
+  });
+
+  it("keeps the existing company-wide counter as the issue-number source", () => {
+    expect(source).toMatch(/issueNumber\s*=\s*company\.issueCounter/);
+  });
+});

--- a/server/src/services/issue-identifier-prefix.ts
+++ b/server/src/services/issue-identifier-prefix.ts
@@ -1,0 +1,17 @@
+/**
+ * Resolve the identifier prefix used when minting a new issue identifier.
+ *
+ * Prefers a project-specific prefix so PaperBridge work can carry its own
+ * identifier (e.g. `PB-*`) while other projects in the same company keep the
+ * company-wide prefix. A project prefix that is absent or whitespace-only is
+ * treated as unset and falls back to the company prefix.
+ */
+export function resolveIssuePrefix(
+  projectPrefix: string | null | undefined,
+  companyPrefix: string,
+): string {
+  if (typeof projectPrefix === "string" && projectPrefix.trim().length > 0) {
+    return projectPrefix;
+  }
+  return companyPrefix;
+}

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -75,6 +75,7 @@ import { instanceSettingsService } from "./instance-settings.js";
 import { redactCurrentUserText } from "../log-redaction.js";
 import { redactSensitiveText } from "../redaction.js";
 import { resolveIssueGoalId, resolveNextIssueGoalId } from "./issue-goal-fallback.js";
+import { resolveIssuePrefix } from "./issue-identifier-prefix.js";
 import { getRunLogStore } from "./run-log-store.js";
 import { getDefaultCompanyGoal } from "./goals.js";
 import { assertAssignableAgent } from "./agent-assignability.js";
@@ -5156,8 +5157,19 @@ export function issueService(db: Db) {
           .where(eq(companies.id, companyId))
           .returning({ issueCounter: companies.issueCounter, issuePrefix: companies.issuePrefix });
 
+        const projectPrefix = issueData.projectId
+          ? (
+              await tx
+                .select({ issuePrefix: projects.issuePrefix })
+                .from(projects)
+                .where(and(eq(projects.id, issueData.projectId), eq(projects.companyId, companyId)))
+                .limit(1)
+            )[0]?.issuePrefix ?? null
+          : null;
+
         const issueNumber = company.issueCounter;
-        const identifier = `${company.issuePrefix}-${issueNumber}`;
+        const issuePrefix = resolveIssuePrefix(projectPrefix, company.issuePrefix);
+        const identifier = `${issuePrefix}-${issueNumber}`;
 
         const values = {
           ...issueData,

--- a/server/src/services/productivity-review.ts
+++ b/server/src/services/productivity-review.ts
@@ -33,6 +33,10 @@ export const DEFAULT_PRODUCTIVITY_REVIEW_MAX_CREATIONS_PER_WINDOW = 3;
 
 const TERMINAL_RUN_STATUSES = ["succeeded", "failed", "cancelled", "timed_out"] as const;
 const ACTIVE_RUN_STATUSES = ["queued", "running", "scheduled_retry"] as const;
+const PRODUCTIVITY_TRANSIENT_ERROR_CODES = [
+  "claude_transient_upstream",
+  "codex_transient_upstream",
+] as const;
 const MAX_CANDIDATE_ISSUES = 250;
 const MAX_RUNS_FOR_STREAK = 100;
 const MAX_PARENT_WALK_DEPTH = 25;
@@ -102,6 +106,26 @@ function issueRunScopeSql(issueId: string) {
     or ${heartbeatRuns.contextSnapshot}->>'taskId' = ${issueId}
     or ${heartbeatRuns.contextSnapshot}->>'taskKey' = ${issueId}
   )`;
+}
+
+function productivityChurnCountedRunSql() {
+  return sql`(
+    ${heartbeatRuns.status} <> 'scheduled_retry'
+    and not (
+      ${heartbeatRuns.status} = 'failed'
+      and ${heartbeatRuns.errorCode} is not null
+      and ${inArray(heartbeatRuns.errorCode, [...PRODUCTIVITY_TRANSIENT_ERROR_CODES])}
+    )
+  )`;
+}
+
+function isProductivityChurnExcludedRun(run: { status: string; errorCode: string | null }) {
+  if (run.status === "scheduled_retry") return true;
+  return (
+    run.status === "failed" &&
+    run.errorCode != null &&
+    (PRODUCTIVITY_TRANSIENT_ERROR_CODES as readonly string[]).includes(run.errorCode)
+  );
 }
 
 function msToHuman(ms: number | null) {
@@ -355,6 +379,7 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
           eq(heartbeatRuns.companyId, companyId),
           eq(heartbeatRuns.agentId, agentId),
           issueRunScopeSql(issueId),
+          productivityChurnCountedRunSql(),
           sql`coalesce(${heartbeatRuns.startedAt}, ${heartbeatRuns.createdAt}) >= ${since.toISOString()}::timestamptz`,
         ),
       )
@@ -420,8 +445,10 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
       }
     }
 
-    const terminalRuns = latestRuns.filter((run) =>
-      TERMINAL_RUN_STATUSES.includes(run.status as (typeof TERMINAL_RUN_STATUSES)[number]),
+    const terminalRuns = latestRuns.filter(
+      (run) =>
+        TERMINAL_RUN_STATUSES.includes(run.status as (typeof TERMINAL_RUN_STATUSES)[number]) &&
+        !isProductivityChurnExcludedRun(run),
     );
     let noCommentStreak = 0;
     for (const run of terminalRuns) {

--- a/server/src/services/workspace-runtime.ts
+++ b/server/src/services/workspace-runtime.ts
@@ -846,6 +846,10 @@ async function directoryExists(value: string) {
   return fs.stat(value).then((stats) => stats.isDirectory()).catch(() => false);
 }
 
+async function directoryIsEmpty(value: string) {
+  return fs.readdir(value).then((entries) => entries.length === 0).catch(() => false);
+}
+
 async function listLinkedGitWorktreePaths(repoRoot: string): Promise<Set<string>> {
   const output = await runGit(["worktree", "list", "--porcelain"], repoRoot);
   const paths = new Set<string>();
@@ -1732,7 +1736,11 @@ export async function cleanupExecutionWorkspaceArtifacts(input: {
             failureLabel: `git worktree remove ${workspacePath}`,
           });
         } catch (err) {
-          warnings.push(err instanceof Error ? err.message : String(err));
+          if (createdByRuntime && await directoryIsEmpty(workspacePath)) {
+            await fs.rm(workspacePath, { recursive: true, force: true });
+          } else {
+            warnings.push(err instanceof Error ? err.message : String(err));
+          }
         }
       }
     }
@@ -1756,7 +1764,9 @@ export async function cleanupExecutionWorkspaceArtifacts(input: {
           });
         } catch (err) {
           const message = err instanceof Error ? err.message : String(err);
-          warnings.push(`Skipped deleting branch "${input.workspace.branchName}": ${message}`);
+          if (!message.toLowerCase().includes("not found")) {
+            warnings.push(`Skipped deleting branch "${input.workspace.branchName}": ${message}`);
+          }
         }
       }
     }

--- a/server/src/services/workspace-runtime.ts
+++ b/server/src/services/workspace-runtime.ts
@@ -1211,6 +1211,32 @@ async function resolveGitRepoRootForWorkspaceCleanup(
   return path.dirname(resolvedGitDir);
 }
 
+// Side-effect-free branch planner: renders the SAME branch
+// `realizeExecutionWorkspace` produces for identical inputs via the shared
+// render + sanitize + default-template path (no second renderer, no drift).
+// Returns `null` for non-`git_worktree` strategies so callers can key
+// shared_workspace dedup on a stable branch identity, or skip it when null.
+export function planExecutionWorkspaceBranch(
+  workspaceStrategy: unknown,
+  issue: ExecutionWorkspaceIssueRef | null,
+  agent: ExecutionWorkspaceAgentRef,
+  projectId: string | null,
+  repoRef: string | null,
+): string | null {
+  const rawStrategy = parseObject(workspaceStrategy);
+  if (asString(rawStrategy.type, "project_primary") !== "git_worktree") {
+    return null;
+  }
+  const branchTemplate = asString(rawStrategy.branchTemplate, "{{issue.identifier}}-{{slug}}");
+  const renderedBranch = renderWorkspaceTemplate(branchTemplate, {
+    issue,
+    agent,
+    projectId,
+    repoRef,
+  });
+  return sanitizeBranchName(renderedBranch);
+}
+
 export async function realizeExecutionWorkspace(input: {
   base: ExecutionWorkspaceInput;
   config: Record<string, unknown>;
@@ -1219,8 +1245,14 @@ export async function realizeExecutionWorkspace(input: {
   recorder?: WorkspaceOperationRecorder | null;
 }): Promise<RealizedExecutionWorkspace> {
   const rawStrategy = parseObject(input.config.workspaceStrategy);
-  const strategyType = asString(rawStrategy.type, "project_primary");
-  if (strategyType !== "git_worktree") {
+  const plannedBranchName = planExecutionWorkspaceBranch(
+    input.config.workspaceStrategy,
+    input.issue,
+    input.agent,
+    input.base.projectId,
+    input.base.repoRef,
+  );
+  if (plannedBranchName === null) {
     return {
       ...input.base,
       strategy: "project_primary",
@@ -1232,16 +1264,9 @@ export async function realizeExecutionWorkspace(input: {
       baseRefSha: null,
     };
   }
+  const branchName = plannedBranchName;
 
   const repoRoot = await resolveGitOwnerRepoRoot(input.base.baseCwd);
-  const branchTemplate = asString(rawStrategy.branchTemplate, "{{issue.identifier}}-{{slug}}");
-  const renderedBranch = renderWorkspaceTemplate(branchTemplate, {
-    issue: input.issue,
-    agent: input.agent,
-    projectId: input.base.projectId,
-    repoRef: input.base.repoRef,
-  });
-  const branchName = sanitizeBranchName(renderedBranch);
   const configuredParentDir = asString(rawStrategy.worktreeParentDir, "");
   const worktreeParentDir = configuredParentDir
     ? resolveConfiguredPath(configuredParentDir, repoRoot)


### PR DESCRIPTION
## Summary
- Validate compact working-state packets before emitting handoff markdown.
- Reuse the heartbeat mutation path through a tested helper so compact handoff markdown is set only for reset sessions with a self-report and persisted session id.
- Bind the server validator to the shared compact working-state fixture corpus to reduce contract drift.

## Root cause
The Step 2 emitter accepted nested packet sections as opaque input and serialized markdown without compact contract validation, so invalid packets could pass through the server path.

## Validation
- pnpm --filter @paperclipai/server exec vitest run src/__tests__/compact-working-state-builder.test.ts src/__tests__/compact-working-state-handoff-markdown.test.ts src/__tests__/heartbeat-workspace-session.test.ts: 103/103 passing
- pnpm --filter @paperclipai/server typecheck: passing
- node --test pipeline-v2/compact-working-state.test.mjs: 18/18 passing
- git diff --check: passing