### PR TITLE
feat(task-bridge): add get-task command, blocked-by-issue-id support, and stricter resume validation

### DIFF
--- a/doc/operations/pilot-research-pipeline-repair-2026-07-10.md
+++ b/doc/operations/pilot-research-pipeline-repair-2026-07-10.md
@@ -1,0 +1,50 @@
+# Pilot Research Pipeline Repair — Build Record and Playbook
+
+**Date:** 2026-07-10  
+**Scope:** Paperclip Pilot Research company
+
+## Outcome
+
+The Pilot Research chain is now constrained to a staged, project-scoped handoff:
+
+`Research Lead → Source Gatherer → Fact-Checker → Reporting Agent → Research Lead closeout`
+
+No raw Paperclip credential is stored in an agent prompt or in a report.
+
+## Controls Implemented
+
+1. **MCP lifecycle cleanup.** Hermes now skips cancellation/await of lifecycle tasks owned by a closed foreign event loop. This removes the `Event loop is closed` teardown failure path.
+2. **Heartbeat containment.** Every Pilot Research agent uses `maxConcurrentRuns: 1`, a 60-second cooldown, a 15-minute timer, demand wakeups, and idle-work suppression. All four agents remain paused after repair.
+3. **Controlled Paperclip writes.** Each role has a dedicated `task_bridge` key held in Paperclip secret storage and bounded to the `Pilot Research Pipeline` project. Each key can assign only the next role in the chain.
+4. **Native handoffs.** Roles use `paperclip-task.mjs` with a child-task handoff. A stage completes, then creates its single successor with the complete artifact in the successor description. This preserves read boundaries: an assignee only needs its own task.
+5. **Lead-only orchestration.** The Lead has `terminal,todo` only; no browser or web tools. It dispatches Source work, marks the root blocked during stage execution, then completes the root only from a `[Close]` task assigned back to it.
+6. **Fallback availability.** Hermes global `fallback_providers` is present for every adapter-launched Hermes run. The configured order begins `z-ai/glm-5.2 → x-ai/grok-4.5 → openrouter/free` and continues through Nvidia free models and `deepseek/deepseek-v4-flash`.
+
+## Verification Evidence
+
+- `python -m pytest -q tests/tools/test_mcp_lifecycle_cleanup.py` — **2 passed**.
+- `python scripts/validate_pilot_pipeline_e2e.py` — **passed**. The no-LLM test created and closed Lead, Source, Fact, Report, and Lead-close tasks; verified parent/project links and a forbidden cross-role assignment returned HTTP 403.
+- The proof log is stored at `C:\Users\rcatl\.paperclip\pilot-research-pipeline-e2e-validation-2026-07-10.json` and contains identifiers/statuses only, never raw keys.
+- Post-change API audit confirmed all four Pilot Research agents are paused, carry the one-run heartbeat policy, and have no active heartbeat runs.
+
+## Operating Procedure
+
+1. Keep all four agents paused until an operator intentionally starts a Pilot Research root task in the `Pilot Research Pipeline` project.
+2. Assign the root to Research Lead.
+3. Review the Lead closure task and root completion artifact after the chain finishes.
+4. If a stage blocks, inspect its assigned Paperclip task and comments. Do not widen a task-bridge scope or put credentials into AGENTS.md.
+
+## Rollback
+
+1. Pause the four Pilot Research agents if they are not already paused.
+2. Delete the four `Pilot Research task bridge` keys and their associated Paperclip secrets.
+3. Restore the four prior AGENTS.md instruction files from the Paperclip instance backup or version control.
+4. Reapply a known-good heartbeat policy only after verifying no active run remains.
+
+## Related Files
+
+- `scripts/repair_pilot_pipeline.py`
+- `scripts/rotate_pilot_task_bridge_scopes.py`
+- `scripts/validate_pilot_pipeline_e2e.py`
+- `packages/adapters/hermes/skills/paperclip-task-bridge/paperclip-task.mjs`
+- `packages/adapters/hermes/skills/paperclip-task-bridge/SKILL.md`

--- a/packages/adapters/hermes/skills/paperclip-task-bridge/SKILL.md
+++ b/packages/adapters/hermes/skills/paperclip-task-bridge/SKILL.md
@@ -54,12 +54,14 @@ Commands:
 
 ```sh
 node ./paperclip-task.mjs list-assigned
+node ./paperclip-task.mjs get-task --issue PAP-123
 node ./paperclip-task.mjs create-task --parent-id "00000000-0000-4000-8000-000000000000" --title "Investigate checkout failures" --description "Capture failing request and root cause."
+node ./paperclip-task.mjs create-task --parent-id "00000000-0000-4000-8000-000000000000" --project-id "00000000-0000-4000-8000-000000000000" --assignee-agent-id "00000000-0000-4000-8000-000000000000" --title "Hand off evidence" --description "Use a project-scoped bridge key."
 node ./paperclip-task.mjs comment --issue PAP-123 --body "Found the failing request path."
 node ./paperclip-task.mjs update-status --issue PAP-123 --status in_review --comment "Ready for review."
 ```
 
-`create-task` defaults to assigning the task to the authenticated Hermes agent so the work is immediately actionable. Use `--unassigned` to create backlog work instead. Use `--assignee-agent-id <uuid>` only when the Paperclip API key has permission to assign work to that agent.
+`create-task` defaults to assigning the task to the authenticated Hermes agent so the work is immediately actionable. Use `--unassigned` to create backlog work instead. Use `--assignee-agent-id <uuid>` only when the Paperclip API key has permission to assign work to that agent. Use `get-task` only for an assigned or bridge-created task. `--blocked-by-issue-id <uuid[,uuid]>` records native Paperclip dependencies; it is appropriate when the creating bridge key will not need to mutate the downstream task.
 
 For multiline bodies, prefer files or stdin:
 

--- a/packages/adapters/hermes/skills/paperclip-task-bridge/paperclip-task.mjs
+++ b/packages/adapters/hermes/skills/paperclip-task-bridge/paperclip-task.mjs
@@ -11,6 +11,7 @@ const HELP = `Paperclip task bridge for Hermes
 
 Usage:
   paperclip-task.mjs list-assigned [--status todo,in_progress,in_review,blocked] [--limit 20]
+  paperclip-task.mjs get-task --issue <id|identifier>
   paperclip-task.mjs create-task --title <title> [--description <text>|--description-file <path|->] [options]
   paperclip-task.mjs comment --issue <id|identifier> (--body <text>|--body-file <path|->) [--resume|--reopen]
   paperclip-task.mjs update-status --issue <id|identifier> --status <status> [--comment <text>|--comment-file <path|->]
@@ -30,6 +31,7 @@ create-task options:
   --parent-id <uuid>              Parent issue id.
   --goal-id <uuid>                Goal id.
   --project-id <uuid>             Project id.
+  --blocked-by-issue-id <uuid[,uuid]>  Block until one or more issue ids are done.
   --priority <critical|high|medium|low>
   --status <backlog|todo|in_progress|in_review|done|blocked|cancelled>
   --work-mode <standard|ask|planning>
@@ -219,6 +221,16 @@ function parseLimit(args) {
   return value;
 }
 
+function parseUuidListFlag(args, name) {
+  const raw = readStringFlag(args, name);
+  if (!raw) return [];
+  const values = [...new Set(raw.split(",").map((value) => value.trim()).filter(Boolean))];
+  if (values.some((value) => !UUID_RE.test(value))) {
+    throw new UsageError(`--${name} must contain one or more comma-separated UUIDs`);
+  }
+  return values;
+}
+
 async function listAssigned(config, args) {
   const identity = await resolveIdentity(config);
   const status = readStringFlag(args, "status") || "todo,in_progress,in_review,blocked";
@@ -234,6 +246,19 @@ async function listAssigned(config, args) {
     agentId: identity.agentId,
     count: filteredIssues.length,
     issues: filteredIssues.map(issueSummary),
+  });
+}
+
+async function getTask(config, args) {
+  const issueRef = requireStringFlag(args, "issue");
+  const issue = await apiFetch(config, `/issues/${encodeURIComponent(issueRef)}`);
+  printJson({
+    command: "get-task",
+    issue: {
+      ...issueSummary(issue),
+      description: issue?.description ?? null,
+      blockedByIssueIds: Array.isArray(issue?.blockedByIssueIds) ? issue.blockedByIssueIds : [],
+    },
   });
 }
 
@@ -270,6 +295,8 @@ async function createTask(config, args) {
     const value = readStringFlag(args, flag);
     if (value) body[field] = value;
   }
+  const blockedByIssueIds = parseUuidListFlag(args, "blocked-by-issue-id");
+  if (blockedByIssueIds.length > 0) body.blockedByIssueIds = blockedByIssueIds;
   const status = readStringFlag(args, "status");
   if (status) body.status = validateEnum(status, STATUSES, "status");
 
@@ -302,12 +329,20 @@ async function updateStatus(config, args) {
   const issueRef = requireStringFlag(args, "issue");
   const status = validateEnum(requireStringFlag(args, "status"), STATUSES, "status");
   const commentText = await readBody(args, "comment", "comment-file");
-  const body = {
-    status,
-    ...(commentText && commentText.trim().length > 0 ? { comment: commentText } : {}),
-    ...(boolFlag(args, "resume") ? { resume: true } : {}),
-    ...(boolFlag(args, "reopen") ? { reopen: true } : {}),
-  };
+  const resume = boolFlag(args, "resume");
+  if (resume && status !== "todo") {
+    throw new UsageError("--resume is only valid with --status todo");
+  }
+  if (resume && (!commentText || commentText.trim().length === 0)) {
+    throw new UsageError("--resume requires --comment or --comment-file");
+  }
+  const body = resume
+    ? { resume: true, comment: commentText }
+    : {
+        status,
+        ...(commentText && commentText.trim().length > 0 ? { comment: commentText } : {}),
+        ...(boolFlag(args, "reopen") ? { reopen: true } : {}),
+      };
   const issue = await apiFetch(config, `/issues/${encodeURIComponent(issueRef)}`, {
     method: "PATCH",
     mutating: true,
@@ -325,6 +360,7 @@ async function main() {
   }
   const config = getConfig();
   if (command === "list-assigned") return listAssigned(config, args);
+  if (command === "get-task") return getTask(config, args);
   if (command === "create-task") return createTask(config, args);
   if (command === "comment") return comment(config, args);
   if (command === "update-status") return updateStatus(config, args);

--- a/scripts/repair_pilot_pipeline.py
+++ b/scripts/repair_pilot_pipeline.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+"""Apply the Pilot Research pipeline guardrails through the Paperclip board API.
+
+This script intentionally never prints or writes raw API-key material.  Each
+agent receives a project-bounded task-bridge key stored as a Paperclip secret.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+API = "http://127.0.0.1:3100/api"
+COMPANY_ID = "3026a09a-da4a-499b-a633-032058933429"
+PROJECT_NAME = "Pilot Research Pipeline"
+LOG_PATH = Path(r"C:\Users\rcatl\.paperclip\pilot-research-pipeline-repair-2026-07-10.json")
+
+ROLE_CONFIG = {
+    "Research Lead": {
+        "toolsets": "terminal,todo",
+        "secret_key": "PAPERCLIP_BRIDGE_RESEARCH_LEAD",
+        "allowed_assignee_names": ["Source Gatherer"],
+        "can_assign": True,
+        "can_create_agents": False,
+        "can_create_skills": False,
+    },
+    "Source Gatherer": {
+        "toolsets": "web,browser,terminal,todo",
+        "secret_key": "PAPERCLIP_BRIDGE_SOURCE_GATHERER",
+        "allowed_assignee_names": ["Fact-Checker"],
+        "can_assign": True,
+        "can_create_agents": False,
+        "can_create_skills": False,
+    },
+    "Fact-Checker": {
+        "toolsets": "web,browser,terminal,todo",
+        "secret_key": "PAPERCLIP_BRIDGE_FACT_CHECKER",
+        "allowed_assignee_names": ["Reporting Agent"],
+        "can_assign": True,
+        "can_create_agents": False,
+        "can_create_skills": False,
+    },
+    "Reporting Agent": {
+        "toolsets": "terminal,todo",
+        "secret_key": "PAPERCLIP_BRIDGE_REPORTING_AGENT",
+        "allowed_assignee_names": ["Research Lead"],
+        "can_assign": True,
+        "can_create_agents": False,
+        "can_create_skills": False,
+    },
+}
+
+HEARTBEAT_POLICY = {
+    "enabled": True,
+    "cooldownSec": 60,
+    "intervalSec": 900,
+    "wakeOnDemand": True,
+    "maxConcurrentRuns": 1,
+    "skipTimerWhenNoActionableWork": True,
+}
+
+
+def request(method: str, path: str, payload: dict[str, Any] | None = None) -> Any:
+    body = None if payload is None else json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(
+        API + path,
+        data=body,
+        headers={"Content-Type": "application/json"} if body is not None else {},
+        method=method,
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=45) as response:
+            return json.load(response)
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", "replace")[:1000]
+        raise RuntimeError(f"{method} {path} failed ({exc.code}): {detail}") from exc
+
+
+def response_token(key_result: dict[str, Any]) -> str:
+    # The board returns the one-time key material in `token`; retain it only in
+    # process memory long enough to put it into encrypted Paperclip secret storage.
+    token = key_result.get("token")
+    if not isinstance(token, str) or not token.strip():
+        raise RuntimeError("Paperclip did not return one-time task-bridge key material")
+    return token
+
+
+def main() -> int:
+    agents = request("GET", f"/companies/{COMPANY_ID}/agents")
+    if not isinstance(agents, list):
+        raise RuntimeError("Agent listing did not return a list")
+    by_name = {agent.get("name"): agent for agent in agents}
+    missing = sorted(set(ROLE_CONFIG) - set(by_name))
+    if missing:
+        raise RuntimeError(f"Required Pilot Research agents are missing: {', '.join(missing)}")
+    if any(agent.get("status") != "paused" for agent in by_name.values() if agent.get("name") in ROLE_CONFIG):
+        raise RuntimeError("Refusing to change the pipeline while a Pilot Research agent is not paused")
+
+    projects = request("GET", f"/companies/{COMPANY_ID}/projects")
+    project = next((item for item in projects if item.get("name") == PROJECT_NAME), None)
+    project_created = False
+    if project is None:
+        lead_id = by_name["Research Lead"]["id"]
+        project = request(
+            "POST",
+            f"/companies/{COMPANY_ID}/projects",
+            {
+                "name": PROJECT_NAME,
+                "description": (
+                    "Bounded four-stage research flow: Lead dispatches Source, Fact-Checker, "
+                    "and Report Writer child tasks through scoped Paperclip task-bridge credentials."
+                ),
+                "status": "planned",
+                "leadAgentId": lead_id,
+                "icon": "layers",
+            },
+        )
+        project_created = True
+    project_id = project.get("id")
+    if not isinstance(project_id, str):
+        raise RuntimeError("Pilot Research Pipeline project has no id")
+
+    generated_key_ids: list[tuple[str, str]] = []
+    generated_secret_ids: list[str] = []
+    result: dict[str, Any] = {
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "companyId": COMPANY_ID,
+        "projectId": project_id,
+        "projectCreated": project_created,
+        "heartbeatPolicy": HEARTBEAT_POLICY,
+        "agents": {},
+    }
+
+    try:
+        for name, role in ROLE_CONFIG.items():
+            agent = by_name[name]
+            agent_id = agent["id"]
+            scope: dict[str, Any] = {"kind": "task_bridge", "projectId": project_id}
+            allowed_assignee_names = role.get("allowed_assignee_names", [])
+            if allowed_assignee_names:
+                scope["allowedAssigneeAgentIds"] = [by_name[agent_name]["id"] for agent_name in allowed_assignee_names]
+
+            key = request(
+                "POST",
+                f"/agents/{agent_id}/keys",
+                {"name": "Pilot Research task bridge", "scope": scope},
+            )
+            generated_key_ids.append((agent_id, key["id"]))
+            token = response_token(key)
+
+            secret = request(
+                "POST",
+                f"/companies/{COMPANY_ID}/secrets",
+                {
+                    "name": f"Pilot Research task bridge — {name}",
+                    "key": role["secret_key"],
+                    "provider": "local_encrypted",
+                    "managedMode": "paperclip_managed",
+                    "value": token,
+                    "description": f"Project-bounded task-bridge credential for {name}.",
+                },
+            )
+            # Drop the raw one-time token immediately after encrypted storage succeeds.
+            token = ""
+            generated_secret_ids.append(secret["id"])
+
+            existing_env = dict((agent.get("adapterConfig") or {}).get("env") or {})
+            existing_env["PAPERCLIP_BRIDGE_API_KEY"] = {
+                "type": "secret_ref",
+                "secretId": secret["id"],
+                "version": "latest",
+            }
+            request(
+                "PATCH",
+                f"/agents/{agent_id}",
+                {
+                    "adapterConfig": {
+                        "toolsets": role["toolsets"],
+                        "env": existing_env,
+                    },
+                    "runtimeConfig": {"heartbeat": HEARTBEAT_POLICY},
+                },
+            )
+            request(
+                "PATCH",
+                f"/agents/{agent_id}/permissions",
+                {
+                    "canCreateAgents": role["can_create_agents"],
+                    "canCreateSkills": role["can_create_skills"],
+                    "canAssignTasks": role["can_assign"],
+                },
+            )
+            result["agents"][name] = {
+                "agentId": agent_id,
+                "taskBridgeKeyId": key["id"],
+                "secretId": secret["id"],
+                "toolsets": role["toolsets"],
+                "canAssignTasks": role["can_assign"],
+            }
+    except Exception:
+        # Avoid leaving usable credentials behind when the configuration only
+        # partially applied. The project is retained as an auditable boundary.
+        for secret_id in reversed(generated_secret_ids):
+            try:
+                request("DELETE", f"/secrets/{secret_id}")
+            except Exception:
+                pass
+        for agent_id, key_id in reversed(generated_key_ids):
+            try:
+                request("DELETE", f"/agents/{agent_id}/keys/{key_id}")
+            except Exception:
+                pass
+        raise
+
+    LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+    LOG_PATH.write_text(json.dumps(result, indent=2) + "\n", encoding="utf-8")
+    print(json.dumps({
+        "ok": True,
+        "projectId": project_id,
+        "projectCreated": project_created,
+        "configuredAgents": sorted(result["agents"]),
+        "maxConcurrentRuns": HEARTBEAT_POLICY["maxConcurrentRuns"],
+        "log": str(LOG_PATH),
+    }, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except Exception as exc:
+        print(json.dumps({"ok": False, "error": str(exc)}))
+        raise SystemExit(1)

--- a/scripts/rotate_pilot_task_bridge_scopes.py
+++ b/scripts/rotate_pilot_task_bridge_scopes.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Rotate Pilot Research bridge keys to least-privilege sequential handoff scopes."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from repair_pilot_pipeline import (
+    COMPANY_ID,
+    LOG_PATH,
+    PROJECT_NAME,
+    ROLE_CONFIG,
+    request,
+    response_token,
+)
+
+
+def main() -> int:
+    record = json.loads(LOG_PATH.read_text(encoding="utf-8"))
+    agents = request("GET", f"/companies/{COMPANY_ID}/agents")
+    by_name = {agent["name"]: agent for agent in agents}
+    projects = request("GET", f"/companies/{COMPANY_ID}/projects")
+    project = next((item for item in projects if item.get("name") == PROJECT_NAME), None)
+    if not project:
+        raise RuntimeError("Pilot Research Pipeline project is missing")
+    project_id = project["id"]
+
+    rotated: dict[str, dict[str, object]] = {}
+    for name, role in ROLE_CONFIG.items():
+        agent = by_name.get(name)
+        old = record.get("agents", {}).get(name, {})
+        if not agent or not old.get("taskBridgeKeyId") or not old.get("secretId"):
+            raise RuntimeError(f"Missing current bridge state for {name}")
+        scope = {
+            "kind": "task_bridge",
+            "projectId": project_id,
+            "allowedAssigneeAgentIds": [by_name[target]["id"] for target in role["allowed_assignee_names"]],
+        }
+        new_key = None
+        try:
+            new_key = request(
+                "POST",
+                f"/agents/{agent['id']}/keys",
+                {"name": "Pilot Research task bridge v2", "scope": scope},
+            )
+            request("POST", f"/secrets/{old['secretId']}/rotate", {"value": response_token(new_key)})
+            request(
+                "PATCH",
+                f"/agents/{agent['id']}/permissions",
+                {"canCreateAgents": False, "canCreateSkills": False, "canAssignTasks": True},
+            )
+            request("DELETE", f"/agents/{agent['id']}/keys/{old['taskBridgeKeyId']}")
+            record["agents"][name].update(
+                {
+                    "taskBridgeKeyId": new_key["id"],
+                    "canAssignTasks": True,
+                    "taskBridgeScope": scope,
+                }
+            )
+            rotated[name] = {"agentId": agent["id"], "taskBridgeKeyId": new_key["id"], "scope": scope}
+        except Exception:
+            if new_key and new_key.get("id"):
+                try:
+                    request("DELETE", f"/agents/{agent['id']}/keys/{new_key['id']}")
+                except Exception:
+                    pass
+            raise
+
+    record["bridgeScopesRotated"] = rotated
+    LOG_PATH.write_text(json.dumps(record, indent=2) + "\n", encoding="utf-8")
+    print(json.dumps({"ok": True, "projectId": project_id, "rotated": sorted(rotated)}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_pilot_pipeline_e2e.py
+++ b/scripts/validate_pilot_pipeline_e2e.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""No-LLM end-to-end validation of the Pilot Research scoped handoff chain."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+API = "http://127.0.0.1:3100/api"
+COMPANY_ID = "3026a09a-da4a-499b-a633-032058933429"
+PROJECT_ID = "67a1f416-5420-403c-9584-604fb2370b2a"
+BRIDGE = r"C:\Users\rcatl\paperclip\packages\adapters\hermes\skills\paperclip-task-bridge\paperclip-task.mjs"
+LOG_PATH = Path(r"C:\Users\rcatl\.paperclip\pilot-research-pipeline-e2e-validation-2026-07-10.json")
+
+
+def request(method: str, path: str, payload: dict[str, Any] | None = None) -> Any:
+    data = None if payload is None else json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(
+        API + path,
+        data=data,
+        headers={"Content-Type": "application/json"} if data is not None else {},
+        method=method,
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=40) as response:
+            return json.load(response)
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", "replace")[:1000]
+        raise RuntimeError(f"{method} {path} failed ({exc.code}): {detail}") from exc
+
+
+def run_bridge(token: str, agent_id: str, *args: str, expect_ok: bool = True) -> dict[str, Any]:
+    env = os.environ.copy()
+    env.update(
+        {
+            "PAPERCLIP_API_URL": "http://127.0.0.1:3100",
+            "PAPERCLIP_COMPANY_ID": COMPANY_ID,
+            "PAPERCLIP_AGENT_ID": agent_id,
+            "PAPERCLIP_BRIDGE_API_KEY": token,
+        }
+    )
+    result = subprocess.run(
+        ["node", BRIDGE, *args],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        env=env,
+        timeout=50,
+        check=False,
+    )
+    if expect_ok:
+        if result.returncode != 0:
+            raise RuntimeError(f"Bridge {' '.join(args[:2])} failed: {result.stdout[-1000:]} {result.stderr[-500:]}")
+        return json.loads(result.stdout)
+    if result.returncode == 0:
+        raise RuntimeError("A scoped bridge key unexpectedly performed a forbidden cross-role assignment")
+    response = json.loads(result.stdout)
+    if response.get("status") not in {401, 403}:
+        raise RuntimeError(f"Expected authorization denial, received: {response}")
+    return response
+
+
+def main() -> int:
+    agents = request("GET", f"/companies/{COMPANY_ID}/agents")
+    by_name = {agent["name"]: agent for agent in agents}
+    required = ["Research Lead", "Source Gatherer", "Fact-Checker", "Reporting Agent"]
+    if any(by_name.get(name, {}).get("status") != "paused" for name in required):
+        raise RuntimeError("Validation requires all Pilot Research agents to remain paused")
+
+    role_ids = {name: by_name[name]["id"] for name in required}
+    scopes = {
+        "Research Lead": [role_ids["Source Gatherer"]],
+        "Source Gatherer": [role_ids["Fact-Checker"]],
+        "Fact-Checker": [role_ids["Reporting Agent"]],
+        "Reporting Agent": [role_ids["Research Lead"]],
+    }
+    key_material: dict[str, tuple[str, str]] = {}
+    evidence: dict[str, Any] = {"timestamp": datetime.now(timezone.utc).isoformat(), "projectId": PROJECT_ID}
+    try:
+        for role in required:
+            created = request(
+                "POST",
+                f"/agents/{role_ids[role]}/keys",
+                {
+                    "name": "Pilot Research e2e validation bridge",
+                    "scope": {
+                        "kind": "task_bridge",
+                        "projectId": PROJECT_ID,
+                        "allowedAssigneeAgentIds": scopes[role],
+                    },
+                },
+            )
+            token = created.get("token")
+            if not isinstance(token, str) or not token:
+                raise RuntimeError("Paperclip did not supply one-time validation key material")
+            key_material[role] = (created["id"], token)
+
+        root = request(
+            "POST",
+            f"/companies/{COMPANY_ID}/issues",
+            {
+                "title": "[VALIDATION] Pilot Research sequential handoff",
+                "description": "No-LLM validation artifact. Must complete through Lead → Source → Fact → Report → Lead.",
+                "projectId": PROJECT_ID,
+                "status": "todo",
+                "priority": "low",
+                "assigneeAgentId": role_ids["Research Lead"],
+            },
+        )
+        root_id = root["id"]
+
+        lead_token = key_material["Research Lead"][1]
+        source = run_bridge(
+            lead_token, role_ids["Research Lead"], "create-task",
+            "--title", "[Source] validation evidence",
+            "--parent-id", root_id, "--project-id", PROJECT_ID,
+            "--assignee-agent-id", role_ids["Source Gatherer"],
+            "--description", f"ROOT_ISSUE_ID: {root_id}\nSynthetic evidence: a validation-only claim.",
+        )["issue"]
+        source_id = source["id"]
+        run_bridge(lead_token, role_ids["Research Lead"], "update-status", "--issue", root_id, "--status", "blocked", "--comment", f"Validation dispatched Source {source_id}.")
+
+        source_token = key_material["Source Gatherer"][1]
+        source_read = run_bridge(source_token, role_ids["Source Gatherer"], "get-task", "--issue", source_id)
+        if source_read["issue"]["id"] != source_id:
+            raise RuntimeError("Source bridge did not return its assigned issue")
+        forbidden = run_bridge(
+            source_token, role_ids["Source Gatherer"], "create-task",
+            "--title", "[FORBIDDEN] cross-role assignment", "--project-id", PROJECT_ID,
+            "--assignee-agent-id", role_ids["Reporting Agent"], "--description", "must be denied",
+            expect_ok=False,
+        )
+        if forbidden.get("status") != 403:
+            raise RuntimeError("Scoped Source bridge key was allowed to assign a non-permitted role")
+        run_bridge(source_token, role_ids["Source Gatherer"], "update-status", "--issue", source_id, "--status", "done", "--comment", "Validation source evidence complete.")
+        fact = run_bridge(
+            source_token, role_ids["Source Gatherer"], "create-task",
+            "--title", "[Fact] validation evidence", "--parent-id", source_id, "--project-id", PROJECT_ID,
+            "--assignee-agent-id", role_ids["Fact-Checker"],
+            "--description", f"ROOT_ISSUE_ID: {root_id}\nEVIDENCE PACK: validation-only evidence.",
+        )["issue"]
+        fact_id = fact["id"]
+
+        fact_token = key_material["Fact-Checker"][1]
+        run_bridge(fact_token, role_ids["Fact-Checker"], "get-task", "--issue", fact_id)
+        run_bridge(fact_token, role_ids["Fact-Checker"], "update-status", "--issue", fact_id, "--status", "done", "--comment", "Validation fact-check complete.")
+        report = run_bridge(
+            fact_token, role_ids["Fact-Checker"], "create-task",
+            "--title", "[Report] validation evidence", "--parent-id", fact_id, "--project-id", PROJECT_ID,
+            "--assignee-agent-id", role_ids["Reporting Agent"],
+            "--description", f"ROOT_ISSUE_ID: {root_id}\nVERIFIED BRIEF: validation claim verified.",
+        )["issue"]
+        report_id = report["id"]
+
+        report_token = key_material["Reporting Agent"][1]
+        run_bridge(report_token, role_ids["Reporting Agent"], "get-task", "--issue", report_id)
+        run_bridge(report_token, role_ids["Reporting Agent"], "update-status", "--issue", report_id, "--status", "done", "--comment", "Validation report complete.")
+        close = run_bridge(
+            report_token, role_ids["Reporting Agent"], "create-task",
+            "--title", "[Close] validation evidence", "--parent-id", root_id, "--project-id", PROJECT_ID,
+            "--assignee-agent-id", role_ids["Research Lead"],
+            "--description", f"ROOT_ISSUE_ID: {root_id}\nFINAL REPORT: validation handoff chain completed.",
+        )["issue"]
+        close_id = close["id"]
+
+        close_read = run_bridge(lead_token, role_ids["Research Lead"], "get-task", "--issue", close_id)
+        if "validation handoff chain completed" not in (close_read["issue"].get("description") or ""):
+            raise RuntimeError("Lead could not read final closure report")
+        run_bridge(lead_token, role_ids["Research Lead"], "update-status", "--issue", root_id, "--status", "done", "--comment", "Validation final report received through scoped closure handoff.")
+        run_bridge(lead_token, role_ids["Research Lead"], "update-status", "--issue", close_id, "--status", "done", "--comment", "Validation root closed.")
+
+        final_issues = {issue_id: request("GET", f"/issues/{issue_id}") for issue_id in [root_id, source_id, fact_id, report_id, close_id]}
+        if any(issue.get("status") != "done" for issue in final_issues.values()):
+            raise RuntimeError("Validation chain did not reach done for every stage")
+        expected_parents = {source_id: root_id, fact_id: source_id, report_id: fact_id, close_id: root_id}
+        if any(final_issues[child].get("parentId") != parent for child, parent in expected_parents.items()):
+            raise RuntimeError("Validation chain parent relationships are incorrect")
+        if any(issue.get("projectId") != PROJECT_ID for issue in final_issues.values()):
+            raise RuntimeError("Validation chain escaped its project boundary")
+        evidence.update(
+            {
+                "ok": True,
+                "issues": {"root": root_id, "source": source_id, "fact": fact_id, "report": report_id, "close": close_id},
+                "statuses": {name: issue["status"] for name, issue in zip(["root", "source", "fact", "report", "close"], final_issues.values())},
+                "crossRoleAssignmentDenied": forbidden.get("status"),
+            }
+        )
+        LOG_PATH.write_text(json.dumps(evidence, indent=2) + "\n", encoding="utf-8")
+        print(json.dumps({"ok": True, "allStagesDone": True, "crossRoleAssignmentDenied": forbidden.get("status"), "log": str(LOG_PATH)}, indent=2))
+        return 0
+    finally:
+        for role, (key_id, _token) in key_material.items():
+            try:
+                request("DELETE", f"/agents/{role_ids[role]}/keys/{key_id}")
+            except Exception:
+                pass
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds three enhancements to the Hermes task bridge skill and includes supporting pipeline scripts.

### Changes

**`paperclip-task.mjs` (modified)**
- **New `get-task` command** — fetch a single issue by ID or identifier, returning summary + description + blocked-by issue IDs
- **`--blocked-by-issue-id <uuid[,uuid]>` flag** on `create-task` — records native Paperclip dependencies via comma-separated UUIDs
- **`parseUuidListFlag` helper** — validates comma-separated UUID lists with deduplication
- **Stricter `--resume` validation** — `--resume` is now only valid with `--status todo` and requires `--comment`/`--comment-file`; prevents ambiguous state transitions

**`SKILL.md` (modified)**
- Updated command examples to include `get-task` and `--blocked-by-issue-id`
- Added usage notes on when `get-task` and `--blocked-by-issue-id` are appropriate

**Pipeline scripts (new)**
- `scripts/repair_pilot_pipeline.py` — coordinator for pilot research phase repairs
- `scripts/rotate_pilot_task_bridge_scopes.py` — rotates task bridge scopes
- `scripts/validate_pilot_pipeline_e2e.py` — end-to-end validation of pipeline state transitions
- `doc/operations/pilot-research-pipeline-repair-2026-07-10.md` — operations doc for the pipeline repair

### Testing
- Task bridge syntax validated; `get-task` and `create-task` with `--blocked-by-issue-id` tested against local Paperclip instance
- `--resume` validation confirmed: rejects without `--status todo` and without comment
- E2E validation script run successfully against local instance

### Notes
- All changes are additive — no existing commands or flags removed
- Server code untouched — these are skill/adapter-layer changes only