### PR TITLE
Fix Skill Studio markdown dirty tracking

### DIFF
--- a/ui/src/pages/SkillStudio.test.tsx
+++ b/ui/src/pages/SkillStudio.test.tsx
@@ -95,7 +95,29 @@ vi.mock("@/components/SearchableSelect", () => ({
 }));
 
 vi.mock("@/components/MarkdownEditor", () => ({
-  MarkdownEditor: ({ value }: { value: string }) => <textarea readOnly value={value} />,
+  MarkdownEditor: ({
+    value,
+    onChange,
+    readOnly,
+  }: {
+    value: string;
+    onChange: (value: string) => void;
+    readOnly?: boolean;
+  }) => (
+    <textarea
+      data-testid="markdown-editor"
+      readOnly={readOnly}
+      value={value}
+      onChange={(event) => {
+        if (!readOnly) onChange(event.target.value);
+      }}
+      onKeyDown={(event) => {
+        if (!readOnly && event.key === "E") {
+          onChange(`${value}\n\nEdited body\n`);
+        }
+      }}
+    />
+  ),
 }));
 
 vi.mock("@/components/MarkdownBody", () => ({
@@ -178,6 +200,12 @@ async function inputValue(input: HTMLInputElement | HTMLTextAreaElement, value: 
 async function click(button: HTMLButtonElement) {
   await act(async () => {
     button.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+  });
+}
+
+async function keyDown(element: HTMLElement, key: string) {
+  await act(async () => {
+    element.dispatchEvent(new KeyboardEvent("keydown", { bubbles: true, key }));
   });
 }
 
@@ -554,6 +582,54 @@ describe("SkillStudio editor frontmatter", () => {
     const toggle = node.querySelector<HTMLButtonElement>('button[aria-controls="frontmatter-panel-body"]');
     expect(toggle?.getAttribute("aria-expanded")).toBe("false");
     expect(node.querySelector("#fm-name")).toBeNull();
+  });
+
+  it("marks rich markdown body edits dirty and saves the edited markdown", async () => {
+    mockCompanySkillsApi.updateFile.mockImplementationOnce((
+      _companyId: string,
+      _skillId: string,
+      path: string,
+      content: string,
+    ) => Promise.resolve({
+      path,
+      content,
+      markdown: true,
+      editable: true,
+      editableReason: null,
+    }));
+
+    const node = await renderStudio();
+
+    let bodyEditor: HTMLTextAreaElement | undefined;
+    await waitFor(() => {
+      bodyEditor = Array.from(node.querySelectorAll<HTMLTextAreaElement>('[data-testid="markdown-editor"]')).find(
+        (editor) => editor.value.includes("# Demo Skill"),
+      );
+      expect(bodyEditor).toBeTruthy();
+    });
+
+    await keyDown(bodyEditor as HTMLElement, "E");
+
+    await waitFor(() => expect(node.textContent).toContain("Unsaved"));
+
+    const saveButton = buttonsNamed(node, "Save").find((button) => !button.disabled);
+    expect(saveButton).toBeTruthy();
+    await click(saveButton as HTMLButtonElement);
+
+    await waitFor(() => {
+      expect(mockCompanySkillsApi.updateFile).toHaveBeenCalledWith(
+        "company-1",
+        "source-skill",
+        "SKILL.md",
+        expect.stringContaining("Edited body"),
+      );
+    });
+    expect(mockCompanySkillsApi.updateFile).toHaveBeenCalledWith(
+      "company-1",
+      "source-skill",
+      "SKILL.md",
+      expect.stringContaining("---\nname: Demo Skill"),
+    );
   });
 
   it("offers an 'Edit a copy' CTA on the read-only banner (PAP-13112)", async () => {

--- a/ui/src/pages/SkillStudio.tsx
+++ b/ui/src/pages/SkillStudio.tsx
@@ -1264,6 +1264,9 @@ function SkillPane({
   // MDXEditor can emit a normalizing onChange on mount, which would otherwise
   // dirty the file on open and break the byte-identity guarantee (PAP-13156).
   const bodyInteractedRef = useRef(false);
+  const markBodyInteracted = useCallback(() => {
+    bodyInteractedRef.current = true;
+  }, []);
 
   const nodes: FileTreeNode[] = useMemo(
     () => buildFileTree(Object.fromEntries(paths.map((p) => [p, ""]))),
@@ -1510,9 +1513,12 @@ function SkillPane({
         ) : null}
         <div
           className="min-h-0 flex-1 overflow-auto px-3 pb-3"
-          onInput={() => {
-            bodyInteractedRef.current = true;
-          }}
+          onBeforeInputCapture={markBodyInteracted}
+          onDropCapture={markBodyInteracted}
+          onInput={markBodyInteracted}
+          onKeyDownCapture={markBodyInteracted}
+          onPasteCapture={markBodyInteracted}
+          onPointerDownCapture={markBodyInteracted}
         >
           {isMarkdown && markdownBlock ? (
             <MarkdownEditor


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Skill Studio is the UI surface for editing skill package files, including `SKILL.md`.
> - Markdown files are split into frontmatter fields plus a rich markdown body editor.
> - The dirty-state guard intentionally ignores markdown editor normalization during initial mount.
> - That guard was too narrow: rich markdown body edits could happen before the file was marked as user-interacted, so edits did not reliably enable Save.
> - This pull request broadens the user-interaction signals around the markdown body editor and adds a regression test for saving body edits.
> - The benefit is that editing `SKILL.md` in Skill Studio now behaves like normal file editing: changes show as unsaved and Save persists the full markdown document.

## Linked Issues or Issue Description

No public GitHub issue exists. Inline bug description follows.

### What happened?

Editing a Skill Studio markdown body did not reliably mark the file dirty, so the Save action could remain unavailable or fail to persist the body edit.

### Expected behavior

User edits in the markdown body editor should mark the file unsaved and allow saving the updated `SKILL.md` content.

### Steps to reproduce

1. Open a Skill Studio markdown file such as `SKILL.md`.
2. Edit the markdown body in the rich editor.
3. Observe whether the unsaved state appears and Save becomes enabled.
4. Save and reload the file.

### Paperclip version or commit

Reproduced on `master` before this fix.

### Deployment mode

Local dev (`pnpm dev`).

## What Changed

- Mark markdown body interaction on capture-phase key, pointer, paste, drop, before-input, and input events around the rich editor.
- Preserve the existing guard that prevents MDXEditor mount-time normalization from dirtying a clean file.
- Add a Skill Studio regression test that edits the markdown body, observes the Unsaved state, enables Save, and verifies the saved `SKILL.md` includes both frontmatter and the edited body.

## Verification

- `pnpm vitest run ui/src/pages/SkillStudio.test.tsx`

Manual reviewer path:

- Open a Skill Studio markdown file such as `SKILL.md`.
- Edit the body text in the rich markdown editor.
- Confirm the UI shows an unsaved state and the Save button is enabled.
- Save and confirm the updated markdown body persists.

## Risks

Low risk. The change only broadens interaction detection before applying existing dirty-state logic, and the guard still prevents initial editor normalization from marking an unopened file dirty.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

OpenAI Codex CLI using GPT-5, with repository file editing, shell execution, and GitHub CLI tool use.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
