### PR TITLE
ci: wire .github/scripts/tests unit suite into pr.yml policy job

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -61,6 +61,36 @@ jobs:
       - name: Test standalone package build concurrency
         run: node --test ./scripts/__tests__/build-standalone-concurrency.test.mjs
 
+      - name: Test commitperclip bot token resolution
+        run: node --test .github/scripts/tests/get-bot-token.test.mjs
+
+      - name: Test PR file fetching
+        run: node --test .github/scripts/tests/fetch-pr-files.test.mjs
+
+      - name: Test PR template quality gate
+        run: node --test .github/scripts/tests/check-pr-template.test.mjs
+
+      - name: Test PR linked-issue quality gate
+        run: node --test .github/scripts/tests/check-pr-linked-issue.test.mjs
+
+      - name: Test PR dedup-search quality gate
+        run: node --test .github/scripts/tests/check-pr-dedup-search.test.mjs
+
+      - name: Test PR test-coverage quality gate
+        run: node --test .github/scripts/tests/check-pr-test-coverage.test.mjs
+
+      - name: Test PR lockfile quality gate
+        run: node --test .github/scripts/tests/check-pr-lockfile.test.mjs
+
+      - name: Test PR dependency quality gate
+        run: node --test .github/scripts/tests/check-pr-dependencies.test.mjs
+
+      - name: Test PR security review gates
+        run: node --test .github/scripts/tests/check-pr-security.test.mjs
+
+      - name: Test quality gate orchestration
+        run: node --test .github/scripts/tests/run-quality-gates.test.mjs
+
       - name: Validate release package manifest
         run: node ./scripts/release-package-map.mjs check
 


### PR DESCRIPTION
## Thinking Path
The 10 test files under `.github/scripts/tests/` (`check-pr-dedup-search.test.mjs`, `check-pr-dependencies.test.mjs`, `check-pr-linked-issue.test.mjs`, `check-pr-lockfile.test.mjs`, `check-pr-security.test.mjs`, `check-pr-template.test.mjs`, `check-pr-test-coverage.test.mjs`, `fetch-pr-files.test.mjs`, `get-bot-token.test.mjs`, `run-quality-gates.test.mjs`) are dependency-injected unit tests for the corresponding `.github/scripts/*.mjs` production scripts. Grepping every workflow for `.github/scripts/tests` or any generic `node --test` glob covering that directory turned up nothing — none of the 10 files were ever invoked anywhere.

I checked whether `commitperclip-review.yml` already covers this: it runs `get-bot-token.mjs`, `run-quality-gates.mjs`, and `check-pr-security.mjs` directly, but that's a live integration check against a real PR (secrets, real GitHub API calls), not a unit-test invocation — it never executes any `*.test.mjs` file. So wiring the unit suite into `pr.yml` is additive, not redundant.

I looked at how the three existing `node --test` steps in `pr.yml`'s `policy` job were added (one file, one named step, added incrementally over separate PRs) and followed that same convention rather than introducing a single glob step, so each check keeps its own pass/fail visibility in the Actions UI.

## What Changed
- Added 10 new named steps to `pr.yml`'s `policy` job, each running `node --test` against one of the 10 test files in `.github/scripts/tests/`, placed after the existing `Test standalone package build concurrency` step.
- No production script or test file was modified — all 123 tests across the 10 files pass unchanged.

## Verification
- `node --test .github/scripts/tests/get-bot-token.test.mjs` → 3/3 pass
- `node --test .github/scripts/tests/fetch-pr-files.test.mjs` → 2/2 pass
- `node --test .github/scripts/tests/check-pr-template.test.mjs` → 10/10 pass
- `node --test .github/scripts/tests/check-pr-linked-issue.test.mjs` → 31/31 pass
- `node --test .github/scripts/tests/check-pr-dedup-search.test.mjs` → 14/14 pass
- `node --test .github/scripts/tests/check-pr-test-coverage.test.mjs` → 20/20 pass
- `node --test .github/scripts/tests/check-pr-lockfile.test.mjs` → 4/4 pass
- `node --test .github/scripts/tests/check-pr-dependencies.test.mjs` → 3/3 pass
- `node --test .github/scripts/tests/check-pr-security.test.mjs` → 34/34 pass
- `node --test .github/scripts/tests/run-quality-gates.test.mjs` → 2/2 pass
- Total: 123/123 pass, run exactly as each new CI step invokes them.
- `git diff --stat master` → only `.github/workflows/pr.yml` changed, 30 insertions, 0 deletions.
- `pnpm-lock.yaml` untouched.

## Risks
Low — additive CI-only change. Adds ~10 short-lived `node --test` steps (all sub-second individually) to an already-fast lane of the `policy` job; no existing step, script, or test behavior is altered.

## Model Used
Claude Sonnet 4.5 (claude-sonnet-4-5), 200k context window, no extended thinking, tool use: bash/read/edit/grep for repo investigation, local test execution, and git/gh for branch/PR management.

- [x] I have searched GitHub for duplicate or related PRs and linked them above