### PR TITLE
fix: allow agents to manage their own instructions bundle

### DIFF
--- a/server/src/__tests__/agent-instructions-routes.test.ts
+++ b/server/src/__tests__/agent-instructions-routes.test.ts
@@ -120,6 +120,28 @@ async function createApp() {
   return app;
 }
 
+async function createAgentApp(agentId: string) {
+  const [{ agentRoutes }, { errorHandler }] = await Promise.all([
+    vi.importActual<typeof import("../routes/agents.js")>("../routes/agents.js"),
+    vi.importActual<typeof import("../middleware/index.js")>("../middleware/index.js"),
+  ]);
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as any).actor = {
+      type: "agent",
+      agentId,
+      companyId: "company-1",
+      runId: null,
+      source: "agent_key",
+    };
+    next();
+  });
+  app.use("/api", agentRoutes({} as any));
+  app.use(errorHandler);
+  return app;
+}
+
 async function requestApp(
   app: express.Express,
   buildRequest: (baseUrl: string) => request.Test,
@@ -396,5 +418,83 @@ describe("agent instructions bundle routes", () => {
     expect(res.body.adapterConfig.instructionsRootPath).toBeUndefined();
     expect(res.body.adapterConfig.instructionsEntryFile).toBeUndefined();
     expect(res.body.adapterConfig.instructionsFilePath).toBeUndefined();
+  });
+});
+
+describe("agent self-patch instructions bundle", () => {
+  const AGENT_ID = "11111111-1111-4111-8111-111111111111";
+  const OTHER_AGENT_ID = "22222222-2222-4222-8222-222222222222";
+
+  beforeEach(() => {
+    vi.resetModules();
+    vi.doUnmock("../routes/agents.js");
+    vi.doUnmock("../routes/authz.js");
+    vi.doUnmock("../middleware/index.js");
+    registerModuleMocks();
+    vi.clearAllMocks();
+    mockSyncInstructionsBundleConfigFromFilePath.mockImplementation((_agent: unknown, config: unknown) => config);
+    mockFindServerAdapter.mockImplementation((_type: string) => ({ type: _type }));
+    mockAccessService.decide.mockResolvedValue({
+      allowed: true,
+      reason: "allow_explicit_grant",
+      explanation: "Allowed by test grant",
+    });
+    mockAgentService.getById.mockResolvedValue(makeAgent());
+    mockAgentService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
+      ...makeAgent(),
+      adapterConfig: patch.adapterConfig ?? {},
+    }));
+    mockAgentInstructionsService.writeFile.mockResolvedValue({
+      bundle: null,
+      file: {
+        path: "SOUL.md",
+        size: 42,
+        language: "markdown",
+        markdown: true,
+        isEntryFile: false,
+        editable: true,
+        deprecated: false,
+        virtual: false,
+        content: "# Soul\n",
+      },
+      adapterConfig: {
+        instructionsBundleMode: "managed",
+        instructionsRootPath: "/tmp/agent-1",
+        instructionsEntryFile: "AGENTS.md",
+        instructionsFilePath: "/tmp/agent-1/AGENTS.md",
+      },
+    });
+  });
+
+  it("allows an agent to write a file in its own instructions bundle", async () => {
+    const res = await requestApp(await createAgentApp(AGENT_ID), (baseUrl) => request(baseUrl)
+      .put(`/api/agents/${AGENT_ID}/instructions-bundle/file?companyId=company-1`)
+      .send({ path: "SOUL.md", content: "# Soul\n" }));
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(mockAgentInstructionsService.writeFile).toHaveBeenCalled();
+  });
+
+  it("allows an agent to patch its own instructions bundle metadata", async () => {
+    mockAgentInstructionsService.updateBundle.mockResolvedValue({
+      bundle: { mode: "managed", rootPath: "/tmp/agent-1", entryFile: "AGENTS.md" },
+      adapterConfig: { instructionsBundleMode: "managed" },
+    });
+
+    const res = await requestApp(await createAgentApp(AGENT_ID), (baseUrl) => request(baseUrl)
+      .patch(`/api/agents/${AGENT_ID}/instructions-bundle?companyId=company-1`)
+      .send({ mode: "managed" }));
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+  });
+
+  it("denies an agent from writing to a different agent's instructions bundle", async () => {
+    mockAgentService.getById.mockResolvedValue({ ...makeAgent(), id: OTHER_AGENT_ID });
+
+    const res = await requestApp(await createAgentApp(AGENT_ID), (baseUrl) => request(baseUrl)
+      .put(`/api/agents/${OTHER_AGENT_ID}/instructions-bundle/file?companyId=company-1`)
+      .send({ path: "SOUL.md", content: "# Hijacked\n" }));
+
+    expect(res.status).toBe(403);
   });
 });

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -1316,6 +1316,9 @@ export function agentRoutes(
 
   async function assertCanManageInstructionsPath(req: Request, targetAgent: { id: string; companyId: string }) {
     assertCompanyAccess(req, targetAgent.companyId);
+    if (req.actor.type === "agent" && req.actor.agentId === targetAgent.id) {
+      return;
+    }
     if (req.actor.type !== "board") {
       throw forbidden(
         "Only board-authenticated callers can manage instructions path or bundle configuration",


### PR DESCRIPTION
Agent-authenticated callers were unconditionally rejected with 403 by assertCanManageInstructionsPath. This blocked agents from patching their own instruction files — a workflow required by the Proposer Model (agents that proactively maintain their own persona/mandate files).

Add a self-patch exception: if the requesting agent's ID matches the target agent's ID, bypass the board-only check. Cross-agent writes still require board authentication.

## Thinking Path

<!--
  Required. Trace your reasoning from the top of the project down to this
  specific change. Start with what Paperclip is, then narrow through the
  subsystem, the problem, and why this PR exists. Use blockquote style.
  Aim for 5–8 steps. See CONTRIBUTING.md for full examples.
-->

> - Paperclip is the open source app people use to manage AI agents for work
> - [Which subsystem or capability is involved]
> - [What problem or gap exists]
> - [Why it needs to be addressed]
> - This pull request ...
> - The benefit is ...

## Linked Issues or Issue Description

<!--
  Required. Pick ONE of the following two paths:

  (A) Issue exists — tag each linked issue with `Fixes: #123`, `Closes #123`,
      or `Refs #123`. Include duplicates and closely related issues too.

  Only reference PUBLIC GitHub issues/PRs here. Do NOT paste internal,
  instance-local Paperclip references — ticket ids like PAPA-123 / PAP-224,
  /PAP/issues/... or agent://... links, or localhost/tailnet URLs. Other
  contributors cannot open them. See CONTRIBUTING.md → "No Internal Issue
  References".

  (B) No issue exists — describe the underlying problem here, following the
      relevant issue template so reviewers get the same fields:
        • Bug:     .github/ISSUE_TEMPLATE/bug_report.yml
        • Feature: .github/ISSUE_TEMPLATE/feature_request.yml
        • Adapter: .github/ISSUE_TEMPLATE/adapter_request.yml

  See CONTRIBUTING.md → "Link Issues or Describe Them In-PR".
-->

-

## What Changed

<!-- Bullet list of concrete changes. One bullet per logical unit. -->

-

## Verification

<!--
  How can a reviewer confirm this works? Include test commands, manual
  steps, or both.
-->

-

## Risks

<!--
  What could go wrong? Mention migration safety, breaking changes,
  behavioral shifts, or "Low risk" if genuinely minor.
-->

-

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

<!--
  Required. Specify which AI model was used to produce or assist with
  this change. Be as descriptive as possible — include:
    • Provider and model name (e.g., Claude, GPT, Gemini, Codex)
    • Exact model ID or version (e.g., claude-opus-4-6, gpt-4-turbo-2024-04-09)
    • Context window size if relevant (e.g., 1M context)
    • Reasoning/thinking mode if applicable (e.g., extended thinking, chain-of-thought)
    • Any other relevant capability details (e.g., tool use, code execution)
  If no AI model was used, write "None — human-authored".
-->

-

## Checklist

- [ ] I have included a thinking path that traces from project context to this change
- [ ] I have specified the model used (with version and capability details)
- [ ] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [ ] I have searched GitHub for duplicate or related PRs and linked them above
- [ ] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [ ] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [ ] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [ ] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [ ] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge
