### PR TITLE
Warn when sandbox Codex auth is shadowed

### DIFF
--- a/packages/adapters/codex-local/src/server/auth-precedence.test.ts
+++ b/packages/adapters/codex-local/src/server/auth-precedence.test.ts
@@ -100,7 +100,7 @@ describe("resolveCodexAuthPrecedence", () => {
   describe("constants", () => {
     it("warning message is stable and human-readable", () => {
       expect(CODEX_SANDBOX_AUTH_PRECEDENCE_WARNING).toBe(
-        "snapshot login present but host credentials take precedence",
+        "snapshot login present but configured or host credentials take precedence",
       );
     });
 

--- a/packages/adapters/codex-local/src/server/auth-precedence.test.ts
+++ b/packages/adapters/codex-local/src/server/auth-precedence.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "vitest";
+import {
+  CODEX_SANDBOX_AUTH_EXISTS_COMMAND,
+  CODEX_SANDBOX_AUTH_PRECEDENCE_WARNING,
+  CODEX_SANDBOX_AUTH_PRECEDENCE_WARNING_LOG_LINE,
+  resolveCodexAuthPrecedence,
+} from "./auth-precedence.js";
+
+describe("resolveCodexAuthPrecedence", () => {
+  describe("precedence order", () => {
+    it("configured_api_key wins over all other sources", () => {
+      const result = resolveCodexAuthPrecedence({
+        configuredApiKey: true,
+        hostAuthJson: true,
+        sandboxAuthJson: true,
+      });
+      expect(result.winner).toBe("configured_api_key");
+    });
+
+    it("host_auth_json wins when no configured api key", () => {
+      const result = resolveCodexAuthPrecedence({
+        configuredApiKey: false,
+        hostAuthJson: true,
+        sandboxAuthJson: true,
+      });
+      expect(result.winner).toBe("host_auth_json");
+    });
+
+    it("sandbox_auth_json wins when no host credentials", () => {
+      const result = resolveCodexAuthPrecedence({
+        configuredApiKey: false,
+        hostAuthJson: false,
+        sandboxAuthJson: true,
+      });
+      expect(result.winner).toBe("sandbox_auth_json");
+    });
+
+    it("none when no credentials present", () => {
+      const result = resolveCodexAuthPrecedence({
+        configuredApiKey: false,
+        hostAuthJson: false,
+        sandboxAuthJson: false,
+      });
+      expect(result.winner).toBe("none");
+    });
+  });
+
+  describe("sandbox login shadowing and warning", () => {
+    it("warns when configured_api_key shadows sandbox login", () => {
+      const result = resolveCodexAuthPrecedence({
+        configuredApiKey: true,
+        hostAuthJson: false,
+        sandboxAuthJson: true,
+      });
+      expect(result.sandboxLoginShadowed).toBe(true);
+      expect(result.shouldWarn).toBe(true);
+    });
+
+    it("warns when host_auth_json shadows sandbox login", () => {
+      const result = resolveCodexAuthPrecedence({
+        configuredApiKey: false,
+        hostAuthJson: true,
+        sandboxAuthJson: true,
+      });
+      expect(result.sandboxLoginShadowed).toBe(true);
+      expect(result.shouldWarn).toBe(true);
+    });
+
+    it("does not warn when sandbox login wins (no host credentials)", () => {
+      const result = resolveCodexAuthPrecedence({
+        configuredApiKey: false,
+        hostAuthJson: false,
+        sandboxAuthJson: true,
+      });
+      expect(result.sandboxLoginShadowed).toBe(false);
+      expect(result.shouldWarn).toBe(false);
+    });
+
+    it("does not warn when no sandbox login exists (sandbox-only gate)", () => {
+      const result = resolveCodexAuthPrecedence({
+        configuredApiKey: true,
+        hostAuthJson: true,
+        sandboxAuthJson: false,
+      });
+      expect(result.sandboxLoginShadowed).toBe(false);
+      expect(result.shouldWarn).toBe(false);
+    });
+
+    it("does not warn when no credentials exist at all (fail-open)", () => {
+      const result = resolveCodexAuthPrecedence({
+        configuredApiKey: false,
+        hostAuthJson: false,
+        sandboxAuthJson: false,
+      });
+      expect(result.sandboxLoginShadowed).toBe(false);
+      expect(result.shouldWarn).toBe(false);
+    });
+  });
+
+  describe("constants", () => {
+    it("warning message is stable and human-readable", () => {
+      expect(CODEX_SANDBOX_AUTH_PRECEDENCE_WARNING).toBe(
+        "snapshot login present but host credentials take precedence",
+      );
+    });
+
+    it("log line wraps the warning message", () => {
+      expect(CODEX_SANDBOX_AUTH_PRECEDENCE_WARNING_LOG_LINE).toContain(
+        CODEX_SANDBOX_AUTH_PRECEDENCE_WARNING,
+      );
+      expect(CODEX_SANDBOX_AUTH_PRECEDENCE_WARNING_LOG_LINE).toMatch(
+        /^\[paperclip\] Warning:/,
+      );
+    });
+
+    it("sandbox auth exists command is a static shell test", () => {
+      expect(CODEX_SANDBOX_AUTH_EXISTS_COMMAND).toBe(
+        'test -f "$HOME/.codex/auth.json"',
+      );
+      expect(CODEX_SANDBOX_AUTH_EXISTS_COMMAND).not.toContain("cat");
+      expect(CODEX_SANDBOX_AUTH_EXISTS_COMMAND).not.toContain("readFile");
+    });
+  });
+});

--- a/packages/adapters/codex-local/src/server/auth-precedence.ts
+++ b/packages/adapters/codex-local/src/server/auth-precedence.ts
@@ -1,5 +1,5 @@
 export const CODEX_SANDBOX_AUTH_PRECEDENCE_WARNING =
-  "snapshot login present but host credentials take precedence";
+  "snapshot login present but configured or host credentials take precedence";
 export const CODEX_SANDBOX_AUTH_PRECEDENCE_WARNING_LOG_LINE =
   `[paperclip] Warning: ${CODEX_SANDBOX_AUTH_PRECEDENCE_WARNING}.\n`;
 export const CODEX_SANDBOX_AUTH_EXISTS_COMMAND =

--- a/packages/adapters/codex-local/src/server/auth-precedence.ts
+++ b/packages/adapters/codex-local/src/server/auth-precedence.ts
@@ -1,0 +1,46 @@
+export const CODEX_SANDBOX_AUTH_PRECEDENCE_WARNING =
+  "snapshot login present but host credentials take precedence";
+export const CODEX_SANDBOX_AUTH_PRECEDENCE_WARNING_LOG_LINE =
+  `[paperclip] Warning: ${CODEX_SANDBOX_AUTH_PRECEDENCE_WARNING}.\n`;
+export const CODEX_SANDBOX_AUTH_EXISTS_COMMAND =
+  'test -f "$HOME/.codex/auth.json"';
+
+export type CodexAuthPrecedenceWinner =
+  | "configured_api_key"
+  | "host_auth_json"
+  | "sandbox_auth_json"
+  | "none";
+
+export interface CodexAuthPrecedenceInput {
+  configuredApiKey: boolean;
+  hostAuthJson: boolean;
+  sandboxAuthJson: boolean;
+}
+
+export interface CodexAuthPrecedenceResolution {
+  winner: CodexAuthPrecedenceWinner;
+  sandboxLoginShadowed: boolean;
+  shouldWarn: boolean;
+}
+
+export function resolveCodexAuthPrecedence(
+  input: CodexAuthPrecedenceInput,
+): CodexAuthPrecedenceResolution {
+  const winner: CodexAuthPrecedenceWinner =
+    input.configuredApiKey
+      ? "configured_api_key"
+      : input.hostAuthJson
+        ? "host_auth_json"
+        : input.sandboxAuthJson
+          ? "sandbox_auth_json"
+          : "none";
+  const sandboxLoginShadowed =
+    input.sandboxAuthJson &&
+    (winner === "configured_api_key" || winner === "host_auth_json");
+
+  return {
+    winner,
+    sandboxLoginShadowed,
+    shouldWarn: sandboxLoginShadowed,
+  };
+}

--- a/packages/adapters/codex-local/src/server/index.ts
+++ b/packages/adapters/codex-local/src/server/index.ts
@@ -1,5 +1,14 @@
 export { execute, ensureCodexSkillsInjected } from "./execute.js";
 export {
+  resolveCodexAuthPrecedence,
+  CODEX_SANDBOX_AUTH_PRECEDENCE_WARNING,
+  CODEX_SANDBOX_AUTH_PRECEDENCE_WARNING_LOG_LINE,
+  CODEX_SANDBOX_AUTH_EXISTS_COMMAND,
+  type CodexAuthPrecedenceInput,
+  type CodexAuthPrecedenceResolution,
+  type CodexAuthPrecedenceWinner,
+} from "./auth-precedence.js";
+export {
   reconcileManagedCodexHome,
   isManagedCodexHomePath,
   evaluateCodexCredentialReadiness,


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The `codex-local` adapter runs Codex (OpenAI's coding CLI) as an agent execution backend, handling credential injection, sandbox HOME management, and execution isolation
> - When a managed Codex sandbox has baked-in credentials (a snapshot `~/.codex/auth.json` inside the sandbox HOME), the host Paperclip environment may also supply credentials via `OPENAI_API_KEY` or a host-level `auth.json`
> - Host credentials silently take precedence over sandbox credentials, with no indication to users or operators that their sandbox login is being shadowed — users who authenticate to Codex within the sandbox discover only later (or never) that their session was ignored
> - This PR adds a pure auth precedence resolver (`auth-precedence.ts`) that formalizes the credential precedence order and exposes a `shouldWarn` flag for the shadowing condition
> - The benefit is that the execution layer can detect when a sandbox login is overridden and emit a visible run-log warning, rather than silently discarding the sandbox session

## Linked Issues or Issue Description

I have searched GitHub for duplicate or related PRs — https://github.com/paperclipai/paperclip/pull/3681 is the closest (preserve managed Codex auth and repo-root env loading) but covers a different concern (preservation, not precedence warning). No public GitHub issue exists for this change.

**Subsystem affected:** `packages/adapters` — codex-local adapter

**Problem or motivation**

When a Codex sandbox has a snapshot-baked login (`~/.codex/auth.json` in the sandbox `$HOME`) and the host Paperclip environment also provides credentials (`OPENAI_API_KEY` or a host-level `auth.json`), the sandbox credentials are silently overridden with no visible indication. Users who authenticate to Codex within the sandbox have no way to know their session is being ignored in favor of host credentials.

**Proposed solution**

Add a pure precedence resolver (`auth-precedence.ts`) that determines which credential source wins and surfaces a `shouldWarn` boolean when a sandbox login is shadowed. This decouples the precedence logic from the warning emission, making both independently testable and wiring the warning into the execution path a follow-up PR.

**Alternatives considered**

Emitting the warning directly in `execute.ts` inline without a resolver module — rejected because the precedence logic would be entangled with side-effecting execution code and harder to test in isolation. A dedicated resolver keeps the logic pure and independently verifiable.

**Roadmap alignment**

Relates to the "Cloud / Sandbox agents" roadmap entry — improving the operator experience of running agents in managed sandboxes.

## What Changed

- Adds `packages/adapters/codex-local/src/server/auth-precedence.ts`: a pure, side-effect-free module that resolves Codex credential precedence across three sources
- **Precedence order (highest to lowest):** `configured_api_key` → `host_auth_json` → `sandbox_auth_json` → `none`
- `resolveCodexAuthPrecedence(input)` returns the winning source and a `shouldWarn` flag that is `true` when a sandbox login is shadowed by host or configured credentials
- Exports named constants: `CODEX_SANDBOX_AUTH_PRECEDENCE_WARNING` (human-readable message), `CODEX_SANDBOX_AUTH_PRECEDENCE_WARNING_LOG_LINE` (formatted log line), and `CODEX_SANDBOX_AUTH_EXISTS_COMMAND` (shell probe command for detecting sandbox auth presence)
- Adds `packages/adapters/codex-local/src/server/auth-precedence.test.ts`: unit tests covering the full precedence table, warning condition, sandbox-only gate, fail-open behavior, and constant stability

## Verification

- Unit tests: `corepack pnpm exec vitest run packages/adapters/codex-local/src/server/auth-precedence.test.ts`
- TypeScript compilation: `corepack pnpm --filter @paperclipai/adapter-codex-local typecheck`

## Risks

**Low risk.** This is a pure utility module with no integration into any execution path. No behavioral change in this PR — existing Codex execution, credential injection, and sandbox HOME management are unaffected. The module is available for a follow-up PR to wire into the sandbox execution flow.

## Model Used

- **Provider:** Anthropic
- **Model ID:** `claude-sonnet-4-6`
- **Context:** 200k-token context window, extended tool use enabled
- **Reasoning:** standard mode (no extended thinking)
- Used for commit authoring, test authoring, and PR composition

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green (pending CI run)
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups (pending review)
- [ ] I will address all Greptile and reviewer comments before requesting merge