### PR TITLE
Fix budget aggregate from seat budgets

### DIFF
--- a/server/src/__tests__/costs-service.test.ts
+++ b/server/src/__tests__/costs-service.test.ts
@@ -507,6 +507,83 @@ describeEmbeddedPostgres("cost and finance aggregate overflow handling", () => {
     expect(byAgentModelRow?.costCents).toBe(4_000_000_000);
   });
 
+  it("derives the cost summary budget aggregate from live agent seat budgets", async () => {
+    const companyId = randomUUID();
+    const firstAgentId = randomUUID();
+    const secondAgentId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+      budgetMonthlyCents: 0,
+    });
+    await db.insert(agents).values([
+      {
+        id: firstAgentId,
+        companyId,
+        name: "First Seat",
+        role: "engineer",
+        status: "idle",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+        budgetMonthlyCents: 10_000,
+      },
+      {
+        id: secondAgentId,
+        companyId,
+        name: "Second Seat",
+        role: "engineer",
+        status: "running",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+        budgetMonthlyCents: 20_000,
+      },
+      {
+        id: randomUUID(),
+        companyId,
+        name: "Terminated Seat",
+        role: "engineer",
+        status: "terminated",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+        budgetMonthlyCents: 50_000,
+      },
+    ]);
+    await db.insert(costEvents).values({
+      companyId,
+      agentId: firstAgentId,
+      provider: "openai",
+      biller: "openai",
+      billingType: "metered_api",
+      model: "gpt-5",
+      inputTokens: 10,
+      cachedInputTokens: 0,
+      outputTokens: 2,
+      costCents: 7_500,
+      occurredAt: new Date("2026-04-10T00:00:00.000Z"),
+    });
+
+    const summary = await costs.summary(companyId, {
+      from: new Date("2026-04-01T00:00:00.000Z"),
+      to: new Date("2026-04-30T23:59:59.999Z"),
+    });
+
+    expect(summary).toEqual({
+      companyId,
+      spendCents: 7_500,
+      budgetCents: 30_000,
+      utilizationPercent: 25,
+    });
+  });
+
   it("aggregates issue costs across recursive descendants only", async () => {
     const companyId = randomUUID();
     const agentId = randomUUID();

--- a/server/src/__tests__/dashboard-service.test.ts
+++ b/server/src/__tests__/dashboard-service.test.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
-import { agents, companies, createDb, heartbeatRuns } from "@paperclipai/db";
+import { agents, companies, costEvents, createDb, heartbeatRuns } from "@paperclipai/db";
 import {
   getEmbeddedPostgresTestSupport,
   startEmbeddedPostgresTestDatabase,
@@ -47,6 +47,7 @@ describeEmbeddedPostgres("dashboard service", () => {
   }, 20_000);
 
   afterEach(async () => {
+    await db.delete(costEvents);
     await db.delete(heartbeatRuns);
     await db.delete(agents);
     await db.delete(companies);
@@ -165,5 +166,77 @@ describeEmbeddedPostgres("dashboard service", () => {
       other: 1,
       total: 3,
     });
+  });
+
+  it("derives the monthly budget aggregate from live agent seat budgets", async () => {
+    const companyId = randomUUID();
+    const firstAgentId = randomUUID();
+    const secondAgentId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+      budgetMonthlyCents: 0,
+    });
+
+    await db.insert(agents).values([
+      {
+        id: firstAgentId,
+        companyId,
+        name: "First Seat",
+        role: "engineer",
+        status: "idle",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+        budgetMonthlyCents: 10_000,
+      },
+      {
+        id: secondAgentId,
+        companyId,
+        name: "Second Seat",
+        role: "engineer",
+        status: "running",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+        budgetMonthlyCents: 20_000,
+      },
+      {
+        id: randomUUID(),
+        companyId,
+        name: "Draft Seat",
+        role: "engineer",
+        status: "pending_approval",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+        budgetMonthlyCents: 50_000,
+      },
+    ]);
+
+    await db.insert(costEvents).values({
+      companyId,
+      agentId: firstAgentId,
+      provider: "openai",
+      biller: "openai",
+      billingType: "metered_api",
+      model: "gpt-5",
+      inputTokens: 10,
+      cachedInputTokens: 0,
+      outputTokens: 2,
+      costCents: 7_500,
+      occurredAt: new Date(),
+    });
+
+    const summary = await dashboardService(db).summary(companyId);
+
+    expect(summary.costs.monthBudgetCents).toBe(30_000);
+    expect(summary.costs.monthUtilizationPercent).toBe(25);
   });
 });

--- a/server/src/services/budget-aggregates.ts
+++ b/server/src/services/budget-aggregates.ts
@@ -1,0 +1,25 @@
+import { and, eq, notInArray, sql } from "drizzle-orm";
+import type { Db } from "@paperclipai/db";
+import { agents, companies } from "@paperclipai/db";
+
+const NON_LIVE_AGENT_BUDGET_STATUSES = ["pending_approval", "terminated"];
+
+export async function getCompanyBudgetAggregateCents(
+  db: Db,
+  company: Pick<typeof companies.$inferSelect, "id" | "budgetMonthlyCents">,
+) {
+  const [row] = await db
+    .select({
+      seatBudgetCents: sql<number>`coalesce(sum(${agents.budgetMonthlyCents}), 0)::double precision`,
+    })
+    .from(agents)
+    .where(
+      and(
+        eq(agents.companyId, company.id),
+        notInArray(agents.status, NON_LIVE_AGENT_BUDGET_STATUSES),
+      ),
+    );
+
+  const seatBudgetCents = Number(row?.seatBudgetCents ?? 0);
+  return seatBudgetCents > 0 ? seatBudgetCents : company.budgetMonthlyCents;
+}

--- a/server/src/services/costs.ts
+++ b/server/src/services/costs.ts
@@ -115,15 +115,17 @@ export function costService(db: Db, budgetHooks: BudgetServiceHooks = {}) {
       if (range?.from) conditions.push(gte(costEvents.occurredAt, range.from));
       if (range?.to) conditions.push(lte(costEvents.occurredAt, range.to));
 
-      const [{ total }] = await db
-        .select({
-          total: sumAsNumber(costEvents.costCents),
-        })
-        .from(costEvents)
-        .where(and(...conditions));
+      const [[{ total }], budgetCents] = await Promise.all([
+        db
+          .select({
+            total: sumAsNumber(costEvents.costCents),
+          })
+          .from(costEvents)
+          .where(and(...conditions)),
+        getCompanyBudgetAggregateCents(db, company),
+      ]);
 
       const spendCents = Number(total);
-      const budgetCents = await getCompanyBudgetAggregateCents(db, company);
       const utilization =
         budgetCents > 0
           ? (spendCents / budgetCents) * 100

--- a/server/src/services/costs.ts
+++ b/server/src/services/costs.ts
@@ -3,6 +3,7 @@ import { alias } from "drizzle-orm/pg-core";
 import type { Db } from "@paperclipai/db";
 import { activityLog, agents, companies, costEvents, heartbeatRuns, issues, projects } from "@paperclipai/db";
 import { notFound, unprocessable } from "../errors.js";
+import { getCompanyBudgetAggregateCents } from "./budget-aggregates.js";
 import { budgetService, type BudgetServiceHooks } from "./budgets.js";
 
 export interface CostDateRange {
@@ -122,15 +123,16 @@ export function costService(db: Db, budgetHooks: BudgetServiceHooks = {}) {
         .where(and(...conditions));
 
       const spendCents = Number(total);
+      const budgetCents = await getCompanyBudgetAggregateCents(db, company);
       const utilization =
-        company.budgetMonthlyCents > 0
-          ? (spendCents / company.budgetMonthlyCents) * 100
+        budgetCents > 0
+          ? (spendCents / budgetCents) * 100
           : 0;
 
       return {
         companyId,
         spendCents,
-        budgetCents: company.budgetMonthlyCents,
+        budgetCents,
         utilizationPercent: Number(utilization.toFixed(2)),
       };
     },

--- a/server/src/services/dashboard.ts
+++ b/server/src/services/dashboard.ts
@@ -129,12 +129,14 @@ export function dashboardService(db: Db) {
         bucket.total += count;
       }
 
-      const budgetMonthlyCents = await getCompanyBudgetAggregateCents(db, company);
+      const [budgetMonthlyCents, budgetOverview] = await Promise.all([
+        getCompanyBudgetAggregateCents(db, company),
+        budgets.overview(companyId),
+      ]);
       const utilization =
         budgetMonthlyCents > 0
           ? (monthSpendCents / budgetMonthlyCents) * 100
           : 0;
-      const budgetOverview = await budgets.overview(companyId);
 
       return {
         companyId,

--- a/server/src/services/dashboard.ts
+++ b/server/src/services/dashboard.ts
@@ -2,6 +2,7 @@ import { and, eq, gte, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import { agents, approvals, companies, costEvents, heartbeatRuns, issues } from "@paperclipai/db";
 import { notFound } from "../errors.js";
+import { getCompanyBudgetAggregateCents } from "./budget-aggregates.js";
 import { budgetService } from "./budgets.js";
 
 const DASHBOARD_RUN_ACTIVITY_DAYS = 14;
@@ -128,9 +129,10 @@ export function dashboardService(db: Db) {
         bucket.total += count;
       }
 
+      const budgetMonthlyCents = await getCompanyBudgetAggregateCents(db, company);
       const utilization =
-        company.budgetMonthlyCents > 0
-          ? (monthSpendCents / company.budgetMonthlyCents) * 100
+        budgetMonthlyCents > 0
+          ? (monthSpendCents / budgetMonthlyCents) * 100
           : 0;
       const budgetOverview = await budgets.overview(companyId);
 
@@ -145,7 +147,7 @@ export function dashboardService(db: Db) {
         tasks: taskCounts,
         costs: {
           monthSpendCents,
-          monthBudgetCents: company.budgetMonthlyCents,
+          monthBudgetCents: budgetMonthlyCents,
           monthUtilizationPercent: Number(utilization.toFixed(2)),
         },
         pendingApprovals,


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source control plane for managing AI-agent companies and their work.
> - Budgeting is part of the control plane's safety and operator-visibility layer.
> - The dashboard and costs summary expose the aggregate monthly budget operators use to understand spend utilization.
> - Seat-level agent budgets can be applied while the legacy company-level budget remains zero.
> - When those endpoints read only the company-level field, they report a zero aggregate even though live seats have non-zero budgets.
> - This pull request makes aggregate budget reads derive from live agent seat budgets and keeps the legacy company field as a fallback.
> - The benefit is one trustworthy aggregate value across the dashboard and costs summary without changing the public response shape.

## Linked Issues or Issue Description

Bug report:

### What happened?

`GET /api/companies/{companyId}/dashboard` and `GET /api/companies/{companyId}/costs/summary` read `companies.budgetMonthlyCents` directly, so they can return `0` after seat budgets are applied even when live agent seat budgets are non-zero. Operators cannot rely on aggregate utilization percentages or budget-alert surfaces in that state.

### Expected behavior

Aggregate budget endpoints should expose one trustworthy monthly budget value that matches current seat-level budget configuration.

### Steps to reproduce

1. Create a company with `budgetMonthlyCents` set to `0`.
2. Add live agents with non-zero `budgetMonthlyCents`.
3. Call the dashboard or costs summary endpoint.
4. Observe that the returned monthly budget aggregate is `0` instead of the sum of live seat budgets.

### Paperclip version or commit

Reproduced against `master` before this PR.

### Deployment mode

Self-hosted server.

Duplicate search:

- Searched GitHub PRs for `budget aggregate seat budgets`; only this PR matched.

## What Changed

- Added `getCompanyBudgetAggregateCents` as the shared aggregate budget read helper.
- Derive aggregate budgets from live agent seat budgets, excluding `pending_approval` and `terminated` seats.
- Fall back to `companies.budgetMonthlyCents` only when the live seat-budget sum is zero.
- Updated dashboard and costs summary services to use the shared helper.
- Parallelized independent budget/spend and budget-overview reads to avoid extra sequential latency.
- Added regression coverage for non-zero seat budgets with zero company budget in both summary paths.

## Verification

- `npx -y pnpm@9.15.4 exec vitest run server/src/__tests__/dashboard-service.test.ts server/src/__tests__/costs-service.test.ts`
- `npx -y pnpm@9.15.4 --filter @paperclipai/server typecheck`

## Risks

- Low migration risk: no schema change and no response-shape change.
- Behavior changes for companies with both live seat budgets and a non-zero company budget: the live seat-budget aggregate now wins because it reflects the active operating configuration.
- The helper adds one budget aggregate query to each summary path; independent reads are parallelized where possible.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex, GPT-5 coding agent, with shell and GitHub CLI tool use.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

