### PR TITLE
fix(ui): make plugin page Back return to the plugin root from deep links

### DIFF
--- a/ui/src/pages/PluginPage.test.tsx
+++ b/ui/src/pages/PluginPage.test.tsx
@@ -16,6 +16,13 @@ const mockParams = vi.hoisted(() => ({
   pluginRoutePath: undefined as string | undefined,
   "*": undefined as string | undefined,
 }));
+const mockLocation = vi.hoisted(() => ({
+  pathname: "/PAP/wiki",
+  search: "",
+  hash: "",
+  state: null,
+  key: "default",
+}));
 
 vi.mock("@/api/plugins", () => ({
   pluginsApi: mockPluginsApi,
@@ -38,6 +45,7 @@ vi.mock("@/lib/router", () => ({
   Link: ({ to, children }: { to: string; children: React.ReactNode }) => <a href={to}>{children}</a>,
   Navigate: () => null,
   useParams: () => mockParams,
+  useLocation: () => mockLocation,
 }));
 
 vi.mock("@/plugins/slots", async () => {
@@ -115,6 +123,8 @@ describe("PluginPage", () => {
     mockParams.pluginId = undefined;
     mockParams.pluginRoutePath = undefined;
     mockParams["*"] = undefined;
+    mockLocation.pathname = "/PAP/wiki";
+    mockLocation.search = "";
   });
 
   afterEach(() => {
@@ -135,6 +145,52 @@ describe("PluginPage", () => {
     ]);
     expect(container.textContent).toContain("Back");
     expect(container.querySelector('a[href="/PAP/dashboard"]')).not.toBeNull();
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  it("points Back at the plugin page root when the URL carries query-string deep-link state", async () => {
+    mockParams.pluginRoutePath = "wiki";
+    mockLocation.search = "?kind=request&id=abc-123";
+    mockPluginsApi.listUiContributions.mockResolvedValue([pageContribution()]);
+
+    const root = await renderPage(container);
+
+    expect(container.querySelector('a[href="/PAP/wiki"]')).not.toBeNull();
+    expect(container.querySelector('a[href="/PAP/dashboard"]')).toBeNull();
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  it("points Back at the plugin page root when the route splat selects a sub-screen", async () => {
+    mockParams.pluginRoutePath = "wiki";
+    mockParams["*"] = "page/notes.md";
+    mockPluginsApi.listUiContributions.mockResolvedValue([pageContribution()]);
+
+    const root = await renderPage(container);
+
+    expect(container.querySelector('a[href="/PAP/wiki"]')).not.toBeNull();
+    expect(container.querySelector('a[href="/PAP/dashboard"]')).toBeNull();
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  it("points Back at the plugin-id page root for deep links on the plugin-id route", async () => {
+    mockParams.pluginId = "plugin-wiki";
+    mockLocation.pathname = "/PAP/plugins/plugin-wiki";
+    mockLocation.search = "?tab=history";
+    mockPluginsApi.listUiContributions.mockResolvedValue([pageContribution()]);
+
+    const root = await renderPage(container);
+
+    expect(container.querySelector('a[href="/PAP/plugins/plugin-wiki"]')).not.toBeNull();
+    expect(container.querySelector('a[href="/PAP/dashboard"]')).toBeNull();
 
     await act(async () => {
       root.unmount();

--- a/ui/src/pages/PluginPage.tsx
+++ b/ui/src/pages/PluginPage.tsx
@@ -98,10 +98,10 @@ export function PluginPage() {
   );
 
   // Plugins encode sub-screens in the query string or the route splat (e.g.
-  // `/FUS/nodeview?kind=request&id=…`). From such a deep link, Back must
-  // return to the plugin page's own root — jumping to the dashboard would
-  // skip every screen the plugin manages. Only from the plugin root itself
-  // does Back leave the plugin toward the dashboard.
+  // a detail view at `/PREFIX/myplugin?kind=request&id=123`). From such a
+  // deep link, Back must return to the plugin page's own root; jumping to
+  // the dashboard would skip every screen the plugin manages. Only from the
+  // plugin root itself does Back leave the plugin toward the dashboard.
   const backTo = useMemo(() => {
     const dashboardPath = companyPrefix ? `/${companyPrefix}/dashboard` : "/dashboard";
     const hasPluginSubScreen = Boolean(location.search) || Boolean(pluginRouteSplat);

--- a/ui/src/pages/PluginPage.tsx
+++ b/ui/src/pages/PluginPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo } from "react";
-import { Link, Navigate, useParams } from "@/lib/router";
+import { Link, Navigate, useLocation, useParams } from "@/lib/router";
 import { useQuery } from "@tanstack/react-query";
 import { useCompany } from "@/context/CompanyContext";
 import { useBreadcrumbs } from "@/context/BreadcrumbContext";
@@ -31,6 +31,7 @@ export function PluginPage() {
   }>();
   const { companyPrefix: routeCompanyPrefix, pluginId, pluginRoutePath } = params;
   const pluginRouteSplat = params["*"];
+  const location = useLocation();
   const { companies, selectedCompanyId } = useCompany();
   const { setBreadcrumbs } = useBreadcrumbs();
   const routeCompany = useMemo(() => {
@@ -95,6 +96,20 @@ export function PluginPage() {
     }),
     [resolvedCompanyId, companyPrefix],
   );
+
+  // Plugins encode sub-screens in the query string or the route splat (e.g.
+  // `/FUS/nodeview?kind=request&id=…`). From such a deep link, Back must
+  // return to the plugin page's own root — jumping to the dashboard would
+  // skip every screen the plugin manages. Only from the plugin root itself
+  // does Back leave the plugin toward the dashboard.
+  const backTo = useMemo(() => {
+    const dashboardPath = companyPrefix ? `/${companyPrefix}/dashboard` : "/dashboard";
+    const hasPluginSubScreen = Boolean(location.search) || Boolean(pluginRouteSplat);
+    if (!hasPluginSubScreen) return dashboardPath;
+    if (companyPrefix && pluginRoutePath) return `/${companyPrefix}/${pluginRoutePath}`;
+    if (companyPrefix && pluginId) return `/${companyPrefix}/plugins/${pluginId}`;
+    return dashboardPath;
+  }, [companyPrefix, location.search, pluginId, pluginRoutePath, pluginRouteSplat]);
 
   // When the active route has a routeSidebar slot, the sidebar provides the
   // back affordance, but the top bar still needs a route-specific title.
@@ -168,7 +183,7 @@ export function PluginPage() {
       {!routeSidebarActive && (
         <div className="flex items-center gap-2">
           <Button variant="ghost" size="sm" asChild>
-            <Link to={companyPrefix ? `/${companyPrefix}/dashboard` : "/dashboard"}>
+            <Link to={backTo}>
               <ArrowLeft className="h-4 w-4 mr-1" />
               Back
             </Link>


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Plugins can own a full company-context page route (`/:companyPrefix/:pluginRoutePath/*` or `/:companyPrefix/plugins/:pluginId`), rendered by `ui/src/pages/PluginPage.tsx` with a host-chrome "Back" button above the plugin slot
> - That Back button is hardcoded to `/:companyPrefix/dashboard`, but plugins encode their own sub-screens in the query string or the route splat (e.g. a detail view at `/PREFIX/myplugin?kind=request&id=<uuid>`)
> - From inside such a sub-screen, Back skips the plugin's own root screen entirely and jumps to the dashboard, which users experience as broken navigation ("back goes all the way out")
> - This pull request makes the Back target context-aware: deep-link state sends Back to the plugin page's base route; only the plugin root keeps pointing at the dashboard
> - The benefit is that host chrome navigation matches user expectation ("one screen back") for every plugin that manages sub-screens on its page route, with no change for plugins that don't

## Linked Issues or Issue Description

No existing public issue found (searched open/closed issues and PRs for plugin page back navigation).

**Bug description (per bug_report template):**
- **What happened:** On a plugin page that encodes a sub-screen in the URL (query string like `?kind=request&id=<uuid>`, or a route splat), clicking the host-chrome "Back" button at the top of the page navigates to `/:companyPrefix/dashboard`, skipping the plugin's own root/list screen.
- **What was expected:** Back returns one screen, to the plugin page's base route (e.g. `/PREFIX/myplugin`), and only navigates out to the dashboard when already at the plugin root.
- **Steps to reproduce:** Install any plugin with a `page` slot that opens a detail view via query params. Open the plugin page, open a detail item (URL gains query params), click the top-left "Back". Observe landing on the dashboard instead of the plugin root.
- **Environment:** Reproduced on `paperclipai@2026.626.0` (self-hosted, Windows) and confirmed the same hardcoded link on current `master`.

## What Changed

- `ui/src/pages/PluginPage.tsx`: compute the Back link target from the current location. When the URL carries query-string or splat deep-link state, target the plugin page's base route (`/:companyPrefix/:pluginRoutePath` or `/:companyPrefix/plugins/:pluginId`); otherwise keep targeting the dashboard. Routes with a `routeSidebar` slot are unaffected (they already hide this Back button).
- `ui/src/pages/PluginPage.test.tsx`: add `useLocation` to the router mock and three tests covering query-string deep links, splat deep links, and the plugin-id route; existing tests still assert the dashboard target at the plugin root.

## Verification

- `pnpm exec vitest run ui/src/pages/PluginPage.test.tsx`: 6/6 pass (3 existing + 3 new).
- `pnpm --filter @paperclipai/ui typecheck`: clean.
- Manual: reproduced the bug on a live `2026.626.0` instance with a query-param plugin page (Back from `/PREFIX/<plugin>?kind=request&id=…` landed on `/PREFIX/dashboard`); with this change the same click targets `/PREFIX/<plugin>`.

## Risks

- Low risk, UI-only. Behavior changes only when the plugin-page URL carries query/splat state; the plugin-root case and the routeSidebar case are unchanged.
- Plugins that put non-navigational state in the query string at their root would now get a two-step exit (root-without-query, then dashboard); this matches the "one screen back" expectation and is reversible by the plugin using its own navigation.

## Model Used

- Claude Fable 5 (Anthropic, model ID `claude-fable-5`), extended thinking enabled, agentic tool use via Claude Code (file edits, test execution, live-instance reproduction in a driven browser).

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above (closest matches #7597 and #3302 address company-prefix accumulation, a different plugin-route bug)
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes (no doc changes needed; behavior documented in code comment and tests)
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
