### PR TITLE
feat(ui): explain when a message won't reopen a blocked issue (Rule C, PAP-13554)

### DIFF
--- a/ui/src/components/IssueBlockedNotice.test.tsx
+++ b/ui/src/components/IssueBlockedNotice.test.tsx
@@ -264,7 +264,9 @@ describe("IssueBlockedNotice", () => {
     );
 
     expect(node.querySelector('[data-testid="issue-blocked-notice-live"]')).toBeNull();
-    expect(node.textContent).toContain("Work on this task is blocked by the linked task");
+    // Rule C: a `blocked` issue with an unresolved blocker explains that a
+    // human message will not reopen it yet.
+    expect(node.textContent).toContain("A message won’t move this back to todo yet");
     expect(node.querySelector('[data-blocker-attention-state="covered"]')).not.toBeNull();
   });
 
@@ -338,6 +340,111 @@ describe("IssueBlockedNotice", () => {
     if (!runningStep) throw new Error("Expected a running live-work step.");
     expect(runningStep.querySelector('svg[aria-label="In Progress status"]')).not.toBeNull();
     expect(node.querySelector('[data-testid="issue-blocked-notice-now-running"]')).toBeNull();
+  });
+
+  it("explains a human message won't reopen a blocked issue and names the unresolved leaf (Rule C)", () => {
+    const node = render(
+      <IssueBlockedNotice
+        issueStatus="blocked"
+        agentName="CodexCoder"
+        blockers={[
+          {
+            id: "blocker-1",
+            identifier: "PAP-500",
+            title: "Server work in flight",
+            status: "in_progress",
+            priority: "medium",
+            assigneeAgentId: "agent-1",
+            assigneeUserId: null,
+          },
+        ]}
+      />,
+    );
+
+    expect(node.textContent).toContain("A message won’t move this back to todo yet");
+    expect(node.textContent).toContain("Comments still wake CodexCoder");
+    const suppressed = node.querySelector('[data-testid="issue-blocked-notice-reopen-suppressed"]');
+    expect(suppressed).not.toBeNull();
+    expect(suppressed!.textContent).toContain("Still blocked by");
+    expect(suppressed!.textContent).toContain("PAP-500");
+    expect(suppressed!.textContent).toContain("(in progress)");
+    expect(suppressed!.textContent).not.toContain("other task");
+  });
+
+  it("names the deepest unresolved terminal leaf, not the direct blocker (Rule C)", () => {
+    const node = render(
+      <IssueBlockedNotice
+        issueStatus="blocked"
+        blockers={[
+          {
+            id: "blocker-1",
+            identifier: "PAP-600",
+            title: "Waiting in review",
+            status: "in_review",
+            priority: "medium",
+            assigneeAgentId: "agent-1",
+            assigneeUserId: null,
+            terminalBlockers: [
+              {
+                id: "terminal-1",
+                identifier: "PAP-777",
+                title: "Actual work",
+                status: "in_progress",
+                priority: "medium",
+                assigneeAgentId: "agent-2",
+                assigneeUserId: null,
+              },
+            ],
+          },
+        ]}
+      />,
+    );
+
+    const suppressed = node.querySelector('[data-testid="issue-blocked-notice-reopen-suppressed"]');
+    expect(suppressed).not.toBeNull();
+    expect(suppressed!.textContent).toContain("PAP-777");
+    expect(suppressed!.textContent).toContain("(in progress)");
+    expect(suppressed!.textContent).not.toContain("PAP-600");
+  });
+
+  it("summarizes the count when several blockers keep a comment from reopening (Rule C)", () => {
+    const node = render(
+      <IssueBlockedNotice
+        issueStatus="blocked"
+        blockers={[
+          {
+            id: "blocker-1",
+            identifier: "PAP-501",
+            title: "First",
+            status: "in_progress",
+            priority: "medium",
+            assigneeAgentId: "agent-1",
+            assigneeUserId: null,
+          },
+          {
+            id: "blocker-2",
+            identifier: "PAP-502",
+            title: "Second",
+            status: "todo",
+            priority: "medium",
+            assigneeAgentId: "agent-1",
+            assigneeUserId: null,
+          },
+        ]}
+      />,
+    );
+
+    const suppressed = node.querySelector('[data-testid="issue-blocked-notice-reopen-suppressed"]');
+    expect(suppressed).not.toBeNull();
+    expect(suppressed!.textContent).toContain("and 1 other task");
+  });
+
+  it("does not claim a message won't reopen when a blocked issue has no unresolved blockers (Rule B path)", () => {
+    const node = render(<IssueBlockedNotice issueStatus="blocked" blockers={[]} />);
+
+    expect(node.textContent).toContain("Work on this task is blocked until it is moved back to todo");
+    expect(node.textContent).not.toContain("A message won’t move this back to todo yet");
+    expect(node.querySelector('[data-testid="issue-blocked-notice-reopen-suppressed"]')).toBeNull();
   });
 
   it("shows external now-running blockers beneath the label on a separate line", () => {

--- a/ui/src/components/IssueBlockedNotice.tsx
+++ b/ui/src/components/IssueBlockedNotice.tsx
@@ -432,6 +432,43 @@ export function IssueBlockedNotice({
   })();
   const showStalledRow = isStalled && stalledLeafBlockers.length > 0;
 
+  // Rule C (PAP-13554 / plan §Rule C): when the issue is `blocked` and a
+  // blocker edge is genuinely not done, a human comment does NOT reopen it —
+  // the reopen gate keeps it blocked. `blockers` here is the *unresolved* set
+  // (status ≠ done/cancelled), so a non-empty list on a `blocked` issue is
+  // exactly the case the human's message can't move to todo. Done-but-pending-
+  // finalize blockers are `done`, so they fall out of this set and into the
+  // Rule B reopen path — we must not claim "a message won't reopen" for those.
+  // Name the deepest unresolved leaf (prefer terminal leaves) with its status
+  // so "I sent a message and nothing happened" can't recur silently.
+  const responsibleName = agentName ?? "the responsible agent";
+  const reopenSuppressed = issueStatus === "blocked" && !isStalled && blockers.length > 0;
+  const unresolvedLeafBlockers = (() => {
+    if (!reopenSuppressed) return [] as IssueRelationIssueSummary[];
+    const seen = new Set<string>();
+    const collected: IssueRelationIssueSummary[] = [];
+    for (const blocker of blockers) {
+      const terminals = (blocker.terminalBlockers ?? []).filter(
+        (leaf) => leaf.status !== "done" && leaf.status !== "cancelled",
+      );
+      const leaves = terminals.length > 0 ? terminals : [blocker];
+      for (const leaf of leaves) {
+        if (seen.has(leaf.id)) continue;
+        seen.add(leaf.id);
+        collected.push(leaf);
+      }
+    }
+    return collected;
+  })();
+  const reopenSuppressedLeaf = unresolvedLeafBlockers[0] ?? null;
+  const reopenSuppressedLeafId = reopenSuppressedLeaf
+    ? reopenSuppressedLeaf.identifier ?? reopenSuppressedLeaf.id.slice(0, 8)
+    : null;
+  const reopenSuppressedLeafStatus = reopenSuppressedLeaf
+    ? reopenSuppressedLeaf.status.replace(/_/g, " ")
+    : null;
+  const reopenSuppressedOtherCount = Math.max(unresolvedLeafBlockers.length - 1, 0);
+
   const renderBlockerChip = (blocker: IssueRelationIssueSummary) => {
     const issuePathId = blocker.identifier ?? blocker.id;
     const recoveryAction = blocker.activeRecoveryAction ?? null;
@@ -546,9 +583,27 @@ export function IssueBlockedNotice({
                     ? stalledLeafBlockers.length > 1
                       ? <>Work on this task is blocked by {blockerLabel}, but the chain is stalled in review without a clear next step. Resolve the stalled reviews below or remove them as blockers.</>
                       : <>Work on this task is blocked by {blockerLabel}, but the chain is stalled in review without a clear next step. Resolve the stalled review below or remove it as a blocker.</>
-                    : <>Work on this task is blocked by {blockerLabel} until {blockers.length === 1 ? "it is" : "they are"} complete. Comments still wake the responsible for questions or triage.</>
+                    : reopenSuppressed
+                      ? <>A message won&rsquo;t move this back to todo yet — it stays blocked by {blockerLabel} until {blockers.length === 1 ? "it is" : "they are"} done, then it reopens automatically. Comments still wake {responsibleName} for questions or triage in the meantime.</>
+                      : <>Work on this task is blocked by {blockerLabel} until {blockers.length === 1 ? "it is" : "they are"} complete. Comments still wake the responsible for questions or triage.</>
                   : <>Work on this task is blocked until it is moved back to todo. Comments still wake the responsible for questions or triage.</>}
               </p>
+              {reopenSuppressed && reopenSuppressedLeafId ? (
+                <p
+                  data-testid="issue-blocked-notice-reopen-suppressed"
+                  className="text-xs font-medium leading-5 text-amber-900 dark:text-amber-100"
+                >
+                  Still blocked by{" "}
+                  <span className="font-mono">{reopenSuppressedLeafId}</span>
+                  {reopenSuppressedLeafStatus ? <> ({reopenSuppressedLeafStatus})</> : null}
+                  {reopenSuppressedOtherCount > 0
+                    ? ` and ${reopenSuppressedOtherCount} other ${
+                        reopenSuppressedOtherCount === 1 ? "task" : "tasks"
+                      }`
+                    : null}
+                  .
+                </p>
+              ) : null}
               {blockers.length > 0 ? (
                 <div className="flex flex-wrap gap-1.5">
                   {blockers.map(renderBlockerChip)}

--- a/ui/storybook/stories/issue-blocked-notice.stories.tsx
+++ b/ui/storybook/stories/issue-blocked-notice.stories.tsx
@@ -1,0 +1,138 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { IssueRelationIssueSummary } from "@paperclipai/shared";
+import { IssueBlockedNotice } from "@/components/IssueBlockedNotice";
+
+// Rule C (PAP-13554): when a human comment on a `blocked` issue does not reopen
+// it, the blocked notice must state why and name the unresolved blocker leaf.
+// These stories exercise the reopen-suppressed copy and its neighbours so the
+// notice copy can be reviewed at a glance.
+
+function blocker(
+  overrides: Partial<IssueRelationIssueSummary> & Pick<IssueRelationIssueSummary, "id" | "identifier" | "title" | "status">,
+): IssueRelationIssueSummary {
+  return {
+    priority: "medium",
+    assigneeAgentId: "agent-1",
+    assigneeUserId: null,
+    ...overrides,
+  } as IssueRelationIssueSummary;
+}
+
+function Frame({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="mx-auto max-w-[640px] space-y-2 p-6">
+      <div className="text-xs uppercase tracking-wide text-muted-foreground">{label}</div>
+      {children}
+    </div>
+  );
+}
+
+const meta = {
+  title: "Product/Issue/Blocked notice",
+  component: IssueBlockedNotice,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Blocked/recovery notice on the issue thread. Rule C: a `blocked` issue with a genuinely unresolved (not-done) blocker tells the human that a message won't reopen it yet and names the unresolved leaf with its status. Done-but-pending-finalize blockers are `done`, so they fall into the Rule B reopen path and are NOT shown as reopen-suppressed.",
+      },
+    },
+  },
+} satisfies Meta<typeof IssueBlockedNotice>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const RuleCSingleBlocker: Story = {
+  name: "Rule C · single unresolved blocker",
+  render: () => (
+    <Frame label="Blocked · one in-progress blocker — a message won't reopen it yet">
+      <IssueBlockedNotice
+        issueId="issue-1"
+        issueStatus="blocked"
+        agentName="CodexCoder"
+        blockers={[
+          blocker({
+            id: "b1",
+            identifier: "PAP-500",
+            title: "Server work still in flight",
+            status: "in_progress",
+          }),
+        ]}
+      />
+    </Frame>
+  ),
+};
+
+export const RuleCChainNamesLeaf: Story = {
+  name: "Rule C · chain names the deepest leaf",
+  render: () => (
+    <Frame label="Blocked · direct blocker in review, ultimately waiting on an in-progress leaf">
+      <IssueBlockedNotice
+        issueId="issue-2"
+        issueStatus="blocked"
+        agentName="CodexCoder"
+        blockers={[
+          blocker({
+            id: "b1",
+            identifier: "PAP-600",
+            title: "Waiting in review",
+            status: "in_review",
+            terminalBlockers: [
+              blocker({
+                id: "t1",
+                identifier: "PAP-777",
+                title: "Actual work",
+                status: "in_progress",
+                assigneeAgentId: "agent-2",
+              }),
+            ],
+          }),
+        ]}
+      />
+    </Frame>
+  ),
+};
+
+export const RuleCMultipleBlockers: Story = {
+  name: "Rule C · several unresolved blockers",
+  render: () => (
+    <Frame label="Blocked · two unresolved blockers — count is summarized">
+      <IssueBlockedNotice
+        issueId="issue-3"
+        issueStatus="blocked"
+        agentName="CodexCoder"
+        blockers={[
+          blocker({ id: "b1", identifier: "PAP-501", title: "First dependency", status: "in_progress" }),
+          blocker({ id: "b2", identifier: "PAP-502", title: "Second dependency", status: "todo" }),
+        ]}
+      />
+    </Frame>
+  ),
+};
+
+export const BlockedNoUnresolvedBlockers: Story = {
+  name: "Rule B path · blocked, no unresolved blockers",
+  render: () => (
+    <Frame label="Blocked · all blocker edges done/absent — a message WILL move it back to todo">
+      <IssueBlockedNotice issueId="issue-4" issueStatus="blocked" agentName="CodexCoder" blockers={[]} />
+    </Frame>
+  ),
+};
+
+export const InProgressWithBlocker: Story = {
+  name: "In progress · blocker edge (not a reopen case)",
+  render: () => (
+    <Frame label="In progress · has a blocker edge — no reopen framing">
+      <IssueBlockedNotice
+        issueId="issue-5"
+        issueStatus="in_progress"
+        agentName="CodexCoder"
+        blockers={[
+          blocker({ id: "b1", identifier: "PAP-800", title: "Dependency", status: "in_progress" }),
+        ]}
+      />
+    </Frame>
+  ),
+};

--- a/ui/storybook/stories/issue-blocked-notice.stories.tsx
+++ b/ui/storybook/stories/issue-blocked-notice.stories.tsx
@@ -30,6 +30,9 @@ function Frame({ label, children }: { label: string; children: React.ReactNode }
 const meta = {
   title: "Product/Issue/Blocked notice",
   component: IssueBlockedNotice,
+  // Each story supplies its own props via `render`; this default satisfies the
+  // component's one required prop (`blockers`) so the story args type-checks.
+  args: { blockers: [] },
   parameters: {
     docs: {
       description: {


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - When an agent's task is `blocked`, humans often comment on the issue thread expecting it to reopen and resume
> - If the issue stays `blocked` because an unresolved (not-done) blocker still gates the reopen path, the UI said nothing — the human "sent a message and nothing happened" (a real silent-failure report)
> - That silence makes the product feel broken even though the gate is working as designed
> - This pull request adds Rule C copy to the existing `IssueBlockedNotice` surface: when a comment won't reopen a blocked issue, it explains why and names the deepest unresolved blocker leaf with its status
> - The benefit is that the human immediately understands the task is *paused, not stuck*, and knows exactly which task to act on to unblock it

## Linked Issues or Issue Description

<!-- No public GitHub issue — describing the underlying problem inline (path B), following the feature issue template. -->

**Problem or motivation**

A human comments on a `blocked` issue expecting it to move back to `todo` and resume. When the reopen gate keeps it blocked because an unresolved (not-`done`) blocker remains, nothing in the UI communicates this, so the user perceives a dropped message ("I sent a message and nothing happened").

**Proposed solution**

Reuse the existing amber `IssueBlockedNotice` surface (the designated blocked/recovery surface — no new component). When a message won't reopen a blocked issue, the notice states that it won't reopen yet, names the unresolved blocker leaf with its status (e.g. "Still blocked by PAP-XXXXX (in progress)"), and reassures that it reopens automatically once the blocker is done. UI-only; no server change.

**Alternatives considered**

Adding a server signal (a reopen-suppressed reason on the comment/notice payload) was considered but rejected as unnecessary — the unresolved-blocker set is already available client-side, so the copy is derived in the component. Done-but-pending-finalize blockers are `done`, so they fall out of the unresolved set into the standard reopen (Rule B) path and are correctly not shown as reopen-suppressed.

## What Changed

- `ui/src/components/IssueBlockedNotice.tsx`: added reopen-suppressed messaging for `blocked` issues that still have unresolved blockers — a lead sentence ("a message won't reopen it yet, then it reopens automatically"), the named unresolved blocker leaf with its status, and an "and N other task(s)" summarization when multiple blockers remain.
- `ui/src/components/IssueBlockedNotice.test.tsx`: added/updated tests covering the single, nested-chain (deepest-leaf), multiple-blocker, and empty-blocker states, plus the not-a-reopen-case (`in_progress`) path.
- `ui/storybook/stories/issue-blocked-notice.stories.tsx`: new Storybook stories rendering each notice state for copy review.

## Verification

- `cd ui && tsc -b` — typecheck clean (previously failed TS2322 on the story meta; fixed by a default `args`).
- Vitest: `IssueBlockedNotice.test.tsx` green (single / nested / multiple / empty / in-progress states).
- Storybook stories rendered at 1440×900 for all four states; screenshots posted on the tracking issue.
- UXDesigner reviewed the notice copy and signed off (no copy edits required).

## Risks

Low risk. UI-only, additive copy on an already-shipped amber notice surface; no server or schema changes. The reopen behavior itself is unchanged — this only explains the existing gate. Worst case is copy wording, which had a design review.

## Model Used

Claude — claude-opus-4-8 (Opus 4.8), extended thinking, with tool use / code execution in the Paperclip harness.

---

- [x] I searched the GitHub PR list for similar/duplicate PRs before opening this one.
