### PR TITLE
fix(agent-runtime): ship ripgrep in the base image

### DIFF
--- a/docker/agent-runtime/Dockerfile.base
+++ b/docker/agent-runtime/Dockerfile.base
@@ -19,8 +19,14 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH:-amd64} \
 # Add it when git workspace population lands.
 FROM ubuntu:22.04 AS base
 ARG NODE_VERSION
+# ripgrep (rg): required on PATH so OpenCode's skill tooling uses the system
+# binary instead of trying to download a pinned build from github.com at run
+# time. A sandbox with locked-down egress makes that download hang ~127s then
+# fail ("Transport error ... BurntSushi/ripgrep/releases/..."), wasting run
+# budget on every agent run. The root repo Dockerfile already ships rg; this
+# restores parity for the agent-runtime image.
 RUN apt-get update && apt-get install -y --no-install-recommends \
-      ca-certificates curl git tini gnupg \
+      ca-certificates curl git tini gnupg ripgrep \
     && rm -rf /var/lib/apt/lists/* \
     && curl -fsSL https://deb.nodesource.com/setup_${NODE_VERSION}.x | bash - \
     && apt-get install -y --no-install-recommends nodejs \


### PR DESCRIPTION
## What

Add `ripgrep` to the apt install in `docker/agent-runtime/Dockerfile.base`.

## Why

OpenCode's skill tooling shells out to ripgrep. When `rg` is not on PATH it tries to download a pinned build from github.com at run time. In a sandbox with locked-down egress that download hangs ~127s and then fails (`Transport error ... BurntSushi/ripgrep/releases/download/...`), burning run budget on every agent run before the agent reaches its actual work.

The root repo `Dockerfile` already installs ripgrep; the agent-runtime base image drifted without it. This restores parity so OpenCode uses the system binary and never reaches for the network.

## Change

One line: add `ripgrep` to the existing `apt-get install --no-install-recommends` list, plus an explanatory comment. No behavior change beyond shipping the binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)