### PR TITLE
fix(agents): cascade-clean cost/finance telemetry on agent delete (decommission 500)

### DIFF
--- a/server/src/__tests__/agent-remove-cascade.test.ts
+++ b/server/src/__tests__/agent-remove-cascade.test.ts
@@ -1,0 +1,163 @@
+// Regression: deleting a tenant agent that has ACTUALLY RUN must succeed.
+//
+// Live decommission 500 (2026-07): DELETE /api/agents/:id failed with
+//   "delete on table heartbeat_runs violates foreign key constraint
+//    cost_events_heartbeat_run_id_heartbeat_runs_id_fk"
+// The agent-remove path deleted heartbeat_runs but never cleaned the
+// cost_events / finance_events that reference those runs (and the agent) —
+// tables added after the base delete handler was written. A bare-agent delete
+// test would NOT have caught this: the failure only appears once the agent has
+// a heartbeat_run with a linked cost_event, which every real conversation
+// produces. (The original hypothesis — instructions-bundle / env-binding rows —
+// was not the cause: those aren't agents.id foreign keys.)
+
+import { randomUUID } from "node:crypto";
+
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import {
+  agents,
+  companies,
+  costEvents,
+  createDb,
+  financeEvents,
+  heartbeatRuns,
+} from "@paperclipai/db";
+
+import { agentService } from "../services/agents.ts";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+
+describe("agentService.remove — tenant decommission cascade", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-agent-remove-");
+    db = createDb(tempDb.connectionString);
+  });
+
+  afterEach(async () => {
+    await db.delete(financeEvents);
+    await db.delete(costEvents);
+    await db.delete(heartbeatRuns);
+    await db.delete(agents);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  async function seedCompany(): Promise<string> {
+    const companyId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Smoke Septic Co",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    return companyId;
+  }
+
+  async function insertAgent(companyId: string, name: string): Promise<string> {
+    const agentId = randomUUID();
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name,
+      role: "general",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    return agentId;
+  }
+
+  // The exact shape the live 500 hit: an agent with a heartbeat_run whose
+  // cost_event and finance_event reference both the run and the agent.
+  async function seedAgentWithUsage(companyId: string, name: string) {
+    const agentId = await insertAgent(companyId, name);
+    const runId = randomUUID();
+    const costId = randomUUID();
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId,
+      agentId,
+      invocationSource: "on_demand",
+      status: "completed",
+      startedAt: new Date("2026-07-06T00:00:00.000Z"),
+      finishedAt: new Date("2026-07-06T00:01:00.000Z"),
+    });
+    await db.insert(costEvents).values({
+      id: costId,
+      companyId,
+      agentId,
+      heartbeatRunId: runId, // cost_events_heartbeat_run_id_... FK — the blocker
+      provider: "openai",
+      model: "gpt-4o-mini",
+      costCents: 3,
+      occurredAt: new Date("2026-07-06T00:01:00.000Z"),
+    });
+    await db.insert(financeEvents).values({
+      companyId,
+      agentId,
+      heartbeatRunId: runId,
+      costEventId: costId, // finance → cost (RESTRICT): finance must delete first
+      eventKind: "model_usage",
+      biller: "openai",
+      amountCents: 3,
+      occurredAt: new Date("2026-07-06T00:01:00.000Z"),
+    });
+    return { agentId, runId, costId };
+  }
+
+  it("deletes an agent that has heartbeat_runs + cost_events + finance_events", async () => {
+    const companyId = await seedCompany();
+    const { agentId } = await seedAgentWithUsage(companyId, "intake-smoke-septic");
+
+    const svc = agentService(db);
+    const removed = await svc.remove(agentId);
+
+    expect(removed?.id).toBe(agentId);
+    expect(await svc.getById(agentId)).toBeNull();
+    // usage telemetry for this agent is cleaned, unblocking the runs + agent delete
+    expect(await db.select().from(financeEvents)).toHaveLength(0);
+    expect(await db.select().from(costEvents)).toHaveLength(0);
+    expect(await db.select().from(heartbeatRuns)).toHaveLength(0);
+  });
+
+  it("does not touch another agent's usage rows in the same company", async () => {
+    const companyId = await seedCompany();
+    const { agentId: doomed } = await seedAgentWithUsage(companyId, "coordinator-smoke-septic");
+    const { agentId: keeper } = await seedAgentWithUsage(companyId, "keeper-agent");
+
+    await agentService(db).remove(doomed);
+
+    // the keeper's telemetry survives (one run/cost/finance row each)
+    expect(await agentService(db).getById(keeper)).not.toBeNull();
+    expect(await db.select().from(costEvents)).toHaveLength(1);
+    expect(await db.select().from(financeEvents)).toHaveLength(1);
+    expect(await db.select().from(heartbeatRuns)).toHaveLength(1);
+  });
+
+  it("is idempotent — a second remove returns null (route maps this to 404)", async () => {
+    const companyId = await seedCompany();
+    const { agentId } = await seedAgentWithUsage(companyId, "intake-smoke-septic");
+
+    const svc = agentService(db);
+    expect((await svc.remove(agentId))?.id).toBe(agentId);
+    expect(await svc.remove(agentId)).toBeNull();
+  });
+
+  it("still deletes a bare agent that never ran", async () => {
+    const companyId = await seedCompany();
+    const agentId = await insertAgent(companyId, "never-ran");
+    expect((await agentService(db).remove(agentId))?.id).toBe(agentId);
+  });
+});

--- a/server/src/services/agents.ts
+++ b/server/src/services/agents.ts
@@ -9,12 +9,21 @@ import {
   agentTaskSessions,
   agentWakeupRequests,
   activityLog,
+  approvals,
+  approvalComments,
+  assets,
   costEvents,
+  financeEvents,
+  goals,
   heartbeatRunEvents,
   heartbeatRuns,
   issueExecutionDecisions,
   issues,
   issueComments,
+  issueThreadInteractions,
+  joinRequests,
+  projects,
+  routines,
 } from "@paperclipai/db";
 import { AGENT_DEFAULT_MAX_CONCURRENT_RUNS, isUuidLike, normalizeAgentUrlKey } from "@paperclipai/shared";
 import { conflict, notFound, unprocessable } from "../errors.js";
@@ -508,6 +517,27 @@ export function agentService(db: Db) {
           .update(issues)
           .set({ assigneeAgentId: null, createdByAgentId: null })
           .where(or(eq(issues.assigneeAgentId, id), eq(issues.createdByAgentId, id)));
+        // Null agent references on entities that OUTLIVE the agent. These FKs
+        // have no onDelete rule, so the DB won't null them for us and the final
+        // delete(agents) would FK-fail; "set null" is the right semantic (the
+        // project/routine/goal/approval/asset survives, just loses this agent as
+        // its lead/owner/author). Added for tenant decommission robustness — a
+        // used tenant agent can accumulate any of these.
+        await tx.update(projects).set({ leadAgentId: null }).where(eq(projects.leadAgentId, id));
+        await tx.update(routines).set({ assigneeAgentId: null }).where(eq(routines.assigneeAgentId, id));
+        await tx.update(goals).set({ ownerAgentId: null }).where(eq(goals.ownerAgentId, id));
+        await tx.update(joinRequests).set({ createdAgentId: null }).where(eq(joinRequests.createdAgentId, id));
+        await tx.update(approvals).set({ requestedByAgentId: null }).where(eq(approvals.requestedByAgentId, id));
+        await tx.update(approvalComments).set({ authorAgentId: null }).where(eq(approvalComments.authorAgentId, id));
+        await tx.update(assets).set({ createdByAgentId: null }).where(eq(assets.createdByAgentId, id));
+        await tx
+          .update(issueThreadInteractions)
+          .set({ createdByAgentId: null })
+          .where(eq(issueThreadInteractions.createdByAgentId, id));
+        await tx
+          .update(issueThreadInteractions)
+          .set({ resolvedByAgentId: null })
+          .where(eq(issueThreadInteractions.resolvedByAgentId, id));
         await tx.delete(heartbeatRunEvents).where(eq(heartbeatRunEvents.agentId, id));
         await tx.delete(agentTaskSessions).where(eq(agentTaskSessions.agentId, id));
         await tx.delete(activityLog).where(
@@ -518,6 +548,25 @@ export function agentService(db: Db) {
         );
         await tx.delete(issueExecutionDecisions).where(eq(issueExecutionDecisions.actorAgentId, id));
         await tx.delete(issueComments).where(eq(issueComments.authorAgentId, id));
+        // Usage telemetry references BOTH the agent (agent_id, RESTRICT) AND its
+        // heartbeat_runs (heartbeat_run_id, RESTRICT), so it must be removed
+        // BEFORE delete(heartbeatRuns) below. This was the live decommission 500:
+        // "cost_events_heartbeat_run_id_heartbeat_runs_id_fk" fired when a used
+        // agent's runs had cost rows. finance_events references cost_events
+        // (cost_event_id, RESTRICT), so it is deleted first.
+        await tx.delete(financeEvents).where(
+          or(
+            eq(financeEvents.agentId, id),
+            sql`${financeEvents.heartbeatRunId} in (select ${heartbeatRuns.id} from ${heartbeatRuns} where ${heartbeatRuns.agentId} = ${id})`,
+            sql`${financeEvents.costEventId} in (select ${costEvents.id} from ${costEvents} where ${costEvents.agentId} = ${id} or ${costEvents.heartbeatRunId} in (select ${heartbeatRuns.id} from ${heartbeatRuns} where ${heartbeatRuns.agentId} = ${id}))`,
+          ),
+        );
+        await tx.delete(costEvents).where(
+          or(
+            eq(costEvents.agentId, id),
+            sql`${costEvents.heartbeatRunId} in (select ${heartbeatRuns.id} from ${heartbeatRuns} where ${heartbeatRuns.agentId} = ${id})`,
+          ),
+        );
         await tx.delete(heartbeatRuns).where(eq(heartbeatRuns.agentId, id));
         await tx.delete(agentWakeupRequests).where(eq(agentWakeupRequests.agentId, id));
         await tx.delete(agentApiKeys).where(eq(agentApiKeys.agentId, id));


### PR DESCRIPTION
## Symptom

Tenant decommission failed at `remove_agents` with a 500 (crash past validation, not a schema error):

```
DELETE /api/agents/b52c2d98-... 500 — Failed query: delete from "heartbeat_runs" where "agent_id" = $1
caused by: update or delete on table "heartbeat_runs" violates foreign key constraint
  "cost_events_heartbeat_run_id_heartbeat_runs_id_fk" on table "cost_events"
```

(Confirmed from the live backend log for the failing agent.)

## Root cause

`agentService.remove()` deletes `heartbeat_runs` for the agent, but was written before usage-telemetry tables existed. It never cleans:
- **`cost_events`** — FKs both `agent_id` (RESTRICT) and `heartbeat_run_id` (RESTRICT)
- **`finance_events`** — same, plus `cost_event_id` (RESTRICT) → cost_events

Every real agent conversation produces a `cost_event` linked to its `heartbeat_run`, so deleting `heartbeat_runs` FK-fails. This blocked decommission for **every agent that had ever run**. The canonical never-run agents delete fine, which is why a bare-agent delete test never caught it.

> The original hypothesis (instructions-bundle / env-binding rows) was **not** the cause — neither is an `agents.id` foreign key. The blocker was cost/finance telemetry.

A schema audit of all `agents.id` and `heartbeat_runs.id` FKs found these are the only RESTRICT tables the delete path missed; everything else is `set null`/`cascade` or already handled.

## Fix (inside the `remove()` transaction)

1. Delete `finance_events` then `cost_events` (finance→cost is RESTRICT, so finance first) matching the agent **or** its `heartbeat_runs`, **before** deleting `heartbeat_runs` — mirroring the existing `activity_log` run-subquery pattern.
2. Null the remaining no-`onDelete` agent references on entities that outlive the agent (`projects.lead_agent_id`, `routines.assignee_agent_id`, `goals.owner_agent_id`, `join_requests.created_agent_id`, `approvals.requested_by_agent_id`, `approval_comments.author_agent_id`, `assets.created_by_agent_id`, `issue_thread_interactions.created_by/resolved_by`) so a used tenant agent can always be removed. "Set null" preserves those entities.

## Idempotency (asked)

Already idempotent — `getAccessibleAgent` returns **404** when the agent is gone, so a decommission retry no-ops cleanly. No client special-casing needed. Covered by a test.

## Tests

New `agent-remove-cascade.test.ts` (real embedded Postgres, real FK enforcement): creates an agent **with a heartbeat_run + cost_event + finance_event** and deletes it — the scenario a bare-agent test can't reach. Also covers cross-agent isolation (a sibling agent's telemetry survives), idempotency (second remove → null → route 404), and the bare-agent case.

- New test: **4 passed**
- Blast radius (agent lifecycle, costs, finance, approvals, dashboard, company-portability, instructions-bundle routes, permissions, cleanup-removal, cross-tenant authz): **121 passed**
- `tsc --noEmit`: clean for the change (only the pre-existing plugin-sdk baseline errors remain)

## Note on non-blocking leaks (follow-up candidates, not fixed here)

Agent delete is DB-only, so it doesn't clean the on-disk instructions-bundle files or the `company_secret_bindings` env-binding rows (polymorphic target, no agent FK — doesn't block the delete). Neither causes the 500; both are orphaned-resource tidiness for a separate change.

## Deploy / re-run

Requires a paperclip image rebuild + container recreate (this is the main app, not the governor). Once deployed, `provision-tenant.py --decommission` will delete the two live agents (which are safe as-is now — nothing was deleted by the failed run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)