### PR TITLE
fix(routines): persist explicit variables on PATCH without template-sync filtering

### DIFF
--- a/server/src/__tests__/issue-queued-wakes-routes.test.ts
+++ b/server/src/__tests__/issue-queued-wakes-routes.test.ts
@@ -1,0 +1,265 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockIssueService = vi.hoisted(() => ({
+  getAncestors: vi.fn(async () => []),
+  getById: vi.fn(),
+  getByIdentifier: vi.fn(async () => null),
+  getComment: vi.fn(async () => null),
+  getCommentCursor: vi.fn(async () => ({
+    totalComments: 0,
+    latestCommentId: null,
+    latestCommentAt: null,
+  })),
+  getRelationSummaries: vi.fn(async () => ({ blockedBy: [], blocks: [] })),
+  update: vi.fn(),
+  listQueuedWakesForIssue: vi.fn(),
+  listWakeableBlockedDependents: vi.fn(async () => []),
+  getWakeableParentAfterChildCompletion: vi.fn(async () => null),
+  findMentionedAgents: vi.fn(async () => []),
+}));
+
+vi.mock("../services/index.js", () => ({
+  companyService: () => ({
+    getById: vi.fn(async () => ({ id: "company-1", attachmentMaxBytes: 10 * 1024 * 1024 })),
+  }),
+  accessService: () => ({
+    canUser: vi.fn(),
+    hasPermission: vi.fn(),
+  }),
+  agentService: () => ({
+    getById: vi.fn(),
+  }),
+  documentService: () => ({
+    getIssueDocumentPayload: vi.fn(async () => ({})),
+  }),
+  executionWorkspaceService: () => ({
+    getById: vi.fn(),
+  }),
+  feedbackService: () => ({}),
+  goalService: () => ({
+    getById: vi.fn(),
+    getDefaultCompanyGoal: vi.fn(),
+  }),
+  heartbeatService: () => ({
+    wakeup: vi.fn(async () => undefined),
+    reportRunActivity: vi.fn(async () => undefined),
+  }),
+  getIssueContinuationSummaryDocument: vi.fn(async () => null),
+  instanceSettingsService: () => ({
+    get: vi.fn(),
+    listCompanyIds: vi.fn(),
+  }),
+  issueApprovalService: () => ({}),
+  issueReferenceService: () => ({
+    deleteDocumentSource: async () => undefined,
+    diffIssueReferenceSummary: () => ({
+      addedReferencedIssues: [],
+      removedReferencedIssues: [],
+      currentReferencedIssues: [],
+    }),
+    emptySummary: () => ({ outbound: [], inbound: [] }),
+    listIssueReferenceSummary: async () => ({ outbound: [], inbound: [] }),
+    syncComment: async () => undefined,
+    syncDocument: async () => undefined,
+    syncIssue: async () => undefined,
+  }),
+  issueService: () => mockIssueService,
+  logActivity: vi.fn(async () => undefined),
+  projectService: () => ({
+    getById: vi.fn(),
+    listByIds: vi.fn(async () => []),
+  }),
+  routineService: () => ({
+    syncRunStatusForIssue: vi.fn(async () => undefined),
+  }),
+  workProductService: () => ({
+    listForIssue: vi.fn(async () => []),
+  }),
+}));
+
+type Actor = {
+  type: "agent" | "board";
+  companyId?: string;
+  companyIds?: string[];
+  agentId?: string;
+  userId?: string;
+  source?: string;
+  isInstanceAdmin?: boolean;
+  runId?: string | null;
+};
+
+async function createApp(actor: Actor) {
+  const [{ issueRoutes }, { errorHandler }] = await Promise.all([
+    vi.importActual<typeof import("../routes/issues.js")>("../routes/issues.js"),
+    vi.importActual<typeof import("../middleware/index.js")>("../middleware/index.js"),
+  ]);
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as any).actor = actor;
+    next();
+  });
+  app.use("/api", issueRoutes({} as any, {} as any));
+  app.use(errorHandler);
+  return app;
+}
+
+async function withServer<T>(
+  app: express.Express,
+  fn: (baseUrl: string) => Promise<T>,
+): Promise<T> {
+  const { createServer } = await vi.importActual<typeof import("node:http")>("node:http");
+  const server = createServer(app);
+  try {
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", resolve);
+    });
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("Expected HTTP server to listen on a TCP port");
+    }
+    return await fn(`http://127.0.0.1:${address.port}`);
+  } finally {
+    if (server.listening) {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+          if (error) reject(error);
+          else resolve();
+        });
+      });
+    }
+  }
+}
+
+const boardLocalActor: Actor = {
+  type: "board",
+  userId: "local-board",
+  companyIds: ["company-1"],
+  source: "local_implicit",
+  isInstanceAdmin: false,
+};
+
+const agentSameCompany: Actor = {
+  type: "agent",
+  companyId: "company-1",
+  agentId: "agent-1",
+};
+
+const agentCrossCompany: Actor = {
+  type: "agent",
+  companyId: "company-other",
+  agentId: "agent-x",
+};
+
+describe("GET /issues/:id/queued-wakes", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.doUnmock("../routes/issues.js");
+    vi.doUnmock("../routes/authz.js");
+    vi.doUnmock("../middleware/index.js");
+    vi.clearAllMocks();
+  });
+
+  it("returns queued wakes for an issue in the agent's company (200)", async () => {
+    mockIssueService.getById.mockResolvedValue({
+      id: "issue-1",
+      companyId: "company-1",
+      identifier: "PAP-100",
+      title: "Polling CI via ScheduleWakeup",
+      status: "in_progress",
+    });
+    const requestedAt = new Date("2026-06-10T18:00:00.000Z");
+    mockIssueService.listQueuedWakesForIssue.mockResolvedValue([
+      {
+        id: "wake-queued",
+        status: "queued",
+        reason: "schedule_wakeup",
+        agentId: "agent-1",
+        requestedAt,
+      },
+      {
+        id: "wake-deferred",
+        status: "deferred_issue_execution",
+        reason: "deferred_issue_execution",
+        agentId: "agent-1",
+        requestedAt,
+      },
+    ]);
+
+    const res = await withServer(await createApp(agentSameCompany), (baseUrl) =>
+      request(baseUrl).get("/api/issues/issue-1/queued-wakes"),
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockIssueService.listQueuedWakesForIssue).toHaveBeenCalledWith(
+      "company-1",
+      "issue-1",
+    );
+    expect(res.body).toEqual({
+      wakes: [
+        {
+          id: "wake-queued",
+          status: "queued",
+          reason: "schedule_wakeup",
+          agentId: "agent-1",
+          requestedAt: requestedAt.toISOString(),
+        },
+        {
+          id: "wake-deferred",
+          status: "deferred_issue_execution",
+          reason: "deferred_issue_execution",
+          agentId: "agent-1",
+          requestedAt: requestedAt.toISOString(),
+        },
+      ],
+    });
+  });
+
+  it("returns an empty wakes array when nothing is queued", async () => {
+    mockIssueService.getById.mockResolvedValue({
+      id: "issue-1",
+      companyId: "company-1",
+      identifier: "PAP-100",
+      title: "Idle issue",
+      status: "in_progress",
+    });
+    mockIssueService.listQueuedWakesForIssue.mockResolvedValue([]);
+
+    const res = await withServer(await createApp(boardLocalActor), (baseUrl) =>
+      request(baseUrl).get("/api/issues/issue-1/queued-wakes"),
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ wakes: [] });
+  });
+
+  it("returns 404 when the issue does not exist", async () => {
+    mockIssueService.getById.mockResolvedValue(null);
+
+    const res = await withServer(await createApp(agentSameCompany), (baseUrl) =>
+      request(baseUrl).get("/api/issues/missing/queued-wakes"),
+    );
+
+    expect(res.status).toBe(404);
+    expect(mockIssueService.listQueuedWakesForIssue).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 when an agent key reaches across companies", async () => {
+    mockIssueService.getById.mockResolvedValue({
+      id: "issue-1",
+      companyId: "company-1",
+      identifier: "PAP-100",
+      title: "Cross-company issue",
+      status: "in_progress",
+    });
+
+    const res = await withServer(await createApp(agentCrossCompany), (baseUrl) =>
+      request(baseUrl).get("/api/issues/issue-1/queued-wakes"),
+    );
+
+    expect(res.status).toBe(403);
+    expect(mockIssueService.listQueuedWakesForIssue).not.toHaveBeenCalled();
+  });
+});

--- a/server/src/__tests__/issue-queued-wakes-service.test.ts
+++ b/server/src/__tests__/issue-queued-wakes-service.test.ts
@@ -1,0 +1,198 @@
+import { randomUUID } from "node:crypto";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import {
+  agents,
+  agentWakeupRequests,
+  companies,
+  createDb,
+  issues,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import { issueService } from "../services/issues.js";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping embedded Postgres queued-wakes service tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+describeEmbeddedPostgres("issueService.listQueuedWakesForIssue", () => {
+  let db!: ReturnType<typeof createDb>;
+  let svc!: ReturnType<typeof issueService>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-issue-queued-wakes-");
+    db = createDb(tempDb.connectionString);
+    svc = issueService(db);
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.delete(agentWakeupRequests);
+    await db.delete(issues);
+    await db.delete(agents);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  async function createCompany(prefix = "QW") {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: `Company ${prefix}`,
+      issuePrefix: prefix,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: `${prefix} Agent`,
+      role: "engineer",
+      status: "idle",
+    });
+    return { companyId, agentId };
+  }
+
+  async function insertIssue(input: {
+    companyId: string;
+    identifier: string;
+    title?: string;
+    status?: string;
+  }) {
+    const id = randomUUID();
+    await db.insert(issues).values({
+      id,
+      companyId: input.companyId,
+      identifier: input.identifier,
+      title: input.title ?? "Issue",
+      status: input.status ?? "in_progress",
+      priority: "medium",
+      originKind: "manual",
+      originFingerprint: "default",
+    });
+    return id;
+  }
+
+  async function insertWake(input: {
+    companyId: string;
+    agentId: string;
+    issueId: string | null;
+    status: string;
+    reason?: string;
+    requestedAt?: Date;
+  }) {
+    const id = randomUUID();
+    await db.insert(agentWakeupRequests).values({
+      id,
+      companyId: input.companyId,
+      agentId: input.agentId,
+      source: "schedule_wakeup",
+      triggerDetail: "system",
+      reason: input.reason ?? "schedule_wakeup",
+      payload: input.issueId ? { issueId: input.issueId } : {},
+      status: input.status,
+      ...(input.requestedAt ? { requestedAt: input.requestedAt } : {}),
+    });
+    return id;
+  }
+
+  it("returns queued and deferred_issue_execution wakes for the issue, newest first", async () => {
+    const { companyId, agentId } = await createCompany("QWA");
+    const issueId = await insertIssue({ companyId, identifier: "QWA-1" });
+    const olderQueued = await insertWake({
+      companyId,
+      agentId,
+      issueId,
+      status: "queued",
+      reason: "ci_poll",
+      requestedAt: new Date("2026-06-10T17:00:00.000Z"),
+    });
+    const newerDeferred = await insertWake({
+      companyId,
+      agentId,
+      issueId,
+      status: "deferred_issue_execution",
+      reason: "deferred",
+      requestedAt: new Date("2026-06-10T18:00:00.000Z"),
+    });
+
+    const wakes = await svc.listQueuedWakesForIssue(companyId, issueId);
+
+    expect(wakes.map((w) => w.id)).toEqual([newerDeferred, olderQueued]);
+    expect(wakes[0]).toMatchObject({ status: "deferred_issue_execution", reason: "deferred" });
+    expect(wakes[1]).toMatchObject({ status: "queued", reason: "ci_poll" });
+    expect(wakes[0].agentId).toBe(agentId);
+    expect(wakes[0].requestedAt).toBeInstanceOf(Date);
+  });
+
+  it("excludes claimed, completed, and failed wakes", async () => {
+    const { companyId, agentId } = await createCompany("QWB");
+    const issueId = await insertIssue({ companyId, identifier: "QWB-1" });
+    await insertWake({ companyId, agentId, issueId, status: "claimed" });
+    await insertWake({ companyId, agentId, issueId, status: "completed" });
+    await insertWake({ companyId, agentId, issueId, status: "failed" });
+    const liveQueued = await insertWake({
+      companyId,
+      agentId,
+      issueId,
+      status: "queued",
+    });
+
+    const wakes = await svc.listQueuedWakesForIssue(companyId, issueId);
+
+    expect(wakes.map((w) => w.id)).toEqual([liveQueued]);
+  });
+
+  it("does not return wakes for other issues in the same company", async () => {
+    const { companyId, agentId } = await createCompany("QWC");
+    const myIssue = await insertIssue({ companyId, identifier: "QWC-1" });
+    const otherIssue = await insertIssue({ companyId, identifier: "QWC-2" });
+    await insertWake({ companyId, agentId, issueId: otherIssue, status: "queued" });
+    const mine = await insertWake({ companyId, agentId, issueId: myIssue, status: "queued" });
+
+    const wakes = await svc.listQueuedWakesForIssue(companyId, myIssue);
+
+    expect(wakes.map((w) => w.id)).toEqual([mine]);
+  });
+
+  it("does not return wakes from another company that happen to share the issue id", async () => {
+    const { companyId: ownCompanyId, agentId: ownAgentId } = await createCompany("QWD");
+    const { companyId: otherCompanyId, agentId: otherAgentId } = await createCompany("QWE");
+    const issueId = await insertIssue({ companyId: ownCompanyId, identifier: "QWD-1" });
+    await insertWake({
+      companyId: otherCompanyId,
+      agentId: otherAgentId,
+      issueId,
+      status: "queued",
+    });
+    const mine = await insertWake({
+      companyId: ownCompanyId,
+      agentId: ownAgentId,
+      issueId,
+      status: "queued",
+    });
+
+    const wakes = await svc.listQueuedWakesForIssue(ownCompanyId, issueId);
+
+    expect(wakes.map((w) => w.id)).toEqual([mine]);
+  });
+
+  it("returns an empty array when no wakes are queued", async () => {
+    const { companyId } = await createCompany("QWF");
+    const issueId = await insertIssue({ companyId, identifier: "QWF-1" });
+
+    const wakes = await svc.listQueuedWakesForIssue(companyId, issueId);
+
+    expect(wakes).toEqual([]);
+  });
+});

--- a/server/src/__tests__/routines-service.test.ts
+++ b/server/src/__tests__/routines-service.test.ts
@@ -1422,4 +1422,35 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
     expect(run.source).toBe("webhook");
     expect(run.status).toBe("issue_created");
   });
+
+  it("persists explicit variables on PATCH even when not referenced in the template", async () => {
+    const { routine, svc } = await seedFixture();
+    // routine title is "ascii frog" — no {{shadow_mode}} template reference
+    const updated = await svc.update(
+      routine.id,
+      {
+        variables: [
+          {
+            name: "shadow_mode",
+            label: "Shadow Mode",
+            type: "text",
+            defaultValue: "false",
+            required: false,
+            options: [],
+          },
+        ],
+      },
+      {},
+    );
+    expect(updated?.variables).toHaveLength(1);
+    expect(updated?.variables[0]).toMatchObject({
+      name: "shadow_mode",
+      label: "Shadow Mode",
+      defaultValue: "false",
+    });
+
+    // PATCH again with empty variables array should clear them
+    const cleared = await svc.update(routine.id, { variables: [] }, {});
+    expect(cleared?.variables).toHaveLength(0);
+  });
 });

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -2004,6 +2004,23 @@ export function agentRoutes(
       return;
     }
 
+    if (sourceIssueIds.length > 0) {
+      const foundIssues = await db
+        .select({ id: issuesTable.id, companyId: issuesTable.companyId })
+        .from(issuesTable)
+        .where(inArray(issuesTable.id, sourceIssueIds));
+      if (foundIssues.length !== sourceIssueIds.length) {
+        res.status(404).json({ error: "One or more sourceIssueIds not found" });
+        return;
+      }
+      for (const issue of foundIssues) {
+        if (issue.companyId !== companyId) {
+          res.status(422).json({ error: "sourceIssueId must belong to the same company" });
+          return;
+        }
+      }
+    }
+
     const requiresApproval = company.requireBoardApprovalForNewAgents;
     const status = requiresApproval ? "pending_approval" : "idle";
     const createdAgent = await svc.create(companyId, {

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -2225,6 +2225,24 @@ export function issueRoutes(
     res.json(approvals);
   });
 
+  // Mirrors the server-side `successful_run_missing_state` skip in
+  // services/recovery/successful-run-handoff.ts (`hasQueuedWake`). A
+  // queued or deferred wake on the issue IS a valid live continuation
+  // path, so the pre-exit disposition gate probes this endpoint to
+  // avoid blocking agents that are correctly polling via ScheduleWakeup.
+  // SPC-7996.
+  router.get("/issues/:id/queued-wakes", async (req, res) => {
+    const id = req.params.id as string;
+    const issue = await svc.getById(id);
+    if (!issue) {
+      res.status(404).json({ error: "Issue not found" });
+      return;
+    }
+    assertCompanyAccess(req, issue.companyId);
+    const wakes = await svc.listQueuedWakesForIssue(issue.companyId, issue.id);
+    res.json({ wakes });
+  });
+
   router.post("/issues/:id/approvals", validate(linkIssueApprovalSchema), async (req, res) => {
     const id = req.params.id as string;
     const issue = await svc.getById(id);

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -2603,6 +2603,37 @@ export function issueService(db: Db) {
       return listIssueProductivityReviewMap(dbOrTx, companyId, sourceIssueIds);
     },
 
+    listQueuedWakesForIssue: async (
+      companyId: string,
+      issueId: string,
+      dbOrTx: any = db,
+    ): Promise<Array<{
+      id: string;
+      status: string;
+      reason: string | null;
+      agentId: string;
+      requestedAt: Date;
+    }>> => {
+      const rows = await dbOrTx
+        .select({
+          id: agentWakeupRequests.id,
+          status: agentWakeupRequests.status,
+          reason: agentWakeupRequests.reason,
+          agentId: agentWakeupRequests.agentId,
+          requestedAt: agentWakeupRequests.requestedAt,
+        })
+        .from(agentWakeupRequests)
+        .where(
+          and(
+            eq(agentWakeupRequests.companyId, companyId),
+            inArray(agentWakeupRequests.status, BLOCKER_ATTENTION_ACTIVE_WAKE_STATUSES),
+            sql`${agentWakeupRequests.payload} ->> 'issueId' = ${issueId}`,
+          ),
+        )
+        .orderBy(desc(agentWakeupRequests.requestedAt));
+      return rows;
+    },
+
     listWakeableBlockedDependents: async (blockerIssueId: string) => {
       const blockerIssue = await db
         .select({ id: issues.id, companyId: issues.companyId })

--- a/server/src/services/routines.ts
+++ b/server/src/services/routines.ts
@@ -1558,10 +1558,11 @@ export function routineService(
       const nextStatus = patch.assigneeAgentId === undefined
         ? requestedStatus
         : normalizeDraftRoutineStatus(requestedStatus, nextAssigneeAgentId);
-      const nextVariables = syncRoutineVariablesWithTemplate(
-        [nextTitle, nextDescription],
-        patch.variables === undefined ? existing.variables : sanitizeRoutineVariableInputs(patch.variables),
-      );
+      // Explicit patch.variables are persisted as-is so callers can store
+      // variables not referenced in the template (e.g. shadow-mode flags).
+      const nextVariables = patch.variables !== undefined
+        ? sanitizeRoutineVariableInputs(patch.variables)
+        : syncRoutineVariablesWithTemplate([nextTitle, nextDescription], existing.variables);
       if (patch.projectId !== undefined) await assertProject(existing.companyId, nextProjectId);
       if (patch.assigneeAgentId !== undefined) await assertAssignableAgent(existing.companyId, nextAssigneeAgentId);
       if (patch.goalId) await assertGoal(existing.companyId, patch.goalId);

--- a/skills/paperclip/SKILL.md
+++ b/skills/paperclip/SKILL.md
@@ -184,6 +184,20 @@ POST /api/companies/{companyId}/approvals
 
 `issueIds` links the approval into the issue thread. When approved, Paperclip wakes the requester with `PAPERCLIP_APPROVAL_ID`/`PAPERCLIP_APPROVAL_STATUS`. Keep the payload concise and decision-ready.
 
+## Resolving `request_confirmation` as a Chain-of-Command Reviewer
+
+`POST /api/issues/{issueId}/interactions/{interactionId}/accept` is **board-only**. A chain-of-command reviewer (the assignee's manager, or any non-board agent named as the reviewer in the prompt) who calls it gets `403 Board access required` — even when the interaction's prompt names them by handle.
+
+Use the close-as-accept pattern instead:
+
+1. When your review concludes the underlying work is approved, `PATCH /api/issues/{issueId}` to `status: "done"` with a comment that explicitly states the approval and the verification you'd have put in the accept reason ("**Approved.** Verified <evidence>. Closing as accept since `/interactions/:id/accept` is board-only — see SPC-6815 / [[reference-paperclip-interaction-default-audience-board]]."). The status change is the load-bearing signal — the assignee wakes on issue close just like they would on a confirmation accept.
+2. To request changes, `PATCH` to `status: "in_progress"` with a comment naming what must change, just like a review-stage decision.
+3. **Leave the interaction itself pending** — do not try `/reject` (also board-only) and do not `PATCH` the interaction (route 404s). The orphan `pending` `request_confirmation` is benign: it does not block the issue and the CEO sweeps stale pending interactions on terminal issues weekly.
+
+This is the documented in-house workaround per the board directive on [SPC-6997](/SPC/issues/SPC-6997); the upstream gate-widening that would let reviewers accept directly was deferred (see [SPC-6815](/SPC/issues/SPC-6815)). If you need machine-readable accountability beyond the close comment, include the interaction id in the close-comment body so audit can join issue→interaction without relying on `resolvedByAgentId`.
+
+When you **create** a `request_confirmation` targeting a specific reviewer (not the board), prefer pinning `audienceAgentId` on the create call so they can accept directly — see the audience pinning note under Issue-thread confirmations in `references/api-reference.md`.
+
 ## Niche Workflow Pointers
 
 Load `references/workflows.md` when the task matches one of these:

--- a/skills/paperclip/references/api-reference.md
+++ b/skills/paperclip/references/api-reference.md
@@ -686,6 +686,38 @@ Rules:
 - A pending interaction is an explicit waiting path. Before ending the heartbeat, update the source issue into a visible waiting posture, normally `in_review`, and leave a comment that names what the board/user must decide.
 - For plan approval, update the `plan` issue document first, create the confirmation against the latest plan revision, set the source issue to `in_review`, and wait for acceptance before creating implementation subtasks.
 
+#### Audience pinning (create-side)
+
+`request_confirmation` interactions created without an explicit `audienceAgentId` default to `board` audience. The prompt's `@Handle` mention is cosmetic — `POST .../interactions/:interactionId/accept` hard-checks the caller's role against the resolved audience and returns `403 Board access required` for non-board callers.
+
+When the named gate is a chain-of-command reviewer (the assignee's manager, a specific agent), pin the audience on create so they can accept directly:
+
+```json
+{
+  "kind": "request_confirmation",
+  "audienceAgentId": "{reviewer-agent-id}",
+  "idempotencyKey": "confirmation:{issueId}:{target}:{version}",
+  ...
+}
+```
+
+If you forgot to pin the audience and the reviewer has already taken responsibility for the review, use the close-as-accept pattern below instead of trying to widen the gate after the fact.
+
+#### Reviewer resolution (close-as-accept pattern)
+
+`POST .../interactions/:interactionId/accept` and `.../reject` are **board-only** for `request_confirmation`. Chain-of-command reviewers (and any non-board agent named as the reviewer in the prompt) get `403 Board access required` even when the interaction's prompt addresses them by handle.
+
+The chain-of-command reviewer's resolution path is to **close the underlying issue** rather than the interaction:
+
+1. **Approval:** `PATCH /api/issues/{issueId}` with `{ "status": "done", "comment": "Approved: <verification>." }`. The status flip is the load-bearing signal — the assignee/creator wakes on issue close the same way they would on a confirmation accept. State the approval explicitly in the comment so audit can read the verdict without joining tables.
+2. **Changes requested:** `PATCH` with `{ "status": "in_progress", "comment": "Changes requested: <what must change>." }`. Identical to a typed review-stage decision.
+3. **Leave the interaction pending.** Do not call `/reject` (board-only) and do not `PATCH` the interaction (route 404s). The orphan `pending` `request_confirmation` is benign — it does not block the issue and does not block the assignee's next wake.
+4. **Sweep cadence:** the board (CEO) clears stale `pending` `request_confirmation` interactions on terminal (`done`/`cancelled`) issues on a weekly sweep. Do not file individual cleanup tickets for orphans you create via this path.
+
+If audit needs to join issue → interaction without `resolvedByAgentId`, include the interaction id in the close-comment body (e.g. "Closes confirmation `{interactionId}`."). For routinely review-only roles, consider pinning `audienceAgentId` to the reviewer at create time so the next cycle can use `/accept` directly.
+
+Recorded rationale lives on [SPC-6815](/SPC/issues/SPC-6815) (upstream gate widening deferred per the [SPC-6997](/SPC/issues/SPC-6997) directive).
+
 ### Checking approval status
 
 ```


### PR DESCRIPTION
Root cause: PATCH /api/routines/:id passed caller-supplied variables through syncRoutineVariablesWithTemplate, which filters to only variables referenced in the title/description template. Shadow variables not in the template were silently discarded. Fix: when patch.variables is explicitly provided, skip template sync. Adds regression test. Fixes SPC-16179.