### PR TITLE
Non-retryable billing-limit classification + reset session on routine re-check wakes

### DIFF
--- a/server/src/__tests__/heartbeat-timer-wake-session-reset-pf4.test.ts
+++ b/server/src/__tests__/heartbeat-timer-wake-session-reset-pf4.test.ts
@@ -47,6 +47,18 @@ describe("PF-4 shouldResetTaskSessionForWake", () => {
     expect(shouldResetTaskSessionForWake({ wakeReason: "transient_failure_retry" })).toBe(false);
   });
 
+  it("resets for issue_monitor_due (routine re-check starts fresh — ALAA-1613 R3)", () => {
+    expect(shouldResetTaskSessionForWake({ wakeReason: "issue_monitor_due" })).toBe(true);
+  });
+
+  it("resets for issue_assignment_recovery (recovery re-check starts fresh — ALAA-1613 R3)", () => {
+    expect(shouldResetTaskSessionForWake({ wakeReason: "issue_assignment_recovery" })).toBe(true);
+  });
+
+  it("resets for issue_continuation_needed (continuation re-check starts fresh — ALAA-1613 R3)", () => {
+    expect(shouldResetTaskSessionForWake({ wakeReason: "issue_continuation_needed" })).toBe(true);
+  });
+
   it("does not reset for unknown wake reasons", () => {
     expect(shouldResetTaskSessionForWake({ wakeReason: "unknown_reason" })).toBe(false);
   });
@@ -94,6 +106,18 @@ describe("PF-4 describeSessionResetReason", () => {
     expect(describeSessionResetReason(undefined)).toBeNull();
   });
 
+  it("returns explicit reasons for ALAA-1613 R3 routine re-check wake reasons", () => {
+    expect(describeSessionResetReason({ wakeReason: "issue_monitor_due" })).toBe(
+      "wake reason is issue_monitor_due (routine re-check starts fresh)",
+    );
+    expect(describeSessionResetReason({ wakeReason: "issue_assignment_recovery" })).toBe(
+      "wake reason is issue_assignment_recovery (recovery re-check starts fresh)",
+    );
+    expect(describeSessionResetReason({ wakeReason: "issue_continuation_needed" })).toBe(
+      "wake reason is issue_continuation_needed (continuation re-check starts fresh)",
+    );
+  });
+
   it("agrees with shouldResetTaskSessionForWake on every input — non-null reason iff should reset", () => {
     const cases: Array<Record<string, unknown> | null | undefined> = [
       { wakeReason: "heartbeat_timer" },
@@ -104,6 +128,9 @@ describe("PF-4 describeSessionResetReason", () => {
       { forceFreshSession: true },
       { wakeReason: "issue_commented" },
       { wakeReason: "transient_failure_retry" },
+      { wakeReason: "issue_monitor_due" },
+      { wakeReason: "issue_assignment_recovery" },
+      { wakeReason: "issue_continuation_needed" },
       { wakeReason: "unknown_reason" },
       null,
       undefined,

--- a/server/src/services/heartbeat-stop-metadata.test.ts
+++ b/server/src/services/heartbeat-stop-metadata.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
+  BILLING_LIMIT_ERROR_CODE,
   buildHeartbeatRunStopMetadata,
+  isBillingLimitErrorMessage,
   mergeHeartbeatRunStopMetadata,
   resolveHeartbeatRunTimeoutPolicy,
 } from "./heartbeat-stop-metadata.js";
@@ -115,6 +117,58 @@ describe("heartbeat stop metadata", () => {
       timeoutConfigured: true,
       timeoutSource: "default",
       timeoutFired: false,
+    });
+  });
+
+  describe("billing/spending-limit error detection", () => {
+    it("detects workspace monthly spending limit exhausted message", () => {
+      expect(isBillingLimitErrorMessage("workspace monthly spending limit exhausted")).toBe(true);
+      expect(isBillingLimitErrorMessage("Workspace monthly spending limit of $160 exhausted")).toBe(true);
+      expect(isBillingLimitErrorMessage("adapter_failed: workspace monthly spending limit exhausted")).toBe(true);
+    });
+
+    it("detects billing limit and credit exhaustion variants", () => {
+      expect(isBillingLimitErrorMessage("billing limit exhausted")).toBe(true);
+      expect(isBillingLimitErrorMessage("credit balance insufficient")).toBe(true);
+      expect(isBillingLimitErrorMessage("quota exhausted for this period")).toBe(true);
+      expect(isBillingLimitErrorMessage("billing threshold exceeded")).toBe(true);
+    });
+
+    it("does not false-positive on non-billing errors", () => {
+      expect(isBillingLimitErrorMessage("Adapter failed: connection refused")).toBe(false);
+      expect(isBillingLimitErrorMessage("Timed out after 45s")).toBe(false);
+      expect(isBillingLimitErrorMessage("session not found")).toBe(false);
+      expect(isBillingLimitErrorMessage(null)).toBe(false);
+      expect(isBillingLimitErrorMessage(undefined)).toBe(false);
+      expect(isBillingLimitErrorMessage("")).toBe(false);
+    });
+
+    it("classifies billing-limit failures as billing_limit_exhausted stop reason", () => {
+      expect(
+        buildHeartbeatRunStopMetadata({
+          adapterType: "opencode_local",
+          adapterConfig: {},
+          outcome: "failed",
+          errorCode: null,
+          errorMessage: "workspace monthly spending limit exhausted",
+        }).stopReason,
+      ).toBe("billing_limit_exhausted");
+    });
+
+    it("does not classify non-billing adapter failures as billing_limit_exhausted", () => {
+      expect(
+        buildHeartbeatRunStopMetadata({
+          adapterType: "opencode_local",
+          adapterConfig: {},
+          outcome: "failed",
+          errorCode: null,
+          errorMessage: "connection refused",
+        }).stopReason,
+      ).toBe("adapter_failed");
+    });
+
+    it("exports the canonical billing limit error code constant", () => {
+      expect(BILLING_LIMIT_ERROR_CODE).toBe("billing_limit_exhausted");
     });
   });
 });

--- a/server/src/services/heartbeat-stop-metadata.ts
+++ b/server/src/services/heartbeat-stop-metadata.ts
@@ -8,7 +8,18 @@ export type HeartbeatRunStopReason =
   | "paused"
   | "max_turns_exhausted"
   | "process_lost"
+  | "billing_limit_exhausted"
   | "adapter_failed";
+
+export const BILLING_LIMIT_ERROR_CODE = "billing_limit_exhausted" as const;
+
+const BILLING_LIMIT_ERROR_RE =
+  /spending\s*limit|monthly\s*spending\s*limit|billing[.\s_-]*(?:limit|balance|threshold).*(?:exhaust|exceed|reached|insufficient)|workspace.*(spending|billing).*limit|credit.*(exhaust|insufficient)|quota.*exhaust/i;
+
+export function isBillingLimitErrorMessage(message: string | null | undefined): boolean {
+  if (!message) return false;
+  return BILLING_LIMIT_ERROR_RE.test(message);
+}
 
 export interface HeartbeatRunTimeoutPolicy {
   effectiveTimeoutSec: number | null;
@@ -92,6 +103,9 @@ export function inferHeartbeatRunStopReason(input: {
     if (message.includes("budget")) return "budget_paused";
     if (message.includes("pause") || message.includes("paused")) return "paused";
     return "cancelled";
+  }
+  if (input.outcome === "failed" && isBillingLimitErrorMessage(input.errorMessage)) {
+    return "billing_limit_exhausted";
   }
   return "adapter_failed";
 }

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -85,6 +85,8 @@ import {
 } from "./heartbeat-run-summary.js";
 import {
   buildHeartbeatRunStopMetadata,
+  isBillingLimitErrorMessage,
+  BILLING_LIMIT_ERROR_CODE,
   mergeHeartbeatRunStopMetadata,
   normalizeMaxTurnStopReason,
 } from "./heartbeat-stop-metadata.js";
@@ -2405,7 +2407,16 @@ export function shouldResetTaskSessionForWake(
     // session toward the 64k compaction threshold (observed in CEO run
     // 292a5fd1, where timer wakes repeatedly bloated a long-lived manager
     // session). Reset on every timer wake so each interval starts fresh.
-    wakeReason === "heartbeat_timer"
+    wakeReason === "heartbeat_timer" ||
+    // ALAA-1613 R3: routine re-checks (monitor wakes, stranded-issue recovery)
+    // do not carry meaningful continuation state — the agent re-reads the issue
+    // thread from the API on each run. Reusing the prior task session for these
+    // paths accumulates 2-5.5M cached-input tokens re-sent per run at
+    // $0.7-1.76/run. Starting fresh caps the context at ~100-300K tokens
+    // (system prompt + wake payload + fetched issue thread).
+    wakeReason === "issue_monitor_due" ||
+    wakeReason === "issue_assignment_recovery" ||
+    wakeReason === "issue_continuation_needed"
   ) {
     return true;
   }
@@ -2514,6 +2525,10 @@ export function describeSessionResetReason(
   // PF-4: paired with shouldResetTaskSessionForWake — keep the reason wording
   // explicit so run logs make session reuse/reset behavior legible.
   if (wakeReason === "heartbeat_timer") return "wake reason is heartbeat_timer (timer-driven wake starts fresh)";
+  // ALAA-1613 R3: routine re-checks start fresh to cap cached-input token cost.
+  if (wakeReason === "issue_monitor_due") return "wake reason is issue_monitor_due (routine re-check starts fresh)";
+  if (wakeReason === "issue_assignment_recovery") return "wake reason is issue_assignment_recovery (recovery re-check starts fresh)";
+  if (wakeReason === "issue_continuation_needed") return "wake reason is issue_continuation_needed (continuation re-check starts fresh)";
   return null;
 }
 
@@ -10972,9 +10987,12 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           ? "timeout"
           : outcome === "cancelled"
             ? (latestRun?.errorCode ?? "cancelled")
-            : outcome === "failed"
-              ? (adapterResult.errorCode ?? "adapter_failed")
-              : null;
+          : outcome === "failed"
+            ? (adapterResult.errorCode
+              ?? (isBillingLimitErrorMessage(adapterResult.errorMessage)
+                ? BILLING_LIMIT_ERROR_CODE
+                : "adapter_failed"))
+            : null;
 
       let logSummary: { bytes: number; sha256?: string; compressed: boolean } | null = null;
       if (handle) {
@@ -11092,6 +11110,22 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         });
         const livenessRun = finalizedRun;
         await refreshContinuationSummaryForRun(livenessRun, agent);
+        if (issueId && runErrorCode === BILLING_LIMIT_ERROR_CODE) {
+          try {
+            await db.update(issues)
+              .set({ monitorNextCheckAt: null, updatedAt: new Date() })
+              .where(and(eq(issues.id, issueId), eq(issues.companyId, run.companyId)));
+            await appendRunEvent(livenessRun, seq++, {
+              eventType: "lifecycle",
+              stream: "system",
+              level: "warn",
+              message: "Billing/spending-limit error detected; issue monitor cleared to prevent futile re-wake loop",
+              payload: { errorCode: BILLING_LIMIT_ERROR_CODE },
+            });
+          } catch (monitorClearErr) {
+            logger.warn({ err: monitorClearErr, issueId }, "failed to clear issue monitor after billing-limit error");
+          }
+        }
         const skipRunIssueComment = parseObject(livenessRun.contextSnapshot).skipIssueComment === true;
         if (issueId && outcome === "succeeded" && !skipRunIssueComment) {
           try {
@@ -11235,8 +11269,11 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       );
       const workspaceValidationFailure = isWorkspaceValidationFailure(err) ? err : null;
       const configurationIncompleteFailure = isConfigurationIncompleteFailure(err) ? err : null;
-      const failureErrorCode =
-        workspaceValidationFailure?.code ?? configurationIncompleteFailure?.code ?? "adapter_failed";
+      const failureErrorCode = workspaceValidationFailure?.code
+        ?? configurationIncompleteFailure?.code
+        ?? (isBillingLimitErrorMessage(message)
+          ? BILLING_LIMIT_ERROR_CODE
+          : "adapter_failed");
       logger.error({ err, runId }, "heartbeat execution failed");
 
       let logSummary: { bytes: number; sha256?: string; compressed: boolean } | null = null;
@@ -11346,6 +11383,9 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           const setupFailureErrorCode =
             workspaceValidationSetupFailure?.code ?? configurationIncompleteSetupFailure?.code ?? "setup_failed";
           logger.error({ err: outerErr, runId }, "heartbeat execution setup failed");
+          const setupFailureErrorCode = isBillingLimitErrorMessage(message)
+            ? BILLING_LIMIT_ERROR_CODE
+            : "adapter_failed";
           const setupFailureAgent = await getAgent(run.agentId).catch(() => null);
           const setupFailureWrite = await setRunStatusIfRunning(runId, "failed", {
             error: message,

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -11380,12 +11380,15 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           // recovery path routes it to a human owner instead of looping retries.
           const workspaceValidationSetupFailure = isWorkspaceValidationFailure(outerErr) ? outerErr : null;
           const configurationIncompleteSetupFailure = isConfigurationIncompleteFailure(outerErr) ? outerErr : null;
+          // ALAA-1613 R2: classify billing/spending-limit setup failures as their own
+          // non-retryable code (ahead of the generic setup_failed default) so recovery
+          // routes them to a human owner instead of looping retries. Workspace-validation
+          // and configuration-incomplete codes still take precedence when present.
           const setupFailureErrorCode =
-            workspaceValidationSetupFailure?.code ?? configurationIncompleteSetupFailure?.code ?? "setup_failed";
+            workspaceValidationSetupFailure?.code
+            ?? configurationIncompleteSetupFailure?.code
+            ?? (isBillingLimitErrorMessage(message) ? BILLING_LIMIT_ERROR_CODE : "setup_failed");
           logger.error({ err: outerErr, runId }, "heartbeat execution setup failed");
-          const setupFailureErrorCode = isBillingLimitErrorMessage(message)
-            ? BILLING_LIMIT_ERROR_CODE
-            : "adapter_failed";
           const setupFailureAgent = await getAgent(run.agentId).catch(() => null);
           const setupFailureWrite = await setRunStatusIfRunning(runId, "failed", {
             error: message,

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -199,6 +199,7 @@ const TRANSIENT_INFRA_CONTINUATION_ERROR_CODES = new Set<string>([
 const NON_RETRYABLE_CONTINUATION_ERROR_CODES = new Set<string>([
   "agent_not_invokable",
   "agent_not_found",
+  "billing_limit_exhausted",
   "budget_blocked",
   "budget_exhausted",
   "issue_paused",


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The heartbeat/recovery subsystem decides, on each wake, whether a failed run should be retried and whether the agent's prior task session (and its cached-input context) should be resumed or reset.
> - Two gaps exist there. (1) When an adapter fails because the workspace/billing spend limit is exhausted, that error is classified as a generic `adapter_failed` — so it is auto-retried and keeps heartbeating, producing a futile recovery loop that cannot succeed until a human raises the limit. (2) Routine re-check wakes (monitor-due, assignment recovery, continuation re-check) resume the full prior task session even though the agent re-reads the issue thread from the API on every run — accumulating multi-million cached-input tokens re-sent per run.
> - Both waste money and, in the billing case, spin uselessly. They should be addressed at the classification and session-reset layers.
> - This pull request adds a billing/spend-limit error classifier (`billing_limit_exhausted`), marks it non-retryable, clears the issue monitor on that error to stop re-wake loops, and extends `shouldResetTaskSessionForWake` so routine re-check wakes start a fresh session — while active-synthesis / continuation wakes keep full context unchanged.
> - The benefit is no more futile retry loops on spend-limit exhaustion, and a large cached-input token/cost reduction on routine re-check wakes with no loss of continuation correctness.

## Linked Issues or Issue Description

No public GitHub issue. Problem (bug), described in-PR:

- **Billing-limit runs are misclassified and looped.** An adapter failure whose message indicates a workspace/monthly spending-limit or billing/quota exhaustion is currently coded `adapter_failed`. The recovery service treats that as retryable, so the run auto-retries and continues heartbeating even though nothing can succeed until a human raises the limit.
- **Routine re-check wakes resume full context needlessly.** Monitor-due / assignment-recovery / continuation re-check wakes re-read the issue thread from the API on each run, so the prior task session carries no needed continuation state — yet it is resumed, re-sending multi-million cached-input tokens per run. Only timer wakes were previously reset (PF-4, #4838); this extends the same treatment to the routine re-check reasons.

### Related PRs (dedup search)

Searched the GitHub PR list for overlapping heartbeat session-reset / recovery work. Related but distinct — none covers billing-limit non-retryable classification plus resets for `issue_monitor_due` / `issue_assignment_recovery` / `issue_continuation_needed`:
- #6650 — force fresh sessions for comment wakes (different wake reason)
- #5287 / #5295 — reset timer heartbeat sessions (timer wake only; this builds on the same PF-4 mechanism, #4838)
- #8407 — reduce scoped recovery token replay (adjacent finops theme, different mechanism)

- [x] I have searched GitHub for duplicate or related PRs and linked them above

## What Changed

- Add `isBillingLimitErrorMessage()` + `billing_limit_exhausted` stop reason/error code in `heartbeat-stop-metadata.ts`; classify failed runs whose message matches spend-limit/billing/quota exhaustion as `billing_limit_exhausted` in `inferHeartbeatRunStopReason` and in `heartbeat.ts` run-finalization/setup-failure paths.
- Add `billing_limit_exhausted` to `NON_RETRYABLE_CONTINUATION_ERROR_CODES` in `recovery/service.ts` so these runs are not auto-retried.
- On a `billing_limit_exhausted` run, clear the issue's `monitorNextCheckAt` (self-healing; a later successful run re-arms it) and append a `lifecycle`/`warn` run event, to stop futile re-wake loops.
- Extend `shouldResetTaskSessionForWake` to reset the task session for `issue_monitor_due`, `issue_assignment_recovery`, and `issue_continuation_needed` wakes (join the existing `heartbeat_timer` case); update `describeSessionResetReason` to match. Active-synthesis/interactive-continuation wakes are unchanged and still resume full context.
- The billing-limit classification in the outer setup-failure catch is folded into the single existing `setupFailureErrorCode` declaration (behind `workspaceValidationSetupFailure?.code ?? configurationIncompleteSetupFailure?.code`, ahead of the `setup_failed` default) — no duplicate declaration, no loss of the existing error-code precedence.

## Verification

- `vitest run` on the changed server suites:
  - `server/src/__tests__/heartbeat-timer-wake-session-reset-pf4.test.ts` — 16/16 (routine re-check reasons reset; synthesis/continuation still resume).
  - `server/src/services/heartbeat-stop-metadata.test.ts` — 12/12 (billing classifier + stop-reason inference).
  - `server/src/__tests__/heartbeat-workspace-session.test.ts` — 68/68 (no session-reuse-correctness regression).
- `tsc -p server --noEmit` clean (0 errors, workspace packages built).
- Full cross-workspace matrix runs in this PR's CI (ubuntu).

## Risks

- Low risk. No schema/data migration. The only DB write is clearing `monitorNextCheckAt` on a billing-limit error, which is benign and self-healing. Behavioral change is scoped to (a) the classification of spend-limit failures and (b) which wake reasons start a fresh session; continuation/synthesis correctness is unchanged and covered by the workspace-session suite. Rollback = revert this change (restores prior classification and full-context resume); nothing to migrate back.

## Model Used

Claude Opus 4.8 (`claude-opus-4-8`), extended thinking + tool use (agentic coding).
