### PR TITLE
feat(ui): add selection debug instrumentation

### DIFF
--- a/ui/src/components/DocumentAnnotationLayer.tsx
+++ b/ui/src/components/DocumentAnnotationLayer.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useId, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { Profiler, useCallback, useEffect, useId, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { AlertTriangle, MessageSquarePlus } from "lucide-react";
 import type {
   DocumentAnnotationAnchorState,
@@ -11,6 +11,14 @@ import {
   getContainerTextOffset,
   rangesForNormalizedSpan,
 } from "@/lib/document-annotation-selection";
+import {
+  initializeSelectionDebug,
+  isSelectionDebugEnabled,
+  recordAnnotationCommit,
+  recordCaptureSelection,
+  recordMarkdownMutations,
+  recordSelectionChange,
+} from "@/lib/document-annotation-debug";
 import type { DocumentAnnotationAnchorSelector } from "@paperclipai/shared";
 
 export interface AnnotationOverlayThread {
@@ -245,6 +253,8 @@ export function DocumentAnnotationLayer({
     [reactId],
   );
   const nativeHighlightsSupported = getNativeHighlightApi() !== null;
+  const selectionDebugEnabled = isSelectionDebugEnabled();
+  if (selectionDebugEnabled) initializeSelectionDebug();
 
   const visibleThreads = useMemo(() => {
     if (!hideResolved) return threads;
@@ -365,6 +375,12 @@ export function DocumentAnnotationLayer({
 
     const mutationObserver = typeof window.MutationObserver === "function" && container
       ? new window.MutationObserver((mutations) => {
+        if (selectionDebugEnabled) {
+          const markdownMutations = mutations.filter((mutation) =>
+            Boolean(elementFromNode(mutation.target)?.closest(".paperclip-markdown")),
+          );
+          if (markdownMutations.length > 0) recordMarkdownMutations(markdownMutations.length);
+        }
         const onlyLayerMutations = mutations.every((mutation) => {
           const target = elementFromNode(mutation.target);
           return !!target?.closest(".paperclip-doc-annotation-layer, .paperclip-doc-annotation-visual-layer");
@@ -392,7 +408,7 @@ export function DocumentAnnotationLayer({
       window.removeEventListener("resize", handleResizeOrScroll);
       window.removeEventListener("scroll", handleResizeOrScroll, true);
     };
-  }, [computeHighlightRects, containerRef]);
+  }, [computeHighlightRects, containerRef, selectionDebugEnabled]);
 
   const captureSelection = useCallback((): PendingAnchor | null => {
     const container = containerRef.current;
@@ -421,7 +437,17 @@ export function DocumentAnnotationLayer({
   useEffect(() => {
     if (typeof document === "undefined") return;
     const handleSelectionChange = () => {
+      const selection = window.getSelection();
+      const range = selection && selection.rangeCount > 0 ? selection.getRangeAt(0) : null;
+      const selectionIsActive = Boolean(
+        selection && !selection.isCollapsed && range && containerRef.current?.contains(range.commonAncestorContainer),
+      );
+      if (selectionDebugEnabled) recordSelectionChange(selectionIsActive);
+      const captureStartedAt = selectionDebugEnabled ? performance.now() : 0;
       const anchor = captureSelection();
+      if (selectionDebugEnabled) {
+        recordCaptureSelection(performance.now() - captureStartedAt, Boolean(anchor));
+      }
       if (!anchor) {
         onPendingAnchorChange(null);
         setToolbarPosition(null);
@@ -431,7 +457,7 @@ export function DocumentAnnotationLayer({
     };
     document.addEventListener("selectionchange", handleSelectionChange);
     return () => document.removeEventListener("selectionchange", handleSelectionChange);
-  }, [captureSelection, onPendingAnchorChange]);
+  }, [captureSelection, containerRef, onPendingAnchorChange, selectionDebugEnabled]);
 
   useEffect(() => {
     if (captureSelectionRequestId === undefined) return;
@@ -449,7 +475,7 @@ export function DocumentAnnotationLayer({
     if (pendingAnchor) onRequestComment(pendingAnchor);
   };
 
-  return (
+  const content = (
     <>
       {!nativeHighlightsSupported ? (
         <div className="paperclip-doc-annotation-visual-layer pointer-events-none absolute inset-0 z-0" aria-hidden="true">
@@ -578,4 +604,10 @@ export function DocumentAnnotationLayer({
       </div>
     </>
   );
+
+  return selectionDebugEnabled ? (
+    <Profiler id="DocumentAnnotationLayer" onRender={recordAnnotationCommit}>
+      {content}
+    </Profiler>
+  ) : content;
 }

--- a/ui/src/components/IssueDocumentAnnotations.tsx
+++ b/ui/src/components/IssueDocumentAnnotations.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
+import { Profiler, useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { useQuery } from "@tanstack/react-query";
 import type { Agent, DocumentAnnotationThreadWithComments, IssueDocument } from "@paperclipai/shared";
 import { MessageSquare } from "lucide-react";
@@ -7,6 +7,11 @@ import { cn } from "@/lib/utils";
 import { documentAnnotationsApi, type DocumentAnnotationTarget } from "@/api/document-annotations";
 import { queryKeys } from "@/lib/queryKeys";
 import { parseDocumentAnnotationHash } from "@/lib/document-annotation-hash";
+import {
+  initializeSelectionDebug,
+  isSelectionDebugEnabled,
+  recordAnnotationCommit,
+} from "@/lib/document-annotation-debug";
 import { DocumentAnnotationLayer, type PendingAnchor } from "./DocumentAnnotationLayer";
 import { DocumentAnnotationPanel } from "./DocumentAnnotationPanel";
 import type { CompanyUserProfile } from "@/lib/company-members";
@@ -67,6 +72,8 @@ export function IssueDocumentAnnotations({
   initialComposerAnchor,
   onInitialComposerAnchorConsumed,
 }: IssueDocumentAnnotationsProps) {
+  const selectionDebugEnabled = isSelectionDebugEnabled();
+  if (selectionDebugEnabled) initializeSelectionDebug();
   const containerRef = useRef<HTMLElement | null>(null);
   const [focusedThreadId, setFocusedThreadId] = useState<string | null>(defaultFocusedThreadId ?? null);
   const [focusedCommentId, setFocusedCommentId] = useState<string | null>(null);
@@ -337,7 +344,7 @@ export function IssueDocumentAnnotations({
     />
   ) : null;
 
-  return (
+  const content = (
     <div className="paperclip-doc-annotation-host relative">
       <section
         ref={(element) => {
@@ -384,6 +391,12 @@ export function IssueDocumentAnnotations({
       {panelOpen && isMobile ? annotationPanel : null}
     </div>
   );
+
+  return selectionDebugEnabled ? (
+    <Profiler id="IssueDocumentAnnotations" onRender={recordAnnotationCommit}>
+      {content}
+    </Profiler>
+  ) : content;
 }
 
 export interface DocumentAnnotationsCountChipProps {

--- a/ui/src/lib/document-annotation-debug.test.ts
+++ b/ui/src/lib/document-annotation-debug.test.ts
@@ -32,13 +32,15 @@ describe("document annotation selection diagnostics", () => {
     const state = initializeSelectionDebug();
 
     recordSelectionChange(true);
+    recordSelectionChange(false);
     recordCaptureSelection(12.5, true);
     recordAnnotationCommit("DocumentAnnotationLayer", "update", 4.25);
+    expect(state.lastSelectionChangeAt).not.toBeNull();
     state.lastSelectionChangeAt = performance.now() - 200;
     recordMarkdownMutations(3);
 
     const snapshot = state.snapshot();
-    expect(snapshot.selectionChanges).toBe(1);
+    expect(snapshot.selectionChanges).toBe(2);
     expect(snapshot.activeSelectionChanges).toBe(1);
     expect(snapshot.captureCount).toBe(1);
     expect(snapshot.captureDurationMs).toBe(12.5);

--- a/ui/src/lib/document-annotation-debug.test.ts
+++ b/ui/src/lib/document-annotation-debug.test.ts
@@ -1,0 +1,50 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  SELECTION_DEBUG_STORAGE_KEY,
+  initializeSelectionDebug,
+  isSelectionDebugEnabled,
+  recordAnnotationCommit,
+  recordCaptureSelection,
+  recordMarkdownMutations,
+  recordSelectionChange,
+} from "./document-annotation-debug";
+
+describe("document annotation selection diagnostics", () => {
+  afterEach(() => {
+    window.localStorage.removeItem(SELECTION_DEBUG_STORAGE_KEY);
+    delete window.__paperclipSelectionDebug;
+    vi.restoreAllMocks();
+  });
+
+  it("stays disabled until the dev localStorage flag is enabled", () => {
+    expect(isSelectionDebugEnabled()).toBe(false);
+
+    window.localStorage.setItem(SELECTION_DEBUG_STORAGE_KEY, "true");
+
+    expect(isSelectionDebugEnabled()).toBe(true);
+  });
+
+  it("records selection cadence, capture cost, commits, and idle markdown mutations", () => {
+    window.localStorage.setItem(SELECTION_DEBUG_STORAGE_KEY, "1");
+    vi.spyOn(console, "debug").mockImplementation(() => {});
+    const state = initializeSelectionDebug();
+
+    recordSelectionChange(true);
+    recordCaptureSelection(12.5, true);
+    recordAnnotationCommit("DocumentAnnotationLayer", "update", 4.25);
+    state.lastSelectionChangeAt = performance.now() - 200;
+    recordMarkdownMutations(3);
+
+    const snapshot = state.snapshot();
+    expect(snapshot.selectionChanges).toBe(1);
+    expect(snapshot.activeSelectionChanges).toBe(1);
+    expect(snapshot.captureCount).toBe(1);
+    expect(snapshot.captureDurationMs).toBe(12.5);
+    expect(snapshot.maxCaptureDurationMs).toBe(12.5);
+    expect(snapshot.reactCommits.DocumentAnnotationLayer).toBe(1);
+    expect(snapshot.idleMutationCallbacks).toBe(1);
+    expect(snapshot.idleMutationRecords).toBe(3);
+  });
+});

--- a/ui/src/lib/document-annotation-debug.ts
+++ b/ui/src/lib/document-annotation-debug.ts
@@ -122,7 +122,7 @@ export function recordSelectionChange(active: boolean): void {
   if (active) {
     state.activeSelectionChanges += 1;
   }
-  state.lastSelectionChangeAt = active ? timestamp : null;
+  state.lastSelectionChangeAt = timestamp;
   record("selectionchange", {
     active,
     elapsedSincePreviousMs: elapsedSincePreviousMs ?? -1,

--- a/ui/src/lib/document-annotation-debug.ts
+++ b/ui/src/lib/document-annotation-debug.ts
@@ -1,0 +1,156 @@
+export const SELECTION_DEBUG_STORAGE_KEY = "paperclipDebugSelection";
+
+type SelectionDebugEvent = {
+  at: number;
+  type: string;
+  details: Record<string, number | string | boolean>;
+};
+
+type SelectionDebugState = {
+  enabledAt: number;
+  selectionChanges: number;
+  activeSelectionChanges: number;
+  captureCount: number;
+  captureDurationMs: number;
+  maxCaptureDurationMs: number;
+  mutationCallbacks: number;
+  mutationRecords: number;
+  idleMutationCallbacks: number;
+  idleMutationRecords: number;
+  reactCommits: Record<string, number>;
+  events: SelectionDebugEvent[];
+  lastSelectionChangeAt: number | null;
+  reset: () => void;
+  snapshot: () => Omit<SelectionDebugState, "reset" | "snapshot">;
+};
+
+declare global {
+  interface Window {
+    __paperclipSelectionDebug?: SelectionDebugState;
+  }
+}
+
+const MAX_DEBUG_EVENTS = 250;
+const IDLE_SELECTION_WINDOW_MS = 150;
+
+function now(): number {
+  return typeof performance !== "undefined" ? performance.now() : Date.now();
+}
+
+function createState(): SelectionDebugState {
+  const state: SelectionDebugState = {
+    enabledAt: now(),
+    selectionChanges: 0,
+    activeSelectionChanges: 0,
+    captureCount: 0,
+    captureDurationMs: 0,
+    maxCaptureDurationMs: 0,
+    mutationCallbacks: 0,
+    mutationRecords: 0,
+    idleMutationCallbacks: 0,
+    idleMutationRecords: 0,
+    reactCommits: {},
+    events: [],
+    lastSelectionChangeAt: null,
+    reset: () => {
+      state.enabledAt = now();
+      state.selectionChanges = 0;
+      state.activeSelectionChanges = 0;
+      state.captureCount = 0;
+      state.captureDurationMs = 0;
+      state.maxCaptureDurationMs = 0;
+      state.mutationCallbacks = 0;
+      state.mutationRecords = 0;
+      state.idleMutationCallbacks = 0;
+      state.idleMutationRecords = 0;
+      state.reactCommits = {};
+      state.events = [];
+      state.lastSelectionChangeAt = null;
+    },
+    snapshot: () => ({
+      enabledAt: state.enabledAt,
+      selectionChanges: state.selectionChanges,
+      activeSelectionChanges: state.activeSelectionChanges,
+      captureCount: state.captureCount,
+      captureDurationMs: state.captureDurationMs,
+      maxCaptureDurationMs: state.maxCaptureDurationMs,
+      mutationCallbacks: state.mutationCallbacks,
+      mutationRecords: state.mutationRecords,
+      idleMutationCallbacks: state.idleMutationCallbacks,
+      idleMutationRecords: state.idleMutationRecords,
+      reactCommits: { ...state.reactCommits },
+      events: [...state.events],
+      lastSelectionChangeAt: state.lastSelectionChangeAt,
+    }),
+  };
+  return state;
+}
+
+export function isSelectionDebugEnabled(): boolean {
+  if (import.meta.env.MODE === "production" || typeof window === "undefined") return false;
+  try {
+    const value = window.localStorage.getItem(SELECTION_DEBUG_STORAGE_KEY);
+    return value === "1" || value === "true";
+  } catch {
+    return false;
+  }
+}
+
+export function initializeSelectionDebug(): SelectionDebugState {
+  if (!window.__paperclipSelectionDebug) {
+    window.__paperclipSelectionDebug = createState();
+    console.info(`[paperclip selection debug] enabled; set localStorage.${SELECTION_DEBUG_STORAGE_KEY} = "0" and reload to disable`);
+  }
+  return window.__paperclipSelectionDebug;
+}
+
+function record(type: string, details: SelectionDebugEvent["details"]): void {
+  const state = initializeSelectionDebug();
+  const event = { at: now(), type, details };
+  state.events.push(event);
+  if (state.events.length > MAX_DEBUG_EVENTS) state.events.shift();
+  console.debug("[paperclip selection debug]", event);
+}
+
+export function recordSelectionChange(active: boolean): void {
+  const state = initializeSelectionDebug();
+  const timestamp = now();
+  const elapsedSincePreviousMs = state.lastSelectionChangeAt === null
+    ? null
+    : timestamp - state.lastSelectionChangeAt;
+  state.selectionChanges += 1;
+  if (active) {
+    state.activeSelectionChanges += 1;
+  }
+  state.lastSelectionChangeAt = active ? timestamp : null;
+  record("selectionchange", {
+    active,
+    elapsedSincePreviousMs: elapsedSincePreviousMs ?? -1,
+  });
+}
+
+export function recordCaptureSelection(durationMs: number, captured: boolean): void {
+  const state = initializeSelectionDebug();
+  state.captureCount += 1;
+  state.captureDurationMs += durationMs;
+  state.maxCaptureDurationMs = Math.max(state.maxCaptureDurationMs, durationMs);
+  record("captureSelection", { durationMs, captured });
+}
+
+export function recordAnnotationCommit(id: string, phase: string, actualDuration: number): void {
+  const state = initializeSelectionDebug();
+  state.reactCommits[id] = (state.reactCommits[id] ?? 0) + 1;
+  record("react-commit", { id, phase, actualDuration });
+}
+
+export function recordMarkdownMutations(recordCount: number): void {
+  const state = initializeSelectionDebug();
+  const idle = state.lastSelectionChangeAt !== null && now() - state.lastSelectionChangeAt >= IDLE_SELECTION_WINDOW_MS;
+  state.mutationCallbacks += 1;
+  state.mutationRecords += recordCount;
+  if (idle) {
+    state.idleMutationCallbacks += 1;
+    state.idleMutationRecords += recordCount;
+  }
+  record("markdown-mutation", { recordCount, idle });
+}


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source control plane people use to manage AI agents and their work
> - Issue documents support inline annotations by translating browser text selections into durable markdown anchors
> - Selection failures are difficult to diagnose because browser events, parsing cost, React commits, and DOM mutations were not observable together
> - The problem is especially sensitive to mobile/WebKit behavior and long or heavily annotated documents
> - A development-only measurement layer is needed before changing selection behavior, so fixes can target a confirmed mechanism rather than a guess
> - This pull request adds opt-in selection instrumentation around the existing annotation flow without changing production behavior
> - The benefit is reproducible evidence for selection stability investigations with bounded, inspectable metrics

## Linked Issues or Issue Description

No public GitHub issue currently tracks this investigation.

### What happened?

Text selection in annotated issue documents can become unstable in some browsers, but the current UI does not expose enough data to distinguish selection-event frequency, markdown capture cost, React subtree commits, or DOM mutation churn.

### Expected behavior

Developers should be able to opt into a diagnostic harness that records those signals while reproducing selection behavior, with no production runtime effect.

### Steps to reproduce

1. Run Paperclip from source in development mode.
2. Open an issue with a markdown document and existing annotations.
3. Select text while observing browser events and DOM changes.
4. Notice there is no consolidated selection instrumentation or snapshot API for comparing browsers and document sizes.

### Paperclip version or commit

current `master`

### Deployment mode

Local dev (`pnpm dev`)

### Installation method

Built from source

### Agent adapters involved

Not adapter-specific (core UI)

### Database mode

Not database-related

### Access context

Board (human operator)

### Node.js version

v22.22.1

### Operating system

Linux 6.8.0-90-generic x86_64

### Relevant logs or config

None; this PR adds the missing diagnostic surface.

### Privacy checklist

No private instance links, identifiers, secrets, logs, or user data are included.

## What Changed

- Adds a development-only `paperclipDebugSelection` local-storage flag and `window.__paperclipSelectionDebug` snapshot/reset API.
- Records active `selectionchange` frequency and `captureSelection()` duration/count metrics.
- Counts React Profiler commits for the annotation layer and issue-document annotation subtree.
- Records markdown MutationObserver callbacks and records, including mutations while a selection is idle.
- Adds focused tests for flag handling, metric aggregation, and snapshot reporting.

## Verification

- `pnpm exec vitest run ui/src/lib/document-annotation-debug.test.ts`
- `pnpm --filter @paperclipai/ui typecheck`
- `pnpm check:token-gates`
- Manual development usage: set `localStorage.paperclipDebugSelection = "1"`, reload, reproduce a selection, then inspect `window.__paperclipSelectionDebug.snapshot()`.

## Risks

- Low production risk: instrumentation is disabled when `import.meta.env.MODE === "production"`.
- In development, enabling the flag adds console output and React Profiler callbacks, which intentionally affect measurements slightly; the harness is opt-in and bounded to 250 retained events.
- The change observes existing selection and mutation behavior but does not alter selection anchoring or annotation persistence.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex using GPT-5.4, medium reasoning mode, with repository tool use and local code execution. Context window size was not surfaced by the runtime.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

