### PR TITLE
test(skills-catalog): cover packaged npm artifacts

### DIFF
--- a/packages/skills-catalog/src/packaged-artifacts.test.ts
+++ b/packages/skills-catalog/src/packaged-artifacts.test.ts
@@ -52,5 +52,5 @@ describe("skills catalog package artifacts", () => {
     expect(paths).toContain("catalog/bundled/software-development/github-pr-workflow/SKILL.md");
     expect(paths).toContain("catalog/optional/browser/agent-browser/SKILL.md");
     expect(paths).toContain("package.json");
-  });
+  }, 30_000);
 });

--- a/packages/skills-catalog/src/packaged-artifacts.test.ts
+++ b/packages/skills-catalog/src/packaged-artifacts.test.ts
@@ -1,13 +1,15 @@
 import { fileURLToPath } from "node:url";
 import { execFileSync } from "node:child_process";
+import { mkdtempSync } from "node:fs";
 import { rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 
 const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 
-function readPackMetadata() {
-  const output = execFileSync("npm", ["pack", "--json"], {
+function readPackMetadata(packDestination: string) {
+  const output = execFileSync("npm", ["pack", "--json", "--pack-destination", packDestination], {
     cwd: packageRoot,
     encoding: "utf8",
   });
@@ -21,22 +23,26 @@ function readPackMetadata() {
 describe("skills catalog package artifacts", () => {
   const cleanup: string[] = [];
 
+  function createPackDestination() {
+    const destination = mkdtempSync(path.join(tmpdir(), "paperclip-skills-catalog-pack-"));
+    cleanup.push(destination);
+    return destination;
+  }
+
   afterEach(async () => {
-    await Promise.all(cleanup.map((entry) => rm(entry, { force: true })));
+    await Promise.all(cleanup.map((entry) => rm(entry, { force: true, recursive: true })));
     cleanup.length = 0;
   });
 
   it("packs dist manifest and catalog files for npm artifact consumers", () => {
-    let metadata = readPackMetadata();
-    cleanup.push(path.join(packageRoot, metadata.filename));
+    let metadata = readPackMetadata(createPackDestination());
 
     if (!metadata.files.some((entry) => entry.path === "dist/generated/catalog.json")) {
       execFileSync("pnpm", ["--filter", "@paperclipai/skills-catalog", "build"], {
         cwd: packageRoot,
         stdio: "ignore",
       });
-      metadata = readPackMetadata();
-      cleanup.push(path.join(packageRoot, metadata.filename));
+      metadata = readPackMetadata(createPackDestination());
     }
 
     const paths = metadata.files.map((entry) => entry.path);

--- a/packages/skills-catalog/src/packaged-artifacts.test.ts
+++ b/packages/skills-catalog/src/packaged-artifacts.test.ts
@@ -1,0 +1,50 @@
+import { fileURLToPath } from "node:url";
+import { execFileSync } from "node:child_process";
+import { rm } from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+function readPackMetadata() {
+  const output = execFileSync("npm", ["pack", "--json"], {
+    cwd: packageRoot,
+    encoding: "utf8",
+  });
+  const metadata = JSON.parse(output);
+  if (!Array.isArray(metadata) || metadata.length === 0 || typeof metadata[0]?.filename !== "string") {
+    throw new Error(`Unexpected npm pack output from ${packageRoot}: ${output}`);
+  }
+  return metadata[0] as { filename: string; files: Array<{ path: string }> };
+}
+
+describe("skills catalog package artifacts", () => {
+  const cleanup: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(cleanup.map((entry) => rm(entry, { force: true })));
+    cleanup.length = 0;
+  });
+
+  it("packs dist manifest and catalog files for npm artifact consumers", () => {
+    let metadata = readPackMetadata();
+    cleanup.push(path.join(packageRoot, metadata.filename));
+
+    if (!metadata.files.some((entry) => entry.path === "dist/generated/catalog.json")) {
+      execFileSync("pnpm", ["--filter", "@paperclipai/skills-catalog", "build"], {
+        cwd: packageRoot,
+        stdio: "ignore",
+      });
+      metadata = readPackMetadata();
+      cleanup.push(path.join(packageRoot, metadata.filename));
+    }
+
+    const paths = metadata.files.map((entry) => entry.path);
+
+    expect(paths).toContain("dist/generated/catalog.json");
+    expect(paths).toContain("generated/catalog.json");
+    expect(paths).toContain("catalog/bundled/software-development/github-pr-workflow/SKILL.md");
+    expect(paths).toContain("catalog/optional/browser/agent-browser/SKILL.md");
+    expect(paths).toContain("package.json");
+  });
+});


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The skills catalog package publishes bundled and optional skills for installs and downstream runtime consumers.
> - Published package consumers depend on both generated catalog manifests and the source skill files being present in the npm artifact.
> - Prior fixes improved published package resolution, but the package contents themselves did not have a smoke test guarding against regressions.
> - This pull request adds an npm-pack artifact test for the skills catalog package and hardens the test cleanup path.
> - The benefit is that packaging regressions are caught before release instead of after users install a broken catalog package.

## Linked Issues or Issue Description

Bug description:
The skills catalog npm artifact needs to include the generated catalog manifests plus bundled and optional skill files. Without a package-level smoke test, a future change to `files`, build output, or catalog paths could publish an artifact that installs successfully but cannot serve catalog consumers correctly.

Expected behavior:
The package artifact produced by `npm pack` includes `dist/generated/catalog.json`, `generated/catalog.json`, representative bundled and optional skill `SKILL.md` files, and `package.json`.

Actual risk before this PR:
Package content regressions could ship without a focused local test detecting the missing files.

## What Changed

- Added a Vitest smoke test for `@paperclipai/skills-catalog` that runs `npm pack --json` and verifies required artifact paths.
- Added a build fallback inside the test when `dist/generated/catalog.json` is absent before packing.
- Packs into registered temporary directories and recursively removes them after each test run so generated `.tgz` files do not leak when parsing or assertions fail.
- Allows enough time for the smoke test to exercise the build fallback path on fresh CI runners.

## Verification

- `pnpm --filter @paperclipai/skills-catalog test`
- `pnpm --filter @paperclipai/skills-catalog clean && pnpm --filter @paperclipai/skills-catalog test`
- Searched for duplicate/related PRs; existing PR #8327 is already merged and this PR adds regression coverage around the package artifact.
- Checked `ROADMAP.md`; no overlapping roadmap entry for this packaging test.
- Confirmed the branch diff does not touch `pnpm-lock.yaml` or `.github/workflows`.

## Risks

Low risk. This is test-only coverage for package contents. The main practical risk is a slightly slower skills catalog test run because it invokes `npm pack` and may build the package manifest when `dist` is absent.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

OpenAI GPT-5 Codex coding agent with shell and GitHub CLI tool use. Context window not exposed by the runtime.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge