### PR TITLE
Guard duplicate subscription homes across active agents

### DIFF
--- a/server/src/__tests__/subscription-home-guard.test.ts
+++ b/server/src/__tests__/subscription-home-guard.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from "vitest";
+import os from "node:os";
+import path from "node:path";
+import {
+  allowsSharedSubscriptionHome,
+  findSubscriptionHomeConflicts,
+  listSubscriptionHomeBindings,
+  normalizeSubscriptionHomePath,
+} from "../services/subscription-home-guard.js";
+
+describe("listSubscriptionHomeBindings", () => {
+  it("returns bindings for plain string subscription-home env values", () => {
+    const bindings = listSubscriptionHomeBindings({
+      env: {
+        CODEX_HOME: "/auth-homes/codex-aleks",
+        CLAUDE_CONFIG_DIR: "/auth-homes/claude-aleks",
+        HOME: "/auth-homes/aleks",
+        OPENAI_API_KEY: "sk-should-be-ignored",
+      },
+    });
+    expect(bindings).toEqual([
+      { envKey: "CODEX_HOME", homePath: "/auth-homes/codex-aleks" },
+      { envKey: "CLAUDE_CONFIG_DIR", homePath: "/auth-homes/claude-aleks" },
+      { envKey: "HOME", homePath: "/auth-homes/aleks" },
+    ]);
+  });
+
+  it("supports plain env binding records and skips secret refs", () => {
+    const bindings = listSubscriptionHomeBindings({
+      env: {
+        CLAUDE_CONFIG_DIR: { type: "plain", value: "/auth-homes/claude-paul" },
+        CODEX_HOME: { type: "secret_ref", secretId: "abc" },
+      },
+    });
+    expect(bindings).toEqual([
+      { envKey: "CLAUDE_CONFIG_DIR", homePath: "/auth-homes/claude-paul" },
+    ]);
+  });
+
+  it("returns nothing for missing env, empty values, or non-object configs", () => {
+    expect(listSubscriptionHomeBindings({})).toEqual([]);
+    expect(listSubscriptionHomeBindings(null)).toEqual([]);
+    expect(listSubscriptionHomeBindings({ env: { HOME: "   " } })).toEqual([]);
+  });
+
+  it("skips env keys resolved from secrets when requested", () => {
+    const bindings = listSubscriptionHomeBindings(
+      { env: { HOME: "/resolved-from-secret", CODEX_HOME: "/plain" } },
+      { skipEnvKeys: new Set(["HOME"]) },
+    );
+    expect(bindings).toEqual([{ envKey: "CODEX_HOME", homePath: "/plain" }]);
+  });
+});
+
+describe("normalizeSubscriptionHomePath", () => {
+  it("expands ~ and resolves relative segments", () => {
+    expect(normalizeSubscriptionHomePath("~/auth/claude")).toBe(
+      path.join(os.homedir(), "auth", "claude"),
+    );
+    expect(normalizeSubscriptionHomePath("~")).toBe(os.homedir());
+    expect(normalizeSubscriptionHomePath("/a/b/../c/")).toBe("/a/c");
+  });
+});
+
+describe("findSubscriptionHomeConflicts", () => {
+  const candidateBindings = listSubscriptionHomeBindings({
+    env: { CLAUDE_CONFIG_DIR: "/auth-homes/claude-aleks" },
+  });
+
+  it("flags another active agent binding the same resolved path", () => {
+    const conflicts = findSubscriptionHomeConflicts({
+      candidateBindings,
+      otherAgents: [
+        {
+          id: "agent-b",
+          name: "Outreach",
+          status: "idle",
+          adapterConfig: { env: { CLAUDE_CONFIG_DIR: "/auth-homes/claude-aleks/" } },
+        },
+      ],
+    });
+    expect(conflicts).toHaveLength(1);
+    expect(conflicts[0]).toMatchObject({
+      envKey: "CLAUDE_CONFIG_DIR",
+      otherEnvKey: "CLAUDE_CONFIG_DIR",
+      homePath: "/auth-homes/claude-aleks",
+      otherAgentId: "agent-b",
+      otherAgentName: "Outreach",
+    });
+  });
+
+  it("flags cross-key collisions on the same resolved path", () => {
+    const conflicts = findSubscriptionHomeConflicts({
+      candidateBindings,
+      otherAgents: [
+        {
+          id: "agent-c",
+          adapterConfig: { env: { HOME: "/auth-homes/claude-aleks" } },
+        },
+      ],
+    });
+    expect(conflicts).toHaveLength(1);
+    expect(conflicts[0]).toMatchObject({ envKey: "CLAUDE_CONFIG_DIR", otherEnvKey: "HOME" });
+  });
+
+  it("does not flag distinct homes or agents without explicit subscription env", () => {
+    const conflicts = findSubscriptionHomeConflicts({
+      candidateBindings,
+      otherAgents: [
+        { id: "agent-d", adapterConfig: { env: { CLAUDE_CONFIG_DIR: "/auth-homes/claude-paul" } } },
+        { id: "agent-e", adapterConfig: { env: { OPENAI_API_KEY: "sk-x" } } },
+        { id: "agent-f", adapterConfig: {} },
+      ],
+    });
+    expect(conflicts).toEqual([]);
+  });
+
+  it("skips agents that explicitly allow shared subscription homes", () => {
+    const conflicts = findSubscriptionHomeConflicts({
+      candidateBindings,
+      otherAgents: [
+        {
+          id: "agent-g",
+          adapterConfig: {
+            allowSharedSubscriptionHome: true,
+            env: { CLAUDE_CONFIG_DIR: "/auth-homes/claude-aleks" },
+          },
+        },
+      ],
+    });
+    expect(conflicts).toEqual([]);
+  });
+
+  it("returns no conflicts when the candidate declares no bindings", () => {
+    expect(
+      findSubscriptionHomeConflicts({
+        candidateBindings: [],
+        otherAgents: [
+          { id: "agent-h", adapterConfig: { env: { HOME: "/auth-homes/aleks" } } },
+        ],
+      }),
+    ).toEqual([]);
+  });
+});
+
+describe("allowsSharedSubscriptionHome", () => {
+  it("requires an explicit boolean true", () => {
+    expect(allowsSharedSubscriptionHome({ allowSharedSubscriptionHome: true })).toBe(true);
+    expect(allowsSharedSubscriptionHome({ allowSharedSubscriptionHome: "true" })).toBe(false);
+    expect(allowsSharedSubscriptionHome({})).toBe(false);
+    expect(allowsSharedSubscriptionHome(null)).toBe(false);
+  });
+});

--- a/server/src/__tests__/subscription-home-guard.test.ts
+++ b/server/src/__tests__/subscription-home-guard.test.ts
@@ -103,6 +103,50 @@ describe("findSubscriptionHomeConflicts", () => {
     expect(conflicts[0]).toMatchObject({ envKey: "CLAUDE_CONFIG_DIR", otherEnvKey: "HOME" });
   });
 
+  it("flags case-only differences as the same subscription home", () => {
+    const conflicts = findSubscriptionHomeConflicts({
+      candidateBindings: listSubscriptionHomeBindings({
+        env: { CODEX_HOME: "/Users/Alice/.codex" },
+      }),
+      otherAgents: [
+        {
+          id: "agent-case",
+          adapterConfig: { env: { CODEX_HOME: "/Users/alice/.codex" } },
+        },
+      ],
+    });
+    expect(conflicts).toHaveLength(1);
+    expect(conflicts[0]).toMatchObject({
+      envKey: "CODEX_HOME",
+      otherEnvKey: "CODEX_HOME",
+      homePath: "/Users/Alice/.codex",
+    });
+  });
+
+  it("ignores agents that are not currently runnable", () => {
+    const conflicts = findSubscriptionHomeConflicts({
+      candidateBindings,
+      otherAgents: [
+        {
+          id: "agent-paused",
+          status: "paused",
+          adapterConfig: { env: { CLAUDE_CONFIG_DIR: "/auth-homes/claude-aleks" } },
+        },
+        {
+          id: "agent-pending",
+          status: "pending_approval",
+          adapterConfig: { env: { CLAUDE_CONFIG_DIR: "/auth-homes/claude-aleks" } },
+        },
+        {
+          id: "agent-terminated",
+          status: "terminated",
+          adapterConfig: { env: { CLAUDE_CONFIG_DIR: "/auth-homes/claude-aleks" } },
+        },
+      ],
+    });
+    expect(conflicts).toEqual([]);
+  });
+
   it("does not flag distinct homes or agents without explicit subscription env", () => {
     const conflicts = findSubscriptionHomeConflicts({
       candidateBindings,

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -103,6 +103,13 @@ import { recoveryService } from "../services/recovery/service.js";
 import { resolveCoreTrustPreset } from "../services/trust-preset-resolver.js";
 import { readObject } from "../lib/objects.js";
 import { listInvalidOrgChainDescendantIds } from "../services/agent-invokability.js";
+import {
+  allowsSharedSubscriptionHome,
+  findSubscriptionHomeConflicts,
+  formatSubscriptionHomeConflict,
+  listOtherActiveAgentsForSubscriptionHomeCheck,
+  listSubscriptionHomeBindings,
+} from "../services/subscription-home-guard.js";
 
 const RUN_LOG_DEFAULT_LIMIT_BYTES = 256_000;
 const RUN_LOG_MAX_LIMIT_BYTES = 1024 * 1024;
@@ -1187,6 +1194,30 @@ export function agentRoutes(
     };
   }
 
+  // Runtime hardening (PAU-281): two active agents of one company must not
+  // resolve the same subscription home (CODEX_HOME / CLAUDE_CONFIG_DIR / HOME)
+  // through their adapter env, because that silently shares one provider login
+  // across employees. Intentional sharing (same employee, several agents) is
+  // acknowledged via adapterConfig.allowSharedSubscriptionHome=true.
+  async function assertNoCrossAgentSubscriptionHomeConflict(
+    companyId: string,
+    agentId: string,
+    adapterConfig: Record<string, unknown>,
+  ): Promise<void> {
+    const candidateBindings = listSubscriptionHomeBindings(adapterConfig);
+    if (candidateBindings.length === 0) return;
+    if (allowsSharedSubscriptionHome(adapterConfig)) return;
+    const otherAgents = await listOtherActiveAgentsForSubscriptionHomeCheck(db, companyId, agentId);
+    const conflicts = findSubscriptionHomeConflicts({ candidateBindings, otherAgents });
+    if (conflicts.length === 0) return;
+    throw conflict(
+      `Subscription home conflict: ${conflicts.map(formatSubscriptionHomeConflict).join("; ")}. ` +
+        "Two active agents must not share the same subscription home unless the sharing is intentional " +
+        "(same employee). Use a distinct auth home per employee, or set " +
+        "adapterConfig.allowSharedSubscriptionHome=true to acknowledge intentional sharing.",
+    );
+  }
+
   function applyCreateDefaultsByAdapterType(
     adapterType: string | null | undefined,
     adapterConfig: Record<string, unknown>,
@@ -2242,6 +2273,7 @@ export function agentRoutes(
       normalizeNewAgentRuntimeConfig(hireInput.runtimeConfig),
       normalizedAdapterConfig,
     );
+    await assertNoCrossAgentSubscriptionHomeConflict(companyId, hiredAgentId, normalizedAdapterConfig);
     const normalizedHireInput = {
       ...hireInput,
       adapterConfig: normalizedAdapterConfig,
@@ -2435,6 +2467,7 @@ export function agentRoutes(
       normalizeNewAgentRuntimeConfig(createInput.runtimeConfig),
       normalizedAdapterConfig,
     );
+    await assertNoCrossAgentSubscriptionHomeConflict(companyId, agentId, normalizedAdapterConfig);
     await assertAgentEnvironmentSelection(companyId, createInput.adapterType, createInput.defaultEnvironmentId);
     await assertAgentDefaultEnvironmentSelection(companyId, createInput.defaultEnvironmentId, {
       allowedDrivers: allowedEnvironmentDriversForAgent(createInput.adapterType),
@@ -2898,6 +2931,11 @@ export function agentRoutes(
         adapterType: requestedAdapterType,
         adapterConfig: effectiveAdapterConfig,
       });
+      await assertNoCrossAgentSubscriptionHomeConflict(
+        existing.companyId,
+        existing.id,
+        normalizedEffectiveAdapterConfig,
+      );
       patchData.adapterConfig = syncInstructionsBundleConfigFromFilePath(existing, normalizedEffectiveAdapterConfig);
     }
     if (requestedRuntimeConfig) {

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -1194,10 +1194,10 @@ export function agentRoutes(
     };
   }
 
-  // Runtime hardening (PAU-281): two active agents of one company must not
-  // resolve the same subscription home (CODEX_HOME / CLAUDE_CONFIG_DIR / HOME)
-  // through their adapter env, because that silently shares one provider login
-  // across employees. Intentional sharing (same employee, several agents) is
+  // Runtime hardening: two active agents of one company must not resolve the
+  // same subscription home (CODEX_HOME / CLAUDE_CONFIG_DIR / HOME) through
+  // their adapter env, because that silently shares one provider login across
+  // employees. Intentional sharing (same employee, several agents) is
   // acknowledged via adapterConfig.allowSharedSubscriptionHome=true.
   async function assertNoCrossAgentSubscriptionHomeConflict(
     companyId: string,

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -9837,11 +9837,10 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       ...effectiveResolvedConfig,
       paperclipRuntimeSkills: runtimeSkillEntries,
     };
-    // Runtime hardening (PAU-281): warn (never abort) when this run resolves a
-    // subscription home (CODEX_HOME / CLAUDE_CONFIG_DIR / HOME) that another
-    // active agent of the same company also binds — that means two agents share
-    // one provider login, which risks cross-employee account mixing. Env keys
-    // resolved from secrets are skipped so secret-derived values never reach logs.
+    // Runtime hardening: warn (never abort) when this run resolves a subscription
+    // home (CODEX_HOME / CLAUDE_CONFIG_DIR / HOME) that another active agent of
+    // the same company also binds. Env keys resolved from secrets are skipped so
+    // secret-derived values never reach logs.
     try {
       const subscriptionHomeBindings = listSubscriptionHomeBindings(effectiveResolvedConfig, {
         skipEnvKeys: secretKeys,

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -94,6 +94,12 @@ import {
 } from "./run-liveness.js";
 import { logActivity, publishPluginDomainEvent, type LogActivityInput } from "./activity-log.js";
 import {
+  allowsSharedSubscriptionHome,
+  findSubscriptionHomeConflicts,
+  listOtherActiveAgentsForSubscriptionHomeCheck,
+  listSubscriptionHomeBindings,
+} from "./subscription-home-guard.js";
+import {
   buildWorkspaceReadyComment,
   cleanupExecutionWorkspaceArtifacts,
   ensurePersistedExecutionWorkspaceAvailable,
@@ -9831,6 +9837,38 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       ...effectiveResolvedConfig,
       paperclipRuntimeSkills: runtimeSkillEntries,
     };
+    // Runtime hardening (PAU-281): warn (never abort) when this run resolves a
+    // subscription home (CODEX_HOME / CLAUDE_CONFIG_DIR / HOME) that another
+    // active agent of the same company also binds — that means two agents share
+    // one provider login, which risks cross-employee account mixing. Env keys
+    // resolved from secrets are skipped so secret-derived values never reach logs.
+    try {
+      const subscriptionHomeBindings = listSubscriptionHomeBindings(effectiveResolvedConfig, {
+        skipEnvKeys: secretKeys,
+      });
+      if (subscriptionHomeBindings.length > 0 && !allowsSharedSubscriptionHome(effectiveResolvedConfig)) {
+        const subscriptionHomeConflicts = findSubscriptionHomeConflicts({
+          candidateBindings: subscriptionHomeBindings,
+          otherAgents: await listOtherActiveAgentsForSubscriptionHomeCheck(db, agent.companyId, agent.id),
+        });
+        if (subscriptionHomeConflicts.length > 0) {
+          logger.warn(
+            {
+              companyId: agent.companyId,
+              agentId: agent.id,
+              runId: run.id,
+              conflicts: subscriptionHomeConflicts,
+            },
+            "Run starts with a subscription home that another active agent also binds; provider logins may mix across employees. Set adapterConfig.allowSharedSubscriptionHome=true if the sharing is intentional.",
+          );
+        }
+      }
+    } catch (error) {
+      logger.warn(
+        { err: error, companyId: agent.companyId, agentId: agent.id, runId: run.id },
+        "Subscription home duplicate check failed at run start; continuing without it",
+      );
+    }
     const latestAgentConfigRevision = await getLatestAgentConfigRevision(agent.companyId, agent.id);
     const sessionConfigMetadata = await buildEffectiveRunSessionConfigMetadata({
       adapterType: agent.adapterType,

--- a/server/src/services/subscription-home-guard.ts
+++ b/server/src/services/subscription-home-guard.ts
@@ -1,0 +1,147 @@
+import os from "node:os";
+import path from "node:path";
+import { and, eq, ne } from "drizzle-orm";
+import type { Db } from "@paperclipai/db";
+import { agents } from "@paperclipai/db";
+
+// Subscription-scoped auth homes for local CLI adapters. Two active agents
+// resolving the same home means two agents share one provider login, which
+// risks cross-account/credential mixing when the homes belong to different
+// employees (see PAU-263/PAU-281).
+export const SUBSCRIPTION_HOME_ENV_KEYS = ["CODEX_HOME", "CLAUDE_CONFIG_DIR", "HOME"] as const;
+
+export type SubscriptionHomeEnvKey = (typeof SUBSCRIPTION_HOME_ENV_KEYS)[number];
+
+export type SubscriptionHomeBinding = {
+  envKey: SubscriptionHomeEnvKey;
+  homePath: string;
+};
+
+export type SubscriptionHomeConflict = {
+  envKey: SubscriptionHomeEnvKey;
+  otherEnvKey: SubscriptionHomeEnvKey;
+  homePath: string;
+  otherAgentId: string;
+  otherAgentName: string | null;
+  otherAgentStatus: string | null;
+};
+
+type AgentLike = {
+  id: string;
+  name?: string | null;
+  status?: string | null;
+  adapterConfig?: unknown;
+};
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+// Accepts plain string env values and { type: "plain", value } bindings.
+// Secret refs are skipped: their resolved values are unknown at config time
+// and must not be surfaced in errors or logs.
+function asPlainEnvString(value: unknown): string | null {
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  }
+  const record = asRecord(value);
+  if (record?.type !== "plain") return null;
+  if (typeof record.value !== "string") return null;
+  const trimmed = record.value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+export function normalizeSubscriptionHomePath(value: string): string {
+  let expanded = value;
+  if (expanded === "~") {
+    expanded = os.homedir();
+  } else if (expanded.startsWith("~/")) {
+    expanded = path.join(os.homedir(), expanded.slice(2));
+  }
+  return path.resolve(expanded);
+}
+
+export function allowsSharedSubscriptionHome(adapterConfig: unknown): boolean {
+  const config = asRecord(adapterConfig);
+  return config?.allowSharedSubscriptionHome === true;
+}
+
+export function listSubscriptionHomeBindings(
+  adapterConfig: unknown,
+  options?: { skipEnvKeys?: ReadonlySet<string> },
+): SubscriptionHomeBinding[] {
+  const config = asRecord(adapterConfig);
+  const env = asRecord(config?.env);
+  if (!env) return [];
+  const bindings: SubscriptionHomeBinding[] = [];
+  for (const envKey of SUBSCRIPTION_HOME_ENV_KEYS) {
+    if (options?.skipEnvKeys?.has(envKey)) continue;
+    const raw = asPlainEnvString(env[envKey]);
+    if (!raw) continue;
+    bindings.push({ envKey, homePath: normalizeSubscriptionHomePath(raw) });
+  }
+  return bindings;
+}
+
+// Conflicts are detected by resolved path, not env key: HOME=/x on one agent
+// and CLAUDE_CONFIG_DIR=/x on another still point both logins at /x.
+export function findSubscriptionHomeConflicts(input: {
+  candidateBindings: readonly SubscriptionHomeBinding[];
+  otherAgents: readonly AgentLike[];
+}): SubscriptionHomeConflict[] {
+  if (input.candidateBindings.length === 0) return [];
+  const conflicts: SubscriptionHomeConflict[] = [];
+  for (const other of input.otherAgents) {
+    if (allowsSharedSubscriptionHome(other.adapterConfig)) continue;
+    const otherBindings = listSubscriptionHomeBindings(other.adapterConfig);
+    if (otherBindings.length === 0) continue;
+    for (const candidate of input.candidateBindings) {
+      for (const otherBinding of otherBindings) {
+        if (candidate.homePath !== otherBinding.homePath) continue;
+        conflicts.push({
+          envKey: candidate.envKey,
+          otherEnvKey: otherBinding.envKey,
+          homePath: candidate.homePath,
+          otherAgentId: other.id,
+          otherAgentName: other.name ?? null,
+          otherAgentStatus: other.status ?? null,
+        });
+      }
+    }
+  }
+  return conflicts;
+}
+
+export async function listOtherActiveAgentsForSubscriptionHomeCheck(
+  db: Db,
+  companyId: string,
+  excludeAgentId: string,
+): Promise<AgentLike[]> {
+  return db
+    .select({
+      id: agents.id,
+      name: agents.name,
+      status: agents.status,
+      adapterConfig: agents.adapterConfig,
+    })
+    .from(agents)
+    .where(
+      and(
+        eq(agents.companyId, companyId),
+        ne(agents.id, excludeAgentId),
+        ne(agents.status, "terminated"),
+      ),
+    );
+}
+
+export function formatSubscriptionHomeConflict(conflictEntry: SubscriptionHomeConflict): string {
+  const otherAgentLabel = conflictEntry.otherAgentName
+    ? `"${conflictEntry.otherAgentName}" (${conflictEntry.otherAgentId})`
+    : conflictEntry.otherAgentId;
+  return (
+    `env ${conflictEntry.envKey} resolves to "${conflictEntry.homePath}", which agent ${otherAgentLabel} ` +
+    `already binds via ${conflictEntry.otherEnvKey}`
+  );
+}

--- a/server/src/services/subscription-home-guard.ts
+++ b/server/src/services/subscription-home-guard.ts
@@ -1,14 +1,16 @@
 import os from "node:os";
 import path from "node:path";
-import { and, eq, ne } from "drizzle-orm";
+import { and, eq, ne, notInArray } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import { agents } from "@paperclipai/db";
 
 // Subscription-scoped auth homes for local CLI adapters. Two active agents
 // resolving the same home means two agents share one provider login, which
 // risks cross-account/credential mixing when the homes belong to different
-// employees (see PAU-263/PAU-281).
+// employees.
 export const SUBSCRIPTION_HOME_ENV_KEYS = ["CODEX_HOME", "CLAUDE_CONFIG_DIR", "HOME"] as const;
+const NON_RUNNABLE_SUBSCRIPTION_HOME_AGENT_STATUSES = ["paused", "pending_approval", "terminated"] as const;
+const nonRunnableSubscriptionHomeAgentStatuses = new Set<string>(NON_RUNNABLE_SUBSCRIPTION_HOME_AGENT_STATUSES);
 
 export type SubscriptionHomeEnvKey = (typeof SUBSCRIPTION_HOME_ENV_KEYS)[number];
 
@@ -63,6 +65,14 @@ export function normalizeSubscriptionHomePath(value: string): string {
   return path.resolve(expanded);
 }
 
+function subscriptionHomeComparisonKey(homePath: string): string {
+  return homePath.toLowerCase();
+}
+
+export function isRunnableSubscriptionHomeAgentStatus(status: string | null | undefined): boolean {
+  return !nonRunnableSubscriptionHomeAgentStatuses.has(status ?? "");
+}
+
 export function allowsSharedSubscriptionHome(adapterConfig: unknown): boolean {
   const config = asRecord(adapterConfig);
   return config?.allowSharedSubscriptionHome === true;
@@ -94,12 +104,15 @@ export function findSubscriptionHomeConflicts(input: {
   if (input.candidateBindings.length === 0) return [];
   const conflicts: SubscriptionHomeConflict[] = [];
   for (const other of input.otherAgents) {
+    if (!isRunnableSubscriptionHomeAgentStatus(other.status)) continue;
     if (allowsSharedSubscriptionHome(other.adapterConfig)) continue;
     const otherBindings = listSubscriptionHomeBindings(other.adapterConfig);
     if (otherBindings.length === 0) continue;
     for (const candidate of input.candidateBindings) {
       for (const otherBinding of otherBindings) {
-        if (candidate.homePath !== otherBinding.homePath) continue;
+        if (subscriptionHomeComparisonKey(candidate.homePath) !== subscriptionHomeComparisonKey(otherBinding.homePath)) {
+          continue;
+        }
         conflicts.push({
           envKey: candidate.envKey,
           otherEnvKey: otherBinding.envKey,
@@ -131,7 +144,7 @@ export async function listOtherActiveAgentsForSubscriptionHomeCheck(
       and(
         eq(agents.companyId, companyId),
         ne(agents.id, excludeAgentId),
-        ne(agents.status, "terminated"),
+        notInArray(agents.status, [...NON_RUNNABLE_SUBSCRIPTION_HOME_AGENT_STATUSES]),
       ),
     );
 }


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agent employees and run their work through local, remote, or sandboxed adapters.
> - Local subscription-backed adapters such as Codex and Claude often depend on a provider auth directory, exposed through env values like `CODEX_HOME`, `CLAUDE_CONFIG_DIR`, or `HOME`.
> - When several agents are active in one company, two agents can accidentally resolve to the same auth home, which silently shares one provider login across people.
> - Sharing can be intentional for several agents owned by the same employee, but accidental sharing across employees is a security and operability risk.
> - Agent create/hire/patch persistence is the right place to reject new conflicting config because it prevents new bad state before runs start.
> - Heartbeat run start still needs a non-fatal warning for already-persisted configs so existing agents are observable without abruptly breaking them.
> - This pull request adds a narrow server-side guard and warning path that compares only explicit plain subscription-home env values and avoids logging secret-derived values.
> - The benefit is safer multi-employee local subscription usage while preserving an explicit opt-in for intentional shared homes.

## Linked Issues or Issue Description

No public GitHub issue exists for this exact runtime-hardening gap, so the issue is described inline as an enhancement proposal.

Related public PRs found during duplicate search:

- #8403 — managed Codex auth into isolated homes; related auth-home work, but does not guard cross-agent duplicate homes.
- #6882 — pins Claude memory/config to an agent-scoped directory; related Claude config isolation, but not a duplicate guard.
- #8499 — seeds managed agent auth homes; related managed auth setup, but not cross-agent conflict detection.

Enhancement proposal fields:

- Pre-submission checklist: I searched existing open and closed PRs for `subscription home`, `CODEX_HOME`, `CLAUDE_CONFIG_DIR`, `allowSharedSubscriptionHome`, and related auth-home terms; I did not find a duplicate PR for this guard.
- What existing behavior does this improve: server-side agent adapter config persistence and heartbeat startup handling for local adapter subscription-home env values.
- Subsystem affected: `server/` — REST API and orchestration services.
- Current behavior: Paperclip can persist or start active agents in the same company whose local adapter config points at the same provider auth home. That can mix provider logins across employees without an obvious warning.
- Proposed behavior: reject newly persisted conflicting active-agent configs unless the adapter config explicitly sets `allowSharedSubscriptionHome: true`, and warn at run start for pre-existing duplicates without aborting those runs.
- Reason and benefit: multi-employee companies can use local subscription-backed adapters with less risk of cross-employee account mixing, while same-employee intentional sharing remains possible.
- Breaking changes: new persistence attempts that duplicate another active agent's explicit plain subscription home now return `409 Conflict` unless explicitly acknowledged. Existing persisted agents keep running and only produce a warning.

## What Changed

- Added `server/src/services/subscription-home-guard.ts` to extract, normalize, compare, and format explicit subscription-home bindings.
- Added unit coverage for plain bindings, secret refs, normalization, cross-key conflicts, case-only path conflicts, non-runnable agents, and sharing opt-in.
- Wired the guard into agent hire/create/patch persistence paths so conflicting active-agent subscription homes are rejected before save.
- Added a heartbeat run-start warning for already-persisted duplicate subscription homes, skipping env keys resolved from secrets so secret-derived values are not logged.
- Tightened review follow-up behavior so paused, pending-approval, and terminated agents do not block homes, while case-only path differences still collide.

## Verification

- `pnpm exec vitest run server/src/__tests__/subscription-home-guard.test.ts` — 1 file, 13 tests passed.
- `pnpm exec vitest run server/src/__tests__/agent-adapter-validation-routes.test.ts server/src/__tests__/heartbeat-project-env.test.ts server/src/__tests__/heartbeat-workspace-session.test.ts` — 3 files, 124 tests passed.
- `pnpm --filter @paperclipai/server typecheck` — exited 0.

## Risks

- Persistence behavior changes for agents that intentionally share one auth home but do not set `adapterConfig.allowSharedSubscriptionHome: true`; the error message names the acknowledgement knob.
- The guard compares explicit plain adapter env values only. Secret refs are intentionally skipped so secret-derived homes are not resolved or logged.
- Path comparison is case-folded to catch shared auth homes on case-insensitive local filesystems; unusual case-sensitive setups that intentionally use case-only distinct auth directories may need distinct non-case-only paths.
- Run-start behavior is warning-only for existing persisted duplicates to avoid breaking active companies during upgrade.
- `ROADMAP.md` has broad local-agent and agent-setup themes, but I did not find a roadmap item that duplicates this narrow runtime-hardening guard.

## Model Used

OpenAI GPT-5 Codex in the Codex coding-agent environment assisted with this change. Tool use was enabled for repository inspection, shell-based verification, git operations, and GitHub CLI PR management; the exact context-window allocation is not surfaced by this environment.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
