### PR TITLE
fix(heartbeat): bound automatic issue continuations

### DIFF
--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -282,10 +282,13 @@ async function spawnOrphanedProcessGroup() {
 describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
   let db!: ReturnType<typeof createDb>;
   let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+  let previousContinuationBaseDelayMs: string | undefined;
   const childProcesses = new Set<ChildProcess>();
   const cleanupPids = new Set<number>();
 
   beforeAll(async () => {
+    previousContinuationBaseDelayMs = process.env.PAPERCLIP_CONTINUATION_BASE_DELAY_MS;
+    process.env.PAPERCLIP_CONTINUATION_BASE_DELAY_MS = "5";
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-heartbeat-recovery-");
     db = createDb(tempDb.connectionString);
   }, 20_000);
@@ -427,6 +430,11 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
   });
 
   afterAll(async () => {
+    if (previousContinuationBaseDelayMs === undefined) {
+      delete process.env.PAPERCLIP_CONTINUATION_BASE_DELAY_MS;
+    } else {
+      process.env.PAPERCLIP_CONTINUATION_BASE_DELAY_MS = previousContinuationBaseDelayMs;
+    }
     for (const child of childProcesses) {
       child.kill("SIGKILL");
     }
@@ -453,6 +461,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     includeIssue?: boolean;
     runErrorCode?: string | null;
     runError?: string | null;
+    runtimeConfig?: Record<string, unknown>;
     contextSnapshot?: Record<string, unknown>;
   }) {
     const companyId = randomUUID();
@@ -479,7 +488,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       status: input?.agentStatus ?? "paused",
       adapterType: input?.adapterType ?? "codex_local",
       adapterConfig: {},
-      runtimeConfig: {},
+      runtimeConfig: input?.runtimeConfig ?? {},
       permissions: {},
     });
 
@@ -533,6 +542,37 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     }
 
     return { companyId, agentId, runId, wakeupRequestId, issueId };
+  }
+
+  async function seedIssueAutomationRuns(input: {
+    companyId: string;
+    agentId: string;
+    issueId: string;
+    count: number;
+  }) {
+    const now = new Date("2026-03-19T00:01:00.000Z");
+    if (input.count <= 0) return [];
+    const rows = Array.from({ length: input.count }, () => ({
+      id: randomUUID(),
+      companyId: input.companyId,
+      agentId: input.agentId,
+      invocationSource: "automation" as const,
+      triggerDetail: "system" as const,
+      status: "failed" as const,
+      contextSnapshot: {
+        issueId: input.issueId,
+        taskId: input.issueId,
+        wakeReason: "issue_continuation_needed",
+        retryReason: "issue_continuation_needed",
+      },
+      errorCode: "test_existing_continuation",
+      error: "existing continuation attempt",
+      startedAt: now,
+      finishedAt: now,
+      updatedAt: now,
+    }));
+    await db.insert(heartbeatRuns).values(rows);
+    return rows;
   }
 
   async function seedEnvironmentLeaseFixture(input: {
@@ -1315,6 +1355,111 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       .then((rows) => rows[0] ?? null);
     expect(lease?.status).toBe("failed");
     expect(lease?.releasedAt).toBeTruthy();
+  });
+
+  it("blocks direct continuation requeue when the per-issue automation budget is exhausted", async () => {
+    const { companyId, agentId, runId, issueId } = await seedRunFixture({
+      agentStatus: "idle",
+      processPid: 999_999_999,
+      processLossRetryCount: 1,
+    });
+    await seedIssueAutomationRuns({ companyId, agentId, issueId, count: 2 });
+    const heartbeat = heartbeatService(db, {
+      issueContinuationCap: 2,
+      continuationBaseDelayMs: 5,
+    });
+
+    const result = await heartbeat.reapOrphanedRuns();
+    expect(result.reaped).toBe(1);
+    expect(result.runIds).toEqual([runId]);
+
+    const directContinuations = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(and(eq(heartbeatRuns.retryOfRunId, runId), eq(heartbeatRuns.invocationSource, "automation")));
+    expect(directContinuations).toHaveLength(0);
+
+    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(issue?.status).toBe("blocked");
+    expect(issue?.executionRunId).toBeNull();
+    expect(issue?.checkoutRunId).toBeNull();
+    await waitForHeartbeatIdle(db);
+  });
+
+  it("leaves below-cap direct continuation queued until the exponential backoff elapses", async () => {
+    const { companyId, agentId, runId, issueId } = await seedRunFixture({
+      agentStatus: "idle",
+      processPid: 999_999_999,
+      processLossRetryCount: 1,
+    });
+    await seedIssueAutomationRuns({ companyId, agentId, issueId, count: 1 });
+    const heartbeat = heartbeatService(db, {
+      issueContinuationCap: 10,
+      continuationBaseDelayMs: 25,
+    });
+    const executeCallsBeforeReap = mockAdapterExecute.mock.calls.length;
+
+    const result = await heartbeat.reapOrphanedRuns();
+    expect(result.reaped).toBe(1);
+    expect(result.runIds).toEqual([runId]);
+
+    const [retryRun] = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(and(eq(heartbeatRuns.retryOfRunId, runId), eq(heartbeatRuns.invocationSource, "automation")));
+    expect(retryRun).toBeTruthy();
+    expect(retryRun?.status).toBe("queued");
+    expect((retryRun?.contextSnapshot as Record<string, unknown> | undefined)?.retryReason).toBe(
+      "issue_continuation_needed",
+    );
+    expect(mockAdapterExecute).toHaveBeenCalledTimes(executeCallsBeforeReap);
+
+    const startedRun = await waitForValue(async () => {
+      if (!retryRun) return null;
+      const row = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.id, retryRun.id)).then((rows) => rows[0] ?? null);
+      return row && row.status !== "queued" ? row : null;
+    }, 2_000);
+    expect(["running", "succeeded"]).toContain(startedRun?.status);
+    expect(mockAdapterExecute.mock.calls.length).toBeGreaterThan(executeCallsBeforeReap);
+    if (retryRun) {
+      const settledRun = await waitForRunToSettle(heartbeat, retryRun.id, 2_000);
+      expect(settledRun?.status).toBe("succeeded");
+    }
+  });
+
+  it("blocks direct continuation requeue when wakeOnDemand is disabled", async () => {
+    const { agentId, runId, issueId } = await seedRunFixture({
+      agentStatus: "idle",
+      processPid: 999_999_999,
+      processLossRetryCount: 1,
+      runtimeConfig: {
+        heartbeat: {
+          wakeOnDemand: false,
+          maxConcurrentRuns: 1,
+        },
+      },
+    });
+    const heartbeat = heartbeatService(db, {
+      issueContinuationCap: 10,
+      continuationBaseDelayMs: 5,
+    });
+
+    const result = await heartbeat.reapOrphanedRuns();
+    expect(result.reaped).toBe(1);
+    expect(result.runIds).toEqual([runId]);
+
+    const directContinuations = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(and(eq(heartbeatRuns.retryOfRunId, runId), eq(heartbeatRuns.invocationSource, "automation")));
+    expect(directContinuations).toHaveLength(0);
+
+    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(issue?.assigneeAgentId).toBe(agentId);
+    expect(issue?.status).toBe("blocked");
+    expect(issue?.executionRunId).toBeNull();
+    expect(issue?.checkoutRunId).toBeNull();
+    await waitForHeartbeatIdle(db);
   });
 
   it.skipIf(process.platform === "win32")("reaps orphaned descendant process groups when the parent pid is already gone", async () => {

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -967,6 +967,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       name: "Paperclip",
       issuePrefix,
       requireBoardApprovalForNewAgents: false,
+      defaultResponsibleUserId: "responsible-user",
     });
 
     await db.insert(agents).values({
@@ -1203,6 +1204,274 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     return { companyId, agentId, runId, wakeupRequestId, issueId };
   }
 
+  async function seedQueuedAgentRunsFixture(count: number) {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const now = new Date("2026-03-19T00:00:00.000Z");
+    const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix,
+      requireBoardApprovalForNewAgents: false,
+      defaultResponsibleUserId: "responsible-user",
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "CodexCoder",
+      role: "engineer",
+      status: "idle",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {
+        heartbeat: {
+          wakeOnDemand: true,
+          maxConcurrentRuns: 1,
+        },
+      },
+      permissions: {},
+    });
+
+    const wakeupRows = Array.from({ length: count }, (_, index) => {
+      const wakeupRequestId = randomUUID();
+      const runId = randomUUID();
+      const createdAt = new Date(now.getTime() + index);
+      return {
+        wakeupRequest: {
+          id: wakeupRequestId,
+          companyId,
+          agentId,
+          source: "automation",
+          triggerDetail: "system",
+          reason: "test_parallel_start",
+          payload: {},
+          status: "queued",
+          runId,
+          requestedAt: createdAt,
+          updatedAt: createdAt,
+        },
+        run: {
+          id: runId,
+          companyId,
+          agentId,
+          invocationSource: "automation",
+          triggerDetail: "system",
+          status: "queued",
+          wakeupRequestId,
+          contextSnapshot: { wakeReason: "test_parallel_start" },
+          responsibleUserId: "responsible-user",
+          createdAt,
+          updatedAt: createdAt,
+        },
+      };
+    });
+
+    await db.insert(agentWakeupRequests).values(wakeupRows.map((row) => row.wakeupRequest));
+    await db.insert(heartbeatRuns).values(wakeupRows.map((row) => row.run));
+
+    return {
+      companyId,
+      agentId,
+      runIds: wakeupRows.map((row) => row.run.id),
+    };
+  }
+
+  it("serializes queued-run starts per agent under maxConcurrentRuns", async () => {
+    const releases: Array<() => void> = [];
+    mockAdapterExecute.mockImplementation(async () =>
+      new Promise((resolve) => {
+        releases.push(() => resolve({
+          exitCode: 0,
+          signal: null,
+          timedOut: false,
+          errorMessage: null,
+          summary: "Recovered stranded heartbeat work.",
+          provider: "test",
+          model: "test-model",
+        }));
+      }),
+    );
+
+    const { agentId } = await seedQueuedAgentRunsFixture(5);
+    const heartbeat = heartbeatService(db);
+
+    try {
+      await Promise.all(Array.from({ length: 10 }, () => heartbeat.resumeQueuedRuns()));
+      await waitForValue(async () => mockAdapterExecute.mock.calls.length > 0 ? true : null, 2_000);
+
+      const runs = await db
+        .select()
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.agentId, agentId));
+      const runningRuns = runs.filter((run) => run.status === "running");
+      const queuedRuns = runs.filter((run) => run.status === "queued");
+
+      expect(runningRuns).toHaveLength(1);
+      expect(queuedRuns).toHaveLength(4);
+      expect(runningRuns[0]?.startedAt).toBeTruthy();
+    } finally {
+      const now = new Date();
+      await db
+        .update(heartbeatRuns)
+        .set({
+          status: "cancelled",
+          finishedAt: now,
+          updatedAt: now,
+          errorCode: "test_cleanup",
+          error: "Cancelled by queued-run serialization test",
+        })
+        .where(and(eq(heartbeatRuns.agentId, agentId), eq(heartbeatRuns.status, "queued")));
+      for (const release of releases) release();
+      await waitForHeartbeatIdle(db, 5_000);
+    }
+  });
+
+  it("skips system automation wakeups when the per-issue continuation budget is exhausted", async () => {
+    const { companyId, agentId, issueId } = await seedRunFixture({
+      agentStatus: "idle",
+      runStatus: "failed",
+    });
+    await seedIssueAutomationRuns({ companyId, agentId, issueId, count: 2 });
+    const heartbeat = heartbeatService(db, {
+      issueContinuationCap: 2,
+      continuationBaseDelayMs: 5,
+    });
+
+    const run = await heartbeat.wakeup(agentId, {
+      source: "automation",
+      triggerDetail: "system",
+      payload: { issueId },
+    });
+
+    expect(run).toBeNull();
+
+    const skippedRequests = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(and(
+        eq(agentWakeupRequests.agentId, agentId),
+        eq(agentWakeupRequests.reason, "issue.continuationBudget.exhausted"),
+      ));
+    expect(skippedRequests).toHaveLength(1);
+    expect(skippedRequests[0]).toMatchObject({
+      source: "automation",
+      triggerDetail: "system",
+      status: "skipped",
+    });
+
+    const automationRuns = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(and(
+        eq(heartbeatRuns.agentId, agentId),
+        eq(heartbeatRuns.invocationSource, "automation"),
+        eq(heartbeatRuns.triggerDetail, "system"),
+      ));
+    expect(automationRuns).toHaveLength(2);
+  });
+
+  it("does not apply the per-issue continuation budget to manual automation wakeups", async () => {
+    const releases: Array<() => void> = [];
+    mockAdapterExecute.mockImplementationOnce(async () =>
+      new Promise((resolve) => {
+        releases.push(() => resolve({
+          exitCode: 0,
+          signal: null,
+          timedOut: false,
+          errorMessage: null,
+          summary: "Manual wake completed.",
+          provider: "test",
+          model: "test-model",
+        }));
+      }),
+    );
+    const { companyId, agentId, issueId } = await seedRunFixture({
+      agentStatus: "idle",
+      runStatus: "failed",
+    });
+    await seedIssueAutomationRuns({ companyId, agentId, issueId, count: 2 });
+    const heartbeat = heartbeatService(db, {
+      issueContinuationCap: 2,
+      continuationBaseDelayMs: 5,
+    });
+
+    const run = await heartbeat.wakeup(agentId, {
+      source: "automation",
+      triggerDetail: "manual",
+      payload: { issueId },
+    });
+
+    try {
+      expect(run).toBeTruthy();
+      await waitForValue(async () => mockAdapterExecute.mock.calls.length > 0 ? true : null, 2_000);
+
+      const skippedRequests = await db
+        .select()
+        .from(agentWakeupRequests)
+        .where(and(
+          eq(agentWakeupRequests.agentId, agentId),
+          eq(agentWakeupRequests.reason, "issue.continuationBudget.exhausted"),
+        ));
+      expect(skippedRequests).toHaveLength(0);
+
+      const manualRuns = await db
+        .select()
+        .from(heartbeatRuns)
+        .where(and(
+          eq(heartbeatRuns.agentId, agentId),
+          eq(heartbeatRuns.invocationSource, "automation"),
+          eq(heartbeatRuns.triggerDetail, "manual"),
+        ));
+      expect(manualRuns).toHaveLength(1);
+    } finally {
+      for (const release of releases) release();
+      await waitForHeartbeatIdle(db, 5_000);
+    }
+  });
+
+  it("does not apply the per-issue continuation budget to system automation wakeups without an issue", async () => {
+    const { companyId, agentId, issueId } = await seedRunFixture({
+      agentStatus: "idle",
+      runStatus: "failed",
+    });
+    await seedIssueAutomationRuns({ companyId, agentId, issueId, count: 2 });
+    const heartbeat = heartbeatService(db, {
+      issueContinuationCap: 2,
+      continuationBaseDelayMs: 5,
+    });
+
+    const run = await heartbeat.wakeup(agentId, {
+      source: "automation",
+      triggerDetail: "system",
+      payload: { note: "no issue context" },
+    });
+
+    expect(run).toBeTruthy();
+
+    const skippedRequests = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(and(
+        eq(agentWakeupRequests.agentId, agentId),
+        eq(agentWakeupRequests.reason, "issue.continuationBudget.exhausted"),
+      ));
+    expect(skippedRequests).toHaveLength(0);
+
+    const systemRuns = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(and(
+        eq(heartbeatRuns.agentId, agentId),
+        eq(heartbeatRuns.invocationSource, "automation"),
+        eq(heartbeatRuns.triggerDetail, "system"),
+      ));
+    expect(systemRuns).toHaveLength(3);
+    await waitForHeartbeatIdle(db, 5_000);
+  });
+
   it("keeps a local run active when the recorded pid is still alive", async () => {
     const child = spawnAliveProcess();
     childProcesses.add(child);
@@ -1420,7 +1689,13 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       return row && row.status !== "queued" ? row : null;
     }, 2_000);
     expect(["running", "succeeded"]).toContain(startedRun?.status);
-    expect(mockAdapterExecute.mock.calls.length).toBeGreaterThan(executeCallsBeforeReap);
+    await waitForValue(
+      () =>
+        mockAdapterExecute.mock.calls.length > executeCallsBeforeReap
+          ? mockAdapterExecute.mock.calls.length
+          : null,
+      2_000,
+    );
     if (retryRun) {
       const settledRun = await waitForRunToSettle(heartbeat, retryRun.id, 2_000);
       expect(settledRun?.status).toBe("succeeded");

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -85,8 +85,17 @@ export interface Config {
   feedbackExportBackendToken: string | undefined;
   heartbeatSchedulerEnabled: boolean;
   heartbeatSchedulerIntervalMs: number;
+  issueContinuationCap: number;
+  continuationBaseDelayMs: number;
   companyDeletionEnabled: boolean;
   telemetryEnabled: boolean;
+}
+
+function readClampedIntegerEnv(name: string, defaultValue: number, min: number, max: number) {
+  const raw = process.env[name];
+  const parsed = raw === undefined ? NaN : Number(raw);
+  const value = Number.isFinite(parsed) ? Math.floor(parsed) : defaultValue;
+  return Math.max(min, Math.min(max, value));
 }
 
 function detectTailnetBindHost(): string | undefined {
@@ -265,6 +274,13 @@ export function loadConfig(): Config {
       fileDatabaseBackup?.dir ??
       resolveDefaultBackupDir(),
   );
+  const issueContinuationCap = readClampedIntegerEnv("PAPERCLIP_ISSUE_CONTINUATION_CAP", 10, 1, 200);
+  const continuationBaseDelayMs = readClampedIntegerEnv(
+    "PAPERCLIP_CONTINUATION_BASE_DELAY_MS",
+    15_000,
+    0,
+    600_000,
+  );
   const bindValidationErrors = validateConfiguredBindMode({
     deploymentMode,
     deploymentExposure,
@@ -331,6 +347,8 @@ export function loadConfig(): Config {
     feedbackExportBackendToken,
     heartbeatSchedulerEnabled: process.env.HEARTBEAT_SCHEDULER_ENABLED !== "false",
     heartbeatSchedulerIntervalMs: Math.max(10000, Number(process.env.HEARTBEAT_SCHEDULER_INTERVAL_MS) || 30000),
+    issueContinuationCap,
+    continuationBaseDelayMs,
     companyDeletionEnabled,
     telemetryEnabled: fileConfig?.telemetry?.enabled ?? true,
   };

--- a/server/src/services/agent-start-lock.ts
+++ b/server/src/services/agent-start-lock.ts
@@ -1,47 +1,22 @@
-import { logger } from "../middleware/logger.js";
-
-const AGENT_START_LOCK_STALE_MS = 30_000;
-const startLocksByAgent = new Map<string, { promise: Promise<void>; startedAtMs: number }>();
-
-async function waitForAgentStartLock(agentId: string, lock: { promise: Promise<void>; startedAtMs: number }) {
-  const elapsedMs = Date.now() - lock.startedAtMs;
-  const remainingMs = AGENT_START_LOCK_STALE_MS - elapsedMs;
-  if (remainingMs <= 0) {
-    logger.warn({ agentId, staleMs: elapsedMs }, "agent start lock stale; continuing queued-run start");
-    return;
-  }
-
-  let timedOut = false;
-  let timeout: ReturnType<typeof setTimeout> | null = null;
-  await Promise.race([
-    lock.promise,
-    new Promise<void>((resolve) => {
-      timeout = setTimeout(() => {
-        timedOut = true;
-        resolve();
-      }, remainingMs);
-    }),
-  ]);
-  if (timeout) clearTimeout(timeout);
-
-  if (timedOut) {
-    logger.warn({ agentId, staleMs: AGENT_START_LOCK_STALE_MS }, "agent start lock timed out; continuing queued-run start");
-  }
-}
+const startLocksByAgent = new Map<string, Promise<void>>();
 
 export async function withAgentStartLock<T>(agentId: string, fn: () => Promise<T>) {
-  const previous = startLocksByAgent.get(agentId);
-  const waitForPrevious = previous ? waitForAgentStartLock(agentId, previous) : Promise.resolve();
-  const run = waitForPrevious.then(fn);
-  const marker = run.then(
-    () => undefined,
-    () => undefined,
+  const previous = startLocksByAgent.get(agentId) ?? Promise.resolve();
+  let releaseCurrent!: () => void;
+  const current = new Promise<void>((resolve) => {
+    releaseCurrent = resolve;
+  });
+  const marker = previous.then(
+    () => current,
+    () => current,
   );
-  startLocksByAgent.set(agentId, { promise: marker, startedAtMs: Date.now() });
+  startLocksByAgent.set(agentId, marker);
   try {
-    return await run;
+    await previous.catch(() => undefined);
+    return await fn();
   } finally {
-    if (startLocksByAgent.get(agentId)?.promise === marker) {
+    releaseCurrent();
+    if (startLocksByAgent.get(agentId) === marker) {
       startLocksByAgent.delete(agentId);
     }
   }

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -231,11 +231,14 @@ import {
   type EffectiveRunConfigSecretManifestEntry,
 } from "./effective-run-config-fingerprints.js";
 import type { PluginWorkerManager } from "./plugin-worker-manager.js";
+import { loadConfig } from "../config.js";
 
 const MAX_LIVE_LOG_CHUNK_BYTES = 8 * 1024;
 const MAX_PERSISTED_LOG_CHUNK_CHARS = 64 * 1024;
 const MAX_RUN_EVENT_PAYLOAD_STRING_CHARS = 16 * 1024;
 const MAX_RUN_EVENT_PAYLOAD_ARRAY_ITEMS = 50;
+const CONTINUATION_BACKOFF_MAX_MS = 600_000;
+const delayedQueuedRunStarts = new Map<string, number>();
 
 export function redactDetectedSuccessfulRunProgressSummaryForBoard(
   summary: string,
@@ -4794,9 +4797,16 @@ export type HeartbeatEnvironmentRuntime = ReturnType<typeof environmentRuntimeSe
 export interface HeartbeatServiceOptions {
   pluginWorkerManager?: PluginWorkerManager;
   environmentRuntime?: HeartbeatEnvironmentRuntime;
+  issueContinuationCap?: number;
+  continuationBaseDelayMs?: number;
 }
 
 export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) {
+  const config = loadConfig();
+  const issueContinuationCap = Math.max(1, Math.min(200, Math.floor(options.issueContinuationCap ?? config.issueContinuationCap)));
+  const continuationBaseDelayMs = Math.max(0, Math.min(CONTINUATION_BACKOFF_MAX_MS, Math.floor(
+    options.continuationBaseDelayMs ?? config.continuationBaseDelayMs,
+  )));
   const instanceSettings = instanceSettingsService(db);
   const getCurrentUserRedactionOptions = async () => ({
     enabled: (await instanceSettings.getGeneral()).censorUsernameInLogs,
@@ -9780,6 +9790,32 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     return recovery.reconcileIssueGraphLiveness(opts);
   }
 
+  function continuationStartDelayMs(existingAutomationRunCount: number) {
+    if (existingAutomationRunCount <= 0 || continuationBaseDelayMs <= 0) return 0;
+    return Math.min(
+      continuationBaseDelayMs * (2 ** existingAutomationRunCount),
+      CONTINUATION_BACKOFF_MAX_MS,
+    );
+  }
+
+  function scheduleDelayedQueuedRunStart(run: typeof heartbeatRuns.$inferSelect, delayMs: number) {
+    if (delayMs <= 0) return;
+    const notBeforeMs = Date.now() + delayMs;
+    delayedQueuedRunStarts.set(run.id, notBeforeMs);
+    // The delay is process-local by design; if the server restarts,
+    // resumeQueuedRuns picks the queued run up on the next scheduler sweep.
+    const timeout = setTimeout(() => {
+      delayedQueuedRunStarts.delete(run.id);
+      void startNextQueuedRunForAgent(run.agentId).catch((err) => {
+        logger.error(
+          { err, runId: run.id, agentId: run.agentId, delayMs },
+          "delayed continuation queued run start failed",
+        );
+      });
+    }, delayMs);
+    timeout.unref?.();
+  }
+
   async function updateRuntimeState(
     agent: typeof agents.$inferSelect,
     run: typeof heartbeatRuns.$inferSelect,
@@ -9856,11 +9892,21 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         .from(heartbeatRuns)
         .where(and(eq(heartbeatRuns.agentId, agentId), eq(heartbeatRuns.status, "queued")))
         .orderBy(asc(heartbeatRuns.createdAt));
-      if (queuedRuns.length === 0) return [];
+      const nowMs = Date.now();
+      const startableQueuedRuns = queuedRuns.filter((queuedRun) => {
+        const notBeforeMs = delayedQueuedRunStarts.get(queuedRun.id);
+        if (notBeforeMs === undefined) return true;
+        if (nowMs >= notBeforeMs) {
+          delayedQueuedRunStarts.delete(queuedRun.id);
+          return true;
+        }
+        return false;
+      });
+      if (startableQueuedRuns.length === 0) return [];
 
-      const dependencyReadiness = await listQueuedRunDependencyReadiness(agent.companyId, queuedRuns);
+      const dependencyReadiness = await listQueuedRunDependencyReadiness(agent.companyId, startableQueuedRuns);
       const queuedIssueIds = [...new Set(
-        queuedRuns
+        startableQueuedRuns
           .map((run) => readNonEmptyString(parseObject(run.contextSnapshot).issueId))
           .filter((issueId): issueId is string => Boolean(issueId)),
       )];
@@ -9878,7 +9924,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         );
       const issueById = new Map(issueRows.map((row) => [row.id, row]));
       const companyAgents = await listCompanyAgentOrgRows(agent.companyId);
-      const prioritizedRuns = [...queuedRuns].sort((left, right) => {
+      const prioritizedRuns = [...startableQueuedRuns].sort((left, right) => {
         const leftIssueId = readNonEmptyString(parseObject(left.contextSnapshot).issueId);
         const rightIssueId = readNonEmptyString(parseObject(right.contextSnapshot).issueId);
         const leftReadiness = leftIssueId ? dependencyReadiness.get(leftIssueId) : null;
@@ -12842,15 +12888,11 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         };
       }
 
-      const shouldBlockImmediately =
-        !recoveryAgentInvokable ||
-        !recoveryAgent ||
-        isWorkspaceValidationFailedRun(run) ||
-        isConfigurationIncompleteFailedRun(run) ||
-        didAutomaticRecoveryFail(run, issue.status === "todo" ? "assignment_recovery" : "issue_continuation_needed");
-      if (shouldBlockImmediately) {
-        const workspaceValidationFailure = isWorkspaceValidationFailedRun(run);
-        const configurationIncompleteFailure = isConfigurationIncompleteFailedRun(run);
+      const blockedPromotion = (
+        recoveryCause?: typeof WORKSPACE_VALIDATION_RECOVERY_CAUSE | typeof CONFIGURATION_INCOMPLETE_RECOVERY_CAUSE,
+      ) => {
+        const workspaceValidationFailure = recoveryCause === WORKSPACE_VALIDATION_RECOVERY_CAUSE;
+        const configurationIncompleteFailure = recoveryCause === CONFIGURATION_INCOMPLETE_RECOVERY_CAUSE;
         const comment = workspaceValidationFailure
           ? buildWorkspaceValidationRecoveryComment({ latestRun: run })
           : configurationIncompleteFailure
@@ -12870,6 +12912,52 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
               ? CONFIGURATION_INCOMPLETE_RECOVERY_CAUSE
               : undefined,
         };
+      };
+
+      const shouldBlockImmediately =
+        !recoveryAgentInvokable ||
+        !recoveryAgent ||
+        isWorkspaceValidationFailedRun(run) ||
+        isConfigurationIncompleteFailedRun(run) ||
+        didAutomaticRecoveryFail(run, issue.status === "todo" ? "assignment_recovery" : "issue_continuation_needed");
+      if (shouldBlockImmediately) {
+        return blockedPromotion(
+          isWorkspaceValidationFailedRun(run)
+            ? WORKSPACE_VALIDATION_RECOVERY_CAUSE
+            : isConfigurationIncompleteFailedRun(run)
+              ? CONFIGURATION_INCOMPLETE_RECOVERY_CAUSE
+              : undefined,
+        );
+      }
+
+      const recoveryAgentPolicy = parseHeartbeatPolicy(recoveryAgent);
+      if (!recoveryAgentPolicy.wakeOnDemand) {
+        logger.warn(
+          { agentId: recoveryAgent.id, issueId: issue.id },
+          `wakeOnDemand disabled for agent ${recoveryAgent.id} - not auto-continuing issue ${issue.id}`,
+        );
+        return blockedPromotion();
+      }
+
+      const automationRunCountRow = await tx
+        .select({ count: sql<number>`count(*)::int` })
+        .from(heartbeatRuns)
+        .where(
+          and(
+            eq(heartbeatRuns.companyId, issue.companyId),
+            eq(heartbeatRuns.invocationSource, "automation"),
+            eq(heartbeatRuns.triggerDetail, "system"),
+            sql`${heartbeatRuns.contextSnapshot} ->> 'issueId' = ${issue.id}`,
+          ),
+        )
+        .then((rows) => rows[0] ?? null);
+      const automationRunCount = Number(automationRunCountRow?.count ?? 0);
+      if (automationRunCount >= issueContinuationCap) {
+        logger.warn(
+          { issueId: issue.id, automationRunCount, issueContinuationCap },
+          `continuation budget exhausted for issue ${issue.id}: ${automationRunCount} automation runs - blocking`,
+        );
+        return blockedPromotion();
       }
 
       const retryReason = issue.status === "todo" ? "assignment_recovery" : "issue_continuation_needed";
@@ -12965,6 +13053,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       return {
         kind: "queued_recovery" as const,
         run: queuedRun,
+        automationRunCount,
       };
     });
 
@@ -12998,6 +13087,24 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
 
     const promotedRun = promotionResult?.run ?? null;
     if (!promotedRun) return;
+    const queuedRecoveryAutomationRunCount =
+      promotionResult?.kind === "queued_recovery" ? promotionResult.automationRunCount : null;
+    const queuedRecoveryStartDelayMs =
+      queuedRecoveryAutomationRunCount !== null
+        ? continuationStartDelayMs(queuedRecoveryAutomationRunCount)
+        : 0;
+    if (queuedRecoveryStartDelayMs > 0) {
+      scheduleDelayedQueuedRunStart(promotedRun, queuedRecoveryStartDelayMs);
+      logger.info(
+        {
+          runId: promotedRun.id,
+          agentId: promotedRun.agentId,
+          delayMs: queuedRecoveryStartDelayMs,
+          automationRunCount: queuedRecoveryAutomationRunCount,
+        },
+        "scheduled queued recovery run after continuation backoff",
+      );
+    }
 
     if (promotionResult?.kind === "promoted" && promotionResult.reopenedActivity) {
       await logActivity(db, promotionResult.reopenedActivity);
@@ -13015,7 +13122,9 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       },
     });
 
-    await startNextQueuedRunForAgent(promotedRun.agentId);
+    if (queuedRecoveryStartDelayMs === 0) {
+      await startNextQueuedRunForAgent(promotedRun.agentId);
+    }
   }
 
   async function enqueueWakeup(agentId: string, opts: WakeupOptions = {}) {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -13071,7 +13071,8 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
               : promotionResult.recoveryCause === EXECUTION_REVIEW_PARTICIPANT_RECOVERY_CAUSE
                 ? EXECUTION_REVIEW_PARTICIPANT_RECOVERY_CAUSE
               : undefined,
-        recoveryOwnerAgentId: promotionResult.recoveryOwnerAgentId,
+        recoveryOwnerAgentId:
+          "recoveryOwnerAgentId" in promotionResult ? promotionResult.recoveryOwnerAgentId : undefined,
       });
       return;
     }
@@ -13088,7 +13089,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     const promotedRun = promotionResult?.run ?? null;
     if (!promotedRun) return;
     const queuedRecoveryAutomationRunCount =
-      promotionResult?.kind === "queued_recovery" ? promotionResult.automationRunCount : null;
+      promotionResult?.kind === "queued_recovery" ? (promotionResult.automationRunCount ?? 0) : null;
     const queuedRecoveryStartDelayMs =
       queuedRecoveryAutomationRunCount !== null
         ? continuationStartDelayMs(queuedRecoveryAutomationRunCount)
@@ -13318,6 +13319,39 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     if (source !== "timer" && !policy.wakeOnDemand) {
       await writeSkippedRequest("heartbeat.wakeOnDemand.disabled");
       return null;
+    }
+
+    if (source === "automation" && triggerDetail === "system" && issueId) {
+      const automationRunCountRow = await db
+        .select({ count: sql<number>`count(*)::int` })
+        .from(heartbeatRuns)
+        .where(
+          and(
+            eq(heartbeatRuns.companyId, agent.companyId),
+            eq(heartbeatRuns.invocationSource, "automation"),
+            eq(heartbeatRuns.triggerDetail, "system"),
+            sql`${heartbeatRuns.contextSnapshot} ->> 'issueId' = ${issueId}`,
+          ),
+        )
+        .then((rows) => rows[0] ?? null);
+      const automationRunCount = Number(automationRunCountRow?.count ?? 0);
+      if (automationRunCount >= issueContinuationCap) {
+        await writeSkippedRequest("issue.continuationBudget.exhausted", {
+          error: `Wake suppressed because issue ${issueId} already has ${automationRunCount} system automation runs`,
+        });
+        logger.warn(
+          {
+            agentId,
+            issueId,
+            automationRunCount,
+            issueContinuationCap,
+            source,
+            triggerDetail,
+          },
+          "enqueueWakeup: issue continuation budget exhausted; skipping automation wake",
+        );
+        return null;
+      }
     }
 
     const genericTimerWake =


### PR DESCRIPTION
Branch: `upstream-pr/1-continuation-guardrails`

Local commits:

- `6465a4bbc` - `fix(heartbeat): bound automatic issue continuations`
- `e131ba67f` - `fix(heartbeat): serialize queued starts and cap wakeups`

## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Heartbeat recovery is the subsystem that keeps agent-owned work moving after lost processes, queued wakes, or interrupted execution.
> - That recovery path is supposed to preserve explicit issue ownership and budget/control-plane safety.
> - Repeated system automation wakes for the same issue can otherwise continue to enqueue more runs without a per-issue cap.
> - Concurrent queued-run starters can also race around the per-agent `maxConcurrentRuns` check.
> - This pull request adds a bounded per-issue automation continuation budget, backoff for repeated continuations, and a serialized per-agent queued-run start gate.
> - The benefit is safer autonomy: Paperclip can recover stranded work without turning one issue into an unbounded run storm.

## Linked Issues or Issue Description

Bug fix - no upstream issue linked yet.

**Related open PRs** (found via duplicate search): #4725, #4518, #4509 approach continuation-storm protection with rolling/consecutive caps. This PR differs by budgeting per-issue at the config layer (clamped env knobs), covering BOTH the direct recovery-continuation and wakeup-backed enqueue paths, adding exponential backoff below the cap, and serializing queued starts per agent so `maxConcurrentRuns` cannot be raced.


What happened: automatic heartbeat recovery could repeatedly queue system automation runs for the same issue, including through wakeup-backed enqueue paths. Concurrent queued-run start attempts could also race around the intended per-agent concurrency limit.

Expected behavior: system automation should have a bounded per-issue continuation budget, repeated continuations should back off, wakeups should respect the same cap, and only one queued run should start for an agent when `maxConcurrentRuns` is `1`.

Steps to reproduce:

1. Seed an agent-owned issue with prior system automation runs in `heartbeat_runs.context_snapshot.issueId`.
2. Trigger orphaned-process recovery or `heartbeat.wakeup()` with `source: "automation"` and `triggerDetail: "system"` for the same issue.
3. Without this fix, another run can be queued after the issue already consumed the intended automation budget.
4. Start multiple `resumeQueuedRuns()` calls concurrently against the same agent and queued run set.
5. Without the serialized start gate, multiple callers can pass the read-then-act running-run count.

Paperclip version/commit: upstream `master` at `5cdf5103c9eaa4bb5e065b67ab6d4817fd90a196` plus local commits `6465a4bbc` and `e131ba67f`.

Deployment mode: local/self-hosted Paperclip heartbeat scheduler.

## What Changed

- Add clamped config knobs for automatic issue continuation budget and continuation backoff:
  - `PAPERCLIP_ISSUE_CONTINUATION_CAP`, default `10`, clamped `1..200`
  - `PAPERCLIP_CONTINUATION_BASE_DELAY_MS`, default `15000`, clamped `0..600000`
- Count prior system automation runs by company and issue before direct recovery continuation.
- Block direct automatic continuation and surface the existing blocked/recovery path when the per-issue cap is exhausted.
- Respect `heartbeat.wakeOnDemand: false` before direct automatic continuation.
- Delay below-cap repeated continuations with bounded exponential backoff.
- Apply the same per-issue budget to `enqueueWakeup()` for `source: "automation"` and `triggerDetail: "system"` when an issue id is present.
- Keep manual automation wakes and system automation wakes without issue context outside this per-issue cap.
- Serialize queued-run starts per agent so concurrent `resumeQueuedRuns()` calls cannot all pass the same `maxConcurrentRuns` slot check.
- Rebase note: conflict resolution preserved upstream's configuration-incomplete recovery cause in `blockedPromotion()` and upstream responsible-user dispatch fields while adding the continuation controls.

## Verification

```sh
pnpm vitest run server/src/__tests__/heartbeat-process-recovery.test.ts
# PASS: 1 test file, 76 tests

pnpm typecheck
# PASS

pnpm build
# PASS
```

Build emitted existing CSS/font/dynamic import/chunk-size warnings and exited 0.

## Risks

- Behavioral: automatic recovery may block an issue instead of continuing after the cap. That is intentional, but operators may need clear UI/recovery messaging.
- Operational: the backoff delay is process-local. A restart resumes queued runs on the next scheduler sweep rather than preserving the exact delay.
- Upstream churn: `server/src/services/heartbeat.ts` is active code, and this branch resolved conflicts against upstream's execution release gates and preflight budget-cap changes.

## Model Used

OpenAI Codex, GPT-5 coding agent, tool-enabled repository analysis. Context window not exposed in this environment.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this aligns with core budgeting/autonomy controls
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass on the rebased upstream branch
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots - not applicable
- [ ] I have updated relevant documentation to reflect my changes, if maintainers want env vars documented
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge

