### PR TITLE
feat(issues): enforce SEO closure evidence gate on issue close

### DIFF
--- a/server/src/routes/issues.seo-closure-gate.test.ts
+++ b/server/src/routes/issues.seo-closure-gate.test.ts
@@ -1,0 +1,532 @@
+import { randomUUID } from "node:crypto";
+import { and, eq, sql } from "drizzle-orm";
+import express from "express";
+import request from "supertest";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { activityLog, agents, companies, createDb } from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "../__tests__/helpers/embedded-postgres.js";
+import { errorHandler } from "../middleware/index.js";
+
+const { activityLogFailureControl } = vi.hoisted(() => ({
+  activityLogFailureControl: {
+    failAction: null as string | null,
+  },
+}));
+
+vi.mock("../services/index.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../services/index.js")>();
+  return {
+    ...actual,
+    logActivity: vi.fn(async (db, input) => {
+      if (activityLogFailureControl.failAction && input.action === activityLogFailureControl.failAction) {
+        activityLogFailureControl.failAction = null;
+        throw new Error(`forced activity failure for ${input.action}`);
+      }
+      return actual.logActivity(db, input);
+    }),
+  };
+});
+
+import { issueRoutes } from "./issues.js";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping SEO closure gate route tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+type Actor = Record<string, unknown>;
+
+function createApp(db: ReturnType<typeof createDb>, actor: Actor) {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as any).actor = actor;
+    next();
+  });
+  app.use("/api", issueRoutes(db, {} as any));
+  app.use(errorHandler);
+  return app;
+}
+
+describeEmbeddedPostgres("issues route SEO closure gate", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-seo-closure-gate-routes-");
+    db = createDb(tempDb.connectionString);
+  }, 20_000);
+
+  afterEach(async () => {
+    activityLogFailureControl.failAction = null;
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    await db.execute(sql.raw(`
+      TRUNCATE TABLE
+        companies,
+        instance_settings
+      RESTART IDENTITY CASCADE
+    `));
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  async function seedFixture() {
+    const companyId = randomUUID();
+    const cmoAgentId = randomUUID();
+    const engineerAgentId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values([
+      {
+        id: cmoAgentId,
+        companyId,
+        name: "CMO",
+        role: "cmo",
+        status: "active",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+      {
+        id: engineerAgentId,
+        companyId,
+        name: "Engineer",
+        role: "engineer",
+        status: "active",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+    ]);
+
+    const boardApp = createApp(db, {
+      type: "board",
+      userId: "board-user",
+      companyIds: [companyId],
+      source: "local_implicit",
+      isInstanceAdmin: false,
+    });
+    const cmoApp = createApp(db, {
+      type: "agent",
+      agentId: cmoAgentId,
+      companyId,
+      source: "api_key",
+    });
+    const engineerApp = createApp(db, {
+      type: "agent",
+      agentId: engineerAgentId,
+      companyId,
+      source: "api_key",
+    });
+
+    return { companyId, boardApp, cmoApp, engineerApp };
+  }
+
+  async function createLabel(app: ReturnType<typeof createApp>, companyId: string, name: string) {
+    const res = await request(app)
+      .post(`/api/companies/${companyId}/labels`)
+      .send({ name, color: "#12A150" });
+    expect(res.status).toBe(201);
+    return res.body.id as string;
+  }
+
+  async function createIssue(
+    app: ReturnType<typeof createApp>,
+    companyId: string,
+    input?: { priority?: "low" | "medium" | "high" | "critical"; labelIds?: string[] },
+  ) {
+    const res = await request(app)
+      .post(`/api/companies/${companyId}/issues`)
+      .send({
+        title: `SEO closure test ${randomUUID().slice(0, 8)}`,
+        priority: input?.priority ?? "medium",
+        status: "backlog",
+        labelIds: input?.labelIds ?? [],
+      });
+    expect(res.status).toBe(201);
+    return res.body.id as string;
+  }
+
+  async function addIssueComment(app: ReturnType<typeof createApp>, issueId: string, body: string) {
+    const res = await request(app)
+      .post(`/api/issues/${issueId}/comments`)
+      .send({ body });
+    expect(res.status).toBe(201);
+    return res.body.id as string;
+  }
+
+  function completeEvidenceComment() {
+    return [
+      "## URL scope list",
+      "- /landing",
+      "",
+      "## KPI snapshot",
+      "- Before: 3.1% CTR, After: 4.0% CTR",
+      "",
+      "## Technical validation",
+      "- canonical and hreflang validator output attached",
+      "",
+      "## Deployment proof",
+      "- PR #42, commit abc123, release 2026.04.21",
+      "",
+      "## Post-deploy verification",
+      "- Search Console reindex + sitemap submission verified",
+    ].join("\n");
+  }
+
+  function partialEvidenceComment(extra?: string) {
+    return [
+      "## Scope",
+      "- /pricing",
+      "",
+      "## KPI snapshot",
+      "- baseline collected",
+      "",
+      extra ?? "",
+    ].join("\n");
+  }
+
+  it("1) allows non-SEO issues to close with no comment", async () => {
+    const { companyId, boardApp } = await seedFixture();
+    const issueId = await createIssue(boardApp, companyId);
+
+    const res = await request(boardApp)
+      .patch(`/api/issues/${issueId}`)
+      .send({ status: "done" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe("done");
+  });
+
+  it("2) allows SEO issues to close when all five evidence sections are present", async () => {
+    const { companyId, boardApp } = await seedFixture();
+    const seoLabelId = await createLabel(boardApp, companyId, "SEO");
+    const issueId = await createIssue(boardApp, companyId, { labelIds: [seoLabelId] });
+
+    const res = await request(boardApp)
+      .patch(`/api/issues/${issueId}`)
+      .send({ status: "done", comment: completeEvidenceComment() });
+
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe("done");
+  });
+
+  it("3) rejects SEO close with no comment and returns closureTemplate", async () => {
+    const { companyId, boardApp } = await seedFixture();
+    const seoLabelId = await createLabel(boardApp, companyId, "SEO");
+    const issueId = await createIssue(boardApp, companyId, { labelIds: [seoLabelId] });
+
+    const res = await request(boardApp)
+      .patch(`/api/issues/${issueId}`)
+      .send({ status: "done" });
+
+    expect(res.status).toBe(422);
+    expect(res.body.error).toBe("SEO closure evidence is incomplete");
+    expect(res.body.details.missingEvidence).toEqual(expect.arrayContaining([
+      "urlScopeList",
+      "kpiSnapshot",
+      "technicalValidation",
+      "deploymentProof",
+      "postDeployVerification",
+    ]));
+    expect(res.body.details.closureTemplate).toContain("### URL scope list");
+    expect(res.body.details.closureTemplate).toContain("### KPI snapshot");
+    expect(res.body.details.closureTemplate).toContain("### Technical validation");
+    expect(res.body.details.closureTemplate).toContain("### Deployment proof");
+    expect(res.body.details.closureTemplate).toContain("### Post-deploy verification");
+  });
+
+  it("3b) rejects close when the request adds the SEO label alongside status done", async () => {
+    const { companyId, boardApp } = await seedFixture();
+    const seoLabelId = await createLabel(boardApp, companyId, "SEO");
+    const issueId = await createIssue(boardApp, companyId);
+
+    const res = await request(boardApp)
+      .patch(`/api/issues/${issueId}`)
+      .send({ status: "done", labelIds: [seoLabelId] });
+
+    expect(res.status).toBe(422);
+    expect(res.body.error).toBe("SEO closure evidence is incomplete");
+
+    const issueRes = await request(boardApp).get(`/api/issues/${issueId}`);
+    expect(issueRes.status).toBe(200);
+    expect(issueRes.body.status).toBe("backlog");
+    expect(issueRes.body.labelIds).toEqual([]);
+  });
+
+  it("4) rejects high-priority SEO partial evidence even with valid CMO exception", async () => {
+    const { companyId, boardApp, cmoApp } = await seedFixture();
+    const seoLabelId = await createLabel(boardApp, companyId, "SEO");
+    const issueId = await createIssue(boardApp, companyId, { priority: "high", labelIds: [seoLabelId] });
+    const exceptionCommentId = await addIssueComment(cmoApp, issueId, "CMO approved temporary exception.");
+
+    const res = await request(boardApp)
+      .patch(`/api/issues/${issueId}`)
+      .send({
+        status: "done",
+        comment: partialEvidenceComment(`CMO exception comment: ${exceptionCommentId}`),
+      });
+
+    expect(res.status).toBe(422);
+    expect(res.body.details.priority).toBe("high");
+    expect(res.body.details.requiresCmoException).toBe(false);
+  });
+
+  it("5) allows medium-priority SEO partial evidence only with same-issue CMO exception comment", async () => {
+    const { companyId, boardApp, cmoApp } = await seedFixture();
+    const seoLabelId = await createLabel(boardApp, companyId, "SEO");
+    const issueId = await createIssue(boardApp, companyId, { priority: "medium", labelIds: [seoLabelId] });
+    const exceptionCommentId = await addIssueComment(cmoApp, issueId, "Approved by CMO.");
+
+    const res = await request(boardApp)
+      .patch(`/api/issues/${issueId}`)
+      .send({
+        status: "done",
+        comment: partialEvidenceComment(`CMO exception comment: ${exceptionCommentId}`),
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe("done");
+  });
+
+  it("5b) evaluates the requested priority when closing with a valid CMO exception", async () => {
+    const { companyId, boardApp, cmoApp } = await seedFixture();
+    const seoLabelId = await createLabel(boardApp, companyId, "SEO");
+    const issueId = await createIssue(boardApp, companyId, { priority: "high", labelIds: [seoLabelId] });
+    const exceptionCommentId = await addIssueComment(cmoApp, issueId, "Approved by CMO after reprioritization.");
+
+    const res = await request(boardApp)
+      .patch(`/api/issues/${issueId}`)
+      .send({
+        status: "done",
+        priority: "medium",
+        comment: partialEvidenceComment(`CMO exception comment: ${exceptionCommentId}`),
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe("done");
+    expect(res.body.priority).toBe("medium");
+  });
+
+  it("6) rejects medium-priority SEO partial evidence when exception comment is missing", async () => {
+    const { companyId, boardApp } = await seedFixture();
+    const seoLabelId = await createLabel(boardApp, companyId, "SEO");
+    const issueId = await createIssue(boardApp, companyId, { priority: "medium", labelIds: [seoLabelId] });
+    const missingCommentId = randomUUID();
+
+    const res = await request(boardApp)
+      .patch(`/api/issues/${issueId}`)
+      .send({
+        status: "done",
+        comment: partialEvidenceComment(`CMO exception comment: ${missingCommentId}`),
+      });
+
+    expect(res.status).toBe(422);
+    expect(res.body.details.exceptionCommentId).toBe(missingCommentId);
+    expect(res.body.details.exceptionReason).toBe("comment_not_found");
+  }, 10_000);
+
+  it("7) rejects medium-priority SEO partial evidence when exception author is not CMO", async () => {
+    const { companyId, boardApp, engineerApp } = await seedFixture();
+    const seoLabelId = await createLabel(boardApp, companyId, "SEO");
+    const issueId = await createIssue(boardApp, companyId, { priority: "medium", labelIds: [seoLabelId] });
+    const exceptionCommentId = await addIssueComment(engineerApp, issueId, "Engineer says this is okay.");
+
+    const res = await request(boardApp)
+      .patch(`/api/issues/${issueId}`)
+      .send({
+        status: "done",
+        comment: partialEvidenceComment(`CMO exception comment: ${exceptionCommentId}`),
+      });
+
+    expect(res.status).toBe(422);
+    expect(res.body.details.exceptionCommentId).toBe(exceptionCommentId);
+    expect(res.body.details.exceptionReason).toBe("author_not_cmo");
+  });
+
+  it("8) logs issue.seo_closure_exception_used for allowed medium/low exception path", async () => {
+    const { companyId, boardApp, cmoApp } = await seedFixture();
+    const seoLabelId = await createLabel(boardApp, companyId, "SEO");
+    const issueId = await createIssue(boardApp, companyId, { priority: "low", labelIds: [seoLabelId] });
+    const exceptionCommentId = await addIssueComment(cmoApp, issueId, "CMO approved low-priority exception.");
+
+    const res = await request(boardApp)
+      .patch(`/api/issues/${issueId}`)
+      .send({
+        status: "done",
+        comment: partialEvidenceComment(`CMO exception comment: ${exceptionCommentId}`),
+      });
+
+    expect(res.status).toBe(200);
+
+    const rows = await db
+      .select({ details: activityLog.details })
+      .from(activityLog)
+      .where(and(eq(activityLog.entityId, issueId), eq(activityLog.action, "issue.seo_closure_exception_used")));
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.details).toMatchObject({
+      priority: "low",
+      missingEvidence: expect.arrayContaining(["technicalValidation", "deploymentProof", "postDeployVerification"]),
+      exceptionCommentId,
+      source: "seo_closure_gate",
+    });
+  });
+
+  it("9) rejected closure attempt does not mutate status, add comment, or write bypass audit log", async () => {
+    const { companyId, boardApp } = await seedFixture();
+    const seoLabelId = await createLabel(boardApp, companyId, "SEO");
+    const issueId = await createIssue(boardApp, companyId, { priority: "medium", labelIds: [seoLabelId] });
+
+    const initialCommentsRes = await request(boardApp).get(`/api/issues/${issueId}/comments`);
+    expect(initialCommentsRes.status).toBe(200);
+    expect(initialCommentsRes.body).toHaveLength(0);
+
+    const rejectRes = await request(boardApp)
+      .patch(`/api/issues/${issueId}`)
+      .send({
+        status: "done",
+        comment: partialEvidenceComment(),
+      });
+    expect(rejectRes.status).toBe(422);
+
+    const issueRes = await request(boardApp).get(`/api/issues/${issueId}`);
+    expect(issueRes.status).toBe(200);
+    expect(issueRes.body.status).toBe("backlog");
+
+    const commentsRes = await request(boardApp).get(`/api/issues/${issueId}/comments`);
+    expect(commentsRes.status).toBe(200);
+    expect(commentsRes.body).toHaveLength(0);
+
+    const bypassRows = await db
+      .select({ id: activityLog.id })
+      .from(activityLog)
+      .where(and(eq(activityLog.entityId, issueId), eq(activityLog.action, "issue.seo_closure_exception_used")));
+    expect(bypassRows).toHaveLength(0);
+  });
+
+  it("10) honors section aliases and enforces strict checks for 'Checks passed'", async () => {
+    const { companyId, boardApp } = await seedFixture();
+    const seoLabelId = await createLabel(boardApp, companyId, "SEO");
+
+    const invalidIssueId = await createIssue(boardApp, companyId, { labelIds: [seoLabelId] });
+    const invalidAliasComment = [
+      "## Scope",
+      "- /docs",
+      "",
+      "## Metrics delta",
+      "- clicks +14%",
+      "",
+      "## Checks passed",
+      "- looks good",
+      "",
+      "## Release",
+      "- commit abc123",
+      "",
+      "## Verification",
+      "- crawled key pages",
+    ].join("\n");
+    const invalidRes = await request(boardApp)
+      .patch(`/api/issues/${invalidIssueId}`)
+      .send({ status: "done", comment: invalidAliasComment });
+    expect(invalidRes.status).toBe(422);
+    expect(invalidRes.body.details.missingEvidence).toContain("technicalValidation");
+    expect(invalidRes.body.details.missingEvidence).not.toContain("kpiSnapshot");
+
+    const failingIssueId = await createIssue(boardApp, companyId, { labelIds: [seoLabelId] });
+    const explicitFailureComment = [
+      "## URL scope",
+      "- /docs",
+      "",
+      "## Metrics delta",
+      "- clicks +14%",
+      "",
+      "## Checks passed",
+      "- schema validator failed and sitemap is missing",
+      "",
+      "## Release",
+      "- commit abc123",
+      "",
+      "## Verification",
+      "- crawled key pages",
+    ].join("\n");
+    const failingRes = await request(boardApp)
+      .patch(`/api/issues/${failingIssueId}`)
+      .send({ status: "done", comment: explicitFailureComment });
+    expect(failingRes.status).toBe(422);
+    expect(failingRes.body.details.missingEvidence).toContain("technicalValidation");
+
+    const validIssueId = await createIssue(boardApp, companyId, { labelIds: [seoLabelId] });
+    const validAliasComment = [
+      "## URL scope",
+      "- /blog",
+      "",
+      "## Metrics delta",
+      "- impressions +8%",
+      "",
+      "## Checks passed",
+      "- canonical + hreflang validator outputs clean, sitemap and schema checks passed",
+      "",
+      "## PR",
+      "- PR #77",
+      "",
+      "## Post deploy",
+      "- verified index coverage and rendering",
+    ].join("\n");
+    const validRes = await request(boardApp)
+      .patch(`/api/issues/${validIssueId}`)
+      .send({ status: "done", comment: validAliasComment });
+    expect(validRes.status).toBe(200);
+    expect(validRes.body.status).toBe("done");
+  });
+
+  it("11) rolls back the close when the SEO bypass audit log fails", async () => {
+    const { companyId, boardApp, cmoApp } = await seedFixture();
+    const seoLabelId = await createLabel(boardApp, companyId, "SEO");
+    const issueId = await createIssue(boardApp, companyId, { priority: "low", labelIds: [seoLabelId] });
+    const exceptionCommentId = await addIssueComment(cmoApp, issueId, "CMO approved low-priority exception.");
+
+    activityLogFailureControl.failAction = "issue.seo_closure_exception_used";
+
+    const res = await request(boardApp)
+      .patch(`/api/issues/${issueId}`)
+      .send({
+        status: "done",
+        comment: partialEvidenceComment(`CMO exception comment: ${exceptionCommentId}`),
+      });
+
+    expect(res.status).toBe(500);
+
+    const issueRes = await request(boardApp).get(`/api/issues/${issueId}`);
+    expect(issueRes.status).toBe(200);
+    expect(issueRes.body.status).toBe("backlog");
+
+    const commentsRes = await request(boardApp).get(`/api/issues/${issueId}/comments`);
+    expect(commentsRes.status).toBe(200);
+    expect(commentsRes.body).toHaveLength(1);
+    expect(commentsRes.body[0]?.id).toBe(exceptionCommentId);
+
+    const bypassRows = await db
+      .select({ id: activityLog.id })
+      .from(activityLog)
+      .where(and(eq(activityLog.entityId, issueId), eq(activityLog.action, "issue.seo_closure_exception_used")));
+    expect(bypassRows).toHaveLength(0);
+  });
+});

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -16,6 +16,7 @@ import {
   issueRelations,
   issues as issueRows,
   issueWorkProducts,
+  labels,
   pipelineCaseIssueLinks,
   pipelineCases,
   pipelineStages,
@@ -159,6 +160,7 @@ import {
   type TrustPresetResolution,
 } from "../services/trust-preset-resolver.js";
 import { externalObjectService } from "../services/external-objects.js";
+import { evaluateSeoClosureGate, isSeoTaggedIssue } from "../services/issue-seo-closure-gate.js";
 
 const MAX_ISSUE_COMMENT_LIMIT = 500;
 const updateIssueRouteSchema = updateIssueSchema.extend({
@@ -6224,11 +6226,41 @@ export function issueRoutes(
       }
     }
 
+    const seoGateLabels = Array.isArray(updateFields.labelIds)
+      ? await db
+          .select()
+          .from(labels)
+          .where(and(eq(labels.companyId, existing.companyId), inArray(labels.id, updateFields.labelIds)))
+      : existing.labels;
+    const seoGateIssue = {
+      ...existing,
+      priority: typeof updateFields.priority === "string" ? updateFields.priority : existing.priority,
+      labels: seoGateLabels,
+      labelIds: Array.isArray(updateFields.labelIds) ? updateFields.labelIds : existing.labelIds,
+    };
+    const seoGate = await evaluateSeoClosureGate({
+      issue: seoGateIssue,
+      requestedStatus: typeof updateFields.status === "string" ? updateFields.status : undefined,
+      commentBody,
+      issuesSvc: svc,
+      agentsSvc,
+    });
+    if (!seoGate.ok) {
+      res.status(422).json({ error: seoGate.error, details: seoGate.details });
+      return;
+    }
+    const shouldPersistSeoCloseComment =
+      Boolean(commentBody) &&
+      typeof updateFields.status === "string" &&
+      updateFields.status === "done" &&
+      isSeoTaggedIssue(seoGateIssue);
     let issue;
+    let comment = null;
     try {
       if (transition.decision && decisionId) {
         const decision = transition.decision;
         issue = await db.transaction(async (tx) => {
+          const txDb = tx as unknown as Db;
           const updated = await svc.update(
             id,
             {
@@ -6252,6 +6284,64 @@ export function issueRoutes(
             body: decision.body,
             createdByRunId: actor.runId ?? null,
           });
+
+          if (seoGate.auditBypass) {
+            await logActivity(txDb, {
+              companyId: updated.companyId,
+              actorType: actor.actorType,
+              actorId: actor.actorId,
+              agentId: actor.agentId,
+              runId: actor.runId,
+              action: "issue.seo_closure_exception_used",
+              entityType: "issue",
+              entityId: updated.id,
+              details: seoGate.auditBypass,
+            });
+          }
+          if (shouldPersistSeoCloseComment) {
+            comment = await svc.addComment(id, commentBody!, {
+              agentId: actor.agentId ?? undefined,
+              userId: actor.actorType === "user" ? actor.actorId : undefined,
+              runId: actor.runId,
+            }, {
+              sourceTrust: await sourceTrustForActorWrite(updated, actor),
+            }, tx);
+          }
+
+          return updated;
+        });
+      } else if (seoGate.auditBypass || shouldPersistSeoCloseComment) {
+        issue = await db.transaction(async (tx) => {
+          const txDb = tx as unknown as Db;
+          const updated = await svc.update(id, {
+            ...updateFields,
+            actorAgentId: actor.agentId ?? null,
+            actorUserId: actor.actorType === "user" ? actor.actorId : null,
+          }, tx);
+          if (!updated) return null;
+
+          if (seoGate.auditBypass) {
+            await logActivity(txDb, {
+              companyId: updated.companyId,
+              actorType: actor.actorType,
+              actorId: actor.actorId,
+              agentId: actor.agentId,
+              runId: actor.runId,
+              action: "issue.seo_closure_exception_used",
+              entityType: "issue",
+              entityId: updated.id,
+              details: seoGate.auditBypass,
+            });
+          }
+          if (shouldPersistSeoCloseComment) {
+            comment = await svc.addComment(id, commentBody!, {
+              agentId: actor.agentId ?? undefined,
+              userId: actor.actorType === "user" ? actor.actorId : undefined,
+              runId: actor.runId,
+            }, {
+              sourceTrust: await sourceTrustForActorWrite(updated, actor),
+            }, tx);
+          }
 
           return updated;
         });
@@ -6620,17 +6710,18 @@ export function issueRoutes(
       }
     }
 
-    let comment = null;
     if (commentBody) {
       const commentReferenceSummaryBefore = updateReferenceSummaryAfter
         ?? await issueReferencesSvc.listIssueReferenceSummary(issue.id);
-      comment = await svc.addComment(id, commentBody, {
-        agentId: actor.agentId ?? undefined,
-        userId: actor.actorType === "user" ? actor.actorId : undefined,
-        runId: actor.runId,
-      }, {
-        sourceTrust: await sourceTrustForActorWrite(issue, actor),
-      });
+      if (!comment) {
+        comment = await svc.addComment(id, commentBody, {
+          agentId: actor.agentId ?? undefined,
+          userId: actor.actorType === "user" ? actor.actorId : undefined,
+          runId: actor.runId,
+        }, {
+          sourceTrust: await sourceTrustForActorWrite(issue, actor),
+        });
+      }
       await issueReferencesSvc.syncComment(comment.id);
       await externalObjectsSvc.syncCommentSafely(comment.id);
       const commentReferenceSummaryAfter = await issueReferencesSvc.listIssueReferenceSummary(issue.id);

--- a/server/src/services/issue-seo-closure-gate.ts
+++ b/server/src/services/issue-seo-closure-gate.ts
@@ -1,0 +1,338 @@
+type IssueLabelLike = { name?: string | null } | null | undefined;
+type IssueLike = {
+  id?: string;
+  identifier?: string | null;
+  priority?: string | null;
+  labels?: IssueLabelLike[] | null;
+  labelIds?: string[] | null;
+};
+
+type IssueCommentLike = {
+  id: string;
+  issueId: string;
+  authorAgentId: string | null;
+};
+
+type IssuesServiceLike = {
+  getComment(commentId: string): Promise<IssueCommentLike | null>;
+};
+
+type AgentsServiceLike = {
+  getById(agentId: string): Promise<{ role?: string | null } | null>;
+};
+
+type EvidenceKey =
+  | "urlScopeList"
+  | "kpiSnapshot"
+  | "technicalValidation"
+  | "deploymentProof"
+  | "postDeployVerification";
+
+type ParsedSeoEvidence = Record<EvidenceKey, string>;
+
+const REQUIRED_EVIDENCE_KEYS: EvidenceKey[] = [
+  "urlScopeList",
+  "kpiSnapshot",
+  "technicalValidation",
+  "deploymentProof",
+  "postDeployVerification",
+];
+
+const HEADING_TO_KEY: Record<string, EvidenceKey> = {
+  scope: "urlScopeList",
+  "url scope": "urlScopeList",
+  "url scope list": "urlScopeList",
+  "before/after kpi": "kpiSnapshot",
+  "kpi snapshot": "kpiSnapshot",
+  "metrics delta": "kpiSnapshot",
+  "technical validation": "technicalValidation",
+  "checks passed": "technicalValidation",
+  "validation outputs": "technicalValidation",
+  "deployment proof": "deploymentProof",
+  deployment: "deploymentProof",
+  pr: "deploymentProof",
+  commit: "deploymentProof",
+  release: "deploymentProof",
+  "post-deploy verification": "postDeployVerification",
+  verification: "postDeployVerification",
+  "post deploy": "postDeployVerification",
+};
+
+const UUID_LOOKING =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+type ValidationResult =
+  | { ok: true; comment: IssueCommentLike }
+  | { ok: false; reason: "comment_not_found" | "wrong_issue" | "author_not_cmo" };
+
+function normalizeHeaderCandidate(line: string) {
+  return line
+    .trim()
+    .replace(/^[-*]\s+/, "")
+    .replace(/^#{1,6}\s*/, "")
+    .replace(/^\*\*(.+)\*\*$/, "$1")
+    .replace(/\s*:\s*$/, "")
+    .toLowerCase();
+}
+
+function getEvidenceKeyFromHeading(line: string): EvidenceKey | null {
+  const normalized = normalizeHeaderCandidate(line);
+  return HEADING_TO_KEY[normalized] ?? null;
+}
+
+function hasAnyPatternMatch(value: string, patterns: RegExp[]) {
+  return patterns.some((pattern) => pattern.test(value));
+}
+
+function sectionHasFailureLanguage(value: string) {
+  return hasAnyPatternMatch(value, [
+    /\bfail(?:ed|ing|ure)?\b/i,
+    /\berror(?:s)?\b/i,
+    /\binvalid\b/i,
+    /\bmissing\b/i,
+    /\bnot\s+(?:run|checked|verified|present|indexed)\b/i,
+    /\bpending\b/i,
+    /\btbd\b/i,
+    /\btodo\b/i,
+    /\bblocked\b/i,
+  ]);
+}
+
+function sectionHasEvidence(key: EvidenceKey, body: string) {
+  const trimmed = body.trim();
+  if (trimmed.length === 0) return false;
+
+  switch (key) {
+    case "urlScopeList":
+      return hasAnyPatternMatch(trimmed, [
+        /(^|\n)\s*[-*]\s+(\/|https?:\/\/|www\.)/i,
+        /\b[a-z0-9._-]+\/[a-z0-9/_-]+\b/i,
+        /\b(?:urls?|pages?|patterns?)\b/i,
+      ]);
+    case "kpiSnapshot":
+      return hasAnyPatternMatch(trimmed, [
+        /\bbefore\b[\s\S]{0,80}\d/i,
+        /\bafter\b[\s\S]{0,80}\d/i,
+        /\b(?:ctr|clicks|impressions|position|traffic|sessions|conversions|rank)\b[\s\S]{0,80}\d/i,
+        /\bdelta\b[\s\S]{0,40}(?:\d|%)/i,
+      ]) && /\d/.test(trimmed);
+    case "technicalValidation":
+      return !sectionHasFailureLanguage(trimmed)
+        && hasAnyPatternMatch(trimmed, [
+          /\b(?:schema|canonical|hreflang|sitemap|validator)\b/i,
+          /\bvalidation outputs?\b/i,
+        ])
+        && hasAnyPatternMatch(trimmed, [
+          /\b(?:passed|clean|valid|ok|attached|output|report|screenshot|200)\b/i,
+          /\bno issues\b/i,
+        ]);
+    case "deploymentProof":
+      return hasAnyPatternMatch(trimmed, [
+        /\bpr\s*#\d+\b/i,
+        /\bcommit\s+[0-9a-f]{6,40}\b/i,
+        /\brelease\s+[a-z0-9._-]+\b/i,
+        /\bdeploy(?:ed|ment)?\b[\s\S]{0,40}\b(?:sha|commit|tag|build)\b/i,
+      ]);
+    case "postDeployVerification":
+      return hasAnyPatternMatch(trimmed, [
+        /\bverif(?:y|ied|ication)\b/i,
+        /\bchecked\b/i,
+        /\bcrawled\b/i,
+        /\breindex(?:ed)?\b/i,
+        /\bsearch console\b/i,
+        /\bindex coverage\b/i,
+        /\brender(?:ing)?\b/i,
+        /\bsmoke test\b/i,
+      ]);
+  }
+}
+
+export function isSeoTaggedIssue(issue: IssueLike) {
+  if (!Array.isArray(issue.labels)) return false;
+  return issue.labels.some((label) => {
+    if (!label || typeof label.name !== "string") return false;
+    return label.name.trim().toLowerCase() === "seo";
+  });
+}
+
+export function parseSeoClosureEvidence(commentBody: string | undefined) {
+  const sections: Array<{ key: EvidenceKey; alias: string; bodyLines: string[] }> = [];
+  let active: { key: EvidenceKey; alias: string; bodyLines: string[] } | null = null;
+  const lines = String(commentBody ?? "").split(/\r?\n/);
+  for (const line of lines) {
+    const headingKey = getEvidenceKeyFromHeading(line);
+    if (headingKey) {
+      if (active) sections.push(active);
+      active = {
+        key: headingKey,
+        alias: normalizeHeaderCandidate(line),
+        bodyLines: [],
+      };
+      continue;
+    }
+    if (active) active.bodyLines.push(line);
+  }
+  if (active) sections.push(active);
+
+  const parsed = {
+    urlScopeList: "",
+    kpiSnapshot: "",
+    technicalValidation: "",
+    deploymentProof: "",
+    postDeployVerification: "",
+  } satisfies ParsedSeoEvidence;
+
+  for (const key of REQUIRED_EVIDENCE_KEYS) {
+    const matchingSections = sections.filter((section) => section.key === key);
+    const firstWithEvidence = matchingSections.find((section) =>
+      sectionHasEvidence(section.key, section.bodyLines.join("\n")));
+    if (firstWithEvidence) {
+      parsed[key] = firstWithEvidence.bodyLines.join("\n").trim();
+    }
+  }
+  return parsed;
+}
+
+export function buildSeoClosureTemplate(missingKeys: EvidenceKey[] = []) {
+  const missingLine = missingKeys.length > 0
+    ? `Missing evidence: ${missingKeys.join(", ")}`
+    : "Fill all required sections:";
+  return [
+    "## SEO Closure Evidence",
+    "",
+    missingLine,
+    "",
+    "### URL scope list",
+    "- Affected URLs/patterns:",
+    "",
+    "### KPI snapshot",
+    "- Before/after KPI:",
+    "",
+    "### Technical validation",
+    "- Include validator/schema/canonical/hreflang/sitemap evidence:",
+    "",
+    "### Deployment proof",
+    "- PR/commit/release:",
+    "",
+    "### Post-deploy verification",
+    "- Verification checks:",
+    "",
+    "CMO exception comment: <uuid> (optional for medium/low only)",
+  ].join("\n");
+}
+
+export function extractCmoExceptionCommentId(commentBody: string | undefined) {
+  const body = String(commentBody ?? "");
+  const match = body.match(/^\s*CMO exception comment:\s*([0-9a-f-]{36})\s*$/im);
+  if (!match) return null;
+  const candidate = match[1]?.trim();
+  return candidate && UUID_LOOKING.test(candidate) ? candidate : null;
+}
+
+export async function validateCmoExceptionComment({
+  issueId,
+  exceptionCommentId,
+  issuesSvc,
+  agentsSvc,
+}: {
+  issueId: string;
+  exceptionCommentId: string;
+  issuesSvc: IssuesServiceLike;
+  agentsSvc: AgentsServiceLike;
+}): Promise<ValidationResult> {
+  const comment = await issuesSvc.getComment(exceptionCommentId);
+  if (!comment) return { ok: false, reason: "comment_not_found" };
+  if (comment.issueId !== issueId) return { ok: false, reason: "wrong_issue" };
+  if (!comment.authorAgentId) return { ok: false, reason: "author_not_cmo" };
+  const author = await agentsSvc.getById(comment.authorAgentId);
+  if (!author || author.role !== "cmo") return { ok: false, reason: "author_not_cmo" };
+  return { ok: true, comment };
+}
+
+export async function evaluateSeoClosureGate({
+  issue,
+  requestedStatus,
+  commentBody,
+  issuesSvc,
+  agentsSvc,
+}: {
+  issue: IssueLike & { id: string };
+  requestedStatus: string | undefined;
+  commentBody: string | undefined;
+  issuesSvc: IssuesServiceLike;
+  agentsSvc: AgentsServiceLike;
+}) {
+  if (requestedStatus !== "done" || !isSeoTaggedIssue(issue)) {
+    return { ok: true as const, auditBypass: null };
+  }
+
+  const evidence = parseSeoClosureEvidence(commentBody);
+  const missingEvidence = REQUIRED_EVIDENCE_KEYS.filter((key) => evidence[key].trim().length === 0);
+  if (missingEvidence.length === 0) {
+    return { ok: true as const, auditBypass: null };
+  }
+
+  const priority = String(issue.priority ?? "medium").toLowerCase();
+  const closureTemplate = buildSeoClosureTemplate(missingEvidence);
+  if (priority === "high" || priority === "critical") {
+    return {
+      ok: false as const,
+      error: "SEO closure evidence is incomplete",
+      details: {
+        missingEvidence,
+        priority,
+        requiresCmoException: false,
+        closureTemplate,
+      },
+      auditBypass: null,
+    };
+  }
+
+  const exceptionCommentId = extractCmoExceptionCommentId(commentBody);
+  if (!exceptionCommentId) {
+    return {
+      ok: false as const,
+      error: "SEO closure evidence is incomplete",
+      details: {
+        missingEvidence,
+        priority,
+        requiresCmoException: true,
+        closureTemplate,
+      },
+      auditBypass: null,
+    };
+  }
+
+  const exceptionValidation = await validateCmoExceptionComment({
+    issueId: issue.id,
+    exceptionCommentId,
+    issuesSvc,
+    agentsSvc,
+  });
+  if (!exceptionValidation.ok) {
+    return {
+      ok: false as const,
+      error: "SEO closure evidence is incomplete",
+      details: {
+        missingEvidence,
+        priority,
+        requiresCmoException: true,
+        exceptionCommentId,
+        exceptionReason: exceptionValidation.reason,
+        closureTemplate,
+      },
+      auditBypass: null,
+    };
+  }
+
+  return {
+    ok: true as const,
+    auditBypass: {
+      identifier: issue.identifier ?? null,
+      priority,
+      missingEvidence,
+      exceptionCommentId,
+      source: "seo_closure_gate",
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- Ports the reviewed INS-351 SEO closure evidence gate onto current `origin/master` — the original diff no longer applied cleanly after the route file changed underneath it (conflict at `60b649ed`).
- Adds `evaluateSeoClosureGate` / `isSeoTaggedIssue` (`server/src/services/issue-seo-closure-gate.ts`) and wires it into the issue update route (`server/src/routes/issues.ts`) so SEO-tagged issues can't close without evidence unless an audited bypass exception is used (logged via `issue.seo_closure_exception_used`).
- Re-verified after the rebase per LeadEngineer request: StaffEngineer confidence-check confirmed no semantic drift, QA reran the full route suite.

## Verification
- `pnpm --filter @paperclipai/server typecheck` — pass
- `pnpm exec vitest run server/src/routes/issues.seo-closure-gate.test.ts` — 13/13 pass
- StaffEngineer confidence-check: approved, no blocking issues in the ported scope
- QA note: local macOS run required a workaround for an unrelated embedded-postgres native dylib gap, tracked separately as INS-872; not a regression from this change and CI (Linux) is unaffected

## Test plan
- [x] Route-level SEO closure gate suite passes (13/13)
- [x] Typecheck passes
- [x] StaffEngineer review: no semantic drift from rebase