### PR TITLE
fix(shared): tolerate empty-string user name in profile/session parse

### DIFF
--- a/packages/shared/src/validators/access.test.ts
+++ b/packages/shared/src/validators/access.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import { authSessionSchema, currentUserProfileSchema } from "./access.js";
+
+describe("currentUserProfileSchema", () => {
+  it("coerces empty-string name to null", () => {
+    const result = currentUserProfileSchema.safeParse({
+      id: "u1",
+      email: "a@b.com",
+      name: "",
+      image: null,
+    });
+    expect(result.success).toBe(true);
+    expect(result.success && result.data.name).toBe(null);
+  });
+
+  it("coerces whitespace-only name to null", () => {
+    const result = currentUserProfileSchema.safeParse({
+      id: "u1",
+      email: "a@b.com",
+      name: "   ",
+      image: null,
+    });
+    expect(result.success).toBe(true);
+    expect(result.success && result.data.name).toBe(null);
+  });
+
+  it("preserves a real name unchanged", () => {
+    const result = currentUserProfileSchema.safeParse({
+      id: "u1",
+      email: "a@b.com",
+      name: "Jane",
+      image: null,
+    });
+    expect(result.success).toBe(true);
+    expect(result.success && result.data.name).toBe("Jane");
+  });
+
+  it("preserves null name as null", () => {
+    const result = currentUserProfileSchema.safeParse({
+      id: "u1",
+      email: "a@b.com",
+      name: null,
+      image: null,
+    });
+    expect(result.success).toBe(true);
+    expect(result.success && result.data.name).toBe(null);
+  });
+});
+
+describe("authSessionSchema", () => {
+  it("parses a session where user name is empty string (identity provider without a name)", () => {
+    const result = authSessionSchema.safeParse({
+      session: { id: "s1", userId: "u1" },
+      user: { id: "u1", email: "a@b.com", name: "", image: null },
+    });
+    expect(result.success).toBe(true);
+    expect(result.success && result.data.user.name).toBe(null);
+  });
+
+  it("parses a session where user has a real name", () => {
+    const result = authSessionSchema.safeParse({
+      session: { id: "s1", userId: "u1" },
+      user: { id: "u1", email: "a@b.com", name: "Jane", image: null },
+    });
+    expect(result.success).toBe(true);
+    expect(result.success && result.data.user.name).toBe("Jane");
+  });
+
+  it("parses a session where user name is null", () => {
+    const result = authSessionSchema.safeParse({
+      session: { id: "s1", userId: "u1" },
+      user: { id: "u1", email: "a@b.com", name: null, image: null },
+    });
+    expect(result.success).toBe(true);
+    expect(result.success && result.data.user.name).toBe(null);
+  });
+});

--- a/packages/shared/src/validators/access.test.ts
+++ b/packages/shared/src/validators/access.test.ts
@@ -45,6 +45,60 @@ describe("currentUserProfileSchema", () => {
     expect(result.success).toBe(true);
     expect(result.success && result.data.name).toBe(null);
   });
+
+  it("coerces empty-string email to null", () => {
+    const result = currentUserProfileSchema.safeParse({
+      id: "u1",
+      email: "",
+      name: "Jane",
+      image: null,
+    });
+    expect(result.success).toBe(true);
+    expect(result.success && result.data.email).toBe(null);
+  });
+
+  it("coerces whitespace-only email to null", () => {
+    const result = currentUserProfileSchema.safeParse({
+      id: "u1",
+      email: "   ",
+      name: "Jane",
+      image: null,
+    });
+    expect(result.success).toBe(true);
+    expect(result.success && result.data.email).toBe(null);
+  });
+
+  it("preserves a real email unchanged", () => {
+    const result = currentUserProfileSchema.safeParse({
+      id: "u1",
+      email: "a@b.com",
+      name: "Jane",
+      image: null,
+    });
+    expect(result.success).toBe(true);
+    expect(result.success && result.data.email).toBe("a@b.com");
+  });
+
+  it("preserves null email as null", () => {
+    const result = currentUserProfileSchema.safeParse({
+      id: "u1",
+      email: null,
+      name: "Jane",
+      image: null,
+    });
+    expect(result.success).toBe(true);
+    expect(result.success && result.data.email).toBe(null);
+  });
+
+  it("still rejects a malformed non-empty email", () => {
+    const result = currentUserProfileSchema.safeParse({
+      id: "u1",
+      email: "not-an-email",
+      name: "Jane",
+      image: null,
+    });
+    expect(result.success).toBe(false);
+  });
 });
 
 describe("authSessionSchema", () => {
@@ -73,5 +127,14 @@ describe("authSessionSchema", () => {
     });
     expect(result.success).toBe(true);
     expect(result.success && result.data.user.name).toBe(null);
+  });
+
+  it("parses a session where user email is empty string (identity provider without an email)", () => {
+    const result = authSessionSchema.safeParse({
+      session: { id: "s1", userId: "u1" },
+      user: { id: "u1", email: "", name: "Jane", image: null },
+    });
+    expect(result.success).toBe(true);
+    expect(result.success && result.data.user.email).toBe(null);
   });
 });

--- a/packages/shared/src/validators/access.ts
+++ b/packages/shared/src/validators/access.ts
@@ -180,7 +180,10 @@ const profileImageSchema = z
 export const currentUserProfileSchema = z.object({
   id: z.string().min(1),
   email: z.string().email().nullable(),
-  name: z.string().min(1).max(120).nullable(),
+  name: z.preprocess(
+    (v) => (typeof v === "string" && v.trim() === "" ? null : v),
+    z.string().min(1).max(120).nullable(),
+  ),
   image: profileImageSchema.nullable(),
 });
 

--- a/packages/shared/src/validators/access.ts
+++ b/packages/shared/src/validators/access.ts
@@ -179,7 +179,10 @@ const profileImageSchema = z
 
 export const currentUserProfileSchema = z.object({
   id: z.string().min(1),
-  email: z.string().email().nullable(),
+  email: z.preprocess(
+    (v) => (typeof v === "string" && v.trim() === "" ? null : v),
+    z.string().email().nullable(),
+  ),
   name: z.preprocess(
     (v) => (typeof v === "string" && v.trim() === "" ? null : v),
     z.string().min(1).max(120).nullable(),


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Humans sign in through the auth layer; every authenticated request parses the session/user profile with `currentUserProfileSchema` in `packages/shared`
> - The schema requires `name` to be `null` or a non-empty string, but some identity providers hand back `name: ""` for users who never set a display name
> - For those users the session payload fails validation on every request, so the app treats them as unauthenticated and bounces them to `/auth` in a loop — they can never get in
> - This pull request preprocesses empty/whitespace-only names to `null` before validation, so the existing `min(1).max(120).nullable()` rule still holds for real names
> - Review found the sibling `email` field has the same failure mode (the DB `auth` schema declares `email` as `notNull`, so a provider that supplies no email stores `""`, which `z.string().email()` rejects); the same preprocess is applied there
> - The benefit is that users whose provider reports an empty name (or email) can sign in normally instead of being locked out, with no change in behavior for anyone else

## Linked Issues or Issue Description

No existing issue; described in-PR following the bug report template:

**What happened?**

Users whose auth provider returns `name: ""` (empty string) in the profile payload fail `currentUserProfileSchema` / `authSessionSchema` parsing (`name: z.string().min(1)...`). The parse failure makes the session look invalid and the UI redirects to `/auth` on every attempt — an endless sign-in loop. The `email` field has the same failure mode (`z.string().email()` rejects `""`).

**Expected behavior:**

An empty display name (or email) should be treated the same as a missing one (`null`); the user should be signed in normally.

**Steps to reproduce:**

Sign in with an account whose upstream identity record has an empty-string name (or set a user's `name` column to `''` directly), then load the app: session parse fails and you are bounced back to `/auth`.

**Adapter(s) involved:**

Not adapter-specific (core bug).

**Deployment mode / version:**

Any; reproduces on current `master`.

## What Changed

- `packages/shared/src/validators/access.ts`: `currentUserProfileSchema.name` now runs through `z.preprocess` that coerces empty or whitespace-only strings to `null` before the existing `z.string().min(1).max(120).nullable()` validation.
- `packages/shared/src/validators/access.ts`: the same preprocess is applied to `email` (review follow-up): `users.email` is `notNull` in the DB schema, so a provider without an email stores `""`, which `z.string().email()` rejects — the identical lockout loop. Empty/whitespace-only emails now coerce to `null` (the field was already nullable); malformed non-empty emails are still rejected.
- `packages/shared/src/validators/access.test.ts` (new): covers empty-string → `null`, whitespace-only → `null`, real values preserved, `null` preserved, and malformed non-empty email still rejected — for both `name` and `email`, and the same cases through `authSessionSchema`.

## Verification

- `vitest run src/validators/access.test.ts` in `packages/shared` — 13 tests pass.
- `tsc --noEmit -p packages/shared` passes.
- Manual: parse `{ id, email: "", name: "", image: null }` with `currentUserProfileSchema` — succeeds with `name: null` and `email: null` instead of failing validation.

## Risks

- Low risk. The change only widens accepted input (empty/whitespace string → `null` for `name` and `email`); every previously valid payload parses identically. `updateCurrentUserProfileSchema` (user-initiated rename) is untouched and still rejects empty names.

## Model Used

Claude Fable 5 (Anthropic, `claude-fable-5`, agentic coding harness via Claude Code, extended reasoning enabled). Original fix drafted with Claude Sonnet 4.6.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
