### PR TITLE
feat(adapter-utils): classify inference and sandbox-infra run failures

### DIFF
--- a/packages/adapter-utils/src/index.ts
+++ b/packages/adapter-utils/src/index.ts
@@ -74,6 +74,25 @@ export type {
   RuntimeStatusUpdate,
 } from "./runtime-progress.js";
 export { inferOpenAiCompatibleBiller } from "./billing.js";
+export type {
+  InferenceFailureCode,
+  InferenceFailureClassification,
+  InferenceFailureRetryPolicy,
+  InferenceFailureDescription,
+  InferenceFailureInput,
+} from "./inference-failure.js";
+export {
+  classifyInferenceFailure,
+  inferenceFailureRetryPolicy,
+  inferenceFailureErrorCode,
+  describeRunFailure,
+} from "./inference-failure.js";
+export type { SandboxInfraFailureCode } from "./sandbox-infra-failure.js";
+export {
+  SANDBOX_NOT_READY_ERROR_CODE,
+  SANDBOX_UNSCHEDULABLE_ERROR_CODE,
+  classifySandboxInfraFailure,
+} from "./sandbox-infra-failure.js";
 // Keep the root adapter-utils entry browser-safe because the UI imports it.
 // The sandbox callback bridge stays available via its dedicated subpath export.
 export type {

--- a/packages/adapter-utils/src/inference-failure.test.ts
+++ b/packages/adapter-utils/src/inference-failure.test.ts
@@ -93,6 +93,39 @@ describe("classifyInferenceFailure", () => {
     expect(result?.code).toBe("UNKNOWN");
   });
 
+  it("does not treat a bare 000 without the http prefix as MODEL_UNAVAILABLE", () => {
+    const result = classifyInferenceFailure({
+      errorMessage: "model run wrote 000 tokens before failing",
+    });
+    expect(result?.code).toBe("UNKNOWN");
+  });
+
+  it("returns null for a connection failure without inference context", () => {
+    expect(
+      classifyInferenceFailure({
+        errorMessage: "upstream database connection refused",
+      }),
+    ).toBeNull();
+  });
+
+  it("classifies a provider connection failure as MODEL_UNAVAILABLE", () => {
+    const result = classifyInferenceFailure({
+      stderr: "openrouter: connection reset by peer while calling chat/completions",
+    });
+    expect(result?.code).toBe("MODEL_UNAVAILABLE");
+    expect(result?.cause).toContain("connection reset");
+  });
+
+  it("keeps only the matched marker as cause, never the surrounding output", () => {
+    const result = classifyInferenceFailure({
+      errorMessage: "invalid api key",
+      stderr: "request was sent with key sk-live-abc123-secret",
+    });
+    expect(result?.code).toBe("AUTH_INVALID");
+    expect(result?.cause).toBe("invalid api key");
+    expect(result?.cause).not.toContain("sk-live-abc123-secret");
+  });
+
   it("prefers the more specific class when several markers are present", () => {
     // A budget error often also carries a 4xx/5xx code; OUT_OF_CREDITS must win.
     const result = classifyInferenceFailure({

--- a/packages/adapter-utils/src/inference-failure.test.ts
+++ b/packages/adapter-utils/src/inference-failure.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  classifyInferenceFailure,
+  describeRunFailure,
+  inferenceFailureErrorCode,
+  inferenceFailureRetryPolicy,
+} from "./inference-failure.js";
+
+describe("classifyInferenceFailure", () => {
+  it("returns null when there is no inference-failure signal", () => {
+    expect(
+      classifyInferenceFailure({
+        errorMessage: "fatal: not a git repository",
+        exitCode: 128,
+      }),
+    ).toBeNull();
+    expect(classifyInferenceFailure({})).toBeNull();
+  });
+
+  it("classifies a Bifrost virtual key 401 as AUTH_INVALID and keeps the cause", () => {
+    const result = classifyInferenceFailure({
+      errorMessage:
+        '{"error":{"message":"virtual_key_not_found","type":"invalid_request_error","code":401}}',
+    });
+    expect(result?.code).toBe("AUTH_INVALID");
+    expect(result?.cause).toContain("virtual_key_not_found");
+  });
+
+  it("classifies a bare HTTP 401 unauthorized as AUTH_INVALID", () => {
+    const result = classifyInferenceFailure({
+      stderr: "HTTP 401: Unauthorized",
+    });
+    expect(result?.code).toBe("AUTH_INVALID");
+  });
+
+  it("classifies a gateway budget-exceeded error as OUT_OF_CREDITS", () => {
+    const result = classifyInferenceFailure({
+      errorMessage: "Budget has been exceeded! Max budget: 0.0",
+    });
+    expect(result?.code).toBe("OUT_OF_CREDITS");
+    expect(result?.cause).toContain("Budget has been exceeded");
+  });
+
+  it("classifies an out-of-credits / payment-required error as OUT_OF_CREDITS", () => {
+    expect(
+      classifyInferenceFailure({ errorMessage: "insufficient credits" })?.code,
+    ).toBe("OUT_OF_CREDITS");
+    expect(
+      classifyInferenceFailure({ stderr: "HTTP 402: Payment Required" })?.code,
+    ).toBe("OUT_OF_CREDITS");
+  });
+
+  it("classifies a 429 / rate-limit error as RATE_LIMITED", () => {
+    expect(
+      classifyInferenceFailure({ stderr: "HTTP 429: Too Many Requests" })?.code,
+    ).toBe("RATE_LIMITED");
+    expect(
+      classifyInferenceFailure({ errorMessage: "rate limit exceeded, please retry" })
+        ?.code,
+    ).toBe("RATE_LIMITED");
+  });
+
+  it("classifies a model timeout / HTTP 000 / 504 as MODEL_UNAVAILABLE", () => {
+    expect(
+      classifyInferenceFailure({ errorMessage: "upstream request timed out" })?.code,
+    ).toBe("MODEL_UNAVAILABLE");
+    expect(classifyInferenceFailure({ stderr: "curl: HTTP 000" })?.code).toBe(
+      "MODEL_UNAVAILABLE",
+    );
+    expect(
+      classifyInferenceFailure({ stderr: "HTTP 504 Gateway Timeout" })?.code,
+    ).toBe("MODEL_UNAVAILABLE");
+    expect(
+      classifyInferenceFailure({ errorMessage: "model not served by this provider" })
+        ?.code,
+    ).toBe("MODEL_UNAVAILABLE");
+  });
+
+  it("classifies a generic 5xx and OpenCode's opaque wrapper as UPSTREAM_ERROR", () => {
+    expect(
+      classifyInferenceFailure({ stderr: "HTTP 503 Service Unavailable" })?.code,
+    ).toBe("UPSTREAM_ERROR");
+    expect(
+      classifyInferenceFailure({ errorMessage: "Unexpected server error" })?.code,
+    ).toBe("UPSTREAM_ERROR");
+  });
+
+  it("classifies an inference-context failure with no specific marker as UNKNOWN", () => {
+    const result = classifyInferenceFailure({
+      errorMessage: "the language model provider returned an unparsable response",
+    });
+    expect(result?.code).toBe("UNKNOWN");
+  });
+
+  it("prefers the more specific class when several markers are present", () => {
+    // A budget error often also carries a 4xx/5xx code; OUT_OF_CREDITS must win.
+    const result = classifyInferenceFailure({
+      errorMessage: "HTTP 400: Budget has been exceeded! Max budget: 0.0",
+    });
+    expect(result?.code).toBe("OUT_OF_CREDITS");
+  });
+});
+
+describe("inferenceFailureRetryPolicy", () => {
+  it("fails fast (no retry) on permanent classes", () => {
+    expect(inferenceFailureRetryPolicy("AUTH_INVALID").retry).toBe(false);
+    expect(inferenceFailureRetryPolicy("AUTH_INVALID").family).toBeNull();
+    expect(inferenceFailureRetryPolicy("OUT_OF_CREDITS").retry).toBe(false);
+    expect(inferenceFailureRetryPolicy("OUT_OF_CREDITS").family).toBeNull();
+    expect(inferenceFailureRetryPolicy("UNKNOWN").retry).toBe(false);
+  });
+
+  it("retries transient classes via the transient_upstream family", () => {
+    for (const code of ["RATE_LIMITED", "UPSTREAM_ERROR"] as const) {
+      const policy = inferenceFailureRetryPolicy(code);
+      expect(policy.retry).toBe(true);
+      expect(policy.family).toBe("transient_upstream");
+      expect(policy.maxAttempts).toBeGreaterThan(0);
+    }
+  });
+
+  it("allows only a small bounded retry for MODEL_UNAVAILABLE", () => {
+    const policy = inferenceFailureRetryPolicy("MODEL_UNAVAILABLE");
+    expect(policy.retry).toBe(true);
+    expect(policy.family).toBe("transient_upstream");
+    expect(policy.maxAttempts).toBeLessThanOrEqual(2);
+    expect(policy.maxAttempts).toBeGreaterThan(0);
+  });
+
+  it("never lets a permanent failure burn more attempts than a transient one", () => {
+    expect(inferenceFailureRetryPolicy("AUTH_INVALID").maxAttempts).toBe(0);
+    expect(inferenceFailureRetryPolicy("OUT_OF_CREDITS").maxAttempts).toBe(0);
+  });
+});
+
+describe("inferenceFailureErrorCode", () => {
+  it("maps each class to a stable snake_case run errorCode", () => {
+    expect(inferenceFailureErrorCode("AUTH_INVALID")).toBe("inference_auth_invalid");
+    expect(inferenceFailureErrorCode("OUT_OF_CREDITS")).toBe(
+      "inference_out_of_credits",
+    );
+    expect(inferenceFailureErrorCode("MODEL_UNAVAILABLE")).toBe(
+      "inference_model_unavailable",
+    );
+    expect(inferenceFailureErrorCode("RATE_LIMITED")).toBe("inference_rate_limited");
+    expect(inferenceFailureErrorCode("UPSTREAM_ERROR")).toBe(
+      "inference_upstream_error",
+    );
+    expect(inferenceFailureErrorCode("UNKNOWN")).toBe("inference_unknown");
+  });
+});
+
+describe("describeRunFailure", () => {
+  it("returns null for non-inference / unknown error codes", () => {
+    expect(describeRunFailure(null)).toBeNull();
+    expect(describeRunFailure(undefined)).toBeNull();
+    expect(describeRunFailure("process_lost")).toBeNull();
+    expect(describeRunFailure("adapter_failed")).toBeNull();
+  });
+
+  it("describes OUT_OF_CREDITS with a plain, actionable message", () => {
+    const desc = describeRunFailure("inference_out_of_credits");
+    expect(desc).not.toBeNull();
+    expect(desc?.message.toLowerCase()).toContain("credits");
+    expect(desc?.action.toLowerCase()).toContain("add credits");
+    expect(desc?.internal).toBe(false);
+  });
+
+  it("describes MODEL_UNAVAILABLE as a temporary, self-healing state", () => {
+    const desc = describeRunFailure("inference_model_unavailable");
+    expect(desc?.message.toLowerCase()).toContain("temporarily unavailable");
+    expect(desc?.internal).toBe(false);
+  });
+
+  it("hides raw upstream detail for AUTH_INVALID", () => {
+    const desc = describeRunFailure("inference_auth_invalid");
+    expect(desc?.internal).toBe(true);
+    expect(desc?.message.toLowerCase()).toContain("credentials");
+  });
+
+  it("accepts the InferenceFailureCode enum directly", () => {
+    expect(describeRunFailure("OUT_OF_CREDITS")?.action.toLowerCase()).toContain(
+      "add credits",
+    );
+  });
+
+  it("never uses em or en dashes in user-facing copy", () => {
+    for (const code of [
+      "inference_auth_invalid",
+      "inference_out_of_credits",
+      "inference_model_unavailable",
+      "inference_rate_limited",
+      "inference_upstream_error",
+      "inference_unknown",
+    ]) {
+      const desc = describeRunFailure(code);
+      expect(desc).not.toBeNull();
+      expect(desc?.message).not.toMatch(/[–—]/);
+      expect(desc?.action).not.toMatch(/[–—]/);
+    }
+  });
+});

--- a/packages/adapter-utils/src/inference-failure.ts
+++ b/packages/adapter-utils/src/inference-failure.ts
@@ -28,8 +28,10 @@ export type InferenceFailureCode =
 export interface InferenceFailureClassification {
   code: InferenceFailureCode;
   /**
-   * The concrete upstream cause text we matched on, retained verbatim for
-   * support and telemetry. This is what used to be thrown away.
+   * The concrete upstream marker text we matched on, retained for support and
+   * telemetry. Only the matched excerpt is kept, never the full
+   * errorMessage/stdout/stderr, so credential material in surrounding output
+   * (relevant for AUTH_INVALID) is not carried into telemetry.
    */
   cause: string;
 }
@@ -83,7 +85,7 @@ const CLASS_BY_ERROR_CODE: Record<string, InferenceFailureCode> = Object.fromEnt
 // Does the text look like an inference/model failure at all? Gates the whole
 // classifier so unrelated failures (git, workspace, filesystem) stay untouched.
 const INFERENCE_CONTEXT_RE =
-  /(?:virtual_key_not_found|budget\s+has\s+been\s+exceeded|max\s+budget|out\s+of\s+(?:inference\s+)?credits|insufficient\s+(?:credits|balance|funds)|payment\s+required|\b40[123]\b|\b429\b|\b5\d{2}\b|\bhttp\s*000\b|rate[-\s]?limit|too\s+many\s+requests|throttl|unauthorized|invalid[\s_]+api[\s_]?key|authentication[\s_]error|unexpected\s+server\s+error|service\s+unavailable|gateway\s+timeout|timed?\s*out|no\s+healthy\s+upstream|model\b|completion|chat\/completions|provider|upstream|bifrost|litellm|openrouter)/i;
+  /(?:virtual_key_not_found|budget\s+has\s+been\s+exceeded|max\s+budget|out\s+of\s+(?:inference\s+)?credits|insufficient\s+(?:credits|balance|funds)|payment\s+required|\b40[123]\b|\b429\b|\b5\d{2}\b|\bhttp\s*000\b|rate[-\s]?limit|too\s+many\s+requests|throttl|unauthorized|invalid[\s_]+api[\s_]?key|authentication[\s_]error|unexpected\s+server\s+error|service\s+unavailable|gateway\s+timeout|timed?\s*out|no\s+healthy\s+upstream|model\b|completion|chat\/completions|provider|upstream\s+error|bifrost|litellm|openrouter)/i;
 
 // Order matters: the most specific / most permanent classes are tested first so
 // a budget error that also carries a 4xx code resolves to OUT_OF_CREDITS.
@@ -94,7 +96,15 @@ const AUTH_INVALID_RE =
 const RATE_LIMITED_RE =
   /(?:\b429\b|rate[-\s]?limit(?:ed)?|rate_limit_error|too\s+many\s+requests|throttl(?:ed|ing)?)/i;
 const MODEL_UNAVAILABLE_RE =
-  /(?:\bhttp\s*000\b|\b000\b|\b504\b|gateway\s+timeout|timed?\s*out|connection\s+(?:refused|reset)|econnrefused|econnreset|no\s+healthy\s+upstream|model\s+(?:is\s+)?(?:temporarily\s+)?(?:unavailable|not\s+(?:found|served|available)|cold|overloaded)|(?:not\s+served|no\s+provider)\s+for\s+model)/i;
+  /(?:\bhttp\s*000\b|\b504\b|gateway\s+timeout|timed?\s*out|no\s+healthy\s+upstream|model\s+(?:is\s+)?(?:temporarily\s+)?(?:unavailable|not\s+(?:found|served|available)|cold|overloaded)|(?:not\s+served|no\s+provider)\s+for\s+model)/i;
+// Connection-level failures ("connection refused", ECONNRESET) are only an
+// unavailable model when the text also names an inference-shaped component;
+// on their own they are just as likely a database or webhook failure, so they
+// must not flip to a retryable MODEL_UNAVAILABLE without that context.
+const MODEL_CONNECTION_FAILURE_RE =
+  /(?:connection\s+(?:refused|reset)|econnrefused|econnreset)/i;
+const MODEL_CONNECTION_CONTEXT_RE =
+  /(?:model\b|provider|inference|completion|chat\/completions|bifrost|litellm|openrouter)/i;
 const UPSTREAM_ERROR_RE =
   /(?:\b50[023]\b|\b5\d{2}\b|internal\s+server\s+error|bad\s+gateway|service\s+unavailable|upstream\s+error|unexpected\s+server\s+error)/i;
 
@@ -117,15 +127,25 @@ export function classifyInferenceFailure(
   input: InferenceFailureInput,
 ): InferenceFailureClassification | null {
   const haystack = buildHaystack(input);
-  if (!haystack || !INFERENCE_CONTEXT_RE.test(haystack)) return null;
+  if (!haystack) return null;
+  const contextMatch = INFERENCE_CONTEXT_RE.exec(haystack);
+  if (!contextMatch) return null;
 
-  const cause = haystack;
-  if (OUT_OF_CREDITS_RE.test(haystack)) return { code: "OUT_OF_CREDITS", cause };
-  if (AUTH_INVALID_RE.test(haystack)) return { code: "AUTH_INVALID", cause };
-  if (RATE_LIMITED_RE.test(haystack)) return { code: "RATE_LIMITED", cause };
-  if (MODEL_UNAVAILABLE_RE.test(haystack)) return { code: "MODEL_UNAVAILABLE", cause };
-  if (UPSTREAM_ERROR_RE.test(haystack)) return { code: "UPSTREAM_ERROR", cause };
-  return { code: "UNKNOWN", cause };
+  const creditsMatch = OUT_OF_CREDITS_RE.exec(haystack);
+  if (creditsMatch) return { code: "OUT_OF_CREDITS", cause: creditsMatch[0] };
+  const authMatch = AUTH_INVALID_RE.exec(haystack);
+  if (authMatch) return { code: "AUTH_INVALID", cause: authMatch[0] };
+  const rateMatch = RATE_LIMITED_RE.exec(haystack);
+  if (rateMatch) return { code: "RATE_LIMITED", cause: rateMatch[0] };
+  const modelMatch = MODEL_UNAVAILABLE_RE.exec(haystack);
+  if (modelMatch) return { code: "MODEL_UNAVAILABLE", cause: modelMatch[0] };
+  const connectionMatch = MODEL_CONNECTION_FAILURE_RE.exec(haystack);
+  if (connectionMatch && MODEL_CONNECTION_CONTEXT_RE.test(haystack)) {
+    return { code: "MODEL_UNAVAILABLE", cause: connectionMatch[0] };
+  }
+  const upstreamMatch = UPSTREAM_ERROR_RE.exec(haystack);
+  if (upstreamMatch) return { code: "UPSTREAM_ERROR", cause: upstreamMatch[0] };
+  return { code: "UNKNOWN", cause: contextMatch[0] };
 }
 
 const RETRY_POLICY_BY_CLASS: Record<InferenceFailureCode, InferenceFailureRetryPolicy> = {

--- a/packages/adapter-utils/src/inference-failure.ts
+++ b/packages/adapter-utils/src/inference-failure.ts
@@ -1,0 +1,210 @@
+// ---------------------------------------------------------------------------
+// Inference-failure classification
+//
+// When an agent run's completion call fails at the inference provider, the
+// distinct causes (an invalid-key 401, an exhausted budget, a cold/unavailable
+// model, a 429, a generic 5xx) all collapse into one opaque "adapter failed"
+// outcome: the run is retried blindly, the raw error is shown, and the real
+// cause is lost. This module classifies the upstream/adapter failure into a
+// small, stable enum so retry behaviour can be correct and the user-facing
+// message can be plain and actionable.
+//
+// It is intentionally provider-shaped (OpenAI-compatible error payloads,
+// including gateways such as Bifrost, LiteLLM, or OpenRouter) and side-effect
+// free so adapters, the run scheduler, and the UI can all share one source of
+// truth.
+// ---------------------------------------------------------------------------
+
+import type { AdapterExecutionErrorFamily } from "./types.js";
+
+export type InferenceFailureCode =
+  | "AUTH_INVALID"
+  | "OUT_OF_CREDITS"
+  | "MODEL_UNAVAILABLE"
+  | "RATE_LIMITED"
+  | "UPSTREAM_ERROR"
+  | "UNKNOWN";
+
+export interface InferenceFailureClassification {
+  code: InferenceFailureCode;
+  /**
+   * The concrete upstream cause text we matched on, retained verbatim for
+   * support and telemetry. This is what used to be thrown away.
+   */
+  cause: string;
+}
+
+export interface InferenceFailureRetryPolicy {
+  /** Whether this class should be retried at all. */
+  retry: boolean;
+  /** Explicit, bounded attempt cap so a permanent failure cannot burn time. */
+  maxAttempts: number;
+  /**
+   * The recovery family the run scheduler keys retries off. Only transient
+   * classes carry "transient_upstream"; permanent classes carry null so the run
+   * fails fast.
+   */
+  family: AdapterExecutionErrorFamily | null;
+}
+
+export interface InferenceFailureDescription {
+  /** Short, plain message shown to the user (house style, no em/en dashes). */
+  message: string;
+  /** The single suggested next action. */
+  action: string;
+  /**
+   * True when the raw upstream detail must not be surfaced as the primary
+   * message (e.g. auth errors, which are an operator-side configuration
+   * problem and may reference key material).
+   */
+  internal: boolean;
+}
+
+export interface InferenceFailureInput {
+  errorMessage?: string | null;
+  stdout?: string | null;
+  stderr?: string | null;
+  exitCode?: number | null;
+}
+
+const ERROR_CODE_BY_CLASS: Record<InferenceFailureCode, string> = {
+  AUTH_INVALID: "inference_auth_invalid",
+  OUT_OF_CREDITS: "inference_out_of_credits",
+  MODEL_UNAVAILABLE: "inference_model_unavailable",
+  RATE_LIMITED: "inference_rate_limited",
+  UPSTREAM_ERROR: "inference_upstream_error",
+  UNKNOWN: "inference_unknown",
+};
+
+const CLASS_BY_ERROR_CODE: Record<string, InferenceFailureCode> = Object.fromEntries(
+  Object.entries(ERROR_CODE_BY_CLASS).map(([code, errorCode]) => [errorCode, code as InferenceFailureCode]),
+) as Record<string, InferenceFailureCode>;
+
+// Does the text look like an inference/model failure at all? Gates the whole
+// classifier so unrelated failures (git, workspace, filesystem) stay untouched.
+const INFERENCE_CONTEXT_RE =
+  /(?:virtual_key_not_found|budget\s+has\s+been\s+exceeded|max\s+budget|out\s+of\s+(?:inference\s+)?credits|insufficient\s+(?:credits|balance|funds)|payment\s+required|\b40[123]\b|\b429\b|\b5\d{2}\b|\bhttp\s*000\b|rate[-\s]?limit|too\s+many\s+requests|throttl|unauthorized|invalid[\s_]+api[\s_]?key|authentication[\s_]error|unexpected\s+server\s+error|service\s+unavailable|gateway\s+timeout|timed?\s*out|no\s+healthy\s+upstream|model\b|completion|chat\/completions|provider|upstream|bifrost|litellm|openrouter)/i;
+
+// Order matters: the most specific / most permanent classes are tested first so
+// a budget error that also carries a 4xx code resolves to OUT_OF_CREDITS.
+const OUT_OF_CREDITS_RE =
+  /(?:budget\s+has\s+been\s+exceeded|max\s+budget|out\s+of\s+(?:inference\s+)?credits|insufficient\s+(?:credits|balance|funds)|payment\s+required|\b402\b|exceeded\s+your\s+(?:monthly\s+)?(?:credit|spend|budget))/i;
+const AUTH_INVALID_RE =
+  /(?:virtual_key_not_found|invalid[\s_]+api[\s_]?key|invalid_request_error[\s\S]*?\b401\b|authentication[\s_]error|unauthorized|\b401\b|\b403\b|forbidden|api\s+key\s+(?:is\s+)?(?:invalid|not\s+found|missing))/i;
+const RATE_LIMITED_RE =
+  /(?:\b429\b|rate[-\s]?limit(?:ed)?|rate_limit_error|too\s+many\s+requests|throttl(?:ed|ing)?)/i;
+const MODEL_UNAVAILABLE_RE =
+  /(?:\bhttp\s*000\b|\b000\b|\b504\b|gateway\s+timeout|timed?\s*out|connection\s+(?:refused|reset)|econnrefused|econnreset|no\s+healthy\s+upstream|model\s+(?:is\s+)?(?:temporarily\s+)?(?:unavailable|not\s+(?:found|served|available)|cold|overloaded)|(?:not\s+served|no\s+provider)\s+for\s+model)/i;
+const UPSTREAM_ERROR_RE =
+  /(?:\b50[023]\b|\b5\d{2}\b|internal\s+server\s+error|bad\s+gateway|service\s+unavailable|upstream\s+error|unexpected\s+server\s+error)/i;
+
+function buildHaystack(input: InferenceFailureInput): string {
+  return [input.errorMessage, input.stderr, input.stdout]
+    .map((part) => (typeof part === "string" ? part : ""))
+    .filter((part) => part.trim().length > 0)
+    .join("\n")
+    .trim();
+}
+
+/**
+ * Classify an upstream/adapter inference failure into a stable enum.
+ *
+ * Returns null when the text shows no recognizable inference-failure signal, so
+ * callers only override genuine inference failures and leave other failures
+ * (git, workspace, etc.) classified as before.
+ */
+export function classifyInferenceFailure(
+  input: InferenceFailureInput,
+): InferenceFailureClassification | null {
+  const haystack = buildHaystack(input);
+  if (!haystack || !INFERENCE_CONTEXT_RE.test(haystack)) return null;
+
+  const cause = haystack;
+  if (OUT_OF_CREDITS_RE.test(haystack)) return { code: "OUT_OF_CREDITS", cause };
+  if (AUTH_INVALID_RE.test(haystack)) return { code: "AUTH_INVALID", cause };
+  if (RATE_LIMITED_RE.test(haystack)) return { code: "RATE_LIMITED", cause };
+  if (MODEL_UNAVAILABLE_RE.test(haystack)) return { code: "MODEL_UNAVAILABLE", cause };
+  if (UPSTREAM_ERROR_RE.test(haystack)) return { code: "UPSTREAM_ERROR", cause };
+  return { code: "UNKNOWN", cause };
+}
+
+const RETRY_POLICY_BY_CLASS: Record<InferenceFailureCode, InferenceFailureRetryPolicy> = {
+  // Permanent for this run: a bad key or an empty budget will not fix itself.
+  AUTH_INVALID: { retry: false, maxAttempts: 0, family: null },
+  OUT_OF_CREDITS: { retry: false, maxAttempts: 0, family: null },
+  // Transient: a cold/unavailable model usually recovers, but cap it tight so a
+  // genuinely dead model does not hang.
+  MODEL_UNAVAILABLE: { retry: true, maxAttempts: 2, family: "transient_upstream" },
+  // Transient: backoff is exactly the right response.
+  RATE_LIMITED: { retry: true, maxAttempts: 3, family: "transient_upstream" },
+  UPSTREAM_ERROR: { retry: true, maxAttempts: 3, family: "transient_upstream" },
+  // Ambiguous: fail fast rather than burn time on a cause we cannot confirm
+  // is transient.
+  UNKNOWN: { retry: false, maxAttempts: 0, family: null },
+};
+
+export function inferenceFailureRetryPolicy(
+  code: InferenceFailureCode,
+): InferenceFailureRetryPolicy {
+  return RETRY_POLICY_BY_CLASS[code];
+}
+
+/** The stable snake_case run errorCode persisted for a classified failure. */
+export function inferenceFailureErrorCode(code: InferenceFailureCode): string {
+  return ERROR_CODE_BY_CLASS[code];
+}
+
+function normalizeToClass(
+  value: string | null | undefined,
+): InferenceFailureCode | null {
+  if (!value) return null;
+  const trimmed = value.trim();
+  if (trimmed in ERROR_CODE_BY_CLASS) return trimmed as InferenceFailureCode;
+  return CLASS_BY_ERROR_CODE[trimmed] ?? null;
+}
+
+const DESCRIPTION_BY_CLASS: Record<InferenceFailureCode, InferenceFailureDescription> = {
+  AUTH_INVALID: {
+    message: "The inference provider rejected the configured credentials.",
+    action: "Check the inference key configured for this agent.",
+    internal: true,
+  },
+  OUT_OF_CREDITS: {
+    message: "The inference account is out of credits.",
+    action: "Add credits to the inference provider account to continue.",
+    internal: false,
+  },
+  MODEL_UNAVAILABLE: {
+    message: "The model is temporarily unavailable.",
+    action: "This run will retry shortly. No action needed.",
+    internal: false,
+  },
+  RATE_LIMITED: {
+    message: "The inference service is busy right now.",
+    action: "This run will retry shortly. No action needed.",
+    internal: false,
+  },
+  UPSTREAM_ERROR: {
+    message: "The inference service hit a temporary error.",
+    action: "This run will retry shortly. No action needed.",
+    internal: false,
+  },
+  UNKNOWN: {
+    message: "This run could not complete because of an inference error.",
+    action: "Try again. If it keeps happening, contact support.",
+    internal: false,
+  },
+};
+
+/**
+ * Map a persisted run errorCode (or an InferenceFailureCode) to a short, plain,
+ * user-facing message and suggested action. Returns null for any code that is
+ * not an inference-failure code, so callers can fall back to existing display.
+ */
+export function describeRunFailure(
+  errorCodeOrClass: string | null | undefined,
+): InferenceFailureDescription | null {
+  const code = normalizeToClass(errorCodeOrClass);
+  if (!code) return null;
+  return DESCRIPTION_BY_CLASS[code];
+}

--- a/packages/adapter-utils/src/sandbox-infra-failure.test.ts
+++ b/packages/adapter-utils/src/sandbox-infra-failure.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import {
+  SANDBOX_NOT_READY_ERROR_CODE,
+  SANDBOX_UNSCHEDULABLE_ERROR_CODE,
+  classifySandboxInfraFailure,
+} from "./sandbox-infra-failure.js";
+
+describe("classifySandboxInfraFailure", () => {
+  it("classifies the kubernetes plugin's unschedulable message as sandbox_unschedulable", () => {
+    expect(
+      classifySandboxInfraFailure(
+        "Sandbox pod could not be scheduled: cluster has no capacity for it. This is an infrastructure issue, not a problem with your task.",
+      ),
+    ).toBe(SANDBOX_UNSCHEDULABLE_ERROR_CODE);
+  });
+
+  it("classifies the message when it is embedded in a prep-exec failure wrapper", () => {
+    expect(
+      classifySandboxInfraFailure(
+        "command -v 'opencode' >/dev/null 2>&1 failed with exit code 1: Sandbox pod could not be scheduled: cluster has no capacity for it.",
+      ),
+    ).toBe(SANDBOX_UNSCHEDULABLE_ERROR_CODE);
+  });
+
+  it("classifies the plugin's readiness-timeout message as sandbox_not_ready", () => {
+    expect(
+      classifySandboxInfraFailure("Sandbox pod did not become Ready within 300000ms"),
+    ).toBe(SANDBOX_NOT_READY_ERROR_CODE);
+  });
+
+  it("classifies the orchestrator's raw timeout message as sandbox_not_ready", () => {
+    expect(
+      classifySandboxInfraFailure(
+        "Sandbox paperclip-acme/pc-abc did not reach Ready phase within 300000ms",
+      ),
+    ).toBe(SANDBOX_NOT_READY_ERROR_CODE);
+  });
+
+  it("prefers the unschedulable class when both markers appear", () => {
+    expect(
+      classifySandboxInfraFailure(
+        "Sandbox pod did not become Ready within 300000ms; Sandbox pod could not be scheduled: cluster has no capacity for it.",
+      ),
+    ).toBe(SANDBOX_UNSCHEDULABLE_ERROR_CODE);
+  });
+
+  it("returns null for unrelated failures", () => {
+    expect(classifySandboxInfraFailure("OpenCode exited with code 1")).toBeNull();
+    expect(classifySandboxInfraFailure("fatal: repository not found")).toBeNull();
+    expect(classifySandboxInfraFailure("")).toBeNull();
+    expect(classifySandboxInfraFailure(null)).toBeNull();
+    expect(classifySandboxInfraFailure(undefined)).toBeNull();
+  });
+});

--- a/packages/adapter-utils/src/sandbox-infra-failure.ts
+++ b/packages/adapter-utils/src/sandbox-infra-failure.ts
@@ -1,0 +1,59 @@
+// ---------------------------------------------------------------------------
+// Sandbox infrastructure failure classification
+//
+// When the sandbox provider cannot bring a pod up at all (the cluster has no
+// capacity for it, or the pod never reports Ready), the failure surfaces to
+// the run as an opaque exec failure and is recorded as a generic
+// "adapter_failed". That mis-drives recovery: a capacity stall does not
+// resolve on the short generic backoff, so retries burn full timeout windows
+// back to back.
+//
+// Sandbox providers emit stable marker phrases for these conditions. The
+// kubernetes sandbox provider plugin emits the readiness-timeout markers
+// today (see packages/plugins/sandbox-providers/kubernetes plugin.ts /
+// sandbox-cr-orchestrator.ts; keep the regexes below in sync with those
+// messages), and the unschedulable marker is the stable phrase for a
+// capacity stall. This module recognizes them wherever the text lands (an
+// adapter result's errorMessage, a thrown prep-exec error message) and maps
+// them to distinct, stable run error codes so recovery can apply a
+// capacity-appropriate backoff and the user sees an honest infrastructure
+// error. Mirrors the classifyInferenceFailure pattern in this package.
+// ---------------------------------------------------------------------------
+
+/** The sandbox pod cannot be placed on any node (cluster out of capacity). */
+export const SANDBOX_UNSCHEDULABLE_ERROR_CODE = "sandbox_unschedulable";
+
+/** The sandbox pod was scheduled but never reported Ready in time. */
+export const SANDBOX_NOT_READY_ERROR_CODE = "sandbox_not_ready";
+
+export type SandboxInfraFailureCode =
+  | typeof SANDBOX_UNSCHEDULABLE_ERROR_CODE
+  | typeof SANDBOX_NOT_READY_ERROR_CODE;
+
+// Marker emitted by the kubernetes plugin when the readiness wait detects a
+// persistently Unschedulable pod.
+const SANDBOX_UNSCHEDULABLE_RE = /sandbox pod could not be scheduled/i;
+
+// Markers emitted when the readiness wait times out: the plugin's graceful
+// exec result ("Sandbox pod did not become Ready within Xms") and the
+// orchestrator's SandboxCrTimeoutError ("did not reach Ready phase within").
+const SANDBOX_NOT_READY_RE =
+  /sandbox pod did not become ready within|did not reach ready phase within/i;
+
+/**
+ * Classify a failure message as a sandbox infrastructure failure.
+ *
+ * Returns null when the text carries no sandbox-infra marker so callers only
+ * override genuine capacity/readiness failures and leave every other failure
+ * classified as before.
+ */
+export function classifySandboxInfraFailure(
+  text: string | null | undefined,
+): SandboxInfraFailureCode | null {
+  if (typeof text !== "string" || text.trim().length === 0) return null;
+  // Unschedulable is the more specific diagnosis: a pod that cannot be
+  // scheduled also never becomes Ready, so test it first.
+  if (SANDBOX_UNSCHEDULABLE_RE.test(text)) return SANDBOX_UNSCHEDULABLE_ERROR_CODE;
+  if (SANDBOX_NOT_READY_RE.test(text)) return SANDBOX_NOT_READY_ERROR_CODE;
+  return null;
+}


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Agent runs execute through adapters; when a run fails, the server's recovery logic decides whether and how to retry
> - Today very different failure causes (an invalid inference key, an exhausted provider budget, a 429, a cold model, a sandbox pod that never came up) all collapse into one opaque `adapter_failed`, so the raw error is shown to the user and every failure gets the same blind retry treatment
> - That mis-drives recovery: permanent failures (bad key, no credits) are retried forever and burn full timeout windows, while transient ones get no category-appropriate backoff, and call sites resort to ad-hoc string matching
> - This pull request adds two small, side-effect-free classifiers to `@paperclipai/adapter-utils`: one for inference-provider failures (stable enum + per-class retry policy + stable run errorCode + plain user-facing copy) and one for sandbox infrastructure failures (unschedulable pod, pod never Ready)
> - The benefit is one shared source of truth that adapters, the run scheduler, recovery, and the UI can all key off, so retries become category-correct and users see honest, actionable error messages instead of raw provider payloads

## Linked Issues or Issue Description

- Refs #7535 (terminal-run recovery retries permanently-failing configs forever, no backoff/give-up — these classifiers give recovery the category signal to fail fast on permanent causes)
- Refs #8222 (failures read as generic `adapter_failed` because upstream detail is discarded — the classification retains the matched cause verbatim)
- Refs #7891 (provider failure retries with no provider-down awareness — the transient/permanent split is the needed foundation)

## What Changed

- New `packages/adapter-utils/src/inference-failure.ts`:
  - `classifyInferenceFailure(input)` classifies OpenAI-compatible provider/gateway error text (errorMessage/stdout/stderr) into a stable enum: `AUTH_INVALID`, `OUT_OF_CREDITS`, `MODEL_UNAVAILABLE`, `RATE_LIMITED`, `UPSTREAM_ERROR`, `UNKNOWN`. Returns `null` when the text carries no inference-failure signal, so unrelated failures (git, workspace, filesystem) stay untouched. The matched cause text is retained verbatim for support/telemetry.
  - `inferenceFailureRetryPolicy(code)` gives each class an explicit retry decision (permanent classes fail fast with `maxAttempts: 0`; transient classes carry the existing `transient_upstream` error family with a bounded attempt cap).
  - `inferenceFailureErrorCode(code)` maps each class to a stable snake_case run errorCode (`inference_auth_invalid`, `inference_out_of_credits`, ...).
  - `describeRunFailure(errorCode)` maps a persisted errorCode (or the enum directly) to short, plain user-facing message + action copy; `internal: true` marks classes whose raw upstream detail must not be surfaced (auth errors can reference key material).
- New `packages/adapter-utils/src/sandbox-infra-failure.ts`:
  - `classifySandboxInfraFailure(text)` recognizes sandbox capacity/readiness marker phrases wherever they land (adapter result errorMessage, thrown prep-exec error) and maps them to `sandbox_unschedulable` / `sandbox_not_ready`. The kubernetes sandbox-provider plugin already emits the readiness-timeout markers (`plugin.ts`, `sandbox-cr-orchestrator.ts`); the unschedulable marker is the stable phrase for a capacity stall.
- Unit tests for both modules (27 tests) covering real provider payload shapes (gateway virtual-key 401, budget-exceeded, 402/429/5xx, HTTP 000/504 timeouts), precedence when multiple markers appear, retry-policy invariants, and errorCode/description mapping.
- Exported both modules from the package root `index.ts` (types + functions; browser-safe, no new imports).

This PR is deliberately foundation-first: it ships the classifiers standalone with no behavior change. Wiring the server-side call sites (run recovery, scheduler retry, UI error display) is a small follow-up PR, along with the kubernetes plugin emitting the unschedulable marker on scheduling stalls.

## Verification

- `npx vitest run --project "@paperclipai/adapter-utils" packages/adapter-utils/src/inference-failure.test.ts packages/adapter-utils/src/sandbox-infra-failure.test.ts` — 2 files, 27 tests, all pass.
- `npx tsc --noEmit -p packages/adapter-utils` — clean.
- No runtime behavior changes: nothing imports the new modules yet.

## Risks

- Low risk: additive, side-effect free, no existing code paths import the new modules.
- The classifiers are regex-based over error text; a mis-match would only matter once call sites adopt them (follow-up PR), and both return `null` for unrecognized text so callers fall back to existing behavior.
- The sandbox-infra regexes must stay in sync with the kubernetes plugin's marker phrases; this is called out in a comment at the regex definitions.

## Model Used

- Claude (Anthropic), Fable 5 (`claude-fable-5`), via Claude Code with tool use (agentic editing, local test execution).

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
