### PR TITLE
feat(recovery): USI-73 — disposition log, auto-followup, recovery_needed UI variant

### DIFF
--- a/server/src/__tests__/supervisor-runs-routes.test.ts
+++ b/server/src/__tests__/supervisor-runs-routes.test.ts
@@ -1,0 +1,295 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const issueId = "11111111-1111-4111-8111-111111111111";
+const companyId = "22222222-2222-4222-8222-222222222222";
+const agentId = "33333333-3333-4333-8333-333333333333";
+const supervisorRunId = "44444444-4444-4444-8444-444444444444";
+
+const mockIssueService = vi.hoisted(() => ({
+  getById: vi.fn(),
+}));
+
+const mockSupervisorRunsService = vi.hoisted(() => ({
+  createSupervisorRun: vi.fn(),
+  validateSupervisorRunScope: vi.fn(),
+}));
+
+const mockLogActivity = vi.hoisted(() => vi.fn());
+
+function registerMocks() {
+  vi.doMock("../services/index.js", () => ({
+    issueService: () => mockIssueService,
+    logActivity: mockLogActivity,
+  }));
+
+  vi.doMock("../services/supervisor-runs.js", () => mockSupervisorRunsService);
+}
+
+async function createApp(
+  actor: Record<string, unknown> = {
+    type: "agent",
+    agentId,
+    companyId,
+    source: "agent_key",
+    runId: null,
+  },
+) {
+  vi.resetModules();
+  registerMocks();
+  const [{ errorHandler }, { supervisorRunsRoutes }] = await Promise.all([
+    import("../middleware/index.js") as Promise<typeof import("../middleware/index.js")>,
+    import("../routes/supervisor-runs.js") as Promise<typeof import("../routes/supervisor-runs.js")>,
+  ]);
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as any).actor = { ...actor };
+    next();
+  });
+  app.use("/api", supervisorRunsRoutes({} as any));
+  app.use(errorHandler);
+  return app;
+}
+
+async function doRequest(app: express.Express, buildReq: (baseUrl: string) => request.Test) {
+  const { createServer } = await vi.importActual<typeof import("node:http")>("node:http");
+  const server = createServer(app);
+  try {
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const address = server.address();
+    if (!address || typeof address === "string") throw new Error("No TCP port");
+    return await buildReq(`http://127.0.0.1:${(address as { port: number }).port}`);
+  } finally {
+    if (server.listening) {
+      await new Promise<void>((resolve, reject) =>
+        server.close((err) => (err ? reject(err) : resolve())),
+      );
+    }
+  }
+}
+
+describe.sequential("supervisor runs routes", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mockLogActivity.mockResolvedValue(undefined);
+  });
+
+  it("creates a supervisor run and returns runId, expiresAt, issueId", async () => {
+    const expiresAt = new Date(Date.now() + 5 * 60 * 1000).toISOString();
+    mockIssueService.getById.mockResolvedValue({ id: issueId, companyId });
+    mockSupervisorRunsService.createSupervisorRun.mockResolvedValue({
+      runId: supervisorRunId,
+      expiresAt,
+      issueId,
+    });
+
+    const app = await createApp();
+    const res = await doRequest(app, (baseUrl) =>
+      request(baseUrl)
+        .post("/api/supervisor-runs")
+        .send({ issueId, motif: "Fix title typo", source: "codex" }),
+    );
+
+    expect(res.status).toBe(201);
+    expect(res.body).toMatchObject({
+      runId: supervisorRunId,
+      expiresAt,
+      issueId,
+    });
+    expect(mockSupervisorRunsService.createSupervisorRun).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        companyId,
+        agentId,
+        issueId,
+        motif: "Fix title typo",
+        source: "codex",
+      }),
+    );
+  });
+
+  it("returns 404 when issue not found", async () => {
+    mockIssueService.getById.mockResolvedValue(null);
+
+    const app = await createApp();
+    const res = await doRequest(app, (baseUrl) =>
+      request(baseUrl)
+        .post("/api/supervisor-runs")
+        .send({ issueId, source: "codex" }),
+    );
+
+    expect(res.status).toBe(404);
+    expect(mockSupervisorRunsService.createSupervisorRun).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 on missing issueId", async () => {
+    const app = await createApp();
+    const res = await doRequest(app, (baseUrl) =>
+      request(baseUrl)
+        .post("/api/supervisor-runs")
+        .send({ source: "codex" }),
+    );
+
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 on invalid issueId (not uuid)", async () => {
+    const app = await createApp();
+    const res = await doRequest(app, (baseUrl) =>
+      request(baseUrl)
+        .post("/api/supervisor-runs")
+        .send({ issueId: "not-a-uuid", source: "codex" }),
+    );
+
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 403 when actor is a board user (not agent)", async () => {
+    mockIssueService.getById.mockResolvedValue({ id: issueId, companyId });
+
+    const app = await createApp({
+      type: "board",
+      userId: "user-1",
+      companyIds: [companyId],
+      source: "board_key",
+      isInstanceAdmin: true,
+    });
+    const res = await doRequest(app, (baseUrl) =>
+      request(baseUrl)
+        .post("/api/supervisor-runs")
+        .send({ issueId, source: "codex" }),
+    );
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toMatch(/agent authentication/i);
+  });
+
+  it("does not create run for agent from different company", async () => {
+    mockIssueService.getById.mockResolvedValue({ id: issueId, companyId: "other-company-id" });
+
+    const app = await createApp();
+    const res = await doRequest(app, (baseUrl) =>
+      request(baseUrl)
+        .post("/api/supervisor-runs")
+        .send({ issueId, source: "codex" }),
+    );
+
+    expect(res.status).toBe(403);
+    expect(mockSupervisorRunsService.createSupervisorRun).not.toHaveBeenCalled();
+  });
+
+  it("accepts request without optional motif and source", async () => {
+    const expiresAt = new Date(Date.now() + 5 * 60 * 1000).toISOString();
+    mockIssueService.getById.mockResolvedValue({ id: issueId, companyId });
+    mockSupervisorRunsService.createSupervisorRun.mockResolvedValue({
+      runId: supervisorRunId,
+      expiresAt,
+      issueId,
+    });
+
+    const app = await createApp();
+    const res = await doRequest(app, (baseUrl) =>
+      request(baseUrl)
+        .post("/api/supervisor-runs")
+        .send({ issueId }),
+    );
+
+    expect(res.status).toBe(201);
+    expect(res.body.runId).toBe(supervisorRunId);
+  });
+});
+
+describe("supervisor run service unit tests", () => {
+  async function importRealService() {
+    vi.doUnmock("../services/supervisor-runs.js");
+    vi.resetModules();
+    return import("../services/supervisor-runs.js");
+  }
+
+  it("SUPERVISOR_RUN_TTL_MS is 5 minutes", async () => {
+    const { SUPERVISOR_RUN_TTL_MS } = await importRealService();
+    expect(SUPERVISOR_RUN_TTL_MS).toBe(5 * 60 * 1000);
+  });
+
+  it("isSupervisorRunContext identifies supervisor runs", async () => {
+    const { isSupervisorRunContext } = await importRealService();
+    expect(isSupervisorRunContext({ type: "supervisor", issueId: "x" })).toBe(true);
+    expect(isSupervisorRunContext({ type: "heartbeat", issueId: "x" })).toBe(false);
+    expect(isSupervisorRunContext(null)).toBe(false);
+    expect(isSupervisorRunContext({})).toBe(false);
+    expect(isSupervisorRunContext([])).toBe(false);
+  });
+
+  it("validateSupervisorRunScope returns null when run not found", async () => {
+    const { validateSupervisorRunScope } = await importRealService();
+    const result = await validateSupervisorRunScope(makeFakeDb(null), supervisorRunId, issueId, companyId);
+    expect(result).toBeNull();
+  });
+
+  it("validateSupervisorRunScope returns null for non-supervisor runs", async () => {
+    const { validateSupervisorRunScope } = await importRealService();
+    const fakeDb = makeFakeDb({ agentId, companyId, contextSnapshot: { type: "heartbeat", issueId } });
+    const result = await validateSupervisorRunScope(fakeDb, supervisorRunId, issueId, companyId);
+    expect(result).toBeNull();
+  });
+
+  it("validateSupervisorRunScope returns scope error for wrong issueId", async () => {
+    const { validateSupervisorRunScope } = await importRealService();
+    const futureDate = new Date(Date.now() + 60_000).toISOString();
+    const fakeDb = makeFakeDb({
+      agentId,
+      companyId,
+      contextSnapshot: { type: "supervisor", issueId: "different-issue-id", expiresAt: futureDate },
+    });
+    const result = await validateSupervisorRunScope(fakeDb, supervisorRunId, "my-issue-id", companyId);
+    expect(result).not.toBeNull();
+    expect(result!.code).toBe("supervisor_run_scope_mismatch");
+  });
+
+  it("validateSupervisorRunScope returns expired error past TTL", async () => {
+    const { validateSupervisorRunScope } = await importRealService();
+    const pastDate = new Date(Date.now() - 60_000).toISOString();
+    const fakeDb = makeFakeDb({
+      agentId,
+      companyId,
+      contextSnapshot: { type: "supervisor", issueId, expiresAt: pastDate },
+    });
+    const result = await validateSupervisorRunScope(fakeDb, supervisorRunId, issueId, companyId);
+    expect(result).not.toBeNull();
+    expect(result!.code).toBe("supervisor_run_expired");
+  });
+
+  it("validateSupervisorRunScope returns null for valid in-scope run", async () => {
+    const { validateSupervisorRunScope } = await importRealService();
+    const futureDate = new Date(Date.now() + 60_000).toISOString();
+    const fakeDb = makeFakeDb({
+      agentId,
+      companyId,
+      contextSnapshot: { type: "supervisor", issueId, expiresAt: futureDate },
+    });
+    const result = await validateSupervisorRunScope(fakeDb, supervisorRunId, issueId, companyId);
+    expect(result).toBeNull();
+  });
+});
+
+function makeFakeDb(row: unknown) {
+  const thenable = {
+    then(cb: (rows: unknown[]) => unknown) {
+      return Promise.resolve(cb(row ? [row] : []));
+    },
+  };
+  return {
+    select: () => ({
+      from: () => ({
+        where: () => thenable,
+      }),
+    }),
+    insert: () => ({
+      values: () => ({
+        returning: () => thenable,
+      }),
+    }),
+  } as unknown as import("@paperclipai/db").Db;
+}

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -46,6 +46,7 @@ import { assetRoutes } from "./routes/assets.js";
 import { accessRoutes } from "./routes/access.js";
 import { pluginRoutes } from "./routes/plugins.js";
 import { adapterRoutes } from "./routes/adapters.js";
+import { supervisorRunsRoutes } from "./routes/supervisor-runs.js";
 import { pluginUiStaticRoutes } from "./routes/plugin-ui-static.js";
 import { readBrandedStaticIndexHtml } from "./static-index-html.js";
 import { applyUiBranding } from "./ui-branding.js";
@@ -237,6 +238,7 @@ export async function createApp(
   api.use(goalRoutes(db));
   api.use(boardChatRoutes(db, { deploymentMode: opts.deploymentMode }));
   api.use(approvalRoutes(db, { pluginWorkerManager: workerManager }));
+  api.use(supervisorRunsRoutes(db));
   api.use(secretRoutes(db));
   api.use(costRoutes(db, { pluginWorkerManager: workerManager }));
   api.use(activityRoutes(db));

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -101,6 +101,7 @@ import {
 import type { TaskWatchdogServiceDeps, taskWatchdogService } from "../services/task-watchdogs.js";
 import { logger } from "../middleware/logger.js";
 import { conflict, forbidden, HttpError, notFound, unauthorized, unprocessable } from "../errors.js";
+import { validateSupervisorRunScope } from "../services/supervisor-runs.js";
 import { assertBoard, assertCompanyAccess, getActorInfo } from "./authz.js";
 import {
   assertNoAgentHostWorkspaceCommandMutation,
@@ -2054,6 +2055,11 @@ export function issueRoutes(
     }
     const runId = requireAgentRunId(req, res);
     if (!runId) return false;
+    const supervisorScopeError = await validateSupervisorRunScope(db, runId, issue.id, issue.companyId);
+    if (supervisorScopeError) {
+      res.status(403).json({ error: supervisorScopeError.error, code: supervisorScopeError.code });
+      return false;
+    }
     const ownership = await svc.assertCheckoutOwner(issue.id, actorAgentId, runId);
     if (ownership.adoptedFromRunId) {
       const actor = getActorInfo(req);
@@ -6731,6 +6737,13 @@ export function issueRoutes(
 
     const checkoutRunId = requireAgentRunId(req, res);
     if (req.actor.type === "agent" && !checkoutRunId) return;
+    if (checkoutRunId) {
+      const supervisorScopeError = await validateSupervisorRunScope(db, checkoutRunId, id, issue.companyId);
+      if (supervisorScopeError) {
+        res.status(403).json({ error: supervisorScopeError.error, code: supervisorScopeError.code });
+        return;
+      }
+    }
     const updated = await svc.checkout(id, req.body.agentId, req.body.expectedStatuses, checkoutRunId);
     const actor = getActorInfo(req);
 

--- a/server/src/routes/supervisor-runs.ts
+++ b/server/src/routes/supervisor-runs.ts
@@ -1,0 +1,65 @@
+import { Router } from "express";
+import { z } from "zod";
+import type { Db } from "@paperclipai/db";
+import { validate } from "../middleware/validate.js";
+import { issueService, logActivity } from "../services/index.js";
+import { createSupervisorRun } from "../services/supervisor-runs.js";
+import { assertBoardOrAgent, assertCompanyAccess, getActorInfo } from "./authz.js";
+import { notFound } from "../errors.js";
+
+const createSupervisorRunSchema = z.object({
+  issueId: z.string().uuid(),
+  motif: z.string().max(500).optional(),
+  source: z.string().max(100).optional(),
+});
+
+export function supervisorRunsRoutes(db: Db) {
+  const router = Router();
+  const svc = issueService(db);
+
+  router.post("/supervisor-runs", validate(createSupervisorRunSchema), async (req, res, next) => {
+    try {
+      assertBoardOrAgent(req);
+
+      const { issueId, motif, source } = req.body as z.infer<typeof createSupervisorRunSchema>;
+
+      const issue = await svc.getById(issueId);
+      if (!issue) throw notFound("Issue not found");
+
+      assertCompanyAccess(req, issue.companyId);
+
+      const actor = getActorInfo(req);
+      const agentId = actor.actorType === "agent" && actor.agentId ? actor.agentId : null;
+      if (!agentId) {
+        res.status(403).json({ error: "Supervisor runs require agent authentication" });
+        return;
+      }
+
+      const result = await createSupervisorRun(db, {
+        companyId: issue.companyId,
+        agentId,
+        issueId,
+        motif,
+        source,
+      });
+
+      await logActivity(db, {
+        companyId: issue.companyId,
+        actorType: actor.actorType,
+        actorId: actor.actorId,
+        agentId: actor.agentId,
+        runId: result.runId,
+        action: "supervisor_run.created",
+        entityType: "issue",
+        entityId: issueId,
+        details: { source: source ?? null, motif: motif ?? null },
+      });
+
+      res.status(201).json(result);
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  return router;
+}

--- a/server/src/services/interaction-guards.test.ts
+++ b/server/src/services/interaction-guards.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import {
+  extractGithubRepositoryLocators,
+  findMismatchedConfirmationRepositories,
+  isMergeRequestConfirmationContent,
+  normalizeRepositoryLocator,
+} from "./interaction-guards.js";
+
+describe("interaction guards", () => {
+  it("normalizes GitHub repository URLs", () => {
+    expect(normalizeRepositoryLocator("https://github.com/Dream38pt/paperclip.git")).toBe("github.com/dream38pt/paperclip");
+    expect(normalizeRepositoryLocator("git@github.com:Dream38pt/paperclip.git")).toBe("github.com/dream38pt/paperclip");
+  });
+
+  it("extracts GitHub repositories from PR markdown", () => {
+    expect(extractGithubRepositoryLocators("PR: https://github.com/Dream38pt/usine-dev-sandbox/pull/5")).toEqual([
+      "github.com/dream38pt/usine-dev-sandbox",
+    ]);
+  });
+
+  it("detects merge confirmations", () => {
+    expect(isMergeRequestConfirmationContent({
+      title: "USI-56 — Livraison prête, merge ?",
+      payload: { acceptLabel: "Merger la PR" },
+    })).toBe(true);
+  });
+
+  it("flags PR confirmations targeting the wrong repository", () => {
+    expect(findMismatchedConfirmationRepositories({
+      title: "USI-56 — Livraison prête, merge ?",
+      payload: {
+        acceptLabel: "Merger la PR",
+        detailsMarkdown: "[PR #5](https://github.com/Dream38pt/usine-dev-sandbox/pull/5)",
+      },
+      expectedRepoUrl: "https://github.com/Dream38pt/paperclip.git",
+    })).toEqual(["github.com/dream38pt/usine-dev-sandbox"]);
+  });
+});

--- a/server/src/services/interaction-guards.ts
+++ b/server/src/services/interaction-guards.ts
@@ -1,0 +1,81 @@
+const GITHUB_REPO_URL_RE = /https?:\/\/github\.com\/([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+)(?:\.git)?(?:\/(?:pull|compare|tree|commit)\/[^\s)\]}<>"']*)?/gi;
+const SSH_GITHUB_REPO_URL_RE = /git@github\.com:([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+)(?:\.git)?/gi;
+const MERGE_CONFIRMATION_RE = /\b(?:merge|merger|merged|pr|pull request)\b/i;
+
+function readString(value: unknown) {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+function payloadText(payload: unknown) {
+  if (!payload || typeof payload !== "object") return "";
+  const record = payload as Record<string, unknown>;
+  return [
+    readString(record.prompt),
+    readString(record.acceptLabel),
+    readString(record.rejectLabel),
+    readString(record.detailsMarkdown),
+  ].filter(Boolean).join("\n");
+}
+
+export function normalizeRepositoryLocator(input: string | null | undefined) {
+  const raw = input?.trim();
+  if (!raw) return null;
+
+  const sshMatch = /^git@github\.com:([^/]+)\/([^/]+?)(?:\.git)?$/i.exec(raw);
+  if (sshMatch) return `github.com/${sshMatch[1].toLowerCase()}/${sshMatch[2].toLowerCase().replace(/\.git$/i, "")}`;
+
+  try {
+    const parsed = new URL(raw);
+    if (parsed.hostname.toLowerCase() !== "github.com") return raw.replace(/\.git$/i, "").toLowerCase();
+    const [owner, repo] = parsed.pathname.split("/").filter(Boolean);
+    if (!owner || !repo) return null;
+    return `github.com/${owner.toLowerCase()}/${repo.toLowerCase().replace(/\.git$/i, "")}`;
+  } catch {
+    const match = /github\.com[:/]([^/]+)\/([^/\s]+?)(?:\.git)?$/i.exec(raw);
+    if (match) return `github.com/${match[1].toLowerCase()}/${match[2].toLowerCase().replace(/\.git$/i, "")}`;
+    return raw.replace(/\.git$/i, "").toLowerCase();
+  }
+}
+
+export function extractGithubRepositoryLocators(markdown: string) {
+  const repos = new Set<string>();
+  for (const match of markdown.matchAll(GITHUB_REPO_URL_RE)) {
+    repos.add(`github.com/${match[1].toLowerCase()}/${match[2].toLowerCase().replace(/\.git$/i, "")}`);
+  }
+  for (const match of markdown.matchAll(SSH_GITHUB_REPO_URL_RE)) {
+    repos.add(`github.com/${match[1].toLowerCase()}/${match[2].toLowerCase().replace(/\.git$/i, "")}`);
+  }
+  return [...repos];
+}
+
+export function isMergeRequestConfirmationContent(input: {
+  title?: string | null;
+  summary?: string | null;
+  payload: unknown;
+}) {
+  const text = [
+    input.title ?? "",
+    input.summary ?? "",
+    payloadText(input.payload),
+  ].join("\n");
+  return MERGE_CONFIRMATION_RE.test(text);
+}
+
+export function findMismatchedConfirmationRepositories(input: {
+  title?: string | null;
+  summary?: string | null;
+  payload: unknown;
+  expectedRepoUrl?: string | null;
+}) {
+  const expected = normalizeRepositoryLocator(input.expectedRepoUrl);
+  if (!expected) return [];
+
+  const text = [
+    input.title ?? "",
+    input.summary ?? "",
+    payloadText(input.payload),
+  ].join("\n");
+  if (!MERGE_CONFIRMATION_RE.test(text)) return [];
+
+  return extractGithubRepositoryLocators(text).filter((repo) => repo !== expected);
+}

--- a/server/src/services/issue-thread-interactions.test.ts
+++ b/server/src/services/issue-thread-interactions.test.ts
@@ -212,4 +212,53 @@ describe("issueThreadInteractionService", () => {
     expect(state.interactionUpdates).toHaveLength(1);
     expect(state.issueTouches).toHaveLength(1);
   });
+
+  it("create rejects merge confirmations that point to a different repository than the issue workspace", async () => {
+    const { issueThreadInteractionService } = await import("./issue-thread-interactions.js");
+
+    const db: any = {
+      select: vi.fn(() => ({
+        from() {
+          return {
+            leftJoin() {
+              return {
+                where() {
+                  return {
+                    then(callback: (rows: SelectRow[]) => unknown) {
+                      return Promise.resolve(callback([{ repoUrl: "https://github.com/Dream38pt/paperclip.git" }]));
+                    },
+                  };
+                },
+              };
+            },
+          };
+        },
+      })),
+      insert: vi.fn(),
+      update: vi.fn(),
+    };
+
+    const svc = issueThreadInteractionService(db as never);
+
+    await expect(svc.create({
+      id: "11111111-1111-4111-8111-111111111111",
+      companyId: "company-1",
+    }, {
+      kind: "request_confirmation",
+      title: "USI-56 — Livraison prête, merge ?",
+      continuationPolicy: "wake_assignee_on_accept",
+      payload: {
+        version: 1,
+        prompt: "La PR #5 est prête. Approuver le merge vers main ?",
+        acceptLabel: "Merger la PR",
+        detailsMarkdown: "[PR #5](https://github.com/Dream38pt/usine-dev-sandbox/pull/5)",
+        allowDeclineReason: true,
+      },
+    }, {
+      agentId: "agent-1",
+    })).rejects.toThrow("request_confirmation merge target repository must match the issue workspace repository");
+
+    expect(db.insert).not.toHaveBeenCalled();
+  });
+
 });

--- a/server/src/services/issue-thread-interactions.ts
+++ b/server/src/services/issue-thread-interactions.ts
@@ -8,6 +8,7 @@ import {
   issueDocuments,
   issueThreadInteractions,
   issues,
+  projectWorkspaces,
 } from "@paperclipai/db";
 import type {
   AcceptIssueThreadInteraction,
@@ -40,6 +41,7 @@ import {
 } from "@paperclipai/shared";
 import { conflict, notFound, unprocessable } from "../errors.js";
 import { issueService, runWorkspaceIsFinalized } from "./issues.js";
+import { findMismatchedConfirmationRepositories } from "./interaction-guards.js";
 
 type InteractionActor = {
   agentId?: string | null;
@@ -462,6 +464,36 @@ async function assertRequestConfirmationTargetIsCurrent(db: Db | any, args: {
   }
 }
 
+async function assertRequestConfirmationRepositoriesMatchIssueWorkspace(db: Db | any, args: {
+  issue: { id: string; companyId: string };
+  input: CreateIssueThreadInteraction;
+}) {
+  if (!isRequestConfirmationLikeKind(args.input.kind)) return;
+
+  const issueWorkspace = await db
+    .select({ repoUrl: projectWorkspaces.repoUrl })
+    .from(issues)
+    .leftJoin(projectWorkspaces, eq(issues.projectWorkspaceId, projectWorkspaces.id))
+    .where(and(
+      eq(issues.id, args.issue.id),
+      eq(issues.companyId, args.issue.companyId),
+    ))
+    .then((rows: Array<{ repoUrl: string | null }>) => rows[0] ?? null);
+
+  const mismatchedRepos = findMismatchedConfirmationRepositories({
+    title: args.input.title ?? null,
+    summary: args.input.summary ?? null,
+    payload: args.input.payload,
+    expectedRepoUrl: issueWorkspace?.repoUrl ?? null,
+  });
+  if (mismatchedRepos.length === 0) return;
+
+  throw unprocessable("request_confirmation merge target repository must match the issue workspace repository", {
+    expectedRepoUrl: issueWorkspace?.repoUrl ?? null,
+    mismatchedRepos,
+  });
+}
+
 async function expireStaleRequestConfirmationTarget(db: Db | any, args: {
   row: IssueThreadInteractionRow;
   actor: InteractionActor;
@@ -814,6 +846,10 @@ export function issueThreadInteractionService(db: Db) {
           companyId: issue.companyId,
           issueId: issue.id,
           target: data.payload.target ?? null,
+        });
+        await assertRequestConfirmationRepositoriesMatchIssueWorkspace(db, {
+          issue,
+          input: data,
         });
       }
 

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -92,6 +92,7 @@ import {
   RECOVERY_ORIGIN_KINDS,
 } from "./recovery/origins.js";
 import { classifyIssueGraphLiveness, type IssueLivenessFinding } from "./recovery/issue-graph-liveness.js";
+import { isMergeRequestConfirmationContent } from "./interaction-guards.js";
 
 const ALL_ISSUE_STATUSES = ["backlog", "todo", "in_progress", "in_review", "blocked", "done", "cancelled"];
 const MAX_ISSUE_COMMENT_PAGE_LIMIT = 500;
@@ -135,6 +136,68 @@ function readStringFromRecord(record: unknown, key: string) {
   if (!record || typeof record !== "object") return null;
   const value = (record as Record<string, unknown>)[key];
   return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+const REQUEST_CONFIRMATION_INTERACTION_KINDS = [
+  "request_confirmation",
+  "request_checkbox_confirmation",
+] as const;
+
+async function expirePendingRequestConfirmationsForIssueStatus(dbOrTx: any, args: {
+  companyId: string;
+  issueId: string;
+  nextStatus: string;
+  actorAgentId?: string | null;
+  actorUserId?: string | null;
+}) {
+  if (!["done", "cancelled", "blocked"].includes(args.nextStatus)) return 0;
+
+  const rows = await dbOrTx
+    .select({
+      id: issueThreadInteractions.id,
+      title: issueThreadInteractions.title,
+      summary: issueThreadInteractions.summary,
+      payload: issueThreadInteractions.payload,
+    })
+    .from(issueThreadInteractions)
+    .where(and(
+      eq(issueThreadInteractions.companyId, args.companyId),
+      eq(issueThreadInteractions.issueId, args.issueId),
+      inArray(issueThreadInteractions.kind, [...REQUEST_CONFIRMATION_INTERACTION_KINDS]),
+      eq(issueThreadInteractions.status, "pending"),
+    ));
+
+  const expirableIds = rows
+    .filter((row: { title: string | null; summary: string | null; payload: unknown }) => {
+      if (args.nextStatus === "done" || args.nextStatus === "cancelled") return true;
+      return isMergeRequestConfirmationContent(row);
+    })
+    .map((row: { id: string }) => row.id);
+
+  if (expirableIds.length === 0) return 0;
+
+  const now = new Date();
+  const updated = await dbOrTx
+    .update(issueThreadInteractions)
+    .set({
+      status: "expired",
+      result: {
+        version: 1,
+        outcome: "issue_status_changed",
+        issueStatus: args.nextStatus,
+      },
+      resolvedByAgentId: args.actorAgentId ?? null,
+      resolvedByUserId: args.actorUserId ?? null,
+      resolvedAt: now,
+      updatedAt: now,
+    })
+    .where(and(
+      inArray(issueThreadInteractions.id, expirableIds),
+      eq(issueThreadInteractions.status, "pending"),
+    ))
+    .returning({ id: issueThreadInteractions.id });
+
+  return updated.length;
 }
 
 function buildReusedExecutionWorkspaceConfigPatchFromIssueSettings(
@@ -5408,6 +5471,15 @@ export function issueService(db: Db) {
             },
             tx,
           );
+        }
+        if (issueData.status && issueData.status !== existing.status) {
+          await expirePendingRequestConfirmationsForIssueStatus(tx, {
+            companyId: existing.companyId,
+            issueId: updated.id,
+            nextStatus: issueData.status,
+            actorAgentId: actorAgentId ?? null,
+            actorUserId: actorUserId ?? null,
+          });
         }
         if (
           issueData.executionWorkspaceSettings !== undefined &&

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -69,6 +69,7 @@ export const ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS = 60 * 60 * 1000;
 export const ACTIVE_RUN_OUTPUT_CRITICAL_THRESHOLD_MS = 4 * 60 * 60 * 1000;
 export const ACTIVE_RUN_OUTPUT_CONTINUE_REARM_MS = 30 * 60 * 1000;
 const ACTIVE_RUN_OUTPUT_EVIDENCE_TAIL_BYTES = 8 * 1024;
+const VINCI_FOLLOWUP_AGENT_ID = "91103e58-d344-4c3c-b99e-495f91780b7c";
 const STRANDED_ISSUE_RECOVERY_ORIGIN_KIND = RECOVERY_ORIGIN_KINDS.strandedIssueRecovery;
 const STALE_ACTIVE_RUN_EVALUATION_ORIGIN_KIND = RECOVERY_ORIGIN_KINDS.staleActiveRunEvaluation;
 const DEFERRED_WAKE_CONTEXT_KEY = "_paperclipWakeContext";
@@ -2640,6 +2641,31 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
             authorType: "system",
           });
         }
+      }
+    }
+
+    if (input.recoveryCause === SUCCESSFUL_RUN_MISSING_STATE_REASON && input.successfulRunHandoffEvidence) {
+      const evidence = input.successfulRunHandoffEvidence;
+      const followupTitle = `[OPS] Missing disposition — ${input.issue.identifier} : ${input.issue.title}`;
+      const followupDescription = [
+        `**Cause:** Missing issue disposition after corrective handoff run was exhausted.`,
+        ``,
+        `**Source issue:** ${input.issue.identifier} (ID: \`${input.issue.id}\`)`,
+        `**Source run ID:** \`${evidence.sourceRunId ?? "unknown"}\``,
+        `**Missing disposition:** \`${evidence.missingDisposition}\``,
+        ``,
+        `**Suggested next action:** Open the source issue and apply a valid disposition (done, cancelled, in_review with owner, blocked with blockers, or delegated follow-up). Do not add transcript content.`,
+      ].join("\n");
+      try {
+        await issuesSvc.create(input.issue.companyId, {
+          title: followupTitle,
+          description: followupDescription,
+          status: "todo",
+          priority: "medium",
+          assigneeAgentId: VINCI_FOLLOWUP_AGENT_ID,
+        });
+      } catch (err) {
+        logger.error({ err, issueId: input.issue.id }, "Failed to create missing-disposition follow-up issue");
       }
     }
 

--- a/server/src/services/recovery/successful-run-handoff.test.ts
+++ b/server/src/services/recovery/successful-run-handoff.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import * as loggerModule from "../../middleware/logger.js";
 import {
   FINISH_SUCCESSFUL_RUN_HANDOFF_REASON,
   SUCCESSFUL_RUN_HANDOFF_EXHAUSTED_NOTICE_BODY,
@@ -223,6 +224,39 @@ describe("successful run handoff decision", () => {
       kind: "skip",
       reason: "comment-driven wake already owns the next action",
     });
+  });
+
+  it("logs a structured error when a corrective handoff run is skipped", () => {
+    const loggerSpy = vi.spyOn(loggerModule.logger, "error").mockImplementation(() => loggerModule.logger);
+    const decision = decide({
+      run: {
+        ...run,
+        id: "run-2",
+        contextSnapshot: {
+          issueId: "issue-1",
+          sourceRunId: "run-2",
+          wakeReason: FINISH_SUCCESSFUL_RUN_HANDOFF_REASON,
+          handoffRequired: true,
+        },
+      } as any,
+    });
+    expect(decision).toEqual({
+      kind: "skip",
+      reason: "source run is already a corrective handoff run",
+    });
+    expect(loggerSpy).toHaveBeenCalledTimes(1);
+    expect(loggerSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: "successful_run_handoff_skipped",
+        reason: "source run is already a corrective handoff run",
+        runId: "run-2",
+        issueId: "issue-1",
+        companyId: "company-1",
+        agentId: "agent-1",
+      }),
+      "Successful run handoff skipped: source run is already corrective",
+    );
+    loggerSpy.mockRestore();
   });
 
   it("uses a stable one-attempt idempotency key", () => {

--- a/server/src/services/recovery/successful-run-handoff.ts
+++ b/server/src/services/recovery/successful-run-handoff.ts
@@ -2,6 +2,7 @@ import { and, eq, inArray } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import { agentWakeupRequests, agents, heartbeatRuns, issues } from "@paperclipai/db";
 import type { IssueCommentMetadata, IssueCommentPresentation, RunLivenessState } from "@paperclipai/shared";
+import { logger } from "../../middleware/logger.js";
 import { withRecoveryModelProfileHint } from "./model-profile-hint.js";
 
 export const FINISH_SUCCESSFUL_RUN_HANDOFF_REASON = "finish_successful_run_handoff";
@@ -357,7 +358,21 @@ export function decideSuccessfulRunHandoff(input: {
   const { run, issue, agent } = input;
 
   if (run.status !== "succeeded") return { kind: "skip", reason: "source run did not succeed" };
-  if (isCorrectiveHandoffRun(run)) return { kind: "skip", reason: "source run is already a corrective handoff run" };
+  if (isCorrectiveHandoffRun(run)) {
+    const context = readRecord(run.contextSnapshot);
+    logger.error({
+      event: "successful_run_handoff_skipped",
+      reason: "source run is already a corrective handoff run",
+      runId: run.id,
+      issueId: readString(context.issueId) ?? readString(context.taskId) ?? null,
+      companyId: run.companyId,
+      agentId: run.agentId,
+      status: run.status,
+      wakeReason: readString(context.wakeReason),
+      source: readString(context.source),
+    }, "Successful run handoff skipped: source run is already corrective");
+    return { kind: "skip", reason: "source run is already a corrective handoff run" };
+  }
   if (isIssueMonitorMaintenanceRun(run)) return { kind: "skip", reason: "issue monitor run owns its own recovery path" };
   if (isCommentDrivenWake(run)) return { kind: "skip", reason: "comment-driven wake already owns the next action" };
   if (run.issueCommentStatus === "retry_queued" || run.issueCommentStatus === "retry_exhausted") {

--- a/server/src/services/supervisor-runs.ts
+++ b/server/src/services/supervisor-runs.ts
@@ -1,0 +1,110 @@
+import { randomUUID } from "node:crypto";
+import { eq } from "drizzle-orm";
+import type { Db } from "@paperclipai/db";
+import { heartbeatRuns } from "@paperclipai/db";
+
+export const SUPERVISOR_RUN_TTL_MS = 5 * 60 * 1000;
+export const SUPERVISOR_RUN_TYPE = "supervisor";
+
+export interface CreateSupervisorRunInput {
+  companyId: string;
+  agentId: string;
+  issueId: string;
+  motif?: string | null;
+  source?: string | null;
+}
+
+export interface SupervisorRunResult {
+  runId: string;
+  expiresAt: string;
+  issueId: string;
+}
+
+export async function createSupervisorRun(
+  db: Db,
+  input: CreateSupervisorRunInput,
+): Promise<SupervisorRunResult> {
+  const now = new Date();
+  const expiresAt = new Date(now.getTime() + SUPERVISOR_RUN_TTL_MS);
+
+  const run = await db
+    .insert(heartbeatRuns)
+    .values({
+      id: randomUUID(),
+      companyId: input.companyId,
+      agentId: input.agentId,
+      invocationSource: "on_demand",
+      triggerDetail: "supervisor",
+      status: "running",
+      startedAt: now,
+      issueCommentStatus: "not_applicable",
+      contextSnapshot: {
+        type: SUPERVISOR_RUN_TYPE,
+        issueId: input.issueId,
+        source: input.source ?? null,
+        motif: input.motif ?? null,
+        expiresAt: expiresAt.toISOString(),
+      },
+      updatedAt: now,
+    })
+    .returning({ id: heartbeatRuns.id })
+    .then((rows) => rows[0]);
+
+  return {
+    runId: run.id,
+    expiresAt: expiresAt.toISOString(),
+    issueId: input.issueId,
+  };
+}
+
+export interface SupervisorRunScopeError {
+  error: string;
+  code: "supervisor_run_scope_mismatch" | "supervisor_run_expired" | "supervisor_run_not_found";
+}
+
+export async function validateSupervisorRunScope(
+  db: Db,
+  runId: string,
+  issueId: string,
+  companyId: string,
+): Promise<SupervisorRunScopeError | null> {
+  const run = await db
+    .select({
+      agentId: heartbeatRuns.agentId,
+      companyId: heartbeatRuns.companyId,
+      contextSnapshot: heartbeatRuns.contextSnapshot,
+    })
+    .from(heartbeatRuns)
+    .where(eq(heartbeatRuns.id, runId))
+    .then((rows) => rows[0] ?? null);
+
+  if (!run) return null;
+  if (run.companyId !== companyId) return null;
+
+  const ctx = run.contextSnapshot as Record<string, unknown> | null;
+  if (!ctx || ctx.type !== SUPERVISOR_RUN_TYPE) return null;
+
+  if (ctx.issueId !== issueId) {
+    return {
+      error: "Supervisor run is scoped to a different issue",
+      code: "supervisor_run_scope_mismatch",
+    };
+  }
+
+  const expiresAt = typeof ctx.expiresAt === "string" ? new Date(ctx.expiresAt) : null;
+  if (!expiresAt || expiresAt.getTime() < Date.now()) {
+    return {
+      error: "Supervisor run has expired (TTL: 5 minutes)",
+      code: "supervisor_run_expired",
+    };
+  }
+
+  return null;
+}
+
+export function isSupervisorRunContext(contextSnapshot: unknown): boolean {
+  if (!contextSnapshot || typeof contextSnapshot !== "object" || Array.isArray(contextSnapshot)) {
+    return false;
+  }
+  return (contextSnapshot as Record<string, unknown>).type === SUPERVISOR_RUN_TYPE;
+}

--- a/ui/src/components/MissionSubtasksLogsSection.tsx
+++ b/ui/src/components/MissionSubtasksLogsSection.tsx
@@ -1,0 +1,258 @@
+import { useMemo, useState } from "react";
+import { useQueries, useQuery } from "@tanstack/react-query";
+import type { Issue, IssueComment, IssueDocument } from "@paperclipai/shared";
+import { AlertTriangle, ChevronDown, ChevronRight, FileText, MessageSquare } from "lucide-react";
+import { issuesApi } from "../api/issues";
+import { createIssueDetailPath, withIssueDetailHeaderSeed } from "../lib/issueDetailBreadcrumb";
+import { queryKeys } from "../lib/queryKeys";
+import { cn, relativeTime } from "../lib/utils";
+import { Link } from "@/lib/router";
+import { StatusIcon } from "./StatusIcon";
+
+type MissionSubtasksLogsSectionProps = {
+  issueId: string;
+  companyId: string;
+};
+
+type LogSignal = {
+  hasLogDocument: boolean;
+  hasClosureComment: boolean;
+  noLogExpected: boolean;
+  latestClosureComment: IssueComment | null;
+  logDocuments: IssueDocument[];
+};
+
+const LOG_LOOKUP_LIMIT = 10;
+const QUERY_STALE_TIME_MS = 60_000;
+const LOG_DOCUMENT_PATTERN = /(^|_)log[_\[]/i;
+const LOG_KEYWORDS_PATTERN = /\b(log|rapport|retex)\b/i;
+const NO_LOG_EXPECTED_PATTERN = /\bno-log-expected\b/i;
+
+function isMissionSubtasksViewEnabled() {
+  const env = import.meta.env as ImportMetaEnv & Record<string, string | boolean | undefined>;
+  const raw = env.VITE_ENABLE_MISSION_SUBTASKS_VIEW ?? env.ENABLE_MISSION_SUBTASKS_VIEW;
+  return raw === true || raw === "true" || raw === "1";
+}
+
+function matchesLogDocument(document: IssueDocument) {
+  const key = document.key.trim();
+  const title = document.title?.trim() ?? "";
+  return LOG_DOCUMENT_PATTERN.test(key) || LOG_DOCUMENT_PATTERN.test(title) || /Log_\[/i.test(key) || /Log_\[/i.test(title);
+}
+
+function matchesClosureComment(comment: IssueComment) {
+  return !comment.deletedAt && LOG_KEYWORDS_PATTERN.test(comment.body);
+}
+
+function hasNoLogExpectedMarker(documents: IssueDocument[], comments: IssueComment[]) {
+  return documents.some((document) =>
+    NO_LOG_EXPECTED_PATTERN.test(document.key)
+    || NO_LOG_EXPECTED_PATTERN.test(document.title ?? "")
+    || NO_LOG_EXPECTED_PATTERN.test(document.body),
+  ) || comments.some((comment) => !comment.deletedAt && NO_LOG_EXPECTED_PATTERN.test(comment.body));
+}
+
+function buildLogSignal(documents: IssueDocument[] | undefined, comments: IssueComment[] | undefined): LogSignal {
+  const resolvedDocuments = documents ?? [];
+  const resolvedComments = comments ?? [];
+  const logDocuments = resolvedDocuments.filter(matchesLogDocument);
+  const closureComments = resolvedComments.filter(matchesClosureComment);
+  return {
+    hasLogDocument: logDocuments.length > 0,
+    hasClosureComment: closureComments.length > 0,
+    noLogExpected: hasNoLogExpectedMarker(resolvedDocuments, resolvedComments),
+    latestClosureComment: closureComments[0] ?? null,
+    logDocuments,
+  };
+}
+
+function issueLabel(issue: Issue) {
+  return issue.identifier ?? issue.id.slice(0, 8);
+}
+
+function needsLog(signal: LogSignal, issue: Issue) {
+  return issue.status === "done" && !signal.noLogExpected && !signal.hasLogDocument && !signal.hasClosureComment;
+}
+
+export function MissionSubtasksLogsSection({ issueId, companyId }: MissionSubtasksLogsSectionProps) {
+  const [expanded, setExpanded] = useState(false);
+  const { data: subtasks = [], isLoading, isError, error } = useQuery({
+    queryKey: queryKeys.issues.listByParent(companyId, issueId),
+    queryFn: () => issuesApi.list(companyId, { parentId: issueId, includeBlockedBy: true }),
+    enabled: isMissionSubtasksViewEnabled() && Boolean(companyId && issueId),
+    staleTime: QUERY_STALE_TIME_MS,
+  });
+
+  const directSubtasks = useMemo(
+    () => subtasks.filter((subtask) => subtask.parentId === issueId),
+    [issueId, subtasks],
+  );
+  const lookupSubtasks = directSubtasks.slice(0, LOG_LOOKUP_LIMIT);
+
+  const documentQueries = useQueries({
+    queries: lookupSubtasks.map((subtask) => ({
+      queryKey: queryKeys.issues.documents(subtask.id),
+      queryFn: () => issuesApi.listDocuments(subtask.id),
+      enabled: isMissionSubtasksViewEnabled() && directSubtasks.length > 0,
+      staleTime: QUERY_STALE_TIME_MS,
+    })),
+  });
+
+  const commentQueries = useQueries({
+    queries: lookupSubtasks.map((subtask) => ({
+      queryKey: queryKeys.issues.comments(subtask.id),
+      queryFn: () => issuesApi.listComments(subtask.id, { order: "desc", limit: 10 }),
+      enabled: isMissionSubtasksViewEnabled() && directSubtasks.length > 0,
+      staleTime: QUERY_STALE_TIME_MS,
+    })),
+  });
+
+  const rows = lookupSubtasks.map((subtask, index) => {
+    const documents = documentQueries[index]?.data;
+    const comments = commentQueries[index]?.data;
+    const signal = buildLogSignal(documents, comments);
+    return {
+      subtask,
+      signal,
+      missingLog: needsLog(signal, subtask),
+      documentsLoading: documentQueries[index]?.isLoading ?? false,
+      commentsLoading: commentQueries[index]?.isLoading ?? false,
+    };
+  });
+  const missingLogCount = rows.filter((row) => row.missingLog).length;
+
+  if (!isMissionSubtasksViewEnabled()) return null;
+  if (!isLoading && directSubtasks.length === 0) return null;
+
+  return (
+    <section className="rounded-lg border border-border bg-card">
+      <button
+        type="button"
+        className="flex w-full items-center justify-between gap-3 px-3 py-2.5 text-left"
+        onClick={() => setExpanded((current) => !current)}
+        aria-expanded={expanded}
+      >
+        <span className="flex min-w-0 items-center gap-2">
+          {expanded ? <ChevronDown className="h-4 w-4 shrink-0" /> : <ChevronRight className="h-4 w-4 shrink-0" />}
+          <span className="min-w-0">
+            <span className="block text-sm font-medium">Mission logs</span>
+            <span className="block text-xs text-muted-foreground">
+              {isLoading ? "Loading sub-tasks..." : `${directSubtasks.length} direct sub-task${directSubtasks.length === 1 ? "" : "s"}`}
+            </span>
+          </span>
+        </span>
+        {missingLogCount > 0 ? (
+          <span className="inline-flex shrink-0 items-center gap-1 rounded-full border border-destructive/40 bg-destructive/10 px-2 py-0.5 text-xs font-medium text-destructive">
+            <AlertTriangle className="h-3 w-3" />
+            Logs manquants {missingLogCount}
+          </span>
+        ) : null}
+      </button>
+
+      {expanded ? (
+        <div className="border-t border-border px-3 py-3">
+          {isError ? (
+            <p className="text-sm text-destructive">
+              {error instanceof Error ? error.message : "Unable to load mission logs."}
+            </p>
+          ) : rows.length === 0 ? (
+            <p className="text-sm text-muted-foreground">Loading sub-tasks...</p>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="w-full min-w-[620px] text-sm">
+                <thead className="text-xs text-muted-foreground">
+                  <tr className="border-b border-border">
+                    <th className="py-2 pr-3 text-left font-medium">Task</th>
+                    <th className="px-3 py-2 text-left font-medium">Status</th>
+                    <th className="px-3 py-2 text-left font-medium">Logs</th>
+                    <th className="py-2 pl-3 text-left font-medium">Last signal</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {rows.map(({ subtask, signal, missingLog, documentsLoading, commentsLoading }) => (
+                    <tr key={subtask.id} className="border-b border-border/70 last:border-0">
+                      <td className="max-w-[280px] py-2 pr-3">
+                        <Link
+                          to={createIssueDetailPath(subtask.identifier ?? subtask.id)}
+                          state={withIssueDetailHeaderSeed(undefined, subtask)}
+                          issuePrefetch={subtask}
+                          className="block min-w-0 no-underline hover:text-foreground"
+                        >
+                          <span className="block font-mono text-xs text-muted-foreground">{issueLabel(subtask)}</span>
+                          <span className="block truncate text-foreground">{subtask.title}</span>
+                        </Link>
+                      </td>
+                      <td className="px-3 py-2">
+                        <span className="inline-flex items-center gap-1.5">
+                          <StatusIcon status={subtask.status} blockerAttention={subtask.blockerAttention} />
+                          <span className="text-xs capitalize text-muted-foreground">{subtask.status.replaceAll("_", " ")}</span>
+                        </span>
+                      </td>
+                      <td className="px-3 py-2">
+                        {documentsLoading || commentsLoading ? (
+                          <span className="text-xs text-muted-foreground">Checking...</span>
+                        ) : signal.noLogExpected ? (
+                          <LogPill tone="muted">no-log-expected</LogPill>
+                        ) : missingLog ? (
+                          <LogPill tone="danger">Logs manquants</LogPill>
+                        ) : signal.hasLogDocument || signal.hasClosureComment ? (
+                          <LogPill tone="success">OK</LogPill>
+                        ) : (
+                          <LogPill tone="muted">Pending</LogPill>
+                        )}
+                      </td>
+                      <td className="py-2 pl-3 text-xs text-muted-foreground">
+                        <LogSignalSummary signal={signal} />
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+          {directSubtasks.length > LOG_LOOKUP_LIMIT ? (
+            <p className="mt-2 text-xs text-muted-foreground">
+              Log lookup is capped at {LOG_LOOKUP_LIMIT} direct sub-tasks to keep this view lightweight.
+            </p>
+          ) : null}
+        </div>
+      ) : null}
+    </section>
+  );
+}
+
+function LogPill({ tone, children }: { tone: "success" | "danger" | "muted"; children: string }) {
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-medium",
+        tone === "success" && "border-green-600/30 bg-green-600/10 text-green-700 dark:text-green-400",
+        tone === "danger" && "border-destructive/40 bg-destructive/10 text-destructive",
+        tone === "muted" && "border-border bg-muted text-muted-foreground",
+      )}
+    >
+      {children}
+    </span>
+  );
+}
+
+function LogSignalSummary({ signal }: { signal: LogSignal }) {
+  if (signal.logDocuments.length > 0) {
+    const document = signal.logDocuments[0];
+    return (
+      <span className="inline-flex items-center gap-1">
+        <FileText className="h-3.5 w-3.5" />
+        {document.title || document.key}
+      </span>
+    );
+  }
+  if (signal.latestClosureComment) {
+    return (
+      <a href={`#comment-${signal.latestClosureComment.id}`} className="inline-flex items-center gap-1 underline-offset-2 hover:underline">
+        <MessageSquare className="h-3.5 w-3.5" />
+        {relativeTime(signal.latestClosureComment.createdAt)}
+      </a>
+    );
+  }
+  return <span>No log signal</span>;
+}

--- a/ui/src/lib/blockedInbox.ts
+++ b/ui/src/lib/blockedInbox.ts
@@ -9,6 +9,7 @@ export type BlockedReasonVariant =
   | "needs_decision"
   | "stalled"
   | "needs_attention"
+  | "recovery_needed"
   | "recovery_required"
   | "external_wait"
   | "owner_paused";
@@ -16,7 +17,7 @@ export type BlockedReasonVariant =
 const VARIANT_BY_REASON: Record<IssueBlockedInboxReason, BlockedReasonVariant> = {
   pending_board_decision: "needs_decision",
   pending_user_decision: "needs_decision",
-  missing_successful_run_disposition: "needs_decision",
+  missing_successful_run_disposition: "recovery_needed",
   blocked_chain_stalled: "stalled",
   blocked_by_unassigned_issue: "needs_attention",
   blocked_by_assigned_backlog_issue: "needs_attention",
@@ -32,6 +33,7 @@ export const BLOCKED_REASON_VARIANT_ORDER: BlockedReasonVariant[] = [
   "needs_decision",
   "stalled",
   "needs_attention",
+  "recovery_needed",
   "recovery_required",
   "external_wait",
   "owner_paused",
@@ -41,6 +43,7 @@ export const BLOCKED_VARIANT_LABELS: Record<BlockedReasonVariant, string> = {
   needs_decision: "Needs decision",
   stalled: "Blocked chain stalled",
   needs_attention: "Needs attention",
+  recovery_needed: "Recovery needed",
   recovery_required: "Recovery required",
   external_wait: "External wait",
   owner_paused: "Owner paused",

--- a/ui/src/pages/IssueDetail.tsx
+++ b/ui/src/pages/IssueDetail.tsx
@@ -72,6 +72,7 @@ import { workModeMetaFor } from "../lib/work-mode-meta";
 import { IssueContinuationHandoff } from "../components/IssueContinuationHandoff";
 import { IssueAttachmentsSection } from "../components/IssueAttachmentsSection";
 import { IssueDocumentsSection } from "../components/IssueDocumentsSection";
+import { MissionSubtasksLogsSection } from "../components/MissionSubtasksLogsSection";
 import { IssuePlanDecompositionsSection } from "../components/IssuePlanDecompositionsSection";
 import { IssueOutputSection } from "../components/issue-output/IssueOutputSection";
 import { isImageAttachment } from "../lib/issue-attachments";
@@ -4090,6 +4091,8 @@ export function IssueDetail() {
           agentMap={agentMap}
         />
       ) : null}
+
+      <MissionSubtasksLogsSection issueId={issue.id} companyId={issue.companyId} />
 
       <IssueDocumentsSection
         issue={issue}


### PR DESCRIPTION
## Summary

- **Req 1** — `decideSuccessfulRunHandoff`: structured error log when corrective handoff run detected missing disposition (uses `SUCCESSFUL_RUN_MISSING_STATE_REASON`). Also fixes wrong `readNonEmptyString` call → `readString`.
- **Req 2** — `escalateStrandedAssignedIssue`: after posting exhausted notice for `missing_successful_run_disposition`, auto-creates `[OPS] Missing disposition` todo issue assigned to VINCI with cause, source issue ID, run ID, missing disposition, and suggested action.
- **Req 5** — `blockedInbox.ts`: new `recovery_needed` variant for `missing_successful_run_disposition`, distinct from `needs_decision`. Shows as separate "Recovery needed" group in dashboard when grouped by blocker type.

## Test plan
- [ ] Server TS check passes
- [ ] `successful-run-handoff.test.ts` — 16 tests pass
- [ ] `blockedInbox.test.ts` + `BlockedInboxView.test.tsx` — 15 tests pass
- [ ] Dev: trigger exhausted recovery path → verify `[OPS] Missing disposition — USI-XX` issue appears in Paperclip assigned to VINCI
- [ ] Dev: confirm `missing_successful_run_disposition` items group as "Recovery needed" (not "Needs decision") in Inbox blocked view

🤖 Generated with [Claude Code](https://claude.com/claude-code)