### PR TITLE
[codex] Trust managed non-git workspaces

### DIFF
--- a/packages/adapters/codex-local/src/server/execute.remote.test.ts
+++ b/packages/adapters/codex-local/src/server/execute.remote.test.ts
@@ -110,6 +110,7 @@ describe("codex remote execution", () => {
       },
       config: {
         command: "codex",
+        engine: "cli",
         env: {
           CODEX_HOME: codexHomeDir,
         },
@@ -162,6 +163,7 @@ describe("codex remote execution", () => {
       },
       config: {
         command: "codex",
+        engine: "cli",
         env: {
           CODEX_HOME: codexHomeDir,
         },

--- a/packages/adapters/codex-local/src/server/execute.remote.test.ts
+++ b/packages/adapters/codex-local/src/server/execute.remote.test.ts
@@ -84,6 +84,107 @@ describe("codex remote execution", () => {
     }
   });
 
+  it("adds the git trust bypass for local managed project-primary workspaces outside a git checkout", async () => {
+    const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-codex-managed-nongit-"));
+    cleanupDirs.push(rootDir);
+    const workspaceDir = path.join(rootDir, "workspace");
+    const codexHomeDir = path.join(rootDir, "codex-home");
+    await mkdir(workspaceDir, { recursive: true });
+    await mkdir(codexHomeDir, { recursive: true });
+    await writeFile(path.join(codexHomeDir, "auth.json"), "{}", "utf8");
+
+    await execute({
+      runId: "run-managed-nongit",
+      agent: {
+        id: "agent-1",
+        companyId: "company-1",
+        name: "CodexCoder",
+        adapterType: "codex_local",
+        adapterConfig: {},
+      },
+      runtime: {
+        sessionId: null,
+        sessionParams: null,
+        sessionDisplayId: null,
+        taskKey: null,
+      },
+      config: {
+        command: "codex",
+        env: {
+          CODEX_HOME: codexHomeDir,
+        },
+      },
+      context: {
+        paperclipWorkspace: {
+          cwd: workspaceDir,
+          source: "project_primary",
+          strategy: "project_primary",
+        },
+      },
+      onLog: async () => {},
+    });
+
+    expect(runChildProcess).toHaveBeenCalledTimes(1);
+    const call = runChildProcess.mock.calls[0] as unknown as [string, string, string[]] | undefined;
+    expect(call?.[2]).toEqual([
+      "exec",
+      "--json",
+      "--skip-git-repo-check",
+      "-",
+    ]);
+  });
+
+  it("does not add the git trust bypass for local project-primary workspaces inside a git checkout", async () => {
+    const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-codex-managed-git-"));
+    cleanupDirs.push(rootDir);
+    const workspaceDir = path.join(rootDir, "workspace");
+    const nestedWorkspaceDir = path.join(workspaceDir, "nested");
+    const codexHomeDir = path.join(rootDir, "codex-home");
+    await mkdir(nestedWorkspaceDir, { recursive: true });
+    await mkdir(codexHomeDir, { recursive: true });
+    await writeFile(path.join(workspaceDir, ".git"), "gitdir: /tmp/paperclip-fixture.git\n", "utf8");
+    await writeFile(path.join(codexHomeDir, "auth.json"), "{}", "utf8");
+
+    await execute({
+      runId: "run-managed-git",
+      agent: {
+        id: "agent-1",
+        companyId: "company-1",
+        name: "CodexCoder",
+        adapterType: "codex_local",
+        adapterConfig: {},
+      },
+      runtime: {
+        sessionId: null,
+        sessionParams: null,
+        sessionDisplayId: null,
+        taskKey: null,
+      },
+      config: {
+        command: "codex",
+        env: {
+          CODEX_HOME: codexHomeDir,
+        },
+      },
+      context: {
+        paperclipWorkspace: {
+          cwd: nestedWorkspaceDir,
+          source: "project_primary",
+          strategy: "project_primary",
+        },
+      },
+      onLog: async () => {},
+    });
+
+    expect(runChildProcess).toHaveBeenCalledTimes(1);
+    const call = runChildProcess.mock.calls[0] as unknown as [string, string, string[]] | undefined;
+    expect(call?.[2]).toEqual([
+      "exec",
+      "--json",
+      "-",
+    ]);
+  });
+
   it("prepares the workspace, syncs CODEX_HOME, and restores workspace changes for remote SSH execution", async () => {
     const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-codex-remote-"));
     cleanupDirs.push(rootDir);

--- a/packages/adapters/codex-local/src/server/execute.ts
+++ b/packages/adapters/codex-local/src/server/execute.ts
@@ -149,6 +149,16 @@ async function isLikelyPaperclipRepoRoot(candidate: string): Promise<boolean> {
   return hasWorkspace && hasPackageJson && hasServerDir && hasAdapterUtilsDir;
 }
 
+async function isInsideGitWorkspace(candidate: string): Promise<boolean> {
+  let cursor = path.resolve(candidate);
+  for (;;) {
+    if (await pathExists(path.join(cursor, ".git"))) return true;
+    const parent = path.dirname(cursor);
+    if (parent === cursor) return false;
+    cursor = parent;
+  }
+}
+
 async function isLikelyPaperclipRuntimeSkillPath(
   candidate: string,
   skillName: string,
@@ -522,6 +532,16 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     const runtimeExecutionTarget = overrideAdapterExecutionTargetRemoteCwd(executionTarget, effectiveExecutionCwd);
     const executionTargetIsSandbox =
       runtimeExecutionTarget?.kind === "remote" && runtimeExecutionTarget.transport === "sandbox";
+    const executionTargetNeedsGitTrustBypass =
+      executionTargetIsSandbox ||
+      (
+        !executionTargetIsRemote &&
+        workspaceSource === "project_primary" &&
+        workspaceStrategy !== "git_worktree" &&
+        workspaceRepoUrl.length === 0 &&
+        workspaceWorktreePath.length === 0 &&
+        !(await isInsideGitWorkspace(effectiveExecutionCwd))
+      );
     const restoreRemoteWorkspace = preparedExecutionTargetRuntime
       ? () => preparedExecutionTargetRuntime.restoreWorkspace((line) => onLog("stdout", line))
       : null;
@@ -792,9 +812,11 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       }
       return notes;
     })();
-    if (executionTargetIsSandbox) {
+    if (executionTargetNeedsGitTrustBypass) {
       commandNotes.push(
-        "Added --skip-git-repo-check for sandbox execution because Codex requires an explicit trust bypass in headless remote workspaces.",
+        executionTargetIsSandbox
+          ? "Added --skip-git-repo-check for sandbox execution because Codex requires an explicit trust bypass in headless remote workspaces."
+          : "Added --skip-git-repo-check for managed project-primary execution because the workspace is not inside a git checkout.",
       );
     }
     if (preparedRuntimeConfig.notes.length > 0) {
@@ -824,7 +846,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         forceSaferInvocation ? { ...config, fastMode: false } : config,
         {
           resumeSessionId,
-          skipGitRepoCheck: executionTargetIsSandbox,
+          skipGitRepoCheck: executionTargetNeedsGitTrustBypass,
         },
       );
       const args = execArgs.args;


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Local adapters launch provider CLIs, including Codex, inside a selected execution workspace.
> - Some Paperclip-managed project-primary workspaces are intentionally plain directories rather than git checkouts.
> - Codex rejects untrusted non-git directories unless the adapter passes its git trust bypass flag.
> - The Codex adapter already bypassed this check for sandbox targets, but not for local managed project-primary directories.
> - This pull request adds a narrow bypass for local managed non-git project workspaces while preserving normal behavior for real git and remote SSH workspaces.
> - The benefit is that managed routine and worker runs can start in their configured project workspace instead of failing before agent code runs.

## Linked Issues or Issue Description

No public GitHub issue currently tracks this exact failure. I searched open GitHub issues for `codex skip-git-repo-check trusted directory workspace` and open PRs for `codex local skip git repo check trust managed workspace`; only this PR matched the fix.

### Bug report

#### Pre-submission checklist

- [x] I have searched existing open and closed issues and this is not a duplicate.
- [x] I am on the latest released version of Paperclip (or can reproduce on `master`).
- [x] I have confirmed the error originates in Paperclip itself, not in my agent adapter, API provider, or local configuration.

#### What happened?

A local Codex run configured to use a Paperclip-managed project-primary workspace failed before agent code started with Codex's trusted-directory error because the workspace directory was not inside a git repository and the adapter did not pass `--skip-git-repo-check`.

#### Expected behavior

Paperclip-managed local project workspaces should be trusted by the adapter when they are intentionally non-git directories. Remote SSH git workspaces and local git/worktree directories should keep the existing git-check behavior.

#### Steps to reproduce

1. Configure a local Codex adapter run with `workspaceStrategy=project_primary`.
2. Point the project workspace at a path that has no `.git` directory or `.git` file in its ancestor chain.
3. Start the run.
4. Before this fix, the spawned Codex command omits `--skip-git-repo-check` and exits during preflight.

#### Paperclip version or commit

Reproduced on `master` before this PR.

#### Deployment mode

Local dev (`pnpm dev`) with local adapter execution.

#### Installation method

Built from source (`pnpm dev` / `pnpm build`).

#### Agent adapter(s) involved

- [x] Codex

#### Database mode

Not database-related.

#### Access context

Agent.

#### Node.js version

Not version-specific.

#### Operating system

Linux local adapter host.

#### Relevant logs or output

```shell
Not inside a trusted directory and --skip-git-repo-check was not specified.
```

#### Relevant config (if applicable)

```json
{
  "adapterType": "codex_local",
  "workspaceStrategy": "project_primary"
}
```

#### Additional context

The failing workspace shape is a Paperclip-managed project workspace that is a plain directory by design, not a git checkout.

#### Privacy checklist

- [x] I have reviewed all pasted output for PII (usernames, file paths, API keys, tokens, company names) and redacted where necessary.

## What Changed

- Added an `isInsideGitWorkspace` helper that detects both `.git` directories and worktree-style `.git` files in the workspace ancestor chain.
- Broadened Codex argument construction so `--skip-git-repo-check` is passed for local, managed, project-primary, non-git workspaces that are not already inside a git checkout.
- Preserved the existing sandbox bypass and kept remote SSH execution excluded from the new local managed-workspace bypass.
- Added regression tests for a plain managed non-git workspace and for a nested workspace inside a git/worktree-style checkout. The new tests are pinned to `engine: "cli"` because this assertion verifies Codex CLI argument construction while the adapter package now defaults local execution through ACP.

## Verification

- PASS: `pnpm exec vitest run --root packages/adapters/codex-local --config vitest.config.ts src/server/execute.remote.test.ts` (1 file, 6 tests).
- PASS: `pnpm test:run:general -- --group general-workspaces-b` after commit `f0e95a1` (shared 34 files/214 tests, skills-catalog 4/17, db 11/74, adapter-utils 13/187, adapter-codex-local 15/101, adapter-opencode-local 7/33, plugin-sdk 3/16, create-paperclip-plugin 1/2).
- PASS: `git diff --check -- packages/adapters/codex-local/src/server/execute.ts packages/adapters/codex-local/src/server/execute.remote.test.ts`.
- PASS: GitHub PR workflow for commit `c106a92` is green, including `verify`, `Build`, `Typecheck + Release Registry`, `General tests (workspaces-b)`, all server shards, serialized server shards, e2e, canary, commitperclip review, Greptile, Socket, and Snyk.

## Risks

Low risk. The bypass is limited to local managed project-primary workspaces that are neither remote nor git-worktree execution targets and that do not have a `.git` entry in their ancestor chain. The main risk is misclassifying a git workspace, covered by the regression test that uses a worktree-style `.git` file. Remote SSH git workspace behavior remains unchanged.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

OpenAI GPT-5 Codex, CLI coding-agent environment with shell, git, GitHub CLI, and local test execution. Reasoning was used internally; no hidden reasoning content is required to review the diff.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [ ] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

