### PR TITLE
fix: serve text/markdown attachments as downloads, not inline

### DIFF
--- a/server/src/__tests__/attachment-types.test.ts
+++ b/server/src/__tests__/attachment-types.test.ts
@@ -122,4 +122,9 @@ describe("isInlineAttachmentContentType", () => {
     expect(isInlineAttachmentContentType("text/html")).toBe(false);
     expect(isInlineAttachmentContentType("application/zip")).toBe(false);
   });
+
+  it("rejects text/markdown because browsers cannot render it inline", () => {
+    expect(INLINE_ATTACHMENT_TYPES).not.toContain("text/markdown");
+    expect(isInlineAttachmentContentType("text/markdown")).toBe(false);
+  });
 });

--- a/server/src/__tests__/issue-attachment-routes.test.ts
+++ b/server/src/__tests__/issue-attachment-routes.test.ts
@@ -478,6 +478,17 @@ describe("issue attachment routes", () => {
     expect(res.headers["content-disposition"]).toBe('attachment; filename="clip.webm"');
   });
 
+  it("serves markdown attachments as downloads (not inline) so webviews do not show a blank screen", async () => {
+    const storage = createStorageService();
+    mockIssueService.getAttachmentById.mockResolvedValue(makeAttachment("text/markdown", "notes.md"));
+
+    const app = await createApp(storage);
+    const res = await request(app).get("/api/attachments/attachment-1/content");
+
+    expect(res.status).toBe(200);
+    expect(res.headers["content-disposition"]).toBe('attachment; filename="notes.md"');
+  });
+
   it("rejects invalid byte ranges without streaming the object", async () => {
     const storage = createStorageService();
     mockIssueService.getAttachmentById.mockResolvedValue(makeAttachment("video/mp4", "clip.mp4"));

--- a/server/src/attachment-types.ts
+++ b/server/src/attachment-types.ts
@@ -44,7 +44,6 @@ export const INLINE_ATTACHMENT_TYPES: readonly string[] = [
   "image/*",
   "application/pdf",
   "text/plain",
-  "text/markdown",
   "application/json",
   "text/csv",
   "video/mp4",


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open-source app people use to manage AI agents at work
> - The attachment serving subsystem controls how files are delivered to clients via `/api/attachments/{id}/content`
> - `INLINE_ATTACHMENT_TYPES` in `server/src/attachment-types.ts` determines which MIME types receive `Content-Disposition: inline` vs `attachment`
> - `text/markdown` was listed as an inline type, but no browser or desktop webview can natively render Markdown — they show a blank screen instead
> - When a Paperclip desktop app user clicks an attachment link for a `.md` file, the webview intercepts the navigation, receives the `inline` response, fails to render it, and displays a blank screen
> - This PR removes `text/markdown` from `INLINE_ATTACHMENT_TYPES` so `.md` files always receive `Content-Disposition: attachment`, triggering a file download dialog
> - The benefit is that users can reliably access generated Markdown documents without encountering blank screens

## Linked Issues or Issue Description

**Bug:** Clicking a `text/markdown` attachment link in the Paperclip desktop app shows a blank screen.

- **What happened:** The `/api/attachments/{id}/content` endpoint served `.md` files with `Content-Disposition: inline`. The desktop app's webview intercepted the navigation and attempted to render the Markdown content natively — which no webview supports — resulting in a blank screen.
- **Expected behavior:** Clicking a `.md` attachment should trigger a file download, not attempt inline rendering.
- **Root cause:** `text/markdown` was included in `INLINE_ATTACHMENT_TYPES`. Unlike `image/*`, `application/pdf`, and `video/*`, Markdown has no native browser/webview renderer.
- **Deployment mode:** Paperclip desktop app (Electron webview)

## What Changed

- Removed `"text/markdown"` from `INLINE_ATTACHMENT_TYPES` in `server/src/attachment-types.ts` — markdown attachments now receive `Content-Disposition: attachment` by default
- Added a unit test to `server/src/__tests__/attachment-types.test.ts` asserting `text/markdown` is not an inline type
- Added an integration test to `server/src/__tests__/issue-attachment-routes.test.ts` asserting that a `.md` attachment is served with `Content-Disposition: attachment; filename="notes.md"`

## Verification

```bash
# Run the targeted test files
pnpm test -- --filter server
```

Manual verification:
1. Upload a `.md` file as an attachment to an issue
2. Click the attachment link in the Paperclip desktop app
3. Confirm a file download dialog appears instead of a blank screen
4. Confirm `?download=1` path still works (unchanged)
5. Confirm images and PDFs still serve inline (unchanged)

## Risks

Low risk. This is a one-line removal from an array constant:

- **Behavioral change:** Users who previously accessed `.md` attachments from a regular browser will now get a download dialog instead of raw text display. This is strictly better UX for Markdown files.
- **No migration needed:** No database changes, no API contract change.
- **Other inline types unaffected:** `text/plain`, `text/csv`, `application/json`, images, PDFs, and videos are unchanged.

## Model Used

- Provider: Anthropic
- Model: Claude Sonnet 4.6 (`claude-sonnet-4-6`)
- Context: 200k token context window
- Capabilities: tool use, code execution

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have described the issue in-PR following the bug report template
- [x] I have not referenced internal/instance-local Paperclip issues or links
- [x] My branch name describes the change and contains no internal ticket ids
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge
