### PR TITLE
fix: reject out-of-bound self checkout before lock acquisition

### DIFF
--- a/server/src/__tests__/low-trust-red-team-routes.test.ts
+++ b/server/src/__tests__/low-trust-red-team-routes.test.ts
@@ -630,6 +630,46 @@ describeEmbeddedPostgres("low-trust red-team HTTP route regression suite", () =>
     expect(unmentionedComment.body.error).toBe("Issue is outside this actor's authorization boundary");
   });
 
+  it("rejects low-trust checkout on self-assigned issues outside the boundary before writing locks", async () => {
+    const fixture = await seedLowTrustFixture(db);
+    const [outOfScopeAssigned] = await db.insert(issues).values({
+      companyId: fixture.company.id,
+      projectId: fixture.projects.outOfScope.id,
+      title: "Out-of-bound standing issue",
+      status: "todo",
+      priority: "medium",
+      assigneeAgentId: fixture.agents.lowTrust.id,
+    }).returning();
+
+    const checkout = await request(createApp(db, agentActor(fixture)))
+      .post(`/api/issues/${outOfScopeAssigned!.id}/checkout`)
+      .send({
+        agentId: fixture.agents.lowTrust.id,
+        expectedStatuses: ["todo"],
+      });
+
+    expect(checkout.status, JSON.stringify(checkout.body)).toBe(403);
+    expect(checkout.body.error).toBe("Issue is outside this actor's authorization boundary");
+
+    const row = await db
+      .select({
+        status: issues.status,
+        assigneeAgentId: issues.assigneeAgentId,
+        checkoutRunId: issues.checkoutRunId,
+        executionRunId: issues.executionRunId,
+      })
+      .from(issues)
+      .where(eq(issues.id, outOfScopeAssigned!.id))
+      .then((rows) => rows[0]);
+
+    expect(row).toEqual({
+      status: "todo",
+      assigneeAgentId: fixture.agents.lowTrust.id,
+      checkoutRunId: null,
+      executionRunId: null,
+    });
+  });
+
   it("propagates denied low-trust policy conflicts on control-plane guards", async () => {
     const fixture = await seedLowTrustFixture(db);
     const conflictingExecutionPolicy = {

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -6629,6 +6629,18 @@ export function issueRoutes(
       return;
     }
 
+    if (
+      req.actor.type === "agent" &&
+      req.actor.agentId === req.body.agentId &&
+      issue.assigneeAgentId === req.body.agentId
+    ) {
+      const boundaryDecision = await decideIssueAccess(req, issue, "issue:mutate");
+      if (!boundaryDecision.allowed) {
+        res.status(403).json({ error: "Issue is outside this actor's authorization boundary" });
+        return;
+      }
+    }
+
     if (issue.assigneeAgentId !== req.body.agentId) {
       await assertCanAssignTasks(req, issue.companyId, {
         issueId: issue.id,


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the control plane that assigns, checks out, and releases issue work for agent teams.
> - This change is in the server-side issue authorization and checkout flow.
> - A checked-out standing issue can become trapped when checkout succeeds for an agent that later fails the same issue's mutate/comment/release boundary.
> - That trap is especially harmful for standing loops because it leaves the issue `in_progress` with no clean release path.
> - The underlying gap is that `POST /api/issues/:id/checkout` did not enforce the same issue boundary that later issue mutations enforce for a self-assigned agent.
> - This pull request closes that gap by rejecting out-of-bound self-checkout before any execution lock is written and adds a regression test for the low-trust route.
> - The benefit is coherent authorization: if an agent cannot later mutate or release the issue, it cannot create the checked-out state in the first place.

## Linked Issues or Issue Description

- No public GitHub issue found for this exact bug.
- Problem:
  - An agent assigned to an issue outside its effective authorization boundary could successfully call `POST /api/issues/:id/checkout` for itself.
  - After checkout, the same actor could then fail `PATCH /api/issues/:id`, `POST /api/issues/:id/comments`, or `POST /api/issues/:id/release` with `Issue is outside this actor's authorization boundary`.
  - That left the issue stranded in `in_progress` with a checkout lock but without a symmetric release path.
- Expected behavior:
  - Checkout and later issue mutation/release permissions should be coherent for the same self-assigned actor.
  - If the actor is outside the issue boundary, checkout should be rejected before any lock is written.

## What Changed

- Added a self-checkout authorization guard in `server/src/routes/issues.ts` so an agent checking out an issue already assigned to itself must also satisfy `issue:mutate`.
- Added an embedded-Postgres regression in `server/src/__tests__/low-trust-red-team-routes.test.ts` proving a low-trust agent cannot check out a self-assigned issue outside its boundary and that no checkout/execution lock is written.

## Verification

- Passed: `pnpm exec vitest run server/src/__tests__/low-trust-red-team-routes.test.ts`
- Passed: `pnpm -r typecheck`
- Passed: `pnpm build`
- Not fully green: `pnpm test:run`
  - Unrelated existing failures in `server/src/__tests__/workspace-runtime.test.ts`
  - Failing cases:
    - `adopts a live auto-port shared service after runtime state is reset`
    - `does not reuse a stopped auto-port service port while another process owns it`
- Local environment note:
  - Plain `pnpm install` failed during `sharp` postinstall under Node `26.1.0` + Python `3.14` because `distutils` is unavailable.
  - I used `pnpm install --ignore-scripts` to complete the route/typecheck/build verification above.

## Risks

- Low risk: this only narrows checkout for the self-assigned agent path and does not widen any cross-agent mutation capability.
- The guard is intentionally specific to self-checkout on already-assigned issues; takeover flows that rely on `tasks:assign` still use the existing path.
- If there is any hidden workflow that depended on out-of-bound self-checkout succeeding, it will now fail earlier with a 403 instead of getting stuck later in `in_progress`.

> I checked `ROADMAP.md` keywords related to checkout/authz and did not find a roadmap item that duplicates this bug fix. Related public PRs exist around adjacent authz behavior (`#8701`, `#8640`, `#8325`), but this checkout preflight gap appears distinct.

## Model Used

- OpenAI Codex Engineer (GPT-5-based coding agent in Codex CLI-style environment)
- Tool-using model with shell execution, git, and patch application capabilities
- Used with repository-local code inspection, test execution, and direct file edits

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change and contains no internal Paperclip ticket id or instance-derived details
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
