### PR TITLE
test(cli): isolate command tests from local context

### DIFF
--- a/cli/src/__tests__/company.test.ts
+++ b/cli/src/__tests__/company.test.ts
@@ -1,4 +1,7 @@
 import { Command } from "commander";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { CompanyPortabilityPreviewResult } from "@paperclipai/shared";
 import {
@@ -70,7 +73,10 @@ describe("company CLI commands", () => {
   let errorSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
-    process.env = { ...ORIGINAL_ENV };
+    process.env = {
+      ...ORIGINAL_ENV,
+      PAPERCLIP_CONTEXT: path.join(fs.mkdtempSync(path.join(os.tmpdir(), "paperclip-company-cli-")), "context.json"),
+    };
     delete process.env.PAPERCLIP_API_URL;
     delete process.env.PAPERCLIP_API_KEY;
     delete process.env.PAPERCLIP_COMPANY_ID;

--- a/cli/src/__tests__/company.test.ts
+++ b/cli/src/__tests__/company.test.ts
@@ -71,11 +71,13 @@ describe("company CLI commands", () => {
   let fetchMock: ReturnType<typeof vi.fn>;
   let logSpy: ReturnType<typeof vi.spyOn>;
   let errorSpy: ReturnType<typeof vi.spyOn>;
+  let tempContextDir: string | undefined;
 
   beforeEach(() => {
+    tempContextDir = fs.mkdtempSync(path.join(os.tmpdir(), "paperclip-company-cli-"));
     process.env = {
       ...ORIGINAL_ENV,
-      PAPERCLIP_CONTEXT: path.join(fs.mkdtempSync(path.join(os.tmpdir(), "paperclip-company-cli-")), "context.json"),
+      PAPERCLIP_CONTEXT: path.join(tempContextDir, "context.json"),
     };
     delete process.env.PAPERCLIP_API_URL;
     delete process.env.PAPERCLIP_API_KEY;
@@ -88,6 +90,10 @@ describe("company CLI commands", () => {
 
   afterEach(() => {
     process.env = { ...ORIGINAL_ENV };
+    if (tempContextDir) {
+      fs.rmSync(tempContextDir, { recursive: true, force: true });
+      tempContextDir = undefined;
+    }
     vi.unstubAllGlobals();
     vi.restoreAllMocks();
   });

--- a/cli/src/__tests__/project-goal.test.ts
+++ b/cli/src/__tests__/project-goal.test.ts
@@ -24,10 +24,13 @@ function createProgram(): Command {
 }
 
 describe("project and goal commands", () => {
+  let tempContextDir: string | undefined;
+
   beforeEach(() => {
+    tempContextDir = fs.mkdtempSync(path.join(os.tmpdir(), "paperclip-project-goal-cli-"));
     process.env = {
       ...ORIGINAL_ENV,
-      PAPERCLIP_CONTEXT: path.join(fs.mkdtempSync(path.join(os.tmpdir(), "paperclip-project-goal-cli-")), "context.json"),
+      PAPERCLIP_CONTEXT: path.join(tempContextDir, "context.json"),
     };
     vi.restoreAllMocks();
     delete process.env.PAPERCLIP_API_KEY;
@@ -37,6 +40,10 @@ describe("project and goal commands", () => {
 
   afterEach(() => {
     process.env = { ...ORIGINAL_ENV };
+    if (tempContextDir) {
+      fs.rmSync(tempContextDir, { recursive: true, force: true });
+      tempContextDir = undefined;
+    }
     vi.restoreAllMocks();
   });
 

--- a/cli/src/__tests__/project-goal.test.ts
+++ b/cli/src/__tests__/project-goal.test.ts
@@ -1,4 +1,7 @@
 import { Command } from "commander";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { registerGoalCommands } from "../commands/client/goal.js";
 import { registerProjectCommands } from "../commands/client/project.js";
@@ -6,6 +9,7 @@ import { registerProjectCommands } from "../commands/client/project.js";
 const COMPANY_ID = "22222222-2222-4222-8222-222222222222";
 const PROJECT_ID = "33333333-3333-4333-8333-333333333333";
 const GOAL_ID = "44444444-4444-4444-8444-444444444444";
+const ORIGINAL_ENV = { ...process.env };
 
 function createProgram(): Command {
   const program = new Command();
@@ -21,6 +25,10 @@ function createProgram(): Command {
 
 describe("project and goal commands", () => {
   beforeEach(() => {
+    process.env = {
+      ...ORIGINAL_ENV,
+      PAPERCLIP_CONTEXT: path.join(fs.mkdtempSync(path.join(os.tmpdir(), "paperclip-project-goal-cli-")), "context.json"),
+    };
     vi.restoreAllMocks();
     delete process.env.PAPERCLIP_API_KEY;
     delete process.env.PAPERCLIP_API_URL;
@@ -28,6 +36,7 @@ describe("project and goal commands", () => {
   });
 
   afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
     vi.restoreAllMocks();
   });
 


### PR DESCRIPTION
## Thinking Path
SAG-5447 reported CLI tests failing because mocked command tests were picking up the checkout's live Paperclip CLI context. I reproduced the failures locally and confirmed the unexpected company-scoped requests came from ancestor discovery of `.paperclip/context.json`, not from the command code under test. The fix is to isolate the affected tests from developer-machine state by pointing `PAPERCLIP_CONTEXT` at a per-test temporary context file. After review feedback, the tests also remove those temporary context directories in cleanup so repeated local or CI runs do not leave empty directories behind.

## Linked Issue
SAG-5447

## Linked Issues or Issue Description

No public GitHub issue is linked. Inline issue description from PR title: `test(cli): isolate command tests from local context`.

## What Changed
- Set `PAPERCLIP_CONTEXT` to a fresh temporary context path in `company.test.ts` setup.
- Set `PAPERCLIP_CONTEXT` to a fresh temporary context path in `project-goal.test.ts` setup.
- Restored `process.env` after project/goal tests so later tests do not inherit temporary context state.
- Removed temporary context directories in `afterEach`.

## Verification
- `pnpm exec vitest run cli/src/__tests__/company.test.ts cli/src/__tests__/project-goal.test.ts --reporter=dot`
  - 20 tests passed
- `pnpm --filter @paperclipai/plugin-sdk ensure-build-deps`
- `pnpm --filter paperclipai typecheck`
- `git diff --check`

## Risks
- Low. Test-only change; no runtime behavior changed.
- The broader CLI suite was also run before splitting this PR and passed locally; this branch is re-verified with targeted tests and CLI typecheck after the split.

## Model Used
GPT-5.5 via Hermes.

## Checklist
- [x] Tests added/updated where appropriate
- [x] Targeted tests pass locally
- [x] Typecheck passes locally
- [x] No runtime behavior changed
