### PR TITLE
Default Codex workers to GPT-5.6 Terra xhigh

### DIFF
--- a/packages/adapters/codex-local/src/index.test.ts
+++ b/packages/adapters/codex-local/src/index.test.ts
@@ -14,6 +14,7 @@ describe("codex local adapter metadata", () => {
       model: "gpt-5.6-terra",
       modelReasoningEffort: "xhigh",
     });
+    expect(models.map((model) => model.id)).toContain("gpt-5.5");
     expect(models.map((model) => model.id)).not.toContain("gpt-5.3-codex");
   });
 

--- a/packages/adapters/codex-local/src/index.test.ts
+++ b/packages/adapters/codex-local/src/index.test.ts
@@ -1,9 +1,28 @@
 import { describe, expect, it } from "vitest";
-import { DEFAULT_CODEX_LOCAL_MODEL, models } from "./index.js";
+import {
+  applyCodexLocalWorkerDefaults,
+  DEFAULT_CODEX_LOCAL_MODEL,
+  DEFAULT_CODEX_LOCAL_REASONING_EFFORT,
+  models,
+} from "./index.js";
 
 describe("codex local adapter metadata", () => {
-  it("does not advertise the ChatGPT-unsupported gpt-5.3-codex model as a default option", () => {
-    expect(DEFAULT_CODEX_LOCAL_MODEL).toBe("gpt-5.5");
+  it("defaults workers to Terra at xhigh without advertising unsupported gpt-5.3-codex", () => {
+    expect(DEFAULT_CODEX_LOCAL_MODEL).toBe("gpt-5.6-terra");
+    expect(DEFAULT_CODEX_LOCAL_REASONING_EFFORT).toBe("xhigh");
+    expect(applyCodexLocalWorkerDefaults({})).toMatchObject({
+      model: "gpt-5.6-terra",
+      modelReasoningEffort: "xhigh",
+    });
     expect(models.map((model) => model.id)).not.toContain("gpt-5.3-codex");
+  });
+
+  it("preserves explicit worker model and reasoning overrides", () => {
+    expect(
+      applyCodexLocalWorkerDefaults({
+        model: "gpt-5.6-sol",
+        reasoningEffort: "high",
+      }),
+    ).toEqual({ model: "gpt-5.6-sol", reasoningEffort: "high" });
   });
 });

--- a/packages/adapters/codex-local/src/index.ts
+++ b/packages/adapters/codex-local/src/index.ts
@@ -5,9 +5,28 @@ export const label = "Codex";
 
 export const SANDBOX_INSTALL_COMMAND = "npm install -g @openai/codex";
 
-export const DEFAULT_CODEX_LOCAL_MODEL = "gpt-5.5";
+export const DEFAULT_CODEX_LOCAL_MODEL = "gpt-5.6-terra";
+export const DEFAULT_CODEX_LOCAL_REASONING_EFFORT = "xhigh";
 export const DEFAULT_CODEX_LOCAL_BYPASS_APPROVALS_AND_SANDBOX = true;
 export const CODEX_LOCAL_FAST_MODE_SUPPORTED_MODELS = ["gpt-5.5", "gpt-5.4"] as const;
+
+function nonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+export function applyCodexLocalWorkerDefaults(
+  config: Record<string, unknown>,
+): Record<string, unknown> {
+  const next = { ...config };
+  if (!nonEmptyString(next.model)) next.model = DEFAULT_CODEX_LOCAL_MODEL;
+  if (
+    !nonEmptyString(next.modelReasoningEffort) &&
+    !nonEmptyString(next.reasoningEffort)
+  ) {
+    next.modelReasoningEffort = DEFAULT_CODEX_LOCAL_REASONING_EFFORT;
+  }
+  return next;
+}
 
 function normalizeModelId(model: string | null | undefined): string {
   return typeof model === "string" ? model.trim() : "";
@@ -39,6 +58,7 @@ export function isCodexLocalFastModeSupported(model: string | null | undefined):
 
 export const models = [
   { id: DEFAULT_CODEX_LOCAL_MODEL, label: DEFAULT_CODEX_LOCAL_MODEL },
+  { id: "gpt-5.6-sol", label: "gpt-5.6-sol" },
   { id: "gpt-5.4", label: "gpt-5.4" },
   { id: "gpt-5.4-mini", label: "gpt-5.4-mini" },
   { id: "gpt-5.3-codex-spark", label: "gpt-5.3-codex-spark" },
@@ -73,8 +93,8 @@ Core fields:
 - engine (string, optional): leave unset/auto to use ACP when prerequisites pass and fall back to the Codex CLI with diagnostics. Use "cli" to pin the CLI lane or "acp" to require ACP.
 - cwd (string, optional): default absolute working directory fallback for the agent process (created if missing when possible)
 - instructionsFilePath (string, optional): absolute path to a markdown instructions file prepended to stdin prompt at runtime
-- model (string, optional): Codex model id
-- modelReasoningEffort (string, optional): reasoning effort override (minimal|low|medium|high|xhigh) passed via -c model_reasoning_effort=...
+- model (string, optional): Codex model id; defaults to gpt-5.6-terra
+- modelReasoningEffort (string, optional): reasoning effort override (minimal|low|medium|high|xhigh) passed via -c model_reasoning_effort=...; defaults to xhigh
 - promptTemplate (string, optional): run prompt template
 - search (boolean, optional): run codex with --search
 - fastMode (boolean, optional): enable Codex Fast mode; supported on GPT-5.5, GPT-5.4 and passed through for manual model IDs

--- a/packages/adapters/codex-local/src/index.ts
+++ b/packages/adapters/codex-local/src/index.ts
@@ -44,13 +44,8 @@ export function isCodexLocalManualModel(model: string | null | undefined): boole
 }
 
 export function isCodexLocalFastModeSupported(model: string | null | undefined): boolean {
-  if (isCodexLocalManualModel(model)) return true;
-  const normalizedModel = typeof model === "string" ? model.trim() : "";
-  // Empty means we're omitting --model so the Codex CLI picks its own default.
-  // On subscription auth that's gpt-5.5 (fast-mode capable); manual model IDs
-  // are also treated as supported. Match that policy: pass the fast-mode
-  // overrides through and let the CLI reject them if the chosen model can't use them.
-  if (!normalizedModel) return true;
+  const normalizedModel = normalizeModelId(model) || DEFAULT_CODEX_LOCAL_MODEL;
+  if (isCodexLocalManualModel(normalizedModel)) return true;
   return CODEX_LOCAL_FAST_MODE_SUPPORTED_MODELS.includes(
     normalizedModel as (typeof CODEX_LOCAL_FAST_MODE_SUPPORTED_MODELS)[number],
   );

--- a/packages/adapters/codex-local/src/index.ts
+++ b/packages/adapters/codex-local/src/index.ts
@@ -59,6 +59,7 @@ export function isCodexLocalFastModeSupported(model: string | null | undefined):
 export const models = [
   { id: DEFAULT_CODEX_LOCAL_MODEL, label: DEFAULT_CODEX_LOCAL_MODEL },
   { id: "gpt-5.6-sol", label: "gpt-5.6-sol" },
+  { id: "gpt-5.5", label: "gpt-5.5" },
   { id: "gpt-5.4", label: "gpt-5.4" },
   { id: "gpt-5.4-mini", label: "gpt-5.4-mini" },
   { id: "gpt-5.3-codex-spark", label: "gpt-5.3-codex-spark" },

--- a/packages/adapters/codex-local/src/server/codex-args.test.ts
+++ b/packages/adapters/codex-local/src/server/codex-args.test.ts
@@ -70,21 +70,17 @@ describe("buildCodexExecArgs", () => {
     ]);
   });
 
-  it("enables Codex fast mode overrides when model is omitted (CLI default)", () => {
+  it("ignores fast mode when model is omitted because the worker default is Terra", () => {
     const result = buildCodexExecArgs({
       fastMode: true,
     });
 
     expect(result.fastModeRequested).toBe(true);
-    expect(result.fastModeApplied).toBe(true);
-    expect(result.fastModeIgnoredReason).toBeNull();
+    expect(result.fastModeApplied).toBe(false);
+    expect(result.fastModeIgnoredReason).toContain("model (default)");
     expect(result.args).toEqual([
       "exec",
       "--json",
-      "-c",
-      'service_tier="fast"',
-      "-c",
-      "features.fast_mode=true",
       "-",
     ]);
   });

--- a/packages/adapters/codex-local/src/server/execute.remote.test.ts
+++ b/packages/adapters/codex-local/src/server/execute.remote.test.ts
@@ -262,6 +262,10 @@ describe("codex remote execution", () => {
     expect(call?.[2]).toEqual([
       "exec",
       "--json",
+      "--model",
+      "gpt-5.6-terra",
+      "-c",
+      'model_reasoning_effort="xhigh"',
       "-",
     ]);
   });
@@ -333,6 +337,10 @@ describe("codex remote execution", () => {
     expect(call?.[2]).toEqual([
       "exec",
       "--json",
+      "--model",
+      "gpt-5.6-terra",
+      "-c",
+      'model_reasoning_effort="xhigh"',
       "resume",
       "session-123",
       "-",
@@ -412,6 +420,10 @@ describe("codex remote execution", () => {
     expect(call?.[2]).toEqual([
       "exec",
       "--json",
+      "--model",
+      "gpt-5.6-terra",
+      "-c",
+      'model_reasoning_effort="xhigh"',
       "resume",
       "session-123",
       "-",

--- a/packages/adapters/codex-local/src/server/execute.ts
+++ b/packages/adapters/codex-local/src/server/execute.ts
@@ -57,7 +57,10 @@ import {
 import { prepareCodexRuntimeConfig } from "./runtime-config.js";
 import { resolveCodexDesiredSkillNames } from "./skills.js";
 import { buildCodexExecArgs } from "./codex-args.js";
-import { SANDBOX_INSTALL_COMMAND } from "../index.js";
+import {
+  applyCodexLocalWorkerDefaults,
+  SANDBOX_INSTALL_COMMAND,
+} from "../index.js";
 import {
   CODEX_OUTPUT_INACTIVITY_MONITOR_SIGTERM_GRACE_MS,
   createCodexOutputInactivityMonitor,
@@ -328,10 +331,14 @@ export async function ensureCodexSkillsInjected(
 }
 
 export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExecutionResult> {
-  const engineSelection = await resolveCodexExecutionEngineForRun(ctx);
+  const effectiveCtx = {
+    ...ctx,
+    config: applyCodexLocalWorkerDefaults(ctx.config),
+  };
+  const engineSelection = await resolveCodexExecutionEngineForRun(effectiveCtx);
   if (engineSelection.engine === "acp") {
     try {
-      return await executeCodexAcp(ctx);
+      return await executeCodexAcp(effectiveCtx);
     } catch (err) {
       if (engineSelection.explicit) throw err;
       const reason = err instanceof Error ? err.message : String(err);
@@ -345,7 +352,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     await ctx.onLog("stderr", formatCodexAcpFallbackMessage(engineSelection.fallbackReason));
   }
 
-  const { runId, agent, runtime, config, context, onLog, onMeta, onSpawn, authToken } = ctx;
+  const { runId, agent, runtime, config, context, onLog, onMeta, onSpawn, authToken } = effectiveCtx;
 
   const promptTemplate = asString(
     config.promptTemplate,

--- a/packages/adapters/codex-local/src/ui/build-config.test.ts
+++ b/packages/adapters/codex-local/src/ui/build-config.test.ts
@@ -63,9 +63,23 @@ describe("buildCodexLocalConfig", () => {
     });
   });
 
-  it("omits model when the operator leaves it blank", () => {
+  it("applies worker defaults when the operator leaves model and reasoning blank", () => {
     const config = buildCodexLocalConfig(makeValues({ model: "" }));
 
-    expect(config).not.toHaveProperty("model");
+    expect(config).toMatchObject({
+      model: "gpt-5.6-terra",
+      modelReasoningEffort: "xhigh",
+    });
+  });
+
+  it("preserves explicit model and reasoning overrides", () => {
+    const config = buildCodexLocalConfig(
+      makeValues({ model: "gpt-5.6-sol", thinkingEffort: "high" }),
+    );
+
+    expect(config).toMatchObject({
+      model: "gpt-5.6-sol",
+      modelReasoningEffort: "high",
+    });
   });
 });

--- a/packages/adapters/codex-local/src/ui/build-config.ts
+++ b/packages/adapters/codex-local/src/ui/build-config.ts
@@ -1,5 +1,8 @@
 import type { CreateConfigValues } from "@paperclipai/adapter-utils";
-import { DEFAULT_CODEX_LOCAL_BYPASS_APPROVALS_AND_SANDBOX } from "../index.js";
+import {
+  applyCodexLocalWorkerDefaults,
+  DEFAULT_CODEX_LOCAL_BYPASS_APPROVALS_AND_SANDBOX,
+} from "../index.js";
 
 function parseCommaArgs(value: string): string[] {
   return value
@@ -107,5 +110,5 @@ export function buildCodexLocalConfig(v: CreateConfigValues): Record<string, unk
   }
   if (v.command) ac.command = v.command;
   if (v.extraArgs) ac.extraArgs = parseCommaArgs(v.extraArgs);
-  return ac;
+  return applyCodexLocalWorkerDefaults(ac);
 }

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -85,7 +85,10 @@ import { redactCurrentUserValue } from "../log-redaction.js";
 import { renderOrgChartSvg, renderOrgChartPng, type OrgNode, type OrgChartStyle, ORG_CHART_STYLES } from "./org-chart-svg.js";
 import { instanceSettingsService } from "../services/instance-settings.js";
 import { runClaudeLogin } from "@paperclipai/adapter-claude-local/server";
-import { DEFAULT_CODEX_LOCAL_BYPASS_APPROVALS_AND_SANDBOX } from "@paperclipai/adapter-codex-local";
+import {
+  applyCodexLocalWorkerDefaults,
+  DEFAULT_CODEX_LOCAL_BYPASS_APPROVALS_AND_SANDBOX,
+} from "@paperclipai/adapter-codex-local";
 import { DEFAULT_CURSOR_LOCAL_MODEL } from "@paperclipai/adapter-cursor-local";
 import { DEFAULT_GEMINI_LOCAL_MODEL } from "@paperclipai/adapter-gemini-local";
 import { DEFAULT_OPENCODE_LOCAL_MODEL } from "@paperclipai/adapter-opencode-local";
@@ -1190,7 +1193,9 @@ export function agentRoutes(
     adapterType: string | null | undefined,
     adapterConfig: Record<string, unknown>,
   ): Record<string, unknown> {
-    const next = { ...adapterConfig };
+    const next = adapterType === "codex_local"
+      ? applyCodexLocalWorkerDefaults(adapterConfig)
+      : { ...adapterConfig };
     if (adapterType === "codex_local") {
       const hasBypassFlag =
         typeof next.dangerouslyBypassApprovalsAndSandbox === "boolean" ||


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents through provider adapters.
> - Blank `codex_local` worker configuration previously inherited the host's primary interactive model.
> - The fleet intentionally separates primary sessions from spawned workers.
> - This change makes blank worker configuration deterministic at `gpt-5.6-terra` with `xhigh` reasoning, while preserving explicit overrides.

## Linked Issues or Issue Description

- Refs #9322.
- Refs #9342.

### Problem / motivation

Blank Codex adapter configurations coupled worker execution to the surrounding interactive Codex installation. That made worker routing drift when operators intentionally used a different primary-session model.

### Proposed solution

Apply idempotent worker defaults at UI configuration creation, server-side agent creation, and runtime execution so both new and previously saved blank configurations resolve to Terra/xhigh. Preserve explicit `model`, `modelReasoningEffort`, and legacy `reasoningEffort` values.

### Alternatives considered

- Changing the host-wide primary model would erase the intended primary/worker split.
- Manual edits would leave existing blank configurations vulnerable to drift.
- UI-only defaults would miss API-created agents and saved blank configurations.

### Roadmap alignment

This is a narrow adapter-default policy change. It is rebased onto current `master`, including the related GPT-5.6 catalog work.

## What Changed

- Added `applyCodexLocalWorkerDefaults` with Terra/xhigh defaults and explicit-override preservation.
- Applied defaults in UI creation, server creation, CLI execution, and ACP execution.
- Kept GPT-5.5 in the fallback picker and advertised `gpt-5.6-sol` as an explicit alternate.
- Corrected blank-model fast-mode eligibility so the new Terra default is not treated as fast-mode capable.
- Updated adapter documentation and focused regressions.

## Verification

- Focused blank-model fast-mode test: 7/7 passed after first proving the regression with a failing assertion.
- Full workspace typecheck: pass.
- Full workspace build: pass.
- Required GitHub policy, typecheck, build, general tests, serialized suites, canary, e2e, security, and final verification checks: green on `958b8352`.
- Greptile: 5/5 on `958b8352`, with no open P2s, recommendations, or follow-ups.

The unsupported monolithic local test runner was stopped after it reproduced two broad workspace-runtime failures outside the touched adapter path; GitHub's supported sharded suite passed every corresponding required gate.

## Risks

- Blank configurations now select Terra/xhigh instead of inheriting the host model; this is intentional.
- Environments without Terra access must set an explicit available model.
- Explicit model and reasoning values remain unchanged.
- No migration or UI layout change is involved.

## Model Used

OpenAI Codex `gpt-5.6-sol` for the primary review session. Delegated fleet worker profiles use `gpt-5.6-terra` with `xhigh` reasoning.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used
- [x] I have checked roadmap alignment and related PRs/issues
- [x] I have not referenced internal or instance-local Paperclip issues
- [x] My branch name describes the change
- [ ] I have run the monolithic local test command to completion with no failures
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation
- [x] I have considered and documented risks
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] All reviewer comments are addressed
