### PR TITLE
fix(recovery): suppress continuation for scheduled monitors

### DIFF
--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -1240,6 +1240,41 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(issue?.checkoutRunId).toBeNull();
   });
 
+  it("does not immediately re-enqueue continuation for a column-only future scheduled monitor", async () => {
+    const monitorNextCheckAt = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000);
+    const { agentId, runId, issueId } = await seedRunFixture({
+      agentStatus: "idle",
+      processPid: 999_999_999,
+      processLossRetryCount: 1,
+      monitorNextCheckAt,
+      executionPolicy: { mode: "normal" },
+      executionState: null,
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reapOrphanedRuns();
+    expect(result.reaped).toBe(1);
+    expect(result.runIds).toEqual([runId]);
+
+    const runs = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.agentId, agentId));
+    expect(runs).toHaveLength(1);
+    expect(runs[0]?.status).toBe("failed");
+
+    const wakeups = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.agentId, agentId));
+    expect(wakeups.some((row) => row.reason === "issue_continuation_needed")).toBe(false);
+
+    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(issue?.status).toBe("in_progress");
+    expect(issue?.executionRunId).toBeNull();
+    expect(issue?.checkoutRunId).toBeNull();
+  });
+
   it("blocks failed recovery work in place during immediate terminal-run cleanup", async () => {
     const sourceIssueId = randomUUID();
     const { companyId, agentId, runId, issueId } = await seedRunFixture({
@@ -2962,6 +2997,42 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     const [issue] = await db.select().from(issues).where(eq(issues.id, issueId));
     expect(issue?.status).toBe("in_progress");
     expect(issue?.monitorNextCheckAt).toBeNull();
+  });
+
+  it("does not re-enqueue continuation for stranded in-progress work parked on a column-only future scheduled monitor", async () => {
+    const monitorNextCheckAt = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000);
+    const { companyId, agentId, issueId } = await seedStrandedIssueFixture({
+      status: "in_progress",
+      runStatus: "succeeded",
+      livenessState: "advanced",
+      monitorNextCheckAt,
+      executionPolicy: { mode: "normal" },
+      executionState: null,
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(result.dispatchRequeued).toBe(0);
+    expect(result.continuationRequeued).toBe(0);
+    expect(result.escalated).toBe(0);
+    expect(result.skipped).toBe(1);
+
+    const runs = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.agentId, agentId));
+    expect(runs).toHaveLength(1);
+
+    const wakeups = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.agentId, agentId));
+    expect(wakeups.filter((row) => row.payload?.issueId === issueId)).toHaveLength(1);
+    expect(wakeups.some((row) => row.reason === "issue_continuation_needed")).toBe(false);
+
+    const [issue] = await db.select().from(issues).where(eq(issues.id, issueId));
+    expect(issue?.status).toBe("in_progress");
+    expect(issue?.monitorNextCheckAt).toEqual(monitorNextCheckAt);
   });
 
   it.each([

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -2926,9 +2926,17 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
         maxAttempts: 1,
       },
     },
+    {
+      name: "exhausted execution-state attempts",
+      monitorAttemptCount: 0,
+      stateMonitorAttemptCount: 1,
+      monitorPolicy: {
+        maxAttempts: 1,
+      },
+    },
   ])(
     "re-enqueues continuation for stranded in-progress work with a future scheduled monitor that is $name",
-    async ({ monitorAttemptCount, monitorPolicy }) => {
+    async ({ monitorAttemptCount, stateMonitorAttemptCount, monitorPolicy }) => {
       const monitorNextCheckAt = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000);
       const { agentId, issueId, runId } = await seedStrandedIssueFixture({
         status: "in_progress",
@@ -2949,7 +2957,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
           monitor: {
             status: "scheduled",
             nextCheckAt: monitorNextCheckAt.toISOString(),
-            attemptCount: monitorAttemptCount,
+            attemptCount: stateMonitorAttemptCount ?? monitorAttemptCount,
             ...monitorPolicy,
           },
         },

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -454,6 +454,10 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     runErrorCode?: string | null;
     runError?: string | null;
     contextSnapshot?: Record<string, unknown>;
+    monitorAttemptCount?: number;
+    monitorNextCheckAt?: Date | null;
+    executionPolicy?: Record<string, unknown> | null;
+    executionState?: Record<string, unknown> | null;
   }) {
     const companyId = randomUUID();
     const agentId = randomUUID();
@@ -525,6 +529,10 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
         assigneeAgentId: agentId,
         checkoutRunId: runId,
         executionRunId: runId,
+        executionPolicy: input?.executionPolicy ?? null,
+        executionState: input?.executionState ?? null,
+        monitorAttemptCount: input?.monitorAttemptCount ?? 0,
+        monitorNextCheckAt: input?.monitorNextCheckAt ?? null,
         issueNumber: 1,
         identifier: `${issuePrefix}-1`,
       });
@@ -1184,6 +1192,52 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(comments[0]?.body).toContain("retried continuation");
     expect(comments[0]?.body).toContain(`Recovery action: \`${recoveryAction.id}\``);
     expect(comments[0]?.body).toContain("Recovery owner: [CodexCoder]");
+  });
+
+  it("does not immediately re-enqueue continuation when terminal cleanup finds a future scheduled monitor", async () => {
+    const monitorNextCheckAt = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000);
+    const { companyId, agentId, runId, issueId } = await seedRunFixture({
+      agentStatus: "idle",
+      processPid: 999_999_999,
+      processLossRetryCount: 1,
+      executionPolicy: {
+        mode: "normal",
+        monitor: {
+          nextCheckAt: monitorNextCheckAt.toISOString(),
+          wakeReason: "scheduled_publish",
+        },
+      },
+      executionState: {
+        status: "idle",
+        monitor: {
+          status: "scheduled",
+          nextCheckAt: monitorNextCheckAt.toISOString(),
+        },
+      },
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reapOrphanedRuns();
+    expect(result.reaped).toBe(1);
+    expect(result.runIds).toEqual([runId]);
+
+    const runs = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.agentId, agentId));
+    expect(runs).toHaveLength(1);
+    expect(runs[0]?.status).toBe("failed");
+
+    const wakeups = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.agentId, agentId));
+    expect(wakeups.some((row) => row.reason === "issue_continuation_needed")).toBe(false);
+
+    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(issue?.status).toBe("in_progress");
+    expect(issue?.executionRunId).toBeNull();
+    expect(issue?.checkoutRunId).toBeNull();
   });
 
   it("blocks failed recovery work in place during immediate terminal-run cleanup", async () => {
@@ -2869,7 +2923,6 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       status: "in_progress",
       runStatus: "succeeded",
       livenessState: "advanced",
-      monitorNextCheckAt,
       executionPolicy: {
         mode: "normal",
         monitor: {
@@ -2908,7 +2961,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
 
     const [issue] = await db.select().from(issues).where(eq(issues.id, issueId));
     expect(issue?.status).toBe("in_progress");
-    expect(issue?.monitorNextCheckAt?.toISOString()).toBe(monitorNextCheckAt.toISOString());
+    expect(issue?.monitorNextCheckAt).toBeNull();
   });
 
   it.each([

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -585,6 +585,9 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     livenessState?: "completed" | "advanced" | "plan_only" | "empty_response" | "blocked" | "failed" | "needs_followup" | null;
     runErrorCode?: string | null;
     runError?: string | null;
+    monitorNextCheckAt?: Date | null;
+    executionPolicy?: Record<string, unknown> | null;
+    executionState?: Record<string, unknown> | null;
   }) {
     const companyId = randomUUID();
     const agentId = randomUUID();
@@ -683,6 +686,9 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
         assigneeUserId: input.assignToUser ? "user-1" : null,
         checkoutRunId: input.status === "in_progress" ? runId : null,
         executionRunId: null,
+        executionPolicy: input.executionPolicy ?? null,
+        executionState: input.executionState ?? null,
+        monitorNextCheckAt: input.monitorNextCheckAt ?? null,
         issueNumber: input.activePauseHold ? 2 : 1,
         identifier: `${issuePrefix}-${input.activePauseHold ? 2 : 1}`,
         startedAt: input.status === "in_progress" ? now : null,
@@ -2853,6 +2859,54 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     if (retryRun) {
       await waitForRunToSettle(heartbeat, retryRun.id);
     }
+  });
+
+  it("does not re-enqueue continuation for stranded in-progress work parked on a future scheduled monitor", async () => {
+    const monitorNextCheckAt = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000);
+    const { companyId, agentId, issueId } = await seedStrandedIssueFixture({
+      status: "in_progress",
+      runStatus: "succeeded",
+      livenessState: "advanced",
+      monitorNextCheckAt,
+      executionPolicy: {
+        mode: "normal",
+        monitor: {
+          nextCheckAt: monitorNextCheckAt.toISOString(),
+          wakeReason: "scheduled_publish",
+        },
+      },
+      executionState: {
+        status: "idle",
+        monitor: {
+          status: "scheduled",
+          nextCheckAt: monitorNextCheckAt.toISOString(),
+        },
+      },
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(result.dispatchRequeued).toBe(0);
+    expect(result.continuationRequeued).toBe(0);
+    expect(result.escalated).toBe(0);
+    expect(result.skipped).toBe(1);
+
+    const runs = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.agentId, agentId));
+    expect(runs).toHaveLength(1);
+
+    const wakeups = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.agentId, agentId));
+    expect(wakeups.filter((row) => row.payload?.issueId === issueId)).toHaveLength(1);
+    expect(wakeups.some((row) => row.reason === "issue_continuation_needed")).toBe(false);
+
+    const [issue] = await db.select().from(issues).where(eq(issues.id, issueId));
+    expect(issue?.status).toBe("in_progress");
+    expect(issue?.monitorNextCheckAt?.toISOString()).toBe(monitorNextCheckAt.toISOString());
   });
 
   it("does not continue seeded in-progress work that has no run linkage", async () => {

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -585,6 +585,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     livenessState?: "completed" | "advanced" | "plan_only" | "empty_response" | "blocked" | "failed" | "needs_followup" | null;
     runErrorCode?: string | null;
     runError?: string | null;
+    monitorAttemptCount?: number;
     monitorNextCheckAt?: Date | null;
     executionPolicy?: Record<string, unknown> | null;
     executionState?: Record<string, unknown> | null;
@@ -688,6 +689,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
         executionRunId: null,
         executionPolicy: input.executionPolicy ?? null,
         executionState: input.executionState ?? null,
+        monitorAttemptCount: input.monitorAttemptCount ?? 0,
         monitorNextCheckAt: input.monitorNextCheckAt ?? null,
         issueNumber: input.activePauseHold ? 2 : 1,
         identifier: `${issuePrefix}-${input.activePauseHold ? 2 : 1}`,
@@ -2908,6 +2910,73 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(issue?.status).toBe("in_progress");
     expect(issue?.monitorNextCheckAt?.toISOString()).toBe(monitorNextCheckAt.toISOString());
   });
+
+  it.each([
+    {
+      name: "expired timeout",
+      monitorAttemptCount: 0,
+      monitorPolicy: {
+        timeoutAt: new Date(Date.now() - 60_000).toISOString(),
+      },
+    },
+    {
+      name: "exhausted attempts",
+      monitorAttemptCount: 1,
+      monitorPolicy: {
+        maxAttempts: 1,
+      },
+    },
+  ])(
+    "re-enqueues continuation for stranded in-progress work with a future scheduled monitor that is $name",
+    async ({ monitorAttemptCount, monitorPolicy }) => {
+      const monitorNextCheckAt = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000);
+      const { agentId, issueId, runId } = await seedStrandedIssueFixture({
+        status: "in_progress",
+        runStatus: "succeeded",
+        livenessState: "advanced",
+        monitorAttemptCount,
+        monitorNextCheckAt,
+        executionPolicy: {
+          mode: "normal",
+          monitor: {
+            nextCheckAt: monitorNextCheckAt.toISOString(),
+            wakeReason: "scheduled_publish",
+            ...monitorPolicy,
+          },
+        },
+        executionState: {
+          status: "idle",
+          monitor: {
+            status: "scheduled",
+            nextCheckAt: monitorNextCheckAt.toISOString(),
+            attemptCount: monitorAttemptCount,
+            ...monitorPolicy,
+          },
+        },
+      });
+      const heartbeat = heartbeatService(db);
+
+      const result = await heartbeat.reconcileStrandedAssignedIssues();
+      expect(result.dispatchRequeued).toBe(0);
+      expect(result.continuationRequeued).toBe(1);
+      expect(result.escalated).toBe(0);
+      expect(result.skipped).toBe(0);
+      expect(result.issueIds).toEqual([issueId]);
+
+      const runs = await db
+        .select()
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.agentId, agentId));
+      expect(runs).toHaveLength(2);
+
+      const retryRun = runs.find((row) => row.id !== runId);
+      expect(retryRun?.id).toBeTruthy();
+      expect((retryRun?.contextSnapshot as Record<string, unknown>)?.retryReason).toBe("issue_continuation_needed");
+      if (retryRun) {
+        await waitForRunToSettle(heartbeat, retryRun.id);
+      }
+    },
+  );
 
   it("does not continue seeded in-progress work that has no run linkage", async () => {
     const companyId = randomUUID();

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -108,6 +108,7 @@ import { issueService } from "./issues.js";
 import {
   buildIssueMonitorClearedPatch,
   buildIssueMonitorTriggeredPatch,
+  issueHasFutureScheduledMonitor,
   normalizeIssueExecutionPolicy,
   parseIssueExecutionState,
 } from "./issue-execution-policy.js";
@@ -10744,6 +10745,9 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         return { kind: "released" as const };
       }
       if (options.suppressImmediateRecovery) {
+        return { kind: "released" as const };
+      }
+      if (issue.status === "in_progress" && issueHasFutureScheduledMonitor(issue)) {
         return { kind: "released" as const };
       }
 

--- a/server/src/services/issue-execution-policy.ts
+++ b/server/src/services/issue-execution-policy.ts
@@ -409,6 +409,59 @@ export function parseIssueExecutionState(input: unknown): IssueExecutionState | 
   return parsed.data;
 }
 
+function readMonitorDate(value: unknown): Date | null {
+  if (!(typeof value === "string" || value instanceof Date)) return null;
+  const date = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function readPositiveInteger(value: unknown): number | null {
+  return typeof value === "number" && Number.isInteger(value) && value > 0 ? value : null;
+}
+
+function readNonNegativeInteger(value: unknown): number | null {
+  return typeof value === "number" && Number.isInteger(value) && value >= 0 ? value : null;
+}
+
+function readObject(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value) ? value as Record<string, unknown> : {};
+}
+
+function readNonEmptyString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+export function issueHasFutureScheduledMonitor(issue: Pick<
+  IssueLike,
+  "status" | "executionPolicy" | "executionState" | "monitorAttemptCount" | "monitorNextCheckAt"
+>): boolean {
+  const policy = normalizeIssueExecutionPolicy(issue.executionPolicy ?? null);
+  const state = parseIssueExecutionState(issue.executionState ?? null);
+  const rawState = readObject(issue.executionState);
+  const rawStateMonitor = readObject(rawState.monitor);
+  const monitor = derivePersistedMonitorState({ issue, state, policy });
+  if (monitor?.status !== "scheduled") return false;
+  if ((state?.status ?? readNonEmptyString(rawState.status)) !== "idle") return false;
+
+  const now = Date.now();
+  const nextCheckAt = readMonitorDate(monitor.nextCheckAt);
+  if (!nextCheckAt || nextCheckAt.getTime() <= now) return false;
+
+  const timeoutAt = readMonitorDate(monitor.timeoutAt);
+  if (timeoutAt && timeoutAt.getTime() <= now) return false;
+
+  const maxAttempts = readPositiveInteger(monitor.maxAttempts);
+  const columnAttemptCount = readNonNegativeInteger(issue.monitorAttemptCount) ?? 0;
+  const stateAttemptCount =
+    readNonNegativeInteger(state?.monitor?.attemptCount) ??
+    readNonNegativeInteger(rawStateMonitor.attemptCount) ??
+    0;
+  const attemptCount = Math.max(columnAttemptCount, stateAttemptCount);
+  if (maxAttempts !== null && attemptCount >= maxAttempts) return false;
+
+  return true;
+}
+
 export function assigneePrincipal(input: AssigneeLike): IssueExecutionStagePrincipal | null {
   if (input.assigneeAgentId) {
     return { type: "agent", agentId: input.assigneeAgentId, userId: null };

--- a/server/src/services/issue-execution-policy.ts
+++ b/server/src/services/issue-execution-policy.ts
@@ -441,7 +441,8 @@ export function issueHasFutureScheduledMonitor(issue: Pick<
   const rawStateMonitor = readObject(rawState.monitor);
   const monitor = derivePersistedMonitorState({ issue, state, policy });
   if (monitor?.status !== "scheduled") return false;
-  if ((state?.status ?? readNonEmptyString(rawState.status)) !== "idle") return false;
+  const stateStatus = state?.status ?? readNonEmptyString(rawState.status);
+  if (stateStatus && stateStatus !== "idle") return false;
 
   const now = Date.now();
   const nextCheckAt = readMonitorDate(monitor.nextCheckAt);

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -386,12 +386,17 @@ function readDate(value: unknown): Date | null {
   return Number.isNaN(date.getTime()) ? null : date;
 }
 
+function readPositiveInteger(value: unknown): number | null {
+  return typeof value === "number" && Number.isInteger(value) && value > 0 ? value : null;
+}
+
 function hasFutureScheduledMonitor(issue: Pick<
   typeof issues.$inferSelect,
-  "executionPolicy" | "executionState" | "monitorNextCheckAt"
+  "executionPolicy" | "executionState" | "monitorAttemptCount" | "monitorNextCheckAt"
 >) {
+  const now = Date.now();
   const monitorNextCheckAt = readDate(issue.monitorNextCheckAt);
-  if (!monitorNextCheckAt || monitorNextCheckAt.getTime() <= Date.now()) return false;
+  if (!monitorNextCheckAt || monitorNextCheckAt.getTime() <= now) return false;
 
   const executionState = parseObject(issue.executionState);
   const stateStatus = readNonEmptyString(executionState.status);
@@ -405,6 +410,14 @@ function hasFutureScheduledMonitor(issue: Pick<
   if (policyNextCheckAt && Math.abs(policyNextCheckAt.getTime() - monitorNextCheckAt.getTime()) > 1_000) {
     return false;
   }
+
+  const timeoutAt = readDate(policyMonitor.timeoutAt ?? stateMonitor.timeoutAt);
+  if (timeoutAt && timeoutAt.getTime() <= now) return false;
+
+  const maxAttempts = readPositiveInteger(policyMonitor.maxAttempts ?? stateMonitor.maxAttempts);
+  const stateAttemptCount = readPositiveInteger(stateMonitor.attemptCount) ?? 0;
+  const attemptCount = issue.monitorAttemptCount ?? stateAttemptCount;
+  if (maxAttempts !== null && attemptCount >= maxAttempts) return false;
 
   return true;
 }

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -37,6 +37,7 @@ import { instanceSettingsService } from "../instance-settings.js";
 import { issueRecoveryActionService } from "../issue-recovery-actions.js";
 import { issueTreeControlService } from "../issue-tree-control.js";
 import { TERMINAL_HEARTBEAT_RUN_STATUSES, issueService } from "../issues.js";
+import { issueHasFutureScheduledMonitor } from "../issue-execution-policy.js";
 import { evaluateAgentInvokabilityFromDb } from "../agent-invokability.js";
 import { getRunLogStore } from "../run-log-store.js";
 import {
@@ -378,53 +379,6 @@ function isRepeatedProductiveContinuationRecovery(latestRun: SuccessfulLatestIss
   return readNonEmptyString(latestContext.retryReason) === "issue_continuation_needed" &&
     readNonEmptyString(latestContext.source) === "issue.productive_terminal_continuation_recovery" &&
     isProductiveContinuationRun(latestRun);
-}
-
-function readDate(value: unknown): Date | null {
-  if (!(typeof value === "string" || value instanceof Date)) return null;
-  const date = value instanceof Date ? value : new Date(value);
-  return Number.isNaN(date.getTime()) ? null : date;
-}
-
-function readPositiveInteger(value: unknown): number | null {
-  return typeof value === "number" && Number.isInteger(value) && value > 0 ? value : null;
-}
-
-function readNonNegativeInteger(value: unknown): number | null {
-  return typeof value === "number" && Number.isInteger(value) && value >= 0 ? value : null;
-}
-
-function hasFutureScheduledMonitor(issue: Pick<
-  typeof issues.$inferSelect,
-  "executionPolicy" | "executionState" | "monitorAttemptCount" | "monitorNextCheckAt"
->) {
-  const now = Date.now();
-  const monitorNextCheckAt = readDate(issue.monitorNextCheckAt);
-  if (!monitorNextCheckAt || monitorNextCheckAt.getTime() <= now) return false;
-
-  const executionState = parseObject(issue.executionState);
-  const stateStatus = readNonEmptyString(executionState.status);
-  const stateMonitor = parseObject(executionState.monitor);
-  const monitorStatus = readNonEmptyString(stateMonitor.status);
-  if (monitorStatus !== "scheduled") return false;
-  if (stateStatus !== "idle") return false;
-
-  const policyMonitor = parseObject(parseObject(issue.executionPolicy).monitor);
-  const policyNextCheckAt = readDate(policyMonitor.nextCheckAt);
-  if (policyNextCheckAt && Math.abs(policyNextCheckAt.getTime() - monitorNextCheckAt.getTime()) > 1_000) {
-    return false;
-  }
-
-  const timeoutAt = readDate(policyMonitor.timeoutAt ?? stateMonitor.timeoutAt);
-  if (timeoutAt && timeoutAt.getTime() <= now) return false;
-
-  const maxAttempts = readPositiveInteger(policyMonitor.maxAttempts ?? stateMonitor.maxAttempts);
-  const columnAttemptCount = readNonNegativeInteger(issue.monitorAttemptCount) ?? 0;
-  const stateAttemptCount = readNonNegativeInteger(stateMonitor.attemptCount) ?? 0;
-  const attemptCount = Math.max(columnAttemptCount, stateAttemptCount);
-  if (maxAttempts !== null && attemptCount >= maxAttempts) return false;
-
-  return true;
 }
 
 function parseLivenessIncidentKey(incidentKey: string | null | undefined) {
@@ -2901,7 +2855,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         result.skipped += 1;
         continue;
       }
-      if (hasFutureScheduledMonitor(issue)) {
+      if (issueHasFutureScheduledMonitor(issue)) {
         result.skipped += 1;
         continue;
       }

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -390,6 +390,10 @@ function readPositiveInteger(value: unknown): number | null {
   return typeof value === "number" && Number.isInteger(value) && value > 0 ? value : null;
 }
 
+function readNonNegativeInteger(value: unknown): number | null {
+  return typeof value === "number" && Number.isInteger(value) && value >= 0 ? value : null;
+}
+
 function hasFutureScheduledMonitor(issue: Pick<
   typeof issues.$inferSelect,
   "executionPolicy" | "executionState" | "monitorAttemptCount" | "monitorNextCheckAt"
@@ -415,8 +419,9 @@ function hasFutureScheduledMonitor(issue: Pick<
   if (timeoutAt && timeoutAt.getTime() <= now) return false;
 
   const maxAttempts = readPositiveInteger(policyMonitor.maxAttempts ?? stateMonitor.maxAttempts);
-  const stateAttemptCount = readPositiveInteger(stateMonitor.attemptCount) ?? 0;
-  const attemptCount = issue.monitorAttemptCount ?? stateAttemptCount;
+  const columnAttemptCount = readNonNegativeInteger(issue.monitorAttemptCount) ?? 0;
+  const stateAttemptCount = readNonNegativeInteger(stateMonitor.attemptCount) ?? 0;
+  const attemptCount = Math.max(columnAttemptCount, stateAttemptCount);
   if (maxAttempts !== null && attemptCount >= maxAttempts) return false;
 
   return true;

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -380,6 +380,35 @@ function isRepeatedProductiveContinuationRecovery(latestRun: SuccessfulLatestIss
     isProductiveContinuationRun(latestRun);
 }
 
+function readDate(value: unknown): Date | null {
+  if (!(typeof value === "string" || value instanceof Date)) return null;
+  const date = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function hasFutureScheduledMonitor(issue: Pick<
+  typeof issues.$inferSelect,
+  "executionPolicy" | "executionState" | "monitorNextCheckAt"
+>) {
+  const monitorNextCheckAt = readDate(issue.monitorNextCheckAt);
+  if (!monitorNextCheckAt || monitorNextCheckAt.getTime() <= Date.now()) return false;
+
+  const executionState = parseObject(issue.executionState);
+  const stateStatus = readNonEmptyString(executionState.status);
+  const stateMonitor = parseObject(executionState.monitor);
+  const monitorStatus = readNonEmptyString(stateMonitor.status);
+  if (monitorStatus !== "scheduled") return false;
+  if (stateStatus !== "idle") return false;
+
+  const policyMonitor = parseObject(parseObject(issue.executionPolicy).monitor);
+  const policyNextCheckAt = readDate(policyMonitor.nextCheckAt);
+  if (policyNextCheckAt && Math.abs(policyNextCheckAt.getTime() - monitorNextCheckAt.getTime()) > 1_000) {
+    return false;
+  }
+
+  return true;
+}
+
 function parseLivenessIncidentKey(incidentKey: string | null | undefined) {
   if (!incidentKey) return null;
   return parseIssueGraphLivenessIncidentKey(incidentKey);
@@ -2851,6 +2880,10 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       }
 
       if (!latestRun && !issue.checkoutRunId && !issue.executionRunId) {
+        result.skipped += 1;
+        continue;
+      }
+      if (hasFutureScheduledMonitor(issue)) {
         result.skipped += 1;
         continue;
       }


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The affected subsystem is issue execution recovery, which decides when an issue needs an immediate continuation wake after an execution run ends.
> - Some issues are intentionally parked with a future scheduled monitor, so recovery must distinguish dormant waiting from work that is stranded.
> - The existing suppression covered the periodic stranded-issue scan but not the immediate terminal-run cleanup path.
> - The existing detector also missed monitor schedules persisted only in execution policy/state data.
> - This pull request shares the scheduled-monitor detector and applies it to both recovery paths.
> - The benefit is that parked issues wait until their monitor time instead of receiving an immediate continuation wake.

## Linked Issues or Issue Description

No public GitHub issue exists for this operator-observed regression.

### What happened?

A scheduled issue was restored to `in_progress` with a future monitor after blockers cleared. Its monitor schedule existed in execution policy/state data and can also exist in top-level monitor columns, but immediate terminal-run cleanup still treated the issue as continuation-needed and woke the assignee immediately.

### Expected behavior

An `in_progress` issue with a future scheduled monitor should not receive an immediate continuation wake until the monitor is due. Overdue, timed-out, or exhausted monitors should still be eligible for recovery.

### Steps to reproduce

1. Create an assigned `in_progress` issue with a terminal execution run.
2. Persist a future scheduled monitor either in execution policy/state data or only in the top-level monitor columns.
3. Run terminal-run cleanup or stranded-issue reconciliation.
4. Observe that the issue should stay parked without an `issue_continuation_needed` wake.

### Paperclip version or commit

Regression reproduced against the pre-fix recovery implementation; this PR fixes it at branch head `f1b179990`.

### Deployment mode

Self-hosted server.

## What Changed

- Shared the future scheduled-monitor detector through `issue-execution-policy.ts` so recovery code recognizes monitor data persisted in policy/state shapes.
- Suppressed immediate terminal-run continuation recovery for `in_progress` issues that are intentionally parked on a future scheduled monitor.
- Kept the existing stranded-issue scanner suppression, now using the shared detector.
- Added regression coverage for the immediate cleanup path and the policy/state-only future-monitor shape.

## Verification

- `pnpm vitest run server/src/__tests__/heartbeat-process-recovery.test.ts`
- `pnpm --filter @paperclipai/server typecheck`

## Risks

Low risk. The suppression only applies when a monitor is scheduled for the future, so overdue monitors and genuinely stranded issues remain eligible for recovery.

## Model Used

Codex CLI using GPT-5 with tool use and code execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge


