### PR TITLE
Clarify interaction UI skill audience

### DIFF
--- a/.agents/skills/create-issue-interaction-ui/SKILL.md
+++ b/.agents/skills/create-issue-interaction-ui/SKILL.md
@@ -6,7 +6,10 @@ description: >
   checkbox confirmations, ask_user_questions, or suggest_tasks.
 ---
 
-# Create a new issue-thread interaction UI (developer skill)
+# Create a new issue-thread interaction UI (Developer/maintainer skill)
+
+Do NOT install this on production Paperclip agents. This is a developer/maintainer
+skill for contributors changing Paperclip source code.
 
 This skill walks a Paperclip contributor through introducing a new issue-thread
 interaction kind from shared contract to issue-detail wiring, helpers, and


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Paperclip contributors also maintain repo-local skills that guide agent and developer workflows.
> - The `create-issue-interaction-ui` skill is meant for contributors changing Paperclip source code, not for runtime company agents.
> - Its opening wording did not make that boundary prominent enough after the previous mixed-purpose PR was reverted.
> - This pull request isolates the skill-audience clarification from the default-model adapter fix.
> - The benefit is a small, reviewable documentation-only change with no UI, adapter, or runtime behavior changes.

## Linked Issues or Issue Description

This PR clarifies that the `create-issue-interaction-ui` skill is a developer/maintainer skill and should not be installed on production Paperclip agents. There is no public GitHub issue for this documentation-only cleanup.

## What Changed

- Updated the `create-issue-interaction-ui` skill title to identify it as a developer/maintainer skill.
- Added an explicit warning that the skill should not be installed on production Paperclip agents.

## Verification

- Ran `git diff --stat origin/master...HEAD` and confirmed the PR contains only `.agents/skills/create-issue-interaction-ui/SKILL.md`.
- Ran `gh pr list --search "clarify interaction UI skill audience in:title,body" --state all --limit 10 --json number,title,state,headRefName,url`; no duplicate PRs were returned.
- Checked `ROADMAP.md` for related skill/agent roadmap overlap; this is a narrow docs clarification and does not duplicate planned core work.
- No automated tests run because this is a documentation-only skill guidance change.

## Risks

Low risk. This changes contributor-facing skill wording only and does not affect product source, runtime behavior, schemas, APIs, or UI.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

OpenAI GPT-5 via Codex CLI, with tool use and local code execution in the Paperclip execution workspace.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
