### PR TITLE
[codex] Document review bots and issue authorization

### DIFF
--- a/packages/skills-catalog/catalog/bundled/software-development/github-pr-workflow/SKILL.md
+++ b/packages/skills-catalog/catalog/bundled/software-development/github-pr-workflow/SKILL.md
@@ -70,6 +70,24 @@ Skip the `Risk and rollback` section only for clearly trivial PRs (typos, docs).
 - For migrations, include a dry-run plan and reversal steps.
 - For performance changes, include a before/after measurement, not adjectives.
 
+## Automated code-review bots
+
+Automated review bots (Greptile, Superagent, Socket, Snyk, and similar) leave
+their verdicts on the PR itself rather than in the required-checks list. Treat
+their signal as part of the merge gate, not commentary:
+
+- Before flipping a PR from draft to ready, resolve every open bot comment on
+  the current head. If the bot exposes a confidence score (Greptile: `x/5`),
+  the exit condition is the top score, not "green enough".
+- If a bot posts new comments after you push, address them in the same run —
+  do not defer to a later heartbeat and do not wait to be asked.
+- If a bot's verdict is genuinely wrong, resolve the thread with a one-sentence
+  rationale on the PR. Silent dismissal reads as "not addressed" to the human
+  reviewer.
+- For long-lived split PRs (child PRs of a larger recovery/split), run this
+  loop on every child before handing the parent back — don't rely on the human
+  to fan out the ask.
+
 ## Replying to review comments
 
 - Reply on every comment, even with just "fixed in <commit-sha>" — silent fixes leave the reviewer guessing.
@@ -80,6 +98,10 @@ Skip the `Risk and rollback` section only for clearly trivial PRs (typos, docs).
 ## Merge checklist
 
 - All required checks green.
+- All automated code-review bots satisfied on the current head SHA (Greptile
+  at top confidence with zero unresolved threads, Superagent security scan
+  cleared, etc.). Bot signals sit outside the required-checks list and must
+  be checked separately.
 - All review comments resolved.
 - PR title/body still accurate (update if scope changed mid-review).
 - Linked issue moves to `in_review` or `done` per project convention.

--- a/packages/skills-catalog/generated/catalog.json
+++ b/packages/skills-catalog/generated/catalog.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "packageName": "@paperclipai/skills-catalog",
   "packageVersion": "0.3.1",
-  "generatedAt": "2026-07-15T22:20:53.895Z",
+  "generatedAt": "2026-07-17T22:03:42.589Z",
   "skills": [
     {
       "id": "paperclipai:bundled:docs:doc-maintenance",
@@ -374,11 +374,11 @@
         {
           "path": "SKILL.md",
           "kind": "skill",
-          "sizeBytes": 3970,
-          "sha256": "f498ec4ebb1779dea37adeb1db8a8b22316282798e35ee02e2fc5ff627d7e261"
+          "sizeBytes": 5176,
+          "sha256": "0d4bfa03d0feedfe526bd8e3af87fee022d075df366262809731c4588220b595"
         }
       ],
-      "contentHash": "sha256:90f278c89aa0711be150c1cd2456ca25620d02f36995b113ca9837d756a37f6c"
+      "contentHash": "sha256:f44303c86eed17c65772129039ebb1b24e50e631a19fa9081aeb96ca8644e1ff"
     },
     {
       "id": "paperclipai:optional:browser:agent-browser",

--- a/packages/skills-catalog/src/shipped-catalog.test.ts
+++ b/packages/skills-catalog/src/shipped-catalog.test.ts
@@ -178,6 +178,21 @@ describe("shipped skills catalog", () => {
     expect(resolveCatalogSkillRef(sample.slug)).toMatchObject({ key: sample.key });
   });
 
+  it("keeps review-bot and issue-authorization guidance explicit", () => {
+    const githubPrWorkflow = readFileSync(
+      new URL("../catalog/bundled/software-development/github-pr-workflow/SKILL.md", import.meta.url),
+      "utf8",
+    );
+    const paperclipSkill = readFileSync(new URL("../../../skills/paperclip/SKILL.md", import.meta.url), "utf8");
+
+    expect(githubPrWorkflow).toContain("## Automated code-review bots");
+    expect(githubPrWorkflow).toContain("top confidence with zero unresolved threads");
+    expect(paperclipSkill).toContain("Paperclip evaluates `issue:read`, `issue:comment`, and `issue:mutate`");
+    expect(paperclipSkill).toContain("separately. Local task-bridge credentials are run-scoped");
+    expect(paperclipSkill).toContain("`authorizationBoundary` field");
+    expect(paperclipSkill).toContain("do not infer mutation access");
+  });
+
   it("keeps the Ramp wrapper fail-closed on mixed-provenance playbooks", () => {
     const rampSkill = readFileSync(new URL("../catalog/optional/finance/ramp/SKILL.md", import.meta.url), "utf8");
 

--- a/skills/paperclip/SKILL.md
+++ b/skills/paperclip/SKILL.md
@@ -450,6 +450,40 @@ PUT /api/issues/{issueId}/documents/plan
 
 If `plan` already exists, fetch the current document first and send its latest `baseRevisionId` when you update it.
 
+## Authorization boundaries — check ownership before mutating another agent's issue
+
+Paperclip evaluates `issue:read`, `issue:comment`, and `issue:mutate`
+separately. Local task-bridge credentials are run-scoped, so access that was
+valid from one checked-out issue may not be valid from another run. A mention
+grant can allow reading and commenting on another agent's issue, but it does
+not grant mutation access. A successful `GET` therefore does not prove that a
+later `PATCH` is authorized.
+
+If a write falls outside the active boundary, the API returns
+`403 Issue is outside this actor's authorization boundary` and drops it. Do
+not retry the same mutation with a different verb or from an unrelated run.
+
+**Before writing to another issue:**
+
+1. Fetch the issue and inspect `assigneeAgentId`, then confirm that the current
+   wake, assignment, mention, linked-issue context, or delegated child task
+   explicitly gives this run the required action. The issue response does not
+   expose an `authorizationBoundary` field, so do not infer mutation access
+   from read access alone.
+2. If the run has read/comment access only, route the requested mutation via:
+   - A comment on your own issue naming the target owner and the desired change.
+   - A child issue assigned to the owner with the mutation encoded as its body.
+   - An `interactions` request on your issue when a human/board approval is
+     the correct escalation.
+
+**Do not** treat the 403 as a signal to retry with a different verb — the
+boundary is real. Retrying wastes the heartbeat and leaves the mutation
+un-owned.
+
+This applies especially to coordinator roles (CTO, plan owners, routine
+owners) that regularly need to clear blockers on issues held by engineers,
+QA, or CloudOps.
+
 ## Key Endpoints (Hot Routes)
 
 | Action                                | Endpoint                                                                                                                        |


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Skills encode repeatable operating procedures for those agents and contributors
> - Pull-request workflows need to treat automated review bots as explicit merge gates, not optional commentary
> - Paperclip coordination guidance also needs to explain that issue read, comment, and mutation permissions are distinct and can be run-scoped
> - An earlier attempt at these docs was closed, while this PR accumulated unrelated runtime, timeline, and test changes
> - This pull request rebuilds the active branch on current `master` with only the reflection-sweep skill guidance and regenerated catalog metadata
> - The benefit is a focused, current, reviewable documentation change without unrelated stack commits

## Linked Issues or Issue Description

No public GitHub issue tracks this maintenance change.

Related work:

- #9270 was the closed earlier attempt to publish the same review-bot and authorization-boundary guidance.
- #9411 is a related implementation refactor for the server-side issue write boundary; this PR documents the current API behavior without depending on that refactor.

### Problem or motivation

Automated review-bot outcomes and Paperclip issue authorization failures are recurring workflow details. Without durable guidance, agents may hand off PRs before bot feedback is fully resolved or incorrectly infer mutation access from successful issue reads.

### Proposed solution

Document automated review bots as merge gates in the bundled GitHub PR workflow skill. Document the current separation between issue read, comment, and mutation authorization in the Paperclip skill, including safe routing options when a run lacks mutation access. Refresh the generated skills catalog metadata.

### Alternatives considered

Leaving these as team conventions would require each agent to rediscover the same review and authorization behavior. Keeping the previous mixed branch would preserve unrelated runtime, UI, and test changes in a documentation PR.

### Roadmap alignment

This is maintenance for existing contributor and agent workflows. It does not introduce a core product feature or overlap with roadmap feature work.

## What Changed

- Added automated review-bot handling and merge-gate guidance to the bundled GitHub PR workflow skill.
- Added current, run-scoped issue authorization guidance to the Paperclip coordination skill, including the distinction between read, comment, and mutate access.
- Regenerated the bundled skills catalog manifest for the updated workflow skill.
- Added a shipped-catalog regression test for the review-bot and authorization guidance.
- Removed the unrelated runtime, timeline, and heartbeat-test commits that previously existed on this PR branch.

## Verification

- `pnpm --filter @paperclipai/skills-catalog validate` — catalog manifest valid with 14 skills.
- `pnpm --filter @paperclipai/skills-catalog test` — 5 files and 21 tests passed.
- `git diff --check origin/master...HEAD` — passed.
- Guardrail check confirmed no `pnpm-lock.yaml` or `.github/workflows/*` changes.
- `pnpm exec prettier --check ...` was unavailable because this workspace install does not expose a `prettier` binary; no formatter configuration was added.

## Risks

- Low runtime risk: the change is limited to skill documentation and generated catalog metadata.
- Process guidance can become stale as authorization policies evolve; the wording avoids claiming that read access implies mutation access and points agents toward explicit task context and routing.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

OpenAI Codex CLI coding agent using a GPT-5-class Codex model with shell and code-editing tools. The runtime did not expose the exact hosted model ID or context-window size.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge


