### PR TITLE
fix(recovery): chunk issue-recovery-action lookup to avoid unbounded IN clause

### DIFF
--- a/server/src/__tests__/heartbeat-issue-liveness-escalation.test.ts
+++ b/server/src/__tests__/heartbeat-issue-liveness-escalation.test.ts
@@ -742,6 +742,56 @@ describeEmbeddedPostgres("heartbeat issue graph liveness escalation", () => {
     });
   });
 
+  it("reconciles correctly when the company has more issues than one recovery-action query batch", async () => {
+    // Regression test: collectIssueGraphLivenessFindings() used to pass every
+    // in-analysis issue id into a single `inArray(...)` query. With enough issues
+    // in a company that grows a large backlog (as happens after a busy initial
+    // import), the parameter list could balloon into the tens of thousands and
+    // the query would fail on every heartbeat cycle. The fix chunks that lookup;
+    // this test proves reconciliation still finds the right issue even when it's
+    // seeded well past the chunk boundary among hundreds of unrelated issues.
+    await enableAutoRecovery();
+    const { companyId, coderId, blockedIssueId, blockerIssueId } = await seedBlockedChain({
+      blockerStatus: "backlog",
+      blockerAssigneeAgentId: "coder",
+    });
+    const [companyRow] = await db
+      .select({ issuePrefix: companies.issuePrefix })
+      .from(companies)
+      .where(eq(companies.id, companyId));
+    const fillerIssueCount = 600;
+    await db.insert(issues).values(
+      Array.from({ length: fillerIssueCount }, (_, index) => ({
+        id: randomUUID(),
+        companyId,
+        title: `Filler issue ${index}`,
+        status: "done",
+        priority: "low",
+        issueNumber: 3 + index,
+        identifier: `${companyRow!.issuePrefix}-${3 + index}`,
+      })),
+    );
+
+    const heartbeat = heartbeatService(db);
+    const first = await heartbeat.reconcileIssueGraphLiveness();
+    const second = await heartbeat.reconcileIssueGraphLiveness();
+
+    expect(first.findings).toBe(1);
+    expect(first.escalationsCreated).toBe(1);
+    expect(second.findings).toBe(0);
+    expect(second.escalationsCreated).toBe(0);
+
+    const escalations = await db
+      .select()
+      .from(issues)
+      .where(and(eq(issues.companyId, companyId), eq(issues.originKind, "harness_liveness_escalation")));
+    expect(escalations).toHaveLength(1);
+    expect(escalations[0]).toMatchObject({
+      parentId: blockerIssueId,
+      assigneeAgentId: coderId,
+    });
+  });
+
   it("treats open recovery issues as active waiting paths for non-assigned-backlog states", async () => {
     await enableAutoRecovery();
     const { companyId, managerId, blockedIssueId, blockerIssueId } = await seedBlockedChain();

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -81,6 +81,7 @@ const STALE_ACTIVE_RUN_EVALUATION_ORIGIN_KIND = RECOVERY_ORIGIN_KINDS.staleActiv
 const DEFERRED_WAKE_CONTEXT_KEY = "_paperclipWakeContext";
 const EXECUTION_REVIEW_PARTICIPANT_RECOVERY_REASON = "execution_review_participant_recovery";
 const RESOLVED_DEPENDENCY_WAKE_BACKSTOP_CANDIDATE_LIMIT = 500;
+const ISSUE_RECOVERY_ACTION_QUERY_CHUNK_SIZE = 500;
 const SESSIONED_LOCAL_ADAPTERS = new Set([
   "claude_local",
   "codex_local",
@@ -3495,6 +3496,30 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     return result;
   }
 
+  function chunkIds<T>(values: T[], size: number): T[][] {
+    const chunks: T[][] = [];
+    for (let index = 0; index < values.length; index += size) {
+      chunks.push(values.slice(index, index + size));
+    }
+    return chunks;
+  }
+
+  function fetchActiveRecoveryActionsForIds(idChunk: string[]) {
+    return db
+      .select({
+        companyId: issueRecoveryActions.companyId,
+        issueId: issueRecoveryActions.sourceIssueId,
+        status: issueRecoveryActions.status,
+      })
+      .from(issueRecoveryActions)
+      .where(
+        and(
+          inArray(issueRecoveryActions.status, ["active", "escalated"]),
+          inArray(issueRecoveryActions.sourceIssueId, idChunk),
+        ),
+      );
+  }
+
   async function collectIssueGraphLivenessFindings() {
     const issueRowsPromise = Promise.resolve(db
       .select({
@@ -3625,23 +3650,16 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
             notInArray(issues.status, ["done", "cancelled"]),
           ),
         ),
-      issueRowsPromise.then((rows) => {
+      issueRowsPromise.then(async (rows) => {
         const issueIdsUnderAnalysis = rows.map((row) => row.id);
-        return issueIdsUnderAnalysis.length === 0
-          ? []
-          : db
-            .select({
-              companyId: issueRecoveryActions.companyId,
-              issueId: issueRecoveryActions.sourceIssueId,
-              status: issueRecoveryActions.status,
-            })
-            .from(issueRecoveryActions)
-            .where(
-              and(
-                inArray(issueRecoveryActions.status, ["active", "escalated"]),
-                inArray(issueRecoveryActions.sourceIssueId, issueIdsUnderAnalysis),
-              ),
-            );
+        if (issueIdsUnderAnalysis.length === 0) return [];
+        // Chunked to stay well under the Postgres/driver bind-parameter limit —
+        // this list is a system-wide, unbounded scan and can reach tens of thousands of ids.
+        const results: Awaited<ReturnType<typeof fetchActiveRecoveryActionsForIds>> = [];
+        for (const idChunk of chunkIds(issueIdsUnderAnalysis, ISSUE_RECOVERY_ACTION_QUERY_CHUNK_SIZE)) {
+          results.push(...(await fetchActiveRecoveryActionsForIds(idChunk)));
+        }
+        return results;
       }),
     ]);
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The issue-graph liveness/recovery subsystem (`server/src/services/recovery/service.ts`) runs on every heartbeat cycle to find stranded or blocked issues and reconcile recovery actions for them
> - `collectIssueGraphLivenessFindings()` builds its candidate issue-id list from an unbounded, system-wide scan of the `issues` table, then passes the *entire* list into one `inArray(issueRecoveryActions.sourceIssueId, issueIdsUnderAnalysis)` query
> - On an instance with a large issue backlog (e.g. after a busy initial import, or the self-generated `stranded_issue_recovery` issues this same subsystem creates), that list can reach tens of thousands of ids — the resulting query becomes slow enough to hit Postgres's `statement_timeout` and gets cancelled outright
> - Because this runs on every heartbeat cycle (every ~30–45s) as well as at startup, the failure repeats continuously — each attempt re-logs the full failed query (including every bind parameter), which burns CPU re-attempting the query and floods the log (observed: journald suppressing 90k+ messages from the service within a few minutes on one affected instance, which can fill the disk over time)
> - This pull request chunks the id list into batches before querying, matching the batching convention already used for the same kind of lookup elsewhere in the codebase
> - The benefit is the query completes well within `statement_timeout` regardless of backlog size, stopping the crash loop, the CPU burn, and the log flood

## Linked Issues or Issue Description

Fixes: #4625

That issue reports the exact same failure (`periodic heartbeat recovery failed`), just surfaced via a different Postgres error at cancellation time (`canceling statement due to statement timeout`, code `57014`) rather than the log-flood/CPU symptom — same root cause: the unbounded `IN (...)` query taking too long once the candidate-id list is large.

## What Changed

- `server/src/services/recovery/service.ts`: added `ISSUE_RECOVERY_ACTION_QUERY_CHUNK_SIZE = 500` and a small `chunkIds()` helper (mirrors the existing `chunkList`/`ISSUE_LIST_RELATED_QUERY_CHUNK_SIZE` pattern already used in `server/src/services/issues.ts` for the same kind of lookup).
- Replaced the single unbounded `inArray(issueRecoveryActions.sourceIssueId, issueIdsUnderAnalysis)` query inside `collectIssueGraphLivenessFindings()` with a loop that queries in batches of 500 ids and concatenates the results. Behavior/output is unchanged; only the query shape changes.
- `server/src/__tests__/heartbeat-issue-liveness-escalation.test.ts`: added a regression test that seeds a company with 600+ issues (past the new batch boundary) plus a real blocked/backlog pair, and verifies `heartbeatService(db).reconcileIssueGraphLiveness()` still finds and escalates it correctly on the first pass and doesn't duplicate on a second pass.

## Verification

- `pnpm --filter @paperclipai/server exec tsc --noEmit -p .` — no new type errors introduced by this diff (the sandbox used to verify this has some pre-existing, unrelated errors from an unbuilt `@paperclipai/plugin-sdk` package; none are in the touched files).
- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/heartbeat-issue-liveness-escalation.test.ts src/__tests__/recovery-classifiers.test.ts src/__tests__/issue-recovery-actions.test.ts` — all passing (49/49 before this change, 50/50 with the new regression test added).
- Diagnosed this against a real affected instance (~62k stale `stranded_issue_recovery` issues from a runaway-loop incident, matching #4625's timeframe). This fix has not been deployed there yet — the immediate incident was mitigated by cleaning up the stale issue backlog, which is why this PR exists: to stop the same failure mode from recurring once any instance's backlog grows large again.

## Risks

Low risk. The query's filters and result shape are unchanged — only batching was added around an existing, already-tested lookup. For instances under the batch size (500), behavior is byte-for-byte identical (a single batch, same as before). For instances over it, the fix trades one large query for several smaller sequential ones, which is strictly safer for `statement_timeout` at the cost of a few extra round-trips — negligible next to a heartbeat cycle that runs every 30–45s.

## Model Used

Claude Sonnet 5 (Claude Code), standard reasoning mode, with tool use (repo search/read/edit, local typecheck, and test execution via the Bash tool) to diagnose the root cause against a live production incident, implement the fix, and verify it.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
