### PR TITLE
fix(codex): reset incompatible resumed sessions

### DIFF
--- a/server/src/__tests__/heartbeat-model-profile.test.ts
+++ b/server/src/__tests__/heartbeat-model-profile.test.ts
@@ -41,6 +41,23 @@ describe("heartbeat model profile application", () => {
     });
   });
 
+  it("uses the cheap model as the effective model even when the primary Codex model is explicit", async () => {
+    const modelProfile = resolveModelProfileApplication({
+      adapterModelProfiles: await listAdapterModelProfiles("codex_local"),
+      agentRuntimeConfig: {},
+      issueModelProfile: null,
+      contextSnapshot: { modelProfile: "cheap" },
+    });
+
+    const merged = mergeModelProfileAdapterConfig({
+      baseConfig: { model: "gpt-5.5" },
+      modelProfile,
+      issueAdapterConfig: null,
+    });
+
+    expect(merged.model).toBe("gpt-5.3-codex-spark");
+  });
+
   it("applies cheap profile patches before explicit issue adapter config overrides", () => {
     const modelProfile = resolveModelProfileApplication({
       adapterModelProfiles: [cheapProfile],

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -6,6 +6,7 @@ import {
   activityLog,
   agents,
   agentRuntimeState,
+  agentTaskSessions,
   agentWakeupRequests,
   budgetPolicies,
   companySecretBindings,
@@ -347,6 +348,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     await new Promise((resolve) => setTimeout(resolve, 100));
     await db.delete(activityLog);
     await db.delete(agentRuntimeState);
+    await db.delete(agentTaskSessions);
     await db.delete(companySkills);
     await db.delete(costEvents);
     await db.delete(workspaceOperations);
@@ -1162,6 +1164,301 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
 
     return { companyId, agentId, runId, wakeupRequestId, issueId };
   }
+
+  it("suppresses an explicit source-run resume when a cheap recovery profile resets the task session", async () => {
+    const { companyId, agentId, runId: sourceRunId, issueId } = await seedStrandedIssueFixture({
+      status: "in_progress",
+      runStatus: "succeeded",
+      livenessState: "advanced",
+    });
+    const sourceSessionId = "primary-sol-session";
+
+    await db
+      .update(agents)
+      .set({ adapterConfig: { model: "gpt-5.5" }, updatedAt: new Date() })
+      .where(eq(agents.id, agentId));
+    await db
+      .update(heartbeatRuns)
+      .set({
+        sessionIdAfter: sourceSessionId,
+        resultJson: { sessionId: sourceSessionId },
+        updatedAt: new Date(),
+      })
+      .where(eq(heartbeatRuns.id, sourceRunId));
+    await db.insert(agentTaskSessions).values({
+      companyId,
+      agentId,
+      adapterType: "codex_local",
+      taskKey: issueId,
+      sessionParamsJson: {
+        sessionId: sourceSessionId,
+        __paperclipConfiguredModel: "gpt-5.5",
+      },
+      sessionDisplayId: sourceSessionId,
+      lastRunId: sourceRunId,
+    });
+    mockAdapterExecute.mockImplementationOnce(async () => {
+      await db
+        .update(issues)
+        .set({ status: "done", completedAt: new Date(), updatedAt: new Date() })
+        .where(eq(issues.id, issueId));
+      return {
+        exitCode: 0,
+        signal: null,
+        timedOut: false,
+        errorMessage: null,
+        summary: "Status-only recovery completed without resuming the primary model session.",
+        provider: "test",
+        model: "gpt-5.3-codex-spark",
+      };
+    });
+    const heartbeat = heartbeatService(db);
+
+    const recoveryRun = await heartbeat.wakeup(agentId, {
+      source: "automation",
+      triggerDetail: "system",
+      reason: "status_only_recovery",
+      payload: {
+        issueId,
+        modelProfile: "cheap",
+        resumeFromRunId: sourceRunId,
+        allowDeliverableWork: false,
+        allowDocumentUpdates: false,
+        resumeRequiresNormalModel: true,
+      },
+      contextSnapshot: {
+        issueId,
+        taskId: issueId,
+        wakeReason: "status_only_recovery",
+      },
+    });
+
+    expect(recoveryRun).not.toBeNull();
+    const settledRun = await waitForRunToSettle(heartbeat, recoveryRun!.id, 5_000);
+    expect(settledRun?.status).toBe("succeeded");
+    expect(mockAdapterExecute).toHaveBeenCalledTimes(1);
+
+    const adapterInput = mockAdapterExecute.mock.calls[0]?.[0] as {
+      runtime: {
+        sessionId: string | null;
+        sessionParams: Record<string, unknown> | null;
+        sessionDisplayId: string | null;
+      };
+    };
+    expect(adapterInput.runtime).toMatchObject({
+      sessionId: null,
+      sessionParams: null,
+      sessionDisplayId: null,
+    });
+
+    const persistedContext = settledRun?.contextSnapshot as Record<string, unknown>;
+    expect(persistedContext).toMatchObject({
+      resumeFromRunId: sourceRunId,
+      resumeSessionDisplayId: sourceSessionId,
+      resumeSessionParams: {
+        sessionId: sourceSessionId,
+      },
+      paperclipModelProfile: {
+        requested: "cheap",
+        applied: "cheap",
+      },
+    });
+    expect(settledRun?.resultJson).toMatchObject({
+      configFreshness: {
+        session: {
+          reset: true,
+          resetReasons: expect.arrayContaining([
+            'configured model changed from "gpt-5.5" to "gpt-5.3-codex-spark"',
+          ]),
+          taskSessionAvailable: true,
+          taskSessionReused: false,
+        },
+      },
+      modelProfile: {
+        requested: "cheap",
+        applied: "cheap",
+      },
+    });
+  });
+
+  it.each([
+    {
+      name: "starts fresh for an older explicit session that used a different model",
+      sourceRunStatus: "succeeded" as const,
+      sourceModel: "gpt-5.3-codex-spark",
+      taskSessionKind: "verified-current" as const,
+      shouldResume: false,
+      expectedResetReason: 'explicit resume session model changed from "gpt-5.3-codex-spark" to "gpt-5.5"',
+    },
+    {
+      name: "resumes an older explicit session that used the same model",
+      sourceRunStatus: "succeeded" as const,
+      sourceModel: "gpt-5.5",
+      taskSessionKind: "verified-current" as const,
+      shouldResume: true,
+      expectedResetReason: null,
+    },
+    {
+      name: "resumes a compatible source session when the current task session is missing",
+      sourceRunStatus: "succeeded" as const,
+      sourceModel: "gpt-5.5",
+      taskSessionKind: "none" as const,
+      shouldResume: true,
+      expectedResetReason: null,
+    },
+    {
+      name: "fails closed when a failed source run only records an attempted compatible model",
+      sourceRunStatus: "failed" as const,
+      sourceModel: "gpt-5.5",
+      taskSessionKind: "none" as const,
+      shouldResume: false,
+      expectedResetReason: "explicit Codex resume session compatibility cannot be verified",
+    },
+    {
+      name: "fails closed for a failed source run sharing an unverified legacy task session",
+      sourceRunStatus: "failed" as const,
+      sourceModel: "gpt-5.5",
+      taskSessionKind: "legacy-source" as const,
+      shouldResume: false,
+      expectedResetReason: "explicit Codex resume session compatibility cannot be verified",
+    },
+  ])("$name", async ({
+    sourceRunStatus,
+    sourceModel,
+    taskSessionKind,
+    shouldResume,
+    expectedResetReason,
+  }) => {
+    const { companyId, agentId, runId: sourceRunId, issueId } = await seedStrandedIssueFixture({
+      status: "in_progress",
+      runStatus: sourceRunStatus,
+      livenessState: "advanced",
+    });
+    const currentSolSessionId = "current-sol-session";
+    const sourceSessionId = "selected-source-session";
+
+    await db
+      .update(agents)
+      .set({ adapterConfig: { model: "gpt-5.5" }, updatedAt: new Date() })
+      .where(eq(agents.id, agentId));
+    await db
+      .update(heartbeatRuns)
+      .set({
+        sessionIdAfter: sourceSessionId,
+        resultJson: {
+          sessionId: sourceSessionId,
+          model: sourceModel,
+        },
+        updatedAt: new Date(),
+      })
+      .where(eq(heartbeatRuns.id, sourceRunId));
+    const hasTaskSession = taskSessionKind !== "none";
+    if (hasTaskSession) {
+      const taskSessionId = taskSessionKind === "legacy-source"
+        ? sourceSessionId
+        : currentSolSessionId;
+      await db.insert(agentTaskSessions).values({
+        companyId,
+        agentId,
+        adapterType: "codex_local",
+        taskKey: issueId,
+        sessionParamsJson: taskSessionKind === "legacy-source"
+          ? { sessionId: taskSessionId }
+          : {
+              sessionId: taskSessionId,
+              __paperclipConfiguredModel: "gpt-5.5",
+            },
+        sessionDisplayId: taskSessionId,
+        lastRunId: null,
+      });
+    }
+    mockAdapterExecute.mockImplementationOnce(async () => {
+      await db
+        .update(issues)
+        .set({ status: "done", completedAt: new Date(), updatedAt: new Date() })
+        .where(eq(issues.id, issueId));
+      return {
+        exitCode: 0,
+        signal: null,
+        timedOut: false,
+        errorMessage: null,
+        summary: shouldResume
+          ? "Resumed the selected compatible source session."
+          : "Started fresh instead of resuming the incompatible source session.",
+        provider: "test",
+        model: "gpt-5.5",
+      };
+    });
+    const heartbeat = heartbeatService(db);
+
+    const recoveryRun = await heartbeat.wakeup(agentId, {
+      source: "automation",
+      triggerDetail: "system",
+      reason: "issue_blockers_resolved",
+      payload: {
+        issueId,
+        resumeFromRunId: sourceRunId,
+        interactionId: "accepted-plan-continuation",
+        interactionKind: "request_confirmation",
+        interactionStatus: "accepted",
+        mutation: "interaction",
+      },
+      contextSnapshot: {
+        issueId,
+        taskId: issueId,
+        wakeReason: "issue_blockers_resolved",
+        workspaceRefreshReason: "accepted_plan_confirmation",
+      },
+    });
+
+    expect(recoveryRun).not.toBeNull();
+    const settledRun = await waitForRunToSettle(heartbeat, recoveryRun!.id, 5_000);
+    expect(settledRun?.status).toBe("succeeded");
+    expect(mockAdapterExecute).toHaveBeenCalledTimes(1);
+
+    const adapterInput = mockAdapterExecute.mock.calls[0]?.[0] as {
+      runtime: {
+        sessionId: string | null;
+        sessionParams: Record<string, unknown> | null;
+        sessionDisplayId: string | null;
+      };
+    };
+    expect(adapterInput.runtime).toMatchObject(shouldResume
+      ? {
+          sessionId: sourceSessionId,
+          sessionParams: { sessionId: sourceSessionId },
+          sessionDisplayId: sourceSessionId,
+        }
+      : {
+          sessionId: null,
+          sessionParams: null,
+          sessionDisplayId: null,
+        });
+
+    const persistedContext = settledRun?.contextSnapshot as Record<string, unknown>;
+    expect(persistedContext).toMatchObject({
+      resumeFromRunId: sourceRunId,
+      resumeSessionDisplayId: sourceSessionId,
+      resumeSessionParams: {
+        sessionId: sourceSessionId,
+      },
+    });
+    if (sourceRunStatus === "succeeded") {
+      expect(persistedContext).toMatchObject({ resumeSessionConfiguredModel: sourceModel });
+    } else {
+      expect(persistedContext).not.toHaveProperty("resumeSessionConfiguredModel");
+    }
+    expect(settledRun?.resultJson).toMatchObject({
+      configFreshness: {
+        session: {
+          reset: !shouldResume,
+          resetReasons: expectedResetReason ? [expectedResetReason] : [],
+          taskSessionAvailable: hasTaskSession,
+          taskSessionReused: shouldResume && hasTaskSession,
+        },
+      },
+    });
+  });
 
   it("keeps a local run active when the recorded pid is still alive", async () => {
     const child = spawnAliveProcess();

--- a/server/src/__tests__/heartbeat-workspace-session.test.ts
+++ b/server/src/__tests__/heartbeat-workspace-session.test.ts
@@ -16,6 +16,7 @@ import {
   buildEffectiveRunSessionConfigMetadata,
   buildEffectiveRunWorkspaceConfigMetadata,
   buildWorkspaceConfigFreshnessOperation,
+  decodePersistedTaskSessionParams,
   deriveTaskKeyWithHeartbeatFallback,
   extractWakeCommentIds,
   formatRuntimeWorkspaceWarningLog,
@@ -28,6 +29,7 @@ import {
   resolveExecutionWorkspaceConfigFreshness,
   resolveExecutionWorkspaceReuseRequestForIssue,
   resolveExecutionWorkspaceReuseProvisioningPolicy,
+  resolveExplicitResumeSessionCompatibility,
   resolveNextSessionState,
   resolveTaskSessionConfigFreshness,
   requiresPushCapabilityPreflight,
@@ -1685,7 +1687,7 @@ describe("shouldResetTaskSessionForModelChange", () => {
     ).toBe(false);
   });
 
-  it("does not reset when configured model is missing", () => {
+  it("resets when an explicit session model returns to the adapter/CLI default", () => {
     expect(
       shouldResetTaskSessionForModelChange({
         configuredModel: null,
@@ -1694,7 +1696,7 @@ describe("shouldResetTaskSessionForModelChange", () => {
           __paperclipConfiguredModel: "gpt-5.4-mini",
         },
       }),
-    ).toBe(false);
+    ).toBe(true);
   });
 
   it("does not reset when task session params are missing", () => {
@@ -1797,6 +1799,49 @@ function sessionParamsWithConfigMetadata(
 }
 
 describe("effective run session config freshness", () => {
+  it("keeps Paperclip metadata outside the Codex resume codec and resets cheap sessions before implicit-default runs", async () => {
+    const cheap = await buildSessionConfigMetadata({
+      effectiveAdapterConfig: {
+        command: "codex",
+        model: "gpt-5.3-codex-spark",
+      },
+      modelProfile: {
+        requested: "cheap",
+        requestedBy: "wake_context",
+        applied: "cheap",
+        configSource: "adapter_default",
+        fallbackReason: null,
+      },
+    });
+    const normal = await buildSessionConfigMetadata({
+      effectiveAdapterConfig: {
+        command: "codex",
+      },
+      modelProfile: null,
+    });
+    const persistedParams = sessionParamsWithConfigMetadata(cheap, "gpt-5.3-codex-spark");
+    const params = decodePersistedTaskSessionParams({
+      sessionCodec: codexSessionCodec,
+      sessionParamsJson: persistedParams,
+    });
+
+    expect(params.resumeParams).toEqual({ sessionId: "thread-1" });
+    expect(params.freshnessParams).toEqual(persistedParams);
+
+    const decision = resolveTaskSessionConfigFreshness({
+      hasTaskSession: true,
+      configuredModel: null,
+      taskSessionParams: params.freshnessParams,
+      configMetadata: normal,
+    });
+
+    expect(decision.reset).toBe(true);
+    expect(decision.changedCategories).toEqual(expect.arrayContaining(["adapterConfig", "modelProfile"]));
+    expect(decision.reasons).toContain(
+      'configured model changed from "gpt-5.3-codex-spark" to the adapter/CLI default',
+    );
+  });
+
   it("resets when effective adapter config changes after model/profile/env resolution", async () => {
     const base = await buildSessionConfigMetadata();
     const next = await buildSessionConfigMetadata({
@@ -2167,6 +2212,148 @@ describe("comment wake batching", () => {
     );
 
     expect(merged.forceFreshSession).toBe(true);
+  });
+});
+
+describe("resolveExplicitResumeSessionCompatibility", () => {
+  it("allows an explicit resume when it identifies the current task session", () => {
+    expect(resolveExplicitResumeSessionCompatibility({
+      adapterType: "codex_local",
+      explicitResumeRequested: true,
+      explicitResumeSessionParams: { sessionId: "same-session" },
+      explicitResumeSessionDisplayId: "same-session",
+      explicitResumeConfigFingerprint: null,
+      explicitResumeConfiguredModel: null,
+      taskSessionParams: { sessionId: "same-session" },
+      taskSessionDisplayId: "same-session",
+      taskSessionConfigVerified: true,
+      currentConfigFingerprint: "current-fingerprint",
+      currentConfiguredModel: "gpt-5.5",
+    })).toEqual({ reset: false, reason: null });
+  });
+
+  it("does not trust a matching Codex session identity without verified task metadata", () => {
+    expect(resolveExplicitResumeSessionCompatibility({
+      adapterType: "codex_local",
+      explicitResumeRequested: true,
+      explicitResumeSessionParams: { sessionId: "same-session" },
+      explicitResumeSessionDisplayId: "same-session",
+      explicitResumeConfigFingerprint: null,
+      explicitResumeConfiguredModel: null,
+      taskSessionParams: { sessionId: "same-session" },
+      taskSessionDisplayId: "same-session",
+      taskSessionConfigVerified: false,
+      currentConfigFingerprint: "current-fingerprint",
+      currentConfiguredModel: "gpt-5.5",
+    })).toEqual({
+      reset: true,
+      reason: "explicit Codex resume session compatibility cannot be verified",
+    });
+  });
+
+  it("allows an older explicit session when its persisted effective config matches", () => {
+    expect(resolveExplicitResumeSessionCompatibility({
+      adapterType: "codex_local",
+      explicitResumeRequested: true,
+      explicitResumeSessionParams: { sessionId: "older-session" },
+      explicitResumeSessionDisplayId: "older-session",
+      explicitResumeConfigFingerprint: "same-fingerprint",
+      explicitResumeConfiguredModel: null,
+      taskSessionParams: { sessionId: "current-session" },
+      taskSessionDisplayId: "current-session",
+      taskSessionConfigVerified: true,
+      currentConfigFingerprint: "same-fingerprint",
+      currentConfiguredModel: "gpt-5.5",
+    })).toEqual({ reset: false, reason: null });
+  });
+
+  it("resets an older explicit session when its persisted effective config differs", () => {
+    expect(resolveExplicitResumeSessionCompatibility({
+      adapterType: "codex_local",
+      explicitResumeRequested: true,
+      explicitResumeSessionParams: { sessionId: "older-session" },
+      explicitResumeSessionDisplayId: "older-session",
+      explicitResumeConfigFingerprint: "older-fingerprint",
+      explicitResumeConfiguredModel: "gpt-5.5",
+      taskSessionParams: { sessionId: "current-session" },
+      taskSessionDisplayId: "current-session",
+      taskSessionConfigVerified: true,
+      currentConfigFingerprint: "current-fingerprint",
+      currentConfiguredModel: "gpt-5.5",
+    })).toEqual({
+      reset: true,
+      reason: "explicit resume session effective configuration differs from the current run",
+    });
+  });
+
+  it("fails closed when an older explicit session used a different model", () => {
+    expect(resolveExplicitResumeSessionCompatibility({
+      adapterType: "codex_local",
+      explicitResumeRequested: true,
+      explicitResumeSessionParams: { sessionId: "older-session" },
+      explicitResumeSessionDisplayId: "older-session",
+      explicitResumeConfigFingerprint: null,
+      explicitResumeConfiguredModel: "gpt-5.3-codex-spark",
+      taskSessionParams: { sessionId: "current-session" },
+      taskSessionDisplayId: "current-session",
+      taskSessionConfigVerified: true,
+      currentConfigFingerprint: "current-fingerprint",
+      currentConfiguredModel: "gpt-5.5",
+    })).toEqual({
+      reset: true,
+      reason: 'explicit resume session model changed from "gpt-5.3-codex-spark" to "gpt-5.5"',
+    });
+  });
+
+  it("allows a verified compatible source session when no current task session exists", () => {
+    expect(resolveExplicitResumeSessionCompatibility({
+      adapterType: "codex_local",
+      explicitResumeRequested: true,
+      explicitResumeSessionParams: { sessionId: "older-session" },
+      explicitResumeSessionDisplayId: "older-session",
+      explicitResumeConfigFingerprint: "same-fingerprint",
+      explicitResumeConfiguredModel: null,
+      taskSessionParams: null,
+      taskSessionDisplayId: null,
+      taskSessionConfigVerified: false,
+      currentConfigFingerprint: "same-fingerprint",
+      currentConfiguredModel: "gpt-5.5",
+    })).toEqual({ reset: false, reason: null });
+  });
+
+  it("fails closed for an unverifiable historical Codex session", () => {
+    expect(resolveExplicitResumeSessionCompatibility({
+      adapterType: "codex_local",
+      explicitResumeRequested: true,
+      explicitResumeSessionParams: { sessionId: "older-session" },
+      explicitResumeSessionDisplayId: "older-session",
+      explicitResumeConfigFingerprint: null,
+      explicitResumeConfiguredModel: null,
+      taskSessionParams: null,
+      taskSessionDisplayId: null,
+      taskSessionConfigVerified: false,
+      currentConfigFingerprint: "current-fingerprint",
+      currentConfiguredModel: "gpt-5.5",
+    })).toEqual({
+      reset: true,
+      reason: "explicit Codex resume session compatibility cannot be verified",
+    });
+  });
+
+  it("preserves unverifiable historical resumes for other adapters", () => {
+    expect(resolveExplicitResumeSessionCompatibility({
+      adapterType: "claude_local",
+      explicitResumeRequested: true,
+      explicitResumeSessionParams: { sessionId: "older-session" },
+      explicitResumeSessionDisplayId: "older-session",
+      explicitResumeConfigFingerprint: null,
+      explicitResumeConfiguredModel: null,
+      taskSessionParams: null,
+      taskSessionDisplayId: null,
+      taskSessionConfigVerified: false,
+      currentConfigFingerprint: "current-fingerprint",
+      currentConfiguredModel: "claude-opus-4-1",
+    })).toEqual({ reset: false, reason: null });
   });
 });
 

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -2340,6 +2340,100 @@ type ResumeSessionRow = {
   lastRunId: string | null;
 };
 
+function readSessionIdentity(
+  sessionParams: Record<string, unknown> | null | undefined,
+  sessionDisplayId: string | null | undefined,
+) {
+  return (
+    readNonEmptyString(sessionParams?.sessionId) ??
+    readNonEmptyString(sessionParams?.session_id) ??
+    readNonEmptyString(sessionDisplayId)
+  );
+}
+
+export function resolveExplicitResumeSessionCompatibility(input: {
+  adapterType: string | null | undefined;
+  explicitResumeRequested: boolean;
+  explicitResumeSessionParams: Record<string, unknown> | null | undefined;
+  explicitResumeSessionDisplayId: string | null | undefined;
+  explicitResumeConfigFingerprint: string | null | undefined;
+  explicitResumeConfiguredModel: string | null | undefined;
+  taskSessionParams: Record<string, unknown> | null | undefined;
+  taskSessionDisplayId: string | null | undefined;
+  taskSessionConfigVerified: boolean;
+  currentConfigFingerprint: string | null | undefined;
+  currentConfiguredModel: string | null | undefined;
+}) {
+  if (!input.explicitResumeRequested) {
+    return { reset: false, reason: null as string | null };
+  }
+
+  const explicitSessionIdentity = readSessionIdentity(
+    input.explicitResumeSessionParams,
+    input.explicitResumeSessionDisplayId,
+  );
+  if (!explicitSessionIdentity) {
+    return {
+      reset: true,
+      reason: "explicit resume session identity is missing",
+    };
+  }
+
+  const taskSessionIdentity = readSessionIdentity(
+    input.taskSessionParams,
+    input.taskSessionDisplayId,
+  );
+  if (
+    input.taskSessionConfigVerified &&
+    taskSessionIdentity &&
+    explicitSessionIdentity === taskSessionIdentity
+  ) {
+    // The normal task-session freshness check validates the effective config
+    // for this exact session identity.
+    return { reset: false, reason: null as string | null };
+  }
+
+  const explicitConfigFingerprint = readNonEmptyString(input.explicitResumeConfigFingerprint);
+  const currentConfigFingerprint = readNonEmptyString(input.currentConfigFingerprint);
+  if (explicitConfigFingerprint && currentConfigFingerprint) {
+    if (explicitConfigFingerprint === currentConfigFingerprint) {
+      return { reset: false, reason: null as string | null };
+    }
+    return {
+      reset: true,
+      reason: "explicit resume session effective configuration differs from the current run",
+    };
+  }
+
+  const explicitConfiguredModel = readNonEmptyString(input.explicitResumeConfiguredModel);
+  if (explicitConfiguredModel) {
+    if (explicitConfiguredModel === input.currentConfiguredModel) {
+      return { reset: false, reason: null as string | null };
+    }
+    const nextModel = input.currentConfiguredModel
+      ? `"${input.currentConfiguredModel}"`
+      : "the adapter/CLI default";
+    return {
+      reset: true,
+      reason: `explicit resume session model changed from "${explicitConfiguredModel}" to ${nextModel}`,
+    };
+  }
+
+  // Codex can compact before the selected model samples. If the selected
+  // historical session cannot be tied to a known effective config/model, a
+  // speculative resume can therefore fail before doing any useful work.
+  if (input.adapterType === "codex_local") {
+    return {
+      reset: true,
+      reason: "explicit Codex resume session compatibility cannot be verified",
+    };
+  }
+
+  // Preserve the established explicit-resume behavior for adapters that do
+  // not currently persist enough metadata for a compatibility decision.
+  return { reset: false, reason: null as string | null };
+}
+
 export function buildExplicitResumeSessionOverride(input: {
   adapterType?: string | null;
   resumeFromRunId: string;
@@ -3640,7 +3734,7 @@ export function shouldResetTaskSessionForModelChange(input: {
   taskSessionParams: Record<string, unknown> | null | undefined;
 }) {
   const { configuredModel, taskSessionParams } = input;
-  if (!configuredModel || !taskSessionParams) return false;
+  if (!taskSessionParams) return false;
   const sessionModel = readConfiguredModelFromSessionParams(taskSessionParams);
   return !!sessionModel && sessionModel !== configuredModel;
 }
@@ -3691,7 +3785,10 @@ export function resolveTaskSessionConfigFreshness(input: {
     taskSessionParams: input.taskSessionParams,
   });
   if (modelChangedSinceTaskSession && taskSessionConfiguredModel) {
-    reasons.push(`configured model changed from "${taskSessionConfiguredModel}" to "${input.configuredModel}"`);
+    const nextModel = input.configuredModel
+      ? `"${input.configuredModel}"`
+      : "the adapter/CLI default";
+    reasons.push(`configured model changed from "${taskSessionConfiguredModel}" to ${nextModel}`);
   }
 
   let changedCategories: EffectiveRunSessionConfigCategory[] = [];
@@ -4716,6 +4813,21 @@ function getAdapterSessionCodec(adapterType: string) {
 export function normalizeSessionParams(params: Record<string, unknown> | null | undefined) {
   if (!params) return null;
   return Object.keys(params).length > 0 ? params : null;
+}
+
+export function decodePersistedTaskSessionParams(input: {
+  sessionCodec: AdapterSessionCodec;
+  sessionParamsJson: Record<string, unknown> | null | undefined;
+}) {
+  // Adapter codecs intentionally keep only adapter-owned resume fields. Read
+  // Paperclip's freshness metadata from the persisted envelope before the
+  // codec strips unknown keys.
+  const freshnessParams = normalizeSessionParams(parseObject(input.sessionParamsJson));
+  const resumeParams = normalizeSessionParams(input.sessionCodec.deserialize(freshnessParams));
+  return {
+    freshnessParams,
+    resumeParams,
+  };
 }
 
 type RunSessionOutcome = "succeeded" | "interrupted" | "failed" | "cancelled" | "timed_out";
@@ -6255,8 +6367,10 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     const resumeRun = await db
       .select({
         id: heartbeatRuns.id,
+        status: heartbeatRuns.status,
         contextSnapshot: heartbeatRuns.contextSnapshot,
         resultJson: heartbeatRuns.resultJson,
+        usageJson: heartbeatRuns.usageJson,
         sessionIdBefore: heartbeatRuns.sessionIdBefore,
         sessionIdAfter: heartbeatRuns.sessionIdAfter,
       })
@@ -6278,6 +6392,18 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       : null;
     const sessionCodec = getAdapterSessionCodec(agent.adapterType);
     const resumeRunResult = parseObject(resumeRun.resultJson);
+    const resumeRunConfigFreshness = parseObject(resumeRunResult.configFreshness);
+    const resumeRunSessionConfigFreshness = parseObject(resumeRunConfigFreshness.session);
+    const resumeRunUsage = parseObject(resumeRun.usageJson);
+    // Attempted config/model metadata does not prove that a failed run ever
+    // sampled with it. Only a successful source run can establish metadata
+    // for a historical session that is no longer the current task session.
+    const resumeSessionConfigFingerprint = resumeRun.status === "succeeded"
+      ? readNonEmptyString(resumeRunSessionConfigFreshness.nextFingerprint)
+      : null;
+    const resumeSessionConfiguredModel = resumeRun.status === "succeeded"
+      ? readNonEmptyString(resumeRunUsage.model) ?? readNonEmptyString(resumeRunResult.model)
+      : null;
     const resumeRunSessionId = requiresCanonicalSessionIds(agent.adapterType)
       ? readNonEmptyString(resumeRunResult.sessionId) ?? readNonEmptyString(resumeRunResult.session_id)
       : null;
@@ -6299,6 +6425,8 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       taskId: readNonEmptyString(resumeContext.taskId) ?? readNonEmptyString(resumeContext.issueId),
       sessionDisplayId: sessionOverride.sessionDisplayId,
       sessionParams: sessionOverride.sessionParams,
+      sessionConfigFingerprint: resumeSessionConfigFingerprint,
+      sessionConfiguredModel: resumeSessionConfiguredModel,
     };
   }
 
@@ -10362,8 +10490,17 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     const taskSession = taskKey
       ? await getTaskSession(agent.companyId, agent.id, agent.adapterType, taskKey)
       : null;
-    const taskSessionDecodedParams = normalizeSessionParams(
-      sessionCodec.deserialize(taskSession?.sessionParamsJson ?? null),
+    const {
+      freshnessParams: taskSessionFreshnessParams,
+      resumeParams: taskSessionDecodedParams,
+    } = decodePersistedTaskSessionParams({
+      sessionCodec,
+      sessionParamsJson: taskSession?.sessionParamsJson,
+    });
+    const taskSessionDisplayId = truncateDisplayId(
+      (sessionCodec.getDisplayId ? sessionCodec.getDisplayId(taskSessionDecodedParams) : null) ??
+        readNonEmptyString(taskSessionDecodedParams?.sessionId) ??
+        taskSession?.sessionDisplayId,
     );
     const explicitResumeSessionParams = normalizeResumeParamsForAdapter(
       agent.adapterType,
@@ -10747,18 +10884,53 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     const sessionConfigFreshness = resolveTaskSessionConfigFreshness({
       hasTaskSession: taskSession != null,
       configuredModel,
-      taskSessionParams: taskSessionDecodedParams,
+      taskSessionParams: taskSessionFreshnessParams,
       configMetadata: sessionConfigMetadata,
       wakeResetReason: wakeSessionResetReason,
       preserveLegacySessionWithoutConfigMetadata: acceptedPlanContinuationWake && !acceptedPlanWakeRoutingDecision,
     });
-    const resetTaskSession = shouldResetTaskSessionForWake(context) || sessionConfigFreshness.reset;
-    const sessionResetReason = sessionConfigFreshness.reasons.join("; ") || null;
+    const taskSessionConfiguredModel = readConfiguredModelFromSessionParams(taskSessionFreshnessParams);
+    const explicitResumeSessionCompatibility = resolveExplicitResumeSessionCompatibility({
+      adapterType: agent.adapterType,
+      explicitResumeRequested: Boolean(
+        readNonEmptyString(context.resumeFromRunId) ||
+        explicitResumeSessionParams ||
+        explicitResumeSessionDisplayId,
+      ),
+      explicitResumeSessionParams,
+      explicitResumeSessionDisplayId,
+      explicitResumeConfigFingerprint: readNonEmptyString(context.resumeSessionConfigFingerprint),
+      explicitResumeConfiguredModel: readNonEmptyString(context.resumeSessionConfiguredModel),
+      taskSessionParams: taskSessionDecodedParams,
+      taskSessionDisplayId,
+      taskSessionConfigVerified:
+        !sessionConfigFreshness.reset &&
+        (
+          Boolean(sessionConfigFreshness.storedFingerprint) ||
+          (
+            taskSessionConfiguredModel != null &&
+            taskSessionConfiguredModel === configuredModel
+          )
+        ),
+      currentConfigFingerprint: sessionConfigMetadata.fingerprint,
+      currentConfiguredModel: configuredModel,
+    });
+    const taskSessionResetReasons = [
+      ...sessionConfigFreshness.reasons,
+      ...(explicitResumeSessionCompatibility.reason ? [explicitResumeSessionCompatibility.reason] : []),
+    ];
+    const resetTaskSession =
+      shouldResetTaskSessionForWake(context) ||
+      sessionConfigFreshness.reset ||
+      explicitResumeSessionCompatibility.reset;
+    const sessionResetReason = taskSessionResetReasons.join("; ") || null;
     const taskSessionForRun = resetTaskSession ? null : taskSession;
+    const explicitResumeSessionParamsForRun = resetTaskSession ? null : explicitResumeSessionParams;
+    const explicitResumeSessionDisplayIdForRun = resetTaskSession ? null : explicitResumeSessionDisplayId;
     const previousSessionParams =
-      explicitResumeSessionParams ??
-      (isCanonicalSessionIdForAdapter(agent.adapterType, explicitResumeSessionDisplayId)
-        ? { sessionId: explicitResumeSessionDisplayId }
+      explicitResumeSessionParamsForRun ??
+      (isCanonicalSessionIdForAdapter(agent.adapterType, explicitResumeSessionDisplayIdForRun)
+        ? { sessionId: explicitResumeSessionDisplayIdForRun }
         : null) ??
       normalizeResumeParamsForAdapter(
         agent.adapterType,
@@ -11282,7 +11454,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         ? runtime.sessionId
         : null;
     const runtimeSessionDisplayId = truncateDisplayId(
-      explicitResumeSessionDisplayId ??
+      explicitResumeSessionDisplayIdForRun ??
         taskSessionForRun?.sessionDisplayId ??
         (sessionCodec.getDisplayId ? sessionCodec.getDisplayId(runtimeSessionParams) : null) ??
         readNonEmptyString(runtimeSessionParams?.sessionId) ??
@@ -11337,7 +11509,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         fingerprintVersion: sessionConfigMetadata.version,
         categories: sessionConfigMetadata.categories,
         reset: resetTaskSession,
-        resetReasons: sessionConfigFreshness.reasons,
+        resetReasons: taskSessionResetReasons,
         changedCategories: sessionConfigFreshness.changedCategories,
         taskSessionAvailable: taskSession != null,
         taskSessionReused: taskSessionForRun != null,
@@ -13379,6 +13551,16 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       enrichedContextSnapshot.resumeFromRunId = explicitResumeSession.resumeFromRunId;
       enrichedContextSnapshot.resumeSessionDisplayId = explicitResumeSession.sessionDisplayId;
       enrichedContextSnapshot.resumeSessionParams = explicitResumeSession.sessionParams;
+      if (explicitResumeSession.sessionConfigFingerprint) {
+        enrichedContextSnapshot.resumeSessionConfigFingerprint = explicitResumeSession.sessionConfigFingerprint;
+      } else {
+        delete enrichedContextSnapshot.resumeSessionConfigFingerprint;
+      }
+      if (explicitResumeSession.sessionConfiguredModel) {
+        enrichedContextSnapshot.resumeSessionConfiguredModel = explicitResumeSession.sessionConfiguredModel;
+      } else {
+        delete enrichedContextSnapshot.resumeSessionConfiguredModel;
+      }
       if (!readNonEmptyString(enrichedContextSnapshot.issueId) && explicitResumeSession.issueId) {
         enrichedContextSnapshot.issueId = explicitResumeSession.issueId;
       }


### PR DESCRIPTION
## Thinking Path

> - Paperclip coordinates repeatable work by persisting adapter sessions across heartbeats for the same task.
> - The heartbeat service also applies model profiles, so the effective adapter model can change between normal work and cheap recovery work.
> - A persisted Codex session is not always safe to resume after that effective configuration changes.
> - Paperclip's adapter codec could discard Paperclip-owned compatibility metadata before freshness evaluation, while an explicit source-run resume could bypass an earlier reset decision.
> - This pull request keeps the metadata needed for comparison, evaluates the fully merged configuration, and validates any explicit historical resume before it reaches the adapter.
> - The benefit is that compatible sessions retain continuity while incompatible Codex sessions start fresh instead of entering pre-sampling compaction or failing before useful work begins.

## Linked Issues or Issue Description

- Fixes #9177
- Refs #2088

## What Changed

- Preserve Paperclip-owned session configuration metadata before adapter session-codec deserialization.
- Compare stored task sessions against the current effective adapter configuration after model-profile and issue-level overrides are merged.
- Suppress explicit `resumeFromRunId` session parameters when session freshness requires a reset.
- Validate historical Codex resumes using successful source-run model/fingerprint metadata, fail closed when compatibility cannot be verified, and leave existing non-Codex historical-resume behavior unchanged.
- Add regression coverage for normal/cheap profile transitions, compatible and incompatible explicit historical resumes, missing task sessions, failed source runs, legacy session records, and non-Codex adapters.

No database migration or public API change is required.

## Verification

- Rebased onto `master` at `555391fed77d3a10949b859dc3e84f108dc052d6`; `git range-diff` confirms the only integration delta is retaining the upstream `interrupted` run outcome alongside this PR's session-decoding helper.
- `npx --yes pnpm@9.15.4 -r typecheck` — passed.
- `npx --yes pnpm@9.15.4 build` — passed.
- Core session/model regression set — 5 files and 226 tests passed.
- Adjacent restart/workspace recovery set — 117 tests passed. Two macOS-only path assertions (`/var` vs `/private/var`) failed identically on an unmodified worktree at the same upstream commit.
- `npx --yes pnpm@9.15.4 test:run` — 245 files passed and 6 files failed (2,092 tests passed, 3 failed, 87 skipped):
  - Four suites hit 10-second setup/cleanup hook timeouts during the 20-minute serialized run; all four passed when rerun individually (128 tests).
  - Two branch-containment assertions compare `/var` with macOS's canonical `/private/var`; both reproduce unchanged on upstream `master`.
  - One worktree-suppression fixture deletes `heartbeat_runs` before `heartbeat_run_events`, causing a foreign-key violation; it reproduces unchanged on upstream `master`.
- `git diff --check upstream/master...HEAD` — passed.

## Risks

- A historical Codex resume with no trustworthy model/fingerprint metadata now starts fresh. This can reduce conversational continuity for legacy or failed runs, but avoids sending an unverifiably compatible session to Codex.
- The stricter fail-closed behavior is scoped to `codex_local`; other adapters retain their prior behavior.
- Compatible same-model/same-configuration task and historical sessions continue to resume, including when the current task-session row is missing.
- Interrupted source runs are not trusted as successful evidence for historical session compatibility; verified current task sessions remain reusable.
- No schema, migration, or external API risk.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex, GPT-5 family (the exact serving revision is not exposed to this agent), with tool use and code execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with the available version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [ ] I have run tests locally and they pass (targeted tests, isolated reruns, typecheck, and build pass; the full suite retains upstream-reproducible macOS failures described above)
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes (not applicable: no user-facing contract changes)
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
