### PR TITLE
fix(instructions): self-heal managed agent instructions before each run

### DIFF
--- a/packages/db/src/migrations/0126_agent_managed_instructions_snapshot.sql
+++ b/packages/db/src/migrations/0126_agent_managed_instructions_snapshot.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "agents" ADD COLUMN IF NOT EXISTS "managed_instructions_snapshot" jsonb;

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -883,6 +883,13 @@
       "when": 1782440100000,
       "tag": "0125_environment_custom_image_templates",
       "breakpoints": true
+    },
+    {
+      "idx": 126,
+      "version": "7",
+      "when": 1782440200000,
+      "tag": "0126_agent_managed_instructions_snapshot",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/agents.ts
+++ b/packages/db/src/schema/agents.ts
@@ -33,6 +33,11 @@ export const agents = pgTable(
     pausedAt: timestamp("paused_at", { withTimezone: true }),
     errorReason: text("error_reason"),
     permissions: jsonb("permissions").$type<Record<string, unknown>>().notNull().default({}),
+    // Durable copy of a managed instructions bundle so a run can re-materialize
+    // it after the (possibly ephemeral) instance-root disk is wiped. Null for
+    // agents without a managed bundle.
+    managedInstructionsSnapshot: jsonb("managed_instructions_snapshot")
+      .$type<{ entryFile: string; files: Record<string, string> }>(),
     lastHeartbeatAt: timestamp("last_heartbeat_at", { withTimezone: true }),
     metadata: jsonb("metadata").$type<Record<string, unknown>>(),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),

--- a/server/src/__tests__/agent-instructions-selfheal.test.ts
+++ b/server/src/__tests__/agent-instructions-selfheal.test.ts
@@ -1,0 +1,201 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { agentInstructionsService } from "../services/agent-instructions.js";
+
+type TestAgent = {
+  id: string;
+  companyId: string;
+  name: string;
+  role?: string | null;
+  adapterConfig: Record<string, unknown>;
+};
+
+async function makeTempDir(prefix: string) {
+  return fs.mkdtemp(path.join(os.tmpdir(), prefix));
+}
+
+function managedRootFor(paperclipHome: string) {
+  return path.join(
+    paperclipHome,
+    "instances",
+    "test-instance",
+    "companies",
+    "company-1",
+    "agents",
+    "agent-1",
+    "instructions",
+  );
+}
+
+function makeManagedAgent(managedRoot: string, role = "general"): TestAgent {
+  return {
+    id: "agent-1",
+    companyId: "company-1",
+    name: "Agent 1",
+    role,
+    adapterConfig: {
+      instructionsBundleMode: "managed",
+      instructionsRootPath: managedRoot,
+      instructionsEntryFile: "AGENTS.md",
+      instructionsFilePath: path.join(managedRoot, "AGENTS.md"),
+    },
+  };
+}
+
+describe("agent instructions self-heal (ensureManagedInstructionsMaterialized)", () => {
+  const originalPaperclipHome = process.env.PAPERCLIP_HOME;
+  const originalPaperclipInstanceId = process.env.PAPERCLIP_INSTANCE_ID;
+  const cleanupDirs = new Set<string>();
+
+  afterEach(async () => {
+    if (originalPaperclipHome === undefined) delete process.env.PAPERCLIP_HOME;
+    else process.env.PAPERCLIP_HOME = originalPaperclipHome;
+    if (originalPaperclipInstanceId === undefined) delete process.env.PAPERCLIP_INSTANCE_ID;
+    else process.env.PAPERCLIP_INSTANCE_ID = originalPaperclipInstanceId;
+
+    await Promise.all([...cleanupDirs].map(async (dir) => {
+      await fs.rm(dir, { recursive: true, force: true });
+      cleanupDirs.delete(dir);
+    }));
+  });
+
+  async function setupHome() {
+    const paperclipHome = await makeTempDir("paperclip-selfheal-home-");
+    cleanupDirs.add(paperclipHome);
+    process.env.PAPERCLIP_HOME = paperclipHome;
+    process.env.PAPERCLIP_INSTANCE_ID = "test-instance";
+    return paperclipHome;
+  }
+
+  it("regenerates the default bundle by role when the managed dir was wiped", async () => {
+    const paperclipHome = await setupHome();
+    const managedRoot = managedRootFor(paperclipHome);
+    const agent = makeManagedAgent(managedRoot, "ceo");
+    const loadDefaults = vi.fn(async (role: string) => ({
+      "AGENTS.md": `# Default ${role} persona\n`,
+    }));
+
+    const svc = agentInstructionsService();
+    const result = await svc.ensureManagedInstructionsMaterialized(agent, {
+      durableSnapshot: null,
+      loadDefaults,
+    });
+
+    expect(result.status).toBe("restored");
+    expect(result.source).toBe("default");
+    expect(result.regenerated).toBe(true);
+    // Observability contract: a restoration surfaces a warning the run path
+    // turns into a log/run-event signal (so the underlying wipe is detectable).
+    expect(result.warnings.length).toBeGreaterThan(0);
+    expect(loadDefaults).toHaveBeenCalledWith("ceo");
+    await expect(fs.readFile(path.join(managedRoot, "AGENTS.md"), "utf8")).resolves.toBe(
+      "# Default ceo persona\n",
+    );
+    // The restored content becomes the durable snapshot so later runs are consistent.
+    expect(result.snapshotToPersist).not.toBeNull();
+    expect(result.snapshotToPersist?.files["AGENTS.md"]).toBe("# Default ceo persona\n");
+  });
+
+  it("restores customized content from the durable snapshot when the managed dir was wiped", async () => {
+    const paperclipHome = await setupHome();
+    const managedRoot = managedRootFor(paperclipHome);
+    const agent = makeManagedAgent(managedRoot);
+    const loadDefaults = vi.fn(async () => ({ "AGENTS.md": "# Default\n" }));
+
+    const svc = agentInstructionsService();
+    const result = await svc.ensureManagedInstructionsMaterialized(agent, {
+      durableSnapshot: {
+        entryFile: "AGENTS.md",
+        files: {
+          "AGENTS.md": "# Custom hand-edited persona\n",
+          "TOOLS.md": "## custom tools\n",
+        },
+      },
+      loadDefaults,
+    });
+
+    expect(result.status).toBe("restored");
+    expect(result.source).toBe("durable");
+    // Durable content preferred: the default template must not be consulted.
+    expect(loadDefaults).not.toHaveBeenCalled();
+    await expect(fs.readFile(path.join(managedRoot, "AGENTS.md"), "utf8")).resolves.toBe(
+      "# Custom hand-edited persona\n",
+    );
+    await expect(fs.readFile(path.join(managedRoot, "TOOLS.md"), "utf8")).resolves.toBe(
+      "## custom tools\n",
+    );
+    // Already durable: nothing new to persist.
+    expect(result.snapshotToPersist).toBeNull();
+  });
+
+  it("leaves an existing managed bundle in place and captures a durable snapshot when none exists", async () => {
+    const paperclipHome = await setupHome();
+    const managedRoot = managedRootFor(paperclipHome);
+    await fs.mkdir(managedRoot, { recursive: true });
+    await fs.writeFile(path.join(managedRoot, "AGENTS.md"), "# On-disk custom persona\n", "utf8");
+    const agent = makeManagedAgent(managedRoot);
+    const loadDefaults = vi.fn(async () => ({ "AGENTS.md": "# Default\n" }));
+
+    const svc = agentInstructionsService();
+    const result = await svc.ensureManagedInstructionsMaterialized(agent, {
+      durableSnapshot: null,
+      loadDefaults,
+    });
+
+    expect(result.status).toBe("present");
+    expect(result.source).toBe("disk");
+    expect(result.regenerated).toBe(false);
+    expect(loadDefaults).not.toHaveBeenCalled();
+    // Existing on-disk content is captured durably so a future wipe can restore it.
+    expect(result.snapshotToPersist?.files["AGENTS.md"]).toBe("# On-disk custom persona\n");
+  });
+
+  it("does not re-capture when the durable snapshot already matches disk", async () => {
+    const paperclipHome = await setupHome();
+    const managedRoot = managedRootFor(paperclipHome);
+    await fs.mkdir(managedRoot, { recursive: true });
+    await fs.writeFile(path.join(managedRoot, "AGENTS.md"), "# Stable persona\n", "utf8");
+    const agent = makeManagedAgent(managedRoot);
+
+    const svc = agentInstructionsService();
+    const result = await svc.ensureManagedInstructionsMaterialized(agent, {
+      durableSnapshot: { entryFile: "AGENTS.md", files: { "AGENTS.md": "# Stable persona\n" } },
+      loadDefaults: async () => ({ "AGENTS.md": "# Default\n" }),
+    });
+
+    expect(result.status).toBe("present");
+    expect(result.snapshotToPersist).toBeNull();
+  });
+
+  it("is a no-op for non-managed (external) agents with a missing file", async () => {
+    const paperclipHome = await setupHome();
+    const missingExternal = path.join(paperclipHome, "external", "AGENTS.md");
+    const agent: TestAgent = {
+      id: "agent-1",
+      companyId: "company-1",
+      name: "Agent 1",
+      role: "general",
+      adapterConfig: {
+        instructionsBundleMode: "external",
+        instructionsRootPath: path.dirname(missingExternal),
+        instructionsEntryFile: "AGENTS.md",
+        instructionsFilePath: missingExternal,
+      },
+    };
+    const loadDefaults = vi.fn(async () => ({ "AGENTS.md": "# Default\n" }));
+
+    const svc = agentInstructionsService();
+    const result = await svc.ensureManagedInstructionsMaterialized(agent, {
+      durableSnapshot: null,
+      loadDefaults,
+    });
+
+    expect(result.status).toBe("skipped");
+    expect(loadDefaults).not.toHaveBeenCalled();
+    expect(result.snapshotToPersist).toBeNull();
+    // Must not fabricate a file for a self-hosted user's optional external bundle.
+    await expect(fs.stat(missingExternal)).rejects.toThrow();
+  });
+});

--- a/server/src/services/agent-instructions.ts
+++ b/server/src/services/agent-instructions.ts
@@ -34,6 +34,40 @@ type AgentLike = {
   adapterConfig: unknown;
 };
 
+/**
+ * A durable, storage-backed copy of a managed instructions bundle. Managed
+ * bundle files otherwise live only on the (possibly ephemeral) instance-root
+ * disk, so persisting this snapshot lets a run re-materialize the exact bundle
+ * after the disk is wiped (e.g. an emptyDir pod restart), preserving both the
+ * default persona and any hand-edited customizations.
+ */
+export type ManagedInstructionsSnapshot = {
+  entryFile: string;
+  files: Record<string, string>;
+};
+
+type EnsureManagedAgent = AgentLike & { role?: string | null };
+
+type EnsureManagedInstructionsInput = {
+  /** The durable snapshot persisted from a previous materialize/run, if any. */
+  durableSnapshot?: ManagedInstructionsSnapshot | null;
+  /** Loads the default bundle for the agent role as the guaranteed fallback. */
+  loadDefaults: (role: string) => Promise<Record<string, string>>;
+};
+
+type EnsureManagedInstructionsResult = {
+  /** "skipped" for non-managed agents, "present" when disk already had it, "restored" when re-materialized. */
+  status: "skipped" | "present" | "restored";
+  /** Where the on-disk content ended up coming from. */
+  source: "disk" | "durable" | "default" | null;
+  /** True only when files were (re)written because the entry file was missing. */
+  regenerated: boolean;
+  entryPath: string | null;
+  /** A snapshot the caller should durably persist (null when nothing changed). */
+  snapshotToPersist: ManagedInstructionsSnapshot | null;
+  warnings: string[];
+};
+
 type AgentInstructionsFileSummary = {
   path: string;
   size: number;
@@ -722,6 +756,137 @@ export function agentInstructionsService() {
     return { bundle, adapterConfig };
   }
 
+  async function readManagedBundleFromDisk(
+    rootPath: string,
+    entryFile: string,
+  ): Promise<ManagedInstructionsSnapshot> {
+    const relativePaths = await listFilesRecursive(rootPath);
+    const entries = await Promise.all(
+      relativePaths.map(async (relativePath) => {
+        const absolutePath = resolvePathWithinRoot(rootPath, relativePath);
+        const content = await fs.readFile(absolutePath, "utf8");
+        return [relativePath, content] as const;
+      }),
+    );
+    return { entryFile, files: Object.fromEntries(entries) };
+  }
+
+  async function writeSnapshotToDisk(rootPath: string, snapshot: ManagedInstructionsSnapshot) {
+    await fs.mkdir(rootPath, { recursive: true });
+    for (const [relativePath, content] of Object.entries(snapshot.files)) {
+      const absolutePath = resolvePathWithinRoot(rootPath, relativePath);
+      const existing = await statIfExists(absolutePath);
+      // Never clobber a file that survived a partial wipe.
+      if (existing?.isFile()) continue;
+      await fs.mkdir(path.dirname(absolutePath), { recursive: true });
+      await fs.writeFile(absolutePath, content, "utf8");
+    }
+    // Guarantee the configured entry file exists even if the snapshot used a
+    // different entry name (or was empty).
+    const entryPath = resolvePathWithinRoot(rootPath, snapshot.entryFile);
+    const entryStat = await statIfExists(entryPath);
+    if (!entryStat?.isFile()) {
+      const fallback = snapshot.files[snapshot.entryFile]
+        ?? snapshot.files[ENTRY_FILE_DEFAULT]
+        ?? Object.values(snapshot.files)[0]
+        ?? "";
+      await fs.mkdir(path.dirname(entryPath), { recursive: true });
+      await fs.writeFile(entryPath, fallback, "utf8");
+    }
+  }
+
+  /**
+   * Self-healing guard for the run path: idempotently ensures a MANAGED agent's
+   * instructions bundle exists on disk before the adapter reads it. Managed
+   * bundle files live under the (possibly ephemeral) instance root, so a pod
+   * restart on an emptyDir wipes them and the run would otherwise inject no
+   * persona/tools/hiring guidance. When the entry file is missing this restores
+   * the bundle from the durable snapshot (preserving hand edits) or, as a
+   * guaranteed fallback, regenerates the role default template. It never fails a
+   * run and never touches non-managed / external bundles.
+   */
+  async function ensureManagedInstructionsMaterialized(
+    agent: EnsureManagedAgent,
+    input: EnsureManagedInstructionsInput,
+  ): Promise<EnsureManagedInstructionsResult> {
+    const state = deriveBundleState(agent);
+    // Only ever self-heal MANAGED bundles. External/legacy bundles may
+    // legitimately point instructionsFilePath at a user-supplied optional file
+    // that we must never fabricate or overwrite.
+    if (state.mode !== "managed") {
+      return {
+        status: "skipped",
+        source: null,
+        regenerated: false,
+        entryPath: state.resolvedEntryPath,
+        snapshotToPersist: null,
+        warnings: [],
+      };
+    }
+
+    const managedRoot = resolveManagedInstructionsRoot(agent);
+    const entryFile = state.entryFile || ENTRY_FILE_DEFAULT;
+    const entryPath = resolvePathWithinRoot(managedRoot, entryFile);
+    const durableSnapshot = input.durableSnapshot ?? null;
+
+    const entryContent = await fs.readFile(entryPath, "utf8").catch(() => null);
+    if (entryContent !== null) {
+      // Bundle is present on disk. Opportunistically capture it durably so a
+      // future disk wipe can restore the exact content (including hand edits).
+      const needsCapture =
+        !durableSnapshot
+        || durableSnapshot.entryFile !== entryFile
+        || durableSnapshot.files[entryFile] !== entryContent;
+      const snapshotToPersist = needsCapture
+        ? await readManagedBundleFromDisk(managedRoot, entryFile)
+        : null;
+      return {
+        status: "present",
+        source: "disk",
+        regenerated: false,
+        entryPath,
+        snapshotToPersist,
+        warnings: [],
+      };
+    }
+
+    // Entry file missing: the managed bundle disk was wiped. Restore it,
+    // preferring durable content (preserves customizations) and falling back to
+    // the role default template (always available) so recovery never fails.
+    let restore: ManagedInstructionsSnapshot;
+    let source: "durable" | "default";
+    if (durableSnapshot && Object.keys(durableSnapshot.files).length > 0) {
+      restore = durableSnapshot;
+      source = "durable";
+    } else {
+      const role = typeof agent.role === "string" && agent.role.trim().length > 0
+        ? agent.role
+        : "general";
+      const files = await input.loadDefaults(role);
+      restore = { entryFile, files };
+      source = "default";
+    }
+
+    await writeSnapshotToDisk(managedRoot, restore);
+
+    // Persist the restored snapshot unless it already came from the durable
+    // store (in which case it is already persisted).
+    const snapshotToPersist = source === "durable"
+      ? null
+      : await readManagedBundleFromDisk(managedRoot, entryFile);
+
+    return {
+      status: "restored",
+      source,
+      regenerated: true,
+      entryPath,
+      snapshotToPersist,
+      warnings: [
+        `Re-materialized missing managed instructions bundle for agent ${agent.id} from ${source} source.`,
+      ],
+    };
+  }
+
   return {
     getBundle,
     readFile,
@@ -731,5 +896,6 @@ export function agentInstructionsService() {
     exportFiles,
     ensureManagedBundle: ensureWritableBundle,
     materializeManagedBundle,
+    ensureManagedInstructionsMaterialized,
   };
 }

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -123,6 +123,11 @@ import {
   refreshIssueContinuationSummary,
 } from "./issue-continuation-summary.js";
 import { buildPlanReviewContext } from "./plan-review-context.js";
+import { agentInstructionsService } from "./agent-instructions.js";
+import {
+  loadDefaultAgentInstructionsBundle,
+  resolveDefaultAgentInstructionsBundleRole,
+} from "./default-agent-instructions.js";
 import { executionWorkspaceService, mergeExecutionWorkspaceConfig } from "./execution-workspaces.js";
 import { workspaceOperationService, type WorkspaceOperationRecorder } from "./workspace-operations.js";
 import { isProcessGroupAlive, terminateLocalService } from "./local-service-supervisor.js";
@@ -10650,6 +10655,61 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       };
 
       const adapter = getServerAdapter(agent.adapterType);
+      // Self-heal a managed agent's instructions bundle before the adapter reads
+      // it. The managed bundle lives under the (possibly ephemeral) instance
+      // root, so an app-pod restart on an emptyDir wipes it; without this the run
+      // would inject no persona/tools/hiring guidance. The guard self-gates: it
+      // no-ops for any agent whose instructions bundle is not in managed mode, so
+      // external/legacy bundles are never touched. Restore prefers the durable
+      // snapshot (keeps hand edits), falls back to the role default template, and
+      // is best-effort: it never fails the run.
+      try {
+        const ensured = await agentInstructionsService().ensureManagedInstructionsMaterialized(agent, {
+          durableSnapshot: agent.managedInstructionsSnapshot ?? null,
+          loadDefaults: (role) =>
+            loadDefaultAgentInstructionsBundle(resolveDefaultAgentInstructionsBundleRole(role)),
+        });
+        if (ensured.snapshotToPersist) {
+          await db
+            .update(agents)
+            .set({ managedInstructionsSnapshot: ensured.snapshotToPersist, updatedAt: new Date() })
+            .where(eq(agents.id, agent.id));
+        }
+        if (ensured.status === "restored") {
+          // Observability: the bundle was missing on disk and had to be
+          // re-materialized. The run proceeds normally WITH instructions; this
+          // signal lets us detect the underlying instance-root wipe.
+          logger.warn(
+            {
+              companyId: agent.companyId,
+              agentId: agent.id,
+              runId: run.id,
+              adapterType: agent.adapterType,
+              source: ensured.source,
+            },
+            "re-materialized missing managed instructions bundle before run",
+          );
+          await appendRunEvent(currentRun, seq++, {
+            eventType: "instructions.rematerialized",
+            stream: "system",
+            level: "warn",
+            message: "Re-materialized missing managed instructions bundle before run",
+            payload: { source: ensured.source, entryPath: ensured.entryPath },
+          });
+        }
+      } catch (err) {
+        // Never let the self-heal guard turn a recoverable situation into a
+        // user-visible failure. Log and continue; the adapter still runs.
+        logger.warn(
+          {
+            companyId: agent.companyId,
+            agentId: agent.id,
+            runId: run.id,
+            err: err instanceof Error ? err.message : String(err),
+          },
+          "failed to ensure managed instructions bundle; continuing without self-heal",
+        );
+      }
       const authToken = adapter.supportsLocalAgentJwt
         ? createLocalAgentJwt(agent.id, agent.companyId, agent.adapterType, run.id)
         : null;


### PR DESCRIPTION
## Symptom

After an app-pod restart, managed agents run with **no persona/tools/hiring guidance** and no error surfaces. Every managed agent silently degrades to a "naked" run.

## Root cause

A managed agent's instructions bundle (persona + tools + hiring guidance) is materialized to the instance-root disk **only** at agent creation/import/plugin-reconcile. The run path never re-materializes it. When the instance root is an ephemeral volume (e.g. an `emptyDir` pod mount), a restart wipes the bundle. The adapter's `fs.readFile` then `ENOENT`s and the run proceeds with no instructions, silently.

## Fix (resilience-first, never fail a run)

- **`agentInstructions.ensureManagedInstructionsMaterialized()`** — a new managed-only, idempotent, self-gating guard. It no-ops for any agent whose instructions bundle is not in `managed` mode, so external/legacy bundles are never fabricated or overwritten. If the managed bundle is present it opportunistically captures a durable snapshot; if the entry file is missing it restores from the durable snapshot (preserving hand edits) or, as a guaranteed fallback, regenerates the role-default template.
- **Durable content store** — a new nullable `agents.managed_instructions_snapshot` jsonb column so customized bundles survive a wipe too. The migration adds **one nullable column** (safe, additive).
- **Heartbeat run path** — calls the guard before the adapter reads the bundle, persists the snapshot, and on a restore emits an observability `warn` + an `instructions.rematerialized` run event so the underlying instance-root wipe is detectable. Wrapped in `try/catch`: the self-heal can never turn a recoverable state into a user-visible failure.
- Non-managed / external bundles are untouched.

## Tests

`server/src/__tests__/agent-instructions-selfheal.test.ts` (5 tests): non-managed skip, present-on-disk capture, restore-from-durable-snapshot (preserves hand edits), regenerate-from-role-default fallback, and idempotency. All pass; server typecheck is clean.