### PR TITLE
feat(ui): show project name as a clickable breadcrumb on issue detail

### DIFF
--- a/ui/src/lib/issueDetailBreadcrumb.test.ts
+++ b/ui/src/lib/issueDetailBreadcrumb.test.ts
@@ -4,6 +4,7 @@ import {
   createIssueDetailLocationState,
   createIssueDetailPath,
   hasLegacyIssueDetailQuery,
+  issueProjectBreadcrumb,
   readIssueDetailHeaderSeed,
   readIssueDetailLocationState,
   readIssueDetailBreadcrumb,
@@ -207,6 +208,26 @@ describe("issueDetailBreadcrumb", () => {
       projectName: "Paperclip App",
       originKind: "manual",
       originId: null,
+    });
+  });
+
+  it("omits the project crumb when the issue has no resolvable project", () => {
+    expect(issueProjectBreadcrumb(null)).toBeNull();
+    expect(issueProjectBreadcrumb(undefined)).toBeNull();
+  });
+
+  it("builds a project crumb from the project's short URL key when available", () => {
+    expect(
+      issueProjectBreadcrumb({ id: "project-1", name: "Paperclip App", urlKey: "paperclip-app" }),
+    ).toEqual({ label: "Paperclip App", href: "/projects/paperclip-app" });
+  });
+
+  it("derives the crumb href from the project name when there is no URL key", () => {
+    expect(
+      issueProjectBreadcrumb({ id: "11111111-1111-4111-8111-111111111111", name: "Paperclip App", urlKey: null }),
+    ).toEqual({
+      label: "Paperclip App",
+      href: "/projects/paperclip-app",
     });
   });
 

--- a/ui/src/lib/issueDetailBreadcrumb.ts
+++ b/ui/src/lib/issueDetailBreadcrumb.ts
@@ -1,4 +1,5 @@
 import type { Issue } from "@paperclipai/shared";
+import { projectUrl } from "./utils";
 
 type IssueDetailSource = "issues" | "inbox";
 
@@ -143,6 +144,13 @@ function inferIssueDetailSource(
 function breadcrumbForSource(source: IssueDetailSource): IssueDetailBreadcrumb {
   if (source === "inbox") return { label: "Inbox", href: "/inbox" };
   return { label: "Tasks", href: "/issues" };
+}
+
+export function issueProjectBreadcrumb(
+  project: { id: string; name: string; urlKey?: string | null } | null | undefined,
+): IssueDetailBreadcrumb | null {
+  if (!project) return null;
+  return { label: project.name, href: projectUrl(project) };
 }
 
 export function createIssueDetailLocationState(

--- a/ui/src/pages/IssueDetail.tsx
+++ b/ui/src/pages/IssueDetail.tsx
@@ -33,6 +33,7 @@ import { collectLiveIssueIds } from "../lib/liveIssueIds";
 import {
   hasLegacyIssueDetailQuery,
   createIssueDetailPath,
+  issueProjectBreadcrumb,
   readIssueDetailLocationState,
   readIssueDetailBreadcrumb,
   readIssueDetailHeaderSeed,
@@ -74,7 +75,7 @@ import {
 } from "../lib/optimistic-issue-comments";
 import { clearIssueExecutionRun, removeLiveRunById, upsertInterruptedRun } from "../lib/optimistic-issue-runs";
 import { useProjectOrder } from "../hooks/useProjectOrder";
-import { relativeTime, cn, formatDurationMs, formatTokens, projectUrl, visibleRunCostUsd } from "../lib/utils";
+import { relativeTime, cn, formatDurationMs, formatTokens, visibleRunCostUsd } from "../lib/utils";
 import { liveBlueBadge } from "../lib/status-colors";
 import { ApprovalCard } from "../components/ApprovalCard";
 import { InlineEditor } from "../components/InlineEditor";
@@ -3098,8 +3099,9 @@ export function IssueDetail() {
 
   useEffect(() => {
     const crumbs: Breadcrumb[] = [sourceBreadcrumb];
-    if (resolvedProject) {
-      crumbs.push({ label: resolvedProject.name, href: projectUrl(resolvedProject) });
+    const projectCrumb = issueProjectBreadcrumb(resolvedProject);
+    if (projectCrumb) {
+      crumbs.push(projectCrumb);
     }
     crumbs.push({
       // The status glyph (leading) already conveys in-progress/live state;

--- a/ui/src/pages/IssueDetail.tsx
+++ b/ui/src/pages/IssueDetail.tsx
@@ -23,7 +23,7 @@ import { useDialogActions } from "../context/DialogContext";
 import { usePanel } from "../context/PanelContext";
 import { useSidebar } from "../context/SidebarContext";
 import { useToastActions } from "../context/ToastContext";
-import { useBreadcrumbs } from "../context/BreadcrumbContext";
+import { useBreadcrumbs, type Breadcrumb } from "../context/BreadcrumbContext";
 import { assigneeValueFromSelection, formatAssigneeUserLabel, formatUserLabel, suggestedCommentAssigneeValue } from "../lib/assignees";
 import { buildCompanyUserInlineOptions, buildCompanyUserLabelMap, buildCompanyUserProfileMap, buildMarkdownMentionOptions, isAgentTaskTarget } from "../lib/company-members";
 import { extractIssueTimelineEvents } from "../lib/issue-timeline-events";
@@ -74,7 +74,7 @@ import {
 } from "../lib/optimistic-issue-comments";
 import { clearIssueExecutionRun, removeLiveRunById, upsertInterruptedRun } from "../lib/optimistic-issue-runs";
 import { useProjectOrder } from "../hooks/useProjectOrder";
-import { relativeTime, cn, formatDurationMs, formatTokens, visibleRunCostUsd } from "../lib/utils";
+import { relativeTime, cn, formatDurationMs, formatTokens, projectUrl, visibleRunCostUsd } from "../lib/utils";
 import { liveBlueBadge } from "../lib/status-colors";
 import { ApprovalCard } from "../components/ApprovalCard";
 import { InlineEditor } from "../components/InlineEditor";
@@ -3097,19 +3097,22 @@ export function IssueDetail() {
   });
 
   useEffect(() => {
-    setBreadcrumbs([
-      sourceBreadcrumb,
-      {
-        // The status glyph (leading) already conveys in-progress/live state;
-        // no redundant 🔵 emoji prefix on the title.
-        label: breadcrumbTitle,
-        leading: breadcrumbStatusLeading,
-        leadingKey: breadcrumbStatusKey,
-      },
-    ]);
+    const crumbs: Breadcrumb[] = [sourceBreadcrumb];
+    if (resolvedProject) {
+      crumbs.push({ label: resolvedProject.name, href: projectUrl(resolvedProject) });
+    }
+    crumbs.push({
+      // The status glyph (leading) already conveys in-progress/live state;
+      // no redundant 🔵 emoji prefix on the title.
+      label: breadcrumbTitle,
+      leading: breadcrumbStatusLeading,
+      leadingKey: breadcrumbStatusKey,
+    });
+    setBreadcrumbs(crumbs);
   }, [
     breadcrumbTitle,
     hasLiveRuns,
+    resolvedProject,
     setBreadcrumbs,
     sourceBreadcrumb.href,
     sourceBreadcrumb.label,


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The issue detail page is the primary surface where users read and act on a single task, and the header breadcrumb is its main orientation/navigation affordance
> - Today the breadcrumb only shows the source view (e.g. Inbox) and the issue title — the project the issue belongs to is invisible until you scan the properties rail, and there is no one-click path from an issue to its project
> - Users who triage across several projects lose context on which project an issue belongs to, and navigating to the project takes multiple clicks
> - This pull request inserts a clickable project-name crumb between the source crumb and the issue title, using the existing `projectUrl` helper so short URL keys are respected
> - The benefit is faster orientation and one-click navigation from any issue to its project, with no behavior change for issues that have no resolvable project

## Linked Issues or Issue Description

Originally part of #5467, which bundled several unrelated changes and was closed as superseded; this resubmits the breadcrumb change as its own focused PR (Refs #5467).

**Feature description (no standalone issue):** On the issue detail page the breadcrumb reads `Inbox › <issue title>`. The project an issue belongs to is not shown in the breadcrumb and there is no direct link to it. Expected: `Inbox › <project name> › <issue title>` with the project crumb linking to the project page.

## What Changed

- `ui/src/lib/issueDetailBreadcrumb.ts`: new `issueProjectBreadcrumb` helper that returns `{ label, href }` for a resolvable project (href via the existing `projectUrl`, which respects short URL keys with a derived-slug/UUID fallback) or `null` when the issue has no project
- `ui/src/pages/IssueDetail.tsx`: the breadcrumb effect now builds the crumb list dynamically and inserts the project crumb between the source crumb and the issue-title crumb when `issueProjectBreadcrumb(resolvedProject)` is non-null; added `resolvedProject` to the effect dependency list
- `ui/src/lib/issueDetailBreadcrumb.test.ts`: unit tests for the helper — crumb omitted without a project, short-URL-key hrefs, and the derived-slug fallback when `urlKey` is absent

## Screenshots

Before (issue detail, no project crumb — also exactly how issues **without** a resolvable project render after this change, since the crumb is conditionally omitted):

![Breadcrumb before: Tasks > issue title](https://raw.githubusercontent.com/lacymorrow/paperclip/6fdccb48d2d7bc832171084e51f6962650fde939/breadcrumb-before-full.png)

After (issue that belongs to a project — clickable project crumb between source and title):

![Breadcrumb after: Tasks > Website Redesign > issue title](https://raw.githubusercontent.com/lacymorrow/paperclip/6fdccb48d2d7bc832171084e51f6962650fde939/breadcrumb-after-full.png)

## Verification

- `pnpm vitest run src/lib/issueDetailBreadcrumb.test.ts` — 12 passed (includes the 3 new `issueProjectBreadcrumb` tests)
- `pnpm exec tsc --noEmit` in `ui/` passes
- Manual: open any issue that belongs to a project — the breadcrumb shows `<source> › <project name> › <issue title>`; clicking the project crumb navigates to the project; issues without a resolvable project render exactly as before (see screenshots)

## Risks

- Low risk. UI-only, additive; when `resolvedProject` is null the crumb list is identical to the previous behavior. The status glyph on the title crumb is preserved unchanged.

## Model Used

Claude Fable 5 (`claude-fable-5`, Anthropic) — agentic coding via Claude Code with tool use.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable (unit tests for the new `issueProjectBreadcrumb` helper in `issueDetailBreadcrumb.test.ts`)
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups (screenshots + tests added; re-review complete at 5/5)
- [x] I will address all Greptile and reviewer comments before requesting merge

