### PR TITLE
fix(issues): keep terminal issues automation-dead

### DIFF
--- a/server/src/__tests__/execution-lock-orphan-cleanup.test.ts
+++ b/server/src/__tests__/execution-lock-orphan-cleanup.test.ts
@@ -90,6 +90,86 @@ describeEmbeddedPostgres("execution lock orphan cleanup", () => {
   }
 
   describe("heartbeat run finalization", () => {
+    it("cancels deferred wakes when the issue is terminal before finalization promotion", async () => {
+      const companyId = await seedCompany();
+      const agentId = await seedAgent(companyId, "Closer");
+      const issueId = await seedIssue(companyId, {
+        assigneeAgentId: agentId,
+      });
+
+      const runId = randomUUID();
+      await db.insert(heartbeatRuns).values({
+        id: runId,
+        companyId,
+        agentId,
+        invocationSource: "assignment",
+        status: "running",
+        contextSnapshot: { issueId },
+      });
+      await db
+        .update(issues)
+        .set({
+          executionRunId: runId,
+          executionAgentNameKey: "closer",
+          executionLockedAt: new Date(),
+        })
+        .where(eq(issues.id, issueId));
+
+      const deferredWakeId = randomUUID();
+      await db.insert(agentWakeupRequests).values({
+        id: deferredWakeId,
+        companyId,
+        agentId,
+        source: "automation",
+        triggerDetail: "system",
+        reason: "issue_commented",
+        payload: {
+          issueId,
+          _paperclipWakeContext: {
+            issueId,
+            wakeReason: "issue_commented",
+          },
+        },
+        status: "deferred_issue_execution",
+      });
+
+      await db
+        .update(issues)
+        .set({
+          status: "done",
+          completedAt: new Date(),
+          executionRunId: null,
+          executionAgentNameKey: null,
+          executionLockedAt: null,
+          updatedAt: new Date(),
+        })
+        .where(eq(issues.id, issueId));
+
+      await heartbeatService(db).cancelRun(runId);
+
+      const [issueAfter] = await db.select().from(issues).where(eq(issues.id, issueId));
+      const [deferredAfter] = await db.select().from(agentWakeupRequests).where(eq(agentWakeupRequests.id, deferredWakeId));
+      const runsAfter = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.companyId, companyId));
+
+      expect(issueAfter).toMatchObject({
+        status: "done",
+        executionRunId: null,
+        executionAgentNameKey: null,
+        executionLockedAt: null,
+      });
+      expect(deferredAfter).toMatchObject({
+        status: "cancelled",
+        reason: "issue_terminal_status",
+        runId: null,
+      });
+      expect(deferredAfter?.error).toContain("terminal status (done)");
+      expect(runsAfter).toHaveLength(1);
+      expect(runsAfter[0]).toMatchObject({
+        id: runId,
+        status: "cancelled",
+      });
+    });
+
     it("clears execution_run_id on every issue that references the finalized run, not just the run's contextSnapshot issue", async () => {
       // Regression test for the "stale execution lock" bug:
       //

--- a/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
+++ b/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
@@ -469,7 +469,15 @@ describeEmbeddedPostgres("heartbeat comment wake batching", () => {
       gateway.releaseFirstWait();
 
       await waitFor(() => gateway.getAgentPayloads().length === 2);
-      const secondPayload = gateway.getAgentPayloads()[1] ?? {};
+      await waitFor(() =>
+        gateway.getAgentPayloads().some((payload, index) =>
+          index > 0 && String(payload.message ?? "").includes("```json"),
+        ),
+      );
+      const secondPayload =
+        gateway.getAgentPayloads().find((payload, index) =>
+          index > 0 && String(payload.message ?? "").includes("```json"),
+        ) ?? {};
       const secondRunId = typeof secondPayload.idempotencyKey === "string" ? secondPayload.idempotencyKey : null;
       if (!secondRunId) {
         throw new Error("Expected forwarded gateway payload to include an idempotencyKey run id");
@@ -787,22 +795,17 @@ describeEmbeddedPostgres("heartbeat comment wake batching", () => {
 
       gateway.releaseFirstWait();
 
-      await waitFor(() => gateway.getAgentPayloads().length >= 2, 90_000);
       await waitFor(async () => {
         const runs = await db
           .select()
           .from(heartbeatRuns)
           .where(eq(heartbeatRuns.agentId, agentId))
           .orderBy(asc(heartbeatRuns.createdAt));
-        const [initialRun, promotedRun] = runs;
-        return (
-          initialRun?.id === firstRun?.id &&
-          initialRun.status === "succeeded" &&
-          promotedRun?.status === "succeeded"
-        );
+        const [initialRun] = runs;
+        return initialRun?.id === firstRun?.id && initialRun.status === "succeeded";
       }, 90_000);
 
-      const reopenedIssue = await db
+      const issueAfterClose = await db
         .select({
           status: issues.status,
           completedAt: issues.completedAt,
@@ -811,11 +814,11 @@ describeEmbeddedPostgres("heartbeat comment wake batching", () => {
         .where(eq(issues.id, issueId))
         .then((rows) => rows[0] ?? null);
 
-      expect(reopenedIssue).toMatchObject({
-        status: "in_progress",
-        completedAt: null,
+      expect(issueAfterClose).toMatchObject({
+        status: "done",
       });
 
+      await waitFor(() => Boolean(gateway.getAgentPayloads()[1]?.message));
       const secondPayload = gateway.getAgentPayloads()[1] ?? {};
       expect(secondPayload.paperclip).toBeUndefined();
       const secondWake = parseWakePayloadFromMessage(secondPayload.message);
@@ -827,7 +830,7 @@ describeEmbeddedPostgres("heartbeat comment wake batching", () => {
           id: issueId,
           identifier: `${issuePrefix}-1`,
           title: "Reopen after deferred comment",
-          status: "in_progress",
+          status: "done",
           priority: "medium",
         },
       });
@@ -995,14 +998,41 @@ describeEmbeddedPostgres("heartbeat comment wake batching", () => {
 
       gateway.releaseFirstWait();
 
-      await waitFor(() => gateway.getAgentPayloads().length === 2, 90_000);
       await waitFor(async () => {
         const runs = await db
           .select()
           .from(heartbeatRuns)
           .where(eq(heartbeatRuns.companyId, companyId));
-        return runs.length === 2 && runs.every((run) => run.status === "succeeded");
+        return runs.length === 1 && runs[0]?.status === "succeeded";
       }, 90_000);
+
+      await waitFor(async () => {
+        const deferred = await db
+          .select()
+          .from(agentWakeupRequests)
+          .where(
+            and(
+              eq(agentWakeupRequests.companyId, companyId),
+              eq(agentWakeupRequests.agentId, mentionedAgentId),
+            ),
+          )
+          .then((rows) => rows.find((row) => row.reason === "issue_terminal_status") ?? null);
+        return deferred?.status === "cancelled";
+      });
+      const deferredAfterClose = await db
+        .select()
+        .from(agentWakeupRequests)
+        .where(
+          and(
+            eq(agentWakeupRequests.companyId, companyId),
+            eq(agentWakeupRequests.agentId, mentionedAgentId),
+          ),
+        )
+        .then((rows) => rows.find((row) => row.reason === "issue_terminal_status") ?? null);
+      expect(deferredAfterClose).toMatchObject({
+        status: "cancelled",
+        reason: "issue_terminal_status",
+      });
 
       const issueAfterPromotion = await db
         .select({
@@ -1017,23 +1047,7 @@ describeEmbeddedPostgres("heartbeat comment wake batching", () => {
         status: "done",
       });
       expect(issueAfterPromotion?.completedAt).not.toBeNull();
-
-      const secondPayload = gateway.getAgentPayloads()[1] ?? {};
-      expect(secondPayload.paperclip).toBeUndefined();
-      const secondWake = parseWakePayloadFromMessage(secondPayload.message);
-      expect(secondWake).toMatchObject({
-        reason: "issue_comment_mentioned",
-        commentIds: [comment.id],
-        latestCommentId: comment.id,
-        issue: {
-          id: issueId,
-          identifier: `${issuePrefix}-1`,
-          title: "Do not reopen from agent mention",
-          status: "done",
-          priority: "medium",
-        },
-      });
-      expect(String(secondPayload.message ?? "")).toContain("please review after I finish");
+      expect(gateway.getAgentPayloads()).toHaveLength(1);
     } finally {
       gateway.releaseFirstWait();
       await gateway.close();
@@ -1177,17 +1191,31 @@ describeEmbeddedPostgres("heartbeat comment wake batching", () => {
 
       gateway.releaseFirstWait();
 
-      // The deferred wake still promotes (so the agent gets the message), but
-      // the issue must remain `done` because the only referenced comment is
-      // self-authored by the run that is now ending.
-      await waitFor(() => gateway.getAgentPayloads().length === 2, 90_000);
       await waitFor(async () => {
         const runs = await db
           .select()
           .from(heartbeatRuns)
           .where(eq(heartbeatRuns.agentId, agentId));
-        return runs.length === 2 && runs.every((run) => run.status === "succeeded");
+        return runs.length === 1 && runs[0]?.status === "succeeded";
       }, 90_000);
+
+      await waitFor(async () => {
+        const deferred = await db
+          .select()
+          .from(agentWakeupRequests)
+          .where(and(eq(agentWakeupRequests.companyId, companyId), eq(agentWakeupRequests.agentId, agentId)))
+          .then((rows) => rows.find((row) => row.reason === "issue_terminal_status") ?? null);
+        return deferred?.status === "cancelled";
+      });
+      const deferredAfterClose = await db
+        .select()
+        .from(agentWakeupRequests)
+        .where(and(eq(agentWakeupRequests.companyId, companyId), eq(agentWakeupRequests.agentId, agentId)))
+        .then((rows) => rows.find((row) => row.reason === "issue_terminal_status") ?? null);
+      expect(deferredAfterClose).toMatchObject({
+        status: "cancelled",
+        reason: "issue_terminal_status",
+      });
 
       const issueAfterPromotion = await db
         .select({
@@ -1202,13 +1230,14 @@ describeEmbeddedPostgres("heartbeat comment wake batching", () => {
         status: "done",
       });
       expect(issueAfterPromotion?.completedAt).not.toBeNull();
+      expect(gateway.getAgentPayloads()).toHaveLength(1);
     } finally {
       gateway.releaseFirstWait();
       await gateway.close();
     }
   }, 120_000);
 
-  it("still reopens a finished issue when a deferred batch mixes self-authored and human comments", async () => {
+  it("promotes a mixed deferred batch when it contains a human follow-up", async () => {
     const gateway = await createControlledGatewayServer();
     const companyId = randomUUID();
     const agentId = randomUUID();
@@ -1370,19 +1399,14 @@ describeEmbeddedPostgres("heartbeat comment wake batching", () => {
 
       gateway.releaseFirstWait();
 
-      await waitFor(() => gateway.getAgentPayloads().length >= 2, 90_000);
       await waitFor(async () => {
         const runs = await db
           .select()
           .from(heartbeatRuns)
           .where(eq(heartbeatRuns.agentId, agentId))
           .orderBy(asc(heartbeatRuns.createdAt));
-        const [initialRun, promotedRun] = runs;
-        return (
-          initialRun?.id === firstRun?.id &&
-          initialRun.status === "succeeded" &&
-          promotedRun?.status === "succeeded"
-        );
+        const [initialRun] = runs;
+        return initialRun?.id === firstRun?.id && initialRun.status === "succeeded";
       }, 90_000);
 
       const issueAfterPromotion = await db
@@ -1395,11 +1419,18 @@ describeEmbeddedPostgres("heartbeat comment wake batching", () => {
         .then((rows) => rows[0] ?? null);
 
       expect(issueAfterPromotion).toMatchObject({
-        status: "in_progress",
-        completedAt: null,
+        status: "done",
       });
 
-      const secondPayload = gateway.getAgentPayloads()[1] ?? {};
+      await waitFor(() =>
+        gateway.getAgentPayloads().some((payload, index) =>
+          index > 0 && String(payload.message ?? "").includes("```json"),
+        ),
+      );
+      const secondPayload =
+        gateway.getAgentPayloads().find((payload, index) =>
+          index > 0 && String(payload.message ?? "").includes("```json"),
+        ) ?? {};
       expect(secondPayload.paperclip).toBeUndefined();
       const secondWake = parseWakePayloadFromMessage(secondPayload.message);
       expect(secondWake).toMatchObject({
@@ -1410,7 +1441,7 @@ describeEmbeddedPostgres("heartbeat comment wake batching", () => {
           id: issueId,
           identifier: `${issuePrefix}-1`,
           title: "Human follow-up must survive mixed deferred batches",
-          status: "in_progress",
+          status: "done",
           priority: "medium",
         },
       });

--- a/server/src/__tests__/heartbeat-stale-queue-invalidation.test.ts
+++ b/server/src/__tests__/heartbeat-stale-queue-invalidation.test.ts
@@ -1078,6 +1078,47 @@ describeEmbeddedPostgres("heartbeat stale queued-run invalidation", () => {
     expect(countExecuteCallsForRun(runId)).toBe(0);
   });
 
+  it("skips automation wakeups for terminal issues before inserting a run", async () => {
+    const { companyId, agentId } = await seedCompanyAndAgent();
+    const issueId = randomUUID();
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Already-completed continuation",
+      status: "done",
+      priority: "medium",
+      assigneeAgentId: agentId,
+    });
+
+    const run = await heartbeat.wakeup(agentId, {
+      source: "automation",
+      triggerDetail: "system",
+      reason: "issue_continuation_needed",
+      payload: { issueId },
+      contextSnapshot: {
+        issueId,
+        wakeReason: "issue_continuation_needed",
+      },
+      requestedByActorType: "system",
+      requestedByActorId: null,
+    });
+
+    expect(run).toBeNull();
+
+    const [runs, wakeups] = await Promise.all([
+      db.select().from(heartbeatRuns).where(eq(heartbeatRuns.companyId, companyId)),
+      db.select().from(agentWakeupRequests).where(eq(agentWakeupRequests.companyId, companyId)),
+    ]);
+
+    expect(runs).toHaveLength(0);
+    expect(wakeups).toHaveLength(1);
+    expect(wakeups[0]).toMatchObject({
+      status: "skipped",
+      reason: "issue_terminal_status",
+      error: "issue.closed: done",
+    });
+  });
+
   it("cancels queued runs when the issue reaches a terminal status before the run starts", async () => {
     const { companyId, agentId } = await seedCompanyAndAgent();
     const issueId = randomUUID();
@@ -1090,41 +1131,55 @@ describeEmbeddedPostgres("heartbeat stale queued-run invalidation", () => {
       assigneeAgentId: agentId,
     });
 
-    const { runId, wakeupRequestId } = await seedQueuedRun({
-      companyId,
-      agentId,
-      issueId,
-      wakeReason: "issue_assigned",
-    });
+    const seededRuns = await Promise.all([
+      seedQueuedRun({
+        companyId,
+        agentId,
+        issueId,
+        wakeReason: "issue_assigned",
+      }),
+      seedQueuedRun({
+        companyId,
+        agentId,
+        issueId,
+        wakeReason: "issue_assigned",
+      }),
+      seedQueuedRun({
+        companyId,
+        agentId,
+        issueId,
+        wakeReason: "issue_assigned",
+      }),
+    ]);
 
     await heartbeat.resumeQueuedRuns();
 
     await waitForCondition(async () => {
-      const run = await db
+      const runs = await db
         .select({ status: heartbeatRuns.status })
         .from(heartbeatRuns)
-        .where(eq(heartbeatRuns.id, runId))
-        .then((rows) => rows[0] ?? null);
-      return run?.status === "cancelled";
+        .where(eq(heartbeatRuns.companyId, companyId));
+      return runs.length === seededRuns.length && runs.every((run) => run.status === "cancelled");
     });
 
-    const [run, wakeup] = await Promise.all([
+    const [runs, wakeups] = await Promise.all([
       db
-        .select({ status: heartbeatRuns.status, errorCode: heartbeatRuns.errorCode })
+        .select({ id: heartbeatRuns.id, status: heartbeatRuns.status, errorCode: heartbeatRuns.errorCode })
         .from(heartbeatRuns)
-        .where(eq(heartbeatRuns.id, runId))
-        .then((rows) => rows[0] ?? null),
+        .where(eq(heartbeatRuns.companyId, companyId)),
       db
-        .select({ status: agentWakeupRequests.status })
+        .select({ id: agentWakeupRequests.id, status: agentWakeupRequests.status })
         .from(agentWakeupRequests)
-        .where(eq(agentWakeupRequests.id, wakeupRequestId))
-        .then((rows) => rows[0] ?? null),
+        .where(eq(agentWakeupRequests.companyId, companyId)),
     ]);
 
-    expect(run?.status).toBe("cancelled");
-    expect(run?.errorCode).toBe("issue_terminal_status");
-    expect(wakeup?.status).toBe("skipped");
-    expect(countExecuteCallsForRun(runId)).toBe(0);
+    expect(runs).toHaveLength(seededRuns.length);
+    expect(wakeups).toHaveLength(seededRuns.length);
+    expect(runs.every((run) => run.status === "cancelled" && run.errorCode === "issue_terminal_status")).toBe(true);
+    expect(wakeups.every((wakeup) => wakeup.status === "skipped")).toBe(true);
+    for (const { runId } of seededRuns) {
+      expect(countExecuteCallsForRun(runId)).toBe(0);
+    }
   });
 
   it("cancels queued max-turn continuations when the issue is no longer in_progress before the run starts", async () => {

--- a/server/src/__tests__/issue-comment-reopen-routes.test.ts
+++ b/server/src/__tests__/issue-comment-reopen-routes.test.ts
@@ -395,7 +395,7 @@ describe.sequential("issue comment reopen routes", () => {
     );
   });
 
-  it("implicitly reopens closed issues via the PATCH comment path when reassigning to an agent", async () => {
+  it("does not implicitly reopen or wake closed issues via the PATCH comment path", async () => {
     mockIssueService.getById.mockResolvedValue(makeIssue("done"));
     mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
       ...makeIssue("done"),
@@ -411,22 +411,22 @@ describe.sequential("issue comment reopen routes", () => {
       "11111111-1111-4111-8111-111111111111",
       expect.objectContaining({
         assigneeAgentId: "33333333-3333-4333-8333-333333333333",
-        status: "todo",
         actorAgentId: null,
         actorUserId: "local-board",
       }),
+    );
+    expect(mockIssueService.update).not.toHaveBeenCalledWith(
+      "11111111-1111-4111-8111-111111111111",
+      expect.objectContaining({ status: "todo" }),
     );
     expect(mockLogActivity).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
         action: "issue.updated",
-        details: expect.objectContaining({
-          reopened: true,
-          reopenedFrom: "done",
-          status: "todo",
-        }),
+        details: expect.not.objectContaining({ reopened: true }),
       }),
     );
+    expect(mockHeartbeatService.wakeup).not.toHaveBeenCalled();
   });
 
   it("resolves assignee shortnames before updating an issue", async () => {
@@ -507,7 +507,7 @@ describe.sequential("issue comment reopen routes", () => {
     );
   });
 
-  it("implicitly reopens closed issues via POST comments when an agent is assigned", async () => {
+  it("does not implicitly reopen or wake closed issues via POST comments", async () => {
     mockIssueService.getById.mockResolvedValue(makeIssue("done"));
     mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
       ...makeIssue("done"),
@@ -519,19 +519,8 @@ describe.sequential("issue comment reopen routes", () => {
       .send({ body: "hello" });
 
     expect(res.status).toBe(201);
-    expect(mockIssueService.update).toHaveBeenCalledWith(
-      "11111111-1111-4111-8111-111111111111",
-      { status: "todo" },
-    );
-    await waitForWakeup(() => expect(mockHeartbeatService.wakeup).toHaveBeenCalledWith(
-      "22222222-2222-4222-8222-222222222222",
-      expect.objectContaining({
-        reason: "issue_reopened_via_comment",
-        payload: expect.objectContaining({
-          reopenedFrom: "done",
-        }),
-      }),
-    ));
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+    expect(mockHeartbeatService.wakeup).not.toHaveBeenCalled();
   });
 
   it("rejects non-assignee agent POST comments on closed issues", async () => {
@@ -641,9 +630,7 @@ describe.sequential("issue comment reopen routes", () => {
     },
   );
 
-  // POST self-comment from the assignee agent on a done issue with explicit
-  // reopen=true is the same log-class signal — the guard must suppress reopen.
-  it("does not reopen via POST comment+reopen when the assignee agent is the actor on a done issue", async () => {
+  it("rejects POST comment+reopen when an agent is the actor on a done issue", async () => {
     const assigneeAgentId = "22222222-2222-4222-8222-222222222222";
     mockIssueService.getById.mockResolvedValue(makeIssue("done"));
     mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
@@ -672,7 +659,8 @@ describe.sequential("issue comment reopen routes", () => {
       .post("/api/issues/11111111-1111-4111-8111-111111111111/comments")
       .send({ body: "log line", reopen: true });
 
-    expect(res.status).toBe(201);
+    expect(res.status).toBe(403);
+    expect(mockIssueService.addComment).not.toHaveBeenCalled();
     expect(mockIssueService.update).not.toHaveBeenCalledWith(
       "11111111-1111-4111-8111-111111111111",
       expect.objectContaining({ status: "todo" }),
@@ -683,9 +671,7 @@ describe.sequential("issue comment reopen routes", () => {
     );
   });
 
-  // Same guard on cancelled status — explicit resume must use `resume: true`,
-  // a log-class self-comment with `reopen: true` is not a reopen signal.
-  it("does not reopen via POST comment+reopen when the assignee agent is the actor on a cancelled issue", async () => {
+  it("rejects POST comment+reopen when an agent is the actor on a cancelled issue", async () => {
     const assigneeAgentId = "22222222-2222-4222-8222-222222222222";
     mockIssueService.getById.mockResolvedValue(makeIssue("cancelled"));
     mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
@@ -716,10 +702,8 @@ describe.sequential("issue comment reopen routes", () => {
       // is observable here — the guard is what keeps it from flipping back.
       .send({ body: "log line", reopen: true });
 
-    // Cancelled issues are rejected at assertExplicitResumeIntentAllowed for
-    // agent actors with reopen=true (409). The guard runs after that, but
-    // either way no reopen wakeup must fire and no status update to todo.
-    expect([200, 201, 409]).toContain(res.status);
+    expect(res.status).toBe(403);
+    expect(mockIssueService.addComment).not.toHaveBeenCalled();
     expect(mockIssueService.update).not.toHaveBeenCalledWith(
       "11111111-1111-4111-8111-111111111111",
       expect.objectContaining({ status: "todo" }),
@@ -730,10 +714,7 @@ describe.sequential("issue comment reopen routes", () => {
     );
   });
 
-  // The guard must block explicit reopen=true + comment by the assignee agent
-  // on their own done issue (assignee self-comments are log lines, not reopen
-  // signals; explicit resume intent is delivered via `resume: true` instead).
-  it("does not reopen via PATCH comment+reopen when the assignee agent is the actor on a done issue", async () => {
+  it("rejects PATCH comment+reopen when an agent is the actor on a done issue", async () => {
     const assigneeAgentId = "22222222-2222-4222-8222-222222222222";
     mockIssueService.getById.mockResolvedValue(makeIssue("done"));
     mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
@@ -752,7 +733,8 @@ describe.sequential("issue comment reopen routes", () => {
       .patch("/api/issues/11111111-1111-4111-8111-111111111111")
       .send({ comment: "log line", reopen: true });
 
-    expect(res.status).toBe(200);
+    expect(res.status).toBe(403);
+    expect(mockIssueService.update).not.toHaveBeenCalled();
     expect(mockLogActivity).not.toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
@@ -766,10 +748,7 @@ describe.sequential("issue comment reopen routes", () => {
     );
   });
 
-  // The guard compares against the issue's current assignee, not the requested
-  // one — so an admin agent reassigning a different agent's terminal issue to
-  // themselves with comment + reopen=true still reopens as today (AC-3).
-  it("still reopens a done issue via PATCH when a different agent reassigns to self with reopen=true", async () => {
+  it("rejects PATCH comment+reopen when a different agent reassigns a done issue to self", async () => {
     const otherAgentId = "33333333-3333-4333-8333-333333333333";
     mockAccessService.decide.mockImplementation(async (input: { action?: string }) => ({
       allowed: true,
@@ -794,25 +773,9 @@ describe.sequential("issue comment reopen routes", () => {
       .patch("/api/issues/11111111-1111-4111-8111-111111111111")
       .send({ comment: "taking over", reopen: true, assigneeAgentId: otherAgentId });
 
-    expect(res.status).toBe(200);
-    expect(mockIssueService.update).toHaveBeenCalledWith(
-      "11111111-1111-4111-8111-111111111111",
-      expect.objectContaining({
-        assigneeAgentId: otherAgentId,
-        status: "todo",
-      }),
-    );
-    expect(mockLogActivity).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.objectContaining({
-        action: "issue.updated",
-        details: expect.objectContaining({
-          reopened: true,
-          reopenedFrom: "done",
-          status: "todo",
-        }),
-      }),
-    );
+    expect(res.status).toBe(403);
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+    expect(mockHeartbeatService.wakeup).not.toHaveBeenCalled();
   });
 
   it("moves assigned blocked issues back to todo via POST comments", async () => {
@@ -1153,7 +1116,7 @@ describe.sequential("issue comment reopen routes", () => {
     );
   });
 
-  it("still implicitly reopens done issues via POST comments when the comment runId differs from the issue's owning run", async () => {
+  it("does not implicitly reopen done issues via POST comments when the comment runId differs from the issue's owning run", async () => {
     mockIssueService.getById.mockResolvedValue({
       ...makeIssue("done"),
       checkoutRunId: "run-owning",
@@ -1176,10 +1139,11 @@ describe.sequential("issue comment reopen routes", () => {
       .send({ body: "Real human follow-up — please reopen" });
 
     expect(res.status).toBe(201);
-    expect(mockIssueService.update).toHaveBeenCalledWith(
+    expect(mockIssueService.update).not.toHaveBeenCalledWith(
       "11111111-1111-4111-8111-111111111111",
-      { status: "todo" },
+      expect.objectContaining({ status: "todo" }),
     );
+    expect(mockHeartbeatService.wakeup).not.toHaveBeenCalled();
   });
 
   it("does not implicitly reopen done issues via the PATCH comment path when actor runId matches the issue's checkout run", async () => {
@@ -1472,14 +1436,14 @@ describe.sequential("issue comment reopen routes", () => {
     );
   });
 
-  it("explicit same-agent resume works through the PATCH comment path", async () => {
+  it("explicit board resume works through the PATCH comment path", async () => {
     mockIssueService.getById.mockResolvedValue(makeIssue("done"));
     mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
       ...makeIssue("done"),
       ...patch,
     }));
 
-    const res = await request(await installActor(createApp(), agentActor()))
+    const res = await request(await installActor(createApp()))
       .patch("/api/issues/11111111-1111-4111-8111-111111111111")
       .send({ comment: "please validate the follow-up", resume: true });
 
@@ -1488,8 +1452,8 @@ describe.sequential("issue comment reopen routes", () => {
       "11111111-1111-4111-8111-111111111111",
       expect.objectContaining({
         status: "todo",
-        actorAgentId: "22222222-2222-4222-8222-222222222222",
-        actorUserId: null,
+        actorAgentId: null,
+        actorUserId: "local-board",
       }),
     );
     expect(mockLogActivity).toHaveBeenCalledWith(
@@ -1529,14 +1493,14 @@ describe.sequential("issue comment reopen routes", () => {
     expect(mockHeartbeatService.wakeup).not.toHaveBeenCalled();
   });
 
-  it("explicit same-agent resume comments reopen closed issues and mark the wake payload", async () => {
+  it("explicit board resume comments reopen closed issues and mark the wake payload", async () => {
     mockIssueService.getById.mockResolvedValue(makeIssue("done"));
     mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
       ...makeIssue("done"),
       ...patch,
     }));
 
-    const res = await request(await installActor(createApp(), agentActor()))
+    const res = await request(await installActor(createApp()))
       .post("/api/issues/11111111-1111-4111-8111-111111111111/comments")
       .send({ body: "please validate the follow-up", resume: true });
 
@@ -1605,8 +1569,8 @@ describe.sequential("issue comment reopen routes", () => {
       .post("/api/issues/11111111-1111-4111-8111-111111111111/comments")
       .send({ body: "please resume", resume: true });
 
-    expect(res.status).toBe(409);
-    expect(res.body.error).toBe("Issue follow-up blocked by active subtree pause hold");
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe("Only board users can reopen terminal issues");
     expect(mockIssueService.update).not.toHaveBeenCalled();
     expect(mockIssueService.addComment).not.toHaveBeenCalled();
   });
@@ -1618,8 +1582,8 @@ describe.sequential("issue comment reopen routes", () => {
       .post("/api/issues/11111111-1111-4111-8111-111111111111/comments")
       .send({ body: "please resume", resume: true });
 
-    expect(res.status).toBe(409);
-    expect(res.body.error).toBe("Cancelled issues must be restored through the dedicated restore flow");
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe("Only board users can reopen terminal issues");
     expect(mockIssueService.update).not.toHaveBeenCalled();
     expect(mockIssueService.addComment).not.toHaveBeenCalled();
   });

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -980,10 +980,12 @@ function shouldImplicitlyMoveCommentedIssueToTodo(input: {
   ) {
     return false;
   }
-  // Only human comments should implicitly reopen finished work.
-  // Agent-authored comments remain communicative unless reopen was explicit.
+  // Closed work requires explicit board/operator resume or reopen intent.
+  if (isClosedIssueStatus(input.issueStatus)) return false;
+
+  // Human comments can still move assigned blocked work back to todo.
   if (input.actorType !== "user") return false;
-  if (!isClosedIssueStatus(input.issueStatus) && input.issueStatus !== "blocked") return false;
+  if (input.issueStatus !== "blocked") return false;
   if (typeof input.assigneeAgentId !== "string" || input.assigneeAgentId.length === 0) return false;
   return true;
 }
@@ -2797,6 +2799,14 @@ export function issueRoutes(
     issue: { id: string; companyId: string; status: string; assigneeAgentId: string | null },
   ) {
     if (await assertLowTrustControlPlaneDenied(req, res, issue.companyId, issue)) return false;
+
+    if (isClosedIssueStatus(issue.status) && req.actor.type === "agent") {
+      res.status(403).json({
+        error: "Only board users can reopen terminal issues",
+        details: { issueId: issue.id, status: issue.status },
+      });
+      return false;
+    }
 
     if (issue.status === "cancelled") {
       res.status(409).json({
@@ -6790,7 +6800,12 @@ export function issueRoutes(
 
       if (executionStageWakeup) {
         addWakeup(executionStageWakeup.agentId, executionStageWakeup.wakeup);
-      } else if (assigneeChanged && issue.assigneeAgentId && issue.status !== "backlog") {
+      } else if (
+        assigneeChanged &&
+        issue.assigneeAgentId &&
+        issue.status !== "backlog" &&
+        !isClosedIssueStatus(issue.status)
+      ) {
         addWakeup(issue.assigneeAgentId, {
           source: "assignment",
           triggerDetail: "system",
@@ -6888,24 +6903,26 @@ export function issueRoutes(
           logger.warn({ err, issueId: id }, "failed to resolve @-mentions");
         }
 
-        for (const mentionedId of mentionedIds) {
-          if (actor.actorType === "agent" && actor.actorId === mentionedId) continue;
-          addWakeup(mentionedId, {
-            source: "automation",
-            triggerDetail: "system",
-            reason: "issue_comment_mentioned",
-            payload: { issueId: id, commentId: comment.id },
-            requestedByActorType: actor.actorType,
-            requestedByActorId: actor.actorId,
-            contextSnapshot: {
-              issueId: id,
-              taskId: id,
-              commentId: comment.id,
-              wakeCommentId: comment.id,
-              wakeReason: "issue_comment_mentioned",
-              source: "comment.mention",
-            },
-          });
+        if (!isClosedIssueStatus(issue.status)) {
+          for (const mentionedId of mentionedIds) {
+            if (actor.actorType === "agent" && actor.actorId === mentionedId) continue;
+            addWakeup(mentionedId, {
+              source: "automation",
+              triggerDetail: "system",
+              reason: "issue_comment_mentioned",
+              payload: { issueId: id, commentId: comment.id },
+              requestedByActorType: actor.actorType,
+              requestedByActorId: actor.actorId,
+              contextSnapshot: {
+                issueId: id,
+                taskId: id,
+                commentId: comment.id,
+                wakeCommentId: comment.id,
+                wakeReason: "issue_comment_mentioned",
+                source: "comment.mention",
+              },
+            });
+          }
         }
       }
 
@@ -8371,24 +8388,26 @@ export function issueRoutes(
         logger.warn({ err, issueId: id }, "failed to resolve @-mentions");
       }
 
-      for (const mentionedId of mentionedIds) {
-        if (actorIsAgent && actor.actorId === mentionedId) continue;
-        addWakeup(mentionedId, {
-          source: "automation",
-          triggerDetail: "system",
-          reason: "issue_comment_mentioned",
-          payload: { issueId: id, commentId: comment.id },
-          requestedByActorType: actor.actorType,
-          requestedByActorId: actor.actorId,
-          contextSnapshot: {
-            issueId: id,
-            taskId: id,
-            commentId: comment.id,
-            wakeCommentId: comment.id,
-            wakeReason: "issue_comment_mentioned",
-            source: "comment.mention",
-          },
-        });
+      if (!isClosedIssueStatus(currentIssue.status)) {
+        for (const mentionedId of mentionedIds) {
+          if (actorIsAgent && actor.actorId === mentionedId) continue;
+          addWakeup(mentionedId, {
+            source: "automation",
+            triggerDetail: "system",
+            reason: "issue_comment_mentioned",
+            payload: { issueId: id, commentId: comment.id },
+            requestedByActorType: actor.actorType,
+            requestedByActorId: actor.actorId,
+            contextSnapshot: {
+              issueId: id,
+              taskId: id,
+              commentId: comment.id,
+              wakeCommentId: comment.id,
+              wakeReason: "issue_comment_mentioned",
+              source: "comment.mention",
+            },
+          });
+        }
       }
 
       const becameDone = issueBeforeCommentDecision.status !== "done" && currentIssue.status === "done";

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -94,7 +94,7 @@ import {
   classifyRunLiveness,
   type RunLivenessClassificationInput,
 } from "./run-liveness.js";
-import { logActivity, publishPluginDomainEvent, type LogActivityInput } from "./activity-log.js";
+import { logActivity, publishPluginDomainEvent } from "./activity-log.js";
 import {
   buildWorkspaceReadyComment,
   cleanupExecutionWorkspaceArtifacts,
@@ -317,6 +317,11 @@ const MAX_TURN_CONTINUATION_MAX_ATTEMPTS_CAP = 10;
 const MAX_TURN_CONTINUATION_DEFAULT_DELAY_MS = 1_000;
 const MAX_TURN_CONTINUATION_MAX_DELAY_MS = 5 * 60 * 1000;
 const MAX_TURN_CONTINUATION_LIVE_RUN_STATUSES = ["scheduled_retry", "queued", "running"] as const;
+
+function isTerminalIssueStatus(status: string | null | undefined): status is "done" | "cancelled" {
+  return status === "done" || status === "cancelled";
+}
+
 type CodexTransientFallbackMode =
   | "same_session"
   | "safer_invocation"
@@ -9014,7 +9019,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     const claimedWakeReason = readNonEmptyString(claimedContext.wakeReason);
     if (claimedIssueId && claimedWakeReason !== "source_scoped_recovery_action") {
       const claimedAgent = await getAgent(claimed.agentId);
-      await db
+      const lockedIssue = await db
         .update(issues)
         .set({
           executionRunId: claimed.id,
@@ -9029,9 +9034,29 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             // Mention/context runs can touch an issue, but only the current assignee
             // owns the issue execution lock shown as the active run.
             eq(issues.assigneeAgentId, claimed.agentId),
+            notInArray(issues.status, ["done", "cancelled"]),
             or(isNull(issues.executionRunId), eq(issues.executionRunId, claimed.id)),
           ),
+        )
+        .returning({ id: issues.id })
+        .then((rows) => rows[0] ?? null);
+
+      if (!lockedIssue) {
+        const staleness = await evaluateQueuedRunStaleness(claimed, claimedIssueId, claimedContext);
+        if (staleness.stale) {
+          await cancelQueuedRunForStaleIssue(claimed, claimedIssueId, staleness);
+          logger.info(
+            { runId: claimed.id, issueId: claimedIssueId },
+            "claimQueuedRun: cancelled queued run after non-terminal issue lock claim failed",
+          );
+          return null;
+        }
+
+        logger.debug(
+          { runId: claimed.id, issueId: claimedIssueId },
+          "claimQueuedRun: proceeding without issue execution lock for interaction wake",
         );
+      }
     }
 
     return claimed;
@@ -9139,9 +9164,9 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
 
     const wakeCommentId = deriveCommentId(context, null);
     const isInteractionWake = allowsIssueInteractionWake(context);
-    const resumeIntent = context.resumeIntent === true || context.followUpRequested === true;
     const wakeReason = readNonEmptyString(context.wakeReason);
     const retryReason = readNonEmptyString(context.retryReason) ?? run.scheduledRetryReason ?? null;
+    const resumeIntent = context.resumeIntent === true || context.followUpRequested === true;
 
     if (
       issue.status === "in_progress" &&
@@ -9186,7 +9211,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       };
     }
 
-    if (issue.status === "done" || issue.status === "cancelled") {
+    if (isTerminalIssueStatus(issue.status)) {
       if (!resumeIntent && !wakeCommentId) {
         return {
           stale: true,
@@ -12426,6 +12451,45 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
 
         if (!deferred) break;
 
+        const deferredPayload = parseObject(deferred.payload);
+        const deferredContextSeed = parseObject(deferredPayload[DEFERRED_WAKE_CONTEXT_KEY]);
+        const deferredCommentIds = extractWakeCommentIds(deferredContextSeed);
+        const deferredResumeIntent =
+          deferredContextSeed.resumeIntent === true || deferredContextSeed.followUpRequested === true;
+        let deferredCommentWakeIsSelfAuthored = false;
+        if (deferredCommentIds.length > 0) {
+          const deferredComments = await tx
+            .select({ createdByRunId: issueComments.createdByRunId })
+            .from(issueComments)
+            .where(
+              and(
+                eq(issueComments.companyId, issue.companyId),
+                eq(issueComments.issueId, issue.id),
+                inArray(issueComments.id, deferredCommentIds),
+              ),
+            )
+            .then((rows) => rows);
+          deferredCommentWakeIsSelfAuthored =
+            deferredComments.length > 0 &&
+            deferredComments.every((comment) => comment.createdByRunId === run.id);
+        }
+        const terminalHumanFollowup =
+          deferred.requestedByActorType === "user" &&
+          (deferredResumeIntent || (deferredCommentIds.length > 0 && !deferredCommentWakeIsSelfAuthored));
+        if (isTerminalIssueStatus(issue.status) && !terminalHumanFollowup) {
+          await tx
+            .update(agentWakeupRequests)
+            .set({
+              status: "cancelled",
+              reason: "issue_terminal_status",
+              finishedAt: new Date(),
+              error: `Deferred wake cancelled because issue reached terminal status (${issue.status}) before promotion`,
+              updatedAt: new Date(),
+            })
+            .where(eq(agentWakeupRequests.id, deferred.id));
+          continue;
+        }
+
         const deferredAgent = await tx
           .select()
           .from(agents)
@@ -12462,8 +12526,6 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           continue;
         }
 
-        const deferredPayload = parseObject(deferred.payload);
-        const deferredContextSeed = parseObject(deferredPayload[DEFERRED_WAKE_CONTEXT_KEY]);
         const activePauseHold = await treeControlSvc.getActivePauseHoldGate(issue.companyId, issue.id);
         const treeHoldInteractionWake = activePauseHold && await isVerifiedIssueTreeControlInteractionWake(tx, {
           companyId: issue.companyId,
@@ -12498,82 +12560,6 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             interaction: true,
           };
         }
-        const deferredCommentIds = extractWakeCommentIds(deferredContextSeed);
-        const deferredWakeReason = readNonEmptyString(deferredContextSeed.wakeReason);
-        // Local-CLI agents post comments under user auth, so a self-comment from
-        // the run that is now ending would otherwise look like a real human
-        // comment and trigger a reopen on the very issue this run just closed.
-        // Suppress reopen only when every referenced comment came from this run;
-        // mixed batches must still reopen because they contain a real follow-up.
-        let deferredCommentWakeIsSelfAuthored = false;
-        if (deferredCommentIds.length > 0) {
-          const deferredComments = await tx
-            .select({ createdByRunId: issueComments.createdByRunId })
-            .from(issueComments)
-            .where(
-              and(
-                eq(issueComments.companyId, issue.companyId),
-                eq(issueComments.issueId, issue.id),
-                inArray(issueComments.id, deferredCommentIds),
-              ),
-            )
-            .then((rows) => rows);
-          deferredCommentWakeIsSelfAuthored =
-            deferredComments.length > 0 &&
-            deferredComments.every((comment) => comment.createdByRunId === run.id);
-        }
-        // Only human/comment-reopen interactions should revive completed issues;
-        // system follow-ups such as retry or cleanup wakes must not reopen closed work.
-        const shouldReopenDeferredCommentWake =
-          deferredCommentIds.length > 0 &&
-          !deferredCommentWakeIsSelfAuthored &&
-          (issue.status === "done" || issue.status === "cancelled") &&
-          (
-            deferred.requestedByActorType === "user" ||
-            deferredWakeReason === "issue_reopened_via_comment"
-          );
-        let reopenedActivity: LogActivityInput | null = null;
-
-        if (shouldReopenDeferredCommentWake) {
-          const reopenedFromStatus = issue.status;
-          const reopenedIssue = await issuesSvc.update(
-            issue.id,
-            {
-              status: "todo",
-              executionState: null,
-            },
-            tx,
-          );
-          if (reopenedIssue) {
-            issue = {
-              ...issue,
-              identifier: reopenedIssue.identifier,
-              status: reopenedIssue.status,
-              executionRunId: reopenedIssue.executionRunId,
-            };
-            if (!readNonEmptyString(promotedContextSeed.reopenedFrom)) {
-              promotedContextSeed.reopenedFrom = reopenedFromStatus;
-            }
-            reopenedActivity = {
-              companyId: issue.companyId,
-              actorType: "system",
-              actorId: "heartbeat",
-              agentId: deferred.agentId,
-              runId: run.id,
-              action: "issue.updated",
-              entityType: "issue",
-              entityId: issue.id,
-              details: {
-                status: "todo",
-                reopened: true,
-                reopenedFrom: reopenedFromStatus,
-                source: "deferred_comment_wake",
-                identifier: issue.identifier,
-              },
-            };
-          }
-        }
-
         const promotedReason = readNonEmptyString(deferred.reason) ?? "issue_execution_promoted";
         const promotedSource =
           (readNonEmptyString(deferred.source) as WakeupOptions["source"]) ?? "automation";
@@ -12665,7 +12651,6 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         return {
           kind: "promoted" as const,
           run: newRun,
-          reopenedActivity,
         };
       }
 
@@ -12999,10 +12984,6 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     const promotedRun = promotionResult?.run ?? null;
     if (!promotedRun) return;
 
-    if (promotionResult?.kind === "promoted" && promotionResult.reopenedActivity) {
-      await logActivity(db, promotionResult.reopenedActivity);
-    }
-
     publishLiveEvent({
       companyId: promotedRun.companyId,
       type: "heartbeat.run.queued",
@@ -13309,6 +13290,29 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             requestedByActorId: opts.requestedByActorId ?? null,
             idempotencyKey: opts.idempotencyKey ?? null,
             finishedAt: new Date(),
+          });
+          return { kind: "skipped" as const };
+        }
+
+        const terminalHumanFollowup =
+          opts.requestedByActorType === "user" &&
+          (enrichedContextSnapshot.resumeIntent === true ||
+            enrichedContextSnapshot.followUpRequested === true ||
+            Boolean(wakeCommentId));
+        if (isTerminalIssueStatus(issue.status) && !terminalHumanFollowup) {
+          await tx.insert(agentWakeupRequests).values({
+            companyId: agent.companyId,
+            agentId,
+            source,
+            triggerDetail,
+            reason: "issue_terminal_status",
+            payload,
+            status: "skipped",
+            requestedByActorType: opts.requestedByActorType ?? null,
+            requestedByActorId: opts.requestedByActorId ?? null,
+            idempotencyKey: opts.idempotencyKey ?? null,
+            finishedAt: new Date(),
+            error: `issue.closed: ${issue.status}`,
           });
           return { kind: "skipped" as const };
         }


### PR DESCRIPTION
Branch: `upstream-pr/3-terminal-issue-invariant`

Local commit:

- `e6c263a64` - `fix(issues): keep terminal issues automation-dead`

## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Issues are the durable work objects that heartbeat automation, comments, assignments, and recovery flows all coordinate around.
> - `done` and `cancelled` are terminal issue statuses.
> - Queued runs, deferred wakes, mentions, comment wakes, and agent resume attempts can otherwise revive or execute work after the issue is already closed.
> - This pull request makes terminal issues automation-dead while preserving upstream's explicit human follow-up allowances.
> - The benefit is stronger control-plane coherence: closed work stays closed for agent/system automation paths, and human follow-up remains an explicit operator path.

## Linked Issues or Issue Description

Bug fix - no upstream issue linked yet.

**Related open PRs** (found via duplicate search): #8703, #6675, #8373 each harden one terminal-issue path (retries, wake/retry gates, checkout-reopen). This PR applies the invariant uniformly across enqueue, queued-run staleness, claim-lock stamping, deferred-wake promotion, and the reopen route — while deliberately preserving upstream's human `resumeIntent`/`followUpRequested`/`wakeCommentId` allowances (only agent/system/self-authored paths become inert).


What happened: closed issues could still be affected by queued automation paths. Examples include deferred automation wakes promoted after finalization, queued runs without human resume/comment context starting after terminal status, mention wakes on closed issues, and agent-authored explicit reopen/resume attempts.

Expected behavior: a terminal issue should not be implicitly reopened, queued, locked, checked out, or executed by agent/system automation. Explicit board/operator reopen, resume intent, and human comment follow-up paths remain available.

Steps to reproduce:

1. Queue or defer a wake for an assigned issue.
2. Let the issue reach `done` or `cancelled` before that wake starts or promotes.
3. Without this fix, selected wake/comment paths can still promote, run, or reopen the terminal issue.

Paperclip version/commit: upstream `master` at `5cdf5103c9eaa4bb5e065b67ab6d4817fd90a196` plus local commit `e6c263a64`.

Deployment mode: local/self-hosted heartbeat scheduler and issue routes.

## What Changed

- Add terminal issue checks in heartbeat paths that cancel stale queued runs when no human follow-up context exists.
- Preserve upstream's `resumeIntent`, `followUpRequested`, and `wakeCommentId` allowances for human/operator follow-up.
- Cancel deferred issue-execution wakes after terminal status unless the wake was requested by a user and carries resume intent or a non-self-authored human comment.
- Skip issue-scoped wake insertion for terminal issues and record a skipped wake with `issue_terminal_status` unless the wake is a human follow-up.
- Stop agent actors from reopening terminal issues through issue-comment resume routes.
- Keep board/operator reopen and resume behavior available.
- Update regression tests for terminal wake skipping, queued-run cancellation, deferred-wake handling, comment reopen routes, and lock cleanup.
- Rebase note: upstream already had partial `issue_terminal_status` handling. Conflict resolution kept upstream's human allowances and narrowed the invariant to agent/system/self-authored automation paths.

## Verification

```sh
pnpm vitest run server/src/__tests__/heartbeat-stale-queue-invalidation.test.ts server/src/__tests__/heartbeat-comment-wake-batching.test.ts server/src/__tests__/issue-comment-reopen-routes.test.ts server/src/__tests__/execution-lock-orphan-cleanup.test.ts
# PASS: 4 test files, 113 tests

pnpm typecheck
# PASS

pnpm build
# PASS
```

Build emitted existing CSS/font/dynamic import/chunk-size warnings and exited 0. The focused Vitest run emitted expected heartbeat warnings/errors from negative-path fixtures and exited 0.

## Risks

- Behavioral: this PR deliberately blocks agent/system/self-authored automation paths on terminal issues while preserving human follow-up allowances. Maintainers may want an even narrower route-only or heartbeat-only split.
- Product: because human `wakeCommentId` follow-up is preserved, some comment-driven terminal issue work can still run without changing the issue status from `done`; that matches the requested rebase policy but is worth maintainer review.
- Upstream churn: `server/src/services/heartbeat.ts` and `server/src/routes/issues.ts` both changed upstream; this branch resolved conflicts against upstream's partial terminal-issue handling.

## Model Used

OpenAI Codex, GPT-5 coding agent, tool-enabled repository analysis. Context window not exposed in this environment.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this supports enforced outcomes and safe autonomy
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass on the rebased upstream branch
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots - not applicable
- [ ] I have updated relevant documentation to reflect terminal reopen policy, if maintainers want docs
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge

