### PR TITLE
fix(health): include authReady in redacted authenticated health response

### DIFF
--- a/server/src/__tests__/health.test.ts
+++ b/server/src/__tests__/health.test.ts
@@ -151,6 +151,7 @@ describe("GET /health", () => {
       status: "ok",
       deploymentMode: "authenticated",
       deploymentExposure: "public",
+      authReady: true,
       bootstrapStatus: "ready",
       bootstrapInviteActive: false,
     });
@@ -188,6 +189,7 @@ describe("GET /health", () => {
       status: "ok",
       deploymentMode: "authenticated",
       deploymentExposure: "public",
+      authReady: true,
       bootstrapStatus: "ready",
       bootstrapInviteActive: false,
     });

--- a/server/src/routes/health.ts
+++ b/server/src/routes/health.ts
@@ -167,6 +167,7 @@ export function healthRoutes(
         status: "ok",
         deploymentMode: opts.deploymentMode,
         deploymentExposure: opts.deploymentExposure,
+        authReady: opts.authReady,
         bootstrapStatus,
         bootstrapInviteActive,
         ...(devServer ? { devServer } : {}),


### PR DESCRIPTION
## Problem

`GET /api/health`'s redacted branch (served to anonymous callers when `deploymentMode === "authenticated"`) includes `deploymentExposure` but omits `authReady`:

```json
{"status":"ok","deploymentMode":"authenticated","deploymentExposure":"private","bootstrapStatus":"ready","bootstrapInviteActive":false}
```

Paperclip Desktop's remote preflight parser (`parseHealthPayload`) only accepts two shapes: fully-populated (`deploymentExposure` **and** `authReady` both present) or fully-redacted (both absent/null). This half-redacted response matches neither, so Desktop rejects a reachable, healthy, correctly-configured authenticated remote with:

> This host does not appear to expose the Paperclip health endpoint.

The error message points users at DNS/TLS/firewall debugging when the actual cause is a response-shape mismatch between server and (third-party) client.

Originally reported at #8137, moved to `aronprins/paperclip-desktop#25` (still open, no fix landed on either side as of this PR).

## Fix

Add `authReady: opts.authReady` to the redacted response branch in `server/src/routes/health.ts`, matching the field already present in the full-details branch immediately below. `authReady` is a plain boolean (auth-subsystem readiness), not sensitive — safe to expose alongside the `deploymentExposure`/`bootstrapStatus` fields already redacted-but-included.

## Verification

- `pnpm vitest run src/__tests__/health.test.ts` — 7/7 passing (updated the two existing redaction tests to assert `authReady: true` is now present).
- `tsc --noEmit` — clean.
- Reproduced against a live self-hosted 2026.626.0 instance: before the fix, the response failed Desktop's own bundled `parseHealthPayload`/`preflightRemoteConnection`; after adding `authReady` to the response, `preflightRemoteConnection` returns `{ ok: true, paperclipDetected: true, sessionState: "signed_out" }`.

## Files changed

- `server/src/routes/health.ts` — add `authReady` to redacted response
- `server/src/__tests__/health.test.ts` — update 2 existing test expectations
