### PR TITLE
fix: guard routine heartbeats from dirty checkout pulls

### DIFF
--- a/server/src/__tests__/heartbeat-workspace-session.test.ts
+++ b/server/src/__tests__/heartbeat-workspace-session.test.ts
@@ -528,19 +528,30 @@ describe("assertRoutineDirtyCheckoutGuardValid", () => {
   it("rejects routine heartbeats when tracked local edits would block git pull origin master", async () => {
     const fixture = await createDirtyGuardFixture();
     try {
+      const localHead = await execFile("git", ["rev-parse", "HEAD"], { cwd: fixture.checkout })
+        .then((result) => result.stdout.trim());
+      const upstreamHead = await execFile("git", ["rev-parse", "HEAD"], { cwd: fixture.seed })
+        .then((result) => result.stdout.trim());
       const localContent = "base instructions\nlocal unsaved edit\n";
       await fs.writeFile(path.join(fixture.checkout, "AGENTS.md"), localContent, "utf8");
       await fs.writeFile(path.join(fixture.checkout, "README.md"), "base readme\nlocal-only edit\n", "utf8");
 
-      await expect(assertRoutineDirtyCheckoutGuardValid({
-        adapterType: "codex_local",
-        issue: {
-          id: "issue-1",
-          identifier: "PAP-1",
-          originKind: "routine_execution",
-        },
-        cwd: fixture.checkout,
-      })).rejects.toMatchObject({
+      let failure: unknown;
+      try {
+        await assertRoutineDirtyCheckoutGuardValid({
+          adapterType: "codex_local",
+          issue: {
+            id: "issue-1",
+            identifier: "PAP-1",
+            originKind: "routine_execution",
+          },
+          cwd: fixture.checkout,
+        });
+      } catch (error) {
+        failure = error;
+      }
+
+      expect(failure).toMatchObject({
         code: "workspace_validation_failed",
         message: expect.stringContaining("AGENTS.md"),
         resultJson: {
@@ -550,9 +561,13 @@ describe("assertRoutineDirtyCheckoutGuardValid", () => {
             issueId: "issue-1",
             executionWorkspaceCwd: fixture.checkout,
             blockingFiles: ["AGENTS.md"],
+            localHead,
+            upstreamHead,
           }),
         },
       });
+      expect(failure).toMatchObject({ message: expect.stringContaining(localHead) });
+      expect(failure).toMatchObject({ message: expect.stringContaining(upstreamHead) });
 
       await expect(fs.readFile(path.join(fixture.checkout, "AGENTS.md"), "utf8"))
         .resolves.toBe(localContent);

--- a/server/src/__tests__/heartbeat-workspace-session.test.ts
+++ b/server/src/__tests__/heartbeat-workspace-session.test.ts
@@ -11,6 +11,7 @@ import {
   applyPersistedExecutionWorkspaceConfig,
   assertGitSensitiveAdapterWorkspaceValid,
   assertPushCapabilityCheckoutValid,
+  assertRoutineDirtyCheckoutGuardValid,
   buildExplicitResumeSessionOverride,
   buildEffectiveRunSessionConfigMetadata,
   buildEffectiveRunWorkspaceConfigMetadata,
@@ -130,6 +131,36 @@ async function createGitCheckout(options: { withRemote: boolean }) {
     await runGit(root, ["remote", "add", "origin", "https://github.com/example/repo.git"]);
   }
   return root;
+}
+
+async function createDirtyGuardFixture() {
+  const remote = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-dirty-remote-"));
+  const seed = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-dirty-seed-"));
+  const checkout = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-dirty-checkout-"));
+
+  await runGit(remote, ["init", "--bare"]);
+  await runGit(seed, ["init"]);
+  await runGit(seed, ["config", "user.email", "paperclip-test@example.com"]);
+  await runGit(seed, ["config", "user.name", "Paperclip Test"]);
+  await fs.writeFile(path.join(seed, "AGENTS.md"), "base instructions\n", "utf8");
+  await fs.writeFile(path.join(seed, "README.md"), "base readme\n", "utf8");
+  await runGit(seed, ["add", "AGENTS.md", "README.md"]);
+  await runGit(seed, ["commit", "-m", "initial"]);
+  await runGit(seed, ["branch", "-M", "master"]);
+  await runGit(seed, ["remote", "add", "origin", remote]);
+  await runGit(seed, ["push", "-u", "origin", "master"]);
+
+  await fs.rm(checkout, { recursive: true, force: true });
+  await execFile("git", ["clone", remote, checkout]);
+  await runGit(checkout, ["config", "user.email", "paperclip-test@example.com"]);
+  await runGit(checkout, ["config", "user.name", "Paperclip Test"]);
+
+  await fs.writeFile(path.join(seed, "AGENTS.md"), "base instructions\nupstream change\n", "utf8");
+  await runGit(seed, ["add", "AGENTS.md"]);
+  await runGit(seed, ["commit", "-m", "upstream agents change"]);
+  await runGit(seed, ["push", "origin", "master"]);
+
+  return { remote, seed, checkout };
 }
 
 async function expectWorkspaceValidationFailure(
@@ -489,6 +520,97 @@ describe("assertPushCapabilityCheckoutValid", () => {
       })).resolves.toBeUndefined();
     } finally {
       await fs.rm(cwd, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("assertRoutineDirtyCheckoutGuardValid", () => {
+  it("rejects routine heartbeats when tracked local edits would block git pull origin master", async () => {
+    const fixture = await createDirtyGuardFixture();
+    try {
+      const localContent = "base instructions\nlocal unsaved edit\n";
+      await fs.writeFile(path.join(fixture.checkout, "AGENTS.md"), localContent, "utf8");
+      await fs.writeFile(path.join(fixture.checkout, "README.md"), "base readme\nlocal-only edit\n", "utf8");
+
+      await expect(assertRoutineDirtyCheckoutGuardValid({
+        adapterType: "codex_local",
+        issue: {
+          id: "issue-1",
+          identifier: "PAP-1",
+          originKind: "routine_execution",
+        },
+        cwd: fixture.checkout,
+      })).rejects.toMatchObject({
+        code: "workspace_validation_failed",
+        message: expect.stringContaining("AGENTS.md"),
+        resultJson: {
+          workspaceValidation: expect.objectContaining({
+            reason: "dirty_checkout_blocks_git_pull",
+            adapterType: "codex_local",
+            issueId: "issue-1",
+            executionWorkspaceCwd: fixture.checkout,
+            blockingFiles: ["AGENTS.md"],
+          }),
+        },
+      });
+
+      await expect(fs.readFile(path.join(fixture.checkout, "AGENTS.md"), "utf8"))
+        .resolves.toBe(localContent);
+      await expect(fs.readFile(path.join(fixture.checkout, "README.md"), "utf8"))
+        .resolves.toBe("base readme\nlocal-only edit\n");
+    } finally {
+      await fs.rm(fixture.checkout, { recursive: true, force: true });
+      await fs.rm(fixture.seed, { recursive: true, force: true });
+      await fs.rm(fixture.remote, { recursive: true, force: true });
+    }
+  });
+
+  it("allows a clean routine checkout that is behind origin master without pulling it forward", async () => {
+    const fixture = await createDirtyGuardFixture();
+    try {
+      const headBefore = await execFile("git", ["rev-parse", "HEAD"], { cwd: fixture.checkout })
+        .then((result) => result.stdout.trim());
+
+      await expect(assertRoutineDirtyCheckoutGuardValid({
+        adapterType: "codex_local",
+        issue: {
+          id: "issue-1",
+          identifier: "PAP-1",
+          originKind: "routine_execution",
+        },
+        cwd: fixture.checkout,
+      })).resolves.toBeUndefined();
+
+      const headAfter = await execFile("git", ["rev-parse", "HEAD"], { cwd: fixture.checkout })
+        .then((result) => result.stdout.trim());
+      expect(headAfter).toBe(headBefore);
+      await expect(fs.readFile(path.join(fixture.checkout, "AGENTS.md"), "utf8"))
+        .resolves.toBe("base instructions\n");
+    } finally {
+      await fs.rm(fixture.checkout, { recursive: true, force: true });
+      await fs.rm(fixture.seed, { recursive: true, force: true });
+      await fs.rm(fixture.remote, { recursive: true, force: true });
+    }
+  });
+
+  it("does not apply the dirty checkout guard to non-routine issue heartbeats", async () => {
+    const fixture = await createDirtyGuardFixture();
+    try {
+      await fs.writeFile(path.join(fixture.checkout, "AGENTS.md"), "base instructions\nlocal unsaved edit\n", "utf8");
+
+      await expect(assertRoutineDirtyCheckoutGuardValid({
+        adapterType: "codex_local",
+        issue: {
+          id: "issue-1",
+          identifier: "PAP-1",
+          originKind: "manual",
+        },
+        cwd: fixture.checkout,
+      })).resolves.toBeUndefined();
+    } finally {
+      await fs.rm(fixture.checkout, { recursive: true, force: true });
+      await fs.rm(fixture.seed, { recursive: true, force: true });
+      await fs.rm(fixture.remote, { recursive: true, force: true });
     }
   });
 });

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -1294,47 +1294,58 @@ function formatBlockingFiles(files: string[]) {
   return `${shown.map((file) => `\`${file}\``).join(", ")}${suffix}`;
 }
 
+async function readGitRevision(cwd: string, ref: string) {
+  return runGitForDirtyCheckoutGuard(cwd, ["rev-parse", "--verify", ref])
+    .then((result) => readNonEmptyString(result.stdout.trim()))
+    .catch(() => null);
+}
+
 export async function inspectDirtyCheckoutPullBlockers(input: {
   cwd: string | null | undefined;
 }): Promise<{
   checked: boolean;
   blockingFiles: string[];
   reason: string | null;
+  localHead: string | null;
+  upstreamHead: string | null;
 }> {
   const cwd = readNonEmptyString(input.cwd);
-  if (!cwd) return { checked: false, blockingFiles: [], reason: "missing_cwd" };
+  if (!cwd) return { checked: false, blockingFiles: [], reason: "missing_cwd", localHead: null, upstreamHead: null };
   if (!await hasGitMetadata(cwd)) {
-    return { checked: false, blockingFiles: [], reason: "missing_git_metadata" };
+    return { checked: false, blockingFiles: [], reason: "missing_git_metadata", localHead: null, upstreamHead: null };
   }
 
   const insideWorkTree = await runGitForDirtyCheckoutGuard(cwd, ["rev-parse", "--is-inside-work-tree"])
     .then((result) => result.stdout.trim() === "true")
     .catch(() => false);
   if (!insideWorkTree) {
-    return { checked: false, blockingFiles: [], reason: "not_inside_work_tree" };
+    return { checked: false, blockingFiles: [], reason: "not_inside_work_tree", localHead: null, upstreamHead: null };
   }
 
+  const localHead = await readGitRevision(cwd, "HEAD");
   const dirtyFiles = uniqueSorted([
-    ...await listGitFiles(cwd, ["diff", "--name-only", "HEAD", "--"]),
-    ...await listGitFiles(cwd, ["diff", "--name-only", "--cached", "--"]),
+    ...await listGitFiles(cwd, ["diff", "--name-only", "HEAD", "--"]).catch(() => []),
+    ...await listGitFiles(cwd, ["diff", "--name-only", "--cached", "--"]).catch(() => []),
   ]);
   if (dirtyFiles.length === 0) {
-    return { checked: true, blockingFiles: [], reason: null };
+    return { checked: true, blockingFiles: [], reason: null, localHead, upstreamHead: null };
   }
 
+  // The manager startup command this protects is intentionally `git pull origin master`.
   const fetch = await runGitForDirtyCheckoutGuard(cwd, ["fetch", "--no-tags", "origin", "master"])
     .catch((error) => ({ error }));
   if ("error" in fetch) {
     const reason = fetch.error instanceof Error ? fetch.error.message : String(fetch.error);
-    return { checked: false, blockingFiles: [], reason: `fetch_failed: ${reason}` };
+    return { checked: false, blockingFiles: [], reason: `fetch_failed: ${reason}`, localHead, upstreamHead: null };
   }
 
+  const upstreamHead = await readGitRevision(cwd, "FETCH_HEAD");
   const upstreamFiles = new Set(
     await listGitFiles(cwd, ["diff", "--name-only", "HEAD", "FETCH_HEAD", "--"])
       .catch(() => []),
   );
   const blockingFiles = dirtyFiles.filter((file) => upstreamFiles.has(file));
-  return { checked: true, blockingFiles, reason: null };
+  return { checked: true, blockingFiles, reason: null, localHead, upstreamHead };
 }
 
 export async function assertRoutineDirtyCheckoutGuardValid(input: {
@@ -1354,7 +1365,7 @@ export async function assertRoutineDirtyCheckoutGuardValid(input: {
   const cwd = readNonEmptyString(input.cwd);
   const blockingFiles = uniqueSorted(inspection.blockingFiles);
   throw new WorkspaceValidationFailure(
-    `Issue ${input.issue.identifier ?? input.issue.id} is a routine heartbeat, but checkout "${cwd}" has tracked local modifications that would be overwritten by \`git pull origin master\`: ${formatBlockingFiles(blockingFiles)}. Resolve or move the existing work first; Paperclip will not stash, reset, delete, or overwrite unknown edits.`,
+    `Issue ${input.issue.identifier ?? input.issue.id} is a routine heartbeat, but checkout "${cwd}" has tracked local modifications that would be overwritten by \`git pull origin master\`: ${formatBlockingFiles(blockingFiles)}. Current HEAD: ${inspection.localHead ?? "unknown"}; origin/master: ${inspection.upstreamHead ?? "unknown"}. Resolve or move the existing work first; Paperclip will not stash, reset, delete, or overwrite unknown edits.`,
     {
       workspaceValidation: {
         reason: "dirty_checkout_blocks_git_pull",
@@ -1364,6 +1375,8 @@ export async function assertRoutineDirtyCheckoutGuardValid(input: {
         executionWorkspaceCwd: cwd,
         blockingFiles,
         checked: inspection.checked,
+        localHead: inspection.localHead,
+        upstreamHead: inspection.upstreamHead,
       },
     },
   );

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -228,6 +228,8 @@ const MAX_LIVE_LOG_CHUNK_BYTES = 8 * 1024;
 const MAX_PERSISTED_LOG_CHUNK_CHARS = 64 * 1024;
 const MAX_RUN_EVENT_PAYLOAD_STRING_CHARS = 16 * 1024;
 const MAX_RUN_EVENT_PAYLOAD_ARRAY_ITEMS = 50;
+const DIRTY_CHECKOUT_GUARD_MAX_FILES = 25;
+const DIRTY_CHECKOUT_GUARD_GIT_TIMEOUT_MS = 20_000;
 
 export function redactDetectedSuccessfulRunProgressSummaryForBoard(
   summary: string,
@@ -1265,6 +1267,108 @@ async function hasGitPushRemote(cwd: string | null | undefined) {
   return false;
 }
 
+async function runGitForDirtyCheckoutGuard(cwd: string, args: string[]) {
+  return execFile("git", args, {
+    cwd,
+    env: sanitizeRuntimeServiceBaseEnv(process.env),
+    timeout: DIRTY_CHECKOUT_GUARD_GIT_TIMEOUT_MS,
+  });
+}
+
+async function listGitFiles(cwd: string, args: string[]) {
+  const output = await runGitForDirtyCheckoutGuard(cwd, args);
+  return output.stdout
+    .split(/\r?\n/)
+    .map((value) => value.trim())
+    .filter((value) => value.length > 0);
+}
+
+function uniqueSorted(values: Iterable<string>) {
+  return [...new Set(values)].sort((a, b) => a.localeCompare(b));
+}
+
+function formatBlockingFiles(files: string[]) {
+  const shown = files.slice(0, DIRTY_CHECKOUT_GUARD_MAX_FILES);
+  const remaining = files.length - shown.length;
+  const suffix = remaining > 0 ? ` and ${remaining} more` : "";
+  return `${shown.map((file) => `\`${file}\``).join(", ")}${suffix}`;
+}
+
+export async function inspectDirtyCheckoutPullBlockers(input: {
+  cwd: string | null | undefined;
+}): Promise<{
+  checked: boolean;
+  blockingFiles: string[];
+  reason: string | null;
+}> {
+  const cwd = readNonEmptyString(input.cwd);
+  if (!cwd) return { checked: false, blockingFiles: [], reason: "missing_cwd" };
+  if (!await hasGitMetadata(cwd)) {
+    return { checked: false, blockingFiles: [], reason: "missing_git_metadata" };
+  }
+
+  const insideWorkTree = await runGitForDirtyCheckoutGuard(cwd, ["rev-parse", "--is-inside-work-tree"])
+    .then((result) => result.stdout.trim() === "true")
+    .catch(() => false);
+  if (!insideWorkTree) {
+    return { checked: false, blockingFiles: [], reason: "not_inside_work_tree" };
+  }
+
+  const dirtyFiles = uniqueSorted([
+    ...await listGitFiles(cwd, ["diff", "--name-only", "HEAD", "--"]),
+    ...await listGitFiles(cwd, ["diff", "--name-only", "--cached", "--"]),
+  ]);
+  if (dirtyFiles.length === 0) {
+    return { checked: true, blockingFiles: [], reason: null };
+  }
+
+  const fetch = await runGitForDirtyCheckoutGuard(cwd, ["fetch", "--no-tags", "origin", "master"])
+    .catch((error) => ({ error }));
+  if ("error" in fetch) {
+    const reason = fetch.error instanceof Error ? fetch.error.message : String(fetch.error);
+    return { checked: false, blockingFiles: [], reason: `fetch_failed: ${reason}` };
+  }
+
+  const upstreamFiles = new Set(
+    await listGitFiles(cwd, ["diff", "--name-only", "HEAD", "FETCH_HEAD", "--"])
+      .catch(() => []),
+  );
+  const blockingFiles = dirtyFiles.filter((file) => upstreamFiles.has(file));
+  return { checked: true, blockingFiles, reason: null };
+}
+
+export async function assertRoutineDirtyCheckoutGuardValid(input: {
+  adapterType: string;
+  issue: {
+    id: string;
+    identifier: string | null;
+    originKind?: string | null;
+  } | null;
+  cwd: string | null | undefined;
+}) {
+  if (input.issue?.originKind !== "routine_execution") return;
+
+  const inspection = await inspectDirtyCheckoutPullBlockers({ cwd: input.cwd });
+  if (inspection.blockingFiles.length === 0) return;
+
+  const cwd = readNonEmptyString(input.cwd);
+  const blockingFiles = uniqueSorted(inspection.blockingFiles);
+  throw new WorkspaceValidationFailure(
+    `Issue ${input.issue.identifier ?? input.issue.id} is a routine heartbeat, but checkout "${cwd}" has tracked local modifications that would be overwritten by \`git pull origin master\`: ${formatBlockingFiles(blockingFiles)}. Resolve or move the existing work first; Paperclip will not stash, reset, delete, or overwrite unknown edits.`,
+    {
+      workspaceValidation: {
+        reason: "dirty_checkout_blocks_git_pull",
+        adapterType: input.adapterType,
+        issueId: input.issue.id,
+        issueIdentifier: input.issue.identifier,
+        executionWorkspaceCwd: cwd,
+        blockingFiles,
+        checked: inspection.checked,
+      },
+    },
+  );
+}
+
 export async function assertPushCapabilityCheckoutValid(input: {
   enabled: boolean;
   issue: {
@@ -1299,6 +1403,7 @@ export async function assertGitSensitiveAdapterWorkspaceValid(input: {
     identifier: string | null;
     projectId: string | null;
     projectWorkspaceId: string | null;
+    originKind?: string | null;
   } | null;
   resolvedWorkspace: ResolvedWorkspaceForRun;
   executionWorkspace: RealizedExecutionWorkspace;
@@ -10853,6 +10958,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
               identifier: issueRef.identifier,
               projectId: issueRef.projectId,
               projectWorkspaceId: issueRef.projectWorkspaceId,
+              originKind: issueContext?.originKind ?? null,
             }
           : null,
         resolvedWorkspace,
@@ -10861,6 +10967,17 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         executionTarget,
         environmentDriver: selectedEnvironment.driver,
         leaseMetadata: activeEnvironmentLease.lease.metadata,
+      });
+      await assertRoutineDirtyCheckoutGuardValid({
+        adapterType: agent.adapterType,
+        issue: issueRef
+          ? {
+              id: issueRef.id,
+              identifier: issueRef.identifier,
+              originKind: issueContext?.originKind ?? null,
+            }
+          : null,
+        cwd: executionWorkspace.cwd,
       });
       await assertPushCapabilityCheckoutValid({
         enabled: pushCapabilityPreflightRequired && executionTarget?.kind === "local",


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Scheduled routines run manager-style heartbeat jobs that often start by trusting repo-local instructions and intel files.
> - Those routines can execute in shared local checkouts, where another human or agent may already have tracked edits.
> - A prompt-level `git checkout master; git pull origin master` is not enough when tracked edits would be overwritten by the pull, because the run can continue from stale code after the git command fails.
> - The control plane needs to detect that checkout state before launching the adapter, without stashing, resetting, deleting, or overwriting unknown work.
> - This pull request adds a pre-adapter dirty-checkout guard for routine heartbeats and makes the refusal output actionable for operators.
> - The benefit is that manager routines fail loudly with blocking files and commit state instead of silently proceeding from stale repo state.

## Linked Issues or Issue Description

No public GitHub issue exists for this instance-discovered bug.

Bug description: scheduled manager routines can begin in a shared checkout with tracked local modifications. If `origin/master` has also changed one of those files, the routine's startup `git pull origin master` fails with a local-changes overwrite error, but the agent process may still continue using stale local files. Expected behavior is for Paperclip to gate the heartbeat before adapter execution, name the blocking files and commit state, and leave the workspace untouched.

Dedup search: searched open and closed GitHub PRs for `dirty checkout guard`; the only exact match is this PR (#8948). Related older workspace hygiene PRs do not implement this routine heartbeat guard.

## What Changed

- Added `inspectDirtyCheckoutPullBlockers()` and `assertRoutineDirtyCheckoutGuardValid()` in `heartbeat.ts`.
- Runs the guard before adapter execution for `routine_execution` issues only.
- Fetches `origin master` into Git metadata, compares tracked dirty files against files changed in `FETCH_HEAD`, and rejects only when the local edits would block the manager startup pull.
- Includes blocking files, current local `HEAD`, and fetched `origin/master` / `FETCH_HEAD` in the failure message and structured validation payload.
- Keeps the guard non-mutating: no stash, reset, checkout, untracked-file deletion, or working tree overwrite.
- Added integration coverage with a real bare remote and local checkout fixture for dirty, clean-behind, and non-routine paths.

## Verification

- `pnpm vitest run server/src/__tests__/heartbeat-workspace-session.test.ts` - 109 passed
- `pnpm --filter @paperclipai/server typecheck` - passed
- `git diff --check` - passed

## Risks

Low risk. The new guard is limited to routine execution issues and only blocks when tracked local modifications overlap files changed by the fetched `origin/master`. Fetch failures and unusual git diff failures fail open to avoid breaking heartbeats for checkouts the guard cannot inspect. The guard intentionally preserves the existing hardcoded startup target, `git pull origin master`, instead of inferring another remote or branch.

## Model Used

OpenAI GPT-5 Codex, tool-using coding agent in the Codex CLI environment.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

