### PR TITLE
fix(opencode): reject empty model config before spawn

### DIFF
--- a/packages/adapters/opencode-local/src/server/execute.remote.test.ts
+++ b/packages/adapters/opencode-local/src/server/execute.remote.test.ts
@@ -122,6 +122,43 @@ describe("opencode remote execution", () => {
     }
   });
 
+  it("fails before spawning when config.model is empty", async () => {
+    const result = await execute({
+      runId: "run-empty-model",
+      agent: {
+        id: "agent-1",
+        companyId: "company-1",
+        name: "OpenCode Builder",
+        adapterType: "opencode_local",
+        adapterConfig: {},
+      },
+      runtime: {
+        sessionId: null,
+        sessionParams: null,
+        sessionDisplayId: null,
+        taskKey: null,
+      },
+      config: {
+        command: "opencode",
+        model: "   ",
+      },
+      context: {},
+      onLog: async () => {},
+    });
+
+    expect(result).toMatchObject({
+      exitCode: 1,
+      signal: null,
+      timedOut: false,
+      errorCode: "adapter_config_invalid",
+      errorMessage:
+        "opencode adapter: config.model is empty — set adapterConfig.model on the agent",
+      model: null,
+    });
+    expect(runChildProcess).not.toHaveBeenCalled();
+    expect(startAdapterExecutionTargetPaperclipBridge).not.toHaveBeenCalled();
+  });
+
   it("prepares the workspace, syncs OpenCode skills, and restores workspace changes for remote SSH execution", async () => {
     const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-opencode-remote-"));
     cleanupDirs.push(rootDir);

--- a/packages/adapters/opencode-local/src/server/execute.ts
+++ b/packages/adapters/opencode-local/src/server/execute.ts
@@ -231,6 +231,25 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   );
   const command = asString(config.command, "opencode");
   const model = asString(config.model, "").trim();
+  if (!model) {
+    const message =
+      "opencode adapter: config.model is empty — set adapterConfig.model on the agent";
+    return {
+      exitCode: 1,
+      signal: null,
+      timedOut: false,
+      errorMessage: message,
+      errorCode: "adapter_config_invalid",
+      provider: null,
+      biller: null,
+      model: null,
+      billingType: "unknown",
+      costUsd: null,
+      resultJson: {
+        stderr: message,
+      },
+    };
+  }
   const variant = asString(config.variant, "").trim();
 
   const workspaceContext = parseObject(context.paperclipWorkspace);


### PR DESCRIPTION
Branch: `upstream-pr/2-opencode-empty-model`

Local commit:

- `2218fe423` - `fix(opencode): reject empty model config`

## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Local adapters turn agent configuration into external CLI invocations.
> - The OpenCode adapter accepts a `model` value from adapter config.
> - An empty model silently produces a modelless spawn path, making the actual runtime behavior ambiguous and harder to diagnose.
> - This pull request rejects empty model config before spawning the child process.
> - The benefit is a fail-loud configuration error instead of a confusing adapter launch.

## Linked Issues or Issue Description

Bug fix - no upstream issue linked yet; the underlying problem is described inline below following the bug-report template.

**Related PRs** (found via duplicate search): #8165 (closed) added a fallback model for `opencode_local` zombie/reattach flows; #8396 (open) prevents an unintended fallback model for `codex_local`. Neither makes an empty `adapterConfig.model` fail loudly before spawn for `opencode_local`, which is what this PR does.

What happened: `opencode_local` trimmed `config.model`, but did not stop when the result was empty.

Expected behavior: empty model config should return a structured adapter configuration error before any child process or bridge starts.

Steps to reproduce:

1. Configure an `opencode_local` agent with `adapterConfig.model` set to whitespace or an empty string.
2. Start a run.
3. Without this fix, the adapter proceeds toward spawn with no usable model value.

Paperclip version/commit: upstream `master` at `5cdf5103c9eaa4bb5e065b67ab6d4817fd90a196` plus local commit `2218fe423`.

Deployment mode: local/self-hosted adapter execution.

## What Changed

- Validate the trimmed OpenCode adapter `model` before spawn.
- Return `exitCode: 1`, `errorCode: "adapter_config_invalid"`, `model: null`, and a user-facing error message.
- Add a remote execution unit test proving no child process or bridge starts when the model is empty.
- Rebase note: removed the fork-specific phrase from the error string; the message is now `opencode adapter: config.model is empty — set adapterConfig.model on the agent`.

## Verification

```sh
pnpm vitest run packages/adapters/opencode-local/src/server/execute.remote.test.ts
# PASS: 1 test file, 4 tests

pnpm typecheck
# PASS

pnpm build
# PASS
```

Build emitted existing CSS/font/dynamic import/chunk-size warnings and exited 0.

## Risks

- Low behavior risk for valid configs.
- Breaking behavior for installs relying on OpenCode CLI defaults when `model` is omitted. The explicit error is preferable if upstream agrees the adapter must be deterministic.

## Model Used

OpenAI Codex, GPT-5 coding agent, tool-enabled repository analysis. Context window not exposed in this environment.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this is a targeted adapter bug fix
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass on the rebased upstream branch
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots - not applicable
- [x] I have updated relevant documentation to reflect my changes - not applicable
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge

