### PR TITLE
Fix default model adapter test config

### DIFF
--- a/.agents/skills/create-issue-interaction-ui/SKILL.md
+++ b/.agents/skills/create-issue-interaction-ui/SKILL.md
@@ -6,7 +6,10 @@ description: >
   checkbox confirmations, ask_user_questions, or suggest_tasks.
 ---
 
-# Create a new issue-thread interaction UI (developer skill)
+# Create a new issue-thread interaction UI (Developer/maintainer skill)
+
+Do NOT install this on production Paperclip agents. This is a developer/maintainer
+skill for contributors changing Paperclip source code.
 
 This skill walks a Paperclip contributor through introducing a new issue-thread
 interaction kind from shared contract to issue-detail wiring, helpers, and

--- a/ui/src/components/AgentConfigForm.render.test.tsx
+++ b/ui/src/components/AgentConfigForm.render.test.tsx
@@ -7,6 +7,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Agent, Environment } from "@paperclipai/shared";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { AgentConfigForm } from "./AgentConfigForm";
+import { defaultCreateValues } from "./agent-config-defaults";
 
 const mockAgentsApi = vi.hoisted(() => ({
   adapterModelProfiles: vi.fn(),
@@ -68,7 +69,9 @@ vi.mock("../adapters", () => ({
       adapterType === "hermes_gateway"
         ? <div data-testid="hermes-gateway-config-fields">Hermes Gateway fields</div>
         : null,
-    buildAdapterConfig: () => ({}),
+    buildAdapterConfig: (values: { model?: string }) => ({
+      model: values.model || undefined,
+    }),
     parseStdoutLine: () => [],
   }),
 }));
@@ -221,6 +224,51 @@ async function renderForm(
 
   await flushReact();
   return { container, root };
+}
+
+async function renderCreateForm(
+  environments: Environment[],
+  valueOverrides: Partial<typeof defaultCreateValues> = {},
+  options: { showAdapterTestEnvironmentButton?: boolean } = {},
+) {
+  mockEnvironmentsApi.list.mockResolvedValue(environments);
+
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  const values = {
+    ...defaultCreateValues,
+    adapterType: "codex_local",
+    ...valueOverrides,
+  };
+  const onChange = vi.fn();
+
+  await act(async () => {
+    root.render(
+      <QueryClientProvider client={queryClient}>
+        <TooltipProvider>
+          <AgentConfigForm
+            mode="create"
+            values={values}
+            onChange={onChange}
+            hidePromptTemplate
+            showAdapterTypeField={false}
+            showAdapterTestEnvironmentButton={options.showAdapterTestEnvironmentButton ?? false}
+          />
+        </TooltipProvider>
+      </QueryClientProvider>,
+    );
+  });
+
+  await flushReact();
+  return { container, root, onChange };
 }
 
 describe("AgentConfigForm environment selector", () => {
@@ -439,9 +487,41 @@ describe("AgentConfigForm environment selector", () => {
     expect(mockAgentsApi.testEnvironment.mock.calls[0]?.[2]).toMatchObject({
       adapterConfig: {},
     });
-    expect((mockAgentsApi.testEnvironment.mock.calls[0]?.[2] as { adapterConfig: Record<string, unknown> }).adapterConfig)
-      .not.toHaveProperty("model");
+    const adapterConfig = (mockAgentsApi.testEnvironment.mock.calls[0]?.[2] as {
+      adapterConfig: Record<string, unknown>;
+    }).adapterConfig;
+    expect(adapterConfig).not.toHaveProperty("model");
     expect(result.container.textContent).not.toContain("Cannot read properties of undefined");
+  });
+
+  it("omits undefined adapter config entries when testing a create form with the default model", async () => {
+    const result = await renderCreateForm([
+      makeEnvironment({ id: "local-1", name: "Local", driver: "local" }),
+    ], {
+      model: "",
+    }, {
+      showAdapterTestEnvironmentButton: true,
+    });
+    roots.push(result.root);
+
+    const testButton = Array.from(result.container.querySelectorAll("button")).find(
+      (button) => button.textContent?.trim() === "Test",
+    );
+    expect(testButton).toBeTruthy();
+
+    await act(async () => {
+      testButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    await flushReact();
+
+    expect(mockAgentsApi.testEnvironment).toHaveBeenCalledTimes(1);
+    expect(mockAgentsApi.testEnvironment.mock.calls[0]?.[2]).toMatchObject({
+      adapterConfig: {},
+    });
+    const adapterConfig = (mockAgentsApi.testEnvironment.mock.calls[0]?.[2] as {
+      adapterConfig: Record<string, unknown>;
+    }).adapterConfig;
+    expect(adapterConfig).not.toHaveProperty("model");
   });
 
   it("flushes pending environment variable edits before testing adapter config", async () => {

--- a/ui/src/components/AgentConfigForm.render.test.tsx
+++ b/ui/src/components/AgentConfigForm.render.test.tsx
@@ -395,6 +395,55 @@ describe("AgentConfigForm environment selector", () => {
     });
   });
 
+  it("tests a Codex agent after clearing the primary model to the adapter default", async () => {
+    const result = await renderForm([
+      makeEnvironment({ id: "local-1", name: "Local", driver: "local" }),
+    ], {
+      adapterConfig: { model: "gpt-5.4" },
+    }, {
+      showAdapterTestEnvironmentButton: true,
+    });
+    roots.push(result.root);
+
+    const modelButton = Array.from(result.container.querySelectorAll("button")).find(
+      (button) => button.textContent?.trim() === "gpt-5.4",
+    );
+    expect(modelButton).toBeTruthy();
+
+    await act(async () => {
+      modelButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    await flushReact();
+
+    const defaultButton = Array.from(document.body.querySelectorAll("button")).find(
+      (button) => button.textContent?.trim() === "Default",
+    );
+    expect(defaultButton).toBeTruthy();
+
+    await act(async () => {
+      defaultButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    await flushReact();
+
+    const testButton = Array.from(result.container.querySelectorAll("button")).find(
+      (button) => button.textContent?.trim() === "Test",
+    );
+    expect(testButton).toBeTruthy();
+
+    await act(async () => {
+      testButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    await flushReact();
+
+    expect(mockAgentsApi.testEnvironment).toHaveBeenCalledTimes(1);
+    expect(mockAgentsApi.testEnvironment.mock.calls[0]?.[2]).toMatchObject({
+      adapterConfig: {},
+    });
+    expect((mockAgentsApi.testEnvironment.mock.calls[0]?.[2] as { adapterConfig: Record<string, unknown> }).adapterConfig)
+      .not.toHaveProperty("model");
+    expect(result.container.textContent).not.toContain("Cannot read properties of undefined");
+  });
+
   it("flushes pending environment variable edits before testing adapter config", async () => {
     const result = await renderForm([
       makeEnvironment({ id: "local-1", name: "Local", driver: "local" }),

--- a/ui/src/components/AgentConfigForm.tsx
+++ b/ui/src/components/AgentConfigForm.tsx
@@ -195,6 +195,12 @@ function clampDelayMsFromSeconds(value: number) {
   return clampInteger(value, 0, MAX_TURN_CONTINUATION_MAX_DELAY_SEC) * 1000;
 }
 
+function omitUndefinedEntries(value: Record<string, unknown>) {
+  return Object.fromEntries(
+    Object.entries(value).filter(([, entryValue]) => entryValue !== undefined),
+  );
+}
+
 
 /* ---- Form ---- */
 
@@ -545,7 +551,7 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
     if (adapterConfigPatch) {
       Object.assign(next, adapterConfigPatch);
     }
-    return next;
+    return omitUndefinedEntries(next);
   }
 
   function buildCheapAdapterConfigForTest(adapterConfigPatch?: Record<string, unknown>): Record<string, unknown> {
@@ -747,9 +753,10 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
   }, [props.onTestFeedbackChange, testActionError, testEnvironment.data, testEnvironment.error]);
 
   // Current model for display
-  const currentModelId = isCreate
-    ? val!.model
+  const currentModelValue = isCreate
+    ? val!.model ?? ""
     : eff("adapterConfig", "model", String(config.model ?? ""));
+  const currentModelId = typeof currentModelValue === "string" ? currentModelValue : "";
 
   async function handleRefreshModels() {
     if (!selectedCompanyId) return;

--- a/ui/src/components/AgentConfigForm.tsx
+++ b/ui/src/components/AgentConfigForm.tsx
@@ -55,7 +55,7 @@ import { shouldShowLegacyWorkingDirectoryField } from "../lib/legacy-agent-confi
 import { listAdapterOptions, listVisibleAdapterTypes } from "../adapters/metadata";
 import { getAdapterDisplay, getAdapterLabel } from "../adapters/adapter-display-registry";
 import { useDisabledAdaptersSync } from "../adapters/use-disabled-adapters";
-import { buildAgentUpdatePatch, type AgentConfigOverlay } from "../lib/agent-config-patch";
+import { buildAgentUpdatePatch, omitUndefinedEntries, type AgentConfigOverlay } from "../lib/agent-config-patch";
 import { useAdapterCapabilities } from "../adapters/use-adapter-capabilities";
 import { resolveForcedKubernetesEnvironment } from "../lib/forced-kubernetes-environment";
 
@@ -194,13 +194,6 @@ function clampInteger(value: number, min: number, max: number) {
 function clampDelayMsFromSeconds(value: number) {
   return clampInteger(value, 0, MAX_TURN_CONTINUATION_MAX_DELAY_SEC) * 1000;
 }
-
-function omitUndefinedEntries(value: Record<string, unknown>) {
-  return Object.fromEntries(
-    Object.entries(value).filter(([, entryValue]) => entryValue !== undefined),
-  );
-}
-
 
 /* ---- Form ---- */
 
@@ -544,7 +537,7 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
       if (adapterConfigPatch) {
         Object.assign(next, adapterConfigPatch);
       }
-      return next;
+      return omitUndefinedEntries(next);
     }
     const base = config as Record<string, unknown>;
     const next = { ...base, ...overlay.adapterConfig };

--- a/ui/src/lib/agent-config-patch.ts
+++ b/ui/src/lib/agent-config-patch.ts
@@ -19,7 +19,7 @@ export interface AgentConfigOverlay {
   modelProfiles?: { cheap?: AgentModelProfileOverlay };
 }
 
-function omitUndefinedEntries(value: Record<string, unknown>) {
+export function omitUndefinedEntries(value: Record<string, unknown>) {
   return Object.fromEntries(
     Object.entries(value).filter(([, entryValue]) => entryValue !== undefined),
   );


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The board UI lets operators create and edit agent adapter configuration, including a primary model field and an adapter test action.
> - For Cody and similar adapter forms, selecting the default model means the model value is intentionally unset so the adapter can use its default.
> - The adapter test path still allowed `model: undefined` to survive in the generated adapter config, which could send an invalid test payload instead of omitting the field.
> - This pull request normalizes create/edit adapter test config so default-model selections omit `model` entirely.
> - The benefit is that testing an agent configured to use the adapter default model exercises the same clean config shape that should be saved and run.

## Linked Issues or Issue Description

No public GitHub issue was found for this local UI bug, so the problem is described inline.

Bug description:
- What happened: using the adapter test action after choosing the default model could include `model: undefined` in adapter config and surface a UI/runtime error instead of testing with the adapter default.
- Expected behavior: choosing the default model should omit the `model` field from adapter config so the adapter default is used.
- Steps to reproduce: edit a Codex/Cody-style agent with a concrete model, switch the model selector to Default, then run the adapter Test action.
- Paperclip version/commit: current `master` before this PR.
- Deployment mode: board UI, deployment-mode independent.

## What Changed

- Sanitized adapter test config assembly so undefined adapter config entries are omitted before the test request is sent.
- Made create-mode current model display resilient when the model is unset for adapter defaults.
- Added regression coverage for editing an existing agent from a concrete model back to Default and testing it.
- Added regression coverage for create-mode testing with an unset/default model.
- Hardened the developer skill wording used by the existing server skill utility contract test.

## Verification

- `pnpm --filter @paperclipai/ui exec vitest run src/components/AgentConfigForm.render.test.tsx`
- `pnpm exec vitest run server/src/__tests__/paperclip-skill-utils.test.ts`
- GitHub PR checks on this branch are green, including Typecheck + Release Registry, Build, General tests, e2e, verify, security scans, and Greptile Review.

## Risks

- Low risk: this only removes undefined values from adapter test config payloads, which aligns with the existing persisted patch behavior.
- Low risk: default-model display now treats unset create-mode model values as an empty string.
- No database, API schema, migration, auth, or adapter runtime contract changes.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected - check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

OpenAI Codex, GPT-5 coding agent, tool-enabled software-engineering session. Exact context window size was not exposed by the runtime.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge