### PR TITLE
test: cover raw execution policy patch

### DIFF
--- a/server/src/__tests__/issue-execution-policy-routes.test.ts
+++ b/server/src/__tests__/issue-execution-policy-routes.test.ts
@@ -434,6 +434,67 @@ describe("issue execution policy routes", () => {
     expect(mockHeartbeatService.wakeup).not.toHaveBeenCalled();
   });
 
+  it("patches a raw execution policy with participant reviewers onto an issue missing a policy", async () => {
+    const issue = {
+      id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      companyId: "company-1",
+      status: "todo",
+      assigneeAgentId: "33333333-3333-4333-8333-333333333333",
+      assigneeUserId: null,
+      createdByUserId: "local-board",
+      identifier: "PAP-1008",
+      title: "Routine issue missing execution policy",
+      executionPolicy: null,
+      executionState: null,
+    };
+    mockIssueService.getById.mockResolvedValue(issue);
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
+      ...issue,
+      ...patch,
+      updatedAt: new Date(),
+    }));
+
+    const res = await request(await createApp())
+      .patch("/api/issues/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa")
+      .send({
+        executionPolicy: {
+          mode: "normal",
+          commentRequired: true,
+          stages: [
+            {
+              type: "review",
+              approvalsNeeded: 1,
+              participants: [{ type: "agent", agentId: "44444444-4444-4444-8444-444444444444" }],
+            },
+          ],
+        },
+      });
+
+    expect(res.status).toBe(200);
+    const updatePatch = mockIssueService.update.mock.calls[0]?.[1] as Record<string, unknown>;
+    expect(updatePatch.executionPolicy).toMatchObject({
+      mode: "normal",
+      commentRequired: true,
+      stages: [
+        {
+          type: "review",
+          approvalsNeeded: 1,
+          participants: [
+            {
+              type: "agent",
+              agentId: "44444444-4444-4444-8444-444444444444",
+              userId: null,
+            },
+          ],
+        },
+      ],
+    });
+    expect((updatePatch.executionPolicy as any).stages[0].id).toEqual(expect.any(String));
+    expect((updatePatch.executionPolicy as any).stages[0].participants[0].id).toEqual(expect.any(String));
+    expect(updatePatch.status).toBeUndefined();
+    expect(updatePatch.executionState).toBeUndefined();
+  });
+
   it("triggers a scheduled monitor immediately from the dedicated route", async () => {
     const issue = {
       id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies.
> - Issue execution policies are the governance layer that routes review and approval stages.
> - Routine-generated issues can be created without an execution policy and later repaired through `PATCH /api/issues/:id`.
> - A production repair attempt for a routine issue reported an internal server error when the payload used `stages[].participants[].agentId`.
> - Current live behavior accepts the payload, so this pull request preserves that contract with a focused regression test.
> - The benefit is that future changes to issue update validation or execution-policy normalization cannot break routine issue review-policy repair silently.

## What Changed

- Added a route-level regression test for patching a raw `executionPolicy` payload onto an issue whose policy is missing.
- Asserted the route normalizes generated stage and participant IDs while leaving status and execution state unchanged.

## Verification

- `pnpm vitest run server/src/__tests__/issue-execution-policy-routes.test.ts` passed: 11 tests.
- Live probe: a fresh routine-generated issue accepted the same payload with HTTP 200 and was cancelled after verification.

## Risks

- Low risk. This is test-only coverage and does not alter runtime behavior.

## Model Used

- OpenAI GPT-5 Codex via Codex CLI, tool-enabled coding session with shell, git, and local test execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] I will address all Greptile and reviewer comments before requesting merge
