### PR TITLE
fix(heartbeat): reap stuck non-terminal runs and clear stale locks during suppression

### DIFF
--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -624,7 +624,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       .where(eq(heartbeatRuns.id, runId));
 
     const result = await reaperHeartbeat.reapOrphanedRuns({ staleThresholdMs: 1 });
-    expect(result).toEqual({ reaped: 0, runIds: [] });
+    expect(result).toEqual({ reaped: 0, runIds: [], stuckFinalized: 0, stuckRunIds: [] });
 
     const activeRun = await reaperHeartbeat.getRun(runId);
     expect(activeRun?.status).toBe("running");

--- a/server/src/__tests__/recovery-stale-issue-lock-sweep.test.ts
+++ b/server/src/__tests__/recovery-stale-issue-lock-sweep.test.ts
@@ -6,6 +6,7 @@ import {
   agents,
   companies,
   createDb,
+  heartbeatRunEvents,
   heartbeatRuns,
   issueComments,
   issueRelations,
@@ -46,6 +47,7 @@ describeEmbeddedPostgres("recovery sweepStaleIssueLocks", () => {
     await db.delete(issueRelations);
     await db.delete(activityLog);
     await db.delete(issues);
+    await db.delete(heartbeatRunEvents);
     await db.delete(heartbeatRuns);
     await db.delete(agents);
     await db.delete(companies);
@@ -222,5 +224,273 @@ describeEmbeddedPostgres("recovery sweepStaleIssueLocks", () => {
     const second = await heartbeat.sweepStaleIssueLocks();
     expect(first.cleared).toBe(1);
     expect(second.cleared).toBe(0);
+  });
+
+  // Runs stuck in a non-terminal state (queued / scheduled_retry) whose process is
+  // dead never become terminal on their own, so sweepStaleIssueLocks (which only
+  // clears terminal-referenced locks) can never release their execution lock.
+  // reapOrphanedRuns must finalize them ("finalize-then-sweep") so the sweep can
+  // then clear the lock. These stuck runs are exactly the orphans observed in the
+  // wild at status=scheduled_retry, process_pid=NULL.
+  async function seedCompanyAgent() {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Coder",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    return { companyId, agentId };
+  }
+
+  const HOUR_MS = 60 * 60 * 1000;
+
+  it("finalizes a stuck scheduled_retry run with a dead process past threshold, then the sweep clears the lock with an audit event", async () => {
+    const { companyId, agentId } = await seedCompanyAgent();
+    const stuckRunId = randomUUID();
+    const issueId = randomUUID();
+    const dueLongAgo = new Date(Date.now() - HOUR_MS);
+
+    await db.insert(heartbeatRuns).values({
+      id: stuckRunId,
+      companyId,
+      agentId,
+      status: "scheduled_retry",
+      invocationSource: "automation",
+      processPid: null, // dead: no tracked process — the orphan shape we reap
+      scheduledRetryAt: dueLongAgo,
+      updatedAt: dueLongAgo,
+    });
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Permanently locked by stuck scheduled_retry run",
+      status: "in_progress",
+      priority: "high",
+      assigneeAgentId: agentId,
+      executionRunId: stuckRunId,
+      executionAgentNameKey: "coder",
+      executionLockedAt: dueLongAgo,
+    });
+
+    const heartbeat = heartbeatService(db);
+
+    // The plain sweep cannot clear it yet — the run is still non-terminal.
+    const preSweep = await heartbeat.sweepStaleIssueLocks();
+    expect(preSweep.cleared).toBe(0);
+
+    // Finalize step (R1): drive the dead stuck run terminal.
+    const reap = await heartbeat.reapOrphanedRuns({
+      reapStuckNonTerminalRuns: true,
+      stuckRunStaleThresholdMs: 5 * 60 * 1000,
+    });
+    expect(reap.stuckFinalized).toBe(1);
+    expect(reap.stuckRunIds).toContain(stuckRunId);
+
+    const runAfter = await db
+      .select({ status: heartbeatRuns.status })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, stuckRunId))
+      .then((rows) => rows[0]);
+    expect(runAfter?.status).toBe("failed");
+
+    // Sweep step: the now-terminal run's lock is cleared, with the audit event.
+    const swept = await heartbeat.sweepStaleIssueLocks();
+    expect(swept.cleared).toBe(1);
+    expect(swept.issueIds).toEqual([issueId]);
+
+    const row = await db
+      .select({
+        executionRunId: issues.executionRunId,
+        executionLockedAt: issues.executionLockedAt,
+      })
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0]);
+    expect(row).toEqual({ executionRunId: null, executionLockedAt: null });
+
+    const audit = await db
+      .select({ action: activityLog.action, details: activityLog.details })
+      .from(activityLog)
+      .where(eq(activityLog.action, "issue.stale_lock_cleared"))
+      .then((rows) => rows[0]);
+    expect(audit?.action).toBe("issue.stale_lock_cleared");
+    expect(
+      (audit?.details as { clearedExecutionRunId?: string } | null)?.clearedExecutionRunId,
+    ).toBe(stuckRunId);
+  });
+
+  it("does NOT reap a live scheduled_retry whose scheduledRetryAt is still in the future", async () => {
+    // A legitimately-scheduled retry can sit for up to the 2h+ bounded backoff — or
+    // far longer behind a rate-limit Retry-After. Staleness is measured from the due
+    // time, so a not-yet-due retry keeps its lock and is never reaped.
+    const { companyId, agentId } = await seedCompanyAgent();
+    const liveRunId = randomUUID();
+    const issueId = randomUUID();
+    const dueInFuture = new Date(Date.now() + 2 * HOUR_MS);
+
+    await db.insert(heartbeatRuns).values({
+      id: liveRunId,
+      companyId,
+      agentId,
+      status: "scheduled_retry",
+      invocationSource: "automation",
+      processPid: null,
+      scheduledRetryAt: dueInFuture,
+      updatedAt: new Date(Date.now() - 3 * HOUR_MS), // created long ago, but not yet due
+    });
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Live scheduled retry — lock must be preserved",
+      status: "in_progress",
+      priority: "high",
+      assigneeAgentId: agentId,
+      executionRunId: liveRunId,
+      executionLockedAt: new Date(),
+    });
+
+    const heartbeat = heartbeatService(db);
+    const reap = await heartbeat.reapOrphanedRuns({
+      reapStuckNonTerminalRuns: true,
+      stuckRunStaleThresholdMs: 5 * 60 * 1000,
+    });
+    expect(reap.stuckFinalized).toBe(0);
+
+    const runAfter = await db
+      .select({ status: heartbeatRuns.status })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, liveRunId))
+      .then((rows) => rows[0]);
+    expect(runAfter?.status).toBe("scheduled_retry");
+
+    const swept = await heartbeat.sweepStaleIssueLocks();
+    expect(swept.cleared).toBe(0);
+  });
+
+  it("does NOT reap a recently-queued run still within the staleness threshold", async () => {
+    const { companyId, agentId } = await seedCompanyAgent();
+    const freshRunId = randomUUID();
+    await db.insert(heartbeatRuns).values({
+      id: freshRunId,
+      companyId,
+      agentId,
+      status: "queued",
+      invocationSource: "assignment",
+      processPid: null,
+      updatedAt: new Date(), // fresh — legitimately waiting for its agent slot
+    });
+
+    const heartbeat = heartbeatService(db);
+    const reap = await heartbeat.reapOrphanedRuns({
+      reapStuckNonTerminalRuns: true,
+      stuckRunStaleThresholdMs: 30 * 60 * 1000,
+    });
+    expect(reap.stuckFinalized).toBe(0);
+
+    const runAfter = await db
+      .select({ status: heartbeatRuns.status })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, freshRunId))
+      .then((rows) => rows[0]);
+    expect(runAfter?.status).toBe("queued");
+  });
+
+  it("leaves stuck non-terminal runs untouched when reapStuckNonTerminalRuns is not enabled (opt-in default off)", async () => {
+    // Guards the existing contract: queued runs are legitimately waiting and the
+    // default reapOrphanedRuns() call (used by many callers/tests) must never reap
+    // them. The stuck-run reap is strictly opt-in.
+    const { companyId, agentId } = await seedCompanyAgent();
+    const stuckRunId = randomUUID();
+    await db.insert(heartbeatRuns).values({
+      id: stuckRunId,
+      companyId,
+      agentId,
+      status: "queued",
+      invocationSource: "assignment",
+      processPid: null,
+      updatedAt: new Date(Date.now() - 2 * HOUR_MS),
+    });
+
+    const heartbeat = heartbeatService(db);
+    const reap = await heartbeat.reapOrphanedRuns();
+    expect(reap.stuckFinalized ?? 0).toBe(0);
+
+    const runAfter = await db
+      .select({ status: heartbeatRuns.status })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, stuckRunId))
+      .then((rows) => rows[0]);
+    expect(runAfter?.status).toBe("queued");
+  });
+
+  it("clears a mass-killed run's lock under suppressed hygiene mode without dispatching any new run (proves defect A)", async () => {
+    // During a rate-limit outage (the window in which runs get mass-killed)
+    // scheduling is suppressed, but lock hygiene must still run: reap the dead run
+    // and sweep its lock, with zero model/agent spend (no retry enqueue, no
+    // next-run dispatch).
+    const { companyId, agentId } = await seedCompanyAgent();
+    const killedRunId = randomUUID();
+    const issueId = randomUUID();
+    const longAgo = new Date(Date.now() - HOUR_MS);
+
+    await db.insert(heartbeatRuns).values({
+      id: killedRunId,
+      companyId,
+      agentId,
+      status: "queued",
+      invocationSource: "assignment",
+      processPid: null, // process was mass-killed; nothing tracks it anymore
+      updatedAt: longAgo,
+    });
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Mass-killed run left a permanent lock",
+      status: "in_progress",
+      priority: "high",
+      assigneeAgentId: agentId,
+      executionRunId: killedRunId,
+      executionLockedAt: longAgo,
+    });
+
+    const heartbeat = heartbeatService(db);
+    const reap = await heartbeat.reapOrphanedRuns({
+      reapStuckNonTerminalRuns: true,
+      stuckRunStaleThresholdMs: 5 * 60 * 1000,
+      suppressed: true,
+    });
+    expect(reap.stuckFinalized).toBe(1);
+
+    const swept = await heartbeat.sweepStaleIssueLocks();
+    expect(swept.cleared).toBe(1);
+
+    const row = await db
+      .select({ executionRunId: issues.executionRunId })
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0]);
+    expect(row?.executionRunId).toBeNull();
+
+    // Zero-spend proof: the only run in the table is the one we finalized — the
+    // suppressed hygiene path did not enqueue a retry or dispatch a next run.
+    const allRuns = await db
+      .select({ id: heartbeatRuns.id, status: heartbeatRuns.status })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.companyId, companyId));
+    expect(allRuns).toHaveLength(1);
+    expect(allRuns[0]).toEqual({ id: killedRunId, status: "failed" });
   });
 });

--- a/server/src/__tests__/server-startup-feedback-export.test.ts
+++ b/server/src/__tests__/server-startup-feedback-export.test.ts
@@ -138,6 +138,8 @@ function buildTestConfig(overrides: Record<string, unknown> = {}) {
     feedbackExportBackendToken: "telemetry-token",
     heartbeatSchedulerEnabled: false,
     heartbeatSchedulerIntervalMs: 30000,
+    stuckRunLockReapEnabled: true,
+    stuckRunLockStaleThresholdMs: 30 * 60 * 1000,
     companyDeletionEnabled: false,
     ...overrides,
   };
@@ -300,16 +302,30 @@ describe("startServer feedback export wiring", () => {
     try {
       await startServer();
 
-      expect(heartbeatServiceMock.reapOrphanedRuns).not.toHaveBeenCalled();
+      // Stale-lock hygiene (reap dead runs + sweep their locks) is pure DB
+      // maintenance with zero model/agent spend, so it runs even while scheduling is
+      // suppressed — in suppressed/no-spend mode. The spend-y timer ticks stay
+      // suppressed.
+      expect(heartbeatServiceMock.reapOrphanedRuns).toHaveBeenCalledTimes(1);
+      expect(heartbeatServiceMock.reapOrphanedRuns).toHaveBeenLastCalledWith(
+        expect.objectContaining({ suppressed: true }),
+      );
+      expect(heartbeatServiceMock.sweepStaleIssueLocks).toHaveBeenCalledTimes(1);
       expect(heartbeatServiceMock.tickTimers).not.toHaveBeenCalled();
+      expect(heartbeatServiceMock.promoteDueScheduledRetries).not.toHaveBeenCalled();
       expect(environmentCustomImagesServiceMock.cleanupExpiredSetupSessions).toHaveBeenCalledTimes(1);
 
       expect(intervalCallback).not.toBeNull();
       intervalCallback?.();
       await Promise.resolve();
       await Promise.resolve();
+      await Promise.resolve();
 
+      // The periodic tick also runs the suppressed lock hygiene, still with no spend.
+      expect(heartbeatServiceMock.reapOrphanedRuns).toHaveBeenCalledTimes(2);
+      expect(heartbeatServiceMock.sweepStaleIssueLocks).toHaveBeenCalledTimes(2);
       expect(heartbeatServiceMock.tickTimers).not.toHaveBeenCalled();
+      expect(heartbeatServiceMock.promoteDueScheduledRetries).not.toHaveBeenCalled();
       expect(routineServiceMock.tickScheduledTriggers).toHaveBeenCalledTimes(1);
       expect(environmentCustomImagesServiceMock.cleanupExpiredSetupSessions).toHaveBeenCalledTimes(2);
     } finally {

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -85,6 +85,14 @@ export interface Config {
   feedbackExportBackendToken: string | undefined;
   heartbeatSchedulerEnabled: boolean;
   heartbeatSchedulerIntervalMs: number;
+  // Reap runs stuck in a non-terminal state (queued / scheduled_retry) with a dead
+  // process so their permanent execution lock can be swept. Shipped enabled; flip
+  // STUCK_RUN_LOCK_REAP_ENABLED=false to disable.
+  stuckRunLockReapEnabled: boolean;
+  // How long a stuck run must be idle (queued: since updatedAt; scheduled_retry:
+  // past its scheduledRetryAt due time) before it is reaped. Must comfortably
+  // exceed normal promotion latency so live scheduled retries are never reaped.
+  stuckRunLockStaleThresholdMs: number;
   companyDeletionEnabled: boolean;
   telemetryEnabled: boolean;
 }
@@ -331,6 +339,11 @@ export function loadConfig(): Config {
     feedbackExportBackendToken,
     heartbeatSchedulerEnabled: process.env.HEARTBEAT_SCHEDULER_ENABLED !== "false",
     heartbeatSchedulerIntervalMs: Math.max(10000, Number(process.env.HEARTBEAT_SCHEDULER_INTERVAL_MS) || 30000),
+    stuckRunLockReapEnabled: process.env.STUCK_RUN_LOCK_REAP_ENABLED !== "false",
+    stuckRunLockStaleThresholdMs: Math.max(
+      60_000,
+      Number(process.env.STUCK_RUN_LOCK_STALE_THRESHOLD_MS) || 30 * 60 * 1000,
+    ),
     companyDeletionEnabled,
     telemetryEnabled: fileConfig?.telemetry?.enabled ?? true,
   };

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -833,13 +833,47 @@ export async function startServer(): Promise<StartedServer> {
         { reason: heartbeatSchedulingSuppression.reason },
         "heartbeat scheduling suppressed for this runtime instance",
       );
+      // Stale-lock cleanup is pure DB hygiene with zero model/agent spend, so it
+      // must run even while scheduling is suppressed. Otherwise a run killed during
+      // a rate-limit outage leaves a permanent execution lock that no cleanup path
+      // clears until suppression lifts — an issue's assignee can then never
+      // transition it ("run ownership conflict"). Reap dead runs (in
+      // suppressed/no-spend mode) then sweep their now-terminal locks.
+      const suppressedLockHygiene = (async () => {
+        try {
+          const reaped = await heartbeat.reapOrphanedRuns({
+            reapStuckNonTerminalRuns: config.stuckRunLockReapEnabled,
+            stuckRunStaleThresholdMs: config.stuckRunLockStaleThresholdMs,
+            suppressed: true,
+          });
+          if (reaped.reaped > 0 || reaped.stuckFinalized > 0) {
+            logger.warn({ ...reaped }, "startup suppressed lock hygiene finalized orphaned runs");
+          }
+          const swept = await heartbeat.sweepStaleIssueLocks();
+          if (swept.cleared > 0) {
+            logger.warn({ ...swept }, "startup suppressed stale-lock sweeper cleared issue locks");
+          }
+        } catch (err) {
+          logger.error({ err }, "startup suppressed lock hygiene failed");
+        }
+      })();
+      trackHeartbeatSchedulerWork(suppressedLockHygiene);
+      await suppressedLockHygiene;
     } else {
       const startupHeartbeatRecovery = (async () => {
         for (let attempt = 1; attempt <= 2; attempt++) {
           try {
-            const result = await heartbeat.reapOrphanedRuns();
+            const result = await heartbeat.reapOrphanedRuns({
+              reapStuckNonTerminalRuns: config.stuckRunLockReapEnabled,
+              stuckRunStaleThresholdMs: config.stuckRunLockStaleThresholdMs,
+            });
             logger.info(
-              { reaped: result.reaped, runIds: result.runIds },
+              {
+                reaped: result.reaped,
+                runIds: result.runIds,
+                stuckFinalized: result.stuckFinalized,
+                stuckRunIds: result.stuckRunIds,
+              },
               "startup reap of orphaned heartbeat runs complete",
             );
             break;
@@ -967,9 +1001,15 @@ export async function startServer(): Promise<StartedServer> {
       if (heartbeatSchedulerStopped) return;
       if (!(await heartbeat.resolveSchedulingSuppression()).suppressed) {
         // Periodically reap orphaned runs (5-min staleness threshold) and make sure
-        // persisted queued work is still being driven forward.
+        // persisted queued work is still being driven forward. Also finalizes runs
+        // stuck non-terminal with a dead process so the sweep below can clear their
+        // execution lock.
         trackHeartbeatSchedulerWork(heartbeat
-          .reapOrphanedRuns({ staleThresholdMs: 5 * 60 * 1000 })
+          .reapOrphanedRuns({
+            staleThresholdMs: 5 * 60 * 1000,
+            reapStuckNonTerminalRuns: config.stuckRunLockReapEnabled,
+            stuckRunStaleThresholdMs: config.stuckRunLockStaleThresholdMs,
+          })
           .then(() => heartbeat.promoteDueScheduledRetries())
           .then(async (promotion) => {
             await heartbeat.resumeQueuedRuns();
@@ -1020,6 +1060,32 @@ export async function startServer(): Promise<StartedServer> {
           })
           .catch((err) => {
             logger.error({ err }, "periodic heartbeat recovery failed");
+          }));
+      } else {
+        // Even while scheduling is suppressed, run stale-lock hygiene (reap dead
+        // runs + sweep their now-terminal locks). This is pure DB maintenance with
+        // zero model/agent spend, so it is safe during a rate-limit outage — and is
+        // exactly the window in which permanent locks would otherwise accumulate for
+        // the whole outage. The spend-y recovery steps above stay gated behind
+        // suppression.
+        trackHeartbeatSchedulerWork(heartbeat
+          .reapOrphanedRuns({
+            staleThresholdMs: 5 * 60 * 1000,
+            reapStuckNonTerminalRuns: config.stuckRunLockReapEnabled,
+            stuckRunStaleThresholdMs: config.stuckRunLockStaleThresholdMs,
+            suppressed: true,
+          })
+          .then(async () => {
+            const swept = await heartbeat.sweepStaleIssueLocks();
+            if (swept.cleared > 0) {
+              logger.warn(
+                { ...swept },
+                "periodic suppressed stale-lock sweeper cleared issue locks",
+              );
+            }
+          })
+          .catch((err) => {
+            logger.error({ err }, "periodic suppressed lock hygiene failed");
           }));
       }
       })();

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -10039,8 +10039,22 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       .then((rows) => rows[0] ?? null);
   }
 
-  async function reapOrphanedRuns(opts?: { staleThresholdMs?: number }) {
+  async function reapOrphanedRuns(opts?: {
+    staleThresholdMs?: number;
+    // When true, also finalize runs stuck in a non-terminal state (queued /
+    // scheduled_retry) whose process is dead, so their execution lock can be
+    // swept ("finalize-then-sweep"). Opt-in — callers that only want the classic
+    // "running" reap (and the many tests that rely on queued runs surviving) must
+    // leave it off.
+    reapStuckNonTerminalRuns?: boolean;
+    stuckRunStaleThresholdMs?: number;
+    // When scheduling is suppressed (e.g. during a provider rate-limit outage) the
+    // reap still runs as pure DB lock hygiene, but must not spend — no immediate
+    // recovery dispatch and no next-queued-run start.
+    suppressed?: boolean;
+  }) {
     const staleThresholdMs = opts?.staleThresholdMs ?? 0;
+    const suppressed = opts?.suppressed ?? false;
     const now = new Date();
 
     // Find all runs stuck in "running" state (queued runs are legitimately waiting; resumeQueuedRuns handles them)
@@ -10138,7 +10152,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           retriedRun = await enqueueProcessLossRetry(finalizedRun, agent, now);
         }
       } else {
-        await releaseIssueExecutionAndPromote(finalizedRun);
+        await releaseIssueExecutionAndPromote(finalizedRun, { suppressImmediateRecovery: suppressed });
       }
 
       await appendRunEvent(finalizedRun, await nextRunEventSeq(finalizedRun.id), {
@@ -10157,7 +10171,9 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       });
 
       await finalizeAgentStatus(run.agentId, "failed", baseMessage);
-      await startNextQueuedRunForAgent(run.agentId);
+      // Starting the agent's next queued run is model/agent spend — skip it while
+      // suppressed so the reap stays pure DB hygiene during an outage.
+      if (!suppressed) await startNextQueuedRunForAgent(run.agentId);
       runningProcesses.delete(run.id);
       reaped.push(run.id);
     }
@@ -10165,7 +10181,123 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     if (reaped.length > 0) {
       logger.warn({ reapedCount: reaped.length, runIds: reaped }, "reaped orphaned heartbeat runs");
     }
-    return { reaped: reaped.length, runIds: reaped };
+
+    // Finalize-then-sweep: runs stuck in a non-terminal state (queued /
+    // scheduled_retry) whose process is dead never transition to terminal on their
+    // own, so sweepStaleIssueLocks — which only clears locks referencing a terminal
+    // run — can never release their execution lock, leaving it held permanently.
+    // Drive them to `failed` here; the caller's subsequent sweep then clears the
+    // lock and emits the `issue.stale_lock_cleared` audit event. Opt-in only.
+    const stuckFinalized: string[] = [];
+    if (opts?.reapStuckNonTerminalRuns) {
+      const stuckThresholdMs = opts?.stuckRunStaleThresholdMs ?? 30 * 60 * 1000;
+      const stuckRuns = await db
+        .select({
+          run: heartbeatRuns,
+          adapterType: agents.adapterType,
+          adapterConfig: agents.adapterConfig,
+        })
+        .from(heartbeatRuns)
+        .innerJoin(agents, eq(heartbeatRuns.agentId, agents.id))
+        .where(inArray(heartbeatRuns.status, ["queued", "scheduled_retry"]));
+
+      for (const { run, adapterType, adapterConfig } of stuckRuns) {
+        // A live in-memory execution or a live OS process still owns this run.
+        if (runningProcesses.has(run.id) || activeRunExecutions.has(run.id)) continue;
+        if (run.processPid && isProcessAlive(run.processPid)) continue;
+
+        // Staleness reference:
+        //  - scheduled_retry: the *due* time (scheduledRetryAt). A retry not yet due —
+        //    or due only recently — is a LIVE handoff that promoteDueScheduledRetries
+        //    still owns, so it keeps its lock and is never reaped. Legit retries can be
+        //    scheduled 2h+ out (bounded backoff) or far further behind a rate-limit
+        //    Retry-After, so age-since-creation must never be used here.
+        //  - queued: idle since updatedAt (falling back to createdAt) — a freshly
+        //    queued run legitimately waiting for its agent slot is within threshold.
+        const refTimeSource =
+          run.status === "scheduled_retry"
+            ? (run.scheduledRetryAt ?? run.updatedAt ?? run.createdAt)
+            : (run.updatedAt ?? run.createdAt);
+        // No timing information at all: we cannot prove this run is stale, so leave
+        // it alone rather than reaping it unconditionally.
+        if (!refTimeSource) continue;
+        const refTime = new Date(refTimeSource).getTime();
+        if (now.getTime() - refTime < stuckThresholdMs) continue;
+
+        const staleSeconds = Math.round((now.getTime() - refTime) / 1000);
+        const stuckMessage =
+          `Stale ${run.status} run with no tracked process (idle ${staleSeconds}s, ` +
+          `past ${Math.round(stuckThresholdMs / 1000)}s threshold); driven terminal ` +
+          `so its stale execution lock can be swept`;
+
+        let finalizedRun = await setRunStatus(run.id, "failed", {
+          error: stuckMessage,
+          errorCode: "stale_run_reaped",
+          finishedAt: now,
+          resultJson: mergeRunStopMetadataForAgent(
+            { adapterType, adapterConfig },
+            "failed",
+            {
+              resultJson: parseObject(run.resultJson),
+              errorCode: "stale_run_reaped",
+              errorMessage: stuckMessage,
+            },
+          ),
+        });
+        await setWakeupStatus(run.wakeupRequestId, "failed", {
+          finishedAt: now,
+          error: stuckMessage,
+        });
+        if (!finalizedRun) finalizedRun = await getRun(run.id);
+        if (!finalizedRun) continue;
+        finalizedRun =
+          (await classifyAndPersistRunLiveness(finalizedRun, parseObject(finalizedRun.resultJson))) ??
+          finalizedRun;
+        await releaseEnvironmentLeasesForRun({
+          runId: finalizedRun.id,
+          companyId: finalizedRun.companyId,
+          agentId: finalizedRun.agentId,
+          status: finalizedRun.status,
+          failureReason: finalizedRun.error ?? undefined,
+        });
+        await appendRunEvent(finalizedRun, await nextRunEventSeq(finalizedRun.id), {
+          eventType: "lifecycle",
+          stream: "system",
+          level: "warn",
+          message: stuckMessage,
+          payload: {
+            previousStatus: run.status,
+            staleSeconds,
+            ...(run.scheduledRetryAt
+              ? { scheduledRetryAt: new Date(run.scheduledRetryAt).toISOString() }
+              : {}),
+          },
+        });
+        // Reconcile the owning agent's status so a dead stuck run does not leave the
+        // agent stranded in a non-idle status. keepIdleOnFailure so a queued/retry
+        // run being reaped settles the agent to idle (or stays running if it still
+        // has other live runs) rather than being falsely flagged as errored.
+        await finalizeAgentStatus(run.agentId, "failed", stuckMessage, {
+          keepIdleOnFailure: true,
+        });
+        runningProcesses.delete(run.id);
+        stuckFinalized.push(run.id);
+      }
+
+      if (stuckFinalized.length > 0) {
+        logger.warn(
+          { stuckFinalizedCount: stuckFinalized.length, runIds: stuckFinalized, suppressed },
+          "finalized stuck non-terminal heartbeat runs for stale-lock sweep",
+        );
+      }
+    }
+
+    return {
+      reaped: reaped.length,
+      runIds: reaped,
+      stuckFinalized: stuckFinalized.length,
+      stuckRunIds: stuckFinalized,
+    };
   }
 
   async function resumeQueuedRuns() {


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Each issue an agent works is guarded by an execution lock (`executionRunId`) so two runs can't act on the same issue at once; the lock is meant to be released when the owning run reaches a terminal state.
> - The heartbeat recovery subsystem (`reapOrphanedRuns` + `sweepStaleIssueLocks`) is responsible for driving dead runs terminal and clearing any lock they left behind.
> - Three gaps let that lock survive forever: (1) recovery is fully gated behind scheduling suppression, so during a provider rate-limit outage — exactly when runs get mass-killed — cleanup never runs; (2) the sweep only clears locks that reference a *terminal* run, so a run stuck in `queued`/`scheduled_retry` with a dead process never becomes terminal and its lock is never swept; (3) there's no test coverage or config guard around either path.
> - When the lock survives, the issue's assignee can never transition the issue — every mutating call fails with a "run ownership conflict", and there is no self-service recovery path.
> - This pull request runs stale-lock cleanup as pure zero-spend DB hygiene even while suppressed, and extends `reapOrphanedRuns` to finalize dead non-terminal runs (finalize-then-sweep) so the existing audited sweep can release the lock.
> - The benefit is that abnormally-terminated runs — including a whole fleet killed during a rate-limit outage — no longer strand their issues behind a permanent lock.

## Linked Issues or Issue Description

Fixes #6798
Refs #5771
Refs #4697
Refs #2516
Refs #725

Closest related in-flight PRs (different scope — `running`-only reap / checkout-path reap, not the `queued`/`scheduled_retry` + suppression gaps fixed here): #8502, #6799.

## What Changed

- **A — Suppression hole.** Stale-lock cleanup (`reapOrphanedRuns` + `sweepStaleIssueLocks`) now runs even while `resolveSchedulingSuppression()` reports suppressed, as pure DB hygiene with **zero model/agent spend** — no immediate-recovery dispatch (`suppressImmediateRecovery`) and no next-queued-run start. Wired at both the startup and periodic heartbeat paths in `server/src/index.ts`. The spend-y recovery steps stay gated behind suppression.
- **B — Non-terminal-dead-run hole.** `reapOrphanedRuns` now also finalizes runs stuck in `queued` / `scheduled_retry` whose process is dead (not tracked in-memory, pid not alive) past a configurable staleness threshold, driving them to `failed` so the existing audited sweep clears their execution lock and emits the `issue.stale_lock_cleared` audit event. This is behind a new opt-in option so every other caller's existing queued-run-survival behavior is unchanged.
- **Safety property.** `scheduled_retry` staleness is measured from `scheduledRetryAt` (the *due* time), never from run age — a legitimately-scheduled retry, up to the 2h+ bounded backoff or far longer behind a rate-limit `Retry-After`, keeps its lock and is never reaped. Runs with no timing information at all are left alone rather than reaped, and the owning agent's status is reconciled when a stuck run is finalized (kept idle-on-failure rather than falsely flagged errored).
- **C — Config + tests.** Adds `STUCK_RUN_LOCK_REAP_ENABLED` (default on) and `STUCK_RUN_LOCK_STALE_THRESHOLD_MS` (default 30m) in `server/src/config.ts`. Test coverage in `recovery-stale-issue-lock-sweep.test.ts` (+5 cases: stuck-reap→sweep with audit, live-retry preservation, within-threshold preservation, opt-in default-off, suppressed zero-spend end-to-end); `server-startup-feedback-export.test.ts` and `heartbeat-process-recovery.test.ts` updated to the new suppressed-hygiene behavior / return shape.

No DB migration — all columns already exist.

## Verification

Local, Node 24, embedded Postgres:

```
vitest run recovery-stale-issue-lock-sweep.test.ts execution-lock-orphan-cleanup.test.ts \
  issue-stale-execution-lock-routes.test.ts heartbeat-process-recovery.test.ts \
  server-startup-feedback-export.test.ts

 Test Files  5 passed (5)
      Tests  105 passed (105)
```

```
tsc --noEmit   (server package)  → exit 0
```

The suite includes the preserved-behavior assertions: live `running`/`queued` runs within threshold are NOT reaped, a live foreign checkout still 409s, and a scheduled-retry handoff keeps its lock.

## Risks

Low. The new stuck-run reap is opt-in per call and default-on via a config flag that can be disabled without a deploy (`STUCK_RUN_LOCK_REAP_ENABLED=false`). It only touches runs that are simultaneously non-terminal, un-tracked in-memory, have a dead/absent pid, and are past the staleness threshold — a live scheduled retry or a freshly-queued run is never eligible. The suppressed-mode cleanup performs no dispatch and starts no runs, so it cannot add agent spend during an outage. No schema change.

## Model Used

Claude Opus 4.8 (`claude-opus-4-8`), extended thinking + tool use.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [ ] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details — the branch retains a tooling-generated suffix; the PR title, description, commit, and code comments are all free of internal references. Happy to rename to a fresh branch/PR if maintainers prefer.
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
