### PR TITLE
feat(mcp): add paperclipControlIssueTree for issue-subtree pause/resume

### DIFF
--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -62,6 +62,7 @@ Write tools:
 - `paperclipUpdateIssue`
 - `paperclipCheckoutIssue`
 - `paperclipReleaseIssue`
+- `paperclipControlIssueTree`
 - `paperclipAddComment`
 - `paperclipSuggestTasks`
 - `paperclipAskUserQuestions`

--- a/packages/mcp-server/src/tools.test.ts
+++ b/packages/mcp-server/src/tools.test.ts
@@ -87,6 +87,47 @@ describe("paperclip MCP tools", () => {
     });
   });
 
+  it("resumes an issue subtree to clear a pause hold", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      mockJsonResponse({ hold: { mode: "resume" } }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const tool = getTool("paperclipControlIssueTree");
+    await tool.execute({
+      issueId: "PAP-1135",
+      mode: "resume",
+      reason: "Clearing pause to re-dispatch",
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(String(url)).toBe("http://localhost:3100/api/issues/PAP-1135/tree-holds");
+    expect(init.method).toBe("POST");
+    expect(JSON.parse(String(init.body))).toEqual({
+      mode: "resume",
+      reason: "Clearing pause to re-dispatch",
+    });
+  });
+
+  it("omits reason from the tree-control body when not provided", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(mockJsonResponse({ hold: { mode: "pause" } }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await getTool("paperclipControlIssueTree").execute({ issueId: "PAP-1135", mode: "pause" });
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(JSON.parse(String(init.body))).toEqual({ mode: "pause" });
+  });
+
+  it("rejects an unknown tree-control mode", async () => {
+    const response = await getTool("paperclipControlIssueTree").execute({
+      issueId: "PAP-1135",
+      mode: "unpause",
+    });
+    expect(response.content[0]?.text.toLowerCase()).toContain("error");
+  });
+
   it("allows create issue requests to omit status so the API applies assignee defaults", async () => {
     const fetchMock = vi.fn().mockResolvedValue(
       mockJsonResponse({ id: "issue-1", status: "todo" }),

--- a/packages/mcp-server/src/tools.ts
+++ b/packages/mcp-server/src/tools.ts
@@ -6,6 +6,7 @@ import {
   createApprovalSchema,
   createIssueInputSchema,
   issueThreadInteractionContinuationPolicySchema,
+  issueTreeControlModeSchema,
   requestCheckboxConfirmationPayloadSchema,
   requestConfirmationPayloadSchema,
   suggestTasksPayloadSchema,
@@ -485,6 +486,19 @@ export function createToolDefinitions(client: PaperclipApiClient): ToolDefinitio
       "Release an issue checkout",
       z.object({ issueId: issueIdSchema }),
       async ({ issueId }) => client.requestJson("POST", `/issues/${encodeURIComponent(issueId)}/release`, { body: {} }),
+    ),
+    makeTool(
+      "paperclipControlIssueTree",
+      "Pause, resume, cancel, or restore an issue and its subtree. Use mode 'resume' to clear an active subtree pause hold — the gate behind the 409 \"Issue checkout blocked by active subtree pause hold\" that blocks checkout and dispatch. There is NO separate release/unpause/delete endpoint for holds: a pause is cleared by calling this with mode 'resume', and a cancel by mode 'restore'. mode: pause | resume | cancel | restore.",
+      z.object({
+        issueId: issueIdSchema,
+        mode: issueTreeControlModeSchema,
+        reason: z.string().trim().min(1).max(1000).optional(),
+      }),
+      async ({ issueId, mode, reason }) =>
+        client.requestJson("POST", `/issues/${encodeURIComponent(issueId)}/tree-holds`, {
+          body: { mode, ...(reason ? { reason } : {}) },
+        }),
     ),
     makeTool(
       "paperclipAddComment",


### PR DESCRIPTION
## What

Adds a `paperclipControlIssueTree` MCP tool wrapping `POST /issues/{id}/tree-holds` — pause, resume, cancel, or restore an issue and its subtree. The server routes, service, and `issueTreeControlModeSchema` validator already live on `master`; this exposes them to MCP-driven agents.

## Why

Subtree pause holds gate checkout and dispatch (`409 "Issue checkout blocked by active subtree pause hold"`), but no MCP tool exposes the tree-holds endpoint. An agent that hits the 409 today has to guess raw API paths through the generic request tool — and the hold model's create-with-mode semantics (a pause is cleared by *creating* a hold with mode `resume`; there is no delete/unpause endpoint) make that near-undiscoverable. We watched an agent probe `/holds`, `/subtree-holds`, `/pause-holds`, and `DELETE .../holds/{id}` — all 404 — before giving up.

The tool description spells out the resume-clears-pause semantics so agents pick the right mode without trial and error.

## Testing

- 3 new unit tests (resume clears a pause hold + body shape, optional `reason` omitted when absent, unknown mode rejected by the shared enum) — `pnpm --filter @paperclipai/mcp-server test`: 16/16 pass.
- Typecheck clean.

The tool is running in our deployment (fork-built) where it has already been used to pause a subtree whose runs were destabilizing the host, and to resume it after remediation.