### PR TITLE
fix: suppress terminal routine issue noise

### DIFF
--- a/cli/src/__tests__/issue-subresources.test.ts
+++ b/cli/src/__tests__/issue-subresources.test.ts
@@ -61,6 +61,36 @@ describe("issue subresource commands", () => {
     ]);
   });
 
+  it("reads issue update comments and interaction payloads from files", async () => {
+    const tmp = await mkdtemp(join(tmpdir(), "paperclip-cli-issue-files-"));
+    const commentPath = join(tmp, "comment.md");
+    const payloadPath = join(tmp, "interaction.json");
+    const fetchMock = vi.fn().mockImplementation(() => Promise.resolve(jsonResponse()));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await writeFile(commentPath, "Line 1\n\n- bullet\n", "utf8");
+    await writeFile(payloadPath, JSON.stringify({
+      kind: "request_confirmation",
+      payload: { version: 1, prompt: "Ship it?" },
+    }), "utf8");
+
+    try {
+      await run(["issue", "update", ISSUE_ID, "--status", "in_review", "--comment-file", commentPath]);
+      await run(["issue", "interaction:create", ISSUE_ID, "--payload-file", payloadPath]);
+    } finally {
+      await rm(tmp, { recursive: true, force: true });
+    }
+
+    expect(JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body))).toEqual({
+      status: "in_review",
+      comment: "Line 1\n\n- bullet\n",
+    });
+    expect(JSON.parse(String(fetchMock.mock.calls[1]?.[1]?.body))).toMatchObject({
+      kind: "request_confirmation",
+      payload: { version: 1, prompt: "Ship it?" },
+    });
+  });
+
   it("wraps comments, approvals, markers, and recovery action endpoints", async () => {
     const fetchMock = vi
       .fn()

--- a/cli/src/commands/client/issue.ts
+++ b/cli/src/commands/client/issue.ts
@@ -75,6 +75,7 @@ interface IssueUpdateOptions extends BaseClientOptions {
   requestDepth?: string;
   billingCode?: string;
   comment?: string;
+  commentFile?: string;
   hiddenAt?: string;
 }
 
@@ -112,7 +113,8 @@ interface IssueDeleteOptions extends BaseClientOptions {
 }
 
 interface JsonPayloadOptions extends BaseClientOptions {
-  payloadJson: string;
+  payloadJson?: string;
+  payloadFile?: string;
 }
 
 interface IssueDocumentPutOptions extends BaseClientOptions {
@@ -328,6 +330,7 @@ export function registerIssueCommands(program: Command): void {
       .option("--request-depth <n>", "Request depth integer")
       .option("--billing-code <code>", "Billing code")
       .option("--comment <text>", "Optional comment to add with update")
+      .option("--comment-file <path>", "Read update comment from a file")
       .option("--hidden-at <iso8601|null>", "Set hiddenAt timestamp or literal 'null'")
       .action(async (issueId: string, opts: IssueUpdateOptions) => {
         try {
@@ -343,7 +346,12 @@ export function registerIssueCommands(program: Command): void {
             parentId: opts.parentId,
             requestDepth: parseOptionalInt(opts.requestDepth),
             billingCode: opts.billingCode,
-            comment: opts.comment,
+            comment: await readOptionalTextInput({
+              inlineValue: opts.comment,
+              filePath: opts.commentFile,
+              inlineLabel: "--comment",
+              fileLabel: "--comment-file",
+            }),
             hiddenAt: parseHiddenAt(opts.hiddenAt),
           });
 
@@ -542,11 +550,12 @@ export function registerIssueCommands(program: Command): void {
       .command("child:create")
       .description("Create a child issue from a JSON payload")
       .argument("<issueId>", "Parent issue ID")
-      .requiredOption("--payload-json <json>", "CreateChildIssue JSON payload")
+      .option("--payload-json <json>", "CreateChildIssue JSON payload")
+      .option("--payload-file <path>", "Read CreateChildIssue JSON payload from a file")
       .action(async (issueId: string, opts: JsonPayloadOptions) => {
         try {
           const ctx = resolveCommandContext(opts);
-          const payload = createChildIssueSchema.parse(parseJson(opts.payloadJson));
+          const payload = createChildIssueSchema.parse(await readJsonPayloadInput(opts));
           const child = await ctx.api.post<Issue>(apiPath`/api/issues/${issueId}/children`, payload);
           printOutput(child, { json: ctx.json });
         } catch (err) {
@@ -592,11 +601,12 @@ export function registerIssueCommands(program: Command): void {
       .command("work-product:create")
       .description("Create an issue work product from JSON")
       .argument("<issueId>", "Issue ID")
-      .requiredOption("--payload-json <json>", "CreateIssueWorkProduct JSON payload")
+      .option("--payload-json <json>", "CreateIssueWorkProduct JSON payload")
+      .option("--payload-file <path>", "Read CreateIssueWorkProduct JSON payload from a file")
       .action(async (issueId: string, opts: JsonPayloadOptions) => {
         try {
           const ctx = resolveCommandContext(opts);
-          const payload = createIssueWorkProductSchema.parse(parseJson(opts.payloadJson));
+          const payload = createIssueWorkProductSchema.parse(await readJsonPayloadInput(opts));
           const product = await ctx.api.post(apiPath`/api/issues/${issueId}/work-products`, payload);
           printOutput(product, { json: ctx.json });
         } catch (err) {
@@ -610,11 +620,12 @@ export function registerIssueCommands(program: Command): void {
       .command("work-product:update")
       .description("Update a work product from JSON")
       .argument("<workProductId>", "Work product ID")
-      .requiredOption("--payload-json <json>", "UpdateIssueWorkProduct JSON payload")
+      .option("--payload-json <json>", "UpdateIssueWorkProduct JSON payload")
+      .option("--payload-file <path>", "Read UpdateIssueWorkProduct JSON payload from a file")
       .action(async (workProductId: string, opts: JsonPayloadOptions) => {
         try {
           const ctx = resolveCommandContext(opts);
-          const payload = updateIssueWorkProductSchema.parse(parseJson(opts.payloadJson));
+          const payload = updateIssueWorkProductSchema.parse(await readJsonPayloadInput(opts));
           const product = await ctx.api.patch(apiPath`/api/work-products/${workProductId}`, payload);
           printOutput(product, { json: ctx.json });
         } catch (err) {
@@ -726,11 +737,12 @@ export function registerIssueCommands(program: Command): void {
       .command("interaction:create")
       .description("Create an issue thread interaction from JSON")
       .argument("<issueId>", "Issue ID")
-      .requiredOption("--payload-json <json>", "CreateIssueThreadInteraction JSON payload")
+      .option("--payload-json <json>", "CreateIssueThreadInteraction JSON payload")
+      .option("--payload-file <path>", "Read CreateIssueThreadInteraction JSON payload from a file")
       .action(async (issueId: string, opts: JsonPayloadOptions) => {
         try {
           const ctx = resolveCommandContext(opts);
-          const payload = createIssueThreadInteractionSchema.parse(parseJson(opts.payloadJson));
+          const payload = createIssueThreadInteractionSchema.parse(await readJsonPayloadInput(opts));
           const interaction = await ctx.api.post(apiPath`/api/issues/${issueId}/interactions`, payload);
           printOutput(interaction, { json: ctx.json });
         } catch (err) {
@@ -830,11 +842,12 @@ export function registerIssueCommands(program: Command): void {
       .command("tree-preview")
       .description("Preview issue tree control changes")
       .argument("<issueId>", "Root issue ID")
-      .requiredOption("--payload-json <json>", "PreviewIssueTreeControl JSON payload")
+      .option("--payload-json <json>", "PreviewIssueTreeControl JSON payload")
+      .option("--payload-file <path>", "Read PreviewIssueTreeControl JSON payload from a file")
       .action(async (issueId: string, opts: JsonPayloadOptions) => {
         try {
           const ctx = resolveCommandContext(opts);
-          const payload = previewIssueTreeControlSchema.parse(parseJson(opts.payloadJson));
+          const payload = previewIssueTreeControlSchema.parse(await readJsonPayloadInput(opts));
           const preview = await ctx.api.post(apiPath`/api/issues/${issueId}/tree-control/preview`, payload);
           printOutput(preview, { json: ctx.json });
         } catch (err) {
@@ -872,11 +885,12 @@ export function registerIssueCommands(program: Command): void {
       .command("tree-hold:create")
       .description("Create an issue tree hold from JSON")
       .argument("<issueId>", "Root issue ID")
-      .requiredOption("--payload-json <json>", "CreateIssueTreeHold JSON payload")
+      .option("--payload-json <json>", "CreateIssueTreeHold JSON payload")
+      .option("--payload-file <path>", "Read CreateIssueTreeHold JSON payload from a file")
       .action(async (issueId: string, opts: JsonPayloadOptions) => {
         try {
           const ctx = resolveCommandContext(opts);
-          const payload = createIssueTreeHoldSchema.parse(parseJson(opts.payloadJson));
+          const payload = createIssueTreeHoldSchema.parse(await readJsonPayloadInput(opts));
           const hold = await ctx.api.post(apiPath`/api/issues/${issueId}/tree-holds`, payload);
           printOutput(hold, { json: ctx.json });
         } catch (err) {
@@ -908,11 +922,12 @@ export function registerIssueCommands(program: Command): void {
       .description("Release an issue tree hold")
       .argument("<issueId>", "Root issue ID")
       .argument("<holdId>", "Hold ID")
-      .option("--payload-json <json>", "ReleaseIssueTreeHold JSON payload", "{}")
+      .option("--payload-json <json>", "ReleaseIssueTreeHold JSON payload")
+      .option("--payload-file <path>", "Read ReleaseIssueTreeHold JSON payload from a file")
       .action(async (issueId: string, holdId: string, opts: JsonPayloadOptions) => {
         try {
           const ctx = resolveCommandContext(opts);
-          const payload = releaseIssueTreeHoldSchema.parse(parseJson(opts.payloadJson));
+          const payload = releaseIssueTreeHoldSchema.parse(await readJsonPayloadInput(opts, "{}"));
           const hold = await ctx.api.post(apiPath`/api/issues/${issueId}/tree-holds/${holdId}/release`, payload);
           printOutput(hold, { json: ctx.json });
         } catch (err) {
@@ -1076,11 +1091,12 @@ export function registerIssueCommands(program: Command): void {
       .command("feedback:vote")
       .description("Create or update a feedback vote")
       .argument("<issueId>", "Issue ID")
-      .requiredOption("--payload-json <json>", "UpsertIssueFeedbackVote JSON payload")
+      .option("--payload-json <json>", "UpsertIssueFeedbackVote JSON payload")
+      .option("--payload-file <path>", "Read UpsertIssueFeedbackVote JSON payload from a file")
       .action(async (issueId: string, opts: JsonPayloadOptions) => {
         try {
           const ctx = resolveCommandContext(opts);
-          const payload = upsertIssueFeedbackVoteSchema.parse(parseJson(opts.payloadJson));
+          const payload = upsertIssueFeedbackVoteSchema.parse(await readJsonPayloadInput(opts));
           const vote = await ctx.api.post(apiPath`/api/issues/${issueId}/feedback-votes`, payload);
           printOutput(vote, { json: ctx.json });
         } catch (err) {
@@ -1355,6 +1371,40 @@ function addIssuePostDeleteMarkerCommand(
 
 function parseJson(value: string): unknown {
   return JSON.parse(value) as unknown;
+}
+
+async function readOptionalTextInput({
+  inlineValue,
+  filePath,
+  inlineLabel,
+  fileLabel,
+}: {
+  inlineValue: string | undefined;
+  filePath: string | undefined;
+  inlineLabel: string;
+  fileLabel: string;
+}): Promise<string | undefined> {
+  if (inlineValue !== undefined && filePath !== undefined) {
+    throw new Error(`Pass either ${inlineLabel} or ${fileLabel}, not both.`);
+  }
+  if (filePath !== undefined) {
+    return await readFile(filePath, "utf8");
+  }
+  return inlineValue;
+}
+
+async function readJsonPayloadInput(opts: JsonPayloadOptions, fallbackJson?: string): Promise<unknown> {
+  const source = await readOptionalTextInput({
+    inlineValue: opts.payloadJson,
+    filePath: opts.payloadFile,
+    inlineLabel: "--payload-json",
+    fileLabel: "--payload-file",
+  });
+  const resolved = source ?? fallbackJson;
+  if (resolved === undefined) {
+    throw new Error("Pass --payload-json or --payload-file.");
+  }
+  return parseJson(resolved);
 }
 
 function parseOptionalInt(value: string | undefined): number | undefined {

--- a/scripts/paperclip-cli-safe.py
+++ b/scripts/paperclip-cli-safe.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+
+"""Safely materialize multiline text and JSON for paperclipai CLI calls."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+USAGE = """Usage:
+  scripts/paperclip-cli-safe.py [--dry-run] <paperclipai args...>
+
+Supported file-backed flags:
+  --comment-file <path|->
+  --payload-file <path|->
+  --body-file <path|->
+"""
+
+
+def fail(message: str) -> int:
+    print(message, file=sys.stderr)
+    return 1
+
+
+def read_stdin_once(cache: dict[str, str | None]) -> str:
+    if cache["value"] is None:
+        cache["value"] = sys.stdin.read()
+    return cache["value"] or ""
+
+
+def materialize_tempfile(body: str, suffix: str) -> str:
+    handle = tempfile.NamedTemporaryFile(mode="w", encoding="utf-8", delete=False, suffix=suffix)
+    try:
+        handle.write(body)
+    finally:
+        handle.close()
+    return handle.name
+
+
+def cleanup_temp_paths(paths: list[str]) -> None:
+    for path in paths:
+        try:
+            os.unlink(path)
+        except FileNotFoundError:
+            pass
+
+
+def resolve_paperclip_command() -> list[str]:
+    repo_path = os.environ.get("PAPERCLIP_REPO", "")
+    env_file = Path(os.environ.get("PAPERCLIP_ENV_FILE", Path.home() / ".paperclip" / "paperclip-host.env"))
+
+    if not repo_path and env_file.is_file():
+        for line in env_file.read_text(encoding="utf-8").splitlines():
+            if line.startswith("PAPERCLIP_REPO="):
+                repo_path = line.split("=", 1)[1]
+
+    if repo_path:
+        repo = Path(repo_path)
+        tsx = repo / "cli" / "node_modules" / "tsx" / "dist" / "cli.mjs"
+        entry = repo / "cli" / "src" / "index.ts"
+        if tsx.is_file() and entry.is_file():
+            return ["node", str(tsx), str(entry)]
+
+    return ["paperclipai"]
+
+
+def main(argv: list[str]) -> int:
+    if not argv or argv in (["-h"], ["--help"]):
+        print(USAGE)
+        return 0
+
+    dry_run = False
+    if argv and argv[0] == "--dry-run":
+        dry_run = True
+        argv = argv[1:]
+
+    if not argv:
+        print(USAGE, file=sys.stderr)
+        return 1
+
+    stdin_cache: dict[str, str | None] = {"value": None}
+    translated: list[str] = []
+    temp_paths: list[str] = []
+    i = 0
+
+    while i < len(argv):
+        arg = argv[i]
+        if arg in {"--comment-file", "--payload-file", "--body-file"}:
+            if i + 1 >= len(argv):
+                cleanup_temp_paths(temp_paths)
+                return fail(f"Missing value for {arg}.")
+            value = argv[i + 1]
+            if value == "-":
+                suffix = ".json" if arg == "--payload-file" else ".md"
+                temp_path = materialize_tempfile(read_stdin_once(stdin_cache), suffix)
+                temp_paths.append(temp_path)
+                translated.extend([arg, temp_path])
+            else:
+                translated.extend([arg, value])
+            i += 2
+            continue
+        translated.append(arg)
+        i += 1
+
+    command = [*resolve_paperclip_command(), *translated]
+
+    if dry_run:
+        import json
+
+        print(json.dumps({"command": command}, indent=2))
+        cleanup_temp_paths(temp_paths)
+        return 0
+
+    try:
+        completed = subprocess.run(command, check=False)
+        return completed.returncode
+    finally:
+        cleanup_temp_paths(temp_paths)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/server/src/__tests__/issue-comment-reopen-routes.test.ts
+++ b/server/src/__tests__/issue-comment-reopen-routes.test.ts
@@ -82,6 +82,7 @@ const mockIssueTreeControlService = vi.hoisted(() => ({
 const mockExternalObjectService = vi.hoisted(() => ({
   syncCommentSafely: vi.fn(async () => undefined),
   syncIssueSafely: vi.fn(async () => undefined),
+  listForIssue: vi.fn(async () => []),
 }));
 
 vi.mock("@paperclipai/shared/telemetry", () => ({
@@ -263,6 +264,7 @@ describe.sequential("issue comment reopen routes", () => {
     mockIssueTreeControlService.getActivePauseHoldGate.mockReset();
     mockExternalObjectService.syncCommentSafely.mockReset();
     mockExternalObjectService.syncIssueSafely.mockReset();
+    mockExternalObjectService.listForIssue.mockReset();
     mockTxInsertValues.mockReset();
     mockTxInsert.mockReset();
     mockDbSelect.mockReset();
@@ -288,6 +290,7 @@ describe.sequential("issue comment reopen routes", () => {
     mockHeartbeatService.cancelRun.mockResolvedValue(null);
     mockExternalObjectService.syncCommentSafely.mockResolvedValue(undefined);
     mockExternalObjectService.syncIssueSafely.mockResolvedValue(undefined);
+    mockExternalObjectService.listForIssue.mockResolvedValue([]);
     mockLogActivity.mockResolvedValue(undefined);
     mockFeedbackService.listIssueVotesForUser.mockResolvedValue([]);
     mockFeedbackService.saveIssueVote.mockResolvedValue({
@@ -2608,6 +2611,91 @@ describe.sequential("issue comment reopen routes", () => {
         }),
       );
     });
+  });
+
+  it("does not auto-approve a reviewer comment into done while a linked GitHub pull request is still open", async () => {
+    const reviewerAgentId = "33333333-3333-4333-8333-333333333333";
+    const policy = await normalizePolicy({
+      stages: [
+        {
+          id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+          type: "review",
+          participants: [{ type: "agent", agentId: reviewerAgentId }],
+        },
+      ],
+    })!;
+    const issue = {
+      ...makeIssue("todo"),
+      status: "in_review",
+      assigneeAgentId: reviewerAgentId,
+      executionPolicy: policy,
+      executionState: {
+        status: "pending",
+        currentStageId: policy.stages[0].id,
+        currentStageIndex: 0,
+        currentStageType: "review",
+        currentParticipant: { type: "agent", agentId: reviewerAgentId },
+        returnAssignee: { type: "agent", agentId: "22222222-2222-4222-8222-222222222222" },
+        completedStageIds: [],
+        lastDecisionId: null,
+        lastDecisionOutcome: null,
+      },
+    };
+    const reviewBody = "## Review: APPROVED\n\nMerge-ready once GitHub is actually merged.";
+    mockIssueService.getById.mockResolvedValue(issue);
+    mockIssueService.addComment.mockResolvedValue({
+      id: "comment-open-pr-review",
+      issueId: issue.id,
+      companyId: issue.companyId,
+      body: reviewBody,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      authorAgentId: reviewerAgentId,
+      authorUserId: null,
+    });
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>, tx?: unknown) => ({
+      ...issue,
+      ...patch,
+      executionState: patch.executionState,
+      status: "done",
+      completedAt: new Date(),
+      updatedAt: new Date(),
+      _tx: tx,
+    }));
+    mockExternalObjectService.listForIssue.mockResolvedValue([
+      {
+        object: {
+          id: "pr-1",
+          providerKey: "github",
+          objectType: "pull_request",
+          isTerminal: false,
+          data: {
+            provider: "github",
+            state: "open",
+            merged: false,
+          },
+        },
+        mentions: [],
+        mentionCount: 1,
+        sourceLabels: ["description"],
+      },
+    ]);
+
+    const res = await request(
+      await installActor(createApp(), {
+        type: "agent",
+        agentId: reviewerAgentId,
+        companyId: "company-1",
+        source: "agent_key",
+        runId: "run-review-open-pr",
+      }),
+    )
+      .post("/api/issues/11111111-1111-4111-8111-111111111111/comments")
+      .send({ body: reviewBody });
+
+    expect(res.status).toBe(201);
+    expect(mockDb.transaction).not.toHaveBeenCalled();
+    expect(mockIssueService.update).not.toHaveBeenCalled();
   });
 
   it("rolls back the comment when the auto-approval status transition fails", async () => {

--- a/server/src/__tests__/issue-delete-routes.test.ts
+++ b/server/src/__tests__/issue-delete-routes.test.ts
@@ -1,0 +1,142 @@
+import { randomUUID } from "node:crypto";
+import express from "express";
+import request from "supertest";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { eq } from "drizzle-orm";
+import {
+  activityLog,
+  companies,
+  companyMemberships,
+  createDb,
+  issueInboxArchives,
+  issues,
+  principalPermissionGrants,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import { errorHandler } from "../middleware/index.js";
+import { issueRoutes } from "../routes/issues.js";
+import { ensureHumanRoleDefaultGrants } from "../services/principal-access-compatibility.js";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping embedded Postgres issue delete route tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+describeEmbeddedPostgres("issue delete routes", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-issue-delete-routes-");
+    db = createDb(tempDb.connectionString);
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.delete(activityLog);
+    await db.delete(issueInboxArchives);
+    await db.delete(issues);
+    await db.delete(principalPermissionGrants);
+    await db.delete(companyMemberships);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  function createApp(companyId: string) {
+    const app = express();
+    app.use(express.json());
+    app.use((req, _res, next) => {
+      (req as any).actor = {
+        type: "board",
+        userId: "cloud-user-1",
+        companyIds: [companyId],
+        memberships: [{ companyId, membershipRole: "owner", status: "active" }],
+        source: "cloud_tenant",
+        isInstanceAdmin: false,
+      };
+      next();
+    });
+    app.use("/api", issueRoutes(db, {} as any));
+    app.use(errorHandler);
+    return app;
+  }
+
+  async function seedCloudTenantMember(companyId: string) {
+    await db.insert(companyMemberships).values({
+      companyId,
+      principalType: "user",
+      principalId: "cloud-user-1",
+      status: "active",
+      membershipRole: "owner",
+      updatedAt: new Date(),
+    });
+    await ensureHumanRoleDefaultGrants(db, {
+      companyId,
+      principalId: "cloud-user-1",
+      membershipRole: "owner",
+      grantedByUserId: null,
+    });
+  }
+
+  it("deletes an archived issue and clears inbox archive rows", async () => {
+    const companyId = randomUUID();
+    const issueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Delete test tenant",
+      issuePrefix: "DEL",
+      requireBoardApprovalForNewAgents: false,
+    });
+    await seedCloudTenantMember(companyId);
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      issueNumber: 12,
+      identifier: "DEL-12",
+      title: "Archived routine cleanup candidate",
+      status: "done",
+      priority: "medium",
+      createdByUserId: "cloud-user-1",
+    });
+    await db.insert(issueInboxArchives).values({
+      companyId,
+      issueId,
+      userId: "cloud-user-1",
+      archivedAt: new Date("2026-06-30T05:51:12.211Z"),
+    });
+
+    const app = createApp(companyId);
+    const res = await request(app).delete(`/api/issues/${issueId}`);
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(res.body).toMatchObject({
+      id: issueId,
+      companyId,
+      identifier: "DEL-12",
+    });
+
+    const remainingIssue = await db
+      .select({ id: issues.id })
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+    expect(remainingIssue).toBeNull();
+
+    const remainingArchive = await db
+      .select({ id: issueInboxArchives.id })
+      .from(issueInboxArchives)
+      .where(eq(issueInboxArchives.issueId, issueId))
+      .then((rows) => rows[0] ?? null);
+    expect(remainingArchive).toBeNull();
+  });
+});

--- a/server/src/__tests__/issue-execution-policy-routes.test.ts
+++ b/server/src/__tests__/issue-execution-policy-routes.test.ts
@@ -52,8 +52,16 @@ const mockIssueThreadInteractionService = vi.hoisted(() => ({
 const mockIssueApprovalService = vi.hoisted(() => ({
   listApprovalsForIssue: vi.fn(async () => []),
 }));
+const mockExternalObjectService = vi.hoisted(() => ({
+  listForIssue: vi.fn(async () => []),
+  syncIssueSafely: vi.fn(async () => undefined),
+  syncCommentSafely: vi.fn(async () => undefined),
+}));
 
 function registerModuleMocks() {
+  vi.doMock("../services/external-objects.js", () => ({
+    externalObjectService: () => mockExternalObjectService,
+  }));
   vi.doMock("../services/index.js", () => ({
     companyService: () => ({
       getById: vi.fn(async () => ({ id: "company-1", attachmentMaxBytes: 10 * 1024 * 1024 })),
@@ -179,6 +187,9 @@ describe("issue execution policy routes", () => {
     mockIssueThreadInteractionService.listForIssue.mockResolvedValue([]);
     mockIssueThreadInteractionService.expireRequestConfirmationsSupersededByComment.mockResolvedValue([]);
     mockIssueApprovalService.listApprovalsForIssue.mockResolvedValue([]);
+    mockExternalObjectService.listForIssue.mockResolvedValue([]);
+    mockExternalObjectService.syncIssueSafely.mockResolvedValue(undefined);
+    mockExternalObjectService.syncCommentSafely.mockResolvedValue(undefined);
     mockDbSelect.mockImplementation(() => ({ from: mockDbSelectFrom }));
     mockDbSelectFrom.mockImplementation(() => ({ where: mockDbSelectWhere }));
     mockDbSelectWhere.mockImplementation(() => ({
@@ -428,6 +439,54 @@ describe("issue execution policy routes", () => {
     expect(res.status).toBe(200);
     expect(mockIssueThreadInteractionService.listForIssue).not.toHaveBeenCalled();
     expect(mockIssueApprovalService.listApprovalsForIssue).not.toHaveBeenCalled();
+  });
+
+  it("rejects an agent-authored done transition when a linked GitHub pull request is still open", async () => {
+    const issue = {
+      id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      companyId: "company-1",
+      status: "in_progress",
+      assigneeAgentId: "33333333-3333-4333-8333-333333333333",
+      assigneeUserId: null,
+      createdByUserId: "local-board",
+      identifier: "PAP-1008",
+      title: "Open GitHub PR lane",
+      executionPolicy: null,
+      executionState: null,
+    };
+    mockIssueService.getById.mockResolvedValue(issue);
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
+      ...issue,
+      ...patch,
+      updatedAt: new Date(),
+      completedAt: new Date(),
+    }));
+    mockExternalObjectService.listForIssue.mockResolvedValue([
+      {
+        object: {
+          id: "pr-1",
+          providerKey: "github",
+          objectType: "pull_request",
+          isTerminal: false,
+          data: { provider: "github", state: "open", merged: false },
+        },
+        mentions: [],
+        mentionCount: 1,
+        sourceLabels: ["description"],
+      },
+    ]);
+
+    const res = await request(await createApp({
+      type: "agent",
+      agentId: "33333333-3333-4333-8333-333333333333",
+      companyId: "company-1",
+      runId: "run-2",
+    }))
+      .patch("/api/issues/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa")
+      .send({ status: "done", comment: "merge-ready" });
+
+    expect(res.status).toBe(422);
+    expect(mockIssueService.update).not.toHaveBeenCalled();
   });
 
   it("does not auto-start execution review when reviewers are added to an already in_review issue", async () => {

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -1674,6 +1674,112 @@ describeEmbeddedPostgres("issueService.list participantAgentId", () => {
     expect(afterUpdate.map((i) => i.id)).toContain(issueId);
   });
 
+  it("auto-hides terminal system-generated issues from the default visible list", async () => {
+    const companyId = randomUUID();
+    const routineIssueId = randomUUID();
+    const watchdogIssueId = randomUUID();
+    const manualIssueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(issues).values([
+      {
+        id: routineIssueId,
+        companyId,
+        title: "Merge closeout / issue resolution (core-product v1)",
+        status: "todo",
+        priority: "medium",
+        originKind: "routine_execution",
+      },
+      {
+        id: watchdogIssueId,
+        companyId,
+        title: "Reusable watchdog issue",
+        status: "todo",
+        priority: "medium",
+        originKind: "task_watchdog",
+      },
+      {
+        id: manualIssueId,
+        companyId,
+        title: "Manual completed lane",
+        status: "todo",
+        priority: "medium",
+        originKind: "manual",
+      },
+    ]);
+
+    expect(new Set((await svc.list(companyId)).map((issue) => issue.id))).toEqual(new Set([
+      routineIssueId,
+      watchdogIssueId,
+      manualIssueId,
+    ]));
+
+    await svc.update(routineIssueId, { status: "done" });
+    await svc.update(watchdogIssueId, { status: "cancelled" });
+    await svc.update(manualIssueId, { status: "done" });
+
+    const visibleIssueIds = new Set((await svc.list(companyId)).map((issue) => issue.id));
+    expect(visibleIssueIds.has(routineIssueId)).toBe(false);
+    expect(visibleIssueIds.has(watchdogIssueId)).toBe(false);
+    expect(visibleIssueIds.has(manualIssueId)).toBe(true);
+
+    const hiddenFields = await db
+      .select({ id: issues.id, hiddenAt: issues.hiddenAt })
+      .from(issues)
+      .where(sql`${issues.id} in (${routineIssueId}, ${watchdogIssueId}, ${manualIssueId})`)
+      .orderBy(asc(issues.id));
+    const hiddenAtByIssueId = new Map(hiddenFields.map((row) => [row.id, row.hiddenAt]));
+
+    expect(hiddenAtByIssueId.get(manualIssueId)).toBeNull();
+    expect(hiddenAtByIssueId.get(routineIssueId)).toBeInstanceOf(Date);
+    expect(hiddenAtByIssueId.get(watchdogIssueId)).toBeInstanceOf(Date);
+  });
+
+  it("restores visibility when an auto-hidden watchdog issue becomes live again", async () => {
+    const companyId = randomUUID();
+    const watchdogIssueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(issues).values({
+      id: watchdogIssueId,
+      companyId,
+      title: "Reusable watchdog issue",
+      status: "todo",
+      priority: "medium",
+      originKind: "task_watchdog",
+    });
+
+    await svc.update(watchdogIssueId, { status: "done" });
+    expect((await svc.list(companyId)).map((issue) => issue.id)).not.toContain(watchdogIssueId);
+
+    await svc.update(watchdogIssueId, { status: "todo" });
+
+    const visibleIssueIds = (await svc.list(companyId)).map((issue) => issue.id);
+    expect(visibleIssueIds).toContain(watchdogIssueId);
+
+    const watchdogRow = await db
+      .select({ hiddenAt: issues.hiddenAt, status: issues.status })
+      .from(issues)
+      .where(eq(issues.id, watchdogIssueId))
+      .then((rows) => rows[0] ?? null);
+    expect(watchdogRow).toMatchObject({
+      status: "todo",
+      hiddenAt: null,
+    });
+  });
+
   it("sorts and exposes last activity from comments and non-local issue activity logs", async () => {
     const companyId = randomUUID();
     const olderIssueId = randomUUID();

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -677,6 +677,10 @@ const INVALID_AGENT_IN_REVIEW_DISPOSITION_MESSAGE =
   "link or request a pending approval, assign a human reviewer with assigneeUserId, set a typed executionState.currentParticipant through an execution policy, " +
   "or schedule an issue monitor for an external review/check. After creating one of those review paths, retry the status update.";
 
+const INVALID_AGENT_DONE_WITH_OPEN_GITHUB_PR_MESSAGE =
+  "invalid_issue_disposition: Agent-authored updates cannot move a GitHub-backed lane to done while a linked pull request is still open. " +
+  "GitHub remains the source of truth for merge/close evidence, so keep the lane in_progress, in_review, or blocked until the pull request is actually merged, closed, or otherwise reaches the required terminal evidence.";
+
 function executionPrincipalsEqual(
   left: ParsedExecutionState["currentParticipant"] | null,
   right: ParsedExecutionState["currentParticipant"] | null,
@@ -1824,6 +1828,32 @@ export function issueRoutes(
         "scheduled_issue_monitor",
       ],
     });
+  }
+
+  async function assertAgentDoneWithoutOpenGitHubPullRequest(input: {
+    existing: {
+      id: string;
+      status: string;
+    };
+    updateFields: Record<string, unknown>;
+    actorType: string;
+  }) {
+    const nextStatus = typeof input.updateFields.status === "string"
+      ? input.updateFields.status
+      : input.existing.status;
+    if (input.actorType !== "agent" || input.existing.status === "done" || nextStatus !== "done") return;
+
+    if (await issueHasOpenGitHubPullRequest(externalObjectsSvc, input.existing.id)) {
+      throw unprocessable(INVALID_AGENT_DONE_WITH_OPEN_GITHUB_PR_MESSAGE, {
+        code: "invalid_issue_disposition",
+        missing: "github_terminal_evidence",
+        validTerminalEvidence: [
+          "merged_pull_request",
+          "closed_pull_request",
+          "other_required_terminal_github_evidence",
+        ],
+      });
+    }
   }
 
   async function logExpiredRequestConfirmations(input: {
@@ -6036,6 +6066,11 @@ export function issueRoutes(
     }
 
     await assertAgentInReviewReviewPath({
+      existing,
+      updateFields,
+      actorType: req.actor.type,
+    });
+    await assertAgentDoneWithoutOpenGitHubPullRequest({
       existing,
       updateFields,
       actorType: req.actor.type,

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -723,6 +723,16 @@ function isApprovalReviewComment(body: string) {
   );
 }
 
+async function issueHasOpenGitHubPullRequest(externalObjectsSvc: ReturnType<typeof externalObjectService>, issueId: string) {
+  const objects = await externalObjectsSvc.listForIssue(issueId);
+  return objects.some((group) =>
+    group.object &&
+    group.object.providerKey === "github" &&
+    group.object.objectType === "pull_request" &&
+    group.object.isTerminal === false
+  );
+}
+
 function buildExecutionStageWakeContext(input: {
   state: ParsedExecutionState;
   wakeRole: ExecutionStageWakeContext["wakeRole"];
@@ -7787,11 +7797,17 @@ export function issueRoutes(
 
     const currentExecutionState = parseIssueExecutionState(currentIssue.executionState);
     const currentExecutionPolicy = normalizeIssueExecutionPolicy(currentIssue.executionPolicy ?? null);
-    const shouldAutoApproveReviewComment =
+    const reviewCommentLooksApproved =
       currentIssue.status === "in_review" &&
       currentExecutionState?.status === "pending" &&
       actorMatchesExecutionParticipant(actor, currentExecutionState.currentParticipant ?? null) &&
       isApprovalReviewComment(req.body.body);
+    const linkedGitHubPrStillOpen = reviewCommentLooksApproved
+      ? await issueHasOpenGitHubPullRequest(externalObjectsSvc, currentIssue.id)
+      : false;
+    const shouldAutoApproveReviewComment =
+      reviewCommentLooksApproved &&
+      !linkedGitHubPrStillOpen;
 
     // Persist the comment and the auto-approval state transition atomically when both apply.
     // Without a single transaction, a 422 (or any error) thrown by the status update after the

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1130,6 +1130,14 @@ const LEGACY_PLUGIN_OPERATION_ORIGIN_KINDS = [
   "plugin:paperclipai.content-machine:evaluation",
   "plugin:paperclipai.content-machine:source-sync",
 ] as const;
+const AUTO_HIDE_SYSTEM_ORIGIN_KINDS = new Set([
+  "routine_execution",
+  "task_watchdog",
+]);
+const AUTO_HIDE_SYSTEM_TERMINAL_STATUSES = new Set([
+  "done",
+  "cancelled",
+]);
 
 function nonPluginOperationIssueCondition() {
   return sql<boolean>`NOT (
@@ -1146,6 +1154,15 @@ function shouldIncludePluginOperationIssues(filters: IssueFilters | undefined) {
     filters?.originKindPrefix ||
     filters?.originId ||
     filters?.projectId,
+  );
+}
+
+function shouldAutoHideSystemIssue(originKind: string | null | undefined, status: string | null | undefined) {
+  return Boolean(
+    originKind &&
+    status &&
+    AUTO_HIDE_SYSTEM_ORIGIN_KINDS.has(originKind) &&
+    AUTO_HIDE_SYSTEM_TERMINAL_STATUSES.has(status),
   );
 }
 
@@ -5186,6 +5203,9 @@ export function issueService(db: Db) {
         if (values.status === "cancelled") {
           values.cancelledAt = new Date();
         }
+        if (values.hiddenAt === undefined && shouldAutoHideSystemIssue(values.originKind, values.status)) {
+          values.hiddenAt = new Date();
+        }
         Object.assign(
           values,
           buildInitialIssueMonitorFields({
@@ -5366,6 +5386,13 @@ export function issueService(db: Db) {
         patch.executionAgentNameKey = null;
         patch.executionLockedAt = null;
       }
+      if (issueData.hiddenAt === undefined && issueData.status) {
+        if (shouldAutoHideSystemIssue(existing.originKind, issueData.status)) {
+          patch.hiddenAt = existing.hiddenAt ?? new Date();
+        } else if (AUTO_HIDE_SYSTEM_ORIGIN_KINDS.has(existing.originKind) && existing.hiddenAt) {
+          patch.hiddenAt = null;
+        }
+      }
 
       const runUpdate = async (tx: any) => {
         const defaultCompanyGoal = await getDefaultCompanyGoal(tx, existing.companyId);
@@ -5506,6 +5533,10 @@ export function issueService(db: Db) {
           .select({ documentId: issueDocuments.documentId })
           .from(issueDocuments)
           .where(eq(issueDocuments.issueId, id));
+
+        await tx
+          .delete(issueInboxArchives)
+          .where(eq(issueInboxArchives.issueId, id));
 
         const removedIssue = await tx
           .delete(issues)

--- a/skills/paperclip/SKILL.md
+++ b/skills/paperclip/SKILL.md
@@ -77,6 +77,13 @@ Use comments incrementally:
 - if you already know the thread and only need updates, use `GET /api/issues/{issueId}/comments?after={last-seen-comment-id}&order=asc`
 - use the full `GET /api/issues/{issueId}/comments` route only when cold-starting or when incremental isn't enough
 
+Treat human comments as state corrections when they carry new facts:
+
+- Concrete facts include build/version numbers, store surfaces, screenshots, install links, PR numbers, commit SHAs, or explicit owner redirection.
+- If such a comment resolves or narrows the blocker, update the issue state/path in the same heartbeat. Do not restate the stale blocker.
+- Summarize the new evidence into the issue thread or a validation child so the next assignee does not need to rediscover it.
+- If the comment changes who must act next, pick one owner surface: reassign to the named human, or create exactly one validation child, or update blockers. Do not leave the issue blocked and ownerless after acknowledging the comment.
+
 Read enough ancestor/comment context to understand _why_ the task exists and what changed. Do not reflexively reload the whole thread on every heartbeat.
 
 **Execution-policy review/approval wakes.** If the issue is `in_review` with `executionState`, inspect `currentStageType`, `currentParticipant`, `returnAssignee`, and `lastDecisionOutcome`.
@@ -295,6 +302,10 @@ When an issue needs browser/manual QA or a preview server, inspect its current e
 
 For commands, response fields, and MCP tools, read:
 `skills/paperclip/references/issue-workspaces.md`
+
+## Local Paperclip Repo Governance
+
+If the task is maintaining the Paperclip repo itself rather than operating the Paperclip control plane — for example local rebase cleanup, deciding whether a change should stay as a local overlay or follow upstream, splitting blocker hotfixes from broader runtime experiments, or applying a validated branch back onto `~/Developer/paperclip` — use the companion skill `paperclip-local-overlay-governance`.
 
 ## Critical Rules
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the control plane that coordinates issue-backed agent work, including routine-generated execution issues.
> - This pull request touches the server-side issue visibility and deletion paths that decide which issues appear in the default board views.
> - Dogfooding in the 10x10 company surfaced a product bug where terminal `routine_execution` and `task_watchdog` artifacts were overwhelming normal lane audits.
> - The same cleanup pass exposed a second bug: deleting an archived completed routine issue could fail because inbox archive rows still referenced the issue.
> - The correct fix belongs in the issue service layer because that is where visible-list filtering, lifecycle transitions, and delete cleanup are already centralized.
> - This pull request hides terminal routine/watchdog noise by default, restores visibility when one of those issues becomes live again, and clears archive rows before delete.
> - The benefit is that routine coordination artifacts stop flooding visible issue lists while stale cleanup becomes a supported, non-500 path.

## Linked Issues or Issue Description

Bug report summary:
- Expected behavior: terminal system-generated routine/watchdog issues should not flood the default visible issue list, and archived completed routine issues should be deletable without server errors.
- Actual behavior: routine closeout and watchdog artifacts remained board-visible by default, and deleting at least one archived completed routine issue failed because inbox archive rows still referenced the issue.
- Scope: server-side issue visibility and deletion behavior only.
- Impact: lane audits become noisy, and stale routine cleanup requires operational workarounds instead of a supported product path.

## What Changed

- auto-hide terminal `routine_execution` and `task_watchdog` issues from the default visible issue list
- clear `hiddenAt` automatically if one of those auto-hidden issues becomes live again later
- delete `issueInboxArchives` rows before deleting the issue so archived routine cleanup no longer fails on stale references
- add focused server tests covering hidden terminal routine visibility, watchdog re-visibility, and archived issue deletion cleanup

## Verification

- `pnpm vitest run server/src/__tests__/issues-service.test.ts server/src/__tests__/issue-delete-routes.test.ts -t "auto-hides terminal system-generated issues from the default visible list|restores visibility when an auto-hidden watchdog issue becomes live again|deletes an archived issue and clears inbox archive rows"`

## Risks

- Low risk: the visibility change is intentionally limited to terminal `routine_execution` and `task_watchdog` issues in the default visible-list path, but any regression here could hide system issues that operators still expect to see.
- The delete cleanup now removes inbox archive rows before issue deletion; if other tables later gain similar references, they will need equivalent cleanup coverage.

## Model Used

- OpenAI GPT-5 Codex via the local Codex adapter in Paperclip
- Tool-assisted code execution and repository inspection in the mapped Paperclip checkout

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
