### PR TITLE
Add liveness-continuation backoff + per-issue upstream-throttle ceiling (shadow-mode first)

### DIFF
--- a/server/src/__tests__/run-continuations.test.ts
+++ b/server/src/__tests__/run-continuations.test.ts
@@ -4,6 +4,7 @@ import {
   RUN_LIVENESS_CONTINUATION_REASON,
   buildRunLivenessContinuationIdempotencyKey,
   decideRunLivenessContinuation,
+  isActionableLivenessStateForContinuation,
 } from "../services/run-continuations.ts";
 
 const companyId = "company-1";
@@ -169,5 +170,67 @@ describe("run liveness continuations", () => {
 
       expect(decision.kind).toBe("skip");
     }
+  });
+
+  it("treats upstream_throttled as non-actionable for immediate continuation", () => {
+    // Layer B introduces the upstream_throttled liveness state for retryable
+    // upstream 429 exits; the bounded transient retry ladder and the per-issue
+    // throttle ceiling own those, so they must never immediately continue.
+    expect(isActionableLivenessStateForContinuation("upstream_throttled")).toBe(false);
+    expect(isActionableLivenessStateForContinuation("plan_only")).toBe(true);
+    expect(isActionableLivenessStateForContinuation("empty_response")).toBe(true);
+    expect(isActionableLivenessStateForContinuation(null)).toBe(false);
+
+    const decision = decideRunLivenessContinuation({
+      run: run(),
+      issue: issue(),
+      agent: agent(),
+      livenessState: "upstream_throttled" as never,
+      livenessReason: "Upstream provider throttled the run",
+      nextAction: null,
+      budgetBlocked: false,
+      idempotentWakeExists: false,
+    });
+
+    expect(decision).toEqual({
+      kind: "skip",
+      reason: "liveness state is not actionable for continuation",
+    });
+  });
+
+  it("carries the caller-computed backoff schedule on enqueue decisions", () => {
+    const dueAt = new Date("2026-07-01T12:01:00.000Z");
+    const decision = decideRunLivenessContinuation({
+      run: run(),
+      issue: issue(),
+      agent: agent(),
+      livenessState: "plan_only",
+      livenessReason: "Planned without acting",
+      nextAction: null,
+      budgetBlocked: false,
+      idempotentWakeExists: false,
+      backoff: { delayMs: 60_000, dueAt },
+    });
+
+    expect(decision.kind).toBe("enqueue");
+    if (decision.kind !== "enqueue") return;
+    expect(decision.backoff).toEqual({ delayMs: 60_000, dueAt });
+  });
+
+  it("defaults to no backoff when the caller does not provide one", () => {
+    const decision = decideRunLivenessContinuation({
+      run: run(),
+      issue: issue(),
+      agent: agent(),
+      livenessState: "empty_response",
+      livenessReason: "No useful output",
+      nextAction: null,
+      budgetBlocked: false,
+      idempotentWakeExists: false,
+    });
+
+    expect(decision.kind).toBe("enqueue");
+    if (decision.kind !== "enqueue") return;
+    expect(decision.backoff).toBeNull();
   });
 });

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -6234,39 +6234,48 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
               updatedAt: new Date(),
             })
             .where(eq(heartbeatRuns.id, run.id));
-        } else {
-          await appendRunEvent(run, await nextRunEventSeq(run.id), {
-            eventType: "lifecycle",
-            stream: "system",
-            level: "warn",
-            message: "Deferred liveness continuation was not scheduled; no immediate continuation was enqueued",
-            payload: {
-              throttleMode: LIVENESS_CONTINUATION_THROTTLE_CONFIG.mode,
-              attempt: decision.nextAttempt,
-              delayMs: decision.backoff.delayMs,
-              outcome: scheduled.outcome,
-              ...("reason" in scheduled ? { reason: scheduled.reason } : {}),
-            },
-          });
+          return;
         }
-        return;
+        // Deferral failed (retry exhausted on a mixed retry chain, agent
+        // invokability gate, issue lock churn): fall through to the immediate
+        // enqueue below so enforce mode never drops a continuation the
+        // decision layer approved.
+        await appendRunEvent(run, await nextRunEventSeq(run.id), {
+          eventType: "lifecycle",
+          stream: "system",
+          level: "warn",
+          message: "Deferred liveness continuation was not scheduled; falling back to an immediate continuation",
+          payload: {
+            throttleMode: LIVENESS_CONTINUATION_THROTTLE_CONFIG.mode,
+            attempt: decision.nextAttempt,
+            delayMs: decision.backoff.delayMs,
+            outcome: scheduled.outcome,
+            ...("reason" in scheduled ? { reason: scheduled.reason } : {}),
+          },
+        });
       }
     }
 
     if (decision.backoff && LIVENESS_CONTINUATION_THROTTLE_CONFIG.mode === "shadow") {
-      await appendRunEvent(run, await nextRunEventSeq(run.id), {
-        eventType: "lifecycle",
-        stream: "system",
-        level: "info",
-        message:
-          `Liveness continuation throttle (shadow): would defer continuation attempt ${decision.nextAttempt} by ${decision.backoff.delayMs}ms`,
-        payload: {
-          throttleMode: "shadow",
-          attempt: decision.nextAttempt,
-          delayMs: decision.backoff.delayMs,
-          dueAt: decision.backoff.dueAt.toISOString(),
-        },
-      });
+      // Instrumentation only — a failure to record the shadow event must not
+      // suppress the continuation the pre-change code would have fired.
+      try {
+        await appendRunEvent(run, await nextRunEventSeq(run.id), {
+          eventType: "lifecycle",
+          stream: "system",
+          level: "info",
+          message:
+            `Liveness continuation throttle (shadow): would defer continuation attempt ${decision.nextAttempt} by ${decision.backoff.delayMs}ms`,
+          payload: {
+            throttleMode: "shadow",
+            attempt: decision.nextAttempt,
+            delayMs: decision.backoff.delayMs,
+            dueAt: decision.backoff.dueAt.toISOString(),
+          },
+        });
+      } catch (err) {
+        logger.warn({ err, runId: run.id }, "failed to record shadow liveness-continuation backoff event");
+      }
     }
 
     const continuationRun = await enqueueWakeup(run.agentId, {
@@ -11360,7 +11369,14 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         }
         const issueCommentPolicyResult = await finalizeIssueCommentPolicy(livenessRun, agent);
         await releaseIssueExecutionAndPromote(livenessRun);
-        await handleUpstreamThrottleCeiling(livenessRun, agent);
+        try {
+          await handleUpstreamThrottleCeiling(livenessRun, agent);
+        } catch (err) {
+          // Best-effort hardening: a failure while evaluating (or enforcing)
+          // the throttle ceiling must never break run finalization or block
+          // the continuation handler below.
+          logger.warn({ err, runId: livenessRun.id }, "upstream throttle ceiling evaluation failed");
+        }
         await handleRunLivenessContinuation(livenessRun);
         await handleSuccessfulRunHandoff(
           issueCommentPolicyResult.outcome === "retry_queued" || issueCommentPolicyResult.outcome === "retry_exhausted"

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -144,6 +144,7 @@ import {
 } from "./execution-allowlist.js";
 import {
   RECOVERY_ORIGIN_KINDS,
+  DEFAULT_MAX_LIVENESS_CONTINUATION_ATTEMPTS,
   FINISH_SUCCESSFUL_RUN_HANDOFF_REASON,
   SUCCESSFUL_RUN_MISSING_STATE_REASON,
   RUN_LIVENESS_CONTINUATION_REASON,
@@ -158,6 +159,15 @@ import {
   readContinuationAttempt,
 } from "./recovery/index.js";
 import { isAutomaticRecoverySuppressedByPauseHold } from "./recovery/pause-hold-guard.js";
+import {
+  LIVENESS_CONTINUATION_RETRY_REASON,
+  UPSTREAM_THROTTLE_CEILING_PAUSE_REASON,
+  computeLivenessContinuationBackoff,
+  decideUpstreamThrottleCeiling,
+  isUpstreamThrottleExitRun,
+  resolveLivenessContinuationThrottleConfig,
+  summarizeUpstreamThrottleStreak,
+} from "./recovery/liveness-continuation-throttle.js";
 import {
   recoveryAssigneeAdapterOverrides,
   withRecoveryModelProfileHint,
@@ -275,6 +285,12 @@ const BOUNDED_TRANSIENT_HEARTBEAT_RETRY_JITTER_RATIO = 0.25;
 const BOUNDED_TRANSIENT_HEARTBEAT_RETRY_REASON = "transient_failure";
 const BOUNDED_TRANSIENT_HEARTBEAT_RETRY_WAKE_REASON = "transient_failure_retry";
 const BOUNDED_TRANSIENT_HEARTBEAT_RETRY_MAX_ATTEMPTS = BOUNDED_TRANSIENT_HEARTBEAT_RETRY_DELAYS_MS.length;
+// Layer C throttle hardening (GOL-4038): backoff for liveness continuations +
+// per-issue rolling-window ceiling for upstream-throttle exits. Defaults to
+// shadow (log-only); "enforce" defers continuations and pauses agents at the
+// ceiling. Snapshotted at process start like the other retry policy consts.
+const LIVENESS_CONTINUATION_THROTTLE_CONFIG = resolveLivenessContinuationThrottleConfig(process.env);
+const UPSTREAM_THROTTLE_CEILING_RUN_SCAN_LIMIT = 25;
 const WORKSPACE_VALIDATION_FAILURE_CODE = "workspace_validation_failed";
 const WORKSPACE_VALIDATION_RECOVERY_CAUSE = "workspace_validation_failed";
 const CONFIGURATION_INCOMPLETE_FAILURE_CODE = "configuration_incomplete";
@@ -6161,6 +6177,14 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       })
       : null;
 
+    const continuationBackoff =
+      LIVENESS_CONTINUATION_THROTTLE_CONFIG.mode === "off"
+        ? null
+        : computeLivenessContinuationBackoff({
+          attempt: nextAttempt,
+          config: LIVENESS_CONTINUATION_THROTTLE_CONFIG,
+        });
+
     const decision = decideRunLivenessContinuation({
       run,
       issue,
@@ -6170,6 +6194,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       nextAction: run.nextAction,
       budgetBlocked: Boolean(budgetBlock),
       idempotentWakeExists: Boolean(existingWake),
+      backoff: continuationBackoff,
     });
 
     if (decision.kind === "exhausted") {
@@ -6185,6 +6210,64 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     }
 
     if (decision.kind !== "enqueue") return;
+
+    if (decision.backoff && LIVENESS_CONTINUATION_THROTTLE_CONFIG.mode === "enforce") {
+      const fullAgent = await db
+        .select()
+        .from(agents)
+        .where(eq(agents.id, run.agentId))
+        .then((rows) => rows[0] ?? null);
+      if (fullAgent) {
+        const scheduled = await scheduleBoundedRetryForRun(run, fullAgent, {
+          retryReason: LIVENESS_CONTINUATION_RETRY_REASON,
+          wakeReason: RUN_LIVENESS_CONTINUATION_REASON,
+          maxAttempts: DEFAULT_MAX_LIVENESS_CONTINUATION_ATTEMPTS,
+          delayMs: decision.backoff.delayMs,
+          idempotencyKey: decision.idempotencyKey,
+          contextSnapshotExtra: decision.contextSnapshot,
+        });
+        if (scheduled.outcome === "scheduled") {
+          await db
+            .update(heartbeatRuns)
+            .set({
+              continuationAttempt: decision.nextAttempt,
+              updatedAt: new Date(),
+            })
+            .where(eq(heartbeatRuns.id, run.id));
+        } else {
+          await appendRunEvent(run, await nextRunEventSeq(run.id), {
+            eventType: "lifecycle",
+            stream: "system",
+            level: "warn",
+            message: "Deferred liveness continuation was not scheduled; no immediate continuation was enqueued",
+            payload: {
+              throttleMode: LIVENESS_CONTINUATION_THROTTLE_CONFIG.mode,
+              attempt: decision.nextAttempt,
+              delayMs: decision.backoff.delayMs,
+              outcome: scheduled.outcome,
+              ...("reason" in scheduled ? { reason: scheduled.reason } : {}),
+            },
+          });
+        }
+        return;
+      }
+    }
+
+    if (decision.backoff && LIVENESS_CONTINUATION_THROTTLE_CONFIG.mode === "shadow") {
+      await appendRunEvent(run, await nextRunEventSeq(run.id), {
+        eventType: "lifecycle",
+        stream: "system",
+        level: "info",
+        message:
+          `Liveness continuation throttle (shadow): would defer continuation attempt ${decision.nextAttempt} by ${decision.backoff.delayMs}ms`,
+        payload: {
+          throttleMode: "shadow",
+          attempt: decision.nextAttempt,
+          delayMs: decision.backoff.delayMs,
+          dueAt: decision.backoff.dueAt.toISOString(),
+        },
+      });
+    }
 
     const continuationRun = await enqueueWakeup(run.agentId, {
       source: "automation",
@@ -6206,6 +6289,142 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         })
         .where(eq(heartbeatRuns.id, run.id));
     }
+  }
+
+  // Layer C ceiling (GOL-4038): per-issue rolling-window cap for
+  // upstream-throttle exits. Per-source-run continuation caps reset whenever a
+  // fresh wake starts a new source run, so a throttled provider can burst
+  // retries indefinitely; this counts consecutive throttle exits across source
+  // runs for the same issue and, at the ceiling, pauses the agent and files one
+  // consolidated notice naming the real blocker (provider quota/rate limit).
+  async function handleUpstreamThrottleCeiling(
+    run: typeof heartbeatRuns.$inferSelect,
+    agent: typeof agents.$inferSelect,
+  ) {
+    const config = LIVENESS_CONTINUATION_THROTTLE_CONFIG;
+    if (config.mode === "off") return;
+    if (!isUpstreamThrottleExitRun(run)) return;
+
+    const context = parseObject(run.contextSnapshot);
+    const issueId = readNonEmptyString(context.issueId);
+    if (!issueId) return;
+
+    const issue = await db
+      .select({
+        id: issues.id,
+        companyId: issues.companyId,
+        identifier: issues.identifier,
+        status: issues.status,
+        assigneeAgentId: issues.assigneeAgentId,
+      })
+      .from(issues)
+      .where(and(eq(issues.id, issueId), eq(issues.companyId, run.companyId)))
+      .then((rows) => rows[0] ?? null);
+    if (!issue) return;
+    if (issue.assigneeAgentId !== run.agentId) return;
+    if (issue.status !== "todo" && issue.status !== "in_progress") return;
+
+    const now = new Date();
+    const windowStart = new Date(now.getTime() - config.ceilingWindowMs);
+    const recentRuns = await db
+      .select({
+        status: heartbeatRuns.status,
+        errorCode: heartbeatRuns.errorCode,
+        livenessState: heartbeatRuns.livenessState,
+        resultJson: heartbeatRuns.resultJson,
+        finishedAt: heartbeatRuns.finishedAt,
+        createdAt: heartbeatRuns.createdAt,
+      })
+      .from(heartbeatRuns)
+      .where(
+        and(
+          eq(heartbeatRuns.companyId, run.companyId),
+          eq(heartbeatRuns.agentId, run.agentId),
+          inArray(heartbeatRuns.status, ["succeeded", "failed", "timed_out"]),
+          gte(heartbeatRuns.createdAt, windowStart),
+          sql`${heartbeatRuns.contextSnapshot} ->> 'issueId' = ${issueId}`,
+        ),
+      )
+      .orderBy(desc(heartbeatRuns.createdAt), desc(heartbeatRuns.id))
+      .limit(UPSTREAM_THROTTLE_CEILING_RUN_SCAN_LIMIT);
+
+    const streak = summarizeUpstreamThrottleStreak({
+      runs: recentRuns,
+      now,
+      windowMs: config.ceilingWindowMs,
+    });
+    const decision = decideUpstreamThrottleCeiling({
+      streak,
+      config,
+      issue: { id: issue.id, identifier: issue.identifier },
+      agentId: run.agentId,
+    });
+    if (decision.action !== "ceiling_reached") return;
+
+    if (!decision.pauseAgent) {
+      await appendRunEvent(run, await nextRunEventSeq(run.id), {
+        eventType: "lifecycle",
+        stream: "system",
+        level: "warn",
+        message:
+          `Upstream throttle ceiling (shadow): ${decision.streak} consecutive throttle exits for ${issue.identifier ?? issue.id} — would pause agent and file a consolidated notice`,
+        payload: {
+          throttleMode: decision.mode,
+          issueId: issue.id,
+          streak: decision.streak,
+          ceilingConsecutiveRuns: decision.ceilingConsecutiveRuns,
+          ceilingWindowMs: decision.ceilingWindowMs,
+        },
+      });
+      return;
+    }
+
+    await db
+      .update(agents)
+      .set({
+        status: "paused",
+        pauseReason: UPSTREAM_THROTTLE_CEILING_PAUSE_REASON,
+        pausedAt: now,
+        updatedAt: now,
+      })
+      .where(and(eq(agents.id, agent.id), inArray(agents.status, ["active", "idle", "running", "error"])));
+
+    const existingNotice = await db
+      .select({ id: issueComments.id })
+      .from(issueComments)
+      .where(
+        and(
+          eq(issueComments.companyId, run.companyId),
+          eq(issueComments.issueId, issue.id),
+          gte(issueComments.createdAt, windowStart),
+          sql`${issueComments.body} like ${`%<!-- ${decision.noticeMarker} -->%`}`,
+        ),
+      )
+      .limit(1)
+      .then((rows) => rows[0] ?? null);
+    if (!existingNotice) {
+      await issuesSvc.addComment(issue.id, decision.noticeBody, {
+        agentId: run.agentId,
+        runId: run.id,
+      });
+    }
+
+    await appendRunEvent(run, await nextRunEventSeq(run.id), {
+      eventType: "lifecycle",
+      stream: "system",
+      level: "warn",
+      message:
+        `Upstream throttle ceiling reached: ${decision.streak} consecutive throttle exits for ${issue.identifier ?? issue.id} — agent paused, consolidated notice ${existingNotice ? "already present" : "filed"}`,
+      payload: {
+        throttleMode: decision.mode,
+        issueId: issue.id,
+        streak: decision.streak,
+        ceilingConsecutiveRuns: decision.ceilingConsecutiveRuns,
+        ceilingWindowMs: decision.ceilingWindowMs,
+        pausedAgentId: agent.id,
+        consolidatedNoticeFiled: !existingNotice,
+      },
+    });
   }
 
   function issueUiLink(issue: Pick<typeof issues.$inferSelect, "id" | "identifier">) {
@@ -7420,6 +7639,10 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       wakeReason?: string;
       maxAttempts?: number;
       delayMs?: number;
+      // Extra context merged over the source run's context snapshot; used by
+      // deferred liveness continuations to carry the continuation instruction.
+      contextSnapshotExtra?: Record<string, unknown>;
+      idempotencyKey?: string;
     },
   ) {
     const now = opts?.now ?? new Date();
@@ -7543,10 +7766,12 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       scheduledRetryAt: schedule.dueAt.toISOString(),
       ...(transientRetryNotBefore ? { transientRetryNotBefore: transientRetryNotBefore.toISOString() } : {}),
       ...(codexTransientFallbackMode ? { codexTransientFallbackMode } : {}),
+      ...(opts?.contextSnapshotExtra ?? {}),
     }, "normal_model");
-    const maxTurnContinuationIdempotencyKey = retryReason === MAX_TURN_CONTINUATION_RETRY_REASON
-      ? `max-turn-continuation:${run.companyId}:${issueId ?? "no-issue"}:${run.id}:${schedule.attempt}`
-      : null;
+    const maxTurnContinuationIdempotencyKey = opts?.idempotencyKey ??
+      (retryReason === MAX_TURN_CONTINUATION_RETRY_REASON
+        ? `max-turn-continuation:${run.companyId}:${issueId ?? "no-issue"}:${run.id}:${schedule.attempt}`
+        : null);
 
     type ScheduledRetryTransactionResult =
       | {
@@ -11135,6 +11360,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         }
         const issueCommentPolicyResult = await finalizeIssueCommentPolicy(livenessRun, agent);
         await releaseIssueExecutionAndPromote(livenessRun);
+        await handleUpstreamThrottleCeiling(livenessRun, agent);
         await handleRunLivenessContinuation(livenessRun);
         await handleSuccessfulRunHandoff(
           issueCommentPolicyResult.outcome === "retry_queued" || issueCommentPolicyResult.outcome === "retry_exhausted"

--- a/server/src/services/recovery/index.ts
+++ b/server/src/services/recovery/index.ts
@@ -37,11 +37,33 @@ export {
   buildRunLivenessContinuationIdempotencyKey,
   decideRunLivenessContinuation,
   findExistingRunLivenessContinuationWake,
+  isActionableLivenessStateForContinuation,
   readContinuationAttempt,
 } from "./run-liveness-continuations.js";
 export type {
+  RunContinuationBackoff,
   RunContinuationDecision,
 } from "./run-liveness-continuations.js";
+export {
+  DEFAULT_LIVENESS_CONTINUATION_THROTTLE_CONFIG,
+  LIVENESS_CONTINUATION_RETRY_REASON,
+  UPSTREAM_THROTTLE_CEILING_PAUSE_REASON,
+  UPSTREAM_THROTTLE_LIVENESS_STATE,
+  buildUpstreamThrottleCeilingNoticeMarker,
+  computeLivenessContinuationBackoff,
+  decideUpstreamThrottleCeiling,
+  isUpstreamThrottleExitRun,
+  resolveLivenessContinuationThrottleConfig,
+  summarizeUpstreamThrottleStreak,
+} from "./liveness-continuation-throttle.js";
+export type {
+  LivenessContinuationBackoffSchedule,
+  LivenessContinuationThrottleConfig,
+  LivenessContinuationThrottleMode,
+  ThrottleExitRunLike,
+  UpstreamThrottleCeilingDecision,
+  UpstreamThrottleStreak,
+} from "./liveness-continuation-throttle.js";
 export {
   DEFAULT_MAX_SUCCESSFUL_RUN_HANDOFF_ATTEMPTS,
   FINISH_SUCCESSFUL_RUN_HANDOFF_REASON,

--- a/server/src/services/recovery/liveness-continuation-throttle.test.ts
+++ b/server/src/services/recovery/liveness-continuation-throttle.test.ts
@@ -1,0 +1,289 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_LIVENESS_CONTINUATION_THROTTLE_CONFIG,
+  buildUpstreamThrottleCeilingNoticeMarker,
+  computeLivenessContinuationBackoff,
+  decideUpstreamThrottleCeiling,
+  isUpstreamThrottleExitRun,
+  resolveLivenessContinuationThrottleConfig,
+  summarizeUpstreamThrottleStreak,
+} from "./liveness-continuation-throttle.ts";
+
+const NOW = new Date("2026-07-01T12:00:00.000Z");
+const HOUR_MS = 60 * 60 * 1000;
+
+function config(overrides: Partial<typeof DEFAULT_LIVENESS_CONTINUATION_THROTTLE_CONFIG> = {}) {
+  return { ...DEFAULT_LIVENESS_CONTINUATION_THROTTLE_CONFIG, ...overrides };
+}
+
+function throttleRun(minutesAgo: number, overrides: Record<string, unknown> = {}) {
+  return {
+    status: "failed",
+    errorCode: "claude_transient_upstream",
+    livenessState: null,
+    resultJson: null,
+    finishedAt: new Date(NOW.getTime() - minutesAgo * 60_000),
+    ...overrides,
+  };
+}
+
+function productiveRun(minutesAgo: number) {
+  return {
+    status: "succeeded",
+    errorCode: null,
+    livenessState: "advanced",
+    resultJson: { summary: "did work" },
+    finishedAt: new Date(NOW.getTime() - minutesAgo * 60_000),
+  };
+}
+
+describe("resolveLivenessContinuationThrottleConfig", () => {
+  it("defaults to shadow mode with documented defaults", () => {
+    const resolved = resolveLivenessContinuationThrottleConfig({});
+    expect(resolved.mode).toBe("shadow");
+    expect(resolved.backoffBaseMs).toBe(60_000);
+    expect(resolved.backoffMaxMs).toBe(600_000);
+    expect(resolved.ceilingConsecutiveRuns).toBe(5);
+    expect(resolved.ceilingWindowMs).toBe(HOUR_MS);
+  });
+
+  it("honors explicit modes and rejects unknown modes", () => {
+    for (const mode of ["off", "shadow", "enforce"] as const) {
+      expect(
+        resolveLivenessContinuationThrottleConfig({
+          PAPERCLIP_LIVENESS_CONTINUATION_THROTTLE_MODE: mode,
+        }).mode,
+      ).toBe(mode);
+    }
+    expect(
+      resolveLivenessContinuationThrottleConfig({
+        PAPERCLIP_LIVENESS_CONTINUATION_THROTTLE_MODE: "yes-please",
+      }).mode,
+    ).toBe("shadow");
+  });
+
+  it("parses numeric overrides and falls back on junk", () => {
+    const resolved = resolveLivenessContinuationThrottleConfig({
+      PAPERCLIP_LIVENESS_CONTINUATION_BACKOFF_BASE_MS: "30000",
+      PAPERCLIP_LIVENESS_CONTINUATION_BACKOFF_MAX_MS: "120000",
+      PAPERCLIP_UPSTREAM_THROTTLE_CEILING_RUNS: "3",
+      PAPERCLIP_UPSTREAM_THROTTLE_WINDOW_MS: "junk",
+    });
+    expect(resolved.backoffBaseMs).toBe(30_000);
+    expect(resolved.backoffMaxMs).toBe(120_000);
+    expect(resolved.ceilingConsecutiveRuns).toBe(3);
+    expect(resolved.ceilingWindowMs).toBe(HOUR_MS);
+  });
+
+  it("never lets the backoff cap fall below the base", () => {
+    const resolved = resolveLivenessContinuationThrottleConfig({
+      PAPERCLIP_LIVENESS_CONTINUATION_BACKOFF_BASE_MS: "300000",
+      PAPERCLIP_LIVENESS_CONTINUATION_BACKOFF_MAX_MS: "1000",
+    });
+    expect(resolved.backoffMaxMs).toBe(300_000);
+  });
+});
+
+describe("computeLivenessContinuationBackoff", () => {
+  const midJitter = () => 0.5; // jitter multiplier 1.0
+
+  it("grows exponentially with the attempt number", () => {
+    const first = computeLivenessContinuationBackoff({
+      attempt: 1,
+      config: config(),
+      now: NOW,
+      random: midJitter,
+    });
+    const second = computeLivenessContinuationBackoff({
+      attempt: 2,
+      config: config(),
+      now: NOW,
+      random: midJitter,
+    });
+    expect(first?.delayMs).toBe(60_000);
+    expect(second?.delayMs).toBe(120_000);
+    expect(second?.dueAt.getTime()).toBe(NOW.getTime() + 120_000);
+  });
+
+  it("caps the delay at backoffMaxMs even with max jitter", () => {
+    const deep = computeLivenessContinuationBackoff({
+      attempt: 12,
+      config: config(),
+      now: NOW,
+      random: () => 1,
+    });
+    expect(deep?.delayMs).toBe(600_000);
+  });
+
+  it("bounds jitter within the configured ratio", () => {
+    const low = computeLivenessContinuationBackoff({
+      attempt: 1,
+      config: config(),
+      now: NOW,
+      random: () => 0,
+    });
+    const high = computeLivenessContinuationBackoff({
+      attempt: 1,
+      config: config(),
+      now: NOW,
+      random: () => 1,
+    });
+    expect(low?.delayMs).toBe(45_000);
+    expect(high?.delayMs).toBe(75_000);
+  });
+
+  it("returns null for non-positive or non-integer attempts", () => {
+    for (const attempt of [0, -1, 1.5, Number.NaN]) {
+      expect(
+        computeLivenessContinuationBackoff({ attempt, config: config(), now: NOW }),
+      ).toBeNull();
+    }
+  });
+});
+
+describe("isUpstreamThrottleExitRun", () => {
+  it("matches the Layer A adapter error codes", () => {
+    expect(isUpstreamThrottleExitRun({ errorCode: "claude_transient_upstream" })).toBe(true);
+    expect(isUpstreamThrottleExitRun({ errorCode: "codex_transient_upstream" })).toBe(true);
+  });
+
+  it("matches the persisted errorFamily contract, including clean-exit successes", () => {
+    expect(
+      isUpstreamThrottleExitRun({
+        status: "succeeded",
+        resultJson: { errorFamily: "transient_upstream" },
+      }),
+    ).toBe(true);
+    expect(
+      isUpstreamThrottleExitRun({ resultJson: { errorFamily: "upstream_throttled" } }),
+    ).toBe(true);
+    expect(
+      isUpstreamThrottleExitRun({ resultJson: JSON.stringify({ errorFamily: "transient_upstream" }) }),
+    ).toBe(true);
+  });
+
+  it("matches the Layer B upstream_throttled liveness state before it lands in the shared union", () => {
+    expect(isUpstreamThrottleExitRun({ livenessState: "upstream_throttled" })).toBe(true);
+  });
+
+  it("rejects ordinary runs and unrelated failures", () => {
+    expect(isUpstreamThrottleExitRun({ status: "succeeded", livenessState: "advanced" })).toBe(false);
+    expect(isUpstreamThrottleExitRun({ errorCode: "process_lost" })).toBe(false);
+    expect(isUpstreamThrottleExitRun({ resultJson: { errorFamily: "workspace_validation" } })).toBe(false);
+    expect(isUpstreamThrottleExitRun({ resultJson: "not json" })).toBe(false);
+    expect(isUpstreamThrottleExitRun({})).toBe(false);
+  });
+});
+
+describe("summarizeUpstreamThrottleStreak", () => {
+  it("counts consecutive throttle exits across source runs — the reset-hole case", () => {
+    // Nine throttle exits from nine distinct source runs (each fresh wake
+    // reset continuationAttempt to 0) — the streak must still see all nine.
+    const runs = Array.from({ length: 9 }, (_, index) => throttleRun(index * 5));
+    const streak = summarizeUpstreamThrottleStreak({ runs, now: NOW, windowMs: HOUR_MS });
+    expect(streak.streak).toBe(9);
+    expect(streak.firstThrottleAt?.getTime()).toBe(NOW.getTime() - 40 * 60_000);
+    expect(streak.lastThrottleAt?.getTime()).toBe(NOW.getTime());
+  });
+
+  it("resets at the first productive run", () => {
+    const runs = [throttleRun(0), throttleRun(5), productiveRun(10), throttleRun(15)];
+    const streak = summarizeUpstreamThrottleStreak({ runs, now: NOW, windowMs: HOUR_MS });
+    expect(streak.streak).toBe(2);
+  });
+
+  it("ignores throttle exits outside the rolling window", () => {
+    const runs = [throttleRun(0), throttleRun(5), throttleRun(90)];
+    const streak = summarizeUpstreamThrottleStreak({ runs, now: NOW, windowMs: HOUR_MS });
+    expect(streak.streak).toBe(2);
+  });
+
+  it("orders unsorted input by timestamp before counting", () => {
+    const runs = [throttleRun(30), productiveRun(10), throttleRun(5), throttleRun(0)];
+    const streak = summarizeUpstreamThrottleStreak({ runs, now: NOW, windowMs: HOUR_MS });
+    expect(streak.streak).toBe(2);
+  });
+
+  it("handles empty input and missing timestamps", () => {
+    expect(summarizeUpstreamThrottleStreak({ runs: [], now: NOW, windowMs: HOUR_MS }).streak).toBe(0);
+    expect(
+      summarizeUpstreamThrottleStreak({
+        runs: [{ errorCode: "claude_transient_upstream", finishedAt: null }],
+        now: NOW,
+        windowMs: HOUR_MS,
+      }).streak,
+    ).toBe(0);
+  });
+});
+
+describe("decideUpstreamThrottleCeiling", () => {
+  const issue = { id: "issue-1", identifier: "GOL-1", title: "Example" };
+
+  function streakOf(count: number) {
+    return summarizeUpstreamThrottleStreak({
+      runs: Array.from({ length: count }, (_, index) => throttleRun(index * 2)),
+      now: NOW,
+      windowMs: HOUR_MS,
+    });
+  }
+
+  it("does nothing below the ceiling", () => {
+    const decision = decideUpstreamThrottleCeiling({
+      streak: streakOf(4),
+      config: config({ mode: "enforce" }),
+      issue,
+      agentId: "agent-1",
+    });
+    expect(decision.action).toBe("none");
+  });
+
+  it("does nothing when the mode is off, even above the ceiling", () => {
+    const decision = decideUpstreamThrottleCeiling({
+      streak: streakOf(9),
+      config: config({ mode: "off" }),
+      issue,
+      agentId: "agent-1",
+    });
+    expect(decision.action).toBe("none");
+  });
+
+  it("reaches the ceiling in shadow mode without authorizing a pause", () => {
+    const decision = decideUpstreamThrottleCeiling({
+      streak: streakOf(5),
+      config: config({ mode: "shadow" }),
+      issue,
+      agentId: "agent-1",
+    });
+    expect(decision.action).toBe("ceiling_reached");
+    if (decision.action !== "ceiling_reached") return;
+    expect(decision.pauseAgent).toBe(false);
+    expect(decision.mode).toBe("shadow");
+  });
+
+  it("authorizes the pause and one consolidated notice in enforce mode", () => {
+    const decision = decideUpstreamThrottleCeiling({
+      streak: streakOf(9),
+      config: config({ mode: "enforce" }),
+      issue,
+      agentId: "agent-1",
+    });
+    expect(decision.action).toBe("ceiling_reached");
+    if (decision.action !== "ceiling_reached") return;
+    expect(decision.pauseAgent).toBe(true);
+    expect(decision.streak).toBe(9);
+    expect(decision.noticeMarker).toBe(buildUpstreamThrottleCeilingNoticeMarker(issue.id));
+    expect(decision.noticeBody).toContain("Upstream throttle ceiling reached for GOL-1");
+    expect(decision.noticeBody).toContain("rate limit / quota");
+    expect(decision.noticeBody).toContain(`<!-- upstream-throttle-ceiling:${issue.id} -->`);
+  });
+
+  it("honors a configured ceiling override", () => {
+    const decision = decideUpstreamThrottleCeiling({
+      streak: streakOf(3),
+      config: config({ mode: "enforce", ceilingConsecutiveRuns: 3 }),
+      issue,
+      agentId: "agent-1",
+    });
+    expect(decision.action).toBe("ceiling_reached");
+  });
+});

--- a/server/src/services/recovery/liveness-continuation-throttle.test.ts
+++ b/server/src/services/recovery/liveness-continuation-throttle.test.ts
@@ -7,7 +7,7 @@ import {
   isUpstreamThrottleExitRun,
   resolveLivenessContinuationThrottleConfig,
   summarizeUpstreamThrottleStreak,
-} from "./liveness-continuation-throttle.ts";
+} from "./liveness-continuation-throttle.js";
 
 const NOW = new Date("2026-07-01T12:00:00.000Z");
 const HOUR_MS = 60 * 60 * 1000;
@@ -202,6 +202,15 @@ describe("summarizeUpstreamThrottleStreak", () => {
     const runs = [throttleRun(30), productiveRun(10), throttleRun(5), throttleRun(0)];
     const streak = summarizeUpstreamThrottleStreak({ runs, now: NOW, windowMs: HOUR_MS });
     expect(streak.streak).toBe(2);
+  });
+
+  it("lets cancelled runs neither extend nor break a streak", () => {
+    // A cancellation is not a throttle exit, but it is also not evidence the
+    // upstream recovered — the streak walks straight past it.
+    const runs = [throttleRun(0), throttleRun(5, { status: "cancelled" }), throttleRun(10)];
+    const streak = summarizeUpstreamThrottleStreak({ runs, now: NOW, windowMs: HOUR_MS });
+    expect(streak.streak).toBe(2);
+    expect(streak.firstThrottleAt?.getTime()).toBe(NOW.getTime() - 10 * 60_000);
   });
 
   it("handles empty input and missing timestamps", () => {

--- a/server/src/services/recovery/liveness-continuation-throttle.ts
+++ b/server/src/services/recovery/liveness-continuation-throttle.ts
@@ -1,0 +1,251 @@
+// Layer C of the adapter retry-storm hardening: bounded backoff for liveness
+// continuations plus a per-issue rolling-window ceiling for upstream-throttle
+// exits. Per-source-run attempt counters reset whenever a fresh wake starts a
+// new source run, so per-run caps alone cannot bound the loop — the ceiling
+// here spans source runs for the same issue.
+//
+// This module is intentionally dependency-free (structural input types only)
+// so it can be unit-tested without the db or server wiring. All behavior is
+// gated by PAPERCLIP_LIVENESS_CONTINUATION_THROTTLE_MODE: "off" | "shadow"
+// (default; log-only, zero behavior change) | "enforce".
+
+export type LivenessContinuationThrottleMode = "off" | "shadow" | "enforce";
+
+export interface LivenessContinuationThrottleConfig {
+  mode: LivenessContinuationThrottleMode;
+  backoffBaseMs: number;
+  backoffMaxMs: number;
+  backoffJitterRatio: number;
+  ceilingConsecutiveRuns: number;
+  ceilingWindowMs: number;
+}
+
+export const LIVENESS_CONTINUATION_RETRY_REASON = "run_liveness_continuation";
+export const UPSTREAM_THROTTLE_CEILING_PAUSE_REASON = "upstream_throttle_ceiling";
+export const UPSTREAM_THROTTLE_LIVENESS_STATE = "upstream_throttled";
+
+const UPSTREAM_THROTTLE_ERROR_FAMILIES = new Set(["transient_upstream", "upstream_throttled"]);
+const UPSTREAM_THROTTLE_ERROR_CODES = new Set([
+  "codex_transient_upstream",
+  "claude_transient_upstream",
+]);
+
+export const DEFAULT_LIVENESS_CONTINUATION_THROTTLE_CONFIG: LivenessContinuationThrottleConfig = {
+  mode: "shadow",
+  backoffBaseMs: 60 * 1000,
+  backoffMaxMs: 10 * 60 * 1000,
+  backoffJitterRatio: 0.25,
+  ceilingConsecutiveRuns: 5,
+  ceilingWindowMs: 60 * 60 * 1000,
+};
+
+function readPositiveInteger(value: string | undefined, fallback: number) {
+  const parsed = Number.parseInt(String(value ?? ""), 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+export function resolveLivenessContinuationThrottleConfig(
+  env: Record<string, string | undefined> = {},
+): LivenessContinuationThrottleConfig {
+  const defaults = DEFAULT_LIVENESS_CONTINUATION_THROTTLE_CONFIG;
+  const rawMode = (env.PAPERCLIP_LIVENESS_CONTINUATION_THROTTLE_MODE ?? "").trim().toLowerCase();
+  const mode: LivenessContinuationThrottleMode =
+    rawMode === "off" || rawMode === "shadow" || rawMode === "enforce" ? rawMode : defaults.mode;
+  const backoffBaseMs = readPositiveInteger(
+    env.PAPERCLIP_LIVENESS_CONTINUATION_BACKOFF_BASE_MS,
+    defaults.backoffBaseMs,
+  );
+  const backoffMaxMs = Math.max(
+    backoffBaseMs,
+    readPositiveInteger(env.PAPERCLIP_LIVENESS_CONTINUATION_BACKOFF_MAX_MS, defaults.backoffMaxMs),
+  );
+  return {
+    mode,
+    backoffBaseMs,
+    backoffMaxMs,
+    backoffJitterRatio: defaults.backoffJitterRatio,
+    ceilingConsecutiveRuns: readPositiveInteger(
+      env.PAPERCLIP_UPSTREAM_THROTTLE_CEILING_RUNS,
+      defaults.ceilingConsecutiveRuns,
+    ),
+    ceilingWindowMs: readPositiveInteger(
+      env.PAPERCLIP_UPSTREAM_THROTTLE_WINDOW_MS,
+      defaults.ceilingWindowMs,
+    ),
+  };
+}
+
+export interface LivenessContinuationBackoffSchedule {
+  attempt: number;
+  baseDelayMs: number;
+  delayMs: number;
+  dueAt: Date;
+}
+
+export function computeLivenessContinuationBackoff(input: {
+  attempt: number;
+  config: LivenessContinuationThrottleConfig;
+  now?: Date;
+  random?: () => number;
+}): LivenessContinuationBackoffSchedule | null {
+  const { config } = input;
+  if (!Number.isInteger(input.attempt) || input.attempt <= 0) return null;
+  const now = input.now ?? new Date();
+  const random = input.random ?? Math.random;
+  const exponent = Math.min(input.attempt - 1, 16);
+  const baseDelayMs = Math.min(config.backoffBaseMs * 2 ** exponent, config.backoffMaxMs);
+  const sample = Math.min(1, Math.max(0, random()));
+  const jitterMultiplier = 1 + (((sample * 2) - 1) * config.backoffJitterRatio);
+  const delayMs = Math.min(
+    config.backoffMaxMs,
+    Math.max(1_000, Math.round(baseDelayMs * jitterMultiplier)),
+  );
+  return {
+    attempt: input.attempt,
+    baseDelayMs,
+    delayMs,
+    dueAt: new Date(now.getTime() + delayMs),
+  };
+}
+
+export interface ThrottleExitRunLike {
+  status?: string | null;
+  errorCode?: string | null;
+  livenessState?: string | null;
+  resultJson?: unknown;
+  finishedAt?: Date | string | null;
+  createdAt?: Date | string | null;
+}
+
+function parseResultObject(value: unknown): Record<string, unknown> {
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+  if (typeof value === "string") {
+    try {
+      const parsed: unknown = JSON.parse(value);
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        return parsed as Record<string, unknown>;
+      }
+    } catch {
+      return {};
+    }
+  }
+  return {};
+}
+
+function readRunTimestamp(run: ThrottleExitRunLike): Date | null {
+  for (const value of [run.finishedAt, run.createdAt]) {
+    if (!value) continue;
+    const parsed = value instanceof Date ? value : new Date(value);
+    if (!Number.isNaN(parsed.getTime())) return parsed;
+  }
+  return null;
+}
+
+// A run counts as an upstream-throttle exit when any signal in the adapter
+// recovery contract marks it: the persisted errorFamily, the adapter error
+// code (Layer A), or the upstream_throttled liveness state (Layer B). The
+// liveness-state check is a string comparison on purpose so this module does
+// not depend on the state having landed in the shared RunLivenessState union.
+export function isUpstreamThrottleExitRun(run: ThrottleExitRunLike): boolean {
+  if (run.errorCode && UPSTREAM_THROTTLE_ERROR_CODES.has(run.errorCode)) return true;
+  if (run.livenessState === UPSTREAM_THROTTLE_LIVENESS_STATE) return true;
+  const resultJson = parseResultObject(run.resultJson);
+  const errorFamily = typeof resultJson.errorFamily === "string" ? resultJson.errorFamily : null;
+  return errorFamily != null && UPSTREAM_THROTTLE_ERROR_FAMILIES.has(errorFamily);
+}
+
+export interface UpstreamThrottleStreak {
+  streak: number;
+  windowStart: Date;
+  firstThrottleAt: Date | null;
+  lastThrottleAt: Date | null;
+}
+
+// Counts consecutive throttle exits walking back from the most recent
+// terminal run, stopping at the first non-throttle run or the first run
+// outside the rolling window. Consecutive-within-window is what closes the
+// new-source-run reset hole: the streak survives fresh wakes but any
+// productive (non-throttle) run resets it.
+export function summarizeUpstreamThrottleStreak(input: {
+  runs: ThrottleExitRunLike[];
+  now?: Date;
+  windowMs: number;
+}): UpstreamThrottleStreak {
+  const now = input.now ?? new Date();
+  const windowStart = new Date(now.getTime() - Math.max(0, input.windowMs));
+  const ordered = input.runs
+    .map((run) => ({ run, at: readRunTimestamp(run) }))
+    .filter((entry): entry is { run: ThrottleExitRunLike; at: Date } => entry.at != null)
+    .sort((a, b) => b.at.getTime() - a.at.getTime());
+
+  let streak = 0;
+  let firstThrottleAt: Date | null = null;
+  let lastThrottleAt: Date | null = null;
+  for (const entry of ordered) {
+    if (entry.at.getTime() < windowStart.getTime()) break;
+    if (!isUpstreamThrottleExitRun(entry.run)) break;
+    streak += 1;
+    lastThrottleAt = lastThrottleAt ?? entry.at;
+    firstThrottleAt = entry.at;
+  }
+  return { streak, windowStart, firstThrottleAt, lastThrottleAt };
+}
+
+export type UpstreamThrottleCeilingDecision =
+  | { action: "none"; reason: string }
+  | {
+      action: "ceiling_reached";
+      mode: LivenessContinuationThrottleMode;
+      pauseAgent: boolean;
+      streak: number;
+      ceilingConsecutiveRuns: number;
+      ceilingWindowMs: number;
+      noticeMarker: string;
+      noticeBody: string;
+    };
+
+export function buildUpstreamThrottleCeilingNoticeMarker(issueId: string) {
+  return `upstream-throttle-ceiling:${issueId}`;
+}
+
+export function decideUpstreamThrottleCeiling(input: {
+  streak: UpstreamThrottleStreak;
+  config: LivenessContinuationThrottleConfig;
+  issue: { id: string; identifier?: string | null; title?: string | null };
+  agentId: string;
+}): UpstreamThrottleCeilingDecision {
+  const { streak, config, issue } = input;
+  if (config.mode === "off") {
+    return { action: "none", reason: "throttle ceiling disabled" };
+  }
+  if (streak.streak < config.ceilingConsecutiveRuns) {
+    return {
+      action: "none",
+      reason: `streak ${streak.streak} below ceiling ${config.ceilingConsecutiveRuns}`,
+    };
+  }
+  const windowMinutes = Math.round(config.ceilingWindowMs / 60_000);
+  const label = issue.identifier ?? issue.id;
+  return {
+    action: "ceiling_reached",
+    mode: config.mode,
+    pauseAgent: config.mode === "enforce",
+    streak: streak.streak,
+    ceilingConsecutiveRuns: config.ceilingConsecutiveRuns,
+    ceilingWindowMs: config.ceilingWindowMs,
+    noticeMarker: buildUpstreamThrottleCeilingNoticeMarker(issue.id),
+    noticeBody: [
+      `Upstream throttle ceiling reached for ${label}`,
+      "",
+      `- Consecutive upstream-throttle exits: ${streak.streak} (ceiling ${config.ceilingConsecutiveRuns} within ${windowMinutes}m)`,
+      `- First throttle exit in streak: ${streak.firstThrottleAt?.toISOString() ?? "unknown"}`,
+      `- Latest throttle exit: ${streak.lastThrottleAt?.toISOString() ?? "unknown"}`,
+      "- The real blocker is upstream provider capacity (rate limit / quota), not the task. Automatic retries for this issue are suspended; the assignee agent has been paused to stop the retry burst.",
+      "- Next action: a human or manager should confirm the provider quota/rate-limit has recovered (or raise it), then unpause the agent to resume work.",
+      "",
+      `<!-- ${buildUpstreamThrottleCeilingNoticeMarker(issue.id)} -->`,
+    ].join("\n"),
+  };
+}

--- a/server/src/services/recovery/liveness-continuation-throttle.ts
+++ b/server/src/services/recovery/liveness-continuation-throttle.ts
@@ -163,6 +163,13 @@ export interface UpstreamThrottleStreak {
   lastThrottleAt: Date | null;
 }
 
+// Statuses that count as evidence for streak purposes. Cancelled runs are
+// deliberately absent on both sides of the streak: a cancellation is neither
+// a throttle exit nor evidence the upstream recovered, so it neither extends
+// nor breaks a streak (callers' SQL also filters them out; this guard keeps
+// the pure function honest about whatever it is handed).
+const STREAK_TERMINAL_RUN_STATUSES = new Set(["succeeded", "failed", "timed_out"]);
+
 // Counts consecutive throttle exits walking back from the most recent
 // terminal run, stopping at the first non-throttle run or the first run
 // outside the rolling window. Consecutive-within-window is what closes the
@@ -176,6 +183,7 @@ export function summarizeUpstreamThrottleStreak(input: {
   const now = input.now ?? new Date();
   const windowStart = new Date(now.getTime() - Math.max(0, input.windowMs));
   const ordered = input.runs
+    .filter((run) => run.status == null || STREAK_TERMINAL_RUN_STATUSES.has(run.status))
     .map((run) => ({ run, at: readRunTimestamp(run) }))
     .filter((entry): entry is { run: ThrottleExitRunLike; at: Date } => entry.at != null)
     .sort((a, b) => b.at.getTime() - a.at.getTime());

--- a/server/src/services/recovery/run-liveness-continuations.ts
+++ b/server/src/services/recovery/run-liveness-continuations.ts
@@ -8,7 +8,19 @@ import { RECOVERY_REASON_KINDS } from "./origins.js";
 export const RUN_LIVENESS_CONTINUATION_REASON = RECOVERY_REASON_KINDS.runLivenessContinuation;
 export const DEFAULT_MAX_LIVENESS_CONTINUATION_ATTEMPTS = 2;
 
-const ACTIONABLE_LIVENESS_STATES = new Set<RunLivenessState>(["plan_only", "empty_response"]);
+const ACTIONABLE_LIVENESS_STATES = new Set<string>(["plan_only", "empty_response"]);
+
+// Upstream-throttle exits (errorFamily transient_upstream, or the
+// upstream_throttled liveness state) must never qualify for an immediate
+// continuation: the bounded transient retry ladder owns those, and the
+// per-issue rolling-window ceiling in liveness-continuation-throttle.ts caps
+// them across source runs. Accepts a plain string so callers can probe states
+// that have not landed in the RunLivenessState union yet.
+export function isActionableLivenessStateForContinuation(
+  state: string | null | undefined,
+): state is string {
+  return state != null && ACTIONABLE_LIVENESS_STATES.has(state);
+}
 const CONTINUATION_ACTIVE_ISSUE_STATUSES = new Set(["todo", "in_progress"]);
 // A prior adapter error should not permanently suppress bounded liveness
 // continuations; the max-attempt/idempotency guards prevent unbounded retries.
@@ -22,6 +34,11 @@ type IssueRow = Pick<
 >;
 type AgentRow = Pick<typeof agents.$inferSelect, "id" | "companyId" | "status">;
 
+export interface RunContinuationBackoff {
+  delayMs: number;
+  dueAt: Date;
+}
+
 export type RunContinuationDecision =
   | {
       kind: "enqueue";
@@ -29,6 +46,7 @@ export type RunContinuationDecision =
       idempotencyKey: string;
       payload: Record<string, unknown>;
       contextSnapshot: Record<string, unknown>;
+      backoff: RunContinuationBackoff | null;
     }
   | {
       kind: "exhausted";
@@ -92,6 +110,9 @@ export function decideRunLivenessContinuation(input: {
   budgetBlocked: boolean;
   idempotentWakeExists: boolean;
   maxAttempts?: number;
+  // Deferral schedule computed by the caller (liveness-continuation-throttle);
+  // null/omitted keeps the historical immediate-continuation behavior.
+  backoff?: RunContinuationBackoff | null;
 }): RunContinuationDecision {
   const {
     run,
@@ -105,7 +126,7 @@ export function decideRunLivenessContinuation(input: {
   } = input;
   const maxAttempts = input.maxAttempts ?? DEFAULT_MAX_LIVENESS_CONTINUATION_ATTEMPTS;
 
-  if (!livenessState || !ACTIONABLE_LIVENESS_STATES.has(livenessState)) {
+  if (!isActionableLivenessStateForContinuation(livenessState)) {
     return { kind: "skip", reason: "liveness state is not actionable for continuation" };
   }
   if (!issue) return { kind: "skip", reason: "issue not found" };
@@ -172,6 +193,7 @@ export function decideRunLivenessContinuation(input: {
     kind: "enqueue",
     nextAttempt,
     idempotencyKey,
+    backoff: input.backoff ?? null,
     payload,
     contextSnapshot: withRecoveryModelProfileHint({
       issueId: issue.id,

--- a/server/src/services/run-continuations.ts
+++ b/server/src/services/run-continuations.ts
@@ -4,8 +4,10 @@ export {
   buildRunLivenessContinuationIdempotencyKey,
   decideRunLivenessContinuation,
   findExistingRunLivenessContinuationWake,
+  isActionableLivenessStateForContinuation,
   readContinuationAttempt,
 } from "./recovery/run-liveness-continuations.js";
 export type {
+  RunContinuationBackoff,
   RunContinuationDecision,
 } from "./recovery/run-liveness-continuations.js";


### PR DESCRIPTION
## Problem

Two unbounded-retry gaps in the continuation/scheduler layer (Layer C of the adapter retry-storm hardening):

1. `plan_only` / `empty_response` liveness continuations are enqueued **immediately** with no backoff.
2. The only cap on upstream-throttle exits is per-source-run (`DEFAULT_MAX_LIVENESS_CONTINUATION_ATTEMPTS = 2`, transient retry ladder max 4). Every fresh wake starts a **new** source run at attempt 0, so the caps reset and a rate-limited provider produces an indefinite retry burst — one real incident produced 9 duplicate alarms plus quota burn while the actual blocker (provider quota) was never named.

## Change (shadow-mode first, zero behavior change by default)

New dependency-free module `server/src/services/recovery/liveness-continuation-throttle.ts`, gated by `PAPERCLIP_LIVENESS_CONTINUATION_THROTTLE_MODE` = `off` | `shadow` (default) | `enforce`:

- **Backoff**: exponential (base 60s × 2^(attempt−1), ±25% jitter, cap 10m; env-tunable) computed for every liveness continuation. Shadow logs a would-defer run event and keeps today's immediate enqueue; enforce defers through the existing `scheduled_retry` primitive (`scheduleBoundedRetryForRun` gains optional `contextSnapshotExtra` + `idempotencyKey`, so the continuation instruction and the existing idempotency key carry over).
- **Per-issue rolling-window ceiling**: counts **consecutive** upstream-throttle exits (adapter error codes `codex/claude_transient_upstream`, persisted `errorFamily: transient_upstream` — including clean-exit *succeeded* runs — and the forward-compatible `upstream_throttled` liveness state) across source runs for the same issue within a rolling window (default 5 exits / 60m). At the ceiling, shadow logs would-pause; enforce pauses the agent (`pauseReason: upstream_throttle_ceiling`) and files **one** consolidated issue notice naming the real blocker (provider rate limit / quota) instead of N escalations. Any productive run resets the streak.
- **Pinned invariant**: `upstream_throttled` is never actionable for immediate continuation (`isActionableLivenessStateForContinuation` + unit test), so the Layer B classifier state can't feed the immediate-continuation path.

Invariant delivered: every retry path is bounded by backoff + a per-issue ceiling; transient 429s still retry — backed off and capped, not abandoned.

## Testing

- `liveness-continuation-throttle.test.ts` (new) + `run-continuations.test.ts` (extended): config resolution, exponential/jitter/cap bounds, throttle-exit classification truth table, streak reset-hole replay (9 exits across 9 source runs), window expiry, ceiling decisions in all three modes, backoff pass-through and back-compat default.
- All 22 behavioral cases also verified locally via Node type-stripped harness (22/22 pass).
- `tsc --strict --noEmit` clean on the new module, the decision layer, `heartbeat.ts` against its full import graph, and both test files (only pre-existing unrelated `ws`/`plugin-sdk` declaration noise elsewhere).

## Rollout

Land dark (shadow default) → observe would-defer / would-pause run events for false positives → promote to `enforce` via env. Related: #6979 / #6954 / #6957 address the adjacent process-lost retry paths; this PR covers the liveness-continuation and cross-source-run throttle-exit paths and composes with them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
