### PR TITLE
fix(codex-local): default retry backoff for usage-limit errors without a reset clock

### DIFF
--- a/packages/adapters/codex-local/src/server/parse.test.ts
+++ b/packages/adapters/codex-local/src/server/parse.test.ts
@@ -132,12 +132,12 @@ describe("isCodexTransientUpstreamError", () => {
     );
   });
 
-  it("prefers the explicit reset clock over the default backoff when both are present", () => {
-    const errorMessage = "You've hit your usage limit for GPT-5.3-Codex-Spark. Switch to another model now, or try again at 11:31 PM.";
-    const now = new Date(2026, 3, 22, 22, 29, 2);
+  it("falls back to the default backoff when the model-specific variant carries an unparseable clock", () => {
+    const errorMessage = "You've hit your usage limit for GPT-5.3-Codex-Spark. Switch to another model now, or try again at half past nine.";
+    const now = new Date("2026-07-04T17:33:00.000Z");
 
-    expect(extractCodexRetryNotBefore({ errorMessage }, now)?.getTime()).toBe(
-      new Date(2026, 3, 22, 23, 31, 0, 0).getTime(),
+    expect(extractCodexRetryNotBefore({ errorMessage }, now)?.toISOString()).toBe(
+      "2026-07-04T18:03:00.000Z",
     );
   });
 

--- a/packages/adapters/codex-local/src/server/parse.test.ts
+++ b/packages/adapters/codex-local/src/server/parse.test.ts
@@ -122,6 +122,29 @@ describe("isCodexTransientUpstreamError", () => {
     );
   });
 
+  it("classifies generic usage-limit variants without a reset clock and applies the default backoff", () => {
+    const errorMessage = "You've hit your usage limit. Upgrade to Pro (https://chatgpt.com/upgrade) or try again later.";
+    const now = new Date("2026-07-04T17:33:00.000Z");
+
+    expect(isCodexTransientUpstreamError({ errorMessage })).toBe(true);
+    expect(extractCodexRetryNotBefore({ errorMessage }, now)?.toISOString()).toBe(
+      "2026-07-04T18:03:00.000Z",
+    );
+  });
+
+  it("prefers the explicit reset clock over the default backoff when both are present", () => {
+    const errorMessage = "You've hit your usage limit for GPT-5.3-Codex-Spark. Switch to another model now, or try again at 11:31 PM.";
+    const now = new Date(2026, 3, 22, 22, 29, 2);
+
+    expect(extractCodexRetryNotBefore({ errorMessage }, now)?.getTime()).toBe(
+      new Date(2026, 3, 22, 23, 31, 0, 0).getTime(),
+    );
+  });
+
+  it("does not apply the usage-limit backoff to unrelated deterministic errors", () => {
+    expect(extractCodexRetryNotBefore({ stderr: "Error: ENOENT no such file or directory" })).toBe(null);
+  });
+
   it("does not classify deterministic compaction errors as transient", () => {
     expect(
       isCodexTransientUpstreamError({

--- a/packages/adapters/codex-local/src/server/parse.ts
+++ b/packages/adapters/codex-local/src/server/parse.ts
@@ -10,6 +10,11 @@ const CODEX_TRANSIENT_UPSTREAM_RE =
 const CODEX_REMOTE_COMPACTION_RE = /remote\s+compact\s+task/i;
 const CODEX_USAGE_LIMIT_RE =
   /you(?:'|’)ve hit your usage limit for .+\.\s+switch to another model now,\s+or try again at\s+([^.!\n]+)(?:[.!]|\n|$)/i;
+// Generic usage-limit variants ("You've hit your usage limit. Upgrade to Pro …") carry
+// no reset clock. Without a retryNotBefore they fall through to a generic adapter
+// failure and wake-driven retries hammer a quota that cannot succeed until it resets.
+const CODEX_USAGE_LIMIT_GENERIC_RE = /you(?:'|’)ve hit your usage limit/i;
+const CODEX_USAGE_LIMIT_DEFAULT_BACKOFF_MS = 30 * 60 * 1000;
 
 export function parseCodexJsonl(stdout: string) {
   let sessionId: string | null = null;
@@ -241,8 +246,14 @@ export function extractCodexRetryNotBefore(input: {
 }, now = new Date()): Date | null {
   const haystack = buildCodexErrorHaystack(input);
   const usageLimitMatch = haystack.match(CODEX_USAGE_LIMIT_RE);
-  if (!usageLimitMatch) return null;
-  return parseLocalClockTime(usageLimitMatch[1] ?? "", now);
+  if (usageLimitMatch) {
+    const explicit = parseLocalClockTime(usageLimitMatch[1] ?? "", now);
+    if (explicit) return explicit;
+  }
+  if (CODEX_USAGE_LIMIT_GENERIC_RE.test(haystack)) {
+    return new Date(now.getTime() + CODEX_USAGE_LIMIT_DEFAULT_BACKOFF_MS);
+  }
+  return null;
 }
 
 export function isCodexTransientUpstreamError(input: {


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The codex-local adapter classifies failed runs; `extractCodexRetryNotBefore` recognizes ChatGPT usage-limit messages and returns the reset time so the transient-upstream machinery can space retries
> - The matcher only recognizes the variant that names a model and reset clock ("You've hit your usage limit for X. Switch to another model now, or try again at 11:31 PM.")
> - ChatGPT also emits a generic variant with no reset time ("You've hit your usage limit. Upgrade to Pro …"); this falls through — not transient, no retryNotBefore — and surfaces as a generic adapter failure
> - Issue-driven wakes (`issue_assigned`, `issue_continuation_needed`, `missing_issue_comment`) then hot-retry a quota that cannot succeed until it resets, each attempt failing within seconds
> - This PR detects the generic usage-limit wording and returns a default 30-minute `retryNotBefore`, engaging the existing transient classification and retry spacing; an explicit reset clock still wins when present
> - The benefit is that quota-exhausted codex agents back off instead of crash-looping the wake queue

## Linked Issues or Issue Description

No existing issue found (searched: "usage limit retry codex", "codex quota", "transient_upstream retry"). Bug description per the bug template:

Refs #8692 — the claude-local sibling of this bug family (session-limit wording not classified, tight retry loop); this PR fixes the codex-local usage-limit variant.

**What happened:** a codex-local agent whose ChatGPT account had exhausted its usage limit was re-woken by issue wakes and failed within ~3 seconds each time (8 runs in 2 minutes observed), because the error text "You've hit your usage limit. Upgrade to Pro (https://chatgpt.com/upgrade) …" matches neither `CODEX_USAGE_LIMIT_RE` (which requires "for <model> … try again at <time>") nor `CODEX_TRANSIENT_UPSTREAM_RE`'s scoped shapes.

**Expected:** quota exhaustion is transient-until-reset; the run should carry a `retryNotBefore` so retries are spaced, exactly as the recognized usage-limit variant already behaves.

## What Changed

- `packages/adapters/codex-local/src/server/parse.ts`: `extractCodexRetryNotBefore` now falls back to a generic usage-limit regex when the model-specific variant is absent or its clock text does not parse, returning `now + 30 minutes`. The explicit reset clock, when present and parseable, is still preferred.
- `packages/adapters/codex-local/src/server/parse.test.ts`: cases for the generic variant (transient + default backoff), explicit-clock precedence, and non-application to unrelated deterministic errors.

## Verification

- `pnpm -F @paperclipai/adapter-codex-local exec vitest run src/server/parse.test.ts` → 12 passed (3 new).
- Production validation (same logic deployed as a dist patch on 2026.626.0, against a genuinely quota-exhausted account): the next wake produced one run classified `codex_transient_upstream` with `retryNotBefore` 30 minutes out, and the ~3-second re-wake loop stopped.

## Risks

Low. The fallback only fires when the error text contains "you've hit your usage limit", which is currently not classified at all — no existing classification changes. The 30-minute default is conservative for a quota window; when ChatGPT includes an explicit reset time the existing parse still takes precedence.

## Model Used

Claude Fable 5 (`claude-fable-5`), extended thinking, agentic tool use via Claude Code. Human-reviewed before submission.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

