### PR TITLE
fix: omit empty features object from redacted health response

### DIFF
--- a/server/src/__tests__/health.test.ts
+++ b/server/src/__tests__/health.test.ts
@@ -340,6 +340,42 @@ describe("GET /health", () => {
     expect(res.body.serverInfo).toBeUndefined();
   });
 
+  it("includes redacted feature flags only when explicitly configured", async () => {
+    const devServerStatus = await import("../dev-server-status.js");
+    vi.spyOn(devServerStatus, "readPersistedDevServerStatus").mockReturnValue(undefined);
+    const { healthRoutes } = await import("../routes/health.js");
+    const db = {
+      execute: vi.fn().mockResolvedValue([{ "?column?": 1 }]),
+      select: vi.fn(() => ({
+        from: vi.fn(() => ({
+          where: vi.fn().mockResolvedValue([{ count: 1 }]),
+        })),
+      })),
+    } as unknown as Db;
+    const app = express();
+    app.use((req, _res, next) => {
+      (req as any).actor = { type: "none", source: "none" };
+      next();
+    });
+    app.use(
+      "/health",
+      healthRoutes(db, {
+        deploymentMode: "authenticated",
+        deploymentExposure: "public",
+        authReady: true,
+        authDisableSignUp: true,
+        companyDeletionEnabled: false,
+        serverInfo: testServerInfo,
+      }),
+    );
+
+    const res = await request(app).get("/health");
+
+    expect(res.status).toBe(200);
+    expect(res.body.features).toEqual({ authDisableSignUp: true });
+    expect(res.body.serverInfo).toBeUndefined();
+  });
+
   it("redacts detailed metadata when authenticated mode is reached without auth middleware", async () => {
     const devServerStatus = await import("../dev-server-status.js");
     vi.spyOn(devServerStatus, "readPersistedDevServerStatus").mockReturnValue(undefined);

--- a/server/src/__tests__/setup-supertest.ts
+++ b/server/src/__tests__/setup-supertest.ts
@@ -44,7 +44,7 @@ if (!SupertestTest.prototype.__paperclipLoopbackPatched) {
     }
 
     const host = listeningAddress.address === "::"
-      ? "[::1]"
+      ? "127.0.0.1"
       : listeningAddress.address === "0.0.0.0"
         ? "127.0.0.1"
         : listeningAddress.address;

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -149,6 +149,7 @@ export async function createApp(
     allowedHostnames: string[];
     bindHost: string;
     authReady: boolean;
+    authDisableSignUp: boolean;
     companyDeletionEnabled: boolean;
     instanceId?: string;
     hostVersion?: string;
@@ -218,6 +219,7 @@ export async function createApp(
       deploymentMode: opts.deploymentMode,
       deploymentExposure: opts.deploymentExposure,
       authReady: opts.authReady,
+      authDisableSignUp: opts.authDisableSignUp,
       companyDeletionEnabled: opts.companyDeletionEnabled,
       databaseBackupHealth: opts.databaseBackupHealth,
     }),

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -685,6 +685,7 @@ export async function startServer(): Promise<StartedServer> {
     allowedHostnames: config.allowedHostnames,
     bindHost: config.host,
     authReady,
+    authDisableSignUp: config.authDisableSignUp,
     companyDeletionEnabled: config.companyDeletionEnabled,
     pluginMigrationDb: pluginMigrationDb as any,
     betterAuthHandler,

--- a/server/src/routes/health.ts
+++ b/server/src/routes/health.ts
@@ -62,6 +62,7 @@ export function healthRoutes(
     deploymentMode: DeploymentMode;
     deploymentExposure: DeploymentExposure;
     authReady: boolean;
+    authDisableSignUp?: boolean;
     companyDeletionEnabled: boolean;
     serverInfo?: ServerInfoSnapshot;
     databaseBackupHealth?: InspectDatabaseBackupHealthOptions;
@@ -198,12 +199,17 @@ export function healthRoutes(
     if (!exposeFullDetails) {
       const redactedDatabaseBackup = databaseBackup ? redactedDatabaseBackupHealth(databaseBackup) : undefined;
       const redactedWarnings = redactedDatabaseBackup?.warnings.length ? redactedDatabaseBackup.warnings : undefined;
+      const features =
+        typeof opts.authDisableSignUp === "boolean"
+          ? { authDisableSignUp: opts.authDisableSignUp }
+          : undefined;
       res.json({
         status: "ok",
         deploymentMode: opts.deploymentMode,
         deploymentExposure: opts.deploymentExposure,
         bootstrapStatus,
         bootstrapInviteActive,
+        ...(features ? { features } : {}),
         ...(redactedDatabaseBackup ? { databaseBackup: redactedDatabaseBackup } : {}),
         ...(redactedWarnings ? { warnings: redactedWarnings } : {}),
         ...(devServer ? { devServer } : {}),

--- a/ui/src/api/health.ts
+++ b/ui/src/api/health.ts
@@ -23,6 +23,7 @@ export type HealthStatus = {
   bootstrapStatus?: "ready" | "bootstrap_pending";
   bootstrapInviteActive?: boolean;
   features?: {
+    authDisableSignUp?: boolean;
     companyDeletionEnabled?: boolean;
   };
   serverInfo?: ServerInfoSnapshot;


### PR DESCRIPTION
## Thinking Path

> - Paperclip exposes a health endpoint used by operators and automated probes.
> - In authenticated deployments, anonymous callers receive a redacted health response rather than full server metadata.
> - That redacted response can still include safe feature state, such as whether sign-up is disabled.
> - The response should avoid emitting empty objects when no redacted feature flags are present.
> - Returning `features: {}` adds noise without carrying useful state.
> - This pull request only includes the redacted `features` object when it contains an explicit flag.
> - The benefit is a cleaner response shape while preserving the useful `authDisableSignUp` signal when configured.

## Linked Issues or Issue Description

Fixes #9267

## What Changed

- Plumb `authDisableSignUp` into the health route options.
- Include `features.authDisableSignUp` in redacted health responses when it is explicitly configured.
- Omit `features` entirely from redacted health responses when no redacted feature flags are available.
- Update the UI health response type to include `authDisableSignUp`.
- Add a focused health test for the explicit redacted feature flag case.
- Make the Supertest loopback helper connect to `127.0.0.1` when Node reports an unspecified IPv6 listener, so local test runs work in IPv4-only loopback environments.

## Verification

- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/health.test.ts`
- `pnpm --filter @paperclipai/server typecheck`
- `pnpm --filter @paperclipai/ui typecheck`

## Risks

Low risk. This changes only the JSON shape of the redacted health response and a test-only loopback helper:

- callers that use `features.authDisableSignUp` still receive it when configured
- callers do not receive an empty `features` object when no redacted flags are available
- full-detail health responses are unchanged
- no migrations or persisted data changes
- the Supertest helper change only affects local/CI test URL construction

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

OpenAI Codex GPT-5.5 with tool use and code execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
