### PR TITLE
fix(hermes-gateway): compact over-length session keys for prompt_cache_key (64-char limit)

### DIFF
--- a/packages/adapters/hermes/src/gateway/server/execute.test.ts
+++ b/packages/adapters/hermes/src/gateway/server/execute.test.ts
@@ -69,6 +69,50 @@ describe("resolveSessionKey", () => {
       }),
     ).toBeNull();
   });
+
+  describe("compaction for prompt_cache_key 64-char limit", () => {
+    const uuids = {
+      companyId: "11111111-2222-3333-4444-555555555555",
+      agentId: "66666666-7777-8888-9999-aaaaaaaaaaaa",
+      issueId: "bbbbbbbb-cccc-dddd-eeee-ffffffffffff",
+      runId: "12121212-3434-5656-7878-909090909090",
+    };
+
+    it("compacts over-length issue keys to <=64 chars while staying namespaced", () => {
+      const key = resolveSessionKey({ strategy: "issue", ...uuids });
+      expect(key).not.toBeNull();
+      expect(key!.length).toBeLessThanOrEqual(64);
+      expect(key).toMatch(/^paperclip:h:[0-9a-f]{48}$/);
+    });
+
+    it("compacts over-length agent keys (97 chars) as well", () => {
+      const key = resolveSessionKey({ strategy: "agent", ...uuids });
+      expect(key!.length).toBeLessThanOrEqual(64);
+      expect(key).toMatch(/^paperclip:h:[0-9a-f]{48}$/);
+    });
+
+    it("is stable: same scope yields the same compacted key", () => {
+      const a = resolveSessionKey({ strategy: "issue", ...uuids });
+      const b = resolveSessionKey({ strategy: "issue", ...uuids });
+      expect(a).toBe(b);
+    });
+
+    it("isolates: different issues yield different keys", () => {
+      const a = resolveSessionKey({ strategy: "issue", ...uuids });
+      const b = resolveSessionKey({
+        strategy: "issue",
+        ...uuids,
+        issueId: "00000000-1111-2222-3333-444444444444",
+      });
+      expect(a).not.toBe(b);
+    });
+
+    it("leaves within-limit keys (run strategy) untouched", () => {
+      expect(resolveSessionKey({ strategy: "run", ...uuids })).toBe(
+        `paperclip:run:${uuids.runId}`,
+      );
+    });
+  });
 });
 
 describe("parseSseFramesForTest", () => {

--- a/packages/adapters/hermes/src/gateway/server/execute.ts
+++ b/packages/adapters/hermes/src/gateway/server/execute.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import type {
   AdapterExecutionContext,
   AdapterExecutionResult,
@@ -146,6 +147,21 @@ function issueIdFromContext(ctx: AdapterExecutionContext): string | null {
   return nonEmpty(ctx.context.taskId) ?? nonEmpty(ctx.context.issueId);
 }
 
+// Hermes forwards the session key to its Codex/OpenAI transport as the
+// `prompt_cache_key`, which has a 64-character maximum. The "issue" (up to
+// ~140 chars with UUID ids) and "agent" (~97) strategies overflow that limit,
+// so the key is rejected downstream and prompt caching + per-issue session
+// continuity are silently lost. Compact over-length keys to a stable, namespaced
+// hash: same scope -> same key (continuity preserved), 192-bit digest (per-issue
+// isolation preserved). Keys already within the limit pass through unchanged.
+const MAX_SESSION_KEY_CHARS = 64;
+
+function compactSessionKey(key: string): string {
+  if (key.length <= MAX_SESSION_KEY_CHARS) return key;
+  const digest = createHash("sha256").update(key).digest("hex").slice(0, 48);
+  return `paperclip:h:${digest}`;
+}
+
 export function resolveSessionKey(input: {
   strategy: SessionKeyStrategy;
   companyId: string;
@@ -155,13 +171,15 @@ export function resolveSessionKey(input: {
 }): string | null {
   if (input.strategy === "none") return null;
   if (input.strategy === "agent") {
-    return `paperclip:company:${input.companyId}:agent:${input.agentId}`;
+    return compactSessionKey(`paperclip:company:${input.companyId}:agent:${input.agentId}`);
   }
   if (input.strategy === "run") {
-    return `paperclip:run:${input.runId}`;
+    return compactSessionKey(`paperclip:run:${input.runId}`);
   }
   const issuePart = input.issueId ? `issue:${input.issueId}` : `run:${input.runId}`;
-  return `paperclip:company:${input.companyId}:agent:${input.agentId}:${issuePart}`;
+  return compactSessionKey(
+    `paperclip:company:${input.companyId}:agent:${input.agentId}:${issuePart}`,
+  );
 }
 
 function stringifyForLog(value: unknown, maxChars = 4_000): string {


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Agents can run remotely through the `hermes_gateway` adapter, which resumes a per-issue Hermes session via a session key forwarded as `X-Hermes-Session-Key` / `session_id`
> - Hermes in turn passes that session key to its Codex/OpenAI transport as the `prompt_cache_key`, which has a hard 64-character maximum
> - But `resolveSessionKey` emits keys up to 140 chars for the `issue` strategy (the default) and 97 for `agent` — both overflow the limit
> - Over-length keys are silently rejected/ignored downstream, so prompt caching and per-issue session continuity are lost; the only workaround, `sessionKeyStrategy: "none"`, disables continuity entirely
> - This PR adds `compactSessionKey()`, which deterministically rehashes only over-length keys into a stable, namespaced ≤64-char form
> - The benefit is that the `issue` and `agent` strategies keep working over the gateway without losing session continuity or per-issue isolation

## Linked Issues or Issue Description

Fixes #8713.

Related (add the `hermes_gateway` adapter; neither addresses the key-length issue): #2363, #4359.

## What Changed

- Add `compactSessionKey()` in `packages/adapters/hermes/src/gateway/server/execute.ts`: when a key exceeds 64 chars, return `paperclip:h:<first-48-hex-of-sha256>` (60 chars); otherwise return the key unchanged.
- Apply it to every non-null `resolveSessionKey` return path (`agent`, `run`, and the `issue`/`run` fallback).
- Add five unit tests to the existing `resolveSessionKey` suite covering: over-length `issue` and `agent` keys compacting to ≤64 and matching `^paperclip:h:[0-9a-f]{48}$`, stability (same scope → same key), isolation (distinct issues → distinct keys), and pass-through for within-limit keys.

## Verification

```bash
# from packages/adapters/hermes
pnpm exec vitest run src/gateway/server/execute.test.ts
#  Test Files  1 passed (1)
#       Tests  26 passed (26)

npx tsc --noEmit -p tsconfig.json   # clean, no output
```

Character counts that motivate the fix (UUID company/agent/issue ids): `issue` = 140, `agent` = 97, `run` = 50, `none` = null. After the change all emitted keys are ≤ 64.

## Risks

Low. Keys already within the limit — including the `run` strategy and short ids — pass through byte-for-byte, so existing behavior is unchanged for them. Only over-length keys change shape; any live session keyed off an over-length value re-keys once on its next wake, which is harmless (a single fresh session, no data loss). No schema migration, no API surface change, no config change.

## Model Used

- **Provider / model:** Anthropic — Claude Opus 4.8 (`claude-opus-4-8`)
- **Harness:** Claude Code (agentic tool use: repo read, edits, local test/typecheck execution)
- **Reasoning mode:** extended thinking enabled
- **Context window:** 200K tokens

The change was authored and locally verified by the model; a human operator reviewed and approved opening the PR.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes — N/A, no user-facing docs cover this internal session-key behavior
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green — pending CI
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups — this update resolves the only open P2 (missing template sections); awaiting re-review
- [x] I will address all Greptile and reviewer comments before requesting merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
