### PR TITLE
docs: normalize approval and blocker handoff language

### DIFF
--- a/docs/guides/agent-developer/comments-and-communication.md
+++ b/docs/guides/agent-developer/comments-and-communication.md
@@ -26,15 +26,18 @@ Use concise markdown with:
 - A short status line
 - Bullets for what changed or what is blocked
 - Links to related entities when available
+- For blocker handoffs, name the unblock owner and the exact next action
+- For review or approval handoffs, say who is reviewing and why the issue is in `in_review`
 
 ```markdown
 ## Update
 
 Submitted CTO hire request and linked it for board review.
 
-- Approval: [ca6ba09d](/approvals/ca6ba09d-b558-4a53-a552-e7ef87e54a1b)
-- Pending agent: [CTO draft](/agents/66b3c071-6cb8-4424-b833-9d9b6318de0b)
-- Source issue: [PC-142](/issues/244c0c2c-8416-43b6-84c9-ec183c074cc1)
+- Approval: [ca6ba09d](/PC/approvals/ca6ba09d-b558-4a53-a552-e7ef87e54a1b)
+- Pending agent: [CTO draft](/PC/agents/cto-draft)
+- Source issue: [PC-142](/PC/issues/PC-142)
+- Next step: board reviews the hire request and either approves or requests changes
 ```
 
 ## @-Mentions
@@ -57,6 +60,11 @@ The name must match the agent's `name` field exactly (case-insensitive). This tr
 - **Mention handoff exception** — if an agent is explicitly @-mentioned with a clear directive to take a task, they may self-assign via checkout
 
 ## Structured Decisions
+
+Use status language consistently when handing work off:
+
+- `in_review` means a real reviewer, approver, or board/user interaction is now the active path forward
+- `blocked` means work cannot continue until a named owner takes a concrete unblock action or another issue resolves
 
 Use issue-thread interactions when the user should respond through a structured UI card instead of a free-form comment:
 

--- a/docs/guides/agent-developer/heartbeat-protocol.md
+++ b/docs/guides/agent-developer/heartbeat-protocol.md
@@ -72,6 +72,11 @@ Leave durable progress in comments, documents, or work products, and include the
 
 When the board/user must choose tasks, answer structured questions, or confirm a proposal before work can continue, create an issue-thread interaction with `POST /api/issues/{issueId}/interactions`. Use `request_confirmation` for explicit yes/no decisions instead of asking for them in markdown. For plan approval, update the `plan` document first, create a confirmation bound to the latest revision, and wait for acceptance before creating implementation subtasks.
 
+Use status handoffs precisely:
+
+- `in_review` when a reviewer, approver, or board/user interaction is now the active path forward
+- `blocked` only when a named owner must take an unblock action or another issue is the blocker
+
 ### Step 8: Update Status
 
 Always include the run ID header on state changes:
@@ -88,6 +93,14 @@ If blocked:
 PATCH /api/issues/{issueId}
 Headers: X-Paperclip-Run-Id: {runId}
 { "status": "blocked", "comment": "What is blocked, why, and who needs to unblock it." }
+```
+
+If waiting on review, approval, or confirmation:
+
+```
+PATCH /api/issues/{issueId}
+Headers: X-Paperclip-Run-Id: {runId}
+{ "status": "in_review", "comment": "Ready for review: what changed, what to verify, and who owns the next decision." }
 ```
 
 ### Step 9: Delegate if Needed
@@ -110,6 +123,7 @@ Always set `parentId` and `goalId` on subtasks.
 - **Leave a clear next action** in durable issue context
 - **Use child issues instead of polling** for long or parallel delegated work
 - **Use `request_confirmation`** for issue-scoped yes/no decisions and plan approval cards
+- **Use `in_review` for real handoffs** and `blocked` only for true blockers
 - **Always set parentId** on subtasks
 - **Never cancel cross-team tasks** — reassign to your manager
 - **Escalate when stuck** — use your chain of command

--- a/docs/guides/agent-developer/task-workflow.md
+++ b/docs/guides/agent-developer/task-workflow.md
@@ -45,10 +45,23 @@ If you can't make progress:
 
 ```
 PATCH /api/issues/{issueId}
-{ "status": "blocked", "comment": "Need DBA review for migration PR #38. Reassigning to @EngineeringLead." }
+{ "status": "blocked", "comment": "Blocked: migration PR #38 needs DBA review before merge.\n\n- Unblock owner: Engineering Lead\n- Next action: route the migration to a DBA reviewer and return with approval or requested changes" }
 ```
 
 Never sit silently on blocked work. Comment the blocker, update the status, and escalate.
+
+Use `blocked` only when work truly cannot continue until someone else acts or another issue resolves. Do not use `blocked` for normal review, approval, or confirmation waits.
+
+## Review Handoff Pattern
+
+If the next step is a reviewer, approver, or board/user confirmation:
+
+```
+PATCH /api/issues/{issueId}
+{ "status": "in_review", "assigneeAgentId": "{reviewerAgentId}", "comment": "Ready for review: implementation complete.\n\n- What changed: added JWT signing and refresh token rotation\n- What to verify: auth happy path, token expiry, and revocation handling\n- Unblock owner: QA reviewer" }
+```
+
+`in_review` is the correct state when a real review path exists. Keep the issue there while the review, approval, or interaction is pending.
 
 ## Delegation Pattern
 

--- a/docs/guides/board-operator/managing-tasks.md
+++ b/docs/guides/board-operator/managing-tasks.md
@@ -42,7 +42,8 @@ backlog -> todo -> in_progress -> in_review -> done
 ```
 
 - `in_progress` requires an atomic checkout (only one agent at a time)
-- `blocked` should include a comment explaining the blocker
+- `in_review` means a real handoff is pending: reviewer, approver, or board/user confirmation
+- `blocked` means work cannot continue until a named owner acts or a blocker issue resolves
 - `done` and `cancelled` are terminal states
 
 ## Monitoring Progress


### PR DESCRIPTION
## Thinking Path
CON-3878 found that several operations docs blurred normal review or approval waits with true execution blockers. The docs should make `in_review` the explicit handoff state when a reviewer, approver, or board/user interaction owns the next step. They should reserve `blocked` for cases where work cannot continue without a named unblock action or blocker issue. Aligning the agent-facing and board-facing guides reduces board-state drift because both operators and agents see the same state semantics.

## What Changed
- Clarified comment guidance to name unblock owner and next action for blocker handoffs.
- Added explicit `in_review` vs `blocked` status guidance to the heartbeat protocol.
- Added a review handoff pattern to the task workflow guide.
- Aligned the board operator task status guide with the same semantics.

## Verification
- Reviewed the docs diff for consistency across `comments-and-communication.md`, `heartbeat-protocol.md`, `task-workflow.md`, and `managing-tasks.md`.
- GitHub PR workflow checks are green except the metadata-only `commitperclip PR Review` gate, which this body update is intended to satisfy on rerun.
- No local test suite run; docs-only change.

## Risks
- Low runtime risk: documentation-only change.
- Main risk is operator confusion if future docs drift; this PR reduces that by aligning four guides to the same handoff language.

## Model Used
GPT-5 Codex

## Checklist
- [x] No duplicate issue creation needed for this docs normalization PR.
- [x] Documentation-only diff reviewed for status-handoff consistency.
- [x] Verification approach documented above.
