### PR TITLE
fix(issues): don't 500 when checkout-owner adoption collides with sibling routine slot (DRO-758)

### DIFF
--- a/server/src/__tests__/dro758-checkout-owner-routine-slot-conflict.test.ts
+++ b/server/src/__tests__/dro758-checkout-owner-routine-slot-conflict.test.ts
@@ -1,0 +1,251 @@
+import { randomUUID } from "node:crypto";
+import express from "express";
+import request from "supertest";
+import { eq } from "drizzle-orm";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import {
+  activityLog,
+  agents,
+  companies,
+  createDb,
+  heartbeatRuns,
+  issueComments,
+  issueRelations,
+  issues,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import { errorHandler } from "../middleware/index.js";
+import { issueRoutes } from "../routes/issues.js";
+
+// Regression coverage for DRO-758.
+//
+// Reported symptom: PATCH /api/issues/:id and DELETE /api/issues/:id/comments/:id
+// both returned a bare 500 for a routine_execution-origin issue whose own
+// checkout/execution lock columns had been cleared (e.g. by
+// clearExecutionRunIfTerminal after its run went terminal) while a sibling
+// issue from the *same* routine dispatch (same companyId + originKind +
+// originId + originFingerprint) still legitimately held the single "live
+// execution slot" enforced by the issues_open_routine_execution_uq partial
+// unique index.
+//
+// Root cause: assertAgentIssueMutationAllowed -> svc.assertCheckoutOwner tries
+// to adopt the unowned/stale checkout lock for the acting agent's live run by
+// writing a non-null executionRunId onto the target issue. That write collides
+// with the sibling's slot and throws a raw Postgres unique-violation wrapped in
+// drizzle-orm's DrizzleQueryError, uncaught, producing a bare 500 on ANY
+// mutating route that funnels through assertCheckoutOwner (PATCH, DELETE
+// comment, and /release all share this call).
+//
+// Fix: adoptStaleCheckoutRun / adoptUnownedCheckoutRun now catch specifically
+// this constraint conflict (walking the DrizzleQueryError -> PostgresError
+// cause chain, since the top-level error's .code/.constraint are undefined)
+// and treat it as "adoption failed" -- the same outcome as any other
+// lock-adoption precondition miss. The caller's existing fallback path then
+// surfaces a real 409 "Issue run ownership conflict" instead of an uncaught
+// 500.
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping DRO-758 regression coverage on this host: ${
+      embeddedPostgresSupport.reason ?? "unsupported environment"
+    }`,
+  );
+}
+
+describeEmbeddedPostgres("DRO-758: checkout-owner adoption vs. sibling routine-execution slot", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-dro758-");
+    db = createDb(tempDb.connectionString);
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.delete(issueComments);
+    await db.delete(issueRelations);
+    await db.delete(activityLog);
+    await db.delete(issues);
+    await db.delete(heartbeatRuns);
+    await db.delete(agents);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  function createApp(actor: Express.Request["actor"]) {
+    const app = express();
+    app.use(express.json());
+    app.use((req, _res, next) => {
+      req.actor = actor;
+      next();
+    });
+    app.use("/api", issueRoutes(db, {} as any));
+    app.use(errorHandler);
+    return app;
+  }
+
+  function agentActor(companyId: string, agentId: string, runId: string): Express.Request["actor"] {
+    return {
+      type: "agent",
+      agentId,
+      companyId,
+      runId,
+      source: "agent_jwt",
+    };
+  }
+
+  async function seedConflictingSiblingIssues() {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const routineId = randomUUID();
+    const fingerprint = "test-fingerprint";
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "CodexCoder",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    // Sibling run + issue: currently holds the "live execution slot" for this
+    // routine+fingerprint (mirrors DRO-788 relative to DRO-745 in the original
+    // report).
+    const siblingRunId = randomUUID();
+    await db.insert(heartbeatRuns).values({
+      id: siblingRunId,
+      companyId,
+      agentId,
+      status: "running",
+      invocationSource: "automation",
+      startedAt: new Date(),
+    });
+    await db.insert(issues).values({
+      id: randomUUID(),
+      companyId,
+      title: "Sibling supervisor run (live)",
+      status: "in_progress",
+      priority: "medium",
+      assigneeAgentId: agentId,
+      checkoutRunId: siblingRunId,
+      executionRunId: siblingRunId,
+      executionLockedAt: new Date(),
+      originKind: "routine_execution",
+      originId: routineId,
+      originRunId: siblingRunId,
+      originFingerprint: fingerprint,
+    });
+
+    // Target issue: mirrors DRO-745 exactly -- in_progress, assigned, but
+    // checkoutRunId/executionRunId both cleared, same routine+fingerprint as
+    // the sibling above.
+    const targetIssueId = randomUUID();
+    await db.insert(issues).values({
+      id: targetIssueId,
+      companyId,
+      title: "M4 goal supervisor (stuck)",
+      status: "in_progress",
+      priority: "medium",
+      assigneeAgentId: agentId,
+      checkoutRunId: null,
+      executionRunId: null,
+      originKind: "routine_execution",
+      originId: routineId,
+      originRunId: siblingRunId,
+      originFingerprint: fingerprint,
+    });
+
+    // Actor's own live run, used as actorRunId for lock adoption.
+    const actorRunId = randomUUID();
+    await db.insert(heartbeatRuns).values({
+      id: actorRunId,
+      companyId,
+      agentId,
+      status: "running",
+      invocationSource: "automation",
+      startedAt: new Date(),
+    });
+
+    return { companyId, agentId, targetIssueId, actorRunId };
+  }
+
+  it("returns 409 (not 500) on PATCH when a sibling issue holds the routine's open-execution slot", async () => {
+    const { companyId, agentId, targetIssueId, actorRunId } = await seedConflictingSiblingIssues();
+
+    const res = await request(createApp(agentActor(companyId, agentId, actorRunId)))
+      .patch(`/api/issues/${targetIssueId}`)
+      .send({});
+
+    expect(res.status, JSON.stringify(res.body)).toBe(409);
+    expect(res.body.error).toBe("Issue run ownership conflict");
+
+    // The target issue's lock columns must remain untouched -- the conflicting
+    // write must have rolled back cleanly, not partially applied.
+    const row = await db
+      .select({ checkoutRunId: issues.checkoutRunId, executionRunId: issues.executionRunId })
+      .from(issues)
+      .where(eq(issues.id, targetIssueId))
+      .then((rows) => rows[0]);
+    expect(row?.checkoutRunId).toBeNull();
+    expect(row?.executionRunId).toBeNull();
+  });
+
+  it("returns 409 (not 500) on DELETE /comments/:id when a sibling issue holds the routine's open-execution slot", async () => {
+    const { companyId, agentId, targetIssueId, actorRunId } = await seedConflictingSiblingIssues();
+
+    // Posting a comment does NOT go through assertCheckoutOwner (it uses
+    // assertAgentIssueCommentAllowed instead), so this must still succeed even
+    // while the issue is in the conflicting state -- matching the original
+    // report's observation that POST /comments worked fine.
+    const postRes = await request(createApp(agentActor(companyId, agentId, actorRunId)))
+      .post(`/api/issues/${targetIssueId}/comments`)
+      .send({ body: "probe comment" });
+    expect(postRes.status, JSON.stringify(postRes.body)).toBe(201);
+    const commentId = postRes.body.id as string;
+
+    const deleteRes = await request(createApp(agentActor(companyId, agentId, actorRunId)))
+      .delete(`/api/issues/${targetIssueId}/comments/${commentId}`)
+      .send();
+
+    expect(deleteRes.status, JSON.stringify(deleteRes.body)).toBe(409);
+    expect(deleteRes.body.error).toBe("Issue run ownership conflict");
+  });
+
+  it("still allows a board (human) actor to PATCH the same issue, since assertAgentIssueMutationAllowed short-circuits for non-agent actors", async () => {
+    const { companyId, targetIssueId } = await seedConflictingSiblingIssues();
+
+    const res = await request(
+      createApp({
+        type: "board",
+        userId: "board-user",
+        companyIds: [companyId],
+        memberships: [{ companyId, membershipRole: "admin", status: "active" }],
+        isInstanceAdmin: false,
+        source: "session",
+      }),
+    )
+      .patch(`/api/issues/${targetIssueId}`)
+      .send({ title: "Manually retitled by a human" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(res.body.title).toBe("Manually retitled by a human");
+  });
+});

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -460,6 +460,42 @@ function sameRunLock(checkoutRunId: string | null, actorRunId: string | null) {
   return checkoutRunId == null;
 }
 
+// Drizzle's postgres-js driver wraps every failed query in a DrizzleQueryError
+// whose own `.code`/`.constraint` are undefined — the real Postgres error
+// (with `.code` and `.constraint_name`) lives on `.cause`. Checking only the
+// top-level error (as some other conflict matchers in this codebase do) never
+// matches. Walk the cause chain so both shapes are handled.
+function isUniqueConstraintViolation(error: unknown, constraintName: string): boolean {
+  let current: unknown = error;
+  const seen = new Set<unknown>();
+  while (current && typeof current === "object" && !seen.has(current)) {
+    seen.add(current);
+    const candidate = current as { code?: unknown; constraint?: unknown; constraint_name?: unknown; cause?: unknown };
+    if (
+      candidate.code === "23505" &&
+      (candidate.constraint === constraintName || candidate.constraint_name === constraintName)
+    ) {
+      return true;
+    }
+    current = candidate.cause;
+  }
+  return false;
+}
+
+// Checkout-lock adoption (adoptUnownedCheckoutRun / adoptStaleCheckoutRun)
+// claims `executionRunId` for the actor's run on a routine_execution-origin
+// issue. If a sibling issue from the same routine dispatch (same companyId +
+// originKind + originId + originFingerprint) already holds the single "live
+// execution slot" enforced by issues_open_routine_execution_uq, that claim
+// collides — this is a real, expected race (e.g. a routine that already
+// dispatched a fresh execution issue while this one's own lock columns were
+// cleared), not a bug in the caller's request. Treat it as "adoption failed",
+// the same outcome as any other lock-adoption precondition miss, instead of
+// letting the raw DB conflict surface as an uncaught 500 (DRO-758).
+function isOpenRoutineExecutionSlotConflict(error: unknown): boolean {
+  return isUniqueConstraintViolation(error, "issues_open_routine_execution_uq");
+}
+
 export const TERMINAL_HEARTBEAT_RUN_STATUSES = new Set(["succeeded", "failed", "cancelled", "timed_out"]);
 const ISSUE_LIST_DESCRIPTION_MAX_CHARS = 1200;
 const ISSUE_LIST_DESCRIPTION_MAX_BYTES = ISSUE_LIST_DESCRIPTION_MAX_CHARS * 4;
@@ -4012,87 +4048,111 @@ export function issueService(db: Db) {
     actorRunId: string;
     expectedCheckoutRunId: string;
   }) {
-    return db.transaction(async (tx) => {
-      const lockedIssue = await tx
-        .select({
-          id: issues.id,
-          status: issues.status,
-          assigneeAgentId: issues.assigneeAgentId,
-          checkoutRunId: issues.checkoutRunId,
-          executionRunId: issues.executionRunId,
-        })
-        .from(issues)
-        .where(eq(issues.id, input.issueId))
-        .for("update")
-        .then((rows) => rows[0] ?? null);
-      if (!lockedIssue) {
-        return { adopted: null, latest: null };
-      }
+    try {
+      return await db.transaction(async (tx) => {
+        const lockedIssue = await tx
+          .select({
+            id: issues.id,
+            status: issues.status,
+            assigneeAgentId: issues.assigneeAgentId,
+            checkoutRunId: issues.checkoutRunId,
+            executionRunId: issues.executionRunId,
+          })
+          .from(issues)
+          .where(eq(issues.id, input.issueId))
+          .for("update")
+          .then((rows) => rows[0] ?? null);
+        if (!lockedIssue) {
+          return { adopted: null, latest: null };
+        }
 
-      if (
-        lockedIssue.status !== "in_progress" ||
-        lockedIssue.assigneeAgentId !== input.actorAgentId ||
-        lockedIssue.checkoutRunId !== input.expectedCheckoutRunId
-      ) {
-        return { adopted: null, latest: lockedIssue };
-      }
+        if (
+          lockedIssue.status !== "in_progress" ||
+          lockedIssue.assigneeAgentId !== input.actorAgentId ||
+          lockedIssue.checkoutRunId !== input.expectedCheckoutRunId
+        ) {
+          return { adopted: null, latest: lockedIssue };
+        }
 
-      await Promise.all([
-        tx.execute(
-          sql`select ${heartbeatRuns.id} from ${heartbeatRuns} where ${heartbeatRuns.id} = ${input.expectedCheckoutRunId} for update`,
-        ),
-        tx.execute(
-          sql`select ${heartbeatRuns.id} from ${heartbeatRuns} where ${heartbeatRuns.id} = ${input.actorRunId} for update`,
-        ),
-      ]);
-      const [existingRun, actorRun] = await Promise.all([
-        tx
-          .select({ status: heartbeatRuns.status })
-          .from(heartbeatRuns)
-          .where(eq(heartbeatRuns.id, input.expectedCheckoutRunId))
-          .then((rows) => rows[0] ?? null),
-        tx
-          .select({ status: heartbeatRuns.status })
-          .from(heartbeatRuns)
-          .where(eq(heartbeatRuns.id, input.actorRunId))
-          .then((rows) => rows[0] ?? null),
-      ]);
-      const stale = !existingRun || TERMINAL_HEARTBEAT_RUN_STATUSES.has(existingRun.status);
-      const actorLive = actorRun && !TERMINAL_HEARTBEAT_RUN_STATUSES.has(actorRun.status);
-      if (!stale || !actorLive) {
-        return { adopted: null, latest: lockedIssue };
-      }
-
-      const now = new Date();
-      const adopted = await tx
-        .update(issues)
-        .set({
-          checkoutRunId: input.actorRunId,
-          executionRunId: input.actorRunId,
-          executionLockedAt: now,
-          updatedAt: now,
-        })
-        .where(
-          and(
-            eq(issues.id, input.issueId),
-            eq(issues.status, "in_progress"),
-            eq(issues.assigneeAgentId, input.actorAgentId),
-            eq(issues.checkoutRunId, input.expectedCheckoutRunId),
+        await Promise.all([
+          tx.execute(
+            sql`select ${heartbeatRuns.id} from ${heartbeatRuns} where ${heartbeatRuns.id} = ${input.expectedCheckoutRunId} for update`,
           ),
-        )
-        .returning({
-          id: issues.id,
-          status: issues.status,
-          assigneeAgentId: issues.assigneeAgentId,
-          checkoutRunId: issues.checkoutRunId,
-          executionRunId: issues.executionRunId,
-        })
-        .then((rows) => rows[0] ?? null);
-      if (adopted) {
-        return { adopted, latest: adopted };
-      }
+          tx.execute(
+            sql`select ${heartbeatRuns.id} from ${heartbeatRuns} where ${heartbeatRuns.id} = ${input.actorRunId} for update`,
+          ),
+        ]);
+        const [existingRun, actorRun] = await Promise.all([
+          tx
+            .select({ status: heartbeatRuns.status })
+            .from(heartbeatRuns)
+            .where(eq(heartbeatRuns.id, input.expectedCheckoutRunId))
+            .then((rows) => rows[0] ?? null),
+          tx
+            .select({ status: heartbeatRuns.status })
+            .from(heartbeatRuns)
+            .where(eq(heartbeatRuns.id, input.actorRunId))
+            .then((rows) => rows[0] ?? null),
+        ]);
+        const stale = !existingRun || TERMINAL_HEARTBEAT_RUN_STATUSES.has(existingRun.status);
+        const actorLive = actorRun && !TERMINAL_HEARTBEAT_RUN_STATUSES.has(actorRun.status);
+        if (!stale || !actorLive) {
+          return { adopted: null, latest: lockedIssue };
+        }
 
-      const latest = await tx
+        const now = new Date();
+        const adopted = await tx
+          .update(issues)
+          .set({
+            checkoutRunId: input.actorRunId,
+            executionRunId: input.actorRunId,
+            executionLockedAt: now,
+            updatedAt: now,
+          })
+          .where(
+            and(
+              eq(issues.id, input.issueId),
+              eq(issues.status, "in_progress"),
+              eq(issues.assigneeAgentId, input.actorAgentId),
+              eq(issues.checkoutRunId, input.expectedCheckoutRunId),
+            ),
+          )
+          .returning({
+            id: issues.id,
+            status: issues.status,
+            assigneeAgentId: issues.assigneeAgentId,
+            checkoutRunId: issues.checkoutRunId,
+            executionRunId: issues.executionRunId,
+          })
+          .then((rows) => rows[0] ?? null);
+        if (adopted) {
+          return { adopted, latest: adopted };
+        }
+
+        const latest = await tx
+          .select({
+            id: issues.id,
+            status: issues.status,
+            assigneeAgentId: issues.assigneeAgentId,
+            checkoutRunId: issues.checkoutRunId,
+            executionRunId: issues.executionRunId,
+          })
+          .from(issues)
+          .where(eq(issues.id, input.issueId))
+          .then((rows) => rows[0] ?? null);
+        return { adopted: null, latest };
+      });
+    } catch (error) {
+      if (!isOpenRoutineExecutionSlotConflict(error)) throw error;
+      // Another issue sharing this routine's open-execution slot won the race.
+      // Report this the same way as any other failed-precondition adoption
+      // attempt: no adoption, with the current row state for the caller to
+      // re-evaluate (outside the now-aborted transaction).
+      logger.warn(
+        { issueId: input.issueId, actorAgentId: input.actorAgentId, actorRunId: input.actorRunId },
+        "adoptStaleCheckoutRun: open routine-execution slot already held by a sibling issue",
+      );
+      const latest = await db
         .select({
           id: issues.id,
           status: issues.status,
@@ -4104,7 +4164,7 @@ export function issueService(db: Db) {
         .where(eq(issues.id, input.issueId))
         .then((rows) => rows[0] ?? null);
       return { adopted: null, latest };
-    });
+    }
   }
 
   async function adoptUnownedCheckoutRun(input: {
@@ -4112,46 +4172,60 @@ export function issueService(db: Db) {
     actorAgentId: string;
     actorRunId: string;
   }) {
-    return db.transaction(async (tx) => {
-      await tx.execute(
-        sql`select ${heartbeatRuns.id} from ${heartbeatRuns} where ${heartbeatRuns.id} = ${input.actorRunId} for update`,
+    try {
+      return await db.transaction(async (tx) => {
+        await tx.execute(
+          sql`select ${heartbeatRuns.id} from ${heartbeatRuns} where ${heartbeatRuns.id} = ${input.actorRunId} for update`,
+        );
+        const actorRun = await tx
+          .select({ status: heartbeatRuns.status })
+          .from(heartbeatRuns)
+          .where(eq(heartbeatRuns.id, input.actorRunId))
+          .then((rows) => rows[0] ?? null);
+        if (!actorRun || TERMINAL_HEARTBEAT_RUN_STATUSES.has(actorRun.status)) return null;
+
+        const now = new Date();
+        const adopted = await tx
+          .update(issues)
+          .set({
+            checkoutRunId: input.actorRunId,
+            executionRunId: input.actorRunId,
+            executionLockedAt: now,
+            updatedAt: now,
+          })
+          .where(
+            and(
+              eq(issues.id, input.issueId),
+              eq(issues.status, "in_progress"),
+              eq(issues.assigneeAgentId, input.actorAgentId),
+              isNull(issues.checkoutRunId),
+              or(isNull(issues.executionRunId), eq(issues.executionRunId, input.actorRunId)),
+            ),
+          )
+          .returning({
+            id: issues.id,
+            status: issues.status,
+            assigneeAgentId: issues.assigneeAgentId,
+            checkoutRunId: issues.checkoutRunId,
+            executionRunId: issues.executionRunId,
+          })
+          .then((rows) => rows[0] ?? null);
+
+        return adopted;
+      });
+    } catch (error) {
+      if (!isOpenRoutineExecutionSlotConflict(error)) throw error;
+      // Another issue sharing this routine's open-execution slot won the race
+      // (see isOpenRoutineExecutionSlotConflict). Report this the same way as
+      // any other failed adoption precondition: no adoption. The caller
+      // (resolveOwnership) already re-fetches the current row and falls
+      // through to its normal "ownership conflict" 409 path in that case.
+      logger.warn(
+        { issueId: input.issueId, actorAgentId: input.actorAgentId, actorRunId: input.actorRunId },
+        "adoptUnownedCheckoutRun: open routine-execution slot already held by a sibling issue",
       );
-      const actorRun = await tx
-        .select({ status: heartbeatRuns.status })
-        .from(heartbeatRuns)
-        .where(eq(heartbeatRuns.id, input.actorRunId))
-        .then((rows) => rows[0] ?? null);
-      if (!actorRun || TERMINAL_HEARTBEAT_RUN_STATUSES.has(actorRun.status)) return null;
-
-      const now = new Date();
-      const adopted = await tx
-        .update(issues)
-        .set({
-          checkoutRunId: input.actorRunId,
-          executionRunId: input.actorRunId,
-          executionLockedAt: now,
-          updatedAt: now,
-        })
-        .where(
-          and(
-            eq(issues.id, input.issueId),
-            eq(issues.status, "in_progress"),
-            eq(issues.assigneeAgentId, input.actorAgentId),
-            isNull(issues.checkoutRunId),
-            or(isNull(issues.executionRunId), eq(issues.executionRunId, input.actorRunId)),
-          ),
-        )
-        .returning({
-          id: issues.id,
-          status: issues.status,
-          assigneeAgentId: issues.assigneeAgentId,
-          checkoutRunId: issues.checkoutRunId,
-          executionRunId: issues.executionRunId,
-        })
-        .then((rows) => rows[0] ?? null);
-
-      return adopted;
-    });
+      return null;
+    }
   }
 
   async function clearExecutionRunIfTerminal(issueId: string): Promise<boolean> {


### PR DESCRIPTION
## Summary

- **DRO-758**: `PATCH /api/issues/:id`, `DELETE /api/issues/:id/comments/:id`, and `POST /api/issues/:id/release` all returned a bare `500 {"error":"Internal server error"}` for at least one live `routine_execution`-origin issue (DRO-745). `GET` and `POST /comments` worked. Board (human) `PATCH` worked. The stuck issue could not be corrected to `done` via any agent-accessible API.
- Root cause: those routes funnel through `assertAgentIssueMutationAllowed` → `svc.assertCheckoutOwner`. When the target row's `checkoutRunId`/`executionRunId` were both null (state that `clearExecutionRunIfTerminal` leaves behind after a run goes terminal) but its status was still open, `assertCheckoutOwner` tried to adopt the lock by writing a non-null `executionRunId`. For a `routine_execution` row, that write collided with the `issues_open_routine_execution_uq` partial unique index whenever a **sibling** issue from the same routine dispatch still legitimately held the routine's single "live execution slot". The raw Postgres `23505` was wrapped in `DrizzleQueryError` and reached the error handler uncaught → 500.
- Fix: `adoptStaleCheckoutRun` and `adoptUnownedCheckoutRun` in `server/src/services/issues.ts` now catch this specific constraint violation and treat it as "adoption failed" (identical to any other lock-adoption precondition miss). The caller's existing fallback path then surfaces a proper `409 "Issue run ownership conflict"` instead of a 500.

### Why the previous matcher would not have caught it

`drizzle-orm`'s `postgres-js` driver wraps every failed query in a `DrizzleQueryError` whose own `.code`/`.constraint` are `undefined` — the real `PostgresError` (`.code = '23505'`, `.constraint_name`) lives on `.cause`. This PR's `isUniqueConstraintViolation()` helper walks the cause chain and accepts both `.constraint` and `.constraint_name`. **Followup (out of scope for this PR):** several other conflict matchers in the codebase (e.g. `isOpenExecutionConflict` in `server/src/services/routines.ts` around line 1564) check only the top-level error and are silently non-functional against `postgres-js` today; worth a sweep in a separate change.

### Scope

- Fixed only the two adoption paths I could reproduce a 500 through. `checkout()` in `services/issues.ts` has parallel writes to `executionRunId` in the same shape (~lines 5647 / 5693 / 5746) and could conceivably hit the same conflict; **deliberately not touching those in this PR** to keep the change narrow and reviewable. Happy to follow up.
- No schema changes. No behavior change for board (human) actors — `assertAgentIssueMutationAllowed` still short-circuits at the top for non-agent actors, confirmed by test 3.

## Test plan

- [x] New regression suite `server/src/__tests__/dro758-checkout-owner-routine-slot-conflict.test.ts` (3 tests, all passing in isolation on embedded Postgres). Seeds the exact shape from the bug report — a sibling issue holding the live-execution slot + a target issue matching DRO-745's state — and exercises the three cases from the reproducer table:
  1. `PATCH {}` returns **409 "Issue run ownership conflict"** (previously 500). Lock columns on the target row remain untouched — clean rollback, not partial write.
  2. `POST /comments` returns **201** (must still succeed — uses `assertAgentIssueCommentAllowed`, not `assertCheckoutOwner`); then `DELETE /comments/:id` returns **409** (previously 500).
  3. Board (human) actor `PATCH` returns **200** with the update applied (control — non-agent actors were never affected).
- [x] `pnpm --filter @paperclipai/server exec tsc --noEmit` clean.
- [ ] Reviewer to run the wider `server/src/__tests__/issues-service.test.ts` suite on a machine without concurrent embedded-postgres load (I saw sporadic `beforeAll` hook timeouts under contention in my sandbox, unrelated to this change — each affected test passes in isolation).

## Related

- Original bug report: DRO-758 (with live-repro table against DRO-745).
- The specific stuck issue this fix would have prevented: DRO-745 (`originKind: routine_execution`, `successfulRunHandoff.state: escalated`, `originRunId` pointing at a terminated run whose sibling in the same routine dispatch still held the slot).

🤖 Generated with [Claude Code](https://claude.com/claude-code)