### PR TITLE
fix(adapters/hermes): provide Paperclip write helper

### DIFF
--- a/packages/adapters/hermes/src/server/execute.ts
+++ b/packages/adapters/hermes/src/server/execute.ts
@@ -80,8 +80,9 @@ function resolvePaperclipApiUrl(config: Record<string, unknown>): string {
     cfgString(config.paperclipApiUrl) ||
     process.env.PAPERCLIP_API_URL ||
     "http://127.0.0.1:3100/api";
+  paperclipApiUrl = paperclipApiUrl.replace(/\/+$/, "");
   if (!paperclipApiUrl.endsWith("/api")) {
-    paperclipApiUrl = paperclipApiUrl.replace(/\/+$/, "") + "/api";
+    paperclipApiUrl += "/api";
   }
   return paperclipApiUrl;
 }

--- a/packages/adapters/hermes/src/server/execute.ts
+++ b/packages/adapters/hermes/src/server/execute.ts
@@ -103,6 +103,7 @@ import json
 import sys
 import urllib.error
 import urllib.request
+from urllib.parse import quote
 
 API_URL = ${JSON.stringify(input.apiUrl)}
 API_KEY = ${JSON.stringify(input.apiKey)}
@@ -140,7 +141,8 @@ def main():
             print("usage: paperclip_write.py patch-issue ISSUE_ID STATUS COMMENT_FILE", file=sys.stderr)
             return 2
         _, _, issue_id, status, comment_file = sys.argv
-        return request("PATCH", f"/issues/{issue_id}", {
+        encoded_issue_id = quote(issue_id, safe="")
+        return request("PATCH", f"/issues/{encoded_issue_id}", {
             "status": status,
             "comment": read_text(comment_file),
         })
@@ -149,7 +151,8 @@ def main():
             print("usage: paperclip_write.py comment-issue ISSUE_ID COMMENT_FILE", file=sys.stderr)
             return 2
         _, _, issue_id, comment_file = sys.argv
-        return request("POST", f"/issues/{issue_id}/comments", {
+        encoded_issue_id = quote(issue_id, safe="")
+        return request("POST", f"/issues/{encoded_issue_id}/comments", {
             "body": read_text(comment_file),
         })
     print(f"unknown command: {cmd}", file=sys.stderr)
@@ -542,9 +545,16 @@ export async function execute(
   // BUG FIX: Inject authToken as PAPERCLIP_API_KEY (matches adapter-claude-local behavior)
   if ((ctx as any).authToken) env.PAPERCLIP_API_KEY = (ctx as any).authToken;
   const paperclipApiUrl = resolvePaperclipApiUrl(config);
-  env.PAPERCLIP_API_URL = env.PAPERCLIP_API_URL || paperclipApiUrl;
-  env.PAPERCLIP_BASE_URL = env.PAPERCLIP_BASE_URL || paperclipApiUrl;
-  env.PAPERCLIP_API_BASE_URL = env.PAPERCLIP_API_BASE_URL || paperclipApiUrl;
+  const envPaperclipApiUrl = resolvePaperclipApiUrl({
+    paperclipApiUrl:
+      env.PAPERCLIP_API_URL ||
+      env.PAPERCLIP_API_BASE_URL ||
+      env.PAPERCLIP_BASE_URL ||
+      paperclipApiUrl,
+  });
+  env.PAPERCLIP_API_URL = envPaperclipApiUrl;
+  env.PAPERCLIP_BASE_URL = envPaperclipApiUrl;
+  env.PAPERCLIP_API_BASE_URL = envPaperclipApiUrl;
   env.PAPERCLIP_WRITE_HELPER = paperclipWriteHelper;
 
   // BUG FIX: Read task context from ctx.context (wake context), not ctx.config (adapter config)
@@ -562,7 +572,7 @@ export async function execute(
   if (env.PAPERCLIP_API_KEY && env.PAPERCLIP_RUN_ID) {
     await writePaperclipHelper({
       path: paperclipWriteHelper,
-      apiUrl: paperclipApiUrl,
+      apiUrl: envPaperclipApiUrl,
       apiKey: env.PAPERCLIP_API_KEY,
       runId: env.PAPERCLIP_RUN_ID,
     });

--- a/packages/adapters/hermes/src/server/execute.ts
+++ b/packages/adapters/hermes/src/server/execute.ts
@@ -19,6 +19,7 @@
  */
 
 import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 
 import type {
@@ -74,6 +75,93 @@ export function resolveHermesCommand(config: Record<string, unknown>): string {
   return cfgString(config.hermesCommand) || cfgString(config.command) || HERMES_CLI;
 }
 
+function resolvePaperclipApiUrl(config: Record<string, unknown>): string {
+  let paperclipApiUrl =
+    cfgString(config.paperclipApiUrl) ||
+    process.env.PAPERCLIP_API_URL ||
+    "http://127.0.0.1:3100/api";
+  if (!paperclipApiUrl.endsWith("/api")) {
+    paperclipApiUrl = paperclipApiUrl.replace(/\/+$/, "") + "/api";
+  }
+  return paperclipApiUrl;
+}
+
+function paperclipWriteHelperPath(runId?: string): string {
+  const safeRunId = (runId || "no-run-id").replace(/[^a-zA-Z0-9_.-]/g, "_");
+  return path.join(os.tmpdir(), `hermes-paperclip-${safeRunId}`, "paperclip_write.py");
+}
+
+async function writePaperclipHelper(input: {
+  path: string;
+  apiUrl: string;
+  apiKey: string;
+  runId: string;
+}): Promise<void> {
+  await fs.mkdir(path.dirname(input.path), { recursive: true });
+  const script = `#!/usr/bin/env python3
+import json
+import sys
+import urllib.error
+import urllib.request
+
+API_URL = ${JSON.stringify(input.apiUrl)}
+API_KEY = ${JSON.stringify(input.apiKey)}
+RUN_ID = ${JSON.stringify(input.runId)}
+
+def request(method, path, body=None):
+    headers = {
+        "Authorization": "Bearer " + API_KEY,
+        "X-Paperclip-Run-Id": RUN_ID,
+    }
+    data = None
+    if body is not None:
+        data = json.dumps(body).encode("utf-8")
+        headers["Content-Type"] = "application/json"
+    req = urllib.request.Request(API_URL.rstrip("/") + path, data=data, headers=headers, method=method)
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            print(resp.read().decode("utf-8", "replace"))
+            return 0
+    except urllib.error.HTTPError as exc:
+        print(exc.read().decode("utf-8", "replace"), file=sys.stderr)
+        return 1
+
+def read_text(path):
+    with open(path, "r", encoding="utf-8") as f:
+        return f.read()
+
+def main():
+    if len(sys.argv) < 2:
+        print("usage: paperclip_write.py patch-issue ISSUE_ID STATUS COMMENT_FILE | comment-issue ISSUE_ID COMMENT_FILE", file=sys.stderr)
+        return 2
+    cmd = sys.argv[1]
+    if cmd == "patch-issue":
+        if len(sys.argv) != 5:
+            print("usage: paperclip_write.py patch-issue ISSUE_ID STATUS COMMENT_FILE", file=sys.stderr)
+            return 2
+        _, _, issue_id, status, comment_file = sys.argv
+        return request("PATCH", f"/issues/{issue_id}", {
+            "status": status,
+            "comment": read_text(comment_file),
+        })
+    if cmd == "comment-issue":
+        if len(sys.argv) != 4:
+            print("usage: paperclip_write.py comment-issue ISSUE_ID COMMENT_FILE", file=sys.stderr)
+            return 2
+        _, _, issue_id, comment_file = sys.argv
+        return request("POST", f"/issues/{issue_id}/comments", {
+            "body": read_text(comment_file),
+        })
+    print(f"unknown command: {cmd}", file=sys.stderr)
+    return 2
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+`;
+  await fs.writeFile(input.path, script, { encoding: "utf8", mode: 0o700 });
+  await fs.chmod(input.path, 0o700);
+}
+
 // ---------------------------------------------------------------------------
 // Wake-up prompt builder
 // ---------------------------------------------------------------------------
@@ -94,12 +182,10 @@ const HERMES_DEFAULT_PROMPT_TEMPLATE = [
   "- Include `-H \"Authorization: Bearer $PAPERCLIP_API_KEY\"` on API requests.",
   "- Include `-H \"X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID\"` on mutating issue requests.",
   "- For multiline comments or status updates, preserve newlines with `jq --arg` or a heredoc-fed helper rather than hand-escaping JSON.",
+  "- Prefer `$PAPERCLIP_WRITE_HELPER` for mutating issue writes. It already supplies Authorization and X-Paperclip-Run-Id, so you do not need to construct those headers.",
   "",
-  "Safe multiline update pattern:",
+  "Safe disposition update pattern:",
   "```bash",
-  "api=\"${PAPERCLIP_API_URL%/}\"",
-  "case \"$api\" in */api) ;; *) api=\"$api/api\" ;; esac",
-  "",
   "body=$(cat <<'MD'",
   "Summary line",
   "",
@@ -107,12 +193,8 @@ const HERMES_DEFAULT_PROMPT_TEMPLATE = [
   "- Detail two",
   "MD",
   ")",
-  "jq -n --arg status done --arg comment \"$body\" '{status:$status, comment:$comment}' | \\",
-  "  curl -sS -X PATCH \"$api/issues/{{context.issueId}}\" \\",
-  "    -H \"Authorization: Bearer $PAPERCLIP_API_KEY\" \\",
-  "    -H \"X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID\" \\",
-  "    -H \"Content-Type: application/json\" \\",
-  "    --data-binary @-",
+  "printf '%s\\n' \"$body\" > /tmp/paperclip-comment.txt",
+  "python3 \"$PAPERCLIP_WRITE_HELPER\" patch-issue \"{{context.issueId}}\" done /tmp/paperclip-comment.txt",
   "```",
   "",
   DEFAULT_PAPERCLIP_AGENT_PROMPT_TEMPLATE,
@@ -148,15 +230,8 @@ export function buildPrompt(
   const companyName = cfgString(context.companyName) || cfgString(ctx.config?.companyName) || "";
   const projectName = cfgString(context.projectName) || cfgString(ctx.config?.projectName) || "";
 
-  // Build API URL — ensure it has the /api path
-  let paperclipApiUrl =
-    cfgString(config.paperclipApiUrl) ||
-    process.env.PAPERCLIP_API_URL ||
-    "http://127.0.0.1:3100/api";
-  // Ensure /api suffix
-  if (!paperclipApiUrl.endsWith("/api")) {
-    paperclipApiUrl = paperclipApiUrl.replace(/\/+$/, "") + "/api";
-  }
+  const paperclipApiUrl = resolvePaperclipApiUrl(config);
+  const paperclipWriteHelper = cfgString(config.paperclipWriteHelper) || paperclipWriteHelperPath(ctx.runId);
 
   const wakePrompt = renderPaperclipWakePrompt(context.paperclipWake, {
     resumedSession: options.resumedSession === true,
@@ -182,6 +257,7 @@ export function buildPrompt(
     wakeReason,
     projectName,
     paperclipApiUrl,
+    paperclipWriteHelper,
     paperclipWakePrompt: wakePrompt,
     paperclipTaskMarkdown,
     taskContext: paperclipTaskMarkdown,
@@ -400,7 +476,8 @@ export async function execute(
   }
 
   // ── Build prompt ───────────────────────────────────────────────────────
-  let prompt = buildPrompt(ctx, config, { resumedSession: Boolean(prevSessionId) });
+  const paperclipWriteHelper = paperclipWriteHelperPath(ctx.runId);
+  let prompt = buildPrompt(ctx, { ...config, paperclipWriteHelper }, { resumedSession: Boolean(prevSessionId) });
   if (agentInstructions) {
     prompt = agentInstructions + "\n\n---\n\n" + prompt;
   }
@@ -464,6 +541,11 @@ export async function execute(
 
   // BUG FIX: Inject authToken as PAPERCLIP_API_KEY (matches adapter-claude-local behavior)
   if ((ctx as any).authToken) env.PAPERCLIP_API_KEY = (ctx as any).authToken;
+  const paperclipApiUrl = resolvePaperclipApiUrl(config);
+  env.PAPERCLIP_API_URL = env.PAPERCLIP_API_URL || paperclipApiUrl;
+  env.PAPERCLIP_BASE_URL = env.PAPERCLIP_BASE_URL || paperclipApiUrl;
+  env.PAPERCLIP_API_BASE_URL = env.PAPERCLIP_API_BASE_URL || paperclipApiUrl;
+  env.PAPERCLIP_WRITE_HELPER = paperclipWriteHelper;
 
   // BUG FIX: Read task context from ctx.context (wake context), not ctx.config (adapter config)
   const ctxContext = (ctx as any).context || {};
@@ -475,6 +557,17 @@ export async function execute(
   if (envCommentId) env.PAPERCLIP_WAKE_COMMENT_ID = envCommentId;
   const wakePayloadJson = stringifyPaperclipWakePayload(ctxContext.paperclipWake);
   if (wakePayloadJson) env.PAPERCLIP_WAKE_PAYLOAD_JSON = wakePayloadJson;
+
+  let paperclipWriteHelperCreated = false;
+  if (env.PAPERCLIP_API_KEY && env.PAPERCLIP_RUN_ID) {
+    await writePaperclipHelper({
+      path: paperclipWriteHelper,
+      apiUrl: paperclipApiUrl,
+      apiKey: env.PAPERCLIP_API_KEY,
+      runId: env.PAPERCLIP_RUN_ID,
+    });
+    paperclipWriteHelperCreated = true;
+  }
 
   // ── Resolve working directory ──────────────────────────────────────────
   const cwd =
@@ -495,6 +588,11 @@ export async function execute(
       "stdout",
       `[hermes] Resuming session: ${prevSessionId}\n`,
     );
+  }
+  if (paperclipWriteHelperCreated) {
+    await ctx.onLog("stdout", `[paperclip] Prepared write helper: ${paperclipWriteHelper}\n`);
+  } else {
+    await ctx.onLog("stdout", "[paperclip] Write helper unavailable: missing Paperclip API key or run ID\n");
   }
 
   // ── Execute ────────────────────────────────────────────────────────────
@@ -521,13 +619,20 @@ export async function execute(
     return ctx.onLog(stream, chunk);
   };
 
-  const result = await runChildProcess(ctx.runId, hermesCmd, args, {
-    cwd,
-    env,
-    timeoutSec,
-    graceSec,
-    onLog: wrappedOnLog,
-  });
+  let result: Awaited<ReturnType<typeof runChildProcess>>;
+  try {
+    result = await runChildProcess(ctx.runId, hermesCmd, args, {
+      cwd,
+      env,
+      timeoutSec,
+      graceSec,
+      onLog: wrappedOnLog,
+    });
+  } finally {
+    if (paperclipWriteHelperCreated) {
+      await fs.rm(path.dirname(paperclipWriteHelper), { recursive: true, force: true });
+    }
+  }
 
   // ── Parse output ───────────────────────────────────────────────────────
   const parsed = parseHermesOutput(result.stdout || "", result.stderr || "");

--- a/packages/adapters/hermes/src/server/execute.ts
+++ b/packages/adapters/hermes/src/server/execute.ts
@@ -76,8 +76,12 @@ export function resolveHermesCommand(config: Record<string, unknown>): string {
 }
 
 function resolvePaperclipApiUrl(config: Record<string, unknown>): string {
+  const configEnv = config.env as Record<string, unknown> | undefined;
   let paperclipApiUrl =
     cfgString(config.paperclipApiUrl) ||
+    cfgString(configEnv?.PAPERCLIP_API_URL) ||
+    cfgString(configEnv?.PAPERCLIP_API_BASE_URL) ||
+    cfgString(configEnv?.PAPERCLIP_BASE_URL) ||
     process.env.PAPERCLIP_API_URL ||
     "http://127.0.0.1:3100/api";
   paperclipApiUrl = paperclipApiUrl.replace(/\/+$/, "");
@@ -546,16 +550,9 @@ export async function execute(
   // BUG FIX: Inject authToken as PAPERCLIP_API_KEY (matches adapter-claude-local behavior)
   if ((ctx as any).authToken) env.PAPERCLIP_API_KEY = (ctx as any).authToken;
   const paperclipApiUrl = resolvePaperclipApiUrl(config);
-  const envPaperclipApiUrl = resolvePaperclipApiUrl({
-    paperclipApiUrl:
-      env.PAPERCLIP_API_URL ||
-      env.PAPERCLIP_API_BASE_URL ||
-      env.PAPERCLIP_BASE_URL ||
-      paperclipApiUrl,
-  });
-  env.PAPERCLIP_API_URL = envPaperclipApiUrl;
-  env.PAPERCLIP_BASE_URL = envPaperclipApiUrl;
-  env.PAPERCLIP_API_BASE_URL = envPaperclipApiUrl;
+  env.PAPERCLIP_API_URL = paperclipApiUrl;
+  env.PAPERCLIP_BASE_URL = paperclipApiUrl;
+  env.PAPERCLIP_API_BASE_URL = paperclipApiUrl;
   env.PAPERCLIP_WRITE_HELPER = paperclipWriteHelper;
 
   // BUG FIX: Read task context from ctx.context (wake context), not ctx.config (adapter config)
@@ -573,7 +570,7 @@ export async function execute(
   if (env.PAPERCLIP_API_KEY && env.PAPERCLIP_RUN_ID) {
     await writePaperclipHelper({
       path: paperclipWriteHelper,
-      apiUrl: envPaperclipApiUrl,
+      apiUrl: paperclipApiUrl,
       apiKey: env.PAPERCLIP_API_KEY,
       runId: env.PAPERCLIP_RUN_ID,
     });

--- a/packages/adapters/hermes/src/server/prompt-rendering.test.ts
+++ b/packages/adapters/hermes/src/server/prompt-rendering.test.ts
@@ -202,7 +202,7 @@ test("keeps authoritative parent and ancestor context from task markdown", () =>
   expect(prompt).not.toContain("check the issue body or comments for references");
 });
 
-test("renders safe Paperclip API examples from environment variables with multiline update preservation", () => {
+test("renders safe Paperclip API examples from environment variables with helper-based write preservation", () => {
   const prompt = buildPrompt(baseContext(), {
     paperclipApiUrl: "http://paperclip.local/api",
   });
@@ -211,9 +211,12 @@ test("renders safe Paperclip API examples from environment variables with multil
   expect(prompt).toContain("Displayed command logs may redact secrets");
   expect(prompt).toContain('-H "Authorization: Bearer $PAPERCLIP_API_KEY"');
   expect(prompt).toContain('-H "X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID"');
+  expect(prompt).toContain("Prefer `$PAPERCLIP_WRITE_HELPER` for mutating issue writes");
   expect(prompt).toContain("body=$(cat <<'MD'");
-  expect(prompt).toContain("jq -n --arg status done --arg comment \"$body\"");
-  expect(prompt).toContain("--data-binary @-");
+  expect(prompt).toContain("printf '%s\\n' \"$body\" > /tmp/paperclip-comment.txt");
+  expect(prompt).toContain("python3 \"$PAPERCLIP_WRITE_HELPER\" patch-issue \"issue-1\" done /tmp/paperclip-comment.txt");
+  expect(prompt).not.toContain("jq -n --arg status done --arg comment \"$body\"");
+  expect(prompt).not.toContain("--data-binary @-");
   expect(prompt).not.toContain("Authorization: Bearer <");
 });
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Agent adapters are the boundary between the Paperclip control plane and the local or remote process that performs work.
> - Since v2026.626.0 / #8543, Hermes local and gateway adapters are built into Paperclip, so reliability fixes for current installs belong in `packages/adapters/hermes`.
> - Hermes local runs need to report issue disposition back to Paperclip with run-scoped identity so the control plane can distinguish real completion from a successful process that left task state stale.
> - The current prompt asks the model to hand-build authenticated mutating API calls, which is brittle when shell transcripts redact secrets or the model mishandles header/JSON construction.
> - This pull request moves the mutating issue-write path into adapter-owned helper code and gives Hermes a narrow command for status/comment writes.
> - The benefit is fewer false missing-disposition recoveries for Hermes local agents and less model reasoning spent on Paperclip auth plumbing.

## Linked Issues or Issue Description

Fixes #8684.

Related public context: #8543 made Hermes a built-in adapter package in this repository, while external adapter packages may still override or shadow the built-ins.

## What Changed

- Added a per-run `PAPERCLIP_WRITE_HELPER` script for Hermes local runs.
- Added helper commands for atomic issue status/comment updates and issue comments.
- Encoded issue IDs before inserting them into helper request paths.
- Normalized Paperclip API URL environment aliases so prompt reads and helper writes use the same API base.
- Updated the default Hermes local prompt to prefer the helper for mutating issue writes instead of hand-building auth headers.
- Cleaned up the helper directory after the Hermes child process exits.
- Updated prompt-rendering tests to cover the helper-based disposition pattern.

## Verification

- `corepack pnpm --filter @paperclipai/hermes-paperclip-adapter typecheck`
- `corepack pnpm --filter @paperclipai/hermes-paperclip-adapter test -- src/server/prompt-rendering.test.ts src/server/command-resolution.test.ts`
- Local smoke verification against a private Paperclip instance confirmed helper creation, successful disposition update, and no missing-disposition recovery. Deployment-specific agent names, task IDs, URLs, and logs are intentionally omitted because they are not public or useful to reviewers.

## Risks

- Medium risk: the helper writes a run-scoped API token to a temporary file while the Hermes child process runs. The file is mode `0700`, scoped to the run, and removed after process exit.
- Low compatibility risk: this changes default prompt guidance for Hermes local writes but preserves env variables and read guidance.
- If the helper cannot be created because run auth is unavailable, the adapter logs that explicitly and Hermes still receives the rest of the Paperclip prompt.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

OpenAI Codex, GPT-5 coding agent, tool use enabled in a local repository workspace. Context window size is not exposed in this environment.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
