### PR TITLE
docs: sync legacy CLI reference with worktree and benchmark commands

### DIFF
--- a/doc/CLI.md
+++ b/doc/CLI.md
@@ -54,6 +54,30 @@ pnpm paperclipai env-lab status --json
 pnpm paperclipai env-lab down
 ```
 
+## Worktree Helpers (Safe Local Initialization)
+
+Use worktree commands to keep local experiments isolated from your main instance:
+
+```sh
+pnpm paperclipai worktree:make local-lab
+pnpm paperclipai worktree:list
+pnpm paperclipai worktree:cleanup local-lab --force
+```
+
+## Benchmark Command
+
+Run the issue-thread render benchmark from the repo root:
+
+```sh
+pnpm perf:issue-chat-long-thread
+```
+
+Useful overrides:
+
+- `PAPERCLIP_PERF_BASE_URL`
+- `PAPERCLIP_PERF_COMPANY_PREFIX`
+- `PAPERCLIP_PERF_BEARER_TOKEN`
+
 All client commands support:
 
 - `--data-dir <path>`


### PR DESCRIPTION
## Thinking Path

> - Paperclip has both current CLI docs and a legacy reference used by existing contributors.
> - Worktree helpers and the issue-chat benchmark were absent from the legacy page.
> - That drift makes valid commands harder to discover and compare.
> - This pull request synchronizes only those existing commands into the legacy reference.
> - The benefit is consistent command discovery without changing runtime behavior.

## Linked Issues or Issue Description

No public issue was found. The legacy CLI reference had fallen behind already-registered worktree and benchmark commands.

## What Changed

- Added existing worktree helper command forms to doc/CLI.md.
- Added the root issue-chat benchmark command and supported overrides.

## Verification

- git diff --check upstream/master...HEAD
- Verified referenced commands against cli/src/commands/worktree.ts and package.json.

## Risks

Low. Documentation-only synchronization of existing behavior.

## Model Used

OpenAI GPT-5.3 Codex Spark for initial branch work; OpenAI GPT-5 Codex for review and follow-up fixes, with repository and GitHub tool use. Context-window sizes were not exposed in this session.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this docs PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked or described the problem above
- [x] I have either linked an existing issue or described the issue in-PR
- [x] I have not referenced internal/instance-local Paperclip issues or links
- [x] My branch name describes the change and contains no internal ticket id
- [x] I have run focused validation locally
- [x] I have added or updated tests where applicable (documentation-only; no runtime tests needed)
- [x] I have updated the relevant documentation
- [x] I have considered and documented risks above
- [x] All Paperclip CI gates are green on the latest commit
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups on the latest commit
- [x] I will address all Greptile and reviewer comments before requesting merge