### PR TITLE
Sort workspace routines by name

### DIFF
--- a/ui/src/lib/workspace-routines.test.ts
+++ b/ui/src/lib/workspace-routines.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   getWorkspaceSpecificRoutineVariableNames,
   routineHasWorkspaceSpecificVariables,
+  sortWorkspaceRoutinesByName,
 } from "./workspace-routines";
 
 function createRoutine(overrides: Partial<RoutineListItem> = {}): RoutineListItem {
@@ -67,5 +68,32 @@ describe("workspace routine helpers", () => {
     });
 
     expect(routineHasWorkspaceSpecificVariables(routine)).toBe(false);
+  });
+
+  it("sorts workspace routines by name regardless of update order", () => {
+    const routines = [
+      createRoutine({
+        id: "routine-2",
+        title: "zeta review",
+        updatedAt: new Date("2026-05-02T00:00:00.000Z"),
+      }),
+      createRoutine({
+        id: "routine-3",
+        title: "Alpha review",
+        updatedAt: new Date("2026-04-30T00:00:00.000Z"),
+      }),
+      createRoutine({
+        id: "routine-1",
+        title: "alpha review",
+        updatedAt: new Date("2026-05-03T00:00:00.000Z"),
+      }),
+    ];
+
+    expect(sortWorkspaceRoutinesByName(routines).map((routine) => routine.id)).toEqual([
+      "routine-1",
+      "routine-3",
+      "routine-2",
+    ]);
+    expect(routines.map((routine) => routine.id)).toEqual(["routine-2", "routine-3", "routine-1"]);
   });
 });

--- a/ui/src/lib/workspace-routines.ts
+++ b/ui/src/lib/workspace-routines.ts
@@ -29,3 +29,11 @@ export function getWorkspaceSpecificRoutineVariableNames(routine: RoutineListIte
 export function routineHasWorkspaceSpecificVariables(routine: RoutineListItem): boolean {
   return getWorkspaceSpecificRoutineVariableNames(routine).length > 0;
 }
+
+export function sortWorkspaceRoutinesByName(routines: RoutineListItem[]): RoutineListItem[] {
+  return [...routines].sort((left, right) => {
+    const titleOrder = left.title.localeCompare(right.title, undefined, { sensitivity: "base" });
+    if (titleOrder !== 0) return titleOrder;
+    return left.id.localeCompare(right.id);
+  });
+}

--- a/ui/src/pages/ExecutionWorkspaceDetail.tsx
+++ b/ui/src/pages/ExecutionWorkspaceDetail.tsx
@@ -40,6 +40,7 @@ import { cn, formatDateTime, issueUrl, projectRouteRef, projectWorkspaceUrl } fr
 import {
   getWorkspaceSpecificRoutineVariableNames,
   routineHasWorkspaceSpecificVariables,
+  sortWorkspaceRoutinesByName,
 } from "../lib/workspace-routines";
 
 type WorkspaceFormState = {
@@ -445,7 +446,7 @@ function ExecutionWorkspaceRoutinesList({
   });
 
   const workspaceRoutines = useMemo(
-    () => (routines ?? []).filter(routineHasWorkspaceSpecificVariables),
+    () => sortWorkspaceRoutinesByName((routines ?? []).filter(routineHasWorkspaceSpecificVariables)),
     [routines],
   );
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Execution workspace pages can show routines that are specific to the current workspace
> - Operators scan that list to find the automation they want to inspect or run
> - The list was using the API/update order, which can make routine discovery feel unstable as routines change
> - This pull request sorts workspace-specific routines by name while preserving deterministic tie-breaking
> - The benefit is a more predictable workspace routine list without changing routine data or API behavior

## Linked Issues or Issue Description

No public GitHub issue found after searching related PR titles.

Bug fix / UX improvement:

### What happened?
Workspace-specific routines appeared in update/order-of-arrival order on the workspace detail page.

### Expected behavior
Operators should see workspace-specific routines in a stable name order that is easy to scan.

### Steps to reproduce
1. Create multiple workspace-specific routines with names that do not match their update order.
2. Open the execution workspace detail page.
3. Observe that the workspace-specific routine list follows update/arrival order instead of name order.

### Paperclip version or commit
`origin/master` at `43b005b70` before this change.

### Deployment mode
Local development / board UI.

## What Changed

- Added `sortWorkspaceRoutinesByName` to the workspace routine helper module.
- Updated the execution workspace routine list to sort filtered workspace-specific routines by name.
- Added a regression test confirming case-insensitive name sorting, deterministic ID tie-breaking, and non-mutating behavior.

## Verification

- `/srv/paperclip/home/paperclipai/paperclip/node_modules/.bin/vitest run ui/src/lib/workspace-routines.test.ts` initially failed before dependency links were populated in the new worktree.
- `pnpm install --frozen-lockfile` completed in the worktree with plugin SDK bin warnings from unbuilt optional plugin packages, and did not change the lockfile.
- `/srv/paperclip/home/paperclipai/paperclip/node_modules/.bin/vitest run ui/src/lib/workspace-routines.test.ts` passed: 1 file, 4 tests.

## Risks

- Low risk. This only changes client-side ordering for the workspace-specific routine list and includes focused helper coverage.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

OpenAI Codex, GPT-5 coding agent, tool use enabled. Exact service-side context window was not exposed in this runtime.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

