### PR TITLE
fix(invite): consume invite token after signup-via-invite for non-bootstrap company invites

### DIFF
--- a/ui/src/pages/InviteLanding.test.tsx
+++ b/ui/src/pages/InviteLanding.test.tsx
@@ -506,6 +506,84 @@ describe("InviteLandingPage", () => {
     });
   });
 
+  it("consumes a non-bootstrap invite from sign-up onSuccess even when the session query has not refreshed yet", async () => {
+    // The session query keeps resolving to null for the whole flow, so the
+    // auto-accept effect (which requires a session) can never fire. This pins
+    // the responsibility on authMutation.onSuccess: after a fresh sign-up it
+    // must consume the invite token itself, otherwise the brand-new user gets
+    // an account but is never added to the inviting company's membership.
+    getSessionMock.mockResolvedValue(null);
+    acceptInviteMock.mockResolvedValue({
+      id: "join-1",
+      companyId: "company-1",
+      requestType: "human",
+      status: "approved",
+    });
+
+    const root = createRoot(container);
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+
+    await act(async () => {
+      root.render(
+        <MemoryRouter initialEntries={["/invite/pcp_invite_test"]}>
+          <QueryClientProvider client={queryClient}>
+            <Routes>
+              <Route path="/invite/:token" element={<InviteLandingPage />} />
+            </Routes>
+          </QueryClientProvider>
+        </MemoryRouter>,
+      );
+    });
+    await flushReact();
+    await flushReact();
+
+    const inputValueSetter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")?.set;
+    expect(inputValueSetter).toBeTypeOf("function");
+
+    const nameInput = container.querySelector('input[name="name"]') as HTMLInputElement | null;
+    const emailInput = container.querySelector('input[name="email"]') as HTMLInputElement | null;
+    const passwordInput = container.querySelector('input[name="password"]') as HTMLInputElement | null;
+    expect(nameInput).not.toBeNull();
+    expect(emailInput).not.toBeNull();
+    expect(passwordInput).not.toBeNull();
+
+    await act(async () => {
+      inputValueSetter!.call(nameInput, "Jane Example");
+      nameInput!.dispatchEvent(new Event("input", { bubbles: true }));
+      inputValueSetter!.call(emailInput, "jane@example.com");
+      emailInput!.dispatchEvent(new Event("input", { bubbles: true }));
+      inputValueSetter!.call(passwordInput, "supersecret");
+      passwordInput!.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+
+    const authForm = container.querySelector('[data-testid="invite-inline-auth"]') as HTMLFormElement | null;
+    expect(authForm).not.toBeNull();
+
+    await act(async () => {
+      authForm?.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+    });
+    await flushReact();
+    await flushReact();
+    await flushReact();
+    await flushReact();
+
+    expect(signUpEmailMock).toHaveBeenCalledWith({
+      name: "Jane Example",
+      email: "jane@example.com",
+      password: "supersecret",
+    });
+    // The invite token must be consumed so the new user joins the company.
+    expect(acceptInviteMock).toHaveBeenCalledWith("pcp_invite_test", { requestType: "human" });
+    expect(setSelectedCompanyIdMock).toHaveBeenCalledWith("company-1", { source: "manual" });
+    expect(localStorage.getItem("paperclip:pending-invite-token")).toBeNull();
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
   it("shows the pending approval page with the company icon and linked access instructions", async () => {
     acceptInviteMock.mockResolvedValue({
       id: "join-1",

--- a/ui/src/pages/InviteLanding.test.tsx
+++ b/ui/src/pages/InviteLanding.test.tsx
@@ -550,6 +550,84 @@ describe("InviteLandingPage", () => {
     });
   });
 
+  it("consumes a non-bootstrap invite from sign-up onSuccess even when the session query has not refreshed yet", async () => {
+    // The session query keeps resolving to null for the whole flow, so the
+    // auto-accept effect (which requires a session) can never fire. This pins
+    // the responsibility on authMutation.onSuccess: after a fresh sign-up it
+    // must consume the invite token itself, otherwise the brand-new user gets
+    // an account but is never added to the inviting company's membership.
+    getSessionMock.mockResolvedValue(null);
+    acceptInviteMock.mockResolvedValue({
+      id: "join-1",
+      companyId: "company-1",
+      requestType: "human",
+      status: "approved",
+    });
+
+    const root = createRoot(container);
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+
+    await act(async () => {
+      root.render(
+        <MemoryRouter initialEntries={["/invite/pcp_invite_test"]}>
+          <QueryClientProvider client={queryClient}>
+            <Routes>
+              <Route path="/invite/:token" element={<InviteLandingPage />} />
+            </Routes>
+          </QueryClientProvider>
+        </MemoryRouter>,
+      );
+    });
+    await flushReact();
+    await flushReact();
+
+    const inputValueSetter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")?.set;
+    expect(inputValueSetter).toBeTypeOf("function");
+
+    const nameInput = container.querySelector('input[name="name"]') as HTMLInputElement | null;
+    const emailInput = container.querySelector('input[name="email"]') as HTMLInputElement | null;
+    const passwordInput = container.querySelector('input[name="password"]') as HTMLInputElement | null;
+    expect(nameInput).not.toBeNull();
+    expect(emailInput).not.toBeNull();
+    expect(passwordInput).not.toBeNull();
+
+    await act(async () => {
+      inputValueSetter!.call(nameInput, "Jane Example");
+      nameInput!.dispatchEvent(new Event("input", { bubbles: true }));
+      inputValueSetter!.call(emailInput, "jane@example.com");
+      emailInput!.dispatchEvent(new Event("input", { bubbles: true }));
+      inputValueSetter!.call(passwordInput, "supersecret");
+      passwordInput!.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+
+    const authForm = container.querySelector('[data-testid="invite-inline-auth"]') as HTMLFormElement | null;
+    expect(authForm).not.toBeNull();
+
+    await act(async () => {
+      authForm?.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+    });
+    await flushReact();
+    await flushReact();
+    await flushReact();
+    await flushReact();
+
+    expect(signUpEmailMock).toHaveBeenCalledWith({
+      name: "Jane Example",
+      email: "jane@example.com",
+      password: "supersecret",
+    });
+    // The invite token must be consumed so the new user joins the company.
+    expect(acceptInviteMock).toHaveBeenCalledWith("pcp_invite_test", { requestType: "human" });
+    expect(setSelectedCompanyIdMock).toHaveBeenCalledWith("company-1", { source: "manual" });
+    expect(localStorage.getItem("paperclip:pending-invite-token")).toBeNull();
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
   it("shows the pending approval page with the company icon and non-clickable access instructions", async () => {
     acceptInviteMock.mockResolvedValue({
       id: "join-1",

--- a/ui/src/pages/InviteLanding.tsx
+++ b/ui/src/pages/InviteLanding.tsx
@@ -384,13 +384,27 @@ export function InviteLandingPage() {
         return;
       }
 
-      if (!invite || invite.inviteType !== "bootstrap_ceo") {
+      if (!invite) {
         return;
       }
 
+      // A brand-new account that just signed up via this invite is not a member
+      // of the inviting company yet, so we must consume the invite token here.
+      // Without this, sign-up creates the account but never adds the user to the
+      // company membership. (Bootstrap invites take the bootstrap branch below.)
       try {
         const payload = await acceptMutation.mutateAsync();
-        if (isBootstrapAcceptancePayload(payload)) {
+        if (invite.inviteType === "bootstrap_ceo") {
+          if (isBootstrapAcceptancePayload(payload)) {
+            navigate("/", { replace: true });
+          }
+          return;
+        }
+        // Non-bootstrap company invite: acceptMutation.onSuccess already cleared
+        // the pending token and invalidated caches. Navigate the newly joined
+        // user into the company, mirroring the existing-account accept path.
+        if (invite.companyId && isApprovedHumanJoinPayload(payload, showsAgentForm)) {
+          setSelectedCompanyId(invite.companyId, { source: "manual" });
           navigate("/", { replace: true });
         }
       } catch {

--- a/ui/src/pages/InviteLanding.tsx
+++ b/ui/src/pages/InviteLanding.tsx
@@ -401,12 +401,8 @@ export function InviteLandingPage() {
           return;
         }
         // Non-bootstrap company invite: acceptMutation.onSuccess already cleared
-        // the pending token and invalidated caches. Navigate the newly joined
-        // user into the company, mirroring the existing-account accept path.
-        if (invite.companyId && isApprovedHumanJoinPayload(payload, showsAgentForm)) {
-          setSelectedCompanyId(invite.companyId, { source: "manual" });
-          navigate("/", { replace: true });
-        }
+        // the pending token, invalidated caches, and navigated the user.
+        // Nothing more to do here.
       } catch {
         return;
       }

--- a/ui/src/pages/InviteLanding.tsx
+++ b/ui/src/pages/InviteLanding.tsx
@@ -421,12 +421,8 @@ export function InviteLandingPage() {
           return;
         }
         // Non-bootstrap company invite: acceptMutation.onSuccess already cleared
-        // the pending token and invalidated caches. Navigate the newly joined
-        // user into the company, mirroring the existing-account accept path.
-        if (invite.companyId && isApprovedHumanJoinPayload(payload, showsAgentForm)) {
-          setSelectedCompanyId(invite.companyId, { source: "manual" });
-          navigate("/", { replace: true });
-        }
+        // the pending token, invalidated caches, and navigated the user.
+        // Nothing more to do here.
       } catch {
         return;
       }

--- a/ui/src/pages/InviteLanding.tsx
+++ b/ui/src/pages/InviteLanding.tsx
@@ -404,13 +404,27 @@ export function InviteLandingPage() {
         return;
       }
 
-      if (!invite || invite.inviteType !== "bootstrap_ceo") {
+      if (!invite) {
         return;
       }
 
+      // A brand-new account that just signed up via this invite is not a member
+      // of the inviting company yet, so we must consume the invite token here.
+      // Without this, sign-up creates the account but never adds the user to the
+      // company membership. (Bootstrap invites take the bootstrap branch below.)
       try {
         const payload = await acceptMutation.mutateAsync();
-        if (isBootstrapAcceptancePayload(payload)) {
+        if (invite.inviteType === "bootstrap_ceo") {
+          if (isBootstrapAcceptancePayload(payload)) {
+            navigate("/", { replace: true });
+          }
+          return;
+        }
+        // Non-bootstrap company invite: acceptMutation.onSuccess already cleared
+        // the pending token and invalidated caches. Navigate the newly joined
+        // user into the company, mirroring the existing-account accept path.
+        if (invite.companyId && isApprovedHumanJoinPayload(payload, showsAgentForm)) {
+          setSelectedCompanyId(invite.companyId, { source: "manual" });
           navigate("/", { replace: true });
         }
       } catch {


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Companies grow by inviting people: an invite link lands on `InviteLanding`, where the recipient either signs in or creates a brand-new account inline
> - For a brand-new user on a **non-bootstrap company invite**, the post-signup handler (`authMutation.onSuccess`) had an early `return` for any invite that is not `bootstrap_ceo`, so it never called the accept mutation
> - The auto-accept effect that would normally cover this only fires once the session query refreshes to an authenticated session; in the common race where `onSuccess` runs first, nobody consumes the invite token
> - The result: the new user gets an account but is never added to the inviting company's membership — the invite silently does nothing
> - This pull request makes the post-signup path accept company invites too (mirroring the existing-account accept path) and then navigates the newly joined user into the company
> - The benefit is that signup-via-invite reliably lands new users in the company that invited them, instead of leaving them stranded with an orphan account

## Linked Issues or Issue Description

No public issue exists; describing the bug in-PR per the bug template:

- **What happened:** A brand-new user (no existing account) opens a non-bootstrap company invite link and signs up inline on `InviteLanding`. The account is created, but the user is never added to the inviting company — the invite token is never consumed.
- **What was expected:** After signing up via the invite, the user should be a member of the inviting company and land inside it.
- **Root cause:** `authMutation.onSuccess` in `ui/src/pages/InviteLanding.tsx` bailed out early for any invite that is not `bootstrap_ceo`:

  ```ts
  if (!invite || invite.inviteType !== "bootstrap_ceo") {
    return; // <- non-bootstrap company invite bails out here, accept never runs
  }
  ```

  The fallback auto-accept effect only fires after the session query refreshes to an authenticated session, so when `onSuccess` wins that race, the invite is never accepted.
- **Impact/frequency:** Deterministic in the race-losing case, which is the common ordering; affects every new-user signup through a company invite link.

Related invite PRs being reopened in parallel (kept out of this diff on purpose): auto-join (supersedes #8128), inviter-company landing (supersedes #8133), and invite security hardening (supersedes #8147). This PR is strictly the token-consumption fix.

Supersedes #8127.

## What Changed

- `ui/src/pages/InviteLanding.tsx`: in the post-signup (`authMutation.onSuccess`) path, dropped the non-bootstrap early return and now call `acceptMutation.mutateAsync()` for company invites as well; on an approved human join, select the invited company and navigate to `/` (mirroring the existing-account accept path). The `bootstrap_ceo` branch keeps its exact existing behavior. The accept mutation's own `onSuccess` already clears the remembered invite token and invalidates the relevant caches.
- `ui/src/pages/InviteLanding.test.tsx`: added a regression test that pins the responsibility on `onSuccess`: with the session query held at `null` (so the auto-accept effect can never fire), a fresh sign-up must still consume the invite token (`acceptInvite` called) and select the company. The test fails on the old code (accept called 0 times) and passes with the fix.

## Verification

- `cd ui && npx vitest run src/pages/InviteLanding.test.tsx` — 14/14 tests pass (13 pre-existing + the new regression test).
- `npx tsc --noEmit -p ui` — no errors in the touched files.
- Manual: create a company invite (non-bootstrap), open the link in a fresh browser profile, sign up inline; the new user should end up as a member of the inviting company and be navigated into it.

## Risks

- Low risk. The change is confined to the post-signup branch of `InviteLanding`; the bootstrap invite flow and the existing-account accept flow are untouched. Accepting is idempotent with the auto-accept effect: whichever runs first consumes the token, and the accept mutation's `onSuccess` clears the pending token so the other path no-ops.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

Claude (Anthropic) — Claude Fable 5 (`claude-fable-5`), extended thinking enabled, running in Claude Code with tool use (file edits, bash, test execution).

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
