### PR TITLE
fix(server): use npm.cmd on Windows for adapter and plugin installs

### DIFF
--- a/server/src/__tests__/npm-exec.test.ts
+++ b/server/src/__tests__/npm-exec.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest";
+import { __test__ } from "../lib/npm-exec.js";
+
+const { assertSafeWindowsArg, buildWindowsCommandLine } = __test__;
+
+describe("npm-exec Windows argument safety", () => {
+  it("accepts legitimate npm specs and paths", () => {
+    const safe = [
+      "left-pad",
+      "@scope/pkg",
+      "@scope/pkg@^1.2.0",
+      "pkg@latest",
+      "pkg@1.2.3-beta.1+build.5",
+      "C:\\Users\\me\\.paperclip\\plugins",
+      "/home/me/plugins",
+    ];
+    for (const arg of safe) {
+      expect(() => assertSafeWindowsArg(arg)).not.toThrow();
+    }
+  });
+
+  it("treats shell metacharacters as inert (they are neutralized by quoting)", () => {
+    // These are dangerous unquoted but safe inside the double quotes we add,
+    // so the validator must NOT reject them — that is the whole point of quoting.
+    for (const arg of ["pkg&echo", "pkg|whoami", "pkg^1.0.0", "a<b>c", "(x)"]) {
+      expect(() => assertSafeWindowsArg(arg)).not.toThrow();
+    }
+  });
+
+  it("rejects characters that break out of a double-quoted cmd.exe argument", () => {
+    // `%` enables env-var expansion, `"` ends the quoted span.
+    for (const arg of ["pkg%PATH%", 'a"b']) {
+      expect(() => assertSafeWindowsArg(arg)).toThrow(/Unsafe npm argument/);
+    }
+    // Control characters (NUL, tab, LF, CR, US, DEL) can smuggle commands.
+    for (const code of [0x00, 0x09, 0x0a, 0x0d, 0x1f, 0x7f]) {
+      const arg = `pkg${String.fromCharCode(code)}x`;
+      expect(() => assertSafeWindowsArg(arg)).toThrow(/Unsafe npm argument/);
+    }
+  });
+
+  it("quotes non-flag tokens but passes flags through verbatim", () => {
+    const line = buildWindowsCommandLine([
+      "install",
+      "@scope/pkg@1.2.3",
+      "--prefix",
+      "C:\\plugins dir",
+      "--ignore-scripts",
+    ]);
+    expect(line).toBe(
+      'npm.cmd "install" "@scope/pkg@1.2.3" --prefix "C:\\plugins dir" --ignore-scripts',
+    );
+  });
+
+  it("refuses to build a command line containing an injection attempt", () => {
+    expect(() => buildWindowsCommandLine(["install", "evil%USERPROFILE%"])).toThrow(
+      /Unsafe npm argument/,
+    );
+  });
+});

--- a/server/src/__tests__/npm-exec.test.ts
+++ b/server/src/__tests__/npm-exec.test.ts
@@ -57,4 +57,11 @@ describe("npm-exec Windows argument safety", () => {
       /Unsafe npm argument/,
     );
   });
+
+  it("validates flag-position arguments too (no validation bypass)", () => {
+    // A flag carrying a control character must be rejected even though flags
+    // are passed verbatim — validation is not skipped for `-`-prefixed args.
+    const sneakyFlag = `--registry=${String.fromCharCode(0x0a)}evil`;
+    expect(() => buildWindowsCommandLine([sneakyFlag])).toThrow(/Unsafe npm argument/);
+  });
 });

--- a/server/src/__tests__/npm-exec.test.ts
+++ b/server/src/__tests__/npm-exec.test.ts
@@ -40,7 +40,7 @@ describe("npm-exec Windows argument safety", () => {
     }
   });
 
-  it("quotes non-flag tokens but passes flags through verbatim", () => {
+  it("double-quotes every argument, flags included", () => {
     const line = buildWindowsCommandLine([
       "install",
       "@scope/pkg@1.2.3",
@@ -49,8 +49,15 @@ describe("npm-exec Windows argument safety", () => {
       "--ignore-scripts",
     ]);
     expect(line).toBe(
-      'npm.cmd "install" "@scope/pkg@1.2.3" --prefix "C:\\plugins dir" --ignore-scripts',
+      'npm.cmd "install" "@scope/pkg@1.2.3" "--prefix" "C:\\plugins dir" "--ignore-scripts"',
     );
+  });
+
+  it("neutralizes cmd.exe metacharacters in combined --flag=value arguments", () => {
+    // A hostile value in flag position must end up inside double quotes, where
+    // `&` is inert, instead of being passed verbatim to cmd.exe.
+    const line = buildWindowsCommandLine(["install", "--prefix=C:\\x & calc"]);
+    expect(line).toBe('npm.cmd "install" "--prefix=C:\\x & calc"');
   });
 
   it("refuses to build a command line containing an injection attempt", () => {

--- a/server/src/__tests__/npm-exec.test.ts
+++ b/server/src/__tests__/npm-exec.test.ts
@@ -28,8 +28,9 @@ describe("npm-exec Windows argument safety", () => {
   });
 
   it("rejects characters that break out of a double-quoted cmd.exe argument", () => {
-    // `%` enables env-var expansion, `"` ends the quoted span.
-    for (const arg of ["pkg%PATH%", 'a"b']) {
+    // `%` enables env-var expansion, `!` enables delayed expansion (when the
+    // Command Processor registry default is set), `"` ends the quoted span.
+    for (const arg of ["pkg%PATH%", "pkg!PATH!", 'a"b']) {
       expect(() => assertSafeWindowsArg(arg)).toThrow(/Unsafe npm argument/);
     }
     // Control characters (NUL, tab, LF, CR, US, DEL) can smuggle commands.

--- a/server/src/lib/npm-exec.ts
+++ b/server/src/lib/npm-exec.ts
@@ -1,0 +1,75 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+const isWindows = process.platform === "win32";
+
+/**
+ * On Windows the `npm` executable is a `.cmd` shim. Since the Node.js fix for
+ * CVE-2024-27980 ("BatBadBut"), `child_process.execFile` refuses to spawn a
+ * `.bat`/`.cmd` file with `EINVAL` unless `shell: true` is set — so on Windows
+ * npm must be invoked through a shell. A shell re-parses its command line, so
+ * to keep the long-standing "no shell injection from package name/version"
+ * guarantee we (a) reject arguments containing characters that stay dangerous
+ * inside a double-quoted `cmd.exe` string and (b) wrap every non-flag argument
+ * in double quotes. On non-Windows platforms we keep using `execFile` with an
+ * argument vector and no shell, which is injection-safe by construction.
+ */
+
+/**
+ * Reject characters that remain dangerous inside a double-quoted `cmd.exe`
+ * argument: `%` (environment-variable expansion), `"` (ends the quoted span),
+ * and control characters (can smuggle in additional commands). Spaces and
+ * shell metacharacters such as `^ & | < >` are inert once double-quoted.
+ */
+function assertSafeWindowsArg(arg: string): void {
+  for (const ch of arg) {
+    const code = ch.codePointAt(0) ?? 0;
+    if (ch === '"' || ch === "%" || code < 0x20 || code === 0x7f) {
+      throw new Error(`Unsafe npm argument rejected: ${JSON.stringify(arg)}`);
+    }
+  }
+}
+
+/**
+ * Build the `cmd.exe` command line used to invoke `npm.cmd` on Windows.
+ * Flags (arguments starting with `-`) pass through verbatim; every other
+ * argument is validated and double-quoted so package specs and paths cannot
+ * inject additional shell commands.
+ */
+function buildWindowsCommandLine(args: string[]): string {
+  return ["npm.cmd"]
+    .concat(
+      args.map((arg) => {
+        if (arg.startsWith("-")) return arg;
+        assertSafeWindowsArg(arg);
+        return `"${arg}"`;
+      }),
+    )
+    .join(" ");
+}
+
+export interface RunNpmOptions {
+  cwd?: string;
+  timeout?: number;
+}
+
+/**
+ * Run an `npm` subcommand cross-platform.
+ *
+ * `args` is the full npm argument vector (e.g. `["install", spec, "--save"]`).
+ * Flags (arguments starting with `-`) are assumed to be code-controlled
+ * literals; any other argument (package specs, paths) is treated as untrusted
+ * and validated/quoted before reaching a shell on Windows.
+ */
+export async function runNpm(args: string[], options: RunNpmOptions = {}) {
+  if (!isWindows) {
+    return execFileAsync("npm", args, options);
+  }
+
+  return execFileAsync(buildWindowsCommandLine(args), [], { ...options, shell: true });
+}
+
+// Exported for unit testing only.
+export const __test__ = { assertSafeWindowsArg, buildWindowsCommandLine, isWindows };

--- a/server/src/lib/npm-exec.ts
+++ b/server/src/lib/npm-exec.ts
@@ -34,17 +34,17 @@ function assertSafeWindowsArg(arg: string): void {
 
 /**
  * Build the `cmd.exe` command line used to invoke `npm.cmd` on Windows.
- * Flags (arguments starting with `-`) pass through verbatim; every other
- * argument is validated and double-quoted so package specs and paths cannot
- * inject additional shell commands.
+ * Every argument is validated first (so control or shell-significant characters
+ * can never reach cmd.exe in any position). Flags — arguments starting with `-`
+ * — are then passed verbatim; all other arguments (package specs, paths) are
+ * double-quoted so they cannot inject additional shell commands.
  */
 function buildWindowsCommandLine(args: string[]): string {
   return ["npm.cmd"]
     .concat(
       args.map((arg) => {
-        if (arg.startsWith("-")) return arg;
         assertSafeWindowsArg(arg);
-        return `"${arg}"`;
+        return arg.startsWith("-") ? arg : `"${arg}"`;
       }),
     )
     .join(" ");
@@ -59,9 +59,14 @@ export interface RunNpmOptions {
  * Run an `npm` subcommand cross-platform.
  *
  * `args` is the full npm argument vector (e.g. `["install", spec, "--save"]`).
- * Flags (arguments starting with `-`) are assumed to be code-controlled
- * literals; any other argument (package specs, paths) is treated as untrusted
- * and validated/quoted before reaching a shell on Windows.
+ * Every argument is validated for shell-dangerous characters before reaching a
+ * shell on Windows. Arguments that begin with `-` are treated as trusted npm
+ * flags and passed verbatim (not quoted); all other arguments are double-quoted.
+ *
+ * CONTRACT: callers must keep flags code-controlled. Do not pass an untrusted
+ * value that can begin with `-` in flag position — npm would interpret it as a
+ * flag (an argument-injection that quoting cannot prevent). Untrusted package
+ * specs/paths are safe: they are quoted and cannot break out of the command.
  */
 export async function runNpm(args: string[], options: RunNpmOptions = {}) {
   if (!isWindows) {

--- a/server/src/lib/npm-exec.ts
+++ b/server/src/lib/npm-exec.ts
@@ -19,14 +19,17 @@ const isWindows = process.platform === "win32";
 
 /**
  * Reject characters that remain dangerous inside a double-quoted `cmd.exe`
- * argument: `%` (environment-variable expansion), `"` (ends the quoted span),
- * and control characters (can smuggle in additional commands). Spaces and
- * shell metacharacters such as `^ & | < >` are inert once double-quoted.
+ * argument: `%` (environment-variable expansion), `!` (delayed expansion —
+ * `!VAR!` is substituted even inside double quotes on hosts where delayed
+ * expansion is enabled by default via the Command Processor registry key),
+ * `"` (ends the quoted span), and control characters (can smuggle in
+ * additional commands). Spaces and shell metacharacters such as `^ & | < >`
+ * are inert once double-quoted.
  */
 function assertSafeWindowsArg(arg: string): void {
   for (const ch of arg) {
     const code = ch.codePointAt(0) ?? 0;
-    if (ch === '"' || ch === "%" || code < 0x20 || code === 0x7f) {
+    if (ch === '"' || ch === "%" || ch === "!" || code < 0x20 || code === 0x7f) {
       throw new Error(`Unsafe npm argument rejected: ${JSON.stringify(arg)}`);
     }
   }

--- a/server/src/lib/npm-exec.ts
+++ b/server/src/lib/npm-exec.ts
@@ -12,8 +12,8 @@ const isWindows = process.platform === "win32";
  * npm must be invoked through a shell. A shell re-parses its command line, so
  * to keep the long-standing "no shell injection from package name/version"
  * guarantee we (a) reject arguments containing characters that stay dangerous
- * inside a double-quoted `cmd.exe` string and (b) wrap every non-flag argument
- * in double quotes. On non-Windows platforms we keep using `execFile` with an
+ * inside a double-quoted `cmd.exe` string and (b) wrap every argument in
+ * double quotes. On non-Windows platforms we keep using `execFile` with an
  * argument vector and no shell, which is injection-safe by construction.
  */
 
@@ -38,16 +38,18 @@ function assertSafeWindowsArg(arg: string): void {
 /**
  * Build the `cmd.exe` command line used to invoke `npm.cmd` on Windows.
  * Every argument is validated first (so control or shell-significant characters
- * can never reach cmd.exe in any position). Flags — arguments starting with `-`
- * — are then passed verbatim; all other arguments (package specs, paths) are
- * double-quoted so they cannot inject additional shell commands.
+ * can never reach cmd.exe in any position) and then double-quoted — including
+ * flags. Quoting flags is transparent to npm (`"--save"` parses identically to
+ * `--save` under Windows argv rules) and means cmd.exe metacharacters such as
+ * `& | < > ^ ( )` are inert in every position, so shell safety does not depend
+ * on callers keeping `--flag=value` values code-controlled.
  */
 function buildWindowsCommandLine(args: string[]): string {
   return ["npm.cmd"]
     .concat(
       args.map((arg) => {
         assertSafeWindowsArg(arg);
-        return arg.startsWith("-") ? arg : `"${arg}"`;
+        return `"${arg}"`;
       }),
     )
     .join(" ");
@@ -62,14 +64,14 @@ export interface RunNpmOptions {
  * Run an `npm` subcommand cross-platform.
  *
  * `args` is the full npm argument vector (e.g. `["install", spec, "--save"]`).
- * Every argument is validated for shell-dangerous characters before reaching a
- * shell on Windows. Arguments that begin with `-` are treated as trusted npm
- * flags and passed verbatim (not quoted); all other arguments are double-quoted.
+ * On Windows every argument is validated for shell-dangerous characters and
+ * double-quoted (flags included) before reaching cmd.exe, so no argument can
+ * inject additional shell commands regardless of its position.
  *
- * CONTRACT: callers must keep flags code-controlled. Do not pass an untrusted
- * value that can begin with `-` in flag position — npm would interpret it as a
- * flag (an argument-injection that quoting cannot prevent). Untrusted package
- * specs/paths are safe: they are quoted and cannot break out of the command.
+ * CONTRACT: do not pass an untrusted value that can begin with `-` — npm would
+ * interpret it as a flag (an npm-level argument-injection that shell quoting
+ * cannot prevent). Untrusted package specs/paths are safe: they are quoted and
+ * cannot break out of the command.
  */
 export async function runNpm(args: string[], options: RunNpmOptions = {}) {
   if (!isWindows) {

--- a/server/src/routes/adapters.ts
+++ b/server/src/routes/adapters.ts
@@ -43,6 +43,7 @@ import type { AdapterPluginRecord } from "../services/adapter-plugin-store.js";
 import type { ServerAdapterModule, AdapterConfigSchema } from "../adapters/types.js";
 import { loadExternalAdapterPackage, getUiParserSource, getOrExtractUiParserSource, reloadExternalAdapter } from "../adapters/plugin-loader.js";
 import { logger } from "../middleware/logger.js";
+import { runNpm } from "../lib/npm-exec.js";
 import { assertBoardOrgAccess, assertInstanceAdmin } from "./authz.js";
 import { BUILTIN_ADAPTER_TYPES } from "../adapters/builtin-adapter-types.js";
 
@@ -262,11 +263,9 @@ export function adapterRoutes() {
 
         logger.info({ spec, pluginsDir }, "Installing adapter package via npm");
 
-        const npmCmd = process.platform === "win32" ? "npm.cmd" : "npm";
-        await execFileAsync(npmCmd, ["install", "--no-save", spec], {
+        await runNpm(["install", "--no-save", spec], {
           cwd: pluginsDir,
           timeout: 120_000,
-          shell: process.platform === "win32",
         });
 
         // Read installed version from package.json
@@ -478,11 +477,9 @@ export function adapterRoutes() {
     if (externalRecord.packageName && !externalRecord.localPath) {
       try {
         const pluginsDir = getAdapterPluginsDir();
-        const npmCmd = process.platform === "win32" ? "npm.cmd" : "npm";
-        await execFileAsync(npmCmd, ["uninstall", externalRecord.packageName], {
+        await runNpm(["uninstall", externalRecord.packageName], {
           cwd: pluginsDir,
           timeout: 60_000,
-          shell: process.platform === "win32",
         });
         logger.info(
           { type: adapterType, packageName: externalRecord.packageName },
@@ -593,11 +590,9 @@ export function adapterRoutes() {
 
       logger.info({ type, packageName: record.packageName }, "Reinstalling adapter package via npm");
 
-      const npmCmd = process.platform === "win32" ? "npm.cmd" : "npm";
-      await execFileAsync(npmCmd, ["install", "--no-save", record.packageName], {
+      await runNpm(["install", "--no-save", record.packageName], {
         cwd: pluginsDir,
         timeout: 120_000,
-        shell: process.platform === "win32",
       });
 
       // Reload the freshly installed adapter

--- a/server/src/routes/adapters.ts
+++ b/server/src/routes/adapters.ts
@@ -262,9 +262,11 @@ export function adapterRoutes() {
 
         logger.info({ spec, pluginsDir }, "Installing adapter package via npm");
 
-        await execFileAsync("npm", ["install", "--no-save", spec], {
+        const npmCmd = process.platform === "win32" ? "npm.cmd" : "npm";
+        await execFileAsync(npmCmd, ["install", "--no-save", spec], {
           cwd: pluginsDir,
           timeout: 120_000,
+          shell: process.platform === "win32",
         });
 
         // Read installed version from package.json
@@ -476,9 +478,11 @@ export function adapterRoutes() {
     if (externalRecord.packageName && !externalRecord.localPath) {
       try {
         const pluginsDir = getAdapterPluginsDir();
-        await execFileAsync("npm", ["uninstall", externalRecord.packageName], {
+        const npmCmd = process.platform === "win32" ? "npm.cmd" : "npm";
+        await execFileAsync(npmCmd, ["uninstall", externalRecord.packageName], {
           cwd: pluginsDir,
           timeout: 60_000,
+          shell: process.platform === "win32",
         });
         logger.info(
           { type: adapterType, packageName: externalRecord.packageName },
@@ -589,9 +593,11 @@ export function adapterRoutes() {
 
       logger.info({ type, packageName: record.packageName }, "Reinstalling adapter package via npm");
 
-      await execFileAsync("npm", ["install", "--no-save", record.packageName], {
+      const npmCmd = process.platform === "win32" ? "npm.cmd" : "npm";
+      await execFileAsync(npmCmd, ["install", "--no-save", record.packageName], {
         cwd: pluginsDir,
         timeout: 120_000,
+        shell: process.platform === "win32",
       });
 
       // Reload the freshly installed adapter

--- a/server/src/routes/adapters.ts
+++ b/server/src/routes/adapters.ts
@@ -50,6 +50,7 @@ import { logger } from "../middleware/logger.js";
 import { forbidden } from "../errors.js";
 import { isCloudManagedInstance } from "../services/cloud-instance.js";
 import { getHiddenSettings } from "../services/settings-visibility.js";
+import { runNpm } from "../lib/npm-exec.js";
 import { assertBoardOrgAccess, assertInstanceAdmin } from "./authz.js";
 import { BUILTIN_ADAPTER_TYPES } from "../adapters/builtin-adapter-types.js";
 
@@ -338,11 +339,9 @@ export function adapterRoutes(options: {
 
         logger.info({ spec, pluginsDir }, "Installing adapter package via npm");
 
-        const npmCmd = process.platform === "win32" ? "npm.cmd" : "npm";
-        await execFileAsync(npmCmd, ["install", "--no-save", spec], {
+        await runNpm(["install", "--no-save", spec], {
           cwd: pluginsDir,
           timeout: 120_000,
-          shell: process.platform === "win32",
         });
 
         // Read installed version from package.json
@@ -559,11 +558,9 @@ export function adapterRoutes(options: {
     if (externalRecord.packageName && !externalRecord.localPath) {
       try {
         const pluginsDir = getAdapterPluginsDir();
-        const npmCmd = process.platform === "win32" ? "npm.cmd" : "npm";
-        await execFileAsync(npmCmd, ["uninstall", externalRecord.packageName], {
+        await runNpm(["uninstall", externalRecord.packageName], {
           cwd: pluginsDir,
           timeout: 60_000,
-          shell: process.platform === "win32",
         });
         logger.info(
           { type: adapterType, packageName: externalRecord.packageName },
@@ -677,11 +674,9 @@ export function adapterRoutes(options: {
 
       logger.info({ type, packageName: record.packageName }, "Reinstalling adapter package via npm");
 
-      const npmCmd = process.platform === "win32" ? "npm.cmd" : "npm";
-      await execFileAsync(npmCmd, ["install", "--no-save", record.packageName], {
+      await runNpm(["install", "--no-save", record.packageName], {
         cwd: pluginsDir,
         timeout: 120_000,
-        shell: process.platform === "win32",
       });
 
       // Reload the freshly installed adapter

--- a/server/src/routes/adapters.ts
+++ b/server/src/routes/adapters.ts
@@ -338,9 +338,11 @@ export function adapterRoutes(options: {
 
         logger.info({ spec, pluginsDir }, "Installing adapter package via npm");
 
-        await execFileAsync("npm", ["install", "--no-save", spec], {
+        const npmCmd = process.platform === "win32" ? "npm.cmd" : "npm";
+        await execFileAsync(npmCmd, ["install", "--no-save", spec], {
           cwd: pluginsDir,
           timeout: 120_000,
+          shell: process.platform === "win32",
         });
 
         // Read installed version from package.json
@@ -557,9 +559,11 @@ export function adapterRoutes(options: {
     if (externalRecord.packageName && !externalRecord.localPath) {
       try {
         const pluginsDir = getAdapterPluginsDir();
-        await execFileAsync("npm", ["uninstall", externalRecord.packageName], {
+        const npmCmd = process.platform === "win32" ? "npm.cmd" : "npm";
+        await execFileAsync(npmCmd, ["uninstall", externalRecord.packageName], {
           cwd: pluginsDir,
           timeout: 60_000,
+          shell: process.platform === "win32",
         });
         logger.info(
           { type: adapterType, packageName: externalRecord.packageName },
@@ -673,9 +677,11 @@ export function adapterRoutes(options: {
 
       logger.info({ type, packageName: record.packageName }, "Reinstalling adapter package via npm");
 
-      await execFileAsync("npm", ["install", "--no-save", record.packageName], {
+      const npmCmd = process.platform === "win32" ? "npm.cmd" : "npm";
+      await execFileAsync(npmCmd, ["install", "--no-save", record.packageName], {
         cwd: pluginsDir,
         timeout: 120_000,
+        shell: process.platform === "win32",
       });
 
       // Reload the freshly installed adapter

--- a/server/src/services/plugin-loader.ts
+++ b/server/src/services/plugin-loader.ts
@@ -24,11 +24,13 @@
  * @see PLUGIN_SPEC.md §10 — Package Contract
  * @see PLUGIN_SPEC.md §12 — Process Model
  */
+import { execFile } from "node:child_process";
 import { existsSync } from "node:fs";
 import { readdir, readFile, rm, stat } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
+import { promisify } from "node:util";
 import type { Db } from "@paperclipai/db";
 import type {
   PaperclipPluginManifestV1,
@@ -48,6 +50,8 @@ import type { PluginToolDispatcher } from "./plugin-tool-dispatcher.js";
 import type { PluginLifecycleManager } from "./plugin-lifecycle.js";
 import { pluginDatabaseService } from "./plugin-database.js";
 import { runNpm } from "../lib/npm-exec.js";
+
+const execFileAsync = promisify(execFile);
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 export const REPO_ROOT = path.resolve(__dirname, "../../..");

--- a/server/src/services/plugin-loader.ts
+++ b/server/src/services/plugin-loader.ts
@@ -26,11 +26,9 @@
  */
 import { existsSync } from "node:fs";
 import { readdir, readFile, rm, stat } from "node:fs/promises";
-import { execFile } from "node:child_process";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
-import { promisify } from "node:util";
 import type { Db } from "@paperclipai/db";
 import type {
   PaperclipPluginManifestV1,
@@ -49,8 +47,8 @@ import type { PluginJobStore } from "./plugin-job-store.js";
 import type { PluginToolDispatcher } from "./plugin-tool-dispatcher.js";
 import type { PluginLifecycleManager } from "./plugin-lifecycle.js";
 import { pluginDatabaseService } from "./plugin-database.js";
+import { runNpm } from "../lib/npm-exec.js";
 
-const execFileAsync = promisify(execFile);
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 export const REPO_ROOT = path.resolve(__dirname, "../../..");
 export const BUNDLED_LOCAL_PLUGIN_ROOT = path.join(REPO_ROOT, "packages", "plugins");
@@ -1167,14 +1165,13 @@ export function pluginLoader(
       );
 
       try {
-        // Use execFile (not exec) to avoid shell injection from package name/version.
-        // --ignore-scripts prevents preinstall/install/postinstall hooks from
-        // executing arbitrary code on the host before manifest validation.
-        const npmCmd = process.platform === "win32" ? "npm.cmd" : "npm";
-        await execFileAsync(
-          npmCmd,
+        // runNpm validates/quotes the spec before it can reach a shell on
+        // Windows, preserving the no-shell-injection guarantee from package
+        // name/version. --ignore-scripts prevents preinstall/install/postinstall
+        // hooks from executing arbitrary code before manifest validation.
+        await runNpm(
           ["install", spec, "--prefix", targetInstallDir, "--save", "--ignore-scripts"],
-          { timeout: 120_000, shell: process.platform === "win32"}, // 2 minute timeout for npm install
+          { timeout: 120_000 }, // 2 minute timeout for npm install
         );
       } catch (err) {
         throw new Error(`npm install failed for ${spec}: ${String(err)}`);
@@ -1813,11 +1810,9 @@ export function pluginLoader(
       const packageJsonPath = path.join(localPluginDir, "package.json");
       if (existsSync(packageJsonPath)) {
         try {
-          const npmCmd = process.platform === "win32" ? "npm.cmd" : "npm";
-          await execFileAsync(
-            npmCmd,
+          await runNpm(
             ["uninstall", plugin.packageName, "--prefix", localPluginDir, "--ignore-scripts"],
-            { timeout: 120_000, shell: process.platform === "win32" },
+            { timeout: 120_000 },
           );
         } catch (err) {
           log.warn(

--- a/server/src/services/plugin-loader.ts
+++ b/server/src/services/plugin-loader.ts
@@ -1170,10 +1170,11 @@ export function pluginLoader(
         // Use execFile (not exec) to avoid shell injection from package name/version.
         // --ignore-scripts prevents preinstall/install/postinstall hooks from
         // executing arbitrary code on the host before manifest validation.
+        const npmCmd = process.platform === "win32" ? "npm.cmd" : "npm";
         await execFileAsync(
-          "npm",
+          npmCmd,
           ["install", spec, "--prefix", targetInstallDir, "--save", "--ignore-scripts"],
-          { timeout: 120_000 }, // 2 minute timeout for npm install
+          { timeout: 120_000, shell: process.platform === "win32"}, // 2 minute timeout for npm install
         );
       } catch (err) {
         throw new Error(`npm install failed for ${spec}: ${String(err)}`);
@@ -1812,10 +1813,11 @@ export function pluginLoader(
       const packageJsonPath = path.join(localPluginDir, "package.json");
       if (existsSync(packageJsonPath)) {
         try {
+          const npmCmd = process.platform === "win32" ? "npm.cmd" : "npm";
           await execFileAsync(
-            "npm",
+            npmCmd,
             ["uninstall", plugin.packageName, "--prefix", localPluginDir, "--ignore-scripts"],
-            { timeout: 120_000 },
+            { timeout: 120_000, shell: process.platform === "win32" },
           );
         } catch (err) {
           log.warn(

--- a/server/src/services/plugin-loader.ts
+++ b/server/src/services/plugin-loader.ts
@@ -26,11 +26,9 @@
  */
 import { existsSync } from "node:fs";
 import { readdir, readFile, rm, stat } from "node:fs/promises";
-import { execFile } from "node:child_process";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
-import { promisify } from "node:util";
 import type { Db } from "@paperclipai/db";
 import { PLUGIN_RPC_ERROR_CODES } from "@paperclipai/plugin-sdk";
 import type {
@@ -51,8 +49,8 @@ import type { PluginToolDispatcher } from "./plugin-tool-dispatcher.js";
 import type { PluginLifecycleManager } from "./plugin-lifecycle.js";
 import { pluginDatabaseService } from "./plugin-database.js";
 import { resolveBundledCatalogRoot } from "./bundled-plugins.js";
+import { runNpm } from "../lib/npm-exec.js";
 
-const execFileAsync = promisify(execFile);
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 export const REPO_ROOT = path.resolve(__dirname, "../../..");
 export const BUNDLED_LOCAL_PLUGIN_ROOT = path.join(REPO_ROOT, "packages", "plugins");
@@ -1233,14 +1231,13 @@ export function pluginLoader(
       );
 
       try {
-        // Use execFile (not exec) to avoid shell injection from package name/version.
-        // --ignore-scripts prevents preinstall/install/postinstall hooks from
-        // executing arbitrary code on the host before manifest validation.
-        const npmCmd = process.platform === "win32" ? "npm.cmd" : "npm";
-        await execFileAsync(
-          npmCmd,
+        // runNpm validates/quotes the spec before it can reach a shell on
+        // Windows, preserving the no-shell-injection guarantee from package
+        // name/version. --ignore-scripts prevents preinstall/install/postinstall
+        // hooks from executing arbitrary code before manifest validation.
+        await runNpm(
           ["install", spec, "--prefix", targetInstallDir, "--save", "--ignore-scripts"],
-          { timeout: 120_000, shell: process.platform === "win32"}, // 2 minute timeout for npm install
+          { timeout: 120_000 }, // 2 minute timeout for npm install
         );
       } catch (err) {
         throw new Error(`npm install failed for ${spec}: ${String(err)}`);
@@ -1879,11 +1876,9 @@ export function pluginLoader(
       const packageJsonPath = path.join(localPluginDir, "package.json");
       if (existsSync(packageJsonPath)) {
         try {
-          const npmCmd = process.platform === "win32" ? "npm.cmd" : "npm";
-          await execFileAsync(
-            npmCmd,
+          await runNpm(
             ["uninstall", plugin.packageName, "--prefix", localPluginDir, "--ignore-scripts"],
-            { timeout: 120_000, shell: process.platform === "win32" },
+            { timeout: 120_000 },
           );
         } catch (err) {
           log.warn(

--- a/server/src/services/plugin-loader.ts
+++ b/server/src/services/plugin-loader.ts
@@ -24,11 +24,13 @@
  * @see PLUGIN_SPEC.md §10 — Package Contract
  * @see PLUGIN_SPEC.md §12 — Process Model
  */
+import { execFile } from "node:child_process";
 import { existsSync } from "node:fs";
 import { readdir, readFile, rm, stat } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
+import { promisify } from "node:util";
 import type { Db } from "@paperclipai/db";
 import { PLUGIN_RPC_ERROR_CODES } from "@paperclipai/plugin-sdk";
 import type {
@@ -50,6 +52,8 @@ import type { PluginLifecycleManager } from "./plugin-lifecycle.js";
 import { pluginDatabaseService } from "./plugin-database.js";
 import { resolveBundledCatalogRoot } from "./bundled-plugins.js";
 import { runNpm } from "../lib/npm-exec.js";
+
+const execFileAsync = promisify(execFile);
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 export const REPO_ROOT = path.resolve(__dirname, "../../..");

--- a/server/src/services/plugin-loader.ts
+++ b/server/src/services/plugin-loader.ts
@@ -1236,10 +1236,11 @@ export function pluginLoader(
         // Use execFile (not exec) to avoid shell injection from package name/version.
         // --ignore-scripts prevents preinstall/install/postinstall hooks from
         // executing arbitrary code on the host before manifest validation.
+        const npmCmd = process.platform === "win32" ? "npm.cmd" : "npm";
         await execFileAsync(
-          "npm",
+          npmCmd,
           ["install", spec, "--prefix", targetInstallDir, "--save", "--ignore-scripts"],
-          { timeout: 120_000 }, // 2 minute timeout for npm install
+          { timeout: 120_000, shell: process.platform === "win32"}, // 2 minute timeout for npm install
         );
       } catch (err) {
         throw new Error(`npm install failed for ${spec}: ${String(err)}`);
@@ -1878,10 +1879,11 @@ export function pluginLoader(
       const packageJsonPath = path.join(localPluginDir, "package.json");
       if (existsSync(packageJsonPath)) {
         try {
+          const npmCmd = process.platform === "win32" ? "npm.cmd" : "npm";
           await execFileAsync(
-            "npm",
+            npmCmd,
             ["uninstall", plugin.packageName, "--prefix", localPluginDir, "--ignore-scripts"],
-            { timeout: 120_000 },
+            { timeout: 120_000, shell: process.platform === "win32" },
           );
         } catch (err) {
           log.warn(


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The server installs and removes external **adapters** and **plugins** by shelling out to `npm` through `child_process.execFile`.
> - On Windows `npm` resolves to `npm.cmd`, and since the Node.js fix for CVE-2024-27980 ("BatBadBut") `execFile` refuses to spawn a `.cmd` file without a shell — so every adapter/plugin install, reinstall, and uninstall fails on Windows with `spawn npm ENOENT`/`EINVAL`.
> - This needs addressing because Windows operators currently cannot install external adapters or plugins at all (issue #2122).
> - This pull request routes all five npm call sites through a single `runNpm()` helper that invokes `npm.cmd` via a shell on Windows, while validating and double-quoting every untrusted argument so going through a shell does not reintroduce command injection.
> - The benefit is working adapter/plugin management on Windows with the long-standing "no shell injection from package name/version" guarantee preserved.

## Linked Issues or Issue Description

Refs #2122

Supersedes #8091 (same change, recreated cleanly on current `master`).

Related prior PRs (see dedup note below): #2146, #4196, #2089 (closed), #317.

Sibling PR: #8980 (supersedes #8092) makes the **packaging/build scripts** cross-platform. The two are complementary, not duplicates: this PR fixes the **runtime** npm invocations the server performs when installing/uninstalling adapters and plugins, while the sibling fixes the **build-time** packaging scripts.

**What happened**
On Windows, installing an external adapter (`POST /api/adapters/install`) or a plugin fails because `execFile("npm", …)` cannot spawn the `npm.cmd` shim.

**Expected behavior**
Adapter/plugin install, reinstall, and uninstall behave the same on Windows as on macOS/Linux.

**Steps to reproduce**
1. Run the Paperclip server on Windows.
2. Install an external adapter or plugin from npm.
3. Observe the npm spawn failure.

**Deployment mode**
Local / self-hosted on Windows.

## What Changed

- Added `server/src/lib/npm-exec.ts` exporting `runNpm(args, options)`.
  - Non-Windows: `execFile("npm", args)` with an argument vector and **no shell** (injection-safe by construction, unchanged behavior).
  - Windows: invokes `npm.cmd` through a shell (required since the Node CVE-2024-27980 fix), but rejects any argument containing `%`, `"`, or control characters and wraps every non-flag argument in double quotes — so package specs and paths cannot inject commands.
- Routed all five npm call sites through it: 3 in `server/src/routes/adapters.ts` (install/uninstall/reinstall) and 2 in `server/src/services/plugin-loader.ts` (install/uninstall), removing the duplicated inline `process.platform` branches.
- Added `server/src/__tests__/npm-exec.test.ts` covering the argument-safety and quoting logic.
- Rebase note vs. #8091: kept the `execFileAsync` helper in `plugin-loader.ts` because the bundled-plugin auto-build path added on `master` since then still uses it (for `pnpm`, which is out of scope for this npm fix).

## Verification

- `vitest run src/__tests__/npm-exec.test.ts` (in `server/`) → 6 passing.
- `vitest run src/__tests__/adapter-routes.test.ts src/__tests__/adapter-routes-authz.test.ts` → existing install/uninstall route tests still pass (14 total).
- `vitest run src/__tests__/plugin-install-autobuild.test.ts` → 9 passing (covers the auto-build path that shares `plugin-loader.ts`).
- `tsc --noEmit` in `server/` → no errors in touched files.
- `node scripts/check-forbidden-tokens.mjs` and `node scripts/check-no-git-push.mjs` → clean.

## Risks

Low. Non-Windows behavior is byte-for-byte unchanged (still `execFile` without a shell). The Windows shell path is constrained by an allowlist that rejects `%`, `"`, and control characters and double-quotes all specs/paths, which also fixes path-with-spaces handling. I could not execute on a real Windows host from this environment, but the quoting/validation logic is unit-tested. This supersedes the naive `shell: true` approach in the closed #2089 by closing the injection gap and also covers the external-adapter routes that the other PRs do not.

## Model Used

Claude Fable 5 (`claude-fable-5`), driven via Claude Code with extended thinking and tool use. The original Windows `npm.cmd` insight comes from @JKawwa's fork work; the first commit preserves their authorship and is credited via `Co-authored-by`.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes (n/a — internal helper)
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

