### PR TITLE
fix(productivity): honor scheduled issue monitors

### DIFF
--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -651,6 +651,10 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     livenessState?: "completed" | "advanced" | "plan_only" | "empty_response" | "blocked" | "failed" | "needs_followup" | null;
     runErrorCode?: string | null;
     runError?: string | null;
+    monitorNextCheckAt?: Date | null;
+    executionPolicy?: Record<string, unknown> | null;
+    executionState?: Record<string, unknown> | null;
+    monitorAttemptCount?: number | null;
   }) {
     const companyId = randomUUID();
     const agentId = randomUUID();
@@ -749,6 +753,10 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
         assigneeUserId: input.assignToUser ? "user-1" : null,
         checkoutRunId: input.status === "in_progress" ? runId : null,
         executionRunId: null,
+        executionPolicy: input.executionPolicy ?? null,
+        executionState: input.executionState ?? null,
+        monitorNextCheckAt: input.monitorNextCheckAt ?? null,
+        monitorAttemptCount: input.monitorAttemptCount ?? 0,
         issueNumber: input.activePauseHold ? 2 : 1,
         identifier: `${issuePrefix}-${input.activePauseHold ? 2 : 1}`,
         startedAt: input.status === "in_progress" ? now : null,
@@ -3676,6 +3684,51 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
 
     const wakeups = await db.select().from(agentWakeupRequests).where(eq(agentWakeupRequests.agentId, agentId));
     expect(wakeups).toHaveLength(2);
+  });
+
+  it("does not re-enqueue continuation for in-progress work parked on a future issue monitor", async () => {
+    const nextCheckAt = new Date(Date.now() + 30 * 24 * 60 * 60 * 1_000).toISOString();
+    const { agentId, issueId, runId } = await seedStrandedIssueFixture({
+      status: "in_progress",
+      runStatus: "succeeded",
+      livenessState: "needs_followup",
+      monitorNextCheckAt: new Date(nextCheckAt),
+      executionPolicy: {
+        monitor: {
+          nextCheckAt,
+          service: "linkedin-publish-runner",
+        },
+      },
+      executionState: {
+        monitor: {
+          status: "scheduled",
+          nextCheckAt,
+          service: "linkedin-publish-runner",
+          attemptCount: 0,
+        },
+      },
+      monitorAttemptCount: 0,
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(result.continuationRequeued).toBe(0);
+    expect(result.escalated).toBe(0);
+    expect(result.skipped).toBe(1);
+    expect(result.issueIds).toEqual([]);
+
+    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(issue?.status).toBe("in_progress");
+    expect(issue?.assigneeAgentId).toBe(agentId);
+
+    const runs = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.agentId, agentId));
+    expect(runs.map((row) => row.id)).toEqual([runId]);
+
+    const wakeups = await db.select().from(agentWakeupRequests).where(eq(agentWakeupRequests.agentId, agentId));
+    expect(wakeups).toHaveLength(1);
   });
 
   it("blocks stranded in-progress work after a productive continuation retry was already used", async () => {

--- a/server/src/__tests__/productivity-review-service.test.ts
+++ b/server/src/__tests__/productivity-review-service.test.ts
@@ -55,6 +55,12 @@ describeEmbeddedPostgres("productivity review service", () => {
     startedAt?: Date;
     parentId?: string | null;
     originKind?: string;
+    executionPolicy?: Record<string, unknown> | null;
+    executionState?: Record<string, unknown> | null;
+    monitorNextCheckAt?: Date | null;
+    monitorAttemptCount?: number;
+    monitorNotes?: string | null;
+    monitorScheduledBy?: string | null;
   }) {
     const companyId = randomUUID();
     const managerId = randomUUID();
@@ -106,6 +112,12 @@ describeEmbeddedPostgres("productivity review service", () => {
       issueNumber: 1,
       identifier: `${issuePrefix}-1`,
       startedAt: opts?.startedAt ?? createdAt,
+      executionPolicy: opts?.executionPolicy ?? null,
+      executionState: opts?.executionState ?? null,
+      monitorNextCheckAt: opts?.monitorNextCheckAt ?? null,
+      monitorAttemptCount: opts?.monitorAttemptCount ?? 0,
+      monitorNotes: opts?.monitorNotes ?? null,
+      monitorScheduledBy: opts?.monitorScheduledBy ?? null,
       createdAt,
       updatedAt: createdAt,
     });
@@ -358,6 +370,179 @@ describeEmbeddedPostgres("productivity review service", () => {
     expect(review?.description).toContain("Primary trigger: `long_active_duration`");
     expect(review?.priority).toBe("medium");
     expect(hold.held).toBe(false);
+  });
+
+  it("skips long-active review for RR-4120-shaped in-progress issues with a future scheduled monitor", async () => {
+    const now = new Date("2026-07-01T21:00:00.000Z");
+    const nextCheckAt = "2026-08-03T14:00:00.000Z";
+    const seeded = await seedAssignedIssue({
+      status: "in_progress",
+      startedAt: new Date("2026-06-20T12:00:00.000Z"),
+      executionPolicy: {
+        mode: "normal",
+        commentRequired: true,
+        stages: [],
+        monitor: {
+          nextCheckAt,
+          notes: "Publish scheduled LinkedIn post.",
+          scheduledBy: "assignee",
+          kind: "external",
+          serviceName: "LinkedIn",
+        },
+      },
+      executionState: {
+        status: "idle",
+        currentStageId: null,
+        currentStageIndex: null,
+        currentStageType: null,
+        currentParticipant: null,
+        returnAssignee: null,
+        reviewRequest: null,
+        completedStageIds: [],
+        lastDecisionId: null,
+        lastDecisionOutcome: null,
+        monitor: {
+          status: "scheduled",
+          nextCheckAt,
+          lastTriggeredAt: null,
+          attemptCount: 0,
+          notes: "Publish scheduled LinkedIn post.",
+          scheduledBy: "assignee",
+          kind: "external",
+          serviceName: "LinkedIn",
+          timeoutAt: null,
+          maxAttempts: null,
+          recoveryPolicy: null,
+          clearedAt: null,
+          clearReason: null,
+        },
+      },
+      monitorNextCheckAt: new Date(nextCheckAt),
+      monitorAttemptCount: 0,
+      monitorNotes: "Publish scheduled LinkedIn post.",
+      monitorScheduledBy: "assignee",
+    });
+
+    const result = await productivityReviewService(db).reconcileProductivityReviews({
+      now,
+      companyId: seeded.companyId,
+    });
+
+    expect(result.created).toBe(0);
+    expect(result.skipped).toBe(1);
+    expect(await listProductivityReviews(seeded.companyId)).toHaveLength(0);
+  });
+
+  it("still creates long-active reviews for past-due scheduled monitors", async () => {
+    const now = new Date("2026-07-01T21:00:00.000Z");
+    const nextCheckAt = "2026-07-01T14:00:00.000Z";
+    const seeded = await seedAssignedIssue({
+      status: "in_progress",
+      startedAt: new Date("2026-06-30T12:00:00.000Z"),
+      executionPolicy: {
+        mode: "normal",
+        commentRequired: true,
+        stages: [],
+        monitor: {
+          nextCheckAt,
+          scheduledBy: "assignee",
+        },
+      },
+      executionState: {
+        status: "idle",
+        currentStageId: null,
+        currentStageIndex: null,
+        currentStageType: null,
+        currentParticipant: null,
+        returnAssignee: null,
+        reviewRequest: null,
+        completedStageIds: [],
+        lastDecisionId: null,
+        lastDecisionOutcome: null,
+        monitor: {
+          status: "scheduled",
+          nextCheckAt,
+          lastTriggeredAt: null,
+          attemptCount: 0,
+          notes: null,
+          scheduledBy: "assignee",
+          kind: null,
+          serviceName: null,
+          timeoutAt: null,
+          maxAttempts: null,
+          recoveryPolicy: null,
+          clearedAt: null,
+          clearReason: null,
+        },
+      },
+      monitorNextCheckAt: new Date(nextCheckAt),
+      monitorScheduledBy: "assignee",
+    });
+
+    const result = await productivityReviewService(db).reconcileProductivityReviews({
+      now,
+      companyId: seeded.companyId,
+    });
+
+    expect(result.created).toBe(1);
+    const [review] = await listProductivityReviews(seeded.companyId);
+    expect(review?.description).toContain("Primary trigger: `long_active_duration`");
+  });
+
+  it("still creates long-active reviews for cleared stale monitor state", async () => {
+    const now = new Date("2026-07-01T21:00:00.000Z");
+    const nextCheckAt = "2026-08-03T14:00:00.000Z";
+    const seeded = await seedAssignedIssue({
+      status: "in_progress",
+      startedAt: new Date("2026-06-30T12:00:00.000Z"),
+      executionPolicy: {
+        mode: "normal",
+        commentRequired: true,
+        stages: [],
+        monitor: {
+          nextCheckAt,
+          scheduledBy: "assignee",
+        },
+      },
+      executionState: {
+        status: "idle",
+        currentStageId: null,
+        currentStageIndex: null,
+        currentStageType: null,
+        currentParticipant: null,
+        returnAssignee: null,
+        reviewRequest: null,
+        completedStageIds: [],
+        lastDecisionId: null,
+        lastDecisionOutcome: null,
+        monitor: {
+          status: "cleared",
+          nextCheckAt: null,
+          lastTriggeredAt: null,
+          attemptCount: 0,
+          notes: null,
+          scheduledBy: "assignee",
+          kind: null,
+          serviceName: null,
+          timeoutAt: null,
+          maxAttempts: null,
+          recoveryPolicy: null,
+          clearedAt: "2026-07-01T20:00:00.000Z",
+          clearReason: "cancelled",
+        },
+      },
+      monitorNextCheckAt: new Date(nextCheckAt),
+      monitorScheduledBy: "assignee",
+    });
+
+    const result = await productivityReviewService(db).reconcileProductivityReviews({
+      now,
+      companyId: seeded.companyId,
+    });
+
+    expect(result.created).toBe(1);
+    const [review] = await listProductivityReviews(seeded.companyId);
+    expect(review?.description).toContain("Primary trigger: `long_active_duration`");
   });
 
   it("creates a high-churn review even when every sampled run has a progress comment", async () => {

--- a/server/src/services/productivity-review.ts
+++ b/server/src/services/productivity-review.ts
@@ -138,6 +138,23 @@ function coerceDate(value: Date | string | null | undefined) {
   return value instanceof Date ? value : new Date(value);
 }
 
+function readRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null;
+}
+
+function readDateMs(value: unknown): number | null {
+  if (!(typeof value === "string" || value instanceof Date)) return null;
+  const date = value instanceof Date ? value : new Date(value);
+  const time = date.getTime();
+  return Number.isNaN(time) ? null : time;
+}
+
+function readPositiveIntegerValue(value: unknown): number | null {
+  return typeof value === "number" && Number.isInteger(value) && value > 0 ? value : null;
+}
+
 function buildThresholds(overrides?: Partial<ProductivityReviewThresholds>): ProductivityReviewThresholds {
   return {
     noCommentStreakRuns: readPositiveInteger(
@@ -198,6 +215,39 @@ function formatTrigger(trigger: ProductivityReviewTrigger) {
   if (trigger === "no_comment_streak") return "No-comment streak";
   if (trigger === "high_churn") return "High churn";
   return "Long active duration";
+}
+
+function hasFutureActiveIssueMonitor(sourceIssue: Pick<
+  IssueRow,
+  "status" | "assigneeAgentId" | "assigneeUserId" | "executionPolicy" | "executionState" | "monitorAttemptCount" | "monitorNextCheckAt"
+>, now: Date) {
+  if (sourceIssue.status !== "in_progress" || !sourceIssue.assigneeAgentId || sourceIssue.assigneeUserId) {
+    return false;
+  }
+
+  const nowMs = now.getTime();
+  const nextCheckAtMs = readDateMs(sourceIssue.monitorNextCheckAt);
+  if (nextCheckAtMs === null || nextCheckAtMs <= nowMs) return false;
+
+  const policyMonitor = readRecord(readRecord(sourceIssue.executionPolicy)?.monitor);
+  const stateMonitor = readRecord(readRecord(sourceIssue.executionState)?.monitor);
+  if (!policyMonitor || stateMonitor?.status !== "scheduled") return false;
+
+  const policyNextCheckAtMs = readDateMs(policyMonitor.nextCheckAt);
+  if (policyNextCheckAtMs === null || policyNextCheckAtMs <= nowMs) return false;
+
+  const stateNextCheckAtMs = readDateMs(stateMonitor.nextCheckAt);
+  if (stateNextCheckAtMs === null || stateNextCheckAtMs <= nowMs) return false;
+
+  const timeoutAtMs = readDateMs(policyMonitor.timeoutAt ?? stateMonitor.timeoutAt);
+  if (timeoutAtMs !== null && timeoutAtMs <= nowMs) return false;
+
+  const maxAttempts = readPositiveIntegerValue(policyMonitor.maxAttempts ?? stateMonitor.maxAttempts);
+  const stateAttemptCount = readPositiveIntegerValue(stateMonitor.attemptCount) ?? 0;
+  const attemptCount = sourceIssue.monitorAttemptCount ?? stateAttemptCount;
+  if (maxAttempts !== null && attemptCount >= maxAttempts) return false;
+
+  return true;
 }
 
 export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: EnqueueWakeup }) {
@@ -476,7 +526,10 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
       : null;
 
     const noComment = noCommentStreak >= thresholds.noCommentStreakRuns;
-    const longActive = elapsedMs !== null && elapsedMs >= thresholds.longActiveMs;
+    const longActive =
+      elapsedMs !== null &&
+      elapsedMs >= thresholds.longActiveMs &&
+      !hasFutureActiveIssueMonitor(sourceIssue, now);
     const highChurn =
       runCountLastHour >= thresholds.highChurnHourly ||
       assigneeRunCommentCountLastHour >= thresholds.highChurnHourly ||

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -380,6 +380,39 @@ function isRepeatedProductiveContinuationRecovery(latestRun: SuccessfulLatestIss
     isProductiveContinuationRun(latestRun);
 }
 
+function readDateMs(value: unknown): number | null {
+  if (!(typeof value === "string" || value instanceof Date)) return null;
+  const time = (value instanceof Date ? value : new Date(value)).getTime();
+  return Number.isNaN(time) ? null : time;
+}
+
+function readPositiveInteger(value: unknown): number | null {
+  return typeof value === "number" && Number.isInteger(value) && value > 0 ? value : null;
+}
+
+function hasScheduledIssueMonitor(issue: Pick<
+  typeof issues.$inferSelect,
+  "executionPolicy" | "executionState" | "monitorAttemptCount" | "monitorNextCheckAt"
+>) {
+  const nowMs = Date.now();
+  const nextCheckAtMs = readDateMs(issue.monitorNextCheckAt);
+  if (nextCheckAtMs === null || nextCheckAtMs <= nowMs) return false;
+
+  const policyMonitor = parseObject(parseObject(issue.executionPolicy)?.monitor);
+  const stateMonitor = parseObject(parseObject(issue.executionState)?.monitor);
+  if (stateMonitor?.status !== "scheduled") return false;
+
+  const timeoutAtMs = readDateMs(policyMonitor?.timeoutAt ?? stateMonitor?.timeoutAt);
+  if (timeoutAtMs !== null && timeoutAtMs <= nowMs) return false;
+
+  const maxAttempts = readPositiveInteger(policyMonitor?.maxAttempts ?? stateMonitor?.maxAttempts);
+  const stateAttemptCount = readPositiveInteger(stateMonitor?.attemptCount) ?? 0;
+  const attemptCount = issue.monitorAttemptCount ?? stateAttemptCount;
+  if (maxAttempts !== null && attemptCount >= maxAttempts) return false;
+
+  return true;
+}
+
 function parseLivenessIncidentKey(incidentKey: string | null | undefined) {
   if (!incidentKey) return null;
   return parseIssueGraphLivenessIncidentKey(incidentKey);
@@ -2756,6 +2789,11 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       }
 
       if (await hasPendingWakeInteraction(issue.companyId, issue.id)) {
+        result.skipped += 1;
+        continue;
+      }
+
+      if (issue.status === "in_progress" && hasScheduledIssueMonitor(issue)) {
         result.skipped += 1;
         continue;
       }


### PR DESCRIPTION
## Summary

- Suppress `long_active_duration` productivity reviews when an in-progress agent-owned issue has an active future scheduled issue monitor.
- Require the denormalized monitor timestamp, execution policy monitor, and execution state monitor to all indicate a future scheduled wake path.
- Keep long-active review protection for no monitor, past-due monitors, and cleared/stale monitor state.
- Retains the branch's existing recovery-service scheduled monitor guard from the prior commit.

## Proof

- `pnpm exec vitest run src/__tests__/productivity-review-service.test.ts --config vitest.config.ts` from `server/`: 14 passed.
- `pnpm --filter @paperclipai/server typecheck`: passed.

## Notes

- Covers [RR-4152](/RR/issues/RR-4152) and [RR-4120](/RR/issues/RR-4120)-shaped scheduled monitor data with `nextCheckAt = 2026-08-03T14:00:00Z`.
