### PR TITLE
fix: suppress retries for terminal issues

### DIFF
--- a/server/src/__tests__/heartbeat-retry-scheduling.test.ts
+++ b/server/src/__tests__/heartbeat-retry-scheduling.test.ts
@@ -74,9 +74,12 @@ describeEmbeddedPostgres("heartbeat bounded retry scheduling", () => {
     resultJson?: Record<string, unknown> | null;
     adapterType?: "codex_local" | "claude_local";
     agentName?: string;
+    issueId?: string;
+    issueStatus?: "backlog" | "todo" | "in_progress" | "in_review" | "blocked" | "done" | "cancelled";
   }) {
     const adapterType = input.adapterType ?? "codex_local";
     const agentName = input.agentName ?? (adapterType === "claude_local" ? "ClaudeCoder" : "CodexCoder");
+    const issueId = input.issueId ?? randomUUID();
     await db.insert(companies).values({
       id: input.companyId,
       name: "Paperclip",
@@ -122,12 +125,28 @@ describeEmbeddedPostgres("heartbeat bounded retry scheduling", () => {
           : {}),
       },
       contextSnapshot: {
-        issueId: randomUUID(),
+        issueId,
         wakeReason: "issue_assigned",
       },
       updatedAt: input.now,
       createdAt: input.now,
     });
+
+    if (input.issueStatus) {
+      await db.insert(issues).values({
+        id: issueId,
+        companyId: input.companyId,
+        title: "Retry target",
+        status: input.issueStatus,
+        priority: "medium",
+        assigneeAgentId: input.agentId,
+        executionRunId: input.runId,
+        executionAgentNameKey: agentName.toLowerCase(),
+        executionLockedAt: input.now,
+        issueNumber: 1,
+        identifier: `T${input.companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}-1`,
+      });
+    }
   }
 
   async function seedMaxTurnFixture(input?: {
@@ -1390,6 +1409,50 @@ describeEmbeddedPostgres("heartbeat bounded retry scheduling", () => {
     expect((wakeupRequest?.payload as Record<string, unknown> | null)?.transientRetryNotBefore).toBe(
       retryNotBefore.toISOString(),
     );
+  });
+
+  it("does not schedule transient retries for completed issues", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const runId = randomUUID();
+    const issueId = randomUUID();
+    const now = new Date("2026-04-22T22:29:00.000Z");
+    const retryNotBefore = new Date("2026-04-22T23:31:00.000Z");
+
+    await seedRetryFixture({
+      runId,
+      companyId,
+      agentId,
+      issueId,
+      issueStatus: "done",
+      now,
+      errorCode: "adapter_failed",
+      errorFamily: "transient_upstream",
+      retryNotBefore: retryNotBefore.toISOString(),
+    });
+
+    const scheduled = await heartbeat.scheduleBoundedRetry(runId, {
+      now,
+      random: () => 0.5,
+    });
+
+    expect(scheduled).toMatchObject({
+      outcome: "not_scheduled",
+      errorCode: "issue_terminal_status",
+      issueId,
+    });
+
+    const retryRows = await db
+      .select({ id: heartbeatRuns.id })
+      .from(heartbeatRuns)
+      .where(and(eq(heartbeatRuns.retryOfRunId, runId), eq(heartbeatRuns.status, "scheduled_retry")));
+    expect(retryRows).toHaveLength(0);
+
+    const wakeupRows = await db
+      .select({ id: agentWakeupRequests.id })
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.agentId, agentId));
+    expect(wakeupRows).toHaveLength(0);
   });
 
   it("schedules bounded retries for claude_transient_upstream and honors its retry-not-before hint", async () => {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -6599,27 +6599,32 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
 
     const contextSnapshot = parseObject(run.contextSnapshot);
     const issueId = readNonEmptyString(contextSnapshot.issueId);
-    if (retryReason === MAX_TURN_CONTINUATION_RETRY_REASON) {
+    if (retryReason === MAX_TURN_CONTINUATION_RETRY_REASON || issueId) {
       const gate = await evaluateScheduledRetryGate({ run, agent, contextSnapshot, retryReason });
       if (!gate.allowed) {
-        await appendRunEvent(run, await nextRunEventSeq(run.id), {
-          eventType: "lifecycle",
-          stream: "system",
-          level: "warn",
-          message: gate.reason,
-          payload: {
-            retryReason,
-            scheduledRetryAttempt: nextAttempt,
-            maxAttempts,
-            ...gate.details,
-          },
-        });
-        return {
-          outcome: "not_scheduled" as const,
-          reason: gate.reason,
-          errorCode: gate.errorCode,
-          issueId: gate.issueId,
-        };
+        if (gate.errorCode === "issue_not_found" && retryReason !== MAX_TURN_CONTINUATION_RETRY_REASON) {
+          // Preserve legacy transient retry behavior for runs that only carry a
+          // loose task context rather than a persisted issue row.
+        } else {
+          await appendRunEvent(run, await nextRunEventSeq(run.id), {
+            eventType: "lifecycle",
+            stream: "system",
+            level: "warn",
+            message: gate.reason,
+            payload: {
+              retryReason,
+              scheduledRetryAttempt: nextAttempt,
+              maxAttempts,
+              ...gate.details,
+            },
+          });
+          return {
+            outcome: "not_scheduled" as const,
+            reason: gate.reason,
+            errorCode: gate.errorCode,
+            issueId: gate.issueId,
+          };
+        }
       }
     }
     const taskKey = deriveTaskKeyWithHeartbeatFallback(contextSnapshot, null);


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The heartbeat service owns automatic retry scheduling after agent runs fail or need continuation.
> - Bounded retries already protect max-turn continuations with issue-state gates, and adapter quota failures already carry retry timing metadata.
> - But plain transient retries tied to an issue could still schedule a future run after the issue had already reached a terminal disposition.
> - That creates wasted retry traffic and can amplify upstream quota failures into unnecessary agent runs.
> - This pull request reuses the existing scheduled retry gate for all persisted issue-scoped bounded retries while preserving legacy loose task-context retries.
> - The benefit is that completed or cancelled work cannot keep generating retry traffic, without weakening retry behavior for non-terminal work.

## Linked Issues or Issue Description

No public GitHub issue exists for this instance-observed bug.

Bug summary:
- What happened: a bounded transient adapter retry could be scheduled for a run whose context referenced an issue that had already reached `done` or `cancelled`.
- Expected behavior: issue-scoped automatic retries should not be scheduled once the target issue has a terminal disposition.
- Steps to reproduce: create a failed transient heartbeat run with `contextSnapshot.issueId` pointing at a completed issue, then call `scheduleBoundedRetry`; before this change it could create a `scheduled_retry` heartbeat row and wakeup request.
- Paperclip version/commit: reproduced against current `master` before this fix.
- Deployment mode: local trusted development/test environment.

Related but not duplicate: #5299 discusses provider-level pause/resume on hard rate-limit hits. This PR is narrower and guards issue-scoped retry scheduling against terminal issue state.

## What Changed

- Apply the existing scheduled retry gate to all bounded retries that carry a persisted `issueId`, not only max-turn continuation retries.
- Preserve legacy behavior for transient retries that only carry loose task context by allowing the existing `issue_not_found` path outside max-turn continuations.
- Extend heartbeat retry scheduling tests with a completed-issue regression that asserts no scheduled retry row or wakeup request is created.

## Verification

- `npx --yes pnpm@9.15.4 exec vitest run server/src/__tests__/heartbeat-retry-scheduling.test.ts`
- Result: 1 test file passed, 21 tests passed.

## Risks

Low risk. The change reuses an existing gate and only broadens it to issue-scoped bounded retries. The main behavioral shift is intentional: automatic retries will now stop when the referenced issue is terminal, reassigned, paused, budget-blocked, or dependency-blocked. Retries without a persisted issue row keep the previous loose task-context behavior.

## Model Used

OpenAI GPT-5 via a Codex local coding agent, with shell/tool use for repository inspection, editing, GitHub CLI operations, and targeted Vitest verification.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge
