### PR TITLE
docs: add local adapter preflight checklist

### DIFF
--- a/docs/agents-runtime.md
+++ b/docs/agents-runtime.md
@@ -164,6 +164,24 @@ Claude-specific note:
 
 - If `ANTHROPIC_API_KEY` is set in adapter env or host environment, Claude uses API-key auth instead of subscription login. Paperclip surfaces this as a warning in environment tests, not a hard error.
 
+## 8.1 Safe Local-Run Preflight (CPU-leaning)
+
+Before starting local adapter runs, run a short preflight in this order:
+
+1. Install and authenticate the adapter CLI the runner will execute:
+   - `claude` for `claude_local`
+   - `codex` for `codex_local`
+   - `opencode` for `opencode_local`
+   - `hermes` for `hermes_local`
+2. `pnpm paperclipai doctor` in the target instance.
+3. `pnpm paperclipai run --data-dir <path>` once to ensure the local instance starts with the intended paths.
+4. For repository-bound tasks, run one manual `paperclipai agent local-cli <agent-ref> --company-id <company-id>` setup and verify the emitted `PAPERCLIP_API_URL`, `PAPERCLIP_COMPANY_ID`, and `PAPERCLIP_AGENT_ID` values reference the intended target instance.
+5. Confirm the workspace exists and is writable before wakeup:
+   - `PAPERCLIP_IN_WORKTREE` is set automatically in managed worktree environments.
+   - `pnpm paperclipai workspace list --company-id <company-id>` shows the expected project/execution workspace references.
+
+If any step fails, pause the agent and fix the dependency or auth state before resuming recurring heartbeats.
+
 ## 9. Security and risk notes
 
 Local CLI adapters run unsandboxed on the host machine.

--- a/docs/agents-runtime.md
+++ b/docs/agents-runtime.md
@@ -175,7 +175,7 @@ Before starting local adapter runs, run a short preflight in this order:
    - `hermes` for `hermes_local`
 2. `pnpm paperclipai doctor --data-dir <path>` in the target instance.
 3. `pnpm paperclipai run --data-dir <path>` once to ensure the local instance starts with the intended paths.
-4. For repository-bound tasks, run one manual `pnpm paperclipai agent local-cli <agent-ref> --company-id <company-id> --data-dir <path>` setup, load its emitted exports in the current shell, and verify `PAPERCLIP_API_URL`, `PAPERCLIP_COMPANY_ID`, and `PAPERCLIP_AGENT_ID` reference the intended target instance.
+4. For repository-bound tasks, run one manual `pnpm paperclipai agent local-cli <agent-ref> --company-id <company-id> --api-base <target-api-url> --data-dir <path>` setup, load its emitted exports in the current shell, and verify `PAPERCLIP_API_URL`, `PAPERCLIP_COMPANY_ID`, and `PAPERCLIP_AGENT_ID` reference the intended target instance. The explicit `--api-base` prevents a stale `PAPERCLIP_API_URL` or context profile from selecting another instance.
 5. Check the target API is reachable, for example `curl "$PAPERCLIP_API_URL/api/health"` after loading those exports.
 6. Confirm the workspace exists and is writable before wakeup:
    - `PAPERCLIP_IN_WORKTREE` is set automatically in managed worktree environments.

--- a/docs/agents-runtime.md
+++ b/docs/agents-runtime.md
@@ -175,7 +175,7 @@ Before starting local adapter runs, run a short preflight in this order:
    - `hermes` for `hermes_local`
 2. `pnpm paperclipai doctor --data-dir <path>` in the target instance.
 3. `pnpm paperclipai run --data-dir <path>` once to ensure the local instance starts with the intended paths.
-4. For repository-bound tasks, run one manual `pnpm paperclipai agent local-cli <agent-ref> --company-id <company-id>` setup, load its emitted exports in the current shell, and verify `PAPERCLIP_API_URL`, `PAPERCLIP_COMPANY_ID`, and `PAPERCLIP_AGENT_ID` reference the intended target instance.
+4. For repository-bound tasks, run one manual `pnpm paperclipai agent local-cli <agent-ref> --company-id <company-id> --data-dir <path>` setup, load its emitted exports in the current shell, and verify `PAPERCLIP_API_URL`, `PAPERCLIP_COMPANY_ID`, and `PAPERCLIP_AGENT_ID` reference the intended target instance.
 5. Check the target API is reachable, for example `curl "$PAPERCLIP_API_URL/api/health"` after loading those exports.
 6. Confirm the workspace exists and is writable before wakeup:
    - `PAPERCLIP_IN_WORKTREE` is set automatically in managed worktree environments.

--- a/docs/agents-runtime.md
+++ b/docs/agents-runtime.md
@@ -173,10 +173,11 @@ Before starting local adapter runs, run a short preflight in this order:
    - `codex` for `codex_local`
    - `opencode` for `opencode_local`
    - `hermes` for `hermes_local`
-2. `pnpm paperclipai doctor` in the target instance.
+2. `pnpm paperclipai doctor --data-dir <path>` in the target instance.
 3. `pnpm paperclipai run --data-dir <path>` once to ensure the local instance starts with the intended paths.
-4. For repository-bound tasks, run one manual `pnpm paperclipai agent local-cli <agent-ref> --company-id <company-id>` setup and verify the emitted `PAPERCLIP_API_URL`, `PAPERCLIP_COMPANY_ID`, and `PAPERCLIP_AGENT_ID` values reference the intended target instance.
-5. Confirm the workspace exists and is writable before wakeup:
+4. Check the local API is reachable, for example `curl "$PAPERCLIP_API_URL/api/health"` after loading the target instance env.
+5. For repository-bound tasks, run one manual `pnpm paperclipai agent local-cli <agent-ref> --company-id <company-id>` setup and verify the emitted `PAPERCLIP_API_URL`, `PAPERCLIP_COMPANY_ID`, and `PAPERCLIP_AGENT_ID` values reference the intended target instance.
+6. Confirm the workspace exists and is writable before wakeup:
    - `PAPERCLIP_IN_WORKTREE` is set automatically in managed worktree environments.
    - `pnpm paperclipai workspace list --company-id <company-id>` shows the expected project/execution workspace references.
 

--- a/docs/agents-runtime.md
+++ b/docs/agents-runtime.md
@@ -175,7 +175,7 @@ Before starting local adapter runs, run a short preflight in this order:
    - `hermes` for `hermes_local`
 2. `pnpm paperclipai doctor` in the target instance.
 3. `pnpm paperclipai run --data-dir <path>` once to ensure the local instance starts with the intended paths.
-4. For repository-bound tasks, run one manual `paperclipai agent local-cli <agent-ref> --company-id <company-id>` setup and verify the emitted `PAPERCLIP_API_URL`, `PAPERCLIP_COMPANY_ID`, and `PAPERCLIP_AGENT_ID` values reference the intended target instance.
+4. For repository-bound tasks, run one manual `pnpm paperclipai agent local-cli <agent-ref> --company-id <company-id>` setup and verify the emitted `PAPERCLIP_API_URL`, `PAPERCLIP_COMPANY_ID`, and `PAPERCLIP_AGENT_ID` values reference the intended target instance.
 5. Confirm the workspace exists and is writable before wakeup:
    - `PAPERCLIP_IN_WORKTREE` is set automatically in managed worktree environments.
    - `pnpm paperclipai workspace list --company-id <company-id>` shows the expected project/execution workspace references.

--- a/docs/agents-runtime.md
+++ b/docs/agents-runtime.md
@@ -175,8 +175,8 @@ Before starting local adapter runs, run a short preflight in this order:
    - `hermes` for `hermes_local`
 2. `pnpm paperclipai doctor --data-dir <path>` in the target instance.
 3. `pnpm paperclipai run --data-dir <path>` once to ensure the local instance starts with the intended paths.
-4. Check the local API is reachable, for example `curl "$PAPERCLIP_API_URL/api/health"` after loading the target instance env.
-5. For repository-bound tasks, run one manual `pnpm paperclipai agent local-cli <agent-ref> --company-id <company-id>` setup and verify the emitted `PAPERCLIP_API_URL`, `PAPERCLIP_COMPANY_ID`, and `PAPERCLIP_AGENT_ID` values reference the intended target instance.
+4. For repository-bound tasks, run one manual `pnpm paperclipai agent local-cli <agent-ref> --company-id <company-id>` setup, load its emitted exports in the current shell, and verify `PAPERCLIP_API_URL`, `PAPERCLIP_COMPANY_ID`, and `PAPERCLIP_AGENT_ID` reference the intended target instance.
+5. Check the target API is reachable, for example `curl "$PAPERCLIP_API_URL/api/health"` after loading those exports.
 6. Confirm the workspace exists and is writable before wakeup:
    - `PAPERCLIP_IN_WORKTREE` is set automatically in managed worktree environments.
    - `pnpm paperclipai workspace list --company-id <company-id>` shows the expected project/execution workspace references.


### PR DESCRIPTION
## Thinking Path

> - Paperclip runs local AI adapters against a selected instance and workspace.
> - A preflight must validate the same instance that later receives agent traffic.
> - Missing CLI arguments or stale environment values can make checks pass against the wrong target.
> - This pull request adds an ordered, instance-scoped local-run preflight.
> - The benefit is safer repository-bound runs before recurring heartbeats begin.

## Linked Issues or Issue Description

No public issue was found. Local adapter documentation lacked one ordered checklist covering CLI authentication, instance selection, API reachability, agent exports, and workspace readiness.

## What Changed

- Added a concise local adapter preflight.
- Scoped doctor, run, and ^Ggent local-cli to the same --data-dir.
- Required loading and checking emitted target exports before the health check.
- Added workspace existence and writability checks.

## Verification

- git diff --check upstream/master...HEAD
- Verified --data-dir is provided by the shared client options.
- Verified ^Ggent local-cli requires an agent reference and company id and emits the documented variables.

## Risks

Low. Documentation-only; ordering and instance selection were tightened after review.

## Model Used

OpenAI GPT-5.3 Codex Spark for initial branch work; OpenAI GPT-5 Codex for review and follow-up fixes, with repository and GitHub tool use. Context-window sizes were not exposed in this session.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this docs PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked or described the problem above
- [x] I have either linked an existing issue or described the issue in-PR
- [x] I have not referenced internal/instance-local Paperclip issues or links
- [x] My branch name describes the change and contains no internal ticket id
- [x] I have run focused validation locally
- [x] I have added or updated tests where applicable (documentation-only; no runtime tests needed)
- [x] I have updated the relevant documentation
- [x] I have considered and documented risks above
- [x] All Paperclip CI gates are green on the latest commit
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups on the latest commit
- [x] I will address all Greptile and reviewer comments before requesting merge