### PR TITLE
fix(config): log invalid config.json instead of silently falling back (#8908)

### DIFF
--- a/server/src/__tests__/config-file.test.ts
+++ b/server/src/__tests__/config-file.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+/**
+ * Regression test for https://github.com/paperclipai/paperclip/issues/8908
+ *
+ * When an instance config.json fails schema validation, readConfigFile()
+ * used to swallow the Zod error in an empty `catch {}` and silently boot with
+ * all defaults — while the startup banner still printed the ignored config
+ * path, making the failure very hard to trace. It must now (a) still fall back
+ * to defaults (return null) and (b) log a WARN naming the offending field so
+ * operators can diagnose it.
+ */
+
+const mockResolvePath = vi.hoisted(() => vi.fn());
+const mockReadFileSync = vi.hoisted(() => vi.fn());
+
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  return { ...actual, default: { ...actual, existsSync: () => true, readFileSync: mockReadFileSync }, existsSync: () => true, readFileSync: mockReadFileSync };
+});
+vi.mock("../paths.js", () => ({ resolvePaperclipConfigPath: mockResolvePath }));
+
+import { readConfigFile } from "../config-file.ts";
+
+describe("readConfigFile invalid-config diagnostics (#8908)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns null and WARNs with the offending field path on schema failure", () => {
+    // Unique path per test so the warn-once cache doesn't suppress this call.
+    mockResolvePath.mockReturnValue("/tmp/pc-test-schema.json");
+    mockReadFileSync.mockReturnValue(
+      JSON.stringify({
+        $meta: { version: 1, updatedAt: "2026-07-03T01:12:00.000Z", source: "provisioned-by-script" },
+        server: { deploymentMode: "local_trusted", port: 3112 },
+      }),
+    );
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    expect(readConfigFile()).toBeNull();
+    expect(warn).toHaveBeenCalledTimes(1);
+    const msg = warn.mock.calls[0][0] as string;
+    expect(msg).toContain("/tmp/pc-test-schema.json");
+    expect(msg).toContain("$meta.source");
+  });
+
+  it("returns null and WARNs on invalid JSON", () => {
+    mockResolvePath.mockReturnValue("/tmp/pc-test-json.json");
+    mockReadFileSync.mockReturnValue("{ not json ");
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    expect(readConfigFile()).toBeNull();
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][0]).toContain("invalid JSON");
+  });
+});

--- a/server/src/config-file.ts
+++ b/server/src/config-file.ts
@@ -1,16 +1,45 @@
 import fs from "node:fs";
 import { paperclipConfigSchema, type PaperclipConfig } from "@paperclipai/shared";
+import { ZodError } from "zod";
 import { resolvePaperclipConfigPath } from "./paths.js";
+
+// ponytail: warn once per path per process. readConfigFile is called repeatedly
+// (config load, logger init, model listing) — a persistently-invalid file must
+// not spam the log on every call.
+const warnedPaths = new Set<string>();
+
+function warnConfigIgnored(configPath: string, reason: string): void {
+  if (warnedPaths.has(configPath)) return;
+  warnedPaths.add(configPath);
+  console.warn(
+    `[paperclip] Ignoring config at ${configPath}: ${reason}. Booting with defaults.`,
+  );
+}
 
 export function readConfigFile(): PaperclipConfig | null {
   const configPath = resolvePaperclipConfigPath();
 
   if (!fs.existsSync(configPath)) return null;
 
+  let raw: unknown;
   try {
-    const raw = JSON.parse(fs.readFileSync(configPath, "utf-8"));
+    raw = JSON.parse(fs.readFileSync(configPath, "utf-8"));
+  } catch (err) {
+    warnConfigIgnored(configPath, `invalid JSON (${(err as Error).message})`);
+    return null;
+  }
+
+  try {
     return paperclipConfigSchema.parse(raw);
-  } catch {
+  } catch (err) {
+    if (err instanceof ZodError) {
+      const detail = err.issues
+        .map((issue) => `${issue.path.join(".") || "<root>"}: ${issue.message}`)
+        .join("; ");
+      warnConfigIgnored(configPath, `failed schema validation (${detail})`);
+    } else {
+      warnConfigIgnored(configPath, (err as Error).message);
+    }
     return null;
   }
 }


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Each instance is configured by a `config.json` (deployment mode, port, database, logging) that the server loads at startup via `readConfigFile()`
> - When that file fails JSON parsing or schema validation, `readConfigFile()` wrapped `paperclipConfigSchema.parse()` in an empty `catch {}` and returned `null` — so the **entire** file was discarded and the server booted with all defaults
> - The failure was silent: nothing was logged, yet the startup banner still printed the ignored config path, so operators saw "Config: <path>" while the file was in fact being ignored — a single bad field (e.g. a free-text `$meta.source`, which is a closed enum) invalidated the whole document and looked like a rogue/mis-booted instance
> - This PR makes the fallback loud: it logs a WARN naming the config path and the offending field(s), then falls back to defaults as before
> - The benefit is that invalid-config boots are diagnosable in seconds instead of costing an operator a long trace

## Linked Issues or Issue Description

Fixes: #8908

## What Changed

- `server/src/config-file.ts`: split JSON-parse and schema-validation into separate `try` blocks. On failure, log `[paperclip] Ignoring config at <path>: <reason>. Booting with defaults.` where `<reason>` is the JSON parse error, or — for a `ZodError` — the `path: message` of each issue (so `$meta.source` and similar point straight at the bad field). Still returns `null` (defaults) on failure, so boot behavior is unchanged.
- Warning is deduped once per config path per process, because `readConfigFile()` is called repeatedly (config load, logger init, model listing) and a persistently-invalid file must not spam the log.
- `server/src/__tests__/config-file.test.ts`: new regression test — invalid schema (the exact repro config from #8908) returns `null` and WARNs naming `$meta.source`; invalid JSON returns `null` and WARNs `invalid JSON`.

## Verification

```bash
pnpm --filter @paperclipai/server exec vitest run src/__tests__/config-file.test.ts   # 2 passed
pnpm --filter @paperclipai/server typecheck                                            # clean
```

The test drives the real `paperclipConfigSchema` against the reporter's exact invalid config, so the diagnostic message (offending field path) is exercised end-to-end, not mocked.

## Risks

Low risk. Behavior on a *valid* config is unchanged. Behavior on an *invalid* config is unchanged except that it now logs (previously silent) — the server still falls back to defaults rather than failing fast, preserving current boot semantics. No schema change (the reporter's suggestion to loosen `$meta.source` to `z.string()` is deliberately left out — that's a product decision about whether `source` is informational or a closed enum; this PR only fixes the silent-failure diagnosability, which helps *every* invalid-config case, not just that one field). No telemetry changes.

## Model Used

Claude Opus 4.8 (Anthropic), model ID `claude-opus-4-8`, 1M context window, extended thinking + tool use (Claude Code).

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` OR (b) described the issue in-PR
- [x] I have not referenced internal/instance-local Paperclip issues or links
- [x] My branch name describes the change (`fix/log-invalid-config-fallback`) and contains no internal ticket id
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes (none needed — behavior-preserving diagnostics only)
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green (will confirm after CI runs)
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups (will address on review)
- [x] I will address all Greptile and reviewer comments before requesting merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
