### PR TITLE
fix(codex-local): refresh models from Codex cache

### DIFF
--- a/server/src/__tests__/adapter-models.test.ts
+++ b/server/src/__tests__/adapter-models.test.ts
@@ -1,3 +1,6 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { models as claudeFallbackModels } from "@paperclipai/adapter-claude-local";
 import { resetClaudeModelsCacheForTests } from "@paperclipai/adapter-claude-local/server";
@@ -17,7 +20,11 @@ vi.mock("acpx/runtime", () => ({
 }));
 
 describe("adapter model listing", () => {
-  beforeEach(() => {
+  let isolatedCodexHome: string;
+
+  beforeEach(async () => {
+    isolatedCodexHome = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-codex-models-"));
+    process.env.CODEX_HOME = isolatedCodexHome;
     delete process.env.OPENAI_API_KEY;
     delete process.env.ANTHROPIC_API_KEY;
     delete process.env.ANTHROPIC_BASE_URL;
@@ -30,6 +37,11 @@ describe("adapter model listing", () => {
     setCursorModelsRunnerForTests(null);
     resetOpenCodeModelsCacheForTests();
     vi.restoreAllMocks();
+  });
+
+  afterEach(async () => {
+    delete process.env.CODEX_HOME;
+    await fs.rm(isolatedCodexHome, { recursive: true, force: true });
   });
 
   it("returns an empty list for unknown adapters", async () => {
@@ -53,6 +65,43 @@ describe("adapter model listing", () => {
     expect(models.some((model) => model.id === "gpt-5.6-terra")).toBe(true);
     expect(models.some((model) => model.id === "gpt-5.6-luna")).toBe(true);
     expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("reads visible Codex cache models without an OpenAI API key", async () => {
+    await fs.writeFile(
+      path.join(isolatedCodexHome, "models_cache.json"),
+      JSON.stringify({
+        models: [
+          { slug: "gpt-cache-visible", display_name: "Visible cached Codex model", visibility: "list" },
+          { slug: "gpt-cache-hidden", display_name: "Hidden cached Codex model", visibility: "hidden" },
+        ],
+      }),
+    );
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+    const models = await listAdapterModels("codex_local");
+
+    expect(models).toContainEqual({ id: "gpt-cache-visible", label: "Visible cached Codex model" });
+    expect(models.some((model) => model.id === "gpt-cache-hidden")).toBe(false);
+    expect(models.some((model) => model.id === "codex-mini-latest")).toBe(true);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("re-reads the Codex cache when models are refreshed", async () => {
+    const cacheFile = path.join(isolatedCodexHome, "models_cache.json");
+    await fs.writeFile(cacheFile, JSON.stringify({
+      models: [{ slug: "gpt-cache-before-refresh", visibility: "list" }],
+    }));
+
+    const initial = await listAdapterModels("codex_local");
+    await fs.writeFile(cacheFile, JSON.stringify({
+      models: [{ slug: "gpt-cache-after-refresh", visibility: "list" }],
+    }));
+    const refreshed = await refreshAdapterModels("codex_local");
+
+    expect(initial.some((model) => model.id === "gpt-cache-before-refresh")).toBe(true);
+    expect(refreshed.some((model) => model.id === "gpt-cache-after-refresh")).toBe(true);
+    expect(refreshed.some((model) => model.id === "gpt-cache-before-refresh")).toBe(false);
   });
 
   it("returns claude fallback models including the latest Opus alias when no Anthropic key is available", async () => {

--- a/server/src/adapters/codex-models.ts
+++ b/server/src/adapters/codex-models.ts
@@ -1,5 +1,8 @@
+import fs from "node:fs/promises";
+import path from "node:path";
 import type { AdapterModel } from "./types.js";
 import { models as codexFallbackModels } from "@paperclipai/adapter-codex-local";
+import { codexHomeDir } from "@paperclipai/adapter-codex-local/server";
 import { readConfigFile } from "../config-file.js";
 
 const OPENAI_MODELS_ENDPOINT = "https://api.openai.com/v1/models";
@@ -41,6 +44,35 @@ function resolveOpenAiApiKey(): string | null {
   return configKey && configKey.length > 0 ? configKey : null;
 }
 
+interface CodexCacheEntry {
+  slug?: unknown;
+  display_name?: unknown;
+  visibility?: unknown;
+}
+
+async function readCodexModelsCache(): Promise<AdapterModel[]> {
+  try {
+    const file = path.join(codexHomeDir(), "models_cache.json");
+    const raw = JSON.parse(await fs.readFile(file, "utf8")) as { models?: unknown };
+    const models = Array.isArray(raw.models) ? raw.models : [];
+    return dedupeModels(
+      models.flatMap((model): AdapterModel[] => {
+        if (typeof model !== "object" || model === null) return [];
+        const entry = model as CodexCacheEntry;
+        if (entry.visibility !== "list" || typeof entry.slug !== "string") return [];
+        const id = entry.slug.trim();
+        if (!id) return [];
+        const label = typeof entry.display_name === "string" && entry.display_name.trim()
+          ? entry.display_name.trim()
+          : id;
+        return [{ id, label }];
+      }),
+    );
+  } catch {
+    return [];
+  }
+}
+
 async function fetchOpenAiModels(apiKey: string): Promise<AdapterModel[]> {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), OPENAI_MODELS_TIMEOUT_MS);
@@ -72,8 +104,13 @@ async function fetchOpenAiModels(apiKey: string): Promise<AdapterModel[]> {
 
 async function loadCodexModels(options?: { forceRefresh?: boolean }): Promise<AdapterModel[]> {
   const forceRefresh = options?.forceRefresh === true;
-  const apiKey = resolveOpenAiApiKey();
   const fallback = dedupeModels(codexFallbackModels);
+
+  // The Codex client owns this file cache; each list/refresh reads its latest catalog.
+  const fromCodexCache = await readCodexModelsCache();
+  if (fromCodexCache.length > 0) return mergedWithFallback(fromCodexCache);
+
+  const apiKey = resolveOpenAiApiKey();
   if (!apiKey) return fallback;
 
   const now = Date.now();


### PR DESCRIPTION
## Thinking Path

> - Paperclip is an open-source control plane for managing AI agents at work.
> - Its Codex-local adapter needs to expose the models available through a user’s local Codex installation.
> - Model discovery currently falls through from the OpenAI API to a static fallback list.
> - ChatGPT-authenticated Codex users commonly have no `OPENAI_API_KEY`, even though Codex maintains their current model catalog locally.
> - As a result, Paperclip can show stale fallback models and **Refresh models** can appear to do nothing.
> - Codex stores its catalog in `CODEX_HOME/models_cache.json`.
> - This pull request reads that cache as the highest-priority source, while retaining the existing API and static fallback paths.
> - The benefit is that ChatGPT-authenticated Codex users see their actual available models without extra credentials or network calls.

## Linked Issues or Issue Description

Fixes #1317.
Supersedes #5087.

## What Changed

- Read the Codex CLI model catalog from `CODEX_HOME/models_cache.json` before the OpenAI API and static fallback paths.
- Include only cached models with `visibility: "list"`, preserving their display names and merging them with the static fallback models.
- Re-read the Codex-owned cache on every list/refresh request so **Refresh models** sees catalog changes without an in-memory TTL.
- Use async file I/O with safe fallback behavior when the cache is missing, empty, malformed, or unreadable.
- Added integration coverage for visibility filtering and for `refreshAdapterModels` detecting changes to the cache between calls.

## Verification

- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/adapter-models.test.ts`
- `pnpm --filter @paperclipai/server typecheck`
- CI passed build, typecheck, e2e, security scans, and the remaining test shards on the submitted commit.
- The new integration tests use isolated temporary `CODEX_HOME` directories and verify both model filtering and refresh behavior after the cache file changes.

## Risks

- **Low risk.** The change is scoped to Codex-local model discovery and preserves the existing OpenAI API and static fallback paths.
- The Codex cache may be stale if Codex has not refreshed it recently; this matches Codex’s own local state, while the fallback list remains available.
- The cache is intentionally re-read for each request. This adds a small local-file read but ensures refreshes reflect Codex-owned updates.
- No migration, new network call, or new authentication requirement is introduced.

## Model Used

- OpenAI GPT-5.6 Terra (`gpt-5.6-terra`) via Hermes Agent, with shell, GitHub API, and tool-use capabilities.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have linked existing public GitHub issues with `Fixes:` / `Supersedes:`
- [x] I have not referenced internal or instance-local Paperclip issues or links
- [x] My branch name describes the change and contains no internal Paperclip ticket ID
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes (N/A — adapter-internal behavior; no user-facing documentation change needed)
- [x] I have considered and documented risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
