### PR TITLE
fix(ui): surface Zod field details in skill create errors

### DIFF
--- a/ui/src/api/client.test.ts
+++ b/ui/src/api/client.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+
+import { ApiError, formatApiError } from "./client";
+
+// The server's error handler responds to a failed Zod parse with
+// `{ error: "Validation error", details: err.errors }`. `err.errors` is the
+// ZodIssue list — each issue carries `path` (segments) and `message`. These
+// fixtures reproduce that wire shape so the test exercises the real payload the
+// create-skill modal receives, without pulling zod into the ui package.
+function validationApiError(details: Array<{ path: (string | number)[]; message: string }>): ApiError {
+  return new ApiError("Validation error", 400, { error: "Validation error", details });
+}
+
+describe("formatApiError", () => {
+  it("names the offending field instead of a bare 'Validation error'", () => {
+    const error = validationApiError([
+      { path: ["tagline"], message: "String must contain at most 120 character(s)" },
+    ]);
+    const message = formatApiError(error, "Failed to create skill.");
+    expect(message).toContain("tagline");
+    expect(message).toContain("120");
+    expect(message).not.toBe("Validation error");
+  });
+
+  it("joins multiple field issues", () => {
+    const error = validationApiError([
+      { path: ["name"], message: "String must contain at least 1 character(s)" },
+      { path: ["categories", 0], message: "String must contain at least 1 character(s)" },
+    ]);
+    const message = formatApiError(error);
+    expect(message).toContain("name");
+    expect(message).toContain("categories.0");
+    expect(message).toContain(";");
+  });
+
+  it("falls back to the error message when there are no field details", () => {
+    const error = new ApiError("Missing permission: can create agents", 403, {
+      error: "Missing permission: can create agents",
+    });
+    expect(formatApiError(error)).toBe("Missing permission: can create agents");
+  });
+
+  it("uses the provided fallback for non-Error values", () => {
+    expect(formatApiError(null, "Failed to create skill.")).toBe("Failed to create skill.");
+  });
+});

--- a/ui/src/api/client.ts
+++ b/ui/src/api/client.ts
@@ -36,6 +36,42 @@ async function request<T>(path: string, init?: RequestInit): Promise<T> {
   return res.json();
 }
 
+// Turn a Zod issue list (the `details` body the server attaches to a 400
+// "Validation error") into readable "field: message" lines. Without this the
+// UI only ever shows the generic top-level "Validation error" string and the
+// user can't tell which field was rejected.
+function zodIssueMessages(details: unknown): string[] {
+  if (!Array.isArray(details)) return [];
+  const lines: string[] = [];
+  for (const issue of details) {
+    if (!issue || typeof issue !== "object") continue;
+    const { path, message } = issue as { path?: unknown; message?: unknown };
+    if (typeof message !== "string" || message.length === 0) continue;
+    const field = Array.isArray(path)
+      ? path.filter((segment) => segment !== "" && segment != null).join(".")
+      : "";
+    lines.push(field ? `${field}: ${message}` : message);
+  }
+  return lines;
+}
+
+// Build a user-facing message from a thrown request error, naming the specific
+// field(s) when the server returned Zod validation `details`. Falls back to the
+// error message and finally to `fallback`.
+export function formatApiError(error: unknown, fallback = "Request failed."): string {
+  if (error instanceof ApiError) {
+    const body = error.body as { details?: unknown } | null;
+    const fieldMessages = zodIssueMessages(body?.details);
+    if (fieldMessages.length > 0) {
+      const prefix = error.message && error.message !== "Validation error" ? `${error.message}: ` : "";
+      return `${prefix}${fieldMessages.join("; ")}`;
+    }
+    return error.message || fallback;
+  }
+  if (error instanceof Error && error.message) return error.message;
+  return fallback;
+}
+
 export const api = {
   get: <T>(path: string) => request<T>(path),
   post: <T>(path: string, body: unknown) =>

--- a/ui/src/pages/CompanySkills.tsx
+++ b/ui/src/pages/CompanySkills.tsx
@@ -22,6 +22,7 @@ import type {
   CompanySkillVersion,
 } from "@paperclipai/shared";
 import { companySkillsApi } from "../api/companySkills";
+import { formatApiError } from "../api/client";
 import { agentsApi } from "../api/agents";
 import { useCompany } from "../context/CompanyContext";
 import { useBreadcrumbs } from "../context/BreadcrumbContext";
@@ -3984,7 +3985,7 @@ export function CompanySkills() {
       });
     },
     onError: (error) => {
-      const message = error instanceof Error ? error.message : "Failed to create skill.";
+      const message = formatApiError(error, "Failed to create skill.");
       setCreateError(message);
       pushToast({
         tone: "error",


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The Skills Store lets a company author a local skill through the "Create a new skill" modal, which POSTs to `/companies/:companyId/skills`
> - That route validates the body with `companySkillCreateSchema`; on failure the server responds `400 { error: "Validation error", details: <ZodIssue[]> }`
> - The UI client wraps the response in `ApiError` (message = the top-level `error` string) but the create-skill mutation only read `error.message`, so the modal always showed a bare "Validation error" with no field named — even though the offending field (e.g. a tagline over 120 chars) was right there in `details`
> - Users had no way to know what to fix, making the modal feel broken even when the create endpoint was behaving correctly
> - This pull request surfaces the `details` issue list as readable "field: message" lines in the modal error
> - The benefit is a self-explaining validation error that names the field, instead of a dead-end generic message

## Linked Issues or Issue Description

No public GitHub issue exists. Describing the bug inline, following the bug report template:

### What happened

Creating a skill via the "Create a new skill" modal can fail with a generic "Validation error" banner/toast that never says which field is invalid. The create endpoint accepts the same fields when called directly, so the rejected value is one the user cannot see — for example a tagline longer than 120 characters, or an empty category token. The server already returns the Zod `details` issue list, but the UI dropped it and rendered only the top-level `error` string.

### Expected behavior

The modal should name the rejected field (and the constraint) so the user can correct the input, instead of showing only "Validation error".

### Steps to reproduce

1. Open the Skills Store and choose New → Create new skill.
2. Enter a valid name, then set a tagline longer than 120 characters (or any input that violates `companySkillCreateSchema`).
3. Submit the wizard.
4. Observe the error banner reads only "Validation error" with no indication of the offending field.

### Paperclip version or commit

master (reproduced against current `ui/src/pages/CompanySkills.tsx` create-skill flow).

### Deployment mode

Local instance (any deployment; this is a client-side error-reporting bug).

## What Changed

- Add `formatApiError(error, fallback?)` to `ui/src/api/client.ts`. When an `ApiError` carries a Zod `details` array it returns readable `field: message` lines (joined with `; `); otherwise it falls back to the error message and finally to the provided fallback.
- Use `formatApiError` in the create-skill mutation's `onError` in `ui/src/pages/CompanySkills.tsx` so the modal banner and toast name the field.
- Add `ui/src/api/client.test.ts` covering the field-naming, multi-issue join, message fallback, and non-Error fallback paths.

## Verification

- `pnpm --filter @paperclipai/ui exec vitest run src/api/client.test.ts` → 4 passed
- `pnpm --filter @paperclipai/ui exec tsc -b` → clean (exit 0)
- Manual trace: a 400 `{ error: "Validation error", details: [{ path: ["tagline"], message: "String must contain at most 120 character(s)" }] }` now renders as `tagline: String must contain at most 120 character(s)` instead of `Validation error`.

## Risks

Low risk. UI-only, additive helper; no API, schema, or payload changes. Non-validation errors (permission denials, 500s) keep their existing message because the helper falls back to `error.message` when there are no field `details`.

## Model Used

Claude Opus 4.8 (claude-opus-4-8), extended thinking + tool use, via Claude Code.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
