### PR TITLE
fix(issues): reopen done blockers pending finalize

### DIFF
--- a/server/src/__tests__/issue-comment-reopen-routes.test.ts
+++ b/server/src/__tests__/issue-comment-reopen-routes.test.ts
@@ -853,6 +853,56 @@ describe.sequential("issue comment reopen routes", () => {
     ));
   });
 
+  it("moves blocked issues to todo via POST human comments when all blocker edges are done but finalize is pending", async () => {
+    mockIssueService.getById.mockResolvedValue(makeIssue("blocked"));
+    mockIssueService.getDependencyReadiness.mockResolvedValue({
+      issueId: "11111111-1111-4111-8111-111111111111",
+      blockerIssueIds: ["33333333-3333-4333-8333-333333333333"],
+      unresolvedBlockerIssueIds: ["33333333-3333-4333-8333-333333333333"],
+      unresolvedBlockerCount: 1,
+      allBlockersDone: true,
+      isDependencyReady: false,
+    });
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
+      ...makeIssue("blocked"),
+      ...patch,
+    }));
+
+    const res = await request(await installActor(createApp()))
+      .post("/api/issues/11111111-1111-4111-8111-111111111111/comments")
+      .send({ body: "please continue" });
+
+    expect(res.status).toBe(201);
+    expect(mockIssueService.update).toHaveBeenCalledWith(
+      "11111111-1111-4111-8111-111111111111",
+      { status: "todo" },
+    );
+  });
+
+  it("does not move blocked issues to todo via POST agent comments when all blocker edges are done but finalize is pending", async () => {
+    const issue = makeIssue("blocked");
+    mockIssueService.getById.mockResolvedValue(issue);
+    mockIssueService.getDependencyReadiness.mockResolvedValue({
+      issueId: issue.id,
+      blockerIssueIds: ["33333333-3333-4333-8333-333333333333"],
+      unresolvedBlockerIssueIds: ["33333333-3333-4333-8333-333333333333"],
+      unresolvedBlockerCount: 1,
+      allBlockersDone: true,
+      isDependencyReady: false,
+    });
+
+    const res = await request(await installActor(createApp(), agentActor()))
+      .post("/api/issues/11111111-1111-4111-8111-111111111111/comments")
+      .send({ body: "agent progress update" });
+
+    expect(res.status).toBe(201);
+    expect(mockIssueService.update).not.toHaveBeenCalledWith(
+      "11111111-1111-4111-8111-111111111111",
+      expect.objectContaining({ status: "todo" }),
+    );
+    expect(mockIssueService.getDependencyReadiness).not.toHaveBeenCalled();
+  });
+
   it("moves in-progress issues with a scheduled retry back to todo via POST human comments", async () => {
     const issue = {
       ...makeIssue("in_progress"),
@@ -1246,6 +1296,32 @@ describe.sequential("issue comment reopen routes", () => {
         }),
       }),
     ));
+  });
+
+  it("moves blocked issues to todo via PATCH human comments when all blocker edges are done but finalize is pending", async () => {
+    mockIssueService.getById.mockResolvedValue(makeIssue("blocked"));
+    mockIssueService.getDependencyReadiness.mockResolvedValue({
+      issueId: "11111111-1111-4111-8111-111111111111",
+      blockerIssueIds: ["33333333-3333-4333-8333-333333333333"],
+      unresolvedBlockerIssueIds: ["33333333-3333-4333-8333-333333333333"],
+      unresolvedBlockerCount: 1,
+      allBlockersDone: true,
+      isDependencyReady: false,
+    });
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
+      ...makeIssue("blocked"),
+      ...patch,
+    }));
+
+    const res = await request(await installActor(createApp()))
+      .patch("/api/issues/11111111-1111-4111-8111-111111111111")
+      .send({ comment: "please continue" });
+
+    expect(res.status).toBe(200);
+    expect(mockIssueService.update).toHaveBeenCalledWith(
+      "11111111-1111-4111-8111-111111111111",
+      expect.objectContaining({ status: "todo" }),
+    );
   });
 
   it("moves in-progress issues with a scheduled retry back to todo via the PATCH comment path", async () => {

--- a/server/src/__tests__/issue-comment-reopen-routes.test.ts
+++ b/server/src/__tests__/issue-comment-reopen-routes.test.ts
@@ -903,6 +903,28 @@ describe.sequential("issue comment reopen routes", () => {
     expect(mockIssueService.getDependencyReadiness).not.toHaveBeenCalled();
   });
 
+  it("keeps the finalize barrier for explicit POST reopen requests that also include a human comment", async () => {
+    mockIssueService.getById.mockResolvedValue(makeIssue("blocked"));
+    mockIssueService.getDependencyReadiness.mockResolvedValue({
+      issueId: "11111111-1111-4111-8111-111111111111",
+      blockerIssueIds: ["33333333-3333-4333-8333-333333333333"],
+      unresolvedBlockerIssueIds: ["33333333-3333-4333-8333-333333333333"],
+      unresolvedBlockerCount: 1,
+      allBlockersDone: true,
+      isDependencyReady: false,
+    });
+
+    const res = await request(await installActor(createApp()))
+      .post("/api/issues/11111111-1111-4111-8111-111111111111/comments")
+      .send({ body: "please continue", reopen: true });
+
+    expect(res.status).toBe(201);
+    expect(mockIssueService.update).not.toHaveBeenCalledWith(
+      "11111111-1111-4111-8111-111111111111",
+      expect.objectContaining({ status: "todo" }),
+    );
+  });
+
   it("moves in-progress issues with a scheduled retry back to todo via POST human comments", async () => {
     const issue = {
       ...makeIssue("in_progress"),
@@ -1322,6 +1344,26 @@ describe.sequential("issue comment reopen routes", () => {
       "11111111-1111-4111-8111-111111111111",
       expect.objectContaining({ status: "todo" }),
     );
+  });
+
+  it("keeps the finalize barrier for explicit PATCH resume requests that also include a human comment", async () => {
+    mockIssueService.getById.mockResolvedValue(makeIssue("blocked"));
+    mockIssueService.getDependencyReadiness.mockResolvedValue({
+      issueId: "11111111-1111-4111-8111-111111111111",
+      blockerIssueIds: ["33333333-3333-4333-8333-333333333333"],
+      unresolvedBlockerIssueIds: ["33333333-3333-4333-8333-333333333333"],
+      unresolvedBlockerCount: 1,
+      allBlockersDone: true,
+      isDependencyReady: false,
+    });
+
+    const res = await request(await installActor(createApp()))
+      .patch("/api/issues/11111111-1111-4111-8111-111111111111")
+      .send({ comment: "please continue", resume: true });
+
+    expect(res.status).toBe(409);
+    expect(res.body.error).toBe("Issue follow-up blocked by unresolved blockers");
+    expect(mockIssueService.update).not.toHaveBeenCalled();
   });
 
   it("moves in-progress issues with a scheduled retry back to todo via the PATCH comment path", async () => {

--- a/server/src/__tests__/issue-comment-reopen-routes.test.ts
+++ b/server/src/__tests__/issue-comment-reopen-routes.test.ts
@@ -860,6 +860,7 @@ describe.sequential("issue comment reopen routes", () => {
       blockerIssueIds: ["33333333-3333-4333-8333-333333333333"],
       unresolvedBlockerIssueIds: ["33333333-3333-4333-8333-333333333333"],
       unresolvedBlockerCount: 1,
+      pendingFinalizeBlockerIssueIds: ["33333333-3333-4333-8333-333333333333"],
       allBlockersDone: true,
       isDependencyReady: false,
     });
@@ -887,6 +888,7 @@ describe.sequential("issue comment reopen routes", () => {
       blockerIssueIds: ["33333333-3333-4333-8333-333333333333"],
       unresolvedBlockerIssueIds: ["33333333-3333-4333-8333-333333333333"],
       unresolvedBlockerCount: 1,
+      pendingFinalizeBlockerIssueIds: ["33333333-3333-4333-8333-333333333333"],
       allBlockersDone: true,
       isDependencyReady: false,
     });
@@ -910,6 +912,7 @@ describe.sequential("issue comment reopen routes", () => {
       blockerIssueIds: ["33333333-3333-4333-8333-333333333333"],
       unresolvedBlockerIssueIds: ["33333333-3333-4333-8333-333333333333"],
       unresolvedBlockerCount: 1,
+      pendingFinalizeBlockerIssueIds: ["33333333-3333-4333-8333-333333333333"],
       allBlockersDone: true,
       isDependencyReady: false,
     });
@@ -1327,6 +1330,7 @@ describe.sequential("issue comment reopen routes", () => {
       blockerIssueIds: ["33333333-3333-4333-8333-333333333333"],
       unresolvedBlockerIssueIds: ["33333333-3333-4333-8333-333333333333"],
       unresolvedBlockerCount: 1,
+      pendingFinalizeBlockerIssueIds: ["33333333-3333-4333-8333-333333333333"],
       allBlockersDone: true,
       isDependencyReady: false,
     });

--- a/server/src/__tests__/issue-comment-reopen-service-routes.test.ts
+++ b/server/src/__tests__/issue-comment-reopen-service-routes.test.ts
@@ -1,0 +1,251 @@
+import { randomUUID } from "node:crypto";
+import express from "express";
+import request from "supertest";
+import { eq } from "drizzle-orm";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import {
+  activityLog,
+  agents,
+  companies,
+  companyMemberships,
+  createDb,
+  executionWorkspaces,
+  issueComments,
+  issueRelations,
+  issues,
+  principalPermissionGrants,
+  projects,
+  workspaceOperations,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import { errorHandler } from "../middleware/index.js";
+import { ensureHumanRoleDefaultGrants } from "../services/principal-access-compatibility.js";
+
+const mockHeartbeatService = vi.hoisted(() => ({
+  wakeup: vi.fn(async () => undefined),
+  reportRunActivity: vi.fn(async () => undefined),
+  getRun: vi.fn(async () => null),
+  getActiveRunForAgent: vi.fn(async () => null),
+  cancelRun: vi.fn(async () => null),
+}));
+
+vi.mock("../services/index.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../services/index.js")>();
+  return {
+    ...actual,
+    heartbeatService: () => mockHeartbeatService,
+  };
+});
+
+const { issueRoutes } = await import("../routes/issues.js");
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping embedded Postgres issue comment reopen route tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+describeEmbeddedPostgres.sequential("issue comment reopen routes with issueService", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-issue-comment-reopen-routes-");
+    db = createDb(tempDb.connectionString);
+  }, 20_000);
+
+  afterEach(async () => {
+    vi.clearAllMocks();
+    await db.delete(activityLog);
+    await db.delete(issueComments);
+    await db.delete(workspaceOperations);
+    await db.delete(issueRelations);
+    await db.delete(issues);
+    await db.delete(executionWorkspaces);
+    await db.delete(projects);
+    await db.delete(principalPermissionGrants);
+    await db.delete(companyMemberships);
+    await db.delete(agents);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  function createApp(companyId: string, actor?: Record<string, unknown>) {
+    const app = express();
+    app.use(express.json());
+    app.use((req, _res, next) => {
+      (req as any).actor = actor ?? {
+        type: "board",
+        userId: "cloud-user-1",
+        companyIds: [companyId],
+        memberships: [{ companyId, membershipRole: "owner", status: "active" }],
+        source: "cloud_tenant",
+        isInstanceAdmin: false,
+      };
+      next();
+    });
+    app.use("/api", issueRoutes(db, {} as any, { taskWatchdogEnqueueWakeup: null }));
+    app.use(errorHandler);
+    return app;
+  }
+
+  async function seedScenario(blockerStatus: "done" | "in_progress") {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const projectId = randomUUID();
+    const blockerIssueId = randomUUID();
+    const dependentIssueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `R${randomUUID().replace(/-/g, "").slice(0, 5).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(companyMemberships).values({
+      companyId,
+      principalType: "user",
+      principalId: "cloud-user-1",
+      status: "active",
+      membershipRole: "owner",
+      updatedAt: new Date(),
+    });
+    await ensureHumanRoleDefaultGrants(db, {
+      companyId,
+      principalId: "cloud-user-1",
+      membershipRole: "owner",
+      grantedByUserId: null,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Assigned Agent",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    await db.insert(projects).values({ id: projectId, companyId, name: "Rule B" });
+    await db.insert(issues).values([
+      {
+        id: blockerIssueId,
+        companyId,
+        projectId,
+        title: "Blocker",
+        identifier: "RLB-1",
+        issueNumber: 1,
+        status: blockerStatus,
+        assigneeAgentId: agentId,
+      },
+      {
+        id: dependentIssueId,
+        companyId,
+        projectId,
+        title: "Dependent",
+        identifier: "RLB-2",
+        issueNumber: 2,
+        status: "blocked",
+        assigneeAgentId: agentId,
+      },
+    ]);
+    await db.insert(issueRelations).values({
+      companyId,
+      issueId: blockerIssueId,
+      relatedIssueId: dependentIssueId,
+      type: "blocks",
+      createdByUserId: "cloud-user-1",
+    });
+
+    if (blockerStatus === "done") {
+      const executionWorkspaceId = randomUUID();
+      await db.insert(executionWorkspaces).values({
+        id: executionWorkspaceId,
+        companyId,
+        projectId,
+        sourceIssueId: blockerIssueId,
+        mode: "isolated",
+        strategyType: "git_worktree",
+        name: "rule-b-blocker",
+      });
+      await db.update(issues).set({ executionWorkspaceId }).where(eq(issues.id, blockerIssueId));
+      await db.insert(workspaceOperations).values({
+        companyId,
+        executionWorkspaceId,
+        issueId: blockerIssueId,
+        phase: "adapter_execute",
+        status: "succeeded",
+        finishedAt: new Date(),
+      });
+    }
+
+    return { agentId, companyId, dependentIssueId };
+  }
+
+  it("reopens a blocked issue when every blocker edge is done but finalize is pending", async () => {
+    const { agentId, companyId, dependentIssueId } = await seedScenario("done");
+
+    const response = await request(createApp(companyId))
+      .post(`/api/issues/${dependentIssueId}/comments`)
+      .send({ body: "Please continue." });
+
+    expect(response.status).toBe(201);
+    await expect(db.select({ status: issues.status }).from(issues).where(eq(issues.id, dependentIssueId)))
+      .resolves.toEqual([{ status: "todo" }]);
+    await vi.waitFor(() => expect(mockHeartbeatService.wakeup).toHaveBeenCalledWith(
+      agentId,
+      expect.objectContaining({
+        reason: "issue_reopened_via_comment",
+        payload: expect.objectContaining({ issueId: dependentIssueId, reopenedFrom: "blocked" }),
+      }),
+    ));
+  });
+
+  it("does not reopen a blocked issue for an agent comment", async () => {
+    const { agentId, companyId, dependentIssueId } = await seedScenario("done");
+
+    const response = await request(createApp(companyId, {
+      type: "agent",
+      agentId,
+      companyId,
+      source: "agent_key",
+      runId: null,
+    }))
+      .post(`/api/issues/${dependentIssueId}/comments`)
+      .send({ body: "Agent progress update." });
+
+    expect(response.status).toBe(201);
+    await expect(db.select({ status: issues.status }).from(issues).where(eq(issues.id, dependentIssueId)))
+      .resolves.toEqual([{ status: "blocked" }]);
+    expect(mockHeartbeatService.wakeup).not.toHaveBeenCalledWith(
+      agentId,
+      expect.objectContaining({ reason: "issue_reopened_via_comment" }),
+    );
+  });
+
+  it("keeps a blocked issue blocked when a blocker edge is unresolved", async () => {
+    const { agentId, companyId, dependentIssueId } = await seedScenario("in_progress");
+
+    const response = await request(createApp(companyId))
+      .post(`/api/issues/${dependentIssueId}/comments`)
+      .send({ body: "Can this continue?" });
+
+    expect(response.status).toBe(201);
+    await expect(db.select({ status: issues.status }).from(issues).where(eq(issues.id, dependentIssueId)))
+      .resolves.toEqual([{ status: "blocked" }]);
+    await vi.waitFor(() => expect(mockHeartbeatService.wakeup).toHaveBeenCalledWith(
+      agentId,
+      expect.objectContaining({ reason: "issue_commented" }),
+    ));
+  });
+});

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -1760,9 +1760,9 @@ function shouldImplicitlyMoveCommentedIssueToTodo(input: {
 function hasUnresolvedBlockersForCommentMove(input: {
   allBlockersDone: boolean;
   unresolvedBlockerCount: number;
-  implicitHumanCommentMoveRequested: boolean;
+  relaxFinalizeBarrierForHumanComment: boolean;
 }) {
-  return input.implicitHumanCommentMoveRequested
+  return input.relaxFinalizeBarrierForHumanComment
     ? !input.allBlockersDone
     : input.unresolvedBlockerCount > 0;
 }
@@ -7782,6 +7782,8 @@ export function issueRoutes(
       (explicitMoveToTodoRequested ||
         implicitHumanCommentMoveRequested ||
         shouldResumeInProgressScheduledRetry);
+    const relaxFinalizeBarrierForHumanComment =
+      implicitHumanCommentMoveRequested && !explicitMoveToTodoRequested;
     const updateReferenceSummaryBefore = titleOrDescriptionChanged
       ? await issueReferencesSvc.listIssueReferenceSummary(existing.id)
       : null;
@@ -7793,7 +7795,7 @@ export function issueRoutes(
       ? hasUnresolvedBlockersForCommentMove({
           allBlockersDone: dependencyReadiness.allBlockersDone,
           unresolvedBlockerCount: dependencyReadiness.unresolvedBlockerCount,
-          implicitHumanCommentMoveRequested,
+          relaxFinalizeBarrierForHumanComment,
         })
       : false;
     if (resumeRequested === true && isBlocked && hasUnresolvedFirstClassBlockers) {
@@ -9971,6 +9973,8 @@ export function issueRoutes(
       (explicitMoveToTodoRequested ||
         implicitHumanCommentMoveRequested ||
         shouldResumeInProgressScheduledRetry);
+    const relaxFinalizeBarrierForHumanComment =
+      implicitHumanCommentMoveRequested && !explicitMoveToTodoRequested;
     const dependencyReadiness =
       isBlocked && effectiveMoveToTodoRequested
         ? await svc.getDependencyReadiness(issue.id)
@@ -9979,7 +9983,7 @@ export function issueRoutes(
       ? hasUnresolvedBlockersForCommentMove({
           allBlockersDone: dependencyReadiness.allBlockersDone,
           unresolvedBlockerCount: dependencyReadiness.unresolvedBlockerCount,
-          implicitHumanCommentMoveRequested,
+          relaxFinalizeBarrierForHumanComment,
         })
       : false;
     if (resumeRequested === true && isBlocked && hasUnresolvedFirstClassBlockers) {

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -1758,13 +1758,19 @@ function shouldImplicitlyMoveCommentedIssueToTodo(input: {
 }
 
 function hasUnresolvedBlockersForCommentMove(input: {
-  allBlockersDone: boolean;
+  unresolvedBlockerIssueIds: string[];
   unresolvedBlockerCount: number;
+  pendingFinalizeBlockerIssueIds: string[];
   relaxFinalizeBarrierForHumanComment: boolean;
 }) {
-  return input.relaxFinalizeBarrierForHumanComment
-    ? !input.allBlockersDone
-    : input.unresolvedBlockerCount > 0;
+  if (!input.relaxFinalizeBarrierForHumanComment) {
+    return input.unresolvedBlockerCount > 0;
+  }
+
+  const pendingFinalizeBlockerIssueIds = new Set(input.pendingFinalizeBlockerIssueIds);
+  return input.unresolvedBlockerIssueIds.some(
+    (blockerIssueId) => !pendingFinalizeBlockerIssueIds.has(blockerIssueId),
+  );
 }
 
 function shouldHumanCommentResumeInProgressScheduledRetry(input: {
@@ -7793,8 +7799,9 @@ export function issueRoutes(
         : null;
     const hasUnresolvedFirstClassBlockers = dependencyReadiness
       ? hasUnresolvedBlockersForCommentMove({
-          allBlockersDone: dependencyReadiness.allBlockersDone,
+          unresolvedBlockerIssueIds: dependencyReadiness.unresolvedBlockerIssueIds,
           unresolvedBlockerCount: dependencyReadiness.unresolvedBlockerCount,
+          pendingFinalizeBlockerIssueIds: dependencyReadiness.pendingFinalizeBlockerIssueIds,
           relaxFinalizeBarrierForHumanComment,
         })
       : false;
@@ -9981,8 +9988,9 @@ export function issueRoutes(
         : null;
     const hasUnresolvedFirstClassBlockers = dependencyReadiness
       ? hasUnresolvedBlockersForCommentMove({
-          allBlockersDone: dependencyReadiness.allBlockersDone,
+          unresolvedBlockerIssueIds: dependencyReadiness.unresolvedBlockerIssueIds,
           unresolvedBlockerCount: dependencyReadiness.unresolvedBlockerCount,
+          pendingFinalizeBlockerIssueIds: dependencyReadiness.pendingFinalizeBlockerIssueIds,
           relaxFinalizeBarrierForHumanComment,
         })
       : false;

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -1757,6 +1757,16 @@ function shouldImplicitlyMoveCommentedIssueToTodo(input: {
   return true;
 }
 
+function hasUnresolvedBlockersForCommentMove(input: {
+  allBlockersDone: boolean;
+  unresolvedBlockerCount: number;
+  implicitHumanCommentMoveRequested: boolean;
+}) {
+  return input.implicitHumanCommentMoveRequested
+    ? !input.allBlockersDone
+    : input.unresolvedBlockerCount > 0;
+}
+
 function shouldHumanCommentResumeInProgressScheduledRetry(input: {
   hasComment: boolean;
   issueStatus: string | null | undefined;
@@ -7756,27 +7766,36 @@ export function issueRoutes(
       actorType: actor.actorType,
       actorId: actor.actorId,
     });
+    const implicitHumanCommentMoveRequested =
+      !!commentBody &&
+      shouldImplicitlyMoveCommentedIssueToTodo({
+        issueStatus: existing.status,
+        assigneeAgentId: requestedAssigneeAgentId,
+        actorType: actor.actorType,
+        actorId: actor.actorId,
+        actorRunId: actor.runId,
+        checkoutRunId: existing.checkoutRunId,
+        executionRunId: existing.executionRunId,
+      });
     const effectiveMoveToTodoRequested =
       !assigneeSelfCommentOnTerminal &&
       (explicitMoveToTodoRequested ||
-        (!!commentBody &&
-          shouldImplicitlyMoveCommentedIssueToTodo({
-            issueStatus: existing.status,
-            assigneeAgentId: requestedAssigneeAgentId,
-            actorType: actor.actorType,
-            actorId: actor.actorId,
-            actorRunId: actor.runId,
-            checkoutRunId: existing.checkoutRunId,
-            executionRunId: existing.executionRunId,
-          })) ||
+        implicitHumanCommentMoveRequested ||
         shouldResumeInProgressScheduledRetry);
     const updateReferenceSummaryBefore = titleOrDescriptionChanged
       ? await issueReferencesSvc.listIssueReferenceSummary(existing.id)
       : null;
-    const hasUnresolvedFirstClassBlockers =
+    const dependencyReadiness =
       isBlocked && effectiveMoveToTodoRequested
-        ? (await svc.getDependencyReadiness(existing.id)).unresolvedBlockerCount > 0
-        : false;
+        ? await svc.getDependencyReadiness(existing.id)
+        : null;
+    const hasUnresolvedFirstClassBlockers = dependencyReadiness
+      ? hasUnresolvedBlockersForCommentMove({
+          allBlockersDone: dependencyReadiness.allBlockersDone,
+          unresolvedBlockerCount: dependencyReadiness.unresolvedBlockerCount,
+          implicitHumanCommentMoveRequested,
+        })
+      : false;
     if (resumeRequested === true && isBlocked && hasUnresolvedFirstClassBlockers) {
       res.status(409).json({ error: "Issue follow-up blocked by unresolved blockers" });
       return;
@@ -9937,23 +9956,32 @@ export function issueRoutes(
       actorType: actor.actorType,
       actorId: actor.actorId,
     });
+    const implicitHumanCommentMoveRequested =
+      shouldImplicitlyMoveCommentedIssueToTodo({
+        issueStatus: issue.status,
+        assigneeAgentId: issue.assigneeAgentId,
+        actorType: actor.actorType,
+        actorId: actor.actorId,
+        actorRunId: actor.runId,
+        checkoutRunId: issue.checkoutRunId,
+        executionRunId: issue.executionRunId,
+      });
     const effectiveMoveToTodoRequested =
       !assigneeSelfCommentOnTerminal &&
       (explicitMoveToTodoRequested ||
-        shouldImplicitlyMoveCommentedIssueToTodo({
-          issueStatus: issue.status,
-          assigneeAgentId: issue.assigneeAgentId,
-          actorType: actor.actorType,
-          actorId: actor.actorId,
-          actorRunId: actor.runId,
-          checkoutRunId: issue.checkoutRunId,
-          executionRunId: issue.executionRunId,
-        }) ||
+        implicitHumanCommentMoveRequested ||
         shouldResumeInProgressScheduledRetry);
-    const hasUnresolvedFirstClassBlockers =
+    const dependencyReadiness =
       isBlocked && effectiveMoveToTodoRequested
-        ? (await svc.getDependencyReadiness(issue.id)).unresolvedBlockerCount > 0
-        : false;
+        ? await svc.getDependencyReadiness(issue.id)
+        : null;
+    const hasUnresolvedFirstClassBlockers = dependencyReadiness
+      ? hasUnresolvedBlockersForCommentMove({
+          allBlockersDone: dependencyReadiness.allBlockersDone,
+          unresolvedBlockerCount: dependencyReadiness.unresolvedBlockerCount,
+          implicitHumanCommentMoveRequested,
+        })
+      : false;
     if (resumeRequested === true && isBlocked && hasUnresolvedFirstClassBlockers) {
       res.status(409).json({ error: "Issue follow-up blocked by unresolved blockers" });
       return;


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source control plane people use to coordinate AI-agent companies.
> - Issue blocker edges determine when assigned agent work is actionable.
> - Completed blockers intentionally remain behind a workspace-finalize barrier until their runs finish cleanup.
> - Human comments on blocked work represent board intent, while agent comments and explicit dispatch requests must preserve stricter execution safeguards.
> - The prior route fix used `allBlockersDone`, but the real dependency service reports that value as false while a done blocker is pending finalize.
> - This pull request distinguishes literal blocker-edge completion from finalize-gated dispatch readiness and verifies the real service-backed route.
> - The benefit is reliable human reopening without agent self-reopen behavior or bypassing genuinely unresolved blockers.

## Linked Issues or Issue Description

No public GitHub issue exists for this report, so the bug is described inline.

**What happened**

A human commented on an assigned `blocked` issue after every blocker issue had reached `done`, but the issue remained `blocked` when a completed blocker still lacked a successful `workspace_finalize` operation. The mocked route tests passed because they supplied `allBlockersDone: true`, while the real dependency service correctly returned `allBlockersDone: false` for the finalize-gated readiness state.

**Expected behavior**

A human comment should move the assigned issue to `todo` when every literal blocker edge is `done` or no blocker edges exist. A not-done blocker should still keep the issue blocked, agent-authored comments should remain non-reopening activity, and explicit reopen/resume requests should retain the finalize barrier.

**Steps to reproduce**

1. Create an assigned issue blocked by another issue.
2. Mark the blocker `done` while its latest workspace operation has no successful `workspace_finalize`.
3. Add a human comment to the blocked issue through the normal service-backed route.
4. Observe that finalize-gated `allBlockersDone` is false and the issue does not reopen without this fix.

**Version / deployment mode**

Reproduced on the standard server route flow with embedded Postgres; deployment-mode independent.

Related work found during duplicate search:

- #9416 releases finalize barriers held by dead runs.
- #9413 documents finalize-barrier liveness and human reopen semantics.
- #9417 explains genuinely unresolved blocker suppression in the UI.
- #8811 narrows implicit reopen to session-backed actors; this PR preserves its actor/self-reopen boundary.

## What Changed

- Added a comment-move blocker decision that treats pending-finalize blocker IDs as literally completed only for implicit human comment reopening.
- Kept explicit reopen/resume requests on the stricter finalize-aware dependency gate.
- Applied the behavior consistently to POST comment creation and PATCH issue-with-comment routes.
- Added route regressions plus a real embedded-Postgres service-backed suite covering human reopen with missing finalize, agent non-reopen, and genuinely unresolved blockers.

## Verification

- `pnpm exec vitest run server/src/__tests__/issue-comment-reopen-routes.test.ts server/src/__tests__/issue-comment-reopen-service-routes.test.ts` — 80 tests passed.
- Latest-head GitHub Actions `Typecheck + Release Registry` — passed.
- `git diff --check origin/master...HEAD` — passed.

## Risks

- Low risk: the change is isolated to blocked-comment reopen decisions and covered through both route entry points plus the real dependency service.
- The intentional behavior shift allows a human comment to set board state to `todo` before workspace finalize succeeds; checkout and explicit dispatch paths still enforce the existing finalize barrier.
- No schema, migration, API shape, or documentation changes are required.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex, model `gpt-5.5`, with reasoning, tool use, local code execution, focused test verification, Git operations, and GitHub CLI integration. Context-window size is not exposed by this runtime.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge