### PR TITLE
fix(catalog): pin catalog files to LF to stop CRLF hash mismatch (RAM-7)

### DIFF
--- a/packages/skills-catalog/.gitattributes
+++ b/packages/skills-catalog/.gitattributes
@@ -1,0 +1,9 @@
+# Catalog skill files are integrity-pinned by sha256 in generated/catalog.json.
+# Those hashes (and the runtime check in server readCatalogFileBytes) are computed
+# over the RAW file bytes, so the working-tree bytes must equal the committed (LF)
+# bytes on every platform. Without pinning EOL, core.autocrlf=true on Windows
+# rewrites these files to CRLF at checkout; the runtime hash then no longer matches
+# the pinned hash and every catalog skill install fails with HTTP 422
+# "Pinned catalog file hash mismatch". Force LF so the bytes are identical everywhere.
+catalog/** text eol=lf
+generated/catalog.json text eol=lf

--- a/packages/teams-catalog/.gitattributes
+++ b/packages/teams-catalog/.gitattributes
@@ -1,0 +1,8 @@
+# Team catalog files are integrity-pinned by sha256 in generated/catalog.json
+# (per-file sha256 + per-team contentHash), computed over the RAW file bytes.
+# The working-tree bytes must equal the committed (LF) bytes on every platform,
+# otherwise core.autocrlf=true on Windows rewrites them to CRLF at checkout and
+# the content no longer matches its pinned hash (the same failure mode that broke
+# skills-catalog installs with HTTP 422). Force LF so bytes are identical everywhere.
+catalog/** text eol=lf
+generated/catalog.json text eol=lf


### PR DESCRIPTION
## Summary

Fixes catalog **skill installs failing with HTTP 422 "Pinned catalog file hash mismatch"** on Windows checkouts (RAM-7).

### Root cause
Catalog files are integrity-pinned by `sha256` in `generated/catalog.json`, and the server re-hashes the raw working-tree bytes at install/preview (`readCatalogFileBytes`). With `core.autocrlf=true` and no `.gitattributes`, git rewrote the LF-committed catalog files to CRLF at checkout, so the runtime hash (CRLF bytes) never matched the pinned hash (LF bytes) -> 422. `git diff` showed nothing because git normalizes CRLF for comparison, which hid the drift.

### Fix
- Add scoped `.gitattributes` to `packages/skills-catalog` and `packages/teams-catalog` forcing `catalog/** text eol=lf` plus the generated manifest, so working-tree bytes equal committed LF bytes on every platform regardless of `core.autocrlf`.
- Renormalize the already-mangled working-tree files back to LF.

### Verification
- Recomputed sha256 of every hash-pinned file vs the manifest: **skills-catalog 20/20 match, teams-catalog 22/22 match, 0 mismatches.**
- CRLF counterfactual: simulating a CRLF rewrite of the same files reproduces 422 for all of them, confirming CRLF was the exact failure mechanism.
- Live on the running instance: `GET .../agent-browser/files?path=SKILL.md` -> 200 (was 422); `POST .../skills/install-catalog` (agent-browser) -> 201 `{"action":"created"}` (was 422).

### Notes
- `teams-catalog` had the same latent CRLF drift (22 files); fixed identically for byte-consistency.
- The `last30days` skill has no vendored catalog files by design (external-sourced from `mvanhorn/last30days-skill`); not a bug.

Branch: `fix/catalog-crlf-hash-mismatch` @ `3b1461076`.