### PR TITLE
fix(claude-local): pipe print prompt via stdin

### DIFF
--- a/packages/adapter-utils/src/execution-target-sandbox.test.ts
+++ b/packages/adapter-utils/src/execution-target-sandbox.test.ts
@@ -194,6 +194,48 @@ describe("sandbox adapter execution targets", () => {
     });
   });
 
+  it("preserves stdin when wrapping sandbox adapter commands for run-log streaming", async () => {
+    const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-run-log-stdin-"));
+    cleanupDirs.push(rootDir);
+    const target: AdapterSandboxExecutionTarget = {
+      kind: "remote",
+      transport: "sandbox",
+      providerKey: "local-test",
+      remoteCwd: rootDir,
+      timeoutMs: 30_000,
+      streamRunLogs: true,
+      runner: createLocalSandboxRunner(),
+    };
+    const logsDir = path.posix.join(rootDir, ".paperclip-runtime", "bridge", "logs");
+    const runLogTail = createSandboxRunLogTailFactory({
+      runner: target.runner!,
+      remoteCwd: rootDir,
+      logsDir,
+      shellCommand: "bash",
+    }).create();
+    const events: Array<{ stream: "stdout" | "stderr"; chunk: string }> = [];
+
+    const result = await runAdapterExecutionTargetProcess(
+      "run-log-stdin",
+      target,
+      process.execPath,
+      ["-e", "process.stdin.setEncoding('utf8'); let s=''; process.stdin.on('data', c => s += c); process.stdin.on('end', () => process.stdout.write('stdin=' + s));"],
+      {
+        cwd: rootDir,
+        env: {},
+        stdin: "hello-through-wrapper",
+        timeoutSec: 5,
+        graceSec: 1,
+        runLogTail: { create: () => runLogTail },
+        onLog: async (stream, chunk) => { events.push({ stream, chunk }); },
+      },
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe("stdin=hello-through-wrapper");
+    expect(combinedStream(events, "stdout")).toContain("stdin=hello-through-wrapper");
+  });
+
   it("bridges bidirectional sandbox process sessions through a local ACPX-spawnable proxy", async () => {
     const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-process-session-"));
     cleanupDirs.push(rootDir);

--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -736,7 +736,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     resumeSessionId: string | null,
     attemptInstructionsFilePath: string | undefined,
   ) => {
-    const args = ["--print", "-", "--output-format", "stream-json", "--verbose"];
+    const args = ["--print", "--output-format", "stream-json", "--verbose"];
     if (resumeSessionId) args.push("--resume", resumeSessionId);
     args.push(...buildClaudeExecutionPermissionArgs({
       dangerouslySkipPermissions,

--- a/server/src/__tests__/claude-local-execute.test.ts
+++ b/server/src/__tests__/claude-local-execute.test.ts
@@ -376,6 +376,9 @@ describe("claude execute", () => {
         onMeta: async () => {},
       });
       const captured = JSON.parse(await fs.readFile(capturePath, "utf-8"));
+      expect(captured.argv).toContain("--print");
+      expect(captured.argv).not.toContain("-");
+      expect(captured.prompt).toContain("Do work.");
       expect(captured.argv).toContain("--append-system-prompt-file");
     } finally {
       restore();


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The `claude_local` adapter is responsible for launching Claude Code in non-interactive `--print` mode and delivering the Paperclip task prompt to it.
> - Claude Code accepts `--print` input either from stdin or as a prompt argument, but the adapter was also passing a literal `-` argv marker.
> - With current Claude Code releases, that argv shape can fail before the model sees the task prompt, even though Paperclip is already writing the prompt to stdin.
> - The smallest fix is to keep `--print` mode and stdin delivery, but remove the stale `-` argument.
> - This pull request adds regression coverage for both the Claude argv/prompt behavior and the sandbox run-log wrapper path so future refactors do not break stdin delivery.
> - The benefit is that `claude_local` can run headless Paperclip tasks through Claude Code without requiring users to copy the prompt into argv or store provider API keys in Paperclip.

## Linked Issues or Issue Description

Fixes #2444
Refs #4947

Bug summary:
- `claude_local` can invoke Claude Code as `claude --print - --output-format stream-json --verbose`.
- Current Claude Code expects `--print` input from stdin or a prompt argument; the literal `-` can cause startup failure instead of consuming the prompt that Paperclip writes to stdin.
- Expected behavior: Paperclip keeps writing the issue/task prompt to stdin and launches Claude Code with a valid `--print` argv shape.

## What Changed

- Removed the stale `"-"` argv marker from the Claude Code `--print` invocation.
- Added a `claude_local` regression assertion that `--print` is present, `"-"` is absent, and the prompt still reaches stdin.
- Added adapter-utils regression coverage proving sandbox run-log command wrapping preserves stdin while streaming logs.

## Verification

Local targeted verification from a clean worktree based on `origin/master`:

```sh
pnpm install --frozen-lockfile
pnpm exec vitest run packages/adapter-utils/src/execution-target-sandbox.test.ts server/src/__tests__/claude-local-execute.test.ts
pnpm --filter @paperclipai/adapter-claude-local typecheck
pnpm --filter @paperclipai/adapter-utils typecheck
```

Results:

- Vitest: 2 files passed, 50 tests passed.
- `@paperclipai/adapter-claude-local` typecheck passed.
- `@paperclipai/adapter-utils` typecheck passed.

Manual smoke:

- Verified with Claude Code `2.1.206` that a local Paperclip task using the patched `claude_local` path can consume its prompt via stdin and complete through the Paperclip issue lifecycle.

## Risks

Low risk.

- This narrows the Claude argv list by one stale positional marker while preserving the existing stdin transport.
- If older Claude Code versions specifically expected `-` as a stdin sentinel, this changes that behavior; the added tests document Paperclip's intended contract as stdin delivery without an argv prompt placeholder.
- No database, API, UI, or migration behavior changes.

## Model Used

- OpenAI Codex, `gpt-5.5`, Hermes Agent tool-use session. Assisted with patch packaging, verification, and PR preparation.

## Checklist
- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
