### PR TITLE
Implement antigravity-local adapter

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ COPY packages/mcp-server/package.json packages/mcp-server/
 COPY packages/skills-catalog/package.json packages/skills-catalog/
 COPY packages/teams-catalog/package.json packages/teams-catalog/
 COPY packages/adapters/acpx-local/package.json packages/adapters/acpx-local/
+COPY packages/adapters/antigravity-local/package.json packages/adapters/antigravity-local/
 COPY packages/adapters/claude-local/package.json packages/adapters/claude-local/
 COPY packages/adapters/codex-local/package.json packages/adapters/codex-local/
 COPY packages/adapters/cursor-cloud/package.json packages/adapters/cursor-cloud/

--- a/cli/package.json
+++ b/cli/package.json
@@ -43,6 +43,7 @@
     "@paperclipai/adapter-cursor-cloud": "workspace:*",
     "@paperclipai/adapter-cursor-local": "workspace:*",
     "@paperclipai/adapter-gemini-local": "workspace:*",
+    "@paperclipai/adapter-antigravity-local": "workspace:*",
     "@paperclipai/adapter-grok-local": "workspace:*",
     "@paperclipai/adapter-opencode-local": "workspace:*",
     "@paperclipai/adapter-pi-local": "workspace:*",

--- a/cli/src/adapters/registry.ts
+++ b/cli/src/adapters/registry.ts
@@ -5,6 +5,7 @@ import { printCodexStreamEvent } from "@paperclipai/adapter-codex-local/cli";
 import { printCursorStreamEvent } from "@paperclipai/adapter-cursor-local/cli";
 import { printCursorCloudEvent } from "@paperclipai/adapter-cursor-cloud/cli";
 import { printGeminiStreamEvent } from "@paperclipai/adapter-gemini-local/cli";
+import { printAntigravityStreamEvent } from "@paperclipai/adapter-antigravity-local/cli";
 import { printGrokStreamEvent } from "@paperclipai/adapter-grok-local/cli";
 import { formatStdoutEvent as printHermesGatewayStreamEvent } from "@paperclipai/hermes-paperclip-adapter/gateway/cli";
 import { printHermesStreamEvent } from "@paperclipai/hermes-paperclip-adapter/cli";
@@ -54,6 +55,11 @@ const geminiLocalCLIAdapter: CLIAdapterModule = {
   formatStdoutEvent: printGeminiStreamEvent,
 };
 
+const antigravityLocalCLIAdapter: CLIAdapterModule = {
+  type: "antigravity_local",
+  formatStdoutEvent: printAntigravityStreamEvent,
+};
+
 const grokLocalCLIAdapter: CLIAdapterModule = {
   type: "grok_local",
   formatStdoutEvent: printGrokStreamEvent,
@@ -84,6 +90,7 @@ const adaptersByType = new Map<string, CLIAdapterModule>(
     cursorLocalCLIAdapter,
     cursorCloudCLIAdapter,
     geminiLocalCLIAdapter,
+    antigravityLocalCLIAdapter,
     grokLocalCLIAdapter,
     hermesGatewayCLIAdapter,
     hermesLocalCLIAdapter,

--- a/packages/adapters/antigravity-local/package.json
+++ b/packages/adapters/antigravity-local/package.json
@@ -1,0 +1,61 @@
+{
+  "name": "@paperclipai/adapter-antigravity-local",
+  "version": "0.3.1",
+  "license": "MIT",
+  "homepage": "https://github.com/paperclipai/paperclip",
+  "bugs": {
+    "url": "https://github.com/paperclipai/paperclip/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/paperclipai/paperclip",
+    "directory": "packages/adapters/antigravity-local"
+  },
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./server": "./src/server/index.ts",
+    "./ui": "./src/ui/index.ts",
+    "./cli": "./src/cli/index.ts"
+  },
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      },
+      "./server": {
+        "types": "./dist/server/index.d.ts",
+        "import": "./dist/server/index.js"
+      },
+      "./ui": {
+        "types": "./dist/ui/index.d.ts",
+        "import": "./dist/ui/index.js"
+      },
+      "./cli": {
+        "types": "./dist/cli/index.d.ts",
+        "import": "./dist/cli/index.js"
+      }
+    },
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts"
+  },
+  "files": [
+    "dist",
+    "skills"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "clean": "rm -rf dist",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@paperclipai/adapter-utils": "workspace:*",
+    "picocolors": "^1.1.1"
+  },
+  "devDependencies": {
+    "@types/node": "^22.19.21",
+    "typescript": "^5.7.3"
+  }
+}

--- a/packages/adapters/antigravity-local/src/cli/format-event.ts
+++ b/packages/adapters/antigravity-local/src/cli/format-event.ts
@@ -1,0 +1,227 @@
+import pc from "picocolors";
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+function asString(value: unknown, fallback = ""): string {
+  return typeof value === "string" ? value : fallback;
+}
+
+function asNumber(value: unknown, fallback = 0): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : fallback;
+}
+
+function stringifyUnknown(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (value === null || value === undefined) return "";
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+}
+
+function errorText(value: unknown): string {
+  if (typeof value === "string") return value;
+  const rec = asRecord(value);
+  if (!rec) return "";
+  const msg =
+    (typeof rec.message === "string" && rec.message) ||
+    (typeof rec.error === "string" && rec.error) ||
+    (typeof rec.code === "string" && rec.code) ||
+    "";
+  if (msg) return msg;
+  try {
+    return JSON.stringify(rec);
+  } catch {
+    return "";
+  }
+}
+
+function printTextMessage(prefix: string, colorize: (text: string) => string, messageRaw: unknown): void {
+  if (typeof messageRaw === "string") {
+    const text = messageRaw.trim();
+    if (text) console.log(colorize(`${prefix}: ${text}`));
+    return;
+  }
+
+  const message = asRecord(messageRaw);
+  if (!message) return;
+
+  const directText = asString(message.text).trim();
+  if (directText) console.log(colorize(`${prefix}: ${directText}`));
+
+  const content = Array.isArray(message.content) ? message.content : [];
+  for (const partRaw of content) {
+    const part = asRecord(partRaw);
+    if (!part) continue;
+    const type = asString(part.type).trim();
+
+    if (type === "output_text" || type === "text" || type === "content") {
+      const text = asString(part.text).trim() || asString(part.content).trim();
+      if (text) console.log(colorize(`${prefix}: ${text}`));
+      continue;
+    }
+
+    if (type === "thinking") {
+      const text = asString(part.text).trim();
+      if (text) console.log(pc.gray(`thinking: ${text}`));
+      continue;
+    }
+
+    if (type === "tool_call") {
+      const name = asString(part.name, asString(part.tool, "tool"));
+      console.log(pc.yellow(`tool_call: ${name}`));
+      const input = part.input ?? part.arguments ?? part.args;
+      if (input !== undefined) console.log(pc.gray(stringifyUnknown(input)));
+      continue;
+    }
+
+    if (type === "tool_result" || type === "tool_response") {
+      const isError = part.is_error === true || asString(part.status).toLowerCase() === "error";
+      const contentText =
+        asString(part.output) ||
+        asString(part.text) ||
+        asString(part.result) ||
+        stringifyUnknown(part.output ?? part.result ?? part.text ?? part.response);
+      console.log((isError ? pc.red : pc.cyan)(`tool_result${isError ? " (error)" : ""}`));
+      if (contentText) console.log((isError ? pc.red : pc.gray)(contentText));
+    }
+  }
+}
+
+function printUsage(parsed: Record<string, unknown>) {
+  const usage = asRecord(parsed.usage) ?? asRecord(parsed.usageMetadata) ?? asRecord(parsed.stats);
+  const usageMetadata = asRecord(usage?.usageMetadata);
+  const source = usageMetadata ?? usage ?? {};
+  const input = asNumber(source.input_tokens, asNumber(source.inputTokens, asNumber(source.promptTokenCount)));
+  const output = asNumber(source.output_tokens, asNumber(source.outputTokens, asNumber(source.candidatesTokenCount)));
+  const cached = asNumber(
+    source.cached_input_tokens,
+    asNumber(source.cachedInputTokens, asNumber(source.cachedContentTokenCount, asNumber(source.cached))),
+  );
+  const cost = asNumber(parsed.total_cost_usd, asNumber(parsed.cost_usd, asNumber(parsed.cost)));
+  console.log(pc.blue(`tokens: in=${input} out=${output} cached=${cached} cost=$${cost.toFixed(6)}`));
+}
+
+export function printAntigravityStreamEvent(raw: string, _debug: boolean): void {
+  const line = raw.trim();
+  if (!line) return;
+
+  let parsed: Record<string, unknown> | null = null;
+  try {
+    parsed = JSON.parse(line) as Record<string, unknown>;
+  } catch {
+    console.log(line);
+    return;
+  }
+
+  const type = asString(parsed.type);
+
+  if (type === "system") {
+    const subtype = asString(parsed.subtype);
+    if (subtype === "init") {
+      const sessionId =
+        asString(parsed.session_id) ||
+        asString(parsed.sessionId) ||
+        asString(parsed.sessionID) ||
+        asString(parsed.checkpoint_id);
+      const model = asString(parsed.model);
+      const details = [sessionId ? `session: ${sessionId}` : "", model ? `model: ${model}` : ""]
+        .filter(Boolean)
+        .join(", ");
+      console.log(pc.blue(`Antigravity init${details ? ` (${details})` : ""}`));
+      return;
+    }
+    if (subtype === "error") {
+      const text = errorText(parsed.error ?? parsed.message ?? parsed.detail);
+      if (text) console.log(pc.red(`error: ${text}`));
+      return;
+    }
+    console.log(pc.blue(`system: ${subtype || "event"}`));
+    return;
+  }
+
+  if (type === "assistant") {
+    printTextMessage("assistant", pc.green, parsed.message);
+    return;
+  }
+
+  if (type === "user") {
+    printTextMessage("user", pc.gray, parsed.message);
+    return;
+  }
+
+  if (type === "message") {
+    const role = asString(parsed.role).trim().toLowerCase();
+    if (role === "assistant") {
+      printTextMessage("assistant", pc.green, parsed.content);
+      return;
+    }
+    if (role === "user") {
+      printTextMessage("user", pc.gray, parsed.content);
+      return;
+    }
+    return;
+  }
+
+  if (type === "thinking") {
+    const text = asString(parsed.text).trim() || asString(asRecord(parsed.delta)?.text).trim();
+    if (text) console.log(pc.gray(`thinking: ${text}`));
+    return;
+  }
+
+  if (type === "tool_call") {
+    const subtype = asString(parsed.subtype).trim().toLowerCase();
+    const toolCall = asRecord(parsed.tool_call ?? parsed.toolCall);
+    const [toolName] = toolCall ? Object.keys(toolCall) : [];
+    if (!toolCall || !toolName) {
+      console.log(pc.yellow(`tool_call${subtype ? `: ${subtype}` : ""}`));
+      return;
+    }
+    const payload = asRecord(toolCall[toolName]) ?? {};
+    if (subtype === "started" || subtype === "start") {
+      console.log(pc.yellow(`tool_call: ${toolName}`));
+      console.log(pc.gray(stringifyUnknown(payload.args ?? payload.input ?? payload.arguments ?? payload)));
+      return;
+    }
+    if (subtype === "completed" || subtype === "complete" || subtype === "finished") {
+      const isError =
+        parsed.is_error === true ||
+        payload.is_error === true ||
+        payload.error !== undefined ||
+        asString(payload.status).toLowerCase() === "error";
+      console.log((isError ? pc.red : pc.cyan)(`tool_result${isError ? " (error)" : ""}`));
+      console.log((isError ? pc.red : pc.gray)(stringifyUnknown(payload.result ?? payload.output ?? payload.error)));
+      return;
+    }
+    console.log(pc.yellow(`tool_call: ${toolName}${subtype ? ` (${subtype})` : ""}`));
+    return;
+  }
+
+  if (type === "result") {
+    printUsage(parsed);
+    const status = asString(parsed.status).toLowerCase();
+    const isError =
+      parsed.is_error === true || status === "error" || status === "failed";
+    const subtype = asString(parsed.subtype, status || "result");
+    if (subtype || isError) {
+      console.log((isError ? pc.red : pc.blue)(`result: subtype=${subtype} is_error=${isError ? "true" : "false"}`));
+    }
+    if (isError) {
+      const text = errorText(parsed.error ?? parsed.message ?? parsed.result);
+      if (text) console.log(pc.red(`error: ${text}`));
+    }
+    return;
+  }
+
+  if (type === "error") {
+    const text = errorText(parsed.error ?? parsed.message ?? parsed.detail);
+    if (text) console.log(pc.red(`error: ${text}`));
+    return;
+  }
+
+  console.log(line);
+}

--- a/packages/adapters/antigravity-local/src/cli/index.ts
+++ b/packages/adapters/antigravity-local/src/cli/index.ts
@@ -1,0 +1,1 @@
+export { printAntigravityStreamEvent } from "./format-event.js";

--- a/packages/adapters/antigravity-local/src/index.ts
+++ b/packages/adapters/antigravity-local/src/index.ts
@@ -1,0 +1,72 @@
+import {
+  buildSandboxNpmInstallCommand,
+  type AdapterModelProfileDefinition,
+} from "@paperclipai/adapter-utils";
+
+export const type = "antigravity_local";
+export const label = "Antigravity CLI";
+
+export const SANDBOX_INSTALL_COMMAND = buildSandboxNpmInstallCommand("@google/antigravity-cli");
+
+export const DEFAULT_ANTIGRAVITY_LOCAL_MODEL = "auto";
+
+export const models = [
+  { id: DEFAULT_ANTIGRAVITY_LOCAL_MODEL, label: "Auto" },
+  { id: "gemini-3.5-flash-medium", label: "Gemini 3.5 Flash (Medium)" },
+  { id: "gemini-3.5-flash-high", label: "Gemini 3.5 Flash (High)" },
+  { id: "gemini-3.5-flash-low", label: "Gemini 3.5 Flash (Low)" },
+  { id: "gemini-3.1-pro-low", label: "Gemini 3.1 Pro (Low)" },
+  { id: "gemini-3.1-pro-high", label: "Gemini 3.1 Pro (High)" },
+  { id: "claude-sonnet-4.6-thinking", label: "Claude Sonnet 4.6 (Thinking)" },
+  { id: "claude-opus-4.6-thinking", label: "Claude Opus 4.6 (Thinking)" },
+  { id: "gpt-oss-120b-medium", label: "GPT-OSS 120B (Medium)" },
+];
+
+export const modelProfiles: AdapterModelProfileDefinition[] = [
+  {
+    key: "cheap",
+    label: "Cheap",
+    description: "Use Gemini 3.5 Flash (Low) as the budget Antigravity CLI lane while preserving the primary model.",
+    adapterConfig: {
+      model: "gemini-3.5-flash-low",
+    },
+    source: "adapter_default",
+  },
+];
+
+export const agentConfigurationDoc = `# antigravity_local agent configuration
+
+Adapter: antigravity_local
+
+Use when:
+- You want Paperclip to run the Antigravity CLI locally on the host machine
+- You want Antigravity chat sessions resumed across heartbeats with --continue or --conversation <id>
+- You want Paperclip skills injected locally without polluting the global environment
+
+Don't use when:
+- You need webhook-style external invocation (use http or openclaw_gateway)
+- You only need a one-shot script without an AI coding agent loop (use process)
+- Antigravity CLI is not installed on the machine that runs Paperclip
+
+Core fields:
+- cwd (string, optional): default absolute working directory fallback for the agent process (created if missing when possible)
+- instructionsFilePath (string, optional): absolute path to a markdown instructions file prepended to the run prompt
+- promptTemplate (string, optional): run prompt template
+- model (string, optional): Gemini model id used by Antigravity. Defaults to auto.
+- sandbox (boolean, optional): run in sandbox mode (default: false, passes --sandbox)
+- command (string, optional): defaults to "agy"
+- extraArgs (string[], optional): additional CLI args
+- env (object, optional): KEY=VALUE environment variables
+
+Operational fields:
+- timeoutSec (number, optional): run timeout in seconds
+- graceSec (number, optional): SIGTERM grace period in seconds
+
+Notes:
+- Runs use --prompt for non-interactive execution, not stdin.
+- The adapter sets a headless-safe terminal/browser environment for Antigravity CLI child processes so unattended runs do not wait on browser auth or 256-color terminal prompts.
+- Sessions resume with --continue (or --conversation <id>) when stored session cwd matches the current cwd.
+- Paperclip auto-injects local skills into \`~/.gemini/antigravity-cli/skills/\` via symlinks.
+- Authentication can use GEMINI_API_KEY / GOOGLE_API_KEY / ANTIGRAVITY_API_KEY.
+`;
+

--- a/packages/adapters/antigravity-local/src/index.ts
+++ b/packages/adapters/antigravity-local/src/index.ts
@@ -44,7 +44,7 @@ Use when:
 - You want Paperclip skills injected locally without polluting the global environment
 
 Don't use when:
-- You need webhook-style external invocation (use http or openclaw_gateway)
+- You need webhook-style external invocation (use http  or openclaw_gateway)
 - You only need a one-shot script without an AI coding agent loop (use process)
 - Antigravity CLI is not installed on the machine that runs Paperclip
 

--- a/packages/adapters/antigravity-local/src/server/execute.remote.test.ts
+++ b/packages/adapters/antigravity-local/src/server/execute.remote.test.ts
@@ -18,12 +18,12 @@ const {
     signal: null,
     timedOut: false,
     stdout: [
-      JSON.stringify({ type: "system", subtype: "init", session_id: "gemini-session-1", model: "gemini-2.5-pro" }),
+      JSON.stringify({ type: "system", subtype: "init", session_id: "antigravity-session-1", model: "gemini-2.5-pro" }),
       JSON.stringify({ type: "message", role: "assistant", content: "hello" }),
       JSON.stringify({
         type: "result",
         status: "success",
-        session_id: "gemini-session-1",
+        session_id: "antigravity-session-1",
         stats: { input_tokens: 1, cached_input_tokens: 0, output_tokens: 1 },
       }),
     ].join("\n"),
@@ -32,7 +32,7 @@ const {
     startedAt: new Date().toISOString(),
   })),
   ensureCommandResolvable: vi.fn(async () => undefined),
-  resolveCommandForLogs: vi.fn(async () => "ssh://fixture@127.0.0.1:2222/remote/workspace :: gemini"),
+  resolveCommandForLogs: vi.fn(async () => "ssh://fixture@127.0.0.1:2222/remote/workspace :: agy"),
   prepareWorkspaceForSshExecution: vi.fn(async () => ({ gitBacked: false })),
   restoreWorkspaceFromSshExecution: vi.fn(async () => undefined),
   runSshCommand: vi.fn(async () => ({
@@ -88,7 +88,7 @@ vi.mock("@paperclipai/adapter-utils/execution-target", async () => {
 
 import { execute } from "./execute.js";
 
-describe("gemini remote execution", () => {
+describe("antigravity remote execution", () => {
   const cleanupDirs: string[] = [];
 
   afterEach(async () => {
@@ -100,8 +100,8 @@ describe("gemini remote execution", () => {
     }
   });
 
-  it("prepares the workspace, syncs Gemini skills, and restores workspace changes for remote SSH execution", async () => {
-    const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-gemini-remote-"));
+  it("prepares the workspace, syncs Antigravity skills, and restores workspace changes for remote SSH execution", async () => {
+    const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-antigravity-remote-"));
     cleanupDirs.push(rootDir);
     const workspaceDir = path.join(rootDir, "workspace");
     const alternateWorkspaceDir = path.join(rootDir, "workspace-other");
@@ -114,8 +114,8 @@ describe("gemini remote execution", () => {
       agent: {
         id: "agent-1",
         companyId: "company-1",
-        name: "Gemini Builder",
-        adapterType: "gemini_local",
+        name: "Antigravity Builder",
+        adapterType: "antigravity_local",
         adapterConfig: {},
       },
       runtime: {
@@ -125,9 +125,9 @@ describe("gemini remote execution", () => {
         taskKey: null,
       },
       config: {
-        command: "gemini",
+        command: "agy",
         env: {
-          GEMINI_API_KEY: "test-key",
+          ANTIGRAVITY_API_KEY: "test-key",
           NO_COLOR: "1",
         },
       },
@@ -167,7 +167,7 @@ describe("gemini remote execution", () => {
     });
 
     expect(result.sessionParams).toMatchObject({
-      sessionId: "gemini-session-1",
+      sessionId: "antigravity-session-1",
       cwd: managedRemoteWorkspace,
       remoteExecution: {
         transport: "ssh",
@@ -180,12 +180,12 @@ describe("gemini remote execution", () => {
     expect(prepareWorkspaceForSshExecution).toHaveBeenCalledTimes(1);
     expect(syncDirectoryToSsh).toHaveBeenCalledTimes(1);
     expect(syncDirectoryToSsh).toHaveBeenCalledWith(expect.objectContaining({
-      remoteDir: `${managedRemoteWorkspace}/.paperclip-runtime/gemini/skills`,
+      remoteDir: `${managedRemoteWorkspace}/.paperclip-runtime/antigravity/skills`,
       followSymlinks: true,
     }));
     expect(runSshCommand).toHaveBeenCalledWith(
       expect.anything(),
-      expect.stringContaining(".gemini/skills"),
+      expect.stringContaining(".gemini/antigravity-cli/skills"),
       expect.anything(),
     );
     // The headless-auth settings.json write is scoped to managed HOMEs (sandbox
@@ -193,7 +193,7 @@ describe("gemini remote execution", () => {
     // stay visible and the adapter must not create files.
     expect(runSshCommand).not.toHaveBeenCalledWith(
       expect.anything(),
-      expect.stringContaining(".gemini/settings.json"),
+      expect.stringContaining(".gemini/antigravity-cli/settings.json"),
       expect.anything(),
     );
     expect(runSshCommand).not.toHaveBeenCalledWith(
@@ -220,7 +220,7 @@ describe("gemini remote execution", () => {
     ]);
     expect(call?.[3].env.PAPERCLIP_API_URL).toBe("http://127.0.0.1:4310");
     expect(call?.[3].env.PAPERCLIP_API_BRIDGE_MODE).toBe("queue_v1");
-    expect(call?.[3].env.GEMINI_CLI_TRUST_WORKSPACE).toBe("true");
+    expect(call?.[3].env.ANTIGRAVITY_CLI_TRUST_WORKSPACE).toBe("true");
     expect(call?.[3].env.TERM).toBe("xterm-256color");
     expect(call?.[3].env.COLORTERM).toBe("truecolor");
     expect(call?.[3].env.NO_BROWSER).toBe("1");
@@ -231,18 +231,18 @@ describe("gemini remote execution", () => {
   });
 
   it("pre-selects gemini-api-key auth in the managed HOME for sandbox execution", async () => {
-    const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-gemini-sandbox-"));
+    const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-antigravity-sandbox-"));
     cleanupDirs.push(rootDir);
     const workspaceDir = path.join(rootDir, "workspace");
     await mkdir(workspaceDir, { recursive: true });
 
-    const geminiOutput = [
-      JSON.stringify({ type: "system", subtype: "init", session_id: "gemini-session-2", model: "gemini-2.5-pro" }),
+    const antigravityOutput = [
+      JSON.stringify({ type: "system", subtype: "init", session_id: "antigravity-session-2", model: "gemini-2.5-pro" }),
       JSON.stringify({ type: "message", role: "assistant", content: "hello" }),
       JSON.stringify({
         type: "result",
         status: "success",
-        session_id: "gemini-session-2",
+        session_id: "antigravity-session-2",
         stats: { input_tokens: 1, cached_input_tokens: 0, output_tokens: 1 },
       }),
     ].join("\n");
@@ -263,7 +263,7 @@ describe("gemini remote execution", () => {
         exitCode: 0,
         signal: null,
         timedOut: false,
-        stdout: input.command === "gemini" || script.includes("gemini ") ? geminiOutput : "",
+        stdout: input.command === "agy" || script.includes("agy ") ? antigravityOutput : "",
         stderr: "",
         pid: 321,
         startedAt: new Date().toISOString(),
@@ -275,8 +275,8 @@ describe("gemini remote execution", () => {
       agent: {
         id: "agent-1",
         companyId: "company-1",
-        name: "Gemini Builder",
-        adapterType: "gemini_local",
+        name: "Antigravity Builder",
+        adapterType: "antigravity_local",
         adapterConfig: {},
       },
       runtime: {
@@ -286,8 +286,8 @@ describe("gemini remote execution", () => {
         taskKey: null,
       },
       config: {
-        command: "gemini",
-        env: { GEMINI_API_KEY: "test-key" },
+        command: "agy",
+        env: { ANTIGRAVITY_API_KEY: "test-key" },
       },
       context: {
         paperclipWorkspace: {
@@ -308,15 +308,15 @@ describe("gemini remote execution", () => {
     const runnerScripts = runnerExecute.mock.calls.map(
       (call) => `${call[0].command} ${(call[0].args ?? []).join(" ")}`,
     );
-    const settingsWrite = runnerScripts.find((script) => script.includes(".gemini/settings.json"));
+    const settingsWrite = runnerScripts.find((script) => script.includes(".gemini/antigravity-cli/settings.json"));
     expect(settingsWrite).toBeDefined();
     expect(settingsWrite).toContain("gemini-api-key");
     // The managed HOME lives under the per-run runtime root, never a real home.
     expect(settingsWrite).toContain(".paperclip-runtime");
   });
 
-  it("resumes saved Gemini sessions for remote SSH execution only when the identity matches", async () => {
-    const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-gemini-remote-resume-"));
+  it("resumes saved Antigravity sessions for remote SSH execution only when the identity matches", async () => {
+    const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-antigravity-remote-resume-"));
     cleanupDirs.push(rootDir);
     const workspaceDir = path.join(rootDir, "workspace");
     const managedRemoteWorkspace = "/remote/workspace/.paperclip-runtime/runs/run-ssh-resume/workspace";
@@ -327,8 +327,8 @@ describe("gemini remote execution", () => {
       agent: {
         id: "agent-1",
         companyId: "company-1",
-        name: "Gemini Builder",
-        adapterType: "gemini_local",
+        name: "Antigravity Builder",
+        adapterType: "antigravity_local",
         adapterConfig: {},
       },
       runtime: {
@@ -348,7 +348,7 @@ describe("gemini remote execution", () => {
         taskKey: null,
       },
       config: {
-        command: "gemini",
+        command: "agy",
       },
       context: {
         paperclipWorkspace: {
@@ -372,12 +372,12 @@ describe("gemini remote execution", () => {
     });
 
     const call = runChildProcess.mock.calls[0] as unknown as [string, string, string[]] | undefined;
-    expect(call?.[2]).toContain("--resume");
+    expect(call?.[2]).toContain("--conversation");
     expect(call?.[2]).toContain("session-123");
   });
 
   it("restores the remote workspace if skills sync fails after workspace prep", async () => {
-    const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-gemini-remote-sync-fail-"));
+    const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-antigravity-remote-sync-fail-"));
     cleanupDirs.push(rootDir);
     const workspaceDir = path.join(rootDir, "workspace");
     await mkdir(workspaceDir, { recursive: true });
@@ -388,8 +388,8 @@ describe("gemini remote execution", () => {
       agent: {
         id: "agent-1",
         companyId: "company-1",
-        name: "Gemini Builder",
-        adapterType: "gemini_local",
+        name: "Antigravity Builder",
+        adapterType: "antigravity_local",
         adapterConfig: {},
       },
       runtime: {
@@ -399,7 +399,7 @@ describe("gemini remote execution", () => {
         taskKey: null,
       },
       config: {
-        command: "gemini",
+        command: "agy",
       },
       context: {
         paperclipWorkspace: {

--- a/packages/adapters/antigravity-local/src/server/execute.ts
+++ b/packages/adapters/antigravity-local/src/server/execute.ts
@@ -1,0 +1,721 @@
+import fs from "node:fs/promises";
+import type { Dirent } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import type { AdapterExecutionContext, AdapterExecutionResult } from "@paperclipai/adapter-utils";
+import {
+  adapterExecutionTargetIsRemote,
+  adapterExecutionTargetRemoteCwd,
+  overrideAdapterExecutionTargetRemoteCwd,
+  adapterExecutionTargetSessionIdentity,
+  adapterExecutionTargetSessionMatches,
+  adapterExecutionTargetUsesManagedHome,
+  adapterExecutionTargetUsesPaperclipBridge,
+  describeAdapterExecutionTarget,
+  ensureAdapterExecutionTargetCommandResolvable,
+  ensureAdapterExecutionTargetRuntimeCommandInstalled,
+  prepareAdapterExecutionTargetRuntime,
+  readAdapterExecutionTarget,
+  readAdapterExecutionTargetHomeDir,
+  resolveAdapterExecutionTargetTimeoutSec,
+  resolveAdapterExecutionTargetCommandForLogs,
+  runAdapterExecutionTargetProcess,
+  runAdapterExecutionTargetShellCommand,
+  startAdapterExecutionTargetPaperclipBridge,
+} from "@paperclipai/adapter-utils/execution-target";
+import {
+  asBoolean,
+  asNumber,
+  asString,
+  asStringArray,
+  buildPaperclipEnv,
+  buildInvocationEnvForLogs,
+  ensureAbsoluteDirectory,
+  ensurePaperclipSkillSymlink,
+  joinPromptSections,
+  ensurePathInEnv,
+  refreshPaperclipWorkspaceEnvForExecution,
+  readPaperclipRuntimeSkillEntries,
+  readPaperclipIssueWorkModeFromContext,
+  resolvePaperclipDesiredSkillNames,
+  removeMaintainerOnlySkillSymlinks,
+  parseObject,
+  renderTemplate,
+  renderPaperclipWakePrompt,
+  stringifyPaperclipWakePayload,
+  DEFAULT_PAPERCLIP_AGENT_PROMPT_TEMPLATE,
+  runChildProcess,
+} from "@paperclipai/adapter-utils/server-utils";
+import { DEFAULT_ANTIGRAVITY_LOCAL_MODEL, SANDBOX_INSTALL_COMMAND } from "../index.js";
+import {
+  describeAntigravityFailure,
+  detectAntigravityAuthRequired,
+  isAntigravityTransientNetworkError,
+  isAntigravityTurnLimitResult,
+  isAntigravitySessionUnrecoverableError,
+  parseAntigravityJsonl,
+} from "./parse.js";
+import { firstNonEmptyLine } from "./utils.js";
+
+const __moduleDir = path.dirname(fileURLToPath(import.meta.url));
+
+function hasNonEmptyEnvValue(env: Record<string, string>, key: string): boolean {
+  const raw = env[key];
+  return typeof raw === "string" && raw.trim().length > 0;
+}
+
+function resolveAntigravityBillingType(env: Record<string, string>): "api" | "subscription" {
+  return hasNonEmptyEnvValue(env, "ANTIGRAVITY_API_KEY") || hasNonEmptyEnvValue(env, "GEMINI_API_KEY") || hasNonEmptyEnvValue(env, "GOOGLE_API_KEY")
+    ? "api"
+    : "subscription";
+}
+
+function buildAntigravityHeadlessEnv(env: Record<string, string>): Record<string, string> {
+  const next = { ...env };
+  const term = env.TERM?.trim().toLowerCase();
+  if (!term || term === "dumb" || term === "vt100") {
+    next.TERM = "xterm-256color";
+  }
+  if (!next.COLORTERM?.trim()) {
+    next.COLORTERM = "truecolor";
+  }
+  next.NO_BROWSER = "1";
+  delete next.NO_COLOR;
+  return next;
+}
+
+function buildAntigravityRuntimeEnv(env: Record<string, string>): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(ensurePathInEnv({ ...process.env, ...buildAntigravityHeadlessEnv(env) })).filter(
+      (entry): entry is [string, string] => typeof entry[1] === "string",
+    ),
+  );
+}
+
+function renderPaperclipEnvNote(env: Record<string, string>): string {
+  const paperclipKeys = Object.keys(env)
+    .filter((key) => key.startsWith("PAPERCLIP_"))
+    .sort();
+  if (paperclipKeys.length === 0) return "";
+  return [
+    "Paperclip runtime note:",
+    `The following PAPERCLIP_* environment variables are available in this run: ${paperclipKeys.join(", ")}`,
+    "Do not assume these variables are missing without checking your shell environment.",
+    "",
+    "",
+  ].join("\n");
+}
+
+function renderApiAccessNote(env: Record<string, string>): string {
+  if (!hasNonEmptyEnvValue(env, "PAPERCLIP_API_URL") || !hasNonEmptyEnvValue(env, "PAPERCLIP_API_KEY")) return "";
+  return [
+    "Paperclip API access note:",
+    "Use run_shell_command with curl to make Paperclip API requests.",
+    "GET example:",
+    `  run_shell_command({ command: "curl -s -H \\"Authorization: Bearer $PAPERCLIP_API_KEY\\" \\"$PAPERCLIP_API_URL/api/agents/me\\"" })`,
+    "POST/PATCH example:",
+    `  run_shell_command({ command: "curl -s -X POST -H \\"Authorization: Bearer $PAPERCLIP_API_KEY\\" -H 'Content-Type: application/json' -H \\"X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID\\" -d '{...}' \\"$PAPERCLIP_API_URL/api/issues/{id}/checkout\\"" })`,
+    "",
+    "",
+  ].join("\n");
+}
+
+function antigravitySkillsHome(): string {
+  return path.join(os.homedir(), ".gemini", "antigravity-cli", "skills");
+}
+
+/**
+ * Inject Paperclip skills directly into `~/.gemini/antigravity-cli/skills/` via symlinks.
+ * This avoids needing ANTIGRAVITY_CLI_HOME overrides, so the CLI naturally finds
+ * both its auth credentials and the injected skills in the real home directory.
+ */
+async function ensureAntigravitySkillsInjected(
+  onLog: AdapterExecutionContext["onLog"],
+  skillsEntries: Array<{ key: string; runtimeName: string; source: string }>,
+  desiredSkillNames?: string[],
+): Promise<void> {
+  const desiredSet = new Set(desiredSkillNames ?? skillsEntries.map((entry) => entry.key));
+  const selectedEntries = skillsEntries.filter((entry) => desiredSet.has(entry.key));
+  if (selectedEntries.length === 0) return;
+
+  const skillsHome = antigravitySkillsHome();
+  try {
+    await fs.mkdir(skillsHome, { recursive: true });
+  } catch (err) {
+    await onLog(
+      "stderr",
+      `[paperclip] Failed to prepare Antigravity skills directory ${skillsHome}: ${err instanceof Error ? err.message : String(err)}\n`,
+    );
+    return;
+  }
+  const removedSkills = await removeMaintainerOnlySkillSymlinks(
+    skillsHome,
+    selectedEntries.map((entry) => entry.runtimeName),
+  );
+  for (const skillName of removedSkills) {
+    await onLog(
+      "stderr",
+      `[paperclip] Removed maintainer-only Antigravity skill "${skillName}" from ${skillsHome}\n`,
+    );
+  }
+
+  for (const entry of selectedEntries) {
+    const target = path.join(skillsHome, entry.runtimeName);
+
+    try {
+      const result = await ensurePaperclipSkillSymlink(entry.source, target);
+      if (result === "skipped") continue;
+      await onLog(
+        "stderr",
+        `[paperclip] ${result === "repaired" ? "Repaired" : "Linked"} Antigravity skill: ${entry.key}\n`,
+      );
+    } catch (err) {
+      await onLog(
+        "stderr",
+        `[paperclip] Failed to link Antigravity skill "${entry.key}": ${err instanceof Error ? err.message : String(err)}\n`,
+      );
+    }
+  }
+}
+
+async function buildAntigravitySkillsDir(
+  config: Record<string, unknown>,
+): Promise<string> {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-antigravity-skills-"));
+  const target = path.join(tmp, "skills");
+  await fs.mkdir(target, { recursive: true });
+  const availableEntries = await readPaperclipRuntimeSkillEntries(config, __moduleDir);
+  const desiredNames = new Set(resolvePaperclipDesiredSkillNames(config, availableEntries));
+  for (const entry of availableEntries) {
+    if (!desiredNames.has(entry.key)) continue;
+    await fs.symlink(entry.source, path.join(target, entry.runtimeName));
+  }
+  return target;
+}
+
+export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExecutionResult> {
+  const { runId, agent, runtime, config, context, onLog, onMeta, onSpawn, authToken } = ctx;
+  const executionTarget = readAdapterExecutionTarget({
+    executionTarget: ctx.executionTarget,
+    legacyRemoteExecution: ctx.executionTransport?.remoteExecution,
+  });
+  const executionTargetIsRemote = adapterExecutionTargetIsRemote(executionTarget);
+
+  const promptTemplate = asString(
+    config.promptTemplate,
+    DEFAULT_PAPERCLIP_AGENT_PROMPT_TEMPLATE,
+  );
+  const command = asString(config.command, "agy");
+  const model = asString(config.model, DEFAULT_ANTIGRAVITY_LOCAL_MODEL).trim();
+  const sandbox = asBoolean(config.sandbox, false);
+
+  const workspaceContext = parseObject(context.paperclipWorkspace);
+  const workspaceCwd = asString(workspaceContext.cwd, "");
+  const workspaceSource = asString(workspaceContext.source, "");
+  const workspaceId = asString(workspaceContext.workspaceId, "");
+  const workspaceRepoUrl = asString(workspaceContext.repoUrl, "");
+  const workspaceRepoRef = asString(workspaceContext.repoRef, "");
+  const agentHome = asString(workspaceContext.agentHome, "");
+  const workspaceHints = Array.isArray(context.paperclipWorkspaces)
+    ? context.paperclipWorkspaces.filter(
+      (value): value is Record<string, unknown> => typeof value === "object" && value !== null,
+    )
+    : [];
+  const configuredCwd = asString(config.cwd, "");
+  const useConfiguredInsteadOfAgentHome = workspaceSource === "agent_home" && configuredCwd.length > 0;
+  const effectiveWorkspaceCwd = useConfiguredInsteadOfAgentHome ? "" : workspaceCwd;
+  const cwd = effectiveWorkspaceCwd || configuredCwd || process.cwd();
+  let effectiveExecutionCwd = adapterExecutionTargetRemoteCwd(executionTarget, cwd);
+  await ensureAbsoluteDirectory(cwd, { createIfMissing: true });
+  const antigravitySkillEntries = await readPaperclipRuntimeSkillEntries(config, __moduleDir);
+  const desiredAntigravitySkillNames = resolvePaperclipDesiredSkillNames(config, antigravitySkillEntries);
+  if (!executionTargetIsRemote) {
+    await ensureAntigravitySkillsInjected(onLog, antigravitySkillEntries, desiredAntigravitySkillNames);
+  }
+
+  const envConfig = parseObject(config.env);
+  const hasExplicitApiKey =
+    (typeof envConfig.PAPERCLIP_API_KEY === "string" && envConfig.PAPERCLIP_API_KEY.trim().length > 0) ||
+    (typeof envConfig.ANTIGRAVITY_API_KEY === "string" && envConfig.ANTIGRAVITY_API_KEY.trim().length > 0);
+  const env: Record<string, string> = { ...buildPaperclipEnv(agent) };
+  env.PAPERCLIP_RUN_ID = runId;
+  const wakeTaskId =
+    (typeof context.taskId === "string" && context.taskId.trim().length > 0 && context.taskId.trim()) ||
+    (typeof context.issueId === "string" && context.issueId.trim().length > 0 && context.issueId.trim()) ||
+    null;
+  const wakeReason =
+    typeof context.wakeReason === "string" && context.wakeReason.trim().length > 0
+      ? context.wakeReason.trim()
+      : null;
+  const wakeCommentId =
+    (typeof context.wakeCommentId === "string" && context.wakeCommentId.trim().length > 0 && context.wakeCommentId.trim()) ||
+    (typeof context.commentId === "string" && context.commentId.trim().length > 0 && context.commentId.trim()) ||
+    null;
+  const approvalId =
+    typeof context.approvalId === "string" && context.approvalId.trim().length > 0
+      ? context.approvalId.trim()
+      : null;
+  const approvalStatus =
+    typeof context.approvalStatus === "string" && context.approvalStatus.trim().length > 0
+      ? context.approvalStatus.trim()
+      : null;
+  const linkedIssueIds = Array.isArray(context.issueIds)
+    ? context.issueIds.filter((value): value is string => typeof value === "string" && value.trim().length > 0)
+    : [];
+  const wakePayloadJson = stringifyPaperclipWakePayload(context.paperclipWake);
+  const issueWorkMode = readPaperclipIssueWorkModeFromContext(context);
+  if (wakeTaskId) env.PAPERCLIP_TASK_ID = wakeTaskId;
+  if (issueWorkMode) env.PAPERCLIP_ISSUE_WORK_MODE = issueWorkMode;
+  if (wakeReason) env.PAPERCLIP_WAKE_REASON = wakeReason;
+  if (wakeCommentId) env.PAPERCLIP_WAKE_COMMENT_ID = wakeCommentId;
+  if (approvalId) env.PAPERCLIP_APPROVAL_ID = approvalId;
+  if (approvalStatus) env.PAPERCLIP_APPROVAL_STATUS = approvalStatus;
+  if (linkedIssueIds.length > 0) env.PAPERCLIP_LINKED_ISSUE_IDS = linkedIssueIds.join(",");
+  if (wakePayloadJson) env.PAPERCLIP_WAKE_PAYLOAD_JSON = wakePayloadJson;
+  refreshPaperclipWorkspaceEnvForExecution({
+    env,
+    envConfig,
+    workspaceCwd: effectiveWorkspaceCwd,
+    workspaceSource,
+    workspaceId,
+    workspaceRepoUrl,
+    workspaceRepoRef,
+    workspaceHints,
+    agentHome,
+    executionTargetIsRemote,
+    executionCwd: effectiveExecutionCwd,
+  });
+  if (executionTargetIsRemote && typeof env.ANTIGRAVITY_CLI_TRUST_WORKSPACE !== "string") {
+    env.ANTIGRAVITY_CLI_TRUST_WORKSPACE = "true";
+  }
+  if (!hasExplicitApiKey && authToken) {
+    env.PAPERCLIP_API_KEY = authToken;
+  }
+  const runtimeEnv = buildAntigravityRuntimeEnv(env);
+  const billingType = resolveAntigravityBillingType(runtimeEnv);
+  const timeoutSec = resolveAdapterExecutionTargetTimeoutSec(
+    executionTarget,
+    asNumber(config.timeoutSec, 0),
+  );
+  const graceSec = asNumber(config.graceSec, 20);
+  await ensureAdapterExecutionTargetRuntimeCommandInstalled({
+    runId,
+    target: executionTarget,
+    installCommand: ctx.runtimeCommandSpec?.installCommand,
+    detectCommand: ctx.runtimeCommandSpec?.detectCommand,
+    cwd,
+    env: runtimeEnv,
+    timeoutSec,
+    graceSec,
+    onLog,
+  });
+  await ensureAdapterExecutionTargetCommandResolvable(command, executionTarget, cwd, runtimeEnv, {
+    installCommand: SANDBOX_INSTALL_COMMAND,
+    timeoutSec,
+  });
+  const resolvedCommand = await resolveAdapterExecutionTargetCommandForLogs(command, executionTarget, cwd, runtimeEnv);
+  const extraArgs = (() => {
+    const fromExtraArgs = asStringArray(config.extraArgs);
+    if (fromExtraArgs.length > 0) return fromExtraArgs;
+    return asStringArray(config.args);
+  })();
+  let restoreRemoteWorkspace: (() => Promise<void>) | null = null;
+  let remoteSkillsDir: string | null = null;
+  let localSkillsDir: string | null = null;
+  let remoteRuntimeRootDir: string | null = null;
+  let paperclipBridge: Awaited<ReturnType<typeof startAdapterExecutionTargetPaperclipBridge>> = null;
+
+  if (executionTargetIsRemote) {
+    try {
+      localSkillsDir = await buildAntigravitySkillsDir(config);
+      await onLog(
+        "stdout",
+        `[paperclip] Syncing workspace and Antigravity runtime assets to ${describeAdapterExecutionTarget(executionTarget)}.\n`,
+      );
+      const preparedExecutionTargetRuntime = await prepareAdapterExecutionTargetRuntime({
+        runId,
+        target: executionTarget,
+        adapterKey: "antigravity",
+        timeoutSec,
+        workspaceLocalDir: cwd,
+        installCommand: SANDBOX_INSTALL_COMMAND,
+        detectCommand: command,
+        onProgress: (line) => onLog("stdout", line),
+        onRuntimeProgress: ctx.onRuntimeProgress,
+        assets: [{
+          key: "skills",
+          localDir: localSkillsDir,
+          followSymlinks: true,
+        }],
+      });
+      restoreRemoteWorkspace = () =>
+        preparedExecutionTargetRuntime.restoreWorkspace((line) => onLog("stdout", line));
+      effectiveExecutionCwd = preparedExecutionTargetRuntime.workspaceRemoteDir ?? effectiveExecutionCwd;
+      refreshPaperclipWorkspaceEnvForExecution({
+        env,
+        envConfig,
+        workspaceCwd: effectiveWorkspaceCwd,
+        workspaceSource,
+        workspaceId,
+        workspaceRepoUrl,
+        workspaceRepoRef,
+        workspaceHints,
+        agentHome,
+        executionTargetIsRemote,
+        executionCwd: effectiveExecutionCwd,
+      });
+      remoteRuntimeRootDir = preparedExecutionTargetRuntime.runtimeRootDir;
+      const managedHome = adapterExecutionTargetUsesManagedHome(executionTarget);
+      const managedRemoteHomeDir =
+        managedHome && preparedExecutionTargetRuntime.runtimeRootDir
+          ? preparedExecutionTargetRuntime.runtimeRootDir
+          : null;
+      if (managedRemoteHomeDir) {
+        env.HOME = managedRemoteHomeDir;
+      }
+      const remoteHomeDir =
+        managedRemoteHomeDir ??
+        (await readAdapterExecutionTargetHomeDir(runId, executionTarget, {
+          cwd,
+          env,
+          timeoutSec,
+          graceSec,
+          onLog,
+        }));
+      if (remoteHomeDir && preparedExecutionTargetRuntime.assetDirs.skills) {
+        remoteSkillsDir = path.posix.join(remoteHomeDir, ".gemini", "antigravity-cli", "skills");
+        await runAdapterExecutionTargetShellCommand(
+          runId,
+          executionTarget,
+          `mkdir -p ${JSON.stringify(path.posix.dirname(remoteSkillsDir))} && rm -rf ${JSON.stringify(remoteSkillsDir)} && cp -a ${JSON.stringify(preparedExecutionTargetRuntime.assetDirs.skills)} ${JSON.stringify(remoteSkillsDir)}`,
+          { cwd, env, timeoutSec, graceSec, onLog },
+        );
+      }
+      const hasAntigravityApiKey = Boolean(
+        env.ANTIGRAVITY_API_KEY || env.GEMINI_API_KEY || env.GOOGLE_API_KEY ||
+        process.env.ANTIGRAVITY_API_KEY || process.env.GEMINI_API_KEY || process.env.GOOGLE_API_KEY,
+      );
+      if (managedRemoteHomeDir && hasAntigravityApiKey) {
+        const remoteSettingsPath = path.posix.join(managedRemoteHomeDir, ".gemini", "antigravity-cli", "settings.json");
+        const authSettingsJson = JSON.stringify({
+          selectedAuthType: "gemini-api-key",
+          security: { auth: { selectedType: "gemini-api-key" } },
+        });
+        await runAdapterExecutionTargetShellCommand(
+          runId,
+          executionTarget,
+          `mkdir -p ${JSON.stringify(path.posix.dirname(remoteSettingsPath))} && { [ -f ${JSON.stringify(remoteSettingsPath)} ] || printf '%s' ${JSON.stringify(authSettingsJson)} > ${JSON.stringify(remoteSettingsPath)}; }`,
+          { cwd, env, timeoutSec, graceSec, onLog },
+        );
+      }
+    } catch (error) {
+      await Promise.allSettled([
+        restoreRemoteWorkspace?.(),
+        localSkillsDir ? fs.rm(path.dirname(localSkillsDir), { recursive: true, force: true }).catch(() => undefined) : Promise.resolve(),
+      ]);
+      throw error;
+    }
+  }
+  const runtimeExecutionTarget = overrideAdapterExecutionTargetRemoteCwd(executionTarget, effectiveExecutionCwd);
+  if (executionTargetIsRemote && adapterExecutionTargetUsesPaperclipBridge(executionTarget)) {
+    paperclipBridge = await startAdapterExecutionTargetPaperclipBridge({
+      runId,
+      target: runtimeExecutionTarget,
+      runtimeRootDir: remoteRuntimeRootDir,
+      adapterKey: "antigravity",
+      timeoutSec,
+      hostApiToken: env.PAPERCLIP_API_KEY,
+      onLog,
+    });
+    if (paperclipBridge) {
+      Object.assign(env, paperclipBridge.env);
+    }
+  }
+
+  const runtimeSessionParams = parseObject(runtime.sessionParams);
+  const runtimeSessionId = asString(runtimeSessionParams.sessionId, runtime.sessionId ?? "");
+  const runtimeSessionCwd = asString(runtimeSessionParams.cwd, "");
+  const runtimeRemoteExecution = parseObject(runtimeSessionParams.remoteExecution);
+  const canResumeSession =
+    runtimeSessionId.length > 0 &&
+    (runtimeSessionCwd.length === 0 || path.resolve(runtimeSessionCwd) === path.resolve(effectiveExecutionCwd)) &&
+    adapterExecutionTargetSessionMatches(runtimeRemoteExecution, runtimeExecutionTarget);
+  const sessionId = canResumeSession ? runtimeSessionId : null;
+  if (executionTargetIsRemote && runtimeSessionId && !canResumeSession) {
+    await onLog(
+      "stdout",
+      `[paperclip] Antigravity session "${runtimeSessionId}" does not match the current remote execution identity and will not be resumed in "${effectiveExecutionCwd}". Starting a fresh remote session.\n`,
+    );
+  } else if (runtimeSessionId && !canResumeSession) {
+    await onLog(
+      "stdout",
+      `[paperclip] Antigravity session "${runtimeSessionId}" was saved for cwd "${runtimeSessionCwd}" and will not be resumed in "${effectiveExecutionCwd}".\n`,
+    );
+  }
+
+  const instructionsFilePath = asString(config.instructionsFilePath, "").trim();
+  const instructionsDir = instructionsFilePath ? `${path.dirname(instructionsFilePath)}/` : "";
+  let instructionsPrefix = "";
+  if (instructionsFilePath) {
+    try {
+      const instructionsContents = await fs.readFile(instructionsFilePath, "utf8");
+      instructionsPrefix =
+        `${instructionsContents}\n\n` +
+        `The above agent instructions were loaded from ${instructionsFilePath}. ` +
+        `Resolve any relative file references from ${instructionsDir}.\n\n`;
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err);
+      await onLog(
+        "stdout",
+        `[paperclip] Warning: could not read agent instructions file "${instructionsFilePath}": ${reason}\n`,
+      );
+    }
+  }
+  const commandNotes = (() => {
+    const notes: string[] = ["Prompt is passed to Antigravity via --prompt for non-interactive execution."];
+    notes.push("Added --dangerously-skip-permissions for unattended execution.");
+    notes.push("Set headless terminal/browser env so Antigravity fails fast instead of opening interactive auth or color prompts.");
+    if (executionTargetIsRemote) {
+      notes.push("Set ANTIGRAVITY_CLI_TRUST_WORKSPACE=true for remote headless execution.");
+    }
+    if (!instructionsFilePath) return notes;
+    if (instructionsPrefix.length > 0) {
+      notes.push(
+        `Loaded agent instructions from ${instructionsFilePath}`,
+        `Prepended instructions + path directive to prompt (relative references from ${instructionsDir}).`,
+      );
+      return notes;
+    }
+    notes.push(
+      `Configured instructionsFilePath ${instructionsFilePath}, but file could not be read; continuing without injected instructions.`,
+    );
+    return notes;
+  })();
+
+  const bootstrapPromptTemplate = asString(config.bootstrapPromptTemplate, "");
+  const templateData = {
+    agentId: agent.id,
+    companyId: agent.companyId,
+    runId,
+    company: { id: agent.companyId },
+    agent,
+    run: { id: runId, source: "on_demand" },
+    context,
+  };
+  const renderedBootstrapPrompt =
+    !sessionId && bootstrapPromptTemplate.trim().length > 0
+      ? renderTemplate(bootstrapPromptTemplate, templateData).trim()
+      : "";
+  const wakePrompt = renderPaperclipWakePrompt(context.paperclipWake, { resumedSession: Boolean(sessionId) });
+  const shouldUseResumeDeltaPrompt = Boolean(sessionId) && wakePrompt.length > 0;
+  const renderedPrompt = shouldUseResumeDeltaPrompt ? "" : renderTemplate(promptTemplate, templateData);
+  const sessionHandoffNote = asString(context.paperclipSessionHandoffMarkdown, "").trim();
+  const paperclipEnvNote = renderPaperclipEnvNote(env);
+  const apiAccessNote = renderApiAccessNote(env);
+  const prompt = joinPromptSections([
+    instructionsPrefix,
+    renderedBootstrapPrompt,
+    wakePrompt,
+    sessionHandoffNote,
+    paperclipEnvNote,
+    apiAccessNote,
+    renderedPrompt,
+  ]);
+  const promptMetrics = {
+    promptChars: prompt.length,
+    instructionsChars: instructionsPrefix.length,
+    bootstrapPromptChars: renderedBootstrapPrompt.length,
+    wakePromptChars: wakePrompt.length,
+    sessionHandoffChars: sessionHandoffNote.length,
+    runtimeNoteChars: paperclipEnvNote.length + apiAccessNote.length,
+    heartbeatPromptChars: renderedPrompt.length,
+  };
+
+  const buildArgs = (resumeSessionId: string | null) => {
+    const args = ["--output-format", "stream-json"];
+    if (resumeSessionId) {
+      args.push("--conversation", resumeSessionId);
+    }
+    if (model && model !== DEFAULT_ANTIGRAVITY_LOCAL_MODEL) args.push("--model", model);
+    args.push("--dangerously-skip-permissions");
+    if (sandbox) {
+      args.push("--sandbox");
+    }
+    if (extraArgs.length > 0) args.push(...extraArgs);
+    args.push("--prompt", prompt);
+    return args;
+  };
+
+  const runAttempt = async (resumeSessionId: string | null) => {
+    const args = buildArgs(resumeSessionId);
+    const invocationEnv = buildAntigravityHeadlessEnv(env);
+    const invocationRuntimeEnv = buildAntigravityRuntimeEnv(env);
+    const loggedEnv = buildInvocationEnvForLogs(invocationEnv, {
+      runtimeEnv: invocationRuntimeEnv,
+      includeRuntimeKeys: ["HOME"],
+      resolvedCommand,
+    });
+    if (onMeta) {
+      await onMeta({
+        adapterType: "antigravity_local",
+        command: resolvedCommand,
+        cwd: effectiveExecutionCwd,
+        commandNotes,
+        commandArgs: args.map((value, index) => (
+          index === args.length - 1 ? `<prompt ${prompt.length} chars>` : value
+        )),
+        env: loggedEnv,
+        prompt,
+        promptMetrics,
+        context,
+      });
+    }
+
+    const proc = await runAdapterExecutionTargetProcess(runId, runtimeExecutionTarget, command, args, {
+      cwd,
+      env: invocationEnv,
+      timeoutSec,
+      graceSec,
+      onSpawn,
+      onRuntimeProgress: ctx.onRuntimeProgress,
+      onLog,
+      runLogTail: paperclipBridge?.runLogTail,
+    });
+    return {
+      proc,
+      parsed: parseAntigravityJsonl(proc.stdout),
+    };
+  };
+
+  const toResult = (
+    attempt: {
+      proc: {
+        exitCode: number | null;
+        signal: string | null;
+        timedOut: boolean;
+        stdout: string;
+        stderr: string;
+      };
+      parsed: ReturnType<typeof parseAntigravityJsonl>;
+    },
+    clearSessionOnMissingSession = false,
+    isRetry = false,
+  ): AdapterExecutionResult => {
+    const authMeta = detectAntigravityAuthRequired({
+      parsed: attempt.parsed.resultEvent,
+      stdout: attempt.proc.stdout,
+      stderr: attempt.proc.stderr,
+    });
+    const networkUnavailable = isAntigravityTransientNetworkError(attempt.proc.stdout, attempt.proc.stderr);
+
+    if (attempt.proc.timedOut) {
+      return {
+        exitCode: attempt.proc.exitCode,
+        signal: attempt.proc.signal,
+        timedOut: true,
+        errorMessage: `Timed out after ${timeoutSec}s`,
+        errorCode: authMeta.requiresAuth
+          ? "antigravity_auth_required"
+          : networkUnavailable
+            ? "antigravity_network_unavailable"
+            : null,
+        clearSession: clearSessionOnMissingSession,
+      };
+    }
+
+    const parsedError = typeof attempt.parsed.errorMessage === "string" ? attempt.parsed.errorMessage.trim() : "";
+    const stderrLine = firstNonEmptyLine(attempt.proc.stderr);
+    const structuredFailure = attempt.parsed.resultEvent
+      ? describeAntigravityFailure(attempt.parsed.resultEvent)
+      : null;
+    const fallbackErrorMessage =
+      parsedError ||
+      structuredFailure ||
+      stderrLine ||
+      `Antigravity exited with code ${attempt.proc.exitCode ?? -1}`;
+    const failed = (attempt.proc.exitCode ?? 0) !== 0;
+    const clearSessionForTurnLimit = isAntigravityTurnLimitResult(
+      attempt.parsed.resultEvent,
+      attempt.proc.exitCode,
+    );
+
+    // On retry, don't fall back to old session ID — the old session was stale
+    const canFallbackToRuntimeSession = !isRetry;
+    const resolvedSessionId = attempt.parsed.sessionId
+      ?? (canFallbackToRuntimeSession ? (runtimeSessionId ?? runtime.sessionId ?? null) : null);
+    const resolvedSessionParams = resolvedSessionId
+      ? ({
+        sessionId: resolvedSessionId,
+        cwd: effectiveExecutionCwd,
+        ...(workspaceId ? { workspaceId } : {}),
+        ...(workspaceRepoUrl ? { repoUrl: workspaceRepoUrl } : {}),
+        ...(workspaceRepoRef ? { repoRef: workspaceRepoRef } : {}),
+        ...(executionTargetIsRemote
+          ? {
+              remoteExecution: adapterExecutionTargetSessionIdentity(runtimeExecutionTarget),
+            }
+          : {}),
+      } as Record<string, unknown>)
+      : null;
+    const resultJson: Record<string, unknown> = {
+      ...(attempt.parsed.resultEvent ?? {
+        stdout: attempt.proc.stdout,
+        stderr: attempt.proc.stderr,
+      }),
+      ...(failed && clearSessionForTurnLimit ? { stopReason: "max_turns_exhausted" } : {}),
+    };
+
+    return {
+      exitCode: attempt.proc.exitCode,
+      signal: attempt.proc.signal,
+      timedOut: false,
+      errorMessage: failed ? fallbackErrorMessage : null,
+      errorCode: failed && authMeta.requiresAuth
+        ? "antigravity_auth_required"
+        : failed && clearSessionForTurnLimit
+        ? "max_turns_exhausted"
+        : failed && networkUnavailable
+        ? "antigravity_network_unavailable"
+        : null,
+      usage: attempt.parsed.usage,
+      sessionId: resolvedSessionId,
+      sessionParams: resolvedSessionParams,
+      sessionDisplayId: resolvedSessionId,
+      provider: "google",
+      biller: "google",
+      model,
+      billingType,
+      costUsd: attempt.parsed.costUsd,
+      resultJson,
+      summary: attempt.parsed.summary,
+      question: attempt.parsed.question,
+      clearSession: clearSessionForTurnLimit || Boolean(clearSessionOnMissingSession && !resolvedSessionId),
+    };
+  };
+
+  try {
+    const initial = await runAttempt(sessionId);
+    if (
+      sessionId &&
+      !initial.proc.timedOut &&
+      (initial.proc.exitCode ?? 0) !== 0 &&
+      isAntigravitySessionUnrecoverableError(initial.proc.stdout, initial.proc.stderr)
+    ) {
+      await onLog(
+        "stdout",
+        `[paperclip] Antigravity resume session "${sessionId}" is unavailable; retrying with a fresh session.\n`,
+      );
+      const retry = await runAttempt(null);
+      return toResult(retry, true, true);
+    }
+
+    return toResult(initial);
+  } finally {
+    await Promise.all([
+      paperclipBridge?.stop(),
+      restoreRemoteWorkspace?.(),
+      localSkillsDir ? fs.rm(path.dirname(localSkillsDir), { recursive: true, force: true }).catch(() => undefined) : Promise.resolve(),
+    ]);
+  }
+}

--- a/packages/adapters/antigravity-local/src/server/index.ts
+++ b/packages/adapters/antigravity-local/src/server/index.ts
@@ -1,0 +1,72 @@
+export { execute } from "./execute.js";
+export { listAntigravitySkills, syncAntigravitySkills } from "./skills.js";
+export { testEnvironment } from "./test.js";
+export {
+  parseAntigravityJsonl,
+  isAntigravitySessionUnrecoverableError,
+  isAntigravityTransientNetworkError,
+  describeAntigravityFailure,
+  detectAntigravityAuthRequired,
+  isAntigravityTurnLimitResult,
+} from "./parse.js";
+import type { AdapterSessionCodec } from "@paperclipai/adapter-utils";
+
+function readNonEmptyString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+export const sessionCodec: AdapterSessionCodec = {
+  deserialize(raw: unknown) {
+    if (typeof raw !== "object" || raw === null || Array.isArray(raw)) return null;
+    const record = raw as Record<string, unknown>;
+    const sessionId =
+      readNonEmptyString(record.sessionId) ??
+      readNonEmptyString(record.session_id) ??
+      readNonEmptyString(record.sessionID);
+    if (!sessionId) return null;
+    const cwd =
+      readNonEmptyString(record.cwd) ??
+      readNonEmptyString(record.workdir) ??
+      readNonEmptyString(record.folder);
+    const workspaceId = readNonEmptyString(record.workspaceId) ?? readNonEmptyString(record.workspace_id);
+    const repoUrl = readNonEmptyString(record.repoUrl) ?? readNonEmptyString(record.repo_url);
+    const repoRef = readNonEmptyString(record.repoRef) ?? readNonEmptyString(record.repo_ref);
+    return {
+      sessionId,
+      ...(cwd ? { cwd } : {}),
+      ...(workspaceId ? { workspaceId } : {}),
+      ...(repoUrl ? { repoUrl } : {}),
+      ...(repoRef ? { repoRef } : {}),
+    };
+  },
+  serialize(params: Record<string, unknown> | null) {
+    if (!params) return null;
+    const sessionId =
+      readNonEmptyString(params.sessionId) ??
+      readNonEmptyString(params.session_id) ??
+      readNonEmptyString(params.sessionID);
+    if (!sessionId) return null;
+    const cwd =
+      readNonEmptyString(params.cwd) ??
+      readNonEmptyString(params.workdir) ??
+      readNonEmptyString(params.folder);
+    const workspaceId = readNonEmptyString(params.workspaceId) ?? readNonEmptyString(params.workspace_id);
+    const repoUrl = readNonEmptyString(params.repoUrl) ?? readNonEmptyString(params.repo_url);
+    const repoRef = readNonEmptyString(params.repoRef) ?? readNonEmptyString(params.repo_ref);
+    return {
+      sessionId,
+      ...(cwd ? { cwd } : {}),
+      ...(workspaceId ? { workspaceId } : {}),
+      ...(repoUrl ? { repoUrl } : {}),
+      ...(repoRef ? { repoRef } : {}),
+    };
+  },
+  getDisplayId(params: Record<string, unknown> | null) {
+    if (!params) return null;
+    return (
+      readNonEmptyString(params.sessionId) ??
+      readNonEmptyString(params.session_id) ??
+      readNonEmptyString(params.sessionID)
+    );
+  },
+};

--- a/packages/adapters/antigravity-local/src/server/parse.test.ts
+++ b/packages/adapters/antigravity-local/src/server/parse.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, it } from "vitest";
 import {
-  detectGeminiAuthRequired,
-  isGeminiTransientNetworkError,
-  isGeminiSessionUnrecoverableError,
-  parseGeminiJsonl,
+  detectAntigravityAuthRequired,
+  isAntigravityTransientNetworkError,
+  isAntigravitySessionUnrecoverableError,
+  parseAntigravityJsonl,
 } from "./parse.js";
 
-describe("parseGeminiJsonl", () => {
+describe("parseAntigravityJsonl", () => {
   it("collects assistant text from message events with string content", () => {
     const stdout = [
       '{"type":"init","session_id":"session-1"}',
@@ -15,7 +15,7 @@ describe("parseGeminiJsonl", () => {
       '{"type":"result","status":"success"}',
     ].join("\n");
 
-    const parsed = parseGeminiJsonl(stdout);
+    const parsed = parseAntigravityJsonl(stdout);
 
     expect(parsed.sessionId).toBe("session-1");
     expect(parsed.summary).toBe("hello");
@@ -29,7 +29,7 @@ describe("parseGeminiJsonl", () => {
       '{"type":"result","status":"success"}',
     ].join("\n");
 
-    const parsed = parseGeminiJsonl(stdout);
+    const parsed = parseAntigravityJsonl(stdout);
 
     expect(parsed.sessionId).toBe("session-2");
     expect(parsed.summary).toBe("first part\n\nsecond part");
@@ -44,12 +44,12 @@ describe("parseGeminiJsonl", () => {
       '{"type":"result","status":"success"}',
     ].join("\n");
 
-    const parsed = parseGeminiJsonl(stdout);
+    const parsed = parseAntigravityJsonl(stdout);
 
     expect(parsed.summary).toBe("visible response");
   });
 
-  it("captures assistant text from gemini CLI v0.38 stream-json schema", () => {
+  it("captures assistant text from Antigravity CLI stream-json schema", () => {
     const stdout = [
       JSON.stringify({
         type: "init",
@@ -84,7 +84,7 @@ describe("parseGeminiJsonl", () => {
       }),
     ].join("\n");
 
-    const result = parseGeminiJsonl(stdout);
+    const result = parseAntigravityJsonl(stdout);
     expect(result.summary).toBe("hello.");
     expect(result.sessionId).toBe("session-abc");
     expect(result.errorMessage).toBeNull();
@@ -100,7 +100,7 @@ describe("parseGeminiJsonl", () => {
       JSON.stringify({ type: "message", role: "assistant", content: "second" }),
     ].join("\n");
 
-    const result = parseGeminiJsonl(stdout);
+    const result = parseAntigravityJsonl(stdout);
     expect(result.summary).toBe("first\n\nsecond");
   });
 
@@ -118,7 +118,7 @@ describe("parseGeminiJsonl", () => {
       JSON.stringify({ type: "result", subtype: "success", result: "legacy hello" }),
     ].join("\n");
 
-    const result = parseGeminiJsonl(stdout);
+    const result = parseAntigravityJsonl(stdout);
     expect(result.summary).toBe("legacy hello");
     expect(result.sessionId).toBe("legacy-session");
   });
@@ -132,19 +132,19 @@ describe("parseGeminiJsonl", () => {
       }),
     ].join("\n");
 
-    const result = parseGeminiJsonl(stdout);
+    const result = parseAntigravityJsonl(stdout);
     expect(result.errorMessage).toBe("boom");
   });
 
   it("falls back to raw stdout text if no valid JSON events are parsed", () => {
     const stdout = "hello\n";
-    const result = parseGeminiJsonl(stdout);
+    const result = parseAntigravityJsonl(stdout);
     expect(result.summary).toBe("hello");
     expect(result.sessionId).toBeNull();
   });
 
   it("classifies non-interactive manual authorization failures as auth required", () => {
-    const result = detectGeminiAuthRequired({
+    const result = detectAntigravityAuthRequired({
       parsed: null,
       stdout: "",
       stderr:
@@ -155,34 +155,34 @@ describe("parseGeminiJsonl", () => {
   });
 });
 
-describe("isGeminiSessionUnrecoverableError", () => {
+describe("isAntigravitySessionUnrecoverableError", () => {
   it("matches 'unknown session'", () => {
-    expect(isGeminiSessionUnrecoverableError("", "Error: unknown session 'abc-123'")).toBe(true);
+    expect(isAntigravitySessionUnrecoverableError("", "Error: unknown session 'abc-123'")).toBe(true);
   });
 
   it("matches 'session ... not found'", () => {
-    expect(isGeminiSessionUnrecoverableError("", "Resumed session abc-123 not found on disk")).toBe(true);
+    expect(isAntigravitySessionUnrecoverableError("", "Resumed session abc-123 not found on disk")).toBe(true);
   });
 
   it("matches 'exceeds the maximum number of tokens' (compression overflow)", () => {
     const stderr =
       '_ApiError: {"error":{"code":400,"message":"The input token count exceeds the maximum number of tokens allowed 1048576","status":"INVALID_ARGUMENT"}} at ChatCompressionService.compress';
-    expect(isGeminiSessionUnrecoverableError("", stderr)).toBe(true);
+    expect(isAntigravitySessionUnrecoverableError("", stderr)).toBe(true);
   });
 
   it("matches 'input token count exceeds'", () => {
     expect(
-      isGeminiSessionUnrecoverableError("", "input token count exceeds maximum"),
+      isAntigravitySessionUnrecoverableError("", "input token count exceeds maximum"),
     ).toBe(true);
   });
 
   it("does not match unrelated stderr", () => {
-    expect(isGeminiSessionUnrecoverableError("", "Some other error")).toBe(false);
+    expect(isAntigravitySessionUnrecoverableError("", "Some other error")).toBe(false);
   });
 
-  it("does not match transient network errors (those go to isGeminiTransientNetworkError)", () => {
+  it("does not match transient network errors (those go to isAntigravityTransientNetworkError)", () => {
     expect(
-      isGeminiSessionUnrecoverableError(
+      isAntigravitySessionUnrecoverableError(
         "",
         "_GaxiosError: getaddrinfo ENOTFOUND oauth2.googleapis.com",
       ),
@@ -190,16 +190,16 @@ describe("isGeminiSessionUnrecoverableError", () => {
   });
 });
 
-describe("isGeminiTransientNetworkError", () => {
+describe("isAntigravityTransientNetworkError", () => {
   it("matches DNS failure on oauth2.googleapis.com", () => {
     const stderr =
       "_GaxiosError: request to https://oauth2.googleapis.com/token failed, reason: getaddrinfo ENOTFOUND oauth2.googleapis.com";
-    expect(isGeminiTransientNetworkError("", stderr)).toBe(true);
+    expect(isAntigravityTransientNetworkError("", stderr)).toBe(true);
   });
 
   it("matches EAI_AGAIN", () => {
     expect(
-      isGeminiTransientNetworkError("", "Error: getaddrinfo EAI_AGAIN sts.googleapis.com"),
+      isAntigravityTransientNetworkError("", "Error: getaddrinfo EAI_AGAIN sts.googleapis.com"),
     ).toBe(true);
   });
 
@@ -207,16 +207,16 @@ describe("isGeminiTransientNetworkError", () => {
     const stderr =
       "at _UserRefreshClient.refreshTokenNoCache (.../google-auth-library/...)\n" +
       "  caused by: ENOTFOUND oauth2.googleapis.com";
-    expect(isGeminiTransientNetworkError("", stderr)).toBe(true);
+    expect(isAntigravityTransientNetworkError("", stderr)).toBe(true);
   });
 
   it("does not match unrelated stderr", () => {
-    expect(isGeminiTransientNetworkError("", "Some other error")).toBe(false);
+    expect(isAntigravityTransientNetworkError("", "Some other error")).toBe(false);
   });
 
-  it("does not match unknown-session errors (those go to isGeminiSessionUnrecoverableError)", () => {
+  it("does not match unknown-session errors (those go to isAntigravitySessionUnrecoverableError)", () => {
     expect(
-      isGeminiTransientNetworkError("", "Error: unknown session 'abc-123'"),
+      isAntigravityTransientNetworkError("", "Error: unknown session 'abc-123'"),
     ).toBe(false);
   });
 });

--- a/packages/adapters/antigravity-local/src/server/parse.test.ts
+++ b/packages/adapters/antigravity-local/src/server/parse.test.ts
@@ -143,6 +143,13 @@ describe("parseAntigravityJsonl", () => {
     expect(result.sessionId).toBeNull();
   });
 
+  it("truncates raw stdout text if it exceeds the length limit", () => {
+    const stdout = "a".repeat(5000);
+    const result = parseAntigravityJsonl(stdout);
+    expect(result.summary.length).toBe(4003); // 4000 + "..."
+    expect(result.summary.endsWith("...")).toBe(true);
+  });
+
   it("classifies non-interactive manual authorization failures as auth required", () => {
     const result = detectAntigravityAuthRequired({
       parsed: null,

--- a/packages/adapters/antigravity-local/src/server/parse.ts
+++ b/packages/adapters/antigravity-local/src/server/parse.ts
@@ -188,7 +188,9 @@ export function parseAntigravityJsonl(stdout: string) {
 
   let summary = messages.join("\n\n").trim();
   if (jsonEventCount === 0 && stdout.trim().length > 0) {
-    summary = stdout.trim();
+    const trimmed = stdout.trim();
+    const limit = 4000;
+    summary = trimmed.length > limit ? trimmed.slice(0, limit) + "..." : trimmed;
   }
 
   return {

--- a/packages/adapters/antigravity-local/src/server/parse.ts
+++ b/packages/adapters/antigravity-local/src/server/parse.ts
@@ -75,7 +75,7 @@ function accumulateUsage(
   );
 }
 
-export function parseGeminiJsonl(stdout: string) {
+export function parseAntigravityJsonl(stdout: string) {
   let sessionId: string | null = null;
   const messages: string[] = [];
   let errorMessage: string | null = null;
@@ -127,11 +127,6 @@ export function parseGeminiJsonl(stdout: string) {
       continue;
     }
 
-    // Gemini CLI v0.38+ stream-json schema emits assistant turns as:
-    // {"type":"message","role":"assistant","content":"...","delta":true}
-    // These are discrete final messages (one per assistant turn), not
-    // cumulative streaming tokens, so collecting all of them produces the
-    // expected concatenated turn-by-turn summary rather than duplicated text.
     if (type === "message") {
       const role = asString(event.role, "").trim().toLowerCase();
       if (role === "assistant") {
@@ -207,19 +202,19 @@ export function parseGeminiJsonl(stdout: string) {
   };
 }
 
-export function isGeminiSessionUnrecoverableError(stdout: string, stderr: string): boolean {
+export function isAntigravitySessionUnrecoverableError(stdout: string, stderr: string): boolean {
   const haystack = `${stdout}\n${stderr}`
     .split(/\r?\n/)
     .map((line) => line.trim())
     .filter(Boolean)
     .join("\n");
 
-  return /unknown\s+session|session\s+.*\s+not\s+found|resume\s+.*\s+not\s+found|checkpoint\s+.*\s+not\s+found|cannot\s+resume|failed\s+to\s+resume|exceeds\s+the\s+maximum\s+number\s+of\s+tokens|input\s+token\s+count\s+exceeds/i.test(
+  return /unknown\s+session|session\s+.*\s+not\s+found|resume\s+.*\s+not\s+found|continue\s+.*\s+not\s+found|checkpoint\s+.*\s+not\s+found|cannot\s+resume|failed\s+to\s+resume|exceeds\s+the\s+maximum\s+number\s+of\s+tokens|input\s+token\s+count\s+exceeds/i.test(
     haystack,
   );
 }
 
-export function isGeminiTransientNetworkError(stdout: string, stderr: string): boolean {
+export function isAntigravityTransientNetworkError(stdout: string, stderr: string): boolean {
   const haystack = `${stdout}\n${stderr}`
     .split(/\r?\n/)
     .map((line) => line.trim())
@@ -231,7 +226,7 @@ export function isGeminiTransientNetworkError(stdout: string, stderr: string): b
   );
 }
 
-function extractGeminiErrorMessages(parsed: Record<string, unknown>): string[] {
+function extractAntigravityErrorMessages(parsed: Record<string, unknown>): string[] {
   const messages: string[] = [];
   const errorMsg = asString(parsed.error, "").trim();
   if (errorMsg) messages.push(errorMsg);
@@ -260,54 +255,54 @@ function extractGeminiErrorMessages(parsed: Record<string, unknown>): string[] {
   return messages;
 }
 
-export function describeGeminiFailure(parsed: Record<string, unknown>): string | null {
+export function describeAntigravityFailure(parsed: Record<string, unknown>): string | null {
   const status = asString(parsed.status, "");
-  const errors = extractGeminiErrorMessages(parsed);
+  const errors = extractAntigravityErrorMessages(parsed);
 
   const detail = errors[0] ?? "";
-  const parts = ["Gemini run failed"];
+  const parts = ["Antigravity run failed"];
   if (status) parts.push(`status=${status}`);
   if (detail) parts.push(detail);
   return parts.length > 1 ? parts.join(": ") : null;
 }
 
-const GEMINI_AUTH_REQUIRED_RE = /(?:not\s+authenticated|please\s+authenticate|api[_ ]?key\s+(?:required|missing|invalid)|authentication\s+required|manual\s+authorization\s+is\s+required|unauthorized|invalid\s+credentials|not\s+logged\s+in|login\s+required|run\s+`?gemini\s+auth(?:\s+login)?`?\s+first)/i;
-const GEMINI_QUOTA_EXHAUSTED_RE =
+const ANTIGRAVITY_AUTH_REQUIRED_RE = /(?:not\s+authenticated|please\s+authenticate|api[_ ]?key\s+(?:required|missing|invalid)|authentication\s+required|manual\s+authorization\s+is\s+required|unauthorized|invalid\s+credentials|not\s+logged\s+in|login\s+required|run\s+`?agy\s+auth(?:\s+login)?`?\s+first)/i;
+const ANTIGRAVITY_QUOTA_EXHAUSTED_RE =
   /(?:resource_exhausted|quota|rate[-\s]?limit|too many requests|\b429\b|billing details)/i;
 
-export function detectGeminiAuthRequired(input: {
+export function detectAntigravityAuthRequired(input: {
   parsed: Record<string, unknown> | null;
   stdout: string;
   stderr: string;
 }): { requiresAuth: boolean } {
-  const errors = extractGeminiErrorMessages(input.parsed ?? {});
+  const errors = extractAntigravityErrorMessages(input.parsed ?? {});
   const messages = [...errors, input.stdout, input.stderr]
     .join("\n")
     .split(/\r?\n/)
     .map((line) => line.trim())
     .filter(Boolean);
 
-  const requiresAuth = messages.some((line) => GEMINI_AUTH_REQUIRED_RE.test(line));
+  const requiresAuth = messages.some((line) => ANTIGRAVITY_AUTH_REQUIRED_RE.test(line));
   return { requiresAuth };
 }
 
-export function detectGeminiQuotaExhausted(input: {
+export function detectAntigravityQuotaExhausted(input: {
   parsed: Record<string, unknown> | null;
   stdout: string;
   stderr: string;
 }): { exhausted: boolean } {
-  const errors = extractGeminiErrorMessages(input.parsed ?? {});
+  const errors = extractAntigravityErrorMessages(input.parsed ?? {});
   const messages = [...errors, input.stdout, input.stderr]
     .join("\n")
     .split(/\r?\n/)
     .map((line) => line.trim())
     .filter(Boolean);
 
-  const exhausted = messages.some((line) => GEMINI_QUOTA_EXHAUSTED_RE.test(line));
+  const exhausted = messages.some((line) => ANTIGRAVITY_QUOTA_EXHAUSTED_RE.test(line));
   return { exhausted };
 }
 
-export function isGeminiTurnLimitResult(
+export function isAntigravityTurnLimitResult(
   parsed: Record<string, unknown> | null | undefined,
   exitCode?: number | null,
 ): boolean {

--- a/packages/adapters/antigravity-local/src/server/skills.ts
+++ b/packages/adapters/antigravity-local/src/server/skills.ts
@@ -1,0 +1,88 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import type {
+  AdapterSkillContext,
+  AdapterSkillSnapshot,
+} from "@paperclipai/adapter-utils";
+import {
+  buildPersistentSkillSnapshot,
+  ensurePaperclipSkillSymlink,
+  readPaperclipRuntimeSkillEntries,
+  readInstalledSkillTargets,
+  resolvePaperclipDesiredSkillNames,
+} from "@paperclipai/adapter-utils/server-utils";
+
+const __moduleDir = path.dirname(fileURLToPath(import.meta.url));
+
+function asString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+function resolveAntigravitySkillsHome(config: Record<string, unknown>) {
+  const env =
+    typeof config.env === "object" && config.env !== null && !Array.isArray(config.env)
+      ? (config.env as Record<string, unknown>)
+      : {};
+  const configuredHome = asString(env.HOME);
+  const home = configuredHome ? path.resolve(configuredHome) : os.homedir();
+  return path.join(home, ".gemini", "antigravity-cli", "skills");
+}
+
+async function buildAntigravitySkillSnapshot(config: Record<string, unknown>): Promise<AdapterSkillSnapshot> {
+  const availableEntries = await readPaperclipRuntimeSkillEntries(config, __moduleDir);
+  const desiredSkills = resolvePaperclipDesiredSkillNames(config, availableEntries);
+  const skillsHome = resolveAntigravitySkillsHome(config);
+  const installed = await readInstalledSkillTargets(skillsHome);
+  return buildPersistentSkillSnapshot({
+    adapterType: "antigravity_local",
+    availableEntries,
+    desiredSkills,
+    installed,
+    skillsHome,
+    locationLabel: "~/.gemini/antigravity-cli/skills",
+    missingDetail: "Configured but not currently linked into the Antigravity skills home.",
+    externalConflictDetail: "Skill name is occupied by an external installation.",
+    externalDetail: "Installed outside Paperclip management.",
+  });
+}
+
+export async function listAntigravitySkills(ctx: AdapterSkillContext): Promise<AdapterSkillSnapshot> {
+  return buildAntigravitySkillSnapshot(ctx.config);
+}
+
+export async function syncAntigravitySkills(
+  ctx: AdapterSkillContext,
+  desiredSkills: string[],
+): Promise<AdapterSkillSnapshot> {
+  const availableEntries = await readPaperclipRuntimeSkillEntries(ctx.config, __moduleDir);
+  const desiredSet = new Set(desiredSkills);
+  const skillsHome = resolveAntigravitySkillsHome(ctx.config);
+  await fs.mkdir(skillsHome, { recursive: true });
+  const installed = await readInstalledSkillTargets(skillsHome);
+  const availableByRuntimeName = new Map(availableEntries.map((entry) => [entry.runtimeName, entry]));
+
+  for (const available of availableEntries) {
+    if (!desiredSet.has(available.key)) continue;
+    const target = path.join(skillsHome, available.runtimeName);
+    await ensurePaperclipSkillSymlink(available.source, target);
+  }
+
+  for (const [name, installedEntry] of installed.entries()) {
+    const available = availableByRuntimeName.get(name);
+    if (!available) continue;
+    if (desiredSet.has(available.key)) continue;
+    if (installedEntry.targetPath !== available.source) continue;
+    await fs.unlink(path.join(skillsHome, name)).catch(() => {});
+  }
+
+  return buildAntigravitySkillSnapshot(ctx.config);
+}
+
+export function resolveAntigravityDesiredSkillNames(
+  config: Record<string, unknown>,
+  availableEntries: Array<{ key: string }>,
+) {
+  return resolvePaperclipDesiredSkillNames(config, availableEntries);
+}

--- a/packages/adapters/antigravity-local/src/server/test.ts
+++ b/packages/adapters/antigravity-local/src/server/test.ts
@@ -1,0 +1,277 @@
+import path from "node:path";
+import type {
+  AdapterEnvironmentCheck,
+  AdapterEnvironmentTestContext,
+  AdapterEnvironmentTestResult,
+} from "@paperclipai/adapter-utils";
+import {
+  asBoolean,
+  asNumber,
+  asString,
+  asStringArray,
+  ensurePathInEnv,
+  parseObject,
+} from "@paperclipai/adapter-utils/server-utils";
+import {
+  ensureAdapterExecutionTargetCommandResolvable,
+  maybeRunSandboxInstallCommand,
+  ensureAdapterExecutionTargetDirectory,
+  runAdapterExecutionTargetProcess,
+  describeAdapterExecutionTarget,
+  resolveAdapterExecutionTargetCwd,
+} from "@paperclipai/adapter-utils/execution-target";
+import { DEFAULT_ANTIGRAVITY_LOCAL_MODEL, SANDBOX_INSTALL_COMMAND } from "../index.js";
+import { detectAntigravityAuthRequired, detectAntigravityQuotaExhausted, parseAntigravityJsonl } from "./parse.js";
+import { firstNonEmptyLine } from "./utils.js";
+
+function summarizeStatus(checks: AdapterEnvironmentCheck[]): AdapterEnvironmentTestResult["status"] {
+  if (checks.some((check) => check.level === "error")) return "fail";
+  if (checks.some((check) => check.level === "warn")) return "warn";
+  return "pass";
+}
+
+function isNonEmpty(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function commandLooksLike(command: string, expected: string): boolean {
+  const base = path.basename(command).toLowerCase();
+  return base === expected || base === `${expected}.cmd` || base === `${expected}.exe`;
+}
+
+function summarizeProbeDetail(stdout: string, stderr: string, parsedError: string | null): string | null {
+  const raw = parsedError?.trim() || firstNonEmptyLine(stderr) || firstNonEmptyLine(stdout);
+  if (!raw) return null;
+  const clean = raw.replace(/\s+/g, " ").trim();
+  const max = 240;
+  return clean.length > max ? `${clean.slice(0, max - 1)}…` : clean;
+}
+
+export async function testEnvironment(
+  ctx: AdapterEnvironmentTestContext,
+): Promise<AdapterEnvironmentTestResult> {
+  const checks: AdapterEnvironmentCheck[] = [];
+  const config = parseObject(ctx.config);
+  const command = asString(config.command, "agy");
+  const target = ctx.executionTarget ?? null;
+  const targetIsRemote = target?.kind === "remote";
+  const cwd = resolveAdapterExecutionTargetCwd(target, asString(config.cwd, ""), process.cwd());
+  const targetLabel = targetIsRemote
+    ? ctx.environmentName ?? describeAdapterExecutionTarget(target)
+    : null;
+  const runId = `antigravity-envtest-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+
+  if (targetLabel) {
+    checks.push({
+      code: "antigravity_environment_target",
+      level: "info",
+      message: `Probing inside environment: ${targetLabel}`,
+    });
+  }
+
+  try {
+    await ensureAdapterExecutionTargetDirectory(runId, target, cwd, {
+      cwd,
+      env: {},
+      createIfMissing: true,
+    });
+    checks.push({
+      code: "antigravity_cwd_valid",
+      level: "info",
+      message: `Working directory is valid: ${cwd}`,
+    });
+  } catch (err) {
+    checks.push({
+      code: "antigravity_cwd_invalid",
+      level: "error",
+      message: err instanceof Error ? err.message : "Invalid working directory",
+      detail: cwd,
+    });
+  }
+
+  const envConfig = parseObject(config.env);
+  const env: Record<string, string> = {};
+  for (const [key, value] of Object.entries(envConfig)) {
+    if (typeof value === "string") env[key] = value;
+  }
+  if (targetIsRemote && typeof env.ANTIGRAVITY_CLI_TRUST_WORKSPACE !== "string") {
+    env.ANTIGRAVITY_CLI_TRUST_WORKSPACE = "true";
+  }
+  const runtimeEnv = ensurePathInEnv({ ...process.env, ...env });
+  const installCheck = await maybeRunSandboxInstallCommand({
+    runId,
+    target,
+    adapterKey: "antigravity",
+    installCommand: SANDBOX_INSTALL_COMMAND,
+    detectCommand: command,
+    env,
+  });
+  if (installCheck) checks.push(installCheck);
+  try {
+    await ensureAdapterExecutionTargetCommandResolvable(command, target, cwd, runtimeEnv);
+    checks.push({
+      code: "antigravity_command_resolvable",
+      level: "info",
+      message: `Command is executable: ${command}`,
+    });
+  } catch (err) {
+    checks.push({
+      code: "antigravity_command_unresolvable",
+      level: "error",
+      message: err instanceof Error ? err.message : "Command is not executable",
+      detail: command,
+    });
+  }
+
+  const configAntigravityApiKey = env.ANTIGRAVITY_API_KEY;
+  const configGeminiApiKey = env.GEMINI_API_KEY;
+  const hostAntigravityApiKey = targetIsRemote ? undefined : process.env.ANTIGRAVITY_API_KEY;
+  const hostGeminiApiKey = targetIsRemote ? undefined : process.env.GEMINI_API_KEY;
+  const configGoogleApiKey = env.GOOGLE_API_KEY;
+  const hostGoogleApiKey = targetIsRemote ? undefined : process.env.GOOGLE_API_KEY;
+  const hasGca = env.GOOGLE_GENAI_USE_GCA === "true" || (!targetIsRemote && process.env.GOOGLE_GENAI_USE_GCA === "true");
+  if (
+    isNonEmpty(configAntigravityApiKey) ||
+    isNonEmpty(hostAntigravityApiKey) ||
+    isNonEmpty(configGeminiApiKey) ||
+    isNonEmpty(hostGeminiApiKey) ||
+    isNonEmpty(configGoogleApiKey) ||
+    isNonEmpty(hostGoogleApiKey) ||
+    hasGca
+  ) {
+    const source = hasGca
+      ? "Google account login (GCA)"
+      : isNonEmpty(configAntigravityApiKey) || isNonEmpty(configGeminiApiKey) || isNonEmpty(configGoogleApiKey)
+        ? "adapter config env"
+        : "server environment";
+    checks.push({
+      code: "antigravity_api_key_present",
+      level: "info",
+      message: "Antigravity API credentials are set for CLI authentication.",
+      detail: `Detected in ${source}.`,
+    });
+  } else {
+    checks.push({
+      code: "antigravity_api_key_missing",
+      level: "info",
+      message: "No explicit API key detected. Antigravity CLI may still authenticate via `agy auth login` (OAuth).",
+      hint: "If the hello probe fails with an auth error, set ANTIGRAVITY_API_KEY, GEMINI_API_KEY or GOOGLE_API_KEY in adapter env, or run `agy auth login`.",
+    });
+  }
+
+  const canRunProbe =
+    checks.every((check) => check.code !== "antigravity_cwd_invalid" && check.code !== "antigravity_command_unresolvable");
+  if (canRunProbe) {
+    if (!commandLooksLike(command, "agy")) {
+      checks.push({
+        code: "antigravity_hello_probe_skipped_custom_command",
+        level: "info",
+        message: "Skipped hello probe because command is not `agy`.",
+        detail: command,
+        hint: "Use the `agy` CLI command to run the automatic installation and auth probe.",
+      });
+    } else {
+      const model = asString(config.model, DEFAULT_ANTIGRAVITY_LOCAL_MODEL).trim();
+      const sandbox = asBoolean(config.sandbox, false);
+      const helloProbeTimeoutSec = Math.max(1, asNumber(config.helloProbeTimeoutSec, 60));
+      const extraArgs = (() => {
+        const fromExtraArgs = asStringArray(config.extraArgs);
+        if (fromExtraArgs.length > 0) return fromExtraArgs;
+        return asStringArray(config.args);
+      })();
+
+      const args = ["--output-format", "stream-json", "--prompt", "Respond with hello."];
+      if (model && model !== DEFAULT_ANTIGRAVITY_LOCAL_MODEL) args.push("--model", model);
+      args.push("--dangerously-skip-permissions");
+      if (sandbox) {
+        args.push("--sandbox");
+      }
+      if (extraArgs.length > 0) args.push(...extraArgs);
+
+      const probe = await runAdapterExecutionTargetProcess(
+        runId,
+        target,
+        command,
+        args,
+        {
+          cwd,
+          env,
+          timeoutSec: helloProbeTimeoutSec,
+          graceSec: 5,
+          onLog: async () => { },
+        },
+      );
+        
+      const parsed = parseAntigravityJsonl(probe.stdout);     
+      const detail = summarizeProbeDetail(probe.stdout, probe.stderr, parsed.errorMessage);
+      const authMeta = detectAntigravityAuthRequired({
+        parsed: parsed.resultEvent,
+        stdout: probe.stdout,
+        stderr: probe.stderr,
+      });
+      const quotaMeta = detectAntigravityQuotaExhausted({
+        parsed: parsed.resultEvent,
+        stdout: probe.stdout,
+        stderr: probe.stderr,
+      });
+
+      if (quotaMeta.exhausted) {
+        checks.push({
+          code: "antigravity_hello_probe_quota_exhausted",
+          level: "warn",
+          message: probe.timedOut
+            ? "Antigravity CLI is retrying after quota exhaustion."
+            : "Antigravity CLI authentication is configured, but the current account or API key is over quota.",
+          ...(detail ? { detail } : {}),
+          hint: "The configured Antigravity account or API key is over quota. Check ai.google.dev usage/billing, then retry the probe.",
+        });
+      } else if (probe.timedOut) {
+        checks.push({
+          code: "antigravity_hello_probe_timed_out",
+          level: "warn",
+          message: "Antigravity hello probe timed out.",
+          hint: "Retry the probe. If this persists, verify Antigravity can run `Respond with hello.` from this directory manually.",
+        });
+      } else if ((probe.exitCode ?? 1) === 0) {
+        const summary = parsed.summary.trim();
+        const hasHello = /\bhello\b/i.test(summary);
+        checks.push({
+          code: hasHello ? "antigravity_hello_probe_passed" : "antigravity_hello_probe_unexpected_output",
+          level: hasHello ? "info" : "warn",
+          message: hasHello
+            ? "Antigravity hello probe succeeded."
+            : "Antigravity probe ran but did not return `hello` as expected.",
+          ...(summary ? { detail: summary.replace(/\s+/g, " ").trim().slice(0, 240) } : {}),
+          ...(hasHello
+            ? {}
+            : {
+              hint: "Try `agy --prompt \"Respond with hello.\"` manually to inspect full output.",
+            }),
+        });
+      } else if (authMeta.requiresAuth) {
+        checks.push({
+          code: "antigravity_hello_probe_auth_required",
+          level: "warn",
+          message: "Antigravity CLI is installed, but authentication is not ready.",
+          ...(detail ? { detail } : {}),
+          hint: "Run `agy auth` or configure ANTIGRAVITY_API_KEY in adapter env/shell, then retry the probe.",
+        });
+      } else {
+        checks.push({
+          code: "antigravity_hello_probe_failed",
+          level: "error",
+          message: "Antigravity hello probe failed.",
+          ...(detail ? { detail } : {}),
+          hint: "Run `agy --prompt \"Respond with hello.\"` manually in this working directory to debug.",
+        });
+      }
+    }
+  }
+
+  return {
+    adapterType: ctx.adapterType,
+    status: summarizeStatus(checks),
+    checks,
+    testedAt: new Date().toISOString(),
+  };
+}

--- a/packages/adapters/antigravity-local/src/server/utils.ts
+++ b/packages/adapters/antigravity-local/src/server/utils.ts
@@ -1,0 +1,8 @@
+export function firstNonEmptyLine(text: string): string {
+    return (
+        text
+            .split(/\r?\n/)
+            .map((line) => line.trim())
+            .find(Boolean) ?? ""
+    );
+}

--- a/packages/adapters/antigravity-local/src/ui/build-config.ts
+++ b/packages/adapters/antigravity-local/src/ui/build-config.ts
@@ -1,0 +1,74 @@
+import type { CreateConfigValues } from "@paperclipai/adapter-utils";
+import { DEFAULT_ANTIGRAVITY_LOCAL_MODEL } from "../index.js";
+
+function parseCommaArgs(value: string): string[] {
+  return value
+    .split(",")
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+function parseEnvVars(text: string): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const line of text.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    const eq = trimmed.indexOf("=");
+    if (eq <= 0) continue;
+    const key = trimmed.slice(0, eq).trim();
+    const value = trimmed.slice(eq + 1);
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) continue;
+    env[key] = value;
+  }
+  return env;
+}
+
+function parseEnvBindings(bindings: unknown): Record<string, unknown> {
+  if (typeof bindings !== "object" || bindings === null || Array.isArray(bindings)) return {};
+  const env: Record<string, unknown> = {};
+  for (const [key, raw] of Object.entries(bindings)) {
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) continue;
+    if (typeof raw === "string") {
+      env[key] = { type: "plain", value: raw };
+      continue;
+    }
+    if (typeof raw !== "object" || raw === null || Array.isArray(raw)) continue;
+    const rec = raw as Record<string, unknown>;
+    if (rec.type === "plain" && typeof rec.value === "string") {
+      env[key] = { type: "plain", value: rec.value };
+      continue;
+    }
+    if (rec.type === "secret_ref" && typeof rec.secretId === "string") {
+      env[key] = {
+        type: "secret_ref",
+        secretId: rec.secretId,
+        ...(typeof rec.version === "number" || rec.version === "latest"
+          ? { version: rec.version }
+          : {}),
+      };
+    }
+  }
+  return env;
+}
+
+export function buildAntigravityLocalConfig(v: CreateConfigValues): Record<string, unknown> {
+  const ac: Record<string, unknown> = {};
+  if (v.cwd) ac.cwd = v.cwd;
+  if (v.instructionsFilePath) ac.instructionsFilePath = v.instructionsFilePath;
+  ac.model = v.model || DEFAULT_ANTIGRAVITY_LOCAL_MODEL;
+  ac.timeoutSec = 0;
+  ac.graceSec = 15;
+  const env = parseEnvBindings(v.envBindings);
+  const legacy = parseEnvVars(v.envVars);
+  for (const [key, value] of Object.entries(legacy)) {
+    if (!Object.prototype.hasOwnProperty.call(env, key)) {
+      env[key] = { type: "plain", value };
+    }
+  }
+  if (Object.keys(env).length > 0) ac.env = env;
+  ac.sandbox = !v.dangerouslyBypassSandbox;
+
+  if (v.command) ac.command = v.command;
+  if (v.extraArgs) ac.extraArgs = parseCommaArgs(v.extraArgs);
+  return ac;
+}

--- a/packages/adapters/antigravity-local/src/ui/index.ts
+++ b/packages/adapters/antigravity-local/src/ui/index.ts
@@ -1,0 +1,2 @@
+export { parseAntigravityStdoutLine } from "./parse-stdout.js";
+export { buildAntigravityLocalConfig } from "./build-config.js";

--- a/packages/adapters/antigravity-local/src/ui/parse-stdout.test.ts
+++ b/packages/adapters/antigravity-local/src/ui/parse-stdout.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import { parseAntigravityStdoutLine } from "./parse-stdout.js";
+
+const ts = "2026-05-04T05:43:45.198Z";
+
+describe("parseAntigravityStdoutLine", () => {
+  it("renders v0.38 message+role:assistant as an assistant transcript entry", () => {
+    const line = JSON.stringify({
+      type: "message",
+      role: "assistant",
+      content: "hello.",
+      delta: true,
+    });
+    const entries = parseAntigravityStdoutLine(line, ts);
+    expect(entries).toEqual([{ kind: "assistant", ts, text: "hello." }]);
+  });
+
+  it("renders v0.38 message+role:user as a user transcript entry", () => {
+    const line = JSON.stringify({
+      type: "message",
+      role: "user",
+      content: "Respond with hello.",
+    });
+    const entries = parseAntigravityStdoutLine(line, ts);
+    expect(entries).toEqual([{ kind: "user", ts, text: "Respond with hello." }]);
+  });
+
+  it("preserves the legacy claude-style assistant event handler", () => {
+    const line = JSON.stringify({
+      type: "assistant",
+      message: { content: [{ type: "output_text", text: "legacy hello" }] },
+    });
+    const entries = parseAntigravityStdoutLine(line, ts);
+    expect(entries).toEqual([{ kind: "assistant", ts, text: "legacy hello" }]);
+  });
+
+  it("reads token usage from v0.38 result.stats", () => {
+    const line = JSON.stringify({
+      type: "result",
+      status: "success",
+      stats: {
+        total_tokens: 9468,
+        input_tokens: 9095,
+        output_tokens: 29,
+        cached: 8132,
+      },
+    });
+    const [entry] = parseAntigravityStdoutLine(line, ts);
+    expect(entry).toMatchObject({
+      kind: "result",
+      inputTokens: 9095,
+      outputTokens: 29,
+      cachedTokens: 8132,
+      isError: false,
+      subtype: "success",
+    });
+  });
+
+  it("flags v0.38 result.status=error as an error", () => {
+    const line = JSON.stringify({
+      type: "result",
+      status: "error",
+      error: "boom",
+    });
+    const [entry] = parseAntigravityStdoutLine(line, ts);
+    expect(entry).toMatchObject({ kind: "result", isError: true, errors: ["boom"] });
+  });
+
+  it("ignores message events without an actionable role", () => {
+    const line = JSON.stringify({ type: "message", role: "system", content: "ignored" });
+    expect(parseAntigravityStdoutLine(line, ts)).toEqual([]);
+  });
+});

--- a/packages/adapters/antigravity-local/src/ui/parse-stdout.ts
+++ b/packages/adapters/antigravity-local/src/ui/parse-stdout.ts
@@ -1,0 +1,288 @@
+import type { TranscriptEntry } from "@paperclipai/adapter-utils";
+
+function safeJsonParse(text: string): unknown {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return null;
+  }
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+function asString(value: unknown, fallback = ""): string {
+  return typeof value === "string" ? value : fallback;
+}
+
+function asNumber(value: unknown, fallback = 0): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : fallback;
+}
+
+function stringifyUnknown(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (value === null || value === undefined) return "";
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+}
+
+function errorText(value: unknown): string {
+  if (typeof value === "string") return value;
+  const rec = asRecord(value);
+  if (!rec) return "";
+  const msg =
+    (typeof rec.message === "string" && rec.message) ||
+    (typeof rec.error === "string" && rec.error) ||
+    (typeof rec.code === "string" && rec.code) ||
+    "";
+  if (msg) return msg;
+  try {
+    return JSON.stringify(rec);
+  } catch {
+    return "";
+  }
+}
+
+function collectTextEntries(messageRaw: unknown, ts: string, kind: "assistant" | "user"): TranscriptEntry[] {
+  if (typeof messageRaw === "string") {
+    const text = messageRaw.trim();
+    return text ? [{ kind, ts, text }] : [];
+  }
+
+  const message = asRecord(messageRaw);
+  if (!message) return [];
+
+  const entries: TranscriptEntry[] = [];
+  const directText = asString(message.text).trim();
+  if (directText) entries.push({ kind, ts, text: directText });
+
+  const content = Array.isArray(message.content) ? message.content : [];
+  for (const partRaw of content) {
+    const part = asRecord(partRaw);
+    if (!part) continue;
+    const type = asString(part.type).trim();
+    if (type !== "output_text" && type !== "text" && type !== "content") continue;
+    const text = asString(part.text).trim() || asString(part.content).trim();
+    if (text) entries.push({ kind, ts, text });
+  }
+
+  return entries;
+}
+
+function parseAssistantMessage(messageRaw: unknown, ts: string): TranscriptEntry[] {
+  if (typeof messageRaw === "string") {
+    const text = messageRaw.trim();
+    return text ? [{ kind: "assistant", ts, text }] : [];
+  }
+
+  const message = asRecord(messageRaw);
+  if (!message) return [];
+
+  const entries: TranscriptEntry[] = [];
+  const directText = asString(message.text).trim();
+  if (directText) entries.push({ kind: "assistant", ts, text: directText });
+
+  const content = Array.isArray(message.content) ? message.content : [];
+  for (const partRaw of content) {
+    const part = asRecord(partRaw);
+    if (!part) continue;
+    const type = asString(part.type).trim();
+
+    if (type === "output_text" || type === "text" || type === "content") {
+      const text = asString(part.text).trim() || asString(part.content).trim();
+      if (text) entries.push({ kind: "assistant", ts, text });
+      continue;
+    }
+
+    if (type === "thinking") {
+      const text = asString(part.text).trim();
+      if (text) entries.push({ kind: "thinking", ts, text });
+      continue;
+    }
+
+    if (type === "tool_call") {
+      const name = asString(part.name, asString(part.tool, "tool"));
+      entries.push({
+        kind: "tool_call",
+        ts,
+        name,
+        input: part.input ?? part.arguments ?? part.args ?? {},
+      });
+      continue;
+    }
+
+    if (type === "tool_result" || type === "tool_response") {
+      const toolUseId =
+        asString(part.tool_use_id) ||
+        asString(part.toolUseId) ||
+        asString(part.call_id) ||
+        asString(part.id) ||
+        "tool_result";
+      const contentText =
+        asString(part.output) ||
+        asString(part.text) ||
+        asString(part.result) ||
+        stringifyUnknown(part.output ?? part.result ?? part.text ?? part.response);
+      const isError = part.is_error === true || asString(part.status).toLowerCase() === "error";
+      entries.push({
+        kind: "tool_result",
+        ts,
+        toolUseId,
+        content: contentText,
+        isError,
+      });
+    }
+  }
+
+  return entries;
+}
+
+function parseTopLevelToolEvent(parsed: Record<string, unknown>, ts: string): TranscriptEntry[] {
+  const subtype = asString(parsed.subtype).trim().toLowerCase();
+  const callId = asString(parsed.call_id, asString(parsed.callId, asString(parsed.id, "tool_call")));
+  const toolCall = asRecord(parsed.tool_call ?? parsed.toolCall);
+  if (!toolCall) {
+    return [{ kind: "system", ts, text: `tool_call${subtype ? ` (${subtype})` : ""}` }];
+  }
+
+  const [toolName] = Object.keys(toolCall);
+  if (!toolName) {
+    return [{ kind: "system", ts, text: `tool_call${subtype ? ` (${subtype})` : ""}` }];
+  }
+  const payload = asRecord(toolCall[toolName]) ?? {};
+
+  if (subtype === "started" || subtype === "start") {
+    return [{
+      kind: "tool_call",
+      ts,
+      name: toolName,
+      input: payload.args ?? payload.input ?? payload.arguments ?? payload,
+    }];
+  }
+
+  if (subtype === "completed" || subtype === "complete" || subtype === "finished") {
+    const result = payload.result ?? payload.output ?? payload.error;
+    const isError =
+      parsed.is_error === true ||
+      payload.is_error === true ||
+      payload.error !== undefined ||
+      asString(payload.status).toLowerCase() === "error";
+    return [{
+      kind: "tool_result",
+      ts,
+      toolUseId: callId,
+      content: result !== undefined ? stringifyUnknown(result) : `${toolName} completed`,
+      isError,
+    }];
+  }
+
+  return [{ kind: "system", ts, text: `tool_call${subtype ? ` (${subtype})` : ""}: ${toolName}` }];
+}
+
+function readSessionId(parsed: Record<string, unknown>): string {
+  return (
+    asString(parsed.session_id) ||
+    asString(parsed.sessionId) ||
+    asString(parsed.sessionID) ||
+    asString(parsed.checkpoint_id) ||
+    asString(parsed.thread_id)
+  );
+}
+
+function readUsage(parsed: Record<string, unknown>) {
+  const usage = asRecord(parsed.usage) ?? asRecord(parsed.usageMetadata) ?? asRecord(parsed.stats);
+  const usageMetadata = asRecord(usage?.usageMetadata);
+  const source = usageMetadata ?? usage ?? {};
+  return {
+    inputTokens: asNumber(source.input_tokens, asNumber(source.inputTokens, asNumber(source.promptTokenCount))),
+    outputTokens: asNumber(source.output_tokens, asNumber(source.outputTokens, asNumber(source.candidatesTokenCount))),
+    cachedTokens: asNumber(
+      source.cached_input_tokens,
+      asNumber(source.cachedInputTokens, asNumber(source.cachedContentTokenCount, asNumber(source.cached))),
+    ),
+  };
+}
+
+export function parseAntigravityStdoutLine(line: string, ts: string): TranscriptEntry[] {
+  const parsed = asRecord(safeJsonParse(line));
+  if (!parsed) {
+    return [{ kind: "stdout", ts, text: line }];
+  }
+
+  const type = asString(parsed.type);
+
+  if (type === "system") {
+    const subtype = asString(parsed.subtype);
+    if (subtype === "init") {
+      const sessionId = readSessionId(parsed);
+      return [{ kind: "init", ts, model: asString(parsed.model, "antigravity"), sessionId }];
+    }
+    if (subtype === "error") {
+      const text = errorText(parsed.error ?? parsed.message ?? parsed.detail);
+      return [{ kind: "stderr", ts, text: text || "error" }];
+    }
+    return [{ kind: "system", ts, text: `system: ${subtype || "event"}` }];
+  }
+
+  if (type === "assistant") {
+    return parseAssistantMessage(parsed.message, ts);
+  }
+
+  if (type === "user") {
+    return collectTextEntries(parsed.message, ts, "user");
+  }
+
+  if (type === "message") {
+    const role = asString(parsed.role).trim().toLowerCase();
+    if (role === "assistant") {
+      return parseAssistantMessage(parsed.content, ts);
+    }
+    if (role === "user") {
+      return collectTextEntries(parsed.content, ts, "user");
+    }
+    return [];
+  }
+
+  if (type === "thinking") {
+    const text = asString(parsed.text).trim() || asString(asRecord(parsed.delta)?.text).trim();
+    return text ? [{ kind: "thinking", ts, text }] : [];
+  }
+
+  if (type === "tool_call") {
+    return parseTopLevelToolEvent(parsed, ts);
+  }
+
+  if (type === "result") {
+    const usage = readUsage(parsed);
+    const status = asString(parsed.status).toLowerCase();
+    const isError =
+      parsed.is_error === true || status === "error" || status === "failed";
+    const errors = isError
+      ? [errorText(parsed.error ?? parsed.message ?? parsed.result)].filter(Boolean)
+      : [];
+    return [{
+      kind: "result",
+      ts,
+      text: asString(parsed.result) || asString(parsed.text) || asString(parsed.response),
+      inputTokens: usage.inputTokens,
+      outputTokens: usage.outputTokens,
+      cachedTokens: usage.cachedTokens,
+      costUsd: asNumber(parsed.total_cost_usd, asNumber(parsed.cost_usd, asNumber(parsed.cost))),
+      subtype: asString(parsed.subtype, status || "result"),
+      isError,
+      errors,
+    }];
+  }
+
+  if (type === "error") {
+    const text = errorText(parsed.error ?? parsed.message ?? parsed.detail);
+    return [{ kind: "stderr", ts, text: text || "error" }];
+  }
+
+  return [{ kind: "stdout", ts, text: line }];
+}

--- a/packages/adapters/antigravity-local/tsconfig.json
+++ b/packages/adapters/antigravity-local/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/packages/adapters/antigravity-local/vitest.config.ts
+++ b/packages/adapters/antigravity-local/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+  },
+});

--- a/packages/adapters/gemini-local/src/server/parse.test.ts
+++ b/packages/adapters/gemini-local/src/server/parse.test.ts
@@ -143,6 +143,13 @@ describe("parseGeminiJsonl", () => {
     expect(result.sessionId).toBeNull();
   });
 
+  it("truncates raw stdout text if it exceeds the length limit", () => {
+    const stdout = "a".repeat(5000);
+    const result = parseGeminiJsonl(stdout);
+    expect(result.summary.length).toBe(4003); // 4000 + "..."
+    expect(result.summary.endsWith("...")).toBe(true);
+  });
+
   it("classifies non-interactive manual authorization failures as auth required", () => {
     const result = detectGeminiAuthRequired({
       parsed: null,

--- a/packages/adapters/gemini-local/src/server/parse.ts
+++ b/packages/adapters/gemini-local/src/server/parse.ts
@@ -193,7 +193,9 @@ export function parseGeminiJsonl(stdout: string) {
 
   let summary = messages.join("\n\n").trim();
   if (jsonEventCount === 0 && stdout.trim().length > 0) {
-    summary = stdout.trim();
+    const trimmed = stdout.trim();
+    const limit = 4000;
+    summary = trimmed.length > limit ? trimmed.slice(0, limit) + "..." : trimmed;
   }
 
   return {

--- a/packages/teams-catalog/generated/catalog.json
+++ b/packages/teams-catalog/generated/catalog.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "packageName": "@paperclipai/teams-catalog",
   "packageVersion": "0.1.0",
-  "generatedAt": "2026-06-04T18:03:41.262Z",
+  "generatedAt": "2026-07-05T16:11:48.803Z",
   "teams": [
     {
       "id": "paperclipai:bundled:company-defaults:core-exec-team",
@@ -96,43 +96,43 @@
         {
           "path": "TEAM.md",
           "kind": "team",
-          "sizeBytes": 2144,
-          "sha256": "4ab4f57f147e89a56a6753755d7ef142d91741b3c0159f2e53fb333cd2779eaf"
+          "sizeBytes": 2188,
+          "sha256": "44785f11361024ea571f0ea16a96599c73e6affedf885cf4be58a7fa38126394"
         },
         {
           "path": "agents/ceo/AGENTS.md",
           "kind": "agent",
-          "sizeBytes": 2492,
-          "sha256": "50f580c51807762265f09c6fe7bf32d7701d64caeb30595bfd577b2f5087c21b"
+          "sizeBytes": 2543,
+          "sha256": "f0e5579d97918af8580008b6b18b5523c47dd97756b979b394a181f3d59f15a5"
         },
         {
           "path": "agents/cto/AGENTS.md",
           "kind": "agent",
-          "sizeBytes": 1449,
-          "sha256": "596e2e9fe08d7368b3b0cfe72c2635ea80444d92a2c0414157bfb0a17773fcaf"
+          "sizeBytes": 1482,
+          "sha256": "a43e5facb227c3aa94179b0042151e26fd92a2fd6dd08e409e46ee08d5652e82"
         },
         {
           "path": "agents/qa/AGENTS.md",
           "kind": "agent",
-          "sizeBytes": 1307,
-          "sha256": "2a139b88b4b98516048395c569c1bc74fd31cdc2da65db410e9779b8d92c0343"
+          "sizeBytes": 1338,
+          "sha256": "8cb06d89ed362d6c14ea87a7cd24ba876b584ddd8a0e32fea96dc348772400d0"
         },
         {
           "path": "projects/first-project/PROJECT.md",
           "kind": "project",
-          "sizeBytes": 364,
-          "sha256": "1f457ae956da52ff83adc1cf63a3fb84337a4afb25bd43f0d123902d75e871cc"
+          "sizeBytes": 372,
+          "sha256": "ce8b08b34d0786b6d8abbce9ab6f37e38b28fc7b2f632814b1b15deaddd1e99f"
         },
         {
           "path": "projects/first-project/tasks/first-heartbeat/TASK.md",
           "kind": "task",
-          "sizeBytes": 292,
-          "sha256": "bdc979cafa43fc9b8f0d6f0e4120c01cecfb899082781a5da88e26fa262f18e4"
+          "sizeBytes": 301,
+          "sha256": "02b56e304a8214b1e2e7ec401733ed0fbe151cb668ad19f2649ec65e934f7e68"
         }
       ],
       "trustLevel": "markdown_only",
       "compatibility": "compatible",
-      "contentHash": "sha256:0f20e9d56124c1dc90a1e4b128fabd863538bcc935117220f719d9620f7c89f1"
+      "contentHash": "sha256:91b498249140444f185aab8576df0ed017fd051491e6597da547c41c0381ca24"
     },
     {
       "id": "paperclipai:bundled:product:product-design",
@@ -212,31 +212,31 @@
         {
           "path": "TEAM.md",
           "kind": "team",
-          "sizeBytes": 2074,
-          "sha256": "205be8d3ef6c1f5e73729207913c387eee4cc9379191c3ce6d943fcf9ca2545d"
+          "sizeBytes": 2118,
+          "sha256": "7cba9ea75a13b4093efbfa8fcdbe39cc99111ca07423bb97e0880c9cb2fdc52c"
         },
         {
           "path": "agents/ux-designer/AGENTS.md",
           "kind": "agent",
-          "sizeBytes": 2136,
-          "sha256": "f5a4b5696d8249e9f9d808a4373c2a1e6b07faa463e72f83fd9d5bed98d2022f"
+          "sizeBytes": 2181,
+          "sha256": "a589242c1d76851eb9da6ef188dfe913683ce64ff410547a93c4c38666104934"
         },
         {
           "path": "projects/product-design/PROJECT.md",
           "kind": "project",
-          "sizeBytes": 353,
-          "sha256": "4afe346bc5d5958216542d60a06be12983e1e018960cf2709c85c7d578f28420"
+          "sizeBytes": 361,
+          "sha256": "6318207ccd6cb8d58c9c37f9ac463ac84d8d98965134e586b5fbcd4a878289c9"
         },
         {
           "path": "projects/product-design/tasks/weekly-design-review/TASK.md",
           "kind": "task",
-          "sizeBytes": 313,
-          "sha256": "d255115eccc5c8b9f576c34fc2fb46a1cbb86ab36a56b980bdab35a952482d8a"
+          "sizeBytes": 322,
+          "sha256": "a9b9e76776d3d118a6d8bbbc2ba0f3189e0ebf513df73e2c69cb6537d005b877"
         }
       ],
       "trustLevel": "markdown_only",
       "compatibility": "compatible",
-      "contentHash": "sha256:15a04b36f31d4c9a391bb499c92e91fedfcc237cfa6c3d41ea3ddb441bc85c5b"
+      "contentHash": "sha256:df4fe4f6e4b6bb36b1aa408261e5fa2b6b7c5956dfce3aeae45821917e067457"
     },
     {
       "id": "paperclipai:bundled:software-development:product-engineering",
@@ -331,49 +331,49 @@
         {
           "path": "TEAM.md",
           "kind": "team",
-          "sizeBytes": 2583,
-          "sha256": "7204eeef78a48714dd3f82b82e171a4039adc6325e91a6bdf51a442105ee33b0"
+          "sizeBytes": 2634,
+          "sha256": "cf7d167606d11f9cd9032b52de42384b6d804835005d617859cbf42b76be075a"
         },
         {
           "path": ".paperclip.yaml",
           "kind": "extension",
-          "sizeBytes": 81,
-          "sha256": "54babf05ba130ec54a143abf01581d99c0ac2936fd0d929bf0e0edd00e29d861"
+          "sizeBytes": 86,
+          "sha256": "cd676c301e0ac03f7f14ab7d20b48e4f0e38f6a76fe35905d7a6dfd27d278f73"
         },
         {
           "path": "agents/cto/AGENTS.md",
           "kind": "agent",
-          "sizeBytes": 1499,
-          "sha256": "0a1a73ec9e5008056bca0a26325131ded2fcf4c4680a5014ba1e13400b32c173"
+          "sizeBytes": 1533,
+          "sha256": "93ccb39127a2d308ec99334d642fcea2b9178d614c86984428b52333ffcc43d5"
         },
         {
           "path": "agents/qa/AGENTS.md",
           "kind": "agent",
-          "sizeBytes": 1223,
-          "sha256": "2d5738f831aa772befa3471c844a0c9e611584be668e3ec82580ca9e92dc13fc"
+          "sizeBytes": 1253,
+          "sha256": "614bd79d14bb50612807a35d2ca2cbdd53b5b79092d412c03740fedfda51e888"
         },
         {
           "path": "agents/senior-coder/AGENTS.md",
           "kind": "agent",
-          "sizeBytes": 1413,
-          "sha256": "b61071518755d9e584c099ae2082c7a78448d09586093ee91393082fe10872b5"
+          "sizeBytes": 1448,
+          "sha256": "2c70e785b188847d7271219fc849b80ddd79fdbd9b3e18247682b00455e0cfe0"
         },
         {
           "path": "projects/product-engineering/PROJECT.md",
           "kind": "project",
-          "sizeBytes": 358,
-          "sha256": "225d01c5b5b77f5d4dafedc083899c9368c9b079db1d3b7b67cfebd4677fc527"
+          "sizeBytes": 366,
+          "sha256": "e9db8884b8a98a78d2520c3442041a6213e6c86b993779a0a74540939826b80e"
         },
         {
           "path": "projects/product-engineering/tasks/weekly-engineering-sync/TASK.md",
           "kind": "task",
-          "sizeBytes": 322,
-          "sha256": "6acf3ed2da3dfa48de163810b4bc9d385dad537fd34037ca881eec713986a2a8"
+          "sizeBytes": 331,
+          "sha256": "3684350ad5cdb122fd77e4933946f6cebdd90681166789aadb6f14775a0b8307"
         }
       ],
       "trustLevel": "assets",
       "compatibility": "compatible",
-      "contentHash": "sha256:74ddeaeb11805835a4a67fc4530b048ab7f8aa1dc7d2b80acea139a933d158d3"
+      "contentHash": "sha256:0274602ef8e42d25d4b991cbf68abc4bd22ef7a15e4727705f5e4bc93ee858e6"
     },
     {
       "id": "paperclipai:optional:content:content-machine",
@@ -431,37 +431,37 @@
         {
           "path": "TEAM.md",
           "kind": "team",
-          "sizeBytes": 1032,
-          "sha256": "f7c272c8b0c183fc840d49eb4851b7cdd1a30a5aa8d6415d215110f3238f6f13"
+          "sizeBytes": 1062,
+          "sha256": "df50b14fb7d31b824688f12d1f6fae1064071a0fbdee347c2e131826ee9d7aee"
         },
         {
           "path": "agents/content-lead/AGENTS.md",
           "kind": "agent",
-          "sizeBytes": 251,
-          "sha256": "6fc2071ff463b6981780d5b40b2c0784cb119900062f8dc40ed372e7b8415bf7"
+          "sizeBytes": 262,
+          "sha256": "7fe7edbeb61b6494ac7f3f71aad18a03233338b86162fc73e9afe7925b199a0b"
         },
         {
           "path": "projects/content-operations/PROJECT.md",
           "kind": "project",
-          "sizeBytes": 338,
-          "sha256": "1471f61cb0b3ffbb9c639a99d2d370f08217a0c63f97b3e24dbbd47861110206"
+          "sizeBytes": 346,
+          "sha256": "c2c6c934f08e3b61d48fb9669c88a64908d850c18128364ce7a95d63f83d7b09"
         },
         {
           "path": "projects/content-operations/tasks/weekly-content-review/TASK.md",
           "kind": "task",
-          "sizeBytes": 236,
-          "sha256": "3777de716334f2c3f24176f0fe121584ce9c53a7f59e1fca942a2f57995cef77"
+          "sizeBytes": 245,
+          "sha256": "5f522393724a8808e80ef7459154143ddd1df8440d06382bc80ecb70b2444bda"
         },
         {
           "path": "skills/content-calendar/SKILL.md",
           "kind": "skill",
-          "sizeBytes": 340,
-          "sha256": "aa62a332fc3149d6c0d58ca589c6b3910a373d542f16f749ec68ef2f3d7f29e9"
+          "sizeBytes": 352,
+          "sha256": "42c71ff15c34811db69d6b9a0e773ef38cf13fecee03d04a648aa5908a8c83b3"
         }
       ],
       "trustLevel": "markdown_only",
       "compatibility": "compatible",
-      "contentHash": "sha256:06822cec5f2b6910cb37ba0ebd5e04ed5c7e34f77225564ddddc2470779cdaa6"
+      "contentHash": "sha256:25b2b931a40e4517d13daed5c67d6cc594e660713bf912d49dc1ef2cfd88d1a7"
     }
   ]
 }

--- a/scripts/release-package-manifest.json
+++ b/scripts/release-package-manifest.json
@@ -10,6 +10,11 @@
     "publishFromCi": true
   },
   {
+    "dir": "packages/adapters/antigravity-local",
+    "name": "@paperclipai/adapter-antigravity-local",
+    "publishFromCi": true
+  },
+  {
     "dir": "packages/adapters/claude-local",
     "name": "@paperclipai/adapter-claude-local",
     "publishFromCi": true

--- a/scripts/run-vitest-stable.mjs
+++ b/scripts/run-vitest-stable.mjs
@@ -260,10 +260,12 @@ function runVitest(args, label) {
   };
   mkdirSync(env.PAPERCLIP_HOME, { recursive: true });
   mkdirSync(env.TMPDIR, { recursive: true });
+  const shell = process.platform === "win32";
   const result = spawnSync("pnpm", ["exec", "vitest", "run", ...args], {
     cwd: repoRoot,
     env,
     stdio: "inherit",
+    shell,
   });
   if (result.error) {
     console.error(`[test:run] Failed to start Vitest: ${result.error.message}`);

--- a/server/package.json
+++ b/server/package.json
@@ -50,6 +50,7 @@
     "@paperclipai/adapter-cursor-cloud": "workspace:*",
     "@paperclipai/adapter-cursor-local": "workspace:*",
     "@paperclipai/adapter-gemini-local": "workspace:*",
+    "@paperclipai/adapter-antigravity-local": "workspace:*",
     "@paperclipai/adapter-grok-local": "workspace:*",
     "@paperclipai/adapter-openclaw-gateway": "workspace:*",
     "@paperclipai/adapter-opencode-local": "workspace:*",

--- a/server/src/adapters/builtin-adapter-types.ts
+++ b/server/src/adapters/builtin-adapter-types.ts
@@ -8,6 +8,7 @@ export const BUILTIN_ADAPTER_TYPES = new Set([
   "cursor_cloud",
   "cursor",
   "gemini_local",
+  "antigravity_local",
   "grok_local",
   "hermes_gateway",
   "hermes_local",

--- a/server/src/adapters/registry.ts
+++ b/server/src/adapters/registry.ts
@@ -82,6 +82,18 @@ import {
   modelProfiles as geminiModelProfiles,
 } from "@paperclipai/adapter-gemini-local";
 import {
+  execute as antigravityExecute,
+  listAntigravitySkills,
+  syncAntigravitySkills,
+  testEnvironment as antigravityTestEnvironment,
+  sessionCodec as antigravitySessionCodec,
+} from "@paperclipai/adapter-antigravity-local/server";
+import {
+  agentConfigurationDoc as antigravityAgentConfigurationDoc,
+  models as antigravityModels,
+  modelProfiles as antigravityModelProfiles,
+} from "@paperclipai/adapter-antigravity-local";
+import {
   execute as grokExecute,
   listGrokSkills,
   syncGrokSkills,
@@ -325,6 +337,25 @@ const geminiLocalAdapter: ServerAdapterModule = {
   agentConfigurationDoc: geminiAgentConfigurationDoc,
 };
 
+const antigravityLocalAdapter: ServerAdapterModule = {
+  type: "antigravity_local",
+  execute: antigravityExecute,
+  testEnvironment: antigravityTestEnvironment,
+  listSkills: listAntigravitySkills,
+  syncSkills: syncAntigravitySkills,
+  sessionCodec: antigravitySessionCodec,
+  sessionManagement: getAdapterSessionManagement("antigravity_local") ?? undefined,
+  models: antigravityModels,
+  modelProfiles: antigravityModelProfiles,
+  supportsLocalAgentJwt: true,
+  supportsInstructionsBundle: true,
+  instructionsPathKey: "instructionsFilePath",
+  requiresMaterializedRuntimeSkills: true,
+  getRuntimeCommandSpec: (config) =>
+    buildNpmRuntimeCommandSpec(config, "agy", "@google/antigravity-cli"),
+  agentConfigurationDoc: antigravityAgentConfigurationDoc,
+};
+
 const grokLocalAdapter: ServerAdapterModule = {
   type: "grok_local",
   execute: grokExecute,
@@ -421,6 +452,7 @@ function registerBuiltInAdapters() {
     cursorCloudAdapter,
     cursorLocalAdapter,
     geminiLocalAdapter,
+    antigravityLocalAdapter,
     grokLocalAdapter,
     hermesGatewayAdapter,
     hermesLocalAdapter,

--- a/ui/package.json
+++ b/ui/package.json
@@ -40,6 +40,7 @@
     "@paperclipai/adapter-cursor-cloud": "workspace:*",
     "@paperclipai/adapter-cursor-local": "workspace:*",
     "@paperclipai/adapter-gemini-local": "workspace:*",
+    "@paperclipai/adapter-antigravity-local": "workspace:*",
     "@paperclipai/adapter-grok-local": "workspace:*",
     "@paperclipai/adapter-openclaw-gateway": "workspace:*",
     "@paperclipai/adapter-opencode-local": "workspace:*",

--- a/ui/src/adapters/adapter-display-registry.ts
+++ b/ui/src/adapters/adapter-display-registry.ts
@@ -83,6 +83,11 @@ const adapterDisplayMap: Record<string, AdapterDisplayInfo> = {
     description: "Gemini CLI harness",
     icon: Gem,
   },
+  antigravity_local: {
+    label: "Antigravity",
+    description: "Antigravity CLI harness",
+    icon: Sparkles,
+  },
   grok_local: {
     label: "Grok Build",
     description: "Grok Build harness",

--- a/ui/src/adapters/antigravity-local/config-fields.tsx
+++ b/ui/src/adapters/antigravity-local/config-fields.tsx
@@ -1,0 +1,51 @@
+import type { AdapterConfigFieldsProps } from "../types";
+import {
+  DraftInput,
+  Field,
+} from "../../components/agent-config-primitives";
+import { ChoosePathButton } from "../../components/PathInstructionsModal";
+
+const inputClass =
+  "w-full rounded-md border border-border px-2.5 py-1.5 bg-transparent outline-none text-sm font-mono placeholder:text-muted-foreground/40";
+const instructionsFileHint =
+  "Absolute path to a markdown file (e.g. AGENTS.md) that defines this agent's behavior. Prepended to the Antigravity prompt at runtime.";
+
+export function AntigravityLocalConfigFields({
+  isCreate,
+  values,
+  set,
+  config,
+  eff,
+  mark,
+  hideInstructionsFile,
+}: AdapterConfigFieldsProps) {
+  if (hideInstructionsFile) return null;
+  return (
+    <>
+      <Field label="Agent instructions file" hint={instructionsFileHint}>
+        <div className="flex items-center gap-2">
+          <DraftInput
+            value={
+              isCreate
+                ? values!.instructionsFilePath ?? ""
+                : eff(
+                    "adapterConfig",
+                    "instructionsFilePath",
+                    String(config.instructionsFilePath ?? ""),
+                  )
+            }
+            onCommit={(v) =>
+              isCreate
+                ? set!({ instructionsFilePath: v })
+                : mark("adapterConfig", "instructionsFilePath", v || undefined)
+            }
+            immediate
+            className={inputClass}
+            placeholder="/absolute/path/to/AGENTS.md"
+          />
+          <ChoosePathButton />
+        </div>
+      </Field>
+    </>
+  );
+}

--- a/ui/src/adapters/antigravity-local/index.ts
+++ b/ui/src/adapters/antigravity-local/index.ts
@@ -1,0 +1,12 @@
+import type { UIAdapterModule } from "../types";
+import { parseAntigravityStdoutLine } from "@paperclipai/adapter-antigravity-local/ui";
+import { AntigravityLocalConfigFields } from "./config-fields";
+import { buildAntigravityLocalConfig } from "@paperclipai/adapter-antigravity-local/ui";
+
+export const antigravityLocalUIAdapter: UIAdapterModule = {
+  type: "antigravity_local",
+  label: "Antigravity CLI",
+  parseStdoutLine: parseAntigravityStdoutLine,
+  ConfigFields: AntigravityLocalConfigFields,
+  buildAdapterConfig: buildAntigravityLocalConfig,
+};

--- a/ui/src/adapters/registry.ts
+++ b/ui/src/adapters/registry.ts
@@ -5,6 +5,7 @@ import { codexLocalUIAdapter } from "./codex-local";
 import { cursorCloudUIAdapter } from "./cursor-cloud";
 import { cursorLocalUIAdapter } from "./cursor";
 import { geminiLocalUIAdapter } from "./gemini-local";
+import { antigravityLocalUIAdapter } from "./antigravity-local";
 import { grokLocalUIAdapter } from "./grok-local";
 import { hermesGatewayUIAdapter } from "./hermes-gateway";
 import { hermesLocalUIAdapter } from "./hermes-local";
@@ -58,6 +59,7 @@ function registerBuiltInUIAdapters() {
     codexLocalUIAdapter,
     cursorCloudUIAdapter,
     geminiLocalUIAdapter,
+    antigravityLocalUIAdapter,
     grokLocalUIAdapter,
     hermesGatewayUIAdapter,
     hermesLocalUIAdapter,

--- a/ui/src/components/OnboardingWizard.tsx
+++ b/ui/src/components/OnboardingWizard.tsx
@@ -42,6 +42,7 @@ import { buildNewAgentRuntimeConfig } from "../lib/new-agent-runtime-config";
 import { DEFAULT_CODEX_LOCAL_BYPASS_APPROVALS_AND_SANDBOX } from "@paperclipai/adapter-codex-local";
 import { DEFAULT_CURSOR_LOCAL_MODEL } from "@paperclipai/adapter-cursor-local";
 import { DEFAULT_GEMINI_LOCAL_MODEL } from "@paperclipai/adapter-gemini-local";
+import { DEFAULT_ANTIGRAVITY_LOCAL_MODEL } from "@paperclipai/adapter-antigravity-local";
 import { DEFAULT_OPENCODE_LOCAL_MODEL, isValidOpenCodeModelId } from "@paperclipai/adapter-opencode-local";
 import { resolveRouteOnboardingOptions } from "../lib/onboarding-route";
 import { AsciiArtAnimation } from "./AsciiArtAnimation";
@@ -297,6 +298,7 @@ export function OnboardingWizard() {
     claude_local: "claude",
     codex_local: "codex",
     gemini_local: "gemini",
+    antigravity_local: "agy",
     pi_local: "pi",
     cursor: "agent",
     opencode_local: "opencode",
@@ -1311,6 +1313,10 @@ export function OnboardingWizard() {
                               setAdapterType(nextType);
                               if (nextType === "gemini_local" && !model) {
                                 setModel(DEFAULT_GEMINI_LOCAL_MODEL);
+                                return;
+                              }
+                              if (nextType === "antigravity_local" && !model) {
+                                setModel(DEFAULT_ANTIGRAVITY_LOCAL_MODEL);
                                 return;
                               }
                               if (nextType === "cursor" && !model) {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -13,6 +13,7 @@ export default defineConfig({
       "packages/adapters/cursor-cloud",
       "packages/adapters/cursor-local",
       "packages/adapters/gemini-local",
+      "packages/adapters/antigravity-local",
       "packages/adapters/grok-local",
       "packages/adapters/opencode-local",
       "packages/adapters/pi-local",


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source platform for managing AI agents and local AI tooling.
> - This PR introduces a new local adapter package for the Antigravity CLI so it can be used as a first-class local provider within Paperclip.
> - The adapter includes CLI execution, transport, session management, environment validation, UI integration, skills synchronization, and model configuration required for local execution.
> - During implementation, it was also identified that both the Antigravity and Gemini local adapters assumed CLI output was always JSONL. Some commands (such as hello probes) return plain-text output instead.
> - This PR therefore adds a plain-text stdout fallback to the JSONL parsers and updates the available Antigravity model list to match the current CLI.
> - The result is a complete Antigravity local adapter with improved compatibility and more reliable environment validation.

## Linked Issues or Issue Description

Closes #6559

### Description of the Problem

Paperclip did not have a dedicated local adapter for the Antigravity CLI. In addition, the parser used by both the Antigravity and Gemini local adapters expected JSONL output exclusively, causing environment validation commands that returned plain text (for example, `hello\n`) to produce empty summaries.

This PR introduces the new Antigravity local adapter, updates its available model configuration, and improves parser robustness by falling back to raw stdout when no JSON events are available.

## What Changed

- **New Antigravity Local Adapter**
  - Added the new `@paperclipai/adapter-antigravity-local` package.
  - Implemented local CLI execution, SSH/sandbox transport, session management, environment validation, UI integration, CLI formatting, skills synchronization, and model configuration.

- **Model Configuration Updates**
  - Synced the available models with the current output of `agy models`.
  - Updated the default `cheap` profile to use `gemini-3.5-flash-low`.

- **Parser Robustness**
  - Updated `parseAntigravityJsonl` to fall back to raw `stdout` when no JSONL events are parsed.
  - Applied the same fallback behavior to `parseGeminiJsonl` for consistent behavior across local adapters.

- **Unit Testing**
  - Added tests covering the plain-text fallback behavior for both adapters.
  - Verified all existing tests continue to pass.

- **Cleanup**
  - Removed temporary debug logging from the Antigravity adapter.

## Verification

### Automated Tests

- Ran Vitest suites for both impacted adapters:
  ```powershell
  npx vitest run packages/adapters/antigravity-local packages/adapters/gemini-local
  ```
  Result: **All 120 tests pass.**

- Successfully built the packages:
  ```powershell
  pnpm --filter @paperclipai/adapter-antigravity-local build
  pnpm --filter @paperclipai/adapter-gemini-local build
  ```

## Risks

- **Low risk:** The parser fallback is only used when no JSONL events are parsed. Existing structured JSON streams continue to behave exactly as before.

## Model Used

- **Provider**: Google
- **Model Name**: Gemini 3.5 Flash (High)
- **Version/ID**: `gemini-3.5-flash-high`
- **Capabilities**: Extended thinking, tool use, local code build & execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket ID or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green