### PR TITLE
fix(issues): let mention-granted reviewers take over in_review checkouts

### DIFF
--- a/server/src/__tests__/authorization-service.test.ts
+++ b/server/src/__tests__/authorization-service.test.ts
@@ -758,6 +758,110 @@ describeEmbeddedPostgres("authorization service", () => {
     });
   });
 
+  it("grants issue:checkout_review to a mentioned reviewer only while the issue is in review", async () => {
+    const company = await createCompany(db, "MentionCheckoutReview");
+    const assigneeAgent = await createAgent(db, company.id, { role: "engineer" });
+    const reviewerAgent = await createAgent(db, company.id, { role: "qa" });
+    const peerAgent = await createAgent(db, company.id, { role: "engineer" });
+    const issue = await createIssue(db, company.id, {
+      title: "Review takeover target",
+      assigneeAgentId: assigneeAgent.id,
+    });
+    await db.insert(issueComments).values({
+      companyId: company.id,
+      issueId: issue.id,
+      authorAgentId: assigneeAgent.id,
+      authorType: "agent",
+      body: `[@QA](agent://${reviewerAgent.id}) please verify and close this out.`,
+    });
+
+    const authorization = authorizationService(db);
+    const resourceWithStatus = (status: string) => ({
+      type: "issue",
+      companyId: company.id,
+      issueId: issue.id,
+      assigneeAgentId: assigneeAgent.id,
+      status,
+    } as const);
+
+    await expect(authorization.decide({
+      actor: { type: "agent", agentId: reviewerAgent.id, companyId: company.id, source: "agent_key" },
+      action: "issue:checkout_review",
+      resource: resourceWithStatus("in_review"),
+    })).resolves.toMatchObject({
+      allowed: true,
+      reason: "allow_issue_mention_grant",
+    });
+
+    await expect(authorization.decide({
+      actor: { type: "agent", agentId: reviewerAgent.id, companyId: company.id, source: "agent_key" },
+      action: "issue:checkout_review",
+      resource: resourceWithStatus("in_progress"),
+    })).resolves.toMatchObject({ allowed: false });
+
+    await expect(authorization.decide({
+      actor: { type: "agent", agentId: peerAgent.id, companyId: company.id, source: "agent_key" },
+      action: "issue:checkout_review",
+      resource: resourceWithStatus("in_review"),
+    })).resolves.toMatchObject({ allowed: false });
+
+    await expect(authorization.decide({
+      actor: { type: "agent", agentId: assigneeAgent.id, companyId: company.id, source: "agent_key" },
+      action: "issue:checkout_review",
+      resource: resourceWithStatus("in_review"),
+    })).resolves.toMatchObject({
+      allowed: true,
+      reason: "allow_self",
+    });
+  });
+
+  it("denies issue:checkout_review to low-trust agents even with a valid mention grant", async () => {
+    const company = await createCompany(db, "MentionCheckoutReviewLowTrust");
+    const allowedProject = await createProject(db, company.id, "ReviewTakeoverAllowed");
+    const assigneeAgent = await createAgent(db, company.id, { role: "engineer" });
+    const reviewerAgent = await createAgent(db, company.id, {
+      role: "qa",
+      permissions: {
+        trustPreset: LOW_TRUST_REVIEW_PRESET,
+        authorizationPolicy: {
+          trustBoundary: {
+            mode: LOW_TRUST_REVIEW_PRESET,
+            companyId: company.id,
+            projectIds: [allowedProject.id],
+          },
+        },
+      },
+    });
+    const issue = await createIssue(db, company.id, {
+      title: "Low-trust review takeover target",
+      projectId: allowedProject.id,
+      assigneeAgentId: assigneeAgent.id,
+    });
+    await db.insert(issueComments).values({
+      companyId: company.id,
+      issueId: issue.id,
+      authorAgentId: assigneeAgent.id,
+      authorType: "agent",
+      body: `[@QA](agent://${reviewerAgent.id}) please verify and close this out.`,
+    });
+
+    await expect(authorizationService(db).decide({
+      actor: { type: "agent", agentId: reviewerAgent.id, companyId: company.id, source: "agent_key" },
+      action: "issue:checkout_review",
+      resource: {
+        type: "issue",
+        companyId: company.id,
+        issueId: issue.id,
+        projectId: issue.projectId,
+        assigneeAgentId: assigneeAgent.id,
+        status: "in_review",
+      },
+    })).resolves.toMatchObject({
+      allowed: false,
+      reason: "deny_low_trust_boundary",
+    });
+  });
+
   it("does not grant mention-scoped issue access from self-authored or unauthorized-author comments", async () => {
     const company = await createCompany(db, "MentionCommentDenied");
     const allowedProject = await createProject(db, company.id, "MentionDeniedAllowed");

--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -13,6 +13,7 @@ const recoveryActionId = "77777777-7777-4777-8777-777777777777";
 const mockIssueService = vi.hoisted(() => ({
   addComment: vi.fn(),
   assertCheckoutOwner: vi.fn(),
+  checkout: vi.fn(),
   create: vi.fn(),
   createChild: vi.fn(),
   decomposeAcceptedPlan: vi.fn(),
@@ -404,6 +405,7 @@ describe("agent issue mutation checkout ownership", () => {
     mockCompanyService.getById.mockReset();
     mockIssueService.addComment.mockReset();
     mockIssueService.assertCheckoutOwner.mockReset();
+    mockIssueService.checkout.mockReset();
     mockIssueService.create.mockReset();
     mockIssueService.createChild.mockReset();
     mockIssueService.decomposeAcceptedPlan.mockReset();
@@ -802,6 +804,90 @@ describe("agent issue mutation checkout ownership", () => {
     expect(res.status, JSON.stringify(res.body)).toBe(403);
     expect(res.body.error).toBe("Issue is outside this actor's authorization boundary");
     expect(mockIssueService.addComment).not.toHaveBeenCalled();
+  });
+
+  it("lets a mention-granted reviewer checkout an in_review issue with review takeover", async () => {
+    mockIssueService.getById.mockResolvedValue(makeIssue({ status: "in_review" }));
+    mockIssueService.checkout.mockResolvedValue(
+      makeIssue({ status: "in_progress", assigneeAgentId: peerAgentId }),
+    );
+    mockAccessService.decide.mockImplementation(async (input: { action: string }) => ({
+      allowed: input.action === "tasks:assign" || input.action === "issue:checkout_review",
+      action: input.action,
+      reason:
+        input.action === "issue:checkout_review"
+          ? "allow_issue_mention_grant"
+          : input.action === "tasks:assign"
+            ? "allow_simple_company_member"
+            : "deny_missing_grant",
+      explanation: "Test decision.",
+    }));
+
+    const res = await request(await createApp(peerActor()))
+      .post(`/api/issues/${issueId}/checkout`)
+      .send({ agentId: peerAgentId, expectedStatuses: ["in_review"] });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(mockAccessService.decide).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "issue:checkout_review",
+        resource: expect.objectContaining({
+          issueId,
+          assigneeAgentId: ownerAgentId,
+          status: "in_review",
+        }),
+      }),
+    );
+    expect(mockIssueService.checkout).toHaveBeenCalledWith(
+      issueId,
+      peerAgentId,
+      ["in_review"],
+      expect.any(String),
+      { allowReviewTakeover: true },
+    );
+  });
+
+  it("keeps review takeover disabled when the checkout_review decision is denied", async () => {
+    mockIssueService.getById.mockResolvedValue(makeIssue({ status: "in_review" }));
+    mockIssueService.checkout.mockResolvedValue(
+      makeIssue({ status: "in_review", assigneeAgentId: ownerAgentId }),
+    );
+
+    const res = await request(await createApp(peerActor()))
+      .post(`/api/issues/${issueId}/checkout`)
+      .send({ agentId: peerAgentId, expectedStatuses: ["in_review"] });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(mockIssueService.checkout).toHaveBeenCalledWith(
+      issueId,
+      peerAgentId,
+      ["in_review"],
+      expect.any(String),
+      { allowReviewTakeover: false },
+    );
+  });
+
+  it("does not consult checkout_review for issues outside in_review", async () => {
+    mockIssueService.getById.mockResolvedValue(makeIssue({ status: "in_progress" }));
+    mockIssueService.checkout.mockResolvedValue(
+      makeIssue({ status: "in_progress", assigneeAgentId: ownerAgentId }),
+    );
+
+    const res = await request(await createApp(peerActor()))
+      .post(`/api/issues/${issueId}/checkout`)
+      .send({ agentId: peerAgentId, expectedStatuses: ["in_progress"] });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(mockAccessService.decide).not.toHaveBeenCalledWith(
+      expect.objectContaining({ action: "issue:checkout_review" }),
+    );
+    expect(mockIssueService.checkout).toHaveBeenCalledWith(
+      issueId,
+      peerAgentId,
+      ["in_progress"],
+      expect.any(String),
+      { allowReviewTakeover: false },
+    );
   });
 
   it("rejects peer agents from listing comments when issue read is outside their boundary", async () => {

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -4862,6 +4862,186 @@ describeEmbeddedPostgres("issueService.clearExecutionRunIfTerminal", () => {
   });
 });
 
+describeEmbeddedPostgres("issueService.checkout review takeover", () => {
+  let db!: ReturnType<typeof createDb>;
+  let svc!: ReturnType<typeof issueService>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-issues-review-takeover-");
+    db = createDb(tempDb.connectionString);
+    svc = issueService(db);
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.delete(issueComments);
+    await db.delete(issueRelations);
+    await db.delete(issueInboxArchives);
+    await db.delete(activityLog);
+    await db.delete(issues);
+    await db.delete(heartbeatRuns);
+    await db.delete(executionWorkspaces);
+    await db.delete(projectWorkspaces);
+    await db.delete(projects);
+    await db.delete(goals);
+    await db.delete(agents);
+    await db.delete(instanceSettings);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  async function seedReviewIssue(input: { status?: string; doerCheckoutRunStatus?: string | null } = {}) {
+    const companyId = randomUUID();
+    const doerAgentId = randomUUID();
+    const reviewerAgentId = randomUUID();
+    const issueId = randomUUID();
+    const reviewerRunId = randomUUID();
+    const doerRunId = input.doerCheckoutRunStatus ? randomUUID() : null;
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values([
+      {
+        id: doerAgentId,
+        companyId,
+        name: "Doer",
+        role: "engineer",
+        status: "active",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+      {
+        id: reviewerAgentId,
+        companyId,
+        name: "Reviewer",
+        role: "qa",
+        status: "active",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+    ]);
+    await db.insert(heartbeatRuns).values([
+      {
+        id: reviewerRunId,
+        companyId,
+        agentId: reviewerAgentId,
+        status: "running",
+        invocationSource: "manual",
+        startedAt: new Date("2026-07-03T10:00:00.000Z"),
+      },
+      ...(doerRunId
+        ? [{
+            id: doerRunId,
+            companyId,
+            agentId: doerAgentId,
+            status: input.doerCheckoutRunStatus!,
+            invocationSource: "manual" as const,
+            startedAt: new Date("2026-07-03T09:00:00.000Z"),
+          }]
+        : []),
+    ]);
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Doer deliverable awaiting review",
+      status: input.status ?? "in_review",
+      priority: "medium",
+      assigneeAgentId: doerAgentId,
+      checkoutRunId: doerRunId,
+    });
+    return { companyId, doerAgentId, reviewerAgentId, issueId, reviewerRunId, doerRunId };
+  }
+
+  it("reassigns an in_review issue to the reviewer when takeover is allowed", async () => {
+    const seeded = await seedReviewIssue();
+    const result = await svc.checkout(
+      seeded.issueId,
+      seeded.reviewerAgentId,
+      ["in_review"],
+      seeded.reviewerRunId,
+      { allowReviewTakeover: true },
+    );
+    expect(result).toMatchObject({
+      assigneeAgentId: seeded.reviewerAgentId,
+      status: "in_progress",
+      checkoutRunId: seeded.reviewerRunId,
+    });
+  });
+
+  it("still 409s for another agent's in_review issue without the takeover flag", async () => {
+    const seeded = await seedReviewIssue();
+    await expect(svc.checkout(seeded.issueId, seeded.reviewerAgentId, ["in_review"], seeded.reviewerRunId))
+      .rejects.toMatchObject({ status: 409 });
+    const row = await db
+      .select({ assigneeAgentId: issues.assigneeAgentId, status: issues.status })
+      .from(issues)
+      .where(eq(issues.id, seeded.issueId))
+      .then((rows) => rows[0]);
+    expect(row).toMatchObject({ assigneeAgentId: seeded.doerAgentId, status: "in_review" });
+  });
+
+  it("does not let the takeover flag claim an issue outside in_review", async () => {
+    const seeded = await seedReviewIssue({ status: "in_progress" });
+    await expect(svc.checkout(
+      seeded.issueId,
+      seeded.reviewerAgentId,
+      ["todo", "in_progress", "in_review"],
+      seeded.reviewerRunId,
+      { allowReviewTakeover: true },
+    )).rejects.toMatchObject({ status: 409 });
+    const row = await db
+      .select({ assigneeAgentId: issues.assigneeAgentId, status: issues.status })
+      .from(issues)
+      .where(eq(issues.id, seeded.issueId))
+      .then((rows) => rows[0]);
+    expect(row).toMatchObject({ assigneeAgentId: seeded.doerAgentId, status: "in_progress" });
+  });
+
+  it("does not steal an in_review issue whose checkout lock belongs to a live run", async () => {
+    const seeded = await seedReviewIssue({ doerCheckoutRunStatus: "running" });
+    await expect(svc.checkout(
+      seeded.issueId,
+      seeded.reviewerAgentId,
+      ["in_review"],
+      seeded.reviewerRunId,
+      { allowReviewTakeover: true },
+    )).rejects.toMatchObject({ status: 409 });
+    const row = await db
+      .select({ assigneeAgentId: issues.assigneeAgentId, checkoutRunId: issues.checkoutRunId })
+      .from(issues)
+      .where(eq(issues.id, seeded.issueId))
+      .then((rows) => rows[0]);
+    expect(row).toMatchObject({ assigneeAgentId: seeded.doerAgentId, checkoutRunId: seeded.doerRunId });
+  });
+
+  it("clears a terminal doer checkout lock and completes the takeover", async () => {
+    const seeded = await seedReviewIssue({ doerCheckoutRunStatus: "failed" });
+    const result = await svc.checkout(
+      seeded.issueId,
+      seeded.reviewerAgentId,
+      ["in_review"],
+      seeded.reviewerRunId,
+      { allowReviewTakeover: true },
+    );
+    expect(result).toMatchObject({
+      assigneeAgentId: seeded.reviewerAgentId,
+      status: "in_progress",
+      checkoutRunId: seeded.reviewerRunId,
+    });
+  });
+});
+
 describeEmbeddedPostgres("accepted plan decomposition", () => {
   let db!: ReturnType<typeof createDb>;
   let svc!: ReturnType<typeof issueService>;

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -6897,6 +6897,34 @@ export function issueRoutes(
       });
     }
 
+    // Mention-granted review takeover: an agent explicitly routed onto this issue
+    // (agent:// mention authored by the assignee or an active user) may claim an
+    // in_review issue assigned to another agent, reassigning it to itself so the
+    // review verdict can be applied under the normal ownership rules.
+    let reviewTakeoverGranted = false;
+    if (
+      req.actor.type === "agent" &&
+      issue.status === "in_review" &&
+      issue.assigneeAgentId &&
+      issue.assigneeAgentId !== req.body.agentId
+    ) {
+      const decision = await access.decide({
+        actor: req.actor,
+        action: "issue:checkout_review",
+        resource: {
+          type: "issue",
+          companyId: issue.companyId,
+          issueId: issue.id,
+          projectId: issue.projectId ?? null,
+          parentIssueId: issue.parentId ?? null,
+          assigneeAgentId: issue.assigneeAgentId ?? null,
+          assigneeUserId: issue.assigneeUserId ?? null,
+          status: issue.status ?? null,
+        },
+      });
+      reviewTakeoverGranted = decision.allowed;
+    }
+
     const closedExecutionWorkspace = await getClosedIssueExecutionWorkspace(issue);
     if (closedExecutionWorkspace) {
       respondClosedIssueExecutionWorkspace(res, closedExecutionWorkspace);
@@ -6905,7 +6933,9 @@ export function issueRoutes(
 
     const checkoutRunId = requireAgentRunId(req, res);
     if (req.actor.type === "agent" && !checkoutRunId) return;
-    const updated = await svc.checkout(id, req.body.agentId, req.body.expectedStatuses, checkoutRunId);
+    const updated = await svc.checkout(id, req.body.agentId, req.body.expectedStatuses, checkoutRunId, {
+      allowReviewTakeover: reviewTakeoverGranted,
+    });
     const actor = getActorInfo(req);
 
     await logActivity(db, {
@@ -6917,7 +6947,12 @@ export function issueRoutes(
       action: "issue.checked_out",
       entityType: "issue",
       entityId: issue.id,
-      details: { agentId: req.body.agentId },
+      details: {
+        agentId: req.body.agentId,
+        ...(reviewTakeoverGranted
+          ? { reviewTakeover: true, previousAssigneeAgentId: issue.assigneeAgentId }
+          : {}),
+      },
     });
 
     if (

--- a/server/src/services/authorization.ts
+++ b/server/src/services/authorization.ts
@@ -49,6 +49,7 @@ export type AuthorizationAction =
   | "agent:read"
   | "agent:wake"
   | "company_scope:read"
+  | "issue:checkout_review"
   | "issue:comment"
   | "issue:mutate"
   | "issue:read"
@@ -126,7 +127,7 @@ function permissionForAction(action: AuthorizationAction): PermissionKey | null 
   ) {
     return null;
   }
-  if (action === "issue:comment" || action === "issue:mutate") return null;
+  if (action === "issue:checkout_review" || action === "issue:comment" || action === "issue:mutate") return null;
   return action;
 }
 
@@ -763,6 +764,12 @@ export function authorizationService(db: Db) {
       return await projectWithinLowTrustBoundary(boundary, projectId)
         ? lowTrustAllow("Allowed inside the low-trust project boundary.")
         : lowTrustDeny("Project is outside this low-trust boundary.");
+    }
+
+    if (input.action === "issue:checkout_review") {
+      return lowTrustDeny(
+        `${LOW_TRUST_REVIEW_PRESET} agents cannot take over review checkouts; reassignment is a mutate-equivalent write.`,
+      );
     }
 
     if (input.action === "issue:comment" || input.action === "issue:read" || input.action === "issue:mutate") {
@@ -1444,6 +1451,38 @@ export function authorizationService(db: Db) {
         return allowIssueMentionGrant(input.action);
       }
     }
+
+    if (input.action === "issue:checkout_review") {
+      const resource = input.resource.type === "issue" ? input.resource : null;
+      if (resource?.assigneeAgentId === actorAgentId) {
+        return allow({
+          action: input.action,
+          reason: "allow_self",
+          explanation: "Allowed because the actor owns the assigned issue.",
+        });
+      }
+      if (!resource?.assigneeAgentId) {
+        return allow({
+          action: input.action,
+          reason: "allow_company_agent",
+          explanation: "Allowed because the issue has no agent assignee.",
+        });
+      }
+      if (
+        resource.issueId &&
+        resource.status === "in_review" &&
+        await agentHasMentionGrantOnIssue({
+          action: input.action,
+          companyId,
+          issueId: resource.issueId,
+          issueAssigneeAgentId: resource.assigneeAgentId ?? null,
+          actorAgentId,
+        })
+      ) {
+        return allowIssueMentionGrant(input.action);
+      }
+    }
+
     if (
       input.action === "agent_config:update" &&
       input.resource.type === "agent" &&

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -5809,7 +5809,13 @@ export function issueService(db: Db) {
         return enriched;
       }),
 
-    checkout: async (id: string, agentId: string, expectedStatuses: string[], checkoutRunId: string | null) => {
+    checkout: async (
+      id: string,
+      agentId: string,
+      expectedStatuses: string[],
+      checkoutRunId: string | null,
+      options?: { allowReviewTakeover?: boolean },
+    ) => {
       const issueCompany = await db
         .select({ companyId: issues.companyId })
         .from(issues)
@@ -5851,6 +5857,17 @@ export function issueService(db: Db) {
       const executionLockCondition = checkoutRunId
         ? or(isNull(issues.executionRunId), eq(issues.executionRunId, checkoutRunId))
         : isNull(issues.executionRunId);
+      // Review takeover (mention-granted reviewer): may claim an issue assigned to
+      // another agent only while it sits in_review with no live checkout lock. The
+      // execution-lock condition below still applies, so an actively executing run
+      // can never be stolen.
+      const assigneeCondition = options?.allowReviewTakeover
+        ? or(
+          isNull(issues.assigneeAgentId),
+          sameRunAssigneeCondition,
+          and(eq(issues.status, "in_review"), isNull(issues.checkoutRunId)),
+        )
+        : or(isNull(issues.assigneeAgentId), sameRunAssigneeCondition);
       const updated = await db
         .update(issues)
         .set({
@@ -5866,7 +5883,7 @@ export function issueService(db: Db) {
           and(
             eq(issues.id, id),
             inArray(issues.status, expectedStatuses),
-            or(isNull(issues.assigneeAgentId), sameRunAssigneeCondition),
+            assigneeCondition,
             executionLockCondition,
           ),
         )


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Issues carry an ownership model: agent writes (comments, mutations, checkout) are gated on `assigneeAgentId`, with a narrow @-mention grant that lets an explicitly routed non-assignee agent comment
> - The platform's own review pattern relies on that grant: a doer finishes, sets the issue `in_review`, and @-mentions a reviewer agent to render a verdict
> - But the reviewer cannot *act* on the verdict — the checkout endpoint's atomic UPDATE only matches unassigned or self-assigned rows, so the mentioned reviewer 409s and can never move the issue to done/blocked under the ownership rules
> - This pull request adds an `issue:checkout_review` authorization action and an opt-in review-takeover path in the checkout service: a mention-granted reviewer may claim an issue only while it is `in_review` with no live checkout lock, reassigning it to themselves so close-out flows through the existing `allow_self` rules
> - The benefit is that multi-agent review loops complete end-to-end with least privilege — no broadening of the mutate rules, low-trust review agents stay excluded, and every takeover is recorded in the activity log with the previous assignee

## Linked Issues or Issue Description

Refs #5264 — that report asks (option 2 in its "Asks") for *"a 'reviewer' role with scoped write access, granted on @-mention, that bypasses the gate"*. This PR implements the checkout leg of exactly that, scoped to `in_review`.

Since #5264 centers on comment/document writes, here is the checkout-specific bug in bug-template form:

**What happened:** An agent that was @-mentioned onto an issue by the issue's assignee (the standard reviewer-routing pattern) calls `POST /api/issues/{id}/checkout` while the issue is `in_review` and assigned to the doer agent. The call fails with `409 Issue checkout conflict`, even though no run holds the checkout lock.

**Expected behavior:** An explicitly mention-routed reviewer should be able to claim an `in_review` issue so it can apply the review verdict (approve → done, reject → back to the doer) under the normal ownership rules.

**Steps to reproduce:**
1. Agent A is assigned an issue, completes work, sets status `in_review`
2. Agent A (or an active user) posts a comment @-mentioning agent B as reviewer
3. Agent B can comment (mention grant) but `POST /api/issues/{id}/checkout` with `expectedStatuses: ["in_review"]` returns 409
4. The review can only be resolved by a human or by reassignment out-of-band

**Version/commit:** reproduced on master @ `bac7307ec`; **Deployment mode:** self-hosted instance, embedded postgres.

**Alternatives considered:** (a) extending the mention grant to `issue:mutate` — rejected as over-broad (a reviewer could edit arbitrary fields without ever owning the issue); (b) process-only workaround (humans reassign) — rejected, leaves the platform's own review pattern broken by default.

## What Changed

- `server/src/services/authorization.ts` — new `issue:checkout_review` action (null permission key, decided structurally like comment/mutate): `allow_self` for the assignee, `allow_company_agent` when unassigned, and the existing mention grant (`agentHasMentionGrantOnIssue`, same authorship rules) **only when the issue status is `in_review`**. Low-trust review agents are explicitly denied — takeover reassignment is a mutate-equivalent write.
- `server/src/services/issues.ts` — `checkout` accepts an opt-in `options.allowReviewTakeover` flag that widens the atomic UPDATE's assignee condition with `and(status = 'in_review', checkout_run_id IS NULL)`. The execution-lock condition is untouched, so an actively executing run can never be stolen; terminal doer runs already release the lock via `clearCheckoutRunIfTerminal`.
- `server/src/routes/issues.ts` — the checkout route consults `access.decide` for `issue:checkout_review` only when an agent targets an `in_review` issue assigned to a different agent, passes the resulting flag to the service, and stamps the `issue.checked_out` activity entry with `reviewTakeover: true` + `previousAssigneeAgentId` for the audit trail. The pre-existing `tasks:assign` route guard remains unconditional.
- Tests: authorization decisions (grant only in `in_review`, non-mentioned peer denied, low-trust denied), service-level takeover semantics against embedded postgres (reassignment, 409 without the flag, no takeover outside `in_review`, live doer lock blocks, terminal doer lock releases), and route wiring (decide consulted with the right resource, flag forwarding, no consult outside `in_review`).

## Verification

- `pnpm --filter server exec vitest run src/__tests__/issue-agent-mutation-ownership-routes.test.ts` — 64 passed
- `pnpm --filter server exec vitest run src/__tests__/authorization-service.test.ts` — 30 passed
- `pnpm --filter server exec vitest run src/__tests__/issues-service.test.ts` — 102 passed (embedded postgres)
- `pnpm --filter server typecheck` — clean
- Manual review path: doer finishes → `in_review` → assignee @-mentions reviewer → reviewer `POST /checkout` with `expectedStatuses: ["in_review"]` succeeds, issue reassigns to reviewer, activity log shows `reviewTakeover` with the previous assignee; reviewer close-out then flows through existing `allow_self`.

## Risks

- Low risk, no schema changes, no new endpoints. The takeover path is opt-in per request and quadruple-gated: agent actor + `in_review` + valid mention grant (assignee/user-authored) + no live checkout lock in SQL.
- Behavioral shift is intentional and narrow: an issue in `in_review` can now change `assigneeAgentId` to a mention-granted reviewer via checkout. Anyone relying on "assignee never changes during review" observes a new (logged) transition.
- The status gate is enforced twice (authorization decision *and* the SQL condition), so a caller passing broad `expectedStatuses` cannot widen the takeover window.
- Rollback: revert the single commit; no migrations to unwind.

## Model Used

- Anthropic Claude — Claude Fable 5 (model ID `claude-fable-5`), extended thinking enabled, agentic tool use (file edits, test execution) via Claude Code.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes (no doc surface documents the checkout ownership rules; behavior is captured in tests)
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green (pending — will confirm after CI runs)
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups (pending first review)
- [x] I will address all Greptile and reviewer comments before requesting merge