### PR TITLE
Harden forced environment delete cleanup for active custom image sessions

### DIFF
--- a/server/src/__tests__/environment-routes.test.ts
+++ b/server/src/__tests__/environment-routes.test.ts
@@ -38,6 +38,7 @@ const mockEnvironmentService = vi.hoisted(() => ({
   getDeleteBlastRadius: vi.fn(),
   listLeases: vi.fn(),
   getLeaseById: vi.fn(),
+  releaseActiveLeasesForEnvironment: vi.fn(),
 }));
 
 const mockEnvironmentCustomImageService = vi.hoisted(() => ({
@@ -97,6 +98,7 @@ vi.mock("../services/secrets.js", () => ({
 
 vi.mock("../services/environments.js", () => ({
   environmentService: () => mockEnvironmentService,
+  ACTIVE_CUSTOM_IMAGE_SETUP_STATUSES: ["starting", "waiting_for_user", "capturing"],
 }));
 
 vi.mock("../services/execution-workspaces.js", () => ({
@@ -162,6 +164,7 @@ function createDeleteBlastRadius(overrides: Partial<{
   const deleteBlockedReasons = [
     ...(staticReferences.isManagedLocal ? ["managed_local" as const] : []),
     ...(staticReferences.isInstanceDefault ? ["instance_default" as const] : []),
+    ...(activeRuntimeUse.hasActiveRuntimeUse ? ["active_runtime_use" as const] : []),
   ];
   return {
     environmentId: "env-1",
@@ -237,6 +240,7 @@ describe("environment routes", () => {
     mockEnvironmentService.getDeleteBlastRadius.mockReset();
     mockEnvironmentService.listLeases.mockReset();
     mockEnvironmentService.getLeaseById.mockReset();
+    mockEnvironmentService.releaseActiveLeasesForEnvironment.mockReset();
     mockExecutionWorkspaceService.clearEnvironmentSelection.mockReset();
     Object.values(mockEnvironmentCustomImageService).forEach((mock) => mock.mockReset());
     mockEnvironmentCustomImageService.getOverview.mockResolvedValue({
@@ -845,6 +849,76 @@ describe("environment routes", () => {
         entityId: "env-ssh",
       }),
     );
+  });
+
+  it("blocks forced environment delete when active custom image session cannot be cancelled", async () => {
+    const environment = createEnvironment();
+    mockEnvironmentService.getById.mockResolvedValue(environment);
+    mockEnvironmentService.getDeleteBlastRadius.mockResolvedValue(createDeleteBlastRadius({
+      activeCustomImageSetupSessionCount: 1,
+    }));
+    mockEnvironmentCustomImageService.getOverview.mockResolvedValue({
+      activeTemplate: null,
+      activeSession: { id: "session-1" },
+      latestSession: null,
+    });
+    mockEnvironmentCustomImageService.cancelSetupSession.mockResolvedValue({
+      id: "session-1",
+      status: "starting",
+    });
+    const app = createApp({
+      type: "board",
+      userId: "admin-1",
+      source: "local_implicit",
+    });
+
+    const res = await request(app).delete("/api/environments/env-1?force=true");
+
+    expect(res.status).toBe(409);
+    expect(res.body.error).toBe(
+      "Active custom image setup session could not be cancelled. Retry or wait for setup to complete before deleting.",
+    );
+    expect(res.body.details).toEqual({ deleteBlockedReasons: ["active_runtime_use"] });
+    expect(mockEnvironmentCustomImageService.cancelSetupSession).toHaveBeenCalledWith({
+      sessionId: "session-1",
+      reason: "environment_force_delete",
+    });
+    expect(mockEnvironmentService.removeIfDeletable).not.toHaveBeenCalled();
+  });
+
+  it("proceeds with forced environment delete when active custom image session is successfully cancelled", async () => {
+    const environment = createEnvironment();
+    mockEnvironmentService.getById.mockResolvedValue(environment);
+    mockEnvironmentService.getDeleteBlastRadius.mockResolvedValue(createDeleteBlastRadius({
+      activeCustomImageSetupSessionCount: 1,
+    }));
+    mockEnvironmentCustomImageService.getOverview.mockResolvedValue({
+      activeTemplate: null,
+      activeSession: { id: "session-1" },
+      latestSession: null,
+    });
+    mockEnvironmentCustomImageService.cancelSetupSession.mockResolvedValue({
+      id: "session-1",
+      status: "cancelled",
+    });
+    mockEnvironmentService.releaseActiveLeasesForEnvironment.mockResolvedValue(0);
+    mockEnvironmentService.removeIfDeletable.mockResolvedValue(environment);
+    mockInstanceSettingsService.listCompanyIds.mockResolvedValue([]);
+    const app = createApp({
+      type: "board",
+      userId: "admin-1",
+      source: "local_implicit",
+    });
+
+    const res = await request(app).delete("/api/environments/env-1?force=true");
+
+    expect(res.status).toBe(200);
+    expect(mockEnvironmentCustomImageService.cancelSetupSession).toHaveBeenCalledWith({
+      sessionId: "session-1",
+      reason: "environment_force_delete",
+    });
+    expect(mockEnvironmentService.releaseActiveLeasesForEnvironment).toHaveBeenCalledWith("env-1");
+    expect(mockEnvironmentService.removeIfDeletable).toHaveBeenCalledWith("env-1");
   });
 
   it("rejects invalid SSH config on create", async () => {

--- a/server/src/__tests__/environment-routes.test.ts
+++ b/server/src/__tests__/environment-routes.test.ts
@@ -422,8 +422,8 @@ describe("environment routes", () => {
     expect(res.status).toBe(200);
     expect(res.body).toEqual({
       environmentId: "env-1",
-      canDelete: true,
-      deleteBlockedReasons: [],
+      canDelete: false,
+      deleteBlockedReasons: ["active_runtime_use"],
       staticReferences: {
         isManagedLocal: false,
         isInstanceDefault: false,

--- a/server/src/routes/environments.ts
+++ b/server/src/routes/environments.ts
@@ -12,6 +12,7 @@ import {
   redactEnvironmentCustomImageTemplate,
   startEnvironmentCustomImageSetupSessionSchema,
   type EnvironmentDeleteBlastRadius,
+  type EnvironmentCustomImageSetupSessionStatus,
   updateEnvironmentSchema,
 } from "@paperclipai/shared";
 import { conflict, forbidden, unprocessable } from "../errors.js";
@@ -47,8 +48,12 @@ import { listReadyPluginEnvironmentDrivers } from "../services/plugin-environmen
 import { getConfiguredSecretProvider } from "../secrets/configured-provider.js";
 import { assertBoardOrgAccess, getActorInfo } from "./authz.js";
 import type { PluginWorkerManager } from "../services/plugin-worker-manager.js";
-import { environmentService } from "../services/environments.js";
+import { environmentService, ACTIVE_CUSTOM_IMAGE_SETUP_STATUSES } from "../services/environments.js";
 import { executionWorkspaceService } from "../services/execution-workspaces.js";
+
+function isActiveCustomImageSetupStatus(status: EnvironmentCustomImageSetupSessionStatus): boolean {
+  return (ACTIVE_CUSTOM_IMAGE_SETUP_STATUSES as readonly string[]).includes(status);
+}
 
 export function environmentRoutes(
   db: Db,
@@ -813,8 +818,35 @@ export function environmentRoutes(
       res.status(404).json({ error: "Environment not found" });
       return;
     }
-    if (!impact.canDelete) {
+
+    const hasStaticBlocker = impact.deleteBlockedReasons.some(
+      (r) => r === "managed_local" || r === "instance_default",
+    );
+    if (hasStaticBlocker) {
       rejectEnvironmentDelete({ actor, environment: existing, impact });
+    }
+
+    const hasRuntimeBlocker = impact.deleteBlockedReasons.includes("active_runtime_use");
+    const forceDelete = req.query.force === "true";
+    if (hasRuntimeBlocker && !forceDelete) {
+      rejectEnvironmentDelete({ actor, environment: existing, impact });
+    }
+
+    if (hasRuntimeBlocker && forceDelete) {
+      const overview = await customImages.getOverview({ environmentId: existing.id });
+      if (overview.activeSession) {
+        const cancelled = await customImages.cancelSetupSession({
+          sessionId: overview.activeSession.id,
+          reason: "environment_force_delete",
+        });
+        if (isActiveCustomImageSetupStatus(cancelled.status)) {
+          throw conflict(
+            "Active custom image setup session could not be cancelled. Retry or wait for setup to complete before deleting.",
+            { deleteBlockedReasons: ["active_runtime_use"] },
+          );
+        }
+      }
+      await svc.releaseActiveLeasesForEnvironment(existing.id);
     }
 
     const removed = await svc.removeIfDeletable(existing.id);

--- a/server/src/services/environments.ts
+++ b/server/src/services/environments.ts
@@ -1,5 +1,6 @@
 import { and, desc, eq, inArray, ne, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
+import type { EnvironmentCustomImageSetupSessionStatus } from "@paperclipai/shared";
 import {
   agents,
   companySecretBindings,
@@ -42,7 +43,11 @@ const DEFAULT_KUBERNETES_ENVIRONMENT_DESCRIPTION =
 const KUBERNETES_PROVIDER_KEY = "kubernetes";
 /** Metadata marker for the company's managed-by-config Kubernetes sandbox environment. */
 const KUBERNETES_MANAGED_MARKER = "managedKubernetesSandbox";
-const ACTIVE_CUSTOM_IMAGE_SETUP_STATUSES = ["starting", "waiting_for_user", "capturing"] as const;
+export const ACTIVE_CUSTOM_IMAGE_SETUP_STATUSES = [
+  "starting",
+  "waiting_for_user",
+  "capturing",
+] as const satisfies readonly EnvironmentCustomImageSetupSessionStatus[];
 
 /**
  * Configuration accepted by `ensureKubernetesEnvironment`. Mirrors the keys of
@@ -552,11 +557,13 @@ export function environmentService(db: Db) {
 
       const isManagedLocal = environment.driver === "local";
       const isInstanceDefault = countFromRows(instanceDefaultRows) > 0;
+      const activeLeaseCount = countFromRows(activeLeaseRows);
+      const activeCustomImageSetupSessionCount = countFromRows(activeSetupRows);
+      const hasActiveRuntimeUse = activeLeaseCount > 0 || activeCustomImageSetupSessionCount > 0;
       const deleteBlockedReasons: EnvironmentDeleteBlockedReason[] = [];
       if (isManagedLocal) deleteBlockedReasons.push("managed_local");
       if (isInstanceDefault) deleteBlockedReasons.push("instance_default");
-      const activeLeaseCount = countFromRows(activeLeaseRows);
-      const activeCustomImageSetupSessionCount = countFromRows(activeSetupRows);
+      if (hasActiveRuntimeUse) deleteBlockedReasons.push("active_runtime_use");
 
       return {
         environmentId: id,
@@ -574,9 +581,19 @@ export function environmentService(db: Db) {
         activeRuntimeUse: {
           activeLeaseCount,
           activeCustomImageSetupSessionCount,
-          hasActiveRuntimeUse: activeLeaseCount > 0 || activeCustomImageSetupSessionCount > 0,
+          hasActiveRuntimeUse,
         },
       };
+    },
+
+    releaseActiveLeasesForEnvironment: async (id: string): Promise<number> => {
+      const now = new Date();
+      const rows = await db
+        .update(environmentLeases)
+        .set({ status: "released", releasedAt: now, lastUsedAt: now, updatedAt: now })
+        .where(and(eq(environmentLeases.environmentId, id), eq(environmentLeases.status, "active")))
+        .returning();
+      return rows.length;
     },
 
     listLeases: async (


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Environments can have active leases and custom image setup sessions running when a forced delete is requested
> - The environment delete route previously used a single `canDelete` boolean which did not distinguish between static blockers (managed local, instance default) and runtime-use blockers that should be bypassable with `force=true`
> - When a forced delete cancels an active custom image setup session, the cancellation might fail to terminate the session (leaving it in `starting`, `waiting_for_user`, or `capturing` state), so deleting the environment row in that case would leave orphaned setup tracking state
> - This pull request separates the two guard categories, adds atomic lease release on forced delete, and blocks the row delete if image session cancellation yields a non-terminal status
> - The benefit is that forced environment deletes are safe: they only succeed when both the custom image session is fully cancelled and leases are released

## Linked Issues or Issue Description

Closes #9278

## What Changed

- `server/src/services/environments.ts`: Export `ACTIVE_CUSTOM_IMAGE_SETUP_STATUSES` with a `satisfies readonly EnvironmentCustomImageSetupSessionStatus[]` constraint; compute `hasActiveRuntimeUse` before the `deleteBlockedReasons` array so `active_runtime_use` is present in blast-radius responses; add `releaseActiveLeasesForEnvironment` to atomically release active leases for an environment.
- `server/src/routes/environments.ts`: Split the `!impact.canDelete` guard into a static-blocker path (always rejects) and a runtime-use path (only rejects without `force=true`). On a forced delete, cancel any active custom image session and throw 409 if cancellation leaves the session in a non-terminal state (`starting`, `waiting_for_user`, `capturing`); then release leases before removing the environment.
- `server/src/__tests__/environment-routes.test.ts`: Add `releaseActiveLeasesForEnvironment` mock, wire `ACTIVE_CUSTOM_IMAGE_SETUP_STATUSES` into the environments module mock, include `active_runtime_use` in `createDeleteBlastRadius` helper, and add two new test cases covering the 409 non-terminal-cancellation path and the success path.

## Verification

- `git diff --check -- server/src/routes/environments.ts server/src/__tests__/environment-routes.test.ts` passes.
- Two new Vitest test cases added for the non-terminal cancellation 409 path and the successful forced-delete path with custom image session.
- Run focused environment tests after merge: `pnpm --filter @paperclipai/server exec vitest run src/__tests__/environment-routes.test.ts src/__tests__/environment-service.test.ts`

## Risks

- The forced-delete path now calls `cancelSetupSession` and `releaseActiveLeasesForEnvironment` before deleting the row. If `cancelSetupSession` throws unexpectedly (not 409), the error propagates and the row is not deleted — this is the safe failure mode.
- `releaseActiveLeasesForEnvironment` issues a bulk UPDATE with `status='released'`; it is idempotent and does not affect already-released leases.
- Low risk overall: the new guard adds a step before deletion rather than removing an existing guard.

## Model Used

- Provider: Anthropic
- Model: claude-sonnet-4-6 (Claude Sonnet 4.6)
- Tool use: enabled (Claude Code agentic mode)
- Context: extended multi-turn session with full repo access

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge