### PR TITLE
fix(DGG-18218): debounce dev auto-restart SIGTERM origin

### DIFF
--- a/scripts/dev-runner-paths.mjs
+++ b/scripts/dev-runner-paths.mjs
@@ -16,12 +16,27 @@ const ignoredTestConfigBasenames = new Set([
 
 const nodeDiagnosticReportPattern = /^report\.\d{8}\.\d{6}\.\d+\.\d+\.\d+\.json$/i;
 
+const ignoredTopLevelRuntimeDirectories = new Set([
+  "artifacts",
+  "docs",
+  "logs",
+  "team-state",
+]);
+
 export function shouldTrackDevServerPath(relativePath) {
   const normalizedPath = String(relativePath).replaceAll("\\", "/").replace(/^\.\/+/, "");
   if (normalizedPath.length === 0) return false;
 
   const segments = normalizedPath.split("/");
   const basename = segments.at(-1) ?? normalizedPath;
+
+  // DGG-18210: runtime artifacts are operational output, not backend source.
+  // Treating them as code changes let the dev runner SIGTERM the API process
+  // during idle auto-restart, cascading in-flight gateway dispatches into
+  // gateway_request_failed / blocked flips.
+  if (segments[0] === "server" && ignoredTopLevelRuntimeDirectories.has(segments[1] ?? "")) {
+    return false;
+  }
 
   if (nodeDiagnosticReportPattern.test(basename)) {
     return false;

--- a/scripts/dev-runner.ts
+++ b/scripts/dev-runner.ts
@@ -33,6 +33,10 @@ const mode = process.argv[2] === "watch" ? "watch" : "dev";
 const cliArgs = process.argv.slice(3);
 const scanIntervalMs = 1500;
 const autoRestartPollIntervalMs = 2500;
+const autoRestartDebounceMs = Math.max(
+  0,
+  Number.parseInt(process.env.PAPERCLIP_DEV_AUTO_RESTART_DEBOUNCE_MS ?? "30000", 10) || 30_000,
+);
 const gracefulShutdownTimeoutMs = 10_000;
 const changedPathSampleLimit = 5;
 const devServerStatusFilePath = path.join(repoRoot, ".paperclip", "dev-server-status.json");
@@ -592,6 +596,9 @@ async function maybeAutoRestartChild() {
   const manualRestartRequested = consumeDevServerRestartRequest();
   if (!manualRestartRequested && dirtyPaths.size === 0 && pendingMigrations.length === 0) return;
 
+  const dirtyAgeMs = lastChangedAt ? Date.now() - Date.parse(lastChangedAt) : Number.POSITIVE_INFINITY;
+  if (!manualRestartRequested && dirtyAgeMs < autoRestartDebounceMs) return;
+
   restartInFlight = true;
   let health: { devServer?: { enabled?: boolean; autoRestartEnabled?: boolean; activeRunCount?: number } } | null = null;
   try {
@@ -616,6 +623,8 @@ async function maybeAutoRestartChild() {
   }
 
   try {
+    const restartReasons = [...dirtyPaths].sort().slice(0, changedPathSampleLimit).join(", ") || "pending migrations";
+    console.log(`[paperclip] auto-restart SIGTERM origin: dev-runner dirty=${dirtyPaths.size} pendingMigrations=${pendingMigrations.length} sample=${restartReasons}`);
     await maybePreflightMigrations({
       autoApply: true,
       interactive: false,

--- a/scripts/dev-runner.ts
+++ b/scripts/dev-runner.ts
@@ -33,10 +33,13 @@ const mode = process.argv[2] === "watch" ? "watch" : "dev";
 const cliArgs = process.argv.slice(3);
 const scanIntervalMs = 1500;
 const autoRestartPollIntervalMs = 2500;
-const autoRestartDebounceMs = Math.max(
-  0,
-  Number.parseInt(process.env.PAPERCLIP_DEV_AUTO_RESTART_DEBOUNCE_MS ?? "30000", 10) || 30_000,
+const parsedAutoRestartDebounceMs = Number.parseInt(
+  process.env.PAPERCLIP_DEV_AUTO_RESTART_DEBOUNCE_MS ?? "30000",
+  10,
 );
+const autoRestartDebounceMs = Number.isFinite(parsedAutoRestartDebounceMs)
+  ? Math.max(0, parsedAutoRestartDebounceMs)
+  : 30_000;
 const gracefulShutdownTimeoutMs = 10_000;
 const changedPathSampleLimit = 5;
 const devServerStatusFilePath = path.join(repoRoot, ".paperclip", "dev-server-status.json");

--- a/server/src/__tests__/dev-runner-paths.test.ts
+++ b/server/src/__tests__/dev-runner-paths.test.ts
@@ -18,9 +18,13 @@ describe("shouldTrackDevServerPath", () => {
     expect(shouldTrackDevServerPath("packages/shared/tests/helpers.ts")).toBe(false);
     expect(shouldTrackDevServerPath("packages/shared/test/helpers.ts")).toBe(false);
     expect(shouldTrackDevServerPath("vitest.config.ts")).toBe(false);
+    expect(shouldTrackDevServerPath("server/artifacts/session/run.json")).toBe(false);
+    expect(shouldTrackDevServerPath("server/docs/generated/report.md")).toBe(false);
+    expect(shouldTrackDevServerPath("server/logs/paperclip.log")).toBe(false);
+    expect(shouldTrackDevServerPath("server/team-state/kuromi.json")).toBe(false);
   });
 
-  it("keeps runtime paths restart-relevant", () => {
+  it("keeps source paths restart-relevant", () => {
     expect(shouldTrackDevServerPath("server/src/routes/health.ts")).toBe(true);
     expect(shouldTrackDevServerPath("packages/shared/src/index.ts")).toBe(true);
     expect(shouldTrackDevServerPath("server/src/testing/runtime.ts")).toBe(true);

--- a/server/src/__tests__/heartbeat-openclaw-gateway-dispatch-retry.test.ts
+++ b/server/src/__tests__/heartbeat-openclaw-gateway-dispatch-retry.test.ts
@@ -164,6 +164,7 @@ describeEmbeddedPostgres("heartbeat OpenClaw gateway dispatch retry", () => {
       title: "Gateway-backed issue",
       status: "in_progress",
       priority: "high",
+      responsibleUserId: "responsible-user",
       assigneeAgentId: agentId,
     });
     await db.insert(agentWakeupRequests).values({
@@ -184,7 +185,7 @@ describeEmbeddedPostgres("heartbeat OpenClaw gateway dispatch retry", () => {
       triggerDetail: "system",
       status: "queued",
       wakeupRequestId,
-      contextSnapshot: { issueId, wakeReason: "issue_assigned" },
+      contextSnapshot: { issueId, wakeReason: "issue_assigned", responsibleUserId: "responsible-user" },
     });
     await db.update(agentWakeupRequests).set({ runId }).where(eq(agentWakeupRequests.id, wakeupRequestId));
     await db

--- a/server/src/__tests__/heartbeat-openclaw-gateway-dispatch-retry.test.ts
+++ b/server/src/__tests__/heartbeat-openclaw-gateway-dispatch-retry.test.ts
@@ -1,0 +1,321 @@
+import { randomUUID } from "node:crypto";
+import { eq, sql } from "drizzle-orm";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import {
+  activityLog,
+  agents,
+  agentRuntimeState,
+  agentWakeupRequests,
+  companies,
+  companySkills,
+  createDb,
+  documentRevisions,
+  documents,
+  heartbeatRunEvents,
+  heartbeatRuns,
+  issueComments,
+  issueDocuments,
+  issueRelations,
+  issueTreeHolds,
+  issues,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import {
+  heartbeatService,
+  isOpenClawGatewayDispatchRetryableResult,
+  parseOpenClawGatewayDispatchRetryDelaysMs,
+} from "../services/heartbeat.ts";
+import { runningProcesses } from "../adapters/index.ts";
+
+const mockAdapterExecute = vi.hoisted(() =>
+  vi.fn(async () => ({
+    exitCode: 0,
+    signal: null,
+    timedOut: false,
+    errorMessage: null,
+    summary: "OpenClaw gateway dispatch retry test run.",
+    provider: "test",
+    model: "test-model",
+  })),
+);
+
+vi.mock("../adapters/index.ts", async () => {
+  const actual = await vi.importActual<typeof import("../adapters/index.ts")>("../adapters/index.ts");
+  return {
+    ...actual,
+    getServerAdapter: vi.fn(() => ({
+      supportsLocalAgentJwt: false,
+      execute: mockAdapterExecute,
+    })),
+  };
+});
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+async function ensureIssueRelationsTable(db: ReturnType<typeof createDb>) {
+  await db.execute(sql.raw(`
+    CREATE TABLE IF NOT EXISTS "issue_relations" (
+      "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+      "company_id" uuid NOT NULL,
+      "issue_id" uuid NOT NULL,
+      "related_issue_id" uuid NOT NULL,
+      "type" text NOT NULL,
+      "created_by_agent_id" uuid,
+      "created_by_user_id" text,
+      "created_at" timestamptz NOT NULL DEFAULT now(),
+      "updated_at" timestamptz NOT NULL DEFAULT now()
+    );
+  `));
+}
+
+async function waitForCondition(fn: () => Promise<boolean>, timeoutMs = 3_000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await fn()) return true;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  return fn();
+}
+
+describeEmbeddedPostgres("heartbeat OpenClaw gateway dispatch retry", () => {
+  let db!: ReturnType<typeof createDb>;
+  let heartbeat!: ReturnType<typeof heartbeatService>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+  let originalDelayOverride: string | undefined;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-openclaw-dispatch-retry-");
+    db = createDb(tempDb.connectionString);
+    heartbeat = heartbeatService(db);
+    await ensureIssueRelationsTable(db);
+    originalDelayOverride = process.env.PAPERCLIP_OPENCLAW_GATEWAY_DISPATCH_RETRY_DELAYS_MS;
+  }, 20_000);
+
+  afterEach(async () => {
+    mockAdapterExecute.mockReset();
+    mockAdapterExecute.mockImplementation(async () => ({
+      exitCode: 0,
+      signal: null,
+      timedOut: false,
+      errorMessage: null,
+      summary: "OpenClaw gateway dispatch retry test run.",
+      provider: "test",
+      model: "test-model",
+    }));
+    if (originalDelayOverride === undefined) {
+      delete process.env.PAPERCLIP_OPENCLAW_GATEWAY_DISPATCH_RETRY_DELAYS_MS;
+    } else {
+      process.env.PAPERCLIP_OPENCLAW_GATEWAY_DISPATCH_RETRY_DELAYS_MS = originalDelayOverride;
+    }
+    runningProcesses.clear();
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    await db.delete(companySkills);
+    await db.delete(issueComments);
+    await db.delete(issueDocuments);
+    await db.delete(documentRevisions);
+    await db.delete(documents);
+    await db.delete(issueRelations);
+    await db.delete(issueTreeHolds);
+    await db.delete(issues);
+    await db.delete(heartbeatRunEvents);
+    await db.delete(activityLog);
+    await db.delete(heartbeatRuns);
+    await db.delete(agentWakeupRequests);
+    await db.delete(agentRuntimeState);
+    await db.delete(agents);
+    await db.delete(companySkills);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  async function seedOpenClawGatewayIssueRun() {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const issueId = randomUUID();
+    const wakeupRequestId = randomUUID();
+    const runId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Kuromi",
+      role: "ops",
+      status: "active",
+      adapterType: "openclaw_gateway",
+      adapterConfig: {},
+      runtimeConfig: { heartbeat: { wakeOnDemand: true, maxConcurrentRuns: 1 } },
+      permissions: {},
+    });
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Gateway-backed issue",
+      status: "in_progress",
+      priority: "high",
+      assigneeAgentId: agentId,
+    });
+    await db.insert(agentWakeupRequests).values({
+      id: wakeupRequestId,
+      companyId,
+      agentId,
+      source: "assignment",
+      triggerDetail: "system",
+      reason: "issue_assigned",
+      payload: { issueId },
+      status: "queued",
+    });
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId,
+      agentId,
+      invocationSource: "assignment",
+      triggerDetail: "system",
+      status: "queued",
+      wakeupRequestId,
+      contextSnapshot: { issueId, wakeReason: "issue_assigned" },
+    });
+    await db.update(agentWakeupRequests).set({ runId }).where(eq(agentWakeupRequests.id, wakeupRequestId));
+    await db
+      .update(issues)
+      .set({
+        checkoutRunId: runId,
+        executionRunId: runId,
+        executionAgentNameKey: "kuromi",
+        executionLockedAt: new Date(),
+      })
+      .where(eq(issues.id, issueId));
+    return { runId, issueId };
+  }
+
+  it("parses default and overridden retry delays", () => {
+    expect(parseOpenClawGatewayDispatchRetryDelaysMs(undefined)).toEqual([5_000, 15_000, 45_000]);
+    expect(parseOpenClawGatewayDispatchRetryDelaysMs("0,1,2")).toEqual([0, 1, 2]);
+    expect(parseOpenClawGatewayDispatchRetryDelaysMs("bad")).toEqual([5_000, 15_000, 45_000]);
+  });
+
+  it("only retries OpenClaw gateway request failures", () => {
+    expect(isOpenClawGatewayDispatchRetryableResult(
+      { adapterType: "openclaw_gateway" },
+      { exitCode: 1, timedOut: false, errorCode: "openclaw_gateway_request_failed", errorMessage: "gateway request failed" },
+    )).toBe(true);
+    expect(isOpenClawGatewayDispatchRetryableResult(
+      { adapterType: "openclaw_gateway" },
+      { exitCode: 1, timedOut: false, errorCode: "openclaw_gateway_wait_error", errorMessage: "run failed" },
+    )).toBe(false);
+    expect(isOpenClawGatewayDispatchRetryableResult(
+      { adapterType: "codex_local" },
+      { exitCode: 1, timedOut: false, errorCode: "openclaw_gateway_request_failed", errorMessage: "gateway request failed" },
+    )).toBe(false);
+  });
+
+  it("retries transient OpenClaw gateway dispatch failure and preserves the issue lock on success", async () => {
+    process.env.PAPERCLIP_OPENCLAW_GATEWAY_DISPATCH_RETRY_DELAYS_MS = "0,0,0";
+    const { runId, issueId } = await seedOpenClawGatewayIssueRun();
+    mockAdapterExecute
+      .mockResolvedValueOnce({
+        exitCode: 1,
+        signal: null,
+        timedOut: false,
+        errorCode: "openclaw_gateway_request_failed",
+        errorMessage: "gateway request failed",
+        provider: "test",
+        model: "test-model",
+      })
+      .mockResolvedValueOnce({
+        exitCode: 1,
+        signal: null,
+        timedOut: false,
+        errorCode: "openclaw_gateway_request_failed",
+        errorMessage: "gateway request failed",
+        provider: "test",
+        model: "test-model",
+      })
+      .mockResolvedValueOnce({
+        exitCode: 0,
+        signal: null,
+        timedOut: false,
+        errorMessage: null,
+        summary: "Recovered after gateway retry.",
+        provider: "test",
+        model: "test-model",
+      });
+
+    await heartbeat.resumeQueuedRuns();
+    await waitForCondition(async () => {
+      const run = await db
+        .select({ status: heartbeatRuns.status })
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.id, runId))
+        .then((rows) => rows[0] ?? null);
+      return run?.status === "succeeded";
+    });
+
+    const [run, issue, retryEvents] = await Promise.all([
+      db
+        .select({ status: heartbeatRuns.status, errorCode: heartbeatRuns.errorCode })
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.id, runId))
+        .then((rows) => rows[0] ?? null),
+      db
+        .select({ status: issues.status, checkoutRunId: issues.checkoutRunId })
+        .from(issues)
+        .where(eq(issues.id, issueId))
+        .then((rows) => rows[0] ?? null),
+      db
+        .select({ eventType: heartbeatRunEvents.eventType })
+        .from(heartbeatRunEvents)
+        .where(eq(heartbeatRunEvents.runId, runId)),
+    ]);
+
+    expect(mockAdapterExecute).toHaveBeenCalledTimes(3);
+    expect(run?.status).toBe("succeeded");
+    expect(run?.errorCode).toBeNull();
+    expect(issue?.status).toBe("in_progress");
+    expect(issue?.checkoutRunId).toBe(runId);
+    expect(retryEvents.filter((event) => event.eventType === "adapter.retry")).toHaveLength(2);
+  });
+
+  it("fails after all OpenClaw gateway dispatch retries are exhausted", async () => {
+    process.env.PAPERCLIP_OPENCLAW_GATEWAY_DISPATCH_RETRY_DELAYS_MS = "0,0,0";
+    const { runId } = await seedOpenClawGatewayIssueRun();
+    mockAdapterExecute.mockResolvedValue({
+      exitCode: 1,
+      signal: null,
+      timedOut: false,
+      errorCode: "openclaw_gateway_request_failed",
+      errorMessage: "gateway request failed",
+      provider: "test",
+      model: "test-model",
+    });
+
+    await heartbeat.resumeQueuedRuns();
+    await waitForCondition(async () => {
+      const run = await db
+        .select({ status: heartbeatRuns.status })
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.id, runId))
+        .then((rows) => rows[0] ?? null);
+      return run?.status === "failed";
+    });
+
+    const retryEvents = await db
+      .select({ eventType: heartbeatRunEvents.eventType })
+      .from(heartbeatRunEvents)
+      .where(eq(heartbeatRunEvents.runId, runId));
+
+    expect(mockAdapterExecute).toHaveBeenCalledTimes(4);
+    expect(retryEvents.filter((event) => event.eventType === "adapter.retry")).toHaveLength(3);
+  });
+});

--- a/server/src/__tests__/heartbeat-openclaw-gateway-dispatch-retry.test.ts
+++ b/server/src/__tests__/heartbeat-openclaw-gateway-dispatch-retry.test.ts
@@ -185,7 +185,12 @@ describeEmbeddedPostgres("heartbeat OpenClaw gateway dispatch retry", () => {
       triggerDetail: "system",
       status: "queued",
       wakeupRequestId,
-      contextSnapshot: { issueId, wakeReason: "issue_assigned", responsibleUserId: "responsible-user" },
+      contextSnapshot: {
+        issueId,
+        wakeReason: "issue_assigned",
+        responsibleUserId: "responsible-user",
+        skipIssueComment: true,
+      },
     });
     await db.update(agentWakeupRequests).set({ runId }).where(eq(agentWakeupRequests.id, wakeupRequestId));
     await db
@@ -255,12 +260,19 @@ describeEmbeddedPostgres("heartbeat OpenClaw gateway dispatch retry", () => {
 
     await heartbeat.resumeQueuedRuns();
     await waitForCondition(async () => {
-      const run = await db
-        .select({ status: heartbeatRuns.status })
-        .from(heartbeatRuns)
-        .where(eq(heartbeatRuns.id, runId))
-        .then((rows) => rows[0] ?? null);
-      return run?.status === "succeeded";
+      const [run, issue] = await Promise.all([
+        db
+          .select({ status: heartbeatRuns.status })
+          .from(heartbeatRuns)
+          .where(eq(heartbeatRuns.id, runId))
+          .then((rows) => rows[0] ?? null),
+        db
+          .select({ checkoutRunId: issues.checkoutRunId })
+          .from(issues)
+          .where(eq(issues.id, issueId))
+          .then((rows) => rows[0] ?? null),
+      ]);
+      return run?.status === "succeeded" && issue?.checkoutRunId === null;
     });
 
     const [run, issue, retryEvents] = await Promise.all([
@@ -291,6 +303,7 @@ describeEmbeddedPostgres("heartbeat OpenClaw gateway dispatch retry", () => {
   it("fails after all OpenClaw gateway dispatch retries are exhausted", async () => {
     process.env.PAPERCLIP_OPENCLAW_GATEWAY_DISPATCH_RETRY_DELAYS_MS = "0,0,0";
     const { runId } = await seedOpenClawGatewayIssueRun();
+    const callsBefore = mockAdapterExecute.mock.calls.length;
     mockAdapterExecute.mockResolvedValue({
       exitCode: 1,
       signal: null,
@@ -316,7 +329,7 @@ describeEmbeddedPostgres("heartbeat OpenClaw gateway dispatch retry", () => {
       .from(heartbeatRunEvents)
       .where(eq(heartbeatRunEvents.runId, runId));
 
-    expect(mockAdapterExecute).toHaveBeenCalledTimes(4);
+    expect(mockAdapterExecute.mock.calls.length - callsBefore).toBe(4);
     expect(retryEvents.filter((event) => event.eventType === "adapter.retry")).toHaveLength(3);
   });
 });

--- a/server/src/__tests__/heartbeat-openclaw-gateway-dispatch-retry.test.ts
+++ b/server/src/__tests__/heartbeat-openclaw-gateway-dispatch-retry.test.ts
@@ -221,7 +221,7 @@ describeEmbeddedPostgres("heartbeat OpenClaw gateway dispatch retry", () => {
     )).toBe(false);
   });
 
-  it("retries transient OpenClaw gateway dispatch failure and preserves the issue lock on success", async () => {
+  it("retries transient OpenClaw gateway dispatch failure and releases the issue lock on success", async () => {
     process.env.PAPERCLIP_OPENCLAW_GATEWAY_DISPATCH_RETRY_DELAYS_MS = "0,0,0";
     const { runId, issueId } = await seedOpenClawGatewayIssueRun();
     mockAdapterExecute
@@ -284,7 +284,7 @@ describeEmbeddedPostgres("heartbeat OpenClaw gateway dispatch retry", () => {
     expect(run?.status).toBe("succeeded");
     expect(run?.errorCode).toBeNull();
     expect(issue?.status).toBe("in_progress");
-    expect(issue?.checkoutRunId).toBe(runId);
+    expect(issue?.checkoutRunId).toBeNull();
     expect(retryEvents.filter((event) => event.eventType === "adapter.retry")).toHaveLength(2);
   });
 

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -288,6 +288,8 @@ const BOUNDED_TRANSIENT_HEARTBEAT_RETRY_JITTER_RATIO = 0.25;
 const BOUNDED_TRANSIENT_HEARTBEAT_RETRY_REASON = "transient_failure";
 const BOUNDED_TRANSIENT_HEARTBEAT_RETRY_WAKE_REASON = "transient_failure_retry";
 const BOUNDED_TRANSIENT_HEARTBEAT_RETRY_MAX_ATTEMPTS = BOUNDED_TRANSIENT_HEARTBEAT_RETRY_DELAYS_MS.length;
+export const OPENCLAW_GATEWAY_DISPATCH_RETRY_DELAYS_MS = [5_000, 15_000, 45_000] as const;
+const OPENCLAW_GATEWAY_DISPATCH_RETRY_ERROR_CODE = "openclaw_gateway_request_failed";
 const WORKSPACE_VALIDATION_FAILURE_CODE = "workspace_validation_failed";
 const WORKSPACE_VALIDATION_RECOVERY_CAUSE = "workspace_validation_failed";
 const CONFIGURATION_INCOMPLETE_FAILURE_CODE = "configuration_incomplete";
@@ -372,6 +374,32 @@ function readHeartbeatRunErrorFamily(
     return "transient_upstream";
   }
   return null;
+}
+
+export function parseOpenClawGatewayDispatchRetryDelaysMs(value: unknown): number[] {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    return [...OPENCLAW_GATEWAY_DISPATCH_RETRY_DELAYS_MS];
+  }
+  const parsed = value
+    .split(",")
+    .map((part) => Number(part.trim()))
+    .filter((delayMs) => Number.isFinite(delayMs) && delayMs >= 0)
+    .map((delayMs) => Math.floor(delayMs));
+  return parsed.length > 0 ? parsed : [...OPENCLAW_GATEWAY_DISPATCH_RETRY_DELAYS_MS];
+}
+
+export function isOpenClawGatewayDispatchRetryableResult(
+  agent: Pick<typeof agents.$inferSelect, "adapterType">,
+  result: Pick<AdapterExecutionResult, "exitCode" | "timedOut" | "errorCode" | "errorMessage">,
+) {
+  if (agent.adapterType !== "openclaw_gateway") return false;
+  if ((result.exitCode ?? 0) === 0 && !result.timedOut && !result.errorMessage) return false;
+  return result.errorCode === OPENCLAW_GATEWAY_DISPATCH_RETRY_ERROR_CODE;
+}
+
+function sleepMs(delayMs: number) {
+  if (delayMs <= 0) return Promise.resolve();
+  return new Promise((resolve) => setTimeout(resolve, delayMs));
 }
 
 function isMaxTurnExhaustionRun(
@@ -11577,36 +11605,62 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         adapterFinalizeOutcome = status;
       };
 
+      const executeAdapter = () => adapter.execute({
+        runId: run.id,
+        agent,
+        runtime: runtimeForAdapter,
+        config: runtimeConfig,
+        context,
+        runtimeCommandSpec: adapter.getRuntimeCommandSpec?.(runtimeConfig) ?? null,
+        executionTarget,
+        executionTransport: remoteExecution
+          ? { remoteExecution: remoteExecution as unknown as Record<string, unknown> }
+          : undefined,
+        onLog,
+        onMeta: onAdapterMeta,
+        onRuntimeProgress: async (progress) => {
+          await recordCurrentHeartbeatRunRuntimeProgress(run, progress, issueId);
+        },
+        onSpawn: async (meta) => {
+          await persistRunProcessMetadata(run.id, {
+            pid: meta.pid,
+            processGroupId:
+              "processGroupId" in meta && typeof meta.processGroupId === "number"
+                ? meta.processGroupId
+                : null,
+            startedAt: meta.startedAt,
+          });
+        },
+        authToken: authToken ?? undefined,
+      });
+
       let adapterResult: Awaited<ReturnType<typeof adapter.execute>>;
       try {
-        adapterResult = await adapter.execute({
-          runId: run.id,
-          agent,
-          runtime: runtimeForAdapter,
-          config: runtimeConfig,
-          context,
-          runtimeCommandSpec: adapter.getRuntimeCommandSpec?.(runtimeConfig) ?? null,
-          executionTarget,
-          executionTransport: remoteExecution
-            ? { remoteExecution: remoteExecution as unknown as Record<string, unknown> }
-            : undefined,
-          onLog,
-          onMeta: onAdapterMeta,
-          onRuntimeProgress: async (progress) => {
-            await recordCurrentHeartbeatRunRuntimeProgress(run, progress, issueId);
-          },
-          onSpawn: async (meta) => {
-            await persistRunProcessMetadata(run.id, {
-              pid: meta.pid,
-              processGroupId:
-                "processGroupId" in meta && typeof meta.processGroupId === "number"
-                  ? meta.processGroupId
-                  : null,
-              startedAt: meta.startedAt,
+        const dispatchRetryDelaysMs = parseOpenClawGatewayDispatchRetryDelaysMs(
+          process.env.PAPERCLIP_OPENCLAW_GATEWAY_DISPATCH_RETRY_DELAYS_MS,
+        );
+        adapterResult = await executeAdapter();
+        if (isOpenClawGatewayDispatchRetryableResult(agent, adapterResult)) {
+          for (let retryIndex = 0; retryIndex < dispatchRetryDelaysMs.length; retryIndex += 1) {
+            const delayMs = dispatchRetryDelaysMs[retryIndex] ?? 0;
+            await appendRunEvent(currentRun, seq++, {
+              eventType: "adapter.retry",
+              stream: "system",
+              level: "warn",
+              message: `OpenClaw gateway request failed; retrying dispatch ${retryIndex + 1}/${dispatchRetryDelaysMs.length} after ${delayMs}ms`,
+              payload: {
+                adapterType: agent.adapterType,
+                errorCode: adapterResult.errorCode ?? null,
+                delayMs,
+                retryAttempt: retryIndex + 1,
+                maxRetryAttempts: dispatchRetryDelaysMs.length,
+              },
             });
-          },
-          authToken: authToken ?? undefined,
-        });
+            await sleepMs(delayMs);
+            adapterResult = await executeAdapter();
+            if (!isOpenClawGatewayDispatchRetryableResult(agent, adapterResult)) break;
+          }
+        }
         // Adapter returned cleanly, which means its workspace-restore finally
         // block also ran without throwing. Record the workspace_finalize
         // barrier so dependents that share this executionWorkspace can wake.


### PR DESCRIPTION
## What happened?

In local development, Paperclip's dev runner watched all of `server/` as restart-relevant source. Runtime-output writes under `server/artifacts`, `server/docs`, `server/logs`, and `server/team-state` could therefore trigger an automatic server restart. That restart sends SIGTERM to the child server while OpenClaw gateway-backed issue runs may still be dispatching, which can turn a recoverable gateway request failure into blocked/liveness churn.

## Expected behavior

Runtime-output writes should not be treated as backend source changes. Legitimate source changes may still restart the dev server, but restart timing should be debounced and the SIGTERM origin should be visible. Narrow OpenClaw gateway dispatch failures should get bounded retry attempts before Paperclip records the run as failed.

## Steps to reproduce

1. Run Paperclip locally through the dev runner.
2. Let the server write runtime output under `server/artifacts`, `server/docs`, `server/logs`, or `server/team-state` while an OpenClaw gateway-backed issue run is active or being dispatched.
3. Observe the dev runner classifying the write as backend change and killing the server child with SIGTERM, which can cascade into `openclaw_gateway_request_failed` and recovery/liveness follow-up work.

## Paperclip version or commit

Observed on pre-fix `master`; this PR is based on `ad961227f57a217655c9e05e5987e6d0e5524409`.

## Deployment mode

Local dev (`pnpm dev`).

## Thinking Path
> This PR tracks the Paperclip restart cascade work from the current ops sprint. The sharp failure mode was dev auto-restart killing OpenClaw gateway dispatch mid-wake and turning recoverable `openclaw_gateway_request_failed` errors into liveness churn. The smallest safe fix is to stop runtime-output writes from triggering dev restarts, debounce legitimate auto-restarts, and retry only the OpenClaw gateway dispatch failure code.

## What Changed
- Excluded runtime/output directories under `server/` from dev-runner restart tracking: `server/artifacts`, `server/docs`, `server/logs`, `server/team-state`.
- Added `PAPERCLIP_DEV_AUTO_RESTART_DEBOUNCE_MS` debounce around dev auto-restart, defaulting to 30000ms, with an explicit SIGTERM origin log and dirty path sample.
- Added bounded OpenClaw gateway dispatch retry for `openclaw_gateway_request_failed`: 5s, 15s, 45s by default, configurable via `PAPERCLIP_OPENCLAW_GATEWAY_DISPATCH_RETRY_DELAYS_MS`.
- Added focused tests for dev-runner path filtering and OpenClaw gateway dispatch retry behavior.
- Follow-up: preserved `PAPERCLIP_DEV_AUTO_RESTART_DEBOUNCE_MS=0` as a valid no-debounce override after automated review caught the fallback bug.

## Verification
- [x] Searched existing PRs for similar restart-cascade / OpenClaw gateway retry fixes; no public duplicate PR covers this exact runtime-output restart cascade.
- [x] `pnpm exec vitest run server/src/__tests__/dev-runner-paths.test.ts server/src/__tests__/heartbeat-openclaw-gateway-dispatch-retry.test.ts` → 2 files / 6 tests passed.
- [x] `pnpm --filter @paperclipai/server typecheck` → passed.
- [x] PR branch was rebased onto `origin/master`; diff is limited to 5 files for this restart-cascade fix.

## Risks
- Legitimate backend source or migration changes still restart the dev server; this only filters runtime outputs and debounces restart timing.
- Dispatch retry is intentionally narrow to `openclaw_gateway_request_failed` for `openclaw_gateway` agents. Other adapter errors still fail normally.
- The PR reduces restart-cascade risk; final proof still requires merge/deploy and observing a wake through the running adapter.

## Model Used
- codex-proxy/gpt-5.5
