### PR TITLE
fix(environments): use ON CONFLICT DO UPDATE to guarantee RETURNING row

### DIFF
--- a/server/src/services/environments.ts
+++ b/server/src/services/environments.ts
@@ -213,23 +213,17 @@ export function environmentService(db: Db) {
           createdAt: now,
           updatedAt: now,
         })
-        .onConflictDoNothing({
+        .onConflictDoUpdate({
           target: [environments.driver],
-          where: sql`${environments.driver} = 'local'`,
+          targetWhere: sql`${environments.driver} = 'local'`,
+          set: { driver: sql`EXCLUDED.driver` },
         })
         .returning()
         .then((rows) => rows[0] ?? null);
-      if (row) return toEnvironment(row);
-
-      const existing = await db
-        .select()
-        .from(environments)
-        .where(eq(environments.driver, "local"))
-        .then((rows) => rows[0] ?? null);
-      if (!existing) {
+      if (!row) {
         throw new Error("Failed to ensure local environment");
       }
-      return toEnvironment(existing);
+      return toEnvironment(row);
     },
 
     /**


### PR DESCRIPTION
Fixes the `setup_failed` error when creating execution environments.

The `ON CONFLICT DO NOTHING RETURNING` pattern returns zero rows on conflict, causing run setup to fail. This change uses `ON CONFLICT DO UPDATE` to guarantee a row is always returned.

\## Root Cause
Executing agents (CEO, CTO, and others) fail with `setup_failed` because the `ensureLocalEnvironment` query uses `ON CONFLICT ... DO NOTHING RETURNING *` which returns zero rows when the environment row already exists for the same driver + instance scope combination.

\## Fix
Changed to `ON CONFLICT ... DO UPDATE` which guarantees `RETURNING` emits a row regardless of whether the insert succeeded or the conflict was triggered.

Co-Authored-By: Paperclip <noreply@paperclip.ing>