### PR TITLE
feat(plugin-sdk): add projects.create worker RPC gated by a new projects.write capability

### DIFF
--- a/packages/plugins/sdk/src/host-client-factory.ts
+++ b/packages/plugins/sdk/src/host-client-factory.ts
@@ -182,10 +182,11 @@ export interface HostServices {
     get(params: WorkerToHostMethods["companies.get"][0]): Promise<WorkerToHostMethods["companies.get"][1]>;
   };
 
-  /** Provides `projects.list`, `projects.get`, `projects.listWorkspaces`, `projects.getPrimaryWorkspace`, `projects.getWorkspaceForIssue`. */
+  /** Provides `projects.list`, `projects.get`, `projects.create`, `projects.listWorkspaces`, `projects.getPrimaryWorkspace`, `projects.getWorkspaceForIssue`. */
   projects: {
     list(params: WorkerToHostMethods["projects.list"][0]): Promise<WorkerToHostMethods["projects.list"][1]>;
     get(params: WorkerToHostMethods["projects.get"][0]): Promise<WorkerToHostMethods["projects.get"][1]>;
+    create(params: WorkerToHostMethods["projects.create"][0]): Promise<WorkerToHostMethods["projects.create"][1]>;
     listWorkspaces(params: WorkerToHostMethods["projects.listWorkspaces"][0]): Promise<WorkerToHostMethods["projects.listWorkspaces"][1]>;
     getPrimaryWorkspace(params: WorkerToHostMethods["projects.getPrimaryWorkspace"][0]): Promise<WorkerToHostMethods["projects.getPrimaryWorkspace"][1]>;
     getWorkspaceForIssue(params: WorkerToHostMethods["projects.getWorkspaceForIssue"][0]): Promise<WorkerToHostMethods["projects.getWorkspaceForIssue"][1]>;
@@ -406,6 +407,7 @@ const METHOD_CAPABILITY_MAP: Record<WorkerToHostMethodName, PluginCapability | n
   // Projects
   "projects.list": "projects.read",
   "projects.get": "projects.read",
+  "projects.create": "projects.write",
   "projects.listWorkspaces": "project.workspaces.read",
   "projects.getPrimaryWorkspace": "project.workspaces.read",
   "projects.getWorkspaceForIssue": "project.workspaces.read",
@@ -739,6 +741,9 @@ export function createHostClientHandlers(
     }),
     "projects.get": gated("projects.get", async (params) => {
       return services.projects.get(params);
+    }),
+    "projects.create": gated("projects.create", async (params) => {
+      return services.projects.create(params);
     }),
     "projects.listWorkspaces": gated("projects.listWorkspaces", async (params) => {
       return services.projects.listWorkspaces(params);

--- a/packages/plugins/sdk/src/protocol.ts
+++ b/packages/plugins/sdk/src/protocol.ts
@@ -1148,6 +1148,10 @@ export interface WorkerToHostMethods {
     params: { issueId: string; companyId: string },
     result: PluginWorkspace | null,
   ];
+  "projects.create": [
+    params: { name: string; companyId: string; description?: string; metadata?: Record<string, unknown> },
+    result: Project,
+  ];
   "executionWorkspaces.get": [
     params: {
       workspaceId: string;

--- a/packages/plugins/sdk/tests/host-client-factory.test.ts
+++ b/packages/plugins/sdk/tests/host-client-factory.test.ts
@@ -151,6 +151,60 @@ describe("createHostClientHandlers invocation company scope", () => {
     },
   );
 
+  it("rejects projects.create when the plugin lacks projects.write", async () => {
+    const projectsCreate = vi.fn(async () => ({ id: "project-a" }));
+    const services = {
+      projects: {
+        create: projectsCreate,
+      },
+    } as unknown as HostServices;
+
+    const handlers = createHostClientHandlers({
+      pluginId: "paperclip.test",
+      capabilities: ["projects.read"],
+      services,
+    });
+
+    await expect(
+      handlers["projects.create"]({ name: "Project A", companyId: "company-a" }),
+    ).rejects.toBeInstanceOf(CapabilityDeniedError);
+    await expect(
+      handlers["projects.create"]({ name: "Project A", companyId: "company-a" }),
+    ).rejects.toMatchObject({
+      name: "CapabilityDeniedError",
+      message: expect.stringContaining("projects.write"),
+    });
+    expect(projectsCreate).not.toHaveBeenCalled();
+  });
+
+  it("delegates projects.create to the host service when projects.write is granted", async () => {
+    const project = { id: "project-a", name: "Project A" };
+    const projectsCreate = vi.fn(async () => project);
+    const services = {
+      projects: {
+        create: projectsCreate,
+      },
+    } as unknown as HostServices;
+
+    const handlers = createHostClientHandlers({
+      pluginId: "paperclip.test",
+      capabilities: ["projects.write"],
+      services,
+    });
+
+    await expect(
+      handlers["projects.create"](
+        { name: "Project A", companyId: "company-a", description: "First project" },
+        { invocationScope: { companyId: "company-a" } },
+      ),
+    ).resolves.toEqual(project);
+    expect(projectsCreate).toHaveBeenCalledWith({
+      name: "Project A",
+      companyId: "company-a",
+      description: "First project",
+    });
+  });
+
   it("checks invocation company scope before exposing authorization data", async () => {
     const searchAudit = vi.fn(async () => []);
     const services = {

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -942,6 +942,7 @@ export const PLUGIN_CAPABILITIES = [
   "authorization.audit.read",
   "database.namespace.read",
   // Data Write
+  "projects.write",
   "issues.create",
   "issues.update",
   "issue.relations.write",

--- a/server/src/services/plugin-host-services.ts
+++ b/server/src/services/plugin-host-services.ts
@@ -1355,6 +1355,15 @@ export function buildHostServices(
         const project = await projects.getById(params.projectId);
         return (inCompany(project, companyId) ? project : null) as Project | null;
       },
+      async create(params) {
+        const companyId = ensureCompanyId(params.companyId);
+        await ensurePluginAvailableForCompany(companyId);
+        const project = await projects.create(companyId, {
+          name: params.name,
+          description: params.description ?? null,
+        });
+        return project as Project;
+      },
       async listWorkspaces(params) {
         const companyId = ensureCompanyId(params.companyId);
         await ensurePluginAvailableForCompany(companyId);


### PR DESCRIPTION
## Summary
Plugins can currently read projects (`projects.list`, `projects.get` behind `projects.read`) but have no way to create one. Any plugin that provisions or scaffolds work — e.g. an importer that mirrors external boards, a template/bootstrap plugin that sets up a standard project structure for a new company, or an automation that files incoming work into a dedicated project — has to ask a human to create the project first.

This PR adds a `projects.create` worker→host RPC behind a new `projects.write` capability, following the exact pattern of the existing write capabilities (`issues.create`/`issues.update`, etc.).

## Changes
- **`packages/shared/src/constants.ts`**: add `"projects.write"` to `PLUGIN_CAPABILITIES` (Data Write section).
- **`packages/plugins/sdk/src/protocol.ts`**: add `"projects.create"` to `WorkerToHostMethods` — params `{ name, companyId, description?, metadata? }`, result `Project`.
- **`packages/plugins/sdk/src/host-client-factory.ts`**: expose `create` on `HostServices.projects`, map `projects.create → projects.write` in `METHOD_CAPABILITY_MAP`, and add the gated handler.
- **`server/src/services/plugin-host-services.ts`**: host implementation delegates to the existing server projects service with the same company-scoping guards as the neighbouring read methods (`ensureCompanyId` + `ensurePluginAvailableForCompany`).

## Security
Deny-by-default like every capability: plugins without `projects.write` get the standard capability-denied error. Company scoping is enforced host-side; a plugin can only create projects in a company it is available for.

## Notes
- `metadata?` is part of the RPC param type for forward compatibility with richer project provisioning, but the host implementation currently persists only `name` and `description` (the projects model has no metadata column today); hosts ignore it until then.
- No existing surface changes shape; `projects.read` consumers are unaffected.

## Tests
`packages/plugins/sdk/tests/host-client-factory.test.ts` covers both sides of the gate: without `projects.write` the call rejects with the capability-denied error; with it the host service receives the typed params and the result round-trips. Full SDK suite green (18/18); typecheck green in `shared`, `plugins/sdk` and `server`.
