### PR TITLE
docs: document skill guidance for review bots and authorization boundaries

### DIFF
--- a/packages/skills-catalog/catalog/bundled/software-development/github-pr-workflow/SKILL.md
+++ b/packages/skills-catalog/catalog/bundled/software-development/github-pr-workflow/SKILL.md
@@ -70,6 +70,24 @@ Skip the `Risk and rollback` section only for clearly trivial PRs (typos, docs).
 - For migrations, include a dry-run plan and reversal steps.
 - For performance changes, include a before/after measurement, not adjectives.
 
+## Automated code-review bots
+
+Automated review bots (Greptile, Superagent, Socket, Snyk, and similar) leave
+their verdicts on the PR itself rather than in the required-checks list. Treat
+their signal as part of the merge gate, not commentary:
+
+- Before flipping a PR from draft to ready, resolve every open bot comment on
+  the current head. If the bot exposes a confidence score (Greptile: `x/5`),
+  the exit condition is the top score, not "green enough".
+- If a bot posts new comments after you push, address them in the same run —
+  do not defer to a later heartbeat and do not wait to be asked.
+- If a bot's verdict is genuinely wrong, resolve the thread with a one-sentence
+  rationale on the PR. Silent dismissal reads as "not addressed" to the human
+  reviewer.
+- For long-lived split PRs (child PRs of a larger recovery/split), run this
+  loop on every child before handing the parent back — don't rely on the human
+  to fan out the ask.
+
 ## Replying to review comments
 
 - Reply on every comment, even with just "fixed in <commit-sha>" — silent fixes leave the reviewer guessing.
@@ -80,6 +98,10 @@ Skip the `Risk and rollback` section only for clearly trivial PRs (typos, docs).
 ## Merge checklist
 
 - All required checks green.
+- All automated code-review bots satisfied on the current head SHA (Greptile
+  at top confidence with zero unresolved threads, Superagent security scan
+  cleared, etc.). Bot signals sit outside the required-checks list and must
+  be checked separately.
 - All review comments resolved.
 - PR title/body still accurate (update if scope changed mid-review).
 - Linked issue moves to `in_review` or `done` per project convention.

--- a/skills/paperclip/SKILL.md
+++ b/skills/paperclip/SKILL.md
@@ -407,14 +407,17 @@ issue conceptually and still hit 403 from a different task-bridge run.
 
 **Before you mutate another agent's issue:**
 
-1. Always check the target issue's `assigneeAgentId` and `authorizationBoundary` fields:
+1. Always fetch the target issue before writing. This response is the boundary
+   signal agents receive; there is no separate local "current boundary" env var.
+   Capture the target's assignment, bridge origin, and boundary fields:
    ```sh
    curl -sS "$PAPERCLIP_API_URL/api/issues/<targetId>" \
      -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
-     | jq '{assignee: .assigneeAgentId, boundary: .authorizationBoundary}'
+     | jq '{assignee: .assigneeAgentId, origin: {kind: .originKind, id: .originId}, boundary: .authorizationBoundary}'
    ```
-2. If the target issue is not inside your current run's write boundary, do not
-   attempt the write. Route the ask via one of:
+2. If the fetch returns 403, the issue is assigned to another agent, or a
+   non-null `authorizationBoundary` does not clearly include the target issue,
+   do not attempt the write. Route the ask via one of:
    - A comment on your own issue naming the target owner and the desired change.
    - A child issue assigned to the owner with the mutation encoded as its body.
    - An `interactions` request on your issue when a human/board approval is

--- a/skills/paperclip/SKILL.md
+++ b/skills/paperclip/SKILL.md
@@ -396,6 +396,39 @@ PUT /api/issues/{issueId}/documents/plan
 
 If `plan` already exists, fetch the current document first and send its latest `baseRevisionId` when you update it.
 
+## Authorization boundaries — check ownership before mutating another agent's issue
+
+The Paperclip API scopes write access to the authorization boundary of the
+currently-checked-out issue. If you try to `PATCH /api/issues/{id}` or
+`POST /api/issues/{id}/comments` on an issue you do not own, the API returns
+`403 Issue is outside this actor's authorization boundary` and the mutation
+is dropped. This is a per-run scope, not a per-agent scope: you can own an
+issue conceptually and still hit 403 from a different task-bridge run.
+
+**Before you mutate another agent's issue, do one of:**
+
+1. Check the target issue's `assigneeAgentId` and `authorizationBoundary` fields:
+   ```sh
+   curl -sS "$PAPERCLIP_API_URL/api/issues/<targetId>" \
+     -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
+     | jq '{assignee: .assigneeAgentId, boundary: .authorizationBoundary}'
+   ```
+   If the assignee is not you and the boundary does not include you, do not
+   attempt the write. Route the ask instead.
+2. Route the ask via one of:
+   - A comment on your own issue naming the target owner and the desired change.
+   - A child issue assigned to the owner with the mutation encoded as its body.
+   - An `interactions` request on your issue when a human/board approval is
+     the correct escalation.
+
+**Do not** treat the 403 as a signal to retry with a different verb — the
+boundary is real. Retrying wastes the heartbeat and leaves the mutation
+un-owned.
+
+This applies especially to coordinator roles (CTO, plan owners, routine
+owners) that regularly need to clear blockers on issues held by engineers,
+QA, or CloudOps.
+
 ## Key Endpoints (Hot Routes)
 
 | Action                                | Endpoint                                                                                                                        |

--- a/skills/paperclip/SKILL.md
+++ b/skills/paperclip/SKILL.md
@@ -405,17 +405,16 @@ currently-checked-out issue. If you try to `PATCH /api/issues/{id}` or
 is dropped. This is a per-run scope, not a per-agent scope: you can own an
 issue conceptually and still hit 403 from a different task-bridge run.
 
-**Before you mutate another agent's issue, do one of:**
+**Before you mutate another agent's issue:**
 
-1. Check the target issue's `assigneeAgentId` and `authorizationBoundary` fields:
+1. Always check the target issue's `assigneeAgentId` and `authorizationBoundary` fields:
    ```sh
    curl -sS "$PAPERCLIP_API_URL/api/issues/<targetId>" \
      -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
      | jq '{assignee: .assigneeAgentId, boundary: .authorizationBoundary}'
    ```
-   If the assignee is not you and the boundary does not include you, do not
-   attempt the write. Route the ask instead.
-2. Route the ask via one of:
+2. If the target issue is not inside your current run's write boundary, do not
+   attempt the write. Route the ask via one of:
    - A comment on your own issue naming the target owner and the desired change.
    - A child issue assigned to the owner with the mutation encoded as its body.
    - An `interactions` request on your issue when a human/board approval is


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Paperclip skills encode repeatable operating procedures for agents and contributors
> - PR workflow skills need to treat automated review bots as merge gates, because those signals often live outside required checks
> - Paperclip coordination skills also need clear guidance for API authorization boundaries, because retrying forbidden writes wastes heartbeats
> - This pull request documents both procedures in the bundled GitHub PR workflow skill and the Paperclip skill
> - The benefit is more consistent PR follow-through and cleaner cross-issue coordination when an agent lacks write scope

## Linked Issues or Issue Description

No matching public GitHub issue was found. Public duplicate search found no open PR for "skills heartbeat artifact guidance". A broader search for "paperclip skill artifacts" returned an unrelated security-template PR, not a duplicate of this documentation update.

Feature description:

- Problem / motivation: automated review-bot outcomes and Paperclip API authorization boundary failures are recurring process details that agents need to handle consistently.
- Proposed solution: add explicit skill guidance for automated PR review bots and for routing cross-boundary Paperclip issue mutations.
- Alternatives considered: leaving this as oral/team convention; that makes each agent rediscover the same process and failure mode.
- Roadmap alignment: this supports the control-plane goal of making agent work auditable, repeatable, and easier to govern.

## What Changed

- Adds automated code-review bot guidance to the bundled GitHub PR workflow skill.
- Adds bot-satisfaction language to the PR merge checklist in that skill.
- Adds Paperclip API authorization boundary guidance to the Paperclip skill, including routing alternatives when the current run cannot mutate another issue.

## Verification

- `git diff --check origin/master...HEAD` — passed.
- Reviewed the rendered Markdown diff for heading placement, fenced code, and public-safe wording.
- `gh pr checks 9270 --watch --interval 30` — passed on `c1cdd0f` (all checks green; Storybook visual regression skipped by workflow).
- Greptile Review — passed at 5/5 on `c1cdd0f` with no unresolved review threads or follow-ups.
## Risks

- Low risk. This is documentation-only skill guidance. The main risk is process wording that is too strict or too broad for some future workflow.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

OpenAI Codex coding agent based on GPT-5, tool-enabled shell workflow. Exact hosted model variant and context window were not exposed by the runtime.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

