### PR TITLE
fix(ui): finish timeline and artifact navigation

### DIFF
--- a/ui/src/components/Sidebar.test.tsx
+++ b/ui/src/components/Sidebar.test.tsx
@@ -391,6 +391,10 @@ describe("Sidebar", () => {
     const timelineLink = [...container.querySelectorAll("a")].find((anchor) => anchor.textContent === "Timeline");
     expect(timelineLink?.getAttribute("href")).toBe("/timeline");
 
+    const companyText = companySection?.textContent ?? "";
+    expect(companyText.indexOf("Costs")).toBeLessThan(companyText.indexOf("Timeline"));
+    expect(companyText.indexOf("Timeline")).toBeLessThan(companyText.indexOf("Activity"));
+
     flushSync(() => {
       root.unmount();
     });

--- a/ui/src/components/Sidebar.tsx
+++ b/ui/src/components/Sidebar.tsx
@@ -269,8 +269,8 @@ export function Sidebar() {
 
         <SidebarSection label="Company" collapsible={{ open: companyOpen, onOpenChange: setCompanyOpen }}>
           <SidebarNavItem to="/org" label="Org" icon={Network} />
-          <SidebarNavItem to="/timeline" label="Timeline" icon={GanttChartSquare} />
           <SidebarNavItem to="/costs" label="Costs" icon={DollarSign} />
+          <SidebarNavItem to="/timeline" label="Timeline" icon={GanttChartSquare} />
           <SidebarNavItem to="/activity" label="Activity" icon={History} />
           <SidebarNavItem to="/company/settings" label="Settings" icon={Settings} />
         </SidebarSection>

--- a/ui/src/pages/Artifacts.test.tsx
+++ b/ui/src/pages/Artifacts.test.tsx
@@ -177,6 +177,8 @@ describe("Artifacts page", () => {
     const { root } = renderArtifacts(container);
 
     await waitForAssertion(() => {
+      expect(container.querySelector("h1")?.textContent).toBe("Artifacts");
+      expect(container.textContent).toContain("grouped into task stacks by default");
       expect(artifactsApiMock.list).toHaveBeenCalledWith("company-1", {
         kind: "all",
         q: undefined,

--- a/ui/src/pages/Artifacts.tsx
+++ b/ui/src/pages/Artifacts.tsx
@@ -247,6 +247,13 @@ export function Artifacts() {
 
   return (
     <div className="w-full max-w-6xl space-y-5">
+      <div>
+        <h1 className="text-3xl font-semibold tracking-tight">Artifacts</h1>
+        <p className="mt-2 max-w-2xl text-sm leading-6 text-muted-foreground">
+          Browse company outputs, grouped into task stacks by default.
+        </p>
+      </div>
+
       <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <div className="relative w-full sm:max-w-sm">
           <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source control plane people use to manage AI agents at work
> - The company sidebar and output pages are the board's primary way to inspect spend, work history, and deliverables
> - Timeline already exists on current master, but its navigation order places it before the consolidated costs surface
> - Artifacts already defaults to task-grouped stacks, but the page lacks the same visible heading and context as adjacent company views
> - Checkbox confirmations and their Decisions attention projection are already implemented and match the published API contract
> - This pull request finishes the remaining navigation and page-header integration without duplicating those existing systems
> - The benefit is a more coherent Company navigation sequence and an immediately understandable stacked Artifacts surface

## Linked Issues or Issue Description

No public GitHub issue exists for this focused UI integration fix.

- Problem: Timeline is ordered ahead of the costs/usage surface, and Artifacts opens directly into controls without a page title or explanation of its default stacked grouping.
- Expected behavior: Costs precedes Timeline in Company navigation, and Artifacts clearly identifies the page and its task-stack default.
- Reproduction: Open current master at commit `0f9b1d399`, inspect the Company sidebar order, then open `/artifacts`.
- Deployment mode: standard Paperclip board UI in local or authenticated mode.

## What Changed

- Moved Timeline immediately below Costs in the Company sidebar.
- Added an Artifacts page heading and concise description of the default task-stack view.
- Extended focused sidebar and Artifacts tests to lock in the order and header.
- Verified that the existing Timeline route/page, grouped artifact stack implementation, checkbox-confirmation interaction flow, and Decisions attention projection are already present on current master.

## Verification

- `./node_modules/.bin/vitest run ui/src/components/Sidebar.test.tsx ui/src/pages/Artifacts.test.tsx ui/src/pages/Timeline.test.tsx ui/src/components/IssueThreadInteractionCard.test.tsx` — 60 tests passed.
- `./node_modules/.bin/tsx scripts/check-token-gates.mjs` — all three UI token gates clean.
- `git diff --check` — clean.
- UI typecheck was attempted but the locally regenerated dependency tree contains both Lexical 0.35 and 0.46, producing pre-existing `MarkdownEditor.tsx` constructor incompatibilities unrelated to these four changed files.
- The broader `src/lib/attention.test.ts` suite was also sampled: 38/39 passed; its one failure is a pre-existing timezone-sensitive UTC date-bucket assertion under Asia/Kuala_Lumpur.

## Risks

- Low risk. The behavior change is limited to sidebar order and static page copy; no API, schema, routing, or confirmation semantics changed.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex, GPT-5 coding agent. Exact model snapshot and context-window size are not exposed. Used repository inspection, shell execution, web documentation lookup, patch editing, and focused test execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes: #` / `Refs: #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run focused tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] No documentation update is required for this presentation-only integration fix
- [x] I have considered and documented risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
