### PR TITLE
fix: bridge sandbox runtime services

### DIFF
--- a/packages/adapter-utils/src/execution-target-sandbox.test.ts
+++ b/packages/adapter-utils/src/execution-target-sandbox.test.ts
@@ -614,6 +614,79 @@ describe("sandbox adapter execution targets", () => {
     }
   });
 
+  it("bridges localhost runtime services on their sandbox port", async () => {
+    const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-execution-target-runtime-service-bridge-"));
+    cleanupDirs.push(rootDir);
+    const remoteCwd = path.join(rootDir, "workspace");
+    const runtimeRootDir = path.join(remoteCwd, ".paperclip-runtime", "codex");
+    await mkdir(runtimeRootDir, { recursive: true });
+
+    const requests: Array<{ method: string; url: string; auth: string | null; runId: string | null }> = [];
+    const serviceServer = createServer((req, res) => {
+      requests.push({
+        method: req.method ?? "GET",
+        url: req.url ?? "/",
+        auth: req.headers.authorization ?? null,
+        runId: typeof req.headers["x-paperclip-run-id"] === "string" ? req.headers["x-paperclip-run-id"] : null,
+      });
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ status: "ok", service: "linkedin-queue" }));
+    });
+    await new Promise<void>((resolve, reject) => {
+      serviceServer.once("error", reject);
+      serviceServer.listen(0, "127.0.0.2", () => resolve());
+    });
+    const address = serviceServer.address();
+    if (!address || typeof address === "string") {
+      throw new Error("Expected the runtime service test server to listen on a TCP port.");
+    }
+
+    const target: AdapterSandboxExecutionTarget = {
+      kind: "remote",
+      transport: "sandbox",
+      providerKey: "e2b",
+      environmentId: "env-1",
+      leaseId: "lease-1",
+      remoteCwd,
+      runner: createLocalSandboxRunner(),
+      timeoutMs: 30_000,
+    };
+
+    const bridge = await startAdapterExecutionTargetPaperclipBridge({
+      runId: "run-service-bridge",
+      target,
+      runtimeRootDir,
+      adapterKey: "codex",
+      hostApiToken: "real-run-jwt",
+      hostApiUrl: "http://127.0.0.1:9",
+      runtimeServices: [{
+        id: "linkedin-queue",
+        serviceName: "linkedin-queue",
+        port: address.port,
+        url: `http://127.0.0.2:${address.port}`,
+      }],
+    });
+    try {
+      const rewrittenServices = JSON.parse(bridge!.env.PAPERCLIP_RUNTIME_SERVICES_JSON) as Array<{ url: string }>;
+      expect(rewrittenServices[0]?.url).toBe(`http://127.0.0.1:${address.port}`);
+      expect(bridge!.env.PAPERCLIP_RUNTIME_PRIMARY_URL).toBe(`http://127.0.0.1:${address.port}`);
+
+      const response = await fetch(`http://127.0.0.1:${address.port}/health`);
+
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual({ status: "ok", service: "linkedin-queue" });
+      expect(requests).toEqual([{
+        method: "GET",
+        url: "/health",
+        auth: null,
+        runId: null,
+      }]);
+    } finally {
+      await bridge?.stop();
+      await new Promise<void>((resolve) => serviceServer.close(() => resolve()));
+    }
+  });
+
   it("creates a sandbox run log tail factory when bridge streaming is enabled", async () => {
     const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-execution-target-bridge-stream-"));
     cleanupDirs.push(rootDir);

--- a/packages/adapter-utils/src/execution-target.ts
+++ b/packages/adapter-utils/src/execution-target.ts
@@ -15,6 +15,7 @@ import {
   createSandboxCallbackBridgeAsset,
   createSandboxCallbackBridgeToken,
   DEFAULT_SANDBOX_CALLBACK_BRIDGE_MAX_BODY_BYTES,
+  authorizeSandboxCallbackBridgeRequestWithRoutes,
   sandboxCallbackBridgeDirectories,
   startSandboxCallbackBridgeServer,
   startSandboxCallbackBridgeWorker,
@@ -123,6 +124,13 @@ export interface AdapterExecutionTargetPaperclipBridgeHandle {
    */
   runLogTail?: SandboxRunLogTailFactory | null;
   stop(): Promise<void>;
+}
+
+interface PaperclipBridgeRuntimeService {
+  id?: string | null;
+  serviceName?: string | null;
+  port?: number | null;
+  url?: string | null;
 }
 
 export { sanitizeRemoteExecutionEnv } from "./remote-execution-env.js";
@@ -1166,6 +1174,73 @@ function buildBridgeForwardUrl(baseUrl: string, request: { path: string; query: 
   return url;
 }
 
+function parseRuntimeServiceBridgePort(service: PaperclipBridgeRuntimeService): number | null {
+  if (typeof service.port === "number" && Number.isFinite(service.port) && service.port > 0) {
+    return Math.trunc(service.port);
+  }
+  const rawUrl = service.url?.trim();
+  if (!rawUrl) return null;
+  try {
+    const parsed = new URL(rawUrl);
+    const port = Number.parseInt(parsed.port, 10);
+    return Number.isFinite(port) && port > 0 ? port : null;
+  } catch {
+    return null;
+  }
+}
+
+function serviceUrlUsesLocalhost(rawUrl: string): boolean {
+  try {
+    const { hostname } = new URL(rawUrl);
+    return hostname === "localhost" || /^127\./.test(hostname) || hostname === "::1" || hostname === "[::1]";
+  } catch {
+    return false;
+  }
+}
+
+function runtimeServiceBridgeId(service: PaperclipBridgeRuntimeService, index: number): string {
+  const serviceId = service.id?.trim();
+  if (serviceId) return serviceId;
+  const serviceName = service.serviceName?.trim() || "service";
+  const port = parseRuntimeServiceBridgePort(service);
+  return `${serviceName}:${port ?? index}`;
+}
+
+function buildRuntimeServiceBridgeTargets(
+  services: PaperclipBridgeRuntimeService[] | null | undefined,
+): Array<{ id: string; service: PaperclipBridgeRuntimeService; port: number; url: string }> {
+  const targets: Array<{ id: string; service: PaperclipBridgeRuntimeService; port: number; url: string }> = [];
+  const ports = new Set<number>();
+  for (const [index, service] of (services ?? []).entries()) {
+    const url = service.url?.trim();
+    if (!url || !serviceUrlUsesLocalhost(url)) continue;
+    const port = parseRuntimeServiceBridgePort(service);
+    if (!port || ports.has(port)) continue;
+    ports.add(port);
+    targets.push({ id: runtimeServiceBridgeId(service, index), service, port, url });
+  }
+  return targets;
+}
+
+function rewriteRuntimeServicesForBridge(
+  services: PaperclipBridgeRuntimeService[] | null | undefined,
+  bridgeTargets: Array<{ id: string; service: PaperclipBridgeRuntimeService; port: number; url: string }>,
+): PaperclipBridgeRuntimeService[] {
+  const targetByObject = new Map<PaperclipBridgeRuntimeService, { port: number }>();
+  for (const target of bridgeTargets) {
+    targetByObject.set(target.service, { port: target.port });
+  }
+  return (services ?? []).map((service) => {
+    const target = targetByObject.get(service);
+    if (!target) return service;
+    return {
+      ...service,
+      url: `http://127.0.0.1:${target.port}`,
+      port: target.port,
+    };
+  });
+}
+
 function bridgeResponseBodyLimitError(maxBodyBytes: number): Error {
   return new Error(`Bridge response body exceeded the configured size limit of ${maxBodyBytes} bytes.`);
 }
@@ -1208,6 +1283,7 @@ export async function startAdapterExecutionTargetPaperclipBridge(input: {
   timeoutSec?: number | null;
   hostApiToken: string | null | undefined;
   hostApiUrl?: string | null;
+  runtimeServices?: PaperclipBridgeRuntimeService[] | null;
   onLog?: (stream: "stdout" | "stderr", chunk: string) => Promise<void>;
   maxBodyBytes?: number | null;
 }): Promise<AdapterExecutionTargetPaperclipBridgeHandle | null> {
@@ -1242,6 +1318,8 @@ export async function startAdapterExecutionTargetPaperclipBridge(input: {
     process.env.PAPERCLIP_RUNTIME_API_URL?.trim() ||
     process.env.PAPERCLIP_API_URL?.trim() ||
     resolveDefaultPaperclipApiUrl();
+  const runtimeServiceBridgeTargets = buildRuntimeServiceBridgeTargets(input.runtimeServices);
+  const runtimeServiceUrlById = new Map(runtimeServiceBridgeTargets.map((target) => [target.id, target.url]));
   const shellCommand = adapterExecutionTargetShellCommand(target);
   const runner = adapterExecutionTargetCommandRunner(target);
   const bridgeTimeoutMs =
@@ -1256,6 +1334,7 @@ export async function startAdapterExecutionTargetPaperclipBridge(input: {
 
   const bridgeAsset = await createSandboxCallbackBridgeAsset();
   let server: Awaited<ReturnType<typeof startSandboxCallbackBridgeServer>> | null = null;
+  let runtimeServiceServers: Array<Awaited<ReturnType<typeof startSandboxCallbackBridgeServer>>> = [];
   let worker: Awaited<ReturnType<typeof startSandboxCallbackBridgeWorker>> | null = null;
   try {
     const client = createCommandManagedSandboxCallbackBridgeQueueClient({
@@ -1275,8 +1354,19 @@ export async function startAdapterExecutionTargetPaperclipBridge(input: {
       client,
       queueDir,
       maxBodyBytes,
+      authorizeRequest: (request) =>
+        request.targetServiceId?.trim() ? null : authorizeSandboxCallbackBridgeRequestWithRoutes(request),
       handleRequest: async (request) => {
         const method = request.method.trim().toUpperCase() || "GET";
+        const targetServiceId = request.targetServiceId?.trim() || "";
+        const forwardBaseUrl = targetServiceId ? runtimeServiceUrlById.get(targetServiceId) : hostApiUrl;
+        if (!forwardBaseUrl) {
+          return {
+            status: 404,
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({ error: "Unknown runtime service bridge target." }),
+          };
+        }
         if (bridgeDebugEnabled) {
           await onLog(
             "stdout",
@@ -1288,9 +1378,11 @@ export async function startAdapterExecutionTargetPaperclipBridge(input: {
           if (value.trim().length === 0) continue;
           headers.set(key, value);
         }
-        headers.set("authorization", `Bearer ${hostApiToken}`);
-        headers.set("x-paperclip-run-id", input.runId);
-        const response = await fetch(buildBridgeForwardUrl(hostApiUrl, request), {
+        if (!targetServiceId) {
+          headers.set("authorization", `Bearer ${hostApiToken}`);
+          headers.set("x-paperclip-run-id", input.runId);
+        }
+        const response = await fetch(buildBridgeForwardUrl(forwardBaseUrl, request), {
           method,
           headers,
           ...(method === "GET" || method === "HEAD" ? {} : { body: request.body }),
@@ -1320,9 +1412,30 @@ export async function startAdapterExecutionTargetPaperclipBridge(input: {
       maxBodyBytes,
       shellCommand,
     });
+    for (const targetService of runtimeServiceBridgeTargets) {
+      const serviceServer = await startSandboxCallbackBridgeServer({
+        runner,
+        remoteCwd: target.remoteCwd,
+        assetRemoteDir,
+        queueDir,
+        bridgeToken,
+        targetServiceId: targetService.id,
+        requireToken: false,
+        port: targetService.port,
+        timeoutMs: bridgeTimeoutMs,
+        maxBodyBytes,
+        shellCommand,
+      });
+      runtimeServiceServers.push(serviceServer);
+      await onLog(
+        "stdout",
+        `[paperclip] Runtime service bridge ${targetService.service.serviceName ?? targetService.id} listening at ${serviceServer.baseUrl}.\n`,
+      );
+    }
   } catch (error) {
     await Promise.allSettled([
       server?.stop(),
+      ...runtimeServiceServers.map((serviceServer) => serviceServer.stop()),
       worker?.stop(),
       bridgeAsset.cleanup(),
     ]);
@@ -1340,17 +1453,25 @@ export async function startAdapterExecutionTargetPaperclipBridge(input: {
     await onLog("stdout", "[paperclip] Sandbox run log streaming enabled for this run.\n");
   }
 
+  const bridgedRuntimeServices = rewriteRuntimeServicesForBridge(input.runtimeServices, runtimeServiceBridgeTargets);
   return {
     env: {
       PAPERCLIP_API_URL: server.baseUrl,
       PAPERCLIP_API_KEY: bridgeToken,
       PAPERCLIP_API_BRIDGE_MODE: "queue_v1",
       PAPERCLIP_BRIDGE_QUEUE_DIR: queueDir,
+      ...(bridgedRuntimeServices.length > 0
+        ? {
+            PAPERCLIP_RUNTIME_SERVICES_JSON: JSON.stringify(bridgedRuntimeServices),
+            PAPERCLIP_RUNTIME_PRIMARY_URL: bridgedRuntimeServices.find((service) => service.url?.trim())?.url?.trim() ?? "",
+          }
+        : {}),
     },
     runLogTail,
     stop: async () => {
       await Promise.allSettled([
         server?.stop(),
+        ...runtimeServiceServers.map((serviceServer) => serviceServer.stop()),
       ]);
       await Promise.allSettled([
         worker?.stop(),

--- a/packages/adapter-utils/src/sandbox-callback-bridge.ts
+++ b/packages/adapter-utils/src/sandbox-callback-bridge.ts
@@ -110,6 +110,7 @@ export interface SandboxCallbackBridgeRequest {
   path: string;
   query: string;
   headers: Record<string, string>;
+  targetServiceId?: string | null;
   /**
    * UTF-8 body contents. The bridge rejects non-JSON request bodies; binary
    * payloads are intentionally out of scope for this queue protocol.
@@ -308,6 +309,8 @@ export function sandboxCallbackBridgeDirectories(rootDir: string): SandboxCallba
 export function buildSandboxCallbackBridgeEnv(input: {
   queueDir: string;
   bridgeToken: string;
+  targetServiceId?: string | null;
+  requireToken?: boolean | null;
   host?: string;
   port?: number | null;
   pollIntervalMs?: number | null;
@@ -319,6 +322,8 @@ export function buildSandboxCallbackBridgeEnv(input: {
     PAPERCLIP_API_BRIDGE_MODE: "queue_v1",
     PAPERCLIP_BRIDGE_QUEUE_DIR: input.queueDir,
     PAPERCLIP_BRIDGE_TOKEN: input.bridgeToken,
+    PAPERCLIP_BRIDGE_TARGET_SERVICE_ID: input.targetServiceId?.trim() || "",
+    PAPERCLIP_BRIDGE_REQUIRE_TOKEN: input.requireToken === false ? "false" : "true",
     PAPERCLIP_BRIDGE_HOST: input.host?.trim() || "127.0.0.1",
     PAPERCLIP_BRIDGE_PORT: String(input.port && input.port > 0 ? Math.trunc(input.port) : 0),
     PAPERCLIP_BRIDGE_POLL_INTERVAL_MS: String(
@@ -871,6 +876,8 @@ export async function startSandboxCallbackBridgeServer(input: {
   assetRemoteDir: string;
   queueDir: string;
   bridgeToken: string;
+  targetServiceId?: string | null;
+  requireToken?: boolean | null;
   bridgeAsset?: SandboxCallbackBridgeAsset | null;
   host?: string;
   port?: number | null;
@@ -900,6 +907,8 @@ export async function startSandboxCallbackBridgeServer(input: {
   const env = buildSandboxCallbackBridgeEnv({
     queueDir: input.queueDir,
     bridgeToken: input.bridgeToken,
+    targetServiceId: input.targetServiceId,
+    requireToken: input.requireToken,
     host: input.host,
     port: input.port,
     pollIntervalMs: input.pollIntervalMs,
@@ -1021,6 +1030,8 @@ import path from "node:path";
 
 const queueDir = process.env.PAPERCLIP_BRIDGE_QUEUE_DIR;
 const bridgeToken = process.env.PAPERCLIP_BRIDGE_TOKEN;
+const targetServiceId = (process.env.PAPERCLIP_BRIDGE_TARGET_SERVICE_ID || "").trim();
+const requireToken = process.env.PAPERCLIP_BRIDGE_REQUIRE_TOKEN !== "false";
 const host = process.env.PAPERCLIP_BRIDGE_HOST || "127.0.0.1";
 const port = Number(process.env.PAPERCLIP_BRIDGE_PORT || "0");
 const pollIntervalMs = Number(process.env.PAPERCLIP_BRIDGE_POLL_INTERVAL_MS || "100");
@@ -1099,7 +1110,7 @@ const server = createServer(async (req, res) => {
   try {
     const auth = req.headers.authorization || "";
     const receivedToken = auth.startsWith("Bearer ") ? auth.slice("Bearer ".length) : "";
-    if (!tokensMatch(receivedToken)) {
+    if (requireToken && !tokensMatch(receivedToken)) {
       res.statusCode = 401;
       res.setHeader("content-type", "application/json");
       res.end(JSON.stringify({ error: "Invalid bridge token." }));
@@ -1129,6 +1140,7 @@ const server = createServer(async (req, res) => {
       path: url.pathname,
       query: url.search,
       headers: normalizeHeaders(req.headers),
+      targetServiceId: targetServiceId || null,
       body: requestBody,
       createdAt: new Date().toISOString(),
     };

--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -100,6 +100,7 @@ interface ClaudeRuntimeConfig {
   timeoutSec: number;
   graceSec: number;
   extraArgs: string[];
+  runtimeServices: Record<string, unknown>[];
 }
 
 export function claudeSessionCwdMatchesExecutionTarget(input: {
@@ -332,6 +333,7 @@ async function buildClaudeRuntimeConfig(input: ClaudeExecutionInput): Promise<Cl
     timeoutSec,
     graceSec,
     extraArgs,
+    runtimeServices,
   };
 }
 
@@ -449,6 +451,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     timeoutSec,
     graceSec,
     extraArgs,
+    runtimeServices,
   } = runtimeConfig;
   let loggedEnv = initialLoggedEnv;
   let effectiveExecutionCwd = adapterExecutionTargetRemoteCwd(executionTarget, cwd);
@@ -604,6 +607,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       adapterKey: "claude",
       timeoutSec,
       hostApiToken: env.PAPERCLIP_API_KEY,
+      runtimeServices,
       onLog,
     });
     if (paperclipBridge) {

--- a/packages/adapters/codex-local/src/server/execute.ts
+++ b/packages/adapters/codex-local/src/server/execute.ts
@@ -620,6 +620,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         adapterKey: "codex",
         timeoutSec,
         hostApiToken: env.PAPERCLIP_API_KEY,
+        runtimeServices,
         onLog,
       });
       if (paperclipBridge) {


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Sandbox-backed local adapters let agents run in isolated environments while still reporting work back to the Paperclip control plane.
> - The existing sandbox callback bridge made Paperclip API calls reachable from socket-restricted sandboxes, but workspace runtime services were still exposed as host-local URLs.
> - Any sandbox that cannot open direct host sockets would fail when instructions or tooling tried to call a localhost runtime service such as a queue or preview server.
> - Runtime services are already first-class in heartbeat context, so the bridge should translate those localhost services into sandbox-local listeners instead of asking agents to know host networking details.
> - This pull request extends the sandbox callback bridge to expose fixed-target runtime service listeners on their expected local ports, while keeping the Paperclip API bridge authenticated and route-allowlisted.
> - The benefit is that sandboxed agents can use runtime service URLs the same way local agents do.

## Linked Issues or Issue Description

No public GitHub issue exists for this instance-specific bug, so the problem is described inline using the bug-report template fields.

### What happened?

Sandbox-backed local adapter runs received localhost runtime-service URLs from the host context, but direct socket access to those host-local endpoints can be unavailable from the sandbox. The Paperclip API bridge was reachable, while separate runtime services such as queue or preview endpoints still failed with connection-refused or socket-permission errors.

### Expected behavior

A sandbox-backed local adapter run should be able to call Paperclip-provided runtime services through sandbox-local URLs, without needing direct host-network access or adapter-specific endpoint rewrites in the agent instructions.

### Steps to reproduce

1. Start a sandbox-backed local adapter heartbeat that receives a localhost runtime service in its runtime context.
2. From inside the sandboxed run, call the service health endpoint using the injected runtime-service URL.
3. Observe the request fail when the sandbox cannot open direct host sockets, even though Paperclip API calls can use the callback bridge.

### Paperclip version or commit

Reproduced against Paperclip development builds before this change. This PR is based on `9972b01a8` atop upstream `97e075215`.

### Deployment mode

Local dev with sandbox-backed local adapters.

## What Changed

- Added fixed-target runtime-service support to the sandbox callback bridge request protocol.
- Started sandbox-local listeners for localhost runtime services on their configured ports and forwarded those requests through the existing host-side queue bridge.
- Rewrote bridged runtime service URLs in `PAPERCLIP_RUNTIME_SERVICES_JSON` and `PAPERCLIP_RUNTIME_PRIMARY_URL` for Codex and Claude local sandbox runs.
- Added a regression test proving a sandbox-local runtime service `/health` request forwards to the host service without Paperclip API auth headers.

## Verification

- `pnpm vitest run packages/adapter-utils/src/execution-target-sandbox.test.ts`
- `pnpm --filter @paperclipai/adapter-utils typecheck`
- `pnpm --filter @paperclipai/adapter-claude-local typecheck`
- `pnpm --filter @paperclipai/adapter-codex-local typecheck`

Runtime verification depends on an instance-managed sandbox adapter and runtime service. The code-level regression proves the bridge behavior; deploy/run verification should confirm the sandbox receives `PAPERCLIP_API_URL` through the callback bridge and runtime services rewritten to sandbox-local listener URLs.

## Risks

- Runtime service listeners are unauthenticated inside the sandbox to preserve plain localhost service behavior, but each listener forwards only to one fixed service URL selected by the host-side runtime context.
- If a sandbox already has a process listening on the same runtime-service port, bridge startup for that service will fail. That mirrors the local-port contract the agent was already expected to use.

## Model Used

- OpenAI GPT-5 via Codex CLI, tool-assisted coding and test execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge