### PR TITLE
docs: add subscription CLI auth setup

### DIFF
--- a/docker/docker-compose.subscription-auth.yml
+++ b/docker/docker-compose.subscription-auth.yml
@@ -1,0 +1,24 @@
+# Optional override: let local CLI adapters use existing subscription/OAuth homes.
+#
+# Usage:
+#   docker compose \
+#     -f docker/docker-compose.quickstart.yml \
+#     -f docker/docker-compose.subscription-auth.yml \
+#     up
+#
+# Defaults mount the operator's Codex and Claude Code homes read-only. Override
+# CODEX_HOME / CLAUDE_CONFIG_DIR to point at dedicated Paperclip auth-home copies
+# if the CLIs need writable refresh state.
+
+services:
+  paperclip:
+    environment:
+      CODEX_HOME: /host-cli-auth/codex
+      CLAUDE_CONFIG_DIR: /host-cli-auth/claude
+      # Keep provider API-key variables empty so local adapters use CLI
+      # subscription/session auth instead of API-key mode.
+      OPENAI_API_KEY: ""
+      ANTHROPIC_API_KEY: ""
+    volumes:
+      - ${CODEX_HOME:-${HOME}/.codex}:/host-cli-auth/codex:ro
+      - ${CLAUDE_CONFIG_DIR:-${HOME}/.claude}:/host-cli-auth/claude:ro

--- a/docs/adapters/claude-local.md
+++ b/docs/adapters/claude-local.md
@@ -9,7 +9,9 @@ The `claude_local` adapter runs Anthropic's Claude Code CLI locally. It supports
 
 - Claude Code CLI installed (`claude` command available)
 - Either `ANTHROPIC_API_KEY` in adapter env/host env, or a Claude Code
-  subscription login available to the execution target
+  subscription login available through `CLAUDE_CONFIG_DIR` / `~/.claude` to the execution target
+
+For API-key-free local operation, see [Subscription CLI auth](/adapters/subscription-cli-auth).
 
 ## Configuration Fields
 
@@ -69,6 +71,8 @@ On-call checklist if you see this in production:
 ## Skills Injection
 
 The adapter creates a temporary directory with symlinks to Paperclip skills and passes it via `--add-dir`. This makes skills discoverable without polluting the agent's working directory.
+
+For Docker deployments that use Claude Code subscription auth, mount the desired Claude config directory into the container and set `CLAUDE_CONFIG_DIR` to that mounted path. The example `docker/docker-compose.subscription-auth.yml` keeps the mount read-only by default.
 
 ## Remote credential ownership
 

--- a/docs/adapters/codex-local.md
+++ b/docs/adapters/codex-local.md
@@ -14,6 +14,8 @@ The `codex_local` adapter runs OpenAI's Codex CLI locally. It supports session p
   `auth.json`, not directly from the process environment — for a self-managed
   external `CODEX_HOME`, write `auth.json` there directly instead)
 
+For API-key-free local operation, see [Subscription CLI auth](/adapters/subscription-cli-auth).
+
 ## Configuration Fields
 
 | Field | Type | Required | Description |
@@ -48,6 +50,8 @@ Paperclip currently applies that only when the selected model is `gpt-5.4`. On o
 ## Managed `CODEX_HOME`
 
 When Paperclip is running inside a managed worktree instance (`PAPERCLIP_IN_WORKTREE=true`), the adapter instead uses a worktree-isolated `CODEX_HOME` under the Paperclip instance so Codex skills, sessions, logs, and other runtime state do not leak across checkouts. It seeds that isolated home from the user's main Codex home for shared auth/config continuity.
+
+For Docker deployments, mount the desired Codex home into the container and set `CODEX_HOME` to that mounted path. The example `docker/docker-compose.subscription-auth.yml` keeps the mount read-only by default.
 
 ### Per-agent isolation and auth seeding
 
@@ -158,5 +162,5 @@ The environment test checks:
 
 - Codex CLI is installed and accessible
 - Working directory is absolute and available (auto-created if missing and permitted)
-- Authentication signal (`OPENAI_API_KEY` presence)
+- Authentication signal (`OPENAI_API_KEY` presence or native Codex auth under `CODEX_HOME`)
 - A live hello probe (`codex exec --json -` with prompt `Respond with hello.`) to verify the CLI can actually run

--- a/docs/adapters/overview.md
+++ b/docs/adapters/overview.md
@@ -30,6 +30,8 @@ When a heartbeat fires, Paperclip:
 | [Process](/adapters/process) | `process` | Executes arbitrary shell commands |
 | [HTTP](/adapters/http) | `http` | Sends webhooks to external agents |
 
+Local CLI adapters such as `codex_local` and `claude_local` can use provider API keys or existing CLI subscription/OAuth sessions. See [Subscription CLI auth](/adapters/subscription-cli-auth) for the API-key-free setup.
+
 ## Credential ownership for sandbox targets
 
 Local CLI adapters can run on the Paperclip host, SSH targets, or managed

--- a/docs/adapters/subscription-cli-auth.md
+++ b/docs/adapters/subscription-cli-auth.md
@@ -1,0 +1,154 @@
+---
+title: Subscription CLI auth
+summary: Use local Codex and Claude Code subscription/OAuth sessions without API keys
+---
+
+Paperclip can run local CLI adapters with subscription/OAuth logins instead of provider API keys. This is useful for small teams or solo operators who have already authenticated the official CLIs but do not yet want to provision organization API keys.
+
+Supported adapters:
+
+- [`codex_local`](/adapters/codex-local) through Codex CLI's `CODEX_HOME` / `~/.codex` session home.
+- [`claude_local`](/adapters/claude-local) through Claude Code's `CLAUDE_CONFIG_DIR` / `~/.claude` session home.
+
+This mode should be treated as a local-operator convenience, not as a multi-tenant production secret-management model.
+
+## When to use this
+
+Use subscription CLI auth when all of these are true:
+
+- Paperclip is running on a trusted local workstation, VM, or private server.
+- The operator has already run the vendor CLI login flow (`codex login`, `claude login`, or equivalent).
+- You do not want to store `OPENAI_API_KEY` or `ANTHROPIC_API_KEY` values in Paperclip.
+- Agents are allowed to consume the same subscription session as the local CLI user.
+
+Use API keys or a managed secret backend instead when you need tenant isolation, audit-grade provider billing, per-agent spend attribution, or revocable service credentials.
+
+## Host setup
+
+Authenticate each CLI outside Paperclip first:
+
+```sh
+codex login
+claude login
+```
+
+Then verify metadata only. Do not print file contents:
+
+```sh
+test -s "$HOME/.codex/auth.json" && echo "Codex auth present"
+test -s "$HOME/.claude/.credentials.json" && echo "Claude credentials present"
+```
+
+## Docker setup
+
+When Paperclip runs in Docker, mount the CLI session homes into the Paperclip container and point the adapters at those mounted homes.
+
+Use the example override file:
+
+```sh
+docker compose \
+  -f docker/docker-compose.quickstart.yml \
+  -f docker/docker-compose.subscription-auth.yml \
+  up
+```
+
+The override mounts the host homes read-only by default:
+
+```yaml
+services:
+  paperclip:
+    environment:
+      CODEX_HOME: /host-cli-auth/codex
+      CLAUDE_CONFIG_DIR: /host-cli-auth/claude
+    volumes:
+      - ${CODEX_HOME:-${HOME}/.codex}:/host-cli-auth/codex:ro
+      - ${CLAUDE_CONFIG_DIR:-${HOME}/.claude}:/host-cli-auth/claude:ro
+```
+
+Read-only is the safest first posture because the container can use the session but cannot mutate the host's canonical CLI auth state.
+
+If the vendor CLI requires refreshing tokens and fails because the mounted home is read-only, prefer a dedicated Paperclip auth-home copy rather than mounting the operator's canonical CLI home read-write:
+
+```sh
+install -d -m 700 "$HOME/.paperclip-cli-auth/codex" "$HOME/.paperclip-cli-auth/claude"
+cp -a "$HOME/.codex/." "$HOME/.paperclip-cli-auth/codex/"
+cp -a "$HOME/.claude/." "$HOME/.paperclip-cli-auth/claude/"
+```
+
+Then start Docker with:
+
+```sh
+CODEX_HOME="$HOME/.paperclip-cli-auth/codex" \
+CLAUDE_CONFIG_DIR="$HOME/.paperclip-cli-auth/claude" \
+docker compose \
+  -f docker/docker-compose.quickstart.yml \
+  -f docker/docker-compose.subscription-auth.yml \
+  up
+```
+
+If you intentionally allow writes, update the override locally from `:ro` to `:rw`. Do not make this change casually: a compromised or buggy container process could then mutate or exfiltrate refreshable auth state.
+
+## Agent configuration
+
+### Codex
+
+Do not set `OPENAI_API_KEY`. Let Codex CLI read `CODEX_HOME/auth.json`.
+
+```json
+{
+  "adapterType": "codex_local",
+  "adapterConfig": {
+    "command": "codex",
+    "model": "gpt-5.5",
+    "timeoutSec": 360,
+    "graceSec": 15,
+    "env": {
+      "OPENAI_API_KEY": ""
+    }
+  }
+}
+```
+
+Paperclip's `codex_local` adapter creates managed per-agent Codex homes and symlinks `auth.json` from the configured shared `CODEX_HOME` when no API key is configured. That avoids stale copies of refreshable session auth.
+
+### Claude Code
+
+Do not set `ANTHROPIC_API_KEY`. Let Claude Code read `CLAUDE_CONFIG_DIR` / `~/.claude`.
+
+```json
+{
+  "adapterType": "claude_local",
+  "adapterConfig": {
+    "command": "claude",
+    "model": "claude-sonnet-4-6",
+    "timeoutSec": 360,
+    "graceSec": 20,
+    "env": {
+      "ANTHROPIC_API_KEY": ""
+    }
+  }
+}
+```
+
+## Verification checklist
+
+1. Confirm the container can see the mounted homes without printing secrets:
+
+   ```sh
+   docker compose exec paperclip sh -lc '
+     test -s "$CODEX_HOME/auth.json" && echo "Codex auth visible"
+     test -s "$CLAUDE_CONFIG_DIR/.credentials.json" && echo "Claude credentials visible"
+   '
+   ```
+
+2. Use Paperclip's **Test Environment** action for the agent.
+3. Dispatch a tiny synthetic task before assigning real work.
+4. Confirm no provider API-key secret records were created for the subscription-auth agent.
+
+## Security notes
+
+- Subscription CLI auth gives Paperclip processes access to the same account/session as the local operator.
+- Read-only mounts reduce mutation risk but do not prevent session use.
+- Avoid logging file contents or environment dumps.
+- Prefer dedicated copied auth homes if Paperclip needs writable refresh state.
+- For shared or production deployments, use provider API keys or a proper secret backend with revocation and audit controls.

--- a/server/src/__tests__/claude-local-adapter-environment.test.ts
+++ b/server/src/__tests__/claude-local-adapter-environment.test.ts
@@ -233,39 +233,6 @@ describe("claude_local environment diagnostics", () => {
     expect(codes).not.toContain("claude_anthropic_api_key_overrides_subscription");
   });
 
-  it("reports subscription mode possible when CLAUDE_CONFIG_DIR points at a synthetic OAuth home and no API key is set", async () => {
-    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-claude-subscription-auth-"));
-    const claudeConfigDir = path.join(root, "claude-home");
-    const cwd = path.join(root, "workspace");
-
-    try {
-      await fs.mkdir(claudeConfigDir, { recursive: true });
-      await fs.writeFile(path.join(claudeConfigDir, ".credentials.json"), JSON.stringify({ token: "fake-token" }), "utf8");
-      delete process.env.ANTHROPIC_API_KEY;
-      delete process.env.CLAUDE_CODE_USE_BEDROCK;
-      delete process.env.ANTHROPIC_BEDROCK_BASE_URL;
-
-      const result = await testEnvironment({
-        companyId: "company-1",
-        adapterType: "claude_local",
-        config: {
-          command: process.execPath,
-          cwd,
-          env: {
-            CLAUDE_CONFIG_DIR: claudeConfigDir,
-            ANTHROPIC_API_KEY: "",
-          },
-        },
-      });
-
-      expect(result.checks.some((check) => check.code === "claude_subscription_mode_possible")).toBe(true);
-      expect(result.checks.some((check) => check.code === "claude_anthropic_api_key_overrides_subscription")).toBe(false);
-      expect(result.checks.some((check) => check.level === "error")).toBe(false);
-    } finally {
-      await fs.rm(root, { recursive: true, force: true });
-    }
-  });
-
   it("creates a missing working directory when cwd is absolute", async () => {
     const cwd = path.join(
       os.tmpdir(),

--- a/server/src/__tests__/claude-local-adapter-environment.test.ts
+++ b/server/src/__tests__/claude-local-adapter-environment.test.ts
@@ -233,6 +233,39 @@ describe("claude_local environment diagnostics", () => {
     expect(codes).not.toContain("claude_anthropic_api_key_overrides_subscription");
   });
 
+  it("reports subscription mode possible when CLAUDE_CONFIG_DIR points at a synthetic OAuth home and no API key is set", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-claude-subscription-auth-"));
+    const claudeConfigDir = path.join(root, "claude-home");
+    const cwd = path.join(root, "workspace");
+
+    try {
+      await fs.mkdir(claudeConfigDir, { recursive: true });
+      await fs.writeFile(path.join(claudeConfigDir, ".credentials.json"), JSON.stringify({ token: "fake-token" }), "utf8");
+      delete process.env.ANTHROPIC_API_KEY;
+      delete process.env.CLAUDE_CODE_USE_BEDROCK;
+      delete process.env.ANTHROPIC_BEDROCK_BASE_URL;
+
+      const result = await testEnvironment({
+        companyId: "company-1",
+        adapterType: "claude_local",
+        config: {
+          command: process.execPath,
+          cwd,
+          env: {
+            CLAUDE_CONFIG_DIR: claudeConfigDir,
+            ANTHROPIC_API_KEY: "",
+          },
+        },
+      });
+
+      expect(result.checks.some((check) => check.code === "claude_subscription_mode_possible")).toBe(true);
+      expect(result.checks.some((check) => check.code === "claude_anthropic_api_key_overrides_subscription")).toBe(false);
+      expect(result.checks.some((check) => check.level === "error")).toBe(false);
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
   it("creates a missing working directory when cwd is absolute", async () => {
     const cwd = path.join(
       os.tmpdir(),

--- a/server/src/__tests__/codex-local-adapter-environment.test.ts
+++ b/server/src/__tests__/codex-local-adapter-environment.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { testEnvironment } from "@paperclipai/adapter-codex-local/server";
+import { evaluateCodexCredentialReadiness, testEnvironment } from "@paperclipai/adapter-codex-local/server";
 
 const itWindows = process.platform === "win32" ? it : it.skip;
 
@@ -67,6 +67,40 @@ describe("codex_local environment diagnostics", () => {
 
       expect(result.checks.some((check) => check.code === "codex_native_auth_present")).toBe(true);
       expect(result.checks.some((check) => check.code === "codex_openai_api_key_missing")).toBe(false);
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("treats a shared Codex home with auth.json as subscription-auth ready without OPENAI_API_KEY", async () => {
+    const root = path.join(
+      os.tmpdir(),
+      `paperclip-codex-shared-auth-${Date.now()}-${Math.random().toString(16).slice(2)}`,
+    );
+    const codexHome = path.join(root, "codex-home");
+
+    try {
+      await fs.mkdir(codexHome, { recursive: true });
+      await fs.writeFile(
+        path.join(codexHome, "auth.json"),
+        JSON.stringify({ accessToken: "fake-token", refreshToken: "fake-refresh" }),
+      );
+
+      const readiness = await evaluateCodexCredentialReadiness({
+        companyId: "company-1",
+        configuredCodexHome: null,
+        configuredApiKey: null,
+        env: {
+          CODEX_HOME: codexHome,
+          PAPERCLIP_HOME: path.join(root, "paperclip-home"),
+          PAPERCLIP_INSTANCE_ID: "test-instance",
+        },
+      });
+
+      expect(readiness.managed).toBe(true);
+      expect(readiness.authMode).toBe("subscription");
+      expect(readiness.ready).toBe(true);
+      expect(readiness.sharedSourceHome).toBe(codexHome);
     } finally {
       await fs.rm(root, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Local CLI adapters such as `codex_local` and `claude_local` bridge Paperclip's orchestration layer to vendor CLIs running on the operator's machine or private server.
> - Some operators use Codex and Claude Code through subscription/OAuth CLI sessions rather than provider API keys.
> - The adapters already have partial support for this mode, but the public setup path was not obvious from the docs or Docker examples.
> - This pull request documents the API-key-free subscription CLI auth path, adds a Docker Compose override for mounting CLI auth homes, and adds synthetic regression coverage for subscription-home detection.
> - The benefit is that self-hosted/local Paperclip users can start with their existing CLI subscriptions while still keeping provider API-key records out of Paperclip.

## Linked Issues or Issue Description

Refs #3753

Operators may have valid local Claude Code / Codex CLI subscription sessions but no `ANTHROPIC_API_KEY` or `OPENAI_API_KEY`. The adapter docs currently imply API keys are required, and the quickstart Docker config has no documented override for mounting vendor CLI session homes.

## What Changed

- Added `docs/adapters/subscription-cli-auth.md` covering API-key-free Codex and Claude Code subscription/OAuth setup.
- Added `docker/docker-compose.subscription-auth.yml`, an optional read-only CLI auth-home mount override for Docker users.
- Updated `codex_local`, `claude_local`, and adapter overview docs to point at the subscription-auth guide.
- Added a synthetic Codex readiness regression test for shared `CODEX_HOME/auth.json` subscription auth without `OPENAI_API_KEY`.

## Verification

- `../node_modules/.bin/vitest run --config vitest.config.ts src/__tests__/codex-local-adapter-environment.test.ts src/__tests__/claude-local-adapter-environment.test.ts` from `server/`
  - Result: 2 files passed; 14 tests passed; 1 Windows-only test skipped.
- `git diff --cached --check`
  - Result: passed before commit.
- `docker compose -f docker/docker-compose.quickstart.yml -f docker/docker-compose.subscription-auth.yml config`
  - Result: override renders with `CODEX_HOME=/host-cli-auth/codex`, `CLAUDE_CONFIG_DIR=/host-cli-auth/claude`, and read-only auth-home mounts.

## Risks

- Low code risk: this is mostly documentation and examples; tests are synthetic and do not call real provider services.
- Operational risk: subscription CLI auth gives Paperclip processes access to the same vendor session as the local operator. The docs call this out and recommend read-only mounts by default.
- Read-only mounts may fail if a vendor CLI requires token refresh writes. The docs recommend using a dedicated Paperclip auth-home copy rather than making the operator's canonical CLI home writable inside the container.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex / GPT-5.5 via Hermes Agent, with terminal, file, git, and test execution tools.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge
