### PR TITLE
fix(hermes-gateway): keep session keys within provider prompt_cache_key limits

### DIFF
--- a/packages/adapters/hermes/src/gateway/server/execute.test.ts
+++ b/packages/adapters/hermes/src/gateway/server/execute.test.ts
@@ -69,6 +69,176 @@ describe("resolveSessionKey", () => {
       }),
     ).toBeNull();
   });
+
+  it("passes through within-limit keys unchanged (no unnecessary hashing)", () => {
+    expect(
+      resolveSessionKey({
+        strategy: "issue",
+        companyId: "company-1",
+        agentId: "agent-1",
+        runId: "run-1",
+        issueId: "issue-1",
+      }),
+    ).toBe("paperclip:company:company-1:agent:agent-1:issue:issue-1");
+  });
+});
+
+// UUID-length (36-char) ids, matching what Paperclip actually issues for company/agent/issue/run,
+// used to reproduce and verify the fix for https://github.com/paperclipai/paperclip/issues/8713
+// (hermes_gateway session keys exceeding OpenAI's 64-char prompt_cache_key limit).
+describe("resolveSessionKey - prompt_cache_key length limit (issue #8713)", () => {
+  const uuidCompany = "11111111-1111-4111-8111-111111111111";
+  const uuidAgent = "22222222-2222-4222-8222-222222222222";
+  const uuidIssue = "33333333-3333-4333-8333-333333333333";
+  const uuidRun = "44444444-4444-4444-8444-444444444444";
+
+  const otherCompany = "55555555-5555-4555-8555-555555555555";
+  const otherAgent = "66666666-6666-4666-8666-666666666666";
+  const otherIssue = "77777777-7777-4777-8777-777777777777";
+
+  it("keeps issue-strategy keys within the 64-char limit for worst-case UUID ids", () => {
+    const key = resolveSessionKey({
+      strategy: "issue",
+      companyId: uuidCompany,
+      agentId: uuidAgent,
+      runId: uuidRun,
+      issueId: uuidIssue,
+    });
+    expect(key).not.toBeNull();
+    expect((key as string).length).toBeLessThanOrEqual(64);
+    expect(key).toMatch(/^paperclip:i:[0-9a-f]{48}$/);
+  });
+
+  it("keeps agent-strategy keys within the 64-char limit for worst-case UUID ids", () => {
+    const key = resolveSessionKey({
+      strategy: "agent",
+      companyId: uuidCompany,
+      agentId: uuidAgent,
+      runId: uuidRun,
+      issueId: uuidIssue,
+    });
+    expect(key).not.toBeNull();
+    expect((key as string).length).toBeLessThanOrEqual(64);
+    expect(key).toMatch(/^paperclip:a:[0-9a-f]{48}$/);
+  });
+
+  it("keeps run-strategy keys within the 64-char limit for worst-case UUID ids (already fits, passes through)", () => {
+    const key = resolveSessionKey({
+      strategy: "run",
+      companyId: uuidCompany,
+      agentId: uuidAgent,
+      runId: uuidRun,
+      issueId: uuidIssue,
+    });
+    expect(key).toBe(`paperclip:run:${uuidRun}`);
+    expect((key as string).length).toBeLessThanOrEqual(64);
+  });
+
+  it("compacts the issue strategy's run-id fallback (no issueId) the same way once it exceeds the limit", () => {
+    const longRunId = `${uuidRun}-extra-long-suffix-that-forces-overflow`;
+    const key = resolveSessionKey({
+      strategy: "issue",
+      companyId: uuidCompany,
+      agentId: uuidAgent,
+      runId: longRunId,
+      issueId: null,
+    });
+    expect(key).not.toBeNull();
+    expect((key as string).length).toBeLessThanOrEqual(64);
+    expect(key).toMatch(/^paperclip:i:[0-9a-f]{48}$/);
+  });
+
+  it("is deterministic: identical scope inputs always produce the identical compacted key", () => {
+    const input = {
+      strategy: "issue" as const,
+      companyId: uuidCompany,
+      agentId: uuidAgent,
+      runId: uuidRun,
+      issueId: uuidIssue,
+    };
+    const first = resolveSessionKey(input);
+    const second = resolveSessionKey({ ...input });
+    const third = resolveSessionKey({ ...input });
+    expect(first).not.toBeNull();
+    expect(first).toBe(second);
+    expect(second).toBe(third);
+  });
+
+  it("does not collide across distinct issues under the same company/agent", () => {
+    const keyA = resolveSessionKey({
+      strategy: "issue",
+      companyId: uuidCompany,
+      agentId: uuidAgent,
+      runId: uuidRun,
+      issueId: uuidIssue,
+    });
+    const keyB = resolveSessionKey({
+      strategy: "issue",
+      companyId: uuidCompany,
+      agentId: uuidAgent,
+      runId: uuidRun,
+      issueId: otherIssue,
+    });
+    expect(keyA).not.toBeNull();
+    expect(keyB).not.toBeNull();
+    expect(keyA).not.toBe(keyB);
+  });
+
+  it("does not collide across distinct agents under the same company", () => {
+    const keyA = resolveSessionKey({
+      strategy: "agent",
+      companyId: uuidCompany,
+      agentId: uuidAgent,
+      runId: uuidRun,
+      issueId: null,
+    });
+    const keyB = resolveSessionKey({
+      strategy: "agent",
+      companyId: uuidCompany,
+      agentId: otherAgent,
+      runId: uuidRun,
+      issueId: null,
+    });
+    expect(keyA).not.toBe(keyB);
+  });
+
+  it("does not collide across distinct companies", () => {
+    const keyA = resolveSessionKey({
+      strategy: "issue",
+      companyId: uuidCompany,
+      agentId: uuidAgent,
+      runId: uuidRun,
+      issueId: uuidIssue,
+    });
+    const keyB = resolveSessionKey({
+      strategy: "issue",
+      companyId: otherCompany,
+      agentId: uuidAgent,
+      runId: uuidRun,
+      issueId: uuidIssue,
+    });
+    expect(keyA).not.toBe(keyB);
+  });
+
+  it("does not collide across strategies for identical scope ids, and keeps distinguishable scope-letter prefixes", () => {
+    const issueKey = resolveSessionKey({
+      strategy: "issue",
+      companyId: uuidCompany,
+      agentId: uuidAgent,
+      runId: uuidRun,
+      issueId: uuidIssue,
+    });
+    const agentKey = resolveSessionKey({
+      strategy: "agent",
+      companyId: uuidCompany,
+      agentId: uuidAgent,
+      runId: uuidRun,
+      issueId: uuidIssue,
+    });
+    expect(issueKey).not.toBe(agentKey);
+    expect(issueKey).toMatch(/^paperclip:i:/);
+    expect(agentKey).toMatch(/^paperclip:a:/);
+  });
 });
 
 describe("parseSseFramesForTest", () => {

--- a/packages/adapters/hermes/src/gateway/server/execute.ts
+++ b/packages/adapters/hermes/src/gateway/server/execute.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import type {
   AdapterExecutionContext,
   AdapterExecutionResult,
@@ -70,7 +71,14 @@ const SENSITIVE_KEY_PATTERN =
 const BEARER_TOKEN_PATTERN = /Bearer\s+\S+/gi;
 const HERMES_SESSION_KEY_HEADER_PATTERN = /(X-Hermes-Session-Key\s*[:=]\s*)([^\s,;]+)/gi;
 const PAPERCLIP_SESSION_KEY_PATTERN =
-  /\bpaperclip:(?:company:[A-Za-z0-9-]+:agent:[A-Za-z0-9-]+(?::(?:issue|run):[A-Za-z0-9-]+)?|run:[A-Za-z0-9-]+)\b/gi;
+  /\bpaperclip:(?:company:[A-Za-z0-9-]+:agent:[A-Za-z0-9-]+(?::(?:issue|run):[A-Za-z0-9-]+)?|run:[A-Za-z0-9-]+|[iar]:[0-9a-f]{48})\b/gi;
+
+// Hermes forwards X-Hermes-Session-Key to its OpenAI-family transport as `prompt_cache_key`,
+// which OpenAI hard-caps at 64 characters (requests over that limit are rejected with HTTP 400).
+// Composed keys with UUID company/agent/issue ids blow well past this (issue ~140 chars,
+// agent ~97 chars), so every over-length key must be compacted before it leaves this adapter.
+const MAX_SESSION_KEY_CHARS = 64;
+const SESSION_KEY_HASH_HEX_CHARS = 48;
 
 const TERMINAL_STATUSES = new Set([
   "completed",
@@ -146,7 +154,28 @@ function issueIdFromContext(ctx: AdapterExecutionContext): string | null {
   return nonEmpty(ctx.context.taskId) ?? nonEmpty(ctx.context.issueId);
 }
 
-export function resolveSessionKey(input: {
+// Short, human-debuggable label kept ahead of the hash so a compacted key still hints at which
+// strategy produced it (e.g. "paperclip:i:<hash>" reads as issue-scoped) without needing to
+// reverse the hash. The "issue" strategy's run-id fallback (no issueId on the run) still uses
+// "i" since it is the issue strategy falling back, not the run strategy itself.
+function sessionKeyScopeLabel(strategy: Exclude<SessionKeyStrategy, "none">): string {
+  if (strategy === "agent") return "a";
+  if (strategy === "run") return "r";
+  return "i";
+}
+
+// Deterministically compacts a composed session key to fit within MAX_SESSION_KEY_CHARS.
+// Keys already within the limit pass through unchanged. Over-length keys are rehashed with
+// SHA-256 (not truncated) so that scopes sharing a long common prefix — e.g. two issues under
+// the same company/agent — cannot collide, and the same logical scope always produces the same
+// compacted key (no randomness, no timestamps).
+function compactSessionKey(strategy: Exclude<SessionKeyStrategy, "none">, key: string): string {
+  if (key.length <= MAX_SESSION_KEY_CHARS) return key;
+  const digest = createHash("sha256").update(key).digest("hex").slice(0, SESSION_KEY_HASH_HEX_CHARS);
+  return `paperclip:${sessionKeyScopeLabel(strategy)}:${digest}`;
+}
+
+function composeRawSessionKey(input: {
   strategy: SessionKeyStrategy;
   companyId: string;
   agentId: string;
@@ -162,6 +191,20 @@ export function resolveSessionKey(input: {
   }
   const issuePart = input.issueId ? `issue:${input.issueId}` : `run:${input.runId}`;
   return `paperclip:company:${input.companyId}:agent:${input.agentId}:${issuePart}`;
+}
+
+export function resolveSessionKey(input: {
+  strategy: SessionKeyStrategy;
+  companyId: string;
+  agentId: string;
+  runId: string;
+  issueId: string | null;
+}): string | null {
+  const rawKey = composeRawSessionKey(input);
+  if (rawKey === null) return null;
+  // input.strategy is guaranteed to not be "none" here since composeRawSessionKey only
+  // returns null for that case.
+  return compactSessionKey(input.strategy as Exclude<SessionKeyStrategy, "none">, rawKey);
 }
 
 function stringifyForLog(value: unknown, maxChars = 4_000): string {


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Agents can run remotely through the `hermes_gateway` adapter, which resumes a per-issue/per-agent Hermes session by sending a composed key as the `X-Hermes-Session-Key` header
> - Hermes forwards that value to its transport as `prompt_cache_key` when running on OpenAI-family providers, and OpenAI hard-caps `prompt_cache_key` at 64 characters
> - But `resolveSessionKey()` composes keys from UUID company/agent/issue ids that reach ~140 chars for the `issue` strategy (the default) and ~97 chars for `agent` — both blow past the limit and get rejected with an HTTP 400, silently losing prompt caching and per-issue/agent session continuity (the only workaround was `sessionKeyStrategy: "none"`, which drops continuity entirely)
> - This PR adds `compactSessionKey()`, applied at the single point where every strategy produces its final key, so keys ≤64 chars pass through unchanged and over-length keys are deterministically rehashed into a short, strategy-labeled, ≤64-char form
> - The benefit is that `issue` and `agent` session-key strategies keep working against OpenAI-family providers over the gateway, without losing session continuity, per-issue isolation, or prompt caching

## Linked Issues or Issue Description

Fixes #8713.

Related: #8714 (closed, not merged) — an earlier PR by @rsaulo for the same issue, using a similar SHA-256-compaction approach. It went quiet after Greptile review with no explicit rejection reason and was self-closed by the author. Calling it out per CONTRIBUTING's "Before You Start: Search First" / prior-PR guidance. This PR is an independent implementation: it routes all three strategies through one composition point instead of wrapping each strategy branch individually, uses per-strategy scope-letter prefixes (`i`/`a`/`r`) instead of a single generic label so a compacted key still hints at which strategy produced it, updates the existing session-key log-redaction regex to match the new compacted format, and adds a broader test matrix (worst-case 36-char UUIDs, determinism, and pairwise distinctness across issues/agents/companies/strategies).

Real-world confirmation from #8713's comments (self-hosted setup, `hermes_gateway` adapter, default `issue` strategy):
```
HTTP 400: Invalid 'prompt_cache_key': string too long. Expected a string with maximum length 64, but got a string with length 138 instead. (hermes_gateway_run_failed)
```

## What Changed

- `packages/adapters/hermes/src/gateway/server/execute.ts`:
  - Add `MAX_SESSION_KEY_CHARS = 64` and `compactSessionKey()`: keys within the limit pass through unchanged; over-length keys are rehashed with SHA-256 (not truncated — truncation would collide on the long shared `paperclip:company:<id>:agent:<id>:` prefix that `issue` and `agent` scopes share) into `paperclip:<i|a|r>:<48-hex-chars>` (60 chars total), where the letter is a human-debuggable hint at which strategy produced the key.
  - Split `resolveSessionKey()` into `composeRawSessionKey()` (unchanged logical composition per strategy) + a single call into `compactSessionKey()`, so the ≤64-char invariant is structural for all strategies (including any added in the future) rather than bolted onto individual branches.
  - Extend `PAPERCLIP_SESSION_KEY_PATTERN` (used for redacting session keys out of logs) to also match the new compacted format, so compacted keys stay redacted in log output.
- `packages/adapters/hermes/src/gateway/server/execute.test.ts`:
  - New `describe` block with 9 tests covering: `issue`/`agent`/`run` strategies staying ≤64 chars with worst-case 36-char UUID ids; the `issue` strategy's run-id fallback (no `issueId`) compacting the same way when it overflows; determinism (identical scope inputs always produce the identical key across repeated calls); no collisions across distinct issues, agents, companies, or strategies for otherwise-identical scope ids; and pass-through (byte-for-byte, no hashing) for keys already within the limit.

## Verification

```bash
# from packages/adapters/hermes
pnpm exec vitest run src/gateway/server/execute.test.ts
#  Test Files  1 passed (1)
#       Tests  31 passed (31)

pnpm test        # full package suite
#  Test Files  7 passed (7)
#       Tests  65 passed (65)

pnpm typecheck   # tsc --noEmit — clean, no output
pnpm build       # tsc — clean, no output
```

`pnpm lint` in this package invokes `eslint`, but `eslint` isn't declared as a dependency anywhere in the repo (confirmed via `git ls-files | grep -i eslint` — no config, no package.json reference) and isn't part of `.github/workflows/pr.yml`'s CI gates, so it isn't runnable in a clean checkout; not something this PR introduces.

Character counts before/after, using 36-char UUID company/agent/issue ids (matches #8713's table):

| `sessionKeyStrategy` | before | after |
|---|---|---|
| `issue` (default) | 141 | 60 |
| `agent` | 98 | 60 |
| `run` | 50 (unaffected) | 50 (unaffected) |
| `none` | — | — |

## Risks

Low.

- Keys already within the limit — including the `run` strategy and any short/non-UUID ids — pass through byte-for-byte unchanged, so behavior for those is identical to today.
- **Compat note:** `run`-scoped sessions are already per-run, so this change is a no-op for them. `issue`/`agent`-scoped sessions created before this fix — on providers that tolerated the old long keys (i.e. anything not enforcing OpenAI's 64-char `prompt_cache_key` limit) — will get a new (compacted) key exactly once, on their next wake after this ships. That's a one-time cache-key rotation: a single fresh session with no data loss, then the key stays stable going forward, same as before.
- No schema migration, no public API surface change, no config schema change (`sessionKeyStrategy` options are unchanged).
- SHA-256 truncated to 48 hex chars (192-bit) is used instead of naive prefix truncation of the raw key specifically because `issue` and `agent` scopes share a long `paperclip:company:<id>:agent:<id>:` prefix — truncating the raw string would collide different issues/runs under the same agent onto the same key, silently merging their session continuity. Hashing the full raw key (including the differentiating suffix) avoids that.

## Model Used

- **Provider / model:** Anthropic — Claude Sonnet 5 (`claude-sonnet-5`)
- **Harness:** Claude Code (agentic tool use: repo read, edits, local test/typecheck/build execution, `gh` for issue/PR search)
- **Context window:** 200K tokens
- A human operator directed and reviewed this change before it was opened as a PR.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes — N/A, no user-facing docs describe internal session-key composition/length behavior
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green — typecheck, build, and tests pass locally; `lint` is not a wired CI gate and `eslint` isn't installable in this repo (see Verification)
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups — pending automated review on this PR
- [x] I will address all Greptile and reviewer comments before requesting merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
