### PR TITLE
feat(plugins): make issue creation idempotent

### DIFF
--- a/doc/plugins/PLUGIN_SPEC.md
+++ b/doc/plugins/PLUGIN_SPEC.md
@@ -832,6 +832,12 @@ The host enforces capabilities in the SDK layer and refuses calls outside the gr
 - `agent.sessions.send`
 - `agent.sessions.close`
 
+`PluginIssuesClient.create` accepts an optional `idempotencyKey` containing 1-255
+UTF-8 bytes. Keys are unique within a plugin installation and company and durable
+across worker or host restarts. A retry, including one with a different create
+payload, returns the original issue unchanged. The same key may create a separate
+issue for another plugin installation or company.
+
 ### Plugin State
 
 - `plugin.state.read`

--- a/packages/db/src/migrations/0136_plugin_issue_create_idempotency.sql
+++ b/packages/db/src/migrations/0136_plugin_issue_create_idempotency.sql
@@ -1,0 +1,11 @@
+CREATE TABLE "plugin_issue_create_idempotency" (
+	"company_id" uuid NOT NULL,
+	"key_digest" text NOT NULL,
+	"issue_id" uuid,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "plugin_issue_create_idempotency_pk" PRIMARY KEY("company_id","key_digest")
+);
+--> statement-breakpoint
+ALTER TABLE "plugin_issue_create_idempotency" ADD CONSTRAINT "plugin_issue_create_idempotency_company_id_companies_id_fk" FOREIGN KEY ("company_id") REFERENCES "public"."companies"("id") ON DELETE cascade ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "plugin_issue_create_idempotency" ADD CONSTRAINT "plugin_issue_create_idempotency_issue_id_issues_id_fk" FOREIGN KEY ("issue_id") REFERENCES "public"."issues"("id") ON DELETE cascade ON UPDATE no action;

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -939,6 +939,13 @@
       "when": 1783025724120,
       "tag": "0135_repair_run_responsible_user_updated_at_sweep",
       "breakpoints": true
+    },
+    {
+      "idx": 136,
+      "version": "7",
+      "when": 1783025824120,
+      "tag": "0136_plugin_issue_create_idempotency",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -100,4 +100,5 @@ export { pluginEntities } from "./plugin_entities.js";
 export { pluginDatabaseNamespaces, pluginMigrations } from "./plugin_database.js";
 export { pluginJobs, pluginJobRuns } from "./plugin_jobs.js";
 export { pluginWebhookDeliveries } from "./plugin_webhooks.js";
+export { pluginIssueCreateIdempotency } from "./plugin_issue_create_idempotency.js";
 export { pluginLogs } from "./plugin_logs.js";

--- a/packages/db/src/schema/plugin_issue_create_idempotency.ts
+++ b/packages/db/src/schema/plugin_issue_create_idempotency.ts
@@ -1,0 +1,21 @@
+import { pgTable, primaryKey, text, timestamp, uuid } from "drizzle-orm/pg-core";
+import { companies } from "./companies.js";
+import { issues } from "./issues.js";
+
+export const pluginIssueCreateIdempotency = pgTable(
+  "plugin_issue_create_idempotency",
+  {
+    companyId: uuid("company_id")
+      .notNull()
+      .references(() => companies.id, { onDelete: "cascade" }),
+    keyDigest: text("key_digest").notNull(),
+    issueId: uuid("issue_id").references(() => issues.id, { onDelete: "cascade" }),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    pk: primaryKey({
+      columns: [table.companyId, table.keyDigest],
+      name: "plugin_issue_create_idempotency_pk",
+    }),
+  }),
+);

--- a/packages/plugins/sdk/src/protocol.ts
+++ b/packages/plugins/sdk/src/protocol.ts
@@ -1242,6 +1242,7 @@ export interface WorkerToHostMethods {
   "issues.create": [
     params: {
       companyId: string;
+      idempotencyKey?: string;
       projectId?: string;
       goalId?: string;
       parentId?: string;

--- a/packages/plugins/sdk/src/testing.ts
+++ b/packages/plugins/sdk/src/testing.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { pluginOperationIssueOriginKind } from "@paperclipai/shared";
+import { validatePluginIssueIdempotencyKey } from "./types.js";
 import type {
   PaperclipPluginManifestV1,
   PluginCapability,
@@ -489,6 +490,7 @@ export function createTestHarness(options: TestHarnessOptions): TestHarness {
   const routines = new Map<string, Routine>();
   const routineRuns = new Map<string, RoutineRun>();
   const issues = new Map<string, Issue>();
+  const issueCreateIdempotencyKeys = new Map<string, string>();
   const blockedByIssueIds = new Map<string, string[]>();
   const issueComments = new Map<string, IssueComment[]>();
   const issueInteractions = new Map<string, IssueThreadInteraction[]>();
@@ -1549,6 +1551,14 @@ export function createTestHarness(options: TestHarnessOptions): TestHarness {
       },
       async create(input) {
         requireCapability(manifest, capabilitySet, "issues.create");
+        const idempotencyKey = input.idempotencyKey === undefined
+          ? undefined
+          : validatePluginIssueIdempotencyKey(input.idempotencyKey);
+        if (idempotencyKey !== undefined) {
+          const existingId = issueCreateIdempotencyKeys.get(`${input.companyId}\0${idempotencyKey}`);
+          const existing = existingId ? issues.get(existingId) : null;
+          if (existing) return existing;
+        }
         const now = new Date();
         const originKind = normalizePluginOriginKind(
           input.surfaceVisibility === "plugin_operation" && !input.originKind
@@ -1595,6 +1605,9 @@ export function createTestHarness(options: TestHarnessOptions): TestHarness {
           updatedAt: now,
         };
         issues.set(record.id, record);
+        if (idempotencyKey !== undefined) {
+          issueCreateIdempotencyKeys.set(`${input.companyId}\0${idempotencyKey}`, record.id);
+        }
         if (input.blockedByIssueIds) blockedByIssueIds.set(record.id, [...new Set(input.blockedByIssueIds)]);
         return record;
       },

--- a/packages/plugins/sdk/src/types.ts
+++ b/packages/plugins/sdk/src/types.ts
@@ -1314,6 +1314,22 @@ export interface PluginIssueSummariesClient {
   }): Promise<PluginIssueOrchestrationSummary>;
 }
 
+export const PLUGIN_ISSUE_IDEMPOTENCY_KEY_MAX_BYTES = 255;
+
+export function validatePluginIssueIdempotencyKey(value: unknown): string {
+  if (typeof value !== "string") {
+    throw new Error("idempotencyKey must be a non-empty string");
+  }
+  const byteLength = new TextEncoder().encode(value).byteLength;
+  if (byteLength === 0) {
+    throw new Error("idempotencyKey must be a non-empty string");
+  }
+  if (byteLength > PLUGIN_ISSUE_IDEMPOTENCY_KEY_MAX_BYTES) {
+    throw new Error(`idempotencyKey must not exceed ${PLUGIN_ISSUE_IDEMPOTENCY_KEY_MAX_BYTES} UTF-8 bytes`);
+  }
+  return value;
+}
+
 /**
  * `ctx.issues` — read and mutate issues plus comments.
  *
@@ -1344,8 +1360,14 @@ export interface PluginIssuesClient {
     offset?: number;
   }): Promise<Issue[]>;
   get(issueId: string, companyId: string): Promise<Issue | null>;
+  /**
+   * Create an issue, optionally exactly once per plugin, company, and idempotency key.
+   * Reusing a key returns the original issue unchanged, even when the retry
+   * supplies a different payload. Keys must contain 1-255 UTF-8 bytes.
+   */
   create(input: {
     companyId: string;
+    idempotencyKey?: string;
     projectId?: string;
     goalId?: string;
     parentId?: string;

--- a/packages/plugins/sdk/src/worker-rpc-host.ts
+++ b/packages/plugins/sdk/src/worker-rpc-host.ts
@@ -771,6 +771,7 @@ export function startWorkerRpcHost(options: WorkerRpcHostOptions): WorkerRpcHost
         async create(input) {
           return callHost("issues.create", {
             companyId: input.companyId,
+            idempotencyKey: input.idempotencyKey,
             projectId: input.projectId,
             goalId: input.goalId,
             parentId: input.parentId,

--- a/server/src/__tests__/plugin-orchestration-apis.test.ts
+++ b/server/src/__tests__/plugin-orchestration-apis.test.ts
@@ -15,6 +15,7 @@ import {
   heartbeatRuns,
   issueRelations,
   issues,
+  pluginIssueCreateIdempotency,
   pluginManagedResources,
   plugins,
   projects,
@@ -41,6 +42,19 @@ function createEventBusStub() {
 
 function issuePrefix(id: string) {
   return `T${id.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+}
+
+function createBarrier(parties: number) {
+  let arrivals = 0;
+  let release!: () => void;
+  const ready = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  return async () => {
+    arrivals += 1;
+    if (arrivals === parties) release();
+    await ready;
+  };
 }
 
 if (!embeddedPostgresSupport.supported) {
@@ -233,6 +247,185 @@ describeEmbeddedPostgres("plugin orchestration APIs", () => {
         }),
       ]),
     );
+  });
+
+  it("creates plugin issues idempotently within a company without mutating the original payload", async () => {
+    const { companyId } = await seedCompanyAndAgent();
+    const otherCompanyId = randomUUID();
+    await db.insert(companies).values({
+      id: otherCompanyId,
+      name: "Other company",
+      issuePrefix: issuePrefix(otherCompanyId),
+      requireBoardApprovalForNewAgents: false,
+    });
+    const services = buildHostServices(db, "plugin-record-id", "paperclip.missions", createEventBusStub());
+    const otherPluginServices = buildHostServices(
+      db,
+      "other-plugin-record-id",
+      "paperclip.other",
+      createEventBusStub(),
+    );
+
+    const original = await services.issues.create({
+      companyId,
+      title: "Original title",
+      description: "Original description",
+      idempotencyKey: "mission:durable-create",
+    });
+    const retryServices = buildHostServices(db, "plugin-record-id", "paperclip.missions", createEventBusStub());
+    await expect(
+      services.issues.update({
+        issueId: original.id,
+        companyId,
+        patch: { companyId: otherCompanyId },
+      }),
+    ).rejects.toThrow("Unsupported plugin issue update field: companyId");
+    const retry = await retryServices.issues.create({
+      companyId,
+      title: "Changed retry title",
+      description: "Changed retry description",
+      idempotencyKey: "mission:durable-create",
+    });
+    const otherCompanyIssue = await services.issues.create({
+      companyId: otherCompanyId,
+      title: "Other company issue",
+      idempotencyKey: "mission:durable-create",
+    });
+    const otherPluginIssue = await otherPluginServices.issues.create({
+      companyId,
+      title: "Other plugin issue",
+      idempotencyKey: "mission:durable-create",
+    });
+
+    expect(retry).toMatchObject({
+      id: original.id,
+      title: "Original title",
+      description: "Original description",
+    });
+    expect(original).not.toHaveProperty("pluginIssueIdempotencyKey");
+    expect(retry).not.toHaveProperty("pluginIssueIdempotencyKey");
+    expect(otherCompanyIssue.id).not.toBe(original.id);
+    expect(otherPluginIssue.id).not.toBe(original.id);
+    const companyIssues = await db.select().from(issues).where(eq(issues.companyId, companyId));
+    expect(companyIssues).toHaveLength(2);
+    expect(companyIssues[0]).not.toHaveProperty("pluginIssueIdempotencyKey");
+    await expect(
+      db
+        .select()
+        .from(activityLog)
+        .where(and(eq(activityLog.entityType, "issue"), eq(activityLog.entityId, original.id))),
+    ).resolves.toHaveLength(1);
+  });
+
+  it("converges concurrent plugin issue creates with the same company and idempotency key", async () => {
+    const { companyId } = await seedCompanyAndAgent();
+    const afterPrelookup = createBarrier(2);
+    const services = buildHostServices(
+      db,
+      "plugin-record-id",
+      "paperclip.missions",
+      createEventBusStub(),
+      undefined,
+      { testHooks: { afterPluginIssueIdempotencyPrelookup: afterPrelookup } },
+    );
+
+    const [first, second] = await Promise.all([
+      services.issues.create({
+        companyId,
+        title: "Concurrent issue",
+        idempotencyKey: "mission:concurrent-create",
+      }),
+      services.issues.create({
+        companyId,
+        title: "Concurrent issue",
+        idempotencyKey: "mission:concurrent-create",
+      }),
+    ]);
+
+    expect(second.id).toBe(first.id);
+    const nextIssue = await services.issues.create({
+      companyId,
+      title: "Next issue",
+    });
+    expect(nextIssue.issueNumber).toBe(first.issueNumber! + 1);
+    await expect(
+      db.select().from(issues).where(eq(issues.companyId, companyId)),
+    ).resolves.toHaveLength(2);
+    const claims = await db
+      .select()
+      .from(pluginIssueCreateIdempotency)
+      .where(eq(pluginIssueCreateIdempotency.companyId, companyId));
+    expect(claims).toHaveLength(1);
+    expect(claims[0]?.issueId).toBe(first.id);
+    await expect(
+      db
+        .select()
+        .from(activityLog)
+        .where(and(eq(activityLog.entityType, "issue"), eq(activityLog.entityId, first.id))),
+    ).resolves.toHaveLength(1);
+  });
+
+  it("rolls back an idempotent issue when its creation activity cannot persist", async () => {
+    const { companyId } = await seedCompanyAndAgent();
+    const failingServices = buildHostServices(
+      db,
+      "plugin-record-id",
+      "paperclip.missions",
+      createEventBusStub(),
+      undefined,
+      {
+        testHooks: {
+          afterPluginIssueCreatedActivityPersisted: async () => {
+            throw new Error("activity failed");
+          },
+        },
+      },
+    );
+
+    await expect(failingServices.issues.create({
+      companyId,
+      title: "Rolled back issue",
+      idempotencyKey: "mission:activity-failure",
+    })).rejects.toThrow("activity failed");
+    await expect(db.select().from(issues).where(eq(issues.companyId, companyId))).resolves.toHaveLength(0);
+    await expect(db.select().from(pluginIssueCreateIdempotency)).resolves.toHaveLength(0);
+    await expect(db.select().from(activityLog).where(eq(activityLog.companyId, companyId))).resolves.toHaveLength(0);
+
+    const services = buildHostServices(db, "plugin-record-id", "paperclip.missions", createEventBusStub());
+    const issue = await services.issues.create({
+      companyId,
+      title: "Retry after rollback",
+      idempotencyKey: "mission:activity-failure",
+    });
+    expect(issue.issueNumber).toBe(1);
+  });
+
+  it("rejects malformed plugin issue idempotency keys without creating state", async () => {
+    const { companyId } = await seedCompanyAndAgent();
+    const services = buildHostServices(db, "plugin-record-id", "paperclip.missions", createEventBusStub());
+
+    await expect(services.issues.create({
+      companyId,
+      title: "Empty key",
+      idempotencyKey: "",
+    })).rejects.toThrow("idempotencyKey must be a non-empty string");
+    await expect(services.issues.create({
+      companyId,
+      title: "Null key",
+      idempotencyKey: null,
+    } as any)).rejects.toThrow("idempotencyKey must be a non-empty string");
+    await expect(services.issues.create({
+      companyId,
+      title: "Oversized key",
+      idempotencyKey: "é".repeat(128),
+    })).rejects.toThrow("idempotencyKey must not exceed 255 UTF-8 bytes");
+
+    await expect(
+      db.select().from(issues).where(eq(issues.companyId, companyId)),
+    ).resolves.toHaveLength(0);
+    await expect(
+      db.select().from(pluginIssueCreateIdempotency),
+    ).resolves.toHaveLength(0);
   });
 
   it("enforces plugin origin namespaces", async () => {

--- a/server/src/__tests__/plugin-sdk-orchestration-contract.test.ts
+++ b/server/src/__tests__/plugin-sdk-orchestration-contract.test.ts
@@ -3,9 +3,12 @@ import { describe, expect, it } from "vitest";
 import type { Issue, PaperclipPluginManifestV1 } from "@paperclipai/shared";
 import { createTestHarness } from "../../../packages/plugins/sdk/src/testing.js";
 
-function manifest(capabilities: PaperclipPluginManifestV1["capabilities"]): PaperclipPluginManifestV1 {
+function manifest(
+  capabilities: PaperclipPluginManifestV1["capabilities"],
+  id = "paperclip.test-orchestration",
+): PaperclipPluginManifestV1 {
   return {
-    id: "paperclip.test-orchestration",
+    id,
     apiVersion: 1,
     version: "0.1.0",
     displayName: "Test Orchestration",
@@ -113,6 +116,59 @@ describe("plugin SDK orchestration contract", () => {
         },
       },
     });
+  });
+
+  it("models plugin- and company-scoped idempotent issue creation in the test harness", async () => {
+    const companyId = randomUUID();
+    const otherCompanyId = randomUUID();
+    const harness = createTestHarness({
+      manifest: manifest(["issues.create"]),
+    });
+    const otherPluginHarness = createTestHarness({
+      manifest: manifest(["issues.create"], "paperclip.other-orchestration"),
+    });
+
+    const original = await harness.ctx.issues.create({
+      companyId,
+      title: "Original title",
+      idempotencyKey: "sync:create",
+    });
+    const retry = await harness.ctx.issues.create({
+      companyId,
+      title: "Changed retry title",
+      idempotencyKey: "sync:create",
+    });
+    const otherCompanyIssue = await harness.ctx.issues.create({
+      companyId: otherCompanyId,
+      title: "Other company title",
+      idempotencyKey: "sync:create",
+    });
+    const otherPluginIssue = await otherPluginHarness.ctx.issues.create({
+      companyId,
+      title: "Other plugin title",
+      idempotencyKey: "sync:create",
+    });
+
+    expect(retry).toMatchObject({ id: original.id, title: "Original title" });
+    expect(otherCompanyIssue.id).not.toBe(original.id);
+    expect(otherPluginIssue.id).not.toBe(original.id);
+  });
+
+  it("enforces the production idempotency-key bounds in the test harness", async () => {
+    const harness = createTestHarness({
+      manifest: manifest(["issues.create"]),
+    });
+    const companyId = randomUUID();
+    const create = (idempotencyKey: unknown) => harness.ctx.issues.create({
+      companyId,
+      title: "Bounded key",
+      idempotencyKey,
+    } as Parameters<typeof harness.ctx.issues.create>[0]);
+
+    await expect(create("")).rejects.toThrow("idempotencyKey must be a non-empty string");
+    await expect(create(null)).rejects.toThrow("idempotencyKey must be a non-empty string");
+    await expect(create("é".repeat(128))).rejects.toThrow("idempotencyKey must not exceed 255 UTF-8 bytes");
+    await expect(create(`${"é".repeat(127)}a`)).resolves.toMatchObject({ title: "Bounded key" });
   });
 
   it("enforces plugin origin namespaces in the test harness", async () => {

--- a/server/src/services/activity-log.ts
+++ b/server/src/services/activity-log.ts
@@ -62,9 +62,15 @@ export interface LogActivityInput {
   details?: Record<string, unknown> | null;
 }
 
-export async function logActivity(db: Db, input: LogActivityInput) {
+type ActivityDb = Db | Parameters<Parameters<Db["transaction"]>[0]>[0];
+
+export async function logActivity(
+  db: ActivityDb,
+  input: LogActivityInput,
+  options: { publish?: boolean } = {},
+) {
   const currentUserRedactionOptions = {
-    enabled: (await instanceSettingsService(db).getGeneral()).censorUsernameInLogs,
+    enabled: (await instanceSettingsService(db as Db).getGeneral()).censorUsernameInLogs,
   };
   const sanitizedDetails = input.details ? sanitizeRecord(input.details) : null;
   const redactedDetails = sanitizedDetails
@@ -82,38 +88,43 @@ export async function logActivity(db: Db, input: LogActivityInput) {
     details: redactedDetails,
   });
 
-  publishLiveEvent({
-    companyId: input.companyId,
-    type: "activity.logged",
-    payload: {
-      actorType: input.actorType,
-      actorId: input.actorId,
-      action: input.action,
-      entityType: input.entityType,
-      entityId: input.entityId,
-      agentId: input.agentId ?? null,
-      runId: input.runId ?? null,
-      details: redactedDetails,
-    },
-  });
-
-  const pluginEventType = eventTypeForActivityAction(input.action);
-  if (pluginEventType) {
-    const event: PluginEvent = {
-      eventId: randomUUID(),
-      eventType: pluginEventType,
-      occurredAt: new Date().toISOString(),
-      actorId: input.actorId,
-      actorType: input.actorType,
-      entityId: input.entityId,
-      entityType: input.entityType,
+  const publish = () => {
+    publishLiveEvent({
       companyId: input.companyId,
+      type: "activity.logged",
       payload: {
-        ...redactedDetails,
+        actorType: input.actorType,
+        actorId: input.actorId,
+        action: input.action,
+        entityType: input.entityType,
+        entityId: input.entityId,
         agentId: input.agentId ?? null,
         runId: input.runId ?? null,
+        details: redactedDetails,
       },
-    };
-    publishPluginDomainEvent(event);
-  }
+    });
+
+    const pluginEventType = eventTypeForActivityAction(input.action);
+    if (pluginEventType) {
+      const event: PluginEvent = {
+        eventId: randomUUID(),
+        eventType: pluginEventType,
+        occurredAt: new Date().toISOString(),
+        actorId: input.actorId,
+        actorType: input.actorType,
+        entityId: input.entityId,
+        entityType: input.entityType,
+        companyId: input.companyId,
+        payload: {
+          ...redactedDetails,
+          agentId: input.agentId ?? null,
+          runId: input.runId ?? null,
+        },
+      };
+      publishPluginDomainEvent(event);
+    }
+  };
+
+  if (options.publish !== false) publish();
+  return publish;
 }

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -31,6 +31,7 @@ import {
   issueThreadInteractions,
   issues,
   labels,
+  pluginIssueCreateIdempotency,
   projectWorkspaces,
   projects,
   workspaceOperations,
@@ -413,6 +414,7 @@ export interface IssueFilters {
 }
 
 type IssueRow = typeof issues.$inferSelect;
+type IssueDb = Db | Parameters<Parameters<Db["transaction"]>[0]>[0];
 type IssueLabelRow = typeof labels.$inferSelect;
 type IssuePlanDecompositionRow = typeof issuePlanDecompositions.$inferSelect;
 type IssueActiveRunRow = {
@@ -3551,14 +3553,14 @@ export function issueService(db: Db) {
   const instanceSettings = instanceSettingsService(db);
   const treeControlSvc = issueTreeControlService(db);
 
-  async function getIssueByUuid(id: string) {
-    const row = await db
+  async function getIssueByUuid(id: string, dbOrTx: IssueDb = db) {
+    const row = await dbOrTx
       .select()
       .from(issues)
       .where(eq(issues.id, id))
-      .then((rows) => rows[0] ?? null);
+      .then((rows: IssueRow[]) => rows[0] ?? null);
     if (!row) return null;
-    const [enriched] = await withIssueLabels(db, [row]);
+    const [enriched] = await withIssueLabels(dbOrTx, [row]);
     return enriched;
   }
 
@@ -4509,7 +4511,7 @@ export function issueService(db: Db) {
     });
   }
 
-  return {
+  const service = {
     clearExecutionRunIfTerminal,
     clearCheckoutRunIfTerminal,
 
@@ -4914,6 +4916,20 @@ export function issueService(db: Db) {
 
     getByIdentifier: async (identifier: string) => {
       return getIssueByIdentifier(identifier);
+    },
+
+    getByPluginIssueIdempotencyDigest: async (companyId: string, keyDigest: string) => {
+      const row = await db
+        .select({ issueId: pluginIssueCreateIdempotency.issueId })
+        .from(pluginIssueCreateIdempotency)
+        .where(and(
+          eq(pluginIssueCreateIdempotency.companyId, companyId),
+          eq(pluginIssueCreateIdempotency.keyDigest, keyDigest),
+        ))
+        .then((rows) => rows[0] ?? null);
+      if (!row?.issueId) return null;
+      const issue = await getIssueByUuid(row.issueId);
+      return issue?.companyId === companyId ? issue : null;
     },
 
     getCurrentScheduledRetry: async (issueId: string) => {
@@ -5868,9 +5884,11 @@ export function issueService(db: Db) {
       });
     },
 
-    create: async (
+    createIssue: async (
       companyId: string,
       data: IssueCreateInput,
+      pluginIdempotencyDigest?: string,
+      onCreated?: (tx: IssueDb, issue: IssueRow) => Promise<void>,
     ) => {
       const {
         labelIds: inputLabelIds,
@@ -5902,6 +5920,32 @@ export function issueService(db: Db) {
         throw unprocessable("in_progress issues require an assignee");
       }
       return db.transaction(async (tx) => {
+        if (pluginIdempotencyDigest !== undefined) {
+          const claim = await tx
+            .insert(pluginIssueCreateIdempotency)
+            .values({ companyId, keyDigest: pluginIdempotencyDigest })
+            .onConflictDoNothing()
+            .returning({ keyDigest: pluginIssueCreateIdempotency.keyDigest })
+            .then((rows) => rows[0] ?? null);
+          if (!claim) {
+            const existingClaim = await tx
+              .select({ issueId: pluginIssueCreateIdempotency.issueId })
+              .from(pluginIssueCreateIdempotency)
+              .where(and(
+                eq(pluginIssueCreateIdempotency.companyId, companyId),
+                eq(pluginIssueCreateIdempotency.keyDigest, pluginIdempotencyDigest),
+              ))
+              .then((rows) => rows[0] ?? null);
+            if (!existingClaim?.issueId) {
+              throw new Error("Plugin issue idempotency claim is not bound to an issue");
+            }
+            const existingIssue = await getIssueByUuid(existingClaim.issueId, tx);
+            if (!existingIssue || existingIssue.companyId !== companyId) {
+              throw new Error("Plugin issue idempotency claim references a missing issue");
+            }
+            return { issue: existingIssue, created: false };
+          }
+        }
         const defaultCompanyGoal = await getDefaultCompanyGoal(tx, companyId);
         let projectWorkspaceId = issueData.projectWorkspaceId ?? null;
         let executionWorkspaceId = issueData.executionWorkspaceId ?? null;
@@ -6102,9 +6146,19 @@ export function issueService(db: Db) {
             tx,
           );
         }
+        if (pluginIdempotencyDigest !== undefined) {
+          await tx
+            .update(pluginIssueCreateIdempotency)
+            .set({ issueId: issue.id })
+            .where(and(
+              eq(pluginIssueCreateIdempotency.companyId, companyId),
+              eq(pluginIssueCreateIdempotency.keyDigest, pluginIdempotencyDigest),
+            ));
+        }
         const [enriched] = await withIssueLabels(tx, [issue]);
         const [withRelations] = await withIssueRelationSummaries(companyId, [enriched], tx);
-        return withRelations;
+        await onCreated?.(tx, withRelations);
+        return { issue: withRelations, created: true };
       });
     },
 
@@ -7449,5 +7503,16 @@ export function issueService(db: Db) {
         goal: a.goalId ? goalMap.get(a.goalId) ?? null : null,
       }));
     },
+  };
+  const { createIssue, ...publicService } = service;
+  return {
+    ...publicService,
+    create: async (companyId: string, data: IssueCreateInput) => (await createIssue(companyId, data)).issue,
+    createWithPluginIdempotency: (
+      companyId: string,
+      data: IssueCreateInput,
+      keyDigest: string,
+      onCreated?: (tx: IssueDb, issue: IssueRow) => Promise<void>,
+    ) => createIssue(companyId, data, keyDigest, onCreated),
   };
 }

--- a/server/src/services/plugin-host-services.ts
+++ b/server/src/services/plugin-host-services.ts
@@ -89,6 +89,58 @@ const DNS_LOOKUP_TIMEOUT_MS = 5_000;
 /** Only these protocols are allowed for plugin HTTP requests. */
 const ALLOWED_PROTOCOLS = new Set(["http:", "https:"]);
 const TELEMETRY_EVENT_NAME_REGEX = /^[a-z0-9][a-z0-9_-]*$/;
+const PLUGIN_ISSUE_IDEMPOTENCY_KEY_MAX_BYTES = 255;
+const PLUGIN_ISSUE_UPDATE_FIELDS = new Set([
+  "title",
+  "description",
+  "status",
+  "priority",
+  "assigneeAgentId",
+  "assigneeUserId",
+  "billingCode",
+  "originKind",
+  "originId",
+  "originRunId",
+  "requestDepth",
+  "executionWorkspaceId",
+  "executionWorkspacePreference",
+  "blockedByIssueIds",
+  "labelIds",
+  "executionWorkspaceSettings",
+  "actorAgentId",
+  "actorUserId",
+  "actorRunId",
+]);
+
+function assertPluginIssueUpdateFields(patch: Record<string, unknown>): void {
+  for (const field of Object.keys(patch)) {
+    if (!PLUGIN_ISSUE_UPDATE_FIELDS.has(field)) {
+      throw new Error(`Unsupported plugin issue update field: ${field}`);
+    }
+  }
+}
+
+function validatePluginIssueIdempotencyKey(value: unknown): string {
+  if (typeof value !== "string") {
+    throw new Error("idempotencyKey must be a non-empty string");
+  }
+  const byteLength = new TextEncoder().encode(value).byteLength;
+  if (byteLength === 0) {
+    throw new Error("idempotencyKey must be a non-empty string");
+  }
+  if (byteLength > PLUGIN_ISSUE_IDEMPOTENCY_KEY_MAX_BYTES) {
+    throw new Error(`idempotencyKey must not exceed ${PLUGIN_ISSUE_IDEMPOTENCY_KEY_MAX_BYTES} UTF-8 bytes`);
+  }
+  return value;
+}
+
+function pluginIssueIdempotencyDigest(pluginId: string, idempotencyKey: string): string {
+  return createHash("sha256")
+    .update(pluginId)
+    .update("\0")
+    .update(idempotencyKey)
+    .digest("hex");
+}
 
 /**
  * Check if an IP address is in a private/reserved range (RFC 1918, loopback,
@@ -493,7 +545,14 @@ export function buildHostServices(
   pluginKey: string,
   eventBus: PluginEventBus,
   notifyWorker?: (method: string, params: unknown) => void,
-  options: { pluginWorkerManager?: PluginWorkerManager; manifest?: import("@paperclipai/shared").PaperclipPluginManifestV1 } = {},
+  options: {
+    pluginWorkerManager?: PluginWorkerManager;
+    manifest?: import("@paperclipai/shared").PaperclipPluginManifestV1;
+    testHooks?: {
+      afterPluginIssueIdempotencyPrelookup?: () => Promise<void>;
+      afterPluginIssueCreatedActivityPersisted?: () => Promise<void>;
+    };
+  } = {},
 ): HostServices & { dispose(): void } {
   const registry = pluginRegistryService(db);
   const stateStore = pluginStateStore(db);
@@ -691,15 +750,18 @@ export function buildHostServices(
     normalizePluginOriginKind(originKind);
   };
 
-  const logPluginActivity = async (input: {
-    companyId: string;
-    action: string;
-    entityType: string;
-    entityId: string;
-    details?: Record<string, unknown> | null;
-    actor?: { actorAgentId?: string | null; actorUserId?: string | null; actorRunId?: string | null };
-  }) => {
-    await logActivity(db, {
+  const logPluginActivity = async (
+    input: {
+      companyId: string;
+      action: string;
+      entityType: string;
+      entityId: string;
+      details?: Record<string, unknown> | null;
+      actor?: { actorAgentId?: string | null; actorUserId?: string | null; actorRunId?: string | null };
+    },
+    options: { db?: Parameters<typeof logActivity>[0]; publish?: boolean } = {},
+  ) => {
+    return logActivity(options.db ?? db, {
       companyId: input.companyId,
       actorType: "plugin",
       actorId: pluginId,
@@ -709,7 +771,7 @@ export function buildHostServices(
       entityType: input.entityType,
       entityId: input.entityId,
       details: pluginActivityDetails(input.details, input.actor),
-    });
+    }, { publish: options.publish });
   };
 
   const collectIssueSubtreeIds = async (companyId: string, rootIssueId: string) => {
@@ -1544,13 +1606,29 @@ export function buildHostServices(
       async create(params) {
         const companyId = ensureCompanyId(params.companyId);
         await ensurePluginAvailableForCompany(companyId);
-        const { actorAgentId, actorUserId, actorRunId, originKind, surfaceVisibility, ...issueInput } = params;
+        const {
+          actorAgentId,
+          actorUserId,
+          actorRunId,
+          originKind,
+          surfaceVisibility,
+          idempotencyKey,
+          ...issueInput
+        } = params;
+        const idempotencyDigest = idempotencyKey === undefined
+          ? undefined
+          : pluginIssueIdempotencyDigest(pluginId, validatePluginIssueIdempotencyKey(idempotencyKey));
+        if (idempotencyDigest !== undefined) {
+          const existing = await issues.getByPluginIssueIdempotencyDigest(companyId, idempotencyDigest);
+          if (existing) return existing as Issue;
+          await options.testHooks?.afterPluginIssueIdempotencyPrelookup?.();
+        }
         const normalizedOriginKind = normalizePluginOriginKind(
           surfaceVisibility === "plugin_operation" && !originKind
             ? pluginOperationIssueOriginKind(pluginKey)
             : originKind,
         );
-        const issue = (await issues.create(companyId, {
+        const createInput = {
           ...(issueInput as any),
           originKind: normalizedOriginKind,
           originId: params.originId ?? null,
@@ -1559,22 +1637,44 @@ export function buildHostServices(
           createdByUserId: actorUserId ?? null,
           actorResponsibleUserId: actorUserId ?? null,
           trustExplicitResponsibleUserId: true,
-        })) as Issue;
-        await logPluginActivity({
+        };
+        const logCreatedActivity = (
+          createdIssue: Issue,
+          activityOptions?: Parameters<typeof logPluginActivity>[1],
+        ) => logPluginActivity({
           companyId,
           action: "issue.created",
           entityType: "issue",
-          entityId: issue.id,
+          entityId: createdIssue.id,
           actor: { actorAgentId, actorUserId, actorRunId },
           details: {
-            title: issue.title,
-            identifier: issue.identifier,
+            title: createdIssue.title,
+            identifier: createdIssue.identifier,
             originKind: normalizedOriginKind,
-            originId: issue.originId,
-            billingCode: issue.billingCode,
+            originId: createdIssue.originId,
+            billingCode: createdIssue.billingCode,
             blockedByIssueIds: params.blockedByIssueIds ?? [],
           },
-        });
+        }, activityOptions);
+        let publishCreatedActivity: (() => void) | undefined;
+        const result = idempotencyDigest === undefined
+          ? { issue: await issues.create(companyId, createInput), created: true }
+          : await issues.createWithPluginIdempotency(
+            companyId,
+            createInput,
+            idempotencyDigest,
+            async (tx, createdIssue) => {
+              publishCreatedActivity = await logCreatedActivity(createdIssue as Issue, {
+                db: tx,
+                publish: false,
+              });
+              await options.testHooks?.afterPluginIssueCreatedActivityPersisted?.();
+            },
+          );
+        const issue = result.issue as Issue;
+        if (!result.created) return issue;
+        if (publishCreatedActivity) publishCreatedActivity();
+        else await logCreatedActivity(issue);
         return issue;
       },
       async update(params) {
@@ -1582,6 +1682,7 @@ export function buildHostServices(
         await ensurePluginAvailableForCompany(companyId);
         const existing = requireInCompany("Issue", await issues.getById(params.issueId), companyId);
         const patch = { ...(params.patch as Record<string, unknown>) };
+        assertPluginIssueUpdateFields(patch);
         const actorAgentId = typeof patch.actorAgentId === "string" ? patch.actorAgentId : null;
         const actorUserId = typeof patch.actorUserId === "string" ? patch.actorUserId : null;
         const actorRunId = typeof patch.actorRunId === "string" ? patch.actorRunId : null;


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Plugins can create Paperclip issues through `PluginIssuesClient.create`
> - Plugin workers may retry after an interrupted response, and multiple workers or host processes can execute the same logical create concurrently
> - The SDK currently gives plugins no durable idempotency primitive, so process-local locks and list-before-create checks can still produce duplicate issues
> - This pull request carries an optional idempotency key through the plugin SDK and enforces it atomically in the database
> - The benefit is that plugin issue creation becomes safely retryable across workers and host restarts without changing ordinary issue creation

## Linked Issues or Issue Description

Refs #8356, which covers the adjacent board/agent HTTP issue-create route. It does not cover plugin SDK RPC or plugin-scoped keys, and its current select-before-insert implementation does not resolve concurrent plugin-worker creation.

**What happened?**

A plugin that performs list-before-create deduplication can create duplicate Paperclip issues when two worker processes execute the same logical operation concurrently. Both workers can observe no existing issue before either inserts. A retry after an interrupted host response has the same failure mode because the SDK has no durable create token.

**Expected behavior**

Plugins should be able to attach a stable key to an issue-create operation. Repeating that operation from another worker or after a host restart should return the original issue unchanged. Keys should be isolated by plugin installation and company.

**Steps to reproduce on `master`**

1. Start from `d3919713bc9e7ec85389ba0096df6dd95f92ae9f` using either embedded PGlite or external PostgreSQL.
2. Have two plugin worker executions perform the same logical list-before-create operation concurrently.
3. Let both reads complete before either create commits.
4. Observe that both create calls succeed with different issue IDs because `PluginIssuesClient.create` has no idempotency input or database uniqueness boundary.

This is a core plugin-host correctness bug and is not adapter-specific.

## What Changed

- Added optional `idempotencyKey` support to `PluginIssuesClient.create`, worker RPC forwarding, protocol types, and the SDK test harness.
- Added a private plugin issue-create idempotency table with a company-scoped unique digest and issue binding for durable enforcement in PostgreSQL/PGlite.
- Namespaced keys by plugin installation using a fixed-width SHA-256 digest of `pluginId + NUL + caller key`, preventing unrelated plugins from suppressing each other and avoiding raw key persistence.
- Made retries return the original issue unchanged, including retries whose create payload differs.
- Acquired the idempotency claim before issue-number allocation; concurrent losers read and return the winning issue without mutating it or consuming a number.
- Persisted the winning `issue.created` activity in the same transaction as the claim and issue, with live notification deferred until after commit.
- Kept idempotency state outside public issue rows and plugin-controlled update patches.
- Enforced the SDK issue-update field allowlist at the raw plugin RPC boundary and rechecked claim/issue company consistency before returning retries.
- Validated and documented idempotency keys as non-empty strings containing at most 255 UTF-8 bytes.
- Added focused integration coverage for retries, payload drift, deterministic contention, activity rollback/deduplication, issue-number rollback, malformed keys, plugin isolation, company isolation, and SDK forwarding/harness behavior.

## Verification

- `cd server && pnpm exec vitest run src/__tests__/plugin-orchestration-apis.test.ts src/__tests__/plugin-sdk-orchestration-contract.test.ts` — 21/21 passed.
- `pnpm -r typecheck` — passed across all 30 applicable workspace packages; includes migration numbering and safety checks.
- `pnpm build` — passed.
- `git diff --check` — passed.
- Candidate `03e17c04201dd11d29d67036ea7df2c24d9ed58b` is based on current upstream `d3919713bc9e7ec85389ba0096df6dd95f92ae9f`; focused tests and the full build passed on that exact tree.

## Risks

- **Migration:** the change creates a new private claim table and indexes without rewriting existing issue rows. The issue binding uses a foreign key so hard deletion also removes its claim.
- **Hash collision:** keys are stored as SHA-256 digests namespaced by plugin installation. A cryptographic collision could theoretically alias operations but is not practically expected.
- **Retry semantics:** reusing a key intentionally returns the first issue without applying later payload changes. This is documented and tested.
- **Notification boundary:** the durable activity row commits atomically with the issue; its live notification is deliberately best-effort after commit.
- **Compatibility:** the SDK field is optional. Board/general issue creation and the public issue row shape are unaffected.

This is a narrowly scoped plugin correctness fix. `ROADMAP.md` contains no duplicate planned primitive.

## Model Used

OpenAI Codex `gpt-5.6-sol`, with reasoning, tool use, code execution, test execution, and an independent review agent.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

---
###### ✨ This message was AI-generated using gpt-5.6-sol
