### PR TITLE
fix(sandbox-bridge): allow the agent-hire skill's routes through the callback bridge

### DIFF
--- a/packages/adapter-utils/src/sandbox-callback-bridge.test.ts
+++ b/packages/adapter-utils/src/sandbox-callback-bridge.test.ts
@@ -881,6 +881,13 @@ describe("sandbox callback bridge", () => {
       { method: "GET", path: "/api/companies/co-1/approvals" },
       { method: "GET", path: "/api/companies/co-1/routines" },
       { method: "GET", path: "/api/companies/co-1/skills" },
+      // Hire skill (paperclip-create-agent): discovery + submit + issue linking
+      { method: "GET", path: "/llms/agent-configuration.txt" },
+      { method: "GET", path: "/llms/agent-configuration/claude_local.txt" },
+      { method: "GET", path: "/llms/agent-icons.txt" },
+      { method: "GET", path: "/api/companies/co-1/agent-configurations" },
+      { method: "POST", path: "/api/companies/co-1/agent-hires" },
+      { method: "POST", path: "/api/issues/issue-1/approvals" },
       { method: "GET", path: "/api/projects/proj-1" },
       { method: "GET", path: "/api/goals/goal-1" },
       { method: "GET", path: "/api/issues/issue-1" },
@@ -932,6 +939,11 @@ describe("sandbox callback bridge", () => {
       // grows new actions later.
       { method: "POST", path: "/api/execution-workspaces/ws-1/runtime-services/delete" },
       { method: "POST", path: "/api/companies/co-1/agents" },
+      // The hire allowlist must not over-match: only the exact .txt discovery
+      // files, only agent-hires (not /agents), and no sub-resources beyond it.
+      { method: "GET", path: "/llms/agent-configuration" },
+      { method: "GET", path: "/llms/secrets.txt" },
+      { method: "POST", path: "/api/companies/co-1/agent-hires/ap-1" },
       { method: "POST", path: "/api/agents/agent-1/pause" },
       { method: "POST", path: "/api/agents/agent-1/terminate" },
       { method: "POST", path: "/api/agents/agent-1/keys" },

--- a/packages/adapter-utils/src/sandbox-callback-bridge.ts
+++ b/packages/adapter-utils/src/sandbox-callback-bridge.ts
@@ -75,6 +75,18 @@ export const DEFAULT_SANDBOX_CALLBACK_BRIDGE_ROUTE_ALLOWLIST: readonly SandboxCa
   // Subtasks / delegation
   { method: "POST", path: /^\/api\/companies\/[^/]+\/issues$/ },
 
+  // Hiring (paperclip-create-agent skill): adapter/icon discovery, comparing
+  // existing agent configs, submitting the hire request, and linking the
+  // resulting approval to its source issue. Direct agent creation
+  // (POST /api/companies/:id/agents) stays denied — hires must go through the
+  // approval-gated agent-hires endpoint, which the server still permission-checks.
+  { method: "GET", path: /^\/llms\/agent-configuration\.txt$/ },
+  { method: "GET", path: /^\/llms\/agent-configuration\/[^/]+\.txt$/ },
+  { method: "GET", path: /^\/llms\/agent-icons\.txt$/ },
+  { method: "GET", path: /^\/api\/companies\/[^/]+\/agent-configurations$/ },
+  { method: "POST", path: /^\/api\/companies\/[^/]+\/agent-hires$/ },
+  { method: "POST", path: /^\/api\/issues\/[^/]+\/approvals$/ },
+
   // Approvals (request, read, comment)
   { method: "GET", path: /^\/api\/approvals\/[^/]+$/ },
   { method: "GET", path: /^\/api\/approvals\/[^/]+\/issues$/ },


### PR DESCRIPTION
## Problem

Managed agents that run inside a sandbox reach the server only through the sandbox callback bridge, which forwards a fixed route allowlist (`DEFAULT_SANDBOX_CALLBACK_BRIDGE_ROUTE_ALLOWLIST`). The `paperclip-create-agent` skill is documented to call adapter/icon discovery endpoints, compare existing agent configs, submit the hire, and link the resulting approval to its source issue -- but none of those routes were on the allowlist, so an agent following the skill hit `Route not allowed` on every call, including the hire `POST` itself. A correctly-behaving agent therefore could not hire.

## Fix

Add the six routes the skill uses:
- `GET /llms/agent-configuration.txt`
- `GET /llms/agent-configuration/:adapterType.txt`
- `GET /llms/agent-icons.txt`
- `GET /api/companies/:id/agent-configurations`
- `POST /api/companies/:id/agent-hires`
- `POST /api/issues/:id/approvals`

Direct agent creation (`POST /api/companies/:id/agents`) stays **denied** -- hires go through the approval-gated `agent-hires` endpoint, which the server still permission-checks (`canCreateAgents`). The bridge allowlist bounds surface area; it does not replace server-side authorization.

New tests assert the routes are allowed and that the regexes do not over-match (no `/agents`, only `.txt` discovery files, no `agent-hires` sub-resources).

🤖 Generated with [Claude Code](https://claude.com/claude-code)