### PR TITLE
docs: Standardize security review contract

### DIFF
--- a/doc/SECURITY-REVIEW-CONTRACT.md
+++ b/doc/SECURITY-REVIEW-CONTRACT.md
@@ -1,0 +1,91 @@
+# Security Review Contract
+
+Security review tasks need enough context for a reviewer to name concrete risks,
+show evidence, and unblock shipping without re-discovering the whole change. Use
+this contract whenever creating or completing a security-review task.
+
+This contract is for review tasks. It is distinct from the Git handoff block used
+when GitExpert opens or updates a pull request.
+
+## When To Request Review
+
+Create a security-review task before merge for changes that touch any of these
+areas:
+
+- Authentication, sessions, tokens, API keys, OAuth/OIDC, or identity providers
+- Authorization, company scoping, permission grants, roles, or access control
+- Secrets, encryption, signing, key storage, credential handling, or redaction
+- Agent adapter execution, tool permissions, shell/database/eval inputs, or sandboxing
+- Public endpoints, web security headers, CORS, CSRF, SSRF, uploads, or redirects
+- Dependency or plugin loading, remote code/content ingestion, install scripts, or supply chain
+- Analytics, logging, audit trails, billing events, telemetry, or any PII-bearing pipeline
+- Production deployment, infrastructure, IAM, networking, or incident-response changes
+
+If the change includes an active private advisory or unpatched production
+vulnerability, do not put exploit details in the normal task thread. Use the
+private advisory workflow or escalate to CTO for confidential handling.
+
+## Review Packet
+
+The requester must include this packet in the security-review task description
+or first comment.
+
+```md
+## Security Review Packet
+
+- Review mode: design review | code review | release gate | incident follow-up
+- Requested by: <agent/user and source issue link>
+- Change under review: <PR, branch, issue, design doc, or commit range>
+- Security-sensitive areas: <auth/authz/secrets/agent tools/data pipeline/etc.>
+- Intended behavior: <what should become possible>
+- Trust boundaries: <actors, credentials, companies/tenants, external systems>
+- Data handled: <secrets, PII, customer data, logs, artifacts, none>
+- Abuse cases to check: <specific attacker goals or "requester unsure">
+- Verification already run: <tests, manual checks, scanners, none>
+- Known constraints: <deadlines, rollout plan, compatibility limits>
+- Evidence pointers: <files, routes, docs, screenshots, redacted logs>
+```
+
+Minimum acceptable packets name the change under review, the security-sensitive
+areas, the trust boundaries, and the data handled. If any field is unknown, write
+`unknown` and explain what would be needed to answer it.
+
+## Finding Block
+
+SecurityEngineer must use this block for every substantive review result. If the
+review finds no issues, emit one "No blocking findings" block with the same
+evidence, verification, residual-risk, and follow-up fields.
+
+```md
+## Security Review Finding
+
+- Verdict: block | approve with conditions | approve | no blocking findings
+- Vulnerability class: <OWASP/API/LLM class or "none found">
+- Severity: critical | high | medium | low | informational
+- Exploitability: confirmed | likely | plausible | theoretical | not applicable
+- Evidence: <file/line, route, request shape, design path, or negative-test result>
+- Attack path: <what an attacker does and required prerequisites>
+- Blast radius: <whose data/capability is exposed and whether it can pivot>
+- Required fix: <specific code/design/process change, or "none">
+- Tests or verification required: <regression test, manual step, scanner, none>
+- Residual risk: <what remains after the fix or why risk is accepted>
+- Follow-ups: <separate tickets needed, owner, or "none">
+```
+
+Keep proof-of-concept payloads redacted when they contain secrets, customer data,
+or unpatched exploit details. Name the vulnerability class and the affected
+surface clearly enough that the implementer can fix the class, not just one
+instance.
+
+## Completion Rules
+
+- `block`: leave the reviewed task or PR gate unresolved and assign the fix to
+  the implementer or owner with a concrete remediation spec.
+- `approve with conditions`: only use when the remaining work is bounded,
+  separately owned, and not needed before merge.
+- `approve`: state the evidence reviewed and the verification run.
+- `no blocking findings`: still state scope and residual risk so the review is
+  auditable later.
+
+Every remediation for a concrete vulnerability should include or request a
+regression test that would fail before the fix.

--- a/packages/teams-catalog/catalog/bundled/software-development/product-engineering/agents/cto/AGENTS.md
+++ b/packages/teams-catalog/catalog/bundled/software-development/product-engineering/agents/cto/AGENTS.md
@@ -31,4 +31,4 @@ When you wake up, follow the Paperclip skill — it contains the full heartbeat 
 ## Safety
 
 - Never commit secrets, credentials, or customer data. If you spot any in a diff, stop and escalate.
-- Auth, crypto, secrets, or permissions changes require a security review before merge — route to a security reviewer or escalate to your manager if none exists.
+- Auth, crypto, secrets, permissions, public endpoints, plugins/supply chain, agent tools, or PII-bearing logging/analytics changes require a security review before merge. Create the review task with the Security Review Packet from `doc/SECURITY-REVIEW-CONTRACT.md`, or escalate to your manager if no security reviewer exists.

--- a/packages/teams-catalog/catalog/bundled/software-development/product-engineering/agents/senior-coder/AGENTS.md
+++ b/packages/teams-catalog/catalog/bundled/software-development/product-engineering/agents/senior-coder/AGENTS.md
@@ -32,4 +32,4 @@ When you wake up, follow the Paperclip skill — it contains the full heartbeat 
 
 - Never commit secrets, credentials, or customer data.
 - Do not skip pre-commit hooks, signing, or CI without an explicit board approval.
-- Auth, crypto, secrets, permissions, public endpoints, plugins/supply chain, agent tools, or PII-bearing logging/analytics changes require a security review before merge. Create the review task with the Security Review Packet from `doc/SECURITY-REVIEW-CONTRACT.md`.
+- Auth, crypto, secrets, permissions, public endpoints, plugins/supply chain, agent tools, or PII-bearing logging/analytics changes require a security review before merge. Create the review task with the Security Review Packet from `doc/SECURITY-REVIEW-CONTRACT.md`, or escalate to your manager if no security reviewer exists.

--- a/packages/teams-catalog/catalog/bundled/software-development/product-engineering/agents/senior-coder/AGENTS.md
+++ b/packages/teams-catalog/catalog/bundled/software-development/product-engineering/agents/senior-coder/AGENTS.md
@@ -32,4 +32,4 @@ When you wake up, follow the Paperclip skill — it contains the full heartbeat 
 
 - Never commit secrets, credentials, or customer data.
 - Do not skip pre-commit hooks, signing, or CI without an explicit board approval.
-- Auth, crypto, secrets, or permissions changes require a security review before merge.
+- Auth, crypto, secrets, permissions, public endpoints, plugins/supply chain, agent tools, or PII-bearing logging/analytics changes require a security review before merge. Create the review task with the Security Review Packet from `doc/SECURITY-REVIEW-CONTRACT.md`.

--- a/packages/teams-catalog/generated/catalog.json
+++ b/packages/teams-catalog/generated/catalog.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "packageName": "@paperclipai/teams-catalog",
   "packageVersion": "0.1.0",
-  "generatedAt": "2026-06-04T18:03:41.262Z",
+  "generatedAt": "2026-06-30T14:50:45.550Z",
   "teams": [
     {
       "id": "paperclipai:bundled:company-defaults:core-exec-team",
@@ -343,8 +343,8 @@
         {
           "path": "agents/cto/AGENTS.md",
           "kind": "agent",
-          "sizeBytes": 1499,
-          "sha256": "0a1a73ec9e5008056bca0a26325131ded2fcf4c4680a5014ba1e13400b32c173"
+          "sizeBytes": 1662,
+          "sha256": "e5989a5a49d5728a7c1493224da85eb9678522fb36d44309bdcf6f557493144b"
         },
         {
           "path": "agents/qa/AGENTS.md",
@@ -355,8 +355,8 @@
         {
           "path": "agents/senior-coder/AGENTS.md",
           "kind": "agent",
-          "sizeBytes": 1413,
-          "sha256": "b61071518755d9e584c099ae2082c7a78448d09586093ee91393082fe10872b5"
+          "sizeBytes": 1592,
+          "sha256": "003d4e834afa6c2a7b0f80f8df5422e75bffa80733da1ceab1e3ada575ffd0b8"
         },
         {
           "path": "projects/product-engineering/PROJECT.md",
@@ -373,7 +373,7 @@
       ],
       "trustLevel": "assets",
       "compatibility": "compatible",
-      "contentHash": "sha256:74ddeaeb11805835a4a67fc4530b048ab7f8aa1dc7d2b80acea139a933d158d3"
+      "contentHash": "sha256:69183456e07b5396799975046ab8aa9da386870bce6d96a12fc20ed8b4df3cb7"
     },
     {
       "id": "paperclipai:optional:content:content-machine",

--- a/packages/teams-catalog/generated/catalog.json
+++ b/packages/teams-catalog/generated/catalog.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "packageName": "@paperclipai/teams-catalog",
   "packageVersion": "0.1.0",
-  "generatedAt": "2026-06-30T14:50:45.550Z",
+  "generatedAt": "2026-06-30T15:00:59.165Z",
   "teams": [
     {
       "id": "paperclipai:bundled:company-defaults:core-exec-team",
@@ -355,8 +355,8 @@
         {
           "path": "agents/senior-coder/AGENTS.md",
           "kind": "agent",
-          "sizeBytes": 1592,
-          "sha256": "003d4e834afa6c2a7b0f80f8df5422e75bffa80733da1ceab1e3ada575ffd0b8"
+          "sizeBytes": 1652,
+          "sha256": "926276d56eb17689e2903ef2cec278df0327fa27a480deaa9e5e6c28a501320c"
         },
         {
           "path": "projects/product-engineering/PROJECT.md",
@@ -373,7 +373,7 @@
       ],
       "trustLevel": "assets",
       "compatibility": "compatible",
-      "contentHash": "sha256:69183456e07b5396799975046ab8aa9da386870bce6d96a12fc20ed8b4df3cb7"
+      "contentHash": "sha256:44105a9dafc21eb48df74829b56e57a0d59ad2f16cb83c140bfa47c2e3fb2cdf"
     },
     {
       "id": "paperclipai:optional:content:content-machine",

--- a/skills/paperclip-create-agent/references/agents/coder.md
+++ b/skills/paperclip-create-agent/references/agents/coder.md
@@ -50,7 +50,7 @@ When you run tests, do not default to the entire test suite. Run the minimal che
 ## Collaboration and handoffs
 
 - UX-facing changes → loop in `[UXDesigner](/{{issuePrefix}}/agents/uxdesigner)` for review of visual quality and flows.
-- Security-sensitive changes (auth, crypto, secrets, permissions, adapter/tool access, public endpoints, plugins/supply chain, agent tools, or PII-bearing logging/analytics) → create a security-review task for `[SecurityEngineer](/{{issuePrefix}}/agents/securityengineer)` before merging and include the Security Review Packet from `doc/SECURITY-REVIEW-CONTRACT.md`.
+- Security-sensitive changes (auth, crypto, secrets, permissions, adapter/tool access, public endpoints, plugins/supply chain, agent tools, or PII-bearing logging/analytics) → create a security-review task for `[SecurityEngineer](/{{issuePrefix}}/agents/securityengineer)` before merging and include the Security Review Packet from `doc/SECURITY-REVIEW-CONTRACT.md`, or escalate to your manager if no security reviewer exists.
 - Browser validation / user-facing verification → hand to `[QA](/{{issuePrefix}}/agents/qa)` with a reproducible test plan.
 - Skill or instruction quality changes → hand to the skill consultant or equivalent instruction owner.
 

--- a/skills/paperclip-create-agent/references/agents/coder.md
+++ b/skills/paperclip-create-agent/references/agents/coder.md
@@ -50,7 +50,7 @@ When you run tests, do not default to the entire test suite. Run the minimal che
 ## Collaboration and handoffs
 
 - UX-facing changes → loop in `[UXDesigner](/{{issuePrefix}}/agents/uxdesigner)` for review of visual quality and flows.
-- Security-sensitive changes (auth, crypto, secrets, permissions, adapter/tool access) → loop in `[SecurityEngineer](/{{issuePrefix}}/agents/securityengineer)` before merging.
+- Security-sensitive changes (auth, crypto, secrets, permissions, adapter/tool access, public endpoints, plugins/supply chain, agent tools, or PII-bearing logging/analytics) → create a security-review task for `[SecurityEngineer](/{{issuePrefix}}/agents/securityengineer)` before merging and include the Security Review Packet from `doc/SECURITY-REVIEW-CONTRACT.md`.
 - Browser validation / user-facing verification → hand to `[QA](/{{issuePrefix}}/agents/qa)` with a reproducible test plan.
 - Skill or instruction quality changes → hand to the skill consultant or equivalent instruction owner.
 

--- a/skills/paperclip-create-agent/references/agents/securityengineer.md
+++ b/skills/paperclip-create-agent/references/agents/securityengineer.md
@@ -44,6 +44,7 @@ If you receive a private security-advisory URL and the company has installed a d
 
 - **Scope.** Work only on tasks assigned to you or handed off in a comment.
 - **Always comment.** Every task touch gets a comment — never update status silently. Include the vulnerability class, evidence, fix, residual risk, and any follow-ups that need separate tickets.
+- **Review contract.** For security-review tasks, require the packet and emit findings using the standardized blocks in `doc/SECURITY-REVIEW-CONTRACT.md`. If the packet is incomplete, fill what you can from the linked code/design and then state the remaining gap in the finding block instead of doing a vague review.
 - **Escalate production risk immediately.** If you find something actively exploitable in production, comment on the ticket, assign {{managerTitle}}, and state the blast radius in the first line. Do not wait for your next heartbeat.
 - **Keep work moving.** Do not let tickets sit. Need QA? Assign QA with the specific test cases. Need {{managerTitle}} review? Assign them with a clear ask. Blocked? Reassign to the unblocker with exactly what you need.
 - **Disclosure discipline.** Do not discuss unpatched vulnerabilities outside the ticket or advisory thread. No screenshots in public channels. No PoCs in public repos.
@@ -93,6 +94,7 @@ Apply these when reviewing or designing systems. Cite by name in comments so rea
 
 A "looks fine" review is not a review. Concrete findings only.
 
+- **Use the standard finding block** from `doc/SECURITY-REVIEW-CONTRACT.md` for every substantive review result, including "no blocking findings."
 - **Name the vulnerability class** (for example, "IDOR on `GET /companies/:id/agents`", not "authorization issue").
 - **Show the attack.** Proof-of-concept request, payload, or code path. If you cannot demonstrate it, say so and explain why you still believe it is exploitable.
 - **State blast radius.** What does an attacker get? Whose data? What privilege level? Can it pivot?


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Security reviews are part of the engineering control plane when changes touch auth, permissions, secrets, agent tools, public endpoints, supply chain, or PII-bearing data flows.
> - The current agent instructions say to request or perform security review, but they do not give requesters a standard packet or reviewers a standard finding block.
> - That gap makes reviews slower and less auditable because SecurityEngineer has to rediscover scope and different reviews can report findings in different shapes.
> - This pull request adds a small canonical review-task contract and wires requester/reviewer instructions to use it.
> - The benefit is faster, more concrete security reviews with consistent evidence, fixes, residual risk, and follow-up tracking.

## Linked Issues or Issue Description

No public GitHub issue exists. This is a documentation/instruction improvement: define a repeatable security-review task packet and finding block so security-sensitive engineering work reaches SecurityEngineer with enough context and receives auditable review output.

## What Changed

- Added `doc/SECURITY-REVIEW-CONTRACT.md` with request packet fields, finding block fields, and completion rules.
- Updated the SecurityEngineer agent template to require the packet and use the finding block, including for no-finding reviews.
- Updated Coder and bundled product-engineering CTO/Senior Coder instructions to create review tasks with the packet for security-sensitive changes.
- Regenerated the teams catalog manifest for the shipped instruction changes.

## Verification

- [x] `pnpm --filter @paperclipai/teams-catalog test`
- [x] `pnpm --filter @paperclipai/teams-catalog validate`
- [x] `git diff --check`

## Risks

Low risk. This changes documentation and agent instructions only. The main behavioral risk is that review requesters may treat the packet as heavier than intended; the contract keeps minimum acceptable fields explicit and allows `unknown` with explanation.

## Model Used

OpenAI GPT-5 Codex, tool-using coding agent in this Paperclip workspace.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge