### PR TITLE
feat(SAG-5859): configurable recovery/productivity-review owner (prefer EA over CEO)

### DIFF
--- a/packages/db/src/migrations/0128_companies_recovery_review_owner.sql
+++ b/packages/db/src/migrations/0128_companies_recovery_review_owner.sql
@@ -1,0 +1,8 @@
+ALTER TABLE "companies" ADD COLUMN IF NOT EXISTS "recovery_review_owner_agent_id" uuid;--> statement-breakpoint
+DO $$ BEGIN
+	IF NOT EXISTS (
+		SELECT 1 FROM "pg_constraint" WHERE "conname" = 'companies_recovery_review_owner_agent_id_agents_id_fk'
+	) THEN
+		ALTER TABLE "companies" ADD CONSTRAINT "companies_recovery_review_owner_agent_id_agents_id_fk" FOREIGN KEY ("recovery_review_owner_agent_id") REFERENCES "public"."agents"("id") ON DELETE set null ON UPDATE no action;
+	END IF;
+END $$;--> statement-breakpoint

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -897,6 +897,13 @@
       "when": 1782526500000,
       "tag": "0127_environment_custom_images_instance_scoped",
       "breakpoints": true
+    },
+    {
+      "idx": 128,
+      "version": "7",
+      "when": 1782526600000,
+      "tag": "0128_companies_recovery_review_owner",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/companies.ts
+++ b/packages/db/src/schema/companies.ts
@@ -1,4 +1,5 @@
-import { pgTable, uuid, text, integer, timestamp, boolean, uniqueIndex } from "drizzle-orm/pg-core";
+import { type AnyPgColumn, pgTable, uuid, text, integer, timestamp, boolean, uniqueIndex } from "drizzle-orm/pg-core";
+import { agents } from "./agents.js";
 
 export const companies = pgTable(
   "companies",
@@ -26,6 +27,9 @@ export const companies = pgTable(
     feedbackDataSharingConsentByUserId: text("feedback_data_sharing_consent_by_user_id"),
     feedbackDataSharingTermsVersion: text("feedback_data_sharing_terms_version"),
     brandColor: text("brand_color"),
+    recoveryReviewOwnerAgentId: uuid("recovery_review_owner_agent_id").references(
+      (): AnyPgColumn => agents.id,
+    ),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },

--- a/server/src/__tests__/productivity-review-service.test.ts
+++ b/server/src/__tests__/productivity-review-service.test.ts
@@ -113,6 +113,101 @@ describeEmbeddedPostgres("productivity review service", () => {
     return { companyId, managerId, coderId, issueId, issuePrefix, createdAt };
   }
 
+  async function seedCeoEscalationIssue(opts?: {
+    directorReportsToCeo?: boolean;
+    recoveryReviewOwnerAgentId?: string | null;
+    includeCto?: boolean;
+  }) {
+    const companyId = randomUUID();
+    const ceoId = randomUUID();
+    const directorId = randomUUID();
+    const eaId = randomUUID();
+    const issueId = randomUUID();
+    const issuePrefix = `PR${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+    const createdAt = new Date("2026-04-28T10:00:00.000Z");
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Escalation Review Co",
+      issuePrefix,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values([
+      {
+        id: ceoId,
+        companyId,
+        name: "CEO",
+        role: "ceo",
+        status: "idle",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+      {
+        id: eaId,
+        companyId,
+        name: "Executive Assistant",
+        role: "ea",
+        status: "idle",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+      ...(opts?.includeCto
+        ? [
+          {
+            id: randomUUID(),
+            companyId,
+            name: "CTO",
+            role: "cto",
+            status: "idle",
+            adapterType: "codex_local",
+            adapterConfig: {},
+            runtimeConfig: {},
+            permissions: {},
+          },
+        ]
+        : []),
+      {
+        id: directorId,
+        companyId,
+        name: "Engineering Director",
+        role: "engineering_director",
+        status: "idle",
+        reportsTo: opts?.directorReportsToCeo === false ? null : ceoId,
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+    ]);
+    await db
+      .update(companies)
+      .set({
+        recoveryReviewOwnerAgentId:
+          opts?.recoveryReviewOwnerAgentId === undefined ? eaId : opts.recoveryReviewOwnerAgentId,
+      })
+      .where(eq(companies.id, companyId));
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Escalation runbook",
+      status: "in_progress",
+      priority: "medium",
+      assigneeAgentId: directorId,
+      originKind: "manual",
+      issueNumber: 1,
+      identifier: `${issuePrefix}-1`,
+      startedAt: createdAt,
+      createdAt,
+      updatedAt: createdAt,
+    });
+
+    return { companyId, ceoId, directorId, eaId, issueId, issuePrefix, createdAt };
+  }
+
   async function insertRuns(input: {
     companyId: string;
     agentId: string;
@@ -562,5 +657,115 @@ describeEmbeddedPostgres("productivity review service", () => {
     expect(result.failed).toBe(0);
     const [review] = await listProductivityReviews(seeded.companyId);
     expect(review?.requestDepth).toBe(MAX_ISSUE_REQUEST_DEPTH);
+  });
+
+  it("routes a Director's productivity review to the configured recovery-review owner instead of the CEO via reportsTo", async () => {
+    const now = new Date("2026-04-28T12:00:00.000Z");
+    const seeded = await seedCeoEscalationIssue();
+    await insertRuns({
+      companyId: seeded.companyId,
+      agentId: seeded.directorId,
+      issueId: seeded.issueId,
+      count: DEFAULT_PRODUCTIVITY_REVIEW_NO_COMMENT_STREAK_RUNS,
+      now,
+    });
+
+    const result = await productivityReviewService(db).reconcileProductivityReviews({
+      now,
+      companyId: seeded.companyId,
+    });
+
+    expect(result.created).toBe(1);
+    const [review] = await listProductivityReviews(seeded.companyId);
+    expect(review?.assigneeAgentId).toBe(seeded.eaId);
+  });
+
+  it("routes to the configured recovery-review owner via the role-fallback path (no reportsTo/creator/lead)", async () => {
+    const now = new Date("2026-04-28T12:00:00.000Z");
+    const seeded = await seedCeoEscalationIssue({ directorReportsToCeo: false });
+    await insertRuns({
+      companyId: seeded.companyId,
+      agentId: seeded.directorId,
+      issueId: seeded.issueId,
+      count: DEFAULT_PRODUCTIVITY_REVIEW_NO_COMMENT_STREAK_RUNS,
+      now,
+    });
+
+    const result = await productivityReviewService(db).reconcileProductivityReviews({
+      now,
+      companyId: seeded.companyId,
+    });
+
+    expect(result.created).toBe(1);
+    const [review] = await listProductivityReviews(seeded.companyId);
+    expect(review?.assigneeAgentId).toBe(seeded.eaId);
+  });
+
+  it("falls back to the CEO unchanged when recoveryReviewOwnerAgentId is not configured", async () => {
+    const now = new Date("2026-04-28T12:00:00.000Z");
+    const seeded = await seedCeoEscalationIssue({ recoveryReviewOwnerAgentId: null });
+    await insertRuns({
+      companyId: seeded.companyId,
+      agentId: seeded.directorId,
+      issueId: seeded.issueId,
+      count: DEFAULT_PRODUCTIVITY_REVIEW_NO_COMMENT_STREAK_RUNS,
+      now,
+    });
+
+    const result = await productivityReviewService(db).reconcileProductivityReviews({
+      now,
+      companyId: seeded.companyId,
+    });
+
+    expect(result.created).toBe(1);
+    const [review] = await listProductivityReviews(seeded.companyId);
+    expect(review?.assigneeAgentId).toBe(seeded.ceoId);
+  });
+
+  it("still routes a non-CEO manager's direct report review to that manager, unaffected by the configured recovery owner", async () => {
+    const now = new Date("2026-04-28T12:00:00.000Z");
+    const seeded = await seedAssignedIssue();
+    await db
+      .update(companies)
+      .set({ recoveryReviewOwnerAgentId: seeded.coderId })
+      .where(eq(companies.id, seeded.companyId));
+    await insertRuns({
+      companyId: seeded.companyId,
+      agentId: seeded.coderId,
+      issueId: seeded.issueId,
+      count: DEFAULT_PRODUCTIVITY_REVIEW_NO_COMMENT_STREAK_RUNS,
+      now,
+    });
+
+    const result = await productivityReviewService(db).reconcileProductivityReviews({
+      now,
+      companyId: seeded.companyId,
+    });
+
+    expect(result.created).toBe(1);
+    const [review] = await listProductivityReviews(seeded.companyId);
+    expect(review?.assigneeAgentId).toBe(seeded.managerId);
+  });
+
+  it("falls through to the CEO when the configured recovery-review owner is paused", async () => {
+    const now = new Date("2026-04-28T12:00:00.000Z");
+    const seeded = await seedCeoEscalationIssue();
+    await db.update(agents).set({ status: "paused" }).where(eq(agents.id, seeded.eaId));
+    await insertRuns({
+      companyId: seeded.companyId,
+      agentId: seeded.directorId,
+      issueId: seeded.issueId,
+      count: DEFAULT_PRODUCTIVITY_REVIEW_NO_COMMENT_STREAK_RUNS,
+      now,
+    });
+
+    const result = await productivityReviewService(db).reconcileProductivityReviews({
+      now,
+      companyId: seeded.companyId,
+    });
+
+    expect(result.created).toBe(1);
+    const [review] = await listProductivityReviews(seeded.companyId);
+    expect(review?.assigneeAgentId).toBe(seeded.ceoId);
   });
 });

--- a/server/src/services/productivity-review.ts
+++ b/server/src/services/productivity-review.ts
@@ -522,6 +522,29 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
     };
   }
 
+  async function getCompanyRecoveryReviewOwnerAgentId(companyId: string) {
+    return db
+      .select({ recoveryReviewOwnerAgentId: companies.recoveryReviewOwnerAgentId })
+      .from(companies)
+      .where(eq(companies.id, companyId))
+      .then((rows) => rows[0]?.recoveryReviewOwnerAgentId ?? null);
+  }
+
+  async function isCandidateInvokable(companyId: string, sourceIssue: IssueRow, candidate: AgentRow | null) {
+    if (!candidate || candidate.companyId !== companyId || !isAgentInvokable(candidate)) return false;
+    const budgetBlock = await budgets.getInvocationBlock(companyId, candidate.id, {
+      issueId: sourceIssue.id,
+      projectId: sourceIssue.projectId ?? null,
+    });
+    return !budgetBlock;
+  }
+
+  // resolveStaleRunOwnerAgentId / resolveStrandedIssueRecoveryOwnerAgentId /
+  // resolveEscalationOwnerAgentId in recovery/service.ts implement independent
+  // owner-resolution logic for the stale_active_run_evaluation, stranded_issue_recovery,
+  // and harness_liveness_escalation origins respectively; they are not touched here
+  // and still terminate at the CEO role fallback (SAG-5859 scoped this ticket to the
+  // productivity-review origin only).
   async function resolveReviewOwnerAgentId(sourceIssue: IssueRow, sourceAgent: AgentRow) {
     const candidateIds: string[] = [];
     if (sourceAgent.reportsTo) candidateIds.push(sourceAgent.reportsTo);
@@ -541,17 +564,22 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
       .orderBy(sql`case when ${agents.role} = 'cto' then 0 else 1 end`, asc(agents.createdAt), asc(agents.id));
     candidateIds.push(...roleCandidates.map((agent) => agent.id));
 
+    const configuredOwnerId = await getCompanyRecoveryReviewOwnerAgentId(sourceIssue.companyId);
+
     const seen = new Set<string>();
     for (const agentId of candidateIds) {
       if (seen.has(agentId)) continue;
       seen.add(agentId);
       const candidate = await getAgent(agentId);
-      if (!candidate || candidate.companyId !== sourceIssue.companyId || !isAgentInvokable(candidate)) continue;
-      const budgetBlock = await budgets.getInvocationBlock(sourceIssue.companyId, candidate.id, {
-        issueId: sourceIssue.id,
-        projectId: sourceIssue.projectId ?? null,
-      });
-      if (!budgetBlock) return candidate.id;
+      if (!(await isCandidateInvokable(sourceIssue.companyId, sourceIssue, candidate))) continue;
+
+      if (candidate!.role === "ceo" && configuredOwnerId && configuredOwnerId !== candidate!.id) {
+        const configuredOwner = await getAgent(configuredOwnerId);
+        if (await isCandidateInvokable(sourceIssue.companyId, sourceIssue, configuredOwner)) {
+          return configuredOwner!.id;
+        }
+      }
+      return candidate!.id;
     }
     return null;
   }


### PR DESCRIPTION
## Thinking Path
The auto-generated "Review productivity for X" issues were escalating stalled Directors to the CEO through two independent paths: a one-hop `reportsTo` chain that terminates at the CEO, and the terminal `["cto", "ceo"]` role fallback used when no reportsTo/creator/lead exists. Both paths converged on the CEO because every Director in this org chart reports to the CEO, producing the GOVERNANCE.md §13 false-positive escalations flagged in SAG-5850/SAG-5853. Rather than hard-coding a specific agent, the fix adds a company-scoped configurable substitute (`recoveryReviewOwnerAgentId`) that the resolver only consults at the moment a candidate would resolve to a `ceo`-role agent, and only substitutes when that configured owner is itself invokable and budget-free, so the CEO always remains the last-resort fallback rather than being removed as an option. Non-CEO manager routing needed to stay completely untouched, so the substitution check fires only on `candidate.role === "ceo"`, leaving the existing reportsTo/lead paths for non-CEO managers unaffected.

## What Changed
- Added nullable `companies.recoveryReviewOwnerAgentId` (FK -> `agents.id`) + migration `0128_companies_recovery_review_owner.sql`.
- `resolveReviewOwnerAgentId` in `server/src/services/productivity-review.ts` now substitutes the configured owner ahead of the CEO whenever the next-eligible candidate (via `reportsTo` or the `["cto","ceo"]` role fallback) resolves to a `ceo`-role agent, provided the configured owner is invokable and budget-free; otherwise it falls through to the CEO unchanged.
- Confirmed the sibling recovery origins (`stranded_issue_recovery`, `stale_active_run_evaluation`, `harness_liveness_escalation` in `recovery/service.ts`) use independent resolver functions and are out of scope here — left a code comment so they aren't silently assumed fixed.
- Config value intentionally left unset (null) — this PR ships the mechanism only; setting it is a CTO follow-up.

## Verification
- TDD: confirmed the red phase (2/5 new tests failing for the right reason) before implementing.
- `productivity-review-service.test.ts`: 16/16 passing, including 5 new cases (reportsTo->CEO substitution, role-fallback substitution, null-config unchanged CEO fallback, non-CEO manager routing unaffected, paused configured-owner falls through to CEO) — independently re-run by the reviewer with `pnpm --filter server exec vitest run src/__tests__/productivity-review-service.test.ts`, all 16 green.
- Regression: `heartbeat-issue-liveness-escalation.test.ts`, `issue-recovery-actions.test.ts`, `recovery-classifiers.test.ts`, `recovery-stale-issue-lock-sweep.test.ts` + productivity-review suite together — 65/65 passing, no regressions.
- `pnpm run typecheck` clean in `packages/db` and `server/`; `pnpm run check:migrations` clean.

## Risks
Low risk: the change is additive (nullable column, default null) and behavior is unchanged unless a company explicitly sets `recoveryReviewOwnerAgentId`, which this PR does not do. The main residual risk is a misconfigured owner (e.g. pointed at a paused or over-budget agent), which is mitigated by the existing invokable/budget guard falling through to the CEO.

## Model Used
Claude Opus 4.7 (Anthropic) via Claude Code — implementation. Reviewed by Claude Sonnet 4.6 (Claude Code Reviewer).

## Problem or motivation
Auto-generated productivity/recovery-review issues for Directors always escalate to the CEO (via `reportsTo` or the `["cto","ceo"]` role fallback), causing recurring GOVERNANCE.md §13 false-positive review noise on the CEO — see SAG-5850/SAG-5853.

## Proposed solution
Add a nullable, company-scoped `recoveryReviewOwnerAgentId` config and prefer it over the CEO in `resolveReviewOwnerAgentId` whenever the next-eligible candidate would resolve to a `ceo`-role agent, while leaving non-CEO manager routing and the CEO safety-net fallback intact.

## Alternatives considered
Hard-coding an EA as the CEO's review delegate was rejected as not backward compatible and not configurable per company; special-casing "the CEO agent" by name was rejected as brittle versus resolving by role.

## Roadmap alignment
Directly implements the SAG-5853/SAG-5850 §13 routing fix requested by the CEO's weekly productivity review.

Fixes SAG-5859 (child of SAG-5853 / SAG-5850).

- [x] I searched the GitHub PR list (open + recently closed) for similar PRs and confirmed this is not a duplicate — no other open PR touches `resolveReviewOwnerAgentId` or `recoveryReviewOwnerAgentId`.

Not merging — routing to Claude Code Reviewer -> QA -> CTO for the merge gate per ticket instructions.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
