### PR TITLE
fix: keep checkbox confirmation details available after resolution

### DIFF
--- a/ui/src/components/IssueThreadInteractionCard.test.tsx
+++ b/ui/src/components/IssueThreadInteractionCard.test.tsx
@@ -9,6 +9,7 @@ import { ThemeProvider } from "../context/ThemeContext";
 import { TooltipProvider } from "./ui/tooltip";
 import {
   pendingAskUserQuestionsInteraction,
+  acceptedRequestCheckboxConfirmationInteraction,
   commentExpiredAskUserQuestionsInteraction,
   commentExpiredRequestConfirmationInteraction,
   disabledDeclineReasonRequestConfirmationInteraction,
@@ -19,6 +20,7 @@ import {
   pendingSuggestedTasksInteraction,
   completeRequestItemVerdictsInteraction,
   supersededRequestItemVerdictsInteraction,
+  rejectedRequestCheckboxConfirmationInteraction,
   staleTargetRequestConfirmationInteraction,
   rejectedSuggestedTasksInteraction,
 } from "../fixtures/issueThreadInteractionFixtures";
@@ -584,5 +586,59 @@ describe("IssueThreadInteractionCard", () => {
     expect(host.textContent).toContain("expired after a later comment");
     expect(host.textContent).toContain("cannot be");
     expect(host.textContent?.toLowerCase()).toContain("revert");
+  });
+
+  it("keeps checkbox confirmation details available behind a toggle after acceptance", async () => {
+    const host = renderCard({
+      interaction: acceptedRequestCheckboxConfirmationInteraction,
+    });
+
+    expect(host.textContent).toContain("Confirmed 2 of 4 options");
+    expect(host.textContent).not.toContain(
+      "Check the draft documents you want me to delete.",
+    );
+
+    const toggle = Array.from(host.querySelectorAll("button")).find((button) =>
+      button.textContent?.includes("Show details"),
+    );
+    expect(toggle).toBeTruthy();
+
+    await act(async () => {
+      toggle?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(host.textContent).toContain("Hide details");
+    expect(host.textContent).toContain(
+      "Check the draft documents you want me to delete.",
+    );
+    expect(host.textContent).toContain(
+      "Only the checked items will be deleted. Leave an item unchecked to keep it for now.",
+    );
+  });
+
+  it("keeps checkbox confirmation details available behind a toggle after decline", async () => {
+    const host = renderCard({
+      interaction: rejectedRequestCheckboxConfirmationInteraction,
+    });
+
+    expect(host.textContent).toContain(
+      "Don't delete anything yet — let me confirm with the data owner first.",
+    );
+
+    const toggle = Array.from(host.querySelectorAll("button")).find((button) =>
+      button.textContent?.includes("Show details"),
+    );
+    expect(toggle).toBeTruthy();
+
+    await act(async () => {
+      toggle?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(host.textContent).toContain(
+      "Check the draft documents you want me to delete.",
+    );
+    expect(host.textContent).toContain(
+      "Only the checked items will be deleted. Leave an item unchecked to keep it for now.",
+    );
   });
 });

--- a/ui/src/components/IssueThreadInteractionCard.tsx
+++ b/ui/src/components/IssueThreadInteractionCard.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import type { Agent } from "@paperclipai/shared";
-import { AlertTriangle, ArrowUpRight, Check, CheckCircle2, ChevronRight, CircleDashed, ExternalLink, FileText, GitBranch, ImagePlus, Loader2, MessageSquareQuote, MinusCircle, ThumbsUp, X, XCircle } from "lucide-react";
+import { AlertTriangle, ArrowUpRight, Check, CheckCircle2, ChevronDown, ChevronRight, CircleDashed, ExternalLink, FileText, GitBranch, ImagePlus, Loader2, MessageSquareQuote, MinusCircle, ThumbsUp, X, XCircle } from "lucide-react";
 import { Link } from "@/lib/router";
 import { formatAssigneeUserLabel } from "../lib/assignees";
 import {
@@ -30,6 +30,7 @@ import { cn, formatDateTime, formatShortDate } from "../lib/utils";
 import { MarkdownBody, type MarkdownExternalReferenceMap } from "./MarkdownBody";
 import { Button } from "./ui/button";
 import { Checkbox } from "./ui/checkbox";
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "./ui/collapsible";
 import { PriorityIcon } from "./PriorityIcon";
 import { Textarea } from "./ui/textarea";
 import { Tooltip, TooltipContent, TooltipTrigger } from "./ui/tooltip";
@@ -1688,6 +1689,7 @@ function RequestCheckboxConfirmationCard({
   const [rejectAttempted, setRejectAttempted] = useState(false);
   const [acceptAttempted, setAcceptAttempted] = useState(false);
   const [actionError, setActionError] = useState<string | null>(null);
+  const [detailsOpen, setDetailsOpen] = useState(false);
 
   const optionSeed = useMemo(() => optionIds.join("\n"), [optionIds]);
 
@@ -1780,8 +1782,46 @@ function RequestCheckboxConfirmationCard({
 
   if (interaction.status !== "pending") {
     return (
-      <div className="space-y-4">
+      <div className="space-y-2">
         <RequestCheckboxConfirmationResolution interaction={interaction} />
+        {interaction.payload.prompt || interaction.payload.detailsMarkdown ? (
+          <Collapsible open={detailsOpen} onOpenChange={setDetailsOpen}>
+            <CollapsibleTrigger asChild>
+              <Button
+                size="sm"
+                variant="ghost"
+                className="h-7 w-full justify-between px-2 text-xs text-muted-foreground hover:text-foreground"
+              >
+                <span>{detailsOpen ? "Hide details" : "Show details"}</span>
+                <ChevronDown
+                  className={cn(
+                    "h-3.5 w-3.5 transition-transform duration-200",
+                    detailsOpen && "rotate-180",
+                  )}
+                />
+              </Button>
+            </CollapsibleTrigger>
+            <CollapsibleContent>
+              <div className="mt-1 space-y-3 rounded-sm border border-border/70 bg-background/75 p-4">
+                {interaction.payload.prompt ? (
+                  <div className="text-sm leading-6 text-foreground">
+                    {interaction.payload.prompt}
+                  </div>
+                ) : null}
+                {interaction.payload.detailsMarkdown ? (
+                  <div
+                    className={cn(
+                      "text-sm",
+                      interaction.payload.prompt && "border-t border-border/60 pt-3",
+                    )}
+                  >
+                    <MarkdownBody externalReferences={externalReferences}>{interaction.payload.detailsMarkdown}</MarkdownBody>
+                  </div>
+                ) : null}
+              </div>
+            </CollapsibleContent>
+          </Collapsible>
+        ) : null}
       </div>
     );
   }


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Agents pause for human decisions through issue-thread interaction cards; `request_checkbox_confirmation` is the multi-select variant used when the board must confirm exactly which items an agent should act on (e.g. which stale drafts to delete)
> - When a checkbox confirmation is resolved, `RequestCheckboxConfirmationCard` swaps the whole card body for `RequestCheckboxConfirmationResolution` — the selected-option chips (accepted) or the decline reason (rejected) remain, but the original `prompt` and `detailsMarkdown` vanish from the thread
> - Users therefore can no longer see what question the checkboxes were answering or what the fine print said (e.g. "Only the checked items will be deleted"), which undermines the audit value of the decision record
> - #9274 fixed this exact bug for plain `request_confirmation` cards with a collapsed "Show details" disclosure, and explicitly deferred the checkbox variant as a follow-up to keep that fix scoped
> - This pull request applies the same disclosure pattern to the checkbox card so both confirmation variants keep their content reachable after resolution

## Linked Issues or Issue Description

Follow-up to #9274 (same bug class for plain `request_confirmation`; its description names the checkbox variant as an explicit follow-up). Refs https://github.com/lacymorrow/paperclip/issues/16 for the original report of the pattern.

Related PRs found while searching for duplicates:

- #9274 — open; fixes the plain-confirmation variant with the same "Show details" pattern. Both PRs touch the same file (imports + adjacent components), so whichever lands second needs a trivial rebase.
- #9021 — open redesign of the interaction-card shell; it does not restore post-resolution prompt/details for the checkbox card, so this fix is complementary.

Inline description (bug format):

**What happened?** Resolving a `request_checkbox_confirmation` interaction removes the prompt and details markdown from the issue thread. Only the resolution summary ("Confirmed N of M options" with selected chips, or the decline reason) remains.

**Expected behavior** The resolution summary stays, and the original prompt/details remain reachable — collapsed by default, expandable on demand — matching resolved plain confirmations after #9274.

**Steps to reproduce** Have an agent create a `request_checkbox_confirmation` interaction with a prompt and `detailsMarkdown`, then confirm a selection (or decline). The card shows only the resolution; there is no way to view the original question or fine print again.

**Paperclip version or commit** Reproduced on `master` (7cf0d3ebb).

## What Changed

- `ui/src/components/IssueThreadInteractionCard.tsx`: the resolved (non-pending) branch of `RequestCheckboxConfirmationCard` now renders the resolution followed by a `Collapsible` "Show details" section containing the original `prompt` and `detailsMarkdown` (rendered through `MarkdownBody` with `externalReferences`), collapsed by default. The prompt block is omitted when empty, mirroring the plain-confirmation implementation. Applies to accepted, rejected, expired, and failed states.
- `ui/src/components/IssueThreadInteractionCard.test.tsx`: two regression tests — accepted and rejected checkbox confirmations expose a "Show details" toggle that reveals the prompt and details markdown. Both fail without the fix.

## Verification

- `cd ui && npx vitest run src/components/IssueThreadInteractionCard.test.tsx` — 18/18 pass (16 pre-existing + 2 new; the new toggle tests fail on master).
- `cd ui && npx tsc --noEmit` — clean.
- Re-ran both after rebasing onto `master` (7cf0d3ebb).
- Rendered the `CheckboxConfirmationAccepted` / `CheckboxConfirmationRejected` Storybook stories on this branch to capture the screenshots below.

## Screenshots

Captured from the existing Storybook stories (`Chat & Comments/Issue Thread Interactions`) on this branch.

| Accepted — collapsed (default) | Accepted — expanded |
| --- | --- |
| ![Accepted checkbox confirmation with collapsed Show details toggle](https://raw.githubusercontent.com/lacymorrow/paperclip/assets/checkbox-confirmation-screenshots/checkbox-accepted-collapsed.png) | ![Accepted checkbox confirmation with details expanded showing the original prompt and details markdown](https://raw.githubusercontent.com/lacymorrow/paperclip/assets/checkbox-confirmation-screenshots/checkbox-accepted-expanded.png) |

| Declined — collapsed (default) | Declined — expanded |
| --- | --- |
| ![Declined checkbox confirmation with collapsed Show details toggle below the decline reason](https://raw.githubusercontent.com/lacymorrow/paperclip/assets/checkbox-confirmation-screenshots/checkbox-rejected-collapsed.png) | ![Declined checkbox confirmation with details expanded showing the original prompt and details markdown](https://raw.githubusercontent.com/lacymorrow/paperclip/assets/checkbox-confirmation-screenshots/checkbox-rejected-expanded.png) |

## Risks

- Low risk: UI-only, additive rendering in one component; no schema, API, or behavioral changes to the interaction lifecycle.
- Mild merge overlap with #9274 (same imports and file) and #9021 (restyles the same component); conflicts are mechanical, adjacent-line ones.

## Model Used

Claude Fable 5 (`claude-fable-5`, Anthropic) via Claude Code with extended thinking and tool use (code search, test execution).

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes (none needed — UI-only bug fix)
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [x] I will address all Greptile and reviewer comments before requesting merge

