### PR TITLE
fix(server/auth): reject the well-known dev secret in authenticated mode

### DIFF
--- a/server/src/__tests__/better-auth.test.ts
+++ b/server/src/__tests__/better-auth.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import type { BetterAuthOptions } from "better-auth";
 import { getCookies } from "better-auth/cookies";
 import {
+  assertAuthSecretAllowedForDeployment,
   buildBetterAuthAdvancedOptions,
   deriveAuthCookiePrefix,
   deriveAuthTrustedOrigins,
@@ -165,6 +166,18 @@ describe("Better Auth cookie scoping", () => {
       "https://board.example.test:3101",
       "http://board.example.test:3101",
     ]));
+  });
+
+  it("rejects the well-known development secret in authenticated mode", () => {
+    expect(() => assertAuthSecretAllowedForDeployment("paperclip-dev-secret", "authenticated"))
+      .toThrow(/well-known development value/);
+    expect(() => assertAuthSecretAllowedForDeployment("  paperclip-dev-secret  ", "authenticated"))
+      .toThrow(/well-known development value/);
+  });
+
+  it("allows the development secret outside authenticated mode and unique secrets everywhere", () => {
+    expect(() => assertAuthSecretAllowedForDeployment("paperclip-dev-secret", "local_trusted")).not.toThrow();
+    expect(() => assertAuthSecretAllowedForDeployment("k3Fh9tW2mQx7ZpVbN4rL8sJdA6cYeGuH", "authenticated")).not.toThrow();
   });
 
   it("prefers an explicit resolved listen port over the configured port", () => {

--- a/server/src/auth/better-auth.ts
+++ b/server/src/auth/better-auth.ts
@@ -122,6 +122,23 @@ export function deriveAuthTrustedOrigins(config: Config, opts?: { listenPort?: n
   return Array.from(trustedOrigins);
 }
 
+const WELL_KNOWN_DEV_AUTH_SECRET = "paperclip-dev-secret";
+
+export function assertAuthSecretAllowedForDeployment(
+  secret: string,
+  deploymentMode: Config["deploymentMode"],
+): void {
+  if (deploymentMode !== "authenticated") return;
+  if (secret.trim() === WELL_KNOWN_DEV_AUTH_SECRET) {
+    throw new Error(
+      `BETTER_AUTH_SECRET is set to the well-known development value "${WELL_KNOWN_DEV_AUTH_SECRET}", ` +
+      "which is published in this repository and signs both auth sessions and agent JWTs. " +
+      "Set a unique, high-entropy BETTER_AUTH_SECRET before running in authenticated mode " +
+      '(for example: openssl rand -base64 32).',
+    );
+  }
+}
+
 export function createBetterAuthInstance(db: Db, config: Config, trustedOrigins: string[]): BetterAuthInstance {
   const baseUrl = config.authBaseUrlMode === "explicit" ? config.authPublicBaseUrl : undefined;
   const publicUrl = process.env.PAPERCLIP_PUBLIC_URL?.trim() || baseUrl;
@@ -132,6 +149,7 @@ export function createBetterAuthInstance(db: Db, config: Config, trustedOrigins:
       "For local development, set BETTER_AUTH_SECRET=paperclip-dev-secret in your .env file.",
     );
   }
+  assertAuthSecretAllowedForDeployment(secret, config.deploymentMode);
   const disableSecureCookies = shouldDisableSecureAuthCookies({
     deploymentMode: config.deploymentMode,
     deploymentExposure: config.deploymentExposure,


### PR DESCRIPTION
## What

`BETTER_AUTH_SECRET=paperclip-dev-secret` is published in `.env.example`
and, via the `PAPERCLIP_AGENT_JWT_SECRET` fallback, signs both Better Auth
sessions and agent JWTs. A deployment running in `authenticated` mode that
keeps this value is forgeable by anyone who reads the repo.

This adds a startup guard (`assertAuthSecretAllowedForDeployment`) that
throws when the secret equals the well-known dev value while
`deploymentMode === "authenticated"`, pointing the operator to generate a
real one. `local_trusted` mode is unaffected. Includes unit tests.

## Verification

- `npx vitest run server/src/__tests__/better-auth.test.ts` → 16/16 pass.
- Cherry-picked cleanly onto current `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
