### PR TITLE
feat(projects): add bounded project hierarchy

### DIFF
--- a/packages/db/src/migrations/0147_project_tree.sql
+++ b/packages/db/src/migrations/0147_project_tree.sql
@@ -1,0 +1,7 @@
+ALTER TABLE "projects" ADD COLUMN "parent_project_id" uuid;
+--> statement-breakpoint
+ALTER TABLE "projects" ADD CONSTRAINT "projects_parent_project_id_projects_id_fk" FOREIGN KEY ("parent_project_id") REFERENCES "public"."projects"("id") ON DELETE no action ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "projects" ADD CONSTRAINT "projects_parent_not_self" CHECK ("parent_project_id" IS NULL OR "parent_project_id" <> "id");
+--> statement-breakpoint
+CREATE INDEX "projects_company_parent_idx" ON "projects" USING btree ("company_id", "parent_project_id");

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -1016,6 +1016,13 @@
       "when": 1783822632557,
       "tag": "0146_routine_activity_gate",
       "breakpoints": true
+    },
+    {
+      "idx": 147,
+      "version": "7",
+      "when": 1783824000000,
+      "tag": "0147_project_tree",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/projects.ts
+++ b/packages/db/src/schema/projects.ts
@@ -1,4 +1,5 @@
-import { pgTable, uuid, text, timestamp, date, index, jsonb } from "drizzle-orm/pg-core";
+import { sql } from "drizzle-orm";
+import { type AnyPgColumn, pgTable, uuid, text, timestamp, date, index, jsonb, check } from "drizzle-orm/pg-core";
 import type { AgentEnvConfig } from "@paperclipai/shared";
 import { companies } from "./companies.js";
 import { goals } from "./goals.js";
@@ -9,6 +10,7 @@ export const projects = pgTable(
   {
     id: uuid("id").primaryKey().defaultRandom(),
     companyId: uuid("company_id").notNull().references(() => companies.id),
+    parentProjectId: uuid("parent_project_id").references((): AnyPgColumn => projects.id),
     goalId: uuid("goal_id").references(() => goals.id),
     name: text("name").notNull(),
     description: text("description"),
@@ -27,5 +29,7 @@ export const projects = pgTable(
   },
   (table) => ({
     companyIdx: index("projects_company_idx").on(table.companyId),
+    companyParentIdx: index("projects_company_parent_idx").on(table.companyId, table.parentProjectId),
+    notSelfParent: check("projects_parent_not_self", sql`${table.parentProjectId} IS NULL OR ${table.parentProjectId} <> ${table.id}`),
   }),
 );

--- a/packages/plugins/plugin-llm-wiki/tests/plugin.spec.ts
+++ b/packages/plugins/plugin-llm-wiki/tests/plugin.spec.ts
@@ -522,6 +522,7 @@ function existingProject(): Project {
   return {
     id: "55555555-5555-4555-8555-555555555555",
     companyId: COMPANY_ID,
+    parentProjectId: null,
     urlKey: "existing-wiki-project",
     goalId: null,
     goalIds: [],

--- a/packages/plugins/sdk/src/testing.ts
+++ b/packages/plugins/sdk/src/testing.ts
@@ -1027,6 +1027,7 @@ export function createTestHarness(options: TestHarnessOptions): TestHarness {
           const project = {
             id: `project-${projects.size + 1}`,
             companyId,
+            parentProjectId: null,
             urlKey: declaration.projectKey,
             goalId: null,
             goalIds: [],

--- a/packages/shared/src/types/project.ts
+++ b/packages/shared/src/types/project.ts
@@ -78,6 +78,7 @@ export interface ProjectManagedByPlugin {
 export interface Project {
   id: string;
   companyId: string;
+  parentProjectId: string | null;
   urlKey: string;
   /** @deprecated Use goalIds / goals instead */
   goalId: string | null;

--- a/packages/shared/src/validators/project.ts
+++ b/packages/shared/src/validators/project.ts
@@ -98,6 +98,7 @@ export const updateProjectWorkspaceSchema = z.object({
 export type UpdateProjectWorkspace = z.infer<typeof updateProjectWorkspaceSchema>;
 
 const projectFields = {
+  parentProjectId: z.string().uuid().optional().nullable(),
   /** @deprecated Use goalIds instead */
   goalId: z.string().uuid().optional().nullable(),
   goalIds: z.array(z.string().uuid()).optional(),

--- a/server/src/__tests__/project-tree-routes.test.ts
+++ b/server/src/__tests__/project-tree-routes.test.ts
@@ -1,0 +1,131 @@
+import express from "express";
+import request from "supertest";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { activityLog, companies, createDb, projects as projectsTable } from "@paperclipai/db";
+import { errorHandler } from "../middleware/index.js";
+import { projectRoutes } from "../routes/projects.js";
+import { PROJECT_TREE_ERROR_CODES } from "../services/projects.js";
+import { getEmbeddedPostgresTestSupport, startEmbeddedPostgresTestDatabase } from "./helpers/embedded-postgres.js";
+
+const support = await getEmbeddedPostgresTestSupport();
+const describePostgres = support.supported ? describe : describe.skip;
+
+describePostgres("project tree HTTP wire contract", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+  let counter = 0;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-project-tree-routes-");
+    db = createDb(tempDb.connectionString);
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.delete(activityLog);
+    await db.delete(projectsTable);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => tempDb?.cleanup());
+
+  async function createCompany() {
+    counter += 1;
+    return db
+      .insert(companies)
+      .values({ name: `Tree Routes Co ${counter}`, issuePrefix: `WR${counter}` })
+      .returning()
+      .then((rows) => rows[0]!);
+  }
+
+  function createApp(companyId: string) {
+    const app = express();
+    app.locals.paperclipDb = db;
+    app.use(express.json());
+    app.use((req, _res, next) => {
+      (req as any).actor = {
+        type: "board",
+        userId: "project-tree-route-test",
+        companyIds: [companyId],
+        source: "local_implicit",
+        isInstanceAdmin: false,
+      };
+      next();
+    });
+    app.use("/api", projectRoutes(db));
+    app.use(errorHandler);
+    return app;
+  }
+
+  async function createProject(app: express.Express, companyId: string, body: Record<string, unknown>) {
+    const response = await request(app).post(`/api/companies/${companyId}/projects`).send(body);
+    expect(response.status, JSON.stringify(response.body)).toBe(201);
+    return response.body as { id: string; parentProjectId: string | null };
+  }
+
+  function expectTreeConflict(
+    response: request.Response,
+    code: (typeof PROJECT_TREE_ERROR_CODES)[keyof typeof PROJECT_TREE_ERROR_CODES],
+  ) {
+    expect(response.status, JSON.stringify(response.body)).toBe(409);
+    expect(response.body).toMatchObject({ code, details: { code } });
+  }
+
+  it("exposes parentProjectId on list, create, update, and detail responses", async () => {
+    const company = await createCompany();
+    const app = createApp(company.id);
+    const root = await createProject(app, company.id, { name: "Root" });
+    const child = await createProject(app, company.id, {
+      name: "Child",
+      parentProjectId: root.id,
+    });
+
+    expect(root.parentProjectId).toBeNull();
+    expect(child.parentProjectId).toBe(root.id);
+
+    const listResponse = await request(app).get(`/api/companies/${company.id}/projects`);
+    expect(listResponse.status, JSON.stringify(listResponse.body)).toBe(200);
+    expect(listResponse.body).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: root.id, parentProjectId: null }),
+        expect.objectContaining({ id: child.id, parentProjectId: root.id }),
+      ]),
+    );
+
+    const updateResponse = await request(app)
+      .patch(`/api/projects/${child.id}`)
+      .send({ parentProjectId: null });
+    expect(updateResponse.status, JSON.stringify(updateResponse.body)).toBe(200);
+    expect(updateResponse.body).toMatchObject({ id: child.id, parentProjectId: null });
+
+    const detailResponse = await request(app).get(`/api/projects/${child.id}`);
+    expect(detailResponse.status, JSON.stringify(detailResponse.body)).toBe(200);
+    expect(detailResponse.body).toMatchObject({ id: child.id, parentProjectId: null });
+  });
+
+  it("returns stable PROJECT_TREE codes for depth and invalid-parent conflicts", async () => {
+    const company = await createCompany();
+    const app = createApp(company.id);
+    const root = await createProject(app, company.id, { name: "Root" });
+    const level2 = await createProject(app, company.id, {
+      name: "Level 2",
+      parentProjectId: root.id,
+    });
+    const level3 = await createProject(app, company.id, {
+      name: "Level 3",
+      parentProjectId: level2.id,
+    });
+
+    const depthResponse = await request(app)
+      .post(`/api/companies/${company.id}/projects`)
+      .send({ name: "Level 4", parentProjectId: level3.id });
+    expectTreeConflict(depthResponse, PROJECT_TREE_ERROR_CODES.depthExceeded);
+
+    const missingParentResponse = await request(app)
+      .post(`/api/companies/${company.id}/projects`)
+      .send({
+        name: "Missing parent",
+        parentProjectId: "11111111-1111-4111-8111-111111111111",
+      });
+    expectTreeConflict(missingParentResponse, PROJECT_TREE_ERROR_CODES.parentNotFound);
+  });
+});

--- a/server/src/__tests__/project-tree-service.test.ts
+++ b/server/src/__tests__/project-tree-service.test.ts
@@ -1,0 +1,130 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { eq } from "drizzle-orm";
+import { companies, createDb, projects as projectsTable } from "@paperclipai/db";
+import { HttpError } from "../errors.js";
+import { projectService, PROJECT_TREE_ERROR_CODES } from "../services/projects.js";
+import { getEmbeddedPostgresTestSupport, startEmbeddedPostgresTestDatabase } from "./helpers/embedded-postgres.js";
+
+const support = await getEmbeddedPostgresTestSupport();
+const describePostgres = support.supported ? describe : describe.skip;
+
+describePostgres("project tree service", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+  let counter = 0;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-project-tree-");
+    db = createDb(tempDb.connectionString);
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.delete(projectsTable);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => tempDb?.cleanup());
+
+  async function company(name = "Tree Co") {
+    counter += 1;
+    return db.insert(companies).values({ name, issuePrefix: `TR${counter}` }).returning().then((rows) => rows[0]!);
+  }
+
+  async function rejectsCode(promise: Promise<unknown>, code: string) {
+    await expect(promise).rejects.toMatchObject<HttpError>({ status: 409, details: { code } });
+  }
+
+  it("persists nullable parentProjectId and returns it naturally", async () => {
+    const co = await company();
+    const svc = projectService(db);
+    const root = await svc.create(co.id, { name: "Root" });
+    const child = await svc.create(co.id, { name: "Child", parentProjectId: root.id });
+    expect(root.parentProjectId).toBeNull();
+    expect(child.parentProjectId).toBe(root.id);
+    expect((await svc.getById(child.id))?.parentProjectId).toBe(root.id);
+  });
+
+  it("rejects missing, cross-company, archived, and self parents", async () => {
+    const a = await company("A");
+    const b = await company("B");
+    const svc = projectService(db);
+    await rejectsCode(svc.create(a.id, { name: "Missing", parentProjectId: "11111111-1111-4111-8111-111111111111" }), PROJECT_TREE_ERROR_CODES.parentNotFound);
+    const foreign = await svc.create(b.id, { name: "Foreign" });
+    await rejectsCode(svc.create(a.id, { name: "Cross", parentProjectId: foreign.id }), PROJECT_TREE_ERROR_CODES.parentCompanyMismatch);
+    const archived = await svc.create(a.id, { name: "Archived", archivedAt: new Date() });
+    await rejectsCode(svc.create(a.id, { name: "Inactive child", parentProjectId: archived.id }), PROJECT_TREE_ERROR_CODES.parentArchived);
+    const root = await svc.create(a.id, { name: "Root" });
+    await rejectsCode(svc.update(root.id, { parentProjectId: root.id }), PROJECT_TREE_ERROR_CODES.selfParent);
+  });
+
+  it("enforces maximum depth three on create and subtree moves", async () => {
+    const co = await company();
+    const svc = projectService(db);
+    const root = await svc.create(co.id, { name: "Root" });
+    const level2 = await svc.create(co.id, { name: "Level 2", parentProjectId: root.id });
+    const level3 = await svc.create(co.id, { name: "Level 3", parentProjectId: level2.id });
+    await rejectsCode(svc.create(co.id, { name: "Level 4", parentProjectId: level3.id }), PROJECT_TREE_ERROR_CODES.depthExceeded);
+    const subtree = await svc.create(co.id, { name: "Subtree" });
+    await svc.create(co.id, { name: "Subtree child", parentProjectId: subtree.id });
+    await rejectsCode(svc.update(subtree.id, { parentProjectId: level2.id }), PROJECT_TREE_ERROR_CODES.depthExceeded);
+  });
+
+  it("rejects cycles", async () => {
+    const co = await company();
+    const svc = projectService(db);
+    const root = await svc.create(co.id, { name: "Root" });
+    const child = await svc.create(co.id, { name: "Child", parentProjectId: root.id });
+    await rejectsCode(svc.update(root.id, { parentProjectId: child.id }), PROJECT_TREE_ERROR_CODES.cycle);
+  });
+
+  it("serializes concurrent moves that would otherwise create a cycle", async () => {
+    const co = await company();
+    const svc = projectService(db);
+    const left = await svc.create(co.id, { name: "Left" });
+    const right = await svc.create(co.id, { name: "Right" });
+
+    const results = await Promise.allSettled([
+      svc.update(left.id, { parentProjectId: right.id }),
+      svc.update(right.id, { parentProjectId: left.id }),
+    ]);
+
+    expect(results.filter((result) => result.status === "fulfilled")).toHaveLength(1);
+    const rejected = results.find((result) => result.status === "rejected");
+    expect(rejected).toMatchObject({
+      status: "rejected",
+      reason: { status: 409, details: { code: PROJECT_TREE_ERROR_CODES.cycle } },
+    });
+
+    const rows = await db.select().from(projectsTable).where(eq(projectsTable.companyId, co.id));
+    const byId = new Map(rows.map((row) => [row.id, row]));
+    for (const row of rows) {
+      const seen = new Set([row.id]);
+      let current = row;
+      while (current.parentProjectId) {
+        expect(seen.has(current.parentProjectId)).toBe(false);
+        seen.add(current.parentProjectId);
+        current = byId.get(current.parentProjectId)!;
+      }
+    }
+  });
+
+  it("guards archive, unarchive, and hard delete lifecycle operations", async () => {
+    const co = await company();
+    const svc = projectService(db);
+    const root = await svc.create(co.id, { name: "Root" });
+    const child = await svc.create(co.id, { name: "Child", parentProjectId: root.id });
+    await rejectsCode(svc.update(root.id, { archivedAt: new Date() }), PROJECT_TREE_ERROR_CODES.activeDescendants);
+    await svc.update(child.id, { archivedAt: new Date() });
+    await svc.update(root.id, { archivedAt: new Date() });
+    await rejectsCode(svc.update(child.id, { archivedAt: null }), PROJECT_TREE_ERROR_CODES.archivedParent);
+    await rejectsCode(svc.remove(root.id), PROJECT_TREE_ERROR_CODES.descendantsExist);
+    await svc.remove(child.id);
+    await expect(svc.remove(root.id)).resolves.toMatchObject({ id: root.id });
+  });
+
+  it("keeps plugin-managed projects at the root", async () => {
+    const co = await company();
+    const project = await projectService(db).create(co.id, { name: "Plugin root" });
+    expect(project.parentProjectId).toBeNull();
+  });
+});

--- a/server/src/services/projects.ts
+++ b/server/src/services/projects.ts
@@ -32,8 +32,30 @@ import { listCurrentRuntimeServicesForProjectWorkspaces } from "./workspace-runt
 import { parseProjectExecutionWorkspacePolicy } from "./execution-workspace-policy.js";
 import { mergeProjectWorkspaceRuntimeConfig, readProjectWorkspaceRuntimeConfig } from "./project-workspace-runtime-config.js";
 import { resolveManagedProjectWorkspaceDir } from "../home-paths.js";
+import { conflict } from "../errors.js";
 
 type ProjectRow = typeof projects.$inferSelect;
+type ProjectTreeDb = Parameters<Parameters<Db["transaction"]>[0]>[0];
+type ProjectQueryDb = Db | ProjectTreeDb;
+
+export const PROJECT_TREE_MAX_DEPTH = 3;
+export const PROJECT_TREE_ERROR_CODES = {
+  parentNotFound: "PROJECT_PARENT_NOT_FOUND",
+  parentCompanyMismatch: "PROJECT_PARENT_COMPANY_MISMATCH",
+  parentArchived: "PROJECT_PARENT_ARCHIVED",
+  selfParent: "PROJECT_SELF_PARENT",
+  cycle: "PROJECT_PARENT_CYCLE",
+  depthExceeded: "PROJECT_TREE_DEPTH_EXCEEDED",
+  activeDescendants: "PROJECT_ACTIVE_DESCENDANTS",
+  archivedParent: "PROJECT_ARCHIVED_PARENT",
+  descendantsExist: "PROJECT_DESCENDANTS_EXIST",
+} as const;
+
+type ProjectTreeErrorCode = typeof PROJECT_TREE_ERROR_CODES[keyof typeof PROJECT_TREE_ERROR_CODES];
+
+function projectTreeConflict(code: ProjectTreeErrorCode, message: string) {
+  return conflict(message, { code });
+}
 type ProjectWorkspaceRow = typeof projectWorkspaces.$inferSelect;
 type WorkspaceRuntimeServiceRow = typeof workspaceRuntimeServices.$inferSelect;
 const REPO_ONLY_CWD_SENTINEL = "/__paperclip_repo_only__";
@@ -79,7 +101,7 @@ interface ResolveProjectNameOptions {
 }
 
 /** Batch-load goal refs for a set of projects. */
-async function attachGoals(db: Db, rows: ProjectRow[]): Promise<ProjectWithGoals[]> {
+async function attachGoals(db: ProjectQueryDb, rows: ProjectRow[]): Promise<ProjectWithGoals[]> {
   if (rows.length === 0) return [];
 
   const projectIds = rows.map((r) => r.id);
@@ -231,7 +253,7 @@ function pickPrimaryWorkspace(
 }
 
 /** Batch-load workspace refs for a set of projects. */
-async function attachWorkspaces(db: Db, rows: ProjectWithGoals[]): Promise<ProjectWithGoals[]> {
+async function attachWorkspaces(db: ProjectQueryDb, rows: ProjectWithGoals[]): Promise<ProjectWithGoals[]> {
   if (rows.length === 0) return [];
 
   const projectIds = rows.map((r) => r.id);
@@ -400,8 +422,112 @@ async function attachListMetrics(
   }));
 }
 
+async function loadCompanyProjectTree(db: ProjectTreeDb, companyId: string): Promise<ProjectRow[]> {
+  return db.select().from(projects).where(eq(projects.companyId, companyId));
+}
+
+async function withProjectTreeTransaction<T>(
+  db: Db,
+  companyId: string,
+  work: (tx: ProjectTreeDb) => Promise<T>,
+): Promise<T> {
+  return db.transaction(async (tx) => {
+    await tx.execute(sql`select pg_advisory_xact_lock(hashtextextended(${`project-tree:${companyId}`}, 0))`);
+    return work(tx);
+  });
+}
+
+function collectDescendantIds(rows: ProjectRow[], projectId: string): Set<string> {
+  const childrenByParent = new Map<string, string[]>();
+  for (const row of rows) {
+    if (!row.parentProjectId) continue;
+    const children = childrenByParent.get(row.parentProjectId) ?? [];
+    children.push(row.id);
+    childrenByParent.set(row.parentProjectId, children);
+  }
+  const descendants = new Set<string>();
+  const pending = [...(childrenByParent.get(projectId) ?? [])];
+  while (pending.length > 0) {
+    const id = pending.pop()!;
+    if (descendants.has(id)) continue;
+    descendants.add(id);
+    pending.push(...(childrenByParent.get(id) ?? []));
+  }
+  return descendants;
+}
+
+function projectDepth(rowsById: Map<string, ProjectRow>, projectId: string): number {
+  let depth = 1;
+  let current = rowsById.get(projectId) ?? null;
+  const seen = new Set<string>([projectId]);
+  while (current?.parentProjectId) {
+    if (seen.has(current.parentProjectId)) {
+      throw projectTreeConflict(PROJECT_TREE_ERROR_CODES.cycle, "Project parent would create a cycle.");
+    }
+    seen.add(current.parentProjectId);
+    depth += 1;
+    current = rowsById.get(current.parentProjectId) ?? null;
+  }
+  return depth;
+}
+
+function subtreeHeight(rows: ProjectRow[], projectId: string): number {
+  const childrenByParent = new Map<string, string[]>();
+  for (const row of rows) {
+    if (!row.parentProjectId) continue;
+    const children = childrenByParent.get(row.parentProjectId) ?? [];
+    children.push(row.id);
+    childrenByParent.set(row.parentProjectId, children);
+  }
+  const height = (id: string, seen: Set<string>): number => {
+    if (seen.has(id)) {
+      throw projectTreeConflict(PROJECT_TREE_ERROR_CODES.cycle, "Project tree contains a cycle.");
+    }
+    const nextSeen = new Set(seen).add(id);
+    return 1 + Math.max(0, ...(childrenByParent.get(id) ?? []).map((childId) => height(childId, nextSeen)));
+  };
+  return height(projectId, new Set());
+}
+
+async function validateProjectParent(db: ProjectTreeDb, input: {
+  companyId: string;
+  projectId?: string;
+  parentProjectId: string | null;
+  rows?: ProjectRow[];
+}) {
+  if (input.parentProjectId === null) return;
+  if (input.projectId && input.parentProjectId === input.projectId) {
+    throw projectTreeConflict(PROJECT_TREE_ERROR_CODES.selfParent, "A project cannot be its own parent.");
+  }
+
+  const parent = await db.select().from(projects).where(eq(projects.id, input.parentProjectId)).then((rows) => rows[0] ?? null);
+  if (!parent) {
+    throw projectTreeConflict(PROJECT_TREE_ERROR_CODES.parentNotFound, "Parent project does not exist.");
+  }
+  if (parent.companyId !== input.companyId) {
+    throw projectTreeConflict(PROJECT_TREE_ERROR_CODES.parentCompanyMismatch, "Parent project must belong to the same company.");
+  }
+  if (parent.archivedAt) {
+    throw projectTreeConflict(PROJECT_TREE_ERROR_CODES.parentArchived, "Parent project must be active.");
+  }
+
+  const rows = input.rows ?? await loadCompanyProjectTree(db, input.companyId);
+  if (input.projectId && collectDescendantIds(rows, input.projectId).has(input.parentProjectId)) {
+    throw projectTreeConflict(PROJECT_TREE_ERROR_CODES.cycle, "Project parent would create a cycle.");
+  }
+  const rowsById = new Map(rows.map((row) => [row.id, row]));
+  const parentDepth = projectDepth(rowsById, input.parentProjectId);
+  const height = input.projectId ? subtreeHeight(rows, input.projectId) : 1;
+  if (parentDepth + height > PROJECT_TREE_MAX_DEPTH) {
+    throw projectTreeConflict(
+      PROJECT_TREE_ERROR_CODES.depthExceeded,
+      `Project tree depth cannot exceed ${PROJECT_TREE_MAX_DEPTH}.`,
+    );
+  }
+}
+
 /** Sync the project_goals join table for a single project. */
-async function syncGoalLinks(db: Db, projectId: string, companyId: string, goalIds: string[]) {
+async function syncGoalLinks(db: ProjectQueryDb, projectId: string, companyId: string, goalIds: string[]) {
   // Delete existing links
   await db.delete(projectGoals).where(eq(projectGoals.projectId, projectId));
 
@@ -547,32 +673,38 @@ export function projectService(db: Db) {
   ): Promise<ProjectWithGoals> => {
     const { goalIds: inputGoalIds, ...projectData } = data;
     const ids = resolveGoalIds({ goalIds: inputGoalIds, goalId: projectData.goalId });
+    return withProjectTreeTransaction(db, companyId, async (tx) => {
+      await validateProjectParent(tx, {
+        companyId,
+        parentProjectId: projectData.parentProjectId ?? null,
+      });
 
-    // Note: color is intentionally NOT auto-assigned. New projects default to
-    // `color = null` (neutral gray) unless an explicit color is supplied. See PAP-68.
+      // Note: color is intentionally NOT auto-assigned. New projects default to
+      // `color = null` (neutral gray) unless an explicit color is supplied. See PAP-68.
 
-    const existingProjects = await db
-      .select({ id: projects.id, name: projects.name })
-      .from(projects)
-      .where(eq(projects.companyId, companyId));
-    projectData.name = resolveProjectNameForUniqueShortname(projectData.name, existingProjects);
+      const existingProjects = await tx
+        .select({ id: projects.id, name: projects.name })
+        .from(projects)
+        .where(eq(projects.companyId, companyId));
+      projectData.name = resolveProjectNameForUniqueShortname(projectData.name, existingProjects);
 
-    // Also write goalId to the legacy column (first goal or null)
-    const legacyGoalId = ids && ids.length > 0 ? ids[0] : projectData.goalId ?? null;
+      // Also write goalId to the legacy column (first goal or null)
+      const legacyGoalId = ids && ids.length > 0 ? ids[0] : projectData.goalId ?? null;
 
-    const row = await db
-      .insert(projects)
-      .values({ ...projectData, goalId: legacyGoalId, companyId })
-      .returning()
-      .then((rows) => rows[0]);
+      const row = await tx
+        .insert(projects)
+        .values({ ...projectData, goalId: legacyGoalId, companyId })
+        .returning()
+        .then((rows) => rows[0]);
 
-    if (ids && ids.length > 0) {
-      await syncGoalLinks(db, row.id, companyId, ids);
-    }
+      if (ids && ids.length > 0) {
+        await syncGoalLinks(tx, row.id, companyId, ids);
+      }
 
-    const [withGoals] = await attachGoals(db, [row]);
-    const [enriched] = withGoals ? await attachWorkspaces(db, [withGoals]) : [];
-    return enriched!;
+      const [withGoals] = await attachGoals(tx, [row]);
+      const [enriched] = withGoals ? await attachWorkspaces(tx, [withGoals]) : [];
+      return enriched!;
+    });
   };
 
   const getProjectById = async (id: string): Promise<ProjectWithGoals | null> => {
@@ -780,50 +912,91 @@ export function projectService(db: Db) {
       const { goalIds: inputGoalIds, ...projectData } = data;
       const ids = resolveGoalIds({ goalIds: inputGoalIds, goalId: projectData.goalId });
       const existingProject = await db
-        .select({ id: projects.id, companyId: projects.companyId, name: projects.name })
+        .select()
         .from(projects)
         .where(eq(projects.id, id))
         .then((rows) => rows[0] ?? null);
       if (!existingProject) return null;
 
-      if (projectData.name !== undefined) {
-        const existingShortname = normalizeProjectUrlKey(existingProject.name);
-        const nextShortname = normalizeProjectUrlKey(projectData.name);
-        if (existingShortname !== nextShortname) {
-          const existingProjects = await db
-            .select({ id: projects.id, name: projects.name })
-            .from(projects)
-            .where(eq(projects.companyId, existingProject.companyId));
-          projectData.name = resolveProjectNameForUniqueShortname(projectData.name, existingProjects, {
-            excludeProjectId: id,
+      return withProjectTreeTransaction(db, existingProject.companyId, async (tx) => {
+        const lockedProject = await tx
+          .select()
+          .from(projects)
+          .where(eq(projects.id, id))
+          .then((rows) => rows[0] ?? null);
+        if (!lockedProject) return null;
+        const treeRows = await loadCompanyProjectTree(tx, lockedProject.companyId);
+        if (projectData.parentProjectId !== undefined) {
+          await validateProjectParent(tx, {
+            companyId: lockedProject.companyId,
+            projectId: id,
+            parentProjectId: projectData.parentProjectId ?? null,
+            rows: treeRows,
           });
         }
-      }
+        if (projectData.archivedAt) {
+          const descendants = collectDescendantIds(treeRows, id);
+          if (treeRows.some((row) => descendants.has(row.id) && row.archivedAt === null)) {
+            throw projectTreeConflict(
+              PROJECT_TREE_ERROR_CODES.activeDescendants,
+              "Cannot archive a project while it has active descendants.",
+            );
+          }
+        }
+        if (projectData.archivedAt === null) {
+          const parentProjectId = projectData.parentProjectId !== undefined
+            ? projectData.parentProjectId ?? null
+            : lockedProject.parentProjectId;
+          if (parentProjectId) {
+            const parent = treeRows.find((row) => row.id === parentProjectId) ?? null;
+            if (parent?.archivedAt) {
+              throw projectTreeConflict(
+                PROJECT_TREE_ERROR_CODES.archivedParent,
+                "Cannot unarchive a project while its parent is archived.",
+              );
+            }
+          }
+        }
 
-      // Keep legacy goalId column in sync
-      const updates: Partial<typeof projects.$inferInsert> = {
-        ...projectData,
-        updatedAt: new Date(),
-      };
-      if (ids !== undefined) {
-        updates.goalId = ids.length > 0 ? ids[0] : null;
-      }
+        if (projectData.name !== undefined) {
+          const existingShortname = normalizeProjectUrlKey(lockedProject.name);
+          const nextShortname = normalizeProjectUrlKey(projectData.name);
+          if (existingShortname !== nextShortname) {
+            const existingProjects = await tx
+              .select({ id: projects.id, name: projects.name })
+              .from(projects)
+              .where(eq(projects.companyId, existingProject.companyId));
+            projectData.name = resolveProjectNameForUniqueShortname(projectData.name, existingProjects, {
+              excludeProjectId: id,
+            });
+          }
+        }
 
-      const row = await db
-        .update(projects)
-        .set(updates)
-        .where(eq(projects.id, id))
-        .returning()
-        .then((rows) => rows[0] ?? null);
-      if (!row) return null;
+        // Keep legacy goalId column in sync
+        const updates: Partial<typeof projects.$inferInsert> = {
+          ...projectData,
+          updatedAt: new Date(),
+        };
+        if (ids !== undefined) {
+          updates.goalId = ids.length > 0 ? ids[0] : null;
+        }
 
-      if (ids !== undefined) {
-        await syncGoalLinks(db, id, row.companyId, ids);
-      }
+        const row = await tx
+          .update(projects)
+          .set(updates)
+          .where(eq(projects.id, id))
+          .returning()
+          .then((rows) => rows[0] ?? null);
+        if (!row) return null;
 
-      const [withGoals] = await attachGoals(db, [row]);
-      const [enriched] = withGoals ? await attachWorkspaces(db, [withGoals]) : [];
-      return enriched ?? null;
+        if (ids !== undefined) {
+          await syncGoalLinks(tx, id, row.companyId, ids);
+        }
+
+        const [withGoals] = await attachGoals(tx, [row]);
+        const [enriched] = withGoals ? await attachWorkspaces(tx, [withGoals]) : [];
+        return enriched ?? null;
+      });
     },
 
     clearExecutionWorkspaceEnvironmentSelection: async (companyId: string, environmentId: string) => {
@@ -856,16 +1029,30 @@ export function projectService(db: Db) {
       return cleared;
     },
 
-    remove: (id: string) =>
-      db
-        .delete(projects)
-        .where(eq(projects.id, id))
-        .returning()
-        .then((rows) => {
-          const row = rows[0] ?? null;
-          if (!row) return null;
-          return { ...row, urlKey: deriveProjectUrlKey(row.name, row.id) };
-        }),
+    remove: async (id: string) => {
+      const existing = await db.select().from(projects).where(eq(projects.id, id)).then((rows) => rows[0] ?? null);
+      if (!existing) return null;
+      return withProjectTreeTransaction(db, existing.companyId, async (tx) => {
+        const lockedProject = await tx.select().from(projects).where(eq(projects.id, id)).then((rows) => rows[0] ?? null);
+        if (!lockedProject) return null;
+        const treeRows = await loadCompanyProjectTree(tx, lockedProject.companyId);
+        if (collectDescendantIds(treeRows, id).size > 0) {
+          throw projectTreeConflict(
+            PROJECT_TREE_ERROR_CODES.descendantsExist,
+            "Cannot delete a project while it has descendants.",
+          );
+        }
+        return tx
+          .delete(projects)
+          .where(eq(projects.id, id))
+          .returning()
+          .then((rows) => {
+            const row = rows[0] ?? null;
+            if (!row) return null;
+            return { ...row, urlKey: deriveProjectUrlKey(row.name, row.id) };
+          });
+      });
+    },
 
     listWorkspaces: async (projectId: string): Promise<ProjectWorkspace[]> => {
       const rows = await db

--- a/ui/src/components/IssueProperties.test.tsx
+++ b/ui/src/components/IssueProperties.test.tsx
@@ -340,6 +340,7 @@ function createProject(overrides: Partial<Project> = {}): Project {
     id: "project-1",
     companyId: "company-1",
     urlKey: "project-1",
+    parentProjectId: null,
     goalId: null,
     goalIds: [],
     goals: [],

--- a/ui/src/components/NewProjectDialog.tsx
+++ b/ui/src/components/NewProjectDialog.tsx
@@ -1,5 +1,6 @@
-import { useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import type { Project } from "@paperclipai/shared";
 import { useDialog } from "../context/DialogContext";
 import { useCompany } from "../context/CompanyContext";
 import { accessApi } from "../api/access";
@@ -34,6 +35,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { cn } from "../lib/utils";
+import { getProjectDepth, MAX_PROJECT_TREE_DEPTH } from "../lib/project-tree";
 import { MarkdownEditor, type MarkdownEditorRef, type MentionOption } from "./MarkdownEditor";
 import { StatusBadge } from "./StatusBadge";
 import { ChoosePathButton } from "./PathInstructionsModal";
@@ -47,7 +49,7 @@ const projectStatuses = [
 ];
 
 export function NewProjectDialog() {
-  const { newProjectOpen, closeNewProject } = useDialog();
+  const { newProjectOpen, newProjectDefaults, closeNewProject } = useDialog();
   const { selectedCompanyId, selectedCompany } = useCompany();
   const queryClient = useQueryClient();
   const [name, setName] = useState("");
@@ -55,6 +57,7 @@ export function NewProjectDialog() {
   const [status, setStatus] = useState("planned");
   const [goalIds, setGoalIds] = useState<string[]>([]);
   const [targetDate, setTargetDate] = useState("");
+  const [parentProjectId, setParentProjectId] = useState<string | null>(null);
   const [expanded, setExpanded] = useState(false);
   const [workspaceLocalPath, setWorkspaceLocalPath] = useState("");
   const [workspaceRepoUrl, setWorkspaceRepoUrl] = useState("");
@@ -63,6 +66,34 @@ export function NewProjectDialog() {
   const [statusOpen, setStatusOpen] = useState(false);
   const [goalOpen, setGoalOpen] = useState(false);
   const descriptionEditorRef = useRef<MarkdownEditorRef>(null);
+
+  const { data: projects } = useQuery<Project[]>({
+    queryKey: queryKeys.projects.list(selectedCompanyId!),
+    queryFn: () => projectsApi.list(selectedCompanyId!),
+    enabled: !!selectedCompanyId && newProjectOpen,
+  });
+
+  const parentOptions = useMemo(() => (projects ?? [])
+    .map((project) => {
+      const reason = project.archivedAt
+        ? "Archived projects cannot contain projects."
+        : getProjectDepth(projects ?? [], project.id) >= MAX_PROJECT_TREE_DEPTH
+          ? `Projects cannot exceed ${MAX_PROJECT_TREE_DEPTH} levels.`
+          : null;
+      return { project, reason };
+    })
+    .sort((left, right) => left.project.name.localeCompare(right.project.name)), [projects]);
+
+  useEffect(() => {
+    if (newProjectOpen) setParentProjectId(newProjectDefaults.parentProjectId ?? null);
+  }, [newProjectDefaults.parentProjectId, newProjectOpen]);
+
+  const selectedParentOption = parentProjectId
+    ? parentOptions.find(({ project }) => project.id === parentProjectId)
+    : null;
+  const selectedParentReason = parentProjectId
+    ? selectedParentOption?.reason ?? (selectedParentOption ? null : "Parent project is unavailable.")
+    : null;
 
   const { data: goals } = useQuery({
     queryKey: queryKeys.goals.list(selectedCompanyId!),
@@ -107,6 +138,7 @@ export function NewProjectDialog() {
     setStatus("planned");
     setGoalIds([]);
     setTargetDate("");
+    setParentProjectId(null);
     setExpanded(false);
     setWorkspaceLocalPath("");
     setWorkspaceRepoUrl("");
@@ -164,6 +196,7 @@ export function NewProjectDialog() {
         name: name.trim(),
         description: description.trim() || undefined,
         status,
+        parentProjectId,
         // No color is sent — new projects persist color = null (neutral gray). See PAP-68.
         ...(goalIds.length > 0 ? { goalIds } : {}),
         ...(targetDate ? { targetDate } : {}),
@@ -332,6 +365,22 @@ export function NewProjectDialog() {
 
         {/* Property chips */}
         <div className="flex items-center gap-1.5 px-4 py-2 border-t border-border flex-wrap">
+          <label className="inline-flex items-center gap-1.5 rounded-md border border-border px-2 py-1 text-xs">
+            <span className="text-muted-foreground">Parent</span>
+            <select
+              aria-label="Parent project"
+              className="max-w-48 bg-transparent outline-none"
+              value={parentProjectId ?? ""}
+              onChange={(event) => setParentProjectId(event.target.value || null)}
+            >
+              <option value="">No parent</option>
+              {parentOptions.map(({ project, reason }) => (
+                <option key={project.id} value={project.id} disabled={reason !== null} title={reason ?? undefined}>
+                  {project.name}{reason ? ` — ${reason}` : ""}
+                </option>
+              ))}
+            </select>
+          </label>
           {/* Status */}
           <Popover open={statusOpen} onOpenChange={setStatusOpen}>
             <PopoverTrigger asChild>
@@ -427,14 +476,16 @@ export function NewProjectDialog() {
 
         {/* Footer */}
         <div className="flex items-center justify-between px-4 py-2.5 border-t border-border">
-          {createProject.isError ? (
-            <p className="text-xs text-destructive">Failed to create project.</p>
+          {selectedParentReason ? (
+            <p className="text-xs text-destructive">{selectedParentReason}</p>
+          ) : createProject.isError ? (
+            <p className="text-xs text-destructive">{createProject.error.message || "Failed to create project."}</p>
           ) : (
             <span />
           )}
           <Button
             size="sm"
-            disabled={!name.trim() || createProject.isPending}
+            disabled={!name.trim() || createProject.isPending || selectedParentReason !== null}
             onClick={handleSubmit}
           >
             {createProject.isPending ? "Creating…" : "Create project"}

--- a/ui/src/components/RoutineRunVariablesDialog.test.tsx
+++ b/ui/src/components/RoutineRunVariablesDialog.test.tsx
@@ -72,6 +72,7 @@ function createProject(): Project {
     id: "project-1",
     companyId: "company-1",
     urlKey: "workspace-project",
+    parentProjectId: null,
     goalId: null,
     goalIds: [],
     goals: [],

--- a/ui/src/components/SidebarProjects.test.tsx
+++ b/ui/src/components/SidebarProjects.test.tsx
@@ -150,6 +150,7 @@ function makeProject(overrides: Partial<Project>): Project {
     id: "project-a",
     companyId: "company-1",
     urlKey: "alpha",
+    parentProjectId: null,
     goalId: null,
     goalIds: [],
     goals: [],

--- a/ui/src/components/SidebarStarredProjects.test.tsx
+++ b/ui/src/components/SidebarStarredProjects.test.tsx
@@ -64,6 +64,7 @@ function makeProject(overrides: Partial<Project>): Project {
     id: "project-a",
     companyId: "company-1",
     urlKey: "alpha",
+    parentProjectId: null,
     goalId: null,
     goalIds: [],
     goals: [],

--- a/ui/src/components/WorkspaceFileBrowser.test.tsx
+++ b/ui/src/components/WorkspaceFileBrowser.test.tsx
@@ -143,6 +143,7 @@ function createProject(overrides: Partial<Project> = {}): Project {
     id: "project-content",
     companyId: "company-1",
     urlKey: "paperclip-content",
+    parentProjectId: null,
     goalId: null,
     goalIds: [],
     goals: [],

--- a/ui/src/context/DialogContext.tsx
+++ b/ui/src/context/DialogContext.tsx
@@ -20,6 +20,10 @@ interface NewIssueDefaults {
   description?: string;
 }
 
+interface NewProjectDefaults {
+  parentProjectId?: string | null;
+}
+
 interface NewGoalDefaults {
   parentId?: string;
 }
@@ -35,7 +39,8 @@ interface DialogContextValue {
   openNewIssue: (defaults?: NewIssueDefaults) => void;
   closeNewIssue: () => void;
   newProjectOpen: boolean;
-  openNewProject: () => void;
+  newProjectDefaults: NewProjectDefaults;
+  openNewProject: (defaults?: NewProjectDefaults) => void;
   closeNewProject: () => void;
   newGoalOpen: boolean;
   newGoalDefaults: NewGoalDefaults;
@@ -60,6 +65,7 @@ type DialogStateValue = Pick<
   | "newIssueOpen"
   | "newIssueDefaults"
   | "newProjectOpen"
+  | "newProjectDefaults"
   | "newGoalOpen"
   | "newGoalDefaults"
   | "newAgentOpen"
@@ -77,6 +83,7 @@ export function DialogProvider({ children }: { children: ReactNode }) {
   const [newIssueOpen, setNewIssueOpen] = useState(false);
   const [newIssueDefaults, setNewIssueDefaults] = useState<NewIssueDefaults>({});
   const [newProjectOpen, setNewProjectOpen] = useState(false);
+  const [newProjectDefaults, setNewProjectDefaults] = useState<NewProjectDefaults>({});
   const [newGoalOpen, setNewGoalOpen] = useState(false);
   const [newGoalDefaults, setNewGoalDefaults] = useState<NewGoalDefaults>({});
   const [newAgentOpen, setNewAgentOpen] = useState(false);
@@ -94,12 +101,14 @@ export function DialogProvider({ children }: { children: ReactNode }) {
     setNewIssueDefaults({});
   }, []);
 
-  const openNewProject = useCallback(() => {
+  const openNewProject = useCallback((defaults: NewProjectDefaults = {}) => {
+    setNewProjectDefaults(defaults);
     setNewProjectOpen(true);
   }, []);
 
   const closeNewProject = useCallback(() => {
     setNewProjectOpen(false);
+    setNewProjectDefaults({});
   }, []);
 
   const openNewGoal = useCallback((defaults: NewGoalDefaults = {}) => {
@@ -135,6 +144,7 @@ export function DialogProvider({ children }: { children: ReactNode }) {
       newIssueOpen,
       newIssueDefaults,
       newProjectOpen,
+      newProjectDefaults,
       newGoalOpen,
       newGoalDefaults,
       newAgentOpen,
@@ -146,6 +156,7 @@ export function DialogProvider({ children }: { children: ReactNode }) {
       newIssueOpen,
       newIssueDefaults,
       newProjectOpen,
+      newProjectDefaults,
       newGoalOpen,
       newGoalDefaults,
       newAgentOpen,

--- a/ui/src/lib/company-portability-sidebar.test.ts
+++ b/ui/src/lib/company-portability-sidebar.test.ts
@@ -38,6 +38,7 @@ function makeProject(id: string, name: string): Project {
   return {
     id,
     companyId: "company-1",
+    parentProjectId: null,
     goalId: null,
     urlKey: name.toLowerCase(),
     name,

--- a/ui/src/lib/issueDetailBreadcrumb.test.ts
+++ b/ui/src/lib/issueDetailBreadcrumb.test.ts
@@ -74,6 +74,7 @@ describe("issueDetailBreadcrumb", () => {
         id: "project-1",
         companyId: "company-1",
         urlKey: "paperclip-app",
+        parentProjectId: null,
         goalId: null,
         goalIds: [],
         goals: [],

--- a/ui/src/lib/optimistic-issue-comments.test.ts
+++ b/ui/src/lib/optimistic-issue-comments.test.ts
@@ -587,6 +587,7 @@ describe("optimistic issue comments", () => {
           id: "project-1",
           companyId: "company-1",
           urlKey: "project-one",
+          parentProjectId: null,
           goalId: null,
           goalIds: [],
           goals: [],

--- a/ui/src/lib/project-tree.test.ts
+++ b/ui/src/lib/project-tree.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildProjectTree,
+  getActiveDescendants,
+  getDescendantIds,
+  getParentTargetAvailability,
+  getProjectDepth,
+  getSubtreeHeight,
+} from "./project-tree";
+
+type ProjectFixture = {
+  id: string;
+  name: string;
+  parentProjectId: string | null;
+  archivedAt: string | null;
+};
+
+function project(id: string, parentProjectId: string | null = null, archivedAt: string | null = null): ProjectFixture {
+  return { id, name: id, parentProjectId, archivedAt };
+}
+
+const projects = [project("root"), project("child", "root"), project("grandchild", "child")];
+
+describe("project tree utilities", () => {
+  it("builds a three-level tree and ignores archived rows", () => {
+    const tree = buildProjectTree([...projects, project("archived", null, "2026-01-01")]);
+    expect(tree).toHaveLength(1);
+    expect(tree[0].project.id).toBe("root");
+    expect(tree[0].children[0].project.id).toBe("child");
+    expect(tree[0].children[0].children[0].project.id).toBe("grandchild");
+  });
+
+  it("preserves caller order for roots and siblings", () => {
+    const tree = buildProjectTree([
+      project("root-z"),
+      project("child-z", "root-z"),
+      project("child-a", "root-z"),
+      project("root-a"),
+    ]);
+
+    expect(tree.map((node) => node.project.id)).toEqual(["root-z", "root-a"]);
+    expect(tree[0].children.map((node) => node.project.id)).toEqual(["child-z", "child-a"]);
+  });
+
+  it("calculates descendants, depth, and subtree height", () => {
+    expect([...getDescendantIds(projects, "root")]).toEqual(["child", "grandchild"]);
+    expect(getProjectDepth(projects, "grandchild")).toBe(3);
+    expect(getSubtreeHeight(projects, "root")).toBe(3);
+  });
+
+  it("disables self, descendants, archived targets, and moves beyond depth three", () => {
+    expect(getParentTargetAvailability(projects, "child", "child").reason).toMatch(/own parent/);
+    expect(getParentTargetAvailability(projects, "root", "grandchild").reason).toMatch(/descendants/);
+
+    const archived = [...projects, project("archived", null, "2026-01-01")];
+    expect(getParentTargetAvailability(archived, "child", "archived").reason).toMatch(/Archived/);
+
+    const wide = [...projects, project("leaf"), project("second", "grandchild")];
+    expect(getParentTargetAvailability(wide, "leaf", "grandchild").reason).toMatch(/3-level/);
+  });
+
+  it("allows detaching and valid parent moves while finding active descendants", () => {
+    expect(getParentTargetAvailability(projects, "grandchild", "root")).toEqual({ disabled: false, reason: null });
+    expect(getActiveDescendants([...projects, project("old", "root", "2026-01-01")], "root").map((item) => item.id))
+      .toEqual(["child", "grandchild"]);
+  });
+});

--- a/ui/src/lib/project-tree.ts
+++ b/ui/src/lib/project-tree.ts
@@ -1,0 +1,148 @@
+export const MAX_PROJECT_TREE_DEPTH = 3;
+
+export type ProjectTreeItem = {
+  id: string;
+  parentProjectId: string | null;
+  archivedAt?: Date | string | null;
+  name?: string;
+};
+
+export type ProjectTreeNode<T extends ProjectTreeItem> = {
+  project: T;
+  children: ProjectTreeNode<T>[];
+  depth: number;
+};
+
+export type ParentTargetAvailability = {
+  disabled: boolean;
+  reason: string | null;
+};
+
+export function getDescendantIds<T extends ProjectTreeItem>(projects: T[], projectId: string): Set<string> {
+  const childrenByParent = new Map<string, string[]>();
+  for (const project of projects) {
+    if (!project.parentProjectId) continue;
+    const children = childrenByParent.get(project.parentProjectId) ?? [];
+    children.push(project.id);
+    childrenByParent.set(project.parentProjectId, children);
+  }
+
+  const descendants = new Set<string>();
+  const pending = [...(childrenByParent.get(projectId) ?? [])];
+  while (pending.length > 0) {
+    const id = pending.shift()!;
+    if (descendants.has(id)) continue;
+    descendants.add(id);
+    pending.push(...(childrenByParent.get(id) ?? []));
+  }
+  return descendants;
+}
+
+export function getProjectDepth<T extends ProjectTreeItem>(projects: T[], projectId: string): number {
+  const byId = new Map(projects.map((project) => [project.id, project]));
+  const visited = new Set<string>();
+  let current = byId.get(projectId);
+  let depth = 1;
+
+  while (current?.parentProjectId && !visited.has(current.id)) {
+    visited.add(current.id);
+    const parent = byId.get(current.parentProjectId);
+    if (!parent) break;
+    depth += 1;
+    current = parent;
+  }
+  return depth;
+}
+
+export function getSubtreeHeight<T extends ProjectTreeItem>(projects: T[], projectId: string): number {
+  const childrenByParent = new Map<string, string[]>();
+  for (const project of projects) {
+    if (!project.parentProjectId) continue;
+    const children = childrenByParent.get(project.parentProjectId) ?? [];
+    children.push(project.id);
+    childrenByParent.set(project.parentProjectId, children);
+  }
+
+  function height(id: string, visited: Set<string>): number {
+    if (visited.has(id)) return 1;
+    const nextVisited = new Set(visited).add(id);
+    const children = childrenByParent.get(id) ?? [];
+    return 1 + Math.max(0, ...children.map((childId) => height(childId, nextVisited)));
+  }
+
+  return height(projectId, new Set());
+}
+
+export function buildProjectTree<T extends ProjectTreeItem>(projects: T[]): ProjectTreeNode<T>[] {
+  const activeProjects = projects.filter((project) => !project.archivedAt);
+  const byId = new Map(activeProjects.map((project) => [project.id, project]));
+  const childrenByParent = new Map<string | null, T[]>();
+
+  for (const project of activeProjects) {
+    const parentId = project.parentProjectId && byId.has(project.parentProjectId)
+      ? project.parentProjectId
+      : null;
+    const children = childrenByParent.get(parentId) ?? [];
+    children.push(project);
+    childrenByParent.set(parentId, children);
+  }
+
+  function makeNodes(parentId: string | null, depth: number, visited: Set<string>): ProjectTreeNode<T>[] {
+    return (childrenByParent.get(parentId) ?? [])
+      .filter((project) => !visited.has(project.id))
+      .map((project) => ({
+        project,
+        depth,
+        children: depth < MAX_PROJECT_TREE_DEPTH
+          ? makeNodes(project.id, depth + 1, new Set(visited).add(project.id))
+          : [],
+      }));
+  }
+
+  return makeNodes(null, 1, new Set());
+}
+
+export function getParentTargetAvailability<T extends ProjectTreeItem>(
+  projects: T[],
+  movingProjectId: string,
+  targetProjectId: string,
+): ParentTargetAvailability {
+  if (movingProjectId === targetProjectId) {
+    return { disabled: true, reason: "A project cannot be its own parent." };
+  }
+
+  const target = projects.find((project) => project.id === targetProjectId);
+  if (!target) return { disabled: true, reason: "Project is unavailable." };
+  if (target.archivedAt) return { disabled: true, reason: "Archived projects cannot contain projects." };
+  if (getDescendantIds(projects, movingProjectId).has(targetProjectId)) {
+    return { disabled: true, reason: "A project cannot move into one of its descendants." };
+  }
+
+  const resultingDepth = getProjectDepth(projects, targetProjectId) + getSubtreeHeight(projects, movingProjectId);
+  if (resultingDepth > MAX_PROJECT_TREE_DEPTH) {
+    return { disabled: true, reason: `This move would exceed the ${MAX_PROJECT_TREE_DEPTH}-level limit.` };
+  }
+
+  return { disabled: false, reason: null };
+}
+
+export function getActiveDescendants<T extends ProjectTreeItem>(projects: T[], projectId: string): T[] {
+  const descendants = getDescendantIds(projects, projectId);
+  return projects.filter((project) => descendants.has(project.id) && !project.archivedAt);
+}
+
+export function getActiveDescendantCounts<T extends ProjectTreeItem>(projects: T[]): Map<string, number> {
+  const counts = new Map<string, number>();
+  const byId = new Map(projects.map((project) => [project.id, project]));
+  for (const project of projects) {
+    if (project.archivedAt) continue;
+    const visited = new Set<string>();
+    let parentId = project.parentProjectId;
+    while (parentId && !visited.has(parentId)) {
+      visited.add(parentId);
+      counts.set(parentId, (counts.get(parentId) ?? 0) + 1);
+      parentId = byId.get(parentId)?.parentProjectId ?? null;
+    }
+  }
+  return counts;
+}

--- a/ui/src/pages/ExecutionWorkspaceDetail.test.tsx
+++ b/ui/src/pages/ExecutionWorkspaceDetail.test.tsx
@@ -146,6 +146,7 @@ function project(overrides: Partial<Project> = {}): Project {
     id: "project-1",
     companyId: "company-1",
     urlKey: "project-1",
+    parentProjectId: null,
     goalId: null,
     goalIds: [],
     goals: [],

--- a/ui/src/pages/ProjectDetail.test.tsx
+++ b/ui/src/pages/ProjectDetail.test.tsx
@@ -107,6 +107,7 @@ function project(overrides: Partial<Project> = {}): Project {
     id: "project-1",
     companyId: "company-1",
     urlKey: "project-1",
+    parentProjectId: null,
     goalId: null,
     goalIds: [],
     goals: [],

--- a/ui/src/pages/ProjectWorkspaceDetail.test.tsx
+++ b/ui/src/pages/ProjectWorkspaceDetail.test.tsx
@@ -128,6 +128,7 @@ function project(overrides: Partial<Project> = {}): Project {
     id: "project-1",
     companyId: "company-1",
     urlKey: "paperclip-app",
+    parentProjectId: null,
     goalId: null,
     goalIds: [],
     goals: [],

--- a/ui/src/pages/Projects.test.tsx
+++ b/ui/src/pages/Projects.test.tsx
@@ -11,6 +11,7 @@ import { Projects } from "./Projects";
 
 const mockProjectsApi = vi.hoisted(() => ({
   list: vi.fn(),
+  update: vi.fn(),
 }));
 
 const mockResourceMembershipsApi = vi.hoisted(() => ({
@@ -20,10 +21,19 @@ const mockResourceMembershipsApi = vi.hoisted(() => ({
 
 const mockOpenNewProject = vi.hoisted(() => vi.fn());
 const mockSetBreadcrumbs = vi.hoisted(() => vi.fn());
+const mockNavigate = vi.hoisted(() => vi.fn());
 
 vi.mock("@/lib/router", () => ({
   Link: ({ children, to, ...props }: { children?: ReactNode; to: string }) => (
-    <a href={to} {...props}>{children}</a>
+    <a
+      href={to}
+      {...props}
+      onClick={(event) => {
+        if (!event.defaultPrevented) mockNavigate(to);
+      }}
+    >
+      {children}
+    </a>
   ),
 }));
 
@@ -68,6 +78,7 @@ function makeProject(overrides: Partial<Project>): Project {
     companyId: "company-1",
     urlKey: "alpha",
     goalId: null,
+    parentProjectId: null,
     goalIds: [],
     goals: [],
     name: "Alpha",
@@ -145,14 +156,23 @@ describe("Projects", () => {
     mockResourceMembershipsApi.listMine.mockResolvedValue({
       projectMemberships: { "project-b": "left" },
       agentMemberships: {},
+      starredProjectIds: [],
+      starredAgentIds: [],
+      projectStarredAt: {},
+      agentStarredAt: {},
       updatedAt: null,
     });
-    mockResourceMembershipsApi.updateProject.mockResolvedValue({
+    mockResourceMembershipsApi.updateProject.mockImplementation(async (
+      _companyId: string,
+      resourceId: string,
+      body: { state?: "joined" | "left"; starred?: boolean },
+    ) => ({
       resourceType: "project",
-      resourceId: "project-b",
-      state: "joined",
+      resourceId,
+      state: body.state ?? "joined",
+      starredAt: body.starred ? new Date("2026-01-05T00:00:00Z") : null,
       updatedAt: new Date("2026-01-05T00:00:00Z"),
-    });
+    }));
   });
 
   afterEach(async () => {
@@ -196,6 +216,12 @@ describe("Projects", () => {
     await flushReact();
   }
 
+  function visibleProjectNames() {
+    return Array.from(container.querySelectorAll('[role="treeitem"] a'))
+      .map((element) => element.getAttribute("href")?.split("/").pop())
+      .filter((name): name is string => Boolean(name));
+  }
+
   async function chooseSortField(label: string) {
     const item = Array.from(document.body.querySelectorAll("button"))
       .find((element) => element.textContent?.includes(label));
@@ -207,38 +233,146 @@ describe("Projects", () => {
     await flushReact();
   }
 
-  it("groups joined projects above left projects and defaults sorting by name", async () => {
+  it("renders a bounded tree with only project names and status in default rows", async () => {
+    mockProjectsApi.list.mockResolvedValue([
+      makeProject({ id: "root", urlKey: "root", name: "Root" }),
+      makeProject({ id: "child", urlKey: "child", name: "Child", parentProjectId: "root", description: "Hidden description" }),
+      makeProject({ id: "grandchild", urlKey: "grandchild", name: "Grandchild", parentProjectId: "child" }),
+    ]);
+
     await renderProjects();
 
     const content = container.textContent ?? "";
-    expect(container.querySelector('button[title="Sort"]')?.textContent).toContain("Sort: Name");
-    expect(content.indexOf("My Projects")).toBeLessThan(content.indexOf("Alpha"));
-    expect(content.indexOf("Alpha")).toBeLessThan(content.indexOf("Charlie"));
-    expect(content.indexOf("Charlie")).toBeLessThan(content.indexOf("Other Projects"));
-    expect(content.indexOf("Other Projects")).toBeLessThan(content.indexOf("Bravo"));
+    expect(content.indexOf("Root")).toBeLessThan(content.indexOf("Child"));
+    expect(content.indexOf("Child")).toBeLessThan(content.indexOf("Grandchild"));
+    expect(content).not.toContain("Hidden description");
     expect(content).toContain("in progress");
+    expect(container.querySelector('[role="tree"]')).not.toBeNull();
   });
 
-  it("sorts grouped projects by the selected field", async () => {
+  it("keeps children with their root section when membership differs", async () => {
+    mockProjectsApi.list.mockResolvedValue([
+      makeProject({ id: "root", urlKey: "root", name: "Root" }),
+      makeProject({ id: "child", urlKey: "child", name: "Child", parentProjectId: "root" }),
+    ]);
+    mockResourceMembershipsApi.listMine.mockResolvedValue({
+      projectMemberships: { child: "left" },
+      agentMemberships: {},
+      starredProjectIds: [],
+      starredAgentIds: [],
+      projectStarredAt: {},
+      agentStarredAt: {},
+      updatedAt: null,
+    });
+
     await renderProjects();
+
+    const mySection = Array.from(container.querySelectorAll("section"))
+      .find((section) => section.querySelector("h2")?.textContent === "My Projects");
+    expect(mySection?.textContent).toContain("Root");
+    expect(mySection?.textContent).toContain("Child");
+    expect(mySection?.textContent).toContain("2 projects");
+    expect(container.textContent).not.toContain("Other Projects");
+  });
+
+  it("applies name and updated sorting to roots and siblings", async () => {
+    mockProjectsApi.list.mockResolvedValue([
+      makeProject({ id: "root-b", urlKey: "root-b", name: "Beta", updatedAt: new Date("2026-01-01T00:00:00Z") }),
+      makeProject({ id: "child-b", urlKey: "child-b", name: "Bravo", parentProjectId: "root-b", updatedAt: new Date("2026-01-02T00:00:00Z") }),
+      makeProject({ id: "child-a", urlKey: "child-a", name: "Alpha", parentProjectId: "root-b", updatedAt: new Date("2026-01-03T00:00:00Z") }),
+      makeProject({ id: "root-a", urlKey: "root-a", name: "Able", updatedAt: new Date("2026-01-04T00:00:00Z") }),
+    ]);
+    mockResourceMembershipsApi.listMine.mockResolvedValue({
+      projectMemberships: {},
+      agentMemberships: {},
+      starredProjectIds: [],
+      starredAgentIds: [],
+      projectStarredAt: {},
+      agentStarredAt: {},
+      updatedAt: null,
+    });
+
+    await renderProjects();
+    expect(visibleProjectNames()).toEqual(["root-a", "root-b", "child-a", "child-b"]);
+
     await openSortMenu();
     await chooseSortField("Updated");
-
-    const content = container.textContent ?? "";
-    expect(content.indexOf("My Projects")).toBeLessThan(content.indexOf("Charlie"));
-    expect(content.indexOf("Charlie")).toBeLessThan(content.indexOf("Alpha"));
-    expect(content.indexOf("Alpha")).toBeLessThan(content.indexOf("Other Projects"));
+    expect(visibleProjectNames()).toEqual(["root-a", "root-b", "child-a", "child-b"]);
   });
 
-  it("reserves description line height for projects without descriptions", async () => {
+  it("renders membership and star controls and calls their mutation", async () => {
     await renderProjects();
 
-    const bravoLink = Array.from(container.querySelectorAll<HTMLAnchorElement>("a")).find((link) =>
-      link.textContent?.includes("Bravo"),
+    const join = container.querySelector<HTMLButtonElement>('button[aria-label="Join Bravo"]');
+    expect(join).not.toBeNull();
+    await act(async () => { join?.dispatchEvent(new MouseEvent("click", { bubbles: true })); });
+    await flushReact();
+    expect(mockResourceMembershipsApi.updateProject).toHaveBeenCalledWith(
+      "company-1",
+      "project-b",
+      expect.objectContaining({ state: "joined" }),
     );
-    const hiddenDescriptionLine = bravoLink?.querySelector("p[aria-hidden='true']");
 
-    expect(hiddenDescriptionLine).not.toBeNull();
-    expect(hiddenDescriptionLine?.className).toContain("min-h-4");
+    const star = container.querySelector<HTMLButtonElement>('button[aria-label="Star Alpha"]');
+    expect(star).not.toBeNull();
+    await act(async () => { star?.dispatchEvent(new MouseEvent("click", { bubbles: true })); });
+    await flushReact();
+    expect(mockResourceMembershipsApi.updateProject).toHaveBeenCalledWith(
+      "company-1",
+      "project-a",
+      expect.objectContaining({ starred: true }),
+    );
+  });
+
+  it("collapses and expands child projects", async () => {
+    mockProjectsApi.list.mockResolvedValue([
+      makeProject({ id: "root", urlKey: "root", name: "Root" }),
+      makeProject({ id: "child", urlKey: "child", name: "Child", parentProjectId: "root" }),
+    ]);
+    await renderProjects();
+
+    const toggle = container.querySelector<HTMLButtonElement>('button[aria-label="Collapse Root"]');
+    expect(toggle).not.toBeNull();
+    await act(async () => { toggle?.dispatchEvent(new MouseEvent("click", { bubbles: true })); });
+    expect(container.textContent).not.toContain("Child");
+    await act(async () => { container.querySelector<HTMLButtonElement>('button[aria-label="Expand Root"]')?.dispatchEvent(new MouseEvent("click", { bubbles: true })); });
+    expect(container.textContent).toContain("Child");
+  });
+
+  it("opens move and archive dialogs without following the row link", async () => {
+    await renderProjects();
+
+    const openActions = async () => {
+      const trigger = container.querySelector<HTMLButtonElement>('button[aria-label="Actions for Alpha"]');
+      expect(trigger).not.toBeNull();
+      await act(async () => {
+        trigger?.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true, button: 0 }));
+        trigger?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      });
+      await flushReact();
+    };
+
+    await openActions();
+    const move = Array.from(document.body.querySelectorAll<HTMLElement>('[role="menuitem"]'))
+      .find((item) => item.textContent?.includes("Move or detach"));
+    expect(move).toBeTruthy();
+    await act(async () => { move?.dispatchEvent(new MouseEvent("click", { bubbles: true })); });
+    await flushReact();
+    expect(document.body.textContent).toContain("Move Alpha");
+    expect(mockNavigate).not.toHaveBeenCalled();
+
+    const cancelMove = Array.from(document.body.querySelectorAll<HTMLButtonElement>("button"))
+      .find((button) => button.textContent === "Cancel");
+    await act(async () => { cancelMove?.dispatchEvent(new MouseEvent("click", { bubbles: true })); });
+    await flushReact();
+
+    await openActions();
+    const archive = Array.from(document.body.querySelectorAll<HTMLElement>('[role="menuitem"]'))
+      .find((item) => item.textContent?.includes("Archive"));
+    expect(archive).toBeTruthy();
+    await act(async () => { archive?.dispatchEvent(new MouseEvent("click", { bubbles: true })); });
+    await flushReact();
+    expect(document.body.textContent).toContain("Archive Alpha?");
+    expect(mockNavigate).not.toHaveBeenCalled();
   });
 });

--- a/ui/src/pages/Projects.tsx
+++ b/ui/src/pages/Projects.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useMemo, useState } from "react";
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import type { Project } from "@paperclipai/shared";
 import { projectsApi } from "../api/projects";
+import { ApiError } from "../api/client";
 import { useCompany } from "../context/CompanyContext";
 import { useDialogActions } from "../context/DialogContext";
 import { useBreadcrumbs } from "../context/BreadcrumbContext";
@@ -20,10 +21,42 @@ import {
   useResourceMembershipMutation,
   useResourceMemberships,
 } from "../hooks/useResourceMemberships";
+import {
+  buildProjectTree,
+  getActiveDescendantCounts,
+  getParentTargetAvailability,
+  type ProjectTreeNode,
+} from "../lib/project-tree";
 import { Button } from "@/components/ui/button";
-import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
-import { ArrowUpDown, Check, Hexagon, Plus } from "lucide-react";
 import { Card } from "@/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import {
+  Archive,
+  ArrowUpDown,
+  Check,
+  ChevronDown,
+  ChevronRight,
+  FolderPlus,
+  Hexagon,
+  MoreHorizontal,
+  Move,
+  Plus,
+} from "lucide-react";
 
 type ProjectSortField = "name" | "updated" | "created" | "targetDate";
 type ProjectSortDir = "asc" | "desc";
@@ -76,16 +109,216 @@ function sortProjects(projects: Project[], sortField: ProjectSortField, sortDir:
   });
 }
 
+function countProjectTreeNodes(nodes: ProjectTreeNode<Project>[]): number {
+  return nodes.reduce(
+    (count, node) => count + 1 + countProjectTreeNodes(node.children),
+    0,
+  );
+}
+
+function structuredErrorMessage(error: unknown, fallback: string) {
+  if (error instanceof ApiError) {
+    const body = error.body as { error?: string; message?: string; details?: { message?: string } } | null;
+    return body?.details?.message ?? body?.message ?? body?.error ?? error.message;
+  }
+  return error instanceof Error ? error.message : fallback;
+}
+
+function ProjectRow({
+  node,
+  memberships,
+  membershipMutation,
+  activeDescendantCounts,
+  expandedIds,
+  onToggle,
+  onCreateChild,
+  onMove,
+  onArchive,
+}: {
+  node: ProjectTreeNode<Project>;
+  memberships: ReturnType<typeof useResourceMemberships>["data"];
+  membershipMutation: ReturnType<typeof useResourceMembershipMutation>;
+  activeDescendantCounts: Map<string, number>;
+  expandedIds: Set<string>;
+  onToggle: (id: string) => void;
+  onCreateChild: (project: Project) => void;
+  onMove: (project: Project) => void;
+  onArchive: (project: Project) => void;
+}) {
+  const { project, children, depth } = node;
+  const expanded = expandedIds.has(project.id);
+  const hasChildren = children.length > 0;
+  const activeDescendantCount = activeDescendantCounts.get(project.id) ?? 0;
+  const state = resourceMembershipState(memberships, "project", project.id);
+  const pending = membershipMutation.isPending &&
+    membershipMutation.variables?.resourceType === "project" &&
+    membershipMutation.variables.resourceId === project.id;
+  const starPending = pending && membershipMutation.variables?.starred !== undefined;
+  const joinLeavePending = pending && membershipMutation.variables?.starred === undefined;
+  const starred = isStarred(memberships, "project", project.id);
+
+  return (
+    <>
+      <div role="treeitem" aria-expanded={hasChildren ? expanded : undefined}>
+        <EntityRow
+          leading={(
+            <div className="flex items-center" style={{ paddingLeft: `${depth * 20 - 20}px` }}>
+              {hasChildren ? (
+                <button
+                  type="button"
+                  className="mr-1 rounded p-1 text-muted-foreground hover:bg-accent hover:text-foreground"
+                  aria-label={`${expanded ? "Collapse" : "Expand"} ${project.name}`}
+                  onClick={(event) => {
+                    event.preventDefault();
+                    event.stopPropagation();
+                    onToggle(project.id);
+                  }}
+                >
+                  {expanded ? <ChevronDown className="h-4 w-4" /> : <ChevronRight className="h-4 w-4" />}
+                </button>
+              ) : <span className="mr-1 w-6" />}
+              <ProjectTile color={project.color ?? null} icon={project.icon ?? null} size="sm" />
+            </div>
+          )}
+          title={project.name}
+          to={projectUrl(project)}
+          className={state === "left" ? "group text-foreground/55" : "group"}
+          trailing={(
+            <div
+              className="flex items-center gap-3"
+              onClick={(event) => {
+                event.preventDefault();
+                event.stopPropagation();
+              }}
+            >
+              <span
+                className="hidden text-xs text-muted-foreground tabular-nums sm:inline"
+                title={`${formatNumber(project.taskCount ?? 0)} task${(project.taskCount ?? 0) === 1 ? "" : "s"}`}
+              >
+                {formatNumber(project.taskCount ?? 0)} task{(project.taskCount ?? 0) === 1 ? "" : "s"}
+              </span>
+              {project.budget && (
+                <span className="hidden text-xs text-muted-foreground tabular-nums sm:inline">
+                  {formatProjectBudget(project.budget)}
+                </span>
+              )}
+              {project.targetDate && (
+                <span className="hidden text-xs text-muted-foreground md:inline">
+                  {formatDate(project.targetDate)}
+                </span>
+              )}
+              <StatusBadge status={project.status} />
+              <MembershipAction
+                state={state}
+                pending={joinLeavePending}
+                pendingState={joinLeavePending ? membershipMutation.variables?.state : null}
+                resourceName={project.name}
+                onJoin={() => membershipMutation.mutate({
+                  resourceType: "project",
+                  resourceId: project.id,
+                  resourceName: project.name,
+                  state: "joined",
+                })}
+                onLeave={() => membershipMutation.mutate({
+                  resourceType: "project",
+                  resourceId: project.id,
+                  resourceName: project.name,
+                  state: "left",
+                })}
+              />
+              <StarToggle
+                size="row"
+                starred={starred}
+                pending={starPending}
+                resourceName={project.name}
+                onToggle={(next) => membershipMutation.mutate({
+                  resourceType: "project",
+                  resourceId: project.id,
+                  resourceName: project.name,
+                  starred: next,
+                })}
+              />
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="icon-xs"
+                    className="opacity-0 transition-opacity focus:opacity-100 group-hover:opacity-100 data-[state=open]:opacity-100"
+                    aria-label={`Actions for ${project.name}`}
+                    onClick={(event) => {
+                      event.preventDefault();
+                      event.stopPropagation();
+                    }}
+                  >
+                    <MoreHorizontal className="h-4 w-4" />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end" className="w-52">
+                  <DropdownMenuItem
+                    disabled={depth >= 3}
+                    title={depth >= 3 ? "Projects cannot exceed 3 levels." : undefined}
+                    onSelect={() => onCreateChild(project)}
+                  >
+                    <FolderPlus /> Create child
+                  </DropdownMenuItem>
+                  {depth >= 3 ? (
+                    <p className="px-2 py-1 text-xs text-muted-foreground">Projects cannot exceed 3 levels.</p>
+                  ) : null}
+                  <DropdownMenuItem onSelect={() => onMove(project)}>
+                    <Move /> Move or detach
+                  </DropdownMenuItem>
+                  <DropdownMenuSeparator />
+                  <DropdownMenuItem
+                    variant="destructive"
+                    disabled={activeDescendantCount > 0}
+                    title={activeDescendantCount > 0 ? `Archive or move ${activeDescendantCount} active descendant${activeDescendantCount === 1 ? "" : "s"} first.` : undefined}
+                    onSelect={() => onArchive(project)}
+                  >
+                    <Archive /> Archive
+                  </DropdownMenuItem>
+                  {activeDescendantCount > 0 ? (
+                    <p className="px-2 py-1 text-xs text-muted-foreground">
+                      Archive or move {activeDescendantCount} active descendant{activeDescendantCount === 1 ? "" : "s"} first.
+                    </p>
+                  ) : null}
+                </DropdownMenuContent>
+              </DropdownMenu>
+            </div>
+          )}
+        />
+      </div>
+      {hasChildren && expanded ? children.map((child) => (
+        <ProjectRow
+          key={child.project.id}
+          node={child}
+          memberships={memberships}
+          membershipMutation={membershipMutation}
+          activeDescendantCounts={activeDescendantCounts}
+          expandedIds={expandedIds}
+          onToggle={onToggle}
+          onCreateChild={onCreateChild}
+          onMove={onMove}
+          onArchive={onArchive}
+        />
+      )) : null}
+    </>
+  );
+}
+
 export function Projects() {
   const { selectedCompanyId } = useCompany();
   const { openNewProject } = useDialogActions();
   const { setBreadcrumbs } = useBreadcrumbs();
+  const queryClient = useQueryClient();
   const [sortField, setSortField] = useState<ProjectSortField>("name");
   const [sortDir, setSortDir] = useState<ProjectSortDir>("asc");
+  const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set());
+  const [moveProject, setMoveProject] = useState<Project | null>(null);
+  const [moveParentId, setMoveParentId] = useState<string | null>(null);
+  const [archiveProject, setArchiveProject] = useState<Project | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
 
-  useEffect(() => {
-    setBreadcrumbs([{ label: "Projects" }]);
-  }, [setBreadcrumbs]);
+  useEffect(() => setBreadcrumbs([{ label: "Projects" }]), [setBreadcrumbs]);
 
   const { data: allProjects, isLoading, error } = useQuery({
     queryKey: queryKeys.projects.list(selectedCompanyId!),
@@ -94,37 +327,77 @@ export function Projects() {
   });
   const membershipsQuery = useResourceMemberships(selectedCompanyId);
   const membershipMutation = useResourceMembershipMutation(selectedCompanyId);
-  const projects = useMemo(
-    () => (allProjects ?? []).filter((p) => !p.archivedAt),
-    [allProjects],
+  const projects = useMemo(() => (allProjects ?? []) as Project[], [allProjects]);
+  const activeProjects = useMemo(() => projects.filter((project) => !project.archivedAt), [projects]);
+  const sortedActiveProjects = useMemo(
+    () => sortProjects(activeProjects, sortField, sortDir),
+    [activeProjects, sortDir, sortField],
   );
-  const sortedProjects = useMemo(
-    () => sortProjects(projects, sortField, sortDir),
-    [projects, sortDir, sortField],
-  );
-  const groupedProjects = useMemo(() => {
-    const groups = {
-      mine: [] as typeof sortedProjects,
-      other: [] as typeof sortedProjects,
+  const rootTreesByMembership = useMemo(() => {
+    const completeTree = buildProjectTree(sortedActiveProjects);
+    return {
+      mine: completeTree.filter((node) => resourceMembershipState(
+        membershipsQuery.data,
+        "project",
+        node.project.id,
+      ) !== "left"),
+      other: completeTree.filter((node) => resourceMembershipState(
+        membershipsQuery.data,
+        "project",
+        node.project.id,
+      ) === "left"),
     };
-
-    for (const project of sortedProjects) {
-      const state = resourceMembershipState(membershipsQuery.data, "project", project.id);
-      if (state === "left") groups.other.push(project);
-      else groups.mine.push(project);
-    }
-
-    return groups;
-  }, [membershipsQuery.data, sortedProjects]);
+  }, [membershipsQuery.data, sortedActiveProjects]);
+  const rootTreeCounts = useMemo(() => ({
+    mine: countProjectTreeNodes(rootTreesByMembership.mine),
+    other: countProjectTreeNodes(rootTreesByMembership.other),
+  }), [rootTreesByMembership]);
+  const activeDescendantCounts = useMemo(() => getActiveDescendantCounts(projects), [projects]);
+  const selectedMoveTargetAvailability = moveProject && moveParentId
+    ? getParentTargetAvailability(projects, moveProject.id, moveParentId)
+    : null;
+  const moveSelectionInvalid = selectedMoveTargetAvailability?.disabled ?? false;
   const sortLabel = PROJECT_SORT_OPTIONS.find((option) => option.field === sortField)?.label ?? "Name";
 
-  if (!selectedCompanyId) {
-    return <EmptyState icon={Hexagon} message="Select a company to view projects." />;
-  }
+  useEffect(() => {
+    setExpandedIds((current) => {
+      if (current.size > 0) return current;
+      const next = new Set<string>();
+      const collectParents = (nodes: ProjectTreeNode<Project>[]) => {
+        for (const node of nodes) {
+          if (node.children.length > 0) next.add(node.project.id);
+          collectParents(node.children);
+        }
+      };
+      collectParents(rootTreesByMembership.mine);
+      collectParents(rootTreesByMembership.other);
+      return next;
+    });
+  }, [rootTreesByMembership]);
 
-  if (isLoading) {
-    return <PageSkeleton variant="list" />;
-  }
+  const updateMutation = useMutation({
+    mutationFn: ({ projectId, parentProjectId }: { projectId: string; parentProjectId: string | null }) =>
+      projectsApi.update(projectId, { parentProjectId }, selectedCompanyId!),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: queryKeys.projects.list(selectedCompanyId!) });
+      setMoveProject(null);
+      setActionError(null);
+    },
+    onError: (mutationError) => setActionError(structuredErrorMessage(mutationError, "Failed to move project.")),
+  });
+
+  const archiveMutation = useMutation({
+    mutationFn: (projectId: string) => projectsApi.update(projectId, { archivedAt: new Date().toISOString() }, selectedCompanyId!),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: queryKeys.projects.list(selectedCompanyId!) });
+      setArchiveProject(null);
+      setActionError(null);
+    },
+    onError: (mutationError) => setActionError(structuredErrorMessage(mutationError, "Failed to archive project.")),
+  });
+
+  if (!selectedCompanyId) return <EmptyState icon={Hexagon} message="Select a company to view projects." />;
+  if (isLoading) return <PageSkeleton variant="list" />;
 
   return (
     <div className="space-y-4">
@@ -132,24 +405,20 @@ export function Projects() {
         <Popover>
           <PopoverTrigger asChild>
             <Button variant="ghost" size="sm" className="w-fit text-xs" title="Sort">
-              <ArrowUpDown className="h-3.5 w-3.5 sm:h-3 sm:w-3 sm:mr-1" />
+              <ArrowUpDown className="h-3.5 w-3.5 sm:mr-1 sm:h-3 sm:w-3" />
               <span>Sort: {sortLabel}</span>
             </Button>
           </PopoverTrigger>
           <PopoverContent align="start" className="w-44 p-0">
-            <div className="p-2 space-y-0.5">
+            <div className="space-y-0.5 p-2">
               {PROJECT_SORT_OPTIONS.map((option) => (
                 <button
                   key={option.field}
                   type="button"
-                  className={`flex w-full items-center justify-between rounded-sm px-2 py-1.5 text-sm ${
-                    sortField === option.field
-                      ? "bg-accent/50 text-foreground"
-                      : "text-muted-foreground hover:bg-accent/50"
-                  }`}
+                  className={`flex w-full items-center justify-between rounded-sm px-2 py-1.5 text-sm ${sortField === option.field ? "bg-accent/50 text-foreground" : "text-muted-foreground hover:bg-accent/50"}`}
                   onClick={() => {
                     if (sortField === option.field) {
-                      setSortDir((current) => (current === "asc" ? "desc" : "asc"));
+                      setSortDir((current) => current === "asc" ? "desc" : "asc");
                       return;
                     }
                     setSortField(option.field);
@@ -168,117 +437,130 @@ export function Projects() {
             </div>
           </PopoverContent>
         </Popover>
-        <Button size="sm" variant="outline" onClick={openNewProject}>
-          <Plus className="h-4 w-4 mr-1" />
-          Add Project
+        <Button size="sm" variant="outline" onClick={() => openNewProject({ parentProjectId: null })}>
+          <Plus className="mr-1 h-4 w-4" /> Add Project
         </Button>
       </div>
 
-      {error && <p className="text-sm text-destructive">{error.message}</p>}
+      {error ? <p className="text-sm text-destructive">{error.message}</p> : null}
+      {actionError ? <p role="alert" className="rounded border border-destructive/30 bg-destructive/5 px-3 py-2 text-sm text-destructive">{actionError}</p> : null}
 
-      {!isLoading && projects.length === 0 && (
-        <EmptyState
-          icon={Hexagon}
-          message="No projects yet."
-          action="Add Project"
-          onAction={openNewProject}
-        />
-      )}
-
-      {projects.length > 0 && (
+      {activeProjects.length === 0 ? (
+        <EmptyState icon={Hexagon} message="No projects yet." action="Add Project" onAction={() => openNewProject({ parentProjectId: null })} />
+      ) : (
         <div className="space-y-6">
           {([
-            ["My Projects", groupedProjects.mine],
-            ["Other Projects", groupedProjects.other],
-          ] as const).map(([label, sectionProjects]) => {
-            if (sectionProjects.length === 0) return null;
-
+            ["My Projects", rootTreeCounts.mine, rootTreesByMembership.mine],
+            ["Other Projects", rootTreeCounts.other, rootTreesByMembership.other],
+          ] as const).map(([label, sectionProjectCount, sectionTree]) => {
+            if (sectionProjectCount === 0) return null;
             return (
               <section key={label} className="space-y-2">
                 <div className="flex items-center justify-between">
                   <h2 className="text-sm font-medium">{label}</h2>
                   <span className="text-xs text-muted-foreground">
-                    {sectionProjects.length} project{sectionProjects.length === 1 ? "" : "s"}
+                    {sectionProjectCount} project{sectionProjectCount === 1 ? "" : "s"}
                   </span>
                 </div>
-                <Card className="block py-0 overflow-hidden divide-y divide-border">
-                  {sectionProjects.map((project) => {
-                    const state = resourceMembershipState(membershipsQuery.data, "project", project.id);
-                    const pending = membershipMutation.isPending &&
-                      membershipMutation.variables?.resourceType === "project" &&
-                      membershipMutation.variables.resourceId === project.id;
-                    const starPending = pending && membershipMutation.variables?.starred !== undefined;
-                    const joinLeavePending = pending && membershipMutation.variables?.starred === undefined;
-                    const starred = isStarred(membershipsQuery.data, "project", project.id);
-                    return (
-                      <EntityRow
-                        key={project.id}
-                        leading={<ProjectTile color={project.color ?? null} icon={project.icon ?? null} size="sm" />}
-                        title={project.name}
-                        subtitle={project.description ?? undefined}
-                        reserveSubtitleSpace
-                        to={projectUrl(project)}
-                        className={state === "left" ? "group text-foreground/55" : "group"}
-                        trailing={
-                          <div className="flex items-center gap-3">
-                            <span
-                              className="hidden text-xs text-muted-foreground tabular-nums sm:inline"
-                              title={`${formatNumber(project.taskCount ?? 0)} task${(project.taskCount ?? 0) === 1 ? "" : "s"}`}
-                            >
-                              {formatNumber(project.taskCount ?? 0)} task{(project.taskCount ?? 0) === 1 ? "" : "s"}
-                            </span>
-                            {project.budget && (
-                              <span className="hidden text-xs text-muted-foreground tabular-nums sm:inline">
-                                {formatProjectBudget(project.budget)}
-                              </span>
-                            )}
-                            {project.targetDate && (
-                              <span className="hidden text-xs text-muted-foreground md:inline">
-                                {formatDate(project.targetDate)}
-                              </span>
-                            )}
-                            <StatusBadge status={project.status} />
-                            <MembershipAction
-                              state={state}
-                              pending={joinLeavePending}
-                              pendingState={joinLeavePending ? membershipMutation.variables?.state : null}
-                              resourceName={project.name}
-                              onJoin={() => membershipMutation.mutate({
-                                resourceType: "project",
-                                resourceId: project.id,
-                                resourceName: project.name,
-                                state: "joined",
-                              })}
-                              onLeave={() => membershipMutation.mutate({
-                                resourceType: "project",
-                                resourceId: project.id,
-                                resourceName: project.name,
-                                state: "left",
-                              })}
-                            />
-                            <StarToggle
-                              size="row"
-                              starred={starred}
-                              pending={starPending}
-                              resourceName={project.name}
-                              onToggle={(next) => membershipMutation.mutate({
-                                resourceType: "project",
-                                resourceId: project.id,
-                                resourceName: project.name,
-                                starred: next,
-                              })}
-                            />
-                          </div>
-                        }
-                      />
-                    );
-                  })}
+                <Card className="block overflow-hidden py-0" role="tree">
+                  {sectionTree.map((node) => (
+                    <ProjectRow
+                      key={node.project.id}
+                      node={node}
+                      memberships={membershipsQuery.data}
+                      membershipMutation={membershipMutation}
+                      activeDescendantCounts={activeDescendantCounts}
+                      expandedIds={expandedIds}
+                      onToggle={(id) => setExpandedIds((current) => {
+                        const next = new Set(current);
+                        if (next.has(id)) next.delete(id); else next.add(id);
+                        return next;
+                      })}
+                      onCreateChild={(project) => openNewProject({ parentProjectId: project.id })}
+                      onMove={(project) => {
+                        setMoveProject(project);
+                        setMoveParentId(project.parentProjectId);
+                        setActionError(null);
+                      }}
+                      onArchive={(project) => {
+                        setArchiveProject(project);
+                        setActionError(null);
+                      }}
+                    />
+                  ))}
                 </Card>
               </section>
             );
           })}
         </div>
       )}
+
+      <Dialog open={!!moveProject} onOpenChange={(open) => !open && setMoveProject(null)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Move {moveProject?.name}</DialogTitle>
+            <DialogDescription>Choose a parent or detach this project to the root. The tree remains limited to three levels.</DialogDescription>
+          </DialogHeader>
+          <div className="space-y-2">
+            <label className="text-sm font-medium" htmlFor="move-parent">Parent project</label>
+            <select
+              id="move-parent"
+              className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm"
+              value={moveParentId ?? ""}
+              onChange={(event) => setMoveParentId(event.target.value || null)}
+            >
+              <option value="">No parent (root)</option>
+              {moveProject ? projects.map((target) => {
+                const availability = getParentTargetAvailability(projects, moveProject.id, target.id);
+                return (
+                  <option key={target.id} value={target.id} disabled={availability.disabled} title={availability.reason ?? undefined}>
+                    {target.name}{availability.reason ? ` — ${availability.reason}` : ""}
+                  </option>
+                );
+              }) : null}
+            </select>
+          </div>
+          {moveSelectionInvalid ? (
+            <p role="alert" className="text-sm text-destructive">
+              {selectedMoveTargetAvailability?.reason ?? "Selected parent is unavailable."}
+            </p>
+          ) : null}
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setMoveProject(null)}>Cancel</Button>
+            <Button
+              disabled={!moveProject || updateMutation.isPending || moveSelectionInvalid || moveParentId === moveProject.parentProjectId}
+              onClick={() => {
+                if (!moveProject || updateMutation.isPending || moveParentId === moveProject.parentProjectId) return;
+                const availability = moveParentId
+                  ? getParentTargetAvailability(projects, moveProject.id, moveParentId)
+                  : null;
+                if (availability?.disabled) {
+                  setActionError(availability.reason ?? "Selected parent is unavailable.");
+                  return;
+                }
+                updateMutation.mutate({ projectId: moveProject.id, parentProjectId: moveParentId });
+              }}
+            >
+              {updateMutation.isPending ? "Moving…" : moveParentId ? "Move project" : "Detach to root"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={!!archiveProject} onOpenChange={(open) => !open && setArchiveProject(null)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Archive {archiveProject?.name}?</DialogTitle>
+            <DialogDescription>The project will leave the active tree. Its work is not inherited by another project.</DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setArchiveProject(null)}>Cancel</Button>
+            <Button variant="destructive" disabled={archiveMutation.isPending} onClick={() => archiveProject && archiveMutation.mutate(archiveProject.id)}>
+              {archiveMutation.isPending ? "Archiving…" : "Archive project"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/ui/storybook/fixtures/paperclipData.ts
+++ b/ui/storybook/fixtures/paperclipData.ts
@@ -582,6 +582,7 @@ function createProject(overrides: Partial<Project> = {}): Project {
     id,
     companyId: "company-storybook",
     urlKey: "board-ui",
+    parentProjectId: null,
     goalId: "goal-company",
     goalIds: ["goal-company", "goal-board-ux"],
     goals: storybookGoals

--- a/ui/storybook/stories/forms-editors.stories.tsx
+++ b/ui/storybook/stories/forms-editors.stories.tsx
@@ -293,6 +293,7 @@ const storybookProject: Project = {
   id: "project-board-ui",
   companyId: "company-storybook",
   urlKey: "board-ui",
+  parentProjectId: null,
   goalId: "goal-company",
   goalIds: ["goal-company"],
   goals: [{ id: "goal-company", title: "We're building Paperclip" }],


### PR DESCRIPTION
## Summary

- Add an optional three-level parent/child hierarchy for projects.
- Keep project resources and authorization independent across the tree.
- Add transactional validation, migration coverage, tree UI controls, and regression tests.

## Thinking Path

> - Paperclip manages agents and their work through company-scoped projects.
> - Projects are currently flat, which makes related initiatives harder to organize without changing their ownership boundaries.
> - A nullable parent reference provides a small additive hierarchy while preserving existing projects as roots.
> - Limiting the tree to three levels keeps navigation and validation bounded.
> - Hierarchy validation and mutation must be atomic so concurrent moves cannot create cycles or exceed the depth limit.
> - The backend therefore returns a flat same-company list while the UI builds and sorts the visible tree.
> - This pull request adds that bounded hierarchy without inheriting budgets, workspaces, agents, issues, goals, permissions, membership, or status.
> - The benefit is clearer project organization without changing resource ownership or authorization semantics.

## Linked Issues or Issue Description

Projects can only be represented as a flat list today. Teams need to group related projects into a small hierarchy while keeping each project operationally independent.

**Requested behavior**

- Create root, child, and grandchild projects.
- Move a project to another legal parent or detach it to the root.
- Reject missing, cross-company, archived, self, cyclic, fourth-level, and subtree-overflow parent targets.
- Prevent archiving a project while it has active descendants.
- Preserve existing flat projects as roots and avoid resource or permission inheritance.

No matching public issue or pull request was found during the duplicate search. Public issue #1150 concerns sub-issue project inheritance and has different semantics.

## What Changed

- Add nullable `projects.parent_project_id`, a self-parent check, and a company/parent index in migration `0147_project_tree.sql`.
- Add `parentProjectId` to shared project types and validators.
- Validate and mutate hierarchy in a single Drizzle transaction guarded by a transaction-scoped PostgreSQL advisory lock.
- Return `parentProjectId` from project list, create, update, and detail flows with structured hierarchy error codes.
- Add a collapsible Projects tree with create-child, move/detach, archive, membership, star, and sorting behavior.
- Disable illegal parent destinations with an explanatory reason.
- Add service, route, tree utility, page, fixture, concurrency, and row-action navigation regression coverage.

## Verification

- `pnpm exec vitest run server/src/__tests__/project-tree-service.test.ts server/src/__tests__/project-tree-routes.test.ts ui/src/lib/project-tree.test.ts ui/src/pages/Projects.test.tsx` (4 files, 20 tests passed)
- `pnpm typecheck`
- `pnpm build`
- Migration numbering and safety checks through the database package typecheck
- `git diff --check`
- Manual browser verification of root/child/grandchild rendering, collapse/expand, move, detach, leaf archive, illegal parent reasons, depth-three create-child disablement, and active-descendant archive blocking

## Test plan

- [x] Create a root, child, and grandchild and verify tree nesting.
- [x] Collapse and expand parent nodes.
- [x] Detach a grandchild to root and move it back under its parent.
- [x] Archive a leaf without archiving its parent.
- [x] Verify self, archived, depth, cycle, missing, and cross-company parent constraints.
- [x] Verify concurrent opposing moves cannot create a cycle.
- [x] Verify existing flat projects remain roots.
- [x] Verify row action menus do not navigate to project detail.

## Migration

Back up the database first with `pnpm db:backup`, then apply migrations with `pnpm --filter @paperclipai/db migrate`.

Rollback removes the index, self-parent check, foreign key, and `parent_project_id` column. Removing the column returns projects to a flat model without deleting projects or independently owned resources.

## Compatibility

The schema change is additive and nullable. Existing projects remain roots. API consumers receive one new nullable `parentProjectId` field. The backend continues to return a flat same-company project list.

## Risks

- Concurrent hierarchy changes could otherwise race; all tree validation and writes are serialized per company inside one database transaction.
- Rolling back discards hierarchy links because the parent column is removed.
- UI grouping and sorting can accidentally split subtrees; tests cover root-subtree membership grouping and caller-preserved sorting.

## Non-goals

- Arbitrary-depth hierarchy or closure tables.
- Permission, budget, goal, agent, issue, workspace, membership, status, or authorization inheritance.
- Recursive archive or delete.
- Inferring parent relationships for existing projects.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- Neo via Matrix model routing. The exact provider/model ID and context-window size are not exposed to this session. Tool use included repository inspection, code execution, tests, builds, GitHub CLI, and browser automation.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with the version information available to this session)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked or described findings above
- [x] I have described the issue in-PR following the feature request shape
- [x] I have not referenced internal/instance-local Paperclip issues or links
- [x] My branch name describes the change and contains no internal Paperclip ticket id
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have documented migration, compatibility, rollback, risks, and non-goals
- [x] I have considered and documented risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

🤖 Generated with Neo