### PR TITLE
docs: document issue chat performance benchmark command

### DIFF
--- a/docs/cli/setup-commands.md
+++ b/docs/cli/setup-commands.md
@@ -125,12 +125,13 @@ Example:
 
 ```sh
 PAPERCLIP_PERF_BASE_URL=http://localhost:3100 \
-PAPERCLIP_PERF_COMPANY_PREFIX=acme \
 PAPERCLIP_PERF_BEARER_TOKEN=$TOKEN \
 pnpm perf:issue-chat-long-thread
 ```
 
-The command exits with a JSON payload containing:
+For dev builds that register prefixed benchmark routes, add `PAPERCLIP_PERF_COMPANY_PREFIX=<prefix>` to target `/<prefix>/tests/perf/long-thread`.
+
+The script writes a JSON payload to stdout, including:
 
 - `fixtureRowTarget`
 - `virtualized`

--- a/docs/cli/setup-commands.md
+++ b/docs/cli/setup-commands.md
@@ -118,7 +118,6 @@ pnpm perf:issue-chat-long-thread
 Useful environment overrides:
 
 - `PAPERCLIP_PERF_BASE_URL` sets the target Paperclip URL (default `http://localhost:3100`)
-- `PAPERCLIP_PERF_COMPANY_PREFIX` switches the route to `/<prefix>/tests/perf/long-thread` and only works against dev builds that register prefixed benchmark routes. Leave it unset for production or staging URLs.
 - `PAPERCLIP_PERF_BEARER_TOKEN` provides an explicit bearer token
 
 Example:
@@ -128,8 +127,6 @@ PAPERCLIP_PERF_BASE_URL=http://localhost:3100 \
 PAPERCLIP_PERF_BEARER_TOKEN=$TOKEN \
 pnpm perf:issue-chat-long-thread
 ```
-
-For dev builds that register prefixed benchmark routes, add `PAPERCLIP_PERF_COMPANY_PREFIX=<prefix>` to target `/<prefix>/tests/perf/long-thread`.
 
 The script writes a JSON payload to stdout, including:
 

--- a/docs/cli/setup-commands.md
+++ b/docs/cli/setup-commands.md
@@ -107,6 +107,38 @@ Allow a private hostname for authenticated/private mode:
 pnpm paperclipai allowed-hostname my-tailscale-host
 ```
 
+## `pnpm perf:issue-chat-long-thread` Benchmark
+
+Measure issue-thread rendering performance against the long-thread fixture:
+
+```sh
+pnpm perf:issue-chat-long-thread
+```
+
+Useful environment overrides:
+
+- `PAPERCLIP_PERF_BASE_URL` sets the target Paperclip URL (default `http://localhost:3100`)
+- `PAPERCLIP_PERF_COMPANY_PREFIX` switches the route under `/tests/perf/long-thread` for dev routing
+- `PAPERCLIP_PERF_BEARER_TOKEN` provides an explicit bearer token
+
+Example:
+
+```sh
+PAPERCLIP_PERF_BASE_URL=http://localhost:3100 \
+PAPERCLIP_PERF_COMPANY_PREFIX=acme \
+PAPERCLIP_PERF_BEARER_TOKEN=$TOKEN \
+pnpm perf:issue-chat-long-thread
+```
+
+The command exits with a JSON payload containing:
+
+- `fixtureRowTarget`
+- `virtualized`
+- `renderReadyMs`
+- `elapsedMs`
+- `reactProfilerAvailable`
+- `scrollResponsiveMs`
+
 ## Local Storage Paths
 
 | Data | Default Path |

--- a/docs/cli/setup-commands.md
+++ b/docs/cli/setup-commands.md
@@ -118,7 +118,7 @@ pnpm perf:issue-chat-long-thread
 Useful environment overrides:
 
 - `PAPERCLIP_PERF_BASE_URL` sets the target Paperclip URL (default `http://localhost:3100`)
-- `PAPERCLIP_PERF_COMPANY_PREFIX` switches the route under `/tests/perf/long-thread` for dev routing
+- `PAPERCLIP_PERF_COMPANY_PREFIX` switches the route to `/<prefix>/tests/perf/long-thread` and only works against dev builds that register prefixed benchmark routes. Leave it unset for production or staging URLs.
 - `PAPERCLIP_PERF_BEARER_TOKEN` provides an explicit bearer token
 
 Example:


### PR DESCRIPTION
## Thinking Path

> - Paperclip includes a long-thread issue-chat performance benchmark.
> - Contributors need an accurate way to invoke it and interpret its output.
> - The root script and supported environment overrides were not documented in the CLI setup guide.
> - This pull request documents the benchmark as a root pnpm script.
> - The benefit is a reproducible command without implying unsupported prefixed routes.

## Linked Issues or Issue Description

No public issue was found. The benchmark existed in package.json and scripts/measure-issue-chat-long-thread.mjs, but the setup guide did not document its supported invocation, inputs, or output.

## What Changed

- Documented pnpm perf:issue-chat-long-thread as a root benchmark script.
- Documented the supported base URL and bearer-token overrides.
- Described representative JSON fields written to stdout.
- Removed the unsupported company-prefix route after review.

## Verification

- git diff --check upstream/master...HEAD
- Verified the command in package.json and output fields in scripts/measure-issue-chat-long-thread.mjs.

## Risks

Low. Documentation-only; the guide now excludes an override whose target route is not registered.

## Model Used

OpenAI GPT-5.3 Codex Spark for initial branch work; OpenAI GPT-5 Codex for review and follow-up fixes, with repository and GitHub tool use. Context-window sizes were not exposed in this session.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this docs PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked or described the problem above
- [x] I have either linked an existing issue or described the issue in-PR
- [x] I have not referenced internal/instance-local Paperclip issues or links
- [x] My branch name describes the change and contains no internal ticket id
- [x] I have run focused validation locally
- [x] I have added or updated tests where applicable (documentation-only; no runtime tests needed)
- [x] I have updated the relevant documentation
- [x] I have considered and documented risks above
- [x] All Paperclip CI gates are green on the latest commit
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups on the latest commit
- [x] I will address all Greptile and reviewer comments before requesting merge