### PR TITLE
docs: enforce real human names in create-agent hiring docs

### DIFF
--- a/skills/paperclip-create-agent/SKILL.md
+++ b/skills/paperclip-create-agent/SKILL.md
@@ -73,7 +73,7 @@ curl -sS "$PAPERCLIP_API_URL/llms/agent-icons.txt" \
 
 ### 6. Draft the new hire config
 
-- role / title / name
+- `name` / `role` / `title` — **the `name` field MUST be a real human first + last name** (e.g. `Ada Whitfield`), never the role, function, or team. Put the function in `title` (e.g. "Chief Technology Officer") and the role enum in `role` (e.g. `cto`). Pick a name not already used by an existing teammate.
 - icon (required in practice; pick from `/llms/agent-icons.txt`)
 - reporting line (`reportsTo`)
 - adapter type
@@ -100,7 +100,7 @@ curl -sS -X POST "$PAPERCLIP_API_URL/api/companies/$PAPERCLIP_COMPANY_ID/agent-h
   -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
-    "name": "CTO",
+    "name": "Ada Whitfield",
     "role": "cto",
     "title": "Chief Technology Officer",
     "icon": "crown",

--- a/skills/paperclip-create-agent/references/draft-review-checklist.md
+++ b/skills/paperclip-create-agent/references/draft-review-checklist.md
@@ -9,6 +9,7 @@ Use it for every path: exact template, adjacent template, or generic fallback.
 ## A. Identity and framing
 
 - [ ] `name`, `role`, and `title` are set and consistent with each other
+- [ ] `name` is a real human first + last name (e.g. `Ada Whitfield`), not the role/function/team — the function lives in `title` and the enum in `role`; the chosen name is not already used by an existing teammate
 - [ ] `AGENTS.md` names the agent, the role, and the company in the first sentence
 - [ ] The first paragraph points at the Paperclip skill as the source of truth for the heartbeat procedure
 - [ ] The reporting line (`reportsTo`) resolves to a real in-company agent id


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Agent hiring is configured through skills that guide operators through role, title, and profile details
> - The create-agent skill already distinguishes functional role metadata from the displayed person name
> - But the hiring guidance did not make the real first-and-last-name requirement explicit enough at every review point
> - That can let role-like placeholders leak into agent profiles where a human-readable name is expected
> - This pull request tightens the hiring docs and checklist so operators draft hires with real human names
> - The benefit is more consistent agent profiles while preserving role and title as the functional fields

## Linked Issues or Issue Description

No public GitHub issue exists. This is a small documentation correction for the agent hiring skill: the `name` field should be a real first and last human name, while role and title remain the functional descriptors.

## What Changed

- Updated the create-agent skill instructions so the hire config example uses a real first-and-last human name.
- Clarified that `name` must not be a role label or codename.
- Added the same real-name reminder to the draft review checklist.

## Verification

- Confirmed the updated example and checklist text are present in the two changed skill files.
- Ran `git diff --check origin/master..HEAD`; it passed with no whitespace errors.
- Confirmed the branch diff contains only the two intended skill documentation files.

## Risks

Low risk. This is a docs-only skill guidance change. The main risk is wording being too narrow for future naming conventions, but the current requirement is intentionally explicit about real first and last human names.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

OpenAI Codex, GPT-5-based coding agent, with repository file access, shell command execution, and GitHub CLI tooling. The implementation was produced by a Paperclip agent workflow and handed off for GitHub operations.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge
