### PR TITLE
fix(server): sanitize credential-shaped values before persistence

### DIFF
--- a/server/src/__tests__/persistence-sanitizer.test.ts
+++ b/server/src/__tests__/persistence-sanitizer.test.ts
@@ -1,0 +1,180 @@
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { sanitizeForPersistence, sanitizeTextForPersistence } from "../persistence-sanitizer.js";
+import { REDACTED_EVENT_VALUE } from "../redaction.js";
+
+// Fake canary values only — shaped like credentials, never real ones.
+const CANARY = "canary-fake-value-000";
+const CANARY_OPENAI_SHAPED = "sk-canaryFAKE000000000000";
+const CANARY_GITHUB_SHAPED = "ghp_canaryFAKE00000000000000";
+const CANARY_JWT_SHAPED = "eyJhbGciOi.eyJzdWIiOi.c2lnbmF0dXJl";
+
+describe("sanitizeTextForPersistence", () => {
+  it("redacts env-style secret assignments in free text", () => {
+    const out = sanitizeTextForPersistence(`run with MY_API_TOKEN=${CANARY} please`);
+    expect(out).not.toContain(CANARY);
+    expect(out).toContain(REDACTED_EVENT_VALUE);
+  });
+
+  it("redacts bearer authorization headers in comment-like text", () => {
+    const out = sanitizeTextForPersistence(
+      `The request failed. I used Authorization: Bearer ${CANARY} as the header.`,
+    );
+    expect(out).not.toContain(CANARY);
+    expect(out).toContain(REDACTED_EVENT_VALUE);
+  });
+
+  it("redacts provider-shaped tokens embedded in log chunks", () => {
+    const chunk = `stdout: pushing with ${CANARY_GITHUB_SHAPED} and ${CANARY_OPENAI_SHAPED}\n`;
+    const out = sanitizeTextForPersistence(chunk);
+    expect(out).not.toContain(CANARY_GITHUB_SHAPED);
+    expect(out).not.toContain(CANARY_OPENAI_SHAPED);
+  });
+
+  it("redacts JWT-shaped values", () => {
+    const out = sanitizeTextForPersistence(`session resumed with ${CANARY_JWT_SHAPED}`);
+    expect(out).not.toContain(CANARY_JWT_SHAPED);
+  });
+
+  it("redacts JSON secret fields inside serialized text", () => {
+    const out = sanitizeTextForPersistence(`config was {"apiKey": "${CANARY}"}`);
+    expect(out).not.toContain(CANARY);
+  });
+
+  it("leaves ordinary prose intact", () => {
+    const text = "Deployed version 1.2.3 to production; the keyboard shortcut works now.";
+    expect(sanitizeTextForPersistence(text)).toBe(text);
+  });
+
+  it("is idempotent", () => {
+    const once = sanitizeTextForPersistence(`MY_API_TOKEN=${CANARY}`);
+    expect(sanitizeTextForPersistence(once)).toBe(once);
+  });
+});
+
+describe("sanitizeForPersistence", () => {
+  it("redacts secret-named keys in adapter/env/config-like payloads", () => {
+    const out = sanitizeForPersistence({
+      model: "some-model",
+      apiKey: CANARY,
+      env: { SERVICE_ACCESS_TOKEN: CANARY, LOG_LEVEL: "debug" },
+    });
+    expect(out.apiKey).toBe(REDACTED_EVENT_VALUE);
+    expect((out.env as Record<string, unknown>).SERVICE_ACCESS_TOKEN).toBe(REDACTED_EVENT_VALUE);
+    expect((out.env as Record<string, unknown>).LOG_LEVEL).toBe("debug");
+    expect(out.model).toBe("some-model");
+  });
+
+  it("preserves secret_ref bindings and redacts plain bindings under secret keys", () => {
+    const out = sanitizeForPersistence({
+      env: {
+        API_TOKEN: { type: "secret_ref", secretId: "secret-id-1" },
+        OTHER_TOKEN: { type: "plain", value: CANARY },
+      },
+    });
+    const env = out.env as Record<string, unknown>;
+    expect(env.API_TOKEN).toEqual({ type: "secret_ref", secretId: "secret-id-1" });
+    expect(env.OTHER_TOKEN).toEqual({ type: "plain", value: REDACTED_EVENT_VALUE });
+  });
+
+  it("redacts credential-shaped text nested in objects and arrays", () => {
+    const out = sanitizeForPersistence({
+      steps: [
+        { note: `first step ran EXPORTED_API_TOKEN=${CANARY}` },
+        { note: "second step was fine" },
+      ],
+      summary: [`saw ${CANARY_GITHUB_SHAPED} in output`],
+    });
+    const steps = out.steps as Array<Record<string, string>>;
+    expect(steps[0]!.note).not.toContain(CANARY);
+    expect(steps[1]!.note).toBe("second step was fine");
+    expect((out.summary as string[])[0]).not.toContain(CANARY_GITHUB_SHAPED);
+  });
+
+  it("sanitizes activity/event-like payloads while preserving operational metadata", () => {
+    const out = sanitizeForPersistence({
+      action: "issue.updated",
+      entityId: "issue-1",
+      durationMs: 1200,
+      ok: true,
+      detail: `retried after Authorization: Bearer ${CANARY} was rejected`,
+    });
+    expect(out.action).toBe("issue.updated");
+    expect(out.entityId).toBe("issue-1");
+    expect(out.durationMs).toBe(1200);
+    expect(out.ok).toBe(true);
+    expect(out.detail).not.toContain(CANARY);
+  });
+
+  it("handles top-level strings and arrays", () => {
+    expect(sanitizeForPersistence(`X_API_TOKEN=${CANARY}`)).not.toContain(CANARY);
+    const arr = sanitizeForPersistence([`X_API_TOKEN=${CANARY}`, 7, null]);
+    expect(arr[0]).not.toContain(CANARY);
+    expect(arr[1]).toBe(7);
+    expect(arr[2]).toBeNull();
+  });
+
+  it("returns already-safe values unchanged", () => {
+    const payload = {
+      title: "Weekly report",
+      count: 3,
+      done: false,
+      tags: ["ops", "review"],
+      when: null,
+    };
+    expect(sanitizeForPersistence(payload)).toEqual(payload);
+    expect(sanitizeForPersistence(42)).toBe(42);
+    expect(sanitizeForPersistence(null)).toBeNull();
+    expect(sanitizeForPersistence(undefined)).toBeUndefined();
+  });
+
+  it("passes non-JSON values through untouched", () => {
+    const date = new Date("2026-01-01T00:00:00.000Z");
+    expect(sanitizeForPersistence(date)).toBe(date);
+  });
+});
+
+describe("run log store pre-persistence sanitization", () => {
+  let baseDir: string;
+  let store: import("../services/run-log-store.js").RunLogStore;
+
+  beforeAll(async () => {
+    baseDir = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-run-log-sanitize-"));
+    process.env.RUN_LOG_BASE_PATH = baseDir;
+    const { getRunLogStore } = await import("../services/run-log-store.js");
+    store = getRunLogStore();
+  });
+
+  afterAll(async () => {
+    delete process.env.RUN_LOG_BASE_PATH;
+    await fs.rm(baseDir, { recursive: true, force: true });
+  });
+
+  it("sanitizes credential-shaped chunks before they reach disk", async () => {
+    const handle = await store.begin({ companyId: "co-1", agentId: "agent-1", runId: "run-1" });
+    await store.append(handle, {
+      stream: "stdout",
+      chunk: `exporting MY_API_TOKEN=${CANARY} then ${CANARY_GITHUB_SHAPED}\n`,
+      ts: "2026-01-01T00:00:00.000Z",
+    });
+
+    const raw = await fs.readFile(path.join(baseDir, handle.logRef), "utf8");
+    expect(raw).not.toContain(CANARY);
+    expect(raw).not.toContain(CANARY_GITHUB_SHAPED);
+    expect(raw).toContain(REDACTED_EVENT_VALUE);
+
+    const readBack = await store.read(handle);
+    expect(readBack.content).not.toContain(CANARY);
+  });
+
+  it("keeps safe chunks byte-identical", async () => {
+    const handle = await store.begin({ companyId: "co-1", agentId: "agent-1", runId: "run-2" });
+    const chunk = "compiled 14 files in 3.1s\n";
+    await store.append(handle, { stream: "stdout", chunk, ts: "2026-01-01T00:00:01.000Z" });
+
+    const readBack = await store.read(handle);
+    expect(JSON.parse(readBack.content.trim()).chunk).toBe(chunk);
+  });
+});

--- a/server/src/__tests__/pre-persistence-sanitization.test.ts
+++ b/server/src/__tests__/pre-persistence-sanitization.test.ts
@@ -1,0 +1,123 @@
+import { randomUUID } from "node:crypto";
+import { eq } from "drizzle-orm";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import {
+  activityLog,
+  companies,
+  createDb,
+  issueComments,
+  issues,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import { logActivity } from "../services/activity-log.js";
+import { issueService } from "../services/issues.js";
+import { REDACTED_EVENT_VALUE } from "../redaction.js";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe.sequential : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping embedded Postgres pre-persistence sanitization tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+// Fake canary values only — shaped like credentials, never real ones.
+const CANARY = "canary-fake-value-000";
+const CANARY_GITHUB_SHAPED = "ghp_canaryFAKE00000000000000";
+
+describeEmbeddedPostgres("pre-persistence sanitization", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-pre-persist-sanitize-");
+    db = createDb(tempDb.connectionString);
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.delete(activityLog);
+    await db.delete(issueComments);
+    await db.delete(issues);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  async function seedIssue() {
+    const companyId = randomUUID();
+    const issueId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Sanitize Before Persist Co",
+      issuePrefix: `S${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      identifier: "SAN-1",
+      title: "Pre-persistence sanitization",
+      status: "todo",
+      priority: "medium",
+    });
+    return { companyId, issueId };
+  }
+
+  it("sanitizes credential-shaped comment text before the row is written", async () => {
+    const { issueId } = await seedIssue();
+
+    await issueService(db).addComment(
+      issueId,
+      `Reproduced with MY_API_TOKEN=${CANARY} and pushed using ${CANARY_GITHUB_SHAPED}.`,
+      { userId: "user-1" },
+    );
+
+    const [row] = await db.select().from(issueComments).where(eq(issueComments.issueId, issueId));
+    expect(row).toBeDefined();
+    expect(row!.body).not.toContain(CANARY);
+    expect(row!.body).not.toContain(CANARY_GITHUB_SHAPED);
+    expect(row!.body).toContain(REDACTED_EVENT_VALUE);
+  });
+
+  it("keeps ordinary comment text intact at rest", async () => {
+    const { issueId } = await seedIssue();
+    const body = "Deployed version 1.2.3 to production and verified the dashboard.";
+
+    await issueService(db).addComment(issueId, body, { userId: "user-1" });
+
+    const [row] = await db.select().from(issueComments).where(eq(issueComments.issueId, issueId));
+    expect(row!.body).toBe(body);
+  });
+
+  it("sanitizes nested activity payloads before the row is written", async () => {
+    const { companyId, issueId } = await seedIssue();
+
+    await logActivity(db, {
+      companyId,
+      actorType: "system",
+      actorId: "system",
+      action: "issue.updated",
+      entityType: "issue",
+      entityId: issueId,
+      details: {
+        apiKey: CANARY,
+        env: { SERVICE_ACCESS_TOKEN: { type: "plain", value: CANARY } },
+        notes: [`command ran with EXPORTED_API_TOKEN=${CANARY}`],
+        durationMs: 42,
+      },
+    });
+
+    const [row] = await db.select().from(activityLog).where(eq(activityLog.companyId, companyId));
+    expect(row).toBeDefined();
+    const details = row!.details as Record<string, unknown>;
+    expect(JSON.stringify(details)).not.toContain(CANARY);
+    expect(details.apiKey).toBe(REDACTED_EVENT_VALUE);
+    expect(details.durationMs).toBe(42);
+  });
+});

--- a/server/src/persistence-sanitizer.ts
+++ b/server/src/persistence-sanitizer.ts
@@ -1,4 +1,4 @@
-import { redactSensitiveText, sanitizeRecord } from "./redaction.js";
+import { isPlainObject, redactSensitiveText, sanitizeRecord } from "./redaction.js";
 
 /**
  * Pre-persistence sanitization boundary.
@@ -15,12 +15,6 @@ import { redactSensitiveText, sanitizeRecord } from "./redaction.js";
  * to redact. Sanitization is deterministic and idempotent: already-redacted
  * or non-sensitive values pass through unchanged.
  */
-
-function isPlainObject(value: unknown): value is Record<string, unknown> {
-  if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
-  const proto = Object.getPrototypeOf(value);
-  return proto === Object.prototype || proto === null;
-}
 
 /** Sanitize free text (comment bodies, log chunks, event messages) before it is persisted. */
 export function sanitizeTextForPersistence(input: string): string {

--- a/server/src/persistence-sanitizer.ts
+++ b/server/src/persistence-sanitizer.ts
@@ -1,0 +1,56 @@
+import { redactSensitiveText, sanitizeRecord } from "./redaction.js";
+
+/**
+ * Pre-persistence sanitization boundary.
+ *
+ * The redaction helpers in `redaction.ts` are applied at egress points
+ * (response serialization, live events, request logging). Values that reach a
+ * DB insert/update or an on-disk log append before one of those egress points
+ * runs are persisted verbatim, so credential-shaped values written into
+ * comment bodies, run log chunks, run event messages, or activity payloads
+ * survive at rest and resurface through any read path (including backups).
+ *
+ * These helpers wrap the existing redaction primitives so persistence sites
+ * can sanitize once, before the write, instead of relying on every read path
+ * to redact. Sanitization is deterministic and idempotent: already-redacted
+ * or non-sensitive values pass through unchanged.
+ */
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+}
+
+/** Sanitize free text (comment bodies, log chunks, event messages) before it is persisted. */
+export function sanitizeTextForPersistence(input: string): string {
+  return redactSensitiveText(input);
+}
+
+function deepRedactStrings(value: unknown): unknown {
+  if (typeof value === "string") return redactSensitiveText(value);
+  if (Array.isArray(value)) return value.map(deepRedactStrings);
+  if (!isPlainObject(value)) return value;
+  const out: Record<string, unknown> = {};
+  for (const [key, entry] of Object.entries(value)) {
+    out[key] = deepRedactStrings(entry);
+  }
+  return out;
+}
+
+/**
+ * Sanitize an arbitrary JSON-like value (string, array, or nested object)
+ * before it is persisted.
+ *
+ * Plain objects first go through the key-aware `sanitizeRecord` pass (secret
+ * field names, secret bindings, command args, JWT-shaped values), then every
+ * remaining string leaf goes through the text-level pass so credential-shaped
+ * values embedded in free-text fields are also caught. Non-JSON values
+ * (dates, buffers, class instances) are returned unchanged.
+ */
+export function sanitizeForPersistence<T>(value: T): T {
+  if (typeof value === "string") return redactSensitiveText(value) as T;
+  if (Array.isArray(value)) return value.map((entry) => sanitizeForPersistence(entry)) as T;
+  if (isPlainObject(value)) return deepRedactStrings(sanitizeRecord(value)) as T;
+  return value;
+}

--- a/server/src/redaction.ts
+++ b/server/src/redaction.ts
@@ -44,7 +44,7 @@ function maybeContainsSecretText(input: string) {
   return SECRET_TEXT_HINTS.some((hint) => lower.includes(hint)) || input.includes(".");
 }
 
-function isPlainObject(value: unknown): value is Record<string, unknown> {
+export function isPlainObject(value: unknown): value is Record<string, unknown> {
   if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
   const proto = Object.getPrototypeOf(value);
   return proto === Object.prototype || proto === null;

--- a/server/src/routes/activity.ts
+++ b/server/src/routes/activity.ts
@@ -6,7 +6,7 @@ import { validate } from "../middleware/validate.js";
 import { activityService, normalizeActivityLimit } from "../services/activity.js";
 import { assertAuthenticated, assertBoard, assertCompanyAccess, getAccessibleResource, hasCompanyAccess } from "./authz.js";
 import { accessService, heartbeatService, issueService } from "../services/index.js";
-import { sanitizeRecord } from "../redaction.js";
+import { sanitizeForPersistence } from "../persistence-sanitizer.js";
 
 const createActivitySchema = z.object({
   actorType: z.enum(["agent", "user", "system", "plugin"]).optional().default("system"),
@@ -95,7 +95,7 @@ export function activityRoutes(db: Db) {
     const event = await svc.create({
       companyId,
       ...req.body,
-      details: req.body.details ? sanitizeRecord(req.body.details) : null,
+      details: req.body.details ? sanitizeForPersistence(req.body.details) : null,
     });
     res.status(201).json(event);
   });

--- a/server/src/services/activity-log.ts
+++ b/server/src/services/activity-log.ts
@@ -6,7 +6,7 @@ import { isUuidLike, PLUGIN_EVENT_TYPES, type PluginEventType } from "@paperclip
 import type { PluginEvent } from "@paperclipai/plugin-sdk";
 import { publishLiveEvent } from "./live-events.js";
 import { redactCurrentUserValue } from "../log-redaction.js";
-import { sanitizeRecord } from "../redaction.js";
+import { sanitizeForPersistence } from "../persistence-sanitizer.js";
 import { logger } from "../middleware/logger.js";
 import type { PluginEventBus } from "./plugin-event-bus.js";
 import { instanceSettingsService } from "./instance-settings.js";
@@ -128,7 +128,7 @@ export async function logActivity(db: Db, input: LogActivityInput) {
   const currentUserRedactionOptions = {
     enabled: (await instanceSettingsService(db).getGeneral()).censorUsernameInLogs,
   };
-  const sanitizedDetails = input.details ? sanitizeRecord(input.details) : null;
+  const sanitizedDetails = input.details ? sanitizeForPersistence(input.details) : null;
   const redactedDetails = sanitizedDetails
     ? redactCurrentUserValue(sanitizedDetails, currentUserRedactionOptions)
     : null;

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -228,7 +228,8 @@ import {
   redactCurrentUserValue,
   type CurrentUserRedactionOptions,
 } from "../log-redaction.js";
-import { redactEventPayload, redactSensitiveText } from "../redaction.js";
+import { redactSensitiveText } from "../redaction.js";
+import { sanitizeForPersistence, sanitizeTextForPersistence } from "../persistence-sanitizer.js";
 import {
   hasSessionCompactionThresholds,
   resolveSessionCompactionPolicy,
@@ -8170,12 +8171,12 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     const eventAt = new Date();
     const currentUserRedactionOptions = await getCurrentUserRedactionOptions();
     const sanitizedMessage = event.message
-      ? redactCurrentUserText(event.message, currentUserRedactionOptions)
+      ? redactCurrentUserText(sanitizeTextForPersistence(event.message), currentUserRedactionOptions)
       : event.message;
     const boundedPayload = event.payload
       ? boundHeartbeatRunEventPayloadForStorage(event.payload)
       : event.payload;
-    const secretSanitizedPayload = boundedPayload ? redactEventPayload(boundedPayload) : boundedPayload;
+    const secretSanitizedPayload = boundedPayload ? sanitizeForPersistence(boundedPayload) : boundedPayload;
     const sanitizedPayload = secretSanitizedPayload
       ? redactCurrentUserValue(secretSanitizedPayload, currentUserRedactionOptions)
       : secretSanitizedPayload;
@@ -13144,7 +13145,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       const currentUserRedactionOptions = await getCurrentUserRedactionOptions();
       const onLog = async (stream: "stdout" | "stderr", chunk: string) => {
         const sanitizedChunk = compactRunLogChunk(
-          redactCurrentUserText(chunk, currentUserRedactionOptions),
+          redactCurrentUserText(sanitizeTextForPersistence(chunk), currentUserRedactionOptions),
         );
         if (stream === "stdout") stdoutExcerpt = appendExcerpt(stdoutExcerpt, sanitizedChunk);
         if (stream === "stderr") stderrExcerpt = appendExcerpt(stderrExcerpt, sanitizedChunk);
@@ -13707,7 +13708,9 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           : outcome === "succeeded"
             ? null
             : redactCurrentUserText(
-                adapterResult.errorMessage ?? (outcome === "timed_out" ? "Timed out" : "Adapter failed"),
+                sanitizeTextForPersistence(
+                  adapterResult.errorMessage ?? (outcome === "timed_out" ? "Timed out" : "Adapter failed"),
+                ),
                 currentUserRedactionOptions,
               );
       const recordedResponsibleUserDenialCode =

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -88,6 +88,7 @@ import { buildInitialIssueMonitorFields, normalizeIssueExecutionPolicy } from ".
 import { instanceSettingsService } from "./instance-settings.js";
 import { redactCurrentUserText } from "../log-redaction.js";
 import { redactSensitiveText } from "../redaction.js";
+import { sanitizeTextForPersistence } from "../persistence-sanitizer.js";
 import { resolveIssueGoalId, resolveNextIssueGoalId } from "./issue-goal-fallback.js";
 import { getRunLogStore } from "./run-log-store.js";
 import { getDefaultCompanyGoal } from "./goals.js";
@@ -7420,7 +7421,10 @@ export function issueService(db: Db) {
       const currentUserRedactionOptions = {
         enabled: (await instanceSettings.getGeneral()).censorUsernameInLogs,
       };
-      const redactedBody = redactCurrentUserText(body, currentUserRedactionOptions);
+      const redactedBody = redactCurrentUserText(
+        sanitizeTextForPersistence(body),
+        currentUserRedactionOptions,
+      );
       const authorType = issueCommentAuthorTypeSchema.parse(
         options?.authorType ?? (actor.agentId ? "agent" : actor.userId ? "user" : "system"),
       );

--- a/server/src/services/run-log-store.ts
+++ b/server/src/services/run-log-store.ts
@@ -5,6 +5,7 @@ import { notFound } from "../errors.js";
 import { resolvePaperclipInstanceRoot } from "../home-paths.js";
 import { createS3StorageProvider } from "../storage/s3-provider.js";
 import type { StorageProvider } from "../storage/types.js";
+import { sanitizeTextForPersistence } from "../persistence-sanitizer.js";
 
 export type RunLogStoreType = "local_file";
 
@@ -174,7 +175,7 @@ export function createDurableRunLogStore(options: DurableRunLogStoreOptions): Ru
       const line = JSON.stringify({
         ts: event.ts,
         stream: event.stream,
-        chunk: event.chunk,
+        chunk: sanitizeTextForPersistence(event.chunk),
         // Monotonic per-run sequence so readers can dedupe and order records
         // even when several identical chunks share the same millisecond ts
         // (common for ACP-style token deltas).


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Agents produce persisted artifacts: run transcripts, issue comments, run events, and activity payloads, all written to disk or Postgres (and from there into backups)
> - Paperclip already has solid redaction primitives, but they mostly run at egress boundaries — response serialization, live events, and request logging
> - Credential-shaped values that reach a DB insert/update or a run-log append *before* those boundaries are persisted verbatim, survive at rest, and resurface through any read path or backup that predates the redaction
> - This pull request adds a small pre-persistence sanitizer boundary that reuses the existing redaction primitives and applies it at the write sites: comment bodies, run-log chunks, run event messages/payloads, stdout/stderr excerpts, adapter error messages, and activity details
> - The benefit is that sensitive-looking values are neutralized once, before the write, instead of relying on every current and future read path to redact — so logs, DB rows, and backups stay clean by construction

## Linked Issues or Issue Description

- Refs #8047 — "Run transcripts persist raw secret values to run logs, heartbeat_runs, and backups". This PR implements the shape-based masking half of that issue's proposal (its "token-shape masking as defense in depth" item) at the transcript writer and other persistence sites. It does **not** implement redaction-by-value against bound secret values or the backup file-permissions change, which remain open follow-ups on #8047.

Related in-flight PRs found during the duplicate search (different scope — they extend redaction *patterns*, this PR moves sanitization to the *persistence boundary*; happy to rebase or consolidate if maintainers prefer one direction):

- #6373 — extends value-based patterns in the shared redaction primitives and applies them in heartbeat
- #6663 — redacts value-based secret patterns in `compactRunLogChunk`
- #6692 — server-side secret value redaction (currently has merge conflicts)
- #3861 — JWT redaction in `log-redaction.ts`

Thanks to those authors — their pattern work is complementary: any pattern improvement to `redactSensitiveText`/`sanitizeRecord` automatically strengthens the boundary added here.

## What Changed

- Added `server/src/persistence-sanitizer.ts` — a small central pre-persistence boundary exposing `sanitizeTextForPersistence` (free text) and `sanitizeForPersistence` (strings, arrays, nested JSON-like objects). It reuses the existing primitives: a key-aware `sanitizeRecord` pass (secret field names, secret bindings, JWT-shaped values, command args) followed by a text-level `redactSensitiveText` pass on remaining string leaves. Deterministic and idempotent; `secret_ref` bindings and non-sensitive operational metadata pass through unchanged.
- Run logs / transcripts: `run-log-store.ts` sanitizes every chunk in `append` before it reaches disk (covers heartbeat run logs and workspace operation logs).
- Heartbeat: run event messages and payloads, stdout/stderr excerpts, and adapter error messages are sanitized before insert into `heartbeat_run_events` / `heartbeat_runs`.
- Issue comments: `addComment` sanitizes the body before the row is written.
- Activity log: `logActivity` and the activity route sanitize `details` with the new helper (upgrades the existing key-only `sanitizeRecord` call to also catch credential-shaped values embedded in free-text leaves).
- Tests: `persistence-sanitizer.test.ts` (unit + on-disk run-log assertions) and `pre-persistence-sanitization.test.ts` (embedded Postgres, asserts raw DB rows are sanitized and safe values stay byte-identical). All test values are fake canary strings.

## Verification

- `npx vitest run server/src/__tests__/persistence-sanitizer.test.ts server/src/__tests__/pre-persistence-sanitization.test.ts` — new coverage: env-style assignments, bearer headers, provider-shaped tokens, JWT shapes, JSON secret fields, nested objects/arrays, adapter/env/config payloads, activity payloads, secret_ref preservation, idempotency, and already-safe values remaining intact (asserted against raw DB rows and the raw ndjson on disk).
- Regression suites around the touched boundaries pass: `redaction.test.ts`, `redact-sensitive.test.ts`, `log-redaction.test.ts`, `activity-service.test.ts`, `activity-routes.test.ts`, `issue-comment-redaction.test.ts`, `issue-comment-cancel-routes.test.ts`, `issue-comment-reopen-routes.test.ts`, `issue-update-comment-wakeup-routes.test.ts`, `heartbeat-comment-wake-batching.test.ts`, `heartbeat-run-log.test.ts`, `feedback-service.test.ts` (163 tests, all green).
- `pnpm run typecheck` in `server/` is clean.
- Manual check: append a chunk containing a fake `ghp_…`-shaped token through the run-log store and confirm the ndjson on disk contains `***REDACTED***` and not the canary.

## Risks

- Shape-based masking can false-positive: prose that looks like `SOMETHING_TOKEN=value` in a comment will be masked at rest. This is the same trade-off the existing egress redaction already makes (same patterns, same `***REDACTED***` marker); the change is *where* it runs, not *what* it matches.
- Sanitization at write time is lossy by design: the original unredacted text is not recoverable from the DB. That is the point of the fix, but it is a behavioral shift for anyone relying on raw values being present in run logs or comment rows.
- Live agent `adapterConfig`/`runtimeConfig` at rest are intentionally untouched — agents need raw values to execute, `secret_ref` bindings are the supported mechanism, and config revision snapshots were already sanitized. Issue titles/descriptions and document bodies are not covered here (kept out to stay reviewable; can follow up).
- No migrations, no API shape changes, no new dependencies.

## Model Used

- Claude Fable 5 (Anthropic, model ID `claude-fable-5`), running in Claude Code with extended reasoning and tool use (file editing, shell, test execution). Prompting, review, and final approval by the human author.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes (module-level doc comment; no user-facing docs affected)
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

