### PR TITLE
perf(db): index jsonb issueId lookups on heartbeat_runs and agent_wakeup_requests

### DIFF
--- a/packages/db/src/jsonb-issue-id-expression-indexes-migration.test.ts
+++ b/packages/db/src/jsonb-issue-id-expression-indexes-migration.test.ts
@@ -1,0 +1,212 @@
+import { createHash, randomUUID } from "node:crypto";
+import fs from "node:fs";
+import { afterEach, describe, expect, it } from "vitest";
+import postgres from "postgres";
+import {
+  applyPendingMigrations,
+  inspectMigrations,
+} from "./client.js";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./test-embedded-postgres.js";
+
+const ISSUE_ID_INDEX_MIGRATION = "0147_jsonb_issue_id_expression_indexes.sql";
+const HEARTBEAT_RUNS_INDEX = "heartbeat_runs_company_context_issue_idx";
+const WAKEUP_REQUESTS_INDEX = "agent_wakeup_requests_company_payload_issue_idx";
+
+const cleanups: Array<() => Promise<void>> = [];
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+async function createTempDatabase(): Promise<string> {
+  const db = await startEmbeddedPostgresTestDatabase("paperclip-jsonb-issue-idx-");
+  cleanups.push(db.cleanup);
+  return db.connectionString;
+}
+
+async function migrationHash(migrationFile: string): Promise<string> {
+  const content = await fs.promises.readFile(
+    new URL(`./migrations/${migrationFile}`, import.meta.url),
+    "utf8",
+  );
+  return createHash("sha256").update(content).digest("hex");
+}
+
+async function makeIssueIdIndexMigrationPending(
+  sql: ReturnType<typeof postgres>,
+): Promise<void> {
+  const hash = await migrationHash(ISSUE_ID_INDEX_MIGRATION);
+  await sql`
+    DELETE FROM "drizzle"."__drizzle_migrations"
+    WHERE "hash" = ${hash}
+  `;
+}
+
+async function dropIssueIdIndexes(sql: ReturnType<typeof postgres>): Promise<void> {
+  await sql`DROP INDEX IF EXISTS "heartbeat_runs_company_context_issue_idx"`;
+  await sql`DROP INDEX IF EXISTS "agent_wakeup_requests_company_payload_issue_idx"`;
+}
+
+async function createSeedGraph(sql: ReturnType<typeof postgres>, label: string) {
+  const companyId = randomUUID();
+  const agentId = randomUUID();
+  const issueId = randomUUID();
+
+  await sql`
+    INSERT INTO "companies" ("id", "name", "issue_prefix")
+    VALUES (${companyId}, ${`Company ${label}`}, ${`T${label}`})
+  `;
+  await sql`
+    INSERT INTO "agents" ("id", "company_id", "name", "role", "adapter_type", "adapter_config")
+    VALUES (${agentId}, ${companyId}, ${`Agent ${label}`}, 'engineer', 'process', '{}'::jsonb)
+  `;
+  await sql`
+    INSERT INTO "heartbeat_runs" ("id", "company_id", "agent_id", "status", "context_snapshot")
+    VALUES (${randomUUID()}, ${companyId}, ${agentId}, 'succeeded', ${sql.json({ issueId })})
+  `;
+  await sql`
+    INSERT INTO "agent_wakeup_requests" ("id", "company_id", "agent_id", "source", "payload")
+    VALUES (${randomUUID()}, ${companyId}, ${agentId}, 'issue_event', ${sql.json({ issueId })})
+  `;
+
+  return { companyId, agentId, issueId };
+}
+
+async function expectIssueIdIndexes(sql: ReturnType<typeof postgres>): Promise<void> {
+  const indexes = await sql<{ indexname: string; indexdef: string }[]>`
+    SELECT "indexname", "indexdef"
+    FROM "pg_indexes"
+    WHERE "schemaname" = 'public'
+      AND "indexname" IN (${HEARTBEAT_RUNS_INDEX}, ${WAKEUP_REQUESTS_INDEX})
+    ORDER BY "indexname"
+  `;
+  expect(indexes).toEqual([
+    {
+      indexname: WAKEUP_REQUESTS_INDEX,
+      indexdef: expect.stringContaining("(company_id, ((payload ->> 'issueId'::text)))"),
+    },
+    {
+      indexname: HEARTBEAT_RUNS_INDEX,
+      indexdef: expect.stringContaining("(company_id, ((context_snapshot ->> 'issueId'::text)))"),
+    },
+  ]);
+}
+
+async function expectIndexScanForIssueLookups(
+  sql: ReturnType<typeof postgres>,
+  companyId: string,
+  issueId: string,
+): Promise<void> {
+  // Tiny test tables always favor a seq scan, so disable it for this session
+  // to prove the index expression matches the predicate shape used by the
+  // heartbeat/wake query sites.
+  await sql`SET enable_seqscan = off`;
+  const runPlan = await sql.unsafe(
+    `EXPLAIN (FORMAT JSON) SELECT "id" FROM "heartbeat_runs" WHERE "company_id" = '${companyId}' AND "context_snapshot" ->> 'issueId' = '${issueId}'`,
+  );
+  expect(JSON.stringify(runPlan)).toContain(HEARTBEAT_RUNS_INDEX);
+
+  const wakePlan = await sql.unsafe(
+    `EXPLAIN (FORMAT JSON) SELECT "id" FROM "agent_wakeup_requests" WHERE "company_id" = '${companyId}' AND "payload" ->> 'issueId' = '${issueId}'`,
+  );
+  expect(JSON.stringify(wakePlan)).toContain(WAKEUP_REQUESTS_INDEX);
+  await sql`RESET enable_seqscan`;
+}
+
+afterEach(async () => {
+  while (cleanups.length > 0) {
+    const cleanup = cleanups.pop();
+    await cleanup?.();
+  }
+});
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping embedded Postgres jsonb issueId index migration tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+describeEmbeddedPostgres("jsonb issueId expression index migration", () => {
+  it(
+    "fresh installs create both expression indexes and they serve issue-scoped lookups",
+    async () => {
+      const connectionString = await createTempDatabase();
+      const state = await inspectMigrations(connectionString);
+
+      expect(state.status).toBe("upToDate");
+      expect(state.availableMigrations).toContain(ISSUE_ID_INDEX_MIGRATION);
+
+      const sql = postgres(connectionString, { max: 1, onnotice: () => {} });
+      try {
+        await expectIssueIdIndexes(sql);
+        const { companyId, issueId } = await createSeedGraph(sql, "FRESH");
+        await expectIndexScanForIssueLookups(sql, companyId, issueId);
+      } finally {
+        await sql.end();
+      }
+    },
+    20_000,
+  );
+
+  it(
+    "adds the indexes to an existing database that already has run and wake data",
+    async () => {
+      const connectionString = await createTempDatabase();
+      const sql = postgres(connectionString, { max: 1, onnotice: () => {} });
+      try {
+        await dropIssueIdIndexes(sql);
+        await makeIssueIdIndexMigrationPending(sql);
+        await createSeedGraph(sql, "UPGRADE");
+      } finally {
+        await sql.end();
+      }
+
+      const pendingState = await inspectMigrations(connectionString);
+      expect(pendingState).toMatchObject({
+        status: "needsMigrations",
+        pendingMigrations: [ISSUE_ID_INDEX_MIGRATION],
+        reason: "pending-migrations",
+      });
+
+      await applyPendingMigrations(connectionString);
+
+      const verifySql = postgres(connectionString, { max: 1, onnotice: () => {} });
+      try {
+        await expectIssueIdIndexes(verifySql);
+      } finally {
+        await verifySql.end();
+      }
+
+      const finalState = await inspectMigrations(connectionString);
+      expect(finalState.status).toBe("upToDate");
+    },
+    20_000,
+  );
+
+  it(
+    "is idempotent when the indexes already exist",
+    async () => {
+      const connectionString = await createTempDatabase();
+      const sql = postgres(connectionString, { max: 1, onnotice: () => {} });
+      try {
+        await makeIssueIdIndexMigrationPending(sql);
+      } finally {
+        await sql.end();
+      }
+
+      await applyPendingMigrations(connectionString);
+
+      const verifySql = postgres(connectionString, { max: 1, onnotice: () => {} });
+      try {
+        await expectIssueIdIndexes(verifySql);
+      } finally {
+        await verifySql.end();
+      }
+
+      const finalState = await inspectMigrations(connectionString);
+      expect(finalState.status).toBe("upToDate");
+    },
+    20_000,
+  );
+});

--- a/packages/db/src/migrations/0147_jsonb_issue_id_expression_indexes.sql
+++ b/packages/db/src/migrations/0147_jsonb_issue_id_expression_indexes.sql
@@ -1,0 +1,3 @@
+CREATE INDEX IF NOT EXISTS "heartbeat_runs_company_context_issue_idx" ON "heartbeat_runs" ("company_id", ("context_snapshot" ->> 'issueId'));--> statement-breakpoint
+-- paperclip:migration-safety-ignore large-create-index-not-concurrently: the migration runner applies each migration inside a transaction, where CREATE INDEX CONCURRENTLY is not allowed; migrations run at instance startup before traffic is served, so a blocking btree build is acceptable
+CREATE INDEX IF NOT EXISTS "agent_wakeup_requests_company_payload_issue_idx" ON "agent_wakeup_requests" ("company_id", ("payload" ->> 'issueId'));

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -1016,6 +1016,13 @@
       "when": 1783822632557,
       "tag": "0146_routine_activity_gate",
       "breakpoints": true
+    },
+    {
+      "idx": 147,
+      "version": "7",
+      "when": 1784140800000,
+      "tag": "0147_jsonb_issue_id_expression_indexes",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/agent_wakeup_requests.ts
+++ b/packages/db/src/schema/agent_wakeup_requests.ts
@@ -1,3 +1,4 @@
+import { sql } from "drizzle-orm";
 import { pgTable, uuid, text, timestamp, jsonb, integer, index } from "drizzle-orm/pg-core";
 import { companies } from "./companies.js";
 import { agents } from "./agents.js";
@@ -36,5 +37,11 @@ export const agentWakeupRequests = pgTable(
       table.requestedAt,
     ),
     agentRequestedIdx: index("agent_wakeup_requests_agent_requested_idx").on(table.agentId, table.requestedAt),
+    // Wake-dedup lookups filter on the JSONB payload's issueId; see the matching
+    // expression index on heartbeat_runs.context_snapshot.
+    companyPayloadIssueIdx: index("agent_wakeup_requests_company_payload_issue_idx").on(
+      table.companyId,
+      sql`(${table.payload} ->> 'issueId')`,
+    ),
   }),
 );

--- a/packages/db/src/schema/heartbeat_runs.ts
+++ b/packages/db/src/schema/heartbeat_runs.ts
@@ -1,3 +1,4 @@
+import { sql } from "drizzle-orm";
 import { type AnyPgColumn, pgTable, uuid, text, timestamp, jsonb, index, integer, bigint, boolean } from "drizzle-orm/pg-core";
 import { companies } from "./companies.js";
 import { agents } from "./agents.js";
@@ -87,6 +88,12 @@ export const heartbeatRuns = pgTable(
     companyCreatedAtDescIdx: index("heartbeat_runs_company_created_at_desc_idx").on(
       table.companyId,
       table.createdAt.desc(),
+    ),
+    // Callers filter runs by issue via the JSONB context snapshot; without this
+    // expression index every lookup seq-scans and detoasts the whole table.
+    companyContextIssueIdx: index("heartbeat_runs_company_context_issue_idx").on(
+      table.companyId,
+      sql`(${table.contextSnapshot} ->> 'issueId')`,
     ),
   }),
 );


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The control plane links heartbeat runs and wakeup requests to issues through JSONB payloads: `heartbeat_runs.context_snapshot ->> 'issueId'` and `agent_wakeup_requests.payload ->> 'issueId'`
> - Dozens of hot query sites (heartbeat scheduling/dedup, activity feeds, cost roll-ups, issue-tree control, agent routes) filter on exactly these expressions, but neither table has an index covering them
> - Every issue-scoped lookup therefore seq-scans and detoasts the table; both tables are among the largest in an active instance (wakeup requests estimated in the millions of rows), so these lookups get slower as the instance ages and compound the DB-pool pressure that slows authenticated routes (see #9280)
> - This pull request adds composite expression indexes on `(company_id, <jsonb expr> )` for both tables, matching the predicate shape used at the query sites
> - The benefit is that issue-scoped run/wake lookups become index scans instead of full-table scans, keeping heartbeat and dashboard queries flat as run history grows

## Linked Issues or Issue Description

Refs #9280 — same root investigation (slow authenticated API under agent/dashboard load). #9280 removes redundant auth-path queries and right-sizes the pool; this PR shortens the issue-scoped queries that occupy those pool connections.

No standalone public issue exists for the missing indexes; describing inline per `.github/ISSUE_TEMPLATE/bug_report.yml`:

### What happened?

Issue-scoped queries against `heartbeat_runs` and `agent_wakeup_requests` (e.g. wake dedup, per-issue activity, cost roll-ups) filter on `context_snapshot ->> 'issueId'` / `payload ->> 'issueId'`. Neither table indexes those expressions, so Postgres seq-scans and detoasts the JSONB column for every lookup. On long-lived instances these tables grow into the hundreds of thousands to millions of rows, and each lookup holds a pool connection for the duration of the scan.

### Expected behavior

Issue-scoped run and wake lookups should be index scans with latency independent of total table size.

### Steps to reproduce

1. On an instance with substantial run history, run `EXPLAIN ANALYZE SELECT id FROM heartbeat_runs WHERE company_id = '<id>' AND context_snapshot ->> 'issueId' = '<issue-id>';`
2. Observe a sequential scan over the whole table; the same happens for `agent_wakeup_requests.payload ->> 'issueId'`.
3. After this migration, both plans use the new expression indexes.

### Paperclip version or commit

master (3e63a7e3e)

### Deployment mode

Local (embedded Postgres)

### Installation method

npm package

### Agent adapter(s) involved

Adapter-independent (server/DB layer).

## What Changed

- New migration `0147_jsonb_issue_id_expression_indexes.sql`: `CREATE INDEX IF NOT EXISTS` on `heartbeat_runs (company_id, (context_snapshot ->> 'issueId'))` and `agent_wakeup_requests (company_id, (payload ->> 'issueId'))`.
- Matching Drizzle schema index definitions on `heartbeatRuns` and `agentWakeupRequests` so generated schema stays in sync.
- Journal entry `idx 137` added to `_journal.json`.
- Regression test `jsonb-issue-id-expression-indexes-migration.test.ts`: fresh installs get both indexes and issue-scoped lookups plan as index scans; upgrading databases with existing run/wake data gain the indexes; re-applying is idempotent.
- The `agent_wakeup_requests` statement carries a `migration-safety-ignore large-create-index-not-concurrently` pragma: the migration runner applies each migration inside a transaction, where `CREATE INDEX CONCURRENTLY` is not allowed, and migrations run at instance startup before traffic is served, so a blocking build is acceptable.

## Verification

- `pnpm --filter @paperclipai/db run typecheck` — migration numbering + safety checks and `tsc --noEmit` pass.
- `npx vitest run packages/db/src/jsonb-issue-id-expression-indexes-migration.test.ts` — new regression test for this migration against a real embedded Postgres: fresh install creates both indexes and `EXPLAIN` (with `enable_seqscan = off`) shows issue-scoped lookups on both tables using them; a pre-0147 database with existing run/wake data gains the indexes on upgrade; re-applying is idempotent. 3/3 pass.
- `npx vitest run packages/db/src/issue-comment-derived-attribution-migration.test.ts` — applies the full migration chain (including 0147) against a real embedded Postgres on a fresh install and on pre-populated databases; 3/3 pass.
- Grepped `server/src` for `->> 'issueId'` query sites to confirm the index column shape `(company_id, expr)` matches the predicates in heartbeat, activity, costs, and issue-tree-control services.

## Risks

- Migration safety: additive `CREATE INDEX IF NOT EXISTS` only — no data rewrite, idempotent, safe to re-run. The blocking index build on large `agent_wakeup_requests` tables runs during startup migration, not while serving traffic (rationale in the in-file pragma).
- Queries that OR the plain `issueId` key with `payload -> '_paperclipWakeContext' ->> 'issueId'` will not become pure index scans from this change alone; this PR intentionally keeps scope to the two dominant expressions.
- No API or behavior changes; write amplification of two additional btree entries per insert is negligible relative to existing indexes on these tables.

## Model Used

Claude Fable 5 (Anthropic, model ID `claude-fable-5`) via Claude Code — extended thinking with tool use (shell, file edits, embedded-Postgres test runs).

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

