### PR TITLE
feat(sandbox): stream command output live across the plugin worker boundary

### DIFF
--- a/packages/adapter-utils/src/command-managed-runtime.ts
+++ b/packages/adapter-utils/src/command-managed-runtime.ts
@@ -34,6 +34,10 @@ export interface CommandManagedRuntimeRunner {
     // logging. Runners that cannot stream may ignore this and leave `streamed`
     // unset — the caller then falls back to the buffered result unchanged.
     onOutput?: (stream: "stdout" | "stderr", text: string) => void | Promise<void>;
+    // Run correlation id. A streaming runner forwards this to the sandbox
+    // provider so worker-emitted output chunks can be routed back to `onOutput`
+    // over the plugin worker RPC boundary (the callback itself can't cross it).
+    runId?: string;
     onSpawn?: (meta: { pid: number; startedAt: string }) => Promise<void>;
   }): Promise<RunProcessResult>;
 }

--- a/packages/adapter-utils/src/command-managed-runtime.ts
+++ b/packages/adapter-utils/src/command-managed-runtime.ts
@@ -26,6 +26,14 @@ export interface CommandManagedRuntimeRunner {
     stdin?: string;
     timeoutMs?: number;
     onLog?: (stream: "stdout" | "stderr", chunk: string) => Promise<void>;
+    // Optional live-output sink. When the runner supports it, this is invoked
+    // per stdout/stderr chunk AS the command produces output (instead of only
+    // after it exits), letting the caller live-tail progress. A runner that
+    // delivers chunks here MUST set `streamed: true` on its RunProcessResult so
+    // the caller can suppress the trailing buffered dump and avoid double
+    // logging. Runners that cannot stream may ignore this and leave `streamed`
+    // unset — the caller then falls back to the buffered result unchanged.
+    onOutput?: (stream: "stdout" | "stderr", text: string) => void | Promise<void>;
     onSpawn?: (meta: { pid: number; startedAt: string }) => Promise<void>;
   }): Promise<RunProcessResult>;
 }

--- a/packages/adapter-utils/src/execution-target.ts
+++ b/packages/adapter-utils/src/execution-target.ts
@@ -420,6 +420,13 @@ export async function runAdapterExecutionTargetProcess(
       stdin: options.stdin,
       timeoutMs: options.timeoutSec > 0 ? options.timeoutSec * 1000 : target.timeoutMs ?? undefined,
       onLog: options.onLog,
+      // Live-output sink: route each streamed chunk to the same log tail. A
+      // runner that streams sets `streamed` on its result so the buffered dump
+      // is suppressed upstream (no double logging). Sync fire-and-forget — do
+      // not await onLog on the live path so a chunk never stalls the stream.
+      onOutput: (stream, text) => {
+        void options.onLog(stream, text);
+      },
       onSpawn: options.onSpawn
         ? async (meta) => options.onSpawn?.({ ...meta, processGroupId: null })
         : undefined,
@@ -522,6 +529,11 @@ export async function runAdapterExecutionTargetShellCommand(
       env,
       timeoutMs: (options.timeoutSec ?? 15) * 1000,
       onLog,
+      // Route streamed chunks to the same log tail; a streaming runner sets
+      // `streamed` so the buffered dump is suppressed upstream (no double log).
+      onOutput: (stream, text) => {
+        void onLog(stream, text);
+      },
     });
   }
 

--- a/packages/adapter-utils/src/execution-target.ts
+++ b/packages/adapter-utils/src/execution-target.ts
@@ -420,6 +420,9 @@ export async function runAdapterExecutionTargetProcess(
       stdin: options.stdin,
       timeoutMs: options.timeoutSec > 0 ? options.timeoutSec * 1000 : target.timeoutMs ?? undefined,
       onLog: options.onLog,
+      // Forward the run id so a streaming sandbox runner can bridge worker
+      // output chunks back to onLog live (across the plugin worker boundary).
+      runId,
       // Live-output sink: route each streamed chunk to the same log tail. A
       // runner that streams sets `streamed` on its result so the buffered dump
       // is suppressed upstream (no double logging). Sync fire-and-forget — do
@@ -529,6 +532,9 @@ export async function runAdapterExecutionTargetShellCommand(
       env,
       timeoutMs: (options.timeoutSec ?? 15) * 1000,
       onLog,
+      // Forward the run id so a streaming sandbox runner can bridge worker
+      // output chunks back to onLog live (across the plugin worker boundary).
+      runId,
       // Route streamed chunks to the same log tail; a streaming runner sets
       // `streamed` so the buffered dump is suppressed upstream (no double log).
       onOutput: (stream, text) => {

--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -19,6 +19,12 @@ export interface RunProcessResult {
   stderr: string;
   pid: number | null;
   startedAt: string | null;
+  // True when the runner already delivered stdout/stderr live via `onOutput`
+  // (chunk-by-chunk) during execution. Callers use this to suppress the
+  // trailing buffered `onLog(result.stdout/stderr)` dump so live-streamed
+  // output is not logged a second time at the end. Undefined/false means the
+  // caller should fall back to the buffered dump (unchanged legacy behavior).
+  streamed?: boolean;
 }
 
 export interface TerminalResultCleanupOptions {

--- a/packages/plugins/sandbox-providers/kubernetes/src/plugin.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/src/plugin.ts
@@ -1,6 +1,7 @@
 import { randomBytes } from "node:crypto";
 import { definePlugin } from "@paperclipai/plugin-sdk";
 import type {
+  PluginContext,
   PluginEnvironmentAcquireLeaseParams,
   PluginEnvironmentDestroyLeaseParams,
   PluginEnvironmentExecuteParams,
@@ -109,8 +110,15 @@ const readySandboxesByLease = new Set<string>();
 const RESUME_READY_TIMEOUT_MS = 30_000;
 const RESUME_READY_POLL_MS = 1_000;
 
+// Captured at setup() so the environment handlers (which receive only their
+// params, not the context) can reach `ctx.streams` to push live output back to
+// the host over the plugin worker RPC boundary. One worker process runs a
+// single plugin instance, so a module-level singleton is correct here.
+let pluginContext: PluginContext | null = null;
+
 const plugin = definePlugin({
   async setup(ctx) {
+    pluginContext = ctx;
     ctx.logger.info("Kubernetes sandbox provider plugin ready");
   },
 
@@ -523,25 +531,69 @@ const plugin = definePlugin({
   ): Promise<PluginEnvironmentExecuteResult> {
     const { lease, timeoutMs } = params;
 
-    // Live-output sink. When present (in-process callers only; not delivered
-    // over the plugin worker RPC boundary), forward each stdout/stderr chunk as
-    // the command produces it so the caller can live-tail progress instead of
-    // only seeing the buffered output at the end. `onChunk` is a sync,
-    // fire-and-forget shim over the possibly-async `onOutput`: it must not be
-    // awaited inside the exec data handler (that would stall the stream) and a
-    // throwing consumer must never break capture — hence the guard here and in
-    // execInPod. Providers that receive `onOutput` set `streamed: true` on the
-    // result so the caller can suppress the trailing buffered log dump.
+    // Live-output streaming. Two independent sinks, either or both of which may
+    // be active for a single exec:
+    //
+    // 1. In-process `params.onOutput` callback. Only present when the plugin is
+    //    called in-process (not over the worker RPC boundary — a function can't
+    //    be serialized), e.g. some tests. Called per chunk.
+    //
+    // 2. Worker→host `ctx.streams` bridge. On the real cloud path the plugin
+    //    runs in a worker, so `onOutput` is absent; instead the host passes the
+    //    serializable `runId` + `streamOutput: true` and subscribes to the
+    //    stream channel `env-exec-output:${runId}`. We open that channel, emit
+    //    each chunk on it (delivered to the host as a `streams.emit` JSON-RPC
+    //    notification), and close it in a finally. This is the RPC-safe
+    //    replacement for the callback.
+    //
+    // `onChunk` is a sync, fire-and-forget shim: it must not be awaited inside
+    // the exec data handler (that would stall the stream) and a throwing
+    // consumer must never break capture — hence the guards. Whenever a chunk
+    // sink is active the result is flagged `streamed: true` so the caller
+    // suppresses the trailing buffered log dump (no double logging).
     const onOutput = params.onOutput;
-    const onChunk = onOutput
-      ? (stream: "stdout" | "stderr", text: string) => {
-          try {
-            void onOutput(stream, text);
-          } catch {
-            /* best-effort live streaming; buffered result is authoritative */
+    const streams = pluginContext?.streams;
+    const streamViaCtx = Boolean(
+      params.streamOutput && params.runId && params.companyId && streams,
+    );
+    const outputChannel = streamViaCtx ? `env-exec-output:${params.runId}` : null;
+    const onChunk =
+      onOutput || streamViaCtx
+        ? (stream: "stdout" | "stderr", text: string) => {
+            if (onOutput) {
+              try {
+                void onOutput(stream, text);
+              } catch {
+                /* best-effort live streaming; buffered result is authoritative */
+              }
+            }
+            if (streamViaCtx && streams && outputChannel) {
+              try {
+                streams.emit(outputChannel, { stream, text });
+              } catch {
+                /* best-effort live streaming; buffered result is authoritative */
+              }
+            }
           }
+        : undefined;
+    const openOutputChannel = () => {
+      if (streamViaCtx && streams && outputChannel) {
+        try {
+          streams.open(outputChannel, params.companyId);
+        } catch {
+          /* best-effort; a failed open must not abort execution */
         }
-      : undefined;
+      }
+    };
+    const closeOutputChannel = () => {
+      if (streamViaCtx && streams && outputChannel) {
+        try {
+          streams.close(outputChannel);
+        } catch {
+          /* best-effort; close is idempotent on the host side */
+        }
+      }
+    };
 
     if (!lease.providerLeaseId) {
       return {
@@ -770,26 +822,50 @@ const plugin = definePlugin({
         effectiveTimeoutMs - (Date.now() - executeStartedAt),
       );
 
-      let execResult: { exitCode: number; stdout: string; stderr: string };
+      // Open the live-output channel just before the exec (chunks only flow
+      // from execInPod) and close it in a finally so it is torn down on the
+      // success, timeout, and error return paths alike — no leaked channel.
+      openOutputChannel();
       try {
-        execResult = await execInPod(
-          kc,
-          namespace,
-          podName,
-          "agent",
-          execCommand,
-          typeof params.stdin === "string" ? params.stdin : undefined,
-          remainingTimeoutMs,
-          onChunk,
-        );
-      } catch (err) {
-        // Watchdog-fired or WebSocket-setup error. Surface as a timeout so
-        // the caller can retry instead of hanging forever.
+        let execResult: { exitCode: number; stdout: string; stderr: string };
+        try {
+          execResult = await execInPod(
+            kc,
+            namespace,
+            podName,
+            "agent",
+            execCommand,
+            typeof params.stdin === "string" ? params.stdin : undefined,
+            remainingTimeoutMs,
+            onChunk,
+          );
+        } catch (err) {
+          // Watchdog-fired or WebSocket-setup error. Surface as a timeout so
+          // the caller can retry instead of hanging forever.
+          return {
+            exitCode: null,
+            timedOut: true,
+            stdout: "",
+            stderr: err instanceof Error ? err.message : String(err),
+            metadata: {
+              provider: "kubernetes",
+              backend: "sandbox-cr",
+              namespace,
+              sandboxName: lease.providerLeaseId,
+              podName,
+            },
+          };
+        }
+
         return {
-          exitCode: null,
-          timedOut: true,
-          stdout: "",
-          stderr: err instanceof Error ? err.message : String(err),
+          exitCode: execResult.exitCode,
+          timedOut: false,
+          stdout: execResult.stdout,
+          stderr: execResult.stderr,
+          // Output was delivered live via onChunk (params.onOutput and/or the
+          // ctx.streams bridge); flag it so the caller suppresses the trailing
+          // buffered log dump (no double logging).
+          ...(onChunk ? { streamed: true } : {}),
           metadata: {
             provider: "kubernetes",
             backend: "sandbox-cr",
@@ -798,24 +874,9 @@ const plugin = definePlugin({
             podName,
           },
         };
+      } finally {
+        closeOutputChannel();
       }
-
-      return {
-        exitCode: execResult.exitCode,
-        timedOut: false,
-        stdout: execResult.stdout,
-        stderr: execResult.stderr,
-        // Output was delivered live via onChunk -> onOutput; flag it so the
-        // caller suppresses the trailing buffered log dump (no double logging).
-        ...(onChunk ? { streamed: true } : {}),
-        metadata: {
-          provider: "kubernetes",
-          backend: "sandbox-cr",
-          namespace,
-          sandboxName: lease.providerLeaseId,
-          podName,
-        },
-      };
     } else {
       // ── Job backend (legacy / stable fallback) ──────────────────────────────
       // The container entrypoint is baked into the Job spec (Tini + paperclip-agent-shim).
@@ -824,69 +885,77 @@ const plugin = definePlugin({
       //
       // params.command / params.args / params.stdin are intentionally ignored.
 
-      let status;
-      let timedOut = false;
+      // Open the live-output channel around the whole wait+log-scrape region so
+      // it is closed on the success and timeout paths and if the orchestrator
+      // throws — no leaked channel.
+      openOutputChannel();
       try {
-        status = await jobOrchestrator.waitForCompletion(
-          clients,
-          namespace,
-          lease.providerLeaseId,
-          { timeoutMs: effectiveTimeoutMs, pollMs: 2000 },
-        );
-      } catch (err) {
-        if (err instanceof JobTimeoutError) {
-          timedOut = true;
-          status = null;
-        } else {
-          throw err;
+        let status;
+        let timedOut = false;
+        try {
+          status = await jobOrchestrator.waitForCompletion(
+            clients,
+            namespace,
+            lease.providerLeaseId,
+            { timeoutMs: effectiveTimeoutMs, pollMs: 2000 },
+          );
+        } catch (err) {
+          if (err instanceof JobTimeoutError) {
+            timedOut = true;
+            status = null;
+          } else {
+            throw err;
+          }
         }
-      }
 
-      // Collect logs from the pod.
-      const podName =
-        typeof lease.metadata?.podName === "string"
-          ? lease.metadata.podName
-          : await jobOrchestrator.findPod(
-              clients,
-              namespace,
-              lease.providerLeaseId,
-            );
+        // Collect logs from the pod.
+        const podName =
+          typeof lease.metadata?.podName === "string"
+            ? lease.metadata.podName
+            : await jobOrchestrator.findPod(
+                clients,
+                namespace,
+                lease.providerLeaseId,
+              );
 
-      const stdoutChunks: string[] = [];
-      const stderrChunks: string[] = [];
+        const stdoutChunks: string[] = [];
+        const stderrChunks: string[] = [];
 
-      if (podName) {
-        await jobOrchestrator.streamLogs(
-          clients,
-          namespace,
-          podName,
-          async (stream, text) => {
-            if (stream === "stdout") stdoutChunks.push(text);
-            else stderrChunks.push(text);
-            // Forward each streamed log chunk live so the caller can tail Job
-            // output as it arrives, not only after the Job completes.
-            onChunk?.(stream, text);
+        if (podName) {
+          await jobOrchestrator.streamLogs(
+            clients,
+            namespace,
+            podName,
+            async (stream, text) => {
+              if (stream === "stdout") stdoutChunks.push(text);
+              else stderrChunks.push(text);
+              // Forward each streamed log chunk live so the caller can tail Job
+              // output as it arrives, not only after the Job completes.
+              onChunk?.(stream, text);
+            },
+          );
+        }
+
+        return {
+          exitCode: timedOut ? null : status?.phase === "Succeeded" ? 0 : 1,
+          timedOut,
+          stdout: stdoutChunks.join(""),
+          stderr: stderrChunks.join(""),
+          // Chunks were forwarded live above; flag it so the caller does not log
+          // the buffered output a second time.
+          ...(onChunk ? { streamed: true } : {}),
+          metadata: {
+            provider: "kubernetes",
+            backend: "job",
+            namespace,
+            jobName: lease.providerLeaseId,
+            podName: podName ?? null,
+            phase: status?.phase ?? null,
           },
-        );
+        };
+      } finally {
+        closeOutputChannel();
       }
-
-      return {
-        exitCode: timedOut ? null : status?.phase === "Succeeded" ? 0 : 1,
-        timedOut,
-        stdout: stdoutChunks.join(""),
-        stderr: stderrChunks.join(""),
-        // Chunks were forwarded live above; flag it so the caller does not log
-        // the buffered output a second time.
-        ...(onChunk ? { streamed: true } : {}),
-        metadata: {
-          provider: "kubernetes",
-          backend: "job",
-          namespace,
-          jobName: lease.providerLeaseId,
-          podName: podName ?? null,
-          phase: status?.phase ?? null,
-        },
-      };
     }
   },
 });

--- a/packages/plugins/sandbox-providers/kubernetes/src/plugin.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/src/plugin.ts
@@ -523,6 +523,26 @@ const plugin = definePlugin({
   ): Promise<PluginEnvironmentExecuteResult> {
     const { lease, timeoutMs } = params;
 
+    // Live-output sink. When present (in-process callers only; not delivered
+    // over the plugin worker RPC boundary), forward each stdout/stderr chunk as
+    // the command produces it so the caller can live-tail progress instead of
+    // only seeing the buffered output at the end. `onChunk` is a sync,
+    // fire-and-forget shim over the possibly-async `onOutput`: it must not be
+    // awaited inside the exec data handler (that would stall the stream) and a
+    // throwing consumer must never break capture — hence the guard here and in
+    // execInPod. Providers that receive `onOutput` set `streamed: true` on the
+    // result so the caller can suppress the trailing buffered log dump.
+    const onOutput = params.onOutput;
+    const onChunk = onOutput
+      ? (stream: "stdout" | "stderr", text: string) => {
+          try {
+            void onOutput(stream, text);
+          } catch {
+            /* best-effort live streaming; buffered result is authoritative */
+          }
+        }
+      : undefined;
+
     if (!lease.providerLeaseId) {
       return {
         exitCode: 1,
@@ -760,6 +780,7 @@ const plugin = definePlugin({
           execCommand,
           typeof params.stdin === "string" ? params.stdin : undefined,
           remainingTimeoutMs,
+          onChunk,
         );
       } catch (err) {
         // Watchdog-fired or WebSocket-setup error. Surface as a timeout so
@@ -784,6 +805,9 @@ const plugin = definePlugin({
         timedOut: false,
         stdout: execResult.stdout,
         stderr: execResult.stderr,
+        // Output was delivered live via onChunk -> onOutput; flag it so the
+        // caller suppresses the trailing buffered log dump (no double logging).
+        ...(onChunk ? { streamed: true } : {}),
         metadata: {
           provider: "kubernetes",
           backend: "sandbox-cr",
@@ -839,6 +863,9 @@ const plugin = definePlugin({
           async (stream, text) => {
             if (stream === "stdout") stdoutChunks.push(text);
             else stderrChunks.push(text);
+            // Forward each streamed log chunk live so the caller can tail Job
+            // output as it arrives, not only after the Job completes.
+            onChunk?.(stream, text);
           },
         );
       }
@@ -848,6 +875,9 @@ const plugin = definePlugin({
         timedOut,
         stdout: stdoutChunks.join(""),
         stderr: stderrChunks.join(""),
+        // Chunks were forwarded live above; flag it so the caller does not log
+        // the buffered output a second time.
+        ...(onChunk ? { streamed: true } : {}),
         metadata: {
           provider: "kubernetes",
           backend: "job",

--- a/packages/plugins/sandbox-providers/kubernetes/src/pod-exec.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/src/pod-exec.ts
@@ -61,6 +61,14 @@ export async function execInPod(
   command: string[],
   stdin?: string | Buffer,
   timeoutMs?: number,
+  // Optional live-output sink. Called once per stdout/stderr data frame as it
+  // arrives, in addition to the frame being accumulated into the buffered
+  // result. Lets callers stream command output to the UI as it happens instead
+  // of only seeing it in the resolved `{stdout, stderr}` at the end. Sync,
+  // best-effort, fire-and-forget: it MUST NOT be awaited here (awaiting inside
+  // the data handler would stall the stream) and a throwing consumer must never
+  // break output capture — hence the try/catch guard below.
+  onChunk?: (stream: "stdout" | "stderr", text: string) => void,
 ): Promise<{ exitCode: number; stdout: string; stderr: string }> {
   const exec = new Exec(kc);
   const stdoutStream = new PassThrough();
@@ -92,11 +100,25 @@ export async function execInPod(
   let stdoutData = "";
   let stderrData = "";
 
+  const forwardChunk = (stream: "stdout" | "stderr", text: string) => {
+    if (!onChunk) return;
+    try {
+      onChunk(stream, text);
+    } catch {
+      // A throwing live-output consumer must never break output capture or the
+      // exec result. Swallow it; the buffered {stdout, stderr} is authoritative.
+    }
+  };
+
   stdoutStream.on("data", (chunk: Buffer) => {
-    stdoutData += chunk.toString("utf-8");
+    const text = chunk.toString("utf-8");
+    stdoutData += text;
+    forwardChunk("stdout", text);
   });
   stderrStream.on("data", (chunk: Buffer) => {
-    stderrData += chunk.toString("utf-8");
+    const text = chunk.toString("utf-8");
+    stderrData += text;
+    forwardChunk("stderr", text);
   });
 
   return await new Promise<{ exitCode: number; stdout: string; stderr: string }>(

--- a/packages/plugins/sandbox-providers/kubernetes/test/unit/plugin-execute-stream-rpc.test.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/test/unit/plugin-execute-stream-rpc.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock kube-client so no real cluster is touched.
+vi.mock("../../src/kube-client.js", () => ({
+  createKubeConfig: vi.fn(() => ({})),
+  makeKubeClients: vi.fn(() => ({})),
+}));
+
+// Mock the Sandbox-CR orchestrator: report Ready immediately and resolve the
+// pod name from lease metadata so execute() reaches the exec step.
+vi.mock("../../src/sandbox-cr-orchestrator.js", () => ({
+  sandboxCrOrchestrator: {
+    waitForCompletion: vi.fn().mockResolvedValue({ phase: "Ready" }),
+    findPod: vi.fn().mockResolvedValue("pc-abc-pod"),
+  },
+  SandboxCrTimeoutError: class extends Error {},
+}));
+
+// Mock execInPod but keep the real wrapCommandWithEnv.
+const h = vi.hoisted(() => ({
+  execInPod: vi.fn(),
+}));
+vi.mock("../../src/pod-exec.js", async (importActual) => {
+  const actual = await importActual<typeof import("../../src/pod-exec.js")>();
+  return {
+    ...actual,
+    execInPod: h.execInPod,
+  };
+});
+
+import plugin from "../../src/plugin.js";
+
+const CONFIG = { inCluster: true, backend: "sandbox-cr" };
+
+function executeParams(overrides: Record<string, unknown> = {}) {
+  return {
+    driverKey: "kubernetes",
+    companyId: "acme",
+    environmentId: "env-1",
+    config: CONFIG,
+    lease: {
+      providerLeaseId: "pc-abc",
+      metadata: {
+        namespace: "paperclip-acme",
+        podName: "pc-abc-pod",
+        backend: "sandbox-cr",
+      },
+    },
+    command: "echo",
+    args: ["hi"],
+    timeoutMs: 30_000,
+    ...overrides,
+  } as never;
+}
+
+/** A fake `ctx.streams` recording open/emit/close calls. */
+function makeFakeStreams() {
+  const calls: {
+    open: Array<[string, string]>;
+    emit: Array<[string, unknown]>;
+    close: string[];
+  } = { open: [], emit: [], close: [] };
+  const streams = {
+    open: (channel: string, companyId: string) => calls.open.push([channel, companyId]),
+    emit: (channel: string, event: unknown) => calls.emit.push([channel, event]),
+    close: (channel: string) => calls.close.push(channel),
+  };
+  return { streams, calls };
+}
+
+/** Inject a fake context via setup() so onEnvironmentExecute can reach ctx.streams. */
+async function withFakeContext(streams: unknown) {
+  await plugin.definition.setup({
+    logger: { info() {}, warn() {}, error() {}, debug() {} },
+    streams,
+  } as never);
+}
+
+beforeEach(() => {
+  h.execInPod.mockReset();
+});
+
+describe("onEnvironmentExecute ctx.streams bridge (RPC path)", () => {
+  it("opens/emits/closes on the runId channel and returns streamed:true", async () => {
+    h.execInPod.mockImplementation(
+      async (
+        _kc: unknown,
+        _ns: string,
+        _pod: string,
+        _container: string,
+        _cmd: string[],
+        _stdin: unknown,
+        _timeoutMs: number,
+        onChunk?: (stream: "stdout" | "stderr", text: string) => void,
+      ) => {
+        onChunk?.("stdout", "live-1");
+        onChunk?.("stderr", "live-2");
+        return { exitCode: 0, stdout: "live-1", stderr: "live-2" };
+      },
+    );
+
+    const { streams, calls } = makeFakeStreams();
+    await withFakeContext(streams);
+
+    const result = await plugin.definition.onEnvironmentExecute!(
+      executeParams({ runId: "run-1", companyId: "acme", streamOutput: true }),
+    );
+
+    // Channel opened once, scoped to the company.
+    expect(calls.open).toEqual([["env-exec-output:run-1", "acme"]]);
+    // One emit per chunk, in order, with the { stream, text } shape.
+    expect(calls.emit).toEqual([
+      ["env-exec-output:run-1", { stream: "stdout", text: "live-1" }],
+      ["env-exec-output:run-1", { stream: "stderr", text: "live-2" }],
+    ]);
+    // Channel closed exactly once.
+    expect(calls.close).toEqual(["env-exec-output:run-1"]);
+
+    expect(result.streamed).toBe(true);
+    expect(result.stdout).toBe("live-1");
+  });
+
+  it("closes the channel on the exec error/timeout path", async () => {
+    h.execInPod.mockRejectedValue(new Error("websocket blew up"));
+
+    const { streams, calls } = makeFakeStreams();
+    await withFakeContext(streams);
+
+    const result = await plugin.definition.onEnvironmentExecute!(
+      executeParams({ runId: "run-err", companyId: "acme", streamOutput: true }),
+    );
+
+    expect(calls.open).toEqual([["env-exec-output:run-err", "acme"]]);
+    // Even though the exec threw (surfaced as a timeout), the channel is closed.
+    expect(calls.close).toEqual(["env-exec-output:run-err"]);
+    expect(result.timedOut).toBe(true);
+  });
+
+  it("does not stream when runId is null (buffered fallback, streamed unset)", async () => {
+    h.execInPod.mockResolvedValue({ exitCode: 0, stdout: "buffered", stderr: "" });
+
+    const { streams, calls } = makeFakeStreams();
+    await withFakeContext(streams);
+
+    const result = await plugin.definition.onEnvironmentExecute!(
+      executeParams({ runId: null, companyId: "acme", streamOutput: true }),
+    );
+
+    expect(calls.open).toEqual([]);
+    expect(calls.emit).toEqual([]);
+    expect(calls.close).toEqual([]);
+    // No sink was active -> onChunk undefined -> execInPod got no onChunk fn.
+    expect(typeof h.execInPod.mock.calls[0][7]).not.toBe("function");
+    expect(result.streamed).toBeFalsy();
+    expect(result.stdout).toBe("buffered");
+  });
+
+  it("does not stream when streamOutput is not requested", async () => {
+    h.execInPod.mockResolvedValue({ exitCode: 0, stdout: "buffered", stderr: "" });
+
+    const { streams, calls } = makeFakeStreams();
+    await withFakeContext(streams);
+
+    const result = await plugin.definition.onEnvironmentExecute!(
+      executeParams({ runId: "run-1", companyId: "acme" /* no streamOutput */ }),
+    );
+
+    expect(calls.open).toEqual([]);
+    expect(calls.emit).toEqual([]);
+    expect(calls.close).toEqual([]);
+    expect(result.streamed).toBeFalsy();
+  });
+});

--- a/packages/plugins/sandbox-providers/kubernetes/test/unit/plugin-execute-stream.test.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/test/unit/plugin-execute-stream.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock kube-client so no real cluster is touched.
+vi.mock("../../src/kube-client.js", () => ({
+  createKubeConfig: vi.fn(() => ({})),
+  makeKubeClients: vi.fn(() => ({})),
+}));
+
+// Mock the Sandbox-CR orchestrator: report Ready immediately and resolve the
+// pod name from lease metadata so execute() reaches the exec step.
+vi.mock("../../src/sandbox-cr-orchestrator.js", () => ({
+  sandboxCrOrchestrator: {
+    waitForCompletion: vi.fn().mockResolvedValue({ phase: "Ready" }),
+    findPod: vi.fn().mockResolvedValue("pc-abc-pod"),
+  },
+  SandboxCrTimeoutError: class extends Error {},
+}));
+
+// Mock execInPod but keep the real wrapCommandWithEnv.
+const h = vi.hoisted(() => ({
+  execInPod: vi.fn(),
+}));
+vi.mock("../../src/pod-exec.js", async (importActual) => {
+  const actual = await importActual<typeof import("../../src/pod-exec.js")>();
+  return {
+    ...actual,
+    execInPod: h.execInPod,
+  };
+});
+
+import plugin from "../../src/plugin.js";
+
+const CONFIG = { inCluster: true, backend: "sandbox-cr" };
+
+function executeParams(overrides: Record<string, unknown> = {}) {
+  return {
+    driverKey: "kubernetes",
+    companyId: "acme",
+    environmentId: "env-1",
+    config: CONFIG,
+    lease: {
+      providerLeaseId: "pc-abc",
+      metadata: {
+        namespace: "paperclip-acme",
+        podName: "pc-abc-pod",
+        backend: "sandbox-cr",
+      },
+    },
+    command: "echo",
+    args: ["hi"],
+    timeoutMs: 30_000,
+    ...overrides,
+  } as never;
+}
+
+beforeEach(() => {
+  h.execInPod.mockReset();
+});
+
+describe("onEnvironmentExecute streaming (sandbox-cr)", () => {
+  it("threads onOutput to execInPod as onChunk and returns streamed:true", async () => {
+    h.execInPod.mockImplementation(
+      async (
+        _kc: unknown,
+        _ns: string,
+        _pod: string,
+        _container: string,
+        _cmd: string[],
+        _stdin: unknown,
+        _timeoutMs: number,
+        onChunk?: (stream: "stdout" | "stderr", text: string) => void,
+      ) => {
+        onChunk?.("stdout", "live-1");
+        onChunk?.("stdout", "live-2");
+        return { exitCode: 0, stdout: "live-1live-2", stderr: "" };
+      },
+    );
+
+    const received: Array<[string, string]> = [];
+    const result = await plugin.definition.onEnvironmentExecute!(
+      executeParams({
+        onOutput: (stream: "stdout" | "stderr", text: string) => received.push([stream, text]),
+      }),
+    );
+
+    // execInPod was called with an onChunk function (8th positional arg).
+    expect(h.execInPod).toHaveBeenCalledTimes(1);
+    const call = h.execInPod.mock.calls[0];
+    expect(typeof call[7]).toBe("function");
+
+    // Live chunks reached the caller's onOutput.
+    expect(received).toEqual([
+      ["stdout", "live-1"],
+      ["stdout", "live-2"],
+    ]);
+
+    // Result flags that output was streamed live, and the buffered output is intact.
+    expect(result.streamed).toBe(true);
+    expect(result.stdout).toBe("live-1live-2");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("leaves streamed unset when no onOutput is provided (backward-compatible)", async () => {
+    h.execInPod.mockResolvedValue({ exitCode: 0, stdout: "buffered", stderr: "" });
+
+    const result = await plugin.definition.onEnvironmentExecute!(executeParams());
+
+    expect(h.execInPod).toHaveBeenCalledTimes(1);
+    // 8th positional arg (onChunk) is not a function when no onOutput was passed.
+    expect(typeof h.execInPod.mock.calls[0][7]).not.toBe("function");
+    expect(result.streamed).toBeFalsy();
+    expect(result.stdout).toBe("buffered");
+  });
+});

--- a/packages/plugins/sandbox-providers/kubernetes/test/unit/pod-exec-stream.test.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/test/unit/pod-exec-stream.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi } from "vitest";
+
+// Mock @kubernetes/client-node's Exec so execInPod runs against a fake exec
+// that we drive frame-by-frame. h.execImpl is swapped per test.
+const h = vi.hoisted(() => ({
+  execImpl: null as unknown as (...args: unknown[]) => Promise<unknown>,
+}));
+
+vi.mock("@kubernetes/client-node", () => ({
+  Exec: class {
+    constructor(_kc: unknown) {}
+    exec(...args: unknown[]) {
+      return h.execImpl(...args);
+    }
+  },
+}));
+
+import { execInPod } from "../../src/pod-exec.js";
+
+describe("execInPod streaming (onChunk)", () => {
+  it("forwards each stdout/stderr data frame to onChunk while still buffering the full output", async () => {
+    h.execImpl = async (...args: unknown[]) => {
+      const stdout = args[4] as NodeJS.WritableStream;
+      const stderr = args[5] as NodeJS.WritableStream;
+      const statusCb = args[8] as (status: { status: string }) => void;
+      // Emit two stdout frames + one stderr frame, then a Success status, on a
+      // later tick (mirrors the real client's async data delivery).
+      queueMicrotask(() => {
+        stdout.write(Buffer.from("hello ", "utf-8"));
+        stdout.write(Buffer.from("world", "utf-8"));
+        stderr.write(Buffer.from("warn", "utf-8"));
+        statusCb({ status: "Success" });
+        stdout.end();
+        stderr.end();
+      });
+      return { close: () => {} };
+    };
+
+    const chunks: Array<[string, string]> = [];
+    const result = await execInPod(
+      {} as never,
+      "ns",
+      "pod",
+      "agent",
+      ["echo", "hi"],
+      undefined,
+      5_000,
+      (stream, text) => chunks.push([stream, text]),
+    );
+
+    expect(chunks).toEqual([
+      ["stdout", "hello "],
+      ["stdout", "world"],
+      ["stderr", "warn"],
+    ]);
+    // Buffered result is preserved (concatenation of frames).
+    expect(result.stdout).toBe("hello world");
+    expect(result.stderr).toBe("warn");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("still resolves the buffered result when no onChunk is provided (backward-compatible)", async () => {
+    h.execImpl = async (...args: unknown[]) => {
+      const stdout = args[4] as NodeJS.WritableStream;
+      const stderr = args[5] as NodeJS.WritableStream;
+      const statusCb = args[8] as (status: { status: string }) => void;
+      queueMicrotask(() => {
+        stdout.write(Buffer.from("abc", "utf-8"));
+        statusCb({ status: "Success" });
+        stdout.end();
+        stderr.end();
+      });
+      return { close: () => {} };
+    };
+
+    const result = await execInPod({} as never, "ns", "pod", "agent", ["echo"], undefined, 5_000);
+    expect(result.stdout).toBe("abc");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("does not let a throwing onChunk consumer break output capture", async () => {
+    h.execImpl = async (...args: unknown[]) => {
+      const stdout = args[4] as NodeJS.WritableStream;
+      const stderr = args[5] as NodeJS.WritableStream;
+      const statusCb = args[8] as (status: { status: string }) => void;
+      queueMicrotask(() => {
+        stdout.write(Buffer.from("keep", "utf-8"));
+        statusCb({ status: "Success" });
+        stdout.end();
+        stderr.end();
+      });
+      return { close: () => {} };
+    };
+
+    const result = await execInPod(
+      {} as never,
+      "ns",
+      "pod",
+      "agent",
+      ["echo"],
+      undefined,
+      5_000,
+      () => {
+        throw new Error("consumer blew up");
+      },
+    );
+    expect(result.stdout).toBe("keep");
+    expect(result.exitCode).toBe(0);
+  });
+});

--- a/packages/plugins/sdk/src/protocol.ts
+++ b/packages/plugins/sdk/src/protocol.ts
@@ -644,6 +644,21 @@ export interface PluginEnvironmentExecuteParams extends PluginEnvironmentDriverB
   // delivered on in-process execute paths; over RPC it is absent and the
   // provider falls back to buffered-at-end behavior (streamed stays unset).
   onOutput?: (stream: "stdout" | "stderr", text: string) => void | Promise<void>;
+  // Run correlation id for this execution. Serializable, so unlike `onOutput`
+  // it DOES cross the plugin worker RPC boundary. A provider that runs in a
+  // worker uses it (together with `streamOutput`) to name a `ctx.streams`
+  // output channel the host subscribes to, so stdout/stderr can be tailed live
+  // even though the `onOutput` callback itself cannot be serialized. Null when
+  // the caller has no run context (then live streaming is skipped).
+  runId?: string | null;
+  // Set by the host over RPC to request live output streaming: the provider
+  // should open a `ctx.streams` channel named `env-exec-output:${runId}` and
+  // emit each `{ stream, text }` chunk on it as the command produces output,
+  // then set `streamed: true` on the result. When absent/false (or `runId` is
+  // null), the provider falls back to buffered-at-end output. This is the
+  // serializable signal that replaces the non-serializable `onOutput` callback
+  // on the worker RPC path.
+  streamOutput?: boolean;
 }
 
 export interface PluginEnvironmentExecuteResult {

--- a/packages/plugins/sdk/src/protocol.ts
+++ b/packages/plugins/sdk/src/protocol.ts
@@ -636,6 +636,14 @@ export interface PluginEnvironmentExecuteParams extends PluginEnvironmentDriverB
   env?: Record<string, string>;
   stdin?: string;
   timeoutMs?: number;
+  // Optional live-output sink. When present, the provider should forward each
+  // stdout/stderr chunk here AS the command produces it (in addition to
+  // returning the buffered output) and set `streamed: true` on the result so
+  // the caller can suppress the trailing buffered log dump. This callback is
+  // NOT serializable across the plugin worker RPC boundary, so it is only
+  // delivered on in-process execute paths; over RPC it is absent and the
+  // provider falls back to buffered-at-end behavior (streamed stays unset).
+  onOutput?: (stream: "stdout" | "stderr", text: string) => void | Promise<void>;
 }
 
 export interface PluginEnvironmentExecuteResult {
@@ -645,6 +653,10 @@ export interface PluginEnvironmentExecuteResult {
   stdout: string;
   stderr: string;
   metadata?: Record<string, unknown>;
+  // True when the provider already delivered stdout/stderr live via
+  // `onOutput`. Callers use this to avoid logging the buffered output a second
+  // time. Unset/false preserves the legacy buffered-dump behavior.
+  streamed?: boolean;
 }
 
 export type PluginEnvironmentInteractiveSetupStatus =

--- a/server/src/__tests__/environment-execution-target.test.ts
+++ b/server/src/__tests__/environment-execution-target.test.ts
@@ -133,6 +133,99 @@ describe("resolveEnvironmentExecutionTarget", () => {
     });
   });
 
+  it("suppresses the buffered onLog dump when the runner reports streamed output, and forwards onOutput", async () => {
+    mockResolveEnvironmentDriverConfigForRuntime.mockResolvedValue({
+      driver: "sandbox",
+      config: { provider: "fake-plugin", reuseLease: false, timeoutMs: 30_000 },
+    });
+
+    const executeSpy = vi.fn(async (input: Record<string, unknown>) => {
+      // Simulate a streaming provider: deliver output live via onOutput and
+      // flag streamed so the runner does not re-log the buffered output.
+      const onOutput = input.onOutput as
+        | ((stream: "stdout" | "stderr", text: string) => void)
+        | undefined;
+      onOutput?.("stdout", "live-chunk");
+      return { exitCode: 0, timedOut: false, stdout: "live-chunk", stderr: "", streamed: true };
+    });
+
+    const target = await resolveEnvironmentExecutionTarget({
+      db: {} as never,
+      companyId: "company-1",
+      adapterType: "codex_local",
+      environment: { id: "env-1", driver: "sandbox", config: { provider: "fake-plugin" } },
+      leaseId: "lease-1",
+      leaseMetadata: {},
+      lease: { providerLeaseId: "pl-1" } as never,
+      environmentRuntime: { execute: executeSpy } as never,
+    });
+
+    expect(target?.kind).toBe("remote");
+    const runner = (target as { runner?: { execute: (i: unknown) => Promise<unknown> } }).runner!;
+    expect(runner).toBeTruthy();
+
+    const logCalls: Array<[string, string]> = [];
+    const outputCalls: Array<[string, string]> = [];
+    const result = (await runner.execute({
+      command: "echo",
+      args: ["hi"],
+      onLog: async (stream: "stdout" | "stderr", chunk: string) => {
+        logCalls.push([stream, chunk]);
+      },
+      onOutput: (stream: "stdout" | "stderr", text: string) => {
+        outputCalls.push([stream, text]);
+      },
+    })) as { streamed?: boolean; stdout: string };
+
+    // onOutput was threaded into the driver execute and delivered live.
+    expect(executeSpy.mock.calls[0][0]).toHaveProperty("onOutput");
+    expect(outputCalls).toEqual([["stdout", "live-chunk"]]);
+    // The buffered dump is SUPPRESSED because the provider streamed the output.
+    expect(logCalls).toEqual([]);
+    expect(result.streamed).toBe(true);
+    expect(result.stdout).toBe("live-chunk");
+  });
+
+  it("still emits the buffered onLog dump for a legacy (non-streamed) runner result", async () => {
+    mockResolveEnvironmentDriverConfigForRuntime.mockResolvedValue({
+      driver: "sandbox",
+      config: { provider: "fake-plugin", reuseLease: false, timeoutMs: 30_000 },
+    });
+
+    const executeSpy = vi.fn(async () => ({
+      exitCode: 0,
+      timedOut: false,
+      stdout: "buffered-out",
+      stderr: "buffered-err",
+      // no `streamed` flag -> legacy behavior
+    }));
+
+    const target = await resolveEnvironmentExecutionTarget({
+      db: {} as never,
+      companyId: "company-1",
+      adapterType: "codex_local",
+      environment: { id: "env-1", driver: "sandbox", config: { provider: "fake-plugin" } },
+      leaseId: "lease-1",
+      leaseMetadata: {},
+      lease: { providerLeaseId: "pl-1" } as never,
+      environmentRuntime: { execute: executeSpy } as never,
+    });
+
+    const runner = (target as { runner?: { execute: (i: unknown) => Promise<unknown> } }).runner!;
+    const logCalls: Array<[string, string]> = [];
+    await runner.execute({
+      command: "echo",
+      onLog: async (stream: "stdout" | "stderr", chunk: string) => {
+        logCalls.push([stream, chunk]);
+      },
+    });
+
+    expect(logCalls).toEqual([
+      ["stdout", "buffered-out"],
+      ["stderr", "buffered-err"],
+    ]);
+  });
+
   it("resolves SSH execution targets in bridge mode", async () => {
     mockResolveEnvironmentDriverConfigForRuntime.mockResolvedValue({
       driver: "ssh",

--- a/server/src/__tests__/environment-runtime-output-stream.test.ts
+++ b/server/src/__tests__/environment-runtime-output-stream.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it, vi } from "vitest";
+import { createPluginStreamBus } from "../services/plugin-stream-bus.js";
+import {
+  envExecOutputChannel,
+  withPluginExecOutputStream,
+} from "../services/environment-runtime.js";
+
+const PLUGIN_ID = "paperclipinc.kubernetes";
+const COMPANY_ID = "acme";
+const RUN_ID = "run-1";
+
+describe("withPluginExecOutputStream", () => {
+  it("forwards worker-emitted chunks to onOutput in order and unsubscribes after resolve", async () => {
+    const streamBus = createPluginStreamBus();
+    const channel = envExecOutputChannel(RUN_ID);
+    const received: Array<[string, string]> = [];
+    let sawStreamingFlag = false;
+
+    const result = await withPluginExecOutputStream({
+      streamBus,
+      pluginId: PLUGIN_ID,
+      companyId: COMPANY_ID,
+      runId: RUN_ID,
+      onOutput: (stream, text) => {
+        received.push([stream, text]);
+      },
+      run: async (streaming) => {
+        sawStreamingFlag = streaming;
+        // Simulate the worker emitting chunks mid-call via the stream bus.
+        streamBus.publish(PLUGIN_ID, channel, COMPANY_ID, { stream: "stdout", text: "a" });
+        streamBus.publish(PLUGIN_ID, channel, COMPANY_ID, { stream: "stderr", text: "b" });
+        streamBus.publish(PLUGIN_ID, channel, COMPANY_ID, { stream: "stdout", text: "c" });
+        return { exitCode: 0, streamed: true };
+      },
+    });
+
+    expect(sawStreamingFlag).toBe(true);
+    expect(received).toEqual([
+      ["stdout", "a"],
+      ["stderr", "b"],
+      ["stdout", "c"],
+    ]);
+    expect(result).toEqual({ exitCode: 0, streamed: true });
+
+    // Subscription must be torn down: further publishes are NOT delivered.
+    streamBus.publish(PLUGIN_ID, channel, COMPANY_ID, { stream: "stdout", text: "late" });
+    expect(received).toEqual([
+      ["stdout", "a"],
+      ["stderr", "b"],
+      ["stdout", "c"],
+    ]);
+  });
+
+  it("unsubscribes even when run() rejects", async () => {
+    const streamBus = createPluginStreamBus();
+    const channel = envExecOutputChannel(RUN_ID);
+    const received: Array<[string, string]> = [];
+
+    await expect(
+      withPluginExecOutputStream({
+        streamBus,
+        pluginId: PLUGIN_ID,
+        companyId: COMPANY_ID,
+        runId: RUN_ID,
+        onOutput: (stream, text) => received.push([stream, text]),
+        run: async () => {
+          streamBus.publish(PLUGIN_ID, channel, COMPANY_ID, { stream: "stdout", text: "x" });
+          throw new Error("rpc blew up");
+        },
+      }),
+    ).rejects.toThrow("rpc blew up");
+
+    expect(received).toEqual([["stdout", "x"]]);
+
+    // No leak: a publish after rejection is not delivered.
+    streamBus.publish(PLUGIN_ID, channel, COMPANY_ID, { stream: "stdout", text: "after" });
+    expect(received).toEqual([["stdout", "x"]]);
+  });
+
+  it("skips streaming (runs with streaming=false) when runId is null", async () => {
+    const streamBus = createPluginStreamBus();
+    const subscribeSpy = vi.spyOn(streamBus, "subscribe");
+    let streamingFlag: boolean | undefined;
+
+    const result = await withPluginExecOutputStream({
+      streamBus,
+      pluginId: PLUGIN_ID,
+      companyId: COMPANY_ID,
+      runId: null,
+      onOutput: () => {},
+      run: async (streaming) => {
+        streamingFlag = streaming;
+        return "buffered";
+      },
+    });
+
+    expect(streamingFlag).toBe(false);
+    expect(subscribeSpy).not.toHaveBeenCalled();
+    expect(result).toBe("buffered");
+  });
+
+  it("skips streaming when no stream bus is available (buffered fallback)", async () => {
+    let streamingFlag: boolean | undefined;
+    const result = await withPluginExecOutputStream({
+      streamBus: undefined,
+      pluginId: PLUGIN_ID,
+      companyId: COMPANY_ID,
+      runId: RUN_ID,
+      onOutput: () => {},
+      run: async (streaming) => {
+        streamingFlag = streaming;
+        return "buffered";
+      },
+    });
+    expect(streamingFlag).toBe(false);
+    expect(result).toBe("buffered");
+  });
+
+  it("scopes the subscription by companyId (ignores another company's emits)", async () => {
+    const streamBus = createPluginStreamBus();
+    const channel = envExecOutputChannel(RUN_ID);
+    const received: Array<[string, string]> = [];
+
+    await withPluginExecOutputStream({
+      streamBus,
+      pluginId: PLUGIN_ID,
+      companyId: COMPANY_ID,
+      runId: RUN_ID,
+      onOutput: (stream, text) => received.push([stream, text]),
+      run: async () => {
+        // Emit for a DIFFERENT company on the same channel — must be ignored.
+        streamBus.publish(PLUGIN_ID, channel, "other-co", { stream: "stdout", text: "nope" });
+        streamBus.publish(PLUGIN_ID, channel, COMPANY_ID, { stream: "stdout", text: "yes" });
+        return null;
+      },
+    });
+
+    expect(received).toEqual([["stdout", "yes"]]);
+  });
+});

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -319,7 +319,9 @@ export async function createApp(
       { scheduler, jobStore },
       { workerManager },
       { toolDispatcher },
-      { workerManager },
+      // bridgeDeps: expose the worker manager's stream bus so the SSE bridge
+      // route (and any worker→host stream consumer) can subscribe to channels.
+      { workerManager, streamBus: workerManager.streamBus },
     ),
   );
   api.use(adapterRoutes());

--- a/server/src/services/environment-execution-target.ts
+++ b/server/src/services/environment-execution-target.ts
@@ -92,6 +92,10 @@ export async function resolveEnvironmentExecutionTarget(input: {
                 // sets `result.streamed` and we skip the buffered dump below to
                 // avoid logging the same output twice.
                 onOutput: commandInput.onOutput,
+                // Forward the run id so the plugin-backed sandbox driver can
+                // bridge worker output chunks back to onOutput over the worker
+                // RPC boundary (channel env-exec-output:${runId}).
+                runId: commandInput.runId,
               });
               // Only emit the buffered stdout/stderr when the driver did NOT
               // already stream it live via onOutput. Legacy (non-streaming)

--- a/server/src/services/environment-execution-target.ts
+++ b/server/src/services/environment-execution-target.ts
@@ -87,9 +87,19 @@ export async function resolveEnvironmentExecutionTarget(input: {
                 env: commandInput.env,
                 stdin: commandInput.stdin,
                 timeoutMs: commandInput.timeoutMs,
+                // Forward the live-output sink so a driver that streams can
+                // deliver chunks as they arrive. When the driver honors it, it
+                // sets `result.streamed` and we skip the buffered dump below to
+                // avoid logging the same output twice.
+                onOutput: commandInput.onOutput,
               });
-              if (result.stdout) await commandInput.onLog?.("stdout", result.stdout);
-              if (result.stderr) await commandInput.onLog?.("stderr", result.stderr);
+              // Only emit the buffered stdout/stderr when the driver did NOT
+              // already stream it live via onOutput. Legacy (non-streaming)
+              // drivers leave `streamed` unset, preserving the original dump.
+              if (!result.streamed) {
+                if (result.stdout) await commandInput.onLog?.("stdout", result.stdout);
+                if (result.stderr) await commandInput.onLog?.("stderr", result.stderr);
+              }
               return {
                 exitCode: result.exitCode,
                 signal: result.signal ?? null,
@@ -98,6 +108,7 @@ export async function resolveEnvironmentExecutionTarget(input: {
                 stderr: result.stderr,
                 pid: null,
                 startedAt,
+                streamed: result.streamed,
               };
             },
           }

--- a/server/src/services/environment-runtime.ts
+++ b/server/src/services/environment-runtime.ts
@@ -40,6 +40,7 @@ import {
 } from "./sandbox-provider-runtime.js";
 import { pluginRegistryService } from "./plugin-registry.js";
 import type { PluginWorkerManager } from "./plugin-worker-manager.js";
+import type { PluginStreamBus } from "./plugin-stream-bus.js";
 import {
   destroyPluginEnvironmentLease,
   executePluginEnvironmentCommand,
@@ -50,6 +51,55 @@ import {
 } from "./plugin-environment-driver.js";
 import { collectSecretRefPaths } from "./json-schema-secret-refs.js";
 import { buildWorkspaceRealizationRecordFromDriverInput } from "./workspace-realization.js";
+
+/** Channel name a plugin worker emits live exec output on for a given run. */
+export function envExecOutputChannel(runId: string): string {
+  return `env-exec-output:${runId}`;
+}
+
+/**
+ * Bridge live stdout/stderr from a plugin worker back to an in-process
+ * `onOutput` sink across the worker RPC boundary.
+ *
+ * The worker cannot be handed a callback (functions don't serialize over
+ * JSON-RPC), so when the caller provides `onOutput` AND a `runId` AND a stream
+ * bus is available we subscribe to the worker's output channel
+ * (`env-exec-output:${runId}`, scoped to `companyId`) BEFORE running the RPC,
+ * route each emitted `{ stream, text }` chunk to `onOutput`, and unsubscribe on
+ * EVERY exit path (resolve or throw) so no subscription leaks. The `run`
+ * callback is told whether streaming is active so it can set the serializable
+ * `streamOutput` RPC flag; when streaming can't be set up we run with
+ * `streaming=false` and the provider falls back to buffered-at-end output.
+ */
+export async function withPluginExecOutputStream<T>(opts: {
+  streamBus?: PluginStreamBus;
+  pluginId: string;
+  companyId: string;
+  runId?: string | null;
+  onOutput?: (stream: "stdout" | "stderr", text: string) => void | Promise<void>;
+  run: (streaming: boolean) => Promise<T>;
+}): Promise<T> {
+  const { streamBus, pluginId, companyId, runId, onOutput, run } = opts;
+  if (!streamBus || !onOutput || !runId) {
+    return await run(false);
+  }
+  const channel = envExecOutputChannel(runId);
+  const unsubscribe = streamBus.subscribe(pluginId, channel, companyId, (event) => {
+    const chunk = event as { stream?: unknown; text?: unknown } | null | undefined;
+    if (
+      chunk &&
+      typeof chunk.text === "string" &&
+      (chunk.stream === "stdout" || chunk.stream === "stderr")
+    ) {
+      void onOutput(chunk.stream, chunk.text);
+    }
+  });
+  try {
+    return await run(true);
+  } finally {
+    unsubscribe();
+  }
+}
 
 export function buildEnvironmentLeaseContext(input: {
   persistedExecutionWorkspace: Pick<ExecutionWorkspace, "id" | "mode"> | null;
@@ -191,6 +241,12 @@ export interface EnvironmentDriverExecuteInput extends EnvironmentDriverLeaseInp
   // worker today and those providers fall back to buffered-at-end output. The
   // last-mile RPC forwarding of chunks (worker -> host) is a separate change.
   onOutput?: (stream: "stdout" | "stderr", text: string) => void | Promise<void>;
+  // Run correlation id. For plugin-backed sandbox providers this is forwarded
+  // over the worker RPC boundary and used (with `onOutput`) to bridge live
+  // stdout/stderr from the worker back to `onOutput` via the plugin stream bus
+  // (see the `execute` impl below). Null/undefined -> no live streaming, the
+  // provider falls back to buffered-at-end output.
+  runId?: string | null;
 }
 
 export interface EnvironmentRuntimeDriver {
@@ -1217,27 +1273,43 @@ function createSandboxEnvironmentDriver(
             provider: providerKey,
           });
           const sanitizedConfig = stripSandboxProviderEnvelope(config as SandboxEnvironmentConfig);
-          return await pluginWorkerManager.call(pluginId, "environmentExecute", {
-            driverKey: providerKey,
+          const runId = input.runId ?? null;
+          // Bridge live output across the worker RPC boundary: subscribe to the
+          // worker's stream channel and forward chunks to input.onOutput, then
+          // ask the worker to stream (streamOutput flag) since the onOutput
+          // callback itself can't cross the boundary. Falls back to buffered
+          // output when onOutput/runId/streamBus are unavailable.
+          return await withPluginExecOutputStream({
+            streamBus: pluginWorkerManager.streamBus,
+            pluginId,
             companyId: input.lease.companyId,
-            environmentId: input.environment.id,
-            issueId: input.lease.issueId,
-            config: sanitizedConfig,
-            lease: {
-              providerLeaseId: input.lease.providerLeaseId,
-              metadata: input.lease.metadata ?? undefined,
-              expiresAt: input.lease.expiresAt?.toISOString() ?? null,
-            },
-            command: input.command,
-            args: input.args,
-            cwd: input.cwd,
-            env: input.env,
-            stdin: input.stdin,
-            timeoutMs: input.timeoutMs,
-          }, resolvePluginExecuteRpcTimeoutMs({
-            requestedTimeoutMs: input.timeoutMs,
-            config: sanitizedConfig,
-          }));
+            runId,
+            onOutput: input.onOutput,
+            run: (streaming) =>
+              pluginWorkerManager.call(pluginId, "environmentExecute", {
+                driverKey: providerKey,
+                companyId: input.lease.companyId,
+                environmentId: input.environment.id,
+                issueId: input.lease.issueId,
+                config: sanitizedConfig,
+                lease: {
+                  providerLeaseId: input.lease.providerLeaseId,
+                  metadata: input.lease.metadata ?? undefined,
+                  expiresAt: input.lease.expiresAt?.toISOString() ?? null,
+                },
+                command: input.command,
+                args: input.args,
+                cwd: input.cwd,
+                env: input.env,
+                stdin: input.stdin,
+                timeoutMs: input.timeoutMs,
+                runId,
+                ...(streaming ? { streamOutput: true } : {}),
+              }, resolvePluginExecuteRpcTimeoutMs({
+                requestedTimeoutMs: input.timeoutMs,
+                config: sanitizedConfig,
+              })),
+          });
         }
       }
       throw new Error("Sandbox driver does not support direct command execution for built-in providers.");

--- a/server/src/services/environment-runtime.ts
+++ b/server/src/services/environment-runtime.ts
@@ -183,6 +183,14 @@ export interface EnvironmentDriverExecuteInput extends EnvironmentDriverLeaseInp
   env?: Record<string, string>;
   stdin?: string;
   timeoutMs?: number;
+  // Optional live-output sink. When a driver executes in-process it can forward
+  // stdout/stderr chunks here as they arrive and set `streamed: true` on its
+  // result. NOTE: for plugin-backed sandbox providers the actual execute runs
+  // in a worker behind a JSON-RPC boundary (see the `execute` impl below), and
+  // a function cannot cross that boundary — so this sink is not delivered to the
+  // worker today and those providers fall back to buffered-at-end output. The
+  // last-mile RPC forwarding of chunks (worker -> host) is a separate change.
+  onOutput?: (stream: "stdout" | "stderr", text: string) => void | Promise<void>;
 }
 
 export interface EnvironmentRuntimeDriver {

--- a/server/src/services/plugin-worker-manager.ts
+++ b/server/src/services/plugin-worker-manager.ts
@@ -53,6 +53,11 @@ import type {
   InitializeParams,
 } from "@paperclipai/plugin-sdk";
 import { logger } from "../middleware/logger.js";
+import {
+  createPluginStreamBus,
+  type PluginStreamBus,
+  type StreamEventType,
+} from "./plugin-stream-bus.js";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -357,6 +362,18 @@ export interface PluginWorkerManager {
     params: HostToWorkerMethods[M][0],
     timeoutMs?: number,
   ): Promise<HostToWorkerMethods[M][1]>;
+
+  /**
+   * The stream bus this manager publishes worker `streams.*` notifications to.
+   *
+   * Every worker started by this manager forwards its `ctx.streams` open/emit/
+   * close notifications here, so any host code holding the manager (SSE bridge
+   * routes, the environment runtime's live-output bridge) can `subscribe` to a
+   * (pluginId, channel, companyId) tuple without threading a separate bus. The
+   * real factory always populates it; kept optional so hand-rolled test doubles
+   * of this interface don't have to provide one.
+   */
+  readonly streamBus?: PluginStreamBus;
 }
 
 // ---------------------------------------------------------------------------
@@ -1325,6 +1342,45 @@ export interface PluginWorkerManagerOptions {
     signal?: string | null;
     willRestart?: boolean;
   }) => void;
+
+  /**
+   * Stream bus that worker `streams.*` notifications are published to. When
+   * omitted, the manager creates its own in-memory bus. Exposed on the returned
+   * manager as `.streamBus` so host code (SSE bridge, environment runtime) can
+   * subscribe to worker-emitted channels.
+   */
+  streamBus?: PluginStreamBus;
+}
+
+/** Map a `streams.*` notification method to the SSE-style event type. */
+function streamEventTypeForMethod(method: string): StreamEventType {
+  if (method === "streams.open") return "open";
+  if (method === "streams.close") return "close";
+  return "message";
+}
+
+/**
+ * Publish a worker `streams.*` notification onto the stream bus. The worker's
+ * `ctx.streams` API sends `{ channel, companyId, event? }`; the bus fans it out
+ * to subscribers of (pluginId, channel, companyId). Best-effort: a missing
+ * channel/companyId is dropped rather than thrown.
+ */
+function publishStreamNotification(
+  streamBus: PluginStreamBus,
+  pluginId: string,
+  method: string,
+  params: Record<string, unknown>,
+): void {
+  const channel = typeof params.channel === "string" ? params.channel : "";
+  const companyId = typeof params.companyId === "string" ? params.companyId : "";
+  if (!channel || !companyId) return;
+  streamBus.publish(
+    pluginId,
+    channel,
+    companyId,
+    params.event,
+    streamEventTypeForMethod(method),
+  );
 }
 
 /**
@@ -1360,8 +1416,10 @@ export function createPluginWorkerManager(
   const workers = new Map<string, PluginWorkerHandle>();
   /** Per-plugin startup locks to prevent concurrent spawn races. */
   const startupLocks = new Map<string, Promise<PluginWorkerHandle>>();
+  const streamBus = managerOptions?.streamBus ?? createPluginStreamBus();
 
   return {
+    streamBus,
     async startWorker(
       pluginId: string,
       options: WorkerStartOptions,
@@ -1380,7 +1438,19 @@ export function createPluginWorkerManager(
         );
       }
 
-      const handle = createPluginWorkerHandle(pluginId, options);
+      // Fan worker `streams.*` notifications out to the manager's stream bus so
+      // host subscribers (SSE bridge, environment-runtime live output) receive
+      // them, while preserving any caller-supplied onStreamNotification.
+      const callerOnStreamNotification = options.onStreamNotification;
+      const workerStartOptions: WorkerStartOptions = {
+        ...options,
+        onStreamNotification: (method, params) => {
+          publishStreamNotification(streamBus, pluginId, method, params);
+          callerOnStreamNotification?.(method, params);
+        },
+      };
+
+      const handle = createPluginWorkerHandle(pluginId, workerStartOptions);
       workers.set(pluginId, handle);
 
       // Subscribe to crash/ready events for live event forwarding


### PR DESCRIPTION
## Problem

Agent runs that execute in a remote sandbox (the kubernetes sandbox provider, and any provider behind the plugin-worker RPC boundary) feel "stuck" with no feedback for minutes: the whole harness session runs as one buffered call and **no output reaches the client until the run finishes**, then it arrives all at once.

Two root causes:
1. `execInPod` accumulated stdout/stderr and only resolved at the end — the per-frame `data` events already fired but were never relayed.
2. Even with a streaming callback, the kubernetes plugin runs behind a JSON-RPC worker boundary, so a callback (`onOutput`) cannot be serialized across it and was silently dropped on the real path.

## What this does

Additive, backward-compatible live streaming, end to end:

- **`execInPod`** gains an optional `onChunk(stream, text)` invoked per data frame (buffered return unchanged; guarded so a throwing consumer can't break capture).
- **The runner/execute contract** (`CommandManagedRuntimeRunner.execute`, `RunProcessResult`, `PluginEnvironmentExecuteParams/Result`) gains optional `onOutput` and a `streamed` result flag.
- **Worker→host bridge**: the kubernetes plugin emits each chunk over the existing `ctx.streams` channel (`env-exec-output:<runId>`); the host subscribes to that channel via the plugin stream bus for the duration of the `environmentExecute` call and forwards chunks to `onOutput`. The stream bus is now owned by the worker manager and fed to the existing SSE bridge route as well.
- **No double logging**: when output was streamed live, `streamed: true` suppresses the trailing buffered log dump.

All six other sandbox providers accept the optional param unchanged (only kubernetes is wired for real). `runId`/`streamOutput` are plumbed as serializable RPC params. Fully unit-tested at each seam (pod-exec, plugin execute, RPC bridge, host subscription, dedup); existing suites green.

No behavior change when a caller does not opt into streaming (buffered fallback preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)