### PR TITLE
Add plugin upgrade UI and external adapter label humanization

### DIFF
--- a/server/src/services/plugin-loader.ts
+++ b/server/src/services/plugin-loader.ts
@@ -1158,8 +1158,8 @@ export function pluginLoader(
         "plugin-loader: fetching plugin from local path",
       );
     } else {
-      // npm install
-      const spec = version ? `${packageName}@${version}` : packageName!;
+      // npm install — @latest when no pin so upgrades refresh the tarball (prefix package.json can otherwise keep the old semver).
+      const spec = version ? `${packageName}@${version}` : `${packageName}@latest`;
 
       log.info(
         { spec, installDir: targetInstallDir },

--- a/ui/src/adapters/adapter-display-registry.test.ts
+++ b/ui/src/adapters/adapter-display-registry.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { getAdapterLabel } from "./adapter-display-registry";
+
+describe("getAdapterLabel", () => {
+  it("keeps built-in display map labels with local suffix", () => {
+    expect(getAdapterLabel("claude_local")).toBe("Claude Code (local)");
+  });
+
+  it("parenthesizes external adapter type segments after the first", () => {
+    expect(getAdapterLabel("cursor_phantom_agent")).toBe("Cursor (Phantom Agent)");
+    expect(getAdapterLabel("hermes_phantom_agent")).toBe("Hermes (Phantom Agent)");
+  });
+});

--- a/ui/src/adapters/adapter-display-registry.test.ts
+++ b/ui/src/adapters/adapter-display-registry.test.ts
@@ -10,4 +10,8 @@ describe("getAdapterLabel", () => {
     expect(getAdapterLabel("cursor_phantom_agent")).toBe("Cursor (Phantom Agent)");
     expect(getAdapterLabel("hermes_phantom_agent")).toBe("Hermes (Phantom Agent)");
   });
+
+  it("uses flat spacing before suffix for multi-segment local adapters", () => {
+    expect(getAdapterLabel("phantom_agent_local")).toBe("Phantom Agent (local)");
+  });
 });

--- a/ui/src/adapters/adapter-display-registry.ts
+++ b/ui/src/adapters/adapter-display-registry.ts
@@ -146,9 +146,11 @@ function titleCaseSegment(segment: string): string {
 function humanizeType(type: string): string {
   // Strip known type suffixes so "droid_local" → "Droid", not "Droid Local"
   let base = type;
+  let hadKnownSuffix = false;
   for (const suffix of Object.keys(TYPE_SUFFIXES)) {
     if (base.endsWith(suffix)) {
       base = base.slice(0, -suffix.length);
+      hadKnownSuffix = true;
       break;
     }
   }
@@ -156,6 +158,11 @@ function humanizeType(type: string): string {
   const parts = base.split("_").filter(Boolean);
   if (parts.length === 0) return type;
   if (parts.length === 1) return titleCaseSegment(parts[0]!);
+
+  // Suffix types keep flat spacing; withSuffix adds "(local)" / "(gateway)" once.
+  if (hadKnownSuffix) {
+    return parts.map(titleCaseSegment).join(" ");
+  }
 
   // External adapters: cursor_phantom_agent → "Cursor (Phantom Agent)"
   const head = titleCaseSegment(parts[0]!);

--- a/ui/src/adapters/adapter-display-registry.ts
+++ b/ui/src/adapters/adapter-display-registry.ts
@@ -139,6 +139,10 @@ const adapterDisplayMap: Record<string, AdapterDisplayInfo> = {
 // Public API
 // ---------------------------------------------------------------------------
 
+function titleCaseSegment(segment: string): string {
+  return segment.replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
 function humanizeType(type: string): string {
   // Strip known type suffixes so "droid_local" → "Droid", not "Droid Local"
   let base = type;
@@ -148,7 +152,15 @@ function humanizeType(type: string): string {
       break;
     }
   }
-  return base.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+
+  const parts = base.split("_").filter(Boolean);
+  if (parts.length === 0) return type;
+  if (parts.length === 1) return titleCaseSegment(parts[0]!);
+
+  // External adapters: cursor_phantom_agent → "Cursor (Phantom Agent)"
+  const head = titleCaseSegment(parts[0]!);
+  const tail = parts.slice(1).map(titleCaseSegment).join(" ");
+  return `${head} (${tail})`;
 }
 
 export function getAdapterLabel(type: string): string {

--- a/ui/src/api/plugins.ts
+++ b/ui/src/api/plugins.ts
@@ -324,7 +324,7 @@ export const pluginsApi = {
    * @param version - Target version (optional; defaults to latest published).
    */
   upgrade: (pluginId: string, version?: string) =>
-    api.post<{ ok: boolean }>(`/plugins/${pluginId}/upgrade`, version ? { version } : {}),
+    api.post<PluginRecord>(`/plugins/${pluginId}/upgrade`, version ? { version } : {}),
 
   /**
    * Returns normalized UI contribution declarations for ready plugins.

--- a/ui/src/pages/PluginManager.tsx
+++ b/ui/src/pages/PluginManager.tsx
@@ -297,6 +297,8 @@ export function PluginManager() {
 
   const installedPlugins = plugins ?? [];
   const bundledPlugins = bundledQuery.data ?? [];
+  const upgradingPluginId =
+    upgradeMutation.isPending ? (upgradeMutation.variables?.pluginId ?? null) : null;
   const installedByPackageName = new Map(installedPlugins.map((plugin) => [plugin.packageName, plugin]));
   const bundledByPackageName = new Map(bundledPlugins.map((plugin) => [plugin.packageName, plugin]));
   // Scope the in-section banner to bundled (local-path) installs so an npm-dialog
@@ -581,10 +583,15 @@ export function PluginManager() {
                             size="icon-sm"
                             className="h-8 w-8"
                             title="Upgrade plugin (pull latest from npm)"
-                            disabled={upgradeMutation.isPending}
+                            disabled={upgradingPluginId === plugin.id}
                             onClick={() => setUpgradeTarget(plugin)}
                           >
-                            <RefreshCw className={cn("h-4 w-4", upgradeMutation.isPending && "animate-spin")} />
+                            <RefreshCw
+                              className={cn(
+                                "h-4 w-4",
+                                upgradingPluginId === plugin.id && "animate-spin",
+                              )}
+                            />
                           </Button>
                         )}
                         <Button
@@ -641,7 +648,7 @@ export function PluginManager() {
       <UpgradePluginDialog
         plugin={upgradeTarget}
         open={upgradeTarget !== null}
-        isUpgrading={upgradeMutation.isPending}
+        isUpgrading={upgradingPluginId !== null && upgradeTarget?.id === upgradingPluginId}
         onConfirm={(targetVersion) => {
           if (upgradeTarget) {
             upgradeMutation.mutate({ pluginId: upgradeTarget.id, version: targetVersion });

--- a/ui/src/pages/PluginManager.tsx
+++ b/ui/src/pages/PluginManager.tsx
@@ -8,7 +8,7 @@ import { useEffect, useMemo, useState } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import type { PluginRecord } from "@paperclipai/shared";
 import { Link } from "@/lib/router";
-import { AlertTriangle, FlaskConical, Plus, Power, Puzzle, Settings, Trash } from "lucide-react";
+import { AlertTriangle, FlaskConical, Plus, Power, Puzzle, RefreshCw, Settings, Trash } from "lucide-react";
 import { useCompany } from "@/context/CompanyContext";
 import { useBreadcrumbs } from "@/context/BreadcrumbContext";
 import { pluginsApi } from "@/api/plugins";
@@ -68,6 +68,106 @@ function ExperimentalBadge() {
   );
 }
 
+function isNpmInstalledPlugin(plugin: PluginRecord): boolean {
+  return !plugin.packagePath;
+}
+
+function fetchNpmLatestVersion(packageName: string): Promise<string | null> {
+  return fetch(`https://registry.npmjs.org/${encodeURIComponent(packageName)}/latest`, {
+    signal: AbortSignal.timeout(5000),
+  })
+    .then((res) => res.json())
+    .then((data) => (typeof data?.version === "string" ? (data.version as string) : null))
+    .catch(() => null);
+}
+
+function UpgradePluginDialog({
+  plugin,
+  open,
+  isUpgrading,
+  onConfirm,
+  onCancel,
+}: {
+  plugin: PluginRecord | null;
+  open: boolean;
+  isUpgrading: boolean;
+  onConfirm: (targetVersion?: string) => void;
+  onCancel: () => void;
+}) {
+  const { data: latestVersion, isLoading: isFetchingVersion } = useQuery({
+    queryKey: ["npm-latest-version", plugin?.packageName],
+    queryFn: () => {
+      if (!plugin?.packageName) return null;
+      return fetchNpmLatestVersion(plugin.packageName);
+    },
+    enabled: open && !!plugin?.packageName,
+    staleTime: 60_000,
+  });
+
+  const installedVersion = plugin?.manifestJson.version ?? plugin?.version;
+  const isUpToDate = installedVersion && latestVersion && installedVersion === latestVersion;
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => { if (!o) onCancel(); }}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Upgrade Plugin</DialogTitle>
+          <DialogDescription>
+            Pull the latest version of{" "}
+            <strong>{plugin?.packageName}</strong> from npm. Plugin settings are
+            preserved; the worker restarts with the new package.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="rounded-md border bg-muted/50 px-4 py-3 text-sm space-y-1">
+          <div className="flex items-center justify-between">
+            <span className="text-muted-foreground">Package</span>
+            <span className="font-mono">{plugin?.packageName}</span>
+          </div>
+          <div className="flex items-center justify-between">
+            <span className="text-muted-foreground">Installed</span>
+            <span className="font-mono">
+              {installedVersion ? `v${installedVersion}` : "unknown"}
+            </span>
+          </div>
+          <div className="flex items-center justify-between">
+            <span className="text-muted-foreground">Latest on npm</span>
+            <span className="font-mono">
+              {isFetchingVersion
+                ? "checking..."
+                : latestVersion
+                  ? `v${latestVersion}`
+                  : "unavailable"}
+            </span>
+          </div>
+          {isUpToDate && (
+            <p className="text-xs text-muted-foreground pt-1">
+              npm reports you are on the latest published package version.
+            </p>
+          )}
+          {!isUpToDate && latestVersion && installedVersion && (
+            <p className="text-xs text-muted-foreground pt-1">
+              Upgrade will install v{latestVersion} from npm.
+            </p>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={onCancel} disabled={isUpgrading}>
+            Cancel
+          </Button>
+          <Button
+            disabled={isUpgrading || isFetchingVersion}
+            onClick={() => onConfirm(latestVersion ?? undefined)}
+          >
+            {isUpgrading ? "Upgrading..." : latestVersion ? `Upgrade to v${latestVersion}` : "Upgrade"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
 /**
  * PluginManager page component.
  *
@@ -95,6 +195,7 @@ export function PluginManager() {
   const [installDialogOpen, setInstallDialogOpen] = useState(false);
   const [uninstallPluginId, setUninstallPluginId] = useState<string | null>(null);
   const [uninstallPluginName, setUninstallPluginName] = useState<string>("");
+  const [upgradeTarget, setUpgradeTarget] = useState<PluginRecord | null>(null);
   const [errorDetailsPlugin, setErrorDetailsPlugin] = useState<PluginRecord | null>(null);
 
   useEffect(() => {
@@ -169,6 +270,31 @@ export function PluginManager() {
     },
   });
 
+  const upgradeMutation = useMutation({
+    mutationFn: ({ pluginId, version }: { pluginId: string; version?: string }) =>
+      pluginsApi.upgrade(pluginId, version),
+    onSuccess: (result, variables) => {
+      invalidatePluginQueries();
+      setUpgradeTarget(null);
+      const version = result?.manifestJson?.version ?? result?.version;
+      const needsApproval = result?.status === "upgrade_pending";
+      pushToast({
+        title: needsApproval ? "Upgrade pending approval" : "Plugin upgraded",
+        body: needsApproval
+          ? "New capabilities require review — click Enable to activate."
+          : version
+            ? variables.version && version !== variables.version
+              ? `Installed v${version} (requested v${variables.version}).`
+              : `Now running v${version}.`
+            : undefined,
+        tone: needsApproval ? "info" : "success",
+      });
+    },
+    onError: (err: Error) => {
+      pushToast({ title: "Failed to upgrade plugin", body: err.message, tone: "error" });
+    },
+  });
+
   const installedPlugins = plugins ?? [];
   const bundledPlugins = bundledQuery.data ?? [];
   const installedByPackageName = new Map(installedPlugins.map((plugin) => [plugin.packageName, plugin]));
@@ -209,6 +335,7 @@ export function PluginManager() {
               <DialogTitle>Install Plugin</DialogTitle>
               <DialogDescription>
                 Enter the npm package name of the plugin you wish to install.
+                If it is already installed, use <strong>Upgrade</strong> on the plugin row instead.
               </DialogDescription>
             </DialogHeader>
             <div className="grid gap-4 py-4">
@@ -445,13 +572,32 @@ export function PluginManager() {
                             plugin.status === "ready" ? "bg-green-600 hover:bg-green-700" : ""
                           )}
                         >
-                          {plugin.status}
+                          {plugin.status === "upgrade_pending" ? "upgrade pending" : plugin.status}
                         </Badge>
+                        {isNpmInstalledPlugin(plugin) &&
+                          (plugin.status === "ready" || plugin.status === "upgrade_pending") && (
+                          <Button
+                            variant="outline"
+                            size="icon-sm"
+                            className="h-8 w-8"
+                            title="Upgrade plugin (pull latest from npm)"
+                            disabled={upgradeMutation.isPending}
+                            onClick={() => setUpgradeTarget(plugin)}
+                          >
+                            <RefreshCw className={cn("h-4 w-4", upgradeMutation.isPending && "animate-spin")} />
+                          </Button>
+                        )}
                         <Button
                           variant="outline"
                           size="icon-sm"
                           className="h-8 w-8"
-                          title={plugin.status === "ready" ? "Disable" : "Enable"}
+                          title={
+                            plugin.status === "ready"
+                              ? "Disable"
+                              : plugin.status === "upgrade_pending"
+                                ? "Approve upgrade and enable"
+                                : "Enable"
+                          }
                           onClick={() => {
                             if (plugin.status === "ready") {
                               disableMutation.mutate(plugin.id);
@@ -491,6 +637,18 @@ export function PluginManager() {
           </ul>
         )}
       </section>
+
+      <UpgradePluginDialog
+        plugin={upgradeTarget}
+        open={upgradeTarget !== null}
+        isUpgrading={upgradeMutation.isPending}
+        onConfirm={(targetVersion) => {
+          if (upgradeTarget) {
+            upgradeMutation.mutate({ pluginId: upgradeTarget.id, version: targetVersion });
+          }
+        }}
+        onCancel={() => setUpgradeTarget(null)}
+      />
 
       <Dialog
         open={uninstallPluginId !== null}


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Plugins extend Paperclip via npm packages; Plugin Manager is the operator surface for install/enable/configure
> - The upgrade API and CLI already existed, but Plugin Manager only exposed Install — re-installing the same package fails with "already installed"
> - External facade adapters (e.g. `@phantomagent/adapter-paperclip-cursor`) use multi-segment type ids that read poorly in agent dropdowns without per-package display-map entries
> - Operators onboarding Connected Applications need a one-click path to pick up new plugin releases and readable adapter labels
> - This pull request adds Plugin Manager upgrade UI, fixes npm `@latest` on unpinned plugin installs, and humanizes multi-segment external adapter types
> - The benefit is parity with Adapter Manager reinstall and cleaner facade adapter labels for Phantom Connected Application onboarding

## Linked Issues or Issue Description

No existing public issue. **In-PR description (feature):**

**Problem:** Plugin Manager could install npm plugins but not upgrade them in UI. Un-versioned plugin-loader installs could keep stale tarballs. Multi-segment external adapter types (e.g. `cursor_phantom_agent`) displayed as awkward title case.

**Desired behavior:** Upgrade button on installed npm plugins with installed vs latest dialog; server pulls `@latest` when unpinned; adapter dropdown shows `Cursor (Phantom Agent)`.

Refs: Phantom Connected Application onboarding (`@phantomagent/plugin-paperclip`).

- [x] I searched GitHub for duplicate or related PRs before opening this PR

## What Changed

- **Plugin Manager:** Upgrade action (refresh icon) + confirmation dialog fetching npm latest; passes target version to existing `POST /api/plugins/:pluginId/upgrade`
- **Plugin Manager:** Per-plugin in-flight spinner (only the upgrading row spins/disables)
- **plugin-loader:** `npm install` uses `@latest` when no version pin (fixes stale prefix installs on upgrade)
- **plugins API client:** `upgrade()` return type corrected to `PluginRecord`
- **adapter-display-registry:** Multi-segment external types → `Head (Tail)`; suffix types (`_local` / `_gateway`) keep flat spacing before suffix
- **Tests:** `adapter-display-registry.test.ts` for facade labels and suffix edge case

## Verification

```bash
cd ui && pnpm exec vitest run src/adapters/adapter-display-registry.test.ts
```

Manual:
1. Install npm plugin at older version (e.g. `@phantomagent/plugin-paperclip@0.1.10`)
2. Plugin Manager → Upgrade → dialog shows installed vs npm latest → confirm
3. Only the upgrading plugin row shows spinner during upgrade
4. Agent adapter dropdown: `cursor_phantom_agent` → **Cursor (Phantom Agent)**

## Risks

- **Low–medium:** Un-versioned plugin installs now resolve `@latest` instead of bare package name — intentional for upgrade correctness; fresh installs get latest (same as Adapter Manager reinstall behavior)
- **Low:** Upgrade dialog fetches `registry.npmjs.org` client-side — fails gracefully for private/unpublished packages (shows "unavailable")
- **Low:** Adapter label humanization is display-only; adapter `type` strings unchanged

## Model Used

- **Provider:** Cursor (Auto agent router)
- **Model:** Claude (Composer-family coding agent)
- **Assist:** Code generation and review-response edits; human directed scope and PR framing

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes: #` / `Refs: #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (`feat/plugin-upgrade-facade-labels`) and contains no internal Paperclip ticket id
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes (not needed — UI uses existing upgrade API)
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green (pending CI)
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups (addressed code P2s in latest commit)
- [x] I will address all Greptile and reviewer comments before requesting merge

**Screenshots:** Upgrade button + dialog are in Settings → Instance → Plugins on installed npm plugins. (Screenshots to be added during manual QA if required.)
