### PR TITLE
fix(monitor): board fallback for assignee-scheduled monitors with no assignee

### DIFF
--- a/server/src/__tests__/issue-monitor-scheduler.test.ts
+++ b/server/src/__tests__/issue-monitor-scheduler.test.ts
@@ -140,6 +140,7 @@ describeEmbeddedPostgres("issue monitor scheduler", () => {
     issueStatus?: "in_progress" | "in_review";
     monitorAttemptCount?: number;
     monitor?: Record<string, unknown>;
+    unassigned?: boolean;
   }) {
     const companyId = randomUUID();
     const agentId = randomUUID();
@@ -191,7 +192,7 @@ describeEmbeddedPostgres("issue monitor scheduler", () => {
       title: "Watch external deploy",
       status: input?.issueStatus ?? "in_progress",
       priority: "medium",
-      assigneeAgentId: agentId,
+      assigneeAgentId: input?.unassigned ? null : agentId,
       issueNumber: 1,
       identifier: `${issuePrefix}-1`,
       executionPolicy: {
@@ -268,6 +269,46 @@ describeEmbeddedPostgres("issue monitor scheduler", () => {
       .where(eq(activityLog.entityId, issueId))
       .then((rows) => rows.map((row) => row.action));
     expect(activity).toContain("issue.monitor_triggered");
+  });
+
+  it("falls back to a board breadcrumb when an assignee-scheduled monitor fires with no agent assignee", async () => {
+    const { issueId, agentId } = await seedFixture({ unassigned: true, issueStatus: "in_review" });
+    const heartbeat = heartbeatService(db);
+    const tickAt = new Date("2026-04-11T12:31:00.000Z");
+
+    const result = await heartbeat.tickTimers(tickAt);
+
+    expect(result.enqueued).toBe(1);
+
+    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0]!);
+    expect(issue.monitorNextCheckAt).toBeNull();
+    expect(issue.monitorAttemptCount).toBe(1);
+    expect(issue.monitorLastTriggeredAt?.toISOString()).toBe(tickAt.toISOString());
+    expect(parseIssueExecutionState(issue.executionState)?.monitor).toMatchObject({
+      status: "triggered",
+      lastTriggeredAt: tickAt.toISOString(),
+      attemptCount: 1,
+    });
+
+    const wakeups = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.agentId, agentId));
+    expect(wakeups).toHaveLength(0);
+
+    const comments = await db
+      .select()
+      .from(issueComments)
+      .where(eq(issueComments.issueId, issueId));
+    expect(comments).toHaveLength(1);
+    expect(comments[0]!.body).toContain("no agent assignee to wake");
+
+    const activity = await db
+      .select()
+      .from(activityLog)
+      .where(eq(activityLog.entityId, issueId));
+    const triggerEvent = activity.find((row) => row.action === "issue.monitor_triggered");
+    expect(triggerEvent?.details).toMatchObject({ boardFallback: true, attemptCount: 1 });
   });
 
   it("lets the board trigger a scheduled issue monitor immediately", async () => {

--- a/server/src/__tests__/issue-monitor-scheduler.test.ts
+++ b/server/src/__tests__/issue-monitor-scheduler.test.ts
@@ -272,7 +272,7 @@ describeEmbeddedPostgres("issue monitor scheduler", () => {
   });
 
   it("falls back to a board breadcrumb when an assignee-scheduled monitor fires with no agent assignee", async () => {
-    const { issueId, agentId } = await seedFixture({ unassigned: true, issueStatus: "in_review" });
+    const { issueId } = await seedFixture({ unassigned: true, issueStatus: "in_review" });
     const heartbeat = heartbeatService(db);
     const tickAt = new Date("2026-04-11T12:31:00.000Z");
 
@@ -290,10 +290,7 @@ describeEmbeddedPostgres("issue monitor scheduler", () => {
       attemptCount: 1,
     });
 
-    const wakeups = await db
-      .select()
-      .from(agentWakeupRequests)
-      .where(eq(agentWakeupRequests.agentId, agentId));
+    const wakeups = await db.select().from(agentWakeupRequests);
     expect(wakeups).toHaveLength(0);
 
     const comments = await db

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -5384,6 +5384,23 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     ].join("\n");
   }
 
+  function issueMonitorBoardFallbackComment(input: {
+    issue: IssueMonitorDispatchRow;
+    scheduledAtIso: string;
+    nextAttemptCount: number;
+  }) {
+    const label = formatIssueIdentifierLink(input.issue.identifier, input.issue.id);
+    return [
+      `Paperclip escalated the scheduled monitor check for ${label} to the board because the issue has no agent assignee to wake.`,
+      "",
+      `- Scheduled check time: ${input.scheduledAtIso}`,
+      `- Attempt count: ${input.nextAttemptCount}`,
+      ...(input.issue.monitorNotes ? [`- Monitor notes: ${input.issue.monitorNotes}`] : []),
+      "",
+      "Next action: complete the check manually, or assign an agent and reschedule the monitor if more checks are needed.",
+    ].join("\n");
+  }
+
   async function findOpenIssueMonitorRecoveryIssue(claimed: IssueMonitorDispatchRow) {
     return db
       .select()
@@ -5486,7 +5503,10 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       return;
     }
 
-    if (input.recoveryPolicy === "escalate_to_board") {
+    // wake_owner with no agent assignee has nobody to wake; degrade to the
+    // board escalation path instead of failing the recovery.
+    const boardFallback = input.recoveryPolicy === "wake_owner" && !input.claimed.assigneeAgentId;
+    if (input.recoveryPolicy === "escalate_to_board" || boardFallback) {
       await db.insert(issueComments).values({
         companyId: input.claimed.companyId,
         issueId: input.claimed.id,
@@ -5507,7 +5527,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         action: "issue.monitor_escalated_to_board",
         entityType: "issue",
         entityId: input.claimed.id,
-        details,
+        details: boardFallback ? { ...details, boardFallback: true } : details,
       });
       return;
     }
@@ -5634,7 +5654,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       activitySource: "manual" | "scheduled";
     },
   ) {
-    if (!claimed.assigneeAgentId || !claimed.monitorNextCheckAt) {
+    if (!claimed.monitorNextCheckAt) {
       throw conflict("Issue monitor is not ready to dispatch");
     }
 
@@ -5667,6 +5687,55 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         runId: input.runId,
         activitySource: input.activitySource,
       });
+    }
+
+    if (!claimed.assigneeAgentId) {
+      // Assignee-scheduled monitor firing with no agent assignee: fall back to a
+      // board-visible breadcrumb instead of silently dead-lettering the check.
+      await db.insert(issueComments).values({
+        companyId: claimed.companyId,
+        issueId: claimed.id,
+        body: issueMonitorBoardFallbackComment({
+          issue: claimed,
+          scheduledAtIso,
+          nextAttemptCount,
+        }),
+      });
+
+      await db
+        .update(issues)
+        .set({
+          ...buildIssueMonitorTriggeredPatch({
+            issue: claimed,
+            policy,
+            triggeredAt: input.now,
+          }),
+          updatedAt: new Date(),
+        })
+        .where(eq(issues.id, claimed.id));
+
+      await logActivity(db, {
+        companyId: claimed.companyId,
+        actorType: input.actorType,
+        actorId: input.actorId,
+        agentId: input.agentId,
+        runId: input.runId,
+        action: "issue.monitor_triggered",
+        entityType: "issue",
+        entityId: claimed.id,
+        details: {
+          identifier: claimed.identifier,
+          nextCheckAt: scheduledAtIso,
+          lastTriggeredAt: input.now.toISOString(),
+          attemptCount: nextAttemptCount,
+          notes: claimed.monitorNotes ?? null,
+          ...monitorMetadata,
+          boardFallback: true,
+          source: input.activitySource,
+        },
+      });
+
+      return { outcome: "triggered" as const, boardFallback: true };
     }
 
     try {
@@ -5816,7 +5885,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     if (!issue.monitorNextCheckAt) {
       throw conflict("Issue has no scheduled monitor");
     }
-    if (!issue.assigneeAgentId || issue.assigneeUserId) {
+    if (issue.assigneeUserId) {
       throw conflict("Issue monitor requires an agent assignee");
     }
     if (!["in_progress", "in_review"].includes(issue.status)) {
@@ -5836,7 +5905,6 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             eq(issues.id, issueId),
             sql`${issues.monitorNextCheckAt} is not null`,
             isNull(issues.assigneeUserId),
-            sql`${issues.assigneeAgentId} is not null`,
             inArray(issues.status, ["in_progress", "in_review"]),
             or(
               isNull(issues.monitorWakeRequestedAt),
@@ -5878,7 +5946,6 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           sql`${issues.monitorNextCheckAt} is not null`,
           lte(issues.monitorNextCheckAt, now),
           isNull(issues.assigneeUserId),
-          sql`${issues.assigneeAgentId} is not null`,
           inArray(issues.status, ["in_progress", "in_review"]),
           or(
             isNull(issues.monitorWakeRequestedAt),
@@ -5906,7 +5973,6 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
               sql`${issues.monitorNextCheckAt} is not null`,
               lte(issues.monitorNextCheckAt, now),
               isNull(issues.assigneeUserId),
-              sql`${issues.assigneeAgentId} is not null`,
               inArray(issues.status, ["in_progress", "in_review"]),
               or(
                 isNull(issues.monitorWakeRequestedAt),

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -5886,7 +5886,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       throw conflict("Issue has no scheduled monitor");
     }
     if (issue.assigneeUserId) {
-      throw conflict("Issue monitor requires an agent assignee");
+      throw conflict("Issue monitor cannot be dispatched while the issue is assigned to a user");
     }
     if (!["in_progress", "in_review"].includes(issue.status)) {
       throw conflict("Issue monitor can only run while the issue is in progress or in review");


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The issue-monitor scheduler is how parked issues get re-checked on a schedule: at `nextCheckAt` the scheduler claims the monitor row and wakes the assignee or the board
> - Monitors with `scheduledBy: assignee` assume the issue has an agent assignee to wake; the tick query filtered on `assigneeAgentId is not null`, so a null-assignee row was never claimed
> - The scheduled check was then silently skipped — no error, no re-queue, no dead-letter — while the monitor row (`lastTriggeredAt: null`, `attemptCount: 0`) looked armed forever
> - We hit this in production: a Day-2 scheduled validation never fired and was only caught ~7 hours later by manual investigation
> - This pull request makes the scheduler claim those rows and degrade to the board wake path, posting a breadcrumb comment so the degradation is visible
> - The benefit is that no scheduled check can silently vanish: it either wakes the assignee or visibly escalates to the board, and the monitor row always records that it fired

## Linked Issues or Issue Description

No existing public issue covers this; described inline per `bug_report.yml`:

**What happened?** An issue parked `in_review` carried an active monitor with `scheduledBy: assignee` while its `assigneeAgentId` was null. When the monitor came due, `tickDueIssueMonitors` filtered the row out (`assigneeAgentId is not null` predicate), so the check never fired. There was no error, no re-queue, and no dead-letter: the monitor kept `lastTriggeredAt: null`, `attemptCount: 0` indefinitely and the validation SLA slipped invisibly. It was caught ~7 hours late, only via manual investigation.

**Expected behavior** A due monitor should never be dropped silently. If the configured wake target is missing, the scheduler should degrade to a visible path (board wake + breadcrumb comment) and still record the trigger (`lastTriggeredAt` / `attemptCount`).

**Steps to reproduce** Create an issue with an active monitor (`scheduledBy: assignee`, `nextCheckAt` due), set `assigneeAgentId` to null (e.g. park it `in_review` unassigned via a path that bypasses the PATCH monitor transition), run a scheduler tick, and observe the row is never claimed and nothing fires.

**Paperclip version or commit** `master` at the PR base commit. **Deployment mode** self-hosted local instance. **Agent adapter(s) involved** Claude Code (`claude_local`), though the gap is scheduler-side and adapter-independent.

Related (searched, not duplicates): #9115 touches monitor recovery dispatch model profiles; #8196 adds direct-write `monitorNextCheckAt`. Neither addresses the null-assignee silent skip.

## What Changed

- `tickDueIssueMonitors` and `triggerIssueMonitor` now claim null-assignee rows (user-assigned issues remain excluded, as before).
- `dispatchClaimedIssueMonitor`: when the claimed issue has no agent assignee, instead of dropping it now
  - posts a board-visible breadcrumb comment on the issue (same surface as the existing `escalate_to_board` recovery path),
  - applies the normal triggered patch — `lastTriggeredAt` bumped, `attemptCount` incremented, one-shot schedule cleared — so the monitor row shows it fired,
  - logs `issue.monitor_triggered` with `boardFallback: true` in the details (action name unchanged so existing activity consumers keep working).
- `performIssueMonitorRecovery`: `wake_owner` recovery with no assignee degrades to the `escalate_to_board` comment path (with `boardFallback: true` detail) instead of calling `enqueueWakeup(null!)`.
- Review follow-ups: the user-assignee guard message in `triggerIssueMonitor` now states the actual constraint ("cannot be dispatched while the issue is assigned to a user"), and the regression test asserts zero wakeup rows globally rather than only for the fixture agent.

Explicitly **not** included: re-queue-with-backoff / dead-letter machinery — more mechanism than this gap warrants.

### Park-time warn (considered, dropped)

We considered also warning at PATCH time when `status=in_review` is set with an active assignee-scheduled monitor and a null assignee. But `applyMonitorTransition` already clears the monitor with `clearReason: invalid_assignee` on any PATCH that evaluates the policy in that state (visible in the monitor summary), and the PATCH response has no existing warnings channel — adding one is an API-contract change, not a cheap add. The scheduler-side fallback covers rows that reach this state through paths that bypass the PATCH transition.

## Verification

- `cd server && pnpm vitest run src/__tests__/issue-monitor-scheduler.test.ts` — 7 tests pass, including the new regression test: assignee-scheduled monitor + null assignee + due tick ⇒ **no** agent wakeup rows (asserted globally), breadcrumb comment present, `attemptCount` incremented, `lastTriggeredAt` set, `boardFallback: true` activity detail.
- `issue-execution-policy` and `issue-execution-policy-routes` suites (60 tests) also pass locally against embedded Postgres.
- `tsc --noEmit` on `server` shows no errors in the changed files.

## Risks

- Low. Rows that previously sat unclaimed forever are now claimed and fire a board wake — that is the intended behavior change; user-assigned issues remain excluded exactly as before.
- The activity action name is unchanged (`issue.monitor_triggered`, new `boardFallback: true` detail only), so existing activity consumers keep working.
- One-shot schedule clearing and attempt accounting reuse the existing triggered-patch path — no new state machine.

## Model Used

- Claude (Anthropic) via the Claude Code CLI, `claude_local` adapter — extended thinking and tool use enabled. Implementation and tests authored 2026-07-05 with Claude Code's default Anthropic model (Claude 4-family, Opus-class); review follow-ups and this description by Claude Fable 5 (`claude-fable-5`).

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes (no doc surface describes monitor dispatch internals; the breadcrumb comment is self-describing)
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
