### PR TITLE
test(ui): guard issue selection through polling

### DIFF
--- a/ui/src/components/MarkdownBody.rerender.test.tsx
+++ b/ui/src/components/MarkdownBody.rerender.test.tsx
@@ -2,7 +2,8 @@
 
 import { flushSync } from "react-dom";
 import { createRoot } from "react-dom/client";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act as reactAct } from "react";
+import { QueryClient, QueryClientProvider, useQuery } from "@tanstack/react-query";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { ThemeProvider } from "../context/ThemeContext";
 import { MarkdownBody } from "./MarkdownBody";
@@ -30,6 +31,7 @@ let root: ReturnType<typeof createRoot> | null = null;
 let container: HTMLDivElement | null = null;
 
 afterEach(() => {
+  vi.useRealTimers();
   if (root) {
     flushSync(() => root?.unmount());
   }
@@ -37,6 +39,21 @@ afterEach(() => {
   container?.remove();
   container = null;
 });
+
+async function act<T>(callback: () => T | Promise<T>): Promise<T> {
+  if (typeof reactAct === "function") {
+    return await (reactAct(callback) as T | Promise<T>);
+  }
+
+  let result: T | Promise<T> | undefined;
+  flushSync(() => {
+    result = callback();
+  });
+  const resolved = await result;
+  await Promise.resolve();
+  flushSync(() => {});
+  return resolved as T;
+}
 
 const SAMPLE = "Some text\n\n```ts\nconst answer = 42;\n```\n\nAnd a [link](https://example.com).";
 
@@ -48,6 +65,51 @@ function tree(children: string, queryClient: QueryClient) {
       </ThemeProvider>
     </QueryClientProvider>
   );
+}
+
+function IssueDetailPollingHarness({
+  loadContent,
+  loadRuns,
+}: {
+  loadContent: () => Promise<{
+    description: string;
+    comment: string;
+    document: string;
+    refresh: number;
+  }>;
+  loadRuns: () => Promise<{ refresh: number }>;
+}) {
+  const { data: content } = useQuery({
+    queryKey: ["selection-stability", "content"],
+    queryFn: loadContent,
+  });
+  useQuery({
+    queryKey: ["selection-stability", "runs"],
+    queryFn: loadRuns,
+    refetchInterval: 5_000,
+  });
+
+  if (!content) return null;
+
+  return (
+    <main>
+      <section data-testid="issue-description">
+        <MarkdownBody>{content.description}</MarkdownBody>
+      </section>
+      <section data-testid="issue-comment">
+        <MarkdownBody>{content.comment}</MarkdownBody>
+      </section>
+      <section data-testid="issue-document">
+        <MarkdownBody>{content.document}</MarkdownBody>
+      </section>
+    </main>
+  );
+}
+
+async function flushQueries() {
+  await act(async () => {
+    await Promise.resolve();
+  });
 }
 
 describe("MarkdownBody re-render stability (PAP-10767)", () => {
@@ -110,5 +172,74 @@ describe("MarkdownBody re-render stability (PAP-10767)", () => {
     flushSync(() => root?.render(tree(SAMPLE, queryClient)));
 
     expect(window.getSelection()?.toString()).toBe("Some text");
+  });
+
+  it("preserves issue text nodes through polling cycles and query invalidation", async () => {
+    vi.useFakeTimers();
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    let contentRefresh = 0;
+    let runsRefresh = 0;
+    const loadContent = vi.fn(async () => ({
+      description: "Stable issue description",
+      comment: "Stable issue comment",
+      document: "Stable issue document",
+      refresh: contentRefresh++,
+    }));
+    const loadRuns = vi.fn(async () => ({ refresh: runsRefresh++ }));
+    queryClient.setQueryData(["selection-stability", "content"], {
+      description: "Stable issue description",
+      comment: "Stable issue comment",
+      document: "Stable issue document",
+      refresh: -1,
+    });
+    queryClient.setQueryData(["selection-stability", "runs"], { refresh: -1 });
+
+    await act(async () => {
+      root?.render(
+        <QueryClientProvider client={queryClient}>
+          <ThemeProvider>
+            <IssueDetailPollingHarness loadContent={loadContent} loadRuns={loadRuns} />
+          </ThemeProvider>
+        </QueryClientProvider>,
+      );
+    });
+    await flushQueries();
+
+    const descriptionNode = container.querySelector('[data-testid="issue-description"] p')?.firstChild;
+    const commentNode = container.querySelector('[data-testid="issue-comment"] p')?.firstChild;
+    const documentNode = container.querySelector('[data-testid="issue-document"] p')?.firstChild;
+    expect(descriptionNode?.nodeType).toBe(Node.TEXT_NODE);
+    expect(commentNode?.nodeType).toBe(Node.TEXT_NODE);
+    expect(documentNode?.nodeType).toBe(Node.TEXT_NODE);
+
+    const range = document.createRange();
+    range.setStart(documentNode!, 0);
+    range.setEnd(documentNode!, "Stable issue document".length);
+    const selection = window.getSelection();
+    selection?.removeAllRanges();
+    selection?.addRange(range);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(30_000);
+    });
+    expect(loadRuns).toHaveBeenCalledTimes(7);
+    expect(selection?.toString()).toBe("Stable issue document");
+
+    await act(async () => {
+      await queryClient.invalidateQueries({ queryKey: ["selection-stability", "content"] });
+    });
+    await flushQueries();
+
+    expect(container.querySelector('[data-testid="issue-description"] p')?.firstChild).toBe(descriptionNode);
+    expect(container.querySelector('[data-testid="issue-comment"] p')?.firstChild).toBe(commentNode);
+    expect(container.querySelector('[data-testid="issue-document"] p')?.firstChild).toBe(documentNode);
+    expect(selection?.toString()).toBe("Stable issue document");
+    expect(loadContent).toHaveBeenCalledTimes(2);
+    vi.useRealTimers();
   });
 });


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The issue-detail UI renders selectable Markdown for descriptions, comments, and documents while background queries continue polling
> - Browser text selections depend on React preserving the selected text node identities across unrelated re-renders
> - A selection can appear stable during ordinary parent renders but still regress when polling or query invalidation refreshes surrounding issue data
> - This pull request adds an integration-style regression guard that exercises both repeated polling and explicit content invalidation for 30 seconds of simulated time
> - The benefit is an automated signal if future issue-detail changes replace selected Markdown text nodes and disrupt user highlighting

## Linked Issues or Issue Description

- **What happened?** Issue-detail Markdown can be re-rendered while runs/activity queries poll, risking replacement of text nodes that hold a browser selection.
- **Expected behavior:** Selected description, comment, or document text keeps the same DOM node identity through background polling and content invalidation.
- **Steps to reproduce:** Render an issue-detail-like tree, select document text with a `Range`, advance two or more polling cycles, invalidate content, and compare the selected text-node references.
- **Paperclip version:** `master` at `02e2dd271`
- **Deployment/install:** Local development build from source
- **Scope:** Core UI; not adapter- or database-specific

## What Changed

- Added an issue-detail polling harness around description, comment, and document `MarkdownBody` content.
- Added a regression test that advances 30 seconds of 5-second polling, invalidates issue content, and verifies all selected text nodes retain reference identity.
- Added deterministic React `act` and fake-timer cleanup for the asynchronous polling assertions.

## Verification

- `pnpm --filter @paperclipai/ui exec vitest run src/components/MarkdownBody.rerender.test.tsx` — 3 tests passed.
- `pnpm --filter @paperclipai/ui typecheck` — passed.
- `pnpm check:token-gates` — passed.
- `git diff --check origin/master...test/issue-selection-polling-stability` — passed.

## Risks

- Low risk: test-only change with no production runtime behavior changes.
- The harness intentionally models the issue-detail polling topology rather than mounting the full route, keeping the regression focused on DOM identity across React Query updates.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex coding agent; exact backing model ID and context-window size are not exposed in this execution environment; reasoning, repository tool use, shell execution, and test execution enabled.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

