### PR TITLE
Fix ACPX Paperclip API prompt guidance

### DIFF
--- a/packages/adapters/acpx-local/src/server/execute.test.ts
+++ b/packages/adapters/acpx-local/src/server/execute.test.ts
@@ -62,6 +62,7 @@ async function runExecutor(
   options: {
     context?: Record<string, unknown>;
     executionTransport?: Record<string, unknown>;
+    authToken?: string;
   } = {},
 ) {
   const runtimeOptions: Record<string, unknown>[] = [];
@@ -84,6 +85,7 @@ async function runExecutor(
       config,
       context: options.context ?? {},
       executionTransport: options.executionTransport,
+      authToken: options.authToken,
       onLog: async (stream: "stdout" | "stderr", text: string) => {
         logs.push({ stream, text });
       },
@@ -97,6 +99,33 @@ async function runExecutor(
 }
 
 describe("acpx_local runtime skill isolation", () => {
+  it("includes Paperclip env and API access notes in the ACPX prompt without leaking the token", async () => {
+    const { meta } = await runExecutor(
+      { agent: "custom", agentCommand: "node ./fake-acp.js" },
+      {
+        authToken: "runtime-secret-token",
+        context: {
+          taskId: "issue-1",
+          wakeReason: "issue_assigned",
+          paperclipWake: {
+            reason: "issue_assigned",
+            issue: { id: "issue-1", identifier: "TEST-1" },
+          },
+        },
+      },
+    );
+
+    const prompt = String(meta[0]?.prompt ?? "");
+    expect(prompt).toContain("Paperclip runtime note:");
+    expect(prompt).toContain("PAPERCLIP_AGENT_ID");
+    expect(prompt).toContain("PAPERCLIP_API_KEY");
+    expect(prompt).toContain("PAPERCLIP_WAKE_PAYLOAD_JSON");
+    expect(prompt).toContain("Paperclip API access note:");
+    expect(prompt).toContain("$PAPERCLIP_API_URL/api/agents/me");
+    expect(prompt).toContain("X-Paperclip-Run-Id");
+    expect(prompt).not.toContain("runtime-secret-token");
+  });
+
   it.skipIf(process.platform === "win32")("materializes ACPX Claude skills without symlinked descendants", async () => {
     const root = await makeTempRoot();
     const skillRoot = path.join(root, "skills");

--- a/packages/adapters/acpx-local/src/server/execute.test.ts
+++ b/packages/adapters/acpx-local/src/server/execute.test.ts
@@ -122,8 +122,23 @@ describe("acpx_local runtime skill isolation", () => {
     expect(prompt).toContain("PAPERCLIP_WAKE_PAYLOAD_JSON");
     expect(prompt).toContain("Paperclip API access note:");
     expect(prompt).toContain("$PAPERCLIP_API_URL/api/agents/me");
+    expect(prompt).toContain("$PAPERCLIP_API_URL/api/issues/$PAPERCLIP_TASK_ID");
     expect(prompt).toContain("X-Paperclip-Run-Id");
+    expect(prompt).not.toContain("/api/issues/{id}");
+    expect(prompt).not.toContain("-d '{...}'");
     expect(prompt).not.toContain("runtime-secret-token");
+  });
+
+  it("does not show a scoped issue API command when the task id is unavailable", async () => {
+    const { meta } = await runExecutor(
+      { agent: "custom", agentCommand: "node ./fake-acp.js" },
+      { authToken: "runtime-secret-token" },
+    );
+
+    const prompt = String(meta[0]?.prompt ?? "");
+    expect(prompt).toContain("Paperclip API access note:");
+    expect(prompt).toContain("Use a real issue id from the current context before making issue write requests.");
+    expect(prompt).not.toContain("$PAPERCLIP_API_URL/api/issues/$PAPERCLIP_TASK_ID");
   });
 
   it.skipIf(process.platform === "win32")("materializes ACPX Claude skills without symlinked descendants", async () => {

--- a/packages/adapters/acpx-local/src/server/execute.test.ts
+++ b/packages/adapters/acpx-local/src/server/execute.test.ts
@@ -121,9 +121,11 @@ describe("acpx_local runtime skill isolation", () => {
     expect(prompt).toContain("PAPERCLIP_API_KEY");
     expect(prompt).toContain("PAPERCLIP_WAKE_PAYLOAD_JSON");
     expect(prompt).toContain("Paperclip API access note:");
-    expect(prompt).toContain("$PAPERCLIP_API_URL/api/agents/me");
-    expect(prompt).toContain("$PAPERCLIP_API_URL/api/issues/$PAPERCLIP_TASK_ID");
+    expect(prompt).toContain('PAPERCLIP_API_BASE="${PAPERCLIP_API_URL%/}"; PAPERCLIP_API_BASE="${PAPERCLIP_API_BASE%/api}"');
+    expect(prompt).toContain("$PAPERCLIP_API_BASE/api/agents/me");
+    expect(prompt).toContain("$PAPERCLIP_API_BASE/api/issues/$PAPERCLIP_TASK_ID");
     expect(prompt).toContain("X-Paperclip-Run-Id");
+    expect(prompt).not.toContain("$PAPERCLIP_API_URL/api/");
     expect(prompt).not.toContain("/api/issues/{id}");
     expect(prompt).not.toContain("-d '{...}'");
     expect(prompt).not.toContain("runtime-secret-token");

--- a/packages/adapters/acpx-local/src/server/execute.ts
+++ b/packages/adapters/acpx-local/src/server/execute.ts
@@ -1019,14 +1019,21 @@ function renderPaperclipEnvNote(env: Record<string, string>): string {
 
 function renderApiAccessNote(env: Record<string, string>): string {
   if (!env.PAPERCLIP_API_URL || !env.PAPERCLIP_API_KEY) return "";
-  return [
+  const lines = [
     "Paperclip API access note:",
     "Use terminal commands with curl to make Paperclip API requests.",
     "GET example:",
     `  curl -s -H "Authorization: Bearer $PAPERCLIP_API_KEY" "$PAPERCLIP_API_URL/api/agents/me"`,
-    "POST/PATCH example:",
-    `  curl -s -X PATCH -H "Authorization: Bearer $PAPERCLIP_API_KEY" -H "Content-Type: application/json" -H "X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID" -d '{...}' "$PAPERCLIP_API_URL/api/issues/{id}"`,
-  ].join("\n");
+  ];
+  if (env.PAPERCLIP_TASK_ID) {
+    lines.push(
+      "Scoped issue comment example:",
+      `  curl -s -X POST -H "Authorization: Bearer $PAPERCLIP_API_KEY" -H "Content-Type: application/json" -H "X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID" -d '{"body":"Status update from agent."}' "$PAPERCLIP_API_URL/api/issues/$PAPERCLIP_TASK_ID/comments"`,
+    );
+  } else {
+    lines.push("Use a real issue id from the current context before making issue write requests.");
+  }
+  return lines.join("\n");
 }
 
 async function buildPrompt(ctx: AdapterExecutionContext, resumedSession: boolean, env: Record<string, string>): Promise<{

--- a/packages/adapters/acpx-local/src/server/execute.ts
+++ b/packages/adapters/acpx-local/src/server/execute.ts
@@ -1022,13 +1022,15 @@ function renderApiAccessNote(env: Record<string, string>): string {
   const lines = [
     "Paperclip API access note:",
     "Use terminal commands with curl to make Paperclip API requests.",
+    "Normalize the base URL before adding API paths:",
+    `  PAPERCLIP_API_BASE="\${PAPERCLIP_API_URL%/}"; PAPERCLIP_API_BASE="\${PAPERCLIP_API_BASE%/api}"`,
     "GET example:",
-    `  curl -s -H "Authorization: Bearer $PAPERCLIP_API_KEY" "$PAPERCLIP_API_URL/api/agents/me"`,
+    `  curl -s -H "Authorization: Bearer $PAPERCLIP_API_KEY" "$PAPERCLIP_API_BASE/api/agents/me"`,
   ];
   if (env.PAPERCLIP_TASK_ID) {
     lines.push(
       "Scoped issue comment example:",
-      `  curl -s -X POST -H "Authorization: Bearer $PAPERCLIP_API_KEY" -H "Content-Type: application/json" -H "X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID" -d '{"body":"Status update from agent."}' "$PAPERCLIP_API_URL/api/issues/$PAPERCLIP_TASK_ID/comments"`,
+      `  curl -s -X POST -H "Authorization: Bearer $PAPERCLIP_API_KEY" -H "Content-Type: application/json" -H "X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID" -d '{"body":"Status update from agent."}' "$PAPERCLIP_API_BASE/api/issues/$PAPERCLIP_TASK_ID/comments"`,
     );
   } else {
     lines.push("Use a real issue id from the current context before making issue write requests.");

--- a/packages/adapters/acpx-local/src/server/execute.ts
+++ b/packages/adapters/acpx-local/src/server/execute.ts
@@ -1005,7 +1005,31 @@ async function applySessionConfigOptions(input: {
   }
 }
 
-async function buildPrompt(ctx: AdapterExecutionContext, resumedSession: boolean): Promise<{
+function renderPaperclipEnvNote(env: Record<string, string>): string {
+  const paperclipKeys = Object.keys(env)
+    .filter((key) => key.startsWith("PAPERCLIP_"))
+    .sort();
+  if (paperclipKeys.length === 0) return "";
+  return [
+    "Paperclip runtime note:",
+    `The following PAPERCLIP_* environment variables are available in this run: ${paperclipKeys.join(", ")}`,
+    "Do not assume these variables are missing without checking your shell environment.",
+  ].join("\n");
+}
+
+function renderApiAccessNote(env: Record<string, string>): string {
+  if (!env.PAPERCLIP_API_URL || !env.PAPERCLIP_API_KEY) return "";
+  return [
+    "Paperclip API access note:",
+    "Use terminal commands with curl to make Paperclip API requests.",
+    "GET example:",
+    `  curl -s -H "Authorization: Bearer $PAPERCLIP_API_KEY" "$PAPERCLIP_API_URL/api/agents/me"`,
+    "POST/PATCH example:",
+    `  curl -s -X PATCH -H "Authorization: Bearer $PAPERCLIP_API_KEY" -H "Content-Type: application/json" -H "X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID" -d '{...}' "$PAPERCLIP_API_URL/api/issues/{id}"`,
+  ].join("\n");
+}
+
+async function buildPrompt(ctx: AdapterExecutionContext, resumedSession: boolean, env: Record<string, string>): Promise<{
   prompt: string;
   promptMetrics: Record<string, number>;
   commandNotes: string[];
@@ -1057,12 +1081,16 @@ async function buildPrompt(ctx: AdapterExecutionContext, resumedSession: boolean
   const renderedPrompt = shouldUseResumeDeltaPrompt ? "" : renderTemplate(promptTemplate, templateData);
   const sessionHandoffNote = asString(context.paperclipSessionHandoffMarkdown, "").trim();
   const taskContextNote = asString(context.paperclipTaskMarkdown, "").trim();
+  const paperclipEnvNote = renderPaperclipEnvNote(env);
+  const apiAccessNote = renderApiAccessNote(env);
   const prompt = joinPromptSections([
     promptInstructionsPrefix,
     renderedBootstrapPrompt,
     wakePrompt,
     sessionHandoffNote,
     taskContextNote,
+    paperclipEnvNote,
+    apiAccessNote,
     renderedPrompt,
   ]);
 
@@ -1076,6 +1104,7 @@ async function buildPrompt(ctx: AdapterExecutionContext, resumedSession: boolean
       wakePromptChars: wakePrompt.length,
       sessionHandoffChars: sessionHandoffNote.length,
       taskContextChars: taskContextNote.length,
+      runtimeNoteChars: paperclipEnvNote.length + apiAccessNote.length,
       heartbeatPromptChars: renderedPrompt.length,
     },
   };
@@ -1517,7 +1546,7 @@ export function createAcpxLocalExecutor(deps: ExecuteDeps = {}) {
         summary: message,
       };
     }
-    const { prompt, promptMetrics, commandNotes } = await buildPrompt(ctx, resumedSession);
+    const { prompt, promptMetrics, commandNotes } = await buildPrompt(ctx, resumedSession, prepared.env);
     const runPrompt = joinPromptSections([prepared.skillPromptInstructions, prompt]);
     await emitAcpxLog(ctx, {
       type: "acpx.session",


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Local adapters launch external agent runtimes while Paperclip keeps the task, comment, and heartbeat control plane authoritative
> - The ACPX local adapter already injects Paperclip runtime environment variables into the launched agent process
> - But the ACPX prompt did not tell the agent which Paperclip runtime variables were available or how to call the Paperclip API
> - That gap can make ACPX-backed agents assume API access is unavailable even though the runtime provided it
> - This pull request adds prompt-level runtime/API guidance without exposing secret values
> - The benefit is a smaller, more reliable Paperclip callback contract for ACPX-compatible local agents

## Linked Issues or Issue Description

No exact public issue exists for this ACPX prompt contract bug. Related public Antigravity/Gemini adapter work: Refs #7710, Refs #8377, Refs #8521, Refs #6559, Refs #98.

Bug description:

- What happened: ACPX local executions received Paperclip env vars, including API URL/token context, but the generated prompt did not mention those vars or show how to call the Paperclip API.
- Expected behavior: when Paperclip runtime env vars are present, the ACPX prompt should make that runtime contract explicit and provide safe API access examples that reference environment variable names instead of secret values.
- Steps to reproduce: run the ACPX local executor with a Paperclip wake context and auth token, then inspect the prompt metadata sent to the ACP wrapper.
- Paperclip version/commit: current `master` before this PR.
- Deployment mode: local ACPX adapter runtime.

## What Changed

- Added a Paperclip runtime note to ACPX prompts listing available `PAPERCLIP_*` environment variable names.
- Added a Paperclip API access note when `PAPERCLIP_API_URL` and `PAPERCLIP_API_KEY` are available, including safe `curl` examples that reference env vars rather than token values.
- Added prompt metrics for the runtime/API guidance block.
- Added a regression test proving the notes are present and the auth token value is not leaked into the prompt.

## Verification

```bash
pnpm --filter @paperclipai/adapter-acpx-local typecheck
pnpm exec vitest run --config packages/adapters/acpx-local/vitest.config.ts packages/adapters/acpx-local/src/cli/format-event.test.ts packages/adapters/acpx-local/src/server/execute.test.ts packages/adapters/acpx-local/src/server/test.test.ts packages/adapters/acpx-local/src/ui/parse-stdout.test.ts
pnpm exec vitest run server/src/__tests__/acpx-local-execute.test.ts
```

All three commands pass locally.

## Risks

- Low behavioral risk: the adapter execution environment is unchanged; this only adds explicit prompt guidance for runtime variables already present.
- Slight prompt length increase when Paperclip runtime env vars are available.
- The API examples assume the launched agent can run shell commands with `curl`, matching the existing local adapter operating model.

## Model Used

OpenAI GPT-5 Codex via the Codex/Paperclip agent harness, with local shell tool use for repository inspection, code editing, verification, branch preparation, and PR creation.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
