### PR TITLE
Add .ideas idea catalog with corrected Combo 01 phasing

### DIFF
--- a/.ideas/001-fleet-concurrency-governor.md
+++ b/.ideas/001-fleet-concurrency-governor.md
@@ -1,0 +1,45 @@
+# 001 — Fleet Concurrency Governor
+
+## Suggestion
+
+Add a **global admission-control layer** that caps how many agent runs may execute
+concurrently across an entire instance and per company — not just per agent.
+
+Today concurrency is enforced *per agent*: `heartbeat.ts` computes
+`availableSlots = policy.maxConcurrentRuns - runningCount` for a single agent
+(default 20, clamped 1–50). Nothing stops 30 agents from each launching 20 runs at once.
+For an operator running "20 simultaneous Claude Code terminals" (a stated use case in the
+README), this means unbounded real concurrency — which translates directly into runaway
+API spend, machine thrash, and provider rate-limit storms.
+
+A Fleet Concurrency Governor lets an operator say: *"never run more than N agent runs at
+once on this machine"* and *"company X gets at most M concurrent runs."* When the cap is
+hit, new runs queue instead of launching, and the dashboard shows what's running vs.
+waiting.
+
+## How it could be achieved
+
+1. **Settings surface.** Add `instanceMaxConcurrentRuns` to `instance-settings.ts` and a
+   per-company `maxConcurrentRuns` column on the companies table (`packages/db`). Expose
+   both in the existing settings/company routes.
+2. **Central counter.** Introduce a `run-admission` service that holds live counts of
+   active runs keyed by `{instance, companyId}`. The plugin job scheduler
+   (`plugin-job-scheduler.ts`, `maxConcurrentJobs` gate at line ~298) is a near-exact
+   template for the acquire/release pattern.
+3. **Gate the launch path.** Before `heartbeat.ts` actually starts a queued run, call
+   `runAdmission.tryAcquire(companyId)`. If no slot is free, leave the run in a
+   `queued_admission` state instead of starting it, and release the slot on run
+   completion/failure (hook the same place watchdogs mark runs finished).
+4. **Wakeup on free slot.** When a slot releases, pop the highest-priority waiting run and
+   trigger the existing `issue-assignment-wakeup` path so it starts promptly.
+5. **UI.** Add a "Running N / Cap M · K waiting" badge to the dashboard and a per-company
+   row, reusing the live-events websocket so it updates in real time.
+
+## Perceived complexity
+
+**Medium–High.** The acquire/release primitive is straightforward and has a working
+in-repo precedent, but correctness is the hard part: slot accounting must survive crashes,
+process recovery (`heartbeat-process-recovery`), and stale runs, or the system will slowly
+deadlock as leaked slots accumulate. Needs a reconciler that recomputes live counts from
+actual run state on a timer. The DB/settings/UI plumbing is mechanical; the distributed-
+counting correctness is where the effort goes.

--- a/.ideas/002-predictive-budget-circuit-breaker.md
+++ b/.ideas/002-predictive-budget-circuit-breaker.md
@@ -1,0 +1,41 @@
+# 002 — Predictive Budget Circuit Breaker
+
+## Suggestion
+
+Budgets today are mostly a **post-hoc ledger**: spend is tracked and a hard stop trips when
+a limit is crossed. By the time the limit is hit, the money is already spent. Add a
+**predictive circuit breaker** that watches burn rate and intervenes *before* the wall —
+throttling concurrency or pausing low-priority agents when a company is forecast to blow
+its budget within a chosen horizon.
+
+Example operator experience:
+> "At the current burn rate ($4.10/min), Company *Granola-clone* will exhaust its daily
+> budget in 38 minutes. Auto-throttling non-critical agents from 12 → 4 concurrent runs."
+
+This turns budgeting from a guardrail you slam into, into a control loop that smooths spend.
+
+## How it could be achieved
+
+1. **Burn-rate signal.** `costs.ts` / `finance.ts` already aggregate spend. Add a rolling
+   windowed burn computation (e.g. spend over the last 5/15/60 min) exposed as a derived
+   metric per company.
+2. **Forecast.** `timeToLimit = remainingBudget / currentBurnRate`. Compare against a
+   configurable `breakerHorizonMinutes`.
+3. **Graduated responses** rather than a single hard stop:
+   - *Warn* — surface an inbox item / dashboard banner.
+   - *Throttle* — lower the company's effective concurrency cap (pairs directly with
+     idea 001, the Fleet Concurrency Governor).
+   - *Pause* — stop non-critical agents (those whose current issue isn't on the goal's
+     critical path), leaving the CEO/critical agents running.
+4. **Config.** Per-company breaker policy in budgets settings: horizon, which response
+   tier, and a "protected roles" allowlist.
+5. **Audit.** Log every breaker action to `activity-log.ts` so operators can see exactly
+   when and why autonomy was throttled.
+
+## Perceived complexity
+
+**Medium.** The spend ledger and budget primitives already exist, so this is mostly a
+derived-metric + policy-engine layer on top, plus a clean integration point with the
+concurrency governor. The subtle part is avoiding oscillation (throttle → burn drops →
+un-throttle → burn spikes → throttle …); needs hysteresis / a cooldown, similar in spirit
+to the `freeze` cooldown concept. No schema-heavy work required.

--- a/.ideas/003-diminishing-returns-detector.md
+++ b/.ideas/003-diminishing-returns-detector.md
@@ -1,0 +1,39 @@
+# 003 — Diminishing-Returns Detector
+
+## Suggestion
+
+Watchdogs (`task-watchdogs.ts`, `issue-liveness.ts`, `run-liveness.ts`) catch runs that are
+**stuck or crashed**. They do not catch runs that are **busy but unproductive** — an agent
+that keeps waking up, burns tokens, and makes no real progress on the same issue (the
+classic autonomous-agent failure mode: re-reading the same files, re-proposing the same
+plan, looping on a failing test). This is the most expensive failure because it *looks*
+healthy.
+
+Add a **Diminishing-Returns Detector** that flags an agent thrashing on an issue with no
+state change, auto-pauses it, and escalates to a human (or its manager agent) instead of
+letting it quietly spend.
+
+## How it could be achieved
+
+1. **Progress signal per issue.** Define a lightweight "progress fingerprint" updated on
+   each run: issue status, comment/work-product count, diff size, sub-issue count. Store
+   the last K fingerprints per issue (small table or reuse run metadata).
+2. **Stall heuristic.** If the last N runs on an issue produced (a) no status change,
+   (b) no new work products, and (c) cumulative cost over a threshold, mark the issue
+   `diminishing_returns`. The recovery classifiers in `server/src/services/recovery/`
+   and `recovery-classifiers.test.ts` are the natural home for this rule.
+3. **Action.** On trip: pause further auto-wakeups for that issue, post an explanatory
+   comment ("paused after 5 runs / $2.10 with no progress"), and raise an inbox item
+   routed to the assignee's manager via the existing approval/review handoff path.
+4. **Tunable.** Per-company thresholds (runs, spend, time) so cheap exploratory work isn't
+   prematurely killed.
+5. **Optional escalation ladder.** First trip → notify manager agent; second → notify
+   human board. Reuses the org chart for routing.
+
+## Perceived complexity
+
+**Medium.** No new runtime or scheduler — it's an analyzer that reads existing run/issue
+history plus a pause action that hooks the existing wakeup-suppression path. The real
+design effort is the heuristic: tuning it so it catches genuine loops without killing slow-
+but-legitimate work. Worth shipping behind a default-on-but-conservative threshold and
+iterating from real telemetry.

--- a/.ideas/004-company-dry-run-estimator.md
+++ b/.ideas/004-company-dry-run-estimator.md
@@ -1,0 +1,39 @@
+# 004 — Company Dry-Run Estimator
+
+## Suggestion
+
+Before an operator hits "go" on a freshly built company, they have **no idea what it will
+cost or how long it will take**. They configure a CEO, a few reports, budgets, and initial
+tasks — then launch into the unknown and watch the spend meter. Add a **Dry-Run Estimator**
+that simulates the first wave of work and returns a projected cost band, expected concurrency
+profile, and obvious misconfigurations — *without* spending real tokens on production work.
+
+Think of it as a "preflight check" for an autonomous company.
+
+## How it could be achieved
+
+1. **Static checks (cheap, deterministic).** Walk the org chart and config: agents with no
+   reachable tasks, budgets that can't cover even one run at the configured model, missing
+   secrets/adapter bindings, circular reporting, an unreachable goal (no task chain). Most
+   data is already validated piecemeal in `companies.ts`, `agents.ts`, `budgets.ts`,
+   `agent-secret-bindings.ts` — this aggregates them into one report.
+2. **Cost model.** Use historical cost-per-run by adapter/model from `costs.ts` (or a seeded
+   default table when no history exists) to estimate cost of the first heartbeat across all
+   agents, then project N cycles.
+3. **Concurrency projection.** Combine per-agent `maxConcurrentRuns` with the proposed Fleet
+   Governor cap (idea 001) to show "expected peak: 14 concurrent runs, ~$9–22 in the first
+   hour."
+4. **Optional shadow heartbeat.** For higher fidelity, run one real heartbeat per agent in a
+   `dryRun` mode where adapters are asked to *plan only* (no destructive actions, no
+   workspace writes) and report intended actions + token estimate. The adapter boundary
+   already supports capability gating, so a `planOnly` capability flag is a natural fit.
+5. **UI.** A "Preflight" panel on the company page before launch, with a traffic-light
+   summary and an itemized projected-cost table.
+
+## Perceived complexity
+
+**Medium–High.** The static-check aggregation is low effort and immediately useful on its
+own — ship that first. The cost projection is medium (needs a defensible model and a cold-
+start default). The shadow-heartbeat tier is the expensive part: it requires a `planOnly`
+contract across adapters and guarantees that dry-run truly performs no side effects, which
+is a meaningful safety surface to get right. Phase it: static → projection → shadow.

--- a/.ideas/005-spend-schedule-quiet-hours.md
+++ b/.ideas/005-spend-schedule-quiet-hours.md
@@ -1,0 +1,38 @@
+# 005 — Spend-Schedule / Quiet Hours Profiles
+
+## Suggestion
+
+Autonomy is "always on," but an operator's tolerance for spend and concurrency isn't
+constant through the day. They may want the company to **run hard overnight** (cheap, nobody
+watching, big batch work) and **throttle during the workday** (so they can review output
+before more piles up), or pause entirely during a demo. Today the only levers are blunt:
+pause an agent or hit the budget wall.
+
+Add **time-based concurrency/spend profiles** — "quiet hours" for an AI company. The
+operator defines windows, each with its own concurrency cap and/or burn ceiling, and the
+system shifts automatically.
+
+## How it could be achieved
+
+1. **Reuse scheduled routines.** Paperclip already ships first-class scheduling
+   (`routines.ts`, `plugin-managed-routines.ts`, cron-style). A spend profile is a routine
+   whose action mutates the active concurrency cap / budget pace rather than launching work.
+2. **Profile model.** Per company: a list of `{ cronWindow, maxConcurrentRuns, maxBurnPerHour }`.
+   At each window boundary, set the company's effective cap (the same value the Fleet
+   Concurrency Governor, idea 001, reads).
+3. **Default profiles.** Ship presets — "Always full," "Nights & weekends only,"
+   "Business-hours throttle," "Paused" — so operators get value without authoring cron.
+4. **Manual override.** A one-click "boost for the next 2 hours" and "quiet now" that
+   temporarily supersede the schedule, with auto-revert.
+5. **Timezone correctness.** Store the operator's tz on the company so windows mean what
+   they expect; surface the next transition ("throttles to 4 runs at 9:00am") on the
+   dashboard.
+
+## Perceived complexity
+
+**Low–Medium.** This is largely composition of features that already exist: scheduling
+infrastructure is built, and it leans on the concurrency-cap setting from idea 001 (so it's
+best sequenced after that). The genuinely fiddly bits are timezone/DST handling and clean
+interaction with manual overrides and the predictive breaker (idea 002) — they all write the
+same effective-cap value, so there must be one clear precedence order (manual > breaker >
+schedule). Define that precedence up front.

--- a/.ideas/006-org-bottleneck-heatmap.md
+++ b/.ideas/006-org-bottleneck-heatmap.md
@@ -1,0 +1,39 @@
+# 006 — Org Bottleneck Heatmap
+
+## Suggestion
+
+The dashboard shows what each agent is doing, but it doesn't answer the operator's real
+question: **"Where is my company stuck?"** With a deep org chart and a hierarchical task
+tree (every task traces to the goal), work piles up in non-obvious places — a CTO sitting on
+12 unreviewed PRs, a single reviewer agent gating an entire team, a branch of the goal tree
+with no active work at all.
+
+Add an **Org Bottleneck Heatmap**: an org-chart view colored by work pressure, so a glance
+tells the operator where to intervene.
+
+## How it could be achieved
+
+1. **Pressure metrics per agent/node**, computed from existing issue + review data:
+   - *Inbound queue depth* — issues assigned/awaiting this agent.
+   - *Review backlog* — items waiting on this agent's approval (`approvals.ts`,
+     `issue-approvals.ts`).
+   - *Age of oldest blocked item* in this node's subtree.
+   - *Goal coverage* — subtrees of the goal with zero active work (cold spots).
+2. **Reuse the org-chart renderer.** `org-chart-svg.ts` already produces the org chart;
+   overlay a color scale (green → red) per node and a small badge with the queue depth.
+3. **Drill-down.** Clicking a hot node lists the specific blocking items and offers actions:
+   reassign, raise concurrency for that agent (idea 001), or escalate.
+4. **Critical-path highlight.** Trace the longest chain of blocked/dependent issues from the
+   goal downward and draw it, so the operator sees the one path that most constrains
+   throughput.
+5. **Trend.** Optionally store hourly snapshots so the heatmap can animate "pressure over the
+   last day" — useful for spotting a reviewer that's chronically underwater.
+
+## Perceived complexity
+
+**Low–Medium.** Almost entirely a read-model + visualization feature — no changes to the
+execution engine, no new safety surface. The metrics are straightforward aggregations over
+issues/approvals the DB already holds, and the org-chart SVG renderer exists to build on.
+Effort is concentrated in (a) defining a pressure score that's actually meaningful rather
+than noisy, and (b) the front-end overlay/interaction. The critical-path trace is the only
+algorithmically interesting part (a longest-path walk over the blocker graph).

--- a/.ideas/007-holding-company-meta-orchestration.md
+++ b/.ideas/007-holding-company-meta-orchestration.md
@@ -1,0 +1,52 @@
+# 007 — Holding Company (Meta-Orchestration Across Companies)
+
+## Suggestion
+
+Paperclip can run many companies in one instance, but they are **deliberately isolated**:
+`companies` is a flat top-level table with no parent/group concept, and the authorization
+layer actively denies cross-company access (`authorization.ts` — "Cross-company access stays
+denied"; `agent-assignability.ts` has an `ancestor_cross_company` denial; `trust-preset-
+resolver.ts` enforces a `cross_company_boundary`). That isolation is correct as a default —
+but it means there is no way to run a **holding company**: a top-level entity whose agents
+set strategy, allocate budget, and coordinate across the subsidiary companies.
+
+Operators already simulate this manually (e.g. an "Ace Holdings" org with subsidiary
+Presidents), but it's bolted together with regular agents that *can't actually see* the
+companies they supposedly oversee. Make it a first-class primitive: a **meta-company** that
+governs a portfolio of companies through an explicit, audited bridge — without dissolving the
+per-company isolation that keeps subsidiaries safe.
+
+## How it could be achieved
+
+1. **Portfolio model.** Add an optional `parentCompanyId` (self-reference) or a separate
+   `company_groups` table to `packages/db/src/schema/companies.ts`. A meta-company is just a
+   company flagged `kind = 'holding'` that owns a set of member companies.
+2. **Governed cross-company bridge.** Rather than weakening `authorization.ts`, add a narrow,
+   explicit capability — `portfolio_oversight` — granted only to a holding company's agents.
+   It permits a *read* projection of member companies (goals, budgets, burn, top-level issue
+   status, bottlenecks) and a small set of *governed write* actions (set a subsidiary budget,
+   pause/resume a subsidiary, post a directive issue at the subsidiary's goal level). Every
+   such action routes through the existing approval/audit path (`approvals.ts`,
+   `activity-log.ts`).
+3. **Roll-up read model.** A portfolio dashboard that aggregates the per-company metrics that
+   already exist (`budgetMonthlyCents`/`spentMonthlyCents` on each company, costs, goal
+   progress) into one view — burn across the whole portfolio, which subsidiary is at risk.
+   This composes naturally with the Org Bottleneck Heatmap (idea 006), one level up.
+4. **Capital allocation as the killer action.** The holding agent's heartbeat can rebalance
+   budget between subsidiaries (move spend from a stalled company to a winning one) — the
+   highest-value reason to have this layer at all. Each move is an audited budget mutation,
+   reusing the Predictive Budget Circuit Breaker plumbing (idea 002) for safety.
+5. **Directive issues, not direct control.** A holding company influences subsidiaries by
+   filing top-level issues into their goal trees (which their CEOs then decompose), preserving
+   the "all work traces to the goal" invariant rather than reaching into a subsidiary's task
+   tree directly.
+
+## Perceived complexity
+
+**High.** This is the most architecturally invasive idea in the set because it deliberately
+pierces a boundary the system was built to enforce. The schema and roll-up read model are
+straightforward; the hard, security-critical work is the `portfolio_oversight` capability —
+it must be impossible for a subsidiary agent to escalate into it, and every cross-company
+action must be audited and reversible. Build it read-only first (a true portfolio dashboard),
+then add governed writes (budget, pause), and only then capital allocation. Treat the
+authorization changes as a reviewed security surface, not a feature flag.

--- a/.ideas/008-local-llm-adapter.md
+++ b/.ideas/008-local-llm-adapter.md
@@ -1,0 +1,58 @@
+# 008 — First-Class Local LLM Adapter (Ollama / LM Studio / llama.cpp)
+
+## Suggestion
+
+Paperclip ships many local *coding-tool* adapters (claude_local, codex_local, gemini_local,
+grok_local, opencode_local, pi_local, hermes_local) plus generic `http` and `process`
+adapters — but there is **no first-class adapter for a local LLM server** like Ollama, LM
+Studio, or llama.cpp. These are the obvious way to run agents with **zero marginal token
+cost** and **full data privacy**, which is a compelling story for an "always-on, 24/7"
+autonomous company where API spend is the main constraint. Today an operator could wire one
+up via the raw `process`/`http` adapter, but it's bespoke, undiscoverable, and its cost
+tracking is wrong.
+
+The good news: the plumbing is already half there. `inferOpenAiCompatibleBiller`
+(`packages/adapter-utils/src/billing.ts`) already infers a provider from `OPENAI_BASE_URL` /
+`OPENAI_API_BASE`, and `pi-local` already runs through the OpenAI-compatible path. Ollama
+(`:11434/v1`), LM Studio (`:1234/v1`), and llama.cpp's server all expose **OpenAI-compatible
+`/v1` endpoints** — so a dedicated adapter is mostly configuration, presets, and correct
+cost accounting on top of machinery that exists.
+
+## How it could be achieved
+
+1. **New builtin adapter `local_llm`** (or `openai_compatible_local`) added to
+   `BUILTIN_ADAPTER_TYPES` in `server/src/adapters/builtin-adapter-types.ts`, modeled on the
+   existing `pi-local` package under `packages/adapters/`.
+2. **Config = base URL + model + optional key.** Fields: `baseUrl` (default presets for the
+   three runtimes), `model` (free-text, since local model names are arbitrary), optional
+   `apiKey` (LM Studio/llama.cpp ignore it; some setups want it). Ship one-click presets:
+   **Ollama**, **LM Studio**, **llama.cpp**.
+3. **Reuse OpenAI-compatible execution + billing.** Point the existing OpenAI-compatible
+   client at the configured base URL. Extend `inferOpenAiCompatibleBiller` to detect
+   loopback/LAN hosts (`localhost`, `127.0.0.1`, `*.local`, private ranges, `:11434`,
+   `:1234`) and map them to a **`local` provider with $0 cost** — while still recording token
+   counts so productivity metrics and the Diminishing-Returns Detector (idea 003) keep
+   working even when spend is zero.
+4. **Health probe + model discovery.** Reuse `environment-probe.ts` to check the endpoint is
+   up before launch, and call the runtime's model-list endpoint (Ollama `/api/tags`, OpenAI
+   `/v1/models`) to populate a model dropdown instead of free-text where possible.
+5. **Docs + preflight.** A short "Run agents on your own GPU" doc, and a check in the
+   Dry-Run Estimator (idea 004) that confirms the local endpoint is reachable and the named
+   model is pulled before "hit go."
+
+## Why it matters strategically
+
+A local-LLM path makes Paperclip's "always-on 24/7" pitch economically realistic for hobbyist
+and privacy-sensitive operators, and it pairs naturally with mixed fleets — cheap local models
+for high-volume low-stakes agents (triage, summarization, routine reviews) and premium API
+models for the CEO/critical-path roles. That mixed-economy story is a differentiator, not just
+a connector.
+
+## Perceived complexity
+
+**Low–Medium.** Most of the runtime and billing infrastructure already exists and has a direct
+in-repo template (`pi-local` + `inferOpenAiCompatibleBiller`). The bulk of the work is a new
+adapter package, the loopback/LAN → `$0 local provider` billing rule (so cost tracking stays
+honest), preset/health/model-discovery UX, and docs. The main correctness risk is the billing
+inference: misclassifying a local endpoint as a paid provider (or vice-versa) corrupts cost
+data, so that rule needs solid test coverage — `billing.test.ts` already exists to extend.

--- a/.ideas/009-agent-probation-trust-ramp.md
+++ b/.ideas/009-agent-probation-trust-ramp.md
@@ -1,0 +1,38 @@
+# 009 — Agent Probation & Staged Trust Ramp
+
+## Suggestion
+
+When a new agent is hired, it gets its full configured autonomy immediately — same
+concurrency, same spend, same ability to act without review as a battle-tested agent. That's
+risky: a misconfigured prompt or a flaky adapter can burn budget or make a mess before the
+operator notices. Paperclip already models trust (`source-trust.ts`,
+`trust-preset-resolver.ts` with presets and a `cross_company_boundary` notion), but trust is
+**static** — set once, not earned.
+
+Add a **probation period with a staged trust ramp**: newly hired agents start constrained
+(low concurrency, mandatory review on outputs, tighter spend) and **automatically graduate**
+to fuller autonomy as they accumulate a clean track record — or get held back / flagged if
+they don't.
+
+## How it could be achieved
+
+1. **Probation state on the agent.** Add `trustStage` (`probation` → `trusted` → `senior`)
+   and a `hiredAt` / `runsCompleted` counter. New agents default to `probation`.
+2. **Stage → policy mapping.** Resolve effective limits from stage in
+   `trust-preset-resolver.ts`: probation caps `maxConcurrentRuns` low (e.g. 2), forces the
+   review/approval handoff on work products, and applies a reduced spend ceiling.
+3. **Graduation criteria.** Promote when the agent clears thresholds: N completed issues,
+   review approval rate above X%, no Diminishing-Returns trips (idea 003), spend within
+   estimate. Evaluate on a routine (`routines.ts`) or at run completion.
+4. **Demotion path.** A burst of rejected reviews or a budget-breaker trip (idea 002) drops
+   the agent back a stage and raises an inbox item — autonomy that's revocable, not one-way.
+5. **UI.** A trust badge on each agent ("Probation · 3/10 runs to graduate") and an operator
+   override to fast-track or freeze a stage.
+
+## Perceived complexity
+
+**Medium.** The trust-preset machinery and review handoffs already exist, so this is mainly a
+state field, a stage→limits resolver, and a graduation evaluator. The design effort is in the
+criteria — too strict and good agents stay shackled; too loose and probation is theater. Best
+shipped with conservative defaults and per-company tuning, and it composes cleanly with the
+Fleet Concurrency Governor (001) and Diminishing-Returns Detector (003).

--- a/.ideas/010-blocker-graph-deadlock-detector.md
+++ b/.ideas/010-blocker-graph-deadlock-detector.md
@@ -1,0 +1,38 @@
+# 010 — Blocker-Graph Deadlock Detector
+
+## Suggestion
+
+The issue model supports **blockers** and parent/sub-issues (per `doc/PRODUCT.md`). With
+autonomous agents decomposing work and marking dependencies on their own, it's easy to create
+a **deadlock**: issue A blocked on B, B blocked on C, C blocked on A — a cycle where every
+agent involved is "correctly" waiting and nothing ever moves. Worse are silent stalls: a whole
+subtree blocked on one issue that was abandoned or assigned to a paused agent. Nobody is
+crashed, nobody is looping, so the watchdogs (`task-watchdogs.ts`) and the Diminishing-Returns
+Detector (idea 003, which is per-issue) won't catch it — the work is just frozen.
+
+Add a **deadlock/stall detector** that periodically analyzes the blocker graph for cycles and
+dead-end dependency chains, then escalates them.
+
+## How it could be achieved
+
+1. **Build the dependency graph.** From the issues table, construct a directed graph of
+   `blocked-by` edges (plus parent/sub-issue edges where relevant) per company.
+2. **Cycle detection.** Run a standard DFS/Tarjan SCC pass to find any strongly-connected
+   component of size > 1 — those are deadlocks. Cheap; runs on a routine (`routines.ts`).
+3. **Dead-end detection.** Flag chains terminating on an issue that is (a) unassigned,
+   (b) assigned to a paused/removed agent, or (c) untouched beyond a threshold age, while
+   descendants wait on it. This is the more common real-world stall.
+4. **Auto-resolution / escalation.** On a cycle, post a comment on each member, pause further
+   wakeups for the loop, and raise one inbox item that visualizes the cycle and suggests the
+   edge to cut. For a dead-end, route to the blocking issue's assignee's manager via the org
+   chart.
+5. **Visualization.** Surface stalls on the Org Bottleneck Heatmap (idea 006) — a deadlocked
+   cluster is the ultimate bottleneck and should glow red there.
+
+## Perceived complexity
+
+**Medium.** The graph algorithms are textbook and fast at realistic issue counts, so the core
+detector is small. The effort is in edge-case correctness (self-blocks, cross-tree blockers,
+issues that are legitimately waiting on a human) and in making the escalation *actionable*
+rather than noisy — a deadlock alert is only useful if it names the exact edge to cut. Pure
+read-model + escalation; no changes to the execution engine.

--- a/.ideas/011-eval-gated-agent-config-deploys.md
+++ b/.ideas/011-eval-gated-agent-config-deploys.md
@@ -1,0 +1,40 @@
+# 011 — Eval-Gated Agent Config Deploys ("CI for Agents")
+
+## Suggestion
+
+An agent's behavior is defined by its adapter config and prompt (CLAUDE.md, SOUL.md, CLI args,
+etc.). Editing that config is the highest-leverage, highest-risk action an operator takes — a
+one-line prompt change can silently make an agent worse, more expensive, or non-compliant with
+governance, and you only find out after it's spent real money in production. Paperclip already
+ships an **eval harness** (`evals/promptfoo/` with `core.yaml`, `governance.yaml`, and a
+`heartbeat-system.txt` prompt), but it's a repo-level developer tool, not wired into the
+product's agent-editing flow.
+
+Add **eval-gated config deploys**: when an operator changes an agent's config, run it against a
+saved eval suite *before* the change goes live — CI for agents. Regressions block or warn;
+clean runs deploy.
+
+## How it could be achieved
+
+1. **Per-agent eval suites.** Let operators attach a small set of eval cases to an agent
+   (golden scenarios: "given this kind of issue, the plan should X, must not Y"). Reuse the
+   existing promptfoo format/runner under `evals/` rather than inventing one.
+2. **Diff-triggered run.** On an agent config edit, snapshot old vs. new config and execute the
+   suite against the new config (ideally on a **local LLM** — idea 008 — so gating is free and
+   fast).
+3. **Governance assertions.** Ship default checks mirroring `governance.yaml`: the agent stays
+   inside its company boundary, doesn't claim capabilities it lacks, respects spend/approval
+   norms. These catch the dangerous regressions, not just quality drift.
+4. **Gate + record.** Show a pass/fail report inline in the edit UI; on failure, require an
+   explicit override and log it to `activity-log.ts`. Keep a history so an agent's quality is
+   trackable over time (pairs with the trust ramp, idea 009).
+5. **Optional pre-hire eval.** Run the suite once at hire time as part of the Dry-Run
+   Estimator (idea 004) preflight.
+
+## Perceived complexity
+
+**Medium.** The eval runner exists, so the work is product-izing it: attaching suites to agents,
+triggering on config diffs, surfacing results in the UI, and the gate/override/audit flow.
+The conceptually tricky part is making per-agent evals cheap and deterministic enough to run on
+every edit without friction — which is exactly why pairing it with a free local model (idea 008)
+matters. Start as advisory (warn, don't block), graduate to a hard gate for governance checks.

--- a/.ideas/012-provider-fallback-chains.md
+++ b/.ideas/012-provider-fallback-chains.md
@@ -1,0 +1,41 @@
+# 012 — Quota-Aware Provider Fallback Chains
+
+## Suggestion
+
+Paperclip already *observes* provider quota — `quota-windows.ts` asks each adapter for its
+provider quota windows (`getQuotaWindows()`) and aggregates them. But nothing **acts** on
+exhaustion: when an agent's provider is rate-limited or out of quota, its runs just fail or
+stall until the window resets. For an "always-on 24/7" company, hitting Anthropic's or
+OpenAI's rate limit at 2am can freeze a whole team for hours with no human awake to switch
+models.
+
+Add **provider fallback chains**: per agent (or per role), define an ordered list of
+adapter/model options. When the primary is rate-limited, over-quota, or erroring, Paperclip
+automatically retries the run on the next option in the chain — e.g. premium API model →
+cheaper API model → local model (idea 008).
+
+## How it could be achieved
+
+1. **Chain config.** Add an optional `fallbackChain` to an agent's adapter config: an ordered
+   list of `{ adapterType, model }`. Default empty (current behavior).
+2. **Trigger conditions.** Reuse the existing quota signal (`quota-windows.ts`) plus the
+   recovery classifiers (`server/src/services/recovery/`, `recovery-classifiers.test.ts`) to
+   distinguish *fall-back-worthy* failures (429/quota/provider outage) from *don't-retry*
+   failures (auth, bad config, agent logic errors).
+3. **Failover in the run path.** On a qualifying failure, `heartbeat.ts` re-dispatches the same
+   run with the next chain entry instead of marking it failed, preserving session/context where
+   the target adapter supports it. Cap the number of hops to avoid thrash.
+4. **Cost & honesty.** Record which provider actually served each run (costs already track this)
+   so spend and the unit-economics view stay accurate when a fallback is cheaper or free.
+5. **Surface it.** A small "served by fallback: local-llm (primary rate-limited)" note on the
+   run, and an inbox nudge if an agent is *chronically* falling back — that's a signal to raise
+   the primary's quota or rebalance.
+
+## Perceived complexity
+
+**Medium.** The two hard pieces — quota observation and failure classification — already exist
+in the repo; this idea connects them to an action. The real work is the failover logic in the
+run dispatch path (idempotency, hop limits, context preservation across a provider switch) and
+getting the retry-vs-fail classification right so it doesn't burn money retrying a request that
+will always fail. Strong synergy with the local-LLM adapter (008) as a free last resort and with
+the predictive breaker (002), which might *prefer* the cheap fallback under budget pressure.

--- a/.ideas/013-unit-economics-dashboard.md
+++ b/.ideas/013-unit-economics-dashboard.md
@@ -1,0 +1,38 @@
+# 013 — Unit-Economics Dashboard (Cost per Shipped Outcome)
+
+## Suggestion
+
+Paperclip tracks **spend** well (costs, burn, budgets) and has a `productivity-review.ts`
+service, but spend alone doesn't tell an operator the thing they actually need to know:
+**is this company's work worth what it costs?** A burn-rate number is an input; the decision-
+useful metric is *cost per shipped outcome* — dollars per completed issue, per approved work
+product, per goal-milestone reached, and per agent. Without that, an operator can't tell a
+cheap-but-productive agent from a cheap-but-useless one, or know whether the company's unit
+economics are improving or degrading over time.
+
+Add a **unit-economics dashboard** that joins spend to delivered outcomes.
+
+## How it could be achieved
+
+1. **Define outcomes.** Use signals already in the DB: issues moved to done/approved, work
+   products accepted, review approvals (`approvals.ts`), and goal/milestone progress. Each is
+   a countable "outcome."
+2. **Join spend to outcomes.** Costs are already attributed to runs/agents/issues; aggregate
+   `spend ÷ outcomes` along several axes — per agent, per role, per company, per goal subtree.
+3. **Headline metrics.** "Cost per completed issue: $0.84 (▼12% w/w)", "Cost per approved work
+   product", "Rework ratio: % of issues reopened after done" (a quality-cost signal that pure
+   spend hides), and "Idle spend: tokens burned on runs that produced no outcome" (overlaps
+   with — and is quantified by — the Diminishing-Returns Detector, idea 003).
+4. **Comparisons.** Rank agents by cost-effectiveness; flag the expensive-and-unproductive
+   quadrant. This is the data the Holding Company (idea 007) needs to allocate capital and the
+   trust ramp (idea 009) needs to graduate agents.
+5. **Trend over time.** Snapshot weekly so operators see whether unit economics are compounding
+   in the right direction — the single most important question for an autonomous business.
+
+## Perceived complexity
+
+**Low–Medium.** No execution-engine changes — it's a read-model/analytics layer over data that
+already exists (costs, issues, approvals, work products). The effort is in defining "outcome"
+crisply enough to be trustworthy (what counts as shipped? how is rework attributed?) and in the
+dashboard UI. The rework-ratio and idle-spend metrics are the highest-value, least-obvious parts
+and are worth getting right first.

--- a/.ideas/014-emergency-stop-drain-mode.md
+++ b/.ideas/014-emergency-stop-drain-mode.md
@@ -1,0 +1,39 @@
+# 014 — Emergency Stop & Drain Mode (The Big Red Button)
+
+## Suggestion
+
+An autonomous company spends real money and takes real actions without a human in the loop.
+When something goes wrong — a prompt change gone bad, a runaway loop, a provider bill
+spiking, a security worry — the operator needs to **stop everything instantly and safely**.
+Today the levers are per-agent pause and the company `status` / `pauseReason` fields, but
+there's no single, instant, instance-wide *halt* that also brings runs to a clean state.
+"Pause one agent at a time while 30 are burning tokens" is not an emergency control.
+
+Add two first-class controls: a **Panic Stop** (immediate, instance- or company-wide halt of
+all agent runs) and a **Drain Mode** (stop *starting* new runs but let in-flight ones finish
+cleanly) — the graceful counterpart for planned maintenance or winding down.
+
+## How it could be achieved
+
+1. **Global halt flag.** An instance-level and per-company `executionState`
+   (`running` / `draining` / `halted`) checked at the single choke point where
+   `heartbeat.ts` decides to start a queued run. `halted` refuses all new starts; `draining`
+   refuses new starts but leaves running ones alone.
+2. **Panic = halt + cancel.** Panic Stop sets `halted` *and* signals cancellation to live
+   runs (the cancel path already exists — see `issue-comment-cancel-routes`), then records who
+   triggered it and why to `activity-log.ts`.
+3. **Drain = halt new only.** Drain sets `draining` and surfaces a live "N runs draining…"
+   readout, flipping to fully halted once the count hits zero.
+4. **Safe resume.** Resuming from halt should *not* stampede — re-admit runs gradually through
+   the Fleet Concurrency Governor (idea 001) rather than launching everything at once.
+5. **UI.** A persistent, unmistakable control in the top bar with a confirm step, scoped to
+   instance or a single company, plus an auto-trigger hook so the Predictive Budget Breaker
+   (idea 002) can invoke Drain automatically under extreme burn.
+
+## Perceived complexity
+
+**Low–Medium.** The state field and the start-time check are small, and a cancellation path
+already exists to build the panic action on. The work is making the guarantee *trustworthy* —
+the halt must be honored at every place a run can start (including process recovery and
+scheduled retries), or "stop" won't actually stop. That single-choke-point discipline is the
+crux; pairs naturally with the governor (001) for safe resume.

--- a/.ideas/015-company-point-in-time-rewind.md
+++ b/.ideas/015-company-point-in-time-rewind.md
@@ -1,0 +1,43 @@
+# 015 — Company-Level Point-in-Time Rewind
+
+## Suggestion
+
+Autonomous agents make irreversible-feeling messes: a CEO agent reorganizes the whole task
+tree badly, a bad strategic directive cascades into dozens of misguided sub-issues, an agent
+floods the board. Paperclip has instance-level database backups
+(`routes/instance-database-backups.ts`) and company import/export
+(`company-portability.ts`), but no **company-scoped "undo"** — a way to rewind *one* company
+to a known-good state without nuking the whole instance or doing a manual export/reimport
+dance.
+
+Add **point-in-time rewind for a single company**: periodic lightweight snapshots of a
+company's state (org, issues, goals, budgets, documents) and a one-click "restore this company
+to <timestamp>" — a save-state for an autonomous business.
+
+## How it could be achieved
+
+1. **Reuse the portability serializer.** `company-portability.ts` already knows how to
+   serialize/deserialize a whole company. A snapshot is a timestamped, content-hashed export
+   stored in the existing storage layer (`server/src/storage/`); restore is an import scoped to
+   that company id.
+2. **Automatic checkpoints.** Take a snapshot on a routine (`routines.ts`) and *before* high-
+   risk events — a CEO strategic re-plan, a bulk issue mutation, an org-chart change — so
+   there's always a recent clean point to fall back to.
+3. **Diff before restore.** Show the operator what restoring would change (issues created/
+   destroyed since the snapshot, spend in the interval) so rewind is an informed choice, not a
+   blind revert.
+4. **Non-destructive option.** Offer "restore into a new company" (fork) as well as in-place
+   rewind, so an operator can inspect the old state side-by-side — and so a Holding Company
+   (idea 007) could A/B two strategies from the same checkpoint.
+5. **Guard rails.** Rewind itself is a heavyweight, audited action gated behind confirmation
+   and logged to `activity-log.ts`; it should auto-Drain (idea 014) the company first so a
+   restore doesn't race live runs.
+
+## Perceived complexity
+
+**Medium–High.** Snapshot creation is largely free given the existing serializer, but
+*restore* is the hard part: doing it transactionally, deciding what to do with in-flight runs
+and external side effects (an agent's snapshot can't un-send an email it sent), and keeping
+referential integrity for issues/documents/work products. Frame the guarantee honestly —
+rewind restores Paperclip's *control-plane* state, not the outside world — and ship fork-style
+restore (safe) before in-place rewind (destructive).

--- a/.ideas/016-approval-triage-policy-batching.md
+++ b/.ideas/016-approval-triage-policy-batching.md
@@ -1,0 +1,39 @@
+# 016 — Approval Triage & Policy-Based Batching
+
+## Suggestion
+
+Human review is the governance backbone — approvals and review handoffs are first-class
+(`approvals.ts`, `issue-approvals.ts`), surfaced via inbox/sidebar badges
+(`sidebar-badges.ts`, `inbox-dismissals.ts`). But as a company scales, the operator becomes
+the bottleneck: dozens of approval items pile up, each reviewed one at a time, indistinguishable
+high-stakes-from-trivial. The human drowns, autonomy stalls waiting on them, and the natural
+(bad) response is to rubber-stamp everything — which defeats the point of review.
+
+Add an **approval triage layer**: risk-rank pending approvals, group similar ones, and let the
+operator define policies to auto-handle the low-risk long tail so human attention goes where it
+matters.
+
+## How it could be achieved
+
+1. **Risk score per approval.** Compute a lightweight score from signals already present: the
+   acting agent's trust stage (idea 009), spend implied by the action, whether it crosses a
+   sensitive boundary (secrets, external sends, budget changes), and diff size for work
+   products. Sort the inbox by it.
+2. **Grouping.** Cluster approvals by agent, issue subtree, or action type so the operator can
+   review "all 8 doc edits from the marketing team" as one batch with bulk approve/reject.
+3. **Auto-approve policies.** Operator-defined rules — "auto-approve work products from
+   `trusted`+ agents under $0.50 that touch no secrets" — evaluated server-side, every decision
+   (including auto-ones) written to `activity-log.ts` for audit.
+4. **Standing review SLAs.** Flag approvals waiting beyond a threshold and optionally escalate
+   to a manager agent or a second human, so nothing rots silently (complements the deadlock
+   detector, idea 010, for the human-blocked case).
+5. **UI.** A triage inbox: risk-sorted, grouped, keyboard-bulk-actionable, with a clear
+   "auto-handled by policy" lane the operator can audit and tighten.
+
+## Perceived complexity
+
+**Medium.** The approval data model, inbox, and badges already exist, so this is a scoring +
+grouping + policy-engine layer on top, plus inbox UX work. The sensitive part is the auto-
+approve policy engine: it must be conservative, fully audited, and easy to reason about, because
+a wrong rule silently removes the human safeguard. Ship triage/sorting/grouping first (pure
+upside, no risk), then add auto-approve behind explicit, narrow policies.

--- a/.ideas/017-run-change-review-surface.md
+++ b/.ideas/017-run-change-review-surface.md
@@ -1,0 +1,40 @@
+# 017 — Run Change-Review Surface (PR-Style Diff per Agent Run)
+
+## Suggestion
+
+When an agent run touches a workspace, Paperclip records what happened
+(`workspace-operations.ts`, `workspace-operation-log-store.ts`) and produces work products —
+but the operator's review experience is fragmented: read a comment, maybe open files, infer
+what actually changed. There's no single **"here's the diff this run produced"** surface, the
+way a pull request shows exactly what a developer changed before you approve it. For an
+operator governing agents they don't fully trust, *seeing the change* is the core review act,
+and it's harder than it should be.
+
+Add a **change-review surface per run**: a consolidated, PR-style view of everything a run did
+to its workspace — files added/modified/deleted with diffs, commands executed, work products
+generated — attached to the run and wired into the approval flow.
+
+## How it could be achieved
+
+1. **Aggregate the operation log.** `workspace-operation-log-store.ts` already captures file
+   and command operations per run; group them into a single changeset keyed by run id.
+2. **Render diffs.** For text files, compute before/after diffs (reuse the file-resources
+   read path, `routes/file-resources.ts`); for binaries/large files, show metadata and a
+   download. Summarize commands run and their exit status.
+3. **Attach to review.** Surface the changeset directly in the approval item (idea 016) so a
+   reviewer approves *a concrete diff*, not a vague "work product." Feeds the risk score with
+   real diff size.
+4. **Run-to-run comparison.** Let the operator diff the workspace across two runs of the same
+   issue to see incremental progress — and to spot a Diminishing-Returns loop (idea 003)
+   visually: "three runs, basically the same diff."
+5. **AI change summary.** Optionally generate a one-paragraph plain-English summary of the
+   changeset (cheaply, on a local model — idea 008) so reviewers triage faster.
+
+## Perceived complexity
+
+**Medium.** The raw operation data is already logged, so this is primarily an aggregation +
+diff-rendering + review-integration feature, much of it front-end. The fiddly parts are diffing
+large/binary artifacts gracefully and reconstructing accurate before/after states for files the
+run mutated (may need to snapshot file contents at operation time rather than diffing live).
+High operator value relative to effort because it makes the existing review/approval flow
+actually trustworthy.

--- a/.ideas/018-company-blueprint-library.md
+++ b/.ideas/018-company-blueprint-library.md
@@ -1,0 +1,40 @@
+# 018 — Company Blueprint Library (Parameterized Templates)
+
+## Suggestion
+
+Paperclip can import/export whole companies (`company-portability.ts`; `companies.sh` is a
+shipped roadmap item), which makes a company *portable* — but every new company still starts
+from a blank org chart. Standing up a sensible team (CEO → CTO/CMO/CFO → reports, with budgets,
+roles, and initial goals wired correctly) is the highest-friction, most error-prone part of
+getting value from Paperclip, and the Dry-Run Estimator (idea 004) exists partly because it's
+so easy to misconfigure. Export gives you *reuse of a specific company*; what's missing is
+*reusable, parameterized blueprints*.
+
+Add a **blueprint library**: curated, parameterized company templates ("SaaS startup,"
+"content marketing agency," "research lab") that an operator instantiates by answering a few
+prompts (goal, budget, which adapters), producing a ready-to-run org.
+
+## How it could be achieved
+
+1. **Blueprint = parameterized export.** Build on the portability format: a blueprint is a
+   company export with declared *variables* (company goal, total budget, preferred adapter/model
+   per role, team size) and templated fields that get substituted at instantiation.
+2. **Instantiation wizard.** A guided flow collects the variables, validates them with the
+   existing company/agent/budget validators, and runs the Dry-Run Estimator (idea 004)
+   automatically so the operator sees projected cost before launch.
+3. **Built-in starter set.** Ship a handful of opinionated blueprints reflecting real
+   structures (the README's "note-taking app to $1M MRR" is a perfect canonical example),
+   each with role definitions, default adapter configs, and starter goal trees.
+4. **Adapter-agnostic substitution.** Because the agent is defined by its adapter config, a
+   blueprint should let the operator swap the whole org from (say) Claude Code to a local LLM
+   (idea 008) at instantiation — same structure, different runtime/economics.
+5. **Community sharing (later).** A signed, importable blueprint format so operators can publish
+   and exchange org designs — with `source-trust.ts` gating untrusted blueprints on import.
+
+## Perceived complexity
+
+**Medium.** The serialization backbone exists; the new work is the variable/templating layer,
+the instantiation wizard, and a quality starter set. The instantiation logic must be robust —
+a half-applied blueprint that leaves a company in an invalid state is worse than no blueprint —
+so it should build atomically and run validation + dry-run before going live. Community sharing
+adds a trust/security surface and is rightly a later phase.

--- a/.ideas/019-token-budgets-for-subscription-users.md
+++ b/.ideas/019-token-budgets-for-subscription-users.md
@@ -1,0 +1,72 @@
+# 019 — Token-Denominated Budgets for Subscription / Flat-Rate Users
+
+## Suggestion
+
+Paperclip's budgets and cost controls are **dollar-denominated**: company and agent budgets
+are `budgetMonthlyCents` / `spentMonthlyCents`, budget policies enforce on `billed_cents`, and
+the spend bar is computed as `spendCents / budgetMonthlyCents`. That works for pay-per-token
+(metered) API keys — but it's **blind for subscription / flat-rate users**, who are a large and
+growing share of operators (Claude Pro/Max, ChatGPT Plus, Claude Code on a subscription, etc.).
+
+For those users the marginal cost of a run is ≈ $0, so `costCents` ≈ 0. Result: their budget
+shows "$0 spent," their hard-stop never trips, and an agent can burn through the subscription's
+real constraint — **tokens and rate-limit windows** — completely unguarded. The very users who
+most need a guardrail (you can't just "spend less" your way out of a fixed plan's rate limit)
+have none. The system already *knows* this is happening — `BILLING_TYPES` distinguishes
+`metered_api`, `subscription_included`, and `subscription_overage`, and `cost_events` records
+`inputTokens` / `cachedInputTokens` / `outputTokens` per run — but budgets never consume that
+data.
+
+Make **token usage a first-class budget metric** alongside dollars, so subscription users can
+set and enforce real limits.
+
+## Why this is mostly unfinished plumbing, not a greenfield build
+
+The framework already anticipates non-dollar metrics — it's just not implemented:
+
+- `budget_policies.metric` is a generic column that **defaults to `"billed_cents"`** (the
+  schema clearly expected other metrics), with a per-scope-per-metric unique index.
+- A `BudgetMetric` type already exists in shared validators/types.
+- The warn / hard-stop / incident / override machinery in `budgets.ts` is **metric-agnostic** —
+  it threshold-checks `spend vs amount` regardless of unit.
+- The one thing blocking it: `budgets.ts` (~line 161) short-circuits —
+  `if (policy.metric !== "billed_cents") return 0;` — so any token-metric policy computes a
+  spend of 0 and never fires.
+- `costs.ts` already aggregates `inputTokens`/`outputTokens` and even breaks out
+  `subscriptionInputTokens` / `subscriptionOutputTokens` / `subscriptionRunCount` separately.
+
+## How it could be achieved
+
+1. **Extend the metric enum.** Add `total_tokens` (and optionally `input_tokens`,
+   `output_tokens`, `run_count`) to `BudgetMetric` / `BILLING`-adjacent constants.
+2. **Implement the missing spend computation.** Replace the `return 0` short-circuit in
+   `budgets.ts` with real aggregation per metric — sum `costEvents.inputTokens + outputTokens`
+   (or the chosen columns) over the policy window. The summation helper already exists in
+   `costs.ts` (`sumAsNumber` over `costEvents.inputTokens` / `outputTokens`).
+3. **Window alignment for subscriptions.** Subscription limits reset on provider-specific
+   schedules (e.g. rolling 5-hour windows), not calendar months. Let a token policy's
+   `windowKind` mirror the provider quota window already surfaced by `quota-windows.ts`, so a
+   Paperclip token budget can track "tokens used in the current rate-limit window."
+4. **Budget UI for both units.** Let operators set a token budget per company/agent and show
+   token spend next to dollar spend on the budget overview. For `subscription_included`
+   agents, lead with tokens/run-count (the real constraint) and de-emphasize the $0 cost.
+5. **Optional imputed/shadow cost.** For comparison and capital-allocation, compute an
+   *imputed* dollar value of subscription token usage from public list prices ("you used
+   ~$140 of tokens on a flat plan"). This lets the Unit-Economics Dashboard (idea 013) and
+   Holding Company (idea 007) compare metered vs subscription agents on equal footing without
+   implying real cash was spent.
+6. **Mixed enforcement.** A scope can carry both a `billed_cents` policy and a `total_tokens`
+   policy; the hardest-binding one wins. This also makes `subscription_overage` honest — stay
+   within the token budget on the included plan, and only metered-cost budgets bite once you
+   spill into overage pricing.
+
+## Perceived complexity
+
+**Low–Medium.** The schema (`metric` column), the token data (`cost_events`), the
+subscription-aware aggregation (`costs.ts`), and the threshold/incident/override enforcement
+(`budgets.ts`) all already exist — the core work is implementing the non-cents spend
+computation (removing one short-circuit), extending the metric enum, and the budget-setting UI.
+The genuinely subtle parts are (a) aligning token windows to provider rate-limit resets rather
+than calendar periods, and (b) deciding how cached-input tokens count toward a budget (they're
+cheaper/free and shouldn't be penalized like fresh input). Ship calendar-window token budgets
+first (trivial given the above), then add provider-window alignment.

--- a/.ideas/020-outbound-secret-leak-scanning.md
+++ b/.ideas/020-outbound-secret-leak-scanning.md
@@ -1,0 +1,41 @@
+# 020 — Outbound Secret-Leak Scanning
+
+## Suggestion
+
+Paperclip redacts secrets from its **own logs** (`log-redaction.ts`, `redaction.ts`,
+`middleware/redact-sensitive.ts`). But agents produce a lot of *content* that flows back into
+the control plane and out to humans — issue comments, work products, documents, attachments —
+and nothing scans **that** content for leaked secrets. An agent that was bound a database
+password or an API key (`agent-secret-bindings.ts`) can trivially paste it into a comment, a
+generated config file, or a work product, where it's then stored in the DB, shown on the board,
+and included in exports. That's a real exfiltration/leak path, and it's invisible today.
+
+Add **outbound secret-leak scanning**: before agent-generated content is persisted or surfaced,
+scan it for (a) the concrete secret values actually bound to that agent and (b) high-confidence
+secret *patterns* (API key shapes, private keys, JWTs), then redact, block, or flag.
+
+## How it could be achieved
+
+1. **Reuse known secret values.** The agent's bound secrets are already resolvable via
+   `agent-secret-bindings.ts` / `secrets.ts`. Exact-match scanning for those literal values
+   (and common encodings) is high-precision and cheap.
+2. **Pattern detection for the unknown.** Layer in regex/entropy detectors for generic secret
+   shapes (`sk-…`, AWS keys, `BEGIN PRIVATE KEY`, bearer tokens) to catch secrets the agent
+   generated or fetched that Paperclip never issued.
+3. **Hook the write path.** Run the scan in the services that persist agent content — work
+   products (`work-products.ts`), comments/issue threads (`issue-thread-interactions.ts`),
+   documents (`documents.ts`) — reusing the existing redaction utilities.
+4. **Graduated response.** Per company policy: *redact* (replace with `***` and keep the
+   content), *block* (refuse to store, bounce back to the agent to fix), or *flag* (store but
+   raise a high-priority inbox/approval item — pairs with risk-scored triage, idea 016).
+5. **Audit every hit.** Record detections to `activity-log.ts` so operators can see leak
+   attempts over time — a strong signal that an agent is misconfigured or compromised.
+
+## Perceived complexity
+
+**Medium.** The redaction primitives and the bound-secret lookups already exist, so exact-match
+scanning is quick to add. The work is wiring it into every content-write path consistently (a
+missed path is a silent hole) and tuning pattern detection to avoid false positives that mangle
+legitimate output (e.g. a code sample that looks key-shaped). Start with exact-match on bound
+secrets (near-zero false positives, immediate value), then add pattern detection behind a
+confidence threshold.

--- a/.ideas/021-just-in-time-secret-leasing.md
+++ b/.ideas/021-just-in-time-secret-leasing.md
@@ -1,0 +1,41 @@
+# 021 — Just-in-Time Secret Leasing
+
+## Suggestion
+
+Secret access today is a **standing grant**: `agent-secret-bindings.ts` binds a secret to an
+agent, and the agent can resolve it on any run, indefinitely, until a human unbinds it. For
+autonomous agents that run 24/7, that's a wide and permanent blast radius — every run of a
+bound agent is a potential point of exposure for a credential it may only need occasionally.
+The standard mitigation in human infra is **just-in-time, time-boxed access** — and Paperclip
+already has the exact pattern elsewhere: `environmentLeases` lease environments with statuses,
+TTLs, and cleanup. Secrets should work the same way.
+
+Add **just-in-time secret leasing**: an agent acquires a secret for the duration of a specific
+run (or a short TTL), the lease auto-expires and is cleaned up, and every acquisition is
+individually audited — turning a permanent grant into a series of short, accountable check-outs.
+
+## How it could be achieved
+
+1. **Lease model for secrets.** Mirror `environmentLeases`: a `secret_leases` concept keyed by
+   `{ agentId, secretId, runId, status, expiresAt }`. A binding becomes "this agent *may
+   lease* this secret," not "this agent *holds* this secret."
+2. **Acquire at point of need.** When a run resolves a secret, issue a lease with a TTL tied to
+   the run lifetime; on run completion/failure (the same hook watchdogs use), release it. Reuse
+   the lease-cleanup machinery already built for environments.
+3. **Scoped exposure.** A secret value is only materialized into a run's environment while its
+   lease is active, shrinking the window in which it exists in process memory/env.
+4. **Per-acquisition audit.** Log each lease (who, which secret, which run, when, why) to
+   `activity-log.ts`. This gives operators a real access trail — "this key was used by 3 runs
+   this week" — instead of a static binding list, and feeds least-privilege review.
+5. **Anomaly hooks.** Flag a secret leased far more often than usual, or by a run whose issue
+   doesn't plausibly need it — a cheap signal of misuse or a confused agent.
+
+## Perceived complexity
+
+**Medium.** The leasing pattern, TTL, and cleanup all have a working in-repo precedent
+(`environmentLeases`), so this is adapting a proven mechanism to secrets rather than inventing
+one. The careful parts are the acquire/release lifecycle around run boundaries (a leaked lease
+must expire by TTL even if a run crashes) and preserving adapter compatibility — agents that
+expect a secret present for the whole session need the lease scoped to the session, not a single
+tool call. Backward-compatible: existing bindings can map to "always-leasable" until operators
+opt into tighter TTLs.

--- a/.ideas/022-per-agent-network-egress-allowlist.md
+++ b/.ideas/022-per-agent-network-egress-allowlist.md
@@ -1,0 +1,43 @@
+# 022 — Per-Agent Network Egress Allow-Listing
+
+## Suggestion
+
+Paperclip controls *what runtimes* an agent may use (`execution-allowlist.ts` maps
+driver/provider/policy → allow/deny) and has a containment notion for untrusted agents
+(`low-trust-runtime-containment.ts`). What it doesn't control is **where an agent can talk on
+the network**. An autonomous agent executing code or shell commands can reach any host on the
+internet — which is the primary data-exfiltration and supply-chain risk for an AI workforce.
+"This agent may only reach `api.anthropic.com`, `github.com`, and our internal API" is a basic
+control that doesn't exist yet.
+
+Add **per-agent (and per-trust-tier) network egress allow-listing**: declare the destinations an
+agent's runs may contact, and deny the rest at the runtime boundary.
+
+## How it could be achieved
+
+1. **Egress policy model.** Add an `egressAllowlist` (domains/IP ranges/ports) to an agent's
+   execution policy, with sensible defaults per trust tier — a `probation`/low-trust agent
+   (ideas 009, `source-trust.ts`) gets a tight default; a senior agent gets a broader one.
+2. **Enforce at the containment layer.** This is what `low-trust-runtime-containment.ts` and the
+   sandbox runtime (`sandbox-provider-runtime.ts`, `plugin-runtime-sandbox.ts`) are positioned
+   to do. Depending on runtime: a proxy that only forwards allow-listed hosts, container network
+   policy, or DNS/firewall rules injected into the sandbox.
+3. **Default-deny for low trust, default-allow for trusted.** Make the strict mode opt-in per
+   company so it doesn't break existing setups, but ship a recommended baseline allowlist
+   (model providers, package registries, the Paperclip control plane).
+4. **Observability.** Log blocked egress attempts to `activity-log.ts`. A spike of blocked
+   destinations is a strong compromise/misconfiguration signal and complements outbound
+   secret-leak scanning (idea 020) — together they cover "secret leaving in content" and
+   "secret leaving over the wire."
+5. **Allowlist authoring help.** Offer a "learning mode" that records the destinations an agent
+   actually contacts over a trial period, then proposes an allowlist — so operators don't have
+   to author one blind.
+
+## Perceived complexity
+
+**Medium–High.** The policy model and UI are straightforward, but *enforcement* is genuinely
+hard and runtime-dependent: a local `process` adapter on the host machine can't be network-
+contained as cleanly as a real sandbox/container, so this lands first and best for sandboxed /
+cloud runtimes (which the roadmap is already moving toward) and is best-effort for bare local
+processes. Scope honestly: deliver strong enforcement where the runtime supports it, and surface
+clearly where egress control is *not* available so operators aren't lulled into false security.

--- a/.ideas/023-tamper-evident-audit-log.md
+++ b/.ideas/023-tamper-evident-audit-log.md
@@ -1,0 +1,42 @@
+# 023 — Tamper-Evident Audit Log
+
+## Suggestion
+
+Paperclip's vision is autonomous companies that are **governable and accountable**, and the
+`activity-log.ts` service already records who did what. But a plain append table is only as
+trustworthy as the database it lives in — anyone with DB access (a rogue admin, a compromised
+agent that reaches the data layer, a bad migration) can silently rewrite or delete history. For
+a system that's supposed to be the auditable system-of-record for an AI workforce making real
+business decisions and spending real money, "trust me, the log is accurate" isn't enough.
+
+Make the audit log **tamper-evident** via a hash chain: each entry includes the hash of the
+previous entry, so any retroactive edit or deletion breaks the chain and is detectable. You
+can't prevent a sufficiently privileged actor from changing the DB, but you *can* make it
+impossible to do so undetectably.
+
+## How it could be achieved
+
+1. **Hash-chain the log.** Add `prevHash` and `entryHash` columns to the activity-log table.
+   `entryHash = H(prevHash ‖ canonical(entry))`. Each new entry chains off the last — a
+   standard, cheap append-only-verifiability construction.
+2. **Verification endpoint/job.** A routine (`routines.ts`) re-walks the chain and verifies
+   integrity, raising a high-severity inbox alert if a break is found. Operators (and a Holding
+   Company, idea 007) can run on-demand verification before trusting a report.
+3. **Periodic anchoring (optional).** Periodically record the latest `entryHash` somewhere
+   outside the DB — a separate store, a signed file, or even an external timestamp — so even
+   wholesale rewrites of the table can't forge a consistent chain. Reuses the storage layer.
+4. **Cover the decisions that matter.** Ensure the high-stakes events are in the chain: budget
+   changes, approvals/overrides, agent hires, secret access (idea 021), emergency stops
+   (idea 014), and cross-company actions (idea 007).
+5. **Exportable proof.** Include the chain + verification in company exports
+   (`company-portability.ts`) so an operator can hand a regulator/partner an audit trail whose
+   integrity is independently checkable.
+
+## Perceived complexity
+
+**Low–Medium.** The mechanism is well-understood and the logging service already exists — the
+core change is computing/storing two hashes per entry and adding a verifier. The fiddly parts
+are (a) canonical serialization so hashes are stable and reproducible, (b) handling concurrent
+writes to a single chain without contention (may need a per-scope chain or a short serialization
+point), and (c) deciding what to do operationally when verification *fails*. External anchoring
+is an optional hardening tier to add later.

--- a/.ideas/024-per-run-resource-caps.md
+++ b/.ideas/024-per-run-resource-caps.md
@@ -1,0 +1,42 @@
+# 024 — Per-Run Resource Caps
+
+## Suggestion
+
+Paperclip's liveness watchdogs (`task-watchdogs.ts`, `run-liveness.ts`, `issue-liveness.ts`)
+catch runs that are **stuck or silent**, and the Diminishing-Returns Detector (idea 003) catches
+agents that are unproductive **across runs**. Neither catches a single run that is *very much
+alive and working* but has gone off the rails *within* the run — grinding for two hours, making
+500 tool calls, or generating a massive output, burning tokens the whole time. A healthy
+heartbeat is exactly what makes this failure mode expensive: nothing trips.
+
+Add **per-run resource caps**: hard ceilings on a single run's wall-clock time, tool-call /
+step count, and output/token volume, with a defined action when a ceiling is hit (graceful
+wind-down, then stop).
+
+## How it could be achieved
+
+1. **Cap config.** Per agent / trust tier / company: `maxRunWallClockMs`, `maxToolCalls`,
+   `maxRunTokens`, `maxRunCostCents`. Sensible defaults (looser for trusted, tight for
+   `probation` — idea 009); all opt-in so current behavior is unchanged.
+2. **Enforce in the run lifecycle.** `heartbeat.ts` already owns run start/tracking; track
+   cumulative counters per run (tokens already flow through `cost_events`; tool-call/step counts
+   come from the adapter execution stream). When a counter crosses its cap, signal the run to
+   stop via the existing cancel path.
+3. **Graceful wind-down, not a hard kill.** On hitting a cap, prefer asking the agent to wrap
+   up and checkpoint its progress (so work isn't lost), then stop if it doesn't — reusing the
+   continuation-summary machinery (`issue-continuation-summary.ts`) so the next run can resume.
+4. **Explain and escalate.** Post a comment ("run stopped after 500 tool calls / $3.00 cap")
+   and raise an inbox item so the operator can raise the cap or investigate. A run that
+   *chronically* hits caps is a signal the task is mis-scoped.
+5. **Compose with the budget/breaker stack.** Per-run cost caps are the run-level complement to
+   company-level budgets (ideas 002, 019) and the fleet governor (001) — three nested layers:
+   per run, per agent/company, per fleet.
+
+## Perceived complexity
+
+**Medium.** Wall-clock and token/cost caps are straightforward to track and enforce at the
+existing run choke point. Tool-call/step counting depends on each adapter surfacing step events,
+so coverage will be uneven across adapter types — wall-clock and cost caps work everywhere and
+should ship first. The genuinely valuable, slightly harder part is the *graceful* wind-down +
+checkpoint so a capped run resumes cleanly instead of losing work; a hard kill is easy but
+wastes the partial progress.

--- a/.ideas/025-capability-based-auto-assignment.md
+++ b/.ideas/025-capability-based-auto-assignment.md
@@ -1,0 +1,40 @@
+# 025 — Capability-Based Auto-Assignment
+
+## Suggestion
+
+Every agent carries a **capabilities** description (`agents.capabilities` — "a short paragraph
+on what this agent does and when they're relevant," per `doc/PRODUCT.md`, explicitly there to
+help "other agents discover who can help with what"). But that text is essentially passive:
+issues have a single assignee, and choosing it is manual or hard-coded by the agent that
+created the work. As a company grows, this is where throughput dies — work lands on the wrong
+agent, piles up on one overloaded specialist, or sits unassigned because nobody knew who fit.
+
+Add **capability-based auto-assignment**: when an issue needs an owner, Paperclip suggests (or
+auto-selects) the best-fit agent by matching the issue against agents' capabilities, weighted
+by current load, trust, and cost.
+
+## How it could be achieved
+
+1. **Match capability to need.** Score candidate agents for an issue using the existing
+   `capabilities` text plus the issue's content/labels. Start simple (keyword/embedding
+   similarity); the data is already there. `agent-assignability.ts` already encodes *who is
+   eligible* (org/company boundaries) — this adds *who is best* among the eligible.
+2. **Weight by reality, not just fit.** Blend in signals other ideas surface: current queue
+   depth (Org Bottleneck Heatmap, idea 006), trust stage (idea 009), and cost-effectiveness
+   (Unit-Economics, idea 013). Best fit ≠ best choice if that agent is underwater or expensive.
+3. **Suggest, then automate.** Phase 1: surface a ranked "suggested assignee" in the UI and to
+   the creating agent. Phase 2: opt-in auto-assignment for issues left unowned beyond a
+   threshold, so nothing rots unassigned.
+4. **Respect the org.** Route within the proper team/reporting structure by default; allow
+   cross-team assignment only where policy permits (reuses the boundary logic already in
+   `agent-assignability.ts`).
+5. **Learn from outcomes.** Feed back completion/approval/rework rates per (agent, work-type)
+   so matching improves — an agent that keeps getting a category right rises for it.
+
+## Perceived complexity
+
+**Medium.** Eligibility and the capability data already exist, so a first useful version
+(keyword/embedding match → ranked suggestions) is quick. The harder, higher-value work is the
+weighting model (fit × load × trust × cost) and the outcome-feedback loop, plus careful UX so
+auto-assignment is transparent and overridable. Ship as suggestions first (pure assist, no
+risk), then graduate to auto-assignment for the unowned long tail.

--- a/.ideas/026-goal-drift-alignment-auditor.md
+++ b/.ideas/026-goal-drift-alignment-auditor.md
@@ -1,0 +1,40 @@
+# 026 — Goal-Drift Alignment Auditor
+
+## Suggestion
+
+Paperclip's defining principle is **"all work traces to the goal"** — every task exists in
+service of a parent, up to the company goal (`doc/PRODUCT.md`, `goals.ts`, the parent/sub-issue
+tree). But this invariant is asserted at creation, not *maintained*. Autonomous agents
+continuously spawn sub-issues, and over time the tree drifts: orphaned branches whose parent
+goal was completed or abandoned, sub-issues that no longer actually serve their stated parent,
+whole sub-trees of busywork that have quietly decoupled from the mission. Nothing detects this —
+so a company can spend real money working hard on things that no longer matter, which is the
+single most insidious failure mode of an autonomous business.
+
+Add a **goal-drift auditor** that periodically verifies the alignment invariant and flags work
+that has decoupled from a live company goal.
+
+## How it could be achieved
+
+1. **Trace every active issue to a goal.** Walk the parent chain for each open issue to its
+   root. Flag issues whose chain terminates on a goal that is completed, cancelled, deprioritized,
+   or no longer exists — *orphaned work*. This is a pure graph walk over data that exists.
+2. **Semantic alignment check (deeper tier).** For active branches, use a cheap model (local —
+   idea 008) to judge whether a sub-issue's content plausibly serves its stated parent. Low
+   alignment → flag as *drifted*. Run sparingly (on a routine, on new branches) to control cost.
+3. **Quantify drift.** Per company: "% of active work tracing to a live top-priority goal" and
+   "estimated spend on orphaned/drifted work this week." That second number is a powerful
+   operator wake-up call and feeds the Unit-Economics Dashboard (idea 013) as "misaligned spend."
+4. **Act.** Route flagged work to the responsible manager agent (via the org chart) or the board
+   inbox: re-parent it, re-prioritize it, or close it. Auto-pause obviously-orphaned branches so
+   they stop burning budget while awaiting a decision.
+5. **Visualize.** Highlight drifted/orphaned branches on the goal tree and the Org Bottleneck
+   Heatmap (idea 006) — cold, decoupled branches are as important to see as hot, blocked ones.
+
+## Perceived complexity
+
+**Medium.** The structural check (orphaned-work detection) is a straightforward tree walk over
+existing data and delivers most of the value immediately. The semantic alignment tier is more
+involved — it needs a careful, cheap judging prompt and tuning to avoid false "drift" flags on
+legitimately exploratory work — but it's optional and incremental. No execution-engine changes;
+it's an analyzer plus escalation, with an auto-pause action reusing existing wakeup suppression.

--- a/.ideas/027-mobile-push-and-fast-approvals.md
+++ b/.ideas/027-mobile-push-and-fast-approvals.md
@@ -1,0 +1,41 @@
+# 027 — Mobile Push Notifications & Fast Approvals
+
+## Suggestion
+
+The README sells managing your autonomous companies **"from your phone,"** and the UI is
+mobile-aware (responsive sidebar/drawer in `useKeyboardShortcuts.ts`, `plugins/bridge.ts`). But
+the actual mobile experience is just a shrunken desktop board — there's no **push notification**
+when something needs you, and no streamlined mobile flow for the one thing operators most need
+to do on the go: **approve or reject**. An autonomous company runs 24/7; the human is the
+bottleneck precisely when they're away from their desk. If approvals can't reach you on your
+phone, autonomy stalls every evening and weekend.
+
+Deliver on the phone promise: **web push notifications** for the events that need a human, plus a
+fast, mobile-first approval flow.
+
+## How it could be achieved
+
+1. **Web Push (PWA).** Add a service worker and the Web Push API so the existing React UI can be
+   installed as a PWA and receive notifications even when closed — no native app needed. The
+   live-events websocket (`live-events-ws.ts`) and sidebar badges (`sidebar-badges.ts`) already
+   model "something needs attention"; push is a new delivery channel for the same signals.
+2. **Notify on what matters.** Approvals awaiting the operator, budget warn/hard-stop incidents
+   (`budgets.ts`), emergency-stop triggers (idea 014), and chronic fallbacks/leaks (ideas 012,
+   020). Reuse the risk score from approval triage (idea 016) so only high-signal events buzz the
+   phone — notification fatigue would kill this feature.
+3. **Approve from the notification.** Deep-link a push straight into a single-item approval card
+   with the run change-review diff (idea 017) inline and big approve / reject / "request changes"
+   actions — reviewable in ten seconds one-handed.
+4. **Quiet hours + batching.** Respect operator-set quiet hours (compose with idea 005) and batch
+   low-priority items into a periodic summary push instead of buzzing per event.
+5. **Per-user delivery prefs.** With multiple human users (a shipped roadmap item), let each
+   choose channels and thresholds.
+
+## Perceived complexity
+
+**Medium.** Web Push + service worker is well-trodden but new surface area for this codebase
+(subscription management, VAPID keys, a worker, per-user delivery prefs). The signals to notify
+on already exist; the work is the delivery pipeline and a genuinely good mobile approval card.
+Biggest design risk is notification quality — gating on the existing risk score is what keeps it
+useful rather than annoying. A scheduled digest push (idea 029) is a low-effort first slice that
+proves the pipeline before per-event push.

--- a/.ideas/028-agent-shift-handoff-briefings.md
+++ b/.ideas/028-agent-shift-handoff-briefings.md
@@ -1,0 +1,41 @@
+# 028 — Agent Shift-Handoff Briefings
+
+## Suggestion
+
+Paperclip already preserves continuity *within* a single agent's work on an issue
+(`issue-continuation-summary.ts` summarizes prior runs so the next run of the **same** agent
+resumes with context). But work also moves **between** agents — reassignment, escalation to a
+manager, a review handoff, a specialist pulled in — and at those moments the receiving agent
+starts cold. It re-reads the whole issue history, re-derives what's already been tried, and
+often repeats work or contradicts the prior owner. With a single-assignee model and autonomous
+agents constantly rerouting work, these cold handoffs are a quiet, recurring tax on quality and
+cost.
+
+Add **shift-handoff briefings**: when an issue changes hands, auto-generate a structured
+hand-off note — what's done, what's left, what was tried and failed, open decisions, gotchas —
+so the receiving agent starts warm.
+
+## How it could be achieved
+
+1. **Trigger on transfer.** Hook the assignment-change / escalation / review-handoff paths
+   (`agent-assignability.ts`, `issue-approvals.ts`, the reassignment mutation that already fires
+   `issue-assignment-wakeup.ts`).
+2. **Synthesize the briefing.** Reuse the continuation-summary machinery, but framed for a *new*
+   reader: current state, prior approaches and outcomes, blockers, decisions pending, and "things
+   the next owner should not redo." Generate cheaply on a local model (idea 008).
+3. **Attach as first-class context.** Store the briefing on the issue and inject it into the
+   receiving agent's run context, so it's used, not just filed. Keep prior briefings for an
+   auditable chain of custody as work moves through the org.
+4. **Human-readable too.** The same briefing helps an operator understand a reassignment at a
+   glance and pairs with the run change-review surface (idea 017) and approval triage (idea 016).
+5. **Manager rollups.** When work escalates up the org chart, a briefing lets the manager agent
+   act on a summary instead of re-reading a deep sub-tree — directly supporting the alignment and
+   bottleneck flows (ideas 026, 006).
+
+## Perceived complexity
+
+**Medium.** The summarization capability and the transfer hook points both already exist, so this
+is composition: trigger on handoff, repurpose continuation-summary for a new-reader audience, and
+thread the result into the receiving run's context. The main work is prompt/format design for a
+genuinely useful briefing (not a vague recap) and keeping generation cheap enough to run on every
+handoff — again a strong fit for a free local model.

--- a/.ideas/029-scheduled-operator-digest.md
+++ b/.ideas/029-scheduled-operator-digest.md
@@ -1,0 +1,40 @@
+# 029 — Scheduled Operator Digest ("Company Standup")
+
+## Suggestion
+
+To know what happened across an autonomous company, an operator today has to actively go
+*looking* — scan the board, the activity log, the cost view, the inbox. There's no **push
+summary** that comes to them. For a system whose whole pitch is "agents run 24/7 while you're
+away," the missing piece is the morning-after answer to "what did my company do overnight, what
+did it cost, and what needs me?" Human teams have standups and status reports; an AI company
+should generate its own.
+
+Add a **scheduled operator digest**: a periodic, human-readable summary of each company's
+activity — progress, spend, blockers, and decisions awaiting the operator — delivered on a
+cadence the operator chooses.
+
+## How it could be achieved
+
+1. **Schedule it natively.** Digests are a natural use of the existing scheduled-routines system
+   (`routines.ts`, `plugin-managed-routines.ts`) — "every weekday at 8am," "end of day," etc.
+2. **Assemble from existing signals.** Pull from data already tracked: issues opened/closed and
+   goal progress (`goals.ts`), spend and burn (`costs.ts`) — including token usage for
+   subscription users (idea 019) — top blockers (idea 010), drifted/orphaned work (idea 026), and
+   pending approvals (idea 016). No new tracking required, just aggregation.
+3. **Narrate it.** Turn the aggregates into a tight, readable brief with a cheap local model
+   (idea 008): "Shipped 12 issues ($4.10). Marketing is blocked on the CFO's budget approval (2
+   days). 3 items need your sign-off. Burn is trending 18% over plan." Lead with what needs the
+   human.
+4. **Deliver where the operator is.** Inbox by default; via mobile push / PWA (idea 027) or email
+   for the away-from-desk case. Each digest links straight back to the items it mentions.
+5. **Per-company + portfolio.** One per company, and a rolled-up portfolio digest for a Holding
+   Company operator (idea 007) — "here's all five companies in one note."
+
+## Perceived complexity
+
+**Low–Medium.** This is mostly composition over infrastructure that already exists — scheduling,
+the data sources, and (optionally) a local model for narration. No execution-engine changes. The
+effort is in selecting the *right* few things to surface (a digest that reports everything
+reports nothing) and the writing quality of the summary. It's also a low-risk first slice for the
+mobile-push pipeline (idea 027) and a natural consumer of nearly every analyzer idea in this
+folder.

--- a/.ideas/030-revenue-and-pnl-tracking.md
+++ b/.ideas/030-revenue-and-pnl-tracking.md
@@ -1,0 +1,43 @@
+# 030 — Revenue & P&L Tracking (Close the Loop on the Money Goal)
+
+## Suggestion
+
+Paperclip's entire premise is autonomous companies that make money — the canonical goal is
+"$1M MRR in 3 months," and `doc/PRODUCT.md` says a company tracks "**Revenue & expenses** at
+the company level." But in practice only the *expense* side is modeled: budgets are
+`spentMonthlyCents`, costs flow through `cost_events`, and `finance_events` is cost-shaped
+(provider, model, pricingTier, externalInvoiceId, amountCents). There's **no first-class way to
+record revenue** — so a company can't actually measure progress toward its defining goal, can't
+compute profit, ROI, or burn multiple, and the operator is flying blind on the one number that
+matters most: *is this thing making more than it costs?*
+
+Add **revenue tracking and a real P&L**: record income alongside spend, and surface
+profit/margin/MRR and goal progress in actual dollars.
+
+## How it could be achieved
+
+1. **Revenue events.** Add a revenue counterpart to `finance_events` (or a `direction`
+   income/expense field): amount, currency, source, recurring vs one-off, timestamp, and an
+   optional link to the issue/work product that produced it (so revenue can be attributed to
+   work — which feeds Unit-Economics, idea 013).
+2. **Multiple input paths.** (a) Manual entry by the operator. (b) Agent-reported — an agent
+   that closes a sale or ships a paid feature files a revenue event (governed by approval, since
+   self-reported revenue needs a human check). (c) Webhook ingestion from Stripe/Paddle/etc. via
+   the plugin system, so real payment data flows in automatically.
+3. **Real P&L view.** Compute revenue − expenses (expenses already exist) into profit, gross
+   margin, MRR/ARR, and burn multiple, per company and per period. This is the dashboard an
+   operator of an autonomous *business* actually wants.
+4. **Goal progress in dollars.** Tie the company goal ("$1M MRR") to measured MRR so the goal
+   tree shows real progress, not vibes — directly serving the "all work traces to the goal"
+   principle with a quantified top metric.
+5. **Feed the rest.** Revenue unlocks performance-based decisions elsewhere: capital allocation
+   in a Holding Company (idea 007), revenue-scaled budgets, and an honest ROI per agent.
+
+## Perceived complexity
+
+**Medium.** The financial-events plumbing, currency handling, and period aggregation already
+exist on the expense side and can be mirrored for income — the schema/serialization work is
+modest. The real effort is the *input paths* (manual UI, governed agent-reporting, and at least
+one payment-provider webhook integration) and trustworthy revenue attribution. Manual entry +
+P&L view is a small, high-value first slice; agent-reported and webhook ingestion are
+incremental and where the integration work concentrates.

--- a/.ideas/031-agent-run-distributed-tracing.md
+++ b/.ideas/031-agent-run-distributed-tracing.md
@@ -1,0 +1,43 @@
+# 031 — Agent-Run Distributed Tracing
+
+## Suggestion
+
+Paperclip already wires up **OpenTelemetry** (`instrumentation.ts` — auto-instrumentation for
+HTTP / Express / PG), and the UI can show a live run transcript (`RunTranscriptView.tsx`,
+`useLiveRunTranscripts.ts`). But that observability operates at the *infrastructure* layer
+(HTTP requests, DB queries) and the *raw transcript* layer — there's no **semantic trace of an
+agent's work**: a span tree showing this run → its tool calls → its sub-issue creations → its
+handoffs → its cost and tokens, correlated across the agents that touched one piece of work.
+When an autonomous company does something expensive or wrong, reconstructing "what actually
+happened and why" means manually stitching together logs, transcripts, and cost rows.
+
+Add **semantic distributed tracing for agent runs**: emit structured OTel spans for the
+agent-work lifecycle so operators can inspect, debug, and analyze agent behavior in any tracing
+backend — or in a built-in trace view.
+
+## How it could be achieved
+
+1. **Span the run lifecycle.** In `heartbeat.ts` (which owns run start/finish), open a root span
+   per run with attributes: agent, issue, adapter/model, trust tier, cost, tokens, outcome.
+   Child spans for tool calls / steps (from the adapter execution stream), secret leases
+   (idea 021), provider fallbacks (idea 012), and sub-issue creation.
+2. **Propagate context across handoffs.** Carry trace context when work moves between agents
+   (idea 028) and when a run spawns sub-work, so a whole issue's journey across the org is one
+   connected trace — the thing infra-level OTel can't give you.
+3. **Reuse the existing exporter.** It's OTel already, so traces flow to whatever backend an
+   operator configures (Jaeger/Tempo/Honeycomb/etc.) with no new pipeline.
+4. **Built-in trace view (optional).** A waterfall view in the UI keyed off the same spans, so
+   operators without an external backend still get a visual run timeline — a natural companion to
+   the run change-review surface (idea 017) and the transcript view.
+5. **Analytics fallout.** Span attributes (cost, tokens, duration, tool-call counts) become a
+   clean data source for per-run resource caps (idea 024), the Diminishing-Returns Detector
+   (idea 003), and Unit-Economics (idea 013) — one instrumentation layer, many consumers.
+
+## Perceived complexity
+
+**Medium.** The OTel SDK and exporter are already present, so emitting spans is incremental, not
+greenfield — the work is identifying the right span boundaries and attributes and threading trace
+context through the run/handoff paths (and across adapter types, where step granularity varies).
+Wall-clock/cost/outcome spans work for every adapter and should ship first; fine-grained
+tool-call spans depend on each adapter surfacing step events. The built-in trace view is optional
+front-end polish on top.

--- a/.ideas/032-ab-model-bakeoff-harness.md
+++ b/.ideas/032-ab-model-bakeoff-harness.md
@@ -1,0 +1,41 @@
+# 032 — A/B Model Bake-Off Harness
+
+## Suggestion
+
+Paperclip is proudly multi-adapter and multi-model (Claude, Codex, Cursor, Gemini, Grok, local
+LLMs, …), and an operator picks an adapter/model per agent. But there's **no way to actually
+compare them on real work**. Is the cheaper model good enough for triage? Does the premium model
+earn its 10× cost on this company's tasks? Would a local model (idea 008) handle reviews
+acceptably for free? Today that's a guess, re-made per agent, with no evidence — which means
+operators systematically over-pay (defaulting to the expensive model everywhere) or under-deliver
+(cheaping out where quality matters).
+
+Add an **A/B bake-off harness**: run the same task(s) through two or more adapter/model
+configurations and compare cost, speed, and quality side by side, so model selection is
+evidence-based.
+
+## How it could be achieved
+
+1. **Define a bake-off.** Pick a set of representative tasks (real past issues, or eval cases
+   from `evals/promptfoo/`) and two-plus candidate configs (e.g. `claude` vs `local-llm` vs a
+   cheaper API model).
+2. **Run in shadow.** Execute each candidate against each task in an isolated, side-effect-free
+   mode (reuse the `planOnly`/dry-run capability proposed for idea 004 so a bake-off doesn't
+   touch production workspaces or send anything).
+3. **Measure automatically.** Cost and tokens come from `cost_events`; latency from run timing.
+   Quality is scored by the eval assertions (idea 011) plus an optional LLM-judge for open-ended
+   tasks — judged by a *neutral* model to avoid self-preference bias.
+4. **Report a recommendation.** "For `code-review` tasks: local-llm scores 0.92 of premium at
+   $0.00 vs $0.41/run — recommend local-llm." Surface a cost/quality frontier, not just a winner.
+5. **One-click apply.** Let the operator adopt the winning config for an agent/role directly, and
+   re-run bake-offs periodically as models change — model quality/price move fast.
+
+## Perceived complexity
+
+**Medium.** The pieces exist — multiple adapters, per-run cost data, and an eval harness — so the
+harness is orchestration plus comparison reporting rather than new runtime. The two genuinely
+hard parts are (a) a fair, low-bias quality score for open-ended agent work (eval assertions are
+easy; subjective quality needs a careful neutral-judge setup) and (b) guaranteeing the shadow
+runs are truly side-effect-free, which it shares with idea 004's `planOnly` contract. Start with
+eval-scored, deterministic tasks where quality is objective, then extend to judged open-ended
+work.

--- a/.ideas/033-stakeholder-transparency-page.md
+++ b/.ideas/033-stakeholder-transparency-page.md
@@ -1,0 +1,38 @@
+# 033 — Stakeholder Transparency Page
+
+## Suggestion
+
+An autonomous company has stakeholders who aren't operators — investors, partners, a parent
+org, teammates — who want to know "how's it going?" without being handed full board access (and
+its mutation powers, costs, secrets, and noise). Paperclip already has the building blocks for
+controlled external sharing (`feedback.ts` manages `feedbackExports`; `company_skills` carries a
+`publicShareToken`), but there's no **read-only, shareable company progress view** for outside
+stakeholders. Today the choice is binary: full access or nothing.
+
+Add a **stakeholder transparency page**: a curated, read-only, link-shareable snapshot of a
+company's health — goal progress, key metrics, recent shipped outcomes — that an operator can
+hand to an investor or partner.
+
+## How it could be achieved
+
+1. **Tokenized read-only view.** Reuse the `publicShareToken` pattern: a signed, revocable link
+   that renders a fixed, read-only page scoped to one company — no auth into the real board, no
+   write paths, no agent internals.
+2. **Curate what's shown.** Operator-selected metrics: goal progress (and MRR/P&L once revenue
+   tracking lands, idea 030), milestones hit, headline shipped work products, and an optional
+   high-level activity timeline. Explicitly *exclude* spend internals, secrets, raw transcripts,
+   and anything sensitive by default.
+3. **Generated narrative.** Reuse the operator-digest summarizer (idea 029) to produce an
+   investor-readable "state of the company" paragraph, refreshed on a cadence.
+4. **Controls.** Expiring links, revical/rotation, optional passphrase, and an access log
+   (who/when) written to the audit trail (idea 023) — sharing externally is a governance event.
+5. **Portfolio roll-up.** A Holding Company (idea 007) can publish a portfolio-level page across
+   its subsidiaries — one link that shows the whole group's trajectory.
+
+## Perceived complexity
+
+**Low–Medium.** The share-token mechanism, the underlying metrics, and (optionally) the digest
+narrator already exist, so this is primarily a scoped read-only rendering path plus operator
+controls for what's exposed. The real care is on the **security/privacy boundary**: a public
+link must be incapable of leaking anything beyond the explicitly curated fields, and revocation
+must be instant and reliable — get the default-deny exposure model right before adding niceties.

--- a/.ideas/034-data-retention-pii-governance.md
+++ b/.ideas/034-data-retention-pii-governance.md
@@ -1,0 +1,45 @@
+# 034 — Data Retention & PII Governance
+
+## Suggestion
+
+Autonomous agents generate and store enormous amounts of content indefinitely — run transcripts
+(`RunTranscriptView`, `useLiveRunTranscripts`), comments, documents, work products, activity
+logs, cost events. Paperclip has piece-wise hygiene (`plugin-log-retention.ts`, `log-redaction`,
+`redaction`), but no **company-level data retention or PII governance**: nothing ages out old
+transcripts, purges data on request, or scrubs personal information that agents inevitably
+ingest (customer emails, names, support tickets) and then persist forever. For anyone operating
+a real business — especially under GDPR/CCPA-style obligations — "we keep every agent transcript
+indefinitely and never scrub PII" is a liability, and it also bloats the database over time.
+
+Add **configurable data retention and PII governance**: retention policies that age out or
+anonymize old data, and PII detection/redaction on stored content, with a defensible deletion
+path.
+
+## How it could be achieved
+
+1. **Retention policies per company.** Operator-set TTLs by data class (transcripts, completed-
+   issue threads, activity logs, cost-event detail), enforced by a routine (`routines.ts`).
+   Generalize the existing `plugin-log-retention.ts` pattern from plugin logs to core data.
+2. **Tiered handling.** Per class: *delete*, *anonymize* (strip PII, keep structure for
+   analytics/audit), or *archive* (move to cold storage via the storage layer). Keep
+   tamper-evident audit entries (idea 023) even when their referenced content is purged — retain
+   the proof, drop the payload.
+3. **PII detection.** Reuse/extend the redaction utilities and the outbound-secret-leak scanner
+   (idea 020) to also flag personal data (emails, phone numbers, names) in stored content,
+   redacting or tagging it for retention handling.
+4. **Right-to-erasure path.** A scoped "purge all data relating to <subject/identifier>"
+   operation across transcripts, comments, documents, and work products — the concrete capability
+   a privacy request demands — with the action itself audited.
+5. **Defaults & disclosure.** Ship sensible default retention windows and surface "what we keep
+   and for how long" so operators can reason about (and configure) their exposure.
+
+## Perceived complexity
+
+**Medium.** Retention scheduling has an in-repo precedent (`plugin-log-retention.ts`) to
+generalize, and PII detection can build on existing redaction primitives, so the mechanics are
+tractable. The hard parts are correctness and completeness: deletion/anonymization must reach
+*every* place a piece of data was copied (transcripts, exports, caches, search indexes) or
+"erasure" is a false promise, and anonymization must preserve enough for analytics/audit without
+re-identifiability. Reconciling retention with the tamper-evident log (keep proof, drop payload)
+also needs deliberate design. Ship retention TTLs first (clear value, lower risk), then PII
+detection, then full right-to-erasure.

--- a/.ideas/035-adaptive-heartbeat-cadence.md
+++ b/.ideas/035-adaptive-heartbeat-cadence.md
@@ -1,0 +1,40 @@
+# 035 — Adaptive Heartbeat Cadence
+
+## Suggestion
+
+Agents run on **heartbeats** — periodic wake-ups where they check for work and act
+(`heartbeat.ts`). Today cadence is essentially fixed per agent. That's wasteful at both ends: an
+idle agent with an empty queue still wakes on schedule, spends tokens loading context only to
+find nothing to do, and goes back to sleep — pure burn for zero output, multiplied across a
+24/7 company. Meanwhile an agent with a deep, urgent backlog waits out its interval between
+runs, hurting responsiveness exactly when it matters. A fixed cadence can't be right for both.
+
+Add **adaptive heartbeat cadence**: tune each agent's wake frequency dynamically from its actual
+workload — back off when idle, speed up when there's a backlog or time-sensitive work.
+
+## How it could be achieved
+
+1. **Signals already available.** Queue depth for the agent (assigned/ready issues), recent
+   "woke up with nothing to do" outcomes, and pending wake triggers
+   (`issue-assignment-wakeup.ts` already does event-driven wakeups). These drive the cadence.
+2. **Backoff when idle.** After consecutive empty heartbeats, exponentially lengthen the
+   interval (with a cap), so idle agents cost almost nothing — but keep them reachable by the
+   existing event-driven wakeup so new work still pulls them in immediately.
+3. **Speed up under load.** When queue depth or priority crosses a threshold, shorten the
+   interval (down to a floor) so busy agents iterate faster. Respect the Fleet Concurrency
+   Governor (idea 001) and per-run caps (idea 024) so "faster" never means "unbounded."
+4. **Event-first, timer-fallback.** Make the timer a safety net and prefer event-driven
+   wakeups (assignment, mention, blocker cleared). The cadence is just the heartbeat for when no
+   event fires — mirroring how a well-designed poll loop leans on events.
+5. **Bounds & visibility.** Operator-set min/max intervals per agent/tier, and a readout of each
+   agent's current effective cadence and *why* ("idle ×6 → backed off to 30m").
+
+## Perceived complexity
+
+**Medium.** The heartbeat scheduler and an event-driven wakeup path already exist, so this is a
+control policy layered on top rather than new machinery — compute a next-interval from workload
+signals instead of using a constant. The subtle parts are avoiding oscillation (needs hysteresis/
+smoothing, like the budget breaker in idea 002) and guaranteeing a backed-off idle agent still
+responds instantly to a real event, so backoff never feels like the agent "went to sleep on the
+job." Idle-backoff alone is a high-ROI first slice — it directly cuts wasted spend with little
+risk.

--- a/.ideas/036-outbound-webhooks-event-subscriptions.md
+++ b/.ideas/036-outbound-webhooks-event-subscriptions.md
@@ -1,0 +1,42 @@
+# 036 — Outbound Webhooks & Event Subscriptions
+
+## Suggestion
+
+Paperclip has a rich internal event system — a live-events websocket (`live-events-ws.ts`,
+`live-events.ts`) and a plugin event bus (`plugin-event-bus.ts`) — but events stay *inside*
+Paperclip. There's no first-class way for **external systems** to subscribe to what an autonomous
+company does. Operators inevitably want Paperclip to be part of a bigger picture: post to Slack
+when an issue ships, alert PagerDuty on a budget hard-stop, trigger a deploy when a work product
+is approved, log revenue events (idea 030) into a data warehouse. Today that requires building a
+plugin or polling the API.
+
+Add **outbound webhooks**: let operators register HTTPS endpoints that receive signed event
+payloads when chosen company events occur — turning Paperclip into a producer in any automation
+pipeline.
+
+## How it could be achieved
+
+1. **Subscriptions model.** Per company: `{ url, eventTypes[], secret, active }`. Event types map
+   to events the internal bus already emits — issue status changes, approvals, budget incidents
+   (`budgets.ts`), emergency stops (idea 014), revenue (idea 030), run completions.
+2. **Fan out from the existing bus.** Subscribe a delivery service to `plugin-event-bus.ts` /
+   `live-events.ts` and POST matching events to registered URLs — no new event source needed,
+   just a new sink.
+3. **Reliable delivery.** Sign payloads (HMAC with the per-subscription secret) so receivers can
+   verify authenticity; retry with backoff on failure; dead-letter and surface chronic failures
+   to the operator. The plugin job scheduler (`plugin-job-scheduler.ts`) is a good template for
+   the retry/queue mechanics.
+4. **Security.** Reuse the private-hostname guard (`middleware/private-hostname-guard.ts`) to
+   prevent SSRF into internal networks, and scope each subscription to one company's events only.
+5. **Symmetry with inbound.** Paperclip already *ingests* via the HTTP adapter and (proposed)
+   payment webhooks (idea 030); outbound webhooks complete the loop so Paperclip both consumes and
+   emits, making it a first-class node in an automation graph.
+
+## Perceived complexity
+
+**Low–Medium.** The internal event stream exists and a retry/queue pattern is already in the repo
+to copy, so the core is a subscription store plus a signed, retrying delivery worker. The real
+care is operational safety: SSRF prevention (covered by the existing guard), payload signing,
+not leaking sensitive fields in event bodies (curate per event type), and backpressure so a slow
+endpoint can't stall delivery. Start with a handful of high-value event types and at-least-once
+delivery; expand the catalog over time.

--- a/.ideas/037-prompt-cache-aware-context-optimization.md
+++ b/.ideas/037-prompt-cache-aware-context-optimization.md
@@ -1,0 +1,45 @@
+# 037 — Prompt-Cache-Aware Context Optimization
+
+## Suggestion
+
+Paperclip already *measures* cached input tokens — `cost_events.cachedInputTokens` and
+`agent_runtime_state.totalCachedInputTokens` are tracked distinctly from fresh input. That's a
+signal it knows prompt caching exists, but nothing in the product actively **optimizes for it**.
+Modern LLM providers charge a fraction (often ~10%) for cached prompt prefixes, so the single
+biggest lever on token cost for repetitive agent loops is **maximizing cache hits** by keeping
+the stable part of each prompt (system instructions, role/SOUL config, company context,
+long-lived issue context) byte-stable and front-loaded, with only the volatile part at the end.
+Agents that rebuild their context fresh each heartbeat — reordering or regenerating the
+preamble — silently pay full price every run.
+
+Add **cache-aware context assembly**: structure the context Paperclip provides to agents so the
+invariant prefix is stable and cacheable, and surface cache efficiency so operators can see (and
+improve) it.
+
+## How it could be achieved
+
+1. **Stable-prefix discipline.** Where Paperclip assembles run context (instructions, role
+   config, company/goal context, continuation summaries — `agent-instructions.ts`,
+   `issue-continuation-summary.ts`), order it invariant-first / volatile-last and avoid
+   regenerating the stable portion run-to-run. For Anthropic adapters, set explicit cache
+   breakpoints at the prefix boundary.
+2. **Cache-hit metric.** Compute `cachedInputTokens / totalInputTokens` per agent/company from
+   data already collected and surface it: "Marketing-bot cache hit rate: 31% — low." A low rate
+   on a repetitive agent is found money.
+3. **Diagnose cache-busters.** Flag patterns that defeat caching — timestamps or volatile IDs
+   injected near the top of the prompt, instruction churn, per-run reordering — and recommend
+   fixes. The A/B harness (idea 032) and tracing (idea 031) give the data to spot them.
+4. **Adapter-aware.** Caching mechics differ per provider; apply it where the adapter supports
+   explicit cache control and treat it as best-effort elsewhere. Local models (idea 008) have
+   their own prefix-caching behavior worth aligning to.
+5. **Tie to economics.** Show estimated savings from improved cache hits in the Unit-Economics
+   Dashboard (idea 013) — this is one of the clearest cost wins available and is invisible today.
+
+## Perceived complexity
+
+**Medium.** The token data and the context-assembly code already exist, and the cache-hit metric
+is a pure read-model addition (quick, high-insight). The deeper work is auditing every place run
+context is built to enforce stable-prefix ordering and wiring explicit cache breakpoints per
+adapter without breaking adapters that don't support them — careful, incremental plumbing rather
+than algorithmic difficulty. Ship the cache-hit *metric* first to quantify the opportunity, then
+optimize the assembly where the numbers say it pays.

--- a/.ideas/038-approval-delegation-coverage.md
+++ b/.ideas/038-approval-delegation-coverage.md
@@ -1,0 +1,42 @@
+# 038 — Approval Delegation & Coverage
+
+## Suggestion
+
+Human approval is Paperclip's governance backbone (`approvals.ts`, `issue-approvals.ts`), and
+with multiple human users now supported, the operator is still a **single point of stall**: when
+the person whose sign-off is required is asleep, on vacation, or simply busy, autonomous work
+that needs approval freezes — a 24/7 company gated on one human's availability. Approval triage
+(idea 016) helps the human go faster, and mobile push (idea 027) reaches them anywhere, but
+neither helps when that human is genuinely **unavailable**. There's no way to delegate approval
+authority or set coverage.
+
+Add **approval delegation and coverage**: let an approver hand scoped, time-boxed approval
+authority to another human (or a manager agent) so work keeps flowing when they're away — without
+quietly removing the safeguard.
+
+## How it could be achieved
+
+1. **Delegation grants.** An approver creates a scoped, expiring delegation: "while I'm out
+   (dates), <delegate> may approve <these scopes/risk levels> up to <limit>." Scoping reuses the
+   risk score from approval triage (idea 016) so only low/medium-risk items delegate by default.
+2. **Coverage routing.** When an approval sits unactioned beyond an SLA, auto-route it to the
+   designated backup (another human, or escalate up the org chart to a manager agent) instead of
+   rotting — complements the human-blocked case of the deadlock detector (idea 010).
+3. **Agent-as-approver, bounded.** Allow a manager *agent* to hold delegated authority only
+   within tight limits (e.g. approve doc edits under $X from trusted agents), with everything it
+   approves double-logged for the absent human to review on return. High-risk items never
+   delegate to an agent — they wait or escalate to another human.
+4. **Full audit.** Every delegated/covered approval records who actually approved, under whose
+   delegation, and why, in the tamper-evident audit log (idea 023). Delegation is itself a
+   governance event and is logged.
+5. **Out-of-office switch.** A simple "I'm away until <date>, route my approvals to <X>" control,
+   with auto-revert — the human-coverage analog of quiet-hours scheduling (idea 005).
+
+## Perceived complexity
+
+**Medium.** The approval model, multi-user support, and org chart all exist, so this is a
+delegation/scoping/expiry layer plus coverage routing — not new core machinery. The careful parts
+are the **authority model**: scopes and limits must be airtight so delegation can't be used to
+escalate privilege, agent-held authority must be narrowly bounded and fully audited, and
+revocation/expiry must be reliable. Ship human-to-human delegation and SLA coverage routing
+first; bounded agent-as-approver is a later, more sensitive tier.

--- a/.ideas/039-guided-onboarding-demo-company.md
+++ b/.ideas/039-guided-onboarding-demo-company.md
@@ -1,0 +1,41 @@
+# 039 — Guided Onboarding & Runnable Demo Company
+
+## Suggestion
+
+Paperclip is powerful but conceptually dense: companies, org charts, adapters, heartbeats,
+budgets, governance, goal trees. A new user lands on an empty instance facing a blank-slate
+"create your first company" with no obvious path to value — and the fastest way to *understand*
+an autonomous company is to *watch one run*, not to read docs and configure adapters first. The
+repo ships onboarding assets (`onboarding-assets/ceo`, `onboarding-assets/default`) and
+`default-agent-instructions.ts`, so the raw material exists, but there's no **guided first-run
+experience** that turns a cold install into an "aha" in minutes.
+
+Add **guided onboarding with a runnable demo company**: a one-click sample company that's already
+wired up, plus an interactive tour that explains each concept against something real and moving.
+
+## How it could be achieved
+
+1. **One-click demo company.** Ship a Company Blueprint (idea 018) — a pre-built org (CEO + a few
+   reports), a sample goal, starter issues, and a budget — that instantiates from the existing
+   onboarding assets. Default it to a **local LLM** (idea 008) or a safe stubbed adapter so the
+   demo costs ~nothing and needs no API key to explore.
+2. **Interactive tour.** A guided overlay walks the new concepts in order — goal → org chart →
+   an agent's heartbeat → an issue moving → budget/spend → an approval — anchored to the live
+   demo company so each idea is shown, not just told.
+3. **Safe sandbox.** Run the demo in a clearly-labeled mode where actions are contained (no real
+   external side effects), so a newcomer can hit "go," watch agents pick up work, and approve
+   something without fear.
+4. **Graduation path.** End the tour with "now create your real company," carrying lessons
+   forward and pre-filling sensible defaults — and offer the Dry-Run Estimator (idea 004) so
+   their first real company launches with eyes open.
+5. **Re-runnable.** Keep the demo available (not just first-launch) as a living reference and a
+   place to safely try features before using them in production.
+
+## Perceived complexity
+
+**Low–Medium.** Most ingredients exist — onboarding assets, default instructions, and (with the
+blueprint library, idea 018) a clean instantiation path. The work is product/UX: authoring the
+guided tour, packaging a genuinely illustrative demo company, and a contained sandbox mode so the
+demo is safe and free to run. The main risk is keeping the tour in sync as the product evolves —
+anchor steps to stable concepts/landmarks rather than brittle UI details. High leverage for
+adoption relative to effort.

--- a/.ideas/040-operator-owned-training-dataset.md
+++ b/.ideas/040-operator-owned-training-dataset.md
@@ -1,0 +1,62 @@
+# 040 — Operator-Owned Prompt/Response Dataset & Training Pipeline
+
+## Suggestion
+
+Every agent run is a prompt → response pair with a *known outcome* — it got approved, rejected,
+reworked, shipped, or abandoned; it cost X; it did or didn't move the goal. That is exactly the
+raw material for improving agents: better prompts, regression evals, distillation, and
+fine-tuning local models. Paperclip captures the ingredients but not in a usable form:
+
+- **Run logs are opaque.** `run-log-store.ts` persists run output as raw `local_file` blobs
+  (append/read-by-offset). Not queryable, not structured into prompt/response, not labeled.
+- **Feedback exists but points at the vendor.** `feedbackVotes` (👍/👎 + reason, `redactionSummary`,
+  `consentVersion`) and `feedbackExports` ship trace bundles to Paperclip's own telemetry
+  backend (`telemetry.paperclip.ing`), gated by `feedbackDataSharingEnabled`. That improves
+  *Paperclip*, not the operator's specific agents, and it leaves the building.
+
+The gap: an **operator-owned, structured, outcome-labeled dataset** of their agents' interactions
+that *stays with them* and feeds their own improvement loop. Add a first-class capture pipeline
+that turns run history into a queryable, exportable training corpus the operator controls.
+
+## How it could be achieved
+
+1. **Structured interaction records.** Alongside the raw run log, persist a normalized record per
+   run: system/role prompt, input context, the response/actions, tokens & cost (`cost_events`),
+   adapter/model, and IDs linking it to its issue/agent/goal. Promotes today's opaque blobs into
+   queryable rows/objects.
+2. **Automatic outcome labels.** Derive labels from the work lifecycle that already exists —
+   approved/rejected via `approvals.ts`, reopened/reworked, shipped, abandoned, Diminishing-
+   Returns trip (idea 003), capped run (idea 024). These outcome labels are what make the data
+   *training-grade* rather than just archived chatter. Layer the existing `feedbackVotes` 👍/👎 on
+   top as explicit human signal.
+3. **Reuse consent + redaction.** Run every record through the existing `feedback-redaction.ts`
+   and outbound-secret/PII scanners (ideas 020, 034) before storage/export, and gate everything on
+   the existing company consent flags. Critical distinction from the current feature: this dataset
+   is **operator-owned and local by default** — it does not leave the instance unless the operator
+   exports it.
+4. **Useful export formats.** Export to (a) eval cases for the eval harness (idea 011) and A/B
+   bake-offs (idea 032); (b) JSONL fine-tuning/preference-pair format (good vs rejected responses
+   for the same task) for distilling a cheaper or **local model** (idea 008); (c) a plain dataset
+   for external analysis.
+5. **Close the loop.** "Mine your own history": surface which prompts/configs correlate with
+   approvals vs rework, feeding capability-based assignment (idea 025), the trust ramp (idea 009),
+   and prompt-cache/prompt-quality tuning (idea 037).
+
+## Governance note
+
+Two things must be explicit and on by operator choice, not default-on: (a) using captured agent
+outputs as training data can carry **provider terms-of-service** implications depending on the
+model, and (b) the corpus will contain customer/business data, so it inherits the retention/PII
+governance (idea 034) and right-to-erasure obligations. Surface these clearly; keep it
+local-and-consented.
+
+## Perceived complexity
+
+**Medium.** The capture point (`run-log-store.ts`), the outcome signals (approvals, rework,
+votes), and the redaction/consent machinery all already exist — the work is normalizing runs into
+structured, labeled records, a storage/query layer, and exporters for the eval/fine-tune formats.
+The genuinely hard parts are (a) faithful, low-overhead capture across heterogeneous adapters
+(each formats prompts/responses differently), (b) trustworthy automatic labeling, and (c) getting
+the privacy/consent/ToS boundary right so the feature is an asset, not a liability. Ship structured
+capture + auto-labels + a local query view first; add fine-tune/preference-pair export once the
+labeled corpus proves useful.

--- a/.ideas/041-host-resource-aware-local-scheduling.md
+++ b/.ideas/041-host-resource-aware-local-scheduling.md
@@ -1,0 +1,62 @@
+# 041 — Host Resource-Aware Scheduling for Local Agents (Work-Hours Yield)
+
+## Suggestion
+
+Local agents are fundamentally different from cloud/API agents: they run on the operator's
+**own physical machine** and contend for a finite, *shared* resource — CPU, RAM, and especially
+GPU/VRAM — that the human also needs. The local LLM adapter (idea 008) makes this acute: running
+two large local models at once can exhaust VRAM and OOM, saturate the GPU, and make the operator's
+own machine unusable. Paperclip today has **no host-resource awareness at all** — a code scan
+finds no CPU/GPU/VRAM/memory/load monitoring, and the only time-based control (Spend-Schedule,
+idea 005) governs *concurrency caps and budget by clock time*, which is provider-agnostic and
+hardware-blind. The Fleet Concurrency Governor (idea 001) counts *runs*, not whether the GPU can
+actually fit another model.
+
+Two distinct needs follow, both unmet:
+
+- **Capacity:** don't start more local-inference agents than the hardware can physically handle.
+- **Work-hours courtesy:** during the operator's working hours, the human's use of the machine
+  comes first — heavy local agent work should defer to off-hours or to when the machine is idle,
+  then ramp up.
+
+Add **host resource-aware scheduling for local agents**: monitor the machine, admit local runs
+against real capacity, and respect a work-hours profile that yields the machine to its owner.
+
+## How it could be achieved
+
+1. **Host resource probe.** Add a lightweight monitor (new capability — none exists today)
+   sampling CPU load (`os.loadavg`/`os.cpus`), free/total memory (`os.freemem`/`os.totalmem`),
+   and GPU/VRAM where available (e.g. `nvidia-smi`, or platform equivalents). Surface it via the
+   same read-model path the dashboard already uses. `environment-probe.ts` is the natural home.
+2. **Resource-based admission for local runs.** Extend the run-admission gate (idea 001's
+   governor) with a *capacity* check that applies only to local execution targets
+   (`environment-execution-target.ts` already distinguishes local vs remote): refuse/queue a
+   local run when free VRAM/RAM/CPU headroom is below a threshold, rather than counting slots.
+   This is the difference between "max 4 runs" and "as many runs as this GPU can actually hold."
+3. **Per-model resource hints.** Let a local-LLM agent config declare an approximate footprint
+   (model size / VRAM need) so admission can reason about fit before launch instead of
+   discovering OOM at runtime.
+4. **Work-hours profile (yield to the human).** A machine-level schedule: during the operator's
+   defined work hours, cap local-agent resource usage (e.g. ≤30% GPU, low priority) so the human
+   keeps a responsive machine; off-hours, lift the caps and let local agents use the box fully.
+   This is the *physical-resource* sibling of clock-time quiet hours (idea 005), and the two
+   should share one schedule UI with a clear precedence order.
+5. **Reactive yield.** Beyond the schedule, react to live load: when host GPU/CPU spikes (the
+   human starts a heavy task), pause or throttle local agents and resume when the machine goes
+   idle — a "get out of the way" reflex. Pair with adaptive heartbeats (idea 035) so yielded
+   agents back off cleanly instead of busy-retrying.
+6. **Local-only scope.** All of this applies strictly to local execution targets; cloud/remote
+   agents (whose "resource" is provider quota and dollars) keep using the budget/quota controls
+   (ideas 002, 012, 019). Detecting the target is already possible in the execution-target layer.
+
+## Perceived complexity
+
+**Medium.** The scheduling/admission framework to hang this on largely exists (the proposed
+governor in idea 001, the local-vs-remote execution-target distinction, the routine/schedule
+system), so the new core is the **host resource probe**, which the codebase lacks entirely.
+Cross-platform resource sampling is the fiddly part — CPU/RAM are easy and portable via Node's
+`os` module; GPU/VRAM is vendor- and OS-specific (NVIDIA vs Apple Silicon vs AMD) and best
+treated as best-effort with graceful degradation when unavailable. Per-model footprint hints are
+approximate by nature and only need to be good enough to prevent obvious OOMs. Ship CPU/RAM-aware
+admission + the work-hours yield profile first (portable, immediately useful), then add GPU/VRAM
+awareness where the platform supports it.

--- a/.ideas/042-workspace-conflict-coordination.md
+++ b/.ideas/042-workspace-conflict-coordination.md
@@ -1,0 +1,42 @@
+# 042 — Workspace Conflict Coordination for Parallel Agents
+
+## Suggestion
+
+Multiple agents can operate in shared project/execution workspaces
+(`execution-workspaces.ts`, `workspace-operations.ts`). But the workspace model only reasons
+about conflict at **close** time — `execution-workspaces.ts` computes `blockingReasons` /
+`blockingIssues` to decide if a workspace can be destructively closed. There's nothing
+coordinating **concurrent edits**: if two agents work the same files in the same workspace at
+once, they clobber each other — last-write-wins, lost work, or a corrupted tree. As companies
+parallelize work across an engineering team of agents (exactly the scaling story Paperclip
+sells), this silent-collision failure mode grows with every agent you add.
+
+Add **workspace conflict coordination**: file/path ownership and soft-locking so parallel agents
+don't overwrite each other, with detection and resolution when they collide anyway.
+
+## How it could be achieved
+
+1. **Path-level soft locks.** When an agent's run begins editing a file/subtree, record a claim
+   keyed by `{ workspaceId, path, runId, expiresAt }` — reusing the lease pattern already in the
+   repo (`environmentLeases`, and proposed for secrets in idea 021). Claims auto-expire on run
+   end/TTL so a crashed run never wedges a path forever.
+2. **Coordinate, don't just block.** A second agent wanting a claimed path can wait, pick
+   different work, or request a handoff (idea 028) — surfaced as a soft signal, not a hard error,
+   so agents degrade gracefully instead of failing.
+3. **Collision detection.** `workspace-operations.ts` already logs file operations per run;
+   detect overlapping writes to the same path across concurrent runs and flag them, even if locks
+   were bypassed. A detected collision raises an inbox/review item rather than silently merging.
+4. **Ownership zones (coarser option).** Let an operator assign workspace subtrees to teams/agents
+   (e.g. marketing-bot owns `/content`, eng owns `/src`) so most parallelism is conflict-free by
+   construction — the file-ownership discipline humans use for the same problem.
+5. **Compose with admission.** The Fleet Concurrency Governor (idea 001) can factor lock
+   contention into scheduling: don't wake an agent whose only available work is fully locked.
+
+## Perceived complexity
+
+**Medium.** The operation log and a reusable lease/claim pattern already exist, so soft-locking
+and collision detection are tractable additions rather than new infrastructure. The hard parts
+are semantic: locks must be advisory enough not to deadlock autonomous agents (a stuck claim
+must always expire), agents must be *told* about claims in a way they actually honor (prompt/tool
+surface), and resolution UX for genuine collisions needs care. Start with collision *detection*
+from the existing op log (pure visibility, zero risk), then add soft locks and ownership zones.

--- a/.ideas/043-policy-as-code-governance-engine.md
+++ b/.ideas/043-policy-as-code-governance-engine.md
@@ -1,0 +1,46 @@
+# 043 — Policy-as-Code Governance Engine
+
+## Suggestion
+
+Paperclip's governance is powerful but **scattered**: trust presets
+(`trust-preset-resolver.ts`), agent permissions (`agent-permissions.ts`), issue/workspace
+execution policy (`issue-execution-policy.ts`, `execution-workspace-policy.ts`,
+`execution-policy-bootstrap.ts`), execution allowlists (`execution-allowlist.ts`), and budget
+policies all enforce rules, each in its own silo with its own model. An operator who wants to
+express a simple company-wide rule — "no agent may spend over $50 on a single issue without human
+approval," "probation agents can't touch production workspaces," "no destructive actions on
+weekends," "any agent emailing a customer needs review" — has nowhere to write it. The rules
+exist in code and config fragments, not as something the operator can author, read, and audit in
+one place.
+
+Add a **policy-as-code engine**: a single declarative layer where operators define company
+governance rules as readable conditions → actions, evaluated consistently across the events the
+silos already guard.
+
+## How it could be achieved
+
+1. **Unified policy model.** A rule = `when <condition> then <effect>`, where conditions read
+   existing context (agent, trust stage, issue, workspace, spend, action type, time, target) and
+   effects are the actions the system already supports: allow, deny, require-approval, throttle,
+   notify, log. Store rules per company; version and audit them (idea 023).
+2. **One evaluation seam.** Introduce a policy-decision call at the existing enforcement choke
+   points (run admission, tool/command authorization, workspace access, spend checks) that
+   consults the rule set — rather than each silo hard-coding its own logic. The silos become
+   *enforcers* of a central *decision*.
+3. **Readable authoring.** A guided rule builder plus a text/DSL form (YAML-ish) so non-engineers
+   can express policy and engineers can diff it in git. Ship a starter library of common rules.
+4. **Dry-run & simulation.** Evaluate a proposed rule against recent history ("this would have
+   blocked 4 actions last week") before activating — reuses the Dry-Run philosophy (idea 004) and
+   prevents footguns where a rule silently freezes the company.
+5. **Explainable decisions.** Every allow/deny records *which rule* fired and why, surfaced in the
+   audit log (idea 023) and on the affected action, so governance is legible rather than magic.
+
+## Perceived complexity
+
+**Medium–High.** Individually the effects already exist; the hard part is the *unification* —
+introducing a clean policy-decision seam without destabilizing the several enforcement paths that
+currently work independently, and designing a condition/effect model expressive enough to be
+useful but bounded enough to stay safe and analyzable. Backward compatibility matters: existing
+trust presets and permissions should map onto the new engine as default rules, not be replaced
+wholesale. Start with an *advisory* evaluation that logs what it *would* decide alongside the
+current logic, validate it matches, then let it take over enforcement incrementally.

--- a/.ideas/044-agent-reliability-slos.md
+++ b/.ideas/044-agent-reliability-slos.md
@@ -1,0 +1,42 @@
+# 044 — Agent Reliability SLOs & Error Budgets
+
+## Suggestion
+
+Paperclip has solid machinery for *recovering* from broken runs — `run-liveness.ts`,
+`issue-liveness.ts`, `task-watchdogs.ts`, the recovery classifiers (`server/src/services/recovery/`),
+process recovery, scheduled retries. But it has no notion of an agent's **reliability over time**.
+An agent (or its adapter/runtime) that crashes 40% of the time, constantly needs recovery, or
+fails to complete runs is a chronic drain — yet nothing tracks that failure *rate*, sets an
+expectation for it, or escalates when an agent becomes unreliable. Diminishing-Returns (idea 003)
+catches *unproductive* runs and per-run caps (idea 024) catch *runaway* runs; neither catches an
+agent that is simply *flaky*. Operators only notice when they happen to look.
+
+Borrow SRE practice: give agents **reliability SLOs and error budgets** — track success/failure
+rates, define an acceptable threshold, and act when an agent burns through its error budget.
+
+## How it could be achieved
+
+1. **Reliability metrics per agent.** From data the recovery/liveness layer already produces,
+   compute rolling rates: run success vs failure, recovery invocations, crash/timeout frequency,
+   retries-to-completion. These are byproducts of mechanisms that already run.
+2. **Define SLOs + error budgets.** Per agent/role/tier: "≥90% of runs complete without
+   recovery." The error budget is the allowed failure share over a window; burning it fast is the
+   alert signal — standard SRE framing applied to agents.
+3. **Graduated response on burn.** Warn, then auto-constrain a chronically failing agent
+   (lower its concurrency, drop its trust stage — idea 009), then pause and escalate to a human
+   or its manager agent. A flaky agent shouldn't keep getting fed work and budget.
+4. **Diagnose the cause.** Correlate failures with adapter/model/environment so the operator can
+   tell "this *agent* is misconfigured" from "this *provider/runtime* is degraded" — the latter
+   pairs with provider fallback chains (idea 012) and quota windows.
+5. **Surface it.** A reliability column on agents and a fleet reliability view; feed the signal
+   into capability-based assignment (idea 025) so flaky agents get less critical work until they
+   recover.
+
+## Perceived complexity
+
+**Low–Medium.** The failure/recovery events already exist — this is largely a metrics/aggregation
++ thresholding + escalation layer over them, not new runtime. The design care is in defining
+"failure" precisely (a recovered run that still completed isn't the same as a lost one) and in
+windowing so a brief provider outage doesn't nuke an otherwise-good agent's budget. The auto-
+constrain ladder reuses existing levers (concurrency, trust stage, pause). High operator value
+for modest effort: it turns silent flakiness into a tracked, actionable signal.

--- a/.ideas/045-plugin-versioning-rollback-health.md
+++ b/.ideas/045-plugin-versioning-rollback-health.md
@@ -1,0 +1,44 @@
+# 045 — Plugin Versioning, Rollback & Health
+
+## Suggestion
+
+The plugin system is one of Paperclip's richest surfaces (adapters, skills, routines, host
+services, jobs, sandboxes), and the registry already tracks a plugin's `version` / `apiVersion`
+and supports updating the manifest "on upgrade" (`plugin-registry.ts`, `plugin-lifecycle.ts`).
+But the *operational* lifecycle is thin: there's no **pinning, rollback, or health monitoring**.
+A plugin upgrade that breaks an adapter or a host service can take down part of a running company,
+and the operator's only recourse is to manually fix forward — risky for a system meant to run
+autonomously 24/7, where a bad plugin update at 2am can silently wedge agents until morning.
+
+Add **operational plugin lifecycle management**: version pinning, safe upgrade with automatic
+rollback on failure, and continuous plugin health checks.
+
+## How it could be achieved
+
+1. **Version pinning & history.** Let operators pin a plugin to a known-good version and keep a
+   version history. The registry already stores `version`/`apiVersion`; add the prior-version
+   record and the ability to re-activate it.
+2. **Staged upgrade with health gate.** On upgrade, bring the new version up, run a health probe
+   (load, capability validation — `plugin-capability-validator.ts`, `plugin-manifest-validator.ts`
+   already exist — plus a smoke check), and only cut over if it passes. If it fails, **auto-roll
+   back** to the pinned version and raise an inbox alert.
+3. **Continuous health monitoring.** Watch running plugin workers/host services
+   (`plugin-worker-manager.ts`, `plugin-host-services.ts`) for crashes, error spikes, and
+   unresponsiveness; surface plugin status (healthy/degraded/failed) and auto-restart or disable a
+   plugin that's flapping — the plugin analog of agent reliability SLOs (idea 044).
+4. **Blast-radius containment.** A failing plugin should degrade only its own capability, not the
+   control plane — make health failures isolate the plugin (the sandbox/host-service boundary is
+   already there) and clearly mark dependent agents as affected.
+5. **`apiVersion` compatibility checks.** Block or warn on upgrades whose `apiVersion` is
+   incompatible with the host before they're allowed to activate, rather than discovering it at
+   runtime.
+
+## Perceived complexity
+
+**Medium.** Validation, lifecycle, and worker-management primitives already exist, so this is
+composing them into a managed upgrade/rollback/health flow plus a version-history store — not new
+foundations. The genuinely tricky parts are stateful plugins (a rollback must handle data/schema
+the new version may have migrated — overlaps with `plugin-database.ts`) and defining a meaningful
+per-plugin health check generic enough to apply across plugin types. Ship pinning + manual
+rollback + health status first; automatic staged upgrade/rollback is the higher-assurance next
+tier.

--- a/.ideas/046-skill-effectiveness-analytics.md
+++ b/.ideas/046-skill-effectiveness-analytics.md
@@ -1,0 +1,43 @@
+# 046 — Skill Effectiveness Analytics
+
+## Suggestion
+
+Paperclip has a skills layer — a catalog with role recommendations
+(`skills-catalog.ts` exposes `recommendedForRoles`) and per-company installs with usage tracking
+(`company-skills.ts` has `installCount`, `CompanySkillUsageAgent`, `installedHash`). So the system
+already knows *which* skills exist, who installed them, and roughly that they're used. What it
+**doesn't** know is whether a skill actually **helps**: does an agent equipped with a given skill
+produce better outcomes — higher approval rate, less rework, lower cost, faster completion — than
+without it? Skill selection today is based on static role hints and install counts (popularity),
+not evidence of impact. Operators add skills hopefully and prune them never.
+
+Add **skill effectiveness analytics**: link skill usage to work outcomes so operators (and
+auto-assignment) can tell which skills earn their keep and recommend skills based on *results*,
+not just role labels.
+
+## How it could be achieved
+
+1. **Attribute outcomes to skill usage.** Usage is already tracked per agent; join it to the
+   outcome signals that exist — approvals/rejections (`approvals.ts`), rework, cost/tokens
+   (`cost_events`), completion time. For runs where a skill was invoked, compare outcome
+   distributions vs comparable runs without it.
+2. **Effectiveness scorecard.** Per skill (optionally per role/work-type): usage frequency,
+   approval-rate delta, rework delta, cost delta. Surface "this skill correlates with +18% approval
+   on `code-review` tasks" — and the opposite, "installed, never meaningfully used."
+3. **Evidence-based recommendation.** Upgrade `recommendedForRoles` from static metadata to a
+   data-driven suggestion: recommend skills that demonstrably help agents doing similar work, and
+   flag installed-but-dead skills for pruning. Feeds capability-based assignment (idea 025).
+4. **Guard against false causation.** Correlation isn't proof; offer an optional controlled check
+   via the A/B bake-off harness (idea 032) — same tasks with/without the skill — for skills the
+   operator wants to validate rigorously.
+5. **Lifecycle hygiene.** Flag skills whose effectiveness drops after a version change, tying into
+   plugin health (idea 045) when the skill ships via a plugin.
+
+## Perceived complexity
+
+**Low–Medium.** Skill usage tracking and the outcome signals both already exist; this is primarily
+a join + analytics + presentation layer, with no execution-engine changes. The real subtlety is
+statistical honesty — small samples and confounds make naive "skill X → better outcomes" claims
+misleading — so the scorecard should show confidence/sample size and lean on the A/B harness for
+anything high-stakes. Ship descriptive analytics (usage × outcomes) first; evidence-based
+recommendation and causal validation are natural follow-ons.

--- a/.ideas/047-role-based-skill-auto-provisioning.md
+++ b/.ideas/047-role-based-skill-auto-provisioning.md
@@ -1,0 +1,46 @@
+# 047 — Role-Based Skill Auto-Provisioning
+
+## Suggestion
+
+Paperclip already has most of the wiring to connect roles to skills, but nothing closes the
+loop. Skills declare `recommendedForRoles` (`skills-catalog.ts`, `company-skill` validator), and
+the teams catalog declares `requiredSkills` per team (`CatalogTeamSkillRequirement`,
+`catalogTeamSkillRequirementSchema`). Yet skills are still **installed and assigned manually** —
+when an operator hires an engineer agent, nothing automatically equips it with the engineering
+skills its role implies, and nothing keeps that set in sync as role requirements evolve. The
+result: agents are under-equipped by default (you forgot to add the skill), inconsistently
+equipped across a team, and drift out of date when a role's required skills change.
+
+Add **role-based skill auto-provisioning**: define the skills a job/role requires once, and have
+Paperclip automatically equip (and update) agents based on the role they hold.
+
+## How it could be achieved
+
+1. **Role → skill bundles as the source of truth.** Promote the existing signals into an explicit
+   mapping: a role/job has a set of required + recommended skills, seeded from
+   `recommendedForRoles` and the teams catalog's `requiredSkills`. Operators edit the bundle, not
+   each agent.
+2. **Provision on hire / role change.** Hook the hire flow (`hire-hook.ts`) and any role-change
+   mutation: when an agent enters a role, auto-install its required skills into the company (if
+   absent) and bind them to the agent — reusing the existing `company-skills.ts` install path and
+   `installedHash` so it's idempotent.
+3. **Keep in sync (reconciler).** When a role bundle changes, reconcile every agent in that role —
+   add newly-required skills, flag now-removed ones — on a routine (`routines.ts`). Roles stay
+   authoritative; agents converge to them, like desired-state config.
+4. **Required vs recommended.** Required skills install automatically; recommended ones are
+   *suggested* to the operator (or the managing agent) rather than forced — preserving operator
+   control while removing the manual toil.
+5. **Respect governance.** Auto-provisioning honors trust stage (idea 009) and source trust
+   (`source-trust.ts`) — a probationary or low-trust agent might get a restricted bundle, and
+   untrusted skills still require approval before install.
+
+## Perceived complexity
+
+**Low–Medium.** The role-skill metadata, the install path, and the hire hook all already exist —
+this is mainly an explicit role→bundle model plus provisioning-on-hire and a reconciler, with no
+new execution machinery. The care points are idempotency (don't re-install or thrash on every
+heartbeat — `installedHash` helps), the desired-state reconcile semantics (what to do with skills
+an operator added manually that the bundle doesn't include — treat as additive, don't auto-
+remove), and keeping it auditable. Pairs naturally with skill effectiveness analytics (idea 046),
+which tells you *which* skills belong in a role's bundle in the first place, and is a building
+block for competency-gated job postings (idea 048).

--- a/.ideas/048-competency-gated-job-postings.md
+++ b/.ideas/048-competency-gated-job-postings.md
@@ -1,0 +1,51 @@
+# 048 — Competency-Gated Job Postings (Test-to-Hire)
+
+## Suggestion
+
+Hiring in Paperclip today is **immediate and unverified**: an operator creates an agent, gives it
+a role, and it starts working — there's no concept of an open *position* with requirements, and no
+check that the agent can actually do the job before it's handed real work and budget. There's no
+job-posting / vacancy / requisition primitive in the codebase at all (the `hire-hook.ts` flow is
+manual agent creation; the JOB-POST/HIRING-REQUEST patterns some operators use are conventions
+bolted on top). Meanwhile the catalog already knows how to express what a role *needs*
+(teams-catalog `requiredSkills` / `CatalogTeamSkillRequirement`), and the repo ships an eval
+harness (`evals/promptfoo/`) that can *test* whether an agent meets a bar.
+
+Combine them into a real hiring pipeline: a **job posting** is a first-class open position that
+declares required skills and an acceptance test, and it **stays open until a candidate agent
+proves it can do the work** — test-to-hire, not hire-and-hope.
+
+## How it could be achieved
+
+1. **Job posting as a first-class object.** A posting = `{ role, requiredSkills, acceptanceTest,
+   budget, reportsTo, status: open|filled }`. Required skills reuse the teams-catalog
+   `requiredSkills` model; the acceptance test is an eval suite (idea 011) encoding "can this
+   agent actually do this job?"
+2. **Postings sit in a queue.** An open posting is visible, unfilled work-to-staff. It can be
+   filled two ways: (a) an **existing** agent applies/is nominated, or (b) a **new** candidate
+   agent is created to attempt it (reusing the create-agent flow).
+3. **Gate on a competency test.** Before a candidate gets the job, run the posting's acceptance
+   test against the candidate's config in a side-effect-free mode (the `planOnly`/shadow path from
+   ideas 004/032). Only a passing candidate is hired into the role — the eval *is* the interview.
+4. **Skill-readiness gating.** A posting can require skills the candidate must hold first; pair
+   with auto-provisioning (idea 047) so a near-fit agent gets equipped with the missing skills,
+   then re-tested. A posting genuinely "sits until an agent is skilled enough to fulfill it."
+5. **Hire on pass, with probation.** A passing candidate is hired but enters at probation
+   (idea 009) — the test proves baseline competence; the trust ramp proves sustained performance.
+   Every attempt (pass/fail, score, cost) is logged to the audit trail (idea 023) as a hiring
+   record.
+6. **Re-posting & backfill.** If an agent is removed or fails reliability SLOs (idea 044), its
+   role can auto-reopen as a posting, so the org self-heals its staffing instead of silently
+   running short-handed.
+
+## Perceived complexity
+
+**Medium–High.** This introduces a **new domain object** (the job posting) and a hiring state
+machine — open → candidate(s) → tested → hired/rejected → filled — which is more than a thin layer
+over existing services. But the hard sub-parts already exist: required-skill declaration
+(teams-catalog), the testing mechanism (eval harness + shadow execution), and probationary
+onboarding (idea 009). The real design work is the posting/candidate/test lifecycle, a fair and
+side-effect-free competency test (shares the `planOnly` guarantees of ideas 004/032), and the UX
+of an operator-or-agent-driven hiring queue. Ship the posting object + manual "test this candidate
+against this posting" first; auto-backfill and skill-readiness re-testing are powerful follow-ons
+that make staffing genuinely autonomous.

--- a/.ideas/049-shared-credential-fair-share-rate-limiting.md
+++ b/.ideas/049-shared-credential-fair-share-rate-limiting.md
@@ -1,0 +1,43 @@
+# 049 — Shared Credential Pooling & Fair-Share Rate Limiting
+
+## Suggestion
+
+In real deployments, many agents share **one** provider credential — a single Anthropic API key,
+one OpenAI org, one Claude subscription. That shared key has a finite rate limit (RPM/TPM) and,
+for subscriptions, a shared usage window. Paperclip *observes* provider quota
+(`quota-windows.ts`) but a code scan finds **no notion of pooling a shared credential or
+fair-sharing its capacity across agents**. So when ten agents back the same key, they stampede it:
+the noisiest agents starve the rest, everyone hits 429s at once, and a single low-priority agent
+can consume the whole window the CEO agent needed. Per-agent run concurrency (idea 001) doesn't
+help — four runs each making rapid calls on one shared key still blow its rate limit.
+
+Add **shared-credential pooling with fair-share rate limiting**: model a credential as a pooled
+resource with a known capacity, and meter agents' access to it fairly by priority/weight.
+
+## How it could be achieved
+
+1. **Model the pool.** Group agents that resolve the same underlying credential
+   (`agent-secret-bindings.ts`, `secrets.ts`) into a pool with a configured capacity (RPM/TPM, or
+   the provider window from `quota-windows.ts`).
+2. **Fair-share scheduler.** Put a token-bucket / weighted-fair-queue in front of the pool: each
+   agent gets a share of the credential's capacity by weight (role/priority/trust), so no single
+   agent monopolizes it and critical agents get guaranteed headroom. This is the credential-level
+   sibling of the run-level Fleet Governor (idea 001).
+3. **Backpressure, not failure.** When the pool is saturated, *queue* an agent's next call (or
+   defer its heartbeat — idea 035) instead of letting it 429, and prefer the provider-fallback
+   chain (idea 012) — including a local model (idea 008) — for low-priority work when the shared
+   key is hot.
+4. **Reserve capacity.** Let operators reserve a slice of a shared key for critical roles ("CEO +
+   on-call agents always get 20%"), so a marketing batch can't crowd out strategic work.
+5. **Visibility.** Show per-credential utilization and which agents are consuming it — the missing
+   answer to "why is everything rate-limited right now?"
+
+## Perceived complexity
+
+**Medium.** Credential resolution and quota observation already exist; the new core is the pool
+model plus a fair-share/token-bucket gate in the call path, which is well-understood but must be
+correct under concurrency (no double-spend of capacity, graceful when the provider's real limit
+differs from the configured one). The subtle part is estimating per-call cost *before* the call to
+budget the bucket (token counts are only known after) — approximate up front and reconcile after.
+Strong synergy with ideas 001 (run concurrency), 012 (fallback), 019 (token budgets), and 035
+(heartbeat backoff): together they govern load at the run, credential, and provider layers.

--- a/.ideas/050-work-product-security-scanning.md
+++ b/.ideas/050-work-product-security-scanning.md
@@ -1,0 +1,42 @@
+# 050 — Code & Dependency Security Scanning of Work Products
+
+## Suggestion
+
+When code-writing agents produce work products, Paperclip captures them
+(`issue_work_products`, `work-products.ts`) and routes them through review/approval
+(`approvals.ts`). But nothing inspects that code for **security problems** before it's accepted:
+vulnerable dependencies (known CVEs), hardcoded insecure patterns (SQL string-building, disabled
+TLS verification, `eval` of untrusted input), risky license additions, or dependencies pulled from
+untrusted sources. Autonomous agents add packages and write code at machine speed; a human
+reviewer eyeballing a diff (idea 017) will not catch a transitive CVE or a subtly insecure
+pattern. This is the supply-chain/secure-code blind spot that complements the *exfiltration*
+controls already proposed (secret-leak scanning idea 020, egress allow-listing idea 022).
+
+Add **automated security scanning of code work products**: scan agent-produced code and its
+dependencies for vulnerabilities and insecure patterns at the review gate, and block/flag based on
+severity.
+
+## How it could be achieved
+
+1. **Hook the review gate.** When a code work product is submitted for approval, run scanners over
+   the changeset (`workspace-operations.ts` already logs the files touched; idea 017 assembles the
+   diff).
+2. **Dependency vulnerability scan.** Detect added/changed manifests (package.json, requirements,
+   go.mod, etc.) and check dependencies against a vulnerability database (e.g. OSV) for known CVEs
+   and disallowed licenses. New transitive risk is the most common and least visible failure.
+3. **Static pattern checks.** Run lightweight SAST-style rules for high-signal insecure patterns,
+   reusing existing redaction/secret machinery (idea 020) for the "hardcoded credential" subset.
+4. **Severity-graded gate.** Per company policy (and expressible in the policy engine, idea 043):
+   critical findings *block* approval, mediums *flag* and require explicit human override (logged
+   to the audit trail, idea 023), lows are advisory. Feeds the approval risk score (idea 016).
+5. **Feed it back to the agent.** Return findings to the producing agent so it can fix and
+   resubmit autonomously — turning the scan into a correction loop, not just a gate.
+
+## Perceived complexity
+
+**Medium.** The integration points (work products, the diff, the approval gate) exist; the work is
+wiring in scanners and a severity policy. Dependency CVE scanning via an offline/online vuln DB is
+well-trodden and high-value-first; static pattern analysis is broader and noisier and should ship
+behind tuned, high-confidence rules to avoid review fatigue. The main caveats are keeping the vuln
+database current and being language/ecosystem-aware (the value is uneven across stacks) — scope it
+to the languages a company actually produces, and treat it as best-effort elsewhere.

--- a/.ideas/051-disaster-recovery-backup-verification.md
+++ b/.ideas/051-disaster-recovery-backup-verification.md
@@ -1,0 +1,43 @@
+# 051 — Disaster Recovery: Backup Verification & Restore Drills
+
+## Suggestion
+
+Paperclip can take instance database backups (`routes/instance-database-backups.ts`), but a code
+scan finds **no verification, restore-testing, or DR posture** around them — no checksum/integrity
+check, no automated restore drill, no RPO/RTO concept. An untested backup is a hope, not a
+guarantee: the classic ops failure is discovering at the worst possible moment that backups were
+corrupt, incomplete, or never actually restorable. For a system that is the **system-of-record for
+autonomous companies** — holding org structure, financials, work history, and audit trails — a
+silently-broken backup means losing the entire operating state of one or many businesses.
+
+Add **backup verification and restore drills**: continuously prove that backups exist, are intact,
+and can actually be restored, and give operators a clear recovery posture.
+
+## How it could be achieved
+
+1. **Integrity on write.** When a backup is created, record a checksum/size/row-count manifest and
+   verify the artifact in the storage layer (`server/src/storage/`) immediately after upload —
+   catch truncated/corrupt backups at creation, not at recovery.
+2. **Automated restore drills.** On a routine (`routines.ts`), restore the latest backup into an
+   ephemeral throwaway database (the dev PGlite path or a temp PG instance) and run smoke checks
+   (schema present, key tables non-empty, referential sanity). A backup that fails a drill raises a
+   high-severity alert — this is the single highest-value piece.
+3. **Recovery posture surface.** Show operators the facts that matter: last successful backup, last
+   *verified-restorable* backup, effective RPO (data-loss window) and a measured RTO (how long the
+   last drill took to restore). Replace "we have backups" with "we can recover to within N minutes,
+   proven M hours ago."
+4. **Policy & retention.** Configurable backup frequency and retention, integrated with data-
+   retention governance (idea 034), plus optional off-instance/off-site copy via the storage
+   provider abstraction (S3) for true disaster isolation.
+5. **One-button guided restore.** A documented, guided restore flow (with confirmation + Drain,
+   idea 014) so recovery isn't an improvised, error-prone scramble under pressure.
+
+## Perceived complexity
+
+**Medium.** Backup creation and a storage abstraction already exist, so integrity manifests are a
+small add. The substantive work is the **automated restore drill** — standing up a throwaway DB,
+restoring into it, and smoke-testing — which is the part that turns backups from theoretical to
+trustworthy and is worth doing first. Cross-engine nuance (PGlite dev vs real Postgres prod) and
+making drills cheap enough to run regularly are the main practical hurdles. Distinct from company
+point-in-time rewind (idea 015), which is a *logical* per-company undo; this is *infrastructure*
+DR for the whole instance.

--- a/.ideas/052-org-restructuring-simulator.md
+++ b/.ideas/052-org-restructuring-simulator.md
@@ -1,0 +1,40 @@
+# 052 — Org Restructuring Simulator
+
+## Suggestion
+
+A company's org structure — who reports to whom — drives routing, escalation, approval paths, and
+boundary/assignability decisions (`agent-assignability.ts`, the org chart rendered by
+`org-chart-svg.ts`). But reorganizing it is a **blind, manual, risky** edit: an operator moves an
+agent under a new manager or dissolves a team with no preview of the consequences. In an autonomous
+company those consequences are real and immediate — escalation paths reroute, in-flight approvals
+land on a different person, an agent's assignable scope changes, work mid-flight may be orphaned.
+There's no way to see "what will this reorg actually do?" before committing it.
+
+Add an **org restructuring simulator**: model a proposed reorg, preview its impact, and apply it
+safely (or roll it back).
+
+## How it could be achieved
+
+1. **Edit a draft, not the live org.** Let the operator build a proposed structure (move agents,
+   change reporting lines, add/dissolve teams) against a draft copy rather than mutating production.
+2. **Impact preview.** Compute and show the diff of consequences from data that already exists:
+   reassignments implied, approvals that would reroute, escalation chains that change, agents whose
+   assignable scope (`agent-assignability.ts`) widens/narrows, and any in-flight work that would be
+   orphaned or cross a new boundary. Visualize old vs new on the org-chart renderer.
+3. **Warnings.** Flag risky outcomes — an agent left with no manager, a team with no members, a
+   reviewer removed from a path with pending approvals, a span-of-control blowout — before apply.
+4. **Atomic, audited apply.** Commit the reorg as a single transaction (auto-Drain first, idea 014,
+   so it doesn't race live runs), logged to the audit trail (idea 023), with a one-click revert to
+   the prior structure (reuses the snapshot idea from company rewind, idea 015).
+5. **Compose with staffing.** Pair with job postings (idea 048) and reliability SLOs (idea 044):
+   a reorg that leaves a role unstaffed can auto-open a posting; restructuring becomes part of the
+   self-organizing loop.
+
+## Perceived complexity
+
+**Medium.** The org data, the assignability logic, and the chart renderer all exist, so the
+simulator is largely a draft model + an impact-diff computation + visualization — read-heavy, not
+new core machinery. The harder parts are enumerating *all* the consequence types accurately (a
+missed one undermines trust in the preview) and the atomic apply/rollback semantics around live
+work. Ship the draft + impact preview first (pure insight, zero risk), then the safe atomic apply
+and revert.

--- a/.ideas/053-inter-company-shared-services.md
+++ b/.ideas/053-inter-company-shared-services.md
@@ -1,0 +1,47 @@
+# 053 — Inter-Company Shared Services (Agent Lending)
+
+## Suggestion
+
+One Paperclip instance runs many companies, but they're hard-isolated — cross-company access is
+explicitly denied (`authorization.ts`, `agent-assignability.ts`'s `ancestor_cross_company`,
+`trust-preset-resolver.ts`'s `cross_company_boundary`). That isolation is correct as a default, but
+it forces real waste: every company must build or hire its **own** specialists. If you run five
+companies, you stand up five legal reviewers, five designers, five security auditors — duplicated
+cost, duplicated config, inconsistent quality. Human conglomerates solve this with **shared
+services**: a central function (Legal, Design, IT) that subsidiaries draw on. Paperclip has no
+peer-to-peer equivalent.
+
+Add **inter-company shared services**: let a company expose specific agents as services that
+*other* companies in the same instance can request work from, through a governed, audited bridge —
+without dissolving the per-company isolation.
+
+## How it could be achieved
+
+1. **Publish a service, not full access.** A company marks an agent (or role) as an offered
+   *service* with a defined interface: what it does, what it costs (charged back to the requesting
+   company), and what inputs it accepts. This is narrow and explicit — not general cross-company
+   visibility.
+2. **Governed request bridge.** A requesting company files a *service request* (a scoped, typed
+   task) to the providing agent. Reuse the same controlled cross-company capability proposed for
+   the Holding Company (idea 007) — a deliberate, audited seam rather than a weakening of
+   `authorization.ts`. The provider sees only the request payload, never the requester's internals.
+3. **Chargeback.** Work done by a shared service is costed to the *requesting* company's budget
+   (ideas 002/019/030), so shared functions are economically honest — the using company pays, the
+   providing company isn't silently subsidizing it.
+4. **Boundaries preserved.** No shared agent gets standing access to a requester's workspace,
+   secrets, or task tree; everything flows through the typed request/response, scanned for leaks
+   (idea 020) on the way out. Every cross-company interaction is logged to the tamper-evident audit
+   trail (idea 023).
+5. **Discovery.** A shared-services directory at the instance level so a company can find "who
+   offers legal review?" — capability matching (idea 025) applied across the company boundary.
+
+## Perceived complexity
+
+**High.** Like the Holding Company (idea 007), this deliberately pierces a security boundary the
+system was built to enforce, so the governed cross-company bridge is the hard, safety-critical core
+— it must be impossible for a service request to escalate into general access, and chargeback +
+audit must be airtight. The service-interface model and directory are moderate; the isolation
+guarantees are where the real work and review go. Best sequenced after (or alongside) idea 007,
+since both need the same governed cross-company seam — build that seam once and use it for both
+hierarchical oversight (007) and peer service-sharing (053). Ship read-only discovery + manual
+single-request flows first; standing service relationships are a later tier.

--- a/.ideas/054-company-mailbox.md
+++ b/.ideas/054-company-mailbox.md
@@ -1,0 +1,58 @@
+# 054 — Company Mailbox (Inter-Company Inbox / Outbox & Tickets)
+
+## Suggestion
+
+Companies in one Paperclip instance are hard-isolated (`authorization.ts` denies cross-company
+access; `agent-assignability.ts` / `trust-preset-resolver.ts` enforce the boundary), and a code
+scan confirms there is **no inter-company communication primitive** at all — the existing
+`inbox-dismissals` is *operator* notifications, not company-to-company. So today, two companies in
+the same instance literally cannot talk: they can't share a document, hand off a deliverable, or
+ask each other for help, even when the operator wants exactly that.
+
+Add a **company mailbox**: a per-company **inbox** and **outbox** that lets companies exchange
+structured messages across the boundary — share documents, send **tickets** (trackable service
+requests), and pass directives — through one governed, audited channel that preserves isolation by
+making the mailbox the *only* cross-company door.
+
+This is the transport layer the earlier cross-company ideas implicitly need: holding-company
+directives (idea 007) and shared-services requests (idea 053) become **message types on the
+mailbox** rather than separate bespoke bridges.
+
+## How it could be achieved
+
+1. **Mailbox model.** Each company gets an inbox and outbox of **message envelopes**:
+   `{ from, to, type, subject, body, attachments[], status, threadId, createdAt }`. Message
+   `type` covers `document_share`, `service_request` (ticket), `directive`, `status_update`, and
+   `general_message` — one extensible envelope instead of many one-off integrations.
+2. **The mailbox *is* the governed bridge.** Reuse the controlled cross-company seam proposed for
+   ideas 007/053 so the mailbox is the single audited crossing point. A sender sees only what the
+   recipient's mailbox accepts; neither company gets standing access to the other's workspace,
+   secrets, or task tree. Every message is logged to the tamper-evident audit trail (idea 023).
+3. **Tickets that become work.** A `service_request` is a stateful ticket
+   (`open → acknowledged → in_progress → responded → closed`). On acceptance, the receiving company
+   can convert it into a real issue in its own goal tree — reuse `issue-references.ts` to link the
+   ticket to the resulting issue so both sides track the same work, and chargeback its cost to the
+   *requesting* company (ideas 030/049) so shared work is economically honest.
+4. **Document sharing.** A `document_share` transfers a document (a snapshot copy by default, or a
+   read-only shared reference) via the storage layer. Outbound messages and attachments are
+   run through the secret/PII leak scanners (ideas 020/034) before they leave — sending across the
+   boundary is a publish event and treated as one.
+5. **Human governance + visibility.** Operators see each company's in/outbox, can require approval
+   for outbound messages (idea 016 triage applies), and set per-company policy for who may message
+   whom (expressible in the policy engine, idea 043). A delivery receipt / read state closes the
+   loop, and unanswered tickets escalate via SLA like other stuck work (idea 010/038).
+6. **Addressing & discovery.** Companies address each other by id/handle; pair with the shared-
+   services directory (idea 053) so a company can discover *who* to message for a given need, and
+   with capability matching (idea 025) applied across the boundary.
+
+## Perceived complexity
+
+**Medium–High.** The mailbox introduces a **new domain object** plus a ticket state machine, and
+it rides the same security-critical cross-company bridge as ideas 007/053 — that governed seam
+(no escalation into general access, airtight audit, leak-scanned egress) is the hard part and
+should be designed once and shared across all three. The envelope/threading model, inbox/outbox UI,
+and ticket→issue conversion (via existing `issue-references`) are moderate. Strong sequencing
+value: build the mailbox first as the *transport*, then express holding directives (007) and
+service requests (053) as message types on it, rather than building three bridges. Ship intra-
+instance, operator-approved document shares and manual tickets first; automated ticket→issue
+conversion, chargeback, and SLA escalation are natural follow-ons.

--- a/.ideas/055-estimate-vs-actual-calibration.md
+++ b/.ideas/055-estimate-vs-actual-calibration.md
@@ -1,0 +1,40 @@
+# 055 — Estimate-vs-Actual Calibration
+
+## Suggestion
+
+Paperclip tracks what work *actually* cost (`cost_events`, run timing) but a code scan finds **no
+estimate** on issues at all — no expected cost, effort, or duration. So there's no way to ask the
+question every operations team lives on: *did this take what we thought it would?* Without
+estimates and a comparison to actuals, agents (and operators) can't improve their forecasting, the
+Dry-Run Estimator (idea 004) and budgets have no per-issue expectation to anchor to, and a task
+that quietly costs 5× its mental budget looks identical to one that came in on plan.
+
+Add **estimates on work, plus estimate-vs-actual calibration**: capture an expected cost/effort
+when work is created, compare it to the real outcome, and learn per-agent/per-work-type forecasting
+accuracy over time.
+
+## How it could be achieved
+
+1. **Add an estimate to issues.** A lightweight expected-cost / expected-effort field, set by the
+   creating agent or operator when work is defined (the planning skills already reason about
+   estimates — this persists them on the issue). Optional, so nothing breaks if absent.
+2. **Capture the actual.** On completion, the real cost (`cost_events`) and elapsed time are
+   already known — record them alongside the estimate to form an estimate/actual pair.
+3. **Calibration score.** Per agent (and per work-type/role), compute forecast accuracy — mean
+   ratio of actual/estimate, bias (chronically over- or under-estimating), and variance. "Eng-bot
+   underestimates by ~40% on refactors" is directly actionable.
+4. **Feed it forward.** Use calibration to auto-adjust future estimates (apply the agent's known
+   bias), to flag in-flight work trending far past its estimate (early-warning, complements the
+   Diminishing-Returns detector idea 003 and per-run caps idea 024), and to improve the Dry-Run
+   Estimator's projections (idea 004).
+5. **Surface it.** A calibration view per agent and a "biggest estimate misses this week" list —
+   the misses are where scoping or capability problems hide.
+
+## Perceived complexity
+
+**Low–Medium.** Actuals already exist; the additions are an estimate field, the paired record, and
+an analytics/calibration layer — no execution-engine changes. The real work is behavioral and
+statistical: getting agents to produce *meaningful* estimates (a garbage estimate calibrates
+nothing), and handling small samples / high variance honestly so calibration guides rather than
+misleads. Ship estimate capture + the simple actual/estimate comparison first; bias-correction and
+auto-adjustment are natural follow-ons once enough pairs accumulate.

--- a/.ideas/056-business-experiment-framework.md
+++ b/.ideas/056-business-experiment-framework.md
@@ -1,0 +1,46 @@
+# 056 — Business Experiment Framework
+
+## Suggestion
+
+Paperclip's whole purpose is autonomous companies that *grow a business* — and growing a business
+is fundamentally about running experiments: try a price, a landing-page headline, an ad creative,
+a feature; measure; keep what works. But Paperclip has no structured way to run one. Agents do
+ad-hoc work and (with revenue tracking, idea 030) you might see the aggregate needle move, but
+there's no primitive for a **hypothesis → variants → metric → decision** loop. So an autonomous
+company can't reason about *why* a number changed, can't run two variants cleanly, and can't
+accumulate validated learnings — it just acts and hopes. (Note this is distinct from the A/B
+*model* bake-off, idea 032, which compares LLMs; this experiments on the **business itself**.)
+
+Add a **business experiment framework**: a first-class object for running controlled experiments on
+the company's real-world work, with hypotheses, variants, success metrics, and recorded outcomes.
+
+## How it could be achieved
+
+1. **Experiment object.** `{ hypothesis, variants[], primaryMetric, guardrailMetrics[],
+   duration/sampleTarget, status, result }`. Variants are concrete pieces of work (two ad sets, two
+   pricing pages) executed by agents as normal issues, tagged to the experiment.
+2. **Tie metrics to real data.** The primary metric draws on revenue/outcome data (idea 030) and
+   unit economics (idea 013) — signups, conversion, MRR delta — so an experiment is evaluated
+   against actual business results, not vibes. Guardrail metrics (cost, churn) catch variants that
+   win locally but harm globally.
+3. **Decision + learning ledger.** At the end, record the result and the *decision* (ship variant
+   B, kill both, iterate), and append a durable "validated learning" to a company learnings log.
+   Over time this becomes the company's accumulated playbook — the thing that makes it smarter run
+   over run.
+4. **Agent-runnable.** A growth/marketing agent can *propose* experiments (governed by approval,
+   idea 016), launch the variant work, monitor metrics, and call the result — closing the loop
+   autonomously while the operator keeps oversight.
+5. **Goal alignment.** Experiments hang off the goal tree (`goals.ts`) so every experiment traces
+   to the company mission, and the experiment ledger feeds the operator digest (idea 029) and
+   stakeholder page (idea 033): "ran 3 experiments, 1 winner, +6% conversion."
+
+## Perceived complexity
+
+**Medium.** Mechanically the experiment object, variant tagging, and metric wiring are moderate —
+but this idea is **gated on real outcome/revenue data** (idea 030), without which experiments can't
+be scored, so it sequences after that. The genuinely hard parts are statistical rigor (attribution,
+sample size, avoiding false wins on tiny data) and clean variant isolation in a messy real-world
+business where you can't always randomize. Start with simple sequential experiments and explicit
+operator-called results; add proper significance testing and concurrent variants as the data
+volume justifies it. High strategic value: it turns "agents doing stuff" into "a company that
+learns."

--- a/.ideas/057-incident-management-on-call.md
+++ b/.ideas/057-incident-management-on-call.md
@@ -1,0 +1,46 @@
+# 057 — Incident Management & On-Call
+
+## Suggestion
+
+When something goes wrong in a company's *operations* — a production service the company runs goes
+down, a customer reports a critical bug, a security alert fires, a payment integration breaks —
+Paperclip has no way to handle it as an **incident**. The only "incident" concept in the codebase
+is narrow and internal: budget incidents in `budgets.ts` (`createIncidentIfNeeded`). There's no
+severity, no on-call routing, no runbook, no postmortem. For an autonomous company that runs real
+services 24/7, the absence of incident response is glaring: urgent problems land in the normal
+issue queue with no special routing or urgency, and there's no guarantee anyone (agent or human) is
+designated to respond *now*.
+
+Add **incident management with on-call routing**: a first-class incident type with severity,
+fast-path routing to a designated responder, runbooks, and postmortems — generalizing the existing
+budget-incident notion into real operational incident response.
+
+## How it could be achieved
+
+1. **Incident object.** `{ severity (SEV1–4), source, status, responder, timeline,
+   relatedIssues[] }`. Incidents can be raised by agents, humans, monitors, or *automatically* by
+   existing signals — budget hard-stops (idea 002), reliability-SLO burn (idea 044), security
+   alerts (ideas 020/050), deadlocks (idea 010). Generalizes `budgets.ts` incidents into one model.
+2. **On-call routing.** Per company/team, an on-call assignment (an agent, a human, or an
+   escalation chain over the org chart) that high-severity incidents page *immediately* — bypassing
+   normal heartbeat cadence (idea 035) and concurrency queues (idea 001) so response isn't gated by
+   ordinary scheduling. Pairs with mobile push (idea 027) for the human case and approval coverage
+   (idea 038) for after-hours.
+3. **Runbooks.** Attach runbook docs/skills to incident types so a responding agent has a defined
+   procedure (reuses skills + documents), rather than improvising under pressure.
+4. **Severity-driven behavior.** A SEV1 can auto-trigger Drain/Emergency-Stop (idea 014) on the
+   affected scope and pull in additional responders; lower severities follow normal flow with
+   priority. Severity sets the urgency contract.
+5. **Postmortems + learning.** On resolution, capture a structured postmortem (timeline, root
+   cause, follow-ups as issues) into the company learnings ledger (shared with idea 056), so the
+   company gets more reliable over time instead of repeating failures.
+
+## Perceived complexity
+
+**Medium.** A precedent exists to generalize (budget incidents), and the trigger signals, org
+chart, notifications, and emergency controls are all already present or proposed — so this is
+largely a new incident object + severity model + on-call routing wired to existing signals and
+actions. The harder parts are the *fast path* (genuinely bypassing normal scheduling so urgent
+response isn't throttled) and a clean on-call/escalation model that works for mixed agent+human
+responders. Ship manual incident raise + severity + on-call routing first; auto-raising from
+existing signals and auto-Drain on SEV1 are high-value follow-ons.

--- a/.ideas/058-work-templates-definition-of-done.md
+++ b/.ideas/058-work-templates-definition-of-done.md
@@ -1,0 +1,42 @@
+# 058 — Work Templates & Definition-of-Done
+
+## Suggestion
+
+Every issue in Paperclip is free-form. There's no concept of a **work type** with a reusable
+template — a code scan finds no issue templates, acceptance-criteria scaffolds, or
+definition-of-done (DoD) structure on issues. So agents create and complete work to inconsistent
+standards: one "ship a feature" issue includes tests and docs, another doesn't; one bug report has
+repro steps, another is a sentence. Reviewers (idea 016/017) have no consistent bar to check
+against, and an agent has no checklist telling it when work is *actually* done versus
+superficially finished. Consistency and completeness are exactly what scales poorly when the
+workforce is autonomous and tireless.
+
+Add **work templates with definition-of-done**: reusable templates per work type that scaffold an
+issue's structure, required fields, acceptance criteria, and a DoD checklist agents must satisfy
+before work is considered complete.
+
+## How it could be achieved
+
+1. **Template model.** Per company, named work types (`feature`, `bug`, `content`, `research`,
+   `outreach`) each defining: a description scaffold, required fields/inputs, acceptance criteria,
+   and a DoD checklist. Operators author them once; agents instantiate them.
+2. **Instantiate on creation.** When an agent/operator creates an issue of a type, pre-fill it from
+   the template so every issue of that type starts complete and consistent — and the creating agent
+   knows exactly what's expected.
+3. **DoD gate at review.** The DoD checklist becomes the concrete bar the review/approval gate
+   (`approvals.ts`, idea 016) checks against, and that work-product security/scan gates (idea 050)
+   and change-review (idea 017) attach to. "Done" stops being subjective.
+4. **Agent-legible.** Inject the template's acceptance criteria + DoD into the working agent's run
+   context so it self-checks before submitting, reducing rework (which calibration, idea 055, and
+   unit economics, idea 013, will show dropping).
+5. **Library + sharing.** Ship sensible default templates and let them travel with company
+   blueprints (idea 018) / exports, so good standards are reusable across companies.
+
+## Perceived complexity
+
+**Low–Medium.** This is primarily a template data model, instantiation-on-create, and wiring the
+DoD into the existing review gate — no new execution machinery. The effort is in designing a
+template structure that's expressive without being bureaucratic, and in making the DoD checks
+*meaningful* (a checklist agents rubber-stamp is worse than none — ideally some items are
+machine-verifiable, e.g. "tests present," tying to idea 050). Ship templates + pre-fill first;
+DoD-gated review is the higher-value second step that makes quality consistent.

--- a/.ideas/059-goal-decomposition-quality-assistant.md
+++ b/.ideas/059-goal-decomposition-quality-assistant.md
@@ -1,0 +1,42 @@
+# 059 — Goal Decomposition Quality Assistant
+
+## Suggestion
+
+Paperclip's core invariant is that work decomposes from the company goal down through a tree of
+sub-tasks (`goals.ts`, parent/sub-issues). But the *quality* of that decomposition is left entirely
+to agents, and bad decomposition is a silent, upstream cause of waste: a goal broken into chunks
+that are too coarse (an agent "owns" something far too big to execute), too fine (death by a
+thousand trivial sub-issues), overlapping (two branches doing the same thing), or *incomplete*
+(a goal whose children don't actually add up to achieving it). The Goal-Drift Auditor (idea 026)
+checks whether existing work still *traces* to a goal; nothing checks whether a goal was *broken
+down well in the first place*. A flawed plan executed flawlessly still fails.
+
+Add a **decomposition quality assistant**: analyze a goal's breakdown for structural problems and
+help agents/operators produce well-formed task trees before execution pours money into a bad plan.
+
+## How it could be achieved
+
+1. **Structural checks (cheap, deterministic).** Over the goal/issue tree: flag leaf tasks that are
+   suspiciously large (by estimate, idea 055, or scope), branches far deeper/shallower than siblings,
+   single-child chains (pointless nesting), and goals with no children (undecomposed). Pure graph
+   analysis over existing data.
+2. **Completeness check (semantic tier).** Use a cheap model (local, idea 008) to judge "do these
+   sub-tasks, if all completed, plausibly achieve the parent?" and surface likely *gaps* — the
+   missing workstream nobody scoped. This is the highest-value and hardest check.
+3. **Overlap detection.** Flag sibling/cross-branch tasks that look redundant (semantic similarity),
+   catching two agents about to build the same thing — complements workspace conflict coordination
+   (idea 042) at the planning layer rather than the file layer.
+4. **Assistive, at plan time.** Run when a goal is decomposed (or a big issue is broken down) and
+   offer suggestions — split this, merge those, you're missing X — so the plan improves *before*
+   execution, when fixing it is nearly free. Pairs with the Dry-Run Estimator (idea 004).
+5. **Score + trend.** A decomposition-quality score per goal, tracked over time, so operators can
+   see whether their company plans well and improving — feeding the operator digest (idea 029).
+
+## Perceived complexity
+
+**Medium.** The structural checks are a straightforward tree analysis over existing data and deliver
+immediate value. The semantic tiers — completeness and overlap — are more involved: they need
+careful, cheap prompting and tuning to avoid noisy or wrong "you're missing something" flags that
+erode trust, and they're inherently judgment calls. No execution-engine changes; it's an analyzer +
+assistive suggestions. Ship the deterministic structural checks first (cheap, high-signal), then
+layer in the semantic completeness/overlap analysis behind confidence thresholds.

--- a/.ideas/060-knowledge-system.md
+++ b/.ideas/060-knowledge-system.md
@@ -1,0 +1,113 @@
+# 060 — Knowledge System (Built-In Accumulation, Curation & Retrieval)
+
+> Consolidates three earlier ideas into one coherent system: the **engine** that accumulates and
+> curates knowledge, the **authority model** that makes some of it canonical and scoped, and the
+> **retrieval layer** that lets agents and humans find it by meaning.
+
+## Suggestion
+
+An agent is only as good as what it can reliably reference, yet Paperclip has no first-class,
+always-present knowledge layer. The pieces exist but are scattered and optional:
+
+- A capable knowledge **engine** already exists — but as a plugin. `plugin-llm-wiki` ships a
+  `wiki-maintainer` agent, ingest/query/lint/maintain skills, wiki **spaces** with migrations,
+  managed maintenance/ingest routines, and an ingestion security gate
+  (`doc/plans/2026-05-06-llm-wiki-paperclip-asset-security-gate.md`). `doc/SPEC.md:513` deliberately
+  keeps it out of core: *"Not a knowledge base — core has no wiki/docs/vector-DB (plugin territory)."*
+- **Documents** exist but are scoped to `companyId` only — no team or org/instance scope, no
+  "canonical/authoritative" designation, and no path to inject them into an agent's run context. The
+  managed instruction-bundle system (`agent-instructions.ts`) has no knowledge hook.
+- **Search** is keyword-only — `company-search.ts` with GIN trigram indexes (`gin_trgm_ops`) on
+  issues/docs/comments. No semantic/vector retrieval, so agents can't find related-but-differently-
+  worded prior work and re-solve solved problems.
+
+Make knowledge a **first-class, default-on capability** with three layers: an **engine** that
+accumulates and curates, an **authority model** of scoped canonical docs, and a **semantic
+retrieval** layer — one durable, curated source of truth shared by agents and humans.
+
+## The architecture (and the thin-core tension, addressed)
+
+Paperclip's philosophy is "thin core, rich edges," and `SPEC.md` deliberately puts the wiki in
+plugin territory. The resolution is **not** to dump a vector DB into the control plane, nor to leave
+knowledge optional — it's a **contract-in-core + default-bundled provider** split (the same
+batteries-included pattern Paperclip already uses for adapters):
+
+- **Core owns the contract:** a knowledge capability — capture → curate → store → retrieve →
+  serve-to-agent-context — that always exists and that *other core features may depend on*.
+- **The LLM-wiki engine becomes the default first-party provider** of that contract: bundled and
+  enabled by default, with the plugin seam preserved so advanced operators can swap implementations.
+
+This keeps core thin (an interface, not a database) while guaranteeing every company has knowledge
+from day one.
+
+## Layer 1 — Engine: accumulation & curation
+
+1. **Default-bundle the engine.** Ship `plugin-llm-wiki` (or its successor) as a built-in, enabled-
+   by-default capability — no install step. Keep its proven pieces: spaces, the `wiki-maintainer`
+   agent, and the ingest/query/lint/maintain skills.
+2. **A curation lifecycle, not a dumping ground.** Formalize capture → **lint/curate** →
+   canonicalize → serve. Promote `wiki-lint` into a real curation gate so knowledge stays
+   trustworthy (rot is every wiki's failure mode). The `wiki-maintainer` agent runs curation +
+   pruning on managed routines.
+3. **Autoresearch maintenance.** A scheduled research/librarian agent keeps living docs current —
+   refresh market/competitor briefs, fold in accumulated **learnings** from experiments (idea 056),
+   postmortems (idea 057), and calibration (idea 055), and flag stale/contradicted pages. Updates
+   land as revisions **proposed by autoresearch, ratified by a human or manager agent** (review via
+   idea 016), so canon stays trustworthy rather than silently rewritten.
+
+## Layer 2 — Authority: scoped, canonical SOPs & specs
+
+4. **Three scope tiers + inheritance.** Extend documents beyond `companyId` to support **org/
+   instance** and **team** scope. An agent's effective knowledge = union of *org* + *company* +
+   *team* docs, with the more specific tier overriding the general (team beats company beats org).
+5. **Canonical designation + versioning.** Let a doc be marked **canonical** (authoritative, pinned,
+   "always reference this"), distinct from ordinary working docs. Reuse existing `document_revisions`
+   for history and `document-annotations` threads for review.
+6. **Auto-inject into agent context.** Wire the resolved canonical set into the managed instruction-
+   bundle system so relevant SOPs/specs are present in every agent's run context by scope and role —
+   kept cache-friendly (stable prefix, idea 037) since this content is stable by design. Relevance-
+   scope the injected set by role/team so agents aren't drowned in docs.
+
+## Layer 3 — Retrieval: semantic search
+
+7. **Embed content.** Generate embeddings for issues, comments, documents, and work products on
+   create/update, run on a **local model** (idea 008) so indexing is free and private.
+8. **Vector store in Postgres (pgvector).** Keep the single-datastore simplicity Paperclip relies on
+   (PGlite in dev) rather than adding a separate search service.
+9. **Hybrid retrieval.** Combine semantic similarity with the existing trigram/keyword search
+   (`company-search.ts`) so exact matches still win when they should and semantic recall fills the
+   rest. Extend the search service, don't replace it.
+10. **Agent-facing retrieval tool.** Expose semantic search as a tool agents call ("has this been
+    done before? what do we know about X?") — turning company history into retrievable memory and
+    the backbone for shift-handoff briefings (idea 028).
+
+## Cross-cutting: shared, secure, portable
+
+- **Shared by agents and humans** through one surface — agents ingest learnings and cite pages;
+  humans browse, edit, ratify. One curated source of truth, not parallel knowledge.
+- **Security gate into core.** Built-in ingestion = built-in attack surface: carry the existing
+  ingestion security gate plus leak/PII scanning (ideas 020/034) as part of the core contract.
+- **Citeable & legible.** Reference docs/pages by stable id (`issue-references.ts`-style) so work can
+  cite the SOP/spec it followed — useful for audit (idea 023) and DoD/spec-conformance checks
+  (ideas 017/058).
+- **Portable.** Knowledge travels with company blueprints/exports (idea 018,
+  `company-portability.ts`), so an exported company carries its institutional knowledge, and shared
+  org SOPs propagate to every company in the instance.
+
+## Perceived complexity
+
+**Medium–High** as a whole, but cleanly phased — and most pieces already exist, so it's largely
+*promotion + interface design + integration* rather than greenfield.
+
+1. **Static three-tier canonical docs + context injection** (Layer 2) — *Medium*. Highest immediate
+   value, lowest risk; ship first.
+2. **Semantic retrieval** (Layer 3) — *Medium*. pgvector + local embeddings + hybrid ranking; main
+   risks are index freshness/cost and ranking quality.
+3. **Promote the engine to core + autoresearch curation** (Layer 1) — *Medium–High*. The hard part is
+   the **architectural decision and migration**: defining the core knowledge contract without
+   bloating the thin control plane, consciously amending the `SPEC.md` "plugin territory" stance, and
+   migrating existing plugin installs/spaces data safely (release notes show wiki packaging/migrations
+   are delicate).
+
+Done well, these three layers are one stack — *what's authoritative* (Layer 2), *how it's found*
+(Layer 3), and *the engine that accumulates and curates it* (Layer 1) — not three competing plugins.

--- a/.ideas/061-wip-limits-flow-control.md
+++ b/.ideas/061-wip-limits-flow-control.md
@@ -1,0 +1,44 @@
+# 061 — WIP Limits & Flow Control
+
+## Suggestion
+
+Paperclip can limit **compute** concurrency (per-agent `maxConcurrentRuns`, the proposed Fleet
+Governor idea 001, per-run caps idea 024), but it has no concept of **work-in-progress (WIP)
+limits** — a cap on how many issues are *actively in progress* at once per agent, team, or
+workflow stage. A code scan finds no WIP/flow-limit notion anywhere. These are different levers:
+concurrency governs how much *machine* runs at once; WIP governs how much *work* is open at once.
+Without WIP limits, autonomous agents start far more than they finish — dozens of half-done
+issues, constant context-switching, ballooning cycle time, and a board that looks busy while
+little actually ships. WIP limits are the core flow-control discipline of every kanban system,
+and they're missing.
+
+Add **WIP limits**: configurable caps on in-progress work per agent / team / stage, with "stop
+starting, start finishing" enforcement so the company optimizes for *throughput*, not *activity*.
+
+## How it could be achieved
+
+1. **Limits per scope.** Configurable max in-progress issues per agent, per team, and per workflow
+   stage (status column). Issues already carry status, so "how many are in progress for X" is a
+   direct count.
+2. **Enforce at pull, not push.** When an agent would pick up new work but is at its WIP limit,
+   block the *start* and steer it to finish (or unblock) existing work instead — surfaced as a soft
+   signal to the agent, and factored into the admission/assignment path (ideas 001, 025) so blocked
+   work isn't handed to a maxed-out agent.
+3. **Flow metrics.** With WIP bounded, compute the flow numbers that actually matter — cycle time,
+   throughput, and flow efficiency (active vs waiting time) — surfaced per agent/team. These are the
+   leading indicators the Org Bottleneck Heatmap (idea 006) and operator digest (idea 029) want.
+4. **Detect WIP thrash.** Flag agents/teams chronically at their limit (under-capacity) or starting
+   far more than finishing (a "start/finish ratio" alarm) — a different signal than the
+   Diminishing-Returns detector (idea 003), aimed at *flow* rather than *productivity per issue*.
+5. **Operator tuning.** Sensible defaults with per-company override; let operators experiment with
+   tighter limits and watch cycle time respond (pairs with the experiment framework, idea 056).
+
+## Perceived complexity
+
+**Low–Medium.** Issue status and counts already exist, so the core — counting in-progress work per
+scope and gating starts against a limit — is small and has no new execution machinery. The flow
+metrics are straightforward aggregations. The subtle parts are behavioral: making the "stop
+starting" steer feel natural to autonomous agents (they must understand *why* they're being asked
+to finish rather than start), and choosing default limits that improve flow without starving a
+genuinely parallel team. Ship per-agent WIP limits + flow metrics first; team/stage limits and the
+start/finish alarms follow.

--- a/.ideas/062-inbound-intake-channels.md
+++ b/.ideas/062-inbound-intake-channels.md
@@ -1,0 +1,43 @@
+# 062 — Inbound Intake Channels (Email / Webhook → Issue)
+
+## Suggestion
+
+A real company receives work from the **outside**: customer support emails, sales leads, bug
+reports, form submissions, partner requests. Paperclip can *emit* events (outbound webhooks, idea
+036) and agents can *call out*, but there's no first-class way for the outside world to **create
+work inside a company**. A code scan finds no inbound intake — no email-to-issue, no public intake
+webhook, no support-request channel. So an autonomous customer-support or sales company has no
+front door: a human has to manually transcribe every external request into an issue, which defeats
+the point of autonomy.
+
+Add **inbound intake channels**: addresses/endpoints that turn external messages — email, webhook,
+form — into issues in a company's queue, routed and triaged automatically.
+
+## How it could be achieved
+
+1. **Intake endpoints per company.** A unique intake email address and/or a public webhook/form
+   endpoint per company (or per team). Inbound messages become issues in that company's queue. The
+   HTTP plumbing for inbound requests already exists (the http adapter handles inbound agent
+   webhooks); this is a new inbound *intake* surface.
+2. **Map message → issue.** Parse subject/body/attachments into a structured issue, applying a work
+   template (idea 058) for the intake type (support, lead, bug) so intake is consistent and complete.
+3. **Auto-triage on arrival.** Run capability-based assignment (idea 025) and approval/risk triage
+   (idea 016) so an inbound request is routed to the right agent and prioritized — not just dumped
+   in a backlog. A support email can be picked up and worked autonomously within seconds.
+4. **Threading & two-way.** Link replies to the originating thread (reuse `issue-references.ts` /
+   issue threads) so an external conversation maps to one issue, and pair with outbound (idea 036)
+   for responses — closing the loop into genuine two-way external comms (and feeding the mailbox
+   model, idea 054, for the intra-instance case).
+5. **Abuse protection.** Rate-limit and spam-filter intake (the company-search rate-limit pattern
+   and `private-hostname-guard` are precedents), and gate auto-actions on untrusted inbound through
+   source trust (`source-trust.ts`) so a public endpoint can't be weaponized.
+
+## Perceived complexity
+
+**Medium.** Issue creation, threading, routing, and inbound HTTP handling all already exist, so the
+core is the intake surface (email ingestion and/or a public webhook/form endpoint) plus
+message→issue mapping. Email ingestion is the fiddliest piece (an inbound mail provider/parser,
+threading, attachments) and is best delivered via the plugin system; a webhook/form intake is a
+smaller first slice. The real care is **security**: a public front door must be rate-limited, spam-
+filtered, and trust-gated, and inbound content must be leak/PII-scanned (ideas 020/034) before it
+drives any autonomous action. Ship webhook/form intake first, then email.

--- a/.ideas/063-cost-capacity-forecasting.md
+++ b/.ideas/063-cost-capacity-forecasting.md
@@ -1,0 +1,43 @@
+# 063 — Cost & Capacity Forecasting
+
+## Suggestion
+
+Paperclip tracks spend well and (with the proposed predictive breaker, idea 002) can throttle when
+burn threatens a budget in the next minutes/hours. But there's no **forward-looking forecast** over
+the horizon operators actually plan on — days, weeks, the runway to a goal's deadline. The breaker
+answers "am I about to blow today's budget?"; it doesn't answer "at this trajectory, when do I run
+out of money / hit the $1M MRR goal / need to add capacity?" Without that, operators of autonomous
+companies — which can sustain spend 24/7 — can't plan: they can't see runway, can't anticipate when
+a budget needs raising, and can't tell if the current org will reach the goal on time.
+
+Add **cost & capacity forecasting**: project future spend, token usage, and goal progress from
+historical trends, and surface runway, projected goal-attainment dates, and capacity needs.
+
+## How it could be achieved
+
+1. **Trend models over existing data.** Fit simple trend/rolling projections to historical
+   `cost_events`, token usage (idea 019), throughput (idea 061 flow metrics), and — once revenue
+   exists (idea 030) — income. Start with transparent methods (moving averages, linear/seasonal
+   trend); sophistication can come later.
+2. **Runway & attainment.** Combine projected burn with remaining budget/revenue for **runway**
+   ("~6 weeks at current trajectory"), and combine throughput with remaining goal scope for a
+   **projected goal-attainment date** ("on pace to hit the milestone ~2 weeks late").
+3. **Capacity planning.** Answer the staffing question: "to hit the goal by date D, you need ~N more
+   agents of type T / ~$X more budget." Feeds job postings (idea 048) and reorg (idea 052) with a
+   data-driven *why*.
+4. **Scenario knobs.** Let operators run what-ifs — add two agents, double the budget, switch a
+   role to a local model (idea 008) — and see the forecast shift, turning forecasting into planning.
+5. **Surface proactively.** Put runway and attainment on the dashboard, in the operator digest (idea
+   029), and (for a Holding Company, idea 007) at the portfolio level for capital allocation —
+   forecasts are most useful pushed to the operator, not waited-for.
+
+## Perceived complexity
+
+**Medium.** The historical data all exists; basic trend forecasting and runway math are
+straightforward and immediately useful. The harder parts are forecasting *quality* (autonomous
+workloads are bursty and non-stationary, so naive extrapolation misleads — show confidence bands and
+keep methods honest) and capacity modeling (translating "need more throughput" into "N agents of
+type T" requires the calibration and unit-economics data from ideas 055/013). Explicitly distinct
+from the predictive breaker (idea 002), which is short-horizon and reactive; this is long-horizon and
+planning-oriented. Ship spend forecast + runway first; goal-attainment and capacity planning build on
+the throughput/calibration signals as they mature.

--- a/.ideas/064-data-import-migration.md
+++ b/.ideas/064-data-import-migration.md
@@ -1,0 +1,44 @@
+# 064 — Data Import / Migration from Existing Tools
+
+## Suggestion
+
+Paperclip can import/export its **own** company format (`company-portability.ts`), but a code scan
+finds no way to bring in work from the tools teams already use — Jira, Linear, Asana, Trello,
+GitHub Issues, or a plain CSV. For anyone evaluating Paperclip, this is a hard adoption wall: their
+existing backlog, projects, and history live elsewhere, and "start from an empty board and
+re-create everything by hand" is a non-starter. The fastest path to value for a new user is to see
+*their own work* running in Paperclip on day one.
+
+Add **data import/migration**: map issues/projects/structure from common PM tools (and generic CSV)
+into Paperclip companies, so teams can onboard their real backlog instead of starting cold.
+
+## How it could be achieved
+
+1. **Importers per source.** A small adapter per tool (Jira, Linear, Asana, GitHub Issues, Trello,
+   CSV) that pulls issues, statuses, hierarchy, assignees, and comments via the source's API/export.
+   Best delivered through the **plugin system** so importers can ship and evolve independently of
+   core.
+2. **Map to Paperclip's model.** Translate source concepts into Paperclip's: issues → issues,
+   epics/parents → parent issues (preserving the goal-tree invariant), statuses → Paperclip
+   statuses, human assignees → a placeholder/agent mapping the operator confirms. Reuse the
+   portability deserialization path (`company-portability.ts`) as the write target so import lands
+   through one validated seam.
+3. **Assignee/agent mapping.** Since Paperclip employees are agents, imported human assignees map to
+   either a "needs staffing" marker (which can auto-open a job posting, idea 048) or a chosen agent —
+   an explicit step in the import wizard.
+4. **Dry-run + preview.** Show what *will* be created (counts, hierarchy, any unmapped fields) before
+   committing — reuse the Dry-Run philosophy (idea 004) so a big import isn't a blind, irreversible
+   dump. Make the import atomic and reversible (snapshot first, idea 015).
+5. **Incremental sync (later).** Optional ongoing one-way sync for teams migrating gradually, so
+   Paperclip can run alongside an existing tool during a transition rather than requiring a hard
+   cutover.
+
+## Perceived complexity
+
+**Medium.** The write target (validated company deserialization) already exists, so the work is
+per-source extraction + field mapping + an import wizard, not new core machinery. Each importer is
+moderate and independent (ship the highest-demand source first; CSV is the cheapest universal
+fallback). The genuinely tricky parts are faithful hierarchy/status mapping across tools with
+different models, the human→agent assignee gap (unique to Paperclip), and idempotent re-import.
+One-time import is very achievable; incremental two-way sync is a much larger, later undertaking and
+should be scoped as one-way to start.

--- a/.ideas/065-software-building-and-self-hosting.md
+++ b/.ideas/065-software-building-and-self-hosting.md
@@ -1,0 +1,140 @@
+# 065 — Software-Building Capability & Self-Hosting (Paperclip Builds Paperclip)
+
+## Suggestion
+
+Paperclip's canonical pitch is an autonomous company that ships a real product ("note-taking app to
+$1M MRR"), yet **software engineering is not a first-class capability** — agents produce free-form work
+products and there's no built-in engineering loop (repo, branch, tests, CI, PR review, release) that
+turns a goal tree into shipped, verified code. The pieces are scattered: execution workspaces
+(`execution-workspaces.ts`, `workspace-operations.ts`), work products (`work-products.ts`), an eval
+harness (`evals/promptfoo/`), and engineering *skills* that already exist as conventions
+(`devon` the software-engineer skill, `pm-tdd` red→green→refactor→review gates, `qa-engineer`). What's
+missing is welding them into a real **software-building capability**.
+
+Then take it to its natural conclusion: **let Paperclip build itself.** A Paperclip company whose
+codebase *is* Paperclip, consuming its own `.ideas/` backlog as the goal tree — pick an idea, implement
+it test-first, gate it on the eval harness + tests + security scan, open a reviewable diff, ship on
+human ratification. The product improves the product, and every shipped improvement makes the builder
+more capable: a governed dogfood flywheel.
+
+## Why this is the right bet now (grounded research, June 2026)
+
+- **Runtime self-evolution works.** *Live-SWE-agent* autonomously evolves its own scaffold while solving
+  real problems and hits **77.4% on SWE-bench Verified**, beating the best proprietary agents — evidence
+  that agents improving the software they run on is no longer speculative.
+- **But naive self-improvement is brittle.** Self-modifying approaches like the *Darwin-Gödel Machine*
+  "typically require costly offline training on specific benchmarks and may not generalize." → The safe,
+  durable angle is **self-improvement as a governed *org process*** (an org of agents + budgets +
+  approvals + eval gates + audit), not a single self-rewriting scaffold or weight-level training. Process
+  generalizes and is auditable; weight surgery does not and is not.
+- **Long-horizon software evolution is now a measured discipline** (SWE-EVO, async-agent strategies),
+  which is exactly Paperclip's shape: many async, heartbeat-driven agents evolving a codebase over time
+  — not a single synchronous coding session.
+
+## How it could be achieved
+
+### Part A — Software-building as a first-class capability
+1. **A versioned engineering workspace.** Promote execution workspaces into git-backed project
+   workspaces (branch per issue, commit on work-product accept), reusing `workspace-operations.ts` as the
+   operation log and the run change-review surface (idea 017) as the PR-style diff.
+2. **A real build/test loop.** Standard agent tools for `run tests`, `lint`, `build`; capture results as
+   structured run signals (feeds per-run caps 024, reliability SLOs 044). The `pm-tdd` gates
+   (red→green→refactor→review) become the issue lifecycle for engineering work.
+3. **CI-for-the-work, not just the agent.** At the review gate, run tests + the eval/governance suite
+   (idea 011) + dependency/SAST security scan (idea 050); critical failures block, others flag — code is
+   "done" only when gates pass + a human/QA agent approves.
+4. **An engineering org blueprint** (idea 018): PM → Architect → Devs → QA → DevOps, with the right
+   skills auto-provisioned per role (idea 047) and capability-based assignment (idea 025) routing tasks.
+
+### Part B — Self-hosting ("Paperclip builds Paperclip")
+5. **The backlog *is* the goal tree.** Point a Paperclip company at the Paperclip repo with `.ideas/`
+   (and `combinations/`) as its decomposed goals — this very folder becomes the work queue.
+6. **TDD by construction, governed.** Each idea flows devon→qa-engineer through `pm-tdd`; the existing
+   eval harness (`evals/promptfoo/`) plus the repo's own tests are the acceptance bar. No self-modifying
+   magic — just the normal governed pipeline, pointed at itself.
+7. **Self-improvement guardrails (the critical part).** Changes to Paperclip's *own* control-plane,
+   governance, or safety surfaces require human ratification and an eval-gated deploy (idea 011) — a
+   compromised or confused self-builder must not be able to weaken the very guardrails that contain it.
+   Every self-modification is audited in the tamper-evident log (idea 023) and is revertible (point-in-
+   time/DR, ideas 015/051). Trust currency (cross-cut 04) bounds what the self-builder agents may touch.
+8. **The flywheel, closed.** Shipped improvements (e.g. a better diff surface, the local-LLM adapter)
+   make the next build cheaper/better; the operator-owned dataset (idea 040) + calibration (055) learn
+   which approaches ship cleanly — self-improvement as the closed loop of cross-cut 02, applied to
+   Paperclip's own source.
+
+### Part C — The doable path: scale down to a kernel, then bootstrap up (recommended)
+
+Building Part A in full *before* self-hosting is a large up-front bet. The far more achievable path is a
+**capability bootstrap**: hand-build the smallest possible self-builder, then let it add capabilities to
+*itself*, one verified feature at a time. Each shipped feature makes the builder more capable, so the
+*next* feature is cheaper to build — a compounding ratchet rather than a big-bang.
+
+1. **The kernel (hand-built, deliberately tiny).** The minimum that can land one verified change:
+   **one dev agent + a git-backed workspace + a `run_tests` tool + a human approve/merge gate + revert.**
+   No org chart, no budgets engine, no fancy review UI. If it can make a one-line fix, run the tests,
+   and get a human to merge it, the kernel is done.
+2. **Bootstrap by leverage — build the rungs of your own ladder.** Have the kernel build, test, and ship
+   the features that most *reduce the cost or risk of building the next feature*, in order:
+   - **structured test/build result capture** → the builder can now judge its own work programmatically;
+   - **change-review diff surface (idea 017)** → human review gets faster, throughput rises;
+   - **a QA/reviewer agent + the red→green→refactor→review lifecycle (`pm-tdd`)** → quality rises, human
+     review burden falls;
+   - **eval + governance gating (idea 011)** → it can now safely touch more sensitive code;
+   - **capability-based assignment + a 2nd specialist (idea 025)** → it's a small org; work parallelizes;
+   - **security scan (050), per-run caps (024), reliability tracking (044)** → safety & economics;
+   - **the engineering-org blueprint (018) + more roles** → Part A is now fully *grown*, not pre-built.
+3. **Autonomy grows with capability, earned not granted.** The kernel starts at minimum autonomy
+   (Autonomy Dial cross-cut 01 at Level 0–1: every change human-reviewed). As it ships the capabilities
+   that *create* trust signals — tests, QA, eval gates — the trust currency (cross-cut 04) and the dial
+   loosen automatically. Capability and freedom ratchet up *together*, so the system is never more
+   autonomous than its own proven ability to verify itself.
+4. **Each rung is independently shippable and revertible**, so the whole program de-risks into a series
+   of small, tested, human-ratified merges — and stops safely at any rung if a step regresses. Only after
+   the ladder is built does the self-builder approach its own governance/runtime code, still under the
+   mandatory-ratification guardrail (Part B step 7).
+
+The elegance: the ordered self-build sequence above *is* a slice of this very backlog, so the bootstrap
+literally consumes `.ideas/` to assemble the machine that consumes `.ideas/`.
+
+### Part D — Give it a memory (the Code-Knowledge Flywheel)
+
+Pair this with the Knowledge System (idea 060): as the company builds, the llm-wiki accumulates a curated
+**snippet/pattern library** (reuse), an **architecture graph** of the codebase (hybrid vector + call/
+dependency graph, so agents understand what calls what), and **canonical specs/conventions** injected
+into build context. Agents retrieve from all three *before* writing code — so new code fits existing
+patterns and prior solutions aren't re-derived — and the curator writes new learnings back after each
+accepted change. For self-hosting this is close to essential: every rung the bootstrap (Part C) ships is
+indexed into the system's model of *itself*, so the ratchet **compounds** — it builds an ever-better map
+of its own architecture as it grows. Detailed in
+`combinations/cross-cutting/xcombo-code-knowledge-flywheel.md`.
+
+## Why it matters strategically
+
+This is the strongest possible proof of the product: *Paperclip demonstrably ships real, reviewed,
+tested software — including its own features.* It converts the entire `.ideas/` backlog from a wishlist
+into executable work, makes Paperclip the reference customer for its own software-building capability,
+and establishes a defensible, *governed* path to self-improvement that the self-modifying-scaffold
+research warns is otherwise brittle. It also unlocks Paperclip as a genuine software-agency platform for
+everyone else, not just a business-ops orchestrator.
+
+## Perceived complexity
+
+**High** — but unusually *de-risked* because almost every prerequisite already exists as code or skills
+(workspaces, work products, eval harness, change-review, security-scan plan, and the devon/pm-tdd/
+qa-engineer skills). The real work is (a) the git-backed workspace + build/test/CI loop welded into the
+issue lifecycle, and (b) the **self-hosting safety surface** — guaranteeing the self-builder cannot
+weaken its own guardrails, with mandatory human ratification on safety-critical diffs, full audit, and
+reliable revert. **The phasing that makes it tractable is Part C**: instead of building all of Part A
+up front, hand-build the tiny kernel and let it bootstrap its own capabilities one verified, revertible
+feature at a time, with autonomy ratcheting up only as fast as its proven ability to verify itself.
+Under that approach the *initial* lift is small (a single dev agent + git workspace + test runner +
+human gate); the system grows the rest. Keep governance/runtime code behind mandatory human ratification
+until the ladder is fully built and trusted.
+
+## Sources
+
+- [Live-SWE-agent: Can Software Engineering Agents Self-Evolve on the Fly?](https://arxiv.org/html/2511.13646v3)
+- [SWE-EVO: Benchmarking Coding Agents in Long-Horizon Software Evolution](https://arxiv.org/pdf/2512.18470)
+- [Effective Strategies for Asynchronous Software Engineering Agents](https://arxiv.org/pdf/2603.21489)
+- [SWE-agent (Princeton) overview, 2026](https://www.solosoft.dev/post/swe-agent-software-engineering-2026/)
+- [Agentic AI Benchmarks 2026 — CodeSOTA](https://www.codesota.com/agentic)

--- a/.ideas/066-chat-bot-channel-telegram-whatsapp.md
+++ b/.ideas/066-chat-bot-channel-telegram-whatsapp.md
@@ -1,0 +1,74 @@
+# 066 — Built-In Chat Channel (Telegram Bot / WhatsApp) for On-the-Go Operation
+
+## Suggestion
+
+Paperclip's headline promise is managing autonomous companies **"from your phone,"** but the mobile
+surface is thin — a shrunk dashboard, no notifications, and no way to *act* away from your desk (idea 027
+proposes web push; idea 029 a digest). The lowest-friction on-the-go surface isn't a custom app or even a
+PWA — it's a **messaging bot the operator already has open all day.** Add a **built-in chat channel** —
+a **Telegram bot** and/or **WhatsApp** integration — that is a genuinely *two-way* link to a company:
+it pushes what needs the human (approvals, budget incidents, the morning digest, SEV1 alerts) and accepts
+replies, commands, and **inline approve/reject taps** straight back into the control plane.
+
+Unlike notifications, this closes the loop: a 24/7 company that stalls on a human approval every evening
+(combo 05's core problem) can be unblocked from a phone in two taps, anywhere — no app install, no VPN, no
+login.
+
+## How it could be achieved
+
+1. **Channel as a plugin (best fit).** Implement as a Paperclip plugin (host-service + webhook), so the
+   bot transport ships and evolves independently of core — mirroring how intake/outbound are best done as
+   plugins (ideas 062/036). Two channel adapters behind one interface: **Telegram** first (simplest), then
+   **WhatsApp** (ubiquitous, more constrained — see grounding).
+2. **Reuse the signals that already exist.** Subscribe the bot to the same events feeding web push (idea
+   027) and the digest (idea 029): approvals awaiting the operator, budget warn/hard-stop (`budgets.ts`),
+   emergency stop (idea 014), chronic fallbacks/leaks (012/020), SEV1 incidents (057). Gate on the existing
+   approval **risk score** (idea 016) so only high-signal events ping the phone — notification fatigue would
+   kill this.
+3. **Two-way: inline actions → structured decisions (the A2H pattern).** Render approvals as messages with
+   inline buttons (Approve / Reject / Request changes) and the run change-review summary (idea 017) inline.
+   A tap or reply is normalized back into a structured approval the control plane ingests — exactly the
+   **Agent-to-Human (A2H) protocol** ("translate a button click 'Approve' into a structured decision the
+   agent can ingest"). Also support a small **command grammar** ("status", "pause marketing-co", "digest
+   now", "approve PAP-142") routed through the existing API.
+4. **Security is the crux — bind chat identity to a Paperclip user.** A chat account must be explicitly
+   linked to an authorized user (one-time code / deep link), so only that bound identity can approve;
+   per-user delivery prefs (multi-user is a shipped roadmap item). Treat inbound chat as untrusted input:
+   rate-limit, verify webhook signatures, never let an unbound/ spoofed message take a governed action, and
+   audit every chat-originated decision (idea 023). High-risk actions can still require a second factor or
+   fall back to the full UI.
+5. **Channel-specific rules (from grounding).** **Telegram Bot API**: no template approvals, no formal
+   opt-in, no time-window limits, rich inline keyboards — ideal for a self-hosted ops bot; ship first.
+   **WhatsApp Business API**: users must opt in, messages outside a 24-hour window require *pre-approved
+   templates* — so design digest/alert **templates** and an opt-in flow; richer reach, more setup.
+6. **Symmetry with intake (idea 062).** The same bot is also an **inbound intake** surface — a forwarded
+   customer message or a quick "file a bug: …" becomes an issue — making chat both the operator console
+   *and* a front door (composes with the Front Desk, xcombo-09).
+
+## Why it matters
+
+This is what actually delivers the "from your phone" pitch, and uniquely as a **two-way** channel: every
+other notification idea (027/029) is one-directional, while a chat bot lets the human *decide* on the go,
+not just be informed. It's the highest-reach, lowest-friction operator surface (everyone has Telegram/
+WhatsApp open; nobody installs another app), and it's the natural delivery layer for the whole review
+cockpit (combo 05) and the Conversational Operator cut (xcombo-12) — and a clean bridge for an
+Aisha-style chief front end (see `PAPERCLIP_INTEGRATION.md`).
+
+## Perceived complexity
+
+**Medium.** Telegram alone is **Low–Medium** — a well-documented Bot API, inline keyboards, webhook
+delivery; most of the work is the signal subscription (reuse 027/029), the A2H action-normalization, and
+the identity-binding/audit security. WhatsApp is **Medium–High** due to the Business API's opt-in,
+template-approval, and 24-hour-window rules, so it's a fast-follow, not the first slice. The genuine
+risk is **security**: a phone-based approval channel is an attack surface, so identity binding, signature
+verification, rate-limiting, and full audit of chat-originated decisions must be airtight before any
+*write* action is allowed — ship read-only (alerts + digest + status) first, then inline approvals, then
+broader commands. Best delivered as a plugin so the transport stays out of core.
+
+## Sources
+
+- [Telegram Bot API — core.telegram.org](https://core.telegram.org/bots/api)
+- [Telegram vs WhatsApp for an AI Agent (opt-in/template/window differences) — Hermify](https://www.hermify.io/en/blog/telegram-vs-whatsapp-for-ai-agent)
+- [A2H: Agent-to-Human Protocol for AI Agents — arXiv 2602.15831](https://arxiv.org/pdf/2602.15831)
+- [AgentClick: Skill-Based Human-in-the-Loop Review Layer for Terminal AI Agents — arXiv 2604.16520](https://arxiv.org/html/2604.16520v1)
+- [Toward Safe and Responsible AI Agents: Transparency, Accountability, Trustworthiness — arXiv 2601.06223](https://arxiv.org/pdf/2601.06223)

--- a/.ideas/README.md
+++ b/.ideas/README.md
@@ -1,0 +1,89 @@
+# Paperclip Improvement Ideas
+
+A running log of original suggestions to improve Paperclip, generated from reviews of the
+codebase. Each idea is its own markdown file with three sections:
+
+- **Suggestion** — what to build and why it matters
+- **How it could be achieved** — concrete implementation path, grounded in the current code
+- **Perceived complexity** — rough effort/risk estimate
+
+## Index
+
+| # | Idea | Complexity |
+|---|------|-----------|
+| 001 | [Fleet Concurrency Governor](001-fleet-concurrency-governor.md) | Medium–High |
+| 002 | [Predictive Budget Circuit Breaker](002-predictive-budget-circuit-breaker.md) | Medium |
+| 003 | [Diminishing-Returns Detector](003-diminishing-returns-detector.md) | Medium |
+| 004 | [Company Dry-Run Estimator](004-company-dry-run-estimator.md) | Medium–High |
+| 005 | [Spend-Schedule / Quiet Hours Profiles](005-spend-schedule-quiet-hours.md) | Low–Medium |
+| 006 | [Org Bottleneck Heatmap](006-org-bottleneck-heatmap.md) | Low–Medium |
+| 007 | [Holding Company (Meta-Orchestration)](007-holding-company-meta-orchestration.md) | High |
+| 008 | [First-Class Local LLM Adapter](008-local-llm-adapter.md) | Low–Medium |
+| 009 | [Agent Probation & Staged Trust Ramp](009-agent-probation-trust-ramp.md) | Medium |
+| 010 | [Blocker-Graph Deadlock Detector](010-blocker-graph-deadlock-detector.md) | Medium |
+| 011 | [Eval-Gated Agent Config Deploys](011-eval-gated-agent-config-deploys.md) | Medium |
+| 012 | [Quota-Aware Provider Fallback Chains](012-provider-fallback-chains.md) | Medium |
+| 013 | [Unit-Economics Dashboard](013-unit-economics-dashboard.md) | Low–Medium |
+| 014 | [Emergency Stop & Drain Mode](014-emergency-stop-drain-mode.md) | Low–Medium |
+| 015 | [Company Point-in-Time Rewind](015-company-point-in-time-rewind.md) | Medium–High |
+| 016 | [Approval Triage & Policy Batching](016-approval-triage-policy-batching.md) | Medium |
+| 017 | [Run Change-Review Surface](017-run-change-review-surface.md) | Medium |
+| 018 | [Company Blueprint Library](018-company-blueprint-library.md) | Medium |
+| 019 | [Token Budgets for Subscription Users](019-token-budgets-for-subscription-users.md) | Low–Medium |
+| 020 | [Outbound Secret-Leak Scanning](020-outbound-secret-leak-scanning.md) | Medium |
+| 021 | [Just-in-Time Secret Leasing](021-just-in-time-secret-leasing.md) | Medium |
+| 022 | [Per-Agent Network Egress Allow-Listing](022-per-agent-network-egress-allowlist.md) | Medium–High |
+| 023 | [Tamper-Evident Audit Log](023-tamper-evident-audit-log.md) | Low–Medium |
+| 024 | [Per-Run Resource Caps](024-per-run-resource-caps.md) | Medium |
+| 025 | [Capability-Based Auto-Assignment](025-capability-based-auto-assignment.md) | Medium |
+| 026 | [Goal-Drift Alignment Auditor](026-goal-drift-alignment-auditor.md) | Medium |
+| 027 | [Mobile Push & Fast Approvals](027-mobile-push-and-fast-approvals.md) | Medium |
+| 028 | [Agent Shift-Handoff Briefings](028-agent-shift-handoff-briefings.md) | Medium |
+| 029 | [Scheduled Operator Digest](029-scheduled-operator-digest.md) | Low–Medium |
+| 030 | [Revenue & P&L Tracking](030-revenue-and-pnl-tracking.md) | Medium |
+| 031 | [Agent-Run Distributed Tracing](031-agent-run-distributed-tracing.md) | Medium |
+| 032 | [A/B Model Bake-Off Harness](032-ab-model-bakeoff-harness.md) | Medium |
+| 033 | [Stakeholder Transparency Page](033-stakeholder-transparency-page.md) | Low–Medium |
+| 034 | [Data Retention & PII Governance](034-data-retention-pii-governance.md) | Medium |
+| 035 | [Adaptive Heartbeat Cadence](035-adaptive-heartbeat-cadence.md) | Medium |
+| 036 | [Outbound Webhooks & Event Subscriptions](036-outbound-webhooks-event-subscriptions.md) | Low–Medium |
+| 037 | [Prompt-Cache-Aware Context Optimization](037-prompt-cache-aware-context-optimization.md) | Medium |
+| 038 | [Approval Delegation & Coverage](038-approval-delegation-coverage.md) | Medium |
+| 039 | [Guided Onboarding & Demo Company](039-guided-onboarding-demo-company.md) | Low–Medium |
+| 040 | [Operator-Owned Training Dataset](040-operator-owned-training-dataset.md) | Medium |
+| 041 | [Host Resource-Aware Local Scheduling](041-host-resource-aware-local-scheduling.md) | Medium |
+| 042 | [Workspace Conflict Coordination](042-workspace-conflict-coordination.md) | Medium |
+| 043 | [Policy-as-Code Governance Engine](043-policy-as-code-governance-engine.md) | Medium–High |
+| 044 | [Agent Reliability SLOs & Error Budgets](044-agent-reliability-slos.md) | Low–Medium |
+| 045 | [Plugin Versioning, Rollback & Health](045-plugin-versioning-rollback-health.md) | Medium |
+| 046 | [Skill Effectiveness Analytics](046-skill-effectiveness-analytics.md) | Low–Medium |
+| 047 | [Role-Based Skill Auto-Provisioning](047-role-based-skill-auto-provisioning.md) | Low–Medium |
+| 048 | [Competency-Gated Job Postings (Test-to-Hire)](048-competency-gated-job-postings.md) | Medium–High |
+| 049 | [Shared Credential Pooling & Fair-Share Rate Limiting](049-shared-credential-fair-share-rate-limiting.md) | Medium |
+| 050 | [Code & Dependency Security Scanning of Work Products](050-work-product-security-scanning.md) | Medium |
+| 051 | [Disaster Recovery: Backup Verification & Restore Drills](051-disaster-recovery-backup-verification.md) | Medium |
+| 052 | [Org Restructuring Simulator](052-org-restructuring-simulator.md) | Medium |
+| 053 | [Inter-Company Shared Services (Agent Lending)](053-inter-company-shared-services.md) | High |
+| 054 | [Company Mailbox (Inter-Company Inbox/Outbox & Tickets)](054-company-mailbox.md) | Medium–High |
+| 055 | [Estimate-vs-Actual Calibration](055-estimate-vs-actual-calibration.md) | Low–Medium |
+| 056 | [Business Experiment Framework](056-business-experiment-framework.md) | Medium |
+| 057 | [Incident Management & On-Call](057-incident-management-on-call.md) | Medium |
+| 058 | [Work Templates & Definition-of-Done](058-work-templates-definition-of-done.md) | Low–Medium |
+| 059 | [Goal Decomposition Quality Assistant](059-goal-decomposition-quality-assistant.md) | Medium |
+| 060 | [Knowledge System (Accumulation, Curation & Retrieval)](060-knowledge-system.md) — _merges former 060/065/066_ | Medium–High |
+| 061 | [WIP Limits & Flow Control](061-wip-limits-flow-control.md) | Low–Medium |
+| 062 | [Inbound Intake Channels (Email/Webhook → Issue)](062-inbound-intake-channels.md) | Medium |
+| 063 | [Cost & Capacity Forecasting](063-cost-capacity-forecasting.md) | Medium |
+| 064 | [Data Import / Migration from Existing Tools](064-data-import-migration.md) | Medium |
+| 065 | [Software-Building Capability & Self-Hosting (Paperclip Builds Paperclip)](065-software-building-and-self-hosting.md) | High |
+| 066 | [Built-In Chat Channel (Telegram Bot / WhatsApp) for On-the-Go Operation](066-chat-bot-channel-telegram-whatsapp.md) | Medium |
+
+## Architecture notes (for grounding future ideas)
+
+- Per-agent concurrency already exists: `AGENT_DEFAULT_MAX_CONCURRENT_RUNS = 20`
+  (`packages/shared/src/constants.ts`), clamped 1–50 in `server/src/services/heartbeat.ts`.
+  There is **no** instance-wide or company-wide cap — slots are counted per agent/heartbeat only.
+- Budgets, costs, and burn live in `server/src/services/{budgets,costs,finance}.ts`.
+- Watchdogs (`task-watchdogs.ts`) catch stuck/crashed runs but not *unproductive* runs.
+- The plugin job scheduler (`plugin-job-scheduler.ts`) already has a `maxConcurrentJobs`
+  pattern (default 10) that is a good reference for an admission-control loop.

--- a/.ideas/_skeleton-reference.md
+++ b/.ideas/_skeleton-reference.md
@@ -1,0 +1,130 @@
+# Paperclip, Reverse-Engineered to Its Skeletal Working System
+
+*Derived from a direct read of the repo (schema in `packages/db/src/schema`, the engine in
+`server/src/services/heartbeat.ts`, boot in `server/src/index.ts`, the adapter contract in
+`packages/adapter-utils/src/types.ts`, wiring in `server/src/app.ts`). Scale: ~90 tables, 141
+services, a 12,326-line heartbeat. This strips it to the irreducible core — the "kernel" idea 065 Part C
+would hand-build.*
+
+## The one-sentence model
+
+> **A company is a tree of goals decomposed into a tree of issues, worked by a tree of agents, where a
+> timer periodically wakes each agent to pick up an assigned issue and execute it through an adapter,
+> recording every execution as a run.**
+
+Everything else (governance, budgets, secrets, knowledge, plugins, multi-user, UI) is a ring of
+elaboration around that sentence.
+
+## The spine: 5 tables out of ~90
+
+```
+companies ──< agents (org chart: agents.reportsTo → agents.id)
+    │            │
+    │            └── adapterType + adapterConfig   ← what the agent *is*
+    │            └── capabilities, role, budget, status
+    │
+    ├──< goals   (goal tree: goals.parentId → goals.id; level, ownerAgentId)
+    │
+    ├──< issues  (issue tree: issues.parentId → issues.id; issues.goalId → goals.id)
+    │            └── assigneeAgentId, status, priority
+    │            └── checkoutRunId / executionRunId  ← run-level locking
+    │
+    └──< heartbeat_runs  (the execution ledger: companyId, agentId, status,
+                          usageJson, resultJson, sessionIdBefore/After, log*)
+```
+
+- **companies** — the tenant/container. Core fields: `status`/`pauseReason`, `issuePrefix`+`issueCounter`
+  (human IDs), `budgetMonthlyCents`/`spentMonthlyCents` (the spend guardrail anchor).
+- **agents** — the workforce. An agent *is* its `adapterType` + `adapterConfig` (+ `runtimeConfig`).
+  `reportsTo` (self-ref) is the org chart; `capabilities` is free text; `status` drives scheduling.
+- **goals** — the "why." A tree (`parentId`) with `level` (goal→…→task) and `ownerAgentId`. The
+  invariant *all work traces to the goal* lives here.
+- **issues** — the "what/work." A tree (`parentId`) linked to a goal (`goalId`) and an assignee
+  (`assigneeAgentId`). `checkoutRunId`/`executionRunId`/`executionLockedAt` implement *exactly-one-run-
+  at-a-time* per issue.
+- **heartbeat_runs** — the "what happened." Every execution: `status` (queued→running→done/failed),
+  `usageJson` (tokens), `resultJson`, `sessionIdBefore/After` (continuity), `log*` (output). This is the
+  fact table everything analytical hangs off.
+
+## The engine: one tick → wake → pick → execute → record
+
+Boot (`server/src/index.ts`) starts the whole machine with **two `setInterval` timers**:
+
+```
+setInterval → heartbeat.tickTimers(now)          // wakes eligible agents, enqueues runs
+setInterval → heartbeat.tickScheduledTriggers()  // routines (cron-style scheduled work)
+```
+
+A single **heartbeat run** (the core of `heartbeat.ts`) is the entire control loop:
+
+1. **Wake** an eligible agent (timer tick, or an event-driven `agent_wakeup_requests` /
+   `issue-assignment-wakeup`). Event-first, timer as the safety net.
+2. **Admit** — may it start? Per-agent concurrency (`AGENT_DEFAULT_MAX_CONCURRENT_RUNS`), agent/company
+   `status`, the issue's execution lock (`executionLockedAt`). (There is *no* fleet-wide cap — that gap
+   is idea 001.)
+3. **Pick** an assigned, ready issue; check it out (`checkoutRunId`).
+4. **Resolve** the run's adapter config (`resolveExecutionRunAdapterConfig`) — model, workspace, skills,
+   session to resume (`sessionIdBefore`).
+5. **Execute** across the adapter boundary (below). The agent reads its issue/goal context, does work,
+   produces outputs.
+6. **Record** — write the `heartbeat_run` (status, `usageJson`, `resultJson`, `sessionIdAfter`, logs),
+   update the issue `status`, persist work products/comments, release the lock.
+7. **Account** — usage → `cost_events` → budget check (warn / hard-stop).
+
+Liveness is guarded out-of-band: `task-watchdogs`, `run-liveness`, `issue-liveness`,
+`heartbeat_run_watchdog_decisions`, plus process-recovery for crashed runs.
+
+## The one boundary that matters: the adapter contract
+
+The *only* thing that actually talks to an LLM/CLI is an adapter. The seam
+(`packages/adapter-utils/src/types.ts`) is essentially:
+
+```ts
+execute(ctx: AdapterExecutionContext): Promise<AdapterExecutionResult>
+//   ctx:  agent, issue/goal context, model, workspace, session, skills
+//   result: outputs, UsageSummary (tokens → cost), sessionId (continuity),
+//           error family (transient_upstream | model_refusal)
+```
+
+Each builtin (`pi-local`, `claude-local`, `process`, `http`, … in `BUILTIN_ADAPTER_TYPES`) implements
+`execute` (+ a `ServerAdapterModule`/`CLIAdapterModule`, config schema, env checks, session codec, quota
+windows). Swap the adapter, change the brain/runtime; the control plane is unchanged. **This is why
+idea 008 (local LLM) is "mostly config" and why the kernel needs exactly one working adapter.**
+
+## The interface: HTTP CRUD + a chat door + realtime
+
+`app.ts` mounts ~40 Express route modules; the load-bearing few are
+`companies`, `agents`, `goals`, `issues`, `approvals`, `costs`, and **`board-chat`** (the human's door to
+file goals/issues and direct the company). A live-events websocket/SSE (`server/src/realtime`) streams
+run/issue/budget changes to the UI so you can watch the company move.
+
+## The concentric rings (everything else, by distance from the core)
+
+1. **Core (above):** companies · agents · goals · issues · heartbeat_runs · the tick loop · one adapter.
+2. **Accounting & safety:** `cost_events`, `budget_policies`, `budget_incidents`, watchdogs, `activity_log`.
+3. **Governance:** `approvals`/`issue_approvals`, agent permissions, trust presets, secrets +
+   `company_secret_bindings`, execution policy.
+4. **Work substrate:** `execution_workspaces`, `workspace_operations`, `issue_work_products`,
+   `documents`, environments + `environment_leases`.
+5. **Extensibility:** plugins (adapters/skills/routines/jobs/host-services), `skills-catalog`,
+   `teams-catalog`, `mcp-server`.
+6. **People & surface:** auth, memberships, multi-user roles, sidebar/inbox, the `ui/` React app.
+
+The `.ideas/` backlog is almost entirely *ring 2–6 enrichment*; the spine in rings 0–1 barely changes.
+
+## The minimal kernel (what survives if you scale to skeleton — for idea 065 Part C)
+
+The smallest thing that is recognizably Paperclip:
+
+- **Tables:** `companies`, `agents`, `goals`, `issues`, `heartbeat_runs` (drop the other ~85).
+- **Loop:** one `setInterval` → wake an agent → pick its assigned ready issue → execute → record →
+  update status. (Event wakeups optional; timer alone works.)
+- **Adapter:** exactly one (`process` or a single LLM via `http`) implementing `execute()`.
+- **Guardrails (kernel-grade):** a company budget hard-stop from summed `usageJson`, and a manual
+  human-approval gate before a run's output is accepted. (Autonomy Dial Level 0–1, per cross-cut 01.)
+- **Interface:** create company/agent/goal/issue + watch runs (a handful of routes, or even seed scripts).
+
+Everything past that — fleet concurrency, predictive budgets, deadlock/drift detection, knowledge,
+multi-company, the full UI — is a capability the kernel can *grow into* (the 065 bootstrap), one ring at
+a time, rather than a prerequisite. The architecture is already shaped as concentric rings, which is
+precisely what makes "scale it down, then build it up" (idea 065) realistic.

--- a/.ideas/combinations/README.md
+++ b/.ideas/combinations/README.md
@@ -1,0 +1,91 @@
+# Paperclip Idea Combinations
+
+This folder synthesizes the 64 individual ideas in `../` into **13 combined features**. Each
+combination merges ideas that converge on the *same seam, data model, or product surface* into one
+coherent, higher-leverage feature — so they compose by construction instead of being built as
+overlapping one-offs.
+
+Each file states what it combines, the unified idea, why combining beats building separately, a
+phasing plan, and three ratings: **difficulty**, **estimated time**, and **importance (1–10)**.
+
+## The combinations
+
+| # | Combination | Merges ideas | Difficulty | Est. time | Importance |
+|---|-------------|--------------|-----------|-----------|-----------|
+| 01 | [Unified Runtime Control Plane](combo-01-runtime-control-plane.md) | 001, 002, 005, 014, 024, 035, 061, 042 | High | 6–9 wk | **9** |
+| 02 | [Mixed-Economy Model & Provider Fabric](combo-02-model-economy-fabric.md) | 008, 012, 049, 041 | Med–High | 4–6 wk | **8** |
+| 03 | [Autonomous Company Health Sentinel](combo-03-company-health-sentinel.md) | 003, 010, 026, 059, 044, 006, 031 | Med–High | 5–7 wk | **9** |
+| 04 | [Autonomous CFO Suite](combo-04-cfo-suite.md) | 013, 019, 030, 037, 055, 063 | Med–High | 5–7 wk | **8** |
+| 05 | [Operator Review & Approval Cockpit](combo-05-review-cockpit.md) | 016, 017, 027, 029, 038, (033) | Medium | 4–6 wk | **9** |
+| 06 | [Agent CI/CD & Evidence-Based Quality](combo-06-agent-ci.md) | 011, 032, 040, 046 | Med–High | 5–7 wk | **7** |
+| 07 | [Self-Staffing & Self-Organizing Workforce](combo-07-self-staffing-org.md) | 048, 047, 025, 009, 052 | High | 6–9 wk | **7** |
+| 08 | [Zero-Trust Security, Governance & Compliance](combo-08-zero-trust-governance.md) | 043, 020, 021, 022, 023, 034, 050 | High | 8–12 wk | **8** |
+| 09 | [Resilience, DR & Incident Response](combo-09-resilience-recovery.md) | 015, 051, 057, 045, (014) | Med–High | 5–7 wk | **7** |
+| 10 | [Day-One Adoption Kit](combo-10-day-one-adoption.md) | 039, 018, 004, 064, 058 | Medium | 4–6 wk | **8** |
+| 11 | [Institutional Memory & Continuous Learning](combo-11-institutional-memory.md) | 060, 028, 056, (055, 057) | High | 7–10 wk | **7** |
+| 12 | [Two-Way External Integration Fabric](combo-12-external-integration-fabric.md) | 062, 036, (030) | Medium | 3–5 wk | **6** |
+| 13 | [Governed Cross-Company Fabric](combo-13-cross-company-fabric.md) | 054, 007, 053, (033) | High | 8–12 wk | **6** |
+
+Parenthesized ideas are *referenced/woven in* by a combination whose primary home is elsewhere.
+
+## Source-idea → combination map
+
+Every one of the 64 ideas lands in exactly one **primary** combination (cross-references noted in the
+files):
+
+| Idea | Primary combo | Idea | Primary combo |
+|------|---------------|------|---------------|
+| 001 Fleet Concurrency Governor | 01 | 033 Stakeholder Transparency Page | 05 (→13) |
+| 002 Predictive Budget Breaker | 01 | 034 Data Retention & PII | 08 |
+| 003 Diminishing-Returns Detector | 03 | 035 Adaptive Heartbeat Cadence | 01 |
+| 004 Company Dry-Run Estimator | 10 | 036 Outbound Webhooks | 12 |
+| 005 Spend-Schedule / Quiet Hours | 01 | 037 Prompt-Cache Optimization | 04 |
+| 006 Org Bottleneck Heatmap | 03 | 038 Approval Delegation & Coverage | 05 |
+| 007 Holding Company | 13 | 039 Guided Onboarding & Demo | 10 |
+| 008 Local LLM Adapter | 02 | 040 Operator-Owned Training Dataset | 06 |
+| 009 Agent Probation / Trust Ramp | 07 | 041 Host Resource-Aware Scheduling | 02 |
+| 010 Blocker-Graph Deadlock Detector | 03 | 042 Workspace Conflict Coordination | 01 |
+| 011 Eval-Gated Config Deploys | 06 | 043 Policy-as-Code Governance | 08 |
+| 012 Provider Fallback Chains | 02 | 044 Agent Reliability SLOs | 03 (→07,09) |
+| 013 Unit-Economics Dashboard | 04 | 045 Plugin Versioning/Rollback/Health | 09 |
+| 014 Emergency Stop & Drain | 01 (→09) | 046 Skill Effectiveness Analytics | 06 |
+| 015 Company Point-in-Time Rewind | 09 | 047 Role-Based Skill Auto-Provisioning | 07 |
+| 016 Approval Triage & Batching | 05 | 048 Competency-Gated Job Postings | 07 |
+| 017 Run Change-Review Surface | 05 | 049 Shared-Credential Fair-Share | 02 |
+| 018 Company Blueprint Library | 10 | 050 Work-Product Security Scanning | 08 |
+| 019 Token-Denominated Budgets | 04 | 051 DR Backup Verification | 09 |
+| 020 Outbound Secret-Leak Scanning | 08 | 052 Org Restructuring Simulator | 07 |
+| 021 Just-in-Time Secret Leasing | 08 | 053 Inter-Company Shared Services | 13 |
+| 022 Per-Agent Egress Allowlist | 08 | 054 Company Mailbox | 13 |
+| 023 Tamper-Evident Audit Log | 08 | 055 Estimate-vs-Actual Calibration | 04 (→11) |
+| 024 Per-Run Resource Caps | 01 | 056 Business Experiment Framework | 11 |
+| 025 Capability-Based Auto-Assignment | 07 | 057 Incident Management & On-Call | 09 (→11) |
+| 026 Goal-Drift Alignment Auditor | 03 | 058 Work Templates & DoD | 10 (→05) |
+| 027 Mobile Push & Fast Approvals | 05 | 059 Goal Decomposition Quality | 03 |
+| 028 Agent Shift-Handoff Briefings | 11 | 060 Knowledge System | 11 |
+| 029 Scheduled Operator Digest | 05 | 061 WIP Limits & Flow Control | 01 |
+| 030 Revenue & P&L Tracking | 04 (→12) | 062 Inbound Intake Channels | 12 |
+| 031 Agent-Run Distributed Tracing | 03 | 063 Cost & Capacity Forecasting | 04 |
+| 032 A/B Model Bake-Off | 06 | 064 Data Import / Migration | 10 |
+
+## Suggested build order (by importance × foundational-ness)
+
+1. **Combo 01** (Runtime Control Plane) — the safety/cost foundation almost everything composes onto.
+2. **Combo 05** (Review Cockpit) — unblocks the human bottleneck that stalls 24/7 autonomy.
+3. **Combo 03** (Health Sentinel) — catches the expensive failures that look healthy.
+4. **Combo 10** (Day-One Adoption) — without it the rest is academic; drives real usage.
+5. **Combo 04** (CFO Suite) + **Combo 02** (Model Economy) — make the business measurable and cheap.
+6. **Combo 08** (Zero-Trust Governance) — unlocks operating real, regulated businesses.
+7. Then 06, 07, 09, 11, 12, 13 as the company matures toward self-organization and multi-company scale.
+
+## Recurring foundations (shared substrates worth building deliberately)
+
+A few primitives are depended on by many combinations — build them well, once:
+
+- **A `planOnly`/shadow side-effect-free execution mode** — combos 04, 06, 07, 10.
+- **A free local model** (combo 02 / idea 008) — powers cheap evals, embeddings, summaries, judging
+  across combos 03, 05, 06, 11.
+- **The lease/claim pattern** (`environmentLeases`) — secrets (08), workspace locks (01).
+- **The company-portability serializer** — blueprints/demo/import (10), snapshots/rewind (09).
+- **The tamper-evident audit log** (combo 08) — the trustworthy record every governed action lands in.
+- **One governed cross-company seam** (combo 13) — built once, used for oversight, services, and mail.

--- a/.ideas/combinations/combo-01-phasing-corrected.md
+++ b/.ideas/combinations/combo-01-phasing-corrected.md
@@ -1,0 +1,164 @@
+# Combo 01 — Corrected Phase Scope
+
+Companion to [`combo-01-runtime-control-plane.md`](combo-01-runtime-control-plane.md), whose
+**Phasing** section now carries a condensed version of this plan. This file is the detailed
+expansion — per-phase exit criteria and the full changed-vs-original rationale. It exists because the original phasing
+schedules the eight *ideas* but not the four *shared seams* they all write through — so as written,
+Phase 1 builds those seams single-purpose and Phases 2–4 retrofit them, recreating the exact
+"competing writers / five reimplementations" anti-pattern the combo exists to prevent.
+
+## Governing principle
+
+The value of fusing these eight ideas is **compose-by-construction**. That only holds if Phase 1
+builds four things as *extension points*, not as single-purpose code:
+
+1. **The effective-cap resolver** — one function that reduces all cap writers to a single number,
+   honoring a fixed precedence. In Phase 1 it has one input (the configured default); later phases
+   register more. Building it now is what stops Phases 2–3 from each bolting on a competing writer.
+2. **The admission seam** — the single choke point at `heartbeat.ts:8207` (today
+   `availableSlots = maxConcurrentRuns - runningCount`) that every run start passes through. Must be
+   the *only* path a run can start, including process recovery and scheduled retries.
+3. **The run-selection / wakeup hook** — the "which waiting run starts next" decision, made
+   **pluggable** so WIP (061) and lock-awareness (042) refine it later without a rewrite.
+4. **The reconciler** — the crash-safety timer that recomputes live state from ground truth.
+   Designed from day one to reconcile *counters and leases*, not only slot counts.
+
+Precedence order (locked now, even though only the last writer exists in Phase 1):
+
+```
+panic/drain  >  predictive breaker  >  manual override  >  schedule  >  configured default
+```
+
+---
+
+## Phase 1 — Foundations: the four seams + fleet/company cap
+**Target: ~2–3 weeks. Independently shippable. This is the phase the original underscoped.**
+
+Deliverables:
+
+- **Effective-cap resolver** with the precedence order above wired as a registry, seeded with a
+  single writer (configured default). Ships with a unit test that asserts precedence resolution so
+  later writers can't silently reorder it.
+- **Manual override writer** — the "boost / quiet now for N hours, then auto-revert" control. It is
+  *not* attributed to any idea in the original doc but appears in the precedence order, so it gets an
+  owner here, next to the resolver. (Pulled forward from fragments in 005 and 014.)
+- **Fleet + per-company concurrency cap (001).** `instanceMaxConcurrentRuns` on
+  `instance-settings.ts`; per-company `maxConcurrentRuns` column in `packages/db`. Central
+  `run-admission` counter keyed by `{instance, companyId}`, modeled on the acquire/release primitive
+  at `plugin-job-scheduler.ts:298`.
+- **Admission seam.** Gate the launch at `heartbeat.ts:8207`; runs past the cap enter a
+  `queued_admission` state instead of starting. Audit every admit/defer to `activity-log.ts`.
+- **Pluggable run-selection hook.** On slot release, a `selectNextRun` function (default:
+  highest-priority waiting run) fires the existing `issue-assignment-wakeup.ts` path. Defined as an
+  extension point now so 061/042 refine it in Phase 4 without touching the seam.
+- **Reconciler (crash-safe).** Timer that recomputes live counts from actual run state, reclaiming
+  leaked slots. Its interface takes a *ground-truth source* so per-run counters (P2) and lease claims
+  (P4) plug into the same loop. Must cover `heartbeat-process-recovery` and scheduled-retry paths.
+- **UI.** "Running N / cap M · K waiting" badge (instance + per-company row) over the live-events
+  websocket.
+
+Exit criteria: with 30 agents configured for 20 runs each and an instance cap of 10, real concurrency
+never exceeds 10; killing the server mid-run and restarting reclaims the slot within one reconciler
+tick (no permanent leak); the badge reflects true running/waiting counts.
+
+---
+
+## Phase 2 — Per-run ceilings + the Big Red Button (manual)
+**Depends on: Phase 1 seam, resolver, reconciler. Target: ~2 weeks.**
+
+Deliverables:
+
+- **Graceful checkpointed wind-down primitive (built once, shared).** The enabling substrate for
+  *both* items below — reuses `issue-continuation-summary.ts` / `run-continuations.ts` so a stopped
+  run checkpoints and resumes instead of losing partial work. Called out explicitly because the
+  original phasing assumes it twice without scheduling it; if it's weak, both 024 and 014-panic
+  silently degrade to work-destroying hard kills.
+- **Per-run resource caps (024), sub-phased per the idea's own guidance:**
+  - *2a — ships everywhere:* `maxRunWallClockMs` and `maxRunCostCents`, enforced against
+    `cost_events` at the run choke point, terminating via the wind-down primitive.
+  - *2b — uneven adapter coverage:* `maxToolCalls` / step counts, gated on each adapter surfacing
+    step events. Do **not** block 2a on this.
+  - Per-run cumulative counters register with the Phase-1 reconciler (survive crashes).
+- **Panic Stop + Drain (014), manual only.** Instance/company `executionState`
+  (`running`/`draining`/`halted`) checked *at the Phase-1 seam*. Panic = halt + cancel via the
+  existing cancellation path (`issue-tree-control.ts`, `recovery/service.ts`). Drain = refuse new
+  starts, live "N draining…" readout. Safe resume re-admits gradually through the resolver — **not** a
+  stampede. Register `panic/drain` as the top-precedence cap writer.
+
+Note: 014's *auto*-drain-under-burn hook is deliberately deferred to Phase 3 (it needs 002). Phase 2
+ships the button; Phase 3 wires the trigger.
+
+Exit criteria: a run exceeding its wall-clock or cost cap checkpoints and stops with partial work
+recoverable; Panic Stop halts every in-flight run and blocks new starts within one tick; resume ramps
+back through the cap rather than launching everything at once.
+
+---
+
+## Phase 3 — Reactive throttling: burn breaker + schedules
+**Depends on: resolver (writers), cost aggregation. Target: ~2 weeks.**
+**This is where automated runaway-spend protection — the combo's headline justification — actually lands.**
+
+Deliverables:
+
+- **Prerequisite check: real-time-enough burn signal.** Confirm `costs.ts`/`finance.ts` aggregate
+  spend at a latency the forecaster can act on; add a rolling windowed burn metric (5/15/60 min) if
+  the existing aggregation is too batchy. The breaker is only as good as this signal.
+- **Predictive Budget Circuit Breaker (002).** `timeToLimit = remainingBudget / burnRate` vs a
+  configurable horizon; graduated responses (warn → throttle → pause non-critical). Registers as a
+  cap writer above `manual override`. **Hysteresis / cooldown is mandatory** to avoid
+  throttle↔un-throttle oscillation.
+- **Auto-drain hook (completes 014).** Under extreme burn, the breaker invokes Drain from Phase 2 —
+  the deferred half of the Big Red Button.
+- **Spend-Schedule / Quiet Hours (005).** Time-windowed `{maxConcurrentRuns, maxBurnPerHour}` profiles
+  built on `routines.ts`; registers as the `schedule` cap writer (below manual, above default).
+  Timezone/DST correctness on the company; ship presets so operators skip cron authoring.
+
+Exit criteria: a company forecast to exhaust budget within the horizon has its effective cap lowered
+*before* the wall, without oscillating; a scheduled quiet-hours window shifts the cap at the boundary
+and manual override still wins over it.
+
+---
+
+## Phase 4 — Scheduling refinements (split into two tracks)
+**Depends on: the Phase-1 selection hook. The original bundled three ideas here; split them.**
+
+**Track 4A — Flow & cadence (refine selection + heartbeat). Target: ~2 weeks.**
+
+- **Adaptive Heartbeat Cadence (035).** Idle-backoff first (highest ROI, lowest risk): exponentially
+  lengthen intervals after empty heartbeats, kept reachable by `issue-assignment-wakeup.ts`.
+  Speed-up-under-load second, bounded by the Phase-1 cap and Phase-2 per-run caps. Hysteresis to avoid
+  cadence oscillation.
+- **WIP Limits & Flow Control (061).** Per-agent in-progress caps enforced by *refining the Phase-1
+  `selectNextRun` hook* (don't hand work to a maxed-out agent) — not a new seam. Ship per-agent WIP +
+  flow metrics (cycle time, throughput) first; team/stage limits and start/finish alarms follow.
+
+**Track 4B — Workspace correctness (independent concern, can parallelize or defer). Target: ~2 weeks.**
+
+- **Workspace Conflict Coordination (042).** Start with collision *detection* from the existing
+  `workspace-operations.ts` op log (pure visibility, zero risk). Then path-level soft locks via the
+  lease pattern (`environment-runtime.ts` / `environmentLeases`), whose expiry registers with the
+  Phase-1 reconciler. Then the selection hook factors lock contention (don't wake an agent whose only
+  work is locked). Flagged as its own track because it's about *file safety*, not the cap plane — it
+  reuses the seams but delivers value independently and can slip without blocking 4A.
+
+Exit criteria: an idle agent's cadence backs off and still responds instantly to a real event; an
+agent at its WIP limit is steered to finish rather than start; two agents targeting the same file
+surface a collision instead of silently clobbering.
+
+---
+
+## What changed vs. the original phasing
+
+| Original | Correction | Why |
+|----------|-----------|-----|
+| Phase 1 = "seam + cap + reconciler" | Phase 1 also builds the **resolver, manual-override writer, and pluggable selection hook** | Otherwise P2–P3 retrofit competing cap writers and P4 rewrites selection twice |
+| Reconciler = one-off in P1 | Reconciler **designed for counters + leases** from day one | It accretes scope in P2 (per-run counters) and P4 (leases) |
+| 024 as one P2 item | 024 **sub-phased** (wall-clock/cost everywhere; tool-calls where adapters support it) | The idea itself says cost/wall-clock ship first; adapter step coverage is uneven |
+| Wind-down assumed inside 024 + 014 | Wind-down is an **explicit shared P2 primitive** | Both items degrade to work-losing hard kills without it |
+| 002 in P3, no prereq | P3 opens with a **burn-signal freshness check** | The forecaster is only as good as cost-aggregation latency |
+| 014 as one P2 item | 014 **split**: manual button (P2), auto-drain hook (P3) | Its auto-trigger depends on 002, which lands in P3 |
+| Phase 4 bundles 035+061+042 | Split into **4A flow/cadence** and **4B workspace** | 042 is a separable file-safety concern; bundling hides ~2 wk of work in the last slot |
+
+Net effect on estimate: unchanged envelope (~6–9 engineer-weeks) but honestly distributed —
+Phase 1 grows to ~2–3 weeks (it was underscoped), and Phase 4's hidden third idea is surfaced as a
+parallelizable track rather than a silent overrun.

--- a/.ideas/combinations/combo-01-runtime-control-plane.md
+++ b/.ideas/combinations/combo-01-runtime-control-plane.md
@@ -1,0 +1,95 @@
+# Combo 01 — Unified Runtime Control Plane (Load, Spend & Safety Governor)
+
+**Combines:** 001 Fleet Concurrency Governor · 002 Predictive Budget Circuit Breaker ·
+005 Spend-Schedule / Quiet Hours · 014 Emergency Stop & Drain Mode · 024 Per-Run Resource Caps ·
+035 Adaptive Heartbeat Cadence · 061 WIP Limits & Flow Control · 042 Workspace Conflict Coordination
+
+## The unified idea
+
+Today Paperclip enforces concurrency only *per agent*, has no instance/company cap, hits budgets
+post-hoc, can't throttle by time of day, can't stop everything at once, and can't cap a single
+runaway run. These are eight separate ideas — but they are all the **same control surface** asking
+one question at one choke point: *"should this run start right now, and if so, how big may it get?"*
+
+Build **one admission-and-throttle control plane** that owns that decision. Every run start passes
+through a single seam that evaluates a stack of nested limits:
+
+- **Per run** — wall-clock, tool-call, token, and cost ceilings with graceful checkpointed
+  wind-down (024).
+- **Per agent** — existing `maxConcurrentRuns` plus adaptive heartbeat cadence so idle agents back
+  off and busy ones speed up (035), and WIP limits so agents *finish before they start* (061).
+- **Per company / instance** — a fleet concurrency cap with a queue-and-wakeup-on-free-slot pattern
+  (001), modulated by time-based quiet-hours/burst profiles (005) and a predictive budget breaker
+  that throttles *before* the wall, with hysteresis to avoid oscillation (002).
+- **Cross-cutting safety** — a Big Red Button: **Drain** (stop starting, let in-flight finish) and
+  **Panic Stop** (halt + cancel), with gradual non-stampeding resume back through the governor (014).
+- **Workspace correctness** — admission also respects file/path soft-locks so parallel agents don't
+  clobber each other; don't wake an agent whose only available work is fully locked (042).
+
+One precedence order resolves all the throttles writing the same "effective cap": **panic/drain >
+predictive breaker > manual override > schedule > configured default.**
+
+## Why combining wins
+
+These features individually each need: a run-start choke point, a live counter that survives crashes,
+a reconciler, and a UI badge for "running N / cap M / K waiting." Building them separately means five
+re-implementations of the same fragile slot-accounting and five competing writers to the effective
+cap. Built as one plane they *compose by construction* and share one reconciler, one audit path
+(`activity-log.ts`), and one dashboard readout. The `plugin-job-scheduler.ts` `maxConcurrentJobs`
+gate is the in-repo template for the acquire/release primitive.
+
+## Phasing
+
+**Governing principle.** The value of fusing these eight ideas is *compose-by-construction*, and
+that only holds if Phase 1 builds four shared seams as **extension points**, not single-purpose code —
+otherwise Phases 2–4 retrofit competing cap writers and rewrite the selection logic, recreating the
+exact anti-pattern this combo exists to prevent. The four: (1) an **effective-cap resolver** with the
+precedence order below, seeded with one writer but built as a registry; (2) the **admission seam** at
+`heartbeat.ts:8207` as the *only* path a run can start; (3) a **pluggable run-selection/wakeup hook**
+so WIP (061) and locks (042) refine it later without a rewrite; (4) a **reconciler** designed to
+reconcile *counters and leases*, not only slot counts.
+
+Precedence (locked in Phase 1, even though only the last writer exists then):
+`panic/drain > predictive breaker > manual override > schedule > configured default`.
+
+1. **Foundations — four seams + fleet/company cap (~2–3 wk, independently shippable).** The cap
+   resolver + precedence registry; the **manual-override writer** (orphaned in the source ideas — owned
+   here); fleet + per-company cap (001) on the `plugin-job-scheduler.ts:298` acquire/release template;
+   the admission seam (runs past cap → `queued_admission`); the pluggable `selectNextRun` hook firing
+   `issue-assignment-wakeup.ts`; the crash-safe reconciler (covers process recovery + scheduled
+   retries); the "running N / cap M · K waiting" badge.
+2. **Per-run ceilings + Big Red Button, manual (~2 wk).** Graceful checkpointed **wind-down as an
+   explicit shared primitive** (`issue-continuation-summary.ts`) — both items below degrade to
+   work-losing hard kills without it. Per-run caps (024) **sub-phased**: `maxRunWallClockMs` +
+   `maxRunCostCents` everywhere first, `maxToolCalls`/step counts only where adapters emit step events;
+   counters register with the reconciler. Panic Stop + Drain (014, manual) on the Phase-1 seam via the
+   existing cancel path; safe non-stampeding resume through the resolver.
+3. **Reactive throttling — where automated runaway-spend protection actually lands (~2 wk).** Opens
+   with a **burn-signal freshness check** on `costs.ts`/`finance.ts` (the forecaster is only as good as
+   its aggregation latency). Predictive breaker (002) with mandatory hysteresis, registered above
+   manual override; the **auto-drain hook** that completes 014; time-based profiles (005) on
+   `routines.ts` as the `schedule` writer with tz/DST correctness.
+4. **Scheduling refinements — split into two tracks.** *4A Flow & cadence (~2 wk):* adaptive heartbeat
+   (035, idle-backoff first) + WIP limits (061) that refine the Phase-1 `selectNextRun` hook rather
+   than adding a seam. *4B Workspace correctness (~2 wk, parallelizable/deferrable):* conflict
+   coordination (042) — collision *detection* from the `workspace-operations.ts` op log first, then
+   soft locks via the lease pattern (expiry registers with the reconciler), then lock-aware selection.
+   Split out because 042 is a file-safety concern, not the cap plane; it reuses the seams but delivers
+   value independently.
+
+*Corrections vs. an idea-by-idea phasing: the resolver/manual-override/selection-hook are pulled into
+Phase 1 (else P2–3 add competing writers, P4 rewrites selection twice); the reconciler is scoped for
+counters + leases up front; 024 and 014 are each split; wind-down and the burn-signal prereq become
+explicit deliverables; Phase 4's hidden third idea (042) is surfaced as its own track. Net envelope
+unchanged (~6–9 wk), just honestly distributed — Phase 1 was underscoped at ~2 wk. See
+[`combo-01-phasing-corrected.md`](combo-01-phasing-corrected.md) for per-phase exit criteria and the
+full changed-vs-original rationale.*
+
+## Ratings
+
+- **Difficulty:** High — the seam is small, but crash-safe distributed slot accounting and a single
+  honored choke point (including process recovery and scheduled retries) are the hard, correctness-
+  critical core. A leaked slot slowly deadlocks the fleet; a missed choke point makes "stop" a lie.
+- **Estimated time to complete:** ~6–9 engineer-weeks (phased; phase 1 ~2 weeks is independently shippable).
+- **Importance:** 9/10 — directly prevents runaway API spend, machine thrash, and rate-limit storms,
+  the single biggest risk of an always-on autonomous fleet. Almost every other idea composes onto it.

--- a/.ideas/combinations/combo-02-model-economy-fabric.md
+++ b/.ideas/combinations/combo-02-model-economy-fabric.md
@@ -1,0 +1,55 @@
+# Combo 02 — Mixed-Economy Model & Provider Fabric
+
+**Combines:** 008 First-Class Local LLM Adapter · 012 Quota-Aware Provider Fallback Chains ·
+049 Shared Credential Pooling & Fair-Share Rate Limiting · 041 Host Resource-Aware Local Scheduling
+· (builds on 037 Prompt-Cache-Aware Context)
+
+## The unified idea
+
+An always-on company's defining constraint is *the economics of inference*. Four ideas each address
+one face of it; together they form a single **model-execution fabric** that decides, for every run,
+*where to run it, on whose credential, and whether the hardware/quota can take it* — optimizing for
+cost and privacy without thrashing.
+
+- **A free/private tier (008).** A first-class `local_llm` adapter (Ollama / LM Studio / llama.cpp,
+  all OpenAI-`/v1`-compatible) with $0-cost billing for loopback/LAN endpoints while still recording
+  token counts so productivity metrics stay honest. This is the *floor* of the economy.
+- **Graceful degradation (012).** Per-agent ordered fallback chains: premium API → cheap API → local.
+  On a quota/429/outage failure (distinguished from don't-retry failures by the existing recovery
+  classifiers), re-dispatch down the chain instead of stalling at 2am.
+- **Fair sharing of scarce keys (049).** Model a shared credential as a pool with known RPM/TPM
+  capacity and put a weighted-fair-queue in front so the noisy marketing batch can't starve the CEO
+  agent; reserve a capacity slice for critical roles; backpressure (and prefer the local fallback)
+  instead of letting everyone 429 at once.
+- **Don't melt the operator's machine (041).** Host CPU/RAM/GPU/VRAM probe + capacity-based admission
+  for *local* runs only, with per-model footprint hints (avoid OOM) and a "yield to the human during
+  work hours" profile that ramps local work off-hours.
+
+The connective tissue: under budget pressure the predictive breaker (combo 01 / idea 002) *prefers*
+the cheap fallback; the local tier makes evals, embeddings, summaries, and handoff briefings free
+across the rest of the roadmap (ideas 011, 028, 029, 060).
+
+## Why combining wins
+
+These four share the same decision point — the run-dispatch path — and the same goal: serve each run
+on the cheapest viable target without breaking. Fallback chains are nearly useless without a free
+last resort (008); a shared-key fair-share scheduler must know about fallback to shed load; local
+execution must be capacity-gated by the host probe or it OOMs. Build them as one fabric with one
+"select execution target" function rather than four bolt-ons. `inferOpenAiCompatibleBiller` and the
+local-vs-remote `environment-execution-target.ts` distinction are the existing seams.
+
+## Phasing
+
+1. `local_llm` adapter + loopback→$0 billing rule with strong `billing.test.ts` coverage (008).
+2. Provider fallback chains using quota signal + recovery classifiers (012).
+3. Shared-credential pool + weighted fair-share + critical-role reservation (049).
+4. Host resource probe (the one piece the repo entirely lacks) + capacity admission + work-hours yield (041).
+
+## Ratings
+
+- **Difficulty:** Medium–High — 008 has a direct in-repo template; the hard parts are correct billing
+  classification, idempotent failover with hop limits, concurrency-safe capacity accounting, and
+  cross-platform GPU/VRAM sampling (best-effort, graceful degradation).
+- **Estimated time to complete:** ~4–6 engineer-weeks (008 alone ~1 week, high standalone value).
+- **Importance:** 8/10 — makes the "24/7" pitch economically real, is a genuine differentiator
+  (mixed cheap-local / premium-API fleets), and removes the 2am-rate-limit-freeze failure mode.

--- a/.ideas/combinations/combo-03-company-health-sentinel.md
+++ b/.ideas/combinations/combo-03-company-health-sentinel.md
@@ -1,0 +1,58 @@
+# Combo 03 — Autonomous Company Health Sentinel
+
+**Combines:** 003 Diminishing-Returns Detector · 010 Blocker-Graph Deadlock Detector ·
+026 Goal-Drift Alignment Auditor · 059 Goal Decomposition Quality Assistant ·
+044 Agent Reliability SLOs · 006 Org Bottleneck Heatmap · 031 Agent-Run Distributed Tracing
+
+## The unified idea
+
+Paperclip's watchdogs catch runs that are *crashed or silent*. They miss every **expensive failure
+that looks healthy**: an agent thrashing on one issue with no progress (003), a dependency cycle
+where everyone is "correctly" waiting (010), whole sub-trees working hard on work that decoupled
+from a live goal (026), a goal that was *badly broken down in the first place* (059), and an agent
+that's simply *flaky*, burning recovery cycles (044). These are five analyzers over the same data —
+the issue tree, run history, and outcomes — and they all want the same two things: **a place to get
+clean signal from, and a place to show the result.**
+
+Build a single **Health Sentinel**: one analyzer service that runs these checks on a routine and
+escalates *actionably*, fed by one instrumentation layer and surfaced on one visualization.
+
+- **Instrumentation backbone (031).** Emit semantic OTel spans for the run lifecycle (agent, issue,
+  model, cost, tokens, tool-calls, sub-issue creation, handoffs), with trace context propagated
+  across handoffs. This one layer becomes the clean data source every detector reads — instead of
+  each re-stitching logs, transcripts, and cost rows.
+- **The detectors, unified (003, 010, 026, 044, 059).** Per-issue progress fingerprints (003);
+  Tarjan SCC + dead-end detection on the blocker graph (010); parent-chain + semantic alignment walk
+  for orphaned/drifted work (026); structural + completeness/overlap checks on decomposition (059);
+  rolling success/recovery rates vs an error budget per agent (044). Semantic tiers run on a free
+  local model (combo 02 / idea 008).
+- **One escalation contract.** Every trip names the *specific* thing to fix (the edge to cut, the
+  orphan to re-parent, the agent to constrain), auto-pauses where safe, and routes to the manager
+  agent or operator inbox.
+- **One surface (006).** Overlay all of it on the org-chart renderer as a bottleneck heatmap — hot
+  blocked nodes *and* cold decoupled branches both glow — with critical-path highlighting and
+  optional hourly trend snapshots.
+
+## Why combining wins
+
+Each detector alone is "an analyzer + an escalation + a viz." Built together they share the trace
+data source (031), the routine scheduler, the local-model judge, the org-chart overlay (006), and
+one escalation/auto-pause path — and the heatmap becomes genuinely useful only when it shows *all*
+pressure types at once. Reliability (044) and unit economics (combo 04) also consume the same spans.
+
+## Phasing
+
+1. Semantic run spans (031) — the data backbone; ship first, reuse the existing OTel exporter.
+2. Deterministic structural detectors (003 fingerprints, 010 cycle/dead-end, 026 orphan walk, 059
+   structural, 044 rates) + the heatmap surface (006).
+3. Semantic tiers (026 drift, 059 completeness/overlap) on a local model behind confidence thresholds.
+
+## Ratings
+
+- **Difficulty:** Medium–High — the graph algorithms and aggregations are textbook; the real work is
+  threading trace context across adapters/handoffs and *tuning heuristics* so they catch genuine
+  waste without killing slow-but-legitimate work.
+- **Estimated time to complete:** ~5–7 engineer-weeks (deterministic tier ~3 weeks, high value alone).
+- **Importance:** 9/10 — these are the most expensive failure modes precisely because they look fine;
+  catching them is the difference between an autonomous company that compounds value and one that
+  quietly burns money.

--- a/.ideas/combinations/combo-04-cfo-suite.md
+++ b/.ideas/combinations/combo-04-cfo-suite.md
@@ -1,0 +1,58 @@
+# Combo 04 — Autonomous CFO Suite (Economics, P&L & Forecasting)
+
+**Combines:** 013 Unit-Economics Dashboard · 019 Token-Denominated Budgets · 030 Revenue & P&L
+Tracking · 037 Prompt-Cache-Aware Context Optimization · 055 Estimate-vs-Actual Calibration ·
+063 Cost & Capacity Forecasting
+
+## The unified idea
+
+Paperclip tracks *spend* well but can't answer the only question that matters for an autonomous
+*business*: **is this thing making more than it costs, and where is it heading?** Six ideas each
+supply one missing financial organ; together they are a complete **CFO suite** over one shared
+cost/revenue/outcome data model.
+
+- **Close the revenue loop (030).** Add revenue events (manual, governed agent-reported, and
+  Stripe/Paddle webhook ingestion) so the system models income, not just expense — yielding real
+  profit, margin, MRR/ARR, burn multiple, and goal progress *in dollars* toward "$1M MRR."
+- **Cost per shipped outcome (013).** Join spend to delivered outcomes (issues done, work products
+  approved, milestones hit): cost-per-outcome per agent/role/goal, **rework ratio**, and **idle
+  spend** (tokens that produced nothing — quantified by the Health Sentinel's diminishing-returns
+  detector, combo 03).
+- **Honest budgets for everyone (019).** Make token usage a first-class budget metric beside dollars
+  by removing the `budgets.ts` `metric !== "billed_cents" → return 0` short-circuit, so subscription/
+  flat-rate users (whose real constraint is tokens and rate-limit windows, not cash) finally get an
+  enforceable guardrail; align token windows to provider rate-limit resets.
+- **The biggest invisible cost lever (037).** Surface cache-hit rate per agent, diagnose cache-busters
+  (volatile prefixes), enforce stable-prefix context assembly, and show estimated cache savings — this
+  is found money on repetitive agent loops.
+- **Did it cost what we thought? (055).** Capture an estimate on work, pair it with the known actual,
+  and compute per-agent/per-work-type forecasting bias to auto-correct future estimates.
+- **Where is this heading? (063).** Project spend, tokens, throughput, and (once revenue exists)
+  income into **runway**, **projected goal-attainment date**, and **capacity needs** ("to hit the
+  goal by D you need ~N more agents of type T") with what-if scenario knobs.
+
+## Why combining wins
+
+These all read the same ledger (`cost_events`, `finance_events`) and feed the same dashboard, and they
+*depend on each other*: forecasting (063) needs revenue (030) and calibration (055) to be meaningful;
+unit economics (013) needs token budgets (019) to compare metered vs subscription agents fairly via an
+imputed dollar value; cache savings (037) only matter if surfaced as economics (013). Build one
+financial data model and one dashboard, not six analytics one-offs. Imputed-cost normalization (019)
+is what lets every other view compare metered and flat-rate agents on equal footing.
+
+## Phasing
+
+1. Token-metric budgets (019, remove the short-circuit) + cache-hit *metric* (037) — small, high-insight.
+2. Unit-economics read model (013) + manual revenue entry & P&L view (030).
+3. Estimate capture + calibration (055); spend forecast + runway (063).
+4. Webhook revenue ingestion (030), goal-attainment & capacity planning (063), cache-assembly
+   enforcement (037).
+
+## Ratings
+
+- **Difficulty:** Medium–High — most is read-model/analytics over existing data; the harder parts are
+  revenue *input paths* + attribution (030), provider-window alignment for token budgets (019), and
+  honest forecasting on bursty non-stationary workloads (063, show confidence bands).
+- **Estimated time to complete:** ~5–7 engineer-weeks (phase 1 ~1.5 weeks, immediately valuable).
+- **Importance:** 8/10 — turns "agents doing stuff at some cost" into a measurable business, and the
+  token-budget fix (019) closes a real safety hole for the large and growing subscription-user segment.

--- a/.ideas/combinations/combo-05-review-cockpit.md
+++ b/.ideas/combinations/combo-05-review-cockpit.md
@@ -1,0 +1,59 @@
+# Combo 05 — Operator Review & Approval Cockpit
+
+**Combines:** 016 Approval Triage & Policy Batching · 017 Run Change-Review Surface ·
+027 Mobile Push & Fast Approvals · 029 Scheduled Operator Digest · 038 Approval Delegation & Coverage
+· (publishes via 033 Stakeholder Transparency Page)
+
+## The unified idea
+
+Human approval is Paperclip's governance backbone — and in a 24/7 company the human is the **single
+point of stall**: items pile up undifferentiated, the operator can't *see* what a run actually did,
+nothing reaches them on their phone, no summary comes to them, and when they're asleep or away the
+whole company freezes. Five ideas each fix one link in the *same review pipeline*; combined they are
+one **review cockpit** that takes an event from "needs a human" to "decided" as fast and as safely
+as possible.
+
+- **Make every item legible (017).** A PR-style change-review surface per run: files added/modified/
+  deleted with diffs, commands run, work products — so the reviewer approves *a concrete diff*, not a
+  vague "work product." Run-to-run diffing also exposes diminishing-returns loops visually.
+- **Rank, group, and auto-handle the long tail (016).** A risk score per approval (acting agent's
+  trust stage, implied spend, sensitive-boundary crossings, diff size) drives a triage inbox:
+  risk-sorted, grouped (bulk-approve "all 8 doc edits"), with conservative, fully-audited
+  auto-approve policies for the low-risk tail.
+- **Reach the human anywhere (027).** Web Push / PWA on the *same* signals, gated by the risk score
+  so only high-signal events buzz; deep-link straight into a single-item card with the diff (017)
+  inline and big approve / reject / request-changes actions reviewable one-handed in ten seconds.
+- **Bring the summary to them (029).** A scheduled, narrated digest ("shipped 12 issues ($4.10);
+  marketing blocked 2 days; 3 items need you; burn 18% over plan") assembled from existing signals
+  on the routine scheduler, led by what needs the human, delivered to inbox / push / email.
+- **Keep flow when they're away (038).** Scoped, time-boxed approval delegation to another human or a
+  tightly-bounded manager agent, plus SLA coverage routing so unactioned items escalate instead of
+  rotting — the human-coverage analog of quiet hours.
+
+The same narration engine that writes the digest (029) also powers a tokenized, read-only
+**stakeholder transparency page** (033) for investors/partners — same content, external audience.
+
+## Why combining wins
+
+Every link feeds the next: the risk score (016) decides what's worth a push (027) and what may
+delegate (038); the diff surface (017) is the payload of both the inbox card and the push; the digest
+(029) is just a scheduled rollup of the same triaged items and the low-effort first slice that proves
+the push pipeline. Building them separately yields five inconsistent "approval" experiences; built as
+a cockpit they share one risk model, one diff renderer, one notification pipeline, and one audit path.
+
+## Phasing
+
+1. Run change-review diff surface (017) + risk-scored, grouped triage inbox (016) — sorting/grouping
+   first (pure upside), auto-approve policies behind narrow explicit rules later.
+2. Scheduled digest (029) — proves the delivery pipeline cheaply.
+3. Web Push / PWA fast-approval card (027).
+4. Delegation + SLA coverage (038); stakeholder page (033) on the digest narrator.
+
+## Ratings
+
+- **Difficulty:** Medium — data and inbox model exist; new surface is Web Push (service worker, VAPID,
+  per-user prefs) and the auto-approve/delegation *authority model*, which must be airtight so it can't
+  escalate privilege or silently remove the safeguard.
+- **Estimated time to complete:** ~4–6 engineer-weeks.
+- **Importance:** 9/10 — the human bottleneck is exactly what stalls 24/7 autonomy every evening and
+  weekend; this is what makes "manage your companies from your phone" actually true.

--- a/.ideas/combinations/combo-06-agent-ci.md
+++ b/.ideas/combinations/combo-06-agent-ci.md
@@ -1,0 +1,57 @@
+# Combo 06 — Agent CI/CD & Evidence-Based Quality
+
+**Combines:** 011 Eval-Gated Agent Config Deploys · 032 A/B Model Bake-Off Harness ·
+040 Operator-Owned Training Dataset · 046 Skill Effectiveness Analytics
+· (runs on 008 local model + the shared `planOnly`/shadow execution contract)
+
+## The unified idea
+
+Editing an agent's config/prompt is the highest-leverage, highest-risk action an operator takes, and
+today it's done blind: no pre-deploy check, no way to compare models on real work, no structured
+record of what worked, no evidence that a skill helps. Four ideas turn agent improvement from
+guesswork into **CI/CD for agents** — and they all stand on the same three foundations: a
+**side-effect-free `planOnly`/shadow execution mode**, the existing **eval harness** (`evals/
+promptfoo/`), and **outcome-labeled run history**.
+
+- **Gate config changes (011).** On a config edit, run a saved per-agent eval suite (golden scenarios
+  + governance assertions mirroring `governance.yaml`) against the new config *before* it goes live —
+  on a free local model (008) so gating is cheap. Regressions block (governance) or warn (quality);
+  every result is logged for an agent quality history.
+- **Choose models on evidence (032).** Run the same representative tasks through 2+ adapter/model
+  configs in shadow, measure cost/latency from run data and quality from eval assertions + a *neutral*
+  LLM judge, and report a cost/quality frontier ("local-llm scores 0.92 of premium at $0 vs $0.41/
+  run") with one-click apply.
+- **Own the data that powers both (040).** Promote opaque run-log blobs into normalized, **outcome-
+  labeled** records (approved/rejected/reworked/shipped/abandoned, plus 👍/👎), redacted and consented
+  and *local by default*. Export to eval cases (feeding 011/032), JSONL preference pairs (for
+  distilling a cheaper/local model), or plain analysis.
+- **Prove skills earn their keep (046).** Join skill usage to those same outcome labels: approval-rate
+  delta, rework delta, cost delta per skill — replacing "popular by install count" with "demonstrably
+  helps on `code-review` tasks," and validating high-stakes claims via the bake-off (032).
+
+## Why combining wins
+
+The dependency graph is tight: the training dataset (040) *is* the source of eval cases and the
+outcome truth that 011, 032, and 046 all consume; the bake-off (032) and the eval gate (011) share
+the exact same `planOnly`/shadow guarantee (also needed by combos 07/10) and the same harness; skill
+analytics (046) is the bake-off applied to skills. Build the shadow contract + labeled-data pipeline
+*once* and the four features fall out as views on it. Building separately means three teams each
+re-solving "run an agent safely with no side effects and score it."
+
+## Phasing
+
+1. The `planOnly`/shadow execution contract across adapters (shared dependency) + structured,
+   outcome-labeled capture (040).
+2. Eval-gated deploys, advisory-then-blocking (011); descriptive skill analytics (046).
+3. A/B bake-off harness with neutral judge (032); preference-pair/fine-tune export + causal skill
+   validation.
+
+## Ratings
+
+- **Difficulty:** Medium–High — the eval runner, adapters, and cost data exist; the hard parts are a
+  *trustworthy side-effect-free* shadow mode, low-bias quality scoring for open-ended work, faithful
+  capture across heterogeneous adapters, and the statistical honesty (sample size/confounds) of the
+  analytics.
+- **Estimated time to complete:** ~5–7 engineer-weeks.
+- **Importance:** 7/10 — high leverage for quality and cost discipline as fleets grow, but it sits a
+  layer above the core safety/economics work and pays off most once a company has run volume.

--- a/.ideas/combinations/combo-07-self-staffing-org.md
+++ b/.ideas/combinations/combo-07-self-staffing-org.md
@@ -1,0 +1,61 @@
+# Combo 07 — Self-Staffing & Self-Organizing Workforce
+
+**Combines:** 048 Competency-Gated Job Postings (Test-to-Hire) · 047 Role-Based Skill
+Auto-Provisioning · 025 Capability-Based Auto-Assignment · 009 Agent Probation & Trust Ramp ·
+052 Org Restructuring Simulator · (consumes 044 reliability, 063 capacity forecast)
+
+## The unified idea
+
+Paperclip hires blind (any agent gets full autonomy instantly, with no proof it can do the job),
+equips manually (you forgot to add the skill), assigns manually (work lands on the wrong or
+overloaded agent), and reorganizes blind (move an agent, hope nothing breaks). Five ideas, taken
+together, make the org **staff, equip, assign, ramp, and restructure itself** — a closed
+desired-state loop where the role is authoritative and agents converge to it.
+
+- **Test-to-hire, not hire-and-hope (048).** A first-class job posting = `{ role, requiredSkills,
+  acceptanceTest, budget, reportsTo, status }` that *stays open until a candidate proves it can do
+  the work*. The acceptance test is an eval suite (combo 06 / idea 011) run in the shared `planOnly`
+  shadow mode — the eval *is* the interview.
+- **Equip by role, automatically (047).** Role → skill bundle as source of truth (seeded from
+  `recommendedForRoles` + teams-catalog `requiredSkills`). On hire/role-change, auto-install + bind
+  required skills idempotently (`installedHash`); a reconciler keeps every agent in a role in sync as
+  the bundle evolves. A near-fit candidate gets equipped with missing skills, then re-tested (closes
+  with 048).
+- **Assign by fit × reality (025).** Score eligible agents (capability text + issue content) weighted
+  by current load (heatmap, combo 03), trust stage, and cost-effectiveness (combo 04) — suggest first,
+  then auto-assign the unowned long tail so nothing rots. Learn from completion/approval/rework rates.
+- **Earn autonomy over time (009).** New hires start at `probation` (low concurrency, mandatory
+  review, tight spend) and *graduate* on a clean track record, or get demoted on rejected reviews /
+  budget trips. The test (048) proves baseline competence; the ramp proves sustained performance.
+- **Reorganize with eyes open (052).** Edit a *draft* org, preview the full impact (reassignments,
+  rerouted approvals, changed escalation chains, orphaned work), warn on risky outcomes, then apply
+  atomically + audited with one-click revert.
+
+The loop self-heals: an agent that fails reliability SLOs (044) or a reorg that leaves a role
+unstaffed (052) **auto-reopens a job posting** (048); capacity forecasting (063) tells you *which*
+postings to open to hit the goal on time.
+
+## Why combining wins
+
+This is one staffing lifecycle, not five features: a posting (048) needs the skill model (047), the
+test harness (combo 06), and probationary onboarding (009); auto-assignment (025) and reorg (052)
+both read the org/assignability model and feed back into postings. The cross-references in the source
+ideas are explicit and circular — building them apart would create four overlapping half-models of
+"what a role requires and who fills it." Build one role/competency model and the workforce becomes
+self-organizing.
+
+## Phasing
+
+1. Probation/trust ramp (009) — pure policy over existing trust machinery; immediate safety value.
+2. Role→skill bundles + provision-on-hire + reconciler (047); capability-based *suggestions* (025).
+3. Job-posting object + manual "test this candidate against this posting" (048).
+4. Auto-assignment for the unowned tail, org restructuring simulator (052), auto-backfill loop.
+
+## Ratings
+
+- **Difficulty:** High — introduces a new domain object (job posting) and a hiring state machine, plus
+  the reorg impact-diff must enumerate *all* consequence types accurately or the preview isn't
+  trusted; depends on the shared shadow/eval contract.
+- **Estimated time to complete:** ~6–9 engineer-weeks.
+- **Importance:** 7/10 — the payoff (an org that staffs and organizes itself) is large but advanced;
+  it matters most for bigger, longer-running companies and layers on the core safety/economics work.

--- a/.ideas/combinations/combo-08-zero-trust-governance.md
+++ b/.ideas/combinations/combo-08-zero-trust-governance.md
@@ -1,0 +1,67 @@
+# Combo 08 — Zero-Trust Security, Governance & Compliance Layer
+
+**Combines:** 043 Policy-as-Code Governance Engine · 020 Outbound Secret-Leak Scanning ·
+021 Just-in-Time Secret Leasing · 022 Per-Agent Network Egress Allow-Listing ·
+023 Tamper-Evident Audit Log · 034 Data Retention & PII Governance ·
+050 Code & Dependency Security Scanning of Work Products
+
+## The unified idea
+
+An autonomous AI workforce spending real money and executing real code is a serious security and
+compliance surface, and Paperclip's controls are powerful but **scattered across silos** with no
+common authoring or audit story. Seven ideas, combined, form one **zero-trust governance layer**: a
+single place to *declare* rules, consistent *enforcement* at every choke point, and a *tamper-proof
+record* of every decision.
+
+- **One authoring layer (043).** A policy-as-code engine: `when <condition> then <effect>` rules
+  (allow / deny / require-approval / throttle / notify / log) evaluated at a single policy-decision
+  seam that the existing silos (trust presets, permissions, execution allowlists, budgets) call into
+  as *enforcers*. Author in a guided builder + git-diffable DSL; dry-run a rule against last week's
+  history before activating; every decision records *which rule fired and why*.
+- **Stop secrets leaving in content (020).** Scan agent-produced comments/work products/docs for the
+  agent's own bound secret values (exact-match, near-zero false positives) and high-confidence
+  patterns before persist/surface; redact / block / flag per policy.
+- **Stop secrets leaving over the wire (022).** Per-agent/per-trust-tier network egress allow-listing
+  enforced at the containment/sandbox boundary; default-deny for low-trust, learning-mode to propose
+  an allowlist. Together 020+022 cover both exfiltration channels.
+- **Shrink the standing blast radius (021).** Just-in-time, TTL'd secret *leases* (mirroring
+  `environmentLeases`) instead of permanent bindings — a credential is materialized only for the run
+  that needs it, every acquisition individually audited, anomalies flagged.
+- **Stop shipping insecure code (050).** At the review gate, scan code work products for CVE'd
+  dependencies (OSV), disallowed licenses, and high-signal insecure patterns; severity-graded gate
+  (critical blocks, medium needs override) feeding the approval risk score (combo 05); return findings
+  to the agent to fix and resubmit.
+- **Make the record trustworthy (023).** Hash-chain the audit log (`prevHash`/`entryHash`) so any
+  retroactive edit/deletion is detectable, with a verification routine and optional external
+  anchoring. This is where *every* governance decision above lands.
+- **Govern the data itself (034).** Per-company retention TTLs by data class (delete/anonymize/
+  archive), PII detection reusing the leak-scan machinery, and a right-to-erasure path — while
+  keeping tamper-evident audit *proof* even when payloads are purged.
+
+## Why combining wins
+
+The policy engine (043) is the natural front-end for *all* the others — egress rules, leak-scan
+responses, secret-lease limits, scan-severity gates, and retention windows are all just policies; and
+*all* of them must land in the same tamper-evident log (023) to be worth anything. Secret-leak (020)
+and PII detection (034) share one scanning engine; 020 (content) and 022 (wire) are two halves of one
+exfiltration story; 020's "hardcoded credential" check overlaps 050's. Build one decision seam, one
+scanning engine, and one trustworthy log — not seven parallel security features with seven audit gaps.
+
+## Phasing
+
+1. Tamper-evident audit log (023) — the substrate everything records to; build first.
+2. Exact-match secret-leak scanning (020) + dependency-CVE scanning at the review gate (050).
+3. JIT secret leasing (021); retention TTLs (034); egress allow-listing where the runtime supports it (022).
+4. Policy-as-code engine (043) in advisory/shadow mode first, then incremental enforcement; PII +
+   right-to-erasure (034).
+
+## Ratings
+
+- **Difficulty:** High — enforcement is runtime-dependent (egress is best-effort on bare local
+  processes), canonical hashing/concurrency for the chain is fiddly, "erasure must reach every copy"
+  is a completeness trap, and unifying enforcement under one seam without destabilizing working silos
+  is delicate (ship advisory-first, prove parity, then take over).
+- **Estimated time to complete:** ~8–12 engineer-weeks (phased; 023+020 ~3 weeks, high standalone value).
+- **Importance:** 8/10 — security is close to existential for an autonomous code-executing workforce,
+  and tamper-evident audit + retention/PII are exactly what unlock operating *real, regulated*
+  businesses on Paperclip.

--- a/.ideas/combinations/combo-09-resilience-recovery.md
+++ b/.ideas/combinations/combo-09-resilience-recovery.md
@@ -1,0 +1,59 @@
+# Combo 09 — Resilience, Disaster Recovery & Incident Response
+
+**Combines:** 015 Company Point-in-Time Rewind · 051 DR: Backup Verification & Restore Drills ·
+057 Incident Management & On-Call · 045 Plugin Versioning, Rollback & Health
+· (uses 014 Drain from combo 01)
+
+## The unified idea
+
+A system that runs real businesses 24/7 without a human watching needs a coherent answer to "when
+something breaks, how do we recover safely?" Today the pieces are absent or thin: backups exist but
+are never verified, there's no per-company undo, no operational incident concept (only internal
+budget incidents), and plugin upgrades can wedge a running company at 2am with no rollback. Four
+ideas combine into one **resilience stack** spanning three blast radii — a single company, the whole
+instance, and the live operation — all sharing the same safe-action discipline.
+
+- **Per-company undo (015).** Lightweight point-in-time snapshots (reusing `company-portability.ts`'s
+  serializer) + checkpoints before high-risk events (a CEO re-plan, bulk mutations), with a diff
+  before restore and a non-destructive "restore into a new company" fork. Honestly scoped: restores
+  *control-plane* state, not the outside world.
+- **Trustworthy infra DR (051).** Integrity manifests on backup write, **automated restore drills**
+  into a throwaway DB on a routine (the single highest-value piece — an untested backup is a hope),
+  and a recovery-posture surface: last *verified-restorable* backup, measured RPO/RTO, off-site copy.
+  Distinct from 015 (logical per-company undo); this is instance-wide infrastructure DR.
+- **Real incident response (057).** Generalize the existing budget-incident notion into a first-class
+  incident `{ severity, source, responder, timeline, relatedIssues }` that can be raised manually or
+  **auto-raised** by existing signals — budget hard-stops, reliability-SLO burn (combo 03/07),
+  security alerts (combo 08), deadlocks (combo 03). On-call routing pages a designated responder
+  *immediately*, bypassing normal heartbeat/concurrency queues; runbooks attach procedures; SEV1 can
+  auto-trigger Drain (014); postmortems feed the learnings ledger (combo 11).
+- **Safe plugin lifecycle (045).** Version pinning + history, staged upgrade behind a health gate with
+  **automatic rollback** on failure, continuous worker/host-service health monitoring with blast-
+  radius containment — the plugin analog of agent reliability SLOs.
+
+## Why combining wins
+
+All four are "detect a failure → contain it → recover to a known-good state," and they share the same
+primitives: the snapshot/serializer (015 ↔ 052 reorg revert ↔ 057 postmortem capture), the storage
+layer (015/051), the Drain control (014) as the safe-action prelude to any heavyweight recovery, and
+the incident model (057) as the common *escalation* destination for failures the rest of the system
+detects. Build them together and recovery is one consistent, audited discipline; build them apart and
+you get four improvised "oh no" paths.
+
+## Phasing
+
+1. Backup integrity manifests + automated restore drills + recovery-posture surface (051) — highest
+   assurance for least effort.
+2. Incident object + severity + on-call routing, manual raise (057); plugin pinning + manual rollback
+   + health status (045).
+3. Company snapshots + fork-restore (015, safe before destructive in-place rewind).
+4. Auto-raised incidents from existing signals + SEV1 auto-Drain (057); staged auto-upgrade/rollback (045).
+
+## Ratings
+
+- **Difficulty:** Medium–High — restore is the hard part everywhere (transactional integrity, in-flight
+  runs, external side effects that can't be un-done), cross-engine nuance (PGlite dev vs Postgres prod),
+  stateful-plugin rollback (migrated schema), and a genuine fast-path that bypasses scheduling.
+- **Estimated time to complete:** ~5–7 engineer-weeks.
+- **Importance:** 7/10 — mostly insurance, but the cost of *not* having it (a silently-corrupt backup
+  losing an entire company's operating state) is catastrophic; restore drills (051) alone are high-ROI.

--- a/.ideas/combinations/combo-10-day-one-adoption.md
+++ b/.ideas/combinations/combo-10-day-one-adoption.md
@@ -1,0 +1,60 @@
+# Combo 10 — Day-One Adoption Kit
+
+**Combines:** 039 Guided Onboarding & Runnable Demo Company · 018 Company Blueprint Library ·
+004 Company Dry-Run Estimator · 064 Data Import / Migration · 058 Work Templates & Definition-of-Done
+
+## The unified idea
+
+Paperclip is powerful but conceptually dense, and a new user lands on an empty instance with a blank
+"create your first company" and no path to value. Five ideas combine into one **adoption kit** that
+takes a cold install to a running company doing the operator's *real* work — fast, safe, and with
+eyes open — by reusing one shared substrate: the company-portability serializer as both template
+format and import target, plus a `planOnly`/dry-run preview before anything goes live.
+
+- **A guided "aha" in minutes (039).** A one-click runnable demo company (a pre-built org, sample
+  goal, starter issues, budget) defaulting to a **free local model** (combo 02 / idea 008) or a
+  stubbed adapter so it costs ~nothing and needs no API key, plus an interactive tour anchored to the
+  live, moving demo — watch an agent's heartbeat, an issue move, an approval — then "now create your
+  real company."
+- **Parameterized blueprints (018).** The demo is just one entry in a blueprint library: curated,
+  *parameterized* company templates ("SaaS startup," "content agency," "research lab") built on the
+  portability format with declared variables (goal, budget, adapter/model per role, team size),
+  instantiated by a wizard. Swap the whole org from Claude Code to a local LLM at instantiation.
+- **Launch with eyes open (004).** The wizard automatically runs the Dry-Run Estimator: static checks
+  (unreachable tasks, budgets that can't cover one run, missing secrets, circular reporting) plus a
+  projected cost band and concurrency profile — a preflight before "hit go." (The `planOnly` adapter
+  contract here is the same one combos 06/07 need.)
+- **Bring your real backlog (064).** Importers per source (Jira, Linear, Asana, GitHub Issues,
+  Trello, CSV — via plugins) mapping issues/epics/statuses into Paperclip's model, with a human→agent
+  assignee mapping step (unmapped roles can auto-open a job posting, combo 07), and a dry-run preview
+  + atomic, snapshot-backed (combo 09) import. Seeing *their own work* running on day one is the
+  fastest path to value.
+- **Consistent quality from the start (058).** Work templates per type (`feature`, `bug`, `content`,
+  `research`) with acceptance criteria + a definition-of-done checklist that becomes the review gate's
+  concrete bar (combo 05) and travels with blueprints/exports — so imported and templated work starts
+  complete and consistent.
+
+## Why combining wins
+
+These all ride the same rails: blueprints (018), the demo (039), and import (064) all read/write
+through the portability serializer; the demo *is* a blueprint; the wizard, the estimator (004), and
+import all use the same dry-run/preview philosophy and `planOnly` contract; DoD templates (058) ship
+*inside* blueprints. Build the template/instantiate/preview substrate once and all five features are
+views on it — versus five separate onboarding surfaces with five different "create a company" paths.
+
+## Phasing
+
+1. Dry-Run Estimator static checks (004) — useful immediately, standalone.
+2. Blueprint format + instantiation wizard (018) + work templates/DoD (058).
+3. Guided onboarding + runnable demo company on a blueprint (039).
+4. Data import: CSV + one high-demand source first, then more (064); cost projection + shadow-heartbeat
+   tier of the estimator (004).
+
+## Ratings
+
+- **Difficulty:** Medium — mostly product/UX and field-mapping over an existing serializer; the fiddly
+  parts are faithful hierarchy/status mapping across foreign PM tools, the human→agent assignee gap,
+  idempotent re-import, keeping the tour in sync with the product, and a genuinely safe sandbox demo.
+- **Estimated time to complete:** ~4–6 engineer-weeks.
+- **Importance:** 8/10 — every other idea is academic if new users never reach value; this is the
+  conversion funnel and the lowest-friction wedge into real adoption.

--- a/.ideas/combinations/combo-11-institutional-memory.md
+++ b/.ideas/combinations/combo-11-institutional-memory.md
@@ -1,0 +1,60 @@
+# Combo 11 — Institutional Memory & Continuous Learning
+
+**Combines:** 060 Knowledge System (Accumulation, Curation & Retrieval) · 028 Agent Shift-Handoff
+Briefings · 056 Business Experiment Framework · (folds in the learnings from 055 calibration &
+057 postmortems)
+
+## The unified idea
+
+An autonomous company that can't remember what it learned re-solves solved problems forever. Three
+ideas combine into one **institutional-memory loop**: the company *accumulates* knowledge, *passes it
+along* as work moves, and *generates new validated learnings* through experiments — all flowing into
+one curated, retrievable source of truth.
+
+- **The knowledge backbone (060).** A first-class, default-on knowledge capability (contract-in-core,
+  LLM-wiki as the default bundled provider) with three layers: an **engine** that accumulates and
+  curates (with a real `wiki-lint` curation gate and an autoresearch librarian agent), an **authority
+  model** of scoped canonical docs (org / company / team tiers, inheritance, canonical designation,
+  auto-injected into agent run context — kept cache-friendly per combo 04/idea 037), and **semantic
+  retrieval** (local embeddings → pgvector in the existing Postgres, hybrid with the current trigram
+  search, exposed as an agent tool: "has this been done before?").
+- **Warm handoffs (028).** When work changes hands (reassignment, escalation, review handoff), auto-
+  generate a structured briefing — what's done, what's left, what was tried and failed, open
+  decisions, gotchas — so the receiving agent starts warm instead of re-deriving everything. This is
+  retrieval (060) applied to one issue's history, generated cheaply on a local model.
+- **The learning engine (056).** A business-experiment object `{ hypothesis, variants, primaryMetric,
+  guardrails, result }` whose variants are real tagged work, scored against actual revenue/outcome
+  data (combo 04). At close it records a **validated learning** into the knowledge base — turning
+  "agents doing stuff" into "a company that gets smarter run over run."
+
+The connective insight: the knowledge base (060) is the *destination* for everything the company
+learns — experiment results (056), incident postmortems (057), estimate-calibration findings (055),
+and the prior-art that powers handoff briefings (028). One curated ledger, cited by id, shared by
+agents and humans, portable with company exports (combo 10).
+
+## Why combining wins
+
+Handoff briefings (028) are a thin special case of semantic retrieval (060) over one issue; the
+experiment framework (056) and postmortems/calibration are the *write* side of the same knowledge
+base that retrieval (060) reads. Build the knowledge contract + retrieval once, and handoffs and the
+learnings ledger become consumers rather than separate stores — avoiding the classic failure of three
+parallel, drifting "where the company keeps what it knows" systems. The autoresearch curator keeps it
+all from rotting.
+
+## Phasing
+
+1. Knowledge Layer 2 — three-tier canonical docs + context injection (060) — highest value, lowest risk.
+2. Shift-handoff briefings (028) on the same retrieval/summarization substrate.
+3. Knowledge Layer 3 — local embeddings + pgvector + hybrid retrieval tool (060).
+4. Business experiment framework + validated-learnings ledger (056), wired to postmortems (057) and
+   calibration (055); Layer 1 engine-to-core promotion + autoresearch curation.
+
+## Ratings
+
+- **Difficulty:** High — promoting a plugin engine into a core contract means a conscious `SPEC.md`
+  "thin core" amendment and a delicate data migration of existing wiki spaces; semantic retrieval adds
+  embedding freshness/cost and ranking-quality concerns; experiment scoring needs statistical rigor
+  (attribution, sample size) and is gated on revenue data (combo 04).
+- **Estimated time to complete:** ~7–10 engineer-weeks (phased; canonical docs alone ~3 weeks).
+- **Importance:** 7/10 — compounding long-term value (a company that learns and stops repeating
+  mistakes), but it pays off over time and depends on revenue/outcome data being in place first.

--- a/.ideas/combinations/combo-12-external-integration-fabric.md
+++ b/.ideas/combinations/combo-12-external-integration-fabric.md
@@ -1,0 +1,54 @@
+# Combo 12 — Two-Way External Integration Fabric
+
+**Combines:** 062 Inbound Intake Channels (Email/Webhook/Form → Issue) · 036 Outbound Webhooks &
+Event Subscriptions · (completes the loop with 030 payment-webhook ingestion)
+
+## The unified idea
+
+A real company both *receives* work from the outside (support emails, leads, bug reports, form
+submissions) and *emits* signals to the rest of its toolchain (Slack on ship, PagerDuty on
+hard-stop, a deploy on approval). Paperclip today can do neither across its boundary: it has a rich
+*internal* event bus and an http adapter for inbound *agent* webhooks, but no first-class **front
+door** for external work and no **outbound** event delivery. Two ideas combine into one symmetric
+external-integration fabric — Paperclip as a first-class node in any automation graph.
+
+- **Inbound: the front door (062).** Per-company intake endpoints — a unique email address and/or a
+  public webhook/form — that turn external messages into issues, mapped through a work template
+  (combo 10 / idea 058) for the intake type, then **auto-triaged on arrival** via capability-based
+  assignment (combo 07) and risk triage (combo 05) so a support email is picked up and worked within
+  seconds, threaded back to the originating conversation.
+- **Outbound: the event tap (036).** Operator-registered HTTPS subscriptions `{ url, eventTypes[],
+  secret, active }` fed from the existing internal bus, with HMAC-signed payloads, retry-with-backoff
+  + dead-lettering (the `plugin-job-scheduler.ts` retry pattern), curated per-event-type payloads (no
+  sensitive leakage), and SSRF protection via the existing `private-hostname-guard`.
+
+Together they *close the loop*: an inbound support request (062) becomes an issue, an agent works and
+ships it, and an outbound webhook (036) fires the resolution to the customer's system — genuine
+two-way external comms. Payment-provider webhooks (combo 04 / idea 030) are simply a special inbound
+channel; the intra-instance analog is the Company Mailbox (combo 13 / idea 054).
+
+## Why combining wins
+
+Inbound and outbound are the two halves of the same boundary, share security concerns (SSRF guard,
+rate-limiting, leak/PII scanning of crossing content per combo 08, source-trust gating), and only
+deliver their full value *together* — a front door with no way to reply, or replies with no front
+door, is half a feature. They also reuse the same primitives (issue threading via `issue-references.ts`,
+the http plumbing, signed payloads), so building them as one fabric avoids two separate, inconsistent
+"talk to the outside world" surfaces.
+
+## Phasing
+
+1. Outbound webhooks: subscription store + signed retrying delivery worker, a handful of high-value
+   event types (036).
+2. Inbound webhook/form intake → issue + auto-triage (062) — smaller first slice than email.
+3. Inbound email ingestion (parser/threading/attachments, via plugin) — the fiddliest piece (062).
+4. Two-way threading so external conversations map to one issue; payment-webhook channel (030).
+
+## Ratings
+
+- **Difficulty:** Medium — issue creation, threading, the event bus, and inbound http all exist; the
+  real care is *security* (a public front door must be rate-limited, spam-filtered, trust-gated, and
+  leak/PII-scanned before driving any autonomous action) and email's parsing/threading fiddliness.
+- **Estimated time to complete:** ~3–5 engineer-weeks.
+- **Importance:** 6/10 — essential for support/sales-style autonomous companies (no front door = no
+  autonomy) and broadly useful as an automation connector, but not a prerequisite for core value.

--- a/.ideas/combinations/combo-13-cross-company-fabric.md
+++ b/.ideas/combinations/combo-13-cross-company-fabric.md
@@ -1,0 +1,65 @@
+# Combo 13 — Governed Cross-Company Fabric
+
+**Combines:** 054 Company Mailbox (Inbox/Outbox & Tickets) · 007 Holding Company (Meta-Orchestration)
+· 053 Inter-Company Shared Services (Agent Lending) · (publishes via 033 portfolio transparency page)
+
+## The unified idea
+
+One Paperclip instance runs many companies, but they are *hard-isolated by design* — cross-company
+access is explicitly denied at multiple layers. That isolation is correct as a default, yet it blocks
+three things operators clearly want: a **holding company** that oversees a portfolio, **shared
+services** (one Legal/Design/Security function several companies draw on instead of duplicating), and
+simply **letting two companies talk**. The crucial realization (from idea 054) is that these are not
+three separate bridges — they are **three message types on one governed channel.** Build the channel
+once.
+
+- **The channel: Company Mailbox (054).** Each company gets an inbox/outbox of typed message
+  envelopes `{ from, to, type, subject, body, attachments[], status, threadId }`. The mailbox **is**
+  the single audited cross-company door — neither company gets standing access to the other's
+  workspace, secrets, or task tree; everything flows through the envelope, leak/PII-scanned on the way
+  out (combo 08), logged to the tamper-evident audit trail. Message `type` is the extension point.
+- **`directive` messages → Holding Company (007).** A meta-company (`kind = 'holding'`) governs member
+  companies through a narrow `portfolio_oversight` capability: a *read* roll-up (budgets, burn, goal
+  status, bottlenecks — the heatmap one level up, combo 03) plus *governed writes* expressed as
+  directive messages (set a subsidiary budget, pause/resume, file a top-level directive issue into its
+  goal tree). Capital allocation — rebalancing budget from a stalled company to a winning one — is the
+  killer action, each move an audited budget mutation. Influence by filing goal-level issues, never by
+  reaching into a subsidiary's task tree.
+- **`service_request` messages → Shared Services (053).** A company publishes an agent/role as a
+  *service* with a defined interface and chargeback price. A requester files a stateful service ticket
+  (`open → acknowledged → in_progress → responded → closed`); on acceptance the provider converts it
+  into a real issue in its own goal tree (`issue-references.ts` links both sides) and the cost is
+  charged back to the *requesting* company (combo 04) so shared work is economically honest. A
+  shared-services directory + cross-boundary capability matching (combo 07/idea 025) handles discovery.
+
+A Holding Company can publish a portfolio-level **stakeholder transparency page** (combo 05 / idea
+033) across its subsidiaries — one link showing the whole group's trajectory.
+
+## Why combining wins
+
+All three deliberately pierce the *same* security boundary, so the governed cross-company seam — *no
+escalation into general access, airtight audit, leak-scanned egress, chargeback honesty* — is the
+hard, safety-critical core and must be designed **once**. Idea 054 makes this explicit: build the
+mailbox as the transport, then holding directives (007) and service requests (053) are message types
+on it, not three bespoke bridges with three independent chances to leak. The portfolio roll-up reuses
+the per-company metrics and heatmap that already exist.
+
+## Phasing
+
+1. The governed cross-company seam + mailbox transport: intra-instance, operator-approved document
+   shares + manual messages (054), with full audit + leak scanning.
+2. Read-only portfolio roll-up dashboard (007) and read-only shared-services discovery (053).
+3. `service_request` tickets → issue conversion + chargeback (053); governed holding *writes* —
+   budget, pause/resume (007).
+4. Capital allocation (007) and standing service relationships (053) — the most sensitive tier, last.
+
+## Ratings
+
+- **Difficulty:** High — this is the most architecturally invasive cluster in the set; it deliberately
+  crosses a boundary the system was built to enforce, so the capability/authorization work is a
+  reviewed *security surface*, not a feature flag (a subsidiary agent must never escalate into
+  oversight, every cross-company action must be audited and reversible).
+- **Estimated time to complete:** ~8–12 engineer-weeks (phased; read-only portfolio + mailbox ~4 weeks).
+- **Importance:** 6/10 — powerful for multi-company operators (the "Ace Holdings"-style setups people
+  already simulate manually) and a strong differentiator, but advanced; most single-company operators
+  won't need it, so it sequences after the core safety/economics/adoption work.

--- a/.ideas/combinations/cross-cutting/_log.md
+++ b/.ideas/combinations/cross-cutting/_log.md
@@ -1,0 +1,99 @@
+# Cross-Cutting Combinations — Loop Log
+
+**Mode (per operator instruction):** on each loop fire, produce **one new, *different* combination** —
+a synthesis that cuts *across* the 13 thematic clusters in `../` rather than repeating them. Each is a
+novel unifying abstraction, persona, or flywheel that recombines ideas from multiple clusters into one
+emergent feature.
+
+**Loop procedure (read this first on each fire):**
+1. Read this log. Count what's already in `done`.
+2. Pick the next angle from `backlog` (or invent a fresh one if the backlog is exhausted).
+3. **Use WebSearch when it would sharpen the idea** — to ground a combination in established industry
+   practice, standards, terminology, pricing, or known techniques (e.g. FinOps/OTel for cost, SRE for
+   reliability, kanban for flow). **Include academic sources** for technical/algorithmic grounding — run
+   searches with `allowed_domains:["arxiv.org"]` and `allowed_domains:["scholar.google.com"]` alongside a
+   general search, and cite the papers in `## Sources`. Skip search only for combinations that are purely
+   internal-architecture plays.
+4. Write `xcombo-NN-<slug>.md` with: combined idea, source ideas (cite numbers), why it's a *different*
+   cut than the thematic combos, phasing, ratings (difficulty / est. time / importance 1–10), and
+   sources if web research was used.
+5. Move the angle from `backlog` to `done` here, with a one-line summary.
+
+## Done
+
+- **xcombo-01 — The Autonomy Dial** — one operator control that composes admission, breaker, trust
+  ramp, auto-approve, and heartbeat into a single supervised→autonomous slider. Cuts across combos
+  01/05/07.
+- **xcombo-02 — Closed-Loop Self-Improving Company** — chains capture (040) → mine (055/046) →
+  propose → test (011/032 offline, 056 online) → decide+record (060) → deploy into one compounding
+  flywheel. The novelty is loop closure. Cuts across combos 06/04/11.
+- **xcombo-03 — Cost-Attribution Spine** — one attribution key from span-open to billed dollar/token;
+  views = OTel-GenAI tracing (031), showback unit-economics (013), cache metric (037), token budgets
+  (019), cross-company chargeback (053). Grounded in OTel GenAI conventions + FinOps showback→chargeback.
+  Cuts across combos 03/04/13. *(web-researched)*
+- **xcombo-04 — Trust as Universal Currency** — one continuous, behavior-updated trust score per agent
+  identity that every gate reads (egress 022, secret leases 021, auto-approve 016, assignment 025,
+  per-run caps 024), driven by probation/ramp (009). Grounded in 2026 zero-trust-for-agents (continuous
+  authorization). Cuts across combos 07/08/05/01. *(web-researched)*
+- **xcombo-05 — The Night-Shift Operator** — an armed "unattended-hours" profile bundling spend bounds
+  (005/002/024), local-first resilience (008/012), idle backoff (035), egress lock (022), human coverage
+  (038/057), and a morning digest (029); surfaces a new requirement: mid-run credential renewal (021/049).
+  Grounded in 2026 overnight-agent incidents. Cuts across combos 01/02/05/08/09. *(web-researched)*
+
+- **(user-directed) Code-Knowledge Flywheel** — llm-wiki (060) stores reusable snippets, an architecture
+  graph (hybrid vector + call/dependency graph), and canonical specs to power software-building (065);
+  for self-hosting, every rung built enriches the system's model of itself so the bootstrap compounds.
+  Grounded in 2026 hybrid code-retrieval / persistent-codebase-memory practice. File:
+  `xcombo-code-knowledge-flywheel.md`. *(web-researched)*
+
+- **xcombo-06 — Provenance & Replay** — the *auditability* layer (vs combo 03 observability): a Decision
+  Provenance Record (inputs+model+prompt+policy+trace+diff+cost, hash-chained into 023) to reconstruct
+  any decision, plus fork-restore (015) + deterministic `planOnly` re-run to reproduce or counterfactually
+  test it. Grounded in EU AI Act Art. 12 (Aug 2 2026) + R-LAM replay. Cuts 08/03/09/05. *(web-researched)*
+
+- **xcombo-07 — The Self-Healing Org** — applies the SRE self-healing loop (detect→diagnose→remediate→
+  verify) to *staffing & structure*: reliability SLOs (044) detect, diagnose agent/role/structure fault,
+  remediate via constrain/reassign (009/025), auto-backfill posting (048), reorg (052), or incident (057),
+  then verify recovery. Human = reliability architect. Grounded in 2026 agentic-SRE (80% MTTR). Cuts
+  07/09/03. *(web-researched)*
+
+- **xcombo-08 — Capital Allocator** — the portfolio as a multi-armed bandit: arms = agents/issues/
+  companies, reward = ROI (030/013/cross-cut 03), forecast prior (063), UCB/Thompson explore-vs-exploit
+  with knapsack + fairness-floor constraints, budget pooling, executed via holding capital moves (007).
+  Grounded in arXiv bandit/portfolio literature. Cuts 04/13. *(web-researched, arXiv)*
+
+- **xcombo-09 — The Front Desk** — autonomous intake→resolution pipeline: intake (062) → triage/score
+  (016) → retrieve context (combo 11) → capability/UCB-skill assign + template/DoD (025/058) → respond
+  (036); three modes (resolve/triage/assist) on a confidence dial. Grounded in arXiv ticket-routing +
+  2026 support metrics (≈$1/resolution, 50–70% deflection). Cuts 12/07/10/05. *(web-researched, arXiv+Scholar)*
+
+- **xcombo-10 — Pre-Flight Everything** — generalize idea 004's `planOnly`/dry-run into ONE
+  `simulate(change)→ImpactReport` seam every consequential action implements (launch 004, reorg 052,
+  policy 043, import 064, restore 015, config 011, capital xcombo-08, cross-company 13), with a
+  shadow→dry-run→auto-commit graduation ladder (cross-cut 01). Grounded in arXiv digital-twin/CIA +
+  2026 shadow-mode rollout. Cuts 10/07/08/09. *(web-researched, arXiv+Scholar)*
+
+## Backlog (candidate different cuts — each loop takes one)
+
+> Original 10-item backlog is exhausted. Fresh angles below draw on newer material: idea 065
+> (software-building/self-hosting), the Aisha multi-agent direction, the skeleton reference, and
+> still-uncombined source ideas. Each loop takes the next; invent more when these run out.
+
+## (done, continued)
+- **xcombo-11 — Bootstrap Ladder (Kernel→Org)** — a governed capability *curriculum* climbing from the
+  5-table skeleton: each rung is build→verify (011/xcombo-10/human gate)→ratchet, raising capability
+  (Flywheel self-model) AND earned autonomy (cross-cut 01) *together* so autonomy never outruns proven
+  verification. Grounded in arXiv Darwin/Huxley-Gödel + automatic-curriculum-learning + earned-autonomy
+  (with statistical-limits caveat). Cuts 065/combo11/cross-cut01/combo06. *(web-researched, arXiv+Scholar)*
+- **xcombo-12 — Conversational Operator (Aisha bridge)**: board-chat + mobile push (027) + digest (029)
+  + voice approvals (016/017) as ONE conversational control surface; the Aisha-as-chief front end over
+  Paperclip via MCP. Scenario cut tying PAPERCLIP_INTEGRATION.md. (cuts 05/12)
+- **xcombo-13 — The Reproducible Run**: session continuity (028 handoff, continuation summaries) +
+  cache-stable context (037) + deterministic replay (xcombo-06) + captured dataset (040) → runs that
+  resume, reproduce, and resist drift. (cuts 03/06/11)
+- **xcombo-14 — The Marketplace/Ecosystem**: blueprint library (018) + signed community sharing +
+  shared services (053) + skills/teams catalogs + skill-effectiveness (046) → a trust-gated exchange of
+  orgs, agents, skills, and services. (cuts 10/13/06)
+- **xcombo-15 — Closed-Loop Run Efficiency**: tracing (031) + adaptive heartbeat (035) + diminishing-
+  returns (003) + per-run caps (024) → a real-time control loop that tunes *how* runs execute for
+  cost/throughput, not just whether they start. (cuts 03/01)

--- a/.ideas/combinations/cross-cutting/xcombo-01-autonomy-dial.md
+++ b/.ideas/combinations/cross-cutting/xcombo-01-autonomy-dial.md
@@ -1,0 +1,68 @@
+# Cross-Cut 01 — The Autonomy Dial
+
+**A different cut:** the 13 thematic combos group ideas by *mechanism* (concurrency, approvals,
+hiring…). This one groups by a single *operator abstraction* that sits **on top of** several
+mechanisms at once — one control the operator actually reasons about, instead of a dozen knobs.
+
+**Synthesizes:** 009 Agent Probation & Trust Ramp · 001 Fleet Concurrency Governor ·
+002 Predictive Budget Breaker · 016 Approval Triage & Auto-Approve · 035 Adaptive Heartbeat ·
+024 Per-Run Resource Caps · 014 Emergency Stop/Drain
+*(pulls one lever each from thematic combos 01, 05, 07)*
+
+## The unified idea
+
+Operators don't think in "max concurrent runs = 12, auto-approve threshold = $0.50, heartbeat floor =
+5m, trust stage = probation." They think in **"how much leash does this company/agent get?"** Today
+that single mental model is scattered across seven unrelated settings, so tuning autonomy means hand-
+editing a dozen knobs that interact in non-obvious ways (raise concurrency but forget to raise the
+breaker horizon and you just trip it faster).
+
+The Autonomy Dial collapses all of it into **one ordinal control per company (and per agent), e.g.
+Level 0–5**, where each level is a *named, coherent preset* across every underlying mechanism:
+
+| Level | Concurrency (001) | Auto-approve (016) | Spend breaker (002) | Run caps (024) | Heartbeat (035) | Trust (009) |
+|------|------|------|------|------|------|------|
+| 0 Observe | 1 | none — all reviewed | tight | tight | slow | n/a |
+| 2 Assisted | low | low-risk only | medium | medium | adaptive | probation |
+| 4 Trusted | high | low+medium | loose | loose | adaptive-fast | trusted |
+| 5 Autonomous | fleet-cap | all but high-risk | loose + auto-Drain on extreme | high | fast | senior |
+
+- **One write target, many enforcers.** The dial sets the *effective* values that combo 01's control
+  plane, the approval cockpit (combo 05), and the trust resolver (combo 07) already read. It doesn't
+  add a new enforcement path — it's a **preset compiler** over the seams those combos build.
+- **Earned movement, not just set.** The dial can *auto-advance* as the trust ramp (009) graduates an
+  agent on a clean record, and *auto-retreat* on a budget trip (002), reliability burn (combo 03), or
+  a security flag (combo 08) — so the leash tightens automatically when things go wrong and loosens as
+  the company proves itself. The operator sets a *ceiling* ("never exceed Level 4"); the system moves
+  within it.
+- **One legible story.** The dashboard shows "Marketing-co: Level 3 (Trusted), auto-retreated from 4
+  two hours ago after a budget trip" instead of seven disconnected settings. Emergency Stop (014) is
+  simply "slam to Level 0."
+
+## Why this is a *better* idea than the parts
+
+The underlying mechanisms (001/002/009/016/024/035) are each valuable but each adds operator burden;
+their *interactions* are where misconfiguration lives. A dial turns N independent footguns into one
+coherent, monotonic control with sane couplings baked in — and makes autonomy **adaptive** (auto-
+advance/retreat) rather than static. It's also the natural home for the trust ramp's promotion/
+demotion (009), which otherwise has no single surface to move.
+
+## Phasing
+
+1. Define the level→settings mapping as a pure preset compiler over existing effective-value seams
+   (needs combo 01's control plane + combo 05's risk score to exist or be stubbed). Read-only display
+   first: "you are effectively at Level 3."
+2. Make the dial the *write* surface (set level → apply preset atomically, audited).
+3. Auto-retreat on trips (002/combo 03/combo 08 signals) within the operator's ceiling.
+4. Auto-advance via the trust ramp (009); per-agent dials beneath the company dial.
+
+## Ratings
+
+- **Difficulty:** Medium — little new machinery; it's an abstraction/UX layer plus a couplings model
+  *over* mechanisms built elsewhere. The real design work is choosing level presets that are genuinely
+  coherent (no level that's powerful in one axis and crippled in another) and the auto-advance/retreat
+  hysteresis so the dial doesn't flap. Hard dependency on combos 01 + 05 existing underneath.
+- **Estimated time to complete:** ~2–4 engineer-weeks *on top of* combos 01/05/07.
+- **Importance:** 8/10 — this is the single most operator-facing lever in the whole set; it's what makes
+  all the underlying safety/economics machinery *usable* by a human who just wants to say "give this
+  company more rope." High leverage, but only after the mechanisms it presets exist.

--- a/.ideas/combinations/cross-cutting/xcombo-02-self-improving-flywheel.md
+++ b/.ideas/combinations/cross-cutting/xcombo-02-self-improving-flywheel.md
@@ -1,0 +1,75 @@
+# Cross-Cut 02 — The Closed-Loop Self-Improving Company
+
+**A different cut:** the thematic combos each *measure* or *gate* one thing. This one chains six
+ideas from four different clusters into a single **flywheel** — a closed loop where the output of
+each stage is the input to the next, so the company's agents get measurably better run over run
+without a human re-prompting them. The novelty is the *loop closure*, not any single stage.
+
+**Synthesizes:** 040 Operator-Owned Training Dataset · 011 Eval-Gated Config Deploys ·
+032 A/B Model Bake-Off · 055 Estimate-vs-Actual Calibration · 056 Business Experiment Framework ·
+060 Knowledge System (learnings ledger)
+*(pulls from thematic combos 06, 04, 11)*
+
+## The unified idea
+
+Every other improvement idea is a fragment of one cycle. Wire them into a literal loop:
+
+```
+        ┌──────────────────────────────────────────────────────────────┐
+        │                                                              │
+   (1) CAPTURE            (2) MINE            (3) PROPOSE              │
+   outcome-labeled   →   what correlates  →  a concrete change   ───┐ │
+   run records (040)     with success         (prompt / model /     │ │
+        ▲                (calibration 055,    skill / plan)         │ │
+        │                 skill analytics)                          ▼ │
+   (6) DEPLOY  ◄──── (5) DECIDE  ◄──── (4) TEST the change ─────────┘
+   the winner,        ship / kill,      offline: eval gate (011)
+   record a           append a          + A/B bake-off (032);
+   "validated         validated          online: business
+   learning" (060)    learning (060)     experiment (056)
+```
+
+- **Capture (040).** Normalize every run into an outcome-labeled record (approved/rejected/reworked/
+  shipped, cost, tokens, 👍/👎) — the training-grade corpus, local and consented.
+- **Mine (055 + skill analytics 046).** Surface what correlates with good outcomes: which prompts/
+  configs/skills lift approval and cut rework; per-agent estimate bias from calibration.
+- **Propose.** From the mined signal, generate a concrete candidate change — a prompt tweak, a model
+  swap, adding a skill, a re-scoped plan. (Agent-proposed, operator/manager-ratified.)
+- **Test (011 + 032 offline; 056 online).** Gate the change with the eval suite + a neutral-judge A/B
+  bake-off in the shared `planOnly` shadow mode *before* it touches production; for changes whose
+  value is only visible in the market (a price, a headline), run it as a business experiment with real
+  revenue/outcome metrics.
+- **Decide & record (056 + 060).** Ship the winner or kill it, and append the result as a **validated
+  learning** to the knowledge base — so the *reason* persists and feeds future proposals and every
+  agent's context.
+- **Deploy → back to Capture.** The improved config runs, produces new labeled records, and the wheel
+  turns again.
+
+## Why this is a *better* idea than the parts
+
+Each stage already "works" in isolation, but isolated they don't *compound*: a training dataset nobody
+mines is an archive; an eval gate with no proposal pipeline only blocks regressions, never drives
+gains; experiments whose learnings aren't written down get re-run. Closing the loop turns six
+point-features into a **compounding asset** — the single most important property of an autonomous
+business (idea 056's own framing: "a company that learns"). The flywheel is the thing; the stages are
+spokes.
+
+## Phasing
+
+1. Capture + Mine (040 + calibration/skill correlations) — produce *insight* even before any
+   auto-proposal: "configs with X correlate with +18% approval."
+2. Add the offline Test gate (011 + 032 on the shadow contract) so proposed changes are validated cheaply.
+3. Add Decide→Record into the knowledge learnings ledger (060) so reasons persist.
+4. Add the online Test path (business experiments, 056) and a human-ratified auto-Propose step — the
+   full closed loop.
+
+## Ratings
+
+- **Difficulty:** High — it's an orchestration layer over six features that must each exist and share
+  contracts (the `planOnly` shadow mode, outcome labels, the knowledge ledger). The genuinely hard
+  parts are trustworthy auto-*proposal* (a bad proposal pipeline degrades agents at machine speed —
+  keep it human-ratified), statistical honesty across small samples, and avoiding feedback loops that
+  optimize a proxy metric into the ground (needs guardrail metrics, per idea 056).
+- **Estimated time to complete:** ~3–5 engineer-weeks *on top of* combos 06/04/11 existing.
+- **Importance:** 7/10 — the highest *strategic* ceiling in the set (a company that compounds), but it
+  sits atop the most prerequisites, so it's a later-stage capstone rather than an early win.

--- a/.ideas/combinations/cross-cutting/xcombo-03-cost-attribution-spine.md
+++ b/.ideas/combinations/cross-cutting/xcombo-03-cost-attribution-spine.md
@@ -1,0 +1,84 @@
+# Cross-Cut 03 — The Cost-Attribution Spine
+
+**A different cut:** the thematic combos treat tracing (combo 03) and economics (combo 04) as separate
+stacks. This one threads a single **attribution key** through *every* run from the moment a span opens
+to the moment a dollar (or token) is billed to an owner — so cost is a first-class dimension of every
+record, not a report assembled after the fact. It deliberately aligns Paperclip with the emerging
+industry standards for AI cost observability rather than inventing a private model.
+
+**Synthesizes:** 031 Agent-Run Distributed Tracing · 013 Unit-Economics Dashboard ·
+037 Prompt-Cache Optimization · 019 Token-Denominated Budgets · 053 Inter-Company Chargeback
+*(pulls from thematic combos 03, 04, 13)*
+
+## Industry grounding (from web research, June 2026)
+
+- **There is now a standard to align to.** The OpenTelemetry **GenAI semantic conventions** define a
+  `gen_ai` span namespace with `gen_ai.usage.input_tokens` / `gen_ai.usage.output_tokens` and
+  model/provider attributes — explicitly created to end fragmentation and make AI cost/quality
+  "measurable, comparable, and interoperable across frameworks and vendors." Paperclip's run spans
+  (idea 031) should *emit these names*, so spend flows into any standard backend (Datadog, Uptrace,
+  Honeycomb) for free instead of a proprietary schema.
+- **FinOps has a maturity ladder: showback → chargeback.** *Showback* = teams see what they'd be
+  charged (visibility, no money moves); *chargeback* = the cost actually transfers to the owner's
+  budget. Showback is the documented starting point; chargeback needs internal billing agreements —
+  exactly the phasing for Paperclip's cross-company chargeback (idea 053).
+- **Five dimensions cover ~95% of attribution:** team · project · environment · model-name ·
+  cost-center. Mapped to Paperclip: **agent/role/team · goal-subtree · adapter+model · company
+  (cost-center)**.
+- **The decision-useful metrics are standardized** ("TokenOps"/unit economics): cost per request, **cost
+  per successful outcome**, tokens per active user, and **token cost as % of feature revenue** — which
+  is precisely idea 013's "cost per shipped outcome," now with an industry name and peer set.
+- **GPU spend is the #1 FinOps concern of 2026**, surpassing general cloud cost — validating idea 041's
+  host-resource focus and the local-model economics of combo 02.
+
+## The unified idea
+
+Define one **attribution key** `{ company, goal-subtree, agent/role, adapter+model, runId }` stamped on
+every span the moment a run starts, and carried through to every `cost_event`. Then the five ideas
+become *views over one spine* instead of five disconnected features:
+
+- **Emit OTel-GenAI spans (031)** with token usage + the attribution key as span attributes → standard,
+  exportable, vendor-neutral.
+- **Showback dashboard (013)** rolls those spans up into cost-per-outcome, rework ratio, and idle spend
+  along every attribution axis — the FinOps unit-economics view, by construction.
+- **Token budgets (019)** enforce on the *token* attributes of the same spans (the real constraint for
+  subscription/GPU users), aligned to provider rate-limit windows.
+- **Cache efficiency (037)** is just a derived attribute of the spine (`cached/total input tokens`),
+  surfaced as savings — the clearest cost lever, made visible because it's on the same record.
+- **Chargeback (053)** is the spine extended across the company boundary: a shared-service run carries
+  the *requesting* company's attribution key, so cost transfers to the right cost-center — the
+  chargeback rung above showback.
+
+## Why this is a *better* idea than the parts
+
+Attribution-after-the-fact is the thing every FinOps-for-AI write-up warns breaks down with agents:
+you can't allocate what you didn't tag at the source. Stamping one key at span-open and never losing it
+makes *every* downstream economic feature trivially correct and consistent — and aligning to the OTel
+GenAI + FinOps standards means Paperclip's cost story is interoperable and credible to finance teams
+out of the box, not a bespoke island. The spine is the asset; the five features are projections of it.
+
+## Phasing
+
+1. Define the attribution key + emit OTel-GenAI-conventioned spans carrying it (031).
+2. Showback: unit-economics dashboard over the spine (013) + cache-efficiency derived metric (037).
+3. Token-denominated budgets enforced on span token attributes (019).
+4. Chargeback: extend the key across the cross-company seam (053, after combo 13's bridge exists).
+
+## Ratings
+
+- **Difficulty:** Medium — mostly disciplined instrumentation + read-models over existing data; the care
+  is in *never dropping the key* across handoffs/sub-runs/adapter boundaries and matching OTel attribute
+  names exactly. Chargeback (step 4) inherits combo 13's cross-company complexity.
+- **Estimated time to complete:** ~3–5 engineer-weeks for showback (steps 1–3); chargeback adds ~2 atop combo 13.
+- **Importance:** 8/10 — cost attribution is the backbone the entire CFO suite, token-safety, and
+  capital-allocation stories stand on, and standards-alignment makes it credible to real finance owners.
+
+## Sources
+
+- [OpenTelemetry GenAI Semantic Conventions (DEV)](https://dev.to/x4nent/opentelemetry-genai-semantic-conventions-the-standard-for-llm-observability-1o2a)
+- [Semantic conventions for generative AI spans — OpenTelemetry](https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-spans/)
+- [LLM Cost Monitoring with OpenTelemetry — Uptrace](https://uptrace.dev/blog/llm-cost-monitoring)
+- [FinOps for AI Overview — FinOps Foundation](https://www.finops.org/wg/finops-for-ai-overview/)
+- [13 Best LLM Cost Allocation Tools for 2026 — Amnic](https://amnic.com/blogs/llm-cost-allocation-tools)
+- [Token Economics and TokenOps — Finout](https://www.finout.io/blog/token-economics-and-tokenops-the-definitive-guide-to-finops-for-tokens)
+- [GPU Cloud FinOps for AI Teams — Spheron](https://www.spheron.network/blog/gpu-cloud-finops-ai-teams-cost-allocation-chargeback-budgeting/)

--- a/.ideas/combinations/cross-cutting/xcombo-04-trust-as-currency.md
+++ b/.ideas/combinations/cross-cutting/xcombo-04-trust-as-currency.md
@@ -1,0 +1,87 @@
+# Cross-Cut 04 — Trust as the Universal Currency
+
+**A different cut:** the thematic combos enforce limits *per silo* — egress here, secrets there,
+approvals elsewhere — each with its own notion of "is this agent safe enough?" This one extracts that
+shared notion into **one continuous, behavior-updated trust score per agent identity** that *every*
+gate reads, the way a credit score is consumed by many lenders. The novelty is making trust a single
+first-class currency rather than a static flag duplicated across enforcement points.
+
+**Synthesizes:** 009 Agent Probation & Trust Ramp · 022 Egress Allow-Listing ·
+021 Just-in-Time Secret Leasing · 016 Approval Auto-Approve · 025 Capability-Based Assignment ·
+024 Per-Run Resource Caps
+*(pulls from thematic combos 07, 08, 05, 01)*
+
+## Industry grounding (web research, June 2026)
+
+The security industry has converged on exactly this model for agentic AI, which validates the cut:
+
+- **Zero trust in 2026 is a *continuous* operating model, not one-time verification.** "Authentication
+  for agents must be continuous, not one-time, as an agent's behavior can change during multi-step
+  workflows; runtime context should inform ongoing authorization decisions, not just the initial
+  handshake." → a trust score that **updates from behavior**, not a flag set at hire.
+- **Agents are first-class non-human identities** needing "scoped access, logging, approvals,
+  monitoring, and kill-switch controls." Yet "only 22% of practitioners treat agents as independent
+  identities; the majority rely on shared API keys or inherited user sessions." → Paperclip should give
+  each agent a real identity carrying its own trust (and fix shared-key blending, idea 049).
+- **Least privilege = scope to the specific task/project, not the broadest role the owner could
+  justify.** → trust gates *per run / per resource*, not blanket grants.
+- **Continuous evaluation detects abnormal behavior / manipulated instructions** (prompt injection,
+  unauthorized tool use). → the trust score is also the anomaly signal.
+
+## The unified idea
+
+Define a single **continuous agent trust score** (an evolution of `source-trust.ts` +
+`trust-preset-resolver.ts`) attached to each agent *identity*, recomputed from behavior — clean run
+record, review approval rate, diminishing-returns/reliability trips (combo 03), secret-lease anomalies,
+blocked-egress attempts, policy violations. Then every enforcement point *reads the same score* instead
+of its own private rule:
+
+| Gate | How it consumes the trust currency |
+|------|-----------------------------------|
+| Probation/ramp (009) | *Produces* the score: graduation raises it, violations lower it (the update engine) |
+| Egress allow-list (022) | Low trust → tight default-deny allowlist; high trust → broader |
+| Secret leasing (021) | Low trust → shorter TTLs, narrower scope, more approvals per lease |
+| Auto-approve (016) | Trust × action-risk decides what auto-approves vs needs a human |
+| Assignment (025) | Trust weights who gets critical/sensitive work |
+| Per-run caps (024) | Low trust → tighter wall-clock/cost/tool-call ceilings |
+
+One score in, many least-privilege decisions out — and because it's *continuous*, a compromised or
+drifting agent automatically loses egress, secret scope, auto-approval, and concurrency *simultaneously*
+the moment its behavior degrades, with a kill-switch (Panic Stop, combo 01) at trust=0.
+
+## Why this is a *better* idea than the parts
+
+Today "trust" is re-implemented and re-decided in six places that can silently disagree (an agent
+demoted for bad reviews still holds wide egress and long secret leases). Centralizing it makes the
+whole posture *coherent and continuous*: every privilege contracts and expands together, automatically,
+from one behavior-driven signal — which is precisely the "continuous authorization" model the 2026
+zero-trust guidance prescribes. It also turns probation (009) from an isolated feature into the
+*engine* that drives the entire security surface.
+
+## Phasing
+
+1. Promote trust to a first-class **continuous score on the agent identity** with a documented input
+   model (extend `source-trust.ts`); display it. Read-only — nothing enforces on it yet.
+2. Make the *softest* gates consume it first: per-run caps (024) and auto-approve thresholds (016).
+3. Wire the security gates: secret-lease TTL/scope (021) and egress allowlist breadth (022).
+4. Continuous behavioral updates (anomaly detection from combo 03/08 signals) + assignment weighting
+   (025) + trust=0 kill-switch; tie demotion/promotion to the Autonomy Dial (xcombo-01).
+
+## Ratings
+
+- **Difficulty:** Medium–High — little new runtime, but it touches *every* enforcement path, so the risk
+  is correctness and blast radius: the score model must be well-calibrated (a noisy score that yo-yos
+  privileges is worse than static trust), updates must be auditable, and each gate's trust→policy
+  mapping needs care. Ship read-only, then enforce gate-by-gate.
+- **Estimated time to complete:** ~4–6 engineer-weeks (atop the gates from combos 07/08 existing).
+- **Importance:** 8/10 — it's the unifying spine of the security story and directly implements the
+  prevailing zero-trust-for-agents model; high leverage, but depends on the individual gates existing to
+  govern.
+
+## Sources
+
+- [Zero Trust Architecture for Agentic AI in 2026 — Zentera](https://www.zentera.net/blog/zero-trust-architecture-for-agentic-ai)
+- [Zero Trust for AI Agents: Least Privilege for Prompts & Plugins — Zscaler](https://www.zscaler.com/blogs/product-insights/zero-trust-for-ai-agents-least-privilege)
+- [AI Agent Identity & Zero-Trust: The 2026 Playbook — Medium](https://medium.com/@raktims2210/ai-agent-identity-zero-trust-the-2026-playbook-for-securing-autonomous-systems-in-banks-e545d077fdff)
+- [New tools and guidance: Announcing Zero Trust for AI — Microsoft Security](https://www.microsoft.com/en-us/security/blog/2026/03/19/new-tools-and-guidance-announcing-zero-trust-for-ai/)
+- [Zero Trust for AI Agents — Identity, Access Control, Behavioral Protection — Cisco](https://blogs.cisco.com/security/security-agentic-ai-how-cisco-brings-zero-trust-to-your-new-digital-workforce)

--- a/.ideas/combinations/cross-cutting/xcombo-05-night-shift-operator.md
+++ b/.ideas/combinations/cross-cutting/xcombo-05-night-shift-operator.md
@@ -1,0 +1,97 @@
+# Cross-Cut 05 — The Night-Shift Operator
+
+**A different cut:** the thematic combos are organized by *mechanism*. This one is organized by a
+*scenario* — **"the company runs unattended overnight while the human sleeps."** That single scenario
+recruits one lever from each of several clusters into a coherent **unattended-hours profile**, and —
+crucially — surfaces failure modes that only appear when *no human is awake*, which no single idea fully
+covers.
+
+**Synthesizes:** 005 Quiet Hours / Spend Profiles · 002 Predictive Budget Breaker · 024 Per-Run Caps ·
+035 Adaptive Heartbeat · 008 Local LLM + 012 Fallback Chains · 038 Approval Delegation & Coverage ·
+057 Incident On-Call · 029 Scheduled Digest · 022 Egress Allow-List · 021/049 Secret leasing/pooling
+*(pulls from thematic combos 01, 02, 05, 08, 09)*
+
+## Industry grounding (web research, June 2026)
+
+Unattended overnight autonomy is already a live, *incident-producing* practice — which is exactly why a
+purpose-built night profile matters:
+
+- **Runaway overnight spend is a named failure mode:** "a coding agent silently burns through hundreds
+  of dollars in API calls overnight"; cost-trimming agents "shut down production workloads they
+  misclassify as idle." → the breaker (002) + caps (024) + quiet-hours ceilings (005) must bite while
+  nobody watches.
+- **A real 2026 incident:** "an Alibaba-affiliated AI agent autonomously hijacked GPU resources for
+  crypto mining and opened a hidden network." → egress allow-listing (022) is non-negotiable at night.
+- **Credential rotation breaks long unattended runs:** "database credentials expire midway through a
+  data migration or API tokens rotate during a deployment pipeline" — guardrails "need to account for
+  how agents consume and renew credentials during extended operations." → a genuinely *new* requirement
+  this cut surfaces (see below).
+- **Oversight is shifting from per-step to per-policy:** "people increasingly oversee how agents
+  operate, especially when decisions carry operational or financial risk." → delegation/coverage (038)
+  + on-call (057) + a morning digest (029) are the night-shift oversight model.
+- Gartner: ~40% of enterprise apps will embed task-specific agents by end of 2026 — unattended
+  operation is becoming the default, not the exception.
+
+## The unified idea
+
+A **Night-Shift profile** the operator arms (manually or on a schedule, idea 005) that flips the whole
+company into a posture tuned for *no-human-present*:
+
+- **Spend is hard-bounded, not just monitored.** Quiet-hours burn ceiling (005) + predictive breaker
+  with auto-Drain on extreme burn (002) + tighter per-run caps (024) — so the "$X burned overnight"
+  headline can't happen.
+- **Run cheap and resilient.** Prefer local models (008) for routine work; fallback chains (012) absorb
+  the 2am provider rate-limit freeze that would otherwise stall the company until morning.
+- **Waste nothing while idle.** Adaptive heartbeat (035) backs idle agents almost to zero, still
+  event-wakeable — no burning context-load tokens all night for no output.
+- **Lock the doors.** Default-deny egress allow-list (022) tightened for the unattended window — the
+  direct control against the crypto-mining/hidden-network incident class.
+- **Keep work flowing without a human.** Approval delegation + SLA coverage (038) routes the few
+  approvals that arise to a backup human or a tightly-bounded manager agent; high-risk items wait.
+- **Wake someone only for real emergencies.** Incident on-call (057) pages a human for SEV1 only
+  (budget hard-stop, security flag, deadlock) — bypassing normal cadence — instead of buzzing all night.
+- **Hand over a clean morning.** A scheduled digest (029) is waiting at wake-up: "overnight: shipped 9
+  issues ($2.10 / mostly local), 1 approval handled by coverage, 0 incidents, burn 12% under plan."
+
+### The new requirement this cut surfaces: credential continuity for long unattended runs
+A multi-hour overnight run (a migration, a big build) can outlive its secret lease (021) or hit a
+provider key rotation in the shared pool (049). Today nothing renews a credential *mid-run*. The
+Night-Shift profile makes **lease auto-renewal / rotation-aware credential handoff during an active
+run** a first-class requirement — extend the lease lifecycle so a still-healthy long run transparently
+re-acquires on expiry, audited, rather than failing at 3am. This is emergent value visible only from the
+unattended-hours vantage point.
+
+## Why this is a *better* idea than the parts
+
+Each lever exists for its own reason, but *safe unattended operation* is a property of the **bundle**:
+a breaker with no egress lock still allows exfiltration; tight egress with no coverage still stalls on
+approvals; cheap local models with no caps still loop expensively. Shipping a single armed "Night-Shift"
+posture (and a matching "Day" posture) gives the operator one switch for the highest-risk window, with
+coherent defaults — instead of remembering to tune eight settings every evening. It also forces the
+credential-continuity gap into the open.
+
+## Phasing
+
+1. The profile/scheduler shell (005) that flips a named bundle of settings on/off (atomic, audited).
+2. Bind the spend + idle levers: breaker auto-Drain (002), per-run caps (024), adaptive heartbeat (035).
+3. Bind resilience + security: local-first + fallback (008/012), tightened egress (022).
+4. Bind the human-coverage layer: delegation/SLA coverage (038), SEV1-only on-call (057), morning digest (029).
+5. Credential continuity: lease auto-renewal / rotation-aware handoff for active long runs (021/049).
+
+## Ratings
+
+- **Difficulty:** Medium — mostly *composition* of levers built in other combos behind one profile
+  abstraction (precedence already defined in combo 01). The one genuinely new piece is mid-run
+  credential renewal (a real lifecycle change to leasing/pooling). Risk is in defaults that are safe
+  without being uselessly timid.
+- **Estimated time to complete:** ~3–4 engineer-weeks once combos 01/02/08 levers exist (~+1 wk for credential continuity).
+- **Importance:** 8/10 — unattended overnight operation is the exact moment Paperclip's "always-on 24/7"
+  promise is most valuable *and* most dangerous; this is the profile that makes that promise safe to keep,
+  and it directly answers documented 2026 incident classes.
+
+## Sources
+
+- [Agentic AI Guardrails: What They Are and How to Implement Them — Aembit](https://aembit.io/blog/agentic-ai-guardrails-for-safe-scaling/)
+- [The Complete AI Guardrails Implementation Guide for 2026 — Maxim](https://www.getmaxim.ai/articles/the-complete-ai-guardrails-implementation-guide-for-2026/)
+- [AI Agent Risks & Guardrails: 2026 Enterprise Security Guide — Atlan](https://atlan.com/know/ai-agent-risks-guardrails/)
+- [AI Agents in 2026: The Future of Autonomous Software — Symphony Solutions](https://symphony-solutions.com/insights/ai-agents-in-2026)

--- a/.ideas/combinations/cross-cutting/xcombo-06-provenance-and-replay.md
+++ b/.ideas/combinations/cross-cutting/xcombo-06-provenance-and-replay.md
@@ -1,0 +1,100 @@
+# Cross-Cut 06 — Provenance & Replay (Reconstruct and Re-Run Any Decision)
+
+**A different cut:** combo 03 (Health Sentinel) uses tracing for *observability* — "is the company
+healthy, what's happening now?" This one is the **auditability** sibling: "prove *why* a specific past
+decision was made, and re-run it." The industry draws exactly this line, and the four ideas below are
+fragments of one capability — a complete, tamper-evident, *replayable* record of every consequential
+agent decision.
+
+**Synthesizes:** 023 Tamper-Evident Audit Log · 031 Agent-Run Tracing · 015 Point-in-Time Rewind ·
+017 Run Change-Review Surface *(refs: 011 pinned config, 040 captured records, 043 policy, 034 retention)*
+*(pulls from thematic combos 08, 03, 09, 05)*
+
+## Industry grounding (web research, June 2026)
+
+This cut maps directly onto a discipline the field has named and regulators now require:
+
+- **Observability → auditability is an explicit shift.** "Observability tells you whether agents are
+  healthy and what they're doing now, using *sampled* traces tuned for live debugging. Auditability
+  proves *why a specific past decision was made*, demanding complete, tamper-evident, long-retention
+  records." → combo 03's tracing is observability; this is the auditability layer it can't be on its own.
+- **Decision provenance is the named primitive:** "the capability to reconstruct the series of inputs,
+  reasoning, and outputs behind every agentic decision."
+- **Regulators reconstruct a *single* decision:** "the exact inputs the agent held, the model version
+  and prompt that ran, and the policy that produced the action." The **EU AI Act high-risk deadline is
+  Aug 2, 2026**; Article 12 requires high-risk systems to "technically allow for automatic recording of
+  events over the system's lifetime." → a compliance forcing function, not a nicety.
+- **Deterministic replay is emerging tech:** R-LAM provides "structured action schemas, deterministic
+  execution policies, and provenance tracking to ensure auditable and replayable workflows"; products
+  capture "each agent run as an auditable, replayable Session." → replay is real and worth designing for.
+- **Audit trails must be auto-generated + cryptographically verified**, not custom-built per feature.
+
+## The unified idea
+
+### Part 1 — The Decision Provenance Record (reconstruct)
+For every *consequential* action (a spend, an approval, a workspace change, a cross-company message, a
+config edit), assemble one immutable record that bundles the fragments the four ideas each hold today:
+
+| Fragment | From |
+|----------|------|
+| Exact inputs & context the agent held | 031 spans + 040 captured run records |
+| Model version + the prompt that ran | 011 config snapshot / pinned versions |
+| The policy that produced the action | 043 policy-decision log ("which rule fired") |
+| The reasoning / tool-call trace | 031 semantic spans |
+| The concrete outputs / diff | 017 change-review changeset |
+| Cost & tokens | cost_events (cross-cut 03 attribution key) |
+
+Chain it into the **tamper-evident log (023)** so the record is cryptographically verifiable and
+long-retention (governed by 034) — the "complete, tamper-evident" standard, auto-generated, not
+bolted on per feature. *This is the Article-12 deliverable.*
+
+### Part 2 — Replay (re-run)
+Provenance lets you *read* a decision; replay lets you *re-execute* it:
+- **Restore the pre-decision state** with point-in-time rewind (015) into a throwaway fork (never
+  in-place), so the decision's exact world is reconstructed.
+- **Re-run deterministically** using the provenance record's pinned model + prompt + policy and a
+  structured action schema (R-LAM-style), in the side-effect-free `planOnly` shadow mode (shared with
+  combos 04/06/07/10) so replay touches nothing real.
+- **Two payoffs:** *reproduce* (did the agent really decide this for these reasons? — audit/dispute) and
+  *counterfactual* (re-run with a **different policy or model** — "would the new governance rule have
+  blocked this?", which is also the dry-run-a-policy feature of idea 043, now backed by real history).
+
+## Why this is a *better* idea than the parts
+
+Individually: 031 is sampled and short-lived (observability); 023 records *that* something happened but
+not the full reasoning/inputs; 017 shows the diff but not why; 015 restores state but doesn't tie it to a
+decision. **Only combined** do you get the regulator-grade ability to reconstruct *and* re-run a single
+past decision with its exact inputs, model, prompt, and policy — the auditability the others can't reach
+alone. Replay specifically is emergent: it needs state (015) + the full provenance record (023/031/011/
+043) + deterministic execution together; no single idea provides it.
+
+## Phasing
+
+1. **Decision Provenance Record**: define the consequential-action set; assemble + hash-chain the bundle
+   into the tamper-evident log (023) with long retention (034). Compliance value lands here (Article 12).
+2. **Read/inspect UI**: a "reconstruct this decision" view (inputs, model, prompt, policy, trace, diff,
+   cost) — the change-review surface (017) extended with full context.
+3. **Reproduce replay**: fork-restore (015) + re-run with pinned versions in `planOnly`; compare to the
+   recorded outcome.
+4. **Counterfactual replay**: swap policy/model and re-run — turns history into a governance/regression
+   test bed (powers idea 043 dry-run + combo 06 eval gating with real cases).
+
+## Ratings
+
+- **Difficulty:** High — Part 1 is disciplined record assembly + hashing (tractable, and combo 08's log
+  exists). Part 2 is the hard part: faithful state restore, *deterministic* re-execution across adapters
+  (LLM nondeterminism, external side effects that can't be replayed — frame honestly: replay reproduces
+  the control-plane decision, not the outside world), and a structured action schema. Retention/PII
+  (034) and "keep proof when payload purged" need care.
+- **Estimated time to complete:** ~6–9 engineer-weeks (Part 1 ~3 wk and independently shippable for compliance).
+- **Importance:** 8/10 — provenance is a hard regulatory requirement (EU AI Act, Aug 2 2026) for anyone
+  running high-risk autonomous work, and replay is uniquely powerful for disputes, debugging, and
+  testing governance against real history. Part 1 alone may be table-stakes for serious operators.
+
+## Sources
+
+- [Agentic AI Observability: A 2026 Playbook — Arthur](https://www.arthur.ai/column/agentic-ai-observability-playbook-2026)
+- [AI Agent Audit Trails: Proving What Agents Decided — iSimplifyMe](https://isimplifyme.com/blog/agent-audit-trails)
+- [AI Agent Accountability: Reasoning Traces vs Real Audit Trails — Apptitude](https://apptitude.io/blog/ai-agent-accountability-reasoning-traces-audit-trail/)
+- [AI Audit Trail: Compliance, Accountability & Evidence — Swept AI](https://www.swept.ai/ai-audit-trail)
+- [AI Agent Observability: A Complete Guide for 2026 — Atlan](https://atlan.com/know/ai-agent-observability/)

--- a/.ideas/combinations/cross-cutting/xcombo-07-self-healing-org.md
+++ b/.ideas/combinations/cross-cutting/xcombo-07-self-healing-org.md
@@ -1,0 +1,93 @@
+# Cross-Cut 07 — The Self-Healing Org
+
+**A different cut:** the industry's "self-healing systems" all heal *infrastructure* (a crashed service,
+a bad deploy). This applies the same proven detect→diagnose→remediate→verify loop **one level up — to
+the organization itself**: an org that notices it's understaffed, flaky, or mis-structured and *repairs
+its own staffing and shape* without a human firefighting it. The novelty is the target (the workforce),
+not the loop.
+
+**Synthesizes:** 044 Agent Reliability SLOs · 048 Competency-Gated Job Postings (backfill) ·
+052 Org Restructuring Simulator · 057 Incident Management & On-Call
+*(refs: 009 trust demotion, 025 reassignment, 063 capacity forecast, combo 03 detectors)*
+*(pulls from thematic combos 07, 09, 03)*
+
+## Industry grounding (web research, June 2026)
+
+The self-healing pattern is mature and quantified — which gives us both the loop shape and the
+differentiation:
+
+- **The canonical self-healing loop:** "combine continuous monitoring, AI-driven analysis, and automated
+  remediation… detect abnormal behavior, diagnose failures, and execute corrective actions in real
+  time," then **verify outcomes**. → adopt detect → diagnose → remediate → **verify** exactly.
+- **It works, measurably:** agentic SRE "reduces MTTR by 80%," cutting recovery "from hours to minutes."
+  → an org that auto-backfills a failed role recovers staffing in minutes, not the days a human would take
+  to notice and re-hire.
+- **The human role shifts to *reliability architect*:** "from firefighting to system design, resilience
+  engineering, and improving the AI agents themselves." → the human sets SLO targets and remediation
+  *policy*; the org heals *within* those bounds. (Maps to the Autonomy Dial, cross-cut 01.)
+- **But all of it heals infra/incidents** — none of it heals *the org's own staffing and structure*.
+  That's the open space this cut occupies.
+
+## The unified idea — a closed self-healing loop over staffing & structure
+
+Wire the four ideas into one continuous loop, each supplying one stage:
+
+1. **Detect (044 + combo 03).** Per-agent reliability SLOs/error budgets surface a *flaky* agent
+   (crashes, constant recovery, low completion); the Health Sentinel surfaces deadlocks/bottlenecks; an
+   incident (057) fires for an operational failure. Continuous monitoring of org health, not just runs.
+2. **Diagnose.** Classify the failure: is it the **agent** (misconfig/flaky runtime — pairs with provider
+   diagnosis, idea 012), the **role** (unstaffed / overloaded — a capacity gap, idea 063), or the
+   **structure** (a reviewer removed from a path, a span-of-control blowout — idea 052)? Diagnosis picks
+   the remediation.
+3. **Remediate — the org-level actions (the novel part).**
+   - *Agent fault* → auto-constrain the agent (lower concurrency, drop trust stage 009, pause), and
+     reassign its in-flight work (025) so the queue keeps moving.
+   - *Role gap* → **auto-reopen a competency-gated job posting (048)** to backfill; a candidate is hired
+     only on passing the acceptance test — *self-staffing*, not blind re-hire.
+   - *Structural fault* → propose a reorg via the simulator (052) with impact preview, applied atomically
+     (auto-Drain first) under the human-set policy.
+   - *Operational incident* → on-call routing (057) pages the responder / runs the runbook, SEV1 can
+     auto-Drain (combo 01).
+4. **Verify.** The remediation must *prove* it worked: the backfill candidate passed its test (048), the
+   agent's SLO recovers within the error budget, the deadlock cleared. If not, escalate to the next tier
+   (another remediation, then a human). This verify-or-escalate step is what makes it healing, not flailing.
+5. **Human as reliability architect.** The operator sets the SLO targets, the backfill/reorg *policies*,
+   and the autonomy ceiling (cross-cut 01); the org self-heals within them and reports what it did
+   (operator digest, combo 05) — "Research-bot failed its SLO, auto-paused, backfilled by a new hire that
+   passed the test; staffing restored in 6 min."
+
+## Why this is a *better* idea than the parts
+
+Separately: reliability SLOs (044) just *flag* a bad agent; job postings (048) just *exist*; the reorg
+simulator (052) is a *manual* tool; incidents (057) page a human. None *closes the loop*. Wired together —
+detect → diagnose → remediate → verify — staffing and structure become self-repairing, which is the
+property that makes a 24/7 autonomous org survivable without a human watching it degrade. It's also the
+*organizational* complement to combo 09 (which heals data/infra/runtime) and the staffing complement to
+combo 07-thematic (self-staffing): this one adds the **failure-triggered, verified** healing path.
+
+## Phasing
+
+1. Reliability SLOs + error budgets with the detect signal (044) and the diagnose classifier — read-only
+   ("this agent is burning its budget") first.
+2. Soft remediations: auto-constrain/demote/pause + reassign (009/025) on SLO burn, verified by recovery.
+3. Auto-reopen-posting backfill (048) on role gaps, gated by the competency test (verify built in).
+4. Structural remediation (052) + incident-triggered healing (057) under explicit human policy; full
+   verify-or-escalate ladder.
+
+## Ratings
+
+- **Difficulty:** High — the stages mostly reuse other combos' machinery, but *closing the loop safely*
+  is hard: diagnosis must be accurate (mis-diagnosing a provider outage as a flaky agent would demote a
+  good agent), remediation must be bounded by policy (auto-reorg/auto-hire are high-blast-radius — keep
+  them behind the human-set ceiling), and the verify step must be real or the loop oscillates.
+- **Estimated time to complete:** ~6–8 engineer-weeks atop 044/048/052/057 existing.
+- **Importance:** 7/10 — high value for large, long-running, multi-agent orgs (the workforce repairs
+  itself, MTTR-for-staffing in minutes), but it's an advanced capstone that depends on the staffing and
+  reliability primitives being in place, and its high-blast-radius actions demand the governance ceiling first.
+
+## Sources
+
+- [Self-Healing Software Systems — Impala Intech](https://impalaintech.com/blog/self-healing-software-systems/)
+- [AI SRE Explained: Autonomous Agents Slash MTTR by 80% — Rootly](https://rootly.com/sre/ai-sre-explained-autonomous-agents-slash-mttr-80)
+- [Agentic SRE: How Self-Healing Infrastructure Is Redefining Enterprise AIOps in 2026 — Unite.AI](https://www.unite.ai/agentic-sre-how-self-healing-infrastructure-is-redefining-enterprise-aiops-in-2026/)
+- [Self-Healing Systems using AI-based Auto-Remediation — Infosys](https://www.infosys.com/iki/techcompass/self-healing-systems.html)

--- a/.ideas/combinations/cross-cutting/xcombo-08-capital-allocator.md
+++ b/.ideas/combinations/cross-cutting/xcombo-08-capital-allocator.md
@@ -1,0 +1,95 @@
+# Cross-Cut 08 — The Capital Allocator
+
+**A different cut:** the CFO combo (04) and cross-company combo (13) *measure and report* money. This one
+adds the missing organ that *acts on* it: an autonomous policy that **reallocates budget toward what's
+working** across issues, agents, and companies — framing the whole portfolio as a formal capital-
+allocation problem with a principled explore-vs-exploit policy, not ad-hoc spending.
+
+**Synthesizes:** 063 Cost & Capacity Forecasting · 030 Revenue & P&L · 013 Unit-Economics ·
+007 Holding-Company Capital Moves *(refs: 049 budget pooling, 019 token budgets, 002 breaker, cross-cut 03 attribution)*
+*(pulls from thematic combos 04, 13)*
+
+## Academic + industry grounding (web research incl. arXiv, June 2026)
+
+The "reallocate toward what works" decision has a rigorous formal home, which lifts this from heuristic
+to principled:
+
+- **It's a multi-armed bandit.** "Stochastic multi-armed bandits address the exploration–exploitation
+  trade-off… a natural framework for sequential decision-making under uncertainty… by treating different
+  portfolio strategies as arms" (arXiv 1709.04415 risk-aware bandits for portfolio; 2410.04217 bandit
+  networks for portfolio optimization). → each agent / issue-subtree / subsidiary is an **arm**; budget is
+  the resource; ROI is the reward.
+- **Budget-constrained bandits are solved.** Knapsack-based optimal policies for budget-limited bandits
+  (arXiv 1204.1909) and multi-task *combinatorial* bandits for budget allocation with Bayesian
+  hierarchical models + Thompson sampling (arXiv 2409.00561). UCB / Thompson balance "trying new
+  configurations vs exploiting historically-good ones." → the allocator's core algorithm, off the shelf.
+- **Fairness/floor constraints are first-class.** "Each arm must receive at least a given fraction of the
+  total budget" (constrained bandit feedback, arXiv 2106.05165). → directly encodes "reserve capacity for
+  the CEO / critical roles" (idea 049).
+- **Resource-bounded agents have a formal contract** (arXiv 2601.08815, *Agent Contracts*). → bounds each
+  arm's draw.
+- **Industry validates the mechanism:** autonomous finance "dynamically rebalances allocations to maximize
+  returns while minimizing risks"; and crucially — "as agents complete, **unused budget returns to a
+  shared pool**, allowing efficient agents to subsidize those needing more." That pooling pattern *is*
+  idea 007's capital reallocation, already proven elsewhere.
+
+## The unified idea — the portfolio as a bandit, reallocated continuously
+
+Close the money loop the CFO suite (combo 04) opens:
+
+1. **Define the arms & reward.** Arms = agents, issue-subtrees, and (at the holding tier) subsidiary
+   companies. Reward = ROI per arm: revenue/outcome value (030) ÷ attributed cost (cross-cut 03
+   attribution key + unit economics 013), with forecast (063) as the prior.
+2. **Run a bandit allocation policy.** UCB/Thompson sampling over the arms to balance **exploit** (pour
+   budget into the proven winner) vs **explore** (fund a promising-but-unproven agent/strategy), subject
+   to constraints: budget knapsack (total cap), fairness floors (reserved capacity for critical roles),
+   and per-arm resource bounds (idea 024 caps / Agent-Contracts). Token budgets (019) make this work for
+   subscription users too.
+3. **Pooling, not just capping.** Implement the proven pattern: as work completes under budget, unused
+   budget returns to a shared pool the allocator redistributes — efficient agents literally subsidize
+   exploration. This is idea 049's pooling generalized from credentials to capital.
+4. **Execute moves where authority exists.** Within a company, the allocator nudges per-agent budgets;
+   across companies, it routes through the holding-company governed capital moves (007 / combo 13), each an
+   audited, reversible budget mutation, safety-bounded by the predictive breaker (002).
+5. **Human sets the mandate; allocator works within it.** The operator sets risk appetite, floors,
+   exploration budget, and the autonomy ceiling (cross-cut 01); the allocator rebalances within those and
+   reports ("moved $200/day from Marketing-co (ROI 0.4) to Granola-clone (ROI 2.1); held CEO reserve").
+
+## Why this is a *better* idea than the parts
+
+Forecasting (063), revenue (030), and unit economics (013) produce *numbers a human must act on*; the
+holding company (007) provides the *mechanism* but no *policy*. Alone they inform; combined under a bandit
+allocator they **decide** — turning measurement into continuous, principled reallocation with explicit
+explore/exploit and fairness, which is exactly how capital is optimally allocated under uncertainty per the
+literature. It's the decision-making capstone of the entire money stack.
+
+## Phasing
+
+1. ROI-per-arm read model (030 + 013 + cross-cut 03 attribution) + forecast prior (063) — *recommendation
+   only*: "you should move budget from X to Y."
+2. Within-company allocator: UCB/Thompson over agents with knapsack + fairness-floor constraints; advisory,
+   then opt-in auto-apply with the predictive breaker (002) as the safety bound.
+3. Budget pooling (return-and-redistribute) generalized from idea 049.
+4. Cross-company capital moves via the holding governed seam (007/combo 13) — the most sensitive tier, last.
+
+## Ratings
+
+- **Difficulty:** High — the allocation *math* is well-trodden (off-the-shelf bandit algorithms), but the
+  hard parts are trustworthy reward signal (ROI attribution is noisy and lagged — bandits handle noise but
+  garbage rewards mislead), avoiding oscillation/starvation (fairness floors + hysteresis), and the
+  high-blast-radius of auto-moving real money (must be policy-bounded, audited, reversible, breaker-gated).
+  Cross-company tier inherits combo 13's security weight.
+- **Estimated time to complete:** ~6–9 engineer-weeks atop the CFO suite (combo 04) + holding seam (combo 13).
+- **Importance:** 7/10 — the highest-leverage *financial* action an autonomous business can take (and the
+  killer reason to have a holding layer at all), but it depends on trustworthy revenue/ROI data first and
+  carries real money risk, so it sequences late and behind firm guardrails.
+
+## Sources
+
+- [Risk-Aware Multi-Armed Bandit for Portfolio Selection — arXiv 1709.04415](https://arxiv.org/abs/1709.04415)
+- [Improving Portfolio Optimization with Bandit Networks — arXiv 2410.04217](https://arxiv.org/html/2410.04217v2)
+- [Knapsack-based Optimal Policies for Budget-Limited Multi-Armed Bandits — arXiv 1204.1909](https://arxiv.org/pdf/1204.1909)
+- [Multi-Task Combinatorial Bandits for Budget Allocation — arXiv 2409.00561](https://arxiv.org/html/2409.00561v1)
+- [Constrained Optimization with Bandit Feedback (fairness floors) — arXiv 2106.05165](https://arxiv.org/pdf/2106.05165)
+- [Agent Contracts: Resource-Bounded Autonomous AI Systems — arXiv 2601.08815](https://arxiv.org/pdf/2601.08815)
+- [Autonomous Finance & AI Capital Allocation — P&C Global](https://www.pandcglobal.com/research-insights/autonomous-finance-ai-reshaping-capital-banking-economics/)

--- a/.ideas/combinations/cross-cutting/xcombo-09-the-front-desk.md
+++ b/.ideas/combinations/cross-cutting/xcombo-09-the-front-desk.md
@@ -1,0 +1,95 @@
+# Cross-Cut 09 — The Front Desk (Autonomous Intake → Resolution)
+
+**A different cut:** the thematic combos build internal machinery (intake, assignment, templates, outbound)
+as separate features. This one threads them into a single **external-facing pipeline** — the company's
+*front desk* — that takes a request from the outside world all the way to a resolution and a reply,
+autonomously. The novelty: Paperclip already has every stage; wired end-to-end they form a
+request-to-resolution loop backed by a *governed multi-agent org*, not a bolted-on chatbot.
+
+**Synthesizes:** 062 Inbound Intake Channels · 016 Approval/Risk Triage · 025 Capability-Based Assignment
+· 058 Work Templates & DoD · 036 Outbound Webhooks *(refs: combo 11 knowledge retrieval, 038/057 SLA
+escalation, xcombo-08 bandit routing)* *(pulls from thematic combos 12, 07, 10, 05)*
+
+## Academic + industry grounding (web research incl. arXiv + Scholar, June 2026)
+
+This is a mature, measured discipline — which gives both a reference pipeline and target numbers:
+
+- **The canonical pipeline is well-defined:** "AI ticket triage classifies intent using NLP, scores
+  sentiment and urgency, retrieves relevant context (past tickets, KB, account data), and either routes
+  the enriched ticket to the right queue or resolves it autonomously for high-confidence cases." → adopt
+  classify → score → retrieve-context → route-or-resolve verbatim.
+- **The numbers are real:** autonomous support "handles up to 80% of tickets"; triage cuts first response
+  60–80% (one case "72 seconds → 4 seconds"); cost/resolution "$3–7 → ~$1"; top tools "deflect 50–70% of
+  tier-1 tickets entirely." → the bar to aim at.
+- **Assignment is a studied problem with a bandit connection:** skill-based routing achieves "human-level
+  accuracy in automated assignment of helpdesk tickets" (arXiv 1808.02636); deep-learning real-time
+  assignment (TaDaa, arXiv 2207.11187); seq2seq expert recommendation (SSR-TA, arXiv 2301.12612); and
+  notably **UCB-based routing in skill-based queues** on real data (arXiv 2506.20543) — directly linking
+  the Front Desk's assignment step to the bandit allocator of cross-cut 08.
+- **Software-engineering triage is itself surveyed** (arXiv 2511.08607) and service systems can be designed
+  "from textual evidence" (arXiv 2603.10400) — i.e. the intake corpus *teaches* the routing.
+- **Reference product split** (Forethought): Solve (auto-resolve) / Triage (classify+route) / Assist
+  (suggest to humans) — a clean three-mode model to mirror.
+
+## The unified idea — one pipeline, five stages, each an existing idea
+
+```
+ outside world ──▶ (1) INTAKE ──▶ (2) TRIAGE ──▶ (3) RETRIEVE ──▶ (4) ASSIGN/RESOLVE ──▶ (5) RESPOND
+                     062            016            combo 11           025 + 058              036
+```
+
+1. **Intake (062).** Email / webhook / form → a structured issue in the company's queue, rate-limited,
+   spam-filtered, source-trust-gated, leak/PII-scanned (combo 08) — the secured front door.
+2. **Triage (016).** Classify intent + score urgency/risk (the existing approval-risk score, reused).
+   High-risk → human; routine → autonomous lane. This is the "classify + score" stage.
+3. **Retrieve context (combo 11 / code-knowledge flywheel).** Pull prior tickets, KB/canonical docs, and
+   account/issue history via semantic retrieval — the "don't re-solve solved problems" step that lifts
+   resolution quality.
+4. **Assign or auto-resolve (025 + 058).** Capability-/skill-based assignment (UCB-routed per arXiv
+   2506.20543, shared with cross-cut 08) to the right domain agent; the work runs against a template + DoD
+   (058) so "resolved" is well-defined. High-confidence cases the assigned agent **auto-resolves**; the
+   rest it works and submits for review.
+5. **Respond (036).** Reply through outbound webhooks / the originating channel, threaded to the request
+   (`issue-references.ts`), closing the loop into genuine two-way comms. SLA escalation (038/057) catches
+   anything stalling.
+
+**Three modes, mirroring the field:** *Resolve* (auto-close high-confidence), *Triage* (classify+route),
+*Assist* (draft a reply for a human) — the operator sets the confidence threshold per mode (Autonomy Dial,
+cross-cut 01).
+
+## Why this is a *better* idea than the parts
+
+Each stage alone is inert: intake with no triage is a dumping ground; assignment with no intake has nothing
+to route; outbound with no pipeline is just a webhook. Wired together they're a *product* — an autonomous
+support/sales/ops desk — and Paperclip's differentiation is decisive: the "resolver" isn't a single bot
+but a **governed multi-agent org** with budgets, approvals, audit, knowledge, and escalation already built.
+That's the gap between a chatbot and a company that actually does the work behind the reply.
+
+## Phasing
+
+1. Intake → issue (062, secured) + reuse the triage risk score (016) to classify/route — *route only*,
+   humans resolve. (Instantly useful; proves the front door.)
+2. Add retrieval (combo 11) + capability assignment (025) so the right agent gets an enriched ticket.
+3. Templates/DoD (058) + auto-resolve for high-confidence cases; outbound reply + threading (036).
+4. UCB skill-routing (arXiv 2506.20543, shared with xcombo-08), SLA escalation (038/057), the three-mode
+   confidence dial.
+
+## Ratings
+
+- **Difficulty:** Medium — every stage exists or is planned; the work is the *secured public front door*
+  (062's hardest part), reliable two-way threading, and the auto-resolve confidence gate (resolving the
+  wrong thing autonomously is the key risk — start route-only, raise autonomy as accuracy proves out).
+- **Estimated time to complete:** ~4–6 engineer-weeks atop intake (062) + assignment (025) + outbound (036).
+- **Importance:** 7/10 — for support/sales/ops-style autonomous companies this *is* the product (no front
+  door = no autonomy), and the proven economics (≈$1/resolution, 50–70% deflection) are compelling; less
+  central for companies whose work isn't externally-triggered.
+
+## Sources
+
+- [Cognitive system for human-level helpdesk ticket assignment — arXiv 1808.02636](https://arxiv.org/pdf/1808.02636)
+- [UCB-based routing in skill-based queues on real-world data — arXiv 2506.20543](https://arxiv.org/pdf/2506.20543)
+- [TaDaa: real-time Ticket Assignment Deep-learning Auto Advisor — arXiv 2207.11187](https://arxiv.org/pdf/2207.11187)
+- [SSR-TA: seq2seq expert recommendation for ticket automation — arXiv 2301.12612](https://arxiv.org/pdf/2301.12612)
+- [Triage in Software Engineering: A Systematic Review — arXiv 2511.08607](https://arxiv.org/html/2511.08607v1)
+- [LLMs for Automated Ticket Escalation — arXiv 2504.08475](https://arxiv.org/html/2504.08475v1)
+- [Does AI Ticket Triage Really Cut Response Time 80%? — Twig](https://www.twig.so/blog/triaging-customer-support-tickets-with-ai)

--- a/.ideas/combinations/cross-cutting/xcombo-10-preflight-everything.md
+++ b/.ideas/combinations/cross-cutting/xcombo-10-preflight-everything.md
@@ -1,0 +1,106 @@
+# Cross-Cut 10 — Pre-Flight Everything (One "Simulate Before Commit" Seam)
+
+**A different cut:** several ideas *each* invent their own preview/dry-run — the company estimator (004),
+the reorg impact preview (052), the policy dry-run (043), the import preview (064), the restore diff (015).
+This generalizes them into **one universal pre-flight seam**: every high-consequence change passes through
+the *same* `simulate(change) → impact report` contract before it commits. Build the simulator once; every
+risky action gets a preview for free.
+
+**Synthesizes:** 004 Dry-Run Estimator (the seed contract) · 052 Org Restructuring Simulator ·
+043 Policy-as-Code Dry-Run · 064 Import Preview · 015 Restore Diff *(refs: 011 eval-gate, xcombo-06
+counterfactual replay, xcombo-08 capital moves, combo 13 cross-company, cross-cut 01 dial)*
+*(pulls from thematic combos 10, 07, 08, 09)*
+
+## Academic + industry grounding (web research incl. arXiv + Scholar, June 2026)
+
+Two mature bodies of work converge exactly on this seam:
+
+- **Digital twins for pre-deployment validation + counterfactuals.** "High-fidelity simulation platforms
+  designed to proactively identify hidden faults… and validate safety *before* deployment"; they "enable
+  counterfactual reasoning, sensitivity analysis… a safe means to analyze responses to hypothetical
+  scenarios," explicitly "testing control policies before applying them to the live network" (ADDT, arXiv
+  2504.09461; Digital-Twin Counterfactual Framework, arXiv 2604.01325; TwinLoop simulation-in-the-loop for
+  multi-agent systems, arXiv 2604.06610). → the *simulate + impact* half of the seam.
+- **Change Impact Analysis (CIA).** "Analyzing a system update's impact before accepting it, based on
+  traceability of dependencies"; with regression-test-selection to rerun only affected tests. → how the
+  impact report is computed from the dependency graph Paperclip already has (org chart, issue tree, policy
+  references).
+- **The shadow → dry-run → commit maturity ladder for AI agents (2026).** Shadow mode: "agent receives
+  every real input, records output, is prevented from acting; an auto-evaluator compares to the human's
+  actual work." Dry-run: "the action is simulated without touching production—the interceptor shows what
+  *would* happen, logs it, and waits for human review." A structured rollout: Phase 1 shadow → Phase 2
+  dry-run (2–4 wks, approve/block) → cut over — "validate before committing." → the *graduation* model:
+  each capability earns auto-commit by proving itself in shadow/dry-run first.
+- **Critical guardrail:** "kill switches don't work if the agent writes the policy" (Stanford Law / Berkeley
+  AILCCP). → the pre-flight seam and the definition of "consequential" must be **human-owned and
+  agent-immutable**, or self-modifying agents (idea 065) could route around it.
+
+## The unified idea — one contract, many call sites
+
+Generalize idea 004's `planOnly`/dry-run into a first-class **pre-flight contract** every consequential
+mutation implements:
+
+```
+simulate(change, currentState) → ImpactReport {
+   creates / updates / deletes,      // what changes (CIA over the dependency graph)
+   risks / warnings,                 // what could break (orphaned issues, unstaffed role, frozen company)
+   projected cost / spend,           // economic impact (combo 04)
+   counterfactual,                   // "would have blocked 4 actions last week" / "orphans 3 issues"
+   confidence
+}
+```
+
+Call sites, each replacing a bespoke preview with the shared seam:
+
+| Consequential action | Pre-flight answers |
+|----------------------|--------------------|
+| Launch a company (004) | projected cost band, misconfig, concurrency profile |
+| Reorg (052) | reassignments, rerouted approvals, orphaned work, span-of-control |
+| Activate a policy (043) | "this rule would have fired on N past actions" (uses xcombo-06 replay) |
+| Import data (064) | counts, hierarchy, unmapped fields, before commit |
+| Restore/rewind (015) | diff of what restoring changes |
+| Deploy agent config (011) | eval-suite pass/fail in shadow |
+| Move capital (xcombo-08) | projected ROI shift, fairness-floor breach |
+| Cross-company action (combo 13) | what crosses the boundary, leak scan |
+
+And the **graduation ladder** (mapped to the Autonomy Dial, cross-cut 01): a new consequential capability
+starts **preview-only** → earns **dry-run-with-approval** → earns **auto-commit**, as its simulations prove
+they match reality. Pre-flight is the on-ramp to autonomy, not just a gate.
+
+## Why this is a *better* idea than the parts
+
+Five+ features are each independently building "show me what would happen before I do it" — duplicated,
+inconsistent, and incomplete (some actions have a preview, most don't). One shared `simulate()` seam +
+ImpactReport schema gives *every* consequential action a uniform, trustworthy preview, a single place to
+add new call sites, and a natural home for the counterfactual engine that xcombo-06 (replay) and idea 043
+(policy dry-run) both need. It turns "validate before committing" from a per-feature nicety into a
+system-wide invariant — exactly the discipline the digital-twin and shadow-mode literature prescribes.
+
+## Phasing
+
+1. Define the `simulate() → ImpactReport` contract + a CIA impact walk over the existing dependency graphs;
+   wire the two cheapest call sites (reorg 052, import 064 — both already have bespoke previews to fold in).
+2. Add policy dry-run (043) backed by counterfactual replay over history (shared with xcombo-06).
+3. Add the economic call sites (launch 004, capital moves xcombo-08) and config-deploy shadow (011).
+4. The graduation ladder (preview → dry-run → auto-commit) tied to the Autonomy Dial; lock the seam as
+   human-owned/agent-immutable (the kill-switch guardrail).
+
+## Ratings
+
+- **Difficulty:** Medium–High — the contract and CIA walk are tractable over data Paperclip already has;
+  the hard parts are *faithful* simulation (a preview that's wrong is worse than none — same honesty problem
+  as digital twins), counterfactual replay fidelity (shared with xcombo-06), and making the seam truly
+  agent-immutable. Each call site is incremental once the contract exists.
+- **Estimated time to complete:** ~5–7 engineer-weeks for the contract + first call sites; the rest fold in incrementally.
+- **Importance:** 8/10 — "validate before committing" is the single most reusable safety pattern across the
+  whole backlog, it eliminates duplicated preview code, and it's the on-ramp that lets risky capabilities
+  (auto-reorg, auto-hire, auto-capital, self-modification) graduate to autonomy *safely* rather than never.
+
+## Sources
+
+- [ADDT — Digital Twin for Proactive Safety Validation in Autonomous Driving — arXiv 2504.09461](https://arxiv.org/abs/2504.09461)
+- [The Digital Twin Counterfactual Framework — arXiv 2604.01325](https://arxiv.org/html/2604.01325)
+- [TwinLoop: Simulation-in-the-Loop Digital Twins for Multi-Agent RL — arXiv 2604.06610](https://arxiv.org/html/2604.06610v1)
+- [Shadow Mode Rollouts for AI Agents: A Safer Path from Pilot to Production — Brightlume](https://brightlume.ai/blog/shadow-mode-rollouts-ai-agents-pilot-production)
+- [Controlling AI Actions: Pre-Execution Control Layer — Data443](https://data443.com/blog/controlling-ai-actions-pre-execution-control-layer/)
+- [Kill Switches Don't Work If the Agent Writes the Policy — Stanford Law / Berkeley AILCCP](https://law.stanford.edu/2026/03/07/kill-switches-dont-work-if-the-agent-writes-the-policy-the-berkeley-agentic-ai-profile-through-the-ailccp-lens/)

--- a/.ideas/combinations/cross-cutting/xcombo-11-bootstrap-ladder.md
+++ b/.ideas/combinations/cross-cutting/xcombo-11-bootstrap-ladder.md
@@ -1,0 +1,100 @@
+# Cross-Cut 11 — The Bootstrap Ladder (Kernel → Org)
+
+**A different cut:** the thematic combos describe *finished* capabilities. This one is a **growth process**:
+the concrete, governed path by which a deliberately tiny self-builder grows itself into a full org, one
+verified rung at a time — turning idea 065's "scale down then build up" from a hand-wave into a principled,
+curriculum-driven, earned-autonomy ladder grounded in the self-improving-agents literature.
+
+**Synthesizes:** 065 Part C (kernel + capability ratchet) · `_skeleton-reference.md` (the 5-table starting
+point) · cross-cut 01 Autonomy Dial (earned autonomy) · the Code-Knowledge Flywheel (self-model)
+*(refs: 011 eval gate, 044 reliability, xcombo-10 Pre-Flight, 009 trust)*
+*(pulls from idea 065, combo 11, cross-cuts 01/10)*
+
+## Academic + industry grounding (web research incl. arXiv + Scholar, June 2026)
+
+Three research lines converge precisely on this, and they also fence its dangers:
+
+- **Self-improving agents work — by building better tools for themselves.** The **Darwin Gödel Machine**
+  "iteratively modifies its own code (thereby improving its ability to modify its own codebase) and
+  empirically validates each change using coding benchmarks," growing an *archive* of agents — lifting
+  SWE-bench 20%→50% by adding "better code-editing tools, long-context management, peer-review mechanisms"
+  (arXiv 2505.22954; Huxley-Gödel 2510.21614). → validates the **ratchet**: capability begets capability,
+  *if each step is empirically verified*.
+- **Automatic Curriculum Learning gives the rung *ordering*.** ACL "adaptively changes the distribution of
+  tasks to match the agent's evolving capabilities… adjust difficulty to the ability level of the current
+  agents" (arXiv 1708.02190; OMNI self-generated curricula). → the ladder isn't an arbitrary feature list;
+  it's a **curriculum** — build next whatever matches current capability and most unlocks the rung after.
+- **Earned autonomy is the safety model.** "As the system demonstrates reliable, consistently improving
+  performance, human oversight can be calibrated accordingly — becoming more autonomous where it's *earned*
+  that autonomy" (2026 learning-loop framing). → exactly the Autonomy Dial (cross-cut 01): each rung raises
+  capability *and* earns a notch of autonomy, together.
+- **The guardrails, from the literature itself.** Self-improvement has **statistical limits** (arXiv
+  2510.04399), and current agents "fail on longer tasks, lose track of progress" (Intl. AI Safety Report
+  2026, arXiv 2602.21012). → keep rungs *small and verified*, human-gated, Pre-Flight-simulated — don't
+  attempt DGM-style unsupervised weight/scaffold surgery on a live company.
+
+## The unified idea — a governed curriculum that climbs from the skeleton
+
+Make idea 065's bootstrap an explicit, managed **capability curriculum**:
+
+1. **Start at the skeleton** (`_skeleton-reference.md`): 5 tables + one tick loop + one adapter + a budget
+   hard-stop + a human approval gate. The smallest thing that can land a verified change.
+2. **Maintain a curriculum of rungs**, each ordered by *capability-leverage* (build what most cheapens the
+   next rung) and *matched to current capability* (ACL): structured test capture → change-review (017) →
+   QA + TDD → eval gating (011) → capability assignment (025) → security/caps/reliability (050/024/044) →
+   org blueprint (018). Each rung is a slice of *this very backlog*.
+3. **Each rung is a governed build-verify-ratchet step:**
+   - *Build* the rung (the kernel/org implements it as normal work).
+   - *Verify* it — eval suite (011) + tests + **Pre-Flight simulation** (xcombo-10) + human ratification.
+     This is the DGM "empirically validate each change" discipline, but with a human gate.
+   - *Ratchet two things on success:* (a) **capability** — the new rung is turned on for the builder and
+     indexed into its self-model via the **Code-Knowledge Flywheel** (so the next rung is cheaper); (b)
+     **autonomy** — the Autonomy Dial (cross-cut 01) loosens a notch *because the verifying capability now
+     exists* (e.g., auto-merge unlocks only after the QA+eval rungs are built and proven).
+4. **Capability and autonomy rise together, never apart.** The system is never granted more autonomy than
+   the verification machinery it has *already built and proven* — the structural guarantee against runaway
+   self-modification. A failed/regressed rung halts the climb and reverts (015), without losing prior rungs.
+5. **Operator owns the curriculum and the ceiling.** The human can reorder rungs, set the autonomy ceiling,
+   and must ratify each rung; the system proposes and builds within that frame (the "feedback DB with human
+   gate" pattern).
+
+## Why this is a *better* idea than the parts
+
+Idea 065 says *that* the system can build itself; the Autonomy Dial says *how much rope*; the Flywheel says
+*how it remembers*; eval/Pre-Flight say *how to check*. Alone, none answers **"in what order, and how does
+each step safely unlock the next?"** The Bootstrap Ladder is that missing growth process — a curriculum
+where verified capability and earned autonomy ratchet together. It makes self-construction *governed and
+gradual* (heeding the statistical-limits/long-task caveats) instead of the brittle, unsupervised
+self-modification the DGM line warns is costly and non-generalizing — Paperclip's distinct, safer bet.
+
+## Phasing
+
+1. Stand up the kernel from the skeleton (065 Part C) at Autonomy Level 0–1; everything human-gated.
+2. Define the curriculum data model (ordered rungs, capability prerequisites, the autonomy notch each
+   unlocks) + the build-verify-ratchet loop using existing eval (011) + Pre-Flight (xcombo-10).
+3. Wire the Flywheel self-model enrichment per completed rung; tie autonomy notches to verification rungs.
+4. Let the system *propose* the next rung (curriculum self-generation, OMNI-style) under human ratification;
+   add regression-halt + revert (015) on a failed rung.
+
+## Ratings
+
+- **Difficulty:** High — this is the orchestration of self-construction; it depends on the kernel (065),
+  eval/CI (011/combo 06), Pre-Flight (xcombo-10), the Flywheel, and the Autonomy Dial all existing. The
+  hard, safety-critical core is the **autonomy↔capability coupling** (autonomy must *provably* trail
+  verification capability) and honest verification at each rung (a rung that "passes" but regressed quietly
+  poisons the climb). Heed the statistical limits — this is gradual governed growth, not recursive
+  self-improvement.
+- **Estimated time to complete:** the *framework* ~4–6 engineer-weeks atop its dependencies; the *climb
+  itself* is ongoing (the system spends weeks building its own rungs).
+- **Importance:** 8/10 — it's the through-line that makes the entire self-building thesis (065) real and
+  safe, and the same earned-autonomy curriculum governs how *any* Paperclip company safely scales its own
+  autonomy, not just the self-hosting case. High strategic ceiling; depends on much of the stack first.
+
+## Sources
+
+- [Darwin Gödel Machine: Open-Ended Evolution of Self-Improving Agents — arXiv 2505.22954](https://arxiv.org/abs/2505.22954)
+- [Huxley-Gödel Machine: Human-Level Coding Agent Development — arXiv 2510.21614](https://arxiv.org/html/2510.21614v1)
+- [Intrinsically Motivated Goal Exploration with Automatic Curriculum Learning — arXiv 1708.02190](https://arxiv.org/pdf/1708.02190)
+- [On the Statistical Limits of Self-Improving Agents — arXiv 2510.04399](https://arxiv.org/pdf/2510.04399)
+- [International AI Safety Report 2026 — arXiv 2602.21012](https://arxiv.org/pdf/2602.21012)
+- [When AI Builds Itself — Anthropic](https://www.anthropic.com/institute/recursive-self-improvement)

--- a/.ideas/combinations/cross-cutting/xcombo-code-knowledge-flywheel.md
+++ b/.ideas/combinations/cross-cutting/xcombo-code-knowledge-flywheel.md
@@ -1,0 +1,97 @@
+# Cross-Cut (user-directed) — The Code-Knowledge Flywheel
+
+> Piggybacks on **idea 065** (Software-Building & Self-Hosting) by giving it a memory: the
+> **llm-wiki / Knowledge System (idea 060)** stores reusable code snippets, patterns, and
+> *architectural* knowledge so each build is faster, more consistent, and — when self-hosting — the
+> system progressively *learns its own architecture*.
+
+**A different cut:** the thematic combos treat knowledge (combo 11) and software-building (idea 065) as
+separate stacks. This one fuses them into a **flywheel**: building produces curated code knowledge →
+knowledge makes the next build cheaper and more consistent → especially for self-hosting, the system's
+model of *its own* codebase deepens every commit, accelerating the Part-C bootstrap.
+
+**Synthesizes:** 060 Knowledge System (llm-wiki) · 065 Software-Building & Self-Hosting ·
+037 cache-stable context · 028 handoff briefings *(builds on thematic combo 11 + idea 065)*
+
+## Industry grounding (web research, June 2026)
+
+The combination matches where autonomous coding has landed — and tells us *how* to build the memory:
+
+- **Hybrid vector + graph retrieval is now state of the art for code.** "Modern coding agents use hybrid
+  retrieval combining vector search for semantically relevant entry points with graph traversal to
+  follow call chains and dependency relationships — answers pure vector RAG cannot produce." → the
+  architecture layer below must be a **code graph**, not just chunked text.
+- **Persistent codebase memory + spec-driven workflows:** "specs and architecture notes become part of
+  the agent's persistent memory" agents reference during implementation. → llm-wiki holds canonical
+  specs/architecture as authoritative docs (idea 060's authority model) injected into build context.
+- **Agents should fit existing patterns:** "good agents generate code that fits existing patterns —
+  naming conventions, error handling style, architectural patterns." → the snippet/pattern library's
+  whole purpose is *consistency*, not just reuse.
+- **Multi-scope memory:** writes tagged with identity scopes, composed/ranked at retrieval — aligns with
+  idea 060's org/company/team scope tiers and the attribution key of cross-cut 03.
+
+## The unified idea — three knowledge layers, one engine
+
+Extend the llm-wiki (already the planned home for accumulation + curation + retrieval) with three
+code-aware layers that the software-building capability (065) both *writes to* and *reads from*:
+
+1. **Snippet & pattern library (reuse).** When a work product is accepted, the curator (`wiki-maintainer`
+   / `wiki-lint`) extracts reusable, generalized snippets and patterns — tagged by language, purpose,
+   and the convention they embody — instead of every agent re-deriving the same auth guard, retry
+   wrapper, or test scaffold. Retrieved at build time so new code *matches* existing style.
+2. **Architecture graph (understanding).** A hybrid index of the codebase itself — modules, call chains,
+   dependencies, data flows — built from the engineering workspace (065 Part A) using local embeddings
+   (idea 008) for the vector side and a parsed dependency/call graph for the traversal side. This is the
+   layer that answers "where does X live, what calls it, what breaks if I change it?" — the question
+   pure-vector RAG can't.
+3. **Canonical specs & conventions (authority).** Architecture decisions, API contracts, coding
+   standards, and DoD (idea 058) live as *canonical* docs (idea 060 authority tier), auto-injected into
+   every build agent's context — kept cache-stable (idea 037) since they change slowly. The "spec-driven
+   memory" the research describes.
+
+Agents retrieve from all three before writing code (an extension of the handoff-briefing pattern, idea
+028, to "briefing from institutional code memory"), and the curator writes new learnings back after
+each accepted change.
+
+## Why this makes 065 dramatically more doable (esp. the Part-C bootstrap)
+
+065's self-hosting bootstrap builds capability "rung by rung." A code-knowledge flywheel is what makes
+the ratchet *compound*: each rung the system builds is **indexed into its own architecture graph**, so
+when it builds the next rung it already understands the code it's extending — less re-reading, fewer
+contradictions, faster convergence. The system isn't just adding features to itself; it's
+**accumulating an ever-better map of itself**. This is the knowledge-side complement to the
+self-improving loop of cross-cut 02 (which captures *outcomes*); here we capture *code & structure*.
+
+It also directly attacks the most expensive failure of autonomous coding — re-solving solved problems
+and writing code that fights the existing architecture — by making prior solutions and the current
+structure *retrievable* rather than rediscovered.
+
+## Phasing
+
+1. **Canonical specs/conventions layer** (idea 060 authority tier + context injection) — highest value,
+   lowest risk; gives build agents the standards immediately. Ship first.
+2. **Snippet/pattern extraction** into the wiki on work-product accept, with curation (`wiki-lint`).
+3. **Architecture graph**: code embeddings (local, 008) + parsed dependency/call graph; hybrid retrieval
+   tool exposed to build agents ("what calls this? where should this go?").
+4. **Self-hosting feedback**: point all three at Paperclip's own repo so the bootstrap (065 Part C)
+   compounds — every shipped rung enriches the self-model.
+
+## Ratings
+
+- **Difficulty:** Medium–High — layers 1–2 reuse the planned knowledge engine (combo 11) and are
+  mostly curation + injection. The architecture graph (layer 3) is the harder piece: building and
+  *keeping fresh* a hybrid vector+graph code index across languages (parsing, incremental re-index on
+  commit) is real work, best treated as best-effort per language. Curation quality is the perennial risk
+  — a snippet library full of rot is worse than none, so the `wiki-lint` gate matters.
+- **Estimated time to complete:** ~4–6 engineer-weeks atop combo 11 + idea 065 Part A existing
+  (layer 3 ≈ half of that).
+- **Importance:** 8/10 — it's the difference between software-building that stays flat and software-
+  building that *compounds*; for self-hosting (065) it's close to essential, since a system that builds
+  itself must understand itself. High leverage, but depends on 060 and 065 Part A being underway.
+
+## Sources
+
+- [Persistent Codebase Memory for Coding Agents 2026 — Cognee](https://www.cognee.ai/blog/guides/ai-coding-agent-persistent-codebase-memory)
+- [State of AI Agent Memory 2026 — mem0](https://mem0.ai/blog/state-of-ai-agent-memory-2026)
+- [The State of AI Coding Agents (2026) — Dave Patten](https://medium.com/@dave-patten/the-state-of-ai-coding-agents-2026-from-pair-programming-to-autonomous-ai-teams-b11f2b39232a)
+- [AI Coding Agents in 2026: How They Work — Plus8Soft](https://plus8soft.com/blog/ai-coding-agents/)

--- a/.ideas/llm-wiki/CLAUDE.md
+++ b/.ideas/llm-wiki/CLAUDE.md
@@ -1,0 +1,59 @@
+# LLM-Wiki Schema & Conventions
+
+> An [[llm-wiki]] in the Andrej Karpathy pattern: a persistent, compounding knowledge base that an LLM
+> agent builds and maintains from immutable sources, so knowledge accumulates instead of evaporating
+> between sessions. This wiki captures the Paperclip idea-and-research corpus for **human review**.
+> (Pattern: <https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f>)
+
+## Layout
+
+```
+.ideas/llm-wiki/
+├── CLAUDE.md          # this file — schema, conventions, workflows
+├── index.md           # content catalog: every wiki page + one-line summary, by category
+├── log.md             # append-only chronological record of ingest/query/lint passes
+├── raw/               # IMMUTABLE sources — read, never edit. The ground truth.
+│   ├── MANIFEST.md    # what the sources are + where they live
+│   └── research-sources.md   # consolidated external bibliography (web + arXiv)
+└── wiki/              # LLM-compiled concept pages — one concept per file, fully owned by the LLM
+```
+
+The **sources** (the 66 idea files `../0*.md`, the `../combinations/`, `../_skeleton-reference.md`, and
+`../../../Documents/Aisha/PAPERCLIP_INTEGRATION.md`) are treated as immutable ground truth and are
+catalogued in `raw/MANIFEST.md` rather than copied.
+
+## Page conventions (`wiki/*.md`)
+
+- **One concept per file.** Pages are *concept/entity syntheses*, not copies of individual ideas — each
+  page pulls together everything the corpus says about one topic.
+- **YAML frontmatter** on every page:
+  ```yaml
+  ---
+  title: Human-Readable Title
+  type: concept | entity | synthesis | comparison
+  status: draft | reviewed
+  sources: [001, 002, combo-01, xcombo-03, _skeleton-reference, research-sources]
+  updated: 2026-06-24
+  ---
+  ```
+- **`[[wikilinks]]`** for every cross-reference to another wiki page (by filename slug, no extension).
+- **Provenance.** Every claim traces back to a source via its id (idea number, combo name, or a
+  `research-sources` anchor). End each page with a `## Provenance` block listing the source ids.
+- **Human-review affordances.** Each page ends with `## Open questions for human review` — the decisions
+  or uncertainties a human should weigh in on. This wiki exists to be reviewed.
+
+## Workflows
+
+- **Ingest** (add a source): read it, write/refresh the relevant concept page(s) in `wiki/`, add or update
+  `[[wikilinks]]`, update `index.md`, append a dated entry to `log.md`. One source typically touches
+  several concept pages.
+- **Query** (answer a question): synthesize from `wiki/` + `index.md` with citations; if the answer is
+  durable, file it back as a new/expanded page.
+- **Lint** (maintain health): scan for contradictions, stale claims, orphan pages (no inbound links), and
+  concepts mentioned but missing a page; record findings in `log.md`.
+
+## Division of labor
+
+- **Human owns:** source curation, direction, high-level questions, and *reviewing the synthesis*.
+- **LLM owns:** summarization, cross-referencing, file bookkeeping, consistency, contradiction-flagging,
+  and keeping `index.md`/`log.md` current.

--- a/.ideas/llm-wiki/index.md
+++ b/.ideas/llm-wiki/index.md
@@ -1,0 +1,49 @@
+# LLM-Wiki Index
+
+Catalog of compiled concept pages. Retrieval starting point. See `CLAUDE.md` for conventions, `log.md`
+for history, `raw/` for immutable sources. Updated 2026-06-24.
+
+## Foundations
+- [[llm-wiki]] — the Karpathy pattern this knowledge base follows (compounding knowledge vs. RAG).
+- [[paperclip-architecture-skeleton]] — Paperclip reverse-engineered to 5 tables + one loop + an adapter.
+- [[aisha-integration]] — Aisha (voice/RAG multi-agent chief) × Paperclip (orchestration substrate).
+
+## Control, safety & economics
+- [[runtime-control-and-safety]] — admission/throttle/halt control plane; Autonomy Dial; Night-Shift.
+- [[model-economy]] — local LLM, fallback chains, credential pooling, host-resource awareness, cache.
+- [[economics-and-finance]] — CFO suite, cost-attribution spine, capital allocator (bandit).
+
+## People, quality & knowledge
+- [[human-in-the-loop]] — review cockpit, approvals, mobile push, digest, chat channel (Telegram/WhatsApp).
+- [[observability-and-health]] — health sentinel: tracing + detectors (thrash/deadlock/drift) + heatmap.
+- [[agent-quality-and-staffing]] — agent CI/CD, self-staffing, self-healing org, the improvement flywheel.
+- [[security-governance]] — zero-trust layer, trust-as-currency, provenance & replay (auditability).
+- [[knowledge-and-memory]] — knowledge system, handoff briefings, experiments, code-knowledge flywheel.
+
+## Build, scale & integrate
+- [[software-building-and-self-hosting]] — software-building capability + self-hosting + bootstrap ladder.
+- [[pre-flight]] — one "simulate before commit" seam for every consequential action.
+- [[multi-company-and-ecosystem]] — holding company, shared services, mailbox, adoption kit, marketplace.
+- [[external-integration]] — inbound intake, outbound webhooks, the Front Desk pipeline.
+- [[resilience-recovery]] — rewind, DR drills, incident/on-call, plugin health.
+
+## Concept aliases (covered within a pillar; bare `[[links]]` resolve here)
+- `bootstrap-ladder` → [[software-building-and-self-hosting]]
+- `self-healing-org`, `staffing` → [[agent-quality-and-staffing]]
+- `trust-as-currency`, `provenance-and-replay` → [[security-governance]]
+- `cost-attribution`, `capital-allocator` → [[economics-and-finance]]
+- `night-shift` → [[runtime-control-and-safety]]
+- `code-knowledge-flywheel` → [[knowledge-and-memory]]
+- `front-desk` → [[external-integration]]
+- `chat-channel` → [[human-in-the-loop]]
+
+## Coverage
+All 66 source ideas (`001`–`066`), all 13 thematic combos, all 12 cross-cutting combos (`xcombo-01..11` +
+flywheel), the skeleton reference, and the Aisha integration are cited across the 16 pages above (see each
+page's `## Provenance`). Every page carries `## Open questions for human review`.
+
+## Gaps to compile next (lint)
+- Dedicated pages for the highest-traffic aliases (e.g. `bootstrap-ladder`, `provenance-and-replay`) if
+  they outgrow their pillar section.
+- Pages for queued cross-cutting cuts not yet written as combos: `xcombo-12` (Conversational Operator),
+  `xcombo-13` (Reproducible Run), `xcombo-14` (Marketplace), `xcombo-15` (Closed-Loop Run Efficiency).

--- a/.ideas/llm-wiki/log.md
+++ b/.ideas/llm-wiki/log.md
@@ -1,0 +1,35 @@
+# LLM-Wiki Log (append-only)
+
+## [2026-06-24] init | LLM-wiki scaffold created
+Built the Karpathy-pattern knowledge base at `.ideas/llm-wiki/`: `CLAUDE.md` (schema/conventions),
+`index.md`, `log.md`, `raw/MANIFEST.md` (immutable-source catalog), `raw/research-sources.md`
+(consolidated web + arXiv bibliography, grouped by topic with anchor ids).
+
+## [2026-06-24] ingest | Full Paperclip idea + research corpus → 16 concept pages
+Compiled the entire corpus into concept-oriented `wiki/` pages (one concept per file, frontmatter,
+`[[wikilinks]]`, provenance):
+- Foundations: `llm-wiki`, `paperclip-architecture-skeleton`, `aisha-integration`.
+- Pillars: `runtime-control-and-safety`, `model-economy`, `economics-and-finance`, `human-in-the-loop`,
+  `observability-and-health`, `agent-quality-and-staffing`, `security-governance`, `knowledge-and-memory`,
+  `software-building-and-self-hosting`, `pre-flight`, `multi-company-and-ecosystem`, `external-integration`,
+  `resilience-recovery`.
+Sources ingested: ideas 001–066; thematic combos combo-01..13; cross-cutting xcombo-01..11 +
+code-knowledge-flywheel; `_skeleton-reference.md`; `PAPERCLIP_INTEGRATION.md`; the external research
+bibliography. Each page treats the synthesis as *one concept*, not a per-idea copy, and ends with
+`## Open questions for human review` for the human pass.
+
+## [2026-06-24] lint | First health pass
+- **Coverage:** every source idea + combination is cited in ≥1 page's provenance. OK.
+- **Orphans:** none — all 16 pages are reachable from `index.md`.
+- **Unresolved bare links (intentional, marked as future pages):** `[[bootstrap-ladder]]` (in
+  paperclip-architecture-skeleton), `[[self-healing-org]]` (in observability-and-health). Both currently
+  resolve via the alias table in `index.md` to their pillar pages; promote to standalone pages if they grow.
+- **Contradictions:** none flagged this pass.
+- **Provenance:** the loop that generated the combinations was stopped (cron `24931f73` cancelled) before
+  this ingest; queued cuts `xcombo-12..15` are noted in `index.md` gaps but not yet authored as combos.
+
+## How to extend (for the next session)
+- **Ingest a new idea:** read it, update the relevant concept page(s) + `[[links]]` + `index.md`, append
+  an entry here.
+- **Query:** synthesize from `wiki/` + `index.md` with citations; file durable answers back as pages.
+- **Lint:** re-run the health pass above; promote high-traffic aliases to their own pages.

--- a/.ideas/llm-wiki/raw/MANIFEST.md
+++ b/.ideas/llm-wiki/raw/MANIFEST.md
@@ -1,0 +1,26 @@
+# Raw Sources — Manifest
+
+These are the **immutable ground-truth sources** the wiki compiles from. They are *not* copied here
+(they already live in the repo and are git-versioned); the LLM reads them in place and never edits them
+from within the wiki.
+
+## Primary idea corpus
+- `../../0*.md` — the 66 numbered idea files (`001`–`066`) + `../../README.md` index.
+  Each is structured as Suggestion / How it could be achieved / Perceived complexity (+ Sources on newer ones).
+- Notable recent additions: `065` (Software-Building & Self-Hosting), `066` (Chat Channel — Telegram/WhatsApp).
+
+## Synthesis corpus (combinations)
+- `../../combinations/combo-01..13-*.md` — 13 thematic combinations (group ideas by mechanism).
+- `../../combinations/README.md` — combination index + source-idea→combo map + build order.
+- `../../combinations/cross-cutting/xcombo-01..11-*.md` + `xcombo-code-knowledge-flywheel.md` —
+  12 cross-cutting combinations (group by abstraction/scenario/flywheel).
+- `../../combinations/cross-cutting/_log.md` — the cross-cutting loop log (done list + procedure).
+
+## Architecture & integration sources
+- `../../_skeleton-reference.md` — Paperclip reverse-engineered to its 5-table skeletal kernel.
+- `/home/user/Documents/Aisha/PAPERCLIP_INTEGRATION.md` — how Aisha (voice/RAG multi-agent assistant)
+  and Paperclip fit together (Aisha = chief, Paperclip = orchestration substrate).
+
+## External research
+- `research-sources.md` — consolidated bibliography of all web + arXiv sources gathered while developing
+  the combinations (grouped by topic, with the combos each grounds).

--- a/.ideas/llm-wiki/raw/research-sources.md
+++ b/.ideas/llm-wiki/raw/research-sources.md
@@ -1,0 +1,92 @@
+# External Research Sources (Consolidated Bibliography)
+
+All web + arXiv sources gathered while developing the combinations, grouped by topic. Anchor ids (e.g.
+`[finops]`, `[bandits]`) are referenced from wiki pages' `## Provenance` blocks. Captured 2026-06.
+
+## [otel-finops] Cost attribution, observability, FinOps — grounds [[economics-and-finance]], [[cost-attribution]]
+- OpenTelemetry GenAI semantic conventions (gen_ai spans, token usage): https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-spans/
+- LLM cost monitoring with OpenTelemetry — Uptrace: https://uptrace.dev/blog/llm-cost-monitoring
+- FinOps for AI Overview — FinOps Foundation: https://www.finops.org/wg/finops-for-ai-overview/
+- Token Economics & TokenOps — Finout: https://www.finout.io/blog/token-economics-and-tokenops-the-definitive-guide-to-finops-for-tokens
+- GPU Cloud FinOps for AI Teams (chargeback/showback) — Spheron: https://www.spheron.network/blog/gpu-cloud-finops-ai-teams-cost-allocation-chargeback-budgeting/
+
+## [zero-trust] Zero-trust / agent identity / least privilege — grounds [[security-governance]], [[trust-as-currency]]
+- Zero Trust Architecture for Agentic AI in 2026 — Zentera: https://www.zentera.net/blog/zero-trust-architecture-for-agentic-ai
+- Zero Trust for AI Agents: Least Privilege — Zscaler: https://www.zscaler.com/blogs/product-insights/zero-trust-for-ai-agents-least-privilege
+- AI Agent Identity & Zero-Trust: 2026 Playbook: https://medium.com/@raktims2210/ai-agent-identity-zero-trust-the-2026-playbook-for-securing-autonomous-systems-in-banks-e545d077fdff
+- Announcing Zero Trust for AI — Microsoft Security: https://www.microsoft.com/en-us/security/blog/2026/03/19/new-tools-and-guidance-announcing-zero-trust-for-ai/
+- Zero Trust for AI Agents (identity/behavioral) — Cisco: https://blogs.cisco.com/security/security-agentic-ai-how-cisco-brings-zero-trust-to-your-new-digital-workforce
+
+## [guardrails] Unattended/overnight agent guardrails — grounds [[runtime-control-and-safety]], [[night-shift]]
+- Agentic AI Guardrails — Aembit: https://aembit.io/blog/agentic-ai-guardrails-for-safe-scaling/
+- Complete AI Guardrails Implementation Guide 2026 — Maxim: https://www.getmaxim.ai/articles/the-complete-ai-guardrails-implementation-guide-for-2026/
+- AI Agent Risks & Guardrails 2026 — Atlan: https://atlan.com/know/ai-agent-risks-guardrails/
+- AI Agents in 2026 — Symphony Solutions: https://symphony-solutions.com/insights/ai-agents-in-2026
+
+## [provenance] Auditability, decision provenance, replay — grounds [[security-governance]], [[provenance-and-replay]]
+- Agentic AI Observability: A 2026 Playbook — Arthur: https://www.arthur.ai/column/agentic-ai-observability-playbook-2026
+- AI Agent Audit Trails — iSimplifyMe: https://isimplifyme.com/blog/agent-audit-trails
+- Reasoning Traces vs Real Audit Trails — Apptitude: https://apptitude.io/blog/ai-agent-accountability-reasoning-traces-audit-trail/
+- AI Audit Trail: Compliance & Evidence — Swept AI: https://www.swept.ai/ai-audit-trail
+- (EU AI Act Article 12 lifetime event-logging; high-risk deadline 2026-08-02. R-LAM deterministic replay.)
+
+## [self-healing] Self-healing systems / agentic SRE — grounds [[resilience-recovery]], [[self-healing-org]]
+- Self-Healing Software Systems — Impala Intech: https://impalaintech.com/blog/self-healing-software-systems/
+- AI SRE: Autonomous Agents Slash MTTR 80% — Rootly: https://rootly.com/sre/ai-sre-explained-autonomous-agents-slash-mttr-80
+- Agentic SRE / Self-Healing Infrastructure 2026 — Unite.AI: https://www.unite.ai/agentic-sre-how-self-healing-infrastructure-is-redefining-enterprise-aiops-in-2026/
+- Self-Healing Systems / Auto-Remediation — Infosys: https://www.infosys.com/iki/techcompass/self-healing-systems.html
+
+## [bandits] Budget allocation / portfolio bandits (arXiv) — grounds [[economics-and-finance]], [[capital-allocator]]
+- Risk-Aware Multi-Armed Bandit for Portfolio Selection — arXiv 1709.04415: https://arxiv.org/abs/1709.04415
+- Improving Portfolio Optimization with Bandit Networks — arXiv 2410.04217: https://arxiv.org/html/2410.04217v2
+- Knapsack-based Optimal Policies for Budget-Limited Bandits — arXiv 1204.1909: https://arxiv.org/pdf/1204.1909
+- Multi-Task Combinatorial Bandits for Budget Allocation — arXiv 2409.00561: https://arxiv.org/html/2409.00561v1
+- Constrained Optimization with Bandit Feedback (fairness floors) — arXiv 2106.05165: https://arxiv.org/pdf/2106.05165
+- Agent Contracts: Resource-Bounded Autonomous AI — arXiv 2601.08815: https://arxiv.org/pdf/2601.08815
+
+## [routing] Ticket triage / skill-based routing (arXiv) — grounds [[external-integration]], [[front-desk]], [[staffing]]
+- Cognitive system for human-level helpdesk ticket assignment — arXiv 1808.02636: https://arxiv.org/pdf/1808.02636
+- UCB-based routing in skill-based queues (real data) — arXiv 2506.20543: https://arxiv.org/pdf/2506.20543
+- TaDaa: real-time ticket assignment deep-learning advisor — arXiv 2207.11187: https://arxiv.org/pdf/2207.11187
+- SSR-TA: seq2seq expert recommendation for ticket automation — arXiv 2301.12612: https://arxiv.org/pdf/2301.12612
+- Triage in Software Engineering: systematic review — arXiv 2511.08607: https://arxiv.org/html/2511.08607v1
+- LLMs for Automated Ticket Escalation — arXiv 2504.08475: https://arxiv.org/html/2504.08475v1
+- AI Ticket Triage metrics (72s→4s, $1/resolution) — Twig: https://www.twig.so/blog/triaging-customer-support-tickets-with-ai
+
+## [digital-twin] Pre-flight / digital twin / shadow mode — grounds [[pre-flight]], [[provenance-and-replay]]
+- ADDT — Digital Twin for Safety Validation — arXiv 2504.09461: https://arxiv.org/abs/2504.09461
+- Digital Twin Counterfactual Framework — arXiv 2604.01325: https://arxiv.org/html/2604.01325
+- TwinLoop: Simulation-in-the-Loop Digital Twins for Multi-Agent RL — arXiv 2604.06610: https://arxiv.org/html/2604.06610v1
+- Shadow Mode Rollouts for AI Agents — Brightlume: https://brightlume.ai/blog/shadow-mode-rollouts-ai-agents-pilot-production
+- Controlling AI Actions: Pre-Execution Control Layer — Data443: https://data443.com/blog/controlling-ai-actions-pre-execution-control-layer/
+- Kill Switches Don't Work If the Agent Writes the Policy — Stanford Law/Berkeley AILCCP: https://law.stanford.edu/2026/03/07/kill-switches-dont-work-if-the-agent-writes-the-policy-the-berkeley-agentic-ai-profile-through-the-ailccp-lens/
+
+## [chatops] Chat channel / human-in-the-loop messaging — grounds [[human-in-the-loop]], [[chat-channel]]
+- Telegram Bot API: https://core.telegram.org/bots/api
+- Telegram vs WhatsApp for an AI Agent (opt-in/template/window): https://www.hermify.io/en/blog/telegram-vs-whatsapp-for-ai-agent
+- A2H: Agent-to-Human Protocol — arXiv 2602.15831: https://arxiv.org/pdf/2602.15831
+- AgentClick: HITL Review Layer for Terminal AI Agents — arXiv 2604.16520: https://arxiv.org/html/2604.16520v1
+- Toward Safe & Responsible AI Agents (transparency/accountability) — arXiv 2601.06223: https://arxiv.org/pdf/2601.06223
+
+## [self-improve] Self-improving agents / curriculum / bootstrap (arXiv) — grounds [[software-building-and-self-hosting]], [[bootstrap-ladder]]
+- Darwin Gödel Machine: Open-Ended Evolution of Self-Improving Agents — arXiv 2505.22954: https://arxiv.org/abs/2505.22954
+- Huxley-Gödel Machine: Human-Level Coding Agent — arXiv 2510.21614: https://arxiv.org/html/2510.21614v1
+- Intrinsically Motivated Goal Exploration w/ Automatic Curriculum Learning — arXiv 1708.02190: https://arxiv.org/pdf/1708.02190
+- On the Statistical Limits of Self-Improving Agents — arXiv 2510.04399: https://arxiv.org/pdf/2510.04399
+- International AI Safety Report 2026 — arXiv 2602.21012: https://arxiv.org/pdf/2602.21012
+- When AI Builds Itself — Anthropic: https://www.anthropic.com/institute/recursive-self-improvement
+
+## [code-memory] Codebase memory / code retrieval — grounds [[knowledge-and-memory]], [[code-knowledge-flywheel]]
+- Persistent Codebase Memory for Coding Agents — Cognee: https://www.cognee.ai/blog/guides/ai-coding-agent-persistent-codebase-memory
+- State of AI Agent Memory 2026 — mem0: https://mem0.ai/blog/state-of-ai-agent-memory-2026
+- State of AI Coding Agents 2026 — Dave Patten: https://medium.com/@dave-patten/the-state-of-ai-coding-agents-2026-from-pair-programming-to-autonomous-ai-teams-b11f2b39232a
+
+## [swe-agents] Autonomous software engineering (arXiv) — grounds [[software-building-and-self-hosting]]
+- Live-SWE-agent: Self-Evolving SE Agents (77.4% SWE-bench Verified) — arXiv 2511.13646: https://arxiv.org/html/2511.13646v3
+- SWE-EVO: Long-Horizon Software Evolution benchmark — arXiv 2512.18470: https://arxiv.org/pdf/2512.18470
+- Effective Strategies for Asynchronous SE Agents — arXiv 2603.21489: https://arxiv.org/pdf/2603.21489
+
+## [llm-wiki] The Karpathy LLM-wiki pattern itself — grounds [[llm-wiki]]
+- Karpathy llm-wiki gist: https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f
+- Beyond RAG: Karpathy's LLM Wiki Pattern — Level Up Coding: https://levelup.gitconnected.com/beyond-rag-how-andrej-karpathys-llm-wiki-pattern-builds-knowledge-that-actually-compounds-31a08528665e
+- Karpathy shares LLM Knowledge Base architecture — VentureBeat: https://venturebeat.com/data/karpathy-shares-llm-knowledge-base-architecture-that-bypasses-rag-with-an

--- a/.ideas/llm-wiki/wiki/agent-quality-and-staffing.md
+++ b/.ideas/llm-wiki/wiki/agent-quality-and-staffing.md
@@ -1,0 +1,58 @@
+---
+title: Agent Quality, Staffing & Self-Organization
+type: concept
+status: reviewed
+sources: [009, 011, 025, 032, 040, 044, 046, 047, 048, 052, 057, combo-06, combo-07, xcombo-02, xcombo-07, research-sources]
+updated: 2026-06-24
+---
+
+# Agent Quality, Staffing & Self-Organization
+
+How agents are evaluated, equipped, assigned, ramped, and — eventually — how the org staffs and repairs
+itself.
+
+## Agent CI/CD & evidence-based quality (combo-06)
+
+On three shared foundations — a side-effect-free `planOnly`/shadow mode, the eval harness, and
+outcome-labeled run history:
+- **Eval-gated config deploys (011)** — run a saved suite before a config change goes live ("CI for agents").
+- **A/B model bake-off (032)** — same tasks across models; cost/quality frontier with a neutral judge.
+- **Operator-owned training dataset (040)** — normalize runs into outcome-labeled records (local, consented).
+- **Skill effectiveness analytics (046)** — does a skill actually lift approval / cut rework?
+
+## Self-staffing & self-organizing (combo-07)
+
+- **Competency-gated job postings (048)** — a posting stays open until a candidate *passes a test* (the
+  eval *is* the interview).
+- **Role-based skill auto-provisioning (047)** — role→skill bundle; equip on hire; reconcile on change.
+- **Capability-based assignment (025)** — fit × load × trust × cost; UCB skill-routing (arXiv 2506.20543).
+- **Probation & trust ramp (009)** — earn autonomy on a clean record; feeds the [[security-governance|trust currency]].
+- **Org restructuring simulator (052)** — preview a reorg's impact before applying (see [[pre-flight]]).
+
+## The Self-Healing Org (xcombo-07)
+
+Apply the SRE self-healing loop (**detect → diagnose → remediate → verify**) to *staffing & structure*:
+reliability SLOs (044) detect → diagnose agent/role/structure fault → remediate via constrain/reassign
+(009/025), auto-backfill posting (048), reorg (052), or incident (057) → verify recovery. Human =
+"reliability architect." Grounded in 2026 agentic-SRE (≈80% MTTR cuts).
+
+## The self-improving flywheel (xcombo-02)
+
+Capture (040) → mine (055/046) → propose → test (011/032 + business experiments) → record learning (060)
+→ deploy → repeat. The novelty is loop closure: point-features become a *compounding* asset.
+
+## Links
+
+Consumes [[observability-and-health]] (reliability signal) and [[economics-and-finance]] (cost-effectiveness);
+shares the shadow contract with [[pre-flight]] and [[software-building-and-self-hosting]].
+
+## Provenance
+
+- Ideas `009,011,025,032,040,044,046,047,048,052,057`; combos `combo-06`, `combo-07`, `xcombo-02`, `xcombo-07`.
+- `raw/research-sources.md` → `[routing]`, `[self-healing]`.
+
+## Open questions for human review
+
+- Graduation/demotion criteria for the trust ramp — strict enough to matter, loose enough not to shackle good agents?
+- Auto-reorg / auto-hire are high blast-radius — keep behind the human-set autonomy ceiling?
+- Trustworthy auto-*proposal* in the flywheel without degrading agents at machine speed.

--- a/.ideas/llm-wiki/wiki/aisha-integration.md
+++ b/.ideas/llm-wiki/wiki/aisha-integration.md
@@ -1,0 +1,55 @@
+---
+title: Aisha × Paperclip Integration
+type: synthesis
+status: reviewed
+sources: [PAPERCLIP_INTEGRATION, 008, 027, 060, 066, research-sources]
+updated: 2026-06-24
+---
+
+# Aisha × Paperclip Integration
+
+Aisha (a voice-first, multi-LLM, RAG-equipped personal assistant moving toward a multi-agent system with
+a *chief* over domain-leader agents) and Paperclip are **complementary halves of one system**.
+
+## Thesis
+
+> **Aisha is the interactive command layer & chief; Paperclip is the orchestration substrate her org runs
+> on; the domain leaders are shared agents with one definition and two faces (conversational + autonomous).**
+
+The human speaks to one chief; behind her stands a governed, budgeted, 24/7 workforce.
+
+## What each fills in the other
+
+- Aisha already has the **agent-definition primitive** (`AIFriend` ≈ a Paperclip agent) and proto
+  domain-leaders (`researcher`/`coder`/`creative` personas) — but **no orchestration layer** (delegation,
+  heartbeats, budgets, governance). That gap *is* Paperclip ([[paperclip-architecture-skeleton]]).
+- Aisha → Paperclip: a working **local RAG engine** (≈ [[knowledge-and-memory|idea 060]]), a **voice /
+  fast-approval front end** ([[human-in-the-loop]], idea 027 + chat 066), and **local-LLM** know-how
+  ([[model-economy]], idea 008).
+- Paperclip → Aisha: budgets, fallback chains, **governance/trust**, scheduling, multi-agent scale.
+
+## The seam: MCP (both already speak it)
+
+- Paperclip-as-MCP-server → Aisha drives the company by voice (status/approvals/directives).
+- Aisha-as-MCP-tools → Paperclip agents gain voice, web crawler, local retriever.
+
+## Two-tier architecture (the multi-agent direction)
+
+- **Tier 1 (Aisha, synchronous/voice):** the chief — converse, quick tasks, *route*.
+- **Tier 2 (Paperclip, async/autonomous):** delegate team/budget/24-7 work; results report back by voice.
+- Chief's new skill = **mode routing** (sync vs async), i.e. [[agent-quality-and-staffing|capability
+  assignment]] one level up. **One agent definition, two faces.**
+
+## Build-vs-reuse decision (for human review)
+
+Recommended: reuse Paperclip as the orchestration substrate (or a hybrid: thin contract in Aisha +
+Paperclip as the heavyweight provider), rather than rebuilding the whole backlog in Python.
+
+## Provenance
+
+- `/home/user/Documents/Aisha/PAPERCLIP_INTEGRATION.md`; ideas `008,027,060,066`.
+
+## Open questions for human review
+
+- Standalone Aisha orchestrator vs. Paperclip-backed vs. hybrid — this decision shapes everything.
+- Is voice/chat the *primary* operator surface, or one channel among many?

--- a/.ideas/llm-wiki/wiki/economics-and-finance.md
+++ b/.ideas/llm-wiki/wiki/economics-and-finance.md
@@ -1,0 +1,55 @@
+---
+title: Economics, Finance & Capital Allocation
+type: concept
+status: reviewed
+sources: [013, 019, 030, 037, 055, 063, 007, 049, combo-04, xcombo-03, xcombo-08, research-sources]
+updated: 2026-06-24
+---
+
+# Economics, Finance & Capital Allocation
+
+Paperclip tracks *spend* well but can't answer the question that matters for a *business*: is it making
+more than it costs, and where is it heading? This is the money stack.
+
+## The CFO suite (combo-04)
+
+Six organs over one cost/revenue/outcome data model:
+- **Revenue & P&L (030)** — record income (manual, governed agent-reported, Stripe/Paddle webhook) →
+  profit, margin, MRR, goal progress *in dollars*.
+- **Unit economics (013)** — cost per shipped outcome, rework ratio, idle spend (per agent/role/goal).
+- **Token budgets (019)** — make tokens a first-class budget metric (remove the `metric!=billed_cents
+  →return 0` short-circuit) so subscription/flat-rate users get a real guardrail.
+- **Cache optimization (037)** — surface cache-hit rate; stable-prefix context = found money.
+- **Estimate calibration (055)** — estimate vs actual → per-agent forecasting bias.
+- **Forecasting (063)** — runway, projected goal-attainment date, capacity needs.
+
+## The Cost-Attribution Spine (xcombo-03)
+
+One **attribution key** `{company, goal-subtree, agent/role, adapter+model, runId}` stamped on every span
+at run-start and carried to every cost event. Emit **OpenTelemetry GenAI** span names so spend is
+vendor-neutral. Adopt FinOps **showback → chargeback** maturity. Every finance view becomes a projection
+of this one spine.
+
+## The Capital Allocator (xcombo-08)
+
+Treat the portfolio as a **multi-armed bandit**: arms = agents/issues/companies, reward = ROI, forecast =
+prior; UCB/Thompson balance explore-vs-exploit under **knapsack** (total cap) + **fairness-floor**
+(reserve for critical roles) constraints; unused budget returns to a shared pool. Executed via
+[[multi-company-and-ecosystem|holding-company]] capital moves, breaker-gated and audited. Grounded in
+arXiv bandit/portfolio literature.
+
+## Links
+
+Depends on [[runtime-control-and-safety]] (budgets/breaker), [[model-economy]] (cost of inference),
+[[observability-and-health]] (idle spend), [[security-governance]] (audited money moves).
+
+## Provenance
+
+- Ideas `007,013,019,030,037,049,055,063`; combos `combo-04`, `xcombo-03`, `xcombo-08`.
+- `raw/research-sources.md` → `[otel-finops]`, `[bandits]`.
+
+## Open questions for human review
+
+- Imputed dollar value for subscription token usage — include for cross-agent comparison, or avoid implying real cash?
+- How lagged/noisy is ROI before the bandit allocator can be trusted to auto-move money?
+- Provider-rate-limit-window vs calendar-window for token budgets — default?

--- a/.ideas/llm-wiki/wiki/external-integration.md
+++ b/.ideas/llm-wiki/wiki/external-integration.md
@@ -1,0 +1,41 @@
+---
+title: External Integration & The Front Desk
+type: concept
+status: reviewed
+sources: [036, 062, 066, 016, 025, 058, combo-12, xcombo-09, research-sources]
+updated: 2026-06-24
+---
+
+# External Integration & The Front Desk
+
+A real company both *receives* work from outside and *emits* to its toolchain. Paperclip has a rich
+internal event bus but no first-class front door or outbound tap.
+
+## Two-way integration fabric (combo-12)
+
+- **Inbound intake (062)** — email / webhook / form → an issue, secured (rate-limit, spam-filter,
+  source-trust gate, leak/PII scan).
+- **Outbound webhooks (036)** — signed, retrying event delivery (Slack on ship, PagerDuty on hard-stop),
+  SSRF-guarded.
+- Payment webhooks (see [[economics-and-finance|Revenue]]) are a special inbound channel; the
+  intra-instance analog is the [[multi-company-and-ecosystem|Company Mailbox]].
+
+## The Front Desk — autonomous intake→resolution (xcombo-09)
+
+The pipeline: **intake (062) → triage/score (016) → retrieve context ([[knowledge-and-memory]]) →
+capability/UCB-skill assign + template/DoD (025/058) → respond (036)**. Three modes — *resolve* /
+*triage* / *assist* — on a confidence dial ([[runtime-control-and-safety|Autonomy Dial]]). Grounded in
+arXiv ticket-routing (incl. UCB skill-queues, arXiv 2506.20543) + 2026 support metrics (72s→4s response,
+≈$1/resolution, 50–70% deflection). The differentiator: the "resolver" isn't a chatbot — it's a
+**governed multi-agent org** (the link to [[human-in-the-loop|the chat channel]] and
+[[aisha-integration|Aisha]]).
+
+## Provenance
+
+- Ideas `036,062,066`; combos `combo-12`, `xcombo-09`.
+- `raw/research-sources.md` → `[routing]`, `[chatops]`.
+
+## Open questions for human review
+
+- A public front door is an attack surface — start route-only, raise auto-resolve as accuracy proves out?
+- Email ingestion (parser/threading) is fiddly — webhook/form first?

--- a/.ideas/llm-wiki/wiki/human-in-the-loop.md
+++ b/.ideas/llm-wiki/wiki/human-in-the-loop.md
@@ -1,0 +1,52 @@
+---
+title: Human-in-the-Loop (Review, Approvals, On-the-Go)
+type: concept
+status: reviewed
+sources: [016, 017, 027, 029, 033, 038, 066, combo-05, xcombo-12, research-sources]
+updated: 2026-06-24
+---
+
+# Human-in-the-Loop (Review, Approvals, On-the-Go)
+
+In a 24/7 company the human is the **single point of stall**: work that needs approval freezes every
+evening and weekend. This is the surface that makes governance fast and reachable.
+
+## The review cockpit (combo-05)
+
+One pipeline from "needs a human" → "decided":
+- **Change-review (017)** — PR-style diff per run; approve a concrete change, not a vague work product.
+- **Triage & batching (016)** — risk-score (trust × spend × sensitivity × diff size) → sorted, grouped
+  inbox; conservative audited auto-approve for the low-risk tail.
+- **Mobile push (027)** — web push/PWA on the same signals, gated by the risk score.
+- **Digest (029)** — scheduled narrated summary ("shipped 12, marketing blocked 2d, 3 need you").
+- **Delegation & coverage (038)** — scoped time-boxed approval handoff + SLA escalation when away.
+- **Stakeholder page (033)** — tokenized read-only external view from the same narrator.
+
+## On-the-go: the chat channel (idea 066)
+
+A built-in **Telegram bot / WhatsApp** integration — the lowest-friction two-way surface. Pushes
+approvals/digests/alerts and accepts **inline approve/reject taps** normalized back into structured
+decisions (the **A2H — Agent-to-Human — protocol**, arXiv 2602.15831). Telegram first (no opt-in/template
+friction); WhatsApp fast-follow (opt-in + 24h window + approved templates). Security crux: bind chat
+identity to an authorized user, verify signatures, audit every chat-originated decision.
+
+## Conversational Operator (xcombo-12, queued)
+
+Board-chat + push + digest + voice/chat approvals as *one* conversational control surface — the natural
+bridge for an [[aisha-integration|Aisha-as-chief]] front end over Paperclip via MCP.
+
+## Links
+
+Risk score shared with [[security-governance]]; the diff feeds [[observability-and-health]]
+(run-to-run diffing spots diminishing-returns loops); delivery via [[external-integration]].
+
+## Provenance
+
+- Ideas `016,017,027,029,033,038,066`; combos `combo-05`, queued `xcombo-12`.
+- `raw/research-sources.md` → `[chatops]`.
+
+## Open questions for human review
+
+- Notification-quality gating: which risk threshold actually buzzes the phone?
+- Auto-approve & delegation authority model must be airtight against privilege escalation — review needed.
+- Voice/chat as the *primary* operator surface (Aisha) vs. a secondary channel?

--- a/.ideas/llm-wiki/wiki/knowledge-and-memory.md
+++ b/.ideas/llm-wiki/wiki/knowledge-and-memory.md
@@ -1,0 +1,53 @@
+---
+title: Knowledge & Memory
+type: concept
+status: reviewed
+sources: [060, 028, 056, 037, combo-11, xcombo-code-knowledge-flywheel, xcombo-13, research-sources]
+updated: 2026-06-24
+---
+
+# Knowledge & Memory
+
+A company that can't remember what it learned re-solves solved problems forever. This is the institutional
+memory layer — and a recurring instance of the [[llm-wiki]] pattern *inside* the product.
+
+## The Knowledge System (idea 060 / combo-11)
+
+A first-class, default-on knowledge capability via **contract-in-core + default-bundled provider** (the
+llm-wiki engine), in three layers:
+- **Engine** — accumulate + curate (a real `wiki-lint` gate; an autoresearch librarian).
+- **Authority** — scoped canonical docs (org / company / team tiers, inheritance), auto-injected into
+  agent context, kept cache-stable (037).
+- **Retrieval** — local embeddings → pgvector + hybrid (semantic + trigram) search, exposed as an
+  agent tool ("has this been done before?").
+
+## Continuity & learning
+
+- **Shift-handoff briefings (028)** — when work changes hands, auto-generate a "what's done / tried /
+  open" note so the receiver starts warm. (A special case of retrieval over one issue.)
+- **Business experiments (056)** — hypothesis → variants → metric → recorded *validated learning* into
+  the knowledge base. Turns "agents doing stuff" into "a company that learns."
+
+## The Code-Knowledge Flywheel (xcombo-code-knowledge-flywheel)
+
+The knowledge engine specialized for code, to power [[software-building-and-self-hosting]]: a reusable
+**snippet/pattern library** (consistency), an **architecture graph** (hybrid vector + call/dependency
+graph — pure vector RAG can't answer "what calls this?"), and **canonical specs/conventions** injected at
+build time. For self-hosting, every rung built enriches the system's model of itself → the bootstrap
+*compounds*. Grounded in 2026 persistent-codebase-memory practice.
+
+## The Reproducible Run (xcombo-13, queued)
+
+Session continuity (028) + cache-stable context (037) + deterministic replay ([[security-governance|provenance]])
++ captured dataset (040) → runs that resume, reproduce, and resist drift.
+
+## Provenance
+
+- Ideas `028,037,056,060`; combos `combo-11`, `xcombo-code-knowledge-flywheel`, queued `xcombo-13`.
+- `raw/research-sources.md` → `[code-memory]`.
+
+## Open questions for human review
+
+- Promote the llm-wiki engine into a core *contract* (amend the "thin core" SPEC stance) vs. keep optional?
+- Keep the architecture graph fresh across languages — incremental re-index on commit; best-effort scope?
+- Should *this meta-wiki* and the in-product knowledge system share one engine? (see [[llm-wiki]])

--- a/.ideas/llm-wiki/wiki/llm-wiki.md
+++ b/.ideas/llm-wiki/wiki/llm-wiki.md
@@ -1,0 +1,44 @@
+---
+title: The LLM-Wiki Pattern
+type: concept
+status: reviewed
+sources: [research-sources, _skeleton-reference]
+updated: 2026-06-24
+---
+
+# The LLM-Wiki Pattern
+
+A **persistent, compounding knowledge base an LLM builds and maintains** from immutable sources — so
+knowledge *accumulates* across sessions instead of being re-derived each time (the failure mode of plain
+RAG). Proposed by Andrej Karpathy (`raw/research-sources.md#llm-wiki`).
+
+## Core shift: stateful, compiled knowledge vs. stateless retrieval
+
+- **RAG** retrieves raw chunks at query time and re-synthesizes an answer from scratch every time — no
+  accumulation; multi-document synthesis is re-done on every question.
+- **LLM-wiki** *compiles* sources once into human-readable concept pages, then *keeps them current*. The
+  cross-references already exist; contradictions are already flagged. Explorations file back as new pages.
+
+## Three layers
+
+1. **`raw/`** — immutable sources (the [[paperclip-architecture-skeleton|codebase]], the 66 ideas, the
+   combinations, external research). Read, never edited.
+2. **`wiki/`** — LLM-owned concept pages: one concept/file, YAML frontmatter, `[[wikilinks]]`, provenance.
+3. **Schema (`CLAUDE.md`) + `index.md` + `log.md`** — conventions, catalog, and append-only history.
+
+## Why it fits this corpus
+
+This very wiki applies the pattern to the Paperclip idea/research corpus to produce **knowledge for human
+review**. It also recurs *inside* the product as a feature: [[knowledge-and-memory]] proposes bundling an
+llm-wiki engine as Paperclip's default knowledge provider (idea 060), and the
+[[code-knowledge-flywheel]] applies it to code.
+
+## Provenance
+
+- `raw/research-sources.md` → `[llm-wiki]` (Karpathy gist, VentureBeat, Level Up Coding).
+- Internal echoes: idea 060 ([[knowledge-and-memory]]), the code-knowledge flywheel combination.
+
+## Open questions for human review
+
+- Should the in-product knowledge system (idea 060) and *this* meta-wiki share one engine/format?
+- How aggressively should the lint pass auto-resolve contradictions vs. flag for a human?

--- a/.ideas/llm-wiki/wiki/model-economy.md
+++ b/.ideas/llm-wiki/wiki/model-economy.md
@@ -1,0 +1,51 @@
+---
+title: Model & Provider Economy
+type: concept
+status: reviewed
+sources: [008, 012, 041, 049, 037, combo-02, research-sources]
+updated: 2026-06-24
+---
+
+# Model & Provider Economy
+
+The defining constraint of an always-on company is the economics of inference. This is the fabric that
+decides, per run, *where to run it, on whose credential, and whether the hardware/quota can take it*.
+
+## Mixed-economy fabric (combo-02)
+
+- **Free/private floor (008)** — a first-class `local_llm` adapter (Ollama / LM Studio / llama.cpp, all
+  OpenAI-`/v1`-compatible) with $0-cost billing for loopback/LAN endpoints, while still recording tokens
+  so [[observability-and-health|productivity metrics]] keep working.
+- **Graceful degradation (012)** — per-agent fallback chains (premium API → cheap API → local) triggered
+  by quota/429/outage, distinguished from don't-retry errors by the recovery classifiers.
+- **Fair sharing (049)** — model a shared credential as a pool with weighted-fair-queue so the noisy
+  batch can't starve the CEO agent; reserve capacity for critical roles; backpressure instead of 429.
+- **Host-resource awareness (041)** — CPU/RAM/GPU/VRAM probe + capacity-based admission for *local* runs
+  (per-model footprint hints to avoid OOM) + a "yield to the human during work hours" profile.
+
+## Cache as a cost lever (037)
+
+Stable-prefix context assembly maximizes prompt-cache hits — see [[economics-and-finance]] for the savings
+metric. Local models have their own prefix-caching worth aligning to.
+
+## Why it matters
+
+Makes the "24/7" pitch economically real and is a genuine differentiator (mixed cheap-local / premium-API
+fleets). The local tier also makes evals, embeddings, summaries, and handoff briefings *free* across the
+rest of the stack ([[agent-quality-and-staffing]], [[knowledge-and-memory]]). GPU spend is the #1 FinOps
+concern of 2026, validating the host-resource focus.
+
+## Links
+
+The seam is the [[paperclip-architecture-skeleton|adapter contract]]. Composes with
+[[runtime-control-and-safety]] (the breaker prefers the cheap fallback under budget pressure).
+
+## Provenance
+
+- Ideas `008,012,037,041,049`; combo `combo-02`.
+- `raw/research-sources.md` → `[otel-finops]` (GPU FinOps).
+
+## Open questions for human review
+
+- Loopback/LAN → `$0 local provider` billing rule needs solid test coverage — misclassification corrupts cost data.
+- Cross-platform GPU/VRAM sampling (NVIDIA vs Apple vs AMD) — best-effort scope?

--- a/.ideas/llm-wiki/wiki/multi-company-and-ecosystem.md
+++ b/.ideas/llm-wiki/wiki/multi-company-and-ecosystem.md
@@ -1,0 +1,43 @@
+---
+title: Multi-Company, Cross-Company & Ecosystem
+type: concept
+status: reviewed
+sources: [007, 018, 033, 039, 053, 054, 064, combo-10, combo-13, xcombo-14, research-sources]
+updated: 2026-06-24
+---
+
+# Multi-Company, Cross-Company & Ecosystem
+
+Companies in one instance are hard-isolated by design. Three things operators want require *deliberately*
+piercing that boundary through one governed seam — plus the adoption/ecosystem layer around it.
+
+## Governed cross-company fabric (combo-13)
+
+The key insight: holding directives, shared services, and inter-company messages are **three message
+types on one governed channel**, not three bridges.
+- **Company Mailbox (054)** — typed message envelopes; the single audited cross-company door (leak-scanned,
+  see [[security-governance]]).
+- **Holding company (007)** — `directive` messages: a meta-company with a narrow `portfolio_oversight`
+  read + governed-write capability; capital allocation is the killer action (see
+  [[economics-and-finance|Capital Allocator]]).
+- **Shared services (053)** — `service_request` tickets with chargeback so shared work is economically honest.
+
+## Adoption kit (combo-10)
+
+Get a new operator from cold install to value fast: blueprint library (018), guided onboarding + runnable
+demo (039), dry-run estimator (004, see [[pre-flight]]), data import from Jira/Linear/etc. (064), work
+templates & DoD (058). All ride the company-portability serializer + the dry-run preview.
+
+## Ecosystem / marketplace (xcombo-14, queued)
+
+Blueprints (018) + signed community sharing + shared services (053) + skills/teams catalogs + skill-
+effectiveness (046) → a trust-gated exchange of orgs, agents, skills, and services.
+
+## Provenance
+
+- Ideas `007,018,033,039,053,054,064`; combos `combo-10`, `combo-13`, queued `xcombo-14`.
+
+## Open questions for human review
+
+- The cross-company seam is a reviewed *security surface* — build read-only first, then governed writes, then capital?
+- Community blueprint/skill sharing introduces a trust/supply-chain surface — gating model?

--- a/.ideas/llm-wiki/wiki/observability-and-health.md
+++ b/.ideas/llm-wiki/wiki/observability-and-health.md
@@ -1,0 +1,43 @@
+---
+title: Observability & Company Health
+type: concept
+status: reviewed
+sources: [003, 006, 010, 026, 031, 044, 059, combo-03, xcombo-15, research-sources]
+updated: 2026-06-24
+---
+
+# Observability & Company Health
+
+Paperclip's watchdogs catch *crashed/silent* runs. They miss the expensive failures that **look healthy**:
+an agent thrashing with no progress, a dependency deadlock, work that decoupled from a live goal, a badly
+decomposed plan, a flaky agent. This is *observability* (health now) — distinct from
+[[security-governance|auditability]] (defending a past decision).
+
+## The Health Sentinel (combo-03)
+
+One analyzer service + one surface, fed by one instrumentation layer:
+- **Tracing backbone (031)** — semantic OTel spans for the run lifecycle, trace context propagated across
+  handoffs. The clean data source every detector reads (and [[economics-and-finance|unit economics]] too).
+- **Detectors** — diminishing-returns (003, per-issue thrash), deadlock/dead-end on the blocker graph
+  (010, Tarjan SCC), goal-drift/orphaned work (026), decomposition quality (059), reliability SLOs (044).
+- **Surface** — overlay all pressure on the org-chart heatmap (006): hot blocked nodes *and* cold
+  decoupled branches both glow.
+
+## Closed-loop run efficiency (xcombo-15, queued)
+
+Tracing (031) + adaptive heartbeat (035) + diminishing-returns (003) + per-run caps (024) → a real-time
+control loop that tunes *how* runs execute for cost/throughput, not just whether they start.
+
+## Links
+
+Feeds [[agent-quality-and-staffing]] (reliability → assignment/trust), the [[self-healing-org]] (detectors
+are the "detect" stage), and [[economics-and-finance]] (idle/misaligned spend).
+
+## Provenance
+
+- Ideas `003,006,010,026,031,044,059`; combo `combo-03`; queued `xcombo-15`.
+
+## Open questions for human review
+
+- Heuristic tuning: catch genuine loops without killing slow-but-legitimate work — default thresholds?
+- Semantic tiers (drift/decomposition) run on a local model — confidence threshold before auto-pause?

--- a/.ideas/llm-wiki/wiki/paperclip-architecture-skeleton.md
+++ b/.ideas/llm-wiki/wiki/paperclip-architecture-skeleton.md
@@ -1,0 +1,59 @@
+---
+title: Paperclip Architecture & Skeletal Kernel
+type: entity
+status: reviewed
+sources: [_skeleton-reference, 065]
+updated: 2026-06-24
+---
+
+# Paperclip Architecture & Skeletal Kernel
+
+Paperclip is a control plane for autonomous AI companies. Reverse-engineered from the code (~90 tables,
+141 services, a 12.3K-line heartbeat), it reduces to one sentence and five tables.
+
+## The one-sentence model
+
+> A **company** is a tree of **goals** decomposed into a tree of **issues**, worked by a tree of
+> **agents**, where a timer periodically wakes each agent to pick up an assigned issue and execute it
+> through an **adapter**, recording every execution as a **run**.
+
+## The spine — 5 tables (of ~90)
+
+- **companies** — tenant/container; budget anchor.
+- **agents** — the workforce; an agent *is* its `adapterType` + `adapterConfig`; `reportsTo` = org chart.
+- **goals** — the "why"; a tree; the *all-work-traces-to-the-goal* invariant.
+- **issues** — the "what"; a tree linked to a goal + assignee; run-level execution locking.
+- **heartbeat_runs** — the "what happened"; status, token usage, session continuity, logs — the fact table.
+
+## The engine — one loop
+
+Two `setInterval` timers (`tickTimers`, `tickScheduledTriggers`) drive it. A heartbeat run = **wake →
+admit → pick issue → resolve adapter config → execute → record → account (usage→cost→budget)**.
+Event-driven wakeups are primary; the timer is the safety net.
+
+## The one boundary — the adapter contract
+
+`execute(ctx) → AdapterExecutionResult{ outputs, usage, sessionId }` is the *only* thing that talks to an
+LLM/CLI. Swap the adapter, change the brain; the control plane is unchanged — see [[model-economy]].
+
+## Concentric rings (everything else)
+
+Core (above) → accounting/safety ([[runtime-control-and-safety]], [[economics-and-finance]]) →
+governance ([[security-governance]]) → work substrate (workspaces/work-products) → extensibility
+(plugins/MCP, [[external-integration]]) → people & UI. **The entire idea backlog is ring-2–6 enrichment;
+the spine barely changes.**
+
+## The minimal kernel (for [[software-building-and-self-hosting]])
+
+5 tables + one tick loop + one adapter + a budget hard-stop + a manual approval gate + a few CRUD routes.
+Because the architecture is already concentric rings, "[[bootstrap-ladder|scale down to the kernel, then
+build up]]" is a true subset, not a rewrite.
+
+## Provenance
+
+- `../../_skeleton-reference.md` (full reverse-engineering); idea `065` (kernel concept).
+
+## Open questions for human review
+
+- Is the per-agent-only concurrency model (no fleet cap) the most urgent spine gap? (see [[runtime-control-and-safety]])
+- Which ring-2 capability is the right *first* rung for self-hosting?

--- a/.ideas/llm-wiki/wiki/pre-flight.md
+++ b/.ideas/llm-wiki/wiki/pre-flight.md
@@ -1,0 +1,47 @@
+---
+title: Pre-Flight — Simulate Before Commit
+type: concept
+status: reviewed
+sources: [004, 043, 052, 064, 015, 011, xcombo-10, xcombo-06, xcombo-01, research-sources]
+updated: 2026-06-24
+---
+
+# Pre-Flight — Simulate Before Commit
+
+One universal **`simulate(change) → ImpactReport`** seam that every high-consequence mutation passes
+through before it commits — instead of each feature inventing its own preview.
+
+## The unified seam (xcombo-10)
+
+Generalize idea 004's `planOnly`/dry-run into one contract with call sites: launch a company (004), reorg
+(052, see [[agent-quality-and-staffing]]), activate a policy (043, see [[security-governance]]), import
+data (064), restore (015, see [[resilience-recovery]]), deploy config (011), move capital (see
+[[economics-and-finance|Capital Allocator]]), cross-company action (see [[multi-company-and-ecosystem]]).
+
+`ImpactReport` = creates/updates/deletes (Change-Impact-Analysis over the dependency graph) + risks +
+projected cost + **counterfactual** ("would have blocked N past actions" — shares the engine with
+[[security-governance|Provenance & Replay]]) + confidence.
+
+## The graduation ladder
+
+shadow → dry-run-with-approval → auto-commit, mapped to [[runtime-control-and-safety|the Autonomy Dial]].
+Pre-flight is the **on-ramp to autonomy**, not just a gate — a capability earns auto-commit by proving its
+simulations match reality.
+
+## Grounding
+
+Digital-twin pre-deployment validation + counterfactual frameworks (arXiv 2504.09461, 2604.01325,
+2604.06610) supply the simulate-and-impact half; the agent **shadow→dry-run→commit** maturity ladder
+supplies the deployment half. Critical caveat: "kill switches don't work if the agent writes the policy" →
+the pre-flight seam and the definition of "consequential" must be **human-owned and agent-immutable**
+(matters for [[software-building-and-self-hosting|self-hosting]]).
+
+## Provenance
+
+- Ideas `004,011,015,043,052,064`; combos `xcombo-10`, `xcombo-06`.
+- `raw/research-sources.md` → `[digital-twin]`.
+
+## Open questions for human review
+
+- Faithful simulation is the crux — a wrong preview is worse than none. Per-call-site fidelity bar?
+- Make the seam genuinely agent-immutable given self-modifying agents.

--- a/.ideas/llm-wiki/wiki/resilience-recovery.md
+++ b/.ideas/llm-wiki/wiki/resilience-recovery.md
@@ -1,0 +1,41 @@
+---
+title: Resilience, Disaster Recovery & Incidents
+type: concept
+status: reviewed
+sources: [015, 045, 051, 057, 014, combo-09, xcombo-07, research-sources]
+updated: 2026-06-24
+---
+
+# Resilience, Disaster Recovery & Incidents
+
+When something breaks in a 24/7 autonomous system, how do we recover safely? One resilience stack across
+three blast radii — one company, the whole instance, and the live operation.
+
+## The resilience stack (combo-09)
+
+- **Company point-in-time rewind (015)** — lightweight snapshots + checkpoints before high-risk events;
+  fork-restore (safe) before in-place rewind (destructive). Honestly scoped: restores control-plane
+  state, not the outside world. (Shares the simulation/restore engine with [[pre-flight]] and
+  [[security-governance|Provenance & Replay]].)
+- **DR backup verification (051)** — integrity manifests + **automated restore drills** into a throwaway
+  DB (an untested backup is a hope) + a recovery-posture surface (RPO/RTO).
+- **Incident management & on-call (057)** — generalize budget incidents into a real incident object with
+  severity + on-call routing; auto-raisable from existing signals (budget, reliability, security,
+  deadlock); SEV1 can auto-Drain ([[runtime-control-and-safety]]).
+- **Plugin versioning/rollback/health (045)** — pin, staged upgrade with auto-rollback, health monitoring.
+
+## Relationship to the Self-Healing Org
+
+This combo heals *data/infra/runtime*; the [[agent-quality-and-staffing|Self-Healing Org]] (xcombo-07)
+applies the same detect→diagnose→remediate→verify loop to *staffing & structure*. Together: a company that
+repairs both its infrastructure and its workforce.
+
+## Provenance
+
+- Ideas `014,015,045,051,057`; combos `combo-09`, `xcombo-07`.
+- `raw/research-sources.md` → `[self-healing]`.
+
+## Open questions for human review
+
+- Restore is the hard part everywhere (transactional integrity, in-flight runs, un-undoable external side effects) — framing?
+- Incident fast-path that genuinely bypasses normal scheduling for mixed agent+human responders.

--- a/.ideas/llm-wiki/wiki/runtime-control-and-safety.md
+++ b/.ideas/llm-wiki/wiki/runtime-control-and-safety.md
@@ -1,0 +1,49 @@
+---
+title: Runtime Control & Safety
+type: concept
+status: reviewed
+sources: [001, 002, 005, 014, 024, 035, 042, 061, combo-01, xcombo-01, xcombo-05, research-sources]
+updated: 2026-06-24
+---
+
+# Runtime Control & Safety
+
+How much should run right now, and how is it stopped safely? Today Paperclip enforces concurrency only
+*per agent* (no fleet/company cap), hits budgets post-hoc, and has no instant halt — the #1 risk for an
+always-on fleet (runaway spend, machine thrash, rate-limit storms).
+
+## The unified control plane (combo-01)
+
+One admission/throttle seam at the single run-start choke point evaluates nested limits:
+- **Per run** — wall-clock / tool-call / token / cost caps with graceful checkpointed wind-down (024).
+- **Per agent** — concurrency + adaptive heartbeat (035, idle backoff / load speed-up) + WIP limits (061).
+- **Per company / fleet** — a concurrency governor (001) modulated by quiet-hours profiles (005) and a
+  predictive budget breaker that throttles *before* the wall (002).
+- **Safety** — Drain (stop starting) + Panic Stop (halt+cancel) with non-stampeding resume (014).
+- **Correctness** — workspace soft-locks so parallel agents don't clobber (042).
+
+Precedence: **panic/drain > breaker > manual > schedule > default.**
+
+## The operator abstraction: the Autonomy Dial (xcombo-01)
+
+Collapse the knobs into one ordinal "how much leash" control (Level 0–5), each level a coherent preset
+across admission/breaker/auto-approve/caps/heartbeat/[[security-governance|trust]]. It auto-retreats on
+trips and auto-advances as the company proves itself — see [[agent-quality-and-staffing]] (trust ramp).
+
+## The unattended profile: Night-Shift (xcombo-05)
+
+An armed "no-human-present" posture bundling spend bounds, local-first resilience ([[model-economy]]),
+idle backoff, egress lock, human coverage, and a morning digest. Grounded in real 2026 overnight-agent
+incidents (a coding agent burning $$ overnight; an agent hijacking GPUs for crypto-mining → egress lock).
+Surfaces a new requirement: **mid-run credential renewal** for long unattended runs.
+
+## Provenance
+
+- Ideas `001,002,005,014,024,035,042,061`; combos `combo-01`, `xcombo-01`, `xcombo-05`.
+- `raw/research-sources.md` → `[guardrails]`.
+
+## Open questions for human review
+
+- Ship order: governor (001) first, or the Autonomy Dial abstraction over stubs?
+- Where exactly is the single choke point that must honor `halted` (incl. process recovery)?
+- Default Autonomy-Dial level for a fresh company?

--- a/.ideas/llm-wiki/wiki/security-governance.md
+++ b/.ideas/llm-wiki/wiki/security-governance.md
@@ -1,0 +1,55 @@
+---
+title: Security, Governance & Compliance
+type: concept
+status: reviewed
+sources: [020, 021, 022, 023, 034, 043, 050, 009, 016, 025, 024, combo-08, xcombo-04, xcombo-06, research-sources]
+updated: 2026-06-24
+---
+
+# Security, Governance & Compliance
+
+An autonomous, code-executing AI workforce spending real money is a serious security surface, and
+Paperclip's controls are powerful but scattered across silos.
+
+## Zero-trust layer (combo-08)
+
+One policy + enforcement + tamper-proof-record stack:
+- **Policy-as-code (043)** — `when <condition> then <effect>` rules at one decision seam the silos enforce.
+- **Exfiltration controls** — outbound secret-leak scanning (020, content) + egress allow-listing
+  (022, wire) = both channels.
+- **JIT secret leasing (021)** — TTL'd leases, not standing grants.
+- **Work-product security scanning (050)** — CVE/license/SAST at the review gate.
+- **Tamper-evident audit log (023)** — hash-chained; every governed decision lands here.
+- **Retention & PII governance (034)** — TTLs, anonymization, right-to-erasure (keep proof, drop payload).
+
+## Trust as universal currency (xcombo-04)
+
+One **continuous, behavior-updated trust score** per agent identity that *every* gate reads (egress 022,
+secret-lease TTL 021, auto-approve 016, assignment 025, per-run caps 024), driven by the probation/ramp
+(009). A drifting/compromised agent loses egress, secrets, auto-approval, and concurrency
+*simultaneously*; kill-switch at trust=0. Grounded in 2026 zero-trust-for-agents (continuous
+authorization; agents as first-class identities; least privilege scoped to the task).
+
+## Provenance & Replay — auditability (xcombo-06)
+
+Distinct from [[observability-and-health|observability]]: a **Decision Provenance Record**
+(inputs+model+prompt+policy+trace+diff+cost, hash-chained into 023) reconstructs any past decision; plus
+fork-restore + deterministic `planOnly` re-run to **reproduce** or **counterfactually** test it ("would
+the new policy have blocked this?"). Grounded in EU AI Act Article 12 (lifetime logging; high-risk
+deadline 2026-08-02) and R-LAM deterministic replay.
+
+## Links
+
+Trust feeds [[agent-quality-and-staffing]] and [[runtime-control-and-safety|the Autonomy Dial]]; replay
+shares the simulation engine with [[pre-flight]]; audit underpins [[multi-company-and-ecosystem]].
+
+## Provenance
+
+- Ideas `009,016,020,021,022,023,024,025,034,043,050`; combos `combo-08`, `xcombo-04`, `xcombo-06`.
+- `raw/research-sources.md` → `[zero-trust]`, `[provenance]`.
+
+## Open questions for human review
+
+- Roll out policy-as-code advisory-first (log would-be decisions), then enforce — acceptable parity bar?
+- Egress enforcement is best-effort on bare local processes — how to surface that honestly?
+- Trust-score input model & anti-oscillation before any gate enforces on it.

--- a/.ideas/llm-wiki/wiki/software-building-and-self-hosting.md
+++ b/.ideas/llm-wiki/wiki/software-building-and-self-hosting.md
@@ -1,0 +1,53 @@
+---
+title: Software-Building & Self-Hosting (incl. Bootstrap Ladder)
+type: concept
+status: reviewed
+sources: [065, xcombo-11, xcombo-code-knowledge-flywheel, _skeleton-reference, xcombo-01, research-sources]
+updated: 2026-06-24
+---
+
+# Software-Building & Self-Hosting
+
+The thesis that Paperclip can build software as a first-class capability — and, ultimately, **build
+itself**. The ultimate dogfood: the product builds the product.
+
+## Part A — software engineering as a capability (idea 065)
+
+Weld existing pieces into a real engineering loop: git-backed workspaces, a build/test/lint loop, the
+[[human-in-the-loop|PR-style change-review]] (017), CI-at-the-review-gate (eval 011 +
+[[security-governance|security scan]] 050), and an eng-org blueprint (PM→Architect→Devs→QA→DevOps) driven
+by the `devon` / `pm-tdd` / `qa-engineer` skills.
+
+## Part B — self-hosting
+
+Point a Paperclip company at its own repo with `.ideas/` *as the goal tree*. The distinctive, safer bet
+(vs. Darwin-Gödel-style self-modifying scaffolds, which the literature warns are "costly and may not
+generalize"): **self-improvement as a governed *org process*** — agents + budgets + approvals + eval
+gates + audit — not weight/scaffold surgery. Guardrail: the self-builder must **not weaken its own
+guardrails** (mandatory human ratification on safety/governance/runtime diffs, full audit, revert).
+
+## Part C — the Bootstrap Ladder (xcombo-11)
+
+Scale down to the [[paperclip-architecture-skeleton|5-table kernel]], then climb a **capability
+curriculum**, one verified rung at a time. Each rung = **build → verify (eval + [[pre-flight]] + human
+gate) → ratchet**, raising **capability** (the [[knowledge-and-memory|Code-Knowledge Flywheel]] enriches
+the self-model so the next rung is cheaper) *and* **earned autonomy** ([[runtime-control-and-safety|the
+Autonomy Dial]]) *together* — so autonomy never outruns proven verification (e.g. auto-merge unlocks only
+after the QA+eval rungs exist). Grounded in Darwin/Huxley-Gödel + automatic-curriculum-learning +
+earned-autonomy research, heeding the *statistical limits of self-improvement*.
+
+## Why it's now plausible
+
+Runtime self-evolution is proven (Live-SWE-agent: 77.4% SWE-bench Verified by evolving its own scaffold),
+and the kernel→rings architecture makes "scale down then build up" a true subset, not a rewrite.
+
+## Provenance
+
+- Idea `065`; combos `xcombo-11`, `xcombo-code-knowledge-flywheel`; `_skeleton-reference.md`.
+- `raw/research-sources.md` → `[swe-agents]`, `[self-improve]`.
+
+## Open questions for human review
+
+- The first rung after the kernel — which capability has the highest leverage?
+- How to *prove* autonomy trails verification capability (the safety-critical coupling)?
+- Acceptable scope of the self-builder touching its own control-plane code, and under what gates?


### PR DESCRIPTION
## Summary

First commit of the `.ideas/` catalog — the approved idea set for Paperclip's roadmap — plus a corrected phase scope for the highest-priority combination.

- **66 individual ideas** (`.ideas/001-*.md` … `066-*.md`), each with suggestion, implementation sketch, and complexity rating.
- **13 synthesized combinations** (`.ideas/combinations/`) that merge ideas converging on the same seam/data-model/surface.
- **llm-wiki** cross-reference layer and READMEs.

## Combo 01 — Unified Runtime Control Plane (corrected phasing)

Combo 01 governs *how many agent runs execute at once* (fleet/company concurrency cap, per-run resource caps, predictive budget breaker, quiet-hours, WIP limits, Big Red Button, workspace locks). It's rated importance **9/10** and is #1 in the build order because nearly every other combo composes onto it.

The phasing was revised so **Phase 1 builds four shared seams as extension points** rather than single-purpose code — otherwise later phases retrofit competing cap writers and rewrite run-selection, defeating the compose-by-construction benefit that justifies fusing the ideas:

1. **Effective-cap resolver** with a locked precedence order (`panic/drain > breaker > manual override > schedule > default`).
2. **Admission seam** at `heartbeat.ts` as the only path a run can start.
3. **Pluggable run-selection/wakeup hook** so WIP + lock-awareness refine it later without a rewrite.
4. **Reconciler** scoped for counters + leases from day one, not just slot counts.

See `combo-01-phasing-corrected.md` for per-phase exit criteria and the changed-vs-original rationale.

## Notes

- `.ideas/` was previously untracked; this is its first commit. No source code changes — documentation/planning only.
- Implementation of each combo will follow in dedicated branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)