### PR TITLE
fix(sandbox-bridge): forward Idempotency-Key + faithful size limit and error mapping

### DIFF
--- a/packages/adapter-utils/src/execution-target.ts
+++ b/packages/adapter-utils/src/execution-target.ts
@@ -1155,22 +1155,67 @@ export async function startAdapterExecutionTargetPaperclipBridge(input: {
         }
         headers.set("authorization", `Bearer ${hostApiToken}`);
         headers.set("x-paperclip-run-id", input.runId);
-        const response = await fetch(buildBridgeForwardUrl(hostApiUrl, request), {
-          method,
-          headers,
-          ...(method === "GET" || method === "HEAD" ? {} : { body: request.body }),
-          signal: AbortSignal.timeout(30_000),
-        });
+        let response: Response;
+        try {
+          response = await fetch(buildBridgeForwardUrl(hostApiUrl, request), {
+            method,
+            headers,
+            ...(method === "GET" || method === "HEAD" ? {} : { body: request.body }),
+            signal: AbortSignal.timeout(30_000),
+          });
+        } catch (error) {
+          // Map fetch failures to a faithful status the in-sandbox agent can act
+          // on, instead of letting them surface as an opaque generic 502. A
+          // timeout in particular is ambiguous on a mutating call ("did my write
+          // land?"), so it must be distinguishable — otherwise the agent tends to
+          // confabulate an outcome.
+          const name = error instanceof Error ? error.name : "";
+          if (name === "TimeoutError" || name === "AbortError") {
+            return {
+              status: 504,
+              headers: { "content-type": "application/json" },
+              body: JSON.stringify({
+                error: "The Paperclip API did not respond within the 30s bridge timeout. The request may or may not have been applied; re-read state before retrying.",
+                code: "bridge_upstream_timeout",
+              }),
+            };
+          }
+          return {
+            status: 502,
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({
+              error: `Bridge could not reach the Paperclip API: ${error instanceof Error ? error.message : String(error)}`,
+              code: "bridge_upstream_unreachable",
+            }),
+          };
+        }
         if (bridgeDebugEnabled) {
           await onLog(
             "stdout",
             `[paperclip] Bridge proxy response ${response.status} for ${method} ${request.path}${request.query ? `?${request.query}` : ""}\n`,
           );
         }
+        let body: string;
+        try {
+          body = await readBridgeForwardResponseBody(response, maxBodyBytes);
+        } catch (error) {
+          // Oversized response body: surface a clear 413 (not a generic 502) so
+          // the agent knows the call succeeded server-side but the payload was
+          // too large to relay, rather than assuming the operation failed.
+          return {
+            status: 413,
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({
+              error: error instanceof Error ? error.message : String(error),
+              code: "bridge_response_too_large",
+              upstreamStatus: response.status,
+            }),
+          };
+        }
         return {
           status: response.status,
           headers: buildBridgeResponseHeaders(response),
-          body: await readBridgeForwardResponseBody(response, maxBodyBytes),
+          body,
         };
       },
     });

--- a/packages/adapter-utils/src/sandbox-callback-bridge.test.ts
+++ b/packages/adapter-utils/src/sandbox-callback-bridge.test.ts
@@ -205,6 +205,7 @@ describe("sandbox callback bridge", () => {
         authorization: `Bearer ${bridgeToken}`,
         accept: "application/json",
         "if-none-match": '"client-cache-key"',
+        "idempotency-key": "hire-once-123",
         "x-paperclip-run-id": "run-bridge-1",
         "x-bridge-debug": "drop-me",
       },
@@ -251,6 +252,10 @@ describe("sandbox callback bridge", () => {
       headers: {
         accept: "application/json",
         "if-none-match": '"client-cache-key"',
+        // Idempotency-Key must survive the header allowlist so agent retries of
+        // mutating calls (e.g. routine runs, hires) dedupe server-side instead
+        // of double-executing.
+        "idempotency-key": "hire-once-123",
       },
     });
     expect(seenRequests[0]?.headers.authorization).toBeUndefined();

--- a/packages/adapter-utils/src/sandbox-callback-bridge.ts
+++ b/packages/adapter-utils/src/sandbox-callback-bridge.ts
@@ -12,7 +12,13 @@ const DEFAULT_BRIDGE_POLL_INTERVAL_MS = 100;
 const DEFAULT_BRIDGE_RESPONSE_TIMEOUT_MS = 30_000;
 const DEFAULT_BRIDGE_STOP_TIMEOUT_MS = 2_000;
 const DEFAULT_BRIDGE_MAX_QUEUE_DEPTH = 64;
-const DEFAULT_BRIDGE_MAX_BODY_BYTES = 256 * 1024;
+// Must comfortably exceed the largest legitimate request/response an in-sandbox
+// agent exchanges over the bridge. Issue documents (plans/specs) allow a 512KB
+// body (upsertIssueDocumentSchema: z.string().max(524288)); a PUT wraps that in
+// a JSON envelope and a GET returns it with metadata, so 256KB rejected real
+// document reads/writes with an opaque 502. 1MB covers a max document plus its
+// JSON envelope with margin; the queue protocol already base64-chunks large bodies.
+const DEFAULT_BRIDGE_MAX_BODY_BYTES = 1024 * 1024;
 const REMOTE_WRITE_BASE64_CHUNK_SIZE = 32 * 1024;
 const SANDBOX_CALLBACK_BRIDGE_ENTRYPOINT = "paperclip-bridge-server.mjs";
 const SANDBOX_EXEC_CHANNEL_ENV = "PAPERCLIP_SANDBOX_EXEC_CHANNEL";
@@ -102,6 +108,9 @@ export const DEFAULT_SANDBOX_CALLBACK_BRIDGE_HEADER_ALLOWLIST = [
   "content-type",
   "if-match",
   "if-none-match",
+  // Exactly-once semantics for retried mutating calls (e.g. routine runs, hires).
+  // Without this the server can't dedupe an agent's retry and may double-execute.
+  "idempotency-key",
 ] as const;
 
 export interface SandboxCallbackBridgeRequest {


### PR DESCRIPTION
## What

Three faithfulness fixes to the sandbox callback bridge so documented agent flows dedupe correctly and fail transparently instead of opaquely.

### 1. Forward `Idempotency-Key` through the bridge

The header allowlist (`DEFAULT_SANDBOX_CALLBACK_BRIDGE_HEADER_ALLOWLIST`) stripped every header except `accept`/`content-type`/`if-match`/`if-none-match`. Agents are documented to send an `Idempotency-Key` on mutating calls (e.g. `POST /api/routines/:id/run`) so that a retry after a mid-flight failure dedupes server-side instead of executing twice. With the header stripped, a retried hire or routine run could double-execute. This adds `idempotency-key` to the allowlist. `authorization` and `x-paperclip-run-id` remain host-injected, not agent-supplied.

### 2. Body-size cap 256KB -> 1MB

Issue documents (plans/specs) allow a 512KB body (`upsertIssueDocumentSchema: z.string().max(524288)`). A PUT wraps that in a JSON envelope and a GET returns it with metadata, so the old 256KB cap rejected real document reads/writes with an opaque 502. 1MB covers a max document plus its JSON envelope with margin; the queue protocol already base64-chunks large bodies.

### 3. Host-proxy error mapping

A fetch timeout or oversized response previously threw into the worker's generic 502 with a vague message. Now:

- **AbortSignal timeout -> 504** `bridge_upstream_timeout`, with a clear "may or may not have applied; re-read state before retrying" body. A timeout on a mutating call is ambiguous, and an agent that can't tell a timeout from a failure tends to confabulate an outcome.
- **Oversized response body -> 413** `bridge_response_too_large` (the call succeeded server-side, the payload was too large to relay) instead of implying the operation failed.
- **Other unreachable errors -> 502** `bridge_upstream_unreachable`, with the underlying message.

## Tests

`packages/adapter-utils/src/sandbox-callback-bridge.test.ts` asserts `idempotency-key` now reaches the handler while host-injected headers stay stripped.

- `npx tsc -p packages/adapter-utils/tsconfig.json --noEmit` -> exit 0
- `npx vitest run packages/adapter-utils/src/sandbox-callback-bridge.test.ts` -> 13 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)