### PR TITLE
fix(adapter-utils): dedupe execution contract on scoped wake prompts

### DIFF
--- a/packages/adapter-utils/src/server-utils.test.ts
+++ b/packages/adapter-utils/src/server-utils.test.ts
@@ -617,30 +617,60 @@ describe("renderPaperclipWakePrompt", () => {
     );
   });
 
-  it("adds the execution contract to scoped wake prompts", () => {
-    const prompt = renderPaperclipWakePrompt({
-      reason: "issue_assigned",
-      issue: {
-        id: "issue-1",
-        identifier: "PAP-1580",
-        title: "Update prompts",
-        status: "in_progress",
-      },
-      commentWindow: {
-        requestedCount: 0,
-        includedCount: 0,
-        missingCount: 0,
-      },
-      comments: [],
-      fallbackFetchNeeded: false,
-    });
+  const scopedWakePayload = {
+    reason: "issue_assigned",
+    issue: {
+      id: "issue-1",
+      identifier: "PAP-1580",
+      title: "Update prompts",
+      status: "in_progress",
+    },
+    commentWindow: {
+      requestedCount: 0,
+      includedCount: 0,
+      missingCount: 0,
+    },
+    comments: [],
+    fallbackFetchNeeded: false,
+  };
+
+  // The execution contract must appear exactly once in the composed prompt on every path. The
+  // adapter composes `template + wakePrompt` on fresh runs and suppresses the template on
+  // resume-delta runs, so the fresh wake prompt must NOT restate the contract while the
+  // resume-delta wake prompt MUST (it is the only copy the agent gets there).
+  const countContract = (text: string): number =>
+    text.split("Execution contract").length - 1;
+
+  it("does not restate the execution contract on the fresh wake-payload path", () => {
+    const prompt = renderPaperclipWakePrompt(scopedWakePayload);
 
     expect(prompt).toContain("## Paperclip Wake Payload");
+    // The template (composed separately by the adapter) carries the contract on fresh runs.
+    expect(prompt).not.toContain("Execution contract");
+  });
+
+  it("keeps a condensed execution contract on the resume-delta path", () => {
+    const prompt = renderPaperclipWakePrompt(scopedWakePayload, { resumedSession: true });
+
+    expect(prompt).toContain("## Paperclip Resume Delta");
     expect(prompt).toContain("Execution contract: take concrete action in this heartbeat");
     expect(prompt).toContain("clear final disposition");
     expect(prompt).toContain("evidence, not valid liveness paths by themselves");
-    expect(prompt).toContain("Use child issues for long or parallel delegated work instead of polling");
-    expect(prompt).toContain("named unblock owner/action");
+    expect(countContract(prompt)).toBe(1);
+  });
+
+  it("yields the execution contract exactly once on both composed paths", () => {
+    // Fresh run: adapter renders the template AND appends the wake prompt.
+    const freshWake = renderPaperclipWakePrompt(scopedWakePayload);
+    const freshComposed = `${DEFAULT_PAPERCLIP_AGENT_PROMPT_TEMPLATE}\n${freshWake}`;
+    expect(countContract(freshComposed)).toBe(1);
+
+    // Resume-delta run: adapter suppresses the template and sends only the wake prompt.
+    const resumeWake = renderPaperclipWakePrompt(scopedWakePayload, { resumedSession: true });
+    expect(countContract(resumeWake)).toBe(1);
+
+    // Non-wake fresh run: no wake prompt at all, contract comes solely from the template.
+    expect(countContract(DEFAULT_PAPERCLIP_AGENT_PROMPT_TEMPLATE)).toBe(1);
   });
 
   it("renders resolved checkbox selections in scoped wake prompts", () => {

--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -1253,6 +1253,9 @@ export function renderPaperclipWakePrompt(
         "Focus on the new wake delta below and continue the current task without restating the full heartbeat boilerplate.",
         "Fetch the API thread only when `fallbackFetchNeeded` is true or you need broader history than this batch.",
         "",
+        // Keep a condensed execution contract on the resume-delta path only: adapters that send this
+        // delta suppress DEFAULT_PAPERCLIP_AGENT_PROMPT_TEMPLATE, so this is the sole copy the agent
+        // receives on a resumed session (the fresh wake-payload branch below omits it to avoid a duplicate).
         "Execution contract: take concrete action in this heartbeat when the issue is actionable; do not stop at a plan unless planning was requested. Leave durable progress and then give the issue a clear final disposition before ending the heartbeat: `done`, `in_review` with a real reviewer/approval/interaction path, `blocked` with first-class blockers or a named unblock owner/action, delegated follow-up issues with blockers, or `in_progress` only when a live continuation path exists. Use child issues for long or parallel delegated work instead of polling. Comments, documents, screenshots, work products, and `Remaining` bullets are evidence, not valid liveness paths by themselves.",
         "",
         `- reason: ${normalized.reason ?? "unknown"}`,
@@ -1270,8 +1273,11 @@ export function renderPaperclipWakePrompt(
         "Use this inline wake data first before refetching the issue thread.",
         "Only fetch the API thread when `fallbackFetchNeeded` is true or you need broader history than this batch.",
         "",
-        "Execution contract: take concrete action in this heartbeat when the issue is actionable; do not stop at a plan unless planning was requested. Leave durable progress and then give the issue a clear final disposition before ending the heartbeat: `done`, `in_review` with a real reviewer/approval/interaction path, `blocked` with first-class blockers or a named unblock owner/action, delegated follow-up issues with blockers, or `in_progress` only when a live continuation path exists. Use child issues for long or parallel delegated work instead of polling. Comments, documents, screenshots, work products, and `Remaining` bullets are evidence, not valid liveness paths by themselves.",
-        "",
+        // No execution-contract paragraph here: on a fresh (non-resumed) run the adapter renders
+        // DEFAULT_PAPERCLIP_AGENT_PROMPT_TEMPLATE alongside this wake prompt, and that template already
+        // carries the (fuller, bulleted) contract. Restating it here duplicated it (~400 tokens per
+        // heartbeat). The resume-delta branch above keeps a condensed copy because there the template
+        // is suppressed.
         `- reason: ${normalized.reason ?? "unknown"}`,
         `- issue: ${normalized.issue?.identifier ?? normalized.issue?.id ?? "unknown"}${normalized.issue?.title ? ` ${normalized.issue.title}` : ""}`,
         `- pending comments: ${normalized.includedCount}/${normalized.requestedCount}`,


### PR DESCRIPTION
## Thinking Path

> - Paperclip is an open-source app for running AI agents that do work, driven by repeated heartbeat runs.
> - Each heartbeat, a local agent's prompt is composed from a base template (`DEFAULT_PAPERCLIP_AGENT_PROMPT_TEMPLATE`) plus a scoped wake preamble built by `renderPaperclipWakePrompt`.
> - Both surfaces carry an "Execution contract" block describing how the agent should dispose of the issue.
> - On a fresh (non-resumed) run the adapter renders the template AND appends the wake preamble, so the contract is emitted twice — roughly 400 tokens of pure duplication on every scoped wake.
> - Tokens spent restating identical guidance are tokens not spent on the task; across many agents and heartbeats this recurs constantly.
> - The wrinkle is the resume-delta path: there the adapter suppresses the template (`renderedPrompt = ""`), so the wake preamble is the only place the contract can appear.
> - The fix is to drop the contract from the fresh wake branch (the template already carries it there) while keeping one copy on the resume-delta branch — yielding exactly one contract on every path.

## Linked Issues or Issue Description

- No public GitHub issue is linked.
- Problem: on a fresh scoped wake, the execution-contract block is emitted twice (once by the template, once by the wake preamble).

### Related PR (please read)

This overlaps **#7634 ("Reduce Paperclip prompt bootstrap overhead")**, which edits the same lines. The approaches differ and are worth comparing:

- **#7634** replaces both contract copies with a shorter `SCOPED_WAKE_EXECUTION_CONTRACT` string but keeps it on the fresh wake branch, so a fresh run still emits the contract **twice** (just shorter).
- **This PR** removes the contract from the fresh wake branch entirely (the template is the single source there) and keeps one copy only on the resume-delta branch, so a fresh run emits it **once**.

These two PRs conflict on the same lines; maintainers should pick one, or fold this dedup into #7634. Happy to close this in favor of #7634 if the author would rather incorporate the fresh-branch removal there.

## What Changed

- `renderPaperclipWakePrompt`: removed the "Execution contract" paragraph from the fresh wake-payload branch (the template already carries it on fresh runs).
- Kept a copy on the resume-delta branch, where the adapter suppresses the template so this is the only copy the agent receives.
- Added comments documenting the asymmetry so the two branches are not "fixed" back into duplication later.
- Tests: replaced the single "adds the execution contract" assertion with three that pin the contract appearing exactly once on the fresh, resume-delta, and non-wake composed paths.

## Verification

```
pnpm exec vitest run --project "@paperclipai/adapter-utils" src/server-utils.test.ts
```

Result on this branch: 52 passed. The new tests assert: fresh wake prompt contains no "Execution contract"; resume-delta wake prompt contains exactly one; `template + freshWake` contains exactly one; template alone (non-wake run) contains exactly one.

## Risks

- Low. Text-only change to prompt composition; no API or type changes.
- One behavioral invariant to keep in mind: removing the contract from the fresh branch is safe only because every adapter that renders the fresh wake prompt also renders the template. The resume-delta branch retains its own copy for the case where the template is suppressed.

## Model Used

- Provider: Anthropic
- Model: Claude Opus 4.8 (`claude-opus-4-8`), 1M context
- Capabilities: extended thinking, tool use

## Checklist

- [x] I included thinking path traces from project context to the change
- [x] I specified the model used (with version and capability details)
- [x] I checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I searched GitHub for duplicate/related PRs and linked the related one (#7634) above
- [x] I described the issue in-PR (no existing public issue)
- [x] I did not reference internal/instance-local Paperclip issues or links
- [x] My branch name describes the change and contains no internal ticket ids
- [x] I ran tests locally and they pass
- [x] I added/updated tests covering the change
- [x] I considered and documented risks above
- [x] I will address all Greptile reviewer comments before requesting merge
