### PR TITLE
Version the agy-gemini-bridge wrapper for gemini_local (ZIM-427)

### DIFF
--- a/.jcodemunch.jsonc
+++ b/.jcodemunch.jsonc
@@ -1,0 +1,20 @@
+// jcodemunch-mcp project configuration for the Paperclip codebase
+// See ~/.code-index/config.jsonc for full option documentation
+{
+  // Use standard tier (core + analytics + architecture tools)
+  // claude-sonnet maps to "standard" in the model_tier_map automatically
+  "tool_profile": "standard",
+
+  // Enable adaptive tiering so tool set adjusts based on the active model
+  "adaptive_tiering": true,
+
+  // Compact schemas saves ~1-2k tokens per session on top of the profile
+  "compact_schemas": true,
+
+  // File watcher: keep index fresh as code changes
+  "watch": true,
+  "watch_debounce_ms": 3000,
+
+  // Extend staleness threshold since we have a watcher active
+  "staleness_days": 30
+}

--- a/packages/adapters/gemini-local/bin/agy-gemini-bridge
+++ b/packages/adapters/gemini-local/bin/agy-gemini-bridge
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# agy-gemini-bridge
+#
+# Adapts the Paperclip `gemini_local` adapter's CLI invocation to `agy`
+# (Antigravity CLI, subscription/OAuth auth) instead of `gemini` (which
+# requires GOOGLE_API_KEY). Translates the flags gemini_local always sends,
+# runs agy headlessly, and re-emits its plain-text output as the JSONL
+# stream `parseGeminiJsonl` expects (see
+# packages/adapters/gemini-local/src/server/parse.ts).
+#
+# Flag translation (see ZIM-427):
+#   --output-format stream-json  -> dropped (this wrapper always emits JSONL)
+#   --resume <id>                -> --conversation <id>
+#   --model <model>               -> --model <model> (passthrough)
+#   --approval-mode yolo         -> --dangerously-skip-permissions
+#   --sandbox=none / --sandbox   -> dropped (agy has no sandbox flag)
+#   --prompt <text>               -> --print <text>
+#
+# Any other flag is dropped with a stderr warning rather than forwarded,
+# since agy fails hard ("flags provided but not defined") on unknown flags.
+#
+# This script has no assumptions about which host it runs on beyond `agy`
+# being on PATH (or AGY_GEMINI_BRIDGE_AGY_BIN pointing at it) and `node`
+# being available (guaranteed by every Paperclip adapter-runtime image —
+# python3 is not, so JSON encoding below uses `node`, not python3).
+#
+# OAuth token portability: `agy` authenticates via a token file at
+# $HOME/.gemini/antigravity-cli/antigravity-oauth-token. Fresh hosts/sandboxes
+# won't have this file. If AGY_OAUTH_TOKEN_JSON is set (adapterConfig.env,
+# treated as a secret) and the token file is missing, this script writes it
+# out before invoking agy so the adapter config is the single source of truth
+# for credential distribution rather than requiring a pre-provisioned host.
+set -u
+
+AGY_BIN="${AGY_GEMINI_BRIDGE_AGY_BIN:-agy}"
+TOKEN_PATH="${HOME:-/tmp}/.gemini/antigravity-cli/antigravity-oauth-token"
+
+if [ ! -s "$TOKEN_PATH" ] && [ -n "${AGY_OAUTH_TOKEN_JSON:-}" ]; then
+  mkdir -p "$(dirname "$TOKEN_PATH")"
+  printf '%s' "$AGY_OAUTH_TOKEN_JSON" > "$TOKEN_PATH"
+  chmod 600 "$TOKEN_PATH"
+fi
+
+agy_args=()
+prompt=""
+have_prompt=0
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --output-format)
+      shift 2
+      ;;
+    --resume)
+      agy_args+=(--conversation "$2")
+      shift 2
+      ;;
+    --model)
+      agy_args+=(--model "$2")
+      shift 2
+      ;;
+    --approval-mode)
+      # value (always "yolo") is discarded; --dangerously-skip-permissions
+      # is always passed below regardless, so just consume it here.
+      shift 2
+      ;;
+    --sandbox=*)
+      shift
+      ;;
+    --sandbox)
+      shift
+      ;;
+    --prompt)
+      prompt="$2"
+      have_prompt=1
+      shift 2
+      ;;
+    *)
+      echo "[agy-gemini-bridge] warning: dropping unrecognized flag: $1" >&2
+      shift
+      ;;
+  esac
+done
+
+if [ "$have_prompt" -ne 1 ]; then
+  echo "[agy-gemini-bridge] error: no --prompt provided" >&2
+  exit 2
+fi
+
+tmpdir="${TMPDIR:-/tmp}"
+log_file=$(mktemp "$tmpdir/agy-gemini-bridge-XXXXXX.log")
+out_file=$(mktemp "$tmpdir/agy-gemini-bridge-XXXXXX.out")
+cleanup() { rm -f "$log_file" "$out_file"; }
+trap cleanup EXIT
+
+# --log-file isolates this invocation's log from concurrent agy runs, so the
+# conversation ID can be scraped reliably without a newest-mtime race against
+# other agents running agy at the same time.
+"$AGY_BIN" --dangerously-skip-permissions --log-file "$log_file" \
+  "${agy_args[@]}" --print "$prompt" >"$out_file" 2>&1
+exit_code=$?
+
+conversation_id=$(grep -oE '(Created conversation|resuming conversation) [0-9a-fA-F-]{36}' "$log_file" \
+  | tail -1 | awk '{print $NF}')
+
+AGY_BRIDGE_EXIT_CODE="$exit_code" AGY_BRIDGE_CONVERSATION_ID="$conversation_id" AGY_BRIDGE_OUT_FILE="$out_file" node -e '
+const fs = require("fs");
+const exitCode = parseInt(process.env.AGY_BRIDGE_EXIT_CODE, 10);
+const conversationId = process.env.AGY_BRIDGE_CONVERSATION_ID || "";
+const text = fs.readFileSync(process.env.AGY_BRIDGE_OUT_FILE, "utf8").trim();
+
+process.stdout.write(JSON.stringify({ type: "message", role: "assistant", content: text }) + "\n");
+
+const result = { type: "result", is_error: exitCode !== 0 };
+result.result = exitCode === 0 ? "success" : "error";
+if (exitCode !== 0) result.error = text.slice(-4000);
+if (conversationId) result.session_id = conversationId;
+process.stdout.write(JSON.stringify(result) + "\n");
+'
+
+exit "$exit_code"


### PR DESCRIPTION
## Summary
- Checks in the ZIM-427 `agy-gemini-bridge` wrapper script (translates `gemini_local`'s CLI flags to `agy`/Antigravity CLI flags, wraps its plain-text output as JSONL for `parseGeminiJsonl`) at `packages/adapters/gemini-local/bin/agy-gemini-bridge`, instead of leaving it only on one agent's personal sandbox disk.
- Fixes two portability bugs found while relocating it: JSON encoding used `python3` (not installed in `agent-runtime-base`; swapped for `node`, already a hard dependency everywhere else), and the `agy` binary path was hardcoded to one sandbox's home directory (now resolved via `PATH`, overridable with `AGY_GEMINI_BRIDGE_AGY_BIN`).
- Adds self-provisioning for the `agy` OAuth token file from an `AGY_OAUTH_TOKEN_JSON` env var, so adapter config (not a pre-provisioned host) is the source of truth for the credential.

This does **not** fully close ZIM-427 — see that issue for the two remaining blockers (the `agy` binary's install source, and the OAuth-credential distribution decision) that need input before a live `gemini_local` agent can point at this wrapper.

## Test plan
- [x] Ran the wrapper directly with gemini_local-style flags (`--output-format stream-json --sandbox=none --prompt "..."`) — produced valid `{"type":"message",...}` / `{"type":"result",...,"session_id":...}` JSONL, matching `parseGeminiJsonl`.
- [x] Verified `--resume <id>` → `--conversation <id>` session resume: agy correctly recalled prior-turn context.
- [x] Verified the OAuth-token self-provisioning logic writes `AGY_OAUTH_TOKEN_JSON` to `$HOME/.gemini/antigravity-cli/antigravity-oauth-token` with `chmod 600` when the file is missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)