### PR TITLE
fix(claude-local): price Vertex/metered runs so cost isn't stuck at $0

### DIFF
--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -65,6 +65,7 @@ import {
 import { claudeCommandSupportsEffortFlag } from "./cli-capabilities.js";
 import { resolveClaudeDesiredSkillNames } from "./skills.js";
 import { isBedrockModelId } from "./models.js";
+import { computeCostUsdFromUsage } from "./pricing.js";
 import { prepareClaudePromptBundle } from "./prompt-cache.js";
 import { buildClaudeExecutionPermissionArgs } from "./permissions.js";
 import { SANDBOX_INSTALL_COMMAND } from "../index.js";
@@ -132,9 +133,46 @@ function isBedrockAuth(env: Record<string, string>): boolean {
   );
 }
 
+function isVertexAuth(env: Record<string, string>): boolean {
+  return (
+    env.CLAUDE_CODE_USE_VERTEX === "1" ||
+    env.CLAUDE_CODE_USE_VERTEX === "true" ||
+    hasNonEmptyEnvValue(env, "ANTHROPIC_VERTEX_PROJECT_ID")
+  );
+}
+
 function resolveClaudeBillingType(env: Record<string, string>): "api" | "subscription" | "metered_api" {
+  // Bedrock and Vertex are pay-per-token (metered) platforms, not a Claude
+  // subscription. Without these branches a Vertex/Bedrock run with no
+  // ANTHROPIC_API_KEY falls through to "subscription", which the ledger treats
+  // as included-in-plan and books at $0 even though tokens are billed (WOR-47).
   if (isBedrockAuth(env)) return "metered_api";
+  if (isVertexAuth(env)) return "metered_api";
   return hasNonEmptyEnvValue(env, "ANTHROPIC_API_KEY") ? "api" : "subscription";
+}
+
+/**
+ * Resolve the USD cost for a run. Prefer the cost the Claude CLI reports
+ * (`total_cost_usd`), which is authoritative on the first-party API. On metered
+ * platforms (Vertex, Bedrock) the CLI does not price the request, so when it
+ * reports nothing usable we recompute from token usage and per-model rates so
+ * cost reporting isn't stuck at $0 (WOR-47). Subscription runs are left as-is
+ * (the ledger zeroes them). Returns null when we can't determine a cost.
+ */
+function resolveCostUsd(
+  cliCostUsd: number | null,
+  billingType: "api" | "subscription" | "metered_api",
+  model: string | null | undefined,
+  usage: ReturnType<typeof parseClaudeStreamJson>["usage"],
+): number | null {
+  if (typeof cliCostUsd === "number" && Number.isFinite(cliCostUsd) && cliCostUsd > 0) {
+    return cliCostUsd;
+  }
+  if (billingType === "metered_api" || billingType === "api") {
+    const computed = computeCostUsdFromUsage(model, usage);
+    if (computed !== null) return computed;
+  }
+  return cliCostUsd;
 }
 
 async function buildClaudeRuntimeConfig(input: ClaudeExecutionInput): Promise<ClaudeRuntimeConfig> {
@@ -1030,10 +1068,19 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       sessionParams: resolvedSessionParams,
       sessionDisplayId: resolvedSessionId,
       provider: "anthropic",
-      biller: isBedrockAuth(effectiveEnv) ? "aws_bedrock" : "anthropic",
+      biller: isBedrockAuth(effectiveEnv)
+        ? "aws_bedrock"
+        : isVertexAuth(effectiveEnv)
+        ? "google_vertex"
+        : "anthropic",
       model: parsedStream.model || asString(parsed.model, model),
       billingType,
-      costUsd: parsedStream.costUsd ?? asNumber(parsed.total_cost_usd, 0),
+      costUsd: resolveCostUsd(
+        parsedStream.costUsd ?? (typeof parsed.total_cost_usd === "number" ? parsed.total_cost_usd : null),
+        billingType,
+        parsedStream.model || asString(parsed.model, model),
+        usage,
+      ),
       resultJson: mergedResultJson,
       summary: parsedStream.summary || asString(parsed.result, ""),
       clearSession:

--- a/packages/adapters/claude-local/src/server/pricing.test.ts
+++ b/packages/adapters/claude-local/src/server/pricing.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { computeCostUsdFromUsage, lookupModelRate } from "./pricing.js";
+
+describe("lookupModelRate", () => {
+  it("matches bare first-party ids", () => {
+    expect(lookupModelRate("claude-opus-4-8")).toMatchObject({ input: 5, output: 25, cacheRead: 0.5 });
+    expect(lookupModelRate("claude-sonnet-5")).toMatchObject({ input: 3, output: 15 });
+    expect(lookupModelRate("claude-haiku-4-5")).toMatchObject({ input: 1, output: 5 });
+    expect(lookupModelRate("claude-fable-5")).toMatchObject({ input: 10, output: 50 });
+  });
+
+  it("matches platform-qualified ids (vertex @, bedrock prefix)", () => {
+    expect(lookupModelRate("claude-opus-4-8@20260101")).toMatchObject({ input: 5 });
+    expect(lookupModelRate("us.anthropic.claude-opus-4-8-v1")).toMatchObject({ input: 5 });
+  });
+
+  it("returns null for unknown / empty models", () => {
+    expect(lookupModelRate("gpt-4o")).toBeNull();
+    expect(lookupModelRate(null)).toBeNull();
+    expect(lookupModelRate("")).toBeNull();
+  });
+});
+
+describe("computeCostUsdFromUsage", () => {
+  it("prices input, cached-read, and output tokens for opus-4-8", () => {
+    // Regression for WOR-47: Vertex runs report tokens but no CLI cost.
+    const cost = computeCostUsdFromUsage("claude-opus-4-8", {
+      inputTokens: 72170,
+      cachedInputTokens: 51206714,
+      outputTokens: 687289,
+    });
+    expect(cost).toBeCloseTo(43.146432, 4);
+  });
+
+  it("returns null for unknown model (do not book $0)", () => {
+    expect(
+      computeCostUsdFromUsage("mystery-model", {
+        inputTokens: 100,
+        cachedInputTokens: 0,
+        outputTokens: 100,
+      }),
+    ).toBeNull();
+  });
+
+  it("returns null when usage is missing", () => {
+    expect(computeCostUsdFromUsage("claude-opus-4-8", null)).toBeNull();
+  });
+
+  it("treats missing token fields as zero", () => {
+    const cost = computeCostUsdFromUsage("claude-haiku-4-5", {
+      inputTokens: 1_000_000,
+      cachedInputTokens: 0,
+      outputTokens: 0,
+    });
+    expect(cost).toBeCloseTo(1.0, 6);
+  });
+});

--- a/packages/adapters/claude-local/src/server/pricing.ts
+++ b/packages/adapters/claude-local/src/server/pricing.ts
@@ -1,0 +1,86 @@
+import type { UsageSummary } from "@paperclipai/adapter-utils";
+
+/**
+ * Per-model Anthropic token pricing, in USD per **million** tokens.
+ *
+ * The Claude CLI reports `total_cost_usd` only when it authenticates against the
+ * first-party Anthropic API with an API key. On Vertex AI and Amazon Bedrock the
+ * CLI does not know the platform's pricing, so it emits no cost — token I/O is
+ * populated but cost comes back null/0. For those metered paths we recompute the
+ * cost from token usage here so cost reporting isn't stuck at $0 (WOR-47).
+ *
+ * Rates are the published list prices (see the claude-api skill pricing table):
+ *   input  = standard input tokens
+ *   output = output tokens
+ *   cacheRead  = cached input tokens (~0.1x input)
+ *   cacheWrite = 5-minute cache writes (~1.25x input) — used only if the adapter
+ *                ever captures cache-creation tokens (it currently does not).
+ * Matching is by substring against a normalized model id so platform-qualified
+ * ids (e.g. `claude-opus-4-8@20260101`, `us.anthropic.claude-opus-4-8-v1`) resolve.
+ */
+export interface ModelRate {
+  input: number;
+  output: number;
+  cacheRead: number;
+  cacheWrite: number;
+}
+
+// Ordered longest/most-specific match first so `opus-4-8` wins over a broader
+// hypothetical `opus` entry. Each entry: [substring, rate per MTok].
+const MODEL_RATES: Array<[string, ModelRate]> = [
+  // Opus tier: $5 / $25
+  ["opus-4-8", { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 }],
+  ["opus-4-7", { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 }],
+  ["opus-4-6", { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 }],
+  ["opus-4-5", { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 }],
+  ["opus-4-1", { input: 15, output: 75, cacheRead: 1.5, cacheWrite: 18.75 }],
+  ["opus-4", { input: 15, output: 75, cacheRead: 1.5, cacheWrite: 18.75 }],
+  // Fable / Mythos tier: $10 / $50
+  ["fable-5", { input: 10, output: 50, cacheRead: 1.0, cacheWrite: 12.5 }],
+  ["mythos-5", { input: 10, output: 50, cacheRead: 1.0, cacheWrite: 12.5 }],
+  // Sonnet tier: $3 / $15
+  ["sonnet-5", { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 }],
+  ["sonnet-4-6", { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 }],
+  ["sonnet-4-5", { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 }],
+  ["sonnet-4", { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 }],
+  ["sonnet", { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 }],
+  // Haiku tier: $1 / $5
+  ["haiku-4-5", { input: 1, output: 5, cacheRead: 0.1, cacheWrite: 1.25 }],
+  ["haiku", { input: 1, output: 5, cacheRead: 0.1, cacheWrite: 1.25 }],
+];
+
+const PER_MILLION = 1_000_000;
+
+/** Look up the per-MTok rate for a model id, or null if unknown. */
+export function lookupModelRate(model: string | null | undefined): ModelRate | null {
+  if (!model) return null;
+  const normalized = model.toLowerCase();
+  for (const [needle, rate] of MODEL_RATES) {
+    if (normalized.includes(needle)) return rate;
+  }
+  return null;
+}
+
+/**
+ * Compute USD cost from token usage for a given model. Returns null when the
+ * model has no known rate (caller should leave cost unresolved rather than
+ * booking $0). `cachedInputTokens` is priced at the cache-read rate; regular
+ * `inputTokens` at the input rate.
+ *
+ * Note: the claude-local adapter does not currently capture cache-creation
+ * (cache-write) tokens, so those are not included here — the estimate can
+ * slightly undercount when a run writes a large cache prefix.
+ */
+export function computeCostUsdFromUsage(
+  model: string | null | undefined,
+  usage: UsageSummary | null | undefined,
+): number | null {
+  const rate = lookupModelRate(model);
+  if (!rate || !usage) return null;
+  const input = Math.max(0, usage.inputTokens ?? 0);
+  const cached = Math.max(0, usage.cachedInputTokens ?? 0);
+  const output = Math.max(0, usage.outputTokens ?? 0);
+  const cost =
+    (input * rate.input + cached * rate.cacheRead + output * rate.output) / PER_MILLION;
+  return Number.isFinite(cost) ? cost : null;
+}


### PR DESCRIPTION
resolveClaudeBillingType only branched on Bedrock and ANTHROPIC_API_KEY, so Claude-on-Vertex deployments (CLAUDE_CODE_USE_VERTEX=1, no API key) fell through to "subscription" -> the ledger books them as included-in-plan and zeroes cost_cents, even though tokens are metered and billed. The Claude CLI also emits total_cost_usd only on the first-party API, so on Vertex/Bedrock there was no dollar figure to record and no pricing table to derive one.

- Recognize Vertex as metered (isVertexAuth) -> billingType "metered_api", biller "google_vertex".
- Add pricing.ts: per-model USD rates (input/output/cache-read) for opus/sonnet/haiku/fable, substring-matched so platform-qualified model ids resolve; computeCostUsdFromUsage() derives cost from token usage.
- resolveCostUsd(): prefer the CLI cost; for metered runs with no CLI cost, compute from usage x pricing; leave subscription runs untouched.
- Add pricing.test.ts.

Known limitation: the adapter captures cache-read but not cache-creation tokens, so the estimate can slightly undercount runs that write a large cache prefix.

## Thinking Path

<!--
  Required. Trace your reasoning from the top of the project down to this
  specific change. Start with what Paperclip is, then narrow through the
  subsystem, the problem, and why this PR exists. Use blockquote style.
  Aim for 5–8 steps. See CONTRIBUTING.md for full examples.
-->

> - Paperclip is the open source app people use to manage AI agents for work
> - [Which subsystem or capability is involved]
> - [What problem or gap exists]
> - [Why it needs to be addressed]
> - This pull request ...
> - The benefit is ...

## Linked Issues or Issue Description

<!--
  Required. Pick ONE of the following two paths:

  (A) Issue exists — tag each linked issue with `Fixes: #123`, `Closes #123`,
      or `Refs #123`. Include duplicates and closely related issues too.

  Only reference PUBLIC GitHub issues/PRs here. Do NOT paste internal,
  instance-local Paperclip references — ticket ids like PAPA-123 / PAP-224,
  /PAP/issues/... or agent://... links, or localhost/tailnet URLs. Other
  contributors cannot open them. See CONTRIBUTING.md → "No Internal Issue
  References".

  (B) No issue exists — describe the underlying problem here, following the
      relevant issue template so reviewers get the same fields:
        • Bug:     .github/ISSUE_TEMPLATE/bug_report.yml
        • Feature: .github/ISSUE_TEMPLATE/feature_request.yml
        • Adapter: .github/ISSUE_TEMPLATE/adapter_request.yml

  See CONTRIBUTING.md → "Link Issues or Describe Them In-PR".
-->

-

## What Changed

<!-- Bullet list of concrete changes. One bullet per logical unit. -->

-

## Verification

<!--
  How can a reviewer confirm this works? Include test commands, manual
  steps, or both.
-->

-

## Risks

<!--
  What could go wrong? Mention migration safety, breaking changes,
  behavioral shifts, or "Low risk" if genuinely minor.
-->

-

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

<!--
  Required. Specify which AI model was used to produce or assist with
  this change. Be as descriptive as possible — include:
    • Provider and model name (e.g., Claude, GPT, Gemini, Codex)
    • Exact model ID or version (e.g., claude-opus-4-6, gpt-4-turbo-2024-04-09)
    • Context window size if relevant (e.g., 1M context)
    • Reasoning/thinking mode if applicable (e.g., extended thinking, chain-of-thought)
    • Any other relevant capability details (e.g., tool use, code execution)
  If no AI model was used, write "None — human-authored".
-->

-

## Checklist

- [ ] I have included a thinking path that traces from project context to this change
- [ ] I have specified the model used (with version and capability details)
- [ ] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [ ] I have searched GitHub for duplicate or related PRs and linked them above
- [ ] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [ ] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [ ] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [ ] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [ ] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge
