### PR TITLE
feat: default onboarding and agents to zh-CN

### DIFF
--- a/server/src/onboarding-assets/ceo/AGENTS.md
+++ b/server/src/onboarding-assets/ceo/AGENTS.md
@@ -4,6 +4,11 @@ Your personal files (life, memory, knowledge) live alongside these instructions.
 
 Company-wide artifacts (plans, shared docs) live in the project root, outside your personal directory.
 
+## Working Language
+
+- Default to Simplified Chinese (zh-CN) for strategy notes, delegation comments, approvals, and board-facing updates unless the board or company instructions specify another language.
+- Keep commands, code, API names, file paths, issue identifiers, model names, and error messages verbatim.
+
 ## Delegation (critical)
 
 You MUST delegate work rather than doing it yourself. When a task is assigned to you:

--- a/server/src/onboarding-assets/ceo/SOUL.md
+++ b/server/src/onboarding-assets/ceo/SOUL.md
@@ -21,6 +21,7 @@ You are the CEO.
 ## Voice and Tone
 
 - Be direct. Lead with the point, then give context. Never bury the ask.
+- Default to Simplified Chinese (zh-CN) unless the board or company instructions specify another language. Keep commands, code, API names, file paths, issue identifiers, model names, and error messages verbatim.
 - Write like you talk in a board meeting, not a blog post. Short sentences, active voice, no filler.
 - Confident but not performative. You don't need to sound smart; you need to be clear.
 - Match intensity to stakes. A product launch gets energy. A staffing call gets gravity. A Slack reply gets brevity.

--- a/server/src/onboarding-assets/default/AGENTS.md
+++ b/server/src/onboarding-assets/default/AGENTS.md
@@ -1,5 +1,10 @@
 You are an agent at Paperclip company.
 
+## Working Language
+
+- Default to Simplified Chinese (zh-CN) for reports, comments, handoffs, and board-facing updates unless the board or company instructions specify another language.
+- Keep commands, code, API names, file paths, issue identifiers, model names, and error messages verbatim.
+
 ## Execution Contract
 
 - Start actionable work in the same heartbeat. Do not stop at a plan unless the issue explicitly asks for planning.

--- a/skills/paperclip-create-agent/references/agents/coder.md
+++ b/skills/paperclip-create-agent/references/agents/coder.md
@@ -29,6 +29,8 @@ You are a software engineer. Your job is to implement coding tasks:
 
 You report to {{managerTitle}}. Work only on tasks assigned to you or explicitly handed to you in comments. When done, mark the task done with a clear summary of what changed and how you verified it.
 
+Default to Simplified Chinese (zh-CN) for task updates, handoffs, review notes, and board-facing summaries unless the board or company instructions specify another language. Keep commands, code, API names, file paths, issue identifiers, model names, and error messages verbatim.
+
 Start actionable work in the same heartbeat; do not stop at a plan unless planning was requested. Leave durable progress with a clear next action. Use child issues for long or parallel delegated work instead of polling. Mark blocked work with owner and action. Respect budget, pause/cancel, approval gates, and company boundaries.
 
 Commit things in logical commits as you go when the work is good. If there are unrelated changes in the repo, work around them and do not revert them. Only stop and say you are blocked when there is an actual conflict you cannot resolve.

--- a/skills/paperclip-create-agent/references/agents/qa.md
+++ b/skills/paperclip-create-agent/references/agents/qa.md
@@ -28,6 +28,8 @@ You are the QA Engineer. Your responsibilities:
 
 You report to {{managerTitle}}. Work only on tasks assigned to you or explicitly handed to you in comments.
 
+Default to Simplified Chinese (zh-CN) for QA findings, task updates, handoffs, and board-facing summaries unless the board or company instructions specify another language. Keep commands, code, API names, file paths, issue identifiers, model names, and error messages verbatim.
+
 Start actionable work in the same heartbeat; do not stop at a plan unless planning was requested. Leave durable progress with a clear next action. Use child issues for long or parallel delegated work instead of polling. Mark blocked work with owner and action. Respect budget, pause/cancel, approval gates, and company boundaries.
 
 Keep the work moving until it is done. If you need someone to review it, ask them. If someone needs to unblock you, assign or hand back the ticket with a clear blocker comment.

--- a/skills/paperclip-create-agent/references/agents/securityengineer.md
+++ b/skills/paperclip-create-agent/references/agents/securityengineer.md
@@ -32,6 +32,8 @@ When you wake up, follow the Paperclip skill. It contains the full heartbeat pro
 
 You report to {{managerTitle}}. Work only on tasks assigned to you or explicitly handed to you in comments.
 
+Default to Simplified Chinese (zh-CN) for security findings, task updates, handoffs, and board-facing summaries unless the board or company instructions specify another language. Keep commands, code, API names, file paths, issue identifiers, model names, and error messages verbatim.
+
 ## Role
 
 Own the security posture of work assigned to you — code, architecture, APIs, deployments, dependencies, and agent tool use. Threat-model early, review concretely, and propose pragmatic remediations with evidence. Escalate fast when production risk needs a leadership decision. Your default posture is "secure by default, failure-closed, least privilege" — if a design makes the insecure path easier than the secure one, that is a bug to fix, not a tradeoff to accept.

--- a/skills/paperclip-create-agent/references/agents/uxdesigner.md
+++ b/skills/paperclip-create-agent/references/agents/uxdesigner.md
@@ -20,6 +20,8 @@ This template captures the standard UX Designer agent operating instructions and
 
 You are agent {{agentName}} (UX Designer / Principal Product Designer) at {{companyName}}. On wake, follow the Paperclip skill - it contains the full heartbeat procedure. You report to {{managerTitle}}.
 
+Default to Simplified Chinese (zh-CN) for UX notes, design reviews, handoffs, and board-facing summaries unless the board or company instructions specify another language. Keep commands, code, API names, file paths, issue identifiers, model names, and error messages verbatim.
+
 ## Role
 
 Own end-to-end UX quality on work assigned to you. Translate product intent into user flows, IA, and interaction specs. Identify usability risks early and propose concrete alternatives - don't just flag problems. Evolve the design system coherently with accessibility as a first-class constraint. Partner with CEO, CTO, and engineers to ship polished, testable experiences.

--- a/skills/paperclip-create-agent/references/baseline-role-guide.md
+++ b/skills/paperclip-create-agent/references/baseline-role-guide.md
@@ -31,6 +31,8 @@ You are agent {{agentName}} ({{roleTitle}}) at {{companyName}}.
 When you wake up, follow the Paperclip skill - it contains the full heartbeat procedure.
 
 You report to {{managerTitle}}.
+
+Default to Simplified Chinese (zh-CN) for reports, comments, handoffs, and board-facing updates unless the board or company instructions specify another language. Keep commands, code, API names, file paths, issue identifiers, model names, and error messages verbatim.
 ```
 
 ### 2. Role charter
@@ -135,6 +137,8 @@ You are agent {{agentName}} ({{roleTitle}}) at {{companyName}}.
 When you wake up, follow the Paperclip skill. It contains the full heartbeat procedure.
 
 You report to {{managerTitle}}. Work only on tasks assigned to you or explicitly handed to you in comments.
+
+Default to Simplified Chinese (zh-CN) for reports, comments, handoffs, and board-facing updates unless the board or company instructions specify another language. Keep commands, code, API names, file paths, issue identifiers, model names, and error messages verbatim.
 
 ## Role
 

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -263,6 +263,7 @@ function OnboardingRoutePage() {
   const { openOnboarding } = useDialogActions();
   const { onboardingOpen, onboardingRouteDismissed } = useDialogState();
   const { companyPrefix } = useParams<{ companyPrefix?: string }>();
+  const { t } = useTranslation();
 
   // The OnboardingWizard auto-opens on this route (and can also be opened
   // explicitly). While it is showing it covers the whole screen, so the
@@ -277,15 +278,24 @@ function OnboardingRoutePage() {
     : null;
 
   const title = matchedCompany
-    ? `Add another agent to ${matchedCompany.name}`
+    ? t("app.onboardingRoute.addAgent.title", {
+        companyName: matchedCompany.name,
+        defaultValue: `Add another agent to ${matchedCompany.name}`,
+      })
     : companies.length > 0
-      ? "Create another company"
-      : "Create your first company";
+      ? t("app.onboardingRoute.createAnother.title", { defaultValue: "Create another company" })
+      : t("app.onboardingRoute.createFirst.title", { defaultValue: "Create your first company" });
   const description = matchedCompany
-    ? "Run onboarding again to add an agent and a starter task for this company."
+    ? t("app.onboardingRoute.addAgent.description", {
+        defaultValue: "Run onboarding again to add an agent and a starter task for this company.",
+      })
     : companies.length > 0
-      ? "Run onboarding again to create another company and seed its first agent."
-      : "Get started by creating a company and your first agent.";
+      ? t("app.onboardingRoute.createAnother.description", {
+          defaultValue: "Run onboarding again to create another company and seed its first agent.",
+        })
+      : t("app.onboardingRoute.createFirst.description", {
+          defaultValue: "Get started by creating a company and your first agent.",
+        });
 
   return (
     <div className="mx-auto max-w-xl py-10">
@@ -300,7 +310,9 @@ function OnboardingRoutePage() {
                 : openOnboarding()
             }
           >
-            {matchedCompany ? "Add Agent" : "Start Onboarding"}
+            {matchedCompany
+              ? t("app.onboardingRoute.addAgent.cta", { defaultValue: "Add Agent" })
+              : t("app.onboardingRoute.startCta", { defaultValue: "Start Onboarding" })}
           </Button>
         </div>
       </div>

--- a/ui/src/components/OnboardingWizard.tsx
+++ b/ui/src/components/OnboardingWizard.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState, useMemo } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import type { AdapterEnvironmentTestResult } from "@paperclipai/shared";
 import { useLocation, useNavigate, useParams } from "@/lib/router";
+import { useTranslation } from "@/i18n";
 import { useDialog } from "../context/DialogContext";
 import { useCompany } from "../context/CompanyContext";
 import { companiesApi } from "../api/companies";
@@ -100,6 +101,7 @@ function loadSavedState(): Record<string, unknown> | null {
 }
 
 export function OnboardingWizard() {
+  const { t } = useTranslation();
   const {
     onboardingOpen,
     onboardingOptions,
@@ -766,7 +768,9 @@ export function OnboardingWizard() {
             className="absolute top-4 left-4 z-10 rounded-sm p-1.5 text-muted-foreground/60 hover:text-foreground transition-colors"
           >
             <X className="h-5 w-5" />
-            <span className="sr-only">Close</span>
+            <span className="sr-only">
+              {t("app.onboardingWizard.close", { defaultValue: "Close" })}
+            </span>
           </button>
 
           {/* Step 0: Front Door — full-screen choice */}
@@ -798,7 +802,10 @@ export function OnboardingWizard() {
                     <button
                       key={s}
                       type="button"
-                      aria-label={`Step ${s}`}
+                      aria-label={t("app.onboardingWizard.stepLabel", {
+                        step: s,
+                        defaultValue: `Step ${s}`,
+                      })}
                       aria-current={s === step ? "step" : undefined}
                       disabled={!canJump}
                       onClick={() => canJump && setStep(s as Step)}
@@ -957,7 +964,7 @@ export function OnboardingWizard() {
                     className="text-[11px] text-muted-foreground hover:text-foreground transition-colors"
                     onClick={() => { setOnboardingPath(null); setStep(0); }}
                   >
-                    ← Back to start
+                    {t("app.onboardingWizard.backToStart", { defaultValue: "← Back to start" })}
                   </button>
                 </div>
               )}
@@ -970,9 +977,13 @@ export function OnboardingWizard() {
                       <Building2 className="h-5 w-5 text-muted-foreground" />
                     </div>
                     <div>
-                      <h3 className="font-medium">Name your company</h3>
+                      <h3 className="font-medium">
+                        {t("app.onboardingWizard.step1.title", { defaultValue: "Name your company" })}
+                      </h3>
                       <p className="text-xs text-muted-foreground">
-                        What should we call your company?
+                        {t("app.onboardingWizard.step1.description", {
+                          defaultValue: "What should we call your company?",
+                        })}
                       </p>
                     </div>
                   </div>
@@ -985,11 +996,11 @@ export function OnboardingWizard() {
                           : "text-muted-foreground group-focus-within:text-foreground"
                       )}
                     >
-                      Company name
+                      {t("app.onboardingWizard.step1.companyName", { defaultValue: "Company name" })}
                     </label>
                     <input
                       className="w-full rounded-md border border-border bg-transparent px-3 py-2 text-sm outline-none focus:ring-1 focus:ring-ring placeholder:text-muted-foreground/50"
-                      placeholder="Acme Corp"
+                      placeholder={t("app.onboardingWizard.step1.placeholder", { defaultValue: "Acme Corp" })}
                       value={companyName}
                       onChange={(e) => setCompanyName(e.target.value)}
                       onKeyDown={(e) => {
@@ -1006,7 +1017,7 @@ export function OnboardingWizard() {
                     className="text-[11px] text-muted-foreground hover:text-foreground transition-colors"
                     onClick={() => { setOnboardingPath(null); setStep(0); }}
                   >
-                    ← Back to start
+                    {t("app.onboardingWizard.backToStart", { defaultValue: "← Back to start" })}
                   </button>
                 </div>
               )}
@@ -1639,7 +1650,7 @@ export function OnboardingWizard() {
                       disabled={loading}
                     >
                       <ArrowLeft className="h-3.5 w-3.5 mr-1" />
-                      Back
+                      {t("app.onboardingWizard.navigation.back", { defaultValue: "Back" })}
                     </Button>
                   )}
                 </div>
@@ -1653,7 +1664,7 @@ export function OnboardingWizard() {
                         setStep(2);
                       }}
                     >
-                      Next
+                      {t("app.onboardingWizard.navigation.next", { defaultValue: "Next" })}
                       <ArrowRight className="h-3.5 w-3.5 ml-1" />
                     </Button>
                   )}
@@ -1677,7 +1688,7 @@ export function OnboardingWizard() {
                       disabled={!agentName.trim()}
                       onClick={() => setStep(4)}
                     >
-                      Next
+                      {t("app.onboardingWizard.navigation.next", { defaultValue: "Next" })}
                       <ArrowRight className="h-3.5 w-3.5 ml-1" />
                     </Button>
                   )}

--- a/ui/src/i18n/default-locale.test.ts
+++ b/ui/src/i18n/default-locale.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeSupportedLocale, resolveDefaultLocale } from "./default-locale";
+
+describe("default locale resolution", () => {
+  it("defaults new Paperclip sessions to Simplified Chinese", () => {
+    expect(resolveDefaultLocale()).toBe("zh-CN");
+  });
+
+  it("lets configured and stored locales override the built-in default", () => {
+    expect(
+      resolveDefaultLocale({
+        envLocale: "fr",
+        storedLocale: "ja",
+        navigatorLanguages: ["de"],
+      }),
+    ).toBe("fr");
+
+    expect(
+      resolveDefaultLocale({
+        storedLocale: "ja",
+        navigatorLanguages: ["de"],
+      }),
+    ).toBe("ja");
+
+    expect(resolveDefaultLocale({ navigatorLanguages: ["de-DE"] })).toBe("zh-CN");
+    expect(resolveDefaultLocale({ navigatorLanguages: ["de-DE"], defaultLocale: "unknown" })).toBe("de");
+  });
+
+  it("normalizes locale casing and separators", () => {
+    expect(normalizeSupportedLocale("ZH_cn")).toBe("zh-CN");
+    expect(normalizeSupportedLocale("pt-pt")).toBe("pt-PT");
+    expect(normalizeSupportedLocale("zh")).toBe("zh-CN");
+  });
+
+  it("falls back to English only when no default candidate is supported", () => {
+    expect(resolveDefaultLocale({ envLocale: "unknown", defaultLocale: "unknown" })).toBe("en");
+  });
+});

--- a/ui/src/i18n/default-locale.ts
+++ b/ui/src/i18n/default-locale.ts
@@ -1,0 +1,71 @@
+import { DEFAULT_LOCALE, FALLBACK_LOCALE, supportedLocales, type SupportedLocale } from "./locales";
+
+export const DEFAULT_LOCALE_STORAGE_KEY = "paperclip.ui.locale";
+
+type ResolveDefaultLocaleInput = {
+  envLocale?: string;
+  storedLocale?: string | null;
+  navigatorLanguages?: readonly string[];
+  defaultLocale?: SupportedLocale;
+};
+
+const supportedLocaleSet = new Set<string>(supportedLocales);
+
+function normalizeLocaleTag(locale: string) {
+  return locale.trim().replace(/_/g, "-");
+}
+
+export function normalizeSupportedLocale(locale: string | null | undefined): SupportedLocale | null {
+  if (!locale) return null;
+
+  const normalized = normalizeLocaleTag(locale);
+  if (!normalized) return null;
+  if (supportedLocaleSet.has(normalized)) return normalized as SupportedLocale;
+
+  const normalizedLower = normalized.toLowerCase();
+  const exactCaseInsensitive = supportedLocales.find((candidate) => candidate.toLowerCase() === normalizedLower);
+  if (exactCaseInsensitive) return exactCaseInsensitive as SupportedLocale;
+
+  const language = normalizedLower.split("-")[0];
+  const languageMatch = supportedLocales.find((candidate) => candidate.toLowerCase().split("-")[0] === language);
+  return languageMatch ? (languageMatch as SupportedLocale) : null;
+}
+
+export function resolveDefaultLocale({
+  envLocale,
+  storedLocale,
+  navigatorLanguages = [],
+  defaultLocale = DEFAULT_LOCALE,
+}: ResolveDefaultLocaleInput = {}): SupportedLocale {
+  for (const candidate of [envLocale, storedLocale, defaultLocale, ...navigatorLanguages]) {
+    const locale = normalizeSupportedLocale(candidate);
+    if (locale) return locale;
+  }
+
+  return FALLBACK_LOCALE as SupportedLocale;
+}
+
+function readStoredLocale() {
+  try {
+    return globalThis.localStorage?.getItem(DEFAULT_LOCALE_STORAGE_KEY) ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function readNavigatorLanguages() {
+  try {
+    const { languages, language } = globalThis.navigator ?? {};
+    return languages?.length ? languages : language ? [language] : [];
+  } catch {
+    return [];
+  }
+}
+
+export function resolveInitialLocale(): SupportedLocale {
+  return resolveDefaultLocale({
+    envLocale: import.meta.env.VITE_PAPERCLIP_DEFAULT_LOCALE,
+    storedLocale: readStoredLocale(),
+    navigatorLanguages: readNavigatorLanguages(),
+  });
+}

--- a/ui/src/i18n/index.ts
+++ b/ui/src/i18n/index.ts
@@ -1,12 +1,13 @@
 import i18n, { type InitOptions, type TOptions } from "i18next";
 import { initReactI18next, useTranslation as useReactI18nextTranslation } from "react-i18next";
 
-import { DEFAULT_LOCALE, i18nextResources, supportedLocales } from "./locales";
+import { resolveInitialLocale } from "./default-locale";
+import { FALLBACK_LOCALE, i18nextResources, supportedLocales } from "./locales";
 
 const i18nextOptions: InitOptions = {
   resources: i18nextResources,
-  lng: DEFAULT_LOCALE,
-  fallbackLng: DEFAULT_LOCALE,
+  lng: resolveInitialLocale(),
+  fallbackLng: FALLBACK_LOCALE,
   supportedLngs: supportedLocales,
   defaultNS: "translation",
   interpolation: { escapeValue: false },

--- a/ui/src/i18n/locale-validation.test.ts
+++ b/ui/src/i18n/locale-validation.test.ts
@@ -1,12 +1,15 @@
 import { describe, expect, it } from "vitest";
-import { t } from ".";
+import { i18n, t } from ".";
 import en from "./locales/en.json";
-import { localeMessages } from "./locales";
+import zhCN from "./locales/zh-CN.json";
+import { DEFAULT_LOCALE, localeMessages } from "./locales";
 import { validateLocaleMessages } from "./locale-validation";
 
 describe("locale validation", () => {
-  it("resolves English messages with key and default fallbacks", () => {
-    expect(t("app.noCompanies.title")).toBe(en.app.noCompanies.title);
+  it("resolves the default locale with key and default fallbacks", () => {
+    expect(DEFAULT_LOCALE).toBe("zh-CN");
+    expect(i18n.language).toBe("zh-CN");
+    expect(t("app.noCompanies.title")).toBe(zhCN.app.noCompanies.title);
     expect(t("app.missing", { defaultValue: "Fallback" })).toBe("Fallback");
     expect(t("app.missing")).toBe("app.missing");
   });

--- a/ui/src/i18n/locales.ts
+++ b/ui/src/i18n/locales.ts
@@ -2,7 +2,8 @@ import type { Resource } from "i18next";
 
 import { assertValidLocaleMessages } from "./locale-validation";
 
-export const DEFAULT_LOCALE = "en" as const;
+export const FALLBACK_LOCALE = "en" as const;
+export const DEFAULT_LOCALE = "zh-CN" as const;
 
 const localeModules = import.meta.glob("./locales/*.json", {
   eager: true,
@@ -19,6 +20,10 @@ export const localeMessages = Object.fromEntries(
   }),
 );
 
+if (!(FALLBACK_LOCALE in localeMessages)) {
+  throw new Error(`Missing fallback locale messages for ${FALLBACK_LOCALE}`);
+}
+
 if (!(DEFAULT_LOCALE in localeMessages)) {
   throw new Error(`Missing default locale messages for ${DEFAULT_LOCALE}`);
 }
@@ -32,10 +37,10 @@ for (const [locale, messages] of Object.entries(localeMessages)) {
   }
 }
 
-export const supportedLocales = Object.keys(localeMessages);
+export type SupportedLocale = string;
+
+export const supportedLocales = Object.keys(localeMessages) as SupportedLocale[];
 
 export const i18nextResources: Resource = Object.fromEntries(
   Object.entries(localeMessages).map(([locale, messages]) => [locale, { translation: messages }]),
 ) as Resource;
-
-export type SupportedLocale = keyof typeof localeMessages;

--- a/ui/src/i18n/locales/ar.json
+++ b/ui/src/i18n/locales/ar.json
@@ -4,6 +4,37 @@
       "title": "أنشئ شركتك الأولى",
       "description": "ابدأ بإنشاء شركة.",
       "newCompany": "شركة جديدة"
+    },
+    "onboardingRoute": {
+      "addAgent": {
+        "title": "Add another agent to {{companyName}}",
+        "description": "Run onboarding again to add an agent and a starter task for this company.",
+        "cta": "Add Agent"
+      },
+      "createAnother": {
+        "title": "Create another company",
+        "description": "Run onboarding again to create another company and seed its first agent."
+      },
+      "createFirst": {
+        "title": "Create your first company",
+        "description": "Get started by creating a company and your first agent."
+      },
+      "startCta": "Start Onboarding"
+    },
+    "onboardingWizard": {
+      "close": "Close",
+      "stepLabel": "Step {{step}}",
+      "backToStart": "← Back to start",
+      "step1": {
+        "title": "Name your company",
+        "description": "What should we call your company?",
+        "companyName": "Company name",
+        "placeholder": "Acme Corp"
+      },
+      "navigation": {
+        "back": "Back",
+        "next": "Next"
+      }
     }
   }
 }

--- a/ui/src/i18n/locales/bn.json
+++ b/ui/src/i18n/locales/bn.json
@@ -4,6 +4,37 @@
       "title": "আপনার প্রথম কোম্পানি তৈরি করুন",
       "description": "একটি কোম্পানি তৈরি করে শুরু করুন।",
       "newCompany": "নতুন কোম্পানি"
+    },
+    "onboardingRoute": {
+      "addAgent": {
+        "title": "Add another agent to {{companyName}}",
+        "description": "Run onboarding again to add an agent and a starter task for this company.",
+        "cta": "Add Agent"
+      },
+      "createAnother": {
+        "title": "Create another company",
+        "description": "Run onboarding again to create another company and seed its first agent."
+      },
+      "createFirst": {
+        "title": "Create your first company",
+        "description": "Get started by creating a company and your first agent."
+      },
+      "startCta": "Start Onboarding"
+    },
+    "onboardingWizard": {
+      "close": "Close",
+      "stepLabel": "Step {{step}}",
+      "backToStart": "← Back to start",
+      "step1": {
+        "title": "Name your company",
+        "description": "What should we call your company?",
+        "companyName": "Company name",
+        "placeholder": "Acme Corp"
+      },
+      "navigation": {
+        "back": "Back",
+        "next": "Next"
+      }
     }
   }
 }

--- a/ui/src/i18n/locales/cs.json
+++ b/ui/src/i18n/locales/cs.json
@@ -4,6 +4,37 @@
       "title": "Vytvořte svou první společnost",
       "description": "Začněte vytvořením společnosti.",
       "newCompany": "Nová společnost"
+    },
+    "onboardingRoute": {
+      "addAgent": {
+        "title": "Add another agent to {{companyName}}",
+        "description": "Run onboarding again to add an agent and a starter task for this company.",
+        "cta": "Add Agent"
+      },
+      "createAnother": {
+        "title": "Create another company",
+        "description": "Run onboarding again to create another company and seed its first agent."
+      },
+      "createFirst": {
+        "title": "Create your first company",
+        "description": "Get started by creating a company and your first agent."
+      },
+      "startCta": "Start Onboarding"
+    },
+    "onboardingWizard": {
+      "close": "Close",
+      "stepLabel": "Step {{step}}",
+      "backToStart": "← Back to start",
+      "step1": {
+        "title": "Name your company",
+        "description": "What should we call your company?",
+        "companyName": "Company name",
+        "placeholder": "Acme Corp"
+      },
+      "navigation": {
+        "back": "Back",
+        "next": "Next"
+      }
     }
   }
 }

--- a/ui/src/i18n/locales/da.json
+++ b/ui/src/i18n/locales/da.json
@@ -4,6 +4,37 @@
       "title": "Opret din første virksomhed",
       "description": "Kom i gang ved at oprette en virksomhed.",
       "newCompany": "Ny virksomhed"
+    },
+    "onboardingRoute": {
+      "addAgent": {
+        "title": "Add another agent to {{companyName}}",
+        "description": "Run onboarding again to add an agent and a starter task for this company.",
+        "cta": "Add Agent"
+      },
+      "createAnother": {
+        "title": "Create another company",
+        "description": "Run onboarding again to create another company and seed its first agent."
+      },
+      "createFirst": {
+        "title": "Create your first company",
+        "description": "Get started by creating a company and your first agent."
+      },
+      "startCta": "Start Onboarding"
+    },
+    "onboardingWizard": {
+      "close": "Close",
+      "stepLabel": "Step {{step}}",
+      "backToStart": "← Back to start",
+      "step1": {
+        "title": "Name your company",
+        "description": "What should we call your company?",
+        "companyName": "Company name",
+        "placeholder": "Acme Corp"
+      },
+      "navigation": {
+        "back": "Back",
+        "next": "Next"
+      }
     }
   }
 }

--- a/ui/src/i18n/locales/de.json
+++ b/ui/src/i18n/locales/de.json
@@ -4,6 +4,37 @@
       "title": "Erstellen Sie Ihr erstes Unternehmen",
       "description": "Beginnen Sie, indem Sie ein Unternehmen erstellen.",
       "newCompany": "Neues Unternehmen"
+    },
+    "onboardingRoute": {
+      "addAgent": {
+        "title": "Add another agent to {{companyName}}",
+        "description": "Run onboarding again to add an agent and a starter task for this company.",
+        "cta": "Add Agent"
+      },
+      "createAnother": {
+        "title": "Create another company",
+        "description": "Run onboarding again to create another company and seed its first agent."
+      },
+      "createFirst": {
+        "title": "Create your first company",
+        "description": "Get started by creating a company and your first agent."
+      },
+      "startCta": "Start Onboarding"
+    },
+    "onboardingWizard": {
+      "close": "Close",
+      "stepLabel": "Step {{step}}",
+      "backToStart": "← Back to start",
+      "step1": {
+        "title": "Name your company",
+        "description": "What should we call your company?",
+        "companyName": "Company name",
+        "placeholder": "Acme Corp"
+      },
+      "navigation": {
+        "back": "Back",
+        "next": "Next"
+      }
     }
   }
 }

--- a/ui/src/i18n/locales/el.json
+++ b/ui/src/i18n/locales/el.json
@@ -4,6 +4,37 @@
       "title": "Δημιουργήστε την πρώτη σας εταιρεία",
       "description": "Ξεκινήστε δημιουργώντας μια εταιρεία.",
       "newCompany": "Νέα εταιρεία"
+    },
+    "onboardingRoute": {
+      "addAgent": {
+        "title": "Add another agent to {{companyName}}",
+        "description": "Run onboarding again to add an agent and a starter task for this company.",
+        "cta": "Add Agent"
+      },
+      "createAnother": {
+        "title": "Create another company",
+        "description": "Run onboarding again to create another company and seed its first agent."
+      },
+      "createFirst": {
+        "title": "Create your first company",
+        "description": "Get started by creating a company and your first agent."
+      },
+      "startCta": "Start Onboarding"
+    },
+    "onboardingWizard": {
+      "close": "Close",
+      "stepLabel": "Step {{step}}",
+      "backToStart": "← Back to start",
+      "step1": {
+        "title": "Name your company",
+        "description": "What should we call your company?",
+        "companyName": "Company name",
+        "placeholder": "Acme Corp"
+      },
+      "navigation": {
+        "back": "Back",
+        "next": "Next"
+      }
     }
   }
 }

--- a/ui/src/i18n/locales/en.json
+++ b/ui/src/i18n/locales/en.json
@@ -4,6 +4,37 @@
       "title": "Create your first company",
       "description": "Get started by creating a company.",
       "newCompany": "New Company"
+    },
+    "onboardingRoute": {
+      "addAgent": {
+        "title": "Add another agent to {{companyName}}",
+        "description": "Run onboarding again to add an agent and a starter task for this company.",
+        "cta": "Add Agent"
+      },
+      "createAnother": {
+        "title": "Create another company",
+        "description": "Run onboarding again to create another company and seed its first agent."
+      },
+      "createFirst": {
+        "title": "Create your first company",
+        "description": "Get started by creating a company and your first agent."
+      },
+      "startCta": "Start Onboarding"
+    },
+    "onboardingWizard": {
+      "close": "Close",
+      "stepLabel": "Step {{step}}",
+      "backToStart": "← Back to start",
+      "step1": {
+        "title": "Name your company",
+        "description": "What should we call your company?",
+        "companyName": "Company name",
+        "placeholder": "Acme Corp"
+      },
+      "navigation": {
+        "back": "Back",
+        "next": "Next"
+      }
     }
   }
 }

--- a/ui/src/i18n/locales/es.json
+++ b/ui/src/i18n/locales/es.json
@@ -4,6 +4,37 @@
       "title": "Crea tu primera empresa",
       "description": "Comienza creando una empresa.",
       "newCompany": "Nueva empresa"
+    },
+    "onboardingRoute": {
+      "addAgent": {
+        "title": "Add another agent to {{companyName}}",
+        "description": "Run onboarding again to add an agent and a starter task for this company.",
+        "cta": "Add Agent"
+      },
+      "createAnother": {
+        "title": "Create another company",
+        "description": "Run onboarding again to create another company and seed its first agent."
+      },
+      "createFirst": {
+        "title": "Create your first company",
+        "description": "Get started by creating a company and your first agent."
+      },
+      "startCta": "Start Onboarding"
+    },
+    "onboardingWizard": {
+      "close": "Close",
+      "stepLabel": "Step {{step}}",
+      "backToStart": "← Back to start",
+      "step1": {
+        "title": "Name your company",
+        "description": "What should we call your company?",
+        "companyName": "Company name",
+        "placeholder": "Acme Corp"
+      },
+      "navigation": {
+        "back": "Back",
+        "next": "Next"
+      }
     }
   }
 }

--- a/ui/src/i18n/locales/fa.json
+++ b/ui/src/i18n/locales/fa.json
@@ -4,6 +4,37 @@
       "title": "اولین شرکت خود را ایجاد کنید",
       "description": "با ایجاد یک شرکت شروع کنید.",
       "newCompany": "شرکت جدید"
+    },
+    "onboardingRoute": {
+      "addAgent": {
+        "title": "Add another agent to {{companyName}}",
+        "description": "Run onboarding again to add an agent and a starter task for this company.",
+        "cta": "Add Agent"
+      },
+      "createAnother": {
+        "title": "Create another company",
+        "description": "Run onboarding again to create another company and seed its first agent."
+      },
+      "createFirst": {
+        "title": "Create your first company",
+        "description": "Get started by creating a company and your first agent."
+      },
+      "startCta": "Start Onboarding"
+    },
+    "onboardingWizard": {
+      "close": "Close",
+      "stepLabel": "Step {{step}}",
+      "backToStart": "← Back to start",
+      "step1": {
+        "title": "Name your company",
+        "description": "What should we call your company?",
+        "companyName": "Company name",
+        "placeholder": "Acme Corp"
+      },
+      "navigation": {
+        "back": "Back",
+        "next": "Next"
+      }
     }
   }
 }

--- a/ui/src/i18n/locales/fi.json
+++ b/ui/src/i18n/locales/fi.json
@@ -4,6 +4,37 @@
       "title": "Luo ensimmäinen yrityksesi",
       "description": "Aloita luomalla yritys.",
       "newCompany": "Uusi yritys"
+    },
+    "onboardingRoute": {
+      "addAgent": {
+        "title": "Add another agent to {{companyName}}",
+        "description": "Run onboarding again to add an agent and a starter task for this company.",
+        "cta": "Add Agent"
+      },
+      "createAnother": {
+        "title": "Create another company",
+        "description": "Run onboarding again to create another company and seed its first agent."
+      },
+      "createFirst": {
+        "title": "Create your first company",
+        "description": "Get started by creating a company and your first agent."
+      },
+      "startCta": "Start Onboarding"
+    },
+    "onboardingWizard": {
+      "close": "Close",
+      "stepLabel": "Step {{step}}",
+      "backToStart": "← Back to start",
+      "step1": {
+        "title": "Name your company",
+        "description": "What should we call your company?",
+        "companyName": "Company name",
+        "placeholder": "Acme Corp"
+      },
+      "navigation": {
+        "back": "Back",
+        "next": "Next"
+      }
     }
   }
 }

--- a/ui/src/i18n/locales/fil.json
+++ b/ui/src/i18n/locales/fil.json
@@ -4,6 +4,37 @@
       "title": "Gumawa ng iyong unang kumpanya",
       "description": "Magsimula sa paggawa ng kumpanya.",
       "newCompany": "Bagong Kumpanya"
+    },
+    "onboardingRoute": {
+      "addAgent": {
+        "title": "Add another agent to {{companyName}}",
+        "description": "Run onboarding again to add an agent and a starter task for this company.",
+        "cta": "Add Agent"
+      },
+      "createAnother": {
+        "title": "Create another company",
+        "description": "Run onboarding again to create another company and seed its first agent."
+      },
+      "createFirst": {
+        "title": "Create your first company",
+        "description": "Get started by creating a company and your first agent."
+      },
+      "startCta": "Start Onboarding"
+    },
+    "onboardingWizard": {
+      "close": "Close",
+      "stepLabel": "Step {{step}}",
+      "backToStart": "← Back to start",
+      "step1": {
+        "title": "Name your company",
+        "description": "What should we call your company?",
+        "companyName": "Company name",
+        "placeholder": "Acme Corp"
+      },
+      "navigation": {
+        "back": "Back",
+        "next": "Next"
+      }
     }
   }
 }

--- a/ui/src/i18n/locales/fr.json
+++ b/ui/src/i18n/locales/fr.json
@@ -4,6 +4,37 @@
       "title": "Créez votre première entreprise",
       "description": "Commencez par créer une entreprise.",
       "newCompany": "Nouvelle entreprise"
+    },
+    "onboardingRoute": {
+      "addAgent": {
+        "title": "Add another agent to {{companyName}}",
+        "description": "Run onboarding again to add an agent and a starter task for this company.",
+        "cta": "Add Agent"
+      },
+      "createAnother": {
+        "title": "Create another company",
+        "description": "Run onboarding again to create another company and seed its first agent."
+      },
+      "createFirst": {
+        "title": "Create your first company",
+        "description": "Get started by creating a company and your first agent."
+      },
+      "startCta": "Start Onboarding"
+    },
+    "onboardingWizard": {
+      "close": "Close",
+      "stepLabel": "Step {{step}}",
+      "backToStart": "← Back to start",
+      "step1": {
+        "title": "Name your company",
+        "description": "What should we call your company?",
+        "companyName": "Company name",
+        "placeholder": "Acme Corp"
+      },
+      "navigation": {
+        "back": "Back",
+        "next": "Next"
+      }
     }
   }
 }

--- a/ui/src/i18n/locales/he.json
+++ b/ui/src/i18n/locales/he.json
@@ -4,6 +4,37 @@
       "title": "צרו את החברה הראשונה שלכם",
       "description": "התחילו ביצירת חברה.",
       "newCompany": "חברה חדשה"
+    },
+    "onboardingRoute": {
+      "addAgent": {
+        "title": "Add another agent to {{companyName}}",
+        "description": "Run onboarding again to add an agent and a starter task for this company.",
+        "cta": "Add Agent"
+      },
+      "createAnother": {
+        "title": "Create another company",
+        "description": "Run onboarding again to create another company and seed its first agent."
+      },
+      "createFirst": {
+        "title": "Create your first company",
+        "description": "Get started by creating a company and your first agent."
+      },
+      "startCta": "Start Onboarding"
+    },
+    "onboardingWizard": {
+      "close": "Close",
+      "stepLabel": "Step {{step}}",
+      "backToStart": "← Back to start",
+      "step1": {
+        "title": "Name your company",
+        "description": "What should we call your company?",
+        "companyName": "Company name",
+        "placeholder": "Acme Corp"
+      },
+      "navigation": {
+        "back": "Back",
+        "next": "Next"
+      }
     }
   }
 }

--- a/ui/src/i18n/locales/hi.json
+++ b/ui/src/i18n/locales/hi.json
@@ -4,6 +4,37 @@
       "title": "अपनी पहली कंपनी बनाएं",
       "description": "कंपनी बनाकर शुरुआत करें.",
       "newCompany": "नई कंपनी"
+    },
+    "onboardingRoute": {
+      "addAgent": {
+        "title": "Add another agent to {{companyName}}",
+        "description": "Run onboarding again to add an agent and a starter task for this company.",
+        "cta": "Add Agent"
+      },
+      "createAnother": {
+        "title": "Create another company",
+        "description": "Run onboarding again to create another company and seed its first agent."
+      },
+      "createFirst": {
+        "title": "Create your first company",
+        "description": "Get started by creating a company and your first agent."
+      },
+      "startCta": "Start Onboarding"
+    },
+    "onboardingWizard": {
+      "close": "Close",
+      "stepLabel": "Step {{step}}",
+      "backToStart": "← Back to start",
+      "step1": {
+        "title": "Name your company",
+        "description": "What should we call your company?",
+        "companyName": "Company name",
+        "placeholder": "Acme Corp"
+      },
+      "navigation": {
+        "back": "Back",
+        "next": "Next"
+      }
     }
   }
 }

--- a/ui/src/i18n/locales/hu.json
+++ b/ui/src/i18n/locales/hu.json
@@ -4,6 +4,37 @@
       "title": "Hozza létre első vállalatát",
       "description": "Kezdje egy vállalat létrehozásával.",
       "newCompany": "Új vállalat"
+    },
+    "onboardingRoute": {
+      "addAgent": {
+        "title": "Add another agent to {{companyName}}",
+        "description": "Run onboarding again to add an agent and a starter task for this company.",
+        "cta": "Add Agent"
+      },
+      "createAnother": {
+        "title": "Create another company",
+        "description": "Run onboarding again to create another company and seed its first agent."
+      },
+      "createFirst": {
+        "title": "Create your first company",
+        "description": "Get started by creating a company and your first agent."
+      },
+      "startCta": "Start Onboarding"
+    },
+    "onboardingWizard": {
+      "close": "Close",
+      "stepLabel": "Step {{step}}",
+      "backToStart": "← Back to start",
+      "step1": {
+        "title": "Name your company",
+        "description": "What should we call your company?",
+        "companyName": "Company name",
+        "placeholder": "Acme Corp"
+      },
+      "navigation": {
+        "back": "Back",
+        "next": "Next"
+      }
     }
   }
 }

--- a/ui/src/i18n/locales/id.json
+++ b/ui/src/i18n/locales/id.json
@@ -4,6 +4,37 @@
       "title": "Buat perusahaan pertama Anda",
       "description": "Mulai dengan membuat perusahaan.",
       "newCompany": "Perusahaan Baru"
+    },
+    "onboardingRoute": {
+      "addAgent": {
+        "title": "Add another agent to {{companyName}}",
+        "description": "Run onboarding again to add an agent and a starter task for this company.",
+        "cta": "Add Agent"
+      },
+      "createAnother": {
+        "title": "Create another company",
+        "description": "Run onboarding again to create another company and seed its first agent."
+      },
+      "createFirst": {
+        "title": "Create your first company",
+        "description": "Get started by creating a company and your first agent."
+      },
+      "startCta": "Start Onboarding"
+    },
+    "onboardingWizard": {
+      "close": "Close",
+      "stepLabel": "Step {{step}}",
+      "backToStart": "← Back to start",
+      "step1": {
+        "title": "Name your company",
+        "description": "What should we call your company?",
+        "companyName": "Company name",
+        "placeholder": "Acme Corp"
+      },
+      "navigation": {
+        "back": "Back",
+        "next": "Next"
+      }
     }
   }
 }

--- a/ui/src/i18n/locales/it.json
+++ b/ui/src/i18n/locales/it.json
@@ -4,6 +4,37 @@
       "title": "Crea la tua prima azienda",
       "description": "Inizia creando un'azienda.",
       "newCompany": "Nuova azienda"
+    },
+    "onboardingRoute": {
+      "addAgent": {
+        "title": "Add another agent to {{companyName}}",
+        "description": "Run onboarding again to add an agent and a starter task for this company.",
+        "cta": "Add Agent"
+      },
+      "createAnother": {
+        "title": "Create another company",
+        "description": "Run onboarding again to create another company and seed its first agent."
+      },
+      "createFirst": {
+        "title": "Create your first company",
+        "description": "Get started by creating a company and your first agent."
+      },
+      "startCta": "Start Onboarding"
+    },
+    "onboardingWizard": {
+      "close": "Close",
+      "stepLabel": "Step {{step}}",
+      "backToStart": "← Back to start",
+      "step1": {
+        "title": "Name your company",
+        "description": "What should we call your company?",
+        "companyName": "Company name",
+        "placeholder": "Acme Corp"
+      },
+      "navigation": {
+        "back": "Back",
+        "next": "Next"
+      }
     }
   }
 }

--- a/ui/src/i18n/locales/ja.json
+++ b/ui/src/i18n/locales/ja.json
@@ -4,6 +4,37 @@
       "title": "最初の会社を作成",
       "description": "会社を作成して始めましょう。",
       "newCompany": "新しい会社"
+    },
+    "onboardingRoute": {
+      "addAgent": {
+        "title": "Add another agent to {{companyName}}",
+        "description": "Run onboarding again to add an agent and a starter task for this company.",
+        "cta": "Add Agent"
+      },
+      "createAnother": {
+        "title": "Create another company",
+        "description": "Run onboarding again to create another company and seed its first agent."
+      },
+      "createFirst": {
+        "title": "Create your first company",
+        "description": "Get started by creating a company and your first agent."
+      },
+      "startCta": "Start Onboarding"
+    },
+    "onboardingWizard": {
+      "close": "Close",
+      "stepLabel": "Step {{step}}",
+      "backToStart": "← Back to start",
+      "step1": {
+        "title": "Name your company",
+        "description": "What should we call your company?",
+        "companyName": "Company name",
+        "placeholder": "Acme Corp"
+      },
+      "navigation": {
+        "back": "Back",
+        "next": "Next"
+      }
     }
   }
 }

--- a/ui/src/i18n/locales/ko.json
+++ b/ui/src/i18n/locales/ko.json
@@ -4,6 +4,37 @@
       "title": "첫 회사를 만드세요",
       "description": "회사를 만들어 시작하세요.",
       "newCompany": "새 회사"
+    },
+    "onboardingRoute": {
+      "addAgent": {
+        "title": "Add another agent to {{companyName}}",
+        "description": "Run onboarding again to add an agent and a starter task for this company.",
+        "cta": "Add Agent"
+      },
+      "createAnother": {
+        "title": "Create another company",
+        "description": "Run onboarding again to create another company and seed its first agent."
+      },
+      "createFirst": {
+        "title": "Create your first company",
+        "description": "Get started by creating a company and your first agent."
+      },
+      "startCta": "Start Onboarding"
+    },
+    "onboardingWizard": {
+      "close": "Close",
+      "stepLabel": "Step {{step}}",
+      "backToStart": "← Back to start",
+      "step1": {
+        "title": "Name your company",
+        "description": "What should we call your company?",
+        "companyName": "Company name",
+        "placeholder": "Acme Corp"
+      },
+      "navigation": {
+        "back": "Back",
+        "next": "Next"
+      }
     }
   }
 }

--- a/ui/src/i18n/locales/mr.json
+++ b/ui/src/i18n/locales/mr.json
@@ -4,6 +4,37 @@
       "title": "तुमची पहिली कंपनी तयार करा",
       "description": "कंपनी तयार करून सुरुवात करा.",
       "newCompany": "नवीन कंपनी"
+    },
+    "onboardingRoute": {
+      "addAgent": {
+        "title": "Add another agent to {{companyName}}",
+        "description": "Run onboarding again to add an agent and a starter task for this company.",
+        "cta": "Add Agent"
+      },
+      "createAnother": {
+        "title": "Create another company",
+        "description": "Run onboarding again to create another company and seed its first agent."
+      },
+      "createFirst": {
+        "title": "Create your first company",
+        "description": "Get started by creating a company and your first agent."
+      },
+      "startCta": "Start Onboarding"
+    },
+    "onboardingWizard": {
+      "close": "Close",
+      "stepLabel": "Step {{step}}",
+      "backToStart": "← Back to start",
+      "step1": {
+        "title": "Name your company",
+        "description": "What should we call your company?",
+        "companyName": "Company name",
+        "placeholder": "Acme Corp"
+      },
+      "navigation": {
+        "back": "Back",
+        "next": "Next"
+      }
     }
   }
 }

--- a/ui/src/i18n/locales/ms.json
+++ b/ui/src/i18n/locales/ms.json
@@ -4,6 +4,37 @@
       "title": "Cipta syarikat pertama anda",
       "description": "Mulakan dengan mencipta syarikat.",
       "newCompany": "Syarikat Baharu"
+    },
+    "onboardingRoute": {
+      "addAgent": {
+        "title": "Add another agent to {{companyName}}",
+        "description": "Run onboarding again to add an agent and a starter task for this company.",
+        "cta": "Add Agent"
+      },
+      "createAnother": {
+        "title": "Create another company",
+        "description": "Run onboarding again to create another company and seed its first agent."
+      },
+      "createFirst": {
+        "title": "Create your first company",
+        "description": "Get started by creating a company and your first agent."
+      },
+      "startCta": "Start Onboarding"
+    },
+    "onboardingWizard": {
+      "close": "Close",
+      "stepLabel": "Step {{step}}",
+      "backToStart": "← Back to start",
+      "step1": {
+        "title": "Name your company",
+        "description": "What should we call your company?",
+        "companyName": "Company name",
+        "placeholder": "Acme Corp"
+      },
+      "navigation": {
+        "back": "Back",
+        "next": "Next"
+      }
     }
   }
 }

--- a/ui/src/i18n/locales/nb.json
+++ b/ui/src/i18n/locales/nb.json
@@ -4,6 +4,37 @@
       "title": "Opprett ditt første selskap",
       "description": "Kom i gang ved å opprette et selskap.",
       "newCompany": "Nytt selskap"
+    },
+    "onboardingRoute": {
+      "addAgent": {
+        "title": "Add another agent to {{companyName}}",
+        "description": "Run onboarding again to add an agent and a starter task for this company.",
+        "cta": "Add Agent"
+      },
+      "createAnother": {
+        "title": "Create another company",
+        "description": "Run onboarding again to create another company and seed its first agent."
+      },
+      "createFirst": {
+        "title": "Create your first company",
+        "description": "Get started by creating a company and your first agent."
+      },
+      "startCta": "Start Onboarding"
+    },
+    "onboardingWizard": {
+      "close": "Close",
+      "stepLabel": "Step {{step}}",
+      "backToStart": "← Back to start",
+      "step1": {
+        "title": "Name your company",
+        "description": "What should we call your company?",
+        "companyName": "Company name",
+        "placeholder": "Acme Corp"
+      },
+      "navigation": {
+        "back": "Back",
+        "next": "Next"
+      }
     }
   }
 }

--- a/ui/src/i18n/locales/nl.json
+++ b/ui/src/i18n/locales/nl.json
@@ -4,6 +4,37 @@
       "title": "Maak uw eerste bedrijf aan",
       "description": "Begin door een bedrijf aan te maken.",
       "newCompany": "Nieuw bedrijf"
+    },
+    "onboardingRoute": {
+      "addAgent": {
+        "title": "Add another agent to {{companyName}}",
+        "description": "Run onboarding again to add an agent and a starter task for this company.",
+        "cta": "Add Agent"
+      },
+      "createAnother": {
+        "title": "Create another company",
+        "description": "Run onboarding again to create another company and seed its first agent."
+      },
+      "createFirst": {
+        "title": "Create your first company",
+        "description": "Get started by creating a company and your first agent."
+      },
+      "startCta": "Start Onboarding"
+    },
+    "onboardingWizard": {
+      "close": "Close",
+      "stepLabel": "Step {{step}}",
+      "backToStart": "← Back to start",
+      "step1": {
+        "title": "Name your company",
+        "description": "What should we call your company?",
+        "companyName": "Company name",
+        "placeholder": "Acme Corp"
+      },
+      "navigation": {
+        "back": "Back",
+        "next": "Next"
+      }
     }
   }
 }

--- a/ui/src/i18n/locales/pa.json
+++ b/ui/src/i18n/locales/pa.json
@@ -4,6 +4,37 @@
       "title": "ਆਪਣੀ ਪਹਿਲੀ ਕੰਪਨੀ ਬਣਾਓ",
       "description": "ਕੰਪਨੀ ਬਣਾਕੇ ਸ਼ੁਰੂ ਕਰੋ।",
       "newCompany": "ਨਵੀਂ ਕੰਪਨੀ"
+    },
+    "onboardingRoute": {
+      "addAgent": {
+        "title": "Add another agent to {{companyName}}",
+        "description": "Run onboarding again to add an agent and a starter task for this company.",
+        "cta": "Add Agent"
+      },
+      "createAnother": {
+        "title": "Create another company",
+        "description": "Run onboarding again to create another company and seed its first agent."
+      },
+      "createFirst": {
+        "title": "Create your first company",
+        "description": "Get started by creating a company and your first agent."
+      },
+      "startCta": "Start Onboarding"
+    },
+    "onboardingWizard": {
+      "close": "Close",
+      "stepLabel": "Step {{step}}",
+      "backToStart": "← Back to start",
+      "step1": {
+        "title": "Name your company",
+        "description": "What should we call your company?",
+        "companyName": "Company name",
+        "placeholder": "Acme Corp"
+      },
+      "navigation": {
+        "back": "Back",
+        "next": "Next"
+      }
     }
   }
 }

--- a/ui/src/i18n/locales/pl.json
+++ b/ui/src/i18n/locales/pl.json
@@ -4,6 +4,37 @@
       "title": "Utwórz swoją pierwszą firmę",
       "description": "Zacznij od utworzenia firmy.",
       "newCompany": "Nowa firma"
+    },
+    "onboardingRoute": {
+      "addAgent": {
+        "title": "Add another agent to {{companyName}}",
+        "description": "Run onboarding again to add an agent and a starter task for this company.",
+        "cta": "Add Agent"
+      },
+      "createAnother": {
+        "title": "Create another company",
+        "description": "Run onboarding again to create another company and seed its first agent."
+      },
+      "createFirst": {
+        "title": "Create your first company",
+        "description": "Get started by creating a company and your first agent."
+      },
+      "startCta": "Start Onboarding"
+    },
+    "onboardingWizard": {
+      "close": "Close",
+      "stepLabel": "Step {{step}}",
+      "backToStart": "← Back to start",
+      "step1": {
+        "title": "Name your company",
+        "description": "What should we call your company?",
+        "companyName": "Company name",
+        "placeholder": "Acme Corp"
+      },
+      "navigation": {
+        "back": "Back",
+        "next": "Next"
+      }
     }
   }
 }

--- a/ui/src/i18n/locales/pt-BR.json
+++ b/ui/src/i18n/locales/pt-BR.json
@@ -4,6 +4,37 @@
       "title": "Crie sua primeira empresa",
       "description": "Comece criando uma empresa.",
       "newCompany": "Nova empresa"
+    },
+    "onboardingRoute": {
+      "addAgent": {
+        "title": "Add another agent to {{companyName}}",
+        "description": "Run onboarding again to add an agent and a starter task for this company.",
+        "cta": "Add Agent"
+      },
+      "createAnother": {
+        "title": "Create another company",
+        "description": "Run onboarding again to create another company and seed its first agent."
+      },
+      "createFirst": {
+        "title": "Create your first company",
+        "description": "Get started by creating a company and your first agent."
+      },
+      "startCta": "Start Onboarding"
+    },
+    "onboardingWizard": {
+      "close": "Close",
+      "stepLabel": "Step {{step}}",
+      "backToStart": "← Back to start",
+      "step1": {
+        "title": "Name your company",
+        "description": "What should we call your company?",
+        "companyName": "Company name",
+        "placeholder": "Acme Corp"
+      },
+      "navigation": {
+        "back": "Back",
+        "next": "Next"
+      }
     }
   }
 }

--- a/ui/src/i18n/locales/pt-PT.json
+++ b/ui/src/i18n/locales/pt-PT.json
@@ -4,6 +4,37 @@
       "title": "Crie a sua primeira empresa",
       "description": "Comece por criar uma empresa.",
       "newCompany": "Nova empresa"
+    },
+    "onboardingRoute": {
+      "addAgent": {
+        "title": "Add another agent to {{companyName}}",
+        "description": "Run onboarding again to add an agent and a starter task for this company.",
+        "cta": "Add Agent"
+      },
+      "createAnother": {
+        "title": "Create another company",
+        "description": "Run onboarding again to create another company and seed its first agent."
+      },
+      "createFirst": {
+        "title": "Create your first company",
+        "description": "Get started by creating a company and your first agent."
+      },
+      "startCta": "Start Onboarding"
+    },
+    "onboardingWizard": {
+      "close": "Close",
+      "stepLabel": "Step {{step}}",
+      "backToStart": "← Back to start",
+      "step1": {
+        "title": "Name your company",
+        "description": "What should we call your company?",
+        "companyName": "Company name",
+        "placeholder": "Acme Corp"
+      },
+      "navigation": {
+        "back": "Back",
+        "next": "Next"
+      }
     }
   }
 }

--- a/ui/src/i18n/locales/ro.json
+++ b/ui/src/i18n/locales/ro.json
@@ -4,6 +4,37 @@
       "title": "Creați prima companie",
       "description": "Începeți prin crearea unei companii.",
       "newCompany": "Companie nouă"
+    },
+    "onboardingRoute": {
+      "addAgent": {
+        "title": "Add another agent to {{companyName}}",
+        "description": "Run onboarding again to add an agent and a starter task for this company.",
+        "cta": "Add Agent"
+      },
+      "createAnother": {
+        "title": "Create another company",
+        "description": "Run onboarding again to create another company and seed its first agent."
+      },
+      "createFirst": {
+        "title": "Create your first company",
+        "description": "Get started by creating a company and your first agent."
+      },
+      "startCta": "Start Onboarding"
+    },
+    "onboardingWizard": {
+      "close": "Close",
+      "stepLabel": "Step {{step}}",
+      "backToStart": "← Back to start",
+      "step1": {
+        "title": "Name your company",
+        "description": "What should we call your company?",
+        "companyName": "Company name",
+        "placeholder": "Acme Corp"
+      },
+      "navigation": {
+        "back": "Back",
+        "next": "Next"
+      }
     }
   }
 }

--- a/ui/src/i18n/locales/ru.json
+++ b/ui/src/i18n/locales/ru.json
@@ -4,6 +4,37 @@
       "title": "Создайте свою первую компанию",
       "description": "Начните с создания компании.",
       "newCompany": "Новая компания"
+    },
+    "onboardingRoute": {
+      "addAgent": {
+        "title": "Add another agent to {{companyName}}",
+        "description": "Run onboarding again to add an agent and a starter task for this company.",
+        "cta": "Add Agent"
+      },
+      "createAnother": {
+        "title": "Create another company",
+        "description": "Run onboarding again to create another company and seed its first agent."
+      },
+      "createFirst": {
+        "title": "Create your first company",
+        "description": "Get started by creating a company and your first agent."
+      },
+      "startCta": "Start Onboarding"
+    },
+    "onboardingWizard": {
+      "close": "Close",
+      "stepLabel": "Step {{step}}",
+      "backToStart": "← Back to start",
+      "step1": {
+        "title": "Name your company",
+        "description": "What should we call your company?",
+        "companyName": "Company name",
+        "placeholder": "Acme Corp"
+      },
+      "navigation": {
+        "back": "Back",
+        "next": "Next"
+      }
     }
   }
 }

--- a/ui/src/i18n/locales/sv.json
+++ b/ui/src/i18n/locales/sv.json
@@ -4,6 +4,37 @@
       "title": "Skapa ditt första företag",
       "description": "Kom igång genom att skapa ett företag.",
       "newCompany": "Nytt företag"
+    },
+    "onboardingRoute": {
+      "addAgent": {
+        "title": "Add another agent to {{companyName}}",
+        "description": "Run onboarding again to add an agent and a starter task for this company.",
+        "cta": "Add Agent"
+      },
+      "createAnother": {
+        "title": "Create another company",
+        "description": "Run onboarding again to create another company and seed its first agent."
+      },
+      "createFirst": {
+        "title": "Create your first company",
+        "description": "Get started by creating a company and your first agent."
+      },
+      "startCta": "Start Onboarding"
+    },
+    "onboardingWizard": {
+      "close": "Close",
+      "stepLabel": "Step {{step}}",
+      "backToStart": "← Back to start",
+      "step1": {
+        "title": "Name your company",
+        "description": "What should we call your company?",
+        "companyName": "Company name",
+        "placeholder": "Acme Corp"
+      },
+      "navigation": {
+        "back": "Back",
+        "next": "Next"
+      }
     }
   }
 }

--- a/ui/src/i18n/locales/sw.json
+++ b/ui/src/i18n/locales/sw.json
@@ -4,6 +4,37 @@
       "title": "Unda kampuni yako ya kwanza",
       "description": "Anza kwa kuunda kampuni.",
       "newCompany": "Kampuni Mpya"
+    },
+    "onboardingRoute": {
+      "addAgent": {
+        "title": "Add another agent to {{companyName}}",
+        "description": "Run onboarding again to add an agent and a starter task for this company.",
+        "cta": "Add Agent"
+      },
+      "createAnother": {
+        "title": "Create another company",
+        "description": "Run onboarding again to create another company and seed its first agent."
+      },
+      "createFirst": {
+        "title": "Create your first company",
+        "description": "Get started by creating a company and your first agent."
+      },
+      "startCta": "Start Onboarding"
+    },
+    "onboardingWizard": {
+      "close": "Close",
+      "stepLabel": "Step {{step}}",
+      "backToStart": "← Back to start",
+      "step1": {
+        "title": "Name your company",
+        "description": "What should we call your company?",
+        "companyName": "Company name",
+        "placeholder": "Acme Corp"
+      },
+      "navigation": {
+        "back": "Back",
+        "next": "Next"
+      }
     }
   }
 }

--- a/ui/src/i18n/locales/ta.json
+++ b/ui/src/i18n/locales/ta.json
@@ -4,6 +4,37 @@
       "title": "உங்கள் முதல் நிறுவனத்தை உருவாக்குங்கள்",
       "description": "ஒரு நிறுவனத்தை உருவாக்கி தொடங்குங்கள்.",
       "newCompany": "புதிய நிறுவனம்"
+    },
+    "onboardingRoute": {
+      "addAgent": {
+        "title": "Add another agent to {{companyName}}",
+        "description": "Run onboarding again to add an agent and a starter task for this company.",
+        "cta": "Add Agent"
+      },
+      "createAnother": {
+        "title": "Create another company",
+        "description": "Run onboarding again to create another company and seed its first agent."
+      },
+      "createFirst": {
+        "title": "Create your first company",
+        "description": "Get started by creating a company and your first agent."
+      },
+      "startCta": "Start Onboarding"
+    },
+    "onboardingWizard": {
+      "close": "Close",
+      "stepLabel": "Step {{step}}",
+      "backToStart": "← Back to start",
+      "step1": {
+        "title": "Name your company",
+        "description": "What should we call your company?",
+        "companyName": "Company name",
+        "placeholder": "Acme Corp"
+      },
+      "navigation": {
+        "back": "Back",
+        "next": "Next"
+      }
     }
   }
 }

--- a/ui/src/i18n/locales/te.json
+++ b/ui/src/i18n/locales/te.json
@@ -4,6 +4,37 @@
       "title": "మీ మొదటి కంపెనీని సృష్టించండి",
       "description": "కంపెనీని సృష్టించడం ద్వారా ప్రారంభించండి.",
       "newCompany": "కొత్త కంపెనీ"
+    },
+    "onboardingRoute": {
+      "addAgent": {
+        "title": "Add another agent to {{companyName}}",
+        "description": "Run onboarding again to add an agent and a starter task for this company.",
+        "cta": "Add Agent"
+      },
+      "createAnother": {
+        "title": "Create another company",
+        "description": "Run onboarding again to create another company and seed its first agent."
+      },
+      "createFirst": {
+        "title": "Create your first company",
+        "description": "Get started by creating a company and your first agent."
+      },
+      "startCta": "Start Onboarding"
+    },
+    "onboardingWizard": {
+      "close": "Close",
+      "stepLabel": "Step {{step}}",
+      "backToStart": "← Back to start",
+      "step1": {
+        "title": "Name your company",
+        "description": "What should we call your company?",
+        "companyName": "Company name",
+        "placeholder": "Acme Corp"
+      },
+      "navigation": {
+        "back": "Back",
+        "next": "Next"
+      }
     }
   }
 }

--- a/ui/src/i18n/locales/th.json
+++ b/ui/src/i18n/locales/th.json
@@ -4,6 +4,37 @@
       "title": "สร้างบริษัทแรกของคุณ",
       "description": "เริ่มต้นด้วยการสร้างบริษัท",
       "newCompany": "บริษัทใหม่"
+    },
+    "onboardingRoute": {
+      "addAgent": {
+        "title": "Add another agent to {{companyName}}",
+        "description": "Run onboarding again to add an agent and a starter task for this company.",
+        "cta": "Add Agent"
+      },
+      "createAnother": {
+        "title": "Create another company",
+        "description": "Run onboarding again to create another company and seed its first agent."
+      },
+      "createFirst": {
+        "title": "Create your first company",
+        "description": "Get started by creating a company and your first agent."
+      },
+      "startCta": "Start Onboarding"
+    },
+    "onboardingWizard": {
+      "close": "Close",
+      "stepLabel": "Step {{step}}",
+      "backToStart": "← Back to start",
+      "step1": {
+        "title": "Name your company",
+        "description": "What should we call your company?",
+        "companyName": "Company name",
+        "placeholder": "Acme Corp"
+      },
+      "navigation": {
+        "back": "Back",
+        "next": "Next"
+      }
     }
   }
 }

--- a/ui/src/i18n/locales/tr.json
+++ b/ui/src/i18n/locales/tr.json
@@ -4,6 +4,37 @@
       "title": "İlk şirketinizi oluşturun",
       "description": "Bir şirket oluşturarak başlayın.",
       "newCompany": "Yeni Şirket"
+    },
+    "onboardingRoute": {
+      "addAgent": {
+        "title": "Add another agent to {{companyName}}",
+        "description": "Run onboarding again to add an agent and a starter task for this company.",
+        "cta": "Add Agent"
+      },
+      "createAnother": {
+        "title": "Create another company",
+        "description": "Run onboarding again to create another company and seed its first agent."
+      },
+      "createFirst": {
+        "title": "Create your first company",
+        "description": "Get started by creating a company and your first agent."
+      },
+      "startCta": "Start Onboarding"
+    },
+    "onboardingWizard": {
+      "close": "Close",
+      "stepLabel": "Step {{step}}",
+      "backToStart": "← Back to start",
+      "step1": {
+        "title": "Name your company",
+        "description": "What should we call your company?",
+        "companyName": "Company name",
+        "placeholder": "Acme Corp"
+      },
+      "navigation": {
+        "back": "Back",
+        "next": "Next"
+      }
     }
   }
 }

--- a/ui/src/i18n/locales/uk.json
+++ b/ui/src/i18n/locales/uk.json
@@ -4,6 +4,37 @@
       "title": "Створіть свою першу компанію",
       "description": "Почніть зі створення компанії.",
       "newCompany": "Нова компанія"
+    },
+    "onboardingRoute": {
+      "addAgent": {
+        "title": "Add another agent to {{companyName}}",
+        "description": "Run onboarding again to add an agent and a starter task for this company.",
+        "cta": "Add Agent"
+      },
+      "createAnother": {
+        "title": "Create another company",
+        "description": "Run onboarding again to create another company and seed its first agent."
+      },
+      "createFirst": {
+        "title": "Create your first company",
+        "description": "Get started by creating a company and your first agent."
+      },
+      "startCta": "Start Onboarding"
+    },
+    "onboardingWizard": {
+      "close": "Close",
+      "stepLabel": "Step {{step}}",
+      "backToStart": "← Back to start",
+      "step1": {
+        "title": "Name your company",
+        "description": "What should we call your company?",
+        "companyName": "Company name",
+        "placeholder": "Acme Corp"
+      },
+      "navigation": {
+        "back": "Back",
+        "next": "Next"
+      }
     }
   }
 }

--- a/ui/src/i18n/locales/ur.json
+++ b/ui/src/i18n/locales/ur.json
@@ -4,6 +4,37 @@
       "title": "اپنی پہلی کمپنی بنائیں",
       "description": "کمپنی بنا کر شروع کریں۔",
       "newCompany": "نئی کمپنی"
+    },
+    "onboardingRoute": {
+      "addAgent": {
+        "title": "Add another agent to {{companyName}}",
+        "description": "Run onboarding again to add an agent and a starter task for this company.",
+        "cta": "Add Agent"
+      },
+      "createAnother": {
+        "title": "Create another company",
+        "description": "Run onboarding again to create another company and seed its first agent."
+      },
+      "createFirst": {
+        "title": "Create your first company",
+        "description": "Get started by creating a company and your first agent."
+      },
+      "startCta": "Start Onboarding"
+    },
+    "onboardingWizard": {
+      "close": "Close",
+      "stepLabel": "Step {{step}}",
+      "backToStart": "← Back to start",
+      "step1": {
+        "title": "Name your company",
+        "description": "What should we call your company?",
+        "companyName": "Company name",
+        "placeholder": "Acme Corp"
+      },
+      "navigation": {
+        "back": "Back",
+        "next": "Next"
+      }
     }
   }
 }

--- a/ui/src/i18n/locales/vi.json
+++ b/ui/src/i18n/locales/vi.json
@@ -4,6 +4,37 @@
       "title": "Tạo công ty đầu tiên của bạn",
       "description": "Bắt đầu bằng cách tạo một công ty.",
       "newCompany": "Công ty mới"
+    },
+    "onboardingRoute": {
+      "addAgent": {
+        "title": "Add another agent to {{companyName}}",
+        "description": "Run onboarding again to add an agent and a starter task for this company.",
+        "cta": "Add Agent"
+      },
+      "createAnother": {
+        "title": "Create another company",
+        "description": "Run onboarding again to create another company and seed its first agent."
+      },
+      "createFirst": {
+        "title": "Create your first company",
+        "description": "Get started by creating a company and your first agent."
+      },
+      "startCta": "Start Onboarding"
+    },
+    "onboardingWizard": {
+      "close": "Close",
+      "stepLabel": "Step {{step}}",
+      "backToStart": "← Back to start",
+      "step1": {
+        "title": "Name your company",
+        "description": "What should we call your company?",
+        "companyName": "Company name",
+        "placeholder": "Acme Corp"
+      },
+      "navigation": {
+        "back": "Back",
+        "next": "Next"
+      }
     }
   }
 }

--- a/ui/src/i18n/locales/zh-CN.json
+++ b/ui/src/i18n/locales/zh-CN.json
@@ -4,6 +4,37 @@
       "title": "创建您的第一家公司",
       "description": "通过创建公司开始。",
       "newCompany": "新公司"
+    },
+    "onboardingRoute": {
+      "addAgent": {
+        "title": "为 {{companyName}} 添加另一个智能体",
+        "description": "再次运行入门流程，为这家公司添加智能体和起始任务。",
+        "cta": "添加智能体"
+      },
+      "createAnother": {
+        "title": "创建另一家公司",
+        "description": "再次运行入门流程，创建另一家公司并初始化第一个智能体。"
+      },
+      "createFirst": {
+        "title": "创建您的第一家公司",
+        "description": "创建公司和第一个智能体后即可开始。"
+      },
+      "startCta": "开始入门流程"
+    },
+    "onboardingWizard": {
+      "close": "关闭",
+      "stepLabel": "第 {{step}} 步",
+      "backToStart": "← 返回开始",
+      "step1": {
+        "title": "命名您的公司",
+        "description": "我们应该如何称呼您的公司？",
+        "companyName": "公司名称",
+        "placeholder": "示例公司"
+      },
+      "navigation": {
+        "back": "返回",
+        "next": "下一步"
+      }
     }
   }
 }

--- a/ui/src/i18n/locales/zh-TW.json
+++ b/ui/src/i18n/locales/zh-TW.json
@@ -4,6 +4,37 @@
       "title": "建立您的第一家公司",
       "description": "從建立公司開始。",
       "newCompany": "新公司"
+    },
+    "onboardingRoute": {
+      "addAgent": {
+        "title": "為 {{companyName}} 新增另一個智慧體",
+        "description": "再次執行入門流程，為這家公司新增智慧體和起始任務。",
+        "cta": "新增智慧體"
+      },
+      "createAnother": {
+        "title": "建立另一家公司",
+        "description": "再次執行入門流程，建立另一家公司並初始化第一個智慧體。"
+      },
+      "createFirst": {
+        "title": "建立您的第一家公司",
+        "description": "建立公司和第一個智慧體後即可開始。"
+      },
+      "startCta": "開始入門流程"
+    },
+    "onboardingWizard": {
+      "close": "關閉",
+      "stepLabel": "第 {{step}} 步",
+      "backToStart": "← 返回開始",
+      "step1": {
+        "title": "命名您的公司",
+        "description": "我們應該如何稱呼您的公司？",
+        "companyName": "公司名稱",
+        "placeholder": "範例公司"
+      },
+      "navigation": {
+        "back": "返回",
+        "next": "下一步"
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary

- default the Paperclip UI locale to `zh-CN` while keeping English as the i18next fallback locale
- add deterministic locale resolution with env/localStorage override support and focused unit coverage
- wire the companyless onboarding route and first onboarding step through i18n so new users see Simplified Chinese by default
- add `zh-CN` / `zh-TW` translations for the new onboarding keys and English fallback strings for the other registered locale files so locale validation stays strict
- update default onboarding agent templates and `paperclip-create-agent` role templates so agents report in Simplified Chinese unless the board/company asks for another language

## Context

This is a small incremental follow-up to the existing i18n foundation rather than a full UI string extraction. It is intended to make the first-run experience and default agent behavior usable for Chinese-speaking operators while preserving English fallback behavior for missing UI keys.

Refs #960, #1544, #2652, and the broader full-UI i18n effort in #1236.

## Verification

- `pnpm --filter @paperclipai/ui exec vitest run src/i18n/default-locale.test.ts src/i18n/locale-validation.test.ts`
- `pnpm --filter @paperclipai/ui typecheck`
- Browser smoke with Vite dev server + mocked `/api/health` and `/api/companies`: confirmed onboarding first screen renders `关闭`, `命名您的公司`, `公司名称`, `← 返回开始`, and `下一步`.
