### PR TITLE
fix(mcp): pin shared package for desktop bridge

### DIFF
--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paperclipai/mcp-server",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "license": "MIT",
   "homepage": "https://github.com/paperclipai/paperclip",
   "bugs": {
@@ -44,7 +44,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "@paperclipai/shared": "workspace:*",
+    "@paperclipai/shared": "workspace:^",
     "zod": "^3.24.2"
   },
   "devDependencies": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paperclipai/shared",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "license": "MIT",
   "homepage": "https://github.com/paperclipai/paperclip",
   "bugs": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -364,7 +364,7 @@ importers:
         specifier: ^1.29.0
         version: 1.29.0(zod@3.25.76)
       '@paperclipai/shared':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../shared
       zod:
         specifier: ^3.24.2


### PR DESCRIPTION
Closes THE-1317\n\nFixes the Desktop/npx MCP bridge package path by ensuring @paperclipai/mcp-server resolves a shared package version that exports the issue-thread interaction schemas it imports.\n\nVerification:\n- pnpm --filter @paperclipai/shared build\n- pnpm --filter @paperclipai/mcp-server test (13/13)\n- pnpm --filter @paperclipai/mcp-server build\n- Packed @paperclipai/shared@0.3.2 and @paperclipai/mcp-server@0.1.1 into a clean temp install\n- Stdio MCP client connected to the packed bin, listed 41 tools, read THE-1317, listed comments, and rejected /../secrets path\n\nNote: scripts/pre-pr.sh is not present in this repository checkout; used focused package verification instead.