### PR TITLE
chore: ignore materialized Paperclip runtime directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ diagnostics/
 .vscode/
 .claude/settings.local.json
 .paperclip-local/
+.paperclip-runtime/
 /.idea/
 /.agents/
 

--- a/packages/shared/src/gitignore-runtime.test.ts
+++ b/packages/shared/src/gitignore-runtime.test.ts
@@ -1,0 +1,18 @@
+import { execSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+// packages/shared/src/ is three levels below the repo root
+const REPO_ROOT = fileURLToPath(new URL("../../../", import.meta.url));
+
+describe("gitignore: .paperclip-runtime/", () => {
+  it("ignores files under .paperclip-runtime/ via the explicit gitignore rule", () => {
+    const output = execSync(
+      "git check-ignore -v .paperclip-runtime/codex/home/auth.json",
+      { cwd: REPO_ROOT, encoding: "utf8" },
+    ).trim();
+    // Output format: <source>:<line>:<pattern>\t<path>
+    // Asserts that the rule comes from .gitignore and matches .paperclip-runtime/
+    expect(output).toMatch(/^\.gitignore:\d+:\.paperclip-runtime\//);
+  });
+});


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Paperclip materializes agent execution environments (sandboxes, local adapters) and writes runtime state — credential files, adapter configs, sentinel files — into a `.paperclip-runtime/` directory inside the project checkout
> - This directory can contain sensitive material such as OAuth tokens, API keys, and injected credential files
> - Without a `.gitignore` entry, `.paperclip-runtime/` shows up as untracked files in `git status` and could be accidentally staged and committed by tooling or contributors
> - This pull request adds `.paperclip-runtime/` to the root `.gitignore` beside the existing `.paperclip-local/` and `.paperclip/` entries, and adds a Vitest regression to guard against the rule being accidentally removed
> - The benefit is that materialized runtime state and credentials are permanently excluded from version control, eliminating the risk of accidental commits of sensitive data

## Linked Issues or Issue Description

No public GitHub issue exists for this change. Describing the problem inline:

**Type:** Security / Developer Experience improvement

**Problem:** Paperclip's local adapter materializes runtime state and credentials (OAuth tokens, auth files, sentinel markers) into a `.paperclip-runtime/` directory at the project root. Because this path was not in `.gitignore`, the directory appeared as an untracked (committable) file in `git status`. Any tooling or contributor running `git add .` could accidentally commit sensitive credential material.

**Expected behavior:** `.paperclip-runtime/` should be invisible to git and never appear in `git status` output as an untracked or staged file.

**Steps to reproduce:** Clone the repo, run a local Paperclip adapter, observe `?? .paperclip-runtime/` in `git status`.

## What Changed

- Added `.paperclip-runtime/` to `.gitignore` (line 48), grouped with the existing `.paperclip-local/` and `.paperclip/` entries in the "Editor / tool temp files" section
- Added `packages/shared/src/gitignore-runtime.test.ts`: a Vitest regression that asserts `git check-ignore -v .paperclip-runtime/codex/home/auth.json` resolves to the `.paperclip-runtime/` rule in `.gitignore`, preventing accidental removal of the rule from going unnoticed

## Verification

```bash
# After applying the change:
git check-ignore -v .paperclip-runtime/codex/home/auth.json
# Expected: .gitignore:48:.paperclip-runtime/   .paperclip-runtime/codex/home/auth.json

git ls-files .paperclip-runtime .paperclip-runtime/
# Expected: empty output (nothing tracked)

git status --short --ignored .gitignore .paperclip-runtime
# Expected: only ignored (!!) entries under .paperclip-runtime/

git diff --cached --check
# Expected: clean, no issues

# Run the regression test (requires workspace dependencies installed):
pnpm exec vitest run --project @paperclipai/shared packages/shared/src/gitignore-runtime.test.ts
```

## Risks

Low risk. This change only adds a `.gitignore` entry and a test for it. It cannot affect runtime behavior. The only scenario where the `.gitignore` change could matter: if someone had intentionally committed content under `.paperclip-runtime/` (unlikely given it's a materialized runtime dir), those files would become untracked. No such content exists in the repo's history.

## Model Used

- Provider: Anthropic
- Model: Claude Sonnet 4.6 (`claude-sonnet-4-6`)
- Context window: 200K tokens
- Mode: Agentic tool use (Claude Code / Paperclip Harold Kim agent)
- Role: Authored and executed the full change end-to-end

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work (this is a chore/.gitignore fix, not a feature)
- [x] I have searched GitHub for duplicate or related PRs and linked them above (none found)
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass (`git check-ignore` and `git ls-files` verified; Vitest run pending workspace dependency install)
- [x] I have added or updated tests where applicable (added `packages/shared/src/gitignore-runtime.test.ts`)
- [x] I have updated relevant documentation to reflect my changes (no documentation updates needed for a `.gitignore` entry)
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green (pending CI run)
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups (pending Greptile run)
- [ ] I will address all Greptile and reviewer comments before requesting merge