### PR TITLE
fix: detect pi turn-level errors (e.g. insufficient credits) as run failures

### DIFF
--- a/packages/adapters/pi-local/src/server/parse.test.ts
+++ b/packages/adapters/pi-local/src/server/parse.test.ts
@@ -237,6 +237,59 @@ describe("parsePiJsonl", () => {
     expect(parsed.errors).toEqual([]);
   });
 
+  it("surfaces a turn-level error (e.g. insufficient provider credits) even with empty content", () => {
+    const stdout = [
+      JSON.stringify({
+        type: "turn_end",
+        message: {
+          role: "assistant",
+          content: [],
+          stopReason: "error",
+          errorMessage: '402: {"message":"Insufficient credits. Add more using https://openrouter.ai/settings/credits","code":402}',
+          usage: { input: 0, output: 0, cacheRead: 0, cost: { total: 0 } },
+        },
+      }),
+    ].join("\n");
+
+    const parsed = parsePiJsonl(stdout);
+    expect(parsed.errors).toEqual([
+      '402: {"message":"Insufficient credits. Add more using https://openrouter.ai/settings/credits","code":402}',
+    ]);
+    expect(parsed.finalMessage).toBeNull();
+  });
+
+  it("ignores turn-level errors with no error message", () => {
+    const stdout = [
+      JSON.stringify({
+        type: "turn_end",
+        message: {
+          role: "assistant",
+          content: [],
+          stopReason: "error",
+        },
+      }),
+    ].join("\n");
+
+    const parsed = parsePiJsonl(stdout);
+    expect(parsed.errors).toEqual(["Pi reported a turn-level error with no message."]);
+  });
+
+  it("does not treat a normal completed turn as an error", () => {
+    const stdout = [
+      JSON.stringify({
+        type: "turn_end",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "All good" }],
+          stopReason: "completed",
+        },
+      }),
+    ].join("\n");
+
+    const parsed = parsePiJsonl(stdout);
+    expect(parsed.errors).toEqual([]);
+  });
+
   it("surfaces standalone error events", () => {
     const stdout = [
       JSON.stringify({

--- a/packages/adapters/pi-local/src/server/parse.test.ts
+++ b/packages/adapters/pi-local/src/server/parse.test.ts
@@ -258,7 +258,7 @@ describe("parsePiJsonl", () => {
     expect(parsed.finalMessage).toBeNull();
   });
 
-  it("ignores turn-level errors with no error message", () => {
+  it("still surfaces a turn-level error with a generic fallback when errorMessage is absent", () => {
     const stdout = [
       JSON.stringify({
         type: "turn_end",

--- a/packages/adapters/pi-local/src/server/parse.ts
+++ b/packages/adapters/pi-local/src/server/parse.ts
@@ -99,7 +99,18 @@ export function parsePiJsonl(stdout: string): ParsedPiOutput {
           result.finalMessage = text;
           result.messages.push(text);
         }
-        
+
+        // A turn can end with stopReason "error" (e.g. the provider returned
+        // insufficient-credits/rate-limit/etc.) and an empty content array —
+        // Pi's own process still exits 0 in this case. Without surfacing this
+        // as an error here, the run is reported as a content-less success
+        // (effectiveExitCode stays 0 below since `errors` stays empty), so
+        // Paperclip's recovery/handoff logic never sees a failure to act on.
+        if (asString(message.stopReason, "") === "error") {
+          const turnErrorMessage = asString(message.errorMessage, "").trim();
+          result.errors.push(turnErrorMessage || "Pi reported a turn-level error with no message.");
+        }
+
         // Extract usage and cost from assistant message
         const usage = asRecord(message.usage);
         if (usage) {


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work, and the `pi_local` adapter runs the `pi` CLI as an agent's execution engine, parsing its JSONL event stream (`parsePiJsonl`) to extract messages, tool calls, and usage
> - The `pi` process can end a turn with `stopReason: "error"` (the underlying model provider call itself failed — insufficient credits, rate limit, etc.) and an empty `content` array, while the OS process itself still exits with code 0
> - `execute.ts` already has the correct mechanism to turn a parsed error into a real run failure: if `parsed.errors` is non-empty, it forces `effectiveExitCode` to `1` regardless of the raw exit code
> - But `parsePiJsonl`'s `turn_end` handler only ever extracted text content and usage from a turn — it never inspected `stopReason`/`errorMessage`, so a turn-level provider error never reached `parsed.errors`
> - Confirmed this live: a heartbeat run's transcript showed a `turn_end` event with `stopReason: "error"`, `errorMessage` containing an OpenRouter 402 (insufficient credits), and all-zero token usage — yet the run landed in the database as `status: "succeeded"` with no `error`/`error_code` set at all
> - Net effect: every one of Paperclip's recovery, retry, and blocked-issue mechanisms saw a "successful" run and had nothing to react to, so a real, actionable provider failure was completely invisible anywhere in the system — the issue just sat assigned with no progress and no diagnostic trail
> - This pull request adds the missing check to `parsePiJsonl` — no changes needed anywhere else, since `execute.ts`'s errors-to-failure wiring already does the right thing once `errors` is populated

## Linked Issues or Issue Description

No existing public issue covers this — describing it directly, following the bug report fields:

**What happened?**

A heartbeat run using the `pi_local` adapter completed with the process exiting code 0, but the underlying model provider call inside that run had actually failed (an OpenRouter 402 "Insufficient credits" response). The `pi` CLI surfaced this correctly in its own JSONL output as a `turn_end` event with `message.stopReason: "error"` and `message.errorMessage` containing the provider's error text, with an empty `content` array and all-zero usage. `parsePiJsonl` (in `packages/adapters/pi-local/src/server/parse.ts`) ignored `stopReason`/`errorMessage` entirely when processing `turn_end` events — it only extracted text content and usage — so `parsed.errors` stayed empty. `execute.ts`'s outcome logic only overrides the exit code to a failure when `parsed.errors` is non-empty, so with an empty `errors` array the run was reported as a genuine, content-less **success**: `status: "succeeded"`, `error: null`, `error_code: null` in the database, despite zero real work having happened.

**Expected behavior**

A turn that ends with `stopReason: "error"` should be surfaced as a run failure (with the provider's error message preserved), the same way a failed `auto_retry_end` or a standalone `error` event already is — not silently reported as a successful, empty run.

**Steps to reproduce**

1. Configure a `pi_local` agent with a model provider that will return an error mid-session (e.g. an OpenRouter key with exhausted credits, or a rate-limited provider).
2. Trigger a heartbeat run for that agent.
3. Observe the `pi` process's JSONL stdout contains a `turn_end` event with `message.stopReason: "error"` and a populated `message.errorMessage`, and the process itself exits with code 0.
4. Observe the resulting `heartbeat_runs` row has `status: "succeeded"`, `error: null`, `error_code: null` — with no indication anywhere that the underlying model call actually failed.

**Paperclip version or commit**

`ad961227f57a217655c9e05e5987e6d0e5524409` (current `master` at time of writing)

**Deployment mode**

Self-hosted server

## What Changed

- `packages/adapters/pi-local/src/server/parse.ts`: in the `turn_end` handler, when `message.stopReason === "error"`, push `message.errorMessage` (or a fallback string if it's empty) into `result.errors` — mirroring the existing pattern already used for a failed `auto_retry_end` event.
- `packages/adapters/pi-local/src/server/parse.test.ts`: added three tests — a turn-level error with a real provider error message (the exact OpenRouter 402 shape observed live) is surfaced with `finalMessage` staying `null`; a turn-level error with no message falls back to a generic message; a normal `stopReason: "completed"` turn is unaffected.

## Verification

- `npx vitest run packages/adapters/pi-local/src/server/parse.test.ts` — 16/16 passed (13 pre-existing + 3 new).
- `npx vitest run` across the whole `@paperclipai/adapter-pi-local` package — 38/38 passed, no regressions.
- `pnpm exec tsc --noEmit` scoped to the `@paperclipai/adapter-pi-local` package — clean, no errors.
- Manually reproduced and confirmed the root cause live on a real instance: found the exact `stopReason: "error"` / OpenRouter-402 shape in a real run's stored transcript, traced it through `parse.ts` and `execute.ts` to confirm `errors` staying empty was exactly why the run was misreported as succeeded, before writing the fix. Not yet re-verified live with this fix deployed (pending review/merge, or a direct deploy).

## Risks

- Low risk, narrowly scoped. This only adds a new condition inside the existing `turn_end` branch of a single parsing function; it does not change any other event handling, and does not touch `execute.ts` at all (its existing errors-to-failure wiring is reused as-is).
- Behavioral shift: any turn that ends with `stopReason: "error"` will now cause the overall run to be reported as failed (previously silently reported as succeeded if it happened to be the only turn, or ignored if a later successful turn existed). This is the intended fix — a real provider-level failure should be visible — but it does mean any code that assumed `pi_local` runs are always "successful" whenever the process exits 0 needs to instead handle a legitimate failure here.
- No schema or migration changes.

## Model Used

Claude (Anthropic), model `claude-sonnet-5`, used within a coding-agent harness (Claude Code) with tool use (file edit, test execution, live production-instance debugging via SSH/SQL) and extended reasoning. Root-caused by tracing a live "successful but empty" run through its stored transcript, then through `parse.ts` and `execute.ts`, to the exact missing check.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
