### PR TITLE
fix(cursor-local): fail silent 0-token exits as cursor_empty_execution

### DIFF
--- a/packages/adapters/cursor-local/src/server/execute.ts
+++ b/packages/adapters/cursor-local/src/server/execute.ts
@@ -45,7 +45,7 @@ import {
   joinPromptSections,
 } from "@paperclipai/adapter-utils/server-utils";
 import { DEFAULT_CURSOR_LOCAL_MODEL, SANDBOX_INSTALL_COMMAND } from "../index.js";
-import { parseCursorJsonl, isCursorUnknownSessionError } from "./parse.js";
+import { parseCursorJsonl, isCursorUnknownSessionError, isCursorEmptySuccessfulExecution } from "./parse.js";
 import { prepareCursorSandboxCommand } from "./remote-command.js";
 import { normalizeCursorStreamLine } from "../shared/stream.js";
 import { hasCursorTrustBypassArg } from "../shared/trust.js";
@@ -700,6 +700,38 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       parsedError ||
       stderrLine ||
       `Cursor exited with code ${attempt.proc.exitCode ?? -1}`;
+
+    // Policy refusals and silent CLI exits can return exitCode=0 with no tokens;
+    // treat those as adapter failures so recovery does not cascade on fake success.
+    if (isCursorEmptySuccessfulExecution({
+      exitCode: attempt.proc.exitCode,
+      errorMessage: parsedError,
+      usage: attempt.parsed.usage,
+      summary: attempt.parsed.summary,
+    })) {
+      return {
+        exitCode: 1,
+        signal: attempt.proc.signal,
+        timedOut: false,
+        errorMessage: "Cursor exited without invoking the LLM (0 tokens and no assistant output)",
+        errorCode: "cursor_empty_execution",
+        usage: attempt.parsed.usage,
+        sessionId: resolvedSessionId,
+        sessionParams: resolvedSessionParams,
+        sessionDisplayId: resolvedSessionId,
+        provider: providerFromModel,
+        biller: resolveCursorBiller(effectiveEnv, billingType, providerFromModel),
+        model,
+        billingType,
+        costUsd: attempt.parsed.costUsd,
+        resultJson: {
+          stdout: attempt.proc.stdout,
+          stderr: attempt.proc.stderr,
+        },
+        summary: attempt.parsed.summary,
+        clearSession: Boolean(clearSessionOnMissingSession && !resolvedSessionId),
+      };
+    }
 
     return {
       exitCode: attempt.proc.exitCode,

--- a/packages/adapters/cursor-local/src/server/index.ts
+++ b/packages/adapters/cursor-local/src/server/index.ts
@@ -1,7 +1,7 @@
 export { execute, ensureCursorSkillsInjected } from "./execute.js";
 export { listCursorSkills, syncCursorSkills } from "./skills.js";
 export { testEnvironment } from "./test.js";
-export { parseCursorJsonl, isCursorUnknownSessionError } from "./parse.js";
+export { parseCursorJsonl, isCursorUnknownSessionError, isCursorEmptySuccessfulExecution } from "./parse.js";
 import type { AdapterSessionCodec } from "@paperclipai/adapter-utils";
 
 function readNonEmptyString(value: unknown): string | null {

--- a/packages/adapters/cursor-local/src/server/parse.ts
+++ b/packages/adapters/cursor-local/src/server/parse.ts
@@ -149,6 +149,24 @@ export function parseCursorJsonl(stdout: string) {
   };
 }
 
+export function isCursorEmptySuccessfulExecution(input: {
+  exitCode: number | null | undefined;
+  errorMessage?: string | null;
+  usage?: { inputTokens?: number; cachedInputTokens?: number; outputTokens?: number } | null;
+  summary?: string | null;
+}): boolean {
+  const parsedError = typeof input.errorMessage === "string" ? input.errorMessage.trim() : "";
+  if ((input.exitCode ?? 0) !== 0 || parsedError) return false;
+
+  const usage = input.usage ?? {};
+  const hasTokenUsage =
+    (usage.inputTokens ?? 0) > 0 ||
+    (usage.cachedInputTokens ?? 0) > 0 ||
+    (usage.outputTokens ?? 0) > 0;
+  const hasAssistantOutput = (input.summary ?? "").trim().length > 0;
+  return !hasTokenUsage && !hasAssistantOutput;
+}
+
 export function isCursorUnknownSessionError(stdout: string, stderr: string): boolean {
   const haystack = `${stdout}\n${stderr}`
     .split(/\r?\n/)

--- a/server/src/__tests__/cursor-local-adapter.test.ts
+++ b/server/src/__tests__/cursor-local-adapter.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { isCursorUnknownSessionError, parseCursorJsonl } from "@paperclipai/adapter-cursor-local/server";
+import { isCursorUnknownSessionError, isCursorEmptySuccessfulExecution, parseCursorJsonl } from "@paperclipai/adapter-cursor-local/server";
 import { parseCursorStdoutLine } from "@paperclipai/adapter-cursor-local/ui";
 import { printCursorStreamEvent } from "@paperclipai/adapter-cursor-local/cli";
 
@@ -56,6 +56,35 @@ describe("cursor parser", () => {
       outputTokens: 2,
     });
     expect(parsed.costUsd).toBeCloseTo(0.0001, 6);
+  });
+});
+
+describe("cursor empty successful execution detection", () => {
+  it("flags clean exits with no tokens and no assistant output", () => {
+    const stdout = JSON.stringify({ type: "system", subtype: "init", session_id: "chat_silent", model: "auto" });
+    const parsed = parseCursorJsonl(stdout);
+    expect(isCursorEmptySuccessfulExecution({
+      exitCode: 0,
+      errorMessage: parsed.errorMessage,
+      usage: parsed.usage,
+      summary: parsed.summary,
+    })).toBe(true);
+  });
+
+  it("allows clean exits with assistant output even when token usage is missing", () => {
+    expect(isCursorEmptySuccessfulExecution({
+      exitCode: 0,
+      usage: { inputTokens: 0, cachedInputTokens: 0, outputTokens: 0 },
+      summary: "done",
+    })).toBe(false);
+  });
+
+  it("allows clean exits with token usage", () => {
+    expect(isCursorEmptySuccessfulExecution({
+      exitCode: 0,
+      usage: { inputTokens: 1, cachedInputTokens: 0, outputTokens: 0 },
+      summary: "",
+    })).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary

Cursor CLI can exit 0 with only a system init line and no LLM usage.
Treat that as an adapter failure so Paperclip does not mark the run succeeded and trigger recovery/handoff cascades on scoped wakes (e.g. Pi Tester wakes).

- Adds `cursor_empty_execution` guard in `execute.ts`
- Updates `parse.ts` to detect 0-token silent exits
- Adds regression test in `cursor-local-adapter.test.ts`
- All 12 tests pass

Refs: internal SAT-6263
Co-Authored-By: Paperclip <noreply@paperclip.ing>