### PR TITLE
Add Coolify deployment support

### DIFF
--- a/docker/.env.coolify.example
+++ b/docker/.env.coolify.example
@@ -1,0 +1,12 @@
+# Reference only — in Coolify, set these in the resource's
+# Environment Variables tab, not as a committed .env file.
+# See docs/deploy-coolify.md for the full walkthrough.
+
+POSTGRES_PASSWORD=change-me
+BETTER_AUTH_SECRET=change-me
+PAPERCLIP_PUBLIC_URL=https://paperclip.example.com
+
+# Optional
+ANTHROPIC_API_KEY=
+OPENAI_API_KEY=
+GITHUB_TOKEN=

--- a/docker/docker-compose.coolify.yml
+++ b/docker/docker-compose.coolify.yml
@@ -1,0 +1,71 @@
+# Coolify deployment — Docker Compose resource.
+#
+# In Coolify: New Resource -> Docker Compose -> point at this repo, set
+# "Base Directory" to /docker and "Docker Compose Location" to this file
+# (or just this path from the repo root: docker/docker-compose.coolify.yml).
+#
+# Required environment variables (set in Coolify's Environment Variables tab):
+#   POSTGRES_PASSWORD    - password for the bundled Postgres instance
+#   BETTER_AUTH_SECRET    - `openssl rand -base64 32`
+#   PAPERCLIP_PUBLIC_URL   - the https domain Coolify assigns to the `app` service
+#
+# Optional:
+#   ANTHROPIC_API_KEY, OPENAI_API_KEY, GITHUB_TOKEN
+#
+# After assigning a domain to the `app` service in Coolify, set
+# PAPERCLIP_PUBLIC_URL to that domain (e.g. https://paperclip.example.com)
+# and redeploy so auth callback URLs resolve correctly.
+
+services:
+  app:
+    build:
+      context: ..
+      dockerfile: Dockerfile
+    restart: unless-stopped
+    ports:
+      - "3100"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://localhost:3100/api/health || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 30s
+    environment:
+      HOST: "0.0.0.0"
+      PORT: "3100"
+      NODE_ENV: "production"
+      SERVE_UI: "true"
+      DATABASE_URL: "postgres://paperclip:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set}@db:5432/paperclip"
+      BETTER_AUTH_SECRET: "${BETTER_AUTH_SECRET:?BETTER_AUTH_SECRET must be set}"
+      PAPERCLIP_PUBLIC_URL: "${PAPERCLIP_PUBLIC_URL:?PAPERCLIP_PUBLIC_URL must be set}"
+      PAPERCLIP_DEPLOYMENT_MODE: "authenticated"
+      PAPERCLIP_DEPLOYMENT_EXPOSURE: "public"
+      PAPERCLIP_MIGRATION_AUTO_APPLY: "true"
+      HEARTBEAT_SCHEDULER_ENABLED: "true"
+      ANTHROPIC_API_KEY: "${ANTHROPIC_API_KEY:-}"
+      OPENAI_API_KEY: "${OPENAI_API_KEY:-}"
+      GITHUB_TOKEN: "${GITHUB_TOKEN:-}"
+    volumes:
+      - paperclip-data:/paperclip
+    depends_on:
+      db:
+        condition: service_healthy
+
+  db:
+    image: postgres:17-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: paperclip
+      POSTGRES_PASSWORD: "${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set}"
+      POSTGRES_DB: paperclip
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U paperclip -d paperclip"]
+      interval: 2s
+      timeout: 5s
+      retries: 30
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+
+volumes:
+  pgdata:
+  paperclip-data:

--- a/docs/deploy/coolify.md
+++ b/docs/deploy/coolify.md
@@ -1,0 +1,54 @@
+---
+title: Coolify
+summary: Deploy Paperclip to Coolify with the bundled Docker Compose file
+---
+
+Paperclip ships a production [`Dockerfile`](https://github.com/paperclipai/paperclip/blob/main/Dockerfile) plus a Compose file tailored for Coolify's "Docker Compose" resource type: `docker/docker-compose.coolify.yml`. It bundles the app with its own Postgres instance and keeps the database off the public network.
+
+## 1. Create the resource
+
+1. In Coolify: **New Resource -> Docker Compose**.
+2. Connect the `paperclipai/paperclip` repo (or your fork) and pick the branch to deploy.
+3. Set **Docker Compose Location** to `docker/docker-compose.coolify.yml`.
+4. Coolify detects two services: `app` and `db`.
+
+## 2. Set environment variables
+
+In the resource's **Environment Variables** tab, add:
+
+| Variable | Required | Notes |
+|---|---|---|
+| `POSTGRES_PASSWORD` | yes | password for the bundled Postgres instance |
+| `BETTER_AUTH_SECRET` | yes | generate with `openssl rand -base64 32` |
+| `PAPERCLIP_PUBLIC_URL` | yes | the https domain you assign the `app` service, e.g. `https://paperclip.example.com` |
+| `ANTHROPIC_API_KEY` | optional | lets agents use Claude out of the box |
+| `OPENAI_API_KEY` | optional | lets agents use OpenAI out of the box |
+| `GITHUB_TOKEN` | optional | needed for GitHub-integrated workflows |
+
+See [`docker/.env.coolify.example`](https://github.com/paperclipai/paperclip/blob/main/docker/.env.coolify.example) for a reference list (don't commit real secrets into it — set them in Coolify's UI instead).
+
+## 3. Assign a domain
+
+Under the `app` service, add a domain pointing at container port `3100`. Set `PAPERCLIP_PUBLIC_URL` to that exact domain (with `https://`) so auth/session cookies and OAuth callback URLs resolve correctly, then redeploy.
+
+## 4. Deploy
+
+Click **Deploy**. Coolify builds the image from the root `Dockerfile` and starts both services. First boot runs database migrations automatically (`PAPERCLIP_MIGRATION_AUTO_APPLY=true`).
+
+Data persists in two named volumes: `pgdata` (Postgres) and `paperclip-data` (`/paperclip` — instance config, local secrets, file storage). Both survive redeploys; don't delete them unless you want a clean slate.
+
+## 5. Harden after first sign-up
+
+Once you've created your admin account, consider setting:
+
+```
+PAPERCLIP_AUTH_DISABLE_SIGN_UP=true
+```
+
+to stop further public sign-ups on an internet-exposed instance. Use the invite flow to grant access to additional users afterward.
+
+## Troubleshooting
+
+- **Healthcheck failing / container restarting**: check the `app` service logs in Coolify. The healthcheck hits `GET /api/health` on port `3100` — if the app crashes before binding, a missing `BETTER_AUTH_SECRET`/`POSTGRES_PASSWORD` or a `db` connection failure are the usual causes.
+- **Redirect loop or broken login**: `PAPERCLIP_PUBLIC_URL` doesn't match the domain you're visiting. Update it and redeploy.
+- **Slow first deploy**: the image builds the whole pnpm workspace (server, UI, adapters). Subsequent deploys reuse Docker layer cache unless `pnpm-lock.yaml` changes.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -82,6 +82,7 @@
               "deploy/local-development",
               "deploy/tailscale-private-access",
               "deploy/docker",
+              "deploy/coolify",
               "deploy/deployment-modes",
               "deploy/database",
               "deploy/secrets",


### PR DESCRIPTION
Adds a Coolify-tailored Docker Compose file (app + Postgres, no exposed DB port, healthcheck on /api/health) alongside the existing docker-compose.yml/quickstart configs, plus a deploy guide under docs/deploy/coolify.md.

## Thinking Path

<!--
  Required. Trace your reasoning from the top of the project down to this
  specific change. Start with what Paperclip is, then narrow through the
  subsystem, the problem, and why this PR exists. Use blockquote style.
  Aim for 5–8 steps. See CONTRIBUTING.md for full examples.
-->

> - Paperclip is the open source app people use to manage AI agents for work
> - [Which subsystem or capability is involved]
> - [What problem or gap exists]
> - [Why it needs to be addressed]
> - This pull request ...
> - The benefit is ...

## Linked Issues or Issue Description

<!--
  Required. Pick ONE of the following two paths:

  (A) Issue exists — tag each linked issue with `Fixes: #123`, `Closes #123`,
      or `Refs #123`. Include duplicates and closely related issues too.

  Only reference PUBLIC GitHub issues/PRs here. Do NOT paste internal,
  instance-local Paperclip references — ticket ids like PAPA-123 / PAP-224,
  /PAP/issues/... or agent://... links, or localhost/tailnet URLs. Other
  contributors cannot open them. See CONTRIBUTING.md → "No Internal Issue
  References".

  (B) No issue exists — describe the underlying problem here, following the
      relevant issue template so reviewers get the same fields:
        • Bug:     .github/ISSUE_TEMPLATE/bug_report.yml
        • Feature: .github/ISSUE_TEMPLATE/feature_request.yml
        • Adapter: .github/ISSUE_TEMPLATE/adapter_request.yml

  See CONTRIBUTING.md → "Link Issues or Describe Them In-PR".
-->

-

## What Changed

<!-- Bullet list of concrete changes. One bullet per logical unit. -->

-

## Verification

<!--
  How can a reviewer confirm this works? Include test commands, manual
  steps, or both.
-->

-

## Risks

<!--
  What could go wrong? Mention migration safety, breaking changes,
  behavioral shifts, or "Low risk" if genuinely minor.
-->

-

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

<!--
  Required. Specify which AI model was used to produce or assist with
  this change. Be as descriptive as possible — include:
    • Provider and model name (e.g., Claude, GPT, Gemini, Codex)
    • Exact model ID or version (e.g., claude-opus-4-6, gpt-4-turbo-2024-04-09)
    • Context window size if relevant (e.g., 1M context)
    • Reasoning/thinking mode if applicable (e.g., extended thinking, chain-of-thought)
    • Any other relevant capability details (e.g., tool use, code execution)
  If no AI model was used, write "None — human-authored".
-->

-

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [ ] I have specified the model used (with version and capability details)
- [ ] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [ ] I have searched GitHub for duplicate or related PRs and linked them above
- [ ] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [ ] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [ ] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [ ] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [ ] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge
