### PR TITLE
fix(recovery): treat output-inactivity-monitor kills as non-retryable continuations

### DIFF
--- a/server/src/services/recovery/service.pause-durability.test.ts
+++ b/server/src/services/recovery/service.pause-durability.test.ts
@@ -35,4 +35,16 @@ describe("pause durability: continuation retry classification", () => {
     expect(classifyContinuationFailure(run(null)).kind).toBe("default");
     expect(classifyContinuationFailure(run("some_adapter_error")).kind).toBe("default");
   });
+
+  it("output-inactivity-monitor kills are non-retryable (no immediate re-kill loop)", () => {
+    // The monitor SIGTERMs a run after a long stdout-silent stretch; an immediate
+    // continuation retry resumes the same long-quiet work and is killed again.
+    // Classify apart from transient infra so it escalates to `blocked` for
+    // visibility instead of burning a deterministically-failing retry.
+    for (const code of ["claude_output_inactivity_monitor", "codex_output_inactivity_monitor"]) {
+      const c = classifyContinuationFailure(run(code));
+      expect(c.kind).toBe("non_retryable");
+      expect(c.maxAttempts).toBe(0);
+    }
+  });
 });

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -193,6 +193,22 @@ const NON_RETRYABLE_CONTINUATION_ERROR_CODES = new Set<string>([
   "issue_dependencies_blocked",
 ]);
 
+// Output-inactivity-monitor kills are NOT transient infra failures and must be
+// classified apart from process-loss / upstream-transient retries. The monitor
+// SIGTERMs a run after a long stretch with no stdout; an immediate continuation
+// retry just resumes the same long-quiet work and is killed the same way
+// (observed: roughly half of inactivity-killed continuation retries were
+// themselves re-killed — a wasted, deterministically-failing loop). Under the
+// previous `default` classification (maxAttempts 1, no backoff) such a run still
+// ended up `blocked` after one re-kill, so treating these codes as non-retryable
+// reaches the same disposition without burning that re-kill, and surfaces a
+// genuinely hung run for intervention. Defense-in-depth behind the tool-aware
+// monitor change that reduces false kills at the source.
+const OUTPUT_INACTIVITY_MONITOR_CONTINUATION_ERROR_CODES = new Set<string>([
+  "claude_output_inactivity_monitor",
+  "codex_output_inactivity_monitor",
+]);
+
 // A continuation cancelled with this code is a *deliberate wait* (the latest run
 // reported it was parked for review/approval), not a lost execution path. When the
 // issue has a real waiting target we convert it into a normal dependency wait rather
@@ -213,6 +229,9 @@ type ContinuationRetryClassification = {
 export function classifyContinuationFailure(latestRun: LatestIssueRun): ContinuationRetryClassification {
   const errorCode = readNonEmptyString(latestRun?.errorCode);
   if (errorCode && NON_RETRYABLE_CONTINUATION_ERROR_CODES.has(errorCode)) {
+    return { kind: "non_retryable", maxAttempts: 0, baseBackoffMs: 0, errorCode };
+  }
+  if (errorCode && OUTPUT_INACTIVITY_MONITOR_CONTINUATION_ERROR_CODES.has(errorCode)) {
     return { kind: "non_retryable", maxAttempts: 0, baseBackoffMs: 0, errorCode };
   }
   if (errorCode && TRANSIENT_INFRA_CONTINUATION_ERROR_CODES.has(errorCode)) {


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The heartbeat/recovery subsystem retries runs whose live execution path disappears, classifying the failure to decide whether (and how) to retry
> - Local adapters run an output-inactivity monitor that SIGTERMs a run after a long stretch with no stdout; it surfaces a distinct error code per adapter
> - Continuation recovery had no bucket for those codes, so they fell to the `default` classification (one immediate, no-backoff retry)
> - For a run killed for output inactivity, an immediate retry resumes the same long-quiet work and is killed the same way — a wasted, deterministically-failing re-kill (observed: roughly half of inactivity-killed continuation retries were themselves re-killed)
> - This pull request classifies those error codes apart from process-loss / upstream-transient retries and marks them non-retryable
> - The benefit is no wasted re-kill loop: the issue reaches the same `blocked` disposition it already reached after one re-kill, and a genuinely hung run is surfaced for intervention instead of silently retried

## Linked Issues or Issue Description

No public GitHub issue exists. Describing the bug inline, following the bug report template:

### What happened

When a local-adapter run is terminated by the output-inactivity monitor (error codes `claude_output_inactivity_monitor` / `codex_output_inactivity_monitor`), continuation recovery classifies the failure as `default` and enqueues one immediate, no-backoff continuation retry. An inactivity kill means the run produced no stdout for the timeout window — typically a deep run blocked on a long tool/model wait — so re-running resumes the same long-quiet work and trips the same monitor. The retry deterministically re-fails (in practice ~half of inactivity-killed continuation retries were themselves re-killed). Because `default` allows only one attempt, the issue was escalated to `blocked` after that re-kill anyway, so the retry bought nothing.

### Steps to reproduce

1. Run a local Claude or Codex adapter on a task that goes quiet for a long stretch (a deep run blocked on a long tool/model wait with no stdout) until the output-inactivity monitor SIGTERMs it with `claude_output_inactivity_monitor` / `codex_output_inactivity_monitor`.
2. Observe continuation recovery classify the failure as `default` and enqueue one immediate continuation retry.
3. Observe the retry resume the same quiet work, get re-killed by the same monitor, and the issue then move to `blocked`.

### Expected behavior

Inactivity kills are treated as non-retryable by continuation recovery, reaching the same `blocked` disposition without the wasted re-kill, surfacing the hung run for intervention.

### Deployment mode

Local / self-hosted adapter, affecting both the `claude_local` and `codex_local` output-inactivity monitors.

## What Changed

- Added `OUTPUT_INACTIVITY_MONITOR_CONTINUATION_ERROR_CODES` (`claude_output_inactivity_monitor`, `codex_output_inactivity_monitor`) in `server/src/services/recovery/service.ts`.
- `classifyContinuationFailure` now returns `non_retryable` for those codes, classified explicitly apart from the `transient_infra` bucket (process-loss / upstream-transient).
- Added unit tests asserting both codes classify as `non_retryable` with `maxAttempts: 0`.

## Verification

- `pnpm exec vitest run server/src/services/recovery/service.pause-durability.test.ts` → 6 passed (incl. 2 new).
- `pnpm --filter @paperclipai/server typecheck` → clean.

## Risks

Low risk. Behavioral shift is narrow: two specific error codes move from `default` (1 retry → blocked) to `non_retryable` (0 retries → blocked). Final disposition is unchanged (`blocked`); only the redundant intermediate re-kill is removed. No schema or migration changes. The bounded-transient retry path in `heartbeat.ts` is unaffected — it gates on the `transient_upstream` error family, which these codes never carry.

## Model Used

Claude, claude-opus-4-8 (Opus 4.8), extended thinking, with tool use / code execution in an agentic CLI.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
