### PR TITLE
fix(ui): keep revision requests out of pending approvals

### DIFF
--- a/ui/src/pages/Approvals.test.tsx
+++ b/ui/src/pages/Approvals.test.tsx
@@ -1,0 +1,146 @@
+// @vitest-environment jsdom
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { Approval } from "@paperclipai/shared";
+import type { ReactNode } from "react";
+import { flushSync } from "react-dom";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Approvals } from "./Approvals";
+
+const mockApprovalsApi = vi.hoisted(() => ({
+  list: vi.fn(),
+  approve: vi.fn(),
+  reject: vi.fn(),
+}));
+
+const mockAgentsApi = vi.hoisted(() => ({
+  list: vi.fn(),
+}));
+
+const mockNavigate = vi.hoisted(() => vi.fn());
+const mockLocation = vi.hoisted(() => ({ pathname: "/approvals/pending" }));
+
+vi.mock("../api/approvals", () => ({
+  approvalsApi: mockApprovalsApi,
+}));
+
+vi.mock("../api/agents", () => ({
+  agentsApi: mockAgentsApi,
+}));
+
+vi.mock("../context/CompanyContext", () => ({
+  useCompany: () => ({ selectedCompanyId: "company-1" }),
+}));
+
+vi.mock("../context/BreadcrumbContext", () => ({
+  useBreadcrumbs: () => ({ setBreadcrumbs: vi.fn() }),
+}));
+
+vi.mock("../components/PageTabBar", () => ({
+  PageTabBar: ({ items }: { items: Array<{ value: string; label: ReactNode }> }) => (
+    <div>
+      {items.map((item) => (
+        <div key={item.value}>{item.label}</div>
+      ))}
+    </div>
+  ),
+}));
+
+vi.mock("@/lib/router", () => ({
+  Link: ({ to, children, className }: { to: string; children?: ReactNode; className?: string }) => (
+    <a href={to} className={className}>
+      {children}
+    </a>
+  ),
+  useLocation: () => mockLocation,
+  useNavigate: () => mockNavigate,
+}));
+
+function makeApproval(id: string, status: Approval["status"], title: string): Approval {
+  const timestamp = new Date("2026-07-05T10:00:00.000Z");
+  return {
+    id,
+    companyId: "company-1",
+    type: "request_board_approval",
+    requestedByAgentId: null,
+    requestedByUserId: null,
+    status,
+    payload: {
+      title,
+      summary: `${title} summary`,
+      recommendedAction: `${title} action`,
+      risks: [],
+    },
+    decisionNote: null,
+    decidedByUserId: null,
+    decidedAt: null,
+    createdAt: timestamp,
+    updatedAt: timestamp,
+  };
+}
+
+async function flushReact() {
+  await Promise.resolve();
+  await new Promise((resolve) => window.setTimeout(resolve, 0));
+}
+
+async function waitForText(container: HTMLElement, text: string) {
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    if (container.textContent?.includes(text)) return;
+    await flushReact();
+  }
+  expect(container.textContent).toContain(text);
+}
+
+function renderApprovals(container: HTMLElement) {
+  const root = createRoot(container);
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+
+  flushSync(() => {
+    root.render(
+      <QueryClientProvider client={queryClient}>
+        <Approvals />
+      </QueryClientProvider>,
+    );
+  });
+
+  return root;
+}
+
+describe("Approvals", () => {
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    mockApprovalsApi.list.mockResolvedValue([
+      makeApproval("approval-pending", "pending", "Awaiting board"),
+      makeApproval("approval-revision", "revision_requested", "Awaiting requester"),
+    ]);
+    mockAgentsApi.list.mockResolvedValue([]);
+    mockNavigate.mockReset();
+    mockLocation.pathname = "/approvals/pending";
+  });
+
+  afterEach(() => {
+    container.remove();
+    document.body.innerHTML = "";
+    vi.clearAllMocks();
+  });
+
+  it("keeps revision-requested approvals out of the pending queue", async () => {
+    const root = renderApprovals(container);
+    await waitForText(container, "Awaiting board");
+
+    expect(container.textContent).toContain("Awaiting board");
+    expect(container.textContent).not.toContain("Awaiting requester");
+    expect(container.textContent).toContain("Pending1");
+
+    flushSync(() => {
+      root.unmount();
+    });
+  });
+});

--- a/ui/src/pages/Approvals.tsx
+++ b/ui/src/pages/Approvals.tsx
@@ -66,12 +66,12 @@ export function Approvals() {
 
   const filtered = (data ?? [])
     .filter(
-      (a) => statusFilter === "all" || a.status === "pending" || a.status === "revision_requested",
+      (a) => statusFilter === "all" || a.status === "pending",
     )
     .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
 
   const pendingCount = (data ?? []).filter(
-    (a) => a.status === "pending" || a.status === "revision_requested",
+    (a) => a.status === "pending",
   ).length;
 
   if (!selectedCompanyId) {


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The approvals UI is the board-facing surface for decisions that need operator attention.
> - Approval `pending` and `revision_requested` statuses represent different owners: board review versus requester rework.
> - The dashboard count already treats only `pending` approvals as pending board work.
> - The approvals page included `revision_requested` rows in its pending tab and badge, so the list disagreed with the dashboard.
> - This pull request narrows the pending approvals page filter and count to `status === "pending"`.
> - The benefit is a pending approvals queue that matches the dashboard and no longer shows requester-owned revision work as board-owned pending work.

## Linked Issues or Issue Description

- Fixes #9076

## What Changed

- Updated `/approvals/pending` filtering so only approvals with `status === "pending"` appear in the pending queue.
- Updated the pending tab count to exclude `revision_requested` approvals.
- Added a focused UI regression test covering mixed `pending` and `revision_requested` approvals.

## Verification

- `pnpm exec vitest run ui/src/pages/Approvals.test.tsx`
- `pnpm --filter @paperclipai/ui typecheck`

## Risks

- Low risk. This changes only the approvals page's client-side pending filter/count; the all approvals tab still shows revision-requested approvals.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex, GPT-5-based coding agent with tool use and local command execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

