### PR TITLE
Add remote Paperclip MCP bridge

### DIFF
--- a/docs/api/remote-mcp.md
+++ b/docs/api/remote-mcp.md
@@ -1,0 +1,90 @@
+---
+title: Remote MCP
+---
+
+Paperclip exposes a Streamable HTTP MCP endpoint at `/mcp` for Claude Code, Claude Desktop, Claude web custom connectors, and other MCP clients that support remote HTTP transports.
+
+## Endpoint
+
+Use the public HTTPS base URL for your Paperclip deployment:
+
+```bash
+claude mcp add --transport http paperclip-ceo https://<host>/mcp
+```
+
+Claude web, Cowork, and Desktop custom connectors use the same connector URL:
+
+```text
+https://<host>/mcp
+```
+
+The server also accepts `POST /api/mcp` for deployments that route MCP traffic under the API prefix. Non-POST requests return `405` with `Allow: POST`.
+
+## Authentication
+
+Send a Paperclip bearer token with every MCP request:
+
+```http
+Authorization: Bearer <paperclip-api-token>
+```
+
+The bearer token is validated by the normal Paperclip API authentication middleware. Token revocation and rotation use the same process as existing Paperclip API keys. The MCP bridge does not mint or store connector-specific secrets.
+
+## Principal Mapping
+
+The authenticated API actor is the MCP principal. The bridge does not impersonate arbitrary agents. It derives company, agent, and run/audit context from the authenticated actor, then from explicit headers, then from deployment environment defaults.
+
+Optional headers:
+
+- `X-Paperclip-Company-Id`: company scope when the actor can access more than one company.
+- `X-Paperclip-Agent-Id`: agent scope for delegated agent operations.
+- `X-Paperclip-Run-Id`: audit run id attached to writes.
+- `X-Paperclip-Mcp-Scopes`: comma or space separated MCP scopes.
+
+## Write Scope
+
+Read tools are available with a valid bearer token. Write tools are listed only when the request includes `paperclip:write` scope through `X-Paperclip-Mcp-Scopes` or `PAPERCLIP_MCP_SCOPES`.
+
+Supported write scope values:
+
+- `paperclip:write`
+- `write`
+- `*`
+
+Write tool descriptions start with a visible warning and mutating API calls include `X-Paperclip-Run-Id` when run context is available. A direct write request without write scope is rejected before it reaches the Paperclip API.
+
+## Verification
+
+Unauthenticated request:
+
+```bash
+curl -i -X POST https://<host>/mcp \
+  -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}'
+```
+
+Expected result: `401`.
+
+Read-only connector:
+
+```bash
+curl -i -X POST https://<host>/mcp \
+  -H 'Authorization: Bearer <paperclip-api-token>' \
+  -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}'
+```
+
+Expected result: read tools such as `paperclipListIssues` and `paperclipGetIssue` are present; write tools such as `paperclipAddComment` are absent.
+
+Write-scoped connector:
+
+```bash
+curl -i -X POST https://<host>/mcp \
+  -H 'Authorization: Bearer <paperclip-api-token>' \
+  -H 'X-Paperclip-Mcp-Scopes: paperclip:write' \
+  -H 'X-Paperclip-Run-Id: <audit-run-id>' \
+  -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}'
+```
+
+Expected result: guarded write tools are present and visibly marked as write actions.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -118,6 +118,7 @@
             "pages": [
               "api/overview",
               "api/authentication",
+              "api/remote-mcp",
               "api/companies",
               "api/agents",
               "api/issues",

--- a/packages/mcp-server/src/client.ts
+++ b/packages/mcp-server/src/client.ts
@@ -31,6 +31,10 @@ function isWriteMethod(method: string): boolean {
   return !["GET", "HEAD"].includes(method.toUpperCase());
 }
 
+function hasWriteScope(scopes: string[]): boolean {
+  return scopes.includes("paperclip:write") || scopes.includes("write") || scopes.includes("*");
+}
+
 function buildErrorMessage(method: string, path: string, status: number, body: unknown): string {
   if (body && typeof body === "object" && "error" in body && typeof body.error === "string") {
     return `${method} ${path} failed with ${status}: ${body.error}`;
@@ -59,6 +63,10 @@ export class PaperclipApiClient {
     };
   }
 
+  hasWriteScope(): boolean {
+    return hasWriteScope(this.config.scopes);
+  }
+
   resolveCompanyId(companyId?: string | null): string {
     const resolved = companyId?.trim() || this.config.companyId;
     if (!resolved) {
@@ -78,6 +86,9 @@ export class PaperclipApiClient {
   async requestJson<T>(method: string, path: string, options: JsonRequestOptions = {}): Promise<T> {
     if (!path.startsWith("/")) {
       throw new Error(`API path must start with "/": ${path}`);
+    }
+    if (isWriteMethod(method) && !hasWriteScope(this.config.scopes)) {
+      throw new Error("Paperclip MCP write tools require paperclip:write scope");
     }
 
     const url = new URL(path.slice(1), `${this.config.apiUrl}/`);

--- a/packages/mcp-server/src/config.ts
+++ b/packages/mcp-server/src/config.ts
@@ -4,6 +4,7 @@ export interface PaperclipMcpConfig {
   companyId: string | null;
   agentId: string | null;
   runId: string | null;
+  scopes: string[];
 }
 
 function nonEmpty(value: string | undefined): string | null {
@@ -12,6 +13,14 @@ function nonEmpty(value: string | undefined): string | null {
 
 function stripTrailingSlash(value: string): string {
   return value.replace(/\/+$/, "");
+}
+
+function parseScopes(value: string | undefined): string[] {
+  if (!value) return [];
+  return value
+    .split(/[,\s]+/)
+    .map((scope) => scope.trim())
+    .filter(Boolean);
 }
 
 export function normalizeApiUrl(apiUrl: string): string {
@@ -35,5 +44,6 @@ export function readConfigFromEnv(env: NodeJS.ProcessEnv = process.env): Papercl
     companyId: nonEmpty(env.PAPERCLIP_COMPANY_ID),
     agentId: nonEmpty(env.PAPERCLIP_AGENT_ID),
     runId: nonEmpty(env.PAPERCLIP_RUN_ID),
+    scopes: parseScopes(env.PAPERCLIP_MCP_SCOPES),
   };
 }

--- a/packages/mcp-server/src/http.ts
+++ b/packages/mcp-server/src/http.ts
@@ -1,0 +1,28 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import { createPaperclipMcpServer } from "./index.js";
+import type { PaperclipMcpConfig } from "./config.js";
+
+export interface PaperclipStreamableHttpOptions {
+  body?: unknown;
+}
+
+export async function handlePaperclipStreamableHttpRequest(
+  config: PaperclipMcpConfig,
+  req: IncomingMessage,
+  res: ServerResponse,
+  options: PaperclipStreamableHttpOptions = {},
+) {
+  const { server } = createPaperclipMcpServer(config);
+  const transport = new StreamableHTTPServerTransport({
+    sessionIdGenerator: undefined,
+    enableJsonResponse: true,
+  });
+
+  try {
+    await server.connect(transport);
+    await transport.handleRequest(req, res, options.body);
+  } finally {
+    await server.close();
+  }
+}

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -4,6 +4,9 @@ import { PaperclipApiClient } from "./client.js";
 import { readConfigFromEnv, type PaperclipMcpConfig } from "./config.js";
 import { createToolDefinitions } from "./tools.js";
 
+export { normalizeApiUrl, readConfigFromEnv, type PaperclipMcpConfig } from "./config.js";
+export { handlePaperclipStreamableHttpRequest } from "./http.js";
+
 export function createPaperclipMcpServer(config: PaperclipMcpConfig = readConfigFromEnv()) {
   const server = new McpServer({
     name: "paperclip",

--- a/packages/mcp-server/src/tools.test.ts
+++ b/packages/mcp-server/src/tools.test.ts
@@ -2,18 +2,19 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { PaperclipApiClient } from "./client.js";
 import { createToolDefinitions } from "./tools.js";
 
-function makeClient() {
+function makeClient(scopes: string[] = ["paperclip:write"]) {
   return new PaperclipApiClient({
     apiUrl: "http://localhost:3100/api",
     apiKey: "token-123",
     companyId: "11111111-1111-1111-1111-111111111111",
     agentId: "22222222-2222-2222-2222-222222222222",
     runId: "33333333-3333-3333-3333-333333333333",
+    scopes,
   });
 }
 
-function getTool(name: string) {
-  const tool = createToolDefinitions(makeClient()).find((candidate) => candidate.name === name);
+function getTool(name: string, scopes?: string[]) {
+  const tool = createToolDefinitions(makeClient(scopes)).find((candidate) => candidate.name === name);
   if (!tool) throw new Error(`Missing tool ${name}`);
   return tool;
 }
@@ -28,6 +29,31 @@ function mockJsonResponse(body: unknown, status = 200) {
 describe("paperclip MCP tools", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
+  });
+
+
+  it("hides write tools without write scope", () => {
+    const toolNames = createToolDefinitions(makeClient([])).map((tool) => tool.name);
+
+    expect(toolNames).toContain("paperclipListIssues");
+    expect(toolNames).not.toContain("paperclipAddComment");
+    expect(toolNames).not.toContain("paperclipUpdateIssue");
+  });
+
+  it("labels write tools when write scope is present", () => {
+    const tool = getTool("paperclipAddComment");
+
+    expect(tool.description).toContain("WRITE ACTION");
+    expect(tool.description).toContain("paperclip:write");
+  });
+
+  it("rejects direct write requests without write scope", async () => {
+    vi.stubGlobal("fetch", vi.fn());
+    const client = makeClient([]);
+
+    await expect(client.requestJson("POST", "/issues/PAP-1135/comments", {
+      body: { body: "test" },
+    })).rejects.toThrow("paperclip:write scope");
   });
 
   it("adds auth headers and run id to mutating requests", async () => {
@@ -108,6 +134,7 @@ describe("paperclip MCP tools", () => {
       title: "Assigned follow-up",
       workMode: "standard",
       priority: "medium",
+      allowDuplicate: false,
       assigneeAgentId: "22222222-2222-2222-2222-222222222222",
       requestDepth: 0,
     });

--- a/packages/mcp-server/src/tools.ts
+++ b/packages/mcp-server/src/tools.ts
@@ -23,6 +23,7 @@ export interface ToolDefinition {
   execute: (input: Record<string, unknown>) => Promise<{
     content: Array<{ type: "text"; text: string }>;
   }>;
+  write: boolean;
 }
 
 function makeTool<TSchema extends z.ZodRawShape>(
@@ -30,11 +31,14 @@ function makeTool<TSchema extends z.ZodRawShape>(
   description: string,
   schema: z.ZodObject<TSchema>,
   execute: (input: z.infer<typeof schema>) => Promise<unknown>,
+  options: { write?: boolean } = {},
 ): ToolDefinition {
+  const write = options.write ?? false;
   return {
     name,
-    description,
+    description: write ? `[WRITE ACTION: requires paperclip:write scope and sends audit/run headers when available] ${description}` : description,
     schema,
+    write,
     execute: async (input) => {
       try {
         const parsed = schema.parse(input);
@@ -235,7 +239,7 @@ async function getIssueWorkspaceRuntime(client: PaperclipApiClient, issueId: str
 }
 
 export function createToolDefinitions(client: PaperclipApiClient): ToolDefinition[] {
-  return [
+  const tools = [
     makeTool(
       "paperclipMe",
       "Get the current authenticated Paperclip actor details",
@@ -379,6 +383,7 @@ export function createToolDefinitions(client: PaperclipApiClient): ToolDefinitio
           { body: target },
         );
       },
+      { write: true }
     ),
     makeTool(
       "paperclipWaitForIssueWorkspaceService",
@@ -435,6 +440,7 @@ export function createToolDefinitions(client: PaperclipApiClient): ToolDefinitio
         client.requestJson("POST", `/companies/${client.resolveCompanyId(companyId)}/approvals`, {
           body,
         }),
+      { write: true }
     ),
     makeTool(
       "paperclipGetApproval",
@@ -460,6 +466,7 @@ export function createToolDefinitions(client: PaperclipApiClient): ToolDefinitio
       createIssueToolSchema,
       async ({ companyId, ...body }) =>
         client.requestJson("POST", `/companies/${client.resolveCompanyId(companyId)}/issues`, { body }),
+      { write: true }
     ),
     makeTool(
       "paperclipUpdateIssue",
@@ -467,6 +474,7 @@ export function createToolDefinitions(client: PaperclipApiClient): ToolDefinitio
       updateIssueToolSchema,
       async ({ issueId, ...body }) =>
         client.requestJson("PATCH", `/issues/${encodeURIComponent(issueId)}`, { body }),
+      { write: true }
     ),
     makeTool(
       "paperclipCheckoutIssue",
@@ -479,12 +487,14 @@ export function createToolDefinitions(client: PaperclipApiClient): ToolDefinitio
             expectedStatuses: expectedStatuses ?? ["todo", "backlog", "blocked"],
           },
         }),
+      { write: true }
     ),
     makeTool(
       "paperclipReleaseIssue",
       "Release an issue checkout",
       z.object({ issueId: issueIdSchema }),
       async ({ issueId }) => client.requestJson("POST", `/issues/${encodeURIComponent(issueId)}/release`, { body: {} }),
+      { write: true }
     ),
     makeTool(
       "paperclipAddComment",
@@ -492,6 +502,7 @@ export function createToolDefinitions(client: PaperclipApiClient): ToolDefinitio
       addCommentToolSchema,
       async ({ issueId, ...body }) =>
         client.requestJson("POST", `/issues/${encodeURIComponent(issueId)}/comments`, { body }),
+      { write: true }
     ),
     makeTool(
       "paperclipSuggestTasks",
@@ -504,6 +515,7 @@ export function createToolDefinitions(client: PaperclipApiClient): ToolDefinitio
             ...body,
           },
         }),
+      { write: true }
     ),
     makeTool(
       "paperclipAskUserQuestions",
@@ -516,6 +528,7 @@ export function createToolDefinitions(client: PaperclipApiClient): ToolDefinitio
             ...body,
           },
         }),
+      { write: true }
     ),
     makeTool(
       "paperclipRequestConfirmation",
@@ -528,6 +541,7 @@ export function createToolDefinitions(client: PaperclipApiClient): ToolDefinitio
             ...body,
           },
         }),
+      { write: true }
     ),
     makeTool(
       "paperclipRequestCheckboxConfirmation",
@@ -540,6 +554,7 @@ export function createToolDefinitions(client: PaperclipApiClient): ToolDefinitio
             ...body,
           },
         }),
+      { write: true }
     ),
     makeTool(
       "paperclipUpsertIssueDocument",
@@ -551,6 +566,7 @@ export function createToolDefinitions(client: PaperclipApiClient): ToolDefinitio
           `/issues/${encodeURIComponent(issueId)}/documents/${encodeURIComponent(key)}`,
           { body },
         ),
+      { write: true }
     ),
     makeTool(
       "paperclipRestoreIssueDocumentRevision",
@@ -566,6 +582,7 @@ export function createToolDefinitions(client: PaperclipApiClient): ToolDefinitio
           `/issues/${encodeURIComponent(issueId)}/documents/${encodeURIComponent(key)}/revisions/${encodeURIComponent(revisionId)}/restore`,
           { body: {} },
         ),
+      { write: true }
     ),
     makeTool(
       "paperclipLinkIssueApproval",
@@ -575,6 +592,7 @@ export function createToolDefinitions(client: PaperclipApiClient): ToolDefinitio
         client.requestJson("POST", `/issues/${encodeURIComponent(issueId)}/approvals`, {
           body: { approvalId },
         }),
+      { write: true }
     ),
     makeTool(
       "paperclipUnlinkIssueApproval",
@@ -585,6 +603,7 @@ export function createToolDefinitions(client: PaperclipApiClient): ToolDefinitio
           "DELETE",
           `/issues/${encodeURIComponent(issueId)}/approvals/${encodeURIComponent(approvalId)}`,
         ),
+      { write: true }
     ),
     makeTool(
       "paperclipApprovalDecision",
@@ -607,6 +626,7 @@ export function createToolDefinitions(client: PaperclipApiClient): ToolDefinitio
 
         return client.requestJson("POST", path, { body });
       },
+      { write: true }
     ),
     makeTool(
       "paperclipAddApprovalComment",
@@ -616,6 +636,7 @@ export function createToolDefinitions(client: PaperclipApiClient): ToolDefinitio
         client.requestJson("POST", `/approvals/${encodeURIComponent(approvalId)}/comments`, {
           body: { body },
         }),
+      { write: true }
     ),
     makeTool(
       "paperclipApiRequest",
@@ -629,6 +650,9 @@ export function createToolDefinitions(client: PaperclipApiClient): ToolDefinitio
           body: parseOptionalJson(jsonBody),
         });
       },
+      { write: true },
     ),
   ];
+
+  return tools.filter((tool) => !tool.write || client.hasWriteScope());
 }

--- a/server/package.json
+++ b/server/package.json
@@ -56,6 +56,7 @@
     "@paperclipai/adapter-pi-local": "workspace:*",
     "@paperclipai/adapter-utils": "workspace:*",
     "@paperclipai/db": "workspace:*",
+    "@paperclipai/mcp-server": "workspace:*",
     "@paperclipai/plugin-sdk": "workspace:*",
     "@paperclipai/shared": "workspace:*",
     "@paperclipai/skills-catalog": "workspace:*",

--- a/server/src/__tests__/mcp-routes.test.ts
+++ b/server/src/__tests__/mcp-routes.test.ts
@@ -1,0 +1,129 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { errorHandler } from "../middleware/index.js";
+
+const mcpHandler = vi.hoisted(() => vi.fn());
+
+vi.mock("@paperclipai/mcp-server", async () => {
+  return {
+    normalizeApiUrl(value: string) {
+      const trimmed = value.replace(/\/+$/, "");
+      return trimmed.endsWith("/api") ? trimmed : `${trimmed}/api`;
+    },
+    handlePaperclipStreamableHttpRequest: mcpHandler,
+  };
+});
+
+async function createApp(actor: Express.Request["actor"]) {
+  const { mcpRoutes } = await import("../routes/mcp.js");
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    req.actor = actor;
+    next();
+  });
+  app.use(mcpRoutes());
+  app.use(errorHandler);
+  return app;
+}
+
+describe("mcp routes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env.PAPERCLIP_API_URL;
+    delete process.env.PAPERCLIP_MCP_API_URL;
+    delete process.env.PAPERCLIP_AGENT_ID;
+    delete process.env.PAPERCLIP_MCP_AGENT_ID;
+    delete process.env.PAPERCLIP_COMPANY_ID;
+    delete process.env.PAPERCLIP_RUN_ID;
+    delete process.env.PAPERCLIP_MCP_SCOPES;
+    mcpHandler.mockImplementation(async (_config, _req, res) => {
+      res.status(200).json({ ok: true });
+    });
+  });
+
+  it("rejects unauthenticated MCP requests", async () => {
+    const app = await createApp({ type: "none", source: "none" });
+
+    const res = await request(app)
+      .post("/mcp")
+      .send({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} });
+
+    expect(res.status).toBe(401);
+    expect(mcpHandler).not.toHaveBeenCalled();
+  });
+
+  it("derives MCP config from authenticated agent requests", async () => {
+    const app = await createApp({
+      type: "agent",
+      agentId: "agent-1",
+      companyId: "company-1",
+      runId: "run-1",
+      source: "agent_key",
+    });
+
+    const res = await request(app)
+      .post("/mcp")
+      .set("Authorization", "Bearer token-1")
+      .set("Host", "paperclip.example")
+      .send({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} });
+
+    expect(res.status).toBe(200);
+    expect(mcpHandler).toHaveBeenCalledTimes(1);
+    expect(mcpHandler.mock.calls[0]?.[0]).toEqual({
+      apiUrl: "http://paperclip.example/api",
+      apiKey: "token-1",
+      companyId: "company-1",
+      agentId: "agent-1",
+      runId: "run-1",
+      scopes: [],
+    });
+  });
+
+  it("lets board API keys scope company and agent by headers", async () => {
+    process.env.PAPERCLIP_MCP_API_URL = "https://paperclip.ing";
+    const app = await createApp({
+      type: "board",
+      userId: "ceo-1",
+      companyIds: ["company-a", "company-b"],
+      isInstanceAdmin: true,
+      source: "board_key",
+    });
+
+    const res = await request(app)
+      .post("/api/mcp")
+      .set("Authorization", "Bearer board-token")
+      .set("X-Paperclip-Company-Id", "company-b")
+      .set("X-Paperclip-Agent-Id", "agent-ceo")
+      .set("X-Paperclip-Run-Id", "run-ceo")
+      .set("X-Paperclip-Mcp-Scopes", "paperclip:write")
+      .send({ jsonrpc: "2.0", id: 1, method: "tools/list", params: {} });
+
+    expect(res.status).toBe(200);
+    expect(mcpHandler.mock.calls[0]?.[0]).toEqual({
+      apiUrl: "https://paperclip.ing/api",
+      apiKey: "board-token",
+      companyId: "company-b",
+      agentId: "agent-ceo",
+      runId: "run-ceo",
+      scopes: ["paperclip:write"],
+    });
+  });
+
+  it("returns method guidance for non-POST MCP requests", async () => {
+    const app = await createApp({
+      type: "agent",
+      agentId: "agent-1",
+      companyId: "company-1",
+      source: "agent_key",
+    });
+
+    const res = await request(app)
+      .get("/mcp")
+      .set("Authorization", "Bearer token-1");
+
+    expect(res.status).toBe(405);
+    expect(res.headers.allow).toBe("POST");
+  });
+});

--- a/server/src/__tests__/openapi-routes.test.ts
+++ b/server/src/__tests__/openapi-routes.test.ts
@@ -72,6 +72,8 @@ const explicitOpenApiCoverageExclusions = new Set([
   "cases.ts",
   // Smoke lab routes are experimental and not yet represented in the public OpenAPI document.
   "smoke-lab.ts",
+  // Remote MCP routes use the Streamable HTTP protocol and are documented outside the REST OpenAPI surface.
+  "mcp.ts",
 ]);
 
 function createApp() {

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -72,6 +72,7 @@ import { accessRoutes } from "./routes/access.js";
 import { pluginRoutes } from "./routes/plugins.js";
 import { mcpGatewayProtocolRoutes, toolGatewayRoutes } from "./routes/tool-gateway.js";
 import { adapterRoutes } from "./routes/adapters.js";
+import { mcpRoutes } from "./routes/mcp.js";
 import { pluginUiStaticRoutes } from "./routes/plugin-ui-static.js";
 import { readBrandedStaticIndexHtml } from "./static-index-html.js";
 import { applyUiBranding } from "./ui-branding.js";
@@ -330,6 +331,7 @@ export async function createApp(
     app.all("/api/auth/{*authPath}", opts.betterAuthHandler);
   }
   app.use(llmRoutes(db));
+  app.use(mcpRoutes());
 
   const hostServicesDisposers = new Map<string, () => void>();
   const workerManager = opts.pluginWorkerManager ?? createPluginWorkerManager();

--- a/server/src/routes/mcp.ts
+++ b/server/src/routes/mcp.ts
@@ -1,0 +1,92 @@
+import { Router, type Request, type Response } from "express";
+import {
+  handlePaperclipStreamableHttpRequest,
+  normalizeApiUrl,
+  type PaperclipMcpConfig,
+} from "@paperclipai/mcp-server";
+
+function bearerToken(req: Request): string | null {
+  const header = req.header("authorization");
+  if (!header?.toLowerCase().startsWith("bearer ")) return null;
+  const token = header.slice("bearer ".length).trim();
+  return token.length > 0 ? token : null;
+}
+
+function headerValue(req: Request, name: string): string | null {
+  const value = req.header(name)?.trim();
+  return value ? value : null;
+}
+
+function requestOrigin(req: Request): string {
+  const forwardedProto = headerValue(req, "x-forwarded-proto");
+  const proto = forwardedProto?.split(",")[0]?.trim() || req.protocol;
+  return `${proto}://${req.get("host")}`;
+}
+
+function parseScopes(value: string | null | undefined): string[] {
+  if (!value) return [];
+  return value
+    .split(/[,\s]+/)
+    .map((scope) => scope.trim())
+    .filter(Boolean);
+}
+
+export function resolvePaperclipMcpConfigFromRequest(req: Request): PaperclipMcpConfig | null {
+  const apiKey = bearerToken(req);
+  if (!apiKey || req.actor.type === "none") return null;
+
+  const actorCompanyIds = req.actor.type === "board" ? req.actor.companyIds ?? [] : [];
+  const companyId =
+    headerValue(req, "x-paperclip-company-id") ??
+    req.actor.companyId ??
+    (actorCompanyIds.length === 1 ? actorCompanyIds[0] ?? null : null) ??
+    process.env.PAPERCLIP_COMPANY_ID ??
+    null;
+  const agentId =
+    headerValue(req, "x-paperclip-agent-id") ??
+    req.actor.agentId ??
+    process.env.PAPERCLIP_MCP_AGENT_ID ??
+    process.env.PAPERCLIP_AGENT_ID ??
+    null;
+  const runId =
+    headerValue(req, "x-paperclip-run-id") ??
+    req.actor.runId ??
+    process.env.PAPERCLIP_RUN_ID ??
+    null;
+  const apiUrl = normalizeApiUrl(
+    process.env.PAPERCLIP_MCP_API_URL ?? process.env.PAPERCLIP_API_URL ?? requestOrigin(req),
+  );
+  const scopes = parseScopes(
+    headerValue(req, "x-paperclip-mcp-scopes") ?? process.env.PAPERCLIP_MCP_SCOPES,
+  );
+
+  return {
+    apiUrl,
+    apiKey,
+    companyId,
+    agentId,
+    runId,
+    scopes,
+  };
+}
+
+async function handleMcp(req: Request, res: Response) {
+  const config = resolvePaperclipMcpConfigFromRequest(req);
+  if (!config) {
+    res.status(401).json({ error: "Paperclip MCP requires authenticated bearer access" });
+    return;
+  }
+
+  await handlePaperclipStreamableHttpRequest(config, req, res, { body: req.body });
+}
+
+export function mcpRoutes() {
+  const router = Router();
+  router.post("/mcp", handleMcp);
+  router.post("/api/mcp", handleMcp);
+  router.all(["/mcp", "/api/mcp"], (_req, res) => {
+    res.setHeader("Allow", "POST");
+    res.status(405).json({ error: "Paperclip MCP uses Streamable HTTP POST" });
+  });
+  return router;
+}


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Claude remote connectors need a public HTTPS MCP endpoint.
> - Paperclip already has a local MCP package and normal API authentication.
> - Browser and coworker clients cannot use local stdio MCP configuration.
> - This pull request adds a Streamable HTTP MCP bridge at `/mcp`.
> - The bridge reuses Paperclip bearer authentication and normal API principal mapping.
> - The benefit is that Claude clients can list and use Paperclip tools through a narrow remote connector.

## Linked Issues or Issue Description

**Subsystem affected**

server/ — REST API & orchestration services. The change also touches the MCP package and API documentation.

**Problem or motivation**

Claude clients that run outside the local Paperclip host need a public HTTPS MCP connector. Local stdio MCP setup does not cover Claude web, coworker flows, or remote HTTP clients.

**Proposed solution**

Expose a Streamable HTTP MCP endpoint at `/mcp`. Reuse Paperclip bearer authentication. Show read tools by default. Show and execute write tools only when the connector has explicit `paperclip:write` scope.

**Alternatives considered**

Local Desktop stdio MCP configuration was not enough because web and coworker clients cannot use a local process. OAuth would be stronger, but bearer-token auth is the temporary validation path for this connector.

**Roadmap alignment**

This is a server integration surface for controlled agent operations. It does not duplicate an existing roadmap item in `ROADMAP.md`.

## What Changed

- Added `POST /mcp` and `POST /api/mcp` Streamable HTTP MCP routes.
- Added HTTP transport handling in `@paperclipai/mcp-server`.
- Added MCP config derivation from bearer auth, actor context, optional scope headers, and env defaults.
- Added read-only default tool listing and `paperclip:write` gating for write tools.
- Added visible write-action warnings to write tool descriptions.
- Added docs for Claude connector setup, token handling, write scope, and verification.

## Verification

- `pnpm --filter @paperclipai/mcp-server exec vitest run src/tools.test.ts` passed: 16 tests.
- `/home/paperclip/.paperclip/instances/default/workspaces/cf6af118-3398-4fa2-938a-2071987af17d/paperclip-control-plane/node_modules/.bin/vitest run server/src/__tests__/mcp-routes.test.ts` passed: 4 tests.
- `pnpm --filter @paperclipai/mcp-server typecheck` passed.
- `PATH=/home/paperclip/.paperclip/instances/default/workspaces/cf6af118-3398-4fa2-938a-2071987af17d/paperclip-control-plane/node_modules/.bin:$PATH pnpm --filter @paperclipai/server typecheck` passed.
- `git diff --check` passed.
- `bash scripts/pre-pr.sh` could not run because this repository revision has no `scripts/pre-pr.sh` file.

## Risks

- Low runtime risk for normal API routes because `/mcp` is mounted as an isolated POST route.
- Remote MCP write tools depend on Paperclip bearer token permissions plus explicit MCP write scope.
- OAuth is not implemented in this change. Bearer-token auth remains the temporary validation path.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

OpenAI GPT-5 Codex coding agent with tool use and repository command execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [ ] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
