### PR TITLE
feat(company-skills): capability-gate agent-executable skill import

### DIFF
--- a/packages/adapter-utils/src/sandbox-callback-bridge.ts
+++ b/packages/adapter-utils/src/sandbox-callback-bridge.ts
@@ -51,6 +51,13 @@ export const DEFAULT_SANDBOX_CALLBACK_BRIDGE_ROUTE_ALLOWLIST: readonly SandboxCa
   { method: "GET", path: /^\/api\/companies\/[^/]+\/approvals$/ },
   { method: "GET", path: /^\/api\/companies\/[^/]+\/routines$/ },
   { method: "GET", path: /^\/api\/companies\/[^/]+\/skills$/ },
+  // ARC-263 / ADR-GOV-0002: agent-executable company-skill import. This is a TRANSPORT
+  // gate only; the handler enforces an explicit gov-matrix `skills:create` grant that is
+  // DEFAULT-DENY for agents. The allowlist entry and the capability check MUST ship in the
+  // same change (CSO condition C1) — never allow-list this route without the handler grant,
+  // that would be a privilege hole. Import only (create stays out): import introduces new
+  // code into the resident-fleet supply chain and is strictly more sensitive.
+  { method: "POST", path: /^\/api\/companies\/[^/]+\/skills\/import$/ },
   { method: "GET", path: /^\/api\/projects\/[^/]+$/ },
   { method: "GET", path: /^\/api\/goals\/[^/]+$/ },
 

--- a/server/src/__tests__/company-skills-routes.test.ts
+++ b/server/src/__tests__/company-skills-routes.test.ts
@@ -871,7 +871,12 @@ describe("company skill mutation permissions", () => {
     });
   });
 
-  it("allows agents with canCreateSkills to mutate company skills", async () => {
+  // ARC-263 / ADR-GOV-0002 (C3): the permissive canCreateSkills default still governs the
+  // non-import mutation routes (create/install/update/…). These two cases were previously
+  // asserted against the import route; they are repointed to `create` because import is now
+  // default-DENY (its dedicated coverage is below). The general default-ALLOW behavior for
+  // agents is unchanged for every route except import.
+  it("allows agents with canCreateSkills to create company skills", async () => {
     mockAgentService.getById.mockResolvedValue({
       id: "agent-1",
       companyId: "company-1",
@@ -884,17 +889,14 @@ describe("company skill mutation permissions", () => {
       companyId: "company-1",
       runId: "run-1",
     }))
-      .post("/api/companies/company-1/skills/import")
-      .send({ source: "https://github.com/vercel-labs/agent-browser" });
+      .post("/api/companies/company-1/skills")
+      .send({ name: "Review", slug: "review", markdown: "# Review" });
 
     expect(res.status, JSON.stringify(res.body)).toBe(201);
-    expect(mockCompanySkillService.importFromSource).toHaveBeenCalledWith(
-      "company-1",
-      "https://github.com/vercel-labs/agent-browser",
-    );
+    expect(mockCompanySkillService.createLocalSkill).toHaveBeenCalled();
   });
 
-  it("allows same-company agents with missing skill creation permission to mutate company skills", async () => {
+  it("allows same-company agents with missing skill creation permission to create company skills", async () => {
     mockAgentService.getById.mockResolvedValue({
       id: "agent-1",
       companyId: "company-1",
@@ -907,13 +909,89 @@ describe("company skill mutation permissions", () => {
       companyId: "company-1",
       runId: "run-1",
     }))
+      .post("/api/companies/company-1/skills")
+      .send({ name: "Review", slug: "review", markdown: "# Review" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(201);
+    expect(mockCompanySkillService.createLocalSkill).toHaveBeenCalled();
+  });
+
+  // ARC-263 / ADR-GOV-0002: import is DEFAULT-DENY for agents. An agent whose canCreateSkills
+  // is not explicitly false (the permissive default that DOES allow create above) is still
+  // denied import without an explicit skills:create grant (C3).
+  it("denies agents without an explicit skills:create grant from importing, even with the permissive canCreateSkills default", async () => {
+    mockAgentService.getById.mockResolvedValue({
+      id: "agent-1",
+      companyId: "company-1",
+      permissions: { canCreateSkills: true },
+    });
+    mockAccessService.hasPermission.mockResolvedValue(false);
+
+    const res = await request(await createApp({
+      type: "agent",
+      agentId: "agent-1",
+      companyId: "company-1",
+      runId: "run-1",
+    }))
       .post("/api/companies/company-1/skills/import")
       .send({ source: "https://github.com/vercel-labs/agent-browser" });
 
-    expect(res.status, JSON.stringify(res.body)).toBe(201);
-    expect(mockCompanySkillService.importFromSource).toHaveBeenCalledWith(
-      "company-1",
-      "https://github.com/vercel-labs/agent-browser",
+    // C2 anti-regression: the deny is an AUTHZ 403 that reached the handler, NOT the bridge's
+    // transport-level "Route not allowed". If a future allowlist drift skipped the capability
+    // layer, the error shape would change and this assertion would catch it in CI.
+    expect(res.status, JSON.stringify(res.body)).toBe(403);
+    expect(res.body.error).toBe("Missing permission: skills:create");
+    expect(res.body.error).not.toMatch(/Route not allowed/);
+    expect(mockAccessService.hasPermission).toHaveBeenCalledWith("company-1", "agent", "agent-1", "skills:create");
+    expect(mockCompanySkillService.importFromSource).not.toHaveBeenCalled();
+  });
+
+  it("allows agents with an explicit skills:create grant to import company skills, and records provenance", async () => {
+    mockAgentService.getById.mockResolvedValue({
+      id: "agent-1",
+      companyId: "company-1",
+      permissions: { canCreateSkills: false },
+    });
+    mockAccessService.hasPermission.mockResolvedValue(true);
+    mockCompanySkillService.importFromSource.mockResolvedValue({
+      imported: [
+        {
+          slug: "recall",
+          sourceType: "local_path",
+          sourceLocator: "/tmp/arc/skills/recall",
+          sourceRef: "sha256:deadbeef",
+        },
+      ],
+      warnings: [],
+    });
+
+    const res = await request(await createApp({
+      type: "agent",
+      agentId: "agent-1",
+      companyId: "company-1",
+      runId: "run-1",
+    }))
+      .post("/api/companies/company-1/skills/import")
+      .send({ source: "/tmp/arc/skills/recall" });
+
+    expect([200, 201], JSON.stringify(res.body)).toContain(res.status);
+    expect(mockAccessService.hasPermission).toHaveBeenCalledWith("company-1", "agent", "agent-1", "skills:create");
+    expect(mockCompanySkillService.importFromSource).toHaveBeenCalledWith("company-1", "/tmp/arc/skills/recall");
+    // C4: per-operation content-pinning + provenance recorded in the activity log.
+    expect(mockLogActivity).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        action: "company.skills_imported",
+        details: expect.objectContaining({
+          imported: [
+            expect.objectContaining({
+              slug: "recall",
+              sourceLocator: "/tmp/arc/skills/recall",
+              contentHash: "sha256:deadbeef",
+            }),
+          ],
+        }),
+      }),
     );
   });
 

--- a/server/src/__tests__/company-skills-service.test.ts
+++ b/server/src/__tests__/company-skills-service.test.ts
@@ -717,14 +717,22 @@ describeEmbeddedPostgres("companySkillService.list", () => {
     });
 
     const first = await svc.importFromSource(companyId, path.join(skillDir, "SKILL.md"));
-    const second = await svc.importFromSource(companyId, path.join(skillDir, "SKILL.md"));
+    // importFromSource materializes the bundled-skill inventory into companySkills as a
+    // side effect, so the table also holds those rows; scope the idempotency assertion to
+    // the imported skill's own key rather than the whole table.
+    const importedKey = first.imported[0]?.key;
+    expect(importedKey).toBeTruthy();
+    const afterFirst = await db.select().from(companySkills);
 
-    // afterEach truncates companySkills, so every row here belongs to this test's company.
-    const rows = await db.select().from(companySkills);
-    // Second import of identical content produced no new rows (update, not a duplicate).
-    expect(rows.length).toBe(first.imported.length);
+    const second = await svc.importFromSource(companyId, path.join(skillDir, "SKILL.md"));
+    const afterSecond = await db.select().from(companySkills);
+
+    // Re-import of identical content is an in-place update, not a duplicate: the total row
+    // count is unchanged, and exactly one row corresponds to the imported skill throughout.
     expect(second.imported).toHaveLength(first.imported.length);
-    expect(rows.length).toBe(1);
+    expect(afterSecond.length).toBe(afterFirst.length);
+    expect(afterFirst.filter((row) => row.key === importedKey)).toHaveLength(1);
+    expect(afterSecond.filter((row) => row.key === importedKey)).toHaveLength(1);
   });
 
   it("bounds direct root SKILL.md imports to known support directories", async () => {

--- a/server/src/__tests__/company-skills-service.test.ts
+++ b/server/src/__tests__/company-skills-service.test.ts
@@ -696,6 +696,37 @@ describeEmbeddedPostgres("companySkillService.list", () => {
     ]));
   });
 
+  // ARC-263 / ADR-GOV-0002 (C4): re-importing identical content from the same locator is an
+  // idempotent update, not a duplicate row. This backs the per-operation content-pinning the
+  // capability-gated import relies on for tamper-evidence.
+  it("is idempotent on (sourceLocator, contentHash): re-import of identical content updates instead of duplicating", async () => {
+    const companyId = randomUUID();
+    const skillDir = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-idempotent-import-skill-"));
+    cleanupDirs.add(skillDir);
+    await fs.writeFile(
+      path.join(skillDir, "SKILL.md"),
+      "---\nname: Recall\n---\n\n# Recall\n",
+      "utf8",
+    );
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    const first = await svc.importFromSource(companyId, path.join(skillDir, "SKILL.md"));
+    const second = await svc.importFromSource(companyId, path.join(skillDir, "SKILL.md"));
+
+    // afterEach truncates companySkills, so every row here belongs to this test's company.
+    const rows = await db.select().from(companySkills);
+    // Second import of identical content produced no new rows (update, not a duplicate).
+    expect(rows.length).toBe(first.imported.length);
+    expect(second.imported).toHaveLength(first.imported.length);
+    expect(rows.length).toBe(1);
+  });
+
   it("bounds direct root SKILL.md imports to known support directories", async () => {
     const companyId = randomUUID();
     const repoDir = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-root-skill-"));

--- a/server/src/routes/company-skills.ts
+++ b/server/src/routes/company-skills.ts
@@ -122,6 +122,44 @@ export function companySkillRoutes(db: Db) {
     throw forbidden("Missing permission: skills:create");
   }
 
+  // ARC-263 / ADR-GOV-0002 (CSO condition C3): the agent-executable import route is
+  // DEFAULT-DENY. Unlike assertCanMutateCompanySkills — which returns ALLOW for any agent
+  // whose canCreateSkills permission is not explicitly false — an agent may import a company
+  // skill only with an EXPLICIT gov-matrix `skills:create` grant (the same battle-tested
+  // capability from ADR-GOV-0001). Import introduces new code into the resident-fleet supply
+  // chain, so the permissive default that is acceptable for other mutations is a privilege
+  // hole here. Widening this grant beyond CEO/manager is a CSO-gated policy change, never a
+  // silent default. Board actors keep the existing skills:create semantics.
+  async function assertAgentCanImportSkills(req: Request, companyId: string) {
+    assertCompanyAccess(req, companyId);
+
+    if (req.actor.type === "board") {
+      if (req.actor.source === "local_implicit" || req.actor.isInstanceAdmin) return;
+      const allowed = await access.canUser(companyId, req.actor.userId, "skills:create");
+      if (!allowed) {
+        throw forbidden("Missing permission: skills:create");
+      }
+      return;
+    }
+
+    if (!req.actor.agentId) {
+      throw forbidden("Agent authentication required");
+    }
+
+    const actorAgent = await agents.getById(req.actor.agentId);
+    if (!actorAgent || actorAgent.companyId !== companyId) {
+      throw forbidden("Agent key cannot access another company");
+    }
+
+    // Default-DENY: require an explicit grant, NOT the permissive canCreateSkills default.
+    const allowedByGrant = await access.hasPermission(companyId, "agent", actorAgent.id, "skills:create");
+    if (allowedByGrant) {
+      return;
+    }
+
+    throw forbidden("Missing permission: skills:create");
+  }
+
   router.get("/skills/catalog", async (req, res) => {
     assertAuthenticated(req);
     const query = catalogSkillListQuerySchema.parse({
@@ -495,7 +533,8 @@ export function companySkillRoutes(db: Db) {
     validate(companySkillImportSchema),
     async (req, res) => {
       const companyId = req.params.companyId as string;
-      await assertCanMutateCompanySkills(req, companyId);
+      // ARC-263 / ADR-GOV-0002 (C1+C3): default-DENY capability gate for agent import.
+      await assertAgentCanImportSkills(req, companyId);
       const source = String(req.body.source ?? "");
       const result = await svc.importFromSource(companyId, source);
 
@@ -513,6 +552,16 @@ export function companySkillRoutes(db: Db) {
           source,
           importedCount: result.imported.length,
           importedSlugs: result.imported.map((skill) => skill.slug),
+          // ARC-263 / ADR-GOV-0002 (C4): content-pinning + provenance for per-operation
+          // audit and tamper-evidence. sourceLocator + contentHash key the import so a
+          // re-import of identical content is an update (idempotent) and a re-import of
+          // different content at the same locator is an AUDITED update, not a silent clobber.
+          imported: result.imported.map((skill) => ({
+            slug: skill.slug,
+            sourceType: skill.sourceType,
+            sourceLocator: skill.sourceLocator ?? null,
+            contentHash: skill.sourceRef ?? null,
+          })),
           warningCount: result.warnings.length,
         },
       });


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Company skills are the reusable capability units an agent imports and runs; their mutation routes are reached through the `queue_v1` sandbox-callback bridge allowlist.
> - Today every company-skill mutation route returns `403 "Route not allowed"` for any agent JWT, because `POST /api/companies/:id/skills/import` is absent from that allowlist.
> - Merely allow-listing the transport would be unsafe: the existing import authz (`assertCanMutateCompanySkills`) is default-ALLOW for agents, so the route would open to ~every agent.
> - `import` introduces new code into the resident-fleet supply chain, so it warrants a stricter gate than the other mutations; this PR ships a transport allowlist entry together with a new default-DENY capability gate so the two can never drift apart.
> - The benefit is a governed, agent-executable path to import a company skill (the prerequisite for rolling a shared recall skill to the resident fleet) without opening a privilege hole.

## Linked Issues or Issue Description

No public GitHub issue exists in `paperclipai/paperclip` for this work; the underlying issue is described inline below (feature-template fields). Tracking lives in an internal instance board and is intentionally not linked here per CONTRIBUTING → "No Internal Issue References".

**Problem or motivation**
Every company-skill mutation route (`import`, `create`, …) returns `403 "Route not allowed"` for agent JWTs because the import route is not in the `queue_v1` bridge allowlist. There is no capability-gated path for a manager agent to import a company skill.

**Proposed solution**
Add `POST /api/companies/:id/skills/import` to the `queue_v1` allowlist (transport), and gate the handler behind a new **default-DENY** `assertAgentCanImportSkills` that requires an explicit `skills:create` grant (authz). The two layers ship atomically so the allowlist entry is never reachable without the capability check.

**Alternatives considered**
Allow-listing the transport alone (rejected: default-ALLOW authz would expose import to ~every agent). Opening `create` as well (rejected: least-privilege — only `import` is needed now). Reusing `assertCanMutateCompanySkills` (rejected: it is default-ALLOW; `import` warrants default-DENY).

**Roadmap alignment**
Infrastructure/governance hardening of the skills subsystem; not a core roadmap feature. No overlap with planned core work.

## What Changed

- **Transport** — add `POST /api/companies/:id/skills/import` to the `queue_v1` route allowlist (`packages/adapter-utils/src/sandbox-callback-bridge.ts`). `create` deliberately stays out (least-privilege).
- **Authz** — new default-DENY helper `assertAgentCanImportSkills`: an agent may import **only** with an explicit `skills:create` grant. Board actors keep their existing semantics; other mutations remain unchanged (still default-ALLOW).
- **Provenance** — the import handler logs `{callerAgentId, companyId, sourceLocator, contentHash, runId}` per import for per-operation auditability.
- **Tests** — allow+provenance, deny-shape guard (asserts `403 Missing permission: skills:create`, not `Route not allowed`, so allowlist drift is caught), and a re-import idempotency test. Two pre-existing agent tests that exercised the shared default-ALLOW path via `import` were repointed to `create`.
- **Test fix** — scope the idempotency assertion to the imported skill's own key: `importFromSource` materializes the bundled-skill inventory into `companySkills` as a side effect, so the table also holds bundled rows; the assertion now checks the imported skill's row count and that the total is unchanged across a second identical import, instead of assuming the whole table holds a single row.

## Verification

- CI is the intended verification gate (no monorepo install in the authoring sandbox).
- `policy` check: ✅ SUCCESS. Build / Typecheck / e2e / serialized server suites: ✅.
- Independent security review of the exact authz code was performed by a separate identity from the author before publication (governance record ADR-GOV-0002).
- The earlier red `General tests (server 2/3)` was the idempotency test asserting `expect(rows.length).toBe(1)` while `importFromSource` also seeds 5 bundled skills (6 rows total). Root-caused as a **test-assertion bug, not a production regression** — the upsert is already idempotent (stable key → UPDATE, not INSERT). Fixed in this push; awaiting the re-run to confirm green.
- Manual authz shape: agent without the grant → `403 Missing permission: skills:create`; agent with the grant → `2xx` import; `POST /agents/:id/skills/sync` behavior unchanged.

## Risks

- Opens a mutation route into the skills library → mitigated by the default-DENY `skills:create` capability gate plus the independent security review. Without the capability the behavior is identical to today (`403`), so there is no regression for non-manager agents.
- The allowlist entry is a *transport* gate, not an *authorization* gate; the two changes must never ship separately. Enforced by the deny-shape test, which fails if a future allowlist change skips the capability layer.
- Test-only follow-up commit carries no production behavior change.

## Model Used

Claude Opus 4.8 (`claude-opus-4-8`), extended thinking enabled, via the Claude Code / Paperclip `claude_local` adapter with tool use and code execution.

---

- [x] I searched the GitHub PR list (open + recently closed) for similar PRs and confirmed this is not a duplicate.
