### PR TITLE
feat(plugin-sdk): expose read-only routines.list / routines.get to plugin workers

### DIFF
--- a/doc/plugins/PLUGIN_SPEC.md
+++ b/doc/plugins/PLUGIN_SPEC.md
@@ -795,6 +795,7 @@ The host enforces capabilities in the SDK layer and refuses calls outside the gr
 - `issue.relations.read`
 - `issue.subtree.read`
 - `agents.read`
+- `routines.read`
 - `goals.read`
 - `activity.read`
 - `costs.read`

--- a/packages/plugins/sdk/src/host-client-factory.ts
+++ b/packages/plugins/sdk/src/host-client-factory.ts
@@ -199,8 +199,10 @@ export interface HostServices {
     get(params: WorkerToHostMethods["executionWorkspaces.get"][0]): Promise<WorkerToHostMethods["executionWorkspaces.get"][1]>;
   };
 
-  /** Provides `routines.managed.*`. */
+  /** Provides `routines.list`/`routines.get` (read) and `routines.managed.*`. */
   routines: {
+    list(params: WorkerToHostMethods["routines.list"][0]): Promise<WorkerToHostMethods["routines.list"][1]>;
+    get(params: WorkerToHostMethods["routines.get"][0]): Promise<WorkerToHostMethods["routines.get"][1]>;
     managedGet(params: WorkerToHostMethods["routines.managed.get"][0]): Promise<WorkerToHostMethods["routines.managed.get"][1]>;
     managedReconcile(params: WorkerToHostMethods["routines.managed.reconcile"][0]): Promise<WorkerToHostMethods["routines.managed.reconcile"][1]>;
     managedReset(params: WorkerToHostMethods["routines.managed.reset"][0]): Promise<WorkerToHostMethods["routines.managed.reset"][1]>;
@@ -418,6 +420,8 @@ const METHOD_CAPABILITY_MAP: Record<WorkerToHostMethodName, PluginCapability | n
     "routines.managed.reset": "routines.managed",
     "routines.managed.update": "routines.managed",
     "routines.managed.run": "routines.managed",
+    "routines.list": "routines.read",
+    "routines.get": "routines.read",
     "skills.managed.get": "skills.managed",
     "skills.managed.reconcile": "skills.managed",
     "skills.managed.reset": "skills.managed",
@@ -763,6 +767,12 @@ export function createHostClientHandlers(
     }),
 
     // Routines
+    "routines.list": gated("routines.list", async (params) => {
+      return services.routines.list(params);
+    }),
+    "routines.get": gated("routines.get", async (params) => {
+      return services.routines.get(params);
+    }),
     "routines.managed.get": gated("routines.managed.get", async (params) => {
       return services.routines.managedGet(params);
     }),

--- a/packages/plugins/sdk/src/protocol.ts
+++ b/packages/plugins/sdk/src/protocol.ts
@@ -35,6 +35,7 @@ import type {
   PluginManagedRoutineResolution,
   PluginManagedSkillResolution,
   Routine,
+  RoutineListItem,
   RoutineRun,
   Agent,
   Goal,
@@ -1205,6 +1206,16 @@ export interface WorkerToHostMethods {
       projectId?: string | null;
     },
     result: RoutineRun,
+  ];
+
+  // Routines (read)
+  "routines.list": [
+    params: { companyId: string; projectId?: string | null; limit?: number; offset?: number },
+    result: RoutineListItem[],
+  ];
+  "routines.get": [
+    params: { routineId: string; companyId: string },
+    result: Routine | null,
   ];
   "skills.managed.get": [
     params: { skillKey: string; companyId: string },

--- a/packages/plugins/sdk/src/testing.ts
+++ b/packages/plugins/sdk/src/testing.ts
@@ -1114,6 +1114,22 @@ export function createTestHarness(options: TestHarnessOptions): TestHarness {
       },
     },
     routines: {
+      async list(input) {
+        requireCapability(manifest, capabilitySet, "routines.read");
+        const companyId = requireCompanyId(input?.companyId);
+        let out = [...routines.values()].filter((routine) => routine.companyId === companyId);
+        if (input?.projectId) out = out.filter((routine) => routine.projectId === input.projectId);
+        if (input?.offset) out = out.slice(input.offset);
+        if (input?.limit) out = out.slice(0, input.limit);
+        // The in-memory harness carries no trigger/run history, so the
+        // RoutineListItem enrichment fields are empty rather than invented.
+        return out.map((routine) => ({ ...routine, triggers: [], lastRun: null, activeIssue: null }));
+      },
+      async get(routineId, companyId) {
+        requireCapability(manifest, capabilitySet, "routines.read");
+        const routine = routines.get(routineId);
+        return isInCompany(routine, companyId) ? routine : null;
+      },
       managed: {
         async get(routineKey, companyId) {
           requireCapability(manifest, capabilitySet, "routines.managed");

--- a/packages/plugins/sdk/src/types.ts
+++ b/packages/plugins/sdk/src/types.ts
@@ -37,6 +37,7 @@ import type {
   PluginManagedSkillResolution,
   CompanySkill,
   Routine,
+  RoutineListItem,
   RoutineRun,
   Agent,
   Goal,
@@ -71,6 +72,7 @@ export type {
   PluginManagedSkillResolution,
   CompanySkill,
   Routine,
+  RoutineListItem,
   RoutineRun,
   PluginLocalFolderDeclaration,
   PluginCompanySettings,
@@ -890,11 +892,29 @@ export interface PluginExecutionWorkspacesClient {
 }
 
 /**
- * `ctx.routines` — resolve and reconcile plugin-managed Paperclip routines.
+ * `ctx.routines` — read company routines, and resolve/reconcile plugin-managed
+ * Paperclip routines.
  *
- * Requires `routines.managed` capability.
+ * Reads require the `routines.read` capability; `managed.*` requires
+ * `routines.managed`.
  */
 export interface PluginRoutinesClient {
+  /**
+   * List the company's routines (any origin, not just plugin-managed), each
+   * enriched with its triggers, latest run summary, and active issue — the
+   * same shape the REST routine list returns. Requires `routines.read`.
+   */
+  list(input: {
+    companyId: string;
+    projectId?: string | null;
+    limit?: number;
+    offset?: number;
+  }): Promise<RoutineListItem[]>;
+  /**
+   * Fetch one routine by id, company-scoped (null when the routine does not
+   * exist or belongs to another company). Requires `routines.read`.
+   */
+  get(routineId: string, companyId: string): Promise<Routine | null>;
   managed: {
     get(routineKey: string, companyId: string): Promise<PluginManagedRoutineResolution>;
     reconcile(

--- a/packages/plugins/sdk/src/worker-rpc-host.ts
+++ b/packages/plugins/sdk/src/worker-rpc-host.ts
@@ -690,6 +690,17 @@ export function startWorkerRpcHost(options: WorkerRpcHostOptions): WorkerRpcHost
       },
 
       routines: {
+        async list(input) {
+          return callHost("routines.list", {
+            companyId: input.companyId,
+            projectId: input.projectId,
+            limit: input.limit,
+            offset: input.offset,
+          });
+        },
+        async get(routineId: string, companyId: string) {
+          return callHost("routines.get", { routineId, companyId });
+        },
         managed: {
           async get(routineKey: string, companyId: string) {
             return callHost("routines.managed.get", { routineKey, companyId });

--- a/packages/plugins/sdk/tests/host-client-factory.test.ts
+++ b/packages/plugins/sdk/tests/host-client-factory.test.ts
@@ -151,6 +151,47 @@ describe("createHostClientHandlers invocation company scope", () => {
     },
   );
 
+  it("gates routines.list/routines.get behind routines.read and honours the grant", async () => {
+    const routinesList = vi.fn(async () => []);
+    const routinesGet = vi.fn(async () => null);
+    const services = {
+      routines: {
+        list: routinesList,
+        get: routinesGet,
+      },
+    } as unknown as HostServices;
+
+    const denied = createHostClientHandlers({
+      pluginId: "paperclip.test",
+      capabilities: [],
+      services,
+    });
+    await expect(
+      denied["routines.list"]({ companyId: "company-a" }),
+    ).rejects.toMatchObject({
+      name: "CapabilityDeniedError",
+      message: expect.stringContaining("routines.read"),
+    });
+    await expect(
+      denied["routines.get"]({ routineId: "routine-1", companyId: "company-a" }),
+    ).rejects.toBeInstanceOf(CapabilityDeniedError);
+    expect(routinesList).not.toHaveBeenCalled();
+    expect(routinesGet).not.toHaveBeenCalled();
+
+    const granted = createHostClientHandlers({
+      pluginId: "paperclip.test",
+      capabilities: ["routines.read"],
+      services,
+    });
+    await expect(
+      granted["routines.list"](
+        { companyId: "company-a" },
+        { invocationScope: { companyId: "company-a" } },
+      ),
+    ).resolves.toEqual([]);
+    expect(routinesList).toHaveBeenCalledWith({ companyId: "company-a" });
+  });
+
   it("checks invocation company scope before exposing authorization data", async () => {
     const searchAudit = vi.fn(async () => []);
     const services = {

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -904,6 +904,7 @@ export const PLUGIN_CAPABILITIES = [
   "issue.comments.read",
   "issue.documents.read",
   "agents.read",
+  "routines.read",
   "goals.read",
   "goals.create",
   "goals.update",

--- a/server/src/services/plugin-capability-validator.ts
+++ b/server/src/services/plugin-capability-validator.ts
@@ -53,6 +53,8 @@ const OPERATION_CAPABILITIES: Record<string, readonly PluginCapability[]> = {
   "routines.managed.get": ["routines.managed"],
   "routines.managed.reconcile": ["routines.managed"],
   "routines.managed.reset": ["routines.managed"],
+  "routines.list": ["routines.read"],
+  "routines.get": ["routines.read"],
   "project.workspaces.list": ["project.workspaces.read"],
   "project.workspaces.get": ["project.workspaces.read"],
   "execution.workspaces.get": ["execution.workspaces.read"],

--- a/server/src/services/plugin-host-services.ts
+++ b/server/src/services/plugin-host-services.ts
@@ -47,6 +47,7 @@ import { pluginStateStore } from "./plugin-state-store.js";
 import { pluginDatabaseService } from "./plugin-database.js";
 import { pluginManagedAgentService } from "./plugin-managed-agents.js";
 import { pluginManagedRoutineService } from "./plugin-managed-routines.js";
+import { routineService } from "./routines.js";
 import { pluginManagedSkillService } from "./plugin-managed-skills.js";
 import {
   assertConfiguredLocalFolder,
@@ -532,6 +533,9 @@ export function buildHostServices(
     manifest: options.manifest,
   });
   const heartbeat = heartbeatService(db, {
+    pluginWorkerManager: options.pluginWorkerManager,
+  });
+  const routineReads = routineService(db, {
     pluginWorkerManager: options.pluginWorkerManager,
   });
   const projects = projectService(db);
@@ -1472,6 +1476,18 @@ export function buildHostServices(
     },
 
     routines: {
+      async list(params) {
+        const companyId = ensureCompanyId(params.companyId);
+        await ensurePluginAvailableForCompany(companyId);
+        const rows = await routineReads.list(companyId, { projectId: params.projectId ?? undefined });
+        return applyWindow(rows, params);
+      },
+      async get(params) {
+        const companyId = ensureCompanyId(params.companyId);
+        await ensurePluginAvailableForCompany(companyId);
+        const routine = await routineReads.get(params.routineId);
+        return inCompany(routine, companyId) ? routine : null;
+      },
       async managedGet(params) {
         const companyId = ensureCompanyId(params.companyId);
         await ensurePluginAvailableForCompany(companyId);


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Plugins extend it through a sandboxed worker SDK whose host calls are gated by declared capabilities (issues.read, agents.read, goals.read, ...)
> - Routines are the recurring-work primitive, but the SDK only exposes `routines.managed.*`, which is scoped to routines the plugin itself owns
> - A plugin that visualizes or reasons about a company's recurring work (e.g. a workflow board built over `routine_execution` issue chains) therefore cannot resolve routine names, schedules, or run summaries — it can only show raw routine origin ids
> - This pull request adds a narrow read-only capability, `routines.read`, backing `ctx.routines.list()` and `ctx.routines.get()`, mirroring the established `agents.read` / `goals.read` pattern end to end
> - The benefit is that dashboard/visualization plugins can display real routine names and schedule context without being granted any write or managed-resource surface

## Linked Issues or Issue Description

No existing public issue covers this; describing the gap in-PR (feature template fields):

- **Problem:** plugin workers have no read access to company routines. `ctx.routines` exposes only `managed.*` (plugin-owned routines). Plugins rendering recurring work over `routine_execution` issues must display raw origin ids because nothing in the SDK resolves a routine id to its title/schedule/last run.
- **Proposed solution:** a read-only `routines.read` capability with `routines.list` (company-scoped, optional project filter, limit/offset windowing, returning the same enriched `RoutineListItem[]` shape the REST routine list returns) and `routines.get` (company-scoped single fetch, `Routine | null`).
- **Alternatives considered:** deriving names client-side from issue titles (unreliable, and unavailable to workers), or widening `routines.managed` (wrong scope — it is a write/reconcile surface for plugin-owned routines only).

Dedup search: searched open/closed PRs for "routines read", "plugin sdk routine", and related issue queries; closest matches are #5754 (REST `assigneeAgentId` filter on the HTTP routines LIST endpoint) and #1172 (a routines plugin) — neither touches the plugin worker SDK read surface.

## What Changed

- `packages/shared/src/constants.ts`: add `routines.read` to `PLUGIN_CAPABILITIES` (Data Read).
- `packages/plugins/sdk/src/protocol.ts`: new `routines.list` / `routines.get` worker→host methods (`RoutineListItem[]` / `Routine | null`).
- `packages/plugins/sdk/src/host-client-factory.ts`: method→capability map entries and gated handlers delegating to `services.routines.list/get`; `HostServices.routines` interface extended.
- `packages/plugins/sdk/src/worker-rpc-host.ts`: `ctx.routines.list()` / `ctx.routines.get()` in the worker context.
- `packages/plugins/sdk/src/types.ts`: `PluginRoutinesClient.list/get` with docs; re-export `RoutineListItem`.
- `packages/plugins/sdk/src/testing.ts`: in-memory harness parity (company-scoped, capability-gated; enrichment fields empty rather than invented — the harness carries no trigger/run history).
- `server/src/services/plugin-capability-validator.ts`: `routines.list` / `routines.get` → `routines.read`.
- `server/src/services/plugin-host-services.ts`: handlers backed by the existing `routineService` with the same `ensureCompanyId` + `ensurePluginAvailableForCompany` + company-scoping guards the agent read handlers use, plus `applyWindow` for limit/offset.
- `doc/plugins/PLUGIN_SPEC.md`: `routines.read` added to §15.1 Data Read.
- `packages/plugins/sdk/tests/host-client-factory.test.ts`: new test covering the capability-denied path and the granted path.

## Verification

- `packages/plugins/sdk`: `pnpm exec tsc` clean; `pnpm exec vitest run` → 17/17 passing (includes the new gating test).
- `server`: `pnpm exec tsc --noEmit` clean.
- Manual reviewer path: grant a plugin `routines.read`, call `ctx.routines.list({ companyId })` from a worker data handler, and confirm routine titles resolve; without the capability the call rejects with `CapabilityDeniedError`.

## Risks

- Low risk: additive, read-only, and opt-in via a new capability; no change to `routines.managed.*` behaviour or any write surface.
- `routines.list` reuses the REST list's enrichment queries (triggers, latest run, active issue), so cost per call matches the existing `/api/routines` endpoint; limit/offset windowing is applied host-side.
- Company scoping is enforced host-side on both methods (`get` returns null for cross-company ids), matching the agents/goals read handlers.

## Model Used

- Claude Fable 5 (Anthropic, model id `claude-fable-5`), extended thinking enabled, agentic tool use via Claude Code.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
