### PR TITLE
fix(heartbeat): promote parked scheduled retries when an on-demand wake coalesces into them

### DIFF
--- a/server/src/__tests__/heartbeat-on-demand-wake-promotes-retry.test.ts
+++ b/server/src/__tests__/heartbeat-on-demand-wake-promotes-retry.test.ts
@@ -1,0 +1,345 @@
+import { randomUUID } from "node:crypto";
+import { and, eq } from "drizzle-orm";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import {
+  activityLog,
+  agentRuntimeState,
+  agentTaskSessions,
+  agentWakeupRequests,
+  agents,
+  budgetPolicies,
+  companies,
+  companySkills,
+  createDb,
+  executionWorkspaces,
+  heartbeatRunEvents,
+  heartbeatRuns,
+  issueComments,
+  issues,
+  workspaceOperations,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import { heartbeatService } from "../services/heartbeat.ts";
+
+const adapterExecute = vi.hoisted(() => vi.fn(async () => ({
+  exitCode: 0,
+  signal: null,
+  timedOut: false,
+  sessionParams: { sessionId: "fresh-session" },
+  sessionDisplayId: "fresh-session",
+  summary: "On-demand wake promotion test run.",
+  provider: "test",
+  model: "test-model",
+})));
+
+vi.mock("../adapters/index.js", () => ({
+  getServerAdapter: () => ({
+    type: "codex_local",
+    execute: adapterExecute,
+    supportsLocalAgentJwt: false,
+  }),
+  findActiveServerAdapter: () => ({
+    type: "codex_local",
+    execute: adapterExecute,
+    supportsLocalAgentJwt: false,
+  }),
+  listAdapterModelProfiles: async () => [],
+  runningProcesses: new Map(),
+}));
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping embedded Postgres on-demand wake promotion tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+describeEmbeddedPostgres("on-demand wake promotes parked scheduled retries", () => {
+  let db!: ReturnType<typeof createDb>;
+  let heartbeat!: ReturnType<typeof heartbeatService>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-heartbeat-on-demand-promote-");
+    db = createDb(tempDb.connectionString);
+    heartbeat = heartbeatService(db);
+  }, 20_000);
+
+  afterEach(async () => {
+    adapterExecute.mockClear();
+    let idlePolls = 0;
+    for (let attempt = 0; attempt < 100; attempt += 1) {
+      const runs = await db
+        .select({ status: heartbeatRuns.status })
+        .from(heartbeatRuns);
+      const hasActiveRun = runs.some((run) => run.status === "queued" || run.status === "running");
+      if (!hasActiveRun) {
+        idlePolls += 1;
+        if (idlePolls >= 5) break;
+      } else {
+        idlePolls = 0;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+    await db.delete(agentTaskSessions);
+    await db.delete(executionWorkspaces);
+    await db.delete(issueComments);
+    await db.delete(issues);
+    for (let attempt = 0; attempt < 5; attempt += 1) {
+      await db.delete(activityLog);
+      await db.delete(heartbeatRunEvents);
+      try {
+        await db.delete(heartbeatRuns);
+        break;
+      } catch (error) {
+        if (attempt === 4) throw error;
+        await new Promise((resolve) => setTimeout(resolve, 50));
+      }
+    }
+    await db.delete(agentWakeupRequests);
+    await db.delete(agentRuntimeState);
+    await db.delete(budgetPolicies);
+    await db.delete(agents);
+    await db.delete(workspaceOperations);
+    await db.delete(companySkills);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  async function seedParkedRetry() {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const sourceRunId = randomUUID();
+    const now = new Date();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "CodexCoder",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {
+        heartbeat: {
+          wakeOnDemand: true,
+          maxConcurrentRuns: 1,
+        },
+      },
+      permissions: {},
+    });
+
+    // Agent-scoped failure (no issueId): e.g. a provider quota error on a
+    // timer heartbeat. The bounded retry parks a scheduled_retry run whose
+    // backoff outlives the underlying problem once the operator fixes it.
+    await db.insert(heartbeatRuns).values({
+      id: sourceRunId,
+      companyId,
+      agentId,
+      invocationSource: "automation",
+      triggerDetail: "system",
+      status: "failed",
+      error: "You've hit your usage limit.",
+      errorCode: "codex_transient_upstream",
+      finishedAt: now,
+      resultJson: { errorFamily: "transient_upstream" },
+      contextSnapshot: { wakeReason: "heartbeat" },
+      updatedAt: now,
+      createdAt: now,
+    });
+
+    const scheduled = await heartbeat.scheduleBoundedRetry(sourceRunId, {
+      now,
+      random: () => 0.5,
+    });
+    expect(scheduled.outcome).toBe("scheduled");
+    if (scheduled.outcome !== "scheduled") throw new Error("expected scheduled retry");
+    expect(scheduled.dueAt.getTime()).toBeGreaterThan(Date.now());
+
+    return { companyId, agentId, retryRunId: scheduled.run.id };
+  }
+
+  it("keeps the retry parked when an automation wake coalesces into it", async () => {
+    const { agentId, retryRunId } = await seedParkedRetry();
+
+    const returned = await heartbeat.wakeup(agentId, {
+      source: "automation",
+      triggerDetail: "system",
+    });
+    expect(returned?.id).toBe(retryRunId);
+
+    const parked = await db
+      .select({ status: heartbeatRuns.status })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, retryRunId))
+      .then((rows) => rows[0] ?? null);
+    expect(parked?.status).toBe("scheduled_retry");
+    expect(adapterExecute).not.toHaveBeenCalled();
+  });
+
+  it("promotes the parked retry when an on-demand wake coalesces into it", async () => {
+    const { agentId, retryRunId } = await seedParkedRetry();
+
+    const returned = await heartbeat.wakeup(agentId, {
+      source: "on_demand",
+      triggerDetail: "manual",
+      requestedByActorType: "user",
+      requestedByActorId: "operator-1",
+    });
+    expect(returned?.id).toBe(retryRunId);
+    expect(returned?.status).not.toBe("scheduled_retry");
+
+    const wakeupRow = await db
+      .select({
+        status: agentWakeupRequests.status,
+        runId: agentWakeupRequests.runId,
+      })
+      .from(agentWakeupRequests)
+      .where(
+        and(
+          eq(agentWakeupRequests.agentId, agentId),
+          eq(agentWakeupRequests.source, "on_demand"),
+        ),
+      )
+      .then((rows) => rows[0] ?? null);
+    expect(wakeupRow).toMatchObject({ status: "coalesced", runId: retryRunId });
+
+    // The run leaves scheduled_retry immediately and executes to completion.
+    await vi.waitFor(async () => {
+      const latest = await db
+        .select({ status: heartbeatRuns.status })
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.id, retryRunId))
+        .then((rows) => rows[0] ?? null);
+      expect(latest?.status).toBe("succeeded");
+    }, { timeout: 10_000 });
+    expect(adapterExecute).toHaveBeenCalledTimes(1);
+
+    const promotionEvent = await db
+      .select({ message: heartbeatRunEvents.message })
+      .from(heartbeatRunEvents)
+      .where(eq(heartbeatRunEvents.runId, retryRunId))
+      .then((rows) => rows.map((row) => row.message));
+    expect(promotionEvent).toContain("Scheduled retry was promoted by an on-demand wake");
+  });
+
+  it("promotes an issue-scoped parked retry when an on-demand wake coalesces into it", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const issueId = randomUUID();
+    const sourceRunId = randomUUID();
+    const now = new Date();
+    const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "CodexCoder",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {
+        heartbeat: {
+          wakeOnDemand: true,
+          maxConcurrentRuns: 1,
+        },
+      },
+      permissions: {},
+    });
+
+    await db.insert(heartbeatRuns).values({
+      id: sourceRunId,
+      companyId,
+      agentId,
+      invocationSource: "assignment",
+      triggerDetail: "system",
+      status: "failed",
+      error: "You've hit your usage limit.",
+      errorCode: "codex_transient_upstream",
+      finishedAt: now,
+      resultJson: { errorFamily: "transient_upstream" },
+      contextSnapshot: { issueId, wakeReason: "issue_assigned" },
+      updatedAt: now,
+      createdAt: now,
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Retry after quota renewal",
+      status: "in_progress",
+      priority: "medium",
+      assigneeAgentId: agentId,
+      executionRunId: sourceRunId,
+      executionAgentNameKey: "codexcoder",
+      executionLockedAt: now,
+      issueNumber: 1,
+      identifier: `${issuePrefix}-1`,
+    });
+
+    const scheduled = await heartbeat.scheduleBoundedRetry(sourceRunId, {
+      now,
+      random: () => 0.5,
+    });
+    expect(scheduled.outcome).toBe("scheduled");
+    if (scheduled.outcome !== "scheduled") return;
+    const retryRunId = scheduled.run.id;
+
+    const returned = await heartbeat.wakeup(agentId, {
+      source: "on_demand",
+      triggerDetail: "manual",
+      contextSnapshot: { issueId },
+    });
+    expect(returned?.id).toBe(retryRunId);
+    expect(returned?.status).not.toBe("scheduled_retry");
+
+    await vi.waitFor(async () => {
+      const latest = await db
+        .select({ status: heartbeatRuns.status })
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.id, retryRunId))
+        .then((rows) => rows[0] ?? null);
+      expect(latest?.status).toBe("succeeded");
+    }, { timeout: 10_000 });
+    expect(adapterExecute).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not re-promote when the retry was already promoted to queued", async () => {
+    const { agentId, retryRunId } = await seedParkedRetry();
+
+    await db
+      .update(heartbeatRuns)
+      .set({ status: "queued", updatedAt: new Date() })
+      .where(eq(heartbeatRuns.id, retryRunId));
+
+    const returned = await heartbeat.wakeup(agentId, {
+      source: "on_demand",
+      triggerDetail: "manual",
+    });
+    expect(returned?.id).toBe(retryRunId);
+    expect(returned?.status).toBe("queued");
+  });
+});

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -12763,11 +12763,9 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       // Fresh timestamp: a concurrent on-demand wake may have re-pulled
       // scheduledRetryAt a few ms later than promoteNow, and promotion's
       // lte(scheduledRetryAt, now) guard must still see the retry as due.
+      // Callers own the startNextQueuedRunForAgent kick after this returns.
       const promotion = await promoteScheduledRetryRun(pulled, new Date());
-      if (promotion.outcome === "promoted") {
-        await startNextQueuedRunForAgent(agent.id);
-        return promotion.run;
-      }
+      if (promotion.outcome === "promoted") return promotion.run;
       if (promotion.run) return promotion.run;
       return rereadRun();
     };
@@ -13568,7 +13566,11 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       });
 
       const promotedRun = await promoteScheduledRetryForOnDemandWake(mergedRun);
-      return promotedRun ?? mergedRun;
+      if (promotedRun) {
+        await startNextQueuedRunForAgent(agent.id);
+        return promotedRun;
+      }
+      return mergedRun;
     }
 
     const queueOutcome = await db.transaction(async (tx) => {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -12707,6 +12707,71 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     const agent = await getAgent(agentId);
     if (!agent) throw notFound("Agent not found");
 
+    // An on-demand wake is someone explicitly asking the agent to run now —
+    // typically after fixing the failure the retry backoff was waiting out
+    // (quota renewed, credentials rotated, network restored). Absorbing it
+    // into a parked scheduled_retry makes the wake a silent no-op until the
+    // backoff expires. Pull the retry forward and promote it through the
+    // standard gate instead, mirroring retryScheduledRetryNow. Automation
+    // wakes still coalesce without promotion so bounded retry backoff keeps
+    // protecting against wake storms.
+    const promoteScheduledRetryForOnDemandWake = async (
+      run: typeof heartbeatRuns.$inferSelect,
+    ): Promise<typeof heartbeatRuns.$inferSelect | null> => {
+      if (source !== "on_demand" || run.status !== "scheduled_retry") return null;
+      const promoteNow = new Date();
+      const pulled = await db
+        .update(heartbeatRuns)
+        .set({
+          scheduledRetryAt: promoteNow,
+          contextSnapshot: {
+            ...parseObject(run.contextSnapshot),
+            scheduledRetryAt: promoteNow.toISOString(),
+            retryNowRequestedAt: promoteNow.toISOString(),
+            retryNowRequestedByActorType: opts.requestedByActorType ?? null,
+            retryNowRequestedByActorId: opts.requestedByActorId ?? null,
+          },
+          updatedAt: promoteNow,
+        })
+        .where(and(eq(heartbeatRuns.id, run.id), eq(heartbeatRuns.status, "scheduled_retry")))
+        .returning()
+        .then((rows) => rows[0] ?? null);
+      const rereadRun = () =>
+        db
+          .select()
+          .from(heartbeatRuns)
+          .where(eq(heartbeatRuns.id, run.id))
+          .then((rows) => rows[0] ?? null);
+      if (!pulled) {
+        // Lost the race with the scheduler or a concurrent wake — re-read so
+        // the caller reports the run's real status, not the parked snapshot.
+        return rereadRun();
+      }
+      await appendRunEvent(pulled, await nextRunEventSeq(pulled.id), {
+        eventType: "lifecycle",
+        stream: "system",
+        level: "info",
+        message: "Scheduled retry was promoted by an on-demand wake",
+        payload: {
+          scheduledRetryAttempt: pulled.scheduledRetryAttempt,
+          scheduledRetryAt: pulled.scheduledRetryAt ? new Date(pulled.scheduledRetryAt).toISOString() : null,
+          scheduledRetryReason: pulled.scheduledRetryReason,
+          requestedByActorType: opts.requestedByActorType ?? null,
+          requestedByActorId: opts.requestedByActorId ?? null,
+        },
+      });
+      // Fresh timestamp: a concurrent on-demand wake may have re-pulled
+      // scheduledRetryAt a few ms later than promoteNow, and promotion's
+      // lte(scheduledRetryAt, now) guard must still see the retry as due.
+      const promotion = await promoteScheduledRetryRun(pulled, new Date());
+      if (promotion.outcome === "promoted") {
+        await startNextQueuedRunForAgent(agent.id);
+        return promotion.run;
+      }
+      if (promotion.run) return promotion.run;
+      return rereadRun();
+    };
+
     const writeSkippedRequest = async (
       skipReason: string,
       patch: Partial<typeof agentWakeupRequests.$inferInsert> = {},
@@ -13419,8 +13484,9 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
 
       if (outcome.kind === "deferred" || outcome.kind === "skipped") return null;
       if (outcome.kind === "coalesced") {
+        const promotedRun = await promoteScheduledRetryForOnDemandWake(outcome.run);
         await startNextQueuedRunForAgent(agent.id);
-        return outcome.run;
+        return promotedRun ?? outcome.run;
       }
 
       const newRun = outcome.run;
@@ -13500,7 +13566,9 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         runId: mergedRun.id,
         finishedAt: new Date(),
       });
-      return mergedRun;
+
+      const promotedRun = await promoteScheduledRetryForOnDemandWake(mergedRun);
+      return promotedRun ?? mergedRun;
     }
 
     const queueOutcome = await db.transaction(async (tx) => {


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The heartbeat service schedules agent runs; failed runs with transient errors are parked as `scheduled_retry` rows with a bounded backoff (2m/10m/30m/2h ±25%), and `enqueueWakeup` coalesces new wakes into any active run for the same scope
> - When the coalesce target is a parked `scheduled_retry`, the wake is absorbed into the run's context without pulling its schedule forward — the wake silently no-ops until the backoff expires
> - For `on_demand` wakes this is exactly backwards: an operator clicking "run heartbeat" has typically just fixed the failure the backoff was waiting out (quota renewed, credentials rotated, network restored), and gets no run and no feedback
> - The issue-level `POST /api/issues/:id/scheduled-retry/retry-now` endpoint already implements the correct semantics (pull `scheduledRetryAt` forward, promote through the gate), but agent-level wakes and issue-scoped `on_demand` wakes routed through `enqueueWakeup` never reach it
> - This PR promotes a parked scheduled retry when an `on_demand` wake coalesces into it, in both coalescing paths, reusing the existing `promoteScheduledRetryRun` gate; automation wakes still coalesce without promotion
> - The benefit is that a manual "run now" actually runs now (or surfaces the gate's reason), while retry backoff keeps protecting against automated wake storms

## Linked Issues or Issue Description

No existing issue found for this exact behavior (searched: "wake scheduled retry", "on-demand wake coalesce", "run heartbeat button", "coalesce"). Related: Refs #4996 (silent coalescing surprising users on the assignment path), Refs #5222 (wake storms from unclassified quota errors — the storm-protection behavior this PR deliberately preserves for `automation` wakes).

Bug description per the bug template:

**What happened:** a `codex_local` agent's provider quota lapsed and its heartbeat failures parked a `scheduled_retry` run (attempt 3, due 36 minutes out). The operator fixed the quota (renewed the subscription) and clicked the UI "run heartbeat" button three times. Each wake was recorded as `status=coalesced` against the parked run; `scheduled_retry_at` never moved; nothing executed and the UI gave no feedback. Redacted `agent_wakeup_requests` from the live incident (2026-07-05):

```
requested_at  source      status     run_id
04:34:35      automation  completed  71c7XXXX  <- parks the retry, due 05:10:45
04:47:14      on_demand   coalesced  71c7XXXX  <- operator click #1: absorbed
04:47:37      on_demand   coalesced  71c7XXXX  <- operator click #2: absorbed
04:47:58      on_demand   coalesced  71c7XXXX  <- operator click #3: absorbed
```

Manually setting `scheduled_retry_at = now()` in the DB promoted the run at 04:59:01 and it **succeeded** at 05:04:33 — confirming the operator's wake would have worked 12 minutes earlier had promotion happened.

**Expected:** an `on_demand` wake against a parked scheduled retry runs it now (subject to the standard promotion gate), the same way the issue-level retry-now endpoint behaves.

## What Changed

- `server/src/services/heartbeat.ts`: new `promoteScheduledRetryForOnDemandWake` closure inside `enqueueWakeup` — when the wake `source` is `on_demand` and the coalesce target is a `scheduled_retry` run, it pulls `scheduledRetryAt` to now with a status-guarded UPDATE (stamping `retryNowRequestedAt`/`retryNowRequestedBy*` into the context snapshot, mirroring `retryScheduledRetryNow`), appends a lifecycle run event, and promotes through the existing `promoteScheduledRetryRun` gate, then starts the queued run.
- Called from both coalescing paths: the issue-scoped coalesced outcome handler (after the transaction commits) and the generic agent-scoped coalesce branch.
- Lost races (scheduler promoted first, concurrent wake) fall through the status-guarded UPDATE and re-read the run so the caller sees its real status instead of the stale parked snapshot.
- `server/src/__tests__/heartbeat-on-demand-wake-promotes-retry.test.ts`: new regression suite (embedded Postgres, adapter mocked).

## Verification

- `pnpm exec vitest run server/src/__tests__/heartbeat-on-demand-wake-promotes-retry.test.ts` → 4 passed:
  - `automation` wake coalesces into a parked retry → run **stays parked** (storm-protection regression guard)
  - `on_demand` wake into an agent-scoped parked retry → wakeup request `coalesced` against the retry run, run leaves `scheduled_retry`, executes to `succeeded`, promotion lifecycle event present
  - `on_demand` wake with `contextSnapshot.issueId` into an issue-scoped parked retry (real issue row with `executionRunId`/`executionAgentNameKey`) → promoted and executes to `succeeded`
  - `on_demand` wake against an already-`queued` retry → absorbed without re-promotion
- Adjacent suites green: `heartbeat-retry-scheduling`, `issue-scheduled-retry-routes`, `heartbeat-stale-queue-invalidation`, `heartbeat-archived-company-guard`, `agent-live-run-routes`, `heartbeat-accepted-plan-workspace-refresh` (79 tests total), plus `tsc --noEmit` on the server package.
- Live incident evidence above demonstrates the promotion semantics end-to-end on 2026.626.0: pulling `scheduled_retry_at` forward is exactly what the poller needs to promote and execute (run succeeded); this PR automates that pull for on-demand wakes.

## Risks

Low, and scoped to `on_demand` wakes only:

- `automation`/`timer`/`assignment` wakes are untouched — bounded retry backoff still absorbs them, so this cannot reintroduce the wake-storm class (#5222).
- Promotion goes through the existing `promoteScheduledRetryRun` gate: budget blocks, agent invokability, and issue-status gates all still apply; daily caps and dependency holds are still enforced at claim time. A gate-suppressed retry behaves identically to the existing `retry-now` endpoint for the same run.
- Known cosmetic edge: two concurrent on-demand clicks can both win the (non-status-transitioning) pull UPDATE and append duplicate promotion audit events; the promotion itself is exclusive via the status-guarded `scheduled_retry → queued` transition, and the promote call uses a fresh timestamp so a concurrently re-pulled `scheduledRetryAt` still satisfies the due check.

## Model Used

Claude Fable 5 (`claude-fable-5`), extended thinking, agentic tool use via Claude Code. Adversarial code review by OpenAI Codex (`gpt-5.5`, two review rounds; round 1 surfaced the issue-scoped coalescing gap and a stale-response race, both addressed). Human-reviewed before submission.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups *(5/5 "Safe to merge"; the one P2 raised on an earlier revision was fixed in 5dacf12 and replied to inline)*
- [x] I will address all Greptile and reviewer comments before requesting merge
