### PR TITLE
fix(environments): pass company context to sandbox probes

### DIFF
--- a/server/src/__tests__/environment-custom-images-service.test.ts
+++ b/server/src/__tests__/environment-custom-images-service.test.ts
@@ -459,6 +459,43 @@ describeEmbeddedPostgres("environmentCustomImageService", () => {
     });
   });
 
+  it("does not rewrite generic missing image setup failures as template conflicts", async () => {
+    const { environmentId } = await seed();
+    const workerManager = createWorkerManager();
+    workerManager.call.mockImplementation(async (_pluginId, method) => {
+      if (method === "environmentStartInteractiveSetup") {
+        throw new Error("Base image not found in registry");
+      }
+      throw new Error(`Unexpected plugin call: ${method}`);
+    });
+    const service = environmentCustomImageService(db, { pluginWorkerManager: workerManager });
+    const [template] = await db.insert(environmentCustomImageTemplates).values({
+      environmentId,
+      provider: "fake-plugin",
+      templateKind: "snapshot",
+      templateRef: "snapshot-valid",
+      status: "active",
+    }).returning();
+
+    await expect(service.startSetupSession({
+      environmentId,
+      templateId: template!.id,
+      actor: { userId: "user-1" },
+    })).rejects.toThrow("Base image not found in registry");
+
+    const [session] = await db
+      .select({
+        status: environmentCustomImageSetupSessions.status,
+        failureReason: environmentCustomImageSetupSessions.failureReason,
+      })
+      .from(environmentCustomImageSetupSessions)
+      .where(eq(environmentCustomImageSetupSessions.templateId, template!.id));
+    expect(session).toEqual({
+      status: "failed",
+      failureReason: "Base image not found in registry",
+    });
+  });
+
   it("applies the active template regardless of base-config changes and falls back when none exists", async () => {
     const { companyId, environmentId } = await seed();
     const environment = await db.select().from(environments).where(eq(environments.id, environmentId)).then((rows) => rows[0]!);

--- a/server/src/__tests__/environment-custom-images-service.test.ts
+++ b/server/src/__tests__/environment-custom-images-service.test.ts
@@ -419,6 +419,46 @@ describeEmbeddedPostgres("environmentCustomImageService", () => {
     })).rejects.toThrow("Setup template must be the active template");
   });
 
+  it("turns missing provider template setup failures into conflicts", async () => {
+    const { environmentId } = await seed();
+    const workerManager = createWorkerManager();
+    workerManager.call.mockImplementation(async (_pluginId, method) => {
+      if (method === "environmentStartInteractiveSetup") {
+        throw new Error("Snapshot not found");
+      }
+      throw new Error(`Unexpected plugin call: ${method}`);
+    });
+    const service = environmentCustomImageService(db, { pluginWorkerManager: workerManager });
+    const [template] = await db.insert(environmentCustomImageTemplates).values({
+      environmentId,
+      provider: "fake-plugin",
+      templateKind: "snapshot",
+      templateRef: "snapshot-missing",
+      status: "active",
+    }).returning();
+
+    await expect(service.startSetupSession({
+      environmentId,
+      templateId: template!.id,
+      actor: { userId: "user-1" },
+    })).rejects.toMatchObject({
+      status: 409,
+      message: expect.stringContaining("customImage template no longer exists"),
+    });
+
+    const [session] = await db
+      .select({
+        status: environmentCustomImageSetupSessions.status,
+        failureReason: environmentCustomImageSetupSessions.failureReason,
+      })
+      .from(environmentCustomImageSetupSessions)
+      .where(eq(environmentCustomImageSetupSessions.templateId, template!.id));
+    expect(session).toEqual({
+      status: "failed",
+      failureReason: "Selected provider template is missing.",
+    });
+  });
+
   it("applies the active template regardless of base-config changes and falls back when none exists", async () => {
     const { companyId, environmentId } = await seed();
     const environment = await db.select().from(environments).where(eq(environments.id, environmentId)).then((rows) => rows[0]!);

--- a/server/src/services/environment-custom-images.ts
+++ b/server/src/services/environment-custom-images.ts
@@ -185,6 +185,24 @@ function isActiveSetupStatus(status: EnvironmentCustomImageSetupSessionStatus): 
   return (ACTIVE_SETUP_STATUSES as readonly string[]).includes(status);
 }
 
+function providerErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function isProviderMissingTemplateError(error: unknown): boolean {
+  const message = providerErrorMessage(error).toLowerCase();
+  return (
+    (message.includes("snapshot") || message.includes("template") || message.includes("image"))
+    && (message.includes("not found") || message.includes("missing"))
+  );
+}
+
+function missingProviderTemplateConflict() {
+  return conflict(
+    "The selected environment customImage template no longer exists in the sandbox provider. Disable this custom image or roll back to a previous template, then start image setup again.",
+  );
+}
+
 function templateConfigBindingFromDriver(input: {
   templateRefKind?: string | null | undefined;
   templateConfigBinding?: unknown;
@@ -700,11 +718,17 @@ export function environmentCustomImageService(
           connectionPayload: providerSession.connectionPayload ?? null,
         };
       } catch (error) {
+        const failureReason = selectedTemplate && isProviderMissingTemplateError(error)
+          ? "Selected provider template is missing."
+          : providerErrorMessage(error);
         await markSessionStatus({
           sessionId,
           status: "failed",
-          failureReason: error instanceof Error ? error.message : String(error),
+          failureReason,
         });
+        if (selectedTemplate && isProviderMissingTemplateError(error)) {
+          throw missingProviderTemplateConflict();
+        }
         throw error;
       }
     },

--- a/server/src/services/environment-custom-images.ts
+++ b/server/src/services/environment-custom-images.ts
@@ -192,7 +192,7 @@ function providerErrorMessage(error: unknown): string {
 function isProviderMissingTemplateError(error: unknown): boolean {
   const message = providerErrorMessage(error).toLowerCase();
   return (
-    (message.includes("snapshot") || message.includes("template") || message.includes("image"))
+    (message.includes("snapshot") || message.includes("template"))
     && (message.includes("not found") || message.includes("missing"))
   );
 }

--- a/ui/src/api/environments.ts
+++ b/ui/src/api/environments.ts
@@ -65,7 +65,10 @@ export const environmentsApi = {
     config?: Record<string, unknown>;
     metadata?: Record<string, unknown> | null;
   }) => api.patch<Environment>(`/environments/${environmentId}`, body),
-  probe: (environmentId: string) => api.post<EnvironmentProbeResult>(`/environments/${environmentId}/probe`, {}),
+  probe: (environmentId: string, companyId?: string | null) => {
+    const query = companyId ? `?companyId=${encodeURIComponent(companyId)}` : "";
+    return api.post<EnvironmentProbeResult>(`/environments/${environmentId}/probe${query}`, {});
+  },
   probeConfig: (companyId: string, body: {
     name?: string;
     driver: "local" | "ssh" | "sandbox" | "plugin";

--- a/ui/src/pages/CompanyEnvironments.test.tsx
+++ b/ui/src/pages/CompanyEnvironments.test.tsx
@@ -485,7 +485,50 @@ describe("CompanyEnvironments — test provider button", () => {
     expect(buttonsAfter[0].disabled).toBe(true);
     expect(buttonsAfter[1].textContent?.trim()).toBe("Test provider");
     expect(buttonsAfter[1].disabled).toBe(false);
-    expect(mockEnvironmentsApi.probe).toHaveBeenCalledExactlyOnceWith("env-1");
+    expect(mockEnvironmentsApi.probe).toHaveBeenCalledExactlyOnceWith("env-1", "company-1");
+  });
+
+  it("explains that successful sandbox provider tests use a temporary sandbox", async () => {
+    root = createRoot(container);
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    mockEnvironmentsApi.list.mockResolvedValue([
+      { id: "env-1", name: "Daytona", driver: "sandbox", description: null, config: { provider: "daytona" } },
+    ]);
+    mockEnvironmentsApi.capabilities.mockResolvedValue(supportedDaytonaCapabilities());
+    mockEnvironmentsApi.probe.mockResolvedValue({
+      ok: true,
+      driver: "sandbox",
+      summary: "Connected to Daytona sandbox paperclip-probe.",
+      details: {
+        provider: "daytona",
+        diagnostics: [],
+        metadata: {
+          provider: "daytona",
+          sandboxId: "473167E9",
+          sandboxName: "paperclip-probe",
+        },
+      },
+    });
+
+    await act(async () => {
+      root!.render(
+        <QueryClientProvider client={queryClient}>
+          <TooltipProvider>
+            <CompanyEnvironments />
+          </TooltipProvider>
+        </QueryClientProvider>,
+      );
+    });
+    await flushReact();
+
+    await act(async () => {
+      testProviderButtons(container)[0].dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    await flushReact();
+
+    expect(mockEnvironmentsApi.probe).toHaveBeenCalledExactlyOnceWith("env-1", "company-1");
+    expect(container.textContent).toContain("Verified temporary daytona sandbox paperclip-probe (473167E9).");
+    expect(container.textContent).toContain("Test probes clean up the validation sandbox after the check");
   });
 
   it("keeps the second environment's testing state when an earlier probe settles", async () => {

--- a/ui/src/pages/CompanyEnvironments.test.tsx
+++ b/ui/src/pages/CompanyEnvironments.test.tsx
@@ -531,6 +531,50 @@ describe("CompanyEnvironments — test provider button", () => {
     expect(container.textContent).toContain("Test probes clean up the validation sandbox after the check");
   });
 
+  it("does not show sandbox lifecycle success copy for failed sandbox provider tests", async () => {
+    root = createRoot(container);
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    mockEnvironmentsApi.list.mockResolvedValue([
+      { id: "env-1", name: "Daytona", driver: "sandbox", description: null, config: { provider: "daytona" } },
+    ]);
+    mockEnvironmentsApi.capabilities.mockResolvedValue(supportedDaytonaCapabilities());
+    mockEnvironmentsApi.probe.mockResolvedValue({
+      ok: false,
+      driver: "sandbox",
+      summary: "Daytona sandbox probe failed.",
+      details: {
+        provider: "daytona",
+        error: "Sandbox image was not found.",
+        metadata: {
+          provider: "daytona",
+          sandboxId: "473167E9",
+          sandboxName: "paperclip-probe",
+        },
+      },
+    });
+
+    await act(async () => {
+      root!.render(
+        <QueryClientProvider client={queryClient}>
+          <TooltipProvider>
+            <CompanyEnvironments />
+          </TooltipProvider>
+        </QueryClientProvider>,
+      );
+    });
+    await flushReact();
+
+    await act(async () => {
+      testProviderButtons(container)[0].dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    await flushReact();
+
+    expect(container.textContent).toContain("Daytona sandbox probe failed.");
+    expect(container.textContent).toContain("Sandbox image was not found.");
+    expect(container.textContent).not.toContain("Verified temporary daytona sandbox");
+    expect(container.textContent).not.toContain("Test probes clean up the validation sandbox after the check");
+  });
+
   it("keeps the second environment's testing state when an earlier probe settles", async () => {
     root = createRoot(container);
     const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });

--- a/ui/src/pages/CompanyEnvironments.tsx
+++ b/ui/src/pages/CompanyEnvironments.tsx
@@ -215,7 +215,7 @@ function readStringValue(value: unknown): string | null {
 }
 
 function sandboxProbeLifecycleNote(probe: EnvironmentProbeResult): string | null {
-  if (probe.driver !== "sandbox") return null;
+  if (probe.driver !== "sandbox" || !probe.ok) return null;
   const metadata = readProbeMetadata(probe);
   const provider = readStringValue(metadata.provider) ?? readStringValue(readRecord(probe.details)?.provider) ?? "sandbox";
   const sandboxName = readStringValue(metadata.sandboxName);

--- a/ui/src/pages/CompanyEnvironments.tsx
+++ b/ui/src/pages/CompanyEnvironments.tsx
@@ -199,6 +199,36 @@ function readEnvironmentSandboxProvider(environment: Environment): string | null
     : null;
 }
 
+function readRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null;
+}
+
+function readProbeMetadata(probe: EnvironmentProbeResult): Record<string, unknown> {
+  const details = readRecord(probe.details);
+  return readRecord(details?.metadata) ?? {};
+}
+
+function readStringValue(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+function sandboxProbeLifecycleNote(probe: EnvironmentProbeResult): string | null {
+  if (probe.driver !== "sandbox") return null;
+  const metadata = readProbeMetadata(probe);
+  const provider = readStringValue(metadata.provider) ?? readStringValue(readRecord(probe.details)?.provider) ?? "sandbox";
+  const sandboxName = readStringValue(metadata.sandboxName);
+  const sandboxId = readStringValue(metadata.sandboxId);
+  const sandboxLabel = sandboxName && sandboxId
+    ? `${sandboxName} (${sandboxId})`
+    : sandboxName ?? sandboxId;
+  const base = sandboxLabel
+    ? `Verified temporary ${provider} sandbox ${sandboxLabel}.`
+    : `Verified a temporary ${provider} sandbox.`;
+  return `${base} Test probes clean up the validation sandbox after the check, so it may not remain visible in the provider dashboard.`;
+}
+
 function formatDateTime(value: string | Date | null | undefined): string | null {
   if (!value) return null;
   const date = value instanceof Date ? value : new Date(value);
@@ -1150,7 +1180,7 @@ export function CompanyEnvironments() {
   });
 
   const environmentProbeMutation = useMutation({
-    mutationFn: async (environmentId: string) => await environmentsApi.probe(environmentId),
+    mutationFn: async (environmentId: string) => await environmentsApi.probe(environmentId, selectedCompanyId),
     onMutate: (environmentId) => {
       setTestingEnvironmentId(environmentId);
     },
@@ -1409,6 +1439,7 @@ export function CompanyEnvironments() {
           </div>
           {savedEnvironments.map((environment) => {
             const probe = probeResults[environment.id] ?? null;
+            const sandboxLifecycleNote = probe ? sandboxProbeLifecycleNote(probe) : null;
             const isEditing = editingEnvironmentId === environment.id;
             const sandboxProvider = readEnvironmentSandboxProvider(environment);
             const sandboxProviderCapability = sandboxProvider
@@ -1478,6 +1509,9 @@ export function CompanyEnvironments() {
                     }
                   >
                     <div className="font-medium">{probe.summary}</div>
+                    {sandboxLifecycleNote ? (
+                      <div className="mt-1 text-muted-foreground">{sandboxLifecycleNote}</div>
+                    ) : null}
                     {probe.details?.error && typeof probe.details.error === "string" ? (
                       <div className="mt-1 font-mono text-(length:--text-micro)">{probe.details.error}</div>
                     ) : null}


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Environment configuration controls where agent runs and setup probes execute.
> - Saved environment probes need the same company context as environment detail probes so company-scoped sandbox secrets and bindings resolve consistently.
> - Sandbox custom images can also become stale when an image/template is refreshed outside Paperclip, and that should produce an actionable conflict rather than an opaque provider failure.
> - This pull request aligns index-page environment tests with detail-page behavior and makes missing provider templates explicit.
> - The benefit is that operators can test saved sandbox environments from the index reliably and get clearer guidance when a refreshed sandbox image invalidates the selected template.

## Linked Issues or Issue Description

No public GitHub issue exists.

### Pre-submission Checklist

- Existing open and closed public GitHub issues/PRs were searched for `environment sandbox probe`; related sandbox/custom-image history exists, but no duplicate for this specific saved-environment probe company-context bug was found.
- This is reproduced and fixed against current `master`.
- The error originates in Paperclip environment probing/setup behavior, not a specific agent adapter.

### What Happened?

Testing a saved sandbox environment from the environments index could fail even though testing the same environment from the detail page worked. The index-page probe did not pass selected company context, so company-scoped sandbox configuration and secret bindings could resolve differently than the detail-page flow.

Separately, when a selected custom-image provider template was deleted or refreshed out-of-band, setup failed with a low-level missing snapshot/template/image provider error instead of telling the operator that the selected template no longer exists.

### Expected Behavior

- Saved-environment probes from the environments index should pass the selected company context, matching environment detail behavior.
- Successful sandbox probes should explain that Paperclip used a temporary validation sandbox that may be cleaned up after the check.
- Missing provider templates during custom-image setup should return an actionable conflict and mark the setup session failed with a stable reason.

### Steps To Reproduce

1. Create or select a company-scoped sandbox environment with provider configuration or secret bindings that require company context.
2. Run the saved environment test from the environments index.
3. Compare with testing the same environment from the environment detail page.
4. For the custom-image path, refresh/delete the selected provider template out-of-band, then start setup from the stale selected template.

### Paperclip Version Or Commit

`master` at commit `4d898aa7a` plus this PR commit.

### Deployment Mode

Local dev (`pnpm dev`) / built from source.

### Installation Method

Built from source.

### Agent Adapters Involved

Not adapter-specific; core environment and sandbox-provider behavior.

### Database Mode

Embedded PGlite or external Postgres; no schema changes.

### Access Context

Board operator UI.

### Logs Or Output

Missing provider template errors commonly surface as provider messages containing missing/not-found snapshot, template, or image text. This PR maps those setup failures to a `409 Conflict` with an operator-facing message.

### Relevant Config

Sandbox environment config with company-scoped provider configuration or secret bindings. No secrets are included in this PR.

### Additional Context

Related public history includes reusable sandbox custom images and sandbox probe work, but this PR is scoped to saved-environment probing and missing-template setup behavior.

### Privacy Checklist

- Pasted output was reviewed for PII, credentials, tokens, and private local paths.

## What Changed

- Pass selected company context when probing saved environments from the environments index.
- Show a sandbox lifecycle note after successful sandbox probes so operators know the temporary validation sandbox may be cleaned up and absent from the provider dashboard.
- Convert missing provider template setup failures into `409 Conflict` responses with an actionable message and a stable failed setup-session reason.
- Added UI and service coverage for the saved-environment probe company context, sandbox lifecycle copy, and missing provider template conflicts.

## Verification

- `rg -n "(sk-[A-Za-z0-9_-]{20,}|ghp_[A-Za-z0-9_]{20,}|github_pat_[A-Za-z0-9_]+|AKIA[0-9A-Z]{16}|-----BEGIN [A-Z ]*PRIVATE KEY-----|PAPERCLIP_API_KEY|Authorization: Bearer|password|secret|token)" server/src/services/environment-custom-images.ts ui/src/api/environments.ts ui/src/pages/CompanyEnvironments.tsx server/src/__tests__/environment-custom-images-service.test.ts ui/src/pages/CompanyEnvironments.test.tsx`
- `git diff --check`
- `pnpm vitest run ui/src/pages/CompanyEnvironments.test.tsx`
- `pnpm vitest run server/src/__tests__/environment-custom-images-service.test.ts`
- `pnpm check:token-gates`
- `TMPDIR=/private/tmp pnpm -r typecheck` (required escalation locally because sandbox denied `tsx` IPC sockets)
- `TMPDIR=/private/tmp pnpm build` (required escalation locally because sandbox denied `tsx` IPC sockets)
- `TMPDIR=/private/tmp pnpm test:run` was run under escalation and failed in unrelated heartbeat/worktree suites:
- `server/src/__tests__/heartbeat-workspace-branch-containment.test.ts`: two providerRef assertions differed only by `/tmp/...` vs `/private/tmp/...` under the local temp-dir workaround.
- `server/src/__tests__/heartbeat-worktree-suppression.test.ts`: `still creates live-plane assignment runs when suppression is not active` expected one heartbeat run but saw two, followed by test cleanup FK fallout.

## Risks

Low to medium risk. The UI API change is narrow and preserves the previous probe call shape when no company is selected. The server conflict detection intentionally matches common missing snapshot/template/image provider messages; providers with unusual wording may still surface their original error.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

OpenAI GPT-5 via Codex CLI with repository tool use and local command execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge
