### PR TITLE
Add token run reporting endpoints

### DIFF
--- a/server/src/__tests__/costs-service.test.ts
+++ b/server/src/__tests__/costs-service.test.ts
@@ -13,6 +13,8 @@ import {
   heartbeatRuns,
   issues,
   projects,
+  routineRuns,
+  routines,
 } from "@paperclipai/db";
 import { costService } from "../services/costs.ts";
 import { financeService } from "../services/finance.ts";
@@ -83,6 +85,8 @@ const mockCostService = vi.hoisted(() => ({
     runtimeMs: 0,
   }),
   windowSpend: vi.fn().mockResolvedValue([]),
+  topRuns: vi.fn().mockResolvedValue([]),
+  zeroTokenFailedRuns: vi.fn().mockResolvedValue([]),
   byProject: vi.fn().mockResolvedValue([]),
 }));
 const mockFinanceService = vi.hoisted(() => ({
@@ -270,6 +274,33 @@ describe("cost routes", () => {
     });
   });
 
+  it("returns compact top token runs", async () => {
+    mockCostService.topRuns.mockResolvedValueOnce([{ heartbeatRunId: "run-1", totalTokens: 123 }]);
+    const app = await createApp();
+    const res = await request(app)
+      .get("/api/companies/company-1/costs/top-runs")
+      .query({ from: "2026-02-01T00:00:00.000Z", to: "2026-02-28T23:59:59.999Z", limit: "10" });
+
+    expect(res.status).toBe(200);
+    expect(mockCostService.topRuns).toHaveBeenCalledWith("company-1", {
+      from: new Date("2026-02-01T00:00:00.000Z"),
+      to: new Date("2026-02-28T23:59:59.999Z"),
+    }, 10);
+    expect(res.body).toEqual([{ heartbeatRunId: "run-1", totalTokens: 123 }]);
+  });
+
+  it("returns zero-token failed runs", async () => {
+    mockCostService.zeroTokenFailedRuns.mockResolvedValueOnce([{ heartbeatRunId: "run-2", errorCode: "adapter_failed" }]);
+    const app = await createApp();
+    const res = await request(app)
+      .get("/api/companies/company-1/costs/zero-token-failed-runs")
+      .query({ limit: "5" });
+
+    expect(res.status).toBe(200);
+    expect(mockCostService.zeroTokenFailedRuns).toHaveBeenCalledWith("company-1", undefined, 5);
+    expect(res.body).toEqual([{ heartbeatRunId: "run-2", errorCode: "adapter_failed" }]);
+  });
+
   it("returns 400 for invalid finance event list limits", async () => {
     const { parseCostLimit } = await loadCostParsers();
     expect(() => parseCostLimit({ limit: "0" })).toThrow(/invalid 'limit'/i);
@@ -420,6 +451,8 @@ describeEmbeddedPostgres("cost and finance aggregate overflow handling", () => {
   afterEach(async () => {
     await db.delete(financeEvents);
     await db.delete(costEvents);
+    await db.delete(routineRuns);
+    await db.delete(routines);
     await db.delete(activityLog);
     await db.delete(heartbeatRuns);
     await db.delete(issues);
@@ -505,6 +538,161 @@ describeEmbeddedPostgres("cost and finance aggregate overflow handling", () => {
     expect(byAgentRow?.inputTokens).toBe(4_000_000_000);
     expect(byProjectRow?.costCents).toBe(4_000_000_000);
     expect(byAgentModelRow?.costCents).toBe(4_000_000_000);
+  });
+
+  it("ranks top runs by tokens and lists zero-token failed runs separately", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const projectId = randomUUID();
+    const issueId = randomUUID();
+    const routineId = randomUUID();
+    const highRunId = randomUUID();
+    const lowRunId = randomUUID();
+    const failedRunId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Cost Agent",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    await db.insert(projects).values({
+      id: projectId,
+      companyId,
+      name: "Token Project",
+      status: "active",
+    });
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      projectId,
+      title: "Routine issue",
+      status: "in_progress",
+      priority: "medium",
+      issueNumber: 10,
+      identifier: "TST-10",
+    });
+    await db.insert(routines).values({
+      id: routineId,
+      companyId,
+      projectId,
+      title: "Daily report",
+      status: "active",
+    });
+    await db.insert(heartbeatRuns).values([
+      {
+        id: highRunId,
+        companyId,
+        agentId,
+        invocationSource: "routine",
+        status: "succeeded",
+        createdAt: new Date("2026-04-10T00:00:00.000Z"),
+        startedAt: new Date("2026-04-10T00:00:00.000Z"),
+        finishedAt: new Date("2026-04-10T00:01:00.000Z"),
+        contextSnapshot: { issueId, wakeReason: "routine_triggered" },
+        resultJson: { summary: "Published token report." },
+      },
+      {
+        id: lowRunId,
+        companyId,
+        agentId,
+        invocationSource: "assignment",
+        status: "succeeded",
+        createdAt: new Date("2026-04-10T00:05:00.000Z"),
+      },
+      {
+        id: failedRunId,
+        companyId,
+        agentId,
+        invocationSource: "source_scoped_recovery_action",
+        status: "failed",
+        errorCode: "adapter_failed",
+        error: "Adapter failed before model usage.",
+        createdAt: new Date("2026-04-10T00:10:00.000Z"),
+      },
+    ]);
+    await db.insert(routineRuns).values({
+      companyId,
+      routineId,
+      source: "schedule",
+      status: "completed",
+      linkedIssueId: issueId,
+      triggeredAt: new Date("2026-04-10T00:00:00.000Z"),
+    });
+    await db.insert(costEvents).values([
+      {
+        companyId,
+        agentId,
+        issueId,
+        projectId,
+        heartbeatRunId: highRunId,
+        provider: "openai",
+        biller: "chatgpt",
+        billingType: "subscription_included",
+        model: "gpt-5.5",
+        inputTokens: 1000,
+        cachedInputTokens: 800,
+        outputTokens: 50,
+        costCents: 0,
+        occurredAt: new Date("2026-04-10T00:00:30.000Z"),
+      },
+      {
+        companyId,
+        agentId,
+        heartbeatRunId: lowRunId,
+        provider: "openai",
+        biller: "chatgpt",
+        billingType: "subscription_included",
+        model: "gpt-5.5",
+        inputTokens: 10,
+        cachedInputTokens: 1,
+        outputTokens: 2,
+        costCents: 0,
+        occurredAt: new Date("2026-04-10T00:05:30.000Z"),
+      },
+    ]);
+
+    const range = {
+      from: new Date("2026-04-10T00:00:00.000Z"),
+      to: new Date("2026-04-10T23:59:59.999Z"),
+    };
+
+    const topRuns = await costs.topRuns(companyId, range, 2);
+    expect(topRuns.map((row) => row.heartbeatRunId)).toEqual([highRunId, lowRunId]);
+    expect(topRuns[0]).toMatchObject({
+      agentName: "Cost Agent",
+      issueIdentifier: "TST-10",
+      projectName: "Token Project",
+      routineId,
+      routineTitle: "Daily report",
+      costCents: 0,
+      inputTokens: 1000,
+      cachedInputTokens: 800,
+      uncachedInputTokens: 200,
+      outputTokens: 50,
+      totalTokens: 1050,
+      resultSummary: "Published token report.",
+    });
+
+    const failedRuns = await costs.zeroTokenFailedRuns(companyId, range, 5);
+    expect(failedRuns).toHaveLength(1);
+    expect(failedRuns[0]).toMatchObject({
+      heartbeatRunId: failedRunId,
+      agentName: "Cost Agent",
+      errorCode: "adapter_failed",
+      error: "Adapter failed before model usage.",
+    });
   });
 
   it("aggregates issue costs across recursive descendants only", async () => {

--- a/server/src/__tests__/heartbeat-list.test.ts
+++ b/server/src/__tests__/heartbeat-list.test.ts
@@ -224,6 +224,59 @@ describeEmbeddedPostgres("heartbeat list", () => {
     });
   });
 
+  it("filters company run lists by created date range", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const oldRunId = randomUUID();
+    const newRunId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "CodexCoder",
+      role: "engineer",
+      status: "running",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    await db.insert(heartbeatRuns).values([
+      {
+        id: oldRunId,
+        companyId,
+        agentId,
+        invocationSource: "assignment",
+        status: "succeeded",
+        createdAt: new Date("2026-04-10T00:00:00.000Z"),
+      },
+      {
+        id: newRunId,
+        companyId,
+        agentId,
+        invocationSource: "assignment",
+        status: "succeeded",
+        createdAt: new Date("2026-04-11T00:00:00.000Z"),
+      },
+    ]);
+
+    const runs = await heartbeatService(db).list(companyId, undefined, 10, {
+      from: new Date("2026-04-10T12:00:00.000Z"),
+      to: new Date("2026-04-11T12:00:00.000Z"),
+      summary: true,
+    });
+
+    expect(runs.map((run) => run.id)).toEqual([newRunId]);
+  });
+
   it("bounds oversized legacy result json payloads on getRun", async () => {
     const companyId = randomUUID();
     const agentId = randomUUID();

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -120,6 +120,17 @@ function readLiveRunsQueryInt(value: unknown, max: number, fallback = 0) {
   return Math.min(max, Math.trunc(parsed));
 }
 
+function readOptionalDateQuery(value: unknown, name: string, res: Response) {
+  const raw = Array.isArray(value) ? value[0] : value;
+  if (raw == null || raw === "") return null;
+  const date = new Date(String(raw));
+  if (!Number.isFinite(date.getTime())) {
+    res.status(400).json({ error: `invalid '${name}' date` });
+    return false;
+  }
+  return date;
+}
+
 function readRunIssueId(context: Record<string, unknown> | null) {
   const directIssueId = context?.issueId;
   if (typeof directIssueId === "string" && isUuidLike(directIssueId)) return directIssueId;
@@ -3462,7 +3473,15 @@ export function agentRoutes(
     const limitParam = req.query.limit as string | undefined;
     const limit = limitParam ? Math.max(1, Math.min(1000, parseInt(limitParam, 10) || 200)) : undefined;
     const summary = req.query.summary === "true" || req.query.summary === "1";
-    const runs = await heartbeat.list(companyId, agentId, limit, { summary });
+    const from = readOptionalDateQuery(req.query.from, "from", res);
+    if (from === false) return;
+    const to = readOptionalDateQuery(req.query.to, "to", res);
+    if (to === false) return;
+    const runs = await heartbeat.list(companyId, agentId, limit, {
+      summary,
+      from: from ?? undefined,
+      to: to ?? undefined,
+    });
     res.json(runs);
   });
 

--- a/server/src/routes/costs.ts
+++ b/server/src/routes/costs.ts
@@ -274,6 +274,26 @@ export function costRoutes(
     res.json(rows);
   });
 
+  router.get("/companies/:companyId/costs/top-runs", async (req, res) => {
+    const companyId = req.params.companyId as string;
+    assertCompanyAccess(req, companyId);
+    if (!(await assertCompanyCostReadAllowed(req, res, companyId))) return;
+    const range = parseCostDateRange(req.query);
+    const limit = parseCostLimit(req.query);
+    const rows = await costs.topRuns(companyId, range, limit);
+    res.json(rows);
+  });
+
+  router.get("/companies/:companyId/costs/zero-token-failed-runs", async (req, res) => {
+    const companyId = req.params.companyId as string;
+    assertCompanyAccess(req, companyId);
+    if (!(await assertCompanyCostReadAllowed(req, res, companyId))) return;
+    const range = parseCostDateRange(req.query);
+    const limit = parseCostLimit(req.query);
+    const rows = await costs.zeroTokenFailedRuns(companyId, range, limit);
+    res.json(rows);
+  });
+
   router.get("/companies/:companyId/costs/quota-windows", async (req, res) => {
     const companyId = req.params.companyId as string;
     assertCompanyAccess(req, companyId);

--- a/server/src/services/costs.ts
+++ b/server/src/services/costs.ts
@@ -1,7 +1,17 @@
 import { and, desc, eq, gte, isNotNull, isNull, lt, lte, sql } from "drizzle-orm";
 import { alias } from "drizzle-orm/pg-core";
 import type { Db } from "@paperclipai/db";
-import { activityLog, agents, companies, costEvents, heartbeatRuns, issues, projects } from "@paperclipai/db";
+import {
+  activityLog,
+  agents,
+  companies,
+  costEvents,
+  heartbeatRuns,
+  issues,
+  projects,
+  routineRuns,
+  routines,
+} from "@paperclipai/db";
 import { notFound, unprocessable } from "../errors.js";
 import { budgetService, type BudgetServiceHooks } from "./budgets.js";
 
@@ -15,6 +25,20 @@ const SUBSCRIPTION_BILLING_TYPES = ["subscription_included", "subscription_overa
 
 function sumAsNumber(column: typeof costEvents.costCents | typeof costEvents.inputTokens | typeof costEvents.cachedInputTokens | typeof costEvents.outputTokens) {
   return sql<number>`coalesce(sum(${column}), 0)::double precision`;
+}
+
+function costRangeConditions(companyId: string, range?: CostDateRange) {
+  const conditions: ReturnType<typeof eq>[] = [eq(costEvents.companyId, companyId)];
+  if (range?.from) conditions.push(gte(costEvents.occurredAt, range.from));
+  if (range?.to) conditions.push(lte(costEvents.occurredAt, range.to));
+  return conditions;
+}
+
+function runCreatedRangeConditions(companyId: string, range?: CostDateRange) {
+  const conditions: ReturnType<typeof eq>[] = [eq(heartbeatRuns.companyId, companyId)];
+  if (range?.from) conditions.push(gte(heartbeatRuns.createdAt, range.from));
+  if (range?.to) conditions.push(lte(heartbeatRuns.createdAt, range.to));
+  return conditions;
 }
 
 function currentUtcMonthWindow(now = new Date()) {
@@ -363,6 +387,108 @@ export function costService(db: Db, budgetHooks: BudgetServiceHooks = {}) {
         .where(and(...conditions))
         .groupBy(costEvents.biller)
         .orderBy(desc(sumAsNumber(costEvents.costCents)));
+    },
+
+    topRuns: async (companyId: string, range?: CostDateRange, limit = 25) => {
+      const conditions = [
+        ...costRangeConditions(companyId, range),
+        isNotNull(costEvents.heartbeatRunId),
+      ];
+      const inputTokens = sumAsNumber(costEvents.inputTokens);
+      const cachedInputTokens = sumAsNumber(costEvents.cachedInputTokens);
+      const outputTokens = sumAsNumber(costEvents.outputTokens);
+      const costCents = sumAsNumber(costEvents.costCents);
+      const totalTokens = sql<number>`(${inputTokens} + ${outputTokens})`;
+      const issueId = sql<string | null>`coalesce(${costEvents.issueId}::text, ${heartbeatRuns.contextSnapshot} ->> 'issueId')`;
+
+      return db
+        .select({
+          heartbeatRunId: costEvents.heartbeatRunId,
+          agentId: costEvents.agentId,
+          agentName: agents.name,
+          issueId,
+          issueIdentifier: issues.identifier,
+          issueTitle: issues.title,
+          projectId: sql<string | null>`coalesce(${costEvents.projectId}::text, ${issues.projectId}::text)`,
+          projectName: projects.name,
+          routineId: routines.id,
+          routineTitle: routines.title,
+          invocationSource: heartbeatRuns.invocationSource,
+          wakeReason: sql<string | null>`${heartbeatRuns.contextSnapshot} ->> 'wakeReason'`,
+          triggerDetail: heartbeatRuns.triggerDetail,
+          status: heartbeatRuns.status,
+          errorCode: heartbeatRuns.errorCode,
+          retryOfRunId: heartbeatRuns.retryOfRunId,
+          createdAt: heartbeatRuns.createdAt,
+          startedAt: heartbeatRuns.startedAt,
+          finishedAt: heartbeatRuns.finishedAt,
+          resultSummary: sql<string | null>`left(${heartbeatRuns.resultJson} ->> 'summary', 500)`,
+          providerCount: sql<number>`count(distinct ${costEvents.provider})::int`,
+          modelCount: sql<number>`count(distinct ${costEvents.model})::int`,
+          costCents,
+          inputTokens,
+          cachedInputTokens,
+          uncachedInputTokens: sql<number>`greatest(${inputTokens} - ${cachedInputTokens}, 0)`,
+          outputTokens,
+          totalTokens,
+          costEventCount: sql<number>`count(${costEvents.id})::int`,
+        })
+        .from(costEvents)
+        .innerJoin(heartbeatRuns, eq(costEvents.heartbeatRunId, heartbeatRuns.id))
+        .leftJoin(agents, eq(costEvents.agentId, agents.id))
+        .leftJoin(issues, sql`${issues.id}::text = ${issueId}`)
+        .leftJoin(projects, sql`${projects.id}::text = coalesce(${costEvents.projectId}::text, ${issues.projectId}::text)`)
+        .leftJoin(routineRuns, eq(routineRuns.linkedIssueId, issues.id))
+        .leftJoin(routines, eq(routines.id, routineRuns.routineId))
+        .where(and(...conditions))
+        .groupBy(
+          costEvents.heartbeatRunId,
+          costEvents.agentId,
+          agents.name,
+          costEvents.issueId,
+          costEvents.projectId,
+          heartbeatRuns.id,
+          issues.id,
+          projects.id,
+          routines.id,
+        )
+        .orderBy(desc(totalTokens))
+        .limit(limit);
+    },
+
+    zeroTokenFailedRuns: async (companyId: string, range?: CostDateRange, limit = 25) => {
+      const issueId = sql<string | null>`${heartbeatRuns.contextSnapshot} ->> 'issueId'`;
+
+      return db
+        .select({
+          heartbeatRunId: heartbeatRuns.id,
+          agentId: heartbeatRuns.agentId,
+          agentName: agents.name,
+          issueId,
+          issueIdentifier: issues.identifier,
+          issueTitle: issues.title,
+          invocationSource: heartbeatRuns.invocationSource,
+          wakeReason: sql<string | null>`${heartbeatRuns.contextSnapshot} ->> 'wakeReason'`,
+          triggerDetail: heartbeatRuns.triggerDetail,
+          status: heartbeatRuns.status,
+          errorCode: heartbeatRuns.errorCode,
+          error: sql<string | null>`left(${heartbeatRuns.error}, 500)`,
+          retryOfRunId: heartbeatRuns.retryOfRunId,
+          createdAt: heartbeatRuns.createdAt,
+          startedAt: heartbeatRuns.startedAt,
+          finishedAt: heartbeatRuns.finishedAt,
+        })
+        .from(heartbeatRuns)
+        .leftJoin(costEvents, eq(costEvents.heartbeatRunId, heartbeatRuns.id))
+        .leftJoin(agents, eq(heartbeatRuns.agentId, agents.id))
+        .leftJoin(issues, sql`${issues.id}::text = ${issueId}`)
+        .where(and(
+          ...runCreatedRangeConditions(companyId, range),
+          eq(heartbeatRuns.status, "failed"),
+          isNull(costEvents.id),
+        ))
+        .orderBy(desc(heartbeatRuns.createdAt))
+        .limit(limit);
     },
 
     /**

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -13106,10 +13106,14 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       companyId: string,
       agentId?: string,
       limit?: number,
-      options: { summary?: boolean } = {},
+      options: { summary?: boolean; from?: Date; to?: Date } = {},
     ) => {
       const safeForLegacyEncoding = await hasUnsafeTextProjectionDatabase();
       const summary = options.summary === true;
+      const conditions = [eq(heartbeatRuns.companyId, companyId)];
+      if (agentId) conditions.push(eq(heartbeatRuns.agentId, agentId));
+      if (options.from) conditions.push(gte(heartbeatRuns.createdAt, options.from));
+      if (options.to) conditions.push(lte(heartbeatRuns.createdAt, options.to));
       const query = db
         .select(
           summary
@@ -13130,11 +13134,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
               },
         )
         .from(heartbeatRuns)
-        .where(
-          agentId
-            ? and(eq(heartbeatRuns.companyId, companyId), eq(heartbeatRuns.agentId, agentId))
-            : eq(heartbeatRuns.companyId, companyId),
-        )
+        .where(and(...conditions))
         .orderBy(desc(heartbeatRuns.createdAt));
 
       const rows = limit ? await query.limit(limit) : await query;


### PR DESCRIPTION
## Summary
- add compact top token-run reporting endpoint for subscription-included token burn analysis
- add zero-token failed-run endpoint for adapter/recovery loop reporting
- include issue/project/routine/run metadata without returning heavy run JSON/log payloads

## Verification
- pnpm exec vitest run src/__tests__/costs-service.test.ts --config vitest.config.ts (from server/)
- pnpm --filter @paperclipai/server typecheck