### PR TITLE
fix(heartbeat): require lifecycle intent for deferred comment reopens

### DIFF
--- a/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
+++ b/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
@@ -644,7 +644,7 @@ describeEmbeddedPostgres("heartbeat comment wake batching", () => {
     }
   }, 120_000);
 
-  it("promotes deferred comment wakes after the active run closes the issue", async () => {
+  it("promotes deferred comment wakes after the active run closes the issue without reopening it", async () => {
     const gateway = await createControlledGatewayServer();
     const companyId = randomUUID();
     const agentId = randomUUID();
@@ -685,7 +685,7 @@ describeEmbeddedPostgres("heartbeat comment wake batching", () => {
       await db.insert(issues).values({
         id: issueId,
         companyId,
-        title: "Reopen after deferred comment",
+        title: "Terminal deferred comment",
         status: "todo",
         priority: "medium",
         responsibleUserId: "responsible-user",
@@ -730,6 +730,9 @@ describeEmbeddedPostgres("heartbeat comment wake batching", () => {
         return run?.status === "running";
       });
 
+      // Human comment while run is still open: deferred as plain issue_commented
+      // with no reopen markers. After the run marks the issue done, promotion
+      // must deliver the comment without undoing terminal status.
       const comment2 = await db
         .insert(issueComments)
         .values({
@@ -802,7 +805,7 @@ describeEmbeddedPostgres("heartbeat comment wake batching", () => {
         );
       }, 90_000);
 
-      const reopenedIssue = await db
+      const terminalIssue = await db
         .select({
           status: issues.status,
           completedAt: issues.completedAt,
@@ -811,10 +814,10 @@ describeEmbeddedPostgres("heartbeat comment wake batching", () => {
         .where(eq(issues.id, issueId))
         .then((rows) => rows[0] ?? null);
 
-      expect(reopenedIssue).toMatchObject({
-        status: "in_progress",
-        completedAt: null,
+      expect(terminalIssue).toMatchObject({
+        status: "done",
       });
+      expect(terminalIssue?.completedAt).not.toBeNull();
 
       const secondPayload = gateway.getAgentPayloads()[1] ?? {};
       expect(secondPayload.paperclip).toBeUndefined();
@@ -826,8 +829,8 @@ describeEmbeddedPostgres("heartbeat comment wake batching", () => {
         issue: {
           id: issueId,
           identifier: `${issuePrefix}-1`,
-          title: "Reopen after deferred comment",
-          status: "in_progress",
+          title: "Terminal deferred comment",
+          status: "done",
           priority: "medium",
         },
       });
@@ -1208,7 +1211,7 @@ describeEmbeddedPostgres("heartbeat comment wake batching", () => {
     }
   }, 120_000);
 
-  it("still reopens a finished issue when a deferred batch mixes self-authored and human comments", async () => {
+  it("does not reopen a finished issue for a mixed deferred batch of mid-run comments without reopen intent", async () => {
     const gateway = await createControlledGatewayServer();
     const companyId = randomUUID();
     const agentId = randomUUID();
@@ -1249,7 +1252,7 @@ describeEmbeddedPostgres("heartbeat comment wake batching", () => {
       await db.insert(issues).values({
         id: issueId,
         companyId,
-        title: "Human follow-up must survive mixed deferred batches",
+        title: "Mid-run comments stay terminal after close",
         status: "todo",
         priority: "medium",
         responsibleUserId: "responsible-user",
@@ -1312,13 +1315,15 @@ describeEmbeddedPostgres("heartbeat comment wake batching", () => {
 
       expect(firstDeferredRun).toBeNull();
 
+      // Board/user comment while the issue is still open — same deferred shape
+      // that previously reopened terminal issues after approve	odone.
       const humanComment = await db
         .insert(issueComments)
         .values({
           companyId,
           issueId,
           authorUserId: "user-1",
-          body: "Real follow-up from a human after the run closes",
+          body: "Review note while the run is still open",
         })
         .returning()
         .then((rows) => rows[0]);
@@ -1395,9 +1400,9 @@ describeEmbeddedPostgres("heartbeat comment wake batching", () => {
         .then((rows) => rows[0] ?? null);
 
       expect(issueAfterPromotion).toMatchObject({
-        status: "in_progress",
-        completedAt: null,
+        status: "done",
       });
+      expect(issueAfterPromotion?.completedAt).not.toBeNull();
 
       const secondPayload = gateway.getAgentPayloads()[1] ?? {};
       expect(secondPayload.paperclip).toBeUndefined();
@@ -1409,12 +1414,230 @@ describeEmbeddedPostgres("heartbeat comment wake batching", () => {
         issue: {
           id: issueId,
           identifier: `${issuePrefix}-1`,
-          title: "Human follow-up must survive mixed deferred batches",
+          title: "Mid-run comments stay terminal after close",
+          status: "done",
+          priority: "medium",
+        },
+      });
+      expect(String(secondPayload.message ?? "")).toContain("Review note while the run is still open");
+    } finally {
+      gateway.releaseFirstWait();
+      await gateway.close();
+    }
+  }, 120_000);
+
+  it("still reopens a finished issue when a deferred human comment carries explicit reopen intent", async () => {
+    const gateway = await createControlledGatewayServer();
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const issueId = randomUUID();
+    const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+    const heartbeat = heartbeatService(db);
+
+    try {
+      await db.insert(companies).values({
+        id: companyId,
+        name: "Paperclip",
+        issuePrefix,
+        requireBoardApprovalForNewAgents: false,
+        defaultResponsibleUserId: "responsible-user",
+      });
+
+      await db.insert(agents).values({
+        id: agentId,
+        companyId,
+        name: "Local CLI Agent",
+        role: "engineer",
+        status: "idle",
+        adapterType: "openclaw_gateway",
+        adapterConfig: {
+          url: gateway.url,
+          headers: {
+            "x-openclaw-token": "gateway-token",
+          },
+          payloadTemplate: {
+            message: "wake now",
+          },
+          waitTimeoutMs: 2_000,
+        },
+        runtimeConfig: {},
+        permissions: {},
+      });
+
+      await db.insert(issues).values({
+        id: issueId,
+        companyId,
+        title: "Post-close human reopen must still work",
+        status: "todo",
+        priority: "medium",
+        responsibleUserId: "responsible-user",
+        assigneeAgentId: agentId,
+        issueNumber: 1,
+        identifier: `${issuePrefix}-1`,
+      });
+
+      const firstRun = await heartbeat.wakeup(agentId, {
+        source: "assignment",
+        triggerDetail: "system",
+        reason: "issue_assigned",
+        payload: { issueId },
+        contextSnapshot: {
+          issueId,
+          taskId: issueId,
+          wakeReason: "issue_assigned",
+        },
+        requestedByActorType: "system",
+        requestedByActorId: null,
+      });
+
+      expect(firstRun).not.toBeNull();
+      await waitFor(async () => {
+        const run = await db
+          .select({ status: heartbeatRuns.status })
+          .from(heartbeatRuns)
+          .where(eq(heartbeatRuns.id, firstRun!.id))
+          .then((rows) => rows[0] ?? null);
+        return run?.status === "running";
+      });
+
+      // Open-while-running human comment (no lifecycle intent) is deferred first.
+      const midRunComment = await db
+        .insert(issueComments)
+        .values({
+          companyId,
+          issueId,
+          authorUserId: "user-1",
+          body: "Note while work is in flight",
+        })
+        .returning()
+        .then((rows) => rows[0]);
+
+      const midRunDeferred = await heartbeat.wakeup(agentId, {
+        source: "automation",
+        triggerDetail: "system",
+        reason: "issue_commented",
+        payload: { issueId, commentId: midRunComment.id },
+        contextSnapshot: {
+          issueId,
+          taskId: issueId,
+          commentId: midRunComment.id,
+          wakeCommentId: midRunComment.id,
+          wakeReason: "issue_commented",
+        },
+        requestedByActorType: "user",
+        requestedByActorId: "user-1",
+      });
+      expect(midRunDeferred).toBeNull();
+
+      await waitFor(async () => {
+        const deferred = await db
+          .select()
+          .from(agentWakeupRequests)
+          .where(
+            and(
+              eq(agentWakeupRequests.companyId, companyId),
+              eq(agentWakeupRequests.agentId, agentId),
+              eq(agentWakeupRequests.status, "deferred_issue_execution"),
+            ),
+          )
+          .then((rows) => rows[0] ?? null);
+        return Boolean(deferred);
+      });
+
+      // Simulate an explicit post-close reopen arriving into the deferred batch
+      // (routes stamp reopenedFrom + issue_reopened_via_comment).
+      const reopenComment = await db
+        .insert(issueComments)
+        .values({
+          companyId,
+          issueId,
+          authorUserId: "user-1",
+          body: "Please reopen and continue after close",
+        })
+        .returning()
+        .then((rows) => rows[0]);
+
+      const reopenDeferred = await heartbeat.wakeup(agentId, {
+        source: "automation",
+        triggerDetail: "system",
+        reason: "issue_reopened_via_comment",
+        payload: {
+          issueId,
+          commentId: reopenComment.id,
+          reopenedFrom: "done",
+        },
+        contextSnapshot: {
+          issueId,
+          taskId: issueId,
+          commentId: reopenComment.id,
+          wakeCommentId: reopenComment.id,
+          wakeReason: "issue_reopened_via_comment",
+          reopenedFrom: "done",
+          source: "issue.comment.reopen",
+        },
+        requestedByActorType: "user",
+        requestedByActorId: "user-1",
+      });
+      expect(reopenDeferred).toBeNull();
+
+      await db
+        .update(issues)
+        .set({
+          status: "done",
+          completedAt: new Date(),
+          executionRunId: null,
+          executionAgentNameKey: null,
+          executionLockedAt: null,
+          updatedAt: new Date(),
+        })
+        .where(eq(issues.id, issueId));
+
+      gateway.releaseFirstWait();
+
+      await waitFor(() => gateway.getAgentPayloads().length >= 2, 90_000);
+      await waitFor(async () => {
+        const runs = await db
+          .select()
+          .from(heartbeatRuns)
+          .where(eq(heartbeatRuns.agentId, agentId))
+          .orderBy(asc(heartbeatRuns.createdAt));
+        const [initialRun, promotedRun] = runs;
+        return (
+          initialRun?.id === firstRun?.id &&
+          initialRun.status === "succeeded" &&
+          promotedRun?.status === "succeeded"
+        );
+      }, 90_000);
+
+      const issueAfterPromotion = await db
+        .select({
+          status: issues.status,
+          completedAt: issues.completedAt,
+        })
+        .from(issues)
+        .where(eq(issues.id, issueId))
+        .then((rows) => rows[0] ?? null);
+
+      expect(issueAfterPromotion).toMatchObject({
+        status: "in_progress",
+        completedAt: null,
+      });
+
+      const secondPayload = gateway.getAgentPayloads()[1] ?? {};
+      expect(secondPayload.paperclip).toBeUndefined();
+      const secondWake = parseWakePayloadFromMessage(secondPayload.message);
+      expect(secondWake).toMatchObject({
+        commentIds: [midRunComment.id, reopenComment.id],
+        latestCommentId: reopenComment.id,
+        issue: {
+          id: issueId,
+          identifier: `${issuePrefix}-1`,
+          title: "Post-close human reopen must still work",
           status: "in_progress",
           priority: "medium",
         },
       });
-      expect(String(secondPayload.message ?? "")).toContain("Real follow-up from a human after the run closes");
+      expect(String(secondPayload.message ?? "")).toContain("Please reopen and continue after close");
     } finally {
       gateway.releaseFirstWait();
       await gateway.close();

--- a/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
+++ b/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
@@ -1316,7 +1316,7 @@ describeEmbeddedPostgres("heartbeat comment wake batching", () => {
       expect(firstDeferredRun).toBeNull();
 
       // Board/user comment while the issue is still open — same deferred shape
-      // that previously reopened terminal issues after approve	odone.
+      // that previously reopened terminal issues after approve→done.
       const humanComment = await db
         .insert(issueComments)
         .values({
@@ -1638,6 +1638,226 @@ describeEmbeddedPostgres("heartbeat comment wake batching", () => {
         },
       });
       expect(String(secondPayload.message ?? "")).toContain("Please reopen and continue after close");
+    } finally {
+      gateway.releaseFirstWait();
+      await gateway.close();
+    }
+  }, 120_000);
+
+  it("still reopens a finished issue when a deferred comment carries resumeIntent or followUpRequested", async () => {
+    const gateway = await createControlledGatewayServer();
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const issueId = randomUUID();
+    const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+    const heartbeat = heartbeatService(db);
+
+    try {
+      await db.insert(companies).values({
+        id: companyId,
+        name: "Paperclip",
+        issuePrefix,
+        requireBoardApprovalForNewAgents: false,
+        defaultResponsibleUserId: "responsible-user",
+      });
+
+      await db.insert(agents).values({
+        id: agentId,
+        companyId,
+        name: "Local CLI Agent",
+        role: "engineer",
+        status: "idle",
+        adapterType: "openclaw_gateway",
+        adapterConfig: {
+          url: gateway.url,
+          headers: {
+            "x-openclaw-token": "gateway-token",
+          },
+          payloadTemplate: {
+            message: "wake now",
+          },
+          waitTimeoutMs: 2_000,
+        },
+        runtimeConfig: {},
+        permissions: {},
+      });
+
+      await db.insert(issues).values({
+        id: issueId,
+        companyId,
+        title: "Resume intent must still reopen after close",
+        status: "todo",
+        priority: "medium",
+        responsibleUserId: "responsible-user",
+        assigneeAgentId: agentId,
+        issueNumber: 1,
+        identifier: `${issuePrefix}-1`,
+      });
+
+      const firstRun = await heartbeat.wakeup(agentId, {
+        source: "assignment",
+        triggerDetail: "system",
+        reason: "issue_assigned",
+        payload: { issueId },
+        contextSnapshot: {
+          issueId,
+          taskId: issueId,
+          wakeReason: "issue_assigned",
+        },
+        requestedByActorType: "system",
+        requestedByActorId: null,
+      });
+
+      expect(firstRun).not.toBeNull();
+      await waitFor(async () => {
+        const run = await db
+          .select({ status: heartbeatRuns.status })
+          .from(heartbeatRuns)
+          .where(eq(heartbeatRuns.id, firstRun!.id))
+          .then((rows) => rows[0] ?? null);
+        return run?.status === "running";
+      });
+
+      // Mid-run human comment deferred first; without lifecycle intent this would
+      // stay terminal after close. Resume markers arrive as a second deferred wake.
+      const midRunComment = await db
+        .insert(issueComments)
+        .values({
+          companyId,
+          issueId,
+          authorUserId: "user-1",
+          body: "Note while work is in flight",
+        })
+        .returning()
+        .then((rows) => rows[0]);
+
+      const midRunDeferred = await heartbeat.wakeup(agentId, {
+        source: "automation",
+        triggerDetail: "system",
+        reason: "issue_commented",
+        payload: { issueId, commentId: midRunComment.id },
+        contextSnapshot: {
+          issueId,
+          taskId: issueId,
+          commentId: midRunComment.id,
+          wakeCommentId: midRunComment.id,
+          wakeReason: "issue_commented",
+        },
+        requestedByActorType: "user",
+        requestedByActorId: "user-1",
+      });
+      expect(midRunDeferred).toBeNull();
+
+      await waitFor(async () => {
+        const deferred = await db
+          .select()
+          .from(agentWakeupRequests)
+          .where(
+            and(
+              eq(agentWakeupRequests.companyId, companyId),
+              eq(agentWakeupRequests.agentId, agentId),
+              eq(agentWakeupRequests.status, "deferred_issue_execution"),
+            ),
+          )
+          .then((rows) => rows[0] ?? null);
+        return Boolean(deferred);
+      });
+
+      // Explicit agent resume (resumeIntent + followUpRequested) batched into the
+      // deferred wake — same markers routes stamp for `resume: true`.
+      const resumeComment = await db
+        .insert(issueComments)
+        .values({
+          companyId,
+          issueId,
+          authorUserId: "local-cli-user",
+          body: "Resume this issue and continue after close",
+        })
+        .returning()
+        .then((rows) => rows[0]);
+
+      const resumeDeferred = await heartbeat.wakeup(agentId, {
+        source: "automation",
+        triggerDetail: "system",
+        reason: "issue_commented",
+        payload: {
+          issueId,
+          commentId: resumeComment.id,
+        },
+        contextSnapshot: {
+          issueId,
+          taskId: issueId,
+          commentId: resumeComment.id,
+          wakeCommentId: resumeComment.id,
+          wakeReason: "issue_commented",
+          resumeIntent: true,
+          followUpRequested: true,
+        },
+        requestedByActorType: "user",
+        requestedByActorId: "local-cli-user",
+      });
+      expect(resumeDeferred).toBeNull();
+
+      await db
+        .update(issues)
+        .set({
+          status: "done",
+          completedAt: new Date(),
+          executionRunId: null,
+          executionAgentNameKey: null,
+          executionLockedAt: null,
+          updatedAt: new Date(),
+        })
+        .where(eq(issues.id, issueId));
+
+      gateway.releaseFirstWait();
+
+      await waitFor(() => gateway.getAgentPayloads().length >= 2, 90_000);
+      await waitFor(async () => {
+        const runs = await db
+          .select()
+          .from(heartbeatRuns)
+          .where(eq(heartbeatRuns.agentId, agentId))
+          .orderBy(asc(heartbeatRuns.createdAt));
+        const [initialRun, promotedRun] = runs;
+        return (
+          initialRun?.id === firstRun?.id &&
+          initialRun.status === "succeeded" &&
+          promotedRun?.status === "succeeded"
+        );
+      }, 90_000);
+
+      const issueAfterPromotion = await db
+        .select({
+          status: issues.status,
+          completedAt: issues.completedAt,
+        })
+        .from(issues)
+        .where(eq(issues.id, issueId))
+        .then((rows) => rows[0] ?? null);
+
+      expect(issueAfterPromotion).toMatchObject({
+        status: "in_progress",
+        completedAt: null,
+      });
+
+      const secondPayload = gateway.getAgentPayloads()[1] ?? {};
+      expect(secondPayload.paperclip).toBeUndefined();
+      const secondWake = parseWakePayloadFromMessage(secondPayload.message);
+      expect(secondWake).toMatchObject({
+        commentIds: [midRunComment.id, resumeComment.id],
+        latestCommentId: resumeComment.id,
+        issue: {
+          id: issueId,
+          identifier: `${issuePrefix}-1`,
+          title: "Resume intent must still reopen after close",
+          status: "in_progress",
+          priority: "medium",
+        },
+      });
+      expect(String(secondPayload.message ?? "")).toContain(
+        "Resume this issue and continue after close",
+      );
     } finally {
       gateway.releaseFirstWait();
       await gateway.close();

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -13712,11 +13712,22 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         }
         const deferredCommentIds = extractWakeCommentIds(deferredContextSeed);
         const deferredWakeReason = readNonEmptyString(deferredContextSeed.wakeReason);
+        // Only explicit lifecycle intent should revive completed issues. A human
+        // comment that landed while the issue was still open is deferred as
+        // `issue_commented` without reopen markers; promoting that wake after the
+        // active run marks the issue `done` must not undo that close. Real
+        // post-close reopens set `reopenedFrom` / `issue_reopened_via_comment`, or
+        // an agent asks for resume via resumeIntent/followUpRequested.
+        const deferredLifecycleIntent =
+          promotedContextSeed.resumeIntent === true ||
+          promotedContextSeed.followUpRequested === true ||
+          readNonEmptyString(promotedContextSeed.reopenedFrom) !== null ||
+          deferredWakeReason === "issue_reopened_via_comment";
         // Local-CLI agents post comments under user auth, so a self-comment from
         // the run that is now ending would otherwise look like a real human
         // comment and trigger a reopen on the very issue this run just closed.
         // Suppress reopen only when every referenced comment came from this run;
-        // mixed batches must still reopen because they contain a real follow-up.
+        // mixed batches with real post-close reopen intent must still reopen.
         let deferredCommentWakeIsSelfAuthored = false;
         if (deferredCommentIds.length > 0) {
           const deferredComments = await tx
@@ -13734,12 +13745,15 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             deferredComments.length > 0 &&
             deferredComments.every((comment) => comment.createdByRunId === run.id);
         }
-        // Only human/comment-reopen interactions should revive completed issues;
-        // system follow-ups such as retry or cleanup wakes must not reopen closed work.
+        // Only human/comment-reopen interactions with lifecycle intent should
+        // revive completed issues; system follow-ups such as retry or cleanup
+        // wakes, and plain deferred `issue_commented` wakes that predate the
+        // close, must not reopen closed work.
         const shouldReopenDeferredCommentWake =
           deferredCommentIds.length > 0 &&
           !deferredCommentWakeIsSelfAuthored &&
           (issue.status === "done" || issue.status === "cancelled") &&
+          deferredLifecycleIntent &&
           (
             deferred.requestedByActorType === "user" ||
             deferredWakeReason === "issue_reopened_via_comment"


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage and orchestrate AI agents for work.
> - Agents dispose assigned issues at the end of a run (`done` / `blocked` / `cancelled`), and the heartbeat service owns deferred comment-wake promotion when comments land while a run is still active.
> - The promoter currently reopens terminal issues whenever a deferred wake has comments, is not exclusively self-authored by the ending run, and `requestedByActorType === "user"` (or wakeReason is `issue_reopened_via_comment`).
> - A human board comment that arrives while the issue is still open is deferred as plain `issue_commented` with no reopen markers. The active reviewer/assignee run can then mark the issue `done` (including an execution-policy approve → done). When that run ends, the deferred wake is promoted and incorrectly reopens the issue to `todo`, wiping `executionState`.
> - This pull request gates deferred reopens on explicit lifecycle intent so mid-run comments stay deliverable without undoing a terminal close.
> - The benefit is that execution-policy approve → done (and any other intentional terminal disposition) remains terminal unless a human/post-close comment carries real reopen intent.

## Linked Issues or Issue Description

Refs #8749, #8704, #6657, #6159, #4410, #6601

### Bug description (no new GitHub issue filed)

**What happened:** A human comment queued while a reviewer run was active was deferred. That run then approved the work and set status `done`. On run completion, heartbeat promoted the deferred comment wake with `source: deferred_comment_wake` and reopened the issue `todo`, clearing execution review state.

**Expected:** Self-authored approval paths that transition `in_review` → `done` must not reopen via deferred comment wake. Plain mid-run `issue_commented` wakes should promote and deliver comments but leave terminal status alone. Only explicit reopen/resume lifecycle intent should revive `done`/`cancelled`.

**Steps to reproduce:**
1. Put an issue into an agent run (optionally `in_review` with an agent reviewer).
2. While the run is still open, post a human/board comment (wake deferred as `issue_commented`, `requestedByActorType: user`).
3. Let the active run set the issue to `done` and finish.
4. Observe deferred promotion reopen status to `todo` with `source: deferred_comment_wake`.

**Version / mode:** `@paperclipai/server` 2026.707.0 (Desktop / local_trusted), also present on current master around deferred wake promotion in `server/src/services/heartbeat.ts`.

## What Changed

- Require `deferredLifecycleIntent` before reopening on deferred comment wake promotion:
  - `resumeIntent === true`, or
  - `followUpRequested === true`, or
  - non-empty `reopenedFrom`, or
  - `wakeReason === "issue_reopened_via_comment"`
- Keep existing `createdByRunId` self-authored guard and user/reopen actor checks.
- Still promote deferred wakes so comment batches are delivered; only the terminal status flip is suppressed without intent.
- Update batching tests:
  - mid-run human deferred comments no longer reopen after close
  - mixed mid-run self + human deferred comments stay terminal
  - explicit post-close `issue_reopened_via_comment` / `reopenedFrom` still reopens

## Verification

```bash
pnpm --filter @paperclipai/shared build
pnpm --filter @paperclipai/db build
pnpm --filter @paperclipai/adapter-utils build
pnpm exec vitest run server/src/__tests__/heartbeat-comment-wake-batching.test.ts
```

Result: **12/12 passed**.

## Risks

- Behavioral shift: plain human comments deferred mid-run no longer auto-reopen a later terminal disposition. Callers that relied on that accidental reopen must use existing resume (`resume: true` / `resumeIntent` / `followUpRequested`) or the normal post-close comment reopen path (`issue_reopened_via_comment` + `reopenedFrom`).
- Does not fully swallow deferred comments for routine_execution origin (covered by related PRs); this PR only blocks the terminal reopen flip without lifecycle intent.
- Low migration risk: logic-only change in heartbeat promotion, no schema.

## Model Used

Claude (Claude Opus 4.6 / Claude Access) with tool use and code execution for reproduce analysis, edit, and test run.

## Checklist

- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I ran the relevant tests for this change
- [x] PR description follows the template (Thinking Path, What Changed, Verification, Risks, Model Used)
- [x] No internal/instance-local ticket ids or private instance URLs in title/body/commits
