### PR TITLE
fix(server): keep owned in_review issues in review on wake-driven checkout (#8690)

### DIFF
--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -4518,6 +4518,88 @@ describeEmbeddedPostgres("issueService.clearExecutionRunIfTerminal", () => {
     });
   });
 
+  it("checkout leaves an owned in_review issue in review on a wake-driven checkout (#8690)", async () => {
+    // Regression for #8690: the documented Paperclip skill calls
+    // POST /issues/{id}/checkout with expectedStatuses that include "in_review".
+    // When the owning agent is woken while its issue sits in `in_review`, the
+    // checkout is meant to refresh ownership for the new run — it must NOT
+    // silently flip the row to `in_progress` or re-stamp `startedAt`. Before the
+    // fix the main UPDATE matched (in_review ∈ expectedStatuses) and the row
+    // cascade-flipped on every wake of an `in_review` assignee.
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const issueId = randomUUID();
+    const wakeRunId = randomUUID();
+    const reviewStartedAt = new Date("2026-06-10T09:00:00.000Z");
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "CodexCoder",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    await db.insert(heartbeatRuns).values({
+      id: wakeRunId,
+      companyId,
+      agentId,
+      status: "running",
+      invocationSource: "manual",
+      startedAt: new Date("2026-06-10T12:00:00.000Z"),
+    });
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Awaiting review",
+      status: "in_review",
+      priority: "medium",
+      assigneeAgentId: agentId,
+      startedAt: reviewStartedAt,
+    });
+
+    const result = await svc.checkout(
+      issueId,
+      agentId,
+      ["todo", "backlog", "blocked", "in_review"],
+      wakeRunId,
+    );
+
+    // The enriched row returned to the harness must still be in review.
+    expect(result).toMatchObject({ id: issueId, status: "in_review" });
+
+    const row = await db
+      .select({
+        status: issues.status,
+        assigneeAgentId: issues.assigneeAgentId,
+        startedAt: issues.startedAt,
+        checkoutRunId: issues.checkoutRunId,
+        executionRunId: issues.executionRunId,
+      })
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0]);
+
+    expect(row?.status).toBe("in_review");
+    expect(row?.assigneeAgentId).toBe(agentId);
+    // `startedAt` must not be re-stamped by the wake checkout.
+    expect(new Date(row!.startedAt as unknown as string).toISOString()).toBe(
+      reviewStartedAt.toISOString(),
+    );
+    // The no-op review checkout must not silently claim the run locks.
+    expect(row?.checkoutRunId).toBeNull();
+    expect(row?.executionRunId).toBeNull();
+  });
+
   it("checkout adoption of a stale checkoutRunId preserves the issue's assigneeUserId", async () => {
     // Regression for PR #2482 checkout-adoption review finding: any adoption
     // helper that re-locks an existing in_progress issue (e.g. when the prior

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -5563,6 +5563,36 @@ export function issueService(db: Db) {
         throw unprocessable("Issue is blocked by unresolved blockers", { unresolvedBlockerIssueIds });
       }
 
+      // Idempotent review-state checkout (#8690): when the requesting agent
+      // already owns this row in `in_review` and the caller treats `in_review`
+      // as a valid checkout state, a wake-driven checkout must be a no-op for
+      // review posture — not a silent flip back to `in_progress`. Without this
+      // guard the main UPDATE below matches (`in_review` ∈ expectedStatuses, set
+      // by the documented skill path) and re-stamps the row as `in_progress`
+      // with a fresh `startedAt` on every wake of an `in_review` assignee.
+      // Return the current row entirely unchanged: status, `startedAt`,
+      // `assigneeUserId`, and the run-lock columns are all preserved. We do not
+      // claim the run lock for this wake — rows leaving `in_progress` already
+      // clear their lock columns, so an `in_review` row carries none — and
+      // intentional review resume goes through an explicit PATCH → checkout.
+      if (expectedStatuses.includes("in_review")) {
+        const reviewOwnerRow = await db
+          .select()
+          .from(issues)
+          .where(
+            and(
+              eq(issues.id, id),
+              eq(issues.assigneeAgentId, agentId),
+              eq(issues.status, "in_review"),
+            ),
+          )
+          .then((rows) => rows[0] ?? null);
+        if (reviewOwnerRow) {
+          const [enriched] = await withIssueLabels(db, [reviewOwnerRow]);
+          return enriched;
+        }
+      }
+
       const sameRunAssigneeCondition = checkoutRunId
         ? and(
           eq(issues.assigneeAgentId, agentId),


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work, and agent liveness depends on the issue lifecycle staying truthful.
> - The relevant subsystem is the server issue service (`server/src/services/issues.ts`), specifically `issueService.checkout()`, which agent harnesses call on every wake to (re)claim ownership of an issue.
> - The documented Paperclip skill (`skills/paperclip/SKILL.md`) tells every harness to call checkout with `expectedStatuses: ["todo", "backlog", "blocked", "in_review"]`.
> - Because `in_review` is in that list, the main UPDATE guard `inArray(issues.status, expectedStatuses)` matches an `in_review` row the waking agent already owns and atomically re-stamps it as `in_progress` (and re-stamps `startedAt`) — even though no caller passed a status change.
> - The result is a silent, recurring `in_review → in_progress` flip on every wake of an `in_review` assignee, which is not logged as a status change and quietly destroys review posture.
> - This pull request adds an idempotent short-circuit so a wake-driven checkout by the owning agent on its own `in_review` row is a no-op for status, leaving review posture intact.
> - The benefit is that issues parked in review by an agent stay in review across wakes, while intentional resume still works through an explicit `PATCH → checkout`.

## Linked Issues or Issue Description

Fixes #8690

## What Changed

- `server/src/services/issues.ts` — added an idempotent short-circuit at the top of `issueService.checkout()`, after the pause-hold / terminal-run-clearing / blocker checks and before the main UPDATE. When `expectedStatuses` includes `in_review` **and** the requesting agent already owns the row in `in_review`, it returns the current enriched row unchanged instead of letting the UPDATE flip it to `in_progress`.
- The guard is tightly scoped: a different agent still falls through to the existing 409-conflict path, and callers whose `expectedStatuses` does not include `in_review` (e.g. the server-internal heartbeat auto-checkout) are unaffected.
- `server/src/__tests__/issues-service.test.ts` — added a regression test that wakes an owning agent on its own `in_review` issue with the skill's `expectedStatuses` and asserts the row stays `in_review` with `startedAt` and the run-lock columns preserved.
- I intentionally did **not** drop `in_review` from `skills/paperclip/SKILL.md`: making the server idempotent for the owning agent's `in_review` rows fixes the bug while preserving the documented checkout contract, so no skill/doc change is required.

## Verification

- New regression test `checkout leaves an owned in_review issue in review on a wake-driven checkout (#8690)` passes under the embedded-Postgres test harness, and **fails (status flips to `in_progress`) when the server-side guard is reverted**, confirming it pins the reported bug.
- `tsc --noEmit` on the two changed files reports no new type errors.
- Reproduction: PATCH an agent-assigned issue to `in_review`, trigger any wake on that agent, observe the skill-documented `POST /api/issues/{id}/checkout` with `expectedStatuses` including `in_review` — before this change the row becomes `in_progress`; after it stays `in_review`.

## Risks

- Low risk. The change is purely additive and behavior-preserving outside the bug: it only returns early when the requesting agent owns the row, the status is exactly `in_review`, and the caller listed `in_review` in `expectedStatuses`. Every other checkout path (different agent, other statuses, run-lock adoption, conflicts) is untouched.
- Behavioral note (by design, per the issue): the wake checkout is a no-op for run locks — it does not claim `checkoutRunId`/`executionRunId` for the new run while the row is in review. `in_review` rows already carry cleared lock columns, and intentional review resume uses an explicit `PATCH status:"in_progress" → checkout`.

## Model Used

Claude (Anthropic) — Opus 4.8, 1M-token context, with extended thinking and tool use. The fix and regression test were authored with AI assistance and reviewed before submission.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes (N/A — server-internal fix; SKILL.md intentionally unchanged, see "What Changed")
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green (pending CI on this PR)
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups (pending review)
- [x] I will address all Greptile and reviewer comments before requesting merge
