### PR TITLE
[codex] fix outreach routine governance bootstrap

### DIFF
--- a/scripts/audit-outreach-routine-governance.mjs
+++ b/scripts/audit-outreach-routine-governance.mjs
@@ -1,0 +1,155 @@
+#!/usr/bin/env node
+
+const RR_COMPANY_ID = process.env.PAPERCLIP_COMPANY_ID || "0fabe377-3008-4cde-96ad-b1ae5eb5e469";
+const RR_OPERATIONS_PROJECT_ID = "8e99b255-02f1-401d-ab06-93cc8dc15552";
+const RR_OUTREACH_GO_LIVE_PROJECT_ID = "202c77b2-e2d0-4030-a416-e41fcf246a3e";
+const RR_AUTOMATE_LABEL_ID = "519fc58e-0411-4b5d-bdeb-02fb637e4f8f";
+const RR_OUTREACH_LABEL_ID = "7f4ac6f1-6e9e-472d-a751-899b6a0c16d1";
+const RR_CONTENT_LABEL_ID = "6c443851-fe4f-44e9-b11f-a4e2b9a4cbcd";
+const RR_CEO_AGENT_ID = "ce56f1d2-941d-42b1-a54b-fc99897d6e9e";
+const RR_OUTREACH_MANAGER_AGENT_ID = "c100bafe-c428-4e55-be99-0ec4ebaa32a0";
+
+const OUTREACH_DIRECT_REPORT_AGENT_IDS = new Set([
+  "e7651b93-a8ca-4c74-8ac0-2003678abb77",
+  "431f481e-ee9a-4bac-a38a-8076db805f09",
+  "a4a8d13b-3f28-49fb-b16e-78e5ba5a57f3",
+  "6962d181-7524-4a9b-a1a2-de5e7de1f7f1",
+  "e27b046d-6518-492c-99d6-d10ad8cdea63",
+  "7fd12a67-5597-4eba-ae75-e4c2aea9cb7c",
+]);
+const EXEMPT_TITLE_PREFIXES = ["Review productivity for", "[HOT LEAD]", "[INDUSTRY INTEL]", "Content idea:"];
+
+function parseArgs(argv) {
+  const args = { identifiers: [], dryRun: true };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--identifiers") {
+      args.identifiers = (argv[++i] || "").split(",").map((item) => item.trim()).filter(Boolean);
+    } else if (arg === "--apply") {
+      args.dryRun = false;
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+  if (args.identifiers.length === 0) {
+    args.identifiers = ["RR-4282", "RR-4265", "RR-4258"];
+  }
+  return args;
+}
+
+function executionPolicy(reviewerAgentId) {
+  return {
+    mode: "normal",
+    commentRequired: true,
+    stages: [{ type: "review", approvalsNeeded: 1, participants: [{ type: "agent", agentId: reviewerAgentId }] }],
+  };
+}
+
+function isExempt(title) {
+  return EXEMPT_TITLE_PREFIXES.some((prefix) => title.startsWith(prefix));
+}
+
+function isOutreachIssue(issue) {
+  if (issue.companyId && issue.companyId !== RR_COMPANY_ID) return false;
+  if (issue.originKind !== "routine_execution") return false;
+  if (isExempt(issue.title || "")) return false;
+  if (issue.assigneeAgentId === RR_OUTREACH_MANAGER_AGENT_ID) return true;
+  if (issue.assigneeAgentId && OUTREACH_DIRECT_REPORT_AGENT_IDS.has(issue.assigneeAgentId)) return true;
+  return /outreach manager/i.test(issue.title || "");
+}
+
+function expectedGovernance(issue) {
+  const text = `${issue.title || ""}\n${issue.description || ""}`.toLowerCase();
+  const isOrgProcess = /\b(self-improvement|self improvement|automation|automate|executionpolicy scan|policy scan|governance|audit)\b/.test(text);
+  const title = (issue.title || "").toLowerCase();
+  const isLinkedInContent = /\blinkedin\b/.test(title) && /\b(content|publish|post)\b/.test(title);
+  const reviewerAgentId = issue.assigneeAgentId === RR_OUTREACH_MANAGER_AGENT_ID || /outreach manager/i.test(issue.title || "")
+    ? RR_CEO_AGENT_ID
+    : RR_OUTREACH_MANAGER_AGENT_ID;
+  return {
+    projectId: isOrgProcess ? RR_OPERATIONS_PROJECT_ID : RR_OUTREACH_GO_LIVE_PROJECT_ID,
+    labelIds: [
+      ...(isOrgProcess ? [RR_AUTOMATE_LABEL_ID] : []),
+      RR_OUTREACH_LABEL_ID,
+      ...(isLinkedInContent ? [RR_CONTENT_LABEL_ID] : []),
+    ],
+    executionPolicy: executionPolicy(reviewerAgentId),
+  };
+}
+
+function policyReviewer(policy) {
+  return policy?.stages?.[0]?.participants?.[0]?.agentId ?? null;
+}
+
+function diff(issue) {
+  if (!isOutreachIssue(issue)) return null;
+  const expected = expectedGovernance(issue);
+  const patch = {};
+  const reasons = [];
+  if (!issue.executionPolicy) {
+    patch.executionPolicy = expected.executionPolicy;
+    reasons.push("executionPolicy missing");
+  }
+  if (issue.projectId !== expected.projectId) {
+    patch.projectId = expected.projectId;
+    reasons.push(`projectId ${issue.projectId || "missing"} != ${expected.projectId}`);
+  }
+  const actualLabels = new Set(issue.labelIds || []);
+  const missingLabels = expected.labelIds.filter((labelId) => !actualLabels.has(labelId));
+  if (missingLabels.length > 0) {
+    patch.labelIds = [...new Set([...(issue.labelIds || []), ...expected.labelIds])];
+    reasons.push(`labelIds missing ${missingLabels.join(",")}`);
+  }
+  return reasons.length > 0 ? { identifier: issue.identifier, id: issue.id, title: issue.title, reasons, patch, reviewer: policyReviewer(patch.executionPolicy ?? issue.executionPolicy) } : null;
+}
+
+async function api(path, options = {}) {
+  const baseUrl = process.env.PAPERCLIP_API_URL || process.env.PAPERCLIP_BASE_URL;
+  const token = process.env.PAPERCLIP_API_KEY;
+  if (!baseUrl || !token) {
+    throw new Error("PAPERCLIP_API_URL/PAPERCLIP_BASE_URL and PAPERCLIP_API_KEY are required");
+  }
+  const response = await fetch(`${baseUrl}${path}`, {
+    ...options,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+      ...(options.headers || {}),
+    },
+  });
+  if (!response.ok) {
+    throw new Error(`${options.method || "GET"} ${path} failed: ${response.status} ${await response.text()}`);
+  }
+  return response.json();
+}
+
+async function getIssueByIdentifier(identifier) {
+  const results = await api(`/api/companies/${RR_COMPANY_ID}/issues?q=${encodeURIComponent(identifier)}&limit=20`);
+  const match = results.find((issue) => issue.identifier === identifier);
+  if (!match) throw new Error(`Issue ${identifier} not found`);
+  return api(`/api/issues/${match.id}`);
+}
+
+const args = parseArgs(process.argv.slice(2));
+const issues = await Promise.all(args.identifiers.map(getIssueByIdentifier));
+const findings = issues.map(diff).filter(Boolean);
+
+console.log(`Outreach routine governance audit (${args.dryRun ? "dry-run" : "apply"})`);
+for (const finding of findings) {
+  console.log(`- ${finding.identifier}: ${finding.reasons.join("; ")}`);
+  console.log(`  expected reviewer: ${finding.reviewer || "unchanged"}`);
+  console.log(`  patch: ${JSON.stringify(finding.patch)}`);
+}
+if (findings.length === 0) {
+  console.log("No governance gaps found.");
+}
+
+if (!args.dryRun) {
+  for (const finding of findings) {
+    await api(`/api/issues/${finding.id}`, {
+      method: "PATCH",
+      body: JSON.stringify(finding.patch),
+    });
+    console.log(`patched ${finding.identifier}`);
+  }
+}

--- a/server/src/__tests__/routines-service.test.ts
+++ b/server/src/__tests__/routines-service.test.ts
@@ -15,8 +15,10 @@ import {
   heartbeatRuns,
   instanceSettings,
   issueInboxArchives,
+  issueLabels,
   issueReadStates,
   issues,
+  labels,
   projectWorkspaces,
   projects,
   routineDocuments,
@@ -34,6 +36,16 @@ import { instanceSettingsService } from "../services/instance-settings.ts";
 import * as providerRegistry from "../secrets/provider-registry.ts";
 import { routineService } from "../services/routines.ts";
 import { secretService } from "../services/secrets.ts";
+import {
+  RR_AUTOMATE_LABEL_ID,
+  RR_COMPANY_ID,
+  RR_CONTENT_LABEL_ID,
+  RR_OPERATIONS_PROJECT_ID,
+  RR_OUTREACH_GO_LIVE_PROJECT_ID,
+  RR_OUTREACH_LABEL_ID,
+  RR_OUTREACH_MANAGER_AGENT_ID,
+  RR_CEO_AGENT_ID,
+} from "../services/outreach-routine-governance.ts";
 
 const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
 const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
@@ -61,6 +73,7 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
       process.env.PAPERCLIP_SECRETS_PROVIDER = originalSecretsProviderEnv;
     }
     await db.delete(activityLog);
+    await db.delete(issueLabels);
     await db.delete(issueInboxArchives);
     await db.delete(issueReadStates);
     await db.delete(secretAccessEvents);
@@ -78,6 +91,7 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
     await db.delete(executionWorkspaces);
     await db.delete(projectWorkspaces);
     await db.delete(projects);
+    await db.delete(labels);
     await db.delete(agents);
     await db.delete(companies);
     await db.delete(instanceSettings);
@@ -967,6 +981,102 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
       includeRoutineExecutions: true,
     });
     expect(inboxIssues.map((issue) => issue.id)).toContain(previousIssue.id);
+  });
+
+  it("bootstraps governance fields on non-exempt RR Outreach routine execution issues", async () => {
+    const companyId = RR_COMPANY_ID;
+    const issuePrefix = "RR";
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "ReplenishRadar",
+      issuePrefix,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values([
+      {
+        id: RR_OUTREACH_MANAGER_AGENT_ID,
+        companyId,
+        name: "Riley - Outreach Manager",
+        role: "manager",
+        status: "active",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+      {
+        id: RR_CEO_AGENT_ID,
+        companyId,
+        name: "CEO",
+        role: "ceo",
+        status: "active",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+    ]);
+    await db.insert(projects).values([
+      { id: RR_OPERATIONS_PROJECT_ID, companyId, name: "Operations", status: "in_progress" },
+      { id: RR_OUTREACH_GO_LIVE_PROJECT_ID, companyId, name: "Outreach Go-Live", status: "in_progress" },
+    ]);
+    await db.insert(labels).values([
+      { id: RR_AUTOMATE_LABEL_ID, companyId, name: "automate", color: "#64748b" },
+      { id: RR_OUTREACH_LABEL_ID, companyId, name: "outreach", color: "#0f766e" },
+      { id: RR_CONTENT_LABEL_ID, companyId, name: "content", color: "#7c3aed" },
+    ]);
+
+    const wakeups: string[] = [];
+    const svc = routineService(db, {
+      heartbeat: {
+        wakeup: async (_agentId, wakeupOpts) => {
+          const issueId =
+            (typeof wakeupOpts.payload?.issueId === "string" && wakeupOpts.payload.issueId) ||
+            (typeof wakeupOpts.contextSnapshot?.issueId === "string" && wakeupOpts.contextSnapshot.issueId) ||
+            null;
+          if (issueId) wakeups.push(issueId);
+          return null;
+        },
+      },
+    });
+
+    const routine = await svc.create(companyId, {
+      projectId: RR_OPERATIONS_PROJECT_ID,
+      goalId: null,
+      parentIssueId: null,
+      title: "ICP Prospecting",
+      description: "Build the endless affiliate prospect list.",
+      assigneeAgentId: RR_OUTREACH_MANAGER_AGENT_ID,
+      priority: "medium",
+      status: "active",
+      concurrencyPolicy: "coalesce_if_active",
+      catchUpPolicy: "skip_missed",
+    }, {});
+
+    const run = await svc.runRoutine(routine.id, { source: "manual" });
+    expect(run.status).toBe("issue_created");
+    expect(wakeups).toEqual([run.linkedIssueId]);
+
+    const [created] = await db.select().from(issues).where(eq(issues.id, run.linkedIssueId!));
+    expect(created?.projectId).toBe(RR_OUTREACH_GO_LIVE_PROJECT_ID);
+    expect(created?.executionPolicy).toMatchObject({
+      mode: "normal",
+      commentRequired: true,
+      stages: [
+        {
+          type: "review",
+          approvalsNeeded: 1,
+          participants: [{ type: "agent", agentId: RR_CEO_AGENT_ID }],
+        },
+      ],
+    });
+
+    const linkedLabels = await db
+      .select({ labelId: issueLabels.labelId })
+      .from(issueLabels)
+      .where(eq(issueLabels.issueId, run.linkedIssueId!));
+    expect(linkedLabels.map((row) => row.labelId).sort()).toEqual([RR_OUTREACH_LABEL_ID].sort());
   });
 
   it("does not coalesce live routine runs with different resolved variables", async () => {

--- a/server/src/services/outreach-routine-governance.ts
+++ b/server/src/services/outreach-routine-governance.ts
@@ -1,0 +1,81 @@
+export const RR_COMPANY_ID = "0fabe377-3008-4cde-96ad-b1ae5eb5e469";
+export const RR_OPERATIONS_PROJECT_ID = "8e99b255-02f1-401d-ab06-93cc8dc15552";
+export const RR_OUTREACH_GO_LIVE_PROJECT_ID = "202c77b2-e2d0-4030-a416-e41fcf246a3e";
+export const RR_AUTOMATE_LABEL_ID = "519fc58e-0411-4b5d-bdeb-02fb637e4f8f";
+export const RR_OUTREACH_LABEL_ID = "7f4ac6f1-6e9e-472d-a751-899b6a0c16d1";
+export const RR_CONTENT_LABEL_ID = "6c443851-fe4f-44e9-b11f-a4e2b9a4cbcd";
+export const RR_CEO_AGENT_ID = "ce56f1d2-941d-42b1-a54b-fc99897d6e9e";
+export const RR_OUTREACH_MANAGER_AGENT_ID = "c100bafe-c428-4e55-be99-0ec4ebaa32a0";
+
+const RR_OUTREACH_DIRECT_REPORT_AGENT_IDS = new Set([
+  "e7651b93-a8ca-4c74-8ac0-2003678abb77",
+  "431f481e-ee9a-4bac-a38a-8076db805f09",
+  "a4a8d13b-3f28-49fb-b16e-78e5ba5a57f3",
+  "6962d181-7524-4a9b-a1a2-de5e7de1f7f1",
+  "e27b046d-6518-492c-99d6-d10ad8cdea63",
+  "7fd12a67-5597-4eba-ae75-e4c2aea9cb7c",
+]);
+
+const EXEMPT_TITLE_PREFIXES = [
+  "Review productivity for",
+  "[HOT LEAD]",
+  "[INDUSTRY INTEL]",
+  "Content idea:",
+];
+
+function standardReviewPolicy(reviewerAgentId: string): Record<string, unknown> {
+  return {
+    mode: "normal",
+    commentRequired: true,
+    stages: [
+      {
+        type: "review",
+        approvalsNeeded: 1,
+        participants: [{ type: "agent", agentId: reviewerAgentId }],
+      },
+    ],
+  };
+}
+
+export function isOutreachGovernanceExemptTitle(title: string) {
+  return EXEMPT_TITLE_PREFIXES.some((prefix) => title.startsWith(prefix));
+}
+
+export function isRrOutreachRoutineIssue(input: {
+  companyId: string;
+  title: string;
+  assigneeAgentId?: string | null;
+}) {
+  if (input.companyId !== RR_COMPANY_ID) return false;
+  if (isOutreachGovernanceExemptTitle(input.title)) return false;
+  if (input.assigneeAgentId === RR_OUTREACH_MANAGER_AGENT_ID) return true;
+  if (input.assigneeAgentId && RR_OUTREACH_DIRECT_REPORT_AGENT_IDS.has(input.assigneeAgentId)) return true;
+  return /outreach manager/i.test(input.title);
+}
+
+export function resolveRrOutreachRoutineGovernance(input: {
+  companyId: string;
+  title: string;
+  description?: string | null;
+  assigneeAgentId?: string | null;
+}) {
+  if (!isRrOutreachRoutineIssue(input)) return null;
+
+  const text = `${input.title}\n${input.description ?? ""}`.toLowerCase();
+  const isOrgProcess = /\b(self-improvement|self improvement|automation|automate|executionpolicy scan|policy scan|governance|audit)\b/.test(text);
+  const title = input.title.toLowerCase();
+  const isLinkedInContent = /\blinkedin\b/.test(title) && /\b(content|publish|post)\b/.test(title);
+  const reviewerAgentId = input.assigneeAgentId === RR_OUTREACH_MANAGER_AGENT_ID || /outreach manager/i.test(input.title)
+    ? RR_CEO_AGENT_ID
+    : RR_OUTREACH_MANAGER_AGENT_ID;
+
+  return {
+    projectId: isOrgProcess ? RR_OPERATIONS_PROJECT_ID : RR_OUTREACH_GO_LIVE_PROJECT_ID,
+    labelIds: [
+      ...(isOrgProcess ? [RR_AUTOMATE_LABEL_ID] : []),
+      RR_OUTREACH_LABEL_ID,
+      ...(isLinkedInContent ? [RR_CONTENT_LABEL_ID] : []),
+    ],
+    executionPolicy: standardReviewPolicy(reviewerAgentId),
+  };
+}

--- a/server/src/services/routines.ts
+++ b/server/src/services/routines.ts
@@ -58,6 +58,7 @@ import { getTelemetryClient } from "../telemetry.js";
 import { getConfiguredSecretProvider } from "../secrets/configured-provider.js";
 import { issueService } from "./issues.js";
 import { assertAssignableAgent } from "./agent-assignability.js";
+import { resolveRrOutreachRoutineGovernance } from "./outreach-routine-governance.js";
 import { secretService } from "./secrets.js";
 import { getSecretProvider } from "../secrets/provider-registry.js";
 import { parseCron, validateCron } from "./cron.js";
@@ -1437,6 +1438,13 @@ export function routineService(
     const description = [baseDescription, input.descriptionAppendix]
       .filter((part): part is string => Boolean(part && part.trim()))
       .join("\n\n");
+    const outreachGovernance = resolveRrOutreachRoutineGovernance({
+      companyId: input.routine.companyId,
+      title,
+      description,
+      assigneeAgentId,
+    });
+    const issueProjectId = outreachGovernance?.projectId ?? projectId ?? null;
     const triggerPayload = mergeRoutineRunPayload(input.payload, { ...automaticVariables, ...resolvedVariables });
     const managedRoutineBinding = await getManagedRoutineBinding(input.routine);
     const managedIssueTemplate = readManagedRoutineIssueTemplate(managedRoutineBinding?.defaultsJson);
@@ -1447,7 +1455,7 @@ export function routineService(
     const issueBillingCode = managedIssueTemplate?.billingCode ?? null;
     const dispatchFingerprint = createRoutineDispatchFingerprint({
       payload: triggerPayload,
-      projectId,
+      projectId: issueProjectId,
       projectWorkspaceId,
       assigneeAgentId,
       routineRevisionId: input.routine.latestRevisionId,
@@ -1540,7 +1548,7 @@ export function routineService(
 
         try {
           createdIssue = await issueSvc.create(input.routine.companyId, {
-            projectId,
+            projectId: issueProjectId,
             projectWorkspaceId,
             goalId: input.routine.goalId,
             parentId: input.routine.parentIssueId,
@@ -1559,6 +1567,12 @@ export function routineService(
             executionWorkspaceId: input.executionWorkspaceId ?? null,
             executionWorkspacePreference: input.executionWorkspacePreference ?? null,
             executionWorkspaceSettings: input.executionWorkspaceSettings ?? null,
+            ...(outreachGovernance
+              ? {
+                executionPolicy: outreachGovernance.executionPolicy,
+                labelIds: outreachGovernance.labelIds,
+              }
+              : {}),
           });
         } catch (error) {
           const isOpenExecutionConflict =


### PR DESCRIPTION
## Summary

- Add RR-scoped Outreach routine governance defaults for routine-created execution issues.
- Apply the default project, labels, and standard review policy during routine dispatch for non-exempt Outreach Manager / direct-report routine issues.
- Add a dry-run/apply audit script for recent Outreach routine governance gaps.
- Add an embedded Postgres regression test proving a routine with the wrong project creates an execution issue with the documented defaults.

## Root Cause

Routine dispatch created execution issues with the routine project only and never supplied labelIds or executionPolicy. Outreach routine prompts expected agents to patch those fields after wakeup, which let routine execution issues start with missing governance metadata.

## Verification

- `pnpm vitest run server/src/__tests__/routines-service.test.ts -t "bootstraps governance fields"`
- `pnpm --filter @paperclipai/server typecheck`
- `node scripts/audit-outreach-routine-governance.mjs --identifiers RR-4282,RR-4265,RR-4258`

Dry-run summary:

```
RR-4282: projectId missing; missing automate/outreach labels
RR-4265: projectId Operations != Outreach Go-Live; missing outreach label
RR-4258: executionPolicy missing; projectId missing; missing automate/outreach/content labels
```

Attempted `--apply` against the live RR issues, but the current agent token was correctly denied with `403 Issue is outside this actor authorization boundary`. The script remains apply-capable for an authorized actor.
