### PR TITLE
fix: return engineer rework to latest reviewer (DAN-176)

### DIFF
--- a/server/src/__tests__/issue-execution-policy-routes.test.ts
+++ b/server/src/__tests__/issue-execution-policy-routes.test.ts
@@ -9,6 +9,7 @@ const mockIssueService = vi.hoisted(() => ({
   update: vi.fn(),
   createChild: vi.fn(),
   addComment: vi.fn(),
+  listComments: vi.fn(),
   findMentionedAgents: vi.fn(),
   getRelationSummaries: vi.fn(),
   listWakeableBlockedDependents: vi.fn(),
@@ -173,6 +174,7 @@ describe("issue execution policy routes", () => {
     vi.clearAllMocks();
     mockIssueService.assertCheckoutOwner.mockResolvedValue({ adoptedFromRunId: null });
     mockIssueService.findMentionedAgents.mockResolvedValue([]);
+    mockIssueService.listComments.mockResolvedValue([]);
     mockIssueService.getRelationSummaries.mockResolvedValue({ blockedBy: [], blocks: [] });
     mockIssueService.listWakeableBlockedDependents.mockResolvedValue([]);
     mockIssueService.getWakeableParentAfterChildCompletion.mockResolvedValue(null);
@@ -291,6 +293,88 @@ describe("issue execution policy routes", () => {
     expect(mockIssueService.update).toHaveBeenCalledWith(
       "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
       expect.objectContaining({ status: "in_review" }),
+    );
+  });
+
+  it("auto-handoffs an engineer resubmission back to the latest rejecting reviewer", async () => {
+    const issue = {
+      id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      companyId: "company-1",
+      status: "in_progress",
+      assigneeAgentId: "22222222-2222-4222-8222-222222222222",
+      assigneeUserId: null,
+      createdByUserId: "local-board",
+      identifier: "PAP-1005",
+      title: "Return to QA after rework",
+      executionPolicy: null,
+      executionState: null,
+    };
+    mockIssueService.getById.mockResolvedValue(issue);
+    mockIssueService.listComments.mockResolvedValue([
+      {
+        id: "comment-qa-1",
+        issueId: issue.id,
+        companyId: issue.companyId,
+        body: "## QA Review — REPROVADO, devolvendo para o Engineer",
+        authorType: "agent",
+        authorAgentId: "33333333-3333-4333-8333-333333333333",
+        authorUserId: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ]);
+    mockIssueService.addComment.mockResolvedValue({
+      id: "comment-eng-1",
+      issueId: issue.id,
+      companyId: issue.companyId,
+      body: "Correções aplicadas e devolvendo para nova validação.",
+      authorType: "agent",
+      authorAgentId: "22222222-2222-4222-8222-222222222222",
+      authorUserId: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
+      ...issue,
+      ...patch,
+      updatedAt: new Date(),
+    }));
+
+    const res = await request(await createApp({
+      type: "agent",
+      agentId: "22222222-2222-4222-8222-222222222222",
+      companyId: "company-1",
+      runId: "run-2",
+    }))
+      .patch("/api/issues/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa")
+      .send({
+        status: "in_review",
+        comment: "Correções aplicadas e devolvendo para nova validação.",
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      status: "in_review",
+      assigneeAgentId: "33333333-3333-4333-8333-333333333333",
+      assigneeUserId: null,
+    });
+    expect(mockIssueService.update).toHaveBeenCalledWith(
+      "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      expect.objectContaining({
+        status: "in_review",
+        assigneeAgentId: "33333333-3333-4333-8333-333333333333",
+        assigneeUserId: null,
+      }),
+    );
+    expect(mockHeartbeatService.wakeup).toHaveBeenCalledWith(
+      "33333333-3333-4333-8333-333333333333",
+      expect.objectContaining({
+        reason: "issue_assigned",
+        payload: expect.objectContaining({
+          issueId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+          mutation: "update",
+        }),
+      }),
     );
   });
 

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -654,6 +654,40 @@ function isApprovalReviewComment(body: string) {
   );
 }
 
+function parseReviewCommentDecision(body: string): "approved" | "changes_requested" | null {
+  const normalized = body.replace(/\r\n?/g, "\n");
+  if (isApprovalReviewComment(body) || /(?:^|\n)##\s*QA Review\b[^\n]*\b(?:APROVADO|APPROVED)\b/i.test(normalized)) {
+    return "approved";
+  }
+  if (
+    /^[ \t]*kind[ \t]*:[ \t]*review[ \t]*\n[ \t]*decision[ \t]*:[ \t]*(?:changes_requested|rejected)[ \t]*$/im.test(normalized)
+    || /^[ \t]*decision[ \t]*:[ \t]*(?:changes_requested|rejected)[ \t]*\n[ \t]*kind[ \t]*:[ \t]*review[ \t]*$/im.test(normalized)
+    || /(?:^|\n)##\s*QA Review\b[^\n]*\b(?:REPROVADO|REJECT(?:ED|ION)?|CHANGES?\s+REQUESTED)\b/i.test(normalized)
+  ) {
+    return "changes_requested";
+  }
+  const headingMatch = normalized.match(/(?:^|\n)##\s*Review:\s*([^\n]*)/i);
+  if (headingMatch && APPROVAL_NEGATION_REGEX.test(headingMatch[1] ?? "")) {
+    return "changes_requested";
+  }
+  return null;
+}
+
+function findLatestRejectingReviewerAgentId(input: {
+  comments: Array<{ authorType?: string | null; authorAgentId?: string | null; body?: string | null }>;
+  actorAgentId: string;
+}) {
+  for (const comment of input.comments) {
+    if (comment.authorType !== "agent") continue;
+    const authorAgentId = typeof comment.authorAgentId === "string" ? comment.authorAgentId : null;
+    if (!authorAgentId || authorAgentId === input.actorAgentId) continue;
+    const decision = parseReviewCommentDecision(comment.body ?? "");
+    if (decision === "approved") return null;
+    if (decision === "changes_requested") return authorAgentId;
+  }
+  return null;
+}
+
 function buildExecutionStageWakeContext(input: {
   state: ParsedExecutionState;
   wakeRole: ExecutionStageWakeContext["wakeRole"];
@@ -1682,6 +1716,7 @@ export function issueRoutes(
       id: string;
       companyId: string;
       status: string;
+      assigneeAgentId?: string | null;
       assigneeUserId?: string | null;
       executionState?: unknown;
       monitorNextCheckAt?: Date | null;
@@ -1698,6 +1733,14 @@ export function issueRoutes(
       ? input.existing.assigneeUserId
       : input.updateFields.assigneeUserId;
     if (typeof nextAssigneeUserId === "string" && nextAssigneeUserId.trim().length > 0) return;
+    const nextAssigneeAgentId = input.updateFields.assigneeAgentId === undefined
+      ? input.existing.assigneeAgentId
+      : input.updateFields.assigneeAgentId;
+    if (
+      typeof nextAssigneeAgentId === "string"
+      && nextAssigneeAgentId.trim().length > 0
+      && nextAssigneeAgentId !== input.existing.assigneeAgentId
+    ) return;
 
     const nextExecutionState = input.updateFields.executionState === undefined
       ? input.existing.executionState
@@ -1721,6 +1764,7 @@ export function issueRoutes(
       code: "invalid_issue_disposition",
       missing: "review_path",
       validReviewPaths: [
+        "assigned_reviewer_agent_id",
         "pending_issue_thread_interaction",
         "linked_pending_approval",
         "human_assignee_user_id",
@@ -5880,6 +5924,42 @@ export function issueRoutes(
       };
     }
     Object.assign(updateFields, transition.patch);
+    let autoReviewerHandoff = false;
+    const nextStatusForReviewerHandoff = typeof updateFields.status === "string"
+      ? updateFields.status
+      : existing.status;
+    if (
+      req.actor.type === "agent"
+      && req.actor.agentId
+      && existing.status === "in_progress"
+      && nextStatusForReviewerHandoff === "in_review"
+    ) {
+      const nextAssigneeAgentId = updateFields.assigneeAgentId === undefined
+        ? existing.assigneeAgentId
+        : updateFields.assigneeAgentId as string | null | undefined;
+      const nextAssigneeUserId = updateFields.assigneeUserId === undefined
+        ? existing.assigneeUserId
+        : updateFields.assigneeUserId as string | null | undefined;
+      const nextExecutionState = updateFields.executionState === undefined
+        ? existing.executionState
+        : updateFields.executionState;
+      if (
+        !nextAssigneeUserId
+        && !hasExecutionParticipant(nextExecutionState)
+        && (!nextAssigneeAgentId || nextAssigneeAgentId === existing.assigneeAgentId)
+      ) {
+        const comments = await svc.listComments(id, { order: "desc", limit: 25 });
+        const reviewerAgentId = findLatestRejectingReviewerAgentId({
+          comments,
+          actorAgentId: req.actor.agentId,
+        });
+        if (reviewerAgentId) {
+          updateFields.assigneeAgentId = reviewerAgentId;
+          updateFields.assigneeUserId = null;
+          autoReviewerHandoff = true;
+        }
+      }
+    }
     if (reviewRequest !== undefined && transition.patch.executionState === undefined) {
       const existingExecutionState = parseIssueExecutionState(existing.executionState);
       if (!existingExecutionState || existingExecutionState.status !== "pending") {
@@ -5916,7 +5996,7 @@ export function issueRoutes(
       !!existing.createdByUserId &&
       nextAssigneeUserId === existing.createdByUserId;
 
-    if (assigneeWillChange && !transition.workflowControlledAssignment) {
+    if (assigneeWillChange && !transition.workflowControlledAssignment && !autoReviewerHandoff) {
       if (!isAgentReturningIssueToCreator) {
         await assertCanAssignTasks(req, existing.companyId, {
           issueId: existing.id,


### PR DESCRIPTION
## Resumo
- infere o último revisor que reprovou a entrega quando o Engineer devolve o item para `in_review` após retrabalho
- trata handoff explícito para outro agente como caminho válido de review
- cobre o caso com teste de rota

## Task do Paperclip
- DAN-176: http://127.0.0.1:3101/DAN/issues/DAN-176

## Plano técnico
- Não houve plano técnico separado; a implementação segue a definição aprovada em DAN-175.

## Verificação
- `pnpm vitest server/src/__tests__/issue-execution-policy-routes.test.ts --testTimeout 20000`