### PR TITLE
fix(routines): coalesce blocked scheduled executions

### DIFF
--- a/server/src/__tests__/routines-service.test.ts
+++ b/server/src/__tests__/routines-service.test.ts
@@ -969,6 +969,94 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
     expect(inboxIssues.map((issue) => issue.id)).toContain(previousIssue.id);
   });
 
+  it.each([
+    ["blocked", "coalesce_if_active", "coalesced"],
+    ["in_review", "coalesce_if_active", "coalesced"],
+    ["blocked", "skip_if_active", "skipped"],
+  ] as const)(
+    "%s scheduled routine issue without a live heartbeat is %s on the next tick",
+    async (issueStatus, concurrencyPolicy, expectedRunStatus) => {
+      const { companyId, issueSvc, routine, svc, wakeups } = await seedFixture();
+      await db
+        .update(routines)
+        .set({ concurrencyPolicy })
+        .where(eq(routines.id, routine.id));
+
+      const previousRunId = randomUUID();
+      const previousIssue = await issueSvc.create(companyId, {
+        projectId: routine.projectId,
+        title: routine.title,
+        description: routine.description,
+        status: issueStatus,
+        priority: routine.priority,
+        assigneeAgentId: routine.assigneeAgentId,
+        originKind: "routine_execution",
+        originId: routine.id,
+        originRunId: previousRunId,
+      });
+
+      await db.insert(routineRuns).values({
+        id: previousRunId,
+        companyId,
+        routineId: routine.id,
+        triggerId: null,
+        source: "schedule",
+        status: "issue_created",
+        triggeredAt: new Date("2026-03-20T12:00:00.000Z"),
+        linkedIssueId: previousIssue.id,
+        completedAt: new Date("2026-03-20T12:00:00.000Z"),
+      });
+
+      const { trigger } = await svc.createTrigger(
+        routine.id,
+        {
+          kind: "schedule",
+          label: "every two hours",
+          cronExpression: "0 */2 * * *",
+          timezone: "UTC",
+        },
+        {},
+      );
+      await db
+        .update(routineTriggers)
+        .set({ nextRunAt: new Date("2026-03-20T14:00:00.000Z") })
+        .where(eq(routineTriggers.id, trigger.id));
+
+      const result = await svc.tickScheduledTriggers(new Date("2026-03-20T14:00:00.000Z"));
+
+      expect(result.triggered).toBe(1);
+      expect(wakeups).toHaveLength(0);
+
+      const routineIssues = await db
+        .select({ id: issues.id, status: issues.status })
+        .from(issues)
+        .where(eq(issues.originId, routine.id));
+      expect(routineIssues).toEqual([{ id: previousIssue.id, status: issueStatus }]);
+
+      const runs = await db
+        .select()
+        .from(routineRuns)
+        .where(eq(routineRuns.routineId, routine.id));
+      expect(runs).toHaveLength(2);
+      const dedupedRun = runs.find((run) => run.id !== previousRunId);
+      expect(dedupedRun).toMatchObject({
+        source: "schedule",
+        status: expectedRunStatus,
+        linkedIssueId: previousIssue.id,
+        coalescedIntoRunId: previousRunId,
+      });
+
+      const [updatedTrigger] = await db
+        .select({ lastResult: routineTriggers.lastResult, nextRunAt: routineTriggers.nextRunAt })
+        .from(routineTriggers)
+        .where(eq(routineTriggers.id, trigger.id));
+      expect(updatedTrigger?.lastResult).toMatch(new RegExp(expectedRunStatus, "i"));
+      expect(updatedTrigger?.nextRunAt?.getTime()).toBeGreaterThan(
+        new Date("2026-03-20T14:00:00.000Z").getTime(),
+      );
+    },
+  );
+
   it("does not coalesce live routine runs with different resolved variables", async () => {
     const { companyId, agentId, projectId, svc } = await seedFixture();
     const variableRoutine = await svc.create(

--- a/server/src/services/routines.ts
+++ b/server/src/services/routines.ts
@@ -67,6 +67,7 @@ import { logActivity } from "./activity-log.js";
 import type { PluginWorkerManager } from "./plugin-worker-manager.js";
 
 const OPEN_ISSUE_STATUSES = ["backlog", "todo", "in_progress", "in_review", "blocked"];
+const UNRESOLVED_SCHEDULE_COALESCE_STATUSES = ["in_review", "blocked"];
 const LIVE_HEARTBEAT_RUN_STATUSES = ["queued", "running", "scheduled_retry"];
 const TERMINAL_ISSUE_STATUSES = new Set(["done", "cancelled"]);
 const MAX_CATCH_UP_RUNS = 25;
@@ -1241,6 +1242,34 @@ export function routineService(
       .then((rows) => rows[0]?.issues ?? null);
   }
 
+  async function findUnresolvedScheduleExecutionIssue(
+    routine: typeof routines.$inferSelect,
+    executor: Db = db,
+    dispatchFingerprint?: string | null,
+    origin?: { kind: string; id: string | null },
+  ) {
+    const fingerprintCondition = routineExecutionFingerprintCondition(dispatchFingerprint);
+    const originKind = origin?.kind ?? "routine_execution";
+    const originId = origin?.id ?? routine.id;
+
+    return executor
+      .select()
+      .from(issues)
+      .where(
+        and(
+          eq(issues.companyId, routine.companyId),
+          eq(issues.originKind, originKind),
+          eq(issues.originId, originId),
+          inArray(issues.status, UNRESOLVED_SCHEDULE_COALESCE_STATUSES),
+          isNull(issues.hiddenAt),
+          ...(fingerprintCondition ? [fingerprintCondition] : []),
+        ),
+      )
+      .orderBy(desc(issues.updatedAt), desc(issues.createdAt))
+      .limit(1)
+      .then((rows) => rows[0] ?? null);
+  }
+
   async function finalizeRun(runId: string, patch: Partial<typeof routineRuns.$inferInsert>, executor: Db = db) {
     return executor
       .update(routineRuns)
@@ -1507,10 +1536,25 @@ export function routineService(
 
       let createdIssue: Awaited<ReturnType<typeof issueSvc.create>> | null = null;
       try {
-        const activeIssue = await findLiveExecutionIssue(input.routine, txDb, dispatchFingerprint, {
+        const issueOrigin = {
           kind: issueOriginKind,
           id: issueOriginId,
-        });
+        };
+        const activeIssue = await findLiveExecutionIssue(
+          input.routine,
+          txDb,
+          dispatchFingerprint,
+          issueOrigin,
+        ) ?? (
+          input.source === "schedule"
+            ? await findUnresolvedScheduleExecutionIssue(
+              input.routine,
+              txDb,
+              dispatchFingerprint,
+              issueOrigin,
+            )
+            : null
+        );
         if (activeIssue && input.routine.concurrencyPolicy !== "always_enqueue") {
           const status = input.routine.concurrencyPolicy === "skip_if_active" ? "skipped" : "coalesced";
           if (manualRunnerUserId) {


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Scheduled routines turn recurring triggers into execution issues assigned to agents.
> - Routine concurrency already prevents duplicate work while a prior run is live, but the live check is tied to heartbeat run state.
> - A scheduled execution can legitimately end as an open `blocked` or `in_review` issue after its heartbeat is no longer live.
> - When the same scheduled trigger fires again, the current dispatcher can miss that unresolved issue and create another execution issue for the same unresolved external gate.
> - This pull request adds a scheduled-only unresolved execution issue guard after the existing live-run lookup.
> - The benefit is that recurring routines stop piling up duplicate blocked review work while preserving fresh dispatch behavior once the blocker is resolved.

## Linked Issues or Issue Description

No dedicated upstream GitHub issue exists for this exact downstream reproduction, so describing the bug in-PR per the bug-report template.

Related public work:

- Refs #8445 — exact prior draft implementation, still open as draft/unmerged.
- Refs #4770 — adjacent prior work around `coalesce_if_active` and open execution issues.
- Refs #8111 — adjacent prior work around `skip_if_active` and stranded open siblings.

**What happened?**
A downstream weekly scheduled routine that depends on external access credentials repeatedly created new blocked execution issues on later weekly ticks while an equivalent blocked routine execution issue was still open. The actual unblock path was external credential/access work, so each new scheduled tick produced a duplicate blocked task rather than reusing the existing one.

**Expected behavior**
For scheduled routine dispatches, if a same-origin, same-fingerprint routine execution issue is already `blocked` or `in_review`, and the routine policy is not `always_enqueue`, the scheduler should reuse that issue by finalizing the new run as `coalesced` or `skipped` according to the routine concurrency policy. After the existing issue is resolved to a terminal state, future scheduled ticks should create work normally.

**Steps to reproduce**

1. Create a scheduled routine whose `concurrencyPolicy` is `coalesce_if_active` or `skip_if_active`.
2. Let a scheduled tick create a routine execution issue.
3. Mark that issue `blocked` or `in_review` after the owning heartbeat is no longer live.
4. Let the same scheduled trigger fire again with the same dispatch fingerprint.
5. Before this change, a new routine execution issue can be created. After this change, the new run links to the unresolved issue and records `coalesced` or `skipped` in the routine output.

**Paperclip version or commit**
Reproduced against `master` at `e6407b322`.

**Deployment mode**
Self-hosted/local Paperclip routine scheduler. The bug is in core routine dispatch logic and is not deployment-specific.

**Root cause**
`findLiveExecutionIssue` only detects routine execution issues tied to queued/running/scheduled heartbeat runs. Once a scheduled execution issue becomes `blocked` or `in_review`, the heartbeat run is no longer live, so the next scheduled tick can miss the unresolved issue and create another one. The scheduler needed a second scheduled-only lookup for unresolved non-terminal issues that represent the same routine slot.

## What Changed

- Added a scheduled-only unresolved execution issue lookup in `server/src/services/routines.ts` for same-origin, same-fingerprint `blocked` and `in_review` routine execution issues.
- Reused the existing concurrency-policy result path so `coalesce_if_active` records `coalesced`, `skip_if_active` records `skipped`, and both link back to the existing issue/run.
- Preserved current behavior for manual/API/webhook dispatches and for `always_enqueue` routines.
- Added regression coverage for scheduled ticks that encounter `blocked` and `in_review` routine issues without a live heartbeat run.

## Verification

- `pnpm exec vitest run server/src/__tests__/routines-service.test.ts` — 42/42 passed.
- `git diff --check` — clean.
- `pnpm install --frozen-lockfile` — passed.
- `pnpm typecheck` — passed.
- `pnpm build` — passed.

Build emitted existing CSS optimizer and chunk-size warnings, but no failures.

## Risks

Low risk. The behavior change is restricted to scheduled routine dispatches and only checks `blocked`/`in_review` same-fingerprint routine execution issues. A user who wants a fresh scheduled execution while an earlier one is still blocked should resolve or cancel the earlier issue first. No schema or migration changes.

## Model Used

OpenAI Codex, GPT-5-based coding agent in local CLI mode, with repository search, shell execution, tests, typecheck, and build verification. Exact hosted model identifier was not exposed beyond the GPT-5/Codex runtime label.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes (N/A — no public docs describe this internal scheduler edge case)
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
