### PR TITLE
fix(cloudflare): harden sandbox bridge errors

### DIFF
--- a/packages/plugins/sandbox-providers/cloudflare/bridge-template/src/exec.test.ts
+++ b/packages/plugins/sandbox-providers/cloudflare/bridge-template/src/exec.test.ts
@@ -81,6 +81,53 @@ describe("bridge exec", () => {
     expect(onOutput).toHaveBeenCalledWith("stdout", "hello\n");
   });
 
+  it("fails closed when sandbox exec omits both exitCode and explicit success", async () => {
+    const exec = vi.fn().mockResolvedValue({ stdout: "partial\n", stderr: "" });
+    const sandbox = {
+      getSession: vi.fn().mockResolvedValue({ exec }),
+      writeFile: vi.fn(),
+      deleteFile: vi.fn(),
+    } as const;
+
+    const result = await executeInSandbox({
+      sandbox: sandbox as never,
+      command: "pwd",
+      sessionStrategy: "named",
+      sessionId: "paperclip",
+      timeoutMs: 5_000,
+    });
+
+    expect(result).toMatchObject({
+      exitCode: 1,
+      timedOut: false,
+      stdout: "partial\n",
+    });
+    expect(result.stderr).toContain("returned no exit code");
+  });
+
+  it("accepts legacy explicit success without an exitCode", async () => {
+    const exec = vi.fn().mockResolvedValue({ success: true, stdout: "ok\n", stderr: "" });
+    const sandbox = {
+      getSession: vi.fn().mockResolvedValue({ exec }),
+      writeFile: vi.fn(),
+      deleteFile: vi.fn(),
+    } as const;
+
+    const result = await executeInSandbox({
+      sandbox: sandbox as never,
+      command: "pwd",
+      sessionStrategy: "named",
+      sessionId: "paperclip",
+      timeoutMs: 5_000,
+    });
+
+    expect(result).toMatchObject({
+      exitCode: 0,
+      stdout: "ok\n",
+      stderr: "",
+    });
+  });
+
   it("stages stdin through a sandbox temp file and redirects from it", async () => {
     const exec = vi.fn().mockResolvedValue({ exitCode: 0, stdout: "", stderr: "" });
     const writeFile = vi.fn().mockResolvedValue(undefined);

--- a/packages/plugins/sandbox-providers/cloudflare/bridge-template/src/exec.ts
+++ b/packages/plugins/sandbox-providers/cloudflare/bridge-template/src/exec.ts
@@ -69,17 +69,26 @@ function coerceExecuteResult(result: {
   stderr?: string;
   exitCode?: number | null;
 }) {
+  const hasExitCode = typeof result.exitCode === "number" || result.exitCode === null;
+  const exitCode = hasExitCode
+    ? result.exitCode
+    : result.success === true
+      ? 0
+      : 1;
+  const stderr = typeof result.stderr === "string" && result.stderr.length > 0
+    ? result.stderr
+    : (
+        hasExitCode || result.success === true
+          ? ""
+          : "Cloudflare sandbox exec returned no exit code or explicit success marker.\n"
+    );
+
   return {
-    exitCode:
-      typeof result.exitCode === "number" || result.exitCode === null
-        ? result.exitCode
-        : result.success === false
-          ? 1
-          : 0,
+    exitCode,
     signal: null,
     timedOut: false,
     stdout: result.stdout ?? "",
-    stderr: result.stderr ?? "",
+    stderr,
   };
 }
 

--- a/packages/plugins/sandbox-providers/cloudflare/bridge-template/src/routes.ts
+++ b/packages/plugins/sandbox-providers/cloudflare/bridge-template/src/routes.ts
@@ -193,7 +193,7 @@ async function verifySentinel(
     ["-c", `test -s ${shellQuote(buildSentinelPath(input.remoteCwd))}`],
     "/",
   );
-  return !result.timedOut && (result.exitCode ?? 0) === 0;
+  return !result.timedOut && result.exitCode === 0;
 }
 
 export async function handleBridgeRequest(request: Request, env: BridgeEnv): Promise<Response> {

--- a/packages/plugins/sandbox-providers/cloudflare/src/bridge-client.test.ts
+++ b/packages/plugins/sandbox-providers/cloudflare/src/bridge-client.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { CloudflareDriverConfig } from "./types.js";
+import type { CloudflareBridgeError } from "./bridge-client.js";
 import { createCloudflareBridgeClient, resolveRequestTimeoutMs } from "./bridge-client.js";
 
 const baseConfig: CloudflareDriverConfig = {
@@ -88,5 +89,48 @@ describe("Cloudflare bridge client timeouts", () => {
     expect(onOutput).toHaveBeenCalledWith("stdout", "hello\n");
     const init = fetchMock.mock.calls[0]?.[1] as RequestInit;
     expect(JSON.parse(String(init.body))).toMatchObject({ streamOutput: true });
+  });
+
+  it("surfaces Cloudflare 1010 bot protection pages as actionable bridge errors", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(
+      "<html><title>Access denied | Error code 1010</title><body>Cloudflare</body></html>",
+      {
+        status: 403,
+        headers: { "Content-Type": "text/html" },
+      },
+    )));
+    const client = createCloudflareBridgeClient({ config: baseConfig });
+
+    await expect(client.probe({
+      requestedCwd: "/workspace",
+      keepAlive: false,
+      sleepAfter: "10m",
+      normalizeId: true,
+      sessionStrategy: "named",
+      sessionId: "paperclip",
+      timeoutMs: 30_000,
+    })).rejects.toThrow(/Cloudflare 1010 bot protection/);
+  });
+
+  it("rejects malformed successful exec responses instead of treating them as command success", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(
+      JSON.stringify({ success: true, stdout: "looks ok\n" }),
+      {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      },
+    )));
+    const client = createCloudflareBridgeClient({ config: baseConfig });
+
+    await expect(client.execute({
+      providerLeaseId: "lease-1",
+      command: "pwd",
+      sessionStrategy: "named",
+      sessionId: "paperclip",
+    })).rejects.toMatchObject({
+      name: "CloudflareBridgeError",
+      status: 502,
+      code: "malformed_execute_response",
+    } satisfies Partial<CloudflareBridgeError>);
   });
 });

--- a/packages/plugins/sandbox-providers/cloudflare/src/bridge-client.ts
+++ b/packages/plugins/sandbox-providers/cloudflare/src/bridge-client.ts
@@ -31,6 +31,11 @@ interface BridgeErrorBody {
   details?: unknown;
 }
 
+interface ParsedErrorBody {
+  errorBody: BridgeErrorBody;
+  rawText: string | null;
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
@@ -65,6 +70,85 @@ async function parseJson(response: Response): Promise<unknown> {
     return null;
   }
   return await response.json();
+}
+
+async function parseErrorBody(response: Response): Promise<ParsedErrorBody> {
+  const contentType = response.headers.get("content-type") ?? "";
+  if (contentType.toLowerCase().includes("application/json")) {
+    try {
+      const body = await response.json();
+      return {
+        errorBody: isRecord(body) ? body as BridgeErrorBody : {},
+        rawText: null,
+      };
+    } catch (error) {
+      return {
+        errorBody: {},
+        rawText: `Malformed JSON error response: ${error instanceof Error ? error.message : String(error)}`,
+      };
+    }
+  }
+
+  const rawText = await response.text().catch(() => "");
+  return {
+    errorBody: {},
+    rawText,
+  };
+}
+
+function buildBridgeErrorMessage(status: number, errorBody: BridgeErrorBody, rawText: string | null): string {
+  if (typeof errorBody.message === "string" && errorBody.message.trim().length > 0) {
+    return errorBody.message.trim();
+  }
+
+  const text = rawText?.replace(/\s+/g, " ").trim() ?? "";
+  if (status === 403 && /\b1010\b/i.test(text) && /cloudflare/i.test(text)) {
+    return "Cloudflare sandbox bridge request was blocked by Cloudflare 1010 bot protection. Exempt the bridge endpoint or token-authenticated API path from bot/security rules.";
+  }
+
+  if (text.length > 0) {
+    return `Cloudflare sandbox bridge request failed with HTTP ${status}: ${text.slice(0, 240)}`;
+  }
+
+  return `Cloudflare sandbox bridge request failed with HTTP ${status}.`;
+}
+
+function normalizeExecuteResponse(body: unknown): CloudflareBridgeExecuteResponse {
+  if (!isRecord(body)) {
+    throw new CloudflareBridgeError({
+      status: 502,
+      code: "malformed_execute_response",
+      message: "Cloudflare sandbox bridge returned a malformed exec response.",
+      details: body,
+    });
+  }
+
+  const exitCode = body.exitCode;
+  const timedOut = body.timedOut;
+  const stdout = body.stdout;
+  const stderr = body.stderr;
+  if (
+    !(typeof exitCode === "number" || exitCode === null) ||
+    typeof timedOut !== "boolean" ||
+    typeof stdout !== "string" ||
+    typeof stderr !== "string"
+  ) {
+    throw new CloudflareBridgeError({
+      status: 502,
+      code: "malformed_execute_response",
+      message: "Cloudflare sandbox bridge returned a malformed exec response.",
+      details: body,
+    });
+  }
+
+  return {
+    exitCode,
+    signal: typeof body.signal === "string" || body.signal === null ? body.signal : null,
+    timedOut,
+    stdout,
+    stderr,
+    metadata: isRecord(body.metadata) ? body.metadata : undefined,
+  };
 }
 
 function encodeExecuteRequestBody(body: CloudflareBridgeExecuteRequest, options?: BridgeExecuteOptions): string {
@@ -116,19 +200,16 @@ async function requestJson<T>(
       headers: buildHeaders(config, extraHeaders),
       signal: controller.signal,
     });
-    const body = await parseJson(response);
     if (!response.ok) {
-      const errorBody = isRecord(body) ? body as BridgeErrorBody : {};
+      const { errorBody, rawText } = await parseErrorBody(response);
       throw new CloudflareBridgeError({
         status: response.status,
         code: typeof errorBody.error === "string" ? errorBody.error : null,
-        message:
-          typeof errorBody.message === "string" && errorBody.message.trim().length > 0
-            ? errorBody.message
-            : `Cloudflare sandbox bridge request failed with HTTP ${response.status}.`,
+        message: buildBridgeErrorMessage(response.status, errorBody, rawText),
         details: errorBody.details,
       });
     }
+    const body = await parseJson(response);
     return body as T;
   } catch (error) {
     if (error instanceof CloudflareBridgeError) throw error;
@@ -161,15 +242,11 @@ async function requestResponse(
       signal: controller.signal,
     });
     if (!response.ok) {
-      const body = await parseJson(response);
-      const errorBody = isRecord(body) ? body as BridgeErrorBody : {};
+      const { errorBody, rawText } = await parseErrorBody(response);
       throw new CloudflareBridgeError({
         status: response.status,
         code: typeof errorBody.error === "string" ? errorBody.error : null,
-        message:
-          typeof errorBody.message === "string" && errorBody.message.trim().length > 0
-            ? errorBody.message
-            : `Cloudflare sandbox bridge request failed with HTTP ${response.status}.`,
+        message: buildBridgeErrorMessage(response.status, errorBody, rawText),
         details: errorBody.details,
       });
     }
@@ -249,7 +326,7 @@ async function consumeExecuteEventStream(
       }
 
       if (event.event === "complete") {
-        result = JSON.parse(event.data) as CloudflareBridgeExecuteResponse;
+        result = normalizeExecuteResponse(JSON.parse(event.data));
         continue;
       }
 
@@ -346,12 +423,12 @@ export function createCloudflareBridgeClient(options: BridgeClientOptions) {
           extraHeaders,
         ).then((response) => consumeExecuteEventStream(response, options));
       }
-      return requestJson<CloudflareBridgeExecuteResponse>(
+      return requestJson<unknown>(
         config,
         `${apiPrefix}/exec`,
         { method: "POST", body: encodedBody },
         extraHeaders,
-      );
+      ).then(normalizeExecuteResponse);
     },
   };
 }


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Remote sandbox providers let adapters run agent workloads outside the local host while preserving Paperclip control-plane behavior.
> - The Cloudflare sandbox provider depends on a token-authenticated bridge and a normalized command execution result contract.
> - Cloudflare security blocks can return HTML error pages, including 1010 bot protection pages, instead of the bridge's JSON error envelope.
> - The bridge template also treated SDK exec results without an exit code as successful unless `success` was explicitly false.
> - This pull request makes those paths fail clearly: Cloudflare 1010 is surfaced as an actionable bridge configuration error, and malformed exec success envelopes no longer look like command success.
> - The benefit is safer remote execution and faster operator diagnosis when Cloudflare security rules intercept bridge traffic.

## Linked Issues or Issue Description

No public GitHub issue exists for this bug, so the issue is described inline using the public bug report template.

### Pre-submission checklist

- [x] I have searched existing issues and pull requests for this problem.
- [x] I have included enough reproduction and environment context for maintainers to evaluate the bug.

### What happened?

Cloudflare sandbox bridge failures could be misleading in two cases:

- A Cloudflare 1010 bot-protection response can be HTML instead of the bridge's JSON error envelope, but the client collapsed that into a generic HTTP failure.
- The Cloudflare bridge template coerced SDK exec results without an `exitCode` to success unless `success` was explicitly false, so malformed execution responses could look like successful commands.

### Expected behavior

- Cloudflare 1010 responses should identify Cloudflare bot/security blocking and tell operators what to change.
- Command execution responses should require a valid execution envelope or an explicit legacy `success: true` marker.
- `exitCode: null` should not validate workspace sentinel checks as healthy.

### Steps to reproduce

1. Configure the Cloudflare sandbox bridge behind a Cloudflare rule that returns a 403/1010 HTML error page.
2. Call a bridge endpoint from the Paperclip Cloudflare sandbox provider.
3. Observe that the provider reports a generic HTTP error instead of a Cloudflare 1010 diagnostic.
4. Mock a Cloudflare SDK exec response with `stdout`/`stderr` but no `exitCode` and no `success: true`.
5. Observe that the bridge template previously coerced the response to `exitCode: 0`.

### Paperclip version or commit

Observed on current `master` before this PR. This PR is based on `05973b207`.

### Deployment mode

Cloudflare sandbox provider / remote sandbox execution.

### Installation method

Repository source checkout with pnpm workspace packages.

### Agent adapter(s) involved

Local CLI adapters using Cloudflare sandbox execution targets.

### Database mode

Not database-specific.

### Access context

Cloudflare-protected bridge endpoint and token-authenticated bridge API calls.

### Node.js version

Node.js 22.23.0 in the local verification environment.

### Operating system

Linux arm64 in the local verification environment.

### Relevant logs or output

- Cloudflare 1010 HTML response: `Access denied | Error code 1010`
- Malformed SDK exec result shape: `{ success?: boolean, stdout?: string, stderr?: string }` without `exitCode`

### Relevant config (if applicable)

Cloudflare bot/security rules can intercept the bridge endpoint before the bridge worker returns JSON.

### Additional context

The fix is intentionally fail-closed for malformed command execution responses while preserving legacy `success: true` responses.

### Privacy checklist

- [x] No secrets, tokens, customer data, or private instance URLs are included.
- [x] Error examples are generic and synthetic.

## What Changed

- Added Cloudflare bridge error parsing for non-JSON error bodies and a specific Cloudflare 1010 diagnostic.
- Added exec-response validation in the Cloudflare bridge client for JSON and streamed exec completions.
- Changed the Cloudflare bridge template to fail closed when SDK exec omits both `exitCode` and explicit `success: true`.
- Tightened workspace sentinel verification so `exitCode: null` is not treated as healthy.
- Added regression tests for Cloudflare 1010 HTML responses, malformed exec envelopes, and legacy explicit success.

## Verification

- `pnpm test` in `packages/plugins/sandbox-providers/cloudflare` passed: 6 files, 35 tests.
- `pnpm test` in `packages/plugins/sandbox-providers/cloudflare/bridge-template` passed: 4 files, 18 tests.
- `git diff --check` passed.

Typecheck note:

- `pnpm typecheck` in `packages/plugins/sandbox-providers/cloudflare` failed in this fresh worktree because TypeScript could not resolve `@types/node`.
- `pnpm exec tsc --noEmit` in `packages/plugins/sandbox-providers/cloudflare/bridge-template` failed because TypeScript could not resolve `@cloudflare/workers-types`.
- CI typecheck passed on PR #9347.

## Risks

- Low risk for normal Cloudflare bridge responses that already return `exitCode`, `timedOut`, `stdout`, and `stderr`.
- Legacy Cloudflare SDK responses without `exitCode` still pass only when they include explicit `success: true`.
- Operators may see a new failure where malformed results were previously misreported as success.

## Model Used

- OpenAI Codex, GPT-5 class coding agent with tool use and local command execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [ ] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green except the review metadata gate being retriggered by this body update
- [x] Greptile is 4/5 with no required changes
- [x] I will address all Greptile and reviewer comments before requesting merge