### PR TITLE
Fix productivity review monitor continuation path

### DIFF
--- a/server/src/__tests__/productivity-review-service.test.ts
+++ b/server/src/__tests__/productivity-review-service.test.ts
@@ -55,6 +55,9 @@ describeEmbeddedPostgres("productivity review service", () => {
     startedAt?: Date;
     parentId?: string | null;
     originKind?: string;
+    executionPolicy?: Record<string, unknown> | null;
+    executionState?: Record<string, unknown> | null;
+    monitorNextCheckAt?: Date | null;
   }) {
     const companyId = randomUUID();
     const managerId = randomUUID();
@@ -103,6 +106,9 @@ describeEmbeddedPostgres("productivity review service", () => {
       assigneeAgentId: coderId,
       parentId: opts?.parentId ?? null,
       originKind: opts?.originKind ?? "manual",
+      executionPolicy: opts?.executionPolicy ?? null,
+      executionState: opts?.executionState ?? null,
+      monitorNextCheckAt: opts?.monitorNextCheckAt ?? null,
       issueNumber: 1,
       identifier: `${issuePrefix}-1`,
       startedAt: opts?.startedAt ?? createdAt,
@@ -358,6 +364,151 @@ describeEmbeddedPostgres("productivity review service", () => {
     expect(review?.description).toContain("Primary trigger: `long_active_duration`");
     expect(review?.priority).toBe("medium");
     expect(hold.held).toBe(false);
+  });
+
+  it("does not create a long-active review when the issue has a future scheduled monitor", async () => {
+    const now = new Date("2026-04-28T12:00:00.000Z");
+    const nextCheckAt = new Date("2026-04-28T18:00:00.000Z");
+    const monitor = {
+      nextCheckAt: nextCheckAt.toISOString(),
+      notes: "Scheduled publish slot",
+      scheduledBy: "assignee",
+    };
+    const scheduledState = {
+      status: "idle",
+      currentStageId: null,
+      currentStageIndex: null,
+      currentStageType: null,
+      currentParticipant: null,
+      returnAssignee: null,
+      reviewRequest: null,
+      completedStageIds: [],
+      lastDecisionId: null,
+      lastDecisionOutcome: null,
+      monitor: {
+        status: "scheduled",
+        nextCheckAt: nextCheckAt.toISOString(),
+        lastTriggeredAt: null,
+        attemptCount: 0,
+        notes: "Scheduled publish slot",
+        scheduledBy: "assignee",
+        clearedAt: null,
+        clearReason: null,
+      },
+    };
+    const seeded = await seedAssignedIssue({
+      status: "in_progress",
+      startedAt: new Date(now.getTime() - 7 * 60 * 60 * 1000),
+      executionPolicy: {
+        mode: "normal",
+        commentRequired: true,
+        stages: [],
+        monitor,
+      },
+      executionState: scheduledState,
+      monitorNextCheckAt: nextCheckAt,
+    });
+
+    const result = await productivityReviewService(db).reconcileProductivityReviews({
+      now,
+      companyId: seeded.companyId,
+    });
+
+    expect(result.created).toBe(0);
+    expect(result.skipped).toBe(1);
+    expect(await listProductivityReviews(seeded.companyId)).toHaveLength(0);
+  });
+
+  it("keeps long-active review behavior for stale or cleared monitors", async () => {
+    const now = new Date("2026-04-28T12:00:00.000Z");
+    const staleCheckAt = new Date("2026-04-28T11:00:00.000Z");
+    const futureCheckAt = new Date("2026-04-28T18:00:00.000Z");
+    const stale = await seedAssignedIssue({
+      status: "in_progress",
+      startedAt: new Date(now.getTime() - 7 * 60 * 60 * 1000),
+      executionPolicy: {
+        stages: [],
+        monitor: {
+          nextCheckAt: staleCheckAt.toISOString(),
+          notes: null,
+          scheduledBy: "assignee",
+        },
+      },
+      executionState: {
+        status: "idle",
+        currentStageId: null,
+        currentStageIndex: null,
+        currentStageType: null,
+        currentParticipant: null,
+        returnAssignee: null,
+        reviewRequest: null,
+        completedStageIds: [],
+        lastDecisionId: null,
+        lastDecisionOutcome: null,
+        monitor: {
+          status: "scheduled",
+          nextCheckAt: staleCheckAt.toISOString(),
+          lastTriggeredAt: null,
+          attemptCount: 0,
+          notes: null,
+          scheduledBy: "assignee",
+          clearedAt: null,
+          clearReason: null,
+        },
+      },
+      monitorNextCheckAt: staleCheckAt,
+    });
+    const cleared = await seedAssignedIssue({
+      status: "in_progress",
+      startedAt: new Date(now.getTime() - 7 * 60 * 60 * 1000),
+      executionPolicy: {
+        stages: [],
+        monitor: {
+          nextCheckAt: futureCheckAt.toISOString(),
+          notes: null,
+          scheduledBy: "assignee",
+        },
+      },
+      executionState: {
+        status: "idle",
+        currentStageId: null,
+        currentStageIndex: null,
+        currentStageType: null,
+        currentParticipant: null,
+        returnAssignee: null,
+        reviewRequest: null,
+        completedStageIds: [],
+        lastDecisionId: null,
+        lastDecisionOutcome: null,
+        monitor: {
+          status: "cleared",
+          nextCheckAt: futureCheckAt.toISOString(),
+          lastTriggeredAt: null,
+          attemptCount: 0,
+          notes: null,
+          scheduledBy: "assignee",
+          clearedAt: now.toISOString(),
+          clearReason: "manual",
+        },
+      },
+      monitorNextCheckAt: futureCheckAt,
+    });
+
+    const result = await productivityReviewService(db).reconcileProductivityReviews({
+      now,
+      companyId: stale.companyId,
+    });
+
+    expect(result.created).toBe(1);
+    expect(await listProductivityReviews(stale.companyId)).toHaveLength(1);
+
+    const clearedResult = await productivityReviewService(db).reconcileProductivityReviews({
+      now,
+      companyId: cleared.companyId,
+    });
+
+    expect(clearedResult.created).toBe(1);
+    expect(await listProductivityReviews(cleared.companyId)).toHaveLength(1);
   });
 
   it("creates a high-churn review even when every sampled run has a progress comment", async () => {

--- a/server/src/services/productivity-review.ts
+++ b/server/src/services/productivity-review.ts
@@ -1,6 +1,6 @@
 import { and, asc, desc, eq, gt, inArray, isNull, notInArray, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
-import { clampIssueRequestDepth } from "@paperclipai/shared";
+import { clampIssueRequestDepth, issueExecutionPolicySchema, issueExecutionStateSchema } from "@paperclipai/shared";
 import {
   agents,
   companies,
@@ -33,6 +33,7 @@ export const DEFAULT_PRODUCTIVITY_REVIEW_MAX_CREATIONS_PER_WINDOW = 3;
 
 const TERMINAL_RUN_STATUSES = ["succeeded", "failed", "cancelled", "timed_out"] as const;
 const ACTIVE_RUN_STATUSES = ["queued", "running", "scheduled_retry"] as const;
+const ACTIVE_MONITOR_STATUSES = ["scheduled"] as const;
 const MAX_CANDIDATE_ISSUES = 250;
 const MAX_RUNS_FOR_STREAK = 100;
 const MAX_PARENT_WALK_DEPTH = 25;
@@ -136,6 +137,26 @@ function readPositiveInteger(value: number, fallback: number) {
 function coerceDate(value: Date | string | null | undefined) {
   if (!value) return null;
   return value instanceof Date ? value : new Date(value);
+}
+
+function isFutureDate(value: string | Date | null | undefined, now: Date) {
+  const parsed = coerceDate(value);
+  return parsed instanceof Date && Number.isFinite(parsed.getTime()) && parsed.getTime() > now.getTime();
+}
+
+function hasFutureActiveMonitor(sourceIssue: IssueRow, now: Date) {
+  const policy = issueExecutionPolicySchema.safeParse(sourceIssue.executionPolicy ?? null);
+  const state = issueExecutionStateSchema.safeParse(sourceIssue.executionState ?? null);
+  if (!policy.success || !state.success) return false;
+
+  const policyNextCheckAt = policy.data.monitor?.nextCheckAt ?? null;
+  const stateMonitor = state.data.monitor;
+  if (!policyNextCheckAt || !stateMonitor) return false;
+  if (!ACTIVE_MONITOR_STATUSES.includes(stateMonitor.status as (typeof ACTIVE_MONITOR_STATUSES)[number])) {
+    return false;
+  }
+
+  return isFutureDate(policyNextCheckAt, now) && isFutureDate(stateMonitor.nextCheckAt, now);
 }
 
 function buildThresholds(overrides?: Partial<ProductivityReviewThresholds>): ProductivityReviewThresholds {
@@ -476,7 +497,10 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
       : null;
 
     const noComment = noCommentStreak >= thresholds.noCommentStreakRuns;
-    const longActive = elapsedMs !== null && elapsedMs >= thresholds.longActiveMs;
+    const longActive =
+      elapsedMs !== null &&
+      elapsedMs >= thresholds.longActiveMs &&
+      !hasFutureActiveMonitor(sourceIssue, now);
     const highChurn =
       runCountLastHour >= thresholds.highChurnHourly ||
       assigneeRunCommentCountLastHour >= thresholds.highChurnHourly ||


### PR DESCRIPTION
## Summary

Fixes the productivity review detector so `long_active_duration` does not fire for assigned issues that already have a valid future monitor wake path.

## Root cause

The detector treated any `in_progress` issue older than the long-active threshold as lacking a continuation path. It only used run/comment evidence for `nextAction` and did not inspect `executionPolicy.monitor` or `executionState.monitor`, so scheduled future follow-ups looked like stale work.

## Changes

- Parses execution policy/state with the shared issue schemas.
- Suppresses only the `long_active_duration` trigger when the issue has a future monitor timestamp and monitor state is `scheduled`.
- Keeps existing review behavior for no monitor, stale monitor timestamps, and cleared monitors.
- Adds regression coverage for the RR-4206-shaped future scheduled monitor case plus stale/cleared monitor controls.

## Validation

- `pnpm vitest run server/src/__tests__/productivity-review-service.test.ts` - 13 passed
- `pnpm --filter @paperclipai/server typecheck` - passed
