### PR TITLE
claude-local: first-class CLAUDE_CODE_OAUTH_TOKEN subscription auth for headless/remote runs

### DIFF
--- a/packages/adapters/claude-local/src/index.ts
+++ b/packages/adapters/claude-local/src/index.ts
@@ -65,4 +65,5 @@ Notes:
 - The Claude ACP lane requires Node >=22.12.0 and @agentclientprotocol/claude-agent-acp to be installed with this adapter package. Auto engine selection falls back to CLI when those prerequisites are unavailable; explicit engine="acp" fails loudly.
 - For ACP runs, model selection is passed through ANTHROPIC_MODEL at ACP server startup; Paperclip-managed Claude permissions and ephemeral skill materialization are handled by the shared ACP engine.
 - When Paperclip realizes a workspace/runtime for a run, it injects PAPERCLIP_WORKSPACE_* and PAPERCLIP_RUNTIME_* env vars for agent-side tooling.
+- Subscription (Claude Pro/Max) auth in headless/remote runs, where there is no on-disk Claude login, can be provided by setting CLAUDE_CODE_OAUTH_TOKEN in env (mint one with \`claude setup-token\`). Subscription usage/quota reporting requires an on-disk login and is unavailable with token-only auth.
 `;

--- a/packages/adapters/claude-local/src/server/acp.test.ts
+++ b/packages/adapters/claude-local/src/server/acp.test.ts
@@ -8,6 +8,7 @@ import {
   createClaudeAcpExecutor,
   nodeVersionMeetsClaudeAcpMinimum,
   resolveClaudeAcpBillingIdentity,
+  resolveClaudeAuthAdvice,
   resolveClaudeExecutionEngine,
   resolveClaudeExecutionEngineForRun,
   testClaudeAcpEnvironment,
@@ -493,5 +494,31 @@ describe("resolveClaudeAcpBillingIdentity", () => {
         executionTarget: { kind: "remote", transport: "sandbox", remoteCwd: "/work" },
       } as never).billingType,
     ).toBe("subscription");
+  });
+});
+
+describe("resolveClaudeAuthAdvice (ACP lane)", () => {
+  it("recognizes CLAUDE_CODE_OAUTH_TOKEN as valid subscription auth", () => {
+    expect(
+      resolveClaudeAuthAdvice({ CLAUDE_CODE_OAUTH_TOKEN: "sk-ant-oat01-fake-token-value" }),
+    ).toEqual({
+      code: "claude_acp_subscription_token_detected",
+      level: "info",
+      message:
+        "CLAUDE_CODE_OAUTH_TOKEN is set; Claude will authenticate with the configured subscription token.",
+    });
+  });
+
+  it("defers to the ANTHROPIC_API_KEY branch when both are set", () => {
+    expect(
+      resolveClaudeAuthAdvice({
+        ANTHROPIC_API_KEY: "sk-ant-api-fake",
+        CLAUDE_CODE_OAUTH_TOKEN: "sk-ant-oat01-fake-token-value",
+      }),
+    ).toBeNull();
+  });
+
+  it("returns null when neither auth signal is present (unchanged local-login guidance)", () => {
+    expect(resolveClaudeAuthAdvice({})).toBeNull();
   });
 });

--- a/packages/adapters/claude-local/src/server/acp.ts
+++ b/packages/adapters/claude-local/src/server/acp.ts
@@ -308,6 +308,22 @@ function isNonEmpty(value: unknown): value is string {
   return typeof value === "string" && value.trim().length > 0;
 }
 
+// ACP-lane mirror of the CLI-lane auth advice helper in test.ts: same
+// CLAUDE_CODE_OAUTH_TOKEN recognition contract, ACP-prefixed check code to
+// match this file's existing `claude_acp_*` naming.
+export function resolveClaudeAuthAdvice(env: Record<string, unknown>): AdapterEnvironmentCheck | null {
+  if (isNonEmpty(env.ANTHROPIC_API_KEY)) return null;
+  if (isNonEmpty(env.CLAUDE_CODE_OAUTH_TOKEN)) {
+    return {
+      code: "claude_acp_subscription_token_detected",
+      level: "info",
+      message:
+        "CLAUDE_CODE_OAUTH_TOKEN is set; Claude will authenticate with the configured subscription token.",
+    };
+  }
+  return null;
+}
+
 export async function testClaudeAcpEnvironment(
   ctx: AdapterEnvironmentTestContext,
 ): Promise<AdapterEnvironmentTestResult> {
@@ -403,12 +419,17 @@ export async function testClaudeAcpEnvironment(
       detail: `Detected in ${source}.`,
       hint: "Unset ANTHROPIC_API_KEY if you want subscription-based Claude login behavior.",
     });
-  } else if (!targetIsRemote) {
-    checks.push({
-      code: "claude_acp_subscription_mode_possible",
-      level: "info",
-      message: "ANTHROPIC_API_KEY is not set; subscription-based auth can be used if Claude is logged in.",
-    });
+  } else {
+    const authAdvice = resolveClaudeAuthAdvice(envConfig);
+    if (authAdvice) {
+      checks.push(authAdvice);
+    } else if (!targetIsRemote) {
+      checks.push({
+        code: "claude_acp_subscription_mode_possible",
+        level: "info",
+        message: "ANTHROPIC_API_KEY is not set; subscription-based auth can be used if Claude is logged in.",
+      });
+    }
   }
 
   const mode = firstNonEmptyString(config.mode, config.acpMode) ?? DEFAULT_ACP_ENGINE_MODE;

--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -139,7 +139,7 @@ function isBedrockAuth(env: Record<string, string>): boolean {
   );
 }
 
-function resolveClaudeBillingType(env: Record<string, string>): "api" | "subscription" | "metered_api" {
+export function resolveClaudeBillingType(env: Record<string, string>): "api" | "subscription" | "metered_api" {
   if (isBedrockAuth(env)) return "metered_api";
   return hasNonEmptyEnvValue(env, "ANTHROPIC_API_KEY") ? "api" : "subscription";
 }

--- a/packages/adapters/claude-local/src/server/test.auth.test.ts
+++ b/packages/adapters/claude-local/src/server/test.auth.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { resolveClaudeAuthAdvice } from "./test.js";
+import { resolveClaudeBillingType } from "./execute.js";
+
+describe("resolveClaudeAuthAdvice (CLI lane)", () => {
+  it("recognizes CLAUDE_CODE_OAUTH_TOKEN as valid subscription auth", () => {
+    expect(
+      resolveClaudeAuthAdvice({ CLAUDE_CODE_OAUTH_TOKEN: "sk-ant-oat01-fake-token-value" }),
+    ).toEqual({
+      code: "claude_subscription_token_detected",
+      level: "info",
+      message:
+        "CLAUDE_CODE_OAUTH_TOKEN is set; Claude will authenticate with the configured subscription token.",
+    });
+  });
+
+  it("defers to the ANTHROPIC_API_KEY branch when both are set", () => {
+    expect(
+      resolveClaudeAuthAdvice({
+        ANTHROPIC_API_KEY: "sk-ant-api-fake",
+        CLAUDE_CODE_OAUTH_TOKEN: "sk-ant-oat01-fake-token-value",
+      }),
+    ).toBeNull();
+  });
+
+  it("returns null when neither auth signal is present (unchanged local-login guidance)", () => {
+    expect(resolveClaudeAuthAdvice({})).toBeNull();
+  });
+
+  it("does not treat an empty-string token as set", () => {
+    expect(resolveClaudeAuthAdvice({ CLAUDE_CODE_OAUTH_TOKEN: "   " })).toBeNull();
+  });
+});
+
+describe("resolveClaudeBillingType with a subscription token", () => {
+  it("classifies a CLAUDE_CODE_OAUTH_TOKEN-only env as subscription billing (no production change)", () => {
+    expect(
+      resolveClaudeBillingType({ CLAUDE_CODE_OAUTH_TOKEN: "sk-ant-oat01-fake-token-value" }),
+    ).toBe("subscription");
+  });
+});

--- a/packages/adapters/claude-local/src/server/test.ts
+++ b/packages/adapters/claude-local/src/server/test.ts
@@ -48,6 +48,24 @@ function isNonEmpty(value: unknown): value is string {
   return typeof value === "string" && value.trim().length > 0;
 }
 
+// Pure decision for the (non-Bedrock) auth advice check: given the adapter's
+// config env, is there a recognizable auth signal beyond ANTHROPIC_API_KEY
+// (handled by the caller) that we should surface to the operator? Extracted
+// so the CLAUDE_CODE_OAUTH_TOKEN detection contract can be unit tested
+// without exercising the full probe pipeline.
+export function resolveClaudeAuthAdvice(env: Record<string, unknown>): AdapterEnvironmentCheck | null {
+  if (isNonEmpty(env.ANTHROPIC_API_KEY)) return null;
+  if (isNonEmpty(env.CLAUDE_CODE_OAUTH_TOKEN)) {
+    return {
+      code: "claude_subscription_token_detected",
+      level: "info",
+      message:
+        "CLAUDE_CODE_OAUTH_TOKEN is set; Claude will authenticate with the configured subscription token.",
+    };
+  }
+  return null;
+}
+
 function firstNonEmptyLine(text: string): string {
   return (
     text
@@ -278,12 +296,17 @@ export async function testEnvironment(
       detail: `Detected in ${source}.`,
       hint: "Unset ANTHROPIC_API_KEY if you want subscription-based Claude login behavior.",
     });
-  } else if (!targetIsRemote) {
-    checks.push({
-      code: "claude_subscription_mode_possible",
-      level: "info",
-      message: "ANTHROPIC_API_KEY is not set; subscription-based auth can be used if Claude is logged in.",
-    });
+  } else {
+    const authAdvice = resolveClaudeAuthAdvice(env);
+    if (authAdvice) {
+      checks.push(authAdvice);
+    } else if (!targetIsRemote) {
+      checks.push({
+        code: "claude_subscription_mode_possible",
+        level: "info",
+        message: "ANTHROPIC_API_KEY is not set; subscription-based auth can be used if Claude is logged in.",
+      });
+    }
   }
 
   const canRunProbe =


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The claude-local adapter runs the Claude Code CLI, which supports Anthropic API-key auth and Claude Pro/Max subscription auth
> - Subscription auth currently works headlessly only when the machine already has an on-disk login (`~/.claude/.credentials.json`) — remote/sandbox execution targets get a fresh HOME and therefore no subscription auth
> - The Claude Code CLI itself already accepts a long-lived token minted by `claude setup-token` via the `CLAUDE_CODE_OAUTH_TOKEN` env var, and the adapter's env plumbing already delivers `config.env` into runs (including remote targets)
> - The adapter's connection test doesn't know this: with no API key and no local login it steers the user to a local `claude login` that cannot exist on a remote target
> - This pull request makes the token option first-class in the adapter's auth checks and docs — no new transport, just recognition of an auth mode the CLI already supports
> - The benefit is that subscription-based users can run Claude Code on remote/sandbox targets without converting to API-key billing

## Linked Issues or Issue Description

No existing public issue; described inline below. Related but not duplicates: #4606 and #4068 strip host-managed Claude OAuth material from *spawned local* subprocess env for isolation — this PR is about *explicitly configured* adapter env delivered to runs, so the two are complementary (an operator-set `config.env` token is intentional, not host leakage). Also related: #2043 (Claude auth diagnostic probe for Railway Docker — same headless-auth pain point).

**Subsystem affected:** claude-local adapter — connection test (`server/test.ts`), ACP lane check (`server/acp.ts`), adapter configuration docs

**Problem or motivation:** Claude Pro/Max subscription auth works headlessly only with an on-disk login. Remote/sandbox execution targets get a fresh HOME and no subscription auth, and the adapter's connection test recognizes only `ANTHROPIC_API_KEY` or a local login — its guidance (`run claude login`) is impossible to follow on a remote target.

**Proposed solution:** Recognize `CLAUDE_CODE_OAUTH_TOKEN` (the token `claude setup-token` mints, which the CLI natively honors) in the adapter's auth checks, mirror the recognition in the ACP lane, and document the option including its real limitation.

**Alternatives considered:** (a) syncing `~/.claude/.credentials.json` into remote targets (credential file exfiltration surface, rejected); (b) extending quota polling to use the env token (the CLI's quota reporting reads the local oauth credentials, not the env token — deliberately not faked; documented as a limitation instead).

**Roadmap alignment:** Checked `ROADMAP.md` (2026-07-13); this supports the "Cloud / Sandbox agents" direction (running agents in more remote and sandboxed environments) and duplicates no planned core work.

## What Changed

- **Connection test recognizes the token** (`server/test.ts`): with no `ANTHROPIC_API_KEY` and a non-empty `CLAUDE_CODE_OAUTH_TOKEN`, the auth check now passes with "CLAUDE_CODE_OAUTH_TOKEN is set; Claude will authenticate with the configured subscription token." — instead of steering the user to a local `claude login` that doesn't exist on remote targets. `ANTHROPIC_API_KEY` keeps precedence; local-login detection is unchanged as the fallback.
- **ACP lane mirrored** (`server/acp.ts`): same recognition with an ACP-scoped check code, matching the file's existing per-lane check convention.
- **`agentConfigurationDoc`** documents the token option and its one limitation honestly: subscription usage/quota reporting still requires an on-disk login (quota polling reads the local oauth credentials, not the env token) — deliberately not extended here.
- **Billing classification unchanged:** token-only env remains `subscription` (now pinned by a unit test; `resolveClaudeBillingType` gained only an `export` for that assertion).

## Verification

- New `test.auth.test.ts`: precedence, exact message, whitespace-only token, api-key-wins.
- Three ACP-mirror cases in `acp.test.ts`.
- Package suite green locally except one pre-existing `test.probe.test.ts` failure verified identical on the base commit; typecheck clean.
- Manual: `claude setup-token` → set `CLAUDE_CODE_OAUTH_TOKEN` in adapter env on a host with no `~/.claude` login → connection test passes and a run authenticates with the subscription.
- CI note: the `General tests (server (1/3))` failure is a test-teardown FK race in `server/src/__tests__/heartbeat-issue-rewake-throttle.test.ts` (`delete from "agents"` vs. a lingering `agent_wakeup_requests` row) — a file this PR does not touch; this diff is confined to the claude-local adapter package.

## Risks

- Low risk. No new transport or storage: the token flows through the existing `config.env` delivery path; this PR only teaches the auth checks and docs about it.
- The connection test can now pass with a token that is expired/revoked (possession is asserted, not validated) — same as the existing `ANTHROPIC_API_KEY` behavior, which is also not validated at test time; a bad token still fails at run time with the CLI's own error.
- Documented limitation: subscription quota reporting still requires an on-disk login; the doc says so explicitly rather than implying full parity.
- No kubernetes/registry changes, no lockfile changes, no migrations.

## Model Used

Claude Fable 5 (`claude-fable-5`) via Claude Code (Anthropic) — extended thinking enabled, agentic tool use.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
