### PR TITLE
Preserve built-in agent assets in server builds

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -35,7 +35,7 @@
     "dev": "tsx src/index.ts",
     "dev:watch": "cross-env PAPERCLIP_MIGRATION_PROMPT=never PAPERCLIP_MIGRATION_AUTO_APPLY=true tsx ./scripts/dev-watch.ts",
     "prepare:ui-dist": "bash ../scripts/prepare-server-ui-dist.sh",
-    "build": "tsc && mkdir -p dist/onboarding-assets && cp -R src/onboarding-assets/. dist/onboarding-assets/",
+    "build": "tsc && mkdir -p dist/onboarding-assets dist/built-ins && cp -R src/onboarding-assets/. dist/onboarding-assets/ && cp -R src/built-ins/. dist/built-ins/",
     "prepack": "pnpm run prepare:ui-dist",
     "postpack": "rm -rf ui-dist",
     "clean": "rm -rf dist",

--- a/server/src/__tests__/server-package-build-script.test.ts
+++ b/server/src/__tests__/server-package-build-script.test.ts
@@ -1,0 +1,19 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const packageJsonPath = fileURLToPath(new URL("../../package.json", import.meta.url));
+
+describe("server package build script", () => {
+  it("copies static runtime asset directories into dist", () => {
+    const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf8")) as {
+      scripts?: Record<string, string>;
+    };
+    const buildScript = packageJson.scripts?.build ?? "";
+
+    expect(buildScript).toContain("dist/onboarding-assets");
+    expect(buildScript).toContain("cp -R src/onboarding-assets/. dist/onboarding-assets/");
+    expect(buildScript).toContain("dist/built-ins");
+    expect(buildScript).toContain("cp -R src/built-ins/. dist/built-ins/");
+  });
+});

--- a/server/src/__tests__/server-package-build-script.test.ts
+++ b/server/src/__tests__/server-package-build-script.test.ts
@@ -11,9 +11,8 @@ describe("server package build script", () => {
     };
     const buildScript = packageJson.scripts?.build ?? "";
 
-    expect(buildScript).toContain("dist/onboarding-assets");
+    expect(buildScript).toContain("mkdir -p dist/onboarding-assets dist/built-ins");
     expect(buildScript).toContain("cp -R src/onboarding-assets/. dist/onboarding-assets/");
-    expect(buildScript).toContain("dist/built-ins");
     expect(buildScript).toContain("cp -R src/built-ins/. dist/built-ins/");
   });
 });


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The server package ships compiled runtime code plus static runtime assets.
> - Built-in agent definitions live under `server/src/built-ins` and runtime code resolves them relative to compiled server files.
> - The server build already copied onboarding assets into `dist`, but it did not copy built-in agent assets alongside the compiled code.
> - Packaged server builds could therefore miss built-in agent definitions even though source-based development runs worked.
> - This pull request extends the server build copy step to preserve built-in agent assets in `dist/built-ins`.
> - The benefit is packaged server builds keep the same built-in agent runtime assets available as source-based development runs.

## Linked Issues or Issue Description

No public GitHub issue found. This PR describes the underlying bug inline using the bug report template fields.

### What happened?

`@paperclipai/server` build output copied `server/src/onboarding-assets` into `server/dist/onboarding-assets`, but did not copy `server/src/built-ins` into `server/dist/built-ins`. Runtime code for built-in agents resolves those assets relative to the compiled server files, so packaged builds could omit built-in agent markdown assets that are present during source-based development.

### Expected behavior

Packaged server builds should include built-in agent assets under `server/dist/built-ins`, matching the runtime location expected by the compiled server code.

### Steps to reproduce

1. Check out current `master` before this PR.
2. Run `pnpm --filter @paperclipai/server build`.
3. Check for `server/dist/built-ins/agents/reflection-coach/AGENTS.md`.
4. Observe that the built-in agent asset is missing from the server build output.

### Paperclip version or commit

Reproduces on current `master` before this PR. The fix is verified on commit `2b89984ccb7857f06359bf65c48222f110c7aeff`.

### Deployment mode

Build/package artifact behavior. This can affect any deployment mode that runs from the built server package rather than directly from source.

### Installation method

Built from source with `pnpm --filter @paperclipai/server build`.

### Agent adapter(s) involved

Not adapter-specific. This is a core server packaging bug for built-in agent assets.

### Database mode

Not database-related.

### Access context

Not applicable. This happens during package build output generation.

Related search:

- Searched public PRs/issues for `built-ins build copy repo:paperclipai/paperclip`.
- Found no directly related open issue. One old closed Hermes adapter PR was not directly related.

## What Changed

- Updated the `@paperclipai/server` build script to create `dist/built-ins`.
- Added the copy step from `server/src/built-ins` into `server/dist/built-ins` alongside the existing onboarding asset copy.
- Added a focused server package build-script test that asserts both onboarding and built-in static runtime asset directories are copied into `dist`.

## Verification

- `pnpm exec vitest run server/src/__tests__/server-package-build-script.test.ts`
- `pnpm --filter @paperclipai/server build`
- `test -f server/dist/built-ins/agents/reflection-coach/AGENTS.md`

## Risks

Low risk. This changes only the package build asset copy step and adds focused test coverage. The main risk is build-script portability, but it follows the existing `mkdir -p` and `cp -R` pattern already used for onboarding assets.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

OpenAI Codex, GPT-5-based coding agent in a tool-enabled Paperclip heartbeat. Exact model ID and context-window size are not exposed in this runtime.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
