### PR TITLE
fix(codex-local): repoint stale managed catalog skill symlinks

### DIFF
--- a/packages/adapters/codex-local/src/server/execute.ts
+++ b/packages/adapters/codex-local/src/server/execute.ts
@@ -162,8 +162,13 @@ async function isLikelyManagedInstanceSkillPath(
   const skillsIdx = segments.lastIndexOf("skills");
   if (skillsIdx < 0) return false;
 
-  const skillsParent = skillsIdx > 0 ? segments[skillsIdx - 1] : "";
-  if (skillsParent === "companies") {
+  // Company-owned corpus: .../companies/<companyId>/skills/<slug>
+  const companiesIdx = skillsIdx - 2;
+  if (
+    companiesIdx >= 0 &&
+    segments[companiesIdx] === "companies" &&
+    segments[skillsIdx - 1]?.length > 0
+  ) {
     if (options.requireSkillMarkdown !== false && !(await pathExists(path.join(normalized, "SKILL.md")))) {
       return false;
     }

--- a/packages/adapters/codex-local/src/server/execute.ts
+++ b/packages/adapters/codex-local/src/server/execute.ts
@@ -149,11 +149,48 @@ async function isLikelyPaperclipRepoRoot(candidate: string): Promise<boolean> {
   return hasWorkspace && hasPackageJson && hasServerDir && hasAdapterUtilsDir;
 }
 
+const MANAGED_INSTANCE_SKILL_CONTAINER_DIRS = new Set(["__catalog__", "__runtime__"]);
+
+async function isLikelyManagedInstanceSkillPath(
+  candidate: string,
+  skillName: string,
+  options: { requireSkillMarkdown?: boolean } = {},
+): Promise<boolean> {
+  const normalized = path.resolve(candidate);
+  const base = path.basename(normalized);
+  const segments = normalized.split(path.sep);
+  const skillsIdx = segments.lastIndexOf("skills");
+  if (skillsIdx < 0) return false;
+
+  const skillsParent = skillsIdx > 0 ? segments[skillsIdx - 1] : "";
+  if (skillsParent === "companies") {
+    if (options.requireSkillMarkdown !== false && !(await pathExists(path.join(normalized, "SKILL.md")))) {
+      return false;
+    }
+    return true;
+  }
+
+  if (base !== skillName) return false;
+
+  const containerDir = path.basename(path.dirname(normalized));
+  if (!MANAGED_INSTANCE_SKILL_CONTAINER_DIRS.has(containerDir)) return false;
+  if (skillsIdx + 3 >= segments.length) return false;
+  if (segments[skillsIdx + 2] !== containerDir) return false;
+  if (segments[skillsIdx + 3] !== skillName) return false;
+  if (options.requireSkillMarkdown !== false && !(await pathExists(path.join(normalized, "SKILL.md")))) {
+    return false;
+  }
+
+  return segments[skillsIdx + 1].length > 0;
+}
+
 async function isLikelyPaperclipRuntimeSkillPath(
   candidate: string,
   skillName: string,
   options: { requireSkillMarkdown?: boolean } = {},
 ): Promise<boolean> {
+  if (await isLikelyManagedInstanceSkillPath(candidate, skillName, options)) return true;
+
   if (path.basename(candidate) !== skillName) return false;
   const skillsRoot = path.dirname(candidate);
   if (path.basename(skillsRoot) !== "skills") return false;

--- a/server/src/__tests__/codex-local-skill-injection.test.ts
+++ b/server/src/__tests__/codex-local-skill-injection.test.ts
@@ -30,9 +30,36 @@ async function createCustomSkill(root: string, skillName: string) {
   );
 }
 
+async function createManagedCatalogSkill(root: string, companyId: string, runtimeName: string) {
+  const skillDir = path.join(root, "skills", companyId, "__catalog__", runtimeName);
+  await fs.mkdir(skillDir, { recursive: true });
+  await fs.writeFile(
+    path.join(skillDir, "SKILL.md"),
+    `---\nname: ${runtimeName}\n---\n`,
+    "utf8",
+  );
+  return skillDir;
+}
+
+async function createCompanyOwnedSkill(root: string, companyId: string, slug: string) {
+  const skillDir = path.join(root, "companies", companyId, "skills", slug);
+  await fs.mkdir(skillDir, { recursive: true });
+  await fs.writeFile(
+    path.join(skillDir, "SKILL.md"),
+    `---\nname: ${slug}\n---\n`,
+    "utf8",
+  );
+  await fs.mkdir(path.join(skillDir, "references"), { recursive: true });
+  await fs.writeFile(path.join(skillDir, "references", "governance.md"), "# governance\n", "utf8");
+  return skillDir;
+}
+
 describe("codex local adapter skill injection", () => {
   const paperclipKey = "paperclipai/paperclip/paperclip";
   const createAgentKey = "paperclipai/paperclip/paperclip-create-agent";
+  const modernDeliveryKey = "local/928c96addb/modern-delivery";
+  const modernDeliveryRuntimeName = "modern-delivery--126abb30bb";
+  const companyId = "5e0fb142-c4c0-4b6b-ab76-8465065b22e7";
   const cleanupDirs = new Set<string>();
 
   afterEach(async () => {
@@ -91,6 +118,54 @@ describe("codex local adapter skill injection", () => {
       expect.objectContaining({
         stream: "stdout",
         chunk: expect.stringContaining('Injected Codex skill "paperclip-create-agent"'),
+      }),
+    );
+  });
+
+  it("repairs a Codex skill symlink that still points at a stale managed catalog mount", async () => {
+    const instanceRoot = await makeTempDir("paperclip-codex-instance-");
+    const skillsHome = await makeTempDir("paperclip-codex-home-");
+    cleanupDirs.add(instanceRoot);
+    cleanupDirs.add(skillsHome);
+
+    const staleCatalogDir = await createManagedCatalogSkill(
+      instanceRoot,
+      companyId,
+      modernDeliveryRuntimeName,
+    );
+    const currentSource = await createCompanyOwnedSkill(instanceRoot, companyId, "modern-delivery");
+    await fs.writeFile(
+      path.join(staleCatalogDir, "SKILL.md"),
+      "---\nname: stale\n---\n",
+      "utf8",
+    );
+    await fs.symlink(
+      staleCatalogDir,
+      path.join(skillsHome, modernDeliveryRuntimeName),
+    );
+
+    const logs: Array<{ stream: "stdout" | "stderr"; chunk: string }> = [];
+    await ensureCodexSkillsInjected(
+      async (stream, chunk) => {
+        logs.push({ stream, chunk });
+      },
+      {
+        skillsHome,
+        skillsEntries: [{
+          key: modernDeliveryKey,
+          runtimeName: modernDeliveryRuntimeName,
+          source: currentSource,
+        }],
+      },
+    );
+
+    expect(await fs.realpath(path.join(skillsHome, modernDeliveryRuntimeName))).toBe(
+      await fs.realpath(currentSource),
+    );
+    expect(logs).toContainEqual(
+      expect.objectContaining({
+        stream: "stdout",
+        chunk: expect.stringContaining(`Repaired Codex skill "${modernDeliveryRuntimeName}"`),
       }),
     );
   });

--- a/server/src/__tests__/codex-local-skill-injection.test.ts
+++ b/server/src/__tests__/codex-local-skill-injection.test.ts
@@ -170,6 +170,59 @@ describe("codex local adapter skill injection", () => {
     );
   });
 
+  it("repairs a Codex skill symlink that still points at a stale company-owned corpus", async () => {
+    const instanceRoot = await makeTempDir("paperclip-codex-instance-");
+    const skillsHome = await makeTempDir("paperclip-codex-home-");
+    cleanupDirs.add(instanceRoot);
+    cleanupDirs.add(skillsHome);
+
+    const staleCompanyOwnedDir = await createCompanyOwnedSkill(instanceRoot, companyId, "modern-delivery");
+    const currentSource = path.join(
+      instanceRoot,
+      "companies",
+      companyId,
+      "skills",
+      "modern-delivery-v2",
+    );
+    await fs.mkdir(currentSource, { recursive: true });
+    await fs.writeFile(
+      path.join(currentSource, "SKILL.md"),
+      "---\nname: modern-delivery-v2\n---\n",
+      "utf8",
+    );
+    await fs.mkdir(path.join(currentSource, "references"), { recursive: true });
+    await fs.writeFile(path.join(currentSource, "references", "governance.md"), "# governance v2\n", "utf8");
+    await fs.symlink(
+      staleCompanyOwnedDir,
+      path.join(skillsHome, modernDeliveryRuntimeName),
+    );
+
+    const logs: Array<{ stream: "stdout" | "stderr"; chunk: string }> = [];
+    await ensureCodexSkillsInjected(
+      async (stream, chunk) => {
+        logs.push({ stream, chunk });
+      },
+      {
+        skillsHome,
+        skillsEntries: [{
+          key: modernDeliveryKey,
+          runtimeName: modernDeliveryRuntimeName,
+          source: currentSource,
+        }],
+      },
+    );
+
+    expect(await fs.realpath(path.join(skillsHome, modernDeliveryRuntimeName))).toBe(
+      await fs.realpath(currentSource),
+    );
+    expect(logs).toContainEqual(
+      expect.objectContaining({
+        stream: "stdout",
+        chunk: expect.stringContaining(`Repaired Codex skill "${modernDeliveryRuntimeName}"`),
+      }),
+    );
+  });
+
   it("preserves a custom Codex skill symlink outside Paperclip repo checkouts", async () => {
     const currentRepo = await makeTempDir("paperclip-codex-current-");
     const customRoot = await makeTempDir("paperclip-codex-custom-");


### PR DESCRIPTION
## Thinking Path

MOD-518 moved the Modern Delivery company skill to a company-owned staged corpus, but Codex heartbeats still read a stale `__catalog__` symlink because `isLikelyPaperclipRuntimeSkillPath` only treated Paperclip **repo checkout** layouts as replaceable. Extend managed-path detection to cover instance catalog/runtime mounts and company-owned corpora, then prove repoint behavior with a focused regression test.

## What Changed

- Added `isLikelyManagedInstanceSkillPath` in `packages/adapters/codex-local/src/server/execute.ts` to recognize Paperclip-managed skill paths:
  - `skills/<companyId>/__catalog__/<runtimeName>`
  - `skills/<companyId>/__runtime__/<runtimeName>`
  - `companies/<companyId>/skills/<slug>`
- Wired it into `isLikelyPaperclipRuntimeSkillPath` so `ensureCodexSkillsInjected` replaces stale managed symlinks when the authoritative `paperclipRuntimeSkills` source changes.
- Added regression test `repairs a Codex skill symlink that still points at a stale managed catalog mount`.

## Verification

- `pnpm --filter @paperclipai/adapter-codex-local typecheck` — pass
- `pnpm exec vitest run server/src/__tests__/codex-local-skill-injection.test.ts` — 5/5 pass
- GitHub CI on head `356c260fd`: Typecheck + Release Registry, General tests (server 1–3, workspaces a/b), Verify serialized server suites (1–4), Build, Canary Dry Run, e2e — all pass
- QA scope check: 2 files, +112 lines; no unrelated diff pollution

## Risks

- Low blast radius: only affects symlink replacement when an existing Codex skill link already points at a Paperclip-managed path. Custom user-managed skill links outside those layouts remain preserved (existing test coverage retained).
- Post-merge validation still needed: one fresh Codex heartbeat should mount Modern Delivery from the company-owned locator with 8/8 files matching the staged corpus.

## Model Used

Cursor (Platform Dev agent) with human board oversight.

## Issue

Modern Delivery tracker: MOD-533 — Repair Codex runtime skill re-point over stale catalog symlink.

After MOD-518 re-pointed the Modern Delivery company skill to the company-owned staged corpus, fresh Codex heartbeats still loaded `CODEX_HOME/skills/modern-delivery--126abb30bb` from a stale `__catalog__` mount because `ensureCodexSkillsInjected` only replaced symlinks when the prior target looked like a Paperclip repo checkout.

Made with [Cursor](https://cursor.com)