### PR TITLE
fix(acpx-local): don't leak benign nes/close cleanup RPC error to run stderr

### DIFF
--- a/packages/adapters/acpx-local/src/server/execute.test.ts
+++ b/packages/adapters/acpx-local/src/server/execute.test.ts
@@ -1,9 +1,13 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
 import { afterEach, describe, expect, it } from "vitest";
 import type { AcpRuntimeOptions } from "acpx/runtime";
 import { createAcpxLocalExecutor } from "./execute.js";
+
+const execFileAsync = promisify(execFile);
 
 const tempRoots: string[] = [];
 
@@ -495,6 +499,55 @@ describe("acpx_local runtime skill isolation", () => {
     expect(wrapper).toContain("PAPERCLIP_RUN_ID");
     expect(wrapper).toContain("tee -a");
     expect(wrapper).toContain("exec node ./fake-acp.js");
+  });
+
+  it("drops the benign ACP nes/close cleanup RPC line from forwarded stderr but keeps it in the run log (CMOAAA-2790)", async () => {
+    const root = await makeTempRoot();
+    const stateDir = path.join(root, "state");
+
+    const execute = createAcpxLocalExecutor({
+      createRuntime: () => buildRuntime() as never,
+    });
+
+    const fakeAgentPath = path.join(root, "fake-acp.sh");
+    await fs.writeFile(
+      fakeAgentPath,
+      [
+        "#!/usr/bin/env bash",
+        "echo \"Error handling request { method: 'nes/close' } { code: -32601, message: '\\\"Method not found\\\": nes/close' }\" >&2",
+        "echo \"some genuine crash: TypeError: x is not a function\" >&2",
+        "",
+      ].join("\n"),
+      { mode: 0o700 },
+    );
+
+    await execute({
+      runId: "run-nes-close-1",
+      agent: { id: "agent-1", companyId: "company-1" },
+      runtime: {},
+      config: {
+        agent: "custom",
+        agentCommand: fakeAgentPath,
+        stateDir,
+      },
+      context: {},
+      onLog: async () => {},
+      onMeta: async () => {},
+    } as never);
+
+    const wrapperFile = (await fs.readdir(path.join(stateDir, "wrappers"))).find((name) => name.endsWith(".sh"));
+    const wrapperPath = path.join(stateDir, "wrappers", wrapperFile!);
+
+    const { stderr } = await execFileAsync("bash", [wrapperPath], {
+      env: { ...process.env, PAPERCLIP_RUN_ID: "run-nes-close-1" },
+    });
+
+    expect(stderr).not.toContain("nes/close");
+    expect(stderr).toContain("some genuine crash: TypeError: x is not a function");
+
+    const runLog = await fs.readFile(path.join(stateDir, "run-stderr", "run-nes-close-1.log"), "utf8");
+    expect(runLog).toContain("nes/close");
+    expect(runLog).toContain("some genuine crash: TypeError: x is not a function");
   });
 
   it("passes Paperclip env through the ACP agent wrapper instead of process.env", async () => {

--- a/packages/adapters/acpx-local/src/server/execute.ts
+++ b/packages/adapters/acpx-local/src/server/execute.ts
@@ -692,7 +692,13 @@ async function writeAgentWrapper(input: {
     `stderr_dir=${shellQuote(input.childStderrDir)}`,
     "if [[ -n \"${PAPERCLIP_RUN_ID:-}\" ]]; then",
     "  mkdir -p \"$stderr_dir\"",
-    "  exec 2> >(tee -a \"$stderr_dir/$PAPERCLIP_RUN_ID.log\" >&2)",
+    // The full, unfiltered child stderr always lands in the log file for
+    // diagnostics. Only the known-benign "nes/close" cleanup RPC line (the
+    // ACP agent sends console.error("Error handling request", ...) when it
+    // has no unstable_closeNes handler, per PAPA acpx#2790) is dropped from
+    // the stream re-emitted on fd 2, since Paperclip's run harness treats
+    // any stderr output as a failed run.
+    "  exec 2> >(tee -a \"$stderr_dir/$PAPERCLIP_RUN_ID.log\" | grep -Ev \"method: 'nes/close'.*-32601\" >&2 || true)",
     "fi",
     `exec ${input.agentCommandShell} "$@"`,
     "",


### PR DESCRIPTION
## Summary
- Fixes CMOAAA-2790: every `acpx_local` run's generated wrapper script tees the child agent's real stderr through to the parent process (`>&2`) for Paperclip's run harness to observe live.
- `@agentclientprotocol/claude-agent-acp` calls `nes/close` (`unstable_closeNes`) during session cleanup; the ACP SDK's agent-side connection has no handler for it and logs a benign `Error handling request { method: 'nes/close' } { code: -32601, ... }` line to stderr.
- Because the harness treats any run stderr output as a failed run, this self-resolving cleanup RPC error was marking every `acpx_local` run as `status: error`, even when the run completed successfully and produced real work.
- The fix filters only this one known-benign line out of the stream re-emitted on fd 2 in the generated wrapper (`packages/adapters/acpx-local/src/server/execute.ts`), while still teeing the full, unfiltered child stderr to the per-run log file, so genuine failure diagnostics are unaffected.

## Test plan
- [x] Added a regression test (`execute.test.ts`) that spawns a fake agent emitting both the benign `nes/close` line and a genuine crash line, and asserts the benign line is dropped from forwarded stderr while both lines still land in the run log file.
- [x] Ran the full `acpx-local` test suite: `vitest run packages/adapters/acpx-local/src/server/execute.test.ts` — 17/17 passed.