### PR TITLE
build(agent-runtime): ship ripgrep in the base image

### DIFF
--- a/docker/agent-runtime/Dockerfile.base
+++ b/docker/agent-runtime/Dockerfile.base
@@ -19,8 +19,14 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH:-amd64} \
 # Add it when git workspace population lands.
 FROM ubuntu:22.04 AS base
 ARG NODE_VERSION
+# ripgrep (rg): required on PATH so OpenCode's skill tooling uses the system
+# binary instead of trying to download a pinned build from github.com at run
+# time. A sandbox with locked-down egress makes that download hang ~127s then
+# fail ("Transport error ... BurntSushi/ripgrep/releases/..."), wasting run
+# budget on every agent run. The root repo Dockerfile already ships rg; this
+# restores parity for the agent-runtime image.
 RUN apt-get update && apt-get install -y --no-install-recommends \
-      ca-certificates curl git tini gnupg \
+      ca-certificates curl git tini gnupg ripgrep \
     && rm -rf /var/lib/apt/lists/* \
     && curl -fsSL https://deb.nodesource.com/setup_${NODE_VERSION}.x | bash - \
     && apt-get install -y --no-install-recommends nodejs \


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Agents execute inside sandboxed runtime containers built from `docker/agent-runtime/Dockerfile.base`
> - OpenCode's skill tooling shells out to ripgrep; when `rg` is not on PATH it tries to download a pinned build from `github.com/BurntSushi/ripgrep/releases` at run time
> - In a sandbox with locked-down egress that download hangs ~127s and then fails, burning run budget on every agent run before the agent reaches its actual work
> - The root repo `Dockerfile` already installs ripgrep; the agent-runtime base image drifted without it
> - This pull request adds `ripgrep` to the base image's apt install so OpenCode uses the system binary and never reaches for the network
> - The benefit is that every sandboxed agent run stops wasting ~2 minutes on a doomed download and spends its budget on real work

## Linked Issues or Issue Description

No existing issue — problem described here per the bug report template:

- **What happened:** Sandboxed agent runs using OpenCode stall for ~127 seconds at startup, then log `Transport error ... BurntSushi/ripgrep/releases/download/...` before continuing degraded.
- **Expected behavior:** The agent starts working immediately; skill tooling finds `rg` on PATH.
- **Root cause:** The agent-runtime base image (`docker/agent-runtime/Dockerfile.base`) does not ship ripgrep, so OpenCode falls back to downloading a pinned build at run time, which egress-restricted sandboxes block.
- **Reproduction:** Run any OpenCode-backed agent in a sandbox with locked-down egress using the current agent-runtime image; observe the startup hang and transport error.

Supersedes #8859.

## What Changed

- Added `ripgrep` to the existing `apt-get install --no-install-recommends` list in `docker/agent-runtime/Dockerfile.base`
- Added an explanatory comment documenting why ripgrep must be present (run-time download fallback + egress-restricted sandboxes), restoring parity with the root repo `Dockerfile`

## Verification

- `docker build -f docker/agent-runtime/Dockerfile.base .` then `docker run --rm <image> rg --version` — prints the ripgrep version from the system package
- Run an OpenCode-backed agent in an egress-restricted sandbox on the new image: no `BurntSushi/ripgrep` download attempt, no ~127s startup stall

## Risks

- Low risk: no behavior change beyond shipping one additional apt package in the base image; slightly larger image size

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- Claude (Anthropic), model ID `claude-fable-5` (Fable 5), agentic coding via Claude Code with tool use; original change authored with Claude Opus 4.8 (1M context) and re-based/re-verified with Fable 5

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
