### PR TITLE
fix(skills): make paperclip-create-agent available to agents that can hire

### DIFF
--- a/packages/adapter-utils/src/server-utils.test.ts
+++ b/packages/adapter-utils/src/server-utils.test.ts
@@ -11,7 +11,9 @@ import {
   buildInvocationEnvForLogs,
   DEFAULT_PAPERCLIP_AGENT_PROMPT_TEMPLATE,
   materializePaperclipSkillCopy,
+  PAPERCLIP_CREATE_AGENT_SKILL_KEY,
   refreshPaperclipWorkspaceEnvForExecution,
+  resolvePaperclipDesiredSkillNames,
   renderPaperclipWakePrompt,
   runningProcesses,
   runChildProcess,
@@ -382,6 +384,56 @@ describe("adapter skill snapshots", () => {
       state: "stale",
       managed: true,
     }));
+  });
+});
+
+describe("resolvePaperclipDesiredSkillNames", () => {
+  const createAgentEntry = {
+    key: "paperclipai/paperclip/paperclip-create-agent",
+    runtimeName: "paperclip-create-agent",
+    source: "/runtime/paperclip-create-agent",
+  };
+  const otherEntry = {
+    key: "paperclipai/paperclip/paperclip",
+    runtimeName: "paperclip",
+    source: "/runtime/paperclip",
+  };
+
+  it("returns [] when no explicit desiredSkills and no alwaysInclude option (unchanged)", () => {
+    expect(resolvePaperclipDesiredSkillNames({}, [createAgentEntry, otherEntry])).toEqual([]);
+  });
+
+  it("includes an always-include skill even without any explicit desiredSkills", () => {
+    const result = resolvePaperclipDesiredSkillNames({}, [createAgentEntry, otherEntry], {
+      alwaysIncludeSkillKeys: [PAPERCLIP_CREATE_AGENT_SKILL_KEY],
+    });
+    expect(result).toEqual([createAgentEntry.key]);
+  });
+
+  it("does not include an always-include skill that is not available (no phantom)", () => {
+    const result = resolvePaperclipDesiredSkillNames({}, [otherEntry], {
+      alwaysIncludeSkillKeys: [PAPERCLIP_CREATE_AGENT_SKILL_KEY],
+    });
+    expect(result).toEqual([]);
+  });
+
+  it("unions the always-include skill with explicit desiredSkills, deduped", () => {
+    const config = {
+      paperclipSkillSync: { desiredSkills: [otherEntry.key, PAPERCLIP_CREATE_AGENT_SKILL_KEY] },
+    };
+    const result = resolvePaperclipDesiredSkillNames(config, [createAgentEntry, otherEntry], {
+      alwaysIncludeSkillKeys: [PAPERCLIP_CREATE_AGENT_SKILL_KEY],
+    });
+    expect(result).toContain(createAgentEntry.key);
+    expect(result).toContain(otherEntry.key);
+    expect(result.filter((key) => key === createAgentEntry.key)).toHaveLength(1);
+  });
+
+  it("preserves existing explicit desiredSkills behavior when the option is absent", () => {
+    const config = { paperclipSkillSync: { desiredSkills: [otherEntry.key] } };
+    expect(resolvePaperclipDesiredSkillNames(config, [createAgentEntry, otherEntry])).toEqual([
+      otherEntry.key,
+    ]);
   });
 });
 

--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -2426,16 +2426,32 @@ function canonicalizeDesiredPaperclipSkillReference(
   return normalizedReference;
 }
 
+/**
+ * Runtime slug of the upstream skill that documents how an agent hires (creates)
+ * other agents. Agents whose permissions include `canCreateAgents` need this
+ * skill mounted into their sandbox even when they have no explicit desiredSkills
+ * configured, otherwise a lead/CEO agent has no instructions for the hire flow.
+ */
+export const PAPERCLIP_CREATE_AGENT_SKILL_KEY = "paperclip-create-agent";
+
 export function resolvePaperclipDesiredSkillNames(
   config: Record<string, unknown>,
   availableEntries: Array<{ key: string; runtimeName?: string | null }>,
+  opts?: { alwaysIncludeSkillKeys?: string[] },
 ): string[] {
   const preference = readPaperclipSkillSyncPreference(config);
-  if (!preference.explicit) return [];
+  // Skills that must be present regardless of explicit configuration (e.g. the
+  // create-agent skill for agents that can hire). Canonicalize the same way as
+  // explicit desiredSkills, and only keep references that resolve to an actually
+  // available skill so we never reference a phantom entry.
+  const alwaysInclude = (opts?.alwaysIncludeSkillKeys ?? [])
+    .map((reference) => canonicalizeDesiredPaperclipSkillReference(reference, availableEntries))
+    .filter((key) => key.length > 0 && availableEntries.some((entry) => entry.key === key));
+  if (!preference.explicit && alwaysInclude.length === 0) return [];
   const desiredSkills = preference.desiredSkills
     .map((reference) => canonicalizeDesiredPaperclipSkillReference(reference, availableEntries))
     .filter(Boolean);
-  return Array.from(new Set(desiredSkills));
+  return Array.from(new Set([...desiredSkills, ...alwaysInclude]));
 }
 
 export function writePaperclipSkillSyncPreference(

--- a/packages/adapter-utils/src/types.ts
+++ b/packages/adapter-utils/src/types.ts
@@ -12,6 +12,12 @@ export interface AdapterAgent {
   name: string;
   adapterType: string | null;
   adapterConfig: unknown;
+  /**
+   * Agent permissions relevant to runtime asset provisioning. Optional so
+   * existing callers/tests remain valid; adapters read `canCreateAgents` to
+   * decide whether the create-agent skill must be mounted into the sandbox.
+   */
+  permissions?: { canCreateAgents?: boolean; [key: string]: unknown } | null;
 }
 
 export interface AdapterRuntime {

--- a/packages/adapters/opencode-local/src/server/execute.test.ts
+++ b/packages/adapters/opencode-local/src/server/execute.test.ts
@@ -1,6 +1,62 @@
+import { mkdtemp, readdir, rm, mkdir } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 
-import { ensureRemoteOpenCodeModelConfiguredAndAvailable } from "./execute.js";
+import { buildOpenCodeSkillsDir, ensureRemoteOpenCodeModelConfiguredAndAvailable } from "./execute.js";
+
+describe("buildOpenCodeSkillsDir create-agent inclusion", () => {
+  const cleanupDirs: string[] = [];
+
+  afterEach(async () => {
+    while (cleanupDirs.length > 0) {
+      const dir = cleanupDirs.pop();
+      if (!dir) continue;
+      await rm(dir, { recursive: true, force: true }).catch(() => undefined);
+    }
+  });
+
+  async function makeConfigWithSkills() {
+    const root = await mkdtemp(path.join(os.tmpdir(), "paperclip-opencode-skilltest-"));
+    cleanupDirs.push(root);
+    const createAgentSource = path.join(root, "paperclip-create-agent");
+    const otherSource = path.join(root, "paperclip");
+    await mkdir(createAgentSource, { recursive: true });
+    await mkdir(otherSource, { recursive: true });
+    // Runtime skills are configured directly on the adapter config so the helper
+    // resolves them without touching the packaged skills directory.
+    return {
+      paperclipRuntimeSkills: [
+        {
+          key: "paperclipai/paperclip/paperclip-create-agent",
+          runtimeName: "paperclip-create-agent",
+          source: createAgentSource,
+        },
+        {
+          key: "paperclipai/paperclip/paperclip",
+          runtimeName: "paperclip",
+          source: otherSource,
+        },
+      ],
+    } as Record<string, unknown>;
+  }
+
+  it("includes the paperclip-create-agent skill when the agent can hire", async () => {
+    const config = await makeConfigWithSkills();
+    const dir = await buildOpenCodeSkillsDir(config, { canCreateAgents: true });
+    cleanupDirs.push(path.dirname(dir));
+    const entries = await readdir(dir);
+    expect(entries).toContain("paperclip-create-agent");
+  });
+
+  it("excludes the paperclip-create-agent skill when the agent cannot hire", async () => {
+    const config = await makeConfigWithSkills();
+    const dir = await buildOpenCodeSkillsDir(config, { canCreateAgents: false });
+    cleanupDirs.push(path.dirname(dir));
+    const entries = await readdir(dir);
+    expect(entries).not.toContain("paperclip-create-agent");
+  });
+});
 
 describe("ensureRemoteOpenCodeModelConfiguredAndAvailable", () => {
   afterEach(() => {

--- a/packages/adapters/opencode-local/src/server/execute.ts
+++ b/packages/adapters/opencode-local/src/server/execute.ts
@@ -43,6 +43,7 @@ import {
   readPaperclipRuntimeSkillEntries,
   readPaperclipIssueWorkModeFromContext,
   resolvePaperclipDesiredSkillNames,
+  PAPERCLIP_CREATE_AGENT_SKILL_KEY,
 } from "@paperclipai/adapter-utils/server-utils";
 import { isOpenCodeUnknownSessionError, parseOpenCodeJsonl } from "./parse.js";
 import {
@@ -193,12 +194,28 @@ async function ensureOpenCodeSkillsInjected(
   }
 }
 
-async function buildOpenCodeSkillsDir(config: Record<string, unknown>): Promise<string> {
+/**
+ * Skills that must be mounted for this agent regardless of its explicit
+ * desiredSkills configuration. An agent that can hire (`canCreateAgents`) needs
+ * the create-agent skill so it has the hire-flow instructions in its sandbox.
+ */
+function alwaysIncludeSkillKeysForAgent(opts?: { canCreateAgents?: boolean }): string[] {
+  return opts?.canCreateAgents ? [PAPERCLIP_CREATE_AGENT_SKILL_KEY] : [];
+}
+
+export async function buildOpenCodeSkillsDir(
+  config: Record<string, unknown>,
+  opts?: { canCreateAgents?: boolean },
+): Promise<string> {
   const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-opencode-skills-"));
   const target = path.join(tmp, "skills");
   await fs.mkdir(target, { recursive: true });
   const availableEntries = await readPaperclipRuntimeSkillEntries(config, __moduleDir);
-  const desiredNames = new Set(resolvePaperclipDesiredSkillNames(config, availableEntries));
+  const desiredNames = new Set(
+    resolvePaperclipDesiredSkillNames(config, availableEntries, {
+      alwaysIncludeSkillKeys: alwaysIncludeSkillKeysForAgent(opts),
+    }),
+  );
   for (const entry of availableEntries) {
     if (!desiredNames.has(entry.key)) continue;
     await fs.symlink(entry.source, path.join(target, entry.runtimeName));
@@ -241,7 +258,11 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   let effectiveExecutionCwd = adapterExecutionTargetRemoteCwd(executionTarget, cwd);
   await ensureAbsoluteDirectory(cwd, { createIfMissing: true });
   const openCodeSkillEntries = await readPaperclipRuntimeSkillEntries(config, __moduleDir);
-  const desiredOpenCodeSkillNames = resolvePaperclipDesiredSkillNames(config, openCodeSkillEntries);
+  const desiredOpenCodeSkillNames = resolvePaperclipDesiredSkillNames(config, openCodeSkillEntries, {
+    alwaysIncludeSkillKeys: alwaysIncludeSkillKeysForAgent({
+      canCreateAgents: Boolean(agent.permissions?.canCreateAgents),
+    }),
+  });
   if (!executionTargetIsRemote) {
     await ensureOpenCodeSkillsInjected(
       onLog,
@@ -364,7 +385,9 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     let paperclipBridge: Awaited<ReturnType<typeof startAdapterExecutionTargetPaperclipBridge>> = null;
 
     if (executionTarget?.kind === "remote") {
-      localSkillsDir = await buildOpenCodeSkillsDir(config);
+      localSkillsDir = await buildOpenCodeSkillsDir(config, {
+        canCreateAgents: Boolean(agent.permissions?.canCreateAgents),
+      });
       await onLog(
         "stdout",
         `[paperclip] Syncing workspace and OpenCode runtime assets to ${describeAdapterExecutionTarget(executionTarget)}.\n`,


### PR DESCRIPTION
## Problem

Agents whose permissions include `canCreateAgents` (e.g. a lead/CEO agent) cannot actually hire, because the `paperclip-create-agent` skill is never mounted into their k8s sandbox run. The skill's `SKILL.md` is what tells the agent how to submit a hire (`POST /api/companies/$PAPERCLIP_COMPANY_ID/agent-hires` using the injected `$PAPERCLIP_API_KEY`/`$PAPERCLIP_API_URL`), so without it a capable agent has no hire-flow instructions and reports it "cannot access the paperclip-create-agent skill".

### Root cause

At run time the opencode adapter builds the sandbox skills dir via `resolvePaperclipDesiredSkillNames(config, availableEntries)`, which returns `[]` unless the agent has an explicit `adapterConfig.paperclipSkillSync.desiredSkills` (`preference.explicit`). Managed agents (including a seeded CEO) have no explicit `desiredSkills`, so **zero** skills are synced (`Syncing skills to sandbox: 100% (0.0/0.0 MB)`) and `paperclip-create-agent` is absent.

## Fix (run-time, no backfill)

Include the create-agent skill in the sandbox for any agent whose permissions include `canCreateAgents`, resolved at **run time** so it covers both already-existing agents and newly-created ones (no data migration).

- `resolvePaperclipDesiredSkillNames(config, availableEntries, opts?)` gains an optional `opts.alwaysIncludeSkillKeys: string[]`. Those keys are unioned into the result (canonicalized the same way as explicit desired skills, and deduped) even when there is no explicit `desiredSkills` preference. **Behavior is unchanged when the option is absent**, and a requested skill is only included when it actually exists in `availableEntries` (no phantom entries). New exported constant `PAPERCLIP_CREATE_AGENT_SKILL_KEY`.
- The opencode adapter threads the agent's `canCreateAgents` into both skill-dir build paths (`buildOpenCodeSkillsDir` for the remote/sandbox path, and the local injection path), including `paperclip-create-agent` when the agent can hire.
- `AdapterAgent` gains an optional `permissions` field so adapters can read `canCreateAgents`.

Other local adapters can opt in cheaply via the same `alwaysIncludeSkillKeys` option (follow-up); this PR wires the managed-default opencode adapter.

## Tests (TDD)

- `resolvePaperclipDesiredSkillNames`: returns `["paperclip-create-agent"]` with the option and no explicit desiredSkills; `[]` without the option (unchanged); `[]` when the skill is unavailable (no phantom); unions + dedupes with explicit desiredSkills.
- opencode adapter: `buildOpenCodeSkillsDir` includes the create-agent skill when the caller passes `canCreateAgents: true` and excludes it when `false`.

All new and existing opencode/adapter-utils skill+execute tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)