### PR TITLE
fix(plugin-loader): Windows plugin install — spawn npm correctly and pass tsx loader as file:// URL

### DIFF
--- a/server/src/__tests__/plugin-loader-windows-spawn.test.ts
+++ b/server/src/__tests__/plugin-loader-windows-spawn.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildDevLoaderExecArgv,
+  resolveNpmInvocation,
+} from "../services/plugin-loader.js";
+
+/**
+ * Regression coverage for two Windows-only plugin-install bugs:
+ *   1. `execFile("npm", ...)` throws `spawn npm ENOENT` because the launcher
+ *      is `npm.cmd` and cannot be spawned without a shell.
+ *   2. The tsx dev loader passed to `--import` as a bare `E:\...` path is read
+ *      by Node's ESM loader as scheme `e:` → ERR_UNSUPPORTED_ESM_URL_SCHEME,
+ *      crashing the plugin worker on init.
+ */
+describe("resolveNpmInvocation (Windows npm.cmd spawn fix)", () => {
+  it("uses npm.cmd through a shell on Windows", () => {
+    expect(resolveNpmInvocation("win32")).toEqual({
+      command: "npm.cmd",
+      execOptions: { shell: true },
+    });
+  });
+
+  it("uses bare npm with no shell on POSIX", () => {
+    expect(resolveNpmInvocation("linux")).toEqual({
+      command: "npm",
+      execOptions: {},
+    });
+    expect(resolveNpmInvocation("darwin")).toEqual({
+      command: "npm",
+      execOptions: {},
+    });
+  });
+
+  it("never spawns a .cmd launcher without a shell (the ENOENT cause)", () => {
+    const { command, execOptions } = resolveNpmInvocation("win32");
+    if (command.endsWith(".cmd")) {
+      expect((execOptions as { shell?: boolean }).shell).toBe(true);
+    }
+  });
+});
+
+describe("buildDevLoaderExecArgv (Windows ESM --import fix)", () => {
+  it("passes the tsx loader as a file:// URL, not a bare Windows path", () => {
+    const argv = buildDevLoaderExecArgv(
+      "E:\\clones\\paperclip\\cli\\node_modules\\tsx\\dist\\loader.mjs",
+    );
+    expect(argv[0]).toBe("--import");
+    expect(argv[1]!.startsWith("file://")).toBe(true);
+    // A bare drive path (e.g. `E:\...`) is what triggers the
+    // ERR_UNSUPPORTED_ESM_URL_SCHEME (protocol 'e:') crash.
+    expect(argv[1]).not.toMatch(/^[a-zA-Z]:[\\/]/);
+  });
+
+  it("produces a URL Node's ESM loader accepts", () => {
+    const argv = buildDevLoaderExecArgv("/home/user/app/loader.mjs");
+    expect(() => new URL(argv[1]!)).not.toThrow();
+    expect(new URL(argv[1]!).protocol).toBe("file:");
+  });
+});

--- a/server/src/services/plugin-loader.ts
+++ b/server/src/services/plugin-loader.ts
@@ -2174,7 +2174,11 @@ export function pluginLoader(
       // (for example @paperclipai/shared exports). Run those workers through
       // the tsx loader so first-party example plugins work in development.
       if (activePlugin.packagePath && existsSync(DEV_TSX_LOADER_PATH)) {
-        workerOptions.execArgv = ["--import", DEV_TSX_LOADER_PATH];
+        // Node's --import expects a URL; a bare Windows path (e.g. E:\...) is
+        // parsed as a URL with scheme "e:" and rejected with
+        // ERR_UNSUPPORTED_ESM_URL_SCHEME. Pass a file:// URL so the tsx loader
+        // is found on every platform.
+        workerOptions.execArgv = ["--import", pathToFileURL(DEV_TSX_LOADER_PATH).href];
       }
 
       await workerManager.startWorker(pluginId, workerOptions);

--- a/server/src/services/plugin-loader.ts
+++ b/server/src/services/plugin-loader.ts
@@ -52,13 +52,37 @@ import { pluginDatabaseService } from "./plugin-database.js";
 
 const execFileAsync = promisify(execFile);
 
-// On Windows the npm launcher is `npm.cmd`, which `execFile` cannot spawn
-// without a shell (it is not a PE executable) — doing so throws
-// `spawn npm ENOENT`. Resolve the platform-correct binary and run it through
-// the shell only on Windows so `.cmd` scripts are launched correctly.
-const IS_WINDOWS = os.platform() === "win32";
-const NPM_BIN = IS_WINDOWS ? "npm.cmd" : "npm";
-const NPM_EXEC_OPTS = IS_WINDOWS ? { shell: true } : {};
+/**
+ * Resolve how to invoke the npm CLI for the current platform.
+ *
+ * On Windows the npm launcher is `npm.cmd`, which `execFile` cannot spawn
+ * without a shell (it is not a PE executable) — doing so throws
+ * `spawn npm ENOENT`. Use the `.cmd` launcher and run it through the shell on
+ * Windows; on POSIX use bare `npm` with no shell (avoids shell injection).
+ */
+export function resolveNpmInvocation(
+  platform: NodeJS.Platform = os.platform(),
+): { command: string; execOptions: { shell: true } | Record<string, never> } {
+  const isWindows = platform === "win32";
+  return {
+    command: isWindows ? "npm.cmd" : "npm",
+    execOptions: isWindows ? { shell: true } : {},
+  };
+}
+
+const { command: NPM_BIN, execOptions: NPM_EXEC_OPTS } = resolveNpmInvocation();
+
+/**
+ * Build the `execArgv` that runs a worker through the tsx dev loader.
+ *
+ * Node's `--import` expects a URL; a bare Windows path (e.g. `E:\...`) is
+ * parsed as a URL with scheme `e:` and rejected with
+ * ERR_UNSUPPORTED_ESM_URL_SCHEME, crashing the worker on init. Passing a
+ * `file://` URL works on every platform.
+ */
+export function buildDevLoaderExecArgv(loaderPath: string): string[] {
+  return ["--import", pathToFileURL(loaderPath).href];
+}
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 export const REPO_ROOT = path.resolve(__dirname, "../../..");
@@ -2174,11 +2198,7 @@ export function pluginLoader(
       // (for example @paperclipai/shared exports). Run those workers through
       // the tsx loader so first-party example plugins work in development.
       if (activePlugin.packagePath && existsSync(DEV_TSX_LOADER_PATH)) {
-        // Node's --import expects a URL; a bare Windows path (e.g. E:\...) is
-        // parsed as a URL with scheme "e:" and rejected with
-        // ERR_UNSUPPORTED_ESM_URL_SCHEME. Pass a file:// URL so the tsx loader
-        // is found on every platform.
-        workerOptions.execArgv = ["--import", pathToFileURL(DEV_TSX_LOADER_PATH).href];
+        workerOptions.execArgv = buildDevLoaderExecArgv(DEV_TSX_LOADER_PATH);
       }
 
       await workerManager.startWorker(pluginId, workerOptions);

--- a/server/src/services/plugin-loader.ts
+++ b/server/src/services/plugin-loader.ts
@@ -51,6 +51,15 @@ import type { PluginLifecycleManager } from "./plugin-lifecycle.js";
 import { pluginDatabaseService } from "./plugin-database.js";
 
 const execFileAsync = promisify(execFile);
+
+// On Windows the npm launcher is `npm.cmd`, which `execFile` cannot spawn
+// without a shell (it is not a PE executable) — doing so throws
+// `spawn npm ENOENT`. Resolve the platform-correct binary and run it through
+// the shell only on Windows so `.cmd` scripts are launched correctly.
+const IS_WINDOWS = os.platform() === "win32";
+const NPM_BIN = IS_WINDOWS ? "npm.cmd" : "npm";
+const NPM_EXEC_OPTS = IS_WINDOWS ? { shell: true } : {};
+
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 export const REPO_ROOT = path.resolve(__dirname, "../../..");
 export const BUNDLED_LOCAL_PLUGIN_ROOT = path.join(REPO_ROOT, "packages", "plugins");
@@ -1171,9 +1180,9 @@ export function pluginLoader(
         // --ignore-scripts prevents preinstall/install/postinstall hooks from
         // executing arbitrary code on the host before manifest validation.
         await execFileAsync(
-          "npm",
+          NPM_BIN,
           ["install", spec, "--prefix", targetInstallDir, "--save", "--ignore-scripts"],
-          { timeout: 120_000 }, // 2 minute timeout for npm install
+          { timeout: 120_000, ...NPM_EXEC_OPTS }, // 2 minute timeout for npm install
         );
       } catch (err) {
         throw new Error(`npm install failed for ${spec}: ${String(err)}`);
@@ -1813,9 +1822,9 @@ export function pluginLoader(
       if (existsSync(packageJsonPath)) {
         try {
           await execFileAsync(
-            "npm",
+            NPM_BIN,
             ["uninstall", plugin.packageName, "--prefix", localPluginDir, "--ignore-scripts"],
-            { timeout: 120_000 },
+            { timeout: 120_000, ...NPM_EXEC_OPTS },
           );
         } catch (err) {
           log.warn(


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work, and it documents self-hosted single-tenant installs (incl. Windows) as a primary deployment target.
> - The plugin subsystem lets operators install instance-wide plugins from npm or a local path; `server/src/services/plugin-loader.ts` resolves the package, runs npm, and spawns an out-of-process worker.
> - On Windows two OS-specific assumptions break this path: npm is invoked as a bare `npm` (really `npm.cmd`), and the tsx dev loader is handed to Node's `--import` as a bare `E:\...` path.
> - As a result `plugin install` fails outright (`spawn npm ENOENT`) for npm packages, and local-path installs activate then immediately crash the worker (`ERR_UNSUPPORTED_ESM_URL_SCHEME`, protocol `e:`).
> - This pull request resolves both by choosing the platform-correct npm launcher (with a shell only on Windows) and passing the loader as a `file://` URL.
> - The benefit is that plugin install/uninstall and local-path plugin development work on Windows self-hosted instances, matching the documented deployment story, with POSIX behavior unchanged.

## Linked Issues or Issue Description

No tracked public issue, so describing inline (bug report):

**What happened** — On Windows 11 (Node 24, npm 11.16), `POST /api/plugins/install`:
- npm package install fails with `npm install failed for <pkg>: Error: spawn npm ENOENT`.
- local-path install registers the plugin, then the worker crashes on init with `ERR_UNSUPPORTED_ESM_URL_SCHEME ... Received protocol 'e:'`, leaving the plugin in `error`.

**Expected** — plugin installs and reaches `ready` on Windows.

**Root cause** — (1) `execFile("npm", ...)` cannot launch `npm.cmd` (a batch script, not a PE executable) without a shell; (2) `execArgv = ["--import", DEV_TSX_LOADER_PATH]` passes a bare drive path, which Node's ESM loader parses as URL scheme `e:`.

Related / overlapping PRs found while searching (this area has many duplicates; none merged yet): Refs #8091, #2146, #7220, #3874, #4287, #4329, #2058, #4196.

## What Changed

- Added `resolveNpmInvocation(platform)` — returns `npm.cmd` + `{ shell: true }` on Windows, bare `npm` + no shell on POSIX — and use it at both `execFileAsync` npm sites (install and uninstall-cleanup). `--ignore-scripts` preserved.
- Added `buildDevLoaderExecArgv(loaderPath)` — wraps the tsx dev loader path with `pathToFileURL(...).href` so `--import` always receives a valid `file://` URL; used at the local-path worker activation site.
- Added `server/src/__tests__/plugin-loader-windows-spawn.test.ts` covering both helpers across `win32`/`linux`/`darwin`.

## Verification

- `npx vitest run src/__tests__/plugin-loader-windows-spawn.test.ts` → 5 passed.
- Manual, Windows 11 / Node 24 / npm 11.16, against a live self-hosted instance:
  - Before: npm-package install → `spawn npm ENOENT`; local-path install → worker crash `protocol 'e:'`.
  - After: `plugin install paperclip-github-plugin` → `ready`; `plugin install <local path>` → `installed → ready → worker started`, no crash. Verified `plugin list` shows both `ready`.

## Risks

Low risk. Both helpers are pure and platform-gated; POSIX invocation is byte-for-byte unchanged (`npm`, no shell, same args). `shell: true` is Windows-only and arguments are not user-free-form (validated package spec; `--ignore-scripts` retained). No schema/migration/API changes.

## Model Used

Claude Opus 4.8 (`claude-opus-4-8`) via Claude Code (agentic tool use, extended thinking). Changes authored and verified with human direction.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots (N/A — no UI changes)
- [ ] I have updated relevant documentation to reflect my changes (N/A — no behavior/docs surface changes)
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green (pending CI)
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups (pending review)
- [x] I will address all Greptile and reviewer comments before requesting merge
