### PR TITLE
Fix monitored continuation recovery

### DIFF
--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -3179,7 +3179,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
   });
 
   it("does not requeue continuation recovery for in-progress issues with a future monitor", async () => {
-    const monitorNextCheckAt = new Date("2026-07-29T14:00:00.000Z");
+    const monitorNextCheckAt = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000);
     const { agentId, issueId, runId } = await seedStrandedIssueFixture({
       status: "in_progress",
       runStatus: "failed",
@@ -3214,6 +3214,54 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
 
     const runs = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.agentId, agentId));
     expect(runs.map((run) => run.id)).toEqual([runId]);
+  });
+
+  it("requeues continuation recovery when a future issue monitor has exhausted max attempts", async () => {
+    const monitorNextCheckAt = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000);
+    const { agentId, issueId, runId } = await seedStrandedIssueFixture({
+      status: "in_progress",
+      runStatus: "failed",
+      retryReason: "issue_continuation_needed",
+      runErrorCode: "adapter_failed",
+      runError: "ssh: connection reset",
+      monitorNextCheckAt,
+      executionPolicy: {
+        monitor: {
+          nextCheckAt: monitorNextCheckAt.toISOString(),
+          maxAttempts: 0,
+        },
+      },
+      executionState: {
+        monitor: {
+          status: "scheduled",
+          nextCheckAt: monitorNextCheckAt.toISOString(),
+          attemptCount: 0,
+        },
+      },
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(result.continuationRequeued).toBe(1);
+    expect(result.escalated).toBe(0);
+    expect(result.skipped).toBe(0);
+    expect(result.issueIds).toEqual([issueId]);
+
+    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(issue?.status).toBe("in_progress");
+    expect(issue?.monitorNextCheckAt?.toISOString()).toBe(monitorNextCheckAt.toISOString());
+
+    const runs = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.agentId, agentId));
+    expect(runs).toHaveLength(2);
+    const retryRun = runs.find((row) => row.id !== runId);
+    expect(retryRun?.contextSnapshot as Record<string, unknown> | undefined).toMatchObject({
+      issueId,
+      retryReason: "issue_continuation_needed",
+      source: "issue.continuation_recovery",
+    });
+    if (retryRun) {
+      await waitForRunToSettle(heartbeat, retryRun.id);
+    }
   });
 
   it("escalates after repeated adapter_failed continuation retries with the cause in the comment", async () => {

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -651,6 +651,9 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     livenessState?: "completed" | "advanced" | "plan_only" | "empty_response" | "blocked" | "failed" | "needs_followup" | null;
     runErrorCode?: string | null;
     runError?: string | null;
+    monitorNextCheckAt?: Date | null;
+    executionPolicy?: Record<string, unknown> | null;
+    executionState?: Record<string, unknown> | null;
   }) {
     const companyId = randomUUID();
     const agentId = randomUUID();
@@ -749,6 +752,9 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
         assigneeUserId: input.assignToUser ? "user-1" : null,
         checkoutRunId: input.status === "in_progress" ? runId : null,
         executionRunId: null,
+        executionPolicy: input.executionPolicy ?? null,
+        executionState: input.executionState ?? null,
+        monitorNextCheckAt: input.monitorNextCheckAt ?? null,
         issueNumber: input.activePauseHold ? 2 : 1,
         identifier: `${issuePrefix}-${input.activePauseHold ? 2 : 1}`,
         startedAt: input.status === "in_progress" ? now : null,
@@ -3170,6 +3176,44 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     if (retryRun) {
       await waitForRunToSettle(heartbeat, retryRun.id);
     }
+  });
+
+  it("does not requeue continuation recovery for in-progress issues with a future monitor", async () => {
+    const monitorNextCheckAt = new Date("2026-07-29T14:00:00.000Z");
+    const { agentId, issueId, runId } = await seedStrandedIssueFixture({
+      status: "in_progress",
+      runStatus: "failed",
+      retryReason: "issue_continuation_needed",
+      runErrorCode: "adapter_failed",
+      runError: "ssh: connection reset",
+      monitorNextCheckAt,
+      executionPolicy: {
+        monitor: {
+          nextCheckAt: monitorNextCheckAt.toISOString(),
+        },
+      },
+      executionState: {
+        monitor: {
+          status: "scheduled",
+          nextCheckAt: monitorNextCheckAt.toISOString(),
+          attemptCount: 0,
+        },
+      },
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(result.continuationRequeued).toBe(0);
+    expect(result.escalated).toBe(0);
+    expect(result.skipped).toBe(1);
+    expect(result.issueIds).toEqual([]);
+
+    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(issue?.status).toBe("in_progress");
+    expect(issue?.monitorNextCheckAt?.toISOString()).toBe(monitorNextCheckAt.toISOString());
+
+    const runs = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.agentId, agentId));
+    expect(runs.map((run) => run.id)).toEqual([runId]);
   });
 
   it("escalates after repeated adapter_failed continuation retries with the cause in the comment", async () => {

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -130,6 +130,40 @@ type SuccessfulRunHandoffRecoveryEvidence = {
   maxHandoffAttempts: number;
 };
 
+function readMonitorRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null;
+}
+
+function readDateMs(value: unknown): number | null {
+  if (!(typeof value === "string" || value instanceof Date)) return null;
+  const date = value instanceof Date ? value : new Date(value);
+  const time = date.getTime();
+  return Number.isNaN(time) ? null : time;
+}
+
+function readPositiveInteger(value: unknown): number | null {
+  return typeof value === "number" && Number.isInteger(value) && value > 0 ? value : null;
+}
+
+function hasScheduledIssueMonitor(issue: typeof issues.$inferSelect, nowMs = Date.now()): boolean {
+  const nextCheckAtMs = readDateMs(issue.monitorNextCheckAt);
+  if (nextCheckAtMs === null || nextCheckAtMs <= nowMs) return false;
+
+  const policyMonitor = readMonitorRecord(readMonitorRecord(issue.executionPolicy)?.monitor);
+  const stateMonitor = readMonitorRecord(readMonitorRecord(issue.executionState)?.monitor);
+  const timeoutAtMs = readDateMs(policyMonitor?.timeoutAt ?? stateMonitor?.timeoutAt);
+  if (timeoutAtMs !== null && timeoutAtMs <= nowMs) return false;
+
+  const maxAttempts = readPositiveInteger(policyMonitor?.maxAttempts ?? stateMonitor?.maxAttempts);
+  const stateAttemptCount = readPositiveInteger(stateMonitor?.attemptCount) ?? 0;
+  const attemptCount = issue.monitorAttemptCount ?? stateAttemptCount;
+  if (maxAttempts !== null && attemptCount >= maxAttempts) return false;
+
+  return true;
+}
+
 type WatchdogDecisionActor =
   | { type: "board"; userId?: string | null; runId?: string | null }
   | { type: "agent"; agentId?: string | null; runId?: string | null }
@@ -2761,6 +2795,11 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       }
 
       if (await isAutomaticRecoverySuppressedByPauseHold(db, issue.companyId, issue.id, treeControlSvc)) {
+        result.skipped += 1;
+        continue;
+      }
+
+      if (issue.status === "in_progress" && hasScheduledIssueMonitor(issue)) {
         result.skipped += 1;
         continue;
       }

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -143,8 +143,8 @@ function readDateMs(value: unknown): number | null {
   return Number.isNaN(time) ? null : time;
 }
 
-function readPositiveInteger(value: unknown): number | null {
-  return typeof value === "number" && Number.isInteger(value) && value > 0 ? value : null;
+function readNonNegativeInteger(value: unknown): number | null {
+  return typeof value === "number" && Number.isInteger(value) && value >= 0 ? value : null;
 }
 
 function hasScheduledIssueMonitor(issue: typeof issues.$inferSelect, nowMs = Date.now()): boolean {
@@ -156,8 +156,8 @@ function hasScheduledIssueMonitor(issue: typeof issues.$inferSelect, nowMs = Dat
   const timeoutAtMs = readDateMs(policyMonitor?.timeoutAt ?? stateMonitor?.timeoutAt);
   if (timeoutAtMs !== null && timeoutAtMs <= nowMs) return false;
 
-  const maxAttempts = readPositiveInteger(policyMonitor?.maxAttempts ?? stateMonitor?.maxAttempts);
-  const stateAttemptCount = readPositiveInteger(stateMonitor?.attemptCount) ?? 0;
+  const maxAttempts = readNonNegativeInteger(policyMonitor?.maxAttempts ?? stateMonitor?.maxAttempts);
+  const stateAttemptCount = readNonNegativeInteger(stateMonitor?.attemptCount) ?? 0;
   const attemptCount = issue.monitorAttemptCount ?? stateAttemptCount;
   if (maxAttempts !== null && attemptCount >= maxAttempts) return false;
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The recovery service is responsible for waking assigned issues that appear stranded after their prior work has ended.
> - Some assigned issues are intentionally parked with a future monitor, so their lack of an active run is not itself a stranded state.
> - The existing issue graph liveness classifier already treats a future monitor as a valid waiting path, but stranded assigned issue recovery did not apply the same predicate.
> - This pull request aligns recovery with monitor-based liveness so scheduled issues are not immediately re-woken while still preserving timeout and max-attempt recovery behavior.
> - The benefit is fewer duplicate continuation wakes for legitimately scheduled work and lower risk of agents accidentally disturbing parked publish tasks.

## Linked Issues or Issue Description

Related prior work: #8772, #8191

## What happened?

An assigned issue with a future monitor could receive another `issue_continuation_needed` wake after its previous continuation run reached a terminal state. The recovery predicate only checked for active runs and pending interactions before queueing recovery, so a scheduled future monitor did not count as a live waiting path.

## Expected behavior

An assigned issue with a future `monitorNextCheckAt` should remain parked until the monitor is due, unless another explicit event makes it actionable. Exhausted or timed-out monitor states should still be recoverable.

## Steps to reproduce

Create an assigned `in_progress` issue whose prior continuation run is terminal, whose `monitorNextCheckAt` is in the future, and which has no pending interaction or active recovery action. Run stranded assigned issue reconciliation and observe whether it queues `issue_continuation_needed`.

## Paperclip version or commit

Tested on this branch at `d767549d6`.

## Deployment mode

Server recovery service / heartbeat processing.

## What Changed

- Added a shared recovery-side helper that treats future scheduled monitors as valid waiting paths.
- Applied that helper before `reconcileStrandedAssignedIssues()` queues `issue_continuation_needed` recovery.
- Preserved monitor timeout and max-attempt semantics so stale or exhausted monitors can still recover.
- Added a regression test for an assigned issue with a terminal prior continuation run and future monitor.

## Verification

- `pnpm exec vitest run server/src/__tests__/heartbeat-process-recovery.test.ts -t "future monitor"`
- `pnpm exec vitest run server/src/__tests__/heartbeat-process-recovery.test.ts`
- `pnpm --filter @paperclipai/server typecheck`
- Public duplicate PR search run: `gh pr list --repo paperclipai/paperclip --state all --search 'monitored continuation recovery OR monitorNextCheckAt issue_continuation_needed' --limit 20`

## Risks

Low risk. The change only suppresses recovery when a future monitor is still scheduled and not exhausted. Terminal, timed-out, or over-attempt monitor states remain eligible for recovery.

## Model Used

OpenAI Codex, GPT-5, with local shell and GitHub CLI tool use.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [ ] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge