### PR TITLE
feat(server): return childIssues array from GET /api/issues/{id}

### DIFF
--- a/server/src/__tests__/issues-goal-context-routes.test.ts
+++ b/server/src/__tests__/issues-goal-context-routes.test.ts
@@ -18,6 +18,11 @@ const mockIssueService = vi.hoisted(() => ({
   listAttachments: vi.fn(),
 }));
 
+const mockRecoveryActionService = vi.hoisted(() => ({
+  getActiveForIssue: vi.fn(),
+  listActiveForIssues: vi.fn(),
+}));
+
 const mockProjectService = vi.hoisted(() => ({
   getById: vi.fn(),
   listByIds: vi.fn(),
@@ -114,10 +119,7 @@ vi.mock("../services/index.js", () => ({
   heartbeatService: () => mockHeartbeatService,
   instanceSettingsService: () => mockInstanceSettingsService,
   issueApprovalService: () => ({}),
-  issueRecoveryActionService: () => ({
-    getActiveForIssue: vi.fn(async () => null),
-    listActiveForIssues: vi.fn(async () => new Map()),
-  }),
+  issueRecoveryActionService: () => mockRecoveryActionService,
   issueThreadInteractionService: () => ({
     listForIssue: vi.fn(async () => []),
     expireRequestConfirmationsSupersededByComment: vi.fn(async () => []),
@@ -199,6 +201,8 @@ describe.sequential("issue goal context routes", () => {
     mockIssueService.getAncestors.mockResolvedValue([]);
     mockIssueService.getRelationSummaries.mockResolvedValue({ blockedBy: [], blocks: [] });
     mockIssueService.getChildSummaries.mockResolvedValue([]);
+    mockRecoveryActionService.getActiveForIssue.mockResolvedValue(null);
+    mockRecoveryActionService.listActiveForIssues.mockResolvedValue(new Map());
     mockIssueService.findMentionedProjectIds.mockResolvedValue([]);
     mockIssueService.getCommentCursor.mockResolvedValue({
       totalComments: 0,
@@ -317,7 +321,33 @@ describe.sequential("issue goal context routes", () => {
     const res = await request(createApp()).get("/api/issues/11111111-1111-4111-8111-111111111111");
 
     expect(res.status).toBe(200);
-    expect(res.body.childIssues).toEqual(children);
+    // Order preserved; each child enriched with the same activeRecoveryAction field as blockedBy/blocks.
+    expect(res.body.childIssues).toEqual(children.map((child) => ({ ...child, activeRecoveryAction: null })));
+  });
+
+  it("enriches child issues with their active recovery action like blockedBy/blocks", async () => {
+    const childId = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+    const child = {
+      id: childId,
+      identifier: "PAP-600",
+      title: "Child under recovery",
+      status: "in_progress",
+      priority: "high",
+      assigneeAgentId: "33333333-3333-4333-8333-333333333333",
+      assigneeUserId: null,
+    };
+    const recoveryAction = {
+      id: "99999999-9999-4999-8999-999999999999",
+      status: "active",
+      ownerAgentId: "33333333-3333-4333-8333-333333333333",
+    };
+    mockIssueService.getChildSummaries.mockResolvedValue([child]);
+    mockRecoveryActionService.listActiveForIssues.mockResolvedValue(new Map([[childId, recoveryAction]]));
+
+    const res = await request(createApp()).get("/api/issues/11111111-1111-4111-8111-111111111111");
+
+    expect(res.status).toBe(200);
+    expect(res.body.childIssues).toEqual([{ ...child, activeRecoveryAction: recoveryAction }]);
   });
 
   it("keeps GET /issues/:id project and workspace embeds compact for fast detail loads", async () => {

--- a/server/src/__tests__/issues-goal-context-routes.test.ts
+++ b/server/src/__tests__/issues-goal-context-routes.test.ts
@@ -8,6 +8,7 @@ const mockIssueService = vi.hoisted(() => ({
   getById: vi.fn(),
   getAncestors: vi.fn(),
   getRelationSummaries: vi.fn(),
+  getChildSummaries: vi.fn(),
   findMentionedProjectIds: vi.fn(),
   getCommentCursor: vi.fn(),
   getComment: vi.fn(),
@@ -197,6 +198,7 @@ describe.sequential("issue goal context routes", () => {
     mockIssueService.getById.mockResolvedValue(legacyProjectLinkedIssue);
     mockIssueService.getAncestors.mockResolvedValue([]);
     mockIssueService.getRelationSummaries.mockResolvedValue({ blockedBy: [], blocks: [] });
+    mockIssueService.getChildSummaries.mockResolvedValue([]);
     mockIssueService.findMentionedProjectIds.mockResolvedValue([]);
     mockIssueService.getCommentCursor.mockResolvedValue({
       totalComments: 0,
@@ -277,6 +279,45 @@ describe.sequential("issue goal context routes", () => {
       { includeCommentBodies: false },
     );
     expect(mockGoalService.getDefaultCompanyGoal).not.toHaveBeenCalled();
+  });
+
+  it("returns an empty childIssues array from GET /issues/:id when the issue has no children", async () => {
+    const res = await request(createApp()).get("/api/issues/11111111-1111-4111-8111-111111111111");
+
+    expect(res.status).toBe(200);
+    expect(mockIssueService.getChildSummaries).toHaveBeenCalledWith(
+      "11111111-1111-4111-8111-111111111111",
+    );
+    expect(res.body.childIssues).toEqual([]);
+  });
+
+  it("surfaces child issues on GET /issues/:id ordered as the service returns them", async () => {
+    const children = [
+      {
+        id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+        identifier: "PAP-600",
+        title: "First child",
+        status: "todo",
+        priority: "high",
+        assigneeAgentId: "33333333-3333-4333-8333-333333333333",
+        assigneeUserId: null,
+      },
+      {
+        id: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+        identifier: "PAP-601",
+        title: "Second child",
+        status: "in_progress",
+        priority: "medium",
+        assigneeAgentId: null,
+        assigneeUserId: "local-board",
+      },
+    ];
+    mockIssueService.getChildSummaries.mockResolvedValue(children);
+
+    const res = await request(createApp()).get("/api/issues/11111111-1111-4111-8111-111111111111");
+
+    expect(res.status).toBe(200);
+    expect(res.body.childIssues).toEqual(children);
   });
 
   it("keeps GET /issues/:id project and workspace embeds compact for fast detail loads", async () => {

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -744,10 +744,16 @@ type RecoveryActionsLister = {
   ) => Promise<Map<string, NonNullable<IssueRelationIssueSummary["activeRecoveryAction"]>>>;
 };
 
+type RelationSummarySets = {
+  blockedBy: IssueRelationIssueSummary[];
+  blocks: IssueRelationIssueSummary[];
+  childIssues?: IssueRelationIssueSummary[];
+};
+
 async function relationRecoveryActionMap(
   recoveryActionsSvc: RecoveryActionsLister,
   companyId: string,
-  relations: { blockedBy: IssueRelationIssueSummary[]; blocks: IssueRelationIssueSummary[] },
+  relations: RelationSummarySets,
 ): Promise<Map<string, NonNullable<IssueRelationIssueSummary["activeRecoveryAction"]>>> {
   const candidates: IssueRelationIssueSummary[] = [];
   const visit = (summary: IssueRelationIssueSummary) => {
@@ -758,13 +764,14 @@ async function relationRecoveryActionMap(
   };
   for (const blocker of relations.blockedBy) visit(blocker);
   for (const blocking of relations.blocks) visit(blocking);
+  for (const child of relations.childIssues ?? []) visit(child);
   if (candidates.length === 0) return new Map();
   const ids = [...new Set(candidates.map((summary) => summary.id))];
   return recoveryActionsSvc.listActiveForIssues(companyId, ids);
 }
 
 function withRecoveryActionsOnRelationSummaries(
-  relations: { blockedBy: IssueRelationIssueSummary[]; blocks: IssueRelationIssueSummary[] },
+  relations: RelationSummarySets,
   recoveryActionByIssueId: Map<string, NonNullable<IssueRelationIssueSummary["activeRecoveryAction"]>>,
 ) {
   const augment = (summary: IssueRelationIssueSummary): IssueRelationIssueSummary => ({
@@ -775,6 +782,7 @@ function withRecoveryActionsOnRelationSummaries(
   return {
     blockedBy: relations.blockedBy.map(augment),
     blocks: relations.blocks.map(augment),
+    childIssues: (relations.childIssues ?? []).map(augment),
   };
 }
 
@@ -4667,13 +4675,14 @@ export function issueRoutes(
       listIssueLinkedCases(db, issue.companyId, issue.id),
       svc.getChildSummaries(issue.id),
     ]);
+    const relationsWithChildren = { ...relations, childIssues };
     const recoveryActionsByRelationIssue = await relationRecoveryActionMap(
       recoveryActionsSvc,
       issue.companyId,
-      relations,
+      relationsWithChildren,
     );
     const relationsWithRecoveryActions = withRecoveryActionsOnRelationSummaries(
-      relations,
+      relationsWithChildren,
       recoveryActionsByRelationIssue,
     );
     const revalidatedActiveRecoveryAction = await revalidateActiveSourceRecoveryForRead({
@@ -4700,7 +4709,7 @@ export function issueRoutes(
       activeRecoveryAction: revalidatedActiveRecoveryAction,
       blockedBy: relationsWithRecoveryActions.blockedBy,
       blocks: relationsWithRecoveryActions.blocks,
-      childIssues,
+      childIssues: relationsWithRecoveryActions.childIssues,
       relatedWork: referenceSummary,
       referencedIssueIdentifiers: referenceSummary.outbound.map((item) => item.issue.identifier ?? item.issue.id),
       ...documentPayload,

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -4651,6 +4651,7 @@ export function issueRoutes(
       scheduledRetry,
       activeRecoveryAction,
       linkedCases,
+      childIssues,
     ] = await Promise.all([
       resolveIssueProjectAndGoal(issue),
       svc.getAncestors(issue.id),
@@ -4664,6 +4665,7 @@ export function issueRoutes(
       svc.getCurrentScheduledRetry(issue.id),
       recoveryActionsSvc.getActiveForIssue(issue.companyId, issue.id),
       listIssueLinkedCases(db, issue.companyId, issue.id),
+      svc.getChildSummaries(issue.id),
     ]);
     const recoveryActionsByRelationIssue = await relationRecoveryActionMap(
       recoveryActionsSvc,
@@ -4698,6 +4700,7 @@ export function issueRoutes(
       activeRecoveryAction: revalidatedActiveRecoveryAction,
       blockedBy: relationsWithRecoveryActions.blockedBy,
       blocks: relationsWithRecoveryActions.blocks,
+      childIssues,
       relatedWork: referenceSummary,
       referencedIssueIdentifiers: referenceSummary.outbound.map((item) => item.issue.identifier ?? item.issue.id),
       ...documentPayload,

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -4937,6 +4937,29 @@ export function issueService(db: Db) {
       return relations.get(issueId) ?? { blockedBy: [], blocks: [] };
     },
 
+    getChildSummaries: async (issueId: string): Promise<IssueRelationIssueSummary[]> => {
+      const issue = await db
+        .select({ id: issues.id, companyId: issues.companyId })
+        .from(issues)
+        .where(eq(issues.id, issueId))
+        .then((rows) => rows[0] ?? null);
+      if (!issue) throw notFound("Issue not found");
+      const rows = await db
+        .select({
+          relatedId: issues.id,
+          identifier: issues.identifier,
+          title: issues.title,
+          status: issues.status,
+          priority: issues.priority,
+          assigneeAgentId: issues.assigneeAgentId,
+          assigneeUserId: issues.assigneeUserId,
+        })
+        .from(issues)
+        .where(and(eq(issues.companyId, issue.companyId), eq(issues.parentId, issueId)))
+        .orderBy(asc(issues.issueNumber), asc(issues.createdAt));
+      return rows.map(summarizeIssueRelationRow);
+    },
+
     getBlockerDiagnostics: async (
       issueId: string,
       maxBlockers = ISSUE_BLOCKER_DIAGNOSTICS_MAX_BLOCKERS,


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Issues are the unit of work; an epic/parent issue fans out into child issues that different agents pick up
> - `GET /api/issues/{id}` already returns `parentId`, `blockedBy`, `blocks`, and `ancestors`, but has no way to read an issue's *children*
> - Without a children field, an agent reading an epic can't tell it already has subtasks — a real run mis-triaged an epic and re-created duplicate children because the read affordance was missing
> - This pull request adds a `childIssues` array to the issue-detail response, using the same compact summary shape and recovery-action enrichment as `blockedBy`/`blocks`
> - The benefit is that any caller can read an epic's children directly in one request, closing the mis-triage gap without a separate list call

## Linked Issues or Issue Description

No public GitHub issue exists; describing inline per CONTRIBUTING.md → "Link Issues or Describe Them In-PR" (feature request).

- **Subsystem affected:** Server — issues API (`GET /api/issues/{id}` response projection).
- **Problem or motivation:** The issue-detail endpoint exposes upward/sideways relations (`parentId`, `blockedBy`, `blocks`, `ancestors`) but not downward ones. A caller reading a parent issue cannot enumerate its children from the detail response, so an agent reading an epic sees no children field and can re-create subtasks that already exist.
- **Proposed solution:** Add `childIssues: IssueRelationIssueSummary[]` to the response — the same compact summary shape as `blockedBy`/`blocks` (`id, identifier, title, status, priority, assignee`), ordered by `issueNumber` then `createdAt`, empty array when there are no children, and enriched with `activeRecoveryAction` like the sibling relation fields.
- **Alternatives considered:** Returning full child issue rows (rejected — larger payload, inconsistent with the existing relation fields); a separate `GET /api/issues/{id}/children` list endpoint (rejected — the detail read is exactly where the mis-triage happened, so the affordance belongs there).
- **Roadmap alignment:** Small read-only additive API change; does not overlap planned core work in `ROADMAP.md`.

## What Changed

- **`server/src/services/issues.ts`** — new `getChildSummaries(issueId)` next to `getRelationSummaries`, reusing the module-level `summarizeIssueRelationRow` so children return the identical `IssueRelationIssueSummary` shape. Query is scoped to `(companyId, parentId)` (covered by `issues_company_parent_idx`) and ordered by `issueNumber` then `createdAt`.
- **`server/src/routes/issues.ts`** — wired `getChildSummaries` into the `GET /issues/:id` `Promise.all`; `childIssues` is now run through the same `relationRecoveryActionMap` + `withRecoveryActionsOnRelationSummaries` enrichment as `blockedBy`/`blocks`, so a child under an active recovery action reports its `activeRecoveryAction` instead of `undefined`. Extracted a shared `RelationSummarySets` type; `childIssues` is optional so the existing wake-context handler is unaffected.
- **`server/src/__tests__/issues-goal-context-routes.test.ts`** — tests for empty `childIssues`, order preservation (now asserting the enriched shape), and a child under recovery surfacing its `activeRecoveryAction`. The recovery-action service mock was made per-test configurable.

## Verification

- `cd server && node_modules/.bin/tsc --noEmit -p tsconfig.json` — clean.
- `cd server && node_modules/.bin/vitest run src/__tests__/issues-goal-context-routes.test.ts` — 9 passed (incl. 3 `childIssues` cases).
- Related enrichment suites regression check: `vitest run src/__tests__/issue-recovery-actions.test.ts src/__tests__/issue-blocker-attention.test.ts src/__tests__/issue-dependency-wakeups-routes.test.ts` — 46 passed.

## Risks

Low risk. Purely additive read-only field on an existing endpoint; no schema/migration change. The child query hits an existing covering index. The shared enrichment helpers now also return a `childIssues` key, but the other caller (wake-context handler) reads only `.blockedBy`/`.blocks`, so behavior there is unchanged.

## Model Used

Claude Opus 4.8 (Anthropic), model id `claude-opus-4-8`, extended thinking enabled, with tool use / code execution in an agentic coding harness.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [ ] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details — *branch prefix carries a tracking id; renaming would recreate the PR, so leaving as-is and flagging honestly.*
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes — *the `GET /issues/{id}` OpenAPI response is a generic `z.record(z.unknown())` with no field-level schema enumerating `blockedBy`/`blocks`, so there is no field-level shape to extend for `childIssues`; the `{id}` path stays registered. Flagging in case the endpoint should move to a field-level response schema (out of scope here for consistency with existing relation fields).*
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

### Duplicate / related PR search

Searched open + closed PRs for "childIssues" / "child issues". No PR adds a children array to `GET /api/issues/{id}`. Related-but-distinct child-issue work (not duplicates): #6323 (dedupe child issues on originFingerprint), #6787 (inherit projectId on child create), #1927 (UI sub-issue counts), #3525 (block parent close while children open), #4034 (wake parent when child blocked).

