### PR TITLE
fix(recovery): cancel stranded routine-execution issues instead of blocking them

### DIFF
--- a/server/src/__tests__/issue-recovery-actions.test.ts
+++ b/server/src/__tests__/issue-recovery-actions.test.ts
@@ -324,6 +324,67 @@ describeEmbeddedPostgres("issue recovery actions", () => {
     });
   });
 
+  it("cancels a stranded routine-execution issue instead of blocking it into a zombie", async () => {
+    const { companyId, coderId, prefix } = await seedCompany();
+    const enqueueWakeup = vi.fn(async () => null);
+    const recovery = recoveryService(db, { enqueueWakeup });
+
+    const routineIssueId = randomUUID();
+    await db.insert(issues).values({
+      id: routineIssueId,
+      companyId,
+      title: "Daily backlog do",
+      status: "in_progress",
+      priority: "medium",
+      assigneeAgentId: coderId,
+      issueNumber: 2,
+      identifier: `${prefix}-2`,
+      originKind: "routine_execution",
+      originId: randomUUID(),
+    });
+    const [routineIssue] = await db.select().from(issues).where(eq(issues.id, routineIssueId));
+
+    const latestRun = {
+      id: randomUUID(),
+      agentId: coderId,
+      status: "failed",
+      error: "adapter failed",
+      errorCode: "adapter_failed",
+      contextSnapshot: { retryReason: "issue_continuation_needed" },
+      livenessState: "needs_followup",
+    } as const;
+
+    await recovery.escalateStrandedAssignedIssue({
+      issue: routineIssue!,
+      previousStatus: "in_progress",
+      latestRun,
+      comment: "Automatic continuation recovery failed.",
+    });
+
+    // The throwaway routine instance is cancelled, not blocked: the routine
+    // regenerates a fresh execution issue on its next fire, so there is nothing
+    // to recover and no zombie is left in the blocked population.
+    const [updatedIssue] = await db.select().from(issues).where(eq(issues.id, routineIssueId));
+    expect(updatedIssue).toMatchObject({ status: "cancelled" });
+
+    // No source-scoped recovery action is created and no owner is woken, because
+    // there is no recovery work to own.
+    const actionRows = await db
+      .select()
+      .from(issueRecoveryActions)
+      .where(eq(issueRecoveryActions.sourceIssueId, routineIssueId));
+    expect(actionRows).toHaveLength(0);
+    expect(enqueueWakeup).not.toHaveBeenCalled();
+
+    // A single system note explains the cancellation.
+    const comments = await db
+      .select()
+      .from(issueComments)
+      .where(eq(issueComments.issueId, routineIssueId));
+    expect(comments).toHaveLength(1);
+    expect(comments[0]?.body).toContain("cancelled this stranded routine-execution issue");
+  });
+
   it("reuses the same source-scoped action when latest run IDs change while the cause stays the same", async () => {
     const { companyId, managerId, coderId, sourceIssue } = await seedCompany();
     const enqueueWakeup = vi.fn(async () => null);

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -2670,6 +2670,83 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     return updated;
   }
 
+  function isRoutineExecutionIssue(issue: typeof issues.$inferSelect) {
+    return issue.originKind === "routine_execution";
+  }
+
+  function buildCancelledRoutineExecutionRecoveryComment(input: {
+    issue: typeof issues.$inferSelect;
+    previousStatus: StrandedPreviousStatus;
+    latestRun: LatestIssueRun;
+    prefix: string;
+  }) {
+    const runLink = input.latestRun
+      ? runUiLink({ id: input.latestRun.id, agentId: input.latestRun.agentId }, input.prefix)
+      : "none";
+    const failureSummary = summarizeRunFailureForIssueComment(input.latestRun);
+    return [
+      "Paperclip cancelled this stranded routine-execution issue instead of blocking it.",
+      "",
+      `- Previous status: \`${input.previousStatus}\``,
+      `- Latest run: ${runLink}`,
+      `- Latest run status: \`${input.latestRun?.status ?? "unknown"}\``,
+      failureSummary ? `- Failure: ${failureSummary.trim()}` : "- Failure: none recorded",
+      "",
+      "This issue is a disposable instance of a recurring routine. The routine will",
+      "create a fresh execution issue on its next scheduled fire, so there is nothing",
+      "to recover here. No action is required; if the failure recurs across fires,",
+      "repair the routine configuration or the underlying runtime/adapter fault.",
+    ].join("\n");
+  }
+
+  async function cancelStrandedRoutineExecutionIssue(input: {
+    issue: typeof issues.$inferSelect;
+    previousStatus: StrandedPreviousStatus;
+    latestRun: LatestIssueRun;
+    recoveryCause: StrandedRecoveryCause;
+  }) {
+    const updated = await issuesSvc.update(input.issue.id, { status: "cancelled" });
+    if (!updated) return null;
+
+    const prefix = await getCompanyIssuePrefix(input.issue.companyId);
+    await issuesSvc.addComment(
+      input.issue.id,
+      buildCancelledRoutineExecutionRecoveryComment({
+        issue: input.issue,
+        previousStatus: input.previousStatus,
+        latestRun: input.latestRun,
+        prefix,
+      }),
+      {},
+      { authorType: "system" },
+    );
+
+    await logActivity(db, {
+      companyId: input.issue.companyId,
+      actorType: "system",
+      actorId: "system",
+      agentId: null,
+      runId: null,
+      action: "issue.updated",
+      entityType: "issue",
+      entityId: input.issue.id,
+      details: {
+        identifier: input.issue.identifier,
+        status: "cancelled",
+        previousStatus: input.previousStatus,
+        source: "recovery.cancel_stranded_routine_execution",
+        recoveryCause: input.recoveryCause,
+        latestRunId: input.latestRun?.id ?? null,
+        latestRunStatus: input.latestRun?.status ?? null,
+        latestRunErrorCode: input.latestRun?.errorCode ?? null,
+        originKind: input.issue.originKind,
+        originId: input.issue.originId,
+      },
+    });
+
+    return updated;
+  }
+
   async function escalateStrandedAssignedIssue(input: {
     issue: typeof issues.$inferSelect;
     previousStatus: StrandedPreviousStatus;
@@ -2684,6 +2761,24 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         issue: input.issue,
         previousStatus: input.previousStatus,
         latestRun: input.latestRun,
+      });
+    }
+
+    // Routine-execution issues are throwaway instances of a recurring routine: the
+    // routine regenerates a fresh execution issue on its next scheduled fire, so a
+    // stranded instance has nothing to "recover" — the forward path is the next fire,
+    // not a repair of this issue. Parking it in `blocked` therefore produces a
+    // permanent zombie: it carries no first-class blocker (none pre-exists, so the
+    // blocked-with-empty-blockers heuristic flags it as stuck) and its assignee has
+    // no meaningful action to take on a disposable run. Cancel it instead so it
+    // leaves the stranded/blocked population cleanly; the routine restores forward
+    // motion on schedule.
+    if (isRoutineExecutionIssue(input.issue)) {
+      return cancelStrandedRoutineExecutionIssue({
+        issue: input.issue,
+        previousStatus: input.previousStatus,
+        latestRun: input.latestRun,
+        recoveryCause: input.recoveryCause ?? "stranded_assigned_issue",
       });
     }
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Recurring routines fire on a schedule and create a disposable `routine_execution` issue per fire, which an agent then executes
> - When a routine-execution run dies at the infra level (adapter connection refused, output-inactivity kill), the stranded-issue recovery treats the issue like any assigned work and parks it in `blocked`
> - But a routine-execution issue has no meaningful recovery: the routine regenerates a fresh execution issue on its next fire, so repairing this instance is not the forward path. It also carries no first-class blocker (none pre-exists), so heuristics that flag "blocked with empty blockedBy" mark it as permanently stuck, and its assignee has no action to take on a throwaway run
> - The result is a class of permanent zombie issues that accumulate in `blocked` and pollute stuck-work detection
> - This pull request cancels a stranded routine-execution issue instead of blocking it, at the single recovery chokepoint both the immediate and periodic recovery paths flow through
> - The benefit is that disposable routine instances leave the blocked/stranded population cleanly and the routine simply restores forward motion on its next scheduled fire

## Linked Issues or Issue Description

Refs #9201

## What Changed

- `escalateStrandedAssignedIssue` now short-circuits for issues whose `originKind === "routine_execution"`: it cancels the issue (status `cancelled`) rather than creating a recovery action, blocking, and waking an owner.
- Added `cancelStrandedRoutineExecutionIssue` + a system-authored explanatory comment describing why the disposable instance was cancelled and that the routine will regenerate on its next fire.
- The guard sits at the single chokepoint that both the immediate infra-death recovery path and the periodic `reconcileStrandedAssignedIssues` sweep flow through, so both are covered.
- Added a test asserting a stranded `routine_execution` issue is cancelled (not blocked), creates no recovery action, wakes no owner, and posts one system note.

## Verification

- `pnpm --filter @paperclipai/server typecheck` — clean
- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/issue-recovery-actions.test.ts` — 23/23 pass (includes the new cancel test)
- Confirmed `cancelled` is a valid `IssueStatus` and is excluded from `OPEN_ISSUE_STATUSES` used for routine coalescing, so cancelling a stranded instance lets the routine fire a fresh execution issue on schedule (no tight loop, no dedup breakage).

## Risks

Low risk. Behavior change is scoped strictly to `originKind === "routine_execution"` issues that reach stranded-issue recovery; all other stranded work retains the existing block-and-wake-owner behavior. Cancelling is terminal and removes the issue from open-issue projections used for routine coalescing, which is the intended lifecycle for a disposable instance — the routine regenerates on its next fire. No schema or migration changes.

## Model Used

Claude Opus 4.8 (`claude-opus-4-8`), extended thinking, with tool use / code execution in an agentic CLI.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links
- [x] My branch name describes the change and contains no internal Paperclip ticket id
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes (no user-facing docs affected)
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green (pending CI)
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups (pending review)
- [x] I will address all Greptile and reviewer comments before requesting merge
