### PR TITLE
fix(claude-local): trust subtype=success final result over non-zero exit code

### DIFF
--- a/packages/adapters/claude-local/src/server/execute.result.test.ts
+++ b/packages/adapters/claude-local/src/server/execute.result.test.ts
@@ -1,0 +1,140 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { runChildProcess, ensureCommandResolvable, resolveCommandForLogs } = vi.hoisted(() => ({
+  runChildProcess: vi.fn(async () => ({
+    exitCode: 0,
+    signal: null,
+    timedOut: false,
+    stdout: "",
+    stderr: "",
+    pid: 123,
+    startedAt: new Date().toISOString(),
+  })),
+  ensureCommandResolvable: vi.fn(async () => undefined),
+  resolveCommandForLogs: vi.fn(async () => "claude"),
+}));
+
+vi.mock("@paperclipai/adapter-utils/server-utils", async () => {
+  const actual = await vi.importActual<typeof import("@paperclipai/adapter-utils/server-utils")>(
+    "@paperclipai/adapter-utils/server-utils",
+  );
+  return {
+    ...actual,
+    ensureCommandResolvable,
+    resolveCommandForLogs,
+    runChildProcess,
+  };
+});
+
+import { execute } from "./execute.js";
+
+describe("claude run failure classification", () => {
+  const cleanupDirs: string[] = [];
+
+  afterEach(async () => {
+    vi.clearAllMocks();
+    while (cleanupDirs.length > 0) {
+      const dir = cleanupDirs.pop();
+      if (!dir) continue;
+      await rm(dir, { recursive: true, force: true }).catch(() => undefined);
+    }
+  });
+
+  const runExecute = async (proc: { exitCode: number; stdout: string; stderr?: string }) => {
+    const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-claude-result-"));
+    cleanupDirs.push(rootDir);
+    const workspaceDir = path.join(rootDir, "workspace");
+    const instructionsPath = path.join(rootDir, "instructions.md");
+    await mkdir(workspaceDir, { recursive: true });
+    await writeFile(instructionsPath, "Do the work.\n", "utf8");
+
+    runChildProcess.mockResolvedValueOnce({
+      exitCode: proc.exitCode,
+      signal: null,
+      timedOut: false,
+      stdout: proc.stdout,
+      stderr: proc.stderr ?? "",
+      pid: 123,
+      startedAt: new Date().toISOString(),
+    });
+
+    const logLines: string[] = [];
+    const result = await execute({
+      runId: "run-1",
+      agent: {
+        id: "agent-1",
+        companyId: "company-1",
+        name: "Claude Coder",
+        adapterType: "claude_local",
+        adapterConfig: {},
+      },
+      runtime: {
+        sessionId: null,
+        sessionParams: null,
+        sessionDisplayId: null,
+        taskKey: null,
+      },
+      config: {
+        command: "claude",
+        instructionsFilePath: instructionsPath,
+        cwd: workspaceDir,
+      },
+      context: {},
+      onLog: async (_stream, chunk) => {
+        logLines.push(chunk);
+      },
+    });
+    return { result, logLines };
+  };
+
+  it("classifies a subtype=success result as succeeded even when the process exits non-zero", async () => {
+    const { result, logLines } = await runExecute({
+      exitCode: 1,
+      stdout: [
+        JSON.stringify({ type: "system", subtype: "init", session_id: "11111111-1111-4111-8111-111111111111", model: "claude-sonnet" }),
+        JSON.stringify({
+          type: "result",
+          subtype: "success",
+          is_error: false,
+          session_id: "11111111-1111-4111-8111-111111111111",
+          result: "Shipped the fix and opened a PR.",
+          usage: { input_tokens: 1, cache_read_input_tokens: 0, output_tokens: 1 },
+        }),
+      ].join("\n"),
+    });
+
+    expect(result.errorMessage).toBeNull();
+    expect(result.errorCode).toBeNull();
+    expect(result.exitCode).toBe(1);
+    expect(result.summary).toBe("Shipped the fix and opened a PR.");
+    expect(logLines.join("")).toContain("treating the run as succeeded");
+  });
+
+  it("still fails a non-zero exit without a parsed result", async () => {
+    const { result } = await runExecute({
+      exitCode: 1,
+      stdout: "not json at all",
+      stderr: "claude: something broke",
+    });
+
+    expect(result.errorMessage).toBe("Claude exited with code 1: claude: something broke");
+  });
+
+  it("still fails an is_error=true result even with subtype=success", async () => {
+    const { result } = await runExecute({
+      exitCode: 1,
+      stdout: JSON.stringify({
+        type: "result",
+        subtype: "success",
+        is_error: true,
+        session_id: "11111111-1111-4111-8111-111111111111",
+        result: "something went sideways",
+      }),
+    });
+
+    expect(result.errorMessage).toBe("Claude run failed: subtype=success: something went sideways");
+  });
+});

--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -51,6 +51,7 @@ import {
   extractClaudeRetryNotBefore,
   isClaudeMaxTurnsResult,
   isClaudeRefusalResult,
+  isClaudeSuccessResult,
   isClaudeTransientUpstreamError,
   isClaudeUnknownSessionError,
   isClaudePoisonedPreviousMessageIdError,
@@ -805,14 +806,14 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     return { proc, parsedStream, parsed };
   };
 
-  const toAdapterResult = (
+  const toAdapterResult = async (
     attempt: {
       proc: RunProcessResult;
       parsedStream: ReturnType<typeof parseClaudeStreamJson>;
       parsed: Record<string, unknown> | null;
     },
     opts: { fallbackSessionId: string | null; clearSessionOnMissingSession?: boolean },
-  ): AdapterExecutionResult => {
+  ): Promise<AdapterExecutionResult> => {
     const { proc, parsedStream, parsed } = attempt;
     const loginMeta = detectClaudeLoginRequired({
       parsed,
@@ -907,7 +908,21 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     // successful run to Paperclip and the heartbeat stalls silently. See RY-604.
     const claudeRefusal = isClaudeRefusalResult(parsed);
     const parsedIsError = asBoolean(parsed.is_error, false);
-    const failed = (proc.exitCode ?? 0) !== 0 || parsedIsError;
+    // The final result event is authoritative: subtype=success with
+    // is_error=false means the run succeeded even if the CLI process exited
+    // non-zero afterwards. Trusting the exit code here classified successful
+    // runs as failed and recorded the agent's own success summary as the
+    // run error.
+    const succeededDespiteExitCode =
+      (proc.exitCode ?? 0) !== 0 && isClaudeSuccessResult(parsed);
+    const failed =
+      parsedIsError || ((proc.exitCode ?? 0) !== 0 && !succeededDespiteExitCode);
+    if (succeededDespiteExitCode) {
+      await onLog(
+        "stdout",
+        `[paperclip] Claude exited with code ${proc.exitCode} but the final result was subtype=success with is_error=false; treating the run as succeeded.\n`,
+      );
+    }
     // Validate-before-persist guard: never persist a sessionId whose transcript
     // is known-poisoned. The Claude CLI keeps an on-disk JSONL keyed by the
     // session id; if the last entry contains a non-`msg_`-prefixed
@@ -1057,10 +1072,10 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         }
       }
       const retry = await runAttempt(null);
-      return toAdapterResult(retry, { fallbackSessionId: null, clearSessionOnMissingSession: true });
+      return await toAdapterResult(retry, { fallbackSessionId: null, clearSessionOnMissingSession: true });
     }
 
-    return toAdapterResult(initial, { fallbackSessionId: runtimeSessionId || runtime.sessionId });
+    return await toAdapterResult(initial, { fallbackSessionId: runtimeSessionId || runtime.sessionId });
   } finally {
     if (paperclipBridge) {
       await paperclipBridge.stop();

--- a/packages/adapters/claude-local/src/server/parse.test.ts
+++ b/packages/adapters/claude-local/src/server/parse.test.ts
@@ -1,13 +1,46 @@
 import { describe, expect, it } from "vitest";
 import {
+  describeClaudeFailure,
   detectClaudeLoginRequired,
   extractClaudeRetryNotBefore,
   isClaudeTransientUpstreamError,
   isClaudePoisonedPreviousMessageIdError,
   isClaudeRefusalResult,
+  isClaudeSuccessResult,
   isClaudeUnknownSessionError,
   isClaudeImageProcessingError,
 } from "./parse.js";
+
+describe("isClaudeSuccessResult", () => {
+  it("classifies subtype=success with is_error=false as success", () => {
+    expect(
+      isClaudeSuccessResult({ type: "result", subtype: "success", is_error: false, result: "done" }),
+    ).toBe(true);
+  });
+
+  it("does not classify is_error=true as success even with subtype=success", () => {
+    expect(isClaudeSuccessResult({ subtype: "success", is_error: true })).toBe(false);
+  });
+
+  it("does not classify non-success subtypes or missing results as success", () => {
+    expect(isClaudeSuccessResult({ subtype: "error_max_turns", is_error: false })).toBe(false);
+    expect(isClaudeSuccessResult(null)).toBe(false);
+  });
+});
+
+describe("describeClaudeFailure", () => {
+  it("returns null for a subtype=success result instead of echoing the success summary", () => {
+    expect(
+      describeClaudeFailure({ subtype: "success", is_error: false, result: "Shipped the fix." }),
+    ).toBeNull();
+  });
+
+  it("still describes error results", () => {
+    expect(
+      describeClaudeFailure({ subtype: "error_during_execution", is_error: true, result: "boom" }),
+    ).toBe("Claude run failed: subtype=error_during_execution: boom");
+  });
+});
 
 describe("detectClaudeLoginRequired", () => {
   it("classifies Claude's invalid API key login prompt as auth required", () => {

--- a/packages/adapters/claude-local/src/server/parse.ts
+++ b/packages/adapters/claude-local/src/server/parse.ts
@@ -1,5 +1,6 @@
 import type { UsageSummary } from "@paperclipai/adapter-utils";
 import {
+  asBoolean,
   asString,
   asNumber,
   parseObject,
@@ -148,7 +149,16 @@ export function detectClaudeLoginRequired(input: {
   };
 }
 
+export function isClaudeSuccessResult(parsed: Record<string, unknown> | null | undefined): boolean {
+  if (!parsed) return false;
+  const subtype = asString(parsed.subtype, "").trim().toLowerCase();
+  return subtype === "success" && !asBoolean(parsed.is_error, false);
+}
+
 export function describeClaudeFailure(parsed: Record<string, unknown>): string | null {
+  // A subtype=success result without is_error is not a failure; describing it
+  // would surface the agent's own success summary as the error message.
+  if (isClaudeSuccessResult(parsed)) return null;
   const subtype = asString(parsed.subtype, "");
   const resultText = asString(parsed.result, "").trim();
   const errors = extractClaudeErrorMessages(parsed);


### PR DESCRIPTION
**Symptom:** Runs where the Claude CLI stream-json final result is `subtype: "success"` / `is_error: false` are recorded as failed whenever the process exit code is non-zero — and the run's `error` field is filled with the agent's own success summary (`Claude run failed: subtype=success: <normal output>`), polluting failure metrics and alerting.

**Mechanism:** `execute.ts` classifies failure as `(proc.exitCode ?? 0) !== 0 || parsedIsError`, trusting the process exit code over the parsed final result; `describeClaudeFailure()` then describes the success result as if it were an error.

**Fix:** When a parsed final result exists with `subtype === "success"` and `is_error` false, the run is classified as succeeded even if the CLI exited non-zero; the anomalous exit code is surfaced as a `[paperclip]` warning log line instead of a run failure. `describeClaudeFailure()` returns null for such results (this also stops the hello-probe diagnostics echoing success output as a failure detail). Behavior is unchanged when there is no parsed result (exit code still decides), when `is_error` is true, and for non-success subtypes.

**Tests:** New `execute.result.test.ts`: non-zero exit + success result → succeeded (with warning log); non-zero exit + no parsed result → still fails; `is_error: true` → still fails. `parse.test.ts`: covers `isClaudeSuccessResult()` and the `describeClaudeFailure()` guard. Affected files: 40/40 passing; `tsc --noEmit` clean; the 3 failures in `test.probe.test.ts` are pre-existing on clean master (environment-dependent probe tests).

Measured on a production instance running v0.3.1: 430 misclassified heartbeat runs (`error = 'Claude run failed: subtype=success: ...'`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)