### PR TITLE
test(routines): cover execution policy repair on routine issues

### DIFF
--- a/server/src/__tests__/routines-e2e.test.ts
+++ b/server/src/__tests__/routines-e2e.test.ts
@@ -152,8 +152,9 @@ describeEmbeddedPostgres("routine routes end-to-end", () => {
   });
 
   async function createApp(actor: Record<string, unknown>) {
-    const [{ routineRoutes }, { errorHandler }] = await Promise.all([
+    const [{ routineRoutes }, { issueRoutes }, { errorHandler }] = await Promise.all([
       import("../routes/routines.js"),
+      import("../routes/issues.js"),
       import("../middleware/index.js"),
     ]);
     const app = express();
@@ -163,6 +164,7 @@ describeEmbeddedPostgres("routine routes end-to-end", () => {
       next();
     });
     app.use("/api", routineRoutes(db));
+    app.use("/api", issueRoutes(db, {} as any));
     app.use(errorHandler);
     return app;
   }
@@ -337,6 +339,132 @@ describeEmbeddedPostgres("routine routes end-to-end", () => {
         "routine.run_triggered",
       ]),
     );
+  }, 15_000);
+
+  it("repairs execution policy on a completed routine execution issue without 500s", async () => {
+    const { companyId, agentId, projectId, userId } = await seedFixture();
+    const managerAgentId = randomUUID();
+    const managerRunId = randomUUID();
+    await db.insert(agents).values({
+      id: managerAgentId,
+      companyId,
+      name: "Engineering Manager",
+      role: "engineering-manager",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    await db.insert(heartbeatRuns).values({
+      id: managerRunId,
+      companyId,
+      agentId: managerAgentId,
+      status: "running",
+      invocationSource: "manual",
+      startedAt: new Date(),
+    });
+
+    const app = await createApp({
+      type: "agent",
+      agentId: managerAgentId,
+      companyId,
+      runId: managerRunId,
+      source: "agent_jwt",
+    });
+    const boardApp = await createApp({
+      type: "board",
+      userId,
+      source: "session",
+      isInstanceAdmin: false,
+      companyIds: [companyId],
+    });
+
+    const access = accessService(db);
+    const managerMembership = await access.ensureMembership(companyId, "agent", managerAgentId, "member", "active");
+    await access.setMemberPermissions(
+      companyId,
+      managerMembership.id,
+      ["tasks:manage_active_checkouts", "issue:read", "issue:mutate"].map((permissionKey) => ({ permissionKey })),
+      userId,
+    );
+
+    const createRes = await request(boardApp)
+      .post(`/api/companies/${companyId}/routines`)
+      .send({
+        projectId,
+        title: "Policy repair routine",
+        description: "Creates a routine execution issue missing execution policy",
+        assigneeAgentId: agentId,
+        priority: "medium",
+      });
+    expect([200, 201], JSON.stringify(createRes.body)).toContain(createRes.status);
+
+    const runRes = await postRoutineRun(boardApp, createRes.body.id as string, {
+      source: "manual",
+      payload: { origin: "policy-repair-test" },
+    });
+    expect(runRes.status).toBe(202);
+    expect(runRes.body.linkedIssueId, "linkedIssueId must be present in run response").toBeTruthy();
+
+    await db
+      .update(issues)
+      .set({
+        projectId: null,
+        status: "done",
+        completedAt: new Date(),
+        executionRunId: null,
+        executionLockedAt: null,
+      })
+      .where(eq(issues.id, runRes.body.linkedIssueId));
+
+    const policyPatch = {
+      executionPolicy: {
+        mode: "normal",
+        commentRequired: true,
+        stages: [
+          {
+            type: "review",
+            approvalsNeeded: 1,
+            participants: [{ type: "agent", agentId }],
+          },
+        ],
+      },
+    };
+
+    const agentPatchRes = await request(app)
+      .patch(`/api/issues/${runRes.body.linkedIssueId}`)
+      .send(policyPatch);
+
+    expect(agentPatchRes.status, JSON.stringify(agentPatchRes.body)).toBe(403);
+    expect(agentPatchRes.body.error).toBe("Issue is outside this actor's authorization boundary");
+
+    const patchRes = await request(boardApp)
+      .patch(`/api/issues/${runRes.body.linkedIssueId}`)
+      .send(policyPatch);
+    expect(patchRes.status, JSON.stringify(patchRes.body)).toBe(200);
+    expect(patchRes.body).toMatchObject({
+      id: runRes.body.linkedIssueId,
+      originKind: "routine_execution",
+      projectId: null,
+      status: "done",
+      executionPolicy: {
+        mode: "normal",
+        commentRequired: true,
+        stages: [
+          expect.objectContaining({
+            type: "review",
+            participants: [
+              expect.objectContaining({
+                type: "agent",
+                agentId,
+              }),
+            ],
+          }),
+        ],
+      },
+    });
+    expect(patchRes.body.executionState).toBeNull();
   }, 15_000);
 
   it("runs routines with variable inputs and interpolates the execution issue description", async () => {


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Agents and managers coordinate work through issue records, including execution policies that define review stages and approvers.
> - Routine-generated issues can be created before an execution policy is attached, so managers need a supported repair path for adding one later.
> - A private deployment observed a valid execution-policy PATCH against a routine-generated issue returning an untyped HTTP 500 instead of a useful authorization result or a successful persisted repair.
> - This pull request locks the expected behavior into the routine end-to-end suite: unauthorized agent repair attempts return a typed 403, while an authorized board repair succeeds.
> - The benefit is that future changes cannot silently regress this review-policy remediation path back to an internal server error.

## Linked Issues or Issue Description

No public GitHub issue exists for this deployment-discovered bug.

### What happened

On a private Paperclip deployment, a routine-generated issue without an `executionPolicy` could not be repaired through the documented issue PATCH path. A valid `executionPolicy` payload returned HTTP 500, and a follow-up read showed the policy was still null.

### Expected behavior

PATCH `/api/issues/{id}` with a valid execution policy should either persist the policy for an authorized actor or return a typed authorization error for an unauthorized actor. It should not return an untyped HTTP 500.

### Steps to reproduce

1. Create and run a routine so it creates a linked routine-execution issue.
2. Put that linked issue into the completed routine-issue shape, including no project boundary and no execution policy.
3. Attempt to PATCH a valid review execution policy as a management agent outside the issue authorization boundary.
4. Attempt the same PATCH as an authorized board actor.

### Paperclip version or commit

Regression coverage added against commit `33c627c36` on top of `f019f54bb`.

### Deployment mode

Observed on a local Paperclip deployment using the standard API server.

## What Changed

- Wires `issueRoutes` into the routine E2E app helper so the suite can exercise issue PATCH behavior after routine execution.
- Adds a completed `routine_execution` issue fixture matching the observed repair shape, including `projectId: null` and no active execution lock.
- Verifies a non-owner management agent receives a typed 403 instead of a 500 when PATCHing `executionPolicy` outside its authorization boundary.
- Verifies an authorized board actor can PATCH and persist the review `executionPolicy` while leaving `executionState` null.
- Adds an explicit assertion that the routine run response includes `linkedIssueId` before the test mutates or patches the linked issue.

## Verification

- `pnpm vitest run server/src/__tests__/routines-e2e.test.ts --testNamePattern "repairs execution policy"` passed: 1 test passed, 4 skipped.
- Earlier full local suite for `server/src/__tests__/routines-e2e.test.ts` passed before the review assertion was added: 5 tests passed.
- GitHub CI passed on the updated commit, including Commitperclip review, build, server and workspace tests, serialized server suites, e2e, Canary Dry Run, security checks, and Greptile.

## Risks

Low risk. This is regression coverage only and does not change production route behavior. The main maintenance risk is that the fixture mirrors a specific completed routine-issue shape, so future intentional changes to routine linked-issue creation may require updating the test setup.

## Model Used

OpenAI Codex, GPT-5-based coding agent, with repository file access, shell command execution, GitHub CLI usage, and local test execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change and contains no public-facing issue title or instance URL
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

