### PR TITLE
feat: quota fallback — reassign issue to a fallback agent on quota exhaustion (#2014)

### DIFF
--- a/.agents/skills/create-issue-interaction-ui/SKILL.md
+++ b/.agents/skills/create-issue-interaction-ui/SKILL.md
@@ -1,24 +1,22 @@
 ---
 name: create-issue-interaction-ui
 description: >
-  Developer/maintainer skill for adding a new issue-thread interaction kind to
-  the Paperclip codebase end-to-end: shared contract, server service/routes,
-  UI card, fixtures/Storybook, CLI/MCP/plugin SDK helpers, agent guidance, and
-  tests. Use when a Paperclip contributor is asked to introduce a new
-  interaction family (something analogous to `request_confirmation`,
-  `request_checkbox_confirmation`, `ask_user_questions`, or `suggest_tasks`)
-  or to extend the issue-thread interaction system with a new card type. Do
-  NOT install this on production Paperclip agents — it is for repo work, not
-  agent runtime behavior.
+  Add a new Paperclip issue-thread interaction kind end-to-end. Use when repo
+  work introduces or extends interaction cards like request_confirmation,
+  checkbox confirmations, ask_user_questions, or suggest_tasks.
 ---
 
-# Create a new issue-thread interaction UI (developer skill)
+# Create a new issue-thread interaction UI (Developer/maintainer skill)
+
+Developer/maintainer skill. Do NOT install this on production Paperclip agents.
 
 This skill walks a Paperclip contributor through introducing a new issue-thread
 interaction kind from shared contract to issue-detail wiring, helpers, and
 docs. It is intentionally a developer/maintainer skill: the audience is a
 human or coding agent making code changes inside `paperclipai/paperclip`, not
 the operational agents that run inside a deployed Paperclip company.
+
+Do NOT install this on production Paperclip agents. This guide is for repository contributors changing Paperclip itself.
 
 ## When to use
 

--- a/.agents/skills/create-issue-interaction-ui/SKILL.md
+++ b/.agents/skills/create-issue-interaction-ui/SKILL.md
@@ -1,9 +1,15 @@
 ---
 name: create-issue-interaction-ui
 description: >
-  Add a new Paperclip issue-thread interaction kind end-to-end. Use when repo
-  work introduces or extends interaction cards like request_confirmation,
-  checkbox confirmations, ask_user_questions, or suggest_tasks.
+  Developer/maintainer skill for adding a new issue-thread interaction kind to
+  the Paperclip codebase end-to-end: shared contract, server service/routes,
+  UI card, fixtures/Storybook, CLI/MCP/plugin SDK helpers, agent guidance, and
+  tests. Use when a Paperclip contributor is asked to introduce a new
+  interaction family (something analogous to `request_confirmation`,
+  `request_checkbox_confirmation`, `ask_user_questions`, or `suggest_tasks`)
+  or to extend the issue-thread interaction system with a new card type. Do
+  NOT install this on production Paperclip agents — it is for repo work, not
+  agent runtime behavior.
 ---
 
 # Create a new issue-thread interaction UI (developer skill)

--- a/docs/plans/2026-07-10-2014-quota-fallback.md
+++ b/docs/plans/2026-07-10-2014-quota-fallback.md
@@ -1,0 +1,138 @@
+# Quota Fallback: reassign to a fallback agent on quota exhaustion (#2014)
+
+Branch: `tginter/2014-quota-fallback`
+Status: implemented, tests green (see Verification)
+
+## Problem
+
+When an adapter run fails with `errorFamily: provider_quota`, today the only
+recovery is to park the same agent behind a `retryNotBefore` scheduled retry
+until the provider quota resets. Work on the issue stalls for hours even when
+another agent (on a different provider/adapter) is idle and able to continue.
+
+## Design (decided)
+
+On a failed run whose error family matches the agent's configured fallback
+triggers, **reassign the issue to a configured fallback agent** instead of
+scheduling the same-agent retry. The fallback agent has a different
+`adapterType`, so the handoff gets a fresh session by construction (session
+isolation without new machinery). No DB schema changes.
+
+### Config shape (in `agent.adapterConfig`)
+
+```json
+"fallback": {
+  "enabled": true,
+  "agentId": "<uuid of fallback agent>",
+  "on": ["provider_quota"],
+  "when": "immediate"
+}
+```
+
+- `on` — trigger families; defaults to `["provider_quota"]`; may also include
+  `"max_turns"` (max-turn exhaustion runs).
+- `when` — `"immediate"` (default: fall back on the first matching failure) or
+  `"retries_exhausted"` (only once `scheduledRetryAttempt >= maxAttempts`,
+  reusing the existing bounded-retry attempt accounting).
+- All keys optional; block validated by
+  `adapterFallbackConfigSchema` (`packages/shared/src/validators/agent.ts`) —
+  strict inside the block, fully backward compatible outside it.
+
+### Behavior
+
+Decision point: the failed-run retry branch of the heartbeat finalize path
+(`server/src/services/heartbeat.ts`, after `setRunStatusIfRunning`). For both
+the max-turn-continuation branch and the transient-recovery branch, the new
+`maybeFallbackReassign(run, agent)` is consulted first; the existing
+`scheduleBoundedRetryForRun` call runs only when the fallback does **not**
+reassign.
+
+`maybeFallbackReassign`:
+
+1. Parses `adapterConfig.fallback`; bails (`not_applicable`) when disabled,
+   when the run's trigger (`provider_quota` / `max_turns`) is not in `on`, or
+   when `when: "retries_exhausted"` and attempts remain.
+2. Validates the fallback agent: configured, not the same agent, exists in the
+   same company, and passes the same invokability gate used by
+   `scheduleBoundedRetryForRun`. Also requires an issue in the run context,
+   assigned to the failing agent and not in a terminal status. Any validation
+   failure logs a warning + a `warn` run event and returns `not_applied`, so
+   the caller falls through to the untouched existing retry/parking behavior.
+3. On success:
+   - updates `issues.assigneeAgentId` to the fallback agent and releases the
+     execution lock (`executionRunId` / `executionAgentNameKey` /
+     `executionLockedAt`);
+   - writes activity log `issue.quota_fallback_reassigned` with
+     `{fromAgentId, toAgentId, errorFamily, runId}`;
+   - posts an issue comment documenting the handoff;
+   - persists an auditable marker in the failed run's `resultJson`:
+     `{"fallback": {"fromAgentId", "toAgentId", "trigger", "at"}}`;
+   - wakes the fallback agent (`issue_assigned`, source `assignment`).
+4. The original agent's same-adapter retry is suppressed only when the
+   fallback actually reassigned; `retryNotBefore` parking is untouched when
+   fallback is disabled or not matching.
+
+Public surface: `heartbeat.maybeFallbackReassign(runId, opts?)` mirrors
+`heartbeat.scheduleBoundedRetry` for tests and tooling.
+
+## Files changed
+
+- `packages/shared/src/validators/agent.ts` — `adapterFallbackTriggerSchema`,
+  `adapterFallbackConfigSchema`, wired into `adapterConfigSchema.superRefine`.
+- `packages/shared/src/agent-fallback-config.test.ts` — validator coverage.
+- `server/src/services/heartbeat.ts` — `parseAdapterFallbackConfig`,
+  `readAdapterFallbackTriggerFromRun`, `maybeFallbackReassign`, finalize-path
+  wiring, public wrapper.
+- `server/src/__tests__/heartbeat-quota-fallback.test.ts` — embedded-Postgres
+  suite (8 tests).
+
+## Verification
+
+- `server`: `heartbeat-quota-fallback.test.ts` 8/8 pass;
+  `heartbeat-retry-scheduling.test.ts` + `issue-scheduled-retry-routes.test.ts`
+  33/33 pass (regression guard).
+- `packages/shared`: `agent-fallback-config.test.ts` 10/10 pass.
+- `tsc --noEmit` clean in `server` and `packages/shared`.
+
+## Upstream PR description (ready to paste)
+
+> ### Quota fallback: reassign the issue to a fallback agent instead of parking until quota reset
+>
+> Implements the retry-time fallback proposed in #2014.
+>
+> When an agent's run fails with a quota-family error (`provider_quota`, and
+> optionally max-turn exhaustion), the heartbeat finalize path can now hand the
+> issue to a configured fallback agent instead of scheduling the same-agent
+> retry and waiting for the provider quota window to reset. Because the
+> fallback agent runs a different adapter, the handoff starts from a fresh
+> session by construction — no session-sharing or schema changes involved.
+>
+> **Opt-in config** (per agent, inside `adapterConfig`; validated, strict-keyed,
+> fully backward compatible):
+>
+> ```json
+> "fallback": {"enabled": true, "agentId": "<uuid>", "on": ["provider_quota"], "when": "immediate"}
+> ```
+>
+> - `on` defaults to `["provider_quota"]`; `"max_turns"` is also supported.
+> - `when: "immediate"` falls back on the first matching failure;
+>   `"retries_exhausted"` keeps the existing bounded retries and only falls
+>   back once attempts are exhausted.
+>
+> **Semantics**
+> - On fallback: `issues.assigneeAgentId` is updated, the execution lock is
+>   released, an `issue.quota_fallback_reassigned` activity entry and a handoff
+>   issue comment are written, the failed run's `resultJson` gets an auditable
+>   `fallback` marker, and the fallback agent is woken with `issue_assigned`.
+>   The original agent's same-adapter retry is suppressed — the fallback agent
+>   now owns the issue.
+> - Fallback target is validated (same company, different agent, invokable).
+>   Any misconfiguration logs a warning run event and falls through to the
+>   existing retry/parking behavior unchanged; behavior with fallback disabled
+>   or unset is byte-for-byte the status quo.
+>
+> **Tests**: new embedded-Postgres suite covering immediate fallback end to end
+> (reassignment, activity log, comment, no same-agent retry), disabled-fallback
+> regression, `retries_exhausted` gating, invalid/missing/same-agent/paused
+> fallback targets, and non-matching error families; plus validator tests for
+> the config block. Existing retry-scheduling suites pass unchanged.

--- a/packages/shared/src/agent-fallback-config.test.ts
+++ b/packages/shared/src/agent-fallback-config.test.ts
@@ -1,0 +1,97 @@
+import { randomUUID } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { createAgentSchema, updateAgentSchema } from "./validators/agent.js";
+
+function baseCreateInput(adapterConfig: Record<string, unknown>) {
+  return {
+    name: "Fallback Agent",
+    adapterType: "codex_local",
+    adapterConfig,
+  };
+}
+
+describe("adapterConfig.fallback validation", () => {
+  it("accepts an adapterConfig without a fallback block", () => {
+    const parsed = createAgentSchema.safeParse(baseCreateInput({ model: "gpt-5" }));
+    expect(parsed.success).toBe(true);
+  });
+
+  it("accepts a fully specified fallback block", () => {
+    const parsed = createAgentSchema.safeParse(
+      baseCreateInput({
+        fallback: {
+          enabled: true,
+          agentId: randomUUID(),
+          on: ["provider_quota", "max_turns"],
+          when: "retries_exhausted",
+        },
+      }),
+    );
+    expect(parsed.success).toBe(true);
+  });
+
+  it("accepts a minimal fallback block (all keys optional)", () => {
+    const parsed = createAgentSchema.safeParse(
+      baseCreateInput({ fallback: { enabled: true, agentId: randomUUID() } }),
+    );
+    expect(parsed.success).toBe(true);
+  });
+
+  it("rejects unknown keys inside fallback", () => {
+    const parsed = createAgentSchema.safeParse(
+      baseCreateInput({
+        fallback: { enabled: true, agentId: randomUUID(), bogus: 1 },
+      }),
+    );
+    expect(parsed.success).toBe(false);
+  });
+
+  it("rejects a non-uuid agentId", () => {
+    const parsed = createAgentSchema.safeParse(
+      baseCreateInput({ fallback: { enabled: true, agentId: "not-a-uuid" } }),
+    );
+    expect(parsed.success).toBe(false);
+  });
+
+  it("rejects unknown trigger families in on", () => {
+    const parsed = createAgentSchema.safeParse(
+      baseCreateInput({
+        fallback: { enabled: true, agentId: randomUUID(), on: ["model_refusal"] },
+      }),
+    );
+    expect(parsed.success).toBe(false);
+  });
+
+  it("rejects an unknown when value", () => {
+    const parsed = createAgentSchema.safeParse(
+      baseCreateInput({
+        fallback: { enabled: true, agentId: randomUUID(), when: "sometimes" },
+      }),
+    );
+    expect(parsed.success).toBe(false);
+  });
+
+  it("rejects a non-object fallback value", () => {
+    const parsed = createAgentSchema.safeParse(baseCreateInput({ fallback: "yes" }));
+    expect(parsed.success).toBe(false);
+  });
+
+  it("rejects a non-boolean enabled flag", () => {
+    const parsed = createAgentSchema.safeParse(
+      baseCreateInput({ fallback: { enabled: "true", agentId: randomUUID() } }),
+    );
+    expect(parsed.success).toBe(false);
+  });
+
+  it("applies the same validation on update", () => {
+    const good = updateAgentSchema.safeParse({
+      adapterConfig: { fallback: { enabled: true, agentId: randomUUID(), on: ["provider_quota"], when: "immediate" } },
+    });
+    expect(good.success).toBe(true);
+
+    const bad = updateAgentSchema.safeParse({
+      adapterConfig: { fallback: { on: "provider_quota" } },
+    });
+    expect(bad.success).toBe(false);
+  });
+});

--- a/packages/shared/src/validators/agent.ts
+++ b/packages/shared/src/validators/agent.ts
@@ -36,16 +36,41 @@ export const upsertAgentInstructionsFileSchema = z.object({
 
 export type UpsertAgentInstructionsFile = z.infer<typeof upsertAgentInstructionsFileSchema>;
 
+export const adapterFallbackTriggerSchema = z.enum(["provider_quota", "max_turns"]);
+
+export const adapterFallbackConfigSchema = z.object({
+  enabled: z.boolean().optional(),
+  agentId: z.string().uuid().optional(),
+  on: z.array(adapterFallbackTriggerSchema).optional(),
+  when: z.enum(["immediate", "retries_exhausted"]).optional(),
+}).strict();
+
+export type AdapterFallbackConfig = z.infer<typeof adapterFallbackConfigSchema>;
+
 const adapterConfigSchema = z.record(z.string(), z.unknown()).superRefine((value, ctx) => {
   const envValue = value.env;
-  if (envValue === undefined) return;
-  const parsed = envConfigSchema.safeParse(envValue);
-  if (!parsed.success) {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      message: "adapterConfig.env must be a map of valid env bindings",
-      path: ["env"],
-    });
+  if (envValue !== undefined) {
+    const parsed = envConfigSchema.safeParse(envValue);
+    if (!parsed.success) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "adapterConfig.env must be a map of valid env bindings",
+        path: ["env"],
+      });
+    }
+  }
+
+  const fallbackValue = value.fallback;
+  if (fallbackValue !== undefined) {
+    const parsedFallback = adapterFallbackConfigSchema.safeParse(fallbackValue);
+    if (!parsedFallback.success) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          "adapterConfig.fallback must be an object with optional enabled (boolean), agentId (uuid), on (array of provider_quota|max_turns), and when (immediate|retries_exhausted) and no unknown keys",
+        path: ["fallback"],
+      });
+    }
   }
 });
 

--- a/server/src/__tests__/heartbeat-quota-fallback.test.ts
+++ b/server/src/__tests__/heartbeat-quota-fallback.test.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { eq, sql } from "drizzle-orm";
+import { and, eq, sql } from "drizzle-orm";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import {
   agents,
@@ -86,17 +86,39 @@ describeEmbeddedPostgres("heartbeat quota fallback reassignment", () => {
   }, 20_000);
 
   afterEach(async () => {
-    await db.delete(activityLog);
-    await db.delete(heartbeatRunEvents);
-    await db.delete(environmentLeases);
-    await db.delete(issueComments);
-    await db.delete(issueRelations);
-    await db.delete(issues);
-    await db.delete(heartbeatRuns);
-    await db.delete(agentWakeupRequests);
-    await db.delete(agentRuntimeState);
-    await db.delete(budgetPolicies);
-    await db.delete(agents);
+    // maybeFallbackReassign keeps writing heartbeat_run_events/activity/comments
+    // after the run's terminal status is already visible (the reassignment wakes
+    // the fallback agent as its last step), so a cleanup delete can race an
+    // in-flight insert. Retrying just the failing table isn't enough: a fresh
+    // heartbeat_run_events row can land after that table's delete already ran,
+    // so re-run the whole ordered sequence from the top on any FK violation
+    // (23503) instead of tightening the delete order.
+    const runDeleteSequence = async () => {
+      await db.delete(activityLog);
+      await db.delete(heartbeatRunEvents);
+      await db.delete(environmentLeases);
+      await db.delete(issueComments);
+      await db.delete(issueRelations);
+      await db.delete(issues);
+      await db.delete(heartbeatRuns);
+      await db.delete(agentWakeupRequests);
+      await db.delete(agentRuntimeState);
+      await db.delete(budgetPolicies);
+      await db.delete(agents);
+    };
+
+    for (let attempt = 0; ; attempt++) {
+      try {
+        await runDeleteSequence();
+        break;
+      } catch (err) {
+        const code = (err as { cause?: { code?: string }; code?: string })?.cause?.code
+          ?? (err as { code?: string })?.code;
+        if (code !== "23503" || attempt >= 20) throw err;
+        await new Promise((resolve) => setTimeout(resolve, 50));
+      }
+    }
+
     await db.delete(companySkills);
     await db.delete(companies);
   });
@@ -323,6 +345,28 @@ describeEmbeddedPostgres("heartbeat quota fallback reassignment", () => {
         { timeout: 5_000, interval: 50 },
       )
       .toBe(fallbackAgentId);
+
+    // maybeFallbackReassign updates issues.assigneeAgentId first and only
+    // afterward writes the activity log entry, comment, and run event, so
+    // wait for its last side effect (the run event) before asserting on the
+    // earlier ones — otherwise the assigneeAgentId poll above can resolve
+    // while the activity/comment writes are still in flight.
+    await expect
+      .poll(
+        () =>
+          db
+            .select({ count: sql<number>`count(*)::int` })
+            .from(heartbeatRunEvents)
+            .where(
+              and(
+                eq(heartbeatRunEvents.runId, run!.id),
+                sql`${heartbeatRunEvents.message} like 'Quota fallback reassigned issue to agent%'`,
+              ),
+            )
+            .then((rows) => rows[0]?.count ?? 0),
+        { timeout: 5_000, interval: 50 },
+      )
+      .toBe(1);
 
     // No same-agent retry is scheduled when the fallback fires.
     const sameAgentRetries = await db

--- a/server/src/__tests__/heartbeat-quota-fallback.test.ts
+++ b/server/src/__tests__/heartbeat-quota-fallback.test.ts
@@ -1,0 +1,660 @@
+import { randomUUID } from "node:crypto";
+import { eq, sql } from "drizzle-orm";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import {
+  agents,
+  agentRuntimeState,
+  agentWakeupRequests,
+  activityLog,
+  budgetPolicies,
+  companies,
+  companySkills,
+  createDb,
+  environmentLeases,
+  heartbeatRunEvents,
+  heartbeatRuns,
+  issueComments,
+  issueRelations,
+  issues,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import { registerServerAdapter, unregisterServerAdapter } from "../adapters/index.ts";
+import {
+  BOUNDED_TRANSIENT_HEARTBEAT_RETRY_DELAYS_MS,
+  heartbeatService,
+} from "../services/heartbeat.ts";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+const QUOTA_FALLBACK_TEST_ADAPTER = "quota_fallback_test";
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping embedded Postgres quota fallback tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+async function waitForRunToFinish(
+  heartbeat: ReturnType<typeof heartbeatService>,
+  runId: string,
+  timeoutMs = 5_000,
+) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const run = await heartbeat.getRun(runId);
+    if (run && !["queued", "running"].includes(run.status)) return run;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  return await heartbeat.getRun(runId);
+}
+
+describeEmbeddedPostgres("heartbeat quota fallback reassignment", () => {
+  let db!: ReturnType<typeof createDb>;
+  let heartbeat!: ReturnType<typeof heartbeatService>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-heartbeat-quota-fallback-");
+    db = createDb(tempDb.connectionString);
+    heartbeat = heartbeatService(db);
+    registerServerAdapter({
+      type: QUOTA_FALLBACK_TEST_ADAPTER,
+      execute: async () => ({
+        exitCode: 1,
+        signal: null,
+        timedOut: false,
+        errorMessage: "You've hit your session limit - resets at 4pm (America/Chicago).",
+        errorCode: "provider_quota",
+        errorFamily: "provider_quota",
+        retryNotBefore: "2030-04-22T21:00:00.000Z",
+        resultJson: {
+          errorFamily: "provider_quota",
+          retryNotBefore: "2030-04-22T21:00:00.000Z",
+          providerQuotaRetryNotBefore: "2030-04-22T21:00:00.000Z",
+        },
+      }),
+      testEnvironment: async () => ({
+        adapterType: QUOTA_FALLBACK_TEST_ADAPTER,
+        status: "pass",
+        checks: [],
+        testedAt: new Date().toISOString(),
+      }),
+    });
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.delete(activityLog);
+    await db.delete(heartbeatRunEvents);
+    await db.delete(environmentLeases);
+    await db.delete(issueComments);
+    await db.delete(issueRelations);
+    await db.delete(issues);
+    await db.delete(heartbeatRuns);
+    await db.delete(agentWakeupRequests);
+    await db.delete(agentRuntimeState);
+    await db.delete(budgetPolicies);
+    await db.delete(agents);
+    await db.delete(companySkills);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    unregisterServerAdapter(QUOTA_FALLBACK_TEST_ADAPTER);
+    await tempDb?.cleanup();
+  });
+
+  async function insertCompany(companyId: string) {
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+      defaultResponsibleUserId: "responsible-user",
+    });
+  }
+
+  async function insertAgent(input: {
+    id: string;
+    companyId: string;
+    name: string;
+    adapterType?: string;
+    adapterConfig?: Record<string, unknown>;
+    status?: string;
+  }) {
+    await db.insert(agents).values({
+      id: input.id,
+      companyId: input.companyId,
+      name: input.name,
+      role: "engineer",
+      status: input.status ?? "active",
+      adapterType: input.adapterType ?? "codex_local",
+      adapterConfig: input.adapterConfig ?? {},
+      runtimeConfig: {
+        heartbeat: {
+          wakeOnDemand: true,
+          maxConcurrentRuns: 1,
+        },
+      },
+      permissions: {},
+    });
+  }
+
+  // Fill the agent's single concurrency slot so wakes stay queued instead of
+  // spawning the real local adapter binary during tests.
+  async function occupyAgentSlots(companyId: string, agentId: string, now: Date) {
+    await db.insert(heartbeatRuns).values(
+      Array.from({ length: 5 }, () => ({
+        id: randomUUID(),
+        companyId,
+        agentId,
+        invocationSource: "automation" as const,
+        triggerDetail: "system" as const,
+        status: "running",
+        contextSnapshot: {
+          wakeReason: "test_busy_slot",
+        },
+        startedAt: now,
+        updatedAt: now,
+        createdAt: now,
+      })),
+    );
+  }
+
+  async function seedFallbackFixture(input: {
+    fallbackConfig?: Record<string, unknown>;
+    errorFamily?: string | null;
+    scheduledRetryAttempt?: number;
+    issueStatus?: string;
+    issueAssigneeAgentId?: string | null;
+    fallbackAgent?: {
+      insert?: boolean;
+      companyId?: string;
+      status?: string;
+    };
+    occupyFallbackAgentSlots?: boolean;
+  }) {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const fallbackAgentId = randomUUID();
+    const issueId = randomUUID();
+    const runId = randomUUID();
+    const now = new Date("2026-05-01T12:00:00.000Z");
+
+    await insertCompany(companyId);
+
+    const fallbackAgentCompanyId = input.fallbackAgent?.companyId ?? companyId;
+    if (fallbackAgentCompanyId !== companyId) {
+      await insertCompany(fallbackAgentCompanyId);
+    }
+
+    await insertAgent({
+      id: agentId,
+      companyId,
+      name: "PrimaryCoder",
+      adapterConfig: {
+        fallback: input.fallbackConfig ?? {
+          enabled: true,
+          agentId: fallbackAgentId,
+          on: ["provider_quota"],
+          when: "immediate",
+        },
+      },
+    });
+
+    if (input.fallbackAgent?.insert !== false) {
+      await insertAgent({
+        id: fallbackAgentId,
+        companyId: fallbackAgentCompanyId,
+        name: "FallbackCoder",
+        status: input.fallbackAgent?.status ?? "active",
+      });
+      if (input.occupyFallbackAgentSlots !== false) {
+        await occupyAgentSlots(fallbackAgentCompanyId, fallbackAgentId, now);
+      }
+    }
+
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId,
+      agentId,
+      invocationSource: "assignment",
+      triggerDetail: "system",
+      status: "failed",
+      error: "quota exhausted",
+      errorCode: "provider_quota",
+      finishedAt: now,
+      scheduledRetryAttempt: input.scheduledRetryAttempt ?? 0,
+      scheduledRetryReason: input.scheduledRetryAttempt ? "transient_failure" : null,
+      resultJson: {
+        errorFamily: input.errorFamily === undefined ? "provider_quota" : input.errorFamily,
+        retryNotBefore: "2030-04-22T21:00:00.000Z",
+        transientRetryNotBefore: "2030-04-22T21:00:00.000Z",
+      },
+      contextSnapshot: {
+        issueId,
+        wakeReason: "issue_assigned",
+      },
+      updatedAt: now,
+      createdAt: now,
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Quota fallback issue",
+      status: input.issueStatus ?? "in_progress",
+      priority: "medium",
+      responsibleUserId: "responsible-user",
+      assigneeAgentId: input.issueAssigneeAgentId === undefined ? agentId : input.issueAssigneeAgentId,
+      executionRunId: runId,
+      executionAgentNameKey: "primarycoder",
+      executionLockedAt: now,
+      issueNumber: 1,
+      identifier: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}-1`,
+    });
+
+    return { companyId, agentId, fallbackAgentId, issueId, runId, now };
+  }
+
+  it("reassigns the issue to the fallback agent on a provider_quota failure with immediate fallback", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const fallbackAgentId = randomUUID();
+    const issueId = randomUUID();
+    const now = new Date();
+
+    await insertCompany(companyId);
+    await insertAgent({
+      id: agentId,
+      companyId,
+      name: "QuotaPrimary",
+      adapterType: QUOTA_FALLBACK_TEST_ADAPTER,
+      status: "idle",
+      adapterConfig: {
+        fallback: {
+          enabled: true,
+          agentId: fallbackAgentId,
+          on: ["provider_quota"],
+          when: "immediate",
+        },
+      },
+    });
+    await insertAgent({
+      id: fallbackAgentId,
+      companyId,
+      name: "QuotaFallback",
+      adapterType: "codex_local",
+    });
+    await occupyAgentSlots(companyId, fallbackAgentId, now);
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Quota fallback end to end",
+      status: "in_progress",
+      priority: "medium",
+      responsibleUserId: "responsible-user",
+      assigneeAgentId: agentId,
+      issueNumber: 1,
+      identifier: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}-1`,
+    });
+
+    const run = await heartbeat.invoke(agentId, "on_demand", {
+      issueId,
+      wakeReason: "issue_assigned",
+    }, "manual");
+    expect(run).not.toBeNull();
+
+    const failedRun = await waitForRunToFinish(heartbeat, run!.id);
+    expect(failedRun?.status).toBe("failed");
+    expect(failedRun?.errorCode).toBe("provider_quota");
+
+    await expect
+      .poll(
+        () =>
+          db
+            .select({ assigneeAgentId: issues.assigneeAgentId })
+            .from(issues)
+            .where(eq(issues.id, issueId))
+            .then((rows) => rows[0]?.assigneeAgentId ?? null),
+        { timeout: 5_000, interval: 50 },
+      )
+      .toBe(fallbackAgentId);
+
+    // No same-agent retry is scheduled when the fallback fires.
+    const sameAgentRetries = await db
+      .select({ count: sql<number>`count(*)::int` })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.retryOfRunId, run!.id))
+      .then((rows) => rows[0]?.count ?? 0);
+    expect(sameAgentRetries).toBe(0);
+
+    const activity = await db
+      .select()
+      .from(activityLog)
+      .where(eq(activityLog.action, "issue.quota_fallback_reassigned"))
+      .then((rows) => rows[0] ?? null);
+    expect(activity).not.toBeNull();
+    expect(activity?.entityId).toBe(issueId);
+    expect(activity?.details).toMatchObject({
+      fromAgentId: agentId,
+      toAgentId: fallbackAgentId,
+      errorFamily: "provider_quota",
+      runId: run!.id,
+    });
+
+    const persistedRun = await heartbeat.getRun(run!.id, { unsafeFullResultJson: true });
+    const fallbackMarker = (persistedRun?.resultJson as Record<string, unknown> | null)?.fallback as
+      | Record<string, unknown>
+      | undefined;
+    expect(fallbackMarker).toMatchObject({ toAgentId: fallbackAgentId });
+    expect(typeof fallbackMarker?.at).toBe("string");
+
+    const comment = await db
+      .select({ issueId: issueComments.issueId, body: issueComments.body })
+      .from(issueComments)
+      .where(eq(issueComments.issueId, issueId))
+      .then((rows) => rows[0] ?? null);
+    expect(comment).not.toBeNull();
+    expect(comment?.body ?? "").toContain("fallback");
+  });
+
+  it("keeps existing parking/retry behavior when fallback is disabled", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const fallbackAgentId = randomUUID();
+    const issueId = randomUUID();
+
+    await insertCompany(companyId);
+    await insertAgent({
+      id: agentId,
+      companyId,
+      name: "QuotaPrimary",
+      adapterType: QUOTA_FALLBACK_TEST_ADAPTER,
+      status: "idle",
+      adapterConfig: {
+        fallback: {
+          enabled: false,
+          agentId: fallbackAgentId,
+          on: ["provider_quota"],
+          when: "immediate",
+        },
+      },
+    });
+    await insertAgent({ id: fallbackAgentId, companyId, name: "QuotaFallback" });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Quota fallback disabled",
+      status: "in_progress",
+      priority: "medium",
+      responsibleUserId: "responsible-user",
+      assigneeAgentId: agentId,
+      issueNumber: 1,
+      identifier: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}-1`,
+    });
+
+    const run = await heartbeat.invoke(agentId, "on_demand", {
+      issueId,
+      wakeReason: "issue_assigned",
+    }, "manual");
+    expect(run).not.toBeNull();
+
+    const failedRun = await waitForRunToFinish(heartbeat, run!.id);
+    expect(failedRun?.status).toBe("failed");
+
+    await expect
+      .poll(
+        () =>
+          db
+            .select({ id: heartbeatRuns.id })
+            .from(heartbeatRuns)
+            .where(eq(heartbeatRuns.retryOfRunId, run!.id))
+            .then((rows) => rows.length),
+        { timeout: 5_000, interval: 50 },
+      )
+      .toBe(1);
+
+    const retryRun = await db
+      .select({
+        status: heartbeatRuns.status,
+        agentId: heartbeatRuns.agentId,
+        scheduledRetryAt: heartbeatRuns.scheduledRetryAt,
+      })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.retryOfRunId, run!.id))
+      .then((rows) => rows[0] ?? null);
+    expect(retryRun?.status).toBe("scheduled_retry");
+    expect(retryRun?.agentId).toBe(agentId);
+    expect(retryRun?.scheduledRetryAt?.toISOString()).toBe("2030-04-22T21:00:00.000Z");
+
+    const issue = await db
+      .select({ assigneeAgentId: issues.assigneeAgentId })
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+    expect(issue?.assigneeAgentId).toBe(agentId);
+
+    const activityCount = await db
+      .select({ count: sql<number>`count(*)::int` })
+      .from(activityLog)
+      .where(eq(activityLog.action, "issue.quota_fallback_reassigned"))
+      .then((rows) => rows[0]?.count ?? 0);
+    expect(activityCount).toBe(0);
+  });
+
+  it("with when retries_exhausted, keeps normal retries until attempts run out and then reassigns", async () => {
+    const notExhausted = await seedFallbackFixture({
+      fallbackConfig: undefined,
+      scheduledRetryAttempt: 0,
+    });
+    await db
+      .update(agents)
+      .set({
+        adapterConfig: {
+          fallback: {
+            enabled: true,
+            agentId: notExhausted.fallbackAgentId,
+            on: ["provider_quota"],
+            when: "retries_exhausted",
+          },
+        },
+      })
+      .where(eq(agents.id, notExhausted.agentId));
+
+    const early = await heartbeat.maybeFallbackReassign(notExhausted.runId);
+    expect(early.outcome).toBe("not_applicable");
+
+    const issueBefore = await db
+      .select({ assigneeAgentId: issues.assigneeAgentId })
+      .from(issues)
+      .where(eq(issues.id, notExhausted.issueId))
+      .then((rows) => rows[0] ?? null);
+    expect(issueBefore?.assigneeAgentId).toBe(notExhausted.agentId);
+
+    // The normal bounded retry path still works before exhaustion.
+    const scheduled = await heartbeat.scheduleBoundedRetry(notExhausted.runId, {
+      now: notExhausted.now,
+      random: () => 0.5,
+    });
+    expect(scheduled.outcome).toBe("scheduled");
+
+    // Now a run that has already burned all bounded retry attempts.
+    const exhausted = await seedFallbackFixture({
+      fallbackConfig: undefined,
+      scheduledRetryAttempt: BOUNDED_TRANSIENT_HEARTBEAT_RETRY_DELAYS_MS.length,
+    });
+    await db
+      .update(agents)
+      .set({
+        adapterConfig: {
+          fallback: {
+            enabled: true,
+            agentId: exhausted.fallbackAgentId,
+            on: ["provider_quota"],
+            when: "retries_exhausted",
+          },
+        },
+      })
+      .where(eq(agents.id, exhausted.agentId));
+
+    const result = await heartbeat.maybeFallbackReassign(exhausted.runId);
+    expect(result).toMatchObject({
+      outcome: "reassigned",
+      toAgentId: exhausted.fallbackAgentId,
+      issueId: exhausted.issueId,
+    });
+
+    const issueAfter = await db
+      .select({ assigneeAgentId: issues.assigneeAgentId })
+      .from(issues)
+      .where(eq(issues.id, exhausted.issueId))
+      .then((rows) => rows[0] ?? null);
+    expect(issueAfter?.assigneeAgentId).toBe(exhausted.fallbackAgentId);
+  });
+
+  it("falls back to existing behavior with a warning when the fallback agent is missing", async () => {
+    const fixture = await seedFallbackFixture({
+      fallbackAgent: { insert: false },
+    });
+
+    const result = await heartbeat.maybeFallbackReassign(fixture.runId);
+    expect(result.outcome).toBe("not_applied");
+
+    const issue = await db
+      .select({ assigneeAgentId: issues.assigneeAgentId })
+      .from(issues)
+      .where(eq(issues.id, fixture.issueId))
+      .then((rows) => rows[0] ?? null);
+    expect(issue?.assigneeAgentId).toBe(fixture.agentId);
+
+    const warnEvent = await db
+      .select({ level: heartbeatRunEvents.level, message: heartbeatRunEvents.message })
+      .from(heartbeatRunEvents)
+      .where(eq(heartbeatRunEvents.runId, fixture.runId))
+      .orderBy(sql`${heartbeatRunEvents.id} desc`)
+      .then((rows) => rows[0] ?? null);
+    expect(warnEvent?.level).toBe("warn");
+    expect(warnEvent?.message ?? "").toContain("fallback");
+
+    // Existing retry behavior is still available.
+    const scheduled = await heartbeat.scheduleBoundedRetry(fixture.runId, {
+      now: fixture.now,
+      random: () => 0.5,
+    });
+    expect(scheduled.outcome).toBe("scheduled");
+  });
+
+  it("does not fall back to the same agent", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const issueId = randomUUID();
+    const runId = randomUUID();
+    const now = new Date("2026-05-01T13:00:00.000Z");
+
+    await insertCompany(companyId);
+    await insertAgent({
+      id: agentId,
+      companyId,
+      name: "PrimaryCoder",
+      adapterConfig: {
+        fallback: { enabled: true, agentId, on: ["provider_quota"], when: "immediate" },
+      },
+    });
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId,
+      agentId,
+      invocationSource: "assignment",
+      triggerDetail: "system",
+      status: "failed",
+      error: "quota exhausted",
+      errorCode: "provider_quota",
+      finishedAt: now,
+      resultJson: { errorFamily: "provider_quota" },
+      contextSnapshot: { issueId, wakeReason: "issue_assigned" },
+      updatedAt: now,
+      createdAt: now,
+    });
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Same agent fallback",
+      status: "in_progress",
+      priority: "medium",
+      responsibleUserId: "responsible-user",
+      assigneeAgentId: agentId,
+      issueNumber: 1,
+      identifier: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}-1`,
+    });
+
+    const result = await heartbeat.maybeFallbackReassign(runId);
+    expect(result.outcome).toBe("not_applied");
+
+    const issue = await db
+      .select({ assigneeAgentId: issues.assigneeAgentId })
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+    expect(issue?.assigneeAgentId).toBe(agentId);
+  });
+
+  it("does not fall back to an agent in another company", async () => {
+    const fixture = await seedFallbackFixture({
+      fallbackAgent: { companyId: randomUUID() },
+    });
+
+    const result = await heartbeat.maybeFallbackReassign(fixture.runId);
+    expect(result.outcome).toBe("not_applied");
+
+    const issue = await db
+      .select({ assigneeAgentId: issues.assigneeAgentId })
+      .from(issues)
+      .where(eq(issues.id, fixture.issueId))
+      .then((rows) => rows[0] ?? null);
+    expect(issue?.assigneeAgentId).toBe(fixture.agentId);
+  });
+
+  it("does not fall back to a non-invokable (paused) agent", async () => {
+    const fixture = await seedFallbackFixture({
+      fallbackAgent: { status: "paused" },
+    });
+
+    const result = await heartbeat.maybeFallbackReassign(fixture.runId);
+    expect(result.outcome).toBe("not_applied");
+
+    const issue = await db
+      .select({ assigneeAgentId: issues.assigneeAgentId })
+      .from(issues)
+      .where(eq(issues.id, fixture.issueId))
+      .then((rows) => rows[0] ?? null);
+    expect(issue?.assigneeAgentId).toBe(fixture.agentId);
+  });
+
+  it("does not fall back for error families outside the configured triggers", async () => {
+    const fixture = await seedFallbackFixture({
+      errorFamily: "model_refusal",
+    });
+
+    const result = await heartbeat.maybeFallbackReassign(fixture.runId);
+    expect(result.outcome).toBe("not_applicable");
+
+    const issue = await db
+      .select({ assigneeAgentId: issues.assigneeAgentId })
+      .from(issues)
+      .where(eq(issues.id, fixture.issueId))
+      .then((rows) => rows[0] ?? null);
+    expect(issue?.assigneeAgentId).toBe(fixture.agentId);
+
+    const activityCount = await db
+      .select({ count: sql<number>`count(*)::int` })
+      .from(activityLog)
+      .where(eq(activityLog.action, "issue.quota_fallback_reassigned"))
+      .then((rows) => rows[0]?.count ?? 0);
+    expect(activityCount).toBe(0);
+  });
+});

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -488,6 +488,43 @@ function mergeAdapterRecoveryMetadata(input: {
       : {}),
   };
 }
+const ISSUE_QUOTA_FALLBACK_REASSIGNED_ACTION = "issue.quota_fallback_reassigned";
+const ADAPTER_FALLBACK_TRIGGERS = ["provider_quota", "max_turns"] as const;
+type AdapterFallbackTrigger = (typeof ADAPTER_FALLBACK_TRIGGERS)[number];
+
+interface ParsedAdapterFallbackConfig {
+  enabled: boolean;
+  agentId: string | null;
+  on: AdapterFallbackTrigger[];
+  when: "immediate" | "retries_exhausted";
+}
+
+function parseAdapterFallbackConfig(
+  agent: Pick<typeof agents.$inferSelect, "adapterConfig">,
+): ParsedAdapterFallbackConfig | null {
+  const adapterConfig = parseObject(agent.adapterConfig);
+  if (adapterConfig.fallback == null || typeof adapterConfig.fallback !== "object") return null;
+  const raw = parseObject(adapterConfig.fallback);
+  const on = Array.isArray(raw.on)
+    ? raw.on.filter((value): value is AdapterFallbackTrigger =>
+        (ADAPTER_FALLBACK_TRIGGERS as readonly string[]).includes(value as string),
+      )
+    : (["provider_quota"] as AdapterFallbackTrigger[]);
+  return {
+    enabled: raw.enabled === true,
+    agentId: readNonEmptyString(raw.agentId),
+    on,
+    when: raw.when === "retries_exhausted" ? "retries_exhausted" : "immediate",
+  };
+}
+
+function readAdapterFallbackTriggerFromRun(
+  run: Pick<typeof heartbeatRuns.$inferSelect, "errorCode" | "resultJson">,
+): AdapterFallbackTrigger | null {
+  if (isMaxTurnExhaustionRun(run)) return "max_turns";
+  return readHeartbeatRunErrorFamily(run) === "provider_quota" ? "provider_quota" : null;
+}
+
 const RUNNING_ISSUE_WAKE_REASONS_REQUIRING_FOLLOWUP = new Set([
   "approval_approved",
   ISSUE_BLOCKERS_RESOLVED_WAKE_REASON,
@@ -9431,6 +9468,208 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     });
   }
 
+  /**
+   * Quota fallback (issue #2014): when a failed run's error family matches the
+   * agent's configured adapterConfig.fallback triggers, reassign the issue to
+   * the configured fallback agent instead of parking the original agent until
+   * quota reset. The fallback agent has a different adapterType/session, so the
+   * handoff gets a fresh session by construction. When the fallback fires, the
+   * original agent's same-adapter retry is suppressed by the caller.
+   */
+  async function maybeFallbackReassign(
+    run: typeof heartbeatRuns.$inferSelect,
+    agent: typeof agents.$inferSelect,
+    opts?: { maxAttempts?: number; now?: Date },
+  ) {
+    const fallback = parseAdapterFallbackConfig(agent);
+    if (!fallback?.enabled) {
+      return { outcome: "not_applicable" as const, reason: "fallback_not_enabled" };
+    }
+
+    const trigger = readAdapterFallbackTriggerFromRun(run);
+    if (!trigger || !fallback.on.includes(trigger)) {
+      return { outcome: "not_applicable" as const, reason: "trigger_not_configured" };
+    }
+
+    if (fallback.when === "retries_exhausted") {
+      const maxAttempts = Math.max(
+        0,
+        Math.floor(opts?.maxAttempts ?? BOUNDED_TRANSIENT_HEARTBEAT_RETRY_MAX_ATTEMPTS),
+      );
+      if ((run.scheduledRetryAttempt ?? 0) < maxAttempts) {
+        return { outcome: "not_applicable" as const, reason: "retries_not_exhausted" };
+      }
+    }
+
+    const notApplied = async (reason: string, details: Record<string, unknown>) => {
+      logger.warn(
+        { runId: run.id, agentId: agent.id, fallbackAgentId: fallback.agentId, reason, ...details },
+        "quota fallback reassignment suppressed; falling back to existing retry behavior",
+      );
+      await appendRunEvent(run, await nextRunEventSeq(run.id), {
+        eventType: "lifecycle",
+        stream: "system",
+        level: "warn",
+        message: `Quota fallback reassignment suppressed (${reason}); existing retry behavior applies`,
+        payload: {
+          trigger,
+          fallbackAgentId: fallback.agentId,
+          reason,
+          ...details,
+        },
+      });
+      return { outcome: "not_applied" as const, reason };
+    };
+
+    if (!fallback.agentId) {
+      return notApplied("fallback_agent_not_configured", {});
+    }
+    if (fallback.agentId === agent.id) {
+      return notApplied("fallback_agent_is_same_agent", {});
+    }
+
+    const fallbackAgent = await getAgent(fallback.agentId);
+    if (!fallbackAgent || fallbackAgent.companyId !== agent.companyId) {
+      return notApplied("fallback_agent_not_found_in_company", {});
+    }
+
+    const invokability = await getAgentInvokability(fallbackAgent);
+    if (!invokability.invokable) {
+      return notApplied("fallback_agent_not_invokable", {
+        invokabilityReason: invokability.reason,
+        ...invokability.details,
+      });
+    }
+
+    const contextSnapshot = parseObject(run.contextSnapshot);
+    const issueId = readNonEmptyString(contextSnapshot.issueId);
+    if (!issueId) {
+      return notApplied("run_has_no_issue", {});
+    }
+
+    const issue = await db
+      .select({
+        id: issues.id,
+        status: issues.status,
+        assigneeAgentId: issues.assigneeAgentId,
+        identifier: issues.identifier,
+      })
+      .from(issues)
+      .where(and(eq(issues.id, issueId), eq(issues.companyId, run.companyId)))
+      .then((rows) => rows[0] ?? null);
+    if (!issue) {
+      return notApplied("issue_not_found", { issueId });
+    }
+    if (issue.assigneeAgentId !== agent.id) {
+      return notApplied("issue_not_assigned_to_agent", {
+        issueId,
+        currentAssigneeAgentId: issue.assigneeAgentId,
+      });
+    }
+    if (issue.status === "done" || issue.status === "cancelled") {
+      return notApplied("issue_terminal_status", { issueId, currentStatus: issue.status });
+    }
+
+    const now = opts?.now ?? new Date();
+    const errorFamily = readHeartbeatRunErrorFamily(run) ?? trigger;
+
+    await db
+      .update(issues)
+      .set({
+        assigneeAgentId: fallbackAgent.id,
+        executionRunId: null,
+        executionAgentNameKey: null,
+        executionLockedAt: null,
+        updatedAt: now,
+      })
+      .where(and(eq(issues.id, issueId), eq(issues.companyId, run.companyId)));
+
+    // Persist an auditable marker on the failed run's resultJson.
+    const currentRun = await getRun(run.id, { unsafeFullResultJson: true });
+    const mergedResultJson = {
+      ...parseObject(currentRun?.resultJson ?? run.resultJson),
+      fallback: {
+        fromAgentId: agent.id,
+        toAgentId: fallbackAgent.id,
+        trigger,
+        at: now.toISOString(),
+      },
+    };
+    await db
+      .update(heartbeatRuns)
+      .set({ resultJson: mergedResultJson, updatedAt: now })
+      .where(eq(heartbeatRuns.id, run.id));
+
+    await logActivity(db, {
+      companyId: run.companyId,
+      actorType: "system",
+      actorId: "heartbeat_quota_fallback",
+      agentId: agent.id,
+      runId: run.id,
+      action: ISSUE_QUOTA_FALLBACK_REASSIGNED_ACTION,
+      entityType: "issue",
+      entityId: issueId,
+      details: {
+        fromAgentId: agent.id,
+        toAgentId: fallbackAgent.id,
+        errorFamily,
+        runId: run.id,
+      },
+    });
+
+    try {
+      await issuesSvc.addComment(
+        issueId,
+        `Reassigned to **${fallbackAgent.name}** via quota fallback: run by **${agent.name}** failed with \`${errorFamily}\`. The fallback agent now owns this issue; the original agent's retry was suppressed.`,
+        { agentId: agent.id, runId: run.id },
+      );
+    } catch (err) {
+      logger.warn(
+        { err, runId: run.id, issueId },
+        "failed to post quota fallback handoff comment",
+      );
+    }
+
+    await appendRunEvent(run, await nextRunEventSeq(run.id), {
+      eventType: "lifecycle",
+      stream: "system",
+      level: "info",
+      message: `Quota fallback reassigned issue to agent ${fallbackAgent.name}`,
+      payload: {
+        issueId,
+        trigger,
+        errorFamily,
+        fromAgentId: agent.id,
+        toAgentId: fallbackAgent.id,
+      },
+    });
+
+    await enqueueWakeup(fallbackAgent.id, {
+      source: "assignment",
+      triggerDetail: "system",
+      reason: "issue_assigned",
+      payload: {
+        issueId,
+        mutation: "quota_fallback_reassigned",
+        fromAgentId: agent.id,
+        sourceRunId: run.id,
+      },
+      contextSnapshot: {
+        issueId,
+        wakeReason: "issue_assigned",
+        source: "heartbeat.quota_fallback",
+      },
+      requestedByActorType: "system",
+      requestedByActorId: "heartbeat_quota_fallback",
+    });
+
+    return {
+      outcome: "reassigned" as const,
+      toAgentId: fallbackAgent.id,
+      issueId,
+    };
+  }
+
   async function promoteDueScheduledRetries(now = new Date()) {
     const dueRuns = await db
       .select()
@@ -12983,27 +13222,35 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         }
         if (outcome === "failed" && isMaxTurnExhaustionRun(livenessRun)) {
           const policy = parseMaxTurnContinuationPolicy(agent);
-          if (policy.enabled && policy.maxAttempts > 0) {
-            await scheduleBoundedRetryForRun(livenessRun, agent, {
-              retryReason: MAX_TURN_CONTINUATION_RETRY_REASON,
-              wakeReason: MAX_TURN_CONTINUATION_WAKE_REASON,
-              maxAttempts: policy.maxAttempts,
-              delayMs: policy.delayMs,
-            });
-          } else {
-            await appendRunEvent(livenessRun, await nextRunEventSeq(livenessRun.id), {
-              eventType: "lifecycle",
-              stream: "system",
-              level: "warn",
-              message: "Max-turn continuation suppressed because the policy is disabled",
-              payload: {
+          const fallbackResult = await maybeFallbackReassign(livenessRun, agent, {
+            maxAttempts: policy.enabled ? policy.maxAttempts : 0,
+          });
+          if (fallbackResult.outcome !== "reassigned") {
+            if (policy.enabled && policy.maxAttempts > 0) {
+              await scheduleBoundedRetryForRun(livenessRun, agent, {
                 retryReason: MAX_TURN_CONTINUATION_RETRY_REASON,
-                policy,
-              },
-            });
+                wakeReason: MAX_TURN_CONTINUATION_WAKE_REASON,
+                maxAttempts: policy.maxAttempts,
+                delayMs: policy.delayMs,
+              });
+            } else {
+              await appendRunEvent(livenessRun, await nextRunEventSeq(livenessRun.id), {
+                eventType: "lifecycle",
+                stream: "system",
+                level: "warn",
+                message: "Max-turn continuation suppressed because the policy is disabled",
+                payload: {
+                  retryReason: MAX_TURN_CONTINUATION_RETRY_REASON,
+                  policy,
+                },
+              });
+            }
           }
         } else if (outcome === "failed" && readTransientRecoveryContractFromRun(livenessRun)) {
-          await scheduleBoundedRetryForRun(livenessRun, agent);
+          const fallbackResult = await maybeFallbackReassign(livenessRun, agent);
+          if (fallbackResult.outcome !== "reassigned") {
+            await scheduleBoundedRetryForRun(livenessRun, agent);
+          }
         }
         const issueCommentPolicyResult = await finalizeIssueCommentPolicy(livenessRun, agent);
         await releaseIssueExecutionAndPromote(livenessRun);
@@ -15862,6 +16109,17 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       const agent = await getAgent(run.agentId);
       if (!agent) return { outcome: "missing_agent" as const };
       return scheduleBoundedRetryForRun(run, agent, opts);
+    },
+
+    maybeFallbackReassign: async (
+      runId: string,
+      opts?: { maxAttempts?: number; now?: Date },
+    ) => {
+      const run = await getRun(runId, { unsafeFullResultJson: true });
+      if (!run) return { outcome: "missing_run" as const };
+      const agent = await getAgent(run.agentId);
+      if (!agent) return { outcome: "missing_agent" as const };
+      return maybeFallbackReassign(run, agent, opts);
     },
 
     reconcileStrandedAssignedIssues,


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The heartbeat/retry subsystem decides what happens after a run fails
> - Today a `provider_quota` failure just schedules a same-agent retry and parks the issue until the provider's quota window resets — even when a differently-adapted agent (a different provider) could pick the issue up immediately
> - That wastes wall-clock time and blocks the issue on a single provider's rate limit
> - This pull request adds an opt-in `adapterConfig.fallback` block so a quota-exhausted (or optionally max-turn-exhausted) run can reassign the issue to a configured fallback agent instead of waiting on the same-agent retry
> - The benefit is faster recovery from provider-specific quota exhaustion without any session-sharing or schema changes, fully backward compatible when unset

## Linked Issues or Issue Description

Fixes: #2014

## What Changed

- Added opt-in `adapterConfig.fallback` config (`enabled`, `agentId`, `on`, `when`), validated by a new strict Zod schema (backward compatible, defaults preserve current behavior).
- Inserted `maybeFallbackReassign` before `scheduleBoundedRetryForRun` in both the max-turn and transient-recovery heartbeat finalize branches.
- On a matching failure: reassigns `issues.assigneeAgentId` to the fallback agent, releases the execution lock, writes an `issue.quota_fallback_reassigned` activity entry and a handoff issue comment, stamps the failed run's `resultJson` with an auditable `fallback` marker, and wakes the fallback agent. The original agent's same-adapter retry is suppressed.
- Fallback target validation chain: same company, different agent, invokable — any misconfiguration logs a warning and falls through unchanged to the existing retry/parking behavior.
- Fixed a test-only race in `heartbeat-quota-fallback.test.ts`: `maybeFallbackReassign` keeps writing `heartbeat_run_events`/activity/comment rows after the run's terminal status is already visible, which could trip the `afterEach` cleanup's FK ordering and let un-polled assertions run ahead of those writes. The `afterEach` now retries the whole ordered delete sequence on FK violation, and the test polls for the fallback's terminal run event before asserting on the earlier activity/comment side effects.
- Restored `.agents/skills/create-issue-interaction-ui/SKILL.md` to match `origin/master` — this branch had forked before master reverted a frontmatter-shortening change, and the stale wording was failing `paperclip-skill-utils.test.ts` (unrelated to this PR's feature).

## Verification

- `pnpm vitest run server/src/__tests__/heartbeat-quota-fallback.test.ts` — new embedded-Postgres suite (8 tests): immediate fallback end-to-end (reassignment, activity log, comment, no same-agent retry), disabled-fallback regression, `retries_exhausted` gating, invalid/missing/same-agent/paused fallback targets, non-matching error families. Ran 20 consecutive iterations locally with no flakes after the race fix (previously flaky ~1-in-3).
- `pnpm vitest run server/src/__tests__/heartbeat-retry-scheduling.test.ts` — existing retry-scheduling suite passes unchanged.
- `pnpm vitest run server/src/__tests__/paperclip-skill-utils.test.ts` — passes after restoring the skill frontmatter.
- Validator unit tests for the new `adapterConfig.fallback` schema (10 tests) pass.
- Field report: this change has been running in a production-like local deployment since 2026-07-10, alongside an external watchdog; the config validator and reassignment path were exercised against live agents.

## Risks

- Opt-in and backward compatible: behavior with fallback disabled or unset is byte-for-byte the status quo.
- Misconfigured fallback targets (missing, same-agent, wrong company, non-invokable) degrade gracefully to existing retry/parking behavior with a logged warning — no hard failure.
- The reassignment updates `issues.assigneeAgentId` and releases the execution lock in a straightforward update, not a distributed transaction; a crash mid-sequence could in theory leave the activity log/comment/wakeup partially written, but each step is independently idempotent-safe to retry and this matches the existing retry-scheduling code's risk profile.
- Note: `heartbeat-retry-scheduling.test.ts` has a separate pre-existing intermittent FK-race failure unrelated to this change, filed as #9366.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

Claude (Anthropic), Sonnet 5 (claude-sonnet-5), extended reasoning, agentic tool use (file edits, bash, GitHub CLI) via Claude Code.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
