### PR TITLE
Fix skills routes to skip user secret resolution

### DIFF
--- a/server/src/__tests__/agent-skills-routes.test.ts
+++ b/server/src/__tests__/agent-skills-routes.test.ts
@@ -379,6 +379,54 @@ describe.sequential("agent skill routes", () => {
     );
   }, 10_000);
 
+  it("lists skills without resolving required user-secret env bindings", async () => {
+    const adapterConfig = {
+      env: {
+        HOME: "/home/agent",
+        GH_TOKEN: {
+          type: "user_secret_ref" as const,
+          key: "github_pat_read_only",
+          version: "latest" as const,
+          required: true,
+        },
+      },
+    };
+    mockAgentService.getById.mockResolvedValue({
+      ...makeAgent("claude_local"),
+      adapterConfig,
+    });
+    mockSecretService.resolveAdapterConfigForRuntime.mockImplementationOnce(
+      async (
+        _companyId: string,
+        config: Record<string, unknown>,
+        context?: unknown,
+        opts?: { skipUserSecrets?: boolean },
+      ) => {
+        expect(config).toBe(adapterConfig);
+        expect(context).toBeUndefined();
+        expect(opts).toEqual({ adapterType: "claude_local", skipUserSecrets: true });
+        return { config: { env: { HOME: "/home/agent" } } };
+      },
+    );
+
+    const res = await requestApp(
+      await createApp(),
+      (baseUrl) => request(baseUrl)
+        .get("/api/agents/11111111-1111-4111-8111-111111111111/skills?companyId=company-1"),
+    );
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(mockAdapter.listSkills).toHaveBeenCalledWith(
+      expect.objectContaining({
+        adapterType: "claude_local",
+        config: expect.objectContaining({
+          env: { HOME: "/home/agent" },
+          paperclipRuntimeSkills: expect.any(Array),
+        }),
+      }),
+    );
+  });
+
   it("skips runtime materialization when listing Codex skills", async () => {
     mockAgentService.getById.mockResolvedValue(makeAgent("codex_local"));
     mockAdapter.listSkills.mockResolvedValue({
@@ -585,6 +633,61 @@ describe.sequential("agent skill routes", () => {
 
     expect(res.status, JSON.stringify(res.body)).toBe(200);
     expect(mockAdapter.syncSkills).toHaveBeenCalled();
+  });
+
+  it("syncs skills without resolving required user-secret env bindings", async () => {
+    const adapterConfig = {
+      env: {
+        HOME: "/home/agent",
+        GH_TOKEN: {
+          type: "user_secret_ref" as const,
+          key: "github_pat_read_only",
+          version: "latest" as const,
+          required: true,
+        },
+      },
+    };
+    mockAgentService.getById.mockResolvedValue({
+      ...makeAgent("claude_local"),
+      adapterConfig,
+    });
+    mockSecretService.resolveAdapterConfigForRuntime.mockImplementationOnce(
+      async (
+        _companyId: string,
+        config: Record<string, unknown>,
+        context?: unknown,
+        opts?: { skipUserSecrets?: boolean },
+      ) => {
+        expect((config.env as Record<string, unknown>).GH_TOKEN).toMatchObject({
+          type: "user_secret_ref",
+          key: "github_pat_read_only",
+        });
+        expect(context).toBeUndefined();
+        expect(opts).toEqual({ adapterType: "claude_local", skipUserSecrets: true });
+        return {
+          config: {
+            ...config,
+            env: { HOME: "/home/agent" },
+          },
+        };
+      },
+    );
+
+    const res = await requestApp(await createApp(), (baseUrl) => request(baseUrl)
+      .post("/api/agents/11111111-1111-4111-8111-111111111111/skills/sync?companyId=company-1")
+      .send({ desiredSkills: ["paperclipai/paperclip/paperclip"] }));
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(mockAdapter.syncSkills).toHaveBeenCalledWith(
+      expect.objectContaining({
+        adapterType: "claude_local",
+        config: expect.objectContaining({
+          env: { HOME: "/home/agent" },
+          paperclipRuntimeSkills: expect.any(Array),
+        }),
+      }),
+      ["paperclipai/paperclip/paperclip"],
+    );
   });
 
   it("canonicalizes desired skill references before syncing", async () => {

--- a/server/src/__tests__/secrets-service.test.ts
+++ b/server/src/__tests__/secrets-service.test.ts
@@ -616,6 +616,71 @@ describeEmbeddedPostgres("secretService", () => {
     expect(JSON.stringify(events)).not.toContain("user-one-secret");
   });
 
+  it("can skip user-secret refs while resolving adapter config for non-runtime skill discovery", async () => {
+    const companyId = await seedCompany();
+    const svc = secretService(db);
+    await svc.createUserSecretDefinition(companyId, {
+      key: "github_token",
+      name: "GitHub token",
+      provider: "local_encrypted",
+    });
+    const companySecret = await svc.create(companyId, {
+      name: `company-token-${randomUUID()}`,
+      provider: "local_encrypted",
+      value: "company-secret-value",
+    });
+    const adapterConfig = {
+      apiBaseUrl: "http://127.0.0.1:9119/api",
+      apiKey: {
+        type: "user_secret_ref" as const,
+        key: "github_token",
+        version: "latest" as const,
+        required: true,
+      },
+      env: {
+        HOME: "/home/agent",
+        COMPANY_TOKEN: {
+          type: "secret_ref" as const,
+          secretId: companySecret.id,
+          version: "latest" as const,
+        },
+        GH_TOKEN: {
+          type: "user_secret_ref" as const,
+          key: "github_token",
+          version: "latest" as const,
+          required: true,
+        },
+      },
+    };
+
+    await expect(
+      svc.resolveAdapterConfigForRuntime(companyId, adapterConfig, undefined, { adapterType: "hermes_gateway" }),
+    ).rejects.toMatchObject({
+      status: 422,
+      details: { code: "responsible_user_missing" },
+    });
+
+    const resolved = await svc.resolveAdapterConfigForRuntime(
+      companyId,
+      adapterConfig,
+      undefined,
+      { adapterType: "hermes_gateway", skipUserSecrets: true },
+    );
+
+    expect(resolved.config).not.toHaveProperty("apiKey");
+    expect(resolved.config.env).toEqual({
+      HOME: "/home/agent",
+      COMPANY_TOKEN: "company-secret-value",
+    });
+    expect(resolved.secretKeys).toEqual(new Set(["COMPANY_TOKEN"]));
+    expect(resolved.manifest).toEqual([
+      expect.objectContaining({
+        secretId: companySecret.id,
+        outcome: "success",
+      }),
+    ]);
+  });
+
   it("returns conflict when concurrent user secret value creation races the unique index", async () => {
     const companyId = await seedCompany();
     await seedCompanyMember(companyId, "user-1", "owner");

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -1758,6 +1758,8 @@ export function agentRoutes(
     const { config: runtimeConfig } = await secretsSvc.resolveAdapterConfigForRuntime(
       agent.companyId,
       agent.adapterConfig,
+      undefined,
+      { adapterType: agent.adapterType, skipUserSecrets: true },
     );
     const runtimeSkillConfig = await buildRuntimeSkillConfig(
       agent.companyId,
@@ -1824,6 +1826,8 @@ export function agentRoutes(
       const { config: runtimeConfig } = await secretsSvc.resolveAdapterConfigForRuntime(
         updated.companyId,
         updated.adapterConfig,
+        undefined,
+        { adapterType: updated.adapterType, skipUserSecrets: true },
       );
       const runtimeSkillConfig = {
         ...runtimeConfig,

--- a/server/src/services/secrets.ts
+++ b/server/src/services/secrets.ts
@@ -406,6 +406,11 @@ type SecretResolutionOptions = {
   allowUserSecretScope?: boolean;
 };
 
+type ResolveAdapterConfigForRuntimeOptions = {
+  adapterType?: string | null;
+  skipUserSecrets?: boolean;
+};
+
 export type RuntimeSecretManifestEntry = {
   configPath: string;
   envKey: string | null;
@@ -4064,7 +4069,7 @@ export function secretService(db: Db) {
       companyId: string,
       adapterConfig: Record<string, unknown>,
       context?: Omit<SecretConsumerContext, "configPath">,
-      opts?: { adapterType?: string | null },
+      opts?: ResolveAdapterConfigForRuntimeOptions,
     ): Promise<{ config: Record<string, unknown>; secretKeys: Set<string>; manifest: RuntimeSecretManifestEntry[] }> => {
       const resolved = { ...adapterConfig };
       const secretKeys = new Set<string>();
@@ -4102,6 +4107,7 @@ export function secretService(db: Db) {
               manifest.push(secretResolution.manifestEntry);
               secretKeys.add(key);
             } else {
+              if (opts?.skipUserSecrets) continue;
               const secretResolution = await secretService(db).resolveUserSecretValue(
                 companyId,
                 {
@@ -4135,6 +4141,10 @@ export function secretService(db: Db) {
         const binding = canonicalizeBinding(parsed.data as EnvBinding);
         if (binding.type === "plain") continue;
         if (binding.type === "user_secret_ref") {
+          if (opts?.skipUserSecrets) {
+            delete resolved[key];
+            continue;
+          }
           const secretResolution = await secretService(db).resolveUserSecretValue(
             companyId,
             {


### PR DESCRIPTION
## Thinking Path

> - Paperclip is a platform that runs AI agent companies — agents are configured via adapter configs that may include secrets (API keys, tokens) stored as `secret_ref` or `user_secret_ref` bindings
> - The skills subsystem (`GET /api/agents/:id/skills` and `POST /api/agents/:id/skills/sync`) needs to resolve adapter config to create a runtime adapter context before listing or syncing available skills
> - `user_secret_ref` bindings require a `responsibleUser` context (the user whose personal secret store is queried) — this context is only available during active heartbeat execution, not during ambient skill discovery requests
> - When the skills routes called `resolveAdapterConfigForRuntime` without a context, the service correctly raised `422 responsible_user_missing`, making skills permanently unavailable for agents with any `user_secret_ref` binding
> - The skills list/sync paths only need adapter config to communicate with the adapter (e.g. discover skill directories, resolve skill files) — they do not need per-user secret values to enumerate what skills exist
> - This pull request adds a `skipUserSecrets` option to `resolveAdapterConfigForRuntime` and uses it on the two skills routes, so `user_secret_ref` bindings are silently dropped for skill discovery while company `secret_ref` bindings are still resolved normally
> - The benefit is that agents whose adapters have any user-secret binding (a common pattern for personalized GitHub or OAuth tokens) can have their skills listed and synced without a responsible user in context

## Linked Issues or Issue Description

No existing public GitHub issue. Describing the bug inline per the bug report template:

**What happened:** `GET /api/agents/:id/skills` and `POST /api/agents/:id/skills/sync` returned `422 responsible_user_missing` for any agent whose `adapterConfig` contained a `user_secret_ref` binding, even when no user-specific secret value was actually needed to enumerate skills.

**Expected behavior:** Skills routes should succeed regardless of whether the adapter config contains `user_secret_ref` bindings — listing available skills does not require materializing per-user secret values.

**Steps to reproduce:**
1. Create an agent with an `adapterConfig` that includes a `user_secret_ref` binding (e.g. a GitHub PAT stored as a user secret).
2. `GET /api/agents/:id/skills` → `422 {"code":"responsible_user_missing"}`.
3. `POST /api/agents/:id/skills/sync` with a desired skills list → same `422`.

**Paperclip version/commit:** master (confirmed on latest HEAD at time of fix)

**Deployment mode:** all modes (the affected code path is not mode-gated)

Refs: #8307 #8256

## What Changed

- Added `ResolveAdapterConfigForRuntimeOptions` type with a new `skipUserSecrets?: boolean` field to `server/src/services/secrets.ts`
- When `skipUserSecrets: true`, `resolveAdapterConfigForRuntime` skips `user_secret_ref` bindings in env and top-level config, removing the key from the resolved config instead of erroring
- `GET /api/agents/:id/skills` now passes `{ adapterType, skipUserSecrets: true }` to `resolveAdapterConfigForRuntime`
- `POST /api/agents/:id/skills/sync` does the same; company `secret_ref` bindings are still resolved normally on both routes
- Added route regression test: asserts skills list and sync succeed and call the adapter with the resolved config (user secrets stripped, company secrets present) when the adapter config contains a required `user_secret_ref`
- Added secrets-service integration test: asserts that without `skipUserSecrets` a `user_secret_ref`-bearing config raises `422`, and with it the resolved config omits the user-secret key while still resolving company secrets

## Verification

```sh
pnpm exec vitest run server/src/__tests__/agent-skills-routes.test.ts  # 20 passed
pnpm exec vitest run server/src/__tests__/secrets-service.test.ts       # 66 passed
pnpm --filter @paperclipai/server typecheck
```

All three commands pass locally.

## Risks

Low. The change is additive (new opt-in flag on an existing internal function) and scoped to two skills-discovery routes that never materialize user secret values at runtime. The heartbeat/runtime resolution paths are unmodified — they do not pass `skipUserSecrets` and continue to enforce strict `responsible_user_missing` errors. The new regression tests cover both the skip path and the strict path.

## Model Used

OpenAI Codex via `codex_local` adapter — model `gpt-5.5`, standard context window, tool use enabled.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge