### PR TITLE
test(cli): cover board token commands

### DIFF
--- a/cli/src/__tests__/token.test.ts
+++ b/cli/src/__tests__/token.test.ts
@@ -32,9 +32,11 @@ describe("token commands", () => {
     vi.restoreAllMocks();
     delete process.env.PAPERCLIP_API_KEY;
     delete process.env.PAPERCLIP_API_URL;
+    vi.useRealTimers();
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     vi.restoreAllMocks();
   });
 
@@ -131,5 +133,113 @@ describe("token commands", () => {
 
     expect(fetchMock.mock.calls[0]?.[0]).toBe(`http://localhost:3100/api/agents/${AGENT_ID}`);
     expect(fetchMock.mock.calls[1]?.[0]).toBe(`http://localhost:3100/api/agents/${AGENT_ID}/keys`);
+  });
+
+  it("creates a board token with a ttl-derived expiration", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-23T00:00:00.000Z"));
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        id: "board-key-1",
+        name: "external-admin",
+        token: "pcp_board_plaintext",
+        createdAt: "2026-05-23T00:00:00.000Z",
+        lastUsedAt: null,
+        revokedAt: null,
+        expiresAt: "2026-06-06T00:00:00.000Z",
+      }), { status: 201 }));
+    vi.stubGlobal("fetch", fetchMock);
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    await createProgram().parseAsync([
+      "token", "board", "create",
+      "--api-base", "http://localhost:3100",
+      "--api-key", "board-token",
+      "--company-id", COMPANY_ID,
+      "--name", "external-admin",
+      "--ttl-days", "14",
+      "--json",
+    ], { from: "user" });
+
+    expect(fetchMock.mock.calls[0]?.[0]).toBe("http://localhost:3100/api/board-api-keys");
+    expect(JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body))).toEqual({
+      name: "external-admin",
+      requestedCompanyId: COMPANY_ID,
+      expiresAt: "2026-06-06T00:00:00.000Z",
+    });
+    expect(JSON.parse(String(log.mock.calls[0]?.[0]))).toMatchObject({
+      key: {
+        id: "board-key-1",
+        name: "external-admin",
+        token: "pcp_board_plaintext",
+        expiresAt: "2026-06-06T00:00:00.000Z",
+      },
+    });
+  });
+
+  it("creates a non-expiring board token when requested", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        id: "board-key-1",
+        name: "external-admin",
+        token: "pcp_board_plaintext",
+        createdAt: "2026-05-23T00:00:00.000Z",
+        lastUsedAt: null,
+        revokedAt: null,
+        expiresAt: null,
+      }), { status: 201 }));
+    vi.stubGlobal("fetch", fetchMock);
+    vi.spyOn(console, "log").mockImplementation(() => {});
+
+    await createProgram().parseAsync([
+      "token", "board", "create",
+      "--api-base", "http://localhost:3100",
+      "--api-key", "board-token",
+      "--company-id", COMPANY_ID,
+      "--name", "external-admin",
+      "--never-expires",
+      "--json",
+    ], { from: "user" });
+
+    expect(JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body))).toEqual({
+      name: "external-admin",
+      requestedCompanyId: COMPANY_ID,
+      expiresAt: null,
+    });
+  });
+
+  it("lists and revokes board tokens", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify([{
+        id: "board-key-1",
+        name: "external-admin",
+        createdAt: "2026-05-23T00:00:00.000Z",
+        lastUsedAt: null,
+        expiresAt: null,
+        revokedAt: null,
+      }]), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ ok: true, keyId: "board-key-1" }), { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+    vi.spyOn(console, "log").mockImplementation(() => {});
+
+    await createProgram().parseAsync([
+      "token", "board", "list",
+      "--api-base", "http://localhost:3100",
+      "--api-key", "board-token",
+    ], { from: "user" });
+
+    await createProgram().parseAsync([
+      "token", "board", "revoke", "board-key-1",
+      "--api-base", "http://localhost:3100",
+      "--api-key", "board-token",
+      "--json",
+    ], { from: "user" });
+
+    expect(fetchMock.mock.calls[0]?.[0]).toBe("http://localhost:3100/api/board-api-keys");
+    expect(fetchMock.mock.calls[1]?.[0]).toBe("http://localhost:3100/api/board-api-keys/board-key-1");
+    expect(fetchMock.mock.calls[1]?.[1]?.method).toBe("DELETE");
   });
 });


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The CLI is one external control-plane surface for scripts and operators.
> - Board API keys are the headless credential path for board-authenticated automation.
> - The CLI already exposes board token create/list/revoke commands.
> - The existing token tests covered the generic agent token lifecycle, but did not directly cover the board token lifecycle.
> - This pull request adds focused tests for board token creation, listing, revocation, and expiration payload handling.
> - The benefit is safer CLI credential-management work without changing runtime behavior.

## Linked Issues or Issue Description

No public issue found. This is a test coverage follow-up for CLI board token lifecycle behavior described in `doc/plans/2026-05-23-cli-api-parity.md`.

Related context: #4220 tracks/contains board API key product work; this PR only adds tests for the current CLI command behavior on this branch.

## What Changed

- Added `token board create` coverage for `--ttl-days` expiration payloads.
- Added `token board create` coverage for `--never-expires` payloads.
- Added `token board list` and `token board revoke` coverage, including the DELETE route assertion.

## Verification

- `./node_modules/.bin/vitest run cli/src/__tests__/token.test.ts --config cli/vitest.config.ts` passes: 1 file, 6 tests.

## Risks

Low risk. This is test-only coverage for existing CLI behavior.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

OpenAI GPT-5 Codex in Codex desktop, with repository inspection, shell command execution, GitHub CLI usage, and code editing tools.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g., `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge