### PR TITLE
Guard pending interaction issues from timer recovery

### DIFF
--- a/server/src/__tests__/issue-monitor-scheduler.test.ts
+++ b/server/src/__tests__/issue-monitor-scheduler.test.ts
@@ -336,7 +336,7 @@ describeEmbeddedPostgres("issue monitor scheduler", () => {
     const result = await heartbeat.tickTimers(tickAt);
 
     expect(result.enqueued).toBe(0);
-    expect(result.skipped).toBe(0);
+    expect(result.skipped).toBe(1);
 
     const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0]!);
     expect(issue.status).toBe("in_review");

--- a/server/src/__tests__/issue-monitor-scheduler.test.ts
+++ b/server/src/__tests__/issue-monitor-scheduler.test.ts
@@ -16,6 +16,7 @@ import {
   heartbeatRuns,
   issueComments,
   issueDocuments,
+  issueThreadInteractions,
   issues,
   workspaceRuntimeServices,
 } from "@paperclipai/db";
@@ -100,6 +101,7 @@ describeEmbeddedPostgres("issue monitor scheduler", () => {
   async function cleanupRows() {
     await waitForHeartbeatSideEffectsSettled();
     await db.delete(heartbeatRunEvents);
+    await db.delete(issueThreadInteractions);
     await db.delete(issueComments);
     await db.delete(documentRevisions);
     await db.delete(issueDocuments);
@@ -314,6 +316,107 @@ describeEmbeddedPostgres("issue monitor scheduler", () => {
       nextCheckAt: nextCheckAt.toISOString(),
       source: "manual",
     });
+  });
+
+  it("does not trigger a due in-review monitor while a pending wake-assignee interaction is waiting", async () => {
+    const { companyId, issueId, agentId, nextCheckAt } = await seedFixture({ issueStatus: "in_review" });
+    const heartbeat = heartbeatService(db);
+    const tickAt = new Date("2026-04-11T12:31:00.000Z");
+
+    await db.insert(issueThreadInteractions).values({
+      companyId,
+      issueId,
+      kind: "request_confirmation",
+      status: "pending",
+      continuationPolicy: "wake_assignee",
+      createdByAgentId: agentId,
+      payload: { version: 1, prompt: "Approve the plan?" },
+    });
+
+    const result = await heartbeat.tickTimers(tickAt);
+
+    expect(result.enqueued).toBe(0);
+    expect(result.skipped).toBe(0);
+
+    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0]!);
+    expect(issue.status).toBe("in_review");
+    expect(issue.monitorNextCheckAt?.toISOString()).toBe(nextCheckAt.toISOString());
+    expect(issue.monitorAttemptCount).toBe(0);
+    expect(parseIssueExecutionState(issue.executionState)?.monitor).toMatchObject({
+      status: "scheduled",
+      nextCheckAt: nextCheckAt.toISOString(),
+      attemptCount: 0,
+    });
+
+    const wakeups = await db.select().from(agentWakeupRequests).where(eq(agentWakeupRequests.agentId, agentId));
+    expect(wakeups).toHaveLength(0);
+
+    const activity = await db
+      .select()
+      .from(activityLog)
+      .where(eq(activityLog.entityId, issueId))
+      .then((rows) => rows.map((row) => row.action));
+    expect(activity).not.toContain("issue.monitor_triggered");
+    expect(activity).not.toContain("issue.monitor_skipped");
+  });
+
+  it("still triggers an in-review monitor when the assignee is the current execution-policy participant", async () => {
+    const { companyId, issueId, agentId } = await seedFixture({ issueStatus: "in_review" });
+    const heartbeat = heartbeatService(db);
+    const tickAt = new Date("2026-04-11T12:31:00.000Z");
+    const stageId = randomUUID();
+
+    await db.insert(issueThreadInteractions).values({
+      companyId,
+      issueId,
+      kind: "request_confirmation",
+      status: "pending",
+      continuationPolicy: "wake_assignee",
+      createdByAgentId: agentId,
+      payload: { version: 1, prompt: "Approve the plan?" },
+    });
+    await db
+      .update(issues)
+      .set({
+        executionState: {
+          status: "pending",
+          currentStageId: stageId,
+          currentStageIndex: 0,
+          currentStageType: "review",
+          currentParticipant: { type: "agent", agentId, userId: null },
+          returnAssignee: null,
+          completedStageIds: [],
+          lastDecisionId: null,
+          lastDecisionOutcome: null,
+          monitor: {
+            status: "scheduled",
+            nextCheckAt: "2026-04-11T12:30:00.000Z",
+            lastTriggeredAt: null,
+            attemptCount: 0,
+            notes: "Check deploy",
+            scheduledBy: "assignee",
+            serviceName: null,
+            externalRef: null,
+            timeoutAt: null,
+            maxAttempts: null,
+            recoveryPolicy: null,
+            clearedAt: null,
+            clearReason: null,
+          },
+        },
+      })
+      .where(eq(issues.id, issueId));
+
+    const result = await heartbeat.tickTimers(tickAt);
+
+    expect(result.enqueued).toBe(1);
+
+    const wakeup = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.agentId, agentId))
+      .then((rows) => rows[0] ?? null);
+    expect(wakeup?.reason).toBe("issue_monitor_due");
   });
 
   it("clears due monitors that cannot be dispatched and records a skip", async () => {

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -5243,6 +5243,21 @@ describeEmbeddedPostgres("issueService.checkout pending interaction guard", () =
     expect(checkedOut.checkoutRunId).toBe(runId);
     expect(checkedOut.executionRunId).toBe(runId);
   });
+
+  it("allows checkout when the claimed heartbeat run is no longer available", async () => {
+    const { agentId, issueId, runId } = await seedPendingInteractionCheckoutFixture({
+      source: "issue.interaction",
+      wakeReason: "issue_commented",
+      interactionId: "interaction-1",
+    });
+    await db.delete(heartbeatRuns).where(eq(heartbeatRuns.id, runId));
+
+    const checkedOut = await svc.checkout(issueId, agentId, ["in_review"], runId);
+
+    expect(checkedOut.status).toBe("in_progress");
+    expect(checkedOut.checkoutRunId).toBe(runId);
+    expect(checkedOut.executionRunId).toBe(runId);
+  });
 });
 
 describeEmbeddedPostgres("accepted plan decomposition", () => {

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -5244,7 +5244,24 @@ describeEmbeddedPostgres("issueService.checkout pending interaction guard", () =
     expect(checkedOut.executionRunId).toBe(runId);
   });
 
-  it("allows checkout when the claimed heartbeat run is no longer available", async () => {
+  it("rejects deleted timer-run checkout when it cannot prove an interaction/comment wake", async () => {
+    const { agentId, issueId, runId } = await seedPendingInteractionCheckoutFixture({
+      source: "scheduler",
+      wakeReason: "heartbeat_timer",
+    });
+    await db.delete(heartbeatRuns).where(eq(heartbeatRuns.id, runId));
+
+    await expect(svc.checkout(issueId, agentId, ["in_review"], runId)).rejects.toMatchObject({
+      status: 409,
+    });
+
+    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0]!);
+    expect(issue.status).toBe("in_review");
+    expect(issue.checkoutRunId).toBeNull();
+    expect(issue.executionRunId).toBeNull();
+  });
+
+  it("rejects deleted interaction/comment-run checkout when its provenance is unavailable", async () => {
     const { agentId, issueId, runId } = await seedPendingInteractionCheckoutFixture({
       source: "issue.interaction",
       wakeReason: "issue_commented",
@@ -5252,11 +5269,14 @@ describeEmbeddedPostgres("issueService.checkout pending interaction guard", () =
     });
     await db.delete(heartbeatRuns).where(eq(heartbeatRuns.id, runId));
 
-    const checkedOut = await svc.checkout(issueId, agentId, ["in_review"], runId);
+    await expect(svc.checkout(issueId, agentId, ["in_review"], runId)).rejects.toMatchObject({
+      status: 409,
+    });
 
-    expect(checkedOut.status).toBe("in_progress");
-    expect(checkedOut.checkoutRunId).toBeNull();
-    expect(checkedOut.executionRunId).toBeNull();
+    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0]!);
+    expect(issue.status).toBe("in_review");
+    expect(issue.checkoutRunId).toBeNull();
+    expect(issue.executionRunId).toBeNull();
   });
 });
 

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -5255,8 +5255,8 @@ describeEmbeddedPostgres("issueService.checkout pending interaction guard", () =
     const checkedOut = await svc.checkout(issueId, agentId, ["in_review"], runId);
 
     expect(checkedOut.status).toBe("in_progress");
-    expect(checkedOut.checkoutRunId).toBe(runId);
-    expect(checkedOut.executionRunId).toBe(runId);
+    expect(checkedOut.checkoutRunId).toBeNull();
+    expect(checkedOut.executionRunId).toBeNull();
   });
 });
 

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -5139,6 +5139,112 @@ describeEmbeddedPostgres("issueService.clearExecutionRunIfTerminal", () => {
   });
 });
 
+describeEmbeddedPostgres("issueService.checkout pending interaction guard", () => {
+  let db!: ReturnType<typeof createDb>;
+  let svc!: ReturnType<typeof issueService>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-issues-pending-interaction-checkout-");
+    db = createDb(tempDb.connectionString);
+    svc = issueService(db);
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.delete(issueThreadInteractions);
+    await db.delete(issues);
+    await db.delete(heartbeatRuns);
+    await db.delete(agents);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  async function seedPendingInteractionCheckoutFixture(contextSnapshot: Record<string, unknown>) {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const issueId = randomUUID();
+    const runId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "CodexCoder",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId,
+      agentId,
+      status: "running",
+      invocationSource: "timer",
+      contextSnapshot,
+    });
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Waiting confirmation",
+      status: "in_review",
+      priority: "medium",
+      assigneeAgentId: agentId,
+    });
+    await db.insert(issueThreadInteractions).values({
+      companyId,
+      issueId,
+      kind: "request_confirmation",
+      status: "pending",
+      continuationPolicy: "wake_assignee",
+      createdByAgentId: agentId,
+      payload: { version: 1, prompt: "Approve the plan?" },
+    });
+
+    return { agentId, issueId, runId };
+  }
+
+  it("rejects timer checkout of an in-review issue waiting on a pending wake-assignee interaction", async () => {
+    const { agentId, issueId, runId } = await seedPendingInteractionCheckoutFixture({
+      source: "scheduler",
+      wakeReason: "heartbeat_timer",
+    });
+
+    await expect(svc.checkout(issueId, agentId, ["in_review"], runId)).rejects.toMatchObject({
+      status: 409,
+    });
+
+    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0]!);
+    expect(issue.status).toBe("in_review");
+    expect(issue.checkoutRunId).toBeNull();
+    expect(issue.executionRunId).toBeNull();
+  });
+
+  it("allows interaction/comment wake checkout of an in-review issue waiting on a pending wake-assignee interaction", async () => {
+    const { agentId, issueId, runId } = await seedPendingInteractionCheckoutFixture({
+      source: "issue.interaction",
+      wakeReason: "issue_commented",
+      interactionId: "interaction-1",
+    });
+
+    const checkedOut = await svc.checkout(issueId, agentId, ["in_review"], runId);
+
+    expect(checkedOut.status).toBe("in_progress");
+    expect(checkedOut.checkoutRunId).toBe(runId);
+    expect(checkedOut.executionRunId).toBe(runId);
+  });
+});
+
 describeEmbeddedPostgres("accepted plan decomposition", () => {
   let db!: ReturnType<typeof createDb>;
   let svc!: ReturnType<typeof issueService>;

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -6515,7 +6515,10 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     let skipped = 0;
 
     for (const due of dueMonitors) {
-      if (await isIssueMonitorSuppressedByPendingInteraction(due)) continue;
+      if (await isIssueMonitorSuppressedByPendingInteraction(due)) {
+        skipped += 1;
+        continue;
+      }
 
       const claimed = await db.transaction(async (tx) => {
         const [updated] = await tx

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -6384,6 +6384,33 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     }
   }
 
+  async function isIssueMonitorSuppressedByPendingInteraction(issue: IssueMonitorDispatchRow) {
+    if (issue.status !== "in_review") return false;
+
+    const executionState = parseIssueExecutionState(issue.executionState);
+    const currentParticipant = executionState?.status === "pending" ? executionState.currentParticipant : null;
+    if (
+      currentParticipant?.type === "agent" &&
+      currentParticipant.agentId === issue.assigneeAgentId
+    ) {
+      return false;
+    }
+
+    return db
+      .select({ id: issueThreadInteractions.id })
+      .from(issueThreadInteractions)
+      .where(
+        and(
+          eq(issueThreadInteractions.companyId, issue.companyId),
+          eq(issueThreadInteractions.issueId, issue.id),
+          eq(issueThreadInteractions.status, "pending"),
+          eq(issueThreadInteractions.continuationPolicy, "wake_assignee"),
+        ),
+      )
+      .limit(1)
+      .then((rows) => Boolean(rows[0]));
+  }
+
   async function triggerIssueMonitor(issueId: string, input?: {
     now?: Date;
     actorType?: "user" | "agent" | "system";
@@ -6488,6 +6515,8 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     let skipped = 0;
 
     for (const due of dueMonitors) {
+      if (await isIssueMonitorSuppressedByPendingInteraction(due)) continue;
+
       const claimed = await db.transaction(async (tx) => {
         const [updated] = await tx
           .update(issues)

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -4667,7 +4667,8 @@ export function issueService(db: Db) {
       .where(and(eq(heartbeatRuns.companyId, issue.companyId), eq(heartbeatRuns.id, input.checkoutRunId)))
       .then((rows) => rows[0] ?? null);
 
-    return !isInteractionOrCommentWakeContext(run?.contextSnapshot ?? null);
+    if (!run) return false;
+    return !isInteractionOrCommentWakeContext(run.contextSnapshot);
   }
 
   return {

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -6640,6 +6640,18 @@ export function issueService(db: Db) {
         });
       }
 
+      // A checkout run can disappear between wake dispatch and this checkout.
+      // Do not persist an unavailable id: issues has a foreign key to
+      // heartbeat_runs, and a missing run cannot hold the checkout lock.
+      if (checkoutRunId) {
+        const run = await db
+          .select({ id: heartbeatRuns.id })
+          .from(heartbeatRuns)
+          .where(and(eq(heartbeatRuns.companyId, issueCompany.companyId), eq(heartbeatRuns.id, checkoutRunId)))
+          .then((rows) => rows[0] ?? null);
+        if (!run) checkoutRunId = null;
+      }
+
       await clearExecutionRunIfTerminal(id);
       await clearCheckoutRunIfTerminal(id);
       if (await isCheckoutSuppressedByPendingInteraction({ issueId: id, agentId, expectedStatuses, checkoutRunId })) {

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -4667,8 +4667,10 @@ export function issueService(db: Db) {
       .where(and(eq(heartbeatRuns.companyId, issue.companyId), eq(heartbeatRuns.id, input.checkoutRunId)))
       .then((rows) => rows[0] ?? null);
 
-    if (!run) return false;
-    return !isInteractionOrCommentWakeContext(run.contextSnapshot);
+    // A missing run cannot prove this was an interaction/comment wake. Keep
+    // the pending-interaction guard closed in that race; the caller still
+    // clears the unavailable id before it can be persisted as a checkout lock.
+    return !isInteractionOrCommentWakeContext(run?.contextSnapshot ?? null);
   }
 
   return {
@@ -6640,6 +6642,11 @@ export function issueService(db: Db) {
         });
       }
 
+      // Preserve the requested run for pending-interaction provenance even if
+      // it disappears before this checkout. The missing id is normalized away
+      // below so it cannot violate the issues -> heartbeat_runs foreign key.
+      const pendingInteractionCheckoutRunId = checkoutRunId;
+
       // A checkout run can disappear between wake dispatch and this checkout.
       // Do not persist an unavailable id: issues has a foreign key to
       // heartbeat_runs, and a missing run cannot hold the checkout lock.
@@ -6654,7 +6661,12 @@ export function issueService(db: Db) {
 
       await clearExecutionRunIfTerminal(id);
       await clearCheckoutRunIfTerminal(id);
-      if (await isCheckoutSuppressedByPendingInteraction({ issueId: id, agentId, expectedStatuses, checkoutRunId })) {
+      if (await isCheckoutSuppressedByPendingInteraction({
+        issueId: id,
+        agentId,
+        expectedStatuses,
+        checkoutRunId: pendingInteractionCheckoutRunId,
+      })) {
         throw conflict("Issue is waiting on a pending issue-thread interaction", {
           issueId: id,
           status: "in_review",

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -79,7 +79,7 @@ import {
   type ParsedExecutionWorkspaceMode,
 } from "./execution-workspace-policy.js";
 import { mergeExecutionWorkspaceConfig } from "./execution-workspaces.js";
-import { buildInitialIssueMonitorFields, normalizeIssueExecutionPolicy } from "./issue-execution-policy.js";
+import { buildInitialIssueMonitorFields, normalizeIssueExecutionPolicy, parseIssueExecutionState } from "./issue-execution-policy.js";
 import { instanceSettingsService } from "./instance-settings.js";
 import { redactCurrentUserText } from "../log-redaction.js";
 import { redactSensitiveText } from "../redaction.js";
@@ -274,6 +274,32 @@ async function resolveResponsibleUserIdForIssueCreate(
   }
 
   return input.createdByUserId ?? null;
+}
+
+function recordHasNonEmptyStringArray(record: unknown, key: string) {
+  if (!record || typeof record !== "object") return false;
+  const value = (record as Record<string, unknown>)[key];
+  return Array.isArray(value) && value.some((item) => typeof item === "string" && item.trim().length > 0);
+}
+
+function issueHasAssigneeReviewTurn(issue: {
+  assigneeAgentId: string | null;
+  executionState: unknown;
+}) {
+  if (!issue.assigneeAgentId) return false;
+  const executionState = parseIssueExecutionState(issue.executionState);
+  const currentParticipant = executionState?.status === "pending" ? executionState.currentParticipant : null;
+  return currentParticipant?.type === "agent" && currentParticipant.agentId === issue.assigneeAgentId;
+}
+
+function isInteractionOrCommentWakeContext(contextSnapshot: unknown) {
+  const context = parseObject(contextSnapshot);
+  const wakeReason = readStringFromRecord(context, "wakeReason") ?? readStringFromRecord(context, "reason");
+  if (wakeReason === "issue_commented" || wakeReason === "issue_reopened_via_comment") return true;
+  if (readStringFromRecord(context, "interactionId")) return true;
+  if (readStringFromRecord(context, "wakeCommentId")) return true;
+  if (recordHasNonEmptyStringArray(context, "wakeCommentIds")) return true;
+  return false;
 }
 
 function buildReusedExecutionWorkspaceConfigPatchFromIssueSettings(
@@ -4593,6 +4619,57 @@ export function issueService(db: Db) {
     });
   }
 
+  async function isCheckoutSuppressedByPendingInteraction(input: {
+    issueId: string;
+    agentId: string;
+    expectedStatuses: string[];
+    checkoutRunId: string | null;
+  }) {
+    if (!input.expectedStatuses.includes("in_review")) return false;
+    if (!input.checkoutRunId) return false;
+
+    const issue = await db
+      .select({
+        id: issues.id,
+        companyId: issues.companyId,
+        status: issues.status,
+        assigneeAgentId: issues.assigneeAgentId,
+        assigneeUserId: issues.assigneeUserId,
+        executionState: issues.executionState,
+      })
+      .from(issues)
+      .where(eq(issues.id, input.issueId))
+      .then((rows) => rows[0] ?? null);
+
+    if (!issue) throw notFound("Issue not found");
+    if (issue.status !== "in_review") return false;
+    if (issue.assigneeUserId || issue.assigneeAgentId !== input.agentId) return false;
+    if (issueHasAssigneeReviewTurn(issue)) return false;
+
+    const pendingWakeInteraction = await db
+      .select({ id: issueThreadInteractions.id })
+      .from(issueThreadInteractions)
+      .where(
+        and(
+          eq(issueThreadInteractions.companyId, issue.companyId),
+          eq(issueThreadInteractions.issueId, issue.id),
+          eq(issueThreadInteractions.status, "pending"),
+          eq(issueThreadInteractions.continuationPolicy, "wake_assignee"),
+        ),
+      )
+      .limit(1)
+      .then((rows) => rows[0] ?? null);
+    if (!pendingWakeInteraction) return false;
+
+    const run = await db
+      .select({ contextSnapshot: heartbeatRuns.contextSnapshot })
+      .from(heartbeatRuns)
+      .where(and(eq(heartbeatRuns.companyId, issue.companyId), eq(heartbeatRuns.id, input.checkoutRunId)))
+      .then((rows) => rows[0] ?? null);
+
+    return !isInteractionOrCommentWakeContext(run?.contextSnapshot ?? null);
+  }
+
   return {
     clearExecutionRunIfTerminal,
     clearCheckoutRunIfTerminal,
@@ -6564,6 +6641,13 @@ export function issueService(db: Db) {
 
       await clearExecutionRunIfTerminal(id);
       await clearCheckoutRunIfTerminal(id);
+      if (await isCheckoutSuppressedByPendingInteraction({ issueId: id, agentId, expectedStatuses, checkoutRunId })) {
+        throw conflict("Issue is waiting on a pending issue-thread interaction", {
+          issueId: id,
+          status: "in_review",
+          continuationPolicy: "wake_assignee",
+        });
+      }
 
       const dependencyReadiness = await listIssueDependencyReadinessMap(db, issueCompany.companyId, [id]);
       const unresolvedBlockerIssueIds = dependencyReadiness.get(id)?.unresolvedBlockerIssueIds ?? [];


### PR DESCRIPTION
## Thinking Path

> - Paperclip coordinates AI agents through issues, heartbeat runs, and issue-thread interactions.
> - A pending `wake_assignee` interaction is a deliberate waiting state, not an execution failure.
> - Timer and recovery paths must not promote that state into active work.
> - Checkout provenance is stored on the heartbeat run, which can be deleted between dispatch and checkout.
> - This PR preserves proven interaction/comment wakes while failing closed when that provenance is unavailable.
> - The result prevents false recovery churn without broadening the approved guard.

## Linked Issues or Issue Description

No public GitHub issue exists for this operational bug. Related but not duplicate: #5517 covers children-completed wakeups for pending interactions, while this PR covers issue-monitor timer dispatch and checkout/recovery promotion.

### Problem or motivation

An assigned issue can correctly remain `in_review` while a pending issue-thread interaction awaits a board/user response. Timer or recovery execution must not re-enter it. A heartbeat-run row can disappear between wake dispatch and checkout, so missing provenance must not become a guard bypass.

### Proposed solution

Suppress pending-interaction checkout promotion unless a retained run context proves an interaction/comment wake. Normalize an unavailable run ID to `null` before persistence while retaining its requested value for the guard decision.

### Alternatives considered

Allowing all missing-run checkouts reintroduces the timer/recovery bypass; persisting a missing run ID violates the foreign-key invariant.

### Roadmap alignment

This is task-orchestration reliability work. I checked `ROADMAP.md` and found no overlapping planned feature or core-work item.

## What Changed

- Added the due-monitor and checkout guards for assigned `in_review` issues with a pending `wake_assignee` interaction.
- Preserved proven interaction/comment wakes and active execution-policy review participants.
- Retained a missing run ID for guard provenance but normalized it to `null` before persistence.
- Added focused deleted timer-run and deleted interaction/comment-run coverage alongside the approved guard matrix.

## Verification

- `pnpm exec vitest run server/src/__tests__/issues-service.test.ts` - passed; embedded-Postgres cases were skipped because its runtime is unavailable in this environment.
- `pnpm --filter @paperclipai/server typecheck` - passed.
- `git diff --check` - passed.
- CI is expected to run for the pushed exact head.

## Risks

- Suppressed timer monitors intentionally leave monitor state unchanged so the issue can be reconsidered after the interaction resolves.
- If a checkout run row is unavailable, its ID is cleared for the foreign key but the pending-interaction guard fails closed because the deleted row cannot prove interaction/comment provenance. This includes a deleted interaction/comment-context run.
- Explicit interaction/comment wakes remain actionable when their persisted heartbeat-run context proves the wake. The behavior change is limited to assigned `in_review` issues with pending `wake_assignee` interactions; normal `todo`/`in_progress` work is unaffected.

## Model Used

OpenAI Codex, GPT-5 family coding/review model with tool use and code execution enabled. The implementation commits are co-authored by Paperclip.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [ ] My branch name describes the change and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge