### PR TITLE
fix(server): accept board API keys for live-events WS upgrade

### DIFF
--- a/doc/spec/agent-runs.md
+++ b/doc/spec/agent-runs.md
@@ -591,7 +591,7 @@ Rules:
 Primary transport: websocket channel per company.
 
 - Endpoint: `GET /api/companies/:companyId/events/ws`
-- Auth: board session or agent API key (company-bound)
+- Auth: board session, agent API key, or board API key (`pcp_board_*`) — all company-bound
 
 ## 11.2 Event envelope
 

--- a/server/src/__tests__/live-events-ws.test.ts
+++ b/server/src/__tests__/live-events-ws.test.ts
@@ -248,3 +248,61 @@ describe("authorizeUpgrade board API keys", () => {
     expect(boardAuth.touchBoardApiKey).toHaveBeenCalledWith("key-5");
   });
 });
+
+describe("authorizeUpgrade agent API keys", () => {
+  const COMPANY_ID = "company-1";
+  const WS_URL = new URL(`http://localhost/api/companies/${COMPANY_ID}/events/ws`);
+
+  // The agent-key select must hit, so this fake resolves the select chain to
+  // the given key row while the update chain either resolves or rejects.
+  function createAgentFakeDb(keyRow: Record<string, unknown>, opts: { updateFails?: boolean } = {}) {
+    const selectChain: Record<string, unknown> = {};
+    for (const method of ["select", "from", "where"]) {
+      selectChain[method] = () => selectChain;
+    }
+    selectChain.then = (resolve: (rows: unknown[]) => unknown) => Promise.resolve(resolve([keyRow]));
+
+    const updateChain: Record<string, unknown> = {
+      set: () => updateChain,
+      where: () =>
+        opts.updateFails
+          ? Promise.reject(new Error("transient db write failure"))
+          : Promise.resolve([]),
+    };
+
+    return {
+      select: () => selectChain,
+      update: () => updateChain,
+    };
+  }
+
+  function run(db: unknown) {
+    const request = {
+      url: `/api/companies/${COMPANY_ID}/events/ws`,
+      headers: { authorization: "Bearer pcp_agent_valid" },
+    } as unknown as IncomingMessage;
+    return authorizeUpgrade(db as never, request, COMPANY_ID, WS_URL, {
+      deploymentMode: "authenticated",
+    });
+  }
+
+  it("accepts a valid agent key for its own company", async () => {
+    const db = createAgentFakeDb({ id: "akey-1", agentId: "agent-1", companyId: COMPANY_ID });
+
+    const context = await run(db);
+
+    expect(context).toEqual({ companyId: COMPANY_ID, actorType: "agent", actorId: "agent-1" });
+  });
+
+  it("still authorizes when the lastUsedAt bookkeeping write fails", async () => {
+    const db = createAgentFakeDb(
+      { id: "akey-2", agentId: "agent-2", companyId: COMPANY_ID },
+      { updateFails: true },
+    );
+
+    const context = await run(db);
+
+    expect(context).toEqual({ companyId: COMPANY_ID, actorType: "agent", actorId: "agent-2" });
+    expect(logger.warn).toHaveBeenCalled();
+  });
+});

--- a/server/src/__tests__/live-events-ws.test.ts
+++ b/server/src/__tests__/live-events-ws.test.ts
@@ -2,7 +2,9 @@ import { EventEmitter } from "node:events";
 import type { IncomingMessage } from "node:http";
 import type { Duplex } from "node:stream";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { setupLiveEventsWebSocketServer } from "../realtime/live-events-ws.js";
+import type { Mock } from "vitest";
+import { authorizeUpgrade, setupLiveEventsWebSocketServer } from "../realtime/live-events-ws.js";
+import { boardAuthService } from "../services/board-auth.js";
 import { logger } from "../middleware/logger.js";
 
 vi.mock("../middleware/logger.js", () => ({
@@ -10,6 +12,10 @@ vi.mock("../middleware/logger.js", () => ({
     warn: vi.fn(),
     error: vi.fn(),
   },
+}));
+
+vi.mock("../services/board-auth.js", () => ({
+  boardAuthService: vi.fn(),
 }));
 
 class FakeUpgradeSocket extends EventEmitter {
@@ -119,5 +125,111 @@ describe("setupLiveEventsWebSocketServer", () => {
     expect(socket.listenerCount("error")).toBe(0);
     expect(socket.listenerCount("close")).toBe(0);
     expect(socket.listenerCount("finish")).toBe(0);
+  });
+});
+
+describe("authorizeUpgrade board API keys", () => {
+  const COMPANY_ID = "company-1";
+  const WS_URL = new URL(`http://localhost/api/companies/${COMPANY_ID}/events/ws`);
+
+  let boardAuth: {
+    findBoardApiKeyByToken: Mock;
+    resolveBoardAccess: Mock;
+    touchBoardApiKey: Mock;
+  };
+
+  // The agent-key lookup runs first and must miss so we exercise the board
+  // branch. Every drizzle chain method returns the same thenable, and awaiting
+  // the terminal `.where(...)` resolves to an empty row set.
+  function createFakeDb() {
+    const chain: Record<string, unknown> = {};
+    for (const method of ["select", "from", "where", "update", "set"]) {
+      chain[method] = () => chain;
+    }
+    chain.then = (resolve: (rows: unknown[]) => unknown) => Promise.resolve(resolve([]));
+    return chain;
+  }
+
+  function boardRequest(token: string) {
+    return {
+      url: `/api/companies/${COMPANY_ID}/events/ws`,
+      headers: { authorization: `Bearer ${token}` },
+    } as unknown as IncomingMessage;
+  }
+
+  function run(token: string) {
+    return authorizeUpgrade(createFakeDb() as never, boardRequest(token), COMPANY_ID, WS_URL, {
+      deploymentMode: "authenticated",
+    });
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    boardAuth = {
+      findBoardApiKeyByToken: vi.fn(),
+      resolveBoardAccess: vi.fn(),
+      touchBoardApiKey: vi.fn().mockResolvedValue(undefined),
+    };
+    (boardAuthService as Mock).mockReturnValue(boardAuth);
+  });
+
+  it("accepts a valid board key whose owner is a member of the requested company", async () => {
+    boardAuth.findBoardApiKeyByToken.mockResolvedValue({ id: "key-1", userId: "user-1" });
+    boardAuth.resolveBoardAccess.mockResolvedValue({
+      user: { id: "user-1" },
+      companyIds: [COMPANY_ID],
+      isInstanceAdmin: false,
+    });
+
+    const context = await run("pcp_board_valid");
+
+    expect(context).toEqual({ companyId: COMPANY_ID, actorType: "board", actorId: "user-1" });
+    expect(boardAuth.touchBoardApiKey).toHaveBeenCalledWith("key-1");
+  });
+
+  it("accepts an instance admin even without an explicit company membership", async () => {
+    boardAuth.findBoardApiKeyByToken.mockResolvedValue({ id: "key-2", userId: "admin-1" });
+    boardAuth.resolveBoardAccess.mockResolvedValue({
+      user: { id: "admin-1" },
+      companyIds: [],
+      isInstanceAdmin: true,
+    });
+
+    const context = await run("pcp_board_admin");
+
+    expect(context).toEqual({ companyId: COMPANY_ID, actorType: "board", actorId: "admin-1" });
+    expect(boardAuth.touchBoardApiKey).toHaveBeenCalledWith("key-2");
+  });
+
+  it("rejects a valid board key whose owner has no membership and is not an admin", async () => {
+    boardAuth.findBoardApiKeyByToken.mockResolvedValue({ id: "key-3", userId: "user-3" });
+    boardAuth.resolveBoardAccess.mockResolvedValue({
+      user: { id: "user-3" },
+      companyIds: ["other-company"],
+      isInstanceAdmin: false,
+    });
+
+    expect(await run("pcp_board_wrong_company")).toBeNull();
+    expect(boardAuth.touchBoardApiKey).not.toHaveBeenCalled();
+  });
+
+  it("rejects a revoked/expired/unknown board key (service returns null)", async () => {
+    boardAuth.findBoardApiKeyByToken.mockResolvedValue(null);
+
+    expect(await run("pcp_board_revoked")).toBeNull();
+    expect(boardAuth.resolveBoardAccess).not.toHaveBeenCalled();
+    expect(boardAuth.touchBoardApiKey).not.toHaveBeenCalled();
+  });
+
+  it("rejects when the board key resolves to no user", async () => {
+    boardAuth.findBoardApiKeyByToken.mockResolvedValue({ id: "key-4", userId: "ghost" });
+    boardAuth.resolveBoardAccess.mockResolvedValue({
+      user: null,
+      companyIds: [],
+      isInstanceAdmin: false,
+    });
+
+    expect(await run("pcp_board_ghost")).toBeNull();
+    expect(boardAuth.touchBoardApiKey).not.toHaveBeenCalled();
   });
 });

--- a/server/src/__tests__/live-events-ws.test.ts
+++ b/server/src/__tests__/live-events-ws.test.ts
@@ -232,4 +232,19 @@ describe("authorizeUpgrade board API keys", () => {
     expect(await run("pcp_board_ghost")).toBeNull();
     expect(boardAuth.touchBoardApiKey).not.toHaveBeenCalled();
   });
+
+  it("still authorizes when the lastUsedAt bookkeeping write fails", async () => {
+    boardAuth.findBoardApiKeyByToken.mockResolvedValue({ id: "key-5", userId: "user-5" });
+    boardAuth.resolveBoardAccess.mockResolvedValue({
+      user: { id: "user-5" },
+      companyIds: [COMPANY_ID],
+      isInstanceAdmin: false,
+    });
+    boardAuth.touchBoardApiKey.mockRejectedValue(new Error("transient db write failure"));
+
+    const context = await run("pcp_board_touch_fails");
+
+    expect(context).toEqual({ companyId: COMPANY_ID, actorType: "board", actorId: "user-5" });
+    expect(boardAuth.touchBoardApiKey).toHaveBeenCalledWith("key-5");
+  });
 });

--- a/server/src/realtime/live-events-ws.ts
+++ b/server/src/realtime/live-events-ws.ts
@@ -187,10 +187,17 @@ export async function authorizeUpgrade(
       return null;
     }
 
-    await db
-      .update(agentApiKeys)
-      .set({ lastUsedAt: new Date() })
-      .where(eq(agentApiKeys.id, key.id));
+    // Same best-effort rule as the board-key touch below: authentication has
+    // already succeeded, so a transient bookkeeping write failure must not
+    // reject a valid upgrade.
+    try {
+      await db
+        .update(agentApiKeys)
+        .set({ lastUsedAt: new Date() })
+        .where(eq(agentApiKeys.id, key.id));
+    } catch (err) {
+      logger.warn({ err, companyId }, "failed to touch agent api key lastUsedAt on ws upgrade");
+    }
 
     return {
       companyId,

--- a/server/src/realtime/live-events-ws.ts
+++ b/server/src/realtime/live-events-ws.ts
@@ -8,6 +8,7 @@ import { agentApiKeys, companyMemberships, instanceUserRoles } from "@paperclipa
 import type { DeploymentMode } from "@paperclipai/shared";
 import type { BetterAuthSessionResult } from "../auth/better-auth.js";
 import { logger } from "../middleware/logger.js";
+import { boardAuthService } from "../services/board-auth.js";
 import { subscribeCompanyLiveEvents } from "../services/live-events.js";
 
 interface WsSocket {
@@ -114,7 +115,7 @@ function headersFromIncomingMessage(req: IncomingMessage): Headers {
   return headers;
 }
 
-async function authorizeUpgrade(
+export async function authorizeUpgrade(
   db: Db,
   req: IncomingMessage,
   companyId: string,
@@ -181,19 +182,52 @@ async function authorizeUpgrade(
     .where(and(eq(agentApiKeys.keyHash, tokenHash), isNull(agentApiKeys.revokedAt)))
     .then((rows) => rows[0] ?? null);
 
-  if (!key || key.companyId !== companyId) {
+  if (key) {
+    if (key.companyId !== companyId) {
+      return null;
+    }
+
+    await db
+      .update(agentApiKeys)
+      .set({ lastUsedAt: new Date() })
+      .where(eq(agentApiKeys.id, key.id));
+
+    return {
+      companyId,
+      actorType: "agent",
+      actorId: key.agentId,
+    };
+  }
+
+  // Paperclip Desk (and other board CLI clients) authenticate with a board API
+  // key rather than an agent key, so the agent lookup above misses. Mirror the
+  // REST board-bearer path in middleware/auth.ts: resolve the owning user via
+  // the board-auth service (which enforces revocation/expiry), then enforce
+  // company scoping the same way the session-cookie branch above does —
+  // instance admins pass, everyone else must have an active membership in the
+  // requested company.
+  const boardAuth = boardAuthService(db);
+  const boardKey = await boardAuth.findBoardApiKeyByToken(token);
+  if (!boardKey) {
     return null;
   }
 
-  await db
-    .update(agentApiKeys)
-    .set({ lastUsedAt: new Date() })
-    .where(eq(agentApiKeys.id, key.id));
+  const access = await boardAuth.resolveBoardAccess(boardKey.userId);
+  if (!access.user) {
+    return null;
+  }
+
+  const hasCompanyMembership = access.companyIds.includes(companyId);
+  if (!access.isInstanceAdmin && !hasCompanyMembership) {
+    return null;
+  }
+
+  await boardAuth.touchBoardApiKey(boardKey.id);
 
   return {
     companyId,
-    actorType: "agent",
-    actorId: key.agentId,
+    actorType: "board",
+    actorId: boardKey.userId,
   };
 }
 

--- a/server/src/realtime/live-events-ws.ts
+++ b/server/src/realtime/live-events-ws.ts
@@ -222,7 +222,15 @@ export async function authorizeUpgrade(
     return null;
   }
 
-  await boardAuth.touchBoardApiKey(boardKey.id);
+  // Authentication has already succeeded at this point. The lastUsedAt update is
+  // best-effort bookkeeping — a transient write failure must not turn a valid,
+  // authenticated Desk client into a rejected upgrade (the caller maps a thrown
+  // error to a 500 rejection), so swallow and log instead of propagating.
+  try {
+    await boardAuth.touchBoardApiKey(boardKey.id);
+  } catch (err) {
+    logger.warn({ err, companyId }, "failed to touch board api key lastUsedAt on ws upgrade");
+  }
 
   return {
     companyId,


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The live-events subsystem pushes real-time activity to clients over a WebSocket (`server/src/realtime/live-events-ws.ts`), upgraded at `/api/companies/:companyId/events/ws`
> - Clients authenticate that upgrade one of three ways: a BetterAuth session cookie (web board), an agent API key, or a **board API key** (`pcp_board_*`) issued to CLI/desktop clients
> - The upgrade authorizer only ever hash-looked-up `agentApiKeys`; a board API key therefore resolved to `null` and the upgrade was rejected with `403 Forbidden`, so any board-key client could never receive live events
> - This pull request makes the WS upgrade accept board API keys by mirroring the existing REST board-bearer path, with the same revocation/expiry and company-scoping rules
> - The benefit is that desktop/CLI clients authenticating with a board key get live events instead of a silent 403, closing the gap between agent-key and board-key auth on the realtime channel

## Linked Issues or Issue Description

No public GitHub issue exists — describing the bug inline, following `bug_report.yml`:

### What happened?

A WebSocket upgrade to `/api/companies/{companyId}/events/ws` authenticated with a **board API key** (`Authorization: Bearer pcp_board_...`) is rejected with `403 Forbidden` on an authenticated-mode server. The realtime client can therefore never connect, so a board-key client receives no live events. The web board is unaffected because it upgrades with a BetterAuth session cookie.

Root cause: in `authorizeUpgrade` (`server/src/realtime/live-events-ws.ts`), a bearer token is hash-looked-up **only in `agentApiKeys`**. The board-key table (`boardApiKeys`) is never consulted, so a valid board bearer resolves to `null` → `rejectUpgrade(..., "403 Forbidden")`. The REST middleware (`server/src/middleware/auth.ts`) already accepts board bearers via the board-auth service; the realtime path was never taught to.

### Expected behavior

A valid, non-revoked, non-expired board API key whose owner is a member of the requested company (or an instance admin) should complete the upgrade (`101 Switching Protocols`) and receive live events. Revoked, expired, or unknown keys — and keys whose owner lacks access to the company — should still be rejected with `403`.

### Steps to reproduce

1. Run a server in `authenticated` deployment mode.
2. Create a board API key for a user who is a member of company `C` (e.g. via the CLI auth challenge flow).
3. Open a WebSocket upgrade to `/api/companies/C/events/ws` with header `Authorization: Bearer <pcp_board_...>`.
4. Observe the server respond `403 Forbidden` instead of `101 Switching Protocols`.

### Paperclip version or commit

Reproduces on `master` (branch based at commit `d7268b77d`).

### Deployment mode

`authenticated` (the no-token session-cookie and `local_trusted` paths are unaffected; only the bearer-token board-key path was broken).

## What Changed

- `authorizeUpgrade` now falls back to the board-auth service when the `agentApiKeys` lookup misses: `findBoardApiKeyByToken` (enforces `revokedAt` / `expiresAt`), then `resolveBoardAccess` to get the owner's memberships and instance-admin flag.
- Company scoping mirrors the existing session-cookie branch exactly: instance admins pass; everyone else must have an active membership in the requested company. On success it returns `{ actorType: "board", actorId: userId }` and touches `lastUsedAt`.
- Agent keys are still checked first and take the same auth path as before. Per review feedback, the `lastUsedAt` bookkeeping touch is now best-effort on **both** key types (agent and board): a transient write failure is logged and never rejects an already-authenticated upgrade.
- Exported `authorizeUpgrade` and added unit tests for the new branch.

## Verification

- `pnpm --filter @paperclipai/server run typecheck` → clean (exit 0, 0 errors).
- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/live-events-ws.test.ts` → 11/11 pass.
- New tests cover: board-key upgrade accepted for a company member; accepted for an instance admin without explicit membership; rejected for wrong-company; rejected for revoked/expired/unknown keys (service returns `null`); rejected when the key resolves to no user. Agent-key tests cover: valid key accepted for its own company; upgrade still authorized when the `lastUsedAt` write fails (best-effort regression test). The three pre-existing socket-lifecycle tests still pass.

## Risks

Low risk. The change is additive and only runs when the existing agent-key lookup misses, so agent-key and session-cookie auth are untouched. It reuses the same board-auth service and company-scoping semantics already trusted by the REST layer, so it does not widen access beyond what board keys already grant over REST. No schema or migration changes.

## Model Used

Claude Opus 4.8 (1M context) — model id `claude-opus-4-8[1m]`, extended thinking enabled, with tool use / code execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge



