### PR TITLE
Fix Cody default model adapter test config

### DIFF
--- a/ui/src/components/AgentConfigForm.render.test.tsx
+++ b/ui/src/components/AgentConfigForm.render.test.tsx
@@ -7,6 +7,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Agent, Environment } from "@paperclipai/shared";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { AgentConfigForm } from "./AgentConfigForm";
+import { defaultCreateValues } from "./agent-config-defaults";
 
 const mockAgentsApi = vi.hoisted(() => ({
   adapterModelProfiles: vi.fn(),
@@ -68,7 +69,9 @@ vi.mock("../adapters", () => ({
       adapterType === "hermes_gateway"
         ? <div data-testid="hermes-gateway-config-fields">Hermes Gateway fields</div>
         : null,
-    buildAdapterConfig: () => ({}),
+    buildAdapterConfig: (values: { model?: string }) => ({
+      model: values.model || undefined,
+    }),
     parseStdoutLine: () => [],
   }),
 }));
@@ -221,6 +224,51 @@ async function renderForm(
 
   await flushReact();
   return { container, root };
+}
+
+async function renderCreateForm(
+  environments: Environment[],
+  valueOverrides: Partial<typeof defaultCreateValues> = {},
+  options: { showAdapterTestEnvironmentButton?: boolean } = {},
+) {
+  mockEnvironmentsApi.list.mockResolvedValue(environments);
+
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  const values = {
+    ...defaultCreateValues,
+    adapterType: "codex_local",
+    ...valueOverrides,
+  };
+  const onChange = vi.fn();
+
+  await act(async () => {
+    root.render(
+      <QueryClientProvider client={queryClient}>
+        <TooltipProvider>
+          <AgentConfigForm
+            mode="create"
+            values={values}
+            onChange={onChange}
+            hidePromptTemplate
+            showAdapterTypeField={false}
+            showAdapterTestEnvironmentButton={options.showAdapterTestEnvironmentButton ?? false}
+          />
+        </TooltipProvider>
+      </QueryClientProvider>,
+    );
+  });
+
+  await flushReact();
+  return { container, root, onChange };
 }
 
 describe("AgentConfigForm environment selector", () => {
@@ -393,6 +441,87 @@ describe("AgentConfigForm environment selector", () => {
         provider: "budget-provider",
       }),
     });
+  });
+
+  it("tests a Codex agent after clearing the primary model to the adapter default", async () => {
+    const result = await renderForm([
+      makeEnvironment({ id: "local-1", name: "Local", driver: "local" }),
+    ], {
+      adapterConfig: { model: "gpt-5.4" },
+    }, {
+      showAdapterTestEnvironmentButton: true,
+    });
+    roots.push(result.root);
+
+    const modelButton = Array.from(result.container.querySelectorAll("button")).find(
+      (button) => button.textContent?.trim() === "gpt-5.4",
+    );
+    expect(modelButton).toBeTruthy();
+
+    await act(async () => {
+      modelButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    await flushReact();
+
+    const defaultButton = Array.from(document.body.querySelectorAll("button")).find(
+      (button) => button.textContent?.trim() === "Default",
+    );
+    expect(defaultButton).toBeTruthy();
+
+    await act(async () => {
+      defaultButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    await flushReact();
+
+    const testButton = Array.from(result.container.querySelectorAll("button")).find(
+      (button) => button.textContent?.trim() === "Test",
+    );
+    expect(testButton).toBeTruthy();
+
+    await act(async () => {
+      testButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    await flushReact();
+
+    expect(mockAgentsApi.testEnvironment).toHaveBeenCalledTimes(1);
+    expect(mockAgentsApi.testEnvironment.mock.calls[0]?.[2]).toMatchObject({
+      adapterConfig: {},
+    });
+    const adapterConfig = (mockAgentsApi.testEnvironment.mock.calls[0]?.[2] as {
+      adapterConfig: Record<string, unknown>;
+    }).adapterConfig;
+    expect(adapterConfig).not.toHaveProperty("model");
+    expect(result.container.textContent).not.toContain("Cannot read properties of undefined");
+  });
+
+  it("omits undefined adapter config entries when testing a create form with the default model", async () => {
+    const result = await renderCreateForm([
+      makeEnvironment({ id: "local-1", name: "Local", driver: "local" }),
+    ], {
+      model: "",
+    }, {
+      showAdapterTestEnvironmentButton: true,
+    });
+    roots.push(result.root);
+
+    const testButton = Array.from(result.container.querySelectorAll("button")).find(
+      (button) => button.textContent?.trim() === "Test",
+    );
+    expect(testButton).toBeTruthy();
+
+    await act(async () => {
+      testButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    await flushReact();
+
+    expect(mockAgentsApi.testEnvironment).toHaveBeenCalledTimes(1);
+    expect(mockAgentsApi.testEnvironment.mock.calls[0]?.[2]).toMatchObject({
+      adapterConfig: {},
+    });
+    const adapterConfig = (mockAgentsApi.testEnvironment.mock.calls[0]?.[2] as {
+      adapterConfig: Record<string, unknown>;
+    }).adapterConfig;
+    expect(adapterConfig).not.toHaveProperty("model");
   });
 
   it("flushes pending environment variable edits before testing adapter config", async () => {

--- a/ui/src/components/AgentConfigForm.tsx
+++ b/ui/src/components/AgentConfigForm.tsx
@@ -55,7 +55,7 @@ import { shouldShowLegacyWorkingDirectoryField } from "../lib/legacy-agent-confi
 import { listAdapterOptions, listVisibleAdapterTypes } from "../adapters/metadata";
 import { getAdapterDisplay, getAdapterLabel } from "../adapters/adapter-display-registry";
 import { useDisabledAdaptersSync } from "../adapters/use-disabled-adapters";
-import { buildAgentUpdatePatch, type AgentConfigOverlay } from "../lib/agent-config-patch";
+import { buildAgentUpdatePatch, omitUndefinedEntries, type AgentConfigOverlay } from "../lib/agent-config-patch";
 import { useAdapterCapabilities } from "../adapters/use-adapter-capabilities";
 import { resolveForcedKubernetesEnvironment } from "../lib/forced-kubernetes-environment";
 
@@ -194,7 +194,6 @@ function clampInteger(value: number, min: number, max: number) {
 function clampDelayMsFromSeconds(value: number) {
   return clampInteger(value, 0, MAX_TURN_CONTINUATION_MAX_DELAY_SEC) * 1000;
 }
-
 
 /* ---- Form ---- */
 
@@ -538,14 +537,14 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
       if (adapterConfigPatch) {
         Object.assign(next, adapterConfigPatch);
       }
-      return next;
+      return omitUndefinedEntries(next);
     }
     const base = config as Record<string, unknown>;
     const next = { ...base, ...overlay.adapterConfig };
     if (adapterConfigPatch) {
       Object.assign(next, adapterConfigPatch);
     }
-    return next;
+    return omitUndefinedEntries(next);
   }
 
   function buildCheapAdapterConfigForTest(adapterConfigPatch?: Record<string, unknown>): Record<string, unknown> {
@@ -747,9 +746,10 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
   }, [props.onTestFeedbackChange, testActionError, testEnvironment.data, testEnvironment.error]);
 
   // Current model for display
-  const currentModelId = isCreate
-    ? val!.model
+  const currentModelValue = isCreate
+    ? val!.model ?? ""
     : eff("adapterConfig", "model", String(config.model ?? ""));
+  const currentModelId = typeof currentModelValue === "string" ? currentModelValue : "";
 
   async function handleRefreshModels() {
     if (!selectedCompanyId) return;

--- a/ui/src/lib/agent-config-patch.ts
+++ b/ui/src/lib/agent-config-patch.ts
@@ -19,7 +19,7 @@ export interface AgentConfigOverlay {
   modelProfiles?: { cheap?: AgentModelProfileOverlay };
 }
 
-function omitUndefinedEntries(value: Record<string, unknown>) {
+export function omitUndefinedEntries(value: Record<string, unknown>) {
   return Object.fromEntries(
     Object.entries(value).filter(([, entryValue]) => entryValue !== undefined),
   );


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Agent configuration includes adapter-specific model settings and a built-in adapter test action so operators can verify runtime configuration before saving changes.
> - Cody/Codex-style local adapters can use an adapter default model when the user clears the explicit model field.
> - The adapter test path still passed an object containing `model: undefined` in some create/edit flows, which is different from omitting the model and can break default-model behavior.
> - The previous fix was reverted because it also included an unrelated skill documentation edit.
> - This pull request reapplies only the UI default-model test-config fix, with no doc or skill changes.
> - The benefit is that testing Cody/Codex adapter settings with the default model follows the same contract as saving default model settings: no explicit model key is sent.

## Linked Issues or Issue Description

Bug report:

- Summary: Testing a Cody/Codex local agent after selecting the default model could send an adapter config with an undefined model value instead of omitting the model key.
- Expected behavior: Clearing the model to use the adapter default should test with `adapterConfig: {}` unless another model is explicitly selected.
- Actual behavior: The UI test-config path could preserve `model: undefined`, causing the adapter test to fail instead of exercising the default model.
- Related PRs: Reapplies the UI-only portion of #9361 after #9363 reverted the original PR.

## What Changed

- Exported and reused `omitUndefinedEntries` so adapter test config payloads drop undefined adapter config entries before calling the test endpoint.
- Hardened the current model display value so create-mode values that are nullish or non-string do not crash the model selector/test flow.
- Added render coverage for editing a Codex agent back to the default model and for testing a create form with the default model.

## Verification

- `pnpm exec vitest run ui/src/components/AgentConfigForm.render.test.tsx`
- `pnpm check:token-gates`
- Confirmed `git diff origin/master --name-only` contains only:
  - `ui/src/components/AgentConfigForm.render.test.tsx`
  - `ui/src/components/AgentConfigForm.tsx`
  - `ui/src/lib/agent-config-patch.ts`

## Risks

Low risk. The change only removes `undefined` adapter config entries from the UI adapter-test payload and adds focused render coverage. Explicit model values and other adapter config fields are preserved.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

OpenAI Codex, GPT-5 coding agent, tool-use enabled. Context window size not exposed in this runtime.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
