### PR TITLE
fix(security): require instance admin to read plugin instance config

### DIFF
--- a/server/src/__tests__/plugin-routes-authz.test.ts
+++ b/server/src/__tests__/plugin-routes-authz.test.ts
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const mockRegistry = vi.hoisted(() => ({
   getById: vi.fn(),
   getByKey: vi.fn(),
+  getConfig: vi.fn(),
   upsertConfig: vi.fn(),
   getCompanySettings: vi.fn(),
   upsertCompanySettings: vi.fn(),
@@ -330,6 +331,39 @@ describe.sequential("plugin install and upgrade authz", () => {
     expect(res.status).toBe(422);
     expect(res.body.error).toMatch(/secret references are disabled/i);
     expect(mockRegistry.upsertConfig).not.toHaveBeenCalled();
+  }, 20_000);
+
+  it("rejects plugin config reads for non-admin board users", async () => {
+    const { app } = await createApp({
+      type: "board",
+      userId: "user-1",
+      source: "session",
+      isInstanceAdmin: false,
+      companyIds: [companyA],
+    });
+
+    const res = await request(app).get(`/api/plugins/${pluginId}/config`);
+
+    expect(res.status).toBe(403);
+    expect(mockRegistry.getById).not.toHaveBeenCalled();
+  }, 20_000);
+
+  it("allows instance admins to read plugin config", async () => {
+    readyPlugin();
+    mockRegistry.getConfig = vi.fn().mockResolvedValue({ configJson: { foo: "bar" } });
+
+    const { app } = await createApp({
+      type: "board",
+      userId: "admin-1",
+      source: "session",
+      isInstanceAdmin: true,
+      companyIds: [],
+    });
+
+    const res = await request(app).get(`/api/plugins/${pluginId}/config`);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ configJson: { foo: "bar" } });
   }, 20_000);
 
   it("allows instance admins to upgrade plugins", async () => {

--- a/server/src/__tests__/plugin-routes-authz.test.ts
+++ b/server/src/__tests__/plugin-routes-authz.test.ts
@@ -350,7 +350,7 @@ describe.sequential("plugin install and upgrade authz", () => {
 
   it("allows instance admins to read plugin config", async () => {
     readyPlugin();
-    mockRegistry.getConfig = vi.fn().mockResolvedValue({ configJson: { foo: "bar" } });
+    mockRegistry.getConfig.mockResolvedValue({ configJson: { foo: "bar" } });
 
     const { app } = await createApp({
       type: "board",

--- a/server/src/routes/plugins.ts
+++ b/server/src/routes/plugins.ts
@@ -2128,10 +2128,16 @@ export function pluginRoutes(
    * has not yet been configured.
    *
    * Response: `PluginConfig | null`
-   * Errors: 404 if plugin not found
+   * Errors:
+   * - 403 if the caller is not an instance admin
+   * - 404 if plugin not found
    */
   router.get("/plugins/:pluginId/config", async (req, res) => {
-    assertBoardOrgAccess(req);
+    // Plugin instance config is admin-scoped data: it is instance-wide (not
+    // company-scoped) and may contain sensitive values. Mirror the write gate
+    // (POST below) so non-admin board actors cannot read another tenant's
+    // instance plugin configuration.
+    assertInstanceAdmin(req);
     const { pluginId } = req.params;
 
     const plugin = await resolvePlugin(registry, pluginId);


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - A single Paperclip instance can host multiple companies (tenants), and instance-level plugins are configured once per instance via `GET`/`POST /api/plugins/:pluginId/config`
> - Plugin instance config regularly contains sensitive values — API keys, tokens, webhook secrets — matching the plugin's `instanceConfigSchema`
> - Writing that config already requires an instance admin (`assertInstanceAdmin`), but reading it only required `assertBoardOrgAccess`, i.e. any board-level user of any company
> - That asymmetry means a non-admin board user of company A can read secrets the instance admin configured, including credentials effectively belonging to other companies on the instance — a cross-tenant information disclosure
> - This pull request aligns the read gate with the existing write gate: `GET /api/plugins/:pluginId/config` now requires an instance admin, and authz tests cover both the 403 and the admin-allowed path
> - The benefit is that plugin instance configuration (and any secrets inside it) is only readable by the actors who are allowed to write it

## Linked Issues or Issue Description

No public issue exists for this; describing it in-PR (bug template fields below). Given it is a permission-check gap we preferred a PR with the one-line fix over a public issue that spells out an exploit with no fix attached.

**What happened:** On a multi-company instance, any authenticated board-level user (no instance-admin role required) can call `GET /api/plugins/:pluginId/config` and receive the full instance-wide `PluginConfig`, because the route was gated with `assertBoardOrgAccess`. Plugin config is instance-scoped and commonly holds secrets (API keys, tokens), so a board user of company A can read configuration/credentials that the instance admin set up and that other companies on the instance rely on.

**What was expected:** Reading plugin instance config should require the same privilege as writing it. `POST /api/plugins/:pluginId/config` already requires `assertInstanceAdmin`; the GET should too.

**Scope/impact:** Requires an authenticated board session, so single-user/single-company installs are unaffected in practice; multi-company instances leak admin-scoped plugin secrets to every board user.

Refs #6148 (open feature PR that moves plugin config to per-company scoping — a larger redesign of the same surface; this PR is the minimal authorization fix for the current instance-wide model and does not conflict conceptually: whichever lands second just re-applies the matching gate).

## What Changed

- `server/src/routes/plugins.ts`: `GET /plugins/:pluginId/config` now calls `assertInstanceAdmin(req)` instead of `assertBoardOrgAccess(req)`, mirroring the existing write gate on `POST /plugins/:pluginId/config`; route docstring updated to document the 403
- `server/src/__tests__/plugin-routes-authz.test.ts`: two new authz tests — a non-admin board user gets 403 (and the registry is never queried), and an instance admin gets 200 with the config payload

## Verification

- `cd server && npx vitest run src/__tests__/plugin-routes-authz.test.ts` — 37 tests pass (35 existing + 2 new)
- `npx tsc --noEmit -p server` — no errors in touched files
- Manual: as a non-admin board user, `GET /api/plugins/<id>/config` now returns 403; as an instance admin it returns the config as before

## Risks

- Behavioral change: non-admin board users could previously read plugin instance config and now get 403. The only UI caller is `ui/src/pages/PluginSettings.tsx` under Instance Settings, whose save path (POST) was already admin-only — non-admins could see but never edit the config there, so tightening the read closes the leak without breaking any working admin flow
- Textual merge overlap with #6148 (touches the same route and test file); trivial to resolve in either direction
- No schema, migration, or API-shape changes otherwise

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- Claude Fable 5 (Anthropic, model ID `claude-fable-5`) via Claude Code — agentic coding with tool use (file edits, git, local test execution)

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
