### PR TITLE
fix(heartbeat): narrow .git requirement to git-backed workspaces (LUN-3022)

### DIFF
--- a/server/src/__tests__/heartbeat-workspace-session.test.ts
+++ b/server/src/__tests__/heartbeat-workspace-session.test.ts
@@ -421,21 +421,129 @@ describe("assertGitSensitiveAdapterWorkspaceValid", () => {
     }
   });
 
-  it("rejects a workspace-linked issue when adapter cwd has no git metadata", async () => {
+  it("rejects a git-backed workspace-linked issue when adapter cwd has no git metadata", async () => {
     const input = buildWorkspaceValidationInput();
     const cwd = "/tmp/paperclip-workspace-without-git-metadata";
 
     await expectWorkspaceValidationFailure(
       buildWorkspaceValidationInput({
-        resolvedWorkspace: buildResolvedWorkspace({ cwd }),
+        resolvedWorkspace: buildResolvedWorkspace({ cwd, repoUrl: "https://example.com/repo.git" }),
         executionWorkspace: {
           ...input.executionWorkspace,
           baseCwd: cwd,
           cwd,
+          repoUrl: "https://example.com/repo.git",
         },
         persistedExecutionWorkspace: {
           ...input.persistedExecutionWorkspace!,
           cwd,
+          repoUrl: "https://example.com/repo.git",
+        },
+      }),
+      "missing_git_metadata",
+      "has no .git metadata",
+    );
+  });
+
+  it("allows a non-git local_folder project (repoUrl null) to launch without .git metadata", async () => {
+    const input = buildWorkspaceValidationInput();
+    const cwd = "/tmp/paperclip-non-git-local-folder";
+
+    await expect(
+      assertGitSensitiveAdapterWorkspaceValid(
+        buildWorkspaceValidationInput({
+          resolvedWorkspace: buildResolvedWorkspace({ cwd, repoUrl: null }),
+          executionWorkspace: {
+            ...input.executionWorkspace,
+            baseCwd: cwd,
+            cwd,
+            repoUrl: null,
+            strategy: "project_primary",
+          },
+          persistedExecutionWorkspace: {
+            ...input.persistedExecutionWorkspace!,
+            cwd,
+            repoUrl: null,
+            strategyType: "project_primary",
+          },
+        }),
+      ),
+    ).resolves.toBeUndefined();
+  });
+
+  it("still requires .git metadata for git-backed projects (repoUrl set)", async () => {
+    const input = buildWorkspaceValidationInput();
+    const cwd = "/tmp/paperclip-git-backed-without-git-metadata";
+
+    await expectWorkspaceValidationFailure(
+      buildWorkspaceValidationInput({
+        resolvedWorkspace: buildResolvedWorkspace({ cwd, repoUrl: "https://example.com/repo.git" }),
+        executionWorkspace: {
+          ...input.executionWorkspace,
+          baseCwd: cwd,
+          cwd,
+          repoUrl: "https://example.com/repo.git",
+          strategy: "project_primary",
+        },
+        persistedExecutionWorkspace: {
+          ...input.persistedExecutionWorkspace!,
+          cwd,
+          repoUrl: "https://example.com/repo.git",
+          strategyType: "project_primary",
+        },
+      }),
+      "missing_git_metadata",
+      "has no .git metadata",
+    );
+  });
+
+  it("still requires .git metadata for git_worktree strategy even when repoUrl is null", async () => {
+    const input = buildWorkspaceValidationInput();
+    const cwd = "/tmp/paperclip-worktree-without-git-metadata";
+
+    await expectWorkspaceValidationFailure(
+      buildWorkspaceValidationInput({
+        resolvedWorkspace: buildResolvedWorkspace({ cwd, repoUrl: null }),
+        executionWorkspace: {
+          ...input.executionWorkspace,
+          baseCwd: cwd,
+          cwd,
+          repoUrl: null,
+          strategy: "git_worktree",
+        },
+        persistedExecutionWorkspace: {
+          ...input.persistedExecutionWorkspace!,
+          cwd,
+          repoUrl: null,
+          strategyType: "git_worktree",
+          providerRef: cwd,
+        },
+      }),
+      "missing_git_metadata",
+      "has no .git metadata",
+    );
+  });
+
+  it("still requires .git metadata when the persisted strategy is git_worktree even if the realized strategy degraded", async () => {
+    const input = buildWorkspaceValidationInput();
+    const cwd = "/tmp/paperclip-persisted-worktree-without-git-metadata";
+
+    await expectWorkspaceValidationFailure(
+      buildWorkspaceValidationInput({
+        resolvedWorkspace: buildResolvedWorkspace({ cwd, repoUrl: null }),
+        executionWorkspace: {
+          ...input.executionWorkspace,
+          baseCwd: cwd,
+          cwd,
+          repoUrl: null,
+          strategy: "project_primary",
+        },
+        persistedExecutionWorkspace: {
+          ...input.persistedExecutionWorkspace!,
+          cwd,
+          repoUrl: null,
+          strategyType: "git_worktree",
+          providerRef: cwd,
         },
       }),
       "missing_git_metadata",

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -2313,7 +2313,20 @@ export async function assertGitSensitiveAdapterWorkspaceValid(input: {
     );
   }
 
-  if (workspaceExpectation && effectiveCwd && !await hasGitMetadata(effectiveCwd)) {
+  // A Paperclip project can be a deliberately non-git local_folder (codebase
+  // origin === "local_folder" with repoUrl === null), e.g. the 'life' Obsidian
+  // vault. Such workspaces have no .git metadata by design, so only enforce the
+  // git-metadata requirement for git-backed projects (any repoUrl present) or
+  // the git_worktree strategy. All other workspace-binding guards above still
+  // apply unchanged. See LUN-3022.
+  const isGitBackedWorkspace =
+    input.executionWorkspace.strategy === "git_worktree" ||
+    input.persistedExecutionWorkspace?.strategyType === "git_worktree" ||
+    Boolean(readNonEmptyString(input.resolvedWorkspace.repoUrl)) ||
+    Boolean(readNonEmptyString(input.executionWorkspace.repoUrl)) ||
+    Boolean(readNonEmptyString(input.persistedExecutionWorkspace?.repoUrl));
+
+  if (workspaceExpectation && effectiveCwd && isGitBackedWorkspace && !await hasGitMetadata(effectiveCwd)) {
     fail(
       "missing_git_metadata",
       `Issue ${issue.identifier ?? issue.id} expected a git workspace for ${input.adapterType}, but "${effectiveCwd}" has no .git metadata.`,


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The heartbeat subsystem validates an agent's execution workspace before launching a git-sensitive local adapter (claude_local, codex_local, gemini_local, …)
> - `assertGitSensitiveAdapterWorkspaceValid` in `server/src/services/heartbeat.ts` set `workspaceExpectation=true` for any issue with a resolved workspace, then hard-required `.git` metadata at the cwd
> - But a Paperclip project can be a deliberately non-git `local_folder` (codebase `origin === "local_folder"`, `repoUrl === null`) — e.g. an Obsidian vault — which legitimately has no `.git`; every routine/issue bound to such a project aborted pre-launch with `missing_git_metadata`
> - This bit Lunaria 3× (LUN-2888 / LUN-2954 / LUN-3013) and is a latent gap affecting all companies on git-sensitive local adapters
> - This pull request narrows the `.git` requirement so it only fires for genuinely git-backed workspaces (`git_worktree` strategy, realized or persisted, or any non-empty `repoUrl`), leaving all other workspace-binding guards untouched
> - The benefit is non-git `local_folder` projects launch reliably without a manual `git init` workaround, while git-backed projects keep their full git-metadata protection

## Linked Issues or Issue Description

Path (B): no GitHub issue exists, so the bug is described inline below, following the bug report template.

**What happened?**

`assertGitSensitiveAdapterWorkspaceValid` in `server/src/services/heartbeat.ts` over-requires `.git` metadata. Any issue or routine bound to a deliberately non-git `local_folder` project (codebase `origin === "local_folder"`, `repoUrl === null`) aborts pre-launch with `missing_git_metadata` on every git-sensitive local adapter.

**Expected behavior**

A `local_folder` project with `repoUrl === null` and no `git_worktree` strategy launches normally. The `.git` requirement should apply only to genuinely git-backed workspaces.

**Steps to reproduce**

1. Create a Paperclip project whose codebase `origin` is `local_folder` and whose `repoUrl` is null, pointing at a directory with no `.git` (for example an Obsidian vault).
2. Assign an issue or routine on that project to an agent using a git-sensitive local adapter (`claude_local`, `codex_local`, or `gemini_local`).
3. Fire the heartbeat.
4. The run aborts before launch with `missing_git_metadata`.

**Paperclip version or commit**

Reproduced on `master` at the time this branch was cut; the guard is unchanged in current `master`.

**Deployment mode**

Self-hosted, local adapters on macOS (Mac Mini M4).

Tracked in Paperclip (not GitHub issues): LUN-3022 (this fix), LUN-3021 (durable-fix tracker), LUN-3020 (shipped `git init` workaround), LUN-2888 / LUN-2954 / LUN-3013 (impact).

## What Changed

- `server/src/services/heartbeat.ts`: added an `isGitBackedWorkspace` predicate (true for `git_worktree` realized/persisted strategy, or any non-empty `repoUrl` on resolved/execution/persisted workspace) and gated the `missing_git_metadata` check on it. All other guards unchanged.
- `server/src/__tests__/heartbeat-workspace-session.test.ts`: 4 new regression cases (non-git allow path, git-backed reject, explicit `git_worktree` reject, degraded-persisted-strategy reject) + existing case updated to a git-backed fixture.

## Verification

- `npx vitest run server/src/__tests__/heartbeat-workspace-session.test.ts` → **89 passed** (verified independently by reviewer)
- `tsc --noEmit` (server) → 0 errors
- All Paperclip CI gates green (Build, server suites, e2e, typecheck, policy, security scans)

## Risks

Low risk. Change is self-contained, touches no schema/migration, and preserves every existing failure mode for git-backed workspaces. It only relaxes enforcement for workspaces that have no git signal at all (no `repoUrl`, not a worktree), where `.git` was never a meaningful expectation.

## Model Used

Claude (Anthropic) — `claude-opus-4-8`, extended thinking, tool use / code execution. Implemented by CTO Vlad (claude_local adapter); reviewed and signed off (Level B) by Luna (`claude-opus-4-8`).

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

