### PR TITLE
feat(k8s): configurable paperclipServerNamespace and serverPodAppLabel

### DIFF
--- a/packages/plugins/sandbox-providers/kubernetes/src/manifest.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/src/manifest.ts
@@ -45,6 +45,14 @@ const manifest: PaperclipPluginManifestV1 = {
             type: "string",
             description: "Override the auto-derived company slug used in the tenant namespace name.",
           },
+          paperclipServerNamespace: {
+            type: "string",
+            description: "Namespace the paperclip-server pods run in (NetworkPolicy egress allow-list target). Default: paperclip.",
+          },
+          serverPodAppLabel: {
+            type: "string",
+            description: "Value of the `app` pod label on paperclip-server pods (NetworkPolicy egress allow-list target). Default: paperclip-server.",
+          },
           imageRegistry: {
             type: "string",
             description: "Override the default registry for agent runtime images (default: ghcr.io/paperclipai).",

--- a/packages/plugins/sandbox-providers/kubernetes/src/network-policy.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/src/network-policy.ts
@@ -1,6 +1,7 @@
 export interface BuildNetworkPolicyInput {
   namespace: string;
   paperclipServerNamespace: string;
+  serverPodAppLabel?: string;
   egressAllowCidrs: string[];
   /**
    * Adapter-configured FQDNs (e.g. `api.anthropic.com`). Standard
@@ -83,7 +84,7 @@ export function buildNetworkPolicyManifests(input: BuildNetworkPolicyInput): Rec
           to: [
             {
               namespaceSelector: { matchLabels: { "kubernetes.io/metadata.name": input.paperclipServerNamespace } },
-              podSelector: { matchLabels: { app: "paperclip-server" } },
+              podSelector: { matchLabels: { app: input.serverPodAppLabel ?? "paperclip-server" } },
             },
           ],
           ports: [{ protocol: "TCP", port: 3100 }],

--- a/packages/plugins/sandbox-providers/kubernetes/src/plugin.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/src/plugin.ts
@@ -42,11 +42,6 @@ import {
   paperclipLabels,
 } from "./utils.js";
 
-// The namespace paperclip-server itself runs in. Used when building
-// NetworkPolicy manifests so the tenant namespace allows inbound traffic
-// from the server pod.
-const PAPERCLIP_SERVER_NAMESPACE = "paperclip";
-
 // Name of the ServiceAccount created inside each tenant namespace by ensureTenant.
 const TENANT_SERVICE_ACCOUNT = "paperclip-tenant-sa";
 
@@ -244,7 +239,8 @@ const plugin = definePlugin({
     await ensureTenant(clients, {
       namespace,
       companyId: params.companyId,
-      paperclipServerNamespace: PAPERCLIP_SERVER_NAMESPACE,
+      paperclipServerNamespace: config.paperclipServerNamespace,
+      serverPodAppLabel: config.serverPodAppLabel,
       serviceAccountAnnotations: config.serviceAccountAnnotations,
       egressMode: config.egressMode,
       egressAllowFqdns: [...adapterDefaults.allowFqdns, ...config.egressAllowFqdns],

--- a/packages/plugins/sandbox-providers/kubernetes/src/tenant-orchestrator.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/src/tenant-orchestrator.ts
@@ -6,6 +6,7 @@ export interface EnsureTenantInput {
   namespace: string;
   companyId: string;
   paperclipServerNamespace: string;
+  serverPodAppLabel?: string;
   serviceAccountAnnotations: Record<string, string>;
   egressMode: "standard" | "cilium";
   egressAllowFqdns: string[];
@@ -210,6 +211,7 @@ async function ensureNetworkPolicies(clients: KubeClients, input: EnsureTenantIn
   const [denyAll, egressStd] = buildNetworkPolicyManifests({
     namespace: input.namespace,
     paperclipServerNamespace: input.paperclipServerNamespace,
+    serverPodAppLabel: input.serverPodAppLabel,
     egressAllowCidrs: input.egressAllowCidrs,
     egressAllowFqdns: input.egressAllowFqdns,
   });

--- a/packages/plugins/sandbox-providers/kubernetes/src/types.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/src/types.ts
@@ -12,6 +12,9 @@ export const kubernetesProviderConfigSchema = z
     namespacePrefix: z.string().regex(/^[a-z0-9-]{1,32}$/).default("paperclip-"),
     companySlug: z.string().regex(/^[a-z0-9-]{1,32}$/).optional(),
 
+    paperclipServerNamespace: z.string().regex(/^[a-z0-9-]{1,63}$/).default("paperclip"),
+    serverPodAppLabel: z.string().min(1).default("paperclip-server"),
+
     imageRegistry: z.string().url().optional(),
     imageAllowList: z.array(z.string()).default([]),
     imagePullSecrets: z.array(z.string()).default([]),

--- a/packages/plugins/sandbox-providers/kubernetes/test/unit/network-policy.test.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/test/unit/network-policy.test.ts
@@ -92,4 +92,24 @@ describe("buildNetworkPolicyManifests", () => {
     );
     expect(fallback).toBeUndefined();
   });
+
+  it("accepts custom serverPodAppLabel in the callback pod selector", () => {
+    const [, egress] = buildNetworkPolicyManifests({
+      ...baseInput,
+      serverPodAppLabel: "pc-server",
+    });
+    const callbackRule = egress.spec.egress.find((r: { to: { podSelector?: { matchLabels?: Record<string, string> } }[] }) =>
+      r.to.some((t) => t.podSelector?.matchLabels?.app === "pc-server"),
+    );
+    expect(callbackRule).toBeDefined();
+    expect(callbackRule.ports[0].port).toBe(3100);
+  });
+
+  it("falls back to paperclip-server label when serverPodAppLabel is absent", () => {
+    const [, egress] = buildNetworkPolicyManifests(baseInput);
+    const callbackRule = egress.spec.egress.find((r: { to: { podSelector?: { matchLabels?: Record<string, string> } }[] }) =>
+      r.to.some((t) => t.podSelector?.matchLabels?.app === "paperclip-server"),
+    );
+    expect(callbackRule).toBeDefined();
+  });
 });

--- a/packages/plugins/sandbox-providers/kubernetes/test/unit/types.test.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/test/unit/types.test.ts
@@ -36,4 +36,29 @@ describe("kubernetesProviderConfigSchema", () => {
       parseKubernetesProviderConfig({ inCluster: true, egressAllowCidrs: ["not-a-cidr"] }),
     ).toThrow(/CIDR/i);
   });
+
+  it("defaults paperclipServerNamespace and serverPodAppLabel", () => {
+    const parsed = parseKubernetesProviderConfig({ inCluster: true });
+    expect(parsed.paperclipServerNamespace).toBe("paperclip");
+    expect(parsed.serverPodAppLabel).toBe("paperclip-server");
+  });
+
+  it("accepts custom paperclipServerNamespace and serverPodAppLabel", () => {
+    const parsed = parseKubernetesProviderConfig({
+      inCluster: true,
+      paperclipServerNamespace: "stuff-devops",
+      serverPodAppLabel: "pc-server",
+    });
+    expect(parsed.paperclipServerNamespace).toBe("stuff-devops");
+    expect(parsed.serverPodAppLabel).toBe("pc-server");
+  });
+
+  it("rejects invalid paperclipServerNamespace", () => {
+    expect(() =>
+      parseKubernetesProviderConfig({
+        inCluster: true,
+        paperclipServerNamespace: "UPPERCASE_INVALID",
+      }),
+    ).toThrow();
+  });
 });

--- a/server/src/services/environments.ts
+++ b/server/src/services/environments.ts
@@ -46,6 +46,9 @@ export interface KubernetesEnvironmentConfigInput {
   egressAllowFqdns?: string[];
   egressAllowCidrs?: string[];
   namespacePrefix?: string;
+  companySlug?: string;
+  paperclipServerNamespace?: string;
+  serverPodAppLabel?: string;
   imageRegistry?: string;
   adapterType?: string;
   /**

--- a/server/src/services/execution-policy-bootstrap.test.ts
+++ b/server/src/services/execution-policy-bootstrap.test.ts
@@ -132,6 +132,51 @@ describe("parseExecutionPolicyBootstrapEnv", () => {
       ),
     ).toThrow(/PAPERCLIP_K8S_RPC_TIMEOUT_MS/);
   });
+
+  it("reads PAPERCLIP_K8S_COMPANY_SLUG into kubernetesConfig.companySlug", () => {
+    const parsed = parseExecutionPolicyBootstrapEnv(
+      env({
+        PAPERCLIP_EXECUTION_MODE: "kubernetes",
+        PAPERCLIP_K8S_COMPANY_SLUG: "my-company",
+      }),
+    );
+    expect(parsed?.kubernetesConfig.companySlug).toBe("my-company");
+  });
+
+  it("omits companySlug when PAPERCLIP_K8S_COMPANY_SLUG is absent", () => {
+    const parsed = parseExecutionPolicyBootstrapEnv(env({ PAPERCLIP_EXECUTION_MODE: "kubernetes" }));
+    expect(parsed?.kubernetesConfig.companySlug).toBeUndefined();
+  });
+
+  it("reads PAPERCLIP_K8S_SERVER_NAMESPACE into kubernetesConfig.paperclipServerNamespace", () => {
+    const parsed = parseExecutionPolicyBootstrapEnv(
+      env({
+        PAPERCLIP_EXECUTION_MODE: "kubernetes",
+        PAPERCLIP_K8S_SERVER_NAMESPACE: "stuff-devops",
+      }),
+    );
+    expect(parsed?.kubernetesConfig.paperclipServerNamespace).toBe("stuff-devops");
+  });
+
+  it("omits paperclipServerNamespace when PAPERCLIP_K8S_SERVER_NAMESPACE is absent", () => {
+    const parsed = parseExecutionPolicyBootstrapEnv(env({ PAPERCLIP_EXECUTION_MODE: "kubernetes" }));
+    expect(parsed?.kubernetesConfig.paperclipServerNamespace).toBeUndefined();
+  });
+
+  it("reads PAPERCLIP_K8S_SERVER_POD_APP_LABEL into kubernetesConfig.serverPodAppLabel", () => {
+    const parsed = parseExecutionPolicyBootstrapEnv(
+      env({
+        PAPERCLIP_EXECUTION_MODE: "kubernetes",
+        PAPERCLIP_K8S_SERVER_POD_APP_LABEL: "pc-server",
+      }),
+    );
+    expect(parsed?.kubernetesConfig.serverPodAppLabel).toBe("pc-server");
+  });
+
+  it("omits serverPodAppLabel when PAPERCLIP_K8S_SERVER_POD_APP_LABEL is absent", () => {
+    const parsed = parseExecutionPolicyBootstrapEnv(env({ PAPERCLIP_EXECUTION_MODE: "kubernetes" }));
+    expect(parsed?.kubernetesConfig.serverPodAppLabel).toBeUndefined();
+  });
 });
 
 describe("applyExecutionPolicyBootstrap", () => {

--- a/server/src/services/execution-policy-bootstrap.ts
+++ b/server/src/services/execution-policy-bootstrap.ts
@@ -110,6 +110,15 @@ export function parseExecutionPolicyBootstrapEnv(
   const namespacePrefix = env.PAPERCLIP_K8S_NAMESPACE_PREFIX?.trim();
   if (namespacePrefix) kubernetesConfig.namespacePrefix = namespacePrefix;
 
+  const companySlug = env.PAPERCLIP_K8S_COMPANY_SLUG?.trim();
+  if (companySlug) kubernetesConfig.companySlug = companySlug;
+
+  const serverNamespace = env.PAPERCLIP_K8S_SERVER_NAMESPACE?.trim();
+  if (serverNamespace) kubernetesConfig.paperclipServerNamespace = serverNamespace;
+
+  const serverPodAppLabel = env.PAPERCLIP_K8S_SERVER_POD_APP_LABEL?.trim();
+  if (serverPodAppLabel) kubernetesConfig.serverPodAppLabel = serverPodAppLabel;
+
   const imageRegistry = env.PAPERCLIP_K8S_IMAGE_REGISTRY?.trim();
   if (imageRegistry) kubernetesConfig.imageRegistry = imageRegistry;
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source platform for managing AI agents in production
> - The Kubernetes sandbox provider plugin (`@paperclipai/plugin-kubernetes`) is the recommended execution path for self-hosted deployments on EKS/GKE/AKS
> - The provider's egress NetworkPolicy must allow agent pods to reach paperclip-server at its callback port (3100). The server namespace (`paperclip`) and pod label (`app: paperclip-server`) were either hardcoded or only partially configurable — `paperclipServerNamespace` existed in the type system but was hardcoded to `"paperclip"` at runtime, and `serverPodAppLabel` was entirely hardcoded
> - Operators who deploy paperclip-server in a non-default namespace or with a custom `app` label (common in helm-managed deployments with release-scoped labels) cannot use the K8s provider without forking the plugin
> - This PR makes both values configurable: adds `paperclipServerNamespace` and `serverPodAppLabel` to the Zod config schema, the plugin manifest JSON schema, the KubernetesEnvironmentConfigInput interface, and the execution-policy-bootstrap env-var mapping
> - Also adds env-var mapping for the existing `companySlug` config field (PAPERCLIP_K8S_COMPANY_SLUG) which was already in the Zod schema but had no env-var bootstrap path

## Linked Issues or Issue Description

No existing issue. Feature description following the feature request template:

**Subsystem affected:** packages/plugins — plugin system

**Problem or motivation:**
The Kubernetes sandbox provider's egress NetworkPolicy references paperclip-server's namespace and pod label to build the allow-list rule for the callback port (3100). Currently `paperclipServerNamespace` is defined in the type system (e.g. `BuildNetworkPolicyInput.paperclipServerNamespace`) but is hardcoded at runtime to `"paperclip"` via a module-level constant in `plugin.ts`. The pod label selector `app: "paperclip-server"` is entirely hardcoded in `network-policy.ts`. Operators who deploy paperclip-server in a non-default namespace — common in helm-managed deployments with release-scoped namespaces — or with a custom `app` label cannot use the K8s provider's NetworkPolicy generation without forking the plugin. This forces self-hosted operators to either accept incorrect egress policy or maintain a fork, neither of which is sustainable.

**Proposed solution:**
Add `paperclipServerNamespace` (default `"paperclip"`) and `serverPodAppLabel` (default `"paperclip-server"`) as first-class config fields in the Kubernetes sandbox provider. Thread them through: Zod config schema → plugin manifest JSON schema → NetworkPolicy builder → tenant orchestrator. Add corresponding env-var mappings (`PAPERCLIP_K8S_SERVER_NAMESPACE`, `PAPERCLIP_K8S_SERVER_POD_APP_LABEL`) so gitops-driven deployments can set these without API calls. Also add env-var mapping for the existing `companySlug` config field (`PAPERCLIP_K8S_COMPANY_SLUG`).

**Alternatives considered:**
Using the existing `[key: string]: unknown` indexer on `KubernetesEnvironmentConfigInput` to pass these through without schema changes — but that would bypass Zod validation, lose default values, and not surface the fields in the UI plugin config form. Adding a post-deployment hook to patch NetworkPolicy manifests was considered but rejected because it would create a drift between the plugin's desired state and the in-cluster state.

**Roadmap alignment:**
Related to the K8s sandbox provider milestone. The upstream already added `paperclipServerNamespace` to the type system (BuildNetworkPolicyInput, EnsureTenantInput) but did not wire it through the config schema. This PR completes that wiring.

## What Changed

- **packages/plugins/sandbox-providers/kubernetes/src/types.ts** — Added `paperclipServerNamespace` (default: `"paperclip"`) and `serverPodAppLabel` (default: `"paperclip-server"`) to the Zod config schema
- **packages/plugins/sandbox-providers/kubernetes/src/manifest.ts** — Added both fields to the plugin manifest JSON schema for UI configuration
- **packages/plugins/sandbox-providers/kubernetes/src/network-policy.ts** — Added `serverPodAppLabel` to `BuildNetworkPolicyInput`; used with `?? "paperclip-server"` fallback in the pod selector matchLabels
- **packages/plugins/sandbox-providers/kubernetes/src/plugin.ts** — Removed hardcoded `PAPERCLIP_SERVER_NAMESPACE` constant; wired `config.paperclipServerNamespace` and `config.serverPodAppLabel` into the `ensureTenant` call
- **packages/plugins/sandbox-providers/kubernetes/src/tenant-orchestrator.ts** — Added `serverPodAppLabel` to `EnsureTenantInput` and threaded it through to `buildNetworkPolicyManifests`
- **server/src/services/environments.ts** — Added `companySlug`, `paperclipServerNamespace`, and `serverPodAppLabel` to `KubernetesEnvironmentConfigInput`
- **server/src/services/execution-policy-bootstrap.ts** — Added env-var parsing for `PAPERCLIP_K8S_COMPANY_SLUG`, `PAPERCLIP_K8S_SERVER_NAMESPACE`, `PAPERCLIP_K8S_SERVER_POD_APP_LABEL`
- **packages/plugins/sandbox-providers/kubernetes/test/unit/types.test.ts** — Tests for schema defaults, custom values, and invalid input for the new fields
- **packages/plugins/sandbox-providers/kubernetes/test/unit/network-policy.test.ts** — Tests for custom serverPodAppLabel in the pod selector, and fallback to paperclip-server
- **server/src/services/execution-policy-bootstrap.test.ts** — Tests for env-var parsing of the three new bootstrap keys

## Verification

1. `pnpm -r typecheck` passes
2. `pnpm test -- packages/plugins/sandbox-providers/kubernetes/test/unit/types.test.ts` — passes (tests for default values, custom values, invalid namespace)
3. `pnpm test -- packages/plugins/sandbox-providers/kubernetes/test/unit/network-policy.test.ts` — passes (tests for custom pod label, fallback)
4. `pnpm test -- server/src/services/execution-policy-bootstrap.test.ts` — passes (tests for env-var parsing, omitted fields)

## Risks

**Low risk.** Both new fields have defaults matching the previous hardcoded values, so existing deployments see no behavioral change. The env-var mappings are additive (absent env vars = no change). The Zod schema defaults ensure backward compatibility: empty config `{}` produces the same values as the previous hardcoded constants.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

Claude Opus 4 (claude-opus-4-20250514), 200k context, extended thinking mode, via Claude Code CLI.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge