### PR TITLE
fix(recovery): honor session-limit reset window before retrying continuations

### DIFF
--- a/packages/adapters/claude-local/src/server/parse.ts
+++ b/packages/adapters/claude-local/src/server/parse.ts
@@ -10,9 +10,9 @@ const CLAUDE_AUTH_REQUIRED_RE = /(?:not\s+logged\s+in|please\s+log\s+in|please\s
 const URL_RE = /(https?:\/\/[^\s'"`<>()[\]{};,!?]+[^\s'"`<>()[\]{};,!.?:]+)/gi;
 
 const CLAUDE_TRANSIENT_UPSTREAM_RE =
-  /(?:rate[-\s]?limit(?:ed)?|rate_limit_error|too\s+many\s+requests|\b429\b|overloaded(?:_error)?|server\s+overloaded|service\s+unavailable|\b503\b|\b529\b|high\s+demand|try\s+again\s+later|temporarily\s+unavailable|throttl(?:ed|ing)|throttlingexception|servicequotaexceededexception|out\s+of\s+extra\s+usage|extra\s+usage\b|claude\s+usage\s+limit\s+reached|5[-\s]?hour\s+limit\s+reached|weekly\s+limit\s+reached|usage\s+limit\s+reached|usage\s+cap\s+reached)/i;
+  /(?:rate[-\s]?limit(?:ed)?|rate_limit_error|too\s+many\s+requests|\b429\b|overloaded(?:_error)?|server\s+overloaded|service\s+unavailable|\b503\b|\b529\b|high\s+demand|try\s+again\s+later|temporarily\s+unavailable|throttl(?:ed|ing)|throttlingexception|servicequotaexceededexception|out\s+of\s+extra\s+usage|extra\s+usage\b|claude\s+usage\s+limit\s+reached|5[-\s]?hour\s+limit\s+reached|weekly\s+limit\s+reached|usage\s+limit\s+reached|usage\s+cap\s+reached|session\s+limit\s+reached|(?:hit|reached)\s+your\s+session\s+limit)/i;
 const CLAUDE_EXTRA_USAGE_RESET_RE =
-  /(?:out\s+of\s+extra\s+usage|extra\s+usage|usage\s+limit\s+reached|usage\s+cap\s+reached|5[-\s]?hour\s+limit\s+reached|weekly\s+limit\s+reached|claude\s+usage\s+limit\s+reached)[\s\S]{0,80}?\bresets?\s+(?:at\s+)?([^\n()]+?)(?:\s*\(([^)]+)\))?(?:[.!]|\n|$)/i;
+  /(?:out\s+of\s+extra\s+usage|extra\s+usage|usage\s+limit\s+reached|usage\s+cap\s+reached|5[-\s]?hour\s+limit\s+reached|weekly\s+limit\s+reached|claude\s+usage\s+limit\s+reached|session\s+limit\s+reached|(?:hit|reached)\s+your\s+session\s+limit)[\s\S]{0,80}?\bresets?\s+(?:at\s+)?([^\n()]+?)(?:\s*\(([^)]+)\))?(?:[.!]|\n|$)/i;
 
 export function parseClaudeStreamJson(stdout: string) {
   let sessionId: string | null = null;

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -112,7 +112,7 @@ type RecoveryWakeup = (
 
 type LatestIssueRun = Pick<
   typeof heartbeatRuns.$inferSelect,
-  "id" | "agentId" | "status" | "error" | "errorCode" | "contextSnapshot" | "livenessState"
+  "id" | "agentId" | "status" | "error" | "errorCode" | "contextSnapshot" | "livenessState" | "resultJson"
 > | null;
 type SuccessfulLatestIssueRun = NonNullable<LatestIssueRun> & { status: "succeeded" };
 
@@ -152,6 +152,21 @@ export type RunOutputSilenceSummary = {
 
 function readNonEmptyString(value: unknown): string | null {
   return typeof value === "string" && value.trim().length > 0 ? value : null;
+}
+
+// ART-43: transient-upstream failures (e.g. Claude "session limit reached · resets <time>")
+// carry a reset timestamp the adapter parsed into resultJson. The bounded heartbeat retry
+// path already defers to it; the continuation-recovery path must honor it too, otherwise it
+// burns its transient_infra attempts re-failing against a still-exhausted session before the
+// window opens. Mirror of readTransientRetryNotBeforeFromRun in services/heartbeat.ts.
+function readContinuationRetryNotBefore(run: LatestIssueRun): Date | null {
+  const resultJson = parseObject(run?.resultJson);
+  const value = resultJson.retryNotBefore ?? resultJson.transientRetryNotBefore;
+  if (!(typeof value === "string" || typeof value === "number" || value instanceof Date)) {
+    return null;
+  }
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
 }
 
 function summarizeRunFailureForIssueComment(run: LatestIssueRun) {
@@ -497,6 +512,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         errorCode: heartbeatRuns.errorCode,
         contextSnapshot: heartbeatRuns.contextSnapshot,
         livenessState: heartbeatRuns.livenessState,
+        resultJson: heartbeatRuns.resultJson,
       })
       .from(heartbeatRuns)
       .where(
@@ -2966,6 +2982,15 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
           } else {
             result.skipped += 1;
           }
+          continue;
+        }
+
+        // ART-43: do not requeue a transient-upstream failure (session-limit reset)
+        // before its reset window. Defer; a later recovery sweep requeues once the
+        // window has passed. Purely additive guard — never forces an extra retry.
+        const transientRetryNotBefore = readContinuationRetryNotBefore(latestRun);
+        if (transientRetryNotBefore && transientRetryNotBefore.getTime() > Date.now()) {
+          result.skipped += 1;
           continue;
         }
 


### PR DESCRIPTION
## What & why

Claude runs that fail with `You've hit your session limit · resets <time>` were not matched by the adapter's transient-upstream classifier, so they got `errorCode = null` and fell into the *immediately-retryable* default path — re-failing against a still-exhausted session in a tight loop (~5.3x retry amplification observed in production). This brings session-limit exhaustion to parity with the existing extra-usage / 5-hour / weekly limit handling, which already back off to the reset window.

## Changes

**1. `packages/adapters/claude-local/src/server/parse.ts`** — extend `CLAUDE_TRANSIENT_UPSTREAM_RE` and the `CLAUDE_EXTRA_USAGE_RESET_RE` lead-ins to recognize `session limit reached` / `(hit|reached) your session limit`, so the failure is classified `claude_transient_upstream` and the reset timestamp is parsed into `retryNotBefore`.

**2. `server/src/services/recovery/service.ts`** — the continuation-recovery sweep classified `claude_transient_upstream` as `transient_infra` (3 attempts, 60/120/240s backoff) but **ignored** `retryNotBefore`, so it still retried before the reset window. Add `readContinuationRetryNotBefore` (mirror of `readTransientRetryNotBeforeFromRun` in `services/heartbeat.ts`) and a purely-additive guard: if the failed run carries a future `retryNotBefore`, skip the requeue this sweep and defer until the window opens. `resultJson` is added to the `LatestIssueRun` pick and the `getLatestIssueRun` select so the helper has data. The bounded heartbeat retry path already honored `retryNotBefore`; this brings the continuation path to parity.

Net: +28 / −3 across 2 files. Purely additive — never forces an extra retry; only *defers* an already-classified transient retry.

## Verification

Verified locally against `paperclipai 2026.618.0`:

- Production message `"…hit your session limit · resets 7pm (America/Los_Angeles)"` → classifies `claude_transient_upstream = true` and parses reset → `7pm` / `America/Los_Angeles`.
- Generic failures (`"Claude exited with code 1"`) still do **not** match (no false positives).
- Existing controls unchanged: `out of extra usage · resets 4pm`, `5-hour limit reached · resets 3pm`, weekly limit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
