### PR TITLE
Add telemetry data contract docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,6 +102,10 @@ Every PR must include a **Model Used** section specifying which AI model produce
 
 All tests must pass before a PR can be merged. Run them locally first and verify CI is green after pushing.
 
+### Telemetry Changes
+
+If your change adds, removes, or modifies emitted telemetry events, update the [Telemetry Data Contract](packages/shared/src/telemetry/README.md) in the same PR. Keep clients emitting raw dimension values and avoid documenting or relying on private delivery details.
+
 ### Paperclip Gates Must Pass
 
 All Paperclip CI gates (lint, typecheck, tests, build, and any other required checks) must be satisfied before a PR can be merged. Don't ask for a merge while gates are red — fix them first.

--- a/README.md
+++ b/README.md
@@ -409,6 +409,8 @@ Paperclip ships with opt-in OpenTelemetry auto-instrumentation for the server (t
 
 Paperclip collects anonymous usage telemetry to help us understand how the product is used and improve it. No personal information, issue content, prompts, file paths, or secrets are ever collected. Private repository references are hashed with a per-install salt before being sent.
 
+Contributors changing emitted telemetry events should follow the [Telemetry Data Contract](packages/shared/src/telemetry/README.md).
+
 Telemetry is **enabled by default** and can be disabled with any of the following:
 
 | Method               | How                                                     |

--- a/packages/shared/src/telemetry/README.md
+++ b/packages/shared/src/telemetry/README.md
@@ -20,7 +20,7 @@ Use these files when reviewing or changing telemetry code:
 | First-party event names | `PaperclipEventName` in `generated/paperclip-telemetry.ts` |
 | Per-event dimensions and optionality | `EventDimensionsMap` in `generated/paperclip-telemetry.ts` |
 | Enum descriptions for telemetry dimensions | `PAPERCLIP_ENUM_DESCRIPTIONS` in `generated/paperclip-telemetry.ts` |
-| Schema version and event envelope helpers | `SCHEMA_VERSION`, `createPaperclipTelemetryEvent()`, and `createPaperclipTelemetryEnvelope()` in `generated/paperclip-telemetry.ts` |
+| Schema version and event envelope helpers | `SCHEMA_VERSION`, `makeEvent()`, and `makeBatch()` in `generated/paperclip-telemetry.ts` |
 | Runtime-safe event names and dimensions | `TelemetryEventName` and `TelemetryEventDimensions` in `types.ts` |
 | Allowed primitive dimension values | `TelemetryDimensionValue` in `types.ts` |
 | Shared reusable enum domains | Named exports in `constants.ts` |

--- a/packages/shared/src/telemetry/README.md
+++ b/packages/shared/src/telemetry/README.md
@@ -1,132 +1,108 @@
 # Telemetry Data Contract
 
-This document is the public contract for first-party Paperclip telemetry events.
-It covers the event names and dimensions emitted by `packages/shared/src/telemetry/`
-and the shared enum sources in `packages/shared/src/constants.ts`.
+This document explains how contributors should use Paperclip's public telemetry
+contract. It intentionally does not list individual events or dimensions.
 
-It does not describe where events are delivered or how any receiving system is
-implemented. Contributors should treat that path as outside this repository's
-public contract.
+The canonical source for first-party event names, dimensions, optionality,
+allowed primitive value types, and enum descriptions is
+`packages/shared/src/telemetry/generated/paperclip-telemetry.ts`.
 
-## Normalization Boundary
+Shared enum constants live in `packages/shared/src/constants.ts`. Use those
+constants when code needs a reusable domain, but treat the generated telemetry
+types as the final authority for emitted first-party telemetry shapes.
 
-Telemetry emitters send raw dimension values. They must not pre-normalize values
-into the canonical reporting form.
+This document does not describe where events are delivered or how events are
+handled after emission. That is outside this repository's public telemetry
+contract.
 
-The receiving layer owns canonicalization because there should be one place that
-maps legacy spellings, aliases, unknown adapter names, and future values into a
-stable reporting shape. This keeps SDKs and third-party contributors simple:
-emit what the product observed, use the documented sentinel only when a required
-field has no value at all, and let the receiving layer decide the canonical form.
+## Public Sources
 
-Examples:
-
-- `adapter_type`: if the runtime reports a concrete adapter string that is not
-  yet in `AGENT_ADAPTER_TYPES`, emit that raw string. Do not rewrite it to
-  `other`. Use `other` only when the adapter is genuinely unknown and the event
-  requires an `adapter_type` dimension.
-- Interaction labels: if older code, plugin-adjacent code, or a caller reports a
-  same-meaning label that does not match the current enum spelling, emit the raw
-  label. Do not map it in the client before calling `track()`.
-
-The one exception is privacy protection at the emit boundary: if a dimension is
-documented as hashed before emission, emit the hashed value and the matching
-boolean marker rather than the private source value.
-
-## Event Catalog
-
-The source of truth for registered first-party event names is
-`TelemetryEventName`, which is backed by `PaperclipEventName` in
-`generated/paperclip-telemetry.ts`. Plugin events use `trackDynamic()` and are
-not part of this first-party catalog.
-
-Dimension value types are `string`, `number`, and `boolean`. Optional dimensions
-must be omitted when absent; do not emit `null`, `undefined`, objects, or arrays.
-
-| Event | Dimensions |
-| --- | --- |
-| `agent.created` | Required `agent_id`: `string`.<br>Required `agent_role`: `string`, domain `AGENT_ROLES` plus telemetry-only values from `EventDimensionsMap`. |
-| `agent.first_heartbeat` | Required `agent_id`: `string`.<br>Required `agent_role`: `string`, domain `AGENT_ROLES` plus telemetry-only values from `EventDimensionsMap`. |
-| `agent.task_completed` | Required `adapter_type`: `string`, domain `AGENT_ADAPTER_TYPES` plus telemetry-only values from `EventDimensionsMap`.<br>Required `agent_id`: `string`.<br>Required `agent_role`: `string`, domain `AGENT_ROLES` plus telemetry-only values from `EventDimensionsMap`.<br>Optional `model`: `string`. |
-| `company.imported` | Required `source_type`: `string`, domain declared inline in `EventDimensionsMap`.<br>Optional `source_ref`: `string`; hashed before emission when the source is private.<br>Optional `source_ref_hashed`: `boolean`; `true` when `source_ref` is hashed. |
-| `error.handler_crash` | Required `error_code`: `string`. |
-| `goal.created` | Required `goal_level`: `string`, domain `GOAL_LEVELS` plus telemetry-only values from `EventDimensionsMap`. |
-| `install.completed` | Required `adapter_type`: `string`, domain `AGENT_ADAPTER_TYPES` plus telemetry-only values from `EventDimensionsMap`. |
-| `install.started` | No dimensions. |
-| `interaction.resolved` | Required `interaction_kind`: `string`, domain `ISSUE_THREAD_INTERACTION_KINDS` plus telemetry-only values from `EventDimensionsMap`.<br>Required `status`: `string`, terminal values from `ISSUE_THREAD_INTERACTION_STATUSES` plus telemetry-only values from `EventDimensionsMap`.<br>Required `resolved_by_kind`: `string`, domain declared inline in `EventDimensionsMap`.<br>Optional `resolution_reason`: `string`, domain declared inline in `EventDimensionsMap`.<br>Optional `created_by_kind`: `string`, domain declared inline in `EventDimensionsMap`.<br>Optional `creator_agent_role`: `string`, domain `AGENT_ROLES` plus telemetry-only values from `EventDimensionsMap`.<br>Optional `continuation_policy`: `string`, domain `ISSUE_THREAD_INTERACTION_CONTINUATION_POLICIES` plus telemetry-only values from `EventDimensionsMap`.<br>Optional `target_type`: `string`, domain declared inline in `EventDimensionsMap`.<br>Optional `option_count`: `number`.<br>Optional `selected_option_count`: `number`.<br>Optional `question_count`: `number`.<br>Optional `answered_question_count`: `number`.<br>Optional `created_task_count`: `number`.<br>Optional `skipped_task_count`: `number`.<br>Optional `has_reason`: `boolean`.<br>Optional `resolution_latency_seconds`: `number`.<br>Optional `interaction_id`: `string`.<br>Optional `created_by_agent_id`: `string`.<br>Optional `source_run_id`: `string`. |
-| `project.created` | No dimensions. |
-| `routine.created` | No dimensions. |
-| `routine.run` | Required `source`: `string`, domain `ROUTINE_RUN_SOURCES` plus telemetry-only values from `EventDimensionsMap`.<br>Required `status`: `string`, domain `ROUTINE_RUN_STATUSES` plus telemetry-only values from `EventDimensionsMap`. |
-| `skill.imported` | Required `source_type`: `string`, domain declared inline in `EventDimensionsMap`.<br>Optional `skill_ref`: `string`. |
-
-## Value Types And Enum Domains
+Use these files when reviewing or changing telemetry code:
 
 | Contract item | Public source |
 | --- | --- |
-| Allowed dimension value types | `TelemetryDimensionValue` in `types.ts`: `string`, `number`, or `boolean`. |
-| Event names | `TelemetryEventName` in `types.ts`, backed by `PaperclipEventName` in `generated/paperclip-telemetry.ts`. |
-| Per-event dimensions | `EventDimensionsMap` in `generated/paperclip-telemetry.ts`. |
-| Adapter type domain | `AGENT_ADAPTER_TYPES` in `constants.ts`, with telemetry-only values from `EventDimensionsMap`. |
-| Agent role domain | `AGENT_ROLES` in `constants.ts`, with telemetry-only values from `EventDimensionsMap`. |
-| Goal level domain | `GOAL_LEVELS` in `constants.ts`, with telemetry-only values from `EventDimensionsMap`. |
-| Interaction kind domain | `ISSUE_THREAD_INTERACTION_KINDS` in `constants.ts`, with telemetry-only values from `EventDimensionsMap`. |
-| Interaction continuation policy domain | `ISSUE_THREAD_INTERACTION_CONTINUATION_POLICIES` in `constants.ts`, with telemetry-only values from `EventDimensionsMap`. |
-| Routine run source domain | `ROUTINE_RUN_SOURCES` in `constants.ts`, with telemetry-only values from `EventDimensionsMap`. |
-| Routine run status domain | `ROUTINE_RUN_STATUSES` in `constants.ts`, with telemetry-only values from `EventDimensionsMap`. |
-| Other telemetry-only domains | The inline dimension union in `generated/paperclip-telemetry.ts` until a shared `constants.ts` export exists. |
+| First-party event names | `PaperclipEventName` in `generated/paperclip-telemetry.ts` |
+| Per-event dimensions and optionality | `EventDimensionsMap` in `generated/paperclip-telemetry.ts` |
+| Enum descriptions for telemetry dimensions | `PAPERCLIP_ENUM_DESCRIPTIONS` in `generated/paperclip-telemetry.ts` |
+| Schema version and event envelope helpers | `SCHEMA_VERSION`, `createPaperclipTelemetryEvent()`, and `createPaperclipTelemetryEnvelope()` in `generated/paperclip-telemetry.ts` |
+| Runtime-safe event names and dimensions | `TelemetryEventName` and `TelemetryEventDimensions` in `types.ts` |
+| Allowed primitive dimension values | `TelemetryDimensionValue` in `types.ts` |
+| Shared reusable enum domains | Named exports in `constants.ts` |
+| First-party typed emit helpers | `events.ts` |
+| Generic client behavior | `client.ts` |
 
-Do not duplicate enum value lists in new docs or comments when a shared constant
-already exists. Reference the constant by name and keep the emitted values aligned
-with the generated telemetry types.
+Do not copy generated event lists or dimension tables into this README. They
+will drift as the generated contract changes.
 
-## Optionality And Sentinel Fill
+## Emission Boundary
 
-Optionality is defined by `EventDimensionsMap`. Required dimensions must be
-present on every event of that name. Optional dimensions are emitted only when
-the value is known and useful.
+Telemetry emitters send raw dimension values. They must not pre-normalize
+enum-like values into a reporting form just to match today's known domain.
 
-Sentinel values are allowed only to fill a required field that has no observed
-raw value:
+The receiving layer owns canonicalization. Keeping canonicalization in one place
+means emitters can stay simple and accurate: emit what the product observed, use
+the generated contract for required and optional fields, and let the receiving
+layer decide how legacy spellings, aliases, unknown names, and future values map
+to a stable reporting shape.
 
-- Use the event domain's documented sentinel, usually `other`, when the value is
-  missing or unknowable at the emitting layer.
-- Do not use a sentinel to hide a concrete raw value that the current enum does
-  not recognize. Emit the raw value and let the receiving layer canonicalize it.
-- If a field is optional, prefer omitting it over sending a sentinel unless the
-  event contract explicitly says the sentinel carries meaning.
+Do not add client-side lowercasing, alias mapping, or fallback mapping unless
+the generated telemetry contract specifically requires that emitted value.
 
-Worked example: `adapter_type` is required on `install.completed` and
-`agent.task_completed`. If no adapter type is known, emit `other` so the required
-dimension is present. If the adapter type is known but new, custom, or not yet in
-`AGENT_ADAPTER_TYPES`, emit the raw adapter string.
+## Dimension Values
 
-For `company.imported`, `source_ref` is optional and must be omitted when there
-is no source reference. When a source reference is private, emit the hashed value
-as `source_ref` and set `source_ref_hashed` to `true`; otherwise emit the raw
-source reference and set `source_ref_hashed` to `false`.
+Telemetry dimension values must be primitives. Use only the value types allowed
+by `TelemetryDimensionValue`:
 
-## Adding Or Changing A Telemetry Event
+- `string`
+- `number`
+- `boolean`
 
-1. Pick a stable event name using the existing dot-separated style, such as
-   `area.action`. Do not include user content, file paths, local machine details,
-   secrets, or identifiers that are not already part of the public event contract.
-2. Declare the event dimensions in the telemetry schema that produces
-   `generated/paperclip-telemetry.ts`. Define required vs optional fields
-   deliberately.
+Do not emit `null`, `undefined`, arrays, or objects as dimension values. Optional
+dimensions should be omitted when absent.
+
+When a dimension is enum-like, use the shared constant from `constants.ts` when
+one exists. If no shared constant exists, use the generated telemetry type as the
+domain. In all cases, the generated telemetry type remains the source of truth
+for the emitted value.
+
+## Required, Optional, And Sentinel Values
+
+Required and optional dimensions are defined by `EventDimensionsMap`.
+
+Required dimensions must be present for every event of that name. Optional
+dimensions should be emitted only when the value is known and useful.
+
+Sentinel values are only for required fields that have no observed raw value at
+the emitting layer. Do not use a sentinel to hide a concrete value that is new,
+custom, or not yet represented by a shared constant. Emit the concrete raw value
+and let the receiving layer canonicalize it.
+
+If a dimension is privacy-protected before emission, emit only the protected
+value and its matching public marker as defined by the typed helper or generated
+contract. Do not emit private source material in telemetry dimensions.
+
+## Adding Or Changing Telemetry
+
+1. Start from `generated/paperclip-telemetry.ts`. The generated types are what
+   reviewers use to verify event names, dimensions, optionality, value types,
+   enum descriptions, and schema version.
+2. Choose stable event and dimension names. Do not include user content, local
+   machine details, secrets, credentials, private paths, or values that are not
+   part of the public event contract.
 3. Use only `string`, `number`, or `boolean` dimension values.
-4. For enum-like dimensions, reuse the existing shared constant from
-   `constants.ts` when one exists. If no constant exists, use a named generated
-   telemetry domain and consider whether the domain should become a shared
-   constant before adding more call sites.
-5. Keep emitters raw. Do not add client-side normalization, alias mapping, or
-   lowercasing just to satisfy the current enum. Sentinel-fill only truly
-   unknown required values.
-6. Add or update the wrapper in `events.ts` and export it from `index.ts` when
-   the event is first-party and should have a typed helper.
-7. Update or add tests for the wrapper behavior. Include a case that proves raw
-   enum-like values pass through unchanged when that is the intended boundary.
-8. Update this README in the same change so the event catalog remains current.
+4. Reuse a shared constant from `constants.ts` for enum-like dimensions when one
+   exists. If the generated telemetry domain has values beyond a shared constant,
+   keep the emitter aligned with the generated telemetry type.
+5. Keep emitters raw. Do not normalize, alias-map, or lowercase enum-like values
+   in the client unless the generated contract explicitly calls for that emitted
+   value.
+6. Add or update a typed helper in `events.ts` when the event is first-party and
+   should have a stable helper API.
+7. Update tests for helper behavior, including raw pass-through for enum-like
+   values when that is the intended boundary.
+8. Update this README only when the contributor workflow, source-of-truth
+   pointers, or durable invariants change. Do not add an event catalog here.
 
-Before opening a pull request, verify that the docs and generated telemetry
-types agree on event names, dimensions, optionality, value types, and enum-domain
-references.
+Before opening a pull request, verify that the emitted code, typed helpers, and
+generated telemetry contract agree. If they disagree, fix the contract or code
+rather than documenting around the mismatch in this README.

--- a/packages/shared/src/telemetry/README.md
+++ b/packages/shared/src/telemetry/README.md
@@ -1,0 +1,132 @@
+# Telemetry Data Contract
+
+This document is the public contract for first-party Paperclip telemetry events.
+It covers the event names and dimensions emitted by `packages/shared/src/telemetry/`
+and the shared enum sources in `packages/shared/src/constants.ts`.
+
+It does not describe where events are delivered or how any receiving system is
+implemented. Contributors should treat that path as outside this repository's
+public contract.
+
+## Normalization Boundary
+
+Telemetry emitters send raw dimension values. They must not pre-normalize values
+into the canonical reporting form.
+
+The receiving layer owns canonicalization because there should be one place that
+maps legacy spellings, aliases, unknown adapter names, and future values into a
+stable reporting shape. This keeps SDKs and third-party contributors simple:
+emit what the product observed, use the documented sentinel only when a required
+field has no value at all, and let the receiving layer decide the canonical form.
+
+Examples:
+
+- `adapter_type`: if the runtime reports a concrete adapter string that is not
+  yet in `AGENT_ADAPTER_TYPES`, emit that raw string. Do not rewrite it to
+  `other`. Use `other` only when the adapter is genuinely unknown and the event
+  requires an `adapter_type` dimension.
+- Interaction labels: if older code, plugin-adjacent code, or a caller reports a
+  same-meaning label that does not match the current enum spelling, emit the raw
+  label. Do not map it in the client before calling `track()`.
+
+The one exception is privacy protection at the emit boundary: if a dimension is
+documented as hashed before emission, emit the hashed value and the matching
+boolean marker rather than the private source value.
+
+## Event Catalog
+
+The source of truth for registered first-party event names is
+`TelemetryEventName`, which is backed by `PaperclipEventName` in
+`generated/paperclip-telemetry.ts`. Plugin events use `trackDynamic()` and are
+not part of this first-party catalog.
+
+Dimension value types are `string`, `number`, and `boolean`. Optional dimensions
+must be omitted when absent; do not emit `null`, `undefined`, objects, or arrays.
+
+| Event | Dimensions |
+| --- | --- |
+| `agent.created` | Required `agent_id`: `string`.<br>Required `agent_role`: `string`, domain `AGENT_ROLES` plus telemetry-only values from `EventDimensionsMap`. |
+| `agent.first_heartbeat` | Required `agent_id`: `string`.<br>Required `agent_role`: `string`, domain `AGENT_ROLES` plus telemetry-only values from `EventDimensionsMap`. |
+| `agent.task_completed` | Required `adapter_type`: `string`, domain `AGENT_ADAPTER_TYPES` plus telemetry-only values from `EventDimensionsMap`.<br>Required `agent_id`: `string`.<br>Required `agent_role`: `string`, domain `AGENT_ROLES` plus telemetry-only values from `EventDimensionsMap`.<br>Optional `model`: `string`. |
+| `company.imported` | Required `source_type`: `string`, domain declared inline in `EventDimensionsMap`.<br>Optional `source_ref`: `string`; hashed before emission when the source is private.<br>Optional `source_ref_hashed`: `boolean`; `true` when `source_ref` is hashed. |
+| `error.handler_crash` | Required `error_code`: `string`. |
+| `goal.created` | Required `goal_level`: `string`, domain `GOAL_LEVELS` plus telemetry-only values from `EventDimensionsMap`. |
+| `install.completed` | Required `adapter_type`: `string`, domain `AGENT_ADAPTER_TYPES` plus telemetry-only values from `EventDimensionsMap`. |
+| `install.started` | No dimensions. |
+| `interaction.resolved` | Required `interaction_kind`: `string`, domain `ISSUE_THREAD_INTERACTION_KINDS` plus telemetry-only values from `EventDimensionsMap`.<br>Required `status`: `string`, terminal values from `ISSUE_THREAD_INTERACTION_STATUSES` plus telemetry-only values from `EventDimensionsMap`.<br>Required `resolved_by_kind`: `string`, domain declared inline in `EventDimensionsMap`.<br>Optional `resolution_reason`: `string`, domain declared inline in `EventDimensionsMap`.<br>Optional `created_by_kind`: `string`, domain declared inline in `EventDimensionsMap`.<br>Optional `creator_agent_role`: `string`, domain `AGENT_ROLES` plus telemetry-only values from `EventDimensionsMap`.<br>Optional `continuation_policy`: `string`, domain `ISSUE_THREAD_INTERACTION_CONTINUATION_POLICIES` plus telemetry-only values from `EventDimensionsMap`.<br>Optional `target_type`: `string`, domain declared inline in `EventDimensionsMap`.<br>Optional `option_count`: `number`.<br>Optional `selected_option_count`: `number`.<br>Optional `question_count`: `number`.<br>Optional `answered_question_count`: `number`.<br>Optional `created_task_count`: `number`.<br>Optional `skipped_task_count`: `number`.<br>Optional `has_reason`: `boolean`.<br>Optional `resolution_latency_seconds`: `number`.<br>Optional `interaction_id`: `string`.<br>Optional `created_by_agent_id`: `string`.<br>Optional `source_run_id`: `string`. |
+| `project.created` | No dimensions. |
+| `routine.created` | No dimensions. |
+| `routine.run` | Required `source`: `string`, domain `ROUTINE_RUN_SOURCES` plus telemetry-only values from `EventDimensionsMap`.<br>Required `status`: `string`, domain `ROUTINE_RUN_STATUSES` plus telemetry-only values from `EventDimensionsMap`. |
+| `skill.imported` | Required `source_type`: `string`, domain declared inline in `EventDimensionsMap`.<br>Optional `skill_ref`: `string`. |
+
+## Value Types And Enum Domains
+
+| Contract item | Public source |
+| --- | --- |
+| Allowed dimension value types | `TelemetryDimensionValue` in `types.ts`: `string`, `number`, or `boolean`. |
+| Event names | `TelemetryEventName` in `types.ts`, backed by `PaperclipEventName` in `generated/paperclip-telemetry.ts`. |
+| Per-event dimensions | `EventDimensionsMap` in `generated/paperclip-telemetry.ts`. |
+| Adapter type domain | `AGENT_ADAPTER_TYPES` in `constants.ts`, with telemetry-only values from `EventDimensionsMap`. |
+| Agent role domain | `AGENT_ROLES` in `constants.ts`, with telemetry-only values from `EventDimensionsMap`. |
+| Goal level domain | `GOAL_LEVELS` in `constants.ts`, with telemetry-only values from `EventDimensionsMap`. |
+| Interaction kind domain | `ISSUE_THREAD_INTERACTION_KINDS` in `constants.ts`, with telemetry-only values from `EventDimensionsMap`. |
+| Interaction continuation policy domain | `ISSUE_THREAD_INTERACTION_CONTINUATION_POLICIES` in `constants.ts`, with telemetry-only values from `EventDimensionsMap`. |
+| Routine run source domain | `ROUTINE_RUN_SOURCES` in `constants.ts`, with telemetry-only values from `EventDimensionsMap`. |
+| Routine run status domain | `ROUTINE_RUN_STATUSES` in `constants.ts`, with telemetry-only values from `EventDimensionsMap`. |
+| Other telemetry-only domains | The inline dimension union in `generated/paperclip-telemetry.ts` until a shared `constants.ts` export exists. |
+
+Do not duplicate enum value lists in new docs or comments when a shared constant
+already exists. Reference the constant by name and keep the emitted values aligned
+with the generated telemetry types.
+
+## Optionality And Sentinel Fill
+
+Optionality is defined by `EventDimensionsMap`. Required dimensions must be
+present on every event of that name. Optional dimensions are emitted only when
+the value is known and useful.
+
+Sentinel values are allowed only to fill a required field that has no observed
+raw value:
+
+- Use the event domain's documented sentinel, usually `other`, when the value is
+  missing or unknowable at the emitting layer.
+- Do not use a sentinel to hide a concrete raw value that the current enum does
+  not recognize. Emit the raw value and let the receiving layer canonicalize it.
+- If a field is optional, prefer omitting it over sending a sentinel unless the
+  event contract explicitly says the sentinel carries meaning.
+
+Worked example: `adapter_type` is required on `install.completed` and
+`agent.task_completed`. If no adapter type is known, emit `other` so the required
+dimension is present. If the adapter type is known but new, custom, or not yet in
+`AGENT_ADAPTER_TYPES`, emit the raw adapter string.
+
+For `company.imported`, `source_ref` is optional and must be omitted when there
+is no source reference. When a source reference is private, emit the hashed value
+as `source_ref` and set `source_ref_hashed` to `true`; otherwise emit the raw
+source reference and set `source_ref_hashed` to `false`.
+
+## Adding Or Changing A Telemetry Event
+
+1. Pick a stable event name using the existing dot-separated style, such as
+   `area.action`. Do not include user content, file paths, local machine details,
+   secrets, or identifiers that are not already part of the public event contract.
+2. Declare the event dimensions in the telemetry schema that produces
+   `generated/paperclip-telemetry.ts`. Define required vs optional fields
+   deliberately.
+3. Use only `string`, `number`, or `boolean` dimension values.
+4. For enum-like dimensions, reuse the existing shared constant from
+   `constants.ts` when one exists. If no constant exists, use a named generated
+   telemetry domain and consider whether the domain should become a shared
+   constant before adding more call sites.
+5. Keep emitters raw. Do not add client-side normalization, alias mapping, or
+   lowercasing just to satisfy the current enum. Sentinel-fill only truly
+   unknown required values.
+6. Add or update the wrapper in `events.ts` and export it from `index.ts` when
+   the event is first-party and should have a typed helper.
+7. Update or add tests for the wrapper behavior. Include a case that proves raw
+   enum-like values pass through unchanged when that is the intended boundary.
+8. Update this README in the same change so the event catalog remains current.
+
+Before opening a pull request, verify that the docs and generated telemetry
+types agree on event names, dimensions, optionality, value types, and enum-domain
+references.

--- a/packages/shared/src/telemetry/README.md
+++ b/packages/shared/src/telemetry/README.md
@@ -11,10 +11,6 @@ Shared enum constants live in `packages/shared/src/constants.ts`. Use those
 constants when code needs a reusable domain, but treat the generated telemetry
 types as the final authority for emitted first-party telemetry shapes.
 
-This document does not describe where events are delivered or how events are
-handled after emission. That is outside this repository's public telemetry
-contract.
-
 ## Public Sources
 
 Use these files when reviewing or changing telemetry code:
@@ -36,6 +32,12 @@ will drift as the generated contract changes.
 
 ## Emission Boundary
 
+Paperclip telemetry uses named events with explicit dimension fields. Treat
+open-ended string dimensions as public contract values, not as a place for user
+content or private operational data. Do not send PII, secrets, credentials,
+private paths, prompts, model output, or other sensitive values through
+telemetry dimensions.
+
 Telemetry emitters send raw dimension values. They must not pre-normalize
 enum-like values into a reporting form just to match today's known domain.
 
@@ -47,6 +49,10 @@ to a stable reporting shape.
 
 Do not add client-side lowercasing, alias mapping, or fallback mapping unless
 the generated telemetry contract specifically requires that emitted value.
+
+If a dimension is privacy-protected before emission, emit only the protected
+value and its matching public marker as defined by the typed helper or generated
+contract. Do not emit private source material in telemetry dimensions.
 
 ## Dimension Values
 
@@ -77,11 +83,13 @@ the emitting layer. Do not use a sentinel to hide a concrete value that is new,
 custom, or not yet represented by a shared constant. Emit the concrete raw value
 and let the receiving layer canonicalize it.
 
-If a dimension is privacy-protected before emission, emit only the protected
-value and its matching public marker as defined by the typed helper or generated
-contract. Do not emit private source material in telemetry dimensions.
-
 ## Adding Or Changing Telemetry
+
+Client code is responsible for emitting approved telemetry events at the right
+place in the product. It is not responsible for deciding which new events should
+exist. Do not introduce ad hoc event names, dimensions, or enum domains in client
+code; they must exist in the generated telemetry contract before emitters use
+them.
 
 1. Start from `generated/paperclip-telemetry.ts`. The generated types are what
    reviewers use to verify event names, dimensions, optionality, value types,

--- a/packages/shared/src/telemetry/readme-contract.test.ts
+++ b/packages/shared/src/telemetry/readme-contract.test.ts
@@ -1,0 +1,19 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import * as generatedTelemetry from "./generated/paperclip-telemetry.js";
+
+const readmePath = fileURLToPath(new URL("./README.md", import.meta.url));
+
+describe("telemetry README contract", () => {
+  it("documents generated event helper exports that exist", () => {
+    const readme = readFileSync(readmePath, "utf8");
+
+    expect(generatedTelemetry.SCHEMA_VERSION).toBeDefined();
+    expect(generatedTelemetry.makeEvent).toBeTypeOf("function");
+    expect(generatedTelemetry.makeBatch).toBeTypeOf("function");
+    expect(readme).toContain("`SCHEMA_VERSION`, `makeEvent()`, and `makeBatch()`");
+    expect(readme).not.toContain("createPaperclipTelemetryEvent");
+    expect(readme).not.toContain("createPaperclipTelemetryEnvelope");
+  });
+});


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The telemetry subsystem helps maintainers understand product usage while preserving contributor-facing privacy guarantees.
> - Contributors already have generated telemetry types in the shared package, but the public workflow for using those types was not documented in one durable place.
> - That gap makes it easier for emitters to duplicate generated catalogs, normalize values too early, or accidentally document private delivery details.
> - This pull request adds a telemetry data contract README and links it from the main contributor surfaces.
> - The benefit is that contributors get a clear source-of-truth path for telemetry changes without exposing backend, infrastructure, vendor, or endpoint details.

## Linked Issues or Issue Description

No public GitHub issue exists for this documentation gap.

Feature/documentation context:
- Problem: contributor-facing telemetry guidance did not name the generated shared contract as the public source of truth.
- Proposed solution: add a focused telemetry data contract README and link it from README and CONTRIBUTING.
- Alternatives considered: documenting event catalogs directly in the README, rejected because generated event and dimension lists would drift.
- Roadmap alignment: documentation-only change that supports the existing telemetry subsystem.

Related prior work:
- Refs #8818
- Refs #2527

## What Changed

- Added `packages/shared/src/telemetry/README.md` as the public contributor-facing telemetry data contract.
- Pointed contributors to `packages/shared/src/telemetry/generated/paperclip-telemetry.ts` as the generated source of truth.
- Documented raw emission boundaries, primitive dimension values, sentinel usage, privacy limits, and the contributor workflow.
- Linked the telemetry data contract from the root `README.md` and `CONTRIBUTING.md`.
- Added a focused telemetry README contract test for the generated helper names documented in the public-sources table.

## Verification

- `git diff --check origin/master..HEAD`
- `pnpm exec vitest run packages/shared/src/telemetry/readme-contract.test.ts`
- Reviewed the docs diff to confirm it does not introduce backend, infrastructure, vendor, or endpoint implementation details.
- Searched GitHub for duplicate or related telemetry data contract PRs/issues; no matching public issue was found, and the closest related PRs are linked above.

## Risks

Low risk. This is a documentation-only guidance change plus a narrow README contract test. The main risk is that the guidance gets stale if the generated telemetry contract moves or changes names; the README avoids copying generated event catalogs to reduce that drift.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

OpenAI GPT-5 Codex, exact Codex CLI model supplied by the Paperclip `codex_local` adapter in this run, with tool use for repository inspection and Git/GitHub operations. Context window size was not exposed by the runtime.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge