### PR TITLE
docs(skills): add prepare-pr skill to .agents/skills

### DIFF
--- a/.agents/skills/prepare-pr/SKILL.md
+++ b/.agents/skills/prepare-pr/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: prepare-pr
+description: >
+  Prepare and ship a pull request to paperclipai/paperclip from a working
+  branch: safely commit all outstanding work, rebase cleanly onto the target
+  master, respect repo guardrails (no pnpm-lock.yaml, no .github/workflows
+  edits, migration ordering and idempotency, no stray design images), open the
+  PR per CONTRIBUTING.md, then drive the review loops — /greploop until
+  Greptile reports 5/5, then /prcheckloop — and report PR URLs back to the
+  task. Use whenever a task asks to create, prepare, split, or polish PRs from
+  a branch. This skill NEVER merges the PR.
+---
+
+# Prepare PR
+
+The standard Paperclip procedure for turning branch work into a reviewed,
+green pull request against `paperclipai/paperclip` master. Apply it once per
+PR (if a task splits a branch into several PRs, run the whole procedure for
+each one).
+
+## 0. Preconditions — worktree safety
+
+- Do all PR work in a **git worktree** on a dedicated branch. The main
+  `~/paperclip` checkout typically runs the live Paperclip server — never
+  check out branches there. If you are already on a worktree/branch, verify it
+  (`git rev-parse --git-dir`, `git branch --show-current`) and proceed.
+- If the main checkout is unexpectedly off `master`, fix that first without
+  losing work (usually: move that branch's work into a worktree).
+- Confirm which remote/ref you are targeting (normally `master` on the
+  `paperclipai/paperclip` repo; the task may name a specific remote such as
+  `origin` or `public-gh`).
+
+## 1. Commit everything — lose no work
+
+- Make **logical commits** of all uncommitted changes before anything else.
+  Do not stash and forget; do not leave files behind. If commits are missing,
+  make them.
+- Commit messages must end with exactly:
+  `Co-Authored-By: Paperclip <noreply@paperclip.ing>`
+
+## 2. Get changes cleanly on top of master
+
+- Fetch the target remote and rebase (or otherwise replay) your branch on top
+  of the target master so the PR has no merge conflicts.
+- Re-verify after rebase: build/tests relevant to the change still pass at
+  whatever depth the task warrants.
+
+## 3. Guardrails checklist (every PR)
+
+- **Never commit `pnpm-lock.yaml`** — the repo has actions that manage it.
+  If it is already in a commit, rewrite/drop that change before pushing.
+- **Never change `.github/workflows/*`** unless the underlying commit was
+  explicitly about that and the task calls it out.
+- **No design screenshots / wireframe images** committed to the repo unless
+  they are genuinely part of the work product.
+- **Migrations**: numbered incrementally with no conflicts against master. If
+  master moved and took your number, renumber on top. Make migrations
+  **idempotent** so users who already applied the old number are safe.
+- **Greptile file limit**: keep each PR under **100 changed files**; if a PR
+  exceeds that, split it into two.
+
+## 4. Open the PR
+
+- Follow `CONTRIBUTING.md` (repo root,
+  https://github.com/paperclipai/paperclip/blob/master/CONTRIBUTING.md) for
+  the PR title, message format, and issue description.
+- Push the branch and open the PR with `gh`.
+- Record the PR URL immediately — every report must include URLs to every PR.
+
+## 5. Review loops
+
+- Run the **/greploop** company skill: trigger Greptile review, address its
+  comments, push, and repeat until Greptile gives **5/5 with zero unresolved
+  comments** (max 20 turns). Do not stop early while turns remain.
+- Then run the **/prcheckloop** company skill and address any verification /
+  CI failures you can.
+- Wait on these loops as long as you can within the run. If you must cede
+  control while waiting, set the task to `in_review` with a comment saying
+  which loop is pending on which PR.
+
+## 6. Report back and hand off
+
+- Comment on the driving task: what you did, the PR URL(s), the worktree path
+  (use `~` for home), Greptile score, and check status.
+- Create a `pull_request` work product for each opened PR (plus `branch` /
+  `commit` work products where the branch or a commit is itself the handoff).
+- If the task requires follow-up per PR (e.g. sub-issues per PR), create them
+  as the task directs and link them.
+
+## Hard rules
+
+- **YOU DO NOT MERGE THE PR YOURSELF. NEVER MERGE THE PR YOURSELF.**
+- Never lose work: no orphaned stashes, no dropped files, no force-pushes
+  that discard commits.
+- Always post the URLs to every pull request you created.


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Agents ship their work as GitHub pull requests, and the repo keeps reusable agent skills in `.agents/skills/` (e.g. `prcheckloop`, `check-pr`)
> - The standard PR-preparation procedure (logical commits, clean rebase onto master, repo guardrails, CONTRIBUTING.md flow, Greptile `/greploop` then `/prcheckloop` review loops) existed only as a DB-managed company skill inside a Paperclip instance
> - That made the procedure invisible to the repo, unversioned, and impossible to review or share across instances
> - This pull request adds the skill as `.agents/skills/prepare-pr/SKILL.md`, making the repo the source of truth so instances import it as a local-path skill like its siblings
> - The benefit is a reviewable, versioned, shareable definition of "how to prepare a PR for this repo"

## Linked Issues or Issue Description

No public GitHub issue exists; inline description following `.github/ISSUE_TEMPLATE/feature_request.yml`:

**Subsystem affected:** Agent skills / maintainer tooling (`.agents/skills/`)

**Problem or motivation:** The repo's `.agents/skills/` catalog documents PR *checking* loops (`prcheckloop`, `check-pr`) but not the end-to-end PR *preparation* procedure (logical commits, clean rebase, repo guardrails, review loops) that agent routines rely on. That procedure existed only as a DB-managed skill inside a single Paperclip instance — unversioned, unreviewable, and not shareable across instances.

**Proposed solution:** Add the procedure as a docs-only skill file at `.agents/skills/prepare-pr/SKILL.md`, following the same conventions as its sibling skills, so the repo is the source of truth and instances import it as a local-path skill.

**Alternatives considered:** Keeping the skill DB-managed per instance (status quo — loses versioning/review); adding it to the bundled runtime catalog under `./skills` (rejected — it is maintainer tooling like `prcheckloop`, not a runtime skill shipped to every agent).

**Roadmap alignment:** Not core feature work; maintainer tooling documentation only.

**Additional context:** Content matches the previously instance-managed skill byte-for-byte, so importing instances see no behavior change.

## What Changed

- Added `.agents/skills/prepare-pr/SKILL.md` (new file, docs-only): the standard procedure for turning branch work into a reviewed, green PR — worktree safety, logical commits, rebase onto master, repo guardrails (no `pnpm-lock.yaml`, no `.github/workflows` edits, migration numbering/idempotency, Greptile 100-file limit), CONTRIBUTING.md flow, `/greploop` → `/prcheckloop` review loops, reporting/hand-off rules, and a hard never-merge rule

## Verification

- Docs-only change; no code paths affected. `git show --stat` confirms a single new markdown file (95 lines)
- Frontmatter (`name`, `description`) matches the convention of sibling skills (`.agents/skills/prcheckloop/SKILL.md`)
- Verified `server/src/__tests__/paperclip-skill-utils.test.ts` scopes bundled runtime skills to `./skills` and explicitly excludes `.agents/skills`, so no catalog/packaging test needs updating
- Imported the skill from this path into a live Paperclip instance via `POST /api/companies/:id/skills/import` and confirmed it registers as a `local_path` skill with slug `prepare-pr`

## Risks

- Low risk: a single new markdown file (force-added like its tracked siblings under the gitignored `/.agents/` path); no runtime, build, or test impact

## Model Used

- Claude Fable 5 (Anthropic, model id `claude-fable-5`), agentic coding session with extended thinking and tool use (Claude Agent SDK harness)

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass (docs-only; no tests apply)
- [x] I have added or updated tests where applicable (none applicable — docs-only)
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
