### PR TITLE
[codex] Fix Windows embedded Postgres binary resolution

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -55,8 +55,11 @@
     "drizzle-orm": "0.45.2",
     "dotenv": "^17.4.2",
     "commander": "^13.1.0",
-    "embedded-postgres": "^18.1.0-beta.16",
+    "embedded-postgres": "18.1.0-beta.15",
     "picocolors": "^1.1.1"
+  },
+  "optionalDependencies": {
+    "@embedded-postgres/windows-x64": "18.1.0-beta.15"
   },
   "devDependencies": {
     "@types/node": "^22.19.21",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
   "packageManager": "pnpm@9.15.4",
   "pnpm": {
     "patchedDependencies": {
-      "embedded-postgres@18.1.0-beta.16": "patches/embedded-postgres@18.1.0-beta.16.patch"
+      "embedded-postgres@18.1.0-beta.15": "patches/embedded-postgres@18.1.0-beta.15.patch"
     },
     "overrides": {
       "rollup": ">=4.59.0",

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -46,8 +46,11 @@
   "dependencies": {
     "@paperclipai/shared": "workspace:*",
     "drizzle-orm": "^0.45.2",
-    "embedded-postgres": "^18.1.0-beta.16",
+    "embedded-postgres": "18.1.0-beta.15",
     "postgres": "^3.4.9"
+  },
+  "optionalDependencies": {
+    "@embedded-postgres/windows-x64": "18.1.0-beta.15"
   },
   "devDependencies": {
     "@types/node": "^22.19.21",

--- a/patches/embedded-postgres@18.1.0-beta.15.patch
+++ b/patches/embedded-postgres@18.1.0-beta.15.patch
@@ -1,0 +1,30 @@
+diff --git a/dist/index.js b/dist/index.js
+--- a/dist/index.js
++++ b/dist/index.js
+@@ -23,7 +23,7 @@
+  * for a particular string, we need to force that string into the right locale.
+  * @see https://github.com/leinelissen/embedded-postgres/issues/15
+  */
+-const LC_MESSAGES_LOCALE = 'en_US.UTF-8';
++const LC_MESSAGES_LOCALE = 'C';
+ // The default configuration options for the class
+ const defaults = {
+     databaseDir: path.join(process.cwd(), 'data', 'db'),
+@@ -133,7 +133,7 @@
+                     `--pwfile=${passwordFile}`,
+                     `--lc-messages=${LC_MESSAGES_LOCALE}`,
+                     ...this.options.initdbFlags,
+-                ], Object.assign(Object.assign({}, permissionIds), { env: { LC_MESSAGES: LC_MESSAGES_LOCALE } }));
++                ], Object.assign(Object.assign({}, permissionIds), { env: Object.assign(Object.assign({}, globalThis.process.env), { LC_MESSAGES: LC_MESSAGES_LOCALE }) }));
+                 // Connect to stderr, as that is where the messages get sent
+                 (_a = process.stdout) === null || _a === void 0 ? void 0 : _a.on('data', (chunk) => {
+                     // Parse the data as a string and log it
+@@ -177,7 +177,7 @@
+                     '-p',
+                     this.options.port.toString(),
+                     ...this.options.postgresFlags,
+-                ], Object.assign(Object.assign({}, permissionIds), { env: { LC_MESSAGES: LC_MESSAGES_LOCALE } }));
++                ], Object.assign(Object.assign({}, permissionIds), { env: Object.assign(Object.assign({}, globalThis.process.env), { LC_MESSAGES: LC_MESSAGES_LOCALE }) }));
+                 // Connect to stderr, as that is where the messages get sent
+                 (_a = this.process.stderr) === null || _a === void 0 ? void 0 : _a.on('data', (chunk) => {
+                     // Parse the data as a string and log it

--- a/scripts/embedded-postgres-windows-binary.test.mjs
+++ b/scripts/embedded-postgres-windows-binary.test.mjs
@@ -1,0 +1,42 @@
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync } from 'node:fs';
+import test from 'node:test';
+
+const embeddedPostgresVersion = '18.1.0-beta.15';
+const workspaceManifests = [
+  'cli/package.json',
+  'packages/db/package.json',
+  'server/package.json',
+];
+
+function readJson(path) {
+  return JSON.parse(readFileSync(path, 'utf8'));
+}
+
+test('Windows embedded Postgres binary matches the wrapper version', () => {
+  for (const manifestPath of workspaceManifests) {
+    const manifest = readJson(manifestPath);
+
+    assert.equal(
+      manifest.dependencies?.['embedded-postgres'],
+      embeddedPostgresVersion,
+      `${manifestPath} should pin embedded-postgres so the platform binary cannot drift`,
+    );
+    assert.equal(
+      manifest.optionalDependencies?.['@embedded-postgres/windows-x64'],
+      embeddedPostgresVersion,
+      `${manifestPath} should install the matching Windows x64 binary`,
+    );
+  }
+});
+
+test('embedded-postgres patch is registered for the pinned version', () => {
+  const rootManifest = readJson('package.json');
+  const patchPath = `patches/embedded-postgres@${embeddedPostgresVersion}.patch`;
+
+  assert.equal(
+    rootManifest.pnpm?.patchedDependencies?.[`embedded-postgres@${embeddedPostgresVersion}`],
+    patchPath,
+  );
+  assert.equal(existsSync(patchPath), true);
+});

--- a/server/package.json
+++ b/server/package.json
@@ -68,7 +68,7 @@
     "dompurify": "^3.4.8",
     "dotenv": "^17.4.2",
     "drizzle-orm": "^0.45.2",
-    "embedded-postgres": "^18.1.0-beta.16",
+    "embedded-postgres": "18.1.0-beta.15",
     "express": "^5.1.0",
     "jsdom": "^28.1.0",
     "multer": "^2.2.0",
@@ -80,6 +80,9 @@
     "ssh2": "^1.17.0",
     "ws": "^8.19.0",
     "zod": "^3.24.2"
+  },
+  "optionalDependencies": {
+    "@embedded-postgres/windows-x64": "18.1.0-beta.15"
   },
   "devDependencies": {
     "@types/express": "^5.0.0",


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The local quickstart path uses embedded Postgres so users can run Paperclip without provisioning an external database.
> - On Windows, that startup path imports the platform package `@embedded-postgres/windows-x64` from the `embedded-postgres` wrapper.
> - The repository currently depends on `embedded-postgres@18.1.0-beta.16`, but npm does not publish the matching Windows x64 platform package for beta.16.
> - The latest published Windows x64 platform package is `18.1.0-beta.15`.
> - This pull request pins the direct embedded Postgres consumers to that published wrapper/platform version pair and registers the existing patch for the pinned wrapper version.
> - The benefit is that Windows quickstart can resolve the embedded Postgres binary instead of failing before server startup.

## Linked Issues or Issue Description

- Refs #1018

## What Changed

- Pin `embedded-postgres` to `18.1.0-beta.15` in the direct workspace consumers:
  - `cli`
  - `packages/db`
  - `server`
- Add `@embedded-postgres/windows-x64@18.1.0-beta.15` as an explicit optional dependency in those workspaces.
- Register `patches/embedded-postgres@18.1.0-beta.15.patch` in root `pnpm.patchedDependencies`.
- Add `scripts/embedded-postgres-windows-binary.test.mjs` to verify the wrapper and Windows binary stay aligned.
- Leave `pnpm-lock.yaml` unchanged so the repository refresh bot can regenerate it.

## Verification

- `node --test ./scripts/embedded-postgres-windows-binary.test.mjs`
- Parsed all changed `package.json` files with Node.
- `gh search prs --repo paperclipai/paperclip "embedded postgres windows binary" --limit 10` only returned this PR.
- Confirmed npm publishes:
  - `embedded-postgres@18.1.0-beta.15`
  - `@embedded-postgres/windows-x64@18.1.0-beta.15`
- Confirmed npm does not publish `@embedded-postgres/windows-x64@18.1.0-beta.16`.

## Risks

- This pins embedded Postgres to the last version with a published Windows x64 binary. If upstream publishes `@embedded-postgres/windows-x64@18.1.0-beta.16`, this can be moved back to beta.16.
- I could not run the full monorepo suite locally because full repository clone/download repeatedly timed out in this environment.

## Model Used

- OpenAI Codex (GPT-5), with shell/GitHub CLI/API tool use and code execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge