### PR TITLE
feat(push): add board Web Push notifications

### DIFF
--- a/packages/db/src/migrations/0207_web_push_subscriptions.sql
+++ b/packages/db/src/migrations/0207_web_push_subscriptions.sql
@@ -1,0 +1,11 @@
+CREATE TABLE IF NOT EXISTS "web_push_subscriptions" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"endpoint" text NOT NULL,
+	"p256dh" text NOT NULL,
+	"auth" text NOT NULL,
+	"device_label" text DEFAULT '' NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "web_push_subscriptions_endpoint_idx" ON "web_push_subscriptions" USING btree ("endpoint");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "web_push_subscriptions_created_at_idx" ON "web_push_subscriptions" USING btree ("created_at");

--- a/packages/db/src/migrations/0207_web_push_subscriptions.sql
+++ b/packages/db/src/migrations/0207_web_push_subscriptions.sql
@@ -1,11 +1,14 @@
 CREATE TABLE IF NOT EXISTS "web_push_subscriptions" (
 	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"company_id" uuid NOT NULL,
 	"endpoint" text NOT NULL,
 	"p256dh" text NOT NULL,
 	"auth" text NOT NULL,
 	"device_label" text DEFAULT '' NOT NULL,
-	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "web_push_subscriptions_company_id_companies_id_fk" FOREIGN KEY ("company_id") REFERENCES "companies"("id") ON DELETE cascade
 );
 --> statement-breakpoint
-CREATE UNIQUE INDEX IF NOT EXISTS "web_push_subscriptions_endpoint_idx" ON "web_push_subscriptions" USING btree ("endpoint");--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "web_push_subscriptions_company_endpoint_idx" ON "web_push_subscriptions" USING btree ("company_id","endpoint");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "web_push_subscriptions_company_idx" ON "web_push_subscriptions" USING btree ("company_id");--> statement-breakpoint
 CREATE INDEX IF NOT EXISTS "web_push_subscriptions_created_at_idx" ON "web_push_subscriptions" USING btree ("created_at");

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -1436,6 +1436,13 @@
       "when": 1785853648732,
       "tag": "0206_review_path_recovery_idempotency_index",
       "breakpoints": true
+    },
+    {
+      "idx": 207,
+      "version": "7",
+      "when": 1749168000000,
+      "tag": "0207_web_push_subscriptions",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -165,3 +165,4 @@ export { pluginDatabaseNamespaces, pluginMigrations } from "./plugin_database.js
 export { pluginJobs, pluginJobRuns } from "./plugin_jobs.js";
 export { pluginWebhookDeliveries } from "./plugin_webhooks.js";
 export { pluginLogs } from "./plugin_logs.js";
+export { webPushSubscriptions } from "./web_push_subscriptions.js";

--- a/packages/db/src/schema/web_push_subscriptions.ts
+++ b/packages/db/src/schema/web_push_subscriptions.ts
@@ -1,0 +1,17 @@
+import { pgTable, uuid, text, timestamp, uniqueIndex, index } from "drizzle-orm/pg-core";
+
+export const webPushSubscriptions = pgTable(
+  "web_push_subscriptions",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    endpoint: text("endpoint").notNull(),
+    p256dh: text("p256dh").notNull(),
+    auth: text("auth").notNull(),
+    deviceLabel: text("device_label").notNull().default(""),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    endpointIdx: uniqueIndex("web_push_subscriptions_endpoint_idx").on(table.endpoint),
+    createdAtIdx: index("web_push_subscriptions_created_at_idx").on(table.createdAt),
+  }),
+);

--- a/packages/db/src/schema/web_push_subscriptions.ts
+++ b/packages/db/src/schema/web_push_subscriptions.ts
@@ -1,9 +1,11 @@
 import { pgTable, uuid, text, timestamp, uniqueIndex, index } from "drizzle-orm/pg-core";
+import { companies } from "./companies.js";
 
 export const webPushSubscriptions = pgTable(
   "web_push_subscriptions",
   {
     id: uuid("id").primaryKey().defaultRandom(),
+    companyId: uuid("company_id").notNull().references(() => companies.id, { onDelete: "cascade" }),
     endpoint: text("endpoint").notNull(),
     p256dh: text("p256dh").notNull(),
     auth: text("auth").notNull(),
@@ -11,7 +13,8 @@ export const webPushSubscriptions = pgTable(
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => ({
-    endpointIdx: uniqueIndex("web_push_subscriptions_endpoint_idx").on(table.endpoint),
+    endpointIdx: uniqueIndex("web_push_subscriptions_company_endpoint_idx").on(table.companyId, table.endpoint),
+    companyIdx: index("web_push_subscriptions_company_idx").on(table.companyId),
     createdAtIdx: index("web_push_subscriptions_created_at_idx").on(table.createdAt),
   }),
 );

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -885,6 +885,7 @@ export const LIVE_EVENT_TYPES = [
   "issue.user_assigned",
   "issue.interaction.pending",
   "issue.blocked",
+  "issue.stale",
 ] as const;
 export type LiveEventType = (typeof LIVE_EVENT_TYPES)[number];
 

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -882,6 +882,9 @@ export const LIVE_EVENT_TYPES = [
   "plugin.ui.updated",
   "plugin.worker.crashed",
   "plugin.worker.restarted",
+  "issue.user_assigned",
+  "issue.interaction.pending",
+  "issue.blocked",
 ] as const;
 export type LiveEventType = (typeof LIVE_EVENT_TYPES)[number];
 

--- a/server/package.json
+++ b/server/package.json
@@ -78,6 +78,7 @@
     "pino-pretty": "^13.1.3",
     "sharp": "^0.35.3",
     "ssh2": "^1.17.0",
+    "web-push": "^3.6.7",
     "ws": "^8.21.1",
     "zod": "^3.24.2"
   },
@@ -89,6 +90,7 @@
     "@types/node": "^22.20.1",
     "@types/sharp": "^0.32.0",
     "@types/supertest": "^6.0.2",
+    "@types/web-push": "^3.6.4",
     "@types/ws": "^8.18.1",
     "cross-env": "^10.1.0",
     "supertest": "^7.0.0",

--- a/server/src/__tests__/openapi-routes.test.ts
+++ b/server/src/__tests__/openapi-routes.test.ts
@@ -47,6 +47,7 @@ const apiPrefixes: Record<string, string> = {
   "plugin-ui-static.ts": "/api",
   "plugins.ts": "/api",
   "projects.ts": "/api",
+  "push.ts": "/api",
   "resource-memberships.ts": "/api",
   "routines.ts": "/api",
   "secrets.ts": "/api",

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -64,6 +64,7 @@ import { accessRoutes } from "./routes/access.js";
 import { pluginRoutes } from "./routes/plugins.js";
 import { mcpGatewayProtocolRoutes, toolGatewayRoutes } from "./routes/tool-gateway.js";
 import { adapterRoutes } from "./routes/adapters.js";
+import { pushRoutes } from "./routes/push.js";
 import { pluginUiStaticRoutes } from "./routes/plugin-ui-static.js";
 import { readBrandedStaticIndexHtml } from "./static-index-html.js";
 import { applyUiBranding } from "./ui-branding.js";
@@ -417,6 +418,7 @@ export async function createApp(
   api.use(resourceMembershipRoutes(db));
   api.use(inboxDismissalRoutes(db));
   api.use(instanceSettingsRoutes(db));
+  api.use(pushRoutes(db));
   if (opts.databaseBackupService) {
     api.use(instanceDatabaseBackupRoutes(opts.databaseBackupService));
   }

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -65,6 +65,7 @@ import { pluginRoutes } from "./routes/plugins.js";
 import { mcpGatewayProtocolRoutes, toolGatewayRoutes } from "./routes/tool-gateway.js";
 import { adapterRoutes } from "./routes/adapters.js";
 import { pushRoutes } from "./routes/push.js";
+import { initPushFanout } from "./services/push-fanout.js";
 import { pluginUiStaticRoutes } from "./routes/plugin-ui-static.js";
 import { readBrandedStaticIndexHtml } from "./static-index-html.js";
 import { applyUiBranding } from "./ui-branding.js";
@@ -733,10 +734,12 @@ export async function createApp(
     logger.error({ err }, "Failed to load ready plugins on startup");
   });
   app.locals.bundledPluginsStartup = bundledPluginsStartup;
+  const cleanupPushFanout = initPushFanout(db);
   let appServicesShutdown = false;
   const shutdownAppServices = () => {
     if (appServicesShutdown) return;
     appServicesShutdown = true;
+    cleanupPushFanout();
     disableFeedbackExportFlushes();
     devWatcher?.close();
     viteHtmlRenderer?.dispose();

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -33,3 +33,5 @@ export { llmRoutes } from "./llms.js";
 export { accessRoutes } from "./access.js";
 export { instanceSettingsRoutes } from "./instance-settings.js";
 export { instanceDatabaseBackupRoutes } from "./instance-database-backups.js";
+export { cloudUpstreamRoutes } from "./cloud-upstreams.js";
+export { pushRoutes } from "./push.js";

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -33,5 +33,4 @@ export { llmRoutes } from "./llms.js";
 export { accessRoutes } from "./access.js";
 export { instanceSettingsRoutes } from "./instance-settings.js";
 export { instanceDatabaseBackupRoutes } from "./instance-database-backups.js";
-export { cloudUpstreamRoutes } from "./cloud-upstreams.js";
 export { pushRoutes } from "./push.js";

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -148,6 +148,7 @@ import {
 } from "../services/task-watchdog-scope.js";
 import type { TaskWatchdogServiceDeps, taskWatchdogService } from "../services/task-watchdogs.js";
 import { logger } from "../middleware/logger.js";
+import { publishLiveEvent } from "../services/live-events.js";
 import { badRequest, conflict, forbidden, HttpError, notFound, unauthorized, unprocessable } from "../errors.js";
 import { assertBoard, assertCompanyAccess, getAccessibleResource, getActorInfo } from "./authz.js";
 import {
@@ -9735,6 +9736,22 @@ export function issueRoutes(
       }
     })();
 
+    // Fire board push events for immediate and digest lanes.
+    if (issue.assigneeUserId && issue.assigneeUserId !== existing.assigneeUserId) {
+      publishLiveEvent({
+        companyId: issue.companyId,
+        type: "issue.user_assigned",
+        payload: { issueId: issue.id, issueIdentifier: issue.identifier ?? "", issueTitle: issue.title },
+      });
+    }
+    if (issue.status === "blocked" && existing.status !== "blocked") {
+      publishLiveEvent({
+        companyId: issue.companyId,
+        type: "issue.blocked",
+        payload: { issueId: issue.id, issueIdentifier: issue.identifier ?? "", issueTitle: issue.title },
+      });
+    }
+
     await queueTaskWatchdogEvaluation(issue, actor.runId);
     const changes = issueResponse.changes ?? {};
     if (prefersMinimalIssueUpdateResponse(req)) {
@@ -10102,6 +10119,16 @@ export function issueRoutes(
         interactionId: interaction.id,
         agentId: interaction.addresseeAgentId,
       }, "failed to wake addressee on issue interaction creation"));
+    }
+    if (
+      (interaction.kind === "request_confirmation" || interaction.kind === "ask_user_questions") &&
+      interaction.status === "pending"
+    ) {
+      publishLiveEvent({
+        companyId: issue.companyId,
+        type: "issue.interaction.pending",
+        payload: { issueId: issue.id, issueIdentifier: issue.identifier ?? "", issueTitle: issue.title },
+      });
     }
 
     res.status(201).json(interaction);

--- a/server/src/routes/openapi.ts
+++ b/server/src/routes/openapi.ts
@@ -668,6 +668,17 @@ const workTimelineResponseSchema = z.object({
   }).strict(),
 }).strict();
 
+const pushSubscriptionBodySchema = z.object({
+  endpoint: z.string().url(),
+  p256dh: z.string().min(1),
+  auth: z.string().min(1),
+  deviceLabel: z.string().optional(),
+}).strict();
+
+const deletePushSubscriptionBodySchema = z.object({
+  endpoint: z.string().url(),
+}).strict();
+
 function paramsSchemaFromPath(routePath: string): z.ZodObject<z.ZodRawShape> | undefined {
   const names = [...routePath.matchAll(/\{([A-Za-z0-9_]+)\}/g)].map((match) => match[1]);
   if (names.length === 0) return undefined;
@@ -732,6 +743,7 @@ const AUTHENTICATED_SECURITY: Array<Record<string, string[]>> = [
 const PUBLIC_OPERATIONS = new Set([
   "GET /api/health",
   "GET /api/openapi.json",
+  "GET /api/push/vapid-public-key",
   "GET /api/board-claim/{token}",
   "POST /api/cli-auth/challenges",
   "GET /api/cli-auth/challenges/{id}",
@@ -755,6 +767,7 @@ const BOARD_ONLY_PREFIXES = [
   "/api/auth/",
   "/api/admin/",
   "/api/plugins",
+  "/api/push/",
   "/api/instance/",
 ];
 
@@ -957,6 +970,7 @@ const CREATED_OPERATIONS = new Set([
   "POST /api/companies/{companyId}/tools/gateways",
   "POST /api/tool-gateway/gateways/{gatewayId}/tokens",
   "POST /api/tool-gateway/sessions",
+  "POST /api/push/subscriptions",
 ]);
 
 const ACCEPTED_OPERATIONS = new Set([
@@ -1185,6 +1199,87 @@ registry.registerPath({
   tags: ["health"],
   summary: "Get the generated OpenAPI document",
   responses: { 200: r.ok() },
+});
+
+// ─── Push notifications ─────────────────────────────────────────────────────
+
+registry.registerPath({
+  method: "get",
+  path: "/api/push/vapid-public-key",
+  tags: ["push"],
+  summary: "Get the Web Push VAPID public key",
+  responses: {
+    200: r.ok(z.object({ vapidPublicKey: z.string() }).strict()),
+    503: { description: "VAPID is not configured", content: { "application/json": { schema: ErrorSchema } } },
+  },
+});
+
+registry.registerPath({
+  method: "post",
+  path: "/api/push/subscriptions",
+  tags: ["push"],
+  summary: "Subscribe the current browser for Web Push notifications",
+  request: { body: jsonBody(pushSubscriptionBodySchema) },
+  responses: {
+    200: r.ok(z.object({ status: z.literal("subscribed") }).strict()),
+    400: r.badRequest,
+    401: r.unauthorized,
+  },
+});
+
+registry.registerPath({
+  method: "delete",
+  path: "/api/push/subscriptions",
+  tags: ["push"],
+  summary: "Unsubscribe a browser endpoint from Web Push notifications",
+  request: { body: jsonBody(deletePushSubscriptionBodySchema) },
+  responses: {
+    200: r.ok(z.object({ status: z.literal("unsubscribed") }).strict()),
+    400: r.badRequest,
+    401: r.unauthorized,
+  },
+});
+
+registry.registerPath({
+  method: "get",
+  path: "/api/push/subscriptions",
+  tags: ["push"],
+  summary: "List Web Push subscriptions",
+  responses: {
+    200: r.ok(z.object({
+      subscriptions: z.array(z.object({
+        id: z.string(),
+        endpoint: z.string(),
+        deviceLabel: z.string(),
+        createdAt: z.unknown(),
+      }).strict()),
+    }).strict()),
+    401: r.unauthorized,
+  },
+});
+
+registry.registerPath({
+  method: "post",
+  path: "/api/push/test",
+  tags: ["push"],
+  summary: "Send a test Web Push notification",
+  responses: {
+    200: r.ok(),
+    401: r.unauthorized,
+    503: { description: "VAPID is not configured", content: { "application/json": { schema: ErrorSchema } } },
+  },
+});
+
+registry.registerPath({
+  method: "post",
+  path: "/api/push/digest/test",
+  tags: ["push"],
+  summary: "Send a test Web Push digest notification",
+  responses: {
+    200: r.ok(),
+    401: r.unauthorized,
+    503: { description: "VAPID is not configured", content: { "application/json": { schema: ErrorSchema } } },
+  },
 });
 
 // ─── Companies ───────────────────────────────────────────────────────────────

--- a/server/src/routes/openapi.ts
+++ b/server/src/routes/openapi.ts
@@ -825,6 +825,11 @@ const BOARD_ONLY_OPERATIONS = new Set([
   "GET /api/secrets/{id}/usage",
   "GET /api/secrets/{id}/access-events",
   "POST /api/health/dev-server/restart",
+  "GET /api/companies/{companyId}/push/subscriptions",
+  "POST /api/companies/{companyId}/push/subscriptions",
+  "DELETE /api/companies/{companyId}/push/subscriptions",
+  "POST /api/companies/{companyId}/push/test",
+  "POST /api/companies/{companyId}/push/digest/test",
   "GET /api/issues/{issueId}/file-resources/content",
   "GET /api/issues/{issueId}/file-resources/list",
   "GET /api/issues/{issueId}/file-resources/resolve",
@@ -970,7 +975,7 @@ const CREATED_OPERATIONS = new Set([
   "POST /api/companies/{companyId}/tools/gateways",
   "POST /api/tool-gateway/gateways/{gatewayId}/tokens",
   "POST /api/tool-gateway/sessions",
-  "POST /api/push/subscriptions",
+  "POST /api/companies/{companyId}/push/subscriptions",
 ]);
 
 const ACCEPTED_OPERATIONS = new Set([
@@ -1216,10 +1221,13 @@ registry.registerPath({
 
 registry.registerPath({
   method: "post",
-  path: "/api/push/subscriptions",
+  path: "/api/companies/{companyId}/push/subscriptions",
   tags: ["push"],
   summary: "Subscribe the current browser for Web Push notifications",
-  request: { body: jsonBody(pushSubscriptionBodySchema) },
+  request: {
+    params: z.object({ companyId: z.string() }),
+    body: jsonBody(pushSubscriptionBodySchema),
+  },
   responses: {
     200: r.ok(z.object({ status: z.literal("subscribed") }).strict()),
     400: r.badRequest,
@@ -1229,10 +1237,13 @@ registry.registerPath({
 
 registry.registerPath({
   method: "delete",
-  path: "/api/push/subscriptions",
+  path: "/api/companies/{companyId}/push/subscriptions",
   tags: ["push"],
   summary: "Unsubscribe a browser endpoint from Web Push notifications",
-  request: { body: jsonBody(deletePushSubscriptionBodySchema) },
+  request: {
+    params: z.object({ companyId: z.string() }),
+    body: jsonBody(deletePushSubscriptionBodySchema),
+  },
   responses: {
     200: r.ok(z.object({ status: z.literal("unsubscribed") }).strict()),
     400: r.badRequest,
@@ -1242,9 +1253,10 @@ registry.registerPath({
 
 registry.registerPath({
   method: "get",
-  path: "/api/push/subscriptions",
+  path: "/api/companies/{companyId}/push/subscriptions",
   tags: ["push"],
   summary: "List Web Push subscriptions",
+  request: { params: z.object({ companyId: z.string() }) },
   responses: {
     200: r.ok(z.object({
       subscriptions: z.array(z.object({
@@ -1260,9 +1272,10 @@ registry.registerPath({
 
 registry.registerPath({
   method: "post",
-  path: "/api/push/test",
+  path: "/api/companies/{companyId}/push/test",
   tags: ["push"],
   summary: "Send a test Web Push notification",
+  request: { params: z.object({ companyId: z.string() }) },
   responses: {
     200: r.ok(),
     401: r.unauthorized,
@@ -1272,9 +1285,10 @@ registry.registerPath({
 
 registry.registerPath({
   method: "post",
-  path: "/api/push/digest/test",
+  path: "/api/companies/{companyId}/push/digest/test",
   tags: ["push"],
   summary: "Send a test Web Push digest notification",
+  request: { params: z.object({ companyId: z.string() }) },
   responses: {
     200: r.ok(),
     401: r.unauthorized,

--- a/server/src/routes/push.test.ts
+++ b/server/src/routes/push.test.ts
@@ -1,0 +1,89 @@
+import express, { type RequestHandler } from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Db } from "@paperclipai/db";
+import { errorHandler } from "../middleware/index.js";
+
+const upsertSubscription = vi.fn();
+
+vi.mock("../services/web-push.js", () => ({
+  getVapidPublicKey: vi.fn(() => "public-key"),
+  isVapidConfigured: vi.fn(() => true),
+  webPushService: vi.fn(() => ({
+    upsertSubscription,
+    deleteSubscription: vi.fn(),
+    listSubscriptions: vi.fn(async () => []),
+    sendToBoard: vi.fn(async () => ({ sent: 0, pruned: 0 })),
+  })),
+}));
+
+import { pushRoutes } from "./push.js";
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(((req, _res, next) => {
+    req.actor = {
+      type: "board",
+      source: "session",
+      userId: "user-1",
+      companyIds: ["company-1"],
+      memberships: [{ companyId: "company-1", status: "active", membershipRole: "admin" }],
+      isInstanceAdmin: false,
+    };
+    next();
+  }) as RequestHandler);
+  app.use("/api", pushRoutes({} as Db));
+  app.use(errorHandler);
+  return app;
+}
+
+function subscriptionBody(endpoint: string) {
+  return {
+    endpoint,
+    p256dh: "p256dh-key",
+    auth: "auth-secret",
+  };
+}
+
+describe("pushRoutes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it.each([
+    ["plain text", "not-a-url"],
+    ["non-https URL", "http://push.example.com/subscription"],
+    ["localhost URL", "https://localhost/subscription"],
+    ["loopback IP URL", "https://127.0.0.1/subscription"],
+    ["private IP URL", "https://10.1.2.3/subscription"],
+    ["link-local IP URL", "https://169.254.169.254/subscription"],
+    ["multicast IP URL", "https://224.0.0.1/subscription"],
+    ["IPv6 loopback URL", "https://[::1]/subscription"],
+    ["IPv6 unique-local URL", "https://[fd00::1]/subscription"],
+    ["IPv6 link-local URL", "https://[fe80::1]/subscription"],
+  ])("rejects %s subscription endpoints", async (_label, endpoint) => {
+    const res = await request(createApp())
+      .post("/api/companies/company-1/push/subscriptions")
+      .send(subscriptionBody(endpoint));
+
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({ error: "invalid_subscription" });
+    expect(upsertSubscription).not.toHaveBeenCalled();
+  });
+
+  it("accepts an HTTPS public push endpoint", async () => {
+    const res = await request(createApp())
+      .post("/api/companies/company-1/push/subscriptions")
+      .send(subscriptionBody("https://push.example.com/subscription"));
+
+    expect(res.status).toBe(201);
+    expect(upsertSubscription).toHaveBeenCalledWith({
+      companyId: "company-1",
+      endpoint: "https://push.example.com/subscription",
+      p256dh: "p256dh-key",
+      auth: "auth-secret",
+      deviceLabel: undefined,
+    });
+  });
+});

--- a/server/src/routes/push.ts
+++ b/server/src/routes/push.ts
@@ -1,0 +1,68 @@
+import { Router } from "express";
+import type { Db } from "@paperclipai/db";
+import { assertBoard } from "./authz.js";
+import { getVapidPublicKey, isVapidConfigured, webPushService } from "../services/web-push.js";
+
+export function pushRoutes(db: Db) {
+  const router = Router();
+  const svc = webPushService(db);
+
+  router.get("/push/vapid-public-key", (_req, res) => {
+    const key = getVapidPublicKey();
+    if (!key) {
+      res.status(503).json({ error: "vapid_not_configured" });
+      return;
+    }
+    res.json({ vapidPublicKey: key });
+  });
+
+  router.post("/push/subscriptions", async (req, res) => {
+    assertBoard(req);
+    const { endpoint, p256dh, auth, deviceLabel } = req.body ?? {};
+    if (typeof endpoint !== "string" || typeof p256dh !== "string" || typeof auth !== "string") {
+      res.status(400).json({ error: "invalid_subscription" });
+      return;
+    }
+    await svc.upsertSubscription({ endpoint, p256dh, auth, deviceLabel });
+    res.status(201).json({ status: "subscribed" });
+  });
+
+  router.delete("/push/subscriptions", async (req, res) => {
+    assertBoard(req);
+    const { endpoint } = req.body ?? {};
+    if (typeof endpoint !== "string") {
+      res.status(400).json({ error: "missing_endpoint" });
+      return;
+    }
+    await svc.deleteSubscription(endpoint);
+    res.json({ status: "unsubscribed" });
+  });
+
+  router.get("/push/subscriptions", async (req, res) => {
+    assertBoard(req);
+    const subs = await svc.listSubscriptions();
+    res.json({
+      subscriptions: subs.map((s) => ({
+        id: s.id,
+        endpoint: s.endpoint,
+        deviceLabel: s.deviceLabel,
+        createdAt: s.createdAt,
+      })),
+    });
+  });
+
+  router.post("/push/test", async (req, res) => {
+    assertBoard(req);
+    if (!isVapidConfigured()) {
+      res.status(503).json({ error: "vapid_not_configured" });
+      return;
+    }
+    const result = await svc.sendToBoard({
+      title: "Paperclip test notification",
+      body: "Web Push is working.",
+    });
+    res.json(result);
+  });
+
+  return router;
+}

--- a/server/src/routes/push.ts
+++ b/server/src/routes/push.ts
@@ -1,6 +1,6 @@
 import { Router } from "express";
 import type { Db } from "@paperclipai/db";
-import { assertBoard } from "./authz.js";
+import { assertBoard, assertCompanyAccess } from "./authz.js";
 import { getVapidPublicKey, isVapidConfigured, webPushService } from "../services/web-push.js";
 
 export function pushRoutes(db: Db) {
@@ -16,31 +16,44 @@ export function pushRoutes(db: Db) {
     res.json({ vapidPublicKey: key });
   });
 
-  router.post("/push/subscriptions", async (req, res) => {
+  router.post("/companies/:companyId/push/subscriptions", async (req, res) => {
     assertBoard(req);
+    const companyId = req.params.companyId as string;
+    assertCompanyAccess(req, companyId);
     const { endpoint, p256dh, auth, deviceLabel } = req.body ?? {};
-    if (typeof endpoint !== "string" || typeof p256dh !== "string" || typeof auth !== "string") {
+    if (
+      typeof endpoint !== "string" ||
+      typeof p256dh !== "string" ||
+      typeof auth !== "string" ||
+      endpoint.trim().length === 0 ||
+      p256dh.trim().length === 0 ||
+      auth.trim().length === 0
+    ) {
       res.status(400).json({ error: "invalid_subscription" });
       return;
     }
-    await svc.upsertSubscription({ endpoint, p256dh, auth, deviceLabel });
+    await svc.upsertSubscription({ companyId, endpoint, p256dh, auth, deviceLabel });
     res.status(201).json({ status: "subscribed" });
   });
 
-  router.delete("/push/subscriptions", async (req, res) => {
+  router.delete("/companies/:companyId/push/subscriptions", async (req, res) => {
     assertBoard(req);
+    const companyId = req.params.companyId as string;
+    assertCompanyAccess(req, companyId);
     const { endpoint } = req.body ?? {};
-    if (typeof endpoint !== "string") {
+    if (typeof endpoint !== "string" || endpoint.trim().length === 0) {
       res.status(400).json({ error: "missing_endpoint" });
       return;
     }
-    await svc.deleteSubscription(endpoint);
+    await svc.deleteSubscription(companyId, endpoint);
     res.json({ status: "unsubscribed" });
   });
 
-  router.get("/push/subscriptions", async (req, res) => {
+  router.get("/companies/:companyId/push/subscriptions", async (req, res) => {
     assertBoard(req);
-    const subs = await svc.listSubscriptions();
+    const companyId = req.params.companyId as string;
+    assertCompanyAccess(req, companyId);
+    const subs = await svc.listSubscriptions(companyId);
     res.json({
       subscriptions: subs.map((s) => ({
         id: s.id,
@@ -51,26 +64,30 @@ export function pushRoutes(db: Db) {
     });
   });
 
-  router.post("/push/test", async (req, res) => {
+  router.post("/companies/:companyId/push/test", async (req, res) => {
     assertBoard(req);
+    const companyId = req.params.companyId as string;
+    assertCompanyAccess(req, companyId);
     if (!isVapidConfigured()) {
       res.status(503).json({ error: "vapid_not_configured" });
       return;
     }
-    const result = await svc.sendToBoard({
+    const result = await svc.sendToBoard(companyId, {
       title: "Paperclip test notification",
       body: "Web Push is working.",
     });
     res.json(result);
   });
 
-  router.post("/push/digest/test", async (req, res) => {
+  router.post("/companies/:companyId/push/digest/test", async (req, res) => {
     assertBoard(req);
+    const companyId = req.params.companyId as string;
+    assertCompanyAccess(req, companyId);
     if (!isVapidConfigured()) {
       res.status(503).json({ error: "vapid_not_configured" });
       return;
     }
-    const result = await svc.sendToBoard({
+    const result = await svc.sendToBoard(companyId, {
       title: "Paperclip digest test",
       body: "Digest Web Push is working.",
       data: { kind: "digest", blockedCount: 1, staleCount: 1, test: true },

--- a/server/src/routes/push.ts
+++ b/server/src/routes/push.ts
@@ -64,5 +64,19 @@ export function pushRoutes(db: Db) {
     res.json(result);
   });
 
+  router.post("/push/digest/test", async (req, res) => {
+    assertBoard(req);
+    if (!isVapidConfigured()) {
+      res.status(503).json({ error: "vapid_not_configured" });
+      return;
+    }
+    const result = await svc.sendToBoard({
+      title: "Paperclip digest test",
+      body: "Digest Web Push is working.",
+      data: { kind: "digest", blockedCount: 1, staleCount: 1, test: true },
+    });
+    res.json(result);
+  });
+
   return router;
 }

--- a/server/src/routes/push.ts
+++ b/server/src/routes/push.ts
@@ -1,7 +1,61 @@
 import { Router } from "express";
+import { isIP } from "node:net";
 import type { Db } from "@paperclipai/db";
 import { assertBoard, assertCompanyAccess } from "./authz.js";
 import { getVapidPublicKey, isVapidConfigured, webPushService } from "../services/web-push.js";
+
+function isPrivateIpv4(hostname: string) {
+  const octets = hostname.split(".").map((part) => Number.parseInt(part, 10));
+  if (octets.length !== 4 || octets.some((octet) => !Number.isInteger(octet) || octet < 0 || octet > 255)) {
+    return false;
+  }
+  const [a, b] = octets;
+  if (a === 10 || a === 127 || a === 0) return true;
+  if (a === 169 && b === 254) return true;
+  if (a === 172 && b >= 16 && b <= 31) return true;
+  if (a === 192 && b === 168) return true;
+  if (a >= 224) return true;
+  return false;
+}
+
+function isPrivateIpv6(hostname: string) {
+  const normalized = hostname.toLowerCase();
+  return normalized === "::1" ||
+    normalized === "::" ||
+    normalized.startsWith("fc") ||
+    normalized.startsWith("fd") ||
+    normalized.startsWith("fe80:");
+}
+
+function isInternalPushHostname(hostname: string) {
+  const lowerHostname = hostname.toLowerCase();
+  const normalized = lowerHostname.startsWith("[") && lowerHostname.endsWith("]")
+    ? lowerHostname.slice(1, -1)
+    : lowerHostname;
+  if (
+    normalized === "localhost" ||
+    normalized.endsWith(".localhost") ||
+    normalized.endsWith(".local") ||
+    normalized.endsWith(".internal")
+  ) {
+    return true;
+  }
+  if (isIP(normalized) === 4) return isPrivateIpv4(normalized);
+  if (isIP(normalized) === 6) return isPrivateIpv6(normalized);
+  return false;
+}
+
+function normalizePushEndpoint(endpoint: string): string | null {
+  const trimmed = endpoint.trim();
+  try {
+    const url = new URL(trimmed);
+    if (url.protocol !== "https:" || !url.hostname || url.username || url.password) return null;
+    if (isInternalPushHostname(url.hostname)) return null;
+    return url.href;
+  } catch {
+    return null;
+  }
+}
 
 export function pushRoutes(db: Db) {
   const router = Router();
@@ -21,18 +75,19 @@ export function pushRoutes(db: Db) {
     const companyId = req.params.companyId as string;
     assertCompanyAccess(req, companyId);
     const { endpoint, p256dh, auth, deviceLabel } = req.body ?? {};
+    const normalizedEndpoint = typeof endpoint === "string" ? normalizePushEndpoint(endpoint) : null;
     if (
       typeof endpoint !== "string" ||
       typeof p256dh !== "string" ||
       typeof auth !== "string" ||
-      endpoint.trim().length === 0 ||
+      normalizedEndpoint === null ||
       p256dh.trim().length === 0 ||
       auth.trim().length === 0
     ) {
       res.status(400).json({ error: "invalid_subscription" });
       return;
     }
-    await svc.upsertSubscription({ companyId, endpoint, p256dh, auth, deviceLabel });
+    await svc.upsertSubscription({ companyId, endpoint: normalizedEndpoint, p256dh, auth, deviceLabel });
     res.status(201).json({ status: "subscribed" });
   });
 

--- a/server/src/services/live-events.ts
+++ b/server/src/services/live-events.ts
@@ -31,6 +31,9 @@ export function publishLiveEvent(input: {
 }) {
   const event = toLiveEvent(input);
   emitter.emit(input.companyId, event);
+  if (input.companyId !== "*") {
+    emitter.emit("*", event);
+  }
   return event;
 }
 

--- a/server/src/services/push-fanout.test.ts
+++ b/server/src/services/push-fanout.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Set up mocks before imports
+const mockSendToBoard = vi.fn().mockResolvedValue({ sent: 1, pruned: 0 });
+
+vi.mock("./live-events.js", () => ({
+  subscribeGlobalLiveEvents: vi.fn(),
+}));
+
+vi.mock("./web-push.js", () => ({
+  webPushService: vi.fn(() => ({ sendToBoard: mockSendToBoard })),
+}));
+
+import { subscribeGlobalLiveEvents } from "./live-events.js";
+import { initPushFanout } from "./push-fanout.js";
+
+const mockSubscribe = vi.mocked(subscribeGlobalLiveEvents);
+
+function captureListener(): (event: Parameters<Parameters<typeof subscribeGlobalLiveEvents>[0]>[0]) => void {
+  const listener = mockSubscribe.mock.calls[mockSubscribe.mock.calls.length - 1][0];
+  if (!listener) throw new Error("no listener captured");
+  return listener;
+}
+
+function makeIssueEvent(type: string, issueId = "issue-1") {
+  return {
+    id: 1,
+    companyId: "company-1",
+    type,
+    createdAt: new Date().toISOString(),
+    payload: {
+      issueId,
+      issueIdentifier: "SAG-9999",
+      issueTitle: "Test issue",
+    },
+  } as Parameters<Parameters<typeof subscribeGlobalLiveEvents>[0]>[0];
+}
+
+describe("initPushFanout", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSendToBoard.mockResolvedValue({ sent: 1, pruned: 0 });
+    // Use 0-hour dedup TTL so dedup key resets instantly in dedup tests
+    process.env.PAPERCLIP_PUSH_DEDUP_TTL_HOURS = "4";
+    // Set quiet hours to something that won't fire during tests (midnight-1am)
+    process.env.PAPERCLIP_PUSH_QUIET_START = "0";
+    process.env.PAPERCLIP_PUSH_QUIET_END = "1";
+  });
+
+  it("calls sendToBoard on issue.user_assigned", async () => {
+    initPushFanout({} as never);
+    const listener = captureListener();
+
+    await listener(makeIssueEvent("issue.user_assigned"));
+
+    // Allow microtasks to flush
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(mockSendToBoard).toHaveBeenCalledOnce();
+    expect(mockSendToBoard.mock.calls[0][0]).toMatchObject({
+      title: expect.stringContaining("Action needed"),
+    });
+  });
+
+  it("calls sendToBoard on issue.interaction.pending", async () => {
+    initPushFanout({} as never);
+    const listener = captureListener();
+
+    await listener(makeIssueEvent("issue.interaction.pending"));
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(mockSendToBoard).toHaveBeenCalledOnce();
+    expect(mockSendToBoard.mock.calls[0][0]).toMatchObject({
+      title: expect.stringContaining("input needed"),
+    });
+  });
+
+  it("deduplicates repeat immediate events for the same issue within TTL", async () => {
+    process.env.PAPERCLIP_PUSH_DEDUP_TTL_HOURS = "4";
+    initPushFanout({} as never);
+    const listener = captureListener();
+
+    // Fire same event twice — second should be suppressed
+    await listener(makeIssueEvent("issue.user_assigned", "issue-dedup"));
+    await listener(makeIssueEvent("issue.user_assigned", "issue-dedup"));
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(mockSendToBoard).toHaveBeenCalledOnce();
+  });
+
+  it("does NOT dedup events for different issues", async () => {
+    initPushFanout({} as never);
+    const listener = captureListener();
+
+    await listener(makeIssueEvent("issue.user_assigned", "issue-a"));
+    await listener(makeIssueEvent("issue.user_assigned", "issue-b"));
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(mockSendToBoard).toHaveBeenCalledTimes(2);
+  });
+
+  it("buffers issue.blocked without sending immediately", async () => {
+    initPushFanout({} as never);
+    const listener = captureListener();
+
+    // Digest interval is 4h — won't flush immediately
+    process.env.PAPERCLIP_PUSH_DIGEST_INTERVAL_HOURS = "4";
+    await listener(makeIssueEvent("issue.blocked"));
+    await new Promise((r) => setTimeout(r, 10));
+
+    // sendToBoard should NOT have been called (digest not flushed yet)
+    expect(mockSendToBoard).not.toHaveBeenCalled();
+  });
+
+  it("returns a cleanup function that stops the subscriber", () => {
+    const mockUnsubscribe = vi.fn();
+    mockSubscribe.mockReturnValueOnce(mockUnsubscribe);
+
+    const cleanup = initPushFanout({} as never);
+    cleanup();
+
+    expect(mockUnsubscribe).toHaveBeenCalledOnce();
+  });
+});

--- a/server/src/services/push-fanout.test.ts
+++ b/server/src/services/push-fanout.test.ts
@@ -62,7 +62,8 @@ describe("initPushFanout", () => {
     await flushFanout();
 
     expect(mockSendToBoard).toHaveBeenCalledOnce();
-    expect(mockSendToBoard.mock.calls[0][0]).toMatchObject({
+    expect(mockSendToBoard.mock.calls[0][0]).toBe("company-1");
+    expect(mockSendToBoard.mock.calls[0][1]).toMatchObject({
       title: expect.stringContaining("Action needed"),
     });
   });
@@ -74,7 +75,8 @@ describe("initPushFanout", () => {
     await flushFanout();
 
     expect(mockSendToBoard).toHaveBeenCalledOnce();
-    expect(mockSendToBoard.mock.calls[0][0]).toMatchObject({
+    expect(mockSendToBoard.mock.calls[0][0]).toBe("company-1");
+    expect(mockSendToBoard.mock.calls[0][1]).toMatchObject({
       title: expect.stringContaining("input needed"),
     });
   });
@@ -121,10 +123,48 @@ describe("initPushFanout", () => {
     await flushFanout();
 
     expect(mockSendToBoard).toHaveBeenCalledOnce();
-    expect(mockSendToBoard.mock.calls[0][0]).toMatchObject({
+    expect(mockSendToBoard.mock.calls[0][0]).toBe("company-1");
+    expect(mockSendToBoard.mock.calls[0][1]).toMatchObject({
       title: "1 blocked, 1 stale — tap to view",
       data: { kind: "digest", blockedCount: 1, staleCount: 1 },
     });
+  });
+
+  it("keeps digest items queued when sending fails and retries on the next eligible flush", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-07T15:00:00Z"));
+    mockSendToBoard.mockRejectedValueOnce(new Error("temporary push outage"));
+    startFanout();
+
+    publishIssueEvent("issue.blocked", "issue-retry-blocked");
+    vi.setSystemTime(new Date("2026-07-07T16:01:00Z"));
+    publishIssueEvent("issue.stale", "issue-retry-stale");
+    await flushFanout();
+
+    expect(mockSendToBoard).toHaveBeenCalledTimes(1);
+
+    vi.setSystemTime(new Date("2026-07-07T16:02:00Z"));
+    publishIssueEvent("issue.blocked", "issue-retry-trigger");
+    await flushFanout();
+
+    expect(mockSendToBoard).toHaveBeenCalledTimes(2);
+    expect(mockSendToBoard.mock.calls[1][1]).toMatchObject({
+      data: { kind: "digest", blockedCount: 2, staleCount: 1 },
+    });
+  });
+
+  it("evicts expired immediate dedup entries", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-07T15:00:00Z"));
+    process.env.PAPERCLIP_PUSH_DEDUP_TTL_HOURS = "1";
+    startFanout();
+
+    publishIssueEvent("issue.user_assigned", "issue-dedup-expire");
+    vi.setSystemTime(new Date("2026-07-07T16:01:00Z"));
+    publishIssueEvent("issue.user_assigned", "issue-dedup-expire");
+    await flushFanout();
+
+    expect(mockSendToBoard).toHaveBeenCalledTimes(2);
   });
 
   it("defers blocked and stale digest pushes during quiet hours", async () => {

--- a/server/src/services/push-fanout.test.ts
+++ b/server/src/services/push-fanout.test.ts
@@ -1,60 +1,65 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-// Set up mocks before imports
 const mockSendToBoard = vi.fn().mockResolvedValue({ sent: 1, pruned: 0 });
-
-vi.mock("./live-events.js", () => ({
-  subscribeGlobalLiveEvents: vi.fn(),
-}));
 
 vi.mock("./web-push.js", () => ({
   webPushService: vi.fn(() => ({ sendToBoard: mockSendToBoard })),
 }));
 
-import { subscribeGlobalLiveEvents } from "./live-events.js";
-import { initPushFanout } from "./push-fanout.js";
+import { publishLiveEvent } from "./live-events.js";
+import { __resetPushFanoutForTests, initPushFanout } from "./push-fanout.js";
 
-const mockSubscribe = vi.mocked(subscribeGlobalLiveEvents);
+let cleanup: (() => void) | null = null;
 
-function captureListener(): (event: Parameters<Parameters<typeof subscribeGlobalLiveEvents>[0]>[0]) => void {
-  const listener = mockSubscribe.mock.calls[mockSubscribe.mock.calls.length - 1][0];
-  if (!listener) throw new Error("no listener captured");
-  return listener;
+function startFanout() {
+  cleanup?.();
+  cleanup = initPushFanout({} as never);
 }
 
-function makeIssueEvent(type: string, issueId = "issue-1") {
-  return {
-    id: 1,
+function publishIssueEvent(
+  type: "issue.user_assigned" | "issue.interaction.pending" | "issue.blocked" | "issue.stale",
+  issueId = "issue-1",
+) {
+  publishLiveEvent({
     companyId: "company-1",
     type,
-    createdAt: new Date().toISOString(),
     payload: {
       issueId,
       issueIdentifier: "SAG-9999",
       issueTitle: "Test issue",
     },
-  } as Parameters<Parameters<typeof subscribeGlobalLiveEvents>[0]>[0];
+  });
+}
+
+async function flushFanout() {
+  await Promise.resolve();
+  await Promise.resolve();
 }
 
 describe("initPushFanout", () => {
   beforeEach(() => {
+    vi.useRealTimers();
     vi.clearAllMocks();
+    __resetPushFanoutForTests();
     mockSendToBoard.mockResolvedValue({ sent: 1, pruned: 0 });
-    // Use 0-hour dedup TTL so dedup key resets instantly in dedup tests
     process.env.PAPERCLIP_PUSH_DEDUP_TTL_HOURS = "4";
-    // Set quiet hours to something that won't fire during tests (midnight-1am)
+    process.env.PAPERCLIP_PUSH_DIGEST_INTERVAL_HOURS = "1";
     process.env.PAPERCLIP_PUSH_QUIET_START = "0";
     process.env.PAPERCLIP_PUSH_QUIET_END = "1";
   });
 
-  it("calls sendToBoard on issue.user_assigned", async () => {
-    initPushFanout({} as never);
-    const listener = captureListener();
+  afterEach(() => {
+    cleanup?.();
+    cleanup = null;
+    __resetPushFanoutForTests();
+    vi.useRealTimers();
+  });
 
-    await listener(makeIssueEvent("issue.user_assigned"));
+  it("calls sendToBoard once when publishLiveEvent emits issue.user_assigned", async () => {
+    startFanout();
 
-    // Allow microtasks to flush
-    await new Promise((r) => setTimeout(r, 10));
+    publishIssueEvent("issue.user_assigned");
+    await flushFanout();
 
     expect(mockSendToBoard).toHaveBeenCalledOnce();
     expect(mockSendToBoard.mock.calls[0][0]).toMatchObject({
@@ -63,11 +68,10 @@ describe("initPushFanout", () => {
   });
 
   it("calls sendToBoard on issue.interaction.pending", async () => {
-    initPushFanout({} as never);
-    const listener = captureListener();
+    startFanout();
 
-    await listener(makeIssueEvent("issue.interaction.pending"));
-    await new Promise((r) => setTimeout(r, 10));
+    publishIssueEvent("issue.interaction.pending", "issue-interaction");
+    await flushFanout();
 
     expect(mockSendToBoard).toHaveBeenCalledOnce();
     expect(mockSendToBoard.mock.calls[0][0]).toMatchObject({
@@ -76,49 +80,76 @@ describe("initPushFanout", () => {
   });
 
   it("deduplicates repeat immediate events for the same issue within TTL", async () => {
-    process.env.PAPERCLIP_PUSH_DEDUP_TTL_HOURS = "4";
-    initPushFanout({} as never);
-    const listener = captureListener();
+    startFanout();
 
-    // Fire same event twice — second should be suppressed
-    await listener(makeIssueEvent("issue.user_assigned", "issue-dedup"));
-    await listener(makeIssueEvent("issue.user_assigned", "issue-dedup"));
-    await new Promise((r) => setTimeout(r, 10));
+    publishIssueEvent("issue.user_assigned", "issue-dedup");
+    publishIssueEvent("issue.user_assigned", "issue-dedup");
+    await flushFanout();
 
     expect(mockSendToBoard).toHaveBeenCalledOnce();
   });
 
-  it("does NOT dedup events for different issues", async () => {
-    initPushFanout({} as never);
-    const listener = captureListener();
+  it("does not dedup events for different issues", async () => {
+    startFanout();
 
-    await listener(makeIssueEvent("issue.user_assigned", "issue-a"));
-    await listener(makeIssueEvent("issue.user_assigned", "issue-b"));
-    await new Promise((r) => setTimeout(r, 10));
+    publishIssueEvent("issue.user_assigned", "issue-a");
+    publishIssueEvent("issue.user_assigned", "issue-b");
+    await flushFanout();
 
     expect(mockSendToBoard).toHaveBeenCalledTimes(2);
   });
 
   it("buffers issue.blocked without sending immediately", async () => {
-    initPushFanout({} as never);
-    const listener = captureListener();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-07T15:00:00Z"));
+    startFanout();
 
-    // Digest interval is 4h — won't flush immediately
-    process.env.PAPERCLIP_PUSH_DIGEST_INTERVAL_HOURS = "4";
-    await listener(makeIssueEvent("issue.blocked"));
-    await new Promise((r) => setTimeout(r, 10));
+    publishIssueEvent("issue.blocked", "issue-blocked-buffered");
+    await flushFanout();
 
-    // sendToBoard should NOT have been called (digest not flushed yet)
     expect(mockSendToBoard).not.toHaveBeenCalled();
   });
 
-  it("returns a cleanup function that stops the subscriber", () => {
-    const mockUnsubscribe = vi.fn();
-    mockSubscribe.mockReturnValueOnce(mockUnsubscribe);
+  it("batches blocked and stale events into a digest from real published events", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-07T15:00:00Z"));
+    startFanout();
 
-    const cleanup = initPushFanout({} as never);
-    cleanup();
+    publishIssueEvent("issue.blocked", "issue-blocked");
+    vi.setSystemTime(new Date("2026-07-07T16:01:00Z"));
+    publishIssueEvent("issue.stale", "issue-stale");
+    await flushFanout();
 
-    expect(mockUnsubscribe).toHaveBeenCalledOnce();
+    expect(mockSendToBoard).toHaveBeenCalledOnce();
+    expect(mockSendToBoard.mock.calls[0][0]).toMatchObject({
+      title: "1 blocked, 1 stale — tap to view",
+      data: { kind: "digest", blockedCount: 1, staleCount: 1 },
+    });
+  });
+
+  it("defers blocked and stale digest pushes during quiet hours", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-07T23:00:00Z"));
+    process.env.PAPERCLIP_PUSH_QUIET_START = "0";
+    process.env.PAPERCLIP_PUSH_QUIET_END = "24";
+    startFanout();
+
+    publishIssueEvent("issue.blocked", "issue-blocked-quiet");
+    vi.setSystemTime(new Date("2026-07-08T00:01:00Z"));
+    publishIssueEvent("issue.stale", "issue-stale-quiet");
+    await flushFanout();
+
+    expect(mockSendToBoard).not.toHaveBeenCalled();
+  });
+
+  it("returns a cleanup function that stops the subscriber", async () => {
+    startFanout();
+    cleanup?.();
+    cleanup = null;
+
+    publishIssueEvent("issue.user_assigned", "issue-after-cleanup");
+    await flushFanout();
+
+    expect(mockSendToBoard).not.toHaveBeenCalled();
   });
 });

--- a/server/src/services/push-fanout.ts
+++ b/server/src/services/push-fanout.ts
@@ -1,0 +1,135 @@
+import { subscribeGlobalLiveEvents } from "./live-events.js";
+import { webPushService } from "./web-push.js";
+import { logger } from "../middleware/logger.js";
+import type { Db } from "@paperclipai/db";
+
+// Dedup store for immediate-lane pushes: key = `issueId:eventType`, value = last-sent ms
+const immediateDedup = new Map<string, number>();
+
+function getDedupTtlMs(): number {
+  const hours = parseInt(process.env.PAPERCLIP_PUSH_DEDUP_TTL_HOURS ?? "4", 10);
+  return (isNaN(hours) ? 4 : Math.max(1, hours)) * 60 * 60 * 1000;
+}
+
+function isDuped(issueId: string, eventType: string): boolean {
+  const key = `${issueId}:${eventType}`;
+  const now = Date.now();
+  const last = immediateDedup.get(key);
+  if (last !== undefined && now - last < getDedupTtlMs()) return true;
+  immediateDedup.set(key, now);
+  return false;
+}
+
+// Quiet-hours helpers
+function getQuietHours(): { start: number; end: number } {
+  const start = parseInt(process.env.PAPERCLIP_PUSH_QUIET_START ?? "22", 10);
+  const end = parseInt(process.env.PAPERCLIP_PUSH_QUIET_END ?? "7", 10);
+  return {
+    start: isNaN(start) ? 22 : start,
+    end: isNaN(end) ? 7 : end,
+  };
+}
+
+function isInQuietHours(): boolean {
+  const { start, end } = getQuietHours();
+  const hour = new Date().getHours();
+  // handles midnight wrap-around (e.g. 22–7)
+  return start > end ? hour >= start || hour < end : hour >= start && hour < end;
+}
+
+// Digest-lane buffer
+interface DigestItem {
+  issueId: string;
+  issueTitle: string;
+  issueIdentifier: string;
+  kind: "blocked" | "stale";
+  queuedAt: number;
+}
+
+const digestBuffer: DigestItem[] = [];
+let lastDigestFlushAt = 0;
+
+function getDigestFlushIntervalMs(): number {
+  // min interval between digest flushes (default 4 h → ≤2 flushes per 8-h active window)
+  const hours = parseInt(process.env.PAPERCLIP_PUSH_DIGEST_INTERVAL_HOURS ?? "4", 10);
+  return (isNaN(hours) ? 4 : Math.max(1, hours)) * 60 * 60 * 1000;
+}
+
+async function maybeFlushDigest(push: ReturnType<typeof webPushService>): Promise<void> {
+  if (digestBuffer.length === 0) return;
+  if (isInQuietHours()) return; // digest always defers to next window
+  if (Date.now() - lastDigestFlushAt < getDigestFlushIntervalMs()) return;
+
+  const toFlush = digestBuffer.splice(0, digestBuffer.length);
+  lastDigestFlushAt = Date.now();
+
+  const blockedCount = toFlush.filter((i) => i.kind === "blocked").length;
+  const staleCount = toFlush.filter((i) => i.kind === "stale").length;
+  const parts: string[] = [];
+  if (blockedCount > 0) parts.push(`${blockedCount} blocked`);
+  if (staleCount > 0) parts.push(`${staleCount} stale`);
+
+  logger.info({ blockedCount, staleCount }, "push-fanout: flushing digest");
+
+  await push.sendToBoard({
+    title: `${parts.join(", ")} — tap to view`,
+    body: "Issues need your attention",
+    data: { kind: "digest", blockedCount, staleCount },
+  });
+}
+
+export function initPushFanout(db: Db): () => void {
+  const push = webPushService(db);
+  // Start the digest interval from now so the first flush is no sooner than one full interval.
+  lastDigestFlushAt = Date.now();
+
+  const unsubscribe = subscribeGlobalLiveEvents((event) => {
+    void (async () => {
+      try {
+        const { type, payload } = event;
+        const issueId = typeof payload.issueId === "string" ? payload.issueId : undefined;
+        if (!issueId) return;
+
+        const issueIdentifier = typeof payload.issueIdentifier === "string" ? payload.issueIdentifier : issueId;
+        const issueTitle = typeof payload.issueTitle === "string" ? payload.issueTitle : "";
+
+        if (type === "issue.user_assigned" || type === "issue.interaction.pending") {
+          if (isDuped(issueId, type)) {
+            logger.debug({ issueId, type }, "push-fanout: deduped immediate event");
+            return;
+          }
+
+          // Immediate lane — assignment overrides quiet hours per spec; interactions follow same rule.
+          const title = type === "issue.user_assigned"
+            ? `Action needed: ${issueIdentifier}`
+            : `Your input needed: ${issueIdentifier}`;
+
+          await push.sendToBoard({ title, body: issueTitle, data: { issueId, eventType: type } });
+          logger.info({ issueId, type }, "push-fanout: sent immediate push");
+        }
+
+        if (type === "issue.blocked") {
+          digestBuffer.push({ issueId, issueTitle, issueIdentifier, kind: "blocked", queuedAt: Date.now() });
+          await maybeFlushDigest(push);
+        }
+      } catch (err) {
+        logger.warn({ err, eventType: event.type }, "push-fanout: error handling live event");
+      }
+    })();
+  });
+
+  // Periodic digest-flush check (every minute) so digest isn't gated solely on new events.
+  const flushTimer = setInterval(() => {
+    if (digestBuffer.length > 0) {
+      void maybeFlushDigest(push).catch((err) => {
+        logger.warn({ err }, "push-fanout: periodic digest flush failed");
+      });
+    }
+  }, 60_000);
+  flushTimer.unref?.();
+
+  return () => {
+    unsubscribe();
+    clearInterval(flushTimer);
+  };
+}

--- a/server/src/services/push-fanout.ts
+++ b/server/src/services/push-fanout.ts
@@ -49,6 +49,12 @@ interface DigestItem {
 const digestBuffer: DigestItem[] = [];
 let lastDigestFlushAt = 0;
 
+export function __resetPushFanoutForTests(): void {
+  immediateDedup.clear();
+  digestBuffer.splice(0, digestBuffer.length);
+  lastDigestFlushAt = 0;
+}
+
 function getDigestFlushIntervalMs(): number {
   // min interval between digest flushes (default 4 h → ≤2 flushes per 8-h active window)
   const hours = parseInt(process.env.PAPERCLIP_PUSH_DIGEST_INTERVAL_HOURS ?? "4", 10);
@@ -100,16 +106,23 @@ export function initPushFanout(db: Db): () => void {
           }
 
           // Immediate lane — assignment overrides quiet hours per spec; interactions follow same rule.
-          const title = type === "issue.user_assigned"
-            ? `Action needed: ${issueIdentifier}`
-            : `Your input needed: ${issueIdentifier}`;
+          const title =
+            type === "issue.user_assigned"
+              ? `Action needed: ${issueIdentifier}`
+              : `Your input needed: ${issueIdentifier}`;
 
           await push.sendToBoard({ title, body: issueTitle, data: { issueId, eventType: type } });
           logger.info({ issueId, type }, "push-fanout: sent immediate push");
         }
 
-        if (type === "issue.blocked") {
-          digestBuffer.push({ issueId, issueTitle, issueIdentifier, kind: "blocked", queuedAt: Date.now() });
+        if (type === "issue.blocked" || type === "issue.stale") {
+          digestBuffer.push({
+            issueId,
+            issueTitle,
+            issueIdentifier,
+            kind: type === "issue.blocked" ? "blocked" : "stale",
+            queuedAt: Date.now(),
+          });
           await maybeFlushDigest(push);
         }
       } catch (err) {

--- a/server/src/services/push-fanout.ts
+++ b/server/src/services/push-fanout.ts
@@ -3,7 +3,7 @@ import { webPushService } from "./web-push.js";
 import { logger } from "../middleware/logger.js";
 import type { Db } from "@paperclipai/db";
 
-// Dedup store for immediate-lane pushes: key = `issueId:eventType`, value = last-sent ms
+// Dedup store for immediate-lane pushes: key = `companyId:issueId:eventType`, value = last-sent ms
 const immediateDedup = new Map<string, number>();
 
 function getDedupTtlMs(): number {
@@ -11,11 +11,21 @@ function getDedupTtlMs(): number {
   return (isNaN(hours) ? 4 : Math.max(1, hours)) * 60 * 60 * 1000;
 }
 
-function isDuped(issueId: string, eventType: string): boolean {
-  const key = `${issueId}:${eventType}`;
+function pruneExpiredDedupEntries(now: number, ttlMs: number): void {
+  for (const [key, timestamp] of immediateDedup.entries()) {
+    if (now - timestamp >= ttlMs) {
+      immediateDedup.delete(key);
+    }
+  }
+}
+
+function isDuped(companyId: string, issueId: string, eventType: string): boolean {
+  const key = `${companyId}:${issueId}:${eventType}`;
   const now = Date.now();
+  const ttlMs = getDedupTtlMs();
+  pruneExpiredDedupEntries(now, ttlMs);
   const last = immediateDedup.get(key);
-  if (last !== undefined && now - last < getDedupTtlMs()) return true;
+  if (last !== undefined && now - last < ttlMs) return true;
   immediateDedup.set(key, now);
   return false;
 }
@@ -39,6 +49,7 @@ function isInQuietHours(): boolean {
 
 // Digest-lane buffer
 interface DigestItem {
+  companyId: string;
   issueId: string;
   issueTitle: string;
   issueIdentifier: string;
@@ -47,12 +58,12 @@ interface DigestItem {
 }
 
 const digestBuffer: DigestItem[] = [];
-let lastDigestFlushAt = 0;
+const lastDigestFlushAt = new Map<string, number>();
 
 export function __resetPushFanoutForTests(): void {
   immediateDedup.clear();
   digestBuffer.splice(0, digestBuffer.length);
-  lastDigestFlushAt = 0;
+  lastDigestFlushAt.clear();
 }
 
 function getDigestFlushIntervalMs(): number {
@@ -61,38 +72,42 @@ function getDigestFlushIntervalMs(): number {
   return (isNaN(hours) ? 4 : Math.max(1, hours)) * 60 * 60 * 1000;
 }
 
-async function maybeFlushDigest(push: ReturnType<typeof webPushService>): Promise<void> {
-  if (digestBuffer.length === 0) return;
+async function maybeFlushDigest(push: ReturnType<typeof webPushService>, companyId: string): Promise<void> {
+  const companyDigestItems = digestBuffer.filter((item) => item.companyId === companyId);
+  if (companyDigestItems.length === 0) return;
   if (isInQuietHours()) return; // digest always defers to next window
-  if (Date.now() - lastDigestFlushAt < getDigestFlushIntervalMs()) return;
+  if (Date.now() - (lastDigestFlushAt.get(companyId) ?? 0) < getDigestFlushIntervalMs()) return;
 
-  const toFlush = digestBuffer.splice(0, digestBuffer.length);
-  lastDigestFlushAt = Date.now();
-
-  const blockedCount = toFlush.filter((i) => i.kind === "blocked").length;
-  const staleCount = toFlush.filter((i) => i.kind === "stale").length;
+  const blockedCount = companyDigestItems.filter((i) => i.kind === "blocked").length;
+  const staleCount = companyDigestItems.filter((i) => i.kind === "stale").length;
   const parts: string[] = [];
   if (blockedCount > 0) parts.push(`${blockedCount} blocked`);
   if (staleCount > 0) parts.push(`${staleCount} stale`);
 
-  logger.info({ blockedCount, staleCount }, "push-fanout: flushing digest");
+  logger.info({ companyId, blockedCount, staleCount }, "push-fanout: flushing digest");
 
-  await push.sendToBoard({
+  await push.sendToBoard(companyId, {
     title: `${parts.join(", ")} — tap to view`,
     body: "Issues need your attention",
     data: { kind: "digest", blockedCount, staleCount },
   });
+
+  for (let index = digestBuffer.length - 1; index >= 0; index--) {
+    if (digestBuffer[index]?.companyId === companyId) {
+      digestBuffer.splice(index, 1);
+    }
+  }
+  lastDigestFlushAt.set(companyId, Date.now());
 }
 
 export function initPushFanout(db: Db): () => void {
   const push = webPushService(db);
-  // Start the digest interval from now so the first flush is no sooner than one full interval.
-  lastDigestFlushAt = Date.now();
 
   const unsubscribe = subscribeGlobalLiveEvents((event) => {
     void (async () => {
       try {
         const { type, payload } = event;
+        const companyId = event.companyId;
         const issueId = typeof payload.issueId === "string" ? payload.issueId : undefined;
         if (!issueId) return;
 
@@ -100,8 +115,8 @@ export function initPushFanout(db: Db): () => void {
         const issueTitle = typeof payload.issueTitle === "string" ? payload.issueTitle : "";
 
         if (type === "issue.user_assigned" || type === "issue.interaction.pending") {
-          if (isDuped(issueId, type)) {
-            logger.debug({ issueId, type }, "push-fanout: deduped immediate event");
+          if (isDuped(companyId, issueId, type)) {
+            logger.debug({ companyId, issueId, type }, "push-fanout: deduped immediate event");
             return;
           }
 
@@ -111,19 +126,24 @@ export function initPushFanout(db: Db): () => void {
               ? `Action needed: ${issueIdentifier}`
               : `Your input needed: ${issueIdentifier}`;
 
-          await push.sendToBoard({ title, body: issueTitle, data: { issueId, eventType: type } });
-          logger.info({ issueId, type }, "push-fanout: sent immediate push");
+          await push.sendToBoard(companyId, { title, body: issueTitle, data: { issueId, eventType: type } });
+          logger.info({ companyId, issueId, type }, "push-fanout: sent immediate push");
         }
 
         if (type === "issue.blocked" || type === "issue.stale") {
+          if (!lastDigestFlushAt.has(companyId)) {
+            // Start each company digest window at first queued item.
+            lastDigestFlushAt.set(companyId, Date.now());
+          }
           digestBuffer.push({
+            companyId,
             issueId,
             issueTitle,
             issueIdentifier,
             kind: type === "issue.blocked" ? "blocked" : "stale",
             queuedAt: Date.now(),
           });
-          await maybeFlushDigest(push);
+          await maybeFlushDigest(push, companyId);
         }
       } catch (err) {
         logger.warn({ err, eventType: event.type }, "push-fanout: error handling live event");
@@ -134,9 +154,11 @@ export function initPushFanout(db: Db): () => void {
   // Periodic digest-flush check (every minute) so digest isn't gated solely on new events.
   const flushTimer = setInterval(() => {
     if (digestBuffer.length > 0) {
-      void maybeFlushDigest(push).catch((err) => {
-        logger.warn({ err }, "push-fanout: periodic digest flush failed");
-      });
+      for (const companyId of new Set(digestBuffer.map((item) => item.companyId))) {
+        void maybeFlushDigest(push, companyId).catch((err) => {
+          logger.warn({ err, companyId }, "push-fanout: periodic digest flush failed");
+        });
+      }
     }
   }, 60_000);
   flushTimer.unref?.();

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -52,6 +52,7 @@ import {
   findExistingIssueBlockersResolvedWakeForAnyKey,
 } from "../issue-dependency-wakeups.js";
 import { evaluateAgentInvokabilityFromDb } from "../agent-invokability.js";
+import { publishLiveEvent } from "../live-events.js";
 import { getRunLogStore } from "../run-log-store.js";
 import {
   DEFAULT_MAX_SUCCESSFUL_RUN_HANDOFF_ATTEMPTS,
@@ -2255,6 +2256,18 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         sourceIssueId: sourceIssue?.id ?? null,
         silenceAgeMs: evidence.silenceAgeMs,
         lastOutputAt: input.run.lastOutputAt?.toISOString() ?? null,
+      },
+    });
+    publishLiveEvent({
+      companyId: evaluation.companyId,
+      type: "issue.stale",
+      payload: {
+        issueId: evaluation.id,
+        issueIdentifier: evaluation.identifier ?? "",
+        issueTitle: evaluation.title,
+        sourceIssueId: sourceIssue?.id ?? null,
+        staleRunId: input.run.id,
+        level,
       },
     });
     if (level === "critical") {

--- a/server/src/services/web-push.test.ts
+++ b/server/src/services/web-push.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock the web-push module before any imports that use it
+vi.mock("web-push", () => ({
+  default: {
+    setVapidDetails: vi.fn(),
+    sendNotification: vi.fn(),
+  },
+}));
+
+import webPush from "web-push";
+import { webPushService, type PushSubscriptionData } from "./web-push.js";
+
+const mockSendNotification = vi.mocked(webPush.sendNotification);
+
+function makeDb(rows: SRow[] = []) {
+  let store = [...rows];
+
+  return {
+    _store: () => store,
+    insert: () => ({
+      values: () => ({
+        onConflictDoUpdate: () => Promise.resolve(),
+      }),
+    }),
+    delete: () => ({
+      where: () => {
+        // simple delete: remove matching endpoint from store
+        store = store.filter(() => false); // simplified for pruning test
+        return Promise.resolve();
+      },
+    }),
+    select: () => ({
+      from: () => ({
+        orderBy: () => Promise.resolve(store),
+      }),
+    }),
+  } as unknown as Parameters<typeof webPushService>[0];
+}
+
+type SRow = { endpoint: string; p256dh: string; auth: string; id: string; deviceLabel: string; createdAt: Date };
+
+const SUB: PushSubscriptionData = {
+  endpoint: "https://push.example.com/test",
+  p256dh: "BNcRdreALRFXTkOOUHK1EtK2wtwe",
+  auth: "tBHItJI5svbpez7KI4CCXg",
+};
+
+describe("webPushService.sendToSubscription", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.PAPERCLIP_VAPID_PUBLIC_KEY = "BDummyPublicKey1234567890abcdefghijklmnop";
+    process.env.PAPERCLIP_VAPID_PRIVATE_KEY = "DummyPrivateKey1234567890abcdef";
+  });
+
+  it("prunes subscription on 410 Gone", async () => {
+    const deletedEndpoints: string[] = [];
+    const db = {
+      insert: () => ({ values: () => ({ onConflictDoUpdate: () => Promise.resolve() }) }),
+      delete: () => ({
+        where: (_cond: unknown) => {
+          deletedEndpoints.push(SUB.endpoint);
+          return Promise.resolve();
+        },
+      }),
+      select: () => ({ from: () => ({ orderBy: () => Promise.resolve([]) }) }),
+    } as unknown as Parameters<typeof webPushService>[0];
+
+    const err = Object.assign(new Error("Gone"), { statusCode: 410 });
+    mockSendNotification.mockRejectedValueOnce(err);
+
+    const svc = webPushService(db);
+    const result = await svc.sendToSubscription(SUB, { title: "Test" });
+
+    expect(result).toEqual({ sent: false, pruned: true });
+    expect(deletedEndpoints).toContain(SUB.endpoint);
+  });
+
+  it("prunes subscription on 404 Not Found", async () => {
+    const deletedEndpoints: string[] = [];
+    const db = {
+      insert: () => ({ values: () => ({ onConflictDoUpdate: () => Promise.resolve() }) }),
+      delete: () => ({
+        where: (_cond: unknown) => {
+          deletedEndpoints.push(SUB.endpoint);
+          return Promise.resolve();
+        },
+      }),
+      select: () => ({ from: () => ({ orderBy: () => Promise.resolve([]) }) }),
+    } as unknown as Parameters<typeof webPushService>[0];
+
+    const err = Object.assign(new Error("Not Found"), { statusCode: 404 });
+    mockSendNotification.mockRejectedValueOnce(err);
+
+    const svc = webPushService(db);
+    const result = await svc.sendToSubscription(SUB, { title: "Test" });
+
+    expect(result).toEqual({ sent: false, pruned: true });
+    expect(deletedEndpoints).toContain(SUB.endpoint);
+  });
+
+  it("returns sent=true on success", async () => {
+    const db = {
+      insert: () => ({ values: () => ({ onConflictDoUpdate: () => Promise.resolve() }) }),
+      delete: () => ({ where: () => Promise.resolve() }),
+      select: () => ({ from: () => ({ orderBy: () => Promise.resolve([]) }) }),
+    } as unknown as Parameters<typeof webPushService>[0];
+
+    mockSendNotification.mockResolvedValueOnce({ statusCode: 201, body: "", headers: {} } as unknown as Awaited<ReturnType<typeof webPush.sendNotification>>);
+
+    const svc = webPushService(db);
+    const result = await svc.sendToSubscription(SUB, { title: "Test" });
+
+    expect(result).toEqual({ sent: true, pruned: false });
+  });
+
+  it("does not prune on non-404/410 errors", async () => {
+    const deletedEndpoints: string[] = [];
+    const db = {
+      insert: () => ({ values: () => ({ onConflictDoUpdate: () => Promise.resolve() }) }),
+      delete: () => ({
+        where: (_cond: unknown) => {
+          deletedEndpoints.push(SUB.endpoint);
+          return Promise.resolve();
+        },
+      }),
+      select: () => ({ from: () => ({ orderBy: () => Promise.resolve([]) }) }),
+    } as unknown as Parameters<typeof webPushService>[0];
+
+    const err = Object.assign(new Error("Server Error"), { statusCode: 500 });
+    mockSendNotification.mockRejectedValueOnce(err);
+
+    const svc = webPushService(db);
+    const result = await svc.sendToSubscription(SUB, { title: "Test" });
+
+    expect(result).toEqual({ sent: false, pruned: false });
+    expect(deletedEndpoints).toHaveLength(0);
+  });
+});

--- a/server/src/services/web-push.test.ts
+++ b/server/src/services/web-push.test.ts
@@ -41,6 +41,7 @@ function makeDb(rows: SRow[] = []) {
 type SRow = { endpoint: string; p256dh: string; auth: string; id: string; deviceLabel: string; createdAt: Date };
 
 const SUB: PushSubscriptionData = {
+  companyId: "company-1",
   endpoint: "https://push.example.com/test",
   p256dh: "BNcRdreALRFXTkOOUHK1EtK2wtwe",
   auth: "tBHItJI5svbpez7KI4CCXg",
@@ -135,5 +136,36 @@ describe("webPushService.sendToSubscription", () => {
 
     expect(result).toEqual({ sent: false, pruned: false });
     expect(deletedEndpoints).toHaveLength(0);
+  });
+
+  it("sends only to subscriptions for the requested company", async () => {
+    const row = {
+      ...SUB,
+      id: "sub-1",
+      deviceLabel: "Chrome",
+      createdAt: new Date("2026-07-07T00:00:00.000Z"),
+    };
+    let whereCalled = false;
+    const db = {
+      insert: () => ({ values: () => ({ onConflictDoUpdate: () => Promise.resolve() }) }),
+      delete: () => ({ where: () => Promise.resolve() }),
+      select: () => ({
+        from: () => ({
+          where: () => {
+            whereCalled = true;
+            return { orderBy: () => Promise.resolve([row]) };
+          },
+        }),
+      }),
+    } as unknown as Parameters<typeof webPushService>[0];
+
+    mockSendNotification.mockResolvedValueOnce({ statusCode: 201, body: "", headers: {} } as unknown as Awaited<ReturnType<typeof webPush.sendNotification>>);
+
+    const svc = webPushService(db);
+    const result = await svc.sendToBoard("company-1", { title: "Test" });
+
+    expect(result).toEqual({ sent: 1, pruned: 0 });
+    expect(whereCalled).toBe(true);
+    expect(mockSendNotification).toHaveBeenCalledOnce();
   });
 });

--- a/server/src/services/web-push.ts
+++ b/server/src/services/web-push.ts
@@ -1,0 +1,141 @@
+import webPush from "web-push";
+import { eq } from "drizzle-orm";
+import type { Db } from "@paperclipai/db";
+import { webPushSubscriptions } from "@paperclipai/db";
+import { logger } from "../middleware/logger.js";
+
+export type PushSubscriptionData = {
+  endpoint: string;
+  p256dh: string;
+  auth: string;
+  deviceLabel?: string;
+};
+
+export type PushPayload = {
+  title: string;
+  body?: string;
+  icon?: string;
+  data?: Record<string, unknown>;
+};
+
+function getVapidConfig() {
+  const publicKey = process.env.PAPERCLIP_VAPID_PUBLIC_KEY?.trim();
+  const privateKey = process.env.PAPERCLIP_VAPID_PRIVATE_KEY?.trim();
+  const subject = process.env.PAPERCLIP_VAPID_SUBJECT?.trim() ?? "mailto:push@paperclip.local";
+  return { publicKey, privateKey, subject };
+}
+
+export function isVapidConfigured(): boolean {
+  const { publicKey, privateKey } = getVapidConfig();
+  return Boolean(publicKey && privateKey);
+}
+
+export function getVapidPublicKey(): string | undefined {
+  return getVapidConfig().publicKey;
+}
+
+function configureWebPush() {
+  const { publicKey, privateKey, subject } = getVapidConfig();
+  if (!publicKey || !privateKey) return false;
+  webPush.setVapidDetails(subject, publicKey, privateKey);
+  return true;
+}
+
+export function webPushService(db: Db) {
+  async function upsertSubscription(sub: PushSubscriptionData) {
+    await db
+      .insert(webPushSubscriptions)
+      .values({
+        endpoint: sub.endpoint,
+        p256dh: sub.p256dh,
+        auth: sub.auth,
+        deviceLabel: sub.deviceLabel ?? "",
+      })
+      .onConflictDoUpdate({
+        target: webPushSubscriptions.endpoint,
+        set: {
+          p256dh: sub.p256dh,
+          auth: sub.auth,
+          deviceLabel: sub.deviceLabel ?? "",
+        },
+      });
+  }
+
+  async function deleteSubscription(endpoint: string) {
+    await db
+      .delete(webPushSubscriptions)
+      .where(eq(webPushSubscriptions.endpoint, endpoint));
+  }
+
+  async function listSubscriptions() {
+    return db
+      .select()
+      .from(webPushSubscriptions)
+      .orderBy(webPushSubscriptions.createdAt);
+  }
+
+  async function pruneDeadSubscription(endpoint: string) {
+    await db
+      .delete(webPushSubscriptions)
+      .where(eq(webPushSubscriptions.endpoint, endpoint));
+    logger.info({ endpoint }, "Pruned dead Web Push subscription");
+  }
+
+  async function sendToSubscription(
+    sub: { endpoint: string; p256dh: string; auth: string },
+    payload: PushPayload,
+  ): Promise<{ sent: boolean; pruned: boolean }> {
+    if (!configureWebPush()) {
+      logger.warn("VAPID keys not configured — skipping Web Push send");
+      return { sent: false, pruned: false };
+    }
+
+    try {
+      await webPush.sendNotification(
+        {
+          endpoint: sub.endpoint,
+          keys: { p256dh: sub.p256dh, auth: sub.auth },
+        },
+        JSON.stringify(payload),
+      );
+      return { sent: true, pruned: false };
+    } catch (err: unknown) {
+      const status = (err as { statusCode?: number }).statusCode;
+      if (status === 404 || status === 410) {
+        await pruneDeadSubscription(sub.endpoint);
+        return { sent: false, pruned: true };
+      }
+      logger.warn({ err, endpoint: sub.endpoint }, "Web Push send failed");
+      return { sent: false, pruned: false };
+    }
+  }
+
+  async function sendToBoard(payload: PushPayload): Promise<{ sent: number; pruned: number }> {
+    if (!configureWebPush()) {
+      logger.warn("VAPID keys not configured — skipping sendToBoard");
+      return { sent: 0, pruned: 0 };
+    }
+
+    const subs = await listSubscriptions();
+    let sent = 0;
+    let pruned = 0;
+
+    await Promise.all(
+      subs.map(async (sub) => {
+        const result = await sendToSubscription(sub, payload);
+        if (result.sent) sent++;
+        if (result.pruned) pruned++;
+      }),
+    );
+
+    return { sent, pruned };
+  }
+
+  return {
+    upsertSubscription,
+    deleteSubscription,
+    listSubscriptions,
+    sendToSubscription,
+    sendToBoard,
+  };
+}

--- a/server/src/services/web-push.ts
+++ b/server/src/services/web-push.ts
@@ -1,10 +1,11 @@
 import webPush from "web-push";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import { webPushSubscriptions } from "@paperclipai/db";
 import { logger } from "../middleware/logger.js";
 
 export type PushSubscriptionData = {
+  companyId: string;
   endpoint: string;
   p256dh: string;
   auth: string;
@@ -46,13 +47,14 @@ export function webPushService(db: Db) {
     await db
       .insert(webPushSubscriptions)
       .values({
+        companyId: sub.companyId,
         endpoint: sub.endpoint,
         p256dh: sub.p256dh,
         auth: sub.auth,
         deviceLabel: sub.deviceLabel ?? "",
       })
       .onConflictDoUpdate({
-        target: webPushSubscriptions.endpoint,
+        target: [webPushSubscriptions.companyId, webPushSubscriptions.endpoint],
         set: {
           p256dh: sub.p256dh,
           auth: sub.auth,
@@ -61,28 +63,35 @@ export function webPushService(db: Db) {
       });
   }
 
-  async function deleteSubscription(endpoint: string) {
+  async function deleteSubscription(companyId: string, endpoint: string) {
     await db
       .delete(webPushSubscriptions)
-      .where(eq(webPushSubscriptions.endpoint, endpoint));
+      .where(and(
+        eq(webPushSubscriptions.companyId, companyId),
+        eq(webPushSubscriptions.endpoint, endpoint),
+      ));
   }
 
-  async function listSubscriptions() {
+  async function listSubscriptions(companyId: string) {
     return db
       .select()
       .from(webPushSubscriptions)
+      .where(eq(webPushSubscriptions.companyId, companyId))
       .orderBy(webPushSubscriptions.createdAt);
   }
 
-  async function pruneDeadSubscription(endpoint: string) {
+  async function pruneDeadSubscription(companyId: string, endpoint: string) {
     await db
       .delete(webPushSubscriptions)
-      .where(eq(webPushSubscriptions.endpoint, endpoint));
-    logger.info({ endpoint }, "Pruned dead Web Push subscription");
+      .where(and(
+        eq(webPushSubscriptions.companyId, companyId),
+        eq(webPushSubscriptions.endpoint, endpoint),
+      ));
+    logger.info({ companyId, endpoint }, "Pruned dead Web Push subscription");
   }
 
   async function sendToSubscription(
-    sub: { endpoint: string; p256dh: string; auth: string },
+    sub: { companyId: string; endpoint: string; p256dh: string; auth: string },
     payload: PushPayload,
   ): Promise<{ sent: boolean; pruned: boolean }> {
     if (!configureWebPush()) {
@@ -102,7 +111,7 @@ export function webPushService(db: Db) {
     } catch (err: unknown) {
       const status = (err as { statusCode?: number }).statusCode;
       if (status === 404 || status === 410) {
-        await pruneDeadSubscription(sub.endpoint);
+        await pruneDeadSubscription(sub.companyId, sub.endpoint);
         return { sent: false, pruned: true };
       }
       logger.warn({ err, endpoint: sub.endpoint }, "Web Push send failed");
@@ -110,13 +119,13 @@ export function webPushService(db: Db) {
     }
   }
 
-  async function sendToBoard(payload: PushPayload): Promise<{ sent: number; pruned: number }> {
+  async function sendToBoard(companyId: string, payload: PushPayload): Promise<{ sent: number; pruned: number }> {
     if (!configureWebPush()) {
       logger.warn("VAPID keys not configured — skipping sendToBoard");
       return { sent: 0, pruned: 0 };
     }
 
-    const subs = await listSubscriptions();
+    const subs = await listSubscriptions(companyId);
     let sent = 0;
     let pruned = 0;
 

--- a/ui/public/sw.js
+++ b/ui/public/sw.js
@@ -13,6 +13,41 @@ self.addEventListener("activate", (event) => {
   self.clients.claim();
 });
 
+self.addEventListener("push", (event) => {
+  let data = {};
+  try {
+    data = event.data ? event.data.json() : {};
+  } catch {
+    data = { title: "Paperclip", body: event.data ? event.data.text() : "" };
+  }
+  const title = data.title ?? "Paperclip";
+  const options = {
+    body: data.body ?? "",
+    icon: "/android-chrome-192x192.png",
+    badge: "/favicon-32x32.png",
+    data: data.data ?? {},
+  };
+  event.waitUntil(self.registration.showNotification(title, options));
+});
+
+self.addEventListener("notificationclick", (event) => {
+  event.notification.close();
+  const url = event.notification.data?.url ?? "/";
+  event.waitUntil(
+    self.clients
+      .matchAll({ type: "window", includeUncontrolled: true })
+      .then((clients) => {
+        const match = clients.find((c) => c.url.includes(self.location.origin));
+        if (match) {
+          match.focus();
+          match.navigate(url);
+        } else {
+          self.clients.openWindow(url);
+        }
+      })
+  );
+});
+
 self.addEventListener("fetch", (event) => {
   const { request } = event;
   const url = new URL(request.url);

--- a/ui/public/sw.js
+++ b/ui/public/sw.js
@@ -39,11 +39,9 @@ self.addEventListener("notificationclick", (event) => {
       .then((clients) => {
         const match = clients.find((c) => c.url.includes(self.location.origin));
         if (match) {
-          match.focus();
-          match.navigate(url);
-        } else {
-          self.clients.openWindow(url);
+          return match.focus().then((client) => client.navigate(url));
         }
+        return self.clients.openWindow(url);
       })
   );
 });

--- a/ui/public/sw.js
+++ b/ui/public/sw.js
@@ -32,16 +32,25 @@ self.addEventListener("push", (event) => {
 
 self.addEventListener("notificationclick", (event) => {
   event.notification.close();
-  const url = event.notification.data?.url ?? "/";
+  let targetUrl = "/";
+  try {
+    const rawUrl = event.notification.data?.url ?? "/";
+    const parsedUrl = new URL(rawUrl, self.location.origin);
+    if (parsedUrl.origin === self.location.origin) {
+      targetUrl = parsedUrl.href;
+    }
+  } catch {
+    targetUrl = "/";
+  }
   event.waitUntil(
     self.clients
       .matchAll({ type: "window", includeUncontrolled: true })
       .then((clients) => {
         const match = clients.find((c) => c.url.includes(self.location.origin));
         if (match) {
-          return match.focus().then((client) => client.navigate(url));
+          return match.focus().then((client) => client.navigate(targetUrl));
         }
-        return self.clients.openWindow(url);
+        return self.clients.openWindow(targetUrl);
       })
   );
 });

--- a/ui/src/api/push.ts
+++ b/ui/src/api/push.ts
@@ -1,0 +1,26 @@
+import { api } from "./client";
+
+export type PushSubscriptionRecord = {
+  id: string;
+  endpoint: string;
+  deviceLabel: string;
+  createdAt: string;
+};
+
+export const pushApi = {
+  getVapidPublicKey: () =>
+    api.get<{ vapidPublicKey: string }>("/push/vapid-public-key"),
+
+  subscribe: (params: {
+    endpoint: string;
+    p256dh: string;
+    auth: string;
+    deviceLabel?: string;
+  }) => api.post<{ status: string }>("/push/subscriptions", params),
+
+  unsubscribe: (endpoint: string) =>
+    api.delete<{ status: string }>("/push/subscriptions", { endpoint }),
+
+  listSubscriptions: () =>
+    api.get<{ subscriptions: PushSubscriptionRecord[] }>("/push/subscriptions"),
+};

--- a/ui/src/api/push.ts
+++ b/ui/src/api/push.ts
@@ -11,16 +11,16 @@ export const pushApi = {
   getVapidPublicKey: () =>
     api.get<{ vapidPublicKey: string }>("/push/vapid-public-key"),
 
-  subscribe: (params: {
+  subscribe: (companyId: string, params: {
     endpoint: string;
     p256dh: string;
     auth: string;
     deviceLabel?: string;
-  }) => api.post<{ status: string }>("/push/subscriptions", params),
+  }) => api.post<{ status: string }>(`/companies/${encodeURIComponent(companyId)}/push/subscriptions`, params),
 
-  unsubscribe: (endpoint: string) =>
-    api.delete<{ status: string }>("/push/subscriptions", { endpoint }),
+  unsubscribe: (companyId: string, endpoint: string) =>
+    api.delete<{ status: string }>(`/companies/${encodeURIComponent(companyId)}/push/subscriptions`, { endpoint }),
 
-  listSubscriptions: () =>
-    api.get<{ subscriptions: PushSubscriptionRecord[] }>("/push/subscriptions"),
+  listSubscriptions: (companyId: string) =>
+    api.get<{ subscriptions: PushSubscriptionRecord[] }>(`/companies/${encodeURIComponent(companyId)}/push/subscriptions`),
 };

--- a/ui/src/components/PushNotificationSection.test.tsx
+++ b/ui/src/components/PushNotificationSection.test.tsx
@@ -1,0 +1,84 @@
+// @vitest-environment jsdom
+import { createRoot, type Root } from "react-dom/client";
+import { act } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { PushNotificationSection } from "./PushNotificationSection";
+import { usePushNotifications } from "@/hooks/use-push-notifications";
+
+vi.mock("@/hooks/use-push-notifications", () => ({
+  usePushNotifications: vi.fn(),
+}));
+
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let root: Root | null = null;
+let container: HTMLDivElement | null = null;
+
+function renderSection() {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  const createdRoot = createRoot(container);
+  root = createdRoot;
+  act(() => {
+    createdRoot.render(<PushNotificationSection />);
+  });
+  return { text: () => container?.textContent ?? "" };
+}
+
+afterEach(() => {
+  if (root) {
+    act(() => root?.unmount());
+  }
+  container?.remove();
+  root = null;
+  container = null;
+  vi.restoreAllMocks();
+});
+
+describe("PushNotificationSection", () => {
+  it("renders the subscribed device list and marks the current device", () => {
+    vi.mocked(usePushNotifications).mockReturnValue({
+      state: { status: "subscribed", endpoint: "https://push.example/current" },
+      isToggling: false,
+      subscriptions: [
+        {
+          id: "sub-1",
+          endpoint: "https://push.example/current",
+          deviceLabel: "Chrome on Linux",
+          createdAt: "2026-07-04T00:00:00.000Z",
+        },
+        {
+          id: "sub-2",
+          endpoint: "https://push.example/phone",
+          deviceLabel: "Mobile Safari",
+          createdAt: "2026-07-03T00:00:00.000Z",
+        },
+      ],
+      refreshSubscriptions: vi.fn(),
+      enable: vi.fn(),
+      disable: vi.fn(),
+    });
+
+    const view = renderSection();
+
+    expect(view.text()).toContain("Subscribed devices");
+    expect(view.text()).toContain("Chrome on Linux");
+    expect(view.text()).toContain("Mobile Safari");
+    expect(view.text()).toContain("This device");
+  });
+
+  it("renders an empty subscribed-device state", () => {
+    vi.mocked(usePushNotifications).mockReturnValue({
+      state: { status: "unsubscribed" },
+      isToggling: false,
+      subscriptions: [],
+      refreshSubscriptions: vi.fn(),
+      enable: vi.fn(),
+      disable: vi.fn(),
+    });
+
+    const view = renderSection();
+
+    expect(view.text()).toContain("No devices are subscribed yet.");
+  });
+});

--- a/ui/src/components/PushNotificationSection.test.tsx
+++ b/ui/src/components/PushNotificationSection.test.tsx
@@ -20,7 +20,7 @@ function renderSection() {
   const createdRoot = createRoot(container);
   root = createdRoot;
   act(() => {
-    createdRoot.render(<PushNotificationSection />);
+    createdRoot.render(<PushNotificationSection companyId="company-1" />);
   });
   return { text: () => container?.textContent ?? "" };
 }

--- a/ui/src/components/PushNotificationSection.tsx
+++ b/ui/src/components/PushNotificationSection.tsx
@@ -1,0 +1,79 @@
+import { Bell, BellOff, Loader2, ShieldAlert, Smartphone } from "lucide-react";
+import { usePushNotifications } from "@/hooks/use-push-notifications";
+import { ToggleSwitch } from "@/components/ui/toggle-switch";
+import { Card, CardContent } from "@/components/ui/card";
+
+export function PushNotificationSection() {
+  const { state, isToggling, enable, disable } = usePushNotifications();
+
+  return (
+    <div className="space-y-3">
+      <div>
+        <h2 className="text-sm font-semibold flex items-center gap-2">
+          <Smartphone className="h-4 w-4 text-muted-foreground" />
+          Push Notifications
+        </h2>
+        <p className="text-xs text-muted-foreground mt-1">
+          Receive alerts on this device when the board needs your attention.
+        </p>
+      </div>
+
+      <Card>
+        <CardContent className="py-3">
+          {state.status === "loading" ? (
+            <div className="flex items-center gap-2 text-sm text-muted-foreground">
+              <Loader2 className="h-4 w-4 animate-spin" />
+              Checking push support…
+            </div>
+          ) : state.status === "unsupported" ? (
+            <div className="flex items-start gap-2 text-sm text-muted-foreground">
+              <BellOff className="h-4 w-4 mt-0.5 shrink-0" />
+              <span>Push notifications are not supported in this browser.</span>
+            </div>
+          ) : state.status === "insecure" ? (
+            <div className="flex items-start gap-2 text-sm text-amber-600 dark:text-amber-500">
+              <ShieldAlert className="h-4 w-4 mt-0.5 shrink-0" />
+              <span>
+                Push notifications require a secure context (HTTPS). Access this app via
+                your Tailscale HTTPS URL to enable them.
+              </span>
+            </div>
+          ) : state.status === "denied" ? (
+            <div className="flex items-start gap-2 text-sm text-amber-600 dark:text-amber-500">
+              <ShieldAlert className="h-4 w-4 mt-0.5 shrink-0" />
+              <span>
+                Notification permission was denied. To re-enable, open your browser&apos;s
+                site settings for this URL and allow notifications, then reload.
+              </span>
+            </div>
+          ) : state.status === "error" ? (
+            <div className="flex items-start gap-2 text-sm text-destructive">
+              <BellOff className="h-4 w-4 mt-0.5 shrink-0" />
+              <span>{state.message}</span>
+            </div>
+          ) : (
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-2 min-w-0">
+                <Bell className="h-4 w-4 text-muted-foreground shrink-0" />
+                <div className="space-y-0.5 min-w-0">
+                  <p className="text-sm font-medium">Enable push notifications</p>
+                  <p className="text-xs text-muted-foreground">
+                    {state.status === "subscribed"
+                      ? "This device is subscribed and will receive alerts."
+                      : "This device will not receive push alerts."}
+                  </p>
+                </div>
+              </div>
+              <ToggleSwitch
+                checked={state.status === "subscribed"}
+                onCheckedChange={state.status === "subscribed" ? disable : enable}
+                disabled={isToggling}
+                aria-label="Toggle push notifications"
+              />
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/ui/src/components/PushNotificationSection.tsx
+++ b/ui/src/components/PushNotificationSection.tsx
@@ -3,8 +3,12 @@ import { usePushNotifications } from "@/hooks/use-push-notifications";
 import { ToggleSwitch } from "@/components/ui/toggle-switch";
 import { Card, CardContent } from "@/components/ui/card";
 
-export function PushNotificationSection() {
-  const { state, isToggling, subscriptions, enable, disable } = usePushNotifications();
+type PushNotificationSectionProps = {
+  companyId: string | null;
+};
+
+export function PushNotificationSection({ companyId }: PushNotificationSectionProps) {
+  const { state, isToggling, subscriptions, enable, disable } = usePushNotifications(companyId);
   const currentEndpoint = state.status === "subscribed" ? state.endpoint : null;
 
   return (

--- a/ui/src/components/PushNotificationSection.tsx
+++ b/ui/src/components/PushNotificationSection.tsx
@@ -4,7 +4,8 @@ import { ToggleSwitch } from "@/components/ui/toggle-switch";
 import { Card, CardContent } from "@/components/ui/card";
 
 export function PushNotificationSection() {
-  const { state, isToggling, enable, disable } = usePushNotifications();
+  const { state, isToggling, subscriptions, enable, disable } = usePushNotifications();
+  const currentEndpoint = state.status === "subscribed" ? state.endpoint : null;
 
   return (
     <div className="space-y-3">
@@ -52,24 +53,65 @@ export function PushNotificationSection() {
               <span>{state.message}</span>
             </div>
           ) : (
-            <div className="flex items-center justify-between">
-              <div className="flex items-center gap-2 min-w-0">
-                <Bell className="h-4 w-4 text-muted-foreground shrink-0" />
-                <div className="space-y-0.5 min-w-0">
-                  <p className="text-sm font-medium">Enable push notifications</p>
-                  <p className="text-xs text-muted-foreground">
-                    {state.status === "subscribed"
-                      ? "This device is subscribed and will receive alerts."
-                      : "This device will not receive push alerts."}
-                  </p>
+            <div className="space-y-4">
+              <div className="flex items-center justify-between gap-3">
+                <div className="flex items-center gap-2 min-w-0">
+                  <Bell className="h-4 w-4 text-muted-foreground shrink-0" />
+                  <div className="space-y-0.5 min-w-0">
+                    <p className="text-sm font-medium">Enable push notifications</p>
+                    <p className="text-xs text-muted-foreground">
+                      {state.status === "subscribed"
+                        ? "This device is subscribed and will receive alerts."
+                        : "This device will not receive push alerts."}
+                    </p>
+                  </div>
                 </div>
+                <ToggleSwitch
+                  checked={state.status === "subscribed"}
+                  onCheckedChange={state.status === "subscribed" ? disable : enable}
+                  disabled={isToggling}
+                  aria-label="Toggle push notifications"
+                />
               </div>
-              <ToggleSwitch
-                checked={state.status === "subscribed"}
-                onCheckedChange={state.status === "subscribed" ? disable : enable}
-                disabled={isToggling}
-                aria-label="Toggle push notifications"
-              />
+              <div className="border-t pt-3">
+                <div className="flex items-center gap-2 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                  <Smartphone className="h-3.5 w-3.5" />
+                  Subscribed devices
+                </div>
+                {subscriptions.length === 0 ? (
+                  <p className="mt-2 text-xs text-muted-foreground">
+                    No devices are subscribed yet.
+                  </p>
+                ) : (
+                  <ul className="mt-2 divide-y">
+                    {subscriptions.map((subscription) => {
+                      const isCurrent = subscription.endpoint === currentEndpoint;
+                      return (
+                        <li
+                          key={subscription.id}
+                          className="flex items-start justify-between gap-3 py-2 first:pt-0 last:pb-0"
+                        >
+                          <div className="min-w-0">
+                            <div className="flex items-center gap-2">
+                              <p className="truncate text-sm font-medium">
+                                {subscription.deviceLabel || "Unnamed device"}
+                              </p>
+                              {isCurrent ? (
+                                <span className="rounded-sm border px-1.5 py-0.5 text-[11px] leading-none text-muted-foreground">
+                                  This device
+                                </span>
+                              ) : null}
+                            </div>
+                            <p className="mt-0.5 truncate text-xs text-muted-foreground">
+                              Added {new Date(subscription.createdAt).toLocaleDateString()}
+                            </p>
+                          </div>
+                        </li>
+                      );
+                    })}
+                  </ul>
+                )}
+              </div>
             </div>
           )}
         </CardContent>

--- a/ui/src/hooks/use-push-notifications.test.tsx
+++ b/ui/src/hooks/use-push-notifications.test.tsx
@@ -1,0 +1,170 @@
+// @vitest-environment jsdom
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { pushApi } from "@/api/push";
+import { usePushNotifications, type PushState } from "./use-push-notifications";
+
+vi.mock("@/api/push", () => ({
+  pushApi: {
+    getVapidPublicKey: vi.fn(),
+    subscribe: vi.fn(),
+    unsubscribe: vi.fn(),
+    listSubscriptions: vi.fn(),
+  },
+}));
+
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+type HookSnapshot = ReturnType<typeof usePushNotifications>;
+
+let root: Root | null = null;
+let container: HTMLDivElement | null = null;
+let latest: HookSnapshot | null = null;
+
+function setBrowserPushMocks(registration: unknown, permission = "default") {
+  Object.defineProperty(window, "isSecureContext", { value: true, configurable: true });
+  Object.defineProperty(window, "PushManager", { value: function PushManager() {}, configurable: true });
+  vi.stubGlobal("Notification", {
+    permission,
+    requestPermission: vi.fn(),
+  });
+  Object.defineProperty(navigator, "serviceWorker", {
+    value: { ready: Promise.resolve(registration) },
+    configurable: true,
+  });
+}
+
+function Harness() {
+  latest = usePushNotifications();
+  return null;
+}
+
+async function renderHook() {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  await act(async () => {
+    root?.render(<Harness />);
+  });
+}
+
+async function waitForState(status: PushState["status"]) {
+  for (let i = 0; i < 20; i++) {
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+    if (latest?.state.status === status) return;
+  }
+  throw new Error(`Timed out waiting for push state ${status}; saw ${latest?.state.status}`);
+}
+
+beforeEach(() => {
+  vi.mocked(pushApi.getVapidPublicKey).mockResolvedValue({ vapidPublicKey: "AQID" });
+  vi.mocked(pushApi.subscribe).mockResolvedValue({ status: "subscribed" });
+  vi.mocked(pushApi.unsubscribe).mockResolvedValue({ status: "unsubscribed" });
+  vi.mocked(pushApi.listSubscriptions).mockResolvedValue({ subscriptions: [] });
+});
+
+afterEach(() => {
+  if (root) {
+    act(() => root?.unmount());
+  }
+  container?.remove();
+  root = null;
+  container = null;
+  latest = null;
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("usePushNotifications", () => {
+  it("cleans up a browser subscription that is missing from the server list", async () => {
+    const unsubscribe = vi.fn().mockResolvedValue(true);
+    setBrowserPushMocks({
+      pushManager: {
+        getSubscription: vi.fn().mockResolvedValue({
+          endpoint: "https://push.example/local-only",
+          unsubscribe,
+        }),
+      },
+    });
+
+    await renderHook();
+    await waitForState("unsubscribed");
+
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
+    expect(latest?.subscriptions).toEqual([]);
+  });
+
+  it("rolls back the browser subscription when server sync fails during enable", async () => {
+    const unsubscribe = vi.fn().mockResolvedValue(true);
+    const subscription = {
+      endpoint: "https://push.example/new-device",
+      toJSON: () => ({ keys: { p256dh: "p256dh", auth: "auth" } }),
+      unsubscribe,
+    };
+    setBrowserPushMocks({
+      pushManager: {
+        getSubscription: vi.fn().mockResolvedValue(null),
+        subscribe: vi.fn().mockResolvedValue(subscription),
+      },
+    });
+    vi.mocked(Notification.requestPermission).mockResolvedValue("granted");
+    vi.mocked(pushApi.subscribe).mockRejectedValue(new Error("server unavailable"));
+
+    await renderHook();
+    await waitForState("unsubscribed");
+
+    await act(async () => {
+      await latest?.enable();
+    });
+
+    expect(pushApi.subscribe).toHaveBeenCalledWith({
+      endpoint: "https://push.example/new-device",
+      p256dh: "p256dh",
+      auth: "auth",
+      deviceLabel: expect.any(String),
+    });
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
+    expect(latest?.state).toMatchObject({ status: "error", message: "server unavailable" });
+  });
+
+  it("unsubscribes locally before deleting the server subscription", async () => {
+    const calls: string[] = [];
+    const subscription = {
+      endpoint: "https://push.example/current-device",
+      unsubscribe: vi.fn().mockImplementation(async () => {
+        calls.push("local");
+        return true;
+      }),
+    };
+    setBrowserPushMocks({
+      pushManager: {
+        getSubscription: vi.fn().mockResolvedValue(subscription),
+      },
+    });
+    vi.mocked(pushApi.listSubscriptions).mockResolvedValue({
+      subscriptions: [{
+        id: "sub-1",
+        endpoint: "https://push.example/current-device",
+        deviceLabel: "Chrome on Linux",
+        createdAt: "2026-07-04T00:00:00.000Z",
+      }],
+    });
+    vi.mocked(pushApi.unsubscribe).mockImplementation(async () => {
+      calls.push("server");
+      return { status: "unsubscribed" };
+    });
+
+    await renderHook();
+    await waitForState("subscribed");
+
+    await act(async () => {
+      await latest?.disable();
+    });
+
+    expect(calls).toEqual(["local", "server"]);
+    expect(latest?.state.status).toBe("unsubscribed");
+  });
+});

--- a/ui/src/hooks/use-push-notifications.test.tsx
+++ b/ui/src/hooks/use-push-notifications.test.tsx
@@ -36,7 +36,7 @@ function setBrowserPushMocks(registration: unknown, permission = "default") {
 }
 
 function Harness() {
-  latest = usePushNotifications();
+  latest = usePushNotifications("company-1");
   return null;
 }
 
@@ -60,6 +60,7 @@ async function waitForState(status: PushState["status"]) {
 }
 
 beforeEach(() => {
+  vi.clearAllMocks();
   vi.mocked(pushApi.getVapidPublicKey).mockResolvedValue({ vapidPublicKey: "AQID" });
   vi.mocked(pushApi.subscribe).mockResolvedValue({ status: "subscribed" });
   vi.mocked(pushApi.unsubscribe).mockResolvedValue({ status: "unsubscribed" });
@@ -120,7 +121,7 @@ describe("usePushNotifications", () => {
       await latest?.enable();
     });
 
-    expect(pushApi.subscribe).toHaveBeenCalledWith({
+    expect(pushApi.subscribe).toHaveBeenCalledWith("company-1", {
       endpoint: "https://push.example/new-device",
       p256dh: "p256dh",
       auth: "auth",
@@ -128,6 +129,36 @@ describe("usePushNotifications", () => {
     });
     expect(unsubscribe).toHaveBeenCalledTimes(1);
     expect(latest?.state).toMatchObject({ status: "error", message: "server unavailable" });
+  });
+
+  it("does not persist a browser subscription with missing push keys", async () => {
+    const unsubscribe = vi.fn().mockResolvedValue(true);
+    const subscription = {
+      endpoint: "https://push.example/no-keys",
+      toJSON: () => ({ keys: {} }),
+      unsubscribe,
+    };
+    setBrowserPushMocks({
+      pushManager: {
+        getSubscription: vi.fn().mockResolvedValue(null),
+        subscribe: vi.fn().mockResolvedValue(subscription),
+      },
+    });
+    vi.mocked(Notification.requestPermission).mockResolvedValue("granted");
+
+    await renderHook();
+    await waitForState("unsubscribed");
+
+    await act(async () => {
+      await latest?.enable();
+    });
+
+    expect(pushApi.subscribe).not.toHaveBeenCalled();
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
+    expect(latest?.state).toMatchObject({
+      status: "error",
+      message: "Browser did not provide valid push credentials",
+    });
   });
 
   it("unsubscribes locally before deleting the server subscription", async () => {
@@ -165,6 +196,7 @@ describe("usePushNotifications", () => {
     });
 
     expect(calls).toEqual(["local", "server"]);
+    expect(pushApi.unsubscribe).toHaveBeenCalledWith("company-1", "https://push.example/current-device");
     expect(latest?.state.status).toBe("unsubscribed");
   });
 });

--- a/ui/src/hooks/use-push-notifications.ts
+++ b/ui/src/hooks/use-push-notifications.ts
@@ -1,0 +1,118 @@
+import { useState, useEffect, useCallback } from "react";
+import { pushApi } from "@/api/push";
+
+function urlBase64ToUint8Array(base64String: string): ArrayBuffer {
+  const padding = "=".repeat((4 - (base64String.length % 4)) % 4);
+  const base64 = (base64String + padding).replace(/-/g, "+").replace(/_/g, "/");
+  const raw = atob(base64);
+  const bytes = new Uint8Array(raw.length);
+  for (let i = 0; i < raw.length; i++) bytes[i] = raw.charCodeAt(i);
+  return bytes.buffer;
+}
+
+export type PushState =
+  | { status: "unsupported" }
+  | { status: "insecure" }
+  | { status: "loading" }
+  | { status: "denied" }
+  | { status: "subscribed"; endpoint: string }
+  | { status: "unsubscribed" }
+  | { status: "error"; message: string };
+
+export function usePushNotifications() {
+  const [state, setState] = useState<PushState>({ status: "loading" });
+  const [isToggling, setIsToggling] = useState(false);
+
+  useEffect(() => {
+    if (!("serviceWorker" in navigator) || !("PushManager" in window)) {
+      setState({ status: "unsupported" });
+      return;
+    }
+    if (!window.isSecureContext) {
+      setState({ status: "insecure" });
+      return;
+    }
+
+    navigator.serviceWorker.ready
+      .then(async (reg) => {
+        const existing = await reg.pushManager.getSubscription();
+        if (existing) {
+          setState({ status: "subscribed", endpoint: existing.endpoint });
+        } else if (Notification.permission === "denied") {
+          setState({ status: "denied" });
+        } else {
+          setState({ status: "unsubscribed" });
+        }
+      })
+      .catch((err) => {
+        setState({
+          status: "error",
+          message: err instanceof Error ? err.message : "Failed to read push state",
+        });
+      });
+  }, []);
+
+  const enable = useCallback(async () => {
+    if (isToggling) return;
+    setIsToggling(true);
+    try {
+      const permission = await Notification.requestPermission();
+      if (permission === "denied") {
+        setState({ status: "denied" });
+        return;
+      }
+      if (permission !== "granted") {
+        setState({ status: "unsubscribed" });
+        return;
+      }
+
+      const { vapidPublicKey } = await pushApi.getVapidPublicKey();
+      const reg = await navigator.serviceWorker.ready;
+      const sub = await reg.pushManager.subscribe({
+        userVisibleOnly: true,
+        applicationServerKey: urlBase64ToUint8Array(vapidPublicKey),
+      });
+
+      const json = sub.toJSON();
+      const keys = json.keys ?? {};
+      await pushApi.subscribe({
+        endpoint: sub.endpoint,
+        p256dh: keys.p256dh ?? "",
+        auth: keys.auth ?? "",
+        deviceLabel: navigator.userAgent.slice(0, 120),
+      });
+
+      setState({ status: "subscribed", endpoint: sub.endpoint });
+    } catch (err) {
+      setState({
+        status: "error",
+        message: err instanceof Error ? err.message : "Failed to enable push notifications",
+      });
+    } finally {
+      setIsToggling(false);
+    }
+  }, [isToggling]);
+
+  const disable = useCallback(async () => {
+    if (isToggling) return;
+    setIsToggling(true);
+    try {
+      const reg = await navigator.serviceWorker.ready;
+      const sub = await reg.pushManager.getSubscription();
+      if (sub) {
+        await pushApi.unsubscribe(sub.endpoint);
+        await sub.unsubscribe();
+      }
+      setState({ status: "unsubscribed" });
+    } catch (err) {
+      setState({
+        status: "error",
+        message: err instanceof Error ? err.message : "Failed to disable push notifications",
+      });
+    } finally {
+      setIsToggling(false);
+    }
+  }, [isToggling]);
+
+  return { state, isToggling, enable, disable };
+}

--- a/ui/src/hooks/use-push-notifications.ts
+++ b/ui/src/hooks/use-push-notifications.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from "react";
-import { pushApi } from "@/api/push";
+import { pushApi, type PushSubscriptionRecord } from "@/api/push";
 
 function urlBase64ToUint8Array(base64String: string): ArrayBuffer {
   const padding = "=".repeat((4 - (base64String.length % 4)) % 4);
@@ -22,35 +22,62 @@ export type PushState =
 export function usePushNotifications() {
   const [state, setState] = useState<PushState>({ status: "loading" });
   const [isToggling, setIsToggling] = useState(false);
+  const [subscriptions, setSubscriptions] = useState<PushSubscriptionRecord[]>([]);
+
+  const refreshSubscriptions = useCallback(async () => {
+    const result = await pushApi.listSubscriptions();
+    setSubscriptions(result.subscriptions);
+    return result.subscriptions;
+  }, []);
 
   useEffect(() => {
-    if (!("serviceWorker" in navigator) || !("PushManager" in window)) {
-      setState({ status: "unsupported" });
-      return;
-    }
-    if (!window.isSecureContext) {
-      setState({ status: "insecure" });
-      return;
-    }
+    let cancelled = false;
 
-    navigator.serviceWorker.ready
-      .then(async (reg) => {
+    async function load() {
+      try {
+        const serverSubscriptions = await refreshSubscriptions();
+
+        if (!("serviceWorker" in navigator) || !("PushManager" in window)) {
+          if (!cancelled) setState({ status: "unsupported" });
+          return;
+        }
+        if (!window.isSecureContext) {
+          if (!cancelled) setState({ status: "insecure" });
+          return;
+        }
+
+        const reg = await navigator.serviceWorker.ready;
         const existing = await reg.pushManager.getSubscription();
+        if (cancelled) return;
         if (existing) {
-          setState({ status: "subscribed", endpoint: existing.endpoint });
+          const existsOnServer = serverSubscriptions.some((sub) => sub.endpoint === existing.endpoint);
+          if (existsOnServer) {
+            setState({ status: "subscribed", endpoint: existing.endpoint });
+          } else {
+            await existing.unsubscribe();
+            if (!cancelled) setState({ status: "unsubscribed" });
+          }
         } else if (Notification.permission === "denied") {
           setState({ status: "denied" });
         } else {
           setState({ status: "unsubscribed" });
         }
-      })
-      .catch((err) => {
-        setState({
-          status: "error",
-          message: err instanceof Error ? err.message : "Failed to read push state",
-        });
-      });
-  }, []);
+      } catch (err) {
+        if (!cancelled) {
+          setState({
+            status: "error",
+            message: err instanceof Error ? err.message : "Failed to read push state",
+          });
+        }
+      }
+    }
+
+    void load();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [refreshSubscriptions]);
 
   const enable = useCallback(async () => {
     if (isToggling) return;
@@ -75,14 +102,20 @@ export function usePushNotifications() {
 
       const json = sub.toJSON();
       const keys = json.keys ?? {};
-      await pushApi.subscribe({
-        endpoint: sub.endpoint,
-        p256dh: keys.p256dh ?? "",
-        auth: keys.auth ?? "",
-        deviceLabel: navigator.userAgent.slice(0, 120),
-      });
+      try {
+        await pushApi.subscribe({
+          endpoint: sub.endpoint,
+          p256dh: keys.p256dh ?? "",
+          auth: keys.auth ?? "",
+          deviceLabel: navigator.userAgent.slice(0, 120),
+        });
+      } catch (err) {
+        await sub.unsubscribe().catch(() => undefined);
+        throw err;
+      }
 
       setState({ status: "subscribed", endpoint: sub.endpoint });
+      await refreshSubscriptions();
     } catch (err) {
       setState({
         status: "error",
@@ -99,11 +132,18 @@ export function usePushNotifications() {
     try {
       const reg = await navigator.serviceWorker.ready;
       const sub = await reg.pushManager.getSubscription();
+      const endpoint = sub?.endpoint ?? (state.status === "subscribed" ? state.endpoint : undefined);
       if (sub) {
-        await pushApi.unsubscribe(sub.endpoint);
-        await sub.unsubscribe();
+        const unsubscribed = await sub.unsubscribe();
+        if (!unsubscribed) {
+          throw new Error("Browser failed to unsubscribe this device");
+        }
+      }
+      if (endpoint) {
+        await pushApi.unsubscribe(endpoint);
       }
       setState({ status: "unsubscribed" });
+      await refreshSubscriptions();
     } catch (err) {
       setState({
         status: "error",
@@ -112,7 +152,7 @@ export function usePushNotifications() {
     } finally {
       setIsToggling(false);
     }
-  }, [isToggling]);
+  }, [isToggling, refreshSubscriptions, state]);
 
-  return { state, isToggling, enable, disable };
+  return { state, isToggling, subscriptions, refreshSubscriptions, enable, disable };
 }

--- a/ui/src/hooks/use-push-notifications.ts
+++ b/ui/src/hooks/use-push-notifications.ts
@@ -19,22 +19,30 @@ export type PushState =
   | { status: "unsubscribed" }
   | { status: "error"; message: string };
 
-export function usePushNotifications() {
+export function usePushNotifications(companyId: string | null | undefined) {
   const [state, setState] = useState<PushState>({ status: "loading" });
   const [isToggling, setIsToggling] = useState(false);
   const [subscriptions, setSubscriptions] = useState<PushSubscriptionRecord[]>([]);
 
   const refreshSubscriptions = useCallback(async () => {
-    const result = await pushApi.listSubscriptions();
+    if (!companyId) {
+      setSubscriptions([]);
+      return [];
+    }
+    const result = await pushApi.listSubscriptions(companyId);
     setSubscriptions(result.subscriptions);
     return result.subscriptions;
-  }, []);
+  }, [companyId]);
 
   useEffect(() => {
     let cancelled = false;
 
     async function load() {
       try {
+        if (!companyId) {
+          if (!cancelled) setState({ status: "error", message: "Select a company before enabling push notifications" });
+          return;
+        }
         const serverSubscriptions = await refreshSubscriptions();
 
         if (!("serviceWorker" in navigator) || !("PushManager" in window)) {
@@ -77,12 +85,15 @@ export function usePushNotifications() {
     return () => {
       cancelled = true;
     };
-  }, [refreshSubscriptions]);
+  }, [companyId, refreshSubscriptions]);
 
   const enable = useCallback(async () => {
     if (isToggling) return;
     setIsToggling(true);
     try {
+      if (!companyId) {
+        throw new Error("Select a company before enabling push notifications");
+      }
       const permission = await Notification.requestPermission();
       if (permission === "denied") {
         setState({ status: "denied" });
@@ -102,11 +113,15 @@ export function usePushNotifications() {
 
       const json = sub.toJSON();
       const keys = json.keys ?? {};
+      if (!keys.p256dh || !keys.auth) {
+        await sub.unsubscribe().catch(() => undefined);
+        throw new Error("Browser did not provide valid push credentials");
+      }
       try {
-        await pushApi.subscribe({
+        await pushApi.subscribe(companyId, {
           endpoint: sub.endpoint,
-          p256dh: keys.p256dh ?? "",
-          auth: keys.auth ?? "",
+          p256dh: keys.p256dh,
+          auth: keys.auth,
           deviceLabel: navigator.userAgent.slice(0, 120),
         });
       } catch (err) {
@@ -124,12 +139,15 @@ export function usePushNotifications() {
     } finally {
       setIsToggling(false);
     }
-  }, [isToggling]);
+  }, [companyId, isToggling, refreshSubscriptions]);
 
   const disable = useCallback(async () => {
     if (isToggling) return;
     setIsToggling(true);
     try {
+      if (!companyId) {
+        throw new Error("Select a company before disabling push notifications");
+      }
       const reg = await navigator.serviceWorker.ready;
       const sub = await reg.pushManager.getSubscription();
       const endpoint = sub?.endpoint ?? (state.status === "subscribed" ? state.endpoint : undefined);
@@ -140,7 +158,7 @@ export function usePushNotifications() {
         }
       }
       if (endpoint) {
-        await pushApi.unsubscribe(endpoint);
+        await pushApi.unsubscribe(companyId, endpoint);
       }
       setState({ status: "unsubscribed" });
       await refreshSubscriptions();
@@ -152,7 +170,7 @@ export function usePushNotifications() {
     } finally {
       setIsToggling(false);
     }
-  }, [isToggling, refreshSubscriptions, state]);
+  }, [companyId, isToggling, refreshSubscriptions, state]);
 
   return { state, isToggling, subscriptions, refreshSubscriptions, enable, disable };
 }

--- a/ui/src/lib/utils.ts
+++ b/ui/src/lib/utils.ts
@@ -55,6 +55,7 @@ export function formatDate(date: Date | string): string {
     month: "short",
     day: "numeric",
     year: "numeric",
+    timeZone: "UTC",
   });
 }
 

--- a/ui/src/pages/ProfileSettings.tsx
+++ b/ui/src/pages/ProfileSettings.tsx
@@ -277,7 +277,7 @@ export function ProfileSettings() {
         </Card>
       </section>
 
-      <PushNotificationSection />
+      <PushNotificationSection companyId={selectedCompanyId} />
     </div>
   );
 }

--- a/ui/src/pages/ProfileSettings.tsx
+++ b/ui/src/pages/ProfileSettings.tsx
@@ -13,6 +13,7 @@ import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { PushNotificationSection } from "@/components/PushNotificationSection";
 
 function deriveInitials(name: string) {
   const parts = name.trim().split(/\s+/).filter(Boolean);
@@ -275,6 +276,8 @@ export function ProfileSettings() {
           <InboxAgentPolicyControl companyId={selectedCompanyId} />
         </Card>
       </section>
+
+      <PushNotificationSection />
     </div>
   );
 }


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Board users need timely attention signals when agent work needs human input or issue state changes require intervention
> - The existing board UI has in-app activity and live updates, but no device-level Web Push path for permission prompts, subscriptions, or push fanout
> - Prior Web Push work was split across related PRs, which made review and security scanning harder to reason about
> - This pull request consolidates the subscription UI, Web Push storage/service, fanout hooks, and readiness test route into one reviewable branch
> - The benefit is that reviewers can evaluate and scan the complete Web Push feature as a single diff

## Linked Issues or Issue Description

No public GitHub issue was found for this exact consolidated Web Push delivery.

Related prior PRs:
- Replaces and supersedes #7647
- Replaces and supersedes #7648
- Builds on the same Web Push feature area as #7631

Feature context:
- Problem/motivation: board operators need device-level notifications when Paperclip needs human attention, especially for assignment, interaction, blocked, or stale issue events.
- Proposed solution: add Web Push subscription storage, VAPID-backed push sending, a profile-settings subscription UI, service worker notification handling, and server-side fanout from selected issue/live events.
- Alternatives considered: relying only on in-app live updates keeps notifications invisible when the app is backgrounded; keeping separate PRs increased review and scan fragmentation.
- Roadmap alignment: searched `ROADMAP.md` for push/notification/Web Push overlap and found no explicit duplicate roadmap entry.

## What Changed

- Added `web_push_subscriptions` schema/migration and exported the table.
- Added board-authenticated push subscription/test/digest-readiness API routes.
- Added VAPID/web-push service helpers plus tests.
- Added push fanout for board-attention issue events with immediate and digest lanes plus tests.
- Added a service worker and profile-settings Web Push toggle/device list UI plus hook/component tests.
- Routed selected issue and recovery events into live-event push fanout.

## Verification

- `git diff --check upstream/master...HEAD` passed.
- `pnpm exec vitest run server/src/services/push-fanout.test.ts server/src/services/web-push.test.ts ui/src/components/PushNotificationSection.test.tsx ui/src/hooks/use-push-notifications.test.tsx` passed: 4 files, 17 tests.
- `pnpm --filter @paperclipai/server typecheck` passed.
- `pnpm --filter @paperclipai/ui typecheck` passed.
- Security scans are expected to rerun on this new consolidated PR.

## Risks

- Adds a new server dependency (`web-push`) and dev type package; PR CI will regenerate lockfile for verification because this repo does not commit lockfile changes in contributor PRs.
- Web Push behavior depends on VAPID env configuration and secure browser context.
- Fanout is in-process and best-effort; missed process-local events are not persisted notification jobs.
- Digest/quiet-hour timing depends on server local time and environment variables.

## Model Used

OpenAI Codex GPT-5.5 via Paperclip local Codex agent, with shell/GitHub CLI tool use and local code execution for verification. The branch content was inherited from prior automated Web Push work and this PR was opened and verified by Codex.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge