### PR TITLE
fix: serve public robots and sitemap assets

### DIFF
--- a/server/src/__tests__/app-vite-dev-routing.test.ts
+++ b/server/src/__tests__/app-vite-dev-routing.test.ts
@@ -16,6 +16,8 @@ describe("shouldServeViteDevHtml", () => {
   });
 
   it("skips public assets even when the client accepts */*", () => {
+    expect(shouldServeViteDevHtml(createRequest("/robots.txt", "html"))).toBe(false);
+    expect(shouldServeViteDevHtml(createRequest("/sitemap.xml", "html"))).toBe(false);
     expect(shouldServeViteDevHtml(createRequest("/sw.js", "html"))).toBe(false);
     expect(shouldServeViteDevHtml(createRequest("/site.webmanifest", "html"))).toBe(false);
   });

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -87,6 +87,8 @@ const VITE_DEV_STATIC_PATHS = new Set([
   "/favicon-32x32.png",
   "/favicon.ico",
   "/favicon.svg",
+  "/robots.txt",
+  "/sitemap.xml",
   "/site.webmanifest",
   "/sw.js",
 ]);

--- a/ui/public/robots.txt
+++ b/ui/public/robots.txt
@@ -1,0 +1,3 @@
+User-Agent: *
+Allow: /
+Sitemap: https://paperclip.ing/sitemap.xml

--- a/ui/public/sitemap.xml
+++ b/ui/public/sitemap.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+<url><loc>https://paperclip.ing/</loc><changefreq>monthly</changefreq><priority>1.0</priority></url>
+<url><loc>https://paperclip.ing/design-guide</loc><changefreq>monthly</changefreq><priority>0.8</priority></url>
+</urlset>

--- a/ui/src/lib/public-seo-assets.test.ts
+++ b/ui/src/lib/public-seo-assets.test.ts
@@ -1,0 +1,27 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const uiRoot = resolve(fileURLToPath(new URL("../..", import.meta.url)));
+
+describe("public SEO assets", () => {
+  it("publishes robots.txt with the production sitemap reference", () => {
+    const robots = readFileSync(resolve(uiRoot, "public/robots.txt"), "utf8");
+
+    expect(robots).toContain("User-Agent: *");
+    expect(robots).toContain("Allow: /");
+    expect(robots).toContain("Sitemap: https://paperclip.ing/sitemap.xml");
+    expect(robots).not.toContain("<html");
+  });
+
+  it("publishes a sitemap for public indexable routes", () => {
+    const sitemap = readFileSync(resolve(uiRoot, "public/sitemap.xml"), "utf8");
+
+    expect(sitemap).toContain('<?xml version="1.0" encoding="UTF-8"?>');
+    expect(sitemap).toContain("<loc>https://paperclip.ing/</loc>");
+    expect(sitemap).toContain("<loc>https://paperclip.ing/design-guide</loc>");
+    expect((sitemap.match(/<loc>/g) ?? []).length).toBeGreaterThanOrEqual(2);
+    expect(sitemap).not.toContain("<!DOCTYPE html>");
+  });
+});


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The public website relies on static assets for crawler-facing files such as favicons, manifests, service workers, robots files, and sitemaps.
> - Requests for `robots.txt` and `sitemap.xml` currently fall through to the SPA HTML shell when those files are absent from `ui/public`.
> - Search crawlers expect `/robots.txt` to be plain text and `/sitemap.xml` to be XML with public indexable URLs.
> - This pull request adds the missing static assets and keeps Vite dev routing from treating those paths as document requests.
> - The benefit is that production can serve valid crawler metadata without changing the app shell or authenticated product routes.

## Linked Issues or Issue Description

No public GitHub issue exists for this production bug, so the bug report is described inline.

### What happened?

`https://paperclip.ing/robots.txt` and `https://paperclip.ing/sitemap.xml` return the app HTML shell with `content-type: text/html`.

### Expected behavior

`/robots.txt` should return plain text with a sitemap reference, and `/sitemap.xml` should return valid XML with the public indexable routes.

### Steps to reproduce

Request `https://paperclip.ing/robots.txt` and `https://paperclip.ing/sitemap.xml`, then inspect the response content type and body.

### Paperclip version or commit

Observed on production before this PR. The fix branch head is `1145e3912`.

### Deployment mode

Hosted public website at `paperclip.ing`.

Related PR search:

- Searched existing open PRs for `robots sitemap`, `robots.txt`, `sitemap.xml`, and `public SEO assets`; no duplicate PR was found.

## What Changed

- Added `ui/public/robots.txt` with `Sitemap: https://paperclip.ing/sitemap.xml`.
- Added `ui/public/sitemap.xml` with public indexable routes for `/` and `/design-guide`.
- Added `/robots.txt` and `/sitemap.xml` to `VITE_DEV_STATIC_PATHS` so Vite dev static serving does not fall through to the app shell.
- Added focused tests for the public SEO asset contents and the Vite dev static-path guard.

## Verification

- `pnpm install --frozen-lockfile` passed and repaired stale local workspace links.
- `pnpm exec vitest run server/src/__tests__/app-vite-dev-routing.test.ts ui/src/lib/public-seo-assets.test.ts` passed: 2 files, 5 tests.
- `pnpm --filter @paperclipai/ui build` passed with pre-existing CSS/bundle warnings.
- `pnpm --filter @paperclipai/server build` passed.
- Local static smoke from `ui/dist` before the test commit confirmed `GET /robots.txt` returned `200 text/plain`, 66 bytes, no app HTML; `GET /sitemap.xml` returned `200 application/xml`, 324 bytes, and 2 `<loc>` entries.

## Risks

Low risk. This only adds static public assets, extends the Vite dev static-path allowlist, and adds focused tests. The main operational dependency is that production must deploy the merged assets before live smoke checks pass.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

OpenAI Codex coding agent based on GPT-5, with terminal, git, GitHub CLI, local build/test execution, and production HTTP smoke checks.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I searched the GitHub PR list for similar PRs and confirmed this is not a duplicate
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
