### PR TITLE
test(cli): cover project and goal delete guards

### DIFF
--- a/cli/src/__tests__/project-goal.test.ts
+++ b/cli/src/__tests__/project-goal.test.ts
@@ -65,6 +65,7 @@ describe("project and goal commands", () => {
       "project", "update", PROJECT_ID,
       "--api-base", "http://localhost:3100",
       "--api-key", "board-token",
+      "--company-id", COMPANY_ID,
       "--status", "in_progress",
     ], { from: "user" });
 
@@ -74,7 +75,7 @@ describe("project and goal commands", () => {
       status: "planned",
       goalIds: [GOAL_ID],
     });
-    expect(fetchMock.mock.calls[1]?.[0]).toBe(`http://localhost:3100/api/projects/${PROJECT_ID}`);
+    expect(fetchMock.mock.calls[1]?.[0]).toBe(`http://localhost:3100/api/projects/${PROJECT_ID}?companyId=${COMPANY_ID}`);
     expect(fetchMock.mock.calls[1]?.[1]?.method).toBe("PATCH");
   });
 
@@ -97,12 +98,32 @@ describe("project and goal commands", () => {
       "project", "delete", PROJECT_ID,
       "--api-base", "http://localhost:3100",
       "--api-key", "board-token",
+      "--company-id", COMPANY_ID,
       "--yes",
     ], { from: "user" });
 
     expect(fetchMock.mock.calls[0]?.[0]).toBe(`http://localhost:3100/api/companies/${COMPANY_ID}/projects`);
-    expect(fetchMock.mock.calls[1]?.[0]).toBe(`http://localhost:3100/api/projects/${PROJECT_ID}`);
+    expect(fetchMock.mock.calls[1]?.[0]).toBe(`http://localhost:3100/api/projects/${PROJECT_ID}?companyId=${COMPANY_ID}`);
     expect(fetchMock.mock.calls[1]?.[1]?.method).toBe("DELETE");
+  });
+
+  it("refuses to delete projects without explicit confirmation", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(JSON.stringify({ ok: true }), { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    const exit = vi.spyOn(process, "exit").mockImplementation((() => {
+      throw new Error("process.exit called");
+    }) as never);
+
+    await expect(createProgram().parseAsync([
+      "project", "delete", PROJECT_ID,
+      "--api-base", "http://localhost:3100",
+      "--api-key", "board-token",
+    ], { from: "user" })).rejects.toThrow("process.exit called");
+
+    expect(error.mock.calls[0]?.[0]).toContain("Deletion requires --yes");
+    expect(exit).toHaveBeenCalledWith(1);
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it("creates, updates, lists, and deletes goals", async () => {
@@ -152,5 +173,24 @@ describe("project and goal commands", () => {
     expect(fetchMock.mock.calls[2]?.[0]).toBe(`http://localhost:3100/api/companies/${COMPANY_ID}/goals`);
     expect(fetchMock.mock.calls[3]?.[0]).toBe(`http://localhost:3100/api/goals/${GOAL_ID}`);
     expect(fetchMock.mock.calls[3]?.[1]?.method).toBe("DELETE");
+  });
+
+  it("refuses to delete goals without explicit confirmation", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(JSON.stringify({ ok: true }), { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    const exit = vi.spyOn(process, "exit").mockImplementation((() => {
+      throw new Error("process.exit called");
+    }) as never);
+
+    await expect(createProgram().parseAsync([
+      "goal", "delete", GOAL_ID,
+      "--api-base", "http://localhost:3100",
+      "--api-key", "board-token",
+    ], { from: "user" })).rejects.toThrow("process.exit called");
+
+    expect(error.mock.calls[0]?.[0]).toContain("Deletion requires --yes");
+    expect(exit).toHaveBeenCalledWith(1);
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 });

--- a/cli/src/__tests__/project-goal.test.ts
+++ b/cli/src/__tests__/project-goal.test.ts
@@ -28,6 +28,7 @@ describe("project and goal commands", () => {
   });
 
   afterEach(() => {
+    vi.unstubAllGlobals();
     vi.restoreAllMocks();
   });
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Projects and goals are company-scoped control-plane entities.
> - Their CLI commands are useful in scripts, but destructive commands need explicit local confirmation.
> - The existing project/goal tests covered successful create/update/list/delete flows.
> - They did not directly assert that delete commands stop locally without `--yes`.
> - This pull request adds those guard tests and makes project update/delete assertions explicit about company-scoped lookup.
> - The benefit is safer scriptable project/goal lifecycle behavior without changing runtime code.

## Linked Issues or Issue Description

No public issue found. This is a test coverage improvement for existing CLI project and goal lifecycle behavior.

## What Changed

- Added coverage that `project delete` refuses to call the API without `--yes`.
- Added coverage that `goal delete` refuses to call the API without `--yes`.
- Updated project update/delete assertions to pass and expect explicit `companyId` query scoping.

## Verification

- `./node_modules/.bin/vitest run cli/src/__tests__/project-goal.test.ts --config cli/vitest.config.ts` passes: 1 file, 5 tests.

## Risks

Low risk. This is test-only coverage for existing CLI behavior.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

OpenAI GPT-5 Codex in Codex desktop, with repository inspection, shell command execution, GitHub CLI usage, and code editing tools.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g., `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge