### PR TITLE
Add plugin UI slots for approval cards

### DIFF
--- a/doc/plugins/PLUGIN_AUTHORING_GUIDE.md
+++ b/doc/plugins/PLUGIN_AUTHORING_GUIDE.md
@@ -361,6 +361,8 @@ Mount surfaces currently wired in the host include:
 - `contextMenuItem`
 - `commentAnnotation`
 - `commentContextMenuItem`
+- `approvalCard`
+- `approvalPayloadField`
 
 ### `routeSidebar` and the app sidebar
 

--- a/doc/plugins/PLUGIN_SPEC.md
+++ b/doc/plugins/PLUGIN_SPEC.md
@@ -364,6 +364,8 @@ export interface PaperclipPluginManifestV1 {
         | "contextMenuItem"
         | "commentAnnotation"
         | "commentContextMenuItem"
+        | "approvalCard"
+        | "approvalPayloadField"
         | "settingsPage"
         | "companySettingsPage";
       id: string;
@@ -860,6 +862,7 @@ The host enforces capabilities in the SDK layer and refuses calls outside the gr
 - `ui.detailTab.register`
 - `ui.dashboardWidget.register`
 - `ui.commentAnnotation.register`
+- `ui.approval.register`
 - `ui.action.register`
 
 ## 15.2 Forbidden Capabilities
@@ -1123,6 +1126,15 @@ Recommended route pattern:
 ## 19.4 Dashboard Widgets
 
 Plugins may add cards or sections to the dashboard.
+
+## 19.4.1 Approval Slots
+
+Plugins may add rich, decision-local UI to approval cards:
+
+- `approvalCard` renders inside an approval decision card after the host-rendered payload summary.
+- `approvalPayloadField` renders after built-in approval payload fields for smaller payload-specific additions.
+
+Both slots receive `context.companyId` and `context.companyPrefix` when available, plus direct `approval` and `payload` props. Both require the `ui.approval.register` capability. These slots are render-only UI extension points; they do not grant approval-decision, budget-override, or auth-bypass authority.
 
 ## 19.5 Sidebar Entries
 

--- a/packages/plugins/sdk/README.md
+++ b/packages/plugins/sdk/README.md
@@ -218,6 +218,8 @@ Slot types describe where a component mounts. Most values also exist as launcher
 | `taskDetailView` | Entity | (task/issue context) |
 | `commentAnnotation` | Entity | `comment` |
 | `commentContextMenuItem` | Entity | `comment` |
+| `approvalCard` | Approval | — |
+| `approvalPayloadField` | Approval | — |
 | `projectSidebarItem` | Entity | `project` |
 | `toolbarButton` | Entity | varies by host surface |
 | `contextMenuItem` | Entity | varies by host surface |
@@ -285,6 +287,14 @@ A per-comment annotation region rendered below each individual comment in the is
 #### `commentContextMenuItem`
 
 A per-comment context menu item rendered in the "more" dropdown menu (⋮) on each comment in the issue detail timeline. Use this to add per-comment actions such as "Create sub-issue from comment", "Translate", "Flag for review", or custom plugin actions. Receives `PluginCommentContextMenuItemProps` with `context.entityId` set to the comment UUID, `context.entityType` set to `"comment"`, `context.parentEntityId` set to the parent issue UUID, `context.projectId` set to the issue's project (if any), and `context.companyPrefix` set to the active company slug. Plugins can open drawers, modals, or popovers scoped to that comment. The ⋮ menu button only appears on comments where at least one plugin renders visible content. Requires the `ui.action.register` capability.
+
+#### `approvalCard`
+
+An inline extension region rendered inside the approval decision card after the host-rendered payload summary. Use this for approval-specific rich sections such as typed artifact links, contextual checks, or compact decision-support UI. Receives `PluginApprovalCardProps` with `context.companyId` / `context.companyPrefix` plus direct `approval` and `payload` props. Requires the `ui.approval.register` capability.
+
+#### `approvalPayloadField`
+
+A smaller extension region rendered after the built-in approval payload fields. Use this when a plugin wants to add payload-specific fields while leaving the rest of the approval card unchanged. Receives `PluginApprovalPayloadFieldProps` with `context.companyId` / `context.companyPrefix` plus direct `approval` and `payload` props. Requires the `ui.approval.register` capability.
 
 ### Launcher actions and render options
 
@@ -372,6 +382,7 @@ Declare in `manifest.capabilities`. Grouped by scope:
 | | `ui.detailTab.register` |
 | | `ui.dashboardWidget.register` |
 | | `ui.commentAnnotation.register` |
+| | `ui.approval.register` |
 | | `ui.action.register` |
 
 Full list in code: import `PLUGIN_CAPABILITIES` from `@paperclipai/plugin-sdk`.
@@ -866,6 +877,8 @@ Each slot type receives a typed props object with `context: PluginHostContext`. 
 | `toolbarButton` | `PluginToolbarButtonProps` | `entityId: string`, `entityType: string` |
 | `commentAnnotation` | `PluginCommentAnnotationProps` | `entityId: string`, `entityType: "comment"`, `parentEntityId: string`, `projectId`, `companyPrefix` |
 | `commentContextMenuItem` | `PluginCommentContextMenuItemProps` | `entityId: string`, `entityType: "comment"`, `parentEntityId: string`, `projectId`, `companyPrefix` |
+| `approvalCard` | `PluginApprovalCardProps` | `approval`, `payload`, `companyPrefix` |
+| `approvalPayloadField` | `PluginApprovalPayloadFieldProps` | `approval`, `payload`, `companyPrefix` |
 | `projectSidebarItem` | `PluginProjectSidebarItemProps` | `entityId: string`, `entityType: "project"` |
 
 Example detail tab with entity context:

--- a/packages/plugins/sdk/src/ui/index.ts
+++ b/packages/plugins/sdk/src/ui/index.ts
@@ -154,5 +154,7 @@ export type {
   PluginProjectSidebarItemProps,
   PluginCommentAnnotationProps,
   PluginCommentContextMenuItemProps,
+  PluginApprovalCardProps,
+  PluginApprovalPayloadFieldProps,
   PluginSettingsPageProps,
 } from "./types.js";

--- a/packages/plugins/sdk/src/ui/types.ts
+++ b/packages/plugins/sdk/src/ui/types.ts
@@ -19,6 +19,7 @@ import type {
   MouseEvent as ReactMouseEvent,
 } from "react";
 import type {
+  Approval,
   PluginBridgeErrorCode,
   PluginLauncherBounds,
   PluginLauncherRenderEnvironment,
@@ -377,6 +378,35 @@ export interface PluginCommentContextMenuItemProps {
 export interface PluginSettingsPageProps {
   /** The current host context. */
   context: PluginHostContext;
+}
+
+/**
+ * Props passed to a plugin approval card component.
+ *
+ * An approval card slot is rendered inside an approval decision card after the
+ * host-rendered payload summary.
+ */
+export interface PluginApprovalCardProps {
+  /** The current host context, including company id and prefix when available. */
+  context: PluginHostContext;
+  /** The approval rendered by the host card. */
+  approval: Approval;
+  /** Convenience reference to `approval.payload`. */
+  payload: Record<string, unknown>;
+}
+
+/**
+ * Props passed to a plugin approval payload field component.
+ *
+ * This smaller slot renders after the built-in approval payload fields.
+ */
+export interface PluginApprovalPayloadFieldProps {
+  /** The current host context, including company id and prefix when available. */
+  context: PluginHostContext;
+  /** The approval rendered by the host card or detail page. */
+  approval: Approval;
+  /** Convenience reference to `approval.payload`. */
+  payload: Record<string, unknown>;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -971,6 +971,7 @@ export const PLUGIN_CAPABILITIES = [
   "ui.detailTab.register",
   "ui.dashboardWidget.register",
   "ui.commentAnnotation.register",
+  "ui.approval.register",
   "ui.action.register",
 ] as const;
 export type PluginCapability = (typeof PLUGIN_CAPABILITIES)[number];
@@ -1040,6 +1041,8 @@ export const PLUGIN_UI_SLOT_TYPES = [
   "contextMenuItem",
   "commentAnnotation",
   "commentContextMenuItem",
+  "approvalCard",
+  "approvalPayloadField",
   "settingsPage",
   "companySettingsPage",
 ] as const;

--- a/packages/shared/src/types/plugin.ts
+++ b/packages/shared/src/types/plugin.ts
@@ -376,7 +376,7 @@ export interface PluginManagedSkillResolution {
  * @see PLUGIN_SPEC.md §19 — UI Extension Model
  */
 export interface PluginUiSlotDeclaration {
-  /** The type of UI mount point (page, detailTab, taskDetailView, toolbarButton, etc.). */
+  /** The type of UI mount point (page, detailTab, approvalCard, toolbarButton, etc.). */
   type: PluginUiSlotType;
   /** Unique slot identifier within the plugin. */
   id: string;
@@ -387,6 +387,7 @@ export interface PluginUiSlotDeclaration {
   /**
    * Entity targets for context-sensitive slots.
    * Required for `detailTab`, `taskDetailView`, and `contextMenuItem`.
+   * Approval slots receive approval-specific props instead of `entityTypes`.
    */
   entityTypes?: PluginUiSlotEntityType[];
   /**

--- a/packages/shared/src/validators/plugin.test.ts
+++ b/packages/shared/src/validators/plugin.test.ts
@@ -245,4 +245,22 @@ describe("plugin UI slot validators", () => {
     if (parsed.success) return;
     expect(parsed.error.issues.some((issue) => issue.message.includes("reserved by the host"))).toBe(true);
   });
+
+  it("accepts approval slots without entity targeting", () => {
+    const cardSlot = pluginUiSlotDeclarationSchema.parse({
+      type: "approvalCard",
+      id: "artifact-links-card",
+      displayName: "Artifact Links",
+      exportName: "ArtifactLinksCard",
+    });
+    const payloadSlot = pluginUiSlotDeclarationSchema.parse({
+      type: "approvalPayloadField",
+      id: "artifact-links-field",
+      displayName: "Artifact Links",
+      exportName: "ArtifactLinksField",
+    });
+
+    expect(cardSlot.type).toBe("approvalCard");
+    expect(payloadSlot.type).toBe("approvalPayloadField");
+  });
 });

--- a/server/src/__tests__/plugin-approval-slots.test.ts
+++ b/server/src/__tests__/plugin-approval-slots.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import type { PaperclipPluginManifestV1 } from "@paperclipai/shared";
+import { pluginCapabilityValidator } from "../services/plugin-capability-validator.js";
+
+const manifest: PaperclipPluginManifestV1 = {
+  id: "test.approval-slots",
+  apiVersion: 1,
+  version: "1.0.0",
+  displayName: "Approval Slots",
+  description: "Test approval slot plugin",
+  author: "Paperclip",
+  categories: ["ui"],
+  capabilities: ["ui.approval.register"],
+  entrypoints: {
+    worker: "dist/worker.js",
+    ui: "dist/ui.js",
+  },
+  ui: {
+    slots: [
+      {
+        type: "approvalCard",
+        id: "approval-card",
+        displayName: "Approval Card",
+        exportName: "ApprovalCard",
+      },
+      {
+        type: "approvalPayloadField",
+        id: "approval-payload-field",
+        displayName: "Approval Payload Field",
+        exportName: "ApprovalPayloadField",
+      },
+    ],
+  },
+};
+
+describe("plugin approval UI slots", () => {
+  it("requires ui.approval.register for approval card and payload field slots", () => {
+    const validator = pluginCapabilityValidator();
+
+    expect(validator.getUiSlotCapability("approvalCard")).toBe("ui.approval.register");
+    expect(validator.getUiSlotCapability("approvalPayloadField")).toBe("ui.approval.register");
+    expect(validator.checkUiSlot(manifest, "approvalCard")).toMatchObject({ allowed: true });
+    expect(validator.checkUiSlot(manifest, "approvalPayloadField")).toMatchObject({ allowed: true });
+
+    const withoutCapability = {
+      ...manifest,
+      capabilities: ["ui.detailTab.register"],
+    } satisfies PaperclipPluginManifestV1;
+
+    expect(validator.checkUiSlot(withoutCapability, "approvalCard")).toMatchObject({
+      allowed: false,
+      missing: ["ui.approval.register"],
+    });
+    expect(validator.validateManifestCapabilities(withoutCapability)).toMatchObject({
+      allowed: false,
+      missing: ["ui.approval.register"],
+    });
+  });
+});

--- a/server/src/services/plugin-capability-validator.ts
+++ b/server/src/services/plugin-capability-validator.ts
@@ -157,6 +157,8 @@ const UI_SLOT_CAPABILITIES: Record<PluginUiSlotType, PluginCapability> = {
   contextMenuItem: "ui.action.register",
   commentAnnotation: "ui.commentAnnotation.register",
   commentContextMenuItem: "ui.action.register",
+  approvalCard: "ui.approval.register",
+  approvalPayloadField: "ui.approval.register",
   settingsPage: "instance.settings.register",
   companySettingsPage: "instance.settings.register",
   routeSidebar: "ui.sidebar.register",

--- a/ui/src/components/ApprovalCard.test.tsx
+++ b/ui/src/components/ApprovalCard.test.tsx
@@ -1,0 +1,87 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import type { Approval } from "@paperclipai/shared";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ApprovalCard } from "./ApprovalCard";
+
+const mockPluginSlotOutlet = vi.hoisted(() => vi.fn(() => null));
+
+vi.mock("@/plugins/slots", () => ({
+  PluginSlotOutlet: mockPluginSlotOutlet,
+}));
+
+type PluginSlotOutletMockProps = {
+  slotTypes: string[];
+  context: Record<string, unknown>;
+  componentProps: Record<string, unknown>;
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+describe("ApprovalCard", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    mockPluginSlotOutlet.mockClear();
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  it("mounts approvalCard slots with approval and payload props", () => {
+    const payload = {
+      title: "Open deployment deck",
+      summary: "Review typed artifact links before deciding.",
+    };
+    const approval: Approval = {
+      id: "approval-1",
+      companyId: "company-1",
+      type: "request_board_approval",
+      requestedByAgentId: "agent-1",
+      requestedByUserId: null,
+      status: "pending",
+      payload,
+      decisionNote: null,
+      decidedByUserId: null,
+      decidedAt: null,
+      createdAt: new Date("2026-07-03T10:00:00.000Z"),
+      updatedAt: new Date("2026-07-03T10:00:00.000Z"),
+    };
+
+    act(() => {
+      root.render(
+        <ApprovalCard
+          approval={approval}
+          requesterAgent={null}
+          companyPrefix="PAP"
+        />,
+      );
+    });
+
+    const outletCalls = mockPluginSlotOutlet.mock.calls as unknown as Array<[PluginSlotOutletMockProps]>;
+    const cardSlotProps = outletCalls
+      .map(([props]) => props)
+      .find((props) => props.slotTypes.includes("approvalCard"));
+
+    expect(cardSlotProps).toBeDefined();
+    expect(cardSlotProps?.context).toMatchObject({
+      companyId: "company-1",
+      companyPrefix: "PAP",
+    });
+    expect(cardSlotProps?.componentProps).toMatchObject({
+      approval,
+      payload,
+    });
+  });
+});

--- a/ui/src/components/ApprovalCard.tsx
+++ b/ui/src/components/ApprovalCard.tsx
@@ -12,6 +12,7 @@ import {
 } from "./ApprovalPayload";
 import { timeAgo } from "../lib/timeAgo";
 import type { Approval, Agent } from "@paperclipai/shared";
+import { PluginSlotOutlet } from "@/plugins/slots";
 import { cn } from "@/lib/utils";
 
 function statusIcon(status: string) {
@@ -31,6 +32,7 @@ export function ApprovalCard({
   detailLink,
   isPending = false,
   pendingAction = null,
+  companyPrefix = null,
 }: {
   approval: Approval;
   requesterAgent: Agent | null;
@@ -40,8 +42,9 @@ export function ApprovalCard({
   detailLink?: string;
   isPending?: boolean;
   pendingAction?: "approve" | "reject" | null;
+  companyPrefix?: string | null;
 }) {
-  const payload = approval.payload as Record<string, unknown> | null;
+  const payload = approval.payload as Record<string, unknown>;
   const Icon = typeIcon[approval.type] ?? defaultTypeIcon;
   const kindLabel = typeLabel[approval.type] ?? approval.type;
   const subject = approvalSubject(payload);
@@ -96,10 +99,22 @@ export function ApprovalCard({
       <div className="mt-4 border-t border-border/60 pt-4">
         <ApprovalPayloadRenderer
           type={approval.type}
-          payload={approval.payload}
+          payload={payload}
           hidePrimaryTitle={Boolean(subject)}
+          approval={approval}
+          companyPrefix={companyPrefix}
         />
       </div>
+
+      <PluginSlotOutlet
+        slotTypes={["approvalCard"]}
+        context={{
+          companyId: approval.companyId,
+          companyPrefix,
+        }}
+        componentProps={{ approval, payload }}
+        className="mt-4 space-y-3"
+      />
 
       {approval.decisionNote && (
         <div className="mt-4 rounded-lg border border-border/60 bg-muted/30 px-3.5 py-3 text-xs leading-5 text-muted-foreground">

--- a/ui/src/components/ApprovalPayload.test.tsx
+++ b/ui/src/components/ApprovalPayload.test.tsx
@@ -2,8 +2,21 @@
 
 import { act } from "react";
 import { createRoot } from "react-dom/client";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { Approval } from "@paperclipai/shared";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ApprovalPayloadRenderer, approvalLabel } from "./ApprovalPayload";
+
+const mockPluginSlotOutlet = vi.hoisted(() => vi.fn(() => null));
+
+vi.mock("@/plugins/slots", () => ({
+  PluginSlotOutlet: mockPluginSlotOutlet,
+}));
+
+type PluginSlotOutletMockProps = {
+  slotTypes: string[];
+  context: Record<string, unknown>;
+  componentProps: Record<string, unknown>;
+};
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
@@ -24,6 +37,7 @@ describe("ApprovalPayloadRenderer", () => {
   beforeEach(() => {
     container = document.createElement("div");
     document.body.appendChild(container);
+    mockPluginSlotOutlet.mockClear();
   });
 
   afterEach(() => {
@@ -80,6 +94,58 @@ describe("ApprovalPayloadRenderer", () => {
 
     expect(container.textContent).toContain("Board asked for approval before posting the frog.");
     expect(container.textContent).not.toContain("TitleReply with an ASCII frog");
+
+    act(() => {
+      root.unmount();
+    });
+  });
+
+  it("mounts approvalPayloadField slots with approval and payload props", () => {
+    const root = createRoot(container);
+    const payload = {
+      title: "Open deployment deck",
+      summary: "Review typed artifact links before deciding.",
+    };
+    const approval: Approval = {
+      id: "approval-1",
+      companyId: "company-1",
+      type: "request_board_approval",
+      requestedByAgentId: "agent-1",
+      requestedByUserId: null,
+      status: "pending",
+      payload,
+      decisionNote: null,
+      decidedByUserId: null,
+      decidedAt: null,
+      createdAt: new Date("2026-07-03T10:00:00.000Z"),
+      updatedAt: new Date("2026-07-03T10:00:00.000Z"),
+    };
+
+    act(() => {
+      root.render(
+        <ApprovalPayloadRenderer
+          type="request_board_approval"
+          payload={payload}
+          approval={approval}
+          companyPrefix="PAP"
+        />,
+      );
+    });
+
+    const outletCalls = mockPluginSlotOutlet.mock.calls as unknown as Array<[PluginSlotOutletMockProps]>;
+    const payloadSlotProps = outletCalls
+      .map(([props]) => props)
+      .find((props) => props.slotTypes.includes("approvalPayloadField"));
+
+    expect(payloadSlotProps).toBeDefined();
+    expect(payloadSlotProps?.context).toMatchObject({
+      companyId: "company-1",
+      companyPrefix: "PAP",
+    });
+    expect(payloadSlotProps?.componentProps).toMatchObject({
+      approval,
+      payload,
+    });
 
     act(() => {
       root.unmount();

--- a/ui/src/components/ApprovalPayload.tsx
+++ b/ui/src/components/ApprovalPayload.tsx
@@ -1,4 +1,6 @@
 import { UserPlus, Lightbulb, ShieldAlert, ShieldCheck } from "lucide-react";
+import type { Approval } from "@paperclipai/shared";
+import { PluginSlotOutlet } from "@/plugins/slots";
 import { formatCents } from "../lib/utils";
 
 export const typeLabel: Record<string, string> = {
@@ -233,15 +235,38 @@ export function ApprovalPayloadRenderer({
   type,
   payload,
   hidePrimaryTitle = false,
+  approval,
+  companyPrefix = null,
 }: {
   type: string;
   payload: Record<string, unknown>;
   hidePrimaryTitle?: boolean;
+  approval?: Approval | null;
+  companyPrefix?: string | null;
 }) {
-  if (type === "hire_agent") return <HireAgentPayload payload={payload} />;
-  if (type === "budget_override_required") return <BudgetOverridePayload payload={payload} />;
-  if (type === "request_board_approval") {
-    return <BoardApprovalPayload payload={payload} hideTitle={hidePrimaryTitle} />;
-  }
-  return <CeoStrategyPayload payload={payload} />;
+  const builtInPayload = (() => {
+    if (type === "hire_agent") return <HireAgentPayload payload={payload} />;
+    if (type === "budget_override_required") return <BudgetOverridePayload payload={payload} />;
+    if (type === "request_board_approval") {
+      return <BoardApprovalPayload payload={payload} hideTitle={hidePrimaryTitle} />;
+    }
+    return <CeoStrategyPayload payload={payload} />;
+  })();
+
+  return (
+    <>
+      {builtInPayload}
+      {approval ? (
+        <PluginSlotOutlet
+          slotTypes={["approvalPayloadField"]}
+          context={{
+            companyId: approval.companyId,
+            companyPrefix,
+          }}
+          componentProps={{ approval, payload }}
+          className="mt-3 space-y-3"
+        />
+      ) : null}
+    </>
+  );
 }

--- a/ui/src/components/CommentThread.tsx
+++ b/ui/src/components/CommentThread.tsx
@@ -76,6 +76,7 @@ interface CommentThreadProps {
   linkedRuns?: LinkedRunItem[];
   timelineEvents?: IssueTimelineEvent[];
   companyId?: string | null;
+  companyPrefix?: string | null;
   projectId?: string | null;
   onApproveApproval?: (approvalId: string) => Promise<void>;
   onRejectApproval?: (approvalId: string) => Promise<void>;
@@ -568,6 +569,7 @@ const TimelineList = memo(function TimelineList({
   agentMap,
   currentUserId,
   companyId,
+  companyPrefix,
   projectId,
   onApproveApproval,
   onRejectApproval,
@@ -584,6 +586,7 @@ const TimelineList = memo(function TimelineList({
   agentMap?: Map<string, Agent>;
   currentUserId?: string | null;
   companyId?: string | null;
+  companyPrefix?: string | null;
   projectId?: string | null;
   onApproveApproval?: (approvalId: string) => Promise<void>;
   onRejectApproval?: (approvalId: string) => Promise<void>;
@@ -634,6 +637,7 @@ const TimelineList = memo(function TimelineList({
                 detailLink={`/approvals/${approval.id}`}
                 isPending={isPending}
                 pendingAction={isPending ? pendingApprovalAction?.action ?? null : null}
+                companyPrefix={companyPrefix ?? null}
               />
             </div>
           );
@@ -741,6 +745,7 @@ export function CommentThread({
   linkedRuns = [],
   timelineEvents = [],
   companyId,
+  companyPrefix,
   projectId,
   onApproveApproval,
   onRejectApproval,
@@ -971,6 +976,7 @@ export function CommentThread({
         agentMap={agentMap}
         currentUserId={currentUserId}
         companyId={companyId}
+        companyPrefix={companyPrefix}
         projectId={projectId}
         onApproveApproval={onApproveApproval}
         onRejectApproval={onRejectApproval}

--- a/ui/src/pages/ApprovalDetail.test.tsx
+++ b/ui/src/pages/ApprovalDetail.test.tsx
@@ -1,0 +1,200 @@
+// @vitest-environment jsdom
+
+import type { ComponentProps } from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { Approval } from "@paperclipai/shared";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ApprovalDetail } from "./ApprovalDetail";
+
+const mockApprovalsApi = vi.hoisted(() => ({
+  get: vi.fn(),
+  listComments: vi.fn(),
+  listIssues: vi.fn(),
+  addComment: vi.fn(),
+  approve: vi.fn(),
+  reject: vi.fn(),
+  requestRevision: vi.fn(),
+  resubmit: vi.fn(),
+}));
+const mockAgentsApi = vi.hoisted(() => ({
+  list: vi.fn(),
+  remove: vi.fn(),
+}));
+const mockSetBreadcrumbs = vi.hoisted(() => vi.fn());
+const mockSetSelectedCompanyId = vi.hoisted(() => vi.fn());
+const mockNavigate = vi.hoisted(() => vi.fn());
+const mockPluginSlotOutlet = vi.hoisted(() => vi.fn());
+
+vi.mock("../api/approvals", () => ({ approvalsApi: mockApprovalsApi }));
+vi.mock("../api/agents", () => ({ agentsApi: mockAgentsApi }));
+vi.mock("../context/CompanyContext", () => ({
+  useCompany: () => ({
+    selectedCompanyId: "company-1",
+    selectedCompany: { id: "company-1", issuePrefix: "EDE" },
+    setSelectedCompanyId: mockSetSelectedCompanyId,
+  }),
+}));
+vi.mock("../context/BreadcrumbContext", () => ({
+  useBreadcrumbs: () => ({ setBreadcrumbs: mockSetBreadcrumbs }),
+}));
+vi.mock("@/lib/router", () => ({
+  Link: ({ children, to, ...props }: ComponentProps<"a"> & { to: string }) => (
+    <a href={to} {...props}>
+      {children}
+    </a>
+  ),
+  useNavigate: () => mockNavigate,
+  useParams: () => ({ approvalId: "approval-1" }),
+  useSearchParams: () => [new URLSearchParams(), vi.fn()],
+}));
+vi.mock("@/plugins/slots", () => ({
+  PluginSlotOutlet: (props: {
+    slotTypes: string[];
+    context: Record<string, unknown>;
+    componentProps?: {
+      approval?: Approval;
+      payload?: Record<string, unknown>;
+    };
+  }) => {
+    mockPluginSlotOutlet(props);
+    if (!props.slotTypes.includes("approvalCard")) return null;
+
+    const summary = props.componentProps?.payload?.summary;
+    const firstLine = typeof summary === "string" ? summary.split(/\r?\n/, 1)[0].trim() : "";
+    if (!/^https?:\/\//.test(firstLine)) return null;
+
+    return (
+      <section aria-label="Rendered approval deck">
+        <a href={firstLine} target="_blank" rel="noreferrer">
+          Open source
+        </a>
+        <iframe title="Approval deck" srcDoc="<h1>Approval deck</h1>" />
+      </section>
+    );
+  },
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+function approvalWithPayload(payload: Record<string, unknown>): Approval {
+  return {
+    id: "approval-1",
+    companyId: "company-1",
+    type: "request_board_approval",
+    requestedByAgentId: "agent-1",
+    requestedByUserId: null,
+    status: "pending",
+    payload,
+    decisionNote: null,
+    decidedByUserId: null,
+    decidedAt: null,
+    createdAt: new Date("2026-07-03T10:00:00.000Z"),
+    updatedAt: new Date("2026-07-03T10:00:00.000Z"),
+  };
+}
+
+async function flushQueries() {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+}
+
+describe("ApprovalDetail", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+
+    mockApprovalsApi.get.mockReset();
+    mockApprovalsApi.listComments.mockResolvedValue([]);
+    mockApprovalsApi.listIssues.mockResolvedValue([]);
+    mockAgentsApi.list.mockResolvedValue([{ id: "agent-1", name: "Codex" }]);
+    mockPluginSlotOutlet.mockClear();
+    mockSetBreadcrumbs.mockClear();
+    mockSetSelectedCompanyId.mockClear();
+    mockNavigate.mockClear();
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    queryClient.clear();
+    container.remove();
+  });
+
+  async function renderDetail(approval: Approval) {
+    mockApprovalsApi.get.mockResolvedValue(approval);
+
+    act(() => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <ApprovalDetail />
+        </QueryClientProvider>,
+      );
+    });
+    await flushQueries();
+  }
+
+  it("renders deck URL first-line approvalCard slots inline on the detail page", async () => {
+    const deckUrl = "http://127.0.0.1:3199/api/attachments/deck/content";
+    const approval = approvalWithPayload({
+      title: "Review approval deck",
+      summary: `${deckUrl}\nOwner should see this deck inline before deciding.`,
+    });
+
+    await renderDetail(approval);
+
+    const deck = container.querySelector("section[aria-label='Rendered approval deck']");
+    expect(deck?.textContent).toContain("Open source");
+    expect(container.querySelector("iframe[title='Approval deck']")).not.toBeNull();
+    expect(container.querySelector<HTMLAnchorElement>("section[aria-label='Rendered approval deck'] a")?.href).toBe(deckUrl);
+
+    const outletCalls = mockPluginSlotOutlet.mock.calls as unknown as Array<[
+      {
+        slotTypes: string[];
+        context: Record<string, unknown>;
+        componentProps: Record<string, unknown>;
+      },
+    ]>;
+    const detailApprovalSlot = outletCalls
+      .map(([props]) => props)
+      .find((props) => props.slotTypes.includes("approvalCard"));
+
+    expect(detailApprovalSlot).toBeDefined();
+    expect(detailApprovalSlot?.context).toMatchObject({
+      companyId: "company-1",
+      companyPrefix: "EDE",
+    });
+    expect(detailApprovalSlot?.componentProps).toMatchObject({
+      approval,
+      payload: approval.payload,
+    });
+  });
+
+  it("renders nothing for non-deck approval payloads on the detail page", async () => {
+    await renderDetail(
+      approvalWithPayload({
+        title: "Plain approval",
+        summary: "Approve this request without a deck URL.",
+      }),
+    );
+
+    expect(container.querySelector("section[aria-label='Rendered approval deck']")).toBeNull();
+    expect(container.querySelector("iframe[title='Approval deck']")).toBeNull();
+  });
+});

--- a/ui/src/pages/ApprovalDetail.tsx
+++ b/ui/src/pages/ApprovalDetail.tsx
@@ -18,7 +18,7 @@ import { MarkdownBody } from "../components/MarkdownBody";
 
 export function ApprovalDetail() {
   const { approvalId } = useParams<{ approvalId: string }>();
-  const { selectedCompanyId, setSelectedCompanyId } = useCompany();
+  const { selectedCompanyId, selectedCompany, setSelectedCompanyId } = useCompany();
   const { setBreadcrumbs } = useBreadcrumbs();
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
@@ -219,7 +219,12 @@ export function ApprovalDetail() {
               />
             </div>
           )}
-          <ApprovalPayloadRenderer type={approval.type} payload={payload} />
+          <ApprovalPayloadRenderer
+            type={approval.type}
+            payload={payload}
+            approval={approval}
+            companyPrefix={selectedCompany?.issuePrefix ?? null}
+          />
           <button
             type="button"
             className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors mt-2"

--- a/ui/src/pages/ApprovalDetail.tsx
+++ b/ui/src/pages/ApprovalDetail.tsx
@@ -15,6 +15,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { CheckCircle2, ChevronRight, Sparkles } from "lucide-react";
 import type { ApprovalComment } from "@paperclipai/shared";
 import { MarkdownBody } from "../components/MarkdownBody";
+import { PluginSlotOutlet } from "@/plugins/slots";
 
 export function ApprovalDetail() {
   const { approvalId } = useParams<{ approvalId: string }>();
@@ -224,6 +225,15 @@ export function ApprovalDetail() {
             payload={payload}
             approval={approval}
             companyPrefix={selectedCompany?.issuePrefix ?? null}
+          />
+          <PluginSlotOutlet
+            slotTypes={["approvalCard"]}
+            context={{
+              companyId: approval.companyId,
+              companyPrefix: selectedCompany?.issuePrefix ?? null,
+            }}
+            componentProps={{ approval, payload }}
+            className="mt-3 space-y-3"
           />
           <button
             type="button"

--- a/ui/src/pages/Approvals.tsx
+++ b/ui/src/pages/Approvals.tsx
@@ -16,7 +16,7 @@ import { PageSkeleton } from "../components/PageSkeleton";
 type StatusFilter = "pending" | "all";
 
 export function Approvals() {
-  const { selectedCompanyId } = useCompany();
+  const { selectedCompanyId, selectedCompany } = useCompany();
   const { setBreadcrumbs } = useBreadcrumbs();
   const queryClient = useQueryClient();
   const navigate = useNavigate();
@@ -126,6 +126,7 @@ export function Approvals() {
               pendingAction={
                 approveMutation.isPending ? "approve" : rejectMutation.isPending ? "reject" : null
               }
+              companyPrefix={selectedCompany?.issuePrefix ?? null}
             />
           ))}
         </div>

--- a/ui/src/pages/IssueDetail.tsx
+++ b/ui/src/pages/IssueDetail.tsx
@@ -1054,6 +1054,7 @@ type IssueDetailActivityTabProps = {
   issue: Issue;
   issueId: string;
   companyId: string;
+  companyPrefix?: string | null;
   issueStatus: Issue["status"];
   childIssues: Issue[];
   agentMap: Map<string, Agent>;
@@ -1072,6 +1073,7 @@ function IssueDetailActivityTab({
   issue,
   issueId,
   companyId,
+  companyPrefix,
   issueStatus,
   childIssues,
   agentMap,
@@ -1306,6 +1308,7 @@ function IssueDetailActivityTab({
                   ? pendingApprovalAction.action
                   : null
               }
+              companyPrefix={companyPrefix ?? null}
             />
           ))}
         </div>
@@ -1322,7 +1325,7 @@ function IssueDetailActivityTab({
 
 export function IssueDetail() {
   const { issueId } = useParams<{ issueId: string }>();
-  const { selectedCompanyId } = useCompany();
+  const { selectedCompanyId, selectedCompany } = useCompany();
   const { openNewIssue } = useDialogActions();
   const { openPanel, closePanel, panelVisible, setPanelVisible } = usePanel();
   const { setBreadcrumbs, setMobileToolbar } = useBreadcrumbs();
@@ -4362,6 +4365,7 @@ export function IssueDetail() {
               issue={issue}
               issueId={issue.id}
               companyId={issue.companyId}
+              companyPrefix={selectedCompany?.issuePrefix ?? null}
               issueStatus={issue.status}
               childIssues={childIssues}
               agentMap={agentMap}

--- a/ui/src/plugins/slots.test.ts
+++ b/ui/src/plugins/slots.test.ts
@@ -3,11 +3,13 @@
 import { createElement } from "react";
 import { flushSync } from "react-dom";
 import { createRoot, type Root } from "react-dom/client";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   PluginSlotMount,
   _collectRegisterableExportNamesForTests,
   _resetPluginModuleLoader,
+  registerPluginReactComponent,
   registerPluginWebComponent,
   type ResolvedPluginSlot,
 } from "./slots";
@@ -83,5 +85,44 @@ describe("plugin slot export registration", () => {
 
     expect(container.textContent).not.toContain("Content Machine: Content");
     expect(container.querySelector("paperclip-test-sidebar")).not.toBeNull();
+  });
+
+  it("forwards host-provided component props to React slot components", () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    const queryClient = new QueryClient();
+    roots.push(root);
+    const payload = { title: "Open deployment deck" };
+    const slot: ResolvedPluginSlot = {
+      type: "approvalCard",
+      id: "approval-card",
+      displayName: "Approval Card",
+      exportName: "ApprovalCard",
+      pluginId: "approval-plugin",
+      pluginKey: "approval-plugin",
+      pluginDisplayName: "Approval Plugin",
+      pluginVersion: "1.0.0",
+    };
+
+    registerPluginReactComponent("approval-plugin", "ApprovalCard", ({ payload: receivedPayload }) => (
+      createElement("div", null, (receivedPayload as typeof payload).title)
+    ));
+
+    flushSync(() => {
+      root.render(
+        createElement(
+          QueryClientProvider,
+          { client: queryClient },
+          createElement(PluginSlotMount, {
+            slot,
+            context: { companyId: "company-1", companyPrefix: "PAP" },
+            componentProps: { payload },
+          }),
+        ),
+      );
+    });
+
+    expect(container.textContent).toContain("Open deployment deck");
   });
 });

--- a/ui/src/plugins/slots.tsx
+++ b/ui/src/plugins/slots.tsx
@@ -94,6 +94,7 @@ export function resolveRouteSidebarSlot(
 type PluginSlotComponentProps = {
   slot: ResolvedPluginSlot;
   context: PluginSlotContext;
+  [key: string]: unknown;
 };
 
 export type RegisteredPluginComponent =
@@ -736,11 +737,13 @@ function PluginWebComponentMount({
   slot,
   context,
   className,
+  componentProps,
 }: {
   tagName: string;
   slot: ResolvedPluginSlot;
   context: PluginSlotContext;
   className?: string;
+  componentProps?: Record<string, unknown>;
 }) {
   const ref = useRef<HTMLElement | null>(null);
 
@@ -750,10 +753,12 @@ function PluginWebComponentMount({
     const el = ref.current as HTMLElement & {
       pluginSlot?: ResolvedPluginSlot;
       pluginContext?: PluginSlotContext;
+      pluginProps?: Record<string, unknown>;
     };
     el.pluginSlot = slot;
     el.pluginContext = context;
-  }, [context, slot]);
+    el.pluginProps = componentProps ?? {};
+  }, [componentProps, context, slot]);
 
   return createElement(tagName, { ref, className });
 }
@@ -763,6 +768,7 @@ type PluginSlotMountProps = {
   context: PluginSlotContext;
   className?: string;
   missingBehavior?: "hidden" | "placeholder";
+  componentProps?: Record<string, unknown>;
 };
 
 /**
@@ -822,6 +828,7 @@ export function PluginSlotMount({
   context,
   className,
   missingBehavior = "hidden",
+  componentProps,
 }: PluginSlotMountProps) {
   usePluginRegistrySubscription();
   const [, forceRerender] = useState(0);
@@ -854,7 +861,7 @@ export function PluginSlotMount({
   }
 
   if (component.kind === "react") {
-    const node = createElement(component.component, { slot, context });
+    const node = createElement(component.component, { slot, context, ...(componentProps ?? {}) });
     return (
       <PluginSlotErrorBoundary slot={slot} className={className}>
         <PluginBridgeScope pluginId={slot.pluginId} context={context}>
@@ -871,6 +878,7 @@ export function PluginSlotMount({
         slot={slot}
         context={context}
         className={className}
+        componentProps={componentProps}
       />
     </PluginSlotErrorBoundary>
   );
@@ -884,6 +892,7 @@ type PluginSlotOutletProps = {
   itemClassName?: string;
   errorClassName?: string;
   missingBehavior?: "hidden" | "placeholder";
+  componentProps?: Record<string, unknown>;
 };
 
 export function PluginSlotOutlet({
@@ -894,6 +903,7 @@ export function PluginSlotOutlet({
   itemClassName,
   errorClassName,
   missingBehavior = "hidden",
+  componentProps,
 }: PluginSlotOutletProps) {
   const { slots, errorMessage } = usePluginSlots({
     slotTypes,
@@ -920,6 +930,7 @@ export function PluginSlotOutlet({
           context={context}
           className={itemClassName}
           missingBehavior={missingBehavior}
+          componentProps={componentProps}
         />
       ))}
     </div>


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Approval cards are where board/users make governed decisions.
> - The plugin system already supports rich UI slots on pages, sidebars, detail surfaces, toolbar actions, and comments.
> - Approval cards do not currently expose a plugin slot, so plugins cannot render decision-local context without core one-offs.
> - This pull request adds generic approval-card and approval-payload-field slots with explicit approval props and a narrow capability.
> - The benefit is a reusable extension point for rich approval context while keeping artifact-specific rendering outside core.

## Linked Issues or Issue Description

Closes #9079

Related public upstream PRs:

- https://github.com/paperclipai/paperclip/pull/3511
- https://github.com/paperclipai/paperclip/pull/3524

Those PRs build reviewed-artifact persistence and a reusable reviewed-assets panel. This PR is a separate plugin-slot extension point and does not implement reviewed-artifact rendering.

Problem description: approval cards are the decision surface for review, but core currently renders only built-in approval payload fields. Plugins can add pages, sidebars, detail tabs, task detail views, toolbar buttons, and comment annotations, but cannot add decision-local UI to an approval card. That leaves plugin-owned review material, typed artifact links, and rich approval context with two weak options: overload approval payload text/JSON, or add one-off core rendering for each use case.

## What Changed

- Added `approvalCard` and `approvalPayloadField` to plugin UI slot constants and manifest validation.
- Added `ui.approval.register` and server-side capability enforcement for approval slots.
- Added generic `componentProps` forwarding in plugin slot mounts so host surfaces can pass slot-specific props.
- Mounted approval slots in the approval card, the approval detail page, and the payload renderer with direct `{ approval, payload }` props.
- Added SDK UI prop types and documentation for plugin authors.
- Added focused shared/server/UI tests.

## Verification

- `cd ui && pnpm exec vitest run src/components/ApprovalCard.test.tsx src/components/ApprovalPayload.test.tsx src/pages/ApprovalDetail.test.tsx src/plugins/slots.test.ts`
- `cd server && pnpm exec vitest run src/__tests__/plugin-approval-slots.test.ts`
- `cd packages/shared && pnpm exec vitest run src/validators/plugin.test.ts`

## Risks

Low-to-moderate. This introduces a new plugin UI surface and capability, but the slot is render-only and follows existing plugin loading/error-boundary behavior. Existing approval rendering remains unchanged when no plugin registers these slots.

Additional reviewer notes:

- Detail-page mount: `approvalCard` is mounted on the full approval detail page (`ui/src/pages/ApprovalDetail.tsx`) so users landing on `/approvals/{id}` can see approval-card plugin content.
- Plugin bundle load failures: plugin UI module fetch failures already throw from the plugin module loader, and render-time failures are contained by `PluginSlotErrorBoundary`; missing or unpublished plugin bundles should not be treated as production-ready installs.
- Slot placement: `approvalCard` is not added to the approvals list default tab; it is mounted in approval-card/detail surfaces, while `approvalPayloadField` remains available where the built-in payload renderer emits fields.

## Model Used

OpenAI Codex based on GPT-5, running as a local coding agent with shell, test, git, and GitHub CLI tool use. Exact runtime model ID and context window were not exposed by the adapter.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

