### PR TITLE
Harden work timeline security filters

### DIFF
--- a/server/src/__tests__/work-timeline-service.test.ts
+++ b/server/src/__tests__/work-timeline-service.test.ts
@@ -253,6 +253,72 @@ describeEmbeddedPostgres("work timeline aggregation", () => {
     ]));
   });
 
+  it("does not join activity rows to runs from another company", async () => {
+    const { companyId, agentAId } = await seedBase();
+    const otherCompanyId = randomUUID();
+    const otherAgentId = randomUUID();
+    const issueId = randomUUID();
+    const foreignRunId = randomUUID();
+
+    await db.insert(companies).values({
+      id: otherCompanyId,
+      name: "Other Timeline Co",
+      issuePrefix: `O${randomUUID().replace(/-/g, "").slice(0, 4).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: otherAgentId,
+      companyId: otherCompanyId,
+      name: "Foreign Coder",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Local issue",
+      status: "todo",
+      priority: "medium",
+      assigneeAgentId: agentAId,
+      createdAt: new Date("2026-03-02T10:00:00Z"),
+      updatedAt: new Date("2026-03-02T10:00:00Z"),
+    });
+    await db.insert(heartbeatRuns).values({
+      id: foreignRunId,
+      companyId: otherCompanyId,
+      agentId: otherAgentId,
+      status: "completed",
+      invocationSource: "manual",
+      startedAt: new Date("2026-03-02T11:00:00Z"),
+      finishedAt: new Date("2026-03-02T11:15:00Z"),
+      contextSnapshot: {},
+    });
+    await db.insert(activityLog).values({
+      companyId,
+      actorType: "agent",
+      actorId: agentAId,
+      action: "issue.updated",
+      entityType: "issue",
+      entityId: issueId,
+      agentId: agentAId,
+      runId: foreignRunId,
+      createdAt: new Date("2026-03-02T11:05:00Z"),
+    });
+
+    const result = await workTimelineService(db).getTimeline({
+      companyId,
+      from: new Date("2026-03-02T00:00:00Z"),
+      to: new Date("2026-03-03T00:00:00Z"),
+    });
+
+    expect(result.events.map((event) => event.issueId)).toContain(issueId);
+    expect(result.spans.map((span) => span.runId)).not.toContain(foreignRunId);
+  });
+
   it("applies the user lens as a transitive issue subtree", async () => {
     const { companyId, userId, agentAId, agentBId } = await seedBase();
     const rootIssueId = randomUUID();
@@ -343,6 +409,40 @@ describeEmbeddedPostgres("work timeline aggregation", () => {
     expect(result.events.map((event) => event.issueId)).toContain(visibleIssueId);
     expect(result.events.map((event) => event.issueId)).not.toContain(hiddenIssueId);
     expect(result.pagination.totalIssues).toBe(1);
+  });
+
+  it("bounds pre-pagination ACL checks", async () => {
+    const { companyId, agentAId } = await seedBase();
+    const issueCount = 40;
+    await db.insert(issues).values(Array.from({ length: issueCount }, (_, index) => ({
+      id: randomUUID(),
+      companyId,
+      title: `Visible ${index}`,
+      status: "todo",
+      priority: "medium",
+      assigneeAgentId: agentAId,
+      createdAt: new Date(Date.parse("2026-03-04T10:00:00Z") + index * 1000),
+      updatedAt: new Date(Date.parse("2026-03-04T10:00:00Z") + index * 1000),
+    })));
+
+    let activeChecks = 0;
+    let maxActiveChecks = 0;
+    const result = await workTimelineService(db).getTimeline({
+      companyId,
+      from: new Date("2026-03-04T00:00:00Z"),
+      to: new Date("2026-03-05T00:00:00Z"),
+      limit: issueCount,
+      canReadIssue: async () => {
+        activeChecks += 1;
+        maxActiveChecks = Math.max(maxActiveChecks, activeChecks);
+        await new Promise((resolve) => setTimeout(resolve, 1));
+        activeChecks -= 1;
+        return true;
+      },
+    });
+
+    expect(result.pagination.totalIssues).toBe(issueCount);
+    expect(maxActiveChecks).toBeLessThanOrEqual(16);
   });
 
   it("serves GET /api/companies/:companyId/timeline", async () => {

--- a/server/src/services/work-timeline.ts
+++ b/server/src/services/work-timeline.ts
@@ -78,6 +78,7 @@ const MAX_LIMIT = 500;
 const MAX_WINDOW_MS = 31 * 24 * 60 * 60 * 1000;
 const DEFAULT_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
 const MAX_SOURCE_ROWS = 5_000;
+const ACL_FILTER_CONCURRENCY = 16;
 
 function actorId(type: TimelineActorType, id: string) {
   return `${type}:${id}`;
@@ -132,6 +133,34 @@ function runOverlapsWindow(from: Date, to: Date) {
 }
 
 export function workTimelineService(db: Db) {
+  async function filterReadableIssues(
+    rows: IssueRow[],
+    canReadIssue: NonNullable<WorkTimelineQuery["canReadIssue"]> | undefined,
+  ) {
+    if (!canReadIssue) return rows;
+
+    const allowedRows: IssueRow[] = [];
+    for (let index = 0; index < rows.length; index += ACL_FILTER_CONCURRENCY) {
+      const batch = rows.slice(index, index + ACL_FILTER_CONCURRENCY);
+      const decisions = await Promise.all(batch.map(async (issue) => ({
+        issue,
+        allowed: await canReadIssue({
+          id: issue.id,
+          companyId: issue.companyId,
+          projectId: issue.projectId,
+          parentId: issue.parentId,
+          assigneeAgentId: issue.assigneeAgentId,
+          assigneeUserId: issue.assigneeUserId,
+          status: issue.status,
+        }),
+      })));
+      for (const decision of decisions) {
+        if (decision.allowed) allowedRows.push(decision.issue);
+      }
+    }
+    return allowedRows;
+  }
+
   async function collectIssueIds(input: WorkTimelineQuery, from: Date, to: Date) {
     const ids = new Set<string>();
 
@@ -403,20 +432,7 @@ export function workTimelineService(db: Db) {
     const candidateIssueIds = await collectIssueIds(input, from, to);
     const loadedIssues = await loadIssues(input, candidateIssueIds);
     const userScopedIssues = await applyUserLens(input, loadedIssues, from, to);
-    const accessibleIssues = input.canReadIssue
-      ? (await Promise.all(userScopedIssues.map(async (issue) => ({
-        issue,
-        allowed: await input.canReadIssue?.({
-          id: issue.id,
-          companyId: issue.companyId,
-          projectId: issue.projectId,
-          parentId: issue.parentId,
-          assigneeAgentId: issue.assigneeAgentId,
-          assigneeUserId: issue.assigneeUserId,
-          status: issue.status,
-        }),
-      })))).filter((entry) => entry.allowed).map((entry) => entry.issue)
-      : userScopedIssues;
+    const accessibleIssues = await filterReadableIssues(userScopedIssues, input.canReadIssue);
     const sortedIssues = accessibleIssues.sort((left, right) => right.createdAt.getTime() - left.createdAt.getTime());
     const pagedIssues = sortedIssues.slice(offset, offset + limit);
     const issueById = new Map(pagedIssues.map((issue) => [issue.id, issue]));
@@ -519,6 +535,7 @@ export function workTimelineService(db: Db) {
         .where(
           and(
             eq(activityLog.companyId, input.companyId),
+            eq(heartbeatRuns.companyId, input.companyId),
             eq(activityLog.entityType, "issue"),
             inArray(activityLog.entityId, readableIssueIds),
             runOverlapsWindow(from, to),


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The work timeline aggregates issue activity, agent runs, and spans into a company-scoped operational view.
> - Timeline rows are security-sensitive because the route can run through per-issue ACL checks and joins activity rows to heartbeat runs.
> - Activity log rows already carry company scope, but the run join also needs to enforce the same company boundary so a reused run id cannot attach foreign-company run metadata.
> - Pre-pagination ACL checks can also fan out across many candidate issues, so the timeline service should bound that async work before sorting and slicing.
> - This pull request hardens the service-side filters and adds regression coverage for both behaviors.
> - The benefit is a safer timeline query path with predictable ACL-check concurrency.

## Linked Issues or Issue Description

No public GitHub issue exists for this extracted fix.

Bug report fields:

- What happened: the work timeline service joined activity rows to heartbeat runs by run id without also constraining the joined run to the requested company, and it evaluated pre-pagination `canReadIssue` checks with unbounded `Promise.all` fan-out.
- Expected behavior: timeline data for a company should only include run spans from the same company, and ACL checks should be bounded while preserving result ordering.
- Steps to reproduce: create a local-company activity row whose `runId` points at a heartbeat run owned by another company, then request that local company's timeline.
- Paperclip version/commit: reproduced from the branch containing the extracted service fix, rebased onto `master` at `c48feee19`.
- Deployment mode: server-side service path, independent of deployment mode.

Related prior work: #8907 was a closed, unmerged Storybook fixture PR that previously carried this service commit; this PR extracts only the service/security change.

## What Changed

- Added bounded timeline ACL filtering with a concurrency cap of 16 before pagination.
- Added the heartbeat-run company predicate to the work timeline activity/run join.
- Added regression coverage for foreign-company run joins and bounded ACL concurrency.

## Verification

- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/work-timeline-service.test.ts`
- `pnpm --filter @paperclipai/server typecheck`
- GitHub PR checks are green on the latest head SHA.

## Risks

Low risk. The change narrows a join to the requested company and preserves the existing ACL filtering semantics while batching the async checks. The main behavioral risk is that callers relying on accidentally joined cross-company run spans will no longer see those spans.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

OpenAI Codex, GPT-5-based coding agent in the Paperclip runtime, with shell command execution and GitHub CLI/tool use. The exact backend model identifier and context window are not exposed in this runtime.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
