### PR TITLE
fix(wake): suppress self comment-wake when the assignee's own run authored the comment (ENGA-1828 F2(B))

### DIFF
--- a/server/src/__tests__/issue-update-comment-wakeup-routes.test.ts
+++ b/server/src/__tests__/issue-update-comment-wakeup-routes.test.ts
@@ -173,7 +173,7 @@ function registerModuleMocks() {
   }));
 }
 
-async function createApp() {
+async function createApp(actorOverride: Record<string, unknown> = {}) {
   const [{ errorHandler }, { issueRoutes }] = await Promise.all([
     vi.importActual<typeof import("../middleware/index.js")>("../middleware/index.js"),
     vi.importActual<typeof import("../routes/issues.js")>("../routes/issues.js"),
@@ -187,6 +187,7 @@ async function createApp() {
       companyIds: ["company-1"],
       source: "local_implicit",
       isInstanceAdmin: false,
+      ...actorOverride,
     };
     next();
   });
@@ -515,6 +516,67 @@ describe("issue update comment wakeups", () => {
           source: "issue.comment",
         }),
       }),
+    );
+  });
+
+  it("does not comment-wake the assignee when its own active run authored the comment via the board actor (ENGA-1828 F2(B))", async () => {
+    const existing = makeIssue({
+      assigneeAgentId: ASSIGNEE_AGENT_ID,
+      assigneeUserId: null,
+      status: "in_progress",
+    });
+    mockIssueService.getById.mockResolvedValue(existing);
+    mockIssueService.addComment.mockResolvedValue({
+      id: "comment-self",
+      issueId: existing.id,
+      companyId: existing.companyId,
+      body: "族B 完了: blog 1 / note 0（詳細→document posting-summary）",
+    });
+    // The assignee agent is mid-heartbeat and posts its own closing comment
+    // through the board (`local-board`) actor path, carrying its run id.
+    mockHeartbeatService.getActiveRunForAgent.mockImplementation(async (agentId: string) =>
+      agentId === ASSIGNEE_AGENT_ID ? ({ id: "run-self" } as any) : null,
+    );
+
+    const res = await request(await createApp({ runId: "run-self" }))
+      .post(`/api/issues/${existing.id}/comments`)
+      .send({ body: "族B 完了: blog 1 / note 0（詳細→document posting-summary）" });
+
+    expect(res.status).toBe(201);
+    await vi.waitFor(() =>
+      expect(mockHeartbeatService.getActiveRunForAgent).toHaveBeenCalledWith(ASSIGNEE_AGENT_ID),
+    );
+    expect(mockHeartbeatService.wakeup).not.toHaveBeenCalled();
+  });
+
+  it("still comment-wakes the assignee when the comment run is not the assignee's active run", async () => {
+    const existing = makeIssue({
+      assigneeAgentId: ASSIGNEE_AGENT_ID,
+      assigneeUserId: null,
+      status: "in_progress",
+    });
+    mockIssueService.getById.mockResolvedValue(existing);
+    mockIssueService.addComment.mockResolvedValue({
+      id: "comment-other-run",
+      issueId: existing.id,
+      companyId: existing.companyId,
+      body: "handling from a different run",
+    });
+    // The assignee's active run id differs from the run that authored the comment,
+    // so the wake must still fire (e.g. another agent posting under a board key).
+    mockHeartbeatService.getActiveRunForAgent.mockImplementation(async (agentId: string) =>
+      agentId === ASSIGNEE_AGENT_ID ? ({ id: "run-assignee-active" } as any) : null,
+    );
+
+    const res = await request(await createApp({ runId: "run-different" }))
+      .post(`/api/issues/${existing.id}/comments`)
+      .send({ body: "handling from a different run" });
+
+    expect(res.status).toBe(201);
+    await vi.waitFor(() => expect(mockHeartbeatService.wakeup).toHaveBeenCalledTimes(1));
+    expect(mockHeartbeatService.wakeup).toHaveBeenCalledWith(
+      ASSIGNEE_AGENT_ID,
+      expect.objectContaining({ reason: "issue_commented" }),
     );
   });
 

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -2477,6 +2477,24 @@ export function issueRoutes(
   const heartbeat = heartbeatService(db, {
     pluginWorkerManager: opts.pluginWorkerManager,
   });
+  // A comment authored by the assignee's OWN active run must not comment-wake
+  // that same assignee. The existing `actorType === "agent"` self-check misses
+  // the local-board mirror path: when an agent posts through the board actor
+  // (`local-board`, deployment_mode `local_trusted`) the actor becomes
+  // `type: "user"` yet still carries its run id in the `x-paperclip-run-id`
+  // header. Without this guard the orchestrator's own closing comment echoes
+  // back as an `issue_commented` wake to itself — a no-op self-wake loop
+  // (ENGA-1803 / ENGA-1623 / ENGA-1818 / ENGA-1828 F2(B)). A human board
+  // comment carries no run id, so this never suppresses a genuine wake.
+  const commentWakeIsAssigneeSelfAuthored = async (
+    assigneeId: string | null | undefined,
+    actorRunId: string | null | undefined,
+  ): Promise<boolean> => {
+    const runId = actorRunId?.trim();
+    if (!runId || !assigneeId) return false;
+    const assigneeActiveRun = await heartbeat.getActiveRunForAgent(assigneeId);
+    return assigneeActiveRun?.id === runId;
+  };
   const feedback = feedbackService(db);
   const companiesSvc = companyService(db);
   let searchSvc = opts.searchService ?? null;
@@ -8500,7 +8518,9 @@ export function issueRoutes(
       if (commentBody && comment) {
         const assigneeId = issue.assigneeAgentId;
         const actorIsAgent = actor.actorType === "agent";
-        const selfComment = actorIsAgent && actor.actorId === assigneeId;
+        const selfComment =
+          (actorIsAgent && actor.actorId === assigneeId) ||
+          (await commentWakeIsAssigneeSelfAuthored(assigneeId, actor.runId));
         const skipAssigneeCommentWake = selfComment || isClosed;
 
         if (assigneeId && !assigneeChanged && (reopened || !skipAssigneeCommentWake)) {
@@ -10027,7 +10047,9 @@ export function issueRoutes(
 
       const assigneeId = currentIssue.assigneeAgentId;
       const actorIsAgent = actor.actorType === "agent";
-      const selfComment = actorIsAgent && actor.actorId === assigneeId;
+      const selfComment =
+        (actorIsAgent && actor.actorId === assigneeId) ||
+        (await commentWakeIsAssigneeSelfAuthored(assigneeId, actor.runId));
       // Re-derive closed-ness from the post-mutation issue so the auto-approval
       // transition (in_review -> done) suppresses a stale `issue_commented` wake
       // to the returnAssignee for an already-completed issue.


### PR DESCRIPTION
## What

Single-commit re-application of the ENGA-1828 **F2(B)** self comment-wake filter, cherry-picked cleanly onto current `master`.

An agent posting a comment on its own assigned issue through the board (`local-board`) actor path — the default in `local_trusted` deployments — becomes `actorType: "user"`, so the existing `actorType === "agent"` self-comment guard misses it and an `issue_commented` wake fires back to the same assignee. That self-wake echo loop is behind a class of no-op family-B heartbeats.

The board actor still carries its run id in `x-paperclip-run-id`. This adds a guard at **both** comment-wake sites (`PATCH /issues/:id` and `POST /issues/:id/comments`): if the comment's run id equals the assignee's own currently-running run, treat it as self-authored and skip the wake. A human board comment carries no run id, so genuine wakes are unaffected.

## Scope

- `server/src/routes/issues.ts` — guard at the 2 comment-wake sites (+26/-3)
- `server/src/__tests__/issue-update-comment-wakeup-routes.test.ts` — 2 regression tests (suppression + non-assignee-run pass-through)

One commit, 2 files, +87/-3. No deploy-stack or unrelated changes.

## Verify (Node 22, pnpm)

**Targeted vitest** — `server/src/__tests__/issue-update-comment-wakeup-routes.test.ts`:
```
 Test Files  1 passed (1)
      Tests  9 passed (9)
   Duration  2.02s
```
(the `db.transaction` WARN lines in output are unrelated external-object-sync log noise from the harness, not test failures.)

**Typecheck** — `tsc --noEmit` reports **0 errors in `server/src/routes/issues.ts`** (the changed file). Two pre-existing errors remain in `server/src/services/routines.ts` (`activityGateScope` / `activityGatePolicy`), which is byte-identical to `master` in this branch (`git diff --stat master HEAD` = only the 2 files above) — they originate from the `activityGate` schema on `master` HEAD (#9436) and require a schema-typegen step, unrelated to this change.

## Notes

Originally shipped as YukiCrisp/paperclip#12 against a throwaway `base/enga-1828` branch that never reached `master`; this is the clean upstream re-submission on top of current `master`.