### PR TITLE
docs: explain Codex and Claude credential ownership

### DIFF
--- a/docs/adapters/claude-local.md
+++ b/docs/adapters/claude-local.md
@@ -8,7 +8,8 @@ The `claude_local` adapter runs Anthropic's Claude Code CLI locally. It supports
 ## Prerequisites
 
 - Claude Code CLI installed (`claude` command available)
-- `ANTHROPIC_API_KEY` set in the environment or agent config
+- Either `ANTHROPIC_API_KEY` in adapter env/host env, or a Claude Code
+  subscription login available to the execution target
 
 ## Configuration Fields
 
@@ -68,6 +69,33 @@ On-call checklist if you see this in production:
 ## Skills Injection
 
 The adapter creates a temporary directory with symlinks to Paperclip skills and passes it via `--add-dir`. This makes skills discoverable without polluting the agent's working directory.
+
+## Remote credential ownership
+
+`claude_local` uses a snapshot-owns-auth topology for managed remote execution
+targets. When the run uses a sandbox or SSH execution target and no explicit
+`CLAUDE_CONFIG_DIR` is configured, Paperclip creates a remote
+`CLAUDE_CONFIG_DIR` under the run's Claude runtime directory. It uploads
+sanitized host-side settings such as `settings.json` and `CLAUDE.md`, but the
+managed seed does not upload host Claude credential files.
+
+After the seed is copied, the remote materialization command checks the
+execution target's own `$HOME/.claude` directory. For each missing credential
+file, it copies `.credentials.json` or `credentials.json` from that remote home
+into the managed `CLAUDE_CONFIG_DIR`. That means credentials baked into the
+sandbox image, or present on the SSH host, win for managed remote Claude runs.
+
+Worked example: a sandbox image contains `$HOME/.claude/.credentials.json` from
+its own Claude Code login. Paperclip starts a managed remote `claude_local` run,
+uploads only the sanitized config seed, and sets `CLAUDE_CONFIG_DIR` to the
+remote runtime config path. Because the managed config has no credential file,
+the adapter copies the sandbox image's `$HOME/.claude/.credentials.json` into
+that path before invoking Claude. The sandbox snapshot owns the credential for
+the run.
+
+This differs from [`codex_local`](/adapters/codex-local), where a
+Paperclip-managed sandbox run uploads a host-owned `CODEX_HOME/auth.json` and
+therefore shadows any Codex login already present inside the sandbox image.
 
 For manual local CLI usage outside heartbeat runs (for example running as `claudecoder` directly), use:
 

--- a/docs/adapters/codex-local.md
+++ b/docs/adapters/codex-local.md
@@ -8,7 +8,8 @@ The `codex_local` adapter runs OpenAI's Codex CLI locally. It supports session p
 ## Prerequisites
 
 - Codex CLI installed (`codex` command available)
-- `OPENAI_API_KEY` set in the environment or agent config
+- Either a host Codex login with `~/.codex/auth.json`, or a per-agent
+  `OPENAI_API_KEY` configured in adapter env
 
 ## Configuration Fields
 
@@ -54,6 +55,83 @@ A managed home is created empty, so the adapter must provision auth into it befo
 - **Managed homes** (the default home and any configured `CODEX_HOME` under the company tree) are always seeded: the ChatGPT-subscription `auth.json` is symlinked from the host Codex home, or, when a per-agent `OPENAI_API_KEY` is configured, an API-key `auth.json` is written instead.
 - **Genuine external overrides** (a `CODEX_HOME` outside the Paperclip-managed company tree) are treated as self-managed and are never seeded or overwritten.
 - **Fail-fast guard:** if a managed home ends up with no usable `auth.json` and no configured API key, the run fails with an explicit `adapter_failed` ("no Codex credentials provisioned for managed home …") rather than emitting an unauthenticated request.
+
+### Auth ownership and precedence
+
+`codex_local` is host-owns-auth when Paperclip owns the effective
+`CODEX_HOME`. The winning credential file is:
+
+1. **Per-agent API key:** when adapter env contains a non-empty
+   `OPENAI_API_KEY`, Paperclip writes `$CODEX_HOME/auth.json` with only
+   `{ "OPENAI_API_KEY": "..." }`. This overwrites any existing file or symlink
+   at that path. Codex CLI versions that Paperclip supports read the key from
+   `auth.json`, not directly from the process environment.
+2. **Host ChatGPT-subscription login:** when no per-agent key is configured,
+   Paperclip symlinks `auth.json` from the shared host Codex home into the
+   managed home. The symlink keeps rotating/single-use refresh tokens live
+   instead of copying a stale token into the managed home.
+3. **External `CODEX_HOME`:** if adapter env points `CODEX_HOME` outside the
+   Paperclip-managed company tree, that home is self-managed. Paperclip does
+   not seed or overwrite it, so its own `auth.json` wins.
+
+For sandbox or SSH execution, Paperclip uploads the effective managed
+`CODEX_HOME` and launches Codex with `CODEX_HOME` pointing at that uploaded
+directory. Any `auth.json` already baked into the sandbox image is shadowed in
+managed-home mode. If the host has no usable `auth.json` and no per-agent
+`OPENAI_API_KEY`, the managed run fails fast instead of falling back to an
+in-sandbox login.
+
+Worked example: a worker runs in a sandbox image that already has
+`$HOME/.codex/auth.json`, and the Paperclip host is logged in with a ChatGPT
+subscription. For a managed `codex_local` agent, Paperclip symlinks the host
+`auth.json` into the agent's managed home, uploads that home to the sandbox,
+and sets `CODEX_HOME` to the uploaded path. Codex reads the host-owned
+uploaded file, so the sandbox image login does not win.
+
+For high-concurrency sandbox fleets, prefer a per-agent `OPENAI_API_KEY` over a
+shared ChatGPT-subscription login. API-key mode produces a standalone
+`auth.json` for each managed home and avoids many concurrent sandboxes sharing
+one rotating subscription credential. The tradeoff is billing: API-key mode is
+metered per token through the OpenAI API, while ChatGPT-subscription auth uses
+the subscription's flat-plan economics and quota behavior. Pick the mode
+deliberately for the fleet's cost and concurrency profile.
+
+### Deferred config-validation warning spec
+
+This section specifies a warning that is not implemented yet. The warning should
+help operators notice the host-owns-auth topology before they run a sandbox
+fleet with ChatGPT-subscription credentials.
+
+- **Source fields:** resolved Codex auth mode (`api` vs `subscription`) and
+  execution target kind (`local`, `remote:ssh`, or `remote:sandbox`). Infer the
+  auth mode from the final managed `$CODEX_HOME/auth.json` shape after seeding:
+  `{ "OPENAI_API_KEY": ... }` means API-key mode; subscription-token-shaped
+  host auth, including the symlinked host file, means ChatGPT-subscription
+  mode. Use top-level shape only; do not read credential values into the
+  warning. The target kind comes from `AdapterExecutionTarget`.
+- **Transformations:** during config preparation or home seeding for a run,
+  classify `(subscription auth mode AND remote/sandbox execution target)` as a
+  warning condition. This is classification only. Do not read credential values
+  into the warning.
+- **Sink fields:** emit a warning log line through `onLog("stderr", ...)` and,
+  when the config-validation surface supports it, a surfaced validation warning.
+  The sink may include only the auth-mode label and target type.
+- **Retention:** warning text may appear in ephemeral run logs or validation
+  results. Do not persist auth material.
+- **Attacker-observable IDs:** none new. The warning must not print token
+  values, email addresses, or `auth.json` contents.
+- **Hook point:** wire the check at the `codex_local` execute/config-prep path
+  around managed-home seeding: `execute.ts` already has `executionTarget` /
+  target transport in scope, calls `seedManagedCodexHome`, and calls
+  `evaluateCodexCredentialReadiness` before uploading `CODEX_HOME`. If the
+  warning is factored into `codex-home.ts`, pass the resolved target
+  classification in rather than making `codex-home.ts` inspect execution
+  targets on its own.
+
+Because the warning touches authentication behavior, implementation must go
+through the security-review gate. Treat this docs section as the follow-up
+implementation spec, not as authorization to add the warning in a docs-only
+change.
 
 ## Manual Local CLI
 

--- a/docs/adapters/overview.md
+++ b/docs/adapters/overview.md
@@ -31,6 +31,28 @@ When a heartbeat fires, Paperclip:
 | [Process](/adapters/process) | `process` | Executes arbitrary shell commands |
 | [HTTP](/adapters/http) | `http` | Sends webhooks to external agents |
 
+## Credential ownership for sandbox targets
+
+Local CLI adapters can run on the Paperclip host, SSH targets, or managed
+sandbox targets. The adapter decides which credential home is authoritative
+before the CLI starts:
+
+| Adapter | Credential topology | Which credential file wins on managed sandbox targets |
+|---------|---------------------|-------------------------------------------------------|
+| [`codex_local`](/adapters/codex-local) | Host-owns-auth for Paperclip-managed `CODEX_HOME` | A host-owned `auth.json` is symlinked into the managed `CODEX_HOME` and uploaded to the sandbox. If a per-agent `OPENAI_API_KEY` is configured, Paperclip writes an API-key `auth.json` instead and that file wins. A login baked into the sandbox image is shadowed because Codex runs with Paperclip's uploaded `CODEX_HOME`. |
+| [`claude_local`](/adapters/claude-local) | Snapshot-owns-auth for managed remote Claude config | Paperclip uploads only sanitized settings and skill/runtime assets. When the remote managed config has no Claude credential files, it copies `.credentials.json` or `credentials.json` from the sandbox image's own `$HOME/.claude`, so the image's login wins. |
+
+Worked examples:
+
+- **Codex sandbox with host ChatGPT login:** the host `~/.codex/auth.json`
+  is symlinked into the managed home, then uploaded as the sandbox
+  `CODEX_HOME`. Codex reads that uploaded file and does not use any
+  `auth.json` already present inside the sandbox image.
+- **Claude sandbox with image login:** Paperclip materializes a remote
+  `CLAUDE_CONFIG_DIR`, then fills missing `.credentials.json` /
+  `credentials.json` from the sandbox image's own `$HOME/.claude`. The
+  snapshot's Claude login is the credential source for the run.
+
 ### Hermes local vs gateway
 
 Use `hermes_local` when Paperclip should start the local `hermes` CLI on the


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Local CLI adapters (`codex_local`, `claude_local`) can run on the Paperclip host, SSH targets, or managed sandbox targets — each adapter manages a credential home before its CLI starts
> - The docs did not explain which credential file wins when Paperclip provisions a managed sandbox: the host-uploaded file, or one already baked into the sandbox image
> - Operators spinning up sandbox fleets with ChatGPT-subscription credentials needed to know whether the sandbox image login would be shadowed (Codex) or used (Claude) — the difference affects security posture and fleet design
> - This pull request documents the host-owns-auth topology for `codex_local` and the snapshot-owns-auth topology for `claude_local`, with worked examples and a deferred warning spec
> - The benefit is that adapter docs now accurately describe credential precedence in sandbox/SSH scenarios, letting operators choose the right topology before a fleet goes live

## Linked Issues or Issue Description

No public GitHub issue exists. Describing the issue inline per the template:

**Problem:** Operator docs for `codex_local` and `claude_local` did not explain which credential file takes precedence when Paperclip provisions a managed remote or sandbox execution target. Without this, operators building sandbox fleets could not determine whether a host login would shadow an image-baked login, leading to unexpected auth failures or silent credential mismatches.

**Scope:** Docs-only change. Implementation of the deferred config-validation warning remains gated behind a security-review issue; this PR specifies the warning (source/transform/sink/retention/hook-point) without implementing it.

## What Changed

- **`docs/adapters/overview.md`:** Added "Credential ownership for sandbox targets" section with a comparison table (`codex_local` host-owns-auth vs `claude_local` snapshot-owns-auth) and two worked examples.
- **`docs/adapters/codex-local.md`:** Expanded the managed-home section with "Auth ownership and precedence" (per-agent API key → host subscription → external CODEX_HOME precedence chain, sandbox/SSH upload behaviour, high-concurrency API-key recommendation) and "Deferred config-validation warning spec" (source fields, transformations, sink, retention, attacker-observable IDs, hook point in `execute.ts`/`codex-home.ts`).
- **`docs/adapters/claude-local.md`:** Updated prerequisites to mention Claude Code subscription login as an alternative to `ANTHROPIC_API_KEY`; added "Remote credential ownership" section explaining the snapshot-owns-auth topology, the managed `CLAUDE_CONFIG_DIR` seed, and the `$HOME/.claude` credential fallback.

## Verification

These are docs-only changes with no runtime behaviour. Reviewers can verify by reading the three changed files and confirming:
- The worked examples match the implementation in `packages/adapters/codex-local/src/server/codex-home.ts` (`seedManagedCodexHome`, `evaluateCodexCredentialReadiness`), `packages/adapters/codex-local/src/server/execute.ts`, and `packages/adapters/claude-local/src/server/claude-config.ts`.
- No credential values, token contents, or email addresses appear in the added text.
- The warning spec section is clearly marked as deferred and implementation-gated.

## Risks

Low risk — docs-only change. No runtime code is modified. The deferred warning spec is explicitly marked as requiring a separate security-review gate before implementation.

## Model Used

Claude Sonnet 4.6 (`claude-sonnet-4-6`), operated as a Paperclip local adapter agent with tool use and multi-step reasoning. The commit was assembled by applying a patch authored by a Paperclip BackendEngineer agent (Priya Raman) in an isolated workspace; the patch was stored as an API-backed issue document and applied to master HEAD here.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable (docs-only; no tests to add)
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge