### PR TITLE
fix(adapter-utils): best-effort restore-tar with --ignore-failed-read (live workspace teardown)

### DIFF
--- a/packages/adapter-utils/src/sandbox-managed-runtime.test.ts
+++ b/packages/adapter-utils/src/sandbox-managed-runtime.test.ts
@@ -1,4 +1,4 @@
-import { lstat, mkdir, mkdtemp, readFile, readdir, rm, symlink, writeFile } from "node:fs/promises";
+import { chmod, lstat, mkdir, mkdtemp, readFile, readdir, rm, symlink, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { execFile as execFileCallback } from "node:child_process";
@@ -7,6 +7,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { resetLocalGitIndexToHead } from "./git-workspace-sync.js";
 
 import {
+  createRemoteTarballFromDirectoryCommand,
   mirrorDirectory,
   prepareSandboxManagedRuntime,
   type SandboxManagedRuntimeClient,
@@ -823,5 +824,134 @@ describe("sandbox managed runtime", () => {
     const emptyArchiveCommand = runCommands.find((command) => command.includes("dd if=/dev/zero"));
     expect(emptyArchiveCommand).toBeDefined();
     expect(emptyArchiveCommand).not.toContain("/dev/null");
+  });
+
+  describe("best-effort restore tar (--ignore-failed-read probe)", () => {
+    // Installs a fake `tar` ahead of the real one on PATH. `--help` advertises
+    // (or not) --ignore-failed-read so the remote capability probe can be
+    // exercised deterministically on any host tar; every invocation is logged,
+    // and real work is delegated to the system tar with the GNU-only flag
+    // stripped (the host tar may be BSD).
+    async function installTarShim(rootDir: string, input: { supportsIgnoreFailedRead: boolean }): Promise<{
+      binDir: string;
+      invocations: () => Promise<string[]>;
+    }> {
+      const binDir = path.join(rootDir, input.supportsIgnoreFailedRead ? "gnu-like-bin" : "bsd-like-bin");
+      const logPath = path.join(binDir, "tar-invocations.log");
+      await mkdir(binDir, { recursive: true });
+      const realTar = (await execFile("sh", ["-c", "command -v tar"])).stdout.trim();
+      const helpBody = input.supportsIgnoreFailedRead
+        ? "      --ignore-failed-read   do not exit with nonzero status on unreadable files"
+        : "      -c  Create  -f  Archive file";
+      await writeFile(
+        path.join(binDir, "tar"),
+        [
+          "#!/bin/sh",
+          `printf '%s\\n' "$*" >> '${logPath}'`,
+          `if [ "$1" = "--help" ]; then printf '%s\\n' 'Usage: tar [OPTION...]' '${helpBody}'; exit 0; fi`,
+          "for arg do",
+          "  shift",
+          '  if [ "$arg" = "--ignore-failed-read" ]; then continue; fi',
+          '  set -- "$@" "$arg"',
+          "done",
+          `exec '${realTar}' "$@"`,
+          "",
+        ].join("\n"),
+        "utf8",
+      );
+      await chmod(path.join(binDir, "tar"), 0o755);
+      return {
+        binDir,
+        invocations: async () => (await readFile(logPath, "utf8")).split("\n").filter(Boolean),
+      };
+    }
+
+    async function runArchiveCommand(command: string, pathPrefix?: string): Promise<void> {
+      await execFile("sh", ["-c", command], {
+        maxBuffer: 32 * 1024 * 1024,
+        env: pathPrefix ? { ...process.env, PATH: `${pathPrefix}:${process.env.PATH}` } : process.env,
+      });
+    }
+
+    it("applies --ignore-failed-read when the remote tar advertises support", async () => {
+      const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-restore-tar-gnu-"));
+      cleanupDirs.push(rootDir);
+      const remoteDir = path.join(rootDir, "workspace");
+      const archivePath = path.join(rootDir, "out", "workspace.tar");
+      await mkdir(remoteDir, { recursive: true });
+      await writeFile(path.join(remoteDir, "data.txt"), "payload\n", "utf8");
+      const shim = await installTarShim(rootDir, { supportsIgnoreFailedRead: true });
+
+      await runArchiveCommand(createRemoteTarballFromDirectoryCommand({ remoteDir, archivePath }), shim.binDir);
+
+      const invocations = await shim.invocations();
+      expect(invocations).toContain("--help");
+      expect(invocations.some((line) => line.startsWith(`--ignore-failed-read -cf ${archivePath} `))).toBe(true);
+      const { stdout } = await execFile("tar", ["-tf", archivePath], { maxBuffer: 32 * 1024 * 1024 });
+      expect(stdout.split("\n").map((line) => line.trim()).filter(Boolean)).toEqual(["data.txt"]);
+    });
+
+    it("omits --ignore-failed-read when the remote tar does not support it", async () => {
+      const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-restore-tar-bsd-"));
+      cleanupDirs.push(rootDir);
+      const remoteDir = path.join(rootDir, "workspace");
+      const archivePath = path.join(rootDir, "out", "workspace.tar");
+      await mkdir(remoteDir, { recursive: true });
+      await writeFile(path.join(remoteDir, "data.txt"), "payload\n", "utf8");
+      const shim = await installTarShim(rootDir, { supportsIgnoreFailedRead: false });
+
+      await runArchiveCommand(createRemoteTarballFromDirectoryCommand({ remoteDir, archivePath }), shim.binDir);
+
+      const invocations = await shim.invocations();
+      expect(invocations.some((line) => line.includes("--ignore-failed-read"))).toBe(false);
+      expect(invocations.some((line) => line.startsWith(`-cf ${archivePath} `))).toBe(true);
+      const { stdout } = await execFile("tar", ["-tf", archivePath], { maxBuffer: 32 * 1024 * 1024 });
+      expect(stdout.split("\n").map((line) => line.trim()).filter(Boolean)).toEqual(["data.txt"]);
+    });
+
+    it("still fails loudly (without fabricating an archive) when an earlier step of the chain fails", async () => {
+      // Regression: the probe must not break the surrounding `&&` chain. A bare
+      // `;` before the probe made `case ... esac && if ... fi` run even after
+      // `cd` failed, so `dd` fabricated a zero-filled "empty" archive and the
+      // whole command exited 0 — masking the failure as a successful restore.
+      const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-restore-tar-chain-"));
+      cleanupDirs.push(rootDir);
+      const remoteDir = path.join(rootDir, "missing", "workspace");
+      const archivePath = path.join(rootDir, "out", "workspace.tar");
+
+      await expect(runArchiveCommand(createRemoteTarballFromDirectoryCommand({ remoteDir, archivePath })))
+        .rejects.toThrow();
+      await expect(lstat(archivePath)).rejects.toMatchObject({ code: "ENOENT" });
+    });
+
+    it("tolerates files that become unreadable mid-archive on a real GNU tar", async (ctx) => {
+      const { stdout: tarHelp } = await execFile("sh", ["-c", "tar --help 2>&1 || true"], {
+        maxBuffer: 32 * 1024 * 1024,
+      });
+      const runningAsRoot = typeof process.geteuid === "function" && process.geteuid() === 0;
+      if (!tarHelp.includes("--ignore-failed-read") || runningAsRoot) {
+        // Needs a GNU/busybox tar and a non-root user (root can read mode-000 files).
+        ctx.skip();
+        return;
+      }
+      const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-restore-tar-unreadable-"));
+      cleanupDirs.push(rootDir);
+      const remoteDir = path.join(rootDir, "workspace");
+      const archivePath = path.join(rootDir, "out", "workspace.tar");
+      await mkdir(remoteDir, { recursive: true });
+      await writeFile(path.join(remoteDir, "readable.txt"), "survives\n", "utf8");
+      await writeFile(path.join(remoteDir, "vanishing.txt"), "cannot be opened\n", "utf8");
+      await chmod(path.join(remoteDir, "vanishing.txt"), 0o000);
+
+      try {
+        // Without --ignore-failed-read GNU tar exits 2 here and the restore
+        // hard-fails; best-effort mode archives whatever is readable.
+        await runArchiveCommand(createRemoteTarballFromDirectoryCommand({ remoteDir, archivePath }));
+        const { stdout } = await execFile("tar", ["-tf", archivePath], { maxBuffer: 32 * 1024 * 1024 });
+        expect(stdout.split("\n").map((line) => line.trim()).filter(Boolean)).toContain("readable.txt");
+      } finally {
+        await chmod(path.join(remoteDir, "vanishing.txt"), 0o644).catch(() => undefined);
+      }
+    });
   });
 });

--- a/packages/adapter-utils/src/sandbox-managed-runtime.test.ts
+++ b/packages/adapter-utils/src/sandbox-managed-runtime.test.ts
@@ -1,6 +1,6 @@
 import { randomBytes } from "node:crypto";
 import { promises as fsPromises } from "node:fs";
-import { lstat, mkdir, mkdtemp, readFile, readdir, rm, stat, symlink, writeFile } from "node:fs/promises";
+import { chmod, lstat, mkdir, mkdtemp, readFile, readdir, rm, stat, symlink, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { execFile as execFileCallback, spawn } from "node:child_process";
@@ -15,6 +15,7 @@ import {
 
 import {
   assertSyncOperationsConfined,
+  createRemoteTarballFromDirectoryCommand,
   escapeTarExcludeLiteral,
   mirrorDirectory,
   prepareSandboxManagedRuntime,
@@ -4291,5 +4292,134 @@ describe("sandbox git-bundle export transport", () => {
     expect(restoreLines.length).toBeGreaterThan(0);
     expect(restoreLines.some((line) => /\(\d+\.\d\/\d+\.\d MB\)/.test(line))).toBe(true);
     expect(restoreLines.some((line) => line.includes("(0.0/0.0 MB)"))).toBe(false);
+  });
+
+  describe("best-effort restore tar (--ignore-failed-read probe)", () => {
+    // Installs a fake `tar` ahead of the real one on PATH. `--help` advertises
+    // (or not) --ignore-failed-read so the remote capability probe can be
+    // exercised deterministically on any host tar; every invocation is logged,
+    // and real work is delegated to the system tar with the GNU-only flag
+    // stripped (the host tar may be BSD).
+    async function installTarShim(rootDir: string, input: { supportsIgnoreFailedRead: boolean }): Promise<{
+      binDir: string;
+      invocations: () => Promise<string[]>;
+    }> {
+      const binDir = path.join(rootDir, input.supportsIgnoreFailedRead ? "gnu-like-bin" : "bsd-like-bin");
+      const logPath = path.join(binDir, "tar-invocations.log");
+      await mkdir(binDir, { recursive: true });
+      const realTar = (await execFile("sh", ["-c", "command -v tar"])).stdout.trim();
+      const helpBody = input.supportsIgnoreFailedRead
+        ? "      --ignore-failed-read   do not exit with nonzero status on unreadable files"
+        : "      -c  Create  -f  Archive file";
+      await writeFile(
+        path.join(binDir, "tar"),
+        [
+          "#!/bin/sh",
+          `printf '%s\\n' "$*" >> '${logPath}'`,
+          `if [ "$1" = "--help" ]; then printf '%s\\n' 'Usage: tar [OPTION...]' '${helpBody}'; exit 0; fi`,
+          "for arg do",
+          "  shift",
+          '  if [ "$arg" = "--ignore-failed-read" ]; then continue; fi',
+          '  set -- "$@" "$arg"',
+          "done",
+          `exec '${realTar}' "$@"`,
+          "",
+        ].join("\n"),
+        "utf8",
+      );
+      await chmod(path.join(binDir, "tar"), 0o755);
+      return {
+        binDir,
+        invocations: async () => (await readFile(logPath, "utf8")).split("\n").filter(Boolean),
+      };
+    }
+
+    async function runArchiveCommand(command: string, pathPrefix?: string): Promise<void> {
+      await execFile("sh", ["-c", command], {
+        maxBuffer: 32 * 1024 * 1024,
+        env: pathPrefix ? { ...process.env, PATH: `${pathPrefix}:${process.env.PATH}` } : process.env,
+      });
+    }
+
+    it("applies --ignore-failed-read when the remote tar advertises support", async () => {
+      const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-restore-tar-gnu-"));
+      cleanupDirs.push(rootDir);
+      const remoteDir = path.join(rootDir, "workspace");
+      const archivePath = path.join(rootDir, "out", "workspace.tar");
+      await mkdir(remoteDir, { recursive: true });
+      await writeFile(path.join(remoteDir, "data.txt"), "payload\n", "utf8");
+      const shim = await installTarShim(rootDir, { supportsIgnoreFailedRead: true });
+
+      await runArchiveCommand(createRemoteTarballFromDirectoryCommand({ remoteDir, archivePath }), shim.binDir);
+
+      const invocations = await shim.invocations();
+      expect(invocations).toContain("--help");
+      expect(invocations.some((line) => line.startsWith(`--ignore-failed-read -cf ${archivePath} `))).toBe(true);
+      const { stdout } = await execFile("tar", ["-tf", archivePath], { maxBuffer: 32 * 1024 * 1024 });
+      expect(stdout.split("\n").map((line) => line.trim()).filter(Boolean)).toEqual(["data.txt"]);
+    });
+
+    it("omits --ignore-failed-read when the remote tar does not support it", async () => {
+      const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-restore-tar-bsd-"));
+      cleanupDirs.push(rootDir);
+      const remoteDir = path.join(rootDir, "workspace");
+      const archivePath = path.join(rootDir, "out", "workspace.tar");
+      await mkdir(remoteDir, { recursive: true });
+      await writeFile(path.join(remoteDir, "data.txt"), "payload\n", "utf8");
+      const shim = await installTarShim(rootDir, { supportsIgnoreFailedRead: false });
+
+      await runArchiveCommand(createRemoteTarballFromDirectoryCommand({ remoteDir, archivePath }), shim.binDir);
+
+      const invocations = await shim.invocations();
+      expect(invocations.some((line) => line.includes("--ignore-failed-read"))).toBe(false);
+      expect(invocations.some((line) => line.startsWith(`-cf ${archivePath} `))).toBe(true);
+      const { stdout } = await execFile("tar", ["-tf", archivePath], { maxBuffer: 32 * 1024 * 1024 });
+      expect(stdout.split("\n").map((line) => line.trim()).filter(Boolean)).toEqual(["data.txt"]);
+    });
+
+    it("still fails loudly (without fabricating an archive) when an earlier step of the chain fails", async () => {
+      // Regression: the probe must not break the surrounding `&&` chain. A bare
+      // `;` before the probe made `case ... esac && if ... fi` run even after
+      // `cd` failed, so `dd` fabricated a zero-filled "empty" archive and the
+      // whole command exited 0 — masking the failure as a successful restore.
+      const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-restore-tar-chain-"));
+      cleanupDirs.push(rootDir);
+      const remoteDir = path.join(rootDir, "missing", "workspace");
+      const archivePath = path.join(rootDir, "out", "workspace.tar");
+
+      await expect(runArchiveCommand(createRemoteTarballFromDirectoryCommand({ remoteDir, archivePath })))
+        .rejects.toThrow();
+      await expect(lstat(archivePath)).rejects.toMatchObject({ code: "ENOENT" });
+    });
+
+    it("tolerates files that become unreadable mid-archive on a real GNU tar", async (ctx) => {
+      const { stdout: tarHelp } = await execFile("sh", ["-c", "tar --help 2>&1 || true"], {
+        maxBuffer: 32 * 1024 * 1024,
+      });
+      const runningAsRoot = typeof process.geteuid === "function" && process.geteuid() === 0;
+      if (!tarHelp.includes("--ignore-failed-read") || runningAsRoot) {
+        // Needs a GNU/busybox tar and a non-root user (root can read mode-000 files).
+        ctx.skip();
+        return;
+      }
+      const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-restore-tar-unreadable-"));
+      cleanupDirs.push(rootDir);
+      const remoteDir = path.join(rootDir, "workspace");
+      const archivePath = path.join(rootDir, "out", "workspace.tar");
+      await mkdir(remoteDir, { recursive: true });
+      await writeFile(path.join(remoteDir, "readable.txt"), "survives\n", "utf8");
+      await writeFile(path.join(remoteDir, "vanishing.txt"), "cannot be opened\n", "utf8");
+      await chmod(path.join(remoteDir, "vanishing.txt"), 0o000);
+
+      try {
+        // Without --ignore-failed-read GNU tar exits 2 here and the restore
+        // hard-fails; best-effort mode archives whatever is readable.
+        await runArchiveCommand(createRemoteTarballFromDirectoryCommand({ remoteDir, archivePath }));
+        const { stdout } = await execFile("tar", ["-tf", archivePath], { maxBuffer: 32 * 1024 * 1024 });
+        expect(stdout.split("\n").map((line) => line.trim()).filter(Boolean)).toContain("readable.txt");
+      } finally {
+        await chmod(path.join(remoteDir, "vanishing.txt"), 0o644).catch(() => undefined);
+      }
+    });
   });
 });

--- a/packages/adapter-utils/src/sandbox-managed-runtime.ts
+++ b/packages/adapter-utils/src/sandbox-managed-runtime.ts
@@ -336,9 +336,17 @@ function createRemoteTarballFromDirectoryCommand(input: {
     "set -- *",
     `if [ "$#" -eq 1 ] && [ "$1" = "*" ] && [ ! -e "$1" ] && [ ! -L "$1" ]; then set --; fi`,
     `for entry in .[!.]* ..?*; do [ -e "$entry" ] || [ -L "$entry" ] || continue; set -- "$@" "$entry"; done`,
+    // The directory can be LIVE while we archive it (the agent's lingering
+    // processes create/delete temp files during teardown), so GNU tar otherwise
+    // exits 2 on "Cannot open: No such file" for a file that vanished
+    // mid-archive, hard-failing the whole restore. --ignore-failed-read makes it
+    // a best-effort archive of whatever is readable. The flag is
+    // GNU/busybox-only (BSD tar rejects it), so gate it on a capability probe ->
+    // portable across GNU, BSD, and busybox tars.
+    `__pc_ifr=""; case "$(tar --help 2>&1)" in *--ignore-failed-read*) __pc_ifr=--ignore-failed-read;; esac`,
     `if [ "$#" -eq 0 ]; then ` +
       `dd if=/dev/zero of=${shellQuote(input.archivePath)} bs=1024 count=1; ` +
-      `else tar -cf ${shellQuote(input.archivePath)} ${tarExcludeFlags(input.exclude)} -- "$@"; fi`,
+      `else tar $__pc_ifr -cf ${shellQuote(input.archivePath)} ${tarExcludeFlags(input.exclude)} -- "$@"; fi`,
   ].join(" && ");
 }
 

--- a/packages/adapter-utils/src/sandbox-managed-runtime.ts
+++ b/packages/adapter-utils/src/sandbox-managed-runtime.ts
@@ -323,7 +323,8 @@ function tarExcludeFlags(exclude: string[] | undefined): string {
   return ["._*", ...(exclude ?? [])].map((entry) => `--exclude ${shellQuote(entry)}`).join(" ");
 }
 
-function createRemoteTarballFromDirectoryCommand(input: {
+// Exported for tests (not part of the package's public index surface).
+export function createRemoteTarballFromDirectoryCommand(input: {
   remoteDir: string;
   archivePath: string;
   exclude?: string[];
@@ -342,8 +343,11 @@ function createRemoteTarballFromDirectoryCommand(input: {
     // mid-archive, hard-failing the whole restore. --ignore-failed-read makes it
     // a best-effort archive of whatever is readable. The flag is
     // GNU/busybox-only (BSD tar rejects it), so gate it on a capability probe ->
-    // portable across GNU, BSD, and busybox tars.
-    `__pc_ifr=""; case "$(tar --help 2>&1)" in *--ignore-failed-read*) __pc_ifr=--ignore-failed-read;; esac`,
+    // portable across GNU, BSD, and busybox tars. The probe is wrapped in a
+    // { ...; } group command so its internal ";" does not terminate the
+    // surrounding "&&" chain (a bare ";" would make the tar step run even when
+    // an earlier step such as `cd` failed, fabricating an empty archive).
+    `{ __pc_ifr=""; case "$(tar --help 2>&1)" in *--ignore-failed-read*) __pc_ifr=--ignore-failed-read;; esac; }`,
     `if [ "$#" -eq 0 ]; then ` +
       `dd if=/dev/zero of=${shellQuote(input.archivePath)} bs=1024 count=1; ` +
       `else tar $__pc_ifr -cf ${shellQuote(input.archivePath)} ${tarExcludeFlags(input.exclude)} -- "$@"; fi`,

--- a/packages/adapter-utils/src/sandbox-managed-runtime.ts
+++ b/packages/adapter-utils/src/sandbox-managed-runtime.ts
@@ -978,9 +978,17 @@ function createRemoteTarballFromDirectoryCommand(input: {
     "set -- *",
     `if [ "$#" -eq 1 ] && [ "$1" = "*" ] && [ ! -e "$1" ] && [ ! -L "$1" ]; then set --; fi`,
     `for entry in .[!.]* ..?*; do [ -e "$entry" ] || [ -L "$entry" ] || continue; set -- "$@" "$entry"; done`,
+    // The directory can be LIVE while we archive it (the agent's lingering
+    // processes create/delete temp files during teardown), so GNU tar otherwise
+    // exits 2 on "Cannot open: No such file" for a file that vanished
+    // mid-archive, hard-failing the whole restore. --ignore-failed-read makes it
+    // a best-effort archive of whatever is readable. The flag is
+    // GNU/busybox-only (BSD tar rejects it), so gate it on a capability probe ->
+    // portable across GNU, BSD, and busybox tars.
+    `__pc_ifr=""; case "$(tar --help 2>&1)" in *--ignore-failed-read*) __pc_ifr=--ignore-failed-read;; esac`,
     `if [ "$#" -eq 0 ]; then ` +
       `dd if=/dev/zero of=${shellQuote(input.archivePath)} bs=1024 count=1; ` +
-      `else tar -cf ${shellQuote(input.archivePath)} ${tarExcludeFlags(input.exclude)} -- "$@"; fi`,
+      `else tar $__pc_ifr -cf ${shellQuote(input.archivePath)} ${tarExcludeFlags(input.exclude)} -- "$@"; fi`,
   ].join(" && ");
 }
 

--- a/packages/adapter-utils/src/sandbox-managed-runtime.ts
+++ b/packages/adapter-utils/src/sandbox-managed-runtime.ts
@@ -965,7 +965,8 @@ function tarExcludeFlags(exclude: string[] | undefined): string {
   return ["._*", ...(exclude ?? [])].map((entry) => `--exclude ${shellQuote(entry)}`).join(" ");
 }
 
-function createRemoteTarballFromDirectoryCommand(input: {
+// Exported for tests (not part of the package's public index surface).
+export function createRemoteTarballFromDirectoryCommand(input: {
   remoteDir: string;
   archivePath: string;
   exclude?: string[];
@@ -984,8 +985,11 @@ function createRemoteTarballFromDirectoryCommand(input: {
     // mid-archive, hard-failing the whole restore. --ignore-failed-read makes it
     // a best-effort archive of whatever is readable. The flag is
     // GNU/busybox-only (BSD tar rejects it), so gate it on a capability probe ->
-    // portable across GNU, BSD, and busybox tars.
-    `__pc_ifr=""; case "$(tar --help 2>&1)" in *--ignore-failed-read*) __pc_ifr=--ignore-failed-read;; esac`,
+    // portable across GNU, BSD, and busybox tars. The probe is wrapped in a
+    // { ...; } group command so its internal ";" does not terminate the
+    // surrounding "&&" chain (a bare ";" would make the tar step run even when
+    // an earlier step such as `cd` failed, fabricating an empty archive).
+    `{ __pc_ifr=""; case "$(tar --help 2>&1)" in *--ignore-failed-read*) __pc_ifr=--ignore-failed-read;; esac; }`,
     `if [ "$#" -eq 0 ]; then ` +
       `dd if=/dev/zero of=${shellQuote(input.archivePath)} bs=1024 count=1; ` +
       `else tar $__pc_ifr -cf ${shellQuote(input.archivePath)} ${tarExcludeFlags(input.exclude)} -- "$@"; fi`,


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Sandboxed agent runs upload the workspace into the sandbox and, at teardown, `restoreWorkspace` tars the remote workspace back out (`packages/adapter-utils/src/sandbox-managed-runtime.ts`)
> - That archive is taken from a LIVE directory: the agent's lingering child processes can still be creating and deleting temp files while tar walks the tree
> - GNU tar (e.g. 1.34 in common agent images) exits 2 with "Cannot open: No such file or directory" when a file it stat'ed vanishes before it can read it, which hard-fails the whole restore and masks the run's real result
> - This pull request adds `--ignore-failed-read` to the remote restore tar so the teardown archive is best-effort over whatever is readable, gated on a runtime capability probe because the flag is not portable (BSD tar rejects it)
> - The benefit is that agent runs no longer fail spuriously at teardown because of a transient temp file, while dev/CI environments with BSD or busybox tar keep working unchanged

## Linked Issues or Issue Description

No existing issue; described in-PR following the bug report template:

**What happened?**

Sandboxed runs intermittently fail at teardown with tar exit code 2 (`Cannot open: No such file or directory`). `restoreWorkspace` archives the live remote workspace; if any process the agent started deletes a file between tar's directory scan and its read, GNU tar treats it as fatal, the restore throws, and the run is reported as failed even when the agent's work succeeded. Not adapter-specific (shared sandbox runtime in `adapter-utils`).

**Expected behavior**

Teardown should best-effort archive whatever is readable; a file that vanished mid-archive is not an error worth failing the run over. A genuinely broken teardown (e.g. the remote workspace directory is gone) must still fail loudly.

**Steps to reproduce**

Run a sandboxed agent whose process tree keeps writing/removing temp files (e.g. a dev server or watcher still running at teardown). Restore intermittently fails with tar exit 2 on a vanished file.

**Deployment mode**

Any sandboxed execution (all sandbox providers go through the shared managed runtime).

**Paperclip version**

Reproduces on current `master`.

## What Changed

- `createRemoteTarballFromDirectoryCommand` in `packages/adapter-utils/src/sandbox-managed-runtime.ts` now probes the remote tar for `--ignore-failed-read` support (`case "$(tar --help 2>&1)" in *--ignore-failed-read*)`) and applies the flag only when supported. The probe keeps the command portable across GNU (agent images), BSD (macOS dev), and busybox tars; unsupported tars behave exactly as before.
- The probe is wrapped in a `{ ...; }` group command so its internal `;` cannot terminate the surrounding `&&` chain (review finding: a bare `;` made the `case`+`tar` step run even after an earlier step such as `cd` failed, fabricating a zero-filled "empty" archive with exit 0 and masking the failure as a successful restore).
- Added regression tests in `packages/adapter-utils/src/sandbox-managed-runtime.test.ts`: a PATH-shimmed tar (GNU-like vs BSD-like `--help` output) pins that the flag is applied exactly when advertised and that the generated archive stays valid either way; a chain-propagation test pins that a failing `cd` still fails the whole command without fabricating an archive; and a real-GNU test (skipped where tar lacks the flag or when root) pins that an unreadable file no longer fails the archive.

## Verification

- `npx vitest run packages/adapter-utils/src/sandbox-managed-runtime.test.ts` — 13 passed, 1 conditionally skipped (the real-GNU unreadable-file test runs on Linux CI's GNU tar; it self-skips on macOS BSD tar / as root). These tests execute the generated shell command against a real local filesystem, so the modified command is exercised end-to-end, including the empty-workspace path.
- The chain-propagation regression test was verified to fail against the previous (ungrouped) probe line and pass with the group-command fix.
- `tsc --noEmit -p packages/adapter-utils` passes.
- Manual probe check: on macOS BSD tar the probe leaves the flag off; GNU tar's `--help` lists `--ignore-failed-read`, so the flag is applied there.

## Risks

- Low risk. Behavior changes only when the remote tar supports `--ignore-failed-read` AND a file becomes unreadable mid-archive — previously a hard failure of the whole restore, now a best-effort archive without that file. Unsupported tars take the exact previous code path. The probe is a `{ ...; }`-grouped POSIX compound command, so it preserves the `&&` chain's error semantics (pinned by a regression test).

## Model Used

Claude Fable 5 (Anthropic, `claude-fable-5`, agentic coding harness via Claude Code, extended reasoning enabled). Original fix drafted with Claude Opus 4.8 (1M context).

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
