### PR TITLE
middleware: return 401 on invalid Bearer instead of silent local-boar…

### DIFF
--- a/server/src/middleware/auth.test.ts
+++ b/server/src/middleware/auth.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it, vi } from "vitest";
+import type { NextFunction, Request, Response } from "express";
+import type { Db } from "@paperclipai/db";
+import { actorMiddleware } from "./auth.js";
+
+// Fake db returning an empty result for every SELECT chain used by
+// actorMiddleware. The chained calls (`.select().from().where().then(fn)`)
+// and (`.update().set().where()`) both resolve to `[]` / `undefined`.
+function createEmptyDb(): Db {
+  const chain: Record<string, unknown> = {};
+  chain.from = () => chain;
+  chain.where = () => chain;
+  chain.set = () => chain;
+  chain.then = (resolve: (v: unknown) => unknown) => Promise.resolve([]).then(resolve);
+  const db = {
+    select: () => chain,
+    update: () => chain,
+  } as unknown as Db;
+  return db;
+}
+
+function fakeReq(headers: Record<string, string>): Request {
+  const lower: Record<string, string> = {};
+  for (const [k, v] of Object.entries(headers)) lower[k.toLowerCase()] = v;
+  return {
+    header: (name: string) => lower[name.toLowerCase()],
+    method: "POST",
+    originalUrl: "/api/companies/x/issues/y/comments",
+  } as unknown as Request;
+}
+
+function fakeRes() {
+  const state: { statusCode?: number; body?: unknown } = {};
+  const res = {
+    status(code: number) {
+      state.statusCode = code;
+      return res;
+    },
+    json(body: unknown) {
+      state.body = body;
+      return res;
+    },
+  } as unknown as Response;
+  return { res, state };
+}
+
+const LOCAL_TRUSTED = { deploymentMode: "local_trusted" as const };
+
+describe("actorMiddleware — invalid Bearer paths return 401 (no silent local-board fallthrough)", () => {
+  it("returns 401 for an empty token after `Bearer `", async () => {
+    const db = createEmptyDb();
+    const middleware = actorMiddleware(db, LOCAL_TRUSTED);
+    const { res, state } = fakeRes();
+    const next = vi.fn() as NextFunction;
+    await middleware(fakeReq({ authorization: "Bearer   " }), res, next);
+    expect(state.statusCode).toBe(401);
+    expect(state.body).toEqual({ error: "Unauthorized", reason: "invalid_or_missing_bearer" });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 for a Bearer token with no matching board key, agent key, or valid JWT", async () => {
+    const db = createEmptyDb();
+    const middleware = actorMiddleware(db, LOCAL_TRUSTED);
+    const { res, state } = fakeRes();
+    const next = vi.fn() as NextFunction;
+    // "notarealjwt" — not a board API key, not a valid agent API key hash,
+    // not a well-formed local agent JWT.
+    await middleware(fakeReq({ authorization: "Bearer notarealjwt" }), res, next);
+    expect(state.statusCode).toBe(401);
+    expect(state.body).toEqual({ error: "Unauthorized", reason: "invalid_or_missing_bearer" });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("does NOT 401 when no Authorization header is provided (local_trusted default preserved)", async () => {
+    // Deliberately confirms the non-Bearer path (browser console UI in
+    // local_trusted mode) still falls through with the local-board actor.
+    // A future opt-in strict flag would flip this; keeping the default
+    // permissive avoids breaking every existing local paperclipai install.
+    const db = createEmptyDb();
+    const middleware = actorMiddleware(db, LOCAL_TRUSTED);
+    const { res, state } = fakeRes();
+    const next = vi.fn() as NextFunction;
+    await middleware(fakeReq({}), res, next);
+    expect(state.statusCode).toBeUndefined();
+    expect(next).toHaveBeenCalledOnce();
+  });
+
+  it("returns 401 when the Bearer is a syntactically-valid but unsigned JWT-like blob", async () => {
+    const db = createEmptyDb();
+    const middleware = actorMiddleware(db, LOCAL_TRUSTED);
+    const { res, state } = fakeRes();
+    const next = vi.fn() as NextFunction;
+    // Three-segment header.payload.signature but signature won't verify.
+    const fakeJwt = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhIn0.deadbeef";
+    await middleware(fakeReq({ authorization: `Bearer ${fakeJwt}` }), res, next);
+    expect(state.statusCode).toBe(401);
+    expect(state.body).toEqual({ error: "Unauthorized", reason: "invalid_or_missing_bearer" });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 in `authenticated` mode too (no local-board default, but keeps the surface uniform)", async () => {
+    const db = createEmptyDb();
+    const middleware = actorMiddleware(db, { deploymentMode: "authenticated" });
+    const { res, state } = fakeRes();
+    const next = vi.fn() as NextFunction;
+    await middleware(fakeReq({ authorization: "Bearer notarealjwt" }), res, next);
+    expect(state.statusCode).toBe(401);
+    expect(state.body).toEqual({ error: "Unauthorized", reason: "invalid_or_missing_bearer" });
+    expect(next).not.toHaveBeenCalled();
+  });
+});

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -1,5 +1,5 @@
 import { createHash, timingSafeEqual } from "node:crypto";
-import type { Request, RequestHandler } from "express";
+import type { Request, Response, RequestHandler } from "express";
 import { and, eq, isNull } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import { agentApiKeys, agents, authUsers, companies, companyMemberships, instanceUserRoles } from "@paperclipai/db";
@@ -14,6 +14,17 @@ function hashToken(token: string) {
   return createHash("sha256").update(token).digest("hex");
 }
 
+// Any request that presents an `Authorization: Bearer …` header but fails
+// every credential lookup (board key, agent API key, agent JWT) is an
+// EXPLICIT failed authentication attempt. In `local_trusted` mode the
+// pre-Bearer default `req.actor` is `{ type: "board", userId: "local-board",
+// isInstanceAdmin: true }`, so falling through to `next()` on a bad Bearer
+// silently promotes the failed caller to full board access. Return 401 on
+// every such branch so the fallthrough can't happen.
+function rejectInvalidBearer(res: Response) {
+  res.status(401).json({ error: "Unauthorized", reason: "invalid_or_missing_bearer" });
+}
+
 interface ActorMiddlewareOptions {
   deploymentMode: DeploymentMode;
   resolveSession?: (req: Request) => Promise<BetterAuthSessionResult | null>;
@@ -21,7 +32,7 @@ interface ActorMiddlewareOptions {
 
 export function actorMiddleware(db: Db, opts: ActorMiddlewareOptions): RequestHandler {
   const boardAuth = boardAuthService(db);
-  return async (req, _res, next) => {
+  return async (req, res, next) => {
     req.actor =
       opts.deploymentMode === "local_trusted"
         ? {
@@ -103,7 +114,9 @@ export function actorMiddleware(db: Db, opts: ActorMiddlewareOptions): RequestHa
 
     const token = authHeader.slice("bearer ".length).trim();
     if (!token) {
-      next();
+      // Bearer header present but empty token — explicit failed auth. See
+      // rejectInvalidBearer for why we can't fall through in local_trusted.
+      rejectInvalidBearer(res);
       return;
     }
 
@@ -139,7 +152,9 @@ export function actorMiddleware(db: Db, opts: ActorMiddlewareOptions): RequestHa
     if (!key) {
       const claims = verifyLocalAgentJwt(token);
       if (!claims) {
-        next();
+        // Bearer present but not a board key, not an agent API key, and JWT
+        // signature/format is invalid.
+        rejectInvalidBearer(res);
         return;
       }
 
@@ -150,12 +165,16 @@ export function actorMiddleware(db: Db, opts: ActorMiddlewareOptions): RequestHa
         .then((rows) => rows[0] ?? null);
 
       if (!agentRecord || agentRecord.companyId !== claims.company_id) {
-        next();
+        // JWT verified but the agent row is missing or the JWT's company
+        // claim doesn't match the persisted agent row.
+        rejectInvalidBearer(res);
         return;
       }
 
       if (agentRecord.status === "terminated" || agentRecord.status === "pending_approval") {
-        next();
+        // JWT verified but the agent has been terminated or hasn't been
+        // approved. Do not grant board access.
+        rejectInvalidBearer(res);
         return;
       }
 
@@ -183,7 +202,9 @@ export function actorMiddleware(db: Db, opts: ActorMiddlewareOptions): RequestHa
       .then((rows) => rows[0] ?? null);
 
     if (!agentRecord || agentRecord.status === "terminated" || agentRecord.status === "pending_approval") {
-      next();
+      // API-key row exists but the agent it points to is missing, terminated,
+      // or unapproved. Same silent-fallthrough hole as the JWT branch above.
+      rejectInvalidBearer(res);
       return;
     }
 


### PR DESCRIPTION
…d fallthrough

Any `Authorization: Bearer …` header that fails every credential lookup (board API key, agent API key, agent JWT) previously fell through with the mode-default `req.actor`. In `local_trusted` mode that default is `{ type: 'board', userId: 'local-board', isInstanceAdmin: true }` — so callers presenting an invalid Bearer were silently promoted to full board access. Return 401 on every branch where a caller *attempted* Bearer auth and failed. Behavior for callers that send no Authorization header at all is intentionally preserved so existing `local_trusted` console UIs keep working; a follow-up conversation about opt-in strict mode is in the PR body.

Closes five silent-fallthrough branches in server/src/middleware/auth.ts:
  1. Empty token after `Bearer `.
  2. Bearer present but no board key, no agent-API-key row, invalid JWT.
  3. JWT verified but agent row missing / company_id mismatch.
  4. JWT verified but agent status is terminated or pending_approval.
  5. Agent-API-key row valid but agent status terminated or pending_approval.

All five now return `401 { error: 'Unauthorized',
reason: 'invalid_or_missing_bearer' }` — uniform reason string on purpose (no leaking which internal lookup failed to a caller probing tokens).

Tests: 5 new vitest cases in server/src/middleware/auth.test.ts, mirroring the fake-db style of cloud-tenant-actor.test.ts in the same directory.

## Thinking Path

<!--
  Required. Trace your reasoning from the top of the project down to this
  specific change. Start with what Paperclip is, then narrow through the
  subsystem, the problem, and why this PR exists. Use blockquote style.
  Aim for 5–8 steps. See CONTRIBUTING.md for full examples.
-->

> - Paperclip is the open source app people use to manage AI agents for work
> - [Which subsystem or capability is involved]
> - [What problem or gap exists]
> - [Why it needs to be addressed]
> - This pull request ...
> - The benefit is ...

## Linked Issues or Issue Description

<!--
  Required. Pick ONE of the following two paths:

  (A) Issue exists — tag each linked issue with `Fixes: #123`, `Closes #123`,
      or `Refs #123`. Include duplicates and closely related issues too.

  Only reference PUBLIC GitHub issues/PRs here. Do NOT paste internal,
  instance-local Paperclip references — ticket ids like PAPA-123 / PAP-224,
  /PAP/issues/... or agent://... links, or localhost/tailnet URLs. Other
  contributors cannot open them. See CONTRIBUTING.md → "No Internal Issue
  References".

  (B) No issue exists — describe the underlying problem here, following the
      relevant issue template so reviewers get the same fields:
        • Bug:     .github/ISSUE_TEMPLATE/bug_report.yml
        • Feature: .github/ISSUE_TEMPLATE/feature_request.yml
        • Adapter: .github/ISSUE_TEMPLATE/adapter_request.yml

  See CONTRIBUTING.md → "Link Issues or Describe Them In-PR".
-->

-

## What Changed

<!-- Bullet list of concrete changes. One bullet per logical unit. -->

-

## Verification

<!--
  How can a reviewer confirm this works? Include test commands, manual
  steps, or both.
-->

-

## Risks

<!--
  What could go wrong? Mention migration safety, breaking changes,
  behavioral shifts, or "Low risk" if genuinely minor.
-->

-

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

<!--
  Required. Specify which AI model was used to produce or assist with
  this change. Be as descriptive as possible — include:
    • Provider and model name (e.g., Claude, GPT, Gemini, Codex)
    • Exact model ID or version (e.g., claude-opus-4-6, gpt-4-turbo-2024-04-09)
    • Context window size if relevant (e.g., 1M context)
    • Reasoning/thinking mode if applicable (e.g., extended thinking, chain-of-thought)
    • Any other relevant capability details (e.g., tool use, code execution)
  If no AI model was used, write "None — human-authored".
-->

-

## Checklist

- [ ] I have included a thinking path that traces from project context to this change
- [ ] I have specified the model used (with version and capability details)
- [ ] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [ ] I have searched GitHub for duplicate or related PRs and linked them above
- [ ] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [ ] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [ ] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [ ] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [ ] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge
