### PR TITLE
perf(heartbeat): narrow orphan-reap + silent-run polls to avoid heartbeat_runs TOAST detox

### DIFF
--- a/server/src/__tests__/heartbeat-narrow-poll.test.ts
+++ b/server/src/__tests__/heartbeat-narrow-poll.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+// This test is a static regression guard for the heartbeat_runs narrow-poll
+// invariant introduced by commit 6f069694f (PR #9155). The candidate polls in
+// reapOrphanedRuns (server/src/services/heartbeat.ts) and scanSilentActiveRuns
+// (server/src/services/recovery/service.ts) MUST NOT project heavy TOAST
+// columns (resultJson, contextSnapshot, logStore, usageJson). Drift here is
+// the regression that re-triggers the heartbeat_runs TOAST-detox thundering
+// herd.
+//
+// We assert the invariant statically by reading the source and grep'ing for
+// `select()` patterns adjacent to `from(heartbeatRuns)`. This catches any
+// future widening back to `select().from(heartbeatRuns)` (which detoasts every
+// TOAST column) and keeps the test runner hermetic — no DB, no module-mock
+// gymnastics, no drift surface from drizzle version upgrades.
+
+const HEARTBEAT_TS = resolve(__dirname, "../services/heartbeat.ts");
+const RECOVERY_TS = resolve(__dirname, "../services/recovery/service.ts");
+const HEAVY_TOAST_COLUMNS = ["resultJson", "contextSnapshot", "logStore", "usageJson"];
+
+describe("heartbeat narrow poll — static regression guard", () => {
+  it("reapOrphanedRuns source does not project heavy TOAST columns", () => {
+    const src = readFileSync(HEARTBEAT_TS, "utf8");
+    // Find the body of reapOrphanedRuns and assert no TOAST column appears
+    // in the SELECT projection that precedes `from(heartbeatRuns)`.
+    const reapIdx = src.indexOf("async function reapOrphanedRuns");
+    expect(reapIdx, "reapOrphanedRuns should exist").toBeGreaterThan(-1);
+    // Slice to the next sibling function definition to bound the search.
+    const slice = src.slice(reapIdx, reapIdx + 4000);
+
+    // Locate the SELECT projection preceding .from(heartbeatRuns) inside this
+    // function. The narrow-poll marker comment makes this robust to edits.
+    // Source uses chained `db\n  .select({...})` — match `.select({` so the
+    // assertion is insensitive to chain-styling.
+    const selectStart = slice.indexOf(".select({");
+    expect(selectStart, "reapOrphanedRuns should call .select({").toBeGreaterThan(-1);
+    const fromIdx = slice.indexOf(".from(heartbeatRuns)", selectStart);
+    expect(fromIdx, "reapOrphanedRuns select should target heartbeatRuns").toBeGreaterThan(-1);
+
+    const projection = slice.slice(selectStart, fromIdx);
+    for (const col of HEAVY_TOAST_COLUMNS) {
+      expect(
+        projection.includes(`${col}:`),
+        `reapOrphanedRuns projection must NOT include ${col} (TOAST-heavy); ` +
+          `found in: ${projection.slice(0, 200)}…`,
+      ).toBe(false);
+    }
+
+    // Sanity: the narrow projection must still carry the columns the reap
+    // guards actually inspect.
+    expect(projection).toMatch(/id:/);
+    expect(projection).toMatch(/processPid:/);
+    expect(projection).toMatch(/processGroupId:/);
+    expect(projection).toMatch(/processLossRetryCount:/);
+  });
+
+  it("scanSilentActiveRuns source does not project heavy TOAST columns", () => {
+    const src = readFileSync(RECOVERY_TS, "utf8");
+    const scanIdx = src.indexOf("async function scanSilentActiveRuns");
+    expect(scanIdx, "scanSilentActiveRuns should exist").toBeGreaterThan(-1);
+    const slice = src.slice(scanIdx, scanIdx + 4000);
+
+    const selectStart = slice.indexOf(".select({");
+    expect(selectStart, "scanSilentActiveRuns should call .select({").toBeGreaterThan(-1);
+    const fromIdx = slice.indexOf(".from(heartbeatRuns)", selectStart);
+    expect(fromIdx, "scanSilentActiveRuns select should target heartbeatRuns").toBeGreaterThan(-1);
+
+    const projection = slice.slice(selectStart, fromIdx);
+    for (const col of HEAVY_TOAST_COLUMNS) {
+      expect(
+        projection.includes(`${col}:`),
+        `scanSilentActiveRuns projection must NOT include ${col} (TOAST-heavy); ` +
+          `found in: ${projection.slice(0, 200)}…`,
+      ).toBe(false);
+    }
+
+    // The narrow projection must still carry the columns the cheap
+    // quiet-decision guard inspects.
+    expect(projection).toMatch(/id:/);
+    expect(projection).toMatch(/companyId:/);
+  });
+});

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -10616,10 +10616,23 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     const staleThresholdMs = opts?.staleThresholdMs ?? 0;
     const now = new Date();
 
-    // Find all runs stuck in "running" state (queued runs are legitimately waiting; resumeQueuedRuns handles them)
+    // Find all runs stuck in "running" state (queued runs are legitimately waiting; resumeQueuedRuns handles them).
+    // Project only the scalar scheduling/liveness columns the reap guards inspect — selecting the full row
+    // detoasts heavy TOAST columns (resultJson, contextSnapshot, logStore, usageJson, ...) for every running
+    // row on every poll. The one heavy column actually consumed (resultJson) is re-fetched by id below, only
+    // for the small subset of rows genuinely being reaped.
     const activeRuns = await db
       .select({
-        run: heartbeatRuns,
+        run: {
+          id: heartbeatRuns.id,
+          agentId: heartbeatRuns.agentId,
+          updatedAt: heartbeatRuns.updatedAt,
+          processPid: heartbeatRuns.processPid,
+          processGroupId: heartbeatRuns.processGroupId,
+          errorCode: heartbeatRuns.errorCode,
+          processLossRetryCount: heartbeatRuns.processLossRetryCount,
+          wakeupRequestId: heartbeatRuns.wakeupRequestId,
+        },
         adapterType: agents.adapterType,
         adapterConfig: agents.adapterConfig,
       })
@@ -10685,16 +10698,20 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         }
         : null;
 
+      // The poll above omitted resultJson to avoid TOAST detox across all running rows; re-fetch the
+      // heavy row only now, for the row actually being reaped, so the stop-metadata merge is intact.
+      const heavyRun = await getRun(run.id, { unsafeFullResultJson: true });
+
       let finalizedRun = await setRunStatus(run.id, "failed", {
         error: shouldRetry ? `${baseMessage}; retrying once` : baseMessage,
         errorCode: "process_lost",
         finishedAt: now,
-        resultJson: (() => {
+resultJson: (() => {
           const result = mergeRunStopMetadataForAgent(
             { adapterType, adapterConfig },
             "failed",
             {
-              resultJson: parseObject(run.resultJson),
+              resultJson: parseObject(heavyRun?.resultJson),
               errorCode: "process_lost",
               errorMessage: shouldRetry ? `${baseMessage}; retrying once` : baseMessage,
             },

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -2012,8 +2012,12 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
   async function scanSilentActiveRuns(opts?: { now?: Date; companyId?: string; issueCreatedAtGte?: Date | null }) {
     const now = opts?.now ?? new Date();
     const suspicionBefore = new Date(now.getTime() - ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS);
-    let candidates = await db
-      .select()
+// Narrow projection: the candidate poll only needs id + companyId to run the cheap quiet-decision
+    // guard below. Selecting the full row detoasts heavy TOAST columns (contextSnapshot, resultJson,
+    // logStore, usageJson, ...) for every running row on every scan. The heavy columns are re-fetched
+    // by id only for candidates that survive the guard and are actually evaluated.
+    const candidates = await db
+      .select({ id: heartbeatRuns.id, companyId: heartbeatRuns.companyId })
       .from(heartbeatRuns)
       .where(
         and(
@@ -2026,8 +2030,19 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       .limit(100);
 
     if (opts?.issueCreatedAtGte) {
+      // The candidate poll deliberately dropped contextSnapshot to avoid TOAST detox; only the
+      // optional issueCreatedAtGte filter needs it, so re-fetch it as a targeted {id, contextSnapshot}
+      // projection for the (small) candidate set rather than detoasting every running row.
+      const candidateIds = candidates.map((run) => run.id);
+      const contextRows = candidateIds.length > 0
+        ? await db
+            .select({ id: heartbeatRuns.id, contextSnapshot: heartbeatRuns.contextSnapshot })
+            .from(heartbeatRuns)
+            .where(inArray(heartbeatRuns.id, candidateIds))
+        : [];
+      const contextById = new Map(contextRows.map((row) => [row.id, row.contextSnapshot]));
       const issueIds = [...new Set(candidates.flatMap((run) => {
-        const context = parseObject(run.contextSnapshot);
+        const context = parseObject(contextById.get(run.id));
         const issueId = context.issueId ?? context.taskId;
         return typeof issueId === "string" && issueId.length > 0 ? [issueId] : [];
       }))];
@@ -2040,7 +2055,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
           : [],
       );
       candidates = candidates.filter((run) => {
-        const context = parseObject(run.contextSnapshot);
+        const context = parseObject(contextById.get(run.id));
         const issueId = context.issueId ?? context.taskId;
         return typeof issueId === "string" && eligibleIssueIds.has(issueId);
       });
@@ -2057,9 +2072,21 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       evaluationIssueIds: [] as string[],
     };
 
-    for (const run of candidates) {
-      if (await latestActiveOutputQuietUntilDecision(run.companyId, run.id, now)) {
+    for (const candidate of candidates) {
+      if (await latestActiveOutputQuietUntilDecision(candidate.companyId, candidate.id, now)) {
         result.snoozed += 1;
+        continue;
+      }
+      // Re-fetch the full row (heavy TOAST columns) only for candidates that survive the cheap
+      // quiet-decision guard; createOrUpdateStaleRunEvaluation and its helpers read contextSnapshot,
+      // resultJson, and other TOAST columns. If the run vanished since the poll, skip it.
+      const [run] = await db
+        .select()
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.id, candidate.id))
+        .limit(1);
+      if (!run) {
+        result.skipped += 1;
         continue;
       }
       const outcome = await createOrUpdateStaleRunEvaluation({ run, now });

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -2016,7 +2016,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     // guard below. Selecting the full row detoasts heavy TOAST columns (contextSnapshot, resultJson,
     // logStore, usageJson, ...) for every running row on every scan. The heavy columns are re-fetched
     // by id only for candidates that survive the guard and are actually evaluated.
-    const candidates = await db
+    let candidates = await db
       .select({ id: heartbeatRuns.id, companyId: heartbeatRuns.companyId })
       .from(heartbeatRuns)
       .where(


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Its heartbeat subsystem periodically polls the `heartbeat_runs` table to find orphaned or stalled active runs and reconcile their state across agent backends
> - The two long-running polls — `reapOrphanedRuns` in `server/src/services/heartbeat.ts` and `scanSilentActiveRuns` in `server/src/services/recovery/service.ts` — were using a full-row projection on every iteration
> - The `heartbeat_runs` table contains several large TOAST columns (the per-run result blob, a context snapshot, a log store, a usage payload, and log/stdout excerpts) that the candidate poll never needs
> - Reading the full row detoasts those columns for **every** `status='running'` row on every poll, across every concurrent backend — a self-inflicted thundering herd against the database
> - This pull request narrows the SELECT projection to the columns each guard actually inspects, and re-fetches the heavy columns by id only for the small subset of rows that survive the guard and are being acted on
> - The benefit is a large drop in the read-side cost of the heartbeat loop and the recovery scan, without changing the predicate or the candidate set

## Linked Issues or Issue Description

No public GitHub issue exists for this — describing the bug inline following the bug-report template:

**What happened?**
The heartbeat subsystem's two long-running candidate polls over `heartbeat_runs WHERE status='running'` use a full-row projection. The `heartbeat_runs` table has several heavy TOAST columns (per-run result JSON, a context snapshot, a log store, a usage payload, and log/stdout excerpts) that the guard clauses in these polls never inspect, but PostgreSQL detoasts them anyway on every read. With ~16–17 concurrent backends polling every few seconds, this is the dominant contributor to the read-side thundering herd against the database.

**Expected behavior**
The candidate polls should project only the columns the guard clauses actually inspect. The heavy columns are only required for the small subset of rows that survive the guard and are being acted on (reaped / evaluated), and should be re-fetched by id at that point.

**Steps to reproduce**
1. Run a Paperclip deployment with many concurrent running agents (the issue scales with the number of `status='running'` rows × poll frequency).
2. Watch `EXPLAIN ANALYZE` on a representative poll against `heartbeat_runs` and observe the per-row detoast cost on `resultJson` / `contextSnapshot` / `logStore` / `usageJson`.
3. Observe the `WHERE status='running'` predicate touches a wide projection even though the surrounding code only reads a handful of scalar columns.

**Paperclip version or commit:** `master` (no released version contained the issue at the time of writing)
**Deployment mode:** All modes
**Install method:** All install methods (this is a server-side DB query, not installation-specific)

## What Changed

- **`server/src/services/heartbeat.ts` — `reapOrphanedRuns()`**: replaced the full-row `db.select().from(heartbeatRuns).innerJoin(agents, ...)` with a narrow projection carrying only the scalar scheduling/liveness columns the guard clauses inspect (`id`, `agentId`, `updatedAt`, `processPid`, `processGroupId`, `errorCode`, `processLossRetryCount`, `wakeupRequestId`, plus the joined `adapterType` / `adapterConfig`). The heavy row is re-fetched via the existing `getRun(id, { unsafeFullResultJson: true })` helper immediately before the stop-metadata merge — the one point at which `resultJson` is actually needed. Same `WHERE` / `INNER JOIN` / `process-loss retry` logic otherwise unchanged.
- **`server/src/services/recovery/service.ts` — `scanSilentActiveRuns()`**: replaced the full-row candidate poll with `db.select({ id: heartbeatRuns.id, companyId: heartbeatRuns.companyId })`. The cheap `latestActiveOutputQuietUntilDecision` guard runs against the narrow candidate first; the full row is re-fetched by id only for candidates that survive the guard and feed `createOrUpdateStaleRunEvaluation` (whose helpers legitimately read `contextSnapshot` / `resultJson`). Same `WHERE` / `ORDER BY` / `LIMIT 100` otherwise.
- **`server/src/__tests__/heartbeat-narrow-poll.test.ts` (new)**: hermetic source-grep regression guard asserting that the candidate polls in `reapOrphanedRuns` and `scanSilentActiveRuns` do **not** project any of the heavy TOAST columns (`resultJson`, `contextSnapshot`, `logStore`, `usageJson`), and that the narrow projection still carries the columns each guard actually inspects (`id`, `processPid`, `processGroupId`, `processLossRetryCount`, `companyId`). Static-source approach keeps the test hermetic — no DB, no drizzle chain mocking, no drift surface from ORM version upgrades.

## Verification

- `cd server && npx vitest run src/__tests__/heartbeat-narrow-poll.test.ts` — 2/2 pass (new regression guard)
- `cd server && npx vitest run src/__tests__/heartbeat-process-recovery.test.ts` — passes; orphan reap still finalizes process-lost runs with `resultJson` metadata intact
- `cd server && npx vitest run src/__tests__/heartbeat-active-run-output-watchdog.test.ts` — passes; silent-run scan still creates / escalates stale-run evaluations
- `cd server && tsc --noEmit` — clean for both edited files
- Manual: `EXPLAIN ANALYZE` on the new candidate query shows the predicate still matches the same set of rows, but the projected column list is now a handful of scalars rather than the full row

## Risks

Low risk.
- The candidate set is unchanged (same `WHERE` / `INNER JOIN` / `ORDER BY` / `LIMIT`); only the projection is narrowed.
- The re-fetch by id is gated to the small subset of rows that survive the guard, so the worst-case cost is one additional narrow `SELECT *` per reaped / evaluated row, and the guard is still bounded by the original poll.
- `resumeQueuedRuns()` was already narrow and is untouched; no other call sites read from these helpers' intermediate result objects.
- No schema change, no migration, no API change.

## Model Used

- Anthropic Claude Sonnet 4.6 (`claude-sonnet-4-6`) — code change, tests, and PR body authored with AI assistance under extended thinking.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge