### PR TITLE
fix(server): skip overlapping periodic heartbeat reconcile chains

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -818,6 +818,11 @@ export async function startServer(): Promise<StartedServer> {
   let drainHeartbeatRunsForShutdown: ((signal: "SIGINT" | "SIGTERM") => Promise<unknown>) | null = null;
   let heartbeatSchedulerStopped = false;
   let heartbeatSchedulerInterval: ReturnType<typeof setInterval> | null = null;
+  // Guard: only one periodic reconcile chain may run at a time. Without this,
+  // if a chain takes longer than heartbeatSchedulerIntervalMs the next tick
+  // starts another chain while the first still holds DB connections, and the
+  // overlap compounds every tick (pool exhaustion / duplicated recovery work).
+  let periodicReconcileRunning = false;
   const heartbeatSchedulerInFlight = new Set<Promise<void>>();
   const trackHeartbeatSchedulerWork = (work: Promise<unknown>) => {
     let tracked: Promise<void>;
@@ -991,6 +996,11 @@ export async function startServer(): Promise<StartedServer> {
 
       if (heartbeatSchedulerStopped) return;
       if (!(await heartbeat.resolveSchedulingSuppression()).suppressed) {
+        if (periodicReconcileRunning) {
+          logger.warn("periodic heartbeat reconcile skipped because the previous iteration is still running");
+          return;
+        }
+        periodicReconcileRunning = true;
         // Periodically reap orphaned runs (5-min staleness threshold) and make sure
         // persisted queued work is still being driven forward.
         trackHeartbeatSchedulerWork(heartbeat
@@ -1045,6 +1055,9 @@ export async function startServer(): Promise<StartedServer> {
           })
           .catch((err) => {
             logger.error({ err }, "periodic heartbeat recovery failed");
+          })
+          .finally(() => {
+            periodicReconcileRunning = false;
           }));
       }
       })();


### PR DESCRIPTION
## Thinking Path

> - Paperclip's server runs a periodic heartbeat reconcile chain on `setInterval` (`config.heartbeatSchedulerIntervalMs`): reap orphaned runs → promote scheduled retries → resume queued runs → reconcile stranded assignments → issue-graph liveness → task watchdogs → silent-run scan → stale-lock sweep → productivity reviews.
> - Nothing prevents two chains from running concurrently. `trackHeartbeatSchedulerWork` tracks in-flight promises for graceful shutdown, but it is not a mutual-exclusion mechanism — the next tick fires regardless of whether the previous chain finished.
> - On a busy instance the chain can legitimately exceed the interval (large `heartbeat_runs` tables, many stranded issues after an incident, slow storage). When it does, tick N+1 starts a second full chain while tick N still holds DB connections; under sustained load this compounds every tick.
> - We operate a production Paperclip instance (~30 agents) and hit exactly this: an incident made the reconcile chain slow, overlapping chains multiplied, and the embedded Postgres pool was exhausted by stacked reconcile work — a self-amplifying failure precisely when the scheduler most needed to run cleanly.
> - We have carried this guard as a fork patch through several upstream releases; contributing it so the fix lives upstream.

## What Changed

- `server/src/index.ts`: adds a `periodicReconcileRunning` flag next to the existing scheduler state.
  - At the top of the suppression-gated reconcile block, if the previous chain is still running the tick logs `"periodic heartbeat reconcile skipped because the previous iteration is still running"` and returns (the reconcile chain is the last work item in the tick callback, so nothing else is skipped — the timer tick, routines tick, and environment cleanup blocks above it run unconditionally as before).
  - The chain gains a `.finally(() => { periodicReconcileRunning = false; })` after the existing `.catch`, so the flag is released on success and failure alike.
- No behavioural change when chains complete inside the interval: the flag is set and cleared within one tick.

## Verification

- `pnpm --filter @paperclipai/server exec tsc --noEmit` — typechecks.
- Manual: set `heartbeatSchedulerIntervalMs` low (e.g. 2000) and artificially delay a chain step (e.g. `await new Promise(r => setTimeout(r, 10_000))` inside `reapOrphanedRuns`); without the guard the log shows interleaved duplicate chain steps, with the guard subsequent ticks log the skip warning until the first chain completes, then resume normally.
- This exact guard has run in our production fork since June across four upstream rebases (v2026.517 → v2026.707) with zero skipped-tick warnings in steady state and correct skip behaviour under induced slowdown.

## Risks

Low. Worst case a reconcile tick is skipped while a previous one is genuinely still running — which is strictly better than the current behaviour of stacking a concurrent chain on top of it. The flag is cleared in `finally`, so a failed chain cannot wedge the scheduler; if the process crashes mid-chain the flag dies with it. The guard deliberately does not cover the timer/routines/environment blocks above it, which are cheap and idempotent per tick.
