### PR TITLE
Fix heartbeat run JSON hydration OOM

### DIFF
--- a/server/src/__tests__/heartbeat-run-display.test.ts
+++ b/server/src/__tests__/heartbeat-run-display.test.ts
@@ -1,0 +1,183 @@
+import { randomUUID } from "node:crypto";
+import { sql } from "drizzle-orm";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import {
+  agents,
+  companies,
+  createDb,
+  heartbeatRuns,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+
+const mockAdapterExecute = vi.hoisted(() =>
+  vi.fn(async () => ({
+    exitCode: 0,
+    signal: null,
+    timedOut: false,
+    errorMessage: null,
+    summary: "heartbeat run display test",
+    provider: "test",
+    model: "test-model",
+  })),
+);
+
+const mockAdapterRegistry = vi.hoisted(() => ({
+  getServerAdapter: vi.fn(() => ({
+    supportsLocalAgentJwt: false,
+    execute: mockAdapterExecute,
+  })),
+  listAdapterModels: vi.fn(() => []),
+  refreshAdapterModels: vi.fn(async () => []),
+  listServerAdapters: vi.fn(() => []),
+  findServerAdapter: vi.fn(() => null),
+  findActiveServerAdapter: vi.fn(() => null),
+  detectAdapterModel: vi.fn(() => null),
+  listAdapterModelProfiles: vi.fn(() => []),
+  registerServerAdapter: vi.fn(),
+  unregisterServerAdapter: vi.fn(),
+  requireServerAdapter: vi.fn(),
+}));
+
+vi.mock("../adapters/registry.js", () => mockAdapterRegistry);
+vi.mock("../adapters/registry.ts", () => mockAdapterRegistry);
+
+const { heartbeatService } = await import("../services/heartbeat.ts");
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping embedded Postgres heartbeat run display tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+describeEmbeddedPostgres("heartbeat run display access", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("heartbeat-run-display-");
+    db = createDb(tempDb.connectionString);
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.execute(sql.raw(`
+      TRUNCATE TABLE
+        "heartbeat_runs",
+        "agents",
+        "companies"
+      RESTART IDENTITY CASCADE
+    `));
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  async function insertRunWithLargeJson() {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const runId = randomUUID();
+    const executionWorkspaceId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Display Agent",
+      role: "engineer",
+      status: "idle",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId,
+      agentId,
+      invocationSource: "on_demand",
+      triggerDetail: "manual",
+      status: "failed",
+      error: "process failed",
+      logStore: "local_file",
+      logRef: "runs/run.log",
+      resultJson: {
+        summary: "Updated the backend",
+        result: "Patched heartbeat routes",
+        stdout: "x".repeat(128_000),
+        stderr: "y".repeat(128_000),
+        cost_usd: 1.25,
+      },
+      contextSnapshot: {
+        issueId: randomUUID(),
+        taskId: randomUUID(),
+        taskKey: "PAP-123",
+        commentId: randomUUID(),
+        wakeCommentId: randomUUID(),
+        wakeReason: "issue_commented",
+        wakeSource: "on_demand",
+        wakeTriggerDetail: "manual",
+        executionWorkspaceId,
+        paperclipWake: {
+          comments: [{ body: "large comment body".repeat(8_000) }],
+        },
+      },
+    });
+
+    return { companyId, runId, executionWorkspaceId };
+  }
+
+  it("serves run display data without hydrating large result or context payloads", async () => {
+    const { runId } = await insertRunWithLargeJson();
+    const heartbeat = heartbeatService(db);
+
+    const run = await heartbeat.getRunForDisplay(runId);
+
+    expect(run).toMatchObject({
+      id: runId,
+      status: "failed",
+      error: "process failed",
+      resultJson: {
+        summary: "Updated the backend",
+        result: "Patched heartbeat routes",
+        cost_usd: 1.25,
+      },
+    });
+    expect(run?.resultJson).not.toHaveProperty("stdout");
+    expect(run?.resultJson).not.toHaveProperty("stderr");
+    expect(run?.contextSnapshot).toMatchObject({
+      taskKey: "PAP-123",
+      wakeReason: "issue_commented",
+      wakeSource: "on_demand",
+      wakeTriggerDetail: "manual",
+    });
+    expect(run?.contextSnapshot).not.toHaveProperty("paperclipWake");
+    expect(run?.contextSnapshot).not.toHaveProperty("executionWorkspaceId");
+  });
+
+  it("serves route access fields without resultJson or contextSnapshot", async () => {
+    const { companyId, runId, executionWorkspaceId } = await insertRunWithLargeJson();
+    const heartbeat = heartbeatService(db);
+
+    const access = await heartbeat.getRunAccess(runId);
+
+    expect(access).toEqual({
+      id: runId,
+      companyId,
+      executionWorkspaceId,
+    });
+    expect(access).not.toHaveProperty("resultJson");
+    expect(access).not.toHaveProperty("contextSnapshot");
+  });
+});

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -3532,7 +3532,7 @@ export function agentRoutes(
 
   router.get("/heartbeat-runs/:runId", async (req, res) => {
     const runId = req.params.runId as string;
-    const run = await heartbeat.getRun(runId);
+    const run = await heartbeat.getRunForDisplay(runId);
     if (!run) {
       res.status(404).json({ error: "Heartbeat run not found" });
       return;
@@ -3610,7 +3610,7 @@ export function agentRoutes(
 
   router.get("/heartbeat-runs/:runId/events", async (req, res) => {
     const runId = req.params.runId as string;
-    const run = await heartbeat.getRun(runId);
+    const run = await heartbeat.getRunAccess(runId);
     if (!run) {
       res.status(404).json({ error: "Heartbeat run not found" });
       return;
@@ -3652,15 +3652,14 @@ export function agentRoutes(
 
   router.get("/heartbeat-runs/:runId/workspace-operations", async (req, res) => {
     const runId = req.params.runId as string;
-    const run = await heartbeat.getRun(runId);
+    const run = await heartbeat.getRunAccess(runId);
     if (!run) {
       res.status(404).json({ error: "Heartbeat run not found" });
       return;
     }
     assertCompanyAccess(req, run.companyId);
 
-    const context = asRecord(run.contextSnapshot);
-    const executionWorkspaceId = asNonEmptyString(context?.executionWorkspaceId);
+    const executionWorkspaceId = asNonEmptyString(run.executionWorkspaceId);
     const operations = await workspaceOperations.listForRun(runId, executionWorkspaceId);
     res.json(redactCurrentUserValue(operations, await getCurrentUserRedactionOptions()));
   });

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -1530,6 +1530,12 @@ const heartbeatRunLogAccessColumns = {
   logRef: heartbeatRuns.logRef,
 } as const;
 
+const heartbeatRunAccessColumns = {
+  id: heartbeatRuns.id,
+  companyId: heartbeatRuns.companyId,
+  executionWorkspaceId: sql<string | null>`${heartbeatRuns.contextSnapshot} ->> 'executionWorkspaceId'`.as("executionWorkspaceId"),
+} as const;
+
 const heartbeatRunIssueSummaryColumns = {
   id: heartbeatRuns.id,
   status: heartbeatRuns.status,
@@ -3622,6 +3628,80 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       .then((rows) => rows[0] ?? null);
   }
 
+  async function getRunForDisplay(runId: string) {
+    const safeForLegacyEncoding = await hasUnsafeTextProjectionDatabase();
+    const row = await db
+      .select(
+        safeForLegacyEncoding
+          ? {
+              ...heartbeatRunListColumns,
+              error: sql<string | null>`NULL`.as("error"),
+              ...heartbeatRunListContextColumns,
+            }
+          : {
+              ...heartbeatRunListColumns,
+              ...heartbeatRunListContextColumns,
+              ...heartbeatRunListResultColumns,
+            },
+      )
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, runId))
+      .then((rows) => rows[0] ?? null);
+    if (!row) return null;
+
+    const {
+      contextIssueId,
+      contextTaskId,
+      contextTaskKey,
+      contextCommentId,
+      contextWakeCommentId,
+      contextWakeReason,
+      contextWakeSource,
+      contextWakeTriggerDetail,
+      resultSummary,
+      resultResult,
+      resultMessage,
+      resultError,
+      resultTotalCostUsd,
+      resultCostUsd,
+      resultCostUsdCamel,
+      ...rest
+    } = row as typeof row & {
+      resultSummary?: string | null;
+      resultResult?: string | null;
+      resultMessage?: string | null;
+      resultError?: string | null;
+      resultTotalCostUsd?: string | null;
+      resultCostUsd?: string | null;
+      resultCostUsdCamel?: string | null;
+    };
+
+    return {
+      ...rest,
+      contextSnapshot: summarizeHeartbeatRunContextSnapshot({
+        issueId: contextIssueId,
+        taskId: contextTaskId,
+        taskKey: contextTaskKey,
+        commentId: contextCommentId,
+        wakeCommentId: contextWakeCommentId,
+        wakeReason: contextWakeReason,
+        wakeSource: contextWakeSource,
+        wakeTriggerDetail: contextWakeTriggerDetail,
+      }),
+      resultJson: safeForLegacyEncoding
+        ? null
+        : summarizeHeartbeatRunListResultJson({
+            summary: resultSummary,
+            result: resultResult,
+            message: resultMessage,
+            error: resultError,
+            totalCostUsd: resultTotalCostUsd,
+            costUsd: resultCostUsd,
+            costUsdCamel: resultCostUsdCamel,
+          }),
+    };
+  }
+
   async function recordCurrentHeartbeatRunRuntimeProgress(
     run: Pick<typeof heartbeatRuns.$inferSelect, "id" | "companyId" | "agentId" | "status" | "contextSnapshot">,
     update: RuntimeStatusUpdate,
@@ -3644,6 +3724,14 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
   async function getRunLogAccess(runId: string) {
     return db
       .select(heartbeatRunLogAccessColumns)
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, runId))
+      .then((rows) => rows[0] ?? null);
+  }
+
+  async function getRunAccess(runId: string) {
+    return db
+      .select(heartbeatRunAccessColumns)
       .from(heartbeatRuns)
       .where(eq(heartbeatRuns.id, runId))
       .then((rows) => rows[0] ?? null);
@@ -12171,11 +12259,13 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     },
 
     getRun,
+    getRunForDisplay,
 
     decorateActiveRunStatus: decorateHeartbeatRunRuntimeStatus,
     recordRuntimeProgress: recordCurrentHeartbeatRunRuntimeProgress,
     sweepExpiredRuntimeStatuses: sweepExpiredHeartbeatRunRuntimeStatuses,
 
+    getRunAccess,
     getRunLogAccess,
 
     getRuntimeState: async (agentId: string) => {


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The affected subsystem is the server heartbeat-run API used by the board UI to inspect agent runs, stream run logs, list events, and view workspace operations.
> - Production logs showed recurring Node heap OOM crashes while users repeatedly polled heartbeat run/log/workspace-operation views.
> - Current `master` already compacted some run-list result data, but run detail, event authorization, and workspace-operation lookup still used broad run reads that can hydrate large JSONB fields.
> - PR #8387 addressed the same issue on a stale/conflicted branch; this pull request reapplies the narrow fix on current `master`.
> - The benefit is lower memory pressure on read-only polling routes while preserving raw run data for internal execution and recovery paths.

## Linked Issues or Issue Description

Refs: #8387

Bug report fields:

- What happened: Self-hosted production logs showed repeated Node heap OOM crashes from JSON parsing while heartbeat run, run-log, and workspace-operation views were being polled.
- Expected behavior: Read-only UI routes should authorize and render compact run data without hydrating large persisted `resultJson` or `contextSnapshot` payloads.
- Steps to reproduce:
  1. Persist a heartbeat run with large `resultJson.stdout`, `resultJson.stderr`, and nested `contextSnapshot.paperclipWake` payloads.
  2. Read the run detail endpoint, events endpoint, and workspace-operation endpoint repeatedly as the UI does.
  3. Observe that broad run reads can hydrate large JSON blobs even when the route only needs display fields, `companyId`, or `executionWorkspaceId`.
- Paperclip version or commit: Reproduced against current `master` baseline `1a3e39810`; production observation was on Paperclip `0.3.1`.
- Deployment mode: Self-hosted server.
- Installation method: Built from source / service deployment.
- Agent adapters involved: Not adapter-specific; this is a core server API read-path issue.
- Database mode: Postgres-backed heartbeat run storage.

Related/duplicate search: `gh search prs --repo paperclipai/paperclip "heartbeat log views hydrating large run JSON"` found PR #8387, which is stale/conflicted. This PR supersedes it with a current-base diff.

## What Changed

- Added `getRunForDisplay` to read run detail data through the existing compact list/context/result projections.
- Added `getRunAccess` for authorization and workspace-operation lookups, including only `id`, `companyId`, and `executionWorkspaceId`.
- Switched run detail, events, and workspace-operation routes away from broad `getRun` hydration.
- Added an embedded-Postgres regression test proving display/access reads omit large `stdout`, `stderr`, `paperclipWake`, `contextSnapshot`, and `resultJson` fields where appropriate.

## Verification

- `pnpm run preflight:workspace-links && pnpm exec vitest run server/src/__tests__/heartbeat-run-display.test.ts`
- `git diff --check`
- GitHub CI `Typecheck + Release Registry` passed on PR #8651.
- Local `pnpm --filter @paperclipai/server typecheck` failed in this workspace on adapter package resolution errors and an unrelated `server/src/services/issues.ts` readonly-array type error.
- Local `pnpm --filter @paperclipai/server build` failed on the same existing local errors.

## Risks

- Run detail responses now expose the same compact context shape already used by run lists. UI consumers checked in this patch use `issueId`, `taskId`, `taskKey`, and comment IDs, which remain available.
- Full raw run data remains available internally through `getRun` for execution/recovery paths that need it.
- No schema migration is included; this changes read projections and route selection only.

## Model Used

OpenAI Codex, GPT-5 coding agent in Codex desktop with shell, git, GitHub CLI, and embedded-Postgres/Vitest tool use.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge