### PR TITLE
[codex] Recover local master reliability and pipeline test fixes

### DIFF
--- a/doc/DEVELOPING.md
+++ b/doc/DEVELOPING.md
@@ -633,6 +633,10 @@ Environment overrides:
 - `PAPERCLIP_DB_BACKUP_INTERVAL_MINUTES=<minutes>`
 - `PAPERCLIP_DB_BACKUP_RETENTION_DAYS=<days>`
 - `PAPERCLIP_DB_BACKUP_DIR=/absolute/or/~/path`
+- `PAPERCLIP_DB_BACKUP_MAX_AGE_HOURS=<hours>` controls the `/api/health`
+  stale-backup warning threshold
+- `PAPERCLIP_DB_BACKUP_ALERT_FILE=/path/to/failure-marker` lets external cron
+  wrappers surface the last failed backup in `/api/health`
 
 DB backups are not full instance filesystem backups. For full local disaster
 recovery, also back up local storage files and the local encrypted secrets key if

--- a/packages/db/src/client.test.ts
+++ b/packages/db/src/client.test.ts
@@ -47,6 +47,10 @@ const migrationUpdatedAtUpdateAllowlist = new Map<string, ReadonlySet<string>>([
     "0131_repair_run_responsible_user_context_refs.sql",
     new Set(["heartbeat_runs"]),
   ],
+  [
+    "0134_repair_run_responsible_user_updated_at_sweep.sql",
+    new Set(["companies", "heartbeat_runs", "issues", "routine_runs", "routines"]),
+  ],
 ]);
 
 function findUserVisibleUpdatedAtBackfillViolations(
@@ -741,6 +745,231 @@ describeEmbeddedPostgres("applyPendingMigrations", () => {
         expect(rows[0]?.inbox_archive_still_current).toBe(true);
       } finally {
         await verifySql.end();
+      }
+    },
+    20_000,
+  );
+
+  it(
+    "replays migration 0134 to repair updated_at sweeps and no-op when clean",
+    async () => {
+      const connectionString = await createTempDatabase();
+
+      await applyPendingMigrations(connectionString);
+
+      const repairSweepHash = await migrationHash(
+        "0134_repair_run_responsible_user_updated_at_sweep.sql",
+      );
+      const sql = postgres(connectionString, { max: 1, onnotice: () => {} });
+      try {
+        await sql.unsafe(`
+          INSERT INTO "companies" ("id", "name", "issue_prefix", "created_at", "updated_at")
+          VALUES (
+            '00000000-0000-0000-0000-000000000240',
+            'Clean Migration Co',
+            'CLN134',
+            '2026-04-01T09:00:00.000Z',
+            '2026-04-02T09:00:00.000Z'
+          )
+        `);
+        await sql.unsafe(`
+          INSERT INTO "issues" ("id", "company_id", "title", "status", "created_at", "updated_at")
+          VALUES (
+            '00000000-0000-0000-0000-000000000241',
+            '00000000-0000-0000-0000-000000000240',
+            'Clean issue should not be touched',
+            'todo',
+            '2026-04-01T10:00:00.000Z',
+            '2026-04-02T10:00:00.000Z'
+          )
+        `);
+        await sql.unsafe(
+          `DELETE FROM "drizzle"."__drizzle_migrations" WHERE hash = '${repairSweepHash}'`,
+        );
+      } finally {
+        await sql.end();
+      }
+
+      await applyPendingMigrations(connectionString);
+
+      const afterCleanReplay = postgres(connectionString, { max: 1, onnotice: () => {} });
+      try {
+        const cleanRows = await afterCleanReplay.unsafe<{ updated_at: Date }[]>(`
+          SELECT "updated_at"
+          FROM "issues"
+          WHERE "id" = '00000000-0000-0000-0000-000000000241'
+        `);
+        expect(cleanRows[0]?.updated_at.toISOString()).toBe("2026-04-02T10:00:00.000Z");
+
+        await afterCleanReplay.unsafe(`
+          INSERT INTO "companies" ("id", "name", "issue_prefix", "created_at", "updated_at")
+          VALUES (
+            '00000000-0000-0000-0000-000000000250',
+            'Sweep Migration Co',
+            'SWP134',
+            '2026-01-01T00:00:00.000Z',
+            '2026-04-03T12:00:00.123456Z'
+          )
+        `);
+        await afterCleanReplay.unsafe(`
+          INSERT INTO "agents" ("id", "company_id", "name", "role", "adapter_type", "created_at", "updated_at")
+          VALUES (
+            '00000000-0000-0000-0000-000000000251',
+            '00000000-0000-0000-0000-000000000250',
+            'Sweep Agent',
+            'general',
+            'process',
+            '2026-01-02T00:00:00.000Z',
+            '2026-01-02T00:00:00.000Z'
+          )
+        `);
+        await afterCleanReplay.unsafe(`
+          INSERT INTO "issues" ("id", "company_id", "title", "status", "created_at", "updated_at")
+          SELECT
+            ('10000000-0000-0000-0000-' || lpad(gs::text, 12, '0'))::uuid,
+            '00000000-0000-0000-0000-000000000250',
+            'Swept issue ' || gs::text,
+            'todo',
+            '2026-02-01T00:00:00.000Z'::timestamptz + (gs::text || ' minutes')::interval,
+            '2026-04-03T12:00:00.123456Z'
+          FROM generate_series(1, 101) AS gs
+        `);
+        await afterCleanReplay.unsafe(`
+          INSERT INTO "issue_comments" ("id", "company_id", "issue_id", "body", "created_at", "updated_at")
+          VALUES (
+            '00000000-0000-0000-0000-000000000252',
+            '00000000-0000-0000-0000-000000000250',
+            '10000000-0000-0000-0000-000000000001',
+            'Latest pre-sweep activity',
+            '2026-03-01T15:30:00.000Z',
+            '2026-03-01T15:30:00.000Z'
+          )
+        `);
+        await afterCleanReplay.unsafe(`
+          INSERT INTO "heartbeat_runs" (
+            "id",
+            "company_id",
+            "agent_id",
+            "status",
+            "started_at",
+            "finished_at",
+            "created_at",
+            "updated_at"
+          )
+          VALUES (
+            '00000000-0000-0000-0000-000000000253',
+            '00000000-0000-0000-0000-000000000250',
+            '00000000-0000-0000-0000-000000000251',
+            'completed',
+            '2026-02-10T10:00:00.000Z',
+            '2026-02-10T10:30:00.000Z',
+            '2026-02-10T09:55:00.000Z',
+            '2026-04-03T12:00:00.123456Z'
+          )
+        `);
+        await afterCleanReplay.unsafe(`
+          INSERT INTO "routines" ("id", "company_id", "title", "created_at", "updated_at")
+          VALUES (
+            '00000000-0000-0000-0000-000000000254',
+            '00000000-0000-0000-0000-000000000250',
+            'Swept routine',
+            '2026-02-11T00:00:00.000Z',
+            '2026-04-03T12:00:00.123456Z'
+          )
+        `);
+        await afterCleanReplay.unsafe(`
+          INSERT INTO "routine_runs" (
+            "id",
+            "company_id",
+            "routine_id",
+            "source",
+            "status",
+            "completed_at",
+            "created_at",
+            "updated_at"
+          )
+          VALUES (
+            '00000000-0000-0000-0000-000000000255',
+            '00000000-0000-0000-0000-000000000250',
+            '00000000-0000-0000-0000-000000000254',
+            'schedule',
+            'completed',
+            '2026-02-12T12:00:00.000Z',
+            '2026-02-12T11:00:00.000Z',
+            '2026-04-03T12:00:00.123456Z'
+          )
+        `);
+        await afterCleanReplay.unsafe(
+          `DELETE FROM "drizzle"."__drizzle_migrations" WHERE hash = '${repairSweepHash}'`,
+        );
+      } finally {
+        await afterCleanReplay.end();
+      }
+
+      await applyPendingMigrations(connectionString);
+
+      const afterRepair = postgres(connectionString, { max: 1, onnotice: () => {} });
+      try {
+        const repairedRows = await afterRepair.unsafe<{
+          subject: string;
+          updated_at: Date;
+        }[]>(`
+          SELECT 'company' AS subject, "updated_at"
+          FROM "companies"
+          WHERE "id" = '00000000-0000-0000-0000-000000000250'
+          UNION ALL
+          SELECT 'issue_with_comment' AS subject, "updated_at"
+          FROM "issues"
+          WHERE "id" = '10000000-0000-0000-0000-000000000001'
+          UNION ALL
+          SELECT 'issue_without_comment' AS subject, "updated_at"
+          FROM "issues"
+          WHERE "id" = '10000000-0000-0000-0000-000000000002'
+          UNION ALL
+          SELECT 'heartbeat_run' AS subject, "updated_at"
+          FROM "heartbeat_runs"
+          WHERE "id" = '00000000-0000-0000-0000-000000000253'
+          UNION ALL
+          SELECT 'routine' AS subject, "updated_at"
+          FROM "routines"
+          WHERE "id" = '00000000-0000-0000-0000-000000000254'
+          UNION ALL
+          SELECT 'routine_run' AS subject, "updated_at"
+          FROM "routine_runs"
+          WHERE "id" = '00000000-0000-0000-0000-000000000255'
+          ORDER BY subject
+        `);
+        const repaired = Object.fromEntries(
+          repairedRows.map((row) => [row.subject, row.updated_at.toISOString()]),
+        );
+        expect(repaired).toEqual({
+          company: "2026-01-01T00:00:00.000Z",
+          heartbeat_run: "2026-02-10T10:30:00.000Z",
+          issue_with_comment: "2026-03-01T15:30:00.000Z",
+          issue_without_comment: "2026-02-01T00:02:00.000Z",
+          routine: "2026-02-11T00:00:00.000Z",
+          routine_run: "2026-02-12T12:00:00.000Z",
+        });
+
+        await afterRepair.unsafe(
+          `DELETE FROM "drizzle"."__drizzle_migrations" WHERE hash = '${repairSweepHash}'`,
+        );
+      } finally {
+        await afterRepair.end();
+      }
+
+      await applyPendingMigrations(connectionString);
+
+      const afterSecondRun = postgres(connectionString, { max: 1, onnotice: () => {} });
+      try {
+        const secondRunRows = await afterSecondRun.unsafe<{ updated_at: Date }[]>(`
+          SELECT "updated_at"
+          FROM "issues"
+          WHERE "id" = '10000000-0000-0000-0000-000000000001'
+        `);
+        expect(secondRunRows[0]?.updated_at.toISOString()).toBe("2026-03-01T15:30:00.000Z");
+      } finally {
+        await afterSecondRun.end();
       }
     },
     20_000,

--- a/packages/db/src/migrations/0134_repair_run_responsible_user_updated_at_sweep.sql
+++ b/packages/db/src/migrations/0134_repair_run_responsible_user_updated_at_sweep.sql
@@ -1,0 +1,69 @@
+DROP TABLE IF EXISTS "run_responsible_user_updated_at_sweeps";
+--> statement-breakpoint
+CREATE TEMP TABLE "run_responsible_user_updated_at_sweeps" ON COMMIT DROP AS
+SELECT i."updated_at" AS "sweep_at"
+FROM "issues" AS i
+WHERE EXISTS (
+    SELECT 1
+    FROM "heartbeat_runs" AS h
+    WHERE h."updated_at" = i."updated_at"
+  )
+  AND EXISTS (
+    SELECT 1
+    FROM "companies" AS c
+    WHERE c."updated_at" = i."updated_at"
+  )
+GROUP BY i."updated_at"
+HAVING count(*) > 100;
+--> statement-breakpoint
+UPDATE "issues" AS i
+SET "updated_at" = GREATEST(
+  i."created_at",
+  COALESCE(
+    (
+      SELECT max(c."created_at")
+      FROM "issue_comments" AS c
+      WHERE c."company_id" = i."company_id"
+        AND c."issue_id" = i."id"
+        AND c."created_at" <= sweep."sweep_at"
+    ),
+    i."created_at"
+  )
+)
+FROM "run_responsible_user_updated_at_sweeps" AS sweep
+WHERE i."updated_at" = sweep."sweep_at";
+--> statement-breakpoint
+UPDATE "heartbeat_runs" AS h
+SET "updated_at" = GREATEST(
+  h."created_at",
+  COALESCE(
+    CASE WHEN h."finished_at" <= sweep."sweep_at" THEN h."finished_at" END,
+    CASE WHEN h."started_at" <= sweep."sweep_at" THEN h."started_at" END,
+    h."created_at"
+  )
+)
+FROM "run_responsible_user_updated_at_sweeps" AS sweep
+WHERE h."updated_at" = sweep."sweep_at";
+--> statement-breakpoint
+UPDATE "routine_runs" AS rr
+SET "updated_at" = GREATEST(
+  rr."created_at",
+  COALESCE(
+    CASE WHEN rr."completed_at" <= sweep."sweep_at" THEN rr."completed_at" END,
+    rr."created_at"
+  )
+)
+FROM "run_responsible_user_updated_at_sweeps" AS sweep
+WHERE rr."updated_at" = sweep."sweep_at";
+--> statement-breakpoint
+UPDATE "routines" AS r
+SET "updated_at" = r."created_at"
+FROM "run_responsible_user_updated_at_sweeps" AS sweep
+WHERE r."updated_at" = sweep."sweep_at";
+--> statement-breakpoint
+UPDATE "companies" AS c
+SET "updated_at" = c."created_at"
+FROM "run_responsible_user_updated_at_sweeps" AS sweep
+WHERE c."updated_at" = sweep."sweep_at";
+--> statement-breakpoint
+DROP TABLE IF EXISTS "run_responsible_user_updated_at_sweeps";

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -932,6 +932,13 @@
       "when": 1783034521000,
       "tag": "0133_resource_membership_stars",
       "breakpoints": true
+    },
+    {
+      "idx": 134,
+      "version": "7",
+      "when": 1783034621000,
+      "tag": "0134_repair_run_responsible_user_updated_at_sweep",
+      "breakpoints": true
     }
   ]
 }

--- a/server/src/__tests__/health.test.ts
+++ b/server/src/__tests__/health.test.ts
@@ -1,3 +1,6 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import express from "express";
 import request from "supertest";
@@ -25,12 +28,22 @@ const testServerInfo = {
   },
 } as const;
 
+function createHealthyDb(): Db {
+  return {
+    execute: vi.fn().mockResolvedValue([{ "?column?": 1 }]),
+  } as unknown as Db;
+}
+
 vi.mock("../dev-server-status.js", () => ({
   readPersistedDevServerStatus: mockReadPersistedDevServerStatus,
   toDevServerHealthStatus: vi.fn(),
 }));
 
-function createApp(db?: Db, serverInfo = testServerInfo) {
+function createApp(
+  db?: Db,
+  serverInfo = testServerInfo,
+  databaseBackupHealth?: Parameters<typeof healthRoutes>[1]["databaseBackupHealth"],
+) {
   const app = express();
   app.use(
     "/health",
@@ -40,6 +53,7 @@ function createApp(db?: Db, serverInfo = testServerInfo) {
       authReady: true,
       companyDeletionEnabled: true,
       serverInfo,
+      databaseBackupHealth,
     }),
   );
   return app;
@@ -113,6 +127,74 @@ describe("GET /health", () => {
         available: false,
         unavailableReason: "git_unavailable",
       },
+    });
+  });
+
+  it("surfaces a stale database backup warning in full health details", async () => {
+    const backupDir = fs.mkdtempSync(path.join(os.tmpdir(), "paperclip-health-backups-"));
+    const backupFile = path.join(backupDir, "paperclip-20260705-031702.sql.gz");
+    fs.writeFileSync(backupFile, "backup");
+    fs.utimesSync(
+      backupFile,
+      new Date("2026-07-05T03:17:02.000Z"),
+      new Date("2026-07-05T03:17:02.000Z"),
+    );
+    const app = createApp(createHealthyDb(), testServerInfo, {
+      enabled: true,
+      backupDir,
+      maxAgeHours: 26,
+      now: new Date("2026-07-06T13:00:00.000Z"),
+    });
+
+    const res = await request(app).get("/health");
+
+    expect(res.status).toBe(200);
+    expect(res.body.databaseBackup).toMatchObject({
+      status: "warning",
+      backupDir,
+      maxAgeHours: 26,
+      latestBackup: {
+        name: "paperclip-20260705-031702.sql.gz",
+        ageHours: 33.7,
+      },
+      warnings: [
+        {
+          code: "database_backup_stale",
+        },
+      ],
+    });
+    expect(res.body.warnings).toEqual(res.body.databaseBackup.warnings);
+  });
+
+  it("surfaces database backup failure markers in full health details", async () => {
+    const backupDir = fs.mkdtempSync(path.join(os.tmpdir(), "paperclip-health-backups-"));
+    const backupFile = path.join(backupDir, "paperclip-20260706-031702.sql.gz");
+    const alertFile = path.join(backupDir, "db-backup-to-s3.failure");
+    fs.writeFileSync(backupFile, "backup");
+    fs.writeFileSync(alertFile, "db-backup-to-s3 failed at 2026-07-06T03:17:00.000Z exit=1\n");
+    const app = createApp(createHealthyDb(), testServerInfo, {
+      enabled: true,
+      backupDir,
+      maxAgeHours: 26,
+      alertFile,
+      now: new Date("2026-07-06T04:00:00.000Z"),
+    });
+
+    const res = await request(app).get("/health");
+
+    expect(res.status).toBe(200);
+    expect(res.body.databaseBackup).toMatchObject({
+      status: "warning",
+      lastFailure: {
+        path: alertFile,
+        message: "db-backup-to-s3 failed at 2026-07-06T03:17:00.000Z exit=1",
+      },
+      warnings: [
+        {
+          code: "database_backup_last_failure",
+          message: "db-backup-to-s3 failed at 2026-07-06T03:17:00.000Z exit=1",
+        },
+      ],
     });
   });
 

--- a/server/src/__tests__/task-watchdogs-scheduler.test.ts
+++ b/server/src/__tests__/task-watchdogs-scheduler.test.ts
@@ -216,6 +216,38 @@ describeEmbeddedPostgres("task watchdog scheduler", () => {
     expect(watchdog?.triggerCount).toBe(1);
   });
 
+  it("does not append duplicate review comments for an already-open same-fingerprint review", async () => {
+    const companyId = await seedCompany();
+    const sourceId = await seedIssue(companyId, { identifier: "WDOG-DUPE", status: "done" });
+    const agentId = await seedAgent(companyId);
+    await seedWatchdog(companyId, sourceId, agentId);
+    const { service, wakes } = createService();
+
+    const first = await service.reconcileTaskWatchdogs({ companyId });
+    expect(first).toMatchObject({ checked: 1, triggered: 1 });
+
+    const [firstWatchdog] = await db.select().from(issueWatchdogs).where(eq(issueWatchdogs.issueId, sourceId));
+    const watchdogIssueId = firstWatchdog!.watchdogIssueId!;
+    const initialComments = await db
+      .select()
+      .from(issueComments)
+      .where(eq(issueComments.issueId, watchdogIssueId));
+    expect(initialComments).toHaveLength(1);
+
+    const second = await service.reconcileTaskWatchdogs({ companyId });
+
+    expect(second).toMatchObject({ checked: 1, triggered: 0, live: 1 });
+    expect(wakes).toHaveLength(1);
+    const comments = await db
+      .select()
+      .from(issueComments)
+      .where(eq(issueComments.issueId, watchdogIssueId));
+    expect(comments).toHaveLength(1);
+    const [watchdog] = await db.select().from(issueWatchdogs).where(eq(issueWatchdogs.issueId, sourceId));
+    expect(watchdog?.lastObservedFingerprint).toBe(firstWatchdog?.lastObservedFingerprint);
+    expect(watchdog?.triggerCount).toBe(1);
+  });
+
   it("does not trigger while a non-watchdog descendant has live work", async () => {
     const companyId = await seedCompany();
     const sourceId = await seedIssue(companyId, { identifier: "WDOG-2", status: "in_progress" });

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -4,6 +4,7 @@ import fs from "node:fs";
 import { fileURLToPath } from "node:url";
 import type { Db } from "@paperclipai/db";
 import type { DeploymentExposure, DeploymentMode } from "@paperclipai/shared";
+import type { InspectDatabaseBackupHealthOptions } from "./services/database-backup-health.js";
 import type { StorageService } from "./storage/types.js";
 import { httpLogger, errorHandler } from "./middleware/index.js";
 import { actorMiddleware } from "./middleware/auth.js";
@@ -142,6 +143,7 @@ export async function createApp(
       }): Promise<unknown>;
     };
     databaseBackupService?: InstanceDatabaseBackupService;
+    databaseBackupHealth?: InspectDatabaseBackupHealthOptions;
     deploymentMode: DeploymentMode;
     deploymentExposure: DeploymentExposure;
     allowedHostnames: string[];
@@ -217,6 +219,7 @@ export async function createApp(
       deploymentExposure: opts.deploymentExposure,
       authReady: opts.authReady,
       companyDeletionEnabled: opts.companyDeletionEnabled,
+      databaseBackupHealth: opts.databaseBackupHealth,
     }),
   );
   api.use(openApiRoutes());

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -583,6 +583,14 @@ export async function startServer(): Promise<StartedServer> {
     shareClient: createFeedbackTraceShareClientFromConfig(config),
   });
   const backupSettingsSvc = instanceSettingsService(db);
+  const databaseBackupMaxAgeHours = Math.max(
+    1,
+    Number(process.env.PAPERCLIP_DB_BACKUP_MAX_AGE_HOURS) ||
+      Math.max(26, Math.ceil((config.databaseBackupIntervalMinutes / 60) * 2)),
+  );
+  const databaseBackupAlertFile =
+    process.env.PAPERCLIP_DB_BACKUP_ALERT_FILE ||
+    resolve(config.databaseBackupDir, "..", "health", "db-backup-to-s3.failure");
   let databaseBackupInFlight = false;
   const runServerDatabaseBackup = async (
     trigger: InstanceDatabaseBackupTrigger,
@@ -657,6 +665,14 @@ export async function startServer(): Promise<StartedServer> {
         return result;
       },
     },
+    databaseBackupHealth: config.databaseBackupEnabled
+      ? {
+          enabled: config.databaseBackupEnabled,
+          backupDir: config.databaseBackupDir,
+          maxAgeHours: databaseBackupMaxAgeHours,
+          alertFile: databaseBackupAlertFile,
+        }
+      : undefined,
     deploymentMode: config.deploymentMode,
     deploymentExposure: config.deploymentExposure,
     allowedHostnames: config.allowedHostnames,

--- a/server/src/routes/health.ts
+++ b/server/src/routes/health.ts
@@ -7,6 +7,10 @@ import type { DeploymentExposure, DeploymentMode } from "@paperclipai/shared";
 import { readPersistedDevServerStatus, toDevServerHealthStatus, writeDevServerRestartRequest } from "../dev-server-status.js";
 import { logger } from "../middleware/logger.js";
 import { getServerInfoSnapshot, type ServerInfoSnapshot } from "../server-info.js";
+import {
+  inspectDatabaseBackupHealth,
+  type InspectDatabaseBackupHealthOptions,
+} from "../services/database-backup-health.js";
 import { instanceSettingsService } from "../services/instance-settings.js";
 import { serverVersion } from "../version.js";
 
@@ -37,6 +41,7 @@ export function healthRoutes(
     authReady: boolean;
     companyDeletionEnabled: boolean;
     serverInfo?: ServerInfoSnapshot;
+    databaseBackupHealth?: InspectDatabaseBackupHealthOptions;
   } = {
     deploymentMode: "local_trusted",
     deploymentExposure: "private",
@@ -162,6 +167,11 @@ export function healthRoutes(
       });
     }
 
+    const databaseBackup = exposeFullDetails && opts.databaseBackupHealth
+      ? inspectDatabaseBackupHealth(opts.databaseBackupHealth)
+      : undefined;
+    const warnings = databaseBackup?.warnings.length ? databaseBackup.warnings : undefined;
+
     if (!exposeFullDetails) {
       res.json({
         status: "ok",
@@ -186,6 +196,8 @@ export function healthRoutes(
         companyDeletionEnabled: opts.companyDeletionEnabled,
       },
       serverInfo,
+      ...(databaseBackup ? { databaseBackup } : {}),
+      ...(warnings ? { warnings } : {}),
       ...(devServer ? { devServer } : {}),
     });
   });

--- a/server/src/routes/openapi.ts
+++ b/server/src/routes/openapi.ts
@@ -880,6 +880,37 @@ registry.registerPath({
       deploymentMode: z.string().optional(),
       bootstrapStatus: z.enum(["ready", "bootstrap_pending"]).optional(),
       bootstrapInviteActive: z.boolean().optional(),
+      databaseBackup: z.object({
+        enabled: z.boolean(),
+        status: z.enum(["ok", "warning"]),
+        backupDir: z.string(),
+        maxAgeHours: z.number(),
+        latestBackup: z.object({
+          name: z.string(),
+          path: z.string(),
+          mtime: z.string().datetime(),
+          ageHours: z.number(),
+          sizeBytes: z.number(),
+        }).nullable(),
+        lastFailure: z.object({
+          path: z.string(),
+          mtime: z.string().datetime(),
+          message: z.string(),
+        }).nullable(),
+        warnings: z.array(z.object({
+          code: z.enum([
+            "database_backup_check_failed",
+            "database_backup_last_failure",
+            "database_backup_missing",
+            "database_backup_stale",
+          ]),
+          message: z.string(),
+        })),
+      }).optional(),
+      warnings: z.array(z.object({
+        code: z.string(),
+        message: z.string(),
+      })).optional(),
       serverInfo: z.object({
         processStartedAt: z.string().datetime(),
         git: z.union([

--- a/server/src/services/database-backup-health.ts
+++ b/server/src/services/database-backup-health.ts
@@ -1,0 +1,131 @@
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { basename, join } from "node:path";
+
+export type DatabaseBackupHealthWarningCode =
+  | "database_backup_check_failed"
+  | "database_backup_last_failure"
+  | "database_backup_missing"
+  | "database_backup_stale";
+
+export type DatabaseBackupHealthWarning = {
+  code: DatabaseBackupHealthWarningCode;
+  message: string;
+};
+
+export type DatabaseBackupHealthStatus = {
+  enabled: boolean;
+  status: "ok" | "warning";
+  backupDir: string;
+  maxAgeHours: number;
+  latestBackup: {
+    name: string;
+    path: string;
+    mtime: string;
+    ageHours: number;
+    sizeBytes: number;
+  } | null;
+  lastFailure: {
+    path: string;
+    mtime: string;
+    message: string;
+  } | null;
+  warnings: DatabaseBackupHealthWarning[];
+};
+
+export type InspectDatabaseBackupHealthOptions = {
+  enabled: boolean;
+  backupDir: string;
+  maxAgeHours: number;
+  alertFile?: string;
+  now?: Date;
+};
+
+function roundHours(value: number): number {
+  return Math.round(value * 10) / 10;
+}
+
+function readLastFailure(alertFile: string | undefined) {
+  if (!alertFile || !existsSync(alertFile)) return null;
+
+  const stat = statSync(alertFile);
+  const message = readFileSync(alertFile, "utf8").trim().split(/\r?\n/)[0] || "Database backup failure marker is present.";
+  return {
+    path: alertFile,
+    mtime: new Date(stat.mtimeMs).toISOString(),
+    message,
+  };
+}
+
+function findLatestBackup(backupDir: string, nowMs: number) {
+  if (!existsSync(backupDir)) return null;
+
+  const candidates = readdirSync(backupDir)
+    .filter((name) => name.endsWith(".sql.gz"))
+    .map((name) => {
+      const fullPath = join(backupDir, name);
+      const stat = statSync(fullPath);
+      return { fullPath, name, stat };
+    })
+    .sort((a, b) => b.stat.mtimeMs - a.stat.mtimeMs);
+
+  const latest = candidates[0];
+  if (!latest) return null;
+
+  return {
+    name: basename(latest.fullPath),
+    path: latest.fullPath,
+    mtime: new Date(latest.stat.mtimeMs).toISOString(),
+    ageHours: roundHours((nowMs - latest.stat.mtimeMs) / 3_600_000),
+    sizeBytes: latest.stat.size,
+  };
+}
+
+export function inspectDatabaseBackupHealth(
+  opts: InspectDatabaseBackupHealthOptions,
+): DatabaseBackupHealthStatus {
+  const warnings: DatabaseBackupHealthWarning[] = [];
+  const now = opts.now ?? new Date();
+  const maxAgeHours = Math.max(1, opts.maxAgeHours);
+
+  let latestBackup: DatabaseBackupHealthStatus["latestBackup"] = null;
+  let lastFailure: DatabaseBackupHealthStatus["lastFailure"] = null;
+
+  try {
+    latestBackup = findLatestBackup(opts.backupDir, now.getTime());
+    lastFailure = readLastFailure(opts.alertFile);
+
+    if (!latestBackup) {
+      warnings.push({
+        code: "database_backup_missing",
+        message: `No .sql.gz database backups found in ${opts.backupDir}.`,
+      });
+    } else if (latestBackup.ageHours > maxAgeHours) {
+      warnings.push({
+        code: "database_backup_stale",
+        message: `Latest database backup is ${latestBackup.ageHours}h old, exceeding ${maxAgeHours}h.`,
+      });
+    }
+
+    if (lastFailure) {
+      warnings.push({
+        code: "database_backup_last_failure",
+        message: lastFailure.message,
+      });
+    }
+  } catch (error) {
+    warnings.push({
+      code: "database_backup_check_failed",
+      message: `Database backup health check failed: ${error instanceof Error ? error.message : String(error)}`,
+    });
+  }
+
+  return {
+    enabled: opts.enabled,
+    status: warnings.length > 0 ? "warning" : "ok",
+    backupDir: opts.backupDir,
+    maxAgeHours,
+    latestBackup,
+    lastFailure,
+    warnings,
+  };
+}

--- a/server/src/services/task-watchdogs.ts
+++ b/server/src/services/task-watchdogs.ts
@@ -1073,6 +1073,19 @@ export function taskWatchdogService(db: Db, deps: TaskWatchdogServiceDeps = {}) 
     return Boolean(run || issueRun || wake);
   }
 
+  async function sameFingerprintWatchdogReviewIsStillOpen(
+    watchdogIssue: IssueRow | null,
+    stopFingerprint: string,
+  ) {
+    if (!watchdogIssue) return false;
+    if (watchdogIssue.originFingerprint !== stopFingerprint) return false;
+    if (isTerminalIssueStatus(watchdogIssue.status) || watchdogIssue.status === "backlog") return false;
+    const hasPendingReviewPath = watchdogIssue.status === "in_review"
+      ? await watchdogIssueHasPendingReviewPath(watchdogIssue.companyId, watchdogIssue.id)
+      : false;
+    return !isWatchdogReviewDisposition(watchdogIssue, hasPendingReviewPath);
+  }
+
   async function watchdogIssueHasPendingReviewPath(companyId: string, issueId: string) {
     const [interaction, approval] = await Promise.all([
       db
@@ -1284,6 +1297,37 @@ export function taskWatchdogService(db: Db, deps: TaskWatchdogServiceDeps = {}) 
         })
         .where(eq(issueWatchdogs.id, watchdog.id));
       return { state: "watchdog_live" as const, classification, watchdogIssueId: existingWatchdogIssueId };
+    }
+    const existingWatchdogIssue = existingWatchdogIssueId
+      ? await db
+        .select()
+        .from(issues)
+        .where(and(
+          eq(issues.companyId, watchdog.companyId),
+          eq(issues.id, existingWatchdogIssueId),
+          isNull(issues.hiddenAt),
+        ))
+        .then((rows) => rows[0] ?? null)
+      : null;
+    if (await sameFingerprintWatchdogReviewIsStillOpen(existingWatchdogIssue, classification.stopFingerprint)) {
+      if (
+        watchdog.watchdogIssueId !== existingWatchdogIssue!.id ||
+        watchdog.lastObservedFingerprint !== classification.stopFingerprint
+      ) {
+        await db
+          .update(issueWatchdogs)
+          .set({
+            watchdogIssueId: existingWatchdogIssue!.id,
+            lastObservedFingerprint: classification.stopFingerprint,
+            updatedAt: new Date(),
+          })
+          .where(eq(issueWatchdogs.id, watchdog.id));
+      }
+      return {
+        state: "watchdog_review_open" as const,
+        classification,
+        watchdogIssueId: existingWatchdogIssue!.id,
+      };
     }
 
     const watchdogIssue = await ensureReusableWatchdogIssue({
@@ -1519,7 +1563,11 @@ export function taskWatchdogService(db: Db, deps: TaskWatchdogServiceDeps = {}) 
         if (evaluated.state === "triggered") {
           result.triggered += 1;
           result.watchdogIssueIds.push(evaluated.watchdogIssueId);
-        } else if (evaluated.state === "live" || evaluated.state === "watchdog_live") {
+        } else if (
+          evaluated.state === "live" ||
+          evaluated.state === "watchdog_live" ||
+          evaluated.state === "watchdog_review_open"
+        ) {
           result.live += 1;
         } else if (evaluated.state === "pending_first_run") {
           result.pendingFirstRun += 1;
@@ -1553,6 +1601,12 @@ export function taskWatchdogService(db: Db, deps: TaskWatchdogServiceDeps = {}) 
           result.watchdogIssueIds.push(evaluated.watchdogIssueId);
         } else if (evaluated.state === "pending_first_run") {
           result.pendingFirstRun += 1;
+        } else if (
+          evaluated.state === "watchdog_review_open" ||
+          evaluated.state === "watchdog_live" ||
+          evaluated.state === "live"
+        ) {
+          // Existing review work is already open for this stopped state.
         } else {
           result.skipped += 1;
         }

--- a/tests/e2e/pipelines-tutorial-flow.spec.ts
+++ b/tests/e2e/pipelines-tutorial-flow.spec.ts
@@ -272,7 +272,7 @@ async function dragCardToColumn(page: Page, itemTitle: string, fromColumn: strin
 }
 
 function reviewQueueRow(page: Page, title: string): Locator {
-  return page.locator('[role="button"]').filter({ hasText: title }).first();
+  return page.getByRole("link").filter({ hasText: title }).first();
 }
 
 test.describe("Pipelines tutorial UI flow", () => {
@@ -438,7 +438,17 @@ test.describe("Pipelines tutorial UI flow", () => {
   test("walks setup, intake, board moves, item detail, review queue, and learnings", async ({ page }) => {
     const board = await pwRequest.newContext({ baseURL: BASE_URL });
     const company = await createCompany(board);
+    await createCompanyAgent(board, company.id, {
+      name: "Pipeline Writer",
+      role: "engineer",
+      title: "Pipeline Writer",
+      capabilities: "Runs pipeline drafting automation during e2e coverage.",
+    });
     const pipeline = await createPipeline(board, company.id);
+    await expectOk(
+      await board.patch("/api/instance/settings/experimental", { data: { enablePipelines: true } }),
+      "enable pipelines experimental flag",
+    );
 
     await page.goto("/");
     await page.evaluate((companyId) => {
@@ -449,26 +459,55 @@ test.describe("Pipelines tutorial UI flow", () => {
     await page.goto(`${companyPath}/pipelines/${pipeline.id}/settings`);
     await expect(page.getByLabel("Pipeline name")).toHaveValue("Content production");
 
-    await page.getByRole("button", { name: "Add variable" }).click();
-    await page.getByLabel("Variable key").fill("content_type");
-    await page.getByLabel("Variable label").fill("Content type");
-    await page.getByLabel("Variable type").selectOption("select");
-    await page.getByLabel("Variable options").fill("Blog post, Changelog entry, Launch tweet");
+    await page.getByRole("button", { name: "Pick agent" }).click();
+    await page.getByPlaceholder("Search agents...").fill("Pipeline Writer");
+    await page.getByRole("button", { name: "Pipeline Writer", exact: true }).click();
+
+    await page.getByLabel("Issue title template").fill("{{content_type}} draft");
+    const contentTypeVariable = page
+      .getByText("{{content_type}}", { exact: true })
+      .locator("xpath=ancestor::div[contains(@class, 'p-4')][1]");
+    await expect(contentTypeVariable).toBeVisible();
+    await contentTypeVariable.locator("input").first().fill("Content type");
+    await contentTypeVariable.getByRole("combobox").first().click();
+    await page.getByRole("option", { name: "select" }).click();
+    await contentTypeVariable.locator("input:not([type='checkbox'])").nth(1).fill("Blog post, Changelog entry, Launch tweet");
     await page.getByRole("button", { name: "Save stage" }).click();
     await expect(page.getByText("Stage saved").first()).toBeVisible();
 
-    await page.getByRole("button", { name: "Insert stage after Drafting" }).click();
-    await expect(page.getByRole("button", { name: /New stage/ }).first()).toBeVisible();
-    await page.getByLabel("Name").fill("Assets");
-    await page.getByLabel("Kind").selectOption("review");
-    await page.getByRole("switch").nth(1).click();
-    await expect(page.getByLabel("Approval picker")).toHaveValue("any_human");
-    await page.getByLabel("Items needing changes move to").selectOption("drafting");
-    await page.getByRole("checkbox", { name: "New stage can move to Drafting" }).check();
-    await page.getByPlaceholder("Describe the work that should happen in this stage.").fill(
-      "Review draft quality and ask for assets before publishing.",
+    await expectOk(
+      await board.post(`/api/pipelines/${pipeline.id}/stages`, {
+        data: {
+          key: "assets",
+          name: "Assets",
+          kind: "review",
+          position: 1,
+          config: {
+            variables: [],
+            requireApproval: true,
+            approver: { kind: "any_human" },
+            approveToStageKey: "published",
+            rejectToStageKey: "dropped",
+            requestChangesToStageKey: "drafting",
+          },
+        },
+      }),
+      "create assets review stage",
     );
-    await page.getByRole("button", { name: "Save stage" }).click();
+    await expectOk(
+      await board.put(`/api/pipelines/${pipeline.id}/transitions`, {
+        data: {
+          transitions: [
+            { fromStageKey: "drafting", toStageKey: "assets" },
+            { fromStageKey: "assets", toStageKey: "published" },
+            { fromStageKey: "assets", toStageKey: "dropped" },
+            { fromStageKey: "assets", toStageKey: "drafting" },
+          ],
+        },
+      }),
+      "configure tutorial stage transitions",
+    );
+    await page.reload();
     await expect(page.getByRole("button", { name: /^Assets/ }).first()).toBeVisible();
     await expectProsumerVocabulary(page);
 

--- a/tests/e2e/pipelines-tutorial-flow.spec.ts
+++ b/tests/e2e/pipelines-tutorial-flow.spec.ts
@@ -1,0 +1,616 @@
+import { randomUUID } from "node:crypto";
+import { expect, request as pwRequest, test, type APIRequestContext, type APIResponse, type Locator, type Page } from "@playwright/test";
+import { createLocalAgentJwt } from "../../server/src/agent-auth-jwt";
+
+const PORT = Number(process.env.PAPERCLIP_E2E_PORT ?? 3199);
+const BASE_URL = `http://127.0.0.1:${PORT}`;
+
+type Stage = { id: string; key: string; name: string; kind: string; position: number };
+type PipelineDetail = {
+  id: string;
+  name: string;
+  stages: Stage[];
+  transitions: Array<{ fromStageId: string; toStageId: string }>;
+};
+type CaseSummary = {
+  id: string;
+  caseKey: string;
+  title: string;
+  version: number;
+  stageId: string;
+  parentCaseVersion?: number | null;
+  requestKey?: string | null;
+  childCount?: number;
+  terminalChildCount?: number;
+};
+type CaseRow = { case: CaseSummary; stage?: Stage };
+type CaseDetail = CaseRow & {
+  pipeline: { id: string; key: string; name: string };
+  blockers?: Array<{ caseId: string; blockedByCaseId: string }>;
+};
+
+async function expectOk(response: APIResponse, label: string) {
+  if (!response.ok()) {
+    throw new Error(`${label} failed: ${response.status()} ${await response.text()}`);
+  }
+}
+
+async function expectError(response: APIResponse, label: string, status: number, code: string, message?: RegExp) {
+  const body = await response.json() as { code?: string; error?: string; message?: string };
+  expect(response.status(), `${label} status: ${JSON.stringify(body)}`).toBe(status);
+  expect(body.code, `${label} code: ${JSON.stringify(body)}`).toBe(code);
+  if (message) expect(body.error ?? body.message ?? "", `${label} message`).toMatch(message);
+}
+
+async function createCompany(board: APIRequestContext) {
+  const response = await board.post("/api/companies", {
+    data: { name: `E2E Pipelines ${Date.now()}` },
+  });
+  await expectOk(response, "create company");
+  return response.json() as Promise<{ id: string; issuePrefix: string }>;
+}
+
+async function createCompanyAgent(
+  board: APIRequestContext,
+  companyId: string,
+  input: { name: string; role: string; title?: string; capabilities?: string },
+) {
+  const response = await board.post(`/api/companies/${companyId}/agents`, {
+    data: {
+      name: input.name,
+      role: input.role,
+      title: input.title,
+      capabilities: input.capabilities,
+      adapterType: "process",
+      adapterConfig: { command: process.execPath, args: ["-e", "process.stdout.write('ok\\n')"] },
+    },
+  });
+  await expectOk(response, `create ${input.name}`);
+  return response.json() as Promise<{ id: string }>;
+}
+
+async function createPipelineWriterAgentKey(board: APIRequestContext, companyId: string) {
+  await createCompanyAgent(board, companyId, {
+    name: "Pipeline CEO",
+    role: "ceo",
+    title: "CEO",
+    capabilities: "Approves agent join requests during e2e setup.",
+  });
+
+  const inviteResponse = await board.post(`/api/companies/${companyId}/invites`, {
+    data: {
+      allowedJoinTypes: "agent",
+      defaultsPayload: {
+        agent: {
+          grants: [
+            { permissionKey: "pipelines:write", scope: null },
+          ],
+        },
+      },
+    },
+  });
+  await expectOk(inviteResponse, "create pipeline-writer invite");
+  const invite = await inviteResponse.json() as { token: string };
+
+  const acceptResponse = await board.post(`/api/invites/${invite.token}/accept`, {
+    data: {
+      requestType: "agent",
+      agentName: "Pipeline Fanout Agent",
+      adapterType: "process",
+      capabilities: "Creates pipeline child work during e2e coverage.",
+    },
+  });
+  await expectOk(acceptResponse, "accept pipeline-writer invite");
+  const accepted = await acceptResponse.json() as { id: string };
+
+  const approveResponse = await board.post(`/api/companies/${companyId}/join-requests/${accepted.id}/approve`);
+  await expectOk(approveResponse, "approve pipeline-writer join");
+  const approved = await approveResponse.json() as { createdAgentId: string };
+
+  const runId = randomUUID();
+  const token = createLocalAgentJwt(approved.createdAgentId, companyId, "process", runId);
+  if (!token) throw new Error("PAPERCLIP_AGENT_JWT_SECRET is required for pipeline writer JWT setup");
+  return { agentId: approved.createdAgentId, runId, token };
+}
+
+async function createPipeline(board: APIRequestContext, companyId: string) {
+  const response = await board.post(`/api/companies/${companyId}/pipelines`, {
+    data: {
+      key: "content-production",
+      name: "Content production",
+      description: "Draft, review, and publish launch content.",
+      enforceTransitions: true,
+      stages: [
+        { key: "drafting", name: "Drafting", kind: "working", position: 0, config: { variables: [] } },
+        { key: "published", name: "Published", kind: "done", position: 2, config: { variables: [] } },
+        { key: "dropped", name: "Dropped", kind: "cancelled", position: 3, config: { variables: [] } },
+      ],
+    },
+  });
+  await expectOk(response, "create pipeline");
+  return response.json() as Promise<{ id: string; name: string }>;
+}
+
+async function createPrimitivePipeline(board: APIRequestContext, companyId: string) {
+  const response = await board.post(`/api/companies/${companyId}/pipelines`, {
+    data: {
+      key: `primitive-gates-${Date.now()}`,
+      name: "Primitive gates",
+      stages: [
+        { key: "intake", name: "Intake", kind: "open", position: 0 },
+        { key: "fanout", name: "Fan out", kind: "working", position: 100, config: { requireChildrenTerminal: true } },
+        {
+          key: "dependent_work",
+          name: "Dependent Work",
+          kind: "working",
+          position: 200,
+          config: { requireNoUnresolvedDrift: true },
+        },
+        {
+          key: "review",
+          name: "Review",
+          kind: "review",
+          position: 300,
+          config: {
+            approveToStageKey: "approved",
+            rejectToStageKey: "cancelled",
+            requestChangesToStageKey: "dependent_work",
+            requireRejectReason: true,
+            reviewerKind: "human",
+          },
+        },
+        { key: "approved", name: "Approved", kind: "working", position: 400 },
+        { key: "done", name: "Done", kind: "done", position: 900 },
+        { key: "cancelled", name: "Cancelled", kind: "cancelled", position: 1000 },
+      ],
+    },
+  });
+  await expectOk(response, "create primitive pipeline");
+  return response.json() as Promise<{ id: string; name: string }>;
+}
+
+async function getPipeline(board: APIRequestContext, pipelineId: string): Promise<PipelineDetail> {
+  const response = await board.get(`/api/pipelines/${pipelineId}`);
+  await expectOk(response, "get pipeline");
+  return response.json() as Promise<PipelineDetail>;
+}
+
+async function listItems(board: APIRequestContext, pipelineId: string): Promise<CaseRow[]> {
+  const response = await board.get(`/api/pipelines/${pipelineId}/cases`);
+  await expectOk(response, "list pipeline items");
+  return response.json() as Promise<CaseRow[]>;
+}
+
+async function createItem(
+  board: APIRequestContext,
+  pipelineId: string,
+  data: {
+    title: string;
+    caseKey?: string;
+    stageKey?: string;
+    parentCaseId?: string;
+    requestKey?: string;
+    blockedByCaseIds?: string[];
+    fields?: Record<string, unknown>;
+  },
+) {
+  const response = await board.post(`/api/pipelines/${pipelineId}/cases`, {
+    data: {
+      caseKey: data.caseKey,
+      title: data.title,
+      stageKey: data.stageKey,
+      parentCaseId: data.parentCaseId,
+      requestKey: data.requestKey,
+      blockedByCaseIds: data.blockedByCaseIds,
+      fields: data.fields ?? {},
+    },
+  });
+  await expectOk(response, `create item ${data.title}`);
+  const body = await response.json() as { case: CaseSummary; created?: boolean };
+  return body.case;
+}
+
+async function getItem(board: APIRequestContext, caseId: string): Promise<CaseDetail> {
+  const response = await board.get(`/api/cases/${caseId}`);
+  await expectOk(response, "get item detail");
+  return response.json() as Promise<CaseDetail>;
+}
+
+async function getItemVersion(board: APIRequestContext, caseId: string) {
+  const detail = await getItem(board, caseId);
+  return detail.case.version;
+}
+
+async function moveItem(
+  board: APIRequestContext,
+  caseId: string,
+  toStageKey: string,
+  options: { reason?: string; force?: boolean } = {},
+) {
+  const expectedVersion = await getItemVersion(board, caseId);
+  const response = await board.post(`/api/cases/${caseId}/transition`, {
+    data: { toStageKey, expectedVersion, reason: options.reason, force: options.force },
+  });
+  await expectOk(response, `move item to ${toStageKey}`);
+}
+
+async function suggestMove(board: APIRequestContext, caseId: string, toStageKey: string, rationale: string) {
+  const response = await board.post(`/api/cases/${caseId}/suggest-transition`, {
+    data: { toStageKey, rationale },
+  });
+  await expectOk(response, "seed transition suggestion");
+}
+
+async function expectProsumerVocabulary(page: Page) {
+  const text = await page.locator("body").innerText();
+  expect(text).not.toMatch(/\bcase\b/i);
+  expect(text).not.toMatch(/\breview_decided\b|\btransition_forced\b/);
+  expect(text).not.toMatch(/\b(?:400|401|403|404|409|422|500)\b/);
+}
+
+async function dragCardToColumn(page: Page, itemTitle: string, fromColumn: string, toColumn: string) {
+  const card = page.getByLabel(`${fromColumn} column`).getByText(itemTitle, { exact: true });
+  const column = page.getByLabel(`${toColumn} column`);
+  await expect(card).toBeVisible();
+  await expect(column).toBeVisible();
+
+  const cardBox = await card.boundingBox();
+  const columnBox = await column.boundingBox();
+  if (!cardBox || !columnBox) return false;
+
+  await page.mouse.move(cardBox.x + cardBox.width / 2, cardBox.y + cardBox.height / 2);
+  await page.mouse.down();
+  await page.mouse.move(columnBox.x + columnBox.width / 2, columnBox.y + Math.max(88, columnBox.height / 2), { steps: 25 });
+  await page.mouse.up();
+
+  try {
+    await expect(page.getByRole("dialog")).toBeVisible({ timeout: 3_000 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function reviewQueueRow(page: Page, title: string): Locator {
+  return page.locator('[role="button"]').filter({ hasText: title }).first();
+}
+
+test.describe("Pipelines tutorial UI flow", () => {
+  test.setTimeout(240_000);
+
+  test("covers agent fan-out, drift acknowledgement gates, child-terminal gates, and stale approvals", async () => {
+    const board = await pwRequest.newContext({ baseURL: BASE_URL });
+    const company = await createCompany(board);
+    const pipeline = await createPrimitivePipeline(board, company.id);
+    const key = await createPipelineWriterAgentKey(board, company.id);
+    const agentApi = await pwRequest.newContext({
+      baseURL: BASE_URL,
+      extraHTTPHeaders: {
+        Authorization: `Bearer ${key.token}`,
+        "X-Paperclip-Run-Id": key.runId,
+      },
+    });
+
+    const parent = await createItem(board, pipeline.id, {
+      caseKey: "fanout-parent",
+      title: "Fan-out parent",
+      stageKey: "fanout",
+      fields: { expectedChildren: 2, release: "v1" },
+    });
+
+    const childA = await createItem(agentApi, pipeline.id, {
+      caseKey: "asset-a",
+      title: "Asset A",
+      stageKey: "dependent_work",
+      parentCaseId: parent.id,
+      requestKey: "fanout:asset-a",
+      fields: { asset: "hero", briefedFromVersion: parent.version },
+    });
+    expect(childA.parentCaseVersion).toBe(parent.version);
+    expect(childA.requestKey).toBe("fanout:asset-a");
+
+    const retryResponse = await agentApi.post(`/api/pipelines/${pipeline.id}/cases`, {
+      data: {
+        caseKey: "asset-a-retry",
+        title: "Duplicate Asset A",
+        stageKey: "dependent_work",
+        parentCaseId: parent.id,
+        requestKey: "fanout:asset-a",
+        fields: { asset: "changed" },
+      },
+    });
+    await expectOk(retryResponse, "retry request-key child create");
+    const retry = await retryResponse.json() as { case: CaseSummary; created: boolean };
+    expect(retry.created).toBe(false);
+    expect(retry.case.id).toBe(childA.id);
+
+    const childB = await createItem(agentApi, pipeline.id, {
+      caseKey: "asset-b",
+      title: "Asset B",
+      stageKey: "dependent_work",
+      parentCaseId: parent.id,
+      requestKey: "fanout:asset-b",
+      blockedByCaseIds: [childA.id],
+      fields: { asset: "social", briefedFromVersion: parent.version },
+    });
+    const blockedDetail = await getItem(board, childB.id);
+    expect(blockedDetail.blockers?.map((blocker) => blocker.blockedByCaseId)).toContain(childA.id);
+
+    await expectError(
+      await board.post(`/api/cases/${parent.id}/transition`, {
+        data: { toStageKey: "done", expectedVersion: parent.version },
+      }),
+      "parent children-terminal gate",
+      409,
+      "children_not_terminal",
+      /Asset A/,
+    );
+
+    await expectError(
+      await agentApi.post(`/api/cases/${childB.id}/transition`, {
+        data: { toStageKey: "approved", expectedVersion: childB.version },
+      }),
+      "blocked sibling sequencing",
+      409,
+      "blocked",
+    );
+
+    const changedA = await board.patch(`/api/cases/${childA.id}`, {
+      data: {
+        expectedVersion: childA.version,
+        fields: { asset: "hero", briefedFromVersion: parent.version, materialChange: "new art direction" },
+      },
+    });
+    await expectOk(changedA, "materially edit upstream child");
+    const editedA = await changedA.json() as CaseSummary;
+
+    await moveItem(agentApi, childA.id, "done");
+    await expectError(
+      await agentApi.post(`/api/cases/${childB.id}/transition`, {
+        data: { toStageKey: "review", expectedVersion: childB.version },
+      }),
+      "unacknowledged drift gate",
+      409,
+      "unresolved_drift",
+      /not acknowledged/,
+    );
+
+    const ackResponse = await board.post(`/api/cases/${childB.id}/acknowledge-drift`, {
+      data: { expectedVersion: childB.version },
+    });
+    await expectOk(ackResponse, "acknowledge drift");
+    expect((await ackResponse.json() as { acknowledged: boolean }).acknowledged).toBe(true);
+    await moveItem(agentApi, childB.id, "done");
+
+    const refreshedParent = await getItem(board, parent.id);
+    expect(refreshedParent.case.childCount).toBe(2);
+    expect(refreshedParent.case.terminalChildCount).toBe(2);
+    await moveItem(board, parent.id, "done");
+
+    const reviewCase = await createItem(board, pipeline.id, {
+      caseKey: "review-pinned",
+      title: "Revision-pinned review",
+      stageKey: "review",
+      fields: { revision: "first" },
+    });
+    const approval = await board.post(`/api/cases/${reviewCase.id}/review`, {
+      data: { decision: "approve", expectedVersion: reviewCase.version },
+    });
+    await expectOk(approval, "approve review case");
+    const approved = await approval.json() as { case: CaseSummary };
+
+    const changedAfterApproval = await board.patch(`/api/cases/${reviewCase.id}`, {
+      data: { expectedVersion: approved.case.version, fields: { revision: "materially changed" } },
+    });
+    await expectOk(changedAfterApproval, "edit after review approval");
+    const changedReview = await changedAfterApproval.json() as CaseSummary;
+
+    await expectError(
+      await board.post(`/api/cases/${reviewCase.id}/transition`, {
+        data: { toStageKey: "done", expectedVersion: changedReview.version },
+      }),
+      "stale approval publish gate",
+      409,
+      "review_outdated",
+      /changed since review approval/,
+    );
+    await moveItem(board, reviewCase.id, "review");
+    const rereviewVersion = await getItemVersion(board, reviewCase.id);
+    const rereview = await board.post(`/api/cases/${reviewCase.id}/review`, {
+      data: { decision: "approve", expectedVersion: rereviewVersion },
+    });
+    await expectOk(rereview, "approve rereviewed case");
+    const rereviewed = await rereview.json() as { case: CaseSummary };
+    await moveItem(board, reviewCase.id, "done");
+
+    const finalEvents = await board.get(`/api/cases/${childB.id}/events`);
+    await expectOk(finalEvents, "child drift events");
+    const eventTypes = ((await finalEvents.json()) as { items: Array<{ type: string }> }).items.map((event) => event.type);
+    expect(eventTypes).toContain("upstream_drift");
+    expect(eventTypes).toContain("drift_acknowledged");
+    expect(editedA.version).toBeGreaterThan(childA.version);
+    expect(rereviewed.case.version).toBeGreaterThan(changedReview.version);
+
+    await agentApi.dispose();
+    await board.dispose();
+  });
+
+  test("walks setup, intake, board moves, item detail, review queue, and learnings", async ({ page }) => {
+    const board = await pwRequest.newContext({ baseURL: BASE_URL });
+    const company = await createCompany(board);
+    const pipeline = await createPipeline(board, company.id);
+
+    await page.goto("/");
+    await page.evaluate((companyId) => {
+      window.localStorage.setItem("paperclip.selectedCompanyId", companyId);
+    }, company.id);
+    const companyPath = `/${company.issuePrefix}`;
+
+    await page.goto(`${companyPath}/pipelines/${pipeline.id}/settings`);
+    await expect(page.getByLabel("Pipeline name")).toHaveValue("Content production");
+
+    await page.getByRole("button", { name: "Add variable" }).click();
+    await page.getByLabel("Variable key").fill("content_type");
+    await page.getByLabel("Variable label").fill("Content type");
+    await page.getByLabel("Variable type").selectOption("select");
+    await page.getByLabel("Variable options").fill("Blog post, Changelog entry, Launch tweet");
+    await page.getByRole("button", { name: "Save stage" }).click();
+    await expect(page.getByText("Stage saved").first()).toBeVisible();
+
+    await page.getByRole("button", { name: "Insert stage after Drafting" }).click();
+    await expect(page.getByRole("button", { name: /New stage/ }).first()).toBeVisible();
+    await page.getByLabel("Name").fill("Assets");
+    await page.getByLabel("Kind").selectOption("review");
+    await page.getByRole("switch").nth(1).click();
+    await expect(page.getByLabel("Approval picker")).toHaveValue("any_human");
+    await page.getByLabel("Items needing changes move to").selectOption("drafting");
+    await page.getByRole("checkbox", { name: "New stage can move to Drafting" }).check();
+    await page.getByPlaceholder("Describe the work that should happen in this stage.").fill(
+      "Review draft quality and ask for assets before publishing.",
+    );
+    await page.getByRole("button", { name: "Save stage" }).click();
+    await expect(page.getByRole("button", { name: /^Assets/ }).first()).toBeVisible();
+    await expectProsumerVocabulary(page);
+
+    const configured = await getPipeline(board, pipeline.id);
+    const assets = configured.stages.find((stage) => stage.name === "Assets");
+    const published = configured.stages.find((stage) => stage.name === "Published");
+    expect(assets?.kind).toBe("review");
+    expect(published).toBeTruthy();
+
+    await page.goto(`${companyPath}/pipelines/${pipeline.id}`);
+    await page.getByRole("link", { name: "Add items" }).click();
+    await expect(page.getByRole("heading", { name: "Build your list, then submit it all at once" }).first()).toBeVisible();
+
+    const itemPlans = [
+      { title: "Launch blog post", contentType: "Blog post" },
+      { title: "Changelog entry", contentType: "Changelog entry" },
+      { title: "Launch tweet", contentType: "Launch tweet" },
+    ];
+    for (const [index, plan] of itemPlans.entries()) {
+      if (index > 0) await page.getByRole("button", { name: "Add another item" }).click();
+      const row = page.locator("section").filter({ hasText: `Item ${index + 1}` }).first();
+      if (index > 0) await row.getByRole("button", { name: "Expand item" }).click();
+      await row.getByLabel("Name").fill(plan.title);
+      await row.getByRole("combobox").click();
+      await page.getByRole("option", { name: plan.contentType }).click();
+    }
+    await expect(page.getByRole("button", { name: "Submit 3 items" })).toBeEnabled();
+    await page.getByRole("button", { name: "Submit 3 items" }).click();
+
+    const draftingColumn = page.getByLabel("Drafting column");
+    await expect(draftingColumn.getByText("Launch blog post")).toBeVisible();
+    await expect(draftingColumn.getByText("Changelog entry")).toBeVisible();
+    await expect(draftingColumn.getByText("Launch tweet")).toBeVisible();
+    await expectProsumerVocabulary(page);
+
+    const items = await listItems(board, pipeline.id);
+    const blog = items.find((row) => row.case.title === "Launch blog post")?.case;
+    const changelog = items.find((row) => row.case.title === "Changelog entry")?.case;
+    const tweet = items.find((row) => row.case.title === "Launch tweet")?.case;
+    expect(blog).toBeTruthy();
+    expect(changelog).toBeTruthy();
+    expect(tweet).toBeTruthy();
+
+    const blogDragged = await dragCardToColumn(page, "Launch blog post", "Drafting", "Assets");
+    if (blogDragged) {
+      await expect(page.getByRole("heading", { name: "Move Launch blog post?" })).toBeVisible();
+      await page.getByRole("button", { name: "Move it" }).click();
+    } else {
+      await moveItem(board, blog!.id, assets!.key);
+      await page.reload();
+    }
+    await expect(page.getByLabel("Assets column").getByText("Launch blog post")).toBeVisible();
+
+    await moveItem(board, changelog!.id, assets!.key);
+    await page.reload();
+    await expect(page.getByLabel("Assets column").getByText("Changelog entry")).toBeVisible();
+
+    const tweetDragged = await dragCardToColumn(page, "Launch tweet", "Drafting", "Published");
+    const overrideReason = "Tweet can skip review because the blog post already covers the announcement.";
+    if (tweetDragged) {
+      await expect(page.getByRole("heading", { name: "This skips the normal flow" })).toBeVisible();
+      await page.getByLabel("Reason").fill(overrideReason);
+      await expect(page.getByRole("button", { name: "Override and move" })).toBeEnabled();
+      await page.getByRole("button", { name: "Override and move" }).click();
+    } else {
+      await moveItem(board, tweet!.id, published!.key, { reason: overrideReason, force: true });
+      await page.reload();
+    }
+    await expect(page.getByLabel("Published column").getByText("Launch tweet")).toBeVisible();
+    await expectProsumerVocabulary(page);
+
+    const root = await createItem(board, pipeline.id, {
+      title: "Pipeline primitives launch",
+      stageKey: "drafting",
+      fields: { content_type: "Blog post" },
+    });
+    await createItem(board, pipeline.id, {
+      title: "Launch package draft",
+      stageKey: "drafting",
+      parentCaseId: root.id,
+      fields: { content_type: "Blog post" },
+    });
+    await createItem(board, pipeline.id, {
+      title: "Launch package changelog",
+      stageKey: "drafting",
+      parentCaseId: root.id,
+      fields: { content_type: "Changelog entry" },
+    });
+    await suggestMove(board, root.id, assets!.key, "Draft is ready for the next review.");
+
+    await page.goto(`${companyPath}/pipelines/${pipeline.id}/items/${root.id}`);
+    await expect(page.getByRole("heading", { name: "Pipeline primitives launch" }).first()).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Ready to move to Assets?" })).toBeVisible();
+    await expect(page.getByText("Draft is ready for the next review.")).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Built from 2 items" })).toBeVisible();
+    await expect(page.getByText("Launch package draft")).toBeVisible();
+    await expect(page.getByText("Launch package changelog")).toBeVisible();
+    await expectProsumerVocabulary(page);
+
+    await page.getByRole("button", { name: "Approve" }).click();
+    await expect(page.getByText("Move approved")).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Ready to move to Assets?" })).toBeHidden();
+
+    await page.goto(`${companyPath}/review-queue`);
+    await expect(page.getByRole("heading", { name: "Review queue" }).first()).toBeVisible();
+    await expect(page.getByText("Needs your attention")).toBeVisible();
+    await expect(page.getByText("Final calls")).toBeVisible();
+
+    const blogRow = reviewQueueRow(page, "Launch blog post");
+    await expect(blogRow).toBeVisible();
+    await blogRow.getByRole("button", { name: "Approve", exact: true }).click();
+    await expect(blogRow).toBeHidden();
+
+    const changelogRow = reviewQueueRow(page, "Changelog entry");
+    await expect(changelogRow).toBeVisible();
+    await changelogRow.getByRole("button", { name: "Request changes" }).click();
+    const decisionDialog = page.getByRole("dialog");
+    await expect(decisionDialog).toBeVisible();
+    await decisionDialog.getByLabel("Note").fill("Tighten the framing before publishing.");
+    await decisionDialog.getByRole("button", { name: "Request changes" }).click();
+    await expect(changelogRow).toBeHidden();
+    await expectProsumerVocabulary(page);
+
+    await expect.poll(async () => {
+      const refreshed = await listItems(board, pipeline.id);
+      const approved = refreshed.find((row) => row.case.title === "Launch blog post");
+      const sentBack = refreshed.find((row) => row.case.title === "Changelog entry");
+      return {
+        approvedStage: approved?.case.stageId,
+        sentBackStage: sentBack?.case.stageId,
+      };
+    }).toEqual({
+      approvedStage: published!.id,
+      sentBackStage: configured.stages.find((stage) => stage.key === "drafting")!.id,
+    });
+
+    await page.goto(`${companyPath}/learnings`);
+    await expect(page.getByRole("heading", { name: "Learnings" }).first()).toBeVisible();
+    await expect(page.getByText("Tighten the framing before publishing.")).toBeVisible();
+    await expect(page.getByText(overrideReason)).toBeVisible();
+    await expectProsumerVocabulary(page);
+
+    await board.dispose();
+  });
+});

--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -8,7 +8,13 @@ import { defineConfig } from "@playwright/test";
 const PORT = Number(process.env.PAPERCLIP_E2E_PORT ?? 3199);
 const BASE_URL = `http://127.0.0.1:${PORT}`;
 const PAPERCLIP_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "paperclip-e2e-home-"));
+const PAPERCLIP_CONFIG = path.join(PAPERCLIP_HOME, "instances", "playwright-e2e", "config.json");
+const PAPERCLIP_AGENT_JWT_SECRET = process.env.PAPERCLIP_AGENT_JWT_SECRET ?? "playwright-e2e-agent-jwt-secret";
 const PLAYWRIGHT_CHANNEL = process.env.PAPERCLIP_PLAYWRIGHT_CHANNEL;
+
+process.env.PAPERCLIP_HOME = PAPERCLIP_HOME;
+process.env.PAPERCLIP_CONFIG = PAPERCLIP_CONFIG;
+process.env.PAPERCLIP_AGENT_JWT_SECRET = PAPERCLIP_AGENT_JWT_SECRET;
 
 export default defineConfig({
   testDir: ".",
@@ -53,6 +59,8 @@ export default defineConfig({
       ...process.env,
       PORT: String(PORT),
       PAPERCLIP_HOME,
+      PAPERCLIP_CONFIG,
+      PAPERCLIP_AGENT_JWT_SECRET,
       PAPERCLIP_INSTANCE_ID: "playwright-e2e",
       PAPERCLIP_BIND: "loopback",
       PAPERCLIP_DEPLOYMENT_MODE: "local_trusted",


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The affected surface spans database migrations, service health reporting, watchdog wake behavior, and pipeline tutorial coverage.
> - A deployment sync found local-only master commits that were not present on `origin/master`.
> - Those changes needed to move into review instead of being deployed directly from local master.
> - The migration portion also needed to be reconciled with newer upstream migration numbering so it did not collide with the current journal.
> - This pull request rebases the preserved local fixes onto current `master` and keeps the database migration sequence valid.
> - The benefit is that the recovered fixes can go through normal CI/review before any deployment picks them up.

## Linked Issues or Issue Description

No public GitHub issue exists for this recovered local-master delta.

Bug report inline description:

**Pre-submission checklist**

- [x] I have searched existing open and closed issues and this is not a duplicate.
- [x] I am on `master`.
- [x] I have confirmed the error originates in Paperclip itself, not in an agent adapter, API provider, or local configuration.

**What happened?**

A deployment sync found local-only commits on the main checkout that were not present on `origin/master`. Those commits included database migration repair work, health endpoint changes, watchdog wake behavior, and pipeline tutorial coverage. Deploying them directly from the local checkout would bypass the normal PR review path and risk migration-number drift.

**Expected behavior**

Recovered local mainline changes should be rebased onto current `master`, reviewed through a normal PR, keep migration numbering valid, and only be deployed after the PR path resolves.

**Steps to reproduce**

1. Start with a local main checkout containing commits that are ahead of and behind `origin/master`.
2. Fetch `origin/master`.
3. Compare `origin/master..HEAD` and inspect migration journal/file numbering.
4. Attempt to reconcile the preserved local commits onto current `master`.

**Paperclip version or commit**

- Base: `696c694a5`
- PR head: `b9ce15f6791bf6c27d477f9619d02d7387b9954a`

**Deployment mode**

Self-hosted server.

**Installation method**

Built from source.

**Agent adapter(s) involved**

Not adapter-specific.

**Database mode**

Embedded PGlite/Postgres migration path.

**Access context**

Board and agent control-plane surfaces.

**Node.js version**

Not adapter-specific; local verification used the repository toolchain in this checkout.

**Operating system**

Linux.

**Relevant logs or output**

```shell
pnpm --filter @paperclipai/db run check:migrations
pnpm exec vitest run packages/db/src/client.test.ts
pnpm exec vitest run server/src/__tests__/health.test.ts server/src/__tests__/task-watchdogs-scheduler.test.ts
```

**Relevant config**

Not applicable.

**Additional context**

The Playwright e2e target booted a throwaway server and applied migrations through `0134`, but the browser UI half could not run on this host because Playwright Chromium requires `libatk-1.0.so.0`, which is not installed here.

**Privacy checklist**

- [x] I have reviewed all pasted output for PII, usernames, file paths, API keys, tokens, and company names and redacted or omitted sensitive values.

## What Changed

- Added migration `0134_repair_run_responsible_user_updated_at_sweep.sql` and replay coverage for repairing bulk `updated_at` sweeps.
- Added database backup health reporting and health-route coverage.
- Deduplicated open watchdog review wakes and added scheduler coverage.
- Added pipeline tutorial e2e coverage for fan-out, drift acknowledgement, board movement, review, and learnings flows.
- Documented the pipeline tutorial smoke command.

## Verification

Passed locally:

- `pnpm --filter @paperclipai/db run check:migrations`
- `pnpm exec vitest run packages/db/src/client.test.ts`
- `pnpm exec vitest run server/src/__tests__/health.test.ts server/src/__tests__/task-watchdogs-scheduler.test.ts`

Attempted locally:

- `NODE_ENV=development pnpm exec playwright test tests/e2e/pipelines-tutorial-flow.spec.ts --config tests/e2e/playwright.config.ts`
- Result: the throwaway Paperclip server booted, migrations applied through `0134`, and the first API-heavy pipeline test passed. The browser UI test could not launch because this host is missing `libatk-1.0.so.0`, required by Playwright Chromium.

## Risks

- Migration risk: `0134` updates user-visible `updated_at` fields for rows matching a broad sweep signature; the migration safety allowlist and replay test cover the intended tables.
- Health-route risk: backup health reporting may affect `/api/health` details if backup state detection is wrong.
- Watchdog risk: deduplication could suppress a legitimate wake if open review states are misclassified.
- E2E risk: the new Playwright UI test still needs a host with complete browser dependencies or CI validation.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

OpenAI Codex, GPT-5-based coding agent with shell, git, GitHub, and local test execution capabilities.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge
