### PR TITLE
fix(heartbeat): don't auto-checkout a blocked parent on issue_children_completed wake

### DIFF
--- a/server/src/__tests__/heartbeat-auto-checkout-blocked-children-completed.test.ts
+++ b/server/src/__tests__/heartbeat-auto-checkout-blocked-children-completed.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { shouldAutoCheckoutIssueForWake } from "../services/heartbeat.js";
+
+function baseInput() {
+  return {
+    contextSnapshot: { wakeReason: "issue_children_completed" } as Record<string, unknown>,
+    issueStatus: "blocked",
+    issueAssigneeAgentId: "agent-1",
+    isDependencyReady: true,
+    agentId: "agent-1",
+  };
+}
+
+describe("shouldAutoCheckoutIssueForWake", () => {
+  it("does not auto-checkout a blocked parent on an issue_children_completed wake", () => {
+    expect(shouldAutoCheckoutIssueForWake(baseInput())).toBe(false);
+  });
+
+  it("still auto-checkouts a blocked issue when its own dependency was resolved", () => {
+    expect(
+      shouldAutoCheckoutIssueForWake({
+        ...baseInput(),
+        contextSnapshot: { wakeReason: "issue_blockers_resolved" },
+      }),
+    ).toBe(true);
+  });
+
+  it("still auto-checkouts a todo issue on an issue_children_completed wake", () => {
+    expect(
+      shouldAutoCheckoutIssueForWake({
+        ...baseInput(),
+        issueStatus: "todo",
+      }),
+    ).toBe(true);
+  });
+
+  it("still auto-checkouts an in_progress issue on an issue_children_completed wake", () => {
+    expect(
+      shouldAutoCheckoutIssueForWake({
+        ...baseInput(),
+        issueStatus: "in_progress",
+      }),
+    ).toBe(true);
+  });
+});

--- a/server/src/__tests__/heartbeat-auto-checkout-blocked-children-completed.test.ts
+++ b/server/src/__tests__/heartbeat-auto-checkout-blocked-children-completed.test.ts
@@ -25,6 +25,15 @@ describe("shouldAutoCheckoutIssueForWake", () => {
     ).toBe(true);
   });
 
+  it("still auto-checkouts a blocked issue when its own dependency was restored", () => {
+    expect(
+      shouldAutoCheckoutIssueForWake({
+        ...baseInput(),
+        contextSnapshot: { wakeReason: "issue_blockers_restored" },
+      }),
+    ).toBe(true);
+  });
+
   it("still auto-checkouts a todo issue on an issue_children_completed wake", () => {
     expect(
       shouldAutoCheckoutIssueForWake({

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -3545,7 +3545,7 @@ export function resolveTaskSessionConfigFreshness(input: {
   };
 }
 
-function shouldAutoCheckoutIssueForWake(input: {
+export function shouldAutoCheckoutIssueForWake(input: {
   contextSnapshot: Record<string, unknown> | null | undefined;
   issueStatus: string | null;
   issueAssigneeAgentId: string | null;
@@ -3570,6 +3570,13 @@ function shouldAutoCheckoutIssueForWake(input: {
   if (wakeReason === "issue_comment_mentioned") return false;
   if (wakeReason === "source_scoped_recovery_action") return false;
   if (wakeReason.startsWith("execution_")) return false;
+  // A `blocked` status is a deliberate disposition (human- or agent-chosen)
+  // and a completed child is not evidence that disposition changed — unlike
+  // issue_blockers_resolved/_restored, this reason carries no information
+  // about the parent's own blocker. Auto-checking-out here silently flips
+  // the parent to in_progress on every subsequent child completion, and the
+  // agent re-blocking it just re-fires the same wake on the next child event.
+  if (issueStatus === "blocked" && wakeReason === "issue_children_completed") return false;
 
   return true;
 }


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The heartbeat service decides whether to auto-check-out an issue when a wake fires, via `shouldAutoCheckoutIssueForWake()` — currently it treats "dependency ready" as sufficient grounds for any wake reason not on its explicit denylist
> - A `blocked` issue status is a deliberate disposition (human- or agent-chosen), often for a reason with nothing to do with the issue's structural `blockedBy` dependency graph — e.g. waiting on an external multi-week process
> - The `issue_children_completed` wake reason carries no information about whether that disposition changed — a child finishing tells you nothing about the parent's own blocker
> - This PR adds one narrow condition so `issue_children_completed` no longer auto-checks-out a `blocked` parent, while leaving every other wake reason and issue status (including genuine dependency-resolution wakes like `issue_blockers_resolved`) unaffected
> - The benefit is no more silent `blocked` → `in_progress` flips that just get corrected back by the agent, only to refire on the next child completion

## Linked Issues or Issue Description

No existing public GitHub issue found for this exact behavior (searched issue tracker for "children_completed", "blocked parent auto-checkout", "self-echo loop", "auto-checkout blocked" — no hits).

Bug description per the bug template:

**What happened?**

An issue was validly set to `blocked` status, with a named external unblock owner/action (a multi-week external dependency that no amount of re-running would resolve). One of its child issues later completed normally (`status: done`). The harness's `issue_children_completed` wake handler auto-checked-out the parent and silently flipped its status from `blocked` back to `in_progress`. The assigned agent, seeing the actual blocking condition unchanged, correctly re-set it to `blocked` — which put the issue right back where the *next* `issue_children_completed` wake (fired by any other child completing, or a retry) would flip it again.

Observed over a live run history for one affected issue: two `issue_children_completed` runs landed ~73 seconds apart, each one immediately followed by the issue's `updatedAt` timestamp jumping back to `in_progress`, confirming the flip happens purely on the wake and not on any real change to the blocking condition. The issue had accumulated 32 runs total, driven substantially by this blocked → in_progress → blocked cycle repeating across separate child-completion events over several hours.

**Expected behavior**

A `blocked` issue's status should only be auto-progressed by wake reasons that actually carry information about its own blocker resolving (`issue_blockers_resolved`, `issue_blockers_restored`). A child issue completing is not evidence of that, and should not disturb a `blocked` parent's status.

**Steps to reproduce**

1. Set an issue's status to `blocked` (with a `blockedBy` dependency that is *not* the same as the child relationship, or with no structural dependency at all — just a manual/agent-chosen block).
2. Give that issue at least one child issue.
3. Complete the child issue (`status: done`).
4. Observe: the harness fires `issue_children_completed` for the parent and `shouldAutoCheckoutIssueForWake()` returns `true`, checking out the parent and flipping it to `in_progress` even though nothing about the parent's actual blocker changed.
5. Repeat with another child completing (or the same wake re-firing): the loop continues indefinitely, each iteration consuming a full agent run.

**Paperclip version or commit**

`eb2cb916be3271e3e7ab5f643ad3ca3eb7c34d01` (current `master` at time of writing).

**Deployment mode**

Self-hosted server.

**Why this matters beyond one issue:** this is a class bug in the wake-gating logic, not specific to one issue — any long-lived `blocked` issue with children still completing (recovery/review children, scheduled retries, etc.) is a candidate for the same loop, and each iteration is a real billed agent run.

- [x] I have searched GitHub for duplicate or related PRs and linked them above (none found for this exact bug; unrelated to the other in-flight heartbeat PRs from this branch's author).

## What Changed

- Exported `shouldAutoCheckoutIssueForWake()` from `server/src/services/heartbeat.ts` (was module-private) so it can be unit tested directly.
- Added one condition: when `issueStatus === "blocked"` and the wake reason is `issue_children_completed`, return `false` (skip auto-checkout) instead of falling through to the default `true`.
- All other wake reasons (`issue_blockers_resolved`, `issue_blockers_restored`, `heartbeat_timer`, etc.) and all other issue statuses (`todo`, `in_progress`, etc.) are unaffected — they keep the exact same auto-checkout behavior as before.

## Verification

- Added 4 targeted unit tests for `shouldAutoCheckoutIssueForWake` in `server/src/__tests__/heartbeat-auto-checkout-blocked-children-completed.test.ts`:
  - `blocked` + `issue_children_completed` → does **not** auto-checkout (the fix)
  - `blocked` + `issue_blockers_resolved` → still auto-checks-out (dependency-resolution wakes preserved)
  - `todo` + `issue_children_completed` → still auto-checks-out (non-blocked statuses unaffected)
  - `in_progress` + `issue_children_completed` → still auto-checks-out (non-blocked statuses unaffected)
- Ran locally: `pnpm exec vitest run src/__tests__/heartbeat-auto-checkout-blocked-children-completed.test.ts` from `server/` — 1 file, 4 tests, all passing.
- Also ran the full `server/src/__tests__/heartbeat*` suite on this exact head to check for regressions: 26 files, 369 tests, all passing.

## Risks

Low risk. The change is a single added boolean condition, scoped to the exact combination of `blocked` status + `issue_children_completed` wake reason. It cannot affect any other status/wake-reason combination — every other branch of `shouldAutoCheckoutIssueForWake()` is untouched. The behavioral change (a `blocked` parent no longer gets auto-checked-out purely because a child finished) is the intended fix, not a side effect — a genuinely resolved blocker still auto-progresses via `issue_blockers_resolved` / `issue_blockers_restored`, which are untouched.

## Model Used

Claude Sonnet 5 (claude-sonnet-5), via Claude Code, standard reasoning mode, with repo read/write and shell tool access. Investigated the live run history of an affected issue, wrote the fix and tests, and ran the test suite locally before opening this PR.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
