### PR TITLE
Clear stale agent errorReason on recovered run start

### DIFF
--- a/server/src/__tests__/agents-service-clear-error.test.ts
+++ b/server/src/__tests__/agents-service-clear-error.test.ts
@@ -188,6 +188,90 @@ describeEmbeddedPostgres("agent service clearError", () => {
     });
   });
 
+  it("projects stale error reasons only for agents still in error status", async () => {
+    const companyId = randomUUID();
+    const runningAgentId = randomUUID();
+    const idleAgentId = randomUUID();
+    const errorAgentId = randomUUID();
+    const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values([
+      {
+        id: runningAgentId,
+        companyId,
+        name: "RunningCoder",
+        role: "engineer",
+        status: "running",
+        errorReason: "stale process failure",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+      {
+        id: idleAgentId,
+        companyId,
+        name: "IdleCoder",
+        role: "engineer",
+        status: "idle",
+        errorReason: "stale secret failure",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+      {
+        id: errorAgentId,
+        companyId,
+        name: "ErrorCoder",
+        role: "engineer",
+        status: "error",
+        errorReason: "real adapter failure",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+    ]);
+
+    const svc = agentService(db);
+    const listedAgents = await svc.list(companyId);
+    const byId = new Map(listedAgents.map((agent) => [agent.id, agent]));
+
+    expect(byId.get(runningAgentId)).toMatchObject({
+      status: "running",
+      errorReason: null,
+    });
+    expect(byId.get(idleAgentId)).toMatchObject({
+      status: "idle",
+      errorReason: null,
+    });
+    expect(byId.get(errorAgentId)).toMatchObject({
+      status: "error",
+      errorReason: "real adapter failure",
+    });
+
+    await expect(svc.getById(runningAgentId)).resolves.toMatchObject({
+      status: "running",
+      errorReason: null,
+    });
+    await expect(svc.getById(idleAgentId)).resolves.toMatchObject({
+      status: "idle",
+      errorReason: null,
+    });
+    await expect(svc.getById(errorAgentId)).resolves.toMatchObject({
+      status: "error",
+      errorReason: "real adapter failure",
+    });
+  });
+
   it("keeps resume-style terminal and pending-approval protections", async () => {
     const companyId = randomUUID();
     const terminatedAgentId = randomUUID();

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -976,6 +976,51 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(wakeup?.status).toBe("claimed");
   });
 
+  it("clears stale agent errorReason when a recovered run starts", async () => {
+    let finishAdapter: (() => void) | null = null;
+    mockAdapterExecute.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          finishAdapter = () =>
+            resolve({
+              exitCode: 0,
+              signal: null,
+              timedOut: false,
+              errorMessage: null,
+              summary: "Recovered after stale process loss.",
+              provider: "test",
+              model: "test-model",
+            });
+        }),
+    );
+
+    const { agentId, runId } = await seedQueuedIssueRunFixture();
+    await db
+      .update(agents)
+      .set({
+        errorReason: "Process lost -- child pid 81145 is no longer running",
+      })
+      .where(eq(agents.id, agentId));
+
+    const heartbeat = heartbeatService(db);
+    const resumePromise = heartbeat.resumeQueuedRuns();
+
+    const runningAgent = await waitForValue(async () => {
+      const row = await db
+        .select()
+        .from(agents)
+        .where(eq(agents.id, agentId))
+        .then((rows) => rows[0] ?? null);
+      return row?.status === "running" ? row : null;
+    });
+
+    expect(runningAgent?.errorReason).toBeNull();
+
+    finishAdapter?.();
+    await resumePromise;
+    await waitForRunToSettle(heartbeat, runId);
+  });
+
   it("queues exactly one retry when the recorded local pid is dead", async () => {
     const { agentId, runId, issueId } = await seedRunFixture({
       agentStatus: "idle",

--- a/server/src/services/agents.ts
+++ b/server/src/services/agents.ts
@@ -243,6 +243,7 @@ export function agentService(db: Db) {
   function normalizeAgentBaseRow(row: typeof agents.$inferSelect) {
     return withUrlKey({
       ...row,
+      errorReason: row.status === "error" ? row.errorReason : null,
       permissions: normalizeAgentPermissions(row.permissions, row.role),
     });
   }

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -9464,7 +9464,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       // Atomic conditional UPDATE is the sole gate (no read-then-write); 0 rows => abort.
       const runningAgent = await db
         .update(agents)
-        .set({ status: "running", updatedAt: new Date() })
+        .set({ status: "running", errorReason: null, updatedAt: new Date() })
         .where(and(eq(agents.id, agent.id), notInArray(agents.status, [...DIRECT_NON_INVOKABLE_STATUSES])))
         .returning()
         .then((rows) => rows[0] ?? null);


### PR DESCRIPTION
## Thinking Path

> - Paperclip manages AI agent companies, including agent status and runtime health in the API/UI.
> - Agent status and error display are projected through the server agent service before route handlers return list/get responses.
> - A recovered run can make an agent healthy again while an older database row still has `errorReason` populated from a previous failure.
> - The heartbeat path should clear that stale field when it starts a recovered run, but API projections also need to defend against existing stale rows.
> - This pull request clears stale error state on recovered-run start and hides stale `errorReason` values for any non-error agent status.
> - This replaces #8725 on a public-safe branch using the same reviewed commit.

## Linked Issues or Issue Description

No public issue exists.

Bug report:
- Summary: Recovered or otherwise healthy agents could still expose a stale `errorReason` through agent list/get responses.
- Expected: Agent API responses only expose `errorReason` when the agent status is `error`.
- Actual: Stale database rows with `status` like `running` or `idle` could still return an old error reason.
- Duplicate search: searched GitHub PRs for stale agent errorReason; #8725 was the only match and is being replaced for metadata cleanup.

## What Changed

- Clear stale `errorReason` in the recovered-run heartbeat transition to `running`.
- Add a defensive agent projection guard so non-error statuses return `errorReason: null` from list/get service responses.
- Add embedded Postgres regression coverage for stale `running` and `idle` rows, plus a real `error` row that still exposes its reason.

## Verification

- `pnpm exec vitest run server/src/__tests__/heartbeat-process-recovery.test.ts --testNamePattern "clears stale agent errorReason when a recovered run starts"`
- `pnpm vitest run server/src/__tests__/agents-service-clear-error.test.ts`
- `git diff --check`

## Risks

Low risk. This changes API projection only for non-error agents; persisted diagnostics are not deleted by the projection guard, and real error agents still expose their `errorReason`.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI GPT-5 Codex via local Codex ChatGPT/OAuth session, with shell/tool execution in the repository workspace.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge