### PR TITLE
fix(security): keep the Paperclip bearer token out of curl argv in bundled skills

### DIFF
--- a/skills/paperclip-create-agent/SKILL.md
+++ b/skills/paperclip-create-agent/SKILL.md
@@ -24,26 +24,36 @@ If you do not have this permission, escalate to your CEO or board.
 ### 1. Confirm identity and company context
 
 ```sh
-curl -sS "$PAPERCLIP_API_URL/api/agents/me" \
-  -H "Authorization: Bearer $PAPERCLIP_API_KEY"
+# Auth via mode-600 config file keeps the token out of curl argv (/proc/*/cmdline is world-readable).
+_AUTH=$(mktemp); chmod 600 "$_AUTH"
+printf 'header = "Authorization: Bearer %s"\n' "$PAPERCLIP_API_KEY" > "$_AUTH"
+curl -sS --config "$_AUTH" "$PAPERCLIP_API_URL/api/agents/me"
+rm -f "$_AUTH"
 ```
 
 ### 2. Discover adapter configuration for this Paperclip instance
 
 ```sh
-curl -sS "$PAPERCLIP_API_URL/llms/agent-configuration.txt" \
-  -H "Authorization: Bearer $PAPERCLIP_API_KEY"
+# Auth via mode-600 config file keeps the token out of curl argv (/proc/*/cmdline is world-readable).
+_AUTH=$(mktemp); chmod 600 "$_AUTH"
+printf 'header = "Authorization: Bearer %s"\n' "$PAPERCLIP_API_KEY" > "$_AUTH"
+
+curl -sS --config "$_AUTH" "$PAPERCLIP_API_URL/llms/agent-configuration.txt"
 
 # Then the specific adapter you plan to use, e.g. claude_local:
-curl -sS "$PAPERCLIP_API_URL/llms/agent-configuration/claude_local.txt" \
-  -H "Authorization: Bearer $PAPERCLIP_API_KEY"
+curl -sS --config "$_AUTH" "$PAPERCLIP_API_URL/llms/agent-configuration/claude_local.txt"
+
+rm -f "$_AUTH"
 ```
 
 ### 3. Compare existing agent configurations
 
 ```sh
-curl -sS "$PAPERCLIP_API_URL/api/companies/$PAPERCLIP_COMPANY_ID/agent-configurations" \
-  -H "Authorization: Bearer $PAPERCLIP_API_KEY"
+# Auth via mode-600 config file keeps the token out of curl argv (/proc/*/cmdline is world-readable).
+_AUTH=$(mktemp); chmod 600 "$_AUTH"
+printf 'header = "Authorization: Bearer %s"\n' "$PAPERCLIP_API_KEY" > "$_AUTH"
+curl -sS --config "$_AUTH" "$PAPERCLIP_API_URL/api/companies/$PAPERCLIP_COMPANY_ID/agent-configurations"
+rm -f "$_AUTH"
 ```
 
 Note naming, icon, reporting-line, and adapter conventions the company already follows.
@@ -67,8 +77,11 @@ State which path you took in your hire-request comment so the board can see the 
 ### 5. Discover allowed agent icons
 
 ```sh
-curl -sS "$PAPERCLIP_API_URL/llms/agent-icons.txt" \
-  -H "Authorization: Bearer $PAPERCLIP_API_KEY"
+# Auth via mode-600 config file keeps the token out of curl argv (/proc/*/cmdline is world-readable).
+_AUTH=$(mktemp); chmod 600 "$_AUTH"
+printf 'header = "Authorization: Bearer %s"\n' "$PAPERCLIP_API_KEY" > "$_AUTH"
+curl -sS --config "$_AUTH" "$PAPERCLIP_API_URL/llms/agent-icons.txt"
+rm -f "$_AUTH"
 ```
 
 ### 6. Draft the new hire config
@@ -96,8 +109,10 @@ Before submitting, walk the draft-review checklist end-to-end and fix any item t
 ### 8. Submit hire request
 
 ```sh
-curl -sS -X POST "$PAPERCLIP_API_URL/api/companies/$PAPERCLIP_COMPANY_ID/agent-hires" \
-  -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
+# Auth via mode-600 config file keeps the token out of curl argv (/proc/*/cmdline is world-readable).
+_AUTH=$(mktemp); chmod 600 "$_AUTH"
+printf 'header = "Authorization: Bearer %s"\n' "$PAPERCLIP_API_KEY" > "$_AUTH"
+curl -sS -X POST --config "$_AUTH" "$PAPERCLIP_API_URL/api/companies/$PAPERCLIP_COMPANY_ID/agent-hires" \
   -H "Content-Type: application/json" \
   -d '{
     "name": "CTO",
@@ -113,6 +128,7 @@ curl -sS -X POST "$PAPERCLIP_API_URL/api/companies/$PAPERCLIP_COMPANY_ID/agent-h
     "runtimeConfig": {"heartbeat": {"enabled": false, "wakeOnDemand": true}},
     "sourceIssueId": "<issue-id>"
   }'
+rm -f "$_AUTH"
 ```
 
 ### 9. Handle governance state
@@ -122,32 +138,43 @@ curl -sS -X POST "$PAPERCLIP_API_URL/api/companies/$PAPERCLIP_COMPANY_ID/agent-h
 - when the board approves, you will be woken with `PAPERCLIP_APPROVAL_ID`; read linked issues and close/comment follow-up
 
 ```sh
-curl -sS "$PAPERCLIP_API_URL/api/approvals/<approval-id>" \
-  -H "Authorization: Bearer $PAPERCLIP_API_KEY"
+# Auth via mode-600 config file keeps the token out of curl argv (/proc/*/cmdline is world-readable).
+_AUTH=$(mktemp); chmod 600 "$_AUTH"
+printf 'header = "Authorization: Bearer %s"\n' "$PAPERCLIP_API_KEY" > "$_AUTH"
 
-curl -sS -X POST "$PAPERCLIP_API_URL/api/approvals/<approval-id>/comments" \
-  -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
+curl -sS --config "$_AUTH" "$PAPERCLIP_API_URL/api/approvals/<approval-id>"
+
+curl -sS -X POST --config "$_AUTH" "$PAPERCLIP_API_URL/api/approvals/<approval-id>/comments" \
   -H "Content-Type: application/json" \
   -d '{"body":"## CTO hire request submitted\n\n- Approval: [<approval-id>](/approvals/<approval-id>)\n- Pending agent: [<agent-ref>](/agents/<agent-url-key-or-id>)\n- Source issue: [<issue-ref>](/issues/<issue-identifier-or-id>)\n\nUpdated prompt and adapter config per board feedback."}'
+
+rm -f "$_AUTH"
 ```
 
 If the approval already exists and needs manual linking to the issue:
 
 ```sh
-curl -sS -X POST "$PAPERCLIP_API_URL/api/issues/<issue-id>/approvals" \
-  -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
+# Auth via mode-600 config file keeps the token out of curl argv (/proc/*/cmdline is world-readable).
+_AUTH=$(mktemp); chmod 600 "$_AUTH"
+printf 'header = "Authorization: Bearer %s"\n' "$PAPERCLIP_API_KEY" > "$_AUTH"
+curl -sS -X POST --config "$_AUTH" "$PAPERCLIP_API_URL/api/issues/<issue-id>/approvals" \
   -H "Content-Type: application/json" \
   -d '{"approvalId":"<approval-id>"}'
+rm -f "$_AUTH"
 ```
 
 After approval is granted, run this follow-up loop:
 
 ```sh
-curl -sS "$PAPERCLIP_API_URL/api/approvals/$PAPERCLIP_APPROVAL_ID" \
-  -H "Authorization: Bearer $PAPERCLIP_API_KEY"
+# Auth via mode-600 config file keeps the token out of curl argv (/proc/*/cmdline is world-readable).
+_AUTH=$(mktemp); chmod 600 "$_AUTH"
+printf 'header = "Authorization: Bearer %s"\n' "$PAPERCLIP_API_KEY" > "$_AUTH"
 
-curl -sS "$PAPERCLIP_API_URL/api/approvals/$PAPERCLIP_APPROVAL_ID/issues" \
-  -H "Authorization: Bearer $PAPERCLIP_API_KEY"
+curl -sS --config "$_AUTH" "$PAPERCLIP_API_URL/api/approvals/$PAPERCLIP_APPROVAL_ID"
+
+curl -sS --config "$_AUTH" "$PAPERCLIP_API_URL/api/approvals/$PAPERCLIP_APPROVAL_ID/issues"
+
+rm -f "$_AUTH"
 ```
 
 For each linked issue, either:

--- a/skills/paperclip-create-agent/SKILL.md
+++ b/skills/paperclip-create-agent/SKILL.md
@@ -22,38 +22,31 @@ If you do not have this permission, escalate to your CEO or board.
 ## Workflow
 
 ### 1. Confirm identity and company context
-
 ```sh
-# Auth via mode-600 config file keeps the token out of curl argv (/proc/*/cmdline is world-readable).
-_AUTH=$(mktemp); chmod 600 "$_AUTH"
-printf 'header = "Authorization: Bearer %s"\n' "$PAPERCLIP_API_KEY" > "$_AUTH"
-curl -sS --config "$_AUTH" "$PAPERCLIP_API_URL/api/agents/me"
-rm -f "$_AUTH"
+# Auth via a piped curl config: the token stays out of curl argv
+# (/proc/*/cmdline is world-readable) and is never written to disk.
+_auth() { printf 'header = "Authorization: Bearer %s"\n' "$PAPERCLIP_API_KEY"; }
+_auth | curl -sS --config - "$PAPERCLIP_API_URL/api/agents/me"
 ```
 
 ### 2. Discover adapter configuration for this Paperclip instance
-
 ```sh
-# Auth via mode-600 config file keeps the token out of curl argv (/proc/*/cmdline is world-readable).
-_AUTH=$(mktemp); chmod 600 "$_AUTH"
-printf 'header = "Authorization: Bearer %s"\n' "$PAPERCLIP_API_KEY" > "$_AUTH"
+# Auth via a piped curl config: the token stays out of curl argv
+# (/proc/*/cmdline is world-readable) and is never written to disk.
+_auth() { printf 'header = "Authorization: Bearer %s"\n' "$PAPERCLIP_API_KEY"; }
 
-curl -sS --config "$_AUTH" "$PAPERCLIP_API_URL/llms/agent-configuration.txt"
+_auth | curl -sS --config - "$PAPERCLIP_API_URL/llms/agent-configuration.txt"
 
 # Then the specific adapter you plan to use, e.g. claude_local:
-curl -sS --config "$_AUTH" "$PAPERCLIP_API_URL/llms/agent-configuration/claude_local.txt"
-
-rm -f "$_AUTH"
+_auth | curl -sS --config - "$PAPERCLIP_API_URL/llms/agent-configuration/claude_local.txt"
 ```
 
 ### 3. Compare existing agent configurations
-
 ```sh
-# Auth via mode-600 config file keeps the token out of curl argv (/proc/*/cmdline is world-readable).
-_AUTH=$(mktemp); chmod 600 "$_AUTH"
-printf 'header = "Authorization: Bearer %s"\n' "$PAPERCLIP_API_KEY" > "$_AUTH"
-curl -sS --config "$_AUTH" "$PAPERCLIP_API_URL/api/companies/$PAPERCLIP_COMPANY_ID/agent-configurations"
-rm -f "$_AUTH"
+# Auth via a piped curl config: the token stays out of curl argv
+# (/proc/*/cmdline is world-readable) and is never written to disk.
+_auth() { printf 'header = "Authorization: Bearer %s"\n' "$PAPERCLIP_API_KEY"; }
+_auth | curl -sS --config - "$PAPERCLIP_API_URL/api/companies/$PAPERCLIP_COMPANY_ID/agent-configurations"
 ```
 
 Note naming, icon, reporting-line, and adapter conventions the company already follows.
@@ -75,13 +68,11 @@ Generic fallback for no-template hires:
 State which path you took in your hire-request comment so the board can see the reasoning.
 
 ### 5. Discover allowed agent icons
-
 ```sh
-# Auth via mode-600 config file keeps the token out of curl argv (/proc/*/cmdline is world-readable).
-_AUTH=$(mktemp); chmod 600 "$_AUTH"
-printf 'header = "Authorization: Bearer %s"\n' "$PAPERCLIP_API_KEY" > "$_AUTH"
-curl -sS --config "$_AUTH" "$PAPERCLIP_API_URL/llms/agent-icons.txt"
-rm -f "$_AUTH"
+# Auth via a piped curl config: the token stays out of curl argv
+# (/proc/*/cmdline is world-readable) and is never written to disk.
+_auth() { printf 'header = "Authorization: Bearer %s"\n' "$PAPERCLIP_API_KEY"; }
+_auth | curl -sS --config - "$PAPERCLIP_API_URL/llms/agent-icons.txt"
 ```
 
 ### 6. Draft the new hire config
@@ -107,12 +98,11 @@ Before submitting, walk the draft-review checklist end-to-end and fix any item t
 `skills/paperclip-create-agent/references/draft-review-checklist.md`
 
 ### 8. Submit hire request
-
 ```sh
-# Auth via mode-600 config file keeps the token out of curl argv (/proc/*/cmdline is world-readable).
-_AUTH=$(mktemp); chmod 600 "$_AUTH"
-printf 'header = "Authorization: Bearer %s"\n' "$PAPERCLIP_API_KEY" > "$_AUTH"
-curl -sS -X POST --config "$_AUTH" "$PAPERCLIP_API_URL/api/companies/$PAPERCLIP_COMPANY_ID/agent-hires" \
+# Auth via a piped curl config: the token stays out of curl argv
+# (/proc/*/cmdline is world-readable) and is never written to disk.
+_auth() { printf 'header = "Authorization: Bearer %s"\n' "$PAPERCLIP_API_KEY"; }
+_auth | curl -sS -X POST --config - "$PAPERCLIP_API_URL/api/companies/$PAPERCLIP_COMPANY_ID/agent-hires" \
   -H "Content-Type: application/json" \
   -d '{
     "name": "CTO",
@@ -128,7 +118,6 @@ curl -sS -X POST --config "$_AUTH" "$PAPERCLIP_API_URL/api/companies/$PAPERCLIP_
     "runtimeConfig": {"heartbeat": {"enabled": false, "wakeOnDemand": true}},
     "sourceIssueId": "<issue-id>"
   }'
-rm -f "$_AUTH"
 ```
 
 ### 9. Handle governance state
@@ -136,45 +125,37 @@ rm -f "$_AUTH"
 - if the response has `approval`, the hire is `pending_approval`
 - monitor and discuss on the approval thread
 - when the board approves, you will be woken with `PAPERCLIP_APPROVAL_ID`; read linked issues and close/comment follow-up
-
 ```sh
-# Auth via mode-600 config file keeps the token out of curl argv (/proc/*/cmdline is world-readable).
-_AUTH=$(mktemp); chmod 600 "$_AUTH"
-printf 'header = "Authorization: Bearer %s"\n' "$PAPERCLIP_API_KEY" > "$_AUTH"
+# Auth via a piped curl config: the token stays out of curl argv
+# (/proc/*/cmdline is world-readable) and is never written to disk.
+_auth() { printf 'header = "Authorization: Bearer %s"\n' "$PAPERCLIP_API_KEY"; }
 
-curl -sS --config "$_AUTH" "$PAPERCLIP_API_URL/api/approvals/<approval-id>"
+_auth | curl -sS --config - "$PAPERCLIP_API_URL/api/approvals/<approval-id>"
 
-curl -sS -X POST --config "$_AUTH" "$PAPERCLIP_API_URL/api/approvals/<approval-id>/comments" \
+_auth | curl -sS -X POST --config - "$PAPERCLIP_API_URL/api/approvals/<approval-id>/comments" \
   -H "Content-Type: application/json" \
   -d '{"body":"## CTO hire request submitted\n\n- Approval: [<approval-id>](/approvals/<approval-id>)\n- Pending agent: [<agent-ref>](/agents/<agent-url-key-or-id>)\n- Source issue: [<issue-ref>](/issues/<issue-identifier-or-id>)\n\nUpdated prompt and adapter config per board feedback."}'
-
-rm -f "$_AUTH"
 ```
 
 If the approval already exists and needs manual linking to the issue:
-
 ```sh
-# Auth via mode-600 config file keeps the token out of curl argv (/proc/*/cmdline is world-readable).
-_AUTH=$(mktemp); chmod 600 "$_AUTH"
-printf 'header = "Authorization: Bearer %s"\n' "$PAPERCLIP_API_KEY" > "$_AUTH"
-curl -sS -X POST --config "$_AUTH" "$PAPERCLIP_API_URL/api/issues/<issue-id>/approvals" \
+# Auth via a piped curl config: the token stays out of curl argv
+# (/proc/*/cmdline is world-readable) and is never written to disk.
+_auth() { printf 'header = "Authorization: Bearer %s"\n' "$PAPERCLIP_API_KEY"; }
+_auth | curl -sS -X POST --config - "$PAPERCLIP_API_URL/api/issues/<issue-id>/approvals" \
   -H "Content-Type: application/json" \
   -d '{"approvalId":"<approval-id>"}'
-rm -f "$_AUTH"
 ```
 
 After approval is granted, run this follow-up loop:
-
 ```sh
-# Auth via mode-600 config file keeps the token out of curl argv (/proc/*/cmdline is world-readable).
-_AUTH=$(mktemp); chmod 600 "$_AUTH"
-printf 'header = "Authorization: Bearer %s"\n' "$PAPERCLIP_API_KEY" > "$_AUTH"
+# Auth via a piped curl config: the token stays out of curl argv
+# (/proc/*/cmdline is world-readable) and is never written to disk.
+_auth() { printf 'header = "Authorization: Bearer %s"\n' "$PAPERCLIP_API_KEY"; }
 
-curl -sS --config "$_AUTH" "$PAPERCLIP_API_URL/api/approvals/$PAPERCLIP_APPROVAL_ID"
+_auth | curl -sS --config - "$PAPERCLIP_API_URL/api/approvals/$PAPERCLIP_APPROVAL_ID"
 
-curl -sS --config "$_AUTH" "$PAPERCLIP_API_URL/api/approvals/$PAPERCLIP_APPROVAL_ID/issues"
-
-rm -f "$_AUTH"
+_auth | curl -sS --config - "$PAPERCLIP_API_URL/api/approvals/$PAPERCLIP_APPROVAL_ID/issues"
 ```
 
 For each linked issue, either:

--- a/skills/paperclip/SKILL.md
+++ b/skills/paperclip/SKILL.md
@@ -19,6 +19,18 @@ In Paperclip, **task** and **issue** refer to the same work item. The UI may use
 
 Env vars auto-injected: `PAPERCLIP_AGENT_ID`, `PAPERCLIP_COMPANY_ID`, `PAPERCLIP_API_URL`, `PAPERCLIP_RUN_ID`. Optional wake-context vars may also be present: `PAPERCLIP_TASK_ID` (issue/task that triggered this wake), `PAPERCLIP_WAKE_REASON` (why this run was triggered), `PAPERCLIP_WAKE_COMMENT_ID` (specific comment that triggered this wake), `PAPERCLIP_APPROVAL_ID`, `PAPERCLIP_APPROVAL_STATUS`, and `PAPERCLIP_LINKED_ISSUE_IDS` (comma-separated). For local adapters, `PAPERCLIP_API_KEY` is auto-injected as a short-lived run JWT. For sandbox-backed local adapters, the Bash/tool environment may receive `PAPERCLIP_API_URL` and `PAPERCLIP_API_KEY` for a run-scoped bridge instead of the host API directly; use those exact env vars from Bash/curl and do not assume the host port is reachable from browser or web tools. For non-local adapters, your operator should set `PAPERCLIP_API_KEY` in adapter config. All requests use `Authorization: Bearer $PAPERCLIP_API_KEY`. All endpoints under `/api`, all JSON. Never hard-code the API URL, and never paste the API key or bridge token into prompts, comments, documents, restored workspace files, or logs.
 
+**Safe curl pattern (required):** Never pass `$PAPERCLIP_API_KEY` as a literal `-H "Authorization: Bearer $PAPERCLIP_API_KEY"` curl argument — process args are world-readable via `/proc/*/cmdline` on Linux. Always write auth headers to a mode-600 temp file and pass it with `--config`:
+
+```bash
+_AUTH=$(mktemp); chmod 600 "$_AUTH"
+printf 'header = "Authorization: Bearer %s"\n' "$PAPERCLIP_API_KEY" > "$_AUTH"
+printf 'header = "X-Paperclip-Run-Id: %s"\n' "$PAPERCLIP_RUN_ID" >> "$_AUTH"
+curl -sS --config "$_AUTH" [other curl args]
+rm -f "$_AUTH"
+```
+
+The bundled helper `scripts/paperclip-upload-artifact.sh` applies this pattern automatically — prefer it over raw curl for uploads.
+
 Some adapters also inject `PAPERCLIP_WAKE_PAYLOAD_JSON` on comment-driven wakes. When present, it contains the compact issue summary and the ordered batch of new comment payloads for this wake. Use it first. For comment wakes, treat that batch as the highest-priority new context in the heartbeat: in your first task update or response, acknowledge the latest comment and say how it changes your next action before broad repo exploration or generic wake boilerplate. Only fetch the thread/comments API immediately when `fallbackFetchNeeded` is true or you need broader context than the inline batch provides.
 
 Manual local CLI mode (outside heartbeat runs): use `paperclipai agent local-cli <agent-id-or-shortname> --company-id <company-id>` to install Paperclip skills for Claude/Codex and print/export the required `PAPERCLIP_*` environment variables for that agent identity.

--- a/skills/paperclip/SKILL.md
+++ b/skills/paperclip/SKILL.md
@@ -19,14 +19,15 @@ In Paperclip, **task** and **issue** refer to the same work item. The UI may use
 
 Env vars auto-injected: `PAPERCLIP_AGENT_ID`, `PAPERCLIP_COMPANY_ID`, `PAPERCLIP_API_URL`, `PAPERCLIP_RUN_ID`. Optional wake-context vars may also be present: `PAPERCLIP_TASK_ID` (issue/task that triggered this wake), `PAPERCLIP_WAKE_REASON` (why this run was triggered), `PAPERCLIP_WAKE_COMMENT_ID` (specific comment that triggered this wake), `PAPERCLIP_APPROVAL_ID`, `PAPERCLIP_APPROVAL_STATUS`, and `PAPERCLIP_LINKED_ISSUE_IDS` (comma-separated). For local adapters, `PAPERCLIP_API_KEY` is auto-injected as a short-lived run JWT. For sandbox-backed local adapters, the Bash/tool environment may receive `PAPERCLIP_API_URL` and `PAPERCLIP_API_KEY` for a run-scoped bridge instead of the host API directly; use those exact env vars from Bash/curl and do not assume the host port is reachable from browser or web tools. For non-local adapters, your operator should set `PAPERCLIP_API_KEY` in adapter config. All requests use `Authorization: Bearer $PAPERCLIP_API_KEY`. All endpoints under `/api`, all JSON. Never hard-code the API URL, and never paste the API key or bridge token into prompts, comments, documents, restored workspace files, or logs.
 
-**Safe curl pattern (required):** Never pass `$PAPERCLIP_API_KEY` as a literal `-H "Authorization: Bearer $PAPERCLIP_API_KEY"` curl argument — process args are world-readable via `/proc/*/cmdline` on Linux. Always write auth headers to a mode-600 temp file and pass it with `--config`:
-
+**Safe curl pattern (required):** Never pass `$PAPERCLIP_API_KEY` as a literal `-H "Authorization: Bearer $PAPERCLIP_API_KEY"` curl argument — process args are world-readable via `/proc/*/cmdline` on Linux. Pipe the auth headers into `curl --config -` instead. Do not write them to a temp file: that keeps the token out of argv, but leaves a credential on disk whose deletion an interrupted run can skip.
 ```bash
-_AUTH=$(mktemp); chmod 600 "$_AUTH"
-printf 'header = "Authorization: Bearer %s"\n' "$PAPERCLIP_API_KEY" > "$_AUTH"
-printf 'header = "X-Paperclip-Run-Id: %s"\n' "$PAPERCLIP_RUN_ID" >> "$_AUTH"
-curl -sS --config "$_AUTH" [other curl args]
-rm -f "$_AUTH"
+# Auth via a piped curl config: the token stays out of curl argv
+# (/proc/*/cmdline is world-readable) and is never written to disk.
+_auth() {
+  printf 'header = "Authorization: Bearer %s"\n' "$PAPERCLIP_API_KEY"
+  printf 'header = "X-Paperclip-Run-Id: %s"\n' "$PAPERCLIP_RUN_ID"
+}
+_auth | curl -sS --config - [other curl args]
 ```
 
 The bundled helper `scripts/paperclip-upload-artifact.sh` applies this pattern automatically — prefer it over raw curl for uploads.
@@ -68,7 +69,6 @@ Overrides and special cases:
 - Nothing assigned and no valid mention handoff → exit the heartbeat.
 
 **Step 5 — Checkout.** You MUST checkout before doing any work. Include the run ID header:
-
 ```
 POST /api/issues/{issueId}/checkout
 Headers: Authorization: Bearer $PAPERCLIP_API_KEY, X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID
@@ -133,7 +133,6 @@ Before ending any heartbeat, apply this final-disposition checklist:
 - Explicit continuation: keep the issue `in_progress` only when there is an active run, queued continuation, or a real scheduled monitor/recovery path (not a narrated one) that will wake the responsible assignee. Successful artifact work left in `in_progress` with no live path is invalid; update the status/path instead.
 
 When writing issue descriptions or comments, follow the ticket-linking rule in **Comment Style** below.
-
 ```json
 PATCH /api/issues/{issueId}
 Headers: X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID
@@ -141,7 +140,6 @@ Headers: X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID
 ```
 
 For multiline markdown comments, do **not** hand-inline the markdown into a one-line JSON string — that is how comments get "smooshed" together. Use the helper below (or an equivalent `jq --arg` pattern reading from a heredoc/file) so literal newlines survive JSON encoding:
-
 ```bash
 scripts/paperclip-issue-update.sh --issue-id "$PAPERCLIP_TASK_ID" --status done <<'MD'
 Done
@@ -200,7 +198,6 @@ Every archive/unarchive mutation must include `X-Paperclip-Run-Id`. User policy 
 Express "A is blocked by B" as first-class blockers so dependent work auto-resumes.
 
 **Set blockers** via `blockedByIssueIds` (array of issue IDs) on create or update:
-
 ```json
 POST /api/companies/{companyId}/issues
 { "title": "Deploy to prod", "blockedByIssueIds": ["id-1","id-2"], "status": "blocked" }
@@ -223,7 +220,6 @@ The array **replaces** the current set on each update — send `[]` to clear. Is
 ## Requesting Board Approval
 
 Use `request_board_approval` when you need the board to approve/deny a proposed action:
-
 ```json
 POST /api/companies/{companyId}/approvals
 {
@@ -332,7 +328,6 @@ Bundle related cross-issue decisions with `POST /api/companies/{companyId}/decis
 Bundles accept 1–50 decisions and are created atomically. The nested decision payload uses the same fields and limits as the single-create endpoint.
 
 Create a `request_checkbox_confirmation` (board selects any subset, then confirms):
-
 ```json
 POST /api/issues/{issueId}/interactions
 {
@@ -544,7 +539,6 @@ Do NOT use unprefixed paths like `/issues/PAP-123` or `/agents/cto` — always i
 **Preserve markdown line breaks (required):** build multiline JSON bodies from heredoc/file input (via the helper in Step 8 or `jq -n --arg comment "$comment"`). Never manually compress markdown into a one-line JSON `comment` string unless you intentionally want a single paragraph.
 
 Example:
-
 ```md
 ## Update
 
@@ -576,7 +570,6 @@ When asked to convert a plan into executable Paperclip tasks — depth, assignme
 When asked to convert a plan into executable Paperclip tasks — depth, assignment, dependencies, parallelization — use the companion skill `paperclip-converting-plans-to-tasks`.
 
 Recommended API flow:
-
 ```bash
 PUT /api/issues/{issueId}/documents/plan
 {
@@ -621,7 +614,6 @@ Full endpoint table (company imports/exports, OpenClaw invites, company skills, 
 ## Searching Issues
 
 Use the `q` query parameter on the issues list endpoint to search across titles, identifiers, descriptions, and comments:
-
 ```
 GET /api/companies/{companyId}/issues?q=dockerfile
 ```

--- a/skills/paperclip/SKILL.md
+++ b/skills/paperclip/SKILL.md
@@ -17,7 +17,7 @@ In Paperclip, **task** and **issue** refer to the same work item. The UI may use
 
 ## Authentication
 
-Env vars auto-injected: `PAPERCLIP_AGENT_ID`, `PAPERCLIP_COMPANY_ID`, `PAPERCLIP_API_URL`, `PAPERCLIP_RUN_ID`. Optional wake-context vars may also be present: `PAPERCLIP_TASK_ID` (issue/task that triggered this wake), `PAPERCLIP_WAKE_REASON` (why this run was triggered), `PAPERCLIP_WAKE_COMMENT_ID` (specific comment that triggered this wake), `PAPERCLIP_APPROVAL_ID`, `PAPERCLIP_APPROVAL_STATUS`, and `PAPERCLIP_LINKED_ISSUE_IDS` (comma-separated). For local adapters, `PAPERCLIP_API_KEY` is auto-injected as a short-lived run JWT. For sandbox-backed local adapters, the Bash/tool environment may receive `PAPERCLIP_API_URL` and `PAPERCLIP_API_KEY` for a run-scoped bridge instead of the host API directly; use those exact env vars from Bash/curl and do not assume the host port is reachable from browser or web tools. For non-local adapters, your operator should set `PAPERCLIP_API_KEY` in adapter config. All requests use `Authorization: Bearer $PAPERCLIP_API_KEY`. All endpoints under `/api`, all JSON. Never hard-code the API URL, and never paste the API key or bridge token into prompts, comments, documents, restored workspace files, or logs.
+Env vars auto-injected: `PAPERCLIP_AGENT_ID`, `PAPERCLIP_COMPANY_ID`, `PAPERCLIP_API_URL`, `PAPERCLIP_RUN_ID`. Optional wake-context vars may also be present: `PAPERCLIP_TASK_ID` (issue/task that triggered this wake), `PAPERCLIP_WAKE_REASON` (why this run was triggered), `PAPERCLIP_WAKE_COMMENT_ID` (specific comment that triggered this wake), `PAPERCLIP_APPROVAL_ID`, `PAPERCLIP_APPROVAL_STATUS`, and `PAPERCLIP_LINKED_ISSUE_IDS` (comma-separated). For local adapters, `PAPERCLIP_API_KEY` is auto-injected as a short-lived run JWT. For sandbox-backed local adapters, the Bash/tool environment may receive `PAPERCLIP_API_URL` and `PAPERCLIP_API_KEY` for a run-scoped bridge instead of the host API directly; use those exact env vars from Bash/curl and do not assume the host port is reachable from browser or web tools. For non-local adapters, your operator should set `PAPERCLIP_API_KEY` in adapter config. All requests authenticate with `$PAPERCLIP_API_KEY` as a bearer token — see the **Safe curl pattern** below for correct invocation. All endpoints under `/api`, all JSON. Never hard-code the API URL, and never paste the API key or bridge token into prompts, comments, documents, restored workspace files, or logs.
 
 **Safe curl pattern (required):** Never pass `$PAPERCLIP_API_KEY` as a literal `-H "Authorization: Bearer $PAPERCLIP_API_KEY"` curl argument — process args are world-readable via `/proc/*/cmdline` on Linux. Pipe the auth headers into `curl --config -` instead. Do not write them to a temp file: that keeps the token out of argv, but leaves a credential on disk whose deletion an interrupted run can skip.
 ```bash
@@ -69,10 +69,10 @@ Overrides and special cases:
 - Nothing assigned and no valid mention handoff → exit the heartbeat.
 
 **Step 5 — Checkout.** You MUST checkout before doing any work. Include the run ID header:
-```
-POST /api/issues/{issueId}/checkout
-Headers: Authorization: Bearer $PAPERCLIP_API_KEY, X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID
-{ "agentId": "{your-agent-id}", "expectedStatuses": ["todo", "backlog", "blocked", "in_review"] }
+```bash
+_auth | curl -sS --config - -X POST "$PAPERCLIP_API_BASE/api/issues/{issueId}/checkout" \
+  -H "Content-Type: application/json" \
+  -d '{"agentId":"{your-agent-id}","expectedStatuses":["todo","backlog","blocked","in_review"]}'
 ```
 
 If already checked out by you, returns normally. If owned by another agent: `409 Conflict` — stop, pick a different task. **Never retry a 409.**

--- a/skills/paperclip/references/artifacts.md
+++ b/skills/paperclip/references/artifacts.md
@@ -52,31 +52,37 @@ workspace root; do not use host-local absolute paths in `resourceRef`.
 Create the work product with:
 
 ```bash
-curl -sS -X POST \
+# Safe: write auth to config file so token stays out of curl argv (/proc/*/cmdline is world-readable)
+_AUTH=$(mktemp); chmod 600 "$_AUTH"
+printf 'header = "Authorization: Bearer %s"\n' "$PAPERCLIP_API_KEY" > "$_AUTH"
+printf 'header = "X-Paperclip-Run-Id: %s"\n' "$PAPERCLIP_RUN_ID" >> "$_AUTH"
+curl -sS -X POST --config "$_AUTH" \
   "$PAPERCLIP_API_URL/api/issues/$PAPERCLIP_TASK_ID/work-products" \
-  -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
-  -H "X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID" \
   -H "Content-Type: application/json" \
   --data-binary @workspace-file-work-product.json
+rm -f "$_AUTH"
 ```
 
 If the helper is unavailable, use the Paperclip API directly:
 
 ```bash
-curl -sS -X POST \
+_AUTH=$(mktemp); chmod 600 "$_AUTH"
+printf 'header = "Authorization: Bearer %s"\n' "$PAPERCLIP_API_KEY" > "$_AUTH"
+printf 'header = "X-Paperclip-Run-Id: %s"\n' "$PAPERCLIP_RUN_ID" >> "$_AUTH"
+curl -sS -X POST --config "$_AUTH" \
   "$PAPERCLIP_API_URL/api/companies/$PAPERCLIP_COMPANY_ID/issues/$PAPERCLIP_TASK_ID/attachments" \
-  -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
-  -H "X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID" \
   -F 'file=@"path/to/output.webm";type=video/webm'
+rm -f "$_AUTH"
 ```
 
 Then create a work product when the file is the deliverable. The server canonicalizes attachment-backed artifact metadata from the `attachmentId`:
 
 ```bash
-curl -sS -X POST \
+_AUTH=$(mktemp); chmod 600 "$_AUTH"
+printf 'header = "Authorization: Bearer %s"\n' "$PAPERCLIP_API_KEY" > "$_AUTH"
+printf 'header = "X-Paperclip-Run-Id: %s"\n' "$PAPERCLIP_RUN_ID" >> "$_AUTH"
+curl -sS -X POST --config "$_AUTH" \
   "$PAPERCLIP_API_URL/api/issues/$PAPERCLIP_TASK_ID/work-products" \
-  -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
-  -H "X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID" \
   -H "Content-Type: application/json" \
   --data-binary '{
     "type": "artifact",
@@ -87,6 +93,7 @@ curl -sS -X POST \
     "isPrimary": true,
     "metadata": { "attachmentId": "<uploaded-attachment-id>" }
   }'
+rm -f "$_AUTH"
 ```
 
 In your final issue comment, link the uploaded attachment or work product and

--- a/skills/paperclip/references/artifacts.md
+++ b/skills/paperclip/references/artifacts.md
@@ -3,7 +3,6 @@
 When work produces a user-inspectable file, upload true deliverables to the current issue before final disposition. Local filesystem paths are not enough because board users, reviewers, and cloud operators may not have access to the agent workspace.
 
 Use the helper bundled with this skill. From an installed `paperclip` skill directory, the helper lives at `scripts/paperclip-upload-artifact.sh`:
-
 ```bash
 scripts/paperclip-upload-artifact.sh path/to/output.webm \
   --title "Walkthrough render" \
@@ -21,7 +20,6 @@ uploading a deliverable file that a board user should be able to inspect outside
 the workspace.
 
 Annotate the work product with `metadata.resourceRef`:
-
 ```json
 {
   "type": "document",
@@ -50,38 +48,41 @@ optional positive integers. `relativePath` must be relative to the selected
 workspace root; do not use host-local absolute paths in `resourceRef`.
 
 Create the work product with:
-
 ```bash
-# Safe: write auth to config file so token stays out of curl argv (/proc/*/cmdline is world-readable)
-_AUTH=$(mktemp); chmod 600 "$_AUTH"
-printf 'header = "Authorization: Bearer %s"\n' "$PAPERCLIP_API_KEY" > "$_AUTH"
-printf 'header = "X-Paperclip-Run-Id: %s"\n' "$PAPERCLIP_RUN_ID" >> "$_AUTH"
-curl -sS -X POST --config "$_AUTH" \
+# Auth via a piped curl config: the token stays out of curl argv
+# (/proc/*/cmdline is world-readable) and is never written to disk.
+_auth() {
+  printf 'header = "Authorization: Bearer %s"\n' "$PAPERCLIP_API_KEY"
+  printf 'header = "X-Paperclip-Run-Id: %s"\n' "$PAPERCLIP_RUN_ID"
+}
+_auth | curl -sS -X POST --config - \
   "$PAPERCLIP_API_URL/api/issues/$PAPERCLIP_TASK_ID/work-products" \
   -H "Content-Type: application/json" \
   --data-binary @workspace-file-work-product.json
-rm -f "$_AUTH"
 ```
 
 If the helper is unavailable, use the Paperclip API directly:
-
 ```bash
-_AUTH=$(mktemp); chmod 600 "$_AUTH"
-printf 'header = "Authorization: Bearer %s"\n' "$PAPERCLIP_API_KEY" > "$_AUTH"
-printf 'header = "X-Paperclip-Run-Id: %s"\n' "$PAPERCLIP_RUN_ID" >> "$_AUTH"
-curl -sS -X POST --config "$_AUTH" \
+# Auth via a piped curl config: the token stays out of curl argv
+# (/proc/*/cmdline is world-readable) and is never written to disk.
+_auth() {
+  printf 'header = "Authorization: Bearer %s"\n' "$PAPERCLIP_API_KEY"
+  printf 'header = "X-Paperclip-Run-Id: %s"\n' "$PAPERCLIP_RUN_ID"
+}
+_auth | curl -sS -X POST --config - \
   "$PAPERCLIP_API_URL/api/companies/$PAPERCLIP_COMPANY_ID/issues/$PAPERCLIP_TASK_ID/attachments" \
   -F 'file=@"path/to/output.webm";type=video/webm'
-rm -f "$_AUTH"
 ```
 
 Then create a work product when the file is the deliverable. The server canonicalizes attachment-backed artifact metadata from the `attachmentId`:
-
 ```bash
-_AUTH=$(mktemp); chmod 600 "$_AUTH"
-printf 'header = "Authorization: Bearer %s"\n' "$PAPERCLIP_API_KEY" > "$_AUTH"
-printf 'header = "X-Paperclip-Run-Id: %s"\n' "$PAPERCLIP_RUN_ID" >> "$_AUTH"
-curl -sS -X POST --config "$_AUTH" \
+# Auth via a piped curl config: the token stays out of curl argv
+# (/proc/*/cmdline is world-readable) and is never written to disk.
+_auth() {
+  printf 'header = "Authorization: Bearer %s"\n' "$PAPERCLIP_API_KEY"
+  printf 'header = "X-Paperclip-Run-Id: %s"\n' "$PAPERCLIP_RUN_ID"
+}
+_auth | curl -sS -X POST --config - \
   "$PAPERCLIP_API_URL/api/issues/$PAPERCLIP_TASK_ID/work-products" \
   -H "Content-Type: application/json" \
   --data-binary '{
@@ -93,7 +94,6 @@ curl -sS -X POST --config "$_AUTH" \
     "isPrimary": true,
     "metadata": { "attachmentId": "<uploaded-attachment-id>" }
   }'
-rm -f "$_AUTH"
 ```
 
 In your final issue comment, link the uploaded attachment or work product and

--- a/skills/paperclip/references/company-skills.md
+++ b/skills/paperclip/references/company-skills.md
@@ -77,24 +77,22 @@ Two paths cover the common cases:
 Browse, inspect, and install catalog skills before reaching for an external
 source. Bundled skills are the curated defaults for any company; optional
 skills are role- or domain-specific.
-
 ```sh
 # Write auth to a mode-600 config file so the token never appears in curl argv
 # (/proc/*/cmdline is world-readable on Linux). Reused across the calls below.
-_AUTH=$(mktemp); chmod 600 "$_AUTH"
-printf 'header = "Authorization: Bearer %s"\n' "$PAPERCLIP_API_KEY" > "$_AUTH"
+# Auth via a piped curl config: the token stays out of curl argv
+# (/proc/*/cmdline is world-readable) and is never written to disk.
+_auth() { printf 'header = "Authorization: Bearer %s"\n' "$PAPERCLIP_API_KEY"; }
 
-curl -sS --config "$_AUTH" "$PAPERCLIP_API_URL/api/skills/catalog?kind=bundled"
+_auth | curl -sS --config - "$PAPERCLIP_API_URL/api/skills/catalog?kind=bundled"
 
-curl -sS --config "$_AUTH" "$PAPERCLIP_API_URL/api/skills/catalog/ref?ref=github-pr-workflow"
+_auth | curl -sS --config - "$PAPERCLIP_API_URL/api/skills/catalog/ref?ref=github-pr-workflow"
 
-curl -sS -X POST --config "$_AUTH" "$PAPERCLIP_API_URL/api/companies/$PAPERCLIP_COMPANY_ID/skills/install-catalog" \
+_auth | curl -sS -X POST --config - "$PAPERCLIP_API_URL/api/companies/$PAPERCLIP_COMPANY_ID/skills/install-catalog" \
   -H "Content-Type: application/json" \
   -d '{
     "catalogSkillId": "paperclipai:bundled:software-development:github-pr-workflow"
   }'
-
-rm -f "$_AUTH"
 ```
 
 The install response records provenance (`catalogId`, `catalogKey`,
@@ -118,45 +116,39 @@ Import using a **skills.sh URL**, a key-style source string, a GitHub URL, or a 
 **Critical:** If a user gives you a `https://skills.sh/...` URL, use that URL or its key-style equivalent (`org/repo/skill-name`) as the `source`. Do **not** convert it to a GitHub URL — skills.sh is the managed registry and the source of truth for versioning, discovery, and updates.
 
 ### Example: skills.sh import (preferred)
-
 ```sh
-# Auth via mode-600 config file keeps the token out of curl argv (/proc/*/cmdline is world-readable).
-_AUTH=$(mktemp); chmod 600 "$_AUTH"
-printf 'header = "Authorization: Bearer %s"\n' "$PAPERCLIP_API_KEY" > "$_AUTH"
-curl -sS -X POST --config "$_AUTH" "$PAPERCLIP_API_URL/api/companies/$PAPERCLIP_COMPANY_ID/skills/import" \
+# Auth via a piped curl config: the token stays out of curl argv
+# (/proc/*/cmdline is world-readable) and is never written to disk.
+_auth() { printf 'header = "Authorization: Bearer %s"\n' "$PAPERCLIP_API_KEY"; }
+_auth | curl -sS -X POST --config - "$PAPERCLIP_API_URL/api/companies/$PAPERCLIP_COMPANY_ID/skills/import" \
   -H "Content-Type: application/json" \
   -d '{
     "source": "https://skills.sh/google-labs-code/stitch-skills/design-md"
   }'
-rm -f "$_AUTH"
 ```
 
 Or equivalently using the key-style string:
-
 ```sh
-# Auth via mode-600 config file keeps the token out of curl argv (/proc/*/cmdline is world-readable).
-_AUTH=$(mktemp); chmod 600 "$_AUTH"
-printf 'header = "Authorization: Bearer %s"\n' "$PAPERCLIP_API_KEY" > "$_AUTH"
-curl -sS -X POST --config "$_AUTH" "$PAPERCLIP_API_URL/api/companies/$PAPERCLIP_COMPANY_ID/skills/import" \
+# Auth via a piped curl config: the token stays out of curl argv
+# (/proc/*/cmdline is world-readable) and is never written to disk.
+_auth() { printf 'header = "Authorization: Bearer %s"\n' "$PAPERCLIP_API_KEY"; }
+_auth | curl -sS -X POST --config - "$PAPERCLIP_API_URL/api/companies/$PAPERCLIP_COMPANY_ID/skills/import" \
   -H "Content-Type: application/json" \
   -d '{
     "source": "google-labs-code/stitch-skills/design-md"
   }'
-rm -f "$_AUTH"
 ```
 
 ### Example: GitHub import
-
 ```sh
-# Auth via mode-600 config file keeps the token out of curl argv (/proc/*/cmdline is world-readable).
-_AUTH=$(mktemp); chmod 600 "$_AUTH"
-printf 'header = "Authorization: Bearer %s"\n' "$PAPERCLIP_API_KEY" > "$_AUTH"
-curl -sS -X POST --config "$_AUTH" "$PAPERCLIP_API_URL/api/companies/$PAPERCLIP_COMPANY_ID/skills/import" \
+# Auth via a piped curl config: the token stays out of curl argv
+# (/proc/*/cmdline is world-readable) and is never written to disk.
+_auth() { printf 'header = "Authorization: Bearer %s"\n' "$PAPERCLIP_API_KEY"; }
+_auth | curl -sS -X POST --config - "$PAPERCLIP_API_URL/api/companies/$PAPERCLIP_COMPANY_ID/skills/import" \
   -H "Content-Type: application/json" \
   -d '{
     "source": "https://github.com/vercel-labs/agent-browser"
   }'
-rm -f "$_AUTH"
 ```
 
 You can also use source strings such as:
@@ -166,39 +158,32 @@ You can also use source strings such as:
 - `npx skills add https://github.com/vercel-labs/agent-browser --skill agent-browser`
 
 If the task is to discover skills from the company project workspaces first:
-
 ```sh
-# Auth via mode-600 config file keeps the token out of curl argv (/proc/*/cmdline is world-readable).
-_AUTH=$(mktemp); chmod 600 "$_AUTH"
-printf 'header = "Authorization: Bearer %s"\n' "$PAPERCLIP_API_KEY" > "$_AUTH"
-curl -sS -X POST --config "$_AUTH" "$PAPERCLIP_API_URL/api/companies/$PAPERCLIP_COMPANY_ID/skills/scan-projects" \
+# Auth via a piped curl config: the token stays out of curl argv
+# (/proc/*/cmdline is world-readable) and is never written to disk.
+_auth() { printf 'header = "Authorization: Bearer %s"\n' "$PAPERCLIP_API_KEY"; }
+_auth | curl -sS -X POST --config - "$PAPERCLIP_API_URL/api/companies/$PAPERCLIP_COMPANY_ID/skills/scan-projects" \
   -H "Content-Type: application/json" \
   -d '{}'
-rm -f "$_AUTH"
 ```
 
 ## Inspect What Was Installed
-
 ```sh
-# Auth via mode-600 config file keeps the token out of curl argv (/proc/*/cmdline is world-readable).
-_AUTH=$(mktemp); chmod 600 "$_AUTH"
-printf 'header = "Authorization: Bearer %s"\n' "$PAPERCLIP_API_KEY" > "$_AUTH"
-curl -sS --config "$_AUTH" "$PAPERCLIP_API_URL/api/companies/$PAPERCLIP_COMPANY_ID/skills"
-rm -f "$_AUTH"
+# Auth via a piped curl config: the token stays out of curl argv
+# (/proc/*/cmdline is world-readable) and is never written to disk.
+_auth() { printf 'header = "Authorization: Bearer %s"\n' "$PAPERCLIP_API_KEY"; }
+_auth | curl -sS --config - "$PAPERCLIP_API_URL/api/companies/$PAPERCLIP_COMPANY_ID/skills"
 ```
 
 Read the skill entry and its `SKILL.md`:
-
 ```sh
-# Auth via mode-600 config file keeps the token out of curl argv (/proc/*/cmdline is world-readable).
-_AUTH=$(mktemp); chmod 600 "$_AUTH"
-printf 'header = "Authorization: Bearer %s"\n' "$PAPERCLIP_API_KEY" > "$_AUTH"
+# Auth via a piped curl config: the token stays out of curl argv
+# (/proc/*/cmdline is world-readable) and is never written to disk.
+_auth() { printf 'header = "Authorization: Bearer %s"\n' "$PAPERCLIP_API_KEY"; }
 
-curl -sS --config "$_AUTH" "$PAPERCLIP_API_URL/api/companies/$PAPERCLIP_COMPANY_ID/skills/<skill-id>"
+_auth | curl -sS --config - "$PAPERCLIP_API_URL/api/companies/$PAPERCLIP_COMPANY_ID/skills/<skill-id>"
 
-curl -sS --config "$_AUTH" "$PAPERCLIP_API_URL/api/companies/$PAPERCLIP_COMPANY_ID/skills/<skill-id>/files?path=SKILL.md"
-
-rm -f "$_AUTH"
+_auth | curl -sS --config - "$PAPERCLIP_API_URL/api/companies/$PAPERCLIP_COMPANY_ID/skills/<skill-id>/files?path=SKILL.md"
 ```
 
 ## Assign Skills To An Existing Agent
@@ -216,12 +201,11 @@ The request must include a merge mode:
 - `add` adds the named skills and keeps every other assignment.
 - `remove` removes only the named skills.
 - `replace` overwrites the complete desired skill set. Use it only after explicit confirmation.
-
 ```sh
-# Auth via mode-600 config file keeps the token out of curl argv (/proc/*/cmdline is world-readable).
-_AUTH=$(mktemp); chmod 600 "$_AUTH"
-printf 'header = "Authorization: Bearer %s"\n' "$PAPERCLIP_API_KEY" > "$_AUTH"
-curl -sS -X POST --config "$_AUTH" "$PAPERCLIP_API_URL/api/agents/<agent-id>/skills/sync" \
+# Auth via a piped curl config: the token stays out of curl argv
+# (/proc/*/cmdline is world-readable) and is never written to disk.
+_auth() { printf 'header = "Authorization: Bearer %s"\n' "$PAPERCLIP_API_KEY"; }
+_auth | curl -sS -X POST --config - "$PAPERCLIP_API_URL/api/agents/<agent-id>/skills/sync" \
   -H "Content-Type: application/json" \
   -d '{
     "mode": "add",
@@ -229,28 +213,24 @@ curl -sS -X POST --config "$_AUTH" "$PAPERCLIP_API_URL/api/agents/<agent-id>/ski
       "vercel-labs/agent-browser/agent-browser"
     ]
   }'
-rm -f "$_AUTH"
 ```
 
 If you need the current state first:
-
 ```sh
-# Auth via mode-600 config file keeps the token out of curl argv (/proc/*/cmdline is world-readable).
-_AUTH=$(mktemp); chmod 600 "$_AUTH"
-printf 'header = "Authorization: Bearer %s"\n' "$PAPERCLIP_API_KEY" > "$_AUTH"
-curl -sS --config "$_AUTH" "$PAPERCLIP_API_URL/api/agents/<agent-id>/skills"
-rm -f "$_AUTH"
+# Auth via a piped curl config: the token stays out of curl argv
+# (/proc/*/cmdline is world-readable) and is never written to disk.
+_auth() { printf 'header = "Authorization: Bearer %s"\n' "$PAPERCLIP_API_KEY"; }
+_auth | curl -sS --config - "$PAPERCLIP_API_URL/api/agents/<agent-id>/skills"
 ```
 
 ## Include Skills During Hire Or Create
 
 Use the same company skill keys or references in `desiredSkills` when hiring or creating an agent:
-
 ```sh
-# Auth via mode-600 config file keeps the token out of curl argv (/proc/*/cmdline is world-readable).
-_AUTH=$(mktemp); chmod 600 "$_AUTH"
-printf 'header = "Authorization: Bearer %s"\n' "$PAPERCLIP_API_KEY" > "$_AUTH"
-curl -sS -X POST --config "$_AUTH" "$PAPERCLIP_API_URL/api/companies/$PAPERCLIP_COMPANY_ID/agent-hires" \
+# Auth via a piped curl config: the token stays out of curl argv
+# (/proc/*/cmdline is world-readable) and is never written to disk.
+_auth() { printf 'header = "Authorization: Bearer %s"\n' "$PAPERCLIP_API_KEY"; }
+_auth | curl -sS -X POST --config - "$PAPERCLIP_API_URL/api/companies/$PAPERCLIP_COMPANY_ID/agent-hires" \
   -H "Content-Type: application/json" \
   -d '{
     "name": "QA Browser Agent",
@@ -263,16 +243,14 @@ curl -sS -X POST --config "$_AUTH" "$PAPERCLIP_API_URL/api/companies/$PAPERCLIP_
       "agent-browser"
     ]
   }'
-rm -f "$_AUTH"
 ```
 
 For direct create without approval:
-
 ```sh
-# Auth via mode-600 config file keeps the token out of curl argv (/proc/*/cmdline is world-readable).
-_AUTH=$(mktemp); chmod 600 "$_AUTH"
-printf 'header = "Authorization: Bearer %s"\n' "$PAPERCLIP_API_KEY" > "$_AUTH"
-curl -sS -X POST --config "$_AUTH" "$PAPERCLIP_API_URL/api/companies/$PAPERCLIP_COMPANY_ID/agents" \
+# Auth via a piped curl config: the token stays out of curl argv
+# (/proc/*/cmdline is world-readable) and is never written to disk.
+_auth() { printf 'header = "Authorization: Bearer %s"\n' "$PAPERCLIP_API_KEY"; }
+_auth | curl -sS -X POST --config - "$PAPERCLIP_API_URL/api/companies/$PAPERCLIP_COMPANY_ID/agents" \
   -H "Content-Type: application/json" \
   -d '{
     "name": "QA Browser Agent",

--- a/skills/paperclip/references/company-skills.md
+++ b/skills/paperclip/references/company-skills.md
@@ -79,18 +79,22 @@ source. Bundled skills are the curated defaults for any company; optional
 skills are role- or domain-specific.
 
 ```sh
-curl -sS "$PAPERCLIP_API_URL/api/skills/catalog?kind=bundled" \
-  -H "Authorization: Bearer $PAPERCLIP_API_KEY"
+# Write auth to a mode-600 config file so the token never appears in curl argv
+# (/proc/*/cmdline is world-readable on Linux). Reused across the calls below.
+_AUTH=$(mktemp); chmod 600 "$_AUTH"
+printf 'header = "Authorization: Bearer %s"\n' "$PAPERCLIP_API_KEY" > "$_AUTH"
 
-curl -sS "$PAPERCLIP_API_URL/api/skills/catalog/ref?ref=github-pr-workflow" \
-  -H "Authorization: Bearer $PAPERCLIP_API_KEY"
+curl -sS --config "$_AUTH" "$PAPERCLIP_API_URL/api/skills/catalog?kind=bundled"
 
-curl -sS -X POST "$PAPERCLIP_API_URL/api/companies/$PAPERCLIP_COMPANY_ID/skills/install-catalog" \
-  -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
+curl -sS --config "$_AUTH" "$PAPERCLIP_API_URL/api/skills/catalog/ref?ref=github-pr-workflow"
+
+curl -sS -X POST --config "$_AUTH" "$PAPERCLIP_API_URL/api/companies/$PAPERCLIP_COMPANY_ID/skills/install-catalog" \
   -H "Content-Type: application/json" \
   -d '{
     "catalogSkillId": "paperclipai:bundled:software-development:github-pr-workflow"
   }'
+
+rm -f "$_AUTH"
 ```
 
 The install response records provenance (`catalogId`, `catalogKey`,
@@ -116,34 +120,43 @@ Import using a **skills.sh URL**, a key-style source string, a GitHub URL, or a 
 ### Example: skills.sh import (preferred)
 
 ```sh
-curl -sS -X POST "$PAPERCLIP_API_URL/api/companies/$PAPERCLIP_COMPANY_ID/skills/import" \
-  -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
+# Auth via mode-600 config file keeps the token out of curl argv (/proc/*/cmdline is world-readable).
+_AUTH=$(mktemp); chmod 600 "$_AUTH"
+printf 'header = "Authorization: Bearer %s"\n' "$PAPERCLIP_API_KEY" > "$_AUTH"
+curl -sS -X POST --config "$_AUTH" "$PAPERCLIP_API_URL/api/companies/$PAPERCLIP_COMPANY_ID/skills/import" \
   -H "Content-Type: application/json" \
   -d '{
     "source": "https://skills.sh/google-labs-code/stitch-skills/design-md"
   }'
+rm -f "$_AUTH"
 ```
 
 Or equivalently using the key-style string:
 
 ```sh
-curl -sS -X POST "$PAPERCLIP_API_URL/api/companies/$PAPERCLIP_COMPANY_ID/skills/import" \
-  -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
+# Auth via mode-600 config file keeps the token out of curl argv (/proc/*/cmdline is world-readable).
+_AUTH=$(mktemp); chmod 600 "$_AUTH"
+printf 'header = "Authorization: Bearer %s"\n' "$PAPERCLIP_API_KEY" > "$_AUTH"
+curl -sS -X POST --config "$_AUTH" "$PAPERCLIP_API_URL/api/companies/$PAPERCLIP_COMPANY_ID/skills/import" \
   -H "Content-Type: application/json" \
   -d '{
     "source": "google-labs-code/stitch-skills/design-md"
   }'
+rm -f "$_AUTH"
 ```
 
 ### Example: GitHub import
 
 ```sh
-curl -sS -X POST "$PAPERCLIP_API_URL/api/companies/$PAPERCLIP_COMPANY_ID/skills/import" \
-  -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
+# Auth via mode-600 config file keeps the token out of curl argv (/proc/*/cmdline is world-readable).
+_AUTH=$(mktemp); chmod 600 "$_AUTH"
+printf 'header = "Authorization: Bearer %s"\n' "$PAPERCLIP_API_KEY" > "$_AUTH"
+curl -sS -X POST --config "$_AUTH" "$PAPERCLIP_API_URL/api/companies/$PAPERCLIP_COMPANY_ID/skills/import" \
   -H "Content-Type: application/json" \
   -d '{
     "source": "https://github.com/vercel-labs/agent-browser"
   }'
+rm -f "$_AUTH"
 ```
 
 You can also use source strings such as:
@@ -155,27 +168,37 @@ You can also use source strings such as:
 If the task is to discover skills from the company project workspaces first:
 
 ```sh
-curl -sS -X POST "$PAPERCLIP_API_URL/api/companies/$PAPERCLIP_COMPANY_ID/skills/scan-projects" \
-  -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
+# Auth via mode-600 config file keeps the token out of curl argv (/proc/*/cmdline is world-readable).
+_AUTH=$(mktemp); chmod 600 "$_AUTH"
+printf 'header = "Authorization: Bearer %s"\n' "$PAPERCLIP_API_KEY" > "$_AUTH"
+curl -sS -X POST --config "$_AUTH" "$PAPERCLIP_API_URL/api/companies/$PAPERCLIP_COMPANY_ID/skills/scan-projects" \
   -H "Content-Type: application/json" \
   -d '{}'
+rm -f "$_AUTH"
 ```
 
 ## Inspect What Was Installed
 
 ```sh
-curl -sS "$PAPERCLIP_API_URL/api/companies/$PAPERCLIP_COMPANY_ID/skills" \
-  -H "Authorization: Bearer $PAPERCLIP_API_KEY"
+# Auth via mode-600 config file keeps the token out of curl argv (/proc/*/cmdline is world-readable).
+_AUTH=$(mktemp); chmod 600 "$_AUTH"
+printf 'header = "Authorization: Bearer %s"\n' "$PAPERCLIP_API_KEY" > "$_AUTH"
+curl -sS --config "$_AUTH" "$PAPERCLIP_API_URL/api/companies/$PAPERCLIP_COMPANY_ID/skills"
+rm -f "$_AUTH"
 ```
 
 Read the skill entry and its `SKILL.md`:
 
 ```sh
-curl -sS "$PAPERCLIP_API_URL/api/companies/$PAPERCLIP_COMPANY_ID/skills/<skill-id>" \
-  -H "Authorization: Bearer $PAPERCLIP_API_KEY"
+# Auth via mode-600 config file keeps the token out of curl argv (/proc/*/cmdline is world-readable).
+_AUTH=$(mktemp); chmod 600 "$_AUTH"
+printf 'header = "Authorization: Bearer %s"\n' "$PAPERCLIP_API_KEY" > "$_AUTH"
 
-curl -sS "$PAPERCLIP_API_URL/api/companies/$PAPERCLIP_COMPANY_ID/skills/<skill-id>/files?path=SKILL.md" \
-  -H "Authorization: Bearer $PAPERCLIP_API_KEY"
+curl -sS --config "$_AUTH" "$PAPERCLIP_API_URL/api/companies/$PAPERCLIP_COMPANY_ID/skills/<skill-id>"
+
+curl -sS --config "$_AUTH" "$PAPERCLIP_API_URL/api/companies/$PAPERCLIP_COMPANY_ID/skills/<skill-id>/files?path=SKILL.md"
+
+rm -f "$_AUTH"
 ```
 
 ## Assign Skills To An Existing Agent
@@ -195,8 +218,10 @@ The request must include a merge mode:
 - `replace` overwrites the complete desired skill set. Use it only after explicit confirmation.
 
 ```sh
-curl -sS -X POST "$PAPERCLIP_API_URL/api/agents/<agent-id>/skills/sync" \
-  -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
+# Auth via mode-600 config file keeps the token out of curl argv (/proc/*/cmdline is world-readable).
+_AUTH=$(mktemp); chmod 600 "$_AUTH"
+printf 'header = "Authorization: Bearer %s"\n' "$PAPERCLIP_API_KEY" > "$_AUTH"
+curl -sS -X POST --config "$_AUTH" "$PAPERCLIP_API_URL/api/agents/<agent-id>/skills/sync" \
   -H "Content-Type: application/json" \
   -d '{
     "mode": "add",
@@ -204,13 +229,17 @@ curl -sS -X POST "$PAPERCLIP_API_URL/api/agents/<agent-id>/skills/sync" \
       "vercel-labs/agent-browser/agent-browser"
     ]
   }'
+rm -f "$_AUTH"
 ```
 
 If you need the current state first:
 
 ```sh
-curl -sS "$PAPERCLIP_API_URL/api/agents/<agent-id>/skills" \
-  -H "Authorization: Bearer $PAPERCLIP_API_KEY"
+# Auth via mode-600 config file keeps the token out of curl argv (/proc/*/cmdline is world-readable).
+_AUTH=$(mktemp); chmod 600 "$_AUTH"
+printf 'header = "Authorization: Bearer %s"\n' "$PAPERCLIP_API_KEY" > "$_AUTH"
+curl -sS --config "$_AUTH" "$PAPERCLIP_API_URL/api/agents/<agent-id>/skills"
+rm -f "$_AUTH"
 ```
 
 ## Include Skills During Hire Or Create
@@ -218,8 +247,10 @@ curl -sS "$PAPERCLIP_API_URL/api/agents/<agent-id>/skills" \
 Use the same company skill keys or references in `desiredSkills` when hiring or creating an agent:
 
 ```sh
-curl -sS -X POST "$PAPERCLIP_API_URL/api/companies/$PAPERCLIP_COMPANY_ID/agent-hires" \
-  -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
+# Auth via mode-600 config file keeps the token out of curl argv (/proc/*/cmdline is world-readable).
+_AUTH=$(mktemp); chmod 600 "$_AUTH"
+printf 'header = "Authorization: Bearer %s"\n' "$PAPERCLIP_API_KEY" > "$_AUTH"
+curl -sS -X POST --config "$_AUTH" "$PAPERCLIP_API_URL/api/companies/$PAPERCLIP_COMPANY_ID/agent-hires" \
   -H "Content-Type: application/json" \
   -d '{
     "name": "QA Browser Agent",
@@ -232,13 +263,16 @@ curl -sS -X POST "$PAPERCLIP_API_URL/api/companies/$PAPERCLIP_COMPANY_ID/agent-h
       "agent-browser"
     ]
   }'
+rm -f "$_AUTH"
 ```
 
 For direct create without approval:
 
 ```sh
-curl -sS -X POST "$PAPERCLIP_API_URL/api/companies/$PAPERCLIP_COMPANY_ID/agents" \
-  -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
+# Auth via mode-600 config file keeps the token out of curl argv (/proc/*/cmdline is world-readable).
+_AUTH=$(mktemp); chmod 600 "$_AUTH"
+printf 'header = "Authorization: Bearer %s"\n' "$PAPERCLIP_API_KEY" > "$_AUTH"
+curl -sS -X POST --config "$_AUTH" "$PAPERCLIP_API_URL/api/companies/$PAPERCLIP_COMPANY_ID/agents" \
   -H "Content-Type: application/json" \
   -d '{
     "name": "QA Browser Agent",

--- a/skills/paperclip/references/issue-workspaces.md
+++ b/skills/paperclip/references/issue-workspaces.md
@@ -7,8 +7,13 @@ Use this reference when an issue has an isolated execution workspace and you nee
 Start from the issue, not from memory:
 
 ```sh
-curl -sS -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
+# Write auth to a mode-600 config file so the token never appears in curl argv
+# (/proc/*/cmdline is world-readable on Linux).
+_AUTH=$(mktemp); chmod 600 "$_AUTH"
+printf 'header = "Authorization: Bearer %s"\n' "$PAPERCLIP_API_KEY" > "$_AUTH"
+curl -sS --config "$_AUTH" \
   "$PAPERCLIP_API_URL/api/issues/$PAPERCLIP_TASK_ID/heartbeat-context"
+rm -f "$_AUTH"
 ```
 
 Read `currentExecutionWorkspace`:
@@ -25,29 +30,31 @@ If `currentExecutionWorkspace` is `null`, the issue does not currently have a re
 Prefer Paperclip-managed runtime service controls over manual `pnpm dev &` or ad-hoc background processes. These endpoints keep service state, URLs, logs, and ownership visible to other agents and the board.
 
 ```sh
+# Write auth to a mode-600 config file so the token never appears in curl argv
+# (/proc/*/cmdline is world-readable on Linux). Reused across the calls below.
+_AUTH=$(mktemp); chmod 600 "$_AUTH"
+printf 'header = "Authorization: Bearer %s"\n' "$PAPERCLIP_API_KEY" > "$_AUTH"
+printf 'header = "X-Paperclip-Run-Id: %s"\n' "$PAPERCLIP_RUN_ID" >> "$_AUTH"
+
 # Start all configured services; waits for configured readiness checks.
-curl -sS -X POST \
-  -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
-  -H "X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID" \
+curl -sS -X POST --config "$_AUTH" \
   -H "Content-Type: application/json" \
   "$PAPERCLIP_API_URL/api/execution-workspaces/<workspace-id>/runtime-services/start" \
   -d '{}'
 
 # Restart all configured services.
-curl -sS -X POST \
-  -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
-  -H "X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID" \
+curl -sS -X POST --config "$_AUTH" \
   -H "Content-Type: application/json" \
   "$PAPERCLIP_API_URL/api/execution-workspaces/<workspace-id>/runtime-services/restart" \
   -d '{}'
 
 # Stop all running services.
-curl -sS -X POST \
-  -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
-  -H "X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID" \
+curl -sS -X POST --config "$_AUTH" \
   -H "Content-Type: application/json" \
   "$PAPERCLIP_API_URL/api/execution-workspaces/<workspace-id>/runtime-services/stop" \
   -d '{}'
+
+rm -f "$_AUTH"
 ```
 
 To target a configured service, pass one of:

--- a/skills/paperclip/references/issue-workspaces.md
+++ b/skills/paperclip/references/issue-workspaces.md
@@ -5,15 +5,14 @@ Use this reference when an issue has an isolated execution workspace and you nee
 ## Discover the Workspace
 
 Start from the issue, not from memory:
-
 ```sh
 # Write auth to a mode-600 config file so the token never appears in curl argv
 # (/proc/*/cmdline is world-readable on Linux).
-_AUTH=$(mktemp); chmod 600 "$_AUTH"
-printf 'header = "Authorization: Bearer %s"\n' "$PAPERCLIP_API_KEY" > "$_AUTH"
-curl -sS --config "$_AUTH" \
+# Auth via a piped curl config: the token stays out of curl argv
+# (/proc/*/cmdline is world-readable) and is never written to disk.
+_auth() { printf 'header = "Authorization: Bearer %s"\n' "$PAPERCLIP_API_KEY"; }
+_auth | curl -sS --config - \
   "$PAPERCLIP_API_URL/api/issues/$PAPERCLIP_TASK_ID/heartbeat-context"
-rm -f "$_AUTH"
 ```
 
 Read `currentExecutionWorkspace`:
@@ -28,37 +27,36 @@ If `currentExecutionWorkspace` is `null`, the issue does not currently have a re
 ## Control Services
 
 Prefer Paperclip-managed runtime service controls over manual `pnpm dev &` or ad-hoc background processes. These endpoints keep service state, URLs, logs, and ownership visible to other agents and the board.
-
 ```sh
 # Write auth to a mode-600 config file so the token never appears in curl argv
 # (/proc/*/cmdline is world-readable on Linux). Reused across the calls below.
-_AUTH=$(mktemp); chmod 600 "$_AUTH"
-printf 'header = "Authorization: Bearer %s"\n' "$PAPERCLIP_API_KEY" > "$_AUTH"
-printf 'header = "X-Paperclip-Run-Id: %s"\n' "$PAPERCLIP_RUN_ID" >> "$_AUTH"
+# Auth via a piped curl config: the token stays out of curl argv
+# (/proc/*/cmdline is world-readable) and is never written to disk.
+_auth() {
+  printf 'header = "Authorization: Bearer %s"\n' "$PAPERCLIP_API_KEY"
+  printf 'header = "X-Paperclip-Run-Id: %s"\n' "$PAPERCLIP_RUN_ID"
+}
 
 # Start all configured services; waits for configured readiness checks.
-curl -sS -X POST --config "$_AUTH" \
+_auth | curl -sS -X POST --config - \
   -H "Content-Type: application/json" \
   "$PAPERCLIP_API_URL/api/execution-workspaces/<workspace-id>/runtime-services/start" \
   -d '{}'
 
 # Restart all configured services.
-curl -sS -X POST --config "$_AUTH" \
+_auth | curl -sS -X POST --config - \
   -H "Content-Type: application/json" \
   "$PAPERCLIP_API_URL/api/execution-workspaces/<workspace-id>/runtime-services/restart" \
   -d '{}'
 
 # Stop all running services.
-curl -sS -X POST --config "$_AUTH" \
+_auth | curl -sS -X POST --config - \
   -H "Content-Type: application/json" \
   "$PAPERCLIP_API_URL/api/execution-workspaces/<workspace-id>/runtime-services/stop" \
   -d '{}'
-
-rm -f "$_AUTH"
 ```
 
 To target a configured service, pass one of:
-
 ```json
 { "workspaceCommandId": "web" }
 { "runtimeServiceId": "<runtime-service-id>" }

--- a/skills/paperclip/scripts/paperclip-upload-artifact.sh
+++ b/skills/paperclip/scripts/paperclip-upload-artifact.sh
@@ -2,6 +2,18 @@
 
 set -euo pipefail
 
+# All temp files (auth configs that carry the bearer token, plus curl response
+# bodies) live under a single workspace dir owned by the main shell. A main-shell
+# trap removes them on normal exit and on catchable interruption (INT/TERM),
+# closing the window where an interrupted run could leave a mode-600 auth config
+# behind. A per-function trap can't cover this: request_json/upload_file run
+# inside command substitutions, so a signal delivered to this script's process
+# never reaches those subshells. (SIGKILL is uncatchable, so a kill -9 in the
+# gap can still orphan the dir — that residue is inherent to SIGKILL.)
+_WORKDIR="$(mktemp -d)"
+cleanup_workdir() { rm -rf "$_WORKDIR"; }
+trap cleanup_workdir EXIT INT TERM
+
 usage() {
   cat <<'EOF'
 Usage:
@@ -87,7 +99,7 @@ write_auth_config() {
   # Writes auth headers to a mode-600 temp file so they never appear in curl argv
   # (process args are world-readable via /proc/*/cmdline on Linux).
   local cfg
-  cfg="$(mktemp)"
+  cfg="$(mktemp -p "$_WORKDIR")"
   chmod 600 "$cfg"
   printf 'header = "Authorization: Bearer %s"\n' "$PAPERCLIP_API_KEY" > "$cfg"
   printf 'header = "X-Paperclip-Run-Id: %s"\n' "$PAPERCLIP_RUN_ID" >> "$cfg"
@@ -103,7 +115,7 @@ request_json() {
   local auth_cfg
 
   auth_cfg="$(write_auth_config)"
-  response_file="$(mktemp)"
+  response_file="$(mktemp -p "$_WORKDIR")"
   if [[ -n "$body" ]]; then
     status_code="$(
       curl -sS -X "$method" -w '%{http_code}' -o "$response_file" \
@@ -145,7 +157,7 @@ upload_file() {
   escaped_path="${path//\\/\\\\}"
   escaped_path="${escaped_path//\"/\\\"}"
   auth_cfg="$(write_auth_config)"
-  response_file="$(mktemp)"
+  response_file="$(mktemp -p "$_WORKDIR")"
   status_code="$(
     curl -sS -X POST -w '%{http_code}' -o "$response_file" \
       --config "$auth_cfg" \

--- a/skills/paperclip/scripts/paperclip-upload-artifact.sh
+++ b/skills/paperclip/scripts/paperclip-upload-artifact.sh
@@ -83,31 +83,43 @@ detect_content_type() {
   esac
 }
 
+write_auth_config() {
+  # Writes auth headers to a mode-600 temp file so they never appear in curl argv
+  # (process args are world-readable via /proc/*/cmdline on Linux).
+  local cfg
+  cfg="$(mktemp)"
+  chmod 600 "$cfg"
+  printf 'header = "Authorization: Bearer %s"\n' "$PAPERCLIP_API_KEY" > "$cfg"
+  printf 'header = "X-Paperclip-Run-Id: %s"\n' "$PAPERCLIP_RUN_ID" >> "$cfg"
+  printf '%s' "$cfg"
+}
+
 request_json() {
   local method="$1"
   local url="$2"
   local body="${3:-}"
   local response_file
   local status_code
+  local auth_cfg
 
+  auth_cfg="$(write_auth_config)"
   response_file="$(mktemp)"
   if [[ -n "$body" ]]; then
     status_code="$(
       curl -sS -X "$method" -w '%{http_code}' -o "$response_file" \
+        --config "$auth_cfg" \
         "$url" \
-        -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
-        -H "X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID" \
         -H 'Content-Type: application/json' \
         --data-binary "$body"
     )"
   else
     status_code="$(
       curl -sS -X "$method" -w '%{http_code}' -o "$response_file" \
-        "$url" \
-        -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
-        -H "X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID"
+        --config "$auth_cfg" \
+        "$url"
     )"
   fi
+  rm -f "$auth_cfg"
 
   if [[ "$status_code" -lt 200 || "$status_code" -ge 300 ]]; then
     printf 'Request failed (%s): %s\n' "$status_code" "$url" >&2
@@ -128,17 +140,19 @@ upload_file() {
   local escaped_path
   local response_file
   local status_code
+  local auth_cfg
 
   escaped_path="${path//\\/\\\\}"
   escaped_path="${escaped_path//\"/\\\"}"
+  auth_cfg="$(write_auth_config)"
   response_file="$(mktemp)"
   status_code="$(
     curl -sS -X POST -w '%{http_code}' -o "$response_file" \
+      --config "$auth_cfg" \
       "$url" \
-      -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
-      -H "X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID" \
       -F "file=@\"${escaped_path}\";type=${content_type}"
   )"
+  rm -f "$auth_cfg"
 
   if [[ "$status_code" -lt 200 || "$status_code" -ge 300 ]]; then
     printf 'Upload failed (%s): %s\n' "$status_code" "$url" >&2

--- a/skills/paperclip/scripts/paperclip-upload-artifact.sh
+++ b/skills/paperclip/scripts/paperclip-upload-artifact.sh
@@ -2,14 +2,11 @@
 
 set -euo pipefail
 
-# All temp files (auth configs that carry the bearer token, plus curl response
-# bodies) live under a single workspace dir owned by the main shell. A main-shell
-# trap removes them on normal exit and on catchable interruption (INT/TERM),
-# closing the window where an interrupted run could leave a mode-600 auth config
-# behind. A per-function trap can't cover this: request_json/upload_file run
-# inside command substitutions, so a signal delivered to this script's process
-# never reaches those subshells. (SIGKILL is uncatchable, so a kill -9 in the
-# gap can still orphan the dir — that residue is inherent to SIGKILL.)
+# The bearer token is never written to disk and never passed as a curl argument
+# (see write_auth_config). What remains under this workspace is curl response
+# bodies, which hold no credential. A main-shell trap clears them on exit and on
+# catchable interruption; the trap is best-effort tidying, not a security
+# control, so the deferred-trap and SIGKILL cases below cost nothing.
 _WORKDIR="$(mktemp -d)"
 cleanup_workdir() { rm -rf "$_WORKDIR"; }
 trap cleanup_workdir EXIT INT TERM
@@ -96,14 +93,23 @@ detect_content_type() {
 }
 
 write_auth_config() {
-  # Writes auth headers to a mode-600 temp file so they never appear in curl argv
-  # (process args are world-readable via /proc/*/cmdline on Linux).
-  local cfg
-  cfg="$(mktemp -p "$_WORKDIR")"
-  chmod 600 "$cfg"
-  printf 'header = "Authorization: Bearer %s"\n' "$PAPERCLIP_API_KEY" > "$cfg"
-  printf 'header = "X-Paperclip-Run-Id: %s"\n' "$PAPERCLIP_RUN_ID" >> "$cfg"
-  printf '%s' "$cfg"
+  # Emits a curl config carrying the auth headers on stdout, to be piped into
+  # `curl --config -`.
+  #
+  # Two properties matter, and a temp file buys only the first:
+  #
+  #  - The token never appears in curl argv. Process arguments are
+  #    world-readable through /proc/*/cmdline on Linux, so
+  #    `-H "Authorization: Bearer $TOKEN"` hands the credential to every
+  #    process on the host.
+  #  - The token never touches disk at all. A mode-600 temp file still has to
+  #    be deleted, and any deletion can be skipped. A supervisor that signals
+  #    this script's PID does not interrupt curl, and bash defers a trap until
+  #    its foreground child returns, so cleanup can be postponed for as long as
+  #    the request hangs; SIGKILL skips it outright. Passing the config through
+  #    a pipe removes the file, and with it the whole class of problem.
+  printf 'header = "Authorization: Bearer %s"\n' "$PAPERCLIP_API_KEY"
+  printf 'header = "X-Paperclip-Run-Id: %s"\n' "$PAPERCLIP_RUN_ID"
 }
 
 request_json() {
@@ -112,26 +118,23 @@ request_json() {
   local body="${3:-}"
   local response_file
   local status_code
-  local auth_cfg
 
-  auth_cfg="$(write_auth_config)"
   response_file="$(mktemp -p "$_WORKDIR")"
   if [[ -n "$body" ]]; then
     status_code="$(
-      curl -sS -X "$method" -w '%{http_code}' -o "$response_file" \
-        --config "$auth_cfg" \
+      write_auth_config | curl -sS -X "$method" -w '%{http_code}' -o "$response_file" \
+        --config - \
         "$url" \
         -H 'Content-Type: application/json' \
         --data-binary "$body"
     )"
   else
     status_code="$(
-      curl -sS -X "$method" -w '%{http_code}' -o "$response_file" \
-        --config "$auth_cfg" \
+      write_auth_config | curl -sS -X "$method" -w '%{http_code}' -o "$response_file" \
+        --config - \
         "$url"
     )"
   fi
-  rm -f "$auth_cfg"
 
   if [[ "$status_code" -lt 200 || "$status_code" -ge 300 ]]; then
     printf 'Request failed (%s): %s\n' "$status_code" "$url" >&2
@@ -152,19 +155,16 @@ upload_file() {
   local escaped_path
   local response_file
   local status_code
-  local auth_cfg
 
   escaped_path="${path//\\/\\\\}"
   escaped_path="${escaped_path//\"/\\\"}"
-  auth_cfg="$(write_auth_config)"
   response_file="$(mktemp -p "$_WORKDIR")"
   status_code="$(
-    curl -sS -X POST -w '%{http_code}' -o "$response_file" \
-      --config "$auth_cfg" \
+    write_auth_config | curl -sS -X POST -w '%{http_code}' -o "$response_file" \
+      --config - \
       "$url" \
       -F "file=@\"${escaped_path}\";type=${content_type}"
   )"
-  rm -f "$auth_cfg"
 
   if [[ "$status_code" -lt 200 || "$status_code" -ge 300 ]]; then
     printf 'Upload failed (%s): %s\n' "$status_code" "$url" >&2

--- a/skills/paperclip/scripts/paperclip-upload-artifact.test.mjs
+++ b/skills/paperclip/scripts/paperclip-upload-artifact.test.mjs
@@ -2,16 +2,18 @@
 /**
  * Tests for paperclip-upload-artifact.sh authentication handling.
  *
- * Two properties are covered:
+ * The bearer token must never be readable by anything but curl itself, which
+ * means two things:
  *
- *  1. The bearer token never reaches curl's argv. Process arguments are
- *     world-readable through /proc/<pid>/cmdline on Linux, so a token passed
- *     as `-H "Authorization: Bearer $PAPERCLIP_API_KEY"` leaks to every
- *     process on the host. Auth must travel through a mode-600 curl config.
+ *  1. It never reaches curl's argv. Process arguments are world-readable
+ *     through /proc/<pid>/cmdline on Linux, so `-H "Authorization: Bearer
+ *     $PAPERCLIP_API_KEY"` hands the credential to every process on the host.
  *
- *  2. The token-bearing config file does not survive an interrupted run. The
- *     script pools its temp files under one workspace dir and removes it from
- *     a main-shell trap on EXIT/INT/TERM.
+ *  2. It never reaches disk. Writing it to a mode-600 temp file satisfies (1)
+ *     but leaves a credential that has to be deleted, and a deletion can
+ *     always be skipped: bash defers a trap while curl holds the foreground,
+ *     and SIGKILL skips it outright. The script pipes the config into
+ *     `curl --config -` instead, so there is nothing to clean up.
  *
  * Run: node --test skills/paperclip/scripts/paperclip-upload-artifact.test.mjs
  */
@@ -28,6 +30,12 @@ import { fileURLToPath } from 'node:url';
 
 const SCRIPT = fileURLToPath(new URL('./paperclip-upload-artifact.sh', import.meta.url));
 const SOURCE = fs.readFileSync(SCRIPT, 'utf8');
+
+// Executable lines only. Comments legitimately quote the unsafe pattern to say
+// what not to do, and that prose must not trip the checks below.
+const CODE = SOURCE.split('\n')
+  .filter(line => !/^\s*#/.test(line))
+  .join('\n');
 
 // A value distinctive enough that finding it on disk is unambiguous.
 const SENTINEL_TOKEN = 'sentinel-token-4f8a2c91-do-not-use';
@@ -64,6 +72,27 @@ async function filesContainingToken(dir) {
 
 const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
 
+/**
+ * Every running process whose arguments contain the token, as `pid: cmdline`.
+ * Linux only — this is the exposure the fix exists to prevent, so it is worth
+ * asserting against the real kernel view rather than only against the source.
+ */
+async function argvExposingToken() {
+  const hits = [];
+  for (const pid of await fsp.readdir('/proc')) {
+    if (!/^\d+$/.test(pid)) continue;
+    try {
+      const cmdline = await fsp.readFile(`/proc/${pid}/cmdline`, 'utf8');
+      if (cmdline.includes(SENTINEL_TOKEN)) {
+        hits.push(`${pid}: ${cmdline.replace(/\0/g, ' ').trim()}`);
+      }
+    } catch {
+      // Process exited mid-scan, or not ours to read.
+    }
+  }
+  return hits;
+}
+
 /** Poll `predicate` until truthy or `timeoutMs` elapses. */
 async function waitFor(predicate, timeoutMs = 10_000, stepMs = 50) {
   const deadline = Date.now() + timeoutMs;
@@ -78,10 +107,8 @@ async function waitFor(predicate, timeoutMs = 10_000, stepMs = 50) {
 describe('paperclip-upload-artifact.sh auth handling', () => {
   describe('token never reaches curl argv', () => {
     it('passes no Authorization header as a curl argument', () => {
-      // The one permitted mention is the SKILL.md-style warning; the script
-      // itself must not build an -H Authorization argument at all.
       const argvHeader = /-H\s+(["'])Authorization:\s*Bearer[^\n]*\1/g;
-      const matches = SOURCE.match(argvHeader) ?? [];
+      const matches = CODE.match(argvHeader) ?? [];
       assert.deepEqual(
         matches,
         [],
@@ -89,37 +116,46 @@ describe('paperclip-upload-artifact.sh auth handling', () => {
       );
     });
 
-    it('sends auth through a mode-600 curl config file', () => {
-      assert.match(SOURCE, /write_auth_config\(\)/, 'expected a write_auth_config helper');
-      assert.match(SOURCE, /chmod 600/, 'auth config must be created mode 600');
-      assert.match(SOURCE, /--config\s+"\$auth_cfg"/, 'curl must read auth from --config');
+    it('sends auth through a curl config piped on stdin', () => {
+      assert.match(CODE, /write_auth_config\(\)/, 'expected a write_auth_config helper');
+      assert.match(
+        CODE,
+        /write_auth_config \| curl[\s\S]{0,200}?--config -/,
+        'curl must read auth from --config - (stdin)'
+      );
     });
 
-    it('cleans up token files from a main-shell trap', () => {
-      // request_json/upload_file run inside command substitutions, so a signal
-      // sent to the script never reaches them. The trap has to be in the main
-      // shell, over a workspace dir that owns every temp file.
-      assert.match(SOURCE, /trap\s+\w+\s+EXIT\s+INT\s+TERM/, 'expected an EXIT/INT/TERM trap');
-      assert.match(SOURCE, /mktemp -d/, 'expected a single mktemp -d workspace');
+    it('never writes the token to a file', () => {
+      // A temp file keeps the token out of argv but still has to be deleted,
+      // and a deletion can always be skipped — a deferred trap while curl
+      // hangs, or SIGKILL. Piping the config leaves nothing to clean up.
       assert.doesNotMatch(
-        SOURCE,
-        /^\s*(cfg|response_file)="\$\(mktemp\)"/m,
-        'temp files must be created inside the trapped workspace (mktemp -p "$_WORKDIR")'
+        CODE,
+        /PAPERCLIP_API_KEY"?\s*>>?\s*"?\$/,
+        'the token must never be redirected into a file'
+      );
+      assert.doesNotMatch(
+        CODE,
+        /--config\s+"\$\w+"/,
+        'auth must not be read from a temp file on disk'
       );
     });
   });
 
-  describe('interrupted run leaves no token on disk', () => {
+  describe('credential never reaches disk or argv', () => {
     let server;
     let baseUrl;
     let tmpRoot;
     let payload;
+    let requestsSeen = 0;
     const sockets = new Set();
 
     before(async () => {
-      // A server that accepts the request and never answers, so the script is
-      // parked inside curl with its auth config already written to disk.
-      server = createServer(() => {});
+      // A server that accepts the request and never answers, so the script sits
+      // parked inside curl with the credential in play.
+      server = createServer(() => {
+        requestsSeen += 1;
+      });
       server.on('connection', socket => {
         sockets.add(socket);
         socket.on('close', () => sockets.delete(socket));
@@ -145,12 +181,10 @@ describe('paperclip-upload-artifact.sh auth handling', () => {
      * Spawn the script with TMPDIR isolated so we can audit everything it
      * writes, and `detached` so it leads its own process group.
      *
-     * The process group matters. Signalling only the top-level bash does not
-     * interrupt the run: bash is blocked waiting on curl inside a command
-     * substitution, and it defers a trap until that foreground child returns.
-     * With curl parked on a request that never answers, the trap would never
-     * run. A real interruption — a terminal Ctrl-C, or a supervisor tearing a
-     * run down — signals the whole group, which is what this models.
+     * The group matters for teardown. The script is parked on a request that
+     * never answers, and signalling only the top-level bash would not stop it:
+     * bash blocks on curl inside a command substitution and defers signals
+     * until that foreground child returns. Killing the group takes curl too.
      */
     function spawnScript(tmpdir) {
       return spawn('bash', [SCRIPT, payload, '--no-work-product'], {
@@ -177,22 +211,27 @@ describe('paperclip-upload-artifact.sh auth handling', () => {
       }
     }
 
-    it('removes the auth config when the run is terminated mid-request', async () => {
+    it('keeps the token off disk while a request is in flight', async () => {
       const tmpdir = await fsp.mkdtemp(path.join(tmpRoot, 'run-'));
       const child = spawnScript(tmpdir);
 
       try {
-        // Wait until the token is actually on disk. Without this the assertion
-        // could pass simply because the script had not got that far yet.
-        const written = await waitFor(async () => (await filesContainingToken(tmpdir)).length > 0);
-        assert.ok(written, 'auth config holding the token was never written — test cannot conclude');
+        // Park until the request has actually reached the server, so the script
+        // is provably mid-request rather than not yet started.
+        const reached = await waitFor(() => requestsSeen > 0);
+        assert.ok(reached, 'script never issued a request — test cannot conclude');
 
-        signalGroup(child, 'SIGTERM');
-        const exited = await Promise.race([once(child, 'exit'), sleep(10_000).then(() => null)]);
-        assert.ok(exited, 'script did not exit within 10s of SIGTERM to its process group');
+        // The credential must not exist anywhere on disk at this moment. This
+        // is the property a temp file cannot give: with a file, cleanup depends
+        // on a deletion that an interrupted run may never perform.
+        const onDisk = await filesContainingToken(tmpdir);
+        assert.deepEqual(onDisk, [], `token written to disk mid-request: ${onDisk.join(', ')}`);
 
-        const leaked = await filesContainingToken(tmpdir);
-        assert.deepEqual(leaked, [], `token survived SIGTERM in: ${leaked.join(', ')}`);
+        // And it must not be visible in any process's arguments.
+        if (process.platform === 'linux') {
+          const exposed = await argvExposingToken();
+          assert.deepEqual(exposed, [], `token visible in process argv: ${exposed.join(', ')}`);
+        }
       } finally {
         // Never let a stray group keep the test runner alive.
         signalGroup(child, 'SIGKILL');

--- a/skills/paperclip/scripts/paperclip-upload-artifact.test.mjs
+++ b/skills/paperclip/scripts/paperclip-upload-artifact.test.mjs
@@ -1,0 +1,213 @@
+#!/usr/bin/env node
+/**
+ * Tests for paperclip-upload-artifact.sh authentication handling.
+ *
+ * Two properties are covered:
+ *
+ *  1. The bearer token never reaches curl's argv. Process arguments are
+ *     world-readable through /proc/<pid>/cmdline on Linux, so a token passed
+ *     as `-H "Authorization: Bearer $PAPERCLIP_API_KEY"` leaks to every
+ *     process on the host. Auth must travel through a mode-600 curl config.
+ *
+ *  2. The token-bearing config file does not survive an interrupted run. The
+ *     script pools its temp files under one workspace dir and removes it from
+ *     a main-shell trap on EXIT/INT/TERM.
+ *
+ * Run: node --test skills/paperclip/scripts/paperclip-upload-artifact.test.mjs
+ */
+import { after, before, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { createServer } from 'node:http';
+import { once } from 'node:events';
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const SCRIPT = fileURLToPath(new URL('./paperclip-upload-artifact.sh', import.meta.url));
+const SOURCE = fs.readFileSync(SCRIPT, 'utf8');
+
+// A value distinctive enough that finding it on disk is unambiguous.
+const SENTINEL_TOKEN = 'sentinel-token-4f8a2c91-do-not-use';
+
+/** Recursively collect every file under `dir` (empty if dir is gone). */
+async function walk(dir) {
+  let entries;
+  try {
+    entries = await fsp.readdir(dir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+  const out = [];
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...(await walk(full)));
+    else out.push(full);
+  }
+  return out;
+}
+
+/** Every file under `dir` whose bytes contain the sentinel token. */
+async function filesContainingToken(dir) {
+  const hits = [];
+  for (const file of await walk(dir)) {
+    try {
+      if ((await fsp.readFile(file, 'utf8')).includes(SENTINEL_TOKEN)) hits.push(file);
+    } catch {
+      // Unreadable or vanished mid-scan — not a leak.
+    }
+  }
+  return hits;
+}
+
+const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
+
+/** Poll `predicate` until truthy or `timeoutMs` elapses. */
+async function waitFor(predicate, timeoutMs = 10_000, stepMs = 50) {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const value = await predicate();
+    if (value) return value;
+    if (Date.now() > deadline) return null;
+    await sleep(stepMs);
+  }
+}
+
+describe('paperclip-upload-artifact.sh auth handling', () => {
+  describe('token never reaches curl argv', () => {
+    it('passes no Authorization header as a curl argument', () => {
+      // The one permitted mention is the SKILL.md-style warning; the script
+      // itself must not build an -H Authorization argument at all.
+      const argvHeader = /-H\s+(["'])Authorization:\s*Bearer[^\n]*\1/g;
+      const matches = SOURCE.match(argvHeader) ?? [];
+      assert.deepEqual(
+        matches,
+        [],
+        `bearer token passed in curl argv (visible via /proc/*/cmdline):\n${matches.join('\n')}`
+      );
+    });
+
+    it('sends auth through a mode-600 curl config file', () => {
+      assert.match(SOURCE, /write_auth_config\(\)/, 'expected a write_auth_config helper');
+      assert.match(SOURCE, /chmod 600/, 'auth config must be created mode 600');
+      assert.match(SOURCE, /--config\s+"\$auth_cfg"/, 'curl must read auth from --config');
+    });
+
+    it('cleans up token files from a main-shell trap', () => {
+      // request_json/upload_file run inside command substitutions, so a signal
+      // sent to the script never reaches them. The trap has to be in the main
+      // shell, over a workspace dir that owns every temp file.
+      assert.match(SOURCE, /trap\s+\w+\s+EXIT\s+INT\s+TERM/, 'expected an EXIT/INT/TERM trap');
+      assert.match(SOURCE, /mktemp -d/, 'expected a single mktemp -d workspace');
+      assert.doesNotMatch(
+        SOURCE,
+        /^\s*(cfg|response_file)="\$\(mktemp\)"/m,
+        'temp files must be created inside the trapped workspace (mktemp -p "$_WORKDIR")'
+      );
+    });
+  });
+
+  describe('interrupted run leaves no token on disk', () => {
+    let server;
+    let baseUrl;
+    let tmpRoot;
+    let payload;
+    const sockets = new Set();
+
+    before(async () => {
+      // A server that accepts the request and never answers, so the script is
+      // parked inside curl with its auth config already written to disk.
+      server = createServer(() => {});
+      server.on('connection', socket => {
+        sockets.add(socket);
+        socket.on('close', () => sockets.delete(socket));
+      });
+      server.listen(0, '127.0.0.1');
+      await once(server, 'listening');
+      server.unref();
+      baseUrl = `http://127.0.0.1:${server.address().port}`;
+
+      tmpRoot = await fsp.mkdtemp(path.join(os.tmpdir(), 'upload-artifact-test-'));
+      payload = path.join(tmpRoot, 'artifact.txt');
+      await fsp.writeFile(payload, 'artifact body\n');
+    });
+
+    after(async () => {
+      for (const socket of sockets) socket.destroy();
+      server.closeAllConnections?.();
+      server.close();
+      await fsp.rm(tmpRoot, { recursive: true, force: true });
+    });
+
+    /**
+     * Spawn the script with TMPDIR isolated so we can audit everything it
+     * writes, and `detached` so it leads its own process group.
+     *
+     * The process group matters. Signalling only the top-level bash does not
+     * interrupt the run: bash is blocked waiting on curl inside a command
+     * substitution, and it defers a trap until that foreground child returns.
+     * With curl parked on a request that never answers, the trap would never
+     * run. A real interruption — a terminal Ctrl-C, or a supervisor tearing a
+     * run down — signals the whole group, which is what this models.
+     */
+    function spawnScript(tmpdir) {
+      return spawn('bash', [SCRIPT, payload, '--no-work-product'], {
+        detached: true,
+        env: {
+          ...process.env,
+          TMPDIR: tmpdir,
+          PAPERCLIP_API_URL: baseUrl,
+          PAPERCLIP_API_KEY: SENTINEL_TOKEN,
+          PAPERCLIP_COMPANY_ID: 'company-test',
+          PAPERCLIP_TASK_ID: 'issue-test',
+          PAPERCLIP_RUN_ID: 'run-test',
+        },
+        stdio: 'ignore',
+      });
+    }
+
+    /** Signal the whole process group, ignoring an already-dead group. */
+    function signalGroup(child, signal) {
+      try {
+        process.kill(-child.pid, signal);
+      } catch {
+        // Group already gone.
+      }
+    }
+
+    it('removes the auth config when the run is terminated mid-request', async () => {
+      const tmpdir = await fsp.mkdtemp(path.join(tmpRoot, 'run-'));
+      const child = spawnScript(tmpdir);
+
+      try {
+        // Wait until the token is actually on disk. Without this the assertion
+        // could pass simply because the script had not got that far yet.
+        const written = await waitFor(async () => (await filesContainingToken(tmpdir)).length > 0);
+        assert.ok(written, 'auth config holding the token was never written — test cannot conclude');
+
+        signalGroup(child, 'SIGTERM');
+        const exited = await Promise.race([once(child, 'exit'), sleep(10_000).then(() => null)]);
+        assert.ok(exited, 'script did not exit within 10s of SIGTERM to its process group');
+
+        const leaked = await filesContainingToken(tmpdir);
+        assert.deepEqual(leaked, [], `token survived SIGTERM in: ${leaked.join(', ')}`);
+      } finally {
+        // Never let a stray group keep the test runner alive.
+        signalGroup(child, 'SIGKILL');
+      }
+    });
+
+    it('leaves no workspace behind on an early-exit path', async () => {
+      const tmpdir = await fsp.mkdtemp(path.join(tmpRoot, 'help-'));
+      const child = spawn('bash', [SCRIPT, '--help'], {
+        env: { ...process.env, TMPDIR: tmpdir, PAPERCLIP_API_KEY: SENTINEL_TOKEN },
+        stdio: 'ignore',
+      });
+      await once(child, 'exit');
+
+      assert.deepEqual(await walk(tmpdir), [], 'early exit left temp files behind');
+    });
+  });
+});


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Agents get work done through bundled skills, and the `paperclip` skill talks to the Paperclip API with `curl`
> - Those skill templates authenticated with `curl -H "Authorization: Bearer $PAPERCLIP_API_KEY"`, which puts the run token in the process arguments
> - On Linux the arguments of every process are world-readable through `/proc/<pid>/cmdline`, so any process on the host can read the token of any agent that follows the templates
> - The token is a live API credential for that run, so the exposure is a real privilege leak and not only a style problem
> - This pull request moves authentication into a `curl` config that is piped in on stdin, so the credential is never an argument and is never written to a file
> - The benefit is that the token is readable only by curl itself, with no temp file whose deletion an interrupted run could skip

## Linked Issues or Issue Description

No public issue exists for this, so the problem is described inline below.

**What happened?**

The bundled Paperclip skills authenticate by passing the bearer token as a `curl`
argument. On Linux, process arguments are world-readable through
`/proc/<pid>/cmdline`. Any process running on the same host can read the run's
API token while an upload is in flight. The pattern appears in the upload helper
script and across the skill documentation that agents copy from.

A second problem sits behind the first. The obvious fix — write the token to a
mode-600 temp file and delete it after curl returns — keeps it out of argv but
leaves a credential on disk that something must remember to remove. That
deletion is not guaranteed. `SIGKILL` skips it. So does a supervisor that
signals the script's PID rather than its process group: bash blocks on curl
inside a command substitution and defers a trap until that foreground child
returns, so while a request hangs, cleanup is postponed for as long as the hang
lasts.

**Expected behavior**

The token never appears in `curl` argv and is never written to a file. It is
readable only by curl itself.

**Steps to reproduce**

1. Start an artifact upload with the bundled skill script:
   `skills/paperclip/scripts/paperclip-upload-artifact.sh ./file.txt`
2. While the upload runs, from any other process on the same host:
   `tr '\0' '\n' < /proc/<curl-pid>/cmdline | grep Authorization`
3. The `Authorization: Bearer <token>` header is printed.

**Paperclip version or commit**

Reproduced on `master` at `b4815bf96`. The pattern is still present on current
`master` in `skills/paperclip/scripts/paperclip-upload-artifact.sh`.

**Deployment mode**

Self-hosted, agents running locally through the `claude-local` adapter. The
exposure applies to any deployment where an agent process shares a host with
other processes.

## What Changed

- `skills/paperclip/scripts/paperclip-upload-artifact.sh` — added a
  `write_auth_config()` helper that emits the auth headers on stdout, and
  switched `request_json()` and `upload_file()` to pipe it into
  `curl --config -`. The credential is never an argument and never a file.
- Same script — kept the `mktemp -d` workspace and its `trap ... EXIT INT TERM`
  for curl response bodies, which hold no credential. That trap is now
  best-effort tidying rather than a security control, which is what lets the
  deferred-trap and `SIGKILL` cases stop mattering.
- `skills/paperclip/SKILL.md` — documented the required safe pattern under
  Authentication.
- `skills/paperclip/references/artifacts.md`,
  `skills/paperclip/references/issue-workspaces.md`,
  `skills/paperclip/references/company-skills.md`,
  `skills/paperclip-create-agent/SKILL.md` — converted every `curl` example to
  the same `_auth | curl --config -` shape the script uses. Agents copy these
  snippets, so leaving them on the temp-file pattern would have kept
  reproducing it.

  This also cleared a defect the temp-file pattern kept reintroducing: across
  the five files there were 33 `--config "$_AUTH"` call sites but only 24
  matching `rm -f`, so nine documented snippets left the credential on disk.
  The security scanner on this PR flagged one of them. With nothing written,
  there is no cleanup line left to forget — and the docs get 51 lines shorter.
- Added `skills/paperclip/scripts/paperclip-upload-artifact.test.mjs` covering
  both properties.

## Verification

Run the new test:

```
node --test skills/paperclip/scripts/paperclip-upload-artifact.test.mjs
```

It passes on this branch (5/5). It is not a vacuous test — it was checked
against the unfixed sources:

| Script under test | Result |
|---|---|
| This branch | 5 pass, 0 fail |
| Earlier commit on this branch — mode-600 temp file plus trap | 2 pass, **3 fail** |
| `master` — neither fix | 2 pass, **3 fail** |

The behavioral test parks the script against a server that accepts the request
and never answers, waits until the request has provably reached that server,
and then asserts two things while the request is still in flight: no file under
an isolated `TMPDIR` contains the token, and no process on the host exposes it
in `/proc/<pid>/cmdline`.

Worth noting that the middle row is what justifies this approach over the
simpler one. Against the earlier temp-file commit, the in-flight check **fails**
— the credential really is sitting on disk for the duration of the request,
waiting on a deletion that an interrupted run may never perform.

Also confirmed manually:

- `grep -rn '-H "Authorization: Bearer \$PAPERCLIP_API_KEY"' skills/` returns no
  matches, other than the "what NOT to do" warning line in `SKILL.md`.
- `bash -n skills/paperclip/scripts/paperclip-upload-artifact.sh` — syntax OK.
- Against a local sink, both the `Authorization` and `X-Paperclip-Run-Id` headers
  transmit correctly and the token does not appear in curl argv.

## Risks

Low. The change is confined to the bundled skill templates and one helper
script; no server, adapter, or package code is touched.

Two things to be aware of:

- `curl --config -` consumes stdin. Neither call site feeds curl anything else
  on stdin — the JSON body goes through `--data-binary` and the upload through
  `-F file=@path` — so nothing is displaced. A future caller that wants to pipe
  a request body to curl would need to pass the body another way.
- Temp files for curl response bodies now live under one `mktemp -d` workspace.
  Nothing in the repo depended on the old per-file paths.

The `SIGKILL` caveat that applied to the earlier temp-file approach is gone: with
nothing written to disk, there is no residue for an uncatchable signal to leave
behind.

## Model Used

Anthropic Claude, Opus family, driven through the Claude Code agent runtime with
tool use and extended thinking. The original patch was produced on an Opus-class
model; this revision, including the added test and this description, was produced
on `claude-opus-5`.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched the GitHub PR list for similar or duplicate PRs and confirmed this is not a duplicate
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [ ] My branch name describes the change and contains no internal ticket id — the branch carries an internal id from before this rule applied; renaming it would close this PR, so it is left as-is and the title and body have been cleaned instead
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green — pending this push; `Superagent Security Scan` sits at `action_required` and needs a maintainer
- [x] Greptile findings addressed — the two P2s (auth temp file surviving an interrupted run) and the P1 (trap deferred when the script PID rather than the process group is signalled) are all resolved by piping the config instead of writing it
- [x] I will address all Greptile and reviewer comments before requesting merge
