### PR TITLE
feat(dashboard): consecutive auth-failure alert on the company summary

### DIFF
--- a/packages/shared/src/types/dashboard.ts
+++ b/packages/shared/src/types/dashboard.ts
@@ -24,6 +24,28 @@ export interface DashboardRunActivityDay {
   failedByErrorCode: Record<string, number>;
 }
 
+/**
+ * Company-wide credential/auth outage signal derived from the most recent
+ * terminal heartbeat runs. When an adapter's credentials break (missing/invalid
+ * token), runs fail back-to-back with an auth error code — an outage signature
+ * that is otherwise indistinguishable from inactivity-monitor pollution in the
+ * per-day counts. `consecutiveFailures` counts the most-recent terminal runs
+ * that failed on an auth error code, uninterrupted by any other outcome, so a
+ * systemic auth failure is diagnosable at a glance without per-agent DB queries.
+ */
+export interface DashboardAuthFailureAlert {
+  /** Number of most-recent consecutive terminal runs that failed on an auth error code. */
+  consecutiveFailures: number;
+  /** Streak length at which `triggered` flips true. */
+  threshold: number;
+  /** `consecutiveFailures >= threshold`. */
+  triggered: boolean;
+  /** ISO timestamp of the most recent auth failure in the streak, or null if none. */
+  latestFailureAt: string | null;
+  /** The most recent auth error code in the streak (e.g. `auth_required`), or null if none. */
+  errorCode: string | null;
+}
+
 export interface DashboardSummary {
   companyId: string;
   agents: {
@@ -51,4 +73,5 @@ export interface DashboardSummary {
     pausedProjects: number;
   };
   runActivity: DashboardRunActivityDay[];
+  authFailureAlert: DashboardAuthFailureAlert;
 }

--- a/server/src/__tests__/dashboard-service.test.ts
+++ b/server/src/__tests__/dashboard-service.test.ts
@@ -237,4 +237,100 @@ describeEmbeddedPostgres("dashboard service", () => {
     // process_lost kills that recovered must not leak into the failed breakdown.
     expect(bucket?.failedByErrorCode.process_lost).toBeUndefined();
   });
+
+  async function seedAuthAlertCompany() {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "CodexCoder",
+      role: "engineer",
+      status: "running",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    return { companyId, agentId };
+  }
+
+  // Sequential timestamps; higher index = more recent.
+  function minuteAt(index: number): Date {
+    const base = Date.UTC(2026, 3, 20, 12, 0, 0);
+    return new Date(base + index * 60_000);
+  }
+
+  it("flags a systemic auth outage as consecutive auth failures", async () => {
+    const { companyId, agentId } = await seedAuthAlertCompany();
+    const base = { companyId, agentId, invocationSource: "assignment" };
+
+    await db.insert(heartbeatRuns).values([
+      // Older healthy runs, then the credential breaks and every run fails on auth.
+      { ...base, id: randomUUID(), status: "succeeded", createdAt: minuteAt(0) },
+      { ...base, id: randomUUID(), status: "succeeded", createdAt: minuteAt(1) },
+      { ...base, id: randomUUID(), status: "failed", errorCode: "auth_required", createdAt: minuteAt(2) },
+      { ...base, id: randomUUID(), status: "failed", errorCode: "acpx_auth_required", createdAt: minuteAt(3) },
+      { ...base, id: randomUUID(), status: "timed_out", errorCode: "auth_required", createdAt: minuteAt(4) },
+      { ...base, id: randomUUID(), status: "failed", errorCode: "github_token_unavailable", createdAt: minuteAt(5) },
+    ]);
+
+    const summary = await dashboardService(db).summary(companyId);
+
+    expect(summary.authFailureAlert).toMatchObject({
+      consecutiveFailures: 4,
+      threshold: 3,
+      triggered: true,
+      errorCode: "github_token_unavailable",
+    });
+    expect(summary.authFailureAlert.latestFailureAt).toBe(minuteAt(5).toISOString());
+  });
+
+  it("does not flag when a later success or non-auth failure breaks the auth streak", async () => {
+    const { companyId, agentId } = await seedAuthAlertCompany();
+    const base = { companyId, agentId, invocationSource: "assignment" };
+
+    await db.insert(heartbeatRuns).values([
+      { ...base, id: randomUUID(), status: "failed", errorCode: "auth_required", createdAt: minuteAt(0) },
+      { ...base, id: randomUUID(), status: "failed", errorCode: "auth_required", createdAt: minuteAt(1) },
+      // Most recent run succeeded — the company recovered, so the streak is zero.
+      { ...base, id: randomUUID(), status: "succeeded", createdAt: minuteAt(2) },
+    ]);
+
+    const summary = await dashboardService(db).summary(companyId);
+
+    expect(summary.authFailureAlert).toMatchObject({
+      consecutiveFailures: 0,
+      triggered: false,
+      latestFailureAt: null,
+      errorCode: null,
+    });
+  });
+
+  it("does not count non-auth failures toward the auth streak", async () => {
+    const { companyId, agentId } = await seedAuthAlertCompany();
+    const base = { companyId, agentId, invocationSource: "assignment" };
+
+    await db.insert(heartbeatRuns).values([
+      { ...base, id: randomUUID(), status: "failed", errorCode: "auth_required", createdAt: minuteAt(0) },
+      // Inactivity-monitor pollution is a failure but not an auth failure: it
+      // breaks the streak so ordinary noise never trips the credential alert.
+      { ...base, id: randomUUID(), status: "failed", errorCode: "claude_output_inactivity_monitor", createdAt: minuteAt(1) },
+      { ...base, id: randomUUID(), status: "failed", errorCode: "auth_required", createdAt: minuteAt(2) },
+    ]);
+
+    const summary = await dashboardService(db).summary(companyId);
+
+    expect(summary.authFailureAlert).toMatchObject({
+      consecutiveFailures: 1,
+      triggered: false,
+      errorCode: "auth_required",
+    });
+  });
 });

--- a/server/src/services/dashboard.ts
+++ b/server/src/services/dashboard.ts
@@ -1,4 +1,4 @@
-import { and, eq, gte, sql } from "drizzle-orm";
+import { and, desc, eq, gte, inArray, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import { agents, approvals, companies, costEvents, heartbeatRuns, issues } from "@paperclipai/db";
 import { notFound } from "../errors.js";
@@ -6,6 +6,26 @@ import { budgetService } from "./budgets.js";
 import { visibleIssueCondition } from "./issue-visibility.js";
 
 const DASHBOARD_RUN_ACTIVITY_DAYS = 14;
+
+/**
+ * Error codes that indicate a run could not authenticate — i.e. a credential
+ * outage rather than isolated flakiness. When these appear back-to-back across
+ * the whole company, it is almost always a systemic auth failure (expired/
+ * missing token, quoting bug that empties the Bearer header) rather than the
+ * inactivity-monitor pollution that dominates the ordinary failed count.
+ */
+const AUTH_FAILURE_ERROR_CODES = [
+  "auth_required",
+  "acpx_auth_required",
+  "github_auth_required",
+  "github_token_unavailable",
+] as const;
+/** Consecutive auth failures at which the dashboard alert flips on. */
+const AUTH_FAILURE_ALERT_THRESHOLD = 3;
+/** How many most-recent terminal runs to scan when measuring the streak. */
+const AUTH_FAILURE_SCAN_LIMIT = 50;
+/** Statuses that represent a finished run; queued/running runs don't reset the streak. */
+const TERMINAL_RUN_STATUSES = ["succeeded", "failed", "timed_out", "cancelled"] as const;
 
 function formatUtcDateKey(date: Date): string {
   return date.toISOString().slice(0, 10);
@@ -179,6 +199,52 @@ export function dashboardService(db: Db) {
           : 0;
       const budgetOverview = await budgets.overview(companyId);
 
+      // Auth-outage signal: walk the most-recent terminal runs newest-first and
+      // count how many, uninterrupted, failed on an auth error code. A success,
+      // a non-auth failure, or a cancel breaks the streak — so a triggered alert
+      // means the company's latest activity is a run of pure auth failures, the
+      // signature of a credential outage rather than inactivity-monitor noise.
+      const authFailureCodes = new Set<string>(AUTH_FAILURE_ERROR_CODES);
+      const recentTerminalRuns = await db
+        .select({
+          status: heartbeatRuns.status,
+          errorCode: heartbeatRuns.errorCode,
+          createdAt: heartbeatRuns.createdAt,
+        })
+        .from(heartbeatRuns)
+        .where(
+          and(
+            eq(heartbeatRuns.companyId, companyId),
+            inArray(heartbeatRuns.status, [...TERMINAL_RUN_STATUSES]),
+          ),
+        )
+        .orderBy(desc(heartbeatRuns.createdAt))
+        .limit(AUTH_FAILURE_SCAN_LIMIT);
+
+      let consecutiveAuthFailures = 0;
+      let latestAuthFailureAt: Date | null = null;
+      let latestAuthFailureCode: string | null = null;
+      for (const run of recentTerminalRuns) {
+        const isAuthFailure =
+          (run.status === "failed" || run.status === "timed_out") &&
+          run.errorCode != null &&
+          authFailureCodes.has(run.errorCode);
+        if (!isAuthFailure) break;
+        consecutiveAuthFailures += 1;
+        if (latestAuthFailureAt === null) {
+          latestAuthFailureAt = run.createdAt;
+          latestAuthFailureCode = run.errorCode;
+        }
+      }
+
+      const authFailureAlert = {
+        consecutiveFailures: consecutiveAuthFailures,
+        threshold: AUTH_FAILURE_ALERT_THRESHOLD,
+        triggered: consecutiveAuthFailures >= AUTH_FAILURE_ALERT_THRESHOLD,
+        latestFailureAt: latestAuthFailureAt ? latestAuthFailureAt.toISOString() : null,
+        errorCode: latestAuthFailureCode,
+      };
+
       return {
         companyId,
         agents: {
@@ -201,6 +267,7 @@ export function dashboardService(db: Db) {
           pausedProjects: budgetOverview.pausedProjectCount,
         },
         runActivity: Array.from(runActivity.values()),
+        authFailureAlert,
       };
     },
   };

--- a/ui/src/lib/inbox.test.ts
+++ b/ui/src/lib/inbox.test.ts
@@ -305,6 +305,13 @@ const dashboard: DashboardSummary = {
     pausedProjects: 0,
   },
   runActivity: [],
+  authFailureAlert: {
+    consecutiveFailures: 0,
+    threshold: 3,
+    triggered: false,
+    latestFailureAt: null,
+    errorCode: null,
+  },
 };
 
 describe("inbox helpers", () => {

--- a/ui/storybook/fixtures/paperclipData.ts
+++ b/ui/storybook/fixtures/paperclipData.ts
@@ -1302,6 +1302,13 @@ export const storybookDashboardSummary: DashboardSummary = {
     { date: "2026-04-19", succeeded: 5, failed: 2, recovered: 6, other: 1, total: 14, failedByErrorCode: { process_lost: 2 } },
     { date: "2026-04-20", succeeded: 4, failed: 1, recovered: 3, other: 2, total: 10, failedByErrorCode: { process_lost: 1 } },
   ],
+  authFailureAlert: {
+    consecutiveFailures: 0,
+    threshold: 3,
+    triggered: false,
+    latestFailureAt: null,
+    errorCode: null,
+  },
 };
 
 export const storybookLiveRuns: LiveRunForIssue[] = [


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The company dashboard summary (`GET /api/companies/:companyId/dashboard`) is where operators triage fleet health at a glance
> - Its per-day run breakdown already carries `failedByErrorCode`, which separates inactivity-monitor pollution from real regressions in the daily counts
> - What it does **not** surface is a credential outage: when an adapter's token expires, or a header-quoting bug empties the Bearer token, runs fail back-to-back on an auth error code — indistinguishable from any other failure spike in the daily counts and only diagnosable via per-agent DB queries today
> - This pull request adds an `authFailureAlert` field that walks the most-recent terminal runs newest-first and counts how many, uninterrupted, failed on an auth error code
> - The benefit is that a systemic credential outage becomes diagnosable at a glance, cleanly distinguished from ordinary inactivity-monitor noise

## Linked Issues or Issue Description

No public GitHub issue exists for this feature. Described inline below following the [feature request template](https://github.com/paperclipai/paperclip/blob/master/.github/ISSUE_TEMPLATE/feature_request.yml).

### Subsystem affected

server/ — REST API & orchestration services; packages/shared — types, constants, validators, API paths

### Problem or motivation

Operators cannot distinguish a company-wide credential/auth outage (expired or missing token, a quoting bug that empties the `Authorization` header) from ordinary failure noise on the dashboard. Both show up only as an elevated per-day `failed` count dominated by inactivity-monitor pollution. Diagnosing an auth outage today requires per-agent DB queries.

### Proposed solution

Derive a first-class `authFailureAlert` signal on the dashboard summary from the most-recent terminal heartbeat runs. Walk those runs newest-first and count how many, uninterrupted, failed on an auth error code (`auth_required`, `acpx_auth_required`, `github_auth_required`, `github_token_unavailable`). A success, a non-auth failure, or a cancel breaks the streak. `consecutiveFailures >= 3` sets `triggered: true`. The systemic auth-outage pattern is now visible at a glance and separable from inactivity-monitor noise.

### Alternatives considered

Reusing the per-day `failedByErrorCode` breakdown. Rejected: it aggregates by calendar day and does not express "the *latest* activity is an uninterrupted run of auth failures," which is what distinguishes an active outage from a historical blip.

### Roadmap alignment

Not directly listed on `ROADMAP.md`; this is a targeted observability improvement supporting the existing dashboard endpoint.

## What Changed

- **`packages/shared/src/types/dashboard.ts`** — new `DashboardAuthFailureAlert` interface, added as a required `authFailureAlert` field on `DashboardSummary`.
- **`server/src/services/dashboard.ts`** — query the most-recent terminal runs (newest-first, up to 50) for the company and count the leading run of auth failures; expose `consecutiveFailures`, `threshold` (3), `triggered`, `latestFailureAt`, `errorCode`.
- **`server/src/__tests__/dashboard-service.test.ts`** — 3 new cases: systemic outage triggers; a later success breaks the streak; a non-auth (inactivity-monitor) failure does not count toward the streak.
- **`ui/src/lib/inbox.test.ts`**, **`ui/storybook/fixtures/paperclipData.ts`** — fixtures updated to include the new required field.

## Verification

- `server` typecheck: clean in changed files (pre-existing unrelated `acpx/runtime` build-deps error only)
- `server/src/__tests__/dashboard-service.test.ts` (embedded Postgres): 6/6 pass, including the 3 new auth-alert cases
- `ui/src/lib/inbox.test.ts`: 54/54 pass; UI typecheck clean in changed fixtures (pre-existing unrelated dep-resolution errors only)

## Risks

Low risk. Purely additive read-path field on the dashboard summary — no schema migration, no write path, no change to existing fields. The new query is bounded (`LIMIT 50`) and scoped to a single company. The only compatibility consideration is that `authFailureAlert` is a required field on `DashboardSummary`, so all fixtures/consumers of that type were updated in this PR.

## Model Used

Claude Opus (`claude-opus-4-8`), extended thinking, with tool use / code execution in an agentic CLI harness.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above (none found — searched "auth failure alert dashboard" and "authFailureAlert")
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [ ] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge
