### PR TITLE
Allow CEO scoped issue comments and updates

### DIFF
--- a/server/src/__tests__/authorization-service.test.ts
+++ b/server/src/__tests__/authorization-service.test.ts
@@ -739,6 +739,36 @@ describeEmbeddedPostgres("authorization service", () => {
     });
   });
 
+  it("denies a same-role CEO agent from another company access to a company's assigned issues", async () => {
+    const sourceCompany = await createCompany(db, "CeoIssueScopeSource");
+    const targetCompany = await createCompany(db, "CeoIssueScopeTarget");
+    const targetOwnerAgent = await createAgent(db, targetCompany.id, { role: "engineer" });
+    const ceoAgent = await createAgent(db, sourceCompany.id, { role: "ceo" });
+    const issue = await createIssue(db, targetCompany.id, {
+      title: "CEO scoped issue in target company",
+      assigneeAgentId: targetOwnerAgent.id,
+    });
+
+    const authorization = authorizationService(db);
+    const actor = { type: "agent", agentId: ceoAgent.id, companyId: sourceCompany.id, source: "agent_key" } as const;
+    const resource = {
+      type: "issue",
+      companyId: targetCompany.id,
+      issueId: issue.id,
+      assigneeAgentId: targetOwnerAgent.id,
+      status: issue.status,
+    } as const;
+
+    await expect(authorization.decide({ actor, action: "issue:comment", resource })).resolves.toMatchObject({
+      allowed: false,
+      reason: "deny_company_boundary",
+    });
+    await expect(authorization.decide({ actor, action: "issue:mutate", resource })).resolves.toMatchObject({
+      allowed: false,
+      reason: "deny_company_boundary",
+    });
+  });
+
   it("allows a mentioned non-assignee to comment when the mention author is the issue assignee", async () => {
     const company = await createCompany(db, "MentionCommentAssigneeGrant");
     const allowedProject = await createProject(db, company.id, "MentionAssigneeAllowed");

--- a/server/src/__tests__/authorization-service.test.ts
+++ b/server/src/__tests__/authorization-service.test.ts
@@ -710,6 +710,35 @@ describeEmbeddedPostgres("authorization service", () => {
     })).resolves.toMatchObject({ allowed: false, reason: "deny_low_trust_boundary" });
   });
 
+  it("allows same-company CEO agents to comment and mutate assigned issues", async () => {
+    const company = await createCompany(db, "CeoIssueScope");
+    const ownerAgent = await createAgent(db, company.id, { role: "engineer" });
+    const ceoAgent = await createAgent(db, company.id, { role: "ceo" });
+    const issue = await createIssue(db, company.id, {
+      title: "CEO scoped issue",
+      assigneeAgentId: ownerAgent.id,
+    });
+
+    const authorization = authorizationService(db);
+    const actor = { type: "agent", agentId: ceoAgent.id, companyId: company.id, source: "agent_key" } as const;
+    const resource = {
+      type: "issue",
+      companyId: company.id,
+      issueId: issue.id,
+      assigneeAgentId: ownerAgent.id,
+      status: issue.status,
+    } as const;
+
+    await expect(authorization.decide({ actor, action: "issue:comment", resource })).resolves.toMatchObject({
+      allowed: true,
+      reason: "allow_company_ceo",
+    });
+    await expect(authorization.decide({ actor, action: "issue:mutate", resource })).resolves.toMatchObject({
+      allowed: true,
+      reason: "allow_company_ceo",
+    });
+  });
+
   it("allows a mentioned non-assignee to comment when the mention author is the issue assignee", async () => {
     const company = await createCompany(db, "MentionCommentAssigneeGrant");
     const allowedProject = await createProject(db, company.id, "MentionAssigneeAllowed");

--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -1,7 +1,6 @@
 import { Readable } from "node:stream";
 import express from "express";
 import request from "supertest";
-import { conflict } from "../errors.js";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const issueId = "11111111-1111-4111-8111-111111111111";
@@ -1386,9 +1385,35 @@ describe("agent issue mutation checkout ownership", () => {
     expect(mockIssueService.update).not.toHaveBeenCalled();
   });
 
-  it("requires checkout ownership when a CEO transitions another agent's issue into in_progress", async () => {
-    mockIssueService.assertCheckoutOwner.mockRejectedValue(conflict("Issue checkout conflict"));
+  it("requires active-run ownership for a CEO transition into in_progress", async () => {
     mockIssueService.getById.mockResolvedValue(makeIssue({ status: "todo", assigneeAgentId: ownerAgentId }));
+    mockAccessService.decide.mockImplementation(async (input: { action: string }) => ({
+      allowed: input.action === "issue:mutate",
+      action: input.action,
+      reason: input.action === "issue:mutate" ? "allow_company_ceo" : "deny_missing_grant",
+      explanation:
+        input.action === "issue:mutate"
+          ? "Allowed because the actor is the company CEO."
+          : "Missing permission.",
+    }));
+
+    const res = await request(await createApp(peerActor({ runId: undefined })))
+      .patch(`/api/issues/${issueId}`)
+      .send({ status: "in_progress" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(401);
+    expect(res.body.error).toBe("Agent run id required");
+    expect(mockIssueService.assertCheckoutOwner).not.toHaveBeenCalled();
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+  });
+
+  it("checks checkout ownership for a CEO transition into in_progress", async () => {
+    mockIssueService.assertCheckoutOwner.mockResolvedValue({ adoptedFromRunId: null });
+    mockIssueService.getById.mockResolvedValue(makeIssue({ status: "todo", assigneeAgentId: ownerAgentId }));
+    mockIssueService.update.mockResolvedValue({
+      ...makeIssue({ status: "todo", assigneeAgentId: ownerAgentId }),
+      status: "in_progress",
+    });
     mockAccessService.decide.mockImplementation(async (input: { action: string }) => ({
       allowed: input.action === "issue:mutate",
       action: input.action,
@@ -1403,14 +1428,14 @@ describe("agent issue mutation checkout ownership", () => {
       .patch(`/api/issues/${issueId}`)
       .send({ status: "in_progress" });
 
-    expect(res.status, JSON.stringify(res.body)).toBe(409);
-    expect(res.body.error).toBe("Issue checkout conflict");
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(res.body.status).toBe("in_progress");
     expect(mockIssueService.assertCheckoutOwner).toHaveBeenCalledWith(
       issueId,
       peerAgentId,
       "66666666-6666-4666-8666-666666666666",
     );
-    expect(mockIssueService.update).not.toHaveBeenCalled();
+    expect(mockIssueService.update).toHaveBeenCalled();
   });
 
   it.each([

--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -787,6 +787,31 @@ describe("agent issue mutation checkout ownership", () => {
     expect(mockIssueService.update).not.toHaveBeenCalled();
   });
 
+  it("allows CEO-scoped agents to post comments without ownership of an active checkout", async () => {
+    mockAccessService.decide.mockImplementation(async (input: { action: string }) => ({
+      allowed: input.action === "issue:comment",
+      action: input.action,
+      reason: input.action === "issue:comment" ? "allow_company_ceo" : "deny_missing_grant",
+      explanation:
+        input.action === "issue:comment"
+          ? "Allowed because the actor is the company CEO."
+          : "Missing permission.",
+    }));
+
+    const res = await request(await createApp(peerActor()))
+      .post(`/api/issues/${issueId}/comments`)
+      .send({ body: "CEO note." });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(201);
+    expect(mockIssueService.addComment).toHaveBeenCalledWith(
+      issueId,
+      "CEO note.",
+      expect.any(Object),
+      expect.any(Object),
+    );
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+  });
+
   it("rejects non-mentioned peer agents from posting comments", async () => {
     mockAccessService.decide.mockImplementation(async (input: { action: string }) => ({
       allowed: input.action === "issue:read",
@@ -1315,6 +1340,49 @@ describe("agent issue mutation checkout ownership", () => {
     expect(res.status).toBe(200);
     expect(mockIssueService.assertCheckoutOwner).not.toHaveBeenCalled();
     expect(mockIssueService.update).toHaveBeenCalled();
+  });
+
+  it("allows CEO-scoped agents to patch another agent's assigned issue when it is not actively checked out", async () => {
+    mockIssueService.getById.mockResolvedValue(makeIssue({ status: "todo", assigneeAgentId: ownerAgentId }));
+    mockAccessService.decide.mockImplementation(async (input: { action: string }) => ({
+      allowed: input.action === "issue:mutate",
+      action: input.action,
+      reason: input.action === "issue:mutate" ? "allow_company_ceo" : "deny_missing_grant",
+      explanation:
+        input.action === "issue:mutate"
+          ? "Allowed because the actor is the company CEO."
+          : "Missing permission.",
+    }));
+
+    const res = await request(await createApp(peerActor()))
+      .patch(`/api/issues/${issueId}`)
+      .send({ title: "CEO update" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(mockIssueService.assertCheckoutOwner).not.toHaveBeenCalled();
+    expect(mockIssueService.update).toHaveBeenCalledWith(issueId, expect.objectContaining({ title: "CEO update" }));
+  });
+
+  it("keeps active checkout ownership enforced for CEO-scoped patch updates", async () => {
+    mockIssueService.getById.mockResolvedValue(makeIssue({ status: "in_progress", assigneeAgentId: ownerAgentId }));
+    mockAccessService.decide.mockImplementation(async (input: { action: string }) => ({
+      allowed: input.action === "issue:mutate",
+      action: input.action,
+      reason: input.action === "issue:mutate" ? "allow_company_ceo" : "deny_missing_grant",
+      explanation:
+        input.action === "issue:mutate"
+          ? "Allowed because the actor is the company CEO."
+          : "Missing permission.",
+    }));
+
+    const res = await request(await createApp(peerActor()))
+      .patch(`/api/issues/${issueId}`)
+      .send({ title: "CEO active update" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(409);
+    expect(res.body.error).toBe("Issue is checked out by another agent");
+    expect(mockIssueService.assertCheckoutOwner).not.toHaveBeenCalled();
+    expect(mockIssueService.update).not.toHaveBeenCalled();
   });
 
   it.each([

--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -1,6 +1,7 @@
 import { Readable } from "node:stream";
 import express from "express";
 import request from "supertest";
+import { conflict } from "../errors.js";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const issueId = "11111111-1111-4111-8111-111111111111";
@@ -1382,6 +1383,33 @@ describe("agent issue mutation checkout ownership", () => {
     expect(res.status, JSON.stringify(res.body)).toBe(409);
     expect(res.body.error).toBe("Issue is checked out by another agent");
     expect(mockIssueService.assertCheckoutOwner).not.toHaveBeenCalled();
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+  });
+
+  it("requires checkout ownership when a CEO transitions another agent's issue into in_progress", async () => {
+    mockIssueService.assertCheckoutOwner.mockRejectedValue(conflict("Issue checkout conflict"));
+    mockIssueService.getById.mockResolvedValue(makeIssue({ status: "todo", assigneeAgentId: ownerAgentId }));
+    mockAccessService.decide.mockImplementation(async (input: { action: string }) => ({
+      allowed: input.action === "issue:mutate",
+      action: input.action,
+      reason: input.action === "issue:mutate" ? "allow_company_ceo" : "deny_missing_grant",
+      explanation:
+        input.action === "issue:mutate"
+          ? "Allowed because the actor is the company CEO."
+          : "Missing permission.",
+    }));
+
+    const res = await request(await createApp(peerActor()))
+      .patch(`/api/issues/${issueId}`)
+      .send({ status: "in_progress" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(409);
+    expect(res.body.error).toBe("Issue checkout conflict");
+    expect(mockIssueService.assertCheckoutOwner).toHaveBeenCalledWith(
+      issueId,
+      peerAgentId,
+      "66666666-6666-4666-8666-666666666666",
+    );
     expect(mockIssueService.update).not.toHaveBeenCalled();
   });
 

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -2085,8 +2085,8 @@ export function issueRoutes(
     }
     if (issue.assigneeAgentId !== actorAgentId) {
       if (boundaryDecision.reason === "allow_company_ceo") {
-        const isTodoToInProgressTransition = issue.status !== "in_progress" && requestedStatus === "in_progress";
-        if (!isTodoToInProgressTransition) {
+        const isTransitionToInProgress = issue.status !== "in_progress" && requestedStatus === "in_progress";
+        if (!isTransitionToInProgress) {
           if (issue.status === "in_progress") {
             res.status(409).json({
               error: "Issue is checked out by another agent",

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -2083,6 +2083,18 @@ export function issueRoutes(
       return true;
     }
     if (issue.assigneeAgentId !== actorAgentId) {
+      if (boundaryDecision.reason === "allow_company_ceo") {
+        if (issue.status !== "in_progress") return true;
+        res.status(409).json({
+          error: "Issue is checked out by another agent",
+          details: {
+            issueId: issue.id,
+            assigneeAgentId: issue.assigneeAgentId,
+            actorAgentId,
+          },
+        });
+        return false;
+      }
       if (await hasActiveCheckoutManagementOverride(actorAgentId, issue.companyId, issue.assigneeAgentId)) {
         return true;
       }

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -2044,6 +2044,7 @@ export function issueRoutes(
       assigneeAgentId: string | null;
       assigneeUserId: string | null;
     },
+    requestedStatus?: string,
   ) {
     if (req.actor.type !== "agent") return true;
     const actorAgentId = req.actor.agentId;
@@ -2084,16 +2085,43 @@ export function issueRoutes(
     }
     if (issue.assigneeAgentId !== actorAgentId) {
       if (boundaryDecision.reason === "allow_company_ceo") {
-        if (issue.status !== "in_progress") return true;
-        res.status(409).json({
-          error: "Issue is checked out by another agent",
-          details: {
-            issueId: issue.id,
-            assigneeAgentId: issue.assigneeAgentId,
-            actorAgentId,
-          },
-        });
-        return false;
+        const isTodoToInProgressTransition = issue.status !== "in_progress" && requestedStatus === "in_progress";
+        if (!isTodoToInProgressTransition) {
+          if (issue.status === "in_progress") {
+            res.status(409).json({
+              error: "Issue is checked out by another agent",
+              details: {
+                issueId: issue.id,
+                assigneeAgentId: issue.assigneeAgentId,
+                actorAgentId,
+              },
+            });
+            return false;
+          }
+          return true;
+        }
+        const runId = requireAgentRunId(req, res);
+        if (!runId) return false;
+        const ownership = await svc.assertCheckoutOwner(issue.id, actorAgentId, runId);
+        if (ownership.adoptedFromRunId) {
+          const actor = getActorInfo(req);
+          await logActivity(db, {
+            companyId: issue.companyId,
+            actorType: actor.actorType,
+            actorId: actor.actorId,
+            agentId: actor.agentId,
+            runId: actor.runId,
+            action: "issue.checkout_lock_adopted",
+            entityType: "issue",
+            entityId: issue.id,
+            details: {
+              previousCheckoutRunId: ownership.adoptedFromRunId,
+              checkoutRunId: runId,
+              reason: "stale_checkout_run",
+            },
+          });
+        }
+        return true;
       }
       if (await hasActiveCheckoutManagementOverride(actorAgentId, issue.companyId, issue.assigneeAgentId)) {
         return true;
@@ -5726,7 +5754,7 @@ export function issueRoutes(
     }
     assertCompanyAccess(req, existing.companyId);
     assertNoAgentHostWorkspaceCommandMutation(req, collectIssueWorkspaceCommandPaths(req.body));
-    if (!(await assertAgentIssueMutationAllowed(req, res, existing))) return;
+    if (!(await assertAgentIssueMutationAllowed(req, res, existing, req.body.status))) return;
     if (!(await assertCheapRecoveryIssueAssigneeProfileAllowed(req, res, existing, req.body))) return;
 
     const actor = getActorInfo(req);

--- a/server/src/services/authorization.ts
+++ b/server/src/services/authorization.ts
@@ -86,6 +86,7 @@ export type AuthorizationDecision = {
     | "allow_issue_mention_grant"
     | "allow_self"
     | "allow_company_agent"
+    | "allow_company_ceo"
     | "allow_company_member"
     | "allow_simple_company_member"
     | "allow_manager_chain"
@@ -1428,6 +1429,13 @@ export function authorizationService(db: Db) {
           action: input.action,
           reason: "allow_company_agent",
           explanation: "Allowed because the issue has no agent assignee.",
+        });
+      }
+      if (actorAgent.role.toLowerCase() === "ceo") {
+        return allow({
+          action: input.action,
+          reason: "allow_company_ceo",
+          explanation: "Allowed because the actor is the company CEO.",
         });
       }
       if (


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Issue routes enforce both authorization policy and checkout ownership for agent mutations.
> - Same-company CEO agents need limited issue comment/update authority for control-plane recovery and oversight.
> - That authority must not become broad board access or bypass active checkout ownership.
> - This pull request adds a CEO-scoped issue comment/mutate grant while preserving route-level active-lock checks.
> - This replaces #8681 on a public-safe branch using the same reviewed commit.

## Linked Issues or Issue Description

No public issue exists.

Bug report:
- Summary: CEO-scoped agents could not comment on or update same-company assigned issues without broader grants.
- Expected: Same-company CEO agents can comment/update non-active assigned issues for oversight and recovery.
- Actual: The route authorization path denied those actions unless broader permissions were granted.
- Steps to reproduce:
  1. Authenticate as a same-company CEO agent.
  2. Patch or comment on an issue assigned to another agent.
  3. Try to patch that issue to `in_progress` without owning its checkout.
- Expected active-work guard: active checkout ownership still blocks live `in_progress` issues and transitions into `in_progress`.
- Duplicate search: searched GitHub PRs for CEO scoped issue comments and updates; #8681 was the only match and is being replaced for metadata cleanup.

## What Changed

- Added `allow_company_ceo` authorization decision for same-company CEO agents on `issue:comment` and `issue:mutate`.
- Allowed route-level non-active cross-assignee patch updates when the authz decision is the CEO grant.
- Preserved `409` active checkout protection for CEO-scoped patch updates on existing `in_progress` issues.
- Added status-aware mutation guarding so CEO-scoped patches cannot transition another agent issue into `in_progress` without checkout ownership.
- Added service and route regression tests for CEO comments, CEO patch updates, active checkout denial, and `in_progress` transition denial.

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm exec vitest run server/src/__tests__/authorization-service.test.ts server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts`
- `pnpm --filter @paperclipai/server typecheck`

## Risks

Low risk. The CEO grant is limited to same-company issue comment/mutate decisions, and the route guard still enforces checkout ownership for active issues and transitions into active work.

## Model Used

OpenAI GPT-5 Codex via ChatGPT/Codex local subscription, with shell and code-edit tool use.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I searched the GitHub PR list for similar PRs and confirmed this is not a duplicate
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge