### PR TITLE
feat(recovery): liveness-gated auto-timeout for dead runs holding checkout locks

### DIFF
--- a/server/src/__tests__/recovery-dead-run-auto-timeout.test.ts
+++ b/server/src/__tests__/recovery-dead-run-auto-timeout.test.ts
@@ -1,0 +1,260 @@
+import { randomUUID } from "node:crypto";
+import { eq } from "drizzle-orm";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import {
+  activityLog,
+  agents,
+  companies,
+  createDb,
+  heartbeatRuns,
+  issueComments,
+  issueRelations,
+  issues,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+
+const mockTelemetryClient = vi.hoisted(() => ({ track: vi.fn() }));
+vi.mock("../telemetry.ts", () => ({ getTelemetryClient: () => mockTelemetryClient }));
+
+import { heartbeatService } from "../services/heartbeat.ts";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping embedded Postgres dead-run auto-timeout tests on this host: ${
+      embeddedPostgresSupport.reason ?? "unsupported environment"
+    }`,
+  );
+}
+
+// A pid that is (almost) certainly not a live process on the test host. isPidAlive
+// does `process.kill(pid, 0)`, which throws ESRCH for a nonexistent pid.
+const DEAD_PID = 2_147_483_646;
+
+describeEmbeddedPostgres("recovery autoTimeoutDeadSilentRuns", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-dead-run-timeout-");
+    db = createDb(tempDb.connectionString);
+  }, 20_000);
+
+  afterEach(async () => {
+    vi.unstubAllEnvs();
+    await db.delete(issueComments);
+    await db.delete(issueRelations);
+    await db.delete(activityLog);
+    await db.delete(issues);
+    await db.delete(heartbeatRuns);
+    await db.delete(agents);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  function enable() {
+    vi.stubEnv("PAPERCLIP_DEAD_RUN_AUTO_TIMEOUT", "true");
+  }
+
+  async function seedCompanyAndAgent(adapterType: string) {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Coder",
+      role: "engineer",
+      status: "running",
+      adapterType,
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    return { companyId, agentId };
+  }
+
+  async function seedRunningRun(input: {
+    companyId: string;
+    agentId: string;
+    processPid: number | null;
+    ageMs?: number;
+  }) {
+    const runId = randomUUID();
+    const staleAt = new Date(Date.now() - (input.ageMs ?? 60 * 60 * 1000)); // 1h silent by default
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId: input.companyId,
+      agentId: input.agentId,
+      status: "running",
+      invocationSource: "manual",
+      processPid: input.processPid ?? undefined,
+      startedAt: staleAt,
+      createdAt: staleAt,
+    });
+    return runId;
+  }
+
+  async function seedLockedIssue(input: { companyId: string; agentId: string; runId: string }) {
+    const issueId = randomUUID();
+    await db.insert(issues).values({
+      id: issueId,
+      companyId: input.companyId,
+      title: "Locked by a dead run",
+      status: "in_progress",
+      priority: "high",
+      assigneeAgentId: input.agentId,
+      checkoutRunId: input.runId,
+      executionRunId: input.runId,
+      executionLockedAt: new Date(),
+    });
+    return issueId;
+  }
+
+  async function runStatus(runId: string) {
+    return db
+      .select({ status: heartbeatRuns.status, errorCode: heartbeatRuns.errorCode })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, runId))
+      .then((rows) => rows[0]);
+  }
+
+  it("is a no-op while the feature flag is off (ships dark)", async () => {
+    const { companyId, agentId } = await seedCompanyAndAgent("claude_local");
+    const runId = await seedRunningRun({ companyId, agentId, processPid: DEAD_PID });
+
+    const heartbeat = heartbeatService(db);
+    const result = await heartbeat.autoTimeoutDeadSilentRuns();
+
+    expect(result).toEqual({ scanned: 0, timedOut: 0, runIds: [] });
+    expect((await runStatus(runId))?.status).toBe("running");
+  });
+
+  it("times out a provably-dead silent run, and the sweep then clears its lock in the same tick", async () => {
+    enable();
+    const { companyId, agentId } = await seedCompanyAndAgent("claude_local");
+    const runId = await seedRunningRun({ companyId, agentId, processPid: DEAD_PID });
+    const issueId = await seedLockedIssue({ companyId, agentId, runId });
+
+    const heartbeat = heartbeatService(db);
+    const timedOut = await heartbeat.autoTimeoutDeadSilentRuns();
+    expect(timedOut.timedOut).toBe(1);
+    expect(timedOut.runIds).toEqual([runId]);
+
+    const run = await runStatus(runId);
+    expect(run?.status).toBe("timed_out");
+    expect(run?.errorCode).toBe("dead_run_auto_timeout");
+
+    // The existing terminal-gated sweep — same recovery tick — now releases the lock.
+    const swept = await heartbeat.sweepStaleIssueLocks();
+    expect(swept.cleared).toBe(1);
+    const lock = await db
+      .select({ checkoutRunId: issues.checkoutRunId, executionRunId: issues.executionRunId })
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0]);
+    expect(lock).toEqual({ checkoutRunId: null, executionRunId: null });
+
+    const audit = await db
+      .select({ action: activityLog.action })
+      .from(activityLog)
+      .where(eq(activityLog.action, "heartbeat.dead_run_auto_timed_out"))
+      .then((rows) => rows[0]);
+    expect(audit?.action).toBe("heartbeat.dead_run_auto_timed_out");
+
+    // Agent freed to idle so it can pick up new work.
+    const agent = await db
+      .select({ status: agents.status })
+      .from(agents)
+      .where(eq(agents.id, agentId))
+      .then((rows) => rows[0]);
+    expect(agent?.status).toBe("idle");
+  });
+
+  it("never times out a healthy-but-quiet run whose pid is still alive (OTL-131 guard)", async () => {
+    enable();
+    const { companyId, agentId } = await seedCompanyAndAgent("claude_local");
+    // The test process itself is alive — a live pid must never be timed out,
+    // no matter how long it has been silent.
+    const runId = await seedRunningRun({ companyId, agentId, processPid: process.pid });
+    const issueId = await seedLockedIssue({ companyId, agentId, runId });
+
+    const heartbeat = heartbeatService(db);
+    for (let tick = 0; tick < 3; tick++) {
+      const result = await heartbeat.autoTimeoutDeadSilentRuns();
+      expect(result.timedOut).toBe(0);
+    }
+
+    expect((await runStatus(runId))?.status).toBe("running");
+    const lock = await db
+      .select({ checkoutRunId: issues.checkoutRunId })
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0]);
+    expect(lock?.checkoutRunId).toBe(runId); // lock retained
+  });
+
+  it("skips a silent run with no process metadata — death cannot be proven", async () => {
+    enable();
+    const { companyId, agentId } = await seedCompanyAndAgent("claude_local");
+    const runId = await seedRunningRun({ companyId, agentId, processPid: null });
+
+    const heartbeat = heartbeatService(db);
+    const result = await heartbeat.autoTimeoutDeadSilentRuns();
+
+    expect(result.scanned).toBe(1);
+    expect(result.timedOut).toBe(0);
+    expect((await runStatus(runId))?.status).toBe("running");
+  });
+
+  it("skips non-sessioned-local adapters even with a dead pid", async () => {
+    enable();
+    const { companyId, agentId } = await seedCompanyAndAgent("cursor_cloud");
+    const runId = await seedRunningRun({ companyId, agentId, processPid: DEAD_PID });
+
+    const heartbeat = heartbeatService(db);
+    const result = await heartbeat.autoTimeoutDeadSilentRuns();
+
+    expect(result.timedOut).toBe(0);
+    expect((await runStatus(runId))?.status).toBe("running");
+  });
+
+  it("ignores runs that are not yet silent past the TTL", async () => {
+    enable();
+    const { companyId, agentId } = await seedCompanyAndAgent("claude_local");
+    // Only 5s of silence — well under the 15m default TTL.
+    const runId = await seedRunningRun({ companyId, agentId, processPid: DEAD_PID, ageMs: 5_000 });
+
+    const heartbeat = heartbeatService(db);
+    const result = await heartbeat.autoTimeoutDeadSilentRuns();
+
+    expect(result.scanned).toBe(0);
+    expect((await runStatus(runId))?.status).toBe("running");
+  });
+
+  it("is idempotent — a second pass finds nothing left to time out", async () => {
+    enable();
+    const { companyId, agentId } = await seedCompanyAndAgent("claude_local");
+    const runId = await seedRunningRun({ companyId, agentId, processPid: DEAD_PID });
+    await seedLockedIssue({ companyId, agentId, runId });
+
+    const heartbeat = heartbeatService(db);
+    const first = await heartbeat.autoTimeoutDeadSilentRuns();
+    const second = await heartbeat.autoTimeoutDeadSilentRuns();
+    expect(first.timedOut).toBe(1);
+    expect(second.timedOut).toBe(0);
+  });
+});

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -840,6 +840,13 @@ export async function startServer(): Promise<StartedServer> {
         logger.warn({ ...scanned }, "startup active-run output watchdog created review work");
       }
 
+      // OTL-138: time out provably-dead runs BEFORE the sweep so their locks
+      // clear on this same tick rather than the next.
+      const deadTimedOut = await heartbeat.autoTimeoutDeadSilentRuns();
+      if (deadTimedOut.timedOut > 0) {
+        logger.warn({ ...deadTimedOut }, "startup dead-run auto-timeout released stuck runs");
+      }
+
       const swept = await heartbeat.sweepStaleIssueLocks();
       if (swept.cleared > 0) {
         logger.warn({ ...swept }, "startup stale-lock sweeper cleared issue locks");
@@ -938,6 +945,14 @@ export async function startServer(): Promise<StartedServer> {
           const scanned = await heartbeat.scanSilentActiveRuns();
           if (scanned.created > 0 || scanned.escalated > 0) {
             logger.warn({ ...scanned }, "periodic active-run output watchdog created review work");
+          }
+        })
+        .then(async () => {
+          // OTL-138: time out provably-dead runs BEFORE the sweep so their
+          // locks clear on this same tick rather than the next.
+          const deadTimedOut = await heartbeat.autoTimeoutDeadSilentRuns();
+          if (deadTimedOut.timedOut > 0) {
+            logger.warn({ ...deadTimedOut }, "periodic dead-run auto-timeout released stuck runs");
           }
         })
         .then(async () => {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -9053,6 +9053,10 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     return recovery.sweepStaleIssueLocks();
   }
 
+  async function autoTimeoutDeadSilentRuns(opts?: { now?: Date; companyId?: string }) {
+    return recovery.autoTimeoutDeadSilentRuns(opts);
+  }
+
   function issueIdFromRunContext(contextSnapshot: unknown) {
     const context = parseObject(contextSnapshot);
     return readNonEmptyString(context.issueId) ?? readNonEmptyString(context.taskId);
@@ -13372,6 +13376,8 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     },
 
     reconcileStrandedAssignedIssues,
+
+    autoTimeoutDeadSilentRuns,
 
     sweepStaleIssueLocks,
 

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -94,6 +94,22 @@ export const STRANDED_RECENT_PROGRESS_EXEMPTION_MS = Math.max(
   Number(process.env.STRANDED_RECENT_PROGRESS_EXEMPTION_MS) || 30 * 60 * 1000,
 );
 
+// OTL-138: liveness-gated auto-timeout for dead runs holding checkout locks.
+// A run SIGKILLed without a terminal status leaves `sweepStaleIssueLocks()`'s
+// status gate unable to release its lock — held forever. When enabled,
+// `autoTimeoutDeadSilentRuns()` transitions such a run to `timed_out` ONLY when
+// it is silent past this TTL AND provably process-dead (mandatory pid/pgid
+// liveness gate), so the existing terminal-gated sweep releases the lock on the
+// same tick. The TTL is a pre-filter, never the kill criterion — process death
+// is. Ships dark: the enable flag is read at call time (see the function) so it
+// defaults off and can be flipped/rolled back without a redeploy. Floored at 60s
+// so misconfiguration can't make the gate fire on sub-minute silence.
+export const DEAD_RUN_AUTO_TIMEOUT_ENV = "PAPERCLIP_DEAD_RUN_AUTO_TIMEOUT";
+export const DEAD_RUN_SILENCE_TTL_MS = Math.max(
+  60_000,
+  Number(process.env.PAPERCLIP_DEAD_RUN_SILENCE_TTL_MS) || 15 * 60 * 1000,
+);
+
 type RecoveryWakeupOptions = {
   source?: "timer" | "assignment" | "on_demand" | "automation";
   triggerDetail?: "manual" | "ping" | "callback" | "system";
@@ -1184,13 +1200,18 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     }
   }
 
-  async function finalizeAgentAfterSourceResolvedRun(run: typeof heartbeatRuns.$inferSelect, status: "succeeded" | "cancelled") {
+  async function finalizeAgentAfterSourceResolvedRun(run: typeof heartbeatRuns.$inferSelect, status: "succeeded" | "cancelled" | "timed_out") {
     const [runningCountRow] = await db
       .select({ count: sql<number>`count(*)::int` })
       .from(heartbeatRuns)
       .where(and(eq(heartbeatRuns.agentId, run.agentId), eq(heartbeatRuns.status, "running")));
     const runningCount = Number(runningCountRow?.count ?? 0);
-    const nextStatus = runningCount > 0 ? "running" : status === "succeeded" || status === "cancelled" ? "idle" : "error";
+    const nextStatus =
+      runningCount > 0
+        ? "running"
+        : status === "succeeded" || status === "cancelled" || status === "timed_out"
+          ? "idle"
+          : "error";
     await db
       .update(agents)
       .set({
@@ -3895,6 +3916,125 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
   // releaseIssueExecutionAndPromote / clearCheckoutRunIfTerminal / adoption.
   // Idempotent and safe: clears at most one row's worth of lock columns per
   // candidate, and only when the referenced run row is unambiguously terminal.
+  // OTL-138: transition provably-dead silent runs to `timed_out` so the
+  // terminal-gated `sweepStaleIssueLocks()` (which runs immediately after this
+  // in the same recovery tick) can release the checkout lock they would
+  // otherwise hold forever. A healthy-but-quiet run has a live pid and is
+  // skipped every tick, which is what makes the OTL-131 snapshot-race false
+  // positive structurally impossible: silence is only a pre-filter; OS-level
+  // process death, re-checked here at decision time, is the actual criterion.
+  async function autoTimeoutDeadSilentRuns(opts?: { now?: Date; companyId?: string }) {
+    const result = { scanned: 0, timedOut: 0, runIds: [] as string[] };
+
+    // Read the flag at call time so it ships dark and can be flipped/rolled
+    // back without a redeploy.
+    const enabled =
+      (process.env[DEAD_RUN_AUTO_TIMEOUT_ENV] ?? "false").toLowerCase() === "true";
+    if (!enabled) return result;
+
+    const now = opts?.now ?? new Date();
+    const cutoff = new Date(now.getTime() - DEAD_RUN_SILENCE_TTL_MS);
+
+    const candidates = await db
+      .select({ run: heartbeatRuns, adapterType: agents.adapterType })
+      .from(heartbeatRuns)
+      .innerJoin(agents, eq(agents.id, heartbeatRuns.agentId))
+      .where(
+        and(
+          opts?.companyId ? eq(heartbeatRuns.companyId, opts.companyId) : undefined,
+          eq(heartbeatRuns.status, "running"),
+          sql`coalesce(${heartbeatRuns.lastOutputAt}, ${heartbeatRuns.processStartedAt}, ${heartbeatRuns.startedAt}, ${heartbeatRuns.createdAt}) <= ${cutoff.toISOString()}::timestamptz`,
+        ),
+      )
+      .orderBy(asc(heartbeatRuns.createdAt))
+      .limit(100);
+
+    result.scanned = candidates.length;
+
+    for (const { run, adapterType } of candidates) {
+      // Adapter gate: only sessioned local adapters expose a trustworthy OS pid.
+      if (!SESSIONED_LOCAL_ADAPTERS.has(adapterType)) continue;
+
+      const handle = runningProcesses.get(run.id);
+      const pid = handle?.child.pid ?? run.processPid ?? null;
+      const processGroupId = handle?.processGroupId ?? run.processGroupId ?? null;
+
+      // MANDATORY liveness gate: without process metadata we cannot PROVE death,
+      // so we never time the run out. This — plus the live re-check below — is
+      // what prevents a false positive on a healthy-but-quiet run (OTL-131).
+      if (typeof pid !== "number" && typeof processGroupId !== "number") continue;
+
+      const alive =
+        (typeof pid === "number" && isPidAlive(pid)) ||
+        (typeof processGroupId === "number" && isProcessGroupAlive(processGroupId));
+      if (alive) continue;
+
+      // Provably dead. Compare-and-swap to `timed_out`; if another path already
+      // finalized the run the guarded update returns nothing and we skip it.
+      const finalized = await db
+        .update(heartbeatRuns)
+        .set({
+          status: "timed_out",
+          finishedAt: now,
+          errorCode: "dead_run_auto_timeout",
+          resultJson: {
+            ...parseObject(run.resultJson),
+            deadRunAutoTimeout: {
+              pid,
+              processGroupId,
+              ttlMs: DEAD_RUN_SILENCE_TTL_MS,
+              detectedAt: now.toISOString(),
+              source: "recovery.auto_timeout_dead_silent_runs",
+            },
+          },
+          updatedAt: now,
+        })
+        .where(
+          and(
+            eq(heartbeatRuns.id, run.id),
+            eq(heartbeatRuns.companyId, run.companyId),
+            eq(heartbeatRuns.status, "running"),
+          ),
+        )
+        .returning()
+        .then((rows) => rows[0] ?? null);
+
+      if (!finalized) continue;
+
+      runningProcesses.delete(run.id);
+      await finalizeAgentAfterSourceResolvedRun(finalized, "timed_out");
+
+      result.timedOut += 1;
+      result.runIds.push(run.id);
+
+      await logActivity(db, {
+        companyId: run.companyId,
+        actorType: "system",
+        actorId: "system",
+        agentId: null,
+        runId: null,
+        action: "heartbeat.dead_run_auto_timed_out",
+        entityType: "heartbeat_run",
+        entityId: run.id,
+        details: {
+          source: "recovery.auto_timeout_dead_silent_runs",
+          pid,
+          processGroupId,
+          ttlMs: DEAD_RUN_SILENCE_TTL_MS,
+        },
+      });
+    }
+
+    if (result.timedOut > 0) {
+      logger.warn(
+        { timedOut: result.timedOut, runIds: result.runIds },
+        "auto-timed-out provably-dead silent runs",
+      );
+    }
+
+    return result;
+  }
+
   async function sweepStaleIssueLocks() {
     const result = {
       cleared: 0,
@@ -4005,6 +4145,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     recordWatchdogDecision,
     scanSilentActiveRuns,
     reconcileStrandedAssignedIssues,
+    autoTimeoutDeadSilentRuns,
     sweepStaleIssueLocks,
     buildIssueGraphLivenessAutoRecoveryPreview,
     reconcileIssueGraphLiveness,


### PR DESCRIPTION
## Problem

`sweepStaleIssueLocks()` releases a checkout lock only when the holding run reaches a **terminal** status (`isCleanable()` → `TERMINAL_HEARTBEAT_RUN_STATUSES`). A run that dies without setting a terminal status (e.g. SIGKILL) stays `running` forever, so its checkout/execution lock is **held indefinitely** with no TTL and no auto-heal. The silent-run watchdog (1h/4h) only files review issues — it never terminates the run or releases the lock.

Downstream impact (OT Labs OTL-131/OTL-132): agents hit the stuck lock, exhaust ~11 board-gated force-release/cancel paths (all 403), and burn a full heartbeat before standing down.

## Fix

Add `autoTimeoutDeadSilentRuns()` to the recovery service, wired into the recovery timer **immediately before** the existing sweep at both the startup and periodic sites. It transitions a `running` run to `timed_out` **only when** it is silent past a TTL **AND provably process-dead** (mandatory pid/pgid liveness gate, reusing `isPidAlive`/`isProcessGroupAlive`). The existing terminal-gated sweep then releases the lock on the **same tick** — no new lock-release code path is introduced.

### Why it can't false-positive
Silence is only a *pre-filter*; OS-level process death — re-checked at decision time — is the actual kill criterion. A healthy-but-quiet run has a live pid and is skipped every tick, so the OTL-131 snapshot-race false positive is **structurally impossible**. Runs with no process metadata, or on non-sessioned-local adapters, are never timed out.

### Safety / rollout
- **Ships dark.** `PAPERCLIP_DEAD_RUN_AUTO_TIMEOUT` is read at call time (default off); flip or roll back without a redeploy.
- **Tunable.** `PAPERCLIP_DEAD_RUN_SILENCE_TTL_MS` (default 15m, floored 60s). The 1h/4h watchdog thresholds are untouched.
- **CAS.** The status transition is guarded on `status = 'running'`, so it can't double-fire or race another finalizer.
- **No schema change**, no migration.

## Tests

`server/src/__tests__/recovery-dead-run-auto-timeout.test.ts` (7 cases, embedded Postgres):
1. flag off → no-op;
2. dead pid → `timed_out`, then sweep clears the lock **same tick** (+ audit log + agent freed to idle);
3. **live pid → never timed out across 3 ticks, lock retained** (OTL-131 regression guard);
4. no process metadata → skipped;
5. non-local adapter → skipped;
6. silence under TTL → skipped;
7. idempotent second pass.

Existing `recovery-stale-issue-lock-sweep` / `execution-lock-orphan-cleanup` suites still green; `tsc --noEmit` clean.

---
Filed from OT Labs issue OTL-138 (stale-lock recovery). Board-approved design + patch spec; landing upstream via this PR is the merge gate.
