### PR TITLE
fix: queue a real follow-up instead of coalescing issue_assigned wakes

### DIFF
--- a/server/src/__tests__/heartbeat-issue-assigned-followup.test.ts
+++ b/server/src/__tests__/heartbeat-issue-assigned-followup.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import { shouldQueueFollowupForRunningIssueWake } from "../services/heartbeat.ts";
+
+// ---------------------------------------------------------------------------
+// shouldQueueFollowupForRunningIssueWake — decides whether a wake that
+// arrives while the same agent already has an active run for the same issue
+// must be queued as a real follow-up (`deferred_issue_execution`, promoted
+// once the active run finishes) rather than merged into that active run's
+// contextSnapshot.
+//
+// Regression coverage for the `issue_assigned` gap: a plugin (e.g. a
+// workflow/graph engine) advancing an issue to its next node fires an
+// `issue_assigned` wake for the SAME issue whose own just-finished run is
+// often still the "active" run at that exact moment (it produced its final
+// disposition but hasn't finished persisting yet). Before this fix,
+// `issue_assigned` was absent from RUNNING_ISSUE_WAKE_REASONS_REQUIRING_
+// FOLLOWUP, so that wake got silently merged into the already-finishing run
+// and never actually executed — the issue's next step never got a real
+// heartbeat run. Confirmed live via `agent_wakeup_requests` rows with
+// `status: "coalesced"`, `reason: "issue_execution_same_name"` on a WFE
+// plugin's `wfe.advance`-sourced `issue_assigned` wake.
+// ---------------------------------------------------------------------------
+describe("shouldQueueFollowupForRunningIssueWake", () => {
+  it("requires a follow-up queue for issue_assigned wakes (the bug fix)", () => {
+    expect(
+      shouldQueueFollowupForRunningIssueWake({
+        contextSnapshot: { wakeReason: "issue_assigned" },
+        wakeCommentId: null,
+      }),
+    ).toBe(true);
+  });
+
+  it("still requires a follow-up queue for the pre-existing reasons", () => {
+    expect(
+      shouldQueueFollowupForRunningIssueWake({
+        contextSnapshot: { wakeReason: "approval_approved" },
+        wakeCommentId: null,
+      }),
+    ).toBe(true);
+    expect(
+      shouldQueueFollowupForRunningIssueWake({
+        contextSnapshot: { wakeReason: "issue_blockers_resolved" },
+        wakeCommentId: null,
+      }),
+    ).toBe(true);
+  });
+
+  it("always requires a follow-up queue when a wake comment id is present, regardless of reason", () => {
+    expect(
+      shouldQueueFollowupForRunningIssueWake({
+        contextSnapshot: { wakeReason: "heartbeat_timer" },
+        wakeCommentId: "comment-1",
+      }),
+    ).toBe(true);
+  });
+
+  it("does not require a follow-up queue for unrelated wake reasons", () => {
+    expect(
+      shouldQueueFollowupForRunningIssueWake({
+        contextSnapshot: { wakeReason: "heartbeat_timer" },
+        wakeCommentId: null,
+      }),
+    ).toBe(false);
+    expect(
+      shouldQueueFollowupForRunningIssueWake({
+        contextSnapshot: { wakeReason: "execution_review_requested" },
+        wakeCommentId: null,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not require a follow-up queue when there is no wake reason at all", () => {
+    expect(
+      shouldQueueFollowupForRunningIssueWake({
+        contextSnapshot: {},
+        wakeCommentId: null,
+      }),
+    ).toBe(false);
+    expect(
+      shouldQueueFollowupForRunningIssueWake({
+        contextSnapshot: null,
+        wakeCommentId: null,
+      }),
+    ).toBe(false);
+  });
+});

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -685,6 +685,20 @@ const RUNNING_ISSUE_WAKE_REASONS_REQUIRING_FOLLOWUP = new Set([
   "approval_approved",
   ISSUE_BLOCKERS_RESOLVED_WAKE_REASON,
   "issue_recovery_action_restored",
+  // An `issue_assigned` wake means the issue's assignee/next-step just changed
+  // (e.g. a workflow-engine-style plugin advancing an issue to its next node)
+  // and needs a run of its own — it must not be silently merged into an
+  // already-active run for the same issue. That active run is very often the
+  // very run whose own disposition/advance action just triggered this wake in
+  // the first place: by the time the wake fires, the run has already produced
+  // its final output for the previous node and is only finishing persistence,
+  // so merging into it (the default same-issue/same-agent coalescing path)
+  // means the new assignment's context is written into a run that will never
+  // read it again. Queueing a real follow-up (`deferred_issue_execution`,
+  // promoted once the active run finishes — see the promotion loop this run's
+  // finalization uses for exactly this queue) guarantees the new step
+  // actually gets executed instead of silently absorbed.
+  "issue_assigned",
 ]);
 const ISSUE_RESPONSIBLE_USER_WAKE_REASONS = new Set([
   "issue_assigned",
@@ -5221,7 +5235,7 @@ export function shouldAutoCheckoutIssueForWake(input: {
   return true;
 }
 
-function shouldQueueFollowupForRunningIssueWake(input: {
+export function shouldQueueFollowupForRunningIssueWake(input: {
   contextSnapshot: Record<string, unknown> | null | undefined;
   wakeCommentId: string | null;
 }) {


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - When one agent hands an issue off to its own next step (e.g. a workflow/graph-engine plugin advancing an issue to a new node, still assigned to the same agent), core fires a `requestWakeup` with reason `issue_assigned` so the agent picks up the new step
> - If that same agent already has an active run for that exact issue at the moment the wake fires, core's default behavior is to merge ("coalesce") the new wake's context into that active run instead of starting a fresh one, on the assumption the active run will notice the merged context before it exits
> - In practice, the "active" run at that moment is very often the very run whose own disposition/advance action just triggered this wake — it already produced its final output for the previous step and is only finishing persistence (releasing leases, updating issue state), so it never re-checks the merged context
> - Confirmed this live: a plugin's `issue_assigned` wake landed in `agent_wakeup_requests` with `status: "coalesced"`, and the issue's next step never got a real heartbeat run — it sat stuck until a manual out-of-band nudge
> - Core already has the right mechanism for exactly this class of wake — `RUNNING_ISSUE_WAKE_REASONS_REQUIRING_FOLLOWUP` routes specific wake reasons through a "queue a real follow-up, promoted once the active run finishes" path instead of merging — it just didn't include `issue_assigned`
> - This pull request adds `issue_assigned` to that set, so the same already-tested follow-up-queue mechanism used for `approval_approved` and `issue_blockers_resolved` now also covers this reason
> - The benefit is generic: any plugin or caller that fires an `issue_assigned` wake while the same agent has an active run for the same issue (a same-agent, self-referential handoff) now reliably gets a real run for the new step instead of a silently-dropped merge

## Linked Issues or Issue Description

No existing public issue covers this — describing it directly, following the bug report fields:

**What happened?**

A `requestWakeup` call with reason `"issue_assigned"` fired correctly for an issue being handed to its next step (still assigned to the same agent), but because the same agent already had an active run for that exact issue at that moment, core merged ("coalesced") the new wake's context into that active run instead of creating a new one. That active run was the very run whose own advance action had just triggered the new wake — it had already produced its final output for the previous step and was only finishing persistence. It never re-checked the merged context, so the issue's new step never got a real heartbeat run. The issue sat in `todo` (assigned, no live execution path) until a manual, out-of-band wake was sent.

**Expected behavior**

An `issue_assigned` wake that arrives while the same agent has an active run for the same issue should be queued as a genuine follow-up (to run once the active run finishes), not silently merged into a run that has already finished producing output and will never check for it.

**Steps to reproduce**

1. Have an issue whose current step just completed via an agent run that ends with an advance/handoff action — the issue stays assigned to the same agent but moves to a new step.
2. Have the handoff logic fire `heartbeat.wakeup(agentId, { reason: "issue_assigned", ... })` for that issue immediately as part of applying the advance (synchronously, before the triggering run has fully finished persisting).
3. Observe the new wake land in `agent_wakeup_requests` with `status: "coalesced"`, `reason: "issue_execution_same_name"`, merged into the triggering run's id.
4. Observe the issue's new step never receives a heartbeat run — it stays in `todo`/`in_progress` with an assignee but no live execution path, until something else (e.g. a periodic reconciler with an unrelated skip condition, or a manual nudge) eventually notices.

**Paperclip version or commit**

`ad961227f57a217655c9e05e5987e6d0e5524409` (current `master` at time of writing)

**Deployment mode**

Self-hosted server

## What Changed

- Added `"issue_assigned"` to `RUNNING_ISSUE_WAKE_REASONS_REQUIRING_FOLLOWUP` in `server/src/services/heartbeat.ts`, so `shouldQueueFollowupForRunningIssueWake` returns `true` for it — routing it through the existing `deferred_issue_execution` queue-and-promote path instead of the default same-issue/same-agent merge path.
- Exported `shouldQueueFollowupForRunningIssueWake` (previously module-private) so it can be unit tested directly, matching the existing pattern for sibling coalescing helpers (`filterZombieCoalesceTarget`, `isZombieRun`) that are already exported and tested this way.
- Added `server/src/__tests__/heartbeat-issue-assigned-followup.test.ts`: covers the new `issue_assigned` case, the two pre-existing reasons (`approval_approved`, `issue_blockers_resolved`), the `wakeCommentId`-present-always-true case, and the false cases (unrelated reasons, no reason at all).

## Verification

- `npx vitest run server/src/__tests__/heartbeat-issue-assigned-followup.test.ts` — 5/5 new tests pass.
- `npx vitest run` across the full set of heartbeat-prefixed and `issue_assigned`-referencing test files most likely to exercise this coalescing path (`heartbeat-lock-release-on-reassignment`, `heartbeat-comment-wake-batching`, `heartbeat-process-recovery`, `heartbeat-stale-queue-invalidation`, `heartbeat-timer-wake-session-reset-pf4`, `heartbeat-dependency-scheduling`, `heartbeat-list`, `heartbeat-workspace-session`, `agent-live-run-routes`, `issue-update-comment-wakeup-routes`, `issue-assigned-backlog-contract-routes`, `heartbeat-retry-scheduling`, plus the new test file and `heartbeat-zombie-guard`) — 276/276 passed, no regressions.
- `pnpm --filter @paperclipai/server exec tsc --noEmit` — no new errors introduced (confirmed by stashing the change and diffing the error set: identical pre-existing baseline, all in unrelated files — `@paperclipai/plugin-sdk` module-resolution gaps and pre-existing `unknown`-typed `catch` bindings in `routes/plugins.ts`).
- Manually reproduced and confirmed the root cause live on a real instance via `agent_wakeup_requests` (`status: "coalesced"`, `reason: "issue_execution_same_name"`, `payload.contextSource` from the calling plugin's advance action) before writing the fix. Not yet re-verified live against that same instance with this fix deployed (pending review/merge or a direct deploy).

## Risks

- Low-to-moderate risk. This changes the *routing* of one additional wake reason (`issue_assigned`) into an already-existing, already-tested mechanism (`deferred_issue_execution` queue + promotion) used today for two other wake reasons — it does not introduce new coalescing/promotion logic.
- Behavioral shift: `issue_assigned` wakes that arrive while the same agent has an active run for the same issue now always produce a distinct follow-up run once the active run finishes, instead of being merged into the active run's context. For the (likely rare) case where the active run genuinely would have picked up the merged context before finishing, this means one extra run instead of zero — a small cost in exchange for guaranteed delivery of the new step's work.
- No schema or migration changes. No behavior change for any other wake reason.

## Model Used

Claude (Anthropic), model `claude-sonnet-5`, used within a coding-agent harness (Claude Code) with tool use (file edit, test execution, git operations, live production-instance debugging via SSH/SQL) and extended reasoning. Root-caused by tracing a live stall through `agent_wakeup_requests` evidence back to the exact coalescing decision in `heartbeat.ts`, then identifying and reusing an existing, already-tested follow-up-queue mechanism rather than introducing new logic.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
