### PR TITLE
fix: enforce server-side github publish guard (DAN-289)

### DIFF
--- a/packages/adapter-utils/src/authorized-repo-guard.ts
+++ b/packages/adapter-utils/src/authorized-repo-guard.ts
@@ -1,0 +1,155 @@
+/**
+ * Single source of truth for deciding whether an agent-initiated code
+ * publication (push, PR/MR, remote change, package release, etc.) targets a
+ * repository the current issue/workspace/project is authorized to publish
+ * to.
+ *
+ * Origin: DAN-273 (an agent opened a PR against the upstream
+ * `paperclipai/paperclip` repo instead of the authorized fork). The plan in
+ * DAN-278 requires exactly one resolver consumed by every checkpoint
+ * (git push, `git remote add|set-url`, PR/MR creation via CLI or API, and
+ * MCP publish connectors) rather than duplicated per-tool logic.
+ */
+
+export interface NormalizedRepo {
+  host: string;
+  owner: string;
+  repo: string;
+}
+
+export type RepoAuthorizationDecision = "authorized" | "denied" | "unknown";
+
+/**
+ * Normalizes a git/HTTP(S) repository URL or `owner/repo` shorthand into
+ * host+owner+repo. Host is lowercased (case-insensitive per the DAN-278
+ * plan); owner/repo are compared with exact case since the plan mandates
+ * exact-match comparison there. Returns null for unparsable input, which
+ * callers must treat as "unknown" -> denied (fail-closed), never as a
+ * successful match.
+ */
+export function normalizeRepoUrl(input: string | null | undefined): NormalizedRepo | null {
+  if (typeof input !== "string") return null;
+  const trimmed = input.trim();
+  if (!trimmed) return null;
+
+  const stripDotGit = (value: string) => value.replace(/\.git\/?$/i, "");
+
+  // scp-like ssh form: git@host:owner/repo(.git)
+  const scpMatch = trimmed.match(/^[a-zA-Z0-9_.-]+@([^:/]+):(.+)$/);
+  if (scpMatch) {
+    const host = scpMatch[1].toLowerCase();
+    const rest = stripDotGit(scpMatch[2].replace(/^\/+/, ""));
+    const parts = rest.split("/").filter(Boolean);
+    if (parts.length < 2) return null;
+    const [owner, repo] = parts;
+    return { host, owner, repo };
+  }
+
+  // URL forms: ssh://, git://, http(s)://
+  try {
+    const withScheme = /^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//.test(trimmed) ? trimmed : `https://${trimmed}`;
+    const url = new URL(withScheme);
+    const host = url.hostname.toLowerCase();
+    if (!host) return null;
+    const rest = stripDotGit(url.pathname.replace(/^\/+/, ""));
+    const parts = rest.split("/").filter(Boolean);
+    if (parts.length < 2) return null;
+    const [owner, repo] = parts;
+    return { host, owner, repo };
+  } catch {
+    return null;
+  }
+}
+
+export function normalizedReposEqual(a: NormalizedRepo, b: NormalizedRepo): boolean {
+  return a.host === b.host && a.owner === b.owner && a.repo === b.repo;
+}
+
+export function formatNormalizedRepo(repo: NormalizedRepo): string {
+  return `${repo.host}/${repo.owner}/${repo.repo}`;
+}
+
+export interface AuthorizedRepoSourceInput {
+  /** Repo declared on the current issue's execution workspace. Highest priority (DAN-278 section 4.1). */
+  issueWorkspaceRepoUrl?: string | null;
+  /** Repo declared on the project/workspace config. Used only when no issue-level repo exists (section 4.2). */
+  projectRepoUrl?: string | null;
+  /** Additional repos explicitly allow-listed for this scope (e.g. upstream promoted to a write destination). */
+  additionalAuthorizedRepoUrls?: readonly string[];
+}
+
+/**
+ * Resolves the authorized destination set per DAN-278 section 4: issue/workspace
+ * wins over project; if neither is configured there is NO implicit default
+ * (deny-by-default) rather than inferring from whatever remote happens to be
+ * configured locally.
+ */
+export function resolveAuthorizedRepos(input: AuthorizedRepoSourceInput): NormalizedRepo[] {
+  const primary = normalizeRepoUrl(input.issueWorkspaceRepoUrl) ?? normalizeRepoUrl(input.projectRepoUrl);
+  const results: NormalizedRepo[] = [];
+  if (primary) results.push(primary);
+  for (const extra of input.additionalAuthorizedRepoUrls ?? []) {
+    const normalized = normalizeRepoUrl(extra);
+    if (normalized && !results.some((existing) => normalizedReposEqual(existing, normalized))) {
+      results.push(normalized);
+    }
+  }
+  return results;
+}
+
+/**
+ * Classifies a publication destination against the authorized set.
+ * Unresolvable candidates return "unknown" (never silently "authorized");
+ * callers must fail closed on both "denied" and "unknown".
+ */
+export function classifyRepoDestination(
+  candidateUrl: string | null | undefined,
+  authorized: readonly NormalizedRepo[],
+): RepoAuthorizationDecision {
+  const candidate = normalizeRepoUrl(candidateUrl);
+  if (!candidate) return "unknown";
+  const isAuthorized = authorized.some((repo) => normalizedReposEqual(repo, candidate));
+  return isAuthorized ? "authorized" : "denied";
+}
+
+export function isRepoDestinationAuthorized(
+  candidateUrl: string | null | undefined,
+  authorized: readonly NormalizedRepo[],
+): boolean {
+  return classifyRepoDestination(candidateUrl, authorized) === "authorized";
+}
+
+export interface RepoGuardCheckResult {
+  decision: RepoAuthorizationDecision;
+  candidate: NormalizedRepo | null;
+  authorized: NormalizedRepo[];
+  /** Actionable message naming the rejected and expected destination (DAN-278 section 6.6). */
+  message: string;
+}
+
+export function checkRepoDestination(
+  candidateUrl: string | null | undefined,
+  authorizedInput: AuthorizedRepoSourceInput,
+): RepoGuardCheckResult {
+  const authorized = resolveAuthorizedRepos(authorizedInput);
+  const candidate = normalizeRepoUrl(candidateUrl);
+  const decision = classifyRepoDestination(candidateUrl, authorized);
+
+  if (decision === "authorized") {
+    return { decision, candidate, authorized, message: "" };
+  }
+
+  const rejectedLabel = candidate ? formatNormalizedRepo(candidate) : String(candidateUrl ?? "(unresolvable destination)");
+  const expectedLabel = authorized.length > 0
+    ? authorized.map(formatNormalizedRepo).join(", ")
+    : "(no authorized repository configured for this issue/workspace/project)";
+  const reason = decision === "unknown"
+    ? "the destination could not be resolved to a host/owner/repo (fail-closed: unresolvable destinations are treated as denied)"
+    : "the destination is not in the authorized repository list for this issue/workspace/project";
+  const message =
+    `Blocked: publishing to "${rejectedLabel}" is not allowed because ${reason}. ` +
+    `Authorized destination(s): ${expectedLabel}. ` +
+    `If this is intentional, add the destination to the issue/workspace/project's authorized repository configuration before retrying.`;
+
+  return { decision, candidate, authorized, message };
+}

--- a/server/src/__tests__/plugin-tool-dispatcher-publish-guard.test.ts
+++ b/server/src/__tests__/plugin-tool-dispatcher-publish-guard.test.ts
@@ -1,0 +1,255 @@
+import { randomUUID } from "node:crypto";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import {
+  agents,
+  companies,
+  createDb,
+  executionWorkspaces,
+  heartbeatRuns,
+  issues,
+  projectWorkspaces,
+  projects,
+} from "@paperclipai/db";
+import type { PaperclipPluginManifestV1 } from "@paperclipai/shared";
+import type { PluginWorkerManager } from "../services/plugin-worker-manager.js";
+import { createPluginToolDispatcher } from "../services/plugin-tool-dispatcher.js";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+const GITHUB_PLUGIN_ID = "github";
+const GITHUB_PLUGIN_DB_ID = "00000000-0000-4000-8000-000000000123";
+const GITHUB_MANIFEST: PaperclipPluginManifestV1 = {
+  id: GITHUB_PLUGIN_ID,
+  apiVersion: 1,
+  version: "1.0.0",
+  displayName: "GitHub",
+  description: "Test fixture",
+  author: "Paperclip",
+  categories: ["automation"],
+  capabilities: [],
+  entrypoints: { worker: "dist/worker.js" },
+  tools: [
+    {
+      name: "create_pull_request",
+      displayName: "Create pull request",
+      description: "Create a PR",
+      parametersSchema: { type: "object", properties: {} },
+    },
+  ],
+} as unknown as PaperclipPluginManifestV1;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping plugin publish guard dispatcher tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+describeEmbeddedPostgres("plugin tool dispatcher publish guard", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-plugin-publish-guard-");
+    db = createDb(tempDb.connectionString);
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.delete(heartbeatRuns);
+    await db.delete(issues);
+    await db.delete(executionWorkspaces);
+    await db.delete(projectWorkspaces);
+    await db.delete(projects);
+    await db.delete(agents);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  it("allows github.create_pull_request only when the destination matches the issue execution workspace repo", async () => {
+    const fixture = await seedFixture({
+      executionWorkspaceRepoUrl: "https://github.com/acme/allowed-repo.git",
+      projectWorkspaceRepoUrl: "https://github.com/acme/project-repo.git",
+    });
+    const workerManager = createWorkerManager();
+    const dispatcher = createPluginToolDispatcher({ workerManager, db });
+    dispatcher.registerPluginTools(GITHUB_PLUGIN_ID, GITHUB_MANIFEST, GITHUB_PLUGIN_DB_ID);
+
+    await expect(
+      dispatcher.executeTool(
+        "github:create_pull_request",
+        {
+          repository_full_name: "acme/allowed-repo",
+          head_branch: "feature/publish-guard",
+          base_branch: "main",
+          title: "test",
+        },
+        fixture.runContext,
+      ),
+    ).resolves.toEqual(expect.objectContaining({ pluginId: "github", toolName: "create_pull_request" }));
+
+    expect(workerManager.call).toHaveBeenCalledOnce();
+  });
+
+  it("blocks github.create_pull_request when the repository differs from the authorized workspace repo", async () => {
+    const fixture = await seedFixture({
+      executionWorkspaceRepoUrl: "https://github.com/acme/allowed-repo.git",
+      projectWorkspaceRepoUrl: "https://github.com/acme/project-repo.git",
+    });
+    const workerManager = createWorkerManager();
+    const dispatcher = createPluginToolDispatcher({ workerManager, db });
+    dispatcher.registerPluginTools(GITHUB_PLUGIN_ID, GITHUB_MANIFEST, GITHUB_PLUGIN_DB_ID);
+
+    await expect(
+      dispatcher.executeTool(
+        "github:create_pull_request",
+        {
+          repository_full_name: "acme/forbidden-repo",
+          head_branch: "feature/publish-guard",
+          base_branch: "main",
+          title: "test",
+        },
+        fixture.runContext,
+      ),
+    ).rejects.toThrow(/Blocked GitHub publish tool "github[:.]create_pull_request"/);
+
+    expect(workerManager.call).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when the connector request omits repository_full_name", async () => {
+    const fixture = await seedFixture({
+      executionWorkspaceRepoUrl: "https://github.com/acme/allowed-repo.git",
+      projectWorkspaceRepoUrl: "https://github.com/acme/project-repo.git",
+    });
+    const workerManager = createWorkerManager();
+    const dispatcher = createPluginToolDispatcher({ workerManager, db });
+    dispatcher.registerPluginTools(GITHUB_PLUGIN_ID, GITHUB_MANIFEST, GITHUB_PLUGIN_DB_ID);
+
+    await expect(
+      dispatcher.executeTool(
+        "github:create_pull_request",
+        {
+          head_branch: "feature/publish-guard",
+          base_branch: "main",
+          title: "test",
+        },
+        fixture.runContext,
+      ),
+    ).rejects.toThrow(/missing required repository_full_name target/);
+
+    expect(workerManager.call).not.toHaveBeenCalled();
+  });
+
+  async function seedFixture(input: {
+    executionWorkspaceRepoUrl: string;
+    projectWorkspaceRepoUrl: string;
+  }) {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const projectId = randomUUID();
+    const projectWorkspaceId = randomUUID();
+    const executionWorkspaceId = randomUUID();
+    const issueId = randomUUID();
+    const runId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: "TST",
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Engineer",
+      role: "engineer",
+      status: "idle",
+      adapterType: "process",
+      adapterConfig: { command: "true" },
+      runtimeConfig: {},
+      permissions: {},
+    });
+    await db.insert(projects).values({
+      id: projectId,
+      companyId,
+      name: "Publish Guard",
+      status: "in_progress",
+    });
+    await db.insert(projectWorkspaces).values({
+      id: projectWorkspaceId,
+      companyId,
+      projectId,
+      name: "Primary",
+      sourceType: "git_repo",
+      repoUrl: input.projectWorkspaceRepoUrl,
+      isPrimary: true,
+    });
+    await db.insert(executionWorkspaces).values({
+      id: executionWorkspaceId,
+      companyId,
+      projectId,
+      projectWorkspaceId,
+      mode: "isolated_workspace",
+      strategyType: "git_worktree",
+      name: "Issue workspace",
+      status: "active",
+      repoUrl: input.executionWorkspaceRepoUrl,
+      providerType: "git_worktree",
+    });
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      projectId,
+      projectWorkspaceId,
+      executionWorkspaceId,
+      title: "Protect publish",
+      status: "in_progress",
+      priority: "critical",
+      assigneeAgentId: agentId,
+      identifier: "TST-1",
+    });
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId,
+      agentId,
+      status: "running",
+      invocationSource: "assignment",
+      contextSnapshot: {
+        issueId,
+        taskId: issueId,
+        projectId,
+      },
+    });
+
+    return {
+      runContext: {
+        agentId,
+        runId,
+        companyId,
+        projectId,
+      },
+    };
+  }
+});
+
+function createWorkerManager(): PluginWorkerManager & {
+  call: ReturnType<typeof vi.fn>;
+} {
+  const isRunning = vi.fn((id: string) => id === GITHUB_PLUGIN_DB_ID);
+  const call = vi.fn(async () => ({ content: "ok" }));
+  return {
+    startWorker: vi.fn(),
+    stopWorker: vi.fn(),
+    getWorker: vi.fn(),
+    isRunning,
+    stopAll: vi.fn(),
+    diagnostics: vi.fn(() => []),
+    call,
+  } as unknown as PluginWorkerManager & { call: ReturnType<typeof vi.fn> };
+}

--- a/server/src/services/plugin-tool-dispatcher.ts
+++ b/server/src/services/plugin-tool-dispatcher.ts
@@ -27,7 +27,15 @@ import type {
   PaperclipPluginManifestV1,
   PluginRecord,
 } from "@paperclipai/shared";
+import {
+  executionWorkspaces,
+  heartbeatRuns,
+  issues,
+  projectWorkspaces,
+} from "@paperclipai/db";
 import type { ToolRunContext, ToolResult } from "@paperclipai/plugin-sdk";
+import { eq, and } from "drizzle-orm";
+import { checkRepoDestination } from "@paperclipai/adapter-utils/authorized-repo-guard";
 import type { PluginWorkerManager } from "./plugin-worker-manager.js";
 import type { PluginLifecycleManager } from "./plugin-lifecycle.js";
 import {
@@ -43,6 +51,11 @@ import { logger } from "../middleware/logger.js";
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
+
+const GITHUB_CREATE_PULL_REQUEST_TOOLS = new Set([
+  "github:create_pull_request",
+  "github.create_pull_request",
+]);
 
 /**
  * An agent-facing tool descriptor — the shape returned when agents
@@ -241,6 +254,135 @@ export function createPluginToolDispatcher(
 
   let initialized = false;
 
+  async function enforcePublishGuard(
+    namespacedName: string,
+    parameters: unknown,
+    runContext: ToolRunContext,
+  ): Promise<void> {
+    if (!GITHUB_CREATE_PULL_REQUEST_TOOLS.has(namespacedName)) return;
+    if (!db) {
+      throw new Error(
+        `Blocked GitHub publish tool "${namespacedName}": server database access is required to resolve the authorized repository (fail-closed).`,
+      );
+    }
+
+    const repositoryFullName = readNonEmptyString(
+      typeof parameters === "object" && parameters !== null
+        ? (parameters as Record<string, unknown>).repository_full_name
+        : null,
+    );
+    if (!repositoryFullName) {
+      throw new Error(
+        `Blocked GitHub publish tool "${namespacedName}": missing required repository_full_name target (fail-closed).`,
+      );
+    }
+
+    const [run] = await db
+      .select({ contextSnapshot: heartbeatRuns.contextSnapshot })
+      .from(heartbeatRuns)
+      .where(and(
+        eq(heartbeatRuns.id, runContext.runId),
+        eq(heartbeatRuns.companyId, runContext.companyId),
+        eq(heartbeatRuns.agentId, runContext.agentId),
+      ))
+      .limit(1);
+    const issueId = readNonEmptyString(run?.contextSnapshot?.issueId)
+      ?? readNonEmptyString(run?.contextSnapshot?.taskId);
+    if (!issueId) {
+      throw new Error(
+        `Blocked GitHub publish tool "${namespacedName}": run ${runContext.runId} is not linked to an issue/task context, so the authorized repository cannot be resolved (fail-closed).`,
+      );
+    }
+
+    const [issue] = await db
+      .select({
+        projectId: issues.projectId,
+        projectWorkspaceId: issues.projectWorkspaceId,
+        executionWorkspaceId: issues.executionWorkspaceId,
+      })
+      .from(issues)
+      .where(and(eq(issues.id, issueId), eq(issues.companyId, runContext.companyId)))
+      .limit(1);
+    if (!issue) {
+      throw new Error(
+        `Blocked GitHub publish tool "${namespacedName}": issue ${issueId} was not found in company scope, so the authorized repository cannot be resolved (fail-closed).`,
+      );
+    }
+
+    const issueWorkspaceRepoUrl = issue.executionWorkspaceId
+      ? await readExecutionWorkspaceRepoUrl(issue.executionWorkspaceId, runContext.companyId)
+      : null;
+    const projectRepoUrl = await readProjectRepoUrl({
+      companyId: runContext.companyId,
+      projectId: issue.projectId ?? runContext.projectId,
+      projectWorkspaceId: issue.projectWorkspaceId,
+    });
+
+    const decision = checkRepoDestination(
+      repositoryFullName.includes("://") || repositoryFullName.startsWith("github.com/")
+        ? repositoryFullName
+        : `https://github.com/${repositoryFullName}`,
+      {
+        issueWorkspaceRepoUrl,
+        projectRepoUrl,
+      },
+    );
+    if (decision.decision !== "authorized") {
+      throw new Error(
+        `Blocked GitHub publish tool "${namespacedName}": ${decision.message}`,
+      );
+    }
+  }
+
+  async function readExecutionWorkspaceRepoUrl(
+    executionWorkspaceId: string,
+    companyId: string,
+  ): Promise<string | null> {
+    const [row] = await db!
+      .select({ repoUrl: executionWorkspaces.repoUrl })
+      .from(executionWorkspaces)
+      .where(and(
+        eq(executionWorkspaces.id, executionWorkspaceId),
+        eq(executionWorkspaces.companyId, companyId),
+      ))
+      .limit(1);
+    return row?.repoUrl ?? null;
+  }
+
+  async function readProjectRepoUrl(input: {
+    companyId: string;
+    projectId: string | null;
+    projectWorkspaceId: string | null;
+  }): Promise<string | null> {
+    if (input.projectWorkspaceId) {
+      const [workspace] = await db!
+        .select({ repoUrl: projectWorkspaces.repoUrl })
+        .from(projectWorkspaces)
+        .where(and(
+          eq(projectWorkspaces.id, input.projectWorkspaceId),
+          eq(projectWorkspaces.companyId, input.companyId),
+        ))
+        .limit(1);
+      if (workspace?.repoUrl) return workspace.repoUrl;
+    }
+
+    if (!input.projectId) return null;
+    const [primaryWorkspace] = await db!
+      .select({ repoUrl: projectWorkspaces.repoUrl })
+      .from(projectWorkspaces)
+      .where(and(
+        eq(projectWorkspaces.projectId, input.projectId),
+        eq(projectWorkspaces.companyId, input.companyId),
+        eq(projectWorkspaces.isPrimary, true),
+      ))
+      .limit(1);
+    return primaryWorkspace?.repoUrl ?? null;
+  }
+
+  function readNonEmptyString(value: unknown): string | null {
+    return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+  }
+
   // -----------------------------------------------------------------------
   // Internal helpers
   // -----------------------------------------------------------------------
@@ -412,6 +554,8 @@ export function createPluginToolDispatcher(
         },
         "dispatching tool execution",
       );
+
+      await enforcePublishGuard(namespacedName, parameters, runContext);
 
       const result = await registry.executeTool(
         namespacedName,


### PR DESCRIPTION
## Resumo
Implementa o publish guard server-side no caminho do conector GitHub/Paperclip antes da chamada remota de abertura de PR.

## O que mudou
- adiciona enforcement no `PluginToolDispatcher` para bloquear `github:create_pull_request` quando o destino nao corresponder ao repositório autorizado da issue/workspace
- resolve o repositório autorizado a partir do contexto do `heartbeat_run`, com precedencia `execution workspace > project workspace`
- opera em fail-closed quando o destino nao puder ser resolvido ou quando o run nao estiver ligado a uma issue
- adiciona testes cobrindo cenarios de allow, deny e fail-closed no dispatcher

## Impacto
Evita que agentes ou conectores abram PRs via GitHub MCP/connector para repositórios externos ao escopo autorizado da issue, cobrindo o vetor que escapava dos wrappers locais de `git` e `gh`.

## Validacao
- `pnpm vitest run src/__tests__/plugin-tool-dispatcher-publish-guard.test.ts src/__tests__/plugin-tool-dispatcher-pluginDbId.test.ts`
- `pnpm typecheck` falhou por dependencia ausente preexistente: `@paperclipai/hermes-paperclip-adapter` em `server/src/adapters/registry.ts`

## Referencias
- Paperclip task: [DAN-289](http://127.0.0.1:3100/DAN/issues/DAN-289)
- Issue-mae: [DAN-288](http://127.0.0.1:3100/DAN/issues/DAN-288)
