### PR TITLE
authenticated mode: tenant companies are created through onboarding, not fabricated

### DIFF
--- a/docs/deploy/deployment-modes.md
+++ b/docs/deploy/deployment-modes.md
@@ -59,6 +59,23 @@ pnpm paperclipai onboard
 # Choose "authenticated" -> "public"
 ```
 
+### Tenant company creation (trusted-header gateways)
+
+When a trusted gateway fronts the instance with `x-paperclip-cloud-*` headers,
+the stack's company is **not** pre-provisioned. The first stack **owner or
+admin** to sign in is taken through the standard onboarding wizard; the company
+they create is bound to a deterministic id derived from the stack id, so
+gateway slug→company routing needs no coordination. Stack **members** and
+**support** users see a "workspace is being set up" page until onboarding
+completes; their memberships are established automatically on their next
+request afterwards. A concurrent second create for the same stack fails with
+`409 Conflict` (first to complete wins).
+
+> Behavior change (2026-07): earlier builds auto-created a placeholder company
+> ("<Name>'s company") on the first authenticated request. Deployments relying
+> on that should complete onboarding once per stack instead; existing company
+> rows are unaffected.
+
 ## Board Claim Flow
 
 When migrating from `local_trusted` to `authenticated`, Paperclip emits a one-time claim URL at startup:

--- a/server/src/__tests__/auth-session-route.test.ts
+++ b/server/src/__tests__/auth-session-route.test.ts
@@ -1,7 +1,7 @@
 import express from "express";
 import request from "supertest";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { instanceUserRoles } from "@paperclipai/db";
+import { companies, instanceUserRoles } from "@paperclipai/db";
 import { actorMiddleware } from "../middleware/auth.js";
 
 function createSelectChain(rows: unknown[]) {
@@ -94,7 +94,13 @@ describe("actorMiddleware authenticated session profile", () => {
         return chain;
       }),
       delete: vi.fn(() => ({ where: () => Promise.resolve(undefined) })),
-      select: vi.fn(),
+      // The stack's company already exists (onboarding already ran), so the
+      // membership upsert and role-default grants below still fire.
+      select: vi.fn(() => ({
+        from: (table: unknown) => ({
+          where: () => Promise.resolve(table === companies ? [{ id: "stack-alpha-company" }] : []),
+        }),
+      })),
     } as any;
     const app = express();
     app.use(
@@ -128,9 +134,10 @@ describe("actorMiddleware authenticated session profile", () => {
       memberships: [expect.objectContaining({ membershipRole: "owner", status: "active" })],
     });
     expect(res.body.companyIds[0]).toMatch(/^[0-9a-f-]{36}$/);
-    // authUsers, companies, companyMemberships, and the role-default
+    // authUsers, companyMemberships, and the role-default
     // principalPermissionGrants seeded in place of instance-admin elevation.
-    expect(inserts).toHaveLength(4);
+    // The stack company itself is created lazily by onboarding, not here.
+    expect(inserts).toHaveLength(3);
     expect(inserts[0]?.values).toMatchObject({
       id: "global-user-1",
       email: "owner@example.com",

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -18,6 +18,7 @@ import type { BetterAuthSessionResult } from "../auth/better-auth.js";
 import { logger } from "./logger.js";
 import { boardAuthService } from "../services/board-auth.js";
 import { ensureHumanRoleDefaultGrants } from "../services/principal-access-compatibility.js";
+import { cloudTenantCompanyId } from "../services/cloud-tenant-company.js";
 import { forbidden, unprocessable } from "../errors.js";
 
 function hashToken(token: string) {
@@ -386,9 +387,7 @@ export async function resolveCloudTenantActor(db: Db, req: Request): Promise<Exp
   const stackId = requiredCloudHeader(req, "x-paperclip-cloud-stack-id");
   const stackRole = stackMembershipRole(req.header("x-paperclip-cloud-stack-role"));
   const userName = req.header("x-paperclip-cloud-user-name")?.trim() || userEmail;
-  const paperclipCompanyId = req.header("x-paperclip-cloud-paperclip-company-id")?.trim();
   const companyId = cloudTenantCompanyId(stackId);
-  const companyName = paperclipCompanyId || `${stackId} Paperclip`;
   const now = new Date();
 
   await db
@@ -421,73 +420,72 @@ export async function resolveCloudTenantActor(db: Db, req: Request): Promise<Exp
     .delete(instanceUserRoles)
     .where(and(eq(instanceUserRoles.userId, userId), eq(instanceUserRoles.role, "instance_admin")));
 
-  await db
-    .insert(companies)
-    .values({
-      id: companyId,
-      name: companyName,
-      description: `Provisioned by Paperclip Cloud for stack ${stackId}.`,
-      status: "active",
-      issuePrefix: issuePrefixForCloudStack(stackId),
-      updatedAt: now,
-    })
-    .onConflictDoNothing({
-      target: companies.id,
-    });
+  // The stack's company is created lazily through the standard onboarding
+  // wizard (POST /api/companies with the deterministic stack company id) —
+  // never fabricated here. Until it exists this actor simply has no
+  // membership in it; once it exists, this upsert keeps late-joining stack
+  // users (and role changes from the gateway) in sync on every request.
+  const stackCompanyExists = await db
+    .select({ id: companies.id })
+    .from(companies)
+    .where(eq(companies.id, companyId))
+    .then((rows) => rows.length > 0);
 
-  const membershipRole = stackRole === "owner" || stackRole === "admin" ? "owner" : stackRole;
-  const membership = await db
-    .insert(companyMemberships)
-    .values({
-      companyId,
-      principalType: "user",
-      principalId: userId,
-      status: "active",
-      membershipRole,
-      updatedAt: now,
-    })
-    .onConflictDoUpdate({
-      target: [
-        companyMemberships.companyId,
-        companyMemberships.principalType,
-        companyMemberships.principalId,
-      ],
-      set: {
+  const companyIds: string[] = [];
+  const memberships: Array<{ companyId: string; membershipRole?: string | null; status?: string }> = [];
+
+  if (stackCompanyExists) {
+    const membershipRole = stackRole === "owner" || stackRole === "admin" ? "owner" : stackRole;
+    const membership = await db
+      .insert(companyMemberships)
+      .values({
+        companyId,
+        principalType: "user",
+        principalId: userId,
         status: "active",
         membershipRole,
         updatedAt: now,
-      },
-    })
-    .returning()
-    .then((rows) => rows[0] ?? {
+      })
+      .onConflictDoUpdate({
+        target: [
+          companyMemberships.companyId,
+          companyMemberships.principalType,
+          companyMemberships.principalId,
+        ],
+        set: {
+          status: "active",
+          membershipRole,
+          updatedAt: now,
+        },
+      })
+      .returning()
+      .then((rows) => rows[0] ?? { companyId, membershipRole, status: "active" });
+
+    await ensureHumanRoleDefaultGrants(db, {
       companyId,
-      membershipRole,
-      status: "active",
+      principalId: userId,
+      membershipRole: membership.membershipRole,
+      grantedByUserId: userId,
     });
 
-  // Without instance-admin elevation, cloud tenant users are authorized purely
-  // through company-scoped permission grants — seed the same role defaults the
-  // regular membership flows create.
-  await ensureHumanRoleDefaultGrants(db, {
-    companyId,
-    principalId: userId,
-    membershipRole: membership.membershipRole,
-    grantedByUserId: null,
-  });
+    companyIds.push(companyId);
+    memberships.push({
+      companyId,
+      membershipRole: membership.membershipRole,
+      status: membership.status,
+    });
+  }
 
   return {
     type: "board",
     userId,
     userName,
     userEmail,
-    companyIds: [companyId],
-    memberships: [{
-      companyId,
-      membershipRole: membership.membershipRole,
-      status: membership.status,
-    }],
+    companyIds,
+    memberships,
     isInstanceAdmin: false,
     source: "cloud_tenant",
+    cloudStack: { stackId, stackRole },
   };
 }
 
@@ -510,19 +508,6 @@ function constantTimeStringEqual(left: string, right: string): boolean {
   const leftBuffer = Buffer.from(left);
   const rightBuffer = Buffer.from(right);
   return leftBuffer.length === rightBuffer.length && timingSafeEqual(leftBuffer, rightBuffer);
-}
-
-function cloudTenantCompanyId(stackId: string): string {
-  const bytes = createHash("sha256").update(`paperclip-cloud-tenant-company:${stackId}`).digest();
-  bytes[6] = (bytes[6] & 0x0f) | 0x50;
-  bytes[8] = (bytes[8] & 0x3f) | 0x80;
-  const hex = bytes.subarray(0, 16).toString("hex");
-  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20, 32)}`;
-}
-
-function issuePrefixForCloudStack(stackId: string): string {
-  const hash = createHash("sha256").update(stackId).digest("hex").slice(0, 4).toUpperCase();
-  return `PC${hash}`;
 }
 
 export function requireBoard(req: Express.Request) {

--- a/server/src/middleware/cloud-tenant-actor.test.ts
+++ b/server/src/middleware/cloud-tenant-actor.test.ts
@@ -4,31 +4,54 @@ import type { Db } from "@paperclipai/db";
 import { authUsers, companies, companyMemberships, instanceUserRoles } from "@paperclipai/db";
 import { resolveCloudTenantActor } from "./auth.js";
 
+type SeededMembership = { companyId: string; membershipRole: string; status: string };
+
 // Minimal fake Drizzle Db: records every table passed to .insert() / .delete() and
 // supports the chained call shapes used by resolveCloudTenantActor (values /
 // onConflictDo* / returning().then() / delete().where()). The chain is awaitable so
 // directly-awaited statements resolve.
-function createFakeDb(membershipRow = { companyId: "company-x", membershipRole: "owner", status: "active" }) {
+function createFakeDb(options?: {
+  membershipRow?: SeededMembership;
+  seededMemberships?: SeededMembership[];
+  /** Rows returned by the SELECT over `companies` — [] means the stack company does not exist yet. */
+  companyRows?: Array<{ id: string }>;
+}) {
+  const membershipRow: SeededMembership =
+    options?.membershipRow ?? { companyId: "company-x", membershipRole: "owner", status: "active" };
   const insertedTables: unknown[] = [];
   const deletedTables: unknown[] = [];
+  const selectedTables: unknown[] = [];
+  const insertedValues = new Map<unknown, Record<string, unknown>>();
+  let currentTable: unknown = null;
+  const memberships = options?.seededMemberships ?? [membershipRow];
+  const companyRows = options?.companyRows ?? [];
   const chain: Record<string, unknown> = {};
-  chain.values = () => chain;
+  chain.values = (values: Record<string, unknown>) => {
+    if (currentTable !== null) insertedValues.set(currentTable, values);
+    return chain;
+  };
   chain.onConflictDoUpdate = () => chain;
   chain.onConflictDoNothing = () => chain;
-  chain.where = () => chain;
   chain.returning = async () => [membershipRow];
   chain.then = (resolve: (v: unknown) => unknown) => Promise.resolve(undefined).then(resolve);
   const db = {
     insert: (table: unknown) => {
       insertedTables.push(table);
+      currentTable = table;
       return chain;
     },
+    select: () => ({
+      from: (table: unknown) => {
+        selectedTables.push(table);
+        return { where: async () => (table === companies ? companyRows : memberships) };
+      },
+    }),
     delete: (table: unknown) => {
       deletedTables.push(table);
-      return chain;
+      return { where: async () => undefined };
     },
   } as unknown as Db;
-  return { db, insertedTables, deletedTables };
+  return { db, insertedTables, deletedTables, selectedTables, insertedValues };
 }
 
 function fakeReq(headers: Record<string, string>): Request {
@@ -62,7 +85,7 @@ describe("resolveCloudTenantActor (shared-pool hardening)", () => {
   });
 
   it("is scoped to exactly the one company from its stack", async () => {
-    const { db } = createFakeDb();
+    const { db } = createFakeDb({ companyRows: [{ id: "company-x" }] });
     const actor = await resolveCloudTenantActor(db, fakeReq(VALID_HEADERS));
     expect(actor!.companyIds).toHaveLength(1);
     expect(actor!.memberships).toHaveLength(1);
@@ -78,14 +101,6 @@ describe("resolveCloudTenantActor (shared-pool hardening)", () => {
     expect(deletedTables).toContain(instanceUserRoles);
   });
 
-  it("still upserts the user, company, and membership", async () => {
-    const { db, insertedTables } = createFakeDb();
-    await resolveCloudTenantActor(db, fakeReq(VALID_HEADERS));
-    expect(insertedTables).toContain(authUsers);
-    expect(insertedTables).toContain(companies);
-    expect(insertedTables).toContain(companyMemberships);
-  });
-
   it("returns null when the server token is unset", async () => {
     delete process.env.PAPERCLIP_CLOUD_TENANT_SERVER_TOKEN;
     const { db } = createFakeDb();
@@ -94,12 +109,52 @@ describe("resolveCloudTenantActor (shared-pool hardening)", () => {
   });
 
   it("maps a non-owner stack role through to the membership without elevating", async () => {
-    const { db } = createFakeDb({ companyId: "company-y", membershipRole: "member", status: "active" });
+    const { db } = createFakeDb({
+      membershipRow: { companyId: "company-y", membershipRole: "member", status: "active" },
+      companyRows: [{ id: "company-y" }],
+    });
     const actor = await resolveCloudTenantActor(
       db,
       fakeReq({ ...VALID_HEADERS, "x-paperclip-cloud-stack-role": "member" }),
     );
     expect(actor!.isInstanceAdmin).toBe(false);
     expect(actor?.memberships?.[0]?.membershipRole).toBe("member");
+  });
+
+  it("never creates the company (lazy creation)", async () => {
+    const { db, insertedTables } = createFakeDb();
+    const actor = await resolveCloudTenantActor(db, fakeReq(VALID_HEADERS));
+    expect(actor).not.toBeNull();
+    expect(insertedTables).toContain(authUsers);
+    expect(insertedTables).not.toContain(companies);
+  });
+
+  it("skips the membership upsert while the stack company does not exist", async () => {
+    const { db, insertedTables } = createFakeDb({ companyRows: [], seededMemberships: [] });
+    const actor = await resolveCloudTenantActor(db, fakeReq(VALID_HEADERS));
+    expect(insertedTables).not.toContain(companyMemberships);
+    expect(actor!.companyIds).toEqual([]);
+    expect(actor!.memberships).toEqual([]);
+  });
+
+  it("upserts the membership once the stack company exists", async () => {
+    const { db, insertedTables } = createFakeDb({ companyRows: [{ id: "company-x" }] });
+    await resolveCloudTenantActor(db, fakeReq(VALID_HEADERS));
+    expect(insertedTables).toContain(companyMemberships);
+  });
+
+  it("exposes the stack context on the actor", async () => {
+    const { db } = createFakeDb();
+    const actor = await resolveCloudTenantActor(db, fakeReq(VALID_HEADERS));
+    expect(actor!.cloudStack).toEqual({ stackId: "stack-abc", stackRole: "owner" });
+  });
+
+  it("exposes a non-creator stack role verbatim", async () => {
+    const { db } = createFakeDb();
+    const actor = await resolveCloudTenantActor(
+      db,
+      fakeReq({ ...VALID_HEADERS, "x-paperclip-cloud-stack-role": "support" }),
+    );
+    expect(actor!.cloudStack).toEqual({ stackId: "stack-abc", stackRole: "support" });
   });
 });

--- a/server/src/routes/access.ts
+++ b/server/src/routes/access.ts
@@ -2816,6 +2816,7 @@ export function accessRoutes(
       memberships: accessSnapshot.memberships,
       source: req.actor.source ?? "none",
       keyId: req.actor.source === "board_key" ? req.actor.keyId ?? null : null,
+      cloudStack: req.actor.source === "cloud_tenant" ? req.actor.cloudStack ?? null : null,
     });
   });
 

--- a/server/src/routes/companies-cloud-create.test.ts
+++ b/server/src/routes/companies-cloud-create.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { canCreateStackCompany, cloudTenantCompanyId } from "../services/cloud-tenant-company.js";
+
+// The route body is exercised end-to-end in the live check (see the plan's
+// Task 7); here we lock the decision logic the route composes.
+describe("company create authorization for cloud tenants", () => {
+  it("owner/admin of a stack may create; the id is forced to the stack company id", () => {
+    const actor = {
+      source: "cloud_tenant" as const,
+      isInstanceAdmin: false,
+      cloudStack: { stackId: "stack-abc", stackRole: "owner" as const },
+    };
+    const cloudStack = actor.source === "cloud_tenant" ? actor.cloudStack : undefined;
+    expect(canCreateStackCompany(cloudStack)).toBe(true);
+    expect(cloudTenantCompanyId(cloudStack!.stackId)).toBe(cloudTenantCompanyId("stack-abc"));
+  });
+
+  it("member/support may not create", () => {
+    expect(canCreateStackCompany({ stackId: "s", stackRole: "member" })).toBe(false);
+    expect(canCreateStackCompany({ stackId: "s", stackRole: "support" })).toBe(false);
+  });
+
+  it("a non-cloud actor without instance admin may not create via the carve-out", () => {
+    const actor = { source: "session" as const, isInstanceAdmin: false, cloudStack: undefined };
+    const cloudStack = (actor.source as string) === "cloud_tenant" ? actor.cloudStack : undefined;
+    expect(canCreateStackCompany(cloudStack)).toBe(false);
+  });
+});

--- a/server/src/routes/companies-cloud-create.test.ts
+++ b/server/src/routes/companies-cloud-create.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi, beforeEach } from "vitest";
+import { describe, expect, it } from "vitest";
 import { canCreateStackCompany, cloudTenantCompanyId } from "../services/cloud-tenant-company.js";
 
 // The route body is exercised end-to-end in the live check (see the plan's
@@ -12,7 +12,7 @@ describe("company create authorization for cloud tenants", () => {
     };
     const cloudStack = actor.source === "cloud_tenant" ? actor.cloudStack : undefined;
     expect(canCreateStackCompany(cloudStack)).toBe(true);
-    expect(cloudTenantCompanyId(cloudStack!.stackId)).toBe(cloudTenantCompanyId("stack-abc"));
+    expect(cloudTenantCompanyId(cloudStack!.stackId)).toBe("77a7e424-8c06-51f6-9363-bb7e3491582b");
   });
 
   it("member/support may not create", () => {

--- a/server/src/routes/companies.ts
+++ b/server/src/routes/companies.ts
@@ -17,7 +17,7 @@ import {
   updateCompanyBrandingSchema,
   updateCompanySchema,
 } from "@paperclipai/shared";
-import { badRequest, forbidden } from "../errors.js";
+import { badRequest, conflict, forbidden } from "../errors.js";
 import { validate } from "../middleware/validate.js";
 import {
   accessService,
@@ -30,6 +30,11 @@ import {
   logActivity,
   workTimelineService,
 } from "../services/index.js";
+import {
+  canCreateStackCompany,
+  cloudTenantCompanyId,
+  isCompanyIdConflict,
+} from "../services/cloud-tenant-company.js";
 import type { StorageService } from "../storage/types.js";
 import { assertBoard, assertCompanyAccess, assertInstanceAdmin, getActorInfo } from "./authz.js";
 import { COMPANY_IMPORT_ROUTE_PATH } from "./company-import-paths.js";
@@ -372,14 +377,29 @@ export function companyRoutes(db: Db, storage?: StorageService) {
 
   router.post("/", validate(createCompanySchema), async (req, res) => {
     assertBoard(req);
-    if (!(req.actor.source === "local_implicit" || req.actor.isInstanceAdmin)) {
+    const cloudStack = req.actor.source === "cloud_tenant" ? req.actor.cloudStack : undefined;
+    const createsOwnStackCompany = canCreateStackCompany(cloudStack);
+    if (!(req.actor.source === "local_implicit" || req.actor.isInstanceAdmin || createsOwnStackCompany)) {
       throw forbidden("Instance admin required");
     }
     const ownerPrincipalId = req.actor.userId ?? "local-board";
-    const company = await svc.create({
-      ...req.body,
-      defaultResponsibleUserId: req.body.defaultResponsibleUserId ?? ownerPrincipalId,
-    });
+    let company;
+    try {
+      company = await svc.create({
+        ...req.body,
+        // A cloud tenant only ever creates the one company its stack routes
+        // to: the id is server-derived from the stack, never client-supplied,
+        // so gateway slug->company routing keeps working and a tenant cannot
+        // create arbitrary companies.
+        ...(createsOwnStackCompany ? { id: cloudTenantCompanyId(cloudStack.stackId) } : {}),
+        defaultResponsibleUserId: req.body.defaultResponsibleUserId ?? ownerPrincipalId,
+      });
+    } catch (error) {
+      if (createsOwnStackCompany && isCompanyIdConflict(error)) {
+        throw conflict("This workspace's company has already been created");
+      }
+      throw error;
+    }
     await access.ensureMembership(company.id, "user", ownerPrincipalId, "owner", "active");
     await access.ensureRoleDefaultGrants(
       company.id,

--- a/server/src/services/cloud-tenant-company.test.ts
+++ b/server/src/services/cloud-tenant-company.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import {
+  canCreateStackCompany,
+  cloudTenantCompanyId,
+  isCompanyIdConflict,
+} from "./cloud-tenant-company.js";
+
+describe("cloudTenantCompanyId", () => {
+  it("is deterministic and UUID-shaped", () => {
+    const a = cloudTenantCompanyId("stack-abc");
+    const b = cloudTenantCompanyId("stack-abc");
+    expect(a).toBe(b);
+    expect(a).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-5[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
+  });
+
+  it("differs per stack", () => {
+    expect(cloudTenantCompanyId("stack-a")).not.toBe(cloudTenantCompanyId("stack-b"));
+  });
+});
+
+describe("canCreateStackCompany", () => {
+  it("allows owner and admin", () => {
+    expect(canCreateStackCompany({ stackId: "s", stackRole: "owner" })).toBe(true);
+    expect(canCreateStackCompany({ stackId: "s", stackRole: "admin" })).toBe(true);
+  });
+
+  it("denies member, support, and absent context", () => {
+    expect(canCreateStackCompany({ stackId: "s", stackRole: "member" })).toBe(false);
+    expect(canCreateStackCompany({ stackId: "s", stackRole: "support" })).toBe(false);
+    expect(canCreateStackCompany(undefined)).toBe(false);
+    expect(canCreateStackCompany(null)).toBe(false);
+  });
+});
+
+describe("isCompanyIdConflict", () => {
+  it("detects a companies_pkey unique violation, including nested causes", () => {
+    expect(isCompanyIdConflict({ code: "23505", constraint: "companies_pkey" })).toBe(true);
+    expect(
+      isCompanyIdConflict({ cause: { code: "23505", constraint_name: "companies_pkey" } }),
+    ).toBe(true);
+  });
+
+  it("ignores other errors", () => {
+    expect(isCompanyIdConflict({ code: "23505", constraint: "companies_issue_prefix_idx" })).toBe(false);
+    expect(isCompanyIdConflict(new Error("boom"))).toBe(false);
+    expect(isCompanyIdConflict(null)).toBe(false);
+  });
+});

--- a/server/src/services/cloud-tenant-company.ts
+++ b/server/src/services/cloud-tenant-company.ts
@@ -1,0 +1,52 @@
+import { createHash } from "node:crypto";
+
+export type CloudStackRole = "owner" | "admin" | "member" | "support";
+
+export interface CloudStackContext {
+  stackId: string;
+  stackRole: CloudStackRole;
+}
+
+/**
+ * Deterministic company id for a cloud tenant stack. The trusted gateway
+ * routes a stack's traffic to one company; deriving the id from the stack id
+ * keeps that mapping stable whether or not the company row exists yet, so the
+ * company can be created lazily (by onboarding) without any gateway change.
+ */
+export function cloudTenantCompanyId(stackId: string): string {
+  const bytes = createHash("sha256").update(`paperclip-cloud-tenant-company:${stackId}`).digest();
+  bytes[6] = (bytes[6] & 0x0f) | 0x50;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+  const hex = bytes.subarray(0, 16).toString("hex");
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20, 32)}`;
+}
+
+/** Only a stack owner or admin may create (i.e. onboard) the stack's company. */
+export function canCreateStackCompany(
+  cloudStack: CloudStackContext | undefined | null,
+): cloudStack is CloudStackContext {
+  return cloudStack?.stackRole === "owner" || cloudStack?.stackRole === "admin";
+}
+
+/**
+ * Postgres unique violation on the companies primary key — the forced stack
+ * company id already exists (another owner/admin completed onboarding first).
+ * Mirrors the cause-chain walk of isIssuePrefixConflict in companies.ts.
+ */
+export function isCompanyIdConflict(error: unknown): boolean {
+  const seen = new Set<unknown>();
+  let current = error;
+  while (typeof current === "object" && current !== null && !seen.has(current)) {
+    seen.add(current);
+    const maybe = current as {
+      code?: string;
+      constraint?: string;
+      constraint_name?: string;
+      cause?: unknown;
+    };
+    const constraint = maybe.constraint ?? maybe.constraint_name;
+    if (maybe.code === "23505" && constraint === "companies_pkey") return true;
+    current = maybe.cause;
+  }
+  return false;
+}

--- a/server/src/types/express.d.ts
+++ b/server/src/types/express.d.ts
@@ -24,6 +24,11 @@ declare global {
           status?: string;
         }>;
         isInstanceAdmin?: boolean;
+        /** Trusted-gateway stack context; set only when source === "cloud_tenant". */
+        cloudStack?: {
+          stackId: string;
+          stackRole: "owner" | "admin" | "member" | "support";
+        };
         keyId?: string;
         keyScope?: AgentApiKeyScope;
         runId?: string;

--- a/ui/src/api/access.ts
+++ b/ui/src/api/access.ts
@@ -245,6 +245,11 @@ export type CurrentBoardAccess = {
   }>;
   source: string;
   keyId: string | null;
+  /** Trusted-gateway stack context; null outside cloud-tenant requests. */
+  cloudStack?: {
+    stackId: string;
+    stackRole: "owner" | "admin" | "member" | "support";
+  } | null;
 };
 
 function buildInviteListQuery(options: {

--- a/ui/src/components/CloudAccessGate.tsx
+++ b/ui/src/components/CloudAccessGate.tsx
@@ -5,7 +5,9 @@ import { ApiError } from "@/api/client";
 import { authApi } from "@/api/auth";
 import { healthApi } from "@/api/health";
 import { queryKeys } from "@/lib/queryKeys";
+import { resolveCloudZeroCompanyState } from "@/lib/cloud-zero-company";
 import { BootstrapPendingPage } from "@/components/BootstrapPendingPage";
+import { WorkspaceSetupPendingPage } from "@/components/WorkspaceSetupPendingPage";
 import { Card } from "@/components/ui/card";
 
 function NoBoardAccessPage() {
@@ -57,6 +59,12 @@ export function CloudAccessGate() {
     queryFn: () => accessApi.getCurrentBoardAccess(),
     enabled: isAuthenticatedMode && !isBootstrapPending && !!sessionQuery.data,
     retry: false,
+    refetchInterval: (query) => {
+      const data = query.state.data as import("@/api/access").CurrentBoardAccess | undefined;
+      if (!data) return false;
+      return resolveCloudZeroCompanyState(data) === "waiting" ? 3000 : false;
+    },
+    refetchIntervalInBackground: true,
   });
   const claimMutation = useMutation({
     mutationFn: () => accessApi.claimBootstrapAdmin(),
@@ -116,13 +124,12 @@ export function CloudAccessGate() {
     return <Navigate to={`/auth?next=${next}`} replace />;
   }
 
-  if (
-    isAuthenticatedMode &&
-    sessionQuery.data &&
-    !boardAccessQuery.data?.isInstanceAdmin &&
-    (boardAccessQuery.data?.companyIds.length ?? 0) === 0
-  ) {
-    return <NoBoardAccessPage />;
+  if (isAuthenticatedMode && sessionQuery.data && boardAccessQuery.data) {
+    const zeroCompanyState = resolveCloudZeroCompanyState(boardAccessQuery.data);
+    if (zeroCompanyState === "waiting") return <WorkspaceSetupPendingPage />;
+    if (zeroCompanyState === "no_access") return <NoBoardAccessPage />;
+    // "onboard" and null fall through: Layout auto-opens the onboarding
+    // wizard whenever the companies list is empty.
   }
 
   return <Outlet />;

--- a/ui/src/components/Layout.tsx
+++ b/ui/src/components/Layout.tsx
@@ -175,12 +175,14 @@ export function Layout() {
 
   useEffect(() => {
     if (companiesLoading || onboardingTriggered.current) return;
-    if (health?.deploymentMode === "authenticated") return;
+    // In authenticated mode, CloudAccessGate has already routed users who
+    // cannot create a company (waiting page / no-access page), so anyone who
+    // reaches an empty companies list here is allowed to onboard.
     if (companies.length === 0) {
       onboardingTriggered.current = true;
       openOnboarding();
     }
-  }, [companies, companiesLoading, openOnboarding, health?.deploymentMode]);
+  }, [companies, companiesLoading, openOnboarding]);
 
   useEffect(() => {
     if (!companyPrefix || companiesLoading || companies.length === 0) return;

--- a/ui/src/components/OnboardingWizard.tsx
+++ b/ui/src/components/OnboardingWizard.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState, useMemo } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import type { AdapterEnvironmentTestResult } from "@paperclipai/shared";
 import { useLocation, useNavigate, useParams } from "@/lib/router";
+import { ApiError } from "@/api/client";
 import { useDialog } from "../context/DialogContext";
 import { useCompany } from "../context/CompanyContext";
 import { companiesApi } from "../api/companies";
@@ -567,7 +568,15 @@ export function OnboardingWizard() {
 
       setStep(3); // → Create your team lead
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to create company");
+      if (err instanceof ApiError && err.status === 409) {
+        // Another owner/admin finished setting this workspace up first.
+        queryClient.invalidateQueries({ queryKey: queryKeys.companies.all });
+        setError(
+          "This workspace was already set up by a teammate. Close this wizard to jump into the company.",
+        );
+      } else {
+        setError(err instanceof Error ? err.message : "Failed to create company");
+      }
     } finally {
       setLoading(false);
     }

--- a/ui/src/components/WorkspaceSetupPendingPage.tsx
+++ b/ui/src/components/WorkspaceSetupPendingPage.tsx
@@ -1,0 +1,18 @@
+import { Card } from "@/components/ui/card";
+
+export function WorkspaceSetupPendingPage() {
+  return (
+    <div className="mx-auto max-w-xl py-10">
+      <Card className="block p-6">
+        <h1 className="text-xl font-semibold">Your workspace is being set up</h1>
+        <p className="mt-2 text-sm text-muted-foreground">
+          An owner or admin of this workspace hasn&apos;t finished creating the company yet.
+        </p>
+        <p className="mt-2 text-sm text-muted-foreground">
+          This page refreshes automatically — you&apos;ll land in the workspace as soon as it&apos;s
+          ready.
+        </p>
+      </Card>
+    </div>
+  );
+}

--- a/ui/src/lib/cloud-zero-company.test.ts
+++ b/ui/src/lib/cloud-zero-company.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { resolveCloudZeroCompanyState } from "./cloud-zero-company";
+
+const base = { isInstanceAdmin: false, companyIds: [] as string[] };
+
+describe("resolveCloudZeroCompanyState", () => {
+  it("returns null (render app) when the user has companies or is instance admin", () => {
+    expect(resolveCloudZeroCompanyState({ ...base, companyIds: ["c1"] })).toBeNull();
+    expect(resolveCloudZeroCompanyState({ ...base, isInstanceAdmin: true })).toBeNull();
+  });
+
+  it("lets stack owners and admins through to onboard", () => {
+    expect(
+      resolveCloudZeroCompanyState({ ...base, cloudStack: { stackId: "s", stackRole: "owner" } }),
+    ).toBe("onboard");
+    expect(
+      resolveCloudZeroCompanyState({ ...base, cloudStack: { stackId: "s", stackRole: "admin" } }),
+    ).toBe("onboard");
+  });
+
+  it("parks members and support on the waiting page", () => {
+    expect(
+      resolveCloudZeroCompanyState({ ...base, cloudStack: { stackId: "s", stackRole: "member" } }),
+    ).toBe("waiting");
+    expect(
+      resolveCloudZeroCompanyState({ ...base, cloudStack: { stackId: "s", stackRole: "support" } }),
+    ).toBe("waiting");
+  });
+
+  it("falls back to no_access for non-stack users with no memberships", () => {
+    expect(resolveCloudZeroCompanyState(base)).toBe("no_access");
+    expect(resolveCloudZeroCompanyState({ ...base, cloudStack: null })).toBe("no_access");
+  });
+});

--- a/ui/src/lib/cloud-zero-company.ts
+++ b/ui/src/lib/cloud-zero-company.ts
@@ -1,0 +1,18 @@
+export type CloudZeroCompanyState = "onboard" | "waiting" | "no_access";
+
+/**
+ * Decide what an authenticated user with a resolved board-access snapshot
+ * should see. `null` = not a zero-company case; render the app (Layout
+ * auto-opens onboarding when the companies list is empty).
+ */
+export function resolveCloudZeroCompanyState(access: {
+  isInstanceAdmin: boolean;
+  companyIds: string[];
+  cloudStack?: { stackId: string; stackRole: "owner" | "admin" | "member" | "support" } | null;
+}): CloudZeroCompanyState | null {
+  if (access.isInstanceAdmin || access.companyIds.length > 0) return null;
+  const stackRole = access.cloudStack?.stackRole;
+  if (stackRole === "owner" || stackRole === "admin") return "onboard";
+  if (stackRole === "member" || stackRole === "support") return "waiting";
+  return "no_access";
+}


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - It ships multiple deployment modes; `authenticated` mode fronts a shared deployment with a trusted-header gateway (cloud-style hosting)
> - In that mode a tenant's first company is **fabricated by the auth middleware** on first request: a placeholder name ("<Name>'s company"), a stack-id description, and a hash-derived issue prefix — and the product's own onboarding wizard never runs (`Layout` suppresses it in authenticated mode)
> - Self-hosted users get the designed first-run experience; gateway-fronted users get placeholder data they can only rename after the fact — a parity gap between deployment modes with no technical justification
> - This pull request makes the tenant's first company go through the standard onboarding wizard: the middleware stops fabricating, and a stack owner/admin creates the company with a server-forced deterministic id
> - The benefit is one first-run experience across deployment modes, no placeholder company data, and gateway slug→company routing that still needs zero coordination

## Linked Issues or Issue Description

No existing public issue; the underlying problem is described inline below following the feature request template. Related but not duplicates: #2927 (browser-native first-admin bootstrap — single-tenant claim flow, different mode), #3601 (mobile onboarding permissions and signup handoff — onboarding UX, not company provisioning).

**Subsystem affected:** server auth middleware (`resolveCloudTenantActor`), companies API, onboarding UI in authenticated mode

**Problem or motivation:** In `authenticated` deployment mode, cloud-tenant (trusted-header) users get a company fabricated by the auth middleware on their first request, and the onboarding wizard never runs. The first thing a new tenant sees is placeholder data they didn't choose.

**Proposed solution:** Lazy company creation through the standard onboarding wizard: the middleware no longer inserts a company; a stack `owner`/`admin` creates *their stack's* company via `POST /api/companies` with a server-forced deterministic id (`cloudTenantCompanyId(stackId)`); members see a waiting page until the company exists.

**Alternatives considered:** (a) a `cloudTenantProvisioning: eager | lazy` compat flag defaulting to `lazy` — left out to avoid carrying both paths, happy to add it if maintainers prefer an escape hatch; (b) keeping fabrication and prompting a rename after first login — still skips the designed wizard and keeps the hash-derived issue prefix.

**Roadmap alignment:** Checked `ROADMAP.md` (2026-07-13); no overlap with planned core work — this is deployment-mode parity for an existing capability, not a new capability area.

## What Changed

- **Middleware (`resolveCloudTenantActor`)**: still upserts the auth user and purges stale instance-admin grants, but no longer inserts a company. The membership upsert runs only once the stack's company exists. The actor gains `cloudStack: { stackId, stackRole }`.
- **`POST /api/companies`**: a cloud-tenant actor with stack role `owner`/`admin` may create *their stack's* company. The server forces `id = cloudTenantCompanyId(stackId)` (deterministic, moved to `server/src/services/cloud-tenant-company.ts`), so gateway slug→company routing needs no coordination. A concurrent second create maps the `companies_pkey` violation to `409 Conflict` (first to complete wins).
- **`GET /cli-auth/me`**: exposes `cloudStack` (null outside cloud-tenant requests).
- **UI**: `CloudAccessGate` routes zero-company users by role — owner/admin fall through (the standard "zero companies → onboarding wizard" trigger now fires in authenticated mode too), member/support see a new "workspace is being set up" page that polls until the company exists, others keep the no-access page. The wizard handles the create race (409 → refetch + guidance).
- **Docs**: `docs/deploy/deployment-modes.md` gains a "Tenant company creation" subsection including the behavior-change note.

Self-healing design notes:

- The per-request membership upsert doubles as crash recovery: if a creator crashes between the insert and the route's membership grant, their next request grants owner membership.
- The waiting page's poll is also the admission mechanism — a member's own `/cli-auth/me` request passes through the middleware, which upserts their membership once the company exists. No push channel needed.
- The `PC<hash>` issue prefix is gone; the prefix derives from the chosen company name like local. Nothing external depended on the prefix (routing uses the deterministic company id).
- `x-paperclip-cloud-paperclip-company-id` is no longer read by the actor resolver; the tenant-import dedup path still consumes it intentionally.

## Verification

- Unit: deterministic-id/create-access/conflict helpers; middleware suite rewritten for lazy semantics (no company insert, conditional membership, `cloudStack` exposure); UI zero-company state helper.
- Full sweep: typecheck clean across the workspace; suite green except 3 pre-existing/environmental failures in files this branch doesn't touch.
- Live e2e against a fresh isolated authenticated-mode instance with simulated gateway headers:
  - before create: `GET /api/companies` → `[]`, owner `cli-auth/me.companyIds` → `[]`
  - owner `POST /api/companies` → **201**, id exactly `cloudTenantCompanyId("stack-e2e")` (verified against an independent recomputation), name-derived issue prefix
  - second owner POST → **409** `"This workspace's company has already been created"`
  - member `cli-auth/me` after creation → membership present; member POST → **403**
- Known follow-up: an HTTP-harness route test for the create carve-out (the decision logic is unit-tested; the route body was verified live).

## Risks

1. **Behavior change: trusted-header deployments no longer auto-create a placeholder company.** The first stack owner/admin completes onboarding instead; existing company rows are unaffected. If you'd prefer a compat escape hatch, I'm happy to add `cloudTenantProvisioning: eager | lazy` (default `lazy`) — I left it out to avoid carrying both paths.
2. **Behavior change: instance admins with zero companies in authenticated mode now get the onboarding wizard** (previously an empty dashboard): removing the `Layout` suppression applies to them as well. They pass the same route guard they always had (`isInstanceAdmin`), so this only surfaces existing capability.
3. **Threat model (create carve-out):** The company id is server-derived from the gateway-injected stack id, and `createCompanySchema` is a non-passthrough zod object (`validate` replaces `req.body` with the parsed result), so no actor — cloud or otherwise — can supply an id. Stack `member`/`support` and non-cloud non-admin actors are refused at the route gate (`local_implicit || isInstanceAdmin || stack owner/admin`). Cross-stack creation is impossible: the forced id comes from the actor's own stack, never the body.
4. No DB migrations. No lockfile changes.

## Model Used

Claude Opus 4.8 (`claude-opus-4-8`) and Claude Fable 5 (`claude-fable-5`) via Claude Code (Anthropic) — extended thinking enabled, agentic tool use; implementation and independent code-review passes ran as separate model sessions.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
