### PR TITLE
fix: normalize Hermes adapter env values

### DIFF
--- a/packages/adapters/hermes/src/server/command-resolution.test.ts
+++ b/packages/adapters/hermes/src/server/command-resolution.test.ts
@@ -1,10 +1,10 @@
 import os from "node:os";
 import path from "node:path";
-import { chmod, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { chmod, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { expect, test } from "vitest";
 
 import { HERMES_CLI } from "../shared/constants.js";
-import { resolveHermesCommand } from "./execute.js";
+import { execute, resolveHermesCommand } from "./execute.js";
 import { testEnvironment } from "./test.js";
 
 test("resolveHermesCommand prefers hermesCommand over command", () => {
@@ -45,4 +45,140 @@ test("testEnvironment accepts config.command when hermesCommand is absent", asyn
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }
+});
+
+async function runExecuteWithFakeHermes(
+  config: Record<string, unknown>,
+  authToken = "run-auth-token",
+  inheritedEnv: Record<string, string | undefined> = {},
+): Promise<Record<string, string | undefined>> {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "hermes-env-normalization-"));
+  const cliPath = path.join(tempDir, "fake-hermes");
+  const envPath = path.join(tempDir, "env.txt");
+  const previousEnv = Object.fromEntries(
+    Object.keys(inheritedEnv).map((key) => [key, process.env[key]]),
+  );
+
+  try {
+    for (const [key, value] of Object.entries(inheritedEnv)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+
+    await writeFile(
+      cliPath,
+      [
+        "#!/bin/sh",
+        "printf 'HERMES_HOME=%s\\n' \"$HERMES_HOME\" > \"$HERMES_ENV_FILE\"",
+        "printf 'PAPERCLIP_API_KEY=%s\\n' \"$PAPERCLIP_API_KEY\" >> \"$HERMES_ENV_FILE\"",
+        "printf 'IGNORED_VALUE=%s\\n' \"$IGNORED_VALUE\" >> \"$HERMES_ENV_FILE\"",
+        "printf 'ok\\n\\nsession_id: session-test\\n'",
+      ].join("\n") + "\n",
+      "utf8",
+    );
+    await chmod(cliPath, 0o755);
+
+    await execute({
+      runId: "run-test",
+      agent: {
+        id: "agent-test",
+        name: "Hermes Test Agent",
+        companyId: "company-test",
+        adapterConfig: {},
+      },
+      config: {
+        ...config,
+        hermesCommand: cliPath,
+        cwd: tempDir,
+        env: {
+          ...(config.env && typeof config.env === "object" && !Array.isArray(config.env)
+            ? config.env
+            : {}),
+          HERMES_ENV_FILE: envPath,
+        },
+      },
+      runtime: {},
+      onLog: async () => {},
+      authToken,
+    } as any);
+
+    return Object.fromEntries(
+      (await readFile(envPath, "utf8"))
+        .trim()
+        .split("\n")
+        .map((line) => {
+          const [key, ...valueParts] = line.split("=");
+          return [key, valueParts.join("=")];
+        }),
+    );
+  } finally {
+    for (const [key, value] of Object.entries(previousEnv)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+    await rm(tempDir, { recursive: true, force: true });
+  }
+}
+
+test("execute normalizes wrapped env values before spawning Hermes", async () => {
+  const env = await runExecuteWithFakeHermes({
+    env: {
+      HERMES_HOME: { type: "plain", value: "/tmp/hermes-home" },
+      IGNORED_VALUE: { type: "plain" },
+    },
+  });
+
+  expect(env.HERMES_HOME).toBe("/tmp/hermes-home");
+  expect(env.IGNORED_VALUE).toBe("");
+});
+
+test("execute preserves explicit empty env values over inherited values", async () => {
+  const env = await runExecuteWithFakeHermes(
+    {
+      env: {
+        HERMES_HOME: "",
+        IGNORED_VALUE: { type: "plain", value: "" },
+      },
+    },
+    "run-auth-token",
+    {
+      HERMES_HOME: "/stale/hermes-home",
+      IGNORED_VALUE: "stale-value",
+    },
+  );
+
+  expect(env.HERMES_HOME).toBe("");
+  expect(env.IGNORED_VALUE).toBe("");
+});
+
+test("execute ignores malformed env wrappers instead of coercing them", async () => {
+  const env = await runExecuteWithFakeHermes({
+    env: {
+      IGNORED_VALUE: { type: "plain", value: 42 },
+    },
+  });
+
+  expect(env.IGNORED_VALUE).toBe("");
+});
+
+test("execute uses the run token over configured and inherited API keys", async () => {
+  const env = await runExecuteWithFakeHermes(
+    {
+      env: {
+        PAPERCLIP_API_KEY: { type: "plain", value: "configured-api-key" },
+      },
+    },
+    "run-auth-token",
+    {
+      PAPERCLIP_API_KEY: "stale-inherited-api-key",
+    },
+  );
+
+  expect(env.PAPERCLIP_API_KEY).toBe("run-auth-token");
 });

--- a/packages/adapters/hermes/src/server/execute.ts
+++ b/packages/adapters/hermes/src/server/execute.ts
@@ -70,6 +70,31 @@ function cfgStringArray(v: unknown): string[] | undefined {
     ? (v as string[])
     : undefined;
 }
+function cfgEnvString(v: unknown): string | undefined {
+  if (typeof v === "string") return v;
+  if (
+    v &&
+    typeof v === "object" &&
+    "value" in v &&
+    typeof (v as { value?: unknown }).value === "string"
+  ) {
+    return (v as { value: string }).value;
+  }
+  return undefined;
+}
+
+function normalizeEnvConfig(envConfig: unknown): Record<string, string> {
+  if (!envConfig || typeof envConfig !== "object" || Array.isArray(envConfig)) {
+    return {};
+  }
+
+  const env: Record<string, string> = {};
+  for (const [key, value] of Object.entries(envConfig)) {
+    const resolved = cfgEnvString(value);
+    if (resolved !== undefined) env[key] = resolved;
+  }
+  return env;
+}
 
 export function resolveHermesCommand(config: Record<string, unknown>): string {
   return cfgString(config.hermesCommand) || cfgString(config.command) || HERMES_CLI;
@@ -456,10 +481,10 @@ export async function execute(
   }
 
   // ── Build environment ──────────────────────────────────────────────────
-  const userEnv = config.env as Record<string, string> | undefined;
+  const userEnv = normalizeEnvConfig(config.env);
   const env: Record<string, string> = {
     ...(process.env as Record<string, string>),
-    ...(userEnv && typeof userEnv === "object" ? userEnv : {}),
+    ...userEnv,
     ...buildPaperclipEnv(ctx.agent),
   };
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The built-in Hermes local adapter spawns Hermes with a merged child-process environment.
> - Adapter env values can arrive as raw strings or serialized wrappers such as `{ "type": "plain", "value": "..." }`.
> - Passing wrappers directly can coerce them to `"[object Object]"`, while dropping an explicit empty string prevents operators from clearing an inherited host value.
> - Merged PR #9974 established that configured or inherited `PAPERCLIP_API_KEY` values must never override the harness-minted run token.
> - This pull request normalizes Hermes env values, preserves explicit empty overrides, rejects malformed wrappers, and keeps the run-token-only identity invariant.

## Linked Issues or Issue Description

No public Paperclip issue exists yet. Inline bug report:

### Summary

Hermes local adapter env values can reach the spawned process as wrapper objects instead of strings, and explicit empty overrides can be lost.

### What happened?

An adapter env entry such as:

```json
{
  "HERMES_HOME": { "type": "plain", "value": "/path/to/hermes-home" }
}
```

could be passed to the child environment as an object. An entry configured as `""` could also be omitted, allowing an inherited host value to leak into the Hermes process.

### Expected behavior

- Raw strings and wrapper `.value` strings reach Hermes as strings.
- Explicit empty strings are preserved so inherited values can be cleared.
- Malformed wrappers are ignored instead of being coerced.
- `PAPERCLIP_API_KEY` always comes from the harness-minted run token, consistent with #9974.

### Steps to reproduce

1. Set `HERMES_HOME` in the Paperclip server process.
2. Configure a `hermes_local` agent with `HERMES_HOME: ""` or a wrapped value.
3. Start a run and inspect the spawned Hermes environment.

Before this change, the inherited value could remain or the wrapper could be object-coerced.

Related public context: Refs #9974, NousResearch/hermes-paperclip-adapter#78, and NousResearch/hermes-paperclip-adapter#71.

## What Changed

- Normalize raw string env values and wrapper objects with string `.value` fields before spawning Hermes.
- Preserve raw and wrapped empty strings so they override inherited host values.
- Skip malformed wrapper values instead of passing object coercions to the child process.
- Retain #9974 behavior: configured and inherited `PAPERCLIP_API_KEY` values are removed and the run token is the only Paperclip API identity.
- Add fake-Hermes regression coverage for wrapped values, empty clears, malformed wrappers, inherited stale values, and run-token precedence.

## Verification

- `pnpm --filter @paperclipai/hermes-paperclip-adapter test:command-resolution`
  - 7 tests passed
- `pnpm --filter @paperclipai/hermes-paperclip-adapter test`
  - 62 tests passed
- `pnpm --filter @paperclipai/hermes-paperclip-adapter typecheck`
  - passed
- `pnpm --filter @paperclipai/hermes-paperclip-adapter build`
  - passed

## Risks

Low risk and scoped to Hermes local adapter environment construction:

- Existing raw string env values keep working.
- Wrapped values now resolve to their string value.
- Explicit empty values now clear inherited values.
- Malformed wrappers are ignored; an inherited value with the same key remains unless config explicitly clears it with `""`.
- Paperclip API identity follows the existing #9974 run-token-only policy.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

OpenAI Codex, GPT-5.6 Sol, tool-enabled coding session with repository inspection, shell execution, local focused and package test execution, typecheck, build, and GitHub CLI assistance.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes (not applicable: behavior is covered by focused adapter regression tests)
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
