### PR TITLE
feat: add read-only issue relation endpoint

### DIFF
--- a/server/src/__tests__/issue-relations-read-route.test.ts
+++ b/server/src/__tests__/issue-relations-read-route.test.ts
@@ -1,0 +1,268 @@
+import { randomUUID } from "node:crypto";
+import express from "express";
+import request from "supertest";
+import { and, eq } from "drizzle-orm";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import {
+  activityLog,
+  agents,
+  companies,
+  companyMemberships,
+  createDb,
+  issueRelations,
+  issues,
+  principalPermissionGrants,
+  projects,
+} from "@paperclipai/db";
+import { LOW_TRUST_REVIEW_PRESET } from "@paperclipai/shared";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import { errorHandler } from "../middleware/index.js";
+import { issueRoutes } from "../routes/issues.js";
+import { ensureHumanRoleDefaultGrants } from "../services/principal-access-compatibility.js";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping embedded Postgres issue relation read route tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+describeEmbeddedPostgres("issue relation read route", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-issue-relations-read-route-");
+    db = createDb(tempDb.connectionString);
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.delete(activityLog);
+    await db.delete(issueRelations);
+    await db.delete(issues);
+    await db.delete(agents);
+    await db.delete(projects);
+    await db.delete(principalPermissionGrants);
+    await db.delete(companyMemberships);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  function createApp(companyId: string, actor?: Record<string, unknown>) {
+    const app = express();
+    app.use(express.json());
+    app.use((req, _res, next) => {
+      (req as any).actor = actor ?? {
+        type: "board",
+        userId: "cloud-user-1",
+        companyIds: [companyId],
+        memberships: [{ companyId, membershipRole: "owner", status: "active" }],
+        source: "cloud_tenant",
+        isInstanceAdmin: false,
+      };
+      next();
+    });
+    app.use("/api", issueRoutes(db, {} as any, { taskWatchdogEnqueueWakeup: null }));
+    app.use(errorHandler);
+    return app;
+  }
+
+  function uniqueIssuePrefix() {
+    return `REL${randomUUID().replace(/-/g, "").slice(0, 4).toUpperCase()}`;
+  }
+
+  async function seedCloudTenantMember(companyId: string) {
+    await db.insert(companyMemberships).values({
+      companyId,
+      principalType: "user",
+      principalId: "cloud-user-1",
+      status: "active",
+      membershipRole: "owner",
+      updatedAt: new Date(),
+    });
+    await ensureHumanRoleDefaultGrants(db, {
+      companyId,
+      principalId: "cloud-user-1",
+      membershipRole: "owner",
+      grantedByUserId: null,
+    });
+  }
+
+  async function seedCompany() {
+    const companyId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Relation route company",
+      issuePrefix: uniqueIssuePrefix(),
+      requireBoardApprovalForNewAgents: false,
+    });
+    await seedCloudTenantMember(companyId);
+    return companyId;
+  }
+
+  async function seedProject(companyId: string, name: string) {
+    const id = randomUUID();
+    await db.insert(projects).values({
+      id,
+      companyId,
+      name,
+    });
+    return { id, name };
+  }
+
+  async function seedAgent(companyId: string, permissions: Record<string, unknown>) {
+    const id = randomUUID();
+    await db.insert(agents).values({
+      id,
+      companyId,
+      name: "Low trust relation reader",
+      role: "engineer",
+      status: "active",
+      adapterType: "process",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions,
+    });
+    return { id };
+  }
+
+  async function seedIssue(
+    companyId: string,
+    title: string,
+    issueNumber: number,
+    overrides: Partial<typeof issues.$inferInsert> = {},
+  ) {
+    const id = overrides.id ?? randomUUID();
+    const identifier = overrides.identifier ?? `REL-${issueNumber}`;
+    await db.insert(issues).values({
+      id,
+      companyId,
+      title,
+      status: overrides.status ?? "todo",
+      priority: overrides.priority ?? "medium",
+      identifier,
+      issueNumber,
+      createdByUserId: "cloud-user-1",
+      projectId: overrides.projectId,
+      parentId: overrides.parentId,
+      assigneeAgentId: overrides.assigneeAgentId,
+    });
+    return { id, identifier, title };
+  }
+
+  it("returns canonical blocker relation summaries without mutating relation or activity rows", async () => {
+    const companyId = await seedCompany();
+    const blocked = await seedIssue(companyId, "Blocked issue", 1);
+    const blocker = await seedIssue(companyId, "Blocker issue", 2);
+    const downstream = await seedIssue(companyId, "Downstream issue", 3);
+    await db.insert(issueRelations).values([
+      {
+        companyId,
+        issueId: blocker.id,
+        relatedIssueId: blocked.id,
+        type: "blocks",
+        createdByUserId: "cloud-user-1",
+      },
+      {
+        companyId,
+        issueId: blocked.id,
+        relatedIssueId: downstream.id,
+        type: "blocks",
+        createdByUserId: "cloud-user-1",
+      },
+    ]);
+
+    const app = createApp(companyId);
+    const beforeRelations = await db.select().from(issueRelations);
+    const beforeActivity = await db.select().from(activityLog);
+
+    const res = await request(app).get(`/api/issues/${blocked.id}/relations`);
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(res.body).toMatchObject({ issueId: blocked.id });
+    expect(res.body.blockedBy).toEqual([
+      expect.objectContaining({
+        id: blocker.id,
+        identifier: blocker.identifier,
+        title: blocker.title,
+      }),
+    ]);
+    expect(res.body.blocks).toEqual([
+      expect.objectContaining({
+        id: downstream.id,
+        identifier: downstream.identifier,
+        title: downstream.title,
+      }),
+    ]);
+
+    const afterRelations = await db.select().from(issueRelations);
+    const afterActivity = await db.select().from(activityLog);
+    expect(afterRelations).toEqual(beforeRelations);
+    expect(afterActivity).toEqual(beforeActivity);
+  });
+
+  it("returns 404 for a missing issue", async () => {
+    const companyId = await seedCompany();
+    const app = createApp(companyId);
+
+    const res = await request(app).get(`/api/issues/${randomUUID()}/relations`);
+
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ error: "Issue not found" });
+  });
+
+  it("enforces company access before returning relation summaries", async () => {
+    const companyId = await seedCompany();
+    const issue = await seedIssue(companyId, "Private relation issue", 1);
+    const app = createApp(companyId, {
+      type: "board",
+      userId: "cloud-user-2",
+      companyIds: [],
+      memberships: [],
+      source: "cloud_tenant",
+      isInstanceAdmin: false,
+    });
+
+    const res = await request(app).get(`/api/issues/${issue.id}/relations`);
+
+    expect(res.status).toBe(403);
+  });
+
+  it("enforces issue read policy after company access succeeds", async () => {
+    const companyId = await seedCompany();
+    const allowedProject = await seedProject(companyId, "Allowed relation project");
+    const deniedProject = await seedProject(companyId, "Denied relation project");
+    const agent = await seedAgent(companyId, {
+      trustPreset: LOW_TRUST_REVIEW_PRESET,
+      authorizationPolicy: {
+        trustBoundary: {
+          mode: LOW_TRUST_REVIEW_PRESET,
+          projectIds: [allowedProject.id],
+          allowedAgentIds: [],
+        },
+      },
+    });
+    const issue = await seedIssue(companyId, "Outside read boundary", 4, {
+      projectId: deniedProject.id,
+    });
+    const app = createApp(companyId, {
+      type: "agent",
+      agentId: agent.id,
+      companyId,
+      source: "agent_key",
+    });
+
+    const res = await request(app).get(`/api/issues/${issue.id}/relations`);
+
+    expect(res.status).toBe(403);
+    expect(res.body).toEqual({ error: "Issue is outside this actor's authorization boundary" });
+  });
+});

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -3568,6 +3568,23 @@ export function issueRoutes(
     });
   });
 
+  router.get("/issues/:id/relations", async (req, res) => {
+    const id = req.params.id as string;
+    const issue = await svc.getById(id);
+    if (!issue) {
+      res.status(404).json({ error: "Issue not found" });
+      return;
+    }
+    assertCompanyAccess(req, issue.companyId);
+    if (!(await assertIssueReadAllowed(req, res, issue))) return;
+    const relations = await svc.getRelationSummaries(issue.id);
+    res.json({
+      issueId: issue.id,
+      blockedBy: relations.blockedBy,
+      blocks: relations.blocks,
+    });
+  });
+
   router.get("/issues/:id/watchdog", async (req, res) => {
     const id = req.params.id as string;
     const issue = await svc.getById(id);

--- a/server/src/routes/openapi.ts
+++ b/server/src/routes/openapi.ts
@@ -1393,6 +1393,15 @@ registry.registerPath({
 });
 
 registry.registerPath({
+  method: "get",
+  path: "/api/issues/{id}/relations",
+  tags: ["issues"],
+  summary: "Get issue relation summaries",
+  request: { params: z.object({ id: z.string() }) },
+  responses: { 200: r.ok(), 401: r.unauthorized, 403: r.forbidden, 404: r.notFound },
+});
+
+registry.registerPath({
   method: "patch",
   path: "/api/issues/{id}",
   tags: ["issues"],


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Issues are the core work objects that agents and humans coordinate around.
> - Issue dependency relationships already exist in the backend as blocker/blocking relations.
> - Several read-only surfaces need a canonical way to inspect those relationships without using mutation-oriented code paths.
> - The server already has issue authorization helpers for company access and issue-read policy enforcement.
> - This pull request adds a narrow read-only relation endpoint that reuses those guards and returns relation summaries only.
> - The benefit is safer dependency inspection for clients and automation while keeping write behavior unchanged.

## Linked Issues or Issue Description

No public GitHub issue was found for this exact endpoint after searching issues and PRs for issue relation / blocker / blocks relation endpoint terms, so the issue is described in-PR using the feature request template fields.

### Subsystem affected

server/ — REST API & orchestration services

### Problem or motivation

Clients need a stable, read-only API surface for issue blocker/blocking relationships. Without a canonical endpoint, callers must rely on ad hoc or legacy probe names, which makes dependency inspection harder to implement safely and harder to verify against route/spec coverage.

### Proposed solution

Add `GET /api/issues/:id/relations`, enforce the existing company and issue-read authorization checks, and return `{ issueId, blockedBy, blocks }` relation summaries.

### Alternatives considered

Keep using legacy/ad hoc relation probe names. This was rejected because it leaves clients without a canonical route and makes route coverage harder to verify.

### Roadmap alignment

This is a small focused backend API hardening change. ROADMAP.md mentions work queues and issue-centric workflows, but this PR does not duplicate a listed roadmap item.

### Additional context

Duplicate search: searched GitHub PRs and issues in `paperclipai/paperclip` for issue relation / blocker / blocks relation endpoint terms; no duplicate or closely related public PR/issue was found.

## What Changed

- Added `GET /api/issues/:id/relations` to the issue routes.
- Reused existing issue lookup, company access, and issue-read policy checks before returning relation data.
- Returned canonical relation summaries as `{ issueId, blockedBy, blocks }`.
- Documented the endpoint in OpenAPI with `200`, `401`, `403`, and `404` responses.
- Added route tests for:
  - happy-path relation summary shape,
  - no `issueRelations` mutation,
  - no `activityLog` mutation,
  - missing issue `404`,
  - company access denial `403`,
  - issue-read policy denial after company access succeeds.

## Verification

- `corepack pnpm exec vitest run --project @paperclipai/server server/src/__tests__/issue-relations-read-route.test.ts server/src/__tests__/openapi-routes.test.ts --pool=forks --isolate --reporter verbose`
  - passed locally: 2 files, 7 tests.
- `corepack pnpm --filter @paperclipai/server typecheck`
  - passed locally.
- GitHub PR checks after opening the PR:
  - build passed,
  - typecheck/release registry passed,
  - general server and workspace tests passed,
  - serialized server suites passed,
  - e2e passed,
  - security scans passed.

## Risks

- Low risk: the new route is GET-only and does not introduce relation writes, activity log writes, heartbeat updates, or action execution paths.
- Authorization risk is mitigated by reusing the same company and issue-read policy helpers used by adjacent issue routes.
- OpenAPI route coverage was updated so mounted route/spec drift is covered by existing tests.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex via Hermes Agent, model `gpt-5.5`, with tool use for local file editing, terminal verification, GitHub CLI operations, and independent review delegation.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
