### PR TITLE
test: lock in fenced code block rendering under soft breaks + normalizer fast path

### DIFF
--- a/packages/shared/src/validators/issue.test.ts
+++ b/packages/shared/src/validators/issue.test.ts
@@ -223,6 +223,22 @@ describe("issue validators", () => {
     expect(document.body).toBe("# Plan\n\nShip it");
   });
 
+  it("normalizes escaped fenced code blocks in comment bodies", () => {
+    const parsed = addIssueCommentSchema.parse({
+      body: "Found the bug:\\n\\n```ts\\nconst x = await db.query();\\n```\\n\\nFixed.",
+    });
+
+    expect(parsed.body).toBe("Found the bug:\n\n```ts\nconst x = await db.query();\n```\n\nFixed.");
+  });
+
+  it("preserves fenced code blocks with real line breaks", () => {
+    const parsed = addIssueCommentSchema.parse({
+      body: "Here is code:\n\n```js\nconst x = 1;\nconst y = 2;\n```\n\nDone.",
+    });
+
+    expect(parsed.body).toBe("Here is code:\n\n```js\nconst x = 1;\nconst y = 2;\n```\n\nDone.");
+  });
+
   it("clamps oversized requestDepth values on create", () => {
     const parsed = createIssueSchema.parse({
       title: "Clamp request depth",

--- a/packages/shared/src/validators/text.ts
+++ b/packages/shared/src/validators/text.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
 export function normalizeEscapedLineBreaks(value: string): string {
+  if (!value.includes("\\n") && !value.includes("\\r")) return value;
   return value
     .replace(/\\r\\n/g, "\n")
     .replace(/\\n/g, "\n")

--- a/ui/src/components/MarkdownBody.test.tsx
+++ b/ui/src/components/MarkdownBody.test.tsx
@@ -478,6 +478,50 @@ describe("MarkdownBody", () => {
     expect(html).toContain('style="max-width:100%;overflow-x:auto"');
   });
 
+  it("renders multi-line fenced code blocks with softBreaks enabled", () => {
+    const html = renderMarkdown("```js\nconst x = 1;\nconst y = 2;\nconst z = x + y;\n```");
+
+    expect(html).toContain("<pre");
+    expect(html).toContain("<code");
+    expect(html).toContain("const x = 1;\nconst y = 2;\nconst z = x + y;\n");
+    expect(html).not.toContain("<br/>");
+  });
+
+  it("renders fenced code blocks preceded by text without a blank line", () => {
+    const html = renderMarkdown("Here is the fix:\n```ts\nawait db.query();\n```");
+
+    expect(html).toContain("<p");
+    expect(html).toContain("Here is the fix:");
+    expect(html).toContain("<pre");
+    expect(html).toContain("await db.query();");
+  });
+
+  it("renders fenced code blocks without a language tag", () => {
+    const html = renderMarkdown("```\nplain preformatted text\nline two\n```");
+
+    expect(html).toContain("<pre");
+    expect(html).toContain("<code");
+    expect(html).toContain("plain preformatted text\nline two\n");
+    expect(html).not.toContain("<br/>");
+  });
+
+  it("preserves content between text paragraphs and fenced code blocks", () => {
+    const html = renderMarkdown("Before code\n\n```python\nprint('hello')\n```\n\nAfter code");
+
+    expect(html).toContain("Before code");
+    expect(html).toContain("print(&#x27;hello&#x27;)");
+    expect(html).toContain("After code");
+    expect(html).toContain("<pre");
+  });
+
+  it("does not inject break tags inside fenced code block content", () => {
+    const html = renderMarkdown("Comment text\n\n```\nline 1\nline 2\nline 3\n```");
+
+    const preMatch = html.match(/<pre[^>]*>[\s\S]*?<\/pre>/);
+    expect(preMatch).not.toBeNull();
+    expect(preMatch![0]).not.toContain("<br");
+  });
+
   it("renders a copy button alongside fenced code blocks", () => {
     const html = renderMarkdown("```ts\nconst a = 1;\n```");
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Agents and users communicate through issue comments rendered as markdown; the UI applies a custom remark soft-break transform, and the API normalizes escaped `\n` sequences that agents sometimes emit in JSON payloads
> - Fenced code blocks pass through both layers, and a regression in either one would corrupt code snippets in every agent comment — historically this area broke and was fixed, but nothing locks the behavior in
> - An earlier attempt (#5467) guarded the soft-break transform with a `SKIP_NODE_TYPES` set; Greptile correctly flagged the guard as unreachable, since `code`/`inlineCode`/`html` are leaf nodes without `children` and `isParentNode` already rejects them
> - This pull request resubmits only the parts that carry value: regression tests that pin fenced-code-block behavior across both layers, and a fast-path early return in `normalizeEscapedLineBreaks` — the dead guard is dropped, resolving the open Greptile P2 from #5467
> - The benefit is that any future change to the soft-break transform or the line-break normalizer that corrupts code blocks fails CI immediately, and the normalizer no longer runs three regex replaces over bodies with nothing to normalize

## Linked Issues or Issue Description

Refs #5467 (closed as superseded — it bundled unrelated changes and went stale). This is the focused resubmission of its markdown/code-block portion, with the unreachable `SKIP_NODE_TYPES` guard flagged by Greptile removed instead of carried forward.

**Bug/coverage description (no standalone issue):** Fenced code blocks in issue comments flow through `normalizeEscapedLineBreaks` (API) and `remarkSoftBreaks` (UI). Both currently handle them correctly, but no test asserts it, so a regression (e.g. a soft-break transform that descends into `code` values, or a normalizer change that mangles fences) would ship silently.

## What Changed

- `ui/src/components/MarkdownBody.test.tsx`: 5 regression tests — multi-line fenced blocks render as `<pre><code>` with no injected `<br/>`, fences directly after text, fences without a language tag, content preserved around fences, and no break tags inside `<pre>`
- `packages/shared/src/validators/issue.test.ts`: 2 tests — comment bodies with escaped (`\\n`) fenced blocks normalize correctly, and bodies with real newlines pass through untouched
- `packages/shared/src/validators/text.ts`: early return in `normalizeEscapedLineBreaks` when the value contains no `\\n`/`\\r` sequences, skipping three regex passes in the common case
- `ui/src/lib/remark-soft-breaks.ts`: intentionally **not** changed — the previously proposed `SKIP_NODE_TYPES` guard was unreachable (all listed types are leaf nodes, `isParentNode` already returns false), so it is dropped; the new tests prove the transform is already safe for code blocks

## Verification

- `npx vitest run src/validators/issue.test.ts` in `packages/shared` — 27 passed
- `npx vitest run src/components/MarkdownBody.test.tsx` in `ui` — 47 passed

## Risks

- Low risk. Test-only plus a behavior-preserving early return (`value.includes` guard exactly matches the case where all three regexes are no-ops).

## Model Used

Claude Fable 5 (`claude-fable-5`, Anthropic) — agentic coding via Claude Code with tool use.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green (pending CI on this PR)
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups (pending review)
- [x] I will address all Greptile and reviewer comments before requesting merge
