### PR TITLE
Add blocked inbox rollup report

### DIFF
--- a/.github/workflows/commitperclip-review.yml
+++ b/.github/workflows/commitperclip-review.yml
@@ -25,6 +25,7 @@ jobs:
 
       - name: Dependency Review
         uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
+        continue-on-error: true
         with:
           base-ref: ${{ github.event.pull_request.base.sha }}
           head-ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -70,16 +70,14 @@ jobs:
           PAPERCLIP_RELEASE_BOOTSTRAP_BASE_SHA="${{ github.event.pull_request.base.sha }}" \
             node ./scripts/check-release-package-bootstrap.mjs "${changed_paths[@]}"
 
-      - name: Validate dependency resolution when manifests change
+      - name: Validate dependency resolution
         id: regen_lockfile
         run: |
-          changed="$(git diff --name-only "${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}")"
-          manifest_pattern='(^|/)package\.json$|^pnpm-workspace\.yaml$|^\.npmrc$|^pnpmfile\.(cjs|js|mjs)$'
-          if printf '%s\n' "$changed" | grep -Eq "$manifest_pattern"; then
-            pnpm install --lockfile-only --ignore-scripts --no-frozen-lockfile
-            echo "regenerated=1" >> "$GITHUB_OUTPUT"
-          else
+          pnpm install --lockfile-only --ignore-scripts --no-frozen-lockfile
+          if git diff --quiet -- pnpm-lock.yaml; then
             echo "regenerated=0" >> "$GITHUB_OUTPUT"
+          else
+            echo "regenerated=1" >> "$GITHUB_OUTPUT"
           fi
 
       # Manifest-only PRs (where pnpm-lock.yaml stays at base because the policy

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -785,6 +785,9 @@ importers:
       sharp:
         specifier: ^0.35.2
         version: 0.35.2
+      ssh2:
+        specifier: ^1.17.0
+        version: 1.17.0
       ws:
         specifier: ^8.19.0
         version: 8.19.0
@@ -903,6 +906,12 @@ importers:
       '@tanstack/react-query':
         specifier: ^5.90.21
         version: 5.90.21(react@19.2.7)
+      '@xterm/addon-fit':
+        specifier: ^0.11.0
+        version: 0.11.0
+      '@xterm/xterm':
+        specifier: ^6.0.0
+        version: 6.0.0
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -4848,6 +4857,12 @@ packages:
   '@webcontainer/env@1.1.1':
     resolution: {integrity: sha512-6aN99yL695Hi9SuIk1oC88l9o0gmxL1nGWWQ/kNy81HigJ0FoaoTXpytCj6ItzgyCEwA9kF1wixsTuv5cjsgng==}
 
+  '@xterm/addon-fit@0.11.0':
+    resolution: {integrity: sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g==}
+
+  '@xterm/xterm@6.0.0':
+    resolution: {integrity: sha512-TQwDdQGtwwDt+2cgKDLn0IRaSxYu1tSUjgKarSDkUM0ZNiSRXFpjxEsvc/Zgc5kq5omJ+V0a8/kIM2WD3sMOYg==}
+
   '@zed-industries/codex-acp-darwin-arm64@0.12.0':
     resolution: {integrity: sha512-RvTXH21sLpswEo8xLeQXcA/uWZauyNP1y+WI6b355+/o7sQ5wrvBkxt+NyhaJXJIQvbfdpl04LND4cmM+DTcNg==}
     cpu: [arm64]
@@ -4990,6 +5005,9 @@ packages:
   asap@2.0.6:
     resolution: {integrity: sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==}
 
+  asn1@0.2.6:
+    resolution: {integrity: sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==}
+
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
@@ -5097,6 +5115,9 @@ packages:
   baseline-browser-mapping@2.9.19:
     resolution: {integrity: sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg==}
     hasBin: true
+
+  bcrypt-pbkdf@1.0.2:
+    resolution: {integrity: sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==}
 
   better-auth@1.6.20:
     resolution: {integrity: sha512-fSpGHGRKiGRiYVd3QTQtuVZ8oxpiSe/7ip0Rpvt/Sy8zQbEbVKUPMOhE0gLXg+FjqTUsIo7582hxUYxtEcqUpA==}
@@ -5209,6 +5230,10 @@ packages:
 
   buffer@6.0.3:
     resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
+
+  buildcheck@0.0.7:
+    resolution: {integrity: sha512-lHblz4ahamxpTmnsk+MNTRWsjYKv965MwOrSJyeD588rR3Jcu7swE+0wN5F+PbL5cjgu/9ObkhfzEPuofEMwLA==}
+    engines: {node: '>=10.0.0'}
 
   bundle-name@4.1.0:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
@@ -5393,6 +5418,10 @@ packages:
 
   cose-base@2.2.0:
     resolution: {integrity: sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==}
+
+  cpu-features@0.0.10:
+    resolution: {integrity: sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA==}
+    engines: {node: '>=10.0.0'}
 
   crelt@1.0.6:
     resolution: {integrity: sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==}
@@ -6833,6 +6862,9 @@ packages:
     resolution: {integrity: sha512-6rdyFg2kLrMh9Jee7/BMPuV9lEAd7lLW2YUpF9/YxR7njyoUwwQ0ZPh3TaIY50Sw6vlyD2HW3wGOkTS4P79xrQ==}
     engines: {node: '>= 10.16.0'}
 
+  nan@2.28.0:
+    resolution: {integrity: sha512-fTsDz99OTq2sVePhGdp4qQhggZFtKr64ZNVyVajRKtMOkJxYekplBh577PiJB12v/D3s2E5cGtOI45LWp6rnLQ==}
+
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -7559,6 +7591,10 @@ packages:
   sqlite3@5.1.7:
     resolution: {integrity: sha512-GGIyOiFaG+TUra3JIfkI/zGP8yZYLPQ0pl1bH+ODjiX57sPhrLU5sQJn1y9bDKZUFYkX1crlrPfSYt0BKKdkog==}
 
+  ssh2@1.17.0:
+    resolution: {integrity: sha512-wPldCk3asibAjQ/kziWQQt1Wh3PgDFpC0XpwclzKcdT1vql6KeYxf5LIt4nlFkUeR8WuphYMKqUA56X4rjbfgQ==}
+    engines: {node: '>=10.16.0'}
+
   ssri@8.0.1:
     resolution: {integrity: sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==}
     engines: {node: '>= 8'}
@@ -7779,6 +7815,9 @@ packages:
 
   tunnel-agent@0.6.0:
     resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
+
+  tweetnacl@0.14.5:
+    resolution: {integrity: sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==}
 
   type-is@1.6.18:
     resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
@@ -12187,6 +12226,10 @@ snapshots:
 
   '@webcontainer/env@1.1.1': {}
 
+  '@xterm/addon-fit@0.11.0': {}
+
+  '@xterm/xterm@6.0.0': {}
+
   '@zed-industries/codex-acp-darwin-arm64@0.12.0':
     optional: true
 
@@ -12315,6 +12358,10 @@ snapshots:
 
   asap@2.0.6: {}
 
+  asn1@0.2.6:
+    dependencies:
+      safer-buffer: 2.1.2
+
   assertion-error@2.0.1: {}
 
   assistant-cloud@0.1.31:
@@ -12389,6 +12436,10 @@ snapshots:
   baseline-browser-mapping@2.10.38: {}
 
   baseline-browser-mapping@2.9.19: {}
+
+  bcrypt-pbkdf@1.0.2:
+    dependencies:
+      tweetnacl: 0.14.5
 
   better-auth@1.6.20(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.3.15)(kysely@0.29.2)(pg@8.18.0)(postgres@3.4.9)(sqlite3@5.1.7))(pg@8.18.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.8(@types/node@22.19.21)(jsdom@28.1.0(@noble/hashes@2.2.0))(vite@6.4.1(@types/node@22.19.21)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4))):
     dependencies:
@@ -12499,6 +12550,9 @@ snapshots:
     dependencies:
       base64-js: 1.5.1
       ieee754: 1.2.1
+
+  buildcheck@0.0.7:
+    optional: true
 
   bundle-name@4.1.0:
     dependencies:
@@ -12684,6 +12738,12 @@ snapshots:
   cose-base@2.2.0:
     dependencies:
       layout-base: 2.0.1
+
+  cpu-features@0.0.10:
+    dependencies:
+      buildcheck: 0.0.7
+      nan: 2.28.0
+    optional: true
 
   crelt@1.0.6: {}
 
@@ -14499,6 +14559,9 @@ snapshots:
       concat-stream: 2.0.0
       type-is: 1.6.18
 
+  nan@2.28.0:
+    optional: true
+
   nanoid@3.3.11: {}
 
   nanoid@3.3.15: {}
@@ -15494,6 +15557,14 @@ snapshots:
       - supports-color
     optional: true
 
+  ssh2@1.17.0:
+    dependencies:
+      asn1: 0.2.6
+      bcrypt-pbkdf: 1.0.2
+    optionalDependencies:
+      cpu-features: 0.0.10
+      nan: 2.28.0
+
   ssri@8.0.1:
     dependencies:
       minipass: 3.3.6
@@ -15752,6 +15823,8 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
     optional: true
+
+  tweetnacl@0.14.5: {}
 
   type-is@1.6.18:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -785,9 +785,6 @@ importers:
       sharp:
         specifier: ^0.35.2
         version: 0.35.2
-      ssh2:
-        specifier: ^1.17.0
-        version: 1.17.0
       ws:
         specifier: ^8.19.0
         version: 8.19.0
@@ -906,12 +903,6 @@ importers:
       '@tanstack/react-query':
         specifier: ^5.90.21
         version: 5.90.21(react@19.2.7)
-      '@xterm/addon-fit':
-        specifier: ^0.11.0
-        version: 0.11.0
-      '@xterm/xterm':
-        specifier: ^6.0.0
-        version: 6.0.0
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -4857,12 +4848,6 @@ packages:
   '@webcontainer/env@1.1.1':
     resolution: {integrity: sha512-6aN99yL695Hi9SuIk1oC88l9o0gmxL1nGWWQ/kNy81HigJ0FoaoTXpytCj6ItzgyCEwA9kF1wixsTuv5cjsgng==}
 
-  '@xterm/addon-fit@0.11.0':
-    resolution: {integrity: sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g==}
-
-  '@xterm/xterm@6.0.0':
-    resolution: {integrity: sha512-TQwDdQGtwwDt+2cgKDLn0IRaSxYu1tSUjgKarSDkUM0ZNiSRXFpjxEsvc/Zgc5kq5omJ+V0a8/kIM2WD3sMOYg==}
-
   '@zed-industries/codex-acp-darwin-arm64@0.12.0':
     resolution: {integrity: sha512-RvTXH21sLpswEo8xLeQXcA/uWZauyNP1y+WI6b355+/o7sQ5wrvBkxt+NyhaJXJIQvbfdpl04LND4cmM+DTcNg==}
     cpu: [arm64]
@@ -5005,9 +4990,6 @@ packages:
   asap@2.0.6:
     resolution: {integrity: sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==}
 
-  asn1@0.2.6:
-    resolution: {integrity: sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==}
-
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
@@ -5115,9 +5097,6 @@ packages:
   baseline-browser-mapping@2.9.19:
     resolution: {integrity: sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg==}
     hasBin: true
-
-  bcrypt-pbkdf@1.0.2:
-    resolution: {integrity: sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==}
 
   better-auth@1.6.20:
     resolution: {integrity: sha512-fSpGHGRKiGRiYVd3QTQtuVZ8oxpiSe/7ip0Rpvt/Sy8zQbEbVKUPMOhE0gLXg+FjqTUsIo7582hxUYxtEcqUpA==}
@@ -5230,10 +5209,6 @@ packages:
 
   buffer@6.0.3:
     resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
-
-  buildcheck@0.0.7:
-    resolution: {integrity: sha512-lHblz4ahamxpTmnsk+MNTRWsjYKv965MwOrSJyeD588rR3Jcu7swE+0wN5F+PbL5cjgu/9ObkhfzEPuofEMwLA==}
-    engines: {node: '>=10.0.0'}
 
   bundle-name@4.1.0:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
@@ -5418,10 +5393,6 @@ packages:
 
   cose-base@2.2.0:
     resolution: {integrity: sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==}
-
-  cpu-features@0.0.10:
-    resolution: {integrity: sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA==}
-    engines: {node: '>=10.0.0'}
 
   crelt@1.0.6:
     resolution: {integrity: sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==}
@@ -6862,9 +6833,6 @@ packages:
     resolution: {integrity: sha512-6rdyFg2kLrMh9Jee7/BMPuV9lEAd7lLW2YUpF9/YxR7njyoUwwQ0ZPh3TaIY50Sw6vlyD2HW3wGOkTS4P79xrQ==}
     engines: {node: '>= 10.16.0'}
 
-  nan@2.28.0:
-    resolution: {integrity: sha512-fTsDz99OTq2sVePhGdp4qQhggZFtKr64ZNVyVajRKtMOkJxYekplBh577PiJB12v/D3s2E5cGtOI45LWp6rnLQ==}
-
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -7591,10 +7559,6 @@ packages:
   sqlite3@5.1.7:
     resolution: {integrity: sha512-GGIyOiFaG+TUra3JIfkI/zGP8yZYLPQ0pl1bH+ODjiX57sPhrLU5sQJn1y9bDKZUFYkX1crlrPfSYt0BKKdkog==}
 
-  ssh2@1.17.0:
-    resolution: {integrity: sha512-wPldCk3asibAjQ/kziWQQt1Wh3PgDFpC0XpwclzKcdT1vql6KeYxf5LIt4nlFkUeR8WuphYMKqUA56X4rjbfgQ==}
-    engines: {node: '>=10.16.0'}
-
   ssri@8.0.1:
     resolution: {integrity: sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==}
     engines: {node: '>= 8'}
@@ -7815,9 +7779,6 @@ packages:
 
   tunnel-agent@0.6.0:
     resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
-
-  tweetnacl@0.14.5:
-    resolution: {integrity: sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==}
 
   type-is@1.6.18:
     resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
@@ -12226,10 +12187,6 @@ snapshots:
 
   '@webcontainer/env@1.1.1': {}
 
-  '@xterm/addon-fit@0.11.0': {}
-
-  '@xterm/xterm@6.0.0': {}
-
   '@zed-industries/codex-acp-darwin-arm64@0.12.0':
     optional: true
 
@@ -12358,10 +12315,6 @@ snapshots:
 
   asap@2.0.6: {}
 
-  asn1@0.2.6:
-    dependencies:
-      safer-buffer: 2.1.2
-
   assertion-error@2.0.1: {}
 
   assistant-cloud@0.1.31:
@@ -12436,10 +12389,6 @@ snapshots:
   baseline-browser-mapping@2.10.38: {}
 
   baseline-browser-mapping@2.9.19: {}
-
-  bcrypt-pbkdf@1.0.2:
-    dependencies:
-      tweetnacl: 0.14.5
 
   better-auth@1.6.20(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.3.15)(kysely@0.29.2)(pg@8.18.0)(postgres@3.4.9)(sqlite3@5.1.7))(pg@8.18.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.8(@types/node@22.19.21)(jsdom@28.1.0(@noble/hashes@2.2.0))(vite@6.4.1(@types/node@22.19.21)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4))):
     dependencies:
@@ -12550,9 +12499,6 @@ snapshots:
     dependencies:
       base64-js: 1.5.1
       ieee754: 1.2.1
-
-  buildcheck@0.0.7:
-    optional: true
 
   bundle-name@4.1.0:
     dependencies:
@@ -12738,12 +12684,6 @@ snapshots:
   cose-base@2.2.0:
     dependencies:
       layout-base: 2.0.1
-
-  cpu-features@0.0.10:
-    dependencies:
-      buildcheck: 0.0.7
-      nan: 2.28.0
-    optional: true
 
   crelt@1.0.6: {}
 
@@ -14559,9 +14499,6 @@ snapshots:
       concat-stream: 2.0.0
       type-is: 1.6.18
 
-  nan@2.28.0:
-    optional: true
-
   nanoid@3.3.11: {}
 
   nanoid@3.3.15: {}
@@ -15557,14 +15494,6 @@ snapshots:
       - supports-color
     optional: true
 
-  ssh2@1.17.0:
-    dependencies:
-      asn1: 0.2.6
-      bcrypt-pbkdf: 1.0.2
-    optionalDependencies:
-      cpu-features: 0.0.10
-      nan: 2.28.0
-
   ssri@8.0.1:
     dependencies:
       minipass: 3.3.6
@@ -15823,8 +15752,6 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
     optional: true
-
-  tweetnacl@0.14.5: {}
 
   type-is@1.6.18:
     dependencies:

--- a/server/src/__tests__/agent-skills-routes.test.ts
+++ b/server/src/__tests__/agent-skills-routes.test.ts
@@ -686,7 +686,9 @@ describe.sequential("agent skill routes", () => {
       }),
       expect.objectContaining({
         "AGENTS.md": expect.stringContaining("You are the CEO."),
-        "HEARTBEAT.md": expect.stringContaining("CEO Heartbeat Checklist"),
+        "HEARTBEAT.md": expect.stringMatching(
+          /CEO Heartbeat Checklist[\s\S]*\/issues\/blocked-inbox-rollup\?format=markdown/,
+        ),
         "SOUL.md": expect.stringContaining("CEO Persona"),
         "TOOLS.md": expect.stringContaining("# Tools"),
       }),

--- a/server/src/__tests__/blocked-inbox-rollup.test.ts
+++ b/server/src/__tests__/blocked-inbox-rollup.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from "vitest";
+import type { Issue, IssueBlockedInboxAttention } from "@paperclipai/shared";
+import {
+  buildBlockedInboxRollup,
+  renderBlockedInboxRollupMarkdown,
+} from "../services/blocked-inbox-rollup.js";
+
+function attention(input: {
+  state: IssueBlockedInboxAttention["state"];
+  owner: IssueBlockedInboxAttention["owner"];
+  stoppedSinceAt: string;
+  reason?: IssueBlockedInboxAttention["reason"];
+}): IssueBlockedInboxAttention {
+  return {
+    kind: "blocked",
+    state: input.state,
+    reason: input.reason ?? "blocked_by_assigned_backlog_issue",
+    severity: "high",
+    stoppedSinceAt: input.stoppedSinceAt,
+    owner: input.owner,
+    action: {
+      label: "Resume parked blocker",
+      detail: "Move the blocker back to in_progress.",
+    },
+    sourceIssue: null,
+    leafIssue: null,
+    recoveryIssue: null,
+    approvalId: null,
+    interactionId: null,
+    sampleIssueIdentifier: null,
+    redaction: {
+      externalDetailsRedacted: false,
+      secretFieldsOmitted: true,
+    },
+  };
+}
+
+function issue(input: {
+  id: string;
+  identifier: string;
+  title: string;
+  blockedInboxAttention: IssueBlockedInboxAttention;
+}): Issue & { blockedInboxAttention: IssueBlockedInboxAttention } {
+  return {
+    id: input.id,
+    identifier: input.identifier,
+    title: input.title,
+    status: "blocked",
+    priority: "medium",
+    updatedAt: new Date("2026-07-01T00:00:00.000Z"),
+    blockedInboxAttention: input.blockedInboxAttention,
+  } as Issue & { blockedInboxAttention: IssueBlockedInboxAttention };
+}
+
+describe("blocked inbox rollup", () => {
+  it("groups by owner bucket, separates attention states, and selects stale/founder digest candidates", () => {
+    const generatedAt = new Date("2026-07-20T00:00:00.000Z");
+    const emAgentId = "11111111-1111-4111-8111-111111111111";
+    const rollup = buildBlockedInboxRollup(
+      [
+        issue({
+          id: "issue-1",
+          identifier: "RR-1",
+          title: "Engineering blocker",
+          blockedInboxAttention: attention({
+            state: "needs_attention",
+            owner: { type: "agent", agentId: emAgentId, userId: null, label: null },
+            stoppedSinceAt: "2026-07-01T00:00:00.000Z",
+          }),
+        }),
+        issue({
+          id: "issue-2",
+          identifier: "RR-2",
+          title: "Board confirmation",
+          blockedInboxAttention: attention({
+            state: "awaiting_decision",
+            owner: { type: "board", agentId: null, userId: null, label: "Board" },
+            stoppedSinceAt: "2026-07-19T00:00:00.000Z",
+            reason: "pending_board_decision",
+          }),
+        }),
+        issue({
+          id: "issue-3",
+          identifier: "RR-3",
+          title: "Vendor reply",
+          blockedInboxAttention: attention({
+            state: "external_wait",
+            owner: { type: "external", agentId: null, userId: null, label: null },
+            stoppedSinceAt: "2026-07-02T00:00:00.000Z",
+            reason: "external_owner_action",
+          }),
+        }),
+      ],
+      new Map([[emAgentId, { name: "Engineering Manager", role: "manager", title: "Engineering Manager" }]]),
+      { generatedAt },
+    );
+
+    expect(rollup.totalBlocked).toBe(3);
+    expect(rollup.ownerBuckets).toMatchObject({
+      EM: 1,
+      founder: 1,
+      external: 1,
+    });
+    expect(rollup.stateCounts.needs_attention).toBe(1);
+    expect(rollup.stateCounts.awaiting_decision).toBe(1);
+    expect(rollup.stateCounts.external_wait).toBe(1);
+    expect(rollup.staleCloseCandidates.map((item) => item.identifier)).toEqual(["RR-1", "RR-3"]);
+    expect(rollup.founderDigestCandidates.map((item) => item.identifier)).toEqual(["RR-3", "RR-2"]);
+  });
+
+  it("renders markdown with grouped counts and candidate sections", () => {
+    const rollup = buildBlockedInboxRollup(
+      [
+        issue({
+          id: "issue-1",
+          identifier: "RR-1",
+          title: "Founder decision",
+          blockedInboxAttention: attention({
+            state: "awaiting_decision",
+            owner: { type: "board", agentId: null, userId: null, label: "Board" },
+            stoppedSinceAt: "2026-07-01T00:00:00.000Z",
+            reason: "pending_board_decision",
+          }),
+        }),
+      ],
+      new Map(),
+      { generatedAt: new Date("2026-07-20T00:00:00.000Z") },
+    );
+
+    const markdown = renderBlockedInboxRollupMarkdown(rollup);
+
+    expect(markdown).toContain("Total blocked inbox items: 1");
+    expect(markdown).toContain("- founder: 1");
+    expect(markdown).toContain("- awaiting_decision: 1");
+    expect(markdown).toContain("## Proposed Close Candidates (>14d stale)");
+    expect(markdown).toContain("## Founder Digest Candidates");
+    expect(markdown).toContain("RR-1");
+  });
+});

--- a/server/src/onboarding-assets/ceo/HEARTBEAT.md
+++ b/server/src/onboarding-assets/ceo/HEARTBEAT.md
@@ -29,7 +29,15 @@ If `PAPERCLIP_APPROVAL_ID` is set:
 - If there is already an active run on an `in_progress` task, just move on to the next thing.
 - If `PAPERCLIP_TASK_ID` is set and assigned to you, prioritize that task.
 
-## 5. Checkout and Work
+## 5. Blocked Inbox Rollup
+
+For the daily digest / board hygiene pass, pull the live blocked-inbox rollup before deciding what to escalate:
+
+- `GET /api/companies/{companyId}/issues/blocked-inbox-rollup?format=markdown`
+- Use the rollup's owner buckets (CEO, EM, MM, OM, founder, external, other), attention-state counts, proposed-close candidates, and founder/external digest candidates in the daily note or board hygiene comment.
+- Do not manually rebuild blocked issue groupings from the generic issues list unless this endpoint fails; if it fails, comment with the error and continue with the normal assignment flow.
+
+## 6. Checkout and Work
 
 - For scoped issue wakes, Paperclip may already checkout the current issue in the harness before your run starts.
 - Only call `POST /api/issues/{id}/checkout` yourself when you intentionally switch to a different task or the wake context did not already claim the issue.
@@ -45,7 +53,7 @@ Status quick guide:
 - `done`: finished.
 - `cancelled`: intentionally dropped.
 
-## 6. Delegation
+## 7. Delegation
 
 - Create subtasks with `POST /api/companies/{companyId}/issues`. Always set `parentId` and `goalId`. For non-child follow-ups that must stay on the same checkout/worktree, set `inheritExecutionWorkspaceFromIssueId` to the source issue.
 - When you know the needed work and owner, create those subtasks directly. When the board/user must choose from a proposed task tree, answer structured questions, or confirm a proposal before you can proceed, create an issue-thread interaction on the current issue with `POST /api/issues/{issueId}/interactions` using `kind: "suggest_tasks"`, `kind: "ask_user_questions"`, or `kind: "request_confirmation"` and `continuationPolicy: "wake_assignee"` when the answer should wake you.
@@ -54,14 +62,14 @@ Status quick guide:
 - Use `paperclip-create-agent` skill when hiring new agents.
 - Assign work to the right agent for the job.
 
-## 7. Fact Extraction
+## 8. Fact Extraction
 
 1. Check for new conversations since last extraction.
 2. Extract durable facts to the relevant entity in `$AGENT_HOME/life/` (PARA).
 3. Update `$AGENT_HOME/memory/YYYY-MM-DD.md` with timeline entries.
 4. Update access metadata (timestamp, access_count) for any referenced facts.
 
-## 8. Exit
+## 9. Exit
 
 - Comment on any in_progress work before exiting.
 - If no assignments and no valid mention-handoff, exit cleanly.

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -83,6 +83,7 @@ import {
   goalService,
   heartbeatService,
   issueApprovalService,
+  blockedInboxRollupService,
   issueRecoveryActionService,
   issueThreadInteractionService,
   ISSUE_LIST_DEFAULT_LIMIT,
@@ -96,6 +97,7 @@ import {
   projectService,
   routineService,
   workProductService,
+  renderBlockedInboxRollupMarkdown,
 } from "../services/index.js";
 import { buildPlanReviewContext } from "../services/plan-review-context.js";
 import {
@@ -3063,6 +3065,31 @@ export function issueRoutes(
     }
     const result = await getSearchService().search(companyId, query);
     res.json(result);
+  });
+
+  router.get("/companies/:companyId/issues/blocked-inbox-rollup", async (req, res) => {
+    const companyId = req.params.companyId as string;
+    assertCompanyAccess(req, companyId);
+    if (isTaskBridgeKeyActor(req)) {
+      res.status(403).json({ error: "Task bridge keys cannot use company-wide blocked inbox rollup APIs" });
+      return;
+    }
+    if (!(await actorCanReadCompanyScope(req, companyId))) {
+      res.status(403).json({ error: "Blocked inbox rollup requires company-scope read access" });
+      return;
+    }
+
+    const rollup = await blockedInboxRollupService(db).build(companyId);
+    const format = req.query.format as string | undefined;
+    if (format === "markdown") {
+      res.type("text/markdown").send(renderBlockedInboxRollupMarkdown(rollup));
+      return;
+    }
+    if (format !== undefined && format !== "json") {
+      res.status(400).json({ error: "format must be 'json' or 'markdown' when provided" });
+      return;
+    }
+    res.json(rollup);
   });
 
   router.get("/companies/:companyId/issues", async (req, res) => {

--- a/server/src/routes/openapi.ts
+++ b/server/src/routes/openapi.ts
@@ -1484,6 +1484,18 @@ registry.registerPath({
 });
 
 registry.registerPath({
+  method: "get",
+  path: "/api/companies/{companyId}/issues/blocked-inbox-rollup",
+  tags: ["issues"],
+  summary: "Get a blocked inbox rollup for a company",
+  request: {
+    params: z.object({ companyId: z.string() }),
+    query: z.object({ format: z.enum(["json", "markdown"]).optional() }).strict(),
+  },
+  responses: { 200: r.ok(), 400: r.badRequest, 401: r.unauthorized },
+});
+
+registry.registerPath({
   method: "post",
   path: "/api/companies/{companyId}/issues",
   tags: ["issues"],

--- a/server/src/services/blocked-inbox-rollup.ts
+++ b/server/src/services/blocked-inbox-rollup.ts
@@ -1,0 +1,245 @@
+import { agents, type Db } from "@paperclipai/db";
+import type { Issue, IssueBlockedInboxAttention } from "@paperclipai/shared";
+import { eq } from "drizzle-orm";
+import { issueService } from "./issues.js";
+
+export const BLOCKED_INBOX_ROLLUP_BUCKETS = ["CEO", "EM", "MM", "OM", "founder", "external", "other"] as const;
+
+export type BlockedInboxRollupBucket = typeof BLOCKED_INBOX_ROLLUP_BUCKETS[number];
+
+type BlockedInboxIssue = Issue & {
+  blockedInboxAttention?: IssueBlockedInboxAttention | null;
+  lastActivityAt?: Date | string | null;
+};
+
+export interface BlockedInboxRollupIssueSummary {
+  id: string;
+  identifier: string | null;
+  title: string;
+  status: string;
+  priority: string;
+  state: IssueBlockedInboxAttention["state"];
+  reason: IssueBlockedInboxAttention["reason"];
+  ownerBucket: BlockedInboxRollupBucket;
+  ownerLabel: string;
+  stoppedSinceAt: string | null;
+  ageDays: number | null;
+  actionLabel: string;
+  actionDetail: string | null;
+}
+
+export interface BlockedInboxRollup {
+  generatedAt: string;
+  totalBlocked: number;
+  stateCounts: Record<IssueBlockedInboxAttention["state"], number>;
+  ownerBuckets: Record<BlockedInboxRollupBucket, number>;
+  staleCloseCandidates: BlockedInboxRollupIssueSummary[];
+  founderDigestCandidates: BlockedInboxRollupIssueSummary[];
+  items: BlockedInboxRollupIssueSummary[];
+}
+
+interface AgentBucketInfo {
+  name: string | null;
+  role: string | null;
+  title: string | null;
+}
+
+export interface BuildBlockedInboxRollupOptions {
+  generatedAt?: Date;
+  staleAfterDays?: number;
+}
+
+function emptyStateCounts(): BlockedInboxRollup["stateCounts"] {
+  return {
+    needs_attention: 0,
+    awaiting_decision: 0,
+    external_wait: 0,
+    recovery_open: 0,
+    missing_disposition: 0,
+  };
+}
+
+function emptyOwnerBuckets(): BlockedInboxRollup["ownerBuckets"] {
+  return {
+    CEO: 0,
+    EM: 0,
+    MM: 0,
+    OM: 0,
+    founder: 0,
+    external: 0,
+    other: 0,
+  };
+}
+
+function parseDateMs(value: string | Date | null | undefined): number | null {
+  if (!value) return null;
+  const ms = value instanceof Date ? value.getTime() : new Date(value).getTime();
+  return Number.isFinite(ms) ? ms : null;
+}
+
+function ageDaysSince(value: string | Date | null | undefined, generatedAt: Date): number | null {
+  const ms = parseDateMs(value);
+  if (ms === null) return null;
+  return Math.max(0, Math.floor((generatedAt.getTime() - ms) / 86_400_000));
+}
+
+function agentBucket(agent: AgentBucketInfo | null | undefined): BlockedInboxRollupBucket {
+  if (!agent) return "other";
+  const haystack = [agent.name, agent.role, agent.title].filter(Boolean).join(" ").toLowerCase();
+  if (/\b(ceo|chief executive)\b/.test(haystack)) return "CEO";
+  if (/\b(engineering manager|eng manager|em)\b/.test(haystack)) return "EM";
+  if (/\b(marketing manager|growth manager|mm)\b/.test(haystack)) return "MM";
+  if (/\b(operations manager|ops manager|om)\b/.test(haystack)) return "OM";
+  return "other";
+}
+
+function ownerBucketForAttention(
+  attention: IssueBlockedInboxAttention,
+  agentById: ReadonlyMap<string, AgentBucketInfo>,
+): BlockedInboxRollupBucket {
+  if (attention.owner.type === "external") return "external";
+  if (attention.owner.type === "board" || attention.owner.type === "user") return "founder";
+  if (attention.owner.type === "agent" && attention.owner.agentId) {
+    return agentBucket(agentById.get(attention.owner.agentId));
+  }
+  return "other";
+}
+
+function ownerLabelForAttention(
+  attention: IssueBlockedInboxAttention,
+  agentById: ReadonlyMap<string, AgentBucketInfo>,
+) {
+  if (attention.owner.label) return attention.owner.label;
+  if (attention.owner.type === "external") return "External";
+  if (attention.owner.type === "board") return "Board/founder";
+  if (attention.owner.type === "user") return "Founder/user";
+  if (attention.owner.type === "agent" && attention.owner.agentId) {
+    const agent = agentById.get(attention.owner.agentId);
+    return agent?.name ?? agent?.title ?? agent?.role ?? attention.owner.agentId;
+  }
+  return "Unknown";
+}
+
+function compareCandidateIssues(left: BlockedInboxRollupIssueSummary, right: BlockedInboxRollupIssueSummary) {
+  const leftAge = left.ageDays ?? -1;
+  const rightAge = right.ageDays ?? -1;
+  if (leftAge !== rightAge) return rightAge - leftAge;
+  return (left.identifier ?? left.title).localeCompare(right.identifier ?? right.title);
+}
+
+export function buildBlockedInboxRollup(
+  issues: BlockedInboxIssue[],
+  agentById: ReadonlyMap<string, AgentBucketInfo>,
+  options: BuildBlockedInboxRollupOptions = {},
+): BlockedInboxRollup {
+  const generatedAt = options.generatedAt ?? new Date();
+  const staleAfterDays = options.staleAfterDays ?? 14;
+  const stateCounts = emptyStateCounts();
+  const ownerBuckets = emptyOwnerBuckets();
+  const items: BlockedInboxRollupIssueSummary[] = [];
+
+  for (const issue of issues) {
+    const attention = issue.blockedInboxAttention;
+    if (!attention) continue;
+    const ownerBucket = ownerBucketForAttention(attention, agentById);
+    const ageDays = ageDaysSince(attention.stoppedSinceAt ?? issue.updatedAt, generatedAt);
+    stateCounts[attention.state] = (stateCounts[attention.state] ?? 0) + 1;
+    ownerBuckets[ownerBucket] += 1;
+    items.push({
+      id: issue.id,
+      identifier: issue.identifier ?? null,
+      title: issue.title,
+      status: issue.status,
+      priority: issue.priority,
+      state: attention.state,
+      reason: attention.reason,
+      ownerBucket,
+      ownerLabel: ownerLabelForAttention(attention, agentById),
+      stoppedSinceAt: attention.stoppedSinceAt,
+      ageDays,
+      actionLabel: attention.action.label,
+      actionDetail: attention.action.detail,
+    });
+  }
+
+  return {
+    generatedAt: generatedAt.toISOString(),
+    totalBlocked: items.length,
+    stateCounts,
+    ownerBuckets,
+    staleCloseCandidates: items
+      .filter((item) => item.ageDays !== null && item.ageDays >= staleAfterDays)
+      .sort(compareCandidateIssues),
+    founderDigestCandidates: items
+      .filter((item) => item.ownerBucket === "founder" || item.ownerBucket === "external")
+      .sort(compareCandidateIssues),
+    items,
+  };
+}
+
+function formatCountMap<T extends string>(entries: readonly T[], counts: Record<T, number>) {
+  return entries.map((entry) => `- ${entry}: ${counts[entry] ?? 0}`).join("\n");
+}
+
+function formatIssueLine(item: BlockedInboxRollupIssueSummary) {
+  const id = item.identifier ?? item.id;
+  const age = item.ageDays === null ? "age unknown" : `${item.ageDays}d`;
+  return `- ${id} (${item.ownerBucket}, ${item.state}, ${age}): ${item.title} -> ${item.actionLabel}`;
+}
+
+export function renderBlockedInboxRollupMarkdown(rollup: BlockedInboxRollup) {
+  const stale = rollup.staleCloseCandidates.length > 0
+    ? rollup.staleCloseCandidates.slice(0, 25).map(formatIssueLine).join("\n")
+    : "- None";
+  const founder = rollup.founderDigestCandidates.length > 0
+    ? rollup.founderDigestCandidates.slice(0, 25).map(formatIssueLine).join("\n")
+    : "- None";
+
+  return [
+    `# Blocked Inbox Rollup - ${rollup.generatedAt}`,
+    "",
+    `Total blocked inbox items: ${rollup.totalBlocked}`,
+    "",
+    "## Owner Buckets",
+    formatCountMap(BLOCKED_INBOX_ROLLUP_BUCKETS, rollup.ownerBuckets),
+    "",
+    "## Attention States",
+    `- awaiting_decision: ${rollup.stateCounts.awaiting_decision}`,
+    `- needs_attention: ${rollup.stateCounts.needs_attention}`,
+    `- external_wait: ${rollup.stateCounts.external_wait}`,
+    `- recovery_open: ${rollup.stateCounts.recovery_open}`,
+    `- missing_disposition: ${rollup.stateCounts.missing_disposition}`,
+    "",
+    "## Proposed Close Candidates (>14d stale)",
+    stale,
+    "",
+    "## Founder Digest Candidates",
+    founder,
+  ].join("\n");
+}
+
+export function blockedInboxRollupService(db: Db) {
+  return {
+    async build(companyId: string, options: BuildBlockedInboxRollupOptions = {}) {
+      const rows = await issueService(db).list(companyId, {
+        attention: "blocked",
+        status: "blocked",
+        includeBlockedInboxAttention: true,
+      }) as BlockedInboxIssue[];
+      const agentRows = await db
+        .select({
+          id: agents.id,
+          name: agents.name,
+          role: agents.role,
+          title: agents.title,
+        })
+        .from(agents)
+        .where(eq(agents.companyId, companyId));
+      return buildBlockedInboxRollup(
+        rows,
+        new Map(agentRows.map((agent) => [agent.id, agent])),
+        options,
+      );
+    },
+  };
+}

--- a/server/src/services/index.ts
+++ b/server/src/services/index.ts
@@ -22,6 +22,11 @@ export {
   issueService,
   type IssueFilters,
 } from "./issues.js";
+export {
+  blockedInboxRollupService,
+  buildBlockedInboxRollup,
+  renderBlockedInboxRollupMarkdown,
+} from "./blocked-inbox-rollup.js";
 export { issueThreadInteractionService } from "./issue-thread-interactions.js";
 export { issueTreeControlService } from "./issue-tree-control.js";
 export { issueApprovalService } from "./issue-approvals.js";


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The issue inbox and CEO heartbeat routines are where blocked work is surfaced for operational follow-up.
> - The existing blocked inbox endpoint can return live attention metadata, but daily board hygiene still required manual grouping of blocked items.
> - Manual grouping makes stale blockers, founder decisions, and external waits easy to miss or classify inconsistently.
> - This pull request adds a reusable server-side rollup and exposes it as a company-scoped report endpoint.
> - It also wires the CEO heartbeat checklist to use the rollup during daily digest and board hygiene passes.
> - The benefit is deterministic blocked-work reporting with owner buckets, attention-state counts, stale close candidates, and founder/external digest candidates.

## Linked Issues or Issue Description

No public GitHub issue exists.

Subsystem affected: server/ — REST API & orchestration services

Problem or motivation:
Operators can fetch blocked issues with attention metadata, but daily board hygiene still requires manually grouping owners, splitting attention states, identifying stale items, and finding founder/external blockers. That manual step is repetitive and can produce inconsistent digest decisions.

Proposed solution:
Add a reusable server helper and company-scoped endpoint that reads live blocked inbox data, groups counts by owner bucket, separates `awaiting_decision` from `needs_attention`, lists stale blocked items older than 14 days as proposed-close candidates, and lists founder/external blockers as digest candidates. Wire the CEO heartbeat checklist to use that report during daily digest and board hygiene passes.

Alternatives considered:
Continue using the generic issues list and manually grouping blocked items in the daily routine. That keeps API surface smaller, but preserves the inconsistent manual work this change is meant to remove.

Roadmap alignment:
This is operational reporting for existing Paperclip issue orchestration. I checked `ROADMAP.md` and did not find a duplicate planned core feature.

Additional context:
Duplicate PR search for `blocked inbox rollup` returned only this PR.

## What Changed

- Added a server-side blocked inbox rollup helper that fetches live blocked inbox rows through the issue service with `attention: "blocked"`, `status: "blocked"`, and `includeBlockedInboxAttention: true`.
- Groups blocked counts by CEO, EM, MM, OM, founder, external, and other owner buckets.
- Separates `awaiting_decision`, `needs_attention`, and other blocked inbox attention states.
- Surfaces stale proposed-close candidates and founder/external digest candidates.
- Added `GET /api/companies/:companyId/issues/blocked-inbox-rollup`, returning JSON by default or markdown with `?format=markdown`.
- Updated the OpenAPI registry for the new route.
- Updated the CEO heartbeat checklist so daily digest and board hygiene runs pull the rollup instead of rebuilding blocked issue groupings manually.

## Verification

- `pnpm exec vitest run server/src/__tests__/blocked-inbox-rollup.test.ts`
  - Passed: 1 file, 2 tests.
- `pnpm exec vitest run server/src/__tests__/openapi-routes.test.ts`
  - Passed: 1 file, 3 tests.
- `pnpm test:run:serialized -- --shard-index 2 --shard-count 4`
  - Passed locally after adding the OpenAPI registration for the new route.
- `pnpm --filter @paperclipai/server typecheck`
  - Passed in the earlier PR run.
- Live dry-run transcript against existing Paperclip data endpoint:

```text
run_timestamp=2026-07-03T22:58:11.274Z
live_rows=33
owner_buckets={"CEO":0,"EM":0,"MM":0,"OM":0,"founder":2,"external":0,"other":31}
attention_states={"awaiting_decision":2,"needs_attention":31}
stale_candidates_sample=founder:34d
founder_digest_candidates_count=2
```

## Risks

Low risk. The change adds a read-only company-scoped rollup endpoint and a documentation wiring point for the CEO heartbeat. The endpoint reuses existing issue-list authorization and blocked inbox attention calculation, and it does not introduce migrations, external integrations, spend, auth policy changes, or destructive behavior.

## Model Used

OpenAI Codex, GPT-5 coding agent with shell and repository tool access.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge