### PR TITLE
Skill Studio: Edit a copy fork flow and agent switch dialog

### DIFF
--- a/scripts/screenshot-fork-flow.mjs
+++ b/scripts/screenshot-fork-flow.mjs
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+// Screenshot the PAP-13112 "Edit a copy" fork-flow stories.
+import fs from "node:fs/promises";
+import path from "node:path";
+import { chromium } from "@playwright/test";
+
+const OUT = process.argv[2] || "screenshots/pap-13112";
+const BASE = "http://localhost:6006/iframe.html";
+await fs.mkdir(path.resolve(OUT), { recursive: true });
+
+const shots = [
+  { id: "skill-studio-editacopy--read-only-banner-cta", name: "01-readonly-banner-cta", w: 560, h: 260 },
+  { id: "skill-studio-editacopy--fork-dialog-agents-switch-on", name: "02-fork-dialog-switch-on", w: 720, h: 640 },
+  { id: "skill-studio-editacopy--fork-dialog-agents-switch-on", name: "03-fork-dialog-switch-off", w: 720, h: 640, toggleOff: true },
+  { id: "skill-studio-editacopy--fork-dialog-no-agents", name: "04-fork-dialog-no-agents", w: 720, h: 560 },
+  { id: "skill-studio-editacopy--fork-dialog-existing-copy", name: "05-fork-dialog-existing-copy", w: 720, h: 700 },
+  { id: "skill-studio-editacopy--forked-skill-header", name: "06-lineage-chip", w: 720, h: 200 },
+  { id: "skill-studio-editacopy--project-scan-source-notice", name: "07-project-scan-notice", w: 620, h: 200 },
+];
+
+const browser = await chromium.launch({
+  headless: true,
+  executablePath: process.env.CHROME_PATH || undefined,
+  args: ["--no-sandbox", "--disable-dev-shm-usage"],
+});
+try {
+  for (const shot of shots) {
+    const ctx = await browser.newContext({
+      viewport: { width: shot.w, height: shot.h },
+      deviceScaleFactor: 2,
+    });
+    const page = await ctx.newPage();
+    await page.goto(`${BASE}?id=${shot.id}&viewMode=story`, { waitUntil: "networkidle" });
+    await page.waitForTimeout(1200);
+    if (shot.toggleOff) {
+      const toggle = page.locator('button[aria-label="Switch these agents to the copy"]');
+      await toggle.click();
+      await page.waitForTimeout(400);
+    }
+    const out = path.join(OUT, `${shot.name}.png`);
+    await page.screenshot({ path: out, fullPage: false });
+    console.log(`Wrote ${out}`);
+    await ctx.close();
+  }
+} finally {
+  await browser.close();
+}

--- a/ui/src/api/companySkills.ts
+++ b/ui/src/api/companySkills.ts
@@ -12,7 +12,9 @@ import type {
   CompanySkillFileDetail,
   CompanySkillFileDeleteRequest,
   CompanySkillFileDeleteResult,
+  CompanySkillForkPrecheckResult,
   CompanySkillForkRequest,
+  CompanySkillForkResult,
   CompanySkillImportResult,
   CompanySkillInstallCatalogRequest,
   CompanySkillInstallCatalogResult,
@@ -154,9 +156,13 @@ export const companySkillsApi = {
       `/companies/${encodeURIComponent(companyId)}/skills/${encodeURIComponent(skillId)}/star`,
     ),
   fork: (companyId: string, skillId: string, payload: CompanySkillForkRequest = {}) =>
-    api.post<CompanySkill>(
+    api.post<CompanySkillForkResult>(
       `/companies/${encodeURIComponent(companyId)}/skills/${encodeURIComponent(skillId)}/fork`,
       payload,
+    ),
+  forkPrecheck: (companyId: string, skillId: string) =>
+    api.get<CompanySkillForkPrecheckResult>(
+      `/companies/${encodeURIComponent(companyId)}/skills/${encodeURIComponent(skillId)}/fork-precheck`,
     ),
   comments: (companyId: string, skillId: string) =>
     api.get<CompanySkillComment[]>(

--- a/ui/src/components/skill-studio/ForkSkillDialog.test.tsx
+++ b/ui/src/components/skill-studio/ForkSkillDialog.test.tsx
@@ -1,0 +1,304 @@
+// @vitest-environment jsdom
+
+import type { ReactNode } from "react";
+import { flushSync } from "react-dom";
+import { createRoot, type Root } from "react-dom/client";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type {
+  CompanySkillDetail,
+  CompanySkillForkPrecheckResult,
+  CompanySkillForkSummary,
+  CompanySkillUsageAgent,
+} from "@paperclipai/shared";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ForkSkillDialog } from "./ForkSkillDialog";
+
+const mockNavigate = vi.hoisted(() => vi.fn());
+const mockCompanySkillsApi = vi.hoisted(() => ({
+  fork: vi.fn(),
+  forkPrecheck: vi.fn(),
+  detail: vi.fn(),
+}));
+const mockPushToast = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/router", () => ({
+  Link: ({ children, to }: { children: ReactNode; to: string }) => <a href={to}>{children}</a>,
+  useNavigate: () => mockNavigate,
+}));
+vi.mock("@/api/companySkills", () => ({ companySkillsApi: mockCompanySkillsApi }));
+vi.mock("@/context/ToastContext", () => ({
+  useOptionalToastActions: () => ({ pushToast: mockPushToast }),
+}));
+
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let root: Root | null = null;
+let container: HTMLDivElement | null = null;
+
+// React's `act` is not usable in this vitest setup; drive updates via flushSync
+// like SkillStudio.test.tsx / AgentsUsingSkillDialog.test.tsx do.
+async function act(callback: () => void | Promise<void>) {
+  let result: void | Promise<void> = undefined;
+  flushSync(() => {
+    result = callback();
+  });
+  await result;
+}
+
+async function flush() {
+  await Promise.resolve();
+  await new Promise((resolve) => window.setTimeout(resolve, 0));
+}
+
+function teardown() {
+  if (root) flushSync(() => root?.unmount());
+  container?.remove();
+  root = null;
+  container = null;
+  document.body.innerHTML = "";
+}
+
+async function renderNode(node: ReactNode) {
+  teardown();
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  await act(async () => {
+    root?.render(<QueryClientProvider client={queryClient}>{node}</QueryClientProvider>);
+  });
+  await flush();
+}
+
+async function click(el: Element) {
+  await act(async () => {
+    el.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+  });
+  await flush();
+}
+
+function findButton(match: (text: string) => boolean): HTMLButtonElement {
+  const found = Array.from(document.body.querySelectorAll("button")).find((button) =>
+    match(button.textContent?.trim() ?? ""),
+  ) as HTMLButtonElement | undefined;
+  if (!found) throw new Error("button not found");
+  return found;
+}
+
+function makeAgent(over: Partial<CompanySkillUsageAgent> = {}): CompanySkillUsageAgent {
+  return {
+    id: "agent-1",
+    name: "Reviewer",
+    urlKey: "reviewer",
+    adapterType: "claude_local",
+    desired: true,
+    actualState: null,
+    versionId: null,
+    ...over,
+  };
+}
+
+function makeSkill(over: Partial<CompanySkillDetail> = {}): CompanySkillDetail {
+  return {
+    id: "skill-1",
+    companyId: "company-1",
+    key: "github/anthropics/skills",
+    slug: "deep-research",
+    name: "Deep Research",
+    description: null,
+    markdown: "",
+    sourceType: "github",
+    sourceLocator: "https://github.com/anthropics/skills",
+    sourceRef: "0123456789abcdef0123456789abcdef01234567",
+    trustLevel: "markdown_only",
+    compatibility: "compatible",
+    fileInventory: [],
+    iconUrl: null,
+    color: null,
+    tagline: null,
+    authorName: null,
+    homepageUrl: null,
+    categories: [],
+    sharingScope: "company",
+    publicShareToken: null,
+    forkedFromSkillId: null,
+    forkedFromCompanyId: null,
+    starCount: 0,
+    installCount: 0,
+    forkCount: 0,
+    currentVersionId: "ver-1",
+    metadata: null,
+    createdAt: new Date("2026-01-01T00:00:00Z"),
+    updatedAt: new Date("2026-01-02T00:00:00Z"),
+    attachedAgentCount: 0,
+    usedByAgents: [],
+    editable: false,
+    editableReason: "This skill comes from GitHub and is read-only.",
+    sourceLabel: "GitHub",
+    sourceBadge: "github",
+    sourcePath: null,
+    currentVersion: null,
+    starredByCurrentActor: false,
+    existingForks: [],
+    ...over,
+  };
+}
+
+function makePrecheck(over: Partial<CompanySkillForkPrecheckResult> = {}): CompanySkillForkPrecheckResult {
+  return {
+    skillId: "skill-1",
+    original: {
+      id: "skill-1",
+      name: "Deep Research",
+      slug: "deep-research",
+      sourceType: "github",
+      sourceLocator: "https://github.com/anthropics/skills",
+      sourceRef: "0123456789abcdef0123456789abcdef01234567",
+    },
+    agentUsageCount: 0,
+    usedByAgents: [],
+    existingForks: [],
+    ...over,
+  };
+}
+
+function makeForkSummary(over: Partial<CompanySkillForkSummary> = {}): CompanySkillForkSummary {
+  return {
+    id: "fork-existing",
+    name: "Deep Research (copy)",
+    slug: "deep-research-fork",
+    sourceType: "local_path",
+    sourceLocator: null,
+    sourceRef: null,
+    key: "company/deep-research-fork",
+    forkedFromSkillId: "skill-1",
+    forkedFromCompanyId: "company-1",
+    currentVersionId: "v1",
+    createdByCurrentActor: true,
+    diverged: false,
+    createdAt: new Date("2026-07-01T00:00:00Z"),
+    updatedAt: new Date("2026-07-01T00:00:00Z"),
+    ...over,
+  };
+}
+
+beforeEach(() => {
+  mockCompanySkillsApi.forkPrecheck.mockResolvedValue(makePrecheck());
+  mockCompanySkillsApi.fork.mockResolvedValue({
+    skill: { id: "fork-new" },
+    original: makePrecheck().original,
+    reassignments: [],
+  });
+  mockCompanySkillsApi.detail.mockResolvedValue(makeSkill());
+  mockNavigate.mockReset();
+  mockPushToast.mockReset();
+});
+
+afterEach(() => {
+  teardown();
+  vi.clearAllMocks();
+});
+
+describe("ForkSkillDialog", () => {
+  it("shows the agent count prominently and forks with reassignment ON by default", async () => {
+    const agents = [makeAgent({ id: "a1", name: "Reviewer" }), makeAgent({ id: "a2", name: "Planner" })];
+    mockCompanySkillsApi.forkPrecheck.mockResolvedValue(
+      makePrecheck({ agentUsageCount: 2, usedByAgents: agents }),
+    );
+    mockCompanySkillsApi.fork.mockResolvedValue({
+      skill: { id: "fork-new" },
+      original: makePrecheck().original,
+      reassignments: [
+        { agentId: "a1", previousSkillKey: "k", nextSkillKey: "kf" },
+        { agentId: "a2", previousSkillKey: "k", nextSkillKey: "kf" },
+      ],
+    });
+
+    await renderNode(
+      <ForkSkillDialog
+        companyId="company-1"
+        skill={makeSkill({ usedByAgents: agents, attachedAgentCount: 2 })}
+        open
+        onOpenChange={() => {}}
+      />,
+    );
+
+    expect(document.body.textContent).toContain("2 agents currently use this skill");
+    expect(document.body.textContent).toContain("Reviewer");
+    expect(document.body.textContent).toContain("Planner");
+
+    const confirm = findButton((t) => t.startsWith("Create copy & switch 2 agents"));
+    await click(confirm);
+
+    expect(mockCompanySkillsApi.fork).toHaveBeenCalledWith("company-1", "skill-1", {
+      reassignAgentIds: ["a1", "a2"],
+    });
+    expect(mockNavigate).toHaveBeenCalledWith("/skills/studio/fork-new");
+    expect(mockPushToast).toHaveBeenCalledWith(
+      expect.objectContaining({ tone: "success" }),
+    );
+  });
+
+  it("forks with NO reassignment when the toggle is switched off", async () => {
+    const agents = [makeAgent({ id: "a1" })];
+    mockCompanySkillsApi.forkPrecheck.mockResolvedValue(
+      makePrecheck({ agentUsageCount: 1, usedByAgents: agents }),
+    );
+
+    await renderNode(
+      <ForkSkillDialog
+        companyId="company-1"
+        skill={makeSkill({ usedByAgents: agents, attachedAgentCount: 1 })}
+        open
+        onOpenChange={() => {}}
+      />,
+    );
+
+    const toggle = document.body.querySelector<HTMLButtonElement>(
+      'button[aria-label="Switch these agents to the copy"]',
+    );
+    expect(toggle).toBeTruthy();
+    expect(toggle?.getAttribute("aria-checked")).toBe("true");
+    await click(toggle!);
+    expect(toggle?.getAttribute("aria-checked")).toBe("false");
+
+    await click(findButton((t) => t === "Create copy"));
+
+    expect(mockCompanySkillsApi.fork).toHaveBeenCalledWith("company-1", "skill-1", {
+      reassignAgentIds: [],
+    });
+  });
+
+  it("offers 'Open your existing copy' when an un-diverged same-actor fork exists", async () => {
+    mockCompanySkillsApi.forkPrecheck.mockResolvedValue(
+      makePrecheck({ existingForks: [makeForkSummary({ id: "fork-existing" })] }),
+    );
+
+    await renderNode(
+      <ForkSkillDialog
+        companyId="company-1"
+        skill={makeSkill({ existingForks: [makeForkSummary({ id: "fork-existing" })] })}
+        open
+        onOpenChange={() => {}}
+      />,
+    );
+
+    expect(document.body.textContent).toContain("You already have a copy");
+    await click(findButton((t) => t === "Open your existing copy"));
+    expect(mockNavigate).toHaveBeenCalledWith("/skills/studio/fork-existing");
+    expect(mockCompanySkillsApi.fork).not.toHaveBeenCalled();
+  });
+
+  it("hides the toggle and reports zero usage when no agents use the skill", async () => {
+    await renderNode(
+      <ForkSkillDialog companyId="company-1" skill={makeSkill()} open onOpenChange={() => {}} />,
+    );
+
+    expect(document.body.textContent).toContain("No agents currently use this skill");
+    expect(
+      document.body.querySelector('button[aria-label="Switch these agents to the copy"]'),
+    ).toBeNull();
+  });
+});

--- a/ui/src/components/skill-studio/ForkSkillDialog.tsx
+++ b/ui/src/components/skill-studio/ForkSkillDialog.tsx
@@ -1,0 +1,251 @@
+import { useEffect, useMemo, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { GitFork, Loader2, Users } from "lucide-react";
+import type {
+  CompanySkillDetail,
+  CompanySkillForkPrecheckResult,
+} from "@paperclipai/shared";
+import { useNavigate } from "@/lib/router";
+import { companySkillsApi } from "@/api/companySkills";
+import { queryKeys } from "@/lib/queryKeys";
+import { skillStudioRoute } from "@/lib/company-skill-routes";
+import { useOptionalToastActions } from "@/context/ToastContext";
+import {
+  agentUsageSentence,
+  pickReusableFork,
+  reassignTargetIds,
+} from "@/lib/skill-fork";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { ToggleSwitch } from "@/components/ui/toggle-switch";
+import { cn } from "@/lib/utils";
+
+/**
+ * "Edit a copy" confirm dialog for read-only external skills (PAP-13112,
+ * plan §3.1 / §3.2). Forks the skill through the existing fork endpoint and —
+ * critically (P3, Dotta: "important! definitely need to show this to the
+ * user") — surfaces how many agents run the original and offers a default-ON
+ * switch to move them to the copy. When an un-diverged copy by the current
+ * actor already exists, it offers to open that instead of minting another
+ * (fork-sprawl guard, §5).
+ */
+export function ForkSkillDialog({
+  companyId,
+  skill,
+  open,
+  onOpenChange,
+}: {
+  companyId: string;
+  skill: CompanySkillDetail;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const toast = useOptionalToastActions();
+  const [reassign, setReassign] = useState(true);
+
+  // Seed from the already-loaded skill detail so the dialog renders instantly,
+  // then let the dedicated precheck endpoint refresh usage/existing-fork data.
+  const seededPrecheck: CompanySkillForkPrecheckResult = useMemo(
+    () => ({
+      skillId: skill.id,
+      original: {
+        id: skill.id,
+        name: skill.name,
+        slug: skill.slug,
+        sourceType: skill.sourceType,
+        sourceLocator: skill.sourceLocator,
+        sourceRef: skill.sourceRef,
+      },
+      agentUsageCount: skill.usedByAgents.length,
+      usedByAgents: skill.usedByAgents,
+      existingForks: skill.existingForks,
+    }),
+    [skill],
+  );
+
+  const precheckQuery = useQuery({
+    queryKey: queryKeys.companySkills.forkPrecheck(companyId, skill.id),
+    queryFn: () => companySkillsApi.forkPrecheck(companyId, skill.id),
+    enabled: open && Boolean(companyId && skill.id),
+    initialData: seededPrecheck,
+  });
+
+  const precheck = precheckQuery.data ?? seededPrecheck;
+  const usedByAgents = precheck.usedByAgents;
+  const agentCount = precheck.agentUsageCount;
+  const reusableFork = useMemo(
+    () => pickReusableFork(precheck.existingForks),
+    [precheck.existingForks],
+  );
+
+  // Reset the toggle each time the dialog opens (default ON per §3.2).
+  useEffect(() => {
+    if (open) setReassign(true);
+  }, [open]);
+
+  const forkMutation = useMutation({
+    mutationFn: () =>
+      companySkillsApi.fork(companyId, skill.id, {
+        reassignAgentIds: reassign ? reassignTargetIds(usedByAgents) : [],
+      }),
+    onSuccess: (result) => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.companySkills.list(companyId) });
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.companySkills.detail(companyId, skill.id),
+      });
+      queryClient.invalidateQueries({ queryKey: queryKeys.agents.list(companyId) });
+      for (const entry of result.reassignments) {
+        queryClient.invalidateQueries({
+          queryKey: queryKeys.agents.skills(entry.agentId),
+        });
+      }
+      const switched = result.reassignments.length;
+      toast?.pushToast({
+        tone: "success",
+        title: "Editing a copy",
+        body:
+          switched > 0
+            ? `Created a copy of ${skill.name} and switched ${switched} ${switched === 1 ? "agent" : "agents"} to it.`
+            : `Created a copy of ${skill.name}. It's now editable.`,
+      });
+      onOpenChange(false);
+      navigate(skillStudioRoute(result.skill.id));
+    },
+    onError: (error) => {
+      toast?.pushToast({
+        tone: "error",
+        title: "Couldn't create a copy",
+        body: error instanceof Error ? error.message : "The fork request failed.",
+      });
+    },
+  });
+
+  const busy = forkMutation.isPending;
+  const forkLabel =
+    reassign && agentCount > 0
+      ? `Create copy & switch ${agentCount} ${agentCount === 1 ? "agent" : "agents"}`
+      : "Create copy";
+
+  const openExisting = () => {
+    if (!reusableFork) return;
+    onOpenChange(false);
+    navigate(skillStudioRoute(reusableFork.id));
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={(next) => (busy ? undefined : onOpenChange(next))}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <GitFork className="h-4 w-4" />
+            Edit a copy of {skill.name}
+          </DialogTitle>
+          <DialogDescription>
+            {skill.name} is read-only because it comes from an external source.
+            Creating a fully editable copy in your workspace leaves the original
+            untouched and still updatable.
+          </DialogDescription>
+        </DialogHeader>
+
+        {reusableFork ? (
+          <div className="rounded-md border border-primary/40 bg-primary/5 p-3 text-sm">
+            <p className="font-medium text-foreground">You already have a copy</p>
+            <p className="mt-0.5 text-muted-foreground">
+              An unedited copy of this skill already exists. Open it instead of
+              making another.
+            </p>
+            <Button
+              type="button"
+              size="sm"
+              className="mt-2"
+              onClick={openExisting}
+              disabled={busy}
+            >
+              Open your existing copy
+            </Button>
+          </div>
+        ) : null}
+
+        {/* P3 — unmissable agent-switch block (plan §3.2), not fine print. */}
+        <div
+          className={cn(
+            "rounded-md border p-3",
+            agentCount > 0 ? "border-amber-500/40 bg-amber-500/5" : "border-border bg-muted/30",
+          )}
+        >
+          <div className="flex items-center gap-2 text-sm font-medium text-foreground">
+            <Users className="h-4 w-4 shrink-0" />
+            <span>{agentUsageSentence(agentCount)}</span>
+          </div>
+
+          {agentCount > 0 ? (
+            <>
+              <div className="mt-2 flex flex-wrap gap-1.5">
+                {usedByAgents.map((agent) => (
+                  <span
+                    key={agent.id}
+                    className="inline-flex items-center rounded-full border border-border bg-background px-2 py-0.5 text-xs text-foreground"
+                  >
+                    {agent.name}
+                  </span>
+                ))}
+              </div>
+              <label className="mt-3 flex items-start justify-between gap-3">
+                <span className="text-sm">
+                  <span className="font-medium text-foreground">
+                    Switch these agents to the copy
+                  </span>
+                  <span className="mt-0.5 block text-xs text-muted-foreground">
+                    {reassign
+                      ? "These agents will run your copy instead of the original."
+                      : "These agents keep running the original — your copy won't change what they do."}
+                  </span>
+                </span>
+                <ToggleSwitch
+                  checked={reassign}
+                  onCheckedChange={setReassign}
+                  disabled={busy}
+                  aria-label="Switch these agents to the copy"
+                />
+              </label>
+            </>
+          ) : (
+            <p className="mt-1 text-xs text-muted-foreground">
+              Nothing is assigned to it, so your copy won't change any agent's
+              behaviour.
+            </p>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="ghost"
+            onClick={() => onOpenChange(false)}
+            disabled={busy}
+          >
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            variant={reusableFork ? "outline" : "default"}
+            onClick={() => forkMutation.mutate()}
+            disabled={busy}
+          >
+            {busy ? <Loader2 className="mr-1.5 h-4 w-4 animate-spin" /> : null}
+            {reusableFork ? "Create another copy" : forkLabel}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/ui/src/components/skill-studio/ForkSkillDialog.tsx
+++ b/ui/src/components/skill-studio/ForkSkillDialog.tsx
@@ -65,7 +65,7 @@ export function ForkSkillDialog({
         sourceLocator: skill.sourceLocator,
         sourceRef: skill.sourceRef,
       },
-      agentUsageCount: skill.usedByAgents.length,
+      agentUsageCount: skill.attachedAgentCount,
       usedByAgents: skill.usedByAgents,
       existingForks: skill.existingForks,
     }),

--- a/ui/src/components/skill-studio/SkillProvenance.tsx
+++ b/ui/src/components/skill-studio/SkillProvenance.tsx
@@ -1,0 +1,85 @@
+import { useQuery } from "@tanstack/react-query";
+import { FolderGit2, GitFork } from "lucide-react";
+import type { CompanySkillDetail } from "@paperclipai/shared";
+import { Link } from "@/lib/router";
+import { companySkillsApi } from "@/api/companySkills";
+import { queryKeys } from "@/lib/queryKeys";
+import { skillStudioRoute } from "@/lib/company-skill-routes";
+import { formatLineageLabel } from "@/lib/skill-fork";
+import { Button } from "@/components/ui/button";
+
+/**
+ * Lineage chip for forked skills (PAP-13112, plan §3.1): "Forked from
+ * `owner/repo` @ `<short-sha>`" linking back to the original. The fork row only
+ * carries `forkedFromSkillId`, so the original's source locator/ref are fetched
+ * on demand; if the original is gone we still link by id with a soft label.
+ */
+export function SkillLineageChip({
+  companyId,
+  forkedFromSkillId,
+}: {
+  companyId: string;
+  forkedFromSkillId: string | null;
+}) {
+  const originalQuery = useQuery({
+    queryKey: queryKeys.companySkills.detail(companyId, forkedFromSkillId ?? ""),
+    queryFn: () => companySkillsApi.detail(companyId, forkedFromSkillId!),
+    enabled: Boolean(companyId && forkedFromSkillId),
+    staleTime: 60_000,
+  });
+
+  if (!forkedFromSkillId) return null;
+
+  const original = originalQuery.data;
+  const label = original ? formatLineageLabel(original) : "the original skill";
+
+  return (
+    <Link
+      to={skillStudioRoute(forkedFromSkillId)}
+      className="inline-flex max-w-full items-center gap-1.5 rounded-full border border-border bg-muted px-2.5 py-0.5 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+      title={`Forked from ${label}`}
+    >
+      <GitFork className="h-3 w-3 shrink-0" />
+      <span className="truncate">
+        Forked from <span className="font-medium text-foreground">{label}</span>
+      </span>
+    </Link>
+  );
+}
+
+/**
+ * Persistent source notice for repo-synced (`project_scan`) skills (PAP-13112,
+ * plan §3.3). These stay editable, but their saves land as uncommitted writes
+ * in the user's project checkout — disclosed here, with a secondary path to
+ * fork instead of touching the tree. No behaviour change (§3.3, Dotta 07-08).
+ */
+export function ProjectScanNotice({
+  skill,
+  onEditACopy,
+}: {
+  skill: CompanySkillDetail;
+  onEditACopy: () => void;
+}) {
+  const location = skill.sourcePath ?? skill.sourceLabel ?? "the project working tree";
+
+  return (
+    <div className="flex flex-wrap items-start gap-2 border-b border-border bg-muted/40 px-3 py-2 text-xs text-muted-foreground">
+      <FolderGit2 className="mt-0.5 h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+      <div className="min-w-0 flex-1">
+        <span>
+          This skill lives in <span className="font-mono text-foreground">{location}</span>.
+          Saves write to the project working tree and are not committed.
+        </span>{" "}
+        <Button
+          type="button"
+          variant="link"
+          size="sm"
+          className="h-auto p-0 text-xs"
+          onClick={onEditACopy}
+        >
+          Edit a copy instead
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/ui/src/lib/queryKeys.ts
+++ b/ui/src/lib/queryKeys.ts
@@ -13,6 +13,8 @@ export const queryKeys = {
     comments: (companyId: string, skillId: string) => ["company-skills", companyId, skillId, "comments"] as const,
     updateStatus: (companyId: string, skillId: string) =>
       ["company-skills", companyId, skillId, "update-status"] as const,
+    forkPrecheck: (companyId: string, skillId: string) =>
+      ["company-skills", companyId, skillId, "fork-precheck"] as const,
     file: (companyId: string, skillId: string, relativePath: string) =>
       ["company-skills", companyId, skillId, "file", relativePath] as const,
     catalog: (filters: { kind?: string; category?: string; q?: string } = {}) =>

--- a/ui/src/lib/skill-fork.test.ts
+++ b/ui/src/lib/skill-fork.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from "vitest";
+import type {
+  CompanySkillForkSummary,
+  CompanySkillOriginalSummary,
+  CompanySkillUsageAgent,
+} from "@paperclipai/shared";
+import {
+  agentUsageSentence,
+  formatForkSourceName,
+  formatLineageLabel,
+  isProjectScanSkill,
+  pickReusableFork,
+  reassignTargetIds,
+  shortSha,
+} from "./skill-fork";
+
+function original(
+  over: Partial<CompanySkillOriginalSummary> = {},
+): CompanySkillOriginalSummary {
+  return {
+    id: "orig-1",
+    name: "Deep Research",
+    slug: "deep-research",
+    sourceType: "github",
+    sourceLocator: "https://github.com/anthropics/skills",
+    sourceRef: "0123456789abcdef0123456789abcdef01234567",
+    ...over,
+  };
+}
+
+function fork(over: Partial<CompanySkillForkSummary> = {}): CompanySkillForkSummary {
+  return {
+    ...original(),
+    id: "fork-1",
+    key: "deep-research-fork",
+    forkedFromSkillId: "orig-1",
+    forkedFromCompanyId: "co-1",
+    currentVersionId: "v1",
+    createdByCurrentActor: true,
+    diverged: false,
+    createdAt: new Date("2026-07-09T00:00:00Z"),
+    updatedAt: new Date("2026-07-09T00:00:00Z"),
+    ...over,
+  };
+}
+
+describe("shortSha", () => {
+  it("shortens a full hex sha to 7 chars", () => {
+    expect(shortSha("0123456789abcdef0123456789abcdef01234567")).toBe("0123456");
+  });
+  it("leaves branch/tag names intact", () => {
+    expect(shortSha("main")).toBe("main");
+    expect(shortSha("v1.2.0")).toBe("v1.2.0");
+  });
+  it("returns null for empty/nullish refs", () => {
+    expect(shortSha(null)).toBeNull();
+    expect(shortSha("")).toBeNull();
+    expect(shortSha("   ")).toBeNull();
+  });
+});
+
+describe("formatForkSourceName", () => {
+  it("extracts owner/repo from a github url", () => {
+    expect(
+      formatForkSourceName({ sourceType: "github", sourceLocator: "https://github.com/anthropics/skills" }),
+    ).toBe("anthropics/skills");
+  });
+  it("extracts owner/repo from github shorthand with subpath and ref", () => {
+    expect(
+      formatForkSourceName({ sourceType: "github", sourceLocator: "anthropics/skills/some/path#main" }),
+    ).toBe("anthropics/skills");
+  });
+  it("strips .git and ssh scheme", () => {
+    expect(
+      formatForkSourceName({ sourceType: "github", sourceLocator: "git@github.com:anthropics/skills.git" }),
+    ).toBe("anthropics/skills");
+  });
+  it("cleans a url source", () => {
+    expect(
+      formatForkSourceName({ sourceType: "url", sourceLocator: "https://example.com/skill/" }),
+    ).toBe("example.com/skill");
+  });
+  it("falls back to a source-type label when no locator", () => {
+    expect(formatForkSourceName({ sourceType: "skills_sh", sourceLocator: null })).toBe("skills.sh");
+    expect(formatForkSourceName({ sourceType: "catalog", sourceLocator: null })).toBe("the catalog");
+  });
+});
+
+describe("formatLineageLabel", () => {
+  it("includes short sha when a hex ref is pinned", () => {
+    expect(formatLineageLabel(original())).toBe("anthropics/skills @ 0123456");
+  });
+  it("omits the sha clause when no ref is present", () => {
+    expect(formatLineageLabel(original({ sourceRef: null }))).toBe("anthropics/skills");
+  });
+});
+
+describe("pickReusableFork", () => {
+  it("returns an un-diverged fork by the current actor", () => {
+    const reusable = fork({ id: "reuse-me" });
+    expect(pickReusableFork([reusable])?.id).toBe("reuse-me");
+  });
+  it("ignores diverged forks", () => {
+    expect(pickReusableFork([fork({ diverged: true })])).toBeNull();
+  });
+  it("ignores forks created by other actors", () => {
+    expect(pickReusableFork([fork({ createdByCurrentActor: false })])).toBeNull();
+  });
+  it("returns null with no forks", () => {
+    expect(pickReusableFork([])).toBeNull();
+  });
+});
+
+describe("agentUsageSentence", () => {
+  it("handles zero", () => {
+    expect(agentUsageSentence(0)).toBe("No agents currently use this skill");
+  });
+  it("uses singular verb agreement for one agent", () => {
+    expect(agentUsageSentence(1)).toBe("1 agent currently uses this skill");
+  });
+  it("uses plural for many", () => {
+    expect(agentUsageSentence(3)).toBe("3 agents currently use this skill");
+  });
+});
+
+describe("reassignTargetIds", () => {
+  it("maps usage agents to their ids", () => {
+    const agents: CompanySkillUsageAgent[] = [
+      { id: "a1", name: "One", urlKey: "one", adapterType: "claude", desired: true, actualState: null, versionId: null },
+      { id: "a2", name: "Two", urlKey: "two", adapterType: "codex", desired: true, actualState: null, versionId: null },
+    ];
+    expect(reassignTargetIds(agents)).toEqual(["a1", "a2"]);
+  });
+});
+
+describe("isProjectScanSkill", () => {
+  it("detects project_scan metadata", () => {
+    expect(isProjectScanSkill({ sourceKind: "project_scan" })).toBe(true);
+  });
+  it("ignores other source kinds / missing metadata", () => {
+    expect(isProjectScanSkill({ sourceKind: "managed_local" })).toBe(false);
+    expect(isProjectScanSkill(null)).toBe(false);
+    expect(isProjectScanSkill(undefined)).toBe(false);
+    expect(isProjectScanSkill({})).toBe(false);
+  });
+});

--- a/ui/src/lib/skill-fork.ts
+++ b/ui/src/lib/skill-fork.ts
@@ -1,0 +1,119 @@
+import type {
+  CompanySkillForkSummary,
+  CompanySkillOriginalSummary,
+  CompanySkillSourceType,
+  CompanySkillUsageAgent,
+} from "@paperclipai/shared";
+
+/**
+ * Pure logic for the Skill Studio "Edit a copy" fork flow (PAP-13112). Kept
+ * free of React so the dialog's decision logic — lineage labelling, existing-
+ * copy detection, agent-reassignment targeting — is unit-testable in isolation
+ * (plan §3 / §4.2 of PAP-13070).
+ */
+
+/**
+ * Shorten a git commit SHA to 7 characters for display. Branch/tag names and
+ * anything that is not a hex object id are returned unchanged so a pinned
+ * `main`/`v1.2.0` ref still reads sensibly in the lineage chip.
+ */
+export function shortSha(ref: string | null | undefined): string | null {
+  if (!ref) return null;
+  const trimmed = ref.trim();
+  if (!trimmed) return null;
+  return /^[0-9a-f]{8,40}$/i.test(trimmed) ? trimmed.slice(0, 7) : trimmed;
+}
+
+function sourceTypeFallbackLabel(sourceType: CompanySkillSourceType): string {
+  switch (sourceType) {
+    case "github":
+      return "GitHub";
+    case "skills_sh":
+      return "skills.sh";
+    case "url":
+      return "a URL";
+    case "catalog":
+      return "the catalog";
+    case "local_path":
+      return "a local path";
+    default:
+      return "its source";
+  }
+}
+
+/** Extract `owner/repo` from a GitHub URL or `owner/repo[/subpath][#ref]` shorthand. */
+function githubOwnerRepo(locator: string): string | null {
+  let value = locator
+    .replace(/^git@github\.com:/i, "")
+    .replace(/^https?:\/\/github\.com\//i, "");
+  value = value.split("#")[0].split("?")[0].replace(/\.git$/i, "");
+  const segments = value.split("/").filter(Boolean);
+  return segments.length >= 2 ? `${segments[0]}/${segments[1]}` : null;
+}
+
+function prettyUrl(locator: string): string {
+  return locator.replace(/^https?:\/\//i, "").replace(/\/+$/, "");
+}
+
+/**
+ * Human-readable source name for a fork's origin — `owner/repo` for GitHub,
+ * a cleaned host/path for URLs, otherwise the raw locator or a source-type
+ * fallback when no locator is recorded.
+ */
+export function formatForkSourceName(source: {
+  sourceType: CompanySkillSourceType;
+  sourceLocator: string | null;
+}): string {
+  const locator = source.sourceLocator?.trim() ?? "";
+  if (!locator) return sourceTypeFallbackLabel(source.sourceType);
+  if (source.sourceType === "github") return githubOwnerRepo(locator) ?? locator;
+  if (source.sourceType === "url") return prettyUrl(locator);
+  return locator;
+}
+
+/**
+ * The lineage chip label: `owner/repo @ <short-sha>` (the `@ sha` clause is
+ * dropped when the source has no pinned ref, e.g. skills.sh / URL sources).
+ */
+export function formatLineageLabel(original: CompanySkillOriginalSummary): string {
+  const name = formatForkSourceName(original);
+  const sha = shortSha(original.sourceRef);
+  return sha ? `${name} @ ${sha}` : name;
+}
+
+/**
+ * Fork-sprawl guard (plan §5): the first existing fork of this skill that the
+ * current actor created and has not yet diverged, so the dialog can offer
+ * "Open your existing copy" instead of minting `-fork-2`, `-fork-3`, … .
+ */
+export function pickReusableFork(
+  existingForks: CompanySkillForkSummary[],
+): CompanySkillForkSummary | null {
+  return (
+    existingForks.find((fork) => fork.createdByCurrentActor && !fork.diverged) ?? null
+  );
+}
+
+/** Unmissable agent-usage sentence for the dialog body (P3 hard requirement). */
+export function agentUsageSentence(count: number): string {
+  if (count <= 0) return "No agents currently use this skill";
+  return `${count} ${count === 1 ? "agent" : "agents"} currently use${count === 1 ? "s" : ""} this skill`;
+}
+
+/** Agent ids to reassign when the "Switch these agents to the copy" toggle is on. */
+export function reassignTargetIds(usedByAgents: CompanySkillUsageAgent[]): string[] {
+  return usedByAgents.map((agent) => agent.id);
+}
+
+/**
+ * Whether a skill is repo-synced (`project_scan`) — editable, but its saves
+ * write directly into the user's project working tree (plan §3.3). Detected via
+ * the skill's `metadata.sourceKind`.
+ */
+export function isProjectScanSkill(
+  metadata: Record<string, unknown> | null | undefined,
+): boolean {
+  if (!metadata || typeof metadata !== "object") return false;
+  const raw = (metadata as Record<string, unknown>).sourceKind;
+  return typeof raw === "string" && raw.trim() === "project_scan";
+}

--- a/ui/src/pages/SkillStudio.test.tsx
+++ b/ui/src/pages/SkillStudio.test.tsx
@@ -556,7 +556,7 @@ describe("SkillStudio editor frontmatter", () => {
     expect(node.querySelector("#fm-name")).toBeNull();
   });
 
-  it("links read-only skills directly to a Studio fork draft", async () => {
+  it("offers an 'Edit a copy' CTA on the read-only banner (PAP-13112)", async () => {
     mockCompanySkillsApi.detail.mockResolvedValueOnce(makeSkill({
       editable: false,
       editableReason: "Bundled skill.",
@@ -565,9 +565,16 @@ describe("SkillStudio editor frontmatter", () => {
     const node = await renderStudio();
 
     await waitFor(() => expect(node.textContent).toContain("Bundled skill."));
-    const forkLink = Array.from(node.querySelectorAll("a")).find((link) => link.textContent?.trim() === "Fork");
 
-    expect(forkLink?.getAttribute("href")).toBe("/skills/studio/new?forkFrom=source-skill");
-    expect(node.textContent).not.toContain("Fork or import locally");
+    // The dead-end "Fork" text link is replaced by a primary "Edit a copy"
+    // button that opens the fork-confirm dialog (agent-switch flow).
+    const editCopy = Array.from(node.querySelectorAll("button")).find(
+      (button) => button.textContent?.trim() === "Edit a copy",
+    );
+    expect(editCopy).toBeTruthy();
+    const staleForkLink = Array.from(node.querySelectorAll("a")).find((link) =>
+      link.getAttribute("href")?.includes("/skills/studio/new?forkFrom"),
+    );
+    expect(staleForkLink).toBeUndefined();
   });
 });

--- a/ui/src/pages/SkillStudio.tsx
+++ b/ui/src/pages/SkillStudio.tsx
@@ -67,6 +67,12 @@ import {
 } from "@/lib/skill-create";
 import { getRecentStudioSkillIds, trackRecentStudioSkill } from "@/lib/recent-skills";
 import { AgentsUsingSkillBadge } from "@/components/skill-studio/AgentsUsingSkillDialog";
+import { ForkSkillDialog } from "@/components/skill-studio/ForkSkillDialog";
+import {
+  ProjectScanNotice,
+  SkillLineageChip,
+} from "@/components/skill-studio/SkillProvenance";
+import { isProjectScanSkill } from "@/lib/skill-fork";
 import { cn, formatCents, relativeTime } from "@/lib/utils";
 import { SkillCardIcon, type DiscoveryCard } from "./CompanySkills";
 import {
@@ -921,6 +927,7 @@ function StudioShell({
   const [selectedAgentId, setSelectedAgentId] = useState<string | null>(null);
   const [skillDirty, setSkillDirty] = useState(false);
   const [versionSheetOpen, setVersionSheetOpen] = useState(false);
+  const [forkDialogOpen, setForkDialogOpen] = useState(false);
 
   const layoutRef = useRef<PaneLayout>(loadPaneLayout());
 
@@ -965,8 +972,10 @@ function StudioShell({
       companyId={companyId}
       skill={skill}
       onDirtyChange={setSkillDirty}
+      onEditACopy={() => setForkDialogOpen(true)}
     />
   );
+  const projectScan = isProjectScanSkill(skill.metadata);
   const middlePane = (
     <InputPane
       companyId={companyId}
@@ -1018,6 +1027,9 @@ function StudioShell({
           onSelectSkill={(nextSkillId) => navigate(skillStudioRoute(nextSkillId))}
           onOpenVersions={() => setVersionSheetOpen(true)}
         />
+        {projectScan ? (
+          <ProjectScanNotice skill={skill} onEditACopy={() => setForkDialogOpen(true)} />
+        ) : null}
         {isMobile ? (
           <MobileTabs skill={leftPane} input={middlePane} runs={rightPane} />
         ) : (
@@ -1062,6 +1074,12 @@ function StudioShell({
           });
         }}
         onFilterRuns={(inputId) => setSelectedInputId(inputId)}
+      />
+      <ForkSkillDialog
+        companyId={companyId}
+        skill={skill}
+        open={forkDialogOpen}
+        onOpenChange={setForkDialogOpen}
       />
     </TooltipProvider>
   );
@@ -1117,6 +1135,12 @@ function StudioHeader({
       ) : null}
       {!skill.editable ? (
         <Badge variant="secondary">Read-only</Badge>
+      ) : null}
+      {skill.forkedFromSkillId ? (
+        <SkillLineageChip
+          companyId={companyId}
+          forkedFromSkillId={skill.forkedFromSkillId}
+        />
       ) : null}
       <AgentsUsingSkillBadge companyId={companyId} skill={skill} />
       <div className="ml-auto flex items-center gap-1">
@@ -1214,10 +1238,12 @@ function SkillPane({
   companyId,
   skill,
   onDirtyChange,
+  onEditACopy,
 }: {
   companyId: string;
   skill: CompanySkillDetail;
   onDirtyChange: (dirty: boolean) => void;
+  onEditACopy: () => void;
 }) {
   const skillId = skill.id;
   const queryClient = useQueryClient();
@@ -1422,18 +1448,22 @@ function SkillPane({
           />
         </div>
         {readOnly && (
-          <div className="flex items-start gap-2 border-b border-border bg-muted/40 px-3 py-2 text-xs text-muted-foreground">
+          <div className="flex items-start gap-3 border-b border-border bg-muted/40 px-3 py-2.5 text-xs text-muted-foreground">
             <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0 text-amber-500" />
-            <div className="min-w-0">
-              <span>
-                {skill.editableReason ?? "This skill is read-only."}
-              </span>{" "}
-              <Link
-                to={skillStudioNewRoute(skill.id)}
-                className="font-medium text-foreground underline underline-offset-2 hover:text-primary"
+            <div className="min-w-0 flex-1">
+              <p>
+                {skill.editableReason ?? "This skill is read-only because it comes from an external source."}
+                {" "}Make an editable copy to change it — the original stays untouched.
+              </p>
+              <Button
+                type="button"
+                size="sm"
+                className="mt-2"
+                onClick={onEditACopy}
               >
-                Fork
-              </Link>
+                <GitFork className="mr-1.5 h-3.5 w-3.5" />
+                Edit a copy
+              </Button>
             </div>
           </div>
         )}

--- a/ui/storybook/stories/fork-skill-flow.stories.tsx
+++ b/ui/storybook/stories/fork-skill-flow.stories.tsx
@@ -1,0 +1,269 @@
+import { useState, type ReactNode } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { AlertTriangle, GitFork } from "lucide-react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import type {
+  CompanySkillDetail,
+  CompanySkillForkPrecheckResult,
+  CompanySkillForkSummary,
+  CompanySkillUsageAgent,
+} from "@paperclipai/shared";
+import { ForkSkillDialog } from "@/components/skill-studio/ForkSkillDialog";
+import {
+  ProjectScanNotice,
+  SkillLineageChip,
+} from "@/components/skill-studio/SkillProvenance";
+import { AgentsUsingSkillBadge } from "@/components/skill-studio/AgentsUsingSkillDialog";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { queryKeys } from "@/lib/queryKeys";
+
+const COMPANY_ID = "company-storybook";
+const SKILL_ID = "skill-deep-research";
+const ORIGINAL_ID = "skill-deep-research"; // external original
+const FORK_ID = "skill-deep-research-copy"; // the editable fork
+
+function usageAgent(over: Partial<CompanySkillUsageAgent>): CompanySkillUsageAgent {
+  return {
+    id: "agent-1",
+    name: "Reviewer",
+    urlKey: "reviewer",
+    adapterType: "claude_local",
+    desired: true,
+    actualState: null,
+    versionId: null,
+    ...over,
+  };
+}
+
+const USAGE_AGENTS: CompanySkillUsageAgent[] = [
+  usageAgent({ id: "agent-1", name: "Reviewer", urlKey: "reviewer" }),
+  usageAgent({ id: "agent-2", name: "Coder", urlKey: "coder", adapterType: "codex_local" }),
+  usageAgent({ id: "agent-3", name: "Planner", urlKey: "planner" }),
+];
+
+function makeSkill(over: Partial<CompanySkillDetail> = {}): CompanySkillDetail {
+  return {
+    id: SKILL_ID,
+    companyId: COMPANY_ID,
+    key: "github/anthropics/skills",
+    slug: "deep-research",
+    name: "Deep Research",
+    description: "Multi-source research with adversarial verification.",
+    markdown: "",
+    sourceType: "github",
+    sourceLocator: "https://github.com/anthropics/skills",
+    sourceRef: "0123456789abcdef0123456789abcdef01234567",
+    trustLevel: "markdown_only",
+    compatibility: "compatible",
+    fileInventory: [],
+    iconUrl: null,
+    color: null,
+    tagline: null,
+    authorName: null,
+    homepageUrl: null,
+    categories: [],
+    sharingScope: "company",
+    publicShareToken: null,
+    forkedFromSkillId: null,
+    forkedFromCompanyId: null,
+    starCount: 0,
+    installCount: 0,
+    forkCount: 0,
+    currentVersionId: null,
+    metadata: null,
+    createdAt: new Date("2026-01-01T00:00:00Z"),
+    updatedAt: new Date("2026-01-02T00:00:00Z"),
+    attachedAgentCount: USAGE_AGENTS.length,
+    usedByAgents: USAGE_AGENTS,
+    editable: false,
+    editableReason: "This skill comes from GitHub and is read-only.",
+    sourceLabel: "GitHub",
+    sourceBadge: "github",
+    sourcePath: null,
+    currentVersion: null,
+    starredByCurrentActor: false,
+    existingForks: [],
+    ...over,
+  };
+}
+
+function makePrecheck(
+  over: Partial<CompanySkillForkPrecheckResult> = {},
+): CompanySkillForkPrecheckResult {
+  return {
+    skillId: SKILL_ID,
+    original: {
+      id: ORIGINAL_ID,
+      name: "Deep Research",
+      slug: "deep-research",
+      sourceType: "github",
+      sourceLocator: "https://github.com/anthropics/skills",
+      sourceRef: "0123456789abcdef0123456789abcdef01234567",
+    },
+    agentUsageCount: USAGE_AGENTS.length,
+    usedByAgents: USAGE_AGENTS,
+    existingForks: [],
+    ...over,
+  };
+}
+
+function makeForkSummary(over: Partial<CompanySkillForkSummary> = {}): CompanySkillForkSummary {
+  return {
+    id: "fork-existing",
+    name: "Deep Research (copy)",
+    slug: "deep-research-fork",
+    sourceType: "local_path",
+    sourceLocator: null,
+    sourceRef: null,
+    key: "company/deep-research-fork",
+    forkedFromSkillId: ORIGINAL_ID,
+    forkedFromCompanyId: COMPANY_ID,
+    currentVersionId: "v1",
+    createdByCurrentActor: true,
+    diverged: false,
+    createdAt: new Date("2026-07-01T00:00:00Z"),
+    updatedAt: new Date("2026-07-01T00:00:00Z"),
+    ...over,
+  };
+}
+
+/** Prime react-query so the dialog's precheck + lineage lookups resolve offline. */
+function Seed({
+  skill,
+  precheck,
+  children,
+}: {
+  skill: CompanySkillDetail;
+  precheck?: CompanySkillForkPrecheckResult;
+  children: ReactNode;
+}) {
+  const queryClient = useQueryClient();
+  queryClient.setQueryData(
+    queryKeys.companySkills.forkPrecheck(COMPANY_ID, skill.id),
+    precheck ?? makePrecheck(),
+  );
+  // Original detail for the lineage chip on forked skills.
+  queryClient.setQueryData(
+    queryKeys.companySkills.detail(COMPANY_ID, ORIGINAL_ID),
+    makeSkill(),
+  );
+  return <>{children}</>;
+}
+
+const meta: Meta = {
+  title: "Skill Studio/EditACopy",
+  parameters: { layout: "centered" },
+};
+export default meta;
+
+type Story = StoryObj;
+
+/** The read-only external-skill banner with the primary "Edit a copy" CTA. */
+export const ReadOnlyBannerCTA: Story = {
+  render: () => (
+    <div className="w-[30rem] max-w-full overflow-hidden rounded-md border border-border bg-card">
+      <div className="flex items-start gap-3 border-b border-border bg-muted/40 px-3 py-2.5 text-xs text-muted-foreground">
+        <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0 text-amber-500" />
+        <div className="min-w-0 flex-1">
+          <p>
+            This skill comes from GitHub and is read-only. Make an editable copy
+            to change it — the original stays untouched.
+          </p>
+          <Button type="button" size="sm" className="mt-2">
+            <GitFork className="mr-1.5 h-3.5 w-3.5" />
+            Edit a copy
+          </Button>
+        </div>
+      </div>
+      <div className="px-3 py-1.5 font-mono text-xs text-muted-foreground">SKILL.md</div>
+    </div>
+  ),
+};
+
+/** Confirm dialog: three agents use the skill, switch toggle default ON (§3.2). */
+export const ForkDialogAgentsSwitchOn: Story = {
+  render: () => {
+    const skill = makeSkill();
+    return (
+      <Seed skill={skill}>
+        <ForkSkillDialog companyId={COMPANY_ID} skill={skill} open onOpenChange={() => {}} />
+      </Seed>
+    );
+  },
+};
+
+/** Same dialog with no agents assigned — toggle hidden, zero-usage disclosure. */
+export const ForkDialogNoAgents: Story = {
+  render: () => {
+    const skill = makeSkill({ usedByAgents: [], attachedAgentCount: 0 });
+    return (
+      <Seed skill={skill} precheck={makePrecheck({ agentUsageCount: 0, usedByAgents: [] })}>
+        <ForkSkillDialog companyId={COMPANY_ID} skill={skill} open onOpenChange={() => {}} />
+      </Seed>
+    );
+  },
+};
+
+/** Fork-sprawl guard: an un-diverged copy already exists (§5). */
+export const ForkDialogExistingCopy: Story = {
+  render: () => {
+    const existing = [makeForkSummary()];
+    const skill = makeSkill({ existingForks: existing });
+    return (
+      <Seed skill={skill} precheck={makePrecheck({ existingForks: existing })}>
+        <ForkSkillDialog companyId={COMPANY_ID} skill={skill} open onOpenChange={() => {}} />
+      </Seed>
+    );
+  },
+};
+
+/** Studio header row of a forked skill, showing the lineage chip. */
+export const ForkedSkillHeader: Story = {
+  render: () => {
+    const fork = makeSkill({
+      id: FORK_ID,
+      name: "Deep Research (copy)",
+      slug: "deep-research-fork",
+      sourceType: "local_path",
+      sourceLocator: null,
+      sourceRef: null,
+      editable: true,
+      editableReason: null,
+      forkedFromSkillId: ORIGINAL_ID,
+      usedByAgents: [],
+      attachedAgentCount: 0,
+    });
+    return (
+      <Seed skill={fork}>
+        <div className="flex items-center gap-3 rounded-md border border-border bg-card px-3 py-2">
+          <span className="text-base font-semibold">Deep Research (copy)</span>
+          <Badge variant="secondary">Unsaved edits</Badge>
+          <SkillLineageChip companyId={COMPANY_ID} forkedFromSkillId={ORIGINAL_ID} />
+          <AgentsUsingSkillBadge companyId={COMPANY_ID} skill={fork} />
+        </div>
+      </Seed>
+    );
+  },
+};
+
+/** Repo-synced (project_scan) source notice with the "Edit a copy instead" path (§3.3). */
+export const ProjectScanSourceNotice: Story = {
+  render: () => {
+    const skill = makeSkill({
+      name: "Repo Linter",
+      sourceType: "local_path",
+      sourceBadge: "local",
+      metadata: { sourceKind: "project_scan" },
+      sourcePath: "acme-app/.claude/skills/repo-linter",
+      sourceLabel: "acme-app",
+      editable: true,
+      editableReason: null,
+    });
+    return (
+      <div className="w-[30rem] max-w-full overflow-hidden rounded-md border border-border bg-card">
+        <ProjectScanNotice skill={skill} onEditACopy={() => {}} />
+      </div>
+    );
+  },
+};


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Skill Studio is the operator surface for reading, testing, and editing company skills.
> - Some skills are discovered from project files, so direct edits can change the project working tree.
> - Operators still need a safe way to customize those skills for their company without losing lineage to the source.
> - The existing read-only banner had a dead-end fork affordance and did not explain how agent assignments would move.
> - This pull request turns that path into an explicit "Edit a copy" flow with agent-impact confirmation, fork lineage, and repo-sync disclosure.
> - The benefit is a safer customization workflow that makes reassignment intent visible before any agents are moved.

## Linked Issues or Issue Description

No public GitHub issue covers this full Skill Studio fork-flow slice, so the issue is described inline.

### Problem or motivation

Project-discovered skills can be useful starting points, but editing them directly can unexpectedly write back to the project workspace. The UI also needs to show operators when agents currently depend on the skill before creating a company-owned copy.

### Proposed solution

Add a confirm-before-fork flow that opens from the read-only external-skill banner, shows agent usage, defaults to switching affected agents to the copied skill, and preserves lineage and source notices after the fork.

### Alternatives considered

Keeping the old fork link was not enough because it did not explain assignment impact. Making every external skill editable in place was rejected because it hides project working-tree side effects.

### Roadmap alignment

This fits the Skill Studio direction of giving operators an inspectable, testable, and governed way to manage reusable company skills.

Related PRs: Refs #9241.

## What Changed

- Replaced the read-only external-skill "Fork" link with an "Edit a copy" call to action.
- Added `ForkSkillDialog`, including agent usage copy, a default-on reassignment toggle, existing-copy reuse handling, post-fork navigation, and success toast copy.
- Added Skill Studio provenance UI for fork lineage and project-scan source notices.
- Added pure fork-flow helpers and query/API wiring for fork precheck and fork responses.
- Added Storybook states and focused tests for the dialog, helpers, and Skill Studio banner behavior.
- Updated the fork dialog seed to use the canonical attached-agent count before the live precheck resolves.

## Verification

- `pnpm exec vitest run --project @paperclipai/ui ui/src/components/skill-studio/ForkSkillDialog.test.tsx` passed locally with 4 tests.
- Existing branch verification includes the skill-fork helper tests, Skill Studio banner assertion, and Storybook fork-flow states.
- Duplicate PR search checked GitHub for similar open PRs and found only this active PR.

## Risks

- Low migration risk: this is UI/API-client behavior over the existing fork endpoints and does not add a database migration.
- The main behavioral risk is accidentally switching agents to a copied skill; the dialog makes that explicit and keeps the toggle visible before submission.
- The seeded count now uses the canonical attached-agent total, while the live precheck still refreshes the full usage state before submit.

## Model Used

OpenAI GPT-5 Codex coding agent assisted with the latest gate-fix pass using shell, git, GitHub CLI, and local test execution. The original implementation also noted Claude Code assistance in the previous PR description; exact original Claude model metadata was not available in the PR body.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [ ] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
