### PR TITLE
fix(ui): land invitees on the inviter company when membership lags

### DIFF
--- a/ui/src/pages/InviteLanding.test.tsx
+++ b/ui/src/pages/InviteLanding.test.tsx
@@ -634,6 +634,88 @@ describe("InviteLandingPage", () => {
     });
   });
 
+  it("refreshes the companies list until the joined company appears before redirecting an authenticated invitee", async () => {
+    // An already-authenticated user opens /invite/:token as their FIRST page load
+    // (no selected/last company yet). The accept auto-fires, but the new
+    // membership is not yet readable by the companies endpoint. If the page
+    // navigates to "/" on that first stale list, the company root redirect cannot
+    // find the just-joined company and falls back to companies[0] (e.g. a
+    // pre-existing default company), stranding the invitee on the wrong board. The
+    // accept must refetch the list until the joined company appears before it
+    // hands off navigation.
+    getSessionMock.mockResolvedValue({
+      session: { id: "session-1", userId: "user-1" },
+      user: {
+        id: "user-1",
+        name: "Jane Example",
+        email: "jane@example.com",
+        image: null,
+      },
+    });
+    // The membership write lags: the list returns ONLY the user's pre-existing
+    // company for the first few post-accept refetches, then becomes readable and
+    // includes the joined inviter company.
+    listCompaniesMock.mockResolvedValueOnce([{ id: "own-company", name: "Existing Co" }]);
+    listCompaniesMock.mockResolvedValueOnce([{ id: "own-company", name: "Existing Co" }]);
+    listCompaniesMock.mockResolvedValueOnce([{ id: "own-company", name: "Existing Co" }]);
+    listCompaniesMock.mockResolvedValue([
+      { id: "own-company", name: "Existing Co" },
+      { id: "company-1", name: "Acme Robotics" },
+    ]);
+    acceptInviteMock.mockResolvedValue({
+      id: "join-1",
+      companyId: "company-1",
+      requestType: "human",
+      status: "approved",
+    });
+
+    const root = createRoot(container);
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+
+    await act(async () => {
+      root.render(
+        <MemoryRouter initialEntries={["/invite/pcp_invite_test"]}>
+          <QueryClientProvider client={queryClient}>
+            <Routes>
+              <Route path="/invite/:token" element={<InviteLandingPage />} />
+            </Routes>
+          </QueryClientProvider>
+        </MemoryRouter>,
+      );
+    });
+    // Drain the bounded backoff between membership refetches.
+    for (let i = 0; i < 30; i += 1) {
+      await act(async () => {
+        await new Promise((resolve) => window.setTimeout(resolve, 60));
+      });
+      const cached = queryClient.getQueryData(queryKeys.companies.all) as
+        | { companies: Array<{ id: string }> }
+        | undefined;
+      if (cached?.companies.some((company) => company.id === "company-1")) break;
+    }
+
+    expect(acceptInviteMock).toHaveBeenCalledWith("pcp_invite_test", { requestType: "human" });
+    expect(setSelectedCompanyIdMock).toHaveBeenCalledWith("company-1", { source: "manual" });
+
+    // The accept refetched the companies list more than once, waiting out the
+    // lagging membership write rather than navigating on the first stale list.
+    expect(listCompaniesMock.mock.calls.length).toBeGreaterThan(2);
+
+    // The joined company must be present in the shared companies cache by the time
+    // navigation happens, so the company root redirect can resolve the inviter
+    // company rather than falling back to companies[0].
+    const cached = queryClient.getQueryData(queryKeys.companies.all) as
+      | { companies: Array<{ id: string }> }
+      | undefined;
+    expect(cached?.companies.map((company) => company.id)).toContain("company-1");
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
   it("asks unauthenticated users to sign in before completing an accepted human invite", async () => {
     getInviteMock.mockResolvedValue({
       id: "invite-1",

--- a/ui/src/pages/InviteLanding.test.tsx
+++ b/ui/src/pages/InviteLanding.test.tsx
@@ -680,12 +680,15 @@ describe("InviteLandingPage", () => {
           <QueryClientProvider client={queryClient}>
             <Routes>
               <Route path="/invite/:token" element={<InviteLandingPage />} />
+              <Route path="/" element={<div data-testid="company-root-redirect" />} />
             </Routes>
           </QueryClientProvider>
         </MemoryRouter>,
       );
     });
-    // Drain the bounded backoff between membership refetches.
+    // Drain the bounded backoff between membership refetches. While the cache
+    // still holds only the stale list, the page must NOT have navigated to "/"
+    // yet — navigating on a stale list is exactly the bug under test.
     for (let i = 0; i < 30; i += 1) {
       await act(async () => {
         await new Promise((resolve) => window.setTimeout(resolve, 60));
@@ -694,10 +697,17 @@ describe("InviteLandingPage", () => {
         | { companies: Array<{ id: string }> }
         | undefined;
       if (cached?.companies.some((company) => company.id === "company-1")) break;
+      expect(container.querySelector('[data-testid="company-root-redirect"]')).toBeNull();
     }
+    await flushReact();
+    await flushReact();
 
     expect(acceptInviteMock).toHaveBeenCalledWith("pcp_invite_test", { requestType: "human" });
     expect(setSelectedCompanyIdMock).toHaveBeenCalledWith("company-1", { source: "manual" });
+
+    // Navigation to "/" actually fired once the joined company became readable:
+    // the MemoryRouter now renders the company root route.
+    expect(container.querySelector('[data-testid="company-root-redirect"]')).not.toBeNull();
 
     // The accept refetched the companies list more than once, waiting out the
     // lagging membership write rather than navigating on the first stale list.

--- a/ui/src/pages/InviteLanding.test.tsx
+++ b/ui/src/pages/InviteLanding.test.tsx
@@ -726,6 +726,71 @@ describe("InviteLandingPage", () => {
     });
   });
 
+  it("still redirects into the company when the post-accept companies refetch fails", async () => {
+    // The invite accept succeeded on the server, but the post-accept companies
+    // refetch hits a transient network error. Throwing out of the accept
+    // mutation's onSuccess would trip onError and pin the invitee on the invite
+    // page behind a false "Failed to accept invite" error. The handoff must
+    // swallow the refetch failure and navigate anyway: the selection is already
+    // persisted, so the root redirect recovers once the list is readable.
+    getSessionMock.mockResolvedValue({
+      session: { id: "session-1", userId: "user-1" },
+      user: {
+        id: "user-1",
+        name: "Jane Example",
+        email: "jane@example.com",
+        image: null,
+      },
+    });
+    // First call serves the pre-accept membership check; every post-accept
+    // refetch in the bounded retry loop fails.
+    listCompaniesMock.mockResolvedValueOnce([{ id: "own-company", name: "Existing Co" }]);
+    listCompaniesMock.mockRejectedValue(new Error("network error"));
+    acceptInviteMock.mockResolvedValue({
+      id: "join-1",
+      companyId: "company-1",
+      requestType: "human",
+      status: "approved",
+    });
+
+    const root = createRoot(container);
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+
+    await act(async () => {
+      root.render(
+        <MemoryRouter initialEntries={["/invite/pcp_invite_test"]}>
+          <QueryClientProvider client={queryClient}>
+            <Routes>
+              <Route path="/invite/:token" element={<InviteLandingPage />} />
+              <Route path="/" element={<div data-testid="company-root-redirect" />} />
+            </Routes>
+          </QueryClientProvider>
+        </MemoryRouter>,
+      );
+    });
+    for (let i = 0; i < 30; i += 1) {
+      await act(async () => {
+        await new Promise((resolve) => window.setTimeout(resolve, 60));
+      });
+      if (container.querySelector('[data-testid="company-root-redirect"]')) break;
+    }
+    await flushReact();
+
+    expect(acceptInviteMock).toHaveBeenCalledWith("pcp_invite_test", { requestType: "human" });
+    expect(setSelectedCompanyIdMock).toHaveBeenCalledWith("company-1", { source: "manual" });
+
+    // Navigation fired despite the failing refetch, and no false accept error
+    // was shown for an invite that succeeded server-side.
+    expect(container.querySelector('[data-testid="company-root-redirect"]')).not.toBeNull();
+    expect(container.textContent).not.toContain("Failed to accept invite");
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
   it("asks unauthenticated users to sign in before completing an accepted human invite", async () => {
     getInviteMock.mockResolvedValue({
       id: "invite-1",

--- a/ui/src/pages/InviteLanding.tsx
+++ b/ui/src/pages/InviteLanding.tsx
@@ -314,6 +314,45 @@ export function InviteLandingPage() {
     password.trim().length > 0 &&
     (authMode === "sign_in" || (name.trim().length > 0 && password.trim().length >= 8));
 
+  // After a successful accept we hand off to the company root redirect via
+  // navigate("/"). That redirect resolves the destination company by looking the
+  // selected id up in the companies list, so the just-joined company must be in
+  // the list before we navigate. For a user whose FIRST page load is
+  // /invite/:token (no selected/last company yet), the membership write may not
+  // be readable by the companies endpoint on the immediate refetch; if we
+  // navigate before it lands, the root redirect cannot find the selected company
+  // and falls back to companies[0] (e.g. an auto-provisioned default company),
+  // stranding the invitee on the wrong board. Refetch the list a bounded number
+  // of times until the joined company appears, then select + navigate.
+  const enterJoinedCompany = async (companyId: string) => {
+    // Persist the selection up front so it survives the refetch loop and any
+    // re-render: the root redirect keys off this id once the company is in the
+    // list.
+    setSelectedCompanyId(companyId, { source: "manual" });
+    let present = false;
+    for (let attempt = 0; attempt < 4; attempt += 1) {
+      const { companies } = await queryClient.fetchQuery({
+        ...companiesListQueryOptions,
+        staleTime: 0,
+      });
+      if (companies.some((company) => company.id === companyId)) {
+        present = true;
+        break;
+      }
+      // Short backoff for the membership write to become readable before the
+      // next refetch. Skip the wait on the final attempt.
+      if (attempt < 3) {
+        await new Promise((resolve) => setTimeout(resolve, 120 * (attempt + 1)));
+      }
+    }
+    // Navigate regardless: if the list is still lagging after the bounded
+    // retries the selection persists, so the root redirect (or a later companies
+    // refetch) still lands on the right company rather than silently choosing
+    // companies[0].
+    navigate("/", { replace: true });
+    return present;
+  };
+
   const acceptMutation = useMutation({
     mutationFn: async () => {
       if (!invite) throw new Error("Invite not found");
@@ -340,10 +379,10 @@ export function InviteLandingPage() {
       setResult({ kind: asBootstrap ? "bootstrap" : "join", payload });
       await queryClient.invalidateQueries({ queryKey: queryKeys.auth.session });
       await queryClient.invalidateQueries({ queryKey: queryKeys.access.currentBoardAccess });
-      await queryClient.invalidateQueries({ queryKey: queryKeys.companies.all });
       if (invite?.companyId && isApprovedHumanJoinPayload(payload, showsAgentForm)) {
-        setSelectedCompanyId(invite.companyId, { source: "manual" });
-        navigate("/", { replace: true });
+        await enterJoinedCompany(invite.companyId);
+      } else {
+        await queryClient.invalidateQueries({ queryKey: queryKeys.companies.all });
       }
     },
     onError: (err) => {
@@ -379,8 +418,7 @@ export function InviteLandingPage() {
 
       if (invite?.companyId && freshCompanies.some((company) => company.id === invite.companyId)) {
         clearPendingInviteToken(token);
-        setSelectedCompanyId(invite.companyId, { source: "manual" });
-        navigate("/", { replace: true });
+        await enterJoinedCompany(invite.companyId);
         return;
       }
 

--- a/ui/src/pages/InviteLanding.tsx
+++ b/ui/src/pages/InviteLanding.tsx
@@ -329,24 +329,31 @@ export function InviteLandingPage() {
     // re-render: the root redirect keys off this id once the company is in the
     // list.
     setSelectedCompanyId(companyId, { source: "manual" });
-    for (let attempt = 0; attempt < 4; attempt += 1) {
-      const { companies } = await queryClient.fetchQuery({
-        ...companiesListQueryOptions,
-        staleTime: 0,
-      });
-      if (companies.some((company) => company.id === companyId)) {
-        break;
+    try {
+      for (let attempt = 0; attempt < 4; attempt += 1) {
+        const { companies } = await queryClient.fetchQuery({
+          ...companiesListQueryOptions,
+          staleTime: 0,
+        });
+        if (companies.some((company) => company.id === companyId)) {
+          break;
+        }
+        // Short backoff for the membership write to become readable before the
+        // next refetch. Skip the wait on the final attempt.
+        if (attempt < 3) {
+          await new Promise((resolve) => setTimeout(resolve, 120 * (attempt + 1)));
+        }
       }
-      // Short backoff for the membership write to become readable before the
-      // next refetch. Skip the wait on the final attempt.
-      if (attempt < 3) {
-        await new Promise((resolve) => setTimeout(resolve, 120 * (attempt + 1)));
-      }
+    } catch {
+      // A transient refetch failure must not abort the handoff: the invite was
+      // already accepted on the server, and throwing out of onSuccess would
+      // trip the mutation's onError and strand the invitee on the invite page
+      // behind a false "Failed to accept invite" error. Fall through to
+      // navigate below.
     }
-    // Navigate regardless: if the list is still lagging after the bounded
-    // retries the selection persists, so the root redirect (or a later companies
-    // refetch) still lands on the right company rather than silently choosing
-    // companies[0].
+    // Navigate regardless of a lagging list or a failed refetch: the selection
+    // persists, so the root redirect (or a later companies refetch) still lands
+    // on the right company rather than silently choosing companies[0].
     navigate("/", { replace: true });
   };
 

--- a/ui/src/pages/InviteLanding.tsx
+++ b/ui/src/pages/InviteLanding.tsx
@@ -329,14 +329,12 @@ export function InviteLandingPage() {
     // re-render: the root redirect keys off this id once the company is in the
     // list.
     setSelectedCompanyId(companyId, { source: "manual" });
-    let present = false;
     for (let attempt = 0; attempt < 4; attempt += 1) {
       const { companies } = await queryClient.fetchQuery({
         ...companiesListQueryOptions,
         staleTime: 0,
       });
       if (companies.some((company) => company.id === companyId)) {
-        present = true;
         break;
       }
       // Short backoff for the membership write to become readable before the
@@ -350,7 +348,6 @@ export function InviteLandingPage() {
     // refetch) still lands on the right company rather than silently choosing
     // companies[0].
     navigate("/", { replace: true });
-    return present;
   };
 
   const acceptMutation = useMutation({


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Companies are multi-user: teammates join a company through invite links (`/invite/:token`), handled by the `InviteLanding` page in the UI
> - When an authenticated user opens an invite link as their **first page load** (no selected/last company yet), `InviteLanding` auto-accepts and hands off via `navigate("/")`, and the company root redirect resolves the destination by looking the selected company id up in the companies list
> - For a freshly signed-up user (or any deployment that auto-provisions a default company), the new membership is frequently not yet readable by the companies endpoint on the immediate post-accept refetch; the old code fired a single `invalidateQueries` and navigated right away
> - The root redirect then could not find the selected company and fell back to `companies[0]` (the user's own default company) — stranding the invitee un-joined on the wrong board; established users with a warm cache were unaffected, which is why this only reproduced on the first authenticated load
> - This pull request refetches the companies list a bounded number of times (with a short backoff) until the joined company appears, then selects and navigates — applied to both the accept-mutation success path and the post-sign-in existing-member path
> - The benefit is that invitees reliably land on the inviter's company even when membership propagation lags, instead of silently ending up on their own default company

## Linked Issues or Issue Description

No public issue exists for this; describing the bug in-PR (bug-report template fields):

- **Describe the bug:** An authenticated user opening `/invite/:token` as their first page load is auto-accepted into the inviter's company, but lands on their own default company board instead of the inviter's company.
- **Steps to reproduce:** 1) On a deployment that auto-provisions a default company per user, sign up a fresh user. 2) Before ever loading the dashboard, open a valid invite link for another company. 3) Invite is accepted, but after the redirect the user is on `companies[0]` (their own default company), not the inviter's company.
- **Expected behavior:** After accepting the invite the user is taken to the inviter's company.
- **Root cause:** `InviteLanding` navigated immediately after a single `invalidateQueries`; the company root redirect resolves the selected company against the companies list, and the just-joined membership is often not yet readable on the immediate post-accept refetch, so the redirect falls back to `companies[0]`.

Related PRs (same invite-flow hardening series, recreated as clean single-concern PRs): the successors of #8127 (consume invite token after signup-via-invite), #8128 (reliably auto-join authenticated invitees + deployer theme), and #8147 (invite-token entropy + rate limiting). This PR is intentionally scoped to only the post-accept redirect race.

Supersedes #8133.

## What Changed

- `ui/src/pages/InviteLanding.tsx`: after a successful invite accept (and on the post-sign-in existing-member path), set the selected company up front, then refetch the companies list a bounded number of times with a short backoff until the joined company appears before navigating to `/`; if the list still lags after the bounded retries, navigate anyway and let a later refetch land the right company rather than silently falling back to `companies[0]`
- `ui/src/pages/InviteLanding.test.tsx`: regression test — an already-authenticated invitee whose membership lags several refetches behind the accept now refetches until the joined company appears before navigating (FAIL→PASS on this change)

## Verification

- `cd ui && npx vitest run src/pages/InviteLanding.test.tsx` — 14/14 pass, including the new regression test (verified locally on this branch)
- `npx tsc --noEmit -p ui` — no errors in the touched files
- Manual: on a deployment with per-user default companies, sign up a fresh user and open an invite link for another company as the first page load; the user should land on the inviter's company

## Risks

- Low risk, UI-only. Worst case (membership never becomes readable within the bounded retries) the behavior degrades to a short delay followed by the pre-existing navigation, with the selection already set so a later refetch corrects the destination
- The retry loop is bounded with short backoff, so it cannot spin indefinitely or hammer the companies endpoint

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- Claude (Anthropic) — Fable 5 (`claude-fable-5`), extended thinking enabled, running via Claude Code with tool use (file editing, shell, test execution)

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
