### PR TITLE
Classify Claude provider quota failures

### DIFF
--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -46,11 +46,11 @@ import {
 } from "@paperclipai/adapter-utils/server-utils";
 import {
   parseClaudeStreamJson,
+  classifyClaudeProviderLimit,
   describeClaudeFailure,
   detectClaudeLoginRequired,
   extractClaudeRetryNotBefore,
   isClaudeMaxTurnsResult,
-  isClaudeProviderQuotaError,
   isClaudeRefusalResult,
   isClaudeTransientUpstreamError,
   isClaudeUnknownSessionError,
@@ -864,41 +864,53 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
 
     if (!parsed) {
       const fallbackErrorMessage = parseFallbackErrorMessage(proc);
-      const providerQuota =
+      const providerLimit =
         !loginMeta.requiresLogin &&
-        (proc.exitCode ?? 0) !== 0 &&
-        isClaudeProviderQuotaError({
-          parsed: null,
-          stdout: proc.stdout,
-          stderr: proc.stderr,
-          errorMessage: fallbackErrorMessage,
-        });
+        (proc.exitCode ?? 0) !== 0
+          ? classifyClaudeProviderLimit({
+              parsed: null,
+              stdout: proc.stdout,
+              stderr: proc.stderr,
+              errorMessage: fallbackErrorMessage,
+            })
+          : null;
       const transientUpstream =
         !loginMeta.requiresLogin &&
-        !providerQuota &&
         (proc.exitCode ?? 0) !== 0 &&
-        isClaudeTransientUpstreamError({
-          parsed: null,
-          stdout: proc.stdout,
-          stderr: proc.stderr,
-          errorMessage: fallbackErrorMessage,
-        });
-      const transientRetryNotBefore = providerQuota || transientUpstream
+        (providerLimit !== null ||
+          isClaudeTransientUpstreamError({
+            parsed: null,
+            stdout: proc.stdout,
+            stderr: proc.stderr,
+            errorMessage: fallbackErrorMessage,
+          }));
+      const transientRetryNotBefore = transientUpstream
         ? extractClaudeRetryNotBefore({
             parsed: null,
             stdout: proc.stdout,
             stderr: proc.stderr,
             errorMessage: fallbackErrorMessage,
-          })
+        })
         : null;
       const errorCode = loginMeta.requiresLogin
         ? "claude_auth_required"
-        : providerQuota
-        ? "provider_quota"
         : transientUpstream
-        ? "claude_transient_upstream"
+        ? providerLimit?.errorCode ?? "claude_transient_upstream"
         : null;
-      const errorFamily = providerQuota ? "provider_quota" : transientUpstream ? "transient_upstream" : null;
+      const providerRetryMeta = providerLimit
+        ? {
+            provider: providerLimit.provider,
+            retryGuidance: providerLimit.retryGuidance,
+            ...(transientRetryNotBefore ? { resetAt: transientRetryNotBefore.toISOString() } : {}),
+          }
+        : null;
+      const mergedErrorMeta = errorMeta || providerRetryMeta
+        ? {
+            ...(errorMeta ?? {}),
+            ...(providerRetryMeta ?? {}),
+          }
+        : errorMeta;
+      const errorFamily = transientUpstream ? "transient_upstream" : null;
       return {
         exitCode: proc.exitCode,
         signal: proc.signal,
@@ -907,19 +919,17 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         errorCode,
         errorFamily,
         retryNotBefore: transientRetryNotBefore ? transientRetryNotBefore.toISOString() : null,
-        errorMeta,
+        errorMeta: mergedErrorMeta,
         resultJson: {
           stdout: proc.stdout,
           stderr: proc.stderr,
           ...(errorFamily ? { errorFamily } : {}),
+          ...(providerRetryMeta ?? {}),
           ...(transientRetryNotBefore
             ? { retryNotBefore: transientRetryNotBefore.toISOString() }
             : {}),
           ...(transientRetryNotBefore
             ? { transientRetryNotBefore: transientRetryNotBefore.toISOString() }
-            : {}),
-          ...(providerQuota && transientRetryNotBefore
-            ? { providerQuotaRetryNotBefore: transientRetryNotBefore.toISOString() }
             : {}),
         },
         clearSession: Boolean(opts.clearSessionOnMissingSession),
@@ -977,30 +987,31 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     const errorMessage = failed
       ? describeClaudeFailure(parsed) ?? `Claude exited with code ${proc.exitCode ?? -1}`
       : null;
-    const providerQuota =
+    const providerLimit =
       failed &&
       !loginMeta.requiresLogin &&
       !clearSessionForMaxTurns &&
-      !poisonedPreviousMessageId &&
-      isClaudeProviderQuotaError({
-        parsed,
-        stdout: proc.stdout,
-        stderr: proc.stderr,
-        errorMessage,
-      });
+      !poisonedPreviousMessageId
+        ? classifyClaudeProviderLimit({
+            parsed,
+            stdout: proc.stdout,
+            stderr: proc.stderr,
+            errorMessage,
+          })
+        : null;
     const transientUpstream =
       failed &&
       !loginMeta.requiresLogin &&
       !clearSessionForMaxTurns &&
       !poisonedPreviousMessageId &&
-      !providerQuota &&
-      isClaudeTransientUpstreamError({
-        parsed,
-        stdout: proc.stdout,
-        stderr: proc.stderr,
-        errorMessage,
-      });
-    const transientRetryNotBefore = providerQuota || transientUpstream
+      (providerLimit !== null ||
+        isClaudeTransientUpstreamError({
+          parsed,
+          stdout: proc.stdout,
+          stderr: proc.stderr,
+          errorMessage,
+        }));
+    const transientRetryNotBefore = transientUpstream
       ? extractClaudeRetryNotBefore({
           parsed,
           stdout: proc.stdout,
@@ -1014,16 +1025,25 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       ? "max_turns_exhausted"
       : failed && poisonedPreviousMessageId
       ? "claude_poisoned_previous_message_id"
-      : providerQuota
-      ? "provider_quota"
       : transientUpstream
-      ? "claude_transient_upstream"
+      ? providerLimit?.errorCode ?? "claude_transient_upstream"
       : claudeRefusal
       ? "claude_refusal"
       : null;
-    const errorFamily = providerQuota
-      ? "provider_quota"
-      : transientUpstream
+    const providerRetryMeta = providerLimit
+      ? {
+          provider: providerLimit.provider,
+          retryGuidance: providerLimit.retryGuidance,
+          ...(transientRetryNotBefore ? { resetAt: transientRetryNotBefore.toISOString() } : {}),
+        }
+      : null;
+    const mergedErrorMeta = errorMeta || providerRetryMeta
+      ? {
+          ...(errorMeta ?? {}),
+          ...(providerRetryMeta ?? {}),
+        }
+      : errorMeta;
+    const errorFamily = transientUpstream
       ? "transient_upstream"
       : claudeRefusal
       ? "model_refusal"
@@ -1034,9 +1054,9 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       ...(failed && poisonedPreviousMessageId ? { stopReason: "claude_poisoned_previous_message_id" } : {}),
       ...(claudeRefusal ? { stopReason: "refusal", errorFamily: "model_refusal" } : {}),
       ...(errorFamily ? { errorFamily } : {}),
+      ...(providerRetryMeta ?? {}),
       ...(transientRetryNotBefore ? { retryNotBefore: transientRetryNotBefore.toISOString() } : {}),
       ...(transientRetryNotBefore ? { transientRetryNotBefore: transientRetryNotBefore.toISOString() } : {}),
-      ...(providerQuota && transientRetryNotBefore ? { providerQuotaRetryNotBefore: transientRetryNotBefore.toISOString() } : {}),
     };
 
     return {
@@ -1047,7 +1067,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       errorCode: resolvedErrorCode,
       errorFamily,
       retryNotBefore: transientRetryNotBefore ? transientRetryNotBefore.toISOString() : null,
-      errorMeta,
+      errorMeta: mergedErrorMeta,
       usage,
       sessionId: resolvedSessionId,
       sessionParams: resolvedSessionParams,

--- a/packages/adapters/claude-local/src/server/parse.test.ts
+++ b/packages/adapters/claude-local/src/server/parse.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  classifyClaudeProviderLimit,
   detectClaudeLoginRequired,
   extractClaudeRetryNotBefore,
   isClaudeProviderQuotaError,
@@ -51,7 +52,7 @@ describe("isClaudeTransientUpstreamError", () => {
       isClaudeTransientUpstreamError({
         errorMessage: "You're out of extra usage · resets 4pm (America/Chicago)",
       }),
-    ).toBe(false);
+    ).toBe(true);
   });
 
   it("classifies Claude session-limit windows as provider quota and extracts the retry time", () => {
@@ -59,7 +60,7 @@ describe("isClaudeTransientUpstreamError", () => {
     const errorMessage = "You've hit your session limit - resets at 4pm (America/Chicago).";
 
     expect(isClaudeProviderQuotaError({ errorMessage })).toBe(true);
-    expect(isClaudeTransientUpstreamError({ errorMessage })).toBe(false);
+    expect(isClaudeTransientUpstreamError({ errorMessage })).toBe(true);
     expect(extractClaudeRetryNotBefore({ errorMessage }, now)?.toISOString()).toBe(
       "2026-04-22T21:00:00.000Z",
     );
@@ -149,6 +150,44 @@ describe("isClaudeTransientUpstreamError", () => {
         },
       }),
     ).toBe(false);
+  });
+});
+
+describe("classifyClaudeProviderLimit", () => {
+  it("classifies Claude session-limit wording separately from generic transient failures", () => {
+    expect(
+      classifyClaudeProviderLimit({
+        errorMessage: "You've hit your session limit. Try again after 4pm (America/Chicago).",
+      }),
+    ).toMatchObject({
+      errorCode: "provider_session_limit",
+      provider: "anthropic",
+    });
+  });
+
+  it("classifies quota and rate-limit failures with provider-level codes", () => {
+    expect(
+      classifyClaudeProviderLimit({
+        errorMessage: "You're out of extra usage · resets 4pm (America/Chicago)",
+      })?.errorCode,
+    ).toBe("provider_quota_exhausted");
+    expect(
+      classifyClaudeProviderLimit({
+        parsed: {
+          errors: [{ type: "rate_limit_error", message: "Rate limit reached for requests." }],
+        },
+      })?.errorCode,
+    ).toBe("provider_rate_limited");
+  });
+
+  it("keeps generic overloaded failures unclassified", () => {
+    expect(
+      classifyClaudeProviderLimit({
+        parsed: {
+          errors: [{ type: "overloaded_error", message: "Overloaded_error: API is overloaded." }],
+        },
+      }),
+    ).toBeNull();
   });
 });
 

--- a/packages/adapters/claude-local/src/server/parse.ts
+++ b/packages/adapters/claude-local/src/server/parse.ts
@@ -10,11 +10,21 @@ const CLAUDE_AUTH_REQUIRED_RE = /(?:not\s+logged\s+in|please\s+log\s+in|please\s
 const URL_RE = /(https?:\/\/[^\s'"`<>()[\]{};,!?]+[^\s'"`<>()[\]{};,!.?:]+)/gi;
 
 const CLAUDE_TRANSIENT_UPSTREAM_RE =
-  /(?:rate[-\s]?limit(?:ed)?|rate_limit_error|too\s+many\s+requests|\b429\b|overloaded(?:_error)?|server\s+overloaded|service\s+unavailable|\b503\b|\b529\b|high\s+demand|try\s+again\s+later|temporarily\s+unavailable|throttl(?:ed|ing)|throttlingexception|servicequotaexceededexception|out\s+of\s+extra\s+usage|extra\s+usage\b|claude\s+usage\s+limit\s+reached|5[-\s]?hour\s+limit\s+reached|weekly\s+limit\s+reached|usage\s+limit\s+reached|usage\s+cap\s+reached)/i;
+  /(?:rate[-\s]?limit(?:ed)?|rate_limit_error|too\s+many\s+requests|\b429\b|overloaded(?:_error)?|server\s+overloaded|service\s+unavailable|\b503\b|\b529\b|high\s+demand|try\s+again\s+later|temporarily\s+unavailable|throttl(?:ed|ing)|throttlingexception|servicequotaexceededexception|you['’]ve\s+hit\s+your\s+session\s+limit|session\s+limit\s+(?:reached|exceeded)|out\s+of\s+extra\s+usage|extra\s+usage\b|claude\s+usage\s+limit\s+reached|5[-\s]?hour\s+limit\s+reached|weekly\s+limit\s+reached|usage\s+limit\s+reached|usage\s+cap\s+reached)/i;
+const CLAUDE_PROVIDER_SESSION_LIMIT_RE =
+  /(?:you['’]ve\s+hit\s+your\s+session\s+limit|session\s+limit\s+(?:reached|exceeded)|5[-\s]?hour\s+limit\s+reached|weekly\s+limit\s+reached)/i;
 const CLAUDE_PROVIDER_QUOTA_RE =
-  /(?:you(?:'|’)ve\s+hit\s+your\s+session\s+limit|session\s+limit\s+(?:reached|exceeded)|out\s+of\s+extra\s+usage|extra\s+usage\b|claude\s+usage\s+limit\s+reached|5[-\s]?hour\s+limit\s+reached|weekly\s+limit\s+reached|usage\s+limit\s+reached|usage\s+cap\s+reached|servicequotaexceededexception)/i;
+  /(?:out\s+of\s+extra\s+usage|extra\s+usage\b|claude\s+usage\s+limit\s+reached|usage\s+limit\s+reached|usage\s+cap\s+reached|servicequotaexceededexception|quota\s+(?:exceeded|exhausted)|over\s+quota)/i;
+const CLAUDE_PROVIDER_RATE_LIMIT_RE =
+  /(?:rate[-\s]?limit(?:ed)?|rate_limit_error|too\s+many\s+requests|\b429\b|throttl(?:ed|ing)|throttlingexception)/i;
 const CLAUDE_EXTRA_USAGE_RESET_RE =
   /(?:you(?:'|’)ve\s+hit\s+your\s+session\s+limit|session\s+limit\s+(?:reached|exceeded)|out\s+of\s+extra\s+usage|extra\s+usage|usage\s+limit\s+reached|usage\s+cap\s+reached|5[-\s]?hour\s+limit\s+reached|weekly\s+limit\s+reached|claude\s+usage\s+limit\s+reached)[\s\S]{0,120}?\bresets?\s+(?:at\s+)?([^\n()]+?)(?:\s*\(([^)]+)\))?(?:[.!]|\n|$)/i;
+
+export type ClaudeProviderLimitClassification = {
+  errorCode: "provider_quota_exhausted" | "provider_session_limit" | "provider_rate_limited";
+  provider: "anthropic";
+  retryGuidance: string;
+};
 
 export function parseClaudeStreamJson(stdout: string) {
   let sessionId: string | null = null;
@@ -431,7 +441,6 @@ export function isClaudeTransientUpstreamError(input: {
 
   const haystack = buildClaudeTransientHaystack(input);
   if (!haystack) return false;
-  if (isClaudeProviderQuotaError(input)) return false;
   return CLAUDE_TRANSIENT_UPSTREAM_RE.test(haystack);
 }
 
@@ -441,18 +450,51 @@ export function isClaudeProviderQuotaError(input: {
   stderr?: string | null;
   errorMessage?: string | null;
 }): boolean {
+  return classifyClaudeProviderLimit(input) !== null;
+}
+
+export function classifyClaudeProviderLimit(input: {
+  parsed?: Record<string, unknown> | null;
+  stdout?: string | null;
+  stderr?: string | null;
+  errorMessage?: string | null;
+}): ClaudeProviderLimitClassification | null {
   const parsed = input.parsed ?? null;
   if (parsed && (isClaudeMaxTurnsResult(parsed) || isClaudeUnknownSessionError(parsed) || isClaudePoisonedPreviousMessageIdError(parsed) || isClaudeImageProcessingError(parsed))) {
-    return false;
+    return null;
   }
   const loginMeta = detectClaudeLoginRequired({
     parsed,
     stdout: input.stdout ?? "",
     stderr: input.stderr ?? "",
   });
-  if (loginMeta.requiresLogin) return false;
+  if (loginMeta.requiresLogin) return null;
 
   const haystack = buildClaudeTransientHaystack(input);
-  if (!haystack) return false;
-  return CLAUDE_PROVIDER_QUOTA_RE.test(haystack);
+  if (!haystack || !CLAUDE_TRANSIENT_UPSTREAM_RE.test(haystack)) return null;
+  if (CLAUDE_PROVIDER_SESSION_LIMIT_RE.test(haystack)) {
+    return {
+      errorCode: "provider_session_limit",
+      provider: "anthropic",
+      retryGuidance: "Switch to another approved lane or wait for the Claude session window to reset before retrying this provider.",
+    };
+  }
+
+  if (CLAUDE_PROVIDER_QUOTA_RE.test(haystack)) {
+    return {
+      errorCode: "provider_quota_exhausted",
+      provider: "anthropic",
+      retryGuidance: "Switch to another approved lane or wait for Anthropic quota to reset before retrying this provider.",
+    };
+  }
+
+  if (CLAUDE_PROVIDER_RATE_LIMIT_RE.test(haystack)) {
+    return {
+      errorCode: "provider_rate_limited",
+      provider: "anthropic",
+      retryGuidance: "Wait for the provider rate limit to clear or switch to another approved lane.",
+    };
+  }
+
+  return null;
 }

--- a/server/src/__tests__/claude-local-execute.test.ts
+++ b/server/src/__tests__/claude-local-execute.test.ts
@@ -1337,18 +1337,78 @@ describe("claude execute", () => {
       });
 
       expect(result.exitCode).toBe(1);
-      expect(result.errorCode).toBe("provider_quota");
-      expect(result.errorFamily).toBe("provider_quota");
+      expect(result.errorCode).toBe("provider_quota_exhausted");
+      expect(result.errorFamily).toBe("transient_upstream");
       const expectedRetryNotBefore = "2026-04-22T21:00:00.000Z";
       expect(result.retryNotBefore).toBe(expectedRetryNotBefore);
       expect(result.resultJson?.retryNotBefore).toBe(expectedRetryNotBefore);
-      expect(result.resultJson?.providerQuotaRetryNotBefore).toBe(expectedRetryNotBefore);
+      expect(result.resultJson?.provider).toBe("anthropic");
+      expect(result.resultJson?.retryGuidance).toContain("Switch to another approved lane");
+      expect(result.errorMeta?.resetAt).toBe(expectedRetryNotBefore);
       expect(result.errorMessage ?? "").toContain("extra usage");
       expect(new Date(String(result.resultJson?.transientRetryNotBefore)).getTime()).toBe(
         new Date("2026-04-22T21:00:00.000Z").getTime(),
       );
     } finally {
       vi.useRealTimers();
+      if (previousHome === undefined) delete process.env.HOME;
+      else process.env.HOME = previousHome;
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("classifies Claude session-limit failures as provider_session_limit", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-claude-execute-session-limit-"));
+    const workspace = path.join(root, "workspace");
+    const commandPath = path.join(root, "claude");
+    await fs.mkdir(workspace, { recursive: true });
+    await writeFailingClaudeCommand(commandPath, {
+      resultEvent: {
+        type: "result",
+        subtype: "error",
+        session_id: "ffffffff-ffff-4fff-8fff-ffffffffffff",
+        is_error: true,
+        result: "You've hit your session limit. Try again later.",
+        errors: [{ type: "rate_limit_error", message: "You've hit your session limit" }],
+      },
+    });
+
+    const previousHome = process.env.HOME;
+    process.env.HOME = root;
+
+    try {
+      const result = await execute({
+        runId: "run-claude-session-limit",
+        agent: {
+          id: "agent-1",
+          companyId: "company-1",
+          name: "Claude Coder",
+          adapterType: "claude_local",
+          adapterConfig: { engine: "cli" },
+        },
+        runtime: {
+          sessionId: null,
+          sessionParams: null,
+          sessionDisplayId: null,
+          taskKey: null,
+        },
+        config: {
+          engine: "cli",
+          command: commandPath,
+          cwd: workspace,
+          promptTemplate: "Follow the paperclip heartbeat.",
+        },
+        context: {},
+        authToken: "run-jwt-token",
+        onLog: async () => {},
+      });
+
+      expect(result.exitCode).toBe(1);
+      expect(result.errorCode).toBe("provider_session_limit");
+      expect(result.errorFamily).toBe("transient_upstream");
+      expect(result.resultJson?.provider).toBe("anthropic");
+      expect(result.resultJson?.retryGuidance).toContain("Switch to another approved lane");
+    } finally {
       if (previousHome === undefined) delete process.env.HOME;
       else process.env.HOME = previousHome;
       await fs.rm(root, { recursive: true, force: true });

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -381,7 +381,13 @@ function readHeartbeatRunErrorFamily(
   if (run.errorCode === "provider_quota") {
     return "provider_quota";
   }
-  if (run.errorCode === "codex_transient_upstream" || run.errorCode === "claude_transient_upstream") {
+  if (
+    run.errorCode === "codex_transient_upstream" ||
+    run.errorCode === "claude_transient_upstream" ||
+    run.errorCode === "provider_quota_exhausted" ||
+    run.errorCode === "provider_session_limit" ||
+    run.errorCode === "provider_rate_limited"
+  ) {
     return "transient_upstream";
   }
   return null;

--- a/server/src/services/recovery/service.pause-durability.test.ts
+++ b/server/src/services/recovery/service.pause-durability.test.ts
@@ -26,6 +26,14 @@ describe("pause durability: continuation retry classification", () => {
     expect(c.maxAttempts).toBeGreaterThan(0);
   });
 
+  it("provider quota/session/rate-limit failures retry as transient infra", () => {
+    for (const code of ["provider_quota_exhausted", "provider_session_limit", "provider_rate_limited"]) {
+      const c = classifyContinuationFailure(run(code));
+      expect(c.kind).toBe("transient_infra");
+      expect(c.maxAttempts).toBeGreaterThan(0);
+    }
+  });
+
   it("generic cancelled (non-pause cancellation) is NOT non-retryable", () => {
     // non-pause cancellations (the internal invokability cancel and budget pause) keep errorCode "cancelled" -> default branch
     expect(classifyContinuationFailure(run("cancelled")).kind).toBe("default");

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -241,6 +241,9 @@ const TRANSIENT_INFRA_CONTINUATION_ERROR_CODES = new Set<string>([
   "codex_transient_upstream",
   "claude_transient_upstream",
   "provider_quota",
+  "provider_quota_exhausted",
+  "provider_session_limit",
+  "provider_rate_limited",
   "timeout",
 ]);
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Local agent adapters need to report provider-side failures in a way the control plane can act on.
> - Claude quota, session-limit, and short-term rate-limit failures were all collapsing into generic transient upstream failures.
> - That made it harder for operators and recovery logic to distinguish provider quota exhaustion from retryable infrastructure errors or Paperclip budget hard stops.
> - This pull request adds explicit Anthropic provider-limit classification while preserving the existing transient-upstream family.
> - The benefit is clearer run metadata and recovery behavior that can tell operators when to switch lanes or wait for a provider reset.

## Linked Issues or Issue Description

No public GitHub issue exists for this exact change.

Problem: Claude local runs can fail because Anthropic quota is exhausted, the Claude session window is capped, or the provider is rate limiting. Those failures should remain transient upstream failures for recovery purposes, but should expose more specific error codes and retry guidance so operators do not confuse them with Paperclip budget hard stops or generic adapter failures.

## What Changed

- Added Claude provider-limit classification for `provider_quota_exhausted`, `provider_session_limit`, and `provider_rate_limited`.
- Wired classified provider metadata and retry guidance into Claude local execute results and error metadata.
- Taught heartbeat and recovery continuation handling to treat the new provider codes as transient upstream/infra conditions.
- Added parser, execute, and recovery tests for quota/session/rate-limit behavior.

## Verification

Previously verified on the reviewed patch:

- `pnpm run preflight:workspace-links` exited 0.
- `pnpm exec vitest run parse.test.ts claude-local-execute.test.ts service.pause-durability.test.ts` passed: 3 files / 64 tests.
- `pnpm --filter @paperclipai/adapter-claude-local typecheck` exited 0.
- `(cd server && pnpm exec tsc --noEmit)` exited 0.

Additional verification in this environment:

- Confirmed this PR diff is exactly 7 files, +210/-7.
- Confirmed the shared server changes are limited to provider-code allow-list handling.
- Attempted to rerun the targeted Vitest suite in a temporary worktree, but the worktree lacked workspace package links; a frozen pnpm relink attempt hit `ENOSPC` in the sandbox and was stopped.

Related public overlap checked:

- Existing open PRs include #4488 and #8017 in adjacent quota/rate-limit areas. This PR is narrower: Claude local provider-limit classification plus recovery allow-list handling.
- Existing public issues include #2014 and #2234.

## Risks

Low to moderate risk. The change preserves `errorFamily: "transient_upstream"` and existing retry timestamp behavior, but downstream consumers that assumed only `claude_transient_upstream` for all Claude provider failures may now see one of the more specific provider error codes.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

OpenAI GPT-5 Codex, tool-enabled coding agent in a Paperclip heartbeat workspace.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
