### PR TITLE
fix(heartbeat): re-adopt only the current assignee's run on wake

### DIFF
--- a/server/src/__tests__/heartbeat-deferred-wake-handoff.test.ts
+++ b/server/src/__tests__/heartbeat-deferred-wake-handoff.test.ts
@@ -1,0 +1,461 @@
+import { randomUUID } from "node:crypto";
+import { and, eq } from "drizzle-orm";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  agents,
+  agentWakeupRequests,
+  companies,
+  createDb,
+  heartbeatRuns,
+  issues,
+} from "@paperclipai/db";
+import { heartbeatService } from "../services/heartbeat.ts";
+import { startEmbeddedPostgresTestDatabase } from "./helpers/embedded-postgres.ts";
+
+async function closeDbClient(db: ReturnType<typeof createDb> | undefined) {
+  await db?.$client?.end?.({ timeout: 0 });
+}
+
+/**
+ * Spec 0079 — when an issue is handed off in place (reassigned to a new agent
+ * while it was checked out by a live run of the previous agent), the engine
+ * defers the new assignee's wake and must promote it once the carrier is free.
+ *
+ * The dominant suspect (spec §1) is the legacy re-adoption
+ * (heartbeat.ts:10142-10181): when the carrier has no active execution run, the
+ * engine re-locks it to ANY queued/running run whose contextSnapshot.issueId =
+ * carrier, WITHOUT checking that run belongs to the current assignee. A stale
+ * continuation run of the previous owner therefore re-locks the carrier to the
+ * outgoing agent, and the new assignee's wake is orphaned (deferred forever).
+ */
+describe("spec 0079 — deferred wake handoff promotion", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    const started = await startEmbeddedPostgresTestDatabase("paperclip-deferred-wake-handoff-");
+    db = createDb(started.connectionString);
+    tempDb = started;
+  }, 120_000);
+
+  afterAll(async () => {
+    await closeDbClient(db);
+    await tempDb?.cleanup();
+  });
+
+  it("wakes the new assignee even when a stale continuation run of the previous owner is queued on the carrier", async () => {
+    const companyId = randomUUID();
+    const previousOwnerId = randomUUID(); // agent A (the outgoing triage)
+    const newAssigneeId = randomUUID(); // agent B (the gate)
+    const issueId = randomUUID();
+    const otherIssueId = randomUUID();
+    const staleRunId = randomUUID();
+    const busyRunId = randomUUID();
+    const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+    const heartbeat = heartbeatService(db);
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    // A is a root agent (invokable); B reports to A (invokable via the chain).
+    await db.insert(agents).values([
+      {
+        id: previousOwnerId,
+        companyId,
+        name: "Triage",
+        role: "ceo",
+        status: "running",
+        adapterType: "process",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+      {
+        id: newAssigneeId,
+        companyId,
+        name: "Director of Data",
+        role: "manager",
+        status: "idle",
+        reportsTo: previousOwnerId,
+        adapterType: "process",
+        adapterConfig: {},
+        // One concurrency slot, occupied by B's own in-flight run below, so the
+        // promoted carrier wake stays queued (no adapter execution in this unit
+        // test).
+        runtimeConfig: { heartbeat: { maxConcurrentRuns: 1 } },
+        permissions: {},
+      },
+    ]);
+
+    // B's own in-flight run (occupies its concurrency slot). Inserted before the
+    // issues so the carrier issue's execution_run_id FK can reference it.
+    await db.insert(heartbeatRuns).values({
+      id: busyRunId,
+      companyId,
+      agentId: newAssigneeId,
+      invocationSource: "assignment",
+      triggerDetail: "system",
+      status: "running",
+      contextSnapshot: {
+        issueId: otherIssueId,
+        taskId: otherIssueId,
+        wakeReason: "issue_assigned",
+      },
+    });
+
+    // The in-place handoff is done: the carrier is now assigned to B, the
+    // triage's original run has ended, and the execution lock is released.
+    await db.insert(issues).values([
+      {
+        id: issueId,
+        companyId,
+        title: "Governed case carrier",
+        status: "todo",
+        priority: "medium",
+        assigneeAgentId: newAssigneeId,
+        executionRunId: null,
+        issueNumber: 1,
+        identifier: `${issuePrefix}-1`,
+      },
+      {
+        // B is a busy manager: it already has a run in flight on its own work.
+        // This occupies B's single concurrency slot so the promoted wake stays
+        // queued (no real adapter execution in this unit test); it does not
+        // touch the carrier and is unrelated to the re-adoption under test.
+        id: otherIssueId,
+        companyId,
+        title: "B's own in-flight work",
+        status: "in_progress",
+        priority: "medium",
+        assigneeAgentId: newAssigneeId,
+        executionRunId: busyRunId,
+        executionAgentNameKey: "director_of_data",
+        executionLockedAt: new Date(),
+        issueNumber: 2,
+        identifier: `${issuePrefix}-2`,
+      },
+    ]);
+
+    // A stale continuation run of the PREVIOUS owner (A), still queued on the
+    // carrier. This is the run the legacy re-adoption latches onto.
+    await db.insert(heartbeatRuns).values({
+      id: staleRunId,
+      companyId,
+      agentId: previousOwnerId,
+      invocationSource: "automation",
+      triggerDetail: "system",
+      status: "queued",
+      contextSnapshot: {
+        issueId,
+        taskId: issueId,
+        wakeReason: "run_liveness_continuation",
+      },
+    });
+
+    // The assignment wake for the new owner B (what routes/issues.ts fires on
+    // an in-place reassignment).
+    const wokenRun = await heartbeat.wakeup(newAssigneeId, {
+      source: "assignment",
+      triggerDetail: "system",
+      reason: "issue_assigned",
+      payload: { issueId },
+      contextSnapshot: {
+        issueId,
+        taskId: issueId,
+        wakeReason: "issue_assigned",
+      },
+      requestedByActorType: "user",
+      requestedByActorId: "local-board",
+    });
+
+    // The new assignee must be woken — a queued run for B on the carrier.
+    expect(wokenRun).not.toBeNull();
+    expect(wokenRun?.agentId).toBe(newAssigneeId);
+
+    // No deferred wake left orphaned for B.
+    const deferredForB = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(
+        and(
+          eq(agentWakeupRequests.companyId, companyId),
+          eq(agentWakeupRequests.agentId, newAssigneeId),
+          eq(agentWakeupRequests.status, "deferred_issue_execution"),
+        ),
+      )
+      .then((rows) => rows[0] ?? null);
+    expect(deferredForB).toBeNull();
+
+    // B has exactly one run scoped to the carrier, and it is active (queued),
+    // not deferred. (B's busy slot keeps it from starting in this unit test.)
+    const carrierRunsForB = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.agentId, newAssigneeId))
+      .then((rows) =>
+        rows.filter((run) => (run.contextSnapshot as Record<string, unknown>)?.issueId === issueId),
+      );
+    expect(carrierRunsForB).toHaveLength(1);
+    expect(carrierRunsForB[0]?.status).toBe("queued");
+
+    // The carrier's stale run of the previous owner was NOT re-adopted as the
+    // execution lock (root cause, CA-8).
+    const issueAfter = await db
+      .select()
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0]);
+    expect(issueAfter?.executionRunId).not.toBe(staleRunId);
+
+    // The fix does NOT over-correct: the previous owner's stale run is left in
+    // place (still queued), to be cancelled lazily at claim time by the engine's
+    // existing evaluateQueuedRunStaleness → "issue_assignee_changed" path. It is
+    // not eagerly cancelled in the wake handler.
+    const staleRunAfter = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, staleRunId))
+      .then((rows) => rows[0]);
+    expect(staleRunAfter?.status).toBe("queued");
+  });
+
+  it("still defers the new assignee while the previous owner's run is genuinely running on the carrier (CA-3: one agent at a time)", async () => {
+    const companyId = randomUUID();
+    const previousOwnerId = randomUUID(); // agent A
+    const newAssigneeId = randomUUID(); // agent B
+    const issueId = randomUUID();
+    const activeRunId = randomUUID();
+    const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+    const heartbeat = heartbeatService(db);
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values([
+      {
+        id: previousOwnerId,
+        companyId,
+        name: "Triage",
+        role: "ceo",
+        status: "running",
+        adapterType: "process",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+      {
+        id: newAssigneeId,
+        companyId,
+        name: "Director of Data",
+        role: "manager",
+        status: "idle",
+        reportsTo: previousOwnerId,
+        adapterType: "process",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+    ]);
+
+    // The previous owner A's run is GENUINELY RUNNING and still holds the
+    // execution lock (mid-handoff: the carrier was reassigned to B but A's run
+    // has not finished). The wake for B must be deferred, never started.
+    await db.insert(heartbeatRuns).values({
+      id: activeRunId,
+      companyId,
+      agentId: previousOwnerId,
+      invocationSource: "assignment",
+      triggerDetail: "system",
+      status: "running",
+      contextSnapshot: { issueId, taskId: issueId, wakeReason: "issue_assigned" },
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Governed case carrier (lock held)",
+      status: "in_progress",
+      priority: "medium",
+      assigneeAgentId: newAssigneeId,
+      executionRunId: activeRunId,
+      executionAgentNameKey: "triage",
+      executionLockedAt: new Date(),
+      issueNumber: 1,
+      identifier: `${issuePrefix}-1`,
+    });
+
+    const wokenRun = await heartbeat.wakeup(newAssigneeId, {
+      source: "assignment",
+      triggerDetail: "system",
+      reason: "issue_assigned",
+      payload: { issueId },
+      contextSnapshot: { issueId, taskId: issueId, wakeReason: "issue_assigned" },
+      requestedByActorType: "user",
+      requestedByActorId: "local-board",
+    });
+
+    // No premature promotion: B is deferred while A genuinely runs.
+    expect(wokenRun).toBeNull();
+
+    const deferredForB = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(
+        and(
+          eq(agentWakeupRequests.companyId, companyId),
+          eq(agentWakeupRequests.agentId, newAssigneeId),
+          eq(agentWakeupRequests.status, "deferred_issue_execution"),
+        ),
+      )
+      .then((rows) => rows[0] ?? null);
+    expect(deferredForB).not.toBeNull();
+
+    // The active lock of A is untouched; B has no run.
+    const issueAfter = await db
+      .select()
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0]);
+    expect(issueAfter?.executionRunId).toBe(activeRunId);
+
+    const bRuns = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.agentId, newAssigneeId));
+    expect(bRuns).toHaveLength(0);
+  });
+
+  it("still re-adopts a run that belongs to the issue's CURRENT assignee (crash/continuation recovery preserved)", async () => {
+    const companyId = randomUUID();
+    const ownerId = randomUUID(); // agent A, still the assignee
+    const issueId = randomUUID();
+    const otherIssueId = randomUUID();
+    const continuationRunId = randomUUID();
+    const busyRunId = randomUUID();
+    const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+    const heartbeat = heartbeatService(db);
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: ownerId,
+      companyId,
+      name: "Owner",
+      role: "ceo",
+      status: "running",
+      adapterType: "process",
+      adapterConfig: {},
+      // One slot, occupied below, so the re-adopted/coalesced run stays queued.
+      runtimeConfig: { heartbeat: { maxConcurrentRuns: 1 } },
+      permissions: {},
+    });
+
+    // A busy run on unrelated work occupies the agent's single slot.
+    await db.insert(heartbeatRuns).values({
+      id: busyRunId,
+      companyId,
+      agentId: ownerId,
+      invocationSource: "assignment",
+      triggerDetail: "system",
+      status: "running",
+      contextSnapshot: { issueId: otherIssueId, taskId: otherIssueId, wakeReason: "issue_assigned" },
+    });
+
+    await db.insert(issues).values([
+      {
+        id: issueId,
+        companyId,
+        title: "Owner's own carrier (lock released, run still queued)",
+        status: "in_progress",
+        priority: "medium",
+        assigneeAgentId: ownerId,
+        executionRunId: null,
+        issueNumber: 1,
+        identifier: `${issuePrefix}-1`,
+      },
+      {
+        id: otherIssueId,
+        companyId,
+        title: "Owner's unrelated in-flight work",
+        status: "in_progress",
+        priority: "medium",
+        assigneeAgentId: ownerId,
+        executionRunId: busyRunId,
+        executionAgentNameKey: "owner",
+        executionLockedAt: new Date(),
+        issueNumber: 2,
+        identifier: `${issuePrefix}-2`,
+      },
+    ]);
+
+    // A queued continuation run of the SAME assignee on the carrier — the engine
+    // SHOULD re-adopt it (this is the legitimate crash/continuation recovery the
+    // re-adoption exists for).
+    await db.insert(heartbeatRuns).values({
+      id: continuationRunId,
+      companyId,
+      agentId: ownerId,
+      invocationSource: "automation",
+      triggerDetail: "system",
+      status: "queued",
+      contextSnapshot: { issueId, taskId: issueId, wakeReason: "run_liveness_continuation" },
+    });
+
+    const wokenRun = await heartbeat.wakeup(ownerId, {
+      source: "automation",
+      triggerDetail: "system",
+      reason: "issue_assigned",
+      payload: { issueId },
+      contextSnapshot: { issueId, taskId: issueId, wakeReason: "issue_assigned" },
+      requestedByActorType: "user",
+      requestedByActorId: "local-board",
+    });
+
+    // Same-agent wake coalesces into the re-adopted run (not null, not deferred).
+    expect(wokenRun).not.toBeNull();
+
+    // The carrier was re-locked to the assignee's own continuation run.
+    const issueAfter = await db
+      .select()
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0]);
+    expect(issueAfter?.executionRunId).toBe(continuationRunId);
+
+    const deferred = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(
+        and(
+          eq(agentWakeupRequests.companyId, companyId),
+          eq(agentWakeupRequests.status, "deferred_issue_execution"),
+        ),
+      )
+      .then((rows) => rows[0] ?? null);
+    expect(deferred).toBeNull();
+
+    // No duplicate run was created for the carrier.
+    const carrierRuns = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.agentId, ownerId))
+      .then((rows) =>
+        rows.filter((run) => (run.contextSnapshot as Record<string, unknown>)?.issueId === issueId),
+      );
+    expect(carrierRuns).toHaveLength(1);
+    expect(carrierRuns[0]?.id).toBe(continuationRunId);
+  });
+});

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -11361,13 +11361,28 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             .where(eq(issues.id, issue.id));
         }
 
-        if (!activeExecutionRun) {
+        if (!activeExecutionRun && issue.assigneeAgentId) {
+          // Only re-adopt a run that still belongs to the issue's CURRENT
+          // assignee. After an in-place handoff (the carrier is reassigned to a
+          // new agent while a run of the previous owner is still in flight on
+          // it), re-locking the carrier to the outgoing agent's run would
+          // orphan the new assignee's deferred wake forever — the carrier never
+          // drives its governed cycle (spec 0079). This mirrors the ownership
+          // check the engine already applies to stale scheduled retries
+          // (cancelStaleScheduledRetry → "issue_reassigned").
+          //
+          // The previous owner's stale run is intentionally left in place here
+          // (not eagerly cancelled): the engine cancels it lazily, at claim
+          // time, via evaluateQueuedRunStaleness → "issue_assignee_changed"
+          // (it never runs on the carrier). Eager cancellation in this read
+          // path would diverge from that idiom and widen the blast radius.
           const legacyRun = await tx
             .select()
             .from(heartbeatRuns)
             .where(
               and(
                 eq(heartbeatRuns.companyId, issue.companyId),
+                eq(heartbeatRuns.agentId, issue.assigneeAgentId),
                 inArray(heartbeatRuns.status, [...EXECUTION_PATH_HEARTBEAT_RUN_STATUSES]),
                 sql`${heartbeatRuns.contextSnapshot} ->> 'issueId' = ${issue.id}`,
               ),


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Agents pick up issues via the heartbeat/execution system; an issue is checked
>   out by a run, and reassigning an issue is documented to wake the new assignee
> - When an issue is reassigned in place while a run of the previous owner is still
>   in flight, the engine correctly defers the new assignee's wake (one agent at a
>   time)
> - But the deferred wake is never promoted: when the carrier has no active
>   execution run, the legacy re-adoption re-locks it to ANY queued/running run
>   scoped to that issue — without checking the run still belongs to the current
>   assignee
> - So a stale continuation run of the previous owner re-locks the carrier to the
>   outgoing agent, and the new assignee's wake stays `deferred_issue_execution`
>   forever — the issue never drives its work
> - This pull request restricts the re-adoption to runs whose `agentId` equals the
>   issue's current `assigneeAgentId`, mirroring the ownership check the engine
>   already applies elsewhere (`cancelStaleScheduledRetry`, `evaluateQueuedRunStaleness`)
> - The benefit is in-place handoffs actually wake the new owner, fulfilling the
>   engine's own promise ("the new owner will be woken instead")

## Linked Issues or Issue Description

Fixes #1269 — "[Bug] Deferred wake not promoted after execution release when issue
is reassigned via PATCH". That issue describes this exact scenario (an agent checks
out an issue, reassigns it via `PATCH /issues/:id`, and the new assignee is never
woken because the deferred wake is not promoted).

Related (different deferred-wake concerns, not the same root cause, linked for
reviewer context): Refs #4372, Refs #4673, Refs #4393.

Reproduced and confirmed as still present on current `master`.

## What Changed

- `server/src/services/heartbeat.ts` (legacy re-adoption): only re-adopt a run whose
  `agentId` equals the issue's current `assigneeAgentId`. The previous owner's stale
  run is left in place and cancelled lazily at claim time (matching the engine's
  existing `evaluateQueuedRunStaleness → issue_assignee_changed` idiom) — it is not
  eagerly cancelled, to keep the blast radius minimal.
- Tests: new `server/src/__tests__/heartbeat-deferred-wake-handoff.test.ts` covering
  the orphaned-wake reproduction (new assignee woken despite a stale continuation run
  of the previous owner), the one-agent-at-a-time guard (still deferred while the
  previous run genuinely runs), and same-agent continuation recovery preserved.

## Verification

- `pnpm --filter @paperclipai/server exec vitest run heartbeat-deferred-wake-handoff` → 3/3 pass
- Regression zone `vitest run heartbeat issues` → 463/463 pass (no regression)
- `pnpm typecheck` clean
- Revert the `eq(heartbeatRuns.agentId, issue.assigneeAgentId)` guard → the
  reproduction test goes red (the fix is what makes it pass).

## Risks

Medium-low. Touches the legacy re-adoption path, which serves crash/continuation
recovery for all agents — the highest cross-regression surface. Mitigated by:
(a) a same-agent recovery test proving legitimate re-adoption still works;
(b) a one-agent-at-a-time test proving no premature promotion; (c) the change mirrors
an ownership check the engine already enforces in two sibling paths; (d) no eager
cancellation, so the previous owner's run is handled by the engine's existing lazy
path.

## Model Used

Claude Opus 4.8 (`claude-opus-4-8`), 1M-context, extended thinking, agentic tool use
(Claude Code). Built test-first (TDD), with the root cause confirmed by a failing
test rather than assumed.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work (bug fix, not a feature)
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` OR (b) described the issue in-PR — both (Fixes #1269 + description)
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] N/A — this change does not affect the UI (no screenshots needed)
- [x] No docs change needed — the fix makes the engine match its already-documented reassignment behavior
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green — will verify after push
- [x] Greptile is 5/5 — will address all comments after the automated review runs
- [x] I will address all Greptile and reviewer comments before requesting merge
