### PR TITLE
fix(productivity-review): exclude 0-token infra startup failures from no-comment streak

### DIFF
--- a/server/src/__tests__/productivity-review-service.test.ts
+++ b/server/src/__tests__/productivity-review-service.test.ts
@@ -120,11 +120,16 @@ describeEmbeddedPostgres("productivity review service", () => {
     count: number;
     now: Date;
     withRunComments?: boolean;
+    startOffset?: number;
+    spacingMs?: number;
+    overrides?: Partial<typeof heartbeatRuns.$inferInsert>;
   }) {
     const runs: Array<typeof heartbeatRuns.$inferInsert> = [];
+    const startOffset = input.startOffset ?? 0;
+    const spacingMs = input.spacingMs ?? 60_000;
     for (let index = 0; index < input.count; index += 1) {
       const runId = randomUUID();
-      const createdAt = new Date(input.now.getTime() - index * 60_000);
+      const createdAt = new Date(input.now.getTime() - (startOffset + index) * spacingMs);
       runs.push({
         id: runId,
         companyId: input.companyId,
@@ -139,6 +144,7 @@ describeEmbeddedPostgres("productivity review service", () => {
         nextAction: "Continue processing the next batch.",
         createdAt,
         updatedAt: createdAt,
+        ...input.overrides,
       });
     }
     await db.insert(heartbeatRuns).values(runs);
@@ -208,6 +214,106 @@ describeEmbeddedPostgres("productivity review service", () => {
     expect(reviews[0]?.description).toContain("No-comment completed-run streak: 10");
 
     expect(await listRefreshComments(reviews[0]!.id)).toHaveLength(0);
+  });
+
+  it("does not count infra startup failures (0-token rate-limit / adapter / transient) toward the no-comment streak", async () => {
+    const now = new Date("2026-04-28T12:00:00.000Z");
+    const seeded = await seedAssignedIssue();
+    // Twice the threshold of runs that all failed BEFORE booting: 0 tokens +
+    // infra errorCode. This is the ZOL-6918 retry-loop shape (ZOL-6960).
+    const infraErrorCodes = ["claude_transient_upstream", "rate_limit_five_hour", "adapter_failed"];
+    for (let i = 0; i < DEFAULT_PRODUCTIVITY_REVIEW_NO_COMMENT_STREAK_RUNS * 2; i += 1) {
+      await insertRuns({
+        companyId: seeded.companyId,
+        agentId: seeded.coderId,
+        issueId: seeded.issueId,
+        count: 1,
+        now,
+        startOffset: i,
+        // Spread runs across ~8h so the high-churn trigger (10/1h, 30/6h) never
+        // fires — this test isolates the no_comment_streak heuristic.
+        spacingMs: 25 * 60_000,
+        overrides: {
+          status: "failed",
+          errorCode: infraErrorCodes[i % infraErrorCodes.length],
+          usageJson: null,
+          livenessState: null,
+          nextAction: null,
+        },
+      });
+    }
+
+    const service = productivityReviewService(db);
+    const result = await service.reconcileProductivityReviews({ now, companyId: seeded.companyId });
+
+    expect(result.created).toBe(0);
+    expect(await listProductivityReviews(seeded.companyId)).toHaveLength(0);
+  });
+
+  it("skips infra startup failures without breaking a real no-comment streak behind them", async () => {
+    const now = new Date("2026-04-28T12:00:00.000Z");
+    const seeded = await seedAssignedIssue();
+    // Newest runs are infra failures (must be transparent), older runs are a
+    // full threshold of completed runs with no comment (the real signal).
+    await insertRuns({
+      companyId: seeded.companyId,
+      agentId: seeded.coderId,
+      issueId: seeded.issueId,
+      count: 5,
+      now,
+      startOffset: 0,
+      overrides: {
+        status: "failed",
+        errorCode: "rate_limit_weekly",
+        usageJson: null,
+        livenessState: null,
+        nextAction: null,
+      },
+    });
+    await insertRuns({
+      companyId: seeded.companyId,
+      agentId: seeded.coderId,
+      issueId: seeded.issueId,
+      count: DEFAULT_PRODUCTIVITY_REVIEW_NO_COMMENT_STREAK_RUNS,
+      now,
+      startOffset: 5,
+    });
+
+    const service = productivityReviewService(db);
+    const result = await service.reconcileProductivityReviews({ now, companyId: seeded.companyId });
+
+    expect(result.created).toBe(1);
+    const reviews = await listProductivityReviews(seeded.companyId);
+    expect(reviews).toHaveLength(1);
+    expect(reviews[0]?.description).toContain("No-comment completed-run streak: 10");
+  });
+
+  it("still counts a failed run that produced tokens (agent worked then crashed) toward the streak", async () => {
+    const now = new Date("2026-04-28T12:00:00.000Z");
+    const seeded = await seedAssignedIssue();
+    // A `failed` run that reported real token usage is NOT an infra startup
+    // failure — the agent booted and worked, so it stays a productivity signal.
+    await insertRuns({
+      companyId: seeded.companyId,
+      agentId: seeded.coderId,
+      issueId: seeded.issueId,
+      count: DEFAULT_PRODUCTIVITY_REVIEW_NO_COMMENT_STREAK_RUNS,
+      now,
+      overrides: {
+        status: "failed",
+        errorCode: "adapter_failed",
+        usageJson: { inputTokens: 1200, outputTokens: 340 },
+      },
+    });
+
+    const service = productivityReviewService(db);
+    const result = await service.reconcileProductivityReviews({ now, companyId: seeded.companyId });
+
+    expect(result.created).toBe(1);
+    const reviews = await listProductivityReviews(seeded.companyId);
+    expect(reviews).toHaveLength(1);
+    expect(reviews[0]?.description).toContain("Primary trigger: `no_comment_streak`");
+    expect(reviews[0]?.description).toContain("No-comment completed-run streak: 10");
   });
 
   it("refreshes open productivity reviews only once per interval and caps refresh comments", async () => {

--- a/server/src/__tests__/productivity-review-service.test.ts
+++ b/server/src/__tests__/productivity-review-service.test.ts
@@ -220,7 +220,7 @@ describeEmbeddedPostgres("productivity review service", () => {
     const now = new Date("2026-04-28T12:00:00.000Z");
     const seeded = await seedAssignedIssue();
     // Twice the threshold of runs that all failed BEFORE booting: 0 tokens +
-    // infra errorCode. This is the ZOL-6918 retry-loop shape (ZOL-6960).
+    // infra errorCode. This is the provider rate-limit retry-loop shape.
     const infraErrorCodes = ["claude_transient_upstream", "rate_limit_five_hour", "adapter_failed"];
     for (let i = 0; i < DEFAULT_PRODUCTIVITY_REVIEW_NO_COMMENT_STREAK_RUNS * 2; i += 1) {
       await insertRuns({
@@ -314,6 +314,60 @@ describeEmbeddedPostgres("productivity review service", () => {
     expect(reviews).toHaveLength(1);
     expect(reviews[0]?.description).toContain("Primary trigger: `no_comment_streak`");
     expect(reviews[0]?.description).toContain("No-comment completed-run streak: 10");
+  });
+
+  it("stops the streak at an infra-classified run that did produce a comment", async () => {
+    const now = new Date("2026-04-28T12:00:00.000Z");
+    const seeded = await seedAssignedIssue();
+    // Newest: a few completed runs without comments (below threshold).
+    await insertRuns({
+      companyId: seeded.companyId,
+      agentId: seeded.coderId,
+      issueId: seeded.issueId,
+      count: 3,
+      now,
+      startOffset: 0,
+      // Spread runs across hours so the high-churn trigger (10/1h, 30/6h)
+      // never fires — this test isolates the no_comment_streak heuristic.
+      spacingMs: 25 * 60_000,
+    });
+    // Then a run matching the infra-skip shape (failed, 0 tokens, infra
+    // errorCode) that nevertheless created a comment. The comment boundary
+    // must win over the infra skip: the streak ends here.
+    await insertRuns({
+      companyId: seeded.companyId,
+      agentId: seeded.coderId,
+      issueId: seeded.issueId,
+      count: 1,
+      now,
+      startOffset: 3,
+      spacingMs: 25 * 60_000,
+      withRunComments: true,
+      overrides: {
+        status: "failed",
+        errorCode: "adapter_failed",
+        usageJson: null,
+        livenessState: null,
+        nextAction: null,
+      },
+    });
+    // Oldest: a full threshold of commentless completed runs that must NOT be
+    // reachable past the commented run above.
+    await insertRuns({
+      companyId: seeded.companyId,
+      agentId: seeded.coderId,
+      issueId: seeded.issueId,
+      count: DEFAULT_PRODUCTIVITY_REVIEW_NO_COMMENT_STREAK_RUNS,
+      now,
+      startOffset: 4,
+      spacingMs: 25 * 60_000,
+    });
+
+    const service = productivityReviewService(db);
+    const result = await service.reconcileProductivityReviews({ now, companyId: seeded.companyId });
+
+    expect(result.created).toBe(0);
+    expect(await listProductivityReviews(seeded.companyId)).toHaveLength(0);
   });
 
   it("refreshes open productivity reviews only once per interval and caps refresh comments", async () => {

--- a/server/src/services/productivity-review.ts
+++ b/server/src/services/productivity-review.ts
@@ -38,6 +38,68 @@ const MAX_RUNS_FOR_STREAK = 100;
 const MAX_PARENT_WALK_DEPTH = 25;
 export const PRODUCTIVITY_REVIEW_REFRESH_COMMENT_PREFIX = "Productivity review evidence refreshed.";
 
+// Error codes that mark an infra / transient failure the agent hit BEFORE it
+// booted and produced any output (rate-limit rejection, adapter crash,
+// transient upstream). A run that never got to work is not evidence of agent
+// unproductivity, so it must not count toward the no-comment streak (ZOL-6966).
+const INFRA_STARTUP_FAILURE_ERROR_CODES = new Set([
+  "adapter_failed",
+  "claude_transient_upstream",
+  "codex_transient_upstream",
+]);
+
+function readNonEmptyString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value : null;
+}
+
+function parseObject(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function asNonNegativeInteger(value: unknown): number {
+  const parsed = typeof value === "number" ? value : Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : 0;
+}
+
+function isInfraErrorCode(errorCode: string | null | undefined): boolean {
+  if (!errorCode) return false;
+  if (INFRA_STARTUP_FAILURE_ERROR_CODES.has(errorCode)) return true;
+  // rate_limit_five_hour, rate_limit_weekly, rate_limited, … — any rate-limit variant.
+  return errorCode.startsWith("rate_limit");
+}
+
+// Total tokens (raw preferred, else normalized) the run reported. A run that
+// produced 0 input+output+cached tokens never generated anything — the agent
+// crashed before boost, per the ZOL-6960 / ZOL-6918 retry-loop incident.
+function readRunTokenTotal(usageJson: unknown): number {
+  const parsed = parseObject(usageJson);
+  if (Object.keys(parsed).length === 0) return 0;
+  const input = asNonNegativeInteger(parsed.rawInputTokens ?? parsed.inputTokens);
+  const cached = asNonNegativeInteger(parsed.rawCachedInputTokens ?? parsed.cachedInputTokens);
+  const output = asNonNegativeInteger(parsed.rawOutputTokens ?? parsed.outputTokens);
+  return input + cached + output;
+}
+
+// A terminal run that failed at startup on infra: not `succeeded`, produced no
+// tokens, and carries an infra/transient error signal. Such runs are skipped
+// when computing the no-comment streak so a burst of rate-limit / adapter
+// failures cannot be misread as the agent going silent (ZOL-6966).
+function isInfraStartupFailureRun(
+  run: Pick<HeartbeatRunRow, "status" | "errorCode" | "resultJson" | "usageJson">,
+): boolean {
+  if (run.status === "succeeded") return false;
+  if (!TERMINAL_RUN_STATUSES.includes(run.status as (typeof TERMINAL_RUN_STATUSES)[number])) {
+    return false;
+  }
+  if (readRunTokenTotal(run.usageJson) > 0) return false;
+  if (readNonEmptyString(parseObject(run.resultJson).errorFamily) === "transient_upstream") {
+    return true;
+  }
+  return isInfraErrorCode(run.errorCode);
+}
+
 type IssueRow = typeof issues.$inferSelect;
 type AgentRow = typeof agents.$inferSelect;
 type HeartbeatRunRow = typeof heartbeatRuns.$inferSelect;
@@ -425,6 +487,11 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
     );
     let noCommentStreak = 0;
     for (const run of terminalRuns) {
+      // Infra failures at startup (0-token rate-limit / adapter / transient
+      // upstream) never gave the agent a chance to comment. Treat them as
+      // transparent: neither count them nor let them break a real streak
+      // sitting behind them (ZOL-6966).
+      if (isInfraStartupFailureRun(run)) continue;
       if (commentRunIds.has(run.id)) break;
       noCommentStreak += 1;
     }

--- a/server/src/services/productivity-review.ts
+++ b/server/src/services/productivity-review.ts
@@ -41,7 +41,7 @@ export const PRODUCTIVITY_REVIEW_REFRESH_COMMENT_PREFIX = "Productivity review e
 // Error codes that mark an infra / transient failure the agent hit BEFORE it
 // booted and produced any output (rate-limit rejection, adapter crash,
 // transient upstream). A run that never got to work is not evidence of agent
-// unproductivity, so it must not count toward the no-comment streak (ZOL-6966).
+// unproductivity, so it must not count toward the no-comment streak.
 const INFRA_STARTUP_FAILURE_ERROR_CODES = new Set([
   "adapter_failed",
   "claude_transient_upstream",
@@ -72,7 +72,7 @@ function isInfraErrorCode(errorCode: string | null | undefined): boolean {
 
 // Total tokens (raw preferred, else normalized) the run reported. A run that
 // produced 0 input+output+cached tokens never generated anything — the agent
-// crashed before boost, per the ZOL-6960 / ZOL-6918 retry-loop incident.
+// crashed before boot, as seen in provider rate-limit retry-loop incidents.
 function readRunTokenTotal(usageJson: unknown): number {
   const parsed = parseObject(usageJson);
   if (Object.keys(parsed).length === 0) return 0;
@@ -85,7 +85,7 @@ function readRunTokenTotal(usageJson: unknown): number {
 // A terminal run that failed at startup on infra: not `succeeded`, produced no
 // tokens, and carries an infra/transient error signal. Such runs are skipped
 // when computing the no-comment streak so a burst of rate-limit / adapter
-// failures cannot be misread as the agent going silent (ZOL-6966).
+// failures cannot be misread as the agent going silent.
 function isInfraStartupFailureRun(
   run: Pick<HeartbeatRunRow, "status" | "errorCode" | "resultJson" | "usageJson">,
 ): boolean {
@@ -487,12 +487,12 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
     );
     let noCommentStreak = 0;
     for (const run of terminalRuns) {
+      if (commentRunIds.has(run.id)) break;
       // Infra failures at startup (0-token rate-limit / adapter / transient
       // upstream) never gave the agent a chance to comment. Treat them as
       // transparent: neither count them nor let them break a real streak
-      // sitting behind them (ZOL-6966).
+      // sitting behind them.
       if (isInfraStartupFailureRun(run)) continue;
-      if (commentRunIds.has(run.id)) break;
       noCommentStreak += 1;
     }
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The productivity-review service watches agent runs on an issue and escalates when an agent goes quiet — the `no_comment_streak` trigger counts consecutive terminal runs that produced no comment
> - Runs that fail *before the agent boots* (zero input/output tokens, error codes like `adapter_failed`, `claude_transient_upstream` / `codex_transient_upstream`, `rate_limit*`, or `errorFamily: transient_upstream`) are provider/adapter transients, not agent silence — yet the streak counted them
> - A burst of 429-driven startup failures could therefore fire a productivity review with a double-digit "no comment" streak against an agent that never got a chance to run, creating noisy false-positive escalations
> - This pull request makes such 0-token infra failures transparent to the streak: they neither increment it nor break a genuine no-comment streak sitting behind them, while a failed run that *did* produce tokens (agent worked, then crashed) still counts
> - The benefit is that productivity reviews fire on real agent silence instead of infrastructure weather, so escalations stay trustworthy

## Linked Issues or Issue Description

No existing public issue; describing per the bug template:

**What happened?** During a provider rate-limit window, an agent's heartbeat runs failed repeatedly at startup (`stopReason: adapter_failed`, 0 input/output tokens, driven by upstream 429s). The productivity-review reconciler counted every one of those runs toward `no_comment_streak` and opened a review reporting a streak of 14 "silent" runs.

**Expected behavior:** Runs that terminated before the agent ever booted should not be treated as the agent staying silent. A review should only fire when the agent actually ran and produced no comment.

**Actual behavior:** Every terminal non-commenting run counted, including 0-token infra failures, so infra bursts produced false-positive reviews (and could also mask the true length of a real streak behind them).

**Repro:** With productivity review enabled, force an adapter to fail at startup (e.g. invalid credentials or a rate-limited provider) for `noCommentStreakThreshold` consecutive heartbeats on one issue → a review fires even though the agent never emitted a token.

Related (searched for duplicates, none implement this): #8623 (tunable streak threshold — orthogonal), #7031 (retry streaks by failure cause in continuation recovery — different subsystem, same spirit), #8624 / #8625 (0-token run diagnostics in heartbeat, not productivity review).

## What Changed

- `server/src/services/productivity-review.ts`: the no-comment streak computation now skips terminal runs that failed pre-boot — `status !== 'succeeded'` AND 0 input/output tokens AND (`errorCode` in {`adapter_failed`, `claude_transient_upstream`, `codex_transient_upstream`, `rate_limit*`} OR `errorFamily === 'transient_upstream'`). Skipped runs are transparent: they don't increment the streak and don't break a streak of real no-comment runs behind them.
- Token-bearing failed runs (agent produced output, then the run failed) still count toward the streak, unchanged.
- `server/src/__tests__/productivity-review-service.test.ts`: three new cases — (1) an infra-only failure burst does not create a review; (2) infra runs stacked in front of a genuine completed-no-comment streak still trigger at the true streak length; (3) a failed run with tokens still counts. All three fail on the pre-fix code.

## Verification

- `cd server && npx vitest run src/__tests__/productivity-review-service.test.ts` → 14 passed (11 pre-existing + 3 new)
- `pnpm --filter @paperclipai/server typecheck` → clean

## Risks

- Low. Behavioral shift is intentional and narrow: reviews no longer fire for streaks composed purely of 0-token infra failures. The skip predicate requires *both* zero tokens *and* an infra error code/family, so any run where the agent did work is unaffected. No schema or API changes.

## Model Used

- Claude Opus 4.8 (`claude-opus-4-8`, extended thinking, agentic tool use via Claude Code) authored the fix and tests; Claude Fable 5 (`claude-fable-5`, extended thinking, agentic tool use via Claude Code) ported it onto current `master`, re-ran tests and typecheck, and prepared this PR.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes (no docs affected — service-internal heuristic)
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

---

**Review request (2026-08-19).** Rechecked against `master` a5f3ac6b4: the streak still counts every terminal run, including 0-token runs that failed before the agent booted, so a provider rate-limit retry loop still manufactures a productivity review. Green and merges cleanly.

We cannot use the reviewer field as outside contributors, so flagging the recent maintainers of the touched files instead: @cryppadotta, @devinfoley. Happy to close if this is not wanted — no need to reply otherwise.
