### PR TITLE
fix(server): reuse shared execution workspaces safely

### DIFF
--- a/server/src/__tests__/execution-workspaces-service.test.ts
+++ b/server/src/__tests__/execution-workspaces-service.test.ts
@@ -345,11 +345,12 @@ describeEmbeddedPostgres("executionWorkspaceService.getCloseReadiness", () => {
     expect(readExecutionWorkspaceConfig(byId.get(untouchedWorkspaceId) ?? null)).toBeNull();
   });
 
-  it("limits reusable summaries to open non-shared execution workspaces", async () => {
+  it("includes open shared project-primary sessions in reusable summaries", async () => {
     const companyId = randomUUID();
     const projectId = randomUUID();
     const openWorkspaceId = randomUUID();
     const sharedWorkspaceId = randomUUID();
+    const sharedProjectWorkspaceId = randomUUID();
     const closedWorkspaceId = randomUUID();
 
     await db.insert(companies).values({
@@ -366,6 +367,15 @@ describeEmbeddedPostgres("executionWorkspaceService.getCloseReadiness", () => {
       executionWorkspacePolicy: {
         enabled: true,
       },
+    });
+    await db.insert(projectWorkspaces).values({
+      id: sharedProjectWorkspaceId,
+      companyId,
+      projectId,
+      name: "Primary",
+      sourceType: "local_path",
+      isPrimary: true,
+      cwd: "/tmp/project-primary",
     });
     await db.insert(executionWorkspaces).values([
       {
@@ -384,6 +394,7 @@ describeEmbeddedPostgres("executionWorkspaceService.getCloseReadiness", () => {
         id: sharedWorkspaceId,
         companyId,
         projectId,
+        projectWorkspaceId: sharedProjectWorkspaceId,
         mode: "shared_workspace",
         strategyType: "project_primary",
         name: "Shared session",
@@ -411,6 +422,13 @@ describeEmbeddedPostgres("executionWorkspaceService.getCloseReadiness", () => {
     });
 
     expect(summaries).toEqual([
+      expect.objectContaining({
+        id: sharedWorkspaceId,
+        name: "Shared session",
+        mode: "shared_workspace",
+        status: "active",
+        cwd: "/tmp/project-primary",
+      }),
       expect.objectContaining({
         id: openWorkspaceId,
         name: "Open isolated workspace",

--- a/server/src/__tests__/workspace-runtime.test.ts
+++ b/server/src/__tests__/workspace-runtime.test.ts
@@ -2953,6 +2953,42 @@ describe("realizeExecutionWorkspace", () => {
     });
   });
 
+  it("treats shared project-primary local paths as record-only cleanup", async () => {
+    const workspacePath = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-shared-project-primary-"));
+
+    const cleanup = await cleanupExecutionWorkspaceArtifacts({
+      workspace: {
+        id: "execution-workspace-1",
+        cwd: workspacePath,
+        providerType: "local_fs",
+        providerRef: workspacePath,
+        branchName: null,
+        repoUrl: null,
+        baseRef: null,
+        projectId: "project-1",
+        projectWorkspaceId: "workspace-1",
+        sourceIssueId: "issue-1",
+        mode: "shared_workspace",
+        strategyType: "project_primary",
+        metadata: {
+          createdByRuntime: false,
+          source: "project_primary",
+        },
+      },
+      projectWorkspace: {
+        cwd: workspacePath,
+        cleanupCommand: null,
+      },
+    });
+
+    expect(cleanup.cleaned).toBe(true);
+    expect(cleanup.cleanedPath).toBe(workspacePath);
+    expect(cleanup.warnings).toEqual([
+      `Archived execution workspace record only; kept existing local path "${workspacePath}" because Paperclip did not create it.`,
+    ]);
+    await expect(fs.stat(workspacePath)).resolves.toMatchObject({ isDirectory: expect.any(Function) });
+  });
+
   it("keeps an unmerged runtime-created branch and warns instead of force deleting it", async () => {
     const repoRoot = await createTempRepo();
 

--- a/server/src/__tests__/workspace-runtime.test.ts
+++ b/server/src/__tests__/workspace-runtime.test.ts
@@ -2953,7 +2953,7 @@ describe("realizeExecutionWorkspace", () => {
     });
   });
 
-  it("treats shared project-primary local paths as record-only cleanup", async () => {
+  it("treats shared project-primary local paths as clean record-only cleanup", async () => {
     const workspacePath = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-shared-project-primary-"));
 
     const cleanup = await cleanupExecutionWorkspaceArtifacts({
@@ -2983,9 +2983,7 @@ describe("realizeExecutionWorkspace", () => {
 
     expect(cleanup.cleaned).toBe(true);
     expect(cleanup.cleanedPath).toBe(workspacePath);
-    expect(cleanup.warnings).toEqual([
-      `Archived execution workspace record only; kept existing local path "${workspacePath}" because Paperclip did not create it.`,
-    ]);
+    expect(cleanup.warnings).toEqual([]);
     await expect(fs.stat(workspacePath)).resolves.toMatchObject({ isDirectory: expect.any(Function) });
   });
 

--- a/server/src/services/execution-workspaces.ts
+++ b/server/src/services/execution-workspaces.ts
@@ -468,7 +468,7 @@ export function executionWorkspaceService(db: Db) {
     if (filters?.reuseEligible) {
       conditions.push(inArray(executionWorkspaces.status, ["active", "idle", "in_review"]));
       conditions.push(isNull(executionWorkspaces.closedAt));
-      conditions.push(inArray(executionWorkspaces.mode, ["isolated_workspace", "operator_branch", "adapter_managed", "cloud_sandbox"]));
+      conditions.push(inArray(executionWorkspaces.mode, ["shared_workspace", "isolated_workspace", "operator_branch", "adapter_managed", "cloud_sandbox"]));
     }
     return conditions;
   }
@@ -946,7 +946,7 @@ export function executionWorkspaceService(db: Db) {
         });
       }
 
-      if (executionWorkspace.providerType === "git_worktree" && workspacePath) {
+      if (executionWorkspace.providerType === "git_worktree" && git?.createdByRuntime && workspacePath) {
         plannedActions.push({
           kind: "git_worktree_remove",
           label: "Remove git worktree",

--- a/server/src/services/workspace-runtime.ts
+++ b/server/src/services/workspace-runtime.ts
@@ -2094,6 +2094,12 @@ export async function cleanupExecutionWorkspaceArtifacts(input: {
     projectWorkspaceCwd: input.projectWorkspace?.cwd ?? null,
   });
   const createdByRuntime = input.workspace.metadata?.createdByRuntime === true;
+  const isSharedProjectPrimaryLocalSession =
+    !createdByRuntime &&
+    input.workspace.providerType === "local_fs" &&
+    input.workspace.mode === "shared_workspace" &&
+    input.workspace.strategyType === "project_primary" &&
+    input.workspace.metadata?.source === "project_primary";
   const recordOnlyLocalCleanup =
     !createdByRuntime &&
     (input.workspace.providerType === "local_fs" || input.workspace.providerType === "git_worktree");
@@ -2184,7 +2190,7 @@ export async function cleanupExecutionWorkspaceArtifacts(input: {
     }
   } else if (input.workspace.providerType === "local_fs" && workspacePath) {
     if (!createdByRuntime) {
-      if (await directoryExists(workspacePath)) {
+      if (!isSharedProjectPrimaryLocalSession && (await directoryExists(workspacePath))) {
         warnings.push(`Archived execution workspace record only; kept existing local path "${workspacePath}" because Paperclip did not create it.`);
       }
     } else {

--- a/server/src/services/workspace-runtime.ts
+++ b/server/src/services/workspace-runtime.ts
@@ -2063,6 +2063,8 @@ export async function cleanupExecutionWorkspaceArtifacts(input: {
     cwd: string | null;
     providerType: string;
     providerRef: string | null;
+    mode?: string | null;
+    strategyType?: string | null;
     branchName: string | null;
     repoUrl: string | null;
     baseRef: string | null;
@@ -2092,6 +2094,9 @@ export async function cleanupExecutionWorkspaceArtifacts(input: {
     projectWorkspaceCwd: input.projectWorkspace?.cwd ?? null,
   });
   const createdByRuntime = input.workspace.metadata?.createdByRuntime === true;
+  const recordOnlyLocalCleanup =
+    !createdByRuntime &&
+    (input.workspace.providerType === "local_fs" || input.workspace.providerType === "git_worktree");
   const cleanupCommands = [
     input.cleanupCommand ?? null,
     input.projectWorkspace?.cleanupCommand ?? null,
@@ -2128,7 +2133,9 @@ export async function cleanupExecutionWorkspaceArtifacts(input: {
 
   if (input.workspace.providerType === "git_worktree" && workspacePath) {
     const worktreeExists = await directoryExists(workspacePath);
-    if (worktreeExists) {
+    if (worktreeExists && !createdByRuntime) {
+      warnings.push(`Archived execution workspace record only; kept existing local path "${workspacePath}" because Paperclip did not create it.`);
+    } else if (worktreeExists) {
       if (!repoRoot) {
         warnings.push(`Could not resolve git repo root for "${workspacePath}".`);
       } else {
@@ -2175,39 +2182,46 @@ export async function cleanupExecutionWorkspaceArtifacts(input: {
         }
       }
     }
-  } else if (input.workspace.providerType === "local_fs" && createdByRuntime && workspacePath) {
-    const projectWorkspaceCwd = input.projectWorkspace?.cwd ? path.resolve(input.projectWorkspace.cwd) : null;
-    const resolvedWorkspacePath = path.resolve(workspacePath);
-    const containsProjectWorkspace = projectWorkspaceCwd
-      ? (
-          resolvedWorkspacePath === projectWorkspaceCwd ||
-          projectWorkspaceCwd.startsWith(`${resolvedWorkspacePath}${path.sep}`)
-        )
-      : false;
-    if (containsProjectWorkspace) {
-      warnings.push(`Refusing to remove path "${workspacePath}" because it contains the project workspace.`);
+  } else if (input.workspace.providerType === "local_fs" && workspacePath) {
+    if (!createdByRuntime) {
+      if (await directoryExists(workspacePath)) {
+        warnings.push(`Archived execution workspace record only; kept existing local path "${workspacePath}" because Paperclip did not create it.`);
+      }
     } else {
-      await fs.rm(resolvedWorkspacePath, { recursive: true, force: true });
-      if (input.recorder) {
-        await input.recorder.recordOperation({
-          phase: "workspace_teardown",
-          cwd: projectWorkspaceCwd ?? process.cwd(),
-          metadata: {
-            workspaceId: input.workspace.id,
-            workspacePath: resolvedWorkspacePath,
-            cleanupAction: "remove_local_fs",
-          },
-          run: async () => ({
-            status: "succeeded",
-            exitCode: 0,
-            system: `Removed local workspace directory ${resolvedWorkspacePath}\n`,
-          }),
-        });
+      const projectWorkspaceCwd = input.projectWorkspace?.cwd ? path.resolve(input.projectWorkspace.cwd) : null;
+      const resolvedWorkspacePath = path.resolve(workspacePath);
+      const containsProjectWorkspace = projectWorkspaceCwd
+        ? (
+            resolvedWorkspacePath === projectWorkspaceCwd ||
+            projectWorkspaceCwd.startsWith(`${resolvedWorkspacePath}${path.sep}`)
+          )
+        : false;
+      if (containsProjectWorkspace) {
+        warnings.push(`Refusing to remove path "${workspacePath}" because it contains the project workspace.`);
+      } else {
+        await fs.rm(resolvedWorkspacePath, { recursive: true, force: true });
+        if (input.recorder) {
+          await input.recorder.recordOperation({
+            phase: "workspace_teardown",
+            cwd: projectWorkspaceCwd ?? process.cwd(),
+            metadata: {
+              workspaceId: input.workspace.id,
+              workspacePath: resolvedWorkspacePath,
+              cleanupAction: "remove_local_fs",
+            },
+            run: async () => ({
+              status: "succeeded",
+              exitCode: 0,
+              system: `Removed local workspace directory ${resolvedWorkspacePath}\n`,
+            }),
+          });
+        }
       }
     }
   }
 
   const cleaned =
+    recordOnlyLocalCleanup ||
     !workspacePath ||
     !(await directoryExists(workspacePath));
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Execution workspaces are the runtime records that connect an issue heartbeat to a local, git, or shared filesystem workspace.
> - Shared project-primary workspaces are meant to represent a canonical checkout that multiple heartbeats can reuse safely.
> - The list/reuse path excluded `shared_workspace`, so repeated heartbeats could create new active shared records for the same policy key instead of reusing the active session.
> - The archive cleanup path also treated a still-existing canonical shared directory as cleanup failure, even when Paperclip did not create that directory and must not delete it.
> - This pull request fixes the shared workspace lifecycle at the service/runtime boundary and adds regression coverage for both the reuse and archive-cleanup cases.
> - The benefit is fewer leaked active workspace records and safer cleanup semantics for canonical checkouts.

## Linked Issues or Issue Description

No public GitHub issue exists for this internal runtime bug.

Bug report:

- Summary: repeated shared/project-primary heartbeat sessions can create unbounded active execution workspace records for the same canonical checkout, and archive cleanup can mark record-only shared workspaces as `cleanup_failed` because the directory still exists.
- Expected behavior: a shared/project-primary session should be reused by policy key, or safely archived without trying to delete canonical workspace files.
- Actual behavior: shared workspace records are not considered reuse-eligible, and cleanup validates filesystem removal even for non-runtime-created shared local/git paths.
- Impact: workspace list APIs can accumulate many active records for one canonical checkout, while archive attempts produce false cleanup failures.
- Scope: control-plane/runtime lifecycle only; no product app code or deployment config changes.

Related PR search:

- #5620 is related to execution workspace close behavior, but it does not cover shared policy-key reuse or record-only cleanup for canonical shared workspace records.

## What Changed

- Allows active shared workspace records to be selected by the reuse-eligible list conditions.
- Reuses an active shared/project-primary session by matching the workspace policy key before creating another record.
- Treats non-runtime-created shared local/git workspace cleanup as record-only archive behavior instead of filesystem deletion.
- Adds regression tests for repeated shared workspace runs and shared workspace archive cleanup.

## Verification

- `pnpm exec vitest run server/src/__tests__/execution-workspaces-service.test.ts server/src/__tests__/workspace-runtime.test.ts` — passed: 2 files, 87 tests.

## Risks

- Low risk for isolated/runtime-created workspaces: destructive cleanup remains limited to runtime-created workspace artifacts.
- Behavioral shift for shared workspaces: stale canonical shared records now archive without deleting local files, which is intentional for project-primary checkouts.
- Existing duplicated records are not bulk-cleaned by this PR; it prevents new unbounded growth and makes future cleanup safe.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex via `codex_local`, GPT-5.5, tool-assisted local coding and verification.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge