### PR TITLE
fix: restore §7.10.3 pre-close terminal-close guard (structured active-blocker model + recovery carve-out)

### DIFF
--- a/server/src/__tests__/pre-close-guard.test.ts
+++ b/server/src/__tests__/pre-close-guard.test.ts
@@ -1,0 +1,367 @@
+/**
+ * §7.10.3 Pre-close guard test matrix — QUA-2575
+ *
+ * Each test case is a permanent canary for the structured active-blocker model.
+ * Prose token scanning is advisory only; structured state is the sole hard-block source.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  BUILTIN_GUARD_TOKENS,
+  evaluateGuard,
+  findMatchedGuardTokens,
+  stripGuardExclusions,
+} from "../services/pre-close-guard.js";
+
+// ---------------------------------------------------------------------------
+// Helper: clean structured state (no hard blockers)
+// ---------------------------------------------------------------------------
+
+const CLEAN_STATE = {
+  unresolvedBlockerCount: 0,
+  openChildCount: 0,
+  hasPendingConfirmation: false,
+  hasActiveRecoveryAction: false,
+};
+
+// ---------------------------------------------------------------------------
+// stripGuardExclusions (advisory prose pre-processor)
+// ---------------------------------------------------------------------------
+
+describe("stripGuardExclusions", () => {
+  it("removes fenced code blocks", () => {
+    const text = "some text\n```\nunresolved\n```\nafter";
+    expect(stripGuardExclusions(text)).not.toContain("unresolved");
+    expect(stripGuardExclusions(text)).toContain("after");
+  });
+
+  it("removes inline code", () => {
+    expect(stripGuardExclusions("call `unresolved` state")).not.toContain("unresolved");
+  });
+
+  it("removes blockquote lines", () => {
+    const result = stripGuardExclusions("> unresolved issue noted\nactual content");
+    expect(result).not.toContain("unresolved");
+    expect(result).toContain("actual content");
+  });
+
+  it("preserves plain prose", () => {
+    expect(stripGuardExclusions("the issue is unresolved")).toContain("unresolved");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Acceptance criteria test matrix (QUA-2575 §Acceptance criteria)
+// ---------------------------------------------------------------------------
+
+describe("QUA-2575 acceptance criteria — structured hard blocks", () => {
+  // AC-1: Open structured blocker + clean prose → BLOCK (true positive)
+  it("AC-1: open blockedBy link blocks despite clean prose", () => {
+    const result = evaluateGuard({
+      state: { ...CLEAN_STATE, unresolvedBlockerCount: 1 },
+      advisory: { allText: "Implementation complete. All tests green." },
+    });
+    expect(result.decision).toBe("blocked");
+    expect((result as { blockedBy: string[] }).blockedBy).toContain("open_blockedby_links");
+  });
+
+  // AC-2: No structured blocker + thread prose contains "blocked on …" → ALLOW
+  it("AC-2: 'blocked on' in historical prose does not block when state is clean", () => {
+    const result = evaluateGuard({
+      state: CLEAN_STATE,
+      advisory: {
+        allText: "Earlier we were blocked on the DB migration, which is now resolved.",
+      },
+    });
+    expect(result.decision).toBe("pass");
+  });
+
+  // AC-3: No structured blocker + description/code-block quotes "awaiting approval" → ALLOW
+  it("AC-3: 'awaiting approval' inside a code block is not a hard block", () => {
+    const result = evaluateGuard({
+      state: CLEAN_STATE,
+      advisory: {
+        allText: "See example:\n```\nawaiting approval\n```\nAll done now.",
+      },
+    });
+    expect(result.decision).toBe("pass");
+  });
+
+  // AC-4a: Open child issue → BLOCK
+  it("AC-4a: open child issue blocks terminal close", () => {
+    const result = evaluateGuard({
+      state: { ...CLEAN_STATE, openChildCount: 2 },
+    });
+    expect(result.decision).toBe("blocked");
+    expect((result as { blockedBy: string[] }).blockedBy).toContain("open_child_issues");
+  });
+
+  // AC-4b: Pending confirmation → BLOCK
+  it("AC-4b: pending request_confirmation blocks terminal close", () => {
+    const result = evaluateGuard({
+      state: { ...CLEAN_STATE, hasPendingConfirmation: true },
+    });
+    expect(result.decision).toBe("blocked");
+    expect((result as { blockedBy: string[] }).blockedBy).toContain("pending_confirmation");
+  });
+
+  // AC-5: PR merged + CI green + sign-off + no structured blockers + no pending confirmation → ALLOW
+  it("AC-5: clean structured state allows close even with advisory prose tokens", () => {
+    const result = evaluateGuard({
+      state: CLEAN_STATE,
+      advisory: {
+        allText: "PR merged. CI green. Sign-off recorded. This was once unresolved but is now done.",
+      },
+    });
+    // advisory token "unresolved" matched — but decision is still "pass"
+    expect(result.decision).toBe("pass");
+  });
+
+  // AC-6: guardAcknowledge on an advisory → ALLOW + acknowledged flag set
+  it("AC-6: guardAcknowledge on advisory token allows close and records acknowledgment", () => {
+    const result = evaluateGuard({
+      state: CLEAN_STATE,
+      advisory: {
+        allText: "Mechanism: auto-escalates if still unresolved past SLA.",
+        acknowledgedTokens: ["unresolved"],
+        acknowledgedReason: "False positive: SLA mechanism description, not pending work",
+      },
+    });
+    expect(result.decision).toBe("pass");
+    const pass = result as { decision: "pass"; advisory?: { acknowledged: boolean } };
+    expect(pass.advisory?.acknowledged).toBe(true);
+  });
+
+  // AC-7: Comment with no structural change on done issue — status unchanged.
+  // (This is enforced at the route layer, not the guard service. The guard only runs on
+  // terminal-status PATCH. A comment-only PATCH never reaches this code path.)
+  // We document the invariant by verifying the guard itself cannot cause a reopen:
+  it("AC-7: guard evaluates to pass when state is clean (cannot cause a status reopen)", () => {
+    const result = evaluateGuard({ state: CLEAN_STATE });
+    expect(result.decision).toBe("pass");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Multiple hard blockers can stack
+// ---------------------------------------------------------------------------
+
+describe("stacked hard blockers", () => {
+  it("reports all active hard-block reasons", () => {
+    const result = evaluateGuard({
+      state: {
+        unresolvedBlockerCount: 1,
+        openChildCount: 3,
+        hasPendingConfirmation: true,
+        hasActiveRecoveryAction: true,
+      },
+    });
+    expect(result.decision).toBe("blocked");
+    const r = result as { blockedBy: string[] };
+    expect(r.blockedBy).toContain("open_blockedby_links");
+    expect(r.blockedBy).toContain("open_child_issues");
+    expect(r.blockedBy).toContain("pending_confirmation");
+    expect(r.blockedBy).toContain("active_recovery_action");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// guardAcknowledge is advisory-only — cannot dismiss structured hard blockers
+// ---------------------------------------------------------------------------
+
+describe("guardAcknowledge is advisory-only", () => {
+  it("guardAcknowledge does NOT unblock a structured hard blocker", () => {
+    const result = evaluateGuard({
+      state: { ...CLEAN_STATE, unresolvedBlockerCount: 1 },
+      advisory: {
+        allText: "blocked on infra ticket",
+        acknowledgedTokens: ["blocked on"],
+        acknowledgedReason: "prose only",
+      },
+    });
+    // Hard blocker wins regardless of guardAcknowledge
+    expect(result.decision).toBe("blocked");
+    expect((result as { blockedBy: string[] }).blockedBy).toContain("open_blockedby_links");
+  });
+
+  it("partial advisory acknowledgment: unacknowledged token appears in advisory", () => {
+    const result = evaluateGuard({
+      state: CLEAN_STATE,
+      advisory: {
+        allText: "This was unresolved, now awaiting verification from DA.",
+        acknowledgedTokens: ["unresolved"],
+        acknowledgedReason: "historical only",
+      },
+    });
+    // Pass — but advisory shows partial acknowledgment (awaiting verification not acked)
+    expect(result.decision).toBe("pass");
+    const pass = result as { decision: "pass"; advisory?: { acknowledged: boolean; matchedTokens: string[] } };
+    expect(pass.advisory?.acknowledged).toBe(false);
+    expect(pass.advisory?.matchedTokens).toContain("awaiting verification");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Advisory prose scan details
+// ---------------------------------------------------------------------------
+
+describe("advisory prose scan", () => {
+  it("no advisory tokens → clean pass with no advisory field", () => {
+    const result = evaluateGuard({
+      state: CLEAN_STATE,
+      advisory: { allText: "All done. Tests pass." },
+    });
+    expect(result.decision).toBe("pass");
+    expect((result as { advisory?: unknown }).advisory).toBeUndefined();
+  });
+
+  it("advisory prose matched → pass with advisory.matchedTokens", () => {
+    const result = evaluateGuard({
+      state: CLEAN_STATE,
+      advisory: { allText: "This item had unresolved state earlier." },
+    });
+    expect(result.decision).toBe("pass");
+    const pass = result as { advisory?: { matchedTokens: string[] } };
+    expect(pass.advisory?.matchedTokens).toContain("unresolved");
+  });
+
+  it("advisory tokens inside blockquotes are stripped (advisory also respects exclusions)", () => {
+    const result = evaluateGuard({
+      state: CLEAN_STATE,
+      advisory: { allText: "> blocked on the previous run\nNow resolved." },
+    });
+    expect(result.decision).toBe("pass");
+    // "blocked on" is in a blockquote — stripped before advisory scan
+    expect((result as { advisory?: unknown }).advisory).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findMatchedGuardTokens (utility)
+// ---------------------------------------------------------------------------
+
+describe("findMatchedGuardTokens", () => {
+  it("matches multi-word token", () => {
+    expect(findMatchedGuardTokens("blocked on verification", BUILTIN_GUARD_TOKENS)).toContain("blocked on");
+  });
+
+  it("is case-insensitive", () => {
+    expect(findMatchedGuardTokens("UNRESOLVED items remain", BUILTIN_GUARD_TOKENS)).toContain("unresolved");
+  });
+
+  it("does not match inside fenced code block", () => {
+    const text = "description:\n```\nunresolved\n```\nend";
+    expect(findMatchedGuardTokens(text, BUILTIN_GUARD_TOKENS)).not.toContain("unresolved");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// QUA-4139 carve-out — recovery / liveness-escalation forced terminal close.
+//
+// The gate lives in the PATCH /issues/:id route (server/src/routes/issues.ts):
+// a terminal close is allowed past a structured hard block ONLY when the actor
+// is a human/Board user (actorType === "user") AND forceTerminal === true.
+// Agents are ALWAYS subject to the guard — forceTerminal is ignored for them.
+//
+// This pure replica mirrors the exact route condition so the gate has a
+// permanent canary independent of the (heavy) full-route harness.
+// ---------------------------------------------------------------------------
+
+type CarveOutOutcome =
+  | { http: 409; blockedBy: string[] }
+  | { http: 200; audit: { decision: "pass" | "forced"; blockedBy: string[]; forcedByActorId?: string } };
+
+function resolveTerminalClose(args: {
+  guard: ReturnType<typeof evaluateGuard>;
+  forceTerminal: boolean;
+  actorType: "user" | "agent";
+  actorId: string;
+}): CarveOutOutcome {
+  const { guard, forceTerminal, actorType, actorId } = args;
+  // Exact route condition: forceTerminal honored only for human/Board actors.
+  const forcedBypassAllowed = forceTerminal && actorType === "user";
+  if (guard.decision === "blocked" && !forcedBypassAllowed) {
+    return { http: 409, blockedBy: guard.blockedBy };
+  }
+  if (forcedBypassAllowed) {
+    return {
+      http: 200,
+      audit: {
+        decision: "forced",
+        blockedBy: guard.decision === "blocked" ? guard.blockedBy : [],
+        forcedByActorId: actorId,
+      },
+    };
+  }
+  return { http: 200, audit: { decision: "pass", blockedBy: [] } };
+}
+
+describe("QUA-4139 forceTerminal carve-out gate", () => {
+  const blockedGuard = () =>
+    evaluateGuard({ state: { ...CLEAN_STATE, unresolvedBlockerCount: 1 } });
+
+  // (a) agent + forceTerminal:true + structured blocker → still 409
+  it("(a) agent actor with forceTerminal cannot bypass a structured blocker → 409", () => {
+    const outcome = resolveTerminalClose({
+      guard: blockedGuard(),
+      forceTerminal: true,
+      actorType: "agent",
+      actorId: "agent-123",
+    });
+    expect(outcome.http).toBe(409);
+    expect((outcome as { blockedBy: string[] }).blockedBy).toContain("open_blockedby_links");
+  });
+
+  // (b) user + forceTerminal:true + structured blocker → passes (no 409) + audit shows forced
+  it("(b) user actor with forceTerminal bypasses the structured blocker → 200, audit=forced", () => {
+    const outcome = resolveTerminalClose({
+      guard: blockedGuard(),
+      forceTerminal: true,
+      actorType: "user",
+      actorId: "board",
+    });
+    expect(outcome.http).toBe(200);
+    const ok = outcome as { http: 200; audit: { decision: string; blockedBy: string[]; forcedByActorId?: string } };
+    expect(ok.audit.decision).toBe("forced");
+    expect(ok.audit.blockedBy).toContain("open_blockedby_links");
+    expect(ok.audit.forcedByActorId).toBe("board");
+  });
+
+  // (c) user WITHOUT forceTerminal + structured blocker → 409
+  it("(c) user actor without forceTerminal is still subject to the guard → 409", () => {
+    const outcome = resolveTerminalClose({
+      guard: blockedGuard(),
+      forceTerminal: false,
+      actorType: "user",
+      actorId: "board",
+    });
+    expect(outcome.http).toBe(409);
+    expect((outcome as { blockedBy: string[] }).blockedBy).toContain("open_blockedby_links");
+  });
+
+  // (d) user + forceTerminal on a CLEAN state → 200, audit=forced with empty blockedBy
+  it("(d) user actor with forceTerminal on clean state → 200, audit=forced, blockedBy=[]", () => {
+    const outcome = resolveTerminalClose({
+      guard: evaluateGuard({ state: CLEAN_STATE }),
+      forceTerminal: true,
+      actorType: "user",
+      actorId: "board",
+    });
+    expect(outcome.http).toBe(200);
+    const ok = outcome as { http: 200; audit: { decision: string; blockedBy: string[] } };
+    expect(ok.audit.decision).toBe("forced");
+    expect(ok.audit.blockedBy).toEqual([]);
+  });
+
+  // (e) agent on a clean state → normal pass (no forced record)
+  it("(e) agent actor on clean state closes normally → 200, audit=pass", () => {
+    const outcome = resolveTerminalClose({
+      guard: evaluateGuard({ state: CLEAN_STATE }),
+      forceTerminal: false,
+      actorType: "agent",
+      actorId: "agent-123",
+    });
+    expect(outcome.http).toBe(200);
+    expect((outcome as { http: 200; audit: { decision: string } }).audit.decision).toBe("pass");
+  });
+});

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -152,10 +152,21 @@ import {
   type TrustPresetResolution,
 } from "../services/trust-preset-resolver.js";
 import { externalObjectService } from "../services/external-objects.js";
+import { evaluateGuard, type GuardDecision } from "../services/pre-close-guard.js";
 
 const MAX_ISSUE_COMMENT_LIMIT = 500;
 const updateIssueRouteSchema = updateIssueSchema.extend({
   interrupt: z.boolean().optional(),
+  // §7.10.3 QUA-2575: advisory prose-token dismissal (never dismisses a hard blocker).
+  guardAcknowledge: z
+    .object({
+      tokens: z.array(z.string()),
+      reason: z.string().optional(),
+    })
+    .optional(),
+  // QUA-4139 carve-out: human/Board-only bypass of the structured pre-close guard
+  // for legitimate recovery / liveness-escalation closes. Ignored for agent actors.
+  forceTerminal: z.boolean().optional(),
 });
 const refreshExternalObjectsSchema = z.object({
   objectIds: z.array(z.string().uuid()).max(50).optional(),
@@ -5718,6 +5729,12 @@ export function issueRoutes(
     if (!(await assertCheapRecoveryIssueAssigneeProfileAllowed(req, res, existing, req.body))) return;
 
     const actor = getActorInfo(req);
+    // The audit record is either the raw guard decision, or — for a Board-forced
+    // recovery close (QUA-4139 carve-out) — a "forced" record noting what would have blocked.
+    type PreCloseGuardAudit =
+      | GuardDecision
+      | { decision: "forced"; blockedBy: string[]; forcedByActorId: string };
+    let preCloseGuardResult: PreCloseGuardAudit | null = null;
     const isClosed = isClosedIssueStatus(existing.status);
     const isBlocked = existing.status === "blocked";
     const normalizedAssigneeAgentId = await normalizeIssueAssigneeAgentReference(
@@ -5736,8 +5753,12 @@ export function issueRoutes(
       resume: resumeRequested,
       interrupt: interruptRequested,
       hiddenAt: hiddenAtRaw,
+      // §7.10.3 / QUA-4139: control fields — must NOT leak into the persisted update payload.
+      guardAcknowledge: guardAcknowledgeRaw,
+      forceTerminal: forceTerminalRaw,
       ...updateFields
     } = req.body;
+    const forceTerminalRequested = forceTerminalRaw === true;
     const shouldCancelActiveRunForCancelledStatus =
       existing.status !== "cancelled" && updateFields.status === "cancelled";
     if (resumeRequested === true && !commentBody) {
@@ -5759,6 +5780,92 @@ export function issueRoutes(
     await assertIssueEnvironmentSelection(existing.companyId, updateFields.executionWorkspaceSettings?.environmentId);
     const requestedAssigneeAgentId =
       normalizedAssigneeAgentId === undefined ? existing.assigneeAgentId : normalizedAssigneeAgentId;
+    const requestedTerminalStatus =
+      updateFields.status === "done" || updateFields.status === "cancelled"
+        ? updateFields.status
+        : null;
+    if (requestedTerminalStatus) {
+      // §7.10.3 QUA-2575: structured active-blocker evaluation.
+      // Hard blocks come from structured state only — never from prose scanning.
+      const [
+        interactions,
+        dependencyReadiness,
+        openChildren,
+        activeRecoveryAction,
+      ] = await Promise.all([
+        issueThreadInteractionService(db).listForIssue(existing.id),
+        svc.getDependencyReadiness(existing.id),
+        db
+          .select({ id: issueRows.id })
+          .from(issueRows)
+          .where(
+            and(
+              eq(issueRows.companyId, existing.companyId),
+              eq(issueRows.parentId, existing.id),
+              notInArray(issueRows.status, ["done", "cancelled"]),
+            ),
+          ),
+        recoveryActionsSvc.getActiveForIssue(existing.companyId, existing.id),
+      ]);
+      const hasPendingConfirmation = interactions.some(
+        (interaction) =>
+          interaction.kind === "request_confirmation" &&
+          interaction.status === "pending",
+      );
+      const guardAcknowledge =
+        guardAcknowledgeRaw && typeof guardAcknowledgeRaw === "object"
+          ? (guardAcknowledgeRaw as { tokens?: string[]; reason?: string })
+          : undefined;
+      const acknowledgedTokens = Array.isArray(guardAcknowledge?.tokens)
+        ? guardAcknowledge.tokens.filter(
+            (value): value is string =>
+              typeof value === "string" && value.trim().length > 0,
+          )
+        : [];
+      const acknowledgedReason =
+        typeof guardAcknowledge?.reason === "string"
+          ? guardAcknowledge.reason.trim()
+          : undefined;
+      // Advisory prose scan: never blocks, surfaced in pass response for observability.
+      const comments = await svc.listComments(existing.id, { order: "asc" });
+      const allText = [existing.description, ...comments.map((c) => c.body)]
+        .filter((value): value is string => typeof value === "string" && value.length > 0)
+        .join("\n\n");
+      const decision = evaluateGuard({
+        state: {
+          unresolvedBlockerCount: dependencyReadiness.unresolvedBlockerCount,
+          openChildCount: openChildren.length,
+          hasPendingConfirmation,
+          hasActiveRecoveryAction: activeRecoveryAction !== null,
+        },
+        advisory: { allText, acknowledgedTokens, acknowledgedReason },
+      });
+      // QUA-4139 carve-out: a human/Board actor may force terminal close past the
+      // structured guard for legitimate recovery / liveness-escalation. We still RUN
+      // the guard (to record what WOULD have blocked) but do not 409. Agents are
+      // ALWAYS subject to the guard — forceTerminal is ignored for actorType "agent".
+      const forcedBypassAllowed = forceTerminalRequested && actor.actorType === "user";
+      if (decision.decision === "blocked" && !forcedBypassAllowed) {
+        res.status(409).json({
+          error: "PRE_CLOSE_GUARD_BLOCKED",
+          code: "PRE_CLOSE_GUARD_BLOCKED",
+          blockedBy: decision.blockedBy,
+          requestedStatus: requestedTerminalStatus,
+        });
+        return;
+      }
+      if (forcedBypassAllowed) {
+        // Record the forced bypass for audit. blockedBy = the reasons that WOULD have
+        // blocked (empty when structured state was already clean).
+        preCloseGuardResult = {
+          decision: "forced",
+          blockedBy: decision.decision === "blocked" ? decision.blockedBy : [],
+          forcedByActorId: actor.actorId,
+        };
+      } else {
+        preCloseGuardResult = decision;
+      }
+    }
     const explicitMoveToTodoRequested = reopenRequested || resumeRequested === true;
     const recoveryRelevantSourceMutationRequested =
       req.body.status !== undefined ||
@@ -6235,6 +6342,7 @@ export function issueRoutes(
           : {}),
         ...(interruptedRunId ? { interruptedRunId } : {}),
         ...(cancelledStatusRunId ? { cancelledStatusRunId } : {}),
+        ...(preCloseGuardResult ? { preCloseGuard: preCloseGuardResult } : {}),
         ...(workspaceChange ? { workspaceChange } : {}),
         _previous: hasFieldChanges ? previous : undefined,
         ...summarizeIssueReferenceActivityDetails(

--- a/server/src/services/pre-close-guard.ts
+++ b/server/src/services/pre-close-guard.ts
@@ -1,0 +1,141 @@
+/**
+ * §7.10.3 Pre-close guard — structured active-blocker model.
+ *
+ * QUA-2575: replaces substring-based prose scan with structured state evaluation.
+ *
+ * Terminal close (done/cancelled) is BLOCKED iff unresolved STRUCTURED state
+ * exists in any of these fields:
+ *   - open blockedBy relations (unresolvedBlockerCount > 0)
+ *   - open child issues (openChildCount > 0)
+ *   - pending request_confirmation interaction (hasPendingConfirmation)
+ *   - active recovery action (hasActiveRecoveryAction)
+ *
+ * Prose token scanning is retained as NON-BLOCKING advisory only:
+ *   - Matched tokens are surfaced in the pass response for observability.
+ *   - guardAcknowledge { tokens, reason } dismisses an advisory and is audit-logged.
+ *   - guardAcknowledge NEVER dismisses a structured hard blocker.
+ *   - forceTerminal is exception-only (not a routine-close path).
+ *
+ * Implemented: QUA-2315 (original guard), QUA-2428 (false-positive fixes),
+ *              QUA-2575 (structured-blocker model)
+ */
+
+export const BUILTIN_GUARD_TOKENS: readonly string[] = [
+  "blocked on",
+  "awaiting verification",
+  "awaiting approval",
+  "awaiting confirmation",
+  "runtime evidence pending",
+  "follow-up filed",
+  "should now be resolved",
+  "needs verification",
+  "pending review",
+  "unresolved",
+];
+
+/**
+ * Strip content excluded from advisory token scanning:
+ *   - fenced code blocks (``` … ```)
+ *   - inline code (`…`)
+ *   - blockquote lines (lines starting with `>`)
+ */
+export function stripGuardExclusions(text: string): string {
+  let result = text.replace(/```[\s\S]*?```/g, "");
+  result = result.replace(/`[^`]*`/g, "");
+  result = result
+    .split("\n")
+    .filter((line) => !line.trimStart().startsWith(">"))
+    .join("\n");
+  return result;
+}
+
+/** Return tokens that appear (case-insensitive, after exclusion stripping) in text. */
+export function findMatchedGuardTokens(
+  text: string,
+  tokens: readonly string[],
+): string[] {
+  const stripped = stripGuardExclusions(text).toLowerCase();
+  return tokens.filter((token) => stripped.includes(token.toLowerCase()));
+}
+
+/** Reasons a structured hard block was triggered. */
+export type StructuredBlockerReason =
+  | "open_blockedby_links"
+  | "open_child_issues"
+  | "pending_confirmation"
+  | "active_recovery_action";
+
+/** Advisory result from prose token scan — never blocks close. */
+export interface AdvisoryResult {
+  matchedTokens: string[];
+  /** True when all matched tokens are covered by guardAcknowledge. */
+  acknowledged: boolean;
+  acknowledgedReason?: string;
+}
+
+export type GuardDecision =
+  | { decision: "pass"; advisory?: AdvisoryResult }
+  | { decision: "blocked"; blockedBy: StructuredBlockerReason[] };
+
+/** Structured state inputs — the only source of hard-block truth. */
+export interface StructuredBlockerState {
+  /** Count of open blockedBy relations (from getDependencyReadiness). */
+  unresolvedBlockerCount: number;
+  /** Count of non-terminal child issues. */
+  openChildCount: number;
+  /** True if any request_confirmation interaction is in "pending" status. */
+  hasPendingConfirmation: boolean;
+  /** True if there is an active recovery action on this issue. */
+  hasActiveRecoveryAction: boolean;
+}
+
+export interface GuardInput {
+  state: StructuredBlockerState;
+  /**
+   * Optional advisory prose scan. Matched tokens are surfaced in the pass
+   * response but NEVER cause a 409 block.
+   */
+  advisory?: {
+    allText: string;
+    /** Tokens the agent acknowledges as false positives (audit-logged). */
+    acknowledgedTokens?: string[];
+    acknowledgedReason?: string;
+  };
+}
+
+export function evaluateGuard(input: GuardInput): GuardDecision {
+  const { state, advisory } = input;
+
+  const blockedBy: StructuredBlockerReason[] = [];
+  if (state.unresolvedBlockerCount > 0) blockedBy.push("open_blockedby_links");
+  if (state.openChildCount > 0) blockedBy.push("open_child_issues");
+  if (state.hasPendingConfirmation) blockedBy.push("pending_confirmation");
+  if (state.hasActiveRecoveryAction) blockedBy.push("active_recovery_action");
+
+  if (blockedBy.length > 0) {
+    return { decision: "blocked", blockedBy };
+  }
+
+  // Structured state is clean. Run optional advisory prose scan.
+  if (advisory) {
+    const matched = findMatchedGuardTokens(advisory.allText, BUILTIN_GUARD_TOKENS);
+    if (matched.length > 0) {
+      const ackSet = new Set(
+        (advisory.acknowledgedTokens ?? []).map((t) => t.toLowerCase()),
+      );
+      const acknowledged = matched.every((t) => ackSet.has(t.toLowerCase()));
+      return {
+        decision: "pass",
+        advisory: {
+          matchedTokens: matched,
+          acknowledged,
+          acknowledgedReason: acknowledged
+            ? (advisory.acknowledgedReason ?? "")
+            : undefined,
+        },
+      };
+    }
+  }
+
+  return { decision: "pass" };
+}


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Issues carry a structured lifecycle (blockedBy links, parent/child, request_confirmation interactions, recovery actions) and a terminal-close transition (`done` / `cancelled`) via `PATCH /api/issues/:id`
> - There is no server-side guard preventing an agent from marking an issue terminal while it still has unresolved structured state — a blocked issue with open blockers can be closed and the close silently succeeds (HTTP 200)
> - This lets agents close out work whose dependencies are not actually resolved, eroding the integrity of run dispositions and hiding incomplete work
> - This pull request adds a pre-close guard on the terminal-close path that rejects the close with HTTP 409 when unresolved structured blockers exist, while leaving an explicit, audited human/board override for recovery and liveness-escalation closes
> - The benefit is that terminal dispositions become trustworthy: an issue cannot be marked done/cancelled while it still has open structured blockers unless a human operator explicitly forces it

## Linked Issues or Issue Description

No public GitHub issue exists. Describing the underlying bug inline, following `bug_report.yml`:

**What happened?**
The issue-update route (`PATCH /api/issues/:id`) accepts a transition to a terminal status (`done` / `cancelled`) without checking the issue's structured blocker state. An issue that is `blocked` with open `blockedBy` links (or open children, a pending `request_confirmation`, or an active recovery action) can be closed and the API returns `200`. There is no server-side pre-close guard.

**Expected behavior**
A terminal close of an issue that still carries unresolved structured state should be rejected with `409`, so an agent cannot mark work `done`/`cancelled` while its dependencies are unresolved. A human/board operator must retain an explicit, audited override for recovery and liveness-escalation closes.

**Steps to reproduce**
1. Create issue B with status `in_progress`.
2. Create issue A with status `blocked` and `blockedBy: [B]`.
3. As an agent actor, `PATCH /api/issues/A {status:"done"}`.
4. Observed: `200` and A is closed. Expected: `409 PRE_CLOSE_GUARD_BLOCKED`. With a human/board actor and `forceTerminal:true`, the close proceeds and is audited.

**Paperclip version or commit**
Reproduced on `master` (base `e6407b322`); also observed on released server `2026.626.0`, which ships no terminal-close guard.

**Deployment mode**
Self-hosted server (`@paperclipai/server`), core (not adapter-specific).

- [x] I searched the open PR list for similar/duplicate PRs before opening this one.

## What Changed

- `server/src/services/pre-close-guard.ts` (new): pure, dependency-free structured-blocker evaluator. `evaluateGuard({state, advisory})` returns `{decision:"blocked", blockedBy:[...]}` when any of `unresolvedBlockerCount>0`, `openChildCount>0`, `hasPendingConfirmation`, `hasActiveRecoveryAction` holds; otherwise `{decision:"pass"}`. Prose-token scanning is retained as **non-blocking advisory only** (surfaced in the pass response, never causes a 409).
- `server/src/routes/issues.ts` (+108): on a requested terminal transition, fetch dependency readiness, open children, pending confirmations and active recovery action in parallel, evaluate the guard, and return `409 {error/code: "PRE_CLOSE_GUARD_BLOCKED", blockedBy, requestedStatus}` when blocked. The guard decision is recorded in the issue activity audit details (`preCloseGuard`).
- **Recovery / liveness-escalation carve-out:** an optional `forceTerminal: true` on the update body bypasses the block **only when the actor is a human/board user** (`actorType === "user"`). For agent actors `forceTerminal` is ignored — agents are always subject to the guard. A forced close still runs the evaluation and records `{decision:"forced", blockedBy, forcedByActorId}` in the audit details, so every override is attributable.
- `server/src/__tests__/pre-close-guard.test.ts` (new): 26 tests — the structured-blocker matrix plus the carve-out gate (agent + force → still blocked; user + force → passes + audited; user without force → blocked).

## Verification

- `cd server && npx vitest run src/__tests__/pre-close-guard.test.ts` → **26 passed / 0 failed**.
- Pure module type-check: `npx tsc --noEmit server/src/services/pre-close-guard.ts` → clean (exit 0).
- Project type-check (`server/tsconfig.json`) shows an identical pre-existing error count with and without this change (known cross-package staleness); no new type errors fall within the inserted ranges.
- Manual repro above: agent-actor terminal close of a blocked issue → `409`; user-actor `forceTerminal:true` → close proceeds and is audited.

## Risks

Low. The new behavior only affects the terminal-close transition of `PATCH /api/issues/:id`; non-terminal updates are unchanged. The strictest blast radius is that automated/agent callers can no longer terminal-close an issue with unresolved structured blockers — which is the intended behavior. Human/board operators retain a full, audited override via `forceTerminal`. No DB migration. The control fields (`forceTerminal`, `guardAcknowledge`) are explicitly destructured out of the persisted update payload so they do not leak into the DB write.

## Model Used

Claude Opus 4.8 (`claude-opus-4-8`), via the Claude Agent SDK with tool use / code execution; extended-thinking reasoning enabled.
