### PR TITLE
Guard adapter failure escalation routing

### DIFF
--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -972,6 +972,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     kind?: string;
     previousOwnerAgentId?: string | null;
     returnOwnerAgentId?: string | null;
+    transitionReason?: "runtime_failure";
   }) {
     const action = await waitForValue(async () =>
       db.select().from(issueRecoveryActions).where(
@@ -997,12 +998,16 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       attemptCount: 1,
       maxAttempts: null,
     });
-    expect(action.evidence).toMatchObject({
+    const expectedEvidence: Record<string, unknown> = {
       sourceIssueId: input.issueId,
       previousStatus: input.previousStatus,
       latestRunId: input.runId,
       retryReason: input.retryReason ?? null,
-    });
+    };
+    if (input.transitionReason) {
+      expectedEvidence.transitionReason = input.transitionReason;
+    }
+    expect(action.evidence).toMatchObject(expectedEvidence);
     if (input.cause === "execution_review_participant_recovery") {
       expect(action.nextAction).toContain("failed review participant path");
     } else {
@@ -4845,6 +4850,8 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
 
     const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
     expect(issue?.status).toBe("blocked");
+    expect(issue?.status).not.toBe("blocked_pending_human");
+    expect(issue?.assigneeAgentId).toBe(agentId);
 
     await expectSourceScopedStrandedRecoveryAction({
       companyId,
@@ -4853,6 +4860,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       runId,
       previousStatus: "in_progress",
       retryReason: "issue_continuation_needed",
+      transitionReason: "runtime_failure",
     });
 
     const comments = await db.select().from(issueComments).where(eq(issueComments.issueId, issueId));
@@ -4860,6 +4868,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(comments[0]?.body).toContain("retried continuation");
     expect(comments[0]?.body).toContain("3× attempts");
     expect(comments[0]?.body).toContain("Latest cause: `adapter_failed`");
+    expect(comments[0]?.body).not.toContain("pending human");
   });
 
   it("does not count mixed-cause continuation failures toward the transient cap", async () => {

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -2512,6 +2512,10 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     successfulRunHandoffEvidence?: SuccessfulRunHandoffRecoveryEvidence | null;
   }) {
     const context = parseObject(input.latestRun?.contextSnapshot);
+    const latestRunErrorCode = readNonEmptyString(input.latestRun?.errorCode);
+    const transitionReason = latestRunErrorCode && TRANSIENT_INFRA_CONTINUATION_ERROR_CODES.has(latestRunErrorCode)
+      ? "runtime_failure"
+      : null;
     const workspaceValidation = input.recoveryCause === "workspace_validation_failed"
       ? readWorkspaceValidationPayload(input.latestRun)
       : null;
@@ -2525,6 +2529,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       latestRunErrorCode: input.latestRun?.errorCode ?? null,
       retryReason: readNonEmptyString(context.retryReason) ?? null,
       recoveryCause: input.recoveryCause,
+      ...(transitionReason ? { transitionReason } : {}),
       sourceRunId: input.successfulRunHandoffEvidence?.sourceRunId ?? null,
       correctiveRunId: input.successfulRunHandoffEvidence?.correctiveRunId ?? null,
       missingDisposition: input.successfulRunHandoffEvidence?.missingDisposition ?? null,


### PR DESCRIPTION
## Summary
- Records `transitionReason: runtime_failure` in source-scoped recovery action evidence for transient infrastructure continuation failures such as `adapter_failed`, timeout, provider quota, and upstream transient errors.
- Strengthens the heartbeat recovery regression for repeated `adapter_failed` continuation failures.
- Asserts the issue remains machine-actionable `blocked`, not `blocked_pending_human`, keeps an agent owner, and does not present the runtime failure as pending human action.

## Context
SQN-3012 found that runtime failures must not surface as founder-pending decisions. Current `master` already routes this recovery path to `blocked`; this PR adds the explicit runtime-failure transition evidence and locks the invariant with regression coverage.

## Validation
- `pnpm exec vitest run server/src/__tests__/heartbeat-process-recovery.test.ts --no-file-parallelism --maxWorkers=1`
- `pnpm --filter @paperclipai/server typecheck`

## Notes
- Direct push to `paperclipai/paperclip` failed with 403 for account `quratus`, so this branch is pushed from `quratus/paperclip`.
- `pnpm install --frozen-lockfile` completed in the side worktree; optional native bindings logged build failures because the node-gyp cache path contains a space, but install exited 0 and the focused validation passed.