### PR TITLE
fix: require real question answers for interactions

### DIFF
--- a/packages/shared/src/validators/issue.test.ts
+++ b/packages/shared/src/validators/issue.test.ts
@@ -211,7 +211,7 @@ describe("issue validators", () => {
 
   it("normalizes escaped line breaks in thread summaries and documents", () => {
     const response = respondIssueThreadInteractionSchema.parse({
-      answers: [],
+      answers: [{ questionId: "scope", optionIds: ["phase-1"] }],
       summaryMarkdown: "Summary\\n\\nNext action",
     });
     const document = upsertIssueDocumentSchema.parse({
@@ -221,6 +221,13 @@ describe("issue validators", () => {
 
     expect(response.summaryMarkdown).toBe("Summary\n\nNext action");
     expect(document.body).toBe("# Plan\n\nShip it");
+  });
+
+  it("rejects empty thread interaction answer responses", () => {
+    expect(() => respondIssueThreadInteractionSchema.parse({
+      answers: [],
+      summaryMarkdown: "Summary",
+    })).toThrow("At least one question answer is required");
   });
 
   it("clamps oversized requestDepth values on create", () => {

--- a/packages/shared/src/validators/issue.ts
+++ b/packages/shared/src/validators/issue.ts
@@ -970,7 +970,9 @@ export const cancelIssueThreadInteractionSchema = z.object({
 export type CancelIssueThreadInteraction = z.infer<typeof cancelIssueThreadInteractionSchema>;
 
 export const respondIssueThreadInteractionSchema = z.object({
-  answers: z.array(askUserQuestionsAnswerSchema).max(20),
+  answers: z.array(askUserQuestionsAnswerSchema)
+    .min(1, "At least one question answer is required")
+    .max(20),
   summaryMarkdown: multilineTextSchema.pipe(z.string().max(20000)).nullable().optional(),
 });
 export type RespondIssueThreadInteraction = z.infer<typeof respondIssueThreadInteractionSchema>;

--- a/server/src/__tests__/issue-thread-interaction-routes.test.ts
+++ b/server/src/__tests__/issue-thread-interaction-routes.test.ts
@@ -996,4 +996,18 @@ describe.sequential("issue thread interaction routes", () => {
       },
     );
   });
+
+  it("rejects question responses with no answers before service resolution", async () => {
+    const app = await createApp();
+
+    const res = await request(app)
+      .post("/api/issues/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa/interactions/interaction-2/respond")
+      .send({
+        answers: [],
+        summaryMarkdown: "Board approved all issue gates in current sweep; selected the positive/recommended approval path where available.",
+      });
+
+    expect(res.status).toBe(400);
+    expect(mockInteractionService.answerQuestions).not.toHaveBeenCalled();
+  });
 });

--- a/server/src/__tests__/issue-thread-interactions-service.test.ts
+++ b/server/src/__tests__/issue-thread-interactions-service.test.ts
@@ -496,6 +496,114 @@ describeEmbeddedPostgres("issueThreadInteractionService", () => {
     })).rejects.toThrow("Interaction has already been resolved");
   });
 
+  it("rejects ask_user_questions responses with no answers", async () => {
+    const { companyId, issueId } = await seedConfirmationIssue("Reject empty answers");
+
+    const created = await interactionsSvc.create({
+      id: issueId,
+      companyId,
+    }, {
+      kind: "ask_user_questions",
+      continuationPolicy: "wake_assignee",
+      payload: {
+        version: 1,
+        questions: [{
+          id: "scope",
+          prompt: "Choose the scope",
+          selectionMode: "single",
+          options: [{ id: "phase-1", label: "Phase 1" }],
+        }],
+      },
+    }, {
+      userId: "local-board",
+    });
+
+    await expect(interactionsSvc.answerQuestions({
+      id: issueId,
+      companyId,
+    }, created.id, {
+      answers: [],
+    }, {
+      userId: "local-board",
+    })).rejects.toThrow("At least one question answer is required");
+  });
+
+  it("rejects boilerplate sweep summaries without real per-question answers", async () => {
+    const { companyId, issueId } = await seedConfirmationIssue("Reject boilerplate empty answer");
+    const boilerplateSummary =
+      "Board approved all issue gates in current sweep; selected the positive/recommended approval path where available.";
+
+    const created = await interactionsSvc.create({
+      id: issueId,
+      companyId,
+    }, {
+      kind: "ask_user_questions",
+      continuationPolicy: "wake_assignee",
+      payload: {
+        version: 1,
+        questions: [{
+          id: "scope",
+          prompt: "Choose the scope",
+          selectionMode: "single",
+          options: [{ id: "phase-1", label: "Phase 1" }],
+        }],
+      },
+    }, {
+      userId: "local-board",
+    });
+
+    await expect(interactionsSvc.answerQuestions({
+      id: issueId,
+      companyId,
+    }, created.id, {
+      answers: [{ questionId: "scope", optionIds: [] }],
+      summaryMarkdown: boilerplateSummary,
+    }, {
+      userId: "local-board",
+    })).rejects.toThrow("At least one question answer is required");
+  });
+
+  it("accepts boilerplate sweep summaries when a real per-question answer is present", async () => {
+    const { companyId, issueId } = await seedConfirmationIssue("Allow boilerplate with answer");
+    const boilerplateSummary =
+      "Board approved all issue gates in current sweep; selected the positive/recommended approval path where available.";
+
+    const created = await interactionsSvc.create({
+      id: issueId,
+      companyId,
+    }, {
+      kind: "ask_user_questions",
+      continuationPolicy: "wake_assignee",
+      payload: {
+        version: 1,
+        questions: [{
+          id: "scope",
+          prompt: "Choose the scope",
+          selectionMode: "single",
+          options: [{ id: "phase-1", label: "Phase 1" }],
+        }],
+      },
+    }, {
+      userId: "local-board",
+    });
+
+    const answered = await interactionsSvc.answerQuestions({
+      id: issueId,
+      companyId,
+    }, created.id, {
+      answers: [{ questionId: "scope", optionIds: ["phase-1"] }],
+      summaryMarkdown: boilerplateSummary,
+    }, {
+      userId: "local-board",
+    });
+
+    expect(answered.status).toBe("answered");
+    expect(answered.result).toMatchObject({
+      answers: [{ questionId: "scope", optionIds: ["phase-1"] }],
+      summaryMarkdown: boilerplateSummary,
+    });
+  });
+
   it("persists cancelled ask_user_questions interactions without answer data", async () => {
     const companyId = randomUUID();
     const goalId = randomUUID();

--- a/server/src/services/issue-thread-interactions.ts
+++ b/server/src/services/issue-thread-interactions.ts
@@ -37,6 +37,7 @@ import {
   requestCheckboxConfirmationResultSchema,
   requestConfirmationPayloadSchema,
   requestConfirmationResultSchema,
+  respondIssueThreadInteractionSchema,
   suggestTasksPayloadSchema,
   suggestTasksResultSchema,
 } from "@paperclipai/shared";
@@ -536,6 +537,13 @@ function normalizeQuestionAnswers(args: {
     }
 
     const otherText = answer.otherText?.trim() ?? "";
+    if (uniqueOptionIds.length === 0 && !otherText) {
+      if (question.required) {
+        throw unprocessable(`Question ${answer.questionId} requires an answer`);
+      }
+      continue;
+    }
+
     answerByQuestionId.set(answer.questionId, {
       questionId: answer.questionId,
       optionIds: uniqueOptionIds,
@@ -1160,6 +1168,10 @@ export function issueThreadInteractionService(db: Db) {
           .update(issueThreadInteractions)
           .set({
             status: "accepted",
+            result: {
+              version: 1,
+              createdTasks: [],
+            },
             resolvedByAgentId: actor.agentId ?? null,
             resolvedByUserId: actor.userId ?? null,
             resolvedAt,
@@ -1597,11 +1609,15 @@ export function issueThreadInteractionService(db: Db) {
         throw conflict("Interaction has already been resolved");
       }
 
+      const data = respondIssueThreadInteractionSchema.parse(input);
       const interaction = hydrateInteraction(current) as AskUserQuestionsInteraction;
       const normalizedAnswers = normalizeQuestionAnswers({
         questions: interaction.payload.questions,
-        answers: input.answers,
+        answers: data.answers,
       });
+      if (normalizedAnswers.length === 0) {
+        throw unprocessable("At least one question answer is required");
+      }
 
       const [updated] = await db
         .update(issueThreadInteractions)
@@ -1610,7 +1626,7 @@ export function issueThreadInteractionService(db: Db) {
           result: {
             version: 1,
             answers: normalizedAnswers,
-            summaryMarkdown: input.summaryMarkdown ?? null,
+            summaryMarkdown: data.summaryMarkdown ?? null,
           },
           resolvedByAgentId: actor.agentId ?? null,
           resolvedByUserId: actor.userId ?? null,


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Issue-thread interactions are the board-facing control surface for approvals, task suggestions, and structured questions.
> - Structured question responses are only useful if they contain at least one real per-question answer.
> - The previous response contract allowed `answers: []`, and the service could persist `answered` results with no selected option or other-text answer.
> - That made bulk or boilerplate resolution paths able to close pending board questions without capturing an actual decision.
> - This pull request tightens the route validator and service normalization so blank responses cannot resolve question interactions.
> - The benefit is that pending board decisions stay pending until the operator submits real answer data or explicitly cancels the interaction.

## Linked Issues or Issue Description

No public issue exists for this private-instance bug report.

Bug description:
- What happened: an `ask_user_questions` interaction response could be accepted with an empty answers array, or with only blank per-question entries plus boilerplate summary text.
- Expected behavior: answering a question interaction should require at least one real answer: a selected option or non-empty other-text value.
- Steps to reproduce before this fix: create an `ask_user_questions` interaction, call `POST /api/issues/:id/interactions/:interactionId/respond` with `answers: []`, or call the service with an answer object whose `optionIds` is empty and has no `otherText`.
- Deployment mode: local trusted and authenticated deployments share the same route/service contract.

Related open interaction PRs found during duplicate search: Refs #6139, Refs #6535.

## What Changed

- Require `respondIssueThreadInteractionSchema.answers` to contain at least one submitted answer object.
- Normalize `ask_user_questions` service answers by dropping blank optional entries, rejecting blank required entries, and rejecting the response if no real answer remains.
- Keep boilerplate summary text valid only when at least one real per-question answer is present.
- Set an initial empty `suggest_tasks` result when claiming acceptance so resolved interactions never temporarily move non-pending without a result.
- Add service, route, and validator regression coverage for empty and blank answer responses.

## Verification

- `pnpm vitest run server/src/__tests__/issue-thread-interactions-service.test.ts server/src/__tests__/issue-thread-interaction-routes.test.ts packages/shared/src/validators/issue.test.ts server/src/services/issue-thread-interactions.test.ts packages/shared/src/issue-thread-interactions.test.ts`
- `pnpm --filter @paperclipai/shared typecheck`
- `pnpm --filter @paperclipai/server typecheck`

## Risks

- Low-to-moderate behavior change: clients can no longer submit an answered question interaction with no real answer data. Optional unanswered questions are still tolerated when at least one other question has a real answer.
- The `suggest_tasks` placeholder result is overwritten in the same transaction with the final created-task result; if task creation fails, the transaction rolls back.
- No migration is included in this PR.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

OpenAI Codex, GPT-5.5, coding-agent environment with shell/tool execution and repository editing capabilities.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

