### PR TITLE
test(cli): cover connect profile edges

### DIFF
--- a/cli/src/__tests__/connect.test.ts
+++ b/cli/src/__tests__/connect.test.ts
@@ -133,6 +133,59 @@ describe("connect command", () => {
     });
   });
 
+  it("stores a custom api key env var name in board profiles and exports", async () => {
+    const contextPath = createTempContextPath();
+    vi.mocked(prompts.text).mockResolvedValue(API_BASE);
+    vi.mocked(prompts.select).mockResolvedValue(COMPANY_ID);
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = new URL(String(input));
+      if (url.pathname === "/api/health") return jsonResponse({ status: "ok" });
+      if (url.pathname === "/api/companies") {
+        return jsonResponse([{ id: COMPANY_ID, name: "Connect Co" }]);
+      }
+      if (url.pathname === "/api/board-api-keys" && init?.method === "POST") {
+        return jsonResponse({
+          id: "board-key-1",
+          name: "connect-board-token",
+          token: "pcp_board_created",
+          createdAt: "2026-05-24T12:00:00.000Z",
+          expiresAt: null,
+        });
+      }
+      return jsonResponse({ error: `Unexpected ${init?.method ?? "GET"} ${url.pathname}` }, { status: 500 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    await createProgram().parseAsync([
+      "connect",
+      "--persona",
+      "board",
+      "--profile",
+      "cli-board",
+      "--token-name",
+      "connect-board-token",
+      "--api-key-env-var-name",
+      "PAPERCLIP_BOARD_TOKEN",
+      "--context",
+      contextPath,
+      "--api-base",
+      API_BASE,
+      "--json",
+    ], { from: "user" });
+
+    const output = JSON.parse(String(log.mock.calls.at(-1)?.[0]));
+    expect(output.exports).toContain("export PAPERCLIP_BOARD_TOKEN='pcp_board_created'");
+    expect(output.exports).not.toContain("export PAPERCLIP_API_KEY=");
+    expect(readContext(contextPath)).toMatchObject({
+      profiles: {
+        "cli-board": {
+          apiKeyEnvVarName: "PAPERCLIP_BOARD_TOKEN",
+        },
+      },
+    });
+  });
+
   it("drives the interactive agent profile flow through prompts and context writes", async () => {
     const contextPath = createTempContextPath();
     vi.mocked(prompts.text).mockResolvedValue(API_BASE);
@@ -193,5 +246,26 @@ describe("connect command", () => {
         },
       },
     });
+  });
+
+  it("fails clearly when connect runs outside an interactive terminal", async () => {
+    Object.defineProperty(process.stdin, "isTTY", { value: false, configurable: true });
+    Object.defineProperty(process.stdout, "isTTY", { value: false, configurable: true });
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    const exit = vi.spyOn(process, "exit").mockImplementation((() => {
+      throw new Error("process.exit called");
+    }) as never);
+
+    await expect(createProgram().parseAsync([
+      "connect",
+      "--persona",
+      "board",
+      "--api-base",
+      API_BASE,
+    ], { from: "user" })).rejects.toThrow("process.exit called");
+
+    expect(error.mock.calls[0]?.[0]).toContain("`paperclipai connect` is interactive");
+    expect(error.mock.calls[0]?.[0]).toContain("For scripts, pass --api-base/--api-key");
+    expect(exit).toHaveBeenCalledWith(1);
   });
 });


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The CLI is one external control-plane entry point for human operators and scripts.
> - `paperclipai connect` is the onboarding bridge that turns board login into saved board or agent personas.
> - The existing connect tests covered the happy-path board and agent profile flows.
> - Two important edges still deserved direct coverage: custom credential env var names and non-interactive terminal usage.
> - This pull request adds focused tests for those edges without changing runtime behavior.
> - The benefit is safer CLI onboarding/profile work as CLI parity continues.

## Linked Issues or Issue Description

No public issue found. This is a test coverage follow-up for the CLI connect/profile behavior described in `doc/plans/2026-05-23-cli-api-parity.md`.

## What Changed

- Added coverage that `--api-key-env-var-name` is saved into the board profile.
- Added coverage that generated shell exports use the custom token env var instead of defaulting to `PAPERCLIP_API_KEY`.
- Added coverage that `paperclipai connect` fails clearly outside an interactive terminal and points scripts toward explicit `--api-base/--api-key` usage.

## Verification

- `./node_modules/.bin/vitest run cli/src/__tests__/connect.test.ts --config cli/vitest.config.ts` passes: 1 file, 4 tests.

## Risks

Low risk. This is test-only coverage for existing CLI behavior.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

OpenAI GPT-5 Codex in Codex desktop, with repository inspection, shell command execution, GitHub CLI usage, and code editing tools.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g., `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge