### PR TITLE
Restore SAG-5649 ssi_explore.js Playwright tool to SSI Director toolkit

### DIFF
--- a/enrichment/package.json
+++ b/enrichment/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "commonjs"
+}

--- a/enrichment/ssi_explore.js
+++ b/enrichment/ssi_explore.js
@@ -1,0 +1,328 @@
+#!/usr/bin/env node
+"use strict";
+
+const fs = require("node:fs");
+const path = require("node:path");
+const { createRequire } = require("node:module");
+
+const REQUIRED_FIELDS = [
+  "sku",
+  "category_tag",
+  "product_name",
+  "price_per_sqft",
+  "cost_per_sqft",
+  "raw_description",
+];
+
+const DEFAULT_SELECTORS = {
+  item: "[data-ssi-product]",
+  sku: "[data-ssi-sku]",
+  category: "[data-ssi-category]",
+  name: "[data-ssi-name]",
+  price: "[data-ssi-price]",
+  cost: "[data-ssi-cost], [data-ssi-wholesale]",
+  description: "[data-ssi-description]",
+  next: "[data-ssi-next]",
+  username: 'input[name="username"], input[type="email"]',
+  password: 'input[name="password"], input[type="password"]',
+  submit: 'button[type="submit"], input[type="submit"]',
+};
+
+const DEFAULT_MAX_SKUS = 25;
+const DEFAULT_RATE_LIMIT_MS = 1000;
+
+class SecretValue {
+  constructor(value) {
+    this.value = value;
+  }
+
+  toJSON() {
+    return "[redacted]";
+  }
+}
+
+function required(env, key) {
+  const value = env[key];
+  if (!value) {
+    throw new Error(`${key} is required`);
+  }
+  return value;
+}
+
+function parseConfigFromEnv(env = process.env) {
+  const baseUrl = required(env, "SSI_BASE_URL");
+  const authStatePath = required(env, "SSI_AUTH_STATE_PATH");
+  const hasPasswordAuth = Boolean(env.SSI_USERNAME && env.SSI_PASSWORD);
+  const hasTokenAuth = Boolean(env.SSI_SESSION_TOKEN);
+
+  if (!hasPasswordAuth && !hasTokenAuth) {
+    throw new Error("SSI_USERNAME/SSI_PASSWORD or SSI_SESSION_TOKEN is required");
+  }
+
+  const auth = hasTokenAuth
+    ? { kind: "session_token", token: new SecretValue(env.SSI_SESSION_TOKEN) }
+    : {
+        kind: "password",
+        username: env.SSI_USERNAME,
+        password: new SecretValue(env.SSI_PASSWORD),
+      };
+
+  return {
+    baseUrl,
+    loginUrl: env.SSI_LOGIN_URL || baseUrl,
+    authStatePath,
+    auth,
+    selectors: {
+      item: env.SSI_PRODUCT_SELECTOR || DEFAULT_SELECTORS.item,
+      sku: env.SSI_SKU_SELECTOR || DEFAULT_SELECTORS.sku,
+      category: env.SSI_CATEGORY_SELECTOR || DEFAULT_SELECTORS.category,
+      name: env.SSI_NAME_SELECTOR || DEFAULT_SELECTORS.name,
+      price: env.SSI_PRICE_SELECTOR || DEFAULT_SELECTORS.price,
+      cost: env.SSI_COST_SELECTOR || DEFAULT_SELECTORS.cost,
+      description: env.SSI_DESCRIPTION_SELECTOR || DEFAULT_SELECTORS.description,
+      next: env.SSI_NEXT_SELECTOR || DEFAULT_SELECTORS.next,
+      username: env.SSI_USERNAME_SELECTOR || DEFAULT_SELECTORS.username,
+      password: env.SSI_PASSWORD_SELECTOR || DEFAULT_SELECTORS.password,
+      submit: env.SSI_SUBMIT_SELECTOR || DEFAULT_SELECTORS.submit,
+    },
+  };
+}
+
+function positiveIntFromEnv(env, key, fallback) {
+  const raw = env[key];
+  if (raw == null || raw === "") {
+    return fallback;
+  }
+  const value = Number(raw);
+  if (!Number.isInteger(value) || value <= 0) {
+    throw new Error(`${key} must be a positive integer`);
+  }
+  return value;
+}
+
+function buildRunGuards(env = process.env) {
+  return {
+    maxSkus: positiveIntFromEnv(env, "SSI_MAX_SKUS", DEFAULT_MAX_SKUS),
+    rateLimitMs: positiveIntFromEnv(env, "SSI_RATE_LIMIT_MS", DEFAULT_RATE_LIMIT_MS),
+    singleSession: true,
+    readOnly: true,
+  };
+}
+
+function parseMoney(value) {
+  if (value == null || value === "") {
+    return null;
+  }
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? value : null;
+  }
+  const match = String(value).replace(/,/g, "").match(/-?\d+(?:\.\d+)?/);
+  return match ? Number(match[0]) : null;
+}
+
+function firstPresent(source, keys) {
+  for (const key of keys) {
+    if (source[key] != null && source[key] !== "") {
+      return source[key];
+    }
+  }
+  return "";
+}
+
+function normalizeItem(item) {
+  return {
+    sku: String(firstPresent(item, ["sku", "SKU", "source_row_id"])).trim(),
+    category_tag: String(firstPresent(item, ["category_tag", "categoryTag", "category"])).trim(),
+    product_name: String(firstPresent(item, ["product_name", "productName", "name"])).trim(),
+    price_per_sqft: parseMoney(firstPresent(item, ["price_per_sqft", "pricePerSqft", "price"])),
+    cost_per_sqft: parseMoney(firstPresent(item, ["cost_per_sqft", "costPerSqft", "cost", "wholesale"])),
+    raw_description: String(firstPresent(item, ["raw_description", "rawDescription", "description"])).trim(),
+  };
+}
+
+function buildCatalogOutput(items) {
+  const rows = items.map(normalizeItem).map((row) =>
+    REQUIRED_FIELDS.reduce((out, field) => {
+      out[field] = row[field];
+      return out;
+    }, {})
+  );
+  const missingCostSkus = rows
+    .filter((row) => row.cost_per_sqft == null)
+    .map((row) => row.sku || "(missing sku)");
+
+  return {
+    rows,
+    halt: missingCostSkus.length > 0,
+    missingCostSkus,
+  };
+}
+
+function serializeRows(rows) {
+  return `${JSON.stringify(rows, null, 2)}\n`;
+}
+
+async function sleep(ms) {
+  if (ms > 0) {
+    await new Promise((resolve) => setTimeout(resolve, ms));
+  }
+}
+
+function unsafeMethod(method) {
+  return !["GET", "HEAD", "OPTIONS"].includes(method.toUpperCase());
+}
+
+function sameOriginAndPath(url, expectedUrl) {
+  try {
+    const parsed = new URL(url);
+    const expected = new URL(expectedUrl);
+    return parsed.origin === expected.origin && parsed.pathname === expected.pathname;
+  } catch (_err) {
+    return url === expectedUrl;
+  }
+}
+
+async function installReadOnlyRouteGuard(context, loginUrl) {
+  await context.route("**/*", async (route) => {
+    const request = route.request();
+    if (!unsafeMethod(request.method())) {
+      await route.continue();
+      return;
+    }
+    if (request.method().toUpperCase() === "POST" && sameOriginAndPath(request.url(), loginUrl)) {
+      await route.continue();
+      return;
+    }
+    await route.abort("blockedbyclient");
+  });
+}
+
+function loadPlaywright() {
+  const attempts = [
+    () => require("playwright"),
+    () => createRequire(path.join(process.cwd(), "dispatcher", "package.json"))("playwright"),
+    () => createRequire(path.join(process.cwd(), "review-ui", "package.json"))("playwright"),
+  ];
+  for (const attempt of attempts) {
+    try {
+      return attempt();
+    } catch (_err) {
+      // Try the next local package that may already have Playwright installed.
+    }
+  }
+  throw new Error("Playwright is required for live SSI exploration but was not found");
+}
+
+async function authenticate(page, context, config) {
+  if (config.auth.kind === "session_token") {
+    await context.setExtraHTTPHeaders({
+      Authorization: `Bearer ${config.auth.token.value}`,
+    });
+    return;
+  }
+
+  await page.goto(config.loginUrl, { waitUntil: "domcontentloaded" });
+  await page.locator(config.selectors.username).fill(config.auth.username);
+  await page.locator(config.selectors.password).fill(config.auth.password.value);
+  await Promise.all([
+    page.waitForLoadState("networkidle").catch(() => undefined),
+    page.locator(config.selectors.submit).click(),
+  ]);
+}
+
+async function extractCatalogItems(page, config, guards) {
+  const items = [];
+
+  while (items.length < guards.maxSkus) {
+    await page.waitForSelector(config.selectors.item, { timeout: 15000 });
+    const pageItems = await page.$$eval(
+      config.selectors.item,
+      (nodes, selectors) => {
+        const text = (root, selector) => {
+          const found = root.querySelector(selector);
+          return found ? found.textContent.trim() : "";
+        };
+        return nodes.map((node) => ({
+          sku: text(node, selectors.sku),
+          category_tag: text(node, selectors.category),
+          product_name: text(node, selectors.name),
+          price_per_sqft: text(node, selectors.price),
+          cost_per_sqft: text(node, selectors.cost),
+          raw_description: text(node, selectors.description),
+        }));
+      },
+      config.selectors
+    );
+    items.push(...pageItems.slice(0, guards.maxSkus - items.length));
+
+    const next = page.locator(config.selectors.next).first();
+    if ((await next.count()) === 0 || items.length >= guards.maxSkus) {
+      break;
+    }
+    const disabled = await next.evaluate((node) =>
+      node.hasAttribute("disabled") || node.getAttribute("aria-disabled") === "true"
+    );
+    if (disabled) {
+      break;
+    }
+    await sleep(guards.rateLimitMs);
+    await Promise.all([
+      page.waitForLoadState("domcontentloaded").catch(() => undefined),
+      next.click(),
+    ]);
+  }
+
+  return items;
+}
+
+async function runLive() {
+  const config = parseConfigFromEnv();
+  const guards = buildRunGuards();
+  const { chromium } = loadPlaywright();
+  const storageState = fs.existsSync(config.authStatePath) ? config.authStatePath : undefined;
+  const browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext({ storageState });
+  await installReadOnlyRouteGuard(context, config.loginUrl);
+
+  try {
+    const page = await context.newPage();
+    await authenticate(page, context, config);
+    await page.goto(config.baseUrl, { waitUntil: "domcontentloaded" });
+    const items = await extractCatalogItems(page, config, guards);
+    await fs.promises.mkdir(path.dirname(config.authStatePath), { recursive: true });
+    await context.storageState({ path: config.authStatePath });
+
+    const output = buildCatalogOutput(items);
+    process.stdout.write(serializeRows(output.rows));
+    if (output.halt) {
+      process.stderr.write(
+        `HALT: missing SSI cost_per_sqft for SKU(s): ${output.missingCostSkus.join(", ")}\n`
+      );
+      return 2;
+    }
+    return 0;
+  } finally {
+    await browser.close();
+  }
+}
+
+if (require.main === module) {
+  runLive()
+    .then((code) => {
+      process.exitCode = code;
+    })
+    .catch((err) => {
+      process.stderr.write(`${err.message}\n`);
+      process.exitCode = 1;
+    });
+}
+
+module.exports = {
+  REQUIRED_FIELDS,
+  buildCatalogOutput,
+  buildRunGuards,
+  parseConfigFromEnv,
+  serializeRows,
+  installReadOnlyRouteGuard,
+  loadPlaywright,
+};

--- a/enrichment/ssi_explore_selector_validation.md
+++ b/enrichment/ssi_explore_selector_validation.md
@@ -1,0 +1,12 @@
+# SSI Explore Selector Validation
+
+SAG-5649 built the fixture-testable `ssi_explore.js` path without live SSI
+credentials. The remaining live-DOM selector validation is intentionally
+deferred until the operator injects `SSI_BASE_URL`, one supported auth method
+(`SSI_USERNAME` + `SSI_PASSWORD`, or `SSI_SESSION_TOKEN`), and
+`SSI_AUTH_STATE_PATH` into the SSI Director runtime.
+
+The script is read-only after login: non-GET/HEAD/OPTIONS requests are aborted
+except the configured login POST. If live SSI selectors differ from the default
+`data-ssi-*` selectors, provide the `SSI_*_SELECTOR` env overrides documented in
+`parseConfigFromEnv`.

--- a/enrichment/test_ssi_explore.js
+++ b/enrichment/test_ssi_explore.js
@@ -1,0 +1,132 @@
+const assert = require("node:assert/strict");
+const test = require("node:test");
+
+const {
+  REQUIRED_FIELDS,
+  buildCatalogOutput,
+  buildRunGuards,
+  installReadOnlyRouteGuard,
+  parseConfigFromEnv,
+  serializeRows,
+} = require("./ssi_explore.js");
+
+const completeItem = {
+  sku: "SSI-QTZ-001",
+  category_tag: "quartz",
+  product_name: "Arctic White",
+  price_per_sqft: "$42.50",
+  cost_per_sqft: "$28.00",
+  raw_description: "Polished quartz slab",
+};
+
+test("serializes the exact six-field seeder schema", () => {
+  const output = buildCatalogOutput([completeItem]);
+
+  assert.equal(output.halt, false);
+  assert.deepEqual(Object.keys(output.rows[0]), REQUIRED_FIELDS);
+  assert.deepEqual(output.rows[0], {
+    sku: "SSI-QTZ-001",
+    category_tag: "quartz",
+    product_name: "Arctic White",
+    price_per_sqft: 42.5,
+    cost_per_sqft: 28,
+    raw_description: "Polished quartz slab",
+  });
+
+  const parsed = JSON.parse(serializeRows(output.rows));
+  assert.deepEqual(parsed, output.rows);
+});
+
+test("halts and reports SKUs when SSI cost is missing, without fabricating cost", () => {
+  const output = buildCatalogOutput([
+    completeItem,
+    { ...completeItem, sku: "SSI-QTZ-002", cost_per_sqft: "" },
+  ]);
+
+  assert.equal(output.halt, true);
+  assert.deepEqual(output.missingCostSkus, ["SSI-QTZ-002"]);
+  assert.equal(output.rows[1].cost_per_sqft, null);
+});
+
+test("parses username/password credential contract without exposing secret values", () => {
+  const config = parseConfigFromEnv({
+    SSI_BASE_URL: "https://ssi.example.test/catalog",
+    SSI_USERNAME: "operator@example.test",
+    SSI_PASSWORD: "secret-password",
+    SSI_AUTH_STATE_PATH: "tmp/ssi-auth-state.json",
+  });
+
+  assert.equal(config.baseUrl, "https://ssi.example.test/catalog");
+  assert.equal(config.auth.kind, "password");
+  assert.equal(config.auth.username, "operator@example.test");
+  assert.equal(config.authStatePath, "tmp/ssi-auth-state.json");
+  assert.equal(JSON.stringify(config).includes("secret-password"), false);
+});
+
+test("parses session-token auth and fast-fails on missing credentials", () => {
+  const tokenConfig = parseConfigFromEnv({
+    SSI_BASE_URL: "https://ssi.example.test",
+    SSI_SESSION_TOKEN: "session-token-value",
+    SSI_AUTH_STATE_PATH: "tmp/ssi-auth-state.json",
+  });
+
+  assert.equal(tokenConfig.auth.kind, "session_token");
+  assert.equal(JSON.stringify(tokenConfig).includes("session-token-value"), false);
+
+  assert.throws(
+    () =>
+      parseConfigFromEnv({
+        SSI_BASE_URL: "https://ssi.example.test",
+        SSI_AUTH_STATE_PATH: "tmp/ssi-auth-state.json",
+      }),
+    /SSI_USERNAME\/SSI_PASSWORD or SSI_SESSION_TOKEN/
+  );
+});
+
+test("run guards are bounded, rate-limited, single-session, and read-only", () => {
+  const guards = buildRunGuards({ SSI_MAX_SKUS: "12", SSI_RATE_LIMIT_MS: "1500" });
+
+  assert.deepEqual(guards, {
+    maxSkus: 12,
+    rateLimitMs: 1500,
+    singleSession: true,
+    readOnly: true,
+  });
+
+  assert.throws(() => buildRunGuards({ SSI_MAX_SKUS: "0" }), /SSI_MAX_SKUS/);
+  assert.throws(() => buildRunGuards({ SSI_RATE_LIMIT_MS: "-1" }), /SSI_RATE_LIMIT_MS/);
+});
+
+test("read-only route guard allows only exact login POST and blocks nearby mutation POSTs", async () => {
+  let routeHandler;
+  const context = {
+    async route(pattern, handler) {
+      assert.equal(pattern, "**/*");
+      routeHandler = handler;
+    },
+  };
+  await installReadOnlyRouteGuard(context, "https://ssi.example.test/catalog");
+
+  const routeRequest = async (method, url) => {
+    const actions = [];
+    await routeHandler({
+      request: () => ({ method: () => method, url: () => url }),
+      continue: async () => actions.push("continue"),
+      abort: async (reason) => actions.push(`abort:${reason}`),
+    });
+    return actions;
+  };
+
+  assert.deepEqual(
+    await routeRequest("GET", "https://ssi.example.test/catalog/update"),
+    ["continue"]
+  );
+  assert.deepEqual(
+    await routeRequest("POST", "https://ssi.example.test/catalog"),
+    ["continue"]
+  );
+  assert.deepEqual(
+    await routeRequest("POST", "https://ssi.example.test/catalog/update"),
+    ["abort:blockedbyclient"]
+  );
+});


### PR DESCRIPTION
SAG-6383

## Root cause
The SSI Director's own `AGENTS.md` claims `ssi-explore.js` "lives in your private toolkit," but that claim was never true: the SAG-5649 artifact only ever existed as an **untracked** scratch file in an unrelated ephemeral Director-of-Engineering workspace (branch `feature/SAG-5138-canary-remediation`, created 2026-07-02, `git status` showed `??`). It was never `git add`'ed, never committed, never merged to origin or fork on any branch. The SSI Director's actual runtime workspace is empty, and its instructions repo has only ever tracked `AGENTS.md` (single commit, SAG-2191). So this is a genuine gap, not a naming mismatch.

## What this PR does
- Restores the fixture-tested `enrichment/ssi_explore.js` source (Playwright-based, read-only route guard, credential values wrapped in a `SecretValue` redaction class, all `SSI_*` creds read from env at call time — nothing hardcoded).
- Restores its companion `test_ssi_explore.js` (6/6 passing via `node --test`) and `ssi_explore_selector_validation.md`.
- Adds a scoped `enrichment/package.json` (`{"type": "commonjs"}`) since the repo root declares `"type": "module"` and this tool uses CommonJS `require`/`module.exports`.

## Explicitly out of scope
This PR does not perform a live SSI login/pull and does not touch `SSI_*` credentials. Per SAG-6383's scope guard, a live pull remains board-HELD (2026-07-05) pending operator credential injection and the SAG-5660 trust-boundary defect. Landing this file is necessary but not sufficient to unblock that.

## Follow-up needed (not in this PR)
Once merged, the SSI Director needs its reachable-toolkit wiring updated to point at this path (its `AGENTS.md` currently says `ssi-explore.js`, hyphen, with no path) — flagging as a follow-up rather than editing another agent's instructions directly in this PR.

No self-merge — requesting review per SAG-6383 instructions.