### PR TITLE
build(ui): drop redundant tsc type-check from ui build

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -15,7 +15,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc -b && vite build",
+    "build": "vite build",
     "storybook": "storybook dev -p 6006 -c storybook/.storybook",
     "build-storybook": "storybook build -c storybook/.storybook -o storybook-static",
     "preview": "vite preview",


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - CI runs a set of required PR checks; the Canary Dry Run job is the slowest (~4m)
> - Its dominant cost is `release.sh` Step 2 `pnpm build` (~133s), whose critical path is the `ui` package
> - In `ui`, `tsc -b` runs ~46s *before* `vite build` (~20s), but `ui/tsconfig.json` sets `noEmit: true`, so `tsc -b` is a pure type-check that emits nothing — vite produces all artifacts
> - The PR workflow already runs a parallel Typecheck job (`typecheck:build-gaps`) that auto-type-checks any workspace package whose build script omits `tsc`
> - This pull request drops `tsc -b` from the `ui` build so the type-check moves off the build/release critical path onto the slack-rich Typecheck job
> - The benefit is ~46s shaved off the slowest PR check with no loss of type coverage

## What Changed

- `ui/package.json`: `build` script changed from `tsc -b && vite build` to `vite build`.
- Type coverage is preserved automatically: `scripts/run-typecheck-build-gaps.mjs` already type-checks any workspace whose `build` script omits `tsc` and defines a `typecheck` script. With this change, `@paperclipai/ui` (whose `typecheck` is `tsc -b`) is now picked up by the parallel Typecheck job. No script edit was required — the gap-detection is generic.

## Verification

- `pnpm --filter @paperclipai/ui build` produces `ui/dist` via vite alone (no `tsc` invocation).
- `pnpm typecheck:build-gaps` now type-checks `@paperclipai/ui` and exits 0.
- A type error in `ui` still fails the parallel Typecheck job, so type-error coverage is unchanged.

## Risks

- Low. The type-check is relocated, not removed. This is build-tooling only — no migration, no runtime behavior change. If `scripts/run-typecheck-build-gaps.mjs` ever stopped covering `ui`, a type error could slip past the build job — but its gap-detection is generic (any package with a tsc-less build plus a `typecheck` script), and `ui` qualifies.

## Model Used

Claude (Anthropic), `claude-opus-4` family, extended-thinking mode with tool use, operating as an automated CI-health agent.