### PR TITLE
Fix monitored review blocker attention

### DIFF
--- a/packages/shared/src/types/issue.ts
+++ b/packages/shared/src/types/issue.ts
@@ -208,6 +208,8 @@ export interface IssueRelationIssueSummary {
   priority: IssuePriority;
   assigneeAgentId: string | null;
   assigneeUserId: string | null;
+  executionPolicy?: IssueExecutionPolicy | null;
+  monitorNextCheckAt?: Date | null;
   terminalBlockers?: IssueRelationIssueSummary[];
   activeRecoveryAction?: IssueRecoveryAction | null;
 }

--- a/server/src/__tests__/issue-blocker-attention.test.ts
+++ b/server/src/__tests__/issue-blocker-attention.test.ts
@@ -100,6 +100,8 @@ describeEmbeddedPostgres("issue blocker attention", () => {
     originId?: string | null;
     originFingerprint?: string | null;
     executionState?: Record<string, unknown> | null;
+    executionPolicy?: Record<string, unknown> | null;
+    monitorNextCheckAt?: Date | null;
     description?: string | null;
   }) {
     const id = input.id ?? randomUUID();
@@ -117,6 +119,8 @@ describeEmbeddedPostgres("issue blocker attention", () => {
       originId: input.originId ?? null,
       originFingerprint: input.originFingerprint ?? "default",
       executionState: input.executionState ?? null,
+      executionPolicy: input.executionPolicy ?? null,
+      monitorNextCheckAt: input.monitorNextCheckAt ?? null,
       description: input.description ?? null,
     });
     return id;
@@ -421,6 +425,81 @@ describeEmbeddedPostgres("issue blocker attention", () => {
       state: "covered",
       stalledBlockerCount: 0,
     });
+  });
+
+  it("treats a monitored in_review blocker as covered and includes monitor metadata in relation summaries", async () => {
+    const { companyId, agentId } = await createCompany("DYS");
+    const parentId = await insertIssue({ companyId, identifier: "DYS-913", title: "Blocked parent", status: "blocked" });
+    const nestedParentId = await insertIssue({ companyId, identifier: "DYS-914", title: "Nested blocked parent", status: "blocked" });
+    const intermediateId = await insertIssue({ companyId, identifier: "DYS-915", title: "Intermediate blocker", status: "blocked" });
+    const monitorNextCheckAt = new Date(Date.now() + 60 * 60 * 1000);
+    const blockerId = await insertIssue({
+      companyId,
+      identifier: "DYS-1116",
+      title: "Monitored review blocker",
+      status: "in_review",
+      assigneeAgentId: agentId,
+      executionState: {
+        monitor: {
+          status: "scheduled",
+          nextCheckAt: monitorNextCheckAt.toISOString(),
+        },
+      },
+      executionPolicy: {
+        mode: "normal",
+        commentRequired: true,
+        stages: [],
+        monitor: {
+          nextCheckAt: monitorNextCheckAt.toISOString(),
+          notes: "Daily PR #8681 monitor cadence",
+          scheduledBy: "assignee",
+        },
+      },
+      monitorNextCheckAt,
+    });
+    await block({ companyId, blockerIssueId: blockerId, blockedIssueId: parentId });
+    await block({ companyId, blockerIssueId: intermediateId, blockedIssueId: nestedParentId });
+    await block({ companyId, blockerIssueId: blockerId, blockedIssueId: intermediateId });
+
+    const issues = await svc.list(companyId, { status: "blocked", includeBlockedBy: true });
+    const parent = issues.find((issue) => issue.id === parentId);
+    const nestedParent = issues.find((issue) => issue.id === nestedParentId);
+
+    expect(parent?.blockerAttention).toMatchObject({
+      state: "covered",
+      reason: "active_dependency",
+      unresolvedBlockerCount: 1,
+      coveredBlockerCount: 1,
+      stalledBlockerCount: 0,
+      attentionBlockerCount: 0,
+      sampleBlockerIdentifier: "DYS-1116",
+    });
+    expect(parent?.blockedBy).toEqual([
+      expect.objectContaining({
+        id: blockerId,
+        identifier: "DYS-1116",
+        monitorNextCheckAt,
+        executionPolicy: expect.objectContaining({
+          monitor: expect.objectContaining({
+            nextCheckAt: monitorNextCheckAt.toISOString(),
+          }),
+        }),
+      }),
+    ]);
+    expect(nestedParent?.blockedBy).toEqual([expect.objectContaining({ id: intermediateId, identifier: "DYS-915" })]);
+    const nestedRelations = await svc.getRelationSummaries(nestedParentId);
+    expect(nestedRelations.blockedBy[0]?.terminalBlockers).toEqual([
+      expect.objectContaining({
+        id: blockerId,
+        identifier: "DYS-1116",
+        monitorNextCheckAt,
+        executionPolicy: expect.objectContaining({
+          monitor: expect.objectContaining({
+            nextCheckAt: monitorNextCheckAt.toISOString(),
+          }),
+        }),
+      }),
+    ]);
   });
 
   it("flags a deep chain whose leaf is stalled in_review through multiple layers", async () => {

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1373,11 +1373,12 @@ type IssueBlockerAttentionNode = {
   executionRunId?: string | null;
   assigneeAgentId: string | null;
   assigneeUserId: string | null;
+  monitorNextCheckAt?: Date | null;
 };
 type IssueBlockerAttentionInputNode =
   Pick<
     IssueBlockerAttentionNode,
-    "id" | "companyId" | "parentId" | "identifier" | "title" | "status" | "assigneeAgentId" | "assigneeUserId"
+    "id" | "companyId" | "parentId" | "identifier" | "title" | "status" | "assigneeAgentId" | "assigneeUserId" | "monitorNextCheckAt"
   >
   & { executionRunId?: string | null };
 
@@ -1473,6 +1474,8 @@ type IssueRelationSummaryRow = {
   priority: string;
   assigneeAgentId: string | null;
   assigneeUserId: string | null;
+  executionPolicy?: unknown;
+  monitorNextCheckAt?: Date | null;
 };
 
 function summarizeIssueRelationRow(row: IssueRelationSummaryRow): IssueRelationIssueSummary {
@@ -1484,6 +1487,8 @@ function summarizeIssueRelationRow(row: IssueRelationSummaryRow): IssueRelationI
     priority: row.priority as IssueRelationIssueSummary["priority"],
     assigneeAgentId: row.assigneeAgentId,
     assigneeUserId: row.assigneeUserId,
+    executionPolicy: (row.executionPolicy ?? null) as IssueRelationIssueSummary["executionPolicy"],
+    monitorNextCheckAt: row.monitorNextCheckAt ?? null,
   };
 }
 
@@ -1514,6 +1519,8 @@ async function terminalExplicitBlockersByRoot(
           priority: issues.priority,
           assigneeAgentId: issues.assigneeAgentId,
           assigneeUserId: issues.assigneeUserId,
+          executionPolicy: issues.executionPolicy,
+          monitorNextCheckAt: issues.monitorNextCheckAt,
         })
         .from(issueRelations)
         .innerJoin(issues, eq(issueRelations.issueId, issues.id))
@@ -1715,6 +1722,7 @@ async function listIssueBlockerAttentionMap(
           executionRunId: issues.executionRunId,
           assigneeAgentId: issues.assigneeAgentId,
           assigneeUserId: issues.assigneeUserId,
+          monitorNextCheckAt: issues.monitorNextCheckAt,
         })
         .from(issueRelations)
         .innerJoin(issues, eq(issueRelations.issueId, issues.id))
@@ -1740,6 +1748,7 @@ async function listIssueBlockerAttentionMap(
           executionRunId: issues.executionRunId,
           assigneeAgentId: issues.assigneeAgentId,
           assigneeUserId: issues.assigneeUserId,
+          monitorNextCheckAt: issues.monitorNextCheckAt,
         })
         .from(issues)
         .where(
@@ -1775,6 +1784,7 @@ async function listIssueBlockerAttentionMap(
           executionRunId: row.executionRunId,
           assigneeAgentId: row.assigneeAgentId,
           assigneeUserId: row.assigneeUserId,
+          monitorNextCheckAt: row.monitorNextCheckAt,
         });
         nextFrontier.add(row.blockerIssueId);
       }
@@ -1945,7 +1955,8 @@ async function listIssueBlockerAttentionMap(
       return { covered: true, stalled: false, sampleBlockerIdentifier: nodeSample, sampleStalledBlockerIdentifier: null };
     }
     if (node.status === "in_review") {
-      const hasWaitingPath = activeIssueIds.has(node.id) || Boolean(node.assigneeUserId);
+      const hasFutureMonitor = Boolean(node.monitorNextCheckAt && node.monitorNextCheckAt.getTime() > Date.now());
+      const hasWaitingPath = activeIssueIds.has(node.id) || Boolean(node.assigneeUserId) || hasFutureMonitor;
       if (hasWaitingPath) {
         return { covered: true, stalled: false, sampleBlockerIdentifier: nodeSample, sampleStalledBlockerIdentifier: null };
       }
@@ -2279,6 +2290,8 @@ async function blockedByMapForIssues(
         priority: issues.priority,
         assigneeAgentId: issues.assigneeAgentId,
         assigneeUserId: issues.assigneeUserId,
+        executionPolicy: issues.executionPolicy,
+        monitorNextCheckAt: issues.monitorNextCheckAt,
       })
       .from(issueRelations)
       .innerJoin(issues, eq(issueRelations.issueId, issues.id))
@@ -2293,15 +2306,7 @@ async function blockedByMapForIssues(
     for (const row of rows) {
       const blockedBy = map.get(row.currentIssueId);
       if (!blockedBy) continue;
-      blockedBy.push({
-        id: row.relatedId,
-        identifier: row.identifier,
-        title: row.title,
-        status: row.status as IssueRelationIssueSummary["status"],
-        priority: row.priority as IssueRelationIssueSummary["priority"],
-        assigneeAgentId: row.assigneeAgentId,
-        assigneeUserId: row.assigneeUserId,
-      });
+      blockedBy.push(summarizeIssueRelationRow(row));
     }
   }
 
@@ -3678,6 +3683,8 @@ export function issueService(db: Db) {
           priority: issues.priority,
           assigneeAgentId: issues.assigneeAgentId,
           assigneeUserId: issues.assigneeUserId,
+          executionPolicy: issues.executionPolicy,
+          monitorNextCheckAt: issues.monitorNextCheckAt,
         })
         .from(issueRelations)
         .innerJoin(issues, eq(issueRelations.issueId, issues.id))
@@ -3698,6 +3705,8 @@ export function issueService(db: Db) {
           priority: issues.priority,
           assigneeAgentId: issues.assigneeAgentId,
           assigneeUserId: issues.assigneeUserId,
+          executionPolicy: issues.executionPolicy,
+          monitorNextCheckAt: issues.monitorNextCheckAt,
         })
         .from(issueRelations)
         .innerJoin(issues, eq(issueRelations.relatedIssueId, issues.id))


### PR DESCRIPTION
## Thinking Path
PR #8751 was closed because the source branch exposed an internal ticket id. This replacement keeps the exact scoped code commit but moves it to a public-safe branch name: `fix/monitored-review-blocker-attention`.

Dedup search completed before opening this replacement:
- [x] Searched existing PRs for similar/open replacements. Only prior match was closed PR #8751.

## What Changed
- Added blocker attention metadata to shared issue types.
- Included monitored review blocker attention in issue service responses.
- Added focused service coverage for blocker attention behavior.

## Risks
- Low risk. Diff is limited to issue response shaping and focused tests.
- Main risk is stale PR checks from reusing the original commit; fresh replacement PR checks are running on #8759.

## Model Used
codex_local / GPT-5.5

## Verification
- `pnpm exec vitest run server/src/__tests__/issue-blocker-attention.test.ts`
- `pnpm --filter @paperclipai/shared typecheck`
- `pnpm --filter @paperclipai/server typecheck`

Replaces closed PR #8751 from a public-safe branch name.