### PR TITLE
test(cli): clean API client fetch stubs

### DIFF
--- a/cli/src/__tests__/http.test.ts
+++ b/cli/src/__tests__/http.test.ts
@@ -3,6 +3,7 @@ import { ApiConnectionError, ApiRequestError, PaperclipApiClient } from "../clie
 
 describe("PaperclipApiClient", () => {
   afterEach(() => {
+    vi.unstubAllGlobals();
     vi.restoreAllMocks();
   });
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The CLI API client is the shared request layer used by command tests and board/agent workflows.
> - Its unit tests replace the global `fetch` function so requests can be asserted without a live server.
> - `vi.restoreAllMocks()` restores spies and mocks, but it does not undo `vi.stubGlobal()` replacements.
> - That means a mocked global `fetch` can leak into later tests that share the same Vitest worker.
> - This pull request makes the API client test cleanup match the safer CLI test pattern by unstubbing globals after each test.
> - The benefit is more reliable CLI test isolation without changing runtime behavior.

## Linked Issues or Issue Description

- Bug: `cli/src/__tests__/http.test.ts` stubs global `fetch` in multiple tests but only calls `vi.restoreAllMocks()` during cleanup. Vitest does not use `restoreAllMocks()` to undo `vi.stubGlobal()`, so later tests in the same worker can inherit a mocked `fetch` and exercise the wrong behavior.

## What Changed

- Added `vi.unstubAllGlobals()` to the API client test `afterEach` cleanup.
- Kept the change limited to test isolation; no runtime code changed.

## Verification

- `./node_modules/.bin/vitest run cli/src/__tests__/http.test.ts --config cli/vitest.config.ts` passed (5 tests).
- `git diff --check` passed.

## Risks

- Low risk. This only changes test cleanup and should make tests less order-dependent.
- If a future test intentionally relies on a global stub persisting across test cases, it will need to move that setup into its own `beforeEach`; that would be a healthier test shape.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI GPT-5 via Codex, with code editing and local command execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
