### PR TITLE
fix(hermes): reject malformed task bridge successes

### DIFF
--- a/packages/adapters/hermes/skills/paperclip-task-bridge/paperclip-task.mjs
+++ b/packages/adapters/hermes/skills/paperclip-task-bridge/paperclip-task.mjs
@@ -53,6 +53,49 @@ class ApiError extends Error {
   }
 }
 
+function redactDiagnosticValue(value) {
+  if (Array.isArray(value)) {
+    return value.slice(0, 10).map((entry) => redactDiagnosticValue(entry));
+  }
+  if (!value || typeof value !== "object") {
+    return typeof value === "string" && value.length > 500 ? `${value.slice(0, 500)}...` : value;
+  }
+  const out = {};
+  for (const [key, raw] of Object.entries(value).slice(0, 25)) {
+    if (/authorization|api[_-]?key|token|secret|password|credential/i.test(key)) {
+      out[key] = "[redacted]";
+      continue;
+    }
+    out[key] = redactDiagnosticValue(raw);
+  }
+  return out;
+}
+
+function malformedSuccess(command, reason, body) {
+  return new ApiError(502, {
+    error: `Malformed Paperclip API success response for ${command}`,
+    details: {
+      reason,
+      response: redactDiagnosticValue(body),
+    },
+  });
+}
+
+function requireObjectResponse(command, body) {
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    throw malformedSuccess(command, "expected JSON object response", body);
+  }
+  return body;
+}
+
+function requireNonEmptyStringField(command, body, field) {
+  const value = body?.[field];
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw malformedSuccess(command, `expected non-empty ${field}`, body);
+  }
+  return value;
+}
+
 function parseArgs(argv) {
   const out = { _: [] };
   for (let i = 0; i < argv.length; i += 1) {
@@ -224,10 +267,11 @@ async function listAssigned(config, args) {
   const status = readStringFlag(args, "status") || "todo,in_progress,in_review,blocked";
   const limit = parseLimit(args);
   const issues = await apiFetch(config, "/agents/me/inbox-lite");
+  if (!Array.isArray(issues)) {
+    throw malformedSuccess("list-assigned", "expected JSON array response", issues);
+  }
   const allowedStatuses = new Set(status.split(",").map((entry) => entry.trim()).filter(Boolean));
-  const filteredIssues = Array.isArray(issues)
-    ? issues.filter((issue) => !allowedStatuses.size || allowedStatuses.has(issue?.status)).slice(0, limit)
-    : [];
+  const filteredIssues = issues.filter((issue) => !allowedStatuses.size || allowedStatuses.has(issue?.status)).slice(0, limit);
   printJson({
     command: "list-assigned",
     companyId: identity.companyId,
@@ -278,6 +322,8 @@ async function createTask(config, args) {
     mutating: true,
     body,
   });
+  requireObjectResponse("create-task", issue);
+  requireNonEmptyStringField("create-task", issue, "id");
   printJson({ command: "create-task", issue: issueSummary(issue) });
 }
 
@@ -295,6 +341,8 @@ async function comment(config, args) {
     mutating: true,
     body: commentBody,
   });
+  requireObjectResponse("comment", created);
+  requireNonEmptyStringField("comment", created, "id");
   printJson({ command: "comment", issue: issueRef, comment: commentSummary(created) });
 }
 
@@ -313,6 +361,8 @@ async function updateStatus(config, args) {
     mutating: true,
     body,
   });
+  requireObjectResponse("update-status", issue);
+  requireNonEmptyStringField("update-status", issue, "id");
   printJson({ command: "update-status", issue: issueSummary(issue) });
 }
 

--- a/packages/adapters/hermes/src/server/paperclip-task-bridge.test.ts
+++ b/packages/adapters/hermes/src/server/paperclip-task-bridge.test.ts
@@ -83,6 +83,20 @@ describe("paperclip-task-bridge helper", () => {
         return;
       }
       if (req.method === "POST" && req.url === "/api/companies/22222222-2222-4222-8222-222222222222/issues") {
+        if ((body as { title?: string } | null)?.title === "Empty success") {
+          res.statusCode = 200;
+          res.end("");
+          return;
+        }
+        if ((body as { title?: string } | null)?.title === "Missing id success") {
+          res.statusCode = 200;
+          res.end(JSON.stringify({
+            identifier: "PAP-125",
+            title: (body as { title?: string } | null)?.title,
+            authorization: "Bearer should-redact",
+          }));
+          return;
+        }
         res.statusCode = 201;
         res.end(JSON.stringify({
           id: "44444444-4444-4444-8444-444444444444",
@@ -180,5 +194,27 @@ describe("paperclip-task-bridge helper", () => {
     expect(commentRequest?.body).toMatchObject({ body: "Progress from Hermes" });
     expect(patchRequest?.body).toMatchObject({ status: "in_review", comment: "Ready" });
     expect(comment.stdout + update.stdout).not.toContain(apiKey);
+  });
+
+  it("fails create-task when a 2xx response body is empty", async () => {
+    const result = await runHelper(["create-task", "--title", "Empty success"], env());
+
+    expect(result.code).toBe(1);
+    expect(result.stdout).toContain("Malformed Paperclip API success response for create-task");
+    expect(result.stdout).toContain("expected JSON object response");
+    expect(result.stdout).not.toContain(apiKey);
+    expect(result.stderr).not.toContain(apiKey);
+  });
+
+  it("fails create-task when a 2xx response is missing a non-empty issue id", async () => {
+    const result = await runHelper(["create-task", "--title", "Missing id success"], env());
+
+    expect(result.code).toBe(1);
+    expect(result.stdout).toContain("Malformed Paperclip API success response for create-task");
+    expect(result.stdout).toContain("expected non-empty id");
+    expect(result.stdout).toContain("[redacted]");
+    expect(result.stdout).not.toContain("Bearer should-redact");
+    expect(result.stdout).not.toContain(apiKey);
+    expect(result.stderr).not.toContain(apiKey);
   });
 });

--- a/packages/plugins/sandbox-providers/cloudflare/bridge-template/src/exec.test.ts
+++ b/packages/plugins/sandbox-providers/cloudflare/bridge-template/src/exec.test.ts
@@ -81,6 +81,53 @@ describe("bridge exec", () => {
     expect(onOutput).toHaveBeenCalledWith("stdout", "hello\n");
   });
 
+  it("fails closed when sandbox exec omits both exitCode and explicit success", async () => {
+    const exec = vi.fn().mockResolvedValue({ stdout: "partial\n", stderr: "" });
+    const sandbox = {
+      getSession: vi.fn().mockResolvedValue({ exec }),
+      writeFile: vi.fn(),
+      deleteFile: vi.fn(),
+    } as const;
+
+    const result = await executeInSandbox({
+      sandbox: sandbox as never,
+      command: "pwd",
+      sessionStrategy: "named",
+      sessionId: "paperclip",
+      timeoutMs: 5_000,
+    });
+
+    expect(result).toMatchObject({
+      exitCode: 1,
+      timedOut: false,
+      stdout: "partial\n",
+    });
+    expect(result.stderr).toContain("returned no exit code");
+  });
+
+  it("accepts legacy explicit success without an exitCode", async () => {
+    const exec = vi.fn().mockResolvedValue({ success: true, stdout: "ok\n", stderr: "" });
+    const sandbox = {
+      getSession: vi.fn().mockResolvedValue({ exec }),
+      writeFile: vi.fn(),
+      deleteFile: vi.fn(),
+    } as const;
+
+    const result = await executeInSandbox({
+      sandbox: sandbox as never,
+      command: "pwd",
+      sessionStrategy: "named",
+      sessionId: "paperclip",
+      timeoutMs: 5_000,
+    });
+
+    expect(result).toMatchObject({
+      exitCode: 0,
+      stdout: "ok\n",
+      stderr: "",
+    });
+  });
+
   it("stages stdin through a sandbox temp file and redirects from it", async () => {
     const exec = vi.fn().mockResolvedValue({ exitCode: 0, stdout: "", stderr: "" });
     const writeFile = vi.fn().mockResolvedValue(undefined);

--- a/packages/plugins/sandbox-providers/cloudflare/bridge-template/src/exec.ts
+++ b/packages/plugins/sandbox-providers/cloudflare/bridge-template/src/exec.ts
@@ -69,17 +69,26 @@ function coerceExecuteResult(result: {
   stderr?: string;
   exitCode?: number | null;
 }) {
+  const hasExitCode = typeof result.exitCode === "number" || result.exitCode === null;
+  const exitCode = hasExitCode
+    ? result.exitCode
+    : result.success === true
+      ? 0
+      : 1;
+  const stderr = typeof result.stderr === "string" && result.stderr.length > 0
+    ? result.stderr
+    : (
+        hasExitCode || result.success === true
+          ? ""
+          : "Cloudflare sandbox exec returned no exit code or explicit success marker.\n"
+    );
+
   return {
-    exitCode:
-      typeof result.exitCode === "number" || result.exitCode === null
-        ? result.exitCode
-        : result.success === false
-          ? 1
-          : 0,
+    exitCode,
     signal: null,
     timedOut: false,
     stdout: result.stdout ?? "",
-    stderr: result.stderr ?? "",
+    stderr,
   };
 }
 

--- a/packages/plugins/sandbox-providers/cloudflare/bridge-template/src/routes.ts
+++ b/packages/plugins/sandbox-providers/cloudflare/bridge-template/src/routes.ts
@@ -193,7 +193,7 @@ async function verifySentinel(
     ["-c", `test -s ${shellQuote(buildSentinelPath(input.remoteCwd))}`],
     "/",
   );
-  return !result.timedOut && (result.exitCode ?? 0) === 0;
+  return !result.timedOut && result.exitCode === 0;
 }
 
 export async function handleBridgeRequest(request: Request, env: BridgeEnv): Promise<Response> {

--- a/packages/plugins/sandbox-providers/cloudflare/src/bridge-client.test.ts
+++ b/packages/plugins/sandbox-providers/cloudflare/src/bridge-client.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { CloudflareDriverConfig } from "./types.js";
+import type { CloudflareBridgeError } from "./bridge-client.js";
 import { createCloudflareBridgeClient, resolveRequestTimeoutMs } from "./bridge-client.js";
 
 const baseConfig: CloudflareDriverConfig = {
@@ -88,5 +89,48 @@ describe("Cloudflare bridge client timeouts", () => {
     expect(onOutput).toHaveBeenCalledWith("stdout", "hello\n");
     const init = fetchMock.mock.calls[0]?.[1] as RequestInit;
     expect(JSON.parse(String(init.body))).toMatchObject({ streamOutput: true });
+  });
+
+  it("surfaces Cloudflare 1010 bot protection pages as actionable bridge errors", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(
+      "<html><title>Access denied | Error code 1010</title><body>Cloudflare</body></html>",
+      {
+        status: 403,
+        headers: { "Content-Type": "text/html" },
+      },
+    )));
+    const client = createCloudflareBridgeClient({ config: baseConfig });
+
+    await expect(client.probe({
+      requestedCwd: "/workspace",
+      keepAlive: false,
+      sleepAfter: "10m",
+      normalizeId: true,
+      sessionStrategy: "named",
+      sessionId: "paperclip",
+      timeoutMs: 30_000,
+    })).rejects.toThrow(/Cloudflare 1010 bot protection/);
+  });
+
+  it("rejects malformed successful exec responses instead of treating them as command success", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(
+      JSON.stringify({ success: true, stdout: "looks ok\n" }),
+      {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      },
+    )));
+    const client = createCloudflareBridgeClient({ config: baseConfig });
+
+    await expect(client.execute({
+      providerLeaseId: "lease-1",
+      command: "pwd",
+      sessionStrategy: "named",
+      sessionId: "paperclip",
+    })).rejects.toMatchObject({
+      name: "CloudflareBridgeError",
+      status: 502,
+      code: "malformed_execute_response",
+    } satisfies Partial<CloudflareBridgeError>);
   });
 });

--- a/packages/plugins/sandbox-providers/cloudflare/src/bridge-client.ts
+++ b/packages/plugins/sandbox-providers/cloudflare/src/bridge-client.ts
@@ -31,6 +31,11 @@ interface BridgeErrorBody {
   details?: unknown;
 }
 
+interface ParsedErrorBody {
+  errorBody: BridgeErrorBody;
+  rawText: string | null;
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
@@ -65,6 +70,85 @@ async function parseJson(response: Response): Promise<unknown> {
     return null;
   }
   return await response.json();
+}
+
+async function parseErrorBody(response: Response): Promise<ParsedErrorBody> {
+  const contentType = response.headers.get("content-type") ?? "";
+  if (contentType.toLowerCase().includes("application/json")) {
+    try {
+      const body = await response.json();
+      return {
+        errorBody: isRecord(body) ? body as BridgeErrorBody : {},
+        rawText: null,
+      };
+    } catch (error) {
+      return {
+        errorBody: {},
+        rawText: `Malformed JSON error response: ${error instanceof Error ? error.message : String(error)}`,
+      };
+    }
+  }
+
+  const rawText = await response.text().catch(() => "");
+  return {
+    errorBody: {},
+    rawText,
+  };
+}
+
+function buildBridgeErrorMessage(status: number, errorBody: BridgeErrorBody, rawText: string | null): string {
+  if (typeof errorBody.message === "string" && errorBody.message.trim().length > 0) {
+    return errorBody.message.trim();
+  }
+
+  const text = rawText?.replace(/\s+/g, " ").trim() ?? "";
+  if (status === 403 && /\b1010\b/i.test(text) && /cloudflare/i.test(text)) {
+    return "Cloudflare sandbox bridge request was blocked by Cloudflare 1010 bot protection. Exempt the bridge endpoint or token-authenticated API path from bot/security rules.";
+  }
+
+  if (text.length > 0) {
+    return `Cloudflare sandbox bridge request failed with HTTP ${status}: ${text.slice(0, 240)}`;
+  }
+
+  return `Cloudflare sandbox bridge request failed with HTTP ${status}.`;
+}
+
+function normalizeExecuteResponse(body: unknown): CloudflareBridgeExecuteResponse {
+  if (!isRecord(body)) {
+    throw new CloudflareBridgeError({
+      status: 502,
+      code: "malformed_execute_response",
+      message: "Cloudflare sandbox bridge returned a malformed exec response.",
+      details: body,
+    });
+  }
+
+  const exitCode = body.exitCode;
+  const timedOut = body.timedOut;
+  const stdout = body.stdout;
+  const stderr = body.stderr;
+  if (
+    !(typeof exitCode === "number" || exitCode === null) ||
+    typeof timedOut !== "boolean" ||
+    typeof stdout !== "string" ||
+    typeof stderr !== "string"
+  ) {
+    throw new CloudflareBridgeError({
+      status: 502,
+      code: "malformed_execute_response",
+      message: "Cloudflare sandbox bridge returned a malformed exec response.",
+      details: body,
+    });
+  }
+
+  return {
+    exitCode,
+    signal: typeof body.signal === "string" || body.signal === null ? body.signal : null,
+    timedOut,
+    stdout,
+    stderr,
+    metadata: isRecord(body.metadata) ? body.metadata : undefined,
+  };
 }
 
 function encodeExecuteRequestBody(body: CloudflareBridgeExecuteRequest, options?: BridgeExecuteOptions): string {
@@ -116,19 +200,16 @@ async function requestJson<T>(
       headers: buildHeaders(config, extraHeaders),
       signal: controller.signal,
     });
-    const body = await parseJson(response);
     if (!response.ok) {
-      const errorBody = isRecord(body) ? body as BridgeErrorBody : {};
+      const { errorBody, rawText } = await parseErrorBody(response);
       throw new CloudflareBridgeError({
         status: response.status,
         code: typeof errorBody.error === "string" ? errorBody.error : null,
-        message:
-          typeof errorBody.message === "string" && errorBody.message.trim().length > 0
-            ? errorBody.message
-            : `Cloudflare sandbox bridge request failed with HTTP ${response.status}.`,
+        message: buildBridgeErrorMessage(response.status, errorBody, rawText),
         details: errorBody.details,
       });
     }
+    const body = await parseJson(response);
     return body as T;
   } catch (error) {
     if (error instanceof CloudflareBridgeError) throw error;
@@ -161,15 +242,11 @@ async function requestResponse(
       signal: controller.signal,
     });
     if (!response.ok) {
-      const body = await parseJson(response);
-      const errorBody = isRecord(body) ? body as BridgeErrorBody : {};
+      const { errorBody, rawText } = await parseErrorBody(response);
       throw new CloudflareBridgeError({
         status: response.status,
         code: typeof errorBody.error === "string" ? errorBody.error : null,
-        message:
-          typeof errorBody.message === "string" && errorBody.message.trim().length > 0
-            ? errorBody.message
-            : `Cloudflare sandbox bridge request failed with HTTP ${response.status}.`,
+        message: buildBridgeErrorMessage(response.status, errorBody, rawText),
         details: errorBody.details,
       });
     }
@@ -249,7 +326,7 @@ async function consumeExecuteEventStream(
       }
 
       if (event.event === "complete") {
-        result = JSON.parse(event.data) as CloudflareBridgeExecuteResponse;
+        result = normalizeExecuteResponse(JSON.parse(event.data));
         continue;
       }
 
@@ -346,12 +423,12 @@ export function createCloudflareBridgeClient(options: BridgeClientOptions) {
           extraHeaders,
         ).then((response) => consumeExecuteEventStream(response, options));
       }
-      return requestJson<CloudflareBridgeExecuteResponse>(
+      return requestJson<unknown>(
         config,
         `${apiPrefix}/exec`,
         { method: "POST", body: encodedBody },
         extraHeaders,
-      );
+      ).then(normalizeExecuteResponse);
     },
   };
 }


### PR DESCRIPTION
Closes THE-1307

## Summary
- Treat empty or malformed 2xx Paperclip task bridge responses as failures.
- Require non-empty ids for create-task, comment, and update-status success summaries.
- Redact secret-like fields in malformed-success diagnostics.
- Add focused regression tests for empty create response and missing issue id.

## Verification
- pnpm --filter @paperclipai/hermes-paperclip-adapter test -- --run src/server/paperclip-task-bridge.test.ts
- pnpm --filter @paperclipai/hermes-paperclip-adapter build
- scripts/pre-pr.sh: not present in this checkout.