### PR TITLE
Remove legacy local suffix from adapter display names

### DIFF
--- a/docs/adapters/creating-an-adapter.md
+++ b/docs/adapters/creating-an-adapter.md
@@ -54,7 +54,7 @@ my-adapter/                   # external plugin
 
 ```ts
 export const type = "my_agent";        // snake_case, globally unique
-export const label = "My Agent (local)";
+export const label = "My Agent";
 export const models = [
   { id: "model-a", label: "Model A" },
 ];

--- a/docs/adapters/external-adapters.md
+++ b/docs/adapters/external-adapters.md
@@ -116,7 +116,7 @@ The plugin loader calls `createServerAdapter()` from your package root. This fun
 
 ```ts
 export const type = "my_adapter";     // snake_case, globally unique
-export const label = "My Agent (local)";
+export const label = "My Agent";
 
 export const models = [
   { id: "model-a", label: "Model A" },

--- a/packages/adapters/acpx-local/src/index.ts
+++ b/packages/adapters/acpx-local/src/index.ts
@@ -1,7 +1,7 @@
 import type { AdapterModel } from "@paperclipai/adapter-utils";
 
 export const type = "acpx_local";
-export const label = "ACPX (local)";
+export const label = "ACPX";
 
 export const DEFAULT_ACPX_LOCAL_AGENT = "claude";
 export const DEFAULT_ACPX_LOCAL_MODE = "persistent";

--- a/packages/adapters/claude-local/src/index.ts
+++ b/packages/adapters/claude-local/src/index.ts
@@ -1,7 +1,7 @@
 import type { AdapterModelProfileDefinition } from "@paperclipai/adapter-utils";
 
 export const type = "claude_local";
-export const label = "Claude Code (local)";
+export const label = "Claude Code";
 
 export const SANDBOX_INSTALL_COMMAND = "npm install -g @anthropic-ai/claude-code";
 

--- a/packages/adapters/codex-local/src/index.ts
+++ b/packages/adapters/codex-local/src/index.ts
@@ -1,7 +1,7 @@
 import type { AdapterModelProfileDefinition } from "@paperclipai/adapter-utils";
 
 export const type = "codex_local";
-export const label = "Codex (local)";
+export const label = "Codex";
 
 export const SANDBOX_INSTALL_COMMAND = "npm install -g @openai/codex";
 

--- a/packages/adapters/cursor-local/src/index.ts
+++ b/packages/adapters/cursor-local/src/index.ts
@@ -1,7 +1,7 @@
 import type { AdapterModelProfileDefinition } from "@paperclipai/adapter-utils";
 
 export const type = "cursor";
-export const label = "Cursor CLI (local)";
+export const label = "Cursor CLI";
 
 // Cursor CLI is not distributed as an npm package — the official install
 // path is the upstream installer script at cursor.com/install. Other adapters

--- a/packages/adapters/gemini-local/src/index.ts
+++ b/packages/adapters/gemini-local/src/index.ts
@@ -4,7 +4,7 @@ import {
 } from "@paperclipai/adapter-utils";
 
 export const type = "gemini_local";
-export const label = "Gemini CLI (local)";
+export const label = "Gemini CLI";
 
 export const SANDBOX_INSTALL_COMMAND = buildSandboxNpmInstallCommand("@google/gemini-cli");
 

--- a/packages/adapters/grok-local/src/index.ts
+++ b/packages/adapters/grok-local/src/index.ts
@@ -1,5 +1,5 @@
 export const type = "grok_local";
-export const label = "Grok Build (local)";
+export const label = "Grok Build";
 
 export const DEFAULT_GROK_LOCAL_MODEL = "grok-build";
 

--- a/packages/adapters/opencode-local/src/index.ts
+++ b/packages/adapters/opencode-local/src/index.ts
@@ -1,7 +1,7 @@
 import type { AdapterModelProfileDefinition } from "@paperclipai/adapter-utils";
 
 export const type = "opencode_local";
-export const label = "OpenCode (local)";
+export const label = "OpenCode";
 
 // Use OpenCode's official installer instead of `npm install -g opencode-ai`.
 // The npm package reifies four large Linux x64 prebuilt-binary subpackages

--- a/packages/adapters/pi-local/src/index.ts
+++ b/packages/adapters/pi-local/src/index.ts
@@ -1,7 +1,7 @@
 import type { AdapterModelProfileDefinition } from "@paperclipai/adapter-utils";
 
 export const type = "pi_local";
-export const label = "Pi (local)";
+export const label = "Pi";
 
 export const SANDBOX_INSTALL_COMMAND = "npm install -g @earendil-works/pi-coding-agent@0.74.0";
 

--- a/ui/src/adapters/acpx-local/index.ts
+++ b/ui/src/adapters/acpx-local/index.ts
@@ -4,7 +4,7 @@ import { SchemaConfigFields } from "../schema-config-fields";
 
 export const acpxLocalUIAdapter: UIAdapterModule = {
   type: "acpx_local",
-  label: "ACPX (local)",
+  label: "ACPX",
   parseStdoutLine: parseAcpxStdoutLine,
   ConfigFields: SchemaConfigFields,
   buildAdapterConfig: buildAcpxLocalConfig,

--- a/ui/src/adapters/adapter-display-registry.test.ts
+++ b/ui/src/adapters/adapter-display-registry.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import { getAdapterDisplay, getAdapterLabel, getAdapterLabels } from "./adapter-display-registry";
+
+describe("adapter display registry", () => {
+  it("uses user-facing labels without the legacy local qualifier for built-in adapters", () => {
+    expect(getAdapterLabel("codex_local")).toBe("Codex");
+    expect(getAdapterLabel("claude_local")).toBe("Claude Code");
+    expect(getAdapterLabel("acpx_local")).toBe("ACPX");
+    expect(getAdapterLabel("cursor")).toBe("Cursor");
+    expect(getAdapterLabel("gemini_local")).toBe("Gemini CLI");
+    expect(getAdapterLabel("grok_local")).toBe("Grok Build");
+    expect(getAdapterLabel("hermes_local")).toBe("Hermes");
+    expect(getAdapterLabel("opencode_local")).toBe("OpenCode");
+    expect(getAdapterLabel("pi_local")).toBe("Pi");
+
+    expect(getAdapterLabels()).toMatchObject({
+      codex_local: "Codex",
+      claude_local: "Claude Code",
+      acpx_local: "ACPX",
+      cursor: "Cursor",
+      gemini_local: "Gemini CLI",
+      grok_local: "Grok Build",
+      hermes_local: "Hermes",
+      opencode_local: "OpenCode",
+      pi_local: "Pi",
+    });
+  });
+
+  it("drops local suffixes for unknown plugin adapter labels", () => {
+    expect(getAdapterLabel("droid_local")).toBe("Droid");
+    expect(getAdapterDisplay("droid_local")).toMatchObject({
+      label: "Droid",
+      description: "External adapter",
+    });
+  });
+
+  it("keeps a gateway suffix for unknown plugin adapter labels", () => {
+    expect(getAdapterLabel("droid_gateway")).toBe("Droid (gateway)");
+    expect(getAdapterDisplay("droid_gateway")).toMatchObject({
+      label: "Droid (gateway)",
+      description: "External gateway adapter",
+    });
+  });
+});

--- a/ui/src/adapters/adapter-display-registry.ts
+++ b/ui/src/adapters/adapter-display-registry.ts
@@ -21,13 +21,19 @@ import { OpenCodeLogoIcon } from "@/components/OpenCodeLogoIcon";
 // Type suffix parsing
 // ---------------------------------------------------------------------------
 
-const TYPE_SUFFIXES: Record<string, string> = {
-  _local: "local",
+// Suffixes stripped from type ids when deriving a human-readable label for
+// unknown (plugin) adapter types. "_local" is a legacy qualifier from before
+// first-class Environments and is never displayed; "_gateway" is re-appended
+// as " (gateway)" to disambiguate gateway variants. Known adapters in
+// `adapterDisplayMap` have final labels and never get a derived suffix.
+const STRIPPED_TYPE_SUFFIXES = ["_local", "_gateway"] as const;
+
+const DISPLAY_SUFFIXES: Record<string, string> = {
   _gateway: "gateway",
 };
 
 function getTypeSuffix(type: string): string | null {
-  for (const [suffix, mode] of Object.entries(TYPE_SUFFIXES)) {
+  for (const [suffix, mode] of Object.entries(DISPLAY_SUFFIXES)) {
     if (type.endsWith(suffix)) return mode;
   }
   return null;
@@ -55,57 +61,57 @@ export interface AdapterDisplayInfo {
 const adapterDisplayMap: Record<string, AdapterDisplayInfo> = {
   acpx_local: {
     label: "ACPX",
-    description: "Experimental local ACPX multi-agent adapter",
+    description: "Experimental ACPX multi-agent harness",
     icon: Bot,
     experimental: true,
     hideFromVisualSelection: true,
   },
   claude_local: {
     label: "Claude Code",
-    description: "Local Claude agent",
+    description: "Claude Code CLI harness",
     icon: Sparkles,
     recommended: true,
   },
   codex_local: {
     label: "Codex",
-    description: "Local Codex agent",
+    description: "Codex CLI harness",
     icon: Code,
     recommended: true,
   },
   gemini_local: {
     label: "Gemini CLI",
-    description: "Local Gemini agent",
+    description: "Gemini CLI harness",
     icon: Gem,
   },
   grok_local: {
     label: "Grok Build",
-    description: "Local Grok Build agent",
+    description: "Grok Build harness",
     icon: Bot,
   },
   hermes_gateway: {
-    label: "Hermes",
+    label: "Hermes (gateway)",
     description: "Remote Hermes API server",
     icon: Bot,
     hideFromVisualSelection: true,
   },
   hermes_local: {
     label: "Hermes",
-    description: "Local Hermes agent",
+    description: "Hermes harness",
     icon: Bot,
   },
   opencode_local: {
     label: "OpenCode",
-    description: "Local multi-provider agent",
+    description: "OpenCode multi-provider harness",
     icon: OpenCodeLogoIcon,
   },
   pi_local: {
     label: "Pi",
-    description: "Local Pi agent",
+    description: "Pi harness",
     icon: Terminal,
   },
   cursor: {
     label: "Cursor",
-    description: "Local Cursor agent",
+    description: "Cursor CLI harness",
     icon: MousePointer2,
   },
   cursor_cloud: {
@@ -142,7 +148,7 @@ const adapterDisplayMap: Record<string, AdapterDisplayInfo> = {
 function humanizeType(type: string): string {
   // Strip known type suffixes so "droid_local" → "Droid", not "Droid Local"
   let base = type;
-  for (const suffix of Object.keys(TYPE_SUFFIXES)) {
+  for (const suffix of STRIPPED_TYPE_SUFFIXES) {
     if (base.endsWith(suffix)) {
       base = base.slice(0, -suffix.length);
       break;
@@ -152,16 +158,20 @@ function humanizeType(type: string): string {
 }
 
 export function getAdapterLabel(type: string): string {
-  const base = adapterDisplayMap[type]?.label ?? humanizeType(type);
-  return withSuffix(base, getTypeSuffix(type));
+  // Known labels are final — only unknown (plugin) types get a derived
+  // suffix, so labels like "OpenClaw Gateway" don't become
+  // "OpenClaw Gateway (gateway)".
+  const known = adapterDisplayMap[type];
+  if (known) return known.label;
+  return withSuffix(humanizeType(type), getTypeSuffix(type));
 }
 
 export function getAdapterLabels(): Record<string, string> {
-  const suffixed: Record<string, string> = {};
+  const labels: Record<string, string> = {};
   for (const [type, info] of Object.entries(adapterDisplayMap)) {
-    suffixed[type] = withSuffix(info.label, getTypeSuffix(type));
+    labels[type] = info.label;
   }
-  return suffixed;
+  return labels;
 }
 
 export function getAdapterDisplay(type: string): AdapterDisplayInfo {

--- a/ui/src/adapters/claude-local/index.ts
+++ b/ui/src/adapters/claude-local/index.ts
@@ -5,7 +5,7 @@ import { buildClaudeLocalConfig } from "@paperclipai/adapter-claude-local/ui";
 
 export const claudeLocalUIAdapter: UIAdapterModule = {
   type: "claude_local",
-  label: "Claude Code (local)",
+  label: "Claude Code",
   parseStdoutLine: parseClaudeStdoutLine,
   ConfigFields: ClaudeLocalConfigFields,
   buildAdapterConfig: buildClaudeLocalConfig,

--- a/ui/src/adapters/codex-local/index.ts
+++ b/ui/src/adapters/codex-local/index.ts
@@ -5,7 +5,7 @@ import { buildCodexLocalConfig } from "@paperclipai/adapter-codex-local/ui";
 
 export const codexLocalUIAdapter: UIAdapterModule = {
   type: "codex_local",
-  label: "Codex (local)",
+  label: "Codex",
   parseStdoutLine: parseCodexStdoutLine,
   ConfigFields: CodexLocalConfigFields,
   buildAdapterConfig: buildCodexLocalConfig,

--- a/ui/src/adapters/cursor/index.ts
+++ b/ui/src/adapters/cursor/index.ts
@@ -5,7 +5,7 @@ import { buildCursorLocalConfig } from "@paperclipai/adapter-cursor-local/ui";
 
 export const cursorLocalUIAdapter: UIAdapterModule = {
   type: "cursor",
-  label: "Cursor CLI (local)",
+  label: "Cursor CLI",
   parseStdoutLine: parseCursorStdoutLine,
   ConfigFields: CursorLocalConfigFields,
   buildAdapterConfig: buildCursorLocalConfig,

--- a/ui/src/adapters/gemini-local/index.ts
+++ b/ui/src/adapters/gemini-local/index.ts
@@ -5,7 +5,7 @@ import { buildGeminiLocalConfig } from "@paperclipai/adapter-gemini-local/ui";
 
 export const geminiLocalUIAdapter: UIAdapterModule = {
   type: "gemini_local",
-  label: "Gemini CLI (local)",
+  label: "Gemini CLI",
   parseStdoutLine: parseGeminiStdoutLine,
   ConfigFields: GeminiLocalConfigFields,
   buildAdapterConfig: buildGeminiLocalConfig,

--- a/ui/src/adapters/grok-local/index.ts
+++ b/ui/src/adapters/grok-local/index.ts
@@ -5,7 +5,7 @@ import { GrokLocalConfigFields } from "./config-fields";
 
 export const grokLocalUIAdapter: UIAdapterModule = {
   type: "grok_local",
-  label: "Grok Build (local)",
+  label: "Grok Build",
   parseStdoutLine: parseGrokStdoutLine,
   createStdoutParser: createGrokStdoutParser,
   ConfigFields: GrokLocalConfigFields,

--- a/ui/src/adapters/opencode-local/index.ts
+++ b/ui/src/adapters/opencode-local/index.ts
@@ -5,7 +5,7 @@ import { buildOpenCodeLocalConfig } from "@paperclipai/adapter-opencode-local/ui
 
 export const openCodeLocalUIAdapter: UIAdapterModule = {
   type: "opencode_local",
-  label: "OpenCode (local)",
+  label: "OpenCode",
   parseStdoutLine: parseOpenCodeStdoutLine,
   ConfigFields: OpenCodeLocalConfigFields,
   buildAdapterConfig: buildOpenCodeLocalConfig,

--- a/ui/src/adapters/pi-local/index.ts
+++ b/ui/src/adapters/pi-local/index.ts
@@ -5,7 +5,7 @@ import { buildPiLocalConfig } from "@paperclipai/adapter-pi-local/ui";
 
 export const piLocalUIAdapter: UIAdapterModule = {
   type: "pi_local",
-  label: "Pi (local)",
+  label: "Pi",
   parseStdoutLine: parsePiStdoutLine,
   ConfigFields: PiLocalConfigFields,
   buildAdapterConfig: buildPiLocalConfig,

--- a/ui/src/pages/AdapterManager.tsx
+++ b/ui/src/pages/AdapterManager.tsx
@@ -72,7 +72,10 @@ function AdapterRow({
         <div className="min-w-0 flex-1">
           <div className="flex flex-wrap items-center gap-2">
             <span className={cn("font-medium", adapter.disabled && "text-muted-foreground line-through")}>
-              {adapter.label || getAdapterLabel(adapter.type)}
+              {/* The server reports label = raw type id, so prefer the display
+                  registry's human label; keep a real self-reported label if an
+                  external adapter ever provides one. */}
+              {adapter.label && adapter.label !== adapter.type ? adapter.label : getAdapterLabel(adapter.type)}
             </span>
             <Badge variant="outline">{adapter.source === "external" ? "External" : "Built-in"}</Badge>
             {adapter.source === "external" && (

--- a/ui/storybook/.storybook/preview.tsx
+++ b/ui/storybook/.storybook/preview.tsx
@@ -104,7 +104,7 @@ function installStorybookApiFixtures() {
       return Response.json([
         {
           type: "claude_local",
-          label: "Claude Local",
+          label: "Claude Code",
           source: "builtin",
           modelsCount: 2,
           loaded: true,
@@ -119,7 +119,7 @@ function installStorybookApiFixtures() {
         },
         {
           type: "codex_local",
-          label: "Codex Local",
+          label: "Codex",
           source: "builtin",
           modelsCount: 3,
           loaded: true,

--- a/ui/storybook/stories/agent-management.stories.tsx
+++ b/ui/storybook/stories/agent-management.stories.tsx
@@ -298,7 +298,7 @@ const storybookSecrets: CompanySecret[] = [
 const adapterFixtures: AdapterInfo[] = [
   {
     type: "codex_local",
-    label: "Codex Local",
+    label: "Codex",
     source: "builtin",
     modelsCount: 3,
     loaded: true,
@@ -313,7 +313,7 @@ const adapterFixtures: AdapterInfo[] = [
   },
   {
     type: "claude_local",
-    label: "Claude Local",
+    label: "Claude Code",
     source: "builtin",
     modelsCount: 2,
     loaded: true,

--- a/ui/storybook/stories/dialogs-modals.stories.tsx
+++ b/ui/storybook/stories/dialogs-modals.stories.tsx
@@ -373,7 +373,7 @@ function hydrateDialogQueries(queryClient: ReturnType<typeof useQueryClient>) {
   queryClient.setQueryData(queryKeys.adapters.all, [
     {
       type: "codex_local",
-      label: "Codex local",
+      label: "Codex",
       source: "builtin",
       modelsCount: 5,
       loaded: true,
@@ -388,7 +388,7 @@ function hydrateDialogQueries(queryClient: ReturnType<typeof useQueryClient>) {
     },
     {
       type: "claude_local",
-      label: "Claude local",
+      label: "Claude Code",
       source: "builtin",
       modelsCount: 4,
       loaded: true,
@@ -721,7 +721,7 @@ function useCheapLaneAdapterOverrides(variant: CheapLaneVariant) {
     queryClient.setQueryData(queryKeys.adapters.all, [
       {
         type: "codex_local",
-        label: "Codex local",
+        label: "Codex",
         source: "builtin",
         modelsCount: 5,
         loaded: true,
@@ -736,7 +736,7 @@ function useCheapLaneAdapterOverrides(variant: CheapLaneVariant) {
       },
       {
         type: "opencode_local",
-        label: "OpenCode local",
+        label: "OpenCode",
         source: "builtin",
         modelsCount: 2,
         loaded: true,

--- a/ui/storybook/stories/forms-editors.stories.tsx
+++ b/ui/storybook/stories/forms-editors.stories.tsx
@@ -121,7 +121,7 @@ const adapterSchema: JsonSchemaNode = {
       title: "Adapter name",
       description: "Human-readable name shown in the adapter manager.",
       minLength: 3,
-      default: "Codex local",
+      default: "Codex",
     },
     mode: {
       type: "string",
@@ -175,7 +175,7 @@ const adapterSchema: JsonSchemaNode = {
 
 const validAdapterValues = {
   ...getDefaultValues(adapterSchema),
-  adapterName: "Codex local",
+  adapterName: "Codex",
   mode: "implementation",
   apiKey: "secret:openai-api-key",
   concurrency: 2,


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The affected subsystem is adapter selection and adapter metadata shown in the board UI, adapter manager, Storybook fixtures, and adapter-authoring docs
> - Built-in agent adapters still carried legacy user-facing labels like `Codex (local)` from before first-class Environments existed
> - Adapter types still encode harness implementation details such as `_local`, but the display name should describe the harness rather than the execution environment
> - External/plugin adapter labels also need sensible derived names so unknown `_local` types do not surface the legacy qualifier
> - This pull request removes the legacy local qualifier from user-facing adapter labels while keeping adapter type ids unchanged
> - The benefit is cleaner operator-facing naming without changing runtime contracts or adapter configuration semantics

## Linked Issues or Issue Description

No existing public issue. **In-PR description (polish):**

**Problem:** Several built-in adapter names and docs still displayed `"(local)"`, even though Paperclip now models execution environments separately from adapter harnesses. That made adapter names read like environment-specific variants instead of harness names.

**Desired behavior:** User-facing adapter labels should show names such as **Codex**, **Claude Code**, **Gemini CLI**, **OpenCode**, **Grok Build**, and **Pi** without the legacy `"(local)"` suffix. Adapter type ids like `codex_local` remain unchanged for compatibility.

Related but not a duplicate: Refs #8819, which humanizes external multi-segment adapter labels and also touches the display registry. This PR focuses on built-in labels and `_local` suffix display behavior.

- [x] I searched GitHub for duplicate or related PRs before opening this PR

## What Changed

- Removed `"(local)"` from built-in adapter label exports in adapter packages and UI adapter modules.
- Updated the adapter display registry so known built-in labels are final and unknown `_local` plugin adapter types drop the legacy suffix.
- Kept unknown `_gateway` plugin labels disambiguated with `"(gateway)"`.
- Updated Adapter Manager fallback rendering to prefer registry labels when the server-provided label is just the raw adapter type.
- Updated Storybook fixtures and adapter-authoring docs that still used legacy local labels.
- Added targeted registry tests for built-in labels, unknown `_local` labels, and unknown `_gateway` labels.

## Verification

Passed locally:

```bash
git diff --check
rg "\\(local\\)" -n --glob '!**/node_modules/**' --glob '!releases/**'
rg '^(<<<<<<<|=======|>>>>>>>)' -n --glob '!**/node_modules/**'
node ./scripts/check-docker-deps-stage.mjs
node ./scripts/check-no-git-push.mjs
node --test ./scripts/check-no-git-push.test.mjs ./scripts/__tests__/run-vitest-stable-shard.test.mjs ./scripts/__tests__/build-standalone-concurrency.test.mjs
node ./scripts/release-package-map.mjs check
```

Attempted but not completed locally:

```bash
corepack pnpm install --frozen-lockfile
```

That install failed with `ERR_PNPM_ENOSPC` in this workspace while copying packages into `node_modules`, so the new Vitest file could not be run locally here. PR CI should run the dependency-backed Vitest/typecheck/build lanes.

## Risks

Low risk. This is display-label and documentation cleanup; adapter type ids, runtime adapter behavior, config shapes, and model lists are unchanged. The main risk is a UI snapshot or Storybook fixture expecting the legacy string.

## Model Used

OpenAI Codex, GPT-5 coding agent in the Paperclip agent runtime, with shell/tool use enabled and local repository editing. Reasoning mode was enabled for code review, GitHub PR preparation, and verification.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change and contains no internal Paperclip ticket id or instance-derived details
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge