### PR TITLE
fix(productivity): suppress long-active reviews for future monitors

### DIFF
--- a/server/src/__tests__/productivity-review-service.test.ts
+++ b/server/src/__tests__/productivity-review-service.test.ts
@@ -55,6 +55,9 @@ describeEmbeddedPostgres("productivity review service", () => {
     startedAt?: Date;
     parentId?: string | null;
     originKind?: string;
+    monitorNextCheckAt?: Date | null;
+    executionPolicy?: Record<string, unknown> | null;
+    executionState?: Record<string, unknown> | null;
   }) {
     const companyId = randomUUID();
     const managerId = randomUUID();
@@ -103,6 +106,9 @@ describeEmbeddedPostgres("productivity review service", () => {
       assigneeAgentId: coderId,
       parentId: opts?.parentId ?? null,
       originKind: opts?.originKind ?? "manual",
+      monitorNextCheckAt: opts?.monitorNextCheckAt,
+      executionPolicy: opts?.executionPolicy,
+      executionState: opts?.executionState,
       issueNumber: 1,
       identifier: `${issuePrefix}-1`,
       startedAt: opts?.startedAt ?? createdAt,
@@ -358,6 +364,42 @@ describeEmbeddedPostgres("productivity review service", () => {
     expect(review?.description).toContain("Primary trigger: `long_active_duration`");
     expect(review?.priority).toBe("medium");
     expect(hold.held).toBe(false);
+  });
+
+  it.each([
+    {
+      label: "monitor_next_check_at",
+      issueFields: (nextCheckAt: Date) => ({ monitorNextCheckAt: nextCheckAt }),
+    },
+    {
+      label: "executionPolicy.monitor.nextCheckAt",
+      issueFields: (nextCheckAt: Date) => ({
+        executionPolicy: { monitor: { nextCheckAt: nextCheckAt.toISOString() } },
+      }),
+    },
+    {
+      label: "executionState.monitor.nextCheckAt",
+      issueFields: (nextCheckAt: Date) => ({
+        executionState: { monitor: { status: "scheduled", nextCheckAt: nextCheckAt.toISOString() } },
+      }),
+    },
+  ])("suppresses long-active productivity reviews for future scheduled monitors from $label", async ({ issueFields }) => {
+    const now = new Date("2026-04-28T12:00:00.000Z");
+    const nextCheckAt = new Date("2026-04-29T12:00:00.000Z");
+    const seeded = await seedAssignedIssue({
+      status: "in_progress",
+      startedAt: new Date(now.getTime() - 7 * 60 * 60 * 1000),
+      ...issueFields(nextCheckAt),
+    });
+
+    const result = await productivityReviewService(db).reconcileProductivityReviews({
+      now,
+      companyId: seeded.companyId,
+    });
+
+    expect(result.created).toBe(0);
+    expect(result.skipped).toBe(1);
+    expect(await listProductivityReviews(seeded.companyId)).toHaveLength(0);
   });
 
   it("creates a high-churn review even when every sampled run has a progress comment", async () => {

--- a/server/src/services/productivity-review.ts
+++ b/server/src/services/productivity-review.ts
@@ -138,6 +138,27 @@ function coerceDate(value: Date | string | null | undefined) {
   return value instanceof Date ? value : new Date(value);
 }
 
+function readMonitorNextCheckAt(value: unknown) {
+  if (!value || typeof value !== "object") return null;
+  const monitor = (value as { monitor?: unknown }).monitor;
+  if (!monitor || typeof monitor !== "object") return null;
+  const nextCheckAt = (monitor as { nextCheckAt?: unknown }).nextCheckAt;
+  return nextCheckAt instanceof Date || typeof nextCheckAt === "string" ? coerceDate(nextCheckAt) : null;
+}
+
+function isFutureDate(value: Date | null, now: Date) {
+  return Boolean(value && Number.isFinite(value.getTime()) && value.getTime() > now.getTime());
+}
+
+function hasFutureScheduledMonitor(issue: Pick<IssueRow, "status" | "monitorNextCheckAt" | "executionPolicy" | "executionState">, now: Date) {
+  if (issue.status !== "in_progress") return false;
+  return [
+    coerceDate(issue.monitorNextCheckAt),
+    readMonitorNextCheckAt(issue.executionPolicy),
+    readMonitorNextCheckAt(issue.executionState),
+  ].some((nextCheckAt) => isFutureDate(nextCheckAt, now));
+}
+
 function buildThresholds(overrides?: Partial<ProductivityReviewThresholds>): ProductivityReviewThresholds {
   return {
     noCommentStreakRuns: readPositiveInteger(
@@ -476,7 +497,8 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
       : null;
 
     const noComment = noCommentStreak >= thresholds.noCommentStreakRuns;
-    const longActive = elapsedMs !== null && elapsedMs >= thresholds.longActiveMs;
+    const futureMonitorScheduled = hasFutureScheduledMonitor(sourceIssue, now);
+    const longActive = !futureMonitorScheduled && elapsedMs !== null && elapsedMs >= thresholds.longActiveMs;
     const highChurn =
       runCountLastHour >= thresholds.highChurnHourly ||
       assigneeRunCommentCountLastHour >= thresholds.highChurnHourly ||


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The productivity-review service reconciles assigned issues into manager review work when activity patterns look unhealthy.
> - Long-active detection currently only considers elapsed in-progress time from the active episode.
> - A scheduled issue monitor can intentionally leave an issue in progress until a future wake time, so elapsed time alone can look stale even when the wait is healthy.
> - This pull request suppresses only the long-active signal when a future monitor is present on the denormalized issue field, execution policy, or execution state.
> - The benefit is fewer false-positive productivity review tasks without weakening no-comment or high-churn review signals.

## Linked Issues or Issue Description

No public GitHub issue exists for this exact bug.

Bug description:

- Productivity review reconciliation can create `Review productivity for ...` work from `long_active_duration` for an in-progress issue that is intentionally parked on a future scheduled monitor.
- Expected behavior: future scheduled monitor waits should not count as long-active productivity failures.
- Actual behavior: elapsed active time alone can create or refresh productivity review work.

Related public work:

- Refs #8816, which is broader and requires all monitor surfaces to agree before suppressing long-active reviews.
- Refs #4827, which discusses a broader monitor-policy exemption.

## What Changed

- Added monitor timestamp detection for `monitorNextCheckAt`, `executionPolicy.monitor.nextCheckAt`, and `executionState.monitor.nextCheckAt`.
- Suppressed the `long_active_duration` trigger when an in-progress issue has any future scheduled monitor timestamp.
- Added embedded Postgres coverage for all three monitor timestamp surfaces.

## Verification

- `pnpm vitest run server/src/__tests__/productivity-review-service.test.ts` - passed, 14 tests.
- `pnpm exec tsc -p server/tsconfig.json --noEmit` - passed.
- `pnpm --filter @paperclipai/server typecheck` - passed.

## Risks

- Low risk: the change only removes one trigger signal from productivity-review evidence when a future monitor timestamp is present.
- No database schema or migration changes.
- No LinkedIn publish-runner or monitor-runner behavior changes.

## Model Used

- OpenAI Codex, GPT-5 coding agent, tool-enabled terminal workflow.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge