### PR TITLE
Fix local run-header attribution

### DIFF
--- a/server/src/__tests__/auth-middleware.test.ts
+++ b/server/src/__tests__/auth-middleware.test.ts
@@ -22,16 +22,19 @@ function createDb(selectRows: unknown[][]) {
   } as any;
 }
 
+function createApp(selectRows: unknown[][]) {
+  const app = express();
+  app.use(actorMiddleware(createDb(selectRows), { deploymentMode: "local_trusted" }));
+  app.post("/probe", (req, res) => res.json({ actor: req.actor }));
+  return app;
+}
+
 describe("actor middleware", () => {
   it("resolves local trusted run headers to the run agent without bearer auth", async () => {
-    const db = createDb([
+    const app = createApp([
       [{ id: "run-1", agentId: "agent-1", companyId: "company-1" }],
       [{ id: "agent-1", companyId: "company-1", status: "active" }],
     ]);
-    const app = express();
-
-    app.use(actorMiddleware(db, { deploymentMode: "local_trusted" }));
-    app.post("/probe", (req, res) => res.json({ actor: req.actor }));
 
     const res = await request(app).post("/probe").set("X-Paperclip-Run-Id", "run-1");
 
@@ -42,6 +45,41 @@ describe("actor middleware", () => {
       companyId: "company-1",
       runId: "run-1",
       source: "local_run_header",
+    });
+  });
+
+  it.each([
+    ["missing run", [[]]],
+    [
+      "cross-company agent",
+      [
+        [{ id: "run-1", agentId: "agent-1", companyId: "company-1" }],
+        [{ id: "agent-1", companyId: "company-2", status: "active" }],
+      ],
+    ],
+    [
+      "terminated agent",
+      [
+        [{ id: "run-1", agentId: "agent-1", companyId: "company-1" }],
+        [{ id: "agent-1", companyId: "company-1", status: "terminated" }],
+      ],
+    ],
+    [
+      "pending approval agent",
+      [
+        [{ id: "run-1", agentId: "agent-1", companyId: "company-1" }],
+        [{ id: "agent-1", companyId: "company-1", status: "pending_approval" }],
+      ],
+    ],
+  ])("falls back to local board actor for %s", async (_name, selectRows) => {
+    const res = await request(createApp(selectRows)).post("/probe").set("X-Paperclip-Run-Id", "run-1");
+
+    expect(res.status).toBe(200);
+    expect(res.body.actor).toMatchObject({
+      type: "board",
+      userId: "local-board",
+      runId: "run-1",
+      source: "local_implicit",
     });
   });
 });

--- a/server/src/__tests__/auth-middleware.test.ts
+++ b/server/src/__tests__/auth-middleware.test.ts
@@ -1,0 +1,47 @@
+import express from "express";
+import request from "supertest";
+import { describe, expect, it } from "vitest";
+import { actorMiddleware } from "../middleware/auth.js";
+
+function createSelectChain(rows: unknown[]) {
+  return {
+    from() {
+      return {
+        where() {
+          return Promise.resolve(rows);
+        },
+      };
+    },
+  };
+}
+
+function createDb(selectRows: unknown[][]) {
+  let selectIndex = 0;
+  return {
+    select: () => createSelectChain(selectRows[selectIndex++] ?? []),
+  } as any;
+}
+
+describe("actor middleware", () => {
+  it("resolves local trusted run headers to the run agent without bearer auth", async () => {
+    const db = createDb([
+      [{ id: "run-1", agentId: "agent-1", companyId: "company-1" }],
+      [{ id: "agent-1", companyId: "company-1", status: "active" }],
+    ]);
+    const app = express();
+
+    app.use(actorMiddleware(db, { deploymentMode: "local_trusted" }));
+    app.post("/probe", (req, res) => res.json({ actor: req.actor }));
+
+    const res = await request(app).post("/probe").set("X-Paperclip-Run-Id", "run-1");
+
+    expect(res.status).toBe(200);
+    expect(res.body.actor).toMatchObject({
+      type: "agent",
+      agentId: "agent-1",
+      companyId: "company-1",
+      runId: "run-1",
+      source: "local_run_header",
+    });
+  });
+});

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -71,7 +71,7 @@ export function actorMiddleware(db: Db, opts: ActorMiddlewareOptions): RequestHa
 
     const authHeader = req.header("authorization");
     if (!authHeader?.toLowerCase().startsWith("bearer ")) {
-      if (runIdHeader) {
+      if (runIdHeader && opts.deploymentMode === "local_trusted") {
         const runActor = await resolveLocalRunActor(runIdHeader);
         if (runActor) {
           req.actor = runActor;

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -2,7 +2,7 @@ import { createHash, timingSafeEqual } from "node:crypto";
 import type { Request, RequestHandler } from "express";
 import { and, eq, isNull } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
-import { agentApiKeys, agents, authUsers, companies, companyMemberships, instanceUserRoles } from "@paperclipai/db";
+import { agentApiKeys, agents, authUsers, companies, companyMemberships, heartbeatRuns, instanceUserRoles } from "@paperclipai/db";
 import { verifyLocalAgentJwt } from "../agent-auth-jwt.js";
 import { normalizeAgentApiKeyScope, type DeploymentMode } from "@paperclipai/shared";
 import type { BetterAuthSessionResult } from "../auth/better-auth.js";
@@ -21,6 +21,39 @@ interface ActorMiddlewareOptions {
 
 export function actorMiddleware(db: Db, opts: ActorMiddlewareOptions): RequestHandler {
   const boardAuth = boardAuthService(db);
+
+  async function resolveLocalRunActor(runId: string) {
+    if (opts.deploymentMode !== "local_trusted") return null;
+
+    const run = await db
+      .select({
+        id: heartbeatRuns.id,
+        agentId: heartbeatRuns.agentId,
+        companyId: heartbeatRuns.companyId,
+      })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, runId))
+      .then((rows) => rows[0] ?? null);
+    if (!run) return null;
+
+    const agentRecord = await db
+      .select()
+      .from(agents)
+      .where(eq(agents.id, run.agentId))
+      .then((rows) => rows[0] ?? null);
+    if (!agentRecord || agentRecord.companyId !== run.companyId) return null;
+    if (agentRecord.status === "terminated" || agentRecord.status === "pending_approval") return null;
+
+    return {
+      type: "agent" as const,
+      agentId: run.agentId,
+      companyId: run.companyId,
+      keyId: undefined,
+      runId: run.id,
+      source: "local_run_header" as const,
+    };
+  }
+
   return async (req, _res, next) => {
     req.actor =
       opts.deploymentMode === "local_trusted"
@@ -38,6 +71,15 @@ export function actorMiddleware(db: Db, opts: ActorMiddlewareOptions): RequestHa
 
     const authHeader = req.header("authorization");
     if (!authHeader?.toLowerCase().startsWith("bearer ")) {
+      if (runIdHeader) {
+        const runActor = await resolveLocalRunActor(runIdHeader);
+        if (runActor) {
+          req.actor = runActor;
+          next();
+          return;
+        }
+      }
+
       if (opts.deploymentMode === "authenticated" && opts.resolveSession) {
         const cloudTenantActor = await resolveCloudTenantActor(db, req);
         if (cloudTenantActor) {

--- a/server/src/services/authorization.ts
+++ b/server/src/services/authorization.ts
@@ -38,6 +38,7 @@ export type AuthorizationActor =
       | "board_key"
       | "agent_key"
       | "agent_jwt"
+      | "local_run_header"
       | "cloud_tenant"
       | "none";
   };

--- a/server/src/types/express.d.ts
+++ b/server/src/types/express.d.ts
@@ -22,7 +22,15 @@ declare global {
         keyId?: string;
         keyScope?: AgentApiKeyScope;
         runId?: string;
-        source?: "local_implicit" | "session" | "board_key" | "agent_key" | "agent_jwt" | "cloud_tenant" | "none";
+        source?:
+          | "local_implicit"
+          | "session"
+          | "board_key"
+          | "agent_key"
+          | "agent_jwt"
+          | "local_run_header"
+          | "cloud_tenant"
+          | "none";
       };
     }
   }


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to coordinate AI agents, their work, and the durable task trail around that work.
> - The server auth middleware decides whether a mutating API request came from a board user, an agent credential, or an unauthenticated local trusted caller.
> - In local trusted development, agent runs can call the local API with `X-Paperclip-Run-Id` even when they do not attach a bearer token.
> - Before this PR, that no-bearer path preserved the run id but still left the actor as the implicit Local Board user, so agent-authored comments could look like human board comments.
> - That breaks auditability: reviewers cannot reliably tell whether a message was sent by the human operator or by the agent run that produced it.
> - This pull request resolves local run headers to the owning heartbeat run and agent before falling back to the Local Board actor.
> - The benefit is clearer attribution for local trusted automation without weakening authenticated or bearer-token paths.

## Linked Issues or Issue Description

No public GitHub issue exists yet. Inline bug report:

**What happened?**
In `local_trusted` mode, a mutating API request with `X-Paperclip-Run-Id` but no bearer token was stored as the implicit Local Board actor. Agent-authored issue comments could therefore appear as `authorType: user` / `authorUserId: local-board` with no created-by run, even though the request carried a valid run id.

**Expected behavior**
When a no-bearer local trusted request includes a valid `X-Paperclip-Run-Id`, Paperclip should resolve that run to its owning agent and record the actor as that agent/run. If the run is missing, cross-company, or belongs to an invalid agent, the request should not be elevated and should fall back to the local board actor.

**Steps to reproduce**
1. Start Paperclip in `local_trusted` mode.
2. Trigger an agent heartbeat run.
3. From that run context, POST an issue comment with `X-Paperclip-Run-Id` and no `Authorization` header.
4. Inspect the stored comment actor fields.

**Paperclip version or commit**
Observed against the published local package version `@paperclipai/server@2026.626.0`; patched against current `master`.

**Deployment mode / install method**
Local trusted, npm/npx-installed server package.

**Access context**
Agent run calling the local server without bearer auth, using only `X-Paperclip-Run-Id`.

## What Changed

- Added local trusted run-header resolution in `actorMiddleware`: the no-bearer branch now resolves `X-Paperclip-Run-Id` through `heartbeatRuns` and the owning `agents` row before falling back to Local Board.
- Added safety guards for missing runs, cross-company agent/run mismatches, terminated agents, and pending-approval agents.
- Added a `local_run_header` actor source to the Express request actor and authorization actor type unions.
- Added middleware regression tests covering the happy path and all guard/fallback cases described above.

## Verification

- Reproduced locally after restarting Paperclip: a comment created with only `X-Paperclip-Run-Id` is now stored with `authorType: agent`, the expected `authorAgentId`, and `createdByRunId`.
- `npx pnpm@9.15.4 exec vitest run server/src/__tests__/auth-middleware.test.ts`
- `npx pnpm@9.15.4 --filter @paperclipai/server typecheck`

## Risks

Low-to-moderate auth-path risk. The new agent elevation path is limited to `local_trusted` mode and only succeeds when the run exists, the owning agent exists in the same company, and the agent is neither `terminated` nor `pending_approval`. The fallback behavior remains Local Board for invalid headers, so malformed or stale run ids do not gain agent attribution. There are no migrations or persisted schema changes.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

OpenAI GPT-5 via Codex local coding agent, with shell/tool execution for repository inspection, patching, tests, typecheck, GitHub PR creation, and PR updates. No separate context-window-specific capability was used beyond the active Codex session tools.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I searched GitHub PRs for similar changes and found no duplicate (`gh search prs --repo paperclipai/paperclip "local trusted run header attribution"` returned no matches)
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
