### PR TITLE
[codex] Harden pipeline migration backfills

### DIFF
--- a/packages/db/src/client.test.ts
+++ b/packages/db/src/client.test.ts
@@ -118,6 +118,37 @@ describeEmbeddedPostgres("applyPendingMigrations", () => {
     ).toEqual(['9999_bad_backfill.sql: UPDATE "issues" sets updated_at']);
   });
 
+  it("keeps pipeline migration backfills ahead of defaults and opaque fallbacks", async () => {
+    const foundation = await fs.promises.readFile(
+      new URL("./migrations/0113_pipeline_foundation.sql", import.meta.url),
+      "utf8",
+    );
+    const retryEffects = await fs.promises.readFile(
+      new URL("./migrations/0121_pipeline_automation_retry_effects.sql", import.meta.url),
+      "utf8",
+    );
+
+    expect(foundation).not.toContain(`SET "case_key" = "id"::text`);
+    expect(foundation).toContain("Cannot backfill pipeline_cases.case_key");
+    expect(foundation).not.toContain(
+      `ALTER TABLE "pipeline_case_events" ADD COLUMN IF NOT EXISTS "created_at" timestamp with time zone DEFAULT now();`,
+    );
+    expect(retryEffects).not.toContain(
+      `ALTER TABLE "pipeline_case_events" ADD COLUMN IF NOT EXISTS "created_at" timestamp with time zone DEFAULT now();`,
+    );
+
+    const stagePositionAdd = foundation.indexOf(
+      `ALTER TABLE "pipeline_stages" ADD COLUMN IF NOT EXISTS "position" integer;`,
+    );
+    const stagePositionBackfill = foundation.indexOf(`WITH existing_stage_positions AS`);
+    const stagePositionDefault = foundation.indexOf(
+      `ALTER TABLE "pipeline_stages" ALTER COLUMN "position" SET DEFAULT 0;`,
+    );
+    expect(stagePositionAdd).toBeGreaterThanOrEqual(0);
+    expect(stagePositionBackfill).toBeGreaterThan(stagePositionAdd);
+    expect(stagePositionDefault).toBeGreaterThan(stagePositionBackfill);
+  });
+
   it(
     "applies an inserted earlier migration without replaying later legacy migrations",
     async () => {

--- a/packages/db/src/migrations/0113_pipeline_foundation.sql
+++ b/packages/db/src/migrations/0113_pipeline_foundation.sql
@@ -277,9 +277,11 @@ WHERE "pipeline_cases"."id" = unique_candidates."id"
     WHERE "existing_cases"."pipeline_id" = "pipeline_cases"."pipeline_id"
       AND "existing_cases"."case_key" = unique_candidates."candidate"
   );--> statement-breakpoint
-UPDATE "pipeline_cases"
-SET "case_key" = "id"::text
-WHERE "case_key" IS NULL;--> statement-breakpoint
+DO $$ BEGIN
+  IF EXISTS (SELECT 1 FROM "pipeline_cases" WHERE "case_key" IS NULL) THEN
+    RAISE EXCEPTION 'Cannot backfill pipeline_cases.case_key for existing rows without fields key or origin issue identifier';
+  END IF;
+END $$;--> statement-breakpoint
 ALTER TABLE "pipeline_cases" ALTER COLUMN "case_key" SET NOT NULL;--> statement-breakpoint
 ALTER TABLE "pipeline_cases" ADD COLUMN IF NOT EXISTS "parent_case_id" uuid;--> statement-breakpoint
 ALTER TABLE "pipeline_cases" ADD COLUMN IF NOT EXISTS "lease_expires_at" timestamp with time zone;--> statement-breakpoint
@@ -338,8 +340,8 @@ UPDATE "pipeline_case_events"
 SET "payload" = '{}'::jsonb
 WHERE "payload" IS NULL;--> statement-breakpoint
 ALTER TABLE "pipeline_case_events" ALTER COLUMN "payload" SET NOT NULL;--> statement-breakpoint
-ALTER TABLE "pipeline_case_events" ADD COLUMN IF NOT EXISTS "updated_at" timestamp with time zone DEFAULT now();--> statement-breakpoint
-ALTER TABLE "pipeline_case_events" ADD COLUMN IF NOT EXISTS "created_at" timestamp with time zone DEFAULT now();--> statement-breakpoint
+ALTER TABLE "pipeline_case_events" ADD COLUMN IF NOT EXISTS "updated_at" timestamp with time zone;--> statement-breakpoint
+ALTER TABLE "pipeline_case_events" ADD COLUMN IF NOT EXISTS "created_at" timestamp with time zone;--> statement-breakpoint
 UPDATE "pipeline_case_events"
 SET "created_at" = coalesce(
   "pipeline_case_events"."updated_at",
@@ -350,6 +352,12 @@ SET "created_at" = coalesce(
 FROM "pipeline_cases"
 WHERE "pipeline_case_events"."case_id" = "pipeline_cases"."id"
   AND "pipeline_case_events"."created_at" IS NULL;--> statement-breakpoint
+UPDATE "pipeline_case_events"
+SET "updated_at" = "created_at"
+WHERE "updated_at" IS NULL;--> statement-breakpoint
+ALTER TABLE "pipeline_case_events" ALTER COLUMN "updated_at" SET DEFAULT now();--> statement-breakpoint
+ALTER TABLE "pipeline_case_events" ALTER COLUMN "updated_at" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "pipeline_case_events" ALTER COLUMN "created_at" SET DEFAULT now();--> statement-breakpoint
 ALTER TABLE "pipeline_case_events" ALTER COLUMN "created_at" SET NOT NULL;--> statement-breakpoint
 ALTER TABLE "pipeline_cases" ADD COLUMN IF NOT EXISTS "lease_agent_id" uuid;--> statement-breakpoint
 ALTER TABLE "pipeline_cases" ADD COLUMN IF NOT EXISTS "created_by_agent_id" uuid;--> statement-breakpoint

--- a/packages/db/src/migrations/0113_pipeline_foundation.sql
+++ b/packages/db/src/migrations/0113_pipeline_foundation.sql
@@ -150,6 +150,111 @@ CREATE TABLE IF NOT EXISTS "pipelines" (
 	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
 );
 --> statement-breakpoint
+ALTER TABLE "pipelines" ADD COLUMN IF NOT EXISTS "company_id" uuid;--> statement-breakpoint
+ALTER TABLE "pipelines" ALTER COLUMN "company_id" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "pipelines" ADD COLUMN IF NOT EXISTS "project_id" uuid;--> statement-breakpoint
+ALTER TABLE "pipelines" ADD COLUMN IF NOT EXISTS "key" text;--> statement-breakpoint
+UPDATE "pipelines"
+SET "key" = "id"::text
+WHERE "key" IS NULL;--> statement-breakpoint
+ALTER TABLE "pipelines" ALTER COLUMN "key" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "pipeline_cases" ADD COLUMN IF NOT EXISTS "company_id" uuid;--> statement-breakpoint
+UPDATE "pipeline_cases"
+SET "company_id" = "pipelines"."company_id"
+FROM "pipelines"
+WHERE "pipeline_cases"."pipeline_id" = "pipelines"."id"
+  AND "pipeline_cases"."company_id" IS NULL;--> statement-breakpoint
+ALTER TABLE "pipeline_cases" ALTER COLUMN "company_id" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "pipeline_cases" ADD COLUMN IF NOT EXISTS "case_key" text;--> statement-breakpoint
+UPDATE "pipeline_cases"
+SET "case_key" = "id"::text
+WHERE "case_key" IS NULL;--> statement-breakpoint
+ALTER TABLE "pipeline_cases" ALTER COLUMN "case_key" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "pipeline_cases" ADD COLUMN IF NOT EXISTS "parent_case_id" uuid;--> statement-breakpoint
+ALTER TABLE "pipeline_cases" ADD COLUMN IF NOT EXISTS "lease_expires_at" timestamp with time zone;--> statement-breakpoint
+ALTER TABLE "pipeline_automation_executions" ADD COLUMN IF NOT EXISTS "company_id" uuid;--> statement-breakpoint
+UPDATE "pipeline_automation_executions"
+SET "company_id" = "pipeline_cases"."company_id"
+FROM "pipeline_cases"
+WHERE "pipeline_automation_executions"."case_id" = "pipeline_cases"."id"
+  AND "pipeline_automation_executions"."company_id" IS NULL;--> statement-breakpoint
+ALTER TABLE "pipeline_automation_executions" ALTER COLUMN "company_id" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "pipeline_case_blockers" ADD COLUMN IF NOT EXISTS "company_id" uuid;--> statement-breakpoint
+UPDATE "pipeline_case_blockers"
+SET "company_id" = "pipeline_cases"."company_id"
+FROM "pipeline_cases"
+WHERE "pipeline_case_blockers"."case_id" = "pipeline_cases"."id"
+  AND "pipeline_case_blockers"."company_id" IS NULL;--> statement-breakpoint
+ALTER TABLE "pipeline_case_blockers" ALTER COLUMN "company_id" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "pipeline_case_events" ADD COLUMN IF NOT EXISTS "company_id" uuid;--> statement-breakpoint
+UPDATE "pipeline_case_events"
+SET "company_id" = "pipeline_cases"."company_id"
+FROM "pipeline_cases"
+WHERE "pipeline_case_events"."case_id" = "pipeline_cases"."id"
+  AND "pipeline_case_events"."company_id" IS NULL;--> statement-breakpoint
+ALTER TABLE "pipeline_case_events" ALTER COLUMN "company_id" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "pipeline_case_issue_links" ADD COLUMN IF NOT EXISTS "company_id" uuid;--> statement-breakpoint
+UPDATE "pipeline_case_issue_links"
+SET "company_id" = "pipeline_cases"."company_id"
+FROM "pipeline_cases"
+WHERE "pipeline_case_issue_links"."case_id" = "pipeline_cases"."id"
+  AND "pipeline_case_issue_links"."company_id" IS NULL;--> statement-breakpoint
+ALTER TABLE "pipeline_case_issue_links" ALTER COLUMN "company_id" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "pipeline_documents" ADD COLUMN IF NOT EXISTS "company_id" uuid;--> statement-breakpoint
+UPDATE "pipeline_documents"
+SET "company_id" = "pipelines"."company_id"
+FROM "pipelines"
+WHERE "pipeline_documents"."pipeline_id" = "pipelines"."id"
+  AND "pipeline_documents"."company_id" IS NULL;--> statement-breakpoint
+ALTER TABLE "pipeline_documents" ALTER COLUMN "company_id" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "pipeline_case_events" ADD COLUMN IF NOT EXISTS "actor_agent_id" uuid;--> statement-breakpoint
+ALTER TABLE "pipeline_case_events" ADD COLUMN IF NOT EXISTS "type" text;--> statement-breakpoint
+UPDATE "pipeline_case_events"
+SET "type" = 'updated'
+WHERE "type" IS NULL;--> statement-breakpoint
+ALTER TABLE "pipeline_case_events" ALTER COLUMN "type" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "pipeline_case_events" ADD COLUMN IF NOT EXISTS "actor_type" text;--> statement-breakpoint
+UPDATE "pipeline_case_events"
+SET "actor_type" = 'system'
+WHERE "actor_type" IS NULL;--> statement-breakpoint
+ALTER TABLE "pipeline_case_events" ALTER COLUMN "actor_type" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "pipeline_case_events" ADD COLUMN IF NOT EXISTS "actor_user_id" text;--> statement-breakpoint
+ALTER TABLE "pipeline_case_events" ADD COLUMN IF NOT EXISTS "run_id" uuid;--> statement-breakpoint
+ALTER TABLE "pipeline_case_events" ADD COLUMN IF NOT EXISTS "from_stage_id" uuid;--> statement-breakpoint
+ALTER TABLE "pipeline_case_events" ADD COLUMN IF NOT EXISTS "to_stage_id" uuid;--> statement-breakpoint
+ALTER TABLE "pipeline_case_events" ADD COLUMN IF NOT EXISTS "payload" jsonb DEFAULT '{}'::jsonb;--> statement-breakpoint
+UPDATE "pipeline_case_events"
+SET "payload" = '{}'::jsonb
+WHERE "payload" IS NULL;--> statement-breakpoint
+ALTER TABLE "pipeline_case_events" ALTER COLUMN "payload" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "pipeline_case_events" ADD COLUMN IF NOT EXISTS "created_at" timestamp with time zone DEFAULT now();--> statement-breakpoint
+UPDATE "pipeline_case_events"
+SET "created_at" = now()
+WHERE "created_at" IS NULL;--> statement-breakpoint
+ALTER TABLE "pipeline_case_events" ALTER COLUMN "created_at" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "pipeline_cases" ADD COLUMN IF NOT EXISTS "lease_agent_id" uuid;--> statement-breakpoint
+ALTER TABLE "pipeline_cases" ADD COLUMN IF NOT EXISTS "created_by_agent_id" uuid;--> statement-breakpoint
+ALTER TABLE "pipelines" ADD COLUMN IF NOT EXISTS "created_by_agent_id" uuid;--> statement-breakpoint
+ALTER TABLE "pipeline_documents" ADD COLUMN IF NOT EXISTS "key" text;--> statement-breakpoint
+UPDATE "pipeline_documents"
+SET "key" = "id"::text
+WHERE "key" IS NULL;--> statement-breakpoint
+ALTER TABLE "pipeline_documents" ALTER COLUMN "key" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "pipeline_documents" ADD COLUMN IF NOT EXISTS "updated_at" timestamp with time zone DEFAULT now();--> statement-breakpoint
+UPDATE "pipeline_documents"
+SET "updated_at" = now()
+WHERE "updated_at" IS NULL;--> statement-breakpoint
+ALTER TABLE "pipeline_documents" ALTER COLUMN "updated_at" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "pipeline_stages" ADD COLUMN IF NOT EXISTS "key" text;--> statement-breakpoint
+UPDATE "pipeline_stages"
+SET "key" = "id"::text
+WHERE "key" IS NULL;--> statement-breakpoint
+ALTER TABLE "pipeline_stages" ALTER COLUMN "key" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "pipeline_stages" ADD COLUMN IF NOT EXISTS "position" integer DEFAULT 0;--> statement-breakpoint
+UPDATE "pipeline_stages"
+SET "position" = 0
+WHERE "position" IS NULL;--> statement-breakpoint
+ALTER TABLE "pipeline_stages" ALTER COLUMN "position" SET NOT NULL;--> statement-breakpoint
 DO $$ BEGIN
  ALTER TABLE "pipeline_automation_executions" ADD CONSTRAINT "pipeline_automation_executions_company_id_companies_id_fk" FOREIGN KEY ("company_id") REFERENCES "public"."companies"("id") ON DELETE cascade ON UPDATE no action;
 EXCEPTION

--- a/packages/db/src/migrations/0113_pipeline_foundation.sql
+++ b/packages/db/src/migrations/0113_pipeline_foundation.sql
@@ -377,7 +377,7 @@ UPDATE "pipeline_stages"
 SET "key" = "id"::text
 WHERE "key" IS NULL;--> statement-breakpoint
 ALTER TABLE "pipeline_stages" ALTER COLUMN "key" SET NOT NULL;--> statement-breakpoint
-ALTER TABLE "pipeline_stages" ADD COLUMN IF NOT EXISTS "position" integer DEFAULT 0;--> statement-breakpoint
+ALTER TABLE "pipeline_stages" ADD COLUMN IF NOT EXISTS "position" integer;--> statement-breakpoint
 WITH existing_stage_positions AS (
   SELECT "pipeline_id", max("position") AS "max_position"
   FROM "pipeline_stages"
@@ -400,6 +400,7 @@ UPDATE "pipeline_stages"
 SET "position" = ranked_null_positions."next_position"
 FROM ranked_null_positions
 WHERE "pipeline_stages"."id" = ranked_null_positions."id";--> statement-breakpoint
+ALTER TABLE "pipeline_stages" ALTER COLUMN "position" SET DEFAULT 0;--> statement-breakpoint
 ALTER TABLE "pipeline_stages" ALTER COLUMN "position" SET NOT NULL;--> statement-breakpoint
 DO $$ BEGIN
  ALTER TABLE "pipeline_automation_executions" ADD CONSTRAINT "pipeline_automation_executions_company_id_companies_id_fk" FOREIGN KEY ("company_id") REFERENCES "public"."companies"("id") ON DELETE cascade ON UPDATE no action;

--- a/packages/db/src/migrations/0113_pipeline_foundation.sql
+++ b/packages/db/src/migrations/0113_pipeline_foundation.sql
@@ -150,9 +150,45 @@ CREATE TABLE IF NOT EXISTS "pipelines" (
 	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
 );
 --> statement-breakpoint
-ALTER TABLE "pipelines" ADD COLUMN IF NOT EXISTS "company_id" uuid;--> statement-breakpoint
-ALTER TABLE "pipelines" ALTER COLUMN "company_id" SET NOT NULL;--> statement-breakpoint
 ALTER TABLE "pipelines" ADD COLUMN IF NOT EXISTS "project_id" uuid;--> statement-breakpoint
+ALTER TABLE "pipelines" ADD COLUMN IF NOT EXISTS "company_id" uuid;--> statement-breakpoint
+UPDATE "pipelines"
+SET "company_id" = "projects"."company_id"
+FROM "projects"
+WHERE "pipelines"."project_id" = "projects"."id"
+  AND "pipelines"."company_id" IS NULL;--> statement-breakpoint
+DO $$ BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'pipeline_cases'
+      AND column_name = 'company_id'
+  ) THEN
+    UPDATE "pipelines"
+    SET "company_id" = "case_companies"."company_id"
+    FROM (
+      SELECT "pipeline_id", (array_agg(DISTINCT "company_id"))[1] AS "company_id", count(DISTINCT "company_id") AS "company_count"
+      FROM "pipeline_cases"
+      WHERE "company_id" IS NOT NULL
+      GROUP BY "pipeline_id"
+    ) AS "case_companies"
+    WHERE "pipelines"."id" = "case_companies"."pipeline_id"
+      AND "case_companies"."company_count" = 1
+      AND "pipelines"."company_id" IS NULL;
+  END IF;
+END $$;--> statement-breakpoint
+UPDATE "pipelines"
+SET "company_id" = "companies"."id"
+FROM "companies"
+WHERE "pipelines"."company_id" IS NULL
+  AND (SELECT count(*) FROM "companies") = 1;--> statement-breakpoint
+DO $$ BEGIN
+  IF EXISTS (SELECT 1 FROM "pipelines" WHERE "company_id" IS NULL) THEN
+    RAISE EXCEPTION 'Cannot backfill pipelines.company_id for existing rows without project, case, or single-company ownership';
+  END IF;
+END $$;--> statement-breakpoint
+ALTER TABLE "pipelines" ALTER COLUMN "company_id" SET NOT NULL;--> statement-breakpoint
 ALTER TABLE "pipelines" ADD COLUMN IF NOT EXISTS "key" text;--> statement-breakpoint
 UPDATE "pipelines"
 SET "key" = "id"::text
@@ -166,6 +202,81 @@ WHERE "pipeline_cases"."pipeline_id" = "pipelines"."id"
   AND "pipeline_cases"."company_id" IS NULL;--> statement-breakpoint
 ALTER TABLE "pipeline_cases" ALTER COLUMN "company_id" SET NOT NULL;--> statement-breakpoint
 ALTER TABLE "pipeline_cases" ADD COLUMN IF NOT EXISTS "case_key" text;--> statement-breakpoint
+DO $$ BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'pipeline_cases'
+      AND column_name = 'fields'
+  ) THEN
+    WITH candidates AS (
+      SELECT
+        "id",
+        "pipeline_id",
+        coalesce(
+          nullif("fields"->>'caseKey', ''),
+          nullif("fields"->>'case_key', ''),
+          nullif("fields"->>'key', ''),
+          nullif("fields"->>'externalKey', ''),
+          nullif("fields"->>'external_key', '')
+        ) AS "candidate"
+      FROM "pipeline_cases"
+      WHERE "case_key" IS NULL
+    ),
+    unique_candidates AS (
+      SELECT
+        "id",
+        "candidate",
+        count(*) OVER (PARTITION BY "pipeline_id", "candidate") AS "candidate_count"
+      FROM candidates
+      WHERE "candidate" IS NOT NULL
+    )
+    UPDATE "pipeline_cases"
+    SET "case_key" = unique_candidates."candidate"
+    FROM unique_candidates
+    WHERE "pipeline_cases"."id" = unique_candidates."id"
+      AND unique_candidates."candidate_count" = 1
+      AND NOT EXISTS (
+        SELECT 1
+        FROM "pipeline_cases" AS "existing_cases"
+        WHERE "existing_cases"."pipeline_id" = "pipeline_cases"."pipeline_id"
+          AND "existing_cases"."case_key" = unique_candidates."candidate"
+      );
+  END IF;
+END $$;--> statement-breakpoint
+WITH candidates AS (
+  SELECT
+    "pipeline_cases"."id",
+    "pipeline_cases"."pipeline_id",
+    "issues"."identifier" AS "candidate"
+  FROM "pipeline_cases"
+  INNER JOIN "pipeline_case_issue_links"
+    ON "pipeline_case_issue_links"."case_id" = "pipeline_cases"."id"
+   AND "pipeline_case_issue_links"."role" = 'origin'
+  INNER JOIN "issues"
+    ON "issues"."id" = "pipeline_case_issue_links"."issue_id"
+  WHERE "pipeline_cases"."case_key" IS NULL
+    AND "issues"."identifier" IS NOT NULL
+),
+unique_candidates AS (
+  SELECT
+    "id",
+    "candidate",
+    count(*) OVER (PARTITION BY "pipeline_id", "candidate") AS "candidate_count"
+  FROM candidates
+)
+UPDATE "pipeline_cases"
+SET "case_key" = unique_candidates."candidate"
+FROM unique_candidates
+WHERE "pipeline_cases"."id" = unique_candidates."id"
+  AND unique_candidates."candidate_count" = 1
+  AND NOT EXISTS (
+    SELECT 1
+    FROM "pipeline_cases" AS "existing_cases"
+    WHERE "existing_cases"."pipeline_id" = "pipeline_cases"."pipeline_id"
+      AND "existing_cases"."case_key" = unique_candidates."candidate"
+  );--> statement-breakpoint
 UPDATE "pipeline_cases"
 SET "case_key" = "id"::text
 WHERE "case_key" IS NULL;--> statement-breakpoint
@@ -227,10 +338,18 @@ UPDATE "pipeline_case_events"
 SET "payload" = '{}'::jsonb
 WHERE "payload" IS NULL;--> statement-breakpoint
 ALTER TABLE "pipeline_case_events" ALTER COLUMN "payload" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "pipeline_case_events" ADD COLUMN IF NOT EXISTS "updated_at" timestamp with time zone DEFAULT now();--> statement-breakpoint
 ALTER TABLE "pipeline_case_events" ADD COLUMN IF NOT EXISTS "created_at" timestamp with time zone DEFAULT now();--> statement-breakpoint
 UPDATE "pipeline_case_events"
-SET "created_at" = now()
-WHERE "created_at" IS NULL;--> statement-breakpoint
+SET "created_at" = coalesce(
+  "pipeline_case_events"."updated_at",
+  "pipeline_cases"."updated_at",
+  "pipeline_cases"."created_at",
+  now()
+)
+FROM "pipeline_cases"
+WHERE "pipeline_case_events"."case_id" = "pipeline_cases"."id"
+  AND "pipeline_case_events"."created_at" IS NULL;--> statement-breakpoint
 ALTER TABLE "pipeline_case_events" ALTER COLUMN "created_at" SET NOT NULL;--> statement-breakpoint
 ALTER TABLE "pipeline_cases" ADD COLUMN IF NOT EXISTS "lease_agent_id" uuid;--> statement-breakpoint
 ALTER TABLE "pipeline_cases" ADD COLUMN IF NOT EXISTS "created_by_agent_id" uuid;--> statement-breakpoint
@@ -251,9 +370,28 @@ SET "key" = "id"::text
 WHERE "key" IS NULL;--> statement-breakpoint
 ALTER TABLE "pipeline_stages" ALTER COLUMN "key" SET NOT NULL;--> statement-breakpoint
 ALTER TABLE "pipeline_stages" ADD COLUMN IF NOT EXISTS "position" integer DEFAULT 0;--> statement-breakpoint
+WITH existing_stage_positions AS (
+  SELECT "pipeline_id", max("position") AS "max_position"
+  FROM "pipeline_stages"
+  WHERE "position" IS NOT NULL
+  GROUP BY "pipeline_id"
+),
+ranked_null_positions AS (
+  SELECT
+    "pipeline_stages"."id",
+    coalesce(existing_stage_positions."max_position", -1) + row_number() OVER (
+      PARTITION BY "pipeline_stages"."pipeline_id"
+      ORDER BY "pipeline_stages"."created_at" NULLS LAST, "pipeline_stages"."name", "pipeline_stages"."id"
+    ) AS "next_position"
+  FROM "pipeline_stages"
+  LEFT JOIN existing_stage_positions
+    ON existing_stage_positions."pipeline_id" = "pipeline_stages"."pipeline_id"
+  WHERE "position" IS NULL
+)
 UPDATE "pipeline_stages"
-SET "position" = 0
-WHERE "position" IS NULL;--> statement-breakpoint
+SET "position" = ranked_null_positions."next_position"
+FROM ranked_null_positions
+WHERE "pipeline_stages"."id" = ranked_null_positions."id";--> statement-breakpoint
 ALTER TABLE "pipeline_stages" ALTER COLUMN "position" SET NOT NULL;--> statement-breakpoint
 DO $$ BEGIN
  ALTER TABLE "pipeline_automation_executions" ADD CONSTRAINT "pipeline_automation_executions_company_id_companies_id_fk" FOREIGN KEY ("company_id") REFERENCES "public"."companies"("id") ON DELETE cascade ON UPDATE no action;

--- a/packages/db/src/migrations/0121_pipeline_automation_retry_effects.sql
+++ b/packages/db/src/migrations/0121_pipeline_automation_retry_effects.sql
@@ -29,8 +29,8 @@ UPDATE "pipeline_case_events"
 SET "payload" = '{}'::jsonb
 WHERE "payload" IS NULL;--> statement-breakpoint
 ALTER TABLE "pipeline_case_events" ALTER COLUMN "payload" SET NOT NULL;--> statement-breakpoint
-ALTER TABLE "pipeline_case_events" ADD COLUMN IF NOT EXISTS "updated_at" timestamp with time zone DEFAULT now();--> statement-breakpoint
-ALTER TABLE "pipeline_case_events" ADD COLUMN IF NOT EXISTS "created_at" timestamp with time zone DEFAULT now();--> statement-breakpoint
+ALTER TABLE "pipeline_case_events" ADD COLUMN IF NOT EXISTS "updated_at" timestamp with time zone;--> statement-breakpoint
+ALTER TABLE "pipeline_case_events" ADD COLUMN IF NOT EXISTS "created_at" timestamp with time zone;--> statement-breakpoint
 UPDATE "pipeline_case_events"
 SET "created_at" = coalesce(
   "pipeline_case_events"."updated_at",
@@ -41,6 +41,12 @@ SET "created_at" = coalesce(
 FROM "pipeline_cases"
 WHERE "pipeline_case_events"."case_id" = "pipeline_cases"."id"
   AND "pipeline_case_events"."created_at" IS NULL;--> statement-breakpoint
+UPDATE "pipeline_case_events"
+SET "updated_at" = "created_at"
+WHERE "updated_at" IS NULL;--> statement-breakpoint
+ALTER TABLE "pipeline_case_events" ALTER COLUMN "updated_at" SET DEFAULT now();--> statement-breakpoint
+ALTER TABLE "pipeline_case_events" ALTER COLUMN "updated_at" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "pipeline_case_events" ALTER COLUMN "created_at" SET DEFAULT now();--> statement-breakpoint
 ALTER TABLE "pipeline_case_events" ALTER COLUMN "created_at" SET NOT NULL;--> statement-breakpoint
 DROP INDEX IF EXISTS "pipeline_cases_parent_request_key_uq";--> statement-breakpoint
 CREATE UNIQUE INDEX IF NOT EXISTS "pipeline_cases_parent_request_key_uq" ON "pipeline_cases" USING btree ("parent_case_id","request_key") WHERE "pipeline_cases"."request_key" is not null and "pipeline_cases"."retired_at" is null;--> statement-breakpoint

--- a/packages/db/src/migrations/0121_pipeline_automation_retry_effects.sql
+++ b/packages/db/src/migrations/0121_pipeline_automation_retry_effects.sql
@@ -9,6 +9,31 @@ ALTER TABLE "pipeline_case_issue_links" ADD COLUMN IF NOT EXISTS "retired_by_att
 ALTER TABLE "pipeline_case_issue_links" ADD COLUMN IF NOT EXISTS "retired_reason" text;--> statement-breakpoint
 ALTER TABLE "pipeline_automation_executions" ADD COLUMN IF NOT EXISTS "retry_of_execution_id" uuid;--> statement-breakpoint
 ALTER TABLE "pipeline_automation_executions" ADD COLUMN IF NOT EXISTS "generation" integer DEFAULT 1 NOT NULL;--> statement-breakpoint
+ALTER TABLE "pipeline_case_events" ADD COLUMN IF NOT EXISTS "type" text;--> statement-breakpoint
+UPDATE "pipeline_case_events"
+SET "type" = 'updated'
+WHERE "type" IS NULL;--> statement-breakpoint
+ALTER TABLE "pipeline_case_events" ALTER COLUMN "type" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "pipeline_case_events" ADD COLUMN IF NOT EXISTS "actor_type" text;--> statement-breakpoint
+UPDATE "pipeline_case_events"
+SET "actor_type" = 'system'
+WHERE "actor_type" IS NULL;--> statement-breakpoint
+ALTER TABLE "pipeline_case_events" ALTER COLUMN "actor_type" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "pipeline_case_events" ADD COLUMN IF NOT EXISTS "actor_user_id" text;--> statement-breakpoint
+ALTER TABLE "pipeline_case_events" ADD COLUMN IF NOT EXISTS "actor_agent_id" uuid;--> statement-breakpoint
+ALTER TABLE "pipeline_case_events" ADD COLUMN IF NOT EXISTS "run_id" uuid;--> statement-breakpoint
+ALTER TABLE "pipeline_case_events" ADD COLUMN IF NOT EXISTS "from_stage_id" uuid;--> statement-breakpoint
+ALTER TABLE "pipeline_case_events" ADD COLUMN IF NOT EXISTS "to_stage_id" uuid;--> statement-breakpoint
+ALTER TABLE "pipeline_case_events" ADD COLUMN IF NOT EXISTS "payload" jsonb DEFAULT '{}'::jsonb;--> statement-breakpoint
+UPDATE "pipeline_case_events"
+SET "payload" = '{}'::jsonb
+WHERE "payload" IS NULL;--> statement-breakpoint
+ALTER TABLE "pipeline_case_events" ALTER COLUMN "payload" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "pipeline_case_events" ADD COLUMN IF NOT EXISTS "created_at" timestamp with time zone DEFAULT now();--> statement-breakpoint
+UPDATE "pipeline_case_events"
+SET "created_at" = now()
+WHERE "created_at" IS NULL;--> statement-breakpoint
+ALTER TABLE "pipeline_case_events" ALTER COLUMN "created_at" SET NOT NULL;--> statement-breakpoint
 DROP INDEX IF EXISTS "pipeline_cases_parent_request_key_uq";--> statement-breakpoint
 CREATE UNIQUE INDEX IF NOT EXISTS "pipeline_cases_parent_request_key_uq" ON "pipeline_cases" USING btree ("parent_case_id","request_key") WHERE "pipeline_cases"."request_key" is not null and "pipeline_cases"."retired_at" is null;--> statement-breakpoint
 CREATE INDEX IF NOT EXISTS "pipeline_cases_automation_attempt_idx" ON "pipeline_cases" USING btree ("automation_attempt_id");--> statement-breakpoint

--- a/packages/db/src/migrations/0121_pipeline_automation_retry_effects.sql
+++ b/packages/db/src/migrations/0121_pipeline_automation_retry_effects.sql
@@ -29,10 +29,18 @@ UPDATE "pipeline_case_events"
 SET "payload" = '{}'::jsonb
 WHERE "payload" IS NULL;--> statement-breakpoint
 ALTER TABLE "pipeline_case_events" ALTER COLUMN "payload" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "pipeline_case_events" ADD COLUMN IF NOT EXISTS "updated_at" timestamp with time zone DEFAULT now();--> statement-breakpoint
 ALTER TABLE "pipeline_case_events" ADD COLUMN IF NOT EXISTS "created_at" timestamp with time zone DEFAULT now();--> statement-breakpoint
 UPDATE "pipeline_case_events"
-SET "created_at" = now()
-WHERE "created_at" IS NULL;--> statement-breakpoint
+SET "created_at" = coalesce(
+  "pipeline_case_events"."updated_at",
+  "pipeline_cases"."updated_at",
+  "pipeline_cases"."created_at",
+  now()
+)
+FROM "pipeline_cases"
+WHERE "pipeline_case_events"."case_id" = "pipeline_cases"."id"
+  AND "pipeline_case_events"."created_at" IS NULL;--> statement-breakpoint
 ALTER TABLE "pipeline_case_events" ALTER COLUMN "created_at" SET NOT NULL;--> statement-breakpoint
 DROP INDEX IF EXISTS "pipeline_cases_parent_request_key_uq";--> statement-breakpoint
 CREATE UNIQUE INDEX IF NOT EXISTS "pipeline_cases_parent_request_key_uq" ON "pipeline_cases" USING btree ("parent_case_id","request_key") WHERE "pipeline_cases"."request_key" is not null and "pipeline_cases"."retired_at" is null;--> statement-breakpoint


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Database migrations define the durable control-plane contract for existing and fresh installations.
> - Pipeline tables have accumulated company scoping, stable keys, event metadata, retry metadata, and ordering fields over successive migrations.
> - Historical databases can reach partially evolved pipeline schemas where those fields are missing or nullable but rows already exist.
> - Those paths need guarded backfills before `NOT NULL` constraints, defaults, and indexes are enforced.
> - This pull request hardens the affected pipeline migrations and adds regression coverage for the ordering guarantees.
> - The benefit is safer migration replay for installations with existing pipeline data.

## Linked Issues or Issue Description

No public GitHub issue exists. Bug report inline:

**Pre-submission checklist**

- [x] I searched existing open and closed issues and did not find a duplicate.
- [x] I can reproduce the risk on migration replay paths from current `master` migration history.
- [x] The error originates in Paperclip database migrations, not an adapter, provider, or local configuration.

**What happened?**

Partially evolved databases with existing pipeline rows can replay the pipeline migrations with missing or nullable columns such as `pipelines.company_id`, `pipeline_cases.case_key`, `pipeline_case_events.created_at`, and `pipeline_stages.position`. Earlier backfills could enforce constraints too early, stamp historical events with migration time, collapse legacy stage order, or invent opaque case keys.

**Expected behavior**

Migration replay should backfill recoverable ownership, keys, event timestamps, and stage positions before applying defaults, `NOT NULL` constraints, and indexes. If a legacy case key cannot be recovered from existing fields or an origin issue identifier, the migration should fail with an actionable error instead of silently replacing it with an opaque UUID.

**Steps to reproduce**

1. Start from a database with legacy pipeline tables and existing rows but missing the later pipeline metadata columns.
2. Replay the pipeline foundation and retry-effects migrations.
3. Observe that constraints/defaults can be applied before the historical data is repaired.
4. Run the PR branch and verify the guarded backfills run before constraints/defaults, with an explicit failure for unrecoverable case keys.

**Paperclip version or commit**

Current `master` plus this PR branch, latest head `d2e109a15`.

**Deployment mode**

Local dev or self-hosted server using PostgreSQL-backed migrations.

**Installation method**

Built from source.

**Agent adapters involved**

Not adapter-specific; this is a core database migration issue.

**Database mode**

PostgreSQL migration replay, including embedded local PostgreSQL used by the test harness.

**Additional context**

This PR is intentionally SQL-focused so reviewers can evaluate migration safety directly.

## What Changed

- Backfills `pipelines.company_id` from project ownership, case ownership, or a single-company fallback before enforcing `NOT NULL`.
- Backfills `pipeline_cases.case_key` from recoverable JSON/external key fields or origin issue identifiers, and fails explicitly when no recoverable key exists.
- Backfills pipeline event timestamps before setting `DEFAULT now()` and `NOT NULL` in both affected migrations.
- Backfills legacy stage positions with deterministic per-pipeline ordering before setting the default and constraint.
- Adds a regression test that guards against default-before-backfill and opaque key fallback regressions.

## Verification

- Passed: `pnpm exec vitest run packages/db/src/client.test.ts -t "keeps pipeline migration backfills ahead"`
- Passed: `pnpm exec vitest run packages/db/src/client.test.ts -t "applies an inserted earlier migration without replaying later legacy migrations"`
- Passed: `pnpm --filter @paperclipai/db build`
- Passed: Greptile 5/5 with zero unresolved Greptile threads on latest head `d2e109a15`.
- Passed: PR checks green on latest head `d2e109a15`.

## Risks

Moderate migration risk because historical SQL files changed. The changes are guarded with idempotent `ADD COLUMN IF NOT EXISTS`, recoverable backfills, and explicit errors for ambiguous legacy data rather than silent corruption.

## Model Used

OpenAI GPT-5 Codex coding agent with local shell execution, repository editing tools, GitHub CLI access, and iterative PR check repair.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge