### PR TITLE
feat(ui): reply-to-comment thread UI (reply button, composer chip, quoted block)

### DIFF
--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -759,6 +759,7 @@ export type {
   IssueComment,
   IssueCommentDerivedAuthorSource,
   IssueCommentMetadata,
+  IssueCommentReplyToMetadata,
   IssueCommentMetadataSection,
   IssueCommentMetadataRow,
   IssueCommentMetadataTextRow,

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -387,6 +387,7 @@ export type {
   IssueComment,
   IssueCommentDerivedAuthorSource,
   IssueCommentMetadata,
+  IssueCommentReplyToMetadata,
   IssueCommentMetadataSection,
   IssueCommentMetadataRow,
   IssueCommentMetadataTextRow,

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -45,6 +45,7 @@ import { CloudUpstream } from "./pages/CloudUpstream";
 import { CloudUpstreamUxLab } from "./pages/CloudUpstreamUxLab";
 import { BootstrapSetupUxLab } from "./pages/BootstrapSetupUxLab";
 import { ResponsibleUserDenialUxLab } from "./pages/ResponsibleUserDenialUxLab";
+import { IssueChatUxLab } from "./pages/IssueChatUxLab";
 import { CompanySettingsPluginPage } from "./pages/CompanySettingsPluginPage";
 import { CompanyAccess, CompanyAccessLegacyRoute } from "./pages/CompanyAccess";
 import { CompanyInvites } from "./pages/CompanyInvites";
@@ -445,6 +446,7 @@ export function App() {
         <Route path="ux-lab/cloud-upstream" element={<CloudUpstreamUxLab />} />
         <Route path="ux-lab/bootstrap-setup" element={<BootstrapSetupUxLab />} />
         <Route path="ux-lab/responsible-user-denial" element={<ResponsibleUserDenialUxLab />} />
+        <Route path="ux-lab/chat" element={<IssueChatUxLab />} />
 
         <Route element={<CloudAccessGate />}>
           <Route index element={<CompanyRootRedirect />} />

--- a/ui/src/api/issues.ts
+++ b/ui/src/api/issues.ts
@@ -284,13 +284,20 @@ export const issuesApi = {
       allowSharing?: boolean;
     },
   ) => api.post<FeedbackVote>(`/issues/${id}/feedback-votes`, data),
-  addComment: (id: string, body: string, reopen?: boolean, interrupt?: boolean) =>
+  addComment: (
+    id: string,
+    body: string,
+    reopen?: boolean,
+    interrupt?: boolean,
+    replyToCommentId?: string | null,
+  ) =>
     api.post<IssueComment>(
       `/issues/${id}/comments`,
       {
         body,
         ...(reopen === undefined ? {} : { reopen }),
         ...(interrupt === undefined ? {} : { interrupt }),
+        ...(replyToCommentId ? { metadata: { replyTo: { commentId: replyToCommentId } } } : {}),
       },
     ),
   cancelComment: (id: string, commentId: string) =>

--- a/ui/src/components/CommentThread.tsx
+++ b/ui/src/components/CommentThread.tsx
@@ -387,15 +387,17 @@ function ReplyButton({ onClick }: { onClick: () => void }) {
 function ReplyQuote({
   replyTo,
   agentMap,
+  currentUserId,
   targetDeleted,
   onClick,
 }: {
   replyTo: IssueCommentReplyToMetadata;
   agentMap?: Map<string, Agent>;
+  currentUserId?: string | null;
   targetDeleted: boolean;
   onClick?: () => void;
 }) {
-  const authorName = formatReplyAuthorName(replyTo, agentMap);
+  const authorName = formatReplyAuthorName(replyTo, { agentMap, currentUserId });
   const body = (
     <span className="flex min-w-0 items-stretch gap-2">
       <span aria-hidden className="w-0.5 shrink-0 rounded-full bg-primary/40" />
@@ -434,6 +436,7 @@ function ReplyQuote({
 function CommentCard({
   comment,
   agentMap,
+  currentUserId,
   companyId,
   projectId,
   feedbackVote = null,
@@ -450,6 +453,7 @@ function CommentCard({
 }: {
   comment: CommentWithRunMeta;
   agentMap?: Map<string, Agent>;
+  currentUserId?: string | null;
   companyId?: string | null;
   projectId?: string | null;
   feedbackVote?: FeedbackVoteValue | null;
@@ -548,6 +552,7 @@ function CommentCard({
             <ReplyQuote
               replyTo={replyTo}
               agentMap={agentMap}
+              currentUserId={currentUserId}
               targetDeleted={replyTargetDeleted}
               onClick={
                 onScrollToComment && !replyTargetDeleted
@@ -863,6 +868,7 @@ const TimelineList = memo(function TimelineList({
             key={comment.id}
             comment={comment}
             agentMap={agentMap}
+            currentUserId={currentUserId}
             companyId={companyId}
             projectId={projectId}
             feedbackVote={feedbackVoteByTargetId?.get(comment.id) ?? null}
@@ -1026,13 +1032,18 @@ export function CommentThread({
   const handleReply = useCallback(
     (comment: CommentWithRunMeta) => {
       const { excerpt, truncated } = buildReplyExcerpt(comment.body);
-      const authorName = comment.authorAgentId
-        ? agentMap?.get(comment.authorAgentId)?.name ?? comment.authorAgentId.slice(0, 8)
-        : "You";
+      const authorName = formatReplyAuthorName(
+        {
+          authorType: comment.authorType,
+          authorAgentId: comment.authorAgentId,
+          authorUserId: comment.authorUserId,
+        },
+        { agentMap, currentUserId },
+      );
       setReplyingTo({ commentId: comment.id, authorName, excerpt, excerptTruncated: truncated });
       editorRef.current?.focus();
     },
-    [agentMap],
+    [agentMap, currentUserId],
   );
 
   useEffect(() => {
@@ -1224,6 +1235,7 @@ export function CommentThread({
                 key={comment.id}
                 comment={comment}
                 agentMap={agentMap}
+                currentUserId={currentUserId}
                 companyId={companyId}
                 projectId={projectId}
                 highlightCommentId={highlightCommentId}

--- a/ui/src/components/CommentThread.tsx
+++ b/ui/src/components/CommentThread.tsx
@@ -1,4 +1,4 @@
-import { memo, useEffect, useMemo, useRef, useState, type ChangeEvent } from "react";
+import { memo, useCallback, useEffect, useMemo, useRef, useState, type ChangeEvent, type KeyboardEvent } from "react";
 import { Link, useLocation } from "react-router-dom";
 import type {
   Agent,
@@ -7,10 +7,12 @@ import type {
   FeedbackVote,
   FeedbackVoteValue,
   IssueComment,
+  IssueCommentReplyToMetadata,
 } from "@paperclipai/shared";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
-import { ArrowRight, Check, Copy, Paperclip } from "lucide-react";
+import { ArrowRight, Check, Copy, Paperclip, Reply, X } from "lucide-react";
+import { buildReplyExcerpt, formatReplyAuthorName } from "../lib/comment-reply";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { Identity } from "./Identity";
 import { InlineEntitySelector, type InlineEntityOption } from "./InlineEntitySelector";
@@ -88,7 +90,12 @@ interface CommentThreadProps {
     vote: FeedbackVoteValue,
     options?: { allowSharing?: boolean; reason?: string },
   ) => Promise<void>;
-  onAdd: (body: string, reopen?: boolean, reassignment?: CommentReassignment) => Promise<void>;
+  onAdd: (
+    body: string,
+    reopen?: boolean,
+    reassignment?: CommentReassignment,
+    replyToCommentId?: string | null,
+  ) => Promise<void>;
   issueStatus?: string;
   agentMap?: Map<string, Agent>;
   currentUserId?: string | null;
@@ -133,6 +140,50 @@ function saveDraft(draftKey: string, value: string) {
 function clearDraft(draftKey: string) {
   try {
     localStorage.removeItem(draftKey);
+  } catch {
+    // Ignore localStorage failures.
+  }
+}
+
+/**
+ * The active reply target held by the composer. Self-contained (author + excerpt) so the chip
+ * renders without re-resolving the original comment, and survives a reload via localStorage.
+ */
+interface ReplyDraftTarget {
+  commentId: string;
+  authorName: string;
+  excerpt: string;
+  excerptTruncated: boolean;
+}
+
+function replyDraftKey(draftKey: string) {
+  return `${draftKey}:reply`;
+}
+
+function loadReplyDraft(draftKey: string): ReplyDraftTarget | null {
+  try {
+    const raw = localStorage.getItem(replyDraftKey(draftKey));
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Partial<ReplyDraftTarget>;
+    if (typeof parsed?.commentId !== "string" || typeof parsed?.excerpt !== "string") return null;
+    return {
+      commentId: parsed.commentId,
+      authorName: typeof parsed.authorName === "string" ? parsed.authorName : "comment",
+      excerpt: parsed.excerpt,
+      excerptTruncated: parsed.excerptTruncated === true,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function saveReplyDraft(draftKey: string, target: ReplyDraftTarget | null) {
+  try {
+    if (target) {
+      localStorage.setItem(replyDraftKey(draftKey), JSON.stringify(target));
+    } else {
+      localStorage.removeItem(replyDraftKey(draftKey));
+    }
   } catch {
     // Ignore localStorage failures.
   }
@@ -313,6 +364,73 @@ function CopyMarkdownButton({ text }: { text: string }) {
   );
 }
 
+function ReplyButton({ onClick }: { onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      title="Reply"
+      aria-label="Reply to comment"
+      className={cn(
+        "inline-flex min-h-8 items-center justify-center rounded-md px-2 text-muted-foreground transition-[color,background-color,opacity] hover:bg-accent/60 hover:text-foreground",
+        // Hover-reveal on hover-capable pointers; always visible where hover is unavailable (touch).
+        "opacity-100 [@media(hover:hover)]:opacity-0 group-hover/comment:opacity-100 focus-visible:opacity-100",
+      )}
+    >
+      <Reply className="h-3.5 w-3.5" />
+      <span className="sr-only">Reply</span>
+    </button>
+  );
+}
+
+/** Compact quoted header rendered above a sent reply's body (accent bar + author + excerpt). */
+function ReplyQuote({
+  replyTo,
+  agentMap,
+  targetDeleted,
+  onClick,
+}: {
+  replyTo: IssueCommentReplyToMetadata;
+  agentMap?: Map<string, Agent>;
+  targetDeleted: boolean;
+  onClick?: () => void;
+}) {
+  const authorName = formatReplyAuthorName(replyTo, agentMap);
+  const body = (
+    <span className="flex min-w-0 items-stretch gap-2">
+      <span aria-hidden className="w-0.5 shrink-0 rounded-full bg-primary/40" />
+      <span className="min-w-0 flex-1 py-0.5 text-xs">
+        {targetDeleted ? (
+          <span className="italic text-muted-foreground">Original comment deleted</span>
+        ) : (
+          <>
+            <span className="font-medium text-foreground">{authorName}</span>{" "}
+            <span className="text-muted-foreground line-clamp-2 align-baseline">
+              {replyTo.excerpt}
+              {replyTo.excerptTruncated ? "…" : ""}
+            </span>
+          </>
+        )}
+      </span>
+    </span>
+  );
+
+  if (targetDeleted || !onClick) {
+    return <div className="mb-1.5 rounded-sm bg-muted/40 px-2 py-1">{body}</div>;
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      title="Jump to the original comment"
+      className="mb-1.5 block w-full rounded-sm bg-muted/40 px-2 py-1 text-left transition-colors hover:bg-muted/70"
+    >
+      {body}
+    </button>
+  );
+}
+
 function CommentCard({
   comment,
   agentMap,
@@ -326,6 +444,9 @@ function CommentCard({
   highlightCommentId,
   queued = false,
   externalReferences,
+  onReply,
+  onScrollToComment,
+  replyTargetDeleted = false,
 }: {
   comment: CommentWithRunMeta;
   agentMap?: Map<string, Agent>;
@@ -342,18 +463,24 @@ function CommentCard({
   highlightCommentId?: string | null;
   queued?: boolean;
   externalReferences?: MarkdownExternalReferenceMap;
+  onReply?: (comment: CommentWithRunMeta) => void;
+  onScrollToComment?: (commentId: string) => void;
+  replyTargetDeleted?: boolean;
 }) {
   const isHighlighted = highlightCommentId === comment.id;
   const isPending = comment.clientStatus === "pending";
   const isQueued = queued || comment.queueState === "queued" || comment.clientStatus === "queued";
   const isDeleted = Boolean(comment.deletedAt);
   const followUpRequested = comment.followUpRequested === true;
+  const isOptimistic = comment.id.startsWith("optimistic-");
+  const replyTo = comment.metadata?.replyTo ?? null;
+  const canReply = Boolean(onReply) && !isDeleted && !isPending && !isQueued && !isOptimistic;
 
   return (
     <div
       key={comment.id}
       id={`comment-${comment.id}`}
-      className={`border p-3 overflow-hidden min-w-0 rounded-sm transition-colors duration-1000 ${
+      className={`group/comment border p-3 overflow-hidden min-w-0 rounded-sm transition-colors duration-1000 ${
         isQueued
           ? "border-amber-300/70 bg-amber-50/70 dark:border-amber-500/40 dark:bg-amber-500/10"
           : isHighlighted && !isDeleted
@@ -409,13 +536,28 @@ function CommentCard({
               {formatDateTime(comment.createdAt)}
             </a>
           )}
+          {canReply ? <ReplyButton onClick={() => onReply?.(comment)} /> : null}
           {!isDeleted ? <CopyMarkdownButton text={comment.body} /> : null}
         </span>
       </div>
       {isDeleted ? (
         <div className="text-sm italic text-muted-foreground">Comment deleted</div>
       ) : (
-        <MarkdownBody className="text-sm" softBreaks externalReferences={externalReferences}>{comment.body}</MarkdownBody>
+        <>
+          {replyTo ? (
+            <ReplyQuote
+              replyTo={replyTo}
+              agentMap={agentMap}
+              targetDeleted={replyTargetDeleted}
+              onClick={
+                onScrollToComment && !replyTargetDeleted
+                  ? () => onScrollToComment(replyTo.commentId)
+                  : undefined
+              }
+            />
+          ) : null}
+          <MarkdownBody className="text-sm" softBreaks externalReferences={externalReferences}>{comment.body}</MarkdownBody>
+        </>
       )}
       {companyId && !isPending && !isDeleted ? (
         <div className="mt-2 space-y-2">
@@ -579,6 +721,9 @@ const TimelineList = memo(function TimelineList({
   votingTargetId,
   highlightCommentId,
   externalReferences,
+  onReply,
+  onScrollToComment,
+  deletedCommentIds,
 }: {
   timeline: TimelineItem[];
   agentMap?: Map<string, Agent>;
@@ -602,6 +747,9 @@ const TimelineList = memo(function TimelineList({
   votingTargetId?: string | null;
   highlightCommentId?: string | null;
   externalReferences?: MarkdownExternalReferenceMap;
+  onReply?: (comment: CommentWithRunMeta) => void;
+  onScrollToComment?: (commentId: string) => void;
+  deletedCommentIds?: Set<string>;
 }) {
   if (timeline.length === 0) {
     return <p className="text-sm text-muted-foreground">No timeline entries yet.</p>;
@@ -724,6 +872,13 @@ const TimelineList = memo(function TimelineList({
             voting={votingTargetId === comment.id}
             highlightCommentId={highlightCommentId}
             externalReferences={externalReferences}
+            onReply={onReply}
+            onScrollToComment={onScrollToComment}
+            replyTargetDeleted={
+              comment.metadata?.replyTo
+                ? deletedCommentIds?.has(comment.metadata.replyTo.commentId) ?? false
+                : false
+            }
           />
         );
       })}
@@ -771,6 +926,7 @@ export function CommentThread({
   const [reassignTarget, setReassignTarget] = useState(effectiveSuggestedAssigneeValue);
   const [highlightCommentId, setHighlightCommentId] = useState<string | null>(null);
   const [votingTargetId, setVotingTargetId] = useState<string | null>(null);
+  const [replyingTo, setReplyingTo] = useState<ReplyDraftTarget | null>(null);
   const editorRef = useRef<MarkdownEditorRef>(null);
   const attachInputRef = useRef<HTMLInputElement | null>(null);
   const draftTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -847,9 +1003,42 @@ export function CommentThread({
       }));
   }, [agentMap, providedMentions]);
 
+  // Soft-deleted comment ids, so a sent reply whose target was deleted shows a tombstone.
+  const deletedCommentIds = useMemo(() => {
+    const ids = new Set<string>();
+    for (const comment of [...comments, ...queuedComments]) {
+      if (comment.deletedAt) ids.add(comment.id);
+    }
+    return ids;
+  }, [comments, queuedComments]);
+
+  const scrollToComment = useCallback((commentId: string) => {
+    if (typeof document === "undefined") return;
+    const el = document.getElementById(`comment-${commentId}`);
+    if (!el) return;
+    setHighlightCommentId(commentId);
+    el.scrollIntoView({ behavior: "smooth", block: "center" });
+    window.setTimeout(() => {
+      setHighlightCommentId((current) => (current === commentId ? null : current));
+    }, 3000);
+  }, []);
+
+  const handleReply = useCallback(
+    (comment: CommentWithRunMeta) => {
+      const { excerpt, truncated } = buildReplyExcerpt(comment.body);
+      const authorName = comment.authorAgentId
+        ? agentMap?.get(comment.authorAgentId)?.name ?? comment.authorAgentId.slice(0, 8)
+        : "You";
+      setReplyingTo({ commentId: comment.id, authorName, excerpt, excerptTruncated: truncated });
+      editorRef.current?.focus();
+    },
+    [agentMap],
+  );
+
   useEffect(() => {
     if (!draftKey) return;
     setBody(loadDraft(draftKey));
+    setReplyingTo(loadReplyDraft(draftKey));
   }, [draftKey]);
 
   useEffect(() => {
@@ -857,8 +1046,9 @@ export function CommentThread({
     if (draftTimer.current) clearTimeout(draftTimer.current);
     draftTimer.current = setTimeout(() => {
       saveDraft(draftKey, body);
+      saveReplyDraft(draftKey, replyingTo);
     }, DRAFT_DEBOUNCE_MS);
-  }, [body, draftKey]);
+  }, [body, replyingTo, draftKey]);
 
   useEffect(() => {
     return () => {
@@ -907,12 +1097,17 @@ export function CommentThread({
       hasReassignment ? reassignTarget : currentAssigneeValue,
     ) ? true : undefined;
     const submittedBody = trimmed;
+    const submittedReply = replyingTo;
 
     setSubmitting(true);
     setBody("");
+    setReplyingTo(null);
     try {
-      await onAdd(submittedBody, reopen, reassignment ?? undefined);
-      if (draftKey) clearDraft(draftKey);
+      await onAdd(submittedBody, reopen, reassignment ?? undefined, submittedReply?.commentId ?? null);
+      if (draftKey) {
+        clearDraft(draftKey);
+        saveReplyDraft(draftKey, null);
+      }
       setReassignTarget(effectiveSuggestedAssigneeValue);
     } catch {
       setBody((current) =>
@@ -921,9 +1116,25 @@ export function CommentThread({
           submittedBody,
         }),
       );
+      // Restore the reply target too so a failed send can be retried with its quote intact.
+      setReplyingTo((current) => current ?? submittedReply);
       // Parent mutation handlers surface the failure and the draft is restored for retry.
     } finally {
       setSubmitting(false);
+    }
+  }
+
+  function clearReply() {
+    setReplyingTo(null);
+    if (draftKey) saveReplyDraft(draftKey, null);
+  }
+
+  function handleComposerKeyDown(evt: KeyboardEvent<HTMLDivElement>) {
+    // Escape clears the reply target only when the editor is empty (otherwise Escape is the
+    // editor's own concern, e.g. dismissing the mention menu).
+    if (evt.key === "Escape" && replyingTo && !body.trim()) {
+      evt.preventDefault();
+      clearReply();
     }
   }
 
@@ -982,6 +1193,9 @@ export function CommentThread({
         highlightCommentId={highlightCommentId}
         feedbackTermsUrl={feedbackTermsUrl}
         externalReferences={externalReferences}
+        onReply={handleReply}
+        onScrollToComment={scrollToComment}
+        deletedCommentIds={deletedCommentIds}
       />
 
       {liveRunSlot}
@@ -1015,6 +1229,12 @@ export function CommentThread({
                 highlightCommentId={highlightCommentId}
                 queued
                 externalReferences={externalReferences}
+                onScrollToComment={scrollToComment}
+                replyTargetDeleted={
+                  comment.metadata?.replyTo
+                    ? deletedCommentIds.has(comment.metadata.replyTo.commentId)
+                    : false
+                }
               />
             ))}
           </div>
@@ -1026,12 +1246,40 @@ export function CommentThread({
           {composerDisabledReason}
         </div>
       ) : (
-        <div className="space-y-2">
+        <div className="space-y-2" onKeyDown={handleComposerKeyDown}>
+          {replyingTo ? (
+            <div className="flex items-stretch gap-2 rounded-md border border-border bg-muted/40 py-1.5 pl-2 pr-1.5">
+              <span aria-hidden className="w-0.5 shrink-0 rounded-full bg-primary/60" />
+              <button
+                type="button"
+                onClick={() => scrollToComment(replyingTo.commentId)}
+                title="Jump to the original comment"
+                className="min-w-0 flex-1 text-left"
+              >
+                <span className="block text-xs font-medium text-foreground">
+                  Replying to {replyingTo.authorName}
+                </span>
+                <span className="mt-0.5 block truncate text-xs text-muted-foreground">
+                  {replyingTo.excerpt}
+                  {replyingTo.excerptTruncated ? "…" : ""}
+                </span>
+              </button>
+              <button
+                type="button"
+                onClick={clearReply}
+                title="Cancel reply"
+                aria-label="Cancel reply"
+                className="inline-flex h-6 w-6 shrink-0 items-center justify-center self-center rounded-md text-muted-foreground transition-colors hover:bg-accent/60 hover:text-foreground"
+              >
+                <X className="h-3.5 w-3.5" />
+              </button>
+            </div>
+          ) : null}
           <MarkdownEditor
             ref={editorRef}
             value={body}
             onChange={setBody}
-            placeholder="Leave a comment..."
+            placeholder={replyingTo ? `Reply to ${replyingTo.authorName}...` : "Leave a comment..."}
             mentions={mentions}
             onSubmit={handleSubmit}
             imageUploadHandler={imageUploadHandler}

--- a/ui/src/components/IssueChatThread.tsx
+++ b/ui/src/components/IssueChatThread.tsx
@@ -1592,19 +1592,6 @@ function IssueChatUserMessage({
   const isOptimistic = commentId.startsWith("optimistic-");
   const canReply = Boolean(onReply) && !deleted && !pending && !queued && !isOptimistic;
   const isHighlighted = Boolean(highlightCommentId && highlightCommentId === commentId);
-  const handleReply = () => {
-    const { excerpt, truncated } = buildReplyExcerpt(threadMessageText(message));
-    onReply?.({
-      commentId,
-      authorName: authorName ?? "You",
-      excerpt,
-      excerptTruncated: truncated,
-    });
-  };
-  const queueTargetRunId = typeof custom.queueTargetRunId === "string" ? custom.queueTargetRunId : null;
-  const [copied, setCopied] = useState(false);
-  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
-  const toastActions = useOptionalToastActions();
   const {
     isCurrentUser,
     authorName: resolvedAuthorName,
@@ -1615,6 +1602,21 @@ function IssueChatUserMessage({
     currentUserId,
     userProfileMap,
   });
+  const handleReply = () => {
+    const { excerpt, truncated } = buildReplyExcerpt(threadMessageText(message));
+    onReply?.({
+      commentId,
+      // Reuse the resolved bubble label so replying to another user shows their
+      // name (not "You") even when the message carries no custom.authorName.
+      authorName: resolvedAuthorName,
+      excerpt,
+      excerptTruncated: truncated,
+    });
+  };
+  const queueTargetRunId = typeof custom.queueTargetRunId === "string" ? custom.queueTargetRunId : null;
+  const [copied, setCopied] = useState(false);
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+  const toastActions = useOptionalToastActions();
   const authorAvatar = (
     <Avatar size="sm" className="shrink-0">
       {avatarUrl ? <AvatarImage src={avatarUrl} alt={resolvedAuthorName} /> : null}

--- a/ui/src/components/IssueChatThread.tsx
+++ b/ui/src/components/IssueChatThread.tsx
@@ -26,6 +26,7 @@ import {
   type DragEvent as ReactDragEvent,
   type ErrorInfo,
   type KeyboardEvent as ReactKeyboardEvent,
+  type MutableRefObject,
   type Ref,
   type ReactNode,
 } from "react";
@@ -40,9 +41,11 @@ import type {
   IssueRecoveryAction,
   IssueRelationIssueSummary,
   IssueScheduledRetry,
+  IssueCommentReplyToMetadata,
   SuccessfulRunHandoffState,
   IssueWorkMode,
 } from "@paperclipai/shared";
+import { buildReplyExcerpt, formatReplyAuthorName } from "../lib/comment-reply";
 import type { ActiveRunForIssue, LiveRunForIssue } from "../api/heartbeats";
 import { useLiveRunTranscripts } from "./transcript/useLiveRunTranscripts";
 import { usePaperclipIssueRuntime, type PaperclipIssueRuntimeReassignment } from "../hooks/usePaperclipIssueRuntime";
@@ -170,7 +173,7 @@ import { nextWorkMode, titleForPendingWorkMode, workModeMetaFor, workModeMetaLis
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Textarea } from "@/components/ui/textarea";
-import { AlertTriangle, ArrowRight, Brain, Check, ChevronDown, ClipboardList, Copy, Hammer, Loader2, MoreHorizontal, Paperclip, PauseCircle, Search, Square, ThumbsDown, ThumbsUp, Trash2 } from "lucide-react";
+import { AlertTriangle, ArrowRight, Brain, Check, ChevronDown, ClipboardList, Copy, Hammer, Loader2, MoreHorizontal, Paperclip, PauseCircle, Reply, Search, Square, ThumbsDown, ThumbsUp, Trash2, X } from "lucide-react";
 import { IssueBlockedNotice } from "./IssueBlockedNotice";
 import { IssueAssignedBacklogNotice } from "./IssueAssignedBacklogNotice";
 import {
@@ -200,6 +203,14 @@ interface IssueChatMessageContext {
   onInterruptQueued?: (runId: string) => Promise<void>;
   onCancelQueued?: (commentId: string) => void;
   onDeleteComment?: (commentId: string) => Promise<void> | void;
+  /** Start a composer reply targeting this comment (sets the chip + focuses the composer). */
+  onReply?: (target: ReplyDraftTarget) => void;
+  /** Scroll to and briefly highlight a comment by id (jump-to-original from a quoted block). */
+  onScrollToComment?: (commentId: string) => void;
+  /** Comment id currently highlighted after a jump-to-original, so its bubble can pulse. */
+  highlightCommentId?: string | null;
+  /** Soft-deleted comment ids, so a sent reply whose target was deleted shows a tombstone. */
+  deletedCommentIds?: ReadonlySet<string>;
   onImageClick?: (src: string) => void;
   onAcceptInteraction?: (
     interaction:
@@ -416,6 +427,12 @@ interface IssueChatComposerProps {
   issueStatus?: string;
   issueWorkMode?: IssueWorkMode;
   onWorkModeChange?: (workMode: IssueWorkMode) => Promise<void> | void;
+  /** Active reply target rendered as a composer chip; controlled by the parent thread. */
+  replyingTo?: ReplyDraftTarget | null;
+  /** Clear the active reply target (chip X button or Escape on an empty editor). */
+  onClearReply?: () => void;
+  /** Jump to the reply target's original comment when the chip is clicked. */
+  onScrollToComment?: (commentId: string) => void;
 }
 
 interface IssueChatThreadProps {
@@ -466,7 +483,12 @@ interface IssueChatThreadProps {
     vote: FeedbackVoteValue,
     options?: { allowSharing?: boolean; reason?: string },
   ) => Promise<void>;
-  onAdd: (body: string, reopen?: boolean, reassignment?: CommentReassignment) => Promise<void>;
+  onAdd: (
+    body: string,
+    reopen?: boolean,
+    reassignment?: CommentReassignment,
+    replyToCommentId?: string | null,
+  ) => Promise<void>;
   onCancelRun?: () => Promise<void>;
   onStopRun?: (runId: string) => Promise<void>;
   stopRunLabel?: string;
@@ -763,6 +785,135 @@ function clearDraft(draftKey: string) {
   } catch {
     // Ignore localStorage failures.
   }
+}
+
+/**
+ * The active reply target held by the composer. Self-contained (author + excerpt) so the chip
+ * renders without re-resolving the original comment, and survives a reload via localStorage.
+ * Mirrors the CommentThread reply draft shape so the two composers share the same persisted key.
+ */
+interface ReplyDraftTarget {
+  commentId: string;
+  authorName: string;
+  excerpt: string;
+  excerptTruncated: boolean;
+}
+
+function replyDraftStorageKey(draftKey: string) {
+  return `${draftKey}:reply`;
+}
+
+function loadReplyDraft(draftKey: string): ReplyDraftTarget | null {
+  try {
+    const raw = localStorage.getItem(replyDraftStorageKey(draftKey));
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Partial<ReplyDraftTarget>;
+    if (typeof parsed?.commentId !== "string" || typeof parsed?.excerpt !== "string") return null;
+    return {
+      commentId: parsed.commentId,
+      authorName: typeof parsed.authorName === "string" ? parsed.authorName : "comment",
+      excerpt: parsed.excerpt,
+      excerptTruncated: parsed.excerptTruncated === true,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function saveReplyDraft(draftKey: string, target: ReplyDraftTarget | null) {
+  try {
+    if (target) {
+      localStorage.setItem(replyDraftStorageKey(draftKey), JSON.stringify(target));
+    } else {
+      localStorage.removeItem(replyDraftStorageKey(draftKey));
+    }
+  } catch {
+    // Ignore localStorage failures.
+  }
+}
+
+/** Plain-text join of a thread message's text parts, used to seed a reply excerpt. */
+function threadMessageText(message: ThreadMessage): string {
+  return message.content
+    .filter((part): part is TextMessagePart => part.type === "text")
+    .map((part) => part.text)
+    .join("\n\n");
+}
+
+/** Hover-reveal reply affordance shown in a comment bubble's action row. */
+function IssueChatReplyButton({ onClick }: { onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      title="Reply"
+      aria-label="Reply to comment"
+      className="inline-flex h-6 w-6 items-center justify-center text-muted-foreground transition-colors hover:text-foreground"
+    >
+      <Reply className="h-3.5 w-3.5" />
+      <span className="sr-only">Reply</span>
+    </button>
+  );
+}
+
+/**
+ * Compact quoted header rendered above a sent reply's body (accent bar + author + excerpt).
+ * `onAccent` adapts the treatment for the human's blue bubble; a deleted target shows a tombstone.
+ */
+function IssueChatReplyQuote({
+  replyTo,
+  agentMap,
+  targetDeleted,
+  onAccent,
+  onClick,
+}: {
+  replyTo: IssueCommentReplyToMetadata;
+  agentMap?: Map<string, Agent>;
+  targetDeleted: boolean;
+  onAccent?: boolean;
+  onClick?: () => void;
+}) {
+  const authorName = formatReplyAuthorName(replyTo, agentMap);
+  const barClass = onAccent ? "bg-white/60" : "bg-primary/40";
+  const authorClass = onAccent ? "text-white" : "text-foreground";
+  const excerptClass = onAccent ? "text-white/80" : "text-muted-foreground";
+  const surfaceClass = onAccent ? "bg-white/15" : "bg-muted/40";
+  const body = (
+    <span className="flex min-w-0 items-stretch gap-2">
+      <span aria-hidden className={cn("w-0.5 shrink-0 rounded-full", barClass)} />
+      <span className="min-w-0 flex-1 py-0.5 text-xs">
+        {targetDeleted ? (
+          <span className={cn("italic", excerptClass)}>Original comment deleted</span>
+        ) : (
+          <>
+            <span className={cn("font-medium", authorClass)}>{authorName}</span>{" "}
+            <span className={cn("line-clamp-2 align-baseline", excerptClass)}>
+              {replyTo.excerpt}
+              {replyTo.excerptTruncated ? "…" : ""}
+            </span>
+          </>
+        )}
+      </span>
+    </span>
+  );
+
+  if (targetDeleted || !onClick) {
+    return <div className={cn("mb-1.5 rounded-sm px-2 py-1", surfaceClass)}>{body}</div>;
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      title="Jump to the original comment"
+      className={cn(
+        "mb-1.5 block w-full rounded-sm px-2 py-1 text-left transition-colors",
+        onAccent ? "bg-white/15 hover:bg-white/25" : "bg-muted/40 hover:bg-muted/70",
+      )}
+    >
+      {body}
+    </button>
+  );
 }
 
 function parseReassignment(target: string): PaperclipIssueRuntimeReassignment | null {
@@ -1414,10 +1565,17 @@ function IssueChatUserMessage({
     onDeleteComment,
     currentUserId,
     userProfileMap,
+    agentMap,
+    onReply,
+    onScrollToComment,
+    highlightCommentId,
+    deletedCommentIds,
   } = useContext(IssueChatCtx);
   const custom = message.metadata.custom as Record<string, unknown>;
   const anchorId = typeof custom.anchorId === "string" ? custom.anchorId : undefined;
   const commentId = typeof custom.commentId === "string" ? custom.commentId : message.id;
+  const commentMetadata = isIssueCommentMetadata(custom.commentMetadata) ? custom.commentMetadata : null;
+  const replyTo = commentMetadata?.replyTo ?? null;
   const authorName = typeof custom.authorName === "string" ? custom.authorName : null;
   const authorUserId = typeof custom.authorUserId === "string" ? custom.authorUserId : null;
   const queued = custom.queueState === "queued" || custom.clientStatus === "queued";
@@ -1427,6 +1585,18 @@ function IssueChatUserMessage({
   const queueBadgeLabel = queueReason === "hold" ? "\u23f8 Deferred wake" : "Queued";
   const pending = custom.clientStatus === "pending";
   const deleted = Boolean(custom.deletedAt);
+  const isOptimistic = commentId.startsWith("optimistic-");
+  const canReply = Boolean(onReply) && !deleted && !pending && !queued && !isOptimistic;
+  const isHighlighted = Boolean(highlightCommentId && highlightCommentId === commentId);
+  const handleReply = () => {
+    const { excerpt, truncated } = buildReplyExcerpt(threadMessageText(message));
+    onReply?.({
+      commentId,
+      authorName: authorName ?? "You",
+      excerpt,
+      excerptTruncated: truncated,
+    });
+  };
   const queueTargetRunId = typeof custom.queueTargetRunId === "string" ? custom.queueTargetRunId : null;
   const [copied, setCopied] = useState(false);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
@@ -1518,6 +1688,15 @@ function IssueChatUserMessage({
           <div className="text-sm italic text-muted-foreground">Comment deleted</div>
         ) : (
           <div className="min-w-0 max-w-full space-y-3">
+            {replyTo ? (
+              <IssueChatReplyQuote
+                replyTo={replyTo}
+                agentMap={agentMap}
+                targetDeleted={deletedCommentIds?.has(replyTo.commentId) ?? false}
+                onAccent={isCurrentUser && !queued}
+                onClick={onScrollToComment ? () => onScrollToComment(replyTo.commentId) : undefined}
+              />
+            ) : null}
             <IssueChatTextParts message={message} onAccent={isCurrentUser && !queued} />
           </div>
         )}
@@ -1573,6 +1752,7 @@ function IssueChatUserMessage({
               {copied ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
             </button>
           ) : null}
+          {canReply ? <IssueChatReplyButton onClick={handleReply} /> : null}
           {canDeleteComment ? (
             <button
               type="button"
@@ -1591,7 +1771,13 @@ function IssueChatUserMessage({
 
   return (
     <>
-      <div id={anchorId}>
+      <div
+        id={anchorId}
+        className={cn(
+          "rounded-2xl transition-colors duration-1000",
+          isHighlighted && "bg-primary/10 ring-2 ring-primary/40",
+        )}
+      >
         <div className={cn("group flex items-end gap-2", isCurrentUser && "justify-end")}>
           {isCurrentUser ? (
             <>
@@ -1649,9 +1835,15 @@ function IssueChatAssistantMessage({
     stoppingRunLabel = "Stopping...",
     stopRunVariant = "stop",
     runFinalizationActions = [],
+    onReply,
+    onScrollToComment,
+    highlightCommentId,
+    deletedCommentIds,
   } = useContext(IssueChatCtx);
   const custom = message.metadata.custom as Record<string, unknown>;
   const anchorId = typeof custom.anchorId === "string" ? custom.anchorId : undefined;
+  const commentMetadata = isIssueCommentMetadata(custom.commentMetadata) ? custom.commentMetadata : null;
+  const replyTo = commentMetadata?.replyTo ?? null;
   const authorName = typeof custom.authorName === "string"
     ? custom.authorName
     : typeof custom.runAgentName === "string"
@@ -1720,6 +1912,20 @@ function IssueChatAssistantMessage({
   const isGenuineComment =
     kind === "comment" && !!commentId && !isRunning && (hasCommentText || deleted);
 
+  const isOptimistic = commentId?.startsWith("optimistic-") ?? false;
+  const canReply = Boolean(onReply) && isGenuineComment && !!commentId && !deleted && !isOptimistic;
+  const isHighlighted = Boolean(highlightCommentId && commentId && highlightCommentId === commentId);
+  const handleReply = () => {
+    if (!commentId) return;
+    const { excerpt, truncated } = buildReplyExcerpt(threadMessageText(message));
+    onReply?.({
+      commentId,
+      authorName,
+      excerpt,
+      excerptTruncated: truncated,
+    });
+  };
+
   const agentAvatar = (
     <Avatar size="sm" className="shrink-0">
       {agentIcon ? (
@@ -1760,6 +1966,7 @@ function IssueChatAssistantMessage({
           onVote={handleVote}
         />
       ) : null}
+      {canReply ? <IssueChatReplyButton onClick={handleReply} /> : null}
       <Tooltip>
         <TooltipTrigger asChild>
           <a
@@ -1837,7 +2044,13 @@ function IssueChatAssistantMessage({
   // blue bubble in IssueChatUserMessage). See PAP-95 rev 6.
   if (isGenuineComment) {
     return (
-      <div id={anchorId}>
+      <div
+        id={anchorId}
+        className={cn(
+          "rounded-2xl transition-colors duration-1000",
+          isHighlighted && "bg-primary/10 ring-2 ring-primary/40",
+        )}
+      >
         <div className="group flex flex-col items-start py-1.5">
           {/* Icon + name together in a header ABOVE the bubble (PAP-95 rev 7). */}
           <div className="mb-1 flex items-center gap-1.5 px-1">
@@ -1872,6 +2085,14 @@ function IssueChatAssistantMessage({
               <div className="text-sm italic text-muted-foreground">Comment deleted</div>
             ) : (
               <div className="min-w-0 max-w-full space-y-3">
+                {replyTo ? (
+                  <IssueChatReplyQuote
+                    replyTo={replyTo}
+                    agentMap={agentMap}
+                    targetDeleted={deletedCommentIds?.has(replyTo.commentId) ?? false}
+                    onClick={onScrollToComment ? () => onScrollToComment(replyTo.commentId) : undefined}
+                  />
+                ) : null}
                 <IssueChatAssistantParts message={message} hasCoT={false} />
                 {notices.length > 0 ? (
                   <div className="space-y-2">
@@ -3540,6 +3761,9 @@ const IssueChatComposer = forwardRef<IssueChatComposerHandle, IssueChatComposerP
   issueStatus,
   issueWorkMode,
   onWorkModeChange,
+  replyingTo = null,
+  onClearReply,
+  onScrollToComment,
 }, forwardedRef) {
   const api = useAui();
   const [body, setBody] = useState("");
@@ -3585,6 +3809,17 @@ const IssueChatComposer = forwardRef<IssueChatComposerHandle, IssueChatComposerP
     if (!draftKey) return;
     setBody(loadDraft(draftKey));
   }, [draftKey]);
+
+  // Focus the editor when a reply target is newly selected (e.g. the user clicked Reply on a
+  // bubble). The first run is skipped so a reply draft rehydrated on load does not steal focus.
+  const previousReplyCommentIdRef = useRef<string | null>(replyingTo?.commentId ?? null);
+  useEffect(() => {
+    const nextReplyCommentId = replyingTo?.commentId ?? null;
+    if (nextReplyCommentId && nextReplyCommentId !== previousReplyCommentIdRef.current) {
+      editorRef.current?.focus();
+    }
+    previousReplyCommentIdRef.current = nextReplyCommentId;
+  }, [replyingTo?.commentId]);
 
   useEffect(() => {
     if (!draftKey) return;
@@ -3645,6 +3880,10 @@ const IssueChatComposer = forwardRef<IssueChatComposerHandle, IssueChatComposerP
       hasReassignment ? reassignTarget : currentAssigneeValue,
     ) ? true : undefined;
     const submittedBody = trimmed;
+    // An explicit reassignment goes through PATCH /issues, which cannot carry comment metadata,
+    // so a reply target cannot compose with a reassign under the current contract (the upstream
+    // handler drops it). Only forward the reply id on the plain comment path.
+    const replyToCommentId = !reassignment ? replyingTo?.commentId ?? null : null;
     const viewportSnapshot = captureComposerViewportSnapshot(composerContainerRef.current);
 
     const workModeChanged = pendingWorkMode !== resolvedIssueWorkMode;
@@ -3663,12 +3902,14 @@ const IssueChatComposer = forwardRef<IssueChatComposerHandle, IssueChatComposerP
           custom: {
             ...(reopen ? { reopen: true } : {}),
             ...(reassignment ? { reassignment } : {}),
+            ...(replyToCommentId ? { replyToCommentId } : {}),
           },
         },
       });
       queueViewportRestore(viewportSnapshot);
       await appendPromise;
       if (draftKey) clearDraft(draftKey);
+      onClearReply?.();
       setComposerAttachments([]);
       setReassignTarget(effectiveSuggestedAssigneeValue);
     } catch {
@@ -3877,6 +4118,13 @@ const IssueChatComposer = forwardRef<IssueChatComposerHandle, IssueChatComposerP
   const PendingWorkModeIcon = pendingWorkModeMeta.icon;
 
   function handleComposerKeyDown(evt: ReactKeyboardEvent<HTMLDivElement>) {
+    // Escape clears the reply target, but only when the editor is empty so it does not swallow
+    // the editor's own Escape (e.g. dismissing the mention menu) while the user is typing.
+    if (evt.key === "Escape" && replyingTo && !body.trim()) {
+      evt.preventDefault();
+      onClearReply?.();
+      return;
+    }
     // Match the period via both `code` and `key`: iOS Safari with a hardware
     // keyboard often leaves `code` empty for cmd-period, so relying on it alone
     // lets the event fall through and triggers Safari's default cancel/dismiss
@@ -3923,11 +4171,43 @@ const IssueChatComposer = forwardRef<IssueChatComposerHandle, IssueChatComposerP
         </div>
       ) : null}
 
+      {replyingTo ? (
+        <div
+          data-testid="issue-chat-composer-reply-chip"
+          className="mb-2 flex items-stretch gap-2 rounded-md border border-border bg-muted/40 py-1.5 pl-2 pr-1.5"
+        >
+          <span aria-hidden className="w-0.5 shrink-0 rounded-full bg-primary/60" />
+          <button
+            type="button"
+            onClick={() => onScrollToComment?.(replyingTo.commentId)}
+            title="Jump to the original comment"
+            className="min-w-0 flex-1 text-left"
+          >
+            <span className="block text-xs font-medium text-foreground">
+              Replying to {replyingTo.authorName}
+            </span>
+            <span className="mt-0.5 block truncate text-xs text-muted-foreground">
+              {replyingTo.excerpt}
+              {replyingTo.excerptTruncated ? "…" : ""}
+            </span>
+          </button>
+          <button
+            type="button"
+            onClick={() => onClearReply?.()}
+            title="Cancel reply"
+            aria-label="Cancel reply"
+            className="inline-flex h-6 w-6 shrink-0 items-center justify-center self-center rounded-md text-muted-foreground transition-colors hover:bg-accent/60 hover:text-foreground"
+          >
+            <X className="h-3.5 w-3.5" />
+          </button>
+        </div>
+      ) : null}
+
       <MarkdownEditor
         ref={editorRef}
         value={body}
         onChange={setBody}
-        placeholder="Reply"
+        placeholder={replyingTo ? `Reply to ${replyingTo.authorName}...` : "Reply"}
         mentions={mentions}
         onSubmit={handleSubmit}
         imageUploadHandler={onImageUpload}
@@ -4459,12 +4739,72 @@ export function IssueChatThread({
     return true;
   }
 
+  // --- Reply-to-comment composer state (P3, PAP-13802) ---
+  const [replyingTo, setReplyingTo] = useState<ReplyDraftTarget | null>(null);
+  const [highlightCommentId, setHighlightCommentId] = useState<string | null>(null);
+  const highlightTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Soft-deleted comment ids, so a sent reply whose target was deleted shows a tombstone.
+  const deletedCommentIds = useMemo(() => {
+    const ids = new Set<string>();
+    for (const message of messages) {
+      const custom = message.metadata?.custom as Record<string, unknown> | undefined;
+      if (custom?.deletedAt && typeof custom.commentId === "string") {
+        ids.add(custom.commentId);
+      }
+    }
+    return ids;
+  }, [messages]);
+
+  // Load/persist the reply draft alongside the text draft so a reload keeps the pending reply.
+  useEffect(() => {
+    if (!draftKey) return;
+    setReplyingTo(loadReplyDraft(draftKey));
+  }, [draftKey]);
+  useEffect(() => {
+    if (!draftKey) return;
+    saveReplyDraft(draftKey, replyingTo);
+  }, [draftKey, replyingTo]);
+  useEffect(() => () => {
+    if (highlightTimerRef.current) clearTimeout(highlightTimerRef.current);
+  }, []);
+
+  // Merge the parent-provided composer ref with an internal one so a bubble's Reply button can
+  // focus the composer without the parent having to thread focus back down.
+  const internalComposerRef = useRef<IssueChatComposerHandle | null>(null);
+  const setComposerRef = useCallback((handle: IssueChatComposerHandle | null) => {
+    internalComposerRef.current = handle;
+    if (typeof composerRef === "function") composerRef(handle);
+    else if (composerRef) (composerRef as MutableRefObject<IssueChatComposerHandle | null>).current = handle;
+  }, [composerRef]);
+
+  const scrollAndHighlightComment = useStableEvent((commentId: string) => {
+    const found = scrollToThreadAnchor(`comment-${commentId}`, { align: "center" });
+    if (found === false) return;
+    setHighlightCommentId(commentId);
+    if (highlightTimerRef.current) clearTimeout(highlightTimerRef.current);
+    highlightTimerRef.current = setTimeout(() => {
+      setHighlightCommentId((current) => (current === commentId ? null : current));
+    }, 3000);
+  });
+
+  const handleRequestReply = useStableEvent((target: ReplyDraftTarget) => {
+    setReplyingTo(target);
+    // The composer also focuses on target change; focus here too so a repeat reply on the same
+    // comment (target unchanged) still brings the composer into view.
+    internalComposerRef.current?.focus();
+  });
+
+  const clearReply = useStableEvent(() => {
+    setReplyingTo(null);
+  });
+
   const runtime = usePaperclipIssueRuntime({
     messages,
     isRunning,
-    onSend: ({ body, reopen, reassignment }) => {
+    onSend: ({ body, reopen, reassignment, replyToCommentId }) => {
       pendingSubmitScrollRef.current = true;
-      return onAdd(body, reopen, reassignment);
+      return onAdd(body, reopen, reassignment, replyToCommentId);
     },
     onCancel: onCancelRun,
   });
@@ -4801,6 +5141,10 @@ export function IssueChatThread({
       onInterruptQueued: stableOnInterruptQueued,
       onCancelQueued: stableOnCancelQueued,
       onDeleteComment: stableOnDeleteComment,
+      onReply: handleRequestReply,
+      onScrollToComment: scrollAndHighlightComment,
+      highlightCommentId,
+      deletedCommentIds,
       onImageClick: stableOnImageClick,
       onAcceptInteraction: stableOnAcceptInteraction,
       onRejectInteraction: stableOnRejectInteraction,
@@ -4829,6 +5173,10 @@ export function IssueChatThread({
       stableOnInterruptQueued,
       stableOnCancelQueued,
       stableOnDeleteComment,
+      handleRequestReply,
+      scrollAndHighlightComment,
+      highlightCommentId,
+      deletedCommentIds,
       stableOnImageClick,
       stableOnAcceptInteraction,
       stableOnRejectInteraction,
@@ -5011,7 +5359,7 @@ export function IssueChatThread({
             className="sticky bottom-(--sz-calc-8) z-20 space-y-2 bg-gradient-to-t from-background via-background/95 to-background/0 pt-6"
           >
             <IssueChatComposer
-              ref={composerRef}
+              ref={setComposerRef}
               onImageUpload={imageUploadHandler}
               onAttachImage={onAttachImage}
               draftKey={draftKey}
@@ -5029,6 +5377,9 @@ export function IssueChatThread({
               issueStatus={issueStatus}
               issueWorkMode={issueWorkMode}
               onWorkModeChange={onWorkModeChange}
+              replyingTo={replyingTo}
+              onClearReply={clearReply}
+              onScrollToComment={scrollAndHighlightComment}
             />
           </div>
         ) : null}

--- a/ui/src/components/IssueChatThread.tsx
+++ b/ui/src/components/IssueChatThread.tsx
@@ -863,17 +863,21 @@ function IssueChatReplyButton({ onClick }: { onClick: () => void }) {
 function IssueChatReplyQuote({
   replyTo,
   agentMap,
+  currentUserId,
+  userProfileMap,
   targetDeleted,
   onAccent,
   onClick,
 }: {
   replyTo: IssueCommentReplyToMetadata;
   agentMap?: Map<string, Agent>;
+  currentUserId?: string | null;
+  userProfileMap?: ReadonlyMap<string, CompanyUserProfile> | null;
   targetDeleted: boolean;
   onAccent?: boolean;
   onClick?: () => void;
 }) {
-  const authorName = formatReplyAuthorName(replyTo, agentMap);
+  const authorName = formatReplyAuthorName(replyTo, { agentMap, currentUserId, userProfileMap });
   const barClass = onAccent ? "bg-white/60" : "bg-primary/40";
   const authorClass = onAccent ? "text-white" : "text-foreground";
   const excerptClass = onAccent ? "text-white/80" : "text-muted-foreground";
@@ -1692,6 +1696,8 @@ function IssueChatUserMessage({
               <IssueChatReplyQuote
                 replyTo={replyTo}
                 agentMap={agentMap}
+                currentUserId={currentUserId}
+                userProfileMap={userProfileMap}
                 targetDeleted={deletedCommentIds?.has(replyTo.commentId) ?? false}
                 onAccent={isCurrentUser && !queued}
                 onClick={onScrollToComment ? () => onScrollToComment(replyTo.commentId) : undefined}
@@ -1835,6 +1841,8 @@ function IssueChatAssistantMessage({
     stoppingRunLabel = "Stopping...",
     stopRunVariant = "stop",
     runFinalizationActions = [],
+    currentUserId,
+    userProfileMap,
     onReply,
     onScrollToComment,
     highlightCommentId,
@@ -2089,6 +2097,8 @@ function IssueChatAssistantMessage({
                   <IssueChatReplyQuote
                     replyTo={replyTo}
                     agentMap={agentMap}
+                    currentUserId={currentUserId}
+                    userProfileMap={userProfileMap}
                     targetDeleted={deletedCommentIds?.has(replyTo.commentId) ?? false}
                     onClick={onScrollToComment ? () => onScrollToComment(replyTo.commentId) : undefined}
                   />
@@ -4739,7 +4749,7 @@ export function IssueChatThread({
     return true;
   }
 
-  // --- Reply-to-comment composer state (P3, PAP-13802) ---
+  // --- Reply-to-comment composer state ---
   const [replyingTo, setReplyingTo] = useState<ReplyDraftTarget | null>(null);
   const [highlightCommentId, setHighlightCommentId] = useState<string | null>(null);
   const highlightTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -4749,8 +4759,11 @@ export function IssueChatThread({
     const ids = new Set<string>();
     for (const message of messages) {
       const custom = message.metadata?.custom as Record<string, unknown> | undefined;
-      if (custom?.deletedAt && typeof custom.commentId === "string") {
-        ids.add(custom.commentId);
+      if (custom?.deletedAt) {
+        // Match the comment-id fallback used when rendering the message, so a deleted source
+        // without an explicit custom.commentId still marks its replies as tombstoned.
+        const commentId = typeof custom.commentId === "string" ? custom.commentId : message.id;
+        ids.add(commentId);
       }
     }
     return ids;

--- a/ui/src/fixtures/issueChatUxFixtures.ts
+++ b/ui/src/fixtures/issueChatUxFixtures.ts
@@ -338,6 +338,75 @@ export const issueChatUxReviewEvents: IssueTimelineEvent[] = [
   },
 ];
 
+/**
+ * Reply-to-comment (PAP-13802 P3) scenario: a sent reply with a quoted block, a reply whose
+ * source was deleted (tombstone), and the source comments they point back to. Seed
+ * {@link issueChatUxReplyDraftKey} in localStorage to also render the composer reply chip.
+ */
+export const issueChatUxReplyDraftKey = "paperclip:issue-comment-draft:issue-ux-reply";
+
+export const issueChatUxReplyComments: IssueChatComment[] = [
+  createComment({
+    id: "comment-reply-source",
+    authorAgentId: primaryAgent.id,
+    authorUserId: null,
+    body: "I moved the composer reply chip above the editor and clamp the quoted source to 200 chars so long comments stay one line.",
+    createdAt: new Date("2026-04-06T13:00:00.000Z"),
+    updatedAt: new Date("2026-04-06T13:00:00.000Z"),
+    runId: "run-reply-1",
+    runAgentId: primaryAgent.id,
+  }),
+  createComment({
+    id: "comment-reply-sent",
+    body: "Nice — can you make the quoted block jump to the original when clicked?",
+    createdAt: new Date("2026-04-06T13:02:00.000Z"),
+    updatedAt: new Date("2026-04-06T13:02:00.000Z"),
+    metadata: {
+      version: 1,
+      sections: [],
+      replyTo: {
+        commentId: "comment-reply-source",
+        authorType: "agent",
+        authorAgentId: primaryAgent.id,
+        authorUserId: null,
+        excerpt: "I moved the composer reply chip above the editor and clamp the quoted source to 200 chars so long comments stay one line.",
+        excerptTruncated: true,
+      },
+    },
+  }),
+  createComment({
+    id: "comment-reply-deleted-source",
+    body: "This source comment was removed after the reply was posted.",
+    createdAt: new Date("2026-04-06T13:04:00.000Z"),
+    updatedAt: new Date("2026-04-06T13:04:30.000Z"),
+    deletedAt: new Date("2026-04-06T13:05:00.000Z"),
+    deletedByType: "user",
+    deletedByUserId: "user-1",
+  }),
+  createComment({
+    id: "comment-reply-tombstone",
+    authorAgentId: reviewAgent.id,
+    authorUserId: null,
+    body: "Done — and when the source is deleted the quoted header falls back to a tombstone.",
+    createdAt: new Date("2026-04-06T13:06:00.000Z"),
+    updatedAt: new Date("2026-04-06T13:06:00.000Z"),
+    runId: "run-reply-2",
+    runAgentId: reviewAgent.id,
+    metadata: {
+      version: 1,
+      sections: [],
+      replyTo: {
+        commentId: "comment-reply-deleted-source",
+        authorType: "user",
+        authorAgentId: null,
+        authorUserId: "user-1",
+        excerpt: "This source comment was removed after the reply was posted.",
+        excerptTruncated: false,
+      },
+    },
+  }),
+];
+
 export const issueChatUxFeedbackVotes: FeedbackVote[] = [
   {
     id: "feedback-1",

--- a/ui/src/fixtures/issueChatUxFixtures.ts
+++ b/ui/src/fixtures/issueChatUxFixtures.ts
@@ -339,7 +339,7 @@ export const issueChatUxReviewEvents: IssueTimelineEvent[] = [
 ];
 
 /**
- * Reply-to-comment (PAP-13802 P3) scenario: a sent reply with a quoted block, a reply whose
+ * Reply-to-comment scenario: a sent reply with a quoted block, a reply whose
  * source was deleted (tombstone), and the source comments they point back to. Seed
  * {@link issueChatUxReplyDraftKey} in localStorage to also render the composer reply chip.
  */

--- a/ui/src/hooks/usePaperclipIssueRuntime.ts
+++ b/ui/src/hooks/usePaperclipIssueRuntime.ts
@@ -15,6 +15,7 @@ export interface PaperclipIssueRuntimeSendOptions {
   body: string;
   reopen?: boolean;
   reassignment?: PaperclipIssueRuntimeReassignment;
+  replyToCommentId?: string | null;
 }
 
 interface UsePaperclipIssueRuntimeOptions {
@@ -74,10 +75,14 @@ export function usePaperclipIssueRuntime({
             }
           : undefined;
 
+      const replyToCommentId =
+        typeof custom?.replyToCommentId === "string" && custom.replyToCommentId ? custom.replyToCommentId : null;
+
       await onSendRef.current({
         body,
         reopen: custom?.reopen === true ? true : undefined,
         reassignment,
+        replyToCommentId,
       });
     },
     ...(onCancel ? {

--- a/ui/src/lib/comment-reply.test.ts
+++ b/ui/src/lib/comment-reply.test.ts
@@ -1,0 +1,116 @@
+import type { Agent, IssueComment } from "@paperclipai/shared";
+import { describe, expect, it } from "vitest";
+import {
+  REPLY_EXCERPT_MAX_LENGTH,
+  buildOptimisticReplyTo,
+  buildReplyExcerpt,
+  formatReplyAuthorName,
+} from "./comment-reply";
+
+function makeComment(overrides: Partial<IssueComment> = {}): IssueComment {
+  const now = new Date("2026-04-06T13:00:00.000Z");
+  return {
+    id: "comment-1",
+    companyId: "company-1",
+    issueId: "issue-1",
+    authorType: "agent",
+    authorAgentId: "agent-1",
+    authorUserId: null,
+    body: "Hello there",
+    presentation: null,
+    metadata: null,
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  };
+}
+
+describe("buildReplyExcerpt", () => {
+  it("collapses runs of whitespace and newlines into a single line", () => {
+    const { excerpt, truncated } = buildReplyExcerpt("  line one\n\n  line   two\t");
+    expect(excerpt).toBe("line one line two");
+    expect(truncated).toBe(false);
+  });
+
+  it("does not truncate a body at exactly the max length", () => {
+    const body = "a".repeat(REPLY_EXCERPT_MAX_LENGTH);
+    const { excerpt, truncated } = buildReplyExcerpt(body);
+    expect(excerpt).toHaveLength(REPLY_EXCERPT_MAX_LENGTH);
+    expect(truncated).toBe(false);
+  });
+
+  it("clamps and flags a body longer than the max length", () => {
+    const body = "b".repeat(REPLY_EXCERPT_MAX_LENGTH + 50);
+    const { excerpt, truncated } = buildReplyExcerpt(body);
+    expect(excerpt).toHaveLength(REPLY_EXCERPT_MAX_LENGTH);
+    expect(truncated).toBe(true);
+  });
+
+  it("trims trailing whitespace left at the clamp boundary", () => {
+    const body = `${"word ".repeat(60)}`; // well over the limit, boundary lands on a space
+    const { excerpt } = buildReplyExcerpt(body);
+    expect(excerpt.length).toBeLessThanOrEqual(REPLY_EXCERPT_MAX_LENGTH);
+    expect(excerpt).toBe(excerpt.trimEnd());
+  });
+});
+
+describe("buildOptimisticReplyTo", () => {
+  it("mirrors the target's identity and a clamped excerpt", () => {
+    const target = makeComment({
+      id: "comment-src",
+      authorType: "agent",
+      authorAgentId: "agent-7",
+      authorUserId: null,
+      body: "c".repeat(REPLY_EXCERPT_MAX_LENGTH + 10),
+    });
+    const snapshot = buildOptimisticReplyTo(target);
+    expect(snapshot).toEqual({
+      commentId: "comment-src",
+      authorType: "agent",
+      authorAgentId: "agent-7",
+      authorUserId: null,
+      excerpt: "c".repeat(REPLY_EXCERPT_MAX_LENGTH),
+      excerptTruncated: true,
+    });
+  });
+
+  it("normalizes undefined author ids to null for a user comment", () => {
+    const target = makeComment({
+      id: "comment-user",
+      authorType: "user",
+      authorAgentId: undefined as unknown as string | null,
+      authorUserId: "user-9",
+      body: "short",
+    });
+    const snapshot = buildOptimisticReplyTo(target);
+    expect(snapshot.authorAgentId).toBeNull();
+    expect(snapshot.authorUserId).toBe("user-9");
+    expect(snapshot.excerptTruncated).toBe(false);
+  });
+});
+
+describe("formatReplyAuthorName", () => {
+  const agentMap = new Map<string, Agent>([
+    ["agent-1", { id: "agent-1", name: "CodexCoder" } as Agent],
+  ]);
+
+  it("uses the agent name when the target is an agent in the map", () => {
+    expect(
+      formatReplyAuthorName({ authorType: "agent", authorAgentId: "agent-1" }, agentMap),
+    ).toBe("CodexCoder");
+  });
+
+  it("falls back to a short agent id when the agent is unknown", () => {
+    expect(
+      formatReplyAuthorName({ authorType: "agent", authorAgentId: "agent-abcdef123" }, agentMap),
+    ).toBe("agent-ab");
+  });
+
+  it("labels system authors as System", () => {
+    expect(formatReplyAuthorName({ authorType: "system", authorAgentId: null })).toBe("System");
+  });
+
+  it("labels user authors as You", () => {
+    expect(formatReplyAuthorName({ authorType: "user", authorAgentId: null })).toBe("You");
+  });
+});

--- a/ui/src/lib/comment-reply.test.ts
+++ b/ui/src/lib/comment-reply.test.ts
@@ -96,21 +96,59 @@ describe("formatReplyAuthorName", () => {
 
   it("uses the agent name when the target is an agent in the map", () => {
     expect(
-      formatReplyAuthorName({ authorType: "agent", authorAgentId: "agent-1" }, agentMap),
+      formatReplyAuthorName({ authorType: "agent", authorAgentId: "agent-1", authorUserId: null }, { agentMap }),
     ).toBe("CodexCoder");
   });
 
   it("falls back to a short agent id when the agent is unknown", () => {
     expect(
-      formatReplyAuthorName({ authorType: "agent", authorAgentId: "agent-abcdef123" }, agentMap),
+      formatReplyAuthorName(
+        { authorType: "agent", authorAgentId: "agent-abcdef123", authorUserId: null },
+        { agentMap },
+      ),
     ).toBe("agent-ab");
   });
 
   it("labels system authors as System", () => {
-    expect(formatReplyAuthorName({ authorType: "system", authorAgentId: null })).toBe("System");
+    expect(
+      formatReplyAuthorName({ authorType: "system", authorAgentId: null, authorUserId: null }),
+    ).toBe("System");
   });
 
-  it("labels user authors as You", () => {
-    expect(formatReplyAuthorName({ authorType: "user", authorAgentId: null })).toBe("You");
+  it("labels the current user's own comment as You", () => {
+    expect(
+      formatReplyAuthorName(
+        { authorType: "user", authorAgentId: null, authorUserId: "user-1" },
+        { currentUserId: "user-1" },
+      ),
+    ).toBe("You");
+  });
+
+  it("resolves another user's profile label instead of mislabeling them You", () => {
+    const userProfileMap = new Map([["user-2", { label: "Ada Lovelace", image: null }]]);
+    expect(
+      formatReplyAuthorName(
+        { authorType: "user", authorAgentId: null, authorUserId: "user-2" },
+        { currentUserId: "user-1", userProfileMap },
+      ),
+    ).toBe("Ada Lovelace");
+  });
+
+  it("labels another user without a profile as User (never You)", () => {
+    expect(
+      formatReplyAuthorName(
+        { authorType: "user", authorAgentId: null, authorUserId: "user-2" },
+        { currentUserId: "user-1" },
+      ),
+    ).toBe("User");
+  });
+
+  it("labels the board principal as Board", () => {
+    expect(
+      formatReplyAuthorName(
+        { authorType: "user", authorAgentId: null, authorUserId: "local-board" },
+        { currentUserId: "user-1" },
+      ),
+    ).toBe("Board");
   });
 });

--- a/ui/src/lib/comment-reply.ts
+++ b/ui/src/lib/comment-reply.ts
@@ -1,0 +1,47 @@
+import type { Agent, IssueComment, IssueCommentReplyToMetadata } from "@paperclipai/shared";
+
+/**
+ * Max characters shown in a reply excerpt (composer chip + sent quoted header).
+ * Mirrors the server-authored snapshot length so optimistic and persisted quotes match.
+ */
+export const REPLY_EXCERPT_MAX_LENGTH = 200;
+
+/** Collapse markdown/whitespace into a single-line excerpt clamped to {@link REPLY_EXCERPT_MAX_LENGTH}. */
+export function buildReplyExcerpt(body: string): { excerpt: string; truncated: boolean } {
+  const normalized = body.replace(/\s+/g, " ").trim();
+  if (normalized.length <= REPLY_EXCERPT_MAX_LENGTH) {
+    return { excerpt: normalized, truncated: false };
+  }
+  return { excerpt: normalized.slice(0, REPLY_EXCERPT_MAX_LENGTH).trimEnd(), truncated: true };
+}
+
+/**
+ * Build the reply snapshot the server will also produce, so the sent quote renders immediately
+ * (optimistic update) and stays consistent after the authoritative refetch.
+ */
+export function buildOptimisticReplyTo(target: IssueComment): IssueCommentReplyToMetadata {
+  const { excerpt, truncated } = buildReplyExcerpt(target.body);
+  return {
+    commentId: target.id,
+    authorType: target.authorType,
+    authorAgentId: target.authorAgentId ?? null,
+    authorUserId: target.authorUserId ?? null,
+    excerpt,
+    excerptTruncated: truncated,
+  };
+}
+
+/**
+ * Human-readable author label for a reply target. Mirrors {@link CommentCard}'s author rendering:
+ * agent comments show the agent name, everything else collapses to "You".
+ */
+export function formatReplyAuthorName(
+  replyTo: Pick<IssueCommentReplyToMetadata, "authorType" | "authorAgentId">,
+  agentMap?: Map<string, Agent>,
+): string {
+  if (replyTo.authorAgentId) {
+    return agentMap?.get(replyTo.authorAgentId)?.name ?? replyTo.authorAgentId.slice(0, 8);
+  }
+  if (replyTo.authorType === "system") return "System";
+  return "You";
+}

--- a/ui/src/lib/comment-reply.ts
+++ b/ui/src/lib/comment-reply.ts
@@ -1,4 +1,5 @@
 import type { Agent, IssueComment, IssueCommentReplyToMetadata } from "@paperclipai/shared";
+import type { CompanyUserProfile } from "./company-members";
 
 /**
  * Max characters shown in a reply excerpt (composer chip + sent quoted header).
@@ -32,16 +33,30 @@ export function buildOptimisticReplyTo(target: IssueComment): IssueCommentReplyT
 }
 
 /**
- * Human-readable author label for a reply target. Mirrors {@link CommentCard}'s author rendering:
- * agent comments show the agent name, everything else collapses to "You".
+ * Human-readable author label for a reply target. Mirrors the comment bubble's own author
+ * rendering: agent comments show the agent name; a user comment shows "You" only when it is the
+ * current viewer's, otherwise the resolved profile label (or "Board"/"User" when no profile is
+ * available). Resolving the current user matters in multi-user threads, where every non-current
+ * user would otherwise be mislabeled "You".
  */
 export function formatReplyAuthorName(
-  replyTo: Pick<IssueCommentReplyToMetadata, "authorType" | "authorAgentId">,
-  agentMap?: Map<string, Agent>,
+  replyTo: Pick<IssueCommentReplyToMetadata, "authorType" | "authorAgentId" | "authorUserId">,
+  options: {
+    agentMap?: Map<string, Agent> | null;
+    currentUserId?: string | null;
+    userProfileMap?: ReadonlyMap<string, CompanyUserProfile> | null;
+  } = {},
 ): string {
   if (replyTo.authorAgentId) {
-    return agentMap?.get(replyTo.authorAgentId)?.name ?? replyTo.authorAgentId.slice(0, 8);
+    return options.agentMap?.get(replyTo.authorAgentId)?.name ?? replyTo.authorAgentId.slice(0, 8);
   }
   if (replyTo.authorType === "system") return "System";
-  return "You";
+  const authorUserId = replyTo.authorUserId ?? null;
+  if (authorUserId && options.currentUserId && authorUserId === options.currentUserId) {
+    return "You";
+  }
+  const profileLabel = authorUserId ? options.userProfileMap?.get(authorUserId)?.label?.trim() : undefined;
+  if (profileLabel) return profileLabel;
+  if (authorUserId === "local-board") return "Board";
+  return "User";
 }

--- a/ui/src/lib/optimistic-issue-comments.ts
+++ b/ui/src/lib/optimistic-issue-comments.ts
@@ -1,4 +1,4 @@
-import type { Issue, IssueComment } from "@paperclipai/shared";
+import type { Issue, IssueComment, IssueCommentReplyToMetadata } from "@paperclipai/shared";
 
 export interface IssueCommentReassignment {
   assigneeAgentId: string | null;
@@ -49,6 +49,7 @@ export function createOptimisticIssueComment(params: {
   authorUserId: string | null;
   clientStatus?: OptimisticIssueComment["clientStatus"];
   queueTargetRunId?: string | null;
+  replyTo?: IssueCommentReplyToMetadata | null;
 }): OptimisticIssueComment {
   const now = new Date();
   const clientId = createOptimisticCommentId();
@@ -62,7 +63,9 @@ export function createOptimisticIssueComment(params: {
     authorUserId: params.authorUserId,
     body: params.body,
     presentation: null,
-    metadata: null,
+    metadata: params.replyTo
+      ? { version: 1, sections: [], replyTo: params.replyTo }
+      : null,
     clientStatus: params.clientStatus ?? "pending",
     queueTargetRunId: params.queueTargetRunId ?? null,
     createdAt: now,

--- a/ui/src/pages/IssueChatUxLab.tsx
+++ b/ui/src/pages/IssueChatUxLab.tsx
@@ -16,6 +16,8 @@ import {
   issueChatUxLiveRuns,
   issueChatUxMentions,
   issueChatUxReassignOptions,
+  issueChatUxReplyComments,
+  issueChatUxReplyDraftKey,
   issueChatUxReviewComments,
   issueChatUxReviewEvents,
   issueChatUxSubmittingComments,
@@ -142,6 +144,24 @@ function RotatingReasoningDemo({ intervalMs = 2200 }: { intervalMs?: number }) {
 
 export function IssueChatUxLab() {
   const [showComposer, setShowComposer] = useState(true);
+
+  // Seed a composer reply draft so the reply-scenario section renders the chip on load.
+  useEffect(() => {
+    try {
+      localStorage.setItem(
+        `${issueChatUxReplyDraftKey}:reply`,
+        JSON.stringify({
+          commentId: "comment-reply-source",
+          authorName: "CodexCoder",
+          excerpt:
+            "I moved the composer reply chip above the editor and clamp the quoted source to 200 chars so long comments stay one line.",
+          excerptTruncated: true,
+        }),
+      );
+    } catch {
+      // Ignore localStorage failures in the lab preview.
+    }
+  }, []);
 
   return (
     <div className="space-y-6">
@@ -293,6 +313,29 @@ export function IssueChatUxLab() {
           enableLiveTranscriptPolling={false}
           transcriptsByRunId={issueChatUxTranscriptsByRunId}
           hasOutputForRun={(runId) => issueChatUxTranscriptsByRunId.has(runId)}
+        />
+      </LabSection>
+
+      <LabSection
+        id="reply-to-comment"
+        eyebrow="Reply to comment"
+        title="Reply chip, quoted block, and tombstone"
+        description="PAP-13802 P3: hover a bubble to reveal Reply, the composer shows a quoted/clamped source chip (click to jump to the original, X or Escape to clear), sent replies render a quoted header above the body, and a reply whose source was deleted falls back to an 'Original comment deleted' tombstone."
+        accentClassName="bg-[linear-gradient(180deg,rgba(16,185,129,0.06),transparent_28%),var(--background)]"
+      >
+        <IssueChatThread
+          comments={issueChatUxReplyComments}
+          linkedRuns={[]}
+          timelineEvents={[]}
+          issueStatus="in_progress"
+          agentMap={issueChatUxAgentMap}
+          currentUserId="user-1"
+          onAdd={noop}
+          onVote={noop}
+          draftKey={issueChatUxReplyDraftKey}
+          mentions={issueChatUxMentions}
+          showComposer={showComposer}
+          enableLiveTranscriptPolling={false}
         />
       </LabSection>
 

--- a/ui/src/pages/IssueChatUxLab.tsx
+++ b/ui/src/pages/IssueChatUxLab.tsx
@@ -320,7 +320,7 @@ export function IssueChatUxLab() {
         id="reply-to-comment"
         eyebrow="Reply to comment"
         title="Reply chip, quoted block, and tombstone"
-        description="PAP-13802 P3: hover a bubble to reveal Reply, the composer shows a quoted/clamped source chip (click to jump to the original, X or Escape to clear), sent replies render a quoted header above the body, and a reply whose source was deleted falls back to an 'Original comment deleted' tombstone."
+        description="Hover a bubble to reveal Reply, the composer shows a quoted/clamped source chip (click to jump to the original, X or Escape to clear), sent replies render a quoted header above the body, and a reply whose source was deleted falls back to an 'Original comment deleted' tombstone."
         accentClassName="bg-[linear-gradient(180deg,rgba(16,185,129,0.06),transparent_28%),var(--background)]"
       >
         <IssueChatThread

--- a/ui/src/pages/IssueDetail.tsx
+++ b/ui/src/pages/IssueDetail.tsx
@@ -73,6 +73,7 @@ import {
   type IssueCommentReassignment,
   type OptimisticIssueComment,
 } from "../lib/optimistic-issue-comments";
+import { buildOptimisticReplyTo } from "../lib/comment-reply";
 import { clearIssueExecutionRun, removeLiveRunById, upsertInterruptedRun } from "../lib/optimistic-issue-runs";
 import { useProjectOrder } from "../hooks/useProjectOrder";
 import { relativeTime, cn, formatDurationMs, formatTokens, visibleRunCostUsd } from "../lib/utils";
@@ -193,6 +194,7 @@ import {
   type IssueRecoveryAction,
   type IssueAttachment,
   type IssueComment,
+  type IssueCommentReplyToMetadata,
   type IssueWorkProduct,
   type IssueWorkMode,
   type IssueThreadInteraction,
@@ -897,7 +899,12 @@ type IssueDetailChatTabProps = {
     vote: "up" | "down",
     options?: { allowSharing?: boolean; reason?: string },
   ) => Promise<void>;
-  onAdd: (body: string, reopen?: boolean, reassignment?: CommentReassignment) => Promise<void>;
+  onAdd: (
+    body: string,
+    reopen?: boolean,
+    reassignment?: CommentReassignment,
+    replyToCommentId?: string | null,
+  ) => Promise<void>;
   onImageUpload: (file: File) => Promise<string>;
   onAttachImage: (file: File) => Promise<IssueAttachment | void>;
   onInterruptQueued: (runId: string) => Promise<void>;
@@ -2408,9 +2415,15 @@ export function IssueDetail() {
   });
 
   const addComment = useMutation({
-    mutationFn: ({ body, reopen, interrupt }: { body: string; reopen?: boolean; interrupt?: boolean }) =>
-      issuesApi.addComment(issueId!, body, reopen, interrupt),
-    onMutate: async ({ body, reopen, interrupt }) => {
+    mutationFn: ({ body, reopen, interrupt, replyToCommentId }: {
+      body: string;
+      reopen?: boolean;
+      interrupt?: boolean;
+      replyToCommentId?: string | null;
+      replyToSnapshot?: IssueCommentReplyToMetadata | null;
+    }) =>
+      issuesApi.addComment(issueId!, body, reopen, interrupt, replyToCommentId),
+    onMutate: async ({ body, reopen, interrupt, replyToSnapshot }) => {
       await queryClient.cancelQueries({ queryKey: queryKeys.issues.comments(issueId!) });
       await queryClient.cancelQueries({ queryKey: queryKeys.issues.detail(issueId!) });
 
@@ -2424,6 +2437,7 @@ export function IssueDetail() {
             authorUserId: currentUserId,
             clientStatus: queuedComment ? "queued" : "pending",
             queueTargetRunId: queuedComment?.id ?? null,
+            replyTo: replyToSnapshot ?? null,
           })
         : null;
 
@@ -3565,13 +3579,26 @@ export function IssueDetail() {
       sharingPreferenceAtSubmit: feedbackDataSharingPreference,
     });
   }, [feedbackDataSharingPreference, feedbackVoteMutation]);
-  const handleChatAdd = useCallback(async (body: string, reopen?: boolean, reassignment?: CommentReassignment) => {
+  const handleChatAdd = useCallback(async (
+    body: string,
+    reopen?: boolean,
+    reassignment?: CommentReassignment,
+    replyToCommentId?: string | null,
+  ) => {
     if (reassignment) {
+      // The reassign path goes through PATCH /issues, which does not carry comment metadata,
+      // so an explicit reassignment cannot also attach a reply target under the current contract.
       await addCommentAndReassign.mutateAsync({ body, reopen, reassignment });
       return;
     }
-    await addComment.mutateAsync({ body, reopen });
-  }, [addComment, addCommentAndReassign]);
+    // Build the reply snapshot from the loaded comment so the sent quote renders optimistically;
+    // the server rebuilds the authoritative snapshot from replyToCommentId.
+    const replyTarget = replyToCommentId
+      ? threadComments.find((comment) => comment.id === replyToCommentId)
+      : undefined;
+    const replyToSnapshot = replyTarget ? buildOptimisticReplyTo(replyTarget) : null;
+    await addComment.mutateAsync({ body, reopen, replyToCommentId, replyToSnapshot });
+  }, [addComment, addCommentAndReassign, threadComments]);
   const handleCommentImageUpload = useCallback(async (file: File) => {
     const attachment = await uploadAttachment.mutateAsync(file);
     return attachment.contentPath;


### PR DESCRIPTION
> **Stacked on #9473** (server-authoritative reply context). Base is `feat/reply-to-comment-server` until that merges, then this retargets to `master`. Review the net UI diff here; the server/types diff lives in #9473.

## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The issue chat thread is where humans and agents converse on an issue; today you can only append a new message with no way to point at a specific earlier comment
> - When a thread gets long, replies lose their referent — readers can't tell which comment an answer addresses
> - Threading that context into the composer and the sent message makes long conversations legible without heavyweight nested threads
> - This pull request adds a reply affordance: a per-comment Reply button, a composer "replying to" chip, and a compact quoted header on sent replies (with a tombstone when the source is deleted)
> - The benefit is that any reply now carries a one-line, clickable reference back to the comment it answers

## Linked Issues or Issue Description

**Feature.**

- **Problem / motivation:** In a busy issue chat, replies have no explicit referent. Once a thread scrolls, it's ambiguous which earlier comment a message is answering, for both humans and agents.
- **Proposed solution:** A one-level reply model. Hovering a comment reveals a Reply button; clicking it opens a "Replying to {author}" chip in the composer with a clamped excerpt; sending forwards the source comment id so the server records an authoritative snapshot; the sent message renders a compact quoted header linking back to (and highlighting) the original. If the source is later deleted, the header falls back to an "Original comment deleted" tombstone.
- **Alternatives considered:** Full nested threads (rejected — too heavy for the issue chat; one-level quoting keeps the timeline flat and scannable).
- **Roadmap alignment:** Incremental UX improvement to existing issue chat; no new subsystem.

Depends on #9473 for the `replyTo` types and the server snapshot endpoint.

## What Changed

- **Live issue thread (`IssueChatThread`)** — the component the real issue page renders — gains the full reply flow: reply state lifted to the thread root and exposed to bubbles via context; `onAdd`/runtime gain a `replyToCommentId` param forwarded through `runConfig.custom` (dropped on the reassign path to match the server contract).
- **Reply button** — icon-only `Reply` in each non-deleted, persisted comment's toolbar; hover-revealed on desktop, always visible on touch; on both human and genuine agent bubbles.
- **Composer reply chip** — accent bar + "Replying to {author}" + ~200-char clamped excerpt + X; click the body to jump to the original; Escape clears when the editor is empty; the target persists with the localStorage draft and survives reload.
- **Sent quoted header** — compact quoted block above a reply's body (accent-aware for the blue human bubble), clickable to scroll + highlight the original, with an "Original comment deleted" tombstone when the source is soft-deleted.
- **Optimistic rendering** — a client-built `replyTo` snapshot on the `addComment` mutation so the quote renders immediately.
- **Shared helper** (`ui/src/lib/comment-reply.ts`) — surface-agnostic excerpt clamp / snapshot / author-label; also wired into the existing `CommentThread` implementation.
- **UX Lab** — a fixture-backed reply section on the public `/ux-lab/chat` route exercising the chip, sent quoted block, and tombstone for review/QA without a live issue.

## Verification

- `npx tsc --noEmit` in `ui/` — clean.
- `vitest` issue-chat message tests — green.
- Manual: rendered the live `IssueChatThread` on `/ux-lab/chat` with aarch64 chromium at desktop (1440px) and mobile (375px); confirmed reply button (hover + touch), composer chip (normal / truncated / dismissed), sent quoted block, and tombstone all match the wireframes. Screenshots attached to the tracking issue.

## Risks

Low risk. UI-only on top of the server contract in #9473; the existing `CommentThread` and composer semantics (reopen / reassign / interrupt) are unchanged; the reply target is dropped on the reassign path to match the server. No migrations.

## Model Used

Claude Opus 4.8 (`claude-opus-4-8`), extended thinking, tool use / code execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links
- [x] My branch name describes the change and contains no internal Paperclip ticket id
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
