### PR TITLE
docs: codify workspace coherence Contracts A+B (PAP-13574)

### DIFF
--- a/doc/execution-semantics.md
+++ b/doc/execution-semantics.md
@@ -338,7 +338,30 @@ The state `projectWorkspaceId` plus `executionWorkspaceId` without `projectId` i
 
 Workspace incoherence feeds into the same non-terminal liveness and stranded assigned-work model as a disappeared run. The recovery path should first fail or reject the incoherent wake, then either repair and requeue one bounded continuation for the same assignee or surface an explicit recovery action. It must not leave an agent-owned `in_progress` issue healthy solely because a wake record exists that would invoke the adapter in the wrong cwd, a non-git directory where git is required, an unrelated project workspace, or an unrecoverable missing worktree.
 
-For runtime-created `git_worktree` execution workspaces, branch coherence is part of workspace coherence. The persisted execution workspace branch is the recorded branch for future dispatch. Reusing that workspace must verify that the worktree is still registered and that `HEAD` is on the recorded branch. Successful run finalization must perform the same check before recording `workspace_finalize=succeeded`. If the run switched to a publishing/PR branch without updating the execution workspace record, finalization may auto-restore the recorded branch only when the worktree is clean, still registered, and the recorded branch points at the current `HEAD`; the repair is recorded as a workspace operation before the successful finalize row. If that safe repair cannot be proven, finalization records a failed workspace finalize and the run fails with bounded evidence for the expected and actual branch. A branch change is sanctioned when a control-plane path updates the execution workspace record before finalization, when publishing work happens in a separate worktree and the managed issue worktree remains on its recorded branch, or when the finalizer performs this clean same-commit restoration.
+For runtime-created `git_worktree` execution workspaces, branch coherence is part of workspace coherence. The persisted execution workspace branch is the recorded branch for future dispatch. Reusing that workspace must verify that the worktree is still registered and that `HEAD` is on the recorded branch. Successful run finalization must perform the same check before recording `workspace_finalize=succeeded`.
+
+#### Contract A — anchored-clean divergence is self-healing
+
+If a run switched the worktree to another branch without updating the execution workspace record, the resulting recorded-branch divergence is repairable without loss whenever the worktree is *clean*, *still registered*, and *uncontended*, and the live `HEAD` is anchored by a local branch ref. Checking out the recorded branch discards nothing in that state: the foreign commits stay anchored on their own ref. Both start validation and finalization perform this restore instead of failing the run. Each repair is recorded as a workspace operation before the corresponding validation or finalize row, and Paperclip posts one fingerprint-deduped audit comment naming the parked branch so the drift stays visible after it is healed. This subsumes the earlier same-commit-only restore rule: restoring the recorded branch when it already points at the current `HEAD` is the trivial case of the same repair.
+
+Hard stops remain only for divergence that cannot be proven safe to restore:
+
+- dirty trees — take the quarantine path instead of discarding or carrying uncommitted changes
+- in-progress git operations (rebase, merge, cherry-pick, bisect)
+- detached `HEAD`s not covered by the ancestor rule
+- live contention — another workspace claims the live branch and has an active run
+
+In those cases validation or finalization records a failed workspace check and the run fails with bounded evidence for the expected and actual branch.
+
+A branch change is sanctioned when a control-plane path updates the execution workspace record before finalization, when publishing work happens in a separate worktree and the managed issue worktree remains on its recorded branch, or when validation/finalization performs the anchored-clean restore above.
+
+#### Contract B — workspace-validation failures are always visible
+
+Every run that fails workspace validation — including pre-start failures that never invoke the adapter — stamps structured `workspaceValidation` evidence on the run row: the expected and actual branch, the divergence shape, and which repair options were evaluated and why each was or was not taken.
+
+Every such failure yields exactly one live source-scoped, fingerprint-deduped recovery action, regardless of the source issue's status — including `blocked` issues and issues with pending interactions. Opening that action must not clobber the source issue's status, assignee, or pending interactions; visibility is additive. Status-gated promotion or reconciler paths that skip these issues violate this contract: a broken shared workspace must never fail runs silently.
+
+The run page renders diagnosis and repair affordances from the run's own `workspaceValidation` evidence even when no recovery action exists, so a failed validation is never a blank surface. When a consumed wake (for example a comment wake) died on the failed validation, one bounded continuation is replayed after a successful repair so the triggering activity is not silently dropped.
 
 ### Explicit recovery actions
 

--- a/skills/paperclip/SKILL.md
+++ b/skills/paperclip/SKILL.md
@@ -341,6 +341,7 @@ For commands, response fields, and MCP tools, read:
 - **Leave a next action.** Every progress comment should make clear what is complete, what remains, and who owns the next step.
 - **Prefer child issues over polling.** Create bounded child issues for long or parallel delegated work and rely on Paperclip wake events or comments for completion.
 - **Preserve workspace continuity for follow-ups.** Child issues inherit execution workspace from `parentId` server-side. For non-child follow-ups on the same checkout/worktree, send `inheritExecutionWorkspaceFromIssueId` explicitly.
+- **Keep issue worktrees on their recorded branch.** Never end a run with the execution worktree switched to another branch (e.g. a PR/publishing branch). Publish from a separate worktree, or `git checkout "$PAPERCLIP_WORKSPACE_BRANCH"` before finishing — see the branch-discipline section in `skills/paperclip/references/issue-workspaces.md`.
 - **Never cancel cross-team tasks.** Reassign to your manager with a comment.
 - **Use first-class blockers** (`blockedByIssueIds`) rather than free-text "blocked by X" comments.
 - **On a blocked task with no new context, don't re-comment** — see the blocked-task dedup rule in Step 4.

--- a/skills/paperclip/references/issue-workspaces.md
+++ b/skills/paperclip/references/issue-workspaces.md
@@ -1,6 +1,6 @@
 # Issue Workspace Runtime Controls
 
-Use this reference when an issue has an isolated execution workspace and you need to inspect or run that workspace's services, especially for QA/browser verification.
+Use this reference when an issue has an isolated execution workspace and you need to inspect or run that workspace's services (especially for QA/browser verification), or when you work with git branches inside an issue worktree.
 
 ## Discover the Workspace
 
@@ -19,6 +19,28 @@ Read `currentExecutionWorkspace`:
 - `runtimeServices[]` — current services, including `serviceName`, `status`, `healthStatus`, `url`, `port`, and `runtimeServiceId`
 
 If `currentExecutionWorkspace` is `null`, the issue does not currently have a realized execution workspace. For child/follow-up work, create the child with `parentId` or use `inheritExecutionWorkspaceFromIssueId` so Paperclip preserves workspace continuity.
+
+## Branch Discipline in Issue Worktrees
+
+Git-worktree execution workspaces have a *recorded branch* (`branchName` above, also exported as `PAPERCLIP_WORKSPACE_BRANCH`). Paperclip validates that the worktree's `HEAD` is on the recorded branch at run start and at run finalization. Leaving the worktree parked on another branch fails workspace validation for every later run that shares the workspace — including other issues' runs.
+
+When you need to publish work to a different branch (for example a PR branch cherry-picked onto newer master), do one of these:
+
+- **Publish from a separate worktree.** Create a throwaway worktree for the publishing branch and leave the issue worktree untouched:
+
+  ```sh
+  git worktree add "$PAPERCLIP_RUN_SCRATCH_DIR/publish" -b <pr-branch> <base-ref>
+  # commit/cherry-pick/push from that directory, then:
+  git worktree remove "$PAPERCLIP_RUN_SCRATCH_DIR/publish"
+  ```
+
+- **Or restore the recorded branch before the run ends.** If you did switch branches in place, finish with:
+
+  ```sh
+  git checkout "$PAPERCLIP_WORKSPACE_BRANCH"
+  ```
+
+A clean worktree parked on a local branch ref is self-healing (Paperclip restores the recorded branch and posts an audit comment), but do not rely on that: restore deliberately so the workspace is coherent for the next run. Never leave the worktree dirty, mid-rebase/merge, or on a detached `HEAD` — those states cannot be auto-repaired and will stop the next run.
 
 ## Control Services
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Agents run in git-worktree execution workspaces with a recorded branch; a run that parks the worktree on another branch silently breaks every later run sharing that workspace (PAP-13568 incident: 36h of invisible failures)
> - This pull request codifies the accepted contract (PAP-13568 plan rev 2b6e1a88) before the server work lands
> - Contract A: anchored-clean divergence self-heals at start validation and finalization, with an audit trail; hard stops only where safety cannot be proven
> - Contract B: every workspace-validation failure stamps structured evidence on the run row and yields exactly one status-agnostic recovery action, so broken workspaces are never silent
> - The workspace skill now tells agents to publish PR branches from a separate worktree or restore the recorded branch before run end

## What Changed

- `doc/execution-semantics.md` §Adapter-backed workspace coherence: replaced the same-commit-only auto-restore clause with **Contract A — anchored-clean divergence is self-healing** (restore at start validation AND finalization; workspace operation + one fingerprint-deduped audit comment naming the parked branch; hard stops enumerated: dirty trees, in-progress git ops, uncovered detached HEADs, live contention) and added **Contract B — workspace-validation failures are always visible** (structured `workspaceValidation` run evidence including pre-start failures; exactly one live source-scoped fingerprint-deduped recovery action regardless of source-issue status, without clobbering it; run page renders from run evidence without a recovery action; one bounded replay of the consumed wake after repair).
- `skills/paperclip/references/issue-workspaces.md`: new **Branch Discipline in Issue Worktrees** section — publish from a separate worktree or `git checkout "$PAPERCLIP_WORKSPACE_BRANCH"` before run end (the L1 behavior behind the incident).
- `skills/paperclip/SKILL.md`: matching critical rule pointing at the reference.

## Verification

- Docs/skill markdown only — no runtime code, no tests affected. Verified the amended §Adapter-backed workspace coherence reads coherently end-to-end and that the new `#### Contract A` / `#### Contract B` subheads match the section's existing heading style (`#### Recovery action freshness`).
- Confirmed the contract text matches the accepted PAP-13568 plan rev 2b6e1a88 verbatim in substance (contracts, hard-stop list, status-agnostic visibility, no-status-clobber, run-evidence rendering, single bounded wake replay).
- Grepped for tests pinning these files (none reference `execution-semantics.md` or `issue-workspaces.md`).

## Risks

- None at runtime (documentation and skill guidance only). The contract intentionally supersedes the same-commit-only auto-restore clause; server behavior does not change until Phases 2–3 (PAP-13575/PAP-13576) implement it — until then the doc describes the target contract, which is the point of landing it first.

## Model Used

Claude Fable 5 (claude-fable-5) via Paperclip agent Senior Engineer Fable.

Issue: PAP-13574 (parent PAP-13568)

🤖 Generated with [Claude Code](https://claude.com/claude-code)