### PR TITLE
fix(server): enrich issue boundary 403 responses

### DIFF
--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -9,6 +9,9 @@ const ownerAgentId = "33333333-3333-4333-8333-333333333333";
 const peerAgentId = "44444444-4444-4444-8444-444444444444";
 const ownerRunId = "55555555-5555-4555-8555-555555555555";
 const recoveryActionId = "77777777-7777-4777-8777-777777777777";
+const issueBoundaryError = "Issue is outside this actor's authorization boundary";
+const issueBoundaryHint =
+  "Do not retry. Route instead: create a child issue assigned to the owner, comment on your own issue naming the ask, or open an issue-thread interaction for board escalation.";
 
 const mockIssueService = vi.hoisted(() => ({
   addComment: vi.fn(),
@@ -354,6 +357,14 @@ function boardActor() {
     source: "local_implicit",
     isInstanceAdmin: false,
   };
+}
+
+function expectIssueBoundaryDenied(body: Record<string, unknown>, reason: string) {
+  expect(body).toEqual({
+    error: issueBoundaryError,
+    reason,
+    hint: issueBoundaryHint,
+  });
 }
 
 describe("agent issue mutation checkout ownership", () => {
@@ -805,7 +816,26 @@ describe("agent issue mutation checkout ownership", () => {
       .send({ body: "I was not mentioned." });
 
     expect(res.status, JSON.stringify(res.body)).toBe(403);
-    expect(res.body.error).toBe("Issue is outside this actor's authorization boundary");
+    expectIssueBoundaryDenied(res.body, "deny_missing_grant");
+    expect(mockIssueService.addComment).not.toHaveBeenCalled();
+  });
+
+  it("passes through the issue mutate denial reason for peer agents", async () => {
+    mockIssueService.getById.mockResolvedValue(makeIssue({ status: "todo", assigneeAgentId: ownerAgentId }));
+    mockAccessService.decide.mockImplementation(async (input: { action: string }) => ({
+      allowed: input.action !== "issue:mutate",
+      action: input.action,
+      reason: input.action === "issue:mutate" ? "deny_scope" : "allow_explicit_grant",
+      explanation: input.action === "issue:mutate" ? "Issue is outside scope." : "Allowed by test default.",
+    }));
+
+    const res = await request(await createApp(peerActor()))
+      .patch(`/api/issues/${issueId}`)
+      .send({ status: "done" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(403);
+    expectIssueBoundaryDenied(res.body, "deny_scope");
+    expect(mockIssueService.update).not.toHaveBeenCalled();
     expect(mockIssueService.addComment).not.toHaveBeenCalled();
   });
 
@@ -821,7 +851,7 @@ describe("agent issue mutation checkout ownership", () => {
       .get(`/api/issues/${issueId}/comments`);
 
     expect(res.status, JSON.stringify(res.body)).toBe(403);
-    expect(res.body.error).toBe("Issue is outside this actor's authorization boundary");
+    expectIssueBoundaryDenied(res.body, "deny_low_trust_boundary");
     expect(mockAccessService.decide).toHaveBeenCalledWith(expect.objectContaining({ action: "issue:read" }));
   });
 
@@ -837,7 +867,7 @@ describe("agent issue mutation checkout ownership", () => {
       .get(`/api/issues/${issueId}/interactions`);
 
     expect(res.status, JSON.stringify(res.body)).toBe(403);
-    expect(res.body.error).toBe("Issue is outside this actor's authorization boundary");
+    expectIssueBoundaryDenied(res.body, "deny_low_trust_boundary");
     expect(mockAccessService.decide).toHaveBeenCalledWith(expect.objectContaining({ action: "issue:read" }));
     expect(mockIssueThreadInteractionService.listForIssue).not.toHaveBeenCalled();
   });
@@ -883,7 +913,7 @@ describe("agent issue mutation checkout ownership", () => {
       .get(`/api/issues/${issueId}/comments/comment-1`);
 
     expect(res.status, JSON.stringify(res.body)).toBe(403);
-    expect(res.body.error).toBe("Issue is outside this actor's authorization boundary");
+    expectIssueBoundaryDenied(res.body, "deny_low_trust_boundary");
     expect(mockAccessService.decide).toHaveBeenCalledWith(expect.objectContaining({ action: "issue:read" }));
     expect(mockIssueService.getComment).not.toHaveBeenCalled();
   });

--- a/server/src/__tests__/issue-comment-reopen-routes.test.ts
+++ b/server/src/__tests__/issue-comment-reopen-routes.test.ts
@@ -635,7 +635,11 @@ describe.sequential("issue comment reopen routes", () => {
         .send({ body: "Please continue this closed issue.", ...intent });
 
       expect(res.status, JSON.stringify(res.body)).toBe(403);
-      expect(res.body).toEqual({ error: "Issue is outside this actor's authorization boundary" });
+      expect(res.body).toEqual({
+        error: "Issue is outside this actor's authorization boundary",
+        reason: "deny_missing_grant",
+        hint: "Do not retry. Route instead: create a child issue assigned to the owner, comment on your own issue naming the ask, or open an issue-thread interaction for board escalation.",
+      });
       expect(mockAccessService.decide).toHaveBeenCalledWith(expect.objectContaining({ action: "issue:comment" }));
       expect(mockAccessService.decide).toHaveBeenCalledWith(expect.objectContaining({ action: "issue:mutate" }));
       expect(mockIssueService.update).not.toHaveBeenCalled();

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -153,7 +153,7 @@ import {
   ISSUE_WAKE_DIAGNOSTICS_MAX_WAKE_REQUESTS,
   readAcceptedPlanConfirmationTarget,
 } from "../services/issues.js";
-import { authorizationDeniedDetails } from "../services/authorization.js";
+import { authorizationDeniedDetails, type AuthorizationDecision } from "../services/authorization.js";
 import { environmentService } from "../services/environments.js";
 import { environmentRuntimeService } from "../services/environment-runtime.js";
 import { redactSensitiveText } from "../redaction.js";
@@ -185,6 +185,9 @@ import {
 import { externalObjectService } from "../services/external-objects.js";
 
 const MAX_ISSUE_COMMENT_LIMIT = 500;
+const ISSUE_AUTHORIZATION_BOUNDARY_ERROR = "Issue is outside this actor's authorization boundary";
+const ISSUE_AUTHORIZATION_BOUNDARY_HINT =
+  "Do not retry. Route instead: create a child issue assigned to the owner, comment on your own issue naming the ask, or open an issue-thread interaction for board escalation.";
 const updateIssueRouteSchema = updateIssueSchema.extend({
   interrupt: z.boolean().optional(),
 });
@@ -3282,8 +3285,16 @@ export function issueRoutes(
   async function assertIssueReadAllowed(req: Request, res: Response, issue: Parameters<typeof decideIssueAccess>[1]) {
     const decision = await decideIssueAccess(req, issue, "issue:read");
     if (decision.allowed) return true;
-    res.status(403).json({ error: "Issue is outside this actor's authorization boundary" });
+    sendIssueAuthorizationBoundaryDenied(res, decision);
     return false;
+  }
+
+  function sendIssueAuthorizationBoundaryDenied(res: Response, decision: AuthorizationDecision) {
+    res.status(403).json({
+      error: ISSUE_AUTHORIZATION_BOUNDARY_ERROR,
+      reason: decision.reason,
+      hint: ISSUE_AUTHORIZATION_BOUNDARY_HINT,
+    });
   }
 
   async function assertAgentIssueCommentAllowed(
@@ -3322,7 +3333,7 @@ export function issueRoutes(
     }
     const boundaryDecision = await decideIssueAccess(req, issue, "issue:comment");
     if (!boundaryDecision.allowed) {
-      res.status(403).json({ error: "Issue is outside this actor's authorization boundary" });
+      sendIssueAuthorizationBoundaryDenied(res, boundaryDecision);
       return false;
     }
     return boundaryDecision;
@@ -3411,7 +3422,7 @@ export function issueRoutes(
     }
     const boundaryDecision = await decideIssueAccess(req, issue, "issue:mutate");
     if (!boundaryDecision.allowed) {
-      res.status(403).json({ error: "Issue is outside this actor's authorization boundary" });
+      sendIssueAuthorizationBoundaryDenied(res, boundaryDecision);
       return false;
     }
     if (issue.assigneeAgentId === null) {

--- a/skills/paperclip/SKILL.md
+++ b/skills/paperclip/SKILL.md
@@ -301,6 +301,7 @@ For commands, response fields, and MCP tools, read:
 ## Critical Rules
 
 - **Never retry a 409.** The task belongs to someone else.
+- **403 boundary -> never retry; follow the hint in the error body.**
 - **Never look for unassigned work.** No assignments = exit.
 - **Self-assign only for explicit @-mention handoff.** Requires a mention-triggered wake with `PAPERCLIP_WAKE_COMMENT_ID` and a comment that clearly directs you to do the task. Use checkout (never direct assignee patch).
 - **Honor "send it back to me" requests from board users.** If a board/user asks for review handoff (e.g. "let me review it", "assign it back to me"), reassign to them with `assigneeAgentId: null` and `assigneeUserId: "<requesting-user-id>"`, typically setting status to `in_review` instead of `done`. Resolve the user id from the triggering comment's `authorUserId` when available, else the issue's `createdByUserId` if it matches the requester context.


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The issue route subsystem enforces agent authorization boundaries for reads, comments, and mutations.
> - The access engine already returns structured deny reasons, but the route layer flattened several boundary denials into an opaque 403 response.
> - Opaque 403s make it harder for agent harnesses and clients to distinguish retryable failures from policy boundaries.
> - This pull request keeps authorization enforcement centralized and enriches the existing denied response with the engine's machine-readable reason plus a routing hint.
> - The benefit is clearer non-retry guidance for agent clients without adding fetch-before-write probing or happy-path request cost.

## Linked Issues or Issue Description

No public GitHub issue exists for this change.

Problem: agent clients can receive an opaque `403` from issue read/comment/mutate routes when the server authorization boundary denies access. The access service already computes structured deny reasons, but those reasons were discarded at the route response boundary. This change exposes the deny reason and a safe routing hint in the existing 403 body.

Related PR search checked: no duplicate PR found for enriching issue-boundary 403 bodies. Related auth-boundary work includes #8343, #8640, #8024, #8346, and #4873.

## What Changed

- Added a shared issue-boundary denial response helper that returns `error`, `reason`, and `hint` for issue read/comment/mutate 403s.
- Passed through `AuthorizationDecision.reason` instead of flattening all boundary denials to an opaque string.
- Added focused route coverage for distinct deny reasons on comment/read/mutate paths and preserved the existing happy-path mention grant behavior.
- Added the one-line Paperclip skill guidance for 403 boundary responses.

## Verification

- `pnpm vitest run server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts server/src/__tests__/issue-comment-reopen-routes.test.ts` passed: 2 files, 139 tests.
- `pnpm --filter @paperclipai/server typecheck` passed with exit code 0.
- `git diff --check` passed with exit code 0.

## Risks

Low risk. The change only adds fields to existing 403 JSON bodies for issue-boundary denials and leaves the access decision flow unchanged. Clients that require an exact response object for these 403s may need to tolerate the additional fields.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

OpenAI Codex, GPT-5-based coding agent with shell/tool access in an isolated Paperclip worktree.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
