### PR TITLE
fix(recovery): make skills-source EPERM during worktree swap retryable

### DIFF
--- a/packages/adapters/claude-local/src/server/prompt-cache.test.ts
+++ b/packages/adapters/claude-local/src/server/prompt-cache.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  buildClaudePromptBundleKeyWithSwapRetry,
+  SKILLS_SOURCE_UNAVAILABLE_ERROR_CODE,
+  SkillsSourceUnavailableError,
+  transientSkillsSourceFsErrorCode,
+} from "./prompt-cache.js";
+
+function fsError(code: string): NodeJS.ErrnoException {
+  const err = new Error(`${code}: simulated`) as NodeJS.ErrnoException;
+  err.code = code;
+  return err;
+}
+
+const noopLog = vi.fn(async () => {});
+
+describe("transientSkillsSourceFsErrorCode", () => {
+  it("recognizes worktree-swap FS error codes", () => {
+    for (const code of ["EPERM", "EACCES", "ENOENT", "EBUSY"]) {
+      expect(transientSkillsSourceFsErrorCode(fsError(code))).toBe(code);
+    }
+  });
+
+  it("ignores unrelated errors", () => {
+    expect(transientSkillsSourceFsErrorCode(fsError("EROFS"))).toBeNull();
+    expect(transientSkillsSourceFsErrorCode(new Error("plain"))).toBeNull();
+    expect(transientSkillsSourceFsErrorCode(null)).toBeNull();
+  });
+});
+
+describe("buildClaudePromptBundleKeyWithSwapRetry", () => {
+  const input = { skills: [], instructionsContents: null, onLog: noopLog };
+
+  it("returns the freshly computed key when the source is readable", async () => {
+    const computeKey = vi.fn(async () => "cachekey-abc");
+    const key = await buildClaudePromptBundleKeyWithSwapRetry(input, { computeKey });
+    expect(key).toBe("cachekey-abc");
+    expect(computeKey).toHaveBeenCalledTimes(1);
+  });
+
+  it("rides out a brief swap: retries transient FS errors then returns the real key", async () => {
+    let calls = 0;
+    const computeKey = vi.fn(async () => {
+      calls += 1;
+      if (calls < 3) throw fsError("EPERM");
+      return "recovered-key";
+    });
+    const sleep = vi.fn(async () => {});
+    const key = await buildClaudePromptBundleKeyWithSwapRetry(input, {
+      computeKey,
+      sleep,
+      retryBudgetMs: 30_000,
+      initialDelayMs: 1,
+    });
+    // Never returns a stale/empty hash — it recomputes the whole key each time.
+    expect(key).toBe("recovered-key");
+    expect(computeKey).toHaveBeenCalledTimes(3);
+    expect(sleep).toHaveBeenCalledTimes(2);
+  });
+
+  it("raises the dedicated retryable error once the retry budget is exhausted", async () => {
+    // Deterministic virtual clock so the budget elapses without real waiting.
+    let clock = 0;
+    const now = () => clock;
+    const sleep = vi.fn(async (ms: number) => {
+      clock += ms;
+    });
+    const computeKey = vi.fn(async () => {
+      clock += 1;
+      throw fsError("EPERM");
+    });
+    const err = await buildClaudePromptBundleKeyWithSwapRetry(input, {
+      computeKey,
+      sleep,
+      now,
+      retryBudgetMs: 100,
+      initialDelayMs: 25,
+    }).catch((e) => e);
+    expect(err).toBeInstanceOf(SkillsSourceUnavailableError);
+    expect((err as SkillsSourceUnavailableError).code).toBe(SKILLS_SOURCE_UNAVAILABLE_ERROR_CODE);
+  });
+
+  it("rethrows a non-transient error untouched (no masking as swap-unavailable)", async () => {
+    const boom = new Error("genuine bug");
+    const computeKey = vi.fn(async () => {
+      throw boom;
+    });
+    await expect(
+      buildClaudePromptBundleKeyWithSwapRetry(input, { computeKey }),
+    ).rejects.toBe(boom);
+    expect(computeKey).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/adapters/claude-local/src/server/prompt-cache.ts
+++ b/packages/adapters/claude-local/src/server/prompt-cache.ts
@@ -11,6 +11,45 @@ import {
 
 type SkillEntry = PaperclipSkillEntry;
 
+/**
+ * Error code raised when the skills source cannot be read while computing the
+ * prompt-cache bundle key — most commonly because a deploy is swapping the
+ * worktree out from under an in-flight run (EPERM/ENOENT/EBUSY on a
+ * `…/skills/…` source path). It is deliberately distinct from the generic
+ * `adapter_failed` so recovery can treat it as a retryable, swap-window-spanning
+ * transient rather than a hard failure that burns the run and false-escalates
+ * the issue to `blocked`.
+ */
+export const SKILLS_SOURCE_UNAVAILABLE_ERROR_CODE = "skills_source_unavailable";
+
+export class SkillsSourceUnavailableError extends Error {
+  code = SKILLS_SOURCE_UNAVAILABLE_ERROR_CODE;
+
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.name = "SkillsSourceUnavailableError";
+  }
+}
+
+// File-system error codes that indicate the skills source is *temporarily*
+// unreadable (a worktree swap in progress), not permanently broken. Re-reading
+// the same source a moment later usually succeeds once the swap completes.
+const TRANSIENT_SKILLS_SOURCE_FS_ERROR_CODES = new Set(["EPERM", "EACCES", "ENOENT", "EBUSY"]);
+
+export function transientSkillsSourceFsErrorCode(error: unknown): string | null {
+  const code = (error as { code?: unknown } | null)?.code;
+  return typeof code === "string" && TRANSIENT_SKILLS_SOURCE_FS_ERROR_CODES.has(code) ? code : null;
+}
+
+// Bounded in-process retry budget for a skills-source read that fails with a
+// transient FS error. Short by design: it lets a run ride out a *brief* swap
+// window without holding the process hostage. Longer swaps fall through to the
+// dedicated `skills_source_unavailable` error, where recovery/service.ts backs
+// off across the full (~18–20 min) swap window instead of burning attempts here.
+const SKILLS_SOURCE_RETRY_INITIAL_DELAY_MS = 250;
+const SKILLS_SOURCE_RETRY_MAX_DELAY_MS = 4_000;
+const SKILLS_SOURCE_RETRY_BUDGET_MS = 30_000;
+
 export interface ClaudePromptBundle {
   bundleKey: string;
   rootDir: string;
@@ -108,6 +147,72 @@ async function buildClaudePromptBundleKey(input: {
   return hash.digest("hex");
 }
 
+/**
+ * Compute the bundle key, tolerating a *transient* skills-source read failure
+ * (a deploy worktree swap in progress) with a short bounded retry. Critically it
+ * NEVER swallows the failure into an empty/partial hash — the whole key is
+ * recomputed from scratch on each attempt, so a stale bundle can never be
+ * reused. If the source stays unreadable past the retry budget it raises the
+ * dedicated retryable {@link SkillsSourceUnavailableError} instead of letting a
+ * generic FS error surface as `adapter_failed`.
+ */
+export async function buildClaudePromptBundleKeyWithSwapRetry(
+  input: {
+    skills: SkillEntry[];
+    instructionsContents: string | null;
+    onLog: AdapterExecutionContext["onLog"];
+  },
+  options?: {
+    retryBudgetMs?: number;
+    initialDelayMs?: number;
+    maxDelayMs?: number;
+    now?: () => number;
+    sleep?: (ms: number) => Promise<void>;
+    computeKey?: (bundleInput: {
+      skills: SkillEntry[];
+      instructionsContents: string | null;
+    }) => Promise<string>;
+  },
+): Promise<string> {
+  const retryBudgetMs = options?.retryBudgetMs ?? SKILLS_SOURCE_RETRY_BUDGET_MS;
+  const initialDelayMs = options?.initialDelayMs ?? SKILLS_SOURCE_RETRY_INITIAL_DELAY_MS;
+  const maxDelayMs = options?.maxDelayMs ?? SKILLS_SOURCE_RETRY_MAX_DELAY_MS;
+  const now = options?.now ?? (() => Date.now());
+  const sleep = options?.sleep ?? ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
+  const computeKey = options?.computeKey ?? buildClaudePromptBundleKey;
+
+  const deadline = now() + retryBudgetMs;
+  let attempt = 0;
+  let delayMs = initialDelayMs;
+  for (;;) {
+    try {
+      return await computeKey({
+        skills: input.skills,
+        instructionsContents: input.instructionsContents,
+      });
+    } catch (err) {
+      const fsCode = transientSkillsSourceFsErrorCode(err);
+      if (!fsCode) throw err;
+      attempt += 1;
+      const remaining = deadline - now();
+      if (remaining <= 0) {
+        throw new SkillsSourceUnavailableError(
+          `Skills source was unreadable (${fsCode}) after ${attempt} attempt(s) over ` +
+            `${retryBudgetMs}ms; a deploy worktree swap is likely in progress.`,
+          { cause: err },
+        );
+      }
+      await input.onLog(
+        "stderr",
+        `[paperclip] Skills source temporarily unreadable (${fsCode}); retrying prompt-cache ` +
+          `key (attempt ${attempt}) — likely a deploy worktree swap.\n`,
+      );
+      await sleep(Math.min(delayMs, remaining, maxDelayMs));
+      delayMs = Math.min(delayMs * 2, maxDelayMs);
+    }
+  }
+}
+
 async function ensureReadableFile(targetPath: string, contents: string): Promise<void> {
   try {
     await fs.access(targetPath, fsConstants.R_OK);
@@ -138,9 +243,10 @@ export async function prepareClaudePromptBundle(input: {
   onLog: AdapterExecutionContext["onLog"];
 }): Promise<ClaudePromptBundle> {
   const { companyId, skills, instructionsContents, onLog } = input;
-  const bundleKey = await buildClaudePromptBundleKey({
+  const bundleKey = await buildClaudePromptBundleKeyWithSwapRetry({
     skills,
     instructionsContents,
+    onLog,
   });
   const rootDir = path.join(resolveManagedClaudePromptCacheRoot(process.env, companyId), bundleKey);
   const skillsHome = path.join(rootDir, ".claude", "skills");

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -317,6 +317,13 @@ const WORKSPACE_VALIDATION_FAILURE_CODE = "workspace_validation_failed";
 const WORKSPACE_VALIDATION_RECOVERY_CAUSE = "workspace_validation_failed";
 const CONFIGURATION_INCOMPLETE_FAILURE_CODE = "configuration_incomplete";
 const CONFIGURATION_INCOMPLETE_RECOVERY_CAUSE = "configuration_incomplete";
+// Skills source unreadable during a deploy worktree swap (raised by the
+// claude-local prompt-cache bundler once its bounded in-process retry is
+// exhausted). Kept as its own retryable code — not `adapter_failed` — so
+// recovery/service.ts can back off across the full swap window. Matched
+// structurally by `code` because the error crosses the adapter→server package
+// boundary.
+const SKILLS_SOURCE_UNAVAILABLE_FAILURE_CODE = "skills_source_unavailable";
 const EXECUTION_REVIEW_PARTICIPANT_RECOVERY_RETRY_REASON = "execution_review_participant_recovery";
 const EXECUTION_REVIEW_PARTICIPANT_RECOVERY_WAKE_REASON = "execution_review_participant_recovery";
 const EXECUTION_REVIEW_PARTICIPANT_RECOVERY_CAUSE = "execution_review_participant_recovery";
@@ -1395,6 +1402,14 @@ function fingerprintFinalizeWorkspaceBranchValidation(input: {
 
 function isConfigurationIncompleteFailure(error: unknown): error is ConfigurationIncompleteFailure {
   return error instanceof ConfigurationIncompleteFailure;
+}
+
+// Detect the claude-local skills-source-unavailable failure structurally by its
+// `code` string, since the error is thrown in the adapter package and caught
+// here in the server package (an `instanceof` check would not survive the
+// package boundary).
+function isSkillsSourceUnavailableFailure(error: unknown): boolean {
+  return (error as { code?: unknown } | null)?.code === SKILLS_SOURCE_UNAVAILABLE_FAILURE_CODE;
 }
 
 function isConfigurationIncompleteFailedRun(
@@ -13170,11 +13185,13 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       );
       const workspaceValidationFailure = isWorkspaceValidationFailure(err) ? err : null;
       const configurationIncompleteFailure = isConfigurationIncompleteFailure(err) ? err : null;
+      const skillsSourceUnavailable = isSkillsSourceUnavailableFailure(err);
       const recordedResponsibleUserDenialCode =
         normalizeResponsibleUserDenialCode((await getRun(run.id).catch(() => null))?.errorCode);
       const failureErrorCode =
         workspaceValidationFailure?.code
         ?? configurationIncompleteFailure?.code
+        ?? (skillsSourceUnavailable ? SKILLS_SOURCE_UNAVAILABLE_FAILURE_CODE : null)
         ?? recordedResponsibleUserDenialCode
         ?? "adapter_failed";
       logger.error({ err, runId }, "heartbeat execution failed");
@@ -13298,11 +13315,13 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           // recovery path routes it to a human owner instead of looping retries.
           const workspaceValidationSetupFailure = isWorkspaceValidationFailure(outerErr) ? outerErr : null;
           const configurationIncompleteSetupFailure = isConfigurationIncompleteFailure(outerErr) ? outerErr : null;
+          const skillsSourceUnavailableSetupFailure = isSkillsSourceUnavailableFailure(outerErr);
           const recordedResponsibleUserDenialCode =
             normalizeResponsibleUserDenialCode((await getRun(runId).catch(() => null))?.errorCode);
           const setupFailureErrorCode =
             workspaceValidationSetupFailure?.code ??
             configurationIncompleteSetupFailure?.code ??
+            (skillsSourceUnavailableSetupFailure ? SKILLS_SOURCE_UNAVAILABLE_FAILURE_CODE : null) ??
             recordedResponsibleUserDenialCode ??
             "setup_failed";
           logger.error({ err: outerErr, runId }, "heartbeat execution setup failed");

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -245,6 +245,15 @@ const TRANSIENT_INFRA_CONTINUATION_ERROR_CODES = new Set<string>([
   "timeout",
 ]);
 
+// Skills source unreadable during a deploy worktree swap. Retryable like the
+// generic transient set, but the swap window is measured at ~18–20 min — far
+// longer than the 60s×3 (~3 min) generic backoff, which would exhaust its
+// attempts *inside the same swap window* and false-escalate the issue to
+// `blocked`. These codes get a dedicated, swap-window-spanning backoff instead.
+const WORKTREE_SWAP_CONTINUATION_ERROR_CODES = new Set<string>([
+  "skills_source_unavailable",
+]);
+
 const NON_RETRYABLE_CONTINUATION_ERROR_CODES = new Set<string>([
   "agent_not_invokable",
   "agent_not_found",
@@ -263,6 +272,11 @@ const CONTINUATION_WAITING_ON_REVIEW_ERROR_CODE = "issue_continuation_waiting_on
 const CONTINUATION_RECOVERY_TRANSIENT_MAX_ATTEMPTS = 3;
 const CONTINUATION_RECOVERY_DEFAULT_MAX_ATTEMPTS = 1;
 const CONTINUATION_RECOVERY_TRANSIENT_BASE_BACKOFF_MS = 60_000;
+// Worktree-swap backoff: base 5 min, exponential. With 4 attempts the retries
+// land at +5, +15, +35 min cumulative before escalating — so the last retry
+// clears the ~18–20 min swap window instead of burning out inside it.
+const CONTINUATION_RECOVERY_WORKTREE_SWAP_MAX_ATTEMPTS = 4;
+const CONTINUATION_RECOVERY_WORKTREE_SWAP_BASE_BACKOFF_MS = 5 * 60_000;
 
 type ContinuationRetryClassification = {
   kind: "transient_infra" | "non_retryable" | "default";
@@ -275,6 +289,14 @@ export function classifyContinuationFailure(latestRun: LatestIssueRun): Continua
   const errorCode = readNonEmptyString(latestRun?.errorCode);
   if (errorCode && NON_RETRYABLE_CONTINUATION_ERROR_CODES.has(errorCode)) {
     return { kind: "non_retryable", maxAttempts: 0, baseBackoffMs: 0, errorCode };
+  }
+  if (errorCode && WORKTREE_SWAP_CONTINUATION_ERROR_CODES.has(errorCode)) {
+    return {
+      kind: "transient_infra",
+      maxAttempts: CONTINUATION_RECOVERY_WORKTREE_SWAP_MAX_ATTEMPTS,
+      baseBackoffMs: CONTINUATION_RECOVERY_WORKTREE_SWAP_BASE_BACKOFF_MS,
+      errorCode,
+    };
   }
   if (errorCode && TRANSIENT_INFRA_CONTINUATION_ERROR_CODES.has(errorCode)) {
     return {

--- a/server/src/services/recovery/service.worktree-swap.test.ts
+++ b/server/src/services/recovery/service.worktree-swap.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { classifyContinuationFailure } from "./service.js";
+
+const run = (errorCode: string | null) =>
+  ({ errorCode } as unknown as Parameters<typeof classifyContinuationFailure>[0]);
+
+// Mirror of the backoff math in service.ts (requiredDelay = base * 2^(consecutive-1))
+// used only to assert the escalation window, not to couple to internals.
+function cumulativeWindowMs(base: number, maxAttempts: number): number {
+  let total = 0;
+  for (let consecutive = 1; consecutive < maxAttempts; consecutive += 1) {
+    total += base * Math.pow(2, consecutive - 1);
+  }
+  return total;
+}
+
+describe("worktree-swap continuation classification", () => {
+  it("skills_source_unavailable is retryable transient_infra", () => {
+    const c = classifyContinuationFailure(run("skills_source_unavailable"));
+    expect(c.kind).toBe("transient_infra");
+    expect(c.maxAttempts).toBeGreaterThan(0);
+    expect(c.errorCode).toBe("skills_source_unavailable");
+  });
+
+  it("backs off across the full ~18-20 min swap window before escalating to blocked", () => {
+    const c = classifyContinuationFailure(run("skills_source_unavailable"));
+    // The last retry must land past the measured swap window (~18 min) so a run
+    // that dies mid-swap is retried after the swap completes, not false-blocked.
+    const window = cumulativeWindowMs(c.baseBackoffMs, c.maxAttempts);
+    expect(window).toBeGreaterThanOrEqual(20 * 60_000);
+  });
+
+  it("uses a longer window than the generic 60s×3 transient backoff", () => {
+    const swap = classifyContinuationFailure(run("skills_source_unavailable"));
+    const generic = classifyContinuationFailure(run("adapter_failed"));
+    const swapWindow = cumulativeWindowMs(swap.baseBackoffMs, swap.maxAttempts);
+    const genericWindow = cumulativeWindowMs(generic.baseBackoffMs, generic.maxAttempts);
+    expect(swapWindow).toBeGreaterThan(genericWindow);
+    // Sanity: the generic path is exactly the ~3 min that motivated this fix.
+    expect(genericWindow).toBe(180_000);
+  });
+
+  it("generic adapter_failed keeps its existing 60s×3 backoff (no regression)", () => {
+    const c = classifyContinuationFailure(run("adapter_failed"));
+    expect(c.kind).toBe("transient_infra");
+    expect(c.baseBackoffMs).toBe(60_000);
+    expect(c.maxAttempts).toBe(3);
+  });
+});


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The heartbeat/recovery subsystem dispatches agent runs and, when a run's live execution disappears, re-enqueues or escalates the issue
> - Every claude-local run start computes a prompt-cache bundle key by hashing the run's skills source directory (`hashPathContents` in the claude-local adapter)
> - A local deploy that swaps the running git worktree can briefly make that skills source unreadable (EPERM/ENOENT/EBUSY) for an in-flight run; `hashPathContents` had no guard, so the failure surfaced as the generic `adapter_failed`
> - Recovery then treated it as a 60s×3 (~3 min) transient and exhausted all retries *inside the same* multi-minute swap window, false-escalating the issue to `blocked` even though the run would have succeeded moments later
> - This pull request makes the skills-source-unreadable case a first-class retryable condition — ride out brief swaps in-process, and give longer swaps a dedicated backoff that spans the swap window
> - The benefit is that transient deploy-time worktree swaps stop burning runs and stop false-escalating issues to `blocked`

## Linked Issues or Issue Description

No public GitHub issue. Describing in-PR (bug):

**What happens:** During a local deploy that rewrites the running worktree, an in-flight `claude-local` run can hit `EPERM`/`ENOENT` while hashing its skills source to build the prompt-cache key. `hashPathContents` does not guard `fs.lstat`/`fs.readdir`/`fs.readFile`, so the error propagates uncaught and is recorded as the generic `adapter_failed`.

**Why it's harmful:** `adapter_failed` is classified as a transient infra failure with a 60s×3 (~3 min) backoff. A worktree swap can take much longer than that, so all three retries burn inside the same swap window and the issue is escalated to `blocked` — a false positive, since the source becomes readable again once the swap completes.

**Expected:** brief swaps should be ridden out without failing the run; longer swaps should be retried after the swap completes, not escalated during it.

## What Changed

- **claude-local prompt-cache:** wrapped the bundle-key computation in a bounded in-process retry (`buildClaudePromptBundleKeyWithSwapRetry`) that retries only on transient FS error codes (`EPERM`/`EACCES`/`ENOENT`/`EBUSY`) with exponential backoff (250ms → cap 4s, ~30s total budget). The full key is recomputed from scratch on each attempt, so an empty/partial hash can never be reused (no stale cache key). On budget exhaustion it raises a dedicated `SkillsSourceUnavailableError` (code `skills_source_unavailable`) instead of a raw FS error.
- **heartbeat:** classify `skills_source_unavailable` into `failureErrorCode` in both the adapter-execute and setup catch paths, detected structurally by `code` (the error crosses the adapter→server package boundary), instead of falling through to `adapter_failed`.
- **recovery:** give `skills_source_unavailable` a dedicated swap-window-spanning continuation backoff (base 5 min, 4 attempts → retries at +5/+15/+35 min cumulative, so the last retry lands past a ~18–20 min swap window). The existing generic 60s×3 transient backoff for `adapter_failed` et al. is unchanged.
- **tests:** unit tests for the bounded-retry (recover-after-transient, exhaust-to-dedicated-error, rethrow-non-transient, no-stale-key) and for the new continuation classification / backoff window.

## Verification

```
pnpm --filter @paperclipai/adapter-claude-local typecheck   # clean
pnpm --filter @paperclipai/server typecheck                 # clean
npx vitest run \
  packages/adapters/claude-local/src/server/prompt-cache.test.ts \
  server/src/services/recovery/service.worktree-swap.test.ts \
  server/src/services/recovery/service.pause-durability.test.ts   # 15 passed
# regression check on adjacent suites
npx vitest run \
  server/src/__tests__/heartbeat-retry-scheduling.test.ts \
  server/src/__tests__/issue-recovery-actions.test.ts \
  server/src/services/recovery/successful-run-handoff.test.ts      # 67 passed
```

Manual repro of the core path: making a skills source unreadable (`chmod 000` / rename) while starting a `claude-local` run now surfaces `skills_source_unavailable` after the bounded retry (or recovers if the source becomes readable within the budget), rather than `adapter_failed`.

## Risks

Low. Behavioral change is scoped to a previously-unhandled failure path (skills source unreadable). No change to the happy path or to existing error codes. The new backoff lengthens time-to-`blocked` for a genuinely-persistent skills-source failure (~35 min vs ~3 min), which is intentional and bounded — such failures outside a deploy are rare, and escalation still occurs.

> Not core roadmap feature work — a reliability fix in the recovery/adapter path.

## Model Used

Claude Opus 4.8 (claude-opus-4-8), extended thinking, with tool use / code execution in an agentic CLI harness.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge