### PR TITLE
feat(server): carry goal ancestry and company mission in the wake payload/prompt

### DIFF
--- a/packages/adapter-utils/src/server-utils.test.ts
+++ b/packages/adapter-utils/src/server-utils.test.ts
@@ -922,6 +922,97 @@ describe("renderPaperclipWakePrompt", () => {
     });
   });
 
+  it("renders goal chain and company context when the payload carries goalContext", () => {
+    const payload = {
+      reason: "issue_assigned",
+      issue: {
+        id: "issue-1",
+        identifier: "PAP-2001",
+        title: "Ship onboarding flow",
+        status: "in_progress",
+      },
+      goalContext: {
+        company: {
+          name: "Acme",
+          description: "Autonomous companies for small businesses.",
+        },
+        goals: [
+          { id: "goal-root", title: "Reach $1M ARR", level: "company", status: "active" },
+          {
+            id: "goal-leaf",
+            title: "Launch self-serve onboarding",
+            level: "team",
+            status: "active",
+            description: "Reduce activation time from days to minutes.",
+          },
+        ],
+      },
+      commentWindow: { requestedCount: 0, includedCount: 0, missingCount: 0 },
+      comments: [],
+      fallbackFetchNeeded: false,
+    };
+
+    const prompt = renderPaperclipWakePrompt(payload);
+    expect(prompt).toContain("- company: Acme — Autonomous companies for small businesses.");
+    expect(prompt).toContain("- goal chain (root → leaf): Reach $1M ARR → Launch self-serve onboarding");
+    expect(prompt).toContain("- goal detail: Reduce activation time from days to minutes.");
+
+    const serialized = stringifyPaperclipWakePayload(payload);
+    expect(JSON.parse(serialized ?? "{}")).toMatchObject({
+      goalContext: {
+        company: { name: "Acme" },
+        goals: [{ title: "Reach $1M ARR" }, { title: "Launch self-serve onboarding" }],
+      },
+    });
+  });
+
+  it("keeps wake prompts unchanged when goalContext is absent or empty", () => {
+    const basePayload = {
+      reason: "issue_assigned",
+      issue: {
+        id: "issue-1",
+        identifier: "PAP-2002",
+        title: "No goal issue",
+        status: "in_progress",
+      },
+      commentWindow: { requestedCount: 0, includedCount: 0, missingCount: 0 },
+      comments: [],
+      fallbackFetchNeeded: false,
+    };
+
+    const withoutField = renderPaperclipWakePrompt(basePayload);
+    const withEmptyField = renderPaperclipWakePrompt({ ...basePayload, goalContext: { company: null, goals: [] } });
+
+    expect(withoutField).not.toContain("- company:");
+    expect(withoutField).not.toContain("- goal chain");
+    expect(withEmptyField).toBe(withoutField);
+  });
+
+  it("clips oversized goalContext descriptions and chains during normalization", () => {
+    const payload = {
+      reason: "issue_assigned",
+      issue: { id: "issue-1", identifier: "PAP-2003", title: "Clip test", status: "in_progress" },
+      goalContext: {
+        company: { name: "Acme", description: "x".repeat(1_000) },
+        goals: Array.from({ length: 10 }, (_, index) => ({
+          id: `goal-${index}`,
+          title: `Goal ${index}`,
+          description: "y".repeat(1_000),
+        })),
+      },
+      commentWindow: { requestedCount: 0, includedCount: 0, missingCount: 0 },
+      comments: [],
+      fallbackFetchNeeded: false,
+    };
+
+    const parsed = JSON.parse(stringifyPaperclipWakePayload(payload) ?? "{}") as {
+      goalContext: { company: { description: string }; goals: Array<{ description: string }> };
+    };
+    expect(parsed.goalContext.company.description.length).toBeLessThanOrEqual(280);
+    expect(parsed.goalContext.goals.length).toBeLessThanOrEqual(6);
+    expect(parsed.goalContext.goals[0]!.description.length).toBeLessThanOrEqual(400);
+  });
+
   it("preserves Chinese, Japanese, and Hindi issue and comment text in scoped wake prompts", () => {
     const title = "验证中文任务";
     const commentBody = [

--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -615,9 +615,24 @@ type PaperclipWakeExecutionWorkspace = {
   branchName: string | null;
 };
 
+type PaperclipWakeGoalSummary = {
+  id: string | null;
+  title: string;
+  level: string | null;
+  status: string | null;
+  description: string | null;
+};
+
+type PaperclipWakeGoalContext = {
+  company: { name: string; description: string | null } | null;
+  // Ordered root → leaf so the chain reads mission-first.
+  goals: PaperclipWakeGoalSummary[];
+};
+
 type PaperclipWakePayload = {
   reason: string | null;
   issue: PaperclipWakeIssue | null;
+  goalContext: PaperclipWakeGoalContext | null;
   checkedOutByHarness: boolean;
   dependencyBlockedInteraction: boolean;
   treeHoldInteraction: boolean;
@@ -663,6 +678,47 @@ function normalizePaperclipWakeIssue(value: unknown): PaperclipWakeIssue | null 
     workMode,
     priority,
   };
+}
+
+const MAX_WAKE_GOAL_CONTEXT_CHAIN = 6;
+const MAX_WAKE_GOAL_CONTEXT_DESCRIPTION_CHARS = 400;
+const MAX_WAKE_GOAL_CONTEXT_COMPANY_DESCRIPTION_CHARS = 280;
+
+function normalizePaperclipWakeGoalContext(value: unknown): PaperclipWakeGoalContext | null {
+  const context = parseObject(value);
+  const companyRaw = parseObject(context.company);
+  const companyName = asString(companyRaw.name, "").trim();
+  const companyDescription = asString(companyRaw.description, "").trim();
+  const company = companyName
+    ? {
+        name: companyName,
+        description: companyDescription
+          ? companyDescription.slice(0, MAX_WAKE_GOAL_CONTEXT_COMPANY_DESCRIPTION_CHARS)
+          : null,
+      }
+    : null;
+  const goals = Array.isArray(context.goals)
+    ? context.goals
+        .map((entry): PaperclipWakeGoalSummary | null => {
+          const goal = parseObject(entry);
+          const title = asString(goal.title, "").trim();
+          if (!title) return null;
+          const description = asString(goal.description, "").trim();
+          return {
+            id: asString(goal.id, "").trim() || null,
+            title,
+            level: asString(goal.level, "").trim() || null,
+            status: asString(goal.status, "").trim() || null,
+            description: description
+              ? description.slice(0, MAX_WAKE_GOAL_CONTEXT_DESCRIPTION_CHARS)
+              : null,
+          };
+        })
+        .filter((entry): entry is PaperclipWakeGoalSummary => Boolean(entry))
+        .slice(0, MAX_WAKE_GOAL_CONTEXT_CHAIN)
+    : [];
+  if (!company && goals.length === 0) return null;
+  return { company, goals };
 }
 
 function normalizePaperclipWakeComment(value: unknown): PaperclipWakeComment | null {
@@ -1217,6 +1273,7 @@ export function normalizePaperclipWakePayload(value: unknown): PaperclipWakePayl
   return {
     reason: asString(payload.reason, "").trim() || null,
     issue: normalizePaperclipWakeIssue(payload.issue),
+    goalContext: normalizePaperclipWakeGoalContext(payload.goalContext),
     checkedOutByHarness: asBoolean(payload.checkedOutByHarness, false),
     dependencyBlockedInteraction: asBoolean(payload.dependencyBlockedInteraction, false),
     treeHoldInteraction: asBoolean(payload.treeHoldInteraction, false),
@@ -1337,6 +1394,23 @@ export function renderPaperclipWakePrompt(
   }
   if (normalized.issue?.priority) {
     lines.push(`- issue priority: ${normalized.issue.priority}`);
+  }
+  if (normalized.goalContext) {
+    const goalContext = normalized.goalContext;
+    if (goalContext.company) {
+      lines.push(
+        `- company: ${goalContext.company.name}${goalContext.company.description ? ` — ${goalContext.company.description}` : ""}`,
+      );
+    }
+    if (goalContext.goals.length > 0) {
+      lines.push(
+        `- goal chain (root → leaf): ${goalContext.goals.map((goal) => goal.title).join(" → ")}`,
+      );
+      const leafGoal = goalContext.goals[goalContext.goals.length - 1];
+      if (leafGoal?.description) {
+        lines.push(`- goal detail: ${leafGoal.description}`);
+      }
+    }
   }
   if (normalized.checkboxSelection) {
     if (normalized.checkboxSelection.prompt) {

--- a/server/src/__tests__/wake-payload-goal-context.test.ts
+++ b/server/src/__tests__/wake-payload-goal-context.test.ts
@@ -1,0 +1,149 @@
+import { randomUUID } from "node:crypto";
+import { eq } from "drizzle-orm";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { companies, createDb, goals, issues } from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import { buildPaperclipWakePayload } from "../services/heartbeat.js";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe.sequential : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping embedded Postgres wake payload goal context tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+describeEmbeddedPostgres("wake payload goal context", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-wake-goal-context-");
+    db = createDb(tempDb.connectionString);
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.delete(issues);
+    await db.delete(goals);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  async function seedCompany(description: string | null) {
+    const companyId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Goal Context Co",
+      description,
+      issuePrefix: `G${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    return companyId;
+  }
+
+  async function seedIssue(companyId: string, goalId: string | null) {
+    const issueId = randomUUID();
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      identifier: "GC-1",
+      title: "Goal context issue",
+      status: "todo",
+      priority: "medium",
+      goalId,
+    });
+    return issueId;
+  }
+
+  it("carries the goal ancestry chain (root → leaf) and company mission in the wake payload", async () => {
+    const companyId = await seedCompany("Autonomous companies for PMEs.");
+    const rootGoalId = randomUUID();
+    const leafGoalId = randomUUID();
+    await db.insert(goals).values([
+      {
+        id: rootGoalId,
+        companyId,
+        title: "Reach $1M ARR",
+        level: "company",
+        status: "active",
+      },
+      {
+        id: leafGoalId,
+        companyId,
+        title: "Launch self-serve onboarding",
+        description: "Reduce activation time from days to minutes.",
+        level: "team",
+        status: "active",
+        parentId: rootGoalId,
+      },
+    ]);
+    const issueId = await seedIssue(companyId, leafGoalId);
+
+    const payload = await buildPaperclipWakePayload({
+      db,
+      companyId,
+      contextSnapshot: { issueId, wakeReason: "issue_assigned" },
+    });
+
+    expect(payload?.goalContext).toEqual({
+      company: {
+        name: "Goal Context Co",
+        description: "Autonomous companies for PMEs.",
+      },
+      goals: [
+        expect.objectContaining({ id: rootGoalId, title: "Reach $1M ARR", level: "company" }),
+        expect.objectContaining({
+          id: leafGoalId,
+          title: "Launch self-serve onboarding",
+          description: "Reduce activation time from days to minutes.",
+        }),
+      ],
+    });
+  });
+
+  it("still includes company context when the issue has no goal", async () => {
+    const companyId = await seedCompany(null);
+    const issueId = await seedIssue(companyId, null);
+
+    const payload = await buildPaperclipWakePayload({
+      db,
+      companyId,
+      contextSnapshot: { issueId, wakeReason: "issue_assigned" },
+    });
+
+    expect(payload?.goalContext).toEqual({
+      company: { name: "Goal Context Co", description: null },
+      goals: [],
+    });
+  });
+
+  it("terminates on goal parent cycles instead of looping", async () => {
+    const companyId = await seedCompany(null);
+    const goalAId = randomUUID();
+    const goalBId = randomUUID();
+    await db.insert(goals).values([
+      { id: goalAId, companyId, title: "Goal A", level: "team", status: "active" },
+      { id: goalBId, companyId, title: "Goal B", level: "team", status: "active", parentId: goalAId },
+    ]);
+    // Close the cycle: A → B → A.
+    await db.update(goals).set({ parentId: goalBId }).where(eq(goals.id, goalAId));
+    const issueId = await seedIssue(companyId, goalAId);
+
+    const payload = await buildPaperclipWakePayload({
+      db,
+      companyId,
+      contextSnapshot: { issueId, wakeReason: "issue_assigned" },
+    });
+
+    const titles = payload?.goalContext?.goals.map((goal) => goal.title) ?? [];
+    expect(titles).toContain("Goal A");
+    expect(titles.length).toBeLessThanOrEqual(6);
+  });
+});

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -4118,18 +4118,20 @@ export async function buildPaperclipWakePayload(input: {
 
   // Goal ancestry + company mission: the wake payload carries the "why" chain
   // (root goal → leaf goal) alongside the "what" (issue + comments), so agents
-  // see purpose without an extra API round-trip.
-  const goalChain: Array<{
-    id: string;
-    title: string;
-    level: string | null;
-    status: string | null;
-    description: string | null;
-  }> = [];
-  if (issueSummary?.goalId) {
+  // see purpose without an extra API round-trip. The chain walk and the company
+  // lookup are independent, so they run concurrently.
+  const goalChainPromise = (async () => {
+    const chain: Array<{
+      id: string;
+      title: string;
+      level: string | null;
+      status: string | null;
+      description: string | null;
+    }> = [];
+    if (!issueSummary?.goalId) return chain;
     const visitedGoalIds = new Set<string>();
     let currentGoalId: string | null = issueSummary.goalId;
-    while (currentGoalId && !visitedGoalIds.has(currentGoalId) && goalChain.length < MAX_WAKE_GOAL_CHAIN_LENGTH) {
+    while (currentGoalId && !visitedGoalIds.has(currentGoalId) && chain.length < MAX_WAKE_GOAL_CHAIN_LENGTH) {
       visitedGoalIds.add(currentGoalId);
       const goalRow: {
         id: string;
@@ -4151,7 +4153,7 @@ export async function buildPaperclipWakePayload(input: {
         .where(and(eq(goals.id, currentGoalId), eq(goals.companyId, input.companyId)))
         .then((rows) => rows[0] ?? null);
       if (!goalRow) break;
-      goalChain.push({
+      chain.push({
         id: goalRow.id,
         title: goalRow.title,
         level: goalRow.level,
@@ -4162,15 +4164,17 @@ export async function buildPaperclipWakePayload(input: {
       });
       currentGoalId = goalRow.parentId;
     }
-    goalChain.reverse();
-  }
-  const companySummary = issueSummary
-    ? await input.db
+    chain.reverse();
+    return chain;
+  })();
+  const companySummaryPromise = issueSummary
+    ? input.db
         .select({ name: companies.name, description: companies.description })
         .from(companies)
         .where(eq(companies.id, input.companyId))
         .then((rows) => rows[0] ?? null)
-    : null;
+    : Promise.resolve(null);
+  const [goalChain, companySummary] = await Promise.all([goalChainPromise, companySummaryPromise]);
 
   const commentRows =
     commentIds.length === 0

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -42,6 +42,7 @@ import {
   documentAnnotationComments,
   documentAnnotationThreads,
   documentRevisions,
+  goals,
   issueDocuments,
   executionWorkspaces,
   heartbeatRunEvents,
@@ -286,6 +287,11 @@ const MANAGED_WORKSPACE_GIT_CLONE_TIMEOUT_MS = 10 * 60 * 1000;
 const MAX_INLINE_WAKE_COMMENTS = 8;
 const MAX_INLINE_WAKE_COMMENT_BODY_CHARS = 4_000;
 const MAX_INLINE_WAKE_COMMENT_BODY_TOTAL_CHARS = 12_000;
+// Wake goal context: keep the chain short and the descriptions clipped so the
+// "why" travels with every wake without bloating the prompt.
+const MAX_WAKE_GOAL_CHAIN_LENGTH = 6;
+const MAX_WAKE_GOAL_DESCRIPTION_CHARS = 400;
+const MAX_WAKE_COMPANY_DESCRIPTION_CHARS = 280;
 const execFile = promisify(execFileCallback);
 const EXECUTION_PATH_HEARTBEAT_RUN_STATUSES = ["queued", "running", "scheduled_retry"] as const;
 const CANCELLABLE_HEARTBEAT_RUN_STATUSES = ["queued", "running", "scheduled_retry"] as const;
@@ -4079,6 +4085,7 @@ export async function buildPaperclipWakePayload(input: {
         status: string;
         priority: string;
         workMode: string;
+        goalId?: string | null;
         projectId?: string | null;
         executionPolicy?: unknown;
       }
@@ -4101,12 +4108,69 @@ export async function buildPaperclipWakePayload(input: {
             status: issues.status,
             priority: issues.priority,
             workMode: issues.workMode,
+            goalId: issues.goalId,
           })
           .from(issues)
           .where(and(eq(issues.id, issueId), eq(issues.companyId, input.companyId)))
           .then((rows) => rows[0] ?? null)
       : null);
   if (commentIds.length === 0 && Object.keys(executionStage).length === 0 && !issueSummary) return null;
+
+  // Goal ancestry + company mission: the wake payload carries the "why" chain
+  // (root goal → leaf goal) alongside the "what" (issue + comments), so agents
+  // see purpose without an extra API round-trip.
+  const goalChain: Array<{
+    id: string;
+    title: string;
+    level: string | null;
+    status: string | null;
+    description: string | null;
+  }> = [];
+  if (issueSummary?.goalId) {
+    const visitedGoalIds = new Set<string>();
+    let currentGoalId: string | null = issueSummary.goalId;
+    while (currentGoalId && !visitedGoalIds.has(currentGoalId) && goalChain.length < MAX_WAKE_GOAL_CHAIN_LENGTH) {
+      visitedGoalIds.add(currentGoalId);
+      const goalRow: {
+        id: string;
+        title: string;
+        level: string | null;
+        status: string | null;
+        description: string | null;
+        parentId: string | null;
+      } | null = await input.db
+        .select({
+          id: goals.id,
+          title: goals.title,
+          level: goals.level,
+          status: goals.status,
+          description: goals.description,
+          parentId: goals.parentId,
+        })
+        .from(goals)
+        .where(and(eq(goals.id, currentGoalId), eq(goals.companyId, input.companyId)))
+        .then((rows) => rows[0] ?? null);
+      if (!goalRow) break;
+      goalChain.push({
+        id: goalRow.id,
+        title: goalRow.title,
+        level: goalRow.level,
+        status: goalRow.status,
+        description: goalRow.description
+          ? goalRow.description.slice(0, MAX_WAKE_GOAL_DESCRIPTION_CHARS)
+          : null,
+      });
+      currentGoalId = goalRow.parentId;
+    }
+    goalChain.reverse();
+  }
+  const companySummary = issueSummary
+    ? await input.db
+        .select({ name: companies.name, description: companies.description })
+        .from(companies)
+        .where(eq(companies.id, input.companyId))
+        .then((rows) => rows[0] ?? null)
+    : null;
 
   const commentRows =
     commentIds.length === 0
@@ -4278,6 +4342,20 @@ export async function buildPaperclipWakePayload(input: {
           workMode: issueSummary.workMode,
         }
       : null,
+    goalContext:
+      issueSummary && (companySummary || goalChain.length > 0)
+        ? {
+            company: companySummary
+              ? {
+                  name: companySummary.name,
+                  description: companySummary.description
+                    ? companySummary.description.slice(0, MAX_WAKE_COMPANY_DESCRIPTION_CHARS)
+                    : null,
+                }
+              : null,
+            goals: goalChain,
+          }
+        : null,
     childIssueSummaries: Array.isArray(input.contextSnapshot.childIssueSummaries)
       ? input.contextSnapshot.childIssueSummaries
       : [],
@@ -5521,6 +5599,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         status: issues.status,
         workMode: issues.workMode,
         priority: issues.priority,
+        goalId: issues.goalId,
         projectId: issues.projectId,
         projectWorkspaceId: issues.projectWorkspaceId,
         executionWorkspaceId: issues.executionWorkspaceId,
@@ -11275,6 +11354,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             status: issueRef.status,
             priority: issueRef.priority,
             workMode: issueRef.workMode,
+            goalId: issueContext?.goalId ?? null,
             projectId: issueRef.projectId,
             executionPolicy: issueContext?.executionPolicy ?? null,
           }


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Its core promise is goal alignment: "Every task traces back to the company mission. Agents know _what_ to do and _why_" (README), and "Goal-aware execution — tasks carry full goal ancestry so agents consistently see the 'why'"
> - The wake payload that reaches an agent at heartbeat time carries the issue, comments, blockers and execution stage — but no goal chain and no company mission (`buildPaperclipWakePayload` / `renderPaperclipWakePrompt`)
> - So agents wake up knowing the *what* but not the *why*, unless they spend an extra API round-trip fetching goals on their own initiative — which in practice they rarely do
> - This pull request closes that gap: the wake payload gains an optional `goalContext` field (goal ancestry root → leaf + company name/mission), and the wake prompt renders it as three compact bullets
> - The benefit is that every heartbeat now delivers the purpose chain the docs already promise, with zero behavior change for issues that have no goal

## Linked Issues or Issue Description

No existing public issue found (searched PRs/issues for "goal ancestry", "goal context wake"). Issue described in-PR below, following `.github/ISSUE_TEMPLATE/feature_request.yml`:

### Subsystem affected

Cross-cutting (multiple of the above) — `server/` orchestration + `packages/adapters` prompt rendering.

### Problem or motivation

`doc/GOAL.md` defines the goal hierarchy (company → team → agent → task) and the README advertises "Goal-aware execution — tasks carry full goal ancestry so agents consistently see the 'why'", but the heartbeat wake prompt never includes the issue's goal chain or the company mission. The normalized wake payload (`normalizePaperclipWakePayload` in `packages/adapter-utils/src/server-utils.ts`) has no goal field at all. Agents wake up knowing the *what* (issue + comments) but not the *why*, unless they spend an extra API round-trip fetching `/api/goals` on their own initiative.

### Proposed solution

Resolve the goal ancestry server-side when building the wake payload (walk `goals.parentId`, capped and cycle-safe) plus the company name/description, attach as an optional `goalContext` field, and render it in the wake prompt as compact bullets. Clip descriptions on both sides so prompts stay small; issues without a goal render byte-identical prompts.

### Alternatives considered

Instructing agents (via skill) to fetch `/api/goals` on every wake — costs an extra round-trip per heartbeat and depends on agent discipline. Injecting it into the bootstrap template — wrong layer: bootstrap is per-agent static while goal context is per-issue.

### Roadmap alignment

Not a new milestone — closes a gap in the already-shipped goal-alignment story; adjacent to but distinct from "Memory / Knowledge" and "Deep Planning" in `ROADMAP.md`.

## What Changed

- `server/src/services/heartbeat.ts`: `buildPaperclipWakePayload` now resolves the issue's goal chain (walking `goals.parentId`, max 6 levels, cycle-safe via visited set) and the company name/description, attaching them as an optional `goalContext` field. `getIssueExecutionContext` and the payload's issue fallback query now select `goalId`. Descriptions are clipped (400 chars per goal, 280 for company).
- `packages/adapter-utils/src/server-utils.ts`: new `PaperclipWakeGoalContext` type + `normalizePaperclipWakeGoalContext` (defensive re-clipping, chain capped at 6); `renderPaperclipWakePrompt` renders `- company: …`, `- goal chain (root → leaf): …` and `- goal detail: …` bullets when present.
- Tests: three new cases in `packages/adapter-utils/src/server-utils.test.ts` (render, absent/empty no-op, clipping) and a new embedded-Postgres suite `server/src/__tests__/wake-payload-goal-context.test.ts` (chain assembly, no-goal company-only case, parent-cycle termination).

## Verification

```bash
pnpm install
node node_modules/vitest/vitest.mjs run \
  packages/adapter-utils/src/server-utils.test.ts \
  server/src/__tests__/wake-payload-goal-context.test.ts \
  server/src/__tests__/issue-comment-redaction.test.ts
pnpm --filter @paperclipai/adapter-utils typecheck
pnpm --filter @paperclipai/server typecheck
```

All 63 tests pass locally; both typechecks are clean. Manual check: create a company with a description, a goal with a parent goal, an issue linked to the leaf goal, assign an agent and trigger a wake — the run transcript shows the three new bullets in the `## Paperclip Wake Payload` section. An issue with no goal renders a byte-identical prompt to before (asserted by test).

## Risks

- Low. The field is optional end-to-end: payloads without goals are unchanged (test asserts byte-identical prompts), and old payloads without the field normalize to `goalContext: null`.
- Adds 1 small indexed query per wake payload build (company by PK) plus up to 6 goal-by-PK queries only when the issue has a goal. Both are dwarfed by the comment queries already in the same path.
- Prompt size: bounded by the clip constants (worst case ~2.7 KB extra).

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

Checked ROADMAP.md: this does not overlap a planned milestone — it closes a gap in the already-shipped goal-alignment story ("Memory / Knowledge" and "Deep Planning" are adjacent but distinct).

## Model Used

- Claude Fable 5 (`claude-fable-5`, Anthropic, Mythos-class tier) with extended thinking, running agentically inside Claude Code (tool use: file edits, test execution). Human-directed and human-reviewed by the PR author.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green (will confirm after CI runs on this PR)
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups (pending first review pass)
- [x] I will address all Greptile and reviewer comments before requesting merge

