### PR TITLE
fix: scope implicit comment reopen to session actors

### DIFF
--- a/server/src/__tests__/issue-comment-reopen-routes.test.ts
+++ b/server/src/__tests__/issue-comment-reopen-routes.test.ts
@@ -226,6 +226,17 @@ function agentActor(agentId = "22222222-2222-4222-8222-222222222222") {
   };
 }
 
+function boardActor(source: "session" | "local_implicit" = "session", runId?: string) {
+  return {
+    type: "board",
+    userId: "local-board",
+    companyIds: ["company-1"],
+    source,
+    isInstanceAdmin: false,
+    ...(runId ? { runId } : {}),
+  };
+}
+
 async function waitForWakeup(assertion: () => void) {
   await vi.waitFor(assertion);
 }
@@ -402,7 +413,7 @@ describe.sequential("issue comment reopen routes", () => {
       ...patch,
     }));
 
-    const res = await request(await installActor(createApp()))
+    const res = await request(await installActor(createApp(), boardActor("session")))
       .patch("/api/issues/11111111-1111-4111-8111-111111111111")
       .send({ comment: "hello", assigneeAgentId: "33333333-3333-4333-8333-333333333333" });
 
@@ -514,7 +525,7 @@ describe.sequential("issue comment reopen routes", () => {
       ...patch,
     }));
 
-    const res = await request(await installActor(createApp()))
+    const res = await request(await installActor(createApp(), boardActor("session")))
       .post("/api/issues/11111111-1111-4111-8111-111111111111/comments")
       .send({ body: "hello" });
 
@@ -822,7 +833,7 @@ describe.sequential("issue comment reopen routes", () => {
       ...patch,
     }));
 
-    const res = await request(await installActor(createApp()))
+    const res = await request(await installActor(createApp(), boardActor("session")))
       .post("/api/issues/11111111-1111-4111-8111-111111111111/comments")
       .send({ body: "please continue" });
 
@@ -1153,7 +1164,7 @@ describe.sequential("issue comment reopen routes", () => {
     );
   });
 
-  it("still implicitly reopens done issues via POST comments when the comment runId differs from the issue's owning run", async () => {
+  it("still implicitly reopens done issues via session POST comments when the comment runId differs from the issue's owning run", async () => {
     mockIssueService.getById.mockResolvedValue({
       ...makeIssue("done"),
       checkoutRunId: "run-owning",
@@ -1164,14 +1175,7 @@ describe.sequential("issue comment reopen routes", () => {
       ...patch,
     }));
 
-    const res = await request(await installActor(createApp(), {
-      type: "board",
-      userId: "local-board",
-      companyIds: ["company-1"],
-      source: "local_implicit",
-      isInstanceAdmin: false,
-      runId: "run-different",
-    }))
+    const res = await request(await installActor(createApp(), boardActor("session", "run-different")))
       .post("/api/issues/11111111-1111-4111-8111-111111111111/comments")
       .send({ body: "Real human follow-up — please reopen" });
 
@@ -1179,6 +1183,34 @@ describe.sequential("issue comment reopen routes", () => {
     expect(mockIssueService.update).toHaveBeenCalledWith(
       "11111111-1111-4111-8111-111111111111",
       { status: "todo" },
+    );
+  });
+
+  it("does not implicitly reopen done issues via local implicit POST comments when the comment runId differs from the issue's owning run", async () => {
+    mockIssueService.getById.mockResolvedValue({
+      ...makeIssue("done"),
+      checkoutRunId: "run-owning",
+      executionRunId: "run-owning",
+    });
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
+      ...makeIssue("done"),
+      ...patch,
+    }));
+
+    const res = await request(await installActor(createApp(), boardActor("local_implicit", "run-different")))
+      .post("/api/issues/11111111-1111-4111-8111-111111111111/comments")
+      .send({ body: "Local implicit bookkeeping note" });
+
+    expect(res.status).toBe(201);
+    expect(mockIssueService.update).not.toHaveBeenCalledWith(
+      "11111111-1111-4111-8111-111111111111",
+      expect.objectContaining({ status: "todo" }),
+    );
+    expect(mockHeartbeatService.wakeup).not.toHaveBeenCalledWith(
+      "22222222-2222-4222-8222-222222222222",
+      expect.objectContaining({
+        reason: "issue_reopened_via_comment",
+      }),
     );
   });
 
@@ -1219,7 +1251,7 @@ describe.sequential("issue comment reopen routes", () => {
       ...patch,
     }));
 
-    const res = await request(await installActor(createApp()))
+    const res = await request(await installActor(createApp(), boardActor("session")))
       .patch("/api/issues/11111111-1111-4111-8111-111111111111")
       .send({ comment: "please continue" });
 

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -874,6 +874,7 @@ function shouldImplicitlyMoveCommentedIssueToTodo(input: {
   assigneeAgentId: string | null | undefined;
   actorType: "agent" | "user";
   actorId: string;
+  actorSource: "agent_key" | "agent_jwt" | "local_implicit" | "session" | "board_key" | "cloud_tenant";
   actorRunId: string | null | undefined;
   checkoutRunId: string | null | undefined;
   executionRunId: string | null | undefined;
@@ -894,6 +895,7 @@ function shouldImplicitlyMoveCommentedIssueToTodo(input: {
   // Only human comments should implicitly reopen finished work.
   // Agent-authored comments remain communicative unless reopen was explicit.
   if (input.actorType !== "user") return false;
+  if (input.actorSource !== "session") return false;
   if (!isClosedIssueStatus(input.issueStatus) && input.issueStatus !== "blocked") return false;
   if (typeof input.assigneeAgentId !== "string" || input.assigneeAgentId.length === 0) return false;
   return true;
@@ -5864,6 +5866,7 @@ export function issueRoutes(
             assigneeAgentId: requestedAssigneeAgentId,
             actorType: actor.actorType,
             actorId: actor.actorId,
+            actorSource: actor.actorSource,
             actorRunId: actor.runId,
             checkoutRunId: existing.checkoutRunId,
             executionRunId: existing.executionRunId,
@@ -7679,6 +7682,7 @@ export function issueRoutes(
           assigneeAgentId: issue.assigneeAgentId,
           actorType: actor.actorType,
           actorId: actor.actorId,
+          actorSource: actor.actorSource,
           actorRunId: actor.runId,
           checkoutRunId: issue.checkoutRunId,
           executionRunId: issue.executionRunId,


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Issues are the core work objects that humans and agents coordinate around.
> - Closed and blocked issues can be implicitly moved back to todo when a human comments and an agent is assigned.
> - Local trusted requests without an agent token can be attributed to the local implicit board principal, even when they are automation or bookkeeping comments.
> - The previous implicit reopen guard only checked that the normalized actor type was a user, so local implicit comments could reopen finished issues and wake the assignee again.
> - This pull request threads actor source into the implicit reopen guard and only allows session-backed user comments to trigger implicit reopen.
> - The benefit is that local implicit comments stay communicative and inert while real browser-session human comments still reopen assigned work.

## Linked Issues or Issue Description

Refs #3817.

Related prior work found during duplicate search:

- Related open PR: #6778
- Related closed PR: #8142

## What Changed

- Threaded `actorSource` into `shouldImplicitlyMoveCommentedIssueToTodo` from both PATCH issue comments and POST issue comments.
- Required `actorSource === "session"` for implicit comment reopen while leaving explicit `reopen: true` / `resume: true` behavior outside this guard.
- Updated route tests so positive implicit reopen cases use an explicit session actor.
- Added a regression test proving a `local_implicit` POST comment on a done issue does not move it back to `todo` and does not enqueue an `issue_reopened_via_comment` wake.

## Verification

- Failing-test-first evidence before the production guard: `pnpm vitest run server/src/__tests__/issue-comment-reopen-routes.test.ts` failed on the new local implicit regression because `update(... { status: "todo" })` was called.
- After the guard: `pnpm vitest run server/src/__tests__/issue-comment-reopen-routes.test.ts` passed locally: 1 file, 73 tests.

## Risks

- Low risk: this only narrows implicit comment reopen; explicit reopen/resume requests still flow through the existing explicit path.
- Behavior shift: non-session user sources such as local implicit, board key, and cloud tenant no longer implicitly reopen closed or blocked assigned issues by comment alone.
- Session human comments are covered by positive tests and still reopen assigned closed/blocked issues.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex via Paperclip Codex Code Executor, model `gpt-5.5`, with tool use for local file editing, terminal verification, GitHub CLI operations, and PR creation.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge