### PR TITLE
fix: release finalize barriers held by dead runs

### DIFF
--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -1455,17 +1455,16 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
 
   it("sweeps a pre-existing terminal-run finalize barrier exactly once", async () => {
     const fixture = await seedDeadRunFinalizeBarrierFixture({ runStatus: "failed" });
-    const heartbeat = heartbeatService(db);
 
-    const first = await heartbeat.reconcileTerminalRunWorkspaceFinalizes("startup_sweep");
-    const second = await heartbeat.reconcileTerminalRunWorkspaceFinalizes("interval_sweep");
+    const concurrentResults = await Promise.all([
+      heartbeatService(db).reconcileTerminalRunWorkspaceFinalizes("startup_sweep"),
+      heartbeatService(db).reconcileTerminalRunWorkspaceFinalizes("interval_sweep"),
+    ]);
+    const second = await heartbeatService(db).reconcileTerminalRunWorkspaceFinalizes("interval_sweep");
 
-    expect(first).toMatchObject({
-      checked: 1,
-      created: 1,
-      wakesHealed: 1,
-      runIds: [fixture.runId],
-    });
+    expect(concurrentResults.reduce((total, result) => total + result.created, 0)).toBe(1);
+    expect(concurrentResults.reduce((total, result) => total + result.wakesHealed, 0)).toBe(1);
+    expect(concurrentResults.flatMap((result) => result.runIds)).toEqual([fixture.runId]);
     expect(second).toMatchObject({ checked: 1, created: 0, wakesHealed: 0, runIds: [] });
     const syntheticFinalizes = await db
       .select()
@@ -1480,8 +1479,10 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(syntheticFinalizes[0]?.metadata).toMatchObject({
       synthetic: true,
       reason: "process_lost",
-      source: "startup_sweep",
     });
+    expect(["startup_sweep", "interval_sweep"]).toContain(
+      (syntheticFinalizes[0]?.metadata as Record<string, unknown> | null)?.source,
+    );
     await expect(issueService(db).getDependencyReadiness(fixture.dependentIssueId)).resolves.toMatchObject({
       isDependencyReady: true,
       pendingFinalizeBlockerIssueIds: [],

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -101,6 +101,7 @@ import {
   redactDetectedSuccessfulRunProgressSummaryForBoard,
 } from "../services/heartbeat.ts";
 import { secretService } from "../services/secrets.ts";
+import { issueService } from "../services/issues.ts";
 import {
   SUCCESSFUL_RUN_HANDOFF_EXHAUSTED_NOTICE_BODY,
   SUCCESSFUL_RUN_HANDOFF_REQUIRED_NOTICE_BODY,
@@ -581,6 +582,105 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     });
 
     return { environmentId, leaseId };
+  }
+
+  async function seedDeadRunFinalizeBarrierFixture(input?: { runStatus?: "running" | "failed" }) {
+    const seeded = await seedRunFixture({
+      agentStatus: "running",
+      adapterType: "test",
+      runStatus: input?.runStatus ?? "running",
+      runErrorCode: input?.runStatus === "failed" ? "process_lost" : null,
+      runError: input?.runStatus === "failed" ? "Process lost during a prior server lifetime" : null,
+    });
+    const projectId = randomUUID();
+    const executionWorkspaceId = randomUUID();
+    const dependentAgentId = randomUUID();
+    const dependentIssueId = randomUUID();
+    const now = new Date("2026-03-19T00:01:00.000Z");
+
+    await db.insert(projects).values({
+      id: projectId,
+      companyId: seeded.companyId,
+      name: "Dead run finalize barrier project",
+      status: "in_progress",
+    });
+    await db.insert(executionWorkspaces).values({
+      id: executionWorkspaceId,
+      companyId: seeded.companyId,
+      projectId,
+      sourceIssueId: seeded.issueId,
+      mode: "shared_workspace",
+      strategyType: "project_primary",
+      name: "Dead run finalize barrier workspace",
+      status: "active",
+      cwd: "/workspace/dead-run-finalize",
+    });
+    await db
+      .update(issues)
+      .set({
+        status: "done",
+        projectId,
+        executionWorkspaceId,
+        completedAt: now,
+      })
+      .where(eq(issues.id, seeded.issueId));
+    await db
+      .update(heartbeatRuns)
+      .set({
+        contextSnapshot: {
+          issueId: seeded.issueId,
+          executionWorkspaceId,
+        },
+        ...(input?.runStatus === "failed" ? { finishedAt: now, updatedAt: now } : {}),
+      })
+      .where(eq(heartbeatRuns.id, seeded.runId));
+
+    await db.insert(agents).values({
+      id: dependentAgentId,
+      companyId: seeded.companyId,
+      name: "Dependent Agent",
+      role: "engineer",
+      status: "idle",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    await db.insert(issues).values({
+      id: dependentIssueId,
+      companyId: seeded.companyId,
+      projectId,
+      title: "Dependent waiting for dead run finalize",
+      status: "blocked",
+      priority: "medium",
+      assigneeAgentId: dependentAgentId,
+      responsibleUserId: "responsible-user",
+      issueNumber: 2,
+      identifier: `T${seeded.companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}-2`,
+    });
+    await db.insert(issueRelations).values({
+      companyId: seeded.companyId,
+      issueId: seeded.issueId,
+      relatedIssueId: dependentIssueId,
+      type: "blocks",
+    });
+    await db.insert(workspaceOperations).values({
+      companyId: seeded.companyId,
+      executionWorkspaceId,
+      heartbeatRunId: seeded.runId,
+      issueId: seeded.issueId,
+      phase: "adapter_execute",
+      status: "succeeded",
+      startedAt: now,
+      finishedAt: now,
+    });
+
+    return {
+      ...seeded,
+      dependentAgentId,
+      dependentIssueId,
+      executionWorkspaceId,
+    };
   }
 
   it("does not reap active adapter executions started by another heartbeat service instance", async () => {
@@ -1301,6 +1401,126 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     );
     // Terminal run cleanup releases the checkout lock so future checkout 409s only mean a live owner exists.
     expect(checkoutReleasedIssue?.checkoutRunId).toBeNull();
+  });
+
+  it("releases a done blocker finalize barrier when its run is reaped as process_lost", async () => {
+    const fixture = await seedDeadRunFinalizeBarrierFixture();
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reapOrphanedRuns();
+
+    expect(result).toMatchObject({ reaped: 1, runIds: [fixture.runId] });
+    const syntheticFinalizes = await db
+      .select()
+      .from(workspaceOperations)
+      .where(
+        and(
+          eq(workspaceOperations.heartbeatRunId, fixture.runId),
+          eq(workspaceOperations.phase, "workspace_finalize"),
+        ),
+      );
+    expect(syntheticFinalizes).toHaveLength(1);
+    expect(syntheticFinalizes[0]).toMatchObject({
+      companyId: fixture.companyId,
+      executionWorkspaceId: fixture.executionWorkspaceId,
+      issueId: fixture.issueId,
+      status: "succeeded",
+      metadata: expect.objectContaining({
+        synthetic: true,
+        reason: "process_lost",
+        source: "run.reap",
+        outcome: "terminal_without_finalize",
+      }),
+    });
+
+    await expect(issueService(db).getDependencyReadiness(fixture.dependentIssueId)).resolves.toMatchObject({
+      isDependencyReady: true,
+      pendingFinalizeBlockerIssueIds: [],
+    });
+    const wake = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(
+        and(
+          eq(agentWakeupRequests.agentId, fixture.dependentAgentId),
+          eq(agentWakeupRequests.reason, "issue_blockers_resolved"),
+        ),
+      )
+      .then((rows) => rows[0] ?? null);
+    expect(wake).toMatchObject({
+      reason: "issue_blockers_resolved",
+      idempotencyKey: `issue_blockers_resolved:${fixture.dependentIssueId}:${fixture.issueId}`,
+    });
+  });
+
+  it("sweeps a pre-existing terminal-run finalize barrier exactly once", async () => {
+    const fixture = await seedDeadRunFinalizeBarrierFixture({ runStatus: "failed" });
+    const heartbeat = heartbeatService(db);
+
+    const first = await heartbeat.reconcileTerminalRunWorkspaceFinalizes("startup_sweep");
+    const second = await heartbeat.reconcileTerminalRunWorkspaceFinalizes("interval_sweep");
+
+    expect(first).toMatchObject({
+      checked: 1,
+      created: 1,
+      wakesHealed: 1,
+      runIds: [fixture.runId],
+    });
+    expect(second).toMatchObject({ checked: 1, created: 0, wakesHealed: 0, runIds: [] });
+    const syntheticFinalizes = await db
+      .select()
+      .from(workspaceOperations)
+      .where(
+        and(
+          eq(workspaceOperations.heartbeatRunId, fixture.runId),
+          eq(workspaceOperations.phase, "workspace_finalize"),
+        ),
+      );
+    expect(syntheticFinalizes).toHaveLength(1);
+    expect(syntheticFinalizes[0]?.metadata).toMatchObject({
+      synthetic: true,
+      reason: "process_lost",
+      source: "startup_sweep",
+    });
+    await expect(issueService(db).getDependencyReadiness(fixture.dependentIssueId)).resolves.toMatchObject({
+      isDependencyReady: true,
+      pendingFinalizeBlockerIssueIds: [],
+    });
+  });
+
+  it("does not mask an explicit failed workspace finalize with a synthetic success", async () => {
+    const fixture = await seedDeadRunFinalizeBarrierFixture({ runStatus: "failed" });
+    const failedAt = new Date("2026-03-19T00:02:00.000Z");
+    await db.insert(workspaceOperations).values({
+      companyId: fixture.companyId,
+      executionWorkspaceId: fixture.executionWorkspaceId,
+      heartbeatRunId: fixture.runId,
+      issueId: fixture.issueId,
+      phase: "workspace_finalize",
+      status: "failed",
+      metadata: { errorMessage: "sync-back failed" },
+      startedAt: failedAt,
+      finishedAt: failedAt,
+    });
+
+    const result = await heartbeatService(db).reconcileTerminalRunWorkspaceFinalizes("startup_sweep");
+
+    expect(result).toMatchObject({ checked: 1, created: 0, wakesHealed: 0, runIds: [] });
+    const finalizes = await db
+      .select()
+      .from(workspaceOperations)
+      .where(
+        and(
+          eq(workspaceOperations.heartbeatRunId, fixture.runId),
+          eq(workspaceOperations.phase, "workspace_finalize"),
+        ),
+      );
+    expect(finalizes).toHaveLength(1);
+    expect(finalizes[0]).toMatchObject({ status: "failed", metadata: { errorMessage: "sync-back failed" } });
+    await expect(issueService(db).getDependencyReadiness(fixture.dependentIssueId)).resolves.toMatchObject({
+      isDependencyReady: false,
+      pendingFinalizeBlockerIssueIds: [fixture.issueId],
+    });
   });
 
   it("interrupts running runs on graceful shutdown and queues restart recovery without recording a failure", async () => {

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -584,13 +584,26 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     return { environmentId, leaseId };
   }
 
-  async function seedDeadRunFinalizeBarrierFixture(input?: { runStatus?: "running" | "failed" }) {
+  async function seedDeadRunFinalizeBarrierFixture(input?: {
+    runStatus?: "running" | "interrupted" | "failed";
+  }) {
+    const runStatus = input?.runStatus ?? "running";
+    const runErrorCode = runStatus === "failed"
+      ? "process_lost"
+      : runStatus === "interrupted"
+        ? "server_shutdown_interrupted"
+        : null;
+    const runError = runStatus === "failed"
+      ? "Process lost during a prior server lifetime"
+      : runStatus === "interrupted"
+        ? "Run interrupted during graceful server shutdown"
+        : null;
     const seeded = await seedRunFixture({
       agentStatus: "running",
       adapterType: "test",
-      runStatus: input?.runStatus ?? "running",
-      runErrorCode: input?.runStatus === "failed" ? "process_lost" : null,
-      runError: input?.runStatus === "failed" ? "Process lost during a prior server lifetime" : null,
+      runStatus,
+      runErrorCode,
+      runError,
     });
     const projectId = randomUUID();
     const executionWorkspaceId = randomUUID();
@@ -631,7 +644,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
           issueId: seeded.issueId,
           executionWorkspaceId,
         },
-        ...(input?.runStatus === "failed" ? { finishedAt: now, updatedAt: now } : {}),
+        ...(runStatus !== "running" ? { finishedAt: now, updatedAt: now } : {}),
       })
       .where(eq(heartbeatRuns.id, seeded.runId));
 
@@ -1483,6 +1496,41 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(["startup_sweep", "interval_sweep"]).toContain(
       (syntheticFinalizes[0]?.metadata as Record<string, unknown> | null)?.source,
     );
+    await expect(issueService(db).getDependencyReadiness(fixture.dependentIssueId)).resolves.toMatchObject({
+      isDependencyReady: true,
+      pendingFinalizeBlockerIssueIds: [],
+    });
+  });
+
+  it("releases a finalize barrier owned by an interrupted run", async () => {
+    const fixture = await seedDeadRunFinalizeBarrierFixture({ runStatus: "interrupted" });
+
+    const result = await heartbeatService(db).reconcileTerminalRunWorkspaceFinalizes("startup_sweep");
+
+    expect(result).toMatchObject({
+      checked: 1,
+      created: 1,
+      wakesHealed: 1,
+      runIds: [fixture.runId],
+    });
+    const syntheticFinalize = await db
+      .select()
+      .from(workspaceOperations)
+      .where(
+        and(
+          eq(workspaceOperations.heartbeatRunId, fixture.runId),
+          eq(workspaceOperations.phase, "workspace_finalize"),
+        ),
+      )
+      .then((rows) => rows[0] ?? null);
+    expect(syntheticFinalize).toMatchObject({
+      status: "succeeded",
+      metadata: expect.objectContaining({
+        synthetic: true,
+        reason: "server_shutdown_interrupted",
+        terminalRunStatus: "interrupted",
+      }),
+    });
     await expect(issueService(db).getDependencyReadiness(fixture.dependentIssueId)).resolves.toMatchObject({
       isDependencyReady: true,
       pendingFinalizeBlockerIssueIds: [],

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -880,6 +880,14 @@ export async function startServer(): Promise<StartedServer> {
           }
         }
 
+        const finalized = await heartbeat.reconcileTerminalRunWorkspaceFinalizes("startup_sweep");
+        if (finalized.created > 0) {
+          logger.warn(
+            { ...finalized },
+            "startup terminal-run workspace-finalize reconciliation released stuck barriers",
+          );
+        }
+
         const promotion = await heartbeat.promoteDueScheduledRetries();
         await heartbeat.resumeQueuedRuns();
         const reconciled = await heartbeat.reconcileStrandedAssignedIssues();
@@ -995,6 +1003,15 @@ export async function startServer(): Promise<StartedServer> {
         // persisted queued work is still being driven forward.
         trackHeartbeatSchedulerWork(heartbeat
           .reapOrphanedRuns({ staleThresholdMs: 5 * 60 * 1000 })
+          .then(async () => {
+            const finalized = await heartbeat.reconcileTerminalRunWorkspaceFinalizes("interval_sweep");
+            if (finalized.created > 0) {
+              logger.warn(
+                { ...finalized },
+                "periodic terminal-run workspace-finalize reconciliation released stuck barriers",
+              );
+            }
+          })
           .then(() => heartbeat.promoteDueScheduledRetries())
           .then(async (promotion) => {
             await heartbeat.resumeQueuedRuns();

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -880,11 +880,18 @@ export async function startServer(): Promise<StartedServer> {
           }
         }
 
-        const finalized = await heartbeat.reconcileTerminalRunWorkspaceFinalizes("startup_sweep");
-        if (finalized.created > 0) {
-          logger.warn(
-            { ...finalized },
-            "startup terminal-run workspace-finalize reconciliation released stuck barriers",
+        try {
+          const finalized = await heartbeat.reconcileTerminalRunWorkspaceFinalizes("startup_sweep");
+          if (finalized.created > 0) {
+            logger.warn(
+              { ...finalized },
+              "startup terminal-run workspace-finalize reconciliation released stuck barriers",
+            );
+          }
+        } catch (err) {
+          logger.error(
+            { err },
+            "startup terminal-run workspace-finalize reconciliation failed",
           );
         }
 
@@ -1004,11 +1011,18 @@ export async function startServer(): Promise<StartedServer> {
         trackHeartbeatSchedulerWork(heartbeat
           .reapOrphanedRuns({ staleThresholdMs: 5 * 60 * 1000 })
           .then(async () => {
-            const finalized = await heartbeat.reconcileTerminalRunWorkspaceFinalizes("interval_sweep");
-            if (finalized.created > 0) {
-              logger.warn(
-                { ...finalized },
-                "periodic terminal-run workspace-finalize reconciliation released stuck barriers",
+            try {
+              const finalized = await heartbeat.reconcileTerminalRunWorkspaceFinalizes("interval_sweep");
+              if (finalized.created > 0) {
+                logger.warn(
+                  { ...finalized },
+                  "periodic terminal-run workspace-finalize reconciliation released stuck barriers",
+                );
+              }
+            } catch (err) {
+              logger.error(
+                { err },
+                "periodic terminal-run workspace-finalize reconciliation failed",
               );
             }
           })

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -5126,6 +5126,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       if (!issue || issue.status !== "done" || !issue.executionWorkspaceId) {
         return { created: false, wakeHealed: 0 };
       }
+      const executionWorkspaceId = issue.executionWorkspaceId;
 
       const latestOperation = await db
         .select({
@@ -5137,7 +5138,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           and(
             eq(workspaceOperations.companyId, run.companyId),
             eq(workspaceOperations.issueId, issue.id),
-            eq(workspaceOperations.executionWorkspaceId, issue.executionWorkspaceId),
+            eq(workspaceOperations.executionWorkspaceId, executionWorkspaceId),
           ),
         )
         .orderBy(
@@ -5155,43 +5156,84 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         return { created: false, wakeHealed: 0 };
       }
 
-      const existingFinalize = await db
-        .select({ id: workspaceOperations.id })
-        .from(workspaceOperations)
-        .where(
-          and(
-            eq(workspaceOperations.companyId, run.companyId),
-            eq(workspaceOperations.heartbeatRunId, run.id),
-            eq(workspaceOperations.phase, "workspace_finalize"),
-          ),
-        )
-        .limit(1)
-        .then((rows) => rows[0] ?? null);
-      if (existingFinalize) return { created: false, wakeHealed: 0 };
-
       const now = new Date();
       const reason = readNonEmptyString(run.errorCode) ?? run.status;
-      await db.insert(workspaceOperations).values({
-        id: randomUUID(),
-        companyId: run.companyId,
-        executionWorkspaceId: issue.executionWorkspaceId,
-        heartbeatRunId: run.id,
-        issueId: issue.id,
-        phase: "workspace_finalize",
-        status: "succeeded",
-        metadata: {
-          synthetic: true,
-          reason,
-          source,
-          outcome: "terminal_without_finalize",
-          terminalRunStatus: run.status,
-          terminalRunErrorCode: run.errorCode ?? null,
-        },
-        startedAt: now,
-        finishedAt: now,
-        createdAt: now,
-        updatedAt: now,
+      const created = await db.transaction(async (tx) => {
+        const lockedRun = await tx
+          .select({ id: heartbeatRuns.id })
+          .from(heartbeatRuns)
+          .where(and(eq(heartbeatRuns.id, run.id), eq(heartbeatRuns.companyId, run.companyId)))
+          .for("update")
+          .limit(1)
+          .then((rows) => rows[0] ?? null);
+        if (!lockedRun) return false;
+
+        const existingFinalize = await tx
+          .select({ id: workspaceOperations.id })
+          .from(workspaceOperations)
+          .where(
+            and(
+              eq(workspaceOperations.companyId, run.companyId),
+              eq(workspaceOperations.heartbeatRunId, run.id),
+              eq(workspaceOperations.phase, "workspace_finalize"),
+            ),
+          )
+          .limit(1)
+          .then((rows) => rows[0] ?? null);
+        if (existingFinalize) return false;
+
+        const lockedLatestOperation = await tx
+          .select({
+            heartbeatRunId: workspaceOperations.heartbeatRunId,
+            phase: workspaceOperations.phase,
+          })
+          .from(workspaceOperations)
+          .where(
+            and(
+              eq(workspaceOperations.companyId, run.companyId),
+              eq(workspaceOperations.issueId, issue.id),
+              eq(workspaceOperations.executionWorkspaceId, executionWorkspaceId),
+            ),
+          )
+          .orderBy(
+            desc(workspaceOperations.startedAt),
+            desc(workspaceOperations.createdAt),
+            desc(workspaceOperations.id),
+          )
+          .limit(1)
+          .then((rows) => rows[0] ?? null);
+        if (
+          !lockedLatestOperation ||
+          lockedLatestOperation.heartbeatRunId !== run.id ||
+          lockedLatestOperation.phase === "workspace_finalize"
+        ) {
+          return false;
+        }
+
+        await tx.insert(workspaceOperations).values({
+          id: randomUUID(),
+          companyId: run.companyId,
+          executionWorkspaceId,
+          heartbeatRunId: run.id,
+          issueId: issue.id,
+          phase: "workspace_finalize",
+          status: "succeeded",
+          metadata: {
+            synthetic: true,
+            reason,
+            source,
+            outcome: "terminal_without_finalize",
+            terminalRunStatus: run.status,
+            terminalRunErrorCode: run.errorCode ?? null,
+          },
+          startedAt: now,
+          finishedAt: now,
+          createdAt: now,
+          updatedAt: now,
+        });
+        return true;
       });
+      if (!created) return { created: false, wakeHealed: 0 };
 
       const wakeResult = await recovery.reconcileResolvedDependencyWakeBackstop({
         runId: run.id,

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -5088,6 +5088,197 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
   };
   const budgets = budgetService(db, budgetHooks);
   const recovery = recoveryService(db, { enqueueWakeup });
+  const terminalRunFinalizeReconciliations = new Map<string, Promise<{
+    created: boolean;
+    wakeHealed: number;
+  }>>();
+
+  async function reconcileTerminalRunWorkspaceFinalize(
+    run: typeof heartbeatRuns.$inferSelect,
+    source: "run.failure" | "run.reap" | "startup_sweep" | "interval_sweep",
+  ) {
+    const existing = terminalRunFinalizeReconciliations.get(run.id);
+    if (existing) return existing;
+
+    const reconciliation = (async () => {
+      if (
+        !UNSUCCESSFUL_HEARTBEAT_RUN_TERMINAL_STATUSES.includes(
+          run.status as (typeof UNSUCCESSFUL_HEARTBEAT_RUN_TERMINAL_STATUSES)[number],
+        )
+      ) {
+        return { created: false, wakeHealed: 0 };
+      }
+
+      const context = parseObject(run.contextSnapshot);
+      const issueId = readNonEmptyString(context.issueId);
+      if (!issueId) return { created: false, wakeHealed: 0 };
+
+      const issue = await db
+        .select({
+          id: issues.id,
+          companyId: issues.companyId,
+          status: issues.status,
+          executionWorkspaceId: issues.executionWorkspaceId,
+        })
+        .from(issues)
+        .where(and(eq(issues.id, issueId), eq(issues.companyId, run.companyId)))
+        .then((rows) => rows[0] ?? null);
+      if (!issue || issue.status !== "done" || !issue.executionWorkspaceId) {
+        return { created: false, wakeHealed: 0 };
+      }
+
+      const latestOperation = await db
+        .select({
+          heartbeatRunId: workspaceOperations.heartbeatRunId,
+          phase: workspaceOperations.phase,
+        })
+        .from(workspaceOperations)
+        .where(
+          and(
+            eq(workspaceOperations.companyId, run.companyId),
+            eq(workspaceOperations.issueId, issue.id),
+            eq(workspaceOperations.executionWorkspaceId, issue.executionWorkspaceId),
+          ),
+        )
+        .orderBy(
+          desc(workspaceOperations.startedAt),
+          desc(workspaceOperations.createdAt),
+          desc(workspaceOperations.id),
+        )
+        .limit(1)
+        .then((rows) => rows[0] ?? null);
+      if (
+        !latestOperation ||
+        latestOperation.heartbeatRunId !== run.id ||
+        latestOperation.phase === "workspace_finalize"
+      ) {
+        return { created: false, wakeHealed: 0 };
+      }
+
+      const existingFinalize = await db
+        .select({ id: workspaceOperations.id })
+        .from(workspaceOperations)
+        .where(
+          and(
+            eq(workspaceOperations.companyId, run.companyId),
+            eq(workspaceOperations.heartbeatRunId, run.id),
+            eq(workspaceOperations.phase, "workspace_finalize"),
+          ),
+        )
+        .limit(1)
+        .then((rows) => rows[0] ?? null);
+      if (existingFinalize) return { created: false, wakeHealed: 0 };
+
+      const now = new Date();
+      const reason = readNonEmptyString(run.errorCode) ?? run.status;
+      await db.insert(workspaceOperations).values({
+        id: randomUUID(),
+        companyId: run.companyId,
+        executionWorkspaceId: issue.executionWorkspaceId,
+        heartbeatRunId: run.id,
+        issueId: issue.id,
+        phase: "workspace_finalize",
+        status: "succeeded",
+        metadata: {
+          synthetic: true,
+          reason,
+          source,
+          outcome: "terminal_without_finalize",
+          terminalRunStatus: run.status,
+          terminalRunErrorCode: run.errorCode ?? null,
+        },
+        startedAt: now,
+        finishedAt: now,
+        createdAt: now,
+        updatedAt: now,
+      });
+
+      const wakeResult = await recovery.reconcileResolvedDependencyWakeBackstop({
+        runId: run.id,
+        companyId: run.companyId,
+        blockerIssueId: issue.id,
+        source: "workspace.finalize",
+      });
+      return { created: true, wakeHealed: wakeResult.healed };
+    })().finally(() => {
+      terminalRunFinalizeReconciliations.delete(run.id);
+    });
+
+    terminalRunFinalizeReconciliations.set(run.id, reconciliation);
+    return reconciliation;
+  }
+
+  async function reconcileTerminalRunWorkspaceFinalizes(
+    source: "startup_sweep" | "interval_sweep" = "interval_sweep",
+  ) {
+    const blockerRows = await db
+      .select({
+        issueId: issues.id,
+        companyId: issues.companyId,
+        executionWorkspaceId: issues.executionWorkspaceId,
+      })
+      .from(issueRelations)
+      .innerJoin(issues, eq(issueRelations.issueId, issues.id))
+      .where(
+        and(
+          eq(issueRelations.type, "blocks"),
+          eq(issues.status, "done"),
+          sql`${issues.executionWorkspaceId} is not null`,
+        ),
+      );
+
+    const seenIssueIds = new Set<string>();
+    const reconciledRunIds: string[] = [];
+    let checked = 0;
+    let created = 0;
+    let wakesHealed = 0;
+
+    for (const blocker of blockerRows) {
+      if (!blocker.executionWorkspaceId || seenIssueIds.has(blocker.issueId)) continue;
+      seenIssueIds.add(blocker.issueId);
+      checked += 1;
+
+      const latestOperation = await db
+        .select({ heartbeatRunId: workspaceOperations.heartbeatRunId })
+        .from(workspaceOperations)
+        .where(
+          and(
+            eq(workspaceOperations.companyId, blocker.companyId),
+            eq(workspaceOperations.issueId, blocker.issueId),
+            eq(workspaceOperations.executionWorkspaceId, blocker.executionWorkspaceId),
+          ),
+        )
+        .orderBy(
+          desc(workspaceOperations.startedAt),
+          desc(workspaceOperations.createdAt),
+          desc(workspaceOperations.id),
+        )
+        .limit(1)
+        .then((rows) => rows[0] ?? null);
+      if (!latestOperation?.heartbeatRunId) continue;
+
+      const terminalRun = await db
+        .select()
+        .from(heartbeatRuns)
+        .where(
+          and(
+            eq(heartbeatRuns.id, latestOperation.heartbeatRunId),
+            eq(heartbeatRuns.companyId, blocker.companyId),
+            inArray(heartbeatRuns.status, [...UNSUCCESSFUL_HEARTBEAT_RUN_TERMINAL_STATUSES]),
+          ),
+        )
+        .then((rows) => rows[0] ?? null);
+      if (!terminalRun) continue;
+
+      const result = await reconcileTerminalRunWorkspaceFinalize(terminalRun, source);
+      if (!result.created) continue;
+      created += 1;
+      wakesHealed += result.wakeHealed;
+      reconciledRunIds.push(terminalRun.id);
+    }
+
+    return { checked, created, wakesHealed, runIds: reconciledRunIds };
+  }
 
   function isPlanApprovalConfirmationPayload(payload: unknown) {
     const target = parseObject(parseObject(payload).target);
@@ -10715,6 +10906,14 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       if (!finalizedRun) finalizedRun = await getRun(run.id);
       if (!finalizedRun) continue;
       finalizedRun = await classifyAndPersistRunLiveness(finalizedRun, parseObject(finalizedRun.resultJson)) ?? finalizedRun;
+      try {
+        await reconcileTerminalRunWorkspaceFinalize(finalizedRun, "run.reap");
+      } catch (finalizeErr) {
+        logger.warn(
+          { err: finalizeErr, runId: finalizedRun.id },
+          "failed to reconcile workspace finalize after orphaned run reap",
+        );
+      }
       await releaseEnvironmentLeasesForRun({
         runId: finalizedRun.id,
         companyId: finalizedRun.companyId,
@@ -13236,6 +13435,14 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           message,
         });
         const livenessRun = await classifyAndPersistRunLiveness(failedRun) ?? failedRun;
+        try {
+          await reconcileTerminalRunWorkspaceFinalize(livenessRun, "run.failure");
+        } catch (finalizeErr) {
+          logger.warn(
+            { err: finalizeErr, runId: livenessRun.id },
+            "failed to reconcile workspace finalize after terminal run failure",
+          );
+        }
         try {
           await completeSkillTestRunForHeartbeatOutcome({
             run: livenessRun,
@@ -15965,6 +16172,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     reportRunActivity: clearDetachedRunWarning,
 
     reapOrphanedRuns,
+    reconcileTerminalRunWorkspaceFinalizes,
     // Override-aware scheduling-suppression check (honors the worktree
     // run-execution experimental setting). Callers outside the service that
     // gate on suppression should prefer this over the env-only resolver.

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -291,6 +291,10 @@ const EXECUTION_PATH_HEARTBEAT_RUN_STATUSES = ["queued", "running", "scheduled_r
 const CANCELLABLE_HEARTBEAT_RUN_STATUSES = ["queued", "running", "scheduled_retry"] as const;
 const HEARTBEAT_RUN_TERMINAL_STATUSES = ["succeeded", "interrupted", "failed", "cancelled", "timed_out"] as const;
 const UNSUCCESSFUL_HEARTBEAT_RUN_TERMINAL_STATUSES = ["failed", "cancelled", "timed_out"] as const;
+const WORKSPACE_FINALIZE_RECOVERABLE_TERMINAL_STATUSES = [
+  "interrupted",
+  ...UNSUCCESSFUL_HEARTBEAT_RUN_TERMINAL_STATUSES,
+] as const;
 const TIMER_ACTIONABLE_ISSUE_STATUSES = ["todo", "in_progress"] as const;
 export {
   ACTIVE_RUN_OUTPUT_CONTINUE_REARM_MS,
@@ -5102,8 +5106,8 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
 
     const reconciliation = (async () => {
       if (
-        !UNSUCCESSFUL_HEARTBEAT_RUN_TERMINAL_STATUSES.includes(
-          run.status as (typeof UNSUCCESSFUL_HEARTBEAT_RUN_TERMINAL_STATUSES)[number],
+        !WORKSPACE_FINALIZE_RECOVERABLE_TERMINAL_STATUSES.includes(
+          run.status as (typeof WORKSPACE_FINALIZE_RECOVERABLE_TERMINAL_STATUSES)[number],
         )
       ) {
         return { created: false, wakeHealed: 0 };
@@ -5306,7 +5310,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           and(
             eq(heartbeatRuns.id, latestOperation.heartbeatRunId),
             eq(heartbeatRuns.companyId, blocker.companyId),
-            inArray(heartbeatRuns.status, [...UNSUCCESSFUL_HEARTBEAT_RUN_TERMINAL_STATUSES]),
+            inArray(heartbeatRuns.status, [...WORKSPACE_FINALIZE_RECOVERABLE_TERMINAL_STATUSES]),
           ),
         )
         .then((rows) => rows[0] ?? null);


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source control plane people use to coordinate AI-agent companies
> - Heartbeat runs own workspace lifecycle operations that gate dependent issue readiness
> - A completed blocker remains intentionally gated until its owning run records a successful workspace finalize operation
> - If that run becomes terminal before recording finalize, the existing barrier can never be released
> - That leaves dependent issues permanently blocked even though the only owning run is already dead
> - This pull request records an explicit synthetic successful finalize for terminal runs that never produced one, then re-evaluates dependent readiness
> - The benefit is that dead runs cannot permanently wedge the issue graph, while failed real finalize operations remain visible and unreplaced

## Linked Issues or Issue Description

### Pre-submission checklist

- [x] I searched open and closed issues and pull requests; this is not a duplicate.
- [x] The bug reproduces on `master` at commit `e4e12bfb8`.
- [x] The failure originates in Paperclip core, not an adapter, provider, or local configuration.

### What happened?

A heartbeat run can mark its issue done and then be reaped or fail before writing `workspace_finalize`. The dependent-readiness gate sees the missing finalize forever, so completed blockers remain unresolved with no live process capable of releasing them.

### Expected behavior

Once the owning run is terminal, the control plane records a distinguishable synthetic finalize, releases dependent readiness, and emits the same blocker-resolved wake used by normal finalization.

### Steps to reproduce

1. Create a blocker and dependent issue pair.
2. Complete the blocker while its heartbeat run still owns the workspace lifecycle.
3. Terminate the run before it records `workspace_finalize`, then reap it as process-lost.
4. Observe that the dependent remains blocked indefinitely on current `master`.

### Paperclip version or commit

`e4e12bfb890a0fdf4c7de092362472c50a584533`

### Deployment mode

Local dev (`pnpm dev`)

### Installation method

Built from source

### Agent adapter(s) involved

Not adapter-specific (core bug)

### Database mode

Embedded PGlite and external Postgres share the affected service logic.

### Access context

Not applicable; this is an internal heartbeat recovery path.

### Relevant logs or output

A reaped run reaches terminal `failed/process_lost` without an attributed `workspace_finalize` operation; dependent readiness continues to report the completed blocker as unresolved.

### Additional context

The fix preserves explicit failed real finalize operations and only synthesizes success when no attributed finalize operation exists.

### Privacy checklist

- [x] This description contains no pasted PII, credentials, private paths, company data, or tokens.

## What Changed

- Add cross-process-idempotent terminal-run reconciliation that transactionally records a successful `workspace_finalize` operation with `synthetic: true`, the terminal reason, and the source path.
- Reuse workspace-finalize dependency reconciliation so synthetic finalization emits normal `issue_blockers_resolved` wakes.
- Run reconciliation after orphan reaping, normal run failure, server startup, and the periodic recovery sweep.
- Reconcile failed, cancelled, timed-out, and interrupted terminal runs while preserving explicit failed real finalize operations.
- Add focused regression coverage for process-loss release, historical sweep convergence, and explicit finalize failure preservation.

## Verification

- `pnpm vitest run server/src/__tests__/heartbeat-process-recovery.test.ts` — 87 tests passed before review fixes.
- `pnpm vitest run server/src/__tests__/heartbeat-process-recovery.test.ts -t 'finalize barrier|interrupted run'` — 4 focused tests passed on the final head.
- Latest-head GitHub CI — all required checks passed.
- `pnpm --filter @paperclipai/server typecheck` — passed.

## Risks

- **Recovery ordering:** Startup and periodic reconciliation now write workspace operations before later liveness sweeps; the operation is idempotent per terminal run and covered by convergence tests.
- **False success masking:** Synthetic success is only created when no attributed finalize exists; an explicit failed real finalize remains authoritative and is covered by regression tests.
- **Wake duplication:** The existing dependency-wake dedupe/reconciliation path is reused rather than introducing a second wake mechanism.

> This is a targeted liveness bug fix and does not overlap with planned core work in `ROADMAP.md`.

## Model Used

- OpenAI Codex CLI using `gpt-5.3-codex`, with repository tool use, code execution, and reasoning enabled; context window not exposed by the runtime.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge


