### PR TITLE
fix: retry OpenClaw gateway dispatch failures

### DIFF
--- a/server/src/__tests__/heartbeat-openclaw-gateway-dispatch-retry.test.ts
+++ b/server/src/__tests__/heartbeat-openclaw-gateway-dispatch-retry.test.ts
@@ -89,6 +89,36 @@ describe("heartbeat OpenClaw gateway dispatch retry", () => {
     ]);
   });
 
+  it("continues retrying when retry telemetry callback fails", async () => {
+    const execute = vi
+      .fn()
+      .mockResolvedValueOnce({
+        exitCode: 1,
+        timedOut: false,
+        errorCode: "openclaw_gateway_request_failed",
+        errorMessage: "gateway request failed",
+      })
+      .mockResolvedValueOnce({
+        exitCode: 0,
+        timedOut: false,
+        errorCode: null,
+        errorMessage: null,
+        summary: "Recovered even though retry telemetry failed.",
+      });
+
+    const result = await executeOpenClawGatewayDispatchWithRetry({
+      agent: { adapterType: "openclaw_gateway" },
+      execute,
+      retryDelaysMs: [0],
+      onRetry: () => {
+        throw new Error("telemetry write failed");
+      },
+    });
+
+    expect(execute).toHaveBeenCalledTimes(2);
+    expect(result.exitCode).toBe(0);
+  });
+
   it("stops after all OpenClaw gateway dispatch retries are exhausted", async () => {
     const execute = vi.fn().mockResolvedValue({
       exitCode: 1,

--- a/server/src/__tests__/heartbeat-openclaw-gateway-dispatch-retry.test.ts
+++ b/server/src/__tests__/heartbeat-openclaw-gateway-dispatch-retry.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  executeOpenClawGatewayDispatchWithRetry,
+  isOpenClawGatewayDispatchRetryableResult,
+  parseOpenClawGatewayDispatchRetryDelaysMs,
+} from "../services/heartbeat.ts";
+
+describe("heartbeat OpenClaw gateway dispatch retry", () => {
+  it("parses default and overridden retry delays", () => {
+    expect(parseOpenClawGatewayDispatchRetryDelaysMs(undefined)).toEqual([5_000, 15_000, 45_000]);
+    expect(parseOpenClawGatewayDispatchRetryDelaysMs("0,1,2")).toEqual([0, 1, 2]);
+    expect(parseOpenClawGatewayDispatchRetryDelaysMs("bad")).toEqual([5_000, 15_000, 45_000]);
+  });
+
+  it("only retries OpenClaw gateway request failures", () => {
+    expect(
+      isOpenClawGatewayDispatchRetryableResult(
+        { adapterType: "openclaw_gateway" },
+        {
+          exitCode: 1,
+          timedOut: false,
+          errorCode: "openclaw_gateway_request_failed",
+          errorMessage: "gateway request failed",
+        },
+      ),
+    ).toBe(true);
+    expect(
+      isOpenClawGatewayDispatchRetryableResult(
+        { adapterType: "openclaw_gateway" },
+        {
+          exitCode: 1,
+          timedOut: false,
+          errorCode: "openclaw_gateway_wait_error",
+          errorMessage: "run failed",
+        },
+      ),
+    ).toBe(false);
+    expect(
+      isOpenClawGatewayDispatchRetryableResult(
+        { adapterType: "codex_local" },
+        {
+          exitCode: 1,
+          timedOut: false,
+          errorCode: "openclaw_gateway_request_failed",
+          errorMessage: "gateway request failed",
+        },
+      ),
+    ).toBe(false);
+  });
+
+  it("retries transient OpenClaw gateway dispatch failure and returns the recovered result", async () => {
+    const execute = vi
+      .fn()
+      .mockResolvedValueOnce({
+        exitCode: 1,
+        timedOut: false,
+        errorCode: "openclaw_gateway_request_failed",
+        errorMessage: "gateway request failed",
+      })
+      .mockResolvedValueOnce({
+        exitCode: 1,
+        timedOut: false,
+        errorCode: "openclaw_gateway_request_failed",
+        errorMessage: "gateway request failed",
+      })
+      .mockResolvedValueOnce({
+        exitCode: 0,
+        timedOut: false,
+        errorCode: null,
+        errorMessage: null,
+        summary: "Recovered after gateway retry.",
+      });
+    const retryEvents: Array<{ retryAttempt: number; delayMs: number }> = [];
+
+    const result = await executeOpenClawGatewayDispatchWithRetry({
+      agent: { adapterType: "openclaw_gateway" },
+      execute,
+      retryDelaysMs: [0, 0, 0],
+      onRetry: (event) => {
+        retryEvents.push({ retryAttempt: event.retryAttempt, delayMs: event.delayMs });
+      },
+    });
+
+    expect(execute).toHaveBeenCalledTimes(3);
+    expect(result.exitCode).toBe(0);
+    expect(retryEvents).toEqual([
+      { retryAttempt: 1, delayMs: 0 },
+      { retryAttempt: 2, delayMs: 0 },
+    ]);
+  });
+
+  it("stops after all OpenClaw gateway dispatch retries are exhausted", async () => {
+    const execute = vi.fn().mockResolvedValue({
+      exitCode: 1,
+      timedOut: false,
+      errorCode: "openclaw_gateway_request_failed",
+      errorMessage: "gateway request failed",
+    });
+    const retryEvents: number[] = [];
+
+    const result = await executeOpenClawGatewayDispatchWithRetry({
+      agent: { adapterType: "openclaw_gateway" },
+      execute,
+      retryDelaysMs: [0, 0, 0],
+      onRetry: (event) => retryEvents.push(event.retryAttempt),
+    });
+
+    expect(execute).toHaveBeenCalledTimes(4);
+    expect(result.errorCode).toBe("openclaw_gateway_request_failed");
+    expect(retryEvents).toEqual([1, 2, 3]);
+  });
+});

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -288,6 +288,8 @@ const BOUNDED_TRANSIENT_HEARTBEAT_RETRY_JITTER_RATIO = 0.25;
 const BOUNDED_TRANSIENT_HEARTBEAT_RETRY_REASON = "transient_failure";
 const BOUNDED_TRANSIENT_HEARTBEAT_RETRY_WAKE_REASON = "transient_failure_retry";
 const BOUNDED_TRANSIENT_HEARTBEAT_RETRY_MAX_ATTEMPTS = BOUNDED_TRANSIENT_HEARTBEAT_RETRY_DELAYS_MS.length;
+export const OPENCLAW_GATEWAY_DISPATCH_RETRY_DELAYS_MS = [5_000, 15_000, 45_000] as const;
+const OPENCLAW_GATEWAY_DISPATCH_RETRY_ERROR_CODE = "openclaw_gateway_request_failed";
 const WORKSPACE_VALIDATION_FAILURE_CODE = "workspace_validation_failed";
 const WORKSPACE_VALIDATION_RECOVERY_CAUSE = "workspace_validation_failed";
 const CONFIGURATION_INCOMPLETE_FAILURE_CODE = "configuration_incomplete";
@@ -372,6 +374,62 @@ function readHeartbeatRunErrorFamily(
     return "transient_upstream";
   }
   return null;
+}
+
+export function parseOpenClawGatewayDispatchRetryDelaysMs(value: unknown): number[] {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    return [...OPENCLAW_GATEWAY_DISPATCH_RETRY_DELAYS_MS];
+  }
+  const parsed = value
+    .split(",")
+    .map((part) => Number(part.trim()))
+    .filter((delayMs) => Number.isFinite(delayMs) && delayMs >= 0)
+    .map((delayMs) => Math.floor(delayMs));
+  return parsed.length > 0 ? parsed : [...OPENCLAW_GATEWAY_DISPATCH_RETRY_DELAYS_MS];
+}
+
+export function isOpenClawGatewayDispatchRetryableResult(
+  agent: Pick<typeof agents.$inferSelect, "adapterType">,
+  result: Pick<AdapterExecutionResult, "exitCode" | "timedOut" | "errorCode" | "errorMessage">,
+) {
+  if (agent.adapterType !== "openclaw_gateway") return false;
+  if ((result.exitCode ?? 0) === 0 && !result.timedOut && !result.errorMessage) return false;
+  return result.errorCode === OPENCLAW_GATEWAY_DISPATCH_RETRY_ERROR_CODE;
+}
+
+function sleepMs(delayMs: number) {
+  if (delayMs <= 0) return Promise.resolve();
+  return new Promise((resolve) => setTimeout(resolve, delayMs));
+}
+
+export async function executeOpenClawGatewayDispatchWithRetry<T extends Pick<AdapterExecutionResult, "exitCode" | "timedOut" | "errorCode" | "errorMessage">>(args: {
+  agent: Pick<typeof agents.$inferSelect, "adapterType">;
+  execute: () => Promise<T>;
+  retryDelaysMs?: number[];
+  onRetry?: (event: {
+    delayMs: number;
+    retryAttempt: number;
+    maxRetryAttempts: number;
+    result: T;
+  }) => Promise<void> | void;
+}) {
+  const retryDelaysMs = args.retryDelaysMs ?? [...OPENCLAW_GATEWAY_DISPATCH_RETRY_DELAYS_MS];
+  let result = await args.execute();
+  if (!isOpenClawGatewayDispatchRetryableResult(args.agent, result)) return result;
+
+  for (let retryIndex = 0; retryIndex < retryDelaysMs.length; retryIndex += 1) {
+    const delayMs = retryDelaysMs[retryIndex] ?? 0;
+    await args.onRetry?.({
+      delayMs,
+      retryAttempt: retryIndex + 1,
+      maxRetryAttempts: retryDelaysMs.length,
+      result,
+    });
+    await sleepMs(delayMs);
+    result = await args.execute();
+    if (!isOpenClawGatewayDispatchRetryableResult(args.agent, result)) break;
+  }
+  return result;
 }
 
 function isMaxTurnExhaustionRun(
@@ -11578,34 +11636,56 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       };
 
       let adapterResult: Awaited<ReturnType<typeof adapter.execute>>;
+      const executeAdapter = () => adapter.execute({
+        runId: run.id,
+        agent,
+        runtime: runtimeForAdapter,
+        config: runtimeConfig,
+        context,
+        runtimeCommandSpec: adapter.getRuntimeCommandSpec?.(runtimeConfig) ?? null,
+        executionTarget,
+        executionTransport: remoteExecution
+          ? { remoteExecution: remoteExecution as unknown as Record<string, unknown> }
+          : undefined,
+        onLog,
+        onMeta: onAdapterMeta,
+        onRuntimeProgress: async (progress) => {
+          await recordCurrentHeartbeatRunRuntimeProgress(run, progress, issueId);
+        },
+        onSpawn: async (meta) => {
+          await persistRunProcessMetadata(run.id, {
+            pid: meta.pid,
+            processGroupId:
+              "processGroupId" in meta && typeof meta.processGroupId === "number"
+                ? meta.processGroupId
+                : null,
+            startedAt: meta.startedAt,
+          });
+        },
+        authToken: authToken ?? undefined,
+      });
       try {
-        adapterResult = await adapter.execute({
-          runId: run.id,
+        adapterResult = await executeOpenClawGatewayDispatchWithRetry({
           agent,
-          runtime: runtimeForAdapter,
-          config: runtimeConfig,
-          context,
-          runtimeCommandSpec: adapter.getRuntimeCommandSpec?.(runtimeConfig) ?? null,
-          executionTarget,
-          executionTransport: remoteExecution
-            ? { remoteExecution: remoteExecution as unknown as Record<string, unknown> }
-            : undefined,
-          onLog,
-          onMeta: onAdapterMeta,
-          onRuntimeProgress: async (progress) => {
-            await recordCurrentHeartbeatRunRuntimeProgress(run, progress, issueId);
-          },
-          onSpawn: async (meta) => {
-            await persistRunProcessMetadata(run.id, {
-              pid: meta.pid,
-              processGroupId:
-                "processGroupId" in meta && typeof meta.processGroupId === "number"
-                  ? meta.processGroupId
-                  : null,
-              startedAt: meta.startedAt,
+          execute: executeAdapter,
+          retryDelaysMs: parseOpenClawGatewayDispatchRetryDelaysMs(
+            process.env.PAPERCLIP_OPENCLAW_GATEWAY_DISPATCH_RETRY_DELAYS_MS,
+          ),
+          onRetry: async ({ delayMs, retryAttempt, maxRetryAttempts, result }) => {
+            await appendRunEvent(currentRun, seq++, {
+              eventType: "adapter.retry",
+              stream: "system",
+              level: "warn",
+              message: `OpenClaw gateway request failed; retrying dispatch ${retryAttempt}/${maxRetryAttempts} after ${delayMs}ms`,
+              payload: {
+                adapterType: agent.adapterType,
+                errorCode: result.errorCode ?? null,
+                delayMs,
+                retryAttempt,
+                maxRetryAttempts,
+              },
             });
           },
-          authToken: authToken ?? undefined,
         });
         // Adapter returned cleanly, which means its workspace-restore finally
         // block also ran without throwing. Record the workspace_finalize

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -419,12 +419,16 @@ export async function executeOpenClawGatewayDispatchWithRetry<T extends Pick<Ada
 
   for (let retryIndex = 0; retryIndex < retryDelaysMs.length; retryIndex += 1) {
     const delayMs = retryDelaysMs[retryIndex] ?? 0;
-    await args.onRetry?.({
-      delayMs,
-      retryAttempt: retryIndex + 1,
-      maxRetryAttempts: retryDelaysMs.length,
-      result,
-    });
+    try {
+      await args.onRetry?.({
+        delayMs,
+        retryAttempt: retryIndex + 1,
+        maxRetryAttempts: retryDelaysMs.length,
+        result,
+      });
+    } catch {
+      // Non-fatal: continue the dispatch retry even if recording retry telemetry fails.
+    }
     await sleepMs(delayMs);
     result = await args.execute();
     if (!isOpenClawGatewayDispatchRetryableResult(args.agent, result)) break;


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the app people use to manage AI agents and their work through issues, runs, and adapters.
> - The OpenClaw gateway adapter is the dispatch path that wakes an agent session from a Paperclip heartbeat run.
> - During a gateway restart, the first dispatch request can fail with `openclaw_gateway_request_failed` even when the agent and issue are otherwise recoverable.
> - Today that first request failure can become a run failure and then a false blocked issue, which creates restart-cascade churn instead of letting the dispatch retry briefly.
> - This pull request adds a bounded retry around only that gateway request-failure dispatch path.
> - Retry telemetry must be best-effort; a logging failure should not abort a retry that may otherwise recover.
> - The benefit is that transient OpenClaw gateway restarts get a short recovery window while real wait/result failures still surface normally.

## Linked Issues or Issue Description

Bug report:
- Summary: OpenClaw gateway restart can make heartbeat dispatch return `openclaw_gateway_request_failed`, and Paperclip can treat that transient dispatch failure as a real failed run/blocked issue.
- Expected behavior: transient OpenClaw gateway request failures during dispatch should retry with bounded backoff before issue state changes.
- Actual behavior: a single request failure can cascade into false blocked work.
- Affected area: server heartbeat dispatch path for `openclaw_gateway` adapter runs.

## What Changed

- Added OpenClaw gateway dispatch retry parsing with the default `5s,15s,45s` bounded backoff and optional `PAPERCLIP_OPENCLAW_GATEWAY_DISPATCH_RETRY_DELAYS_MS` override.
- Wrapped heartbeat adapter dispatch with retry logic only for `openclaw_gateway_request_failed` on `openclaw_gateway` agents.
- Added `adapter.retry` run events so retry attempts are visible on the run timeline.
- Made retry telemetry non-fatal so a transient `appendRunEvent` failure does not abort the remaining dispatch retries.
- Added regression coverage for default/override parsing, retry eligibility, recovered retry, exhausted retry behavior, and non-fatal retry telemetry failure.

## Verification

- `git diff --check`
- `pnpm exec vitest run server/src/__tests__/heartbeat-openclaw-gateway-dispatch-retry.test.ts` → 1 file / 5 tests passed
- GitHub PR checks were green before the latest telemetry-hardening commit; rerun is pending on PR #9045.

## Risks

- Retry only covers `openclaw_gateway_request_failed` during OpenClaw gateway dispatch; wait, timeout, result, and agent-level errors are intentionally not retried.
- A real persistent gateway request failure now waits through the bounded retry window before surfacing.
- Retry event logging is best-effort; if telemetry writing fails, the retry still proceeds and the missing retry event must be inferred from surrounding run state.
- No migration or schema changes.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

OpenAI Codex via OpenClaw, current run model `codex-proxy/gpt-5.5`.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
