### PR TITLE
perf(server): cut auth middleware DB round-trips and make db pool size configurable

### DIFF
--- a/docs/deploy/environment-variables.md
+++ b/docs/deploy/environment-variables.md
@@ -14,6 +14,7 @@ All environment variables that Paperclip uses for server configuration.
 | `PAPERCLIP_BIND_HOST` | (unset) | Required when `PAPERCLIP_BIND=custom` |
 | `HOST` | `127.0.0.1` | Legacy host override; prefer `PAPERCLIP_BIND` for new setups |
 | `DATABASE_URL` | (embedded) | PostgreSQL connection string |
+| `PAPERCLIP_DB_POOL_MAX` | `25` | Max PostgreSQL connections in the server pool. Lower it for constrained deployments; raise it if many concurrent agents/dashboards saturate the pool. |
 | `PAPERCLIP_HOME` | `~/.paperclip` | Base directory for all Paperclip data |
 | `PAPERCLIP_INSTANCE_ID` | `default` | Instance identifier (for multiple local instances) |
 | `PAPERCLIP_DEPLOYMENT_MODE` | `local_trusted` | Runtime mode override |

--- a/packages/db/src/client.test.ts
+++ b/packages/db/src/client.test.ts
@@ -6,6 +6,7 @@ import {
   applyPendingMigrations,
   inspectMigrations,
   resetPostgresDatabase,
+  resolveDbPoolMax,
 } from "./client.js";
 import {
   getEmbeddedPostgresTestSupport,
@@ -1405,4 +1406,20 @@ describeEmbeddedPostgres("applyPendingMigrations", () => {
     },
     20_000,
   );
+});
+
+describe("resolveDbPoolMax", () => {
+  it("defaults to 25 when unset or invalid", () => {
+    expect(resolveDbPoolMax(undefined)).toBe(25);
+    expect(resolveDbPoolMax("")).toBe(25);
+    expect(resolveDbPoolMax("abc")).toBe(25);
+    expect(resolveDbPoolMax("0")).toBe(25);
+    expect(resolveDbPoolMax("-4")).toBe(25);
+    expect(resolveDbPoolMax("2.5")).toBe(25);
+  });
+
+  it("uses a positive integer override", () => {
+    expect(resolveDbPoolMax("1")).toBe(1);
+    expect(resolveDbPoolMax("40")).toBe(40);
+  });
 });

--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -45,8 +45,20 @@ export type MigrationState =
       reason: "no-migration-journal-empty-db" | "no-migration-journal-non-empty-db" | "pending-migrations";
     };
 
-export function createDb(url: string) {
-  const sql = postgres(url);
+// postgres.js defaults to 10 pooled connections with an unbounded FIFO wait
+// queue. A busy instance (agent heartbeats plus dashboard polling) saturates
+// that in bursts, and every DB-bound request then queues behind the pool for
+// tens of seconds while connectionless routes stay instant.
+const DEFAULT_DB_POOL_MAX = 25;
+
+export function resolveDbPoolMax(raw: string | undefined = process.env.PAPERCLIP_DB_POOL_MAX): number {
+  const parsed = Number(raw);
+  if (Number.isInteger(parsed) && parsed >= 1) return parsed;
+  return DEFAULT_DB_POOL_MAX;
+}
+
+export function createDb(url: string, options?: { max?: number }) {
+  const sql = postgres(url, { max: options?.max ?? resolveDbPoolMax() });
   return drizzlePg(sql, { schema });
 }
 

--- a/server/src/__tests__/agent-auth-middleware.test.ts
+++ b/server/src/__tests__/agent-auth-middleware.test.ts
@@ -6,6 +6,7 @@ import {
   activityLog,
   agentApiKeys,
   agents,
+  authUsers,
   boardApiKeys,
   heartbeatRuns,
 } from "@paperclipai/db";
@@ -41,6 +42,12 @@ function createDbState(input: {
     lastUsedAt?: Date | null;
   };
   run?: { id: string; companyId: string; agentId: string; responsibleUserId?: string | null };
+  boardKey?: {
+    id: string;
+    userId: string;
+    keyHash: string;
+    lastUsedAt?: Date | null;
+  };
 }) {
   const activity: Array<Record<string, unknown>> = [];
   const selectedTables: unknown[] = [];
@@ -70,12 +77,26 @@ function createDbState(input: {
         responsibleUserId: input.run.responsibleUserId ?? null,
       }
     : null;
+  const boardKeyRow = input.boardKey
+    ? {
+        id: input.boardKey.id,
+        userId: input.boardKey.userId,
+        keyHash: input.boardKey.keyHash,
+        lastUsedAt: input.boardKey.lastUsedAt ?? null,
+        revokedAt: null,
+        expiresAt: null,
+      }
+    : null;
+  const boardUserRow = input.boardKey
+    ? { id: input.boardKey.userId, name: "Board User", email: "board@example.com" }
+    : null;
 
   const db = {
     select: () =>
       createSelectChain((table) => {
         selectedTables.push(table);
-        if (table === boardApiKeys) return [];
+        if (table === boardApiKeys) return boardKeyRow ? [boardKeyRow] : [];
+        if (table === authUsers) return boardUserRow ? [boardUserRow] : [];
         if (table === agentApiKeys) return keyRow ? [keyRow] : [];
         if (table === agents) return [agentRow];
         if (table === heartbeatRuns) return runRow ? [runRow] : [];
@@ -487,5 +508,45 @@ describe("agent auth middleware", () => {
       .set("Authorization", `Bearer ${token}`);
     expect(neverRes.status).toBe(200);
     expect(never.updatedTables).toContain(agentApiKeys);
+  });
+
+  it("refreshes board key lastUsedAt only when the stamp is stale", async () => {
+    const token = "pcp_board_test_key";
+    const baseBoardKey = {
+      id: randomUUID(),
+      userId: randomUUID(),
+      keyHash: hashToken(token),
+    };
+
+    const fresh = createDbState({
+      agent: { id: randomUUID(), companyId: randomUUID() },
+      boardKey: { ...baseBoardKey, lastUsedAt: new Date() },
+    });
+    const freshRes = await request(createApp(fresh.db))
+      .get("/actor")
+      .set("Authorization", `Bearer ${token}`);
+    expect(freshRes.status).toBe(200);
+    expect(freshRes.body).toMatchObject({ type: "board", source: "board_key" });
+    expect(fresh.updatedTables).not.toContain(boardApiKeys);
+
+    const stale = createDbState({
+      agent: { id: randomUUID(), companyId: randomUUID() },
+      boardKey: { ...baseBoardKey, lastUsedAt: new Date(Date.now() - 5 * 60_000) },
+    });
+    const staleRes = await request(createApp(stale.db))
+      .get("/actor")
+      .set("Authorization", `Bearer ${token}`);
+    expect(staleRes.status).toBe(200);
+    expect(stale.updatedTables).toContain(boardApiKeys);
+
+    const never = createDbState({
+      agent: { id: randomUUID(), companyId: randomUUID() },
+      boardKey: { ...baseBoardKey, lastUsedAt: null },
+    });
+    const neverRes = await request(createApp(never.db))
+      .get("/actor")
+      .set("Authorization", `Bearer ${token}`);
+    expect(neverRes.status).toBe(200);
+    expect(never.updatedTables).toContain(boardApiKeys);
   });
 });

--- a/server/src/__tests__/agent-auth-middleware.test.ts
+++ b/server/src/__tests__/agent-auth-middleware.test.ts
@@ -32,10 +32,19 @@ function createSelectChain(rowsForTable: (table: unknown) => unknown[]) {
 
 function createDbState(input: {
   agent: { id: string; companyId: string; status?: string };
-  agentKey?: { id: string; agentId: string; companyId: string; keyHash: string; responsibleUserId?: string | null };
+  agentKey?: {
+    id: string;
+    agentId: string;
+    companyId: string;
+    keyHash: string;
+    responsibleUserId?: string | null;
+    lastUsedAt?: Date | null;
+  };
   run?: { id: string; companyId: string; agentId: string; responsibleUserId?: string | null };
 }) {
   const activity: Array<Record<string, unknown>> = [];
+  const selectedTables: unknown[] = [];
+  const updatedTables: unknown[] = [];
   const agentRow = {
     id: input.agent.id,
     companyId: input.agent.companyId,
@@ -48,6 +57,7 @@ function createDbState(input: {
         companyId: input.agentKey.companyId,
         keyHash: input.agentKey.keyHash,
         responsibleUserId: input.agentKey.responsibleUserId ?? null,
+        lastUsedAt: input.agentKey.lastUsedAt ?? null,
         revokedAt: null,
         scopeConfig: null,
       }
@@ -64,16 +74,18 @@ function createDbState(input: {
   const db = {
     select: () =>
       createSelectChain((table) => {
+        selectedTables.push(table);
         if (table === boardApiKeys) return [];
         if (table === agentApiKeys) return keyRow ? [keyRow] : [];
         if (table === agents) return [agentRow];
         if (table === heartbeatRuns) return runRow ? [runRow] : [];
         return [];
       }),
-    update: () => ({
+    update: (table: unknown) => ({
       set() {
         return {
           where() {
+            updatedTables.push(table);
             return Promise.resolve([]);
           },
         };
@@ -87,7 +99,7 @@ function createDbState(input: {
     }),
   } as any;
 
-  return { db, activity };
+  return { db, activity, selectedTables, updatedTables };
 }
 
 function createApp(db: any) {
@@ -377,5 +389,103 @@ describe("agent auth middleware", () => {
       entityId: keyId,
       details: { method: "GET", url: `/companies/${companyId}/protected` },
     });
+  });
+
+  it("authenticates local agent JWTs without querying the key tables", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const runId = randomUUID();
+    const { db, selectedTables } = createDbState({
+      agent: { id: agentId, companyId },
+    });
+    const token = createLocalAgentJwt(agentId, companyId, "codex_local", runId, "user-claim");
+
+    const res = await request(createApp(db))
+      .get("/actor")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ type: "agent", agentId, source: "agent_jwt" });
+    expect(selectedTables).not.toContain(boardApiKeys);
+    expect(selectedTables).not.toContain(agentApiKeys);
+  });
+
+  it("skips the board key lookup for non-board bearer tokens", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const token = "pcp_test_agent_key";
+    const { db, selectedTables } = createDbState({
+      agent: { id: agentId, companyId },
+      agentKey: {
+        id: randomUUID(),
+        agentId,
+        companyId,
+        keyHash: hashToken(token),
+        responsibleUserId: "user-key",
+      },
+    });
+
+    const res = await request(createApp(db))
+      .get("/actor")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ type: "agent", source: "agent_key" });
+    expect(selectedTables).not.toContain(boardApiKeys);
+  });
+
+  it("still checks the board key table for board-prefixed tokens", async () => {
+    const { db, selectedTables } = createDbState({
+      agent: { id: randomUUID(), companyId: randomUUID() },
+    });
+
+    await request(createApp(db))
+      .get("/actor")
+      .set("Authorization", "Bearer pcp_board_unknown_token");
+
+    expect(selectedTables).toContain(boardApiKeys);
+  });
+
+  it("refreshes agent key lastUsedAt only when the stamp is stale", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const token = "pcp_test_agent_key";
+    const baseKey = {
+      id: randomUUID(),
+      agentId,
+      companyId,
+      keyHash: hashToken(token),
+      responsibleUserId: "user-key",
+    };
+
+    const fresh = createDbState({
+      agent: { id: agentId, companyId },
+      agentKey: { ...baseKey, lastUsedAt: new Date() },
+    });
+    const freshRes = await request(createApp(fresh.db))
+      .get("/actor")
+      .set("Authorization", `Bearer ${token}`);
+    expect(freshRes.status).toBe(200);
+    expect(fresh.updatedTables).not.toContain(agentApiKeys);
+
+    const stale = createDbState({
+      agent: { id: agentId, companyId },
+      agentKey: { ...baseKey, lastUsedAt: new Date(Date.now() - 5 * 60_000) },
+    });
+    const staleRes = await request(createApp(stale.db))
+      .get("/actor")
+      .set("Authorization", `Bearer ${token}`);
+    expect(staleRes.status).toBe(200);
+    expect(stale.updatedTables).toContain(agentApiKeys);
+
+    const never = createDbState({
+      agent: { id: agentId, companyId },
+      agentKey: { ...baseKey, lastUsedAt: null },
+    });
+    const neverRes = await request(createApp(never.db))
+      .get("/actor")
+      .set("Authorization", `Bearer ${token}`);
+    expect(neverRes.status).toBe(200);
+    expect(never.updatedTables).toContain(agentApiKeys);
   });
 });

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -306,7 +306,20 @@ export function actorMiddleware(db: Db, opts: ActorMiddlewareOptions): RequestHa
     if (boardKey) {
       const access = await boardAuth.resolveBoardAccess(boardKey.userId);
       if (access.user) {
-        await boardAuth.touchBoardApiKey(boardKey.id);
+        // Same interval + background treatment as agent key lastUsedAt below:
+        // the column is informational, so keep the write off the auth path.
+        const boardKeyLastUsedAtMs = boardKey.lastUsedAt?.getTime();
+        if (
+          !boardKeyLastUsedAtMs ||
+          Date.now() - boardKeyLastUsedAtMs >= AGENT_KEY_LAST_USED_REFRESH_MS
+        ) {
+          void boardAuth.touchBoardApiKey(boardKey.id).catch((err) => {
+            logger.warn(
+              { err, keyId: boardKey.id },
+              "Failed to refresh board API key lastUsedAt",
+            );
+          });
+        }
         req.actor = {
           type: "board",
           userId: boardKey.userId,
@@ -336,14 +349,20 @@ export function actorMiddleware(db: Db, opts: ActorMiddlewareOptions): RequestHa
       return;
     }
 
-    // lastUsedAt is informational; refreshing it once per interval instead of
-    // on every request keeps a write off the per-request auth path.
+    // lastUsedAt is informational; refreshing it once per interval and in the
+    // background keeps the write off the per-request auth path entirely.
     const lastUsedAtMs = key.lastUsedAt?.getTime();
     if (!lastUsedAtMs || Date.now() - lastUsedAtMs >= AGENT_KEY_LAST_USED_REFRESH_MS) {
-      await db
+      void db
         .update(agentApiKeys)
         .set({ lastUsedAt: new Date() })
-        .where(eq(agentApiKeys.id, key.id));
+        .where(eq(agentApiKeys.id, key.id))
+        .catch((err) => {
+          logger.warn(
+            { err, keyId: key.id },
+            "Failed to refresh agent API key lastUsedAt",
+          );
+        });
     }
 
     const agentRecord = await db

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -16,13 +16,15 @@ import { verifyLocalAgentJwt } from "../agent-auth-jwt.js";
 import { isUuidLike, normalizeAgentApiKeyScope, type DeploymentMode } from "@paperclipai/shared";
 import type { BetterAuthSessionResult } from "../auth/better-auth.js";
 import { logger } from "./logger.js";
-import { boardAuthService } from "../services/board-auth.js";
+import { BOARD_API_KEY_PREFIX, boardAuthService } from "../services/board-auth.js";
 import { ensureHumanRoleDefaultGrants } from "../services/principal-access-compatibility.js";
 import { forbidden, unprocessable } from "../errors.js";
 
 function hashToken(token: string) {
   return createHash("sha256").update(token).digest("hex");
 }
+
+export const AGENT_KEY_LAST_USED_REFRESH_MS = 60_000;
 
 function normalizeOptionalString(value: string | null | undefined) {
   return value?.trim() || null;
@@ -226,42 +228,13 @@ export function actorMiddleware(db: Db, opts: ActorMiddlewareOptions): RequestHa
       return;
     }
 
-    const boardKey = await boardAuth.findBoardApiKeyByToken(token);
-    if (boardKey) {
-      const access = await boardAuth.resolveBoardAccess(boardKey.userId);
-      if (access.user) {
-        await boardAuth.touchBoardApiKey(boardKey.id);
-        req.actor = {
-          type: "board",
-          userId: boardKey.userId,
-          userName: access.user?.name ?? null,
-          userEmail: access.user?.email ?? null,
-          companyIds: access.companyIds,
-          memberships: access.memberships,
-          isInstanceAdmin: access.isInstanceAdmin,
-          keyId: boardKey.id,
-          runId: runIdHeader || undefined,
-          source: "board_key",
-        };
-        next();
-        return;
-      }
-    }
-
-    const tokenHash = hashToken(token);
-    const key = await db
-      .select()
-      .from(agentApiKeys)
-      .where(and(eq(agentApiKeys.keyHash, tokenHash), isNull(agentApiKeys.revokedAt)))
-      .then((rows) => rows[0] ?? null);
-
-    if (!key) {
-      const claims = verifyLocalAgentJwt(token);
-      if (!claims) {
-        next();
-        return;
-      }
-
+    // Local-agent JWTs are self-contained and verified synchronously. Checking
+    // them before the key tables keeps the hot agent-heartbeat path off the
+    // database, which otherwise pays two guaranteed-miss key lookups per
+    // request; Paperclip-minted keys carry the "pcp_" prefix and never parse
+    // as JWTs, so no key token can be shadowed by this branch.
+    const claims = verifyLocalAgentJwt(token);
+    if (claims) {
       const agentRecord = await db
         .select()
         .from(agents)
@@ -325,10 +298,53 @@ export function actorMiddleware(db: Db, opts: ActorMiddlewareOptions): RequestHa
       return;
     }
 
-    await db
-      .update(agentApiKeys)
-      .set({ lastUsedAt: new Date() })
-      .where(eq(agentApiKeys.id, key.id));
+    // Board keys are only ever minted with the board prefix; skip the lookup
+    // for agent keys and other tokens.
+    const boardKey = token.startsWith(BOARD_API_KEY_PREFIX)
+      ? await boardAuth.findBoardApiKeyByToken(token)
+      : null;
+    if (boardKey) {
+      const access = await boardAuth.resolveBoardAccess(boardKey.userId);
+      if (access.user) {
+        await boardAuth.touchBoardApiKey(boardKey.id);
+        req.actor = {
+          type: "board",
+          userId: boardKey.userId,
+          userName: access.user?.name ?? null,
+          userEmail: access.user?.email ?? null,
+          companyIds: access.companyIds,
+          memberships: access.memberships,
+          isInstanceAdmin: access.isInstanceAdmin,
+          keyId: boardKey.id,
+          runId: runIdHeader || undefined,
+          source: "board_key",
+        };
+        next();
+        return;
+      }
+    }
+
+    const tokenHash = hashToken(token);
+    const key = await db
+      .select()
+      .from(agentApiKeys)
+      .where(and(eq(agentApiKeys.keyHash, tokenHash), isNull(agentApiKeys.revokedAt)))
+      .then((rows) => rows[0] ?? null);
+
+    if (!key) {
+      next();
+      return;
+    }
+
+    // lastUsedAt is informational; refreshing it once per interval instead of
+    // on every request keeps a write off the per-request auth path.
+    const lastUsedAtMs = key.lastUsedAt?.getTime();
+    if (!lastUsedAtMs || Date.now() - lastUsedAtMs >= AGENT_KEY_LAST_USED_REFRESH_MS) {
+      await db
+        .update(agentApiKeys)
+        .set({ lastUsedAt: new Date() })
+        .where(eq(agentApiKeys.id, key.id));
+    }
 
     const agentRecord = await db
       .select()

--- a/server/src/services/board-auth.ts
+++ b/server/src/services/board-auth.ts
@@ -26,8 +26,10 @@ export function tokenHashesMatch(left: string, right: string) {
   return leftBytes.length === rightBytes.length && timingSafeEqual(leftBytes, rightBytes);
 }
 
+export const BOARD_API_KEY_PREFIX = "pcp_board_";
+
 export function createBoardApiToken() {
-  return `pcp_board_${randomBytes(24).toString("hex")}`;
+  return `${BOARD_API_KEY_PREFIX}${randomBytes(24).toString("hex")}`;
 }
 
 export function createCliAuthSecret() {


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The control-plane API authenticates every agent and board request through the actor middleware, backed by a shared postgres.js connection pool
> - On busy instances (many agents heartbeating plus live dashboards polling), authenticated routes stall for 30–150s while `/api/health` stays instant; server logs show a FIFO queue-drain pattern (`GET /api/agents/me` decaying 149s → 24s over two minutes)
> - The pool defaults to 10 connections with an unbounded wait queue, and the auth middleware pays up to four sequential pool waits per request — two of them guaranteed-miss key lookups for the common local-agent JWT path — so bursts starve every DB-bound route and agents burn minutes on basic API round-trips
> - This pull request reorders the middleware to verify self-contained agent JWTs before any key-table lookup, gates the board key lookup on the `pcp_board_` mint prefix, throttles the per-request `lastUsedAt` write to once per minute, and makes the pool size configurable (default raised to 25)
> - The benefit is that authenticated API latency stays flat under heartbeat/dashboard load instead of collapsing into multi-minute queue waits

## Linked Issues or Issue Description

No existing public issue found (searched for pool/latency/slow-auth issues and PRs). Describing the bug inline per `.github/ISSUE_TEMPLATE/bug_report.yml`:

### What happened?

Authenticated API requests (e.g. `GET /api/agents/me`, issue PATCH/comment routes) intermittently take 30–150s on a local instance under normal multi-agent load, while unauthenticated `/api/health` responds in milliseconds on the same instance at the same moment. Server logs show a FIFO queue-drain pattern (`GET /api/agents/me` decaying 149s → 24s over two minutes; issue PATCH routes peaking at 366s). When the API is fronted by a reverse proxy (e.g. Tailscale serve), the same requests hang past the proxy timeout and return nothing, so remote API access breaks entirely during these windows.

### Expected behavior

Authenticated routes respond in low milliseconds regardless of concurrent heartbeat/dashboard activity, and remote reverse-proxied access stays usable.

### Steps to reproduce

1. Run an instance with ~15+ agents heartbeating and a live dashboard open (the dashboard polls `heartbeat-runs?limit=200&summary=true`, ~0.6s per query, plus per-run logs).
2. `time curl -s http://127.0.0.1:<port>/api/agents/me -H "Authorization: Bearer $KEY"` — observe multi-second to multi-minute latency during bursts while `/api/health` stays instant.
3. Synthetic reproduction on an idle instance: fire 12 concurrent requests at a heavy read route (e.g. `heartbeat-runs?limit=200&summary=true`) and measure `/api/agents/me` concurrently — it degrades from ~9ms to ~930ms (100×) while `/api/health` is unaffected, because the postgres.js pool (default max 10) is saturated and each of the auth middleware's sequential queries re-enters the unbounded wait queue.

### Paperclip version or commit

master (cf8b6e1bd)

### Deployment mode

Local (embedded Postgres)

### Installation method

npm package

### Agent adapter(s) involved

Claude local adapter (issue is adapter-independent — any load source saturating the DB pool triggers it)

## What Changed

- `server/src/middleware/auth.ts`: verify local-agent JWTs (synchronous, self-contained) before any key-table lookup, removing two guaranteed-miss DB queries from the hot agent path; behavior for all token shapes is otherwise preserved.
- `server/src/middleware/auth.ts`: skip the board API key lookup unless the bearer token starts with `pcp_board_` (the only prefix board keys are ever minted with; constant now shared from `board-auth.ts`).
- `server/src/middleware/auth.ts`: refresh `agent_api_keys.lastUsedAt` at most once per 60s per key instead of writing on every authenticated request; the column is informational.
- `packages/db/src/client.ts`: `createDb` now accepts `{ max }` and honors `PAPERCLIP_DB_POOL_MAX`, with the default pool raised from postgres.js's 10 to 25 (embedded Postgres ships with `max_connections=100`, so headroom remains).
- Regression tests: middleware tests assert JWT auth touches neither key table, non-board tokens skip the board lookup, board-prefixed tokens still hit it, and the `lastUsedAt` throttle writes only when stale; db tests cover `resolveDbPoolMax` parsing.

## Verification

- `cd server && npx vitest run src/__tests__/agent-auth-middleware.test.ts src/__tests__/agent-auth-jwt.test.ts src/__tests__/auth-routes.test.ts src/__tests__/cli-auth-routes.test.ts src/__tests__/adapter-routes-authz.test.ts src/__tests__/agent-cross-tenant-authz-routes.test.ts` — 50/50 pass
- `cd packages/db && npx vitest run src/client.test.ts` — new `resolveDbPoolMax` tests pass
- `npx tsc --noEmit` clean in both `server` and `packages/db`
- Manual: on a live instance, agent JWT and agent key requests authenticate identically before/after; under the synthetic 12-concurrent-heavy-reads load above, authenticated latency no longer collapses

## Risks

- Low risk overall; no schema or API surface changes.
- `lastUsedAt` now has up to 60s of slack; it is display/telemetry data, not used for authorization decisions.
- Board keys are matched only when the token has the `pcp_board_` prefix. All board tokens are minted via `createBoardApiToken` with that prefix, so no stored key can be orphaned; unknown-shaped tokens still fall through the full legacy lookup chain.
- Larger default pool (25) raises Postgres connection usage on constrained deployments; `PAPERCLIP_DB_POOL_MAX=10` restores the old size.

## Model Used

Claude Fable 5 (`claude-fable-5`, Anthropic) via Claude Code / Claude Agent SDK, with extended thinking and tool use (code search, local test execution, live-instance latency measurements).

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
