### PR TITLE
Configure git identity per execution worktree

### DIFF
--- a/server/src/__tests__/heartbeat-workspace-session.test.ts
+++ b/server/src/__tests__/heartbeat-workspace-session.test.ts
@@ -8,6 +8,10 @@ import type { agents } from "@paperclipai/db";
 import { sessionCodec as codexSessionCodec } from "@paperclipai/adapter-codex-local/server";
 import { resolveDefaultAgentWorkspaceDir } from "../home-paths.js";
 import {
+  ensurePersistedExecutionWorkspaceAvailable,
+  realizeExecutionWorkspace,
+} from "../services/workspace-runtime.js";
+import {
   applyPersistedExecutionWorkspaceConfig,
   assertGitSensitiveAdapterWorkspaceValid,
   assertPushCapabilityCheckoutValid,
@@ -123,6 +127,11 @@ async function runGit(cwd: string, args: string[]) {
   await execFile("git", args, { cwd });
 }
 
+async function runGitOutput(cwd: string, args: string[]) {
+  const { stdout } = await execFile("git", args, { cwd });
+  return stdout.trim();
+}
+
 async function createGitCheckout(options: { withRemote: boolean }) {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-push-preflight-"));
   await runGit(root, ["init"]);
@@ -149,6 +158,128 @@ async function expectWorkspaceValidationFailure(
     },
   });
 }
+
+describe("execution workspace git identity", () => {
+  async function createCommittedRepo() {
+    const repoRoot = await createGitCheckout({ withRemote: false });
+    await runGit(repoRoot, ["config", "user.email", "repo@example.com"]);
+    await runGit(repoRoot, ["config", "user.name", "Repo User"]);
+    await fs.writeFile(path.join(repoRoot, "README.md"), "initial\n", "utf8");
+    await runGit(repoRoot, ["add", "README.md"]);
+    await runGit(repoRoot, ["commit", "-m", "Initial commit"]);
+    const baseRef = await runGitOutput(repoRoot, ["symbolic-ref", "--quiet", "--short", "HEAD"]);
+    return { repoRoot, baseRef };
+  }
+
+  function workspaceBase(repoRoot: string, baseRef: string) {
+    return {
+      baseCwd: repoRoot,
+      source: "project_primary" as const,
+      projectId: "project-1",
+      workspaceId: "workspace-1",
+      repoUrl: null,
+      repoRef: baseRef,
+    };
+  }
+
+  function workspaceConfig(worktreeParentDir: string) {
+    return {
+      workspaceStrategy: {
+        type: "git_worktree",
+        worktreeParentDir,
+        branchTemplate: "{{issue.identifier}}-{{agent.id}}",
+      },
+    };
+  }
+
+  async function commitFromWorktree(worktreePath: string, filename: string) {
+    await fs.writeFile(path.join(worktreePath, filename), `${filename}\n`, "utf8");
+    await runGit(worktreePath, ["add", filename]);
+    await runGit(worktreePath, ["commit", "-m", `Add ${filename}`]);
+    return await runGitOutput(worktreePath, ["log", "-1", "--format=%an <%ae>"]);
+  }
+
+  it("configures distinct worktree-local authors for concurrent managed worktrees", async () => {
+    const { repoRoot, baseRef } = await createCommittedRepo();
+    const worktreeParentDir = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-worktree-identity-"));
+
+    try {
+      const workspaceA = await realizeExecutionWorkspace({
+        base: workspaceBase(repoRoot, baseRef),
+        config: workspaceConfig(worktreeParentDir),
+        issue: { id: "issue-a", identifier: "PAP-1", title: "First issue" },
+        agent: { id: "agent-a", name: "Agent A", companyId: "company-1" },
+      });
+      const workspaceB = await realizeExecutionWorkspace({
+        base: workspaceBase(repoRoot, baseRef),
+        config: workspaceConfig(worktreeParentDir),
+        issue: { id: "issue-b", identifier: "PAP-2", title: "Second issue" },
+        agent: { id: "agent-b", name: "Agent B", companyId: "company-1" },
+      });
+
+      expect(workspaceA.worktreePath).not.toBe(workspaceB.worktreePath);
+      await expect(runGitOutput(workspaceA.worktreePath!, ["config", "--worktree", "user.email"]))
+        .resolves.toBe("agent-a@agents.paperclip.local");
+      await expect(runGitOutput(workspaceB.worktreePath!, ["config", "--worktree", "user.email"]))
+        .resolves.toBe("agent-b@agents.paperclip.local");
+
+      await expect(commitFromWorktree(workspaceA.worktreePath!, "agent-a.txt"))
+        .resolves.toBe("Agent A <agent-a@agents.paperclip.local>");
+      await expect(commitFromWorktree(workspaceB.worktreePath!, "agent-b.txt"))
+        .resolves.toBe("Agent B <agent-b@agents.paperclip.local>");
+      await expect(runGitOutput(repoRoot, ["config", "user.email"]))
+        .resolves.toBe("repo@example.com");
+    } finally {
+      await fs.rm(worktreeParentDir, { recursive: true, force: true });
+      await fs.rm(repoRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("refreshes worktree-local author identity when restoring a persisted worktree", async () => {
+    const { repoRoot, baseRef } = await createCommittedRepo();
+    const worktreeParentDir = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-worktree-restore-"));
+
+    try {
+      const workspace = await realizeExecutionWorkspace({
+        base: workspaceBase(repoRoot, baseRef),
+        config: workspaceConfig(worktreeParentDir),
+        issue: { id: "issue-a", identifier: "PAP-3", title: "Persisted issue" },
+        agent: { id: "agent-a", name: "Agent A", companyId: "company-1" },
+      });
+      expect(await runGitOutput(workspace.worktreePath!, ["config", "--worktree", "user.email"]))
+        .toBe("agent-a@agents.paperclip.local");
+
+      const restored = await ensurePersistedExecutionWorkspaceAvailable({
+        base: workspaceBase(repoRoot, baseRef),
+        workspace: {
+          id: "execution-workspace-1",
+          mode: "task_session",
+          strategyType: "git_worktree",
+          cwd: workspace.cwd,
+          providerRef: workspace.worktreePath,
+          projectId: "project-1",
+          projectWorkspaceId: "workspace-1",
+          repoUrl: null,
+          baseRef,
+          branchName: workspace.branchName,
+          metadata: null,
+          config: null,
+        },
+        issue: { id: "issue-a", identifier: "PAP-3", title: "Persisted issue" },
+        agent: { id: "agent-b", name: "Agent B", companyId: "company-1" },
+      });
+
+      expect(restored?.worktreePath).toBe(workspace.worktreePath);
+      await expect(runGitOutput(workspace.worktreePath!, ["config", "--worktree", "user.email"]))
+        .resolves.toBe("agent-b@agents.paperclip.local");
+      await expect(commitFromWorktree(workspace.worktreePath!, "agent-b.txt"))
+        .resolves.toBe("Agent B <agent-b@agents.paperclip.local>");
+    } finally {
+      await fs.rm(worktreeParentDir, { recursive: true, force: true });
+      await fs.rm(repoRoot, { recursive: true, force: true });
+    }
+  });
+});
 
 function buildAgent(adapterType: string, runtimeConfig: Record<string, unknown> = {}) {
   return {

--- a/server/src/__tests__/heartbeat-workspace-session.test.ts
+++ b/server/src/__tests__/heartbeat-workspace-session.test.ts
@@ -249,6 +249,9 @@ describe("execution workspace git identity", () => {
       expect(await runGitOutput(workspace.worktreePath!, ["config", "--worktree", "user.email"]))
         .toBe("agent-a@agents.paperclip.local");
 
+      await fs.rm(workspace.worktreePath!, { recursive: true, force: true });
+      await runGit(repoRoot, ["worktree", "prune"]);
+
       const restored = await ensurePersistedExecutionWorkspaceAvailable({
         base: workspaceBase(repoRoot, baseRef),
         workspace: {

--- a/server/src/__tests__/workspace-runtime.test.ts
+++ b/server/src/__tests__/workspace-runtime.test.ts
@@ -876,7 +876,7 @@ describe("realizeExecutionWorkspace", () => {
     const expectedWorktreePath = await fs.realpath(existingWorktree);
     expect(realized.created).toBe(false);
     await expect(fs.realpath(realized.cwd)).resolves.toBe(expectedWorktreePath);
-    expect(operations).toHaveLength(1);
+    expect(operations).toHaveLength(4);
     expect(operations[0]?.phase).toBe("worktree_prepare");
     expect(operations[0]?.command).toBeNull();
     expect(operations[0]?.metadata).toMatchObject({
@@ -885,6 +885,11 @@ describe("realizeExecutionWorkspace", () => {
       reused: true,
       worktreePath: expectedWorktreePath,
     });
+    expect(operations.slice(1).map((operation) => operation.command)).toEqual([
+      "git config extensions.worktreeConfig true",
+      'git config --worktree user.name "Codex Coder"',
+      'git config --worktree user.email "agent-1@agents.paperclip.local"',
+    ]);
   });
 
   it("slugifies unsafe issue titles for branch names and worktree folders", async () => {
@@ -1874,6 +1879,9 @@ describe("realizeExecutionWorkspace", () => {
 
     expect(operations.map((operation) => operation.phase)).toEqual([
       "worktree_prepare",
+      "worktree_prepare",
+      "worktree_prepare",
+      "worktree_prepare",
       "workspace_provision",
     ]);
     expect(operations[0]?.command).toContain("git worktree add");
@@ -1881,7 +1889,12 @@ describe("realizeExecutionWorkspace", () => {
       branchName: "PAP-540-record-workspace-operations",
       created: true,
     });
-    expect(operations[1]?.command).toBe("bash ./scripts/provision.sh");
+    expect(operations.slice(1, 4).map((operation) => operation.command)).toEqual([
+      "git config extensions.worktreeConfig true",
+      'git config --worktree user.name "Codex Coder"',
+      'git config --worktree user.email "agent-1@agents.paperclip.local"',
+    ]);
+    expect(operations[4]?.command).toBe("bash ./scripts/provision.sh");
   });
 
   it("truncates oversized provision command output before storing it in memory", async () => {

--- a/server/src/__tests__/workspace-runtime.test.ts
+++ b/server/src/__tests__/workspace-runtime.test.ts
@@ -2076,6 +2076,75 @@ describe("realizeExecutionWorkspace", () => {
     expect(actualHead).toBe(expectedHead);
   }, 15_000);
 
+  it("stamps the reattaching agent's git identity when a missing persisted git worktree is re-added", async () => {
+    const repoRoot = await createTempRepo();
+    const agentA = { id: "agent-a", name: "Agent Alpha", companyId: "company-1" };
+    const agentB = { id: "agent-b", name: "Agent Beta", companyId: "company-1" };
+
+    const initial = await realizeExecutionWorkspace({
+      base: {
+        baseCwd: repoRoot,
+        source: "project_primary",
+        projectId: "project-1",
+        workspaceId: "workspace-1",
+        repoUrl: null,
+        repoRef: "HEAD",
+      },
+      config: {
+        workspaceStrategy: {
+          type: "git_worktree",
+          branchTemplate: "{{issue.identifier}}-{{slug}}",
+        },
+      },
+      issue: {
+        id: "issue-1",
+        identifier: "PAP-453",
+        title: "Restore identity test",
+      },
+      agent: agentA,
+    });
+
+    await fs.rm(initial.cwd, { recursive: true, force: true });
+
+    const restored = await ensurePersistedExecutionWorkspaceAvailable({
+      base: {
+        baseCwd: repoRoot,
+        source: "project_primary",
+        projectId: "project-1",
+        workspaceId: "workspace-1",
+        repoUrl: null,
+        repoRef: "HEAD",
+      },
+      workspace: {
+        mode: "isolated_workspace",
+        strategyType: "git_worktree",
+        cwd: initial.cwd,
+        providerRef: initial.worktreePath,
+        projectId: "project-1",
+        projectWorkspaceId: "workspace-1",
+        repoUrl: null,
+        baseRef: "HEAD",
+        branchName: initial.branchName,
+        config: {},
+      },
+      issue: {
+        id: "issue-1",
+        identifier: "PAP-453",
+        title: "Restore identity test",
+      },
+      agent: agentB,
+    });
+
+    expect(restored).not.toBeNull();
+
+    await fs.writeFile(path.join(restored!.cwd, "probe.txt"), "identity check\n", "utf8");
+    await runGit(restored!.cwd, ["add", "probe.txt"]);
+    await runGit(restored!.cwd, ["commit", "-m", "identity probe"]);
+
+    const commitEmail = await readGit(restored!.cwd, ["log", "-1", "--format=%ae"]);
+    expect(commitEmail).toBe("agent-b@agents.paperclip.local");
+  }, 15_000);
+
   it("repairs a clean persisted git worktree branch mismatch when both branches point at the same commit", async () => {
     const repoRoot = await createTempRepo();
     const expectedBranch = "PAP-454-repair-clean-branch-mismatch";

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -1818,6 +1818,15 @@ function readNonEmptyString(value: unknown): string | null {
   return typeof value === "string" && value.trim().length > 0 ? value : null;
 }
 
+function resolveAgentGitEmail(agent: { runtimeConfig?: unknown; metadata?: unknown }): string | null {
+  const runtimeConfig = parseObject(agent.runtimeConfig);
+  const metadata = parseObject(agent.metadata);
+  return readNonEmptyString(runtimeConfig.gitEmail)
+    ?? readNonEmptyString(runtimeConfig.git_email)
+    ?? readNonEmptyString(metadata.gitEmail)
+    ?? readNonEmptyString(metadata.git_email);
+}
+
 function readModelProfileKey(value: unknown): ModelProfileKey | null {
   return MODEL_PROFILE_KEYS.includes(value as ModelProfileKey)
     ? (value as ModelProfileKey)
@@ -10236,6 +10245,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             id: agent.id,
             name: agent.name,
             companyId: agent.companyId,
+            gitEmail: resolveAgentGitEmail(agent),
           },
           recorder: workspaceOperationRecorder,
         })
@@ -10248,6 +10258,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         id: agent.id,
         name: agent.name,
         companyId: agent.companyId,
+        gitEmail: resolveAgentGitEmail(agent),
       },
       recorder: workspaceOperationRecorder,
     });

--- a/server/src/services/workspace-runtime.ts
+++ b/server/src/services/workspace-runtime.ts
@@ -2078,6 +2078,13 @@ export async function ensurePersistedExecutionWorkspaceAvailable(input: {
     skipRefresh: true,
   });
 
+  await configureWorktreeGitIdentity({
+    repoRoot,
+    worktreePath,
+    agent: input.agent,
+    recorder: input.recorder ?? null,
+  });
+
   await provisionExecutionWorktree({
     strategy: {
       type: "git_worktree",

--- a/server/src/services/workspace-runtime.ts
+++ b/server/src/services/workspace-runtime.ts
@@ -58,6 +58,7 @@ export interface ExecutionWorkspaceAgentRef {
   id: string | null;
   name: string;
   companyId: string;
+  gitEmail?: string | null;
 }
 
 export interface RealizedExecutionWorkspace extends ExecutionWorkspaceInput {
@@ -375,6 +376,65 @@ function sanitizeSlugPart(value: string | null | undefined, fallback: string): s
     .replace(/-+/g, "-")
     .replace(/^[-_]+|[-_]+$/g, "");
   return normalized.length > 0 ? normalized : fallback;
+}
+
+function sanitizeGitEmailLocalPart(value: string | null | undefined, fallback: string): string {
+  const normalized = (value ?? "")
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9._+-]+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^[^a-z0-9]+|[^a-z0-9]+$/g, "");
+  return normalized.length > 0 ? normalized : fallback;
+}
+
+function resolveAgentGitIdentity(agent: ExecutionWorkspaceAgentRef) {
+  const name = agent.name.trim() || "Paperclip Agent";
+  const configuredEmail = agent.gitEmail?.trim();
+  const email = configuredEmail && configuredEmail.includes("@")
+    ? configuredEmail
+    : `${sanitizeGitEmailLocalPart(agent.id ?? agent.name, "agent")}@agents.paperclip.local`;
+  return { name, email };
+}
+
+async function configureWorktreeGitIdentity(input: {
+  repoRoot: string;
+  worktreePath: string;
+  agent: ExecutionWorkspaceAgentRef;
+  recorder?: WorkspaceOperationRecorder | null;
+}) {
+  const identity = resolveAgentGitIdentity(input.agent);
+  const metadata = {
+    repoRoot: input.repoRoot,
+    worktreePath: input.worktreePath,
+    agentId: input.agent.id,
+    gitIdentity: identity,
+  };
+
+  await recordGitOperation(input.recorder, {
+    phase: "worktree_prepare",
+    args: ["config", "extensions.worktreeConfig", "true"],
+    cwd: input.repoRoot,
+    metadata,
+    successMessage: `Enabled worktree-local git config for ${input.worktreePath}\n`,
+    failureLabel: "git config extensions.worktreeConfig true",
+  });
+  await recordGitOperation(input.recorder, {
+    phase: "worktree_prepare",
+    args: ["config", "--worktree", "user.name", identity.name],
+    cwd: input.worktreePath,
+    metadata,
+    successMessage: `Configured worktree git user.name for ${input.worktreePath}\n`,
+    failureLabel: "git config --worktree user.name",
+  });
+  await recordGitOperation(input.recorder, {
+    phase: "worktree_prepare",
+    args: ["config", "--worktree", "user.email", identity.email],
+    cwd: input.worktreePath,
+    metadata,
+    successMessage: `Configured worktree git user.email for ${input.worktreePath}\n`,
+    failureLabel: "git config --worktree user.email",
+  });
 }
 
 function renderWorkspaceTemplate(template: string, input: {
@@ -1665,6 +1725,12 @@ export async function realizeExecutionWorkspace(input: {
         }),
       });
     }
+    await configureWorktreeGitIdentity({
+      repoRoot,
+      worktreePath: reusablePath,
+      agent: input.agent,
+      recorder: input.recorder ?? null,
+    });
     await provisionExecutionWorktree({
       strategy: rawStrategy,
       base: input.base,
@@ -1782,6 +1848,12 @@ export async function realizeExecutionWorkspace(input: {
       return await reuseExistingWorktree(reusablePath);
     }
   }
+  await configureWorktreeGitIdentity({
+    repoRoot,
+    worktreePath,
+    agent: input.agent,
+    recorder: input.recorder ?? null,
+  });
   await provisionExecutionWorktree({
     strategy: rawStrategy,
     base: input.base,
@@ -1889,6 +1961,12 @@ export async function ensurePersistedExecutionWorkspaceAvailable(input: {
         },
       );
     }
+    await configureWorktreeGitIdentity({
+      repoRoot,
+      worktreePath: reuseWorktreePath,
+      agent: input.agent,
+      recorder: input.recorder ?? null,
+    });
     const baseRefreshWarnings = reuseBaseRef
       ? await refreshRemoteTrackingBaseRef(repoRoot, reuseBaseRef)
       : [];


### PR DESCRIPTION
## Thinking Path

> - Paperclip manages AI agents that work in project repositories through execution workspaces.
> - The execution workspace runtime creates and reuses Git worktrees for issue-scoped agent work.
> - Git `user.name` and `user.email` currently come from the shared repository or global config unless a worktree overrides them.
> - When multiple agents share one repository, that mutable shared identity makes commit authorship unreliable and can bleed across concurrent worktrees.
> - Git supports worktree-local config through `extensions.worktreeConfig` plus `git config --worktree`, which is the narrowest mechanism that survives future shells in the same worktree.
> - This pull request stamps each execution worktree with the responsible agent's Git identity on create, reuse, persisted reuse, and restore paths.
> - The benefit is provable per-worktree authorship without depending on manual shell setup or per-run environment variables.

## Linked Issues or Issue Description

No public GitHub issue exists for this operator-reported bug.

Bug report:

- Summary: Execution worktrees inherit a shared Git identity, so commits made by different agents can appear under the same author.
- Current behavior: A commit created in an agent worktree falls back to repository/global `user.name` and `user.email` when that worktree has no local identity.
- Expected behavior: Each managed execution worktree records the responsible agent's distinct Git author identity and keeps it isolated from other worktrees.
- Impact: Review and merge workflows that rely on commit authorship can misidentify the author when several agents work from one shared checkout.
- Reproduction: Create two Git worktrees from one shared repository, commit in each without worktree-local identity, and compare `git log --format='%an <%ae>'`; both can show the same shared identity.

Related PR search performed:

- `gh pr list --repo paperclipai/paperclip --search "worktree git identity" --state all --limit 20`
- `gh pr list --repo paperclipai/paperclip --search "worktreeConfig" --state all --limit 20`
- Only the superseded PR #8944 matched this exact change.

## What Changed

- Added agent Git identity resolution for execution workspaces, including configured `gitEmail` support and deterministic fallback email generation.
- Configured Git worktree-local identity with `extensions.worktreeConfig` and `git config --worktree user.name/user.email`.
- Applied identity stamping on fresh worktree creation, reusable worktrees, persisted-workspace reuse, and missing-worktree restore.
- Added regression coverage for two-worktree identity isolation and restore-path identity stamping.

## Verification

- `pnpm vitest run server/src/__tests__/heartbeat-workspace-session.test.ts` passed, 108 tests.
- `pnpm --filter @paperclipai/server typecheck` passed.
- Two-worktree / two-identity / zero-bleed proof attached on the operator issue: `/api/attachments/403de624-730c-48e1-83ee-c671bb4d3930/content`.
- Independent reviewer re-ran the two restore-path tests at `dda9efe8f`: 2 passed.

## Risks

- Low runtime risk: this only changes managed Git worktree setup and does not alter customer-facing behavior.
- The shared repo config write for `extensions.worktreeConfig` is idempotent, but concurrent first-time enables can still contend on Git's config lock. The failure mode is a clean setup error, not wrong authorship.
- Existing primary-checkout commits are not covered; this fix covers managed `git_worktree` execution paths.
- Live operator rollout is separate from this upstream PR.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

OpenAI GPT-5 Codex assisted the implementation and PR preparation with shell and GitHub CLI tool use. Claude Sonnet 4.6 reviewers provided independent Paperclip-thread review before PR creation.

## Internal Review Record

Peer reviewers: FoundingEng, AdversarialEng.

- FoundingEng sign-off (initial): /ALM/issues/ALM-3280#comment-3d70c584-895f-4cb8-84b0-90ddf1d6c8e9
- FoundingEng sign-off (current-head eb544e115): /ALM/issues/ALM-3302#comment-20f5bd19-3edd-470a-b4bb-2f2a5c8f4e30
- AdversarialEng sign-off (initial): /ALM/issues/ALM-3281#comment-e294fc5d-83cc-45c9-b4b1-10356c96a027
- AdversarialEng sign-off (current-head eb544e115): /ALM/issues/ALM-3303#comment-ec8fbaad-d065-4ac7-b860-2308f63a72ff
- CEO Paperclip-boundary approval: /ALM/issues/ALM-3260#comment-f2484f9f-2be4-4596-9a0b-8a1b8d72e97d

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [ ] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge