### PR TITLE
fix: preservar adapterConfig.model no GET restrito do agente (DAN-267)

### DIFF
--- a/server/src/__tests__/agent-permissions-routes.test.ts
+++ b/server/src/__tests__/agent-permissions-routes.test.ts
@@ -405,8 +405,33 @@ describe.sequential("agent permission routes", () => {
     mockLogActivity.mockResolvedValue(undefined);
   });
 
-  it("redacts agent detail for authenticated company members without agent admin permission", async () => {
-    mockAccessService.canUser.mockResolvedValue(false);
+  it("redacts peer agent detail while preserving model for agent-authenticated members without agent admin permission", async () => {
+    const peerAgentId = "33333333-3333-4333-8333-333333333333";
+    mockAgentService.getById.mockImplementation(async (id: string) => {
+      if (id === peerAgentId) {
+        return {
+          ...baseAgent,
+          id: peerAgentId,
+          name: "PM",
+          adapterType: "codex_local",
+          adapterConfig: {
+            model: "gpt-5.4",
+            instructionsFilePath: "/tmp/agent/AGENTS.md",
+            env: { PAPERCLIP_API_KEY: "secret-test-key" },
+          },
+          runtimeConfig: {
+            heartbeat: { enabled: true },
+          },
+        };
+      }
+      return {
+        ...baseAgent,
+        id: "reader-agent",
+        name: "QA",
+        permissions: { canCreateAgents: false },
+      };
+    });
+    mockAccessService.hasPermission.mockResolvedValue(false);
     mockAccessService.decide.mockImplementation(async (input: { action?: string }) => ({
       allowed: input.action === "agent:read",
       reason: input.action === "agent:read" ? "allow_test_read" : "deny_missing_grant",
@@ -414,17 +439,17 @@ describe.sequential("agent permission routes", () => {
     }));
 
     const app = await createApp({
-      type: "board",
-      userId: "member-user",
-      source: "session",
-      isInstanceAdmin: false,
-      companyIds: [companyId],
+      type: "agent",
+      agentId: "reader-agent",
+      companyId,
+      source: "agent_key",
+      runId: "run-1",
     });
 
-    const res = await requestApp(app, (baseUrl) => request(baseUrl).get(`/api/agents/${agentId}`));
+    const res = await requestApp(app, (baseUrl) => request(baseUrl).get(`/api/agents/${peerAgentId}`));
 
     expect(res.status).toBe(200);
-    expect(res.body.adapterConfig).toEqual({});
+    expect(res.body.adapterConfig).toEqual({ model: "gpt-5.4" });
     expect(res.body.runtimeConfig).toEqual({});
   }, 20_000);
 

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -1485,9 +1485,17 @@ export function agentRoutes(
 
   function redactForRestrictedAgentView(agent: Awaited<ReturnType<typeof svc.getById>>) {
     if (!agent) return null;
+    const adapterConfig =
+      agent.adapterConfig && typeof agent.adapterConfig === "object" && !Array.isArray(agent.adapterConfig)
+        ? (agent.adapterConfig as Record<string, unknown>)
+        : {};
+    const restrictedAdapterConfig =
+      typeof adapterConfig.model === "string" && adapterConfig.model.trim().length > 0
+        ? { model: adapterConfig.model }
+        : {};
     return {
       ...agent,
-      adapterConfig: {},
+      adapterConfig: restrictedAdapterConfig,
       runtimeConfig: {},
     };
   }


### PR DESCRIPTION
## Thinking Path

> - Paperclip is a control plane for AI-agent companies, so agent detail routes are part of the operator surface that has to balance visibility with configuration redaction.
> - The affected subsystem is the server-side `GET /api/agents/:id` serializer used when an authenticated actor reads another agent record.
> - In the restricted path, `redactForRestrictedAgentView(...)` cleared `adapterConfig` completely.
> - That blanket redaction hid `adapterConfig.model`, which is the one field downstream operational checks still need to see to validate effective model selection.
> - The fix should stay narrow: preserve only `adapterConfig.model` when it is a non-empty string, while continuing to redact all other adapter config keys and all runtime config.
> - This pull request implements that restricted serialization exception and adds an agent-authenticated route test that proves peer-agent reads keep only the model field.
> - The benefit is that operational validation can observe the effective model without reopening broader configuration disclosure.

## Linked Issues or Issue Description

### Pre-submission checklist

- [x] I have searched existing open and closed issues and this is not a duplicate.
- [x] I am on the latest released version of Paperclip (or can reproduce on `master`).
- [x] I have confirmed the error originates in Paperclip itself, specifically the restricted agent-detail serializer.

### What happened?

When an authenticated agent without admin-level configuration access called `GET /api/agents/:id` for a peer agent, the restricted response path returned `adapterConfig: {}` even when the target agent had an explicit `adapterConfig.model`.

### Expected behavior

The restricted response should preserve `adapterConfig.model` when it is present, while still redacting every other adapter configuration field and all runtime configuration.

### Steps to reproduce

1. Create or load an agent with a non-empty `adapterConfig.model`.
2. Authenticate as a different agent in the same company that has read access to agents but not agent-admin configuration access.
3. Call `GET /api/agents/:id` for the target agent and inspect the restricted payload.
4. Before this patch, `adapterConfig` is empty. After this patch, it returns only `{ "model": "..." }`.

### Paperclip version or commit

- Reproduced against `master` before this patch.
- Fixed in commit `41fce788b16f6932432c50369acfd51774803b67` in this PR branch.

### Deployment mode

- Local dev / built from source for verification.

### Installation method

- Built from source (`pnpm` workspace).

### Agent adapter(s) involved

- [x] Codex
- [x] Not adapter-specific (core bug)

### Database mode

- Not database-related.

### Access context

- Agent (bearer API key via `agent_api_keys`).

### Node.js version

- Verified in the project local toolchain used by CI/local test run.

### Operating system

- Ubuntu (CI/local Linux environment).

### Relevant logs or output

```text
Expected restricted response after fix:
adapterConfig = { model: "gpt-5.4" }
runtimeConfig = {}
```

### Relevant config (if applicable)

```json
{
  "adapterConfig": {
    "model": "gpt-5.4"
  }
}
```

### Additional context

- This is intentionally narrow: it exposes only the model identifier needed for operational validation and continues to redact all other adapter/runtime config details.

### Privacy checklist

- [x] I have reviewed all pasted output for PII and redacted where needed.

## What Changed

- preserved only `adapterConfig.model` in the restricted agent-detail serializer when the value is a non-empty string
- kept all other adapter config fields redacted in that restricted response path
- kept `runtimeConfig` fully redacted in the restricted response path
- replaced the existing route test with an agent-authenticated peer-read scenario that verifies only `{ model: "gpt-5.4" }` survives redaction

## Verification

- `pnpm exec vitest run server/src/__tests__/agent-permissions-routes.test.ts -t "redacts peer agent detail while preserving model for agent-authenticated members without agent admin permission"`

## Risks

- Low risk. The change is isolated to the restricted serialization branch for agent detail reads.
- The only behavioral expansion is exposing one already non-secret operational field, `adapterConfig.model`, while all other adapter config keys remain redacted.

> Checked `ROADMAP.md`; this is a bug fix in existing API behavior, not overlapping planned feature work.

## Model Used

- OpenAI Codex, GPT-5-class coding agent in Codex CLI with shell/tool execution for code inspection, patch preparation, and verification.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
