### PR TITLE
fix(server): redact agent config secrets in read and mutation responses

### DIFF
--- a/server/src/__tests__/agent-permissions-routes.test.ts
+++ b/server/src/__tests__/agent-permissions-routes.test.ts
@@ -47,6 +47,7 @@ const mockAgentService = vi.hoisted(() => ({
   terminate: vi.fn(),
   update: vi.fn(),
   updatePermissions: vi.fn(),
+  rollbackConfigRevision: vi.fn(),
   getChainOfCommand: vi.fn(),
   resolveByReference: vi.fn(),
 }));
@@ -312,6 +313,7 @@ describe.sequential("agent permission routes", () => {
     mockAgentService.terminate.mockReset();
     mockAgentService.update.mockReset();
     mockAgentService.updatePermissions.mockReset();
+    mockAgentService.rollbackConfigRevision.mockReset();
     mockAgentService.getChainOfCommand.mockReset();
     mockAgentService.resolveByReference.mockReset();
     mockBuiltInAgentService.ensureCompanyDefaultAgentGrants.mockReset();
@@ -360,6 +362,7 @@ describe.sequential("agent permission routes", () => {
     });
     mockAgentService.update.mockResolvedValue(baseAgent);
     mockAgentService.updatePermissions.mockResolvedValue(baseAgent);
+    mockAgentService.rollbackConfigRevision.mockResolvedValue(baseAgent);
     mockBuiltInAgentService.ensureCompanyDefaultAgentGrants.mockResolvedValue(0);
     mockAccessService.canUser.mockResolvedValue(true);
     mockAccessService.decide.mockImplementation(async (input: { action?: string }) => {
@@ -2035,6 +2038,77 @@ describe.sequential("agent permission routes", () => {
       expect(mockAccessService.decide).toHaveBeenCalledWith(expect.objectContaining({
         action: "agent_config:read",
         resource: { type: "company", companyId },
+      }));
+    });
+
+    it("redacts secret-bearing config values from rollback mutation responses", async () => {
+      const secretBearingAgent = {
+        ...baseAgent,
+        adapterConfig: {
+          model: "local/model",
+          env: {
+            OPENAI_API_KEY: "synthetic-rollback-secret",
+            PUBLIC_MODE: "debug",
+          },
+        },
+        runtimeConfig: {
+          modelProfiles: {
+            default: {
+              enabled: true,
+              adapterConfig: {
+                env: {
+                  ANTHROPIC_API_KEY: "synthetic-runtime-rollback-secret",
+                  LOG_LEVEL: "info",
+                },
+              },
+            },
+          },
+        },
+      };
+      mockAgentService.getById.mockResolvedValue(secretBearingAgent);
+      mockAgentService.rollbackConfigRevision.mockResolvedValue(secretBearingAgent);
+
+      const app = await createApp({
+        type: "board",
+        userId: "board-user",
+        source: "session",
+        isInstanceAdmin: true,
+        companyIds: [companyId],
+      });
+
+      const res = await requestApp(app, (baseUrl) => request(baseUrl)
+        .post(`/api/agents/${agentId}/config-revisions/revision-1/rollback`)
+        .send({}));
+
+      expect(res.status, JSON.stringify(res.body)).toBe(200);
+      expect(JSON.stringify(res.body)).not.toContain("synthetic-rollback-secret");
+      expect(JSON.stringify(res.body)).not.toContain("synthetic-runtime-rollback-secret");
+      expect(res.body.adapterConfig).toMatchObject({
+        model: "local/model",
+        env: {
+          OPENAI_API_KEY: "***REDACTED***",
+          PUBLIC_MODE: "debug",
+        },
+      });
+      expect(res.body.runtimeConfig).toMatchObject({
+        modelProfiles: {
+          default: {
+            enabled: true,
+            adapterConfig: {
+              env: {
+                ANTHROPIC_API_KEY: "***REDACTED***",
+                LOG_LEVEL: "info",
+              },
+            },
+          },
+        },
+      });
+      expect(mockAgentService.rollbackConfigRevision).toHaveBeenCalledWith(agentId, "revision-1", {
+        agentId: null,
+        userId: "board-user",
+      });
+      expect(mockLogActivity).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
+        action: "agent.config_rolled_back",
       }));
     });
   });

--- a/server/src/__tests__/agent-permissions-routes.test.ts
+++ b/server/src/__tests__/agent-permissions-routes.test.ts
@@ -435,7 +435,7 @@ describe.sequential("agent permission routes", () => {
     expect(res.body.runtimeConfig).toEqual({});
   }, 20_000);
 
-  it("keeps board agent detail unredacted for low-trust agents", async () => {
+  it("redacts secret-bearing board agent detail while preserving non-secret config", async () => {
     mockAgentService.getById.mockResolvedValue({
       ...baseAgent,
       permissions: {
@@ -444,11 +444,21 @@ describe.sequential("agent permission routes", () => {
       },
       adapterConfig: {
         command: "pnpm agent:run",
-        env: { PAPERCLIP_API_KEY: "secret-test-key" },
+        model: "local/model",
+        env: {
+          PAPERCLIP_API_KEY: "secret-test-key",
+          PUBLIC_MODE: "debug",
+        },
       },
       runtimeConfig: {
         modelProfiles: {
-          default: { enabled: true, adapterConfig: { model: "openai/gpt-5.4-mini" } },
+          default: {
+            enabled: true,
+            adapterConfig: {
+              model: "openai/gpt-5.4-mini",
+              env: { OPENAI_API_KEY: "runtime-secret-test-key" },
+            },
+          },
         },
       },
     });
@@ -466,14 +476,105 @@ describe.sequential("agent permission routes", () => {
     expect(res.status).toBe(200);
     expect(res.body.adapterConfig).toMatchObject({
       command: "pnpm agent:run",
-      env: { PAPERCLIP_API_KEY: "secret-test-key" },
+      model: "local/model",
+      env: {
+        PAPERCLIP_API_KEY: "***REDACTED***",
+        PUBLIC_MODE: "debug",
+      },
     });
     expect(res.body.runtimeConfig).toMatchObject({
       modelProfiles: {
-        default: { enabled: true, adapterConfig: { model: "openai/gpt-5.4-mini" } },
+        default: {
+          enabled: true,
+          adapterConfig: {
+            model: "openai/gpt-5.4-mini",
+            env: { OPENAI_API_KEY: "***REDACTED***" },
+          },
+        },
       },
     });
+    expect(JSON.stringify(res.body)).not.toContain("secret-test-key");
+    expect(JSON.stringify(res.body)).not.toContain("runtime-secret-test-key");
     expect(res.body.permissions).toMatchObject({ trustPreset: LOW_TRUST_REVIEW_PRESET });
+  }, 20_000);
+
+  it("redacts secret-bearing config values from privileged agent list and detail reads", async () => {
+    const secretBearingAgent = {
+      ...baseAgent,
+      adapterConfig: {
+        model: "local/model",
+        endpoint: "https://agent.example.test",
+        env: {
+          OPENAI_API_KEY: "synthetic-openai-secret",
+          PUBLIC_MODE: "debug",
+        },
+        nested: {
+          bearerToken: "synthetic-bearer-secret",
+        },
+      },
+      runtimeConfig: {
+        modelProfiles: {
+          cheap: {
+            enabled: true,
+            adapterConfig: {
+              model: "openai/gpt-5.4-mini",
+              env: {
+                ANTHROPIC_API_KEY: "synthetic-runtime-secret",
+                LOG_LEVEL: "info",
+              },
+            },
+          },
+        },
+      },
+    };
+    mockAgentService.getById.mockResolvedValue(secretBearingAgent);
+    mockAgentService.list.mockResolvedValue([secretBearingAgent]);
+    mockAccessService.hasPermission.mockResolvedValue(true);
+
+    const app = await createApp({
+      type: "agent",
+      agentId,
+      companyId,
+      companyIds: [companyId],
+    });
+
+    const listRes = await requestApp(app, (baseUrl) => request(baseUrl).get(`/api/companies/${companyId}/agents`));
+    const detailRes = await requestApp(app, (baseUrl) => request(baseUrl).get(`/api/agents/${agentId}`));
+
+    for (const res of [listRes, detailRes]) {
+      expect(res.status).toBe(200);
+      expect(JSON.stringify(res.body)).not.toContain("synthetic-openai-secret");
+      expect(JSON.stringify(res.body)).not.toContain("synthetic-bearer-secret");
+      expect(JSON.stringify(res.body)).not.toContain("synthetic-runtime-secret");
+    }
+
+    const listAgent = listRes.body[0];
+    expect(listAgent.adapterConfig).toMatchObject({
+      model: "local/model",
+      endpoint: "https://agent.example.test",
+      env: {
+        OPENAI_API_KEY: "***REDACTED***",
+        PUBLIC_MODE: "debug",
+      },
+      nested: {
+        bearerToken: "***REDACTED***",
+      },
+    });
+    expect(detailRes.body.adapterConfig).toMatchObject(listAgent.adapterConfig);
+    expect(detailRes.body.runtimeConfig).toMatchObject({
+      modelProfiles: {
+        cheap: {
+          enabled: true,
+          adapterConfig: {
+            model: "openai/gpt-5.4-mini",
+            env: {
+              ANTHROPIC_API_KEY: "***REDACTED***",
+              LOG_LEVEL: "info",
+            },
+          },
+        },
+      },
+    });
   }, 20_000);
 
   it("redacts company agent list for authenticated company members without agent admin permission", async () => {
@@ -623,10 +724,33 @@ describe.sequential("agent permission routes", () => {
   });
 
   it("allows board updates that set cheap-profile workspace commands", async () => {
+    const updatedAgent = {
+      ...baseAgent,
+      adapterType: "codex_local",
+      adapterConfig: {
+        env: {
+          OPENAI_API_KEY: "synthetic-patch-secret",
+          PUBLIC_MODE: "debug",
+        },
+      },
+      runtimeConfig: {
+        modelProfiles: {
+          cheap: {
+            adapterConfig: {
+              env: {
+                ANTHROPIC_API_KEY: "synthetic-patch-runtime-secret",
+                LOG_LEVEL: "info",
+              },
+            },
+          },
+        },
+      },
+    };
     mockAgentService.getById.mockResolvedValue({
       ...baseAgent,
       adapterType: "codex_local",
     });
+    mockAgentService.update.mockResolvedValue(updatedAgent);
 
     const app = await createApp({
       type: "board",
@@ -654,6 +778,26 @@ describe.sequential("agent permission routes", () => {
       .send({ runtimeConfig }));
 
     expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(JSON.stringify(res.body)).not.toContain("synthetic-patch-secret");
+    expect(JSON.stringify(res.body)).not.toContain("synthetic-patch-runtime-secret");
+    expect(res.body.adapterConfig).toMatchObject({
+      env: {
+        OPENAI_API_KEY: "***REDACTED***",
+        PUBLIC_MODE: "debug",
+      },
+    });
+    expect(res.body.runtimeConfig).toMatchObject({
+      modelProfiles: {
+        cheap: {
+          adapterConfig: {
+            env: {
+              ANTHROPIC_API_KEY: "***REDACTED***",
+              LOG_LEVEL: "info",
+            },
+          },
+        },
+      },
+    });
     expect(mockAgentService.update).toHaveBeenCalledWith(
       agentId,
       expect.objectContaining({ runtimeConfig }),
@@ -874,6 +1018,78 @@ describe.sequential("agent permission routes", () => {
       "agent-admin-user",
     );
     expect(mockBuiltInAgentService.ensureCompanyDefaultAgentGrants).toHaveBeenCalledWith(companyId);
+  });
+
+  it("redacts secret-bearing config values from direct creation and hire responses", async () => {
+    const secretBearingAgent = {
+      ...baseAgent,
+      adapterConfig: {
+        model: "local/model",
+        env: {
+          OPENAI_API_KEY: "synthetic-create-secret",
+          PUBLIC_MODE: "debug",
+        },
+      },
+      runtimeConfig: {
+        modelProfiles: {
+          default: {
+            enabled: true,
+            adapterConfig: {
+              env: {
+                ANTHROPIC_API_KEY: "synthetic-runtime-create-secret",
+                LOG_LEVEL: "info",
+              },
+            },
+          },
+        },
+      },
+    };
+    mockAgentService.create.mockResolvedValue(secretBearingAgent);
+
+    const app = await createApp({
+      type: "board",
+      userId: "agent-admin-user",
+      source: "session",
+      isInstanceAdmin: false,
+      companyIds: [companyId],
+    });
+
+    const directRes = await requestApp(app, (baseUrl) => request(baseUrl)
+      .post(`/api/companies/${companyId}/agents`)
+      .send({
+        name: "Builder",
+        role: "engineer",
+        adapterType: "process",
+        adapterConfig: {
+          env: { OPENAI_API_KEY: "synthetic-request-secret" },
+        },
+      }));
+    const hireRes = await requestApp(app, (baseUrl) => request(baseUrl)
+      .post(`/api/companies/${companyId}/agent-hires`)
+      .send({
+        name: "Builder",
+        role: "engineer",
+        adapterType: "process",
+        adapterConfig: {
+          env: { OPENAI_API_KEY: "synthetic-request-secret" },
+        },
+      }));
+
+    for (const res of [directRes, hireRes]) {
+      expect(res.status, JSON.stringify(res.body)).toBe(201);
+      expect(JSON.stringify(res.body)).not.toContain("synthetic-create-secret");
+      expect(JSON.stringify(res.body)).not.toContain("synthetic-runtime-create-secret");
+      expect(JSON.stringify(res.body)).not.toContain("synthetic-request-secret");
+    }
+    expect(directRes.body.adapterConfig).toMatchObject({
+      model: "local/model",
+      env: {
+        OPENAI_API_KEY: "***REDACTED***",
+        PUBLIC_MODE: "debug",
+      },
+    });
+    expect(hireRes.body.agent.adapterConfig).toMatchObject(directRes.body.adapterConfig);
+    expect(hireRes.body).toHaveProperty("approval");
   });
 
   it("rejects direct agent creation when new agents require board approval", async () => {
@@ -1114,6 +1330,24 @@ describe.sequential("agent permission routes", () => {
     const approvedAgent = {
       ...baseAgent,
       status: "idle",
+      adapterConfig: {
+        env: {
+          OPENAI_API_KEY: "synthetic-approve-secret",
+          PUBLIC_MODE: "debug",
+        },
+      },
+      runtimeConfig: {
+        modelProfiles: {
+          default: {
+            adapterConfig: {
+              env: {
+                ANTHROPIC_API_KEY: "synthetic-approve-runtime-secret",
+                LOG_LEVEL: "info",
+              },
+            },
+          },
+        },
+      },
     };
     mockAgentService.getById.mockResolvedValue(pendingAgent);
     mockAgentService.activatePendingApproval.mockResolvedValue({
@@ -1134,6 +1368,26 @@ describe.sequential("agent permission routes", () => {
       .send({}));
 
     expect(res.status).toBe(200);
+    expect(JSON.stringify(res.body)).not.toContain("synthetic-approve-secret");
+    expect(JSON.stringify(res.body)).not.toContain("synthetic-approve-runtime-secret");
+    expect(res.body.adapterConfig).toMatchObject({
+      env: {
+        OPENAI_API_KEY: "***REDACTED***",
+        PUBLIC_MODE: "debug",
+      },
+    });
+    expect(res.body.runtimeConfig).toMatchObject({
+      modelProfiles: {
+        default: {
+          adapterConfig: {
+            env: {
+              ANTHROPIC_API_KEY: "***REDACTED***",
+              LOG_LEVEL: "info",
+            },
+          },
+        },
+      },
+    });
     expect(mockAgentService.activatePendingApproval).toHaveBeenCalledWith(agentId);
     expect(mockApprovalService.approve).not.toHaveBeenCalled();
     expect(mockLogActivity).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({

--- a/server/src/__tests__/low-trust-red-team-routes.test.ts
+++ b/server/src/__tests__/low-trust-red-team-routes.test.ts
@@ -865,7 +865,9 @@ describeEmbeddedPostgres("low-trust red-team HTTP route regression suite", () =>
     const standardActor = agentActor(fixture, fixture.agents.standard.id);
     const standardRes = await request(createApp(db, { ...standardActor, runId: null })).get("/api/agents/me");
     expect(standardRes.status, JSON.stringify(standardRes.body)).toBe(200);
-    expect(JSON.stringify(standardRes.body)).toContain(fixture.canaries.agentConfig);
+    expectNoCanary(standardRes.body, fixture.canaries.agentConfig);
+    expect(standardRes.body.adapterConfig).toMatchObject({ token: "***REDACTED***" });
+    expect(standardRes.body.runtimeConfig).toMatchObject({ env: { SECRET_MARKER: "***REDACTED***" } });
 
     const issueScopedLowTrustRes = await request(createApp(db, standardActor)).get("/api/agents/me");
     expect(issueScopedLowTrustRes.status, JSON.stringify(issueScopedLowTrustRes.body)).toBe(200);

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -2295,7 +2295,7 @@ export function agentRoutes(
       details: { revisionId },
     });
 
-    res.json(updated);
+    res.json(redactAgentReadConfig(updated));
   });
 
   router.get("/agents/:id/runtime-state", async (req, res) => {

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -662,7 +662,7 @@ export function agentRoutes(
     ]);
 
     return {
-      ...(options?.restricted ? redactForRestrictedAgentView(agent) : agent),
+      ...(options?.restricted ? redactForRestrictedAgentView(agent) : redactAgentReadConfig(agent)),
       chainOfCommand,
       access: accessState,
     };
@@ -1630,6 +1630,15 @@ export function agentRoutes(
     };
   }
 
+  function redactAgentReadConfig(agent: Awaited<ReturnType<typeof svc.getById>>) {
+    if (!agent) return null;
+    return {
+      ...agent,
+      adapterConfig: redactEventPayload(asRecord(agent.adapterConfig) ?? {}),
+      runtimeConfig: redactEventPayload(asRecord(agent.runtimeConfig) ?? {}),
+    };
+  }
+
   function redactAgentConfiguration(agent: Awaited<ReturnType<typeof svc.getById>>) {
     if (!agent) return null;
     return {
@@ -1974,7 +1983,7 @@ export function agentRoutes(
     const result = await filterAgentsForActor(req, await svc.list(companyId));
     const canReadConfigs = await actorCanReadConfigurationsForCompany(req, companyId);
     if (canReadConfigs) {
-      res.json(result);
+      res.json(result.map((agent) => redactAgentReadConfig(agent)));
       return;
     }
     res.json(result.map((agent) => redactForRestrictedAgentView(agent)));
@@ -2531,7 +2540,7 @@ export function agentRoutes(
       });
     }
 
-    res.status(201).json({ agent, approval });
+    res.status(201).json({ agent: redactAgentReadConfig(agent), approval });
   });
 
   router.post("/companies/:companyId/agents", validate(createAgentSchema), async (req, res) => {
@@ -2651,7 +2660,7 @@ export function agentRoutes(
       );
     }
 
-    res.status(201).json(agent);
+    res.status(201).json(redactAgentReadConfig(agent));
   });
 
   router.patch("/agents/:id/permissions", validate(updateAgentPermissionsSchema), async (req, res) => {
@@ -3112,7 +3121,7 @@ export function agentRoutes(
       details: summarizeAgentUpdateDetails(patchData),
     });
 
-    res.json(agent);
+    res.json(redactAgentReadConfig(agent));
   });
 
   router.post("/agents/:id/pause", async (req, res) => {
@@ -3138,7 +3147,7 @@ export function agentRoutes(
       entityId: agent.id,
     });
 
-    res.json(agent);
+    res.json(redactAgentReadConfig(agent));
   });
 
   router.post("/agents/:id/resume", async (req, res) => {
@@ -3169,7 +3178,7 @@ export function agentRoutes(
       entityId: agent.id,
     });
 
-    res.json(agent);
+    res.json(redactAgentReadConfig(agent));
   });
 
   router.post("/agents/:id/clear-error", async (req, res) => {
@@ -3201,7 +3210,7 @@ export function agentRoutes(
       entityId: agent.id,
     });
 
-    res.json(agent);
+    res.json(redactAgentReadConfig(agent));
   });
 
   router.post("/agents/:id/approve", async (req, res) => {
@@ -3255,7 +3264,7 @@ export function agentRoutes(
       details: { source: "agent_detail", approvalId: openApproval?.id ?? null },
     });
 
-    res.json(agent);
+    res.json(redactAgentReadConfig(agent));
   });
 
   router.post("/agents/:id/terminate", async (req, res) => {
@@ -3325,7 +3334,7 @@ export function agentRoutes(
       },
     });
 
-    res.json(agent);
+    res.json(redactAgentReadConfig(agent));
   });
 
   router.delete("/agents/:id", async (req, res) => {


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the control plane that lets board users and agents inspect and operate autonomous companies through authenticated APIs.
> - Agent read and mutation routes in `server/` are part of that control plane boundary and routinely expose adapter and runtime configuration to callers.
> - Those configuration payloads can carry secret-bearing env bindings, so leaking them in normal read/list/update responses breaks the repo's security expectations.
> - This scope is not a new feature; it is a narrowly bounded security hardening fix that preserves existing route shapes while redacting sensitive values.
> - Existing duplicate PRs for the same class of bug drifted or conflicted, so the approved fix needed a clean publication path from the already-reviewed head.
> - This pull request publishes that approved head against current `master` with targeted regression coverage for route redaction and log redaction behavior.
> - The benefit is that operators and agents still get inspectable config metadata, but secret material is redacted consistently across agent API responses.

## Linked Issues or Issue Description

Refs #1839
Refs #4763
Refs #6038

This PR addresses a security bug in agent API responses. Prior implementations and duplicate PRs identified that Paperclip could return secret-bearing adapter/runtime configuration values through agent read, list, or update responses, and could preserve plaintext secret-looking env bindings in request-log text. The approved fix for that bug existed on a fallback branch but had not been published to a mergeable upstream PR head.

## What Changed

- Redacted readable agent `adapterConfig` and `runtimeConfig` values in server agent routes while preserving response structure.
- Kept mutation responses on the same redacted path so update/read behavior stays aligned.
- Expanded redaction coverage for plain env-binding/log text to catch secret-looking key/value material before it is surfaced back to callers.
- Added targeted server tests covering agent route redaction and secret-text redaction regressions.

## Verification

- `pnpm exec vitest run server/src/__tests__/agent-permissions-routes.test.ts server/src/__tests__/redact-sensitive.test.ts`
- `pnpm --filter @paperclipai/server typecheck`
- `pnpm check:tokens`
- `git diff --check origin/master..HEAD`

## Risks

Low to moderate risk. The code intentionally redacts more aggressively in agent-readable config payloads and secret-looking text, so the main regression risk is over-redaction of benign values that happen to match secret-key heuristics.

## Model Used

OpenAI GPT-5.5 via Paperclip `codex_local`, with tool use and local code execution in a repo worktree. Runtime context window size was not exposed by the adapter.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
