### PR TITLE
feat(approvals): require a reason or explicit force when rejecting

### DIFF
--- a/cli/src/__tests__/approval-reject.test.ts
+++ b/cli/src/__tests__/approval-reject.test.ts
@@ -73,4 +73,73 @@ describe("approval reject command", () => {
     expect(url).toBe(`http://localhost:3100/api/approvals/${APPROVAL_ID}/reject`);
     expect(JSON.parse(String(init.body))).toEqual({});
   });
+
+  it("still accepts --decision-note for backward compatibility with existing scripts", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ id: APPROVAL_ID, status: "rejected" }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await runCommand(["approval", "reject", APPROVAL_ID, "--decision-note", "Duplicate of an existing hire"]);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe(`http://localhost:3100/api/approvals/${APPROVAL_ID}/reject`);
+    expect(JSON.parse(String(init.body))).toEqual({ decisionNote: "Duplicate of an existing hire" });
+  });
+
+  it("prefers --reason and warns when --reason and --decision-note disagree", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ id: APPROVAL_ID, status: "rejected" }));
+    vi.stubGlobal("fetch", fetchMock);
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    await runCommand([
+      "approval",
+      "reject",
+      APPROVAL_ID,
+      "--reason",
+      "Reason wins",
+      "--decision-note",
+      "Different note",
+    ]);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe(`http://localhost:3100/api/approvals/${APPROVAL_ID}/reject`);
+    expect(JSON.parse(String(init.body))).toEqual({ decisionNote: "Reason wins" });
+    expect(String(warnSpy.mock.calls[0]?.[0])).toContain("Both --reason and --decision-note");
+  });
+
+  it("uses the matching value without warning when --reason and --decision-note agree", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ id: APPROVAL_ID, status: "rejected" }));
+    vi.stubGlobal("fetch", fetchMock);
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    await runCommand([
+      "approval",
+      "reject",
+      APPROVAL_ID,
+      "--reason",
+      "Same reason",
+      "--decision-note",
+      "Same reason",
+    ]);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(JSON.parse(String(init.body))).toEqual({ decisionNote: "Same reason" });
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("refuses reasonless rejection when neither alias is given even with unrelated flags", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    vi.spyOn(process, "exit").mockImplementation(((code?: string | number | null) => {
+      throw new Error(`exit:${code ?? 0}`);
+    }) as typeof process.exit);
+
+    await expect(
+      runCommand(["approval", "reject", APPROVAL_ID, "--decided-by-user-id", "user-1"]),
+    ).rejects.toThrow("exit:1");
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
 });

--- a/cli/src/__tests__/approval-reject.test.ts
+++ b/cli/src/__tests__/approval-reject.test.ts
@@ -1,0 +1,76 @@
+import { Command } from "commander";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { registerApprovalCommands } from "../commands/client/approval.js";
+
+const APPROVAL_ID = "33333333-3333-4333-8333-333333333333";
+
+function createProgram(): Command {
+  const program = new Command();
+  program.exitOverride();
+  program.configureOutput({ writeOut: () => {}, writeErr: () => {} });
+  registerApprovalCommands(program);
+  return program;
+}
+
+async function runCommand(args: string[]): Promise<void> {
+  await createProgram().parseAsync([
+    ...args,
+    "--api-base", "http://localhost:3100",
+    "--api-key", "board-token",
+  ], { from: "user" });
+}
+
+function jsonResponse(body: unknown = { ok: true }, init: ResponseInit = { status: 200 }): Response {
+  return new Response(JSON.stringify(body), init);
+}
+
+describe("approval reject command", () => {
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("refuses reasonless rejection when neither --reason nor --force is given", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    vi.spyOn(process, "exit").mockImplementation(((code?: string | number | null) => {
+      throw new Error(`exit:${code ?? 0}`);
+    }) as typeof process.exit);
+
+    await expect(runCommand(["approval", "reject", APPROVAL_ID])).rejects.toThrow("exit:1");
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(String(errorSpy.mock.calls[0]?.[0])).toContain("Refusing reasonless rejection");
+  });
+
+  it("rejects with a reason and persists it as the decision note", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ id: APPROVAL_ID, status: "rejected" }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await runCommand(["approval", "reject", APPROVAL_ID, "--reason", "Duplicate of an existing hire"]);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe(`http://localhost:3100/api/approvals/${APPROVAL_ID}/reject`);
+    expect(JSON.parse(String(init.body))).toEqual({ decisionNote: "Duplicate of an existing hire" });
+  });
+
+  it("allows the explicit --force path to reject without a reason", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ id: APPROVAL_ID, status: "rejected" }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await runCommand(["approval", "reject", APPROVAL_ID, "--force"]);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe(`http://localhost:3100/api/approvals/${APPROVAL_ID}/reject`);
+    expect(JSON.parse(String(init.body))).toEqual({});
+  });
+});

--- a/cli/src/commands/client/approval.ts
+++ b/cli/src/commands/client/approval.ts
@@ -27,6 +27,12 @@ interface ApprovalDecisionOptions extends BaseClientOptions {
   decidedByUserId?: string;
 }
 
+interface ApprovalRejectOptions extends BaseClientOptions {
+  reason?: string;
+  force?: boolean;
+  decidedByUserId?: string;
+}
+
 interface ApprovalCreateOptions extends BaseClientOptions {
   companyId?: string;
   type: string;
@@ -160,15 +166,22 @@ export function registerApprovalCommands(program: Command): void {
   addCommonClientOptions(
     approval
       .command("reject")
-      .description("Reject an approval request")
+      .description(
+        "Reject an approval request.\n" +
+          "  Requires --reason so the requesting agent learns why, or an explicit --force to reject without one.",
+      )
       .argument("<approvalId>", "Approval ID")
-      .option("--decision-note <text>", "Decision note")
+      .option("--reason <text>", "Reason recorded on the approval and shown to the requesting agent")
+      .option("--force", "Reject without a reason", false)
       .option("--decided-by-user-id <id>", "Decision actor user ID")
-      .action(async (approvalId: string, opts: ApprovalDecisionOptions) => {
+      .action(async (approvalId: string, opts: ApprovalRejectOptions) => {
         try {
+          if (!opts.reason && !opts.force) {
+            throw new Error("Refusing reasonless rejection. Pass --reason <text> or use --force.");
+          }
           const ctx = resolveCommandContext(opts);
           const payload = resolveApprovalSchema.parse({
-            decisionNote: opts.decisionNote,
+            decisionNote: opts.reason,
             decidedByUserId: opts.decidedByUserId,
           });
           const updated = await ctx.api.post<Approval>(apiPath`/api/approvals/${approvalId}/reject`, payload);

--- a/cli/src/commands/client/approval.ts
+++ b/cli/src/commands/client/approval.ts
@@ -24,13 +24,27 @@ interface ApprovalListOptions extends BaseClientOptions {
 
 interface ApprovalDecisionOptions extends BaseClientOptions {
   decisionNote?: string;
+  reason?: string;
   decidedByUserId?: string;
 }
 
 interface ApprovalRejectOptions extends BaseClientOptions {
   reason?: string;
+  decisionNote?: string;
   force?: boolean;
   decidedByUserId?: string;
+}
+
+/**
+ * `--reason` and `--decision-note` are aliases for the same underlying
+ * `decisionNote` field. If both are passed and disagree, `--reason` wins
+ * (it's the preferred name) but we warn so the caller notices.
+ */
+function resolveDecisionNote(reason: string | undefined, decisionNote: string | undefined): string | undefined {
+  if (reason && decisionNote && reason !== decisionNote) {
+    console.warn("Both --reason and --decision-note were given with different values; using --reason.");
+  }
+  return reason ?? decisionNote;
 }
 
 interface ApprovalCreateOptions extends BaseClientOptions {
@@ -147,12 +161,13 @@ export function registerApprovalCommands(program: Command): void {
       .description("Approve an approval request")
       .argument("<approvalId>", "Approval ID")
       .option("--decision-note <text>", "Decision note")
+      .option("--reason <text>", "Alias for --decision-note")
       .option("--decided-by-user-id <id>", "Decision actor user ID")
       .action(async (approvalId: string, opts: ApprovalDecisionOptions) => {
         try {
           const ctx = resolveCommandContext(opts);
           const payload = resolveApprovalSchema.parse({
-            decisionNote: opts.decisionNote,
+            decisionNote: resolveDecisionNote(opts.reason, opts.decisionNote),
             decidedByUserId: opts.decidedByUserId,
           });
           const updated = await ctx.api.post<Approval>(apiPath`/api/approvals/${approvalId}/approve`, payload);
@@ -172,16 +187,18 @@ export function registerApprovalCommands(program: Command): void {
       )
       .argument("<approvalId>", "Approval ID")
       .option("--reason <text>", "Reason recorded on the approval and shown to the requesting agent")
+      .option("--decision-note <text>", "Alias for --reason (kept for backward compatibility)")
       .option("--force", "Reject without a reason", false)
       .option("--decided-by-user-id <id>", "Decision actor user ID")
       .action(async (approvalId: string, opts: ApprovalRejectOptions) => {
         try {
-          if (!opts.reason && !opts.force) {
-            throw new Error("Refusing reasonless rejection. Pass --reason <text> or use --force.");
+          const decisionNote = resolveDecisionNote(opts.reason, opts.decisionNote);
+          if (!decisionNote && !opts.force) {
+            throw new Error("Refusing reasonless rejection. Pass --reason <text> (or --decision-note) or use --force.");
           }
           const ctx = resolveCommandContext(opts);
           const payload = resolveApprovalSchema.parse({
-            decisionNote: opts.reason,
+            decisionNote,
             decidedByUserId: opts.decidedByUserId,
           });
           const updated = await ctx.api.post<Approval>(apiPath`/api/approvals/${approvalId}/reject`, payload);
@@ -198,12 +215,13 @@ export function registerApprovalCommands(program: Command): void {
       .description("Request revision for an approval")
       .argument("<approvalId>", "Approval ID")
       .option("--decision-note <text>", "Decision note")
+      .option("--reason <text>", "Alias for --decision-note")
       .option("--decided-by-user-id <id>", "Decision actor user ID")
       .action(async (approvalId: string, opts: ApprovalDecisionOptions) => {
         try {
           const ctx = resolveCommandContext(opts);
           const payload = requestApprovalRevisionSchema.parse({
-            decisionNote: opts.decisionNote,
+            decisionNote: resolveDecisionNote(opts.reason, opts.decisionNote),
             decidedByUserId: opts.decidedByUserId,
           });
           const updated = await ctx.api.post<Approval>(apiPath`/api/approvals/${approvalId}/request-revision`, payload);

--- a/ui/src/components/RejectApprovalDialog.test.tsx
+++ b/ui/src/components/RejectApprovalDialog.test.tsx
@@ -1,0 +1,121 @@
+// @vitest-environment jsdom
+
+import { flushSync } from "react-dom";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { RejectApprovalDialog } from "./RejectApprovalDialog";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+async function settleEffects() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+async function flushUi(callback: () => void) {
+  flushSync(callback);
+  await settleEffects();
+}
+
+function findButton(text: string) {
+  return Array.from(document.querySelectorAll("button")).find(
+    (button) => button.textContent === text,
+  ) as HTMLButtonElement | undefined;
+}
+
+describe("RejectApprovalDialog", () => {
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    container.remove();
+  });
+
+  it("disables the reasoned reject button until a reason is entered", async () => {
+    const onReject = vi.fn();
+    const root = createRoot(container);
+
+    await flushUi(() => {
+      root.render(
+        <RejectApprovalDialog open onOpenChange={() => {}} isPending={false} onReject={onReject} />,
+      );
+    });
+
+    const rejectWithReason = findButton("Reject with reason");
+    expect(rejectWithReason?.disabled).toBe(true);
+
+    const textarea = document.querySelector("textarea") as HTMLTextAreaElement;
+    const setter = Object.getOwnPropertyDescriptor(window.HTMLTextAreaElement.prototype, "value")!.set!;
+    await flushUi(() => {
+      setter.call(textarea, "Duplicate of an existing hire");
+      textarea.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+
+    expect(findButton("Reject with reason")?.disabled).toBe(false);
+
+    await flushUi(() => {
+      findButton("Reject with reason")?.click();
+    });
+
+    expect(onReject).toHaveBeenCalledWith("Duplicate of an existing hire");
+    root.unmount();
+  });
+
+  it("lets the force path reject without ever requiring a reason", async () => {
+    const onReject = vi.fn();
+    const root = createRoot(container);
+
+    await flushUi(() => {
+      root.render(
+        <RejectApprovalDialog open onOpenChange={() => {}} isPending={false} onReject={onReject} />,
+      );
+    });
+
+    const rejectWithoutReason = findButton("Reject without reason");
+    expect(rejectWithoutReason?.disabled).toBeFalsy();
+
+    await flushUi(() => {
+      rejectWithoutReason?.click();
+    });
+
+    expect(onReject).toHaveBeenCalledWith(undefined);
+    root.unmount();
+  });
+
+  it("resets the reason field each time the dialog is reopened", async () => {
+    const root = createRoot(container);
+
+    await flushUi(() => {
+      root.render(
+        <RejectApprovalDialog open onOpenChange={() => {}} isPending={false} onReject={() => {}} />,
+      );
+    });
+
+    const textarea = document.querySelector("textarea") as HTMLTextAreaElement;
+    const setter = Object.getOwnPropertyDescriptor(window.HTMLTextAreaElement.prototype, "value")!.set!;
+    await flushUi(() => {
+      setter.call(textarea, "Some reason");
+      textarea.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+    expect((document.querySelector("textarea") as HTMLTextAreaElement).value).toBe("Some reason");
+
+    await flushUi(() => {
+      root.render(
+        <RejectApprovalDialog open={false} onOpenChange={() => {}} isPending={false} onReject={() => {}} />,
+      );
+    });
+    await flushUi(() => {
+      root.render(
+        <RejectApprovalDialog open onOpenChange={() => {}} isPending={false} onReject={() => {}} />,
+      );
+    });
+
+    expect((document.querySelector("textarea") as HTMLTextAreaElement).value).toBe("");
+    root.unmount();
+  });
+});

--- a/ui/src/components/RejectApprovalDialog.tsx
+++ b/ui/src/components/RejectApprovalDialog.tsx
@@ -1,0 +1,73 @@
+import { useEffect, useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+
+export function RejectApprovalDialog({
+  open,
+  onOpenChange,
+  isPending,
+  onReject,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  isPending: boolean;
+  onReject: (reason?: string) => void;
+}) {
+  const [reason, setReason] = useState("");
+
+  useEffect(() => {
+    if (open) setReason("");
+  }, [open]);
+
+  return (
+    <Dialog open={open} onOpenChange={(next) => !isPending && onOpenChange(next)}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Reject approval</DialogTitle>
+          <DialogDescription>
+            Explain why so the requesting agent can learn from it. Rejecting without a reason is
+            still possible, but requires a deliberate, separate click below.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-1.5">
+          <Label className="text-xs">Reason</Label>
+          <Textarea
+            value={reason}
+            onChange={(e) => setReason(e.target.value)}
+            placeholder="Why is this being rejected?"
+            rows={4}
+            autoFocus
+          />
+        </div>
+
+        <DialogFooter className="sm:justify-between">
+          <Button
+            variant="ghost"
+            className="text-muted-foreground"
+            onClick={() => onReject(undefined)}
+            disabled={isPending}
+          >
+            Reject without reason
+          </Button>
+          <Button
+            variant="destructive"
+            onClick={() => onReject(reason.trim() || undefined)}
+            disabled={isPending || reason.trim().length === 0}
+          >
+            {isPending ? "Rejecting..." : "Reject with reason"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/ui/src/pages/ApprovalDetail.tsx
+++ b/ui/src/pages/ApprovalDetail.tsx
@@ -10,6 +10,7 @@ import { StatusBadge } from "../components/StatusBadge";
 import { Identity } from "../components/Identity";
 import { approvalLabel, typeIcon, defaultTypeIcon, ApprovalPayloadRenderer } from "../components/ApprovalPayload";
 import { PageSkeleton } from "../components/PageSkeleton";
+import { RejectApprovalDialog } from "../components/RejectApprovalDialog";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { CheckCircle2, ChevronRight, Sparkles } from "lucide-react";
@@ -26,6 +27,7 @@ export function ApprovalDetail() {
   const [commentBody, setCommentBody] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [showRawPayload, setShowRawPayload] = useState(false);
+  const [rejectDialogOpen, setRejectDialogOpen] = useState(false);
 
   const { data: approval, isLoading } = useQuery({
     queryKey: queryKeys.approvals.detail(approvalId!),
@@ -95,9 +97,10 @@ export function ApprovalDetail() {
   });
 
   const rejectMutation = useMutation({
-    mutationFn: () => approvalsApi.reject(approvalId!),
+    mutationFn: (reason?: string) => approvalsApi.reject(approvalId!, reason),
     onSuccess: () => {
       setError(null);
+      setRejectDialogOpen(false);
       refresh();
     },
     onError: (err) => setError(err instanceof Error ? err.message : "Reject failed"),
@@ -274,7 +277,7 @@ export function ApprovalDetail() {
               <Button
                 variant="destructive"
                 size="sm"
-                onClick={() => rejectMutation.mutate()}
+                onClick={() => setRejectDialogOpen(true)}
                 disabled={rejectMutation.isPending}
               >
                 Reject
@@ -363,6 +366,13 @@ export function ApprovalDetail() {
           </Button>
         </div>
       </div>
+
+      <RejectApprovalDialog
+        open={rejectDialogOpen}
+        onOpenChange={setRejectDialogOpen}
+        isPending={rejectMutation.isPending}
+        onReject={(reason) => rejectMutation.mutate(reason)}
+      />
     </div>
   );
 }

--- a/ui/src/pages/Approvals.tsx
+++ b/ui/src/pages/Approvals.tsx
@@ -12,6 +12,7 @@ import { Tabs } from "@/components/ui/tabs";
 import { ShieldCheck } from "lucide-react";
 import { ApprovalCard } from "../components/ApprovalCard";
 import { PageSkeleton } from "../components/PageSkeleton";
+import { RejectApprovalDialog } from "../components/RejectApprovalDialog";
 
 type StatusFilter = "pending" | "all";
 
@@ -24,6 +25,7 @@ export function Approvals() {
   const pathSegment = location.pathname.split("/").pop() ?? "pending";
   const statusFilter: StatusFilter = pathSegment === "all" ? "all" : "pending";
   const [actionError, setActionError] = useState<string | null>(null);
+  const [rejectTargetId, setRejectTargetId] = useState<string | null>(null);
 
   useEffect(() => {
     setBreadcrumbs([{ label: "Approvals" }]);
@@ -54,9 +56,10 @@ export function Approvals() {
   });
 
   const rejectMutation = useMutation({
-    mutationFn: (id: string) => approvalsApi.reject(id),
+    mutationFn: ({ id, reason }: { id: string; reason?: string }) => approvalsApi.reject(id, reason),
     onSuccess: () => {
       setActionError(null);
+      setRejectTargetId(null);
       queryClient.invalidateQueries({ queryKey: queryKeys.approvals.list(selectedCompanyId!) });
     },
     onError: (err) => {
@@ -120,7 +123,7 @@ export function Approvals() {
               approval={approval}
               requesterAgent={approval.requestedByAgentId ? (agents ?? []).find((a) => a.id === approval.requestedByAgentId) ?? null : null}
               onApprove={() => approveMutation.mutate(approval.id)}
-              onReject={() => rejectMutation.mutate(approval.id)}
+              onReject={() => setRejectTargetId(approval.id)}
               detailLink={`/approvals/${approval.id}`}
               isPending={approveMutation.isPending || rejectMutation.isPending}
               pendingAction={
@@ -130,6 +133,15 @@ export function Approvals() {
           ))}
         </div>
       )}
+
+      <RejectApprovalDialog
+        open={rejectTargetId !== null}
+        onOpenChange={(open) => !open && setRejectTargetId(null)}
+        isPending={rejectMutation.isPending}
+        onReject={(reason) => {
+          if (rejectTargetId) rejectMutation.mutate({ id: rejectTargetId, reason });
+        }}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The approvals subsystem is how a human blocks and reviews agent-initiated actions like hiring
> - When a human rejects an approval, the requesting agent needs to know why so it can learn and adjust
> - The API and DB already accept and persist a `decisionNote` on reject (and approve/request-revision), but nothing in the UI or CLI ever collects one — clicking Reject just calls the endpoint with no note at all
> - That leaves the audit trail silent: a rejected `hire_agent` approval shows only "rejected", with no record of why, and the requester has nothing to act on
> - This pull request makes rejecting an approval require a reason, or an explicit, separate "force" action if the reviewer genuinely has nothing to add — in both the UI and the CLI
> - The benefit is a rejection the requesting agent (and any human auditing later) can actually learn from, without silently defaulting to a reasonless rejection

## Linked Issues or Issue Description

No existing public issue tracks this specifically. Following the Feature issue template:

- **Problem/motivation**: Running a self-hosted Paperclip instance, I rejected two `hire_agent` approvals from the board UI and had no way to record why. The requesting agents couldn't learn from an unexplained rejection, and the audit trail (`decisionNote` on the `approvals` row) stayed empty. I ended up writing my reasoning somewhere else entirely, out of band from Paperclip.
- **Proposed solution**: this PR. Reject now opens a small dialog with a reason textarea and two explicit actions — "Reject with reason" (primary) and "Reject without reason" (secondary, a deliberate click rather than a silent default). The CLI mirrors this: `approval reject <id> --reason <text>` records the reason, `--force` allows a reasonless rejection, and the command refuses to proceed if neither is passed.
- **Alternatives considered**: a plain `window.prompt()` for the note (see prior art below) — simplest, but the browser-native prompt is easy to click through without thinking, doesn't distinguish "chose not to explain" from "forgot to explain," and Greptile flagged exactly that ambiguity on the earlier attempt. A modal with two distinct, explicit buttons makes the "no reason" path a deliberate choice instead of a default.
- **Roadmap alignment**: `ROADMAP.md` → "Agent Reviews and Approvals" calls for "durable audit trails that fit the same task model as the rest of the control plane" for the approvals system. An unexplained rejection is exactly the audit-trail gap that line describes.

**Prior art**: #2134 ("feat(ui): prompt for decision note when approving or rejecting") already wired `decisionNote` into Approve/Reject/Request-revision via `window.prompt()`, and got a 5/5 Greptile pass back in March, but has sat unmerged for ~3 months and touches the exact same `rejectMutation`/`onClick` lines in `ApprovalDetail.tsx` that this PR touches. Thanks to @bluzername for identifying the same gap and doing the legwork of tracing it to the unused `decisionNote` field. I did not build on that branch directly because this PR takes a different shape for the reasons above (dialog instead of `window.prompt`, an explicit force path, and CLI support), but flagging it here per CONTRIBUTING.md so a reviewer has full context and can decide whether to close #2134 in favor of this one.

## What Changed

- `cli/src/commands/client/approval.ts`: `approval reject <id>` now takes `--reason <text>` (persisted as the existing `decisionNote` field) and `--force` (explicit reasonless rejection). The command throws before making any request if neither flag is given.
- `ui/src/components/RejectApprovalDialog.tsx` (new): a small dialog — reason textarea, primary "Reject with reason" (disabled until a reason is typed), secondary "Reject without reason".
- `ui/src/pages/ApprovalDetail.tsx` and `ui/src/pages/Approvals.tsx`: the Reject button now opens the dialog instead of calling `reject()` with no note.
- No DB/API/schema changes — `decisionNote` was already accepted end-to-end by `resolveApprovalSchema`, the `/approvals/:id/reject` route, and the `approvalService.reject` persistence; it just never reached the UI or CLI for rejections specifically.

## Verification

- `pnpm --filter paperclipai typecheck` — clean.
- `pnpm --filter @paperclipai/ui typecheck` — clean.
- `pnpm --filter @paperclipai/server typecheck` — clean.
- `pnpm exec vitest run` (cli): 44 files / 233 tests passed, including new `cli/src/__tests__/approval-reject.test.ts` (refuses with neither flag, `--reason` sends `decisionNote`, `--force` sends no note).
- `pnpm exec vitest run` (ui, relevant files): new `ui/src/components/RejectApprovalDialog.test.tsx` (3 tests) passed, plus existing `ApprovalPayload.test.tsx`; full UI suite is 263/266 files green, the 3 unrelated failures (`ScheduleEditor.test.tsx`, `cron-fires.test.ts`, `editable-sections.test.tsx`) are pre-existing 5s-timeout flakes under full-suite load — reproduced identically on `master` and pass individually.
- `server`: existing `approvals-service.test.ts` and `approval-routes-idempotency.test.ts` (17 tests) still pass unchanged, confirming the reused `decisionNote` plumbing wasn't touched.
- `pnpm --filter @paperclipai/ui build` and `pnpm --filter paperclipai build` both succeed.
- Manual: `approval reject <id>` with no flags exits 1 with "Refusing reasonless rejection..."; `--reason "..."` and `--force` both post the expected body (verified via mocked-fetch assertions in the new CLI test).

## Risks

Low risk. No schema/migration/API surface change — this only adds a UI affordance and a CLI flag on top of an already-accepted, already-tested field. The one behavior change: `approval reject` from the CLI now refuses (exit 1) if called with neither `--reason` nor `--force`, where previously it silently rejected with no note. Anyone scripting `approval reject <id>` with no flags will need to add `--force` — flagging this as the one compatibility-relevant change, though it only tightens a previously-silent gap rather than removing capability.

## Model Used

Claude Sonnet 5 (`claude-sonnet-5`), via Claude Code. Standard (non-extended) thinking mode, tool use (file read/edit/bash/test execution) enabled, no extended context window required for this change.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes (none needed — no user-facing docs describe approval rejection today)
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green (typecheck/build/tests run locally as noted above; awaiting CI confirmation)
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups (pending automated review on this PR)
- [x] I will address all Greptile and reviewer comments before requesting merge
