### PR TITLE
test(cli): cover agent command safety

### DIFF
--- a/cli/src/__tests__/agent-lifecycle.test.ts
+++ b/cli/src/__tests__/agent-lifecycle.test.ts
@@ -70,6 +70,41 @@ describe("agent lifecycle commands", () => {
     ]);
   });
 
+  it("refuses to delete an agent without explicit confirmation", async () => {
+    const fetchMock = vi.fn().mockImplementation(() => Promise.resolve(jsonResponse()));
+    vi.stubGlobal("fetch", fetchMock);
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    const exit = vi.spyOn(process, "exit").mockImplementation((() => {
+      throw new Error("process.exit called");
+    }) as never);
+
+    await expect(run(["agent", "delete", AGENT_ID])).rejects.toThrow("process.exit called");
+
+    expect(error.mock.calls[0]?.[0]).toContain("Refusing to delete without --yes");
+    expect(exit).toHaveBeenCalledWith(1);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("validates agent create payloads before posting", async () => {
+    const fetchMock = vi.fn().mockImplementation(() => Promise.resolve(jsonResponse()));
+    vi.stubGlobal("fetch", fetchMock);
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    const exit = vi.spyOn(process, "exit").mockImplementation((() => {
+      throw new Error("process.exit called");
+    }) as never);
+
+    await expect(run([
+      "agent", "create",
+      "--company-id", COMPANY_ID,
+      "--payload-json", JSON.stringify({ name: "" }),
+    ])).rejects.toThrow("process.exit called");
+
+    expect(error.mock.calls[0]?.[0]).toContain("too_small");
+    expect(error.mock.calls[0]?.[0]).toContain("name");
+    expect(exit).toHaveBeenCalledWith(1);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it("wraps configuration, runtime, skills, and instructions endpoints", async () => {
     const fetchMock = vi.fn().mockImplementation(() => Promise.resolve(jsonResponse()));
     vi.stubGlobal("fetch", fetchMock);


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Agent lifecycle commands are mutating control-plane operations.
> - Destructive and schema-backed CLI commands should fail before issuing network requests when input is unsafe.
> - The existing agent lifecycle tests covered route selection for successful operations.
> - They did not directly cover the safety guard for `agent delete` or validation-before-posting for create payloads.
> - This pull request adds focused tests for those two command-boundary cases.
> - The benefit is safer scriptable agent lifecycle behavior without changing runtime code.

## Linked Issues or Issue Description

No public issue found. This is a test coverage improvement for existing CLI agent lifecycle behavior.

Related historical context: #1076 and #374 added/covered agent CRUD command work; this PR only adds safety-boundary tests for the current command behavior.

## What Changed

- Added coverage that `agent delete` refuses to call the API without `--yes`.
- Added coverage that invalid `agent create` payloads are rejected before any POST request.

## Verification

- `./node_modules/.bin/vitest run cli/src/__tests__/agent-lifecycle.test.ts --config cli/vitest.config.ts` passes: 1 file, 4 tests.

## Risks

Low risk. This is test-only coverage for existing CLI behavior.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

OpenAI GPT-5 Codex in Codex desktop, with repository inspection, shell command execution, GitHub CLI usage, and code editing tools.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g., `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge