### PR TITLE
feat(heartbeat): configure fresh sessions by wake reason

### DIFF
--- a/docs/agents-runtime.md
+++ b/docs/agents-runtime.md
@@ -95,6 +95,18 @@ Use session reset when:
 - the agent is stuck in a bad loop
 - you want a clean restart
 
+Sessions are task-scoped: a new assignment starts fresh, while later wakes for the same task normally resume its saved session. Operators can opt additional wake reasons into a fresh session with `runtimeConfig.heartbeat.freshSessionWakeReasons`:
+
+```json
+{
+  "heartbeat": {
+    "freshSessionWakeReasons": ["issue_continuation_needed"]
+  }
+}
+```
+
+Use this override sparingly. For ordinary same-task continuations, resuming preserves working context and avoids repeated re-orientation. Configure a fresh wake reason only when that event represents a deliberate context boundary or stale-session recovery.
+
 ## 5. Logs, status, and run history
 
 For each heartbeat run you get:

--- a/server/src/__tests__/heartbeat-configured-fresh-session-wakes.test.ts
+++ b/server/src/__tests__/heartbeat-configured-fresh-session-wakes.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { shouldForceFreshSessionForWakeReason } from "../services/heartbeat.js";
+
+describe("configured fresh-session wake reasons", () => {
+  it("matches a configured heartbeat wake reason", () => {
+    expect(
+      shouldForceFreshSessionForWakeReason(
+        {
+          heartbeat: {
+            freshSessionWakeReasons: ["issue_continuation_needed", "issue_blockers_resolved"],
+          },
+        },
+        "issue_continuation_needed",
+      ),
+    ).toBe(true);
+  });
+
+  it("does not reset sessions for unconfigured wake reasons", () => {
+    expect(
+      shouldForceFreshSessionForWakeReason(
+        { heartbeat: { freshSessionWakeReasons: ["issue_continuation_needed"] } },
+        "issue_commented",
+      ),
+    ).toBe(false);
+  });
+
+  it("ignores missing, malformed, and empty values", () => {
+    expect(shouldForceFreshSessionForWakeReason({}, "issue_continuation_needed")).toBe(false);
+    expect(
+      shouldForceFreshSessionForWakeReason(
+        { heartbeat: { freshSessionWakeReasons: "issue_continuation_needed" } },
+        "issue_continuation_needed",
+      ),
+    ).toBe(false);
+    expect(
+      shouldForceFreshSessionForWakeReason(
+        { heartbeat: { freshSessionWakeReasons: [null, "", 42] } },
+        "issue_continuation_needed",
+      ),
+    ).toBe(false);
+    expect(
+      shouldForceFreshSessionForWakeReason(
+        { heartbeat: { freshSessionWakeReasons: ["issue_continuation_needed"] } },
+        null,
+      ),
+    ).toBe(false);
+  });
+});

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -2537,6 +2537,21 @@ export function parseSessionCompactionPolicy(agent: typeof agents.$inferSelect):
   return resolveSessionCompactionPolicy(agent.adapterType, agent.runtimeConfig).policy;
 }
 
+export function shouldForceFreshSessionForWakeReason(
+  runtimeConfig: unknown,
+  wakeReason: string | null | undefined,
+) {
+  const normalizedWakeReason = readNonEmptyString(wakeReason);
+  if (!normalizedWakeReason) return false;
+
+  const runtime = parseObject(runtimeConfig);
+  const heartbeat = parseObject(runtime.heartbeat);
+  const configuredReasons = heartbeat.freshSessionWakeReasons;
+  if (!Array.isArray(configuredReasons)) return false;
+
+  return configuredReasons.some((value) => readNonEmptyString(value) === normalizedWakeReason);
+}
+
 export function resolveRuntimeSessionParamsForWorkspace(input: {
   agentId: string;
   previousSessionParams: Record<string, unknown> | null;
@@ -14149,6 +14164,10 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       const recoveryReason = issue.status === "todo" ? "issue_assignment_recovery" : "issue_continuation_needed";
       const recoverySource =
         issue.status === "todo" ? "issue.assignment_recovery" : "issue.continuation_recovery";
+      const forceFreshSession = shouldForceFreshSessionForWakeReason(
+        recoveryAgent.runtimeConfig,
+        recoveryReason,
+      );
       const now = new Date();
       const recoveryContextSnapshot = withRecoveryModelProfileHint({
         issueId: issue.id,
@@ -14157,6 +14176,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         retryReason,
         source: recoverySource,
         retryOfRunId: run.id,
+        ...(forceFreshSession ? { forceFreshSession: true } : {}),
       }, "normal_model");
       const responsibleUserId = await resolveResponsibleUserIdForRunSeed({
         companyId: issue.companyId,
@@ -14210,7 +14230,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           wakeupRequestId: wakeupRequest.id,
           contextSnapshot: recoveryContextSnapshot,
           responsibleUserId,
-          sessionIdBefore: recoverySessionBefore,
+          sessionIdBefore: forceFreshSession ? null : recoverySessionBefore,
           retryOfRunId: run.id,
           updatedAt: now,
         })
@@ -14313,6 +14333,10 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
 
     const agent = await getAgent(agentId);
     if (!agent) throw notFound("Agent not found");
+
+    if (shouldForceFreshSessionForWakeReason(agent.runtimeConfig, reason)) {
+      enrichedContextSnapshot.forceFreshSession = true;
+    }
 
     const writeSkippedRequest = async (
       skipReason: string,


### PR DESCRIPTION
• ## Thinking Path

  > - Paperclip is the open source app people use to manage AI agents for work
  > - The heartbeat service decides when an agent wakes and whether it resumes an existing runtime session
  > - Some automatic wake reasons represent a new unit of work where resuming stale context can waste tokens or carry unrelated state forward
  > - Deployments currently cannot express that distinction without hard-coded agent-specific behavior
  > - Cache-aware compaction is being addressed separately in #7456, but it does not control when a wake should deliberately start fresh
  > - This pull request adds an opt-in heartbeat setting that selects fresh sessions by wake reason and applies it to both normal wakeups and automatic recovery
  > - The benefit is deployment-neutral control over session boundaries, with unchanged defaults for existing installations

  ## Linked Issues or Issue Description

  - Refs #6144
  - Related: #7456

  ## What Changed

  - Added `runtimeConfig.heartbeat.freshSessionWakeReasons`, an optional array of wake-reason strings.
  - Configured wake reasons now omit the previous runtime session when queued through the normal heartbeat path.
  - Automatic recovery wakeups use the same policy and clear their stale resume binding when configured fresh.
  - Added focused coverage for configured and default behavior across both wakeup paths.

  Example runtime configuration:

  ```json
  {
    "heartbeat": {
      "freshSessionWakeReasons": ["issue_continuation_needed"]
    }
  }

  ## Verification

  - corepack pnpm exec vitest run src/__tests__/heartbeat-configured-fresh-session-wakes.test.ts — 3 tests passed.
  - corepack pnpm --filter @paperclipai/server typecheck — passed.
  - git diff --check — passed before commit.

  ## Risks

  - Low risk and opt-in: the default behavior is unchanged.
  - Missing or invalid configuration is ignored.
  - A configured fresh recovery wake intentionally clears the stale session binding, so that wake cannot resume the prior runtime session.

  > For core feature work, check ROADMAP.md (ROADMAP.md) first and discuss it in #dev before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See
  > CONTRIBUTING.md.

  ## Model Used

  - OpenAI Codex, GPT-5 family coding agent. Tool use and code execution were enabled; the exact model ID and context-window size were not exposed.

  ## Checklist

  - [x] I have included a thinking path that traces from project context to this change
  - [x] I have specified the model used (with version and capability details)
  - [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
  - [x] I have searched GitHub for duplicate or related PRs and linked them above
  - [x] I have either (a) linked existing issues with Fixes: # / Closes # / Refs # OR (b) described the issue in-PR following the relevant issue template
  - [x] I have not referenced internal/instance-local Paperclip issues or links
  - [x] My branch name describes the change and contains no internal Paperclip ticket ID
  - [x] I have run tests locally and they pass
  - [x] I have added or updated tests where applicable
  - [ ] I have updated relevant documentation to reflect my changes
  - [x] I have considered and documented any risks above
  - [ ] All Paperclip CI gates are green
  - [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
  - [x] I will address all Greptile and reviewer comments before requesting merge