### PR TITLE
fix(task-watchdog): exclude task_watchdog children from serialization peer scan

### DIFF
--- a/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
+++ b/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
@@ -644,7 +644,7 @@ describeEmbeddedPostgres("heartbeat comment wake batching", () => {
     }
   }, 120_000);
 
-  it("promotes deferred comment wakes after the active run closes the issue", async () => {
+  it("promotes deferred comment wakes after the active run closes the issue without reopening it", async () => {
     const gateway = await createControlledGatewayServer();
     const companyId = randomUUID();
     const agentId = randomUUID();
@@ -685,7 +685,7 @@ describeEmbeddedPostgres("heartbeat comment wake batching", () => {
       await db.insert(issues).values({
         id: issueId,
         companyId,
-        title: "Reopen after deferred comment",
+        title: "Terminal deferred comment",
         status: "todo",
         priority: "medium",
         responsibleUserId: "responsible-user",
@@ -730,6 +730,9 @@ describeEmbeddedPostgres("heartbeat comment wake batching", () => {
         return run?.status === "running";
       });
 
+      // Human comment while run is still open: deferred as plain issue_commented
+      // with no reopen markers. After the run marks the issue done, promotion
+      // must deliver the comment without undoing terminal status.
       const comment2 = await db
         .insert(issueComments)
         .values({
@@ -802,7 +805,7 @@ describeEmbeddedPostgres("heartbeat comment wake batching", () => {
         );
       }, 90_000);
 
-      const reopenedIssue = await db
+      const terminalIssue = await db
         .select({
           status: issues.status,
           completedAt: issues.completedAt,
@@ -811,10 +814,10 @@ describeEmbeddedPostgres("heartbeat comment wake batching", () => {
         .where(eq(issues.id, issueId))
         .then((rows) => rows[0] ?? null);
 
-      expect(reopenedIssue).toMatchObject({
-        status: "in_progress",
-        completedAt: null,
+      expect(terminalIssue).toMatchObject({
+        status: "done",
       });
+      expect(terminalIssue?.completedAt).not.toBeNull();
 
       const secondPayload = gateway.getAgentPayloads()[1] ?? {};
       expect(secondPayload.paperclip).toBeUndefined();
@@ -826,8 +829,8 @@ describeEmbeddedPostgres("heartbeat comment wake batching", () => {
         issue: {
           id: issueId,
           identifier: `${issuePrefix}-1`,
-          title: "Reopen after deferred comment",
-          status: "in_progress",
+          title: "Terminal deferred comment",
+          status: "done",
           priority: "medium",
         },
       });
@@ -1208,7 +1211,7 @@ describeEmbeddedPostgres("heartbeat comment wake batching", () => {
     }
   }, 120_000);
 
-  it("still reopens a finished issue when a deferred batch mixes self-authored and human comments", async () => {
+  it("does not reopen a finished issue for a mixed deferred batch of mid-run comments without reopen intent", async () => {
     const gateway = await createControlledGatewayServer();
     const companyId = randomUUID();
     const agentId = randomUUID();
@@ -1249,7 +1252,7 @@ describeEmbeddedPostgres("heartbeat comment wake batching", () => {
       await db.insert(issues).values({
         id: issueId,
         companyId,
-        title: "Human follow-up must survive mixed deferred batches",
+        title: "Mid-run comments stay terminal after close",
         status: "todo",
         priority: "medium",
         responsibleUserId: "responsible-user",
@@ -1312,13 +1315,15 @@ describeEmbeddedPostgres("heartbeat comment wake batching", () => {
 
       expect(firstDeferredRun).toBeNull();
 
+      // Board/user comment while the issue is still open — same deferred shape
+      // that previously reopened terminal issues after approve	odone.
       const humanComment = await db
         .insert(issueComments)
         .values({
           companyId,
           issueId,
           authorUserId: "user-1",
-          body: "Real follow-up from a human after the run closes",
+          body: "Review note while the run is still open",
         })
         .returning()
         .then((rows) => rows[0]);
@@ -1395,9 +1400,9 @@ describeEmbeddedPostgres("heartbeat comment wake batching", () => {
         .then((rows) => rows[0] ?? null);
 
       expect(issueAfterPromotion).toMatchObject({
-        status: "in_progress",
-        completedAt: null,
+        status: "done",
       });
+      expect(issueAfterPromotion?.completedAt).not.toBeNull();
 
       const secondPayload = gateway.getAgentPayloads()[1] ?? {};
       expect(secondPayload.paperclip).toBeUndefined();
@@ -1409,12 +1414,230 @@ describeEmbeddedPostgres("heartbeat comment wake batching", () => {
         issue: {
           id: issueId,
           identifier: `${issuePrefix}-1`,
-          title: "Human follow-up must survive mixed deferred batches",
+          title: "Mid-run comments stay terminal after close",
+          status: "done",
+          priority: "medium",
+        },
+      });
+      expect(String(secondPayload.message ?? "")).toContain("Review note while the run is still open");
+    } finally {
+      gateway.releaseFirstWait();
+      await gateway.close();
+    }
+  }, 120_000);
+
+  it("still reopens a finished issue when a deferred human comment carries explicit reopen intent", async () => {
+    const gateway = await createControlledGatewayServer();
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const issueId = randomUUID();
+    const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+    const heartbeat = heartbeatService(db);
+
+    try {
+      await db.insert(companies).values({
+        id: companyId,
+        name: "Paperclip",
+        issuePrefix,
+        requireBoardApprovalForNewAgents: false,
+        defaultResponsibleUserId: "responsible-user",
+      });
+
+      await db.insert(agents).values({
+        id: agentId,
+        companyId,
+        name: "Local CLI Agent",
+        role: "engineer",
+        status: "idle",
+        adapterType: "openclaw_gateway",
+        adapterConfig: {
+          url: gateway.url,
+          headers: {
+            "x-openclaw-token": "gateway-token",
+          },
+          payloadTemplate: {
+            message: "wake now",
+          },
+          waitTimeoutMs: 2_000,
+        },
+        runtimeConfig: {},
+        permissions: {},
+      });
+
+      await db.insert(issues).values({
+        id: issueId,
+        companyId,
+        title: "Post-close human reopen must still work",
+        status: "todo",
+        priority: "medium",
+        responsibleUserId: "responsible-user",
+        assigneeAgentId: agentId,
+        issueNumber: 1,
+        identifier: `${issuePrefix}-1`,
+      });
+
+      const firstRun = await heartbeat.wakeup(agentId, {
+        source: "assignment",
+        triggerDetail: "system",
+        reason: "issue_assigned",
+        payload: { issueId },
+        contextSnapshot: {
+          issueId,
+          taskId: issueId,
+          wakeReason: "issue_assigned",
+        },
+        requestedByActorType: "system",
+        requestedByActorId: null,
+      });
+
+      expect(firstRun).not.toBeNull();
+      await waitFor(async () => {
+        const run = await db
+          .select({ status: heartbeatRuns.status })
+          .from(heartbeatRuns)
+          .where(eq(heartbeatRuns.id, firstRun!.id))
+          .then((rows) => rows[0] ?? null);
+        return run?.status === "running";
+      });
+
+      // Open-while-running human comment (no lifecycle intent) is deferred first.
+      const midRunComment = await db
+        .insert(issueComments)
+        .values({
+          companyId,
+          issueId,
+          authorUserId: "user-1",
+          body: "Note while work is in flight",
+        })
+        .returning()
+        .then((rows) => rows[0]);
+
+      const midRunDeferred = await heartbeat.wakeup(agentId, {
+        source: "automation",
+        triggerDetail: "system",
+        reason: "issue_commented",
+        payload: { issueId, commentId: midRunComment.id },
+        contextSnapshot: {
+          issueId,
+          taskId: issueId,
+          commentId: midRunComment.id,
+          wakeCommentId: midRunComment.id,
+          wakeReason: "issue_commented",
+        },
+        requestedByActorType: "user",
+        requestedByActorId: "user-1",
+      });
+      expect(midRunDeferred).toBeNull();
+
+      await waitFor(async () => {
+        const deferred = await db
+          .select()
+          .from(agentWakeupRequests)
+          .where(
+            and(
+              eq(agentWakeupRequests.companyId, companyId),
+              eq(agentWakeupRequests.agentId, agentId),
+              eq(agentWakeupRequests.status, "deferred_issue_execution"),
+            ),
+          )
+          .then((rows) => rows[0] ?? null);
+        return Boolean(deferred);
+      });
+
+      // Simulate an explicit post-close reopen arriving into the deferred batch
+      // (routes stamp reopenedFrom + issue_reopened_via_comment).
+      const reopenComment = await db
+        .insert(issueComments)
+        .values({
+          companyId,
+          issueId,
+          authorUserId: "user-1",
+          body: "Please reopen and continue after close",
+        })
+        .returning()
+        .then((rows) => rows[0]);
+
+      const reopenDeferred = await heartbeat.wakeup(agentId, {
+        source: "automation",
+        triggerDetail: "system",
+        reason: "issue_reopened_via_comment",
+        payload: {
+          issueId,
+          commentId: reopenComment.id,
+          reopenedFrom: "done",
+        },
+        contextSnapshot: {
+          issueId,
+          taskId: issueId,
+          commentId: reopenComment.id,
+          wakeCommentId: reopenComment.id,
+          wakeReason: "issue_reopened_via_comment",
+          reopenedFrom: "done",
+          source: "issue.comment.reopen",
+        },
+        requestedByActorType: "user",
+        requestedByActorId: "user-1",
+      });
+      expect(reopenDeferred).toBeNull();
+
+      await db
+        .update(issues)
+        .set({
+          status: "done",
+          completedAt: new Date(),
+          executionRunId: null,
+          executionAgentNameKey: null,
+          executionLockedAt: null,
+          updatedAt: new Date(),
+        })
+        .where(eq(issues.id, issueId));
+
+      gateway.releaseFirstWait();
+
+      await waitFor(() => gateway.getAgentPayloads().length >= 2, 90_000);
+      await waitFor(async () => {
+        const runs = await db
+          .select()
+          .from(heartbeatRuns)
+          .where(eq(heartbeatRuns.agentId, agentId))
+          .orderBy(asc(heartbeatRuns.createdAt));
+        const [initialRun, promotedRun] = runs;
+        return (
+          initialRun?.id === firstRun?.id &&
+          initialRun.status === "succeeded" &&
+          promotedRun?.status === "succeeded"
+        );
+      }, 90_000);
+
+      const issueAfterPromotion = await db
+        .select({
+          status: issues.status,
+          completedAt: issues.completedAt,
+        })
+        .from(issues)
+        .where(eq(issues.id, issueId))
+        .then((rows) => rows[0] ?? null);
+
+      expect(issueAfterPromotion).toMatchObject({
+        status: "in_progress",
+        completedAt: null,
+      });
+
+      const secondPayload = gateway.getAgentPayloads()[1] ?? {};
+      expect(secondPayload.paperclip).toBeUndefined();
+      const secondWake = parseWakePayloadFromMessage(secondPayload.message);
+      expect(secondWake).toMatchObject({
+        commentIds: [midRunComment.id, reopenComment.id],
+        latestCommentId: reopenComment.id,
+        issue: {
+          id: issueId,
+          identifier: `${issuePrefix}-1`,
+          title: "Post-close human reopen must still work",
           status: "in_progress",
           priority: "medium",
         },
       });
-      expect(String(secondPayload.message ?? "")).toContain("Real follow-up from a human after the run closes");
+      expect(String(secondPayload.message ?? "")).toContain("Please reopen and continue after close");
     } finally {
       gateway.releaseFirstWait();
       await gateway.close();

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -2,7 +2,7 @@ import { createHash, randomUUID } from "node:crypto";
 import { Router, type Request, type Response } from "express";
 import multer from "multer";
 import { z } from "zod";
-import { and, asc, desc, eq, inArray, isNull, notInArray } from "drizzle-orm";
+import { and, asc, desc, eq, inArray, isNull, ne, notInArray } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import {
   activityLog,
@@ -3647,6 +3647,7 @@ export function issueRoutes(
         eq(issueRows.parentId, parent.id),
         inArray(issueRows.status, ["todo", "in_progress", "in_review", "blocked"]),
         isNull(issueRows.hiddenAt),
+        ne(issueRows.originKind, TASK_WATCHDOG_ORIGIN_KIND),
       ))
       .orderBy(asc(issueRows.issueNumber), asc(issueRows.createdAt), asc(issueRows.id));
     return children[0] ?? null;

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -13712,11 +13712,22 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         }
         const deferredCommentIds = extractWakeCommentIds(deferredContextSeed);
         const deferredWakeReason = readNonEmptyString(deferredContextSeed.wakeReason);
+        // Only explicit lifecycle intent should revive completed issues. A human
+        // comment that landed while the issue was still open is deferred as
+        // `issue_commented` without reopen markers; promoting that wake after the
+        // active run marks the issue `done` must not undo that close. Real
+        // post-close reopens set `reopenedFrom` / `issue_reopened_via_comment`, or
+        // an agent asks for resume via resumeIntent/followUpRequested.
+        const deferredLifecycleIntent =
+          promotedContextSeed.resumeIntent === true ||
+          promotedContextSeed.followUpRequested === true ||
+          readNonEmptyString(promotedContextSeed.reopenedFrom) !== null ||
+          deferredWakeReason === "issue_reopened_via_comment";
         // Local-CLI agents post comments under user auth, so a self-comment from
         // the run that is now ending would otherwise look like a real human
         // comment and trigger a reopen on the very issue this run just closed.
         // Suppress reopen only when every referenced comment came from this run;
-        // mixed batches must still reopen because they contain a real follow-up.
+        // mixed batches with real post-close reopen intent must still reopen.
         let deferredCommentWakeIsSelfAuthored = false;
         if (deferredCommentIds.length > 0) {
           const deferredComments = await tx
@@ -13734,12 +13745,15 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             deferredComments.length > 0 &&
             deferredComments.every((comment) => comment.createdByRunId === run.id);
         }
-        // Only human/comment-reopen interactions should revive completed issues;
-        // system follow-ups such as retry or cleanup wakes must not reopen closed work.
+        // Only human/comment-reopen interactions with lifecycle intent should
+        // revive completed issues; system follow-ups such as retry or cleanup
+        // wakes, and plain deferred `issue_commented` wakes that predate the
+        // close, must not reopen closed work.
         const shouldReopenDeferredCommentWake =
           deferredCommentIds.length > 0 &&
           !deferredCommentWakeIsSelfAuthored &&
           (issue.status === "done" || issue.status === "cancelled") &&
+          deferredLifecycleIntent &&
           (
             deferred.requestedByActorType === "user" ||
             deferredWakeReason === "issue_reopened_via_comment"


### PR DESCRIPTION
## Problem

`findCurrentSerializedWatchdogChild` scans all active children of the watched source issue for the serialization head. When a `task_watchdog` review issue is itself a child of the watched source, it gets included in the peer set. A new evaluation child then becomes serialized behind the watchdog issue, creating a circular wait:

- Evaluation waits for watchdog to finish
- Watchdog marks done with "path restored"
- Fingerprint re-triggers because tree is still blocked

Tracked as KYL-66.

## Fix

Add `ne(issueRows.originKind, TASK_WATCHDOG_ORIGIN_KIND)` to `findCurrentSerializedWatchdogChild`'s where clause. Watchdog-origin siblings are never a valid serialization head — they represent platform triage, not source work.

## Changes

- `server/src/routes/issues.ts`: add `ne` to imports + filter condition in `findCurrentSerializedWatchdogChild`