### PR TITLE
fix: keep confirmation details available after confirm/deny

### DIFF
--- a/ui/src/components/IssueThreadInteractionCard.test.tsx
+++ b/ui/src/components/IssueThreadInteractionCard.test.tsx
@@ -484,4 +484,61 @@ describe("IssueThreadInteractionCard", () => {
       "![bug.png](https://cdn.example/shot.png)",
     );
   });
+
+  it("keeps confirmation details available behind a toggle after acceptance", async () => {
+    const host = renderCard({
+      interaction: {
+        ...pendingRequestConfirmationInteraction,
+        status: "accepted",
+        result: { version: 1, outcome: "accepted" },
+      },
+    });
+
+    expect(host.textContent).toContain("Approved");
+    expect(host.textContent).not.toContain(
+      "Approve the plan and let the responsible start implementation?",
+    );
+
+    const toggle = Array.from(host.querySelectorAll("button")).find((button) =>
+      button.textContent?.includes("Show details"),
+    );
+    expect(toggle).toBeTruthy();
+
+    await act(async () => {
+      toggle?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(host.textContent).toContain("Hide details");
+    expect(host.textContent).toContain(
+      "Approve the plan and let the responsible start implementation?",
+    );
+    expect(host.textContent).toContain(
+      "stale approvals are blocked if the plan changes",
+    );
+  });
+
+  it("keeps confirmation details available behind a toggle after decline", async () => {
+    const host = renderCard({
+      interaction: {
+        ...pendingRequestConfirmationInteraction,
+        status: "rejected",
+        result: { version: 1, outcome: "rejected", reason: "Tighten the plan" },
+      },
+    });
+
+    expect(host.textContent).toContain("Tighten the plan");
+
+    const toggle = Array.from(host.querySelectorAll("button")).find((button) =>
+      button.textContent?.includes("Show details"),
+    );
+    expect(toggle).toBeTruthy();
+
+    await act(async () => {
+      toggle?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(host.textContent).toContain(
+      "Approve the plan and let the responsible start implementation?",
+    );
+  });
 });

--- a/ui/src/components/IssueThreadInteractionCard.tsx
+++ b/ui/src/components/IssueThreadInteractionCard.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import type { Agent } from "@paperclipai/shared";
-import { AlertTriangle, CheckCircle2, ChevronRight, CircleDashed, FileText, GitBranch, ImagePlus, Loader2, MessageSquareQuote, X, XCircle } from "lucide-react";
+import { AlertTriangle, CheckCircle2, ChevronDown, ChevronRight, CircleDashed, FileText, GitBranch, ImagePlus, Loader2, MessageSquareQuote, X, XCircle } from "lucide-react";
 import { Link } from "@/lib/router";
 import { formatAssigneeUserLabel } from "../lib/assignees";
 import {
@@ -24,6 +24,7 @@ import { cn, formatDateTime, formatShortDate } from "../lib/utils";
 import { MarkdownBody, type MarkdownExternalReferenceMap } from "./MarkdownBody";
 import { Button } from "./ui/button";
 import { Checkbox } from "./ui/checkbox";
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "./ui/collapsible";
 import { PriorityIcon } from "./PriorityIcon";
 import { Textarea } from "./ui/textarea";
 import { Tooltip, TooltipContent, TooltipTrigger } from "./ui/tooltip";
@@ -1217,6 +1218,7 @@ function RequestConfirmationCard({
   const [shots, setShots] = useState<{ name: string; url: string }[]>([]);
   const [uploading, setUploading] = useState(false);
   const [uploadError, setUploadError] = useState<string | null>(null);
+  const [detailsOpen, setDetailsOpen] = useState(false);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   // Screenshots ride along in the decline reason as markdown image refs so the
   // board can attach images when sending a plan back — no schema change needed.
@@ -1469,7 +1471,40 @@ function RequestConfirmationCard({
           ) : null}
         </div>
       ) : (
-        <RequestConfirmationResolution interaction={interaction} />
+        <div className="space-y-2">
+          <RequestConfirmationResolution interaction={interaction} />
+          {interaction.payload.prompt || interaction.payload.detailsMarkdown ? (
+            <Collapsible open={detailsOpen} onOpenChange={setDetailsOpen}>
+              <CollapsibleTrigger asChild>
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  className="h-7 w-full justify-between px-2 text-xs text-muted-foreground hover:text-foreground"
+                >
+                  <span>{detailsOpen ? "Hide details" : "Show details"}</span>
+                  <ChevronDown
+                    className={cn(
+                      "h-3.5 w-3.5 transition-transform duration-200",
+                      detailsOpen && "rotate-180",
+                    )}
+                  />
+                </Button>
+              </CollapsibleTrigger>
+              <CollapsibleContent>
+                <div className="mt-1 space-y-3 rounded-sm border border-border/70 bg-background/75 p-4">
+                  <div className="text-sm leading-6 text-foreground">
+                    {interaction.payload.prompt}
+                  </div>
+                  {interaction.payload.detailsMarkdown ? (
+                    <div className="border-t border-border/60 pt-3 text-sm">
+                      <MarkdownBody externalReferences={externalReferences}>{interaction.payload.detailsMarkdown}</MarkdownBody>
+                    </div>
+                  ) : null}
+                </div>
+              </CollapsibleContent>
+            </Collapsible>
+          ) : null}
+        </div>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary

When a `request_confirmation` interaction (plan approval or similar dialogue) is resolved, the prompt and `detailsMarkdown` disappear entirely — the board can no longer see what was just approved or declined. This renders the existing resolution summary ("Confirmed" / "Declined" + target chip + decline reason) plus a collapsible **Show details** section, so the plan content stays accessible after the decision instead of vanishing.

Reported in lacymorrow/paperclip#16 (tracked internally as LAC-1291).

## Changes

- `RequestConfirmationCard`: resolved (non-pending) state now renders the resolution summary followed by a `Collapsible` with the original prompt and `detailsMarkdown` (via `MarkdownBody` with `externalReferences`), collapsed by default.
- The checkbox-confirmation variant is untouched — its resolution already retains the selected options.

## Testing

- Added two regression tests: resolved (accepted and rejected) confirmations expose a "Show details" toggle that reveals the prompt and details markdown; both fail without the fix.
- `npx vitest run src/components/IssueThreadInteractionCard.test.tsx` — 18/18 pass.
- `tsc -b` in `ui/` — clean.