### PR TITLE
fix(claude-local, heartbeat): recover from silent session_lost caused by cwd switches

### DIFF
--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -54,6 +54,7 @@ import {
   isClaudeRefusalResult,
   isClaudeTransientUpstreamError,
   isClaudeUnknownSessionError,
+  isClaudeUnknownSessionErrorFromStreams,
   isClaudePoisonedPreviousMessageIdError,
   isClaudeImageProcessingError,
 } from "./parse.js";
@@ -1048,6 +1049,28 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
 
   try {
     const initial = await runAttempt(sessionId ?? null);
+    // Silent-recovery variant: CLI could not resume the requested session for
+    // this cwd (e.g. the session file lives under a different project-encoded
+    // directory because the run's resolved workspace flipped since the session
+    // was persisted), emitted `No conversation found with session ID: <uuid>`
+    // on stderr, and silently started a fresh conversation. Exit code is 0
+    // and parsed result looks successful, so the classic parsed-only detector
+    // (below) does not fire. Log an observability line so operators can
+    // quantify the churn without waiting for the retry-fresh path to trigger.
+    if (
+      sessionId &&
+      !initial.proc.timedOut &&
+      (initial.proc.exitCode ?? 0) === 0 &&
+      !(initial.parsed && initial.parsed["is_error"] === true) &&
+      isClaudeUnknownSessionErrorFromStreams({ parsed: null, stderr: initial.proc.stderr ?? "" })
+    ) {
+      await onLog(
+        "stdout",
+        `[paperclip] Claude CLI could not resume session "${sessionId}" for the current cwd; ` +
+          `initial call silently fell back to a fresh conversation. Persisted session state will ` +
+          `refresh to the new session id.\n`,
+      );
+    }
     const sessionErrorKind =
       sessionId &&
       !initial.proc.timedOut &&

--- a/packages/adapters/claude-local/src/server/parse.test.ts
+++ b/packages/adapters/claude-local/src/server/parse.test.ts
@@ -7,6 +7,7 @@ import {
   isClaudePoisonedPreviousMessageIdError,
   isClaudeRefusalResult,
   isClaudeUnknownSessionError,
+  isClaudeUnknownSessionErrorFromStreams,
   isClaudeImageProcessingError,
 } from "./parse.js";
 
@@ -272,6 +273,50 @@ describe("isClaudeUnknownSessionError", () => {
         result: "Some other failure",
         errors: [{ message: "Network timeout" }],
       }),
+    ).toBe(false);
+  });
+});
+
+describe("isClaudeUnknownSessionErrorFromStreams", () => {
+  it("detects the silent-recovery stderr warning when parsed result looks successful", () => {
+    expect(
+      isClaudeUnknownSessionErrorFromStreams({
+        parsed: { subtype: "success", is_error: false, result: "ok" },
+        stderr: "No conversation found with session ID: 4da9bae3-bb6f-4e5e-b639-b24a3742724a",
+      }),
+    ).toBe(true);
+  });
+
+  it("delegates to isClaudeUnknownSessionError when the parsed payload carries the message", () => {
+    expect(
+      isClaudeUnknownSessionErrorFromStreams({
+        parsed: { result: "Error: No conversation found with session id 1234" },
+        stderr: "",
+      }),
+    ).toBe(true);
+  });
+
+  it("is case-insensitive on stderr", () => {
+    expect(
+      isClaudeUnknownSessionErrorFromStreams({
+        parsed: null,
+        stderr: "no conversation found with session id abc",
+      }),
+    ).toBe(true);
+  });
+
+  it("returns false for unrelated stderr noise", () => {
+    expect(
+      isClaudeUnknownSessionErrorFromStreams({
+        parsed: null,
+        stderr: "Warning: shell exited with signal SIGTERM",
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false when both parsed and stderr are empty", () => {
+    expect(
+      isClaudeUnknownSessionErrorFromStreams({ parsed: null, stderr: "" }),
     ).toBe(false);
   });
 });

--- a/packages/adapters/claude-local/src/server/parse.ts
+++ b/packages/adapters/claude-local/src/server/parse.ts
@@ -218,6 +218,26 @@ export function isClaudeUnknownSessionError(parsed: Record<string, unknown>): bo
   );
 }
 
+/**
+ * Extended detector that also inspects stderr for the CLI's silent-recovery
+ * variant: when Claude Code CLI cannot resolve `--resume <uuid>` in the current
+ * cwd (e.g. the session file lives under a different project-encoded directory
+ * because cwd changed between runs), it prints `No conversation found with
+ * session ID: <uuid>` on stderr, silently starts a fresh conversation, and
+ * still exits with code 0 and `is_error:false`. The plain
+ * `isClaudeUnknownSessionError` only inspects parsed result/errors, which are
+ * empty in that silent-recovery path.
+ */
+export function isClaudeUnknownSessionErrorFromStreams(input: {
+  parsed?: Record<string, unknown> | null;
+  stderr?: string | null;
+}): boolean {
+  if (input.parsed && isClaudeUnknownSessionError(input.parsed)) return true;
+  const stderr = (input.stderr ?? "").trim();
+  if (!stderr) return false;
+  return /no conversation found with session id/i.test(stderr);
+}
+
 export function isClaudePoisonedPreviousMessageIdError(parsed: Record<string, unknown>): boolean {
   const resultText = asString(parsed.result, "").trim();
   const allMessages = [resultText, ...extractClaudeErrorMessages(parsed)]

--- a/server/src/__tests__/heartbeat-workspace-session.test.ts
+++ b/server/src/__tests__/heartbeat-workspace-session.test.ts
@@ -1013,6 +1013,73 @@ describe("resolveRuntimeSessionParamsForWorkspace", () => {
     });
     expect(result.warning).toBeNull();
   });
+
+  it("preserves a task_session when the resolved cwd matches the persisted cwd", async () => {
+    const agentId = "agent-123";
+    // Use a real on-disk cwd so realpath resolution succeeds; the interesting
+    // case is that the task_session's cwd is neither project_primary nor the
+    // fallback agent home. The previous implementation dropped it wholesale.
+    const taskSessionCwd = await fs.mkdtemp(path.join(os.tmpdir(), "pcp-tasksess-"));
+    try {
+      const result = resolveRuntimeSessionParamsForWorkspace({
+        agentId,
+        previousSessionParams: {
+          sessionId: "task-session-abc",
+          cwd: taskSessionCwd,
+          workspaceId: "workspace-9",
+        },
+        resolvedWorkspace: buildResolvedWorkspace({
+          cwd: taskSessionCwd,
+          source: "task_session",
+          projectId: null,
+          workspaceId: "workspace-9",
+        }),
+      });
+
+      expect(result.sessionParams).toEqual({
+        sessionId: "task-session-abc",
+        cwd: taskSessionCwd,
+        workspaceId: "workspace-9",
+      });
+      expect(result.warning).toBeNull();
+    } finally {
+      await fs.rm(taskSessionCwd, { recursive: true, force: true });
+    }
+  });
+
+  it("preserves a fallback-home session that was persisted via a symlink to the real fallback dir", async () => {
+    const agentId = "agent-symlink";
+    const realFallbackCwd = resolveDefaultAgentWorkspaceDir(agentId);
+    await fs.mkdir(realFallbackCwd, { recursive: true });
+    const symlinkDir = await fs.mkdtemp(path.join(os.tmpdir(), "pcp-symlink-"));
+    const symlinkPath = path.join(symlinkDir, "fallback-alias");
+    await fs.symlink(realFallbackCwd, symlinkPath);
+    try {
+      const result = resolveRuntimeSessionParamsForWorkspace({
+        agentId,
+        previousSessionParams: {
+          sessionId: "session-symlink",
+          cwd: symlinkPath, // persisted through symlinked path
+          workspaceId: null,
+        },
+        resolvedWorkspace: buildResolvedWorkspace({
+          cwd: realFallbackCwd, // resolver hands back the real fallback path
+          source: "agent_home",
+          projectId: null,
+          workspaceId: null,
+        }),
+      });
+
+      expect(result.sessionParams).toEqual({
+        sessionId: "session-symlink",
+        cwd: symlinkPath,
+        workspaceId: null,
+      });
+      expect(result.warning).toBeNull();
+    } finally {
+      await fs.rm(symlinkDir, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("applyPersistedExecutionWorkspaceConfig", () => {

--- a/server/src/__tests__/heartbeat-workspace-session.test.ts
+++ b/server/src/__tests__/heartbeat-workspace-session.test.ts
@@ -962,6 +962,57 @@ describe("resolveRuntimeSessionParamsForWorkspace", () => {
     });
     expect(result.warning).toBeNull();
   });
+
+  it("drops persisted session when a project-workspace session is being resumed from agent home", () => {
+    const agentId = "agent-123";
+    const fallbackCwd = resolveDefaultAgentWorkspaceDir(agentId);
+
+    const result = resolveRuntimeSessionParamsForWorkspace({
+      agentId,
+      previousSessionParams: {
+        sessionId: "stale-project-session",
+        cwd: "/tmp/some-project-cwd",
+        workspaceId: "workspace-1",
+      },
+      resolvedWorkspace: buildResolvedWorkspace({
+        cwd: fallbackCwd,
+        source: "agent_home",
+        projectId: null,
+        workspaceId: null,
+      }),
+    });
+
+    expect(result.sessionParams).toBeNull();
+    expect(result.warning).toContain("stale-project-session");
+    expect(result.warning).toContain("fresh session");
+  });
+
+  it("preserves persisted session when resuming into agent home from the same fallback cwd", () => {
+    const agentId = "agent-123";
+    const fallbackCwd = resolveDefaultAgentWorkspaceDir(agentId);
+
+    const result = resolveRuntimeSessionParamsForWorkspace({
+      agentId,
+      previousSessionParams: {
+        sessionId: "session-1",
+        cwd: fallbackCwd,
+        workspaceId: null,
+      },
+      resolvedWorkspace: buildResolvedWorkspace({
+        cwd: fallbackCwd,
+        source: "agent_home",
+        projectId: null,
+        workspaceId: null,
+      }),
+    });
+
+    expect(result.sessionParams).toEqual({
+      sessionId: "session-1",
+      cwd: fallbackCwd,
+      workspaceId: null,
+    });
+    expect(result.warning).toBeNull();
+  });
 });
 
 describe("applyPersistedExecutionWorkspaceConfig", () => {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs/promises";
+import { realpathSync } from "node:fs";
 import path from "node:path";
 import { execFile as execFileCallback } from "node:child_process";
 import { promisify } from "node:util";
@@ -2473,6 +2474,21 @@ export function parseSessionCompactionPolicy(agent: typeof agents.$inferSelect):
   return resolveSessionCompactionPolicy(agent.adapterType, agent.runtimeConfig).policy;
 }
 
+// Canonicalize a cwd for equality comparison across symlinked paths. The CLI
+// encodes session files under the physical directory it saw, so a persisted
+// cwd captured through a symlink must compare equal to the same physical
+// directory expressed as its real path. Falls back to `path.resolve` when the
+// path does not exist on disk (which is legitimate in unit tests and for
+// prospective/planned cwds).
+function canonicalizeCwdForComparison(target: string): string {
+  const normalized = path.resolve(target);
+  try {
+    return realpathSync(normalized);
+  } catch {
+    return normalized;
+  }
+}
+
 export function resolveRuntimeSessionParamsForWorkspace(input: {
   agentId: string;
   previousSessionParams: Record<string, unknown> | null;
@@ -2487,6 +2503,8 @@ export function resolveRuntimeSessionParamsForWorkspace(input: {
       warning: null as string | null,
     };
   }
+  const canonicalPreviousCwd = canonicalizeCwdForComparison(previousCwd);
+  const canonicalResolvedCwd = canonicalizeCwdForComparison(resolvedWorkspace.cwd);
   // Inverse-of-migration case: the persisted session was captured in a
   // project workspace but the current run resolves to the agent's home
   // workspace (e.g. a timer/heartbeat wake with no active issue while the
@@ -2497,8 +2515,20 @@ export function resolveRuntimeSessionParamsForWorkspace(input: {
   // and the state stays coherent (rather than accumulating stderr warnings
   // while the CLI silently self-heals).
   if (resolvedWorkspace.source !== "project_primary") {
+    // Safe to resume when the resolved cwd matches the persisted cwd — the
+    // session jsonl exists under the same directory. Covers the `task_session`
+    // source where `resolveWorkspaceForRun` deliberately reuses the persisted
+    // session's cwd, and any `agent_home` resolution that lands on the exact
+    // same directory that hosted the session.
+    if (canonicalPreviousCwd === canonicalResolvedCwd) {
+      return {
+        sessionParams: previousSessionParams,
+        warning: null as string | null,
+      };
+    }
     const fallbackAgentHomeCwd = resolveDefaultAgentWorkspaceDir(agentId);
-    if (path.resolve(previousCwd) !== path.resolve(fallbackAgentHomeCwd)) {
+    const canonicalFallbackCwd = canonicalizeCwdForComparison(fallbackAgentHomeCwd);
+    if (canonicalPreviousCwd !== canonicalFallbackCwd) {
       return {
         sessionParams: null,
         warning:
@@ -2520,13 +2550,14 @@ export function resolveRuntimeSessionParamsForWorkspace(input: {
     };
   }
   const fallbackAgentHomeCwd = resolveDefaultAgentWorkspaceDir(agentId);
-  if (path.resolve(previousCwd) !== path.resolve(fallbackAgentHomeCwd)) {
+  const canonicalFallbackCwd = canonicalizeCwdForComparison(fallbackAgentHomeCwd);
+  if (canonicalPreviousCwd !== canonicalFallbackCwd) {
     return {
       sessionParams: previousSessionParams,
       warning: null as string | null,
     };
   }
-  if (path.resolve(projectCwd) === path.resolve(previousCwd)) {
+  if (canonicalizeCwdForComparison(projectCwd) === canonicalPreviousCwd) {
     return {
       sessionParams: previousSessionParams,
       warning: null as string | null,

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -2487,7 +2487,26 @@ export function resolveRuntimeSessionParamsForWorkspace(input: {
       warning: null as string | null,
     };
   }
+  // Inverse-of-migration case: the persisted session was captured in a
+  // project workspace but the current run resolves to the agent's home
+  // workspace (e.g. a timer/heartbeat wake with no active issue while the
+  // agent's last useful run happened inside a project). The CLI encodes the
+  // session file under the cwd it was created in, so a `--resume <uuid>` in
+  // agent_home cannot find the jsonl and silently starts a fresh session.
+  // Drop the persisted session id here so the run starts fresh explicitly
+  // and the state stays coherent (rather than accumulating stderr warnings
+  // while the CLI silently self-heals).
   if (resolvedWorkspace.source !== "project_primary") {
+    const fallbackAgentHomeCwd = resolveDefaultAgentWorkspaceDir(agentId);
+    if (path.resolve(previousCwd) !== path.resolve(fallbackAgentHomeCwd)) {
+      return {
+        sessionParams: null,
+        warning:
+          `Persisted session "${previousSessionId}" was captured in workspace "${previousCwd}" ` +
+          `but the current run resolves to "${resolvedWorkspace.cwd}" (source=${resolvedWorkspace.source}). ` +
+          `Starting a fresh session to avoid a stale --resume against a project-encoded cwd.`,
+      };
+    }
     return {
       sessionParams: previousSessionParams,
       warning: null as string | null,


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The `claude_local` adapter drives real Claude Code CLI processes on behalf of an agent; the heartbeat scheduler persists a `sessionId` + `cwd` so subsequent wakes can `--resume` and keep conversation state warm.
> - Claude Code encodes each session's jsonl under the project-encoded directory of the cwd where the session was created. Resuming a session under a different cwd cannot find that file.
> - When the CLI cannot find the session, it logs "No conversation found with session ID: …" on stderr and silently starts a fresh conversation, returning `exit_code=0` `is_error=false`. The parsed CLI result looks successful, so the heartbeat marks the run succeeded and the pattern repeats forever — one wasted CLI invocation per heartbeat wake.
> - The heartbeat already had a "migrate fallback → project" branch (upgrade a home-anchored session when a project cwd becomes available). It did not have the inverse, so home-anchored wakes silently re-forked project-encoded sessions.
> - This pull request adds a stderr-aware detector, a first-class server-side log for the silent-recovery case, and the inverse-migration branch that drops session state deterministically when the resolved cwd cannot host the session file.
> - The benefit is that operators can see this failure mode (it becomes a log line instead of a silent CLI stderr swallow) and the run starts fresh explicitly instead of after a wasted CLI round trip.

## Linked Issues or Issue Description

No existing public issue — describing the bug in-PR (bug template).

**What happened?**
For agents running under `claude_local`, when the heartbeat resolves a run to a cwd that differs from the one persisted with the last `sessionId` (typical case: a project workspace run followed by a heartbeat wake that has no active issue and resolves to `agent_home`), the CLI cannot locate the session jsonl under the new cwd. It writes `No conversation found with session ID: <uuid>` to stderr, silently starts a fresh conversation, and returns success. The `heartbeat_run` is marked succeeded, the persisted `sessionParams` are refreshed with the new (fresh) session, and the pattern repeats every heartbeat while the resolved cwd keeps oscillating.

**Expected behavior**
Either resume the session against a cwd that actually hosts the jsonl, or drop the persisted `sessionParams` before invoking the CLI so the fresh conversation starts explicitly. Operators should have a first-class log line for the failure mode, not a swallowed stderr warning.

**Steps to reproduce**
1. Under `claude_local`, run one heartbeat inside a project workspace so a `sessionId` gets persisted with a project-scoped `cwd`.
2. Trigger a follow-up heartbeat wake for the same agent with no active issue so `resolveWorkspaceForRun` returns `source="agent_home"`.
3. Observe the CLI stderr `No conversation found with session ID: …`, the fresh conversation, and the newly persisted `sessionId` (different from step 1) with `cwd=agent_home`.

**Environment**
Reproduced across multiple heartbeats and multiple agents in one deployment (Claude Code CLI backing `claude_local`).

## What Changed

- `packages/adapters/claude-local/src/server/parse.ts` — new `isClaudeUnknownSessionErrorFromStreams({ parsed, stderr })`. Delegates to the existing parsed detector first, then falls back to matching `/no conversation found with session id/i` on stderr. Needed because the silent-recovery path leaves no signal in the parsed CLI result.
- `packages/adapters/claude-local/src/server/execute.ts` — after the initial CLI invocation, when `exit_code === 0` and the parsed result is not an error, emit a `[paperclip] Claude CLI could not resume session "…" for the current cwd; …` log line if the stderr signature matches. No change to retry semantics — the CLI's own fallback already succeeded — this only surfaces the event so operators can measure it.
- `server/src/services/heartbeat.ts` — `resolveRuntimeSessionParamsForWorkspace` gains an inverse-of-migration branch. When `resolvedWorkspace.source !== "project_primary"` and the persisted session cwd cannot host the session file, return `sessionParams: null` with a diagnostic warning. Two safe-preserve carve-outs:
  1. Preserve when the persisted cwd matches the resolved cwd (covers the `task_session` source, where the resolver deliberately reuses the persisted cwd).
  2. Preserve when the persisted cwd matches the fallback agent-home cwd (unchanged from before).
- `server/src/services/heartbeat.ts` — introduces `canonicalizeCwdForComparison(target)`. All cwd comparisons in `resolveRuntimeSessionParamsForWorkspace` now go through `fs.realpathSync` (with a `path.resolve` fallback for paths that don't exist yet). This prevents false negatives when the persisted cwd was captured through a symlinked path and the resolver reports the physical path (or vice versa).
- `packages/adapters/claude-local/src/server/parse.test.ts` — 5 new tests: stderr detector positive/negative cases, case-insensitivity, precedence over the parsed variant.
- `server/src/__tests__/heartbeat-workspace-session.test.ts` — 4 new tests: (1) inverse-of-migration drops the session when a project-scoped cwd resolves into `agent_home`; (2) resuming into `agent_home` from the same fallback cwd is a safe no-op; (3) a `task_session` whose resolved cwd equals its persisted cwd is preserved; (4) a fallback-home session persisted via a symlink to the real fallback dir is preserved when the resolver returns the physical path.

## Verification

- `pnpm vitest run packages/adapters/claude-local/src/server/parse.test.ts` → 38/38 pass (5 new).
- `pnpm vitest run server/src/__tests__/heartbeat-workspace-session.test.ts` → 122/122 pass (4 new).
- No changes to public types or exported APIs beyond the new `isClaudeUnknownSessionErrorFromStreams` helper and the `canonicalizeCwdForComparison` internal helper.

Manual reasoning for the untested cross-file path: `execute.ts` emits the log line only when the stderr detector matches on a successful CLI invocation; every retry policy remains unchanged. `heartbeat.ts` drops the persisted `sessionParams` one heartbeat earlier than the CLI's silent-recovery would have; the net effect on conversation continuity is identical — the session was already going to be discarded on the next run — but the drop now happens deterministically in server code.

## Risks

- Low behavioral risk. Runs that previously succeeded silently continue to succeed silently; they now gain a log line and, when the persisted cwd is unusable, start fresh one heartbeat earlier.
- The safe-preserve carve-outs for `task_session` and matching cwds are structural: the CLI can find its own jsonl in both cases, so no session is dropped that could still be resumed.
- `canonicalizeCwdForComparison` uses `realpathSync` inside a synchronous function. For paths that exist on disk this is a bounded stat call. For paths that don't exist we fall back to `path.resolve`, so no throw escapes and behavior degrades to the previous string-based comparison.
- No migration, no schema change, no configuration flag. The fix is unconditional because the failure mode is deterministic (there is no cwd under which the CLI-encoded jsonl exists for the wrong-cwd resume).

## Model Used

Claude Opus 4.7 (`claude-opus-4-7`), 200k context, no extended thinking mode. Produced end-to-end by a Paperclip `claude_local` builder agent — code, tests, and body — with human oversight for the "proceed with fix" decision. No manual code edits outside the diff below.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [ ] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

<sub>The branch name predates this convention and cannot be renamed without breaking the open PR ref; happy to squash/rename on merge.</sub>

