### PR TITLE
fix(claude-local): suppress plugin/user hooks on headless runs

### DIFF
--- a/packages/adapters/claude-local/src/server/execute.remote.test.ts
+++ b/packages/adapters/claude-local/src/server/execute.remote.test.ts
@@ -333,4 +333,74 @@ describe("claude remote execution", () => {
     expect(call?.[2]).toContain("12345678-1234-4abc-9def-123456789012");
   });
 
+  const remoteExecutionTransport = {
+    remoteExecution: {
+      host: "127.0.0.1",
+      port: 2222,
+      username: "fixture",
+      remoteWorkspacePath: "/remote/workspace",
+      remoteCwd: "/remote/workspace",
+      privateKey: "PRIVATE KEY",
+      knownHosts: "[127.0.0.1]:2222 ssh-ed25519 AAAA",
+      strictHostKeyChecking: true,
+    },
+  } as const;
+
+  it("suppresses plugin/user hooks on headless runs via a --settings overlay by default", async () => {
+    const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-claude-hooks-default-"));
+    cleanupDirs.push(rootDir);
+    const workspaceDir = path.join(rootDir, "workspace");
+    await mkdir(workspaceDir, { recursive: true });
+
+    await execute({
+      runId: "run-hooks-default",
+      agent: {
+        id: "agent-1",
+        companyId: "company-1",
+        name: "Claude Coder",
+        adapterType: "claude_local",
+        adapterConfig: {},
+      },
+      runtime: { sessionId: null, sessionParams: null, sessionDisplayId: null, taskKey: null },
+      config: { command: "claude" },
+      context: { paperclipWorkspace: { cwd: workspaceDir, source: "project_primary" } },
+      executionTransport: remoteExecutionTransport,
+      onLog: async () => {},
+    });
+
+    expect(runChildProcess).toHaveBeenCalledTimes(1);
+    const call = runChildProcess.mock.calls[0] as unknown as [string, string, string[]] | undefined;
+    const args = call?.[2] ?? [];
+    const settingsIndex = args.indexOf("--settings");
+    expect(settingsIndex).toBeGreaterThanOrEqual(0);
+    expect(JSON.parse(args[settingsIndex + 1] ?? "{}")).toEqual({ disableAllHooks: true });
+  });
+
+  it("leaves hooks enabled on headless runs when config.disableHooks is false", async () => {
+    const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-claude-hooks-optout-"));
+    cleanupDirs.push(rootDir);
+    const workspaceDir = path.join(rootDir, "workspace");
+    await mkdir(workspaceDir, { recursive: true });
+
+    await execute({
+      runId: "run-hooks-optout",
+      agent: {
+        id: "agent-1",
+        companyId: "company-1",
+        name: "Claude Coder",
+        adapterType: "claude_local",
+        adapterConfig: {},
+      },
+      runtime: { sessionId: null, sessionParams: null, sessionDisplayId: null, taskKey: null },
+      config: { command: "claude", disableHooks: false },
+      context: { paperclipWorkspace: { cwd: workspaceDir, source: "project_primary" } },
+      executionTransport: remoteExecutionTransport,
+      onLog: async () => {},
+    });
+
+    expect(runChildProcess).toHaveBeenCalledTimes(1);
+    const call = runChildProcess.mock.calls[0] as unknown as [string, string, string[]] | undefined;
+    expect(call?.[2]).not.toContain("--settings");
+  });
+
 });

--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -383,6 +383,14 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const chrome = asBoolean(config.chrome, false);
   const maxTurns = asNumber(config.maxTurnsPerRun, 0);
   const dangerouslySkipPermissions = asBoolean(config.dangerouslySkipPermissions, true);
+  // Every claude-local run is a headless `--print` heartbeat. Plugin SessionStart hooks (e.g. from
+  // marketplace plugins) re-inject their full skill text on every one of these runs — hundreds to
+  // thousands of tokens each — and Claude settings offer no per-plugin hook disable. Suppress hooks
+  // for these headless runs via a highest-precedence `--settings` overlay (see buildClaudeArgs). This
+  // is scoped to this launcher process only, so a user's interactive `claude` sessions — and their
+  // statusLine hook — are untouched (and a headless `--print` run has no statusline to lose anyway).
+  // Opt out per agent with `config.disableHooks: false`.
+  const disableHooksOnHeadlessRun = asBoolean(config.disableHooks, true);
   const configEnv = parseObject(config.env);
   const workspaceContext = parseObject(context.paperclipWorkspace);
   const workspaceCwd = asString(workspaceContext.cwd, "");
@@ -733,6 +741,11 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       args.push("--append-system-prompt-file", attemptInstructionsFilePath);
     }
     args.push("--add-dir", effectivePromptBundleAddDir);
+    // Suppress plugin/user hooks for this headless run unless the caller supplied an explicit
+    // --settings (respect theirs — they may be steering hooks intentionally).
+    if (disableHooksOnHeadlessRun && !extraArgs.includes("--settings")) {
+      args.push("--settings", JSON.stringify({ disableAllHooks: true }));
+    }
     if (extraArgs.length > 0) args.push(...extraArgs);
     return args;
   };


### PR DESCRIPTION
## Thinking Path

> - Paperclip is an open-source app for running AI agents that do work, driven by repeated heartbeat runs.
> - Local agents are launched through the `claude-local` adapter, which invokes the Claude CLI in headless `--print` mode once per heartbeat.
> - Claude plugins can register `SessionStart` hooks that inject text (e.g. a plugin's full skill/bootstrap content) into every session the CLI starts.
> - In headless heartbeat mode that injection repeats on every run and can cost hundreds to thousands of tokens per run, with no task value added after the first exposure.
> - Claude settings offer no per-plugin hook disable, and the only global switch (`disableAllHooks`) also removes the statusline — which is fine headlessly (there is no statusline on a `--print` run) but not for a human's interactive session.
> - The launcher is the right place to fix this: it can pass a run-scoped `--settings` overlay that suppresses hooks only for the headless process it spawns, leaving interactive sessions untouched.
> - This PR adds that overlay, defaulting on for headless runs, with a per-agent opt-out and respect for any explicit caller `--settings`.

## Linked Issues or Issue Description

- No public GitHub issue is linked.
- Problem: plugin `SessionStart` hooks re-inject their full text on every headless `claude-local` heartbeat, inflating token usage on every run.
- Scope: launcher-side suppression for headless runs only; no change to interactive Claude sessions.

## What Changed

- `claude-local` now passes a highest-precedence `--settings {"disableAllHooks":true}` overlay when building the Claude CLI args for its headless `--print` run.
- The overlay is scoped to the spawned launcher process only, so a user's interactive `claude` sessions and their statusLine hook are unaffected.
- Opt out per agent with `config.disableHooks: false`.
- If a caller already supplied an explicit `--settings` in `extraArgs`, theirs is respected (the overlay is not added), so intentional hook steering is preserved.
- Tests: `execute.remote.test.ts` pins the overlay present by default and absent when `config.disableHooks` is false.

## Verification

```
pnpm exec vitest run --project "@paperclipai/adapter-claude-local" src/server/execute.remote.test.ts
```

Result on this branch: 5 passed (3 existing remote-execution tests + the 2 new hook tests). The default run asserts `--settings` is present with `{"disableAllHooks":true}`; the `disableHooks: false` run asserts `--settings` is absent.

## Risks

- Behavioral shift: hooks are now suppressed by default on headless `claude-local` runs. A deployment that intentionally relies on `SessionStart`/`PreToolUse`/etc. hooks *during headless agent runs* would need to set `config.disableHooks: false` to restore them. This is called out in the code comment and is opt-out-able per agent. Interactive sessions are unaffected.
- Otherwise low risk: additive args-building change, no schema or migration impact, and an explicit caller `--settings` is preserved.

## Model Used

- Provider: Anthropic
- Model: Claude Opus 4.8 (`claude-opus-4-8`), 1M context
- Capabilities: extended thinking, tool use

## Checklist

- [x] I included thinking path traces from project context to the change
- [x] I specified the model used (with version and capability details)
- [x] I checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I searched GitHub for duplicate/related PRs (no open PR touches claude-local hook handling)
- [x] I described the issue in-PR (no existing public issue)
- [x] I did not reference internal/instance-local Paperclip issues or links
- [x] My branch name describes the change and contains no internal ticket ids
- [x] I ran tests locally and they pass
- [x] I added tests covering the change
- [x] I considered and documented risks above
- [x] I will address all Greptile reviewer comments before requesting merge
