### PR TITLE
fix(recovery): skip continuation for scheduled monitors

### DIFF
--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -585,6 +585,9 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     livenessState?: "completed" | "advanced" | "plan_only" | "empty_response" | "blocked" | "failed" | "needs_followup" | null;
     runErrorCode?: string | null;
     runError?: string | null;
+    monitorNextCheckAt?: Date | null;
+    executionPolicy?: Record<string, unknown> | null;
+    executionState?: Record<string, unknown> | null;
   }) {
     const companyId = randomUUID();
     const agentId = randomUUID();
@@ -683,6 +686,9 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
         assigneeUserId: input.assignToUser ? "user-1" : null,
         checkoutRunId: input.status === "in_progress" ? runId : null,
         executionRunId: null,
+        executionPolicy: input.executionPolicy ?? null,
+        executionState: input.executionState ?? null,
+        monitorNextCheckAt: input.monitorNextCheckAt ?? null,
         issueNumber: input.activePauseHold ? 2 : 1,
         identifier: `${issuePrefix}-${input.activePauseHold ? 2 : 1}`,
         startedAt: input.status === "in_progress" ? now : null,
@@ -2853,6 +2859,54 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     if (retryRun) {
       await waitForRunToSettle(heartbeat, retryRun.id);
     }
+  });
+
+  it("does not re-enqueue continuation for stranded in-progress work parked on a future scheduled monitor", async () => {
+    const monitorNextCheckAt = new Date("2026-07-07T14:00:00.000Z");
+    const { companyId, agentId, issueId } = await seedStrandedIssueFixture({
+      status: "in_progress",
+      runStatus: "succeeded",
+      livenessState: "advanced",
+      monitorNextCheckAt,
+      executionPolicy: {
+        mode: "normal",
+        monitor: {
+          nextCheckAt: monitorNextCheckAt.toISOString(),
+          wakeReason: "scheduled_publish",
+        },
+      },
+      executionState: {
+        status: "idle",
+        monitor: {
+          status: "scheduled",
+          nextCheckAt: monitorNextCheckAt.toISOString(),
+        },
+      },
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(result.dispatchRequeued).toBe(0);
+    expect(result.continuationRequeued).toBe(0);
+    expect(result.escalated).toBe(0);
+    expect(result.skipped).toBe(1);
+
+    const runs = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.agentId, agentId));
+    expect(runs).toHaveLength(1);
+
+    const wakeups = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.agentId, agentId));
+    expect(wakeups.filter((row) => row.payload?.issueId === issueId)).toHaveLength(1);
+    expect(wakeups.some((row) => row.reason === "issue_continuation_needed")).toBe(false);
+
+    const [issue] = await db.select().from(issues).where(eq(issues.id, issueId));
+    expect(issue?.status).toBe("in_progress");
+    expect(issue?.monitorNextCheckAt?.toISOString()).toBe(monitorNextCheckAt.toISOString());
   });
 
   it("does not continue seeded in-progress work that has no run linkage", async () => {

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -380,6 +380,35 @@ function isRepeatedProductiveContinuationRecovery(latestRun: SuccessfulLatestIss
     isProductiveContinuationRun(latestRun);
 }
 
+function readDate(value: unknown): Date | null {
+  if (!(typeof value === "string" || value instanceof Date)) return null;
+  const date = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function hasFutureScheduledMonitor(issue: Pick<
+  typeof issues.$inferSelect,
+  "executionPolicy" | "executionState" | "monitorNextCheckAt"
+>) {
+  const monitorNextCheckAt = readDate(issue.monitorNextCheckAt);
+  if (!monitorNextCheckAt || monitorNextCheckAt.getTime() <= Date.now()) return false;
+
+  const executionState = parseObject(issue.executionState);
+  const stateStatus = readNonEmptyString(executionState.status);
+  const stateMonitor = parseObject(executionState.monitor);
+  const monitorStatus = readNonEmptyString(stateMonitor.status);
+  if (stateMonitor && monitorStatus !== "scheduled") return false;
+  if (executionState && stateStatus !== "idle") return false;
+
+  const policyMonitor = parseObject(parseObject(issue.executionPolicy).monitor);
+  const policyNextCheckAt = readDate(policyMonitor.nextCheckAt);
+  if (policyMonitor && policyNextCheckAt && Math.abs(policyNextCheckAt.getTime() - monitorNextCheckAt.getTime()) > 1_000) {
+    return false;
+  }
+
+  return true;
+}
+
 function parseLivenessIncidentKey(incidentKey: string | null | undefined) {
   if (!incidentKey) return null;
   return parseIssueGraphLivenessIncidentKey(incidentKey);
@@ -2851,6 +2880,10 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       }
 
       if (!latestRun && !issue.checkoutRunId && !issue.executionRunId) {
+        result.skipped += 1;
+        continue;
+      }
+      if (hasFutureScheduledMonitor(issue)) {
         result.skipped += 1;
         continue;
       }


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Issue monitors are a control-plane waiting path for scheduled or future-dated work.
> - Stranded assigned-work recovery can enqueue `issue_continuation_needed` when an in-progress issue has no active run.
> - A future scheduled monitor is already a live continuation path, so immediately re-waking the assignee wastes runtime and can create wake loops.
> - This pull request teaches stranded recovery to recognize idle issues parked on a future scheduled monitor.
> - The benefit is that scheduled monitored work sleeps until its monitor fires while genuinely stranded work still gets recovered.

## Linked Issues or Issue Description

Bug fix, no public GitHub issue found.

- What happened: an `in_progress` issue with a future scheduled monitor could be treated as stranded and receive an immediate `issue_continuation_needed` wake after a successful no-op audit run.
- Expected behavior: a future scheduled monitor should count as the live continuation path, so the issue should remain parked until the monitor fires.
- Reproduction shape: assigned agent issue, status `in_progress`, no active run or pending wake interaction, successful prior run, `monitorNextCheckAt` in the future, `executionState.status = idle`, and `executionState.monitor.status = scheduled`.
- Paperclip version/commit tested: branch based on `origin/master` at `e6407b322` plus this PR commit.
- Deployment mode: local development test database.

Related public PRs checked: #8191, #7592, #6574. None covers this scheduled-monitor stranded-continuation path.

## What Changed

- Added a stranded recovery guard that skips `issue_continuation_needed` enqueueing when the issue has a future `monitorNextCheckAt` and an idle/scheduled monitor state.
- Extended the heartbeat recovery fixture to seed monitor metadata.
- Added regression coverage for the scheduled-monitor shape so no extra continuation wake is queued.

## Verification

- `pnpm exec vitest run server/src/__tests__/heartbeat-process-recovery.test.ts` - passed, 61 tests.
- `pnpm typecheck` - passed across workspace packages.

## Risks

Low risk. This only suppresses automatic stranded-continuation recovery when a future scheduled monitor is present and the execution state is idle with a scheduled monitor. Issues without that future scheduled monitor still flow through the existing recovery path and are covered by existing tests.

## Model Used

OpenAI GPT-5 Codex, accessed through the Codex coding agent environment with shell, git, and local test execution tools.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge