### PR TITLE
docs(skill): carve out board decisions from rule #1 (POS-101)

### DIFF
--- a/skills/paperclip/SKILL.md
+++ b/skills/paperclip/SKILL.md
@@ -319,6 +319,8 @@ This is rule #1:
 
 IMPORTANT: **NEVER ASK A HUMAN TO DO WHAT AN AGENT COULD DO**. If you need to escalate, escalate. If you could ask your CEO to do it, then _you do that_ - don't hand it back to a human. Again: Never ask a human to do what an agent _could_ do. Rule number 1.
 
+Carve-out: **board decisions are governance input, not delegable work.** Approvals, confirmations, and other governance gates that a human must own are not tasks an agent "could do" — routing them to a human is correct, not a rule #1 violation.
+
 ## Comment Style (Required)
 
 When posting issue comments or writing issue descriptions, use concise markdown with:


### PR DESCRIPTION
## What

Adds a surgical carve-out to the paperclip skill's **rule #1** ("never ask a human to do what an agent could do") so it doesn't conflict with the governance layer (board approvals/confirmations).

New sentence, added right where rule #1 is stated (`skills/paperclip/SKILL.md`):

> Carve-out: **board decisions are governance input, not delegable work.** Approvals, confirmations, and other governance gates that a human must own are not tasks an agent "could do" — routing them to a human is correct, not a rule #1 violation.

## Why

From the accepted POS-78 plan, phase P3 — Scope hygiene (finding F). Without this, agents can read rule #1 as pressure to avoid ever routing a governance decision to a human, which is exactly what the approval/confirmation gates require.

## Scope

- One file, +2 lines (blank line + carve-out sentence). Nothing else touched.

## Merge

Branch-protected — **human merge by Nick**. Do not auto-merge.

Refs POS-101.