### PR TITLE
Fix recovery owner issue write boundary

### DIFF
--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -246,6 +246,38 @@ function makeIssue(overrides: Record<string, unknown> = {}) {
   };
 }
 
+function makeActiveRecoveryAction(overrides: Record<string, unknown> = {}) {
+  return {
+    id: recoveryActionId,
+    companyId,
+    sourceIssueId: issueId,
+    recoveryIssueId: null,
+    kind: "stranded_assigned_issue",
+    status: "active",
+    ownerType: "agent",
+    ownerAgentId,
+    ownerUserId: null,
+    previousOwnerAgentId: null,
+    returnOwnerAgentId: null,
+    cause: "stranded_assigned_issue",
+    fingerprint: "source-scoped:test",
+    evidence: {},
+    nextAction: "Restore a live execution path.",
+    wakePolicy: null,
+    monitorPolicy: null,
+    attemptCount: 1,
+    maxAttempts: null,
+    timeoutAt: null,
+    lastAttemptAt: new Date("2026-05-13T18:00:00.000Z"),
+    outcome: null,
+    resolutionNote: null,
+    resolvedAt: null,
+    createdAt: new Date("2026-05-13T17:55:00.000Z"),
+    updatedAt: new Date("2026-05-13T18:00:00.000Z"),
+    ...overrides,
+  };
+}
+
 function makeAgent(id: string, overrides: Record<string, unknown> = {}) {
   return {
     id,
@@ -804,6 +836,28 @@ describe("agent issue mutation checkout ownership", () => {
     expect(mockIssueService.addComment).not.toHaveBeenCalled();
   });
 
+  it("allows the named recovery owner to post comments when the base issue boundary denies", async () => {
+    mockAccessService.decide.mockImplementation(async (input: { action: string }) => ({
+      allowed: false,
+      action: input.action,
+      reason: "deny_low_trust_boundary",
+      explanation: "Issue is outside this low-trust boundary.",
+    }));
+    mockIssueRecoveryActionService.getActiveForIssue.mockResolvedValue(makeActiveRecoveryAction());
+
+    const res = await request(await createApp(ownerActor()))
+      .post(`/api/issues/${issueId}/comments`)
+      .send({ body: "Recovered and closing this out." });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(201);
+    expect(mockIssueService.addComment).toHaveBeenCalledWith(
+      issueId,
+      "Recovered and closing this out.",
+      expect.any(Object),
+      expect.any(Object),
+    );
+  });
+
   it("rejects peer agents from listing comments when issue read is outside their boundary", async () => {
     mockAccessService.decide.mockImplementation(async (input: { action: string }) => ({
       allowed: false,
@@ -1348,6 +1402,39 @@ describe("agent issue mutation checkout ownership", () => {
       assigneeAgentId: null,
       title: "Claimable update",
     });
+  });
+
+  it("allows the named recovery owner to update source issue status when the base boundary denies", async () => {
+    mockAccessService.decide.mockImplementation(async (input: { action: string }) => ({
+      allowed: false,
+      action: input.action,
+      reason: "deny_low_trust_boundary",
+      explanation: "Issue is outside this low-trust boundary.",
+    }));
+    mockIssueService.getById.mockResolvedValue(
+      makeIssue({ status: "blocked", assigneeAgentId: ownerAgentId }),
+    );
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
+      ...makeIssue({ status: "blocked", assigneeAgentId: ownerAgentId }),
+      ...patch,
+    }));
+    mockIssueRecoveryActionService.getActiveForIssue.mockResolvedValue(makeActiveRecoveryAction());
+
+    const res = await request(await createApp(ownerActor()))
+      .patch(`/api/issues/${issueId}`)
+      .send({ status: "done", comment: "Recovered and verified." });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(mockIssueService.update).toHaveBeenCalledWith(
+      issueId,
+      expect.objectContaining({ status: "done" }),
+    );
+    expect(mockIssueService.addComment).toHaveBeenCalledWith(
+      issueId,
+      "Recovered and verified.",
+      expect.any(Object),
+      expect.any(Object),
+    );
   });
 
   it("rejects peer-agent status updates that would clear a recovery action they do not own", async () => {

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -1987,6 +1987,7 @@ export function issueRoutes(
     }
     const boundaryDecision = await decideIssueAccess(req, issue, "issue:comment");
     if (!boundaryDecision.allowed) {
+      if (await activeRecoveryActionAllowsAgentBoundaryOverride(req, issue)) return true;
       res.status(403).json({ error: "Issue is outside this actor's authorization boundary" });
       return false;
     }
@@ -2030,6 +2031,29 @@ export function issueRoutes(
       resource: { type: "issue", companyId, assigneeAgentId },
     });
     return decision.allowed;
+  }
+
+  async function activeRecoveryActionAllowsAgentBoundaryOverride(
+    req: Request,
+    issue: { id: string; companyId: string },
+  ) {
+    if (req.actor.type !== "agent") return false;
+    const actorAgentId = req.actor.agentId;
+    if (!actorAgentId) return false;
+
+    let activeRecoveryAction: Awaited<ReturnType<typeof recoveryActionsSvc.getActiveForIssue>> | null = null;
+    try {
+      activeRecoveryAction = await recoveryActionsSvc.getActiveForIssue(issue.companyId, issue.id);
+    } catch (err) {
+      logger.warn(
+        { err, issueId: issue.id, actorAgentId },
+        "failed to evaluate recovery action boundary override",
+      );
+      return false;
+    }
+    if (!activeRecoveryAction?.ownerAgentId) return false;
+    if (activeRecoveryAction.ownerAgentId === actorAgentId) return true;
+    return hasActiveCheckoutManagementOverride(actorAgentId, issue.companyId, activeRecoveryAction.ownerAgentId);
   }
 
   async function assertAgentIssueMutationAllowed(
@@ -2076,6 +2100,7 @@ export function issueRoutes(
     }
     const boundaryDecision = await decideIssueAccess(req, issue, "issue:mutate");
     if (!boundaryDecision.allowed) {
+      if (await activeRecoveryActionAllowsAgentBoundaryOverride(req, issue)) return true;
       res.status(403).json({ error: "Issue is outside this actor's authorization boundary" });
       return false;
     }


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Issue comments and issue updates are the durable write surfaces agents use to report progress, close work, and resolve recovery states.
> - Source-scoped recovery actions can name a recovery owner that is responsible for restoring or resolving the source issue.
> - The route layer already had recovery-action authority checks, but the base issue comment and mutation boundary could reject the recovery owner before those recovery-specific rules had a chance to apply.
> - This pull request adds a narrow boundary fallback for the active recovery action owner on comment and issue mutation routes.
> - The benefit is that a named recovery owner can leave closeout comments and status updates on the source issue without weakening ordinary agent issue access.

## Linked Issues or Issue Description

- Related public context: #8596, #8108, #7736.
- Bug: an agent named as the owner of an active source-scoped recovery action can still receive `403 Issue is outside this actor's authorization boundary` when trying to comment on or update the source issue.
- Expected behavior: the active recovery-action owner, or an agent with the existing checkout-management override for that owner, can use the normal comment and update routes to record recovery progress or closeout on the source issue.
- Actual behavior: base issue authorization can fail first, which leaves recovery work visibly stuck even though the recovery metadata identifies the actor responsible for fixing it.
- Deployment mode: observed in a local Paperclip control-plane workflow; the fix is route-level and covered by server route tests.

## What Changed

- Added a route-level active recovery-action owner fallback for issue comment authorization.
- Added the same narrow fallback for issue mutation authorization before returning the generic boundary 403.
- Kept the fallback limited to the active recovery action owner, plus the existing checkout-management override for that owner.
- Added regression tests for recovery-owner comments and status updates when the base issue boundary denies.

## Verification

- `pnpm exec vitest run src/__tests__/issue-agent-mutation-ownership-routes.test.ts --testTimeout=20000` from `server/` - 63 tests passed.
- `pnpm --filter @paperclipai/server typecheck` - passed.

## Risks

- Main risk is accidentally widening issue edits across authorization boundaries. The fallback is scoped to the active recovery action owner and still leaves downstream route-specific recovery, transition, assignment, and validation checks in place.
- This may overlap adjacent recovery-authority work in #8596 and #8108; this PR specifically covers comment and source issue update lockouts.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected - check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex, GPT-5-based coding agent with local shell/tool use and repository test execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge