### PR TITLE
docs: add CLI setup quick command index

### DIFF
--- a/docs/cli/overview.md
+++ b/docs/cli/overview.md
@@ -75,6 +75,7 @@ The CLI has two categories:
 
 1. **[Setup commands](/cli/setup-commands)** — instance bootstrap, diagnostics, worktree helpers, and benchmarking
 2. **[Control-plane commands](/cli/control-plane-commands)** — issues, agents, approvals, activity
+
 ### Quick command index
 
 - `pnpm paperclipai worktree:make` / `pnpm paperclipai worktree:cleanup`

--- a/docs/cli/overview.md
+++ b/docs/cli/overview.md
@@ -73,5 +73,11 @@ Context is stored at `~/.paperclip/context.json`.
 
 The CLI has two categories:
 
-1. **[Setup commands](/cli/setup-commands)** — instance bootstrap, diagnostics, configuration
+1. **[Setup commands](/cli/setup-commands)** — instance bootstrap, diagnostics, worktree helpers, and benchmarking
 2. **[Control-plane commands](/cli/control-plane-commands)** — issues, agents, approvals, activity
+## Quick command index
+
+- `pnpm paperclipai worktree:make` / `pnpm paperclipai worktree:cleanup`
+- `pnpm paperclipai worktree repair` / `pnpm paperclipai worktree reseed`
+- `pnpm paperclipai worktree env` / `pnpm paperclipai worktree:list`
+- `pnpm perf:issue-chat-long-thread`

--- a/docs/cli/overview.md
+++ b/docs/cli/overview.md
@@ -75,9 +75,9 @@ The CLI has two categories:
 
 1. **[Setup commands](/cli/setup-commands)** — instance bootstrap, diagnostics, worktree helpers, and benchmarking
 2. **[Control-plane commands](/cli/control-plane-commands)** — issues, agents, approvals, activity
-## Quick command index
+### Quick command index
 
 - `pnpm paperclipai worktree:make` / `pnpm paperclipai worktree:cleanup`
 - `pnpm paperclipai worktree repair` / `pnpm paperclipai worktree reseed`
 - `pnpm paperclipai worktree env` / `pnpm paperclipai worktree:list`
-- `pnpm perf:issue-chat-long-thread`
+- Root benchmark script: `pnpm perf:issue-chat-long-thread`


### PR DESCRIPTION
## Thinking Path

> - The CLI overview should route readers quickly to setup and control-plane commands.
> - Worktree helpers and the benchmark were only discoverable deeper in the docs.
> - A short index can improve discovery without duplicating full reference content.
> - This pull request adds that index with correct command categories.
> - The benefit is faster navigation while preserving the document hierarchy.

## Linked Issues or Issue Description

No public issue was found. The CLI overview lacked direct links and examples for established worktree helpers and the root performance benchmark.

## What Changed

- Expanded the setup category description.
- Added a subordinate quick command index.
- Distinguished nested worktree subcommands from colon-form commands.
- Labeled the performance command explicitly as a root benchmark script.

## Verification

- git diff --check upstream/master...HEAD
- Verified headings and command forms against the setup guide and CLI registration.

## Risks

Low. Documentation-only navigation changes.

## Model Used

OpenAI GPT-5.3 Codex Spark for initial branch work; OpenAI GPT-5 Codex for review and follow-up fixes, with repository and GitHub tool use. Context-window sizes were not exposed in this session.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this docs PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked or described the problem above
- [x] I have either linked an existing issue or described the issue in-PR
- [x] I have not referenced internal/instance-local Paperclip issues or links
- [x] My branch name describes the change and contains no internal ticket id
- [x] I have run focused validation locally
- [x] I have added or updated tests where applicable (documentation-only; no runtime tests needed)
- [x] I have updated the relevant documentation
- [x] I have considered and documented risks above
- [x] All Paperclip CI gates are green on the latest commit
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups on the latest commit
- [x] I will address all Greptile and reviewer comments before requesting merge