### PR TITLE
Security: disable implicit Better Auth account linking

### DIFF
--- a/scripts/check-f004-better-auth.mjs
+++ b/scripts/check-f004-better-auth.mjs
@@ -7,7 +7,6 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 const FLOOR = "1.6.11";
-const TARGET = "1.6.20";
 
 function readJson(file) {
   try {
@@ -41,9 +40,11 @@ function inspect(root) {
   const installedVersion = installed?.version;
   const failures = [];
 
-  if (manifestVersion !== TARGET) failures.push("F004_MANIFEST_NOT_TARGET");
+  if (!parseVersion(manifestVersion)) failures.push("F004_MANIFEST_NOT_EXACT");
+  else if (!atLeast(manifestVersion, FLOOR)) failures.push("F004_MANIFEST_BELOW_FLOOR");
   if (!installedVersion) failures.push("F004_INSTALLED_UNRESOLVED");
-  else if (installedVersion !== TARGET) failures.push("F004_INSTALLED_NOT_TARGET");
+  else if (!parseVersion(installedVersion)) failures.push("F004_INSTALLED_INVALID");
+  else if (!atLeast(installedVersion, FLOOR)) failures.push("F004_INSTALLED_BELOW_FLOOR");
   if (manifestVersion && installedVersion && manifestVersion !== installedVersion) {
     failures.push("F004_MANIFEST_INSTALLED_MISMATCH");
   }
@@ -77,40 +78,60 @@ function selfTest() {
     fixture(vulnerable, "1.4.18", "1.4.18");
     results.push(inspect(vulnerable));
     assert.deepEqual(results.at(-1), {
-      failures: ["F004_MANIFEST_NOT_TARGET", "F004_INSTALLED_NOT_TARGET"],
+      failures: ["F004_MANIFEST_BELOW_FLOOR", "F004_INSTALLED_BELOW_FLOOR"],
       floorMet: false,
       manifestVersion: "1.4.18",
       installedVersion: "1.4.18",
     });
 
     const target = path.join(base, "target");
-    fixture(target, TARGET, TARGET);
+    fixture(target, "1.6.20", "1.6.20");
     results.push(inspect(target));
     assert.deepEqual(results.at(-1), {
       failures: [],
       floorMet: true,
-      manifestVersion: TARGET,
-      installedVersion: TARGET,
+      manifestVersion: "1.6.20",
+      installedVersion: "1.6.20",
+    });
+
+    const safeLater = path.join(base, "safe-later");
+    fixture(safeLater, "1.6.21", "1.6.21");
+    results.push(inspect(safeLater));
+    assert.deepEqual(results.at(-1), {
+      failures: [],
+      floorMet: true,
+      manifestVersion: "1.6.21",
+      installedVersion: "1.6.21",
     });
 
     const mismatch = path.join(base, "mismatch");
-    fixture(mismatch, TARGET, FLOOR);
+    fixture(mismatch, "1.6.20", FLOOR);
     results.push(inspect(mismatch));
     assert.deepEqual(results.at(-1), {
-      failures: ["F004_INSTALLED_NOT_TARGET", "F004_MANIFEST_INSTALLED_MISMATCH"],
+      failures: ["F004_MANIFEST_INSTALLED_MISMATCH"],
       floorMet: true,
-      manifestVersion: TARGET,
+      manifestVersion: "1.6.20",
       installedVersion: FLOOR,
     });
 
     const unresolved = path.join(base, "unresolved");
-    fixture(unresolved, TARGET, null);
+    fixture(unresolved, "1.6.20", null);
     results.push(inspect(unresolved));
     assert.deepEqual(results.at(-1), {
       failures: ["F004_INSTALLED_UNRESOLVED"],
       floorMet: false,
-      manifestVersion: TARGET,
+      manifestVersion: "1.6.20",
       installedVersion: "unresolved",
+    });
+
+    const ranged = path.join(base, "ranged");
+    fixture(ranged, "^1.6.20", "1.6.20");
+    results.push(inspect(ranged));
+    assert.deepEqual(results.at(-1), {
+      failures: ["F004_MANIFEST_NOT_EXACT", "F004_MANIFEST_INSTALLED_MISMATCH"],
+      floorMet: false,
+      manifestVersion: "^1.6.20",
+      installedVersion: "1.6.20",
     });
 
     const red = results.filter((result) => result.failures.length > 0).length;
@@ -129,7 +150,7 @@ if (process.argv.includes("--self-test")) {
   console.log(result.floorMet ? "F004_ADVISORY_FLOOR_GREEN" : "F004_ADVISORY_FLOOR_RED");
   for (const failure of result.failures) console.log(failure);
   console.log(
-    `${result.failures.length ? "F004_VERSION_GATE_RED" : "F004_VERSION_GATE_GREEN"} manifest=${result.manifestVersion} installed=${result.installedVersion} floor=${FLOOR} target=${TARGET}`,
+    `${result.failures.length ? "F004_VERSION_GATE_RED" : "F004_VERSION_GATE_GREEN"} manifest=${result.manifestVersion} installed=${result.installedVersion} floor=${FLOOR}`,
   );
   if (result.failures.length) process.exitCode = 1;
 }

--- a/scripts/check-f004-better-auth.mjs
+++ b/scripts/check-f004-better-auth.mjs
@@ -1,0 +1,135 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const FLOOR = "1.6.11";
+const TARGET = "1.6.20";
+
+function readJson(file) {
+  try {
+    return JSON.parse(fs.readFileSync(file, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+function parseVersion(value) {
+  const match = /^(\d+)\.(\d+)\.(\d+)$/.exec(value ?? "");
+  return match ? match.slice(1).map(Number) : null;
+}
+
+function atLeast(value, floor) {
+  const left = parseVersion(value);
+  const right = parseVersion(floor);
+  if (!left || !right) return false;
+  for (let index = 0; index < left.length; index += 1) {
+    if (left[index] !== right[index]) return left[index] > right[index];
+  }
+  return true;
+}
+
+function inspect(root) {
+  const manifest = readJson(path.join(root, "server", "package.json"));
+  const installed = readJson(
+    path.join(root, "server", "node_modules", "better-auth", "package.json"),
+  );
+  const manifestVersion = manifest?.dependencies?.["better-auth"];
+  const installedVersion = installed?.version;
+  const failures = [];
+
+  if (manifestVersion !== TARGET) failures.push("F004_MANIFEST_NOT_TARGET");
+  if (!installedVersion) failures.push("F004_INSTALLED_UNRESOLVED");
+  else if (installedVersion !== TARGET) failures.push("F004_INSTALLED_NOT_TARGET");
+  if (manifestVersion && installedVersion && manifestVersion !== installedVersion) {
+    failures.push("F004_MANIFEST_INSTALLED_MISMATCH");
+  }
+
+  return {
+    failures,
+    floorMet: atLeast(manifestVersion, FLOOR) && atLeast(installedVersion, FLOOR),
+    manifestVersion: manifestVersion ?? "unresolved",
+    installedVersion: installedVersion ?? "unresolved",
+  };
+}
+
+function fixture(root, manifestVersion, installedVersion) {
+  fs.mkdirSync(path.join(root, "server"), { recursive: true });
+  fs.writeFileSync(
+    path.join(root, "server", "package.json"),
+    JSON.stringify({ dependencies: { "better-auth": manifestVersion } }),
+  );
+  if (installedVersion) {
+    const installed = path.join(root, "server", "node_modules", "better-auth");
+    fs.mkdirSync(installed, { recursive: true });
+    fs.writeFileSync(path.join(installed, "package.json"), JSON.stringify({ version: installedVersion }));
+  }
+}
+
+function selfTest() {
+  const base = fs.mkdtempSync(path.join(os.tmpdir(), "f004-version-gate-"));
+  const results = [];
+  try {
+    const vulnerable = path.join(base, "vulnerable");
+    fixture(vulnerable, "1.4.18", "1.4.18");
+    results.push(inspect(vulnerable));
+    assert.deepEqual(results.at(-1), {
+      failures: ["F004_MANIFEST_NOT_TARGET", "F004_INSTALLED_NOT_TARGET"],
+      floorMet: false,
+      manifestVersion: "1.4.18",
+      installedVersion: "1.4.18",
+    });
+
+    const target = path.join(base, "target");
+    fixture(target, TARGET, TARGET);
+    results.push(inspect(target));
+    assert.deepEqual(results.at(-1), {
+      failures: [],
+      floorMet: true,
+      manifestVersion: TARGET,
+      installedVersion: TARGET,
+    });
+
+    const mismatch = path.join(base, "mismatch");
+    fixture(mismatch, TARGET, FLOOR);
+    results.push(inspect(mismatch));
+    assert.deepEqual(results.at(-1), {
+      failures: ["F004_INSTALLED_NOT_TARGET", "F004_MANIFEST_INSTALLED_MISMATCH"],
+      floorMet: true,
+      manifestVersion: TARGET,
+      installedVersion: FLOOR,
+    });
+
+    const unresolved = path.join(base, "unresolved");
+    fixture(unresolved, TARGET, null);
+    results.push(inspect(unresolved));
+    assert.deepEqual(results.at(-1), {
+      failures: ["F004_INSTALLED_UNRESOLVED"],
+      floorMet: false,
+      manifestVersion: TARGET,
+      installedVersion: "unresolved",
+    });
+
+    const red = results.filter((result) => result.failures.length > 0).length;
+    const green = results.length - red;
+    console.log(`F004_VERSION_SELF_TEST_OK red=${red} green=${green}`);
+  } finally {
+    fs.rmSync(base, { recursive: true, force: true });
+  }
+}
+
+if (process.argv.includes("--self-test")) {
+  selfTest();
+} else {
+  const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+  const result = inspect(root);
+  console.log(result.floorMet ? "F004_ADVISORY_FLOOR_GREEN" : "F004_ADVISORY_FLOOR_RED");
+  for (const failure of result.failures) console.log(failure);
+  console.log(
+    `${result.failures.length ? "F004_VERSION_GATE_RED" : "F004_VERSION_GATE_GREEN"} manifest=${result.manifestVersion} installed=${result.installedVersion} floor=${FLOOR} target=${TARGET}`,
+  );
+  if (result.failures.length) process.exitCode = 1;
+}

--- a/server/package.json
+++ b/server/package.json
@@ -32,6 +32,7 @@
     "skills"
   ],
   "scripts": {
+    "check:f004": "node ../scripts/check-f004-better-auth.mjs --self-test && node ../scripts/check-f004-better-auth.mjs",
     "dev": "tsx src/index.ts",
     "dev:watch": "cross-env PAPERCLIP_MIGRATION_PROMPT=never PAPERCLIP_MIGRATION_AUTO_APPLY=true tsx ./scripts/dev-watch.ts",
     "prepare:ui-dist": "bash ../scripts/prepare-server-ui-dist.sh",
@@ -40,6 +41,7 @@
     "postpack": "rm -rf ui-dist",
     "clean": "rm -rf dist",
     "start": "node dist/index.js",
+    "pretypecheck": "pnpm run check:f004",
     "typecheck": "pnpm --filter @paperclipai/plugin-sdk ensure-build-deps && tsc --noEmit"
   },
   "dependencies": {

--- a/server/src/__tests__/better-auth-account-linking.test.ts
+++ b/server/src/__tests__/better-auth-account-linking.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, describe, expect, it } from "vitest";
+import type { Db } from "@paperclipai/db";
+import { createBetterAuthInstance } from "../auth/better-auth.js";
+import type { Config } from "../config.js";
+
+const ENV_KEYS = [
+  "BETTER_AUTH_SECRET",
+  "PAPERCLIP_AGENT_JWT_SECRET",
+  "PAPERCLIP_PUBLIC_URL",
+] as const;
+const ORIGINAL_ENV = Object.fromEntries(ENV_KEYS.map((key) => [key, process.env[key]]));
+
+function restoreEnv() {
+  for (const key of ENV_KEYS) {
+    const value = ORIGINAL_ENV[key];
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+}
+
+describe("Better Auth account linking", () => {
+  afterEach(restoreEnv);
+
+  it("disables implicit linking in the resolved Better Auth context", async () => {
+    process.env.BETTER_AUTH_SECRET = "test-only-secret-012345678901234567890123456789";
+    delete process.env.PAPERCLIP_AGENT_JWT_SECRET;
+    delete process.env.PAPERCLIP_PUBLIC_URL;
+
+    const config = {
+      authBaseUrlMode: "explicit",
+      authPublicBaseUrl: "http://localhost:3100",
+      deploymentMode: "authenticated",
+      allowedHostnames: [],
+      authDisableSignUp: false,
+    } as Config;
+    const auth = createBetterAuthInstance({} as Db, config, []);
+    const context = await (auth as unknown as {
+      $context: Promise<{
+        options: {
+          account?: { accountLinking?: { disableImplicitLinking?: boolean } };
+        };
+      }>;
+    }).$context;
+
+    expect(context.options.account?.accountLinking?.disableImplicitLinking).toBe(true);
+  });
+});

--- a/server/src/__tests__/better-auth-drizzle.test.ts
+++ b/server/src/__tests__/better-auth-drizzle.test.ts
@@ -1,0 +1,92 @@
+import { randomUUID } from "node:crypto";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import {
+  applyPendingMigrations,
+  authAccounts,
+  authUsers,
+  createDb,
+  ensurePostgresDatabase,
+} from "@paperclipai/db";
+import detectPort from "detect-port";
+import { eq } from "drizzle-orm";
+import EmbeddedPostgres from "embedded-postgres";
+import { describe, expect, it } from "vitest";
+import { createBetterAuthInstance } from "../auth/better-auth.js";
+import type { Config } from "../config.js";
+
+const TEMP_PREFIX = path.join(tmpdir(), "paperclip-f004-");
+
+describe("Better Auth Drizzle compatibility", () => {
+  it(
+    "round-trips an email user and account through the production adapter",
+    async () => {
+      const dataDir = await mkdtemp(TEMP_PREFIX);
+      const port = await detectPort(55432);
+      const embedded = new EmbeddedPostgres({
+        databaseDir: dataDir,
+        user: "paperclip",
+        password: "paperclip",
+        port,
+        persistent: false,
+        initdbFlags: ["--encoding=UTF8", "--locale=C"],
+        onLog: () => {},
+        onError: () => {},
+      });
+      let db: ReturnType<typeof createDb> | undefined;
+      const originalSecret = process.env.BETTER_AUTH_SECRET;
+
+      try {
+        await embedded.initialise();
+        await embedded.start();
+
+        const adminUrl = `postgres://paperclip:paperclip@127.0.0.1:${port}/postgres`;
+        await ensurePostgresDatabase(adminUrl, "paperclip");
+        const url = `postgres://paperclip:paperclip@127.0.0.1:${port}/paperclip`;
+        await applyPendingMigrations(url);
+        db = createDb(url);
+
+        process.env.BETTER_AUTH_SECRET = "paperclip-f004-test-secret-at-least-32-characters";
+        const auth = createBetterAuthInstance(
+          db,
+          {
+            authBaseUrlMode: "explicit",
+            authPublicBaseUrl: "http://127.0.0.1",
+            deploymentMode: "authenticated",
+            allowedHostnames: [],
+            authDisableSignUp: false,
+          } as Config,
+          [],
+        );
+        const email = `f004-${randomUUID()}@example.invalid`;
+        const result = await auth.api.signUpEmail({
+          body: { name: "F-004 Canary", email, password: "correct-horse-battery-staple" },
+        });
+
+        expect(result.user.email).toBe(email);
+        const users = await db.select().from(authUsers).where(eq(authUsers.id, result.user.id));
+        const accounts = await db
+          .select()
+          .from(authAccounts)
+          .where(eq(authAccounts.userId, result.user.id));
+        expect(users).toHaveLength(1);
+        expect(accounts).toHaveLength(1);
+      } finally {
+        if (originalSecret === undefined) delete process.env.BETTER_AUTH_SECRET;
+        else process.env.BETTER_AUTH_SECRET = originalSecret;
+        try {
+          if (db) await db.$client.end();
+        } finally {
+          try {
+            await embedded.stop();
+          } finally {
+            if (!dataDir.startsWith(TEMP_PREFIX)) throw new Error("Refusing unsafe test cleanup");
+            await rm(dataDir, { recursive: true, force: true });
+          }
+        }
+      }
+    },
+    120_000,
+  );
+});

--- a/server/src/auth/better-auth.ts
+++ b/server/src/auth/better-auth.ts
@@ -75,7 +75,6 @@ export function shouldDisableSecureAuthCookies(input: {
     )
   );
 }
-
 function headersFromNodeHeaders(rawHeaders: IncomingHttpHeaders): Headers {
   const headers = new Headers();
   for (const [key, raw] of Object.entries(rawHeaders)) {
@@ -157,6 +156,11 @@ export function createBetterAuthInstance(db: Db, config: Config, trustedOrigins:
       enabled: true,
       requireEmailVerification: false,
       disableSignUp: config.authDisableSignUp,
+    },
+    account: {
+      accountLinking: {
+        disableImplicitLinking: true,
+      },
     },
     advanced: buildBetterAuthAdvancedOptions({ disableSecureCookies }),
   };


### PR DESCRIPTION
﻿## Thinking Path

> - Paperclip is the open-source app people use to manage AI agents for work.
> - Authenticated deployments use Better Auth for human identities and sessions.
> - Better Auth can implicitly link accounts that present the same email address.
> - An untrusted provider email match must not silently join an existing Paperclip identity.
> - This pull request disables implicit account linking in the resolved production auth configuration and proves that setting with a focused test.
> - It also gates the exact installed Better Auth version at or above the advisory floor and exercises the production Drizzle adapter against embedded Postgres.
> - The benefit is fail-closed identity linking plus reproducible dependency and adapter evidence.

## Linked Issues or Issue Description

Refs #1676 (related Google sign-in work using Better Auth; this PR does not implement that feature).

No exact public bug issue was found. In-PR bug description:

- **What happened:** the resolved Better Auth configuration did not explicitly disable implicit account linking, leaving identity-linking behavior dependent on library defaults.
- **Expected behavior:** Paperclip must require an explicit trusted linking flow; an email match alone must not join identities.
- **Steps to reproduce:** create the Better Auth instance for an authenticated deployment and inspect `$context.options.account.accountLinking.disableImplicitLinking`; before this change it was not set to `true`.
- **Paperclip commit:** `e4e12bfb` (PR base).
- **Deployment mode:** authenticated self-hosted server; core auth behavior, not adapter-specific.
- **Environment used for verification:** Windows, Node.js `v22.22.0`, built from source, embedded Postgres for the adapter round-trip.

## What Changed

- Set `account.accountLinking.disableImplicitLinking` to `true` in the production Better Auth options.
- Add focused resolved-context coverage for the account-linking policy.
- Add an embedded-Postgres/Drizzle signup round-trip through the production adapter.
- Add a fail-closed gate requiring an exact manifest version, a matching installed version, and Better Auth `>=1.6.11`; wire it before server type-checking.

## Verification

- `node scripts/check-f004-better-auth.mjs --self-test` (`red=4 green=2` after the review follow-up).
- `node scripts/check-f004-better-auth.mjs` (manifest and installed `1.6.20`, floor `1.6.11`).
- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/better-auth-account-linking.test.ts src/__tests__/better-auth.test.ts` (15 passed).
- `pnpm --filter @paperclipai/server typecheck` (passed).
- Initial PR CI passed build, typecheck, e2e, all test shards, security scans, and Greptile 5/5; a follow-up commit addresses Greptile's version-gate maintainability recommendation.

## Risks

- Users who previously relied on automatic same-email linking must use an explicit account-linking flow; this is the intended security boundary.
- The dependency gate intentionally rejects semver ranges and manifest/install mismatches for reproducibility, while allowing future exact versions at or above `1.6.11`.
- No database migration or lockfile change is included.

> This is a targeted security bug fix, not roadmap feature work. `ROADMAP.md` contains no overlapping account-linking item.

## Model Used

- OpenAI Codex, GPT-5-family coding agent (exact serving snapshot/context-window metadata not exposed), high-reasoning mode with terminal and code-editing tools. Claude Code provided an independent Crucible audit; its exact session model metadata was not exposed.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] Relevant behavior and risks are documented in this PR; no separate user documentation is needed
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green after the follow-up commit
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups after the follow-up commit
- [x] I will address all Greptile and reviewer comments before requesting merge

