### PR TITLE
docs: add worktree workspace initialization guidance

### DIFF
--- a/docs/cli/setup-commands.md
+++ b/docs/cli/setup-commands.md
@@ -54,6 +54,58 @@ pnpm paperclipai onboard --yes
 
 On an existing install, `--yes` now preserves the current config and just starts Paperclip with that setup.
 
+## Worktree Helpers (Safe Workspace Initialization)
+
+Paperclip can run local agent workflows from an isolated git worktree instance. Use these when you want to test agent runs without impacting your primary instance.
+
+```sh
+# Create a new worktree and initialize its own Paperclip instance
+pnpm paperclipai worktree:make team-a
+
+# Create a worktree inside an existing checkout (repo-local)
+pnpm paperclipai worktree init --name team-a
+
+# List candidate worktrees
+pnpm paperclipai worktree:list
+
+# Print shell exports for the active worktree config
+pnpm paperclipai worktree env
+
+# Re-seed a live worktree from another Paperclip checkout
+pnpm paperclipai worktree reseed --from . --to team-a
+
+# Repair an existing worktree instance if metadata was partially removed
+pnpm paperclipai worktree repair --branch team-a
+```
+
+### Recommended Initialization Flow
+
+1. `worktree:make` (or `worktree init` if the worktree already exists)
+2. `worktree env` to load the generated `PAPERCLIP_HOME` and `PAPERCLIP_INSTANCE_ID`
+3. `paperclipai run` to start that instance
+4. Run `paperclipai doctor` after first boot to confirm migration and secrets state
+
+### Safety and Cleanup
+
+Use full seeding only when you need shared runtime state (agents, projects, and credentials), otherwise keep `seed-mode minimal` for faster startup:
+
+```sh
+pnpm paperclipai worktree:make team-a --seed-mode minimal
+pnpm paperclipai worktree:make team-a --seed-mode full
+```
+
+When an isolated workspace is no longer needed, clean it up explicitly:
+
+```sh
+pnpm paperclipai worktree:cleanup team-a --force
+```
+
+Keep a safety copy of active tasks first if needed before cleanup:
+
+```sh
+pnpm paperclipai issue list --company-id <company-id> --status in_progress
+```
+
 ## `paperclipai doctor`
 
 Health checks with optional auto-repair:

--- a/docs/cli/setup-commands.md
+++ b/docs/cli/setup-commands.md
@@ -62,7 +62,7 @@ Paperclip can run local agent workflows from an isolated git worktree instance. 
 # Create a new worktree and initialize its own Paperclip instance
 pnpm paperclipai worktree:make team-a
 
-# Create a worktree inside an existing checkout (repo-local)
+# Initialize repo-local Paperclip config inside an existing worktree
 pnpm paperclipai worktree init --name team-a
 
 # List candidate worktrees
@@ -80,18 +80,18 @@ pnpm paperclipai worktree repair --branch team-a
 
 ### Recommended Initialization Flow
 
-1. `worktree:make` (or `worktree init` if the worktree already exists)
-2. `worktree env` to load the generated `PAPERCLIP_HOME` and `PAPERCLIP_INSTANCE_ID`
-3. `paperclipai run` to start that instance
-4. Run `paperclipai doctor` after first boot to confirm migration and secrets state
+1. `pnpm paperclipai worktree:make` (or `pnpm paperclipai worktree init` if the worktree already exists)
+2. `eval "$(pnpm paperclipai worktree env)"` to apply the generated `PAPERCLIP_HOME` and `PAPERCLIP_INSTANCE_ID` exports in bash/zsh
+3. `pnpm paperclipai run` to start that instance
+4. Run `pnpm paperclipai doctor` after first boot to confirm migration and secrets state
 
 ### Safety and Cleanup
 
-Use full seeding only when you need shared runtime state (agents, projects, and credentials), otherwise keep `seed-mode minimal` for faster startup:
+Use full seeding only when you need shared runtime state (agents, projects, and credentials), otherwise keep `--seed-mode minimal` for faster startup:
 
 ```sh
 pnpm paperclipai worktree:make team-a --seed-mode minimal
-pnpm paperclipai worktree:make team-a --seed-mode full
+pnpm paperclipai worktree:make team-a-full --seed-mode full
 ```
 
 When an isolated workspace is no longer needed, clean it up explicitly:


### PR DESCRIPTION
## Thinking Path

> - Paperclip supports isolated local instances for safe agent development.
> - The CLI already provides worktree creation, initialization, environment, repair, reseed, and cleanup helpers.
> - Those commands were difficult to discover as one coherent workflow.
> - This pull request adds a focused command index and safe initialization sequence.
> - The benefit is a copyable workflow that keeps experimental agent state away from the primary instance.

## Linked Issues or Issue Description

No public issue was found. The documentation gap was that existing worktree commands were spread across reference material without a concise setup flow, making command names, environment loading, and seed modes easy to misuse.

## What Changed

- Added a worktree helper command index to the setup guide.
- Documented that worktree init configures an existing worktree rather than creating one.
- Added the bash/zsh eval step required to load exports.
- Used registered repair/reseed command forms and distinct seed examples.

## Verification

- git diff --check upstream/master...HEAD
- Verified every documented command and option against cli/src/commands/worktree.ts.

## Risks

Low. Documentation-only; incorrect command forms and copy/paste ambiguities were corrected during review.

## Model Used

OpenAI GPT-5.3 Codex Spark for initial branch work; OpenAI GPT-5 Codex for review and follow-up fixes, with repository and GitHub tool use. Context-window sizes were not exposed in this session.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this docs PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked or described the problem above
- [x] I have either linked an existing issue or described the issue in-PR
- [x] I have not referenced internal/instance-local Paperclip issues or links
- [x] My branch name describes the change and contains no internal ticket id
- [x] I have run focused validation locally
- [x] I have added or updated tests where applicable (documentation-only; no runtime tests needed)
- [x] I have updated the relevant documentation
- [x] I have considered and documented risks above
- [x] All Paperclip CI gates are green on the latest commit
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups on the latest commit
- [x] I will address all Greptile and reviewer comments before requesting merge