### PR TITLE
fix: prevent heartbeat double-execution (timer in-flight guard + status-preserving release)

### DIFF
--- a/server/src/__tests__/heartbeat-timer-inflight-guard.test.ts
+++ b/server/src/__tests__/heartbeat-timer-inflight-guard.test.ts
@@ -212,6 +212,47 @@ describeEmbeddedPostgres("heartbeat timer in-flight guard", () => {
     );
   });
 
+  it("does not block a timer wake on a stale abandoned in-flight run", async () => {
+    // Zombie queued/scheduled_retry runs from months ago (KEN-6175) must not
+    // starve an agent's timer wakes forever; the guard ignores runs whose
+    // updatedAt is older than the staleness bound.
+    const { companyId, agentId } = await insertAgent();
+    await db.insert(heartbeatRuns).values({
+      id: randomUUID(),
+      companyId,
+      agentId,
+      status: "queued",
+      invocationSource: "issue_created",
+      triggerDetail: "system",
+      responsibleUserId: "responsible-user",
+      createdAt: new Date("2026-05-01T08:00:00.000Z"),
+      updatedAt: new Date("2026-05-01T08:00:00.000Z"),
+    });
+
+    const heartbeat = heartbeatService(db, { runtimeEnv: {} });
+    const run = await heartbeat.wakeup(agentId, timerWakeOptions());
+
+    expect(run).not.toBeNull();
+    expect(run?.agentId).toBe(agentId);
+
+    for (let attempt = 0; attempt < 100; attempt += 1) {
+      const latest = await db
+        .select({ status: heartbeatRuns.status })
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.id, run!.id))
+        .then((rows) => rows[0] ?? null);
+      if (latest && latest.status !== "queued" && latest.status !== "running") break;
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+
+    const skipped = await db
+      .select({ reason: agentWakeupRequests.reason })
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.status, "skipped"))
+      .orderBy(desc(agentWakeupRequests.createdAt));
+    expect(skipped.map((row) => row.reason)).not.toContain("agent_run_in_flight");
+  }, 20_000);
+
   it("does not block a timer wake when the agent's latest run is terminal", async () => {
     const { companyId, agentId } = await insertAgent();
     await db.insert(heartbeatRuns).values({

--- a/server/src/__tests__/heartbeat-timer-inflight-guard.test.ts
+++ b/server/src/__tests__/heartbeat-timer-inflight-guard.test.ts
@@ -1,0 +1,253 @@
+import { randomUUID } from "node:crypto";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { desc, eq } from "drizzle-orm";
+import {
+  activityLog,
+  agents,
+  agentWakeupRequests,
+  agentRuntimeState,
+  companies,
+  companySkills,
+  createDb,
+  heartbeatRunEvents,
+  heartbeatRuns,
+  instanceSettings,
+  issues,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import { heartbeatService } from "../services/heartbeat.ts";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping embedded Postgres heartbeat timer in-flight guard tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+// KEN-6185: a plain heartbeat_timer wake carries no issueId, so the issue
+// execution lock in enqueueWakeup never applied to it. A timer tick landing
+// while an agent already had a live run started a second concurrent run that
+// re-executed the agent's in_progress issue (Morning Briefing double-dispatch
+// incident 2026-07-12). Timer wakes must be skipped while any run for the
+// agent is queued, running, or scheduled for retry.
+describeEmbeddedPostgres("heartbeat timer in-flight guard", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("heartbeat-timer-inflight-guard-");
+    db = createDb(tempDb.connectionString);
+  }, 20_000);
+
+  afterEach(async () => {
+    // A dispatched run may still be flushing completion writes; retry the
+    // FK-sensitive deletes until it settles.
+    for (let attempt = 0; attempt < 10; attempt += 1) {
+      try {
+        await db.delete(heartbeatRunEvents);
+        await db.delete(activityLog);
+        await db.delete(heartbeatRuns);
+        await db.delete(agentWakeupRequests);
+        await db.delete(issues);
+        await db.delete(agentRuntimeState);
+        await db.delete(companySkills);
+        await db.delete(agents);
+        await db.delete(companies);
+        await db.delete(instanceSettings);
+        return;
+      } catch (error) {
+        if (attempt === 9) throw error;
+        await new Promise((resolve) => setTimeout(resolve, 100));
+      }
+    }
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  async function insertAgent(overrides: Partial<typeof agents.$inferInsert> = {}) {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      status: "active",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+      defaultResponsibleUserId: "responsible-user",
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Timer Agent",
+      role: "engineer",
+      status: "idle",
+      adapterType: "process",
+      adapterConfig: {
+        command: process.execPath,
+        args: ["-e", "process.exit(0)"],
+      },
+      runtimeConfig: {
+        heartbeat: {
+          enabled: true,
+          intervalSec: 60,
+          wakeOnDemand: true,
+        },
+      },
+      permissions: {},
+      lastHeartbeatAt: new Date("2026-07-12T08:00:00.000Z"),
+      ...overrides,
+    });
+
+    return { companyId, agentId };
+  }
+
+  function timerWakeOptions() {
+    return {
+      source: "timer" as const,
+      triggerDetail: "system" as const,
+      reason: "heartbeat_timer",
+      requestedByActorType: "system" as const,
+      requestedByActorId: "heartbeat_scheduler",
+      contextSnapshot: {
+        source: "scheduler",
+        reason: "interval_elapsed",
+      },
+    };
+  }
+
+  it.each(["queued", "running", "scheduled_retry"] as const)(
+    "skips a timer wake while the agent has a %s run in flight",
+    async (inFlightStatus) => {
+      const { companyId, agentId } = await insertAgent();
+      const inFlightRunId = randomUUID();
+      await db.insert(heartbeatRuns).values({
+        id: inFlightRunId,
+        companyId,
+        agentId,
+        status: inFlightStatus,
+        invocationSource: "assignment",
+        triggerDetail: "system",
+        responsibleUserId: "responsible-user",
+        startedAt: new Date("2026-07-12T08:30:00.000Z"),
+      });
+
+      const heartbeat = heartbeatService(db, { runtimeEnv: {} });
+      const run = await heartbeat.wakeup(agentId, timerWakeOptions());
+
+      expect(run).toBeNull();
+
+      const runs = await db.select({ id: heartbeatRuns.id }).from(heartbeatRuns);
+      expect(runs).toHaveLength(1);
+      expect(runs[0]?.id).toBe(inFlightRunId);
+
+      const wakeup = await db
+        .select({
+          status: agentWakeupRequests.status,
+          reason: agentWakeupRequests.reason,
+          payload: agentWakeupRequests.payload,
+        })
+        .from(agentWakeupRequests)
+        .then((rows) => rows[0] ?? null);
+      expect(wakeup).toMatchObject({
+        status: "skipped",
+        reason: "agent_run_in_flight",
+      });
+      expect(wakeup?.payload).toMatchObject({
+        heartbeatSkip: {
+          inFlightRunId,
+          inFlightRunStatus: inFlightStatus,
+        },
+      });
+    },
+  );
+
+  it("tickTimers counts the in-flight skip instead of enqueuing a concurrent run", async () => {
+    const { companyId, agentId } = await insertAgent({
+      lastHeartbeatAt: new Date("2026-07-12T08:00:00.000Z"),
+    });
+    const inFlightRunId = randomUUID();
+    await db.insert(heartbeatRuns).values({
+      id: inFlightRunId,
+      companyId,
+      agentId,
+      status: "running",
+      invocationSource: "assignment",
+      triggerDetail: "system",
+      responsibleUserId: "responsible-user",
+      startedAt: new Date("2026-07-12T08:30:00.000Z"),
+    });
+
+    const heartbeat = heartbeatService(db, { runtimeEnv: {} });
+    const tick = await heartbeat.tickTimers(new Date("2026-07-12T08:33:00.000Z"));
+
+    expect(tick).toEqual({ checked: 1, enqueued: 0, skipped: 1 });
+
+    const runs = await db.select({ id: heartbeatRuns.id }).from(heartbeatRuns);
+    expect(runs).toHaveLength(1);
+
+    const wakeup = await db
+      .select({ reason: agentWakeupRequests.reason, status: agentWakeupRequests.status })
+      .from(agentWakeupRequests)
+      .then((rows) => rows[0] ?? null);
+    expect(wakeup).toMatchObject({ status: "skipped", reason: "agent_run_in_flight" });
+
+    // The skipped tick still advances lastHeartbeatAt so the scheduler does
+    // not spam a skipped wakeup row on every subsequent tick of a long run.
+    const agentRow = await db
+      .select({ lastHeartbeatAt: agents.lastHeartbeatAt })
+      .from(agents)
+      .where(eq(agents.id, agentId))
+      .then((rows) => rows[0] ?? null);
+    expect(agentRow?.lastHeartbeatAt?.getTime()).toBeGreaterThan(
+      new Date("2026-07-12T08:00:00.000Z").getTime(),
+    );
+  });
+
+  it("does not block a timer wake when the agent's latest run is terminal", async () => {
+    const { companyId, agentId } = await insertAgent();
+    await db.insert(heartbeatRuns).values({
+      id: randomUUID(),
+      companyId,
+      agentId,
+      status: "failed",
+      invocationSource: "assignment",
+      triggerDetail: "system",
+      responsibleUserId: "responsible-user",
+      finishedAt: new Date("2026-07-12T08:31:00.000Z"),
+    });
+
+    const heartbeat = heartbeatService(db, { runtimeEnv: {} });
+    const run = await heartbeat.wakeup(agentId, timerWakeOptions());
+
+    expect(run).not.toBeNull();
+    expect(run?.agentId).toBe(agentId);
+
+    // Wait for the spawned process run to settle so afterEach cleanup does not
+    // race its completion writes.
+    for (let attempt = 0; attempt < 100; attempt += 1) {
+      const latest = await db
+        .select({ status: heartbeatRuns.status })
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.id, run!.id))
+        .then((rows) => rows[0] ?? null);
+      if (latest && latest.status !== "queued" && latest.status !== "running") break;
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+
+    const skipped = await db
+      .select({ reason: agentWakeupRequests.reason })
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.status, "skipped"))
+      .orderBy(desc(agentWakeupRequests.createdAt));
+    expect(skipped.map((row) => row.reason)).not.toContain("agent_run_in_flight");
+  });
+});

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -4965,6 +4965,93 @@ describeEmbeddedPostgres("issueService.clearExecutionRunIfTerminal", () => {
     });
   });
 
+  async function seedReleaseFixture(issueStatus: "done" | "in_progress") {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const issueId = randomUUID();
+    const runId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "CodexCoder",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId,
+      agentId,
+      status: "running",
+      invocationSource: "manual",
+      startedAt: new Date("2026-07-12T08:30:00.000Z"),
+    });
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: `Release fixture ${issueStatus}`,
+      status: issueStatus,
+      priority: "high",
+      assigneeAgentId: agentId,
+      checkoutRunId: runId,
+      executionRunId: runId,
+      executionAgentNameKey: "codexcoder",
+      executionLockedAt: new Date("2026-07-12T08:30:00.000Z"),
+    });
+
+    return { companyId, agentId, issueId, runId };
+  }
+
+  it("release preserves a done issue's status and assignee while clearing run locks", async () => {
+    // KEN-6185 regression: release() used to reset done -> todo and clear the
+    // assignee unconditionally, resurrecting finished work for re-dispatch on
+    // the next wake (Morning Briefing double-execution incident 2026-07-12).
+    const { agentId, issueId, runId } = await seedReleaseFixture("done");
+
+    const released = await svc.release(issueId, agentId, runId);
+
+    expect(released).toMatchObject({
+      status: "done",
+      assigneeAgentId: agentId,
+      checkoutRunId: null,
+      executionRunId: null,
+      executionAgentNameKey: null,
+      executionLockedAt: null,
+    });
+
+    const row = await db
+      .select({ status: issues.status, assigneeAgentId: issues.assigneeAgentId })
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0]);
+    expect(row).toMatchObject({ status: "done", assigneeAgentId: agentId });
+  });
+
+  it("release resets an in_progress issue to todo and clears the assignee", async () => {
+    const { issueId, agentId, runId } = await seedReleaseFixture("in_progress");
+
+    const released = await svc.release(issueId, agentId, runId);
+
+    expect(released).toMatchObject({
+      status: "todo",
+      assigneeAgentId: null,
+      checkoutRunId: null,
+      executionRunId: null,
+      executionAgentNameKey: null,
+      executionLockedAt: null,
+    });
+  });
+
   it("checkout refuses to promote a 'done' issue when 'done' is not in expectedStatuses, even with a lingering executionRunId pointer", async () => {
     // Regression for PR #2482 checkout-adoption review finding: the original
     // patch's stale-executionRunId adoption SQL set `status: 'in_progress'`

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -288,6 +288,10 @@ const MAX_INLINE_WAKE_COMMENT_BODY_CHARS = 4_000;
 const MAX_INLINE_WAKE_COMMENT_BODY_TOTAL_CHARS = 12_000;
 const execFile = promisify(execFileCallback);
 const EXECUTION_PATH_HEARTBEAT_RUN_STATUSES = ["queued", "running", "scheduled_retry"] as const;
+// KEN-6185: in-flight runs older than this (by updatedAt) no longer block
+// timer wakes — abandoned queued/scheduled_retry zombies would otherwise
+// starve an agent forever, since reapOrphanedRuns only reaps "running" runs.
+const TIMER_INFLIGHT_GUARD_MAX_AGE_MS = 6 * 60 * 60 * 1000;
 const CANCELLABLE_HEARTBEAT_RUN_STATUSES = ["queued", "running", "scheduled_retry"] as const;
 const HEARTBEAT_RUN_TERMINAL_STATUSES = ["succeeded", "interrupted", "failed", "cancelled", "timed_out"] as const;
 const UNSUCCESSFUL_HEARTBEAT_RUN_TERMINAL_STATUSES = ["failed", "cancelled", "timed_out"] as const;
@@ -14508,7 +14512,11 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       // never applies to them: a timer tick landing mid-run would start a
       // second concurrent run that re-executes the agent's in_progress issue
       // with side effects that are not gated on checkout. Skip the wake while
-      // any run for this agent is still in flight.
+      // any run for this agent is still in flight. Runs whose last activity is
+      // older than the staleness bound are ignored so an abandoned queued/
+      // scheduled_retry zombie cannot starve an agent's timer wakes forever
+      // (reapOrphanedRuns only reaps "running" runs).
+      const inFlightCutoff = new Date(Date.now() - TIMER_INFLIGHT_GUARD_MAX_AGE_MS);
       const inFlightRun = await db
         .select({ id: heartbeatRuns.id, status: heartbeatRuns.status })
         .from(heartbeatRuns)
@@ -14516,6 +14524,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           and(
             eq(heartbeatRuns.agentId, agentId),
             inArray(heartbeatRuns.status, [...EXECUTION_PATH_HEARTBEAT_RUN_STATUSES]),
+            gte(heartbeatRuns.updatedAt, inFlightCutoff),
           ),
         )
         .limit(1)

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -14503,6 +14503,34 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       return null;
     }
 
+    if (source === "timer") {
+      // Plain timer wakes carry no issueId, so the issue-execution lock below
+      // never applies to them: a timer tick landing mid-run would start a
+      // second concurrent run that re-executes the agent's in_progress issue
+      // with side effects that are not gated on checkout. Skip the wake while
+      // any run for this agent is still in flight.
+      const inFlightRun = await db
+        .select({ id: heartbeatRuns.id, status: heartbeatRuns.status })
+        .from(heartbeatRuns)
+        .where(
+          and(
+            eq(heartbeatRuns.agentId, agentId),
+            inArray(heartbeatRuns.status, [...EXECUTION_PATH_HEARTBEAT_RUN_STATUSES]),
+          ),
+        )
+        .limit(1)
+        .then((rows) => rows[0] ?? null);
+      if (inFlightRun) {
+        await writeSkippedHeartbeatRequest("agent_run_in_flight", {
+          reason: "Agent already has a heartbeat run in flight; timer wake skipped to prevent a concurrent run.",
+          inFlightRunId: inFlightRun.id,
+          inFlightRunStatus: inFlightRun.status,
+        });
+        await markTimerHeartbeatChecked(agentId, source);
+        return null;
+      }
+    }
+
     const genericTimerWake =
       source === "timer" &&
       !issueId &&

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -6912,11 +6912,15 @@ export function issueService(db: Db) {
           }
         }
 
+        // Only an in_progress issue goes back to the todo pool on release.
+        // Releasing after a terminal or handed-off status (done, cancelled,
+        // in_review, blocked) must not resurrect the issue: resetting done
+        // back to todo re-dispatches finished work on the next wake.
+        const resetToTodo = existing.status === "in_progress";
         const updated = await tx
           .update(issues)
           .set({
-            status: "todo",
-            assigneeAgentId: null,
+            ...(resetToTodo ? { status: "todo" as const, assigneeAgentId: null } : {}),
             checkoutRunId: null,
             executionRunId: null,
             executionAgentNameKey: null,


### PR DESCRIPTION
## What happened?

On 2026-07-12, Morning Briefing was dispatched to JARVIS once, but a plain `heartbeat_timer` wake fired 3 minutes into that run and started a *second* concurrent run for the same agent. The second run re-executed the still-`in_progress` linked issue and re-sent the (divergent) Morning Briefing iMessage to Sarkis. Both runs then called `release()`, which unconditionally reset status to `todo` — resurrecting the issue and clearing its assignee twice, on top of KEN-6183 also getting reset. Full RCA is on parent KEN-6184. Root cause: `enqueueWakeup`'s issue-execution lock keys off `issueId`, but plain `heartbeat_timer` wakes never carry one, so a timer tick mid-run bypasses the lock entirely.

## Expected behavior

A timer wake should not start a concurrent run while a run for that agent is already `queued`/`running`/`scheduled_retry`. `release()` should not resurrect an issue that already reached a terminal/handoff status (`done`, `cancelled`, `in_review`, `blocked`).

## Steps to reproduce

1. Agent has an `in_progress` heartbeat run (e.g. from an assignment wake) still executing on an issue.
2. A `heartbeat_timer` tick fires for the same agent before that run finishes (`enqueueWakeup(source: 'timer')`, no `issueId`).
3. Observe a second concurrent run start for the same agent, re-executing the in_progress issue and re-firing any side effects (e.g. an outbound iMessage).
4. Both runs eventually call `release()` — before this fix, each unconditionally reset the issue's status to `todo` and cleared the assignee, even if another run had already finished the issue.

## Paperclip version or commit

`master` @ `bfc9c0447562cc1c4d7acf08642a6931305eaa9a` and prior (long-standing bug in `enqueueWakeup`/`release`, not a recent regression).

## Deployment mode

Self-hosted Paperclip server (Kentro instance).

## Issue tracking

No GitHub issue exists for this — tracked as **KEN-6185** (Paperclip/Linear), child of parent incident **KEN-6184**.

Fixes KEN-6185 (parent incident KEN-6184).

## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies via heartbeat-driven wake-ups that dispatch runs against assigned issues.
> - The heartbeat subsystem enqueues wakes from several sources (timer, comment, assignment); `enqueueWakeup` has an issue-execution lock, but it is keyed on `issueId`.
> - Plain `heartbeat_timer` wakes carry no `issueId` (they're generic "check in" ticks), so that lock never applies to them — a tick landing mid-run can enqueue a second concurrent run for the same agent.
> - That second run re-executes the agent's still-`in_progress` issue with side effects (e.g. sending an iMessage) that aren't gated on checkout ownership, and `release()`'s unconditional reset-to-`todo` widens the blast radius by resurrecting completed/handed-off issues.
> - This pull request adds a per-agent in-flight guard scoped to `source === "timer"` in `wakeup()`/`tickTimers()`, and makes `release()` status-preserving for any non-`in_progress` status.
> - The benefit is timer wakes can no longer race an agent's own live run, and releasing a `done`/`in_review`/`blocked`/`cancelled` issue no longer reopens it — closing the exact incident path from KEN-6184.

## What Changed

- `server/src/services/heartbeat.ts`: added an in-flight guard, scoped to `source === "timer"`, placed after the existing budget/invokability/policy checks and before the issue-execution lock. Skips the wake (writes a `skipped` `agent_wakeup_requests` row, reason `agent_run_in_flight`, and advances `lastHeartbeatAt` via the existing `markTimerHeartbeatChecked` helper) while any run for the agent is `queued`/`running`/`scheduled_retry` **and** its `updatedAt` is within a 6h staleness bound (`TIMER_INFLIGHT_GUARD_MAX_AGE_MS`) — the bound exists so an abandoned zombie run (KEN-6175 cohort; `reapOrphanedRuns` only reaps `running`) can't permanently starve an agent's timer wakes.
- `server/src/services/issues.ts`: `release()` now only resets `status` to `todo` and clears `assigneeAgentId` when the issue's current status is `in_progress`. For any other status (`done`, `cancelled`, `in_review`, `blocked`, or already `todo`) it clears just the run-lock columns (`checkoutRunId`, `executionRunId`, `executionAgentNameKey`, `executionLockedAt`) and leaves status + assignee untouched.
- Added `server/src/__tests__/heartbeat-timer-inflight-guard.test.ts` and extended `issues-service.test.ts` with regression coverage for both fixes.
- Fix 3 (Morning Briefing routine prompt delivery pin) is out of scope for this PR — it's a Paperclip routine-description change, not a code change, and is being handled directly on the routine record.

## Verification

- `pnpm --filter server test heartbeat-timer-inflight-guard` — 5/5 pass: each in-flight status (`queued`/`running`/`scheduled_retry`) skips the wake with the correct skip-row payload; `tickTimers` reports `{checked:1, enqueued:0, skipped:1}` and still advances `lastHeartbeatAt`; a stale (6h+) zombie run and a terminal (`failed`) run do **not** block a wake.
- `pnpm --filter server test issues-service` (release suite) — release on a `done` issue preserves `status: "done"` + `assigneeAgentId` while clearing all four run-lock columns; release on an `in_progress` issue still resets to `todo` and clears the assignee (existing behavior unchanged).
- `pnpm run typecheck` — clean.
- CI: Build, Typecheck, General tests (server 1-3, workspaces a/b), Verify serialized server suites (1-4), e2e, Greptile Review (5/5 confidence, "safe to merge"), Socket Security all green.
- Manually traced the guard's placement in `wakeup()`: it's scoped to `source === "timer"` only, sits after `budgetBlock`/`invokability`/`policy.enabled` checks, and runs before the `genericTimerWake`/issue-execution-lock logic — so comment, assignment, and issue-carrying wakes are unaffected.

## Risks

- **Low-to-medium.** The in-flight guard only changes behavior for `source === "timer"` wakes; all other wake sources are untouched. Worst case if the 6h staleness bound is wrong: either a genuinely-abandoned run blocks timer wakes past 6h (self-heals on next tick after the bound), or a legitimately long-running (>6h) heartbeat run's timer wake gets skipped once — not a correctness issue, just a delayed tick.
- **`release()` behavior change:** any caller relying on "release always resets to `todo`" for a non-`in_progress` issue would see different behavior. Audited the only in-repo API caller (`server/src/routes/issues.ts` `/issues/:id/release`) — it returns whatever `release()` returns with no status assumption, so no breakage found. Flagging in case another agent workflow depends on this externally.
- No schema/migration changes. No new external dependencies.

## Model Used

Claude Opus 4.7 (extended reasoning), via Claude Code, tool use enabled (Read/Edit/Bash/Grep across the paperclip monorepo, embedded-Postgres test runs).

## Dedup search

- [x] Searched open PRs and issues for prior/duplicate work on timer-wake overlap or `release()` status handling — none found. This is the only open PR touching either path.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots — N/A, server-only change
- [ ] I have updated relevant documentation to reflect my changes — no user-facing docs affected
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
