### PR TITLE
feat(plugins): server-authenticated __actor envelope for worker calls, "user" API-route auth mode, and 403 mapping for worker RBAC denials

### DIFF
--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -1035,7 +1035,7 @@ export type PluginDatabaseCoreReadTable = (typeof PLUGIN_DATABASE_CORE_READ_TABL
 export const PLUGIN_API_ROUTE_METHODS = ["GET", "POST", "PATCH", "DELETE"] as const;
 export type PluginApiRouteMethod = (typeof PLUGIN_API_ROUTE_METHODS)[number];
 
-export const PLUGIN_API_ROUTE_AUTH_MODES = ["board", "agent", "board-or-agent", "webhook"] as const;
+export const PLUGIN_API_ROUTE_AUTH_MODES = ["board", "agent", "board-or-agent", "user", "webhook"] as const;
 export type PluginApiRouteAuthMode = (typeof PLUGIN_API_ROUTE_AUTH_MODES)[number];
 
 export const PLUGIN_API_ROUTE_CHECKOUT_POLICIES = [

--- a/server/src/__tests__/plugin-routes-authz.test.ts
+++ b/server/src/__tests__/plugin-routes-authz.test.ts
@@ -1,6 +1,7 @@
 import express from "express";
 import request from "supertest";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { mergeActorContext } from "../routes/plugin-actor-context.js";
 
 const mockRegistry = vi.hoisted(() => ({
   getById: vi.fn(),
@@ -45,10 +46,12 @@ async function createApp(
     captureJsonContext?: (context: unknown, body: unknown) => void;
   } = {},
 ) {
-  const [{ pluginRoutes }, { errorHandler }] = await Promise.all([
-    import("../routes/plugins.js"),
-    import("../middleware/index.js"),
-  ]);
+  // Import sequentially rather than via Promise.all: plugins.js pulls in a large
+  // dependency graph, and initializing it concurrently with middleware (which shares
+  // deep dependencies) intermittently deadlocked the first createApp() call in this
+  // file under the serialized regression. Sequential ESM init is deterministic.
+  const { pluginRoutes } = await import("../routes/plugins.js");
+  const { errorHandler } = await import("../middleware/index.js");
 
   const loader = {
     installPlugin: vi.fn(),
@@ -425,6 +428,111 @@ describe.sequential("scoped plugin API routes", () => {
       }),
     );
   }, 20_000);
+
+  function readyUserAuthRoutePlugin() {
+    const pluginId = "11111111-1111-4111-8111-111111111111";
+    mockRegistry.getById.mockResolvedValue(null);
+    mockRegistry.getByKey.mockResolvedValue({
+      id: pluginId,
+      pluginKey: "paperclip.example",
+      version: "1.0.0",
+      status: "ready",
+      manifestJson: {
+        id: "paperclip.example",
+        capabilities: ["api.routes.register"],
+        apiRoutes: [
+          {
+            routeKey: "self-feed",
+            method: "GET",
+            path: "/self-feed",
+            auth: "user",
+            capability: "api.routes.register",
+            companyResolution: { from: "query", key: "companyId" },
+          },
+        ],
+      },
+    });
+    return pluginId;
+  }
+
+  it("allows any authenticated board user on user-auth scoped routes", async () => {
+    const pluginId = readyUserAuthRoutePlugin();
+    const workerManager = {
+      call: vi.fn().mockResolvedValue({ status: 200, body: { ok: true } }),
+    };
+    const { app } = await createApp(
+      boardActor({ companyIds: ["company-1"] }),
+      {},
+      { bridgeDeps: { workerManager } },
+    );
+
+    const res = await request(app)
+      .get("/api/plugins/paperclip.example/api/self-feed")
+      .query({ companyId: "company-1" });
+
+    expect(res.status).toBe(200);
+    expect(workerManager.call).toHaveBeenCalledWith(
+      pluginId,
+      "handleApiRequest",
+      expect.objectContaining({ routeKey: "self-feed" }),
+    );
+  }, 20_000);
+
+  it("rejects agent actors on user-auth scoped routes before worker dispatch", async () => {
+    readyUserAuthRoutePlugin();
+    const workerManager = { call: vi.fn() };
+    const { app } = await createApp(agentActor(), {}, { bridgeDeps: { workerManager } });
+
+    const res = await request(app)
+      .get("/api/plugins/paperclip.example/api/self-feed")
+      .query({ companyId: companyA });
+
+    expect(res.status).toBe(403);
+    expect(workerManager.call).not.toHaveBeenCalled();
+  }, 20_000);
+
+  it("rejects anonymous actors on user-auth scoped routes before worker dispatch", async () => {
+    readyUserAuthRoutePlugin();
+    const workerManager = { call: vi.fn() };
+    const { app } = await createApp(
+      { type: "none", source: "none" },
+      {},
+      { bridgeDeps: { workerManager } },
+    );
+
+    const res = await request(app)
+      .get("/api/plugins/paperclip.example/api/self-feed")
+      .query({ companyId: "company-1" });
+
+    expect(res.status).toBe(401);
+    expect(workerManager.call).not.toHaveBeenCalled();
+  }, 20_000);
+});
+
+describe("mergeActorContext boundary", () => {
+  it("strips client-supplied identity keys and injects the authenticated actor", () => {
+    const merged = mergeActorContext(
+      { userId: "spoofed", user_id: "also-spoofed", view: "compact" },
+      { type: "board", userId: "user-1", isInstanceAdmin: true },
+      companyA,
+    );
+
+    expect(merged).toEqual({
+      view: "compact",
+      __actor: {
+        userId: "user-1",
+        isInstanceAdmin: true,
+        type: "board",
+        companyId: companyA,
+      },
+    });
+  });
+
+  it("defaults to a null/none actor when no authenticated actor is present", () => {
+    expect(mergeActorContext(undefined, null)).toEqual({
+      __actor: { userId: null, isInstanceAdmin: false, type: "none", companyId: null },
+    });
+  });
 });
 
 describe.sequential("plugin local folder routes", () => {
@@ -660,10 +768,11 @@ describe.sequential("plugin tool and bridge authz", () => {
       .send({ companyId: companyA, params: { view: "compact" } });
 
     expect(res.status).toBe(200);
+    // objectContaining: the host also injects the reserved `__actor` envelope.
     expect(call).toHaveBeenCalledWith(pluginId, "getData", {
       key: "health",
       companyId: companyA,
-      params: { view: "compact" },
+      params: expect.objectContaining({ view: "compact" }),
       renderEnvironment: null,
     });
   });
@@ -686,9 +795,15 @@ describe.sequential("plugin tool and bridge authz", () => {
       .send({});
 
     expect(res.status).toBe(200);
+    // The host forwards the authenticated actor under the reserved `__actor` key so a
+    // plugin worker can perform RBAC against the REAL caller (the instance-admin
+    // governs the control plane). The action params therefore carry `__actor` in
+    // addition to any client params.
     expect(call).toHaveBeenCalledWith(pluginId, "performAction", {
       key: "sync",
-      params: {},
+      params: expect.objectContaining({
+        __actor: expect.objectContaining({ userId: "admin-1", isInstanceAdmin: true }),
+      }),
       actorContext: {
         type: "user",
         userId: "admin-1",
@@ -720,12 +835,21 @@ describe.sequential("plugin tool and bridge authz", () => {
       });
 
     expect(res.status).toBe(200);
+    // Params use objectContaining because the host ALSO injects the
+    // server-authenticated `__actor` envelope; the spoofed-company override
+    // (companyId: companyA, not companyB) and the first-class actorContext
+    // channel are still asserted verbatim. `__actor.companyId` must be the
+    // VERIFIED company (companyA), never the client-claimed one.
     expect(call).toHaveBeenCalledWith(pluginId, "performAction", {
       key: "sync",
-      params: {
+      params: expect.objectContaining({
         companyId: companyA,
         reviewerUserId: "spoofed-user",
-      },
+        __actor: expect.objectContaining({
+          userId: "user-1",
+          companyId: companyA,
+        }),
+      }),
       actorContext: {
         type: "user",
         userId: "user-1",
@@ -780,12 +904,13 @@ describe.sequential("plugin tool and bridge authz", () => {
       });
 
     expect(res.status).toBe(200);
+    // objectContaining: the host also injects the reserved `__actor` envelope.
     expect(call).toHaveBeenCalledWith(pluginId, "performAction", {
       key: "sync",
-      params: {
+      params: expect.objectContaining({
         companyId: companyA,
         reviewerAgentId: "spoofed-agent",
-      },
+      }),
       actorContext: {
         type: "agent",
         userId: null,
@@ -809,12 +934,13 @@ describe.sequential("plugin tool and bridge authz", () => {
       });
 
     expect(legacyRes.status).toBe(200);
+    // objectContaining: the host also injects the reserved `__actor` envelope.
     expect(call).toHaveBeenCalledWith(pluginId, "performAction", {
       key: "sync",
-      params: {
+      params: expect.objectContaining({
         companyId: companyA,
         reviewerAgentId: "spoofed-agent",
-      },
+      }),
       actorContext: {
         type: "agent",
         userId: null,
@@ -875,6 +1001,43 @@ describe.sequential("plugin tool and bridge authz", () => {
         bridgeCode: "UNKNOWN",
       },
     });
+  });
+
+  it("maps worker RBAC denials to 403 instead of 502 on bridge action errors", async () => {
+    readyPlugin();
+    const call = vi.fn().mockRejectedValue(
+      new Error("FORBIDDEN_NOT_ADMIN: administrator privileges required"),
+    );
+    const { app } = await createApp(boardActor(), {}, {
+      bridgeDeps: {
+        workerManager: { call },
+      },
+    });
+
+    const res = await request(app)
+      .post(`/api/plugins/${pluginId}/actions/sync`)
+      .send({ companyId: companyA });
+
+    expect(res.status).toBe(403);
+    expect(res.body).toMatchObject({
+      message: "FORBIDDEN_NOT_ADMIN: administrator privileges required",
+    });
+  });
+
+  it("maps worker RBAC denials to 403 instead of 502 on bridge data errors", async () => {
+    readyPlugin();
+    const call = vi.fn().mockRejectedValue(new Error("caller is not authorized to read this feed"));
+    const { app } = await createApp(boardActor(), {}, {
+      bridgeDeps: {
+        workerManager: { call },
+      },
+    });
+
+    const res = await request(app)
+      .post(`/api/plugins/${pluginId}/data/health`)
+      .send({ companyId: companyA });
+
+    expect(res.status).toBe(403);
   });
 
   it("rejects manual job triggers for non-admin board users", async () => {

--- a/server/src/routes/plugin-actor-context.ts
+++ b/server/src/routes/plugin-actor-context.ts
@@ -1,0 +1,56 @@
+/**
+ * Plugin worker actor-context security boundary.
+ *
+ * Extracted from `plugins.ts` into this dependency-free module (no express / db /
+ * drizzle imports) so the security boundary can be imported and unit-tested in
+ * isolation — including from the plugin packages whose worker RBAC relies on it —
+ * without pulling the whole Express route module's runtime dependency graph.
+ * `plugins.ts` re-exports both symbols, so existing importers are unaffected.
+ */
+
+/** Server-authenticated actor shape consumed by {@link mergeActorContext}. */
+export interface ActorContextInput {
+  type?: string;
+  userId?: string | null;
+  isInstanceAdmin?: boolean;
+}
+
+/**
+ * Merge the server-authenticated actor into the params a plugin worker receives,
+ * stripping any client-supplied identity keys first.
+ *
+ * This is the security boundary that scopes per-user reads to the calling
+ * authenticated user only. A client request can carry an arbitrary
+ * `params.userId` / `params.user_id`, but those keys are DROPPED here so a worker
+ * can ONLY ever resolve the real caller from the trusted `__actor` envelope —
+ * never from a client claim. This makes per-user exports (e.g. a plugin's
+ * access-list feed) self-only: a caller can never coerce the worker into reading
+ * another user's data by spoofing a user id in the request body.
+ *
+ * NOTE for plugin authors: because `user_id`/`userId` are stripped here, a worker
+ * action that needs a SECOND, distinct user id (e.g. the grantee/TARGET of a
+ * grant-access call — separate from the ACTOR who grants) MUST carry that target
+ * under a different key (e.g. `target_user_id`), since this boundary removes only
+ * the actor-identity keys and leaves every other param untouched.
+ *
+ * Additive and back-compatible: workers that don't read `__actor` simply ignore it.
+ */
+export function mergeActorContext(
+  params: Record<string, unknown> | undefined,
+  actor: ActorContextInput | undefined | null,
+  companyId?: string,
+): Record<string, unknown> {
+  const { userId: _u, user_id: _us, ...clientParams } = (params ?? {}) as Record<
+    string,
+    unknown
+  >;
+  return {
+    ...clientParams,
+    __actor: {
+      userId: actor?.userId ?? null,
+      isInstanceAdmin: Boolean(actor?.isInstanceAdmin),
+      type: actor?.type ?? "none",
+      companyId: companyId ?? null,
+    },
+  };
+}

--- a/server/src/routes/plugins.ts
+++ b/server/src/routes/plugins.ts
@@ -456,6 +456,19 @@ interface PluginToolExecuteRequest {
   runContext: ToolRunContext;
 }
 
+// The actor-context security boundary lives in a dependency-free sibling module so
+// it can be unit-tested in isolation (and imported by plugin worker tests that rely
+// on the strip) without pulling this Express route module's dependency graph. Both
+// symbols are re-exported here so existing importers of `./plugins` are unchanged.
+export {
+  mergeActorContext,
+  type ActorContextInput,
+} from "./plugin-actor-context.js";
+import {
+  mergeActorContext,
+  type ActorContextInput,
+} from "./plugin-actor-context.js";
+
 /**
  * Create Express router for plugin management API.
  *
@@ -615,6 +628,11 @@ export function pluginRoutes(
     if (route.auth === "agent") {
       assertAuthenticated(req);
       if (req.actor.type !== "agent") throw forbidden("Agent access required");
+      return;
+    }
+    if (route.auth === "user") {
+      assertAuthenticated(req);
+      if (req.actor.type !== "board") throw forbidden("User access required");
       return;
     }
     if (route.auth === "webhook") {
@@ -1231,6 +1249,25 @@ export function pluginRoutes(
   }
 
   /**
+   * RBAC denials a plugin worker raises (e.g. a non-admin POSTing an admin-gated
+   * action past the UI) are authorization failures, not bad-gateway/worker faults:
+   * surface them as HTTP 403 (not 502) so a UI/client sees a forbidden response and
+   * the worker's structured FORBIDDEN code reaches the body. Detected by the
+   * forbidden markers a worker RBAC error carries in its message (the worker→host
+   * JSON-RPC boundary propagates only the message string).
+   */
+  function isForbiddenBridgeError(bridgeError: PluginBridgeErrorResponse): boolean {
+    return /FORBIDDEN_NOT_ADMIN|\bFORBIDDEN\b|not authorized|forbidden/i.test(
+      bridgeError.message ?? "",
+    );
+  }
+
+  /** HTTP status for a worker bridge error: 403 for RBAC denials, else 502. */
+  function statusForBridgeError(bridgeError: PluginBridgeErrorResponse): number {
+    return isForbiddenBridgeError(bridgeError) ? 403 : 502;
+  }
+
+  /**
    * POST /api/plugins/:pluginId/bridge/data
    *
    * Proxy a `getData` call from the plugin UI to the plugin worker.
@@ -1297,7 +1334,7 @@ export function pluginRoutes(
       return;
     }
 
-    const companyId = assertPluginBridgeScope(req, body.companyId);
+    const verifiedCompanyId = assertPluginBridgeScope(req, body.companyId);
 
     try {
       const result = await bridgeDeps.workerManager.call(
@@ -1305,8 +1342,13 @@ export function pluginRoutes(
         "getData",
         {
           key: body.key,
-          ...(companyId ? { companyId } : {}),
-          params: body.params ?? {},
+          // existing top-level companyId (server-verified) for the worker-side scope
+          ...(verifiedCompanyId ? { companyId: verifiedCompanyId } : {}),
+          // Same self-only actor envelope as the URL-keyed /data/:key route: the
+          // legacy bridge route must NOT forward raw client params (which could
+          // carry a spoofed `userId`) — inject the server-authenticated identity
+          // and strip client identity keys.
+          params: withActorContext(body.params, req, verifiedCompanyId),
           renderEnvironment: body.renderEnvironment ?? null,
         },
       );
@@ -1319,7 +1361,7 @@ export function pluginRoutes(
         bridgeMethod: "getData",
         dataKey: body.key,
       });
-      res.status(502).json(bridgeError);
+      res.status(statusForBridgeError(bridgeError)).json(bridgeError);
     }
   });
 
@@ -1390,7 +1432,7 @@ export function pluginRoutes(
       return;
     }
 
-    const companyId = assertPluginBridgeScope(req, body.companyId);
+    const verifiedCompanyId = assertPluginBridgeScope(req, body.companyId);
 
     try {
       const result = await bridgeDeps.workerManager.call(
@@ -1398,8 +1440,15 @@ export function pluginRoutes(
         "performAction",
         {
           key: body.key,
-          params: actionParamsWithAuthorizedCompanyScope(body.params, companyId),
-          actorContext: performActionActorContext(req, companyId),
+          // Combined: the authorized company scope in params + the typed
+          // actorContext channel, plus the server-authenticated __actor
+          // envelope (strips spoofable client identity keys).
+          params: withActorContext(
+            actionParamsWithAuthorizedCompanyScope(body.params, verifiedCompanyId),
+            req,
+            verifiedCompanyId,
+          ),
+          actorContext: performActionActorContext(req, verifiedCompanyId),
           renderEnvironment: body.renderEnvironment ?? null,
         },
       );
@@ -1412,13 +1461,32 @@ export function pluginRoutes(
         bridgeMethod: "performAction",
         actionKey: body.key,
       });
-      res.status(502).json(bridgeError);
+      res.status(statusForBridgeError(bridgeError)).json(bridgeError);
     }
   });
 
   // ===========================================================================
   // URL-keyed bridge routes (key as path parameter)
   // ===========================================================================
+
+  /**
+   * Merge the authenticated host actor's identity into the worker call params
+   * under the reserved `__actor` key so a plugin worker that performs RBAC can
+   * resolve the REAL caller (and honor the host instance-admin) instead of
+   * trusting a client-supplied flag. Additive and back-compatible: plugins that
+   * don't read `__actor` simply ignore it.
+   */
+  function withActorContext(
+    params: Record<string, unknown> | undefined,
+    req: Request,
+    companyId?: string,
+  ): Record<string, unknown> {
+    return mergeActorContext(
+      params,
+      req.actor as ActorContextInput,
+      companyId,
+    );
+  }
 
   /**
    * POST /api/plugins/:pluginId/data/:key
@@ -1484,7 +1552,7 @@ export function pluginRoutes(
       renderEnvironment?: PluginLauncherRenderContextSnapshot | null;
     } | undefined;
 
-    const companyId = assertPluginBridgeScope(req, body?.companyId);
+    const verifiedCompanyId = assertPluginBridgeScope(req, body?.companyId);
 
     try {
       const result = await bridgeDeps.workerManager.call(
@@ -1492,8 +1560,12 @@ export function pluginRoutes(
         "getData",
         {
           key,
-          ...(companyId ? { companyId } : {}),
-          params: body?.params ?? {},
+          // existing top-level companyId (server-verified) for the worker-side scope
+          ...(verifiedCompanyId ? { companyId: verifiedCompanyId } : {}),
+          // companyId comes from assertPluginBridgeScope's RETURN (server-verified via
+          // assertCompanyAccess), never the raw client field — so the trusted __actor
+          // envelope can never carry a spoofed company scope.
+          params: withActorContext(body?.params, req, verifiedCompanyId),
           renderEnvironment: body?.renderEnvironment ?? null,
         },
       );
@@ -1506,7 +1578,7 @@ export function pluginRoutes(
         bridgeMethod: "getData",
         dataKey: key,
       });
-      res.status(502).json(bridgeError);
+      res.status(statusForBridgeError(bridgeError)).json(bridgeError);
     }
   });
 
@@ -1574,7 +1646,7 @@ export function pluginRoutes(
       renderEnvironment?: PluginLauncherRenderContextSnapshot | null;
     } | undefined;
 
-    const companyId = assertPluginBridgeScope(req, body?.companyId);
+    const verifiedCompanyId = assertPluginBridgeScope(req, body?.companyId);
 
     try {
       const result = await bridgeDeps.workerManager.call(
@@ -1582,8 +1654,16 @@ export function pluginRoutes(
         "performAction",
         {
           key,
-          params: actionParamsWithAuthorizedCompanyScope(body?.params, companyId),
-          actorContext: performActionActorContext(req, companyId),
+          // Combined: the authorized company scope in params + the typed
+          // actorContext channel, plus the server-authenticated __actor
+          // envelope (companyId is assertPluginBridgeScope's server-verified RETURN,
+          // never the raw client field — no spoofed company scope possible).
+          params: withActorContext(
+            actionParamsWithAuthorizedCompanyScope(body?.params, verifiedCompanyId),
+            req,
+            verifiedCompanyId,
+          ),
+          actorContext: performActionActorContext(req, verifiedCompanyId),
           renderEnvironment: body?.renderEnvironment ?? null,
         },
       );
@@ -1596,7 +1676,7 @@ export function pluginRoutes(
         bridgeMethod: "performAction",
         actionKey: key,
       });
-      res.status(502).json(bridgeError);
+      res.status(statusForBridgeError(bridgeError)).json(bridgeError);
     }
   });
 
@@ -2349,7 +2429,7 @@ export function pluginRoutes(
 
       // Worker unavailable or other RPC errors
       const bridgeError = mapRpcErrorToBridgeError(err);
-      res.status(502).json(bridgeError);
+      res.status(statusForBridgeError(bridgeError)).json(bridgeError);
     }
   });
 


### PR DESCRIPTION
Three related hardening gaps in the plugin bridge:

1. **Workers cannot securely know who is calling.** `performAction` receives a typed `actorContext`, but `getData` receives nothing — and client-supplied `params` can carry a spoofed `userId`/`user_id`. A plugin that serves per-user data (e.g. a per-user feed) has no trustworthy identity channel on the read path. This PR introduces a server-side security boundary, `mergeActorContext` (new dependency-free module `server/src/routes/plugin-actor-context.ts`), applied to **all four** bridge dispatch sites (legacy body-keyed and URL-keyed, `getData` and `performAction`): it **strips** client-supplied `userId`/`user_id` keys from `params` and injects a reserved `__actor` envelope `{ userId, isInstanceAdmin, type, companyId }` built exclusively from the server-authenticated `req.actor` and the *server-verified* return of `assertPluginBridgeScope` (never the raw client `companyId`). Additive and back-compatible: workers that don't read `__actor` ignore it.
   **Harmonization note:** this deliberately *coexists* with the existing `actorContext` channel rather than replacing it — `actorContext` keeps its exact shape and call sites (asserted verbatim in the updated tests). Longer term the two should converge; see "Convergence proposal" below.
2. **No auth mode for "any authenticated end user".** `PLUGIN_API_ROUTE_AUTH_MODES` offers `board` (privileged), `agent`, `board-or-agent`, `webhook` — but nothing for a user-scoped read route where any authenticated human may call for *their own* data (self-only thanks to the `__actor` strip above). This PR adds the `"user"` mode: authenticated board actor required, agents and anonymous rejected before worker dispatch.
3. **Worker RBAC denials surface as 502.** When a worker rejects an action with a FORBIDDEN-style error (e.g. a non-admin invoking an admin-gated action past the UI), the bridge maps it to `502 Bad Gateway` — miscategorizing an authorization failure as a worker fault (alerts, retries, wrong client UX). `statusForBridgeError` maps forbidden-marked worker errors (`FORBIDDEN_NOT_ADMIN`, `FORBIDDEN`, "not authorized", "forbidden") to **403**, everything else stays 502. Applied to all bridge error paths.

**Convergence proposal** (for maintainers — happy to iterate): keep `actorContext` as the *typed, first-class* channel and fold the two guarantees `__actor` adds into it: (a) also deliver it on `getData`, and (b) strip client-supplied identity keys from `params` at the same boundary. Once workers can rely on that, the `__actor` envelope can be deprecated. Until then the envelope is the only spoof-proof identity channel on the read path, and shipping it unblocks self-only per-user plugin routes today.

**Compatibility:** `__actor` is a new reserved key — the only observable change for an existing worker is that client-supplied `params.userId`/`params.user_id` no longer arrive (that is the spoofing fix; the real value is in `__actor.userId`, and a legitimate second user id should travel under a distinct key such as `target_user_id`, documented in the module). The `"user"` mode is opt-in per manifest; existing manifests validate unchanged. No new endpoints.

**Tests:** `server/src/__tests__/plugin-routes-authz.test.ts` (42 passing) — direct `mergeActorContext` unit tests (identity-key strip, param preservation, null-actor defaults), `__actor` injection incl. the spoofed-company case (`__actor.companyId` = verified company, never the client claim), `"user"` auth mode (board dispatches; agent → 403, anonymous → 401, both before worker dispatch), and 403-vs-502 mapping on bridge action/data errors; all pre-existing `actorContext` assertions kept verbatim.
