### PR TITLE
fix(execution): honor realized workspace cwd on remote leases + tolerate benign tar exit 1

### DIFF
--- a/packages/adapter-utils/src/sandbox-managed-runtime.test.ts
+++ b/packages/adapter-utils/src/sandbox-managed-runtime.test.ts
@@ -1,4 +1,4 @@
-import { lstat, mkdir, mkdtemp, readFile, readdir, rm, symlink, writeFile } from "node:fs/promises";
+import { chmod, lstat, mkdir, mkdtemp, readFile, readdir, rm, symlink, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { execFile as execFileCallback } from "node:child_process";
@@ -594,6 +594,81 @@ describe("sandbox managed runtime", () => {
     const downloadMembers = await listTarMembers(rootDir, "workspace-download-list.tar", downloadedTars[0]!.bytes);
     expect(downloadMembers).not.toContain(".");
     expect(downloadMembers).not.toContain("./");
+  });
+
+  it("tolerates a tar exit code 1 (benign 'file changed as we read it') when restoring the workspace", async () => {
+    // GNU/busybox tar returns exit code 1 for benign warnings — most commonly
+    // "file changed as we read it" when archiving a live workspace whose files
+    // mutate during the `tar -c`. That is guaranteed for an active agent run and
+    // must NOT abort the run; only exit code 2 (a real archive error) is fatal.
+    const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-sandbox-tarexit1-"));
+    cleanupDirs.push(rootDir);
+    const localWorkspaceDir = path.join(rootDir, "local-workspace");
+    const remoteWorkspaceDir = path.join(rootDir, "remote-workspace");
+    const fakeBinDir = path.join(rootDir, "fakebin");
+    await mkdir(localWorkspaceDir, { recursive: true });
+    await mkdir(fakeBinDir, { recursive: true });
+    await writeFile(path.join(localWorkspaceDir, "README.md"), "ws\n", "utf8");
+
+    // A `tar` shim that does the real work via the system tar, then exits 1 to
+    // simulate the benign warning. Used only for the remote (client.run) tar
+    // invocations; the local helper tars still use the real system tar.
+    const realTar = (await execFile("sh", ["-c", "command -v tar"]))
+      .stdout.trim();
+    const tarShimPath = path.join(fakeBinDir, "tar");
+    await writeFile(
+      tarShimPath,
+      `#!/bin/sh\n${realTar} "$@"\nstatus=$?\nif [ "$status" -eq 0 ]; then exit 1; fi\nexit "$status"\n`,
+      "utf8",
+    );
+    await chmod(tarShimPath, 0o755);
+
+    const client: SandboxManagedRuntimeClient = {
+      makeDir: async (remotePath) => {
+        await mkdir(remotePath, { recursive: true });
+      },
+      writeFile: async (remotePath, bytes) => {
+        await mkdir(path.dirname(remotePath), { recursive: true });
+        await writeFile(remotePath, Buffer.from(bytes));
+      },
+      readFile: async (remotePath) => await readFile(remotePath),
+      listFiles: async () => [],
+      remove: async (remotePath) => {
+        await rm(remotePath, { recursive: true, force: true });
+      },
+      // Mirror command-managed-runtime semantics: throw on any non-zero exit so
+      // the test exercises the real fatality contract. With the tar shim on PATH
+      // (so the scripts' bare `tar` resolves to it) the restore script must still
+      // exit 0 — proving the tar exit-1 tolerance is baked into the script.
+      run: async (command) => {
+        await execFile("sh", ["-c", command], {
+          maxBuffer: 32 * 1024 * 1024,
+          env: { ...process.env, PATH: `${fakeBinDir}:${process.env.PATH ?? ""}` },
+        }).catch((err: NodeJS.ErrnoException & { code?: number }) => {
+          throw new Error(`run failed with exit code ${err.code ?? "null"}`);
+        });
+      },
+    };
+
+    const prepared = await prepareSandboxManagedRuntime({
+      spec: {
+        transport: "sandbox",
+        provider: "test",
+        sandboxId: "sandbox-1",
+        remoteCwd: remoteWorkspaceDir,
+        timeoutMs: 30_000,
+        apiKey: null,
+      },
+      adapterKey: "test-adapter",
+      client,
+      workspaceLocalDir: localWorkspaceDir,
+    });
+
+    await writeFile(path.join(remoteWorkspaceDir, "README.md"), "remote\n", "utf8");
+    // The restore tar exits 1 via the shim; the script must swallow that and the
+    // workspace must still round-trip back to the local dir.
+    await expect(prepared.restoreWorkspace()).resolves.toBeUndefined();
+    await expect(readFile(path.join(localWorkspaceDir, "README.md"), "utf8")).resolves.toBe("remote\n");
   });
 
   it("excludes transient symlinked home dirs from the asset tar while keeping required content", async () => {

--- a/packages/adapter-utils/src/sandbox-managed-runtime.test.ts
+++ b/packages/adapter-utils/src/sandbox-managed-runtime.test.ts
@@ -671,6 +671,76 @@ describe("sandbox managed runtime", () => {
     await expect(readFile(path.join(localWorkspaceDir, "README.md"), "utf8")).resolves.toBe("remote\n");
   });
 
+  it("still fails the restore when tar exits 2 (real archive error)", async () => {
+    // Negative counterpart to the exit-1 tolerance test: exit code 2 is a real
+    // tar error and must stay fatal. The tolerantTar wrapper rewrites only an
+    // exit status of exactly 1 to 0 (`[ $rc -le 1 ]`); this locks in that a
+    // future loosening (e.g. `-le 2`) breaks the safety contract visibly.
+    const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-sandbox-tarexit2-"));
+    cleanupDirs.push(rootDir);
+    const localWorkspaceDir = path.join(rootDir, "local-workspace");
+    const remoteWorkspaceDir = path.join(rootDir, "remote-workspace");
+    const fakeBinDir = path.join(rootDir, "fakebin");
+    await mkdir(localWorkspaceDir, { recursive: true });
+    await mkdir(fakeBinDir, { recursive: true });
+    await writeFile(path.join(localWorkspaceDir, "README.md"), "ws\n", "utf8");
+
+    // A `tar` shim that fails unconditionally with exit 2, activated only for
+    // the restore phase so prepare still uses the real system tar.
+    const tarShimPath = path.join(fakeBinDir, "tar");
+    await writeFile(tarShimPath, "#!/bin/sh\nexit 2\n", "utf8");
+    await chmod(tarShimPath, 0o755);
+    let tarShimActive = false;
+
+    const client: SandboxManagedRuntimeClient = {
+      makeDir: async (remotePath) => {
+        await mkdir(remotePath, { recursive: true });
+      },
+      writeFile: async (remotePath, bytes) => {
+        await mkdir(path.dirname(remotePath), { recursive: true });
+        await writeFile(remotePath, Buffer.from(bytes));
+      },
+      readFile: async (remotePath) => await readFile(remotePath),
+      listFiles: async () => [],
+      remove: async (remotePath) => {
+        await rm(remotePath, { recursive: true, force: true });
+      },
+      run: async (command) => {
+        await execFile("sh", ["-c", command], {
+          maxBuffer: 32 * 1024 * 1024,
+          env: {
+            ...process.env,
+            PATH: tarShimActive ? `${fakeBinDir}:${process.env.PATH ?? ""}` : process.env.PATH ?? "",
+          },
+        }).catch((err: NodeJS.ErrnoException & { code?: number }) => {
+          throw new Error(`run failed with exit code ${err.code ?? "null"}`);
+        });
+      },
+    };
+
+    const prepared = await prepareSandboxManagedRuntime({
+      spec: {
+        transport: "sandbox",
+        provider: "test",
+        sandboxId: "sandbox-1",
+        remoteCwd: remoteWorkspaceDir,
+        timeoutMs: 30_000,
+        apiKey: null,
+      },
+      adapterKey: "test-adapter",
+      client,
+      workspaceLocalDir: localWorkspaceDir,
+    });
+
+    await writeFile(path.join(remoteWorkspaceDir, "README.md"), "remote\n", "utf8");
+    tarShimActive = true;
+    // The restore tar exits 2 via the shim; the script must propagate that as a
+    // non-zero exit (the `[ $rc -le 1 ]` guard fails, so the && chain aborts),
+    // and the local workspace must be left untouched.
+    await expect(prepared.restoreWorkspace()).rejects.toThrow(/run failed with exit code/);
+    await expect(readFile(path.join(localWorkspaceDir, "README.md"), "utf8")).resolves.toBe("ws\n");
+  });
+
   it("excludes transient symlinked home dirs from the asset tar while keeping required content", async () => {
     const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-sandbox-home-tmp-"));
     cleanupDirs.push(rootDir);

--- a/packages/adapter-utils/src/sandbox-managed-runtime.test.ts
+++ b/packages/adapter-utils/src/sandbox-managed-runtime.test.ts
@@ -1,6 +1,6 @@
 import { randomBytes } from "node:crypto";
 import { promises as fsPromises } from "node:fs";
-import { lstat, mkdir, mkdtemp, readFile, readdir, rm, stat, symlink, writeFile } from "node:fs/promises";
+import { chmod, lstat, mkdir, mkdtemp, readFile, readdir, rm, stat, symlink, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { execFile as execFileCallback, spawn } from "node:child_process";
@@ -3120,6 +3120,153 @@ describe("sandbox managed runtime", () => {
       expect(span!.ended).toBe(true);
       expect(span!.parentName).toBe("stage.sync");
     }
+  });
+
+  it("tolerates a tar exit code 1 (benign 'file changed as we read it') when restoring the workspace", async () => {
+    // GNU/busybox tar returns exit code 1 for benign warnings — most commonly
+    // "file changed as we read it" when archiving a live workspace whose files
+    // mutate during the `tar -c`. That is guaranteed for an active agent run and
+    // must NOT abort the run; only exit code 2 (a real archive error) is fatal.
+    const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-sandbox-tarexit1-"));
+    cleanupDirs.push(rootDir);
+    const localWorkspaceDir = path.join(rootDir, "local-workspace");
+    const remoteWorkspaceDir = path.join(rootDir, "remote-workspace");
+    const fakeBinDir = path.join(rootDir, "fakebin");
+    await mkdir(localWorkspaceDir, { recursive: true });
+    await mkdir(fakeBinDir, { recursive: true });
+    await writeFile(path.join(localWorkspaceDir, "README.md"), "ws\n", "utf8");
+
+    // A `tar` shim that does the real work via the system tar, then exits 1 to
+    // simulate the benign warning. Used only for the remote (client.run) tar
+    // invocations; the local helper tars still use the real system tar.
+    const realTar = (await execFile("sh", ["-c", "command -v tar"]))
+      .stdout.trim();
+    const tarShimPath = path.join(fakeBinDir, "tar");
+    await writeFile(
+      tarShimPath,
+      `#!/bin/sh\n${realTar} "$@"\nstatus=$?\nif [ "$status" -eq 0 ]; then exit 1; fi\nexit "$status"\n`,
+      "utf8",
+    );
+    await chmod(tarShimPath, 0o755);
+
+    const client: SandboxManagedRuntimeClient = {
+      makeDir: async (remotePath) => {
+        await mkdir(remotePath, { recursive: true });
+      },
+      writeFile: async (remotePath, bytes) => {
+        await mkdir(path.dirname(remotePath), { recursive: true });
+        await writeFile(remotePath, Buffer.from(bytes));
+      },
+      readFile: async (remotePath) => await readFile(remotePath),
+      listFiles: async () => [],
+      remove: async (remotePath) => {
+        await rm(remotePath, { recursive: true, force: true });
+      },
+      // Mirror command-managed-runtime semantics: throw on any non-zero exit so
+      // the test exercises the real fatality contract. With the tar shim on PATH
+      // (so the scripts' bare `tar` resolves to it) the restore script must still
+      // exit 0 — proving the tar exit-1 tolerance is baked into the script.
+      run: async (command) => {
+        await execFile("sh", ["-c", command], {
+          maxBuffer: 32 * 1024 * 1024,
+          env: { ...process.env, PATH: `${fakeBinDir}:${process.env.PATH ?? ""}` },
+        }).catch((err: NodeJS.ErrnoException & { code?: number }) => {
+          throw new Error(`run failed with exit code ${err.code ?? "null"}`);
+        });
+      },
+    };
+
+    attachFallbackSyncIn(client);
+    const prepared = await prepareSandboxManagedRuntime({
+      spec: {
+        transport: "sandbox",
+        provider: "test",
+        sandboxId: "sandbox-1",
+        remoteCwd: remoteWorkspaceDir,
+        timeoutMs: 30_000,
+        apiKey: null,
+      },
+      adapterKey: "test-adapter",
+      client,
+      workspaceLocalDir: localWorkspaceDir,
+    });
+
+    await writeFile(path.join(remoteWorkspaceDir, "README.md"), "remote\n", "utf8");
+    // The restore tar exits 1 via the shim; the script must swallow that and the
+    // workspace must still round-trip back to the local dir.
+    await expect(prepared.restoreWorkspace()).resolves.toBeUndefined();
+    await expect(readFile(path.join(localWorkspaceDir, "README.md"), "utf8")).resolves.toBe("remote\n");
+  });
+
+  it("still fails the restore when tar exits 2 (real archive error)", async () => {
+    // Negative counterpart to the exit-1 tolerance test: exit code 2 is a real
+    // tar error and must stay fatal. The tolerantTar wrapper rewrites only an
+    // exit status of exactly 1 to 0 (`[ $rc -le 1 ]`); this locks in that a
+    // future loosening (e.g. `-le 2`) breaks the safety contract visibly.
+    const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-sandbox-tarexit2-"));
+    cleanupDirs.push(rootDir);
+    const localWorkspaceDir = path.join(rootDir, "local-workspace");
+    const remoteWorkspaceDir = path.join(rootDir, "remote-workspace");
+    const fakeBinDir = path.join(rootDir, "fakebin");
+    await mkdir(localWorkspaceDir, { recursive: true });
+    await mkdir(fakeBinDir, { recursive: true });
+    await writeFile(path.join(localWorkspaceDir, "README.md"), "ws\n", "utf8");
+
+    // A `tar` shim that fails unconditionally with exit 2, activated only for
+    // the restore phase so prepare still uses the real system tar.
+    const tarShimPath = path.join(fakeBinDir, "tar");
+    await writeFile(tarShimPath, "#!/bin/sh\nexit 2\n", "utf8");
+    await chmod(tarShimPath, 0o755);
+    let tarShimActive = false;
+
+    const client: SandboxManagedRuntimeClient = {
+      makeDir: async (remotePath) => {
+        await mkdir(remotePath, { recursive: true });
+      },
+      writeFile: async (remotePath, bytes) => {
+        await mkdir(path.dirname(remotePath), { recursive: true });
+        await writeFile(remotePath, Buffer.from(bytes));
+      },
+      readFile: async (remotePath) => await readFile(remotePath),
+      listFiles: async () => [],
+      remove: async (remotePath) => {
+        await rm(remotePath, { recursive: true, force: true });
+      },
+      run: async (command) => {
+        await execFile("sh", ["-c", command], {
+          maxBuffer: 32 * 1024 * 1024,
+          env: {
+            ...process.env,
+            PATH: tarShimActive ? `${fakeBinDir}:${process.env.PATH ?? ""}` : process.env.PATH ?? "",
+          },
+        }).catch((err: NodeJS.ErrnoException & { code?: number }) => {
+          throw new Error(`run failed with exit code ${err.code ?? "null"}`);
+        });
+      },
+    };
+
+    attachFallbackSyncIn(client);
+    const prepared = await prepareSandboxManagedRuntime({
+      spec: {
+        transport: "sandbox",
+        provider: "test",
+        sandboxId: "sandbox-1",
+        remoteCwd: remoteWorkspaceDir,
+        timeoutMs: 30_000,
+        apiKey: null,
+      },
+      adapterKey: "test-adapter",
+      client,
+      workspaceLocalDir: localWorkspaceDir,
+    });
+
+    await writeFile(path.join(remoteWorkspaceDir, "README.md"), "remote\n", "utf8");
+    tarShimActive = true;
+    // The restore tar exits 2 via the shim; the script must propagate that as a
+    // non-zero exit (the `[ $rc -le 1 ]` guard fails, so the && chain aborts),
+    // and the local workspace must be left untouched.
+    await expect(prepared.restoreWorkspace()).rejects.toThrow(/run failed with exit code/);
+    await expect(readFile(path.join(localWorkspaceDir, "README.md"), "utf8")).resolves.toBe("ws\n");
   });
 });
 

--- a/packages/adapter-utils/src/sandbox-managed-runtime.ts
+++ b/packages/adapter-utils/src/sandbox-managed-runtime.ts
@@ -171,13 +171,24 @@ async function withTempDir<T>(prefix: string, fn: (dir: string) => Promise<T>): 
 }
 
 async function execTar(args: string[]): Promise<void> {
-  await execFile("tar", args, {
-    env: {
-      ...process.env,
-      COPYFILE_DISABLE: "1",
-    },
-    maxBuffer: 32 * 1024 * 1024,
-  });
+  try {
+    await execFile("tar", args, {
+      env: {
+        ...process.env,
+        COPYFILE_DISABLE: "1",
+      },
+      maxBuffer: 32 * 1024 * 1024,
+    });
+  } catch (err) {
+    // tar exits 1 for benign warnings ("file changed as we read it" when
+    // archiving a live workspace, "Removing leading '/'", etc). That is not a
+    // failure for our archive/extract use — only exit code 2 is a real error.
+    // Swallow exactly exit 1; rethrow anything else (including spawn errors,
+    // which carry no numeric `code`).
+    const code = (err as { code?: unknown }).code;
+    if (code === 1) return;
+    throw err;
+  }
 }
 
 async function createTarballFromDirectory(input: {
@@ -323,6 +334,19 @@ function tarExcludeFlags(exclude: string[] | undefined): string {
   return ["._*", ...(exclude ?? [])].map((entry) => `--exclude ${shellQuote(entry)}`).join(" ");
 }
 
+// Wrap a remote `tar` invocation so a benign exit code 1 is not treated as a
+// failure. GNU/busybox tar exits 1 for warnings such as "file changed as we
+// read it" / "Removing leading '/'" / "some files differ" — guaranteed when
+// archiving a LIVE workspace whose files mutate mid-archive (every active agent
+// run hits this). Exit code 2 is a real archive error and stays fatal: `tar`
+// runs, and only an exit status of exactly 1 is rewritten to 0; any other
+// non-zero status is preserved. Portable across POSIX `sh` (no GNU-only
+// `--warning=` flag, which busybox tar rejects). The caller still composes the
+// surrounding `&&` chain; this only softens the single tar step.
+function tolerantTar(tarCommand: string): string {
+  return `{ ${tarCommand}; __pc_tar_rc=$?; [ "$__pc_tar_rc" -le 1 ]; }`;
+}
+
 function createRemoteTarballFromDirectoryCommand(input: {
   remoteDir: string;
   archivePath: string;
@@ -338,7 +362,7 @@ function createRemoteTarballFromDirectoryCommand(input: {
     `for entry in .[!.]* ..?*; do [ -e "$entry" ] || [ -L "$entry" ] || continue; set -- "$@" "$entry"; done`,
     `if [ "$#" -eq 0 ]; then ` +
       `dd if=/dev/zero of=${shellQuote(input.archivePath)} bs=1024 count=1; ` +
-      `else tar -cf ${shellQuote(input.archivePath)} ${tarExcludeFlags(input.exclude)} -- "$@"; fi`,
+      `else ${tolerantTar(`tar -cf ${shellQuote(input.archivePath)} ${tarExcludeFlags(input.exclude)} -- "$@"`)}; fi`,
   ].join(" && ");
 }
 
@@ -491,7 +515,7 @@ export async function prepareSandboxManagedRuntime(input: {
           `sh -c ${shellQuote(
             `mkdir -p ${shellQuote(workspaceRemoteDir)} && ` +
               `find ${shellQuote(workspaceRemoteDir)} -mindepth 1 -maxdepth 1 ${preserveFindArgs([".paperclip-runtime"])} -exec rm -rf -- {} + && ` +
-              `tar -xf ${shellQuote(remoteGitTar)} -C ${shellQuote(workspaceRemoteDir)} && ` +
+              `${tolerantTar(`tar -xf ${shellQuote(remoteGitTar)} -C ${shellQuote(workspaceRemoteDir)}`)} && ` +
               `rm -f ${shellQuote(remoteGitTar)}`,
           )}`,
           { timeoutMs: input.spec.timeoutMs },
@@ -533,11 +557,11 @@ export async function prepareSandboxManagedRuntime(input: {
     await workspaceUpload.finish(workspaceTarBytes.byteLength, workspaceTarBytes.byteLength);
     const extractWorkspaceTarCommand = gitSnapshot
       ? `mkdir -p ${shellQuote(workspaceRemoteDir)} && ` +
-        `tar -xf ${shellQuote(remoteWorkspaceTar)} -C ${shellQuote(workspaceRemoteDir)} && ` +
+        `${tolerantTar(`tar -xf ${shellQuote(remoteWorkspaceTar)} -C ${shellQuote(workspaceRemoteDir)}`)} && ` +
         `rm -f ${shellQuote(remoteWorkspaceTar)}`
       : `mkdir -p ${shellQuote(workspaceRemoteDir)} && ` +
         `find ${shellQuote(workspaceRemoteDir)} -mindepth 1 -maxdepth 1 ${preserveFindArgs([...preservedNames])} -exec rm -rf -- {} + && ` +
-        `tar -xf ${shellQuote(remoteWorkspaceTar)} -C ${shellQuote(workspaceRemoteDir)} && ` +
+        `${tolerantTar(`tar -xf ${shellQuote(remoteWorkspaceTar)} -C ${shellQuote(workspaceRemoteDir)}`)} && ` +
         `rm -f ${shellQuote(remoteWorkspaceTar)}`;
     await input.client.run(
       `sh -c ${shellQuote(extractWorkspaceTarCommand)}`,
@@ -577,7 +601,7 @@ export async function prepareSandboxManagedRuntime(input: {
         `sh -c ${shellQuote(
           `rm -rf ${shellQuote(remoteAssetDir)} && ` +
             `mkdir -p ${shellQuote(remoteAssetDir)} && ` +
-            `tar -xf ${shellQuote(remoteAssetTar)} -C ${shellQuote(remoteAssetDir)} && ` +
+            `${tolerantTar(`tar -xf ${shellQuote(remoteAssetTar)} -C ${shellQuote(remoteAssetDir)}`)} && ` +
             `rm -f ${shellQuote(remoteAssetTar)}`,
         )}`,
         { timeoutMs: input.spec.timeoutMs },

--- a/packages/adapter-utils/src/sandbox-managed-runtime.ts
+++ b/packages/adapter-utils/src/sandbox-managed-runtime.ts
@@ -609,13 +609,26 @@ function shellQuote(value: string) {
   return `'${value.replace(/'/g, `'\"'\"'`)}'`;
 }
 
+// Wrap a remote `tar` invocation so a benign exit code 1 is not treated as a
+// failure. GNU/busybox tar exits 1 for warnings such as "file changed as we
+// read it" / "Removing leading '/'" / "some files differ" — guaranteed when
+// archiving a LIVE workspace whose files mutate mid-archive (every active agent
+// run hits this). Exit code 2 is a real archive error and stays fatal: `tar`
+// runs, and only an exit status of exactly 1 is rewritten to 0; any other
+// non-zero status is preserved. Portable across POSIX `sh` (no GNU-only
+// `--warning=` flag, which busybox tar rejects). The caller still composes the
+// surrounding `&&` chain; this only softens the single tar step.
+function tolerantTar(tarCommand: string): string {
+  return `{ ${tarCommand}; __pc_tar_rc=$?; [ "$__pc_tar_rc" -le 1 ]; }`;
+}
+
 function buildDefaultExtractRuntimeAssetCommand(input: {
   remoteAssetDir: string;
   remoteAssetTar: string;
 }): string {
   return `rm -rf ${shellQuote(input.remoteAssetDir)} && ` +
     `mkdir -p ${shellQuote(input.remoteAssetDir)} && ` +
-    `tar -xf ${shellQuote(input.remoteAssetTar)} -C ${shellQuote(input.remoteAssetDir)} && ` +
+    `${tolerantTar(`tar -xf ${shellQuote(input.remoteAssetTar)} -C ${shellQuote(input.remoteAssetDir)}`)} && ` +
     `rm -f ${shellQuote(input.remoteAssetTar)}`;
 }
 
@@ -645,7 +658,7 @@ function buildWorkspaceTarExtractCommand(input: {
     : "";
   return (
     `mkdir -p ${shellQuote(input.workspaceRemoteDir)}${wipe} && ` +
-    `tar -xf ${shellQuote(input.remoteTar)} -C ${shellQuote(input.workspaceRemoteDir)} && ` +
+    `${tolerantTar(`tar -xf ${shellQuote(input.remoteTar)} -C ${shellQuote(input.workspaceRemoteDir)}`)} && ` +
     `rm -f ${shellQuote(input.remoteTar)}`
   );
 }
@@ -800,13 +813,24 @@ async function persistDurableSeedArchive(input: {
 }
 
 async function execTar(args: string[]): Promise<void> {
-  await execFile("tar", args, {
-    env: {
-      ...process.env,
-      COPYFILE_DISABLE: "1",
-    },
-    maxBuffer: 32 * 1024 * 1024,
-  });
+  try {
+    await execFile("tar", args, {
+      env: {
+        ...process.env,
+        COPYFILE_DISABLE: "1",
+      },
+      maxBuffer: 32 * 1024 * 1024,
+    });
+  } catch (err) {
+    // tar exits 1 for benign warnings ("file changed as we read it" when
+    // archiving a live workspace, "Removing leading '/'", etc). That is not a
+    // failure for our archive/extract use — only exit code 2 is a real error.
+    // Swallow exactly exit 1; rethrow anything else (including spawn errors,
+    // which carry no numeric `code`).
+    const code = (err as { code?: unknown }).code;
+    if (code === 1) return;
+    throw err;
+  }
 }
 
 export async function createTarballFromDirectory(input: {
@@ -980,7 +1004,7 @@ function createRemoteTarballFromDirectoryCommand(input: {
     `for entry in .[!.]* ..?*; do [ -e "$entry" ] || [ -L "$entry" ] || continue; set -- "$@" "$entry"; done`,
     `if [ "$#" -eq 0 ]; then ` +
       `dd if=/dev/zero of=${shellQuote(input.archivePath)} bs=1024 count=1; ` +
-      `else tar -cf ${shellQuote(input.archivePath)} ${tarExcludeFlags(input.exclude)} -- "$@"; fi`,
+      `else ${tolerantTar(`tar -cf ${shellQuote(input.archivePath)} ${tarExcludeFlags(input.exclude)} -- "$@"`)}; fi`,
   ].join(" && ");
 }
 

--- a/server/src/__tests__/environment-run-orchestrator.test.ts
+++ b/server/src/__tests__/environment-run-orchestrator.test.ts
@@ -355,6 +355,59 @@ describe("environmentRunOrchestrator — realizeForRun", () => {
     expect(result.persistedExecutionWorkspace).toEqual(updatedEw);
   });
 
+  it("threads the realized remoteCwd from a sandbox driver onto the lease metadata before resolving the target", async () => {
+    // Regression: a plugin-backed sandbox (e.g. the kubernetes provider) reports
+    // its in-environment cwd ("/workspace") via realizeWorkspace, but acquireLease
+    // never records it on the lease. Without persisting it here,
+    // resolveEnvironmentExecutionTarget falls back to the bounded default ("/tmp")
+    // and the adapter syncs/execs the workspace under /tmp inside the server pod.
+    mockResolveEnvironmentExecutionTarget.mockResolvedValue({
+      kind: "remote",
+      transport: "sandbox",
+      providerKey: "kubernetes",
+      remoteCwd: "/workspace",
+      environmentId: "env-1",
+      leaseId: "lease-1",
+    });
+
+    const runtime = makeMockRuntime({
+      realizeWorkspace: vi.fn().mockResolvedValue({
+        // Plugin returns the realized cwd, but NO `workspaceRealization` record
+        // (matches the kubernetes plugin's onEnvironmentRealizeWorkspace shape).
+        cwd: "/workspace",
+        metadata: {
+          provider: "kubernetes",
+          remoteCwd: "/workspace",
+        },
+      }),
+    });
+    const orchestrator = environmentRunOrchestrator(mockDb, { environmentRuntime: runtime });
+
+    await orchestrator.realizeForRun(
+      makeRealizeInput({
+        environment: makeEnvironment("sandbox"),
+        lease: makeLease({
+          provider: "kubernetes",
+          metadata: { driver: "sandbox", sandboxProviderPlugin: true },
+        }),
+      }),
+    );
+
+    // The realized cwd must be persisted as remoteCwd on the lease metadata...
+    expect(mockUpdateLeaseMetadata).toHaveBeenCalledWith(
+      "lease-1",
+      expect.objectContaining({ remoteCwd: "/workspace" }),
+    );
+
+    // ...and threaded into resolveEnvironmentExecutionTarget so it does NOT fall
+    // back to the bounded /tmp default.
+    expect(mockResolveEnvironmentExecutionTarget).toHaveBeenCalledWith(
+      expect.objectContaining({
+        leaseMetadata: expect.objectContaining({ remoteCwd: "/workspace" }),
+      }),
+    );
+  });
+
   it("runs a remote provision command after workspace realization when configured", async () => {
     mockBuildWorkspaceRealizationRequest.mockReturnValue({
       version: 1,

--- a/server/src/__tests__/environment-run-orchestrator.test.ts
+++ b/server/src/__tests__/environment-run-orchestrator.test.ts
@@ -416,6 +416,59 @@ describe("environmentRunOrchestrator — realizeForRun", () => {
     expect(result.persistedExecutionWorkspace).toEqual(updatedEw);
   });
 
+  it("threads the realized remoteCwd from a sandbox driver onto the lease metadata before resolving the target", async () => {
+    // Regression: a plugin-backed sandbox (e.g. the kubernetes provider) reports
+    // its in-environment cwd ("/workspace") via realizeWorkspace, but acquireLease
+    // never records it on the lease. Without persisting it here,
+    // resolveEnvironmentExecutionTarget falls back to the bounded default ("/tmp")
+    // and the adapter syncs/execs the workspace under /tmp inside the server pod.
+    mockResolveEnvironmentExecutionTarget.mockResolvedValue({
+      kind: "remote",
+      transport: "sandbox",
+      providerKey: "kubernetes",
+      remoteCwd: "/workspace",
+      environmentId: "env-1",
+      leaseId: "lease-1",
+    });
+
+    const runtime = makeMockRuntime({
+      realizeWorkspace: vi.fn().mockResolvedValue({
+        // Plugin returns the realized cwd, but NO `workspaceRealization` record
+        // (matches the kubernetes plugin's onEnvironmentRealizeWorkspace shape).
+        cwd: "/workspace",
+        metadata: {
+          provider: "kubernetes",
+          remoteCwd: "/workspace",
+        },
+      }),
+    });
+    const orchestrator = environmentRunOrchestrator(mockDb, { environmentRuntime: runtime });
+
+    await orchestrator.realizeForRun(
+      makeRealizeInput({
+        environment: makeEnvironment("sandbox"),
+        lease: makeLease({
+          provider: "kubernetes",
+          metadata: { driver: "sandbox", sandboxProviderPlugin: true },
+        }),
+      }),
+    );
+
+    // The realized cwd must be persisted as remoteCwd on the lease metadata...
+    expect(mockUpdateLeaseMetadata).toHaveBeenCalledWith(
+      "lease-1",
+      expect.objectContaining({ remoteCwd: "/workspace" }),
+    );
+
+    // ...and threaded into resolveEnvironmentExecutionTarget so it does NOT fall
+    // back to the bounded /tmp default.
+    expect(mockResolveEnvironmentExecutionTarget).toHaveBeenCalledWith(
+      expect.objectContaining({
+        leaseMetadata: expect.objectContaining({ remoteCwd: "/workspace" }),
+      }),
+    );
+  });
+
   it("runs a remote provision command after workspace realization when configured", async () => {
     mockBuildWorkspaceRealizationRequest.mockReturnValue({
       version: 1,

--- a/server/src/services/environment-run-orchestrator.ts
+++ b/server/src/services/environment-run-orchestrator.ts
@@ -442,17 +442,43 @@ export function environmentRunOrchestrator(
       }
     }
 
-    // Step 3: Persist realization metadata on lease and execution workspace
-    if (Object.keys(workspaceRealization).length > 0) {
+    // Step 3: Persist realization metadata on lease and execution workspace.
+    //
+    // Thread the realized working directory through as `remoteCwd` on the lease
+    // metadata. The runtime driver (and, for plugin-backed providers, the plugin
+    // itself, e.g. the kubernetes provider) reports the authoritative in-environment
+    // cwd from realizeWorkspace (e.g. "/workspace"), but acquireLease does NOT
+    // record it on the lease. Without persisting it here,
+    // resolveEnvironmentExecutionTarget (Step 4) finds no `remoteCwd` in the lease
+    // metadata and falls back to DEFAULT_SANDBOX_REMOTE_CWD ("/tmp"), so the
+    // adapter syncs/execs the workspace under /tmp instead of the realized
+    // workspace dir. Persisting it keeps the lease the single source of truth and
+    // makes the executionTarget honor the provider's realized cwd. Generic across
+    // all remote drivers; only writes when the driver reported a non-empty cwd and
+    // the lease does not already carry the same value.
+    const realizedRemoteCwd =
+      environment.driver !== "local" &&
+      typeof realizedWorkspaceCwd === "string" &&
+      realizedWorkspaceCwd.trim().length > 0
+        ? realizedWorkspaceCwd.trim()
+        : null;
+    const shouldPersistRemoteCwd =
+      realizedRemoteCwd !== null && lease.metadata?.remoteCwd !== realizedRemoteCwd;
+    if (Object.keys(workspaceRealization).length > 0 || shouldPersistRemoteCwd) {
       const nextLeaseMetadata = {
         ...(lease.metadata ?? {}),
-        workspaceRealization,
+        ...(Object.keys(workspaceRealization).length > 0 ? { workspaceRealization } : {}),
+        ...(realizedRemoteCwd !== null ? { remoteCwd: realizedRemoteCwd } : {}),
       };
       const updatedLease = await environmentsSvc.updateLeaseMetadata(lease.id, nextLeaseMetadata);
       if (updatedLease) {
         lease = updatedLease;
+      } else {
+        // Keep the in-memory lease consistent even if the persistence layer
+        // returns no row, so Step 4 reads the realized remoteCwd.
+        lease = { ...lease, metadata: nextLeaseMetadata } as typeof lease;
       }
-      if (persistedExecutionWorkspace) {
+      if (persistedExecutionWorkspace && Object.keys(workspaceRealization).length > 0) {
         const updatedEw = await executionWorkspacesSvc.update(persistedExecutionWorkspace.id, {
           metadata: {
             ...(persistedExecutionWorkspace.metadata ?? {}),

--- a/server/src/services/environment-run-orchestrator.ts
+++ b/server/src/services/environment-run-orchestrator.ts
@@ -484,17 +484,43 @@ export function environmentRunOrchestrator(
       }
     }
 
-    // Step 3: Persist realization metadata on lease and execution workspace
-    if (Object.keys(workspaceRealization).length > 0) {
+    // Step 3: Persist realization metadata on lease and execution workspace.
+    //
+    // Thread the realized working directory through as `remoteCwd` on the lease
+    // metadata. The runtime driver (and, for plugin-backed providers, the plugin
+    // itself, e.g. the kubernetes provider) reports the authoritative in-environment
+    // cwd from realizeWorkspace (e.g. "/workspace"), but acquireLease does NOT
+    // record it on the lease. Without persisting it here,
+    // resolveEnvironmentExecutionTarget (Step 4) finds no `remoteCwd` in the lease
+    // metadata and falls back to DEFAULT_SANDBOX_REMOTE_CWD ("/tmp"), so the
+    // adapter syncs/execs the workspace under /tmp instead of the realized
+    // workspace dir. Persisting it keeps the lease the single source of truth and
+    // makes the executionTarget honor the provider's realized cwd. Generic across
+    // all remote drivers; only writes when the driver reported a non-empty cwd and
+    // the lease does not already carry the same value.
+    const realizedRemoteCwd =
+      environment.driver !== "local" &&
+      typeof realizedWorkspaceCwd === "string" &&
+      realizedWorkspaceCwd.trim().length > 0
+        ? realizedWorkspaceCwd.trim()
+        : null;
+    const shouldPersistRemoteCwd =
+      realizedRemoteCwd !== null && lease.metadata?.remoteCwd !== realizedRemoteCwd;
+    if (Object.keys(workspaceRealization).length > 0 || shouldPersistRemoteCwd) {
       const nextLeaseMetadata = {
         ...(lease.metadata ?? {}),
-        workspaceRealization,
+        ...(Object.keys(workspaceRealization).length > 0 ? { workspaceRealization } : {}),
+        ...(realizedRemoteCwd !== null ? { remoteCwd: realizedRemoteCwd } : {}),
       };
       const updatedLease = await environmentsSvc.updateLeaseMetadata(lease.id, nextLeaseMetadata);
       if (updatedLease) {
         lease = updatedLease;
+      } else {
+        // Keep the in-memory lease consistent even if the persistence layer
+        // returns no row, so Step 4 reads the realized remoteCwd.
+        lease = { ...lease, metadata: nextLeaseMetadata } as typeof lease;
       }
-      if (persistedExecutionWorkspace) {
+      if (persistedExecutionWorkspace && Object.keys(workspaceRealization).length > 0) {
         const updatedEw = await executionWorkspacesSvc.update(persistedExecutionWorkspace.id, {
           metadata: {
             ...(persistedExecutionWorkspace.metadata ?? {}),


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Agents can execute on remote environments (SSH / sandbox providers such as a kubernetes plugin) via the environment-run orchestrator, which syncs the workspace into the environment and restores it afterwards
> - Two defects made remote lease execution unfaithful to local semantics: the provider's realized in-environment cwd was discarded (so the adapter synced/exec'd under the `/tmp` fallback instead of the realized workspace dir), and a benign `tar` exit code 1 during workspace sync/restore was treated as a hard failure
> - Together these caused every run on a realized remote workspace to either operate in the wrong directory or abort at workspace restore
> - This pull request threads the realized cwd onto the lease metadata so the execution target honors it, and makes the remote/local tar steps tolerate the benign exit code 1 (exit 2 stays fatal)
> - The benefit is that remote lease execution behaves exactly like local execution: right working directory, and live-workspace archiving no longer flakes runs

## Linked Issues or Issue Description

No public issue exists for this; describing the bug in-PR (bug-report shape):

- **What happened:** running an agent on a remote execution environment (e.g. a kubernetes sandbox provider) failed at workspace sync/restore. Two independent but causally linked defects, both breaking the "remote leases behave like local execution" contract:
  1. **Realized workspace cwd is dropped.** A provider's `onEnvironmentRealizeWorkspace` returns the authoritative in-environment cwd (e.g. `/workspace`), but `acquireLease` does not record it and `realizeForRun` discarded it. `resolveEnvironmentExecutionTarget` then found no `remoteCwd` on the lease and fell back to `DEFAULT_SANDBOX_REMOTE_CWD` (`/tmp`), so the adapter synced/tarred the workspace under `/tmp` instead of the realized directory.
  2. **`tar` exit code 1 treated as fatal.** GNU/busybox `tar` returns exit 1 for the benign "file changed as we read it" warning — guaranteed when archiving a live workspace whose files mutate mid-archive. The sync/restore scripts treated this as a hard failure.
- **Expected behavior:** the adapter executes in the provider's realized workspace directory, and benign tar warnings do not abort the run (a real archive error, exit 2, still does).
- **Environment:** any non-`local` driver (`ssh`, `sandbox`), most visible with plugin-backed sandbox providers.

Supersedes #8287 (closed while re-cutting our open PRs into clean single-concern branches on current master).

## What Changed

Concern 1 — honor the realized workspace cwd on remote leases (`server/`):

- `server/src/services/environment-run-orchestrator.ts`: Step 3 now persists the realized cwd as `remoteCwd` on the lease metadata — only when a non-`local` driver reported a non-empty cwd and the lease does not already carry the same value — so `resolveEnvironmentExecutionTarget` (Step 4) honors it instead of falling back to `/tmp`. If the persistence layer returns no row, the in-memory lease is still updated so Step 4 reads the realized value. Generic across all remote drivers; no provider coupling.
- `server/src/__tests__/environment-run-orchestrator.test.ts`: regression test that a sandbox driver's realized cwd lands on the lease metadata and is threaded into `resolveEnvironmentExecutionTarget`.

Concern 2 — tolerate benign tar exit 1 during workspace sync/restore (`packages/adapter-utils/`):

- `packages/adapter-utils/src/sandbox-managed-runtime.ts`: portable `tolerantTar` shell wrapper (`{ tar…; rc=$?; [ "$rc" -le 1 ]; }`; no GNU-only `--warning=` flag so busybox tar works) applied to the remote git-history/workspace/asset extract steps and the remote restore-archive create step; the local `execTar` helper swallows exactly exit 1. Exit code 2 remains fatal in all paths.
- `packages/adapter-utils/src/sandbox-managed-runtime.test.ts`: test using a `tar` shim that exits 1 after doing the real work, proving prepare + restore still round-trip while non-zero exits from `client.run` stay fatal.

Both concerns ship together because they are causally linked: each one alone still leaves remote lease execution unfaithful to local semantics (wrong cwd, or aborted restore).

## Verification

- `npx vitest run packages/adapter-utils/src/sandbox-managed-runtime.test.ts` — 11 passed (includes the new exit-1 tolerance test)
- `npx vitest run server/src/__tests__/environment-run-orchestrator.test.ts` — 9 passed (includes the new remoteCwd threading test)
- `npx tsc --noEmit -p packages/adapter-utils` and `npx tsc --noEmit -p server` — clean
- Manual: on a plugin-backed sandbox environment, run an agent and confirm the adapter syncs/execs under the realized dir (e.g. `/workspace`) rather than `/tmp`, and that restore succeeds while files change during archiving

## Risks

- Low risk. The lease metadata write is additive and guarded (non-`local` driver, non-empty cwd, value differs); drivers that never report a realized cwd are unaffected.
- Tar tolerance is scoped to exactly exit code 1 on the specific sync/restore tar steps; exit 2 (real archive errors) and all other non-zero exits still fail the run.
- No migrations, no API changes.

## Model Used

- Claude (Anthropic) — original change authored with Claude Opus 4.8 (1M context, extended thinking, tool use via Claude Code); rebase/conflict resolution and re-verification with Claude Fable 5 (`claude-fable-5`, tool use via Claude Code)

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
