### PR TITLE
fix(heartbeat): skip done-issue reopen when deferred comment wake is exclusively self-authored (continues #6576)

### DIFF
--- a/server/src/services/heartbeat-self-comment-wake.test.ts
+++ b/server/src/services/heartbeat-self-comment-wake.test.ts
@@ -10,11 +10,23 @@ const COMMENT_1 = "11111111-1111-1111-1111-111111111111";
 const COMMENT_2 = "22222222-2222-2222-2222-222222222222";
 const COMMENT_3 = "33333333-3333-3333-3333-333333333333";
 
-function rows(...entries: Array<[string, string | null]>): DeferredCommentAuthorRow[] {
-  return entries.map(([id, authorAgentId]) => ({ id, authorAgentId }));
+/**
+ * Test fixture builder. Each entry is `[commentId, authorAgentId, createdByRunAgentId]`
+ * — the two signals the helper consumes per row.
+ */
+function rows(
+  ...entries: Array<[string, string | null, string | null]>
+): DeferredCommentAuthorRow[] {
+  return entries.map(([id, authorAgentId, createdByRunAgentId]) => ({
+    id,
+    authorAgentId,
+    createdByRunAgentId,
+  }));
 }
 
 describe("isExclusivelySelfAuthoredDeferredCommentWake", () => {
+  // -- Boundary cases (no recognition possible) --
+
   it("returns false when no comment IDs are passed (wake is not comment-driven)", () => {
     expect(
       isExclusivelySelfAuthoredDeferredCommentWake({
@@ -30,44 +42,14 @@ describe("isExclusivelySelfAuthoredDeferredCommentWake", () => {
       isExclusivelySelfAuthoredDeferredCommentWake({
         deferredCommentIds: [COMMENT_1],
         assigneeAgentId: null,
-        deferredCommentAuthors: rows([COMMENT_1, AGENT_A]),
+        deferredCommentAuthors: rows([COMMENT_1, AGENT_A, AGENT_A]),
       }),
     ).toBe(false);
     expect(
       isExclusivelySelfAuthoredDeferredCommentWake({
         deferredCommentIds: [COMMENT_1],
         assigneeAgentId: undefined,
-        deferredCommentAuthors: rows([COMMENT_1, AGENT_A]),
-      }),
-    ).toBe(false);
-  });
-
-  it("returns true when every deferred comment is authored by the assignee (the loop-blocking case)", () => {
-    expect(
-      isExclusivelySelfAuthoredDeferredCommentWake({
-        deferredCommentIds: [COMMENT_1, COMMENT_2],
-        assigneeAgentId: AGENT_A,
-        deferredCommentAuthors: rows([COMMENT_1, AGENT_A], [COMMENT_2, AGENT_A]),
-      }),
-    ).toBe(true);
-  });
-
-  it("returns false when at least one deferred comment is human-authored (a real user reply should reopen)", () => {
-    expect(
-      isExclusivelySelfAuthoredDeferredCommentWake({
-        deferredCommentIds: [COMMENT_1, COMMENT_2],
-        assigneeAgentId: AGENT_A,
-        deferredCommentAuthors: rows([COMMENT_1, AGENT_A], [COMMENT_2, null]),
-      }),
-    ).toBe(false);
-  });
-
-  it("returns false when a deferred comment was authored by a different agent (cross-agent mention should reopen)", () => {
-    expect(
-      isExclusivelySelfAuthoredDeferredCommentWake({
-        deferredCommentIds: [COMMENT_1, COMMENT_2],
-        assigneeAgentId: AGENT_A,
-        deferredCommentAuthors: rows([COMMENT_1, AGENT_A], [COMMENT_2, AGENT_B]),
+        deferredCommentAuthors: rows([COMMENT_1, AGENT_A, AGENT_A]),
       }),
     ).toBe(false);
   });
@@ -80,34 +62,122 @@ describe("isExclusivelySelfAuthoredDeferredCommentWake", () => {
       isExclusivelySelfAuthoredDeferredCommentWake({
         deferredCommentIds: [COMMENT_1, COMMENT_2, COMMENT_3],
         assigneeAgentId: AGENT_A,
-        deferredCommentAuthors: rows([COMMENT_1, AGENT_A], [COMMENT_2, AGENT_A]),
+        deferredCommentAuthors: rows(
+          [COMMENT_1, AGENT_A, AGENT_A],
+          [COMMENT_2, AGENT_A, AGENT_A],
+        ),
       }),
     ).toBe(false);
   });
 
-  it("returns true for the single-comment self-authored DONE-summary case (the exact #3980 / #3935 trigger)", () => {
-    // This is the smoking-gun shape: hermes_local agent posts its DONE summary
-    // comment, the comment-post path enqueues a deferred wake, the promoter
-    // runs, the comment table says authorAgentId === assigneeAgentId →
-    // predicate returns true → caller skips the reopen → loop is broken.
+  // -- Signal 1: author_agent_id (MCP-routed self-comments) --
+
+  it("returns true when every deferred comment is authored by the assignee via author_agent_id (MCP-routed path)", () => {
     expect(
       isExclusivelySelfAuthoredDeferredCommentWake({
-        deferredCommentIds: [COMMENT_1],
+        deferredCommentIds: [COMMENT_1, COMMENT_2],
         assigneeAgentId: AGENT_A,
-        deferredCommentAuthors: rows([COMMENT_1, AGENT_A]),
+        deferredCommentAuthors: rows(
+          [COMMENT_1, AGENT_A, AGENT_A],
+          [COMMENT_2, AGENT_A, AGENT_A],
+        ),
       }),
     ).toBe(true);
   });
 
-  it("returns false when assignee matches but comment author is null (human-posted to assignee's issue)", () => {
-    // Common shape: human comments on the assigned agent's issue.
-    // authorAgentId is null. Even though the assignee is set, this is a real
-    // human reply and should reopen the done issue per the platform contract.
+  it("returns true for the single-comment MCP-routed DONE-summary case (the exact #3980 / #3935 trigger via MCP path)", () => {
     expect(
       isExclusivelySelfAuthoredDeferredCommentWake({
         deferredCommentIds: [COMMENT_1],
         assigneeAgentId: AGENT_A,
-        deferredCommentAuthors: rows([COMMENT_1, null]),
+        deferredCommentAuthors: rows([COMMENT_1, AGENT_A, AGENT_A]),
+      }),
+    ).toBe(true);
+  });
+
+  // -- Signal 2: created_by_run_id (shell-routed self-comments on local_trusted) --
+
+  it("returns true when every deferred comment was created during the assignee's own run, even if author_agent_id is null (shell-routed path on local_trusted)", () => {
+    // This is the exact shape produced by an agent posting via `curl` from
+    // its own terminal on local_trusted: the auth middleware loses the
+    // agent identity (so author_agent_id is null + author_user_id is
+    // 'local-board'), but the run-level comment plumbing still links the
+    // comment to the agent's heartbeat run via created_by_run_id.
+    expect(
+      isExclusivelySelfAuthoredDeferredCommentWake({
+        deferredCommentIds: [COMMENT_1, COMMENT_2],
+        assigneeAgentId: AGENT_A,
+        deferredCommentAuthors: rows(
+          [COMMENT_1, null, AGENT_A],
+          [COMMENT_2, null, AGENT_A],
+        ),
+      }),
+    ).toBe(true);
+  });
+
+  it("returns true for mixed self-comments — some MCP-routed (author_agent_id set), some shell-routed (only createdByRunAgentId matches)", () => {
+    // Real-world shape observed in production: an agent posts most comments
+    // via MCP but one or two via shell within the same run. All are still
+    // self-authored — the loop must not fire.
+    expect(
+      isExclusivelySelfAuthoredDeferredCommentWake({
+        deferredCommentIds: [COMMENT_1, COMMENT_2, COMMENT_3],
+        assigneeAgentId: AGENT_A,
+        deferredCommentAuthors: rows(
+          [COMMENT_1, AGENT_A, AGENT_A], // MCP-routed
+          [COMMENT_2, null, AGENT_A],    // shell-routed
+          [COMMENT_3, AGENT_A, AGENT_A], // MCP-routed
+        ),
+      }),
+    ).toBe(true);
+  });
+
+  // -- Real human / cross-agent comments (must NOT be treated as self) --
+
+  it("returns false when at least one deferred comment is human-authored (a real user reply should reopen)", () => {
+    expect(
+      isExclusivelySelfAuthoredDeferredCommentWake({
+        deferredCommentIds: [COMMENT_1, COMMENT_2],
+        assigneeAgentId: AGENT_A,
+        deferredCommentAuthors: rows(
+          [COMMENT_1, AGENT_A, AGENT_A],
+          [COMMENT_2, null, null], // human comment from the dashboard — neither signal matches
+        ),
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false when a deferred comment was authored by a different agent (cross-agent mention should reopen)", () => {
+    expect(
+      isExclusivelySelfAuthoredDeferredCommentWake({
+        deferredCommentIds: [COMMENT_1, COMMENT_2],
+        assigneeAgentId: AGENT_A,
+        deferredCommentAuthors: rows(
+          [COMMENT_1, AGENT_A, AGENT_A],
+          [COMMENT_2, AGENT_B, AGENT_B],
+        ),
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false when assignee matches but comment author is null AND createdByRunAgentId is null (human reply to assignee's issue)", () => {
+    // Common shape: a real human comments on the assigned agent's issue from
+    // the dashboard. Neither signal links the comment to an agent run.
+    expect(
+      isExclusivelySelfAuthoredDeferredCommentWake({
+        deferredCommentIds: [COMMENT_1],
+        assigneeAgentId: AGENT_A,
+        deferredCommentAuthors: rows([COMMENT_1, null, null]),
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false when a comment's createdByRunAgentId is a different agent (a cross-agent run posted on the assignee's issue)", () => {
+    expect(
+      isExclusivelySelfAuthoredDeferredCommentWake({
+        deferredCommentIds: [COMMENT_1],
+        assigneeAgentId: AGENT_A,
+        deferredCommentAuthors: rows([COMMENT_1, null, AGENT_B]),
       }),
     ).toBe(false);
   });

--- a/server/src/services/heartbeat-self-comment-wake.test.ts
+++ b/server/src/services/heartbeat-self-comment-wake.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+import {
+  isExclusivelySelfAuthoredDeferredCommentWake,
+  type DeferredCommentAuthorRow,
+} from "./heartbeat-self-comment-wake.js";
+
+const AGENT_A = "00000000-0000-0000-0000-00000000000a";
+const AGENT_B = "00000000-0000-0000-0000-00000000000b";
+const COMMENT_1 = "11111111-1111-1111-1111-111111111111";
+const COMMENT_2 = "22222222-2222-2222-2222-222222222222";
+const COMMENT_3 = "33333333-3333-3333-3333-333333333333";
+
+function rows(...entries: Array<[string, string | null]>): DeferredCommentAuthorRow[] {
+  return entries.map(([id, authorAgentId]) => ({ id, authorAgentId }));
+}
+
+describe("isExclusivelySelfAuthoredDeferredCommentWake", () => {
+  it("returns false when no comment IDs are passed (wake is not comment-driven)", () => {
+    expect(
+      isExclusivelySelfAuthoredDeferredCommentWake({
+        deferredCommentIds: [],
+        assigneeAgentId: AGENT_A,
+        deferredCommentAuthors: [],
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false when the issue has no assignee agent", () => {
+    expect(
+      isExclusivelySelfAuthoredDeferredCommentWake({
+        deferredCommentIds: [COMMENT_1],
+        assigneeAgentId: null,
+        deferredCommentAuthors: rows([COMMENT_1, AGENT_A]),
+      }),
+    ).toBe(false);
+    expect(
+      isExclusivelySelfAuthoredDeferredCommentWake({
+        deferredCommentIds: [COMMENT_1],
+        assigneeAgentId: undefined,
+        deferredCommentAuthors: rows([COMMENT_1, AGENT_A]),
+      }),
+    ).toBe(false);
+  });
+
+  it("returns true when every deferred comment is authored by the assignee (the loop-blocking case)", () => {
+    expect(
+      isExclusivelySelfAuthoredDeferredCommentWake({
+        deferredCommentIds: [COMMENT_1, COMMENT_2],
+        assigneeAgentId: AGENT_A,
+        deferredCommentAuthors: rows([COMMENT_1, AGENT_A], [COMMENT_2, AGENT_A]),
+      }),
+    ).toBe(true);
+  });
+
+  it("returns false when at least one deferred comment is human-authored (a real user reply should reopen)", () => {
+    expect(
+      isExclusivelySelfAuthoredDeferredCommentWake({
+        deferredCommentIds: [COMMENT_1, COMMENT_2],
+        assigneeAgentId: AGENT_A,
+        deferredCommentAuthors: rows([COMMENT_1, AGENT_A], [COMMENT_2, null]),
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false when a deferred comment was authored by a different agent (cross-agent mention should reopen)", () => {
+    expect(
+      isExclusivelySelfAuthoredDeferredCommentWake({
+        deferredCommentIds: [COMMENT_1, COMMENT_2],
+        assigneeAgentId: AGENT_A,
+        deferredCommentAuthors: rows([COMMENT_1, AGENT_A], [COMMENT_2, AGENT_B]),
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false when the lookup returned fewer rows than IDs requested (missing/deleted comments)", () => {
+    // Conservative: missing rows mean we don't know who authored them.
+    // Better to let the existing predicate decide than to silently skip a
+    // possibly-legitimate reopen.
+    expect(
+      isExclusivelySelfAuthoredDeferredCommentWake({
+        deferredCommentIds: [COMMENT_1, COMMENT_2, COMMENT_3],
+        assigneeAgentId: AGENT_A,
+        deferredCommentAuthors: rows([COMMENT_1, AGENT_A], [COMMENT_2, AGENT_A]),
+      }),
+    ).toBe(false);
+  });
+
+  it("returns true for the single-comment self-authored DONE-summary case (the exact #3980 / #3935 trigger)", () => {
+    // This is the smoking-gun shape: hermes_local agent posts its DONE summary
+    // comment, the comment-post path enqueues a deferred wake, the promoter
+    // runs, the comment table says authorAgentId === assigneeAgentId →
+    // predicate returns true → caller skips the reopen → loop is broken.
+    expect(
+      isExclusivelySelfAuthoredDeferredCommentWake({
+        deferredCommentIds: [COMMENT_1],
+        assigneeAgentId: AGENT_A,
+        deferredCommentAuthors: rows([COMMENT_1, AGENT_A]),
+      }),
+    ).toBe(true);
+  });
+
+  it("returns false when assignee matches but comment author is null (human-posted to assignee's issue)", () => {
+    // Common shape: human comments on the assigned agent's issue.
+    // authorAgentId is null. Even though the assignee is set, this is a real
+    // human reply and should reopen the done issue per the platform contract.
+    expect(
+      isExclusivelySelfAuthoredDeferredCommentWake({
+        deferredCommentIds: [COMMENT_1],
+        assigneeAgentId: AGENT_A,
+        deferredCommentAuthors: rows([COMMENT_1, null]),
+      }),
+    ).toBe(false);
+  });
+});

--- a/server/src/services/heartbeat-self-comment-wake.ts
+++ b/server/src/services/heartbeat-self-comment-wake.ts
@@ -1,0 +1,96 @@
+/**
+ * Helper for the deferred-comment-wake promotion path in `heartbeat.ts`.
+ *
+ * Background
+ * ----------
+ * When a comment is posted on an issue assigned to an agent, Paperclip queues a
+ * `deferred_issue_execution` wakeup so the agent can react to the new comment.
+ * When that deferred wake is later promoted, the promoter must decide whether
+ * to also reopen the issue if it has reached a terminal status (`done` or
+ * `cancelled`). The original predicate distinguished "real human commenter
+ * wants the issue reopened" from "system follow-up that should respect the
+ * disposition" by reading `agent_wakeup_requests.requested_by_actor_type` —
+ * trusting that actor-type to identify whether the triggering write came from
+ * a user or an agent.
+ *
+ * Why that trust was wrong
+ * ------------------------
+ * On `deploymentMode: "local_trusted"` instances, the auth middleware
+ * (`server/src/middleware/auth.ts`) short-circuits unauthenticated localhost
+ * requests to the `local-board` USER principal. Adapters that present a raw
+ * `Authorization: Bearer <agent authToken>` (notably `hermes-paperclip-adapter`
+ * v0.2.0 on `hermes_local`) do not promote that token to an agent JWT, so the
+ * agent's own writes record `requested_by_actor_type: "user"`. The predicate
+ * then mistakes the agent's own DONE-summary comment for a real human commenter
+ * and reopens the just-completed issue — which causes the agent to wake again,
+ * post another DONE-summary comment, and infinite-loop. See:
+ *   - paperclipai/paperclip#3980 (root cause: identity attribution)
+ *   - paperclipai/paperclip#3935 (symptom: Done -> In Progress oscillation)
+ *   - paperclipai/paperclip#2486 (general class: infinite promotion loops)
+ *   - NousResearch/hermes-paperclip-adapter#92 (adapter-side mirror)
+ *
+ * Why this helper is the right fix
+ * --------------------------------
+ * The comment table holds the authoritative author identity
+ * (`issue_comments.author_agent_id`). It does not lie about who authored the
+ * comment regardless of how the auth middleware classified the request. By
+ * looking up the actual comment authors for the deferred wake's comment IDs
+ * and asking "were these comments exclusively written by the assignee agent
+ * itself?", we get a content-based signal that is independent of the wake's
+ * recorded actor-type and the deployment mode. The original actor-type check
+ * remains as defense-in-depth; this helper adds the missing second check.
+ *
+ * The helper is intentionally pure so it can be unit-tested without database
+ * fixtures. The caller (`heartbeat.ts`) is responsible for the lookup.
+ */
+
+export interface DeferredCommentAuthorRow {
+  /** `issue_comments.id` */
+  id: string;
+  /** `issue_comments.author_agent_id` — null for human-authored comments */
+  authorAgentId: string | null;
+}
+
+export interface SelfAuthoredDeferredCommentWakeInput {
+  /** Comment IDs extracted from the deferred wake's context snapshot. */
+  deferredCommentIds: ReadonlyArray<string>;
+  /**
+   * The issue's current `assignee_agent_id`. Null/undefined means the issue is
+   * not assigned to an agent; in that case the wake cannot be "self-authored"
+   * by anyone, so we return false and let the existing predicate decide.
+   */
+  assigneeAgentId: string | null | undefined;
+  /**
+   * The lookup result of `SELECT id, author_agent_id FROM issue_comments WHERE
+   * id IN (deferredCommentIds)`. The caller performs this lookup; we just
+   * compare. Order does not matter.
+   */
+  deferredCommentAuthors: ReadonlyArray<DeferredCommentAuthorRow>;
+}
+
+/**
+ * Returns `true` only when EVERY deferred-wake comment was authored by the
+ * assignee agent itself (a "self-comment wake"). Such wakes must never reopen
+ * a done/cancelled issue, regardless of the wake's recorded `actor_type`.
+ *
+ * Returns `false` when:
+ *   - There are no deferred comment IDs (the wake isn't comment-driven at all).
+ *   - The issue has no assignee agent (no agent can have authored the comments).
+ *   - The lookup returned fewer rows than IDs requested (missing or deleted
+ *     comments; treat as "unknown" and let the existing predicate decide
+ *     conservatively rather than skipping a possibly-legitimate reopen).
+ *   - At least one comment was authored by someone other than the assignee
+ *     (a real human comment or a different agent's comment is in the batch).
+ */
+export function isExclusivelySelfAuthoredDeferredCommentWake(
+  input: SelfAuthoredDeferredCommentWakeInput,
+): boolean {
+  if (input.deferredCommentIds.length === 0) return false;
+  if (!input.assigneeAgentId) return false;
+  if (input.deferredCommentAuthors.length !== input.deferredCommentIds.length) {
+    return false;
+  }
+  return input.deferredCommentAuthors.every(
+    (row) => row.authorAgentId === input.assigneeAgentId,
+  );
+}

--- a/server/src/services/heartbeat-self-comment-wake.ts
+++ b/server/src/services/heartbeat-self-comment-wake.ts
@@ -40,15 +40,47 @@
  * recorded actor-type and the deployment mode. The original actor-type check
  * remains as defense-in-depth; this helper adds the missing second check.
  *
+ * Two-signal recognition (covers BOTH MCP-routed and shell-routed writes)
+ * ----------------------------------------------------------------------
+ * On `local_trusted` the agent has two materially different write paths:
+ *
+ *   - MCP-routed (`paperclipAddComment` etc.) — the comment row gets
+ *     `author_agent_id = <the agent>`, `author_user_id = NULL`, and
+ *     `created_by_run_id` linked to the current heartbeat run.
+ *   - Shell-routed (`curl` from the agent's terminal with the agent's
+ *     Bearer authToken) — the auth middleware's `local_trusted`
+ *     short-circuit promotes the actor to the `local-board` USER principal,
+ *     so the comment row gets `author_agent_id = NULL`,
+ *     `author_user_id = "local-board"`, and `created_by_run_id` STILL linked
+ *     to the agent's heartbeat run.
+ *
+ * The first signal (`author_agent_id === assigneeAgentId`) catches MCP-routed
+ * self-comments. The second signal (`createdByRunAgentId === assigneeAgentId`)
+ * catches shell-routed self-comments, because while the auth middleware loses
+ * the agent identity, the heartbeat-run reference is set by the run-level
+ * comment plumbing and survives. A comment is self-authored when EITHER signal
+ * fires.
+ *
  * The helper is intentionally pure so it can be unit-tested without database
- * fixtures. The caller (`heartbeat.ts`) is responsible for the lookup.
+ * fixtures. The caller (`heartbeat.ts`) is responsible for the lookup (which
+ * is a single `LEFT JOIN` between `issue_comments` and `heartbeat_runs`).
  */
 
 export interface DeferredCommentAuthorRow {
   /** `issue_comments.id` */
   id: string;
-  /** `issue_comments.author_agent_id` — null for human-authored comments */
+  /**
+   * `issue_comments.author_agent_id` — null for human-authored comments AND
+   * for agent-authored comments that round-tripped through a path which lost
+   * agent identity (see "shell-routed" in the file header).
+   */
   authorAgentId: string | null;
+  /**
+   * `heartbeat_runs.agent_id` joined via `issue_comments.created_by_run_id`.
+   * Null if the comment was not created during an agent run (e.g. a real
+   * human comment posted from the dashboard), or if the run is missing/deleted.
+   */
+  createdByRunAgentId: string | null;
 }
 
 export interface SelfAuthoredDeferredCommentWakeInput {
@@ -61,9 +93,16 @@ export interface SelfAuthoredDeferredCommentWakeInput {
    */
   assigneeAgentId: string | null | undefined;
   /**
-   * The lookup result of `SELECT id, author_agent_id FROM issue_comments WHERE
-   * id IN (deferredCommentIds)`. The caller performs this lookup; we just
-   * compare. Order does not matter.
+   * The lookup result of:
+   *
+   *   SELECT ic.id,
+   *          ic.author_agent_id          AS authorAgentId,
+   *          hr.agent_id                 AS createdByRunAgentId
+   *   FROM   issue_comments ic
+   *   LEFT JOIN heartbeat_runs hr ON hr.id = ic.created_by_run_id
+   *   WHERE  ic.id IN (deferredCommentIds);
+   *
+   * Order does not matter.
    */
   deferredCommentAuthors: ReadonlyArray<DeferredCommentAuthorRow>;
 }
@@ -73,6 +112,12 @@ export interface SelfAuthoredDeferredCommentWakeInput {
  * assignee agent itself (a "self-comment wake"). Such wakes must never reopen
  * a done/cancelled issue, regardless of the wake's recorded `actor_type`.
  *
+ * A single comment counts as self-authored when EITHER:
+ *   - `authorAgentId === assigneeAgentId` (the MCP-routed path preserves
+ *     agent identity), OR
+ *   - `createdByRunAgentId === assigneeAgentId` (the shell-routed path loses
+ *     agent identity at the auth layer but the run linkage survives).
+ *
  * Returns `false` when:
  *   - There are no deferred comment IDs (the wake isn't comment-driven at all).
  *   - The issue has no assignee agent (no agent can have authored the comments).
@@ -80,7 +125,9 @@ export interface SelfAuthoredDeferredCommentWakeInput {
  *     comments; treat as "unknown" and let the existing predicate decide
  *     conservatively rather than skipping a possibly-legitimate reopen).
  *   - At least one comment was authored by someone other than the assignee
- *     (a real human comment or a different agent's comment is in the batch).
+ *     by BOTH signals (i.e. neither `authorAgentId` nor `createdByRunAgentId`
+ *     equals the assignee). This is a real human comment or a comment created
+ *     by a different agent's run.
  */
 export function isExclusivelySelfAuthoredDeferredCommentWake(
   input: SelfAuthoredDeferredCommentWakeInput,
@@ -90,7 +137,10 @@ export function isExclusivelySelfAuthoredDeferredCommentWake(
   if (input.deferredCommentAuthors.length !== input.deferredCommentIds.length) {
     return false;
   }
+  const assigneeAgentId = input.assigneeAgentId;
   return input.deferredCommentAuthors.every(
-    (row) => row.authorAgentId === input.assigneeAgentId,
+    (row) =>
+      row.authorAgentId === assigneeAgentId ||
+      row.createdByRunAgentId === assigneeAgentId,
   );
 }

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -10579,13 +10579,29 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         // an infinite reopen loop on done issues (#3935,
         // NousResearch/hermes-paperclip-adapter#92). The comment table holds
         // the authoritative author identity regardless of auth attribution.
+        //
+        // We use TWO signals to recognize a self-authored comment, because the
+        // agent has two write paths on local_trusted (each lossy in a different
+        // way):
+        //   1. `issue_comments.author_agent_id` — set by MCP-routed writes;
+        //      NULL on shell-routed (`curl`) writes that round-trip through
+        //      the `local-board` user principal.
+        //   2. `heartbeat_runs.agent_id` joined via
+        //      `issue_comments.created_by_run_id` — set by the run-level
+        //      comment plumbing on BOTH paths, so it survives even when the
+        //      auth middleware loses the agent identity on the shell path.
+        // The helper treats EITHER signal matching the assignee as
+        // "self-authored". See `heartbeat-self-comment-wake.ts` for the
+        // full mechanism writeup.
         const deferredCommentAuthors = deferredCommentIds.length > 0
           ? await tx
               .select({
                 id: issueComments.id,
                 authorAgentId: issueComments.authorAgentId,
+                createdByRunAgentId: heartbeatRuns.agentId,
               })
               .from(issueComments)
+              .leftJoin(heartbeatRuns, eq(heartbeatRuns.id, issueComments.createdByRunId))
               .where(inArray(issueComments.id, deferredCommentIds))
           : [];
         const deferredWakeIsExclusivelySelfAuthored =

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -58,6 +58,7 @@ import { conflict, HttpError, notFound } from "../errors.js";
 import { logger } from "../middleware/logger.js";
 import { publishLiveEvent } from "./live-events.js";
 import { getRunLogStore, type RunLogHandle } from "./run-log-store.js";
+import { isExclusivelySelfAuthoredDeferredCommentWake } from "./heartbeat-self-comment-wake.js";
 import { getServerAdapter, listAdapterModelProfiles, runningProcesses } from "../adapters/index.js";
 import type {
   AdapterExecutionResult,
@@ -10567,33 +10568,41 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         }
         const deferredCommentIds = extractWakeCommentIds(deferredContextSeed);
         const deferredWakeReason = readNonEmptyString(deferredContextSeed.wakeReason);
-        // Local-CLI agents post comments under user auth, so a self-comment from
-        // the run that is now ending would otherwise look like a real human
-        // comment and trigger a reopen on the very issue this run just closed.
-        // Suppress reopen only when every referenced comment came from this run;
-        // mixed batches must still reopen because they contain a real follow-up.
-        let deferredCommentWakeIsSelfAuthored = false;
-        if (deferredCommentIds.length > 0) {
-          const deferredComments = await tx
-            .select({ createdByRunId: issueComments.createdByRunId })
-            .from(issueComments)
-            .where(
-              and(
-                eq(issueComments.companyId, issue.companyId),
-                eq(issueComments.issueId, issue.id),
-                inArray(issueComments.id, deferredCommentIds),
-              ),
-            )
-            .then((rows) => rows);
-          deferredCommentWakeIsSelfAuthored =
-            deferredComments.length > 0 &&
-            deferredComments.every((comment) => comment.createdByRunId === run.id);
-        }
+
+        // Look up the actual author of every deferred-wake comment so we can
+        // distinguish self-authored "agent posted its DONE-summary comment"
+        // wakes from real human comments. The `deferred.requestedByActorType`
+        // check below is insufficient on `local_trusted` deployments where the
+        // auth middleware short-circuits agent Bearer-token writes to the
+        // `local-board` user principal (see #3980), making every agent
+        // self-comment look like a human comment to the predicate and causing
+        // an infinite reopen loop on done issues (#3935,
+        // NousResearch/hermes-paperclip-adapter#92). The comment table holds
+        // the authoritative author identity regardless of auth attribution.
+        const deferredCommentAuthors = deferredCommentIds.length > 0
+          ? await tx
+              .select({
+                id: issueComments.id,
+                authorAgentId: issueComments.authorAgentId,
+              })
+              .from(issueComments)
+              .where(inArray(issueComments.id, deferredCommentIds))
+          : [];
+        const deferredWakeIsExclusivelySelfAuthored =
+          isExclusivelySelfAuthoredDeferredCommentWake({
+            deferredCommentIds,
+            assigneeAgentId: issue.assigneeAgentId,
+            deferredCommentAuthors,
+          });
+
         // Only human/comment-reopen interactions should revive completed issues;
         // system follow-ups such as retry or cleanup wakes must not reopen closed work.
+        // Self-authored deferred comment wakes (the agent's own DONE-summary
+        // comment triggering its own follow-up wake) must NOT reopen either —
+        // that creates the loop described in #3980/#3935.
         const shouldReopenDeferredCommentWake =
           deferredCommentIds.length > 0 &&
-          !deferredCommentWakeIsSelfAuthored &&
+          !deferredWakeIsExclusivelySelfAuthored &&
           (issue.status === "done" || issue.status === "cancelled") &&
           (
             deferred.requestedByActorType === "user" ||

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -10593,23 +10593,32 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         // The helper treats EITHER signal matching the assignee as
         // "self-authored". See `heartbeat-self-comment-wake.ts` for the
         // full mechanism writeup.
-        const deferredCommentAuthors = deferredCommentIds.length > 0
-          ? await tx
-              .select({
-                id: issueComments.id,
-                authorAgentId: issueComments.authorAgentId,
-                createdByRunAgentId: heartbeatRuns.agentId,
-              })
-              .from(issueComments)
-              .leftJoin(heartbeatRuns, eq(heartbeatRuns.id, issueComments.createdByRunId))
-              .where(inArray(issueComments.id, deferredCommentIds))
-          : [];
-        const deferredWakeIsExclusivelySelfAuthored =
-          isExclusivelySelfAuthoredDeferredCommentWake({
-            deferredCommentIds,
-            assigneeAgentId: issue.assigneeAgentId,
-            deferredCommentAuthors,
-          });
+        // The self-comment guard only matters when the issue is in a terminal
+        // state (done/cancelled) — that's the only condition under which the
+        // predicate below would otherwise fire a reopen. Skip the DB roundtrip
+        // for in-progress / todo / blocked / in_review issues, which is the
+        // common case on every heartbeat tick (per Greptile review on #6576).
+        const issueIsTerminalForReopen =
+          issue.status === "done" || issue.status === "cancelled";
+        const deferredCommentAuthors =
+          issueIsTerminalForReopen && deferredCommentIds.length > 0
+            ? await tx
+                .select({
+                  id: issueComments.id,
+                  authorAgentId: issueComments.authorAgentId,
+                  createdByRunAgentId: heartbeatRuns.agentId,
+                })
+                .from(issueComments)
+                .leftJoin(heartbeatRuns, eq(heartbeatRuns.id, issueComments.createdByRunId))
+                .where(inArray(issueComments.id, deferredCommentIds))
+            : [];
+        const deferredWakeIsExclusivelySelfAuthored = issueIsTerminalForReopen
+          ? isExclusivelySelfAuthoredDeferredCommentWake({
+              deferredCommentIds,
+              assigneeAgentId: issue.assigneeAgentId,
+              deferredCommentAuthors,
+            })
+          : false;
 
         // Only human/comment-reopen interactions should revive completed issues;
         // system follow-ups such as retry or cleanup wakes must not reopen closed work.

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -10610,7 +10610,17 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
                 })
                 .from(issueComments)
                 .leftJoin(heartbeatRuns, eq(heartbeatRuns.id, issueComments.createdByRunId))
-                .where(inArray(issueComments.id, deferredCommentIds))
+                // Keep the same tenant/issue scoping the prior predicate carried: a
+                // stale or corrupted comment ID from the wake context seed must return
+                // zero rows (tripping the length-mismatch guard) rather than silently
+                // resolving a comment that belongs to another issue or company.
+                .where(
+                  and(
+                    eq(issueComments.companyId, issue.companyId),
+                    eq(issueComments.issueId, issue.id),
+                    inArray(issueComments.id, deferredCommentIds),
+                  ),
+                )
             : [];
         const deferredWakeIsExclusivelySelfAuthored = issueIsTerminalForReopen
           ? isExclusivelySelfAuthoredDeferredCommentWake({


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage and orchestrate AI agents for work.
> - Agents disposition their assigned issues at the end of each run (`done` / `blocked` / `cancelled`), and the heartbeat service owns the post-run comment lifecycle: a comment posted on a `done`/`cancelled` issue queues a deferred wake that the promoter can later use to reopen the issue back to `todo`.
> - The promoter decides whether to reopen by checking `deferred.requestedByActorType === "user"` — i.e. "a human commented, so revive the completed issue."
> - On `local_trusted` deployments running local adapters (e.g. `hermes_local`), the auth middleware short-circuits the agent's own Bearer-token writes to the `local-board` **user** principal, so the agent's own DONE-summary comment is recorded as a `"user"` actor.
> - That misclassification makes the agent's own closing comment reopen the very issue it just finished, producing an infinite `done → todo → in_progress → done …` loop (#3935, #3980; mirrored adapter-side at `NousResearch/hermes-paperclip-adapter#92`).
> - This PR recognizes self-authored comments by their actual author identity in the data — `issue_comments.author_agent_id` and the `heartbeat_runs.agent_id` reached via `issue_comments.created_by_run_id` — instead of trusting the lossy actor-type metadata, and skips the reopen when every deferred-wake comment is the assignee's own.
> - The benefit is that agents on `local_trusted` / Hermes stop reopening their own completed work, while genuine human follow-up comments still reopen issues exactly as before.

## Linked Issues or Issue Description

- Refs #3935 — *Task status repeatedly changes from Done → In Progress, loops infinitely.*
- Refs #3980 — *Bug: agent PATCH comment triggers reopen loop on done issues.*

**Heads up on #4346:** that one (already merged) touches the same two issues, so it's worth being clear on why this isn't a dupe. #4346 guards the HTTP route reopen path and only kicks in when `actorType === "agent"`. Our whole problem is that on `local_trusted`/`hermes_local` the agent's own writes get reclassified to the `local-board` user principal, so `actorType === "user"` and that guard just never fires — plus it doesn't touch the heartbeat deferred-wake path this PR fixes at all. Different layer, different signal. The fact that #3935/#3980 are still open after #4346 merged lines up with that.

**Credit / continuation:** This continues #6576 by **@sparkeros**, which had gone stale and into merge conflict against `master`. All of their commits and authorship are preserved unchanged; I rebased the branch onto the current `master` (`v2026.626.0`) and resolved the `heartbeat.ts` conflict. I commented on #6576 offering the rebase and waited for a response before opening this; reopening here so the fix can move forward. Related open PRs exploring the same reopen-loop family (different approaches): #4410, #6671, #6713.

## What Changed

- **New `server/src/services/heartbeat-self-comment-wake.ts`** — a pure, dependency-free helper `isExclusivelySelfAuthoredDeferredCommentWake(...)` that recognizes a self-authored comment via **two** signals, because the agent has two write paths on `local_trusted` (each lossy in a different way):
  1. `issue_comments.author_agent_id` — set on MCP-routed writes; `NULL` on shell-routed (`curl`) writes that round-trip through the `local-board` user principal.
  2. `heartbeat_runs.agent_id` joined via `issue_comments.created_by_run_id` — set on **both** paths, so it survives when the auth middleware loses the agent identity on the shell path.
  The wake is treated as self-authored only when **every** referenced comment matches the assignee (mixed human+self batches still reopen).
- **`server/src/services/heartbeat.ts`** — replace the old `createdByRunId === run.id` self-author predicate with the helper; gate the author lookup on terminal status (`done`/`cancelled`) so the extra DB query is skipped on the common non-terminal heartbeat path.
- **New `server/src/services/heartbeat-self-comment-wake.test.ts`** — 11 unit tests covering both signals, boundary cases (no comment IDs, no assignee, missing rows), and mixed batches.

## Verification

- `tsc --noEmit` — clean on the heartbeat files.
- `vitest run src/services/heartbeat-self-comment-wake.test.ts` — **11/11 pass**.
- `vitest run src/__tests__/heartbeat-comment-wake-batching.test.ts` — integration suite passes.
- This is #6576's branch (which had fully green CI: all server suites, build, e2e, canary) rebased onto `master` `v2026.626.0`; the conflict was confined to the predicate swap in `heartbeat.ts`, which the unit + integration suites above exercise.

## Risks

- **Low.** The change is additive and confined to the `done`/`cancelled` reopen path. Genuine human comments still reopen issues — their `author_agent_id` is null and their `created_by_run_id` does not map to the assignee. Mixed batches (self + human comments) still reopen, because the helper requires **every** comment to be self-authored. The author lookup is now gated on terminal status, which removes a per-tick DB query on the common non-terminal path. No schema changes, no migrations.

## Model Used

- **Original implementation (#6576):** authored by @sparkeros (commits preserved as-is).
- **This rebase, conflict resolution, and verification:** Claude Sonnet 4.6 (`claude-sonnet-4-6`), via Claude Code, with human oversight.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work (this is a bugfix, not core feature work)
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable (preserved from #6576)
- [ ] If this change affects the UI, I have included before/after screenshots (N/A — no UI change)
- [ ] I have updated relevant documentation to reflect my changes (N/A — internal heartbeat logic)
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green (pending — will verify after CI runs)
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups (pending CI/Greptile run)
- [x] I will address all Greptile and reviewer comments before requesting merge

