### PR TITLE
Add SQS/S3 loader event Terraform

### DIFF
--- a/infra/terraform/loader-events/.gitignore
+++ b/infra/terraform/loader-events/.gitignore
@@ -1,0 +1,7 @@
+*.tfstate
+*.tfstate.*
+.terraform/
+.terraform.lock.hcl
+terraform.tfvars
+*.auto.tfvars
+*.auto.tfvars.json

--- a/infra/terraform/loader-events/README.md
+++ b/infra/terraform/loader-events/README.md
@@ -1,0 +1,36 @@
+# Loader Events Terraform
+
+This module wires the canonical telemetry archive bucket to the raw loader queue:
+
+`S3 ObjectCreated -> RawLoaderQueue -> LoaderFunction (added separately)`
+
+## Managed-service choice
+
+This uses managed AWS S3 bucket notifications and SQS because the source data is already in S3 and the next consumer is a Lambda event-source mapping. Alternatives considered:
+
+- EventBridge S3 notifications: useful for richer routing, but adds another managed service and rule surface we do not need for one bucket/prefix to one queue.
+- Kinesis: higher-throughput stream semantics, but the loader needs durable batch retry and DLQ behavior, which SQS provides directly with lower operational overhead.
+- Self-managed queue/worker broker: rejected because SQS gives retention, redrive, IAM integration, and AWS-native S3 delivery without operating infrastructure.
+
+Estimated idle cost is near zero. SQS charges per request and S3 notifications have no separate per-notification infrastructure to operate.
+
+## Apply
+
+Copy `terraform.tfvars.example` to `terraform.tfvars` and set the canonical bucket details:
+
+```sh
+terraform init
+terraform plan
+terraform apply
+```
+
+The `raw_loader_queue_arn` output is consumed by the later loader Lambda deployment and event-source mapping task.
+
+Provider lockfile note: this repo does not currently commit Terraform provider
+lockfiles for infra modules. This environment has OpenTofu but not Terraform;
+the OpenTofu-generated lockfile uses the OpenTofu registry address and is
+therefore intentionally not committed for this Terraform-oriented module.
+
+## Rollback
+
+Rollback is a Terraform destroy or targeted removal of this module. Removing `aws_s3_bucket_notification.canonical_to_raw_loader` stops new S3 events from entering the queue. Removing the queues deletes any in-flight and retained messages, including DLQ messages, so inspect or drain both queues before destroying them in production.

--- a/infra/terraform/loader-events/README.md
+++ b/infra/terraform/loader-events/README.md
@@ -16,7 +16,7 @@ Estimated idle cost is near zero. SQS charges per request and S3 notifications h
 
 ## Apply
 
-Copy `terraform.tfvars.example` to `terraform.tfvars` and set the canonical bucket details:
+Copy `terraform.tfvars.example` to `terraform.tfvars` and set the canonical bucket details. Set `canonical_object_suffix` to the Firehose output data format used by the canonical archive, such as `.gz` or `.parquet`, so metadata or error files under the same prefix are not enqueued.
 
 ```sh
 terraform init

--- a/infra/terraform/loader-events/outputs.tf
+++ b/infra/terraform/loader-events/outputs.tf
@@ -1,0 +1,25 @@
+output "raw_loader_queue_arn" {
+  description = "ARN of the raw loader SQS queue for the loader Lambda event-source mapping."
+  value       = aws_sqs_queue.raw_loader.arn
+}
+
+output "raw_loader_queue_name" {
+  description = "Name of the raw loader SQS queue."
+  value       = aws_sqs_queue.raw_loader.name
+}
+
+output "raw_loader_queue_url" {
+  description = "URL of the raw loader SQS queue."
+  value       = aws_sqs_queue.raw_loader.url
+}
+
+output "raw_loader_dlq_arn" {
+  description = "ARN of the raw loader dead-letter queue."
+  value       = aws_sqs_queue.raw_loader_dlq.arn
+}
+
+output "raw_loader_dlq_name" {
+  description = "Name of the raw loader dead-letter queue."
+  value       = aws_sqs_queue.raw_loader_dlq.name
+}
+

--- a/infra/terraform/loader-events/providers.tf
+++ b/infra/terraform/loader-events/providers.tf
@@ -1,0 +1,25 @@
+terraform {
+  required_version = ">= 1.6"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = var.tags
+  }
+}
+
+data "aws_caller_identity" "current" {}
+
+data "aws_s3_bucket" "canonical" {
+  bucket = var.canonical_bucket_name
+}
+

--- a/infra/terraform/loader-events/sqs.tf
+++ b/infra/terraform/loader-events/sqs.tf
@@ -4,6 +4,15 @@ resource "aws_sqs_queue" "raw_loader_dlq" {
   sqs_managed_sse_enabled   = true
 }
 
+resource "aws_sqs_queue_redrive_allow_policy" "raw_loader_dlq" {
+  queue_url = aws_sqs_queue.raw_loader_dlq.id
+
+  redrive_allow_policy = jsonencode({
+    redrivePermission = "byQueue"
+    sourceQueueArns   = [aws_sqs_queue.raw_loader.arn]
+  })
+}
+
 resource "aws_sqs_queue" "raw_loader" {
   name                       = "${var.name_prefix}-raw-loader-${var.environment}"
   message_retention_seconds  = var.raw_queue_message_retention_seconds
@@ -56,8 +65,8 @@ resource "aws_s3_bucket_notification" "canonical_to_raw_loader" {
     queue_arn     = aws_sqs_queue.raw_loader.arn
     events        = ["s3:ObjectCreated:*"]
     filter_prefix = var.canonical_object_prefix
+    filter_suffix = var.canonical_object_suffix
   }
 
   depends_on = [aws_sqs_queue_policy.raw_loader_from_s3]
 }
-

--- a/infra/terraform/loader-events/sqs.tf
+++ b/infra/terraform/loader-events/sqs.tf
@@ -1,0 +1,63 @@
+resource "aws_sqs_queue" "raw_loader_dlq" {
+  name                      = "${var.name_prefix}-raw-loader-dlq-${var.environment}"
+  message_retention_seconds = var.dlq_message_retention_seconds
+  sqs_managed_sse_enabled   = true
+}
+
+resource "aws_sqs_queue" "raw_loader" {
+  name                       = "${var.name_prefix}-raw-loader-${var.environment}"
+  message_retention_seconds  = var.raw_queue_message_retention_seconds
+  visibility_timeout_seconds = var.raw_queue_visibility_timeout_seconds
+  sqs_managed_sse_enabled    = true
+
+  redrive_policy = jsonencode({
+    deadLetterTargetArn = aws_sqs_queue.raw_loader_dlq.arn
+    maxReceiveCount     = var.raw_queue_max_receive_count
+  })
+}
+
+data "aws_iam_policy_document" "raw_loader_from_s3" {
+  statement {
+    sid     = "AllowCanonicalBucketObjectCreatedNotifications"
+    effect  = "Allow"
+    actions = ["sqs:SendMessage"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["s3.amazonaws.com"]
+    }
+
+    resources = [aws_sqs_queue.raw_loader.arn]
+
+    condition {
+      test     = "ArnEquals"
+      variable = "aws:SourceArn"
+      values   = [data.aws_s3_bucket.canonical.arn]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceAccount"
+      values   = [data.aws_caller_identity.current.account_id]
+    }
+  }
+}
+
+resource "aws_sqs_queue_policy" "raw_loader_from_s3" {
+  queue_url = aws_sqs_queue.raw_loader.id
+  policy    = data.aws_iam_policy_document.raw_loader_from_s3.json
+}
+
+resource "aws_s3_bucket_notification" "canonical_to_raw_loader" {
+  bucket = data.aws_s3_bucket.canonical.id
+
+  queue {
+    id            = "raw-loader-object-created-${var.environment}"
+    queue_arn     = aws_sqs_queue.raw_loader.arn
+    events        = ["s3:ObjectCreated:*"]
+    filter_prefix = var.canonical_object_prefix
+  }
+
+  depends_on = [aws_sqs_queue_policy.raw_loader_from_s3]
+}
+

--- a/infra/terraform/loader-events/terraform.tfvars.example
+++ b/infra/terraform/loader-events/terraform.tfvars.example
@@ -4,4 +4,4 @@ environment = "dev"
 # Existing canonical telemetry archive bucket receiving Firehose output.
 canonical_bucket_name   = "paperclip-telemetry-archive-dev"
 canonical_object_prefix = "year="
-
+canonical_object_suffix = ".gz"

--- a/infra/terraform/loader-events/terraform.tfvars.example
+++ b/infra/terraform/loader-events/terraform.tfvars.example
@@ -1,0 +1,7 @@
+aws_region  = "us-east-1"
+environment = "dev"
+
+# Existing canonical telemetry archive bucket receiving Firehose output.
+canonical_bucket_name   = "paperclip-telemetry-archive-dev"
+canonical_object_prefix = "year="
+

--- a/infra/terraform/loader-events/variables.tf
+++ b/infra/terraform/loader-events/variables.tf
@@ -1,0 +1,88 @@
+variable "aws_region" {
+  description = "AWS region for SQS and the canonical S3 bucket."
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "environment" {
+  description = "Deployment environment: dev, staging, or prod."
+  type        = string
+  default     = "dev"
+
+  validation {
+    condition     = contains(["dev", "staging", "prod"], var.environment)
+    error_message = "Environment must be dev, staging, or prod."
+  }
+}
+
+variable "name_prefix" {
+  description = "Resource name prefix."
+  type        = string
+  default     = "paperclip-telemetry"
+}
+
+variable "canonical_bucket_name" {
+  description = "Existing canonical telemetry archive bucket that emits ObjectCreated events."
+  type        = string
+}
+
+variable "canonical_object_prefix" {
+  description = "Canonical object key prefix to notify on. Use the Firehose success prefix, not error output."
+  type        = string
+  default     = "year="
+}
+
+variable "raw_queue_visibility_timeout_seconds" {
+  description = "Visibility timeout for raw loader messages. T6 should keep the loader Lambda timeout below this value."
+  type        = number
+  default     = 300
+
+  validation {
+    condition     = var.raw_queue_visibility_timeout_seconds >= 30 && var.raw_queue_visibility_timeout_seconds <= 43200
+    error_message = "Visibility timeout must be between 30 seconds and 12 hours."
+  }
+}
+
+variable "raw_queue_message_retention_seconds" {
+  description = "Retention period for raw loader queue messages."
+  type        = number
+  default     = 345600
+
+  validation {
+    condition     = var.raw_queue_message_retention_seconds >= 60 && var.raw_queue_message_retention_seconds <= 1209600
+    error_message = "Raw queue retention must be between 60 seconds and 14 days."
+  }
+}
+
+variable "dlq_message_retention_seconds" {
+  description = "Retention period for raw loader DLQ messages."
+  type        = number
+  default     = 1209600
+
+  validation {
+    condition     = var.dlq_message_retention_seconds >= 60 && var.dlq_message_retention_seconds <= 1209600
+    error_message = "DLQ retention must be between 60 seconds and 14 days."
+  }
+}
+
+variable "raw_queue_max_receive_count" {
+  description = "Number of failed receives before SQS moves a message to the DLQ."
+  type        = number
+  default     = 5
+
+  validation {
+    condition     = var.raw_queue_max_receive_count >= 2 && var.raw_queue_max_receive_count <= 20
+    error_message = "Max receive count must be between 2 and 20."
+  }
+}
+
+variable "tags" {
+  description = "Tags applied to all AWS resources."
+  type        = map(string)
+  default = {
+    Project   = "paperclip"
+    Component = "telemetry-loader"
+    ManagedBy = "terraform"
+  }
+}
+

--- a/infra/terraform/loader-events/variables.tf
+++ b/infra/terraform/loader-events/variables.tf
@@ -32,8 +32,19 @@ variable "canonical_object_prefix" {
   default     = "year="
 }
 
+variable "canonical_object_suffix" {
+  description = "Canonical object key suffix to notify on. Match the Firehose output data format, such as .gz or .parquet."
+  type        = string
+  default     = ".gz"
+
+  validation {
+    condition     = length(var.canonical_object_suffix) > 0
+    error_message = "Canonical object suffix must not be empty."
+  }
+}
+
 variable "raw_queue_visibility_timeout_seconds" {
-  description = "Visibility timeout for raw loader messages. T6 should keep the loader Lambda timeout below this value."
+  description = "Visibility timeout for raw loader messages. The loader Lambda timeout must be below this value to prevent duplicate processing."
   type        = number
   default     = 300
 
@@ -85,4 +96,3 @@ variable "tags" {
     ManagedBy = "terraform"
   }
 }
-


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The telemetry pipeline needs a live delivery path that can move archived raw events toward PostHog without coupling ingestion directly to the loader.
> - Existing Firehose output lands in the canonical S3 archive bucket, so S3 object-created events are the natural handoff point for downstream loading.
> - SQS gives the loader durable buffering, retry, redrive, and Lambda event-source compatibility without operating custom queue infrastructure.
> - Queue policy should constrain S3 sends to the canonical bucket ARN and AWS account, while object-key scoping belongs in the S3 notification filter.
> - This pull request adds the first Terraform slice for that handoff: raw loader queue, DLQ, S3 notification, policy, outputs, and apply notes.
> - The benefit is a small, reviewable infrastructure module that later loader Lambda work can consume by queue ARN without provisioning application code in this PR.

## Linked Issues or Issue Description

Feature request: add infrastructure for the telemetry raw loader event handoff.

- Problem/motivation: the live PostHog delivery path needs AWS-managed S3-to-SQS events so raw archive objects can be queued for a loader Lambda in a later change.
- Proposed solution: add a standalone Terraform module under `infra/terraform/loader-events/` that creates a raw loader SQS queue, DLQ, least-privilege S3 send policy, and canonical bucket notification.
- Alternatives considered: EventBridge, Kinesis, and self-managed queue infrastructure are documented in the module README; SQS is the smallest durable queue surface for this stage.
- Roadmap alignment: this supports live telemetry delivery work and does not duplicate a listed `ROADMAP.md` core feature.

## What Changed

- Added `infra/terraform/loader-events/` Terraform module.
- Added raw loader SQS queue, DLQ, redrive policy, SQS-managed SSE, and bounded retention/visibility settings.
- Added S3-to-SQS queue policy constrained to the canonical bucket ARN and current AWS account.
- Added canonical S3 `ObjectCreated` notification with configurable prefix filter.
- Added queue/DLQ outputs for later loader Lambda event-source mapping work.
- Documented managed-service tradeoffs, estimated idle cost, apply notes, provider-lock decision, and rollback path.

## Verification

- `tofu fmt -check -recursive`
- `tofu init -backend=false`
- `tofu validate`
- Security implementation review PAP-681 approved in Paperclip.

## Risks

- `aws_s3_bucket_notification` is authoritative for the bucket notification document; before provisioning, confirm or import any existing notifications to avoid overwriting unrelated bucket routes.
- No AWS plan/apply was run in this worktree because credentials/state were not available and production provisioning requires explicit approval.
- Terraform CLI was unavailable locally; OpenTofu validated syntax/provider schema.
- CI and Greptile are pending on the newly opened PR.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

OpenAI GPT-5 Codex CLI, coding agent with shell, file, Git, GitHub CLI, and Paperclip API tool access. Reasoning and tool-use capabilities were used for scoped commit/PR handling; implementation was produced by prior Paperclip coding work and committed by Git Expert.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge