### PR TITLE
fix(kubernetes): allow runtime image overrides

### DIFF
--- a/packages/plugins/sandbox-providers/kubernetes/README.md
+++ b/packages/plugins/sandbox-providers/kubernetes/README.md
@@ -65,6 +65,7 @@ Common optional fields:
 | `namespacePrefix` | `"paperclip-"` | Prefix for the per-company tenant namespace. |
 | `companySlug` | derived from companyId | Override the auto-derived company slug. |
 | `imageRegistry` | (none) | Override the default registry for agent runtime images. |
+| `runtimeImages` | `{}` | Per-adapter runtime image overrides keyed by adapter type. Overrides only the image, preserving built-in env keys, probes, and egress defaults. |
 | `imageAllowList` | `[]` | Glob patterns of allowed `target.imageOverride` values. Empty = no override permitted. |
 | `imagePullSecrets` | `[]` | Names of pre-created Docker image pull secrets in the tenant namespace. |
 | `egressAllowFqdns` | `[]` | Additional FQDNs (beyond adapter defaults like `api.anthropic.com`). |
@@ -76,6 +77,25 @@ Common optional fields:
 | `podActivityDeadlineSec` | `3600` | Hard ceiling on a single run's wall-clock time. |
 
 Full JSON Schema in `src/manifest.ts`.
+
+### Runtime image tags
+
+If your Paperclip runtime images are published with immutable tags, set `runtimeImages`
+instead of patching the plugin's built-in defaults:
+
+```json
+{
+  "adapterType": "claude_local",
+  "runtimeImages": {
+    "claude_local": "ghcr.io/paperclipai/agent-runtime-claude:git-b18cbb0dd3d524d3d332f54143c84f00c694636c"
+  }
+}
+```
+
+`runtimeImages` changes only the image for the matching adapter. The plugin still
+uses that adapter's default secret env keys, probe command, and egress FQDNs. If
+`imageRegistry` is also set, the registry prefix is rewritten while the image tag
+from `runtimeImages` is preserved.
 
 ### Task-scoped egress grants
 

--- a/packages/plugins/sandbox-providers/kubernetes/src/adapter-defaults.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/src/adapter-defaults.ts
@@ -9,6 +9,8 @@ export interface AdapterDefaults {
   defaultEnv?: Record<string, string>;
 }
 
+export type RuntimeImageOverrides = Record<string, string>;
+
 const REGISTRY: Record<string, AdapterDefaults> = {
   claude_local: {
     runtimeImage: "ghcr.io/paperclipai/agent-runtime-claude:v1",
@@ -72,24 +74,36 @@ function fromRegistryEntry(entry: AdapterRegistryEntry): AdapterDefaults {
 /**
  * Resolve the runtime defaults for an adapter. When a `registry` is supplied it
  * is authoritative (replace semantics): the type MUST be present and complete,
- * else this throws. With no registry, falls back to the built-in REGISTRY.
+ * else this throws. With no registry, falls back to the built-in REGISTRY. A
+ * matching `runtimeImages` entry overrides only the image, preserving env keys,
+ * egress defaults, probe command, and default env.
  */
 export function getAdapterDefaults(
   adapterType: string,
   registry?: readonly AdapterRegistryEntry[],
+  runtimeImages?: RuntimeImageOverrides,
 ): AdapterDefaults {
   if (registry && registry.length > 0) {
     const entry = registry.find((e) => e.adapterType === adapterType);
     if (!entry) {
       throw new Error(`Adapter "${adapterType}" is not in the configured adapter registry`);
     }
-    return fromRegistryEntry(entry);
+    return applyRuntimeImageOverride(adapterType, fromRegistryEntry(entry), runtimeImages);
   }
   const defaults = REGISTRY[adapterType];
   if (!defaults) {
     throw new Error(`Unknown adapter type: ${adapterType}`);
   }
-  return defaults;
+  return applyRuntimeImageOverride(adapterType, defaults, runtimeImages);
+}
+
+function applyRuntimeImageOverride(
+  adapterType: string,
+  defaults: AdapterDefaults,
+  runtimeImages?: RuntimeImageOverrides,
+): AdapterDefaults {
+  const runtimeImage = runtimeImages?.[adapterType]?.trim();
+  return runtimeImage ? { ...defaults, runtimeImage } : defaults;
 }
 
 /**

--- a/packages/plugins/sandbox-providers/kubernetes/src/manifest.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/src/manifest.ts
@@ -49,6 +49,12 @@ const manifest: PaperclipPluginManifestV1 = {
             type: "string",
             description: "Override the default registry for agent runtime images (default: ghcr.io/paperclipai).",
           },
+          runtimeImages: {
+            type: "object",
+            additionalProperties: { type: "string" },
+            description:
+              "Per-adapter runtime image overrides keyed by adapter type, e.g. {\"claude_local\":\"ghcr.io/paperclipai/agent-runtime-claude:git-sha\"}. Overrides only the image; env keys, probes, and egress defaults remain from the adapter defaults.",
+          },
           imageAllowList: {
             type: "array",
             items: { type: "string" },

--- a/packages/plugins/sandbox-providers/kubernetes/src/plugin.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/src/plugin.ts
@@ -222,7 +222,7 @@ const plugin = definePlugin({
     }
     const warnings: string[] = [];
     const cfg = parsed.data;
-    const adapterDefaults = getAdapterDefaults(cfg.adapterType, cfg.adapters);
+    const adapterDefaults = getAdapterDefaults(cfg.adapterType, cfg.adapters, cfg.runtimeImages);
     const totalFqdns = [...adapterDefaults.allowFqdns, ...cfg.egressAllowFqdns];
     if (cfg.egressMode === "standard" && totalFqdns.length > 0) {
       if (cfg.egressAllowCidrs.length === 0) {
@@ -312,7 +312,7 @@ const plugin = definePlugin({
     // Emit a runtime warning if FQDNs are configured but egressMode=standard
     // cannot enforce them. Mirrors the validateConfig warning so operators see
     // it in paperclip-server logs even if they missed the validation step.
-    const adapterDefaultsForWarn = getAdapterDefaults(effectiveAdapterType, config.adapters);
+    const adapterDefaultsForWarn = getAdapterDefaults(effectiveAdapterType, config.adapters, config.runtimeImages);
     const totalFqdnsForWarn = [...adapterDefaultsForWarn.allowFqdns, ...config.egressAllowFqdns];
     if (config.egressMode === "standard" && totalFqdnsForWarn.length > 0) {
       if (config.egressAllowCidrs.length === 0) {
@@ -334,7 +334,7 @@ const plugin = definePlugin({
 
     // Ensure the tenant namespace and all its RBAC / network policy resources
     // exist before we try to create the Job.
-    const adapterDefaults = getAdapterDefaults(effectiveAdapterType, config.adapters);
+    const adapterDefaults = getAdapterDefaults(effectiveAdapterType, config.adapters, config.runtimeImages);
 
     await ensureTenant(clients, {
       namespace,

--- a/packages/plugins/sandbox-providers/kubernetes/src/types.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/src/types.ts
@@ -4,6 +4,14 @@ import { KNOWN_ADAPTER_TYPES } from "./adapter-defaults.js";
 
 const cidrRegex = /^(\d{1,3}\.){3}\d{1,3}\/\d{1,2}$/;
 
+function getConfiguredAdapterTypes(adapters?: readonly { adapterType: string }[]): Set<string> {
+  const adapterTypes = new Set(KNOWN_ADAPTER_TYPES);
+  for (const adapter of adapters ?? []) {
+    adapterTypes.add(adapter.adapterType);
+  }
+  return adapterTypes;
+}
+
 export const kubernetesProviderConfigSchema = z
   .object({
     inCluster: z.boolean().default(false),
@@ -67,6 +75,19 @@ export const kubernetesProviderConfigSchema = z
      *   installed, or when you need stable (non-alpha) k8s APIs.
      */
     backend: z.enum(["sandbox-cr", "job"]).default("sandbox-cr"),
+  })
+  .superRefine((cfg, ctx) => {
+    const adapterTypes = getConfiguredAdapterTypes(cfg.adapters);
+    for (const adapterType of Object.keys(cfg.runtimeImages)) {
+      if (!adapterTypes.has(adapterType)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["runtimeImages", adapterType],
+          message:
+            "runtimeImages keys must match a known adapter type or an adapter declared in adapters",
+        });
+      }
+    }
   })
   .refine(
     (cfg) => cfg.inCluster || cfg.kubeconfig,

--- a/packages/plugins/sandbox-providers/kubernetes/src/types.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/src/types.ts
@@ -13,6 +13,7 @@ export const kubernetesProviderConfigSchema = z
     companySlug: z.string().regex(/^[a-z0-9-]{1,32}$/).optional(),
 
     imageRegistry: z.string().url().optional(),
+    runtimeImages: z.record(z.string().trim().min(1)).default({}),
     imageAllowList: z.array(z.string()).default([]),
     imagePullSecrets: z.array(z.string()).default([]),
 

--- a/packages/plugins/sandbox-providers/kubernetes/test/unit/adapter-defaults.test.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/test/unit/adapter-defaults.test.ts
@@ -50,6 +50,18 @@ describe("getAdapterDefaults", () => {
     expect(d.defaultEnv).toBeUndefined();
   });
 
+  it("overrides only runtimeImage from runtimeImages while preserving built-in defaults", () => {
+    const d = getAdapterDefaults("claude_local", undefined, {
+      claude_local: "ghcr.io/paperclipai/agent-runtime-claude:git-b18cbb0dd3d524d3d332f54143c84f00c694636c",
+    });
+    expect(d.runtimeImage).toBe(
+      "ghcr.io/paperclipai/agent-runtime-claude:git-b18cbb0dd3d524d3d332f54143c84f00c694636c",
+    );
+    expect(d.envKeys).toEqual(["ANTHROPIC_API_KEY"]);
+    expect(d.allowFqdns).toEqual(["api.anthropic.com"]);
+    expect(d.probeCommand).toEqual(["claude", "--version"]);
+  });
+
   it("throws on an unknown built-in type when no registry is supplied", () => {
     expect(() => getAdapterDefaults("nope")).toThrow(/Unknown adapter type/);
   });
@@ -68,6 +80,28 @@ describe("getAdapterDefaults", () => {
     ];
     const d = getAdapterDefaults("opencode_local", registry);
     expect(d.runtimeImage).toBe("registry.example/opencode:eu");
+    expect(d.defaultEnv).toEqual({ ANTHROPIC_BASE_URL: "http://bifrost:8080" });
+  });
+
+  it("overrides only runtimeImage from runtimeImages while preserving registry defaults", () => {
+    const registry: AdapterRegistryEntry[] = [
+      {
+        adapterType: "opencode_local",
+        enabled: true,
+        runtimeImage: "registry.example/opencode:eu",
+        envKeys: ["ANTHROPIC_API_KEY"],
+        allowFqdns: ["api.anthropic.com"],
+        probeCommand: ["opencode", "--version"],
+        defaultEnv: { ANTHROPIC_BASE_URL: "http://bifrost:8080" },
+      },
+    ];
+    const d = getAdapterDefaults("opencode_local", registry, {
+      opencode_local: "registry.example/opencode:git-sha",
+    });
+    expect(d.runtimeImage).toBe("registry.example/opencode:git-sha");
+    expect(d.envKeys).toEqual(["ANTHROPIC_API_KEY"]);
+    expect(d.allowFqdns).toEqual(["api.anthropic.com"]);
+    expect(d.probeCommand).toEqual(["opencode", "--version"]);
     expect(d.defaultEnv).toEqual({ ANTHROPIC_BASE_URL: "http://bifrost:8080" });
   });
 

--- a/packages/plugins/sandbox-providers/kubernetes/test/unit/image-allowlist.test.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/test/unit/image-allowlist.test.ts
@@ -40,6 +40,18 @@ describe("resolveImage", () => {
     ).toBe("registry.example.com/paperclip/agent-runtime-claude:v1");
   });
 
+  it("preserves a configured runtime image tag when imageRegistry is set", () => {
+    expect(
+      resolveImage(
+        { imageOverride: null },
+        { runtimeImage: "ghcr.io/paperclipai/agent-runtime-claude:git-b18cbb0dd3d524d3d332f54143c84f00c694636c" },
+        { imageAllowList: [], imageRegistry: "registry.example.com/paperclip" },
+      ),
+    ).toBe(
+      "registry.example.com/paperclip/agent-runtime-claude:git-b18cbb0dd3d524d3d332f54143c84f00c694636c",
+    );
+  });
+
   it("accepts imageOverride when in allowlist", () => {
     expect(
       resolveImage(

--- a/packages/plugins/sandbox-providers/kubernetes/test/unit/types.test.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/test/unit/types.test.ts
@@ -50,6 +50,34 @@ describe("kubernetesProviderConfigSchema", () => {
     );
   });
 
+  it("accepts runtime image overrides for declared adapter registry entries", () => {
+    const parsed = parseKubernetesProviderConfig({
+      inCluster: true,
+      adapters: [
+        {
+          adapterType: "custom_local",
+          runtimeImage: "registry.example/custom:v1",
+        },
+      ],
+      runtimeImages: {
+        custom_local: "registry.example/custom:git-b18cbb0",
+      },
+    });
+
+    expect(parsed.runtimeImages.custom_local).toBe("registry.example/custom:git-b18cbb0");
+  });
+
+  it("rejects runtime image overrides for unknown adapter keys", () => {
+    expect(() =>
+      parseKubernetesProviderConfig({
+        inCluster: true,
+        runtimeImages: {
+          claude_locall: "ghcr.io/paperclipai/agent-runtime-claude:git-b18cbb0",
+        },
+      }),
+    ).toThrow(/runtimeImages keys must match a known adapter type/);
+  });
+
   it("rejects blank runtime image override values", () => {
     expect(() =>
       parseKubernetesProviderConfig({ inCluster: true, runtimeImages: { claude_local: "   " } }),

--- a/packages/plugins/sandbox-providers/kubernetes/test/unit/types.test.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/test/unit/types.test.ts
@@ -6,6 +6,7 @@ describe("kubernetesProviderConfigSchema", () => {
     const parsed = parseKubernetesProviderConfig({ inCluster: true });
     expect(parsed.inCluster).toBe(true);
     expect(parsed.namespacePrefix).toBe("paperclip-");
+    expect(parsed.runtimeImages).toEqual({});
     expect(parsed.imageAllowList).toEqual([]);
     expect(parsed.egressMode).toBe("standard");
     expect(parsed.jobTtlSecondsAfterFinished).toBe(900);
@@ -35,5 +36,23 @@ describe("kubernetesProviderConfigSchema", () => {
     expect(() =>
       parseKubernetesProviderConfig({ inCluster: true, egressAllowCidrs: ["not-a-cidr"] }),
     ).toThrow(/CIDR/i);
+  });
+
+  it("accepts per-adapter runtime image overrides", () => {
+    const parsed = parseKubernetesProviderConfig({
+      inCluster: true,
+      runtimeImages: {
+        claude_local: "ghcr.io/paperclipai/agent-runtime-claude:git-b18cbb0dd3d524d3d332f54143c84f00c694636c",
+      },
+    });
+    expect(parsed.runtimeImages.claude_local).toBe(
+      "ghcr.io/paperclipai/agent-runtime-claude:git-b18cbb0dd3d524d3d332f54143c84f00c694636c",
+    );
+  });
+
+  it("rejects blank runtime image override values", () => {
+    expect(() =>
+      parseKubernetesProviderConfig({ inCluster: true, runtimeImages: { claude_local: "   " } }),
+    ).toThrow();
   });
 });


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The Kubernetes sandbox provider dispatches agent runs into cluster workloads using per-adapter runtime images.
> - The provider's built-in adapter defaults currently point at `:v1` runtime image tags.
> - Issue #8757 reports that operators can have only immutable git-SHA runtime image tags available in GHCR, making the built-in `:v1` tags fail with `ErrImagePull`.
> - The existing `adapters` registry can replace the image, but it also replaces env keys, probe commands, and egress defaults when used only to change a tag.
> - This pull request adds a narrower `runtimeImages` driver config map that overrides only the runtime image for a matching adapter.
> - The benefit is that Kubernetes operators can point an adapter at an existing immutable image tag without patching compiled plugin files or losing the adapter's built-in wiring.

## Linked Issues or Issue Description

Fixes: #8757

Related duplicate/overlap check: I searched open PRs for `8757`, `runtimeImages`, `runtime image overrides`, `agent-runtime`, and Kubernetes runtime-image terms before opening this PR. I did not find a matching open PR.

## What Changed

- Added `runtimeImages` to the Kubernetes provider config schema and plugin manifest.
- Threaded `runtimeImages` through adapter default resolution during validation, warning generation, and lease acquisition.
- Kept `runtimeImages` scoped to image selection only, preserving adapter env keys, probe commands, default env, and egress FQDNs.
- Validated `runtimeImages` keys against built-in adapter types plus declared adapter registry entries, so typos fail at config-parse time instead of silently doing nothing.
- Documented the new config field with a git-SHA runtime image example.
- Added unit coverage for config parsing, runtime image override semantics, typo rejection, custom registry keys, and preserving git-SHA tags when `imageRegistry` rewrites the registry prefix.

## Verification

- `CI=true corepack pnpm -C packages/plugins/sandbox-providers/kubernetes test` -> 17 files / 160 tests passed.
- `./node_modules/.bin/tsc --noEmit` from `packages/plugins/sandbox-providers/kubernetes` -> passed.
- `git diff --check` -> passed.

Note: this sandbox-provider package is intentionally excluded from the root pnpm workspace. I installed its standalone package dependencies locally with `corepack pnpm install --ignore-workspace --no-lockfile` for validation; no lockfile or tracked dependency artifact was changed.

## Risks

Low risk. Existing configs keep using the built-in runtime image defaults unless `runtimeImages` is provided. If both `runtimeImages` and `imageRegistry` are set, the existing registry-rewrite behavior still applies and preserves the configured image tag. Unknown override keys now fail validation, which prevents typo-driven silent no-ops.

## Model Used

OpenAI Codex (GPT-5 Codex), operating in Codex desktop with repository file access, shell validation, and GitHub CLI checks.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
