### PR TITLE
fix(agents): detach finance events instead of deleting them on agent removal

### DIFF
--- a/server/src/__tests__/cleanup-removal-service.test.ts
+++ b/server/src/__tests__/cleanup-removal-service.test.ts
@@ -9,6 +9,7 @@ import {
   createDb,
   documents,
   documentRevisions,
+  financeEvents,
   heartbeatRunEvents,
   heartbeatRuns,
   issueComments,
@@ -43,6 +44,7 @@ describeEmbeddedPostgres("cleanup removal services", () => {
   }, 20_000);
 
   afterEach(async () => {
+    await db.delete(financeEvents);
     await db.delete(heartbeatRunEvents);
     await db.delete(activityLog);
     await db.delete(issueReadStates);
@@ -151,6 +153,35 @@ describeEmbeddedPostgres("cleanup removal services", () => {
     await expect(db.select().from(heartbeatRuns).where(eq(heartbeatRuns.id, runId))).resolves.toHaveLength(0);
     await expect(db.select().from(issueComments).where(eq(issueComments.issueId, issueId))).resolves.toHaveLength(0);
     await expect(db.select().from(activityLog).where(eq(activityLog.companyId, companyId))).resolves.toHaveLength(0);
+  });
+
+  it("detaches finance events instead of deleting them when the agent is removed", async () => {
+    const { agentId, companyId, runId } = await seedFixture();
+    const financeEventId = randomUUID();
+
+    await db.insert(financeEvents).values({
+      id: financeEventId,
+      companyId,
+      agentId,
+      heartbeatRunId: runId,
+      eventKind: "provisioned_capacity_charge",
+      direction: "debit",
+      biller: "phantom",
+      amountCents: 1,
+      occurredAt: new Date(),
+    });
+
+    const removed = await agentService(db).remove(agentId);
+
+    expect(removed?.id).toBe(agentId);
+    await expect(db.select().from(agents).where(eq(agents.id, agentId))).resolves.toHaveLength(0);
+    await expect(db.select().from(heartbeatRuns).where(eq(heartbeatRuns.id, runId))).resolves.toHaveLength(0);
+
+    const [financeEvent] = await db.select().from(financeEvents).where(eq(financeEvents.id, financeEventId));
+    expect(financeEvent).toBeDefined();
+    expect(financeEvent.agentId).toBeNull();
+    expect(financeEvent.heartbeatRunId).toBeNull();
+    expect(financeEvent.amountCents).toBe(1);
   });
 
   it("removes issue read states and activity rows before deleting the company", async () => {

--- a/server/src/services/agents.ts
+++ b/server/src/services/agents.ts
@@ -10,6 +10,7 @@ import {
   agentWakeupRequests,
   activityLog,
   costEvents,
+  financeEvents,
   heartbeatRunEvents,
   heartbeatRuns,
   issueExecutionDecisions,
@@ -746,6 +747,15 @@ export function agentService(db: Db) {
           .update(issues)
           .set({ assigneeAgentId: null, createdByAgentId: null })
           .where(or(eq(issues.assigneeAgentId, id), eq(issues.createdByAgentId, id)));
+        // Finance/billing ledger rows must outlive the agent that generated them —
+        // detach the references rather than deleting, so deleting an agent never
+        // silently destroys real cost/billing history. Must run before the
+        // heartbeatRuns delete below, since financeEvents.heartbeatRunId also
+        // references heartbeatRuns.id.
+        await tx
+          .update(financeEvents)
+          .set({ agentId: null, heartbeatRunId: null })
+          .where(eq(financeEvents.agentId, id));
         await tx.delete(heartbeatRunEvents).where(eq(heartbeatRunEvents.agentId, id));
         await tx.delete(agentTaskSessions).where(eq(agentTaskSessions.agentId, id));
         await tx.delete(activityLog).where(


### PR DESCRIPTION
## Summary
- `agentService(db).remove()`'s transaction deletes `heartbeat_runs` without first handling dependent `finance_events` rows, causing a foreign key violation whenever the agent has any billable/ledger history:
  ```
  update or delete on table "heartbeat_runs" violates foreign key constraint
  "finance_events_heartbeat_run_id_heartbeat_runs_id_fk" on table "finance_events"
  ```
- Both `finance_events.agentId` and `finance_events.heartbeatRunId` are nullable references — the schema's own design intent is that billing/ledger history should outlive the agent that produced it, not be silently destroyed by an unrelated deletion.
- Fixed by nulling out those references before the `heartbeat_runs` delete, the same detach-not-delete pattern already used two lines above in the same transaction for `issues.assigneeAgentId`/`createdByAgentId`.

## How this was found
Hit this live while testing a new external adapter against a local instance: a successful agent run correctly produced a `finance_events` ledger row, and deleting the test agent afterward failed with a raw 500.

## Test plan
- [x] Added a regression test (`cleanup-removal-service.test.ts`) that seeds a `finance_events` row referencing an agent's heartbeat run, then asserts `remove()` succeeds and the finance event survives with its references nulled (not deleted)
- [x] Confirmed the test reproduces the exact production error when the fix is reverted, and passes with it applied
- [x] Added `financeEvents` to the suite's shared `afterEach` teardown, which didn't previously account for rows now correctly surviving agent deletion
- [x] `tsc --noEmit` on `server/` — no new errors (one pre-existing, unrelated error in `adapter-utils` confirmed via `git stash` to predate this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)