### PR TITLE
fix(heartbeat): prevent auto-checkout of comment-reopened issues

### DIFF
--- a/server/src/__tests__/heartbeat-auto-checkout.test.ts
+++ b/server/src/__tests__/heartbeat-auto-checkout.test.ts
@@ -12,6 +12,16 @@ describe("shouldAutoCheckoutIssueForWake", () => {
     })).toBe(true);
   });
 
+  it("does not auto-checkout a todo issue reopened via comment", () => {
+    expect(shouldAutoCheckoutIssueForWake({
+      contextSnapshot: { wakeReason: "issue_reopened_via_comment" },
+      issueStatus: "todo",
+      issueAssigneeAgentId: "agent-1",
+      isDependencyReady: true,
+      agentId: "agent-1",
+    })).toBe(false);
+  });
+
   it("does not auto-checkout pending execution-review state even if the row status is todo", () => {
     const reviewerAgentId = "11111111-1111-4111-8111-111111111111";
     const coderAgentId = "22222222-2222-4222-8222-222222222222";

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -3818,6 +3818,7 @@ export function shouldAutoCheckoutIssueForWake(input: {
   const wakeReason = readNonEmptyString(input.contextSnapshot?.wakeReason);
   if (!wakeReason) return false;
   if (wakeReason === "issue_comment_mentioned") return false;
+  if (wakeReason === "issue_reopened_via_comment") return false;
   if (wakeReason === "source_scoped_recovery_action") return false;
   if (wakeReason.startsWith("execution_")) return false;
 


### PR DESCRIPTION
## Summary

- Excludes `issue_reopened_via_comment` from `shouldAutoCheckoutIssueForWake` so the heartbeat does not silently auto-checkout (and flip to `in_progress`) an issue that was implicitly moved to `todo` by a human comment on a `done` issue.
- The implicit `done → todo` reopen on human comment is preserved — the agent still sees the reopened issue in its inbox and gets woken. But the second silent hop `todo → in_progress` (via auto-checkout) is now blocked, letting the agent's heartbeat logic decide whether to pick it up.
- Adds a test case for the new exclusion.

## Root cause

When a human/board user posts a comment on a `done` issue with an agent assignee:
1. `shouldImplicitlyMoveCommentedIssueToTodo` (`routes/issues.ts`) returns `true` → status becomes `todo`
2. A wake is enqueued with `reason: "issue_reopened_via_comment"`
3. `shouldAutoCheckoutIssueForWake` (`services/heartbeat.ts`) did NOT exclude this reason → auto-checkout sets status to `in_progress`

Net effect: `done` → `todo` → `in_progress` with zero explicit PATCH, causing agents to waste heartbeats re-closing routine issues.

## Test plan

- [x] Existing `heartbeat-auto-checkout.test.ts` tests pass
- [x] New test: `issue_reopened_via_comment` wake reason returns `false` from `shouldAutoCheckoutIssueForWake`
- [ ] Manual: close an issue, post a human comment, verify status stays `todo` (not `in_progress`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)