### PR TITLE
feat: thread presentation/metadata through plugin createComment, add phase_boundary kind

### DIFF
--- a/packages/plugins/sdk/src/index.ts
+++ b/packages/plugins/sdk/src/index.ts
@@ -307,6 +307,8 @@ export type {
   Project,
   Issue,
   IssueComment,
+  IssueCommentPresentation,
+  IssueCommentMetadata,
   IssueDocumentSummary,
   Agent,
   Goal,

--- a/packages/plugins/sdk/src/protocol.ts
+++ b/packages/plugins/sdk/src/protocol.ts
@@ -25,6 +25,8 @@ import type {
   Project,
   Issue,
   IssueComment,
+  IssueCommentPresentation,
+  IssueCommentMetadata,
   IssueDocument,
   IssueDocumentSummary,
   IssueAssigneeAdapterOverrides,
@@ -1596,6 +1598,8 @@ export interface WorkerToHostMethods {
       authorAgentId?: string;
       /** Active human company member the comment is attributed to. Requires `issue.comments.create_human_attributed`. */
       actorUserId?: string;
+      presentation?: IssueCommentPresentation | null;
+      metadata?: IssueCommentMetadata | null;
     },
     result: IssueComment,
   ];

--- a/packages/plugins/sdk/src/testing.ts
+++ b/packages/plugins/sdk/src/testing.ts
@@ -1730,8 +1730,8 @@ export function createTestHarness(options: TestHarnessOptions): TestHarness {
           authorUserId: options?.actorUserId ?? null,
           onBehalfOfUserId: null,
           body,
-          presentation: null,
-          metadata: null,
+          presentation: options?.presentation ?? null,
+          metadata: options?.metadata ?? null,
           createdAt: now,
           updatedAt: now,
         };

--- a/packages/plugins/sdk/src/types.ts
+++ b/packages/plugins/sdk/src/types.ts
@@ -19,6 +19,8 @@ import type {
   Project,
   Issue,
   IssueComment,
+  IssueCommentPresentation,
+  IssueCommentMetadata,
   IssueDocument,
   IssueDocumentSummary,
   IssueRelationIssueSummary,
@@ -122,6 +124,8 @@ export type {
   Project,
   Issue,
   IssueComment,
+  IssueCommentPresentation,
+  IssueCommentMetadata,
   IssueDocument,
   IssueDocumentSummary,
   IssueRelationIssueSummary,
@@ -1528,7 +1532,12 @@ export interface PluginIssuesClient {
     issueId: string,
     body: string,
     companyId: string,
-    options?: { authorAgentId?: string; actorUserId?: string },
+    options?: {
+      authorAgentId?: string;
+      actorUserId?: string;
+      presentation?: IssueCommentPresentation | null;
+      metadata?: IssueCommentMetadata | null;
+    },
   ): Promise<IssueComment>;
   createInteraction(
     issueId: string,

--- a/packages/plugins/sdk/src/worker-rpc-host.ts
+++ b/packages/plugins/sdk/src/worker-rpc-host.ts
@@ -42,6 +42,8 @@ import { fileURLToPath } from "node:url";
 
 import type {
   AskUserQuestionsInteraction,
+  IssueCommentMetadata,
+  IssueCommentPresentation,
   PaperclipPluginManifestV1,
   RequestCheckboxConfirmationInteraction,
   RequestConfirmationInteraction,
@@ -898,7 +900,7 @@ export function startWorkerRpcHost(options: WorkerRpcHostOptions): WorkerRpcHost
           issueId: string,
           body: string,
           companyId: string,
-          options?: { authorAgentId?: string; actorUserId?: string },
+          options?: { authorAgentId?: string; actorUserId?: string; presentation?: IssueCommentPresentation | null; metadata?: IssueCommentMetadata | null },
         ) {
           return callHost("issues.createComment", {
             issueId,
@@ -906,6 +908,8 @@ export function startWorkerRpcHost(options: WorkerRpcHostOptions): WorkerRpcHost
             companyId,
             authorAgentId: options?.authorAgentId,
             actorUserId: options?.actorUserId,
+            presentation: options?.presentation,
+            metadata: options?.metadata,
           });
         },
 

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -236,7 +236,11 @@ export type SummarySlotStatus = (typeof SUMMARY_SLOT_STATUSES)[number];
 export const ISSUE_COMMENT_AUTHOR_TYPES = ["user", "agent", "system"] as const;
 export type IssueCommentAuthorType = (typeof ISSUE_COMMENT_AUTHOR_TYPES)[number];
 
-export const ISSUE_COMMENT_PRESENTATION_KINDS = ["message", "system_notice"] as const;
+// "phase_boundary" marks a comment (typically posted by a plugin on a workflow
+// transition) as the start of a new logical section in the issue's activity
+// feed — the UI groups and collapses everything between two boundaries so a
+// ticket spanning many phases doesn't render as one undifferentiated scroll.
+export const ISSUE_COMMENT_PRESENTATION_KINDS = ["message", "system_notice", "phase_boundary"] as const;
 export type IssueCommentPresentationKind = (typeof ISSUE_COMMENT_PRESENTATION_KINDS)[number];
 
 export const ISSUE_COMMENT_PRESENTATION_TONES = ["neutral", "info", "success", "warning", "danger"] as const;

--- a/server/src/services/plugin-host-services.ts
+++ b/server/src/services/plugin-host-services.ts
@@ -2375,6 +2375,7 @@ export function buildHostServices(
           params.issueId,
           params.body,
           { agentId: params.actorUserId ? undefined : params.authorAgentId, userId: params.actorUserId },
+          { presentation: params.presentation ?? null, metadata: params.metadata ?? null },
         )) as IssueComment;
         await logPluginActivity({
           companyId,

--- a/ui/src/lib/issue-chat-messages.test.ts
+++ b/ui/src/lib/issue-chat-messages.test.ts
@@ -1489,4 +1489,12 @@ describe("groupMessagesIntoPhaseSections", () => {
     expect(sections[0]?.boundaryMessage).toBeNull();
     expect(sections[0]?.messages.map((m) => m.id)).toEqual(["c1", "c2"]);
   });
+
+  it("returns a single empty prelude section for an empty thread, never []", () => {
+    const sections = groupMessagesIntoPhaseSections([]);
+    expect(sections).toHaveLength(1);
+    expect(sections[0]?.key).toBe("prelude");
+    expect(sections[0]?.boundaryMessage).toBeNull();
+    expect(sections[0]?.messages).toEqual([]);
+  });
 });

--- a/ui/src/lib/issue-chat-messages.test.ts
+++ b/ui/src/lib/issue-chat-messages.test.ts
@@ -3,6 +3,7 @@ import type { Agent } from "@paperclipai/shared";
 import {
   buildAssistantPartsFromTranscript,
   buildIssueChatMessages,
+  groupMessagesIntoPhaseSections,
   isCoTSegmentActive,
   preserveReadableStreamingRetraction,
   stabilizeThreadMessages,
@@ -1395,5 +1396,97 @@ describe("stabilizeThreadMessages", () => {
     );
 
     expect(secondStable.messages).toBe(firstStable.messages);
+  });
+});
+
+describe("groupMessagesIntoPhaseSections", () => {
+  function phaseBoundaryComment(id: string, title: string, createdAt: Date): IssueChatComment {
+    return createComment({
+      id,
+      authorType: "system",
+      authorUserId: null,
+      body: `## Workflow: advanced\nRouted to next step.`,
+      presentation: { kind: "phase_boundary", tone: "info", title, detailsDefaultOpen: false },
+      createdAt,
+      updatedAt: createdAt,
+    });
+  }
+
+  it("puts everything before the first boundary into a boundary-less prelude section", () => {
+    const messages = buildIssueChatMessages({
+      comments: [
+        createComment({ id: "c1", createdAt: new Date("2026-04-06T12:00:00.000Z"), updatedAt: new Date("2026-04-06T12:00:00.000Z") }),
+        phaseBoundaryComment("c2", "Design", new Date("2026-04-06T12:01:00.000Z")),
+      ],
+      timelineEvents: [],
+      linkedRuns: [],
+      liveRuns: [],
+    });
+
+    const sections = groupMessagesIntoPhaseSections(messages);
+    expect(sections).toHaveLength(2);
+    expect(sections[0]?.boundaryMessage).toBeNull();
+    expect(sections[0]?.messages.map((m) => m.id)).toEqual(["c1"]);
+    expect(sections[1]?.boundaryTitle).toBe("Design");
+    expect(sections[1]?.messages.map((m) => m.id)).toEqual(["c2"]);
+  });
+
+  it("groups every message up to (but not including) the next boundary with its own boundary", () => {
+    const messages = buildIssueChatMessages({
+      comments: [
+        phaseBoundaryComment("c1", "PRD", new Date("2026-04-06T12:00:00.000Z")),
+        createComment({ id: "c2", createdAt: new Date("2026-04-06T12:01:00.000Z"), updatedAt: new Date("2026-04-06T12:01:00.000Z") }),
+        createComment({ id: "c3", createdAt: new Date("2026-04-06T12:02:00.000Z"), updatedAt: new Date("2026-04-06T12:02:00.000Z") }),
+        phaseBoundaryComment("c4", "Design", new Date("2026-04-06T12:03:00.000Z")),
+        createComment({ id: "c5", createdAt: new Date("2026-04-06T12:04:00.000Z"), updatedAt: new Date("2026-04-06T12:04:00.000Z") }),
+      ],
+      timelineEvents: [],
+      linkedRuns: [],
+      liveRuns: [],
+    });
+
+    const sections = groupMessagesIntoPhaseSections(messages);
+    expect(sections).toHaveLength(2);
+    expect(sections[0]?.boundaryTitle).toBe("PRD");
+    expect(sections[0]?.messages.map((m) => m.id)).toEqual(["c1", "c2", "c3"]);
+    expect(sections[1]?.boundaryTitle).toBe("Design");
+    expect(sections[1]?.messages.map((m) => m.id)).toEqual(["c4", "c5"]);
+  });
+
+  it("treats a thread with no boundaries as a single prelude section", () => {
+    const messages = buildIssueChatMessages({
+      comments: [createComment({ id: "c1" })],
+      timelineEvents: [],
+      linkedRuns: [],
+      liveRuns: [],
+    });
+
+    const sections = groupMessagesIntoPhaseSections(messages);
+    expect(sections).toHaveLength(1);
+    expect(sections[0]?.boundaryMessage).toBeNull();
+  });
+
+  it("ignores non-phase-boundary system notices as section dividers", () => {
+    const messages = buildIssueChatMessages({
+      comments: [
+        createComment({
+          id: "c1",
+          authorType: "system",
+          authorUserId: null,
+          presentation: { kind: "system_notice", tone: "warning", title: "Blocked", detailsDefaultOpen: true },
+          createdAt: new Date("2026-04-06T12:00:00.000Z"),
+          updatedAt: new Date("2026-04-06T12:00:00.000Z"),
+        }),
+        createComment({ id: "c2", createdAt: new Date("2026-04-06T12:01:00.000Z"), updatedAt: new Date("2026-04-06T12:01:00.000Z") }),
+      ],
+      timelineEvents: [],
+      linkedRuns: [],
+      liveRuns: [],
+    });
+
+    const sections = groupMessagesIntoPhaseSections(messages);
+    expect(sections).toHaveLength(1);
+    expect(sections[0]?.boundaryMessage).toBeNull();
+    expect(sections[0]?.messages.map((m) => m.id)).toEqual(["c1", "c2"]);
   });
 });

--- a/ui/src/lib/issue-chat-messages.ts
+++ b/ui/src/lib/issue-chat-messages.ts
@@ -1183,9 +1183,11 @@ export interface ThreadMessageSection {
 }
 
 function messagePresentation(message: ThreadMessage): { kind?: string; title?: string | null } | null {
-  const custom = (message.metadata as { custom?: Record<string, unknown> } | undefined)?.custom;
-  const presentation = custom?.presentation as { kind?: string; title?: string | null } | null | undefined;
-  return presentation ?? null;
+  const meta = message.metadata as { custom?: Record<string, unknown> } | null | undefined;
+  if (!meta?.custom) return null;
+  const presentation = meta.custom["presentation"];
+  if (!presentation || typeof presentation !== "object") return null;
+  return presentation as { kind?: string; title?: string | null };
 }
 
 export function groupMessagesIntoPhaseSections(messages: readonly ThreadMessage[]): ThreadMessageSection[] {
@@ -1200,6 +1202,10 @@ export function groupMessagesIntoPhaseSections(messages: readonly ThreadMessage[
       current.messages.push(message);
     }
   }
-  if (current.messages.length > 0) sections.push(current);
+  // Always return at least the prelude section — for a non-empty `messages`
+  // input `current` can never be empty here (every branch above pushes to
+  // it), so this only changes behavior for a genuinely empty thread, letting
+  // callers assume `sections.length >= 1` instead of special-casing `[]`.
+  if (current.messages.length > 0 || sections.length === 0) sections.push(current);
   return sections;
 }

--- a/ui/src/lib/issue-chat-messages.ts
+++ b/ui/src/lib/issue-chat-messages.ts
@@ -1169,3 +1169,37 @@ export function buildIssueChatMessages(args: {
     })
     .map((entry) => entry.message);
 }
+
+// A phase section groups everything between two "phase_boundary" system
+// notices (see IssueCommentPresentation) — typically a plugin's workflow
+// transition comment — so a ticket spanning many phases (PRD, design, dev,
+// QA...) can be rendered as collapsible sections instead of one flat scroll.
+// The section before the first boundary (if any) has no boundary message.
+export interface ThreadMessageSection {
+  key: string;
+  boundaryMessage: ThreadMessage | null;
+  boundaryTitle: string | null;
+  messages: ThreadMessage[];
+}
+
+function messagePresentation(message: ThreadMessage): { kind?: string; title?: string | null } | null {
+  const custom = (message.metadata as { custom?: Record<string, unknown> } | undefined)?.custom;
+  const presentation = custom?.presentation as { kind?: string; title?: string | null } | null | undefined;
+  return presentation ?? null;
+}
+
+export function groupMessagesIntoPhaseSections(messages: readonly ThreadMessage[]): ThreadMessageSection[] {
+  const sections: ThreadMessageSection[] = [];
+  let current: ThreadMessageSection = { key: "prelude", boundaryMessage: null, boundaryTitle: null, messages: [] };
+  for (const message of messages) {
+    const presentation = messagePresentation(message);
+    if (presentation?.kind === "phase_boundary") {
+      if (current.messages.length > 0) sections.push(current);
+      current = { key: message.id, boundaryMessage: message, boundaryTitle: presentation.title ?? null, messages: [message] };
+    } else {
+      current.messages.push(message);
+    }
+  }
+  if (current.messages.length > 0) sections.push(current);
+  return sections;
+}


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work; `issue_comments` has `presentation`/`metadata` JSONB columns that already drive a real `SystemNotice` UI component (tone-colored banner, optional title, collapsible metadata sections)
> - The core service (`server/src/services/issues.ts` `addComment`) already fully validates and persists both fields — core itself uses this today (e.g. `server/src/services/recovery/service.ts`)
> - But the plugin SDK's `createComment()` never exposed either field on its public signature, and the RPC bridge a plugin call actually goes through (`plugin-host-services.ts`) silently dropped them even if a caller tried to pass them anyway — so every plugin-authored comment renders as a bare, untitled system notice, regardless of how much richer context the plugin actually has about what happened
> - Concretely hit this while working on the workflow-engine plugin: it posts a system comment on every workflow node transition (e.g. "Routed to next step (prd)"), and there was no way to give that comment a title/tone naming the phase it just entered — it just looks like a generic gray notice indistinguishable from any other system comment
> - Traced the gap through the whole call chain (SDK types → protocol params → worker-RPC proxy → host bridge → core service) and found it's a pure plumbing gap, not a design constraint — the core service was already capable of doing the right thing
> - Added `presentation`/`metadata` to the SDK's `createComment` end-to-end, and forwarded them through the bridge instead of dropping them
> - Also added a new `"phase_boundary"` presentation kind and a pure `groupMessagesIntoPhaseSections` UI helper as groundwork for a future change that groups a ticket's activity feed into collapsible per-phase sections — today it renders identically to a normal `system_notice` (title + tone), since `SystemNotice`'s render path doesn't branch on `kind` at all, so there's zero visual change for any existing comment

## Linked Issues or Issue Description

No existing public issue covers this — describing it directly, following the bug report fields:

**What happened?**

A plugin calling `ctx.issues.createComment(issueId, body, companyId, options)` has no way to set `presentation` or `metadata` on the resulting comment, even though `issue_comments.presentation`/`issue_comments.metadata` are real, validated, persisted columns that the core `addComment` service already fully supports (`authorType`/`presentation`/`metadata`/`sourceTrust`/`createdAt` options, all schema-validated via `issueCommentPresentationSchema`/`issueCommentMetadataSchema`). The SDK's `createComment` signature (`packages/plugins/sdk/src/types.ts`) only accepted `{ authorAgentId?: string }`. Even if a plugin author reached around the type system and passed extra fields anyway, the RPC bridge handler in `server/src/services/plugin-host-services.ts` (`createComment(params)`) called `issues.addComment(params.issueId, params.body, { agentId: params.authorAgentId })` with no 4th `options` argument at all — silently discarding anything else. Net effect: every plugin-authored system comment renders as a plain, untitled gray notice no matter how much structured context the plugin actually has about what just happened.

**Expected behavior**

A plugin should be able to pass `presentation`/`metadata` through `createComment`, matching what the core service already supports, and have it actually persisted and rendered (title, tone, collapsible metadata sections) — the same richness available to core-authored comments today.

**Steps to reproduce**

1. Write a plugin that calls `ctx.issues.createComment(issueId, "Something happened", companyId, { presentation: { kind: "system_notice", tone: "warning", title: "Retry needed", detailsDefaultOpen: false } })`.
2. Observe the SDK's TypeScript types don't even allow this call to compile (no `presentation` field on the options type).
3. Force it through anyway (e.g. via an `as any` cast) and observe the resulting comment in the database has `presentation: null` — the RPC bridge dropped it before it ever reached `issues.addComment`.

**Paperclip version or commit**

`ad961227f57a217655c9e05e5987e6d0e5524409` (current `master` at time of writing)

**Deployment mode**

Self-hosted server

## What Changed

- `packages/shared/src/constants.ts`: added `"phase_boundary"` to `ISSUE_COMMENT_PRESENTATION_KINDS` — marks a comment as a section-divider for a future activity-feed grouping UI (not wired into rendering in this PR; today it renders identically to `system_notice`).
- `packages/plugins/sdk/src/types.ts`, `protocol.ts`, `worker-rpc-host.ts`, `testing.ts`, `index.ts`: extended `createComment`'s `options` to accept `presentation?: IssueCommentPresentation | null` and `metadata?: IssueCommentMetadata | null` across the full SDK surface (the `PluginContext`-style interface, the RPC protocol's params type, the worker-side RPC proxy that forwards to the host, the in-memory test harness mock, and the public type re-exports plugin authors import from).
- `server/src/services/plugin-host-services.ts`: `createComment`'s handler now forwards `{ presentation, metadata }` as the 4th argument to `issues.addComment` instead of calling it with just an actor and no options.
- `ui/src/lib/issue-chat-messages.ts`: added `groupMessagesIntoPhaseSections`, a pure function that splits a thread's already-built `ThreadMessage[]` into sections at each `phase_boundary` message — groundwork for a follow-up UI change, not wired into `IssueChatThread`'s actual rendering in this PR (that needs live verification against the component's virtualization and anchor-scroll-to-comment logic, which is out of scope here).
- `ui/src/lib/issue-chat-messages.test.ts`: 4 new tests covering the grouping function (prelude-before-first-boundary, multi-section grouping, no-boundary single-section, and that only `phase_boundary` — not other `presentation.kind` values — acts as a divider).

## Verification

- `pnpm --filter @paperclipai/shared exec vitest run` — 196/196 passed.
- `pnpm --filter @paperclipai/plugin-sdk exec vitest run` — 16/16 passed.
- `pnpm --filter @paperclipai/server exec tsc --noEmit` — clean, no new errors.
- `pnpm --filter @paperclipai/server exec vitest run` on the plugin host-service, orchestration, and tenant-isolation suites (the ones exercising this exact RPC path) — 23/23 passed.
- `pnpm --filter @paperclipai/ui exec vitest run src/lib/issue-chat-messages.test.ts` — 31/31 passed (27 pre-existing + 4 new).
- Manually rebuilt and re-packed the SDK (`pnpm --filter @paperclipai/plugin-sdk build && pnpm pack`) and installed it into a real downstream plugin (a workflow-engine plugin consuming this SDK as a `file:` tarball dependency) to confirm the new `createComment` options actually typecheck and resolve correctly from a real external plugin, not just within this monorepo.

## Risks

- Low risk. Every new field is optional (`presentation?`, `metadata?`), so this is purely additive — no existing call site's behavior changes. The RPC bridge change adds one extra options object to an existing service call; the service already treats missing options as `null` defaults today (unchanged for any caller that doesn't pass them).
- The new `"phase_boundary"` presentation kind is unused by any rendering logic yet (verified `SystemNotice`'s render path doesn't branch on `kind`), so there is no behavioral or visual change for existing comments — it only unlocks a plugin's ability to *tag* a comment, not any different rendering yet.
- `groupMessagesIntoPhaseSections` is a new, unused (by any component) pure function — dead code today by design, intended for a follow-up PR once the actual collapsing UI is built and verified live.
- No schema or migration changes (the `presentation`/`metadata` columns already exist and are already used elsewhere).

## Model Used

Claude (Anthropic), model `claude-sonnet-5`, used within a coding-agent harness (Claude Code) with tool use (file edit, test execution, cross-repo build/pack verification against a real downstream plugin consumer). Root-caused by tracing a UI/product question ("why do workflow-transition comments render as plain gray text with no way to add a phase label") backward through the full SDK→bridge→core call chain to find the exact point the fields were dropped.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
