### PR TITLE
test(issues): cover routine execution policy patch

### DIFF
--- a/server/src/__tests__/issue-execution-policy-routes.test.ts
+++ b/server/src/__tests__/issue-execution-policy-routes.test.ts
@@ -348,6 +348,130 @@ describe("issue execution policy routes", () => {
     );
   });
 
+  it("allows an agent-authored routine issue patch with a standard review execution policy", async () => {
+    const issue = {
+      id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      companyId: "company-1",
+      status: "in_progress",
+      assigneeAgentId: "33333333-3333-4333-8333-333333333333",
+      assigneeUserId: null,
+      createdByUserId: "local-board",
+      identifier: "PAP-1008",
+      title: "Routine issue needing review policy",
+      originKind: "routine_execution",
+      originRunId: "77777777-7777-4777-8777-777777777777",
+      executionPolicy: null,
+      executionState: null,
+    };
+    mockIssueService.getById.mockResolvedValue(issue);
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
+      ...issue,
+      ...patch,
+      updatedAt: new Date(),
+    }));
+
+    const res = await request(await createApp({
+      type: "agent",
+      agentId: "33333333-3333-4333-8333-333333333333",
+      companyId: "company-1",
+      runId: "run-1",
+    }))
+      .patch("/api/issues/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa")
+      .set("X-Paperclip-Run-Id", "run-1")
+      .send({
+        status: "in_review",
+        executionPolicy: {
+          mode: "normal",
+          commentRequired: true,
+          stages: [
+            {
+              type: "review",
+              approvalsNeeded: 1,
+              participants: [{ type: "agent", agentId: "44444444-4444-4444-8444-444444444444" }],
+            },
+          ],
+        },
+      });
+
+    expect(res.status).toBe(200);
+    expect(mockIssueService.update).toHaveBeenCalledWith(
+      "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      expect.objectContaining({
+        status: "in_review",
+        actorAgentId: "33333333-3333-4333-8333-333333333333",
+        executionPolicy: expect.objectContaining({
+          mode: "normal",
+          commentRequired: true,
+          stages: [
+            expect.objectContaining({
+              type: "review",
+              approvalsNeeded: 1,
+              participants: [
+                expect.objectContaining({
+                  type: "agent",
+                  agentId: "44444444-4444-4444-8444-444444444444",
+                }),
+              ],
+            }),
+          ],
+        }),
+        executionState: expect.objectContaining({
+          status: "pending",
+          currentStageType: "review",
+          currentParticipant: expect.objectContaining({
+            type: "agent",
+            agentId: "44444444-4444-4444-8444-444444444444",
+          }),
+        }),
+      }),
+    );
+  });
+
+  it("returns a validation error for invalid routine issue execution policy participants", async () => {
+    const issue = {
+      id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      companyId: "company-1",
+      status: "in_progress",
+      assigneeAgentId: "33333333-3333-4333-8333-333333333333",
+      assigneeUserId: null,
+      createdByUserId: "local-board",
+      identifier: "PAP-1009",
+      title: "Routine issue with invalid policy",
+      originKind: "routine_execution",
+      originRunId: "77777777-7777-4777-8777-777777777777",
+      executionPolicy: null,
+      executionState: null,
+    };
+    mockIssueService.getById.mockResolvedValue(issue);
+
+    const res = await request(await createApp({
+      type: "agent",
+      agentId: "33333333-3333-4333-8333-333333333333",
+      companyId: "company-1",
+      runId: "run-1",
+    }))
+      .patch("/api/issues/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa")
+      .set("X-Paperclip-Run-Id", "run-1")
+      .send({
+        executionPolicy: {
+          mode: "normal",
+          commentRequired: true,
+          stages: [
+            {
+              type: "review",
+              approvalsNeeded: 1,
+              participants: [{ type: "agent" }],
+            },
+          ],
+        },
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body).toMatchObject({ error: "Validation error" });
+    expect(JSON.stringify(res.body.details)).toContain("Agent participants require agentId");
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+  });
+
   it("allows an agent-authored in_review transition with a scheduled monitor", async () => {
     const issue = {
       id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The issue PATCH route owns status transitions and execution-policy updates for issues created by routines and agents.
> - A routine-generated issue was reported to return HTTP 500 when patched with a standard review `executionPolicy` payload.
> - That path should either accept a valid policy or reject malformed policy JSON with an actionable 4xx validation response.
> - The current route harness and a live retest did not reproduce the reported 500 for the standard payload.
> - This pull request adds regression coverage for the expected contract on routine-origin issues and malformed participants.
> - The benefit is that a future route/service regression in this path fails as a focused server test instead of surfacing as an operator-facing 500.

## Linked Issues or Issue Description

No public GitHub issue exists for this internal operator report.

Bug report summary:
- Symptom: `PATCH /api/issues/:id` was reported to return HTTP 500 when applying a standard review `executionPolicy` to a routine-generated issue.
- Expected behavior: valid standard review policies are accepted; malformed policy payloads return 4xx validation details before the update path runs.
- Root-cause finding: no current Paperclip route/service root cause was identified because the reported 500 is not reproducible on current `master` in either the isolated route harness or the live API retest. The current code path accepts the standard policy shape. Nearby failure modes are validation/permission failures, and the added invalid-participant case confirms malformed payloads now stay on the 400 validation path instead of reaching issue update.
- Closure rationale: because the live standard-payload retest returned HTTP 200 and the route regression now locks both the valid and invalid contracts, this PR treats the original 500 as an unreproduced transient or since-resolved deployment/runtime condition rather than a code change requiring a new production fix.

## What Changed

- Added server route coverage proving an agent-authored routine issue can be patched to `in_review` with a standard review `executionPolicy`.
- Asserted the route normalizes the policy and initializes pending execution state for the first review participant.
- Added validation coverage proving an invalid agent participant returns HTTP 400 and does not call issue update.

## Verification

- `pnpm exec vitest run server/src/__tests__/issue-execution-policy-routes.test.ts` - 12 tests passed locally.
- Live API retest of the same standard review policy shape against a routine issue returned HTTP 200 and stored the normalized `executionPolicy`.
- PR CI observed green for Build, Typecheck + Release Registry, e2e, General tests server shard 1/3, General tests server shard 2/3, workspaces-a, workspaces-b, and serialized server suite shards 1/4 through 4/4 before this PR-body update. Remaining long-running checks should be read from the current GitHub status.

## Risks

Low risk. The code diff is test-only and does not change runtime behavior. The main residual risk is that the original HTTP 500 came from a live-only transient condition or log-retention gap that this route-level test cannot directly replay.

## Model Used

OpenAI Codex, GPT-5 coding agent, tool-assisted local shell and GitHub CLI workflow.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
