### PR TITLE
fix(issues): enforce §7.10.3 pre-close guard on terminal close

### DIFF
--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -2963,6 +2963,66 @@ describeEmbeddedPostgres("issueService blockers and dependency wake readiness", 
     expect(blockedRelations.blockedBy.map((relation) => relation.id)).toEqual([blockerId]);
   });
 
+  it("§7.10.3 pre-close guard: blocks an agent from closing an issue with unresolved blockers, allows board override and resolved/recovery closes", async () => {
+    const companyId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    const actorAgentId = randomUUID();
+    const actorUserId = randomUUID();
+
+    const blockerId = randomUUID();
+    const blockedId = randomUUID();
+    const recoveryId = randomUUID();
+    await db.insert(issues).values([
+      { id: blockerId, companyId, title: "Blocker", status: "todo", priority: "high" },
+      { id: blockedId, companyId, title: "Blocked issue", status: "blocked", priority: "medium" },
+      {
+        id: recoveryId,
+        companyId,
+        title: "Recovery issue",
+        status: "blocked",
+        priority: "medium",
+        originKind: "stranded_issue_recovery",
+      },
+    ]);
+    await svc.update(blockedId, { blockedByIssueIds: [blockerId] });
+    await svc.update(recoveryId, { blockedByIssueIds: [blockerId] });
+
+    // Agent close while a first-class blocker is unresolved → 409 PRE_CLOSE_GUARD_BLOCKED.
+    await expect(
+      svc.update(blockedId, { status: "done", actorAgentId }),
+    ).rejects.toMatchObject({
+      status: 409,
+      details: { code: "pre_close_guard_blocked", unresolvedBlockerIssueIds: [blockerId] },
+    });
+    // The same guard covers cancellation.
+    await expect(
+      svc.update(blockedId, { status: "cancelled", actorAgentId }),
+    ).rejects.toMatchObject({ status: 409, details: { code: "pre_close_guard_blocked" } });
+
+    // Carve-out: board/user actor override.
+    const boardClosed = await svc.update(blockedId, { status: "done", actorUserId });
+    expect(boardClosed?.status).toBe("done");
+
+    // Carve-out: recovery/liveness-escalation origin closes even with an open blocker.
+    const recoveryClosed = await svc.update(recoveryId, { status: "done", actorAgentId });
+    expect(recoveryClosed?.status).toBe("done");
+
+    // Resolution path: once the blocker is resolved, an agent close succeeds.
+    const blockedId2 = randomUUID();
+    await db.insert(issues).values({
+      id: blockedId2, companyId, title: "Blocked issue 2", status: "blocked", priority: "medium",
+    });
+    await svc.update(blockedId2, { blockedByIssueIds: [blockerId] });
+    await svc.update(blockerId, { status: "done", actorAgentId });
+    const closedAfterResolve = await svc.update(blockedId2, { status: "done", actorAgentId });
+    expect(closedAfterResolve?.status).toBe("done");
+  });
+
   it("adds terminal blockers to immediate blocked-by summaries", async () => {
     const companyId = randomUUID();
     await db.insert(companies).values({

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -3008,9 +3008,32 @@ describeEmbeddedPostgres("issueService blockers and dependency wake readiness", 
     const boardClosed = await svc.update(blockedId, { status: "done", actorUserId });
     expect(boardClosed?.status).toBe("done");
 
-    // Carve-out: recovery/liveness-escalation origin closes even with an open blocker.
+    // Carve-out: a blocker-holding recovery origin (stranded_issue_recovery) closes
+    // even with an open blocker, because it tears down its own blocker edge on close.
     const recoveryClosed = await svc.update(recoveryId, { status: "done", actorAgentId });
     expect(recoveryClosed?.status).toBe("done");
+
+    // Narrowed carve-out: a non-blocker-holding recovery origin (productivity review)
+    // is still guarded — the exemption is limited to BLOCKED_INBOX_RECOVERY_ORIGIN_KINDS.
+    const reviewId = randomUUID();
+    await db.insert(issues).values({
+      id: reviewId, companyId, title: "Productivity review", status: "blocked", priority: "medium",
+      originKind: "issue_productivity_review",
+    });
+    await svc.update(reviewId, { blockedByIssueIds: [blockerId] });
+    await expect(
+      svc.update(reviewId, { status: "done", actorAgentId }),
+    ).rejects.toMatchObject({ status: 409, details: { code: "pre_close_guard_blocked" } });
+
+    // Same-PATCH detach-and-close: clearing the blocker relation in the same update
+    // that closes the issue is allowed (no unresolved blocker remains after the patch).
+    const detachId = randomUUID();
+    await db.insert(issues).values({
+      id: detachId, companyId, title: "Detach-and-close", status: "blocked", priority: "medium",
+    });
+    await svc.update(detachId, { blockedByIssueIds: [blockerId] });
+    const detached = await svc.update(detachId, { status: "done", blockedByIssueIds: [], actorAgentId });
+    expect(detached?.status).toBe("done");
 
     // Resolution path: once the blocker is resolved, an agent close succeeds.
     const blockedId2 = randomUUID();

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -5182,6 +5182,37 @@ export function issueService(db: Db) {
           throw unprocessable("Issue is blocked by unresolved blockers", { unresolvedBlockerIssueIds });
         }
       }
+      // §7.10.3 pre-close evidence guard. An agent actor may not move an issue to a
+      // terminal status (done/cancelled) while it still has unresolved first-class
+      // blockers: doing so silently discards the dependency instead of resolving,
+      // cancelling, or detaching it. The agent must first clear/detach the blocker
+      // (or set the same patch's blockedByIssueIds to an empty/resolved set).
+      // Carve-outs:
+      //  - Board/user actors keep an explicit override (operator authority).
+      //  - Recovery/liveness-escalation issues are exempt because they legitimately
+      //    tear down their own blocker edge as part of closing (see the
+      //    issueGraphLivenessEscalation handling later in this transaction).
+      const isTerminalClose =
+        (patch.status === "done" || patch.status === "cancelled") &&
+        existing.status !== patch.status;
+      const isAgentActor = !!actorAgentId && !actorUserId;
+      const isRecoveryOriginIssue =
+        existing.originKind != null &&
+        (Object.values(RECOVERY_ORIGIN_KINDS) as ReadonlyArray<string>).includes(existing.originKind);
+      if (isTerminalClose && isAgentActor && !isRecoveryOriginIssue) {
+        const unresolvedBlockerIssueIds = blockedByIssueIds !== undefined
+          ? await listUnresolvedBlockerIssueIds(dbOrTx, existing.companyId, blockedByIssueIds)
+          : (
+              await listIssueDependencyReadinessMap(dbOrTx, existing.companyId, [id])
+            ).get(id)?.unresolvedBlockerIssueIds ?? [];
+        if (unresolvedBlockerIssueIds.length > 0) {
+          throw conflict("PRE_CLOSE_GUARD_BLOCKED: issue has unresolved first-class blockers", {
+            code: "pre_close_guard_blocked",
+            requestedStatus: patch.status,
+            unresolvedBlockerIssueIds,
+          });
+        }
+      }
       const shouldValidateNextAssignee =
         Boolean(nextAssigneeAgentId) &&
         (issueData.assigneeAgentId !== undefined || patch.status === "in_progress");

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -5189,17 +5189,22 @@ export function issueService(db: Db) {
       // (or set the same patch's blockedByIssueIds to an empty/resolved set).
       // Carve-outs:
       //  - Board/user actors keep an explicit override (operator authority).
-      //  - Recovery/liveness-escalation issues are exempt because they legitimately
-      //    tear down their own blocker edge as part of closing (see the
-      //    issueGraphLivenessEscalation handling later in this transaction).
+      //  - Blocked-inbox recovery issues (liveness-escalation, stranded-issue
+      //    recovery) are exempt because they legitimately tear down their own
+      //    blocker edge as part of closing (see the issueGraphLivenessEscalation
+      //    handling later in this transaction). Other recovery origins
+      //    (productivity-review, stale-active-run) do not hold a blocker edge they
+      //    must discard on close, so the guard applies to them normally.
       const isTerminalClose =
         (patch.status === "done" || patch.status === "cancelled") &&
         existing.status !== patch.status;
       const isAgentActor = !!actorAgentId && !actorUserId;
-      const isRecoveryOriginIssue =
+      const isBlockerHoldingRecoveryIssue =
         existing.originKind != null &&
-        (Object.values(RECOVERY_ORIGIN_KINDS) as ReadonlyArray<string>).includes(existing.originKind);
-      if (isTerminalClose && isAgentActor && !isRecoveryOriginIssue) {
+        BLOCKED_INBOX_RECOVERY_ORIGIN_KINDS.includes(
+          existing.originKind as (typeof BLOCKED_INBOX_RECOVERY_ORIGIN_KINDS)[number],
+        );
+      if (isTerminalClose && isAgentActor && !isBlockerHoldingRecoveryIssue) {
         const unresolvedBlockerIssueIds = blockedByIssueIds !== undefined
           ? await listUnresolvedBlockerIssueIds(dbOrTx, existing.companyId, blockedByIssueIds)
           : (


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Issue lifecycle is enforced in `server/src/services/issues.ts` (`issues.update()`), the single chokepoint behind `PATCH /api/issues/:id`
> - Issues can carry **first-class blocker** relations; an unresolved blocker means the dependency work is not finished
> - `update()` only rejected unresolved blockers on the `in_progress` transition, so an agent could move a still-`blocked` issue **straight to a terminal status** and the dependency was silently dropped
> - This pull request adds the same unresolved-blocker enforcement to the `done`/`cancelled` (terminal-close) transition
> - The benefit is that closing an issue no longer silently discards an open dependency — the blocker must be resolved, cancelled, or detached first, while operators and blocker-holding recovery flows keep an explicit path through

## Linked Issues or Issue Description

No public issue exists — describing inline per the bug-report template:

### What happened?

`PATCH /api/issues/:id` with `{ "status": "done" }` (or `"cancelled"`) on an issue that is `blocked` by an unresolved first-class blocker returns **HTTP 200** and closes the issue, silently discarding the dependency. The unresolved-blocker check in `issues.update()` is gated on `patch.status === "in_progress"` only, so terminal closes bypass it. `assertTransition()` permits `blocked → done`, and there is no terminal-close evidence guard on the REST path.

### Expected behavior

The terminal close is rejected with **HTTP 409** (`code: "pre_close_guard_blocked"`) until the blocker is resolved, cancelled, or detached — matching the existing behavior of the `in_progress` transition.

### Steps to reproduce

1. Create issue A and issue B; leave B open (e.g. `todo`).
2. Block A on B (`PATCH A { blockedByIssueIds: [B] }`); A becomes `blocked`.
3. As an agent actor, `PATCH A { status: "done" }`.
4. Observed: `200`, A is `done`. Expected: `409 pre_close_guard_blocked`.

### Paperclip version or commit

Reproduced on `@paperclipai/server` 2026.626.0 (and present on 2026.618.0 — the terminal-close path was never guarded). Fix targets current `master`.

### Deployment mode

Self-hosted, authenticated deployment mode (single embedded-Postgres instance).

## What Changed

- `server/src/services/issues.ts` — add a terminal-close guard in `issues.update()`: moving to `done`/`cancelled` with unresolved first-class blockers throws `409` (`conflict`) with `details.code = "pre_close_guard_blocked"` and `unresolvedBlockerIssueIds`. Uses the same per-patch `blockedByIssueIds` recomputation as the `in_progress` check, so detaching/resolving blockers in the same PATCH closes cleanly.
- Carve-outs: **board/user actors** keep an explicit operator override (`actorUserId`); **blocker-holding recovery issues** — the existing `BLOCKED_INBOX_RECOVERY_ORIGIN_KINDS` set (`harness_liveness_escalation`, `stranded_issue_recovery`) — are exempt because they legitimately tear down their own blocker edge on close (consistent with the existing `issueGraphLivenessEscalation` handling in the same transaction). Other recovery origins do not hold a blocker edge and are guarded normally.
- `server/src/__tests__/issues-service.test.ts` — focused test covering the reject path (both `done` and `cancelled`), the board override, the blocker-holding-recovery carve-out, the narrowed-carve-out (productivity-review origin still guarded), the same-PATCH detach-and-close path, and the resolve-then-close path.

## Verification

- `pnpm --filter @paperclipai/server test issues-service` — the new test exercises the guard, both carve-outs, the narrowing, the same-PATCH detach, and the resolve path.
- Manual: with the change, `PATCH` a `blocked` issue (open blocker) to `done` as an agent → `409 pre_close_guard_blocked`; resolve/detach the blocker → `200`.

## Risks

- Governance-enforcement change, platform-wide. Blast radius is limited to **agent self-closes of issues that still carry unresolved first-class blockers** — board/user operators and blocker-holding recovery flows are explicitly unaffected.
- No schema/migration change. No change to the `in_progress` path. Remediation for a blocked agent close is to resolve, cancel, or detach the blocker (or set `blockedByIssueIds` to a resolved set in the same patch) before closing.

## Model Used

Claude Opus 4.8 (`claude-opus-4-8`), reasoning + tool use; ~200k context.

## Checklist

- [x] I searched the open/closed PR list for similar PRs (dedup search) and found none addressing the terminal-close blocker gap.