### PR TITLE
test(cli): cover context commands

### DIFF
--- a/cli/src/__tests__/context-command.test.ts
+++ b/cli/src/__tests__/context-command.test.ts
@@ -1,0 +1,129 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { Command } from "commander";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { registerContextCommands } from "../commands/client/context.js";
+
+function createProgram(): Command {
+  const program = new Command();
+  program.exitOverride();
+  program.configureOutput({
+    writeOut: () => {},
+    writeErr: () => {},
+  });
+  registerContextCommands(program);
+  return program;
+}
+
+function createTempContextPath(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "paperclip-cli-context-command-"));
+  return path.join(dir, "context.json");
+}
+
+describe("context commands", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("sets a profile, marks it active, and shows it as JSON", async () => {
+    const contextPath = createTempContextPath();
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    await createProgram().parseAsync([
+      "context", "set",
+      "--context", contextPath,
+      "--profile", "agent-profile",
+      "--api-base", "http://localhost:3101",
+      "--company-id", "company-123",
+      "--persona", "agent",
+      "--agent-id", "agent-123",
+      "--agent-name", "Builder",
+      "--api-key-env-var-name", "PAPERCLIP_AGENT_TOKEN",
+      "--use",
+      "--json",
+    ], { from: "user" });
+
+    const setOutput = JSON.parse(String(log.mock.calls.at(-1)?.[0]));
+    expect(setOutput).toMatchObject({
+      currentProfile: "agent-profile",
+      profileName: "agent-profile",
+      profile: {
+        apiBase: "http://localhost:3101",
+        companyId: "company-123",
+        persona: "agent",
+        agentId: "agent-123",
+        agentName: "Builder",
+        apiKeyEnvVarName: "PAPERCLIP_AGENT_TOKEN",
+      },
+    });
+
+    await createProgram().parseAsync([
+      "context", "show",
+      "--context", contextPath,
+      "--json",
+    ], { from: "user" });
+
+    const showOutput = JSON.parse(String(log.mock.calls.at(-1)?.[0]));
+    expect(showOutput).toMatchObject({
+      currentProfile: "agent-profile",
+      profileName: "agent-profile",
+      profiles: {
+        "agent-profile": {
+          agentName: "Builder",
+        },
+      },
+    });
+  });
+
+  it("lists profiles and switches the active profile", async () => {
+    const contextPath = createTempContextPath();
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    await createProgram().parseAsync([
+      "context", "set",
+      "--context", contextPath,
+      "--profile", "board",
+      "--persona", "board",
+      "--api-base", "http://localhost:3100",
+      "--json",
+    ], { from: "user" });
+    await createProgram().parseAsync([
+      "context", "set",
+      "--context", contextPath,
+      "--profile", "agent",
+      "--persona", "agent",
+      "--agent-id", "agent-123",
+      "--json",
+    ], { from: "user" });
+    await createProgram().parseAsync([
+      "context", "use", "agent",
+      "--context", contextPath,
+    ], { from: "user" });
+    await createProgram().parseAsync([
+      "context", "list",
+      "--context", contextPath,
+      "--json",
+    ], { from: "user" });
+
+    const rows = JSON.parse(String(log.mock.calls.at(-1)?.[0]));
+    expect(rows).toEqual([
+      expect.objectContaining({ name: "default", current: false }),
+      expect.objectContaining({ name: "board", current: false, persona: "board" }),
+      expect.objectContaining({ name: "agent", current: true, persona: "agent", agentId: "agent-123" }),
+    ]);
+  });
+
+  it("rejects invalid persona values", async () => {
+    await expect(createProgram().parseAsync([
+      "context", "set",
+      "--context", createTempContextPath(),
+      "--persona", "operator",
+    ], { from: "user" })).rejects.toThrow("Invalid --persona value. Use board or agent.");
+  });
+});


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The CLI stores board and agent connection details in context profiles.
> - Those profiles are the basis for scriptable CLI access, persona-aware commands, and connect onboarding.
> - The context store already had direct unit coverage, but the command layer had less coverage.
> - This pull request adds focused command-level tests for `context set`, `show`, `list`, and `use`.
> - It also verifies invalid persona handling at the CLI command boundary.
> - The benefit is safer profile ergonomics as CLI parity work continues.

## Linked Issues or Issue Description

No public issue found. This is a test coverage follow-up for CLI context/profile behavior described in `doc/plans/2026-05-23-cli-api-parity.md`.

## What Changed

- Added command-level tests for setting an agent profile and showing it as JSON.
- Added command-level tests for listing profiles after switching the active profile.
- Added command-level coverage for rejecting invalid `--persona` values.

## Verification

- `./node_modules/.bin/vitest run cli/src/__tests__/context-command.test.ts --config cli/vitest.config.ts` passes: 1 file, 3 tests.

## Risks

Low risk. This is test-only coverage for existing CLI behavior.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

OpenAI GPT-5 Codex in Codex desktop, with repository inspection, shell command execution, GitHub CLI usage, and code editing tools.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g., `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge