### PR TITLE
fix: suppress PATCH close-comment assignee wake

### DIFF
--- a/server/src/__tests__/issue-comment-reopen-routes.test.ts
+++ b/server/src/__tests__/issue-comment-reopen-routes.test.ts
@@ -1472,6 +1472,32 @@ describe.sequential("issue comment reopen routes", () => {
     );
   });
 
+  it("does not wake the assignee with issue_commented when a PATCH comment closes the issue", async () => {
+    const issue = {
+      ...makeIssue("todo"),
+      status: "in_review",
+    };
+    mockIssueService.getById.mockResolvedValue(issue);
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
+      ...issue,
+      ...patch,
+      status: "done",
+      completedAt: new Date(),
+      updatedAt: new Date(),
+    }));
+
+    const res = await request(await installActor(createApp()))
+      .patch("/api/issues/11111111-1111-4111-8111-111111111111")
+      .send({ status: "done", comment: "Closing this out." });
+
+    expect(res.status).toBe(200);
+    await new Promise((resolve) => setImmediate(resolve));
+    const issueCommentedWakeCalls = mockHeartbeatService.wakeup.mock.calls.filter(
+      ([, wakeup]: [string, { reason?: string }]) => wakeup?.reason === "issue_commented",
+    );
+    expect(issueCommentedWakeCalls).toEqual([]);
+  });
+
   it("explicit same-agent resume works through the PATCH comment path", async () => {
     mockIssueService.getById.mockResolvedValue(makeIssue("done"));
     mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -6687,7 +6687,7 @@ export function issueRoutes(
         const assigneeId = issue.assigneeAgentId;
         const actorIsAgent = actor.actorType === "agent";
         const selfComment = actorIsAgent && actor.actorId === assigneeId;
-        const skipAssigneeCommentWake = selfComment || isClosed;
+        const skipAssigneeCommentWake = selfComment || isClosedIssueStatus(issue.status);
 
         if (assigneeId && !assigneeChanged && (reopened || !skipAssigneeCommentWake)) {
           addWakeup(assigneeId, {


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - One core responsibility is keeping issue lifecycle transitions and wake behavior coherent so agents do not re-enter completed work.
> - This PR sits in the server issue-update route, specifically the PATCH path that can both change status and add a comment.
> - The bug shows up when an issue moves from `in_review` to `done` with an inline closing comment.
> - That path was still deciding whether to wake the assignee from the pre-update status, so a terminal close could enqueue a stale `issue_commented` wake.
> - If that deferred wake fires later, the assignee gets dragged back into work that should stay closed.
> - This pull request makes the PATCH comment wake guard use the post-mutation issue status, matching the safer POST comment path.
> - The benefit is that terminal close comments stay terminal, while explicit reopen/resume flows and normal non-terminal comment wakes still behave as before.

## Linked Issues or Issue Description

## What happened?

Closing an issue through the PATCH update route with `status: done` plus an inline comment could still queue an assignee `issue_commented` wake. That let a later heartbeat reopen work that should already have remained terminal.

## Expected behavior

A closing PATCH mutation should treat the issue as terminal after the status transition is applied. Inline close comments should not queue an assignee wake unless the mutation explicitly requests reopen or resume behavior.

## Steps to reproduce

1. Start with an issue assigned to an agent in a non-terminal state such as `in_review`.
2. Update it through the PATCH issue route with `status: done` and an inline `comment`.
3. Observe that the old implementation evaluates the wake guard from the pre-update closed state.
4. Let the deferred wake drain on a later heartbeat.
5. The assignee can get woken back into work that should have stayed closed.

## Paperclip version or commit

Reproduced against the Paperclip server code before this fix on the PR branch for this change, with the regression verified locally in the contributor runtime checkout.

## Deployment mode

Local development runtime and CI on the public `paperclipai/paperclip` pull request.

## What Changed

- Switched the PATCH comment wake suppression check in `server/src/routes/issues.ts` from the pre-update closed state to the post-mutation `issue.status`.
- Added a regression in `server/src/__tests__/issue-comment-reopen-routes.test.ts` for `in_review -> done` via PATCH with `comment`, asserting that no assignee `issue_commented` wake is sent.
- Left existing explicit `resume: true` / `reopen: true` behavior and non-terminal comment wake behavior unchanged.

## Verification

- `pnpm exec vitest run server/src/__tests__/issue-comment-reopen-routes.test.ts`
- `pnpm exec vitest run server/src/__tests__/heartbeat-comment-wake-batching.test.ts`
- `pnpm --filter @paperclipai/server typecheck`
- GitHub PR checks for build, tests, and security scans

## Risks

- Low risk. The code change is a one-line guard adjustment in the PATCH comment wake path plus a targeted regression test.
- Main regression risk would be suppressing a wake that should still fire, which is why the existing explicit resume/reopen and non-terminal wake paths were kept intact.

## Model Used

- OpenAI Codex, GPT-5 coding agent, local tool-using workflow with shell/test execution in the Paperclip repo

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
