### PR TITLE
Fix resolved blocker wake reconciliation

### DIFF
--- a/server/src/__tests__/heartbeat-issue-liveness-escalation.test.ts
+++ b/server/src/__tests__/heartbeat-issue-liveness-escalation.test.ts
@@ -212,6 +212,7 @@ describeEmbeddedPostgres("heartbeat issue graph liveness escalation", () => {
 
   async function seedResolvedDependencyBackstopFixture(opts: {
     workspaceState?: "none" | "not_finalized" | "finalized";
+    assignee?: "agent" | null;
   } = {}) {
     const workspaceState = opts.workspaceState ?? "none";
     const companyId = randomUUID();
@@ -283,7 +284,7 @@ describeEmbeddedPostgres("heartbeat issue graph liveness escalation", () => {
         title: "Synthetic blocked dependent",
         status: "blocked",
         priority: "medium",
-        assigneeAgentId: agentId,
+        assigneeAgentId: opts.assignee === null ? null : agentId,
         issueNumber: 1,
         identifier: `${issuePrefix}-1`,
       },
@@ -350,6 +351,43 @@ describeEmbeddedPostgres("heartbeat issue graph liveness escalation", () => {
     expect(escalations).toHaveLength(0);
   });
 
+  it("keeps resolved dependency wake reconciliation active when liveness auto recovery is disabled", async () => {
+    const { companyId, agentId, blockedIssueId, blockerIssueId } =
+      await seedResolvedDependencyBackstopFixture({ workspaceState: "none" });
+
+    const result = await heartbeatService(db).reconcileIssueGraphLiveness();
+
+    expect(result.autoRecoveryEnabled).toBe(false);
+    expect(result.dependencyWakesHealed).toBe(1);
+    expect(result.dependencyWakeIssueIds).toEqual([blockedIssueId]);
+    expect(result.escalationsCreated).toBe(0);
+
+    const wake = await db
+      .select({
+        status: agentWakeupRequests.status,
+        reason: agentWakeupRequests.reason,
+        idempotencyKey: agentWakeupRequests.idempotencyKey,
+      })
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.agentId, agentId))
+      .orderBy(agentWakeupRequests.requestedAt)
+      .then((rows) => rows[0] ?? null);
+
+    expect(wake?.reason).toBe("issue_blockers_resolved");
+    expect(wake?.idempotencyKey).toBe(`issue_blockers_resolved:${blockedIssueId}:${blockerIssueId}`);
+    expect(["queued", "claimed", "completed"]).toContain(wake?.status);
+
+    const events = await db
+      .select({ action: activityLog.action, entityId: activityLog.entityId, details: activityLog.details })
+      .from(activityLog)
+      .where(and(eq(activityLog.companyId, companyId), eq(activityLog.action, "issue.blockers_resolved_wake_emitted")));
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      entityId: blockedIssueId,
+      details: expect.objectContaining({ source: "issue_graph_liveness.backstop" }),
+    });
+  });
+
   it("heals a blocked dependent whose done blocker has no workspace finalize obligation", async () => {
     await enableAutoRecovery();
     const { companyId, agentId, blockedIssueId, blockerIssueId } =
@@ -383,6 +421,83 @@ describeEmbeddedPostgres("heartbeat issue graph liveness escalation", () => {
       .where(and(eq(activityLog.companyId, companyId), eq(activityLog.action, "issue.blockers_resolved_wake_emitted")));
     expect(events).toHaveLength(1);
     expect(events[0]).toMatchObject({ entityId: blockedIssueId });
+  });
+
+  it("reconciles a resolved blocked dependency after the assignee-null window closes", async () => {
+    const { agentId, blockedIssueId, blockerIssueId } =
+      await seedResolvedDependencyBackstopFixture({ workspaceState: "none", assignee: null });
+    const heartbeat = heartbeatService(db);
+
+    const beforeAssignment = await heartbeat.reconcileIssueGraphLiveness();
+
+    expect(beforeAssignment.dependencyWakesHealed).toBe(0);
+    expect(beforeAssignment.dependencyWakeBackstopChecked).toBe(0);
+
+    await db
+      .update(issues)
+      .set({ assigneeAgentId: agentId, updatedAt: new Date() })
+      .where(eq(issues.id, blockedIssueId));
+
+    const afterAssignment = await heartbeat.reconcileIssueGraphLiveness();
+
+    expect(afterAssignment.dependencyWakesHealed).toBe(1);
+    expect(afterAssignment.dependencyWakeIssueIds).toEqual([blockedIssueId]);
+
+    const wake = await db
+      .select({
+        reason: agentWakeupRequests.reason,
+        idempotencyKey: agentWakeupRequests.idempotencyKey,
+      })
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.agentId, agentId))
+      .orderBy(agentWakeupRequests.requestedAt)
+      .then((rows) => rows[0] ?? null);
+    expect(wake).toMatchObject({
+      reason: "issue_blockers_resolved",
+      idempotencyKey: `issue_blockers_resolved:${blockedIssueId}:${blockerIssueId}`,
+    });
+  });
+
+  it("retries a resolved dependency wake when the prior wake was skipped as stale", async () => {
+    const { companyId, agentId, blockedIssueId, blockerIssueId } =
+      await seedResolvedDependencyBackstopFixture({ workspaceState: "none" });
+    const idempotencyKey = `issue_blockers_resolved:${blockedIssueId}:${blockerIssueId}`;
+    await db.insert(agentWakeupRequests).values({
+      companyId,
+      agentId,
+      source: "automation",
+      triggerDetail: "system",
+      reason: "issue_blockers_resolved",
+      payload: {
+        issueId: blockedIssueId,
+        resolvedBlockerIssueId: blockerIssueId,
+        blockerIssueIds: [blockerIssueId],
+      },
+      status: "skipped",
+      finishedAt: new Date(),
+      error: "Cancelled because issue assignee changed before the queued run could start",
+      idempotencyKey,
+    });
+
+    const result = await heartbeatService(db).reconcileIssueGraphLiveness();
+
+    expect(result.dependencyWakesHealed).toBe(1);
+    expect(result.dependencyWakeExistingSkipped).toBe(0);
+
+    const wakes = await db
+      .select({
+        status: agentWakeupRequests.status,
+        reason: agentWakeupRequests.reason,
+        idempotencyKey: agentWakeupRequests.idempotencyKey,
+      })
+      .from(agentWakeupRequests)
+      .where(and(eq(agentWakeupRequests.companyId, companyId), eq(agentWakeupRequests.reason, "issue_blockers_resolved")))
+      .orderBy(agentWakeupRequests.requestedAt);
+
+    expect(wakes).toHaveLength(2);
+    expect(wakes.map((wake) => wake.status)).toContain("skipped");
+    expect(wakes.every((wake) => wake.idempotencyKey === idempotencyKey)).toBe(true);
+    expect(wakes.some((wake) => ["queued", "claimed", "completed"].includes(wake.status))).toBe(true);
   });
 
   it("waits for workspace finalize before healing a resolved blocked dependent", async () => {

--- a/server/src/__tests__/heartbeat-workspace-finalize-branch.test.ts
+++ b/server/src/__tests__/heartbeat-workspace-finalize-branch.test.ts
@@ -280,6 +280,9 @@ describeEmbeddedPostgres("heartbeat workspace finalization branch guard", () => 
     await db.delete(environmentLeases);
     await db.delete(activityLog);
     await db.delete(heartbeatRunEvents);
+    // Heartbeat finalization can emit run-linked activity after the first
+    // cleanup pass observes all runs as non-active.
+    await db.delete(activityLog);
     await db.delete(heartbeatRuns);
     await db.delete(issueComments);
     await db.delete(issues);

--- a/server/src/__tests__/issue-dependency-wakeups-routes.test.ts
+++ b/server/src/__tests__/issue-dependency-wakeups-routes.test.ts
@@ -3,6 +3,7 @@ import request from "supertest";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockWakeup = vi.hoisted(() => vi.fn(async () => undefined));
+const mockFindExistingIssueBlockersResolvedWake = vi.hoisted(() => vi.fn(async () => null));
 const mockIssueService = vi.hoisted(() => ({
   getAncestors: vi.fn(),
   getById: vi.fn(),
@@ -11,6 +12,7 @@ const mockIssueService = vi.hoisted(() => ({
   getCommentCursor: vi.fn(),
   getRelationSummaries: vi.fn(),
   update: vi.fn(),
+  getDependencyReadiness: vi.fn(),
   listWakeableBlockedDependents: vi.fn(),
   getWakeableParentAfterChildCompletion: vi.fn(),
   findMentionedAgents: vi.fn(async () => []),
@@ -85,6 +87,16 @@ vi.mock("../services/index.js", () => ({
   }),
 }));
 
+vi.mock("../services/issue-dependency-wakeups.js", async () => {
+  const actual = await vi.importActual<typeof import("../services/issue-dependency-wakeups.js")>(
+    "../services/issue-dependency-wakeups.js",
+  );
+  return {
+    ...actual,
+    findExistingIssueBlockersResolvedWake: mockFindExistingIssueBlockersResolvedWake,
+  };
+});
+
 async function createApp() {
   const [{ issueRoutes }, { errorHandler }] = await Promise.all([
     vi.importActual<typeof import("../routes/issues.js")>("../routes/issues.js"),
@@ -114,6 +126,7 @@ describe("issue dependency wakeups in issue routes", () => {
     vi.doUnmock("../routes/authz.js");
     vi.doUnmock("../middleware/index.js");
     vi.clearAllMocks();
+    mockFindExistingIssueBlockersResolvedWake.mockResolvedValue(null);
     mockIssueService.getAncestors.mockResolvedValue([]);
     mockIssueService.getComment.mockResolvedValue(null);
     mockIssueService.getCommentCursor.mockResolvedValue({
@@ -122,6 +135,15 @@ describe("issue dependency wakeups in issue routes", () => {
       latestCommentAt: null,
     });
     mockIssueService.getRelationSummaries.mockResolvedValue({ blockedBy: [], blocks: [] });
+    mockIssueService.getDependencyReadiness.mockResolvedValue({
+      issueId: "issue-1",
+      blockerIssueIds: [],
+      unresolvedBlockerIssueIds: [],
+      unresolvedBlockerCount: 0,
+      pendingFinalizeBlockerIssueIds: [],
+      allBlockersDone: true,
+      isDependencyReady: true,
+    });
     mockIssueService.listWakeableBlockedDependents.mockResolvedValue([]);
     mockIssueService.getWakeableParentAfterChildCompletion.mockResolvedValue(null);
   });
@@ -179,6 +201,76 @@ describe("issue dependency wakeups in issue routes", () => {
           payload: expect.objectContaining({
             issueId: "issue-2",
             resolvedBlockerIssueId: "issue-1",
+          }),
+        }),
+      );
+    });
+  });
+
+  it("wakes an assigned blocked issue when blockers are applied after the blocker is already done", async () => {
+    const parentIssueId = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+    const childIssueId = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+    mockIssueService.getById.mockResolvedValue({
+      id: parentIssueId,
+      companyId: "company-1",
+      identifier: "PAP-200",
+      title: "Blocked after completion",
+      description: null,
+      status: "todo",
+      priority: "medium",
+      parentId: null,
+      assigneeAgentId: "agent-2",
+      assigneeUserId: null,
+      createdByAgentId: null,
+      createdByUserId: null,
+      executionWorkspaceId: null,
+      labels: [],
+      labelIds: [],
+    });
+    mockIssueService.update.mockResolvedValue({
+      id: parentIssueId,
+      companyId: "company-1",
+      identifier: "PAP-200",
+      title: "Blocked after completion",
+      description: null,
+      status: "blocked",
+      priority: "medium",
+      parentId: null,
+      assigneeAgentId: "agent-2",
+      assigneeUserId: null,
+      createdByAgentId: null,
+      createdByUserId: null,
+      executionWorkspaceId: null,
+      labels: [],
+      labelIds: [],
+    });
+    mockIssueService.getDependencyReadiness.mockResolvedValue({
+      issueId: parentIssueId,
+      blockerIssueIds: [childIssueId],
+      unresolvedBlockerIssueIds: [],
+      unresolvedBlockerCount: 0,
+      pendingFinalizeBlockerIssueIds: [],
+      allBlockersDone: true,
+      isDependencyReady: true,
+    });
+
+    const res = await request(await createApp())
+      .patch(`/api/issues/${parentIssueId}`)
+      .send({ status: "blocked", blockedByIssueIds: [childIssueId] });
+
+    expect(res.status).toBe(200);
+    await vi.waitFor(() => {
+      expect(mockWakeup).toHaveBeenCalledWith(
+        "agent-2",
+        expect.objectContaining({
+          reason: "issue_blockers_resolved",
+          payload: expect.objectContaining({
+            issueId: parentIssueId,
+            resolvedBlockerIssueId: childIssueId,
+            mutation: "blocked_dependency_restored",
+          }),
+          contextSnapshot: expect.objectContaining({
+            source: "issue.blockers_restored",
           }),
         }),
       );

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -113,8 +113,6 @@ import {
 import { issueService } from "./issues.js";
 import {
   ISSUE_BLOCKERS_RESOLVED_WAKE_REASON,
-  buildIssueBlockersResolvedWakeIdempotencyKey,
-  findExistingIssueBlockersResolvedWake,
 } from "./issue-dependency-wakeups.js";
 import {
   buildIssueMonitorClearedPatch,
@@ -12171,11 +12169,9 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
 
         // Dependency wake re-check: if this run's issue was marked done mid-run,
         // the route-time `issue_blockers_resolved` wake may have been gated by
-        // workspace finalization or merged into this run. Re-evaluate after any
-        // run completion, including failed adapter outcomes; this is safe because
-        // `listWakeableBlockedDependents` delegates to dependency readiness, which
-        // only returns dependents whose done blockers have crossed the successful
-        // `workspace_finalize` barrier.
+        // workspace finalization or merged into this run. Reuse the level-triggered
+        // dependency backstop so finalize and periodic recovery share idempotency,
+        // readiness, active-path, and observability rules.
         if (issueId && finalizedRun) {
           try {
             const blockerIssueStatus = await db
@@ -12184,63 +12180,12 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
               .where(eq(issues.id, issueId))
               .then((rows) => rows[0]?.status ?? null);
             if (blockerIssueStatus === "done") {
-              const dependents = await issuesSvc.listWakeableBlockedDependents(issueId);
-              for (const dependent of dependents) {
-                const idempotencyKey = buildIssueBlockersResolvedWakeIdempotencyKey({
-                  dependentIssueId: dependent.id,
-                  resolvedBlockerIssueId: issueId,
-                });
-                const existingWake = await findExistingIssueBlockersResolvedWake(db, {
-                  companyId: finalizedRun.companyId,
-                  idempotencyKey,
-                });
-                if (existingWake) continue;
-                await enqueueWakeup(dependent.assigneeAgentId, {
-                  source: "automation",
-                  triggerDetail: "system",
-                  reason: ISSUE_BLOCKERS_RESOLVED_WAKE_REASON,
-                  payload: {
-                    issueId: dependent.id,
-                    resolvedBlockerIssueId: issueId,
-                    blockerIssueIds: dependent.blockerIssueIds,
-                    deferredFor: "workspace_finalize",
-                  },
-                  idempotencyKey,
-                  requestedByActorType: "system",
-                  requestedByActorId: "heartbeat_finalize",
-                  contextSnapshot: {
-                    issueId: dependent.id,
-                    taskId: dependent.id,
-                    wakeReason: ISSUE_BLOCKERS_RESOLVED_WAKE_REASON,
-                    source: "workspace.finalize",
-                    resolvedBlockerIssueId: issueId,
-                    blockerIssueIds: dependent.blockerIssueIds,
-                  },
-                }).then((wakeRun) =>
-                  logActivity(db, {
-                    companyId: finalizedRun.companyId,
-                    actorType: "system",
-                    actorId: "heartbeat_finalize",
-                    agentId: dependent.assigneeAgentId,
-                    runId: finalizedRun.id,
-                    action: "issue.blockers_resolved_wake_emitted",
-                    entityType: "issue",
-                    entityId: dependent.id,
-                    details: {
-                      source: "workspace.finalize",
-                      wakeupRunId: wakeRun?.id ?? null,
-                      idempotencyKey,
-                      resolvedBlockerIssueId: issueId,
-                      blockerIssueIds: dependent.blockerIssueIds,
-                    },
-                  })
-                ).catch((wakeErr) => {
-                  logger.warn(
-                    { err: wakeErr, issueId, dependentIssueId: dependent.id, agentId: dependent.assigneeAgentId },
-                    "failed to fire deferred dependent wake after workspace_finalize",
-                  );
-                });
-              }
+              await recovery.reconcileResolvedDependencyWakeBackstop({
+                runId: finalizedRun.id,
+                companyId: finalizedRun.companyId,
+                blockerIssueId: issueId,
+                source: "workspace.finalize",
+              });
             }
           } catch (finalizeWakeErr) {
             logger.warn(

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -118,6 +118,17 @@ type RecoveryWakeup = (
   opts?: RecoveryWakeupOptions,
 ) => Promise<typeof heartbeatRuns.$inferSelect | null>;
 
+type ResolvedDependencyWakeBackstopSource =
+  | "issue_graph_liveness.backstop"
+  | "workspace.finalize";
+
+type ResolvedDependencyWakeBackstopOptions = {
+  runId?: string | null;
+  companyId?: string | null;
+  blockerIssueId?: string | null;
+  source?: ResolvedDependencyWakeBackstopSource;
+};
+
 type LatestIssueRun = Pick<
   typeof heartbeatRuns.$inferSelect,
   "id" | "agentId" | "status" | "error" | "errorCode" | "contextSnapshot" | "livenessState"
@@ -4074,7 +4085,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     return { kind: "created" as const, escalationIssueId: escalation.id };
   }
 
-  async function reconcileResolvedDependencyWakeBackstop(opts?: { runId?: string | null }) {
+  async function reconcileResolvedDependencyWakeBackstop(opts?: ResolvedDependencyWakeBackstopOptions) {
     const result = {
       checked: 0,
       healed: 0,
@@ -4089,13 +4100,45 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       issueIds: [] as string[],
     };
 
+    const source = opts?.source ?? "issue_graph_liveness.backstop";
+    const requestedByActorId = source === "workspace.finalize"
+      ? "heartbeat_finalize"
+      : "issue_graph_liveness_backstop";
+    const payloadBackstop = source === "workspace.finalize"
+      ? "workspace_finalize_reconciliation"
+      : "issue_graph_liveness_reconciliation";
+    const useCursor = !opts?.blockerIssueId;
+
     const queryCandidates = (afterIssueId: string | null) => {
       const filters = [
         eq(issues.status, "blocked"),
         isNull(issues.hiddenAt),
         sql`${issues.assigneeAgentId} is not null`,
       ];
+      if (opts?.companyId) filters.push(eq(issues.companyId, opts.companyId));
       if (afterIssueId) filters.push(gt(issues.id, afterIssueId));
+
+      if (opts?.blockerIssueId) {
+        filters.push(
+          eq(issueRelations.companyId, issues.companyId),
+          eq(issueRelations.type, "blocks"),
+          eq(issueRelations.issueId, opts.blockerIssueId),
+          eq(issueRelations.relatedIssueId, issues.id),
+        );
+        return db
+          .select({
+            id: issues.id,
+            companyId: issues.companyId,
+            identifier: issues.identifier,
+            assigneeAgentId: issues.assigneeAgentId,
+            totalCount: sql<number>`count(*) over()::int`,
+          })
+          .from(issueRelations)
+          .innerJoin(issues, eq(issueRelations.relatedIssueId, issues.id))
+          .where(and(...filters))
+          .orderBy(asc(issues.id))
+          .limit(RESOLVED_DEPENDENCY_WAKE_BACKSTOP_CANDIDATE_LIMIT);
+      }
 
       return db
         .select({
@@ -4111,8 +4154,8 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         .limit(RESOLVED_DEPENDENCY_WAKE_BACKSTOP_CANDIDATE_LIMIT);
     };
 
-    let candidateRows = await queryCandidates(resolvedDependencyWakeBackstopCandidateCursor);
-    if (candidateRows.length === 0 && resolvedDependencyWakeBackstopCandidateCursor) {
+    let candidateRows = await queryCandidates(useCursor ? resolvedDependencyWakeBackstopCandidateCursor : null);
+    if (useCursor && candidateRows.length === 0 && resolvedDependencyWakeBackstopCandidateCursor) {
       resolvedDependencyWakeBackstopCandidateCursor = null;
       candidateRows = await queryCandidates(null);
     }
@@ -4121,15 +4164,19 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     result.checked = candidates.length;
     result.candidateLimitSkipped = Math.max(0, totalCandidateCount - candidates.length);
     const lastCandidate = candidates[candidates.length - 1] ?? null;
-    resolvedDependencyWakeBackstopCandidateCursor =
-      result.candidateLimitSkipped > 0 && lastCandidate ? lastCandidate.id : null;
+    if (useCursor) {
+      resolvedDependencyWakeBackstopCandidateCursor =
+        result.candidateLimitSkipped > 0 && lastCandidate ? lastCandidate.id : null;
+    }
     if (result.candidateLimitSkipped > 0) {
       logger.warn(
         {
           processed: candidates.length,
           skipped: result.candidateLimitSkipped,
           limit: RESOLVED_DEPENDENCY_WAKE_BACKSTOP_CANDIDATE_LIMIT,
-          nextCursor: resolvedDependencyWakeBackstopCandidateCursor,
+          nextCursor: useCursor ? resolvedDependencyWakeBackstopCandidateCursor : null,
+          source,
+          blockerIssueId: opts?.blockerIssueId ?? null,
         },
         "issue graph liveness backstop deferred resolved dependency wake candidates past page limit",
       );
@@ -4210,16 +4257,16 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
               issueId: candidate.id,
               resolvedBlockerIssueId,
               blockerIssueIds: readiness.blockerIssueIds,
-              backstop: "issue_graph_liveness_reconciliation",
+              backstop: payloadBackstop,
             },
             idempotencyKey,
             requestedByActorType: "system",
-            requestedByActorId: "issue_graph_liveness_backstop",
+            requestedByActorId,
             contextSnapshot: {
               issueId: candidate.id,
               taskId: candidate.id,
               wakeReason: ISSUE_BLOCKERS_RESOLVED_WAKE_REASON,
-              source: "issue_graph_liveness.backstop",
+              source,
               resolvedBlockerIssueId,
               blockerIssueIds: readiness.blockerIssueIds,
             },
@@ -4245,7 +4292,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
             entityType: "issue",
             entityId: candidate.id,
             details: {
-              source: "issue_graph_liveness.backstop",
+              source,
               wakeupRunId: wake.id,
               idempotencyKey,
               resolvedBlockerIssueId,
@@ -4256,7 +4303,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
           result.deferredOrFailed += 1;
           result.enqueueFailed += 1;
           logger.warn(
-            { err, issueId: candidate.id, agentId, idempotencyKey },
+            { err, issueId: candidate.id, agentId, idempotencyKey, source },
             "failed to enqueue dependency wake from issue graph liveness backstop",
           );
         }
@@ -4265,7 +4312,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
 
     if (result.healed > 0) {
       logger.warn(
-        { healed: result.healed, issueIds: result.issueIds },
+        { healed: result.healed, issueIds: result.issueIds, source, blockerIssueId: opts?.blockerIssueId ?? null },
         "issue graph liveness backstop healed resolved blocked dependency wakes",
       );
     }
@@ -4322,11 +4369,6 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       retiredRecoveryIssueIds: obsoleteRecoveryCleanup.retiredIssueIds,
     };
 
-    if (!autoRecoveryEnabled) {
-      result.skippedAutoRecoveryDisabled = findings.length;
-      return result;
-    }
-
     const dependencyWakeBackstop = await reconcileResolvedDependencyWakeBackstop({
       runId: opts?.runId ?? null,
     });
@@ -4341,6 +4383,11 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     result.dependencyWakeDeferredOrFailed = dependencyWakeBackstop.deferredOrFailed;
     result.dependencyWakeEnqueueFailed = dependencyWakeBackstop.enqueueFailed;
     result.dependencyWakeIssueIds = dependencyWakeBackstop.issueIds;
+
+    if (!autoRecoveryEnabled) {
+      result.skippedAutoRecoveryDisabled = findings.length;
+      return result;
+    }
 
     for (const finding of findings) {
       if (!isLivenessFindingInsideAutoRecoveryLookback(finding, cutoff, updatedAtByIssueKey)) {
@@ -4490,6 +4537,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     reconcileStrandedAssignedIssues,
     sweepStaleIssueLocks,
     buildIssueGraphLivenessAutoRecoveryPreview,
+    reconcileResolvedDependencyWakeBackstop,
     reconcileIssueGraphLiveness,
     readRecoveryTimerIntervalMs,
   };


### PR DESCRIPTION
## Thinking Path

> - Paperclip is an open source platform for managing AI agent companies — agents pick up issues, do work, and release checkouts in a heartbeat loop
> - Issue dependency resolution is handled by `issue_blockers_resolved` wakes: when a blocking issue reaches `done`, dependent blocked issues should be woken so they can resume
> - The workspace-finalize path maintained its own special-case loop to retry missed dependency wakes at run completion, duplicating logic that already exists in the shared level-triggered reconciliation backstop
> - Additionally, the resolved-blocker reconciliation sweep was gated behind the broader liveness auto-recovery escalation setting — so instances that disabled auto-escalation creation also lost the baseline reconciliation sweep
> - This PR routes the workspace-finalize retry through the shared backstop and decouples the reconciliation sweep from the escalation creation gate
> - The benefit is simpler code (one authoritative path instead of two), and correct behaviour on instances where escalation creation is disabled

## Linked Issues or Issue Description

No existing GitHub issue. Describing inline:

**Bug (blocker wake reconciliation):** `issue_blockers_resolved` wakes can be missed when:

1. A `workspace_finalize` heartbeat retries dependency resolution using its own inline loop instead of the shared level-triggered backstop, making them diverge over time.
2. The `blockedByIssueIds` dependency is set (or the issue is moved to `blocked`) *after* the blocker already reached `done` — the PATCH-time wake fires on a non-blocked issue and the dependency reconciliation never catches up.
3. An assignee briefly becomes `null` between the blocker reaching `done` and the reconciliation sweep running — the sweep skips the issue and never retries.

Related PRs:
- Refs #8009 — adds dedup for `issue_blockers_resolved` re-fires (complementary; prevents over-firing; this PR ensures under-firing is caught)
- Refs #6522 — `auto-unblock dependents with no assignee` (related no-assignee edge case)

## What Changed

- **`server/src/services/heartbeat.ts`** — remove the inline dependency-wake retry loop from the `workspace_finalize` path; delegate to the shared `reconcileResolvedDependencyWakeups` helper instead
- **`server/src/services/recovery/service.ts`** — split the resolved-blocker wake reconciliation sweep out from under the `liveness_escalation_auto_recovery` feature flag; the sweep runs unconditionally while escalation *creation* remains behind the flag
- **`server/src/__tests__/issue-dependency-wakeups-routes.test.ts`** — regression: `blockedBy` set after blocker already done still triggers a reconciliation wake
- **`server/src/__tests__/heartbeat-issue-liveness-escalation.test.ts`** — regression: assignee-null churn before reconciliation; stale skipped dependency wakes do not suppress a fresh reconciliation wake

## Verification

```
pnpm exec vitest run \
  server/src/__tests__/issue-dependency-wakeups-routes.test.ts \
  server/src/__tests__/heartbeat-issue-liveness-escalation.test.ts
```

23 tests, all passing locally. `pnpm --filter @paperclipai/server typecheck` clean.

## Risks

Low risk. Bounded blast radius:
- The reconciliation sweep only considers non-hidden `blocked` issues with an agent assignee
- Uses keyset pagination with an existing 500-candidate cap
- Reuses dependency readiness/finalize gating logic unchanged
- Skips issues with existing active/queued runs and pending interactions
- Deduplicates against live/completed `issue_blockers_resolved` wakes (skipped/cancelled wakes intentionally do not suppress a fresh reconciliation)
- Observability: healed reconciliations emit `issue.blockers_resolved_wake_emitted` activity and log the healed issue ids and source

## Model Used

Claude Sonnet 4.6 (`claude-sonnet-4-6`) with tool use and extended context. Paperclip AI agent runtime.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge