### PR TITLE
fix: require explicit terminal comment reopen intent

### DIFF
--- a/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
+++ b/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
@@ -662,7 +662,7 @@ describeEmbeddedPostgres("heartbeat comment wake batching", () => {
     }
   }, 120_000);
 
-  it("promotes deferred comment wakes after the active run closes the issue", async () => {
+  it("promotes deferred comment wakes after the active run closes the issue without reopening it", async () => {
     const gateway = await createControlledGatewayServer();
     const companyId = randomUUID();
     const agentId = randomUUID();
@@ -702,7 +702,7 @@ describeEmbeddedPostgres("heartbeat comment wake batching", () => {
       await db.insert(issues).values({
         id: issueId,
         companyId,
-        title: "Reopen after deferred comment",
+        title: "Terminal deferred comment",
         status: "todo",
         priority: "medium",
         assigneeAgentId: agentId,
@@ -820,7 +820,7 @@ describeEmbeddedPostgres("heartbeat comment wake batching", () => {
         );
       }, 90_000);
 
-      const reopenedIssue = await db
+      const terminalIssue = await db
         .select({
           status: issues.status,
           completedAt: issues.completedAt,
@@ -829,10 +829,10 @@ describeEmbeddedPostgres("heartbeat comment wake batching", () => {
         .where(eq(issues.id, issueId))
         .then((rows) => rows[0] ?? null);
 
-      expect(reopenedIssue).toMatchObject({
-        status: "in_progress",
-        completedAt: null,
+      expect(terminalIssue).toMatchObject({
+        status: "done",
       });
+      expect(terminalIssue?.completedAt).not.toBeNull();
 
       const secondPayload = gateway.getAgentPayloads()[1] ?? {};
       expect(secondPayload.paperclip).toBeUndefined();
@@ -844,8 +844,8 @@ describeEmbeddedPostgres("heartbeat comment wake batching", () => {
         issue: {
           id: issueId,
           identifier: `${issuePrefix}-1`,
-          title: "Reopen after deferred comment",
-          status: "in_progress",
+          title: "Terminal deferred comment",
+          status: "done",
           priority: "medium",
         },
       });
@@ -1402,7 +1402,7 @@ describeEmbeddedPostgres("heartbeat comment wake batching", () => {
     }
   }, 120_000);
 
-  it("still reopens a finished issue when a deferred batch mixes self-authored and human comments", async () => {
+  it("keeps a finished issue terminal when a deferred batch mixes self-authored and human comments", async () => {
     const gateway = await createControlledGatewayServer();
     const companyId = randomUUID();
     const agentId = randomUUID();
@@ -1442,7 +1442,7 @@ describeEmbeddedPostgres("heartbeat comment wake batching", () => {
       await db.insert(issues).values({
         id: issueId,
         companyId,
-        title: "Human follow-up must survive mixed deferred batches",
+        title: "Mixed deferred comments stay terminal",
         status: "todo",
         priority: "medium",
         assigneeAgentId: agentId,
@@ -1587,9 +1587,9 @@ describeEmbeddedPostgres("heartbeat comment wake batching", () => {
         .then((rows) => rows[0] ?? null);
 
       expect(issueAfterPromotion).toMatchObject({
-        status: "in_progress",
-        completedAt: null,
+        status: "done",
       });
+      expect(issueAfterPromotion?.completedAt).not.toBeNull();
 
       const secondPayload = gateway.getAgentPayloads()[1] ?? {};
       expect(secondPayload.paperclip).toBeUndefined();
@@ -1601,8 +1601,8 @@ describeEmbeddedPostgres("heartbeat comment wake batching", () => {
         issue: {
           id: issueId,
           identifier: `${issuePrefix}-1`,
-          title: "Human follow-up must survive mixed deferred batches",
-          status: "in_progress",
+          title: "Mixed deferred comments stay terminal",
+          status: "done",
           priority: "medium",
         },
       });

--- a/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
+++ b/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
@@ -830,6 +830,185 @@ describeEmbeddedPostgres("heartbeat comment wake batching", () => {
     }
   }, 120_000);
 
+  it("suppresses deferred comment wakes for terminal routine execution issues", async () => {
+    const gateway = await createControlledGatewayServer();
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const issueId = randomUUID();
+    const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+    const heartbeat = heartbeatService(db);
+
+    try {
+      await db.insert(companies).values({
+        id: companyId,
+        name: "Paperclip",
+        issuePrefix,
+        requireBoardApprovalForNewAgents: false,
+      });
+
+      await db.insert(agents).values({
+        id: agentId,
+        companyId,
+        name: "Gateway Agent",
+        role: "engineer",
+        status: "idle",
+        adapterType: "openclaw_gateway",
+        adapterConfig: {
+          url: gateway.url,
+          headers: {
+            "x-openclaw-token": "gateway-token",
+          },
+          payloadTemplate: {
+            message: "wake now",
+          },
+          waitTimeoutMs: 2_000,
+        },
+        runtimeConfig: {},
+        permissions: {},
+      });
+
+      await db.insert(issues).values({
+        id: issueId,
+        companyId,
+        title: "Routine execution should stay terminal",
+        status: "todo",
+        priority: "medium",
+        assigneeAgentId: agentId,
+        issueNumber: 1,
+        identifier: `${issuePrefix}-1`,
+        originKind: "routine_execution",
+      });
+
+      const comment1 = await db
+        .insert(issueComments)
+        .values({
+          companyId,
+          issueId,
+          authorUserId: "user-1",
+          body: "First routine comment",
+        })
+        .returning()
+        .then((rows) => rows[0]);
+
+      const firstRun = await heartbeat.wakeup(agentId, {
+        source: "automation",
+        triggerDetail: "system",
+        reason: "issue_commented",
+        payload: { issueId, commentId: comment1.id },
+        contextSnapshot: {
+          issueId,
+          taskId: issueId,
+          commentId: comment1.id,
+          wakeReason: "issue_commented",
+        },
+        requestedByActorType: "user",
+        requestedByActorId: "user-1",
+      });
+
+      expect(firstRun).not.toBeNull();
+      await waitFor(async () => {
+        const run = await db
+          .select({ status: heartbeatRuns.status })
+          .from(heartbeatRuns)
+          .where(eq(heartbeatRuns.id, firstRun!.id))
+          .then((rows) => rows[0] ?? null);
+        return run?.status === "running";
+      });
+
+      const comment2 = await db
+        .insert(issueComments)
+        .values({
+          companyId,
+          issueId,
+          authorUserId: "user-1",
+          body: "This should stay history-only",
+        })
+        .returning()
+        .then((rows) => rows[0]);
+
+      const deferredRun = await heartbeat.wakeup(agentId, {
+        source: "automation",
+        triggerDetail: "system",
+        reason: "issue_commented",
+        payload: { issueId, commentId: comment2.id },
+        contextSnapshot: {
+          issueId,
+          taskId: issueId,
+          commentId: comment2.id,
+          wakeReason: "issue_commented",
+        },
+        requestedByActorType: "user",
+        requestedByActorId: "user-1",
+      });
+
+      expect(deferredRun).toBeNull();
+
+      await db
+        .update(issues)
+        .set({
+          status: "done",
+          completedAt: new Date(),
+          executionRunId: null,
+          executionAgentNameKey: null,
+          executionLockedAt: null,
+          updatedAt: new Date(),
+        })
+        .where(eq(issues.id, issueId));
+
+      gateway.releaseFirstWait();
+
+      await waitFor(async () => {
+        const deferred = await db
+          .select({
+            status: agentWakeupRequests.status,
+            error: agentWakeupRequests.error,
+          })
+          .from(agentWakeupRequests)
+          .where(
+            and(
+              eq(agentWakeupRequests.companyId, companyId),
+              eq(agentWakeupRequests.agentId, agentId),
+            ),
+          )
+          .orderBy(asc(agentWakeupRequests.requestedAt))
+          .then((rows) =>
+            rows.find((row) => row.error?.includes("routine execution issue is terminal")) ?? null,
+          );
+        return deferred?.status === "cancelled" && deferred.error?.includes("routine execution issue is terminal");
+      });
+      await waitFor(async () => {
+        const run = await db
+          .select({ status: heartbeatRuns.status })
+          .from(heartbeatRuns)
+          .where(eq(heartbeatRuns.id, firstRun!.id))
+          .then((rows) => rows[0] ?? null);
+        return run?.status === "succeeded";
+      });
+
+      const issue = await db
+        .select({
+          status: issues.status,
+          completedAt: issues.completedAt,
+        })
+        .from(issues)
+        .where(eq(issues.id, issueId))
+        .then((rows) => rows[0] ?? null);
+      expect(issue?.status).toBe("done");
+      expect(issue?.completedAt).not.toBeNull();
+
+      const runs = await db
+        .select()
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.agentId, agentId))
+        .orderBy(asc(heartbeatRuns.createdAt));
+      expect(runs).toHaveLength(1);
+      expect(gateway.getAgentPayloads()).toHaveLength(1);
+    } finally {
+      gateway.releaseFirstWait();
+      await gateway.close();
+    }
+  }, 120_000);
+
   it("does not reopen a finished issue when the deferred comment wake came from another agent", async () => {
     const gateway = await createControlledGatewayServer();
     const companyId = randomUUID();

--- a/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
+++ b/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
@@ -1036,6 +1036,218 @@ describeEmbeddedPostgres("heartbeat comment wake batching", () => {
     }
   }, 120_000);
 
+  it("promotes explicit deferred resume wakes for terminal routine execution issues", async () => {
+    const gateway = await createControlledGatewayServer();
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const issueId = randomUUID();
+    const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+    const heartbeat = heartbeatService(db);
+
+    try {
+      await db.insert(companies).values({
+        id: companyId,
+        name: "Paperclip",
+        issuePrefix,
+        requireBoardApprovalForNewAgents: false,
+      });
+
+      await db.insert(agents).values({
+        id: agentId,
+        companyId,
+        name: "Gateway Agent",
+        role: "engineer",
+        status: "idle",
+        adapterType: "openclaw_gateway",
+        adapterConfig: {
+          url: gateway.url,
+          headers: {
+            "x-openclaw-token": "gateway-token",
+          },
+          payloadTemplate: {
+            message: "wake now",
+          },
+          waitTimeoutMs: 2_000,
+        },
+        runtimeConfig: {},
+        permissions: {},
+      });
+
+      await db.insert(issues).values({
+        id: issueId,
+        companyId,
+        title: "Routine execution explicit resume",
+        status: "todo",
+        priority: "medium",
+        assigneeAgentId: agentId,
+        issueNumber: 1,
+        identifier: `${issuePrefix}-1`,
+        originKind: "routine_execution",
+      });
+
+      const comment1 = await db
+        .insert(issueComments)
+        .values({
+          companyId,
+          issueId,
+          authorUserId: "user-1",
+          body: "First routine comment",
+        })
+        .returning()
+        .then((rows) => rows[0]);
+
+      const firstRun = await heartbeat.wakeup(agentId, {
+        source: "automation",
+        triggerDetail: "system",
+        reason: "issue_commented",
+        payload: { issueId, commentId: comment1.id },
+        contextSnapshot: {
+          issueId,
+          taskId: issueId,
+          commentId: comment1.id,
+          wakeReason: "issue_commented",
+        },
+        requestedByActorType: "user",
+        requestedByActorId: "user-1",
+      });
+
+      expect(firstRun).not.toBeNull();
+      await waitFor(async () => {
+        const run = await db
+          .select({ status: heartbeatRuns.status })
+          .from(heartbeatRuns)
+          .where(eq(heartbeatRuns.id, firstRun!.id))
+          .then((rows) => rows[0] ?? null);
+        return run?.status === "running";
+      });
+
+      const comment2 = await db
+        .insert(issueComments)
+        .values({
+          companyId,
+          issueId,
+          authorUserId: "user-1",
+          body: "Please explicitly resume this routine execution",
+        })
+        .returning()
+        .then((rows) => rows[0]);
+
+      const deferredRun = await heartbeat.wakeup(agentId, {
+        source: "issue.comment.reopen",
+        triggerDetail: "issue_comment",
+        reason: "issue_reopened_via_comment",
+        payload: {
+          issueId,
+          commentId: comment2.id,
+          reopenedFrom: "done",
+          resumeIntent: true,
+          followUpRequested: true,
+        },
+        contextSnapshot: {
+          issueId,
+          taskId: issueId,
+          commentId: comment2.id,
+          wakeReason: "issue_reopened_via_comment",
+          reopenedFrom: "done",
+          resumeIntent: true,
+          followUpRequested: true,
+        },
+        requestedByActorType: "user",
+        requestedByActorId: "user-1",
+      });
+
+      expect(deferredRun).toBeNull();
+
+      await waitFor(async () => {
+        const deferred = await db
+          .select()
+          .from(agentWakeupRequests)
+          .where(
+            and(
+              eq(agentWakeupRequests.companyId, companyId),
+              eq(agentWakeupRequests.agentId, agentId),
+              eq(agentWakeupRequests.status, "deferred_issue_execution"),
+            ),
+          )
+          .then((rows) => rows[0] ?? null);
+        return Boolean(deferred);
+      });
+
+      await db
+        .update(issues)
+        .set({
+          status: "done",
+          completedAt: new Date(),
+          executionRunId: null,
+          executionAgentNameKey: null,
+          executionLockedAt: null,
+          updatedAt: new Date(),
+        })
+        .where(eq(issues.id, issueId));
+
+      gateway.releaseFirstWait();
+
+      await waitFor(() => gateway.getAgentPayloads().length >= 2, 90_000);
+      await waitFor(async () => {
+        const runs = await db
+          .select()
+          .from(heartbeatRuns)
+          .where(eq(heartbeatRuns.agentId, agentId))
+          .orderBy(asc(heartbeatRuns.createdAt));
+        const [initialRun, promotedRun] = runs;
+        return (
+          initialRun?.id === firstRun?.id &&
+          initialRun.status === "succeeded" &&
+          promotedRun?.status === "succeeded"
+        );
+      }, 90_000);
+      await waitForAgentIdle(db, agentId);
+
+      const runs = await db
+        .select()
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.agentId, agentId))
+        .orderBy(asc(heartbeatRuns.createdAt));
+      const promotedContext = runs[1]?.contextSnapshot as Record<string, unknown> | undefined;
+      expect(promotedContext).toMatchObject({
+        wakeReason: "issue_reopened_via_comment",
+        reopenedFrom: "done",
+        resumeIntent: true,
+        followUpRequested: true,
+      });
+
+      const reopenedIssue = await db
+        .select({
+          status: issues.status,
+          completedAt: issues.completedAt,
+        })
+        .from(issues)
+        .where(eq(issues.id, issueId))
+        .then((rows) => rows[0] ?? null);
+
+      expect(reopenedIssue?.status).toBe("in_progress");
+      expect(reopenedIssue?.completedAt).toBeNull();
+
+      const secondPayload = gateway.getAgentPayloads()[1] ?? {};
+      const secondWake = parseWakePayloadFromMessage(secondPayload.message);
+      expect(secondWake).toMatchObject({
+        reason: "issue_reopened_via_comment",
+        commentIds: [comment2.id],
+        latestCommentId: comment2.id,
+        issue: {
+          id: issueId,
+          identifier: `${issuePrefix}-1`,
+          title: "Routine execution explicit resume",
+          status: "in_progress",
+          priority: "medium",
+        },
+      });
+    } finally {
+      gateway.releaseFirstWait();
+      await gateway.close();
+    }
+  }, 120_000);
+
   it("does not reopen a finished issue when the deferred comment wake came from another agent", async () => {
     const gateway = await createControlledGatewayServer();
     const companyId = randomUUID();

--- a/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
+++ b/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
@@ -43,6 +43,18 @@ async function closeDbClient(db: ReturnType<typeof createDb> | undefined) {
   await db?.$client?.end?.({ timeout: 0 });
 }
 
+async function waitForAgentIdle(db: ReturnType<typeof createDb>, agentId: string) {
+  await waitFor(async () => {
+    const agent = await db
+      .select({ status: agents.status })
+      .from(agents)
+      .where(eq(agents.id, agentId))
+      .then((rows) => rows[0] ?? null);
+    return agent?.status !== "running";
+  });
+  await new Promise((resolve) => setTimeout(resolve, 25));
+}
+
 async function createControlledGatewayServer() {
   const server = createServer();
   const wss = new WebSocketServer({ server });
@@ -361,6 +373,7 @@ describeEmbeddedPostgres("heartbeat comment wake batching", () => {
           taskId: issueId,
           commentId: comment1.id,
           wakeReason: "issue_commented",
+          skipIssueComment: true,
         },
         requestedByActorType: "user",
         requestedByActorId: "user-1",
@@ -408,6 +421,7 @@ describeEmbeddedPostgres("heartbeat comment wake batching", () => {
           taskId: issueId,
           commentId: comment2.id,
           wakeReason: "issue_commented",
+          skipIssueComment: true,
         },
         requestedByActorType: "user",
         requestedByActorId: "user-1",
@@ -422,6 +436,7 @@ describeEmbeddedPostgres("heartbeat comment wake batching", () => {
           taskId: issueId,
           commentId: comment3.id,
           wakeReason: "issue_commented",
+          skipIssueComment: true,
         },
         requestedByActorType: "user",
         requestedByActorId: "user-1",
@@ -476,6 +491,7 @@ describeEmbeddedPostgres("heartbeat comment wake batching", () => {
         const statusesByRunId = new Map(runs.map((run) => [run.id, run.status]));
         return statusesByRunId.get(firstRun!.id) === "succeeded" && statusesByRunId.get(secondRunId) === "succeeded";
       }, 90_000);
+      await waitForAgentIdle(db, agentId);
 
       expect(secondPayload.paperclip).toBeUndefined();
       const secondWake = parseWakePayloadFromMessage(secondPayload.message);
@@ -560,6 +576,7 @@ describeEmbeddedPostgres("heartbeat comment wake batching", () => {
           taskId: issueId,
           commentId: comment1.id,
           wakeReason: "issue_commented",
+          skipIssueComment: true,
         },
         requestedByActorType: "user",
         requestedByActorId: "user-1",
@@ -605,6 +622,7 @@ describeEmbeddedPostgres("heartbeat comment wake batching", () => {
           taskId: issueId,
           commentId: queuedComment.id,
           wakeReason: "issue_commented",
+          skipIssueComment: true,
         },
         requestedByActorType: "user",
         requestedByActorId: "user-1",
@@ -626,12 +644,18 @@ describeEmbeddedPostgres("heartbeat comment wake batching", () => {
         missingCount: 0,
       });
       expect(String(promotedPayload.message ?? "")).toContain("Queued follow-up");
+      const promotedRunId = typeof promotedPayload.idempotencyKey === "string" ? promotedPayload.idempotencyKey : null;
+      if (!promotedRunId) {
+        throw new Error("Expected promoted gateway payload to include an idempotencyKey run id");
+      }
 
       gateway.releaseFirstWait();
       await waitFor(async () => {
         const runs = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.agentId, agentId));
-        return runs.length === 2 && runs.every((run) => ["cancelled", "succeeded"].includes(run.status));
+        const statusesByRunId = new Map(runs.map((run) => [run.id, run.status]));
+        return statusesByRunId.get(firstRun!.id) === "cancelled" && statusesByRunId.get(promotedRunId) === "succeeded";
       }, 90_000);
+      await waitForAgentIdle(db, agentId);
     } finally {
       gateway.releaseFirstWait();
       await gateway.close();
@@ -707,6 +731,7 @@ describeEmbeddedPostgres("heartbeat comment wake batching", () => {
           taskId: issueId,
           commentId: comment1.id,
           wakeReason: "issue_commented",
+          skipIssueComment: true,
         },
         requestedByActorType: "user",
         requestedByActorId: "user-1",
@@ -743,6 +768,7 @@ describeEmbeddedPostgres("heartbeat comment wake batching", () => {
           taskId: issueId,
           commentId: comment2.id,
           wakeReason: "issue_commented",
+          skipIssueComment: true,
         },
         requestedByActorType: "user",
         requestedByActorId: "user-1",
@@ -984,6 +1010,7 @@ describeEmbeddedPostgres("heartbeat comment wake batching", () => {
           .then((rows) => rows[0] ?? null);
         return run?.status === "succeeded";
       });
+      await waitForAgentIdle(db, agentId);
 
       const issue = await db
         .select({

--- a/server/src/__tests__/issue-comment-reopen-routes.test.ts
+++ b/server/src/__tests__/issue-comment-reopen-routes.test.ts
@@ -396,7 +396,7 @@ describe.sequential("issue comment reopen routes", () => {
     );
   });
 
-  it("implicitly reopens closed issues via the PATCH comment path when reassigning to an agent", async () => {
+  it("does not implicitly reopen closed issues via the PATCH comment path when reassigning to an agent", async () => {
     mockIssueService.getById.mockResolvedValue(makeIssue("done"));
     mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
       ...makeIssue("done"),
@@ -412,20 +412,19 @@ describe.sequential("issue comment reopen routes", () => {
       "11111111-1111-4111-8111-111111111111",
       expect.objectContaining({
         assigneeAgentId: "33333333-3333-4333-8333-333333333333",
-        status: "todo",
         actorAgentId: null,
         actorUserId: "local-board",
       }),
+    );
+    expect(mockIssueService.update).not.toHaveBeenCalledWith(
+      "11111111-1111-4111-8111-111111111111",
+      expect.objectContaining({ status: "todo" }),
     );
     expect(mockLogActivity).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
         action: "issue.updated",
-        details: expect.objectContaining({
-          reopened: true,
-          reopenedFrom: "done",
-          status: "todo",
-        }),
+        details: expect.not.objectContaining({ reopened: true }),
       }),
     );
   });
@@ -508,7 +507,7 @@ describe.sequential("issue comment reopen routes", () => {
     );
   });
 
-  it("implicitly reopens closed issues via POST comments when an agent is assigned", async () => {
+  it("does not implicitly reopen closed issues via POST comments when an agent is assigned", async () => {
     mockIssueService.getById.mockResolvedValue(makeIssue("done"));
     mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
       ...makeIssue("done"),
@@ -520,19 +519,15 @@ describe.sequential("issue comment reopen routes", () => {
       .send({ body: "hello" });
 
     expect(res.status).toBe(201);
-    expect(mockIssueService.update).toHaveBeenCalledWith(
+    expect(mockIssueService.addComment).toHaveBeenCalled();
+    expect(mockIssueService.update).not.toHaveBeenCalledWith(
       "11111111-1111-4111-8111-111111111111",
-      { status: "todo" },
+      expect.objectContaining({ status: "todo" }),
     );
-    await waitForWakeup(() => expect(mockHeartbeatService.wakeup).toHaveBeenCalledWith(
-      "22222222-2222-4222-8222-222222222222",
-      expect.objectContaining({
-        reason: "issue_reopened_via_comment",
-        payload: expect.objectContaining({
-          reopenedFrom: "done",
-        }),
-      }),
-    ));
+    expect(mockHeartbeatService.wakeup).not.toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ reason: "issue_reopened_via_comment" }),
+    );
   });
 
   it("does not implicitly reopen closed routine execution issues via POST comments", async () => {
@@ -1236,7 +1231,7 @@ describe.sequential("issue comment reopen routes", () => {
     );
   });
 
-  it("still implicitly reopens done issues via POST comments when the comment runId differs from the issue's owning run", async () => {
+  it("does not implicitly reopen done issues via POST comments when the comment runId differs from the issue's owning run", async () => {
     mockIssueService.getById.mockResolvedValue({
       ...makeIssue("done"),
       checkoutRunId: "run-owning",
@@ -1259,9 +1254,10 @@ describe.sequential("issue comment reopen routes", () => {
       .send({ body: "Real human follow-up — please reopen" });
 
     expect(res.status).toBe(201);
-    expect(mockIssueService.update).toHaveBeenCalledWith(
+    expect(mockIssueService.addComment).toHaveBeenCalled();
+    expect(mockIssueService.update).not.toHaveBeenCalledWith(
       "11111111-1111-4111-8111-111111111111",
-      { status: "todo" },
+      expect.objectContaining({ status: "todo" }),
     );
   });
 

--- a/server/src/__tests__/issue-comment-reopen-routes.test.ts
+++ b/server/src/__tests__/issue-comment-reopen-routes.test.ts
@@ -612,6 +612,9 @@ describe.sequential("issue comment reopen routes", () => {
       expect.anything(),
       expect.objectContaining({ reason: "issue_reopened_via_comment" }),
     );
+    expect(mockRoutineService.syncRunStatusForIssue).toHaveBeenCalledWith(
+      "11111111-1111-4111-8111-111111111111",
+    );
   });
 
   it("rejects non-assignee agent POST comments on closed issues", async () => {

--- a/server/src/__tests__/issue-comment-reopen-routes.test.ts
+++ b/server/src/__tests__/issue-comment-reopen-routes.test.ts
@@ -553,7 +553,7 @@ describe.sequential("issue comment reopen routes", () => {
     );
   });
 
-  it("does not explicitly resume closed routine execution issues via POST comments", async () => {
+  it("explicitly resumes closed routine execution issues via POST comments", async () => {
     mockIssueService.getById.mockResolvedValue(makeIssue("done", { originKind: "routine_execution" }));
     mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
       ...makeIssue("done", { originKind: "routine_execution" }),
@@ -566,17 +566,29 @@ describe.sequential("issue comment reopen routes", () => {
 
     expect(res.status).toBe(201);
     expect(mockIssueService.addComment).toHaveBeenCalled();
-    expect(mockIssueService.update).not.toHaveBeenCalledWith(
+    expect(mockIssueService.update).toHaveBeenCalledWith(
       "11111111-1111-4111-8111-111111111111",
-      expect.objectContaining({ status: "todo" }),
+      { status: "todo" },
     );
-    expect(mockHeartbeatService.wakeup).not.toHaveBeenCalledWith(
-      expect.anything(),
-      expect.objectContaining({ reason: "issue_reopened_via_comment" }),
+    expect(mockHeartbeatService.wakeup).toHaveBeenCalledWith(
+      "22222222-2222-4222-8222-222222222222",
+      expect.objectContaining({
+        reason: "issue_reopened_via_comment",
+        payload: expect.objectContaining({
+          reopenedFrom: "done",
+          resumeIntent: true,
+          followUpRequested: true,
+        }),
+        contextSnapshot: expect.objectContaining({
+          wakeReason: "issue_reopened_via_comment",
+          resumeIntent: true,
+          followUpRequested: true,
+        }),
+      }),
     );
   });
 
-  it("does not explicitly reopen closed routine execution issues via the PATCH comment path", async () => {
+  it("explicitly reopens closed routine execution issues via the PATCH comment path", async () => {
     mockIssueService.getById.mockResolvedValue(makeIssue("done", { originKind: "routine_execution" }));
     mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
       ...makeIssue("done", { originKind: "routine_execution" }),
@@ -588,24 +600,35 @@ describe.sequential("issue comment reopen routes", () => {
       .send({
         comment: "historical note",
         reopen: true,
-        assigneeAgentId: "33333333-3333-4333-8333-333333333333",
       });
 
     expect(res.status).toBe(200);
     expect(mockIssueService.update).toHaveBeenCalledWith(
       "11111111-1111-4111-8111-111111111111",
-      expect.not.objectContaining({ status: "todo" }),
+      expect.objectContaining({
+        status: "todo",
+        actorAgentId: null,
+        actorUserId: "local-board",
+      }),
     );
-    expect(mockLogActivity).not.toHaveBeenCalledWith(
+    expect(mockLogActivity).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
         action: "issue.updated",
-        details: expect.objectContaining({ reopened: true }),
+        details: expect.objectContaining({
+          reopened: true,
+          reopenedFrom: "done",
+          status: "todo",
+        }),
       }),
     );
-    expect(mockHeartbeatService.wakeup).not.toHaveBeenCalledWith(
-      expect.anything(),
-      expect.objectContaining({ reason: "issue_reopened_via_comment" }),
+    expect(mockHeartbeatService.wakeup).toHaveBeenCalledWith(
+      "22222222-2222-4222-8222-222222222222",
+      expect.objectContaining({
+        reason: "issue_reopened_via_comment",
+        payload: expect.objectContaining({ reopenedFrom: "done" }),
+        contextSnapshot: expect.objectContaining({ wakeReason: "issue_reopened_via_comment" }),
+      }),
     );
     expect(mockRoutineService.syncRunStatusForIssue).toHaveBeenCalledWith(
       "11111111-1111-4111-8111-111111111111",

--- a/server/src/__tests__/issue-comment-reopen-routes.test.ts
+++ b/server/src/__tests__/issue-comment-reopen-routes.test.ts
@@ -203,7 +203,7 @@ async function normalizePolicy(input: {
   return normalizeIssueExecutionPolicy(input);
 }
 
-function makeIssue(status: "todo" | "done" | "blocked" | "cancelled" | "in_progress") {
+function makeIssue(status: "todo" | "done" | "blocked" | "cancelled" | "in_progress", extra: Record<string, unknown> = {}) {
   return {
     id: "11111111-1111-4111-8111-111111111111",
     companyId: "company-1",
@@ -213,6 +213,7 @@ function makeIssue(status: "todo" | "done" | "blocked" | "cancelled" | "in_progr
     createdByUserId: "local-board",
     identifier: "PAP-580",
     title: "Comment reopen default",
+    ...extra,
   };
 }
 
@@ -532,6 +533,85 @@ describe.sequential("issue comment reopen routes", () => {
         }),
       }),
     ));
+  });
+
+  it("does not implicitly reopen closed routine execution issues via POST comments", async () => {
+    mockIssueService.getById.mockResolvedValue(makeIssue("done", { originKind: "routine_execution" }));
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
+      ...makeIssue("done", { originKind: "routine_execution" }),
+      ...patch,
+    }));
+
+    const res = await request(await installActor(createApp()))
+      .post("/api/issues/11111111-1111-4111-8111-111111111111/comments")
+      .send({ body: "historical note" });
+
+    expect(res.status).toBe(201);
+    expect(mockIssueService.addComment).toHaveBeenCalled();
+    expect(mockIssueService.update).not.toHaveBeenCalledWith(
+      "11111111-1111-4111-8111-111111111111",
+      expect.objectContaining({ status: "todo" }),
+    );
+    expect(mockHeartbeatService.wakeup).not.toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ reason: "issue_reopened_via_comment" }),
+    );
+  });
+
+  it("does not explicitly resume closed routine execution issues via POST comments", async () => {
+    mockIssueService.getById.mockResolvedValue(makeIssue("done", { originKind: "routine_execution" }));
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
+      ...makeIssue("done", { originKind: "routine_execution" }),
+      ...patch,
+    }));
+
+    const res = await request(await installActor(createApp(), agentActor()))
+      .post("/api/issues/11111111-1111-4111-8111-111111111111/comments")
+      .send({ body: "please resume this run", resume: true });
+
+    expect(res.status).toBe(201);
+    expect(mockIssueService.addComment).toHaveBeenCalled();
+    expect(mockIssueService.update).not.toHaveBeenCalledWith(
+      "11111111-1111-4111-8111-111111111111",
+      expect.objectContaining({ status: "todo" }),
+    );
+    expect(mockHeartbeatService.wakeup).not.toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ reason: "issue_reopened_via_comment" }),
+    );
+  });
+
+  it("does not explicitly reopen closed routine execution issues via the PATCH comment path", async () => {
+    mockIssueService.getById.mockResolvedValue(makeIssue("done", { originKind: "routine_execution" }));
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
+      ...makeIssue("done", { originKind: "routine_execution" }),
+      ...patch,
+    }));
+
+    const res = await request(await installActor(createApp()))
+      .patch("/api/issues/11111111-1111-4111-8111-111111111111")
+      .send({
+        comment: "historical note",
+        reopen: true,
+        assigneeAgentId: "33333333-3333-4333-8333-333333333333",
+      });
+
+    expect(res.status).toBe(200);
+    expect(mockIssueService.update).toHaveBeenCalledWith(
+      "11111111-1111-4111-8111-111111111111",
+      expect.not.objectContaining({ status: "todo" }),
+    );
+    expect(mockLogActivity).not.toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        action: "issue.updated",
+        details: expect.objectContaining({ reopened: true }),
+      }),
+    );
+    expect(mockHeartbeatService.wakeup).not.toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ reason: "issue_reopened_via_comment" }),
+    );
   });
 
   it("rejects non-assignee agent POST comments on closed issues", async () => {

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -870,10 +870,10 @@ function shouldImplicitlyMoveCommentedIssueToTodo(input: {
   ) {
     return false;
   }
-  // Only human comments should implicitly reopen finished work.
-  // Agent-authored comments remain communicative unless reopen was explicit.
+  // Human comments can implicitly recover blocked work, but terminal issues
+  // require explicit resume/reopen intent.
   if (input.actorType !== "user") return false;
-  if (!isClosedIssueStatus(input.issueStatus) && input.issueStatus !== "blocked") return false;
+  if (input.issueStatus !== "blocked") return false;
   if (typeof input.assigneeAgentId !== "string" || input.assigneeAgentId.length === 0) return false;
   return true;
 }

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -841,6 +841,13 @@ function isClosedIssueStatus(status: string | null | undefined): status is "done
   return status === "done" || status === "cancelled";
 }
 
+function isTerminalRoutineExecutionIssue(issue: {
+  status: string | null | undefined;
+  originKind?: string | null;
+}) {
+  return issue.originKind === "routine_execution" && isClosedIssueStatus(issue.status);
+}
+
 function shouldImplicitlyMoveCommentedIssueToTodo(input: {
   issueStatus: string | null | undefined;
   assigneeAgentId: string | null | undefined;
@@ -5803,6 +5810,7 @@ export function issueRoutes(
       actorId: actor.actorId,
     });
     const effectiveMoveToTodoRequested =
+      !isTerminalRoutineExecutionIssue(existing) &&
       !assigneeSelfCommentOnTerminal &&
       (explicitMoveToTodoRequested ||
         (!!commentBody &&
@@ -7619,6 +7627,7 @@ export function issueRoutes(
       actorId: actor.actorId,
     });
     const effectiveMoveToTodoRequested =
+      !isTerminalRoutineExecutionIssue(issue) &&
       !assigneeSelfCommentOnTerminal &&
       (explicitMoveToTodoRequested ||
         shouldImplicitlyMoveCommentedIssueToTodo({

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -5809,8 +5809,10 @@ export function issueRoutes(
       actorType: actor.actorType,
       actorId: actor.actorId,
     });
+    const routineTerminalPlainComment =
+      isTerminalRoutineExecutionIssue(existing) && !explicitMoveToTodoRequested;
     const effectiveMoveToTodoRequested =
-      !isTerminalRoutineExecutionIssue(existing) &&
+      !routineTerminalPlainComment &&
       !assigneeSelfCommentOnTerminal &&
       (explicitMoveToTodoRequested ||
         (!!commentBody &&
@@ -7626,8 +7628,10 @@ export function issueRoutes(
       actorType: actor.actorType,
       actorId: actor.actorId,
     });
+    const routineTerminalPlainComment =
+      isTerminalRoutineExecutionIssue(issue) && !explicitMoveToTodoRequested;
     const effectiveMoveToTodoRequested =
-      !isTerminalRoutineExecutionIssue(issue) &&
+      !routineTerminalPlainComment &&
       !assigneeSelfCommentOnTerminal &&
       (explicitMoveToTodoRequested ||
         shouldImplicitlyMoveCommentedIssueToTodo({

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -10608,10 +10608,15 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         }
         // Only human/comment-reopen interactions should revive completed issues;
         // system follow-ups such as retry or cleanup wakes must not reopen closed work.
+        const deferredLifecycleIntent =
+          promotedContextSeed.resumeIntent === true ||
+          promotedContextSeed.followUpRequested === true ||
+          readNonEmptyString(promotedContextSeed.reopenedFrom) !== null;
         const shouldReopenDeferredCommentWake =
           deferredCommentIds.length > 0 &&
           !deferredCommentWakeIsSelfAuthored &&
           (issue.status === "done" || issue.status === "cancelled") &&
+          deferredLifecycleIntent &&
           (
             deferred.requestedByActorType === "user" ||
             deferredWakeReason === "issue_reopened_via_comment"

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -10568,10 +10568,17 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         const deferredCommentIds = extractWakeCommentIds(deferredContextSeed);
         const deferredCommentWakeId = deriveCommentId(deferredContextSeed, deferredPayload);
         const deferredWakeReason = readNonEmptyString(deferredContextSeed.wakeReason);
+        // Only explicit lifecycle intent should revive completed issues. Plain
+        // comments, including routine-execution comments, remain history-only.
+        const deferredLifecycleIntent =
+          promotedContextSeed.resumeIntent === true ||
+          promotedContextSeed.followUpRequested === true ||
+          readNonEmptyString(promotedContextSeed.reopenedFrom) !== null;
         if (
           deferredCommentWakeId &&
           issue.originKind === "routine_execution" &&
-          (issue.status === "done" || issue.status === "cancelled")
+          (issue.status === "done" || issue.status === "cancelled") &&
+          !deferredLifecycleIntent
         ) {
           await tx
             .update(agentWakeupRequests)
@@ -10608,10 +10615,6 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         }
         // Only human/comment-reopen interactions should revive completed issues;
         // system follow-ups such as retry or cleanup wakes must not reopen closed work.
-        const deferredLifecycleIntent =
-          promotedContextSeed.resumeIntent === true ||
-          promotedContextSeed.followUpRequested === true ||
-          readNonEmptyString(promotedContextSeed.reopenedFrom) !== null;
         const shouldReopenDeferredCommentWake =
           deferredCommentIds.length > 0 &&
           !deferredCommentWakeIsSelfAuthored &&

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -10566,7 +10566,24 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           };
         }
         const deferredCommentIds = extractWakeCommentIds(deferredContextSeed);
+        const deferredCommentWakeId = deriveCommentId(deferredContextSeed, deferredPayload);
         const deferredWakeReason = readNonEmptyString(deferredContextSeed.wakeReason);
+        if (
+          deferredCommentWakeId &&
+          issue.originKind === "routine_execution" &&
+          (issue.status === "done" || issue.status === "cancelled")
+        ) {
+          await tx
+            .update(agentWakeupRequests)
+            .set({
+              status: "cancelled",
+              finishedAt: new Date(),
+              error: "Deferred comment wake suppressed because routine execution issue is terminal",
+              updatedAt: new Date(),
+            })
+            .where(eq(agentWakeupRequests.id, deferred.id));
+          continue;
+        }
         // Local-CLI agents post comments under user auth, so a self-comment from
         // the run that is now ending would otherwise look like a real human
         // comment and trigger a reopen on the very issue this run just closed.


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to coordinate AI agents, their work queues, and lifecycle state.
> - This change is in the issue/comment and heartbeat wake path, where user comments can notify assigned agents and sometimes restart work.
> - Terminal issues already represent completed or intentionally stopped work, so ordinary discussion after completion must not erase that lifecycle decision.
> - The regression was that plain comments and deferred comment wakes on assigned terminal issues could move work back to active status and clear completion state.
> - The intended restart path is explicit lifecycle intent through structured `resume: true` or allowed `reopen: true`, while blocked issue recovery remains governed by first-class blockers.
> - This pull request separates inert terminal comments from explicit resume/reopen actions in the route and heartbeat paths.
> - The benefit is that completed/cancelled work can still receive historical comments without surprise reactivation, while deliberate restarts remain available and auditable.

## Linked Issues or Issue Description

No public GitHub issue exists for this regression, so the issue is described inline using the bug report template.

### Pre-submission checklist

- [x] I have searched existing open and closed issues and this is not a duplicate.
- [x] I am on the latest released version of Paperclip (or can reproduce on `master`).
- [x] I have confirmed the error originates in Paperclip itself — not in my agent adapter, API provider, or local configuration.

### What happened?

Plain POST/PATCH comments and deferred comment wakes on assigned `done` or `cancelled` issues could reopen completed work by moving the issue back to active status and clearing terminal completion state.

### Expected behavior

Ordinary comments on terminal issues should persist as comments only. They should not set status to `todo`, enqueue `issue_reopened_via_comment`, or clear completion state. Explicit structured `resume: true` or allowed `reopen: true` should remain the intentional restart path.

### Steps to reproduce

1. Complete or cancel an assigned issue.
2. Add a plain comment through the issue comment route, or allow a deferred plain comment wake to process after completion.
3. Observe that the terminal issue is reopened instead of remaining terminal.
4. Repeat with explicit `resume: true` or allowed `reopen: true` and confirm that explicit lifecycle intent still restarts work.

### Paperclip version or commit

Reproduced and fixed against this PR branch, current head `62433561e62f1840dab2f8e04aad6b36d97b316e`.

### Deployment mode

Local dev (`pnpm dev`) / server runtime.

### Installation method

Built from source.

### Agent adapter(s) involved

Not adapter-specific (core bug).

### Database mode

Database-backed server issue state; not specific to one database mode.

### Access context

Both board/user comments and agent wake processing are involved.

### Relevant logs or output

No stack trace. The symptom is persisted issue state changing from terminal back to active after an ordinary comment/comment wake.

### Relevant config (if applicable)

Not applicable.

### Additional context

The implementation preserves blocked issue recovery through first-class blockers, keeps plain terminal routine-execution comments inert, and allows explicit `resume: true` / allowed `reopen: true` to remain the intentional restart path.

### Privacy checklist

- [x] I have reviewed all pasted output for PII (usernames, file paths, API keys, tokens, company names) and redacted where necessary.

## What Changed

- Added terminal-comment handling in `server/src/routes/issues.ts` so plain POST/PATCH comments on terminal issues preserve terminal status, completion metadata, and wake behavior.
- Preserved explicit structured `resume: true` / allowed `reopen: true` as the route-level restart path, including for terminal routine-execution issues.
- Updated `server/src/services/heartbeat.ts` so deferred plain comment wakes after completion do not reopen terminal routine executions, while deferred explicit resume/reopen wakes still promote and carry restart context.
- Added route and heartbeat regression coverage for plain terminal comments, explicit resume/reopen, blocked issue recovery, deferred plain wake suppression, and deferred explicit routine resume promotion.

## Verification

- `pnpm vitest run server/src/__tests__/issue-comment-reopen-routes.test.ts` — 75 passed
- `pnpm vitest run server/src/__tests__/heartbeat-comment-wake-batching.test.ts --reporter=verbose` — 13 passed; command exited 0, with late async cleanup warnings after the pass summary from DB connection shutdown during environment lease cleanup
- `pnpm --filter @paperclipai/server typecheck`
- `git diff --check`

## Risks

Low to moderate risk. The change intentionally narrows automatic reopen behavior for terminal issues, so the main risk is accidentally suppressing a legitimate restart path. Tests cover the expected distinction: plain terminal comments are inert, explicit `resume: true` / allowed `reopen: true` still restarts, blocked issue recovery remains unchanged, and terminal routine-execution issues only suppress plain-comment wakes.

## Model Used

OpenAI Codex, GPT-5 Codex-class coding model, with repository tool use and local shell verification.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [ ] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
