### PR TITLE
feat(issues): add dueAt, recurrence, and overdue/upcoming list filter

### DIFF
--- a/packages/db/src/migrations/0136_add_due_dates_recurrence.sql
+++ b/packages/db/src/migrations/0136_add_due_dates_recurrence.sql
@@ -1,0 +1,10 @@
+ALTER TABLE "issues" ADD COLUMN "due_at" timestamp with time zone;--> statement-breakpoint
+ALTER TABLE "issues" ADD COLUMN "recurrence" jsonb;--> statement-breakpoint
+ALTER TABLE "issues" ADD COLUMN "recurring_task_id" uuid;--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "issues" ADD CONSTRAINT "issues_recurring_task_id_issues_id_fk" FOREIGN KEY ("recurring_task_id") REFERENCES "public"."issues"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "issues_company_due_at_idx" ON "issues" USING btree ("company_id","due_at");

--- a/packages/db/src/migrations/0136_add_due_dates_recurrence.sql
+++ b/packages/db/src/migrations/0136_add_due_dates_recurrence.sql
@@ -2,9 +2,10 @@ ALTER TABLE "issues" ADD COLUMN "due_at" timestamp with time zone;--> statement-
 ALTER TABLE "issues" ADD COLUMN "recurrence" jsonb;--> statement-breakpoint
 ALTER TABLE "issues" ADD COLUMN "recurring_task_id" uuid;--> statement-breakpoint
 DO $$ BEGIN
- ALTER TABLE "issues" ADD CONSTRAINT "issues_recurring_task_id_issues_id_fk" FOREIGN KEY ("recurring_task_id") REFERENCES "public"."issues"("id") ON DELETE no action ON UPDATE no action;
+ ALTER TABLE "issues" ADD CONSTRAINT "issues_recurring_task_id_issues_id_fk" FOREIGN KEY ("recurring_task_id") REFERENCES "public"."issues"("id") ON DELETE set null ON UPDATE no action;
 EXCEPTION
  WHEN duplicate_object THEN null;
 END $$;
 --> statement-breakpoint
-CREATE INDEX IF NOT EXISTS "issues_company_due_at_idx" ON "issues" USING btree ("company_id","due_at");
+CREATE INDEX IF NOT EXISTS "issues_company_due_at_idx" ON "issues" USING btree ("company_id","due_at");--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "issues_company_recurring_due_at_uq" ON "issues" USING btree ("company_id","recurring_task_id","due_at") WHERE "recurring_task_id" IS NOT NULL AND "due_at" IS NOT NULL;

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -939,6 +939,13 @@
       "when": 1783025724120,
       "tag": "0135_repair_run_responsible_user_updated_at_sweep",
       "breakpoints": true
+    },
+    {
+      "idx": 136,
+      "version": "7",
+      "when": 1783034600000,
+      "tag": "0136_add_due_dates_recurrence",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/issues.ts
+++ b/packages/db/src/schema/issues.ts
@@ -17,7 +17,7 @@ import { companies } from "./companies.js";
 import { heartbeatRuns } from "./heartbeat_runs.js";
 import { projectWorkspaces } from "./project_workspaces.js";
 import { executionWorkspaces } from "./execution_workspaces.js";
-import type { SourceTrustMetadata } from "@paperclipai/shared";
+import type { IssueRecurrence, SourceTrustMetadata } from "@paperclipai/shared";
 
 export const issues = pgTable(
   "issues",
@@ -68,6 +68,9 @@ export const issues = pgTable(
     completedAt: timestamp("completed_at", { withTimezone: true }),
     cancelledAt: timestamp("cancelled_at", { withTimezone: true }),
     hiddenAt: timestamp("hidden_at", { withTimezone: true }),
+    dueAt: timestamp("due_at", { withTimezone: true }),
+    recurrence: jsonb("recurrence").$type<IssueRecurrence | null>(),
+    recurringTaskId: uuid("recurring_task_id").references((): AnyPgColumn => issues.id),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },
@@ -90,6 +93,7 @@ export const issues = pgTable(
     projectWorkspaceIdx: index("issues_company_project_workspace_idx").on(table.companyId, table.projectWorkspaceId),
     executionWorkspaceIdx: index("issues_company_execution_workspace_idx").on(table.companyId, table.executionWorkspaceId),
     dueMonitorIdx: index("issues_company_monitor_due_idx").on(table.companyId, table.monitorNextCheckAt),
+    dueAtIdx: index("issues_company_due_at_idx").on(table.companyId, table.dueAt),
     identifierIdx: uniqueIndex("issues_identifier_idx").on(table.identifier),
     titleSearchIdx: index("issues_title_search_idx").using("gin", table.title.op("gin_trgm_ops")),
     identifierSearchIdx: index("issues_identifier_search_idx").using("gin", table.identifier.op("gin_trgm_ops")),

--- a/packages/db/src/schema/issues.ts
+++ b/packages/db/src/schema/issues.ts
@@ -70,7 +70,7 @@ export const issues = pgTable(
     hiddenAt: timestamp("hidden_at", { withTimezone: true }),
     dueAt: timestamp("due_at", { withTimezone: true }),
     recurrence: jsonb("recurrence").$type<IssueRecurrence | null>(),
-    recurringTaskId: uuid("recurring_task_id").references((): AnyPgColumn => issues.id),
+    recurringTaskId: uuid("recurring_task_id").references((): AnyPgColumn => issues.id, { onDelete: "set null" }),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },
@@ -94,6 +94,9 @@ export const issues = pgTable(
     executionWorkspaceIdx: index("issues_company_execution_workspace_idx").on(table.companyId, table.executionWorkspaceId),
     dueMonitorIdx: index("issues_company_monitor_due_idx").on(table.companyId, table.monitorNextCheckAt),
     dueAtIdx: index("issues_company_due_at_idx").on(table.companyId, table.dueAt),
+    recurringDueAtUniqueIdx: uniqueIndex("issues_company_recurring_due_at_uq")
+      .on(table.companyId, table.recurringTaskId, table.dueAt)
+      .where(sql`${table.recurringTaskId} is not null and ${table.dueAt} is not null`),
     identifierIdx: uniqueIndex("issues_identifier_idx").on(table.identifier),
     titleSearchIdx: index("issues_title_search_idx").using("gin", table.title.op("gin_trgm_ops")),
     identifierSearchIdx: index("issues_identifier_search_idx").using("gin", table.identifier.op("gin_trgm_ops")),

--- a/packages/plugins/sdk/src/testing.ts
+++ b/packages/plugins/sdk/src/testing.ts
@@ -1591,6 +1591,9 @@ export function createTestHarness(options: TestHarnessOptions): TestHarness {
           completedAt: null,
           cancelledAt: null,
           hiddenAt: null,
+          dueAt: null,
+          recurrence: null,
+          recurringTaskId: null,
           createdAt: now,
           updatedAt: now,
         };

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -964,6 +964,16 @@ export {
 } from "./issue-references.js";
 
 export {
+  ISSUE_RECURRENCE_FREQUENCIES,
+  ISSUE_RECURRENCE_MAX_INTERVAL,
+  advanceDate,
+  computeNextDueDate,
+  isIssueRecurrenceFrequency,
+  type IssueRecurrence,
+  type IssueRecurrenceFrequency,
+} from "./issue-recurrence.js";
+
+export {
   anchorSnapshotToSelector,
   createDocumentAnchorSelector,
   normalizeAnchorText,

--- a/packages/shared/src/issue-recurrence.test.ts
+++ b/packages/shared/src/issue-recurrence.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "vitest";
+import {
+  advanceDate,
+  computeNextDueDate,
+  isIssueRecurrenceFrequency,
+  type IssueRecurrence,
+} from "./issue-recurrence.js";
+
+const iso = (d: Date) => d.toISOString();
+
+describe("advanceDate", () => {
+  it("adds days for daily cadence", () => {
+    const out = advanceDate(new Date("2026-06-22T09:00:00.000Z"), { frequency: "daily", interval: 1 });
+    expect(iso(out)).toBe("2026-06-23T09:00:00.000Z");
+  });
+
+  it("adds N*7 days for weekly cadence", () => {
+    const out = advanceDate(new Date("2026-06-22T09:00:00.000Z"), { frequency: "weekly", interval: 2 });
+    expect(iso(out)).toBe("2026-07-06T09:00:00.000Z");
+  });
+
+  it("adds calendar months for monthly cadence", () => {
+    const out = advanceDate(new Date("2026-01-15T12:00:00.000Z"), { frequency: "monthly", interval: 1 });
+    expect(iso(out)).toBe("2026-02-15T12:00:00.000Z");
+  });
+
+  it("clamps day-of-month when the target month is shorter (Jan 31 -> Feb 28)", () => {
+    const out = advanceDate(new Date("2026-01-31T12:00:00.000Z"), { frequency: "monthly", interval: 1 });
+    expect(iso(out)).toBe("2026-02-28T12:00:00.000Z");
+  });
+
+  it("adds years for yearly cadence", () => {
+    const out = advanceDate(new Date("2026-06-22T09:00:00.000Z"), { frequency: "yearly", interval: 1 });
+    expect(iso(out)).toBe("2027-06-22T09:00:00.000Z");
+  });
+
+  it("does not mutate the input date", () => {
+    const input = new Date("2026-06-22T09:00:00.000Z");
+    advanceDate(input, { frequency: "daily", interval: 1 });
+    expect(iso(input)).toBe("2026-06-22T09:00:00.000Z");
+  });
+
+  it("treats interval < 1 as 1", () => {
+    const out = advanceDate(new Date("2026-06-22T09:00:00.000Z"), { frequency: "daily", interval: 0 });
+    expect(iso(out)).toBe("2026-06-23T09:00:00.000Z");
+  });
+});
+
+describe("computeNextDueDate", () => {
+  const weekly: IssueRecurrence = { frequency: "weekly", interval: 1 };
+
+  it("anchors on the previous due date when completed on time", () => {
+    const prevDue = new Date("2026-06-22T09:00:00.000Z");
+    const now = new Date("2026-06-22T10:00:00.000Z");
+    expect(iso(computeNextDueDate(prevDue, weekly, now))).toBe("2026-06-29T09:00:00.000Z");
+  });
+
+  it("rolls forward past 'now' when completed late, instead of spawning already-overdue", () => {
+    const prevDue = new Date("2026-06-01T09:00:00.000Z");
+    const now = new Date("2026-06-20T10:00:00.000Z"); // ~3 weeks late
+    const next = computeNextDueDate(prevDue, weekly, now);
+    expect(next.getTime()).toBeGreaterThan(now.getTime());
+    expect(iso(next)).toBe("2026-06-22T09:00:00.000Z");
+  });
+
+  it("falls back to now when there is no previous due date", () => {
+    const now = new Date("2026-06-22T09:00:00.000Z");
+    expect(iso(computeNextDueDate(null, weekly, now))).toBe("2026-06-29T09:00:00.000Z");
+  });
+});
+
+describe("isIssueRecurrenceFrequency", () => {
+  it("accepts known frequencies and rejects others", () => {
+    expect(isIssueRecurrenceFrequency("weekly")).toBe(true);
+    expect(isIssueRecurrenceFrequency("hourly")).toBe(false);
+    expect(isIssueRecurrenceFrequency(undefined)).toBe(false);
+  });
+});

--- a/packages/shared/src/issue-recurrence.test.ts
+++ b/packages/shared/src/issue-recurrence.test.ts
@@ -63,6 +63,14 @@ describe("computeNextDueDate", () => {
     expect(iso(next)).toBe("2026-06-22T09:00:00.000Z");
   });
 
+  it("rolls very late daily tasks forward past now", () => {
+    const prevDue = new Date("2024-01-01T09:00:00.000Z");
+    const now = new Date("2026-07-07T10:00:00.000Z");
+    const next = computeNextDueDate(prevDue, { frequency: "daily", interval: 1 }, now);
+    expect(next.getTime()).toBeGreaterThan(now.getTime());
+    expect(iso(next)).toBe("2026-07-08T09:00:00.000Z");
+  });
+
   it("falls back to now when there is no previous due date", () => {
     const now = new Date("2026-06-22T09:00:00.000Z");
     expect(iso(computeNextDueDate(null, weekly, now))).toBe("2026-06-29T09:00:00.000Z");

--- a/packages/shared/src/issue-recurrence.ts
+++ b/packages/shared/src/issue-recurrence.ts
@@ -1,0 +1,100 @@
+/**
+ * Recurrence support for issues (FUS-660).
+ *
+ * A recurring issue carries an {@link IssueRecurrence} config plus a `dueAt`.
+ * When the issue is completed, the server spawns the next instance with its
+ * `dueAt` advanced by one recurrence step (see `computeNextDueDate`).
+ */
+
+export const ISSUE_RECURRENCE_FREQUENCIES = ["daily", "weekly", "monthly", "yearly"] as const;
+
+export type IssueRecurrenceFrequency = (typeof ISSUE_RECURRENCE_FREQUENCIES)[number];
+
+export interface IssueRecurrence {
+  /** Cadence unit. */
+  frequency: IssueRecurrenceFrequency;
+  /** Repeat every N units (e.g. interval 2 + weekly = every 2 weeks). >= 1. */
+  interval: number;
+}
+
+/** Largest interval we accept, to keep date math and UI bounded. */
+export const ISSUE_RECURRENCE_MAX_INTERVAL = 365;
+
+export function isIssueRecurrenceFrequency(value: unknown): value is IssueRecurrenceFrequency {
+  return (
+    typeof value === "string" &&
+    (ISSUE_RECURRENCE_FREQUENCIES as readonly string[]).includes(value)
+  );
+}
+
+/**
+ * Advance a date by one recurrence step.
+ *
+ * Calendar-aware: monthly/yearly steps add months/years (so the day-of-month is
+ * preserved where possible) rather than a fixed number of days. Daily/weekly add
+ * a fixed number of days. The returned Date is a new instance; the input is not
+ * mutated.
+ */
+export function advanceDate(from: Date, recurrence: IssueRecurrence): Date {
+  const interval = normalizeInterval(recurrence.interval);
+  const next = new Date(from.getTime());
+  switch (recurrence.frequency) {
+    case "daily":
+      next.setUTCDate(next.getUTCDate() + interval);
+      return next;
+    case "weekly":
+      next.setUTCDate(next.getUTCDate() + interval * 7);
+      return next;
+    case "monthly":
+      addUTCMonths(next, interval);
+      return next;
+    case "yearly":
+      addUTCMonths(next, interval * 12);
+      return next;
+    default:
+      return next;
+  }
+}
+
+/**
+ * Compute the next due date for a recurring issue being completed.
+ *
+ * Anchors on the issue's current `dueAt` when present so cadence does not drift
+ * with completion time; falls back to `completedAt` (now) when no due date is
+ * set. Always returns a due date strictly in the future relative to `now` so a
+ * task completed late does not immediately re-spawn as already-overdue.
+ */
+export function computeNextDueDate(
+  previousDueAt: Date | null | undefined,
+  recurrence: IssueRecurrence,
+  now: Date = new Date(),
+): Date {
+  let next = advanceDate(previousDueAt ?? now, recurrence);
+  // If the task was completed well after its due date, keep stepping until the
+  // next occurrence is in the future so cadence resumes from "now", not the past.
+  let guard = 0;
+  while (next.getTime() <= now.getTime() && guard < ISSUE_RECURRENCE_MAX_INTERVAL + 1) {
+    next = advanceDate(next, recurrence);
+    guard += 1;
+  }
+  return next;
+}
+
+function normalizeInterval(interval: number): number {
+  if (!Number.isFinite(interval)) return 1;
+  const floored = Math.floor(interval);
+  if (floored < 1) return 1;
+  if (floored > ISSUE_RECURRENCE_MAX_INTERVAL) return ISSUE_RECURRENCE_MAX_INTERVAL;
+  return floored;
+}
+
+/** Add whole months in UTC, clamping the day to the target month's length. */
+function addUTCMonths(date: Date, months: number): void {
+  const day = date.getUTCDate();
+  date.setUTCDate(1);
+  date.setUTCMonth(date.getUTCMonth() + months);
+  const daysInTargetMonth = new Date(
+    Date.UTC(date.getUTCFullYear(), date.getUTCMonth() + 1, 0),
+  ).getUTCDate();
+  date.setUTCDate(Math.min(day, daysInTargetMonth));
+}

--- a/packages/shared/src/issue-recurrence.ts
+++ b/packages/shared/src/issue-recurrence.ts
@@ -72,10 +72,8 @@ export function computeNextDueDate(
   let next = advanceDate(previousDueAt ?? now, recurrence);
   // If the task was completed well after its due date, keep stepping until the
   // next occurrence is in the future so cadence resumes from "now", not the past.
-  let guard = 0;
-  while (next.getTime() <= now.getTime() && guard < ISSUE_RECURRENCE_MAX_INTERVAL + 1) {
+  while (next.getTime() <= now.getTime()) {
     next = advanceDate(next, recurrence);
-    guard += 1;
   }
   return next;
 }

--- a/packages/shared/src/issue-recurrence.ts
+++ b/packages/shared/src/issue-recurrence.ts
@@ -1,5 +1,5 @@
 /**
- * Recurrence support for issues (FUS-660).
+ * Recurrence support for issues.
  *
  * A recurring issue carries an {@link IssueRecurrence} config plus a `dueAt`.
  * When the issue is completed, the server spawns the next instance with its

--- a/packages/shared/src/types/issue.ts
+++ b/packages/shared/src/types/issue.ts
@@ -26,6 +26,7 @@ import type {
   IssueThreadInteractionStatus,
   IssueStatus,
 } from "../constants.js";
+import type { IssueRecurrence } from "../issue-recurrence.js";
 import type { Goal } from "./goal.js";
 import type { Project, ProjectWorkspace } from "./project.js";
 import type { ExecutionWorkspace, IssueExecutionWorkspaceSettings } from "./workspace-runtime.js";
@@ -743,6 +744,9 @@ export interface Issue {
   completedAt: Date | null;
   cancelledAt: Date | null;
   hiddenAt: Date | null;
+  dueAt?: Date | null;
+  recurrence?: IssueRecurrence | null;
+  recurringTaskId?: string | null;
   sourceTrust?: SourceTrustMetadata | null;
   labelIds?: string[];
   labels?: IssueLabel[];

--- a/packages/shared/src/validators/issue.ts
+++ b/packages/shared/src/validators/issue.ts
@@ -28,6 +28,7 @@ import {
   MODEL_PROFILE_KEYS,
   REQUEST_CHECKBOX_CONFIRMATION_OPTION_LIMIT,
 } from "../constants.js";
+import { ISSUE_RECURRENCE_FREQUENCIES, ISSUE_RECURRENCE_MAX_INTERVAL } from "../issue-recurrence.js";
 import { multilineTextSchema } from "./text.js";
 import { lowTrustReviewPresetPolicySchema, trustAuthorizationPolicySchema } from "./trust-policy.js";
 
@@ -373,6 +374,13 @@ function withCreateIssueStatusDefault<T extends z.ZodRawShape>(schema: z.ZodObje
   }, schema);
 }
 
+export const issueRecurrenceSchema = z.object({
+  frequency: z.enum(ISSUE_RECURRENCE_FREQUENCIES),
+  interval: z.number().int().positive().max(ISSUE_RECURRENCE_MAX_INTERVAL).default(1),
+}).strict();
+
+export type IssueRecurrenceInput = z.infer<typeof issueRecurrenceSchema>;
+
 const createIssueBaseSchema = z.object({
   projectId: z.string().uuid().optional().nullable(),
   projectWorkspaceId: z.string().uuid().optional().nullable(),
@@ -405,6 +413,8 @@ const createIssueBaseSchema = z.object({
     agentId: z.string().uuid(),
     instructions: multilineTextSchema.optional().nullable(),
   }).strict().optional().nullable(),
+  dueAt: z.string().datetime().optional().nullable(),
+  recurrence: issueRecurrenceSchema.optional().nullable(),
 });
 
 export const createIssueInputSchema = createIssueBaseSchema.extend({

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -60,6 +60,7 @@ import {
   getClosedIsolatedExecutionWorkspaceMessage,
   isClosedIsolatedExecutionWorkspace,
   isUuidLike,
+  computeNextDueDate,
   normalizeIssueIdentifier as normalizeIssueReferenceIdentifier,
   type CompanySearchQuery,
   type CompanySearchResponse,
@@ -4161,6 +4162,8 @@ export function issueRoutes(
         req.query.includeBlockedInboxAttention === "true" || req.query.includeBlockedInboxAttention === "1",
       includeLiveDescendantSummary: includeLiveDescendantSummary === true,
       hasPlanDocument,
+      due:
+        req.query.due === "overdue" ? "overdue" : req.query.due === "upcoming" ? "upcoming" : undefined,
       q: req.query.q as string | undefined,
       limit,
       offset,
@@ -6954,6 +6957,7 @@ export function issueRoutes(
       resume: resumeRequested,
       interrupt: interruptRequested,
       hiddenAt: hiddenAtRaw,
+      dueAt: dueAtRaw,
       ...updateFields
     } = req.body;
     const shouldCancelActiveRunForCancelledStatus =
@@ -7101,6 +7105,9 @@ export function issueRoutes(
 
     if (hiddenAtRaw !== undefined) {
       updateFields.hiddenAt = hiddenAtRaw ? new Date(hiddenAtRaw) : null;
+    }
+    if (dueAtRaw !== undefined) {
+      updateFields.dueAt = dueAtRaw ? new Date(dueAtRaw) : null;
     }
     if (
       commentBody &&
@@ -7626,6 +7633,60 @@ export function issueRoutes(
             model,
           });
         }
+      }
+    }
+
+    // FUS-660: when a recurring issue is completed, spawn its next instance so
+    // cadence work (weekly/monthly reports, review asks) does not depend on memory.
+    if (
+      issue.status === "done" &&
+      existing.status !== "done" &&
+      existing.recurrence &&
+      existing.originKind !== "routine_execution"
+    ) {
+      try {
+        const nextDueAt = computeNextDueDate(existing.dueAt ?? null, existing.recurrence);
+        const spawned = await svc.create(issue.companyId, {
+          title: existing.title,
+          description: existing.description,
+          projectId: existing.projectId,
+          goalId: existing.goalId,
+          parentId: existing.parentId,
+          assigneeAgentId: existing.assigneeAgentId,
+          assigneeUserId: existing.assigneeUserId,
+          priority: existing.priority,
+          workMode: existing.workMode,
+          billingCode: existing.billingCode,
+          status: "todo",
+          dueAt: nextDueAt,
+          recurrence: existing.recurrence,
+          recurringTaskId: existing.recurringTaskId ?? existing.id,
+          createdByAgentId: actor.agentId,
+          createdByUserId: actor.actorType === "user" ? actor.actorId : null,
+        });
+        await issueReferencesSvc.syncIssue(spawned.id);
+        await logActivity(db, {
+          companyId: issue.companyId,
+          actorType: actor.actorType,
+          actorId: actor.actorId,
+          agentId: actor.agentId,
+          runId: actor.runId,
+          action: "issue.recurrence_spawned",
+          entityType: "issue",
+          entityId: spawned.id,
+          details: {
+            identifier: spawned.identifier,
+            sourceIssueId: issue.id,
+            sourceIdentifier: issue.identifier,
+            dueAt: nextDueAt.toISOString(),
+            recurrence: existing.recurrence,
+          },
+        });
+      } catch (err) {
+        logger.error(
+          { err, issueId: issue.id },
+          "failed to spawn next recurring issue instance on completion",
+        );
       }
     }
 

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -4132,6 +4132,15 @@ export function issueRoutes(
       }
     }
     const offset = parsedOffset ?? 0;
+    const dueRaw = req.query.due;
+    let due: "overdue" | "upcoming" | undefined;
+    if (dueRaw !== undefined) {
+      if (Array.isArray(dueRaw) || (dueRaw !== "overdue" && dueRaw !== "upcoming")) {
+        res.status(422).json({ error: "due must be 'overdue' or 'upcoming'" });
+        return;
+      }
+      due = dueRaw;
+    }
 
     const rawResult = await svc.list(companyId, {
       attention: attention === "blocked" ? "blocked" : undefined,
@@ -4162,8 +4171,7 @@ export function issueRoutes(
         req.query.includeBlockedInboxAttention === "true" || req.query.includeBlockedInboxAttention === "1",
       includeLiveDescendantSummary: includeLiveDescendantSummary === true,
       hasPlanDocument,
-      due:
-        req.query.due === "overdue" ? "overdue" : req.query.due === "upcoming" ? "upcoming" : undefined,
+      due,
       q: req.query.q as string | undefined,
       limit,
       offset,
@@ -7644,47 +7652,61 @@ export function issueRoutes(
     if (
       issue.status === "done" &&
       existing.status !== "done" &&
-      existing.recurrence &&
+      issue.recurrence &&
       existing.originKind !== "routine_execution"
     ) {
       try {
-        const nextDueAt = computeNextDueDate(existing.dueAt ?? null, existing.recurrence);
-        const spawned = await svc.create(issue.companyId, {
-          title: existing.title,
-          description: existing.description,
-          projectId: existing.projectId,
-          goalId: existing.goalId,
-          parentId: existing.parentId,
-          assigneeAgentId: existing.assigneeAgentId,
-          assigneeUserId: existing.assigneeUserId,
-          priority: existing.priority,
-          workMode: existing.workMode,
-          billingCode: existing.billingCode,
-          status: "todo",
-          dueAt: nextDueAt,
-          recurrence: existing.recurrence,
-          recurringTaskId: existing.recurringTaskId ?? existing.id,
-          createdByAgentId: actor.agentId,
-          createdByUserId: actor.actorType === "user" ? actor.actorId : null,
-        });
-        await issueReferencesSvc.syncIssue(spawned.id);
-        await logActivity(db, {
-          companyId: issue.companyId,
-          actorType: actor.actorType,
-          actorId: actor.actorId,
-          agentId: actor.agentId,
-          runId: actor.runId,
-          action: "issue.recurrence_spawned",
-          entityType: "issue",
-          entityId: spawned.id,
-          details: {
-            identifier: spawned.identifier,
-            sourceIssueId: issue.id,
-            sourceIdentifier: issue.identifier,
-            dueAt: nextDueAt.toISOString(),
-            recurrence: existing.recurrence,
-          },
-        });
+        const rootRecurringTaskId = issue.recurringTaskId ?? issue.id;
+        const nextDueAt = computeNextDueDate(issue.dueAt ?? null, issue.recurrence);
+        const existingNext = await db
+          .select({ id: issueRows.id })
+          .from(issueRows)
+          .where(and(
+            eq(issueRows.companyId, issue.companyId),
+            eq(issueRows.recurringTaskId, rootRecurringTaskId),
+            eq(issueRows.dueAt, nextDueAt),
+            isNull(issueRows.hiddenAt),
+          ))
+          .limit(1)
+          .then((rows) => rows[0] ?? null);
+        if (!existingNext) {
+          const spawned = await svc.create(issue.companyId, {
+            title: issue.title,
+            description: issue.description,
+            projectId: issue.projectId,
+            goalId: issue.goalId,
+            parentId: issue.parentId,
+            assigneeAgentId: issue.assigneeAgentId,
+            assigneeUserId: issue.assigneeUserId,
+            priority: issue.priority,
+            workMode: issue.workMode,
+            billingCode: issue.billingCode,
+            status: "todo",
+            dueAt: nextDueAt,
+            recurrence: issue.recurrence,
+            recurringTaskId: rootRecurringTaskId,
+            createdByAgentId: actor.agentId,
+            createdByUserId: actor.actorType === "user" ? actor.actorId : null,
+          });
+          await issueReferencesSvc.syncIssue(spawned.id);
+          await logActivity(db, {
+            companyId: issue.companyId,
+            actorType: actor.actorType,
+            actorId: actor.actorId,
+            agentId: actor.agentId,
+            runId: actor.runId,
+            action: "issue.recurrence_spawned",
+            entityType: "issue",
+            entityId: spawned.id,
+            details: {
+              identifier: spawned.identifier,
+              sourceIssueId: issue.id,
+              sourceIdentifier: issue.identifier,
+              dueAt: nextDueAt.toISOString(),
+              recurrence: issue.recurrence,
+            },
+          });
+        }
       } catch (err) {
         logger.error(
           { err, issueId: issue.id },

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -6313,6 +6313,9 @@ export function issueRoutes(
     const createBody = {
       ...rawCreateBody,
       parentId: effectiveParentId,
+      ...(rawCreateBody.dueAt !== undefined
+        ? { dueAt: rawCreateBody.dueAt ? new Date(rawCreateBody.dueAt) : null }
+        : {}),
       ...(normalizedAssigneeAgentId !== undefined ? { assigneeAgentId: normalizedAssigneeAgentId } : {}),
       ...(runWorkspaceInheritanceSourceIssueId
         ? { inheritExecutionWorkspaceFromIssueId: runWorkspaceInheritanceSourceIssueId }
@@ -7636,8 +7639,8 @@ export function issueRoutes(
       }
     }
 
-    // FUS-660: when a recurring issue is completed, spawn its next instance so
-    // cadence work (weekly/monthly reports, review asks) does not depend on memory.
+    // When a recurring issue is completed, spawn its next instance so cadence
+    // work (weekly/monthly reports, review asks) does not depend on memory.
     if (
       issue.status === "done" &&
       existing.status !== "done" &&

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -404,6 +404,8 @@ export interface IssueFilters {
   includeBlockedInboxAttention?: boolean;
   includeLiveDescendantSummary?: boolean;
   hasPlanDocument?: boolean;
+  /** Filter by due-date window. "overdue" = past-due & still open; "upcoming" = due in the future & still open. */
+  due?: "overdue" | "upcoming";
   lowTrustBoundary?: LowTrustBoundary & { companyId: string };
   q?: string;
   limit?: number;
@@ -2386,6 +2388,9 @@ const issueListSelect = {
   completedAt: issues.completedAt,
   cancelledAt: issues.cancelledAt,
   hiddenAt: issues.hiddenAt,
+  dueAt: issues.dueAt,
+  recurrence: issues.recurrence,
+  recurringTaskId: issues.recurringTaskId,
   createdAt: issues.createdAt,
   updatedAt: issues.updatedAt,
 };
@@ -4644,6 +4649,13 @@ export function issueService(db: Db) {
       }
       if (filters?.excludeRoutineExecutions && !filters?.originKind && !filters?.originId) {
         conditions.push(ne(issues.originKind, "routine_execution"));
+      }
+      if (filters?.due === "overdue") {
+        conditions.push(sql<boolean>`${issues.dueAt} IS NOT NULL AND ${issues.dueAt} < now()`);
+        conditions.push(notInArray(issues.status, ["done", "cancelled"]));
+      } else if (filters?.due === "upcoming") {
+        conditions.push(sql<boolean>`${issues.dueAt} IS NOT NULL AND ${issues.dueAt} >= now()`);
+        conditions.push(notInArray(issues.status, ["done", "cancelled"]));
       }
       conditions.push(isNull(issues.hiddenAt));
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Work is organized as issues/tasks, and cadence-based work currently depends on routines, standing checklist tasks, or manual re-creation.
> - Routines cover scheduled execution, but issues themselves do not expose due dates, recurrence metadata, or a simple overdue/upcoming query.
> - That gap makes weekly reports, monthly recaps, review asks, and other cadence work easy to miss once it slips.
> - This pull request adds the data, validation, API, and server behavior needed for issue-level due dates and recurrence.
> - The benefit is that API-driven clients and agents can create cadence-aware tasks now, while UI affordances can build on the same fields later.

## Linked Issues or Issue Description

No public GitHub issue was found for this exact request.

### Subsystem affected

Cross-cutting (`packages/db`, `packages/shared`, `server/`).

### Problem or motivation

Paperclip issues have no first-class due date or recurrence field. Cadence-based work has to be represented with standing checklist tasks or manual re-creation, and slipped work is not queryable as overdue/upcoming issue work.

### Proposed solution

Add nullable issue due dates, a recurrence config for daily/weekly/monthly/yearly intervals, next-instance creation when a recurring issue is completed, and an issue-list filter for overdue/upcoming work.

### Alternatives considered

Use routines only. Routines are still the right tool for scheduled agent execution, but they do not make ordinary issue records due-date-aware or support completion-driven recurrence from an issue template.

### Roadmap alignment

`ROADMAP.md` includes Scheduled Routines. This PR complements that roadmap item by adding issue-level due metadata and completion-based recurrence, while leaving scheduled routine execution intact.

### Additional context

Searched public PRs for `due dates recurrence recurring dueAt`; only this PR matched.

## What Changed

- Added nullable `due_at`, `recurrence`, and `recurring_task_id` issue columns plus a `(company_id, due_at)` index.
- Added shared recurrence types, validators, exports, and calendar-aware date math for daily, weekly, monthly, and yearly intervals.
- Added `dueAt`, `recurrence`, and `recurringTaskId` to shared issue types and create/update validation.
- Added `due=overdue|upcoming` filtering to issue listing.
- Added server-side next-instance spawning when a recurring issue transitions to `done`, with routine-execution issues skipped, duplicate next instances guarded, and spawn failures logged non-fatally.
- Added focused recurrence unit tests covering interval advancement, month/year clamping, late-completion roll-forward, and immutability.

## Verification

- `pnpm exec vitest run packages/shared/src/issue-recurrence.test.ts`
- `pnpm --filter @paperclipai/shared typecheck`
- `pnpm --filter @paperclipai/server typecheck`
- Previous broader verification on this branch also passed for db/plugin-sdk/ui typecheck, migration numbering, and embedded-postgres migration application.

## Risks

- Low migration risk: the schema change is additive and all new columns are nullable.
- Recurrence spawning is intentionally non-fatal, so a spawn error cannot block the original issue completion.
- The API foundation lands before UI controls; users need API/client support to set these fields until a UI follow-up is added.
- Completion-based recurrence is not a replacement for scheduled routines; scheduled execution remains owned by the routines system.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected - check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex, GPT-5 coding agent with local shell/tool use.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [ ] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
