### PR TITLE
fix(ui): mount plugin detail tabs on agents

### DIFF
--- a/ui/src/lib/agent-detail-tabs.test.ts
+++ b/ui/src/lib/agent-detail-tabs.test.ts
@@ -1,11 +1,18 @@
 import { describe, expect, it } from "vitest";
-import { isAgentPluginDetailView, parseAgentDetailView } from "./agent-detail-tabs";
+import { isAgentPluginDetailView, parseAgentDetailView, resolveCanonicalAgentTab } from "./agent-detail-tabs";
 
 describe("agent detail tabs", () => {
   it("preserves a plugin tab route instead of redirecting it to the dashboard", () => {
     const tab = "plugin:costs:agent-costs";
     expect(isAgentPluginDetailView(tab)).toBe(true);
     expect(parseAgentDetailView(tab)).toBe(tab);
+  });
+
+  it("defers plugin deep links while slots load, then rejects stale tabs", () => {
+    const tab = "plugin:costs:agent-costs" as const;
+    expect(resolveCanonicalAgentTab(tab, true, new Set())).toBeNull();
+    expect(resolveCanonicalAgentTab(tab, false, new Set([tab]))).toBe(tab);
+    expect(resolveCanonicalAgentTab(tab, false, new Set())).toBe("dashboard");
   });
 
   it("keeps existing aliases and falls unknown routes back to dashboard", () => {

--- a/ui/src/lib/agent-detail-tabs.test.ts
+++ b/ui/src/lib/agent-detail-tabs.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { isAgentPluginDetailView, parseAgentDetailView } from "./agent-detail-tabs";
+
+describe("agent detail tabs", () => {
+  it("preserves a plugin tab route instead of redirecting it to the dashboard", () => {
+    const tab = "plugin:costs:agent-costs";
+    expect(isAgentPluginDetailView(tab)).toBe(true);
+    expect(parseAgentDetailView(tab)).toBe(tab);
+  });
+
+  it("keeps existing aliases and falls unknown routes back to dashboard", () => {
+    expect(parseAgentDetailView("prompts")).toBe("instructions");
+    expect(parseAgentDetailView("configure")).toBe("configuration");
+    expect(parseAgentDetailView("unknown")).toBe("dashboard");
+  });
+});

--- a/ui/src/lib/agent-detail-tabs.test.ts
+++ b/ui/src/lib/agent-detail-tabs.test.ts
@@ -1,11 +1,16 @@
 import { describe, expect, it } from "vitest";
-import { isAgentPluginDetailView, parseAgentDetailView, resolveCanonicalAgentTab } from "./agent-detail-tabs";
+import { agentDetailTabPath, isAgentPluginDetailView, parseAgentDetailView, resolveCanonicalAgentTab } from "./agent-detail-tabs";
 
 describe("agent detail tabs", () => {
   it("preserves a plugin tab route instead of redirecting it to the dashboard", () => {
     const tab = "plugin:costs:agent-costs";
     expect(isAgentPluginDetailView(tab)).toBe(true);
     expect(parseAgentDetailView(tab)).toBe(tab);
+  });
+
+  it("encodes scoped plugin keys as one route segment", () => {
+    expect(agentDetailTabPath("demo-agent", "plugin:@scope/name:costs"))
+      .toBe("/agents/demo-agent/plugin%3A%40scope%2Fname%3Acosts");
   });
 
   it("defers plugin deep links while slots load, then rejects stale tabs", () => {

--- a/ui/src/lib/agent-detail-tabs.ts
+++ b/ui/src/lib/agent-detail-tabs.ts
@@ -1,0 +1,17 @@
+export type AgentBaseDetailView = "dashboard" | "instructions" | "configuration" | "skills" | "runs" | "budget";
+export type AgentPluginDetailView = `plugin:${string}`;
+export type AgentDetailView = AgentBaseDetailView | AgentPluginDetailView;
+
+export function isAgentPluginDetailView(value: string | null): value is AgentPluginDetailView {
+  return typeof value === "string" && value.startsWith("plugin:");
+}
+
+export function parseAgentDetailView(value: string | null): AgentDetailView {
+  if (isAgentPluginDetailView(value)) return value;
+  if (value === "instructions" || value === "prompts") return "instructions";
+  if (value === "configure" || value === "configuration") return "configuration";
+  if (value === "skills") return "skills";
+  if (value === "budget") return "budget";
+  if (value === "runs") return value;
+  return "dashboard";
+}

--- a/ui/src/lib/agent-detail-tabs.ts
+++ b/ui/src/lib/agent-detail-tabs.ts
@@ -16,6 +16,10 @@ export function parseAgentDetailView(value: string | null): AgentDetailView {
   return "dashboard";
 }
 
+export function agentDetailTabPath(agentRef: string, tab: string): string {
+  return `/agents/${agentRef}/${encodeURIComponent(tab)}`;
+}
+
 export function resolveCanonicalAgentTab(
   activeView: AgentDetailView,
   pluginSlotsLoading: boolean,

--- a/ui/src/lib/agent-detail-tabs.ts
+++ b/ui/src/lib/agent-detail-tabs.ts
@@ -15,3 +15,13 @@ export function parseAgentDetailView(value: string | null): AgentDetailView {
   if (value === "runs") return value;
   return "dashboard";
 }
+
+export function resolveCanonicalAgentTab(
+  activeView: AgentDetailView,
+  pluginSlotsLoading: boolean,
+  availablePluginTabs: ReadonlySet<string>
+): AgentDetailView | null {
+  if (!isAgentPluginDetailView(activeView)) return activeView;
+  if (pluginSlotsLoading) return null;
+  return availablePluginTabs.has(activeView) ? activeView : "dashboard";
+}

--- a/ui/src/pages/AgentDetail.tsx
+++ b/ui/src/pages/AgentDetail.tsx
@@ -53,10 +53,17 @@ import { buildSameOriginWebSocketUrl } from "../lib/websocket-url";
 import { formatCents, formatDate, relativeTime, formatTokens, visibleRunCostUsd } from "../lib/utils";
 import { cn } from "../lib/utils";
 import { describeRunRetryState } from "../lib/runRetryState";
+import {
+  isAgentPluginDetailView,
+  parseAgentDetailView,
+  type AgentDetailView,
+  type AgentPluginDetailView,
+} from "../lib/agent-detail-tabs";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Tabs } from "@/components/ui/tabs";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { PluginSlotMount, usePluginSlots } from "@/plugins/slots";
 import {
   CheckCircle2,
   XCircle,
@@ -252,17 +259,6 @@ function scrollToContainerBottom(container: ScrollContainer, behavior: ScrollBeh
   }
 
   container.scrollTo({ top: container.scrollHeight, behavior });
-}
-
-type AgentDetailView = "dashboard" | "instructions" | "configuration" | "skills" | "runs" | "budget";
-
-function parseAgentDetailView(value: string | null): AgentDetailView {
-  if (value === "instructions" || value === "prompts") return "instructions";
-  if (value === "configure" || value === "configuration") return "configuration";
-  if (value === "skills") return "skills";
-  if (value === "budget") return "budget";
-  if (value === "runs") return value;
-  return "dashboard";
 }
 
 function usageNumber(usage: Record<string, unknown> | null, ...keys: string[]) {
@@ -709,6 +705,21 @@ export function AgentDetail() {
   const canonicalAgentRef = agent ? agentRouteRef(agent) : routeAgentRef;
   const agentLookupRef = agent?.id ?? routeAgentRef;
   const resolvedAgentId = agent?.id ?? null;
+  const { slots: pluginDetailSlots } = usePluginSlots({
+    slotTypes: ["detailTab"],
+    entityType: "agent",
+    companyId: resolvedCompanyId,
+    enabled: Boolean(resolvedCompanyId),
+  });
+  const pluginTabItems = useMemo(
+    () => pluginDetailSlots.map((slot) => ({
+      value: `plugin:${slot.pluginKey}:${slot.id}` as AgentPluginDetailView,
+      label: slot.displayName,
+      slot,
+    })),
+    [pluginDetailSlots],
+  );
+  const activePluginTab = pluginTabItems.find((item) => item.value === activeView) ?? null;
   const membershipsQuery = useResourceMemberships(resolvedCompanyId);
   const membershipMutation = useResourceMembershipMutation(resolvedCompanyId);
   const agentMembershipState = resolvedAgentId
@@ -806,7 +817,9 @@ export function AgentDetail() {
               ? "runs"
               : activeView === "budget"
                 ? "budget"
-              : "dashboard";
+                : isAgentPluginDetailView(activeView)
+                  ? activeView
+                  : "dashboard";
     if (routeAgentRef !== canonicalAgentRef || urlTab !== canonicalTab) {
       navigate(`/agents/${canonicalAgentRef}/${canonicalTab}`, { replace: true });
       return;
@@ -913,12 +926,14 @@ export function AgentDetail() {
         crumbs.push({ label: "Runs" });
       } else if (activeView === "budget") {
         crumbs.push({ label: "Budget" });
+      } else if (isAgentPluginDetailView(activeView)) {
+        crumbs.push({ label: activePluginTab?.label ?? "Plugin" });
       } else {
         crumbs.push({ label: "Dashboard" });
       }
     }
     setBreadcrumbs(crumbs);
-  }, [setBreadcrumbs, agent, routeAgentRef, canonicalAgentRef, activeView, urlRunId]);
+  }, [setBreadcrumbs, agent, routeAgentRef, canonicalAgentRef, activeView, activePluginTab?.label, urlRunId]);
 
   useEffect(() => {
     closePanel();
@@ -1089,6 +1104,7 @@ export function AgentDetail() {
               { value: "configuration", label: "Configuration" },
               { value: "runs", label: "Runs" },
               { value: "budget", label: "Budget" },
+              ...pluginTabItems.map(({ value, label }) => ({ value, label })),
             ]}
             value={activeView}
             onValueChange={(value) => navigate(`/agents/${canonicalAgentRef}/${value}`)}
@@ -1225,6 +1241,19 @@ export function AgentDetail() {
             variant="plain"
           />
         </div>
+      ) : null}
+
+      {activePluginTab && resolvedCompanyId ? (
+        <PluginSlotMount
+          slot={activePluginTab.slot}
+          context={{
+            companyId: resolvedCompanyId,
+            companyPrefix: companyPrefix ?? null,
+            entityId: agent.id,
+            entityType: "agent",
+          }}
+          missingBehavior="placeholder"
+        />
       ) : null}
     </div>
   );

--- a/ui/src/pages/AgentDetail.tsx
+++ b/ui/src/pages/AgentDetail.tsx
@@ -56,6 +56,7 @@ import { describeRunRetryState } from "../lib/runRetryState";
 import {
   isAgentPluginDetailView,
   parseAgentDetailView,
+  resolveCanonicalAgentTab,
   type AgentDetailView,
   type AgentPluginDetailView,
 } from "../lib/agent-detail-tabs";
@@ -705,7 +706,7 @@ export function AgentDetail() {
   const canonicalAgentRef = agent ? agentRouteRef(agent) : routeAgentRef;
   const agentLookupRef = agent?.id ?? routeAgentRef;
   const resolvedAgentId = agent?.id ?? null;
-  const { slots: pluginDetailSlots } = usePluginSlots({
+  const { slots: pluginDetailSlots, isLoading: pluginDetailSlotsLoading } = usePluginSlots({
     slotTypes: ["detailTab"],
     entityType: "agent",
     companyId: resolvedCompanyId,
@@ -806,25 +807,27 @@ export function AgentDetail() {
       }
       return;
     }
-    const canonicalTab =
-      activeView === "instructions"
-        ? "instructions"
-        : activeView === "configuration"
-          ? "configuration"
-          : activeView === "skills"
-            ? "skills"
-            : activeView === "runs"
-              ? "runs"
-              : activeView === "budget"
-                ? "budget"
-                : isAgentPluginDetailView(activeView)
-                  ? activeView
-                  : "dashboard";
+    const canonicalTab = resolveCanonicalAgentTab(
+      activeView,
+      pluginDetailSlotsLoading,
+      new Set(pluginTabItems.map((item) => item.value)),
+    );
+    if (canonicalTab === null) return;
     if (routeAgentRef !== canonicalAgentRef || urlTab !== canonicalTab) {
       navigate(`/agents/${canonicalAgentRef}/${canonicalTab}`, { replace: true });
       return;
     }
-  }, [agent, routeAgentRef, canonicalAgentRef, urlRunId, urlTab, activeView, navigate]);
+  }, [
+    agent,
+    routeAgentRef,
+    canonicalAgentRef,
+    urlRunId,
+    urlTab,
+    activeView,
+    pluginDetailSlotsLoading,
+    pluginTabItems,
+    navigate,
+  ]);
 
   useEffect(() => {
     if (!agent?.companyId || agent.companyId === selectedCompanyId) return;

--- a/ui/src/pages/AgentDetail.tsx
+++ b/ui/src/pages/AgentDetail.tsx
@@ -54,6 +54,7 @@ import { formatCents, formatDate, relativeTime, formatTokens, visibleRunCostUsd 
 import { cn } from "../lib/utils";
 import { describeRunRetryState } from "../lib/runRetryState";
 import {
+  agentDetailTabPath,
   isAgentPluginDetailView,
   parseAgentDetailView,
   resolveCanonicalAgentTab,
@@ -814,7 +815,7 @@ export function AgentDetail() {
     );
     if (canonicalTab === null) return;
     if (routeAgentRef !== canonicalAgentRef || urlTab !== canonicalTab) {
-      navigate(`/agents/${canonicalAgentRef}/${canonicalTab}`, { replace: true });
+      navigate(agentDetailTabPath(canonicalAgentRef, canonicalTab), { replace: true });
       return;
     }
   }, [
@@ -1097,7 +1098,7 @@ export function AgentDetail() {
       {!urlRunId && (
         <Tabs
           value={activeView}
-          onValueChange={(value) => navigate(`/agents/${canonicalAgentRef}/${value}`)}
+          onValueChange={(value) => navigate(agentDetailTabPath(canonicalAgentRef, value))}
         >
           <PageTabBar
             items={[
@@ -1110,7 +1111,7 @@ export function AgentDetail() {
               ...pluginTabItems.map(({ value, label }) => ({ value, label })),
             ]}
             value={activeView}
-            onValueChange={(value) => navigate(`/agents/${canonicalAgentRef}/${value}`)}
+            onValueChange={(value) => navigate(agentDetailTabPath(canonicalAgentRef, value))}
           />
         </Tabs>
       )}


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open-source control plane people use to manage AI agents and their work.
> - Plugins can extend entity detail pages through isolated `detailTab` contributions.
> - The shared plugin contract accepts agent-scoped detail tabs, and project pages already mount the same contribution type.
> - The agent detail page does not discover or mount those declared slots, so valid plugin functionality is silently unavailable.
> - The host should use its existing generic plugin-slot machinery rather than add plugin-specific UI behavior.
> - This pull request adds the missing agent-detail mount, preserves valid deep links, and rejects stale routes after discovery.
> - The benefit is consistent plugin extensibility across supported entity detail surfaces with a small, generic host change.

## Linked Issues or Issue Description

Refs #2798
Refs #9101

The focused agent-detail work in #2798 was closed with unresolved review feedback. #9101 bundled similar work with unrelated changes. This PR supersedes only that focused portion and incorporates route, breadcrumb, encoding, and stale-link fixes with dedicated tests.

**Bug description**

A plugin can install successfully with a `detailTab` declaration whose `entityTypes` contains `agent`, but the tab never appears because `AgentDetail` does not discover or mount agent slots.

**Expected behavior**

Agent-scoped plugin detail tabs should appear, support direct links, contribute breadcrumbs, and render through the same isolated `PluginSlotMount` used by other plugin surfaces.

**Reproduction**

1. Install a plugin declaring a `detailTab` for `entityTypes: ["agent"]`.
2. Open an agent detail page.
3. Observe that only built-in tabs appear.

**Environment**

Current `master`, local source build, Board UI. The issue is independent of adapter and database configuration.

## What Changed

- Discover company-scoped agent `detailTab` contributions with `usePluginSlots`.
- Append discovered contributions to the agent tab bar and breadcrumb.
- Mount the selected contribution through the standard isolated `PluginSlotMount` with agent entity context.
- Preserve valid plugin deep links while discovery is loading and redirect removed or stale plugin routes afterward.
- Encode plugin route values as a single URL segment, including scoped plugin keys.
- Add focused route-resolution tests covering valid, stale, loading, encoded, and legacy paths.

## Verification

- `pnpm --filter @paperclipai/ui typecheck`
- `pnpm exec vitest run ui/src/lib/agent-detail-tabs.test.ts`
- Disposable local source verification confirmed:
  - no contributed tab before plugin installation;
  - the contributed tab after installation;
  - selected-tab and breadcrumb state;
  - isolated plugin rendering;
  - valid deep-link preservation.
- PR CI covers build, typecheck, server/workspace tests, serialized suites, security, and browser E2E.

### Visual verification

**Before — built-in agent tabs only**

![Agent detail before plugin installation](https://raw.githubusercontent.com/alvarosanchez/paperclip/pr-assets-9166/before.png)

**After — contributed Enterprise costs tab visible**

![Agent detail with contributed plugin tab](https://raw.githubusercontent.com/alvarosanchez/paperclip/pr-assets-9166/after-tab.png)

**Selected — breadcrumb and isolated mount**

![Selected agent plugin tab and isolated mount](https://raw.githubusercontent.com/alvarosanchez/paperclip/pr-assets-9166/selected-mount.png)

## Risks

Low risk. The change is additive when no agent detail slots exist. Discovery remains company-scoped, plugin UI remains isolated by the existing mount, and stale or removed plugin URLs fall back to Dashboard instead of leaving an empty page. The main behavioral risk is route canonicalization while asynchronous slot discovery is pending; focused tests cover that transition.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

OpenAI Codex, exact model ID `gpt-5.6-sol`, with tool use, code execution, repository inspection, and independent automated review.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

---
###### ✨ This message was AI-generated using gpt-5.6-sol