### PR TITLE
fix(ui): reflow list names, toolbars, and tabs at <=480px

### DIFF
--- a/ui/src/components/EntityRow.test.tsx
+++ b/ui/src/components/EntityRow.test.tsx
@@ -60,6 +60,25 @@ describe("EntityRow", () => {
     expect(markup).toContain("min-w-0 flex-1");
   });
 
+  it("truncates the title by default but honors a caller wrap override (mobile <=480px)", () => {
+    const plain = renderToStaticMarkup(<EntityRow title="a-very-long-project-name.com" />);
+    // Default: single-line ellipsis so a long name never reflows on wide layouts.
+    expect(plain).toContain("truncate");
+
+    // Override (projects/agents index on mobile): wrap the name instead of
+    // ellipsizing it to an indistinguishable stub; the caller class replaces
+    // the default `truncate` rather than stacking with it.
+    const wrapped = renderToStaticMarkup(
+      <EntityRow
+        title="a-very-long-project-name.com"
+        titleTextClassName="whitespace-normal break-words xl:truncate xl:whitespace-nowrap"
+      />,
+    );
+    expect(wrapped).toContain("whitespace-normal break-words xl:truncate xl:whitespace-nowrap");
+    // the bare default `truncate` class must not also be applied to the span
+    expect(wrapped).not.toContain('class="truncate"');
+  });
+
   it("gives the title a min-width floor and lets meta shrink under titlePriority (PAP-12988)", () => {
     const markup = renderToStaticMarkup(
       <EntityRow

--- a/ui/src/components/IssuesList.tsx
+++ b/ui/src/components/IssuesList.tsx
@@ -1602,7 +1602,9 @@ export function IssuesList({
       ) : null}
 
       {/* Toolbar */}
-      <div className="flex items-center justify-between gap-2 sm:gap-3">
+      {/* On mobile let the control cluster wrap to its own line so the search box
+          and the icon buttons never crush each other into a clipped ~24px row. */}
+      <div className="flex items-center justify-between gap-2 max-sm:flex-wrap max-sm:gap-y-2 sm:gap-3">
         <div className="flex min-w-0 items-center gap-2 sm:gap-3">
           <Button size="sm" variant="outline" onClick={() => openCreateIssueDialog()}>
             <Plus className="h-4 w-4 sm:mr-1" />
@@ -1617,7 +1619,9 @@ export function IssuesList({
           />
         </div>
 
-        <div className="flex items-center gap-0.5 sm:gap-1 shrink-0">
+        {/* Mobile: enforce a >=44px tap-target height on every toolbar button
+            (height-only so labelled controls keep their intrinsic width). */}
+        <div className="flex items-center gap-1 shrink-0 max-sm:[&_button]:h-11 max-sm:[&_button]:min-h-11 sm:gap-1">
           {/* View mode toggle */}
           <div className="flex items-center border border-border rounded-md overflow-hidden mr-1" role="group" aria-label="View mode">
             <button

--- a/ui/src/components/ui/tabs.test.tsx
+++ b/ui/src/components/ui/tabs.test.tsx
@@ -1,0 +1,27 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { Tabs, TabsList, TabsTrigger, tabsListVariants } from "./tabs";
+
+describe("Tabs mobile tap-targets (<=480px)", () => {
+  it("raises the horizontal tabs-list height on mobile", () => {
+    // Desktop height stays h-9; mobile gets h-12 so the row clears the 44px min.
+    expect(tabsListVariants()).toContain("group-data-[orientation=horizontal]/tabs:h-9");
+    expect(tabsListVariants()).toContain(
+      "max-sm:group-data-[orientation=horizontal]/tabs:h-12",
+    );
+  });
+
+  it("gives each trigger a >=44px height on mobile without changing desktop", () => {
+    const markup = renderToStaticMarkup(
+      <Tabs defaultValue="a">
+        <TabsList>
+          <TabsTrigger value="a">Overview</TabsTrigger>
+          <TabsTrigger value="b">Activity</TabsTrigger>
+        </TabsList>
+      </Tabs>,
+    );
+    // desktop token preserved, mobile 44px (h-11) added
+    expect(markup).toContain("h-(--sz-calc-27)");
+    expect(markup).toContain("max-sm:h-11");
+  });
+});

--- a/ui/src/components/ui/tabs.tsx
+++ b/ui/src/components/ui/tabs.tsx
@@ -24,7 +24,7 @@ function Tabs({
 }
 
 const tabsListVariants = cva(
-  "p-(--sz-3px) group-data-[orientation=horizontal]/tabs:h-9 group/tabs-list text-muted-foreground inline-flex w-fit items-center justify-center group-data-[orientation=vertical]/tabs:h-fit group-data-[orientation=vertical]/tabs:flex-col",
+  "p-(--sz-3px) group-data-[orientation=horizontal]/tabs:h-9 max-sm:group-data-[orientation=horizontal]/tabs:h-12 group/tabs-list text-muted-foreground inline-flex w-fit items-center justify-center group-data-[orientation=vertical]/tabs:h-fit group-data-[orientation=vertical]/tabs:flex-col",
   {
     variants: {
       variant: {
@@ -62,7 +62,7 @@ function TabsTrigger({
     <TabsPrimitive.Trigger
       data-slot="tabs-trigger"
       className={cn(
-        "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:outline-ring text-foreground/60 hover:text-foreground dark:text-muted-foreground dark:hover:text-foreground relative inline-flex h-(--sz-calc-27) flex-1 items-center justify-center gap-1.5 border border-transparent px-2 py-1 text-sm font-medium whitespace-nowrap transition-(--tp-color-background-color-border-color-box-shadow) group-data-[orientation=vertical]/tabs:w-full group-data-[orientation=vertical]/tabs:justify-start focus-visible:ring-(length:--rad-3) focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 group-data-[variant=default]/tabs-list:data-[state=active]:shadow-sm group-data-[variant=line]/tabs-list:data-[state=active]:shadow-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:outline-ring text-foreground/60 hover:text-foreground dark:text-muted-foreground dark:hover:text-foreground relative inline-flex h-(--sz-calc-27) max-sm:h-11 flex-1 items-center justify-center gap-1.5 border border-transparent px-2 py-1 text-sm font-medium whitespace-nowrap transition-(--tp-color-background-color-border-color-box-shadow) group-data-[orientation=vertical]/tabs:w-full group-data-[orientation=vertical]/tabs:justify-start focus-visible:ring-(length:--rad-3) focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 group-data-[variant=default]/tabs-list:data-[state=active]:shadow-sm group-data-[variant=line]/tabs-list:data-[state=active]:shadow-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         "group-data-[variant=line]/tabs-list:bg-transparent group-data-[variant=line]/tabs-list:data-[state=active]:bg-transparent dark:group-data-[variant=line]/tabs-list:data-[state=active]:border-transparent dark:group-data-[variant=line]/tabs-list:data-[state=active]:bg-transparent",
         "data-[state=active]:bg-background dark:data-[state=active]:text-foreground dark:data-[state=active]:border-input dark:data-[state=active]:bg-input/30 data-[state=active]:text-foreground",
         "after:bg-foreground after:absolute after:opacity-0 after:transition-opacity group-data-[orientation=horizontal]/tabs:after:inset-x-0 group-data-[orientation=horizontal]/tabs:after:bottom-(--sz-neg-5px) group-data-[orientation=horizontal]/tabs:after:h-0.5 group-data-[orientation=vertical]/tabs:after:inset-y-0 group-data-[orientation=vertical]/tabs:after:-right-1 group-data-[orientation=vertical]/tabs:after:w-0.5 group-data-[variant=line]/tabs-list:data-[state=active]:after:opacity-100",

--- a/ui/src/pages/Projects.tsx
+++ b/ui/src/pages/Projects.tsx
@@ -215,6 +215,10 @@ export function Projects() {
                         key={project.id}
                         leading={<ProjectTile color={project.color ?? null} icon={project.icon ?? null} size="sm" />}
                         title={project.name}
+                        // Wrap the project name on mobile instead of ellipsizing it to
+                        // an indistinguishable stub ("aash-vibes.c…"); keep the single-line
+                        // truncate on wide layouts. Mirrors the agents-index pattern.
+                        titleTextClassName="whitespace-normal break-words xl:truncate xl:whitespace-nowrap"
                         subtitle={project.description ?? undefined}
                         reserveSubtitleSpace
                         to={projectUrl(project)}


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work, with a web cockpit for browsing agents, projects, and issues.
> - The cockpit UI is responsive, but several list/toolbar surfaces were tuned for wide layouts and only degrade gracefully down to the `sm` breakpoint.
> - At phone widths (<=480px) a QA sweep found these surfaces hard-truncate or shrink content instead of reflowing: project names collapse to indistinguishable stubs, the issues toolbar crams ~7 icon buttons into a ~24px row (below the 44px tap-target minimum) and clips the search box, and the tab row falls under 44px.
> - Sub-44px controls and ellipsized-to-nothing names make the cockpit hard to use on a phone, and the agents index already got the name-wrapping treatment in #9236 — the sibling surfaces should match.
> - This pull request adds `max-sm`-guarded rules so those surfaces reflow on mobile: wrap long names, wrap the toolbar cluster and floor button height at 44px, and raise the shared tab trigger/list to 44/48px.
> - The benefit is a usable cockpit at phone widths with no change to `sm`/`xl`+ layouts.

## Linked Issues or Issue Description

No public issue — describing in-PR (bug report form):

**What happened:** On the web cockpit at <=480px viewport width:
1. Projects index (`/projects`): long project names ellipsize to an unreadable stub (`aash-vibes.c…`, `bangerz-arm…`).
2. Issues toolbar: the view/columns/filter/sort/group icon buttons pack into a ~24px-tall row (below the 44px tap-target min) and the search placeholder is clipped.
3. Tab rows (dashboard / detail): render ~25px tall, below the 44px tap-target minimum.

**Expected:** Names wrap rather than truncate to nothing; interactive controls are at least 44px tall; nothing is clipped.

## What Changed

- `ui/src/pages/Projects.tsx` — pass `titleTextClassName="whitespace-normal break-words xl:truncate xl:whitespace-nowrap"` so the project name wraps on mobile and keeps single-line truncate at `xl` (mirrors the agents-index fix in #9236).
- `ui/src/components/IssuesList.tsx` — toolbar row gets `max-sm:flex-wrap max-sm:gap-y-2` so the control cluster reflows onto its own line instead of crushing the search box; the button cluster gets `max-sm:[&_button]:h-11 max-sm:[&_button]:min-h-11` for a >=44px tap-target (height-only, so labelled controls keep intrinsic width).
- `ui/src/components/ui/tabs.tsx` — shared tabs get `max-sm:h-11` (trigger) and `max-sm:group-data-[orientation=horizontal]/tabs:h-12` (list) for a 44px tap-target on mobile.

## Verification

Playwright measurement against the compiled styles at 390px and 1280px:

- Projects name: 390px → wraps, element height 48px, `scrollWidth == clientWidth` (no clip). 1280px → single-line, 24px, clipped/truncated exactly as before.
- Issues toolbar: 390px → all six controls (view toggle, columns, filter, sort, group) measure 44px tall.
- Tabs: 390px → trigger 44px, list 48px. 1280px → 29px / 36px (unchanged).
- No horizontal overflow at either width.

Reproduce: `cd ui && pnpm storybook`, then drive `Product/Issue Management → Full Surface Matrix` at a 390px viewport for the toolbar; project-name and tab heights measured by injecting the real `EntityRow`/`Tabs` class strings into the compiled-CSS page.

## Risks

Low risk. Every rule is `max-sm`/`xl` guarded, so `sm`+ and `xl`+ layouts are byte-for-byte unchanged (confirmed at 1280px). The `tabs.tsx` change touches the shared Tabs primitive but only adds mobile-only heights; desktop tab metrics are unchanged. CSS-only; no logic, data, or API changes.

## Model Used

Claude (Anthropic), model ID `claude-opus-4-8`, extended thinking + tool use (code execution, Playwright-driven browser verification).

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
