### PR TITLE
[codex] Group workspace routines by project

### DIFF
--- a/ui/src/lib/workspace-routines.test.ts
+++ b/ui/src/lib/workspace-routines.test.ts
@@ -2,6 +2,7 @@ import type { RoutineListItem } from "@paperclipai/shared";
 import { describe, expect, it } from "vitest";
 import {
   getWorkspaceSpecificRoutineVariableNames,
+  groupWorkspaceSpecificRoutines,
   routineHasWorkspaceSpecificVariables,
   sortWorkspaceRoutinesByName,
 } from "./workspace-routines";
@@ -95,5 +96,47 @@ describe("workspace routine helpers", () => {
       "routine-2",
     ]);
     expect(routines.map((routine) => routine.id)).toEqual(["routine-2", "routine-3", "routine-1"]);
+  });
+
+  it("groups current-project workspace routines before other workspace routines and ignores non-workspace routines", () => {
+    const currentRoutine = createRoutine({
+      id: "routine-current",
+      projectId: "project-1",
+      title: "Current review",
+      variables: [
+        { name: "workspaceBranch", label: null, type: "text", defaultValue: null, required: true, options: [] },
+      ],
+    });
+    const otherProjectRoutine = createRoutine({
+      id: "routine-other-project",
+      projectId: "project-2",
+      title: "Beta other review",
+      variables: [
+        { name: "workspaceBranch", label: null, type: "text", defaultValue: null, required: true, options: [] },
+      ],
+    });
+    const noProjectRoutine = createRoutine({
+      id: "routine-no-project",
+      projectId: null,
+      title: "Alpha other review",
+      variables: [
+        { name: "workspaceBranch", label: null, type: "text", defaultValue: null, required: true, options: [] },
+      ],
+    });
+    const generalRoutine = createRoutine({
+      id: "routine-general",
+      projectId: "project-1",
+      variables: [
+        { name: "repo", label: null, type: "text", defaultValue: null, required: true, options: [] },
+      ],
+    });
+
+    expect(groupWorkspaceSpecificRoutines(
+      [otherProjectRoutine, generalRoutine, currentRoutine, noProjectRoutine],
+      "project-1",
+    )).toEqual({
+      thisWorkspace: [currentRoutine],
+      otherWorkspaces: [noProjectRoutine, otherProjectRoutine],
+    });
   });
 });

--- a/ui/src/lib/workspace-routines.test.ts
+++ b/ui/src/lib/workspace-routines.test.ts
@@ -139,4 +139,19 @@ describe("workspace routine helpers", () => {
       otherWorkspaces: [noProjectRoutine, otherProjectRoutine],
     });
   });
+
+  it("does not treat company-wide routines as current-workspace routines when the workspace has no project", () => {
+    const noProjectRoutine = createRoutine({
+      id: "routine-no-project",
+      projectId: null,
+      variables: [
+        { name: "workspaceBranch", label: null, type: "text", defaultValue: null, required: true, options: [] },
+      ],
+    });
+
+    expect(groupWorkspaceSpecificRoutines([noProjectRoutine], null)).toEqual({
+      thisWorkspace: [],
+      otherWorkspaces: [noProjectRoutine],
+    });
+  });
 });

--- a/ui/src/lib/workspace-routines.ts
+++ b/ui/src/lib/workspace-routines.ts
@@ -37,3 +37,33 @@ export function sortWorkspaceRoutinesByName(routines: RoutineListItem[]): Routin
     return left.id.localeCompare(right.id);
   });
 }
+
+export interface WorkspaceRoutineGroups {
+  thisWorkspace: RoutineListItem[];
+  otherWorkspaces: RoutineListItem[];
+}
+
+export function groupWorkspaceSpecificRoutines(
+  routines: RoutineListItem[],
+  currentProjectId: string | null,
+): WorkspaceRoutineGroups {
+  const groups: WorkspaceRoutineGroups = {
+    thisWorkspace: [],
+    otherWorkspaces: [],
+  };
+
+  for (const routine of routines) {
+    if (!routineHasWorkspaceSpecificVariables(routine)) continue;
+
+    if (routine.projectId === currentProjectId) {
+      groups.thisWorkspace.push(routine);
+    } else {
+      groups.otherWorkspaces.push(routine);
+    }
+  }
+
+  return {
+    thisWorkspace: sortWorkspaceRoutinesByName(groups.thisWorkspace),
+    otherWorkspaces: sortWorkspaceRoutinesByName(groups.otherWorkspaces),
+  };
+}

--- a/ui/src/lib/workspace-routines.ts
+++ b/ui/src/lib/workspace-routines.ts
@@ -55,7 +55,7 @@ export function groupWorkspaceSpecificRoutines(
   for (const routine of routines) {
     if (!routineHasWorkspaceSpecificVariables(routine)) continue;
 
-    if (routine.projectId === currentProjectId) {
+    if (currentProjectId !== null && routine.projectId === currentProjectId) {
       groups.thisWorkspace.push(routine);
     } else {
       groups.otherWorkspaces.push(routine);

--- a/ui/src/pages/ExecutionWorkspaceDetail.test.tsx
+++ b/ui/src/pages/ExecutionWorkspaceDetail.test.tsx
@@ -2,7 +2,8 @@
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { ExecutionWorkspace, Project, RoutineListItem } from "@paperclipai/shared";
-import { act, type ReactNode } from "react";
+import type { ReactNode } from "react";
+import { flushSync } from "react-dom";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ExecutionWorkspaceDetail } from "./ExecutionWorkspaceDetail";
@@ -239,9 +240,7 @@ async function flush() {
 async function waitForCondition(condition: () => boolean) {
   for (let index = 0; index < 20; index += 1) {
     if (condition()) return;
-    await act(async () => {
-      await flush();
-    });
+    await flush();
   }
   expect(condition()).toBe(true);
 }
@@ -266,7 +265,7 @@ describe("ExecutionWorkspaceDetail plugin slots", () => {
   });
 
   afterEach(() => {
-    act(() => root?.unmount());
+    flushSync(() => root?.unmount());
     root = null;
     container.remove();
     vi.clearAllMocks();
@@ -276,7 +275,7 @@ describe("ExecutionWorkspaceDetail plugin slots", () => {
 
   async function render() {
     const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-    await act(async () => {
+    flushSync(() => {
       root = createRoot(container);
       root.render(
         <QueryClientProvider client={queryClient}>
@@ -284,9 +283,7 @@ describe("ExecutionWorkspaceDetail plugin slots", () => {
         </QueryClientProvider>,
       );
     });
-    await act(async () => {
-      await flush();
-    });
+    await flush();
   }
 
   it("scopes the plugin detail-tab discovery to execution_workspace and the workspace's company", async () => {

--- a/ui/src/pages/ExecutionWorkspaceDetail.test.tsx
+++ b/ui/src/pages/ExecutionWorkspaceDetail.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import type { ExecutionWorkspace, Project } from "@paperclipai/shared";
+import type { ExecutionWorkspace, Project, RoutineListItem } from "@paperclipai/shared";
 import { act, type ReactNode } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -181,6 +181,41 @@ function project(overrides: Partial<Project> = {}): Project {
   };
 }
 
+function routine(overrides: Partial<RoutineListItem> = {}): RoutineListItem {
+  const now = new Date("2026-05-01T00:00:00Z");
+  return {
+    id: "routine-1",
+    companyId: "company-1",
+    projectId: "project-1",
+    goalId: null,
+    parentIssueId: null,
+    title: "Workspace routine",
+    description: null,
+    assigneeAgentId: "agent-1",
+    priority: "medium",
+    status: "active",
+    concurrencyPolicy: "coalesce_if_active",
+    catchUpPolicy: "skip_missed",
+    variables: [
+      { name: "workspaceBranch", label: null, type: "text", defaultValue: null, required: true, options: [] },
+    ],
+    latestRevisionId: null,
+    latestRevisionNumber: 1,
+    createdByAgentId: null,
+    createdByUserId: null,
+    updatedByAgentId: null,
+    updatedByUserId: null,
+    lastTriggeredAt: null,
+    lastEnqueuedAt: null,
+    createdAt: now,
+    updatedAt: now,
+    triggers: [],
+    lastRun: null,
+    activeIssue: null,
+    ...overrides,
+  };
+}
+
 function pluginSlot(overrides: Record<string, unknown> = {}) {
   return {
     id: "changes-tab",
@@ -199,6 +234,16 @@ function pluginSlot(overrides: Record<string, unknown> = {}) {
 async function flush() {
   await new Promise((resolve) => setTimeout(resolve, 0));
   await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+async function waitForCondition(condition: () => boolean) {
+  for (let index = 0; index < 20; index += 1) {
+    if (condition()) return;
+    await act(async () => {
+      await flush();
+    });
+  }
+  expect(condition()).toBe(true);
 }
 
 describe("ExecutionWorkspaceDetail plugin slots", () => {
@@ -318,5 +363,33 @@ describe("ExecutionWorkspaceDetail plugin slots", () => {
       "Routines",
       "Default",
     ]);
+  });
+
+  it("loads all company routines and renders current and other workspace groups", async () => {
+    mockRouteLocation.pathname = "/execution-workspaces/workspace-1/routines";
+    mockRoutinesApi.list.mockResolvedValue([
+      routine({ id: "routine-current", title: "Current workspace routine", projectId: "project-1" }),
+      routine({ id: "routine-other", title: "Other workspace routine", projectId: "project-2" }),
+      routine({
+        id: "routine-general",
+        title: "General routine",
+        projectId: "project-1",
+        variables: [
+          { name: "repo", label: null, type: "text", defaultValue: null, required: true, options: [] },
+        ],
+      }),
+    ]);
+
+    await render();
+
+    await waitForCondition(() => container.textContent?.includes("This workspace") === true);
+
+    expect(mockRoutinesApi.list).toHaveBeenCalledWith("company-1");
+    expect(mockRoutinesApi.list).not.toHaveBeenCalledWith("company-1", { projectId: "project-1" });
+    expect(container.textContent).toContain("This workspace");
+    expect(container.textContent).toContain("Current workspace routine");
+    expect(container.textContent).toContain("Other workspaces");
+    expect(container.textContent).toContain("Other workspace routine");
+    expect(container.textContent).not.toContain("General routine");
   });
 });

--- a/ui/src/pages/ExecutionWorkspaceDetail.test.tsx
+++ b/ui/src/pages/ExecutionWorkspaceDetail.test.tsx
@@ -237,12 +237,13 @@ async function flush() {
   await new Promise((resolve) => setTimeout(resolve, 0));
 }
 
-async function waitForCondition(condition: () => boolean) {
-  for (let index = 0; index < 20; index += 1) {
+async function waitForCondition(condition: () => boolean, timeoutMs = 2000) {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < timeoutMs) {
     if (condition()) return;
     await flush();
   }
-  expect(condition()).toBe(true);
+  expect(condition(), `condition did not become true within ${timeoutMs}ms`).toBe(true);
 }
 
 describe("ExecutionWorkspaceDetail plugin slots", () => {

--- a/ui/src/pages/ExecutionWorkspaceDetail.tsx
+++ b/ui/src/pages/ExecutionWorkspaceDetail.tsx
@@ -39,8 +39,7 @@ import { queryKeys } from "../lib/queryKeys";
 import { cn, formatDateTime, issueUrl, projectRouteRef, projectWorkspaceUrl } from "../lib/utils";
 import {
   getWorkspaceSpecificRoutineVariableNames,
-  routineHasWorkspaceSpecificVariables,
-  sortWorkspaceRoutinesByName,
+  groupWorkspaceSpecificRoutines,
 } from "../lib/workspace-routines";
 
 type WorkspaceFormState = {
@@ -442,6 +441,37 @@ function WorkspaceRoutineRow({
   );
 }
 
+function WorkspaceRoutineGroup({
+  title,
+  routines,
+  runningRoutineId,
+  onRunNow,
+}: {
+  title: string;
+  routines: RoutineListItem[];
+  runningRoutineId: string | null;
+  onRunNow: (routine: RoutineListItem) => void;
+}) {
+  if (routines.length === 0) return null;
+
+  return (
+    <section className="space-y-2">
+      <h3 className="text-sm font-medium text-foreground">{title}</h3>
+      <div className="rounded-lg border border-border">
+        {routines.map((routine) => (
+          <WorkspaceRoutineRow
+            key={routine.id}
+            routine={routine}
+            variableNames={getWorkspaceSpecificRoutineVariableNames(routine)}
+            runningRoutineId={runningRoutineId}
+            onRunNow={onRunNow}
+          />
+        ))}
+      </div>
+    </section>
+  );
+}
+
 function ExecutionWorkspaceRoutinesList({
   workspace,
   project,
@@ -455,8 +485,8 @@ function ExecutionWorkspaceRoutinesList({
   const [runningRoutineId, setRunningRoutineId] = useState<string | null>(null);
 
   const { data: routines, isLoading, error } = useQuery({
-    queryKey: queryKeys.routines.list(workspace.companyId, { projectId: workspace.projectId }),
-    queryFn: () => routinesApi.list(workspace.companyId, { projectId: workspace.projectId }),
+    queryKey: queryKeys.routines.list(workspace.companyId),
+    queryFn: () => routinesApi.list(workspace.companyId),
   });
 
   const { data: agents } = useQuery({
@@ -464,10 +494,12 @@ function ExecutionWorkspaceRoutinesList({
     queryFn: () => agentsApi.list(workspace.companyId),
   });
 
-  const workspaceRoutines = useMemo(
-    () => sortWorkspaceRoutinesByName((routines ?? []).filter(routineHasWorkspaceSpecificVariables)),
-    [routines],
+  const workspaceRoutineGroups = useMemo(
+    () => groupWorkspaceSpecificRoutines(routines ?? [], workspace.projectId),
+    [routines, workspace.projectId],
   );
+  const hasWorkspaceRoutines =
+    workspaceRoutineGroups.thisWorkspace.length > 0 || workspaceRoutineGroups.otherWorkspaces.length > 0;
 
   const runRoutine = useMutation({
     mutationFn: ({ id, data }: { id: string; data?: RoutineRunDialogSubmitData }) => routinesApi.run(id, {
@@ -488,7 +520,7 @@ function ExecutionWorkspaceRoutinesList({
     onSuccess: async (_, { id }) => {
       setRunDialogRoutine(null);
       await Promise.all([
-        queryClient.invalidateQueries({ queryKey: ["routines", workspace.companyId] }),
+        queryClient.invalidateQueries({ queryKey: queryKeys.routines.list(workspace.companyId) }),
         queryClient.invalidateQueries({ queryKey: queryKeys.routines.detail(id) }),
         queryClient.invalidateQueries({ queryKey: queryKeys.issues.listByExecutionWorkspace(workspace.companyId, workspace.id) }),
         queryClient.invalidateQueries({ queryKey: queryKeys.issues.list(workspace.companyId) }),
@@ -527,7 +559,7 @@ function ExecutionWorkspaceRoutinesList({
             <p className="text-sm text-destructive">
               {error instanceof Error ? error.message : "Failed to load routines."}
             </p>
-          ) : workspaceRoutines.length === 0 ? (
+          ) : !hasWorkspaceRoutines ? (
             <div className="flex flex-col items-center gap-2 py-10 text-center">
               <Repeat className="h-5 w-5 text-muted-foreground" />
               <p className="text-sm text-muted-foreground">
@@ -535,16 +567,19 @@ function ExecutionWorkspaceRoutinesList({
               </p>
             </div>
           ) : (
-            <div className="rounded-lg border border-border">
-              {workspaceRoutines.map((routine) => (
-                <WorkspaceRoutineRow
-                  key={routine.id}
-                  routine={routine}
-                  variableNames={getWorkspaceSpecificRoutineVariableNames(routine)}
-                  runningRoutineId={runningRoutineId}
-                  onRunNow={setRunDialogRoutine}
-                />
-              ))}
+            <div className="space-y-5">
+              <WorkspaceRoutineGroup
+                title="This workspace"
+                routines={workspaceRoutineGroups.thisWorkspace}
+                runningRoutineId={runningRoutineId}
+                onRunNow={setRunDialogRoutine}
+              />
+              <WorkspaceRoutineGroup
+                title="Other workspaces"
+                routines={workspaceRoutineGroups.otherWorkspaces}
+                runningRoutineId={runningRoutineId}
+                onRunNow={setRunDialogRoutine}
+              />
             </div>
           )}
         </CardContent>


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Execution workspaces show task, service, configuration, runtime log, and routine controls for a workspace.
> - Workspace routines can be defined for several projects, but the workspace detail page only loaded routines filtered to the current project.
> - That made it hard to see workspace-specific routines that apply to other workspaces from the same company context.
> - This pull request loads company workspace routines and groups them by whether they belong to the current workspace project or another project.
> - The benefit is a clearer routines tab that still prioritizes the current workspace while preserving visibility into other workspace-specific routines.

## Linked Issues or Issue Description

No public GitHub issue exists for this change.

Feature request:
- Problem: the execution workspace routines tab should distinguish routines for the current workspace from workspace-specific routines tied to other projects.
- Expected behavior: workspace-specific routines appear in grouped sections labeled "This workspace" and "Other workspaces".
- Scope: UI grouping and focused tests for workspace routine detection/rendering.

Related public PRs checked:
- Refs #8666
- Refs #4958
- Refs #2539

## What Changed

- Added workspace routine grouping helpers for current-project and other-project routines.
- Updated the execution workspace routines tab to load company routines and render grouped sections.
- Guarded the null-project edge case so company-wide routines are not labeled as current-workspace routines when the current workspace has no project.
- Adjusted routine invalidation to use the shared routine list query key.
- Added focused helper and page tests for grouping behavior, including null current-project coverage.
- Updated the touched page test harness to use `flushSync` and a wall-clock async wait because this React install does not expose runtime `act`.

## Verification

- `pnpm exec vitest run ui/src/lib/workspace-routines.test.ts ui/src/pages/ExecutionWorkspaceDetail.test.tsx` — passed, 11 tests.
- `git diff --check` — passed before the final review-fix commit.
- Greptile re-review completed at 5/5 with no unresolved review threads.
- PR checks are green/neutral on the latest head: commitperclip review, Greptile, Socket, security-review, and Snyk.
- Searched public PRs for duplicate workspace routine grouping work before opening this PR.

## Risks

Low to moderate risk. The routines tab now fetches all company routines instead of only project-filtered routines, so companies with many routines may do a little more client-side filtering in this view. The display still filters to workspace-specific routines only.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

OpenAI Codex, GPT-5-based coding agent with tool use and local command execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
