### PR TITLE
Redact sensitive query parameters from HTTP logs

### DIFF
--- a/server/src/__tests__/logger-redaction.test.ts
+++ b/server/src/__tests__/logger-redaction.test.ts
@@ -1,0 +1,120 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockTransport = vi.hoisted(() => vi.fn(() => ({ write: vi.fn() })));
+const mockPino = vi.hoisted(() => {
+  const fn = vi.fn(() => ({
+    info: vi.fn(),
+    debug: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+    child: vi.fn(),
+  }));
+  (fn as any).transport = mockTransport;
+  (fn as any).stdSerializers = {
+    req: vi.fn((req: any) => ({
+      id: req.id,
+      method: req.method,
+      url: req.url,
+      headers: req.headers,
+    })),
+  };
+  return fn;
+});
+const mockPinoHttp = vi.hoisted(() => vi.fn(() => vi.fn()));
+
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  return { ...actual, mkdirSync: vi.fn() };
+});
+
+vi.mock("pino", () => ({
+  default: mockPino,
+}));
+
+vi.mock("pino-http", () => ({
+  pinoHttp: mockPinoHttp,
+}));
+
+vi.mock("../config-file.js", () => ({
+  readConfigFile: vi.fn(() => null),
+}));
+
+vi.mock("../home-paths.js", () => ({
+  resolveHomeAwarePath: vi.fn((p: string) => p),
+  resolveDefaultLogsDir: vi.fn(() => "/tmp/paperclip-test-logs"),
+}));
+
+describe("HTTP logger redaction", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  async function loadHttpLoggerOptions() {
+    await import("../middleware/logger.js");
+    expect(mockPinoHttp).toHaveBeenCalledOnce();
+    return mockPinoHttp.mock.calls[0][0] as any;
+  }
+
+  it("redacts CLI auth challenge tokens from success and error messages", async () => {
+    const options = await loadHttpLoggerOptions();
+    const req = {
+      method: "GET",
+      url: "/api/cli-auth/challenges/challenge-1?token=pcp_cli_auth_test_secret&after=1",
+    } as any;
+    const res = { statusCode: 200 } as any;
+
+    const successMessage = options.customSuccessMessage(req, res);
+    const errorMessage = options.customErrorMessage(req, { ...res, statusCode: 404 }, new Error("not found"));
+
+    expect(successMessage).toContain("token=[REDACTED]");
+    expect(successMessage).toContain("after=1");
+    expect(successMessage).not.toContain("pcp_cli_auth_test_secret");
+    expect(errorMessage).toContain("token=[REDACTED]");
+    expect(errorMessage).not.toContain("pcp_cli_auth_test_secret");
+  });
+
+  it("redacts sensitive query values from the structured request url", async () => {
+    const options = await loadHttpLoggerOptions();
+    const redirectUri = encodeURIComponent("https://example.test/callback?token=nested-secret&ok=1");
+    const serializedReq = options.serializers.req({
+      id: "req-1",
+      method: "GET",
+      url: `/api/example?access_token=secret-access-token&token=pcp_cli_auth_test_secret&token%5B%5D=bracket-secret&auth%5Btoken%5D=nested-bracket-secret&cursor=2&redirect_uri=${redirectUri}`,
+      headers: {},
+    });
+
+    expect(serializedReq.url).toContain("access_token=[REDACTED]");
+    expect(serializedReq.url).toContain("token=[REDACTED]");
+    expect(serializedReq.url).toContain("token%5B%5D=[REDACTED]");
+    expect(serializedReq.url).toContain("auth%5Btoken%5D=[REDACTED]");
+    expect(serializedReq.url).toContain("redirect_uri=[REDACTED]");
+    expect(serializedReq.url).toContain("cursor=2");
+    expect(serializedReq.url).not.toContain("secret-access-token");
+    expect(serializedReq.url).not.toContain("pcp_cli_auth_test_secret");
+    expect(serializedReq.url).not.toContain("bracket-secret");
+    expect(serializedReq.url).not.toContain("nested-bracket-secret");
+    expect(serializedReq.url).not.toContain("nested-secret");
+  });
+
+  it("redacts token query fields from error custom props", async () => {
+    const options = await loadHttpLoggerOptions();
+    const props = options.customProps({
+      query: {
+        token: "pcp_cli_auth_test_secret",
+        "token[]": "bracket-secret",
+        "auth[token]": "nested-bracket-secret",
+        redirect_uri: "https://example.test/callback?access_token=nested-secret&ok=1",
+        cursor: "2",
+      },
+    } as any, { statusCode: 404 } as any);
+
+    expect(props.reqQuery).toEqual({
+      token: "[REDACTED]",
+      "token[]": "[REDACTED]",
+      "auth[token]": "[REDACTED]",
+      redirect_uri: "[REDACTED]",
+      cursor: "2",
+    });
+  });
+});

--- a/server/src/middleware/logger.ts
+++ b/server/src/middleware/logger.ts
@@ -7,6 +7,139 @@ import { resolveDefaultLogsDir, resolveHomeAwarePath } from "../home-paths.js";
 import { shouldSilenceHttpSuccessLog } from "./http-log-policy.js";
 import { redactSensitive } from "./redact-sensitive.js";
 
+const REDACTED_QUERY_VALUE = "[REDACTED]";
+const CLI_AUTH_TOKEN_PREFIX = "pcp_cli_auth_";
+const SENSITIVE_QUERY_KEYS = new Set([
+  "accesstoken",
+  "apikey",
+  "authorization",
+  "authtoken",
+  "clientsecret",
+  "idtoken",
+  "refreshtoken",
+  "secret",
+  "sessiontoken",
+  "token",
+]);
+
+function decodeQueryComponent(value: string): string {
+  try {
+    return decodeURIComponent(value.replace(/\+/g, " "));
+  } catch {
+    return value;
+  }
+}
+
+function normalizeQueryKey(key: string): string {
+  return decodeQueryComponent(key).replace(/[-_]/g, "").toLowerCase();
+}
+
+function queryKeyCandidates(key: string): string[] {
+  const decodedKey = decodeQueryComponent(key);
+  const candidates = [decodedKey.replace(/\[[^\]]*\]/g, "")];
+  for (const match of decodedKey.matchAll(/\[([^\]]*)\]/g)) {
+    if (match[1]) candidates.push(match[1]);
+  }
+  return candidates.map(normalizeQueryKey).filter(Boolean);
+}
+
+function isSensitiveQueryKey(key: string): boolean {
+  return queryKeyCandidates(key).some((candidate) => SENSITIVE_QUERY_KEYS.has(candidate));
+}
+
+function valueContainsSensitiveQueryKey(value: string): boolean {
+  const decodedValue = decodeQueryComponent(value);
+  const queryKeyPattern = /(?:^|[?&#])([^=&#?]+)=/g;
+  let match: RegExpExecArray | null;
+  while ((match = queryKeyPattern.exec(decodedValue)) !== null) {
+    if (isSensitiveQueryKey(match[1])) return true;
+  }
+  return false;
+}
+
+function isSensitiveQuerySegment(rawKey: string, rawValue: string): boolean {
+  const decodedValue = decodeQueryComponent(rawValue);
+  return isSensitiveQueryKey(rawKey) ||
+    rawValue.includes(CLI_AUTH_TOKEN_PREFIX) ||
+    decodedValue.includes(CLI_AUTH_TOKEN_PREFIX) ||
+    valueContainsSensitiveQueryKey(rawValue);
+}
+
+function queryValueContainsSensitiveToken(value: unknown, depth = 0): boolean {
+  if (depth > 6) return false;
+  if (typeof value === "string") {
+    return value.includes(CLI_AUTH_TOKEN_PREFIX) ||
+      decodeQueryComponent(value).includes(CLI_AUTH_TOKEN_PREFIX) ||
+      valueContainsSensitiveQueryKey(value);
+  }
+  if (Array.isArray(value)) {
+    return value.some((entry) => queryValueContainsSensitiveToken(entry, depth + 1));
+  }
+  if (value && typeof value === "object") {
+    return Object.values(value as Record<string, unknown>)
+      .some((entry) => queryValueContainsSensitiveToken(entry, depth + 1));
+  }
+  return false;
+}
+
+function redactHttpLogQuery(value: unknown, depth = 0): unknown {
+  if (depth > 6) return undefined;
+  if (value === null || typeof value !== "object") {
+    return queryValueContainsSensitiveToken(value) ? REDACTED_QUERY_VALUE : value;
+  }
+  if (Array.isArray(value)) {
+    return value.map((entry) => redactHttpLogQuery(entry, depth + 1));
+  }
+  const out: Record<string, unknown> = {};
+  for (const [key, entry] of Object.entries(value as Record<string, unknown>)) {
+    if (isSensitiveQueryKey(key) || queryValueContainsSensitiveToken(entry)) {
+      out[key] = REDACTED_QUERY_VALUE;
+      continue;
+    }
+    out[key] = redactHttpLogQuery(entry, depth + 1);
+  }
+  return out;
+}
+
+function redactQueryString(query: string): string {
+  return query
+    .split("&")
+    .map((segment) => {
+      if (segment.length === 0) return segment;
+      const equalsIndex = segment.indexOf("=");
+      const rawKey = equalsIndex >= 0 ? segment.slice(0, equalsIndex) : segment;
+      const rawValue = equalsIndex >= 0 ? segment.slice(equalsIndex + 1) : "";
+      return isSensitiveQuerySegment(rawKey, rawValue) ? `${rawKey}=${REDACTED_QUERY_VALUE}` : segment;
+    })
+    .join("&");
+}
+
+export function redactHttpLogUrl(rawUrl: string | undefined): string | undefined {
+  if (!rawUrl) return rawUrl;
+  const hashIndex = rawUrl.indexOf("#");
+  const beforeHash = hashIndex >= 0 ? rawUrl.slice(0, hashIndex) : rawUrl;
+  const hash = hashIndex >= 0 ? rawUrl.slice(hashIndex) : "";
+  const queryIndex = beforeHash.indexOf("?");
+  if (queryIndex < 0) return rawUrl;
+  const path = beforeHash.slice(0, queryIndex);
+  const query = beforeHash.slice(queryIndex + 1);
+  return `${path}?${redactQueryString(query)}${hash}`;
+}
+
+function serializeRequestForLog(req: unknown): Record<string, unknown> {
+  const stdReqSerializer = pino.stdSerializers?.req;
+  const serialized = stdReqSerializer
+    ? (stdReqSerializer(req as any) as unknown as Record<string, unknown>)
+    : { ...(req as Record<string, unknown>) };
+  if (typeof serialized.url === "string") {
+    serialized.url = redactHttpLogUrl(serialized.url);
+  }
+  if (serialized.query && typeof serialized.query === "object") {
+    serialized.query = redactHttpLogQuery(serialized.query);
+  }
+  return serialized;
+}
+
 function resolveServerLogDir(): string {
   const envOverride = process.env.PAPERCLIP_LOG_DIR?.trim();
   if (envOverride) return resolveHomeAwarePath(envOverride);
@@ -48,6 +181,9 @@ export const logger = pino({
 
 export const httpLogger = pinoHttp({
   logger,
+  serializers: {
+    req: serializeRequestForLog,
+  },
   customLogLevel(_req, res, err) {
     if (shouldSilenceHttpSuccessLog(_req.method, _req.url, res.statusCode)) {
       return "silent";
@@ -57,12 +193,12 @@ export const httpLogger = pinoHttp({
     return "info";
   },
   customSuccessMessage(req, res) {
-    return `${req.method} ${req.url} ${res.statusCode}`;
+    return `${req.method} ${redactHttpLogUrl(req.url)} ${res.statusCode}`;
   },
   customErrorMessage(req, res, err) {
     const ctx = (res as any).__errorContext;
     const errMsg = ctx?.error?.message || err?.message || (res as any).err?.message || "unknown error";
-    return `${req.method} ${req.url} ${res.statusCode} — ${errMsg}`;
+    return `${req.method} ${redactHttpLogUrl(req.url)} ${res.statusCode} — ${errMsg}`;
   },
   customProps(req, res) {
     if (res.statusCode >= 400) {
@@ -72,7 +208,7 @@ export const httpLogger = pinoHttp({
           errorContext: ctx.error,
           reqBody: redactSensitive(ctx.reqBody),
           reqParams: redactSensitive(ctx.reqParams),
-          reqQuery: redactSensitive(ctx.reqQuery),
+          reqQuery: redactHttpLogQuery(ctx.reqQuery),
         };
       }
       const props: Record<string, unknown> = {};
@@ -84,7 +220,7 @@ export const httpLogger = pinoHttp({
         props.reqParams = redactSensitive(params);
       }
       if (query && typeof query === "object" && Object.keys(query).length > 0) {
-        props.reqQuery = redactSensitive(query);
+        props.reqQuery = redactHttpLogQuery(query);
       }
       if ((req as any).route?.path) {
         props.routePath = (req as any).route.path;


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The server logs HTTP requests through `pino-http` so operators can diagnose API and UI traffic
> - Some authentication flows and integrations can place short-lived secrets in query parameters
> - The logger redacted selected structured fields, but raw `req.url` still appeared in success/error messages and the serialized request object
> - This meant query parameters such as `token`, `token[]`, `auth[token]`, `access_token`, or nested callback URL tokens could be written to stdout or `server.log`
> - This pull request redacts sensitive query values at the HTTP logging boundary
> - The benefit is safer operator logs without changing route behavior or request handling

## Bug Report

No public GitHub issue was found for this exact bug after searching issues and PRs for `log redaction query token`, `cli-auth token log`, and `req.url token redaction`.

### Pre-submission checklist

- [x] I have searched existing open and closed issues and this is not a duplicate.
- [x] I am on the latest released version of Paperclip or can reproduce on `master`.
- [x] I have confirmed the error originates in Paperclip itself, not in an agent adapter, API provider, or local configuration.

### What happened?

HTTP request logs can include raw query-string values in `req.url`, including secret-like query parameters such as `token`, `token[]`, `auth[token]`, `access_token`, and nested callback URL values like `redirect_uri=https://example.test/callback?token=...`.

### Expected behavior

HTTP logs should preserve useful path and non-sensitive query context while replacing sensitive query values with `[REDACTED]`.

### Steps to reproduce

1. Run the server from an affected commit.
2. Send a request to any application route with a query string such as `?token=pcp_cli_auth_example&cursor=2`.
3. Send a second request with bracketed query keys such as `?token[]=secret&auth[token]=secret`.
4. Send a third request with a nested callback URL such as `?redirect_uri=https%3A%2F%2Fexample.test%2Fcallback%3Ftoken%3Dnested-secret%26ok%3D1`.
5. Inspect HTTP log output. On affected code, raw token values appear in message text and structured `req.url` / error query props.

### Paperclip version or commit

Observed against current `master` before this branch.

### Deployment mode

Self-hosted server. The issue also applies to local trusted and authenticated deployments because the HTTP logging middleware is shared.

### Installation method

npm / pnpm global install or built from source.

### Agent adapter(s) involved

Not adapter-specific (core bug).

### Database mode

Not database-related.

### Access context

Unclear / not applicable. This is request logging behavior, independent of the authenticated actor.

### Relevant logs or output

Synthetic example only; no live tokens included:

```text
GET /api/example?token=pcp_cli_auth_example&cursor=2
```

Affected builds can write the raw token value to HTTP logs. This PR changes that to:

```text
GET /api/example?token=[REDACTED]&cursor=2
```

### Relevant config (if applicable)

Not config-related.

### Additional context

The fix redacts at the logging boundary only; request routing and route handlers still receive the original request.

### Privacy checklist

- [x] I have reviewed all pasted output for PII, file paths, API keys, tokens, company names, and redacted where necessary.

## What Changed

- Added HTTP log URL redaction for sensitive query parameter names, including `token`, bracketed token forms, `access_token`, `refresh_token`, API key and secret variants.
- Redacts values matching the CLI auth token prefix even when the parameter name is not itself sensitive.
- Redacts query values containing nested callback URLs with sensitive nested query keys.
- Applies the redacted URL to pino-http success/error messages and the structured request serializer.
- Extends error custom-prop redaction so `reqQuery.token`, bracketed token keys, and nested query-bearing values are redacted alongside existing sensitive fields.
- Added focused regression tests for message text, structured `req.url`, nested callback query values, bracketed query keys, and error `reqQuery` redaction.

## Verification

From `server/`:

```sh
pnpm exec vitest run --config vitest.config.ts src/__tests__/logger-redaction.test.ts
pnpm exec vitest run --config vitest.config.ts src/__tests__/logger-redaction.test.ts src/__tests__/logger-tz.test.ts src/__tests__/http-log-policy.test.ts src/__tests__/redact-sensitive.test.ts
```

From repo root:

```sh
pnpm --filter @paperclipai/server typecheck
```

All listed commands passed locally.

## Risks

Low risk. This only changes log serialization/message text, not request routing or handler input. The main behavior shift is that benign query parameters named `token` or common secret-like names will be hidden in logs, which is preferable for safety.

## Model Used

OpenAI GPT-5 Codex, tool-using coding agent in a local shell environment. Used repository search, targeted Vitest runs, TypeScript typecheck, local runtime probes, and git/GitHub CLI tooling.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge
