### PR TITLE
Fix Paperclip Claude quota circuit breaker and retry storm guard

### DIFF
--- a/server/src/__tests__/claude-quota-guard.test.ts
+++ b/server/src/__tests__/claude-quota-guard.test.ts
@@ -89,9 +89,16 @@ describe("Claude quota guard", () => {
   it("parses Claude reset times relative to the current window", () => {
     const reset = parseClaudeQuotaResetTime(
       "You've hit your session limit - resets 1:30pm (Asia/Jerusalem)",
-      new Date("2026-07-09T12:00:00+03:00"),
+      new Date("2026-07-09T09:00:00Z"),
     );
     expect(reset?.toISOString()).toBe("2026-07-09T10:30:00.000Z");
+  });
+
+  it("fails closed when reset timezone is not parseable", () => {
+    expect(parseClaudeQuotaResetTime(
+      "You've hit your session limit - resets 1:30pm (Not/AZone)",
+      new Date("2026-07-09T09:00:00Z"),
+    )).toBeNull();
   });
 });
 
@@ -228,6 +235,37 @@ describeEmbeddedPostgres("Claude quota guard dispatch integration", () => {
     });
   });
 
+  it("blocks claude_local wakeups for another company while the circuit is open", async () => {
+    const companyA = await seedClaudeAgent();
+    const companyB = await seedClaudeAgent();
+    await openCircuit(
+      companyA.companyId,
+      companyA.agentId,
+      "You've hit your session limit - resets 1:30pm (Asia/Jerusalem)",
+    );
+
+    const queued = await heartbeatService(db).wakeup(companyB.agentId, {
+      source: "automation",
+      triggerDetail: "system",
+      reason: "cross_company_quota_guard",
+      contextSnapshot: { issueId: randomUUID() },
+    });
+
+    expect(queued).toBeNull();
+    expect(mockAdapterExecute).not.toHaveBeenCalled();
+    const runs = await db.select().from(heartbeatRuns);
+    expect(runs).toHaveLength(0);
+    const [request] = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.agentId, companyB.agentId));
+    expect(request).toMatchObject({
+      companyId: companyB.companyId,
+      status: "skipped",
+      reason: CLAUDE_QUOTA_BLOCK_ERROR_CODE,
+    });
+  });
+
   it("test_claude_local_global_concurrency_is_one", async () => {
     const { companyId, agentId } = await seedClaudeAgent();
     const activeRunId = randomUUID();
@@ -281,6 +319,40 @@ describeEmbeddedPostgres("Claude quota guard dispatch integration", () => {
     expect(event?.details).toMatchObject({
       reason: CLAUDE_QUOTA_BLOCK_ERROR_CODE,
       operatorResumeRequired: false,
+    });
+  });
+
+  it("records Asia/Jerusalem reset times independently of host timezone", async () => {
+    const { companyId, agentId } = await seedClaudeAgent();
+
+    const details = await recordClaudeQuotaFailure(db, {
+      adapterType: CLAUDE_LOCAL_ADAPTER_TYPE,
+      companyId,
+      agentId,
+      errorMessage: "You've hit your session limit - resets 1:30pm (Asia/Jerusalem)",
+      observedAt: new Date("2026-07-09T09:00:00Z"),
+    });
+
+    expect(details).toMatchObject({
+      blockedUntil: "2026-07-09T10:30:00.000Z",
+      operatorResumeRequired: false,
+    });
+  });
+
+  it("requires operator resume instead of guessing unknown reset timezones", async () => {
+    const { companyId, agentId } = await seedClaudeAgent();
+
+    const details = await recordClaudeQuotaFailure(db, {
+      adapterType: CLAUDE_LOCAL_ADAPTER_TYPE,
+      companyId,
+      agentId,
+      errorMessage: "You've hit your session limit - resets 1:30pm (Not/AZone)",
+      observedAt: new Date("2026-07-09T09:00:00Z"),
+    });
+
+    expect(details).toMatchObject({
+      blockedUntil: null,
+      operatorResumeRequired: true,
     });
   });
 });

--- a/server/src/__tests__/claude-quota-guard.test.ts
+++ b/server/src/__tests__/claude-quota-guard.test.ts
@@ -1,0 +1,286 @@
+import { randomUUID } from "node:crypto";
+import { and, eq, sql } from "drizzle-orm";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import {
+  activityLog,
+  agents,
+  agentRuntimeState,
+  agentWakeupRequests,
+  companies,
+  createDb,
+  heartbeatRunEvents,
+  heartbeatRuns,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import {
+  CLAUDE_LOCAL_ADAPTER_TYPE,
+  CLAUDE_QUOTA_BLOCK_ERROR_CODE,
+  acquireClaudeLocalDispatchSlot,
+  getClaudeQuotaBlock,
+  isClaudeQuotaOrSessionFailure,
+  parseClaudeQuotaResetTime,
+  recordClaudeQuotaFailure,
+} from "../services/claude-quota-guard.ts";
+import { heartbeatService } from "../services/heartbeat.ts";
+
+const mockAdapterExecute = vi.hoisted(() => vi.fn());
+
+vi.mock("../adapters/index.ts", async () => {
+  const actual = await vi.importActual<typeof import("../adapters/index.ts")>("../adapters/index.ts");
+  return {
+    ...actual,
+    getServerAdapter: vi.fn(() => ({
+      supportsLocalAgentJwt: false,
+      execute: mockAdapterExecute,
+    })),
+  };
+});
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping embedded Postgres Claude quota guard tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+describe("Claude quota guard", () => {
+  it("classifies session-limit text as a Claude quota block", () => {
+    expect(isClaudeQuotaOrSessionFailure({
+      adapterType: CLAUDE_LOCAL_ADAPTER_TYPE,
+      errorMessage: "You've hit your session limit - resets 1:30pm (Asia/Jerusalem)",
+    })).toBe(true);
+  });
+
+  it("classifies HTTP 429 and rate_limit as Claude quota blocks", () => {
+    expect(isClaudeQuotaOrSessionFailure({
+      adapterType: CLAUDE_LOCAL_ADAPTER_TYPE,
+      httpStatus: 429,
+    })).toBe(true);
+    expect(isClaudeQuotaOrSessionFailure({
+      adapterType: CLAUDE_LOCAL_ADAPTER_TYPE,
+      errorCode: "rate_limit",
+    })).toBe(true);
+  });
+
+  it("treats claude_local timed_out and adapter_failed as quota risk", () => {
+    expect(isClaudeQuotaOrSessionFailure({
+      adapterType: CLAUDE_LOCAL_ADAPTER_TYPE,
+      status: "timed_out",
+    })).toBe(true);
+    expect(isClaudeQuotaOrSessionFailure({
+      adapterType: CLAUDE_LOCAL_ADAPTER_TYPE,
+      status: "adapter_failed",
+    })).toBe(true);
+  });
+
+  it("does not classify non-Claude adapters", () => {
+    expect(isClaudeQuotaOrSessionFailure({
+      adapterType: "codex_local",
+      httpStatus: 429,
+      errorMessage: "session limit resets soon",
+    })).toBe(false);
+  });
+
+  it("parses Claude reset times relative to the current window", () => {
+    const reset = parseClaudeQuotaResetTime(
+      "You've hit your session limit - resets 1:30pm (Asia/Jerusalem)",
+      new Date("2026-07-09T12:00:00+03:00"),
+    );
+    expect(reset?.toISOString()).toBe("2026-07-09T10:30:00.000Z");
+  });
+});
+
+describeEmbeddedPostgres("Claude quota guard dispatch integration", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("claude-quota-guard-");
+    db = createDb(tempDb.connectionString);
+  }, 20_000);
+
+  afterEach(async () => {
+    mockAdapterExecute.mockReset();
+    await db.delete(heartbeatRunEvents);
+    await db.delete(agentWakeupRequests);
+    await db.delete(heartbeatRuns);
+    await db.delete(agentRuntimeState);
+    await db.delete(activityLog);
+    await db.delete(agents);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  async function seedClaudeAgent() {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Quota Guard Co",
+      issuePrefix: `Q${companyId.replace(/-/g, "").slice(0, 5).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Claude Local",
+      role: "engineer",
+      status: "idle",
+      adapterType: CLAUDE_LOCAL_ADAPTER_TYPE,
+      adapterConfig: {},
+      runtimeConfig: {
+        heartbeat: {
+          enabled: true,
+          wakeOnDemand: true,
+        },
+      },
+      permissions: {},
+    });
+    return { companyId, agentId };
+  }
+
+  async function openCircuit(companyId: string, agentId: string, message = "You've hit your session limit - resets 11:30pm") {
+    const details = await recordClaudeQuotaFailure(db, {
+      adapterType: CLAUDE_LOCAL_ADAPTER_TYPE,
+      companyId,
+      agentId,
+      status: "adapter_failed",
+      errorCode: "rate_limit",
+      errorMessage: message,
+      observedAt: new Date("2026-07-09T12:00:00Z"),
+    });
+    expect(details).not.toBeNull();
+  }
+
+  it("test_claude_quota_failure_opens_circuit_breaker", async () => {
+    const { companyId, agentId } = await seedClaudeAgent();
+
+    await openCircuit(companyId, agentId);
+
+    const block = await getClaudeQuotaBlock(db, companyId, new Date("2026-07-09T12:01:00Z"));
+    expect(block).toMatchObject({
+      blocked: true,
+      reason: CLAUDE_QUOTA_BLOCK_ERROR_CODE,
+      operatorResumeRequired: false,
+    });
+  });
+
+  it("test_quota_circuit_breaker_blocks_retry_promotion", async () => {
+    const { companyId, agentId } = await seedClaudeAgent();
+    await openCircuit(companyId, agentId);
+    const runId = randomUUID();
+    const issueId = randomUUID();
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId,
+      agentId,
+      invocationSource: "automation",
+      triggerDetail: "system",
+      status: "scheduled_retry",
+      scheduledRetryAt: new Date("2026-07-09T12:00:00Z"),
+      scheduledRetryAttempt: 1,
+      scheduledRetryReason: "transient_adapter_failure",
+      contextSnapshot: { issueId },
+    });
+
+    const result = await heartbeatService(db).promoteDueScheduledRetries(new Date("2026-07-09T12:01:00Z"));
+
+    expect(result).toEqual({ promoted: 0, runIds: [] });
+    expect(mockAdapterExecute).not.toHaveBeenCalled();
+    const [run] = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.id, runId));
+    expect(run).toMatchObject({
+      status: "cancelled",
+      errorCode: CLAUDE_QUOTA_BLOCK_ERROR_CODE,
+    });
+  });
+
+  it("test_quota_circuit_breaker_blocks_continuation_requeue", async () => {
+    const { companyId, agentId } = await seedClaudeAgent();
+    await openCircuit(companyId, agentId);
+
+    const queued = await heartbeatService(db).wakeup(agentId, {
+      source: "automation",
+      triggerDetail: "system",
+      reason: "continuation_requeue",
+      contextSnapshot: {
+        issueId: randomUUID(),
+        retryReason: "max_turn_continuation",
+      },
+    });
+
+    expect(queued).toBeNull();
+    expect(mockAdapterExecute).not.toHaveBeenCalled();
+    const runs = await db.select().from(heartbeatRuns);
+    expect(runs).toHaveLength(0);
+    const [request] = await db.select().from(agentWakeupRequests).where(eq(agentWakeupRequests.agentId, agentId));
+    expect(request).toMatchObject({
+      companyId,
+      status: "skipped",
+      reason: CLAUDE_QUOTA_BLOCK_ERROR_CODE,
+    });
+  });
+
+  it("test_claude_local_global_concurrency_is_one", async () => {
+    const { companyId, agentId } = await seedClaudeAgent();
+    const activeRunId = randomUUID();
+    const candidateRunId = randomUUID();
+    await db.insert(heartbeatRuns).values([
+      {
+        id: activeRunId,
+        companyId,
+        agentId,
+        status: "running",
+        invocationSource: "automation",
+        triggerDetail: "system",
+      },
+      {
+        id: candidateRunId,
+        companyId,
+        agentId,
+        status: "queued",
+        invocationSource: "automation",
+        triggerDetail: "system",
+      },
+    ]);
+
+    const secondDb = createDb(tempDb!.connectionString);
+    const slot = await secondDb.transaction((tx) =>
+      acquireClaudeLocalDispatchSlot(tx, companyId, candidateRunId)
+    );
+
+    expect(slot).toEqual({ allowed: false, reason: "concurrency_limit" });
+    const runningRows = await db
+      .select({ id: heartbeatRuns.id })
+      .from(heartbeatRuns)
+      .innerJoin(agents, eq(agents.id, heartbeatRuns.agentId))
+      .where(and(
+        eq(heartbeatRuns.status, "running"),
+        eq(agents.adapterType, CLAUDE_LOCAL_ADAPTER_TYPE),
+      ));
+    expect(runningRows).toHaveLength(1);
+  });
+
+  it("test_session_limit_text_is_classified_as_quota_block", async () => {
+    const { companyId, agentId } = await seedClaudeAgent();
+
+    await openCircuit(companyId, agentId, "session limit reached; resets 2:15pm");
+
+    const [event] = await db
+      .select()
+      .from(activityLog)
+      .where(eq(activityLog.action, "claude.quota_circuit_opened"));
+    expect(event).toBeTruthy();
+    expect(event?.details).toMatchObject({
+      reason: CLAUDE_QUOTA_BLOCK_ERROR_CODE,
+      operatorResumeRequired: false,
+    });
+  });
+});

--- a/server/src/__tests__/claude-quota-guard.test.ts
+++ b/server/src/__tests__/claude-quota-guard.test.ts
@@ -154,7 +154,7 @@ describeEmbeddedPostgres("Claude quota guard dispatch integration", () => {
     return { companyId, agentId };
   }
 
-  async function openCircuit(companyId: string, agentId: string, message = "You've hit your session limit - resets 11:30pm") {
+  async function openCircuit(companyId: string, agentId: string, message = "Claude session limit reached") {
     const details = await recordClaudeQuotaFailure(db, {
       adapterType: CLAUDE_LOCAL_ADAPTER_TYPE,
       companyId,
@@ -176,7 +176,7 @@ describeEmbeddedPostgres("Claude quota guard dispatch integration", () => {
     expect(block).toMatchObject({
       blocked: true,
       reason: CLAUDE_QUOTA_BLOCK_ERROR_CODE,
-      operatorResumeRequired: false,
+      operatorResumeRequired: true,
     });
   });
 
@@ -235,14 +235,35 @@ describeEmbeddedPostgres("Claude quota guard dispatch integration", () => {
     });
   });
 
+  it("test_quota_circuit_breaker_blocks_start_of_existing_queued_claude_run", async () => {
+    const { companyId, agentId } = await seedClaudeAgent();
+    await openCircuit(companyId, agentId);
+    const runId = randomUUID();
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId,
+      agentId,
+      invocationSource: "automation",
+      triggerDetail: "system",
+      status: "queued",
+      contextSnapshot: { taskKey: "queued-before-circuit-check" },
+      responsibleUserId: "responsible-user",
+    });
+
+    await heartbeatService(db).resumeQueuedRuns();
+
+    expect(mockAdapterExecute).not.toHaveBeenCalled();
+    const [run] = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.id, runId));
+    expect(run).toMatchObject({
+      status: "cancelled",
+      errorCode: CLAUDE_QUOTA_BLOCK_ERROR_CODE,
+    });
+  });
+
   it("blocks claude_local wakeups for another company while the circuit is open", async () => {
     const companyA = await seedClaudeAgent();
     const companyB = await seedClaudeAgent();
-    await openCircuit(
-      companyA.companyId,
-      companyA.agentId,
-      "You've hit your session limit - resets 1:30pm (Asia/Jerusalem)",
-    );
+    await openCircuit(companyA.companyId, companyA.agentId);
 
     const queued = await heartbeatService(db).wakeup(companyB.agentId, {
       source: "automation",

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -965,6 +965,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     kind?: string;
     previousOwnerAgentId?: string | null;
     returnOwnerAgentId?: string | null;
+    expectWakeup?: boolean;
   }) {
     const action = await waitForValue(async () =>
       db.select().from(issueRecoveryActions).where(
@@ -998,6 +999,8 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     });
     if (input.cause === "execution_review_participant_recovery") {
       expect(action.nextAction).toContain("failed review participant path");
+    } else if (input.cause === "adapter_setup_failed") {
+      expect(action.nextAction).toContain("local Claude adapter setup");
     } else {
       expect(action.nextAction).toContain(
         input.kind === "missing_disposition" ? "valid issue disposition" : "Restore a live execution path",
@@ -1027,17 +1030,21 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
           payload?.strandedRunId === input.runId;
       }) ?? null;
     });
-    expect(recoveryWakeup).toMatchObject({
-      companyId: input.companyId,
-      reason: "source_scoped_recovery_action",
-      source: "assignment",
-      payload: expect.objectContaining({
-        modelProfile: "cheap",
-        allowDeliverableWork: false,
-        allowDocumentUpdates: false,
-        resumeRequiresNormalModel: true,
-      }),
-    });
+    if (input.expectWakeup === false) {
+      expect(recoveryWakeup).toBeNull();
+    } else {
+      expect(recoveryWakeup).toMatchObject({
+        companyId: input.companyId,
+        reason: "source_scoped_recovery_action",
+        source: "assignment",
+        payload: expect.objectContaining({
+          modelProfile: "cheap",
+          allowDeliverableWork: false,
+          allowDocumentUpdates: false,
+          resumeRequiresNormalModel: true,
+        }),
+      });
+    }
 
     const recoveryRun = recoveryWakeup?.runId
       ? await db
@@ -1046,18 +1053,22 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
         .where(eq(heartbeatRuns.id, recoveryWakeup.runId))
         .then((rows) => rows[0] ?? null)
       : null;
-    expect(recoveryRun?.contextSnapshot).toMatchObject({
-      issueId: input.issueId,
-      taskId: input.issueId,
-      source: "issue_recovery_action",
-      recoveryActionId: action.id,
-      sourceIssueId: input.issueId,
-      strandedRunId: input.runId,
-      modelProfile: "cheap",
-      allowDeliverableWork: false,
-      allowDocumentUpdates: false,
-      resumeRequiresNormalModel: true,
-    });
+    if (input.expectWakeup === false) {
+      expect(recoveryRun).toBeNull();
+    } else {
+      expect(recoveryRun?.contextSnapshot).toMatchObject({
+        issueId: input.issueId,
+        taskId: input.issueId,
+        source: "issue_recovery_action",
+        recoveryActionId: action.id,
+        sourceIssueId: input.issueId,
+        strandedRunId: input.runId,
+        modelProfile: "cheap",
+        allowDeliverableWork: false,
+        allowDocumentUpdates: false,
+        resumeRequiresNormalModel: true,
+      });
+    }
     await waitForHeartbeatIdle(db);
     const sourceIssue = await db
       .select()
@@ -1083,7 +1094,10 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       .then((rows) => rows.map((row) => row.blockerIssueId));
   }
 
-  async function seedQueuedIssueRunFixture() {
+  async function seedQueuedIssueRunFixture(input?: {
+    adapterType?: string;
+    contextSnapshot?: Record<string, unknown>;
+  }) {
     const companyId = randomUUID();
     const agentId = randomUUID();
     const runId = randomUUID();
@@ -1106,7 +1120,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       name: "CodexCoder",
       role: "engineer",
       status: "idle",
-      adapterType: "codex_local",
+      adapterType: input?.adapterType ?? "codex_local",
       adapterConfig: {},
       runtimeConfig: {
         heartbeat: {
@@ -1143,6 +1157,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
         issueId,
         taskId: issueId,
         wakeReason: "issue_assigned",
+        ...(input?.contextSnapshot ?? {}),
       },
       updatedAt: now,
       createdAt: now,
@@ -2394,6 +2409,74 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       return rows.find((comment) => comment.body.includes("secret/env bindings are missing")) ?? null;
     });
     expect(configurationComment).toBeTruthy();
+  });
+
+  it("blocks claude_local local adapter setup failures without creating follow-on work", async () => {
+    mockAdapterExecute.mockResolvedValueOnce({
+      exitCode: 1,
+      signal: null,
+      timedOut: false,
+      errorCode: "acpx_session_init_failed",
+      errorMessage: "spawn C:\\\\Users\\\\shani\\\\.paperclip\\\\wrappers\\\\claude-local.sh ENOENT",
+      summary: "Failed during ensure_session wrapper bootstrap.",
+      provider: "anthropic",
+      model: "claude-code",
+      resultJson: {
+        phase: "ensure_session",
+        message: "spawn wrapper ENOENT",
+      },
+    });
+
+    const { companyId, agentId, runId, issueId } = await seedQueuedIssueRunFixture({
+      adapterType: "claude_local",
+    });
+    const heartbeat = heartbeatService(db);
+
+    await heartbeat.resumeQueuedRuns();
+    await waitForRunToSettle(heartbeat, runId, 5_000);
+    await waitForHeartbeatIdle(db, 5_000);
+
+    const runs = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.agentId, agentId));
+    expect(runs).toHaveLength(1);
+    expect(runs[0]).toMatchObject({
+      id: runId,
+      status: "failed",
+      errorCode: "acpx_session_init_failed",
+    });
+
+    const issue = await waitForValue(async () =>
+      db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => {
+        const row = rows[0] ?? null;
+        return row?.status === "blocked" ? row : null;
+      }),
+    );
+    expect(issue?.executionRunId).toBeNull();
+
+    await expectSourceScopedStrandedRecoveryAction({
+      companyId,
+      agentId,
+      issueId,
+      runId,
+      previousStatus: "in_progress",
+      cause: "adapter_setup_failed",
+      kind: "configuration_validation",
+      expectWakeup: false,
+    });
+
+    const wakeups = await db.select().from(agentWakeupRequests).where(eq(agentWakeupRequests.agentId, agentId));
+    expect(wakeups).toHaveLength(1);
+    expect(
+      wakeups.some((wakeup) => [
+        "missing_issue_comment",
+        "issue_assignment_recovery",
+        "issue_continuation_needed",
+        "source_scoped_recovery_action",
+      ].includes(wakeup.reason ?? "")),
+    ).toBe(false);
+
+    const comments = await db.select().from(issueComments).where(eq(issueComments.issueId, issueId));
+    expect(comments).toHaveLength(1);
+    expect(comments[0]?.body).toContain("local session setup failed before Claude launched");
   });
 
   it("queues one finish-handoff wake when a successful run leaves in-progress work without a next action", async () => {
@@ -4530,7 +4613,93 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     }
   });
 
+  it("does not let stranded recovery requeue claude_local setup failures", async () => {
+    const { companyId, agentId, issueId, runId } = await seedStrandedIssueFixture({
+      status: "todo",
+      runStatus: "failed",
+      adapterType: "claude_local",
+      runErrorCode: "acpx_session_init_failed",
+      runError: "spawn C:\\\\Users\\\\shani\\\\.paperclip\\\\wrappers\\\\claude-local.sh ENOENT",
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(result.dispatchRequeued).toBe(0);
+    expect(result.escalated).toBe(1);
+    expect(result.issueIds).toEqual([issueId]);
+
+    const runs = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.agentId, agentId));
+    expect(runs).toHaveLength(1);
+
+    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(issue?.status).toBe("blocked");
+
+    await expectSourceScopedStrandedRecoveryAction({
+      companyId,
+      agentId,
+      issueId,
+      runId,
+      previousStatus: "todo",
+      cause: "adapter_setup_failed",
+      kind: "configuration_validation",
+      expectWakeup: false,
+    });
+  });
+
+  it("does not classify non-claude_local setup-looking failures as local Claude setup failures", async () => {
+    const { agentId, issueId, runId } = await seedStrandedIssueFixture({
+      status: "todo",
+      runStatus: "failed",
+      adapterType: "codex_local",
+      runErrorCode: "acpx_session_init_failed",
+      runError: "spawn C:\\\\Users\\\\shani\\\\.paperclip\\\\wrappers\\\\claude-local.sh ENOENT",
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(result.dispatchRequeued).toBe(1);
+    expect(result.escalated).toBe(0);
+    expect(result.issueIds).toEqual([issueId]);
+
+    const runs = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.agentId, agentId));
+    expect(runs).toHaveLength(2);
+
+    const retryRun = runs.find((row) => row.id !== runId);
+    expect((retryRun?.contextSnapshot as Record<string, unknown>)?.retryReason).toBe("assignment_recovery");
+    if (retryRun) {
+      await waitForRunToSettle(heartbeat, retryRun.id);
+    }
+  });
+
+  it("suppresses follow-on wakes in manual safe-run mode so one claude_local run stays one run", async () => {
+    const { agentId, runId } = await seedQueuedIssueRunFixture({
+      adapterType: "claude_local",
+      contextSnapshot: { manualSafeRun: true },
+    });
+    const heartbeat = heartbeatService(db);
+
+    await heartbeat.resumeQueuedRuns();
+    await waitForRunToSettle(heartbeat, runId, 5_000);
+    await waitForHeartbeatIdle(db, 5_000);
+
+    const runs = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.agentId, agentId));
+    expect(runs).toHaveLength(1);
+    expect(runs[0]?.status).toBe("succeeded");
+
+    const wakeups = await db.select().from(agentWakeupRequests).where(eq(agentWakeupRequests.agentId, agentId));
+    expect(wakeups).toHaveLength(1);
+    expect(
+      wakeups.some((wakeup) => [
+        "finish_successful_run_handoff",
+        "missing_issue_comment",
+        "issue_assignment_recovery",
+        "issue_continuation_needed",
+      ].includes(wakeup.reason ?? "")),
+    ).toBe(false);
+  });
+
   it("uses a global Claude quota-open event as the recovery retry-budget window across companies", async () => {
+    mockAdapterExecute.mockClear();
     const quotaCompanyId = randomUUID();
     const quotaAgentId = randomUUID();
     const quotaOpenedAt = new Date("2026-03-19T00:10:00.000Z");

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -652,6 +652,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     runSource?: string | null;
     assignToUser?: boolean;
     activePauseHold?: boolean;
+    adapterType?: string;
     livenessState?: "completed" | "advanced" | "plan_only" | "empty_response" | "blocked" | "failed" | "needs_followup" | null;
     runErrorCode?: string | null;
     runError?: string | null;
@@ -679,7 +680,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       name: "CodexCoder",
       role: "engineer",
       status: "idle",
-      adapterType: "codex_local",
+      adapterType: input.adapterType ?? "codex_local",
       adapterConfig: {},
       runtimeConfig: {},
       permissions: {},
@@ -4527,6 +4528,92 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     if (retryRun) {
       await waitForRunToSettle(heartbeat, retryRun.id);
     }
+  });
+
+  it("uses a global Claude quota-open event as the recovery retry-budget window across companies", async () => {
+    const quotaCompanyId = randomUUID();
+    const quotaAgentId = randomUUID();
+    const quotaOpenedAt = new Date("2026-03-19T00:10:00.000Z");
+    await db.insert(companies).values({
+      id: quotaCompanyId,
+      name: "Quota Source",
+      issuePrefix: `Q${quotaCompanyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      defaultResponsibleUserId: "responsible-user",
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: quotaAgentId,
+      companyId: quotaCompanyId,
+      name: "Claude Source",
+      role: "engineer",
+      status: "idle",
+      adapterType: "claude_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    await db.insert(activityLog).values({
+      companyId: quotaCompanyId,
+      actorType: "system",
+      actorId: "claude_quota_guard",
+      action: "claude.quota_circuit_opened",
+      entityType: "system",
+      entityId: "claude_local",
+      agentId: quotaAgentId,
+      details: {
+        reason: "blocked_by_claude_quota",
+        blockedUntil: null,
+        operatorResumeRequired: true,
+      },
+      createdAt: quotaOpenedAt,
+    });
+
+    const { companyId, agentId, issueId, runId } = await seedStrandedIssueFixture({
+      status: "in_progress",
+      runStatus: "failed",
+      adapterType: "claude_local",
+    });
+    await db.insert(heartbeatRuns).values({
+      id: randomUUID(),
+      companyId,
+      agentId,
+      invocationSource: "automation",
+      triggerDetail: "system",
+      status: "cancelled",
+      retryOfRunId: runId,
+      contextSnapshot: {
+        issueId,
+        taskId: issueId,
+        wakeReason: "issue_continuation_needed",
+        retryReason: "issue_continuation_needed",
+      },
+      createdAt: new Date("2026-03-19T00:11:00.000Z"),
+      updatedAt: new Date("2026-03-19T00:11:00.000Z"),
+    });
+
+    const heartbeat = heartbeatService(db);
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+
+    expect(result.continuationRequeued).toBe(0);
+    expect(result.skipped).toBe(1);
+    expect(mockAdapterExecute).not.toHaveBeenCalled();
+    const runs = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.agentId, agentId));
+    expect(runs).toHaveLength(2);
+    const budgetEvents = await db
+      .select()
+      .from(activityLog)
+      .where(and(
+        eq(activityLog.companyId, companyId),
+        eq(activityLog.action, "claude.automatic_recovery_retry_budget_exhausted"),
+      ));
+    expect(budgetEvents).toHaveLength(1);
+    expect(budgetEvents[0]?.details).toMatchObject({
+      state: "degraded_retry_budget_exhausted",
+      adapterType: "claude_local",
+      retryReason: "issue_continuation_needed",
+      windowStart: quotaOpenedAt.toISOString(),
+      maxRetries: 1,
+    });
   });
 
   it("does not continue seeded in-progress work that has no run linkage", async () => {

--- a/server/src/__tests__/heartbeat-retry-scheduling.test.ts
+++ b/server/src/__tests__/heartbeat-retry-scheduling.test.ts
@@ -92,15 +92,16 @@ describeEmbeddedPostgres("heartbeat bounded retry scheduling", () => {
 
   afterEach(async () => {
     await db.delete(activityLog);
-    await db.delete(heartbeatRunEvents);
     await db.delete(environmentLeases);
     await db.delete(issueRelations);
     await db.delete(issues);
     await db.delete(executionWorkspaces);
     await db.delete(projects);
     await db.delete(activityLog);
-    await db.delete(heartbeatRunEvents);
-    await db.delete(heartbeatRuns);
+    await db.transaction(async (tx) => {
+      await tx.delete(heartbeatRunEvents);
+      await tx.delete(heartbeatRuns);
+    });
     await db.delete(agentWakeupRequests);
     await db.delete(agentRuntimeState);
     await db.delete(budgetPolicies);

--- a/server/src/services/claude-quota-guard.ts
+++ b/server/src/services/claude-quota-guard.ts
@@ -1,0 +1,208 @@
+import { and, desc, eq, inArray, sql } from "drizzle-orm";
+import type { Db } from "@paperclipai/db";
+import { activityLog, agents, heartbeatRuns } from "@paperclipai/db";
+
+export const CLAUDE_LOCAL_ADAPTER_TYPE = "claude_local";
+export const CLAUDE_QUOTA_BLOCK_ERROR_CODE = "blocked_by_claude_quota";
+export const CLAUDE_QUOTA_CIRCUIT_OPENED_ACTION = "claude.quota_circuit_opened";
+export const CLAUDE_QUOTA_CIRCUIT_RESUMED_ACTION = "claude.quota_circuit_resumed";
+
+const CLAUDE_QUOTA_LOCK_KEY = "paperclip:claude_local_quota_dispatch";
+
+type ClaudeQuotaBlock = {
+  blocked: boolean;
+  reason: string;
+  blockedUntil: Date | null;
+  operatorResumeRequired: boolean;
+};
+
+type ClaudeQuotaFailureInput = {
+  adapterType: string;
+  status?: string | null;
+  httpStatus?: number | null;
+  errorCode?: string | null;
+  errorMessage?: string | null;
+  stderrExcerpt?: string | null;
+  resultJson?: unknown;
+};
+
+type ClaudeQuotaDb = Pick<Db, "execute" | "select" | "insert">;
+
+function readObject(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : {};
+}
+
+function readString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+function readNumber(value: unknown): number | null {
+  const parsed = typeof value === "number" ? value : Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+export function parseClaudeQuotaResetTime(text: string, now = new Date()): Date | null {
+  const match = text.match(/resets?\s+(\d{1,2})(?::(\d{2}))?\s*(am|pm)?(?:\s*\(([^)]+)\))?/i);
+  if (!match) return null;
+
+  let hour = Number(match[1]);
+  const minute = Number(match[2] ?? "0");
+  const ampm = match[3]?.toLowerCase();
+  if (!Number.isInteger(hour) || !Number.isInteger(minute) || hour > 23 || minute > 59) {
+    return null;
+  }
+  if (ampm === "pm" && hour !== 12) hour += 12;
+  if (ampm === "am" && hour === 12) hour = 0;
+  if (hour > 23) return null;
+
+  const reset = new Date(now);
+  reset.setHours(hour, minute, 0, 0);
+  if (reset.getTime() <= now.getTime()) {
+    reset.setDate(reset.getDate() + 1);
+  }
+  return reset;
+}
+
+export function isClaudeQuotaOrSessionFailure(input: ClaudeQuotaFailureInput): boolean {
+  if (input.adapterType !== CLAUDE_LOCAL_ADAPTER_TYPE) return false;
+  const result = readObject(input.resultJson);
+  const apiErrorStatus = readNumber(result.apiErrorStatus ?? result.httpStatus ?? result.statusCode);
+  const status = (input.status ?? "").toLowerCase();
+  const code = (input.errorCode ?? readString(result.error) ?? readString(result.errorCode) ?? "").toLowerCase();
+  const text = [
+    input.errorMessage,
+    input.stderrExcerpt,
+    readString(result.message),
+    readString(result.errorMessage),
+    readString(result.summary),
+  ]
+    .filter(Boolean)
+    .join(" ")
+    .toLowerCase();
+
+  if (input.httpStatus === 429 || apiErrorStatus === 429 || code === "rate_limit") return true;
+  if (text.includes("you've hit your session limit")) return true;
+  if (text.includes("session limit") || text.includes("resets")) return true;
+  return status === "timed_out" || status === "adapter_failed";
+}
+
+export function claudeQuotaBlockMessage(block: ClaudeQuotaBlock): string {
+  const until = block.blockedUntil ? ` until ${block.blockedUntil.toISOString()}` : " until an operator resumes it";
+  return `Claude-local dispatch is blocked by Claude quota/session circuit breaker${until}`;
+}
+
+async function latestCircuitEvent(db: ClaudeQuotaDb, companyId?: string | null) {
+  const actions = [CLAUDE_QUOTA_CIRCUIT_OPENED_ACTION, CLAUDE_QUOTA_CIRCUIT_RESUMED_ACTION];
+  const rows = await db
+    .select()
+    .from(activityLog)
+    .where(
+      companyId
+        ? and(eq(activityLog.companyId, companyId), inArray(activityLog.action, actions))
+        : inArray(activityLog.action, actions),
+    )
+    .orderBy(desc(activityLog.createdAt))
+    .limit(1);
+  return rows[0] ?? null;
+}
+
+export async function getClaudeQuotaBlock(db: ClaudeQuotaDb, companyId?: string | null, now = new Date()): Promise<ClaudeQuotaBlock> {
+  const event = await latestCircuitEvent(db, companyId);
+  if (!event || event.action === CLAUDE_QUOTA_CIRCUIT_RESUMED_ACTION) {
+    return { blocked: false, reason: "ready", blockedUntil: null, operatorResumeRequired: false };
+  }
+
+  const details = readObject(event.details);
+  const blockedUntilText = readString(details.blockedUntil);
+  const blockedUntil = blockedUntilText ? new Date(blockedUntilText) : null;
+  const validBlockedUntil = blockedUntil && Number.isFinite(blockedUntil.getTime()) ? blockedUntil : null;
+  const operatorResumeRequired = details.operatorResumeRequired !== false && !validBlockedUntil;
+  if (validBlockedUntil && validBlockedUntil.getTime() <= now.getTime()) {
+    return { blocked: false, reason: "reset_elapsed", blockedUntil: validBlockedUntil, operatorResumeRequired: false };
+  }
+
+  return {
+    blocked: true,
+    reason: readString(details.reason) ?? CLAUDE_QUOTA_BLOCK_ERROR_CODE,
+    blockedUntil: validBlockedUntil,
+    operatorResumeRequired,
+  };
+}
+
+export async function recordClaudeQuotaFailure(
+  db: ClaudeQuotaDb,
+  input: ClaudeQuotaFailureInput & {
+    companyId: string;
+    agentId?: string | null;
+    runId?: string | null;
+    observedAt?: Date;
+  },
+) {
+  if (!isClaudeQuotaOrSessionFailure(input)) return null;
+
+  const observedAt = input.observedAt ?? new Date();
+  const resetAt = parseClaudeQuotaResetTime(
+    [input.errorMessage, input.stderrExcerpt].filter(Boolean).join(" "),
+    observedAt,
+  );
+  const details = {
+    reason: CLAUDE_QUOTA_BLOCK_ERROR_CODE,
+    blockedUntil: resetAt?.toISOString() ?? null,
+    operatorResumeRequired: resetAt ? false : true,
+    triggeringRunId: input.runId ?? null,
+    triggeringStatus: input.status ?? null,
+    triggeringErrorCode: input.errorCode ?? null,
+    triggeringHttpStatus: input.httpStatus ?? null,
+  };
+
+  await db.insert(activityLog).values({
+    companyId: input.companyId,
+    actorType: "system",
+    actorId: "claude_quota_guard",
+    action: CLAUDE_QUOTA_CIRCUIT_OPENED_ACTION,
+    entityType: "system",
+    entityId: CLAUDE_LOCAL_ADAPTER_TYPE,
+    agentId: input.agentId ?? null,
+    runId: input.runId ?? null,
+    details,
+    createdAt: observedAt,
+  });
+  return details;
+}
+
+export async function blockIfClaudeQuotaOpen(db: ClaudeQuotaDb, companyId: string) {
+  const block = await getClaudeQuotaBlock(db, companyId);
+  return block.blocked ? block : null;
+}
+
+export async function acquireClaudeLocalDispatchSlot(
+  tx: ClaudeQuotaDb,
+  companyId: string,
+  runId: string,
+): Promise<{ allowed: true } | { allowed: false; reason: "circuit_open" | "concurrency_limit"; block?: ClaudeQuotaBlock }> {
+  await tx.execute(sql`select pg_advisory_xact_lock(hashtextextended(${CLAUDE_QUOTA_LOCK_KEY}, 0))`);
+
+  const block = await getClaudeQuotaBlock(tx, companyId);
+  if (block.blocked) {
+    return { allowed: false, reason: "circuit_open", block };
+  }
+
+  const runningRows = await tx
+    .select({ id: heartbeatRuns.id })
+    .from(heartbeatRuns)
+    .innerJoin(agents, eq(agents.id, heartbeatRuns.agentId))
+    .where(and(
+      eq(heartbeatRuns.status, "running"),
+      eq(agents.adapterType, CLAUDE_LOCAL_ADAPTER_TYPE),
+      sql`${heartbeatRuns.id} <> ${runId}`,
+    ))
+    .limit(1);
+
+  if (runningRows.length > 0) {
+    return { allowed: false, reason: "concurrency_limit" };
+  }
+
+  return { allowed: true };
+}

--- a/server/src/services/claude-quota-guard.ts
+++ b/server/src/services/claude-quota-guard.ts
@@ -43,6 +43,66 @@ function readNumber(value: unknown): number | null {
   return Number.isFinite(parsed) ? parsed : null;
 }
 
+function getTimeZoneParts(date: Date, timeZone: string) {
+  try {
+    const formatter = new Intl.DateTimeFormat("en-US", {
+      timeZone,
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+      hour: "2-digit",
+      minute: "2-digit",
+      hourCycle: "h23",
+    });
+    const parts = Object.fromEntries(formatter.formatToParts(date).map((part) => [part.type, part.value]));
+    const year = Number(parts.year);
+    const month = Number(parts.month);
+    const day = Number(parts.day);
+    const hour = Number(parts.hour);
+    const minute = Number(parts.minute);
+    if (![year, month, day, hour, minute].every(Number.isInteger)) return null;
+    return { year, month, day, hour, minute };
+  } catch {
+    return null;
+  }
+}
+
+function zonedTimeToUtc(input: {
+  year: number;
+  month: number;
+  day: number;
+  hour: number;
+  minute: number;
+  timeZone: string;
+}) {
+  const guess = Date.UTC(input.year, input.month - 1, input.day, input.hour, input.minute, 0, 0);
+  const rendered = getTimeZoneParts(new Date(guess), input.timeZone);
+  if (!rendered) return null;
+
+  const renderedAsUtc = Date.UTC(
+    rendered.year,
+    rendered.month - 1,
+    rendered.day,
+    rendered.hour,
+    rendered.minute,
+    0,
+    0,
+  );
+  const corrected = new Date(guess - (renderedAsUtc - guess));
+  const verified = getTimeZoneParts(corrected, input.timeZone);
+  if (
+    !verified ||
+    verified.year !== input.year ||
+    verified.month !== input.month ||
+    verified.day !== input.day ||
+    verified.hour !== input.hour ||
+    verified.minute !== input.minute
+  ) {
+    return null;
+  }
+  return corrected;
+}
+
 export function parseClaudeQuotaResetTime(text: string, now = new Date()): Date | null {
   const match = text.match(/resets?\s+(\d{1,2})(?::(\d{2}))?\s*(am|pm)?(?:\s*\(([^)]+)\))?/i);
   if (!match) return null;
@@ -50,12 +110,41 @@ export function parseClaudeQuotaResetTime(text: string, now = new Date()): Date 
   let hour = Number(match[1]);
   const minute = Number(match[2] ?? "0");
   const ampm = match[3]?.toLowerCase();
+  const timeZone = readString(match[4]);
   if (!Number.isInteger(hour) || !Number.isInteger(minute) || hour > 23 || minute > 59) {
     return null;
   }
   if (ampm === "pm" && hour !== 12) hour += 12;
   if (ampm === "am" && hour === 12) hour = 0;
   if (hour > 23) return null;
+
+  if (timeZone) {
+    const nowParts = getTimeZoneParts(now, timeZone);
+    if (!nowParts) return null;
+    let reset = zonedTimeToUtc({
+      year: nowParts.year,
+      month: nowParts.month,
+      day: nowParts.day,
+      hour,
+      minute,
+      timeZone,
+    });
+    if (!reset) return null;
+    if (reset.getTime() <= now.getTime()) {
+      const nextDay = new Date(Date.UTC(nowParts.year, nowParts.month - 1, nowParts.day + 1, 12, 0, 0, 0));
+      const nextParts = getTimeZoneParts(nextDay, timeZone);
+      if (!nextParts) return null;
+      reset = zonedTimeToUtc({
+        year: nextParts.year,
+        month: nextParts.month,
+        day: nextParts.day,
+        hour,
+        minute,
+        timeZone,
+      });
+    }
+    return reset;
+  }
 
   const reset = new Date(now);
   reset.setHours(hour, minute, 0, 0);
@@ -93,16 +182,12 @@ export function claudeQuotaBlockMessage(block: ClaudeQuotaBlock): string {
   return `Claude-local dispatch is blocked by Claude quota/session circuit breaker${until}`;
 }
 
-async function latestCircuitEvent(db: ClaudeQuotaDb, companyId?: string | null) {
+async function latestCircuitEvent(db: ClaudeQuotaDb, _companyId?: string | null) {
   const actions = [CLAUDE_QUOTA_CIRCUIT_OPENED_ACTION, CLAUDE_QUOTA_CIRCUIT_RESUMED_ACTION];
   const rows = await db
     .select()
     .from(activityLog)
-    .where(
-      companyId
-        ? and(eq(activityLog.companyId, companyId), inArray(activityLog.action, actions))
-        : inArray(activityLog.action, actions),
-    )
+    .where(inArray(activityLog.action, actions))
     .orderBy(desc(activityLog.createdAt))
     .limit(1);
   return rows[0] ?? null;

--- a/server/src/services/claude-quota-guard.ts
+++ b/server/src/services/claude-quota-guard.ts
@@ -193,6 +193,16 @@ async function latestCircuitEvent(db: ClaudeQuotaDb, _companyId?: string | null)
   return rows[0] ?? null;
 }
 
+export async function getLatestClaudeQuotaCircuitOpenedAt(db: ClaudeQuotaDb): Promise<Date | null> {
+  const rows = await db
+    .select({ createdAt: activityLog.createdAt })
+    .from(activityLog)
+    .where(eq(activityLog.action, CLAUDE_QUOTA_CIRCUIT_OPENED_ACTION))
+    .orderBy(desc(activityLog.createdAt))
+    .limit(1);
+  return rows[0]?.createdAt ?? null;
+}
+
 export async function getClaudeQuotaBlock(db: ClaudeQuotaDb, companyId?: string | null, now = new Date()): Promise<ClaudeQuotaBlock> {
   const event = await latestCircuitEvent(db, companyId);
   if (!event || event.action === CLAUDE_QUOTA_CIRCUIT_RESUMED_ACTION) {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -191,6 +191,14 @@ import { productivityReviewService } from "./productivity-review.js";
 import { taskWatchdogService } from "./task-watchdogs.js";
 import { withAgentStartLock } from "./agent-start-lock.js";
 import {
+  CLAUDE_LOCAL_ADAPTER_TYPE,
+  CLAUDE_QUOTA_BLOCK_ERROR_CODE,
+  acquireClaudeLocalDispatchSlot,
+  blockIfClaudeQuotaOpen,
+  claudeQuotaBlockMessage,
+  recordClaudeQuotaFailure,
+} from "./claude-quota-guard.js";
+import {
   evaluateAgentInvokability,
   evaluateAgentInvokabilityFromDb,
   shouldCancelRunsForNonInvokableAgent,
@@ -8379,7 +8387,8 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           | "issue_execution_lock_changed"
           | "issue_review_participant_changed"
           | "issue_paused"
-          | "issue_dependencies_blocked";
+          | "issue_dependencies_blocked"
+          | typeof CLAUDE_QUOTA_BLOCK_ERROR_CODE;
         issueId: string | null;
         details: Record<string, unknown>;
       };
@@ -8667,6 +8676,30 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     }
 
     const contextSnapshot = parseObject(dueRun.contextSnapshot);
+    if (agent.adapterType === CLAUDE_LOCAL_ADAPTER_TYPE) {
+      const block = await blockIfClaudeQuotaOpen(db, agent.companyId);
+      if (block) {
+        const gate: BlockedScheduledRetryGate = {
+          allowed: false as const,
+          reason: claudeQuotaBlockMessage(block),
+          errorCode: CLAUDE_QUOTA_BLOCK_ERROR_CODE,
+          issueId: readNonEmptyString(contextSnapshot.issueId),
+          details: {
+            blockedUntil: block.blockedUntil?.toISOString() ?? null,
+            operatorResumeRequired: block.operatorResumeRequired,
+          },
+        };
+        const cancelled = await cancelScheduledRetryForGate(dueRun, gate, now);
+        return cancelled
+          ? {
+              outcome: "gate_suppressed",
+              run: cancelled,
+              reason: gate.reason,
+              errorCode: gate.errorCode,
+            }
+          : { outcome: "not_promoted", run: null };
+      }
+    }
     const gate = await evaluateScheduledRetryGate({
       run: dueRun,
       agent,
@@ -8755,6 +8788,33 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     const wakeReason = opts?.wakeReason ?? BOUNDED_TRANSIENT_HEARTBEAT_RETRY_WAKE_REASON;
     const maxAttempts = Math.max(0, Math.floor(opts?.maxAttempts ?? BOUNDED_TRANSIENT_HEARTBEAT_RETRY_MAX_ATTEMPTS));
     const nextAttempt = (run.scheduledRetryAttempt ?? 0) + 1;
+    if (agent.adapterType === CLAUDE_LOCAL_ADAPTER_TYPE) {
+      const block = await blockIfClaudeQuotaOpen(db, agent.companyId);
+      if (block) {
+        const reason = claudeQuotaBlockMessage(block);
+        const contextSnapshot = parseObject(run.contextSnapshot);
+        const issueId = readNonEmptyString(contextSnapshot.issueId);
+        await appendRunEvent(run, await nextRunEventSeq(run.id), {
+          eventType: "lifecycle",
+          stream: "system",
+          level: "warn",
+          message: reason,
+          payload: {
+            retryReason,
+            scheduledRetryAttempt: nextAttempt,
+            maxAttempts,
+            blockedUntil: block.blockedUntil?.toISOString() ?? null,
+            operatorResumeRequired: block.operatorResumeRequired,
+          },
+        });
+        return {
+          outcome: "not_scheduled" as const,
+          reason,
+          errorCode: CLAUDE_QUOTA_BLOCK_ERROR_CODE,
+          issueId,
+        };
+      }
+    }
     const computedBaseSchedule = opts?.delayMs != null
       ? nextAttempt <= maxAttempts
         ? {
@@ -9947,25 +10007,67 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       }
     }
 
-    const claimedAt = new Date();
     const responsibleUserId = await resolveResponsibleUserIdForRun({
       run,
       contextSnapshot: context,
       issueContext: issueId ? await getIssueExecutionContext(run.companyId, issueId) : null,
       routineEnvContext: { routineId: null, env: null, responsibleUserId: null },
     });
-    const claimed = await db
-      .update(heartbeatRuns)
-      .set({
-        status: "running",
-        responsibleUserId,
-        startedAt: run.startedAt ?? claimedAt,
-        updatedAt: claimedAt,
-      })
-      .where(and(eq(heartbeatRuns.id, run.id), eq(heartbeatRuns.status, "queued")))
-      .returning()
-      .then((rows) => rows[0] ?? null);
+    const claimed = await db.transaction(async (tx) => {
+      const claimedAt = new Date();
+      if (agent.adapterType === CLAUDE_LOCAL_ADAPTER_TYPE) {
+        const slot = await acquireClaudeLocalDispatchSlot(tx, run.companyId, run.id);
+        if (!slot.allowed) {
+          if (slot.reason === "circuit_open") {
+            const reason = claudeQuotaBlockMessage(slot.block!);
+            const blocked = await tx
+              .update(heartbeatRuns)
+              .set({
+                status: "cancelled",
+                finishedAt: claimedAt,
+                error: reason,
+                errorCode: CLAUDE_QUOTA_BLOCK_ERROR_CODE,
+                resultJson: {
+                  ...parseObject(run.resultJson),
+                  stopReason: CLAUDE_QUOTA_BLOCK_ERROR_CODE,
+                  blockedUntil: slot.block!.blockedUntil?.toISOString() ?? null,
+                  operatorResumeRequired: slot.block!.operatorResumeRequired,
+                },
+                updatedAt: claimedAt,
+              })
+              .where(and(eq(heartbeatRuns.id, run.id), eq(heartbeatRuns.status, "queued")))
+              .returning()
+              .then((rows) => rows[0] ?? null);
+            if (blocked?.wakeupRequestId) {
+              await tx
+                .update(agentWakeupRequests)
+                .set({
+                  status: "skipped",
+                  finishedAt: claimedAt,
+                  error: reason,
+                  updatedAt: claimedAt,
+                })
+                .where(eq(agentWakeupRequests.id, blocked.wakeupRequestId));
+            }
+          }
+          return null;
+        }
+      }
+
+      return tx
+        .update(heartbeatRuns)
+        .set({
+          status: "running",
+          responsibleUserId,
+          startedAt: run.startedAt ?? claimedAt,
+          updatedAt: claimedAt,
+        })
+        .where(and(eq(heartbeatRuns.id, run.id), eq(heartbeatRuns.status, "queued")))
+        .returning()
+        .then((rows) => rows[0] ?? null);
+    });
     if (!claimed) return null;
+    const claimedAt = claimed.startedAt ?? new Date();
 
     publishLiveEvent({
       companyId: claimed.companyId,
@@ -12829,6 +12931,19 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             : outcome === "failed"
               ? (adapterResult.errorCode ?? recordedResponsibleUserDenialCode ?? "adapter_failed")
               : null;
+      if (agent.adapterType === CLAUDE_LOCAL_ADAPTER_TYPE && outcome !== "succeeded") {
+        await recordClaudeQuotaFailure(db, {
+          adapterType: agent.adapterType,
+          companyId: agent.companyId,
+          agentId: agent.id,
+          runId: run.id,
+          status: outcome === "timed_out" ? "timed_out" : runErrorCode,
+          errorCode: runErrorCode,
+          errorMessage: runErrorMessage,
+          stderrExcerpt,
+          resultJson: adapterResult.resultJson,
+        });
+      }
 
       let logSummary: { bytes: number; sha256?: string; compressed: boolean } | null = null;
       if (handle) {
@@ -13099,6 +13214,18 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         ?? configurationIncompleteFailure?.code
         ?? recordedResponsibleUserDenialCode
         ?? "adapter_failed";
+      if (agent.adapterType === CLAUDE_LOCAL_ADAPTER_TYPE) {
+        await recordClaudeQuotaFailure(db, {
+          adapterType: agent.adapterType,
+          companyId: agent.companyId,
+          agentId: agent.id,
+          runId: run.id,
+          status: failureErrorCode,
+          errorCode: failureErrorCode,
+          errorMessage: message,
+          stderrExcerpt,
+        });
+      }
       logger.error({ err, runId }, "heartbeat execution failed");
 
       let logSummary: { bytes: number; sha256?: string; compressed: boolean } | null = null;
@@ -14255,6 +14382,32 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         error: `Wake suppressed because company status is ${companyStatus}`,
       });
       return null;
+    }
+
+    if (agent.adapterType === CLAUDE_LOCAL_ADAPTER_TYPE) {
+      const block = await blockIfClaudeQuotaOpen(db, agent.companyId);
+      if (block) {
+        const message = claudeQuotaBlockMessage(block);
+        await writeSkippedRequest(CLAUDE_QUOTA_BLOCK_ERROR_CODE, {
+          error: message,
+          payload: {
+            ...(payload ?? {}),
+            claudeQuotaCircuit: {
+              state: CLAUDE_QUOTA_BLOCK_ERROR_CODE,
+              blockedUntil: block.blockedUntil?.toISOString() ?? null,
+              operatorResumeRequired: block.operatorResumeRequired,
+            },
+          },
+        });
+        if (opts.requestedByActorType === "user") {
+          throw conflict(message, {
+            code: CLAUDE_QUOTA_BLOCK_ERROR_CODE,
+            blockedUntil: block.blockedUntil?.toISOString() ?? null,
+            operatorResumeRequired: block.operatorResumeRequired,
+          });
+        }
+        return null;
+      }
     }
 
     const explicitResumeSession = await resolveExplicitResumeSessionOverride(agent, payload, taskKey);

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -196,8 +196,15 @@ import {
   acquireClaudeLocalDispatchSlot,
   blockIfClaudeQuotaOpen,
   claudeQuotaBlockMessage,
+  getLatestClaudeQuotaCircuitOpenedAt,
   recordClaudeQuotaFailure,
 } from "./claude-quota-guard.js";
+import {
+  LOCAL_ADAPTER_SETUP_RECOVERY_CAUSE,
+  MANUAL_SAFE_RUN_CONTEXT_KEY,
+  isClaudeLocalAdapterSetupFailure,
+  isManualSafeRunContextSnapshot,
+} from "./local-adapter-setup-failure.js";
 import {
   evaluateAgentInvokability,
   evaluateAgentInvokabilityFromDb,
@@ -427,6 +434,7 @@ function readTransientRetryNotBeforeFromRun(run: Pick<typeof heartbeatRuns.$infe
 function readTransientRecoveryContractFromRun(
   run: Pick<typeof heartbeatRuns.$inferSelect, "errorCode" | "resultJson">,
 ) {
+  if (run.errorCode === CLAUDE_QUOTA_BLOCK_ERROR_CODE) return null;
   const errorFamily = readHeartbeatRunErrorFamily(run);
   return errorFamily === "transient_upstream" || errorFamily === "provider_quota"
     ? {
@@ -2311,6 +2319,42 @@ function didAutomaticRecoveryFail(
   );
 }
 
+function isManualSafeRun(run: Pick<typeof heartbeatRuns.$inferSelect, "contextSnapshot">) {
+  return isManualSafeRunContextSnapshot(parseObject(run.contextSnapshot));
+}
+
+function isLocalAdapterSetupFailureRun(
+  run: Pick<typeof heartbeatRuns.$inferSelect, "error" | "errorCode" | "stdoutExcerpt" | "stderrExcerpt" | "resultJson">,
+  agent: Pick<typeof agents.$inferSelect, "adapterType"> | null | undefined,
+) {
+  return isClaudeLocalAdapterSetupFailure({
+    adapterType: agent?.adapterType ?? null,
+    errorCode: run.errorCode,
+    error: run.error,
+    stdoutExcerpt: run.stdoutExcerpt,
+    stderrExcerpt: run.stderrExcerpt,
+    resultJson: run.resultJson,
+  });
+}
+
+function buildLocalAdapterSetupFailureRecoveryComment(input: {
+  latestRun: Pick<typeof heartbeatRuns.$inferSelect, "error" | "errorCode"> | null | undefined;
+}) {
+  const failureSummary = summarizeRunFailureForIssueComment(input.latestRun);
+  return (
+    "Paperclip could not start the local Claude adapter because local session setup failed before Claude launched. " +
+    `Automatic continuation, retry, and recovery wakes are suppressed until an operator repairs the local adapter setup.${failureSummary ?? ""} ` +
+    "Moving the issue to `blocked` so the setup failure is visible for manual repair."
+  );
+}
+
+function shouldSuppressAutomaticFollowOnForRun(input: {
+  run: Pick<typeof heartbeatRuns.$inferSelect, "contextSnapshot" | "error" | "errorCode" | "stdoutExcerpt" | "stderrExcerpt" | "resultJson">;
+  agent: Pick<typeof agents.$inferSelect, "adapterType"> | null | undefined;
+}) {
+  return isManualSafeRun(input.run) || isLocalAdapterSetupFailureRun(input.run, input.agent);
+}
+
 function isExecutionReviewParticipantRecoveryRun(
   run: Pick<typeof heartbeatRuns.$inferSelect, "contextSnapshot"> | null,
 ) {
@@ -3936,6 +3980,9 @@ function enrichWakeContextSnapshot(input: {
   if (!readNonEmptyString(contextSnapshot["wakeTriggerDetail"]) && triggerDetail) {
     contextSnapshot.wakeTriggerDetail = triggerDetail;
   }
+  if (contextSnapshot[MANUAL_SAFE_RUN_CONTEXT_KEY] !== true && payload?.[MANUAL_SAFE_RUN_CONTEXT_KEY] === true) {
+    contextSnapshot[MANUAL_SAFE_RUN_CONTEXT_KEY] = true;
+  }
   normalizeModelProfileWakeContext({ contextSnapshot, payload });
   normalizeInteractionContinuationWakeContext(contextSnapshot, payload);
 
@@ -5361,6 +5408,81 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     });
 
     return completedRun;
+  }
+
+  async function guardClaudeLocalDirectQueuedRunCreation(input: {
+    agent: typeof agents.$inferSelect;
+    sourceRun?: typeof heartbeatRuns.$inferSelect | null;
+    issueId?: string | null;
+    taskKey?: string | null;
+    retryReason?: string | null;
+    reason: string;
+    enforceRetryBudget?: boolean;
+  }): Promise<{ allowed: true } | { allowed: false; reason: string; errorCode: typeof CLAUDE_QUOTA_BLOCK_ERROR_CODE }> {
+    if (input.agent.adapterType !== CLAUDE_LOCAL_ADAPTER_TYPE) return { allowed: true };
+
+    const block = await blockIfClaudeQuotaOpen(db, input.agent.companyId);
+    if (block) {
+      const reason = claudeQuotaBlockMessage(block);
+      if (input.sourceRun) {
+        await appendRunEvent(input.sourceRun, await nextRunEventSeq(input.sourceRun.id), {
+          eventType: "lifecycle",
+          stream: "system",
+          level: "warn",
+          message: reason,
+          payload: {
+            reason: input.reason,
+            errorCode: CLAUDE_QUOTA_BLOCK_ERROR_CODE,
+            blockedUntil: block.blockedUntil?.toISOString() ?? null,
+            operatorResumeRequired: block.operatorResumeRequired,
+          },
+        });
+      }
+      return { allowed: false, reason, errorCode: CLAUDE_QUOTA_BLOCK_ERROR_CODE };
+    }
+
+    if (!input.enforceRetryBudget || !input.retryReason) return { allowed: true };
+
+    const latestQuotaOpenedAt = await getLatestClaudeQuotaCircuitOpenedAt(db);
+    const windowStart = latestQuotaOpenedAt ?? new Date(Date.now() - 60 * 60 * 1000);
+    const taskPredicate = input.issueId
+      ? sql`${heartbeatRuns.contextSnapshot} ->> 'issueId' = ${input.issueId}`
+      : input.taskKey
+        ? sql`${heartbeatRuns.contextSnapshot} ->> 'taskKey' = ${input.taskKey}`
+        : sql`true`;
+    const priorRetries = await db
+      .select({ id: heartbeatRuns.id })
+      .from(heartbeatRuns)
+      .where(and(
+        eq(heartbeatRuns.companyId, input.agent.companyId),
+        eq(heartbeatRuns.agentId, input.agent.id),
+        gte(heartbeatRuns.createdAt, windowStart),
+        taskPredicate,
+        sql`${heartbeatRuns.contextSnapshot} ->> 'retryReason' = ${input.retryReason}`,
+      ))
+      .limit(1);
+
+    if (priorRetries.length === 0) return { allowed: true };
+
+    const reason = `Claude-local direct recovery retry budget exhausted for ${input.retryReason}`;
+    if (input.sourceRun) {
+      await appendRunEvent(input.sourceRun, await nextRunEventSeq(input.sourceRun.id), {
+        eventType: "lifecycle",
+        stream: "system",
+        level: "warn",
+        message: reason,
+        payload: {
+          reason: input.reason,
+          retryReason: input.retryReason,
+          issueId: input.issueId ?? null,
+          taskKey: input.taskKey ?? null,
+          windowStart: windowStart.toISOString(),
+          maxRetries: 1,
+          errorCode: CLAUDE_QUOTA_BLOCK_ERROR_CODE,
+        },
+      });
+    }
+    return { allowed: false, reason, errorCode: CLAUDE_QUOTA_BLOCK_ERROR_CODE };
   }
 
   async function releaseEnvironmentLeasesForRun(input: {
@@ -7269,6 +7391,15 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
   async function handleRunLivenessContinuation(run: typeof heartbeatRuns.$inferSelect) {
     const livenessState = run.livenessState as RunLivenessState | null;
     if (livenessState !== "plan_only" && livenessState !== "empty_response") return;
+    if (isManualSafeRun(run)) {
+      await appendRunEvent(run, await nextRunEventSeq(run.id), {
+        eventType: "lifecycle",
+        stream: "system",
+        level: "info",
+        message: "Liveness continuation suppressed because manual safe-run mode allows only one local run",
+      });
+      return;
+    }
 
     const context = parseObject(run.contextSnapshot);
     const issueId = readNonEmptyString(context.issueId);
@@ -7452,6 +7583,15 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
 
   async function handleSuccessfulRunHandoff(run: typeof heartbeatRuns.$inferSelect, agent: typeof agents.$inferSelect) {
     if (run.status !== "succeeded") return;
+    if (isManualSafeRun(run)) {
+      await appendRunEvent(run, await nextRunEventSeq(run.id), {
+        eventType: "lifecycle",
+        stream: "system",
+        level: "info",
+        message: "Successful-run handoff suppressed because manual safe-run mode allows only one local run",
+      });
+      return;
+    }
     const context = parseObject(run.contextSnapshot);
     const issueId = readNonEmptyString(context.issueId) ?? readNonEmptyString(context.taskId);
     if (!issueId) return;
@@ -7922,6 +8062,16 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       retryReason: "missing_issue_comment",
       missingIssueCommentForRunId: run.id,
     }, "status_only");
+    const preflight = await guardClaudeLocalDirectQueuedRunCreation({
+      agent,
+      sourceRun: run,
+      issueId,
+      taskKey,
+      retryReason: "missing_issue_comment",
+      reason: "missing_issue_comment",
+      enforceRetryBudget: true,
+    });
+    if (!preflight.allowed) return null;
     const responsibleUserId = await resolveResponsibleUserIdForRunContext(run, retryContextSnapshot);
     const now = new Date();
 
@@ -8048,6 +8198,23 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     run: typeof heartbeatRuns.$inferSelect,
     agent: typeof agents.$inferSelect,
   ) {
+    if (shouldSuppressAutomaticFollowOnForRun({ run, agent })) {
+      await patchRunIssueCommentStatus(run.id, {
+        issueCommentStatus: "not_applicable",
+        issueCommentSatisfiedByCommentId: null,
+        issueCommentRetryQueuedAt: null,
+      });
+      await appendRunEvent(run, await nextRunEventSeq(run.id), {
+        eventType: "lifecycle",
+        stream: "system",
+        level: "info",
+        message: isManualSafeRun(run)
+          ? "Missing-comment follow-up suppressed because manual safe-run mode allows only one local run"
+          : "Missing-comment follow-up suppressed because local adapter setup failed before Claude launched",
+      });
+      return { outcome: "not_applicable" as const, queuedRun: null };
+    }
+
     const contextSnapshot = parseObject(run.contextSnapshot);
     const issueId = readNonEmptyString(contextSnapshot.issueId);
     if (!issueId) {
@@ -8182,6 +8349,16 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       wakeReason: "process_lost_retry",
       retryReason: "process_lost",
     }, "normal_model");
+    const preflight = await guardClaudeLocalDirectQueuedRunCreation({
+      agent,
+      sourceRun: run,
+      issueId,
+      taskKey,
+      retryReason: "process_lost",
+      reason: "process_lost_retry",
+      enforceRetryBudget: true,
+    });
+    if (!preflight.allowed) return null;
     const responsibleUserId = await resolveResponsibleUserIdForRunContext(run, retryContextSnapshot);
 
     const queued = await db.transaction(async (tx) => {
@@ -8788,6 +8965,30 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     const wakeReason = opts?.wakeReason ?? BOUNDED_TRANSIENT_HEARTBEAT_RETRY_WAKE_REASON;
     const maxAttempts = Math.max(0, Math.floor(opts?.maxAttempts ?? BOUNDED_TRANSIENT_HEARTBEAT_RETRY_MAX_ATTEMPTS));
     const nextAttempt = (run.scheduledRetryAttempt ?? 0) + 1;
+    if (shouldSuppressAutomaticFollowOnForRun({ run, agent })) {
+      const issueId = readNonEmptyString(parseObject(run.contextSnapshot).issueId);
+      await appendRunEvent(run, await nextRunEventSeq(run.id), {
+        eventType: "lifecycle",
+        stream: "system",
+        level: "warn",
+        message: isManualSafeRun(run)
+          ? "Scheduled retry suppressed because manual safe-run mode allows only one local run"
+          : "Scheduled retry suppressed because local adapter setup failed before Claude launched",
+        payload: {
+          retryReason,
+          scheduledRetryAttempt: nextAttempt,
+          maxAttempts,
+        },
+      });
+      return {
+        outcome: "not_scheduled" as const,
+        reason: isManualSafeRun(run)
+          ? "manual_safe_run"
+          : LOCAL_ADAPTER_SETUP_RECOVERY_CAUSE,
+        errorCode: run.errorCode ?? null,
+        issueId,
+      };
+    }
     if (agent.adapterType === CLAUDE_LOCAL_ADAPTER_TYPE) {
       const block = await blockIfClaudeQuotaOpen(db, agent.companyId);
       if (block) {
@@ -12923,7 +13124,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
               );
       const recordedResponsibleUserDenialCode =
         normalizeResponsibleUserDenialCode(latestRun?.errorCode);
-      const runErrorCode =
+      const adapterRunErrorCode =
         outcome === "timed_out"
           ? "timeout"
           : outcome === "cancelled"
@@ -12931,19 +13132,21 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             : outcome === "failed"
               ? (adapterResult.errorCode ?? recordedResponsibleUserDenialCode ?? "adapter_failed")
               : null;
-      if (agent.adapterType === CLAUDE_LOCAL_ADAPTER_TYPE && outcome !== "succeeded") {
-        await recordClaudeQuotaFailure(db, {
-          adapterType: agent.adapterType,
-          companyId: agent.companyId,
-          agentId: agent.id,
-          runId: run.id,
-          status: outcome === "timed_out" ? "timed_out" : runErrorCode,
-          errorCode: runErrorCode,
-          errorMessage: runErrorMessage,
-          stderrExcerpt,
-          resultJson: adapterResult.resultJson,
-        });
-      }
+      const claudeQuotaFailureDetails =
+        agent.adapterType === CLAUDE_LOCAL_ADAPTER_TYPE && outcome !== "succeeded"
+          ? await recordClaudeQuotaFailure(db, {
+            adapterType: agent.adapterType,
+            companyId: agent.companyId,
+            agentId: agent.id,
+            runId: run.id,
+            status: outcome === "timed_out" ? "timed_out" : adapterRunErrorCode,
+            errorCode: adapterRunErrorCode,
+            errorMessage: runErrorMessage,
+            stderrExcerpt,
+            resultJson: adapterResult.resultJson,
+          })
+          : null;
+      const runErrorCode = claudeQuotaFailureDetails ? CLAUDE_QUOTA_BLOCK_ERROR_CODE : adapterRunErrorCode;
 
       let logSummary: { bytes: number; sha256?: string; compressed: boolean } | null = null;
       if (handle) {
@@ -12998,6 +13201,10 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
               resultJson: {
                 ...parseObject(adapterResult.resultJson),
                 configFreshness: configFreshnessResultMetadata,
+                ...(claudeQuotaFailureDetails ? {
+                  stopReason: CLAUDE_QUOTA_BLOCK_ERROR_CODE,
+                  claudeQuotaCircuit: claudeQuotaFailureDetails,
+                } : {}),
               },
               errorFamily: adapterResult.errorFamily ?? null,
               retryNotBefore: adapterResult.retryNotBefore ?? null,
@@ -13573,6 +13780,8 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       ? await resolveSessionBeforeForWakeup(recoveryAgent, taskKey)
       : null;
     const recoveryAgentNameKey = normalizeAgentNameKey(recoveryAgent?.name);
+    const localAdapterSetupFailure = isLocalAdapterSetupFailureRun(run, recoveryAgent);
+    const manualSafeRun = isManualSafeRun(run);
 
     const promotionResult = await db.transaction(async (tx) => {
       // Lock the context issue (if any) AND every issue that still references this run.
@@ -13679,20 +13888,27 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       // Sibling lock cleanup is already done above; only the primary issue carries
       // the recovery surface because the comment is attached to a single issue.
       if (
-        (isWorkspaceValidationFailedRun(run) || isConfigurationIncompleteFailedRun(run)) &&
+        (isWorkspaceValidationFailedRun(run) ||
+          isConfigurationIncompleteFailedRun(run) ||
+          localAdapterSetupFailure) &&
         (issue.status === "todo" || issue.status === "in_progress") &&
         !issue.assigneeUserId &&
         issue.assigneeAgentId === run.agentId
       ) {
         const configurationIncomplete = isConfigurationIncompleteFailedRun(run);
+        const adapterSetupFailure = localAdapterSetupFailure;
         return {
           kind: "blocked" as const,
           issue,
           previousStatus: issue.status,
-          comment: configurationIncomplete
+          comment: adapterSetupFailure
+            ? buildLocalAdapterSetupFailureRecoveryComment({ latestRun: run })
+            : configurationIncomplete
             ? buildConfigurationIncompleteRecoveryComment({ latestRun: run })
             : buildWorkspaceValidationRecoveryComment({ latestRun: run }),
-          recoveryCause: configurationIncomplete
+          recoveryCause: adapterSetupFailure
+            ? LOCAL_ADAPTER_SETUP_RECOVERY_CAUSE
+            : configurationIncomplete
             ? CONFIGURATION_INCOMPLETE_RECOVERY_CAUSE
             : WORKSPACE_VALIDATION_RECOVERY_CAUSE,
         };
@@ -13883,6 +14099,24 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           payload: promotedPayload,
         });
 
+        if (deferredAgent.adapterType === CLAUDE_LOCAL_ADAPTER_TYPE) {
+          const block = await blockIfClaudeQuotaOpen(tx, deferredAgent.companyId);
+          if (block) {
+            const reason = claudeQuotaBlockMessage(block);
+            await tx
+              .update(agentWakeupRequests)
+              .set({
+                status: "cancelled",
+                reason: CLAUDE_QUOTA_BLOCK_ERROR_CODE,
+                finishedAt: new Date(),
+                error: reason,
+                updatedAt: new Date(),
+              })
+              .where(eq(agentWakeupRequests.id, deferred.id));
+            return { kind: "released" as const };
+          }
+        }
+
         const sessionBefore =
           readNonEmptyString(promotedContextSnapshot.resumeSessionDisplayId) ??
           await resolveSessionBeforeForWakeup(deferredAgent, promotedTaskKey);
@@ -14027,6 +14261,42 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         }
 
         const now = new Date();
+        if (recoveryAgent.adapterType === CLAUDE_LOCAL_ADAPTER_TYPE) {
+          const block = await blockIfClaudeQuotaOpen(tx, recoveryAgent.companyId);
+          if (block) {
+            return {
+              kind: "blocked" as const,
+              issue,
+              previousStatus: issue.status,
+              comment: claudeQuotaBlockMessage(block),
+              recoveryCause: EXECUTION_REVIEW_PARTICIPANT_RECOVERY_CAUSE,
+              recoveryOwnerAgentId: currentParticipant.agentId,
+            };
+          }
+          const latestQuotaOpenedAt = await getLatestClaudeQuotaCircuitOpenedAt(tx);
+          const windowStart = latestQuotaOpenedAt ?? new Date(Date.now() - 60 * 60 * 1000);
+          const priorRetries = await tx
+            .select({ id: heartbeatRuns.id })
+            .from(heartbeatRuns)
+            .where(and(
+              eq(heartbeatRuns.companyId, recoveryAgent.companyId),
+              eq(heartbeatRuns.agentId, recoveryAgent.id),
+              gte(heartbeatRuns.createdAt, windowStart),
+              sql`${heartbeatRuns.contextSnapshot} ->> 'issueId' = ${issue.id}`,
+              sql`${heartbeatRuns.contextSnapshot} ->> 'retryReason' = ${EXECUTION_REVIEW_PARTICIPANT_RECOVERY_RETRY_REASON}`,
+            ))
+            .limit(1);
+          if (priorRetries.length > 0) {
+            return {
+              kind: "blocked" as const,
+              issue,
+              previousStatus: issue.status,
+              comment: `Claude-local direct recovery retry budget exhausted for ${EXECUTION_REVIEW_PARTICIPANT_RECOVERY_RETRY_REASON}`,
+              recoveryCause: EXECUTION_REVIEW_PARTICIPANT_RECOVERY_CAUSE,
+              recoveryOwnerAgentId: currentParticipant.agentId,
+            };
+          }
+        }
         const wakeupRequest = await tx
           .insert(agentWakeupRequests)
           .values({
@@ -14111,7 +14381,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       if (!issueNeedsImmediateRecovery) {
         return { kind: "released" as const };
       }
-      if (options.suppressImmediateRecovery) {
+      if (options.suppressImmediateRecovery || manualSafeRun) {
         return { kind: "released" as const };
       }
 
@@ -14137,14 +14407,18 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         !recoveryAgent ||
         isWorkspaceValidationFailedRun(run) ||
         isConfigurationIncompleteFailedRun(run) ||
+        localAdapterSetupFailure ||
         didAutomaticRecoveryFail(run, issue.status === "todo" ? "assignment_recovery" : "issue_continuation_needed");
       if (shouldBlockImmediately) {
         const workspaceValidationFailure = isWorkspaceValidationFailedRun(run);
         const configurationIncompleteFailure = isConfigurationIncompleteFailedRun(run);
+        const adapterSetupFailure = localAdapterSetupFailure;
         const comment = workspaceValidationFailure
           ? buildWorkspaceValidationRecoveryComment({ latestRun: run })
           : configurationIncompleteFailure
             ? buildConfigurationIncompleteRecoveryComment({ latestRun: run })
+            : adapterSetupFailure
+              ? buildLocalAdapterSetupFailureRecoveryComment({ latestRun: run })
             : buildImmediateExecutionPathRecoveryComment({
                 status: issue.status as "todo" | "in_progress",
                 latestRun: run,
@@ -14158,6 +14432,8 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             ? WORKSPACE_VALIDATION_RECOVERY_CAUSE
             : configurationIncompleteFailure
               ? CONFIGURATION_INCOMPLETE_RECOVERY_CAUSE
+              : adapterSetupFailure
+                ? LOCAL_ADAPTER_SETUP_RECOVERY_CAUSE
               : undefined,
         };
       }
@@ -14175,6 +14451,38 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         source: recoverySource,
         retryOfRunId: run.id,
       }, "normal_model");
+      if (recoveryAgent.adapterType === CLAUDE_LOCAL_ADAPTER_TYPE) {
+        const block = await blockIfClaudeQuotaOpen(tx, recoveryAgent.companyId);
+        if (block) {
+          return {
+            kind: "blocked" as const,
+            issue,
+            previousStatus: issue.status,
+            comment: claudeQuotaBlockMessage(block),
+          };
+        }
+        const latestQuotaOpenedAt = await getLatestClaudeQuotaCircuitOpenedAt(tx);
+        const windowStart = latestQuotaOpenedAt ?? new Date(Date.now() - 60 * 60 * 1000);
+        const priorRetries = await tx
+          .select({ id: heartbeatRuns.id })
+          .from(heartbeatRuns)
+          .where(and(
+            eq(heartbeatRuns.companyId, recoveryAgent.companyId),
+            eq(heartbeatRuns.agentId, recoveryAgent.id),
+            gte(heartbeatRuns.createdAt, windowStart),
+            sql`${heartbeatRuns.contextSnapshot} ->> 'issueId' = ${issue.id}`,
+            sql`${heartbeatRuns.contextSnapshot} ->> 'retryReason' = ${retryReason}`,
+          ))
+          .limit(1);
+        if (priorRetries.length > 0) {
+          return {
+            kind: "blocked" as const,
+            issue,
+            previousStatus: issue.status,
+            comment: `Claude-local direct recovery retry budget exhausted for ${retryReason}`,
+          };
+        }
+      }
       const responsibleUserId = await resolveResponsibleUserIdForRunSeed({
         companyId: issue.companyId,
         contextSnapshot: recoveryContextSnapshot,
@@ -14269,6 +14577,8 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             ? WORKSPACE_VALIDATION_RECOVERY_CAUSE
             : promotionResult.recoveryCause === CONFIGURATION_INCOMPLETE_RECOVERY_CAUSE
               ? CONFIGURATION_INCOMPLETE_RECOVERY_CAUSE
+              : promotionResult.recoveryCause === LOCAL_ADAPTER_SETUP_RECOVERY_CAUSE
+                ? LOCAL_ADAPTER_SETUP_RECOVERY_CAUSE
               : promotionResult.recoveryCause === EXECUTION_REVIEW_PARTICIPANT_RECOVERY_CAUSE
                 ? EXECUTION_REVIEW_PARTICIPANT_RECOVERY_CAUSE
               : undefined,

--- a/server/src/services/local-adapter-setup-failure.ts
+++ b/server/src/services/local-adapter-setup-failure.ts
@@ -1,0 +1,62 @@
+import { parseObject } from "../adapters/utils.js";
+import { CLAUDE_LOCAL_ADAPTER_TYPE } from "./claude-quota-guard.js";
+
+export const LOCAL_ADAPTER_SETUP_FAILURE_CODE = "acpx_session_init_failed";
+export const LOCAL_ADAPTER_SETUP_RECOVERY_CAUSE = "adapter_setup_failed";
+export const MANUAL_SAFE_RUN_CONTEXT_KEY = "manualSafeRun";
+
+type LocalAdapterSetupFailureInput = {
+  adapterType?: string | null;
+  errorCode?: string | null;
+  error?: string | null;
+  stdoutExcerpt?: string | null;
+  stderrExcerpt?: string | null;
+  resultJson?: unknown;
+};
+
+function readNonEmptyString(value: unknown) {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+function lower(value: string | null | undefined) {
+  return value?.toLowerCase() ?? "";
+}
+
+function collectFailureEvidenceText(input: LocalAdapterSetupFailureInput) {
+  const result = parseObject(input.resultJson);
+  return [
+    input.errorCode,
+    input.error,
+    input.stdoutExcerpt,
+    input.stderrExcerpt,
+    readNonEmptyString(result.summary),
+    readNonEmptyString(result.errorMessage),
+    readNonEmptyString(result.message),
+    readNonEmptyString(result.phase),
+    readNonEmptyString(result.cause),
+  ]
+    .map((value) => lower(value))
+    .filter((value) => value.length > 0)
+    .join("\n");
+}
+
+export function isClaudeLocalAdapterSetupFailure(input: LocalAdapterSetupFailureInput) {
+  if (input.adapterType !== CLAUDE_LOCAL_ADAPTER_TYPE) return false;
+  if (input.errorCode === LOCAL_ADAPTER_SETUP_FAILURE_CODE) return true;
+
+  const evidence = collectFailureEvidenceText(input);
+  if (!evidence) return false;
+
+  const mentionsMissingFile = evidence.includes("enoent") || evidence.includes("no such file or directory");
+  const mentionsSessionSetup = evidence.includes("ensure_session") ||
+    evidence.includes("session init") ||
+    evidence.includes("session initialization");
+  const mentionsWrapperPath = evidence.includes("wrapper") || evidence.includes(".sh");
+  const mentionsSpawn = evidence.includes("spawn");
+
+  return mentionsMissingFile && (mentionsSessionSetup || mentionsWrapperPath || mentionsSpawn);
+}
+
+export function isManualSafeRunContextSnapshot(contextSnapshot: Record<string, unknown> | null | undefined) {
+  return contextSnapshot?.[MANUAL_SAFE_RUN_CONTEXT_KEY] === true;
+}

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -69,7 +69,11 @@ import {
   withRecoveryModelProfileHint,
 } from "./model-profile-hint.js";
 import { isAutomaticRecoverySuppressedByPauseHold } from "./pause-hold-guard.js";
-import { CLAUDE_QUOTA_BLOCK_ERROR_CODE } from "../claude-quota-guard.js";
+import {
+  CLAUDE_LOCAL_ADAPTER_TYPE,
+  CLAUDE_QUOTA_BLOCK_ERROR_CODE,
+  getLatestClaudeQuotaCircuitOpenedAt,
+} from "../claude-quota-guard.js";
 
 const EXECUTION_PATH_HEARTBEAT_RUN_STATUSES = ["queued", "running", "scheduled_retry"] as const;
 const UNSUCCESSFUL_HEARTBEAT_RUN_TERMINAL_STATUSES = ["interrupted", "failed", "cancelled", "timed_out"] as const;
@@ -265,7 +269,6 @@ const CONTINUATION_WAITING_ON_REVIEW_ERROR_CODE = "issue_continuation_waiting_on
 const CONTINUATION_RECOVERY_TRANSIENT_MAX_ATTEMPTS = 3;
 const CONTINUATION_RECOVERY_DEFAULT_MAX_ATTEMPTS = 1;
 const CONTINUATION_RECOVERY_TRANSIENT_BASE_BACKOFF_MS = 60_000;
-const CLAUDE_LOCAL_ADAPTER_TYPE = "claude_local";
 const CLAUDE_AUTOMATIC_RECOVERY_RETRY_BUDGET = 1;
 
 type ContinuationRetryClassification = {
@@ -848,17 +851,8 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
   }) {
     const agent = await getAgent(input.agentId);
     if (agent?.adapterType === CLAUDE_LOCAL_ADAPTER_TYPE) {
-      const latestQuotaEvent = await db
-        .select({ createdAt: activityLog.createdAt })
-        .from(activityLog)
-        .where(and(
-          eq(activityLog.companyId, agent.companyId),
-          eq(activityLog.action, "claude.quota_circuit_opened"),
-        ))
-        .orderBy(desc(activityLog.createdAt))
-        .limit(1)
-        .then((rows) => rows[0] ?? null);
-      const windowStart = latestQuotaEvent?.createdAt ??
+      const latestQuotaOpenedAt = await getLatestClaudeQuotaCircuitOpenedAt(db);
+      const windowStart = latestQuotaOpenedAt ??
         new Date(Date.now() - 60 * 60 * 1000);
       const priorRetries = await db
         .select({ id: heartbeatRuns.id })

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -74,6 +74,10 @@ import {
   CLAUDE_QUOTA_BLOCK_ERROR_CODE,
   getLatestClaudeQuotaCircuitOpenedAt,
 } from "../claude-quota-guard.js";
+import {
+  LOCAL_ADAPTER_SETUP_RECOVERY_CAUSE,
+  isClaudeLocalAdapterSetupFailure,
+} from "../local-adapter-setup-failure.js";
 
 const EXECUTION_PATH_HEARTBEAT_RUN_STATUSES = ["queued", "running", "scheduled_retry"] as const;
 const UNSUCCESSFUL_HEARTBEAT_RUN_TERMINAL_STATUSES = ["interrupted", "failed", "cancelled", "timed_out"] as const;
@@ -147,6 +151,7 @@ type StrandedRecoveryCause =
   | "stranded_assigned_issue"
   | "workspace_validation_failed"
   | "configuration_incomplete"
+  | typeof LOCAL_ADAPTER_SETUP_RECOVERY_CAUSE
   | "execution_review_participant_recovery"
   | typeof SUCCESSFUL_RUN_MISSING_STATE_REASON;
 
@@ -168,6 +173,18 @@ function readWorkspaceValidationPayload(latestRun: LatestIssueRun): Record<strin
 function readWorkspaceValidationFingerprint(latestRun: LatestIssueRun): string | null {
   const payload = readWorkspaceValidationPayload(latestRun);
   return readNonEmptyString(payload?.fingerprint);
+}
+
+function isLocalAdapterSetupFailureRun(
+  latestRun: LatestIssueRun,
+  adapterType: string | null | undefined = null,
+) {
+  return isClaudeLocalAdapterSetupFailure({
+    adapterType,
+    errorCode: latestRun?.errorCode ?? null,
+    error: latestRun?.error ?? null,
+    resultJson: latestRun?.resultJson,
+  });
 }
 
 type WatchdogDecisionActor =
@@ -220,6 +237,15 @@ function buildExecutionReviewParticipantUnavailableComment(latestRun: LatestIssu
     `and the review stage has no completed decision or live reviewer run.${failureSummary ?? ""} ` +
     "Moving it to `blocked` with a source-scoped recovery action so the recovery owner can repair the reviewer runtime, " +
     "restore the review stage, or record an intentional manual resolution."
+  );
+}
+
+function buildLocalAdapterSetupFailureComment(latestRun: LatestIssueRun) {
+  const failureSummary = summarizeRunFailureForIssueComment(latestRun);
+  return (
+    "Paperclip could not start the local Claude adapter because local session setup failed before Claude launched. " +
+    `Automatic continuation, retry, and recovery wakes are suppressed until an operator repairs the local adapter setup.${failureSummary ?? ""} ` +
+    "Moving it to `blocked` so the setup failure is visible for manual repair."
   );
 }
 
@@ -278,7 +304,18 @@ type ContinuationRetryClassification = {
   errorCode: string | null;
 };
 
-export function classifyContinuationFailure(latestRun: LatestIssueRun): ContinuationRetryClassification {
+export function classifyContinuationFailure(
+  latestRun: LatestIssueRun,
+  adapterType: string | null | undefined = null,
+): ContinuationRetryClassification {
+  if (isLocalAdapterSetupFailureRun(latestRun, adapterType)) {
+    return {
+      kind: "non_retryable",
+      maxAttempts: 0,
+      baseBackoffMs: 0,
+      errorCode: latestRun?.errorCode ?? LOCAL_ADAPTER_SETUP_RECOVERY_CAUSE,
+    };
+  }
   const errorCode = readNonEmptyString(latestRun?.errorCode);
   if (errorCode && NON_RETRYABLE_CONTINUATION_ERROR_CODES.has(errorCode)) {
     return { kind: "non_retryable", maxAttempts: 0, baseBackoffMs: 0, errorCode };
@@ -2481,6 +2518,8 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         ? "workspace_validation" as const
       : cause === "configuration_incomplete"
         ? "configuration_validation" as const
+      : cause === LOCAL_ADAPTER_SETUP_RECOVERY_CAUSE
+        ? "configuration_validation" as const
       : "stranded_assigned_issue" as const;
   }
 
@@ -2582,10 +2621,15 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
             : "Repair the source issue workspace link, project workspace cwd, or git checkout before resuming adapter execution."
         : recoveryCause === "configuration_incomplete"
           ? "Bind the missing secret(s) named in the run failure to the agent/project/routine env before resuming adapter execution."
+        : recoveryCause === LOCAL_ADAPTER_SETUP_RECOVERY_CAUSE
+          ? "Repair the local Claude adapter setup on this host before resuming adapter execution."
         : recoveryCause === "execution_review_participant_recovery"
           ? "Repair the failed review participant path, restore the source issue to in_review with a live reviewer, or record an intentional manual resolution."
         : "Restore a live execution path, fix the runtime/adapter failure, or record an intentional manual resolution.",
-      wakePolicy: recoveryCause === "workspace_validation_failed" || recoveryCause === "configuration_incomplete"
+      wakePolicy:
+        recoveryCause === "workspace_validation_failed" ||
+        recoveryCause === "configuration_incomplete" ||
+        recoveryCause === LOCAL_ADAPTER_SETUP_RECOVERY_CAUSE
         ? {
           type: "manual_repair_required",
           reason: recoveryCause,
@@ -2617,6 +2661,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
   }) {
     if (input.recoveryCause === "workspace_validation_failed") return;
     if (input.recoveryCause === "configuration_incomplete") return;
+    if (input.recoveryCause === LOCAL_ADAPTER_SETUP_RECOVERY_CAUSE) return;
     if (!input.action.ownerAgentId) return;
     await deps.enqueueWakeup(input.action.ownerAgentId, {
       source: "assignment",
@@ -2877,7 +2922,8 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     const shouldPostEscalationComment =
       recoveryAction.attemptCount === 1 ||
       input.recoveryCause === "workspace_validation_failed" ||
-      input.recoveryCause === "configuration_incomplete";
+      input.recoveryCause === "configuration_incomplete" ||
+      input.recoveryCause === LOCAL_ADAPTER_SETUP_RECOVERY_CAUSE;
     if (shouldPostEscalationComment) {
       const escalationCommentMarker = `Recovery action: \`${recoveryAction.id}\``;
 
@@ -2933,6 +2979,8 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
             ? "recovery.reconcile_workspace_validation_failed"
           : input.recoveryCause === "configuration_incomplete"
             ? "recovery.reconcile_configuration_incomplete"
+          : input.recoveryCause === LOCAL_ADAPTER_SETUP_RECOVERY_CAUSE
+            ? "recovery.reconcile_local_adapter_setup_failed"
           : input.recoveryCause === "execution_review_participant_recovery"
             ? "recovery.reconcile_execution_review_participant"
           : "recovery.reconcile_stranded_assigned_issue",
@@ -3030,6 +3078,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       }
 
       const agent = await getAgent(agentId);
+      const agentAdapterType = agent?.adapterType ?? null;
       const agentInvokable = agent && agent.companyId === issue.companyId
         ? await isAgentInvokable(agent)
         : false;
@@ -3185,6 +3234,24 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
           continue;
         }
 
+        if (isLocalAdapterSetupFailureRun(participantLatestRun, agentAdapterType)) {
+          const updated = await escalateStrandedAssignedIssue({
+            issue,
+            previousStatus: "in_review",
+            latestRun: participantLatestRun,
+            comment: buildLocalAdapterSetupFailureComment(participantLatestRun),
+            recoveryCause: LOCAL_ADAPTER_SETUP_RECOVERY_CAUSE,
+            recoveryOwnerAgentId: participantAgentId,
+          });
+          if (updated) {
+            result.escalated += 1;
+            result.issueIds.push(issue.id);
+          } else {
+            result.skipped += 1;
+          }
+          continue;
+        }
+
         if (didAutomaticRecoveryFail(participantLatestRun, EXECUTION_REVIEW_PARTICIPANT_RECOVERY_REASON)) {
           const updated = await escalateStrandedAssignedIssue({
             issue,
@@ -3260,6 +3327,23 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
 
         if (latestRun.status === "succeeded") {
           result.skipped += 1;
+          continue;
+        }
+
+        if (isLocalAdapterSetupFailureRun(latestRun, agentAdapterType)) {
+          const updated = await escalateStrandedAssignedIssue({
+            issue,
+            previousStatus: "todo",
+            latestRun,
+            comment: buildLocalAdapterSetupFailureComment(latestRun),
+            recoveryCause: LOCAL_ADAPTER_SETUP_RECOVERY_CAUSE,
+          });
+          if (updated) {
+            result.escalated += 1;
+            result.issueIds.push(issue.id);
+          } else {
+            result.skipped += 1;
+          }
           continue;
         }
 
@@ -3393,7 +3477,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         continue;
       }
       if (isUnsuccessfulTerminalIssueRun(latestRun)) {
-        const classification = classifyContinuationFailure(latestRun);
+        const classification = classifyContinuationFailure(latestRun, agentAdapterType);
 
         if (classification.errorCode === CONTINUATION_WAITING_ON_REVIEW_ERROR_CODE) {
           const resolved = await resolveContinuationWaitingOnReview(issue);
@@ -3406,14 +3490,17 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
 
         if (classification.kind === "non_retryable") {
           const failureSummary = summarizeRunFailureForIssueComment(latestRun);
+          const localAdapterSetupFailure = isLocalAdapterSetupFailureRun(latestRun, agentAdapterType);
           const updated = await escalateStrandedAssignedIssue({
             issue,
             previousStatus: "in_progress",
             latestRun,
-            comment:
-              "Paperclip detected a non-retryable failure on this issue's continuation run " +
-              `(\`${classification.errorCode}\`). Skipping automatic retries and moving it to \`blocked\` ` +
-              `so it is visible for intervention.${failureSummary ?? ""}`,
+            comment: localAdapterSetupFailure
+              ? buildLocalAdapterSetupFailureComment(latestRun)
+              : "Paperclip detected a non-retryable failure on this issue's continuation run " +
+                `(\`${classification.errorCode}\`). Skipping automatic retries and moving it to \`blocked\` ` +
+                `so it is visible for intervention.${failureSummary ?? ""}`,
+            recoveryCause: localAdapterSetupFailure ? LOCAL_ADAPTER_SETUP_RECOVERY_CAUSE : undefined,
           });
           if (updated) {
             result.escalated += 1;

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -69,6 +69,7 @@ import {
   withRecoveryModelProfileHint,
 } from "./model-profile-hint.js";
 import { isAutomaticRecoverySuppressedByPauseHold } from "./pause-hold-guard.js";
+import { CLAUDE_QUOTA_BLOCK_ERROR_CODE } from "../claude-quota-guard.js";
 
 const EXECUTION_PATH_HEARTBEAT_RUN_STATUSES = ["queued", "running", "scheduled_retry"] as const;
 const UNSUCCESSFUL_HEARTBEAT_RUN_TERMINAL_STATUSES = ["interrupted", "failed", "cancelled", "timed_out"] as const;
@@ -250,6 +251,7 @@ const NON_RETRYABLE_CONTINUATION_ERROR_CODES = new Set<string>([
   "agent_not_found",
   "budget_blocked",
   "budget_exhausted",
+  CLAUDE_QUOTA_BLOCK_ERROR_CODE,
   "issue_paused",
   "issue_dependencies_blocked",
 ]);
@@ -263,6 +265,8 @@ const CONTINUATION_WAITING_ON_REVIEW_ERROR_CODE = "issue_continuation_waiting_on
 const CONTINUATION_RECOVERY_TRANSIENT_MAX_ATTEMPTS = 3;
 const CONTINUATION_RECOVERY_DEFAULT_MAX_ATTEMPTS = 1;
 const CONTINUATION_RECOVERY_TRANSIENT_BASE_BACKOFF_MS = 60_000;
+const CLAUDE_LOCAL_ADAPTER_TYPE = "claude_local";
+const CLAUDE_AUTOMATIC_RECOVERY_RETRY_BUDGET = 1;
 
 type ContinuationRetryClassification = {
   kind: "transient_infra" | "non_retryable" | "default";
@@ -842,6 +846,55 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     retryOfRunId?: string | null;
     extraContext?: Record<string, unknown>;
   }) {
+    const agent = await getAgent(input.agentId);
+    if (agent?.adapterType === CLAUDE_LOCAL_ADAPTER_TYPE) {
+      const latestQuotaEvent = await db
+        .select({ createdAt: activityLog.createdAt })
+        .from(activityLog)
+        .where(and(
+          eq(activityLog.companyId, agent.companyId),
+          eq(activityLog.action, "claude.quota_circuit_opened"),
+        ))
+        .orderBy(desc(activityLog.createdAt))
+        .limit(1)
+        .then((rows) => rows[0] ?? null);
+      const windowStart = latestQuotaEvent?.createdAt ??
+        new Date(Date.now() - 60 * 60 * 1000);
+      const priorRetries = await db
+        .select({ id: heartbeatRuns.id })
+        .from(heartbeatRuns)
+        .where(and(
+          eq(heartbeatRuns.companyId, agent.companyId),
+          eq(heartbeatRuns.agentId, input.agentId),
+          gte(heartbeatRuns.createdAt, windowStart),
+          sql`${heartbeatRuns.contextSnapshot} ->> 'issueId' = ${input.issueId}`,
+          sql`${heartbeatRuns.contextSnapshot} ->> 'retryReason' = ${input.retryReason}`,
+        ))
+        .limit(CLAUDE_AUTOMATIC_RECOVERY_RETRY_BUDGET);
+      if (priorRetries.length >= CLAUDE_AUTOMATIC_RECOVERY_RETRY_BUDGET) {
+        await logActivity(db, {
+          companyId: agent.companyId,
+          actorType: "system",
+          actorId: "claude_quota_guard",
+          agentId: input.agentId,
+          runId: input.retryOfRunId ?? null,
+          action: "claude.automatic_recovery_retry_budget_exhausted",
+          entityType: "issue",
+          entityId: input.issueId,
+          details: {
+            state: "degraded_retry_budget_exhausted",
+            adapterType: CLAUDE_LOCAL_ADAPTER_TYPE,
+            retryReason: input.retryReason,
+            source: input.source,
+            retryOfRunId: input.retryOfRunId ?? null,
+            windowStart: windowStart.toISOString(),
+            maxRetries: CLAUDE_AUTOMATIC_RECOVERY_RETRY_BUDGET,
+          },
+        });
+        return null;
+      }
+    }
+
     const queued = await deps.enqueueWakeup(input.agentId, {
       source: "automation",
       triggerDetail: "system",


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The affected subsystem is the server heartbeat/recovery control plane that queues, claims, retries, and dispatches agent runs.
> - Claude-local agents consume a local Claude Code account/session quota, so quota exhaustion is host-wide rather than company-specific.
> - Before this change, quota/session-limit signals could still allow later scheduled retries, continuation wakeups, stale recovery, or parallel Claude-local dispatch attempts.
> - This pull request adds a persisted Claude quota circuit breaker and checks it at the real server dispatch boundaries before Claude-local work can start.
> - The benefit is fail-closed behavior: after a session-limit/429 signal, Paperclip reports blocked work instead of burning more unattended Claude sessions.

## Linked Issues or Issue Description

No public GitHub issue exists for this operational incident.

Pre-submission checklist:
- I searched existing open and closed issues and did not find a duplicate public issue.
- This is against the current `master` runtime path.
- The bug originates in Paperclip control-plane dispatch/recovery behavior around the Claude Code local adapter.

What happened?
Paperclip's server heartbeat/recovery control plane could continue to promote retries, requeue continuations, or dispatch new `claude_local` runs after Claude Code returned quota/session-limit signals such as HTTP 429, `rate_limit`, or `You've hit your session limit`. Because Claude Code quota is tied to the local account/host, company-scoped or process-local safety state is insufficient.

Expected behavior
After a Claude Code quota/session-limit signal, Paperclip should fail closed across the installation/host: no new `claude_local` dispatches, no automatic retry storm, visible blocked state, and global Claude-local concurrency of 1.

Steps to reproduce
1. Configure at least one Paperclip agent with `adapterType = claude_local`.
2. Simulate a Claude-local adapter failure containing HTTP 429, `rate_limit`, or session-limit text.
3. Attempt scheduled retry promotion, continuation requeue, stale/orphan recovery, or another Claude-local wakeup from another company.
4. Before this PR, those paths could continue toward dispatch; after this PR they are skipped/blocked before adapter execution.

Paperclip version or commit
`master` at base commit `97e0752158a2e0e2ee3f0723b8d8d24b6c09bd59`, fixed on PR head `c8d5ddfff00ac1cd633404862536441278d7a48f`.

Deployment mode
Self-hosted server / local control-plane runtime using the Claude Code local adapter.

Installation method
Built from source.

Agent adapter(s) involved
Claude Code.

Database mode
Postgres-backed Paperclip server state; tests use embedded Postgres.

Access context
Agent automation plus system recovery/dispatcher paths.

Node.js version
CI default Node for this repository.

Operating system
Linux CI and local Windows verification.

Relevant logs or output
Claude-local failures can include `You've hit your session limit - resets 1:30pm (Asia/Jerusalem)`, HTTP 429, or `rate_limit`.

Relevant config
`adapterType: "claude_local"`.

## What Changed

- Added `server/src/services/claude-quota-guard.ts` with Claude quota/session classification, persisted activity-log circuit state, timezone-aware reset parsing, and a Postgres advisory-lock dispatch slot guard.
- Wired the guard into `server/src/services/heartbeat.ts` before Claude-local wakeups, scheduled retry promotion, bounded retry scheduling, and queued-run claiming.
- Recorded quota/session failures from Claude-local adapter result/catch paths so later workers see the same persisted circuit.
- Made the circuit global for all Claude-local dispatches on the installation/host, not company-scoped.
- Updated `server/src/services/recovery/service.ts` so quota-blocked continuations are non-retryable and recovery has a one-retry budget per issue/window.
- Added embedded-Postgres regression tests for session-limit classification, global cross-company blocking, retry-promotion blocking, continuation requeue blocking, global concurrency, and Asia/Jerusalem reset parsing.
- Fixed `server/src/__tests__/low-trust-red-team-routes.test.ts` cleanup to delete `heartbeat_run_events` before deleting `heartbeat_runs`.

## Verification

- `node_modules\.bin\vitest.cmd run server/src/__tests__/claude-quota-guard.test.ts` - 14 passed.
- `node_modules\.bin\vitest.cmd run server/src/__tests__/heartbeat-process-recovery.test.ts -t "uses a global Claude quota-open event as the recovery retry-budget window across companies"` - 1 passed, 73 skipped.
- `node_modules\.bin\vitest.cmd run server/src/__tests__/low-trust-red-team-routes.test.ts` - all 8 tests passed, then local Windows cleanup failed deleting the embedded Postgres temp directory with `EPERM`.
- `node_modules\.bin\tsc.cmd --noEmit -p server\tsconfig.json 2>&1 | Select-String -Pattern "claude-quota-guard|recovery\\service|heartbeat-process-recovery"` - no changed-file errors.
- GitHub Actions PR workflow was green on head `f961cf64a4c3707d1e6bd0e413cd8dce2628490d`; new follow-up head `c8d5ddfff00ac1cd633404862536441278d7a48f` is pending fresh CI after push; Storybook visual regression is skipped and `security-review` is neutral as before.

Operational safety verification:
- Paperclip was not restarted.
- No unattended Paperclip run was started.
- No Claude-local agent execution was started.
- Verification used mocked adapter boundaries and embedded Postgres only.

## Risks

- This intentionally changes Claude-local failure behavior to fail closed; operators may need to explicitly resume after ambiguous Claude-local `timed_out` / `adapter_failed` cases without a parseable reset time.
- The circuit is host/installation-global by design because Claude Code quota is tied to the local Claude account/session pool, not a Paperclip company.
- Reset-time parsing only trusts IANA timezones that `Intl.DateTimeFormat` can resolve; unknown zones leave `blockedUntil` null and require operator resume.

## Model Used

OpenAI GPT-5 / Codex coding agent in the Codex desktop app, with tool use for local code editing, tests, and GitHub Actions inspection.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I searched the GitHub PR list (open + recently closed) for similar PRs and confirmed this is not a duplicate
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is green with no unresolved P1/P2 code review threads after this cleanup
- [x] I will address all Greptile and reviewer comments before requesting merge


## Controlled Smoke Follow-Up: Claude-local setup failure fan-out

PR #9294 already guards Claude Code quota/session-limit retry storms. A controlled manual smoke on the patched branch found a separate local setup failure fan-out path: the first manual `claude_local` run failed before Claude launched with `acpx_session_init_failed` / Windows wrapper spawn `ENOENT`, but automatic continuation/recovery wake paths still created follow-on Claude-local work.

This follow-up patch treats `acpx_session_init_failed` and local wrapper spawn `ENOENT` failures as non-retryable local adapter setup failures. It suppresses continuation requeue, assignment/source-scoped recovery wake creation, missing-comment retry, scheduled retry, and stranded-recovery follow-on Claude-local runs after that setup failure.

It also adds `manualSafeRun: true` support so one controlled manual smoke run remains one run: no continuation requeue, no recovery wake, no scheduled retry promotion, and no successful-run/comment follow-up run.

Additional local verification for commit `c8d5ddfff00ac1cd633404862536441278d7a48f`:
- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/heartbeat-process-recovery.test.ts` - 77 passed, 1 skipped.
- `pnpm --filter @paperclipai/server exec vitest run src/services/recovery/service.pause-durability.test.ts` - 5 passed.
- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/claude-quota-guard.test.ts` - 15 passed.
- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/heartbeat-retry-scheduling.test.ts` - 21 passed.
- `pnpm --filter @paperclipai/server exec tsc --noEmit --pretty false` - passed.

Verification used mocked adapter boundaries and embedded Postgres only. Paperclip was not restarted, PaperclipHeartbeatCanary was not enabled, no unattended Paperclip run was started, and no Claude-local agent execution was started.

