### PR TITLE
Prefer reachable runtime API URLs for local adapters

### DIFF
--- a/packages/adapter-utils/src/acpx-engine/execute.ts
+++ b/packages/adapter-utils/src/acpx-engine/execute.ts
@@ -1003,7 +1003,10 @@ async function buildRuntime(input: {
   const envConfig = parseObject(config.env);
   const hasExplicitApiKey =
     typeof envConfig.PAPERCLIP_API_KEY === "string" && envConfig.PAPERCLIP_API_KEY.trim().length > 0;
-  const env: Record<string, string> = { ...buildPaperclipEnv(agent), PAPERCLIP_RUN_ID: runId };
+  const env: Record<string, string> = {
+    ...buildPaperclipEnv(agent, { preferLocalRuntimeUrl: true }),
+    PAPERCLIP_RUN_ID: runId,
+  };
   const wakeTaskId =
     (typeof context.taskId === "string" && context.taskId.trim()) ||
     (typeof context.issueId === "string" && context.issueId.trim()) ||

--- a/packages/adapter-utils/src/execution-target-sandbox.test.ts
+++ b/packages/adapter-utils/src/execution-target-sandbox.test.ts
@@ -1449,6 +1449,80 @@ describe("sandbox adapter execution targets", () => {
     }
   });
 
+  it("does not let a bare PORT override the configured runtime API URL for bridge forwarding", async () => {
+    const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-execution-target-bridge-bare-port-"));
+    cleanupDirs.push(rootDir);
+    const remoteCwd = path.join(rootDir, "workspace");
+    const runtimeRootDir = path.join(remoteCwd, ".paperclip-runtime", "codex");
+    await mkdir(runtimeRootDir, { recursive: true });
+
+    const requests: Array<{ method: string; url: string; auth: string | null; runId: string | null }> = [];
+    const apiServer = createServer((req, res) => {
+      requests.push({
+        method: req.method ?? "GET",
+        url: req.url ?? "/",
+        auth: req.headers.authorization ?? null,
+        runId: typeof req.headers["x-paperclip-run-id"] === "string" ? req.headers["x-paperclip-run-id"] : null,
+      });
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ ok: true }));
+    });
+    await new Promise<void>((resolve, reject) => {
+      apiServer.once("error", reject);
+      apiServer.listen(0, "127.0.0.1", () => resolve());
+    });
+    const address = apiServer.address();
+    if (!address || typeof address === "string") {
+      throw new Error("Expected the bridge bare PORT test API server to listen on a TCP port.");
+    }
+
+    vi.stubEnv("PORT", "1");
+    vi.stubEnv("PAPERCLIP_LISTEN_HOST", "");
+    vi.stubEnv("PAPERCLIP_LISTEN_PORT", "");
+    vi.stubEnv("PAPERCLIP_RUNTIME_API_CANDIDATES_JSON", "[]");
+    vi.stubEnv("PAPERCLIP_RUNTIME_API_URL", `http://127.0.0.1:${address.port}`);
+    vi.stubEnv("PAPERCLIP_API_URL", "http://stale-tailnet.example.test:3101");
+
+    const target: AdapterSandboxExecutionTarget = {
+      kind: "remote",
+      transport: "sandbox",
+      providerKey: "e2b",
+      environmentId: "env-1",
+      leaseId: "lease-1",
+      remoteCwd,
+      runner: createLocalSandboxRunner(),
+      timeoutMs: 30_000,
+    };
+
+    const bridge = await startAdapterExecutionTargetPaperclipBridge({
+      runId: "run-bridge-bare-port",
+      target,
+      runtimeRootDir,
+      adapterKey: "codex",
+      hostApiToken: "real-run-jwt",
+    });
+    try {
+      const response = await fetch(`${bridge!.env.PAPERCLIP_API_URL}/api/agents/me`, {
+        headers: {
+          authorization: `Bearer ${bridge!.env.PAPERCLIP_API_KEY}`,
+          accept: "application/json",
+        },
+      });
+
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual({ ok: true });
+      expect(requests).toEqual([{
+        method: "GET",
+        url: "/api/agents/me",
+        auth: "Bearer real-run-jwt",
+        runId: "run-bridge-bare-port",
+      }]);
+    } finally {
+      await bridge?.stop();
+      await new Promise<void>((resolve) => apiServer.close(() => resolve()));
+    }
+  });
+
   it("uses the effective adapter timeout when starting the sandbox callback bridge", async () => {
     const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-execution-target-bridge-timeout-"));
     cleanupDirs.push(rootDir);

--- a/packages/adapter-utils/src/execution-target-sandbox.test.ts
+++ b/packages/adapter-utils/src/execution-target-sandbox.test.ts
@@ -1298,6 +1298,157 @@ describe("sandbox adapter execution targets", () => {
     }
   });
 
+  it("prefers a loopback runtime candidate for host bridge forwarding", async () => {
+    const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-execution-target-bridge-host-url-"));
+    cleanupDirs.push(rootDir);
+    const remoteCwd = path.join(rootDir, "workspace");
+    const runtimeRootDir = path.join(remoteCwd, ".paperclip-runtime", "codex");
+    await mkdir(runtimeRootDir, { recursive: true });
+
+    const requests: Array<{ method: string; url: string; auth: string | null; runId: string | null }> = [];
+    const apiServer = createServer((req, res) => {
+      requests.push({
+        method: req.method ?? "GET",
+        url: req.url ?? "/",
+        auth: req.headers.authorization ?? null,
+        runId: typeof req.headers["x-paperclip-run-id"] === "string" ? req.headers["x-paperclip-run-id"] : null,
+      });
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ ok: true }));
+    });
+    await new Promise<void>((resolve, reject) => {
+      apiServer.once("error", reject);
+      apiServer.listen(0, "127.0.0.1", () => resolve());
+    });
+    const address = apiServer.address();
+    if (!address || typeof address === "string") {
+      throw new Error("Expected the bridge test API server to listen on a TCP port.");
+    }
+
+    vi.stubEnv("PAPERCLIP_RUNTIME_API_URL", "http://stale-tailnet.example.test:3101");
+    vi.stubEnv("PAPERCLIP_API_URL", "http://stale-tailnet.example.test:3101");
+    vi.stubEnv("PAPERCLIP_RUNTIME_API_CANDIDATES_JSON", JSON.stringify([
+      "http://stale-tailnet.example.test:3101",
+      `http://127.0.0.1:${address.port}`,
+      "http://100.103.164.67:3101",
+    ]));
+
+    const target: AdapterSandboxExecutionTarget = {
+      kind: "remote",
+      transport: "sandbox",
+      providerKey: "e2b",
+      environmentId: "env-1",
+      leaseId: "lease-1",
+      remoteCwd,
+      runner: createLocalSandboxRunner(),
+      timeoutMs: 30_000,
+    };
+
+    const bridge = await startAdapterExecutionTargetPaperclipBridge({
+      runId: "run-bridge-host-url",
+      target,
+      runtimeRootDir,
+      adapterKey: "codex",
+      hostApiToken: "real-run-jwt",
+    });
+    try {
+      const response = await fetch(`${bridge!.env.PAPERCLIP_API_URL}/api/agents/me`, {
+        headers: {
+          authorization: `Bearer ${bridge!.env.PAPERCLIP_API_KEY}`,
+          accept: "application/json",
+        },
+      });
+
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual({ ok: true });
+      expect(requests).toEqual([{
+        method: "GET",
+        url: "/api/agents/me",
+        auth: "Bearer real-run-jwt",
+        runId: "run-bridge-host-url",
+      }]);
+    } finally {
+      await bridge?.stop();
+      await new Promise<void>((resolve) => apiServer.close(() => resolve()));
+    }
+  });
+
+  it("synthesizes a loopback host URL for bridge forwarding when candidates are external-only", async () => {
+    const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-execution-target-bridge-listen-port-"));
+    cleanupDirs.push(rootDir);
+    const remoteCwd = path.join(rootDir, "workspace");
+    const runtimeRootDir = path.join(remoteCwd, ".paperclip-runtime", "codex");
+    await mkdir(runtimeRootDir, { recursive: true });
+
+    const requests: Array<{ method: string; url: string; auth: string | null; runId: string | null }> = [];
+    const apiServer = createServer((req, res) => {
+      requests.push({
+        method: req.method ?? "GET",
+        url: req.url ?? "/",
+        auth: req.headers.authorization ?? null,
+        runId: typeof req.headers["x-paperclip-run-id"] === "string" ? req.headers["x-paperclip-run-id"] : null,
+      });
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ ok: true }));
+    });
+    await new Promise<void>((resolve, reject) => {
+      apiServer.once("error", reject);
+      apiServer.listen(0, "127.0.0.1", () => resolve());
+    });
+    const address = apiServer.address();
+    if (!address || typeof address === "string") {
+      throw new Error("Expected the bridge test API server to listen on a TCP port.");
+    }
+
+    vi.stubEnv("PAPERCLIP_RUNTIME_API_URL", "http://stale-tailnet.example.test:3101");
+    vi.stubEnv("PAPERCLIP_API_URL", "http://stale-tailnet.example.test:3101");
+    vi.stubEnv("PAPERCLIP_RUNTIME_API_CANDIDATES_JSON", JSON.stringify([
+      "http://stale-tailnet.example.test:3101",
+      "http://100.103.164.67:3101",
+    ]));
+    vi.stubEnv("PAPERCLIP_LISTEN_HOST", "127.0.0.1");
+    vi.stubEnv("PAPERCLIP_LISTEN_PORT", String(address.port));
+
+    const target: AdapterSandboxExecutionTarget = {
+      kind: "remote",
+      transport: "sandbox",
+      providerKey: "e2b",
+      environmentId: "env-1",
+      leaseId: "lease-1",
+      remoteCwd,
+      runner: createLocalSandboxRunner(),
+      timeoutMs: 30_000,
+    };
+
+    const bridge = await startAdapterExecutionTargetPaperclipBridge({
+      runId: "run-bridge-listen-port",
+      target,
+      runtimeRootDir,
+      adapterKey: "codex",
+      hostApiToken: "real-run-jwt",
+    });
+    try {
+      const response = await fetch(`${bridge!.env.PAPERCLIP_API_URL}/api/agents/me`, {
+        headers: {
+          authorization: `Bearer ${bridge!.env.PAPERCLIP_API_KEY}`,
+          accept: "application/json",
+        },
+      });
+
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual({ ok: true });
+      expect(requests).toEqual([{
+        method: "GET",
+        url: "/api/agents/me",
+        auth: "Bearer real-run-jwt",
+        runId: "run-bridge-listen-port",
+      }]);
+    } finally {
+      await bridge?.stop();
+      await new Promise<void>((resolve) => apiServer.close(() => resolve()));
+    }
+  });
+
   it("uses the effective adapter timeout when starting the sandbox callback bridge", async () => {
     const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-execution-target-bridge-timeout-"));
     cleanupDirs.push(rootDir);

--- a/packages/adapter-utils/src/execution-target.ts
+++ b/packages/adapter-utils/src/execution-target.ts
@@ -177,6 +177,42 @@ function resolveDefaultPaperclipApiUrl(): string {
   return `http://${runtimeHost}:${runtimePort}`;
 }
 
+function parseRuntimeApiCandidateUrls(rawValue: string | undefined): string[] {
+  if (!rawValue) return [];
+  try {
+    const parsed = JSON.parse(rawValue) as unknown;
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((value): value is string => typeof value === "string" && value.trim().length > 0);
+  } catch {
+    return [];
+  }
+}
+
+function isLoopbackRuntimeUrl(rawUrl: string): boolean {
+  try {
+    const hostname = new URL(rawUrl).hostname.toLowerCase();
+    return hostname === "127.0.0.1" || hostname === "localhost" || hostname === "::1";
+  } catch {
+    return false;
+  }
+}
+
+function resolveBridgeHostApiUrl(input: { explicitHostApiUrl?: string | null | undefined }): string {
+  const explicit = input.explicitHostApiUrl?.trim();
+  if (explicit) return explicit;
+
+  const localCandidate = parseRuntimeApiCandidateUrls(process.env.PAPERCLIP_RUNTIME_API_CANDIDATES_JSON)
+    .find(isLoopbackRuntimeUrl);
+  if (localCandidate) return localCandidate;
+  if (process.env.PAPERCLIP_LISTEN_HOST?.trim() || process.env.PAPERCLIP_LISTEN_PORT?.trim() || process.env.PORT?.trim()) {
+    return resolveDefaultPaperclipApiUrl();
+  }
+  return localCandidate ??
+    process.env.PAPERCLIP_RUNTIME_API_URL?.trim() ??
+    process.env.PAPERCLIP_API_URL?.trim() ??
+    resolveDefaultPaperclipApiUrl();
+}
+
 function isBridgeDebugEnabled(env: NodeJS.ProcessEnv): boolean {
   const value = env.PAPERCLIP_BRIDGE_DEBUG?.trim().toLowerCase();
   return value === "1" || value === "true" || value === "yes";
@@ -1655,11 +1691,7 @@ export async function startAdapterExecutionTargetPaperclipBridge(input: {
     typeof input.maxBodyBytes === "number" && Number.isFinite(input.maxBodyBytes) && input.maxBodyBytes > 0
       ? Math.trunc(input.maxBodyBytes)
       : DEFAULT_SANDBOX_CALLBACK_BRIDGE_MAX_BODY_BYTES;
-  const hostApiUrl =
-    input.hostApiUrl?.trim() ||
-    process.env.PAPERCLIP_RUNTIME_API_URL?.trim() ||
-    process.env.PAPERCLIP_API_URL?.trim() ||
-    resolveDefaultPaperclipApiUrl();
+  const hostApiUrl = resolveBridgeHostApiUrl({ explicitHostApiUrl: input.hostApiUrl });
   const shellCommand = adapterExecutionTargetShellCommand(target);
   const runner = adapterExecutionTargetCommandRunner(target);
   const bridgeTimeoutMs =

--- a/packages/adapter-utils/src/execution-target.ts
+++ b/packages/adapter-utils/src/execution-target.ts
@@ -204,7 +204,7 @@ function resolveBridgeHostApiUrl(input: { explicitHostApiUrl?: string | null | u
   const localCandidate = parseRuntimeApiCandidateUrls(process.env.PAPERCLIP_RUNTIME_API_CANDIDATES_JSON)
     .find(isLoopbackRuntimeUrl);
   if (localCandidate) return localCandidate;
-  if (process.env.PAPERCLIP_LISTEN_HOST?.trim() || process.env.PAPERCLIP_LISTEN_PORT?.trim() || process.env.PORT?.trim()) {
+  if (process.env.PAPERCLIP_LISTEN_HOST?.trim() || process.env.PAPERCLIP_LISTEN_PORT?.trim()) {
     return resolveDefaultPaperclipApiUrl();
   }
   return localCandidate ??

--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -1817,7 +1817,30 @@ export function buildInvocationEnvForLogs(
   return redactEnvForLogs(merged);
 }
 
-export function buildPaperclipEnv(agent: { id: string; companyId: string }): Record<string, string> {
+function parseRuntimeApiCandidateUrls(rawValue: string | undefined): string[] {
+  if (!rawValue?.trim()) return [];
+  try {
+    const parsed = JSON.parse(rawValue);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((value): value is string => typeof value === "string" && value.trim().length > 0);
+  } catch {
+    return [];
+  }
+}
+
+function isLoopbackRuntimeUrl(rawUrl: string): boolean {
+  try {
+    const hostname = new URL(rawUrl).hostname.toLowerCase();
+    return hostname === "127.0.0.1" || hostname === "localhost" || hostname === "::1";
+  } catch {
+    return false;
+  }
+}
+
+export function buildPaperclipEnv(
+  agent: { id: string; companyId: string },
+  options: { preferLocalRuntimeUrl?: boolean } = {},
+): Record<string, string> {
   const resolveHostForUrl = (rawHost: string): string => {
     const host = rawHost.trim();
     if (!host || host === "0.0.0.0" || host === "::") return "localhost";
@@ -1832,7 +1855,18 @@ export function buildPaperclipEnv(agent: { id: string; companyId: string }): Rec
     process.env.PAPERCLIP_LISTEN_HOST ?? process.env.HOST ?? "localhost",
   );
   const runtimePort = process.env.PAPERCLIP_LISTEN_PORT ?? process.env.PORT ?? "3100";
+  const localRuntimeApiUrl = (() => {
+    if (!options.preferLocalRuntimeUrl) return null;
+    const localCandidate = parseRuntimeApiCandidateUrls(process.env.PAPERCLIP_RUNTIME_API_CANDIDATES_JSON)
+      .find(isLoopbackRuntimeUrl);
+    if (localCandidate) return localCandidate;
+    if (process.env.PAPERCLIP_LISTEN_HOST || process.env.PAPERCLIP_LISTEN_PORT) {
+      return `http://${runtimeHost}:${runtimePort}`;
+    }
+    return null;
+  })();
   const apiUrl =
+    localRuntimeApiUrl ??
     process.env.PAPERCLIP_RUNTIME_API_URL ??
     process.env.PAPERCLIP_API_URL ??
     `http://${runtimeHost}:${runtimePort}`;

--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -203,7 +203,7 @@ async function buildClaudeRuntimeConfig(input: ClaudeExecutionInput): Promise<Cl
   const envConfig = parseObject(config.env);
   const hasExplicitApiKey =
     typeof envConfig.PAPERCLIP_API_KEY === "string" && envConfig.PAPERCLIP_API_KEY.trim().length > 0;
-  const env: Record<string, string> = { ...buildPaperclipEnv(agent) };
+  const env: Record<string, string> = { ...buildPaperclipEnv(agent, { preferLocalRuntimeUrl: true }) };
   env.PAPERCLIP_RUN_ID = runId;
 
   const wakeTaskId =

--- a/packages/adapters/codex-local/src/server/execute.ts
+++ b/packages/adapters/codex-local/src/server/execute.ts
@@ -567,7 +567,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     for (const note of preparedRuntimeConfig.notes) {
       await onLog("stdout", `[paperclip] ${note}\n`);
     }
-    const paperclipBaseEnv = buildPaperclipEnv(agent);
+    const paperclipBaseEnv = buildPaperclipEnv(agent, { preferLocalRuntimeUrl: true });
     const runtimeMcpGateways = (ctx.runtimeMcp?.getServers() ?? []).map((server) => ({
       name: server.name,
       endpointPath: server.url,

--- a/packages/adapters/cursor-local/src/server/execute.ts
+++ b/packages/adapters/cursor-local/src/server/execute.ts
@@ -239,7 +239,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const envConfig = parseObject(config.env);
   const hasExplicitApiKey =
     typeof envConfig.PAPERCLIP_API_KEY === "string" && envConfig.PAPERCLIP_API_KEY.trim().length > 0;
-  let env: Record<string, string> = { ...buildPaperclipEnv(agent) };
+  let env: Record<string, string> = { ...buildPaperclipEnv(agent, { preferLocalRuntimeUrl: true }) };
   env.PAPERCLIP_RUN_ID = runId;
   const wakeTaskId =
     (typeof context.taskId === "string" && context.taskId.trim().length > 0 && context.taskId.trim()) ||

--- a/packages/adapters/gemini-local/src/server/execute.ts
+++ b/packages/adapters/gemini-local/src/server/execute.ts
@@ -261,7 +261,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const envConfig = parseObject(config.env);
   const hasExplicitApiKey =
     typeof envConfig.PAPERCLIP_API_KEY === "string" && envConfig.PAPERCLIP_API_KEY.trim().length > 0;
-  const env: Record<string, string> = { ...buildPaperclipEnv(agent) };
+  const env: Record<string, string> = { ...buildPaperclipEnv(agent, { preferLocalRuntimeUrl: true }) };
   env.PAPERCLIP_RUN_ID = runId;
   const wakeTaskId =
     (typeof context.taskId === "string" && context.taskId.trim().length > 0 && context.taskId.trim()) ||

--- a/packages/adapters/grok-local/src/server/execute.ts
+++ b/packages/adapters/grok-local/src/server/execute.ts
@@ -244,7 +244,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     const envConfig = parseObject(config.env);
     const hasExplicitApiKey =
       typeof envConfig.PAPERCLIP_API_KEY === "string" && envConfig.PAPERCLIP_API_KEY.trim().length > 0;
-    const env: Record<string, string> = { ...buildPaperclipEnv(agent) };
+    const env: Record<string, string> = { ...buildPaperclipEnv(agent, { preferLocalRuntimeUrl: true }) };
     env.PAPERCLIP_RUN_ID = runId;
     const wakeTaskId =
       (typeof context.taskId === "string" && context.taskId.trim().length > 0 && context.taskId.trim()) ||

--- a/packages/adapters/opencode-local/src/server/execute.ts
+++ b/packages/adapters/opencode-local/src/server/execute.ts
@@ -254,7 +254,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const envConfig = parseObject(config.env);
   const hasExplicitApiKey =
     typeof envConfig.PAPERCLIP_API_KEY === "string" && envConfig.PAPERCLIP_API_KEY.trim().length > 0;
-  const env: Record<string, string> = { ...buildPaperclipEnv(agent) };
+  const env: Record<string, string> = { ...buildPaperclipEnv(agent, { preferLocalRuntimeUrl: true }) };
   env.PAPERCLIP_RUN_ID = runId;
   const wakeTaskId =
     (typeof context.taskId === "string" && context.taskId.trim().length > 0 && context.taskId.trim()) ||

--- a/packages/adapters/pi-local/src/server/execute.ts
+++ b/packages/adapters/pi-local/src/server/execute.ts
@@ -266,7 +266,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const envConfig = parseObject(config.env);
   const hasExplicitApiKey =
     typeof envConfig.PAPERCLIP_API_KEY === "string" && envConfig.PAPERCLIP_API_KEY.trim().length > 0;
-  const env: Record<string, string> = { ...buildPaperclipEnv(agent) };
+  const env: Record<string, string> = { ...buildPaperclipEnv(agent, { preferLocalRuntimeUrl: true }) };
   env.PAPERCLIP_RUN_ID = runId;
 
   const wakeTaskId =

--- a/server/src/__tests__/paperclip-env.test.ts
+++ b/server/src/__tests__/paperclip-env.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { buildPaperclipEnv } from "../adapters/utils.js";
 
 const ORIGINAL_PAPERCLIP_RUNTIME_API_URL = process.env.PAPERCLIP_RUNTIME_API_URL;
+const ORIGINAL_PAPERCLIP_RUNTIME_API_CANDIDATES_JSON = process.env.PAPERCLIP_RUNTIME_API_CANDIDATES_JSON;
 const ORIGINAL_PAPERCLIP_API_URL = process.env.PAPERCLIP_API_URL;
 const ORIGINAL_PAPERCLIP_LISTEN_HOST = process.env.PAPERCLIP_LISTEN_HOST;
 const ORIGINAL_PAPERCLIP_LISTEN_PORT = process.env.PAPERCLIP_LISTEN_PORT;
@@ -11,6 +12,12 @@ const ORIGINAL_PORT = process.env.PORT;
 afterEach(() => {
   if (ORIGINAL_PAPERCLIP_RUNTIME_API_URL === undefined) delete process.env.PAPERCLIP_RUNTIME_API_URL;
   else process.env.PAPERCLIP_RUNTIME_API_URL = ORIGINAL_PAPERCLIP_RUNTIME_API_URL;
+
+  if (ORIGINAL_PAPERCLIP_RUNTIME_API_CANDIDATES_JSON === undefined) {
+    delete process.env.PAPERCLIP_RUNTIME_API_CANDIDATES_JSON;
+  } else {
+    process.env.PAPERCLIP_RUNTIME_API_CANDIDATES_JSON = ORIGINAL_PAPERCLIP_RUNTIME_API_CANDIDATES_JSON;
+  }
 
   if (ORIGINAL_PAPERCLIP_API_URL === undefined) delete process.env.PAPERCLIP_API_URL;
   else process.env.PAPERCLIP_API_URL = ORIGINAL_PAPERCLIP_API_URL;
@@ -38,6 +45,60 @@ describe("buildPaperclipEnv", () => {
     const env = buildPaperclipEnv({ id: "agent-1", companyId: "company-1" });
 
     expect(env.PAPERCLIP_API_URL).toBe("http://203.0.113.42:3102");
+  });
+
+  it("prefers a loopback runtime candidate for local adapter execution", () => {
+    process.env.PAPERCLIP_RUNTIME_API_URL = "http://stale-tailnet.example.test:3101";
+    process.env.PAPERCLIP_API_URL = "http://stale-tailnet.example.test:3101";
+    process.env.PAPERCLIP_RUNTIME_API_CANDIDATES_JSON = JSON.stringify([
+      "http://stale-tailnet.example.test:3101",
+      "http://127.0.0.1:3101",
+      "http://100.103.164.67:3101",
+    ]);
+    process.env.PAPERCLIP_LISTEN_HOST = "0.0.0.0";
+    process.env.PAPERCLIP_LISTEN_PORT = "3101";
+
+    const env = buildPaperclipEnv(
+      { id: "agent-1", companyId: "company-1" },
+      { preferLocalRuntimeUrl: true },
+    );
+
+    expect(env.PAPERCLIP_API_URL).toBe("http://127.0.0.1:3101");
+  });
+
+  it("synthesizes a local runtime URL when no loopback candidate is exported", () => {
+    process.env.PAPERCLIP_RUNTIME_API_URL = "http://stale-tailnet.example.test:3101";
+    process.env.PAPERCLIP_RUNTIME_API_CANDIDATES_JSON = JSON.stringify([
+      "http://stale-tailnet.example.test:3101",
+      "http://100.103.164.67:3101",
+    ]);
+    process.env.PAPERCLIP_LISTEN_HOST = "0.0.0.0";
+    process.env.PAPERCLIP_LISTEN_PORT = "3101";
+
+    const env = buildPaperclipEnv(
+      { id: "agent-1", companyId: "company-1" },
+      { preferLocalRuntimeUrl: true },
+    );
+
+    expect(env.PAPERCLIP_API_URL).toBe("http://localhost:3101");
+  });
+
+  it("uses the injected listener host when the runtime is bound to a private address", () => {
+    process.env.PAPERCLIP_RUNTIME_API_URL = "http://stale-tailnet.example.test:3101";
+    process.env.PAPERCLIP_API_URL = "http://stale-tailnet.example.test:3101";
+    process.env.PAPERCLIP_RUNTIME_API_CANDIDATES_JSON = JSON.stringify([
+      "http://stale-tailnet.example.test:3101",
+      "http://100.103.164.67:3101",
+    ]);
+    process.env.PAPERCLIP_LISTEN_HOST = "100.103.164.67";
+    process.env.PAPERCLIP_LISTEN_PORT = "3101";
+
+    const env = buildPaperclipEnv(
+      { id: "agent-1", companyId: "company-1" },
+      { preferLocalRuntimeUrl: true },
+    );
+
+    expect(env.PAPERCLIP_API_URL).toBe("http://100.103.164.67:3101");
   });
 
   it("falls back to PAPERCLIP_API_URL when no runtime URL is configured", () => {

--- a/server/src/__tests__/runtime-api.test.ts
+++ b/server/src/__tests__/runtime-api.test.ts
@@ -71,6 +71,8 @@ describe("runtime API discovery", () => {
       "http://198.51.100.10:3102",
       "http://runtime-host.example.test:3102",
       "http://203.0.113.42:3102",
+      "http://localhost:3102",
+      "http://127.0.0.1:3102",
     ]);
   });
 
@@ -88,6 +90,8 @@ describe("runtime API discovery", () => {
       "https://agent-entry.example.test",
       "https://paperclip.example.test",
       "https://198.51.100.10:3102",
+      "http://localhost:3102",
+      "http://127.0.0.1:3102",
     ]);
   });
 

--- a/server/src/adapters/process/execute.ts
+++ b/server/src/adapters/process/execute.ts
@@ -20,7 +20,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const cwd = asString(config.cwd, process.cwd());
   const envConfig = parseObject(config.env);
   const env: Record<string, string> = {
-    ...buildPaperclipEnv(agent),
+    ...buildPaperclipEnv(agent, { preferLocalRuntimeUrl: true }),
   };
   for (const [k, v] of Object.entries(envConfig)) {
     if (typeof v === "string") env[k] = v;

--- a/server/src/runtime-api.ts
+++ b/server/src/runtime-api.ts
@@ -142,6 +142,10 @@ export function buildRuntimeApiCandidateUrls(input: {
   if (bindHost && !isWildcardHost(bindHost)) {
     pushCandidate(candidates, seen, formatOrigin(protocol, bindHost, input.port));
   }
+  if (!bindHost || isWildcardHost(bindHost)) {
+    pushCandidate(candidates, seen, formatOrigin("http:", "localhost", input.port));
+    pushCandidate(candidates, seen, formatOrigin("http:", "127.0.0.1", input.port));
+  }
 
   if (explicitOrigin) {
     const hostname = new URL(explicitOrigin).hostname;


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Local adapters inject Paperclip control-plane environment variables so an agent can read and update its task while it runs.
> - Private or tailnet deployments can expose more than one server origin: a configured external URL for humans, and a listener URL that is reachable from the runtime process.
> - When the configured external hostname is stale or unreachable from an adapter runtime, agents can incorrectly treat the control plane as unavailable even though the server is reachable through the listener path.
> - This pull request teaches local adapter env construction and sandbox bridge forwarding to prefer reachable runtime candidates when they are available.
> - The benefit is that local and sandbox-backed heartbeats keep using the Paperclip API without manual fallback URLs when the public/private hostname path is unavailable.

## Linked Issues or Issue Description

Bug report:

### Pre-submission checklist

- [x] I have searched existing open and closed issues and this is not a duplicate.
- [x] I am on the latest `master` branch for this fix.
- [x] I have confirmed the error originates in Paperclip itself, not an API provider.

### What happened?

Local adapter runs could receive a `PAPERCLIP_API_URL` pointing at a configured external hostname that was not reachable from the runtime, while another runtime listener origin was reachable.

### Expected behavior

Local adapter runs should use the most directly reachable runtime API URL available to the server process or runtime environment.

### Steps to reproduce

1. Run Paperclip with a private or tailnet-style configured API URL plus listener host/port metadata.
2. Execute a local adapter heartbeat from an environment where the configured hostname is unreachable but the listener origin is reachable.
3. Observe that agent API calls using the injected `PAPERCLIP_API_URL` fail even though the server is reachable through the listener origin.

### Paperclip version or commit

Reproduced on a local deployment before this branch; fixed against current `master`.

### Deployment mode

Self-hosted server / local private deployment.

### Installation method

Built from source.

### Agent adapter(s) involved

Codex and other local adapters that use the shared Paperclip env builder.

### Database mode

Not database-related.

### Access context

Agent bearer API key via local adapter heartbeat environment.

### Node.js version

Node.js 22.16.0 was used for local verification.

### Operating system

macOS local development environment.

### Relevant logs or output

The failure mode is a connection timeout to the configured API hostname while the runtime listener origin succeeds. Exact private hostnames and IPs are intentionally omitted from this public PR.

## What Changed

- Export loopback listener candidates for wildcard binds so local runtimes can prefer them over less reliable external hostnames.
- Add a `preferLocalRuntimeUrl` path to local adapter Paperclip env construction.
- Update local/process adapters to request the reachable runtime URL preference.
- Make sandbox callback bridge forwarding prefer loopback candidates and otherwise fall back through resolved listen-host URL logic.
- Add regression coverage for stale external API URLs, private listener-host fallback, and sandbox bridge host forwarding.

## Verification

- `pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm exec vitest run server/src/__tests__/paperclip-env.test.ts server/src/__tests__/runtime-api.test.ts packages/adapter-utils/src/execution-target-sandbox.test.ts -t "prefers a loopback runtime candidate|synthesizes a loopback host URL|buildPaperclipEnv|runtime API discovery"`
- Also tried the full `packages/adapter-utils/src/execution-target-sandbox.test.ts` file; all 19 assertions passed, but Vitest exited nonzero due to an unrelated post-test `write EPIPE` from the existing log-streaming test teardown.

## Risks

- Low to medium risk: changes are scoped to adapter-injected API URLs and sandbox bridge forwarding.
- Operators who intentionally rely on an external `PAPERCLIP_API_URL` inside local adapter environments may now see the adapter use a listener/loopback URL when the adapter requests local preference.
- Non-local/cloud adapter env construction keeps the existing default behavior.

## Model Used

OpenAI GPT-5 Codex, coding-agent mode with shell and git tooling.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge
