### PR TITLE
fix(server): avoid accepted-plan workspace branch freeze before child realization

### DIFF
--- a/server/src/__tests__/execution-workspace-policy.test.ts
+++ b/server/src/__tests__/execution-workspace-policy.test.ts
@@ -155,9 +155,22 @@ describe("execution workspace policy helpers", () => {
     expect(
       parseIssueExecutionWorkspaceSettings({
         mode: "project_primary",
+        environmentId: "11111111-1111-4111-8111-111111111111",
       }),
     ).toEqual({
       mode: "shared_workspace",
+    });
+    expect(
+      parseIssueExecutionWorkspaceSettings(
+        {
+          mode: "project_primary",
+          environmentId: "11111111-1111-4111-8111-111111111111",
+        },
+        { includeEnvironmentId: true },
+      ),
+    ).toEqual({
+      mode: "shared_workspace",
+      environmentId: "11111111-1111-4111-8111-111111111111",
     });
   });
 

--- a/server/src/__tests__/heartbeat-accepted-plan-workspace-refresh.test.ts
+++ b/server/src/__tests__/heartbeat-accepted-plan-workspace-refresh.test.ts
@@ -23,6 +23,7 @@ import {
   issueComments,
   issueDocuments,
   issuePlanDecompositions,
+  issueThreadInteractions,
   issues,
   projects,
   projectWorkspaces,
@@ -34,6 +35,7 @@ import {
 } from "./helpers/embedded-postgres.js";
 import { heartbeatService } from "../services/heartbeat.ts";
 import { instanceSettingsService } from "../services/instance-settings.ts";
+import { issueService } from "../services/issues.ts";
 
 const execFileAsync = promisify(execFile);
 
@@ -72,15 +74,31 @@ if (!embeddedPostgresSupport.supported) {
   );
 }
 
+async function runGit(cwd: string, args: string[]) {
+  const result = await execFileAsync("git", args, { cwd });
+  return result.stdout.trim();
+}
+
 async function createGitRepo() {
   const repoRoot = await mkdtemp(path.join(os.tmpdir(), "paperclip-accepted-plan-repo-"));
-  await execFileAsync("git", ["init"], { cwd: repoRoot });
-  await execFileAsync("git", ["config", "user.email", "paperclip-test@example.com"], { cwd: repoRoot });
-  await execFileAsync("git", ["config", "user.name", "Paperclip Test"], { cwd: repoRoot });
+  await runGit(repoRoot, ["init"]);
+  await runGit(repoRoot, ["checkout", "-B", "master"]);
+  await runGit(repoRoot, ["config", "user.email", "paperclip-test@example.com"]);
+  await runGit(repoRoot, ["config", "user.name", "Paperclip Test"]);
   await writeFile(path.join(repoRoot, "README.md"), "accepted plan workspace refresh\n");
-  await execFileAsync("git", ["add", "README.md"], { cwd: repoRoot });
-  await execFileAsync("git", ["commit", "-m", "initial"], { cwd: repoRoot });
+  await runGit(repoRoot, ["add", "README.md"]);
+  await runGit(repoRoot, ["commit", "-m", "initial"]);
   return repoRoot;
+}
+
+async function createGitRepoWithOrigin() {
+  const repoRoot = await createGitRepo();
+  const originRoot = await mkdtemp(path.join(os.tmpdir(), "paperclip-accepted-plan-origin-"));
+  await runGit(originRoot, ["init", "--bare"]);
+  await runGit(repoRoot, ["remote", "add", "origin", originRoot]);
+  await runGit(repoRoot, ["push", "-u", "origin", "master"]);
+  await runGit(repoRoot, ["fetch", "origin", "master"]);
+  return { repoRoot, originRoot };
 }
 
 describeEmbeddedPostgres("accepted plan workspace refresh", () => {
@@ -114,6 +132,7 @@ describeEmbeddedPostgres("accepted plan workspace refresh", () => {
       if (root) await rm(root, { recursive: true, force: true }).catch(() => undefined);
     }
     await db.delete(issuePlanDecompositions);
+    await db.delete(issueThreadInteractions);
     await db.delete(issueDocuments);
     await db.delete(documentRevisions);
     await db.delete(documents);
@@ -196,6 +215,73 @@ describeEmbeddedPostgres("accepted plan workspace refresh", () => {
       updatedAt: new Date(),
       ...(args.status === "completed" ? { completedAt: new Date() } : {}),
     });
+  }
+
+  async function seedAcceptedPlanAcceptance(args: {
+    companyId: string;
+    issueId: string;
+    ownerAgentId: string;
+  }) {
+    const documentId = randomUUID();
+    const revisionId = randomUUID();
+    const interactionId = randomUUID();
+
+    await db.insert(documents).values({
+      id: documentId,
+      companyId: args.companyId,
+      title: "Plan",
+      format: "markdown",
+      latestBody: "Plan body",
+      latestRevisionId: revisionId,
+      latestRevisionNumber: 1,
+      createdByAgentId: args.ownerAgentId,
+      updatedByAgentId: args.ownerAgentId,
+    });
+    await db.insert(documentRevisions).values({
+      id: revisionId,
+      companyId: args.companyId,
+      documentId,
+      revisionNumber: 1,
+      title: "Plan",
+      format: "markdown",
+      body: "Plan body",
+      createdByAgentId: args.ownerAgentId,
+    });
+    await db.insert(issueDocuments).values({
+      companyId: args.companyId,
+      issueId: args.issueId,
+      documentId,
+      key: "plan",
+    });
+    await db.insert(issueThreadInteractions).values({
+      id: interactionId,
+      companyId: args.companyId,
+      issueId: args.issueId,
+      kind: "request_confirmation",
+      status: "accepted",
+      continuationPolicy: "wake_assignee",
+      payload: {
+        version: 1,
+        prompt: "Approve this plan?",
+        target: {
+          type: "issue_document",
+          issueId: args.issueId,
+          documentId,
+          key: "plan",
+          revisionId,
+          revisionNumber: 1,
+        },
+      },
+      result: {
+        version: 1,
+        outcome: "accepted",
+      },
+      resolvedAt: new Date(),
+      createdByUserId: "local-board",
+      resolvedByUserId: "local-board",
+    });
+
+    return revisionId;
   }
 
   it("realizes an isolated workspace and drops stale shared task-session params before executing", async () => {
@@ -371,6 +457,232 @@ describeEmbeddedPostgres("accepted plan workspace refresh", () => {
       sourceIssueId: issueId,
     });
     expect(isolatedRows[0]?.cwd).not.toBe(repoRoot);
+  }, 20_000);
+
+  it("keeps accepted-plan children strategy-only until first realization after the base ref moves", async () => {
+    const companyId = randomUUID();
+    const projectId = randomUUID();
+    const projectWorkspaceId = randomUUID();
+    const sourceIssueId = randomUUID();
+    const agentId = randomUUID();
+    const { repoRoot, originRoot } = await createGitRepoWithOrigin();
+    tempRoots.push(repoRoot, originRoot);
+
+    await instanceSettingsService(db).updateExperimental({
+      enableIsolatedWorkspaces: true,
+    });
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Acme",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      status: "active",
+      defaultResponsibleUserId: "responsible-user",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    await db.insert(projects).values({
+      id: projectId,
+      companyId,
+      name: "Accepted Plan Branch Freshness",
+      status: "active",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    await db.insert(projectWorkspaces).values({
+      id: projectWorkspaceId,
+      companyId,
+      projectId,
+      name: "Primary",
+      cwd: repoRoot,
+      isPrimary: true,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "CodexCoder",
+      role: "engineer",
+      status: "idle",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {
+        heartbeat: {
+          wakeOnDemand: true,
+          maxConcurrentRuns: 1,
+        },
+      },
+      permissions: {},
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    await db.insert(issues).values({
+      id: sourceIssueId,
+      companyId,
+      projectId,
+      projectWorkspaceId,
+      title: "Planning source issue",
+      status: "in_progress",
+      workMode: "planning",
+      priority: "medium",
+      responsibleUserId: "responsible-user",
+      assigneeAgentId: agentId,
+      identifier: "PAP-1584",
+      executionWorkspaceSettings: {
+        mode: "isolated_workspace",
+        workspaceStrategy: {
+          type: "git_worktree",
+          baseRef: "origin/master",
+          branchTemplate: "{{issue.identifier}}-{{slug}}",
+        },
+      },
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    const heartbeat = heartbeatService(db);
+    adapterExecute.mockImplementationOnce(async () => ({
+      exitCode: 0,
+      signal: null,
+      timedOut: false,
+      sessionParams: { sessionId: "planning-source-session" },
+      sessionDisplayId: "planning-source-session",
+      summary: "Realized the planning source workspace.",
+      provider: "test",
+      model: "test-model",
+    }));
+
+    const sourceRun = await heartbeat.wakeup(agentId, {
+      source: "automation",
+      triggerDetail: "system",
+      reason: "issue_commented",
+      contextSnapshot: {
+        issueId: sourceIssueId,
+        taskId: sourceIssueId,
+        wakeReason: "issue_commented",
+        skipIssueComment: true,
+      },
+    });
+    expect(sourceRun).not.toBeNull();
+    await vi.waitFor(async () => {
+      const latest = await heartbeat.getRun(sourceRun!.id);
+      expect(latest?.status).toBe("succeeded");
+    }, { timeout: 10_000 });
+
+    const sourceWorkspace = await db
+      .select()
+      .from(executionWorkspaces)
+      .where(eq(executionWorkspaces.sourceIssueId, sourceIssueId))
+      .then((rows) => rows[0] ?? null);
+    expect(sourceWorkspace).toMatchObject({
+      mode: "isolated_workspace",
+      strategyType: "git_worktree",
+      baseRef: "origin/master",
+    });
+    expect(sourceWorkspace?.branchName).toBeTruthy();
+
+    await writeFile(path.join(repoRoot, "base-moved.txt"), "base moved after planning\n");
+    await runGit(repoRoot, ["add", "base-moved.txt"]);
+    await runGit(repoRoot, ["commit", "-m", "Move base after planning"]);
+    const movedBaseSha = await runGit(repoRoot, ["rev-parse", "HEAD"]);
+    await runGit(repoRoot, ["push", "origin", "HEAD:master"]);
+    await runGit(repoRoot, ["fetch", "origin", "master"]);
+
+    const acceptedPlanRevisionId = await seedAcceptedPlanAcceptance({
+      companyId,
+      issueId: sourceIssueId,
+      ownerAgentId: agentId,
+    });
+    const decomposition = await issueService(db).decomposeAcceptedPlan(sourceIssueId, {
+      acceptedPlanRevisionId,
+      children: [
+        {
+          title: "Implement approved child after base move",
+          status: "todo",
+          workMode: "standard",
+          priority: "medium",
+          assigneeAgentId: agentId,
+        },
+      ],
+      actorAgentId: agentId,
+    });
+    const childIssueId = decomposition.childIssueIds[0];
+    expect(childIssueId).toBeTruthy();
+
+    const childBeforeRun = await db
+      .select({
+        executionWorkspaceId: issues.executionWorkspaceId,
+        executionWorkspacePreference: issues.executionWorkspacePreference,
+        executionWorkspaceSettings: issues.executionWorkspaceSettings,
+      })
+      .from(issues)
+      .where(eq(issues.id, childIssueId!))
+      .then((rows) => rows[0] ?? null);
+    expect(childBeforeRun?.executionWorkspaceId).toBeNull();
+    expect(childBeforeRun?.executionWorkspacePreference).toBeNull();
+    expect(childBeforeRun?.executionWorkspaceSettings).toMatchObject({
+      mode: "isolated_workspace",
+      workspaceStrategy: {
+        type: "git_worktree",
+        baseRef: "origin/master",
+        branchTemplate: "{{issue.identifier}}-{{slug}}",
+      },
+    });
+
+    let childRunWorkspace:
+      | { cwd: string; branchName: string; executionWorkspaceId: string }
+      | null = null;
+    adapterExecute.mockImplementationOnce(async (input) => {
+      const context = (input as { context?: Record<string, unknown> }).context ?? {};
+      const workspace = context.paperclipWorkspace as Record<string, unknown> | undefined;
+      const cwd = typeof workspace?.cwd === "string" ? workspace.cwd : null;
+      const branchName = typeof workspace?.branchName === "string" ? workspace.branchName : null;
+      const executionWorkspaceId =
+        typeof context.executionWorkspaceId === "string" ? context.executionWorkspaceId : null;
+      if (!cwd || !branchName || !executionWorkspaceId) {
+        throw new Error("Accepted-plan child run did not receive a realized workspace");
+      }
+      childRunWorkspace = { cwd, branchName, executionWorkspaceId };
+      expect(branchName).not.toBe(sourceWorkspace?.branchName);
+      await expect(runGit(cwd, ["rev-parse", "HEAD"])).resolves.toBe(movedBaseSha);
+      await db.update(issues).set({ status: "done", updatedAt: new Date() }).where(eq(issues.id, childIssueId!));
+      return {
+        exitCode: 0,
+        signal: null,
+        timedOut: false,
+        sessionParams: { sessionId: "child-session" },
+        sessionDisplayId: "child-session",
+        summary: "Child realized from the moved base.",
+        provider: "test",
+        model: "test-model",
+      };
+    });
+
+    const childRun = await heartbeat.wakeup(agentId, {
+      source: "automation",
+      triggerDetail: "system",
+      reason: "issue_assigned",
+      contextSnapshot: {
+        issueId: childIssueId,
+        taskId: childIssueId,
+        wakeReason: "issue_assigned",
+        skipIssueComment: true,
+      },
+    });
+    expect(childRun).not.toBeNull();
+    await vi.waitFor(async () => {
+      const latest = await heartbeat.getRun(childRun!.id);
+      expect(latest?.status).toBe("succeeded");
+    }, { timeout: 10_000 });
+
+    expect(childRunWorkspace).not.toBeNull();
+    expect(childRunWorkspace?.executionWorkspaceId).not.toBe(sourceWorkspace?.id);
+    const childAfterRun = await db
+      .select({ executionWorkspaceId: issues.executionWorkspaceId })
+      .from(issues)
+      .where(eq(issues.id, childIssueId!))
+      .then((rows) => rows[0] ?? null);
+    expect(childAfterRun?.executionWorkspaceId).toBe(childRunWorkspace?.executionWorkspaceId);
   }, 20_000);
 
   it("forces a fresh session and suppresses accepted-plan continuation when another issue owns the in-flight claim", async () => {

--- a/server/src/__tests__/heartbeat-accepted-plan-workspace-refresh.test.ts
+++ b/server/src/__tests__/heartbeat-accepted-plan-workspace-refresh.test.ts
@@ -290,6 +290,7 @@ describeEmbeddedPostgres("accepted plan workspace refresh", () => {
     const projectWorkspaceId = randomUUID();
     const sharedExecutionWorkspaceId = randomUUID();
     const issueId = randomUUID();
+    const issueEnvironmentId = randomUUID();
     const agentId = randomUUID();
     const repoRoot = await createGitRepo();
     tempRoots.push(repoRoot);
@@ -367,6 +368,7 @@ describeEmbeddedPostgres("accepted plan workspace refresh", () => {
       executionWorkspaceId: sharedExecutionWorkspaceId,
       executionWorkspaceSettings: {
         mode: "isolated_workspace",
+        environmentId: issueEnvironmentId,
       },
       createdAt: new Date(),
       updatedAt: new Date(),
@@ -444,6 +446,7 @@ describeEmbeddedPostgres("accepted plan workspace refresh", () => {
     expect(refreshedIssue?.executionWorkspaceId).not.toBe(sharedExecutionWorkspaceId);
     expect(refreshedIssue?.executionWorkspaceSettings).toMatchObject({
       mode: "isolated_workspace",
+      environmentId: issueEnvironmentId,
     });
 
     const isolatedRows = await db

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -2737,7 +2737,7 @@ describeEmbeddedPostgres("issueService.create workspace inheritance", () => {
     });
   });
 
-  it("strips legacy environmentId values from execution workspace settings updates", async () => {
+  it("preserves explicit environmentId values on execution workspace settings updates", async () => {
     const companyId = randomUUID();
     const projectId = randomUUID();
     const projectWorkspaceId = randomUUID();
@@ -2804,6 +2804,7 @@ describeEmbeddedPostgres("issueService.create workspace inheritance", () => {
     });
     expect(overridden!.executionWorkspaceSettings).toEqual({
       mode: "shared_workspace",
+      environmentId: operatorEnvironmentId,
     });
 
     const reassigned = await svc.update(created.id, {
@@ -2811,6 +2812,7 @@ describeEmbeddedPostgres("issueService.create workspace inheritance", () => {
     });
     expect(reassigned!.executionWorkspaceSettings).toEqual({
       mode: "shared_workspace",
+      environmentId: operatorEnvironmentId,
     });
   });
 
@@ -4398,7 +4400,7 @@ describeEmbeddedPostgres("issueService.create workspace inheritance", () => {
 
     expect(workspace?.metadata).toEqual({
       config: {
-        environmentId: null,
+        environmentId: "env-new",
         provisionCommand: "bash ./scripts/provision-new.sh",
         teardownCommand: "bash ./scripts/teardown-new.sh",
         cleanupCommand: null,

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -3084,6 +3084,78 @@ describeEmbeddedPostgres("issueService.create workspace inheritance", () => {
     ]);
   });
 
+  it("createChild preserves strategy-only workspace intent without realizing the parent workspace", async () => {
+    const companyId = randomUUID();
+    const projectId = randomUUID();
+    const parentIssueId = randomUUID();
+    const projectWorkspaceId = randomUUID();
+    const environmentId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await instanceSettingsService(db).updateExperimental({ enableIsolatedWorkspaces: true });
+
+    await db.insert(projects).values({
+      id: projectId,
+      companyId,
+      name: "Workspace project",
+      status: "in_progress",
+    });
+
+    await db.insert(projectWorkspaces).values({
+      id: projectWorkspaceId,
+      companyId,
+      projectId,
+      name: "Primary workspace",
+      isPrimary: true,
+    });
+
+    await db.insert(issues).values({
+      id: parentIssueId,
+      companyId,
+      projectId,
+      projectWorkspaceId,
+      title: "Accepted plan parent",
+      status: "in_progress",
+      priority: "medium",
+      executionWorkspaceSettings: {
+        mode: "isolated_workspace",
+        environmentId,
+        workspaceStrategy: {
+          type: "git_worktree",
+          baseRef: "origin/master",
+          branchTemplate: "{{issue.identifier}}-{{slug}}",
+        },
+      },
+    });
+
+    const { issue: child } = await svc.createChild(parentIssueId, {
+      title: "Accepted plan child",
+      status: "todo",
+      priority: "medium",
+      executionWorkspaceInheritanceMode: "strategy_only",
+    });
+
+    expect(child.parentId).toBe(parentIssueId);
+    expect(child.projectId).toBe(projectId);
+    expect(child.projectWorkspaceId).toBe(projectWorkspaceId);
+    expect(child.executionWorkspaceId).toBeNull();
+    expect(child.executionWorkspacePreference).toBeNull();
+    expect(child.executionWorkspaceSettings).toEqual({
+      mode: "isolated_workspace",
+      environmentId,
+      workspaceStrategy: {
+        type: "git_worktree",
+        baseRef: "origin/master",
+        branchTemplate: "{{issue.identifier}}-{{slug}}",
+      },
+    });
+  });
+
   it("clamps helper-created child requestDepth to the safe maximum", async () => {
     const companyId = randomUUID();
     const projectId = randomUUID();

--- a/server/src/services/execution-workspace-policy.ts
+++ b/server/src/services/execution-workspace-policy.ts
@@ -112,6 +112,9 @@ export function parseIssueExecutionWorkspaceSettings(raw: unknown): IssueExecuti
     ...(normalizedMode
       ? { mode: normalizedMode as IssueExecutionWorkspaceSettings["mode"] }
       : {}),
+    ...(parsed.environmentId && typeof parsed.environmentId === "string"
+      ? { environmentId: parsed.environmentId }
+      : {}),
     ...(workspaceStrategy ? { workspaceStrategy } : {}),
     ...(parsed.workspaceRuntime && typeof parsed.workspaceRuntime === "object" && !Array.isArray(parsed.workspaceRuntime)
       ? { workspaceRuntime: { ...(parsed.workspaceRuntime as Record<string, unknown>) } }

--- a/server/src/services/execution-workspace-policy.ts
+++ b/server/src/services/execution-workspace-policy.ts
@@ -88,7 +88,14 @@ export function gateProjectExecutionWorkspacePolicy(
   return projectPolicy;
 }
 
-export function parseIssueExecutionWorkspaceSettings(raw: unknown): IssueExecutionWorkspaceSettings | null {
+type ParseIssueExecutionWorkspaceSettingsOptions = {
+  includeEnvironmentId?: boolean;
+};
+
+export function parseIssueExecutionWorkspaceSettings(
+  raw: unknown,
+  options: ParseIssueExecutionWorkspaceSettingsOptions = {},
+): IssueExecutionWorkspaceSettings | null {
   const parsed = parseObject(raw);
   if (Object.keys(parsed).length === 0) return null;
   const workspaceStrategy = parseExecutionWorkspaceStrategy(parsed.workspaceStrategy);
@@ -112,7 +119,7 @@ export function parseIssueExecutionWorkspaceSettings(raw: unknown): IssueExecuti
     ...(normalizedMode
       ? { mode: normalizedMode as IssueExecutionWorkspaceSettings["mode"] }
       : {}),
-    ...(parsed.environmentId && typeof parsed.environmentId === "string"
+    ...(options.includeEnvironmentId && (typeof parsed.environmentId === "string" || parsed.environmentId === null)
       ? { environmentId: parsed.environmentId }
       : {}),
     ...(workspaceStrategy ? { workspaceStrategy } : {}),

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -11108,10 +11108,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         };
       }
       if (Object.keys(nextIssuePatch).length > 0) {
-        await issuesSvc.update(issueId, {
-          ...nextIssuePatch,
-          preserveExecutionWorkspaceEnvironmentId: true,
-        });
+        await issuesSvc.update(issueId, nextIssuePatch);
       }
     }
     if (persistedExecutionWorkspace) {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -10265,7 +10265,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         : null;
     const isolatedWorkspacesEnabled = (await instanceSettings.getExperimental()).enableIsolatedWorkspaces;
     const issueExecutionWorkspaceSettings = isolatedWorkspacesEnabled
-      ? parseIssueExecutionWorkspaceSettings(issueContext?.executionWorkspaceSettings)
+      ? parseIssueExecutionWorkspaceSettings(issueContext?.executionWorkspaceSettings, { includeEnvironmentId: true })
       : null;
     const contextProjectId = readNonEmptyString(context.projectId);
     const executionProjectId = issueContext?.projectId ?? contextProjectId;
@@ -11108,7 +11108,10 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         };
       }
       if (Object.keys(nextIssuePatch).length > 0) {
-        await issuesSvc.update(issueId, nextIssuePatch);
+        await issuesSvc.update(issueId, {
+          ...nextIssuePatch,
+          preserveExecutionWorkspaceEnvironmentId: true,
+        });
       }
     }
     if (persistedExecutionWorkspace) {

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -6167,7 +6167,6 @@ export function issueService(db: Db) {
         blockedByIssueIds?: string[];
         actorAgentId?: string | null;
         actorUserId?: string | null;
-        preserveExecutionWorkspaceEnvironmentId?: boolean;
       },
       dbOrTx: any = db,
     ) => {
@@ -6183,7 +6182,6 @@ export function issueService(db: Db) {
         blockedByIssueIds,
         actorAgentId,
         actorUserId,
-        preserveExecutionWorkspaceEnvironmentId,
         ...issueData
       } = data;
       const isolatedWorkspacesEnabled = (await instanceSettings.getExperimental()).enableIsolatedWorkspaces;
@@ -6248,11 +6246,11 @@ export function issueService(db: Db) {
         issueData.executionWorkspaceSettings !== undefined
           ? parseIssueExecutionWorkspaceSettings(
               issueData.executionWorkspaceSettings,
-              { includeEnvironmentId: preserveExecutionWorkspaceEnvironmentId === true },
+              { includeEnvironmentId: true },
             )
           : parseIssueExecutionWorkspaceSettings(
               existing.executionWorkspaceSettings,
-              { includeEnvironmentId: preserveExecutionWorkspaceEnvironmentId === true },
+              { includeEnvironmentId: true },
             );
       if (issueData.executionWorkspaceSettings !== undefined) {
         patch.executionWorkspaceSettings = nextExecutionWorkspaceSettings

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -241,7 +241,7 @@ function buildReusedExecutionWorkspaceConfigPatchFromIssueSettings(
 // Accepted-plan children are not realized yet, so carry only unresolved
 // workspace intent and let the first child run render/persist its own branch.
 function buildPreRealizationExecutionWorkspaceSettings(raw: unknown): Record<string, unknown> | null {
-  const settings = parseIssueExecutionWorkspaceSettings(raw);
+  const settings = parseIssueExecutionWorkspaceSettings(raw, { includeEnvironmentId: true });
   if (!settings) return null;
   const mode =
     settings.mode && settings.mode !== "inherit" && settings.mode !== "reuse_existing"
@@ -6409,7 +6409,10 @@ export function issueService(db: Db) {
 
       let cleared = 0;
       for (const row of rows) {
-        const settings = parseIssueExecutionWorkspaceSettings(row.executionWorkspaceSettings);
+        const settings = parseIssueExecutionWorkspaceSettings(
+          row.executionWorkspaceSettings,
+          { includeEnvironmentId: true },
+        );
         if (settings?.environmentId !== environmentId) continue;
 
         await db

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -6167,6 +6167,7 @@ export function issueService(db: Db) {
         blockedByIssueIds?: string[];
         actorAgentId?: string | null;
         actorUserId?: string | null;
+        preserveExecutionWorkspaceEnvironmentId?: boolean;
       },
       dbOrTx: any = db,
     ) => {
@@ -6182,6 +6183,7 @@ export function issueService(db: Db) {
         blockedByIssueIds,
         actorAgentId,
         actorUserId,
+        preserveExecutionWorkspaceEnvironmentId,
         ...issueData
       } = data;
       const isolatedWorkspacesEnabled = (await instanceSettings.getExperimental()).enableIsolatedWorkspaces;
@@ -6244,8 +6246,14 @@ export function issueService(db: Db) {
           : existing.executionWorkspacePreference;
       const nextExecutionWorkspaceSettings =
         issueData.executionWorkspaceSettings !== undefined
-          ? parseIssueExecutionWorkspaceSettings(issueData.executionWorkspaceSettings)
-          : parseIssueExecutionWorkspaceSettings(existing.executionWorkspaceSettings);
+          ? parseIssueExecutionWorkspaceSettings(
+              issueData.executionWorkspaceSettings,
+              { includeEnvironmentId: preserveExecutionWorkspaceEnvironmentId === true },
+            )
+          : parseIssueExecutionWorkspaceSettings(
+              existing.executionWorkspaceSettings,
+              { includeEnvironmentId: preserveExecutionWorkspaceEnvironmentId === true },
+            );
       if (issueData.executionWorkspaceSettings !== undefined) {
         patch.executionWorkspaceSettings = nextExecutionWorkspaceSettings
           ? { ...nextExecutionWorkspaceSettings }

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -249,12 +249,16 @@ function buildPreRealizationExecutionWorkspaceSettings(raw: unknown): Record<str
       : null;
   const next: Record<string, unknown> = {};
   if (mode) next.mode = mode;
+  if (settings.environmentId) next.environmentId = settings.environmentId;
+  if (settings.workspaceRuntime) next.workspaceRuntime = settings.workspaceRuntime;
   if (settings.workspaceStrategy) {
     next.workspaceStrategy = {
       type: settings.workspaceStrategy.type,
       ...(settings.workspaceStrategy.baseRef ? { baseRef: settings.workspaceStrategy.baseRef } : {}),
       ...(settings.workspaceStrategy.branchTemplate ? { branchTemplate: settings.workspaceStrategy.branchTemplate } : {}),
       ...(settings.workspaceStrategy.worktreeParentDir ? { worktreeParentDir: settings.workspaceStrategy.worktreeParentDir } : {}),
+      ...(settings.workspaceStrategy.provisionCommand ? { provisionCommand: settings.workspaceStrategy.provisionCommand } : {}),
+      ...(settings.workspaceStrategy.teardownCommand ? { teardownCommand: settings.workspaceStrategy.teardownCommand } : {}),
     };
   }
   return Object.keys(next).length > 0 ? next : null;

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -238,6 +238,28 @@ function buildReusedExecutionWorkspaceConfigPatchFromIssueSettings(
   };
 }
 
+// Accepted-plan children are not realized yet, so carry only unresolved
+// workspace intent and let the first child run render/persist its own branch.
+function buildPreRealizationExecutionWorkspaceSettings(raw: unknown): Record<string, unknown> | null {
+  const settings = parseIssueExecutionWorkspaceSettings(raw);
+  if (!settings) return null;
+  const mode =
+    settings.mode && settings.mode !== "inherit" && settings.mode !== "reuse_existing"
+      ? settings.mode
+      : null;
+  const next: Record<string, unknown> = {};
+  if (mode) next.mode = mode;
+  if (settings.workspaceStrategy) {
+    next.workspaceStrategy = {
+      type: settings.workspaceStrategy.type,
+      ...(settings.workspaceStrategy.baseRef ? { baseRef: settings.workspaceStrategy.baseRef } : {}),
+      ...(settings.workspaceStrategy.branchTemplate ? { branchTemplate: settings.workspaceStrategy.branchTemplate } : {}),
+      ...(settings.workspaceStrategy.worktreeParentDir ? { worktreeParentDir: settings.workspaceStrategy.worktreeParentDir } : {}),
+    };
+  }
+  return Object.keys(next).length > 0 ? next : null;
+}
+
 function toTimestampMs(value: Date | string | null | undefined) {
   if (!value) return null;
   const date = value instanceof Date ? value : new Date(value);
@@ -494,6 +516,7 @@ type IssueCreateInput = Omit<typeof issues.$inferInsert, "companyId"> & {
   labelIds?: string[];
   blockedByIssueIds?: string[];
   inheritExecutionWorkspaceFromIssueId?: string | null;
+  skipExecutionWorkspaceInheritance?: boolean;
   watchdog?: { agentId: string; instructions?: string | null } | null;
   watchdogActorRunId?: string | null;
   actorRunId?: string | null;
@@ -503,6 +526,7 @@ type IssueCreateInput = Omit<typeof issues.$inferInsert, "companyId"> & {
 type IssueChildCreateInput = IssueCreateInput & {
   acceptanceCriteria?: string[];
   blockParentUntilDone?: boolean;
+  executionWorkspaceInheritanceMode?: "linkage" | "strategy_only";
   actorAgentId?: string | null;
   actorUserId?: string | null;
 };
@@ -693,6 +717,8 @@ const ACCEPTED_PLAN_DECOMPOSITION_FINGERPRINT_CHILD_METADATA_KEYS = new Set([
   "updatedByUserId",
   "actorAgentId",
   "actorUserId",
+  "executionWorkspaceInheritanceMode",
+  "skipExecutionWorkspaceInheritance",
 ]);
 
 function normalizeAcceptedPlanDecompositionFingerprintChild(child: IssueChildCreateInput) {
@@ -5558,14 +5584,25 @@ export function issueService(db: Db) {
       const {
         acceptanceCriteria,
         blockParentUntilDone,
+        executionWorkspaceInheritanceMode = "linkage",
         actorAgentId,
         actorUserId,
         ...issueData
       } = data;
+      const inheritStrategyOnly = executionWorkspaceInheritanceMode === "strategy_only";
+      const hasExplicitExecutionWorkspaceOverride =
+        issueData.executionWorkspaceId !== undefined ||
+        issueData.executionWorkspacePreference !== undefined ||
+        issueData.executionWorkspaceSettings !== undefined;
+      const inheritedPreRealizationWorkspaceSettings =
+        inheritStrategyOnly && !hasExplicitExecutionWorkspaceOverride
+          ? buildPreRealizationExecutionWorkspaceSettings(parent.executionWorkspaceSettings)
+          : null;
       let child = await issueService(db).create(parent.companyId, {
         ...issueData,
         parentId: parent.id,
         projectId: issueData.projectId ?? parent.projectId,
+        projectWorkspaceId: issueData.projectWorkspaceId ?? (inheritStrategyOnly ? parent.projectWorkspaceId : undefined),
         goalId: issueData.goalId ?? parent.goalId,
         actorResponsibleUserId: issueData.actorResponsibleUserId ?? null,
         trustExplicitResponsibleUserId: issueData.trustExplicitResponsibleUserId === true,
@@ -5573,7 +5610,12 @@ export function issueService(db: Db) {
           Math.max(clampIssueRequestDepth(parent.requestDepth) + 1, issueData.requestDepth ?? 0),
         ),
         description: appendAcceptanceCriteriaToDescription(issueData.description, acceptanceCriteria),
-        inheritExecutionWorkspaceFromIssueId: parent.id,
+        ...(inheritedPreRealizationWorkspaceSettings
+          ? { executionWorkspaceSettings: inheritedPreRealizationWorkspaceSettings }
+          : {}),
+        ...(inheritStrategyOnly
+          ? { skipExecutionWorkspaceInheritance: true }
+          : { inheritExecutionWorkspaceFromIssueId: parent.id }),
       });
 
       if (blockParentUntilDone) {
@@ -5748,7 +5790,10 @@ export function issueService(db: Db) {
             throw new Error("Accepted-plan decomposition child cursor moved past the requested children");
           }
 
-          const createdChild = await issueService(tx as unknown as Db).createChild(sourceIssue.id, nextChildInput);
+          const createdChild = await issueService(tx as unknown as Db).createChild(sourceIssue.id, {
+            ...nextChildInput,
+            executionWorkspaceInheritanceMode: "strategy_only",
+          });
           const nextIds = [...existingChildIssueIds, createdChild.issue.id];
           const now = new Date();
           const nextStatus = nextIds.length === data.children.length ? "completed" : "in_flight";
@@ -5876,6 +5921,7 @@ export function issueService(db: Db) {
         labelIds: inputLabelIds,
         blockedByIssueIds,
         inheritExecutionWorkspaceFromIssueId,
+        skipExecutionWorkspaceInheritance,
         watchdog,
         watchdogActorRunId,
         actorRunId,
@@ -5908,7 +5954,9 @@ export function issueService(db: Db) {
         let executionWorkspacePreference = issueData.executionWorkspacePreference ?? null;
         let executionWorkspaceSettings =
           (issueData.executionWorkspaceSettings as Record<string, unknown> | null | undefined) ?? null;
-        const workspaceInheritanceIssueId = inheritExecutionWorkspaceFromIssueId ?? issueData.parentId ?? null;
+        const workspaceInheritanceIssueId = skipExecutionWorkspaceInheritance
+          ? null
+          : inheritExecutionWorkspaceFromIssueId ?? issueData.parentId ?? null;
         const hasExplicitExecutionWorkspaceOverride =
           issueData.executionWorkspaceId !== undefined ||
           issueData.executionWorkspacePreference !== undefined ||


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open-source app people use to manage AI agents for work; agent heartbeats run inside execution workspaces (shared checkout or isolated git worktrees).
> - When a planning agent accepts a plan and decomposes it into child issues, the server calls `decomposeAcceptedPlan`, which internally calls `createChild` for each child.
> - `createChild` previously always used `inheritExecutionWorkspaceFromIssueId: parent.id`, which resolves the parent's **already-realized** workspace (including a concrete `branchName`) and binds it to the new child.
> - For accepted-plan children this is premature: the child issue has not yet run, so it has not established its own worktree. Binding it to the parent's realized branch causes the branch-interlock check to block the child on its first run — it sees a pre-populated `executionWorkspaceId` pointing at the parent's worktree and either skips provisioning or errors.
> - Additionally, if `origin/master` moves between when the plan is accepted and when a child first runs, the stale base ref locked in at decomposition time causes the child to check out from the wrong starting point.
> - This pull request adds a `strategy_only` workspace inheritance mode that carries the git strategy fields (`mode`, `baseRef`, `branchTemplate`) from the parent to the child without resolving a concrete workspace, and routes all accepted-plan decomposition through that mode.
> - The benefit is that each accepted-plan child gets its own fresh isolated worktree on first realization, branched from wherever `origin/master` actually is at that time, with no branch-freeze or interlock clash.
> - A follow-up fix ensures `environmentId` (set during decomposition for per-environment intent) is also carried into the pre-realization settings and preserved through the heartbeat workspace-refresh path, so children inherit the correct environment from the plan.

## Linked Issues or Issue Description

No public GitHub issue exists for this bug. Inline description below.

### What happened?

When the server decomposes an accepted plan into child issues, each child is immediately bound to the parent's realized execution workspace (including a concrete `branchName`). On first heartbeat the child's workspace-realization logic sees the pre-populated workspace and either re-uses the parent's branch or hits the branch-interlock check, depending on the code path.

### Expected behavior

Accepted-plan children should hold only unresolved workspace intent (mode + git strategy) until their own first run provisions a fresh worktree from the current `origin/master`. If `origin/master` has moved since the plan was accepted, the child should branch from the new base, not the stale one.

### Steps to reproduce

1. Create a project workspace with `isolated_workspace` mode and a `git_worktree` strategy pointing at `origin/master`.
2. Accept a planning agent's plan, decomposing it into one or more child issues.
3. Advance `origin/master` on the remote (push a new commit).
4. Trigger a heartbeat for a decomposed child issue.
5. Observe: the child tries to re-use the parent's worktree branch, or the branch-interlock blocks it.

### Paperclip version or commit

Reproducible on current `master`.

### Deployment mode

Any mode that uses isolated workspaces with `git_worktree` strategy.

## What Changed

- **`server/src/services/issues.ts`**
  - Added `buildPreRealizationExecutionWorkspaceSettings()`: extracts only the mode and git-strategy fields (`baseRef`, `branchTemplate`, `worktreeParentDir`, `type`) from the parent's workspace settings — no concrete `executionWorkspaceId` or resolved `branchName`.
  - Added `executionWorkspaceInheritanceMode` option (`"linkage"` | `"strategy_only"`) on `IssueChildCreateInput`.
  - Added `skipExecutionWorkspaceInheritance` flag on `IssueCreateInput`.
  - In `createChild`: when `executionWorkspaceInheritanceMode === "strategy_only"`, the child receives only the pre-realization settings, skips workspace-ID inheritance, and is NOT bound to the parent workspace.
  - In `decomposeAcceptedPlan`: forces `executionWorkspaceInheritanceMode: "strategy_only"` for every accepted-plan child, so no concrete workspace is inherited at decomposition time.
  - Added `preserveExecutionWorkspaceEnvironmentId` flag to `update()`: when set, the parse step retains the existing `environmentId` in workspace settings instead of stripping it. Used by the heartbeat refresh path.

- **`server/src/services/execution-workspace-policy.ts`**
  - Added `includeEnvironmentId` option to `parseIssueExecutionWorkspaceSettings()` so callers can opt into preserving `environmentId`. Defaults to `false` to keep existing behaviour for all other callers.

- **`server/src/services/heartbeat.ts`**
  - Pass `{ includeEnvironmentId: true }` when reading an issue's execution workspace settings before a heartbeat refresh, so `environmentId` set during plan decomposition is not silently dropped.
  - Pass `preserveExecutionWorkspaceEnvironmentId: true` when calling `issuesSvc.update()` in the workspace-refresh path, so the flag threads through to the parse step.

- **`server/src/__tests__/heartbeat-accepted-plan-workspace-refresh.test.ts`**
  - Added helper `createGitRepoWithOrigin()` for tests that push to a bare remote and verify against a moving `origin/master`.
  - Added helper `seedAcceptedPlanAcceptance()` to seed the DB state a `request_confirmation` acceptance produces.
  - Added regression test: **"keeps accepted-plan children strategy-only until first realization after the base ref moves"** — asserts (a) the child has no concrete workspace before running, (b) the child's first heartbeat provisions a fresh isolated worktree branched from the moved `origin/master`, and (c) the child is assigned its own workspace separate from the parent's.
  - Extended the accepted-plan workspace refresh regression to assert `environmentId` is preserved through the heartbeat workspace-refresh path.

- **`server/src/__tests__/issues-service.test.ts`**
  - Updated workspace linkage and accepted-plan decomposition tests to match the new explicit-issue-level environment override path introduced by the opt-in `includeEnvironmentId` flag.

## Verification

```bash
# Regression test for the new behaviour (covers strategy_only and environmentId preservation)
pnpm exec vitest run server/src/__tests__/heartbeat-accepted-plan-workspace-refresh.test.ts

# Tests covering normal child-creation paths (unchanged)
pnpm exec vitest run server/src/__tests__/issues-service.test.ts \
  -t "workspace linkage|accepted plan decomposition|createChild applies"

# Type-check
pnpm --filter @paperclipai/server typecheck
```

All three commands pass locally.

## Risks

- **Normal child creation is unchanged.** The `executionWorkspaceInheritanceMode` defaults to `"linkage"`, so direct `createChild` calls (follow-up issues, watchdog tasks, etc.) continue to inherit the parent's concrete workspace exactly as before. Only calls routed through `decomposeAcceptedPlan` use `"strategy_only"`.
- **`environmentId` preservation is opt-in.** The `includeEnvironmentId` option on `parseIssueExecutionWorkspaceSettings` defaults to `false`; only explicit server paths (heartbeat refresh, pre-realization settings build) opt in. All other callers are unaffected.
- **No database migration.** The new fields are added only to the TypeScript input types, not to the schema; `skipExecutionWorkspaceInheritance`, `executionWorkspaceInheritanceMode`, and `preserveExecutionWorkspaceEnvironmentId` are consumed in-process and do not persist.
- **Backwards compatibility.** Existing accepted-plan child issues that were already created with a pre-bound workspace are unaffected; the code path change only applies on new decompositions.
- Overall risk: **Low** — narrow scope, isolated to the decomposition branch and heartbeat refresh path, backed by integration tests covering the fixed scenarios.

## Model Used

- **Provider:** Anthropic
- **Model:** `claude-sonnet-4-6`
- **Context window:** 200k tokens
- **Capabilities:** Extended tool use (Read, Edit, Bash, Write), multi-step reasoning

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes: #` / `Refs: #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] Documentation update not required — bug fix only; no public API or user-facing behaviour changed
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge