### PR TITLE
fix(ui): avoid disabled auth and built-in-agent requests

### DIFF
--- a/ui/src/components/BuiltInAgentGate.test.tsx
+++ b/ui/src/components/BuiltInAgentGate.test.tsx
@@ -10,6 +10,7 @@ import type { BuiltInAgentState, BuiltInAgentStatus } from "@/api/builtInAgents"
 
 const listMock = vi.hoisted(() => vi.fn());
 const resumeMock = vi.hoisted(() => vi.fn());
+const experimentalSettingsMock = vi.hoisted(() => vi.fn());
 
 vi.mock("@/api/builtInAgents", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/api/builtInAgents")>();
@@ -21,6 +22,10 @@ vi.mock("@/api/builtInAgents", async (importOriginal) => {
 
 vi.mock("@/api/agents", () => ({
   agentsApi: { resume: resumeMock },
+}));
+
+vi.mock("@/api/instanceSettings", () => ({
+  instanceSettingsApi: { getExperimental: experimentalSettingsMock },
 }));
 
 // The configure modal pulls in the full AgentConfigForm; stub it so the gate
@@ -90,6 +95,8 @@ describe("BuiltInAgentGate (PAP-12978)", () => {
     document.body.appendChild(container);
     listMock.mockReset();
     resumeMock.mockReset();
+    experimentalSettingsMock.mockReset();
+    experimentalSettingsMock.mockResolvedValue({ enableBuiltInAgents: true });
   });
 
   afterEach(() => {
@@ -106,6 +113,32 @@ describe("BuiltInAgentGate (PAP-12978)", () => {
     expect(container.textContent).toContain("Set up the Briefs Agent");
     expect(container.textContent).toContain("Configure its model to enable the feature");
     expect(container.querySelector('[data-testid="feature"]')).toBeNull();
+  });
+
+  it("does not request built-in agents while the experimental feature is disabled", async () => {
+    experimentalSettingsMock.mockResolvedValue({ enableBuiltInAgents: false });
+    await renderGate();
+
+    expect(listMock).not.toHaveBeenCalled();
+    expect(container.querySelector('[data-testid="feature"]')).not.toBeNull();
+  });
+
+  it("waits for the experimental flag before requesting built-in agents", async () => {
+    let resolveSettings: ((value: { enableBuiltInAgents: boolean }) => void) | undefined;
+    experimentalSettingsMock.mockImplementation(
+      () => new Promise<{ enableBuiltInAgents: boolean }>((resolve) => {
+        resolveSettings = resolve;
+      }),
+    );
+    listMock.mockResolvedValue([]);
+
+    await renderGate();
+    expect(listMock).not.toHaveBeenCalled();
+    expect(container.querySelector('[data-testid="feature"]')).not.toBeNull();
+
+    resolveSettings?.({ enableBuiltInAgents: true });
+    await flushReact();
+    expect(listMock).toHaveBeenCalledWith("c1");
   });
 
   it("renders the setup empty-state for not_provisioned", async () => {

--- a/ui/src/components/BuiltInAgentGate.tsx
+++ b/ui/src/components/BuiltInAgentGate.tsx
@@ -10,6 +10,7 @@ import { Button } from "@/components/ui/button";
 import { ConfigureBuiltInAgentModal } from "@/components/ConfigureBuiltInAgentModal";
 import { builtInAgentsApi, type BuiltInAgentState } from "@/api/builtInAgents";
 import { agentsApi } from "@/api/agents";
+import { instanceSettingsApi } from "@/api/instanceSettings";
 import { queryKeys } from "@/lib/queryKeys";
 import { agentUrl } from "@/lib/utils";
 import { relativeTime } from "@/lib/utils";
@@ -36,10 +37,16 @@ export function BuiltInAgentGate({ agentKey, companyId, featureLabel, children }
   const queryClient = useQueryClient();
   const [configureOpen, setConfigureOpen] = useState(false);
 
+  const experimentalQuery = useQuery({
+    queryKey: queryKeys.instance.experimentalSettings,
+    queryFn: () => instanceSettingsApi.getExperimental(),
+    enabled: Boolean(companyId),
+  });
+  const builtInAgentsEnabled = experimentalQuery.data?.enableBuiltInAgents === true;
   const { data: states, isLoading } = useQuery({
     queryKey: queryKeys.builtInAgents.list(companyId ?? "__none__"),
     queryFn: () => builtInAgentsApi.list(companyId!),
-    enabled: Boolean(companyId),
+    enabled: Boolean(companyId) && builtInAgentsEnabled,
   });
 
   const state: BuiltInAgentState | undefined = states?.find((entry) => entry.definition.key === agentKey);
@@ -54,6 +61,9 @@ export function BuiltInAgentGate({ agentKey, companyId, featureLabel, children }
 
   // Unknown key or still resolving the company — fail open to the feature.
   if (!companyId) return <>{children}</>;
+  // The built-in-agent API is intentionally unavailable while the experimental
+  // feature is disabled. Do not probe it until the flag has been confirmed.
+  if (!experimentalQuery.isFetched || !builtInAgentsEnabled) return <>{children}</>;
   if (isLoading && !states) return <PageSkeleton variant="detail" />;
   if (!state) return <>{children}</>;
 

--- a/ui/src/components/Sidebar.tsx
+++ b/ui/src/components/Sidebar.tsx
@@ -265,7 +265,10 @@ export function Sidebar() {
         {/* Classic mode restores the per-project collapsible below Work. */}
         {streamlined ? null : <SidebarProjects />}
 
-        <SidebarAgents streamlined={streamlined} />
+        <SidebarAgents
+          streamlined={streamlined}
+          builtInAgentsEnabled={experimentalSettings?.enableBuiltInAgents === true}
+        />
 
         <SidebarSection label="Company" collapsible={{ open: companyOpen, onOpenChange: setCompanyOpen }}>
           <SidebarNavItem to="/org" label="Org" icon={Network} />

--- a/ui/src/components/SidebarAgents.test.tsx
+++ b/ui/src/components/SidebarAgents.test.tsx
@@ -24,6 +24,10 @@ const mockHeartbeatsApi = vi.hoisted(() => ({
   liveRunsForCompany: vi.fn(),
 }));
 
+const mockBuiltInAgentsApi = vi.hoisted(() => ({
+  list: vi.fn(),
+}));
+
 const mockResourceMembershipsApi = vi.hoisted(() => ({
   listMine: vi.fn(),
   updateAgent: vi.fn(),
@@ -99,6 +103,10 @@ vi.mock("../api/auth", () => ({
 
 vi.mock("../api/heartbeats", () => ({
   heartbeatsApi: mockHeartbeatsApi,
+}));
+
+vi.mock("../api/builtInAgents", () => ({
+  builtInAgentsApi: mockBuiltInAgentsApi,
 }));
 
 vi.mock("../api/resourceMemberships", () => ({
@@ -227,6 +235,7 @@ describe("SidebarAgents", () => {
       user: { id: "user-1" },
     });
     mockHeartbeatsApi.liveRunsForCompany.mockResolvedValue([]);
+    mockBuiltInAgentsApi.list.mockResolvedValue([]);
     memberships = {
       projectMemberships: {},
       agentMemberships: {},
@@ -276,19 +285,31 @@ describe("SidebarAgents", () => {
     vi.clearAllMocks();
   });
 
-  async function renderSidebarAgents(streamlined = true) {
+  async function renderSidebarAgents(streamlined = true, builtInAgentsEnabled = false) {
     const currentRoot = createRoot(container);
     root = currentRoot;
 
     await act(async () => {
       currentRoot.render(
         <QueryClientProvider client={queryClient}>
-          <SidebarAgents streamlined={streamlined} />
+          <SidebarAgents streamlined={streamlined} builtInAgentsEnabled={builtInAgentsEnabled} />
         </QueryClientProvider>,
       );
     });
     await flushReact();
   }
+
+  it("does not probe built-in agents while the experimental feature is disabled", async () => {
+    await renderSidebarAgents();
+
+    expect(mockBuiltInAgentsApi.list).not.toHaveBeenCalled();
+  });
+
+  it("loads built-in agent status only when the experimental feature is enabled", async () => {
+    await renderSidebarAgents(true, true);
+
+    expect(mockBuiltInAgentsApi.list).toHaveBeenCalledWith("company-1");
+  });
 
   async function renderSidebarAgentsWithDefaultProps() {
     const currentRoot = createRoot(container);

--- a/ui/src/components/SidebarAgents.tsx
+++ b/ui/src/components/SidebarAgents.tsx
@@ -296,7 +296,13 @@ function SidebarAgentItem({
   );
 }
 
-export function SidebarAgents({ streamlined = false }: { streamlined?: boolean } = {}) {
+export function SidebarAgents({
+  streamlined = false,
+  builtInAgentsEnabled = false,
+}: {
+  streamlined?: boolean;
+  builtInAgentsEnabled?: boolean;
+} = {}) {
   const [open, setOpen] = useState(true);
   const [pendingAgentIds, setPendingAgentIds] = useState<Set<string>>(() => new Set());
   const [liveLingerVersion, setLiveLingerVersion] = useState(0);
@@ -317,7 +323,7 @@ export function SidebarAgents({ streamlined = false }: { streamlined?: boolean }
   const { data: builtInAgents } = useQuery({
     queryKey: queryKeys.builtInAgents.list(selectedCompanyId!),
     queryFn: () => builtInAgentsApi.list(selectedCompanyId!),
-    enabled: !!selectedCompanyId,
+    enabled: !!selectedCompanyId && builtInAgentsEnabled,
   });
   const builtInStatusByAgentId = useMemo(() => {
     const map = new Map<string, BuiltInAgentStatus>();

--- a/ui/src/pages/InstanceGeneralSettings.test.tsx
+++ b/ui/src/pages/InstanceGeneralSettings.test.tsx
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest";
+
+import { shouldShowInstanceSignOut } from "./InstanceGeneralSettings";
+
+describe("InstanceGeneralSettings sign-out visibility", () => {
+  it("shows sign-out only for authenticated deployments", () => {
+    expect(shouldShowInstanceSignOut("authenticated")).toBe(true);
+    expect(shouldShowInstanceSignOut("local_trusted")).toBe(false);
+    expect(shouldShowInstanceSignOut(undefined)).toBe(false);
+  });
+});

--- a/ui/src/pages/InstanceGeneralSettings.tsx
+++ b/ui/src/pages/InstanceGeneralSettings.tsx
@@ -21,6 +21,12 @@ import { cn } from "../lib/utils";
 
 const FEEDBACK_TERMS_URL = import.meta.env.VITE_FEEDBACK_TERMS_URL?.trim() || "https://paperclip.ing/tos";
 
+export function shouldShowInstanceSignOut(
+  deploymentMode: "local_trusted" | "authenticated" | undefined,
+): boolean {
+  return deploymentMode === "authenticated";
+}
+
 export function InstanceGeneralSettings() {
   const { setBreadcrumbs } = useBreadcrumbs();
   const queryClient = useQueryClient();
@@ -351,25 +357,27 @@ export function InstanceGeneralSettings() {
         </div>
       </Card>
 
-      <Card className="block p-5">
-        <div className="flex items-start justify-between gap-4">
-          <div className="space-y-1.5">
-            <h2 className="text-sm font-semibold">Sign out</h2>
-            <p className="max-w-2xl text-sm text-muted-foreground">
-              Sign out of this Paperclip instance. You will be redirected to the login page.
-            </p>
+      {shouldShowInstanceSignOut(healthQuery.data?.deploymentMode) ? (
+        <Card className="block p-5">
+          <div className="flex items-start justify-between gap-4">
+            <div className="space-y-1.5">
+              <h2 className="text-sm font-semibold">Sign out</h2>
+              <p className="max-w-2xl text-sm text-muted-foreground">
+                Sign out of this Paperclip instance. You will be redirected to the login page.
+              </p>
+            </div>
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={signOutMutation.isPending}
+              onClick={() => signOutMutation.mutate()}
+            >
+              <LogOut className="size-4" />
+              {signOutMutation.isPending ? "Signing out..." : "Sign out"}
+            </Button>
           </div>
-          <Button
-            variant="outline"
-            size="sm"
-            disabled={signOutMutation.isPending}
-            onClick={() => signOutMutation.mutate()}
-          >
-            <LogOut className="size-4" />
-            {signOutMutation.isPending ? "Signing out..." : "Sign out"}
-          </Button>
-        </div>
-      </Card>
+        </Card>
+      ) : null}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- stop polling built-in-agent endpoints while the experimental feature is disabled
- preserve built-in-agent discovery when the feature is enabled
- hide the sign-out control in local-trusted deployments where no auth endpoint exists

## Validation

- Terra implementation and independent review: PASS
- focused Vitest: 3 files / 33 tests PASS
- `git diff --check`: PASS
- UI TypeScript remains blocked by a pre-existing MarkdownEditor Lexical version mismatch

Fixes #9402

Generated-By: Terra