### PR TITLE
fix(ui): mobile sidebar edge-swipe opens on scrolls and back-navigation gestures

### DIFF
--- a/ui/src/components/Layout.tsx
+++ b/ui/src/components/Layout.tsx
@@ -28,6 +28,7 @@ import { useCompany } from "../context/CompanyContext";
 import { useSidebar } from "../context/SidebarContext";
 import { useKeyboardShortcuts } from "../hooks/useKeyboardShortcuts";
 import { useCompanyPageMemory } from "../hooks/useCompanyPageMemory";
+import { useSidebarSwipe } from "../hooks/useSidebarSwipe";
 import { healthApi } from "../api/health";
 import { instanceSettingsApi } from "../api/instanceSettings";
 import { shouldSyncCompanySelectionFromRoute } from "../lib/company-selection";
@@ -351,49 +352,7 @@ export function Layout() {
   }, [isMobile]);
 
   // Swipe gesture to open/close sidebar on mobile
-  useEffect(() => {
-    if (!isMobile) return;
-
-    const EDGE_ZONE = 30; // px from left edge to start open-swipe
-    const MIN_DISTANCE = 50; // minimum horizontal swipe distance
-    const MAX_VERTICAL = 75; // max vertical drift before we ignore
-
-    let startX = 0;
-    let startY = 0;
-
-    const onTouchStart = (e: TouchEvent) => {
-      const t = e.touches[0]!;
-      startX = t.clientX;
-      startY = t.clientY;
-    };
-
-    const onTouchEnd = (e: TouchEvent) => {
-      const t = e.changedTouches[0]!;
-      const dx = t.clientX - startX;
-      const dy = Math.abs(t.clientY - startY);
-
-      if (dy > MAX_VERTICAL) return; // vertical scroll, ignore
-
-      // Swipe right from left edge → open
-      if (!sidebarOpen && startX < EDGE_ZONE && dx > MIN_DISTANCE) {
-        setSidebarOpen(true);
-        return;
-      }
-
-      // Swipe left when open → close
-      if (sidebarOpen && dx < -MIN_DISTANCE) {
-        setSidebarOpen(false);
-      }
-    };
-
-    document.addEventListener("touchstart", onTouchStart, { passive: true });
-    document.addEventListener("touchend", onTouchEnd, { passive: true });
-
-    return () => {
-      document.removeEventListener("touchstart", onTouchStart);
-      document.removeEventListener("touchend", onTouchEnd);
-    };
-  }, [isMobile, sidebarOpen, setSidebarOpen]);
+  useSidebarSwipe({ enabled: isMobile, isOpen: sidebarOpen, onOpenChange: setSidebarOpen });
 
   const updateMobileNavVisibility = useCallback((currentTop: number) => {
     const delta = currentTop - lastMainScrollTop.current;

--- a/ui/src/hooks/useSidebarSwipe.test.tsx
+++ b/ui/src/hooks/useSidebarSwipe.test.tsx
@@ -1,0 +1,166 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useSidebarSwipe } from "./useSidebarSwipe";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+function TestHarness({
+  enabled = true,
+  isOpen = false,
+  onOpenChange,
+}: {
+  enabled?: boolean;
+  isOpen?: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  useSidebarSwipe({ enabled, isOpen, onOpenChange });
+  return <div>sidebar swipe test</div>;
+}
+
+type TouchType = "touchstart" | "touchmove" | "touchend" | "touchcancel";
+
+function touch(type: TouchType, x: number, y: number) {
+  const e = new Event(type, { bubbles: true, cancelable: true });
+  const point = { clientX: x, clientY: y };
+  const ended = type === "touchend" || type === "touchcancel";
+  Object.assign(e, { touches: ended ? [] : [point], changedTouches: [point] });
+  document.dispatchEvent(e);
+}
+
+describe("useSidebarSwipe", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  function render(props: { enabled?: boolean; isOpen?: boolean; onOpenChange: (open: boolean) => void }) {
+    act(() => {
+      root.render(<TestHarness {...props} />);
+    });
+  }
+
+  it("opens the sidebar on a deliberate horizontal swipe from the left edge", () => {
+    const onOpenChange = vi.fn();
+    render({ onOpenChange });
+
+    touch("touchstart", 10, 300);
+    touch("touchmove", 40, 302);
+    touch("touchmove", 90, 305);
+    touch("touchend", 90, 305);
+
+    expect(onOpenChange).toHaveBeenCalledWith(true);
+  });
+
+  it("ignores a diagonal scroll that starts near the left edge (GH #19)", () => {
+    const onOpenChange = vi.fn();
+    render({ onOpenChange });
+
+    // First movement is dominantly vertical — the user is scrolling, even
+    // though the gesture drifts right far enough to pass the old threshold.
+    touch("touchstart", 10, 300);
+    touch("touchmove", 40, 340);
+    touch("touchmove", 65, 370);
+    touch("touchend", 65, 370);
+
+    expect(onOpenChange).not.toHaveBeenCalled();
+  });
+
+  it("ignores a swipe that drifts mostly vertical overall", () => {
+    const onOpenChange = vi.fn();
+    render({ onOpenChange });
+
+    touch("touchstart", 10, 300);
+    touch("touchmove", 30, 300);
+    touch("touchend", 75, 240);
+
+    expect(onOpenChange).not.toHaveBeenCalled();
+  });
+
+  it("ignores a gesture the browser cancels (system back-navigation)", () => {
+    const onOpenChange = vi.fn();
+    render({ onOpenChange });
+
+    touch("touchstart", 2, 300);
+    touch("touchmove", 50, 300);
+    touch("touchcancel", 50, 300);
+    // A stray touchend after the cancel must not be attributed to the gesture.
+    touch("touchend", 120, 300);
+
+    expect(onOpenChange).not.toHaveBeenCalled();
+  });
+
+  it("ignores a tap with no movement", () => {
+    const onOpenChange = vi.fn();
+    render({ onOpenChange });
+
+    touch("touchstart", 10, 300);
+    touch("touchend", 12, 300);
+
+    expect(onOpenChange).not.toHaveBeenCalled();
+  });
+
+  it("ignores swipes that start away from the left edge", () => {
+    const onOpenChange = vi.fn();
+    render({ onOpenChange });
+
+    touch("touchstart", 100, 300);
+    touch("touchmove", 150, 300);
+    touch("touchend", 180, 300);
+
+    expect(onOpenChange).not.toHaveBeenCalled();
+  });
+
+  it("closes the sidebar on a left swipe when open", () => {
+    const onOpenChange = vi.fn();
+    render({ isOpen: true, onOpenChange });
+
+    touch("touchstart", 200, 300);
+    touch("touchmove", 150, 300);
+    touch("touchend", 120, 300);
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("tracks isOpen across re-renders", () => {
+    const onOpenChange = vi.fn();
+    render({ isOpen: false, onOpenChange });
+
+    touch("touchstart", 10, 300);
+    touch("touchmove", 50, 300);
+    touch("touchend", 90, 300);
+    expect(onOpenChange).toHaveBeenLastCalledWith(true);
+
+    render({ isOpen: true, onOpenChange });
+
+    touch("touchstart", 200, 300);
+    touch("touchmove", 150, 300);
+    touch("touchend", 120, 300);
+    expect(onOpenChange).toHaveBeenLastCalledWith(false);
+  });
+
+  it("does nothing when disabled", () => {
+    const onOpenChange = vi.fn();
+    render({ enabled: false, onOpenChange });
+
+    touch("touchstart", 10, 300);
+    touch("touchmove", 90, 300);
+    touch("touchend", 90, 300);
+
+    expect(onOpenChange).not.toHaveBeenCalled();
+  });
+});

--- a/ui/src/hooks/useSidebarSwipe.ts
+++ b/ui/src/hooks/useSidebarSwipe.ts
@@ -1,0 +1,92 @@
+import { useEffect } from "react";
+
+const EDGE_ZONE = 24; // px from left edge to start open-swipe
+const MIN_DISTANCE = 60; // minimum horizontal swipe distance
+const AXIS_LOCK_SLOP = 10; // px of movement before the gesture's axis is decided
+const MAX_SLOPE = 0.7; // max |dy|/|dx| for the finished gesture to still count
+
+export interface SidebarSwipeOptions {
+  /** Attach listeners only when true (mobile layout). */
+  enabled: boolean;
+  /** Whether the sidebar is currently open. */
+  isOpen: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+/**
+ * Edge-swipe gesture to open/close the sidebar on mobile.
+ *
+ * Deliberately conservative (GH #19): the first movement past AXIS_LOCK_SLOP
+ * locks the gesture's axis, so a vertical scroll that drifts sideways never
+ * opens the sidebar, and a `touchcancel` — fired when the system claims the
+ * touch for its own edge gesture, e.g. swipe-back navigation — discards the
+ * gesture entirely.
+ */
+export const useSidebarSwipe = ({ enabled, isOpen, onOpenChange }: SidebarSwipeOptions) => {
+  useEffect(() => {
+    if (!enabled) return;
+
+    let startX = 0;
+    let startY = 0;
+    let gesture: "idle" | "pending" | "horizontal" | "vertical" = "idle";
+
+    const onTouchStart = (e: TouchEvent) => {
+      if (e.touches.length !== 1) {
+        gesture = "idle";
+        return;
+      }
+      const t = e.touches[0]!;
+      startX = t.clientX;
+      startY = t.clientY;
+      gesture = "pending";
+    };
+
+    const onTouchMove = (e: TouchEvent) => {
+      if (gesture !== "pending") return;
+      const t = e.touches[0]!;
+      const dx = Math.abs(t.clientX - startX);
+      const dy = Math.abs(t.clientY - startY);
+      if (Math.max(dx, dy) < AXIS_LOCK_SLOP) return;
+      gesture = dx >= dy ? "horizontal" : "vertical";
+    };
+
+    const onTouchEnd = (e: TouchEvent) => {
+      const wasHorizontal = gesture === "horizontal";
+      gesture = "idle";
+      // Never locking horizontal means a tap, a vertical scroll, or no gesture.
+      if (!wasHorizontal) return;
+
+      const t = e.changedTouches[0]!;
+      const dx = t.clientX - startX;
+      const dy = Math.abs(t.clientY - startY);
+      if (dy > Math.abs(dx) * MAX_SLOPE) return; // drifted diagonal overall
+
+      // Swipe right from left edge → open
+      if (!isOpen && startX <= EDGE_ZONE && dx >= MIN_DISTANCE) {
+        onOpenChange(true);
+        return;
+      }
+
+      // Swipe left when open → close
+      if (isOpen && dx <= -MIN_DISTANCE) {
+        onOpenChange(false);
+      }
+    };
+
+    const onTouchCancel = () => {
+      gesture = "idle";
+    };
+
+    document.addEventListener("touchstart", onTouchStart, { passive: true });
+    document.addEventListener("touchmove", onTouchMove, { passive: true });
+    document.addEventListener("touchend", onTouchEnd, { passive: true });
+    document.addEventListener("touchcancel", onTouchCancel, { passive: true });
+
+    return () => {
+      document.removeEventListener("touchstart", onTouchStart);
+      document.removeEventListener("touchmove", onTouchMove);
+      document.removeEventListener("touchend", onTouchEnd);
+      document.removeEventListener("touchcancel", onTouchCancel);
+    };
+  }, [enabled, isOpen, onOpenChange]);
+};


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The web UI has a mobile layout where the navigation sidebar can be opened by swiping right from the left edge of the screen
> - The gesture recognizer was too permissive: any touch starting within 30px of the edge that ended 50px to the right counted as an open-swipe, even with up to 75px of vertical drift, and it never handled `touchcancel`
> - As a result, diagonal scrolls near the edge and system swipe-back navigation gestures kept popping the sidebar open when the user never asked for it
> - This pull request extracts the gesture into a `useSidebarSwipe` hook that locks the gesture axis on the first 10px of movement, caps overall slope, discards gestures the browser cancels (which is what happens when the OS claims an edge swipe for back-navigation), guards multi-touch, and tightens the thresholds
> - The benefit is that the sidebar only opens on a deliberate horizontal edge swipe, so scrolling and navigating back no longer trigger it — and the gesture logic is now unit-tested

## Linked Issues or Issue Description

No matching issue exists on this repo, so the underlying issue is described here following `bug_report.yml` (also reported publicly on a downstream fork: https://github.com/lacymorrow/paperclip/issues/19):

### What happened?

On mobile, the navigation sidebar opens from gestures that aren't menu swipes. Vertical/diagonal scrolling that starts near the left edge opens it, and it opens even while using the browser/OS swipe-back navigation gesture. The recognizer in `Layout.tsx` counted any touch starting < 30px from the edge that ended >= 50px to the right as an open-swipe, tolerated 75px of vertical drift, decided everything at `touchend` with no axis locking, and never listened for `touchcancel` — the event browsers fire when the system claims the touch for its own edge gesture.

### Expected behavior

The sidebar should only open on a deliberate, mostly-horizontal swipe that starts at the left edge. Scrolling and back-navigation should never open it.

### Steps to reproduce

1. Open the Paperclip UI on a phone (or DevTools mobile emulation with touch).
2. Scroll a list with your thumb starting near the left edge, drifting slightly rightward — the sidebar opens.
3. Or use the iOS/Android edge swipe-back gesture — the sidebar opens on top of the navigation.

### Paperclip version or commit

`master` (3e63a7e3e) — behavior present since the gesture was introduced.

### Deployment mode

Any (UI bug, browser-side only). Reproduced against a self-hosted instance; adapter-independent.

## What Changed

- Added `ui/src/hooks/useSidebarSwipe.ts`: extracted the mobile sidebar edge-swipe gesture out of `Layout.tsx` into a hook with a stricter recognizer:
  - Axis lock: the first 10px of movement decides horizontal vs. vertical; a gesture that starts vertical can never open the sidebar
  - Overall slope cap (|dy| ≤ 0.7·|dx|) so a horizontal start that drifts diagonal is discarded
  - `touchcancel` resets the gesture, so system edge gestures (swipe-back navigation) never open the menu
  - Multi-touch guard; taps (no axis lock) are ignored
  - Tightened thresholds: edge zone 30px → 24px, minimum travel 50px → 60px
- `ui/src/components/Layout.tsx`: replaced the inline touch-listener effect with the hook
- Added `ui/src/hooks/useSidebarSwipe.test.tsx`: 9 unit tests rendering the hook under real React, including regressions for the diagonal-scroll and cancelled-gesture (back-navigation) cases — three of these tests fail against the old logic

## Verification

- `cd ui && npx vitest run src/hooks/useSidebarSwipe.test.tsx` — 9/9 pass
- Regression proof: the recognizer was first extracted verbatim with the old thresholds and the new tests run against it — the diagonal-scroll, vertical-drift, and cancelled-gesture tests all failed (sidebar opened); they pass with the new logic
- Full `ui` vitest suite: 2039/2039 tests pass (15 files fail to *collect* in a stale local install due to missing `lexical`/`@xterm`/workspace packages — unrelated to this change, identical on `master`)
- `tsc -b` reports no errors introduced by this change (identical error set before/after on the same checkout)
- Manual: on a touch device or DevTools touch emulation, a deliberate horizontal swipe from the left edge opens the sidebar; scrolling near the edge and swipe-back navigation do not

## Risks

- Low risk, mobile-only surface. The gesture is stricter, so the main behavioral shift is that sloppy-but-intentional open-swipes (very diagonal ones) now require a cleaner horizontal motion; the sidebar remains reachable via the hamburger button regardless
- The hook now also listens to `touchmove` (passive, early-returns after axis lock), which has negligible cost and cannot block scrolling

## Model Used

Claude Fable 5 (`claude-fable-5`, Anthropic), extended thinking enabled, running in Claude Code with tool use (file edits, shell, test execution). Test-first workflow: regression tests were written and confirmed failing against the old recognizer before the fix was implemented.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes (no docs cover this gesture; hook is documented inline)
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green (will confirm once CI runs on this PR)
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups (pending bot review)
- [x] I will address all Greptile and reviewer comments before requesting merge

