### PR TITLE
fix(hermes): sync Paperclip skills into active profile

### DIFF
--- a/packages/adapters/hermes/src/server/skills.test.ts
+++ b/packages/adapters/hermes/src/server/skills.test.ts
@@ -62,6 +62,36 @@ describe("Hermes skill sync", () => {
     expect(skillsHome).toBe(path.join("/tmp/hermes-home", "profiles", "paco-studio", "skills"));
   });
 
+  test.each([
+    ["separate long option", ["--profile", "paco-studio"]],
+    ["separate short option", ["-p", "paco_studio"]],
+    ["equals long option", ["--profile=paco-studio"]],
+    ["equals short option", ["-p=paco_studio"]],
+    ["combined long option", ["--profile paco-studio"]],
+  ])("accepts a valid Hermes profile from the %s form", (_label, extraArgs) => {
+    expect(
+      resolveHermesSkillsHome({
+        env: { HERMES_HOME: "/tmp/hermes-home" },
+        extraArgs,
+      }),
+    ).toMatch(/^\/tmp\/hermes-home\/profiles\/paco[-_]studio\/skills$/);
+  });
+
+  test.each([
+    ["separate long option", ["--profile", "../../outside"]],
+    ["separate short option", ["-p", "../outside"]],
+    ["equals long option", ["--profile=/tmp/outside"]],
+    ["equals short option", ["-p=paco/studio"]],
+    ["combined long option", ["--profile paco\\studio"]],
+  ])("rejects an unsafe Hermes profile from the %s form", (_label, extraArgs) => {
+    expect(() =>
+      resolveHermesSkillsHome({
+        env: { HERMES_HOME: "/tmp/hermes-home" },
+        extraArgs,
+      }),
+    ).toThrow("Invalid Hermes profile name");
+  });
+
   test("copies selected Paperclip skills into the active Hermes profile skills directory", async () => {
     const sourceRoot = path.join(tempRoot, "paperclip-runtime-skills");
     const hermesHome = path.join(tempRoot, "Hermes");

--- a/packages/adapters/hermes/src/server/skills.test.ts
+++ b/packages/adapters/hermes/src/server/skills.test.ts
@@ -1,0 +1,197 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import {
+  listHermesSkills,
+  resolveHermesSkillsHome,
+  syncHermesSkills,
+} from "./skills.js";
+
+const runtimeSkills = vi.hoisted(() => ({
+  entries: [] as Array<{ key: string; runtimeName: string; source: string }>,
+}));
+
+vi.mock("@paperclipai/adapter-utils/server-utils", () => ({
+  readPaperclipRuntimeSkillEntries: vi.fn(async () => runtimeSkills.entries),
+  resolvePaperclipDesiredSkillNames: vi.fn(
+    (config: Record<string, unknown>) => {
+      const raw = config.paperclipSkillSync;
+      if (typeof raw !== "object" || raw === null || Array.isArray(raw)) return [];
+      const desired = (raw as { desiredSkills?: unknown }).desiredSkills;
+      return Array.isArray(desired) ? desired.filter((entry): entry is string => typeof entry === "string") : [];
+    },
+  ),
+}));
+
+async function writeSkill(root: string, name: string, description = "Test skill"): Promise<string> {
+  const skillDir = path.join(root, name);
+  await fs.mkdir(skillDir, { recursive: true });
+  await fs.writeFile(
+    path.join(skillDir, "SKILL.md"),
+    `---\nname: ${name}\ndescription: ${description}\n---\n\n# ${name}\n`,
+    "utf8",
+  );
+  await fs.writeFile(path.join(skillDir, "script.ts"), "export {};\n", "utf8");
+  return skillDir;
+}
+
+describe("Hermes skill sync", () => {
+  let tempRoot: string;
+
+  beforeEach(async () => {
+    tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-hermes-skills-"));
+    runtimeSkills.entries = [];
+  });
+
+  afterEach(async () => {
+    runtimeSkills.entries = [];
+    await fs.rm(tempRoot, { recursive: true, force: true });
+  });
+
+  test("resolves the active profile skills directory from HERMES_HOME and profile args", () => {
+    const skillsHome = resolveHermesSkillsHome({
+      env: {
+        HERMES_HOME: { type: "plain", value: "/tmp/hermes-home" },
+      },
+      extraArgs: ["--profile", "paco-studio"],
+    });
+
+    expect(skillsHome).toBe(path.join("/tmp/hermes-home", "profiles", "paco-studio", "skills"));
+  });
+
+  test("copies selected Paperclip skills into the active Hermes profile skills directory", async () => {
+    const sourceRoot = path.join(tempRoot, "paperclip-runtime-skills");
+    const hermesHome = path.join(tempRoot, "Hermes");
+    const source = await writeSkill(sourceRoot, "paperclip-task-bridge", "Paperclip bridge");
+
+    runtimeSkills.entries = [
+      {
+        key: "paperclip-task-bridge",
+        runtimeName: "paperclip-task-bridge",
+        source,
+      },
+    ];
+
+    const config = {
+      env: { HERMES_HOME: hermesHome },
+      extraArgs: ["--profile", "paco-studio"],
+      paperclipSkillSync: { desiredSkills: ["paperclip-task-bridge"] },
+    };
+
+    const snapshot = await syncHermesSkills(
+      {
+        adapterType: "hermes_local",
+        agentId: "agent-id",
+        companyId: "company-id",
+        config,
+      },
+      ["paperclip-task-bridge"],
+    );
+
+    const target = path.join(
+      hermesHome,
+      "profiles",
+      "paco-studio",
+      "skills",
+      "paperclip-task-bridge",
+    );
+
+    await expect(fs.readFile(path.join(target, "SKILL.md"), "utf8")).resolves.toContain(
+      "name: paperclip-task-bridge",
+    );
+    await expect(fs.readFile(path.join(target, "script.ts"), "utf8")).resolves.toContain(
+      "export {};",
+    );
+
+    const manifest = JSON.parse(
+      await fs.readFile(
+        path.join(hermesHome, "profiles", "paco-studio", "skills", ".paperclip-managed-skills.json"),
+        "utf8",
+      ),
+    ) as { skills: Record<string, { target: string }> };
+
+    expect(manifest.skills["paperclip-task-bridge"]?.target).toBe(target);
+    expect(snapshot.entries).toContainEqual(
+      expect.objectContaining({
+        key: "paperclip-task-bridge",
+        runtimeName: "paperclip-task-bridge",
+        state: "installed",
+        targetPath: target,
+      }),
+    );
+
+    const listed = await listHermesSkills({
+      adapterType: "hermes_local",
+      agentId: "agent-id",
+      companyId: "company-id",
+      config,
+    });
+
+    expect(listed.entries.filter((entry) => entry.key === "paperclip-task-bridge")).toHaveLength(1);
+  });
+
+  test("removes previously managed profile skills when they are deselected", async () => {
+    const sourceRoot = path.join(tempRoot, "paperclip-runtime-skills");
+    const hermesHome = path.join(tempRoot, "Hermes");
+    const source = await writeSkill(sourceRoot, "paperclip-task-bridge");
+
+    runtimeSkills.entries = [
+      {
+        key: "paperclip-task-bridge",
+        runtimeName: "paperclip-task-bridge",
+        source,
+      },
+    ];
+
+    const config = {
+      env: { HERMES_HOME: hermesHome },
+      extraArgs: ["-p=paco-studio"],
+      paperclipSkillSync: { desiredSkills: ["paperclip-task-bridge"] },
+    };
+
+    await syncHermesSkills(
+      {
+        adapterType: "hermes_local",
+        agentId: "agent-id",
+        companyId: "company-id",
+        config,
+      },
+      ["paperclip-task-bridge"],
+    );
+
+    const target = path.join(
+      hermesHome,
+      "profiles",
+      "paco-studio",
+      "skills",
+      "paperclip-task-bridge",
+    );
+    await expect(fs.stat(path.join(target, "SKILL.md"))).resolves.toBeTruthy();
+
+    const deselectedConfig = {
+      ...config,
+      paperclipSkillSync: { desiredSkills: [] },
+    };
+
+    const snapshot = await syncHermesSkills(
+      {
+        adapterType: "hermes_local",
+        agentId: "agent-id",
+        companyId: "company-id",
+        config: deselectedConfig,
+      },
+      [],
+    );
+
+    await expect(fs.stat(target)).rejects.toMatchObject({ code: "ENOENT" });
+    expect(snapshot.entries).toContainEqual(
+      expect.objectContaining({
+        key: "paperclip-task-bridge",
+        state: "available",
+      }),
+    );
+  });
+});

--- a/packages/adapters/hermes/src/server/skills.test.ts
+++ b/packages/adapters/hermes/src/server/skills.test.ts
@@ -194,4 +194,108 @@ describe("Hermes skill sync", () => {
       }),
     );
   });
+
+  test("uses the runtime-name fallback when the declared Hermes skill name is user-owned", async () => {
+    const sourceRoot = path.join(tempRoot, "paperclip-runtime-skills");
+    const hermesHome = path.join(tempRoot, "Hermes");
+    const source = await writeSkill(sourceRoot, "paperclip-task-bridge");
+    const profileSkillsHome = path.join(hermesHome, "profiles", "paco-studio", "skills");
+    const userOwnedTarget = await writeSkill(profileSkillsHome, "shared-name", "User-owned skill");
+    await fs.writeFile(
+      path.join(source, "SKILL.md"),
+      "---\nname: shared-name\ndescription: Paperclip bridge\n---\n\n# shared-name\n",
+      "utf8",
+    );
+
+    runtimeSkills.entries = [
+      {
+        key: "paperclip-task-bridge",
+        runtimeName: "paperclip-task-bridge",
+        source,
+      },
+    ];
+
+    const config = {
+      env: { HERMES_HOME: hermesHome },
+      extraArgs: ["--profile", "paco-studio"],
+      paperclipSkillSync: { desiredSkills: ["paperclip-task-bridge"] },
+    };
+
+    const snapshot = await syncHermesSkills(
+      {
+        adapterType: "hermes_local",
+        agentId: "agent-id",
+        companyId: "company-id",
+        config,
+      },
+      ["paperclip-task-bridge"],
+    );
+
+    const fallbackTarget = path.join(profileSkillsHome, "paperclip-task-bridge");
+
+    await expect(fs.readFile(path.join(userOwnedTarget, "SKILL.md"), "utf8")).resolves.toContain(
+      "User-owned skill",
+    );
+    await expect(fs.readFile(path.join(fallbackTarget, "SKILL.md"), "utf8")).resolves.toContain(
+      "name: shared-name",
+    );
+    expect(snapshot.entries).toContainEqual(
+      expect.objectContaining({
+        key: "paperclip-task-bridge",
+        state: "installed",
+        targetPath: fallbackTarget,
+      }),
+    );
+  });
+
+  test("does not overwrite a user-owned runtime-name fallback target", async () => {
+    const sourceRoot = path.join(tempRoot, "paperclip-runtime-skills");
+    const hermesHome = path.join(tempRoot, "Hermes");
+    const source = await writeSkill(sourceRoot, "paperclip-task-bridge");
+    const profileSkillsHome = path.join(hermesHome, "profiles", "paco-studio", "skills");
+    const declaredTarget = await writeSkill(profileSkillsHome, "shared-name", "User-owned declared skill");
+    const fallbackTarget = await writeSkill(profileSkillsHome, "paperclip-task-bridge", "User-owned fallback skill");
+    await fs.writeFile(
+      path.join(source, "SKILL.md"),
+      "---\nname: shared-name\ndescription: Paperclip bridge\n---\n\n# shared-name\n",
+      "utf8",
+    );
+
+    runtimeSkills.entries = [
+      {
+        key: "paperclip-task-bridge",
+        runtimeName: "paperclip-task-bridge",
+        source,
+      },
+    ];
+
+    const config = {
+      env: { HERMES_HOME: hermesHome },
+      extraArgs: ["--profile", "paco-studio"],
+      paperclipSkillSync: { desiredSkills: ["paperclip-task-bridge"] },
+    };
+
+    const snapshot = await syncHermesSkills(
+      {
+        adapterType: "hermes_local",
+        agentId: "agent-id",
+        companyId: "company-id",
+        config,
+      },
+      ["paperclip-task-bridge"],
+    );
+
+    await expect(fs.readFile(path.join(declaredTarget, "SKILL.md"), "utf8")).resolves.toContain(
+      "User-owned declared skill",
+    );
+    await expect(fs.readFile(path.join(fallbackTarget, "SKILL.md"), "utf8")).resolves.toContain(
+      "User-owned fallback skill",
+    );
+    expect(snapshot.entries).toContainEqual(
+      expect.objectContaining({
+        key: "paperclip-task-bridge",
+        state: "missing",
+      }),
+    );
+  });
 });

--- a/packages/adapters/hermes/src/server/skills.test.ts
+++ b/packages/adapters/hermes/src/server/skills.test.ts
@@ -1,197 +1,45 @@
-import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { describe, expect, test } from "vitest";
 
-import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 
-import {
-  listHermesSkills,
-  resolveHermesSkillsHome,
-  syncHermesSkills,
-} from "./skills.js";
+import { resolveHermesSkillsHome } from "./skills.js";
 
-const runtimeSkills = vi.hoisted(() => ({
-  entries: [] as Array<{ key: string; runtimeName: string; source: string }>,
-}));
-
-vi.mock("@paperclipai/adapter-utils/server-utils", () => ({
-  readPaperclipRuntimeSkillEntries: vi.fn(async () => runtimeSkills.entries),
-  resolvePaperclipDesiredSkillNames: vi.fn(
-    (config: Record<string, unknown>) => {
-      const raw = config.paperclipSkillSync;
-      if (typeof raw !== "object" || raw === null || Array.isArray(raw)) return [];
-      const desired = (raw as { desiredSkills?: unknown }).desiredSkills;
-      return Array.isArray(desired) ? desired.filter((entry): entry is string => typeof entry === "string") : [];
-    },
-  ),
-}));
-
-async function writeSkill(root: string, name: string, description = "Test skill"): Promise<string> {
-  const skillDir = path.join(root, name);
-  await fs.mkdir(skillDir, { recursive: true });
-  await fs.writeFile(
-    path.join(skillDir, "SKILL.md"),
-    `---\nname: ${name}\ndescription: ${description}\n---\n\n# ${name}\n`,
-    "utf8",
-  );
-  await fs.writeFile(path.join(skillDir, "script.ts"), "export {};\n", "utf8");
-  return skillDir;
-}
-
-describe("Hermes skill sync", () => {
-  let tempRoot: string;
-
-  beforeEach(async () => {
-    tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-hermes-skills-"));
-    runtimeSkills.entries = [];
-  });
-
-  afterEach(async () => {
-    runtimeSkills.entries = [];
-    await fs.rm(tempRoot, { recursive: true, force: true });
-  });
-
-  test("resolves the active profile skills directory from HERMES_HOME and profile args", () => {
-    const skillsHome = resolveHermesSkillsHome({
-      env: {
-        HERMES_HOME: { type: "plain", value: "/tmp/hermes-home" },
-      },
-      extraArgs: ["--profile", "paco-studio"],
-    });
-
-    expect(skillsHome).toBe(path.join("/tmp/hermes-home", "profiles", "paco-studio", "skills"));
-  });
-
-  test("copies selected Paperclip skills into the active Hermes profile skills directory", async () => {
-    const sourceRoot = path.join(tempRoot, "paperclip-runtime-skills");
-    const hermesHome = path.join(tempRoot, "Hermes");
-    const source = await writeSkill(sourceRoot, "paperclip-task-bridge", "Paperclip bridge");
-
-    runtimeSkills.entries = [
-      {
-        key: "paperclip-task-bridge",
-        runtimeName: "paperclip-task-bridge",
-        source,
-      },
-    ];
-
-    const config = {
-      env: { HERMES_HOME: hermesHome },
-      extraArgs: ["--profile", "paco-studio"],
-      paperclipSkillSync: { desiredSkills: ["paperclip-task-bridge"] },
-    };
-
-    const snapshot = await syncHermesSkills(
-      {
-        adapterType: "hermes_local",
-        agentId: "agent-id",
-        companyId: "company-id",
-        config,
-      },
-      ["paperclip-task-bridge"],
-    );
-
-    const target = path.join(
-      hermesHome,
-      "profiles",
-      "paco-studio",
-      "skills",
-      "paperclip-task-bridge",
-    );
-
-    await expect(fs.readFile(path.join(target, "SKILL.md"), "utf8")).resolves.toContain(
-      "name: paperclip-task-bridge",
-    );
-    await expect(fs.readFile(path.join(target, "script.ts"), "utf8")).resolves.toContain(
-      "export {};",
-    );
-
-    const manifest = JSON.parse(
-      await fs.readFile(
-        path.join(hermesHome, "profiles", "paco-studio", "skills", ".paperclip-managed-skills.json"),
-        "utf8",
-      ),
-    ) as { skills: Record<string, { target: string }> };
-
-    expect(manifest.skills["paperclip-task-bridge"]?.target).toBe(target);
-    expect(snapshot.entries).toContainEqual(
-      expect.objectContaining({
-        key: "paperclip-task-bridge",
-        runtimeName: "paperclip-task-bridge",
-        state: "installed",
-        targetPath: target,
+describe("Hermes skill path resolution", () => {
+  test.each([
+    ["separate long option", ["--profile", "paco-studio"], "paco-studio"],
+    ["separate short option", ["-p", "paco_studio"], "paco_studio"],
+    ["equals long option", ["--profile=paco-studio"], "paco-studio"],
+    ["equals short option", ["-p=paco_studio"], "paco_studio"],
+    ["combined long option", ["--profile paco-studio"], "paco-studio"],
+  ])("resolves a valid profile from the %s form", (_label, extraArgs, profile) => {
+    expect(
+      resolveHermesSkillsHome({
+        env: { HERMES_HOME: "/tmp/hermes-home" },
+        extraArgs,
       }),
-    );
-
-    const listed = await listHermesSkills({
-      adapterType: "hermes_local",
-      agentId: "agent-id",
-      companyId: "company-id",
-      config,
-    });
-
-    expect(listed.entries.filter((entry) => entry.key === "paperclip-task-bridge")).toHaveLength(1);
+    ).toBe(path.join("/tmp/hermes-home", "profiles", profile, "skills"));
   });
 
-  test("removes previously managed profile skills when they are deselected", async () => {
-    const sourceRoot = path.join(tempRoot, "paperclip-runtime-skills");
-    const hermesHome = path.join(tempRoot, "Hermes");
-    const source = await writeSkill(sourceRoot, "paperclip-task-bridge");
-
-    runtimeSkills.entries = [
-      {
-        key: "paperclip-task-bridge",
-        runtimeName: "paperclip-task-bridge",
-        source,
-      },
-    ];
-
-    const config = {
-      env: { HERMES_HOME: hermesHome },
-      extraArgs: ["-p=paco-studio"],
-      paperclipSkillSync: { desiredSkills: ["paperclip-task-bridge"] },
-    };
-
-    await syncHermesSkills(
-      {
-        adapterType: "hermes_local",
-        agentId: "agent-id",
-        companyId: "company-id",
-        config,
-      },
-      ["paperclip-task-bridge"],
-    );
-
-    const target = path.join(
-      hermesHome,
-      "profiles",
-      "paco-studio",
-      "skills",
-      "paperclip-task-bridge",
-    );
-    await expect(fs.stat(path.join(target, "SKILL.md"))).resolves.toBeTruthy();
-
-    const deselectedConfig = {
-      ...config,
-      paperclipSkillSync: { desiredSkills: [] },
-    };
-
-    const snapshot = await syncHermesSkills(
-      {
-        adapterType: "hermes_local",
-        agentId: "agent-id",
-        companyId: "company-id",
-        config: deselectedConfig,
-      },
-      [],
-    );
-
-    await expect(fs.stat(target)).rejects.toMatchObject({ code: "ENOENT" });
-    expect(snapshot.entries).toContainEqual(
-      expect.objectContaining({
-        key: "paperclip-task-bridge",
-        state: "available",
+  test("uses the default Hermes skills directory when no profile is set", () => {
+    expect(
+      resolveHermesSkillsHome({
+        env: { HERMES_HOME: "/tmp/hermes-home" },
       }),
-    );
+    ).toBe(path.join("/tmp/hermes-home", "skills"));
+  });
+
+  test.each([
+    ["separate long option", ["--profile", "../../outside"]],
+    ["separate short option", ["-p", "../outside"]],
+    ["equals long option", ["--profile=/tmp/outside"]],
+    ["equals short option", ["-p=paco/studio"]],
+    ["combined long option", ["--profile paco\\studio"]],
+  ])("rejects an unsafe profile from the %s form", (_label, extraArgs) => {
+    expect(() =>
+      resolveHermesSkillsHome({
+        env: { HERMES_HOME: "/tmp/hermes-home" },
+        extraArgs,
+      }),
+    ).toThrow("Invalid Hermes profile name");
   });
 });

--- a/packages/adapters/hermes/src/server/skills.ts
+++ b/packages/adapters/hermes/src/server/skills.ts
@@ -13,6 +13,7 @@ import {
 import { fileURLToPath } from "node:url";
 
 const __moduleDir = path.dirname(fileURLToPath(import.meta.url));
+const PAPERCLIP_MANAGED_SKILLS_MANIFEST = ".paperclip-managed-skills.json";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -22,13 +23,65 @@ function asString(value: unknown): string | null {
   return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
 }
 
-function resolveHermesHome(config: Record<string, unknown>): string {
+function envString(value: unknown): string | null {
+  if (typeof value === "string" && value.trim().length > 0) return value.trim();
+  if (
+    value &&
+    typeof value === "object" &&
+    "value" in value &&
+    typeof (value as { value?: unknown }).value === "string" &&
+    (value as { value: string }).value.trim().length > 0
+  ) {
+    return (value as { value: string }).value.trim();
+  }
+  return null;
+}
+
+function configEnv(config: Record<string, unknown>): Record<string, unknown> {
   const env =
     typeof config.env === "object" && config.env !== null && !Array.isArray(config.env)
       ? (config.env as Record<string, unknown>)
       : {};
-  const configuredHome = asString(env.HOME);
-  return configuredHome ? path.resolve(configuredHome) : os.homedir();
+  return env;
+}
+
+function extractProfileFromArgs(value: unknown): string | null {
+  if (!Array.isArray(value) || value.length === 0) return null;
+
+  for (let i = 0; i < value.length; i += 1) {
+    const raw = value[i];
+    if (typeof raw !== "string") continue;
+    const arg = raw.trim();
+    if (!arg) continue;
+
+    const profilePairMatch = arg.match(/^(--profile|-p)\s+(.+)$/);
+    if (profilePairMatch) return profilePairMatch[2].trim() || null;
+
+    if (arg === "--profile" || arg === "-p") {
+      const next = value[i + 1];
+      return typeof next === "string" && next.trim().length > 0 ? next.trim() : null;
+    }
+
+    if (arg.startsWith("--profile=") || arg.startsWith("-p=")) {
+      const [, profile = ""] = arg.split("=", 2);
+      return profile.trim() || null;
+    }
+  }
+
+  return null;
+}
+
+export function resolveHermesSkillsHome(config: Record<string, unknown>): string {
+  const env = configEnv(config);
+  const configuredHermesHome = envString(env.HERMES_HOME);
+  const configuredHome = envString(env.HOME);
+  const hermesHome = configuredHermesHome
+    ? path.resolve(configuredHermesHome)
+    : path.join(configuredHome ? path.resolve(configuredHome) : os.homedir(), ".hermes");
+  const profile = extractProfileFromArgs(config.extraArgs);
+  return profile
+    ? path.join(hermesHome, "profiles", profile, "skills")
+    : path.join(hermesHome, "skills");
 }
 
 interface SkillFrontmatter {
@@ -37,6 +90,21 @@ interface SkillFrontmatter {
   version?: string;
   category?: string;
   metadata?: Record<string, unknown>;
+}
+
+interface ManagedSkillManifestEntry {
+  key: string;
+  runtimeName: string;
+  hermesName: string;
+  source: string;
+  target: string;
+  copiedAt: string;
+}
+
+interface ManagedSkillManifest {
+  version: 1;
+  managedBy: "paperclip";
+  skills: Record<string, ManagedSkillManifestEntry>;
 }
 
 function parseSkillFrontmatter(content: string): SkillFrontmatter {
@@ -57,6 +125,22 @@ function parseSkillFrontmatter(content: string): SkillFrontmatter {
   return frontmatter as SkillFrontmatter;
 }
 
+function isSafeHermesSkillName(value: string): boolean {
+  return /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/.test(value) && !value.includes("..");
+}
+
+async function readSkillDeclaredName(source: string, fallback: string): Promise<string> {
+  try {
+    const content = await fs.readFile(path.join(source, "SKILL.md"), "utf8");
+    const frontmatter = parseSkillFrontmatter(content);
+    const name = asString(frontmatter.name);
+    if (name && isSafeHermesSkillName(name)) return name;
+  } catch {
+    // Fall back to Paperclip's runtime name below.
+  }
+  return fallback;
+}
+
 async function scanHermesSkills(
   skillsHome: string,
 ): Promise<AdapterSkillEntry[]> {
@@ -71,7 +155,7 @@ async function scanHermesSkills(
       // Check if the category directory itself has a SKILL.md (top-level skill)
       const topLevelSkillMd = path.join(catPath, "SKILL.md");
       if (await fs.stat(topLevelSkillMd).catch(() => null)) {
-        entries.push(await buildSkillEntry(cat.name, topLevelSkillMd, cat.name));
+        entries.push(await buildSkillEntry(cat.name, topLevelSkillMd, path.join(skillsHome, cat.name)));
       }
 
       // Scan for sub-skills
@@ -81,7 +165,7 @@ async function scanHermesSkills(
         const skillMd = path.join(catPath, item.name, "SKILL.md");
         if (await fs.stat(skillMd).catch(() => null)) {
           const key = item.name;
-          entries.push(await buildSkillEntry(key, skillMd, `${cat.name}/${item.name}`));
+          entries.push(await buildSkillEntry(key, skillMd, path.join(skillsHome, cat.name, item.name)));
         }
       }
     }
@@ -95,7 +179,7 @@ async function scanHermesSkills(
 async function buildSkillEntry(
   key: string,
   skillMdPath: string,
-  categoryPath: string,
+  locationPath: string,
 ): Promise<AdapterSkillEntry> {
   let description: string | null = null;
   try {
@@ -114,7 +198,7 @@ async function buildSkillEntry(
     state: "installed",
     origin: "user_installed",
     originLabel: "Hermes skill",
-    locationLabel: `~/.hermes/skills/${categoryPath}`,
+    locationLabel: locationPath,
     readOnly: true, // Hermes manages its own skills — Paperclip can't toggle them
     sourcePath: skillMdPath,
     targetPath: null,
@@ -122,13 +206,126 @@ async function buildSkillEntry(
   };
 }
 
+function emptyManagedSkillManifest(): ManagedSkillManifest {
+  return {
+    version: 1,
+    managedBy: "paperclip",
+    skills: {},
+  };
+}
+
+async function readManagedSkillManifest(skillsHome: string): Promise<ManagedSkillManifest> {
+  const manifestPath = path.join(skillsHome, PAPERCLIP_MANAGED_SKILLS_MANIFEST);
+  try {
+    const parsed = JSON.parse(await fs.readFile(manifestPath, "utf8")) as unknown;
+    if (
+      !parsed ||
+      typeof parsed !== "object" ||
+      (parsed as { version?: unknown }).version !== 1 ||
+      (parsed as { managedBy?: unknown }).managedBy !== "paperclip" ||
+      typeof (parsed as { skills?: unknown }).skills !== "object" ||
+      (parsed as { skills?: unknown }).skills === null ||
+      Array.isArray((parsed as { skills?: unknown }).skills)
+    ) {
+      return emptyManagedSkillManifest();
+    }
+    return parsed as ManagedSkillManifest;
+  } catch {
+    return emptyManagedSkillManifest();
+  }
+}
+
+async function writeManagedSkillManifest(skillsHome: string, manifest: ManagedSkillManifest): Promise<void> {
+  await fs.mkdir(skillsHome, { recursive: true });
+  await fs.writeFile(
+    path.join(skillsHome, PAPERCLIP_MANAGED_SKILLS_MANIFEST),
+    `${JSON.stringify(manifest, null, 2)}\n`,
+    "utf8",
+  );
+}
+
+async function copyDirectory(source: string, target: string): Promise<void> {
+  const sourceRoot = path.resolve(source);
+  const targetRoot = path.resolve(target);
+  const relativeTarget = path.relative(sourceRoot, targetRoot);
+  const relativeSource = path.relative(targetRoot, sourceRoot);
+  if (
+    !relativeTarget ||
+    (!relativeTarget.startsWith("..") && !path.isAbsolute(relativeTarget)) ||
+    !relativeSource ||
+    (!relativeSource.startsWith("..") && !path.isAbsolute(relativeSource))
+  ) {
+    throw new Error("Refusing to copy a skill into itself, an ancestor, or one of its descendants.");
+  }
+
+  const sourceStat = await fs.lstat(sourceRoot);
+  if (sourceStat.isSymbolicLink() || !sourceStat.isDirectory()) {
+    throw new Error("Paperclip skills must be real directories.");
+  }
+
+  const tempRoot = `${targetRoot}.tmp-${process.pid}-${Date.now()}`;
+
+  async function copyEntry(sourcePath: string, targetPath: string): Promise<void> {
+    const stat = await fs.lstat(sourcePath);
+    if (stat.isSymbolicLink()) return;
+    if (stat.isDirectory()) {
+      await fs.mkdir(targetPath, { recursive: true });
+      const entries = await fs.readdir(sourcePath, { withFileTypes: true });
+      entries.sort((left, right) => left.name.localeCompare(right.name));
+      for (const entry of entries) {
+        await copyEntry(path.join(sourcePath, entry.name), path.join(targetPath, entry.name));
+      }
+      return;
+    }
+    if (!stat.isFile()) return;
+    await fs.mkdir(path.dirname(targetPath), { recursive: true });
+    await fs.copyFile(sourcePath, targetPath);
+    await fs.chmod(targetPath, stat.mode).catch(() => {});
+  }
+
+  try {
+    await copyEntry(sourceRoot, tempRoot);
+    await fs.rm(targetRoot, { recursive: true, force: true });
+    await fs.rename(tempRoot, targetRoot);
+  } finally {
+    await fs.rm(tempRoot, { recursive: true, force: true }).catch(() => {});
+  }
+}
+
+function isManifestManaged(
+  manifest: ManagedSkillManifest,
+  runtimeName: string,
+  source: string,
+  target: string,
+): boolean {
+  const entry = manifest.skills[runtimeName];
+  return entry?.source === path.resolve(source) && entry.target === path.resolve(target);
+}
+
+function manifestManagedTargets(manifest: ManagedSkillManifest): Set<string> {
+  return new Set(
+    Object.values(manifest.skills).map((entry) => path.resolve(entry.target)),
+  );
+}
+
+async function isSafeManagedTarget(
+  manifest: ManagedSkillManifest,
+  target: string,
+): Promise<boolean> {
+  const resolvedTarget = path.resolve(target);
+  for (const entry of Object.values(manifest.skills)) {
+    if (path.resolve(entry.target) === resolvedTarget) return true;
+  }
+  return !(await fs.stat(target).then(() => true).catch(() => false));
+}
+
 // ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
 
 async function buildHermesSkillSnapshot(config: Record<string, unknown>): Promise<AdapterSkillSnapshot> {
-  const home = resolveHermesHome(config);
-  const hermesSkillsHome = path.join(home, ".hermes", "skills");
+  const hermesSkillsHome = resolveHermesSkillsHome(config);
+  const manifest = await readManagedSkillManifest(hermesSkillsHome);
 
   // 1. Scan Paperclip-managed skills (bundled with the adapter)
   const paperclipEntries = await readPaperclipRuntimeSkillEntries(config, __moduleDir);
@@ -139,35 +336,60 @@ async function buildHermesSkillSnapshot(config: Record<string, unknown>): Promis
   // 2. Scan Hermes's own skills from ~/.hermes/skills/
   const hermesSkillEntries = await scanHermesSkills(hermesSkillsHome);
   const hermesKeys = new Set(hermesSkillEntries.map((e) => e.key));
+  const paperclipRuntimeNames = new Set(paperclipEntries.map((entry) => entry.runtimeName));
+  const managedTargets = manifestManagedTargets(manifest);
 
-  // 3. Merge: Paperclip skills first (ephemeral), then Hermes skills
+  // 3. Merge: Paperclip skills first, then Hermes skills
   const entries: AdapterSkillEntry[] = [];
   const warnings: string[] = [];
 
   // Paperclip-managed skills
   for (const entry of paperclipEntries) {
     const desired = desiredSet.has(entry.key);
+    const hermesName = await readSkillDeclaredName(entry.source, entry.runtimeName);
+    const targetPath = path.join(hermesSkillsHome, hermesName);
+    const managed = isManifestManaged(manifest, entry.runtimeName, entry.source, targetPath);
+    const targetExists = await fs.stat(path.join(targetPath, "SKILL.md")).then(() => true).catch(() => false);
+    const state = managed && targetExists
+      ? desired
+        ? "installed"
+        : "stale"
+      : desired
+        ? "missing"
+        : "available";
     entries.push({
       key: entry.key,
-      runtimeName: entry.runtimeName,
+      runtimeName: hermesName,
       desired,
       managed: true,
-      state: desired ? "configured" : "available",
+      state,
       origin: "company_managed",
       originLabel: "Managed by Paperclip",
       readOnly: false,
       sourcePath: entry.source,
-      targetPath: null,
-      detail: desired
-        ? "Will be available on the next run via Hermes skill loading."
-        : null,
+      targetPath,
+      detail: state === "installed"
+        ? "Copied into the Hermes profile skills directory under the SKILL.md name."
+        : state === "stale"
+          ? "Copied into the Hermes profile skills directory but no longer selected."
+          : desired
+            ? "Configured but not currently copied into the Hermes profile skills directory."
+            : null,
     });
   }
 
   // Hermes-installed skills (read-only, always loaded)
   for (const entry of hermesSkillEntries) {
-    // Skip if Paperclip already manages a skill with the same key
-    if (availableByKey.has(entry.key)) continue;
+    // Skip Paperclip-managed copies. They are reported through the managed
+    // entries above, even though Hermes also sees them as profile-local skills.
+    if (
+      availableByKey.has(entry.key) ||
+      (typeof entry.runtimeName === "string" && paperclipRuntimeNames.has(entry.runtimeName)) ||
+      (typeof entry.sourcePath === "string" &&
+        managedTargets.has(path.resolve(path.dirname(entry.sourcePath))))
+    ) {
+      continue;
+    }
     entries.push(entry);
   }
 
@@ -189,7 +411,7 @@ async function buildHermesSkillSnapshot(config: Record<string, unknown>): Promis
       sourcePath: null,
       targetPath: null,
       detail:
-        "Cannot find this skill in Paperclip or ~/.hermes/skills/.",
+        "Cannot find this skill in Paperclip or the Hermes profile skills directory.",
     });
   }
 
@@ -211,16 +433,55 @@ export async function listHermesSkills(
 
 export async function syncHermesSkills(
   ctx: AdapterSkillContext,
-  _desiredSkills: string[],
+  desiredSkills: string[],
 ): Promise<AdapterSkillSnapshot> {
-  // Hermes manages its own skill loading — sync is a no-op.
-  // Return the current snapshot so the UI stays in sync.
+  const availableEntries = await readPaperclipRuntimeSkillEntries(ctx.config, __moduleDir);
+  const desiredSet = new Set(desiredSkills);
+  const availableByRuntimeName = new Map(availableEntries.map((entry) => [entry.runtimeName, entry]));
+  const skillsHome = resolveHermesSkillsHome(ctx.config);
+  await fs.mkdir(skillsHome, { recursive: true });
+
+  const manifest = await readManagedSkillManifest(skillsHome);
+  const nextManifest = emptyManagedSkillManifest();
+
+  for (const available of availableEntries) {
+    if (!desiredSet.has(available.key)) continue;
+    const hermesName = await readSkillDeclaredName(available.source, available.runtimeName);
+    const preferredTarget = path.join(skillsHome, hermesName);
+    const target = await isSafeManagedTarget(manifest, preferredTarget)
+      ? preferredTarget
+      : path.join(skillsHome, available.runtimeName);
+    await copyDirectory(available.source, target);
+    nextManifest.skills[available.runtimeName] = {
+      key: available.key,
+      runtimeName: available.runtimeName,
+      hermesName: path.basename(target),
+      source: path.resolve(available.source),
+      target: path.resolve(target),
+      copiedAt: new Date().toISOString(),
+    };
+  }
+
+  for (const [runtimeName, manifestEntry] of Object.entries(manifest.skills)) {
+    const available = availableByRuntimeName.get(runtimeName);
+    const nextEntry = nextManifest.skills[runtimeName];
+    if (nextEntry?.target === manifestEntry.target) continue;
+    if (!available || !desiredSet.has(available.key) || nextEntry?.target !== manifestEntry.target) {
+      const target = path.resolve(manifestEntry.target);
+      const relative = path.relative(path.resolve(skillsHome), target);
+      if (relative && !relative.startsWith("..") && !path.isAbsolute(relative)) {
+        await fs.rm(target, { recursive: true, force: true }).catch(() => {});
+      }
+    }
+  }
+
+  await writeManagedSkillManifest(skillsHome, nextManifest);
   return buildHermesSkillSnapshot(ctx.config);
 }
 
 export function resolveHermesDesiredSkillNames(
   config: Record<string, unknown>,
-  availableEntries: Array<{ key: string; runtimeName?: string | null }>,
+  availableEntries: Array<{ key: string; required?: boolean }>,
 ): string[] {
   return resolvePaperclipDesiredSkillNames(config, availableEntries);
 }

--- a/packages/adapters/hermes/src/server/skills.ts
+++ b/packages/adapters/hermes/src/server/skills.ts
@@ -308,6 +308,16 @@ function manifestManagedTargets(manifest: ManagedSkillManifest): Set<string> {
   );
 }
 
+function manifestManagedEntry(
+  manifest: ManagedSkillManifest,
+  runtimeName: string,
+  source: string,
+): ManagedSkillManifest["skills"][string] | undefined {
+  const entry = manifest.skills[runtimeName];
+  if (!entry) return undefined;
+  return entry.source === path.resolve(source) ? entry : undefined;
+}
+
 async function isSafeManagedTarget(
   manifest: ManagedSkillManifest,
   target: string,
@@ -347,8 +357,12 @@ async function buildHermesSkillSnapshot(config: Record<string, unknown>): Promis
   for (const entry of paperclipEntries) {
     const desired = desiredSet.has(entry.key);
     const hermesName = await readSkillDeclaredName(entry.source, entry.runtimeName);
-    const targetPath = path.join(hermesSkillsHome, hermesName);
-    const managed = isManifestManaged(manifest, entry.runtimeName, entry.source, targetPath);
+    const preferredTargetPath = path.join(hermesSkillsHome, hermesName);
+    const manifestEntry = manifestManagedEntry(manifest, entry.runtimeName, entry.source);
+    const targetPath = manifestEntry ? path.resolve(manifestEntry.target) : preferredTargetPath;
+    const managed = manifestEntry
+      ? isManifestManaged(manifest, entry.runtimeName, entry.source, targetPath)
+      : false;
     const targetExists = await fs.stat(path.join(targetPath, "SKILL.md")).then(() => true).catch(() => false);
     const state = managed && targetExists
       ? desired
@@ -369,7 +383,7 @@ async function buildHermesSkillSnapshot(config: Record<string, unknown>): Promis
       sourcePath: entry.source,
       targetPath,
       detail: state === "installed"
-        ? "Copied into the Hermes profile skills directory under the SKILL.md name."
+        ? "Copied into the Hermes profile skills directory."
         : state === "stale"
           ? "Copied into the Hermes profile skills directory but no longer selected."
           : desired
@@ -448,9 +462,12 @@ export async function syncHermesSkills(
     if (!desiredSet.has(available.key)) continue;
     const hermesName = await readSkillDeclaredName(available.source, available.runtimeName);
     const preferredTarget = path.join(skillsHome, hermesName);
-    const target = await isSafeManagedTarget(manifest, preferredTarget)
-      ? preferredTarget
-      : path.join(skillsHome, available.runtimeName);
+    let target = preferredTarget;
+    if (!(await isSafeManagedTarget(manifest, preferredTarget))) {
+      const fallbackTarget = path.join(skillsHome, available.runtimeName);
+      if (!(await isSafeManagedTarget(manifest, fallbackTarget))) continue;
+      target = fallbackTarget;
+    }
     await copyDirectory(available.source, target);
     nextManifest.skills[available.runtimeName] = {
       key: available.key,

--- a/packages/adapters/hermes/src/server/skills.ts
+++ b/packages/adapters/hermes/src/server/skills.ts
@@ -14,6 +14,7 @@ import { fileURLToPath } from "node:url";
 
 const __moduleDir = path.dirname(fileURLToPath(import.meta.url));
 const PAPERCLIP_MANAGED_SKILLS_MANIFEST = ".paperclip-managed-skills.json";
+const HERMES_PROFILE_NAME_RE = /^[a-z0-9][a-z0-9_-]{0,63}$/;
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -79,6 +80,11 @@ export function resolveHermesSkillsHome(config: Record<string, unknown>): string
     ? path.resolve(configuredHermesHome)
     : path.join(configuredHome ? path.resolve(configuredHome) : os.homedir(), ".hermes");
   const profile = extractProfileFromArgs(config.extraArgs);
+  if (profile && !HERMES_PROFILE_NAME_RE.test(profile)) {
+    throw new Error(
+      `Invalid Hermes profile name ${JSON.stringify(profile)}. Expected [a-z0-9][a-z0-9_-]{0,63}.`,
+    );
+  }
   return profile
     ? path.join(hermesHome, "profiles", profile, "skills")
     : path.join(hermesHome, "skills");

--- a/packages/adapters/hermes/src/server/skills.ts
+++ b/packages/adapters/hermes/src/server/skills.ts
@@ -16,6 +16,7 @@ import {
 import { fileURLToPath } from "node:url";
 
 const __moduleDir = path.dirname(fileURLToPath(import.meta.url));
+const HERMES_PROFILE_NAME_RE = /^[a-z0-9][a-z0-9_-]{0,63}$/;
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -25,6 +26,32 @@ function asString(value: unknown): string | null {
   return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
 }
 
+function extractProfileFromArgs(value: unknown): string | null {
+  if (!Array.isArray(value) || value.length === 0) return null;
+
+  for (let i = 0; i < value.length; i += 1) {
+    const raw = value[i];
+    if (typeof raw !== "string") continue;
+    const arg = raw.trim();
+    if (!arg) continue;
+
+    const profilePairMatch = arg.match(/^(--profile|-p)\s+(.+)$/);
+    if (profilePairMatch) return profilePairMatch[2].trim() || null;
+
+    if (arg === "--profile" || arg === "-p") {
+      const next = value[i + 1];
+      return typeof next === "string" && next.trim().length > 0 ? next.trim() : null;
+    }
+
+    if (arg.startsWith("--profile=") || arg.startsWith("-p=")) {
+      const [, profile = ""] = arg.split("=", 2);
+      return profile.trim() || null;
+    }
+  }
+
+  return null;
+}
+
 function resolveHermesHome(config: Record<string, unknown>): string {
   const env =
     typeof config.env === "object" && config.env !== null && !Array.isArray(config.env)
@@ -32,6 +59,26 @@ function resolveHermesHome(config: Record<string, unknown>): string {
       : {};
   const configuredHome = asString(env.HOME);
   return configuredHome ? path.resolve(configuredHome) : os.homedir();
+}
+
+export function resolveHermesSkillsHome(config: Record<string, unknown>): string {
+  const env =
+    typeof config.env === "object" && config.env !== null && !Array.isArray(config.env)
+      ? (config.env as Record<string, unknown>)
+      : {};
+  const configuredHermesHome = asString(env.HERMES_HOME);
+  const hermesHome = configuredHermesHome
+    ? path.resolve(configuredHermesHome)
+    : path.join(resolveHermesHome(config), ".hermes");
+  const profile = extractProfileFromArgs(config.extraArgs);
+  if (profile && !HERMES_PROFILE_NAME_RE.test(profile)) {
+    throw new Error(
+      `Invalid Hermes profile name ${JSON.stringify(profile)}. Expected [a-z0-9][a-z0-9_-]{0,63}.`,
+    );
+  }
+  return profile
+    ? path.join(hermesHome, "profiles", profile, "skills")
+    : path.join(hermesHome, "skills");
 }
 
 interface SkillFrontmatter {
@@ -130,8 +177,7 @@ async function buildSkillEntry(
 // ---------------------------------------------------------------------------
 
 async function buildHermesSkillSnapshot(config: Record<string, unknown>): Promise<AdapterSkillSnapshot> {
-  const home = resolveHermesHome(config);
-  const hermesSkillsHome = path.join(home, ".hermes", "skills");
+  const hermesSkillsHome = resolveHermesSkillsHome(config);
 
   // 1. Scan Paperclip-managed skills (bundled with the adapter)
   const paperclipEntries = await readPaperclipRuntimeSkillEntries(config, __moduleDir);
@@ -224,7 +270,7 @@ export async function reconcileHermesPaperclipSkills(
       ]))
     : resolveLegacyPaperclipDesiredSkillNames(config, availableEntries);
   const desiredSet = new Set(desiredSkills);
-  const skillsHome = path.join(resolveHermesHome(config), ".hermes", "skills");
+  const skillsHome = resolveHermesSkillsHome(config);
   await fs.mkdir(skillsHome, { recursive: true });
   const installed = await readInstalledSkillTargets(skillsHome);
   const availableByRuntimeName = new Map(availableEntries.map((entry) => [entry.runtimeName, entry]));


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The Hermes local adapter exposes Paperclip runtime skills through the shared adapter skills UI
> - Today, selecting skills for Hermes can update Paperclip adapter state without materializing those skills where Hermes actually loads profile-local skills
> - Hermes profile runs need the selected Paperclip skills copied into the active Hermes home/profile skills directory
> - This pull request makes Hermes skill sync persistent and profile-aware while keeping Hermes-installed skills read-only
> - The benefit is that selected Paperclip skills become available to Hermes executions that use `HERMES_HOME` and `--profile`

## Linked Issues or Issue Description

Fixes #2316

## What Changed

- Resolve the Hermes skills directory from `HERMES_HOME`, `HOME`, and `--profile` / `-p` adapter args
- Materialize selected Paperclip runtime skills into the active Hermes skills directory on sync
- Track Paperclip-managed copied skills with a manifest so deselected skills can be cleaned up safely
- Report copied skills as installed/stale/missing without duplicating them as Hermes-installed skills
- Add focused coverage for profile path resolution, skill copy, deduplication, and cleanup

## Verification

- `pnpm --filter @paperclipai/hermes-paperclip-adapter test -- src/server/skills.test.ts --run`
- `pnpm --filter @paperclipai/hermes-paperclip-adapter typecheck`
- `pnpm --filter @paperclipai/hermes-paperclip-adapter build`

## Risks

- Moderate adapter-scope risk: this changes Hermes skill sync from a no-op into filesystem writes under the resolved Hermes skills directory. The implementation limits writes to selected Paperclip runtime skill directories, skips symlinks, uses a Paperclip-managed manifest, and only removes paths previously recorded as managed targets.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

OpenAI Codex GPT-5.5 with code execution and repository inspection.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge