### PR TITLE
fix(recovery): honor scheduled issue monitors

### DIFF
--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -651,6 +651,10 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     livenessState?: "completed" | "advanced" | "plan_only" | "empty_response" | "blocked" | "failed" | "needs_followup" | null;
     runErrorCode?: string | null;
     runError?: string | null;
+    monitorNextCheckAt?: Date | null;
+    executionPolicy?: Record<string, unknown> | null;
+    executionState?: Record<string, unknown> | null;
+    monitorAttemptCount?: number | null;
   }) {
     const companyId = randomUUID();
     const agentId = randomUUID();
@@ -749,6 +753,10 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
         assigneeUserId: input.assignToUser ? "user-1" : null,
         checkoutRunId: input.status === "in_progress" ? runId : null,
         executionRunId: null,
+        executionPolicy: input.executionPolicy ?? null,
+        executionState: input.executionState ?? null,
+        monitorNextCheckAt: input.monitorNextCheckAt ?? null,
+        monitorAttemptCount: input.monitorAttemptCount ?? 0,
         issueNumber: input.activePauseHold ? 2 : 1,
         identifier: `${issuePrefix}-${input.activePauseHold ? 2 : 1}`,
         startedAt: input.status === "in_progress" ? now : null,
@@ -3676,6 +3684,51 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
 
     const wakeups = await db.select().from(agentWakeupRequests).where(eq(agentWakeupRequests.agentId, agentId));
     expect(wakeups).toHaveLength(2);
+  });
+
+  it("does not re-enqueue continuation for in-progress work parked on a future issue monitor", async () => {
+    const nextCheckAt = new Date(Date.now() + 30 * 24 * 60 * 60 * 1_000).toISOString();
+    const { agentId, issueId, runId } = await seedStrandedIssueFixture({
+      status: "in_progress",
+      runStatus: "succeeded",
+      livenessState: "needs_followup",
+      monitorNextCheckAt: new Date(nextCheckAt),
+      executionPolicy: {
+        monitor: {
+          nextCheckAt,
+          service: "linkedin-publish-runner",
+        },
+      },
+      executionState: {
+        monitor: {
+          status: "scheduled",
+          nextCheckAt,
+          service: "linkedin-publish-runner",
+          attemptCount: 0,
+        },
+      },
+      monitorAttemptCount: 0,
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(result.continuationRequeued).toBe(0);
+    expect(result.escalated).toBe(0);
+    expect(result.skipped).toBeGreaterThanOrEqual(1);
+    expect(result.issueIds).toEqual([]);
+
+    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(issue?.status).toBe("in_progress");
+    expect(issue?.assigneeAgentId).toBe(agentId);
+
+    const runs = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.agentId, agentId));
+    expect(runs.map((row) => row.id)).toEqual([runId]);
+
+    const wakeups = await db.select().from(agentWakeupRequests).where(eq(agentWakeupRequests.agentId, agentId));
+    expect(wakeups).toHaveLength(1);
   });
 
   it("blocks stranded in-progress work after a productive continuation retry was already used", async () => {

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -380,6 +380,37 @@ function isRepeatedProductiveContinuationRecovery(latestRun: SuccessfulLatestIss
     isProductiveContinuationRun(latestRun);
 }
 
+function readDateMs(value: unknown): number | null {
+  if (!(typeof value === "string" || value instanceof Date)) return null;
+  const time = (value instanceof Date ? value : new Date(value)).getTime();
+  return Number.isNaN(time) ? null : time;
+}
+
+function readPositiveInteger(value: unknown): number | null {
+  return typeof value === "number" && Number.isInteger(value) && value > 0 ? value : null;
+}
+
+function hasScheduledIssueMonitor(issue: Pick<
+  typeof issues.$inferSelect,
+  "executionPolicy" | "executionState" | "monitorAttemptCount" | "monitorNextCheckAt"
+>) {
+  const nowMs = Date.now();
+  const nextCheckAtMs = readDateMs(issue.monitorNextCheckAt);
+  if (nextCheckAtMs === null || nextCheckAtMs <= nowMs) return false;
+
+  const policyMonitor = parseObject(parseObject(issue.executionPolicy)?.monitor);
+  const stateMonitor = parseObject(parseObject(issue.executionState)?.monitor);
+  const timeoutAtMs = readDateMs(policyMonitor?.timeoutAt ?? stateMonitor?.timeoutAt);
+  if (timeoutAtMs !== null && timeoutAtMs <= nowMs) return false;
+
+  const maxAttempts = readPositiveInteger(policyMonitor?.maxAttempts ?? stateMonitor?.maxAttempts);
+  const stateAttemptCount = readPositiveInteger(stateMonitor?.attemptCount) ?? 0;
+  const attemptCount = issue.monitorAttemptCount ?? stateAttemptCount;
+  if (maxAttempts !== null && attemptCount >= maxAttempts) return false;
+
+  return true;
+}
+
 function parseLivenessIncidentKey(incidentKey: string | null | undefined) {
   if (!incidentKey) return null;
   return parseIssueGraphLivenessIncidentKey(incidentKey);
@@ -2756,6 +2787,11 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       }
 
       if (await hasPendingWakeInteraction(issue.companyId, issue.id)) {
+        result.skipped += 1;
+        continue;
+      }
+
+      if (issue.status === "in_progress" && hasScheduledIssueMonitor(issue)) {
         result.skipped += 1;
         continue;
       }


### PR DESCRIPTION
## Thinking Path

> - Paperclip manages AI agents and issue execution, including when agents should wake for continued work.
> - The heartbeat recovery service looks for assigned in-progress issues that appear stranded after a run finishes.
> - Some issues are intentionally parked on future monitors, so no active heartbeat run is expected until the scheduled monitor fires.
> - The recovery predicate was treating those parked issues as stranded before honoring the future monitor path.
> - This pull request teaches recovery to skip continuation requeues when an issue has a future, non-exhausted scheduled monitor.
> - The benefit is that future-dated handoffs can remain quiet until their monitor time instead of repeatedly waking the assignee.

## Linked Issues or Issue Description

No public GitHub issue exists for this instance-specific bug, so the bug details are included here.

## What happened?

An in-progress issue with no active heartbeat run, a future `monitorNextCheckAt`, and scheduled monitor state was still eligible for productive terminal continuation recovery. That caused an unnecessary `issue_continuation_needed` wake even though the issue already had a valid future monitor path.

## Expected behavior

The recovery loop should leave an assigned in-progress issue alone when it has a future issue monitor that has not exhausted its attempts.

## Steps to reproduce

Seed an assigned in-progress issue with a succeeded terminal run, no active run, `livenessState: needs_followup`, `monitorNextCheckAt` in the future, `executionPolicy.monitor.nextCheckAt`, and `executionState.monitor.status: scheduled`. Run `reconcileStrandedAssignedIssues()` and observe that it should not enqueue another continuation wake.

## Paperclip version

Current `master` before this fix.

Related PR search: #8813, #8803, #8802, #8191, #8772, #6359.

## What Changed

- Skipped stranded assigned-issue continuation recovery when an `in_progress` issue has a future, non-exhausted issue monitor.
- Added regression coverage for the future scheduled monitor handoff shape, including monitor policy, monitor state, and service metadata.
- Updated the regression to compute its future monitor timestamp relative to test execution time so the test does not expire after a fixed calendar date.

## Verification

- `pnpm exec vitest run server/src/__tests__/heartbeat-process-recovery.test.ts --no-file-parallelism --maxWorkers=1` passed 62/62.
- `pnpm --filter @paperclipai/server typecheck` passed before this review update.
- `git diff --check` passed before this review update.
- Local PR body gates passed with `.github/scripts/check-pr-template.mjs`, `.github/scripts/check-pr-linked-issue.mjs`, and `.github/scripts/check-pr-dedup-search.mjs`.

## Risks

Low risk. The change narrows recovery behavior only when an issue has an explicit future scheduled monitor that still has attempts remaining. Issues without that monitor path continue through existing stranded-work recovery.

## Model Used

OpenAI GPT-5 via Codex CLI, tool-assisted coding and test execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [ ] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
