### PR TITLE
Fix apiCompression corrupting/dropping Better Auth responses for gzip clients

### DIFF
--- a/server/src/__tests__/api-compression.test.ts
+++ b/server/src/__tests__/api-compression.test.ts
@@ -105,6 +105,27 @@ function buildApp() {
     res.write(chunk.slice(0, chunk.length / 2));
     res.end(chunk.slice(chunk.length / 2));
   });
+  // Mirrors better-call's setResponse (Better Auth sign-in/sign-up): headers
+  // are committed with writeHead() first, then the web-stream body arrives as
+  // Uint8Array chunks.
+  app.get("/api/auth-bridge", (req, res) => {
+    const body = JSON.stringify({
+      token: "t".repeat(Number(req.query.pad ?? 0)),
+      user: { name: "Dotta", email: "dotta@example.test" },
+    });
+    res.setHeader("content-type", "application/json");
+    res.setHeader("set-cookie", "workspace.session_token=abc; Max-Age=604800; Path=/; HttpOnly; SameSite=Lax");
+    res.writeHead(200);
+    const bytes = new TextEncoder().encode(body);
+    res.write(bytes.subarray(0, 16));
+    res.write(bytes.subarray(16));
+    res.end();
+  });
+  app.get("/api/uint8-json", (req, res) => {
+    const body = JSON.stringify(issueListFixture(Number(req.query.count ?? 1)));
+    res.setHeader("Content-Type", "application/json; charset=utf-8");
+    res.end(new TextEncoder().encode(body));
+  });
   return app;
 }
 
@@ -183,5 +204,38 @@ describe("API compression middleware", () => {
     expect(res.headers["content-disposition"]).toBe("attachment; filename=\"issues.json\"");
     expect(res.headers["content-encoding"]).toBeUndefined();
     expect(JSON.parse(res.body.toString("utf8"))).toHaveLength(500);
+  });
+
+  it("delivers small writeHead+Uint8Array auth responses byte-for-byte (PAP-13466)", async () => {
+    const res = await requestRaw(buildApp(), "/api/auth-bridge", {
+      "accept-encoding": "gzip, deflate",
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.headers["set-cookie"]).toBeDefined();
+    expect(res.headers["content-encoding"]).toBeUndefined();
+    expect(JSON.parse(res.body.toString("utf8")).user.email).toBe("dotta@example.test");
+  });
+
+  it("does not drop the connection for large writeHead+Uint8Array auth responses (PAP-13466)", async () => {
+    const res = await requestRaw(buildApp(), "/api/auth-bridge?pad=2000", {
+      "accept-encoding": "gzip, deflate",
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.headers["content-encoding"]).toBeUndefined();
+    const parsed = JSON.parse(res.body.toString("utf8"));
+    expect(parsed.token).toHaveLength(2000);
+    expect(parsed.user.email).toBe("dotta@example.test");
+  });
+
+  it("compresses large Uint8Array bodies without corrupting them", async () => {
+    const res = await requestRaw(buildApp(), "/api/uint8-json?count=500", {
+      "accept-encoding": "gzip",
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.headers["content-encoding"]).toBe("gzip");
+    expect(JSON.parse(gunzipSync(res.body).toString("utf8"))).toHaveLength(500);
   });
 });

--- a/server/src/__tests__/api-compression.test.ts
+++ b/server/src/__tests__/api-compression.test.ts
@@ -206,7 +206,7 @@ describe("API compression middleware", () => {
     expect(JSON.parse(res.body.toString("utf8"))).toHaveLength(500);
   });
 
-  it("delivers small writeHead+Uint8Array auth responses byte-for-byte (PAP-13466)", async () => {
+  it("delivers small writeHead+Uint8Array auth responses byte-for-byte", async () => {
     const res = await requestRaw(buildApp(), "/api/auth-bridge", {
       "accept-encoding": "gzip, deflate",
     });
@@ -217,7 +217,7 @@ describe("API compression middleware", () => {
     expect(JSON.parse(res.body.toString("utf8")).user.email).toBe("dotta@example.test");
   });
 
-  it("does not drop the connection for large writeHead+Uint8Array auth responses (PAP-13466)", async () => {
+  it("does not drop the connection for large writeHead+Uint8Array auth responses", async () => {
     const res = await requestRaw(buildApp(), "/api/auth-bridge?pad=2000", {
       "accept-encoding": "gzip, deflate",
     });

--- a/server/src/middleware/api-compression.ts
+++ b/server/src/middleware/api-compression.ts
@@ -75,6 +75,10 @@ function shouldPassthroughWrite(res: Parameters<RequestHandler>[1]): boolean {
   const contentType = res.getHeader("Content-Type");
   const alreadyEncoded = res.hasHeader("Content-Encoding") && String(res.getHeader("Content-Encoding")).toLowerCase() !== "identity";
   return (
+    // writeHead() may already have committed the response head (better-call
+    // does this before streaming the body); headers can no longer change, so
+    // buffering for compression would only risk corrupting the stream.
+    res.headersSent ||
     alreadyEncoded ||
     !statusAllowsBody(res.statusCode) ||
     shouldSkipForCacheControl(res.getHeader("Cache-Control")) ||
@@ -95,6 +99,15 @@ function weakenStrongEtag(res: Parameters<RequestHandler>[1]): void {
   }
 
   res.setHeader("ETag", weaken(String(etag)));
+}
+
+function toBodyBuffer(chunk: unknown, encoding: BufferEncoding | undefined): Buffer {
+  if (Buffer.isBuffer(chunk)) return chunk;
+  // Handlers bridged from web Response streams (e.g. Better Auth via
+  // better-call) write Uint8Array chunks; String(chunk) would serialize them
+  // as comma-separated byte values and corrupt the body.
+  if (chunk instanceof Uint8Array) return Buffer.from(chunk.buffer, chunk.byteOffset, chunk.byteLength);
+  return Buffer.from(String(chunk), encoding);
 }
 
 function normalizeEndArgs(args: unknown[]): {
@@ -160,7 +173,7 @@ export function apiCompression(options: ApiCompressionOptions = {}): RequestHand
         return originalWrite(chunk as never, encodingOrCallback as never, callback as never);
       }
       if (chunk !== undefined) {
-        chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk), typeof encodingOrCallback === "string" ? encodingOrCallback : undefined));
+        chunks.push(toBodyBuffer(chunk, typeof encodingOrCallback === "string" ? encodingOrCallback : undefined));
       }
       const writeCallback = typeof encodingOrCallback === "function" ? encodingOrCallback : callback;
       if (writeCallback) writeCallbacks.push(() => writeCallback(null));
@@ -171,13 +184,14 @@ export function apiCompression(options: ApiCompressionOptions = {}): RequestHand
       restore();
       const { chunk, encoding, callback } = normalizeEndArgs(args);
       if (chunk !== undefined) {
-        chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk), encoding));
+        chunks.push(toBodyBuffer(chunk, encoding));
       }
 
       const body = Buffer.concat(chunks);
       const alreadyEncoded = res.hasHeader("Content-Encoding") && String(res.getHeader("Content-Encoding")).toLowerCase() !== "identity";
       const shouldCompress =
         !passthrough &&
+        !res.headersSent &&
         !alreadyEncoded &&
         statusAllowsBody(res.statusCode) &&
         body.length >= thresholdBytes &&
@@ -204,7 +218,14 @@ export function apiCompression(options: ApiCompressionOptions = {}): RequestHand
           originalEnd(compressed, callback);
           for (const writeCallback of writeCallbacks) writeCallback();
         } catch (error) {
-          res.destroy(error instanceof Error ? error : new Error(String(error)));
+          // Compression is best-effort: never turn a healthy response into a
+          // dropped connection. Send the original body if the head allows it.
+          try {
+            originalEnd(body, callback);
+            for (const writeCallback of writeCallbacks) writeCallback();
+          } catch {
+            res.destroy(error instanceof Error ? error : new Error(String(error)));
+          }
         }
       })();
       return res;


### PR DESCRIPTION
## Summary

Standalone port of the PAP-13466 login fix to master (PAP-13485). The `apiCompression` middleware (from #9190) corrupts or drops every Better Auth response for clients that send `Accept-Encoding: gzip` or `deflate` — i.e. all real browsers — while curl (no `Accept-Encoding`) works, which made this easy to misdiagnose.

Two compounding bugs in `server/src/middleware/api-compression.ts`:

1. **Body corruption**: buffered `res.write()` chunks were converted with `String(chunk)`. Better Auth (via better-call) streams `Uint8Array` chunks, which `String()` serializes as comma-separated decimal byte values — corrupting the JSON body and inflating it ~3.4x.
2. **Connection destroyed**: better-call commits headers with `writeHead()` before streaming. When the inflated body crossed the 1024B compression threshold, `setHeader()` threw `ERR_HTTP_HEADERS_SENT`, and the catch block called `res.destroy()` — zero bytes on the wire. Browsers surfaced `net::ERR_EMPTY_RESPONSE` / "Failed to fetch" on sign-in.

## Fix

- Convert `Uint8Array` chunks with `Buffer.from()` instead of `String()`.
- Pass through uncompressed once headers are already sent (`writeHead`-style streaming responses).
- On compression failure, fall back to writing the original uncompressed body instead of destroying the connection.

## Testing

- `pnpm vitest run src/__tests__/api-compression.test.ts` — 10/10 passing, including 3 new regression tests covering `Uint8Array` chunk handling, the headers-already-sent pass-through, and the no-destroy fallback.

Cherry-pick of `257c9dc89` (verified on the PAP-10341 execution workspace, where it fixed browser sign-in). Tracked by PAP-13485, parent PAP-13466.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
