### PR TITLE
Fix Hermes blank model default handling

### DIFF
--- a/packages/adapters/hermes/src/server/command-resolution.test.ts
+++ b/packages/adapters/hermes/src/server/command-resolution.test.ts
@@ -1,10 +1,10 @@
 import os from "node:os";
 import path from "node:path";
-import { chmod, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { chmod, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { expect, test } from "vitest";
 
 import { HERMES_CLI } from "../shared/constants.js";
-import { resolveHermesCommand } from "./execute.js";
+import { execute, resolveHermesCommand } from "./execute.js";
 import { testEnvironment } from "./test.js";
 
 test("resolveHermesCommand prefers hermesCommand over command", () => {
@@ -45,4 +45,86 @@ test("testEnvironment accepts config.command when hermesCommand is absent", asyn
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }
+});
+
+async function runExecuteWithFakeHermes(
+  config: Record<string, unknown>,
+): Promise<{ args: string[]; resultModel: string | null | undefined }> {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "hermes-execute-args-"));
+  const cliPath = path.join(tempDir, "fake-hermes");
+  const argsPath = path.join(tempDir, "args.txt");
+  const previousHome = process.env.HOME;
+  const previousUserProfile = process.env.USERPROFILE;
+  const previousHomeDrive = process.env.HOMEDRIVE;
+  const previousHomePath = process.env.HOMEPATH;
+
+  try {
+    await writeFile(
+      cliPath,
+      [
+        "#!/bin/sh",
+        "printf '%s\\n' \"$@\" > \"$HERMES_ARGS_FILE\"",
+        "printf 'ok\\n\\nsession_id: session-test\\n'",
+      ].join("\n") + "\n",
+      "utf8",
+    );
+    await chmod(cliPath, 0o755);
+
+    process.env.HOME = tempDir;
+    process.env.USERPROFILE = tempDir;
+    delete process.env.HOMEDRIVE;
+    delete process.env.HOMEPATH;
+
+    const result = await execute({
+      runId: "run-test",
+      agent: {
+        id: "agent-test",
+        name: "Hermes Test Agent",
+        companyId: "company-test",
+        adapterConfig: {},
+      },
+      config: {
+        ...config,
+        hermesCommand: cliPath,
+        cwd: tempDir,
+        env: { HERMES_ARGS_FILE: argsPath },
+      },
+      runtime: {},
+      onLog: async () => {},
+    } as any);
+
+    const args = (await readFile(argsPath, "utf8")).trim().split("\n");
+    return { args, resultModel: result.model };
+  } finally {
+    if (previousHome === undefined) delete process.env.HOME;
+    else process.env.HOME = previousHome;
+    if (previousUserProfile === undefined) delete process.env.USERPROFILE;
+    else process.env.USERPROFILE = previousUserProfile;
+    if (previousHomeDrive === undefined) delete process.env.HOMEDRIVE;
+    else process.env.HOMEDRIVE = previousHomeDrive;
+    if (previousHomePath === undefined) delete process.env.HOMEPATH;
+    else process.env.HOMEPATH = previousHomePath;
+    await rm(tempDir, { recursive: true, force: true });
+  }
+}
+
+test("execute omits --model when Hermes model config is blank or missing", async () => {
+  for (const config of [{}, { model: "" }, { model: "   " }]) {
+    const { args, resultModel } = await runExecuteWithFakeHermes(config);
+
+    expect(args).not.toContain("-m");
+    expect(args).not.toContain("auto");
+    expect(resultModel).toBeNull();
+  }
+});
+
+test("execute passes an explicit Hermes model override", async () => {
+  const { args, resultModel } = await runExecuteWithFakeHermes({
+    model: "claude-sonnet-4",
+  });
+
+  const modelFlagIndex = args.indexOf("-m");
+  expect(modelFlagIndex).toBeGreaterThanOrEqual(0);
+  expect(args[modelFlagIndex + 1]).toBe("claude-sonnet-4");
+  expect(resultModel).toBe("claude-sonnet-4");
 });

--- a/packages/adapters/hermes/src/server/execute.ts
+++ b/packages/adapters/hermes/src/server/execute.ts
@@ -42,7 +42,6 @@ import {
   HERMES_CLI,
   DEFAULT_TIMEOUT_SEC,
   DEFAULT_GRACE_SEC,
-  DEFAULT_MODEL,
   VALID_PROVIDERS,
 } from "../shared/constants.js";
 
@@ -57,6 +56,11 @@ import {
 
 function cfgString(v: unknown): string | undefined {
   return typeof v === "string" && v.length > 0 ? v : undefined;
+}
+function cfgNonBlankString(v: unknown): string | undefined {
+  if (typeof v !== "string") return undefined;
+  const trimmed = v.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
 }
 function cfgNumber(v: unknown): number | undefined {
   return typeof v === "number" ? v : undefined;
@@ -328,7 +332,7 @@ export async function execute(
 
   // ── Resolve configuration ──────────────────────────────────────────────
   const hermesCmd = resolveHermesCommand(config);
-  const model = cfgString(config.model) || DEFAULT_MODEL;
+  const model = cfgNonBlankString(config.model);
   const timeoutSec = cfgNumber(config.timeoutSec) || DEFAULT_TIMEOUT_SEC;
   const graceSec = cfgNumber(config.graceSec) || DEFAULT_GRACE_SEC;
   const maxTurns = cfgNumber(config.maxTurnsPerRun);
@@ -488,7 +492,7 @@ export async function execute(
   // ── Log start ──────────────────────────────────────────────────────────
   await ctx.onLog(
     "stdout",
-    `[hermes] Starting Hermes Agent (model=${model}, provider=${resolvedProvider} [${resolvedFrom}], timeout=${timeoutSec}s${maxTurns ? `, max_turns=${maxTurns}` : ""})\n`,
+    `[hermes] Starting Hermes Agent (model=${model ?? "Hermes configured default"}, provider=${resolvedProvider} [${resolvedFrom}], timeout=${timeoutSec}s${maxTurns ? `, max_turns=${maxTurns}` : ""})\n`,
   );
   if (prevSessionId) {
     await ctx.onLog(
@@ -546,7 +550,7 @@ export async function execute(
     signal: result.signal,
     timedOut: result.timedOut,
     provider: resolvedProvider,
-    model,
+    model: model ?? null,
   };
 
   if (parsed.errorMessage) {


### PR DESCRIPTION
## Thinking Path

> - Paperclip manages AI-agent work through adapter packages that translate control-plane runs into tool-specific commands.
> - The Hermes local adapter is responsible for constructing the `hermes chat` command from adapter configuration.
> - A blank model field means Paperclip has no adapter-level model override; it should not invent one.
> - When blank or whitespace model values are passed through command construction, Hermes can receive a synthetic model argument instead of using its configured local default.
> - This pull request treats blank model configuration as absent before building the Hermes argv.
> - It adds command-resolution regression coverage so the emitted argv omits `-m` for blank values while preserving explicit model overrides.
> - The benefit is that Hermes users can leave the Paperclip adapter model unset and rely on their local Hermes configuration.

## Linked Issues or Issue Description

- Fixes #5265

## What Changed

- Normalize the Hermes local adapter model config so blank or whitespace-only values are treated as no override.
- Omit `-m` from the generated `hermes chat` argv when no explicit model override is configured.
- Add fake-CLI regression coverage for blank, whitespace, missing, and explicit model inputs.

## Verification

- `pnpm test:run:general`
- `pnpm typecheck`
- `pnpm build`
- `pnpm --filter @paperclipai/hermes-paperclip-adapter test:command-resolution`

## Risks

Low risk for Hermes command behavior: explicit nonblank model values are still passed through, and only blank or whitespace-only values now defer to Hermes' configured default.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

OpenAI Codex, GPT-5, tool-enabled coding agent with shell and repository editing access.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes (not applicable: behavior is covered by adapter regression tests)
- [x] I have considered and documented any risks above
- [ ] All local Paperclip gates requested for this change are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups (pending on the real upstream PR)
- [ ] I will address all Greptile and reviewer comments before requesting merge
