### PR TITLE
feat(plugins): generic admin-gated UI slots, agent-detail plugin tabs, canonical minimum-host-version resolver, and locale-stable git invocations

### DIFF
--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -915,6 +915,7 @@ export type {
   PluginLauncherRenderContextSnapshot,
   PluginLauncherDeclaration,
   PluginMinimumHostVersion,
+  PluginMinimumHostVersionSource,
   PluginUiDeclaration,
   PluginDatabaseDeclaration,
   PluginApiRouteCompanyResolution,
@@ -936,7 +937,7 @@ export type {
   QuotaWindow,
   ProviderQuotaResult,
 } from "./types/index.js";
-export { COMPANY_SEARCH_SCOPES } from "./types/index.js";
+export { COMPANY_SEARCH_SCOPES, resolvePluginMinimumHostVersion } from "./types/index.js";
 export {
   ISSUE_REFERENCE_IDENTIFIER_RE,
   buildIssueReferenceHref,

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -585,6 +585,7 @@ export type {
   PluginLauncherRenderContextSnapshot,
   PluginLauncherDeclaration,
   PluginMinimumHostVersion,
+  PluginMinimumHostVersionSource,
   PluginUiDeclaration,
   PluginDatabaseDeclaration,
   PluginApiRouteCompanyResolution,
@@ -608,3 +609,4 @@ export type {
   PluginDatabaseNamespaceMode,
   PluginDatabaseNamespaceStatus,
 } from "./plugin.js";
+export { resolvePluginMinimumHostVersion } from "./plugin.js";

--- a/packages/shared/src/types/plugin-minimum-host-version.test.ts
+++ b/packages/shared/src/types/plugin-minimum-host-version.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { resolvePluginMinimumHostVersion } from "./plugin.js";
+
+describe("resolvePluginMinimumHostVersion", () => {
+  it("prefers the generic minimumHostVersion field", () => {
+    expect(
+      resolvePluginMinimumHostVersion({
+        minimumHostVersion: "2.3.0",
+        minimumPaperclipVersion: "1.0.0",
+      }),
+    ).toBe("2.3.0");
+  });
+
+  it("falls back to the legacy minimumPaperclipVersion alias", () => {
+    expect(
+      resolvePluginMinimumHostVersion({ minimumPaperclipVersion: "1.4.2" }),
+    ).toBe("1.4.2");
+  });
+
+  it("returns undefined (no lower bound) when neither field is declared", () => {
+    expect(resolvePluginMinimumHostVersion({})).toBeUndefined();
+  });
+});

--- a/packages/shared/src/types/plugin.ts
+++ b/packages/shared/src/types/plugin.ts
@@ -402,6 +402,22 @@ export interface PluginUiSlotDeclaration {
    * Defaults to host-defined ordering if omitted.
    */
   order?: number;
+  /**
+   * When `true`, the host only mounts this slot (sidebar entry, page route, …)
+   * for a user who is an admin of the active company, resolved by calling the
+   * data handler this slot names in `adminGateHandler` with the active `companyId`.
+   * The check re-runs whenever the active company changes, so visibility tracks
+   * the per-company admin grant. Defaults to `false` (visible to any
+   * authenticated company member).
+   */
+  requiresAdmin?: boolean;
+  /**
+   * Name of the plugin data handler the host calls to resolve the admin gate.
+   * Must return `{ isAdmin: boolean }`. REQUIRED when `requiresAdmin` is
+   * `true`; a gated slot without it resolves fail-closed (hidden) and the
+   * manifest validator rejects it at install time.
+   */
+  adminGateHandler?: string;
 }
 
 /**
@@ -476,6 +492,34 @@ export interface PluginLauncherDeclaration {
  * the declared minimum.
  */
 export type PluginMinimumHostVersion = string;
+
+/**
+ * The minimal manifest shape needed to resolve the compatibility floor.
+ * Accepting this structural subset (instead of the full manifest) lets the
+ * resolver run against partially-parsed manifests and keeps it dependency-free.
+ */
+export interface PluginMinimumHostVersionSource {
+  /** Preferred generic minimum host version field. */
+  minimumHostVersion?: PluginMinimumHostVersion;
+  /** Legacy alias of `minimumHostVersion`. */
+  minimumPaperclipVersion?: PluginMinimumHostVersion;
+}
+
+/**
+ * Resolve the effective minimum host version a manifest gates compatibility on.
+ *
+ * A manifest may declare either the preferred `minimumHostVersion` field or its
+ * legacy alias `minimumPaperclipVersion`. This is the single canonical place
+ * the host reads that contract from: `minimumHostVersion` wins,
+ * falling back to `minimumPaperclipVersion`, and `undefined` when neither is
+ * declared (meaning "no lower bound — compatible with any host"). The host
+ * loader compares its running version against this value to gate install.
+ */
+export function resolvePluginMinimumHostVersion(
+  manifest: PluginMinimumHostVersionSource,
+): PluginMinimumHostVersion | undefined {
+  return manifest.minimumHostVersion ?? manifest.minimumPaperclipVersion;
+}
 
 /**
  * Groups plugin UI declarations that are served from the shared UI bundle

--- a/packages/shared/src/validators/plugin.test.ts
+++ b/packages/shared/src/validators/plugin.test.ts
@@ -245,4 +245,39 @@ describe("plugin UI slot validators", () => {
     if (parsed.success) return;
     expect(parsed.error.issues.some((issue) => issue.message.includes("reserved by the host"))).toBe(true);
   });
+
+  // The schema must KNOW `requiresAdmin` and `adminGateHandler` (z.object()
+  // drops unknown keys, so any route persisting the parsed manifest would
+  // silently lose an admin gate). This round-trip preserves both.
+  it("accepts an admin-gated slot and preserves requiresAdmin + adminGateHandler", () => {
+    const parsed = pluginUiSlotDeclarationSchema.parse({
+      type: "sidebar",
+      id: "admin-tools-sidebar",
+      displayName: "Admin Tools",
+      exportName: "AdminToolsSidebar",
+      requiresAdmin: true,
+      adminGateHandler: "isCompanyAdmin",
+    });
+
+    expect(parsed.requiresAdmin).toBe(true);
+    expect(parsed.adminGateHandler).toBe("isCompanyAdmin");
+  });
+
+  it("rejects a requiresAdmin slot that omits adminGateHandler (fail-closed at install time)", () => {
+    const parsed = pluginUiSlotDeclarationSchema.safeParse({
+      type: "sidebar",
+      id: "admin-tools-sidebar",
+      displayName: "Admin Tools",
+      exportName: "AdminToolsSidebar",
+      requiresAdmin: true,
+    });
+
+    expect(parsed.success).toBe(false);
+    if (parsed.success) return;
+    expect(
+      parsed.error.issues.some((issue) =>
+        issue.message.includes("requiresAdmin slots must declare adminGateHandler"),
+      ),
+    ).toBe(true);
+  });
 });

--- a/packages/shared/src/validators/plugin.ts
+++ b/packages/shared/src/validators/plugin.ts
@@ -330,6 +330,12 @@ export const pluginUiSlotDeclarationSchema = z.object({
     message: "routePath must be a lowercase single-segment slug (letters, numbers, hyphens)",
   }).optional(),
   order: z.number().int().optional(),
+  // Admin-gated slots. Declared here as well as on the TS type: z.object()
+  // strips unknown keys, so omitting them from the schema would silently
+  // drop the admin gate from any code path persisting the parsed manifest.
+  // `adminGateHandler` names the plugin data handler of the gate.
+  requiresAdmin: z.boolean().optional(),
+  adminGateHandler: z.string().min(1).optional(),
 }).superRefine((value, ctx) => {
   // context-sensitive slots require explicit entity targeting.
   const entityScopedTypes = ["detailTab", "taskDetailView", "contextMenuItem", "commentAnnotation", "commentContextMenuItem", "projectSidebarItem"];
@@ -404,6 +410,14 @@ export const pluginUiSlotDeclarationSchema = z.object({
       code: z.ZodIssueCode.custom,
       message: `company settings routePath "${value.routePath}" is reserved by the host`,
       path: ["routePath"],
+    });
+  }
+  if (value.requiresAdmin === true && !value.adminGateHandler) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message:
+        "requiresAdmin slots must declare adminGateHandler (the plugin data handler that resolves the admin gate)",
+      path: ["adminGateHandler"],
     });
   }
 });

--- a/server/src/__tests__/execution-workspaces-service.test.ts
+++ b/server/src/__tests__/execution-workspaces-service.test.ts
@@ -831,4 +831,94 @@ describeEmbeddedPostgres("executionWorkspaceService.getCloseReadiness", () => {
       "git_branch_delete",
     ]));
   }, 20_000);
+
+  it("forces a stable C locale in the environment of every git invocation", async () => {
+    const repoRoot = await createTempRepo();
+    tempDirs.add(repoRoot);
+
+    // A fake `git` first on PATH records the locale environment runGit spawns
+    // it with. Close-readiness inspection (and other callers that parse git's
+    // human-readable output) only works when the child process runs under the
+    // C locale, no matter what locale the host server itself runs under.
+    const shimDir = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-git-shim-"));
+    tempDirs.add(shimDir);
+    await fs.writeFile(
+      path.join(shimDir, "git"),
+      [
+        "#!/bin/sh",
+        "# argv: -C <cwd> <subcommand ...>",
+        "shift 2",
+        'if [ "$1" = "rev-parse" ] && [ "$2" = "--show-toplevel" ]; then',
+        "  printf 'locale-probe LC_ALL=%s LANG=%s LANGUAGE=%s\\n' \"$LC_ALL\" \"$LANG\" \"$LANGUAGE\"",
+        "fi",
+        "exit 0",
+      ].join("\n"),
+      { mode: 0o755 },
+    );
+
+    const companyId = randomUUID();
+    const projectId = randomUUID();
+    const projectWorkspaceId = randomUUID();
+    const executionWorkspaceId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: "PAP",
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(projects).values({
+      id: projectId,
+      companyId,
+      name: "Workspaces",
+      status: "in_progress",
+      executionWorkspacePolicy: {
+        enabled: true,
+      },
+    });
+    await db.insert(projectWorkspaces).values({
+      id: projectWorkspaceId,
+      companyId,
+      projectId,
+      name: "Primary",
+      sourceType: "git_repo",
+      isPrimary: true,
+      cwd: repoRoot,
+    });
+    await db.insert(executionWorkspaces).values({
+      id: executionWorkspaceId,
+      companyId,
+      projectId,
+      projectWorkspaceId,
+      mode: "shared_workspace",
+      strategyType: "project_primary",
+      name: "Shared workspace",
+      status: "active",
+      providerType: "local_fs",
+      cwd: repoRoot,
+      branchName: "main",
+    });
+
+    const savedEnv: Record<string, string | undefined> = {
+      PATH: process.env.PATH,
+      LC_ALL: process.env.LC_ALL,
+      LANG: process.env.LANG,
+      LANGUAGE: process.env.LANGUAGE,
+    };
+    process.env.PATH = `${shimDir}${path.delimiter}${savedEnv.PATH ?? ""}`;
+    // Simulate a non-English host locale: without the LC_ALL=C override the
+    // spawned git would inherit it and emit translated, unparseable output.
+    process.env.LC_ALL = "es_ES.UTF-8";
+    process.env.LANG = "es_ES.UTF-8";
+    process.env.LANGUAGE = "es_ES";
+    try {
+      const readiness = await svc.getCloseReadiness(executionWorkspaceId);
+      expect(readiness?.git?.repoRoot).toBe("locale-probe LC_ALL=C LANG=C LANGUAGE=C");
+    } finally {
+      for (const [key, value] of Object.entries(savedEnv)) {
+        if (value === undefined) delete process.env[key];
+        else process.env[key] = value;
+      }
+    }
+  }, 20_000);
 });

--- a/server/src/services/execution-workspaces.ts
+++ b/server/src/services/execution-workspaces.ts
@@ -73,7 +73,13 @@ async function pathExists(value: string | null | undefined) {
 }
 
 async function runGit(args: string[], cwd: string) {
-  return await execFileAsync("git", ["-C", cwd, ...args], { cwd });
+  // Force a stable C/English locale so git's human-readable output is parseable
+  // regardless of the host's system language (Spanish/other would break callers
+  // that match English git messages).
+  return await execFileAsync("git", ["-C", cwd, ...args], {
+    cwd,
+    env: { ...process.env, LC_ALL: "C", LANG: "C", LANGUAGE: "C" },
+  });
 }
 
 async function inspectGitCloseReadiness(workspace: ExecutionWorkspace): Promise<{

--- a/server/src/services/plugin-loader.ts
+++ b/server/src/services/plugin-loader.ts
@@ -38,6 +38,7 @@ import type {
   PluginRecord,
   PluginUiSlotDeclaration,
 } from "@paperclipai/shared";
+import { resolvePluginMinimumHostVersion } from "@paperclipai/shared";
 import { logger } from "../middleware/logger.js";
 import { pluginManifestValidator } from "./plugin-manifest-validator.js";
 import { pluginCapabilityValidator } from "./plugin-capability-validator.js";
@@ -976,9 +977,11 @@ function compareSemver(left: string, right: string): number {
   return 0;
 }
 
-function getMinimumHostVersion(manifest: PaperclipPluginManifestV1): string | undefined {
-  return manifest.minimumHostVersion ?? manifest.minimumPaperclipVersion;
-}
+// The effective compatibility floor is resolved by the canonical shared helper
+// `resolvePluginMinimumHostVersion`, which owns the `minimumHostVersion ??
+// minimumPaperclipVersion` precedence declared on the manifest type.
+// Aliased here to keep the call site below unchanged.
+const getMinimumHostVersion = resolvePluginMinimumHostVersion;
 
 /**
  * Extract UI contribution metadata from a manifest for route serialization.

--- a/server/src/services/workspace-runtime.ts
+++ b/server/src/services/workspace-runtime.ts
@@ -529,6 +529,12 @@ async function runGit(args: string[], cwd: string): Promise<string> {
     command: "git",
     args,
     cwd,
+    // Force a stable C/English locale so git's human-readable messages
+    // (e.g. "fatal: a branch named X already exists") are parseable regardless
+    // of the host's system language — gitErrorIncludes() below matches English
+    // text, and a Spanish/other locale ("ya existe") would silently break the
+    // existing-branch/worktree detection.
+    env: { ...process.env, LC_ALL: "C", LANG: "C", LANGUAGE: "C" },
   });
   if (proc.code !== 0) {
     throw new Error(proc.stderr.trim() || proc.stdout.trim() || `git ${args.join(" ")} failed`);

--- a/ui/src/lib/queryKeys.ts
+++ b/ui/src/lib/queryKeys.ts
@@ -299,6 +299,8 @@ export const queryKeys = {
       ["plugins", pluginId, "companies", companyId, "local-folders"] as const,
     dashboard: (pluginId: string) => ["plugins", pluginId, "dashboard"] as const,
     logs: (pluginId: string) => ["plugins", pluginId, "logs"] as const,
+    adminVisibility: (pluginId: string, companyId: string | null) =>
+      ["plugins", pluginId, "admin-visibility", companyId ?? "none"] as const,
   },
   adapters: {
     all: ["adapters"] as const,

--- a/ui/src/pages/AgentDetail.tsx
+++ b/ui/src/pages/AgentDetail.tsx
@@ -25,6 +25,7 @@ import { useBreadcrumbs } from "../context/BreadcrumbContext";
 import { queryKeys } from "../lib/queryKeys";
 import { resolveSkillSummaryText } from "../lib/company-skill-summary";
 import { AgentConfigForm } from "../components/AgentConfigForm";
+import { PluginSlotMount, usePluginSlots } from "../plugins/slots";
 import { PageTabBar } from "../components/PageTabBar";
 import { adapterLabels, roleLabels, help } from "../components/agent-config-primitives";
 import { ToggleSwitch } from "@/components/ui/toggle-switch";
@@ -251,7 +252,7 @@ function scrollToContainerBottom(container: ScrollContainer, behavior: ScrollBeh
   container.scrollTo({ top: container.scrollHeight, behavior });
 }
 
-type AgentDetailView = "dashboard" | "instructions" | "configuration" | "skills" | "runs" | "budget";
+type AgentDetailView = "dashboard" | "instructions" | "configuration" | "skills" | "runs" | "budget" | string;
 
 function parseAgentDetailView(value: string | null): AgentDetailView {
   if (value === "instructions" || value === "prompts") return "instructions";
@@ -259,6 +260,8 @@ function parseAgentDetailView(value: string | null): AgentDetailView {
   if (value === "skills") return "skills";
   if (value === "budget") return "budget";
   if (value === "runs") return value;
+  // Allow plugin tab values (e.g., "plugin:acme.tools:agent-insights")
+  if (value && value.startsWith("plugin:")) return value;
   return "dashboard";
 }
 
@@ -678,6 +681,22 @@ export function AgentDetail() {
   const [actionError, setActionError] = useState<string | null>(null);
   const [dismissedLeftAgentIds, setDismissedLeftAgentIds] = useState<Set<string>>(() => new Set());
   const activeView = urlRunId ? "runs" as AgentDetailView : parseAgentDetailView(urlTab ?? null);
+  // Plugin-contributed agent detail tabs (detailTab slots, entityType "agent").
+  const { slots: agentPluginDetailSlots } = usePluginSlots({
+    slotTypes: ["detailTab"],
+    entityType: "agent",
+    companyId: selectedCompanyId ?? undefined,
+    enabled: !!selectedCompanyId,
+  });
+  const agentPluginTabItems = useMemo(
+    () => agentPluginDetailSlots.map((slot) => ({
+      value: `plugin:${slot.pluginKey}:${slot.id}`,
+      label: slot.displayName,
+      slot,
+    })),
+    [agentPluginDetailSlots],
+  );
+  const activeAgentPluginTab = agentPluginTabItems.find((item) => item.value === activeView) ?? null;
   const needsDashboardData = activeView === "dashboard";
   const needsRunData = activeView === "runs" || Boolean(urlRunId);
   const shouldLoadHeartbeats = needsDashboardData || needsRunData;
@@ -803,7 +822,12 @@ export function AgentDetail() {
               ? "runs"
               : activeView === "budget"
                 ? "budget"
-              : "dashboard";
+                // Plugin tabs (e.g. "plugin:acme.tools:agent-insights") are
+                // first-class tab values — preserve them so users navigating
+                // to a plugin slot URL don't get stranded back on dashboard.
+                : typeof activeView === "string" && activeView.startsWith("plugin:")
+                  ? activeView
+                  : "dashboard";
     if (routeAgentRef !== canonicalAgentRef || urlTab !== canonicalTab) {
       navigate(`/agents/${canonicalAgentRef}/${canonicalTab}`, { replace: true });
       return;
@@ -910,6 +934,8 @@ export function AgentDetail() {
         crumbs.push({ label: "Runs" });
       } else if (activeView === "budget") {
         crumbs.push({ label: "Budget" });
+      } else if (activeAgentPluginTab) {
+        crumbs.push({ label: activeAgentPluginTab.label });
       } else {
         crumbs.push({ label: "Dashboard" });
       }
@@ -1069,6 +1095,7 @@ export function AgentDetail() {
               { value: "configuration", label: "Configuration" },
               { value: "runs", label: "Runs" },
               { value: "budget", label: "Budget" },
+              ...agentPluginTabItems,
             ]}
             value={activeView}
             onValueChange={(value) => navigate(`/agents/${canonicalAgentRef}/${value}`)}
@@ -1206,6 +1233,19 @@ export function AgentDetail() {
           />
         </div>
       ) : null}
+
+      {/* Plugin-contributed agent detail tabs */}
+      {activeAgentPluginTab && agent && (
+        <PluginSlotMount
+          slot={activeAgentPluginTab.slot}
+          context={{
+            companyId: agent.companyId,
+            entityId: agent.id,
+            entityType: "agent",
+          }}
+          missingBehavior="placeholder"
+        />
+      )}
     </div>
   );
 }

--- a/ui/src/pages/PluginPage.tsx
+++ b/ui/src/pages/PluginPage.tsx
@@ -96,6 +96,34 @@ export function PluginPage() {
     [resolvedCompanyId, companyPrefix],
   );
 
+  // Defense-in-depth: an admin-gated page route is mounted ONLY for an admin
+  // of the active company. The plugin's authoritative manifest-declared
+  // `adminGateHandler` is consulted (server-resolved, never a client claim),
+  // scoped by `companyId` so the check re-runs on company switch. Fail-closed
+  // while pending / on error.
+  const pageRequiresAdmin = pageSlot?.requiresAdmin === true;
+  const pageAdminGateHandler = pageSlot?.adminGateHandler ?? null;
+  const { data: pageAdmin, isLoading: pageAdminLoading } = useQuery({
+    queryKey: queryKeys.plugins.adminVisibility(pageSlot?.pluginId ?? "none", resolvedCompanyId ?? null),
+    enabled: pageRequiresAdmin && !!pageSlot && !!resolvedCompanyId,
+    queryFn: async () => {
+      // Fail-closed: a gated page whose manifest names no handler never mounts.
+      if (!pageSlot || !pageAdminGateHandler) return { isAdmin: false };
+      try {
+        const response = await pluginsApi.bridgeGetData(
+          pageSlot.pluginId,
+          pageAdminGateHandler,
+          undefined,
+          resolvedCompanyId ?? null,
+        );
+        const payload = response?.data as { isAdmin?: boolean } | null | undefined;
+        return { isAdmin: payload?.isAdmin === true };
+      } catch {
+        return { isAdmin: false };
+      }
+    },
+  });
+
   // When the active route has a routeSidebar slot, the sidebar provides the
   // back affordance, but the top bar still needs a route-specific title.
   const routeSidebarActive = useMemo(() => {
@@ -161,6 +189,17 @@ export function PluginPage() {
       ? `/company/settings/instance/plugins/${pluginId}`
       : "/company/settings/instance/plugins";
     return <Navigate to={settingsPath} replace />;
+  }
+
+  // Host-side admin gate for the full-page route: never mount
+  // the page UI for a non-admin (the plugin's in-page banner is a second gate).
+  if (pageRequiresAdmin) {
+    if (pageAdminLoading) {
+      return <div className="text-sm text-muted-foreground">Loading…</div>;
+    }
+    if (pageAdmin?.isAdmin !== true) {
+      return <NotFoundPage scope="board" />;
+    }
   }
 
   return (

--- a/ui/src/plugins/slots.test.ts
+++ b/ui/src/plugins/slots.test.ts
@@ -3,14 +3,29 @@
 import { createElement } from "react";
 import { flushSync } from "react-dom";
 import { createRoot, type Root } from "react-dom/client";
-import { afterEach, describe, expect, it } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { PluginUiSlotDeclaration } from "@paperclipai/shared";
+import type { PluginUiContribution } from "@/api/plugins";
 import {
   PluginSlotMount,
   _collectRegisterableExportNamesForTests,
   _resetPluginModuleLoader,
   registerPluginWebComponent,
+  usePluginSlots,
   type ResolvedPluginSlot,
 } from "./slots";
+
+// Host tests for the manifest-declared admin gate. The gate calls
+// `pluginsApi.bridgeGetData(pluginId, slot.adminGateHandler, ...)`, so we drive
+// the REAL `usePluginSlots` hook and assert the exact bridge call + fail-closed
+// filtering.
+const mockPluginsApi = vi.hoisted(() => ({
+  listUiContributions: vi.fn(),
+  bridgeGetData: vi.fn(),
+}));
+
+vi.mock("@/api/plugins", () => ({ pluginsApi: mockPluginsApi }));
 
 let roots: Root[] = [];
 
@@ -83,5 +98,188 @@ describe("plugin slot export registration", () => {
 
     expect(container.textContent).not.toContain("Content Machine: Content");
     expect(container.querySelector("paperclip-test-sidebar")).not.toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The admin gate is driven by the MANIFEST-declared `adminGateHandler`, not a
+// host hardcode. These cases render the real `usePluginSlots` hook against a
+// mocked bridge and assert (1) the exact handler name is queried and the slot
+// is visible when admin, (2) a gated slot without a declared handler is never
+// queried and stays hidden (fail-closed), (3) switching the active company
+// re-runs the check.
+// ---------------------------------------------------------------------------
+
+let captured: ReturnType<typeof usePluginSlots> | null = null;
+
+function GateHarness({ filters }: { filters: Parameters<typeof usePluginSlots>[0] }) {
+  captured = usePluginSlots(filters);
+  return null;
+}
+
+function contribution(slots: PluginUiSlotDeclaration[]): PluginUiContribution {
+  return {
+    pluginId: "plugin-1",
+    pluginKey: "plugin-1-key",
+    displayName: "Plugin One",
+    version: "1.0.0",
+    uiEntryFile: "index.js",
+    slots,
+    launchers: [],
+  };
+}
+
+async function settle(): Promise<void> {
+  // Let react-query resolve its async queries and React re-render.
+  for (let i = 0; i < 25; i++) {
+    await Promise.resolve();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    flushSync(() => {});
+  }
+}
+
+function mountGate() {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  roots.push(root);
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } });
+  const render = (filters: Parameters<typeof usePluginSlots>[0]) => {
+    flushSync(() => {
+      root.render(
+        createElement(
+          QueryClientProvider,
+          { client: queryClient },
+          createElement(GateHarness, { filters }),
+        ),
+      );
+    });
+  };
+  return { render };
+}
+
+describe("admin-gated slots resolve via the manifest-declared adminGateHandler", () => {
+  const originalFetch = globalThis.fetch;
+  const originalBridge = (globalThis as unknown as { __paperclipPluginBridge__?: unknown }).__paperclipPluginBridge__;
+
+  beforeEach(() => {
+    captured = null;
+    mockPluginsApi.listUiContributions.mockReset();
+    mockPluginsApi.bridgeGetData.mockReset();
+    // Neutralize plugin UI module loading (irrelevant to the gate): make the
+    // loader's fetch reject so it fails closed and caught, never touching a real bundle.
+    (globalThis as unknown as { __paperclipPluginBridge__?: unknown }).__paperclipPluginBridge__ = {};
+    (globalThis as { fetch: unknown }).fetch = vi.fn(async () => {
+      throw new Error("no plugin module in test");
+    });
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    (globalThis as { fetch: unknown }).fetch = originalFetch;
+    (globalThis as unknown as { __paperclipPluginBridge__?: unknown }).__paperclipPluginBridge__ = originalBridge;
+    vi.restoreAllMocks();
+  });
+
+  it("queries the slot's adminGateHandler and shows the slot for an admin", async () => {
+    mockPluginsApi.listUiContributions.mockResolvedValue([
+      contribution([
+        {
+          type: "sidebar",
+          id: "gated-sidebar",
+          displayName: "Gated",
+          exportName: "GatedSidebar",
+          requiresAdmin: true,
+          adminGateHandler: "customAdminHandler",
+        },
+      ]),
+    ]);
+    mockPluginsApi.bridgeGetData.mockResolvedValue({ data: { isAdmin: true } });
+
+    const { render } = mountGate();
+    render({ slotTypes: ["sidebar"], companyId: "company-1" });
+    await settle();
+
+    // The host called the MANIFEST-declared handler.
+    expect(mockPluginsApi.bridgeGetData).toHaveBeenCalledWith(
+      "plugin-1",
+      "customAdminHandler",
+      undefined,
+      "company-1",
+    );
+    // The admin resolves true → the gated slot is visible.
+    expect((captured?.slots ?? []).map((s) => s.id)).toContain("gated-sidebar");
+  });
+
+  it("never queries and keeps hidden a gated slot that declares no adminGateHandler (fail-closed)", async () => {
+    mockPluginsApi.listUiContributions.mockResolvedValue([
+      contribution([
+        {
+          type: "sidebar",
+          id: "gated-no-handler",
+          displayName: "Gated No Handler",
+          exportName: "GatedNoHandlerSidebar",
+          requiresAdmin: true,
+          // adminGateHandler intentionally absent
+        },
+        {
+          type: "sidebar",
+          id: "open-sidebar",
+          displayName: "Open",
+          exportName: "OpenSidebar",
+        },
+      ]),
+    ]);
+    mockPluginsApi.bridgeGetData.mockResolvedValue({ data: { isAdmin: true } });
+
+    const { render } = mountGate();
+    render({ slotTypes: ["sidebar"], companyId: "company-1" });
+    await settle();
+
+    // A gated slot with no declared handler is never queried …
+    expect(mockPluginsApi.bridgeGetData).not.toHaveBeenCalled();
+    const visibleIds = (captured?.slots ?? []).map((s) => s.id);
+    // … and stays hidden, while the non-gated slot passes through.
+    expect(visibleIds).not.toContain("gated-no-handler");
+    expect(visibleIds).toContain("open-sidebar");
+  });
+
+  it("re-runs the check on company switch: visible for the company where the user is admin, hidden for the other", async () => {
+    mockPluginsApi.listUiContributions.mockResolvedValue([
+      contribution([
+        {
+          type: "sidebar",
+          id: "gated-sidebar",
+          displayName: "Gated",
+          exportName: "GatedSidebar",
+          requiresAdmin: true,
+          adminGateHandler: "customAdminHandler",
+        },
+      ]),
+    ]);
+    // Admin of company-1 only.
+    mockPluginsApi.bridgeGetData.mockImplementation(
+      async (_pluginId: string, _key: string, _params: unknown, companyId: string | null) => ({
+        data: { isAdmin: companyId === "company-1" },
+      }),
+    );
+
+    const { render } = mountGate();
+
+    render({ slotTypes: ["sidebar"], companyId: "company-1" });
+    await settle();
+    expect((captured?.slots ?? []).map((s) => s.id)).toContain("gated-sidebar");
+
+    // Switch to company-2 → the host re-runs the check for the new company.
+    render({ slotTypes: ["sidebar"], companyId: "company-2" });
+    await settle();
+    expect(mockPluginsApi.bridgeGetData).toHaveBeenCalledWith(
+      "plugin-1",
+      "customAdminHandler",
+      undefined,
+      "company-2",
+    );
+    expect((captured?.slots ?? []).map((s) => s.id)).not.toContain("gated-sidebar");
   });
 });

--- a/ui/src/plugins/slots.tsx
+++ b/ui/src/plugins/slots.tsx
@@ -113,6 +113,66 @@ type SlotFilters = {
   enabled?: boolean;
 };
 
+/**
+ * Resolve, per plugin that declares any `requiresAdmin` slot, whether the
+ * current user is an admin of the active company. Each plugin's authoritative
+ * manifest-declared `adminGateHandler` is called (server-resolved — never a
+ * client claim) scoped by `companyId`. The query is
+ * keyed by `companyId`, so toggling the active company re-runs the check and
+ * the resolved visibility flips accordingly.
+ *
+ * Returns a map `pluginId -> isAdmin`. A plugin absent from the map (or mapped
+ * to `false`) has its admin-gated slots hidden. Defaults to hidden while the
+ * check is pending or on error — fail-closed, never leaking an admin surface.
+ */
+function usePluginAdminVisibility(
+  adminGatedPlugins: ReadonlyMap<string, string>, // pluginId -> manifest adminGateHandler
+  companyId: string | null | undefined,
+): Map<string, boolean> {
+  const pluginIdsKey = useMemo(
+    () =>
+      [...adminGatedPlugins.entries()]
+        .map(([pluginId, handler]) => `${pluginId}:${handler}`)
+        .sort()
+        .join("|"),
+    [adminGatedPlugins],
+  );
+  const scopedCompanyId = companyId ?? null;
+
+  const { data } = useQuery({
+    queryKey: queryKeys.plugins.adminVisibility(pluginIdsKey || "none", scopedCompanyId),
+    enabled: pluginIdsKey.length > 0 && !!scopedCompanyId,
+    queryFn: async () => {
+      const results = await Promise.all(
+        [...adminGatedPlugins.entries()].map(async ([pluginId, adminGateHandler]) => {
+          try {
+            const response = await pluginsApi.bridgeGetData(
+              pluginId,
+              adminGateHandler,
+              undefined,
+              scopedCompanyId,
+            );
+            const payload = response?.data as { isAdmin?: boolean } | null | undefined;
+            return [pluginId, payload?.isAdmin === true] as const;
+          } catch {
+            // Fail-closed: a failed admin check hides the gated surface.
+            return [pluginId, false] as const;
+          }
+        }),
+      );
+      return Object.fromEntries(results) as Record<string, boolean>;
+    },
+  });
+
+  return useMemo(() => {
+    const map = new Map<string, boolean>();
+    for (const [pluginId, isAdmin] of Object.entries(data ?? {})) {
+      map.set(pluginId, isAdmin === true);
+    }
+    return map;
+  }, [data]);
+}
+
 type UsePluginSlotsResult = {
   slots: ResolvedPluginSlot[];
   isLoading: boolean;
@@ -651,7 +711,7 @@ export function usePluginSlots(filters: SlotFilters): UsePluginSlotsResult {
 
   const slotTypesKey = useMemo(() => [...filters.slotTypes].sort().join("|"), [filters.slotTypes]);
 
-  const slots = useMemo(() => {
+  const candidateSlots = useMemo(() => {
     const allowedTypes = new Set(slotTypesKey.split("|").filter(Boolean) as PluginUiSlotType[]);
     const rows: ResolvedPluginSlot[] = [];
     for (const contribution of data ?? []) {
@@ -680,6 +740,33 @@ export function usePluginSlots(filters: SlotFilters): UsePluginSlotsResult {
     });
     return rows;
   }, [data, filters.entityType, slotTypesKey]);
+
+  // Plugins declaring admin-gated slots, keyed to the data handler their
+  // MANIFEST names (slot.adminGateHandler). A gated slot without a declared
+  // handler is never queried and stays hidden (fail-closed).
+  const adminGatedPlugins = useMemo(() => {
+    const handlers = new Map<string, string>();
+    for (const slot of candidateSlots) {
+      if (slot.requiresAdmin === true && slot.adminGateHandler) {
+        handlers.set(slot.pluginId, slot.adminGateHandler);
+      }
+    }
+    return handlers;
+  }, [candidateSlots]);
+
+  const adminVisibility = usePluginAdminVisibility(adminGatedPlugins, filters.companyId);
+
+  // Drop admin-gated slots whose plugin did not resolve the current user as an
+  // admin of the active company. Non-gated slots pass through unchanged. The
+  // drop re-evaluates on company switch because `adminVisibility` is keyed by
+  // `companyId`.
+  const slots = useMemo(
+    () =>
+      candidateSlots.filter((slot) =>
+        slot.requiresAdmin === true ? adminVisibility.get(slot.pluginId) === true : true,
+      ),
+    [candidateSlots, adminVisibility],
+  );
 
   // Consider loading until both query and module imports are done.
   const modulesLoaded = data ? aggregateLoadState(data) === "loaded" : true;


### PR DESCRIPTION
Four small, independent developer-experience/substrate improvements for plugin authors and the plugin host. Happy to split into separate PRs on request — they are grouped because each is tiny and they share files.

**1. Generic admin-gated UI slots (`requiresAdmin` + `adminGateHandler`).** A plugin can declare that a UI slot (sidebar entry, page route, …) must only be visible to an "admin" as *the plugin defines it*: the manifest names a plugin data handler (`adminGateHandler`) that the host calls with the active `companyId`; it returns `{ isAdmin: boolean }`. The host filters gated slots fail-closed (hidden while pending, on error, or when the manifest names no handler), re-runs the check on company switch, and the full-page route (`PluginPage`) refuses to mount for non-admins as defense-in-depth. Crucially this is *generic*: the host contains **zero** plugin-specific handler names — the authority is the manifest. Both new fields are declared in the Zod slot schema as well as on the TS type by design: `z.object()` strips unknown keys, so a type-only declaration would let any code path persisting the *parsed* manifest silently drop the admin gate. A `superRefine` additionally rejects `requiresAdmin: true` without a handler at install time.

**2. Agent-detail plugin tabs (`detailTab` for the `agent` entity).** The `detailTab` slot type exists but the agent detail page never mounts it. This PR renders `detailTab` slots (entityType `agent`) as first-class tabs on `AgentDetail` — plugin tab values are URL-preserved (`plugin:<pluginKey>:<slotId>`), included in breadcrumbs, and mounted with the standard `PluginSlotMount` context (`companyId`, `entityId`, `entityType`).

**3. Canonical `resolvePluginMinimumHostVersion`.** The `minimumHostVersion ?? minimumPaperclipVersion` precedence was a private helper inside the server plugin loader; plugins/tools that need to reason about the compatibility floor (e.g. a manifest linter or a plugin's own build) had to duplicate it. The resolver moves to `@paperclipai/shared` next to the manifest types (accepting a minimal structural subset so it runs on partially-parsed manifests) and the loader consumes it — single source of truth, with unit tests.

**4. Locale-stable git invocations.** The host's `runGit` helpers parse git's *human-readable English* output (e.g. the existing-branch/worktree detection matches "already exists"). On a non-English host locale (Spanish: "ya existe") that detection silently breaks. Fix: force `LC_ALL=C, LANG=C, LANGUAGE=C` in the child process env of both `runGit` helpers (`execution-workspaces.ts`, `workspace-runtime.ts`).

All additive/behavior-preserving on English-locale hosts; item 4 is a straight bugfix for non-English hosts.
