### PR TITLE
fix(claude-local): ignore hook events when classifying auth/transient failures

### DIFF
--- a/packages/adapters/claude-local/src/server/parse.test.ts
+++ b/packages/adapters/claude-local/src/server/parse.test.ts
@@ -7,7 +7,46 @@ import {
   isClaudeRefusalResult,
   isClaudeUnknownSessionError,
   isClaudeImageProcessingError,
+  stripClaudeHookEventLines,
 } from "./parse.js";
+
+// A SessionStart hook (e.g. a plugin that injects the previous session's
+// summary) emits `hook_started` / `hook_response` events on the stream-json
+// channel before Claude's own output. This reproduces a successful `hello`
+// probe whose injected hook summary happens to mention a past auth failure.
+// See https://github.com/paperclipai/paperclip/issues/4439.
+const HELLO_PROBE_WITH_HOOK_STDOUT = [
+  JSON.stringify({
+    type: "system",
+    subtype: "hook_started",
+    hook_event: "SessionStart",
+    hook_name: "SessionStart:startup",
+    hook_id: "abc123",
+  }),
+  JSON.stringify({
+    type: "system",
+    subtype: "hook_response",
+    hook_event: "SessionStart",
+    hook_name: "SessionStart:startup",
+    output:
+      "Previous session summary — Tasks: investigated why the probe showed 'Not logged in · Please run /login' and hit a 'usage limit reached' warning.",
+    exit_code: 0,
+    outcome: "success",
+  }),
+  JSON.stringify({ type: "system", subtype: "init", session_id: "s1", model: "claude-opus-4-8" }),
+  JSON.stringify({
+    type: "assistant",
+    message: { content: [{ type: "text", text: "Hello!" }] },
+    session_id: "s1",
+  }),
+  JSON.stringify({
+    type: "result",
+    subtype: "success",
+    is_error: false,
+    result: "Hello!",
+    session_id: "s1",
+  }),
+].join("\n");
 
 describe("detectClaudeLoginRequired", () => {
   it("classifies Claude's invalid API key login prompt as auth required", () => {
@@ -28,6 +67,50 @@ describe("detectClaudeLoginRequired", () => {
         stderr: "Invalid API key",
       }).requiresLogin,
     ).toBe(false);
+  });
+
+  it("ignores login-looking text inside SessionStart hook events on a successful run (#4439)", () => {
+    expect(
+      detectClaudeLoginRequired({
+        parsed: {
+          type: "result",
+          subtype: "success",
+          is_error: false,
+          result: "Hello!",
+        },
+        stdout: HELLO_PROBE_WITH_HOOK_STDOUT,
+        stderr: "",
+      }).requiresLogin,
+    ).toBe(false);
+  });
+
+  it("still detects a genuine auth failure in the result event despite hook noise", () => {
+    const stdout = [
+      JSON.stringify({
+        type: "system",
+        subtype: "hook_response",
+        hook_event: "SessionStart",
+        output: "hello from the hook",
+      }),
+      JSON.stringify({
+        type: "result",
+        subtype: "success",
+        is_error: true,
+        result: "Not logged in · Please run /login",
+      }),
+    ].join("\n");
+    expect(
+      detectClaudeLoginRequired({
+        parsed: {
+          type: "result",
+          subtype: "success",
+          is_error: true,
+          result: "Not logged in · Please run /login",
+        },
+        stdout,
+        stderr: "",
+      }).requiresLogin,
+    ).toBe(true);
   });
 });
 
@@ -118,6 +201,21 @@ describe("isClaudeTransientUpstreamError", () => {
     expect(
       isClaudeTransientUpstreamError({
         errorMessage: "Invalid request_error: Unknown parameter 'foo'.",
+      }),
+    ).toBe(false);
+  });
+
+  it("does not classify usage-limit wording inside a hook event as transient (#4439)", () => {
+    expect(
+      isClaudeTransientUpstreamError({
+        parsed: {
+          type: "result",
+          subtype: "success",
+          is_error: false,
+          result: "Hello!",
+        },
+        stdout: HELLO_PROBE_WITH_HOOK_STDOUT,
+        stderr: "",
       }),
     ).toBe(false);
   });
@@ -326,5 +424,38 @@ describe("extractClaudeRetryNotBefore", () => {
     expect(
       extractClaudeRetryNotBefore({ errorMessage: "Overloaded. Try again later." }, new Date()),
     ).toBeNull();
+  });
+});
+
+describe("stripClaudeHookEventLines", () => {
+  it("removes hook lifecycle events but keeps init/assistant/result lines", () => {
+    const out = stripClaudeHookEventLines(HELLO_PROBE_WITH_HOOK_STDOUT);
+    expect(out).not.toContain("hook_started");
+    expect(out).not.toContain("hook_response");
+    expect(out).not.toContain("Please run /login");
+    expect(out).toContain('"subtype":"init"');
+    expect(out).toContain('"type":"assistant"');
+    expect(out).toContain('"type":"result"');
+  });
+
+  it("detects hook events tagged only by hook metadata (no hook subtype)", () => {
+    const line = JSON.stringify({
+      type: "system",
+      subtype: "",
+      hook_name: "SessionStart:startup",
+      output: "unauthorized: not logged in",
+    });
+    expect(stripClaudeHookEventLines(line)).toBe("");
+  });
+
+  it("leaves non-hook system, assistant, and non-JSON lines untouched", () => {
+    const init = JSON.stringify({ type: "system", subtype: "init", session_id: "s1" });
+    const plain = "not json at all";
+    const stdout = [init, plain].join("\n");
+    expect(stripClaudeHookEventLines(stdout)).toBe(stdout);
+  });
+
+  it("returns the input unchanged when it is empty", () => {
+    expect(stripClaudeHookEventLines("")).toBe("");
   });
 });

--- a/packages/adapters/claude-local/src/server/parse.ts
+++ b/packages/adapters/claude-local/src/server/parse.ts
@@ -14,6 +14,47 @@ const CLAUDE_TRANSIENT_UPSTREAM_RE =
 const CLAUDE_EXTRA_USAGE_RESET_RE =
   /(?:out\s+of\s+extra\s+usage|extra\s+usage|usage\s+limit\s+reached|usage\s+cap\s+reached|5[-\s]?hour\s+limit\s+reached|weekly\s+limit\s+reached|claude\s+usage\s+limit\s+reached)[\s\S]{0,80}?\bresets?\s+(?:at\s+)?([^\n()]+?)(?:\s*\(([^)]+)\))?(?:[.!]|\n|$)/i;
 
+// Claude Code emits hook lifecycle events (SessionStart, PreToolUse, …) on the
+// stream-json channel as `type:"system"` lines with `subtype:"hook_started"` /
+// `"hook_response"`. Those lines wrap arbitrary user-authored hook output — for
+// example a SessionStart plugin that injects the previous session's summary.
+// That output must never feed the auth/transient classifiers below: a summary
+// that merely mentions "Not logged in · Please run /login" or "usage limit
+// reached" would otherwise be misread as a real failure even though the run
+// itself succeeded. See https://github.com/paperclipai/paperclip/issues/4439.
+const CLAUDE_HOOK_EVENT_SUBTYPES = new Set([
+  "hook_started",
+  "hook_response",
+  "hook_completed",
+  "hook_failed",
+]);
+
+function isClaudeHookEventLine(line: string): boolean {
+  const event = parseJson(line);
+  if (!event) return false;
+  if (asString(event.type, "") !== "system") return false;
+  if (CLAUDE_HOOK_EVENT_SUBTYPES.has(asString(event.subtype, ""))) return true;
+  // Some CLI builds omit a hook-specific subtype but still tag the event with
+  // hook identifiers; treat any system event carrying hook metadata as hook
+  // output so its payload never reaches the error classifiers.
+  return "hook_event" in event || "hook_name" in event || "hook_id" in event;
+}
+
+/**
+ * Remove Claude Code hook lifecycle events from a stream-json stdout blob so the
+ * auth/transient classifiers only scan Claude's own output (assistant text,
+ * result/error events, stderr) and never user-authored hook payloads. Lines
+ * that are not recognizable hook events — including non-JSON lines — are kept
+ * unchanged. See https://github.com/paperclipai/paperclip/issues/4439.
+ */
+export function stripClaudeHookEventLines(stdout: string): string {
+  if (!stdout) return stdout;
+  return stdout
+    .split(/\r?\n/)
+    .filter((line) => !isClaudeHookEventLine(line.trim()))
+    .join("\n");
+}
+
 export function parseClaudeStreamJson(stdout: string) {
   let sessionId: string | null = null;
   let model = "";
@@ -135,7 +176,8 @@ export function detectClaudeLoginRequired(input: {
   stderr: string;
 }): { requiresLogin: boolean; loginUrl: string | null } {
   const resultText = asString(input.parsed?.result, "").trim();
-  const messages = [resultText, ...extractClaudeErrorMessages(input.parsed ?? {}), input.stdout, input.stderr]
+  const stdout = stripClaudeHookEventLines(input.stdout);
+  const messages = [resultText, ...extractClaudeErrorMessages(input.parsed ?? {}), stdout, input.stderr]
     .join("\n")
     .split(/\r?\n/)
     .map((line) => line.trim())
@@ -144,7 +186,7 @@ export function detectClaudeLoginRequired(input: {
   const requiresLogin = messages.some((line) => CLAUDE_AUTH_REQUIRED_RE.test(line));
   return {
     requiresLogin,
-    loginUrl: extractClaudeLoginUrl([input.stdout, input.stderr].join("\n")),
+    loginUrl: extractClaudeLoginUrl([stdout, input.stderr].join("\n")),
   };
 }
 
@@ -251,7 +293,7 @@ function buildClaudeTransientHaystack(input: {
     input.errorMessage ?? "",
     resultText,
     ...parsedErrors,
-    input.stdout ?? "",
+    stripClaudeHookEventLines(input.stdout ?? ""),
     input.stderr ?? "",
   ]
     .join("\n")


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Each agent runs through an adapter; the `claude_local` adapter shells out to the real `claude` CLI and reads its `--output-format stream-json` output
> - To surface actionable errors, the adapter scans that stdout to classify a run as "needs login" (`claude_auth_required`) or "transient upstream" (rate limit / overload)
> - But when a user has a Claude Code `SessionStart` hook (any plugin that registers one), the CLI emits `hook_started` / `hook_response` events on the *same* stream-json channel, carrying arbitrary user-authored text before Claude's own output
> - If that hook text happens to mention `Not logged in · Please run /login` or `usage limit reached` (e.g. a plugin that injects the previous session's summary), the classifiers match it and report a failure — even though the run succeeded and returned a normal result
> - This pull request strips hook lifecycle events from stdout before the auth/transient classifiers scan it, while preserving stdout scanning as the deliberate fallback for CLI crashes that never emit a structured result
> - The benefit is that `claude_local` works correctly against a user's real Claude Code environment — plugins, hooks, and subscription login intact — instead of false-flagging healthy runs as logged-out

## Linked Issues or Issue Description

Fixes #4439

## What Changed

- Added `stripClaudeHookEventLines(stdout)` to `packages/adapters/claude-local/src/server/parse.ts`. It removes stream-json lines that are Claude Code hook lifecycle events — `type:"system"` with `subtype` in `hook_started` / `hook_response` / `hook_completed` / `hook_failed`, or any system event tagged with `hook_event` / `hook_name` / `hook_id`. Non-hook lines and non-JSON lines are preserved unchanged.
- `detectClaudeLoginRequired` now scans the hook-stripped stdout (both for the auth regex and for `extractClaudeLoginUrl`).
- `buildClaudeTransientHaystack` (used by `isClaudeTransientUpstreamError` / `extractClaudeRetryNotBefore`) now scans the hook-stripped stdout.
- Added unit tests in `parse.test.ts` covering: a successful `hello` probe whose SessionStart hook injects login/usage-limit wording is **not** classified as auth-required or transient; a genuine auth failure in the `result` event is **still** detected despite hook noise; and direct `stripClaudeHookEventLines` behavior (removes hook events, keeps init/assistant/result/non-JSON lines, handles metadata-only hook lines and empty input).

No public API surface changed: `detectClaudeLoginRequired` / `isClaudeTransientUpstreamError` are internal to the adapter (not re-exported from `server/index.ts`), and the new helper follows the same pattern.

## Verification

Automated (from repo root):

```
node_modules/.bin/vitest run packages/adapters/claude-local
# 5 files, 55 tests passed (7 new)
pnpm --filter @paperclipai/adapter-claude-local typecheck
# tsc --noEmit, clean
```

Real-data before/after — a genuine `claude --print - --output-format stream-json --verbose` capture (real `SessionStart` hook event line + real `init`/`assistant`/`result:success`), with the hook's `output` set to a summary mentioning `Not logged in · Please run /login`, run through the exact classifier logic:

```
real result event: success / Hello!   (auth genuinely works)
BEFORE fix  requiresLogin = true    <-- false positive
AFTER  fix  requiresLogin = false   <-- correct
```

Note: on current `master`, `parseClaudeStreamJson` already locates the terminal `result` event correctly, so the hard "hello probe failed" symptom from the original report no longer reproduces; the remaining gap this PR closes is the auth/transient classifiers scanning raw stdout that includes hook payloads.

## Risks

Low risk.

- The change only removes lines confirmed to be hook lifecycle events; anything not recognized as a hook event (including non-JSON and all of Claude's own `init` / `assistant` / `result` / error lines) is preserved, so genuine auth and transient signals are unaffected.
- stdout scanning is intentionally retained (it is the fallback for CLI crashes that never emit a structured `result` — see the `if (!parsed)` branch in `execute.ts`); this PR denoises that scan rather than removing it.
- Detection matrix is covered by tests to guard against regressions (genuine auth failure still detected; hook-injected wording ignored).

## Model Used

Claude Opus 4.8 (`claude-opus-4-8`, 1M-token context), extended thinking enabled, with tool use (file edit, shell, GitHub CLI) via Claude Code.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work (bug fix, not a feature)
- [x] I have searched GitHub for duplicate or related PRs and linked them above (none found addressing #4439)
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (`fix/claude-adapter-hook-event-false-auth`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes (N/A — internal classifier fix, no user-facing docs or behavior contract changed)
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green (pending CI on this PR)
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups (pending review)
- [x] I will address all Greptile and reviewer comments before requesting merge
