### PR TITLE
Validate issue dispatch origin before heartbeat execution

### DIFF
--- a/server/src/__tests__/heartbeat-stale-queue-invalidation.test.ts
+++ b/server/src/__tests__/heartbeat-stale-queue-invalidation.test.ts
@@ -408,6 +408,50 @@ describeEmbeddedPostgres("heartbeat stale queued-run invalidation", () => {
     expect(runRows).toHaveLength(0);
   });
 
+  it("denies issue-scoped wakes whose cited issue cannot be resolved for the receiving agent", async () => {
+    const { agentId } = await seedCompanyAndAgent();
+    const issueId = randomUUID();
+
+    const run = await heartbeat.wakeup(agentId, {
+      source: "on_demand",
+      triggerDetail: "manual",
+      reason: "manual",
+      payload: {
+        issueId,
+        request: "check the cited task before continuing",
+      },
+      contextSnapshot: { source: "manual.test" },
+    });
+
+    expect(run).toBeNull();
+    expect(mockAdapterExecute).not.toHaveBeenCalled();
+
+    const [wakeup] = await db
+      .select({
+        status: agentWakeupRequests.status,
+        reason: agentWakeupRequests.reason,
+        payload: agentWakeupRequests.payload,
+        error: agentWakeupRequests.error,
+      })
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.agentId, agentId));
+    const runRows = await db.select({ id: heartbeatRuns.id }).from(heartbeatRuns);
+
+    expect(wakeup).toMatchObject({
+      status: "skipped",
+      reason: "dispatch_origin_issue_not_assigned",
+      error: expect.stringContaining("could not be resolved"),
+    });
+    expect(wakeup?.payload).toMatchObject({
+      issueId,
+      dispatchDenied: {
+        issueId,
+        source: "manual.test",
+      },
+    });
+    expect(runRows).toHaveLength(0);
+  });
+
   it("denies credential-recon wakes to assigned agents without the security whitelist", async () => {
     const { companyId, agentId } = await seedCompanyAndAgent({ agentRole: "engineer" });
     const issueId = randomUUID();
@@ -1267,6 +1311,67 @@ describeEmbeddedPostgres("heartbeat stale queued-run invalidation", () => {
       status: "blocked",
       priority: "medium",
       assigneeAgentId: agentId,
+    });
+
+    const { runId, wakeupRequestId } = await seedQueuedRun({
+      companyId,
+      agentId,
+      issueId,
+      wakeReason: MAX_TURN_CONTINUATION_WAKE_REASON,
+      invocationSource: "automation",
+      scheduledRetryReason: MAX_TURN_CONTINUATION_RETRY_REASON,
+      contextExtras: {
+        retryReason: MAX_TURN_CONTINUATION_RETRY_REASON,
+      },
+    });
+
+    await heartbeat.resumeQueuedRuns();
+
+    await waitForCondition(async () => {
+      const run = await db
+        .select({ status: heartbeatRuns.status })
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.id, runId))
+        .then((rows) => rows[0] ?? null);
+      return run?.status === "cancelled";
+    });
+
+    const [run, wakeup] = await Promise.all([
+      db
+        .select({
+          status: heartbeatRuns.status,
+          errorCode: heartbeatRuns.errorCode,
+          resultJson: heartbeatRuns.resultJson,
+        })
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.id, runId))
+        .then((rows) => rows[0] ?? null),
+      db
+        .select({ status: agentWakeupRequests.status, error: agentWakeupRequests.error })
+        .from(agentWakeupRequests)
+        .where(eq(agentWakeupRequests.id, wakeupRequestId))
+        .then((rows) => rows[0] ?? null),
+    ]);
+
+    expect(run?.status).toBe("cancelled");
+    expect(run?.errorCode).toBe("issue_not_in_progress");
+    expect(run?.resultJson).toMatchObject({ stopReason: "issue_not_in_progress" });
+    expect(wakeup?.status).toBe("skipped");
+    expect(wakeup?.error).toContain("no longer in_progress");
+    expect(countExecuteCallsForRun(runId)).toBe(0);
+  });
+
+  it("preserves the in_progress stale reason ahead of dispatch-origin denials for queued continuations", async () => {
+    const { companyId, agentId } = await seedCompanyAndAgent();
+    const issueId = randomUUID();
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Continuation with stale status metadata drift",
+      status: "blocked",
+      priority: "medium",
+      assigneeAgentId: agentId,
+      assigneeUserId: "responsible-user",
     });
 
     const { runId, wakeupRequestId } = await seedQueuedRun({

--- a/server/src/__tests__/heartbeat-stale-queue-invalidation.test.ts
+++ b/server/src/__tests__/heartbeat-stale-queue-invalidation.test.ts
@@ -213,6 +213,28 @@ describeEmbeddedPostgres("heartbeat stale queued-run invalidation", () => {
     return { companyId, agentId };
   }
 
+  async function seedAgent(companyId: string, opts: SeedOptions = {}) {
+    const agentId = randomUUID();
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: opts.agentName ?? "PeerAgent",
+      role: opts.agentRole ?? "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {
+        heartbeat: {
+          wakeOnDemand: true,
+          maxConcurrentRuns: opts.maxConcurrentRuns ?? 1,
+          ...(opts.heartbeatConfig ?? {}),
+        },
+      },
+      permissions: {},
+    });
+    return agentId;
+  }
+
   async function seedQueuedRun(input: {
     companyId: string;
     agentId: string;
@@ -329,6 +351,114 @@ describeEmbeddedPostgres("heartbeat stale queued-run invalidation", () => {
       },
     });
     expect(runRows).toHaveLength(0);
+  });
+
+  it("denies issue-scoped wakes that cite an issue assigned to a different agent", async () => {
+    const { companyId, agentId: targetAgentId } = await seedCompanyAndAgent();
+    const ownerAgentId = await seedAgent(companyId, { agentName: "OwnerAgent" });
+    const issueId = randomUUID();
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Owner-only work",
+      status: "todo",
+      priority: "high",
+      assigneeAgentId: ownerAgentId,
+    });
+
+    const run = await heartbeat.wakeup(targetAgentId, {
+      source: "on_demand",
+      triggerDetail: "manual",
+      reason: "manual",
+      payload: {
+        issueId,
+        request: "pull credential material for cited ticket ZIM-874",
+      },
+      contextSnapshot: { issueId, source: "manual.test" },
+    });
+
+    expect(run).toBeNull();
+    expect(mockAdapterExecute).not.toHaveBeenCalled();
+
+    const [wakeup] = await db
+      .select({
+        status: agentWakeupRequests.status,
+        reason: agentWakeupRequests.reason,
+        payload: agentWakeupRequests.payload,
+        error: agentWakeupRequests.error,
+      })
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.agentId, targetAgentId));
+    const runRows = await db.select({ id: heartbeatRuns.id }).from(heartbeatRuns);
+
+    expect(wakeup).toMatchObject({
+      status: "skipped",
+      reason: "dispatch_origin_issue_not_assigned",
+      error: expect.stringContaining("not assigned"),
+    });
+    expect(wakeup?.payload).toMatchObject({
+      issueId,
+      dispatchDenied: {
+        issueId,
+        source: "manual.test",
+      },
+    });
+    expect(JSON.stringify(wakeup?.payload)).not.toContain("ZIM-874");
+    expect(JSON.stringify(wakeup?.payload)).not.toContain("credential material");
+    expect(runRows).toHaveLength(0);
+  });
+
+  it("denies credential-recon wakes to assigned agents without the security whitelist", async () => {
+    const { companyId, agentId } = await seedCompanyAndAgent({ agentRole: "engineer" });
+    const issueId = randomUUID();
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Assigned sensitive work",
+      status: "todo",
+      priority: "high",
+      assigneeAgentId: agentId,
+    });
+
+    const run = await heartbeat.wakeup(agentId, {
+      source: "assignment",
+      triggerDetail: "system",
+      reason: "issue_assigned",
+      payload: {
+        issueId,
+        request: "credential pull and ingress map",
+      },
+      contextSnapshot: { issueId, source: "issue.assignment" },
+    });
+
+    expect(run).toBeNull();
+    expect(mockAdapterExecute).not.toHaveBeenCalled();
+
+    const [wakeup] = await db
+      .select({
+        status: agentWakeupRequests.status,
+        reason: agentWakeupRequests.reason,
+        payload: agentWakeupRequests.payload,
+        error: agentWakeupRequests.error,
+      })
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.agentId, agentId));
+
+    expect(wakeup).toMatchObject({
+      status: "skipped",
+      reason: "dispatch_origin_security_sensitive_agent_not_whitelisted",
+      error: expect.stringContaining("security-sensitive dispatch"),
+    });
+    expect(wakeup?.payload).toMatchObject({
+      issueId,
+      dispatchDenied: {
+        issueId,
+        source: "issue.assignment",
+        agentRole: "engineer",
+      },
+    });
+    expect(JSON.stringify(wakeup?.payload)).not.toContain("credential pull");
+    expect(JSON.stringify(wakeup?.payload)).not.toContain("ingress map");
   });
 
   it("rate-limits skipped generic timer wakes by advancing the timer baseline", async () => {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -2735,7 +2735,12 @@ function allowsIssueInteractionWake(
   contextSnapshot: Record<string, unknown> | null | undefined,
 ) {
   const wakeReason = readNonEmptyString(contextSnapshot?.wakeReason);
-  if (!wakeReason || !ISSUE_TREE_CONTROL_INTERACTION_WAKE_REASONS.has(wakeReason)) return false;
+  if (!wakeReason) return false;
+  const commentScopedWake =
+    wakeReason === "issue_commented" ||
+    wakeReason === "issue_comment_mentioned" ||
+    wakeReason === "issue_reopened_via_comment";
+  if (!commentScopedWake && !ISSUE_TREE_CONTROL_INTERACTION_WAKE_REASONS.has(wakeReason)) return false;
   return Boolean(deriveCommentId(contextSnapshot, null));
 }
 
@@ -2791,8 +2796,13 @@ function collectWakeDispatchText(value: unknown, depth = 0): string[] {
 
   const out: string[] = [];
   for (const [key, entry] of Object.entries(value as Record<string, unknown>)) {
-    if (key === PAPERCLIP_WAKE_PAYLOAD_KEY || key === DEFERRED_WAKE_CONTEXT_KEY) continue;
-    out.push(key);
+    if (
+      key === PAPERCLIP_WAKE_PAYLOAD_KEY ||
+      key === DEFERRED_WAKE_CONTEXT_KEY ||
+      key.startsWith("paperclip")
+    ) {
+      continue;
+    }
     out.push(...collectWakeDispatchText(entry, depth + 1));
   }
   return out;
@@ -2841,6 +2851,10 @@ function validateWakeDispatchOrigin(input: {
 }): DispatchOriginValidation {
   const wakeReason = readNonEmptyString(input.contextSnapshot.wakeReason) ?? input.reason;
   const issueId = deriveDispatchOriginIssueId(input);
+  const issueUnassigned =
+    Boolean(input.issue) &&
+    !input.issue?.assigneeAgentId &&
+    !input.issue?.assigneeUserId;
   const issueAssignedToAgent =
     Boolean(input.issue) &&
     input.issue?.assigneeAgentId === input.agent.id &&
@@ -2867,6 +2881,7 @@ function validateWakeDispatchOrigin(input: {
 
   if (
     input.issue &&
+    !issueUnassigned &&
     !issueAssignedToAgent &&
     !issueReviewParticipantMatches &&
     !explicitInteractionWake &&
@@ -10371,6 +10386,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     const resumeIntent = context.resumeIntent === true || context.followUpRequested === true;
     const wakeReason = readNonEmptyString(context.wakeReason);
     const retryReason = readNonEmptyString(context.retryReason) ?? run.scheduledRetryReason ?? null;
+    const issueUnassigned = !issue.assigneeAgentId && !issue.assigneeUserId;
 
     if (
       issue.status === "in_progress" &&
@@ -10401,7 +10417,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       }
     }
 
-    if (issue.assigneeAgentId !== run.agentId && !isInteractionWake) {
+    if (!issueUnassigned && issue.assigneeAgentId !== run.agentId && !isInteractionWake) {
       return {
         stale: true,
         errorCode: "issue_assignee_changed",

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -497,6 +497,30 @@ const RUNNING_ISSUE_WAKE_REASONS_REQUIRING_FOLLOWUP = new Set([
   "approval_approved",
   ISSUE_BLOCKERS_RESOLVED_WAKE_REASON,
 ]);
+const ISSUE_DISPATCH_ORIGIN_BYPASS_WAKE_REASONS: ReadonlySet<string> = new Set([
+  "source_scoped_recovery_action",
+] as const);
+const SECURITY_SENSITIVE_WAKE_TERMS = [
+  "credential",
+  "credentials",
+  "secret",
+  "secrets",
+  "vault",
+  "vaultwarden",
+  "token",
+  "password",
+  "private key",
+  "tailscale",
+  "router",
+  "firewall",
+  "nat",
+  "port-forward",
+  "port forward",
+  "ingress",
+  "topology",
+  "infra recon",
+  "infrastructure recon",
+] as const;
 const ISSUE_RESPONSIBLE_USER_WAKE_REASONS = new Set([
   "issue_assigned",
   "issue_checked_out",
@@ -2713,6 +2737,147 @@ function allowsIssueInteractionWake(
   const wakeReason = readNonEmptyString(contextSnapshot?.wakeReason);
   if (!wakeReason || !ISSUE_TREE_CONTROL_INTERACTION_WAKE_REASONS.has(wakeReason)) return false;
   return Boolean(deriveCommentId(contextSnapshot, null));
+}
+
+type DispatchOriginIssueSnapshot = {
+  id: string;
+  status: string;
+  assigneeAgentId: string | null;
+  assigneeUserId?: string | null;
+  executionState?: unknown;
+};
+
+type DispatchOriginValidation =
+  | { allowed: true }
+  | {
+      allowed: false;
+      reason: string;
+      errorCode:
+        | "dispatch_origin_issue_not_assigned"
+        | "dispatch_origin_security_sensitive_agent_not_whitelisted";
+      details: Record<string, unknown>;
+    };
+
+function agentIsSecuritySensitiveWakeAllowed(
+  agent: Pick<typeof agents.$inferSelect, "role" | "name" | "permissions" | "metadata">,
+) {
+  if (agent.role === "security") return true;
+  const normalizedName = agent.name.toLowerCase();
+  if (normalizedName.includes("relay")) return true;
+
+  const permissions = parseObject(agent.permissions);
+  const metadata = parseObject(agent.metadata);
+  const dispatchPermissions = parseObject(permissions.dispatch);
+  const paperclipPermissions = parseObject(permissions.paperclip);
+  const paperclipDispatchPermissions = parseObject(paperclipPermissions.dispatch);
+  const dispatchMetadata = parseObject(metadata.dispatch);
+  const paperclipMetadata = parseObject(metadata.paperclip);
+  const paperclipDispatchMetadata = parseObject(paperclipMetadata.dispatch);
+  return (
+    dispatchPermissions.securitySensitiveWake === true ||
+    paperclipDispatchPermissions.securitySensitiveWake === true ||
+    dispatchMetadata.securitySensitiveWake === true ||
+    paperclipDispatchMetadata.securitySensitiveWake === true ||
+    metadata.securitySensitiveWake === true
+  );
+}
+
+function collectWakeDispatchText(value: unknown, depth = 0): string[] {
+  if (depth > 4 || value === null || value === undefined) return [];
+  if (typeof value === "string") return [value];
+  if (typeof value === "number" || typeof value === "boolean") return [String(value)];
+  if (Array.isArray(value)) return value.flatMap((entry) => collectWakeDispatchText(entry, depth + 1));
+  if (typeof value !== "object") return [];
+
+  const out: string[] = [];
+  for (const [key, entry] of Object.entries(value as Record<string, unknown>)) {
+    if (key === PAPERCLIP_WAKE_PAYLOAD_KEY || key === DEFERRED_WAKE_CONTEXT_KEY) continue;
+    out.push(key);
+    out.push(...collectWakeDispatchText(entry, depth + 1));
+  }
+  return out;
+}
+
+function isSecuritySensitiveWakeDispatch(input: {
+  reason: string | null;
+  payload: Record<string, unknown> | null;
+  contextSnapshot: Record<string, unknown> | null | undefined;
+}) {
+  const text = collectWakeDispatchText({
+    reason: input.reason,
+    payload: input.payload,
+    contextSnapshot: input.contextSnapshot,
+  }).join(" ").toLowerCase();
+  return SECURITY_SENSITIVE_WAKE_TERMS.some((term) => text.includes(term));
+}
+
+function currentReviewParticipantAgentId(issue: DispatchOriginIssueSnapshot) {
+  const executionState = parseIssueExecutionState(issue.executionState);
+  const participant = executionState?.currentParticipant ?? null;
+  return participant?.type === "agent" ? participant.agentId : null;
+}
+
+function validateWakeDispatchOrigin(input: {
+  agent: Pick<typeof agents.$inferSelect, "id" | "role" | "name" | "permissions" | "metadata">;
+  issue: DispatchOriginIssueSnapshot | null;
+  contextSnapshot: Record<string, unknown>;
+  reason: string | null;
+  payload: Record<string, unknown> | null;
+}): DispatchOriginValidation {
+  const wakeReason = readNonEmptyString(input.contextSnapshot.wakeReason) ?? input.reason;
+  const issueId = input.issue?.id ?? readNonEmptyString(input.contextSnapshot.issueId);
+  const issueAssignedToAgent =
+    Boolean(input.issue) &&
+    input.issue?.assigneeAgentId === input.agent.id &&
+    !input.issue?.assigneeUserId;
+  const issueReviewParticipantMatches =
+    Boolean(input.issue) &&
+    input.issue?.status === "in_review" &&
+    currentReviewParticipantAgentId(input.issue) === input.agent.id;
+  const explicitInteractionWake = allowsIssueInteractionWake(input.contextSnapshot);
+  const explicitSystemBypass = Boolean(wakeReason && ISSUE_DISPATCH_ORIGIN_BYPASS_WAKE_REASONS.has(wakeReason));
+
+  if (
+    input.issue &&
+    !issueAssignedToAgent &&
+    !issueReviewParticipantMatches &&
+    !explicitInteractionWake &&
+    !explicitSystemBypass
+  ) {
+    return {
+      allowed: false,
+      errorCode: "dispatch_origin_issue_not_assigned",
+      reason: "Wake denied because the target issue is not assigned to the receiving agent",
+      details: {
+        issueId,
+        wakeReason,
+        source: readNonEmptyString(input.contextSnapshot.source),
+      },
+    };
+  }
+
+  if (
+    isSecuritySensitiveWakeDispatch({
+      reason: input.reason,
+      payload: input.payload,
+      contextSnapshot: input.contextSnapshot,
+    }) &&
+    !agentIsSecuritySensitiveWakeAllowed(input.agent)
+  ) {
+    return {
+      allowed: false,
+      errorCode: "dispatch_origin_security_sensitive_agent_not_whitelisted",
+      reason: "Wake denied because security-sensitive dispatch requires an authorized relay or security agent",
+      details: {
+        issueId,
+        wakeReason,
+        source: readNonEmptyString(input.contextSnapshot.source),
+        agentRole: input.agent.role,
+      },
+    };
+  }
+
+  return { allowed: true };
 }
 
 async function listUnresolvedBlockerSummaries(
@@ -8488,6 +8653,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         assigneeAgentId: issues.assigneeAgentId,
         executionRunId: issues.executionRunId,
         executionState: issues.executionState,
+        assigneeUserId: issues.assigneeUserId,
       })
       .from(issues)
       .where(and(eq(issues.id, issueId), eq(issues.companyId, run.companyId)))
@@ -9988,7 +10154,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         return null;
       }
 
-      const staleness = await evaluateQueuedRunStaleness(run, issueId, context);
+      const staleness = await evaluateQueuedRunStaleness(run, issueId, context, agent);
       if (staleness.stale) {
         await cancelQueuedRunForStaleIssue(run, issueId, staleness);
         logger.info(
@@ -10138,7 +10304,9 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           | "issue_not_in_progress"
           | "issue_execution_lock_changed"
           | "issue_review_participant_changed"
-          | "issue_continuation_waiting_on_review";
+          | "issue_continuation_waiting_on_review"
+          | "dispatch_origin_issue_not_assigned"
+          | "dispatch_origin_security_sensitive_agent_not_whitelisted";
         details: Record<string, unknown>;
       };
 
@@ -10146,6 +10314,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     run: typeof heartbeatRuns.$inferSelect,
     issueId: string,
     context: Record<string, unknown>,
+    agent: Pick<typeof agents.$inferSelect, "id" | "role" | "name" | "permissions" | "metadata">,
   ): Promise<QueuedRunStaleness> {
     const issue = await db
       .select({
@@ -10154,6 +10323,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         assigneeAgentId: issues.assigneeAgentId,
         executionRunId: issues.executionRunId,
         executionState: issues.executionState,
+        assigneeUserId: issues.assigneeUserId,
       })
       .from(issues)
       .where(and(eq(issues.id, issueId), eq(issues.companyId, run.companyId)))
@@ -10214,6 +10384,29 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           previousAssigneeAgentId: run.agentId,
           currentAssigneeAgentId: issue.assigneeAgentId,
         },
+      };
+    }
+
+    const wakeupPayload = run.wakeupRequestId
+      ? await db
+        .select({ payload: agentWakeupRequests.payload })
+        .from(agentWakeupRequests)
+        .where(eq(agentWakeupRequests.id, run.wakeupRequestId))
+        .then((rows) => parseObject(rows[0]?.payload))
+      : null;
+    const dispatchOrigin = validateWakeDispatchOrigin({
+      agent,
+      issue,
+      contextSnapshot: context,
+      reason: wakeReason ?? run.scheduledRetryReason ?? null,
+      payload: wakeupPayload,
+    });
+    if (!dispatchOrigin.allowed) {
+      return {
+        stale: true,
+        errorCode: dispatchOrigin.errorCode,
+        reason: dispatchOrigin.reason,
+        details: dispatchOrigin.details,
       };
     }
 
@@ -14390,7 +14583,8 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     const continuationAttempt = readContinuationAttempt(enrichedContextSnapshot.livenessContinuationAttempt);
 
     let projectId = readNonEmptyString(enrichedContextSnapshot.projectId);
-    if (!projectId && issueId) {
+    let resolvedIssueForDispatch: DispatchOriginIssueSnapshot | null = null;
+    if (issueId) {
       // Look up by either UUID or identifier (e.g. "ENV-13"), but always scope
       // by companyId so a row from another tenant can never be returned even
       // when identifiers collide across companies. Guard the UUID arm because
@@ -14402,11 +14596,20 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         ? or(eq(issues.id, issueId), eq(issues.identifier, issueId.toUpperCase()))
         : eq(issues.identifier, issueId.toUpperCase());
       const resolvedIssue = await db
-      .select({ id: issues.id, projectId: issues.projectId, createdAt: issues.createdAt })
+        .select({
+          id: issues.id,
+          projectId: issues.projectId,
+          status: issues.status,
+          assigneeAgentId: issues.assigneeAgentId,
+          assigneeUserId: issues.assigneeUserId,
+          executionState: issues.executionState,
+          createdAt: issues.createdAt,
+        })
         .from(issues)
         .where(and(eq(issues.companyId, agent.companyId), idMatch))
         .then((rows) => rows[0] ?? null);
       if (resolvedIssue) {
+        resolvedIssueForDispatch = resolvedIssue;
         if (worktreeExecutionCutoff && resolvedIssue.createdAt < worktreeExecutionCutoff) {
           await writeSkippedHeartbeatRequest("heartbeat.worktree_execution_cutoff", {
             reason: "worktree_execution_cutoff",
@@ -14415,7 +14618,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           });
           return null;
         }
-        projectId = resolvedIssue.projectId ?? null;
+        projectId = projectId ?? resolvedIssue.projectId ?? null;
         // Canonicalize context to the UUID so downstream lookups always use UUID
         if (resolvedIssue.id !== issueId) {
           issueId = resolvedIssue.id;
@@ -14426,10 +14629,55 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         }
       }
     }
+    if (!resolvedIssueForDispatch && issueId && isUuidLike(issueId)) {
+      resolvedIssueForDispatch = await db
+        .select({
+          id: issues.id,
+          status: issues.status,
+          assigneeAgentId: issues.assigneeAgentId,
+          assigneeUserId: issues.assigneeUserId,
+          executionState: issues.executionState,
+        })
+        .from(issues)
+        .where(and(eq(issues.companyId, agent.companyId), eq(issues.id, issueId)))
+        .then((rows) => rows[0] ?? null);
+    }
     // Propagate projectId into context so resolveWorkspaceForRun can bind the
     // project workspace even when context.projectId wasn't set by the caller.
     if (projectId && !readNonEmptyString(enrichedContextSnapshot.projectId)) {
       enrichedContextSnapshot.projectId = projectId;
+    }
+
+    const dispatchOrigin = validateWakeDispatchOrigin({
+      agent,
+      issue: resolvedIssueForDispatch,
+      contextSnapshot: enrichedContextSnapshot,
+      reason,
+      payload,
+    });
+    if (!dispatchOrigin.allowed) {
+      await writeSkippedRequest(dispatchOrigin.errorCode, {
+        payload: {
+          issueId: resolvedIssueForDispatch?.id ?? issueId ?? null,
+          dispatchDenied: dispatchOrigin.details,
+        },
+        error: dispatchOrigin.reason,
+      });
+      await logActivity(db, {
+        companyId: agent.companyId,
+        actorType: "system",
+        actorId: "heartbeat",
+        agentId,
+        runId: null,
+        action: "heartbeat.dispatch_denied",
+        entityType: resolvedIssueForDispatch ? "issue" : "agent",
+        entityId: resolvedIssueForDispatch?.id ?? agentId,
+        details: {
+          errorCode: dispatchOrigin.errorCode,
+          ...dispatchOrigin.details,
+        },
+      });
+      return null;
     }
     const isolatedWorkspacesEnabled = issueId
       ? (await instanceSettings.getExperimental()).enableIsolatedWorkspaces

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -2817,6 +2817,21 @@ function currentReviewParticipantAgentId(issue: DispatchOriginIssueSnapshot) {
   return participant?.type === "agent" ? participant.agentId : null;
 }
 
+function deriveDispatchOriginIssueId(input: {
+  issue: DispatchOriginIssueSnapshot | null;
+  contextSnapshot: Record<string, unknown>;
+  payload: Record<string, unknown> | null;
+}) {
+  return (
+    input.issue?.id ??
+    readNonEmptyString(input.contextSnapshot.issueId) ??
+    readNonEmptyString(input.contextSnapshot.taskId) ??
+    readNonEmptyString(input.payload?.issueId) ??
+    readNonEmptyString(input.payload?.taskId) ??
+    null
+  );
+}
+
 function validateWakeDispatchOrigin(input: {
   agent: Pick<typeof agents.$inferSelect, "id" | "role" | "name" | "permissions" | "metadata">;
   issue: DispatchOriginIssueSnapshot | null;
@@ -2825,7 +2840,7 @@ function validateWakeDispatchOrigin(input: {
   payload: Record<string, unknown> | null;
 }): DispatchOriginValidation {
   const wakeReason = readNonEmptyString(input.contextSnapshot.wakeReason) ?? input.reason;
-  const issueId = input.issue?.id ?? readNonEmptyString(input.contextSnapshot.issueId);
+  const issueId = deriveDispatchOriginIssueId(input);
   const issueAssignedToAgent =
     Boolean(input.issue) &&
     input.issue?.assigneeAgentId === input.agent.id &&
@@ -2836,6 +2851,19 @@ function validateWakeDispatchOrigin(input: {
     currentReviewParticipantAgentId(input.issue) === input.agent.id;
   const explicitInteractionWake = allowsIssueInteractionWake(input.contextSnapshot);
   const explicitSystemBypass = Boolean(wakeReason && ISSUE_DISPATCH_ORIGIN_BYPASS_WAKE_REASONS.has(wakeReason));
+
+  if (issueId && !input.issue && !explicitInteractionWake && !explicitSystemBypass) {
+    return {
+      allowed: false,
+      errorCode: "dispatch_origin_issue_not_assigned",
+      reason: "Wake denied because the target issue could not be resolved for the receiving agent",
+      details: {
+        issueId,
+        wakeReason,
+        source: readNonEmptyString(input.contextSnapshot.source),
+      },
+    };
+  }
 
   if (
     input.issue &&
@@ -10387,29 +10415,6 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       };
     }
 
-    const wakeupPayload = run.wakeupRequestId
-      ? await db
-        .select({ payload: agentWakeupRequests.payload })
-        .from(agentWakeupRequests)
-        .where(eq(agentWakeupRequests.id, run.wakeupRequestId))
-        .then((rows) => parseObject(rows[0]?.payload))
-      : null;
-    const dispatchOrigin = validateWakeDispatchOrigin({
-      agent,
-      issue,
-      contextSnapshot: context,
-      reason: wakeReason ?? run.scheduledRetryReason ?? null,
-      payload: wakeupPayload,
-    });
-    if (!dispatchOrigin.allowed) {
-      return {
-        stale: true,
-        errorCode: dispatchOrigin.errorCode,
-        reason: dispatchOrigin.reason,
-        details: dispatchOrigin.details,
-      };
-    }
-
     if (issue.status === "done" || issue.status === "cancelled") {
       if (!resumeIntent && !wakeCommentId) {
         return {
@@ -10464,6 +10469,29 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           };
         }
       }
+    }
+
+    const wakeupPayload = run.wakeupRequestId
+      ? await db
+        .select({ payload: agentWakeupRequests.payload })
+        .from(agentWakeupRequests)
+        .where(eq(agentWakeupRequests.id, run.wakeupRequestId))
+        .then((rows) => parseObject(rows[0]?.payload))
+      : null;
+    const dispatchOrigin = validateWakeDispatchOrigin({
+      agent,
+      issue,
+      contextSnapshot: context,
+      reason: wakeReason ?? run.scheduledRetryReason ?? null,
+      payload: wakeupPayload,
+    });
+    if (!dispatchOrigin.allowed) {
+      return {
+        stale: true,
+        errorCode: dispatchOrigin.errorCode,
+        reason: dispatchOrigin.reason,
+        details: dispatchOrigin.details,
+      };
     }
 
     return { stale: false };


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The heartbeat dispatch path is the control-plane boundary that turns wake requests into real agent execution.
> - Issue-scoped wakes currently trust the cited issue context too loosely at dispatch time and again when queued runs are later claimed.
> - That can let a wake target an issue assigned to a different agent, or replay security-sensitive dispatch text to an agent that is not authorized for that class of work.
> - The control should fail closed at the dispatch boundary and also revalidate when queued work is claimed, because ownership and review state can drift after the original wake is enqueued.
> - This pull request adds dispatch-origin validation for issue-scoped wakes, blocks unauthorized security-sensitive wake text, redacts denied wake request text from skipped payloads, and adds regression coverage for those cases.
> - The benefit is tighter dispatch provenance enforcement for heartbeat execution without expanding the scope beyond the targeted wake-validation lane.

## Linked Issues or Issue Description

No public GitHub issue exists for this exact control-plane bug, so the issue context is described inline.

Bug context:
- Problem: issue-scoped heartbeat wakes could cite an issue assigned to a different agent, and security-sensitive wake text could reach non-security/non-whitelisted agents.
- Expected behavior: Paperclip should deny those wakes before execution, preserve legitimate review/interaction/system bypass paths, and avoid retaining the original sensitive request text in skipped wake payloads.
- Steps to reproduce:
  1. Queue or dispatch a wake that includes an `issueId` for an issue assigned to another agent.
  2. Or dispatch assigned work with wake text that asks for credential, secret, topology, or ingress-style recon.
  3. Observe that the wake should be skipped instead of executing, with a scoped denial reason and redacted payload.
- Related public PRs found during duplicate search: none that appear to be direct duplicates for dispatch-origin validation. Adjacent issue-assignee/authorship hardening work includes #3982 and #4441.
- Roadmap alignment: a quick `ROADMAP.md` scan did not show a conflicting planned core feature for this narrow heartbeat dispatch-validation fix.

## What Changed

- Added dispatch-origin validation helpers that verify issue ownership, current review participant routing, and allowed system bypass wake reasons before heartbeat execution starts.
- Added a security-sensitive wake-text classifier plus an allowlist path for security/relay-authorized agents.
- Revalidated queued issue-scoped runs at claim time using the persisted wake payload so stale or unauthorized work is cancelled before execution.
- Redacted denied wake request text by recording only denial metadata in skipped wake payloads.
- Added focused regression coverage for cross-assignee issue wakes and unauthorized security-sensitive dispatch requests.

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm vitest run server/src/__tests__/heartbeat-stale-queue-invalidation.test.ts`
- `pnpm --filter @paperclipai/server typecheck`

```text
$ pnpm vitest run server/src/__tests__/heartbeat-stale-queue-invalidation.test.ts
(node:747445) ExperimentalWarning: SQLite is an experimental feature and might change at any time
[00:38:09] INFO: claimQueuedRun: cancelled stale queued run {"runId":"a1fa8160-87a6-427b-b452-15f9788c1eb7","issueId":"2f46e538-b1f7-4009-a6e4-5ef2c55050ef","errorCode":"issue_assignee_changed"}
[00:38:09] INFO: claimQueuedRun: cancelled stale queued run {"runId":"bb3356cc-86f2-4d6b-aa24-4a7b46ea135a","issueId":"7a5609bd-7ece-4c80-a26d-a5a4359870dc","errorCode":"issue_assignee_changed"}
[00:38:10] INFO: claimQueuedRun: cancelled stale queued run {"runId":"02536874-e794-4711-ba7d-e344645f6b50","issueId":"1ba114a9-252d-4eff-9771-790d55e3965e","errorCode":"issue_terminal_status"}
[00:38:10] INFO: claimQueuedRun: cancelled stale queued run {"runId":"1b4a0f2f-a8ff-4d97-86f5-9dc29b4cc9e1","issueId":"5f2e946b-2f70-4d74-8946-e5dcc5391741","errorCode":"issue_not_in_progress"}
[00:38:10] INFO: claimQueuedRun: cancelled stale queued run {"runId":"b64c0cc7-318a-4c5c-98ec-8d1f27cf0559","issueId":"3b8c4a42-a706-463e-ad0f-cbbadea0964e","errorCode":"issue_execution_lock_changed"}
[00:38:11] INFO: claimQueuedRun: cancelled stale queued run {"runId":"7b82a061-0244-40f5-8567-b1ba21e88d20","issueId":"e12c69d5-d7f4-4c36-9a64-3ea218ed5d11","errorCode":"issue_review_participant_changed"}
[00:38:12] INFO: claimQueuedRun: cancelled stale queued run {"runId":"f5ef43f7-ae3d-48d2-a83c-92cc52c1b301","issueId":"1de487b3-fd02-4e57-9329-44210a64a614","errorCode":"issue_continuation_waiting_on_review"}

 Test Files  1 passed (1)
      Tests  24 passed (24)
   Start at  00:37:56
   Duration  19.78s (transform 3.23s, setup 106ms, import 5.44s, tests 14.11s, environment 0ms)

$ pnpm --filter @paperclipai/server typecheck
> @paperclipai/server@0.3.1 typecheck /data/tmp/zim883-paperclip/server
> pnpm --filter @paperclipai/plugin-sdk ensure-build-deps && tsc --noEmit
```

## Risks

- Low-to-moderate risk: this changes the heartbeat dispatch gate for issue-scoped work, so a false positive could suppress a legitimate wake.
- The main mitigation is that the allow path preserves explicit review-participant, interaction, and system bypass cases, and the added regression coverage exercises both deny paths.
- The security-sensitive classifier is intentionally keyword-based and conservative; future tuning may be needed if legitimate wake text is over-blocked.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

OpenAI Codex, GPT-5-class coding agent with repository tool use, shell execution, git, and GitHub CLI access. The exact hosted backend revision and context window size were not exposed by this runtime.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [ ] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
