### PR TITLE
fix(claude-local): detect unknown-session errors when CLI output is unparseable

### DIFF
--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -1011,17 +1011,27 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
 
   try {
     const initial = await runAttempt(sessionId ?? null);
+    // When the CLI fails without parseable JSON output (e.g. `--resume` of a session id
+    // that no longer exists in the session store), the unknown-session signature still
+    // appears in the raw stdout/stderr text. Without this fallback check the failure is
+    // classified as transient upstream and retried with the same dead session id forever,
+    // instead of retrying once with a fresh session.
     const sessionErrorKind =
       sessionId &&
       !initial.proc.timedOut &&
-      (initial.proc.exitCode ?? 0) !== 0 &&
-      initial.parsed
-        ? isClaudeUnknownSessionError(initial.parsed)
+      (initial.proc.exitCode ?? 0) !== 0
+        ? initial.parsed
+          ? isClaudeUnknownSessionError(initial.parsed)
+            ? "unknown"
+            : isClaudePoisonedPreviousMessageIdError(initial.parsed)
+            ? "poisoned"
+            : isClaudeImageProcessingError(initial.parsed)
+            ? "image"
+            : null
+          : isClaudeUnknownSessionError({
+              result: [initial.proc.stdout, initial.proc.stderr].filter(Boolean).join("\n"),
+            })
           ? "unknown"
-          : isClaudePoisonedPreviousMessageIdError(initial.parsed)
-          ? "poisoned"
-          : isClaudeImageProcessingError(initial.parsed)
-          ? "image"
           : null
         : null;
 

--- a/packages/adapters/claude-local/src/server/parse.test.ts
+++ b/packages/adapters/claude-local/src/server/parse.test.ts
@@ -228,6 +228,21 @@ describe("isClaudeUnknownSessionError", () => {
     ).toBe(true);
   });
 
+  it("detects the unknown-session signature fed as raw CLI text (unparseable-output fallback)", () => {
+    // execute.ts falls back to this shape when the CLI exits non-zero without
+    // parseable stream-JSON: raw stdout/stderr joined into `result`.
+    expect(
+      isClaudeUnknownSessionError({
+        result: "No conversation found with session ID: 59c33218-29c7-46df-a865-ef835bbe6894",
+      }),
+    ).toBe(true);
+    expect(
+      isClaudeUnknownSessionError({
+        result: "API Error: 529 upstream overloaded",
+      }),
+    ).toBe(false);
+  });
+
   it("detects 'session ... not found' style errors", () => {
     expect(
       isClaudeUnknownSessionError({


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The claude-local adapter resumes each agent's prior CLI session by id, and classifies failed runs so the server can decide between retrying and recovering
> - When `claude --resume <id>` fails because the session id no longer exists in the CLI's session store (`~/.claude/projects/<escaped-cwd>/`), the CLI can exit non-zero **without parseable stream-JSON**; the unknown-session check only runs on parsed output, so these failures fall through to `isClaudeTransientUpstreamError`
> - The permanent failure is then classified `claude_transient_upstream` and retried with the same dead session id indefinitely — the fresh-session retry that upstream already built for exactly this error never engages
> - Any event that changes an agent's execution cwd (the session store key) makes this systemic: every stored session id for that agent dies at once and every wake converts to a transient-retry
> - This PR runs the existing `isClaudeUnknownSessionError` signature match against the raw stdout/stderr text in the unparseable-output branch, so the failure takes the existing retry-with-fresh-session path
> - The benefit is that dead-session failures self-heal in one retry instead of retry-storming

## Linked Issues or Issue Description

Fixes #9012

No pre-existing issue found (searched: "no conversation found", "unknown session transient", "session resume retry") — filed #9012 for this bug. Summary:

**What happened:** In a 16-agent deployment, the repository (each agent's execution cwd) was moved to a new path. The Claude CLI keys its session store by escaped cwd, so every stored `session_id` became unresumable. Each wake failed in seconds with `No conversation found with session ID: <uuid>` on raw stderr (no parseable stream-JSON), was classified `claude_transient_upstream`, and was re-queued. Daily run volume went from ~100 to 765 over 48 hours; 317 of 1,216 runs in that window were these failures.

**Expected:** the unknown-session signature should trigger the existing "retrying with a fresh session" path (`execute.ts` already logs and handles this for parsed output) regardless of whether the CLI output parsed.

**Reproduction:** give a claude-local agent a persisted session id, delete (or move) the matching `~/.claude/projects/<escaped-cwd>/<session-id>.jsonl`, and wake the agent. Before this change the run fails `claude_transient_upstream` and retries with the same id; after, it retries once with a fresh session and succeeds.

## What Changed

- `packages/adapters/claude-local/src/server/execute.ts`: in the unparseable-output branch of the post-run session-error check, feed the raw `stdout`/`stderr` text through the existing `isClaudeUnknownSessionError` matcher (shaped as `{ result }`), so `sessionErrorKind` becomes `"unknown"` and the existing fresh-session retry runs. Parsed-output behavior is unchanged; poisoned/image detection still requires parsed output.
- `packages/adapters/claude-local/src/server/parse.test.ts`: test documenting the raw-text contract (matches the real CLI wording `No conversation found with session ID: <uuid>`, and does not match unrelated upstream errors).

## Verification

- `pnpm -F @paperclipai/adapter-claude-local exec vitest run src/server/parse.test.ts` → 33 passed (1 new).
- Production validation (deployed the same logic as a dist patch on 2026.626.0): before — 212 `claude_transient_upstream` runs in 48h retrying dead session ids; after — 0 dead-session failures, agents resumed normal cadence.

## Risks

Low. The new branch only executes when the run already failed AND output was unparseable AND the strict unknown-session regex matches the raw text; every other such failure classifies exactly as before. The recovery it triggers (fresh-session retry, `clearSessionOnMissingSession`) is the same code path used for the parsed-output case today.

## Model Used

Claude Fable 5 (`claude-fable-5`), extended thinking, agentic tool use via Claude Code. Human-reviewed before submission.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
