### PR TITLE
fix(server): local agents must use loopback API URL, not the auth-proxied public host

### DIFF
--- a/server/src/__tests__/runtime-api.test.ts
+++ b/server/src/__tests__/runtime-api.test.ts
@@ -1,9 +1,36 @@
 import { describe, expect, it } from "vitest";
 import {
   buildRuntimeApiCandidateUrls,
+  chooseAgentRuntimeApiUrl,
   choosePrimaryRuntimeApiUrl,
   collectReachableInterfaceHosts,
 } from "../runtime-api.js";
+
+describe("chooseAgentRuntimeApiUrl", () => {
+  it("ignores the auth-proxied public base URL for co-located local_trusted agents", () => {
+    expect(
+      chooseAgentRuntimeApiUrl({
+        deploymentMode: "local_trusted",
+        authPublicBaseUrl: "https://paperclip.example.com",
+        allowedHostnames: ["paperclip.example.com"],
+        bindHost: "127.0.0.1",
+        port: 3100,
+      }),
+    ).toBe("http://127.0.0.1:3100");
+  });
+
+  it("keeps the public base URL for non-local deployment modes", () => {
+    expect(
+      chooseAgentRuntimeApiUrl({
+        deploymentMode: "authenticated",
+        authPublicBaseUrl: "https://paperclip.example.com",
+        allowedHostnames: ["paperclip.example.com"],
+        bindHost: "127.0.0.1",
+        port: 3100,
+      }),
+    ).toBe("https://paperclip.example.com");
+  });
+});
 
 describe("runtime API discovery", () => {
   it("prefers the explicit public base URL for the primary runtime URL", () => {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -53,7 +53,7 @@ import {
   reconcileAdapterAvailability,
 } from "./services/adapter-registry-bootstrap.js";
 import { createFeedbackTraceShareClientFromConfig } from "./services/feedback-share-client.js";
-import { buildRuntimeApiCandidateUrls, choosePrimaryRuntimeApiUrl } from "./runtime-api.js";
+import { buildRuntimeApiCandidateUrls, chooseAgentRuntimeApiUrl, choosePrimaryRuntimeApiUrl } from "./runtime-api.js";
 import { createPluginWorkerManager } from "./services/plugin-worker-manager.js";
 import { createStorageServiceFromConfig } from "./storage/index.js";
 import { printStartupBanner } from "./startup-banner.js";
@@ -704,13 +704,25 @@ export async function startServer(): Promise<StartedServer> {
   }
   
   const runtimeListenHost = config.host;
-  const runtimeApiUrl = choosePrimaryRuntimeApiUrl({
+  // Public-facing URL for browser login, outbound webhooks and callback
+  // candidates. May resolve to an auth-proxied host (e.g. Cloudflare Access).
+  const publicApiUrl = choosePrimaryRuntimeApiUrl({
     authPublicBaseUrl: config.authPublicBaseUrl ?? null,
     allowedHostnames: config.allowedHostnames,
     bindHost: runtimeListenHost,
     port: listenPort,
   });
-  const configuredApiUrl = process.env.PAPERCLIP_API_URL?.trim() || runtimeApiUrl;
+  // Agent-facing URL. For co-located (local_trusted) deployments this must be
+  // the loopback/bind origin, never the auth-proxied public host, or the
+  // agent's API calls get 302-redirected to the proxy login flow.
+  const runtimeApiUrl = chooseAgentRuntimeApiUrl({
+    deploymentMode: config.deploymentMode,
+    authPublicBaseUrl: config.authPublicBaseUrl ?? null,
+    allowedHostnames: config.allowedHostnames,
+    bindHost: runtimeListenHost,
+    port: listenPort,
+  });
+  const configuredApiUrl = process.env.PAPERCLIP_API_URL?.trim() || publicApiUrl;
   const runtimeApiCandidates = buildRuntimeApiCandidateUrls({
     preferredApiUrl: configuredApiUrl,
     authPublicBaseUrl: config.authPublicBaseUrl ?? null,

--- a/server/src/runtime-api.ts
+++ b/server/src/runtime-api.ts
@@ -80,6 +80,37 @@ export function choosePrimaryRuntimeApiUrl(input: {
   return formatOrigin("http:", "localhost", input.port);
 }
 
+/**
+ * Chooses the API URL that a **local agent** should use to reach the control
+ * plane. Local agents run on the same host as the server, so for co-located
+ * (`local_trusted`) deployments the agent must reach the API over the
+ * loopback/bind address.
+ *
+ * The public base URL (`authPublicBaseUrl`) is meant for browser login and
+ * outbound webhooks and may sit behind an authenticating proxy (e.g. Cloudflare
+ * Access). If the agent is handed that public host, every service-to-service
+ * call is redirected to the proxy's login flow (a 302) and fails. So for
+ * `local_trusted` we deliberately ignore `authPublicBaseUrl` here and let
+ * {@link choosePrimaryRuntimeApiUrl} derive the loopback/bind origin. Other
+ * deployment modes keep the existing behaviour.
+ */
+export function chooseAgentRuntimeApiUrl(input: {
+  deploymentMode: string;
+  authPublicBaseUrl?: string | null;
+  allowedHostnames: string[];
+  bindHost: string;
+  port: number;
+}): string {
+  const authPublicBaseUrl =
+    input.deploymentMode === "local_trusted" ? null : input.authPublicBaseUrl ?? null;
+  return choosePrimaryRuntimeApiUrl({
+    authPublicBaseUrl,
+    allowedHostnames: input.allowedHostnames,
+    bindHost: input.bindHost,
+    port: input.port,
+  });
+}
+
 export function collectReachableInterfaceHosts(input: {
   networkInterfacesMap?: NodeJS.Dict<os.NetworkInterfaceInfo[]>;
 } = {}): string[] {


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The control plane injects `PAPERCLIP_*` env vars into every agent run; `PAPERCLIP_RUNTIME_API_URL` tells the agent where the Paperclip API lives.
> - Those runtime vars are computed at server start in `server/src/index.ts` from `choosePrimaryRuntimeApiUrl(...)`, which returns `authPublicBaseUrl` first when set.
> - For a `local_trusted` deployment the server binds loopback and agents run on the same host, but `authPublicBaseUrl` is the browser/login origin — which may sit behind an authenticating proxy (e.g. Cloudflare Access).
> - Handing that auth-gated public host to a co-located agent means every service-to-service API call is 302-redirected to the proxy login and fails.
> - This PR derives the agent-facing runtime URL separately, ignoring `authPublicBaseUrl` for `local_trusted` so it resolves to the loopback bind origin, while the public URL (login, webhooks, callback candidates) is unchanged.
> - The benefit is local agents reach the API reliably even when the public origin is behind an auth proxy — no per-agent workarounds (which are impossible anyway, since `PAPERCLIP_*` keys are stripped from all config env).

## Linked Issues or Issue Description

Fixes #9492

## What Changed

- Add `chooseAgentRuntimeApiUrl(...)` in `server/src/runtime-api.ts`: for `local_trusted` it ignores `authPublicBaseUrl` and lets `choosePrimaryRuntimeApiUrl` derive the loopback/bind origin; other modes unchanged.
- `server/src/index.ts`: compute the agent-facing `PAPERCLIP_RUNTIME_API_URL` via the new helper; keep the public URL (`PAPERCLIP_API_URL`, webhook/callback candidates) sourced from `authPublicBaseUrl` as before.
- Add unit tests for `chooseAgentRuntimeApiUrl` (local_trusted → loopback; other modes → public base URL).

## Verification

- `cd server && pnpm exec vitest run src/__tests__/runtime-api.test.ts src/__tests__/paperclip-env.test.ts` → **12 passed** (2 new + existing `buildPaperclipEnv` behaviour intact — `PAPERCLIP_RUNTIME_API_URL` is still honoured when explicitly set).
- `cd server && pnpm run typecheck` → clean.
- Manual: on a `local_trusted` instance behind Cloudflare Access, the agent env previously showed the public host (health → 302); with this change the agent-facing URL is the loopback origin (health → 200). The public `PAPERCLIP_API_URL` used for webhooks is unchanged.

## Risks

- Low risk, scoped to `local_trusted` (loopback bind is already enforced in `index.ts`). Only the agent-facing `PAPERCLIP_RUNTIME_API_URL` changes; `PAPERCLIP_API_URL` (login/webhooks) and callback candidates are untouched. Non-`local_trusted` modes keep the previous URL selection.

## Model Used

- Claude Opus 4.8 (`claude-opus-4-8`), extended thinking, with tool use / code execution (read the codebase, applied the change, ran vitest + tsc locally).

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above (none found)
- [x] I have either (a) linked existing issues OR (b) described the issue in-PR
- [x] I have not referenced internal/instance-local Paperclip issues or links
- [x] My branch name describes the change and contains no internal ticket id
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes (no user-facing docs affected)
- [ ] All Paperclip CI gates are green (the earlier `server (1/3)` failure was an unrelated flake — `heartbeat-worktree-suppression.test.ts` worktree/DB teardown + a missing `pr-lockfile` CI artifact — not touched by this change)
- [ ] Greptile is 5/5 with no open P2s (Greptile scored 5/5 "safe to merge" on the prior run)
- [x] I will address all Greptile and reviewer comments before requesting merge
