### PR TITLE
docs(hermes): document OpenAI Codex subscription route

### DIFF
--- a/packages/adapters/hermes/README.md
+++ b/packages/adapters/hermes/README.md
@@ -107,6 +107,53 @@ In the Paperclip UI or via API, create an agent with adapter type `hermes_local`
 This mode shells out to the local `hermes` CLI. Paperclip injects runtime
 environment variables and captures stdout/stderr from the child process.
 
+#### OpenAI Codex through Hermes subscription OAuth
+
+Use `hermes_local` for OpenAI Codex when the usable subscription/OAuth session
+lives in Hermes Agent rather than in the standalone Codex CLI. This is common
+when `hermes chat --provider openai-codex` works but `~/.codex/auth.json` does
+not exist or Codex CLI auth is intentionally unmanaged by Paperclip.
+
+First verify Hermes itself can use the OAuth session without running Codex auth
+commands:
+
+```bash
+hermes chat -q 'Reply with exactly HERMES_CODEX_SMOKE_OK.' \
+  --provider openai-codex \
+  --model gpt-5.5 \
+  -t terminal,file \
+  -Q
+```
+
+Then configure the Paperclip agent explicitly:
+
+```json
+{
+  "name": "Hermes Codex Engineer",
+  "adapterType": "hermes_local",
+  "adapterConfig": {
+    "provider": "openai-codex",
+    "model": "gpt-5.5",
+    "quiet": true,
+    "toolsets": "terminal,file",
+    "timeoutSec": 360,
+    "maxTurnsPerRun": 10
+  }
+}
+```
+
+Notes:
+
+- Do not run `codex login`, `codex logout`, or device-code auth as part of this
+  route. Paperclip is invoking Hermes, not the standalone Codex CLI.
+- Do not copy Hermes OAuth tokens into Codex CLI auth files.
+- If Paperclip runs in a container, the container must be able to execute the
+  configured `hermesCommand` and access the Hermes runtime state required for
+  that OAuth session. Prefer explicit mounts or a gateway deployment over
+  credential copying.
+- Keep `toolsets` explicit for reproducible runs and to avoid warnings from
+  unavailable Hermes toolsets.
+
 ### 3. Create a Hermes gateway agent in Paperclip
 
 Start Hermes with its API server enabled first:

--- a/packages/adapters/hermes/src/server/openai-codex-config.test.ts
+++ b/packages/adapters/hermes/src/server/openai-codex-config.test.ts
@@ -1,0 +1,101 @@
+import os from "node:os";
+import path from "node:path";
+import { chmod, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { expect, test } from "vitest";
+
+import { execute } from "./execute.js";
+
+test("passes explicit OpenAI Codex subscription route config to Hermes CLI", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "hermes-openai-codex-config-"));
+  const fakeHermesPath = path.join(tempDir, "fake-hermes");
+  const argvCapturePath = path.join(tempDir, "argv.json");
+
+  try {
+    await writeFile(
+      fakeHermesPath,
+      [
+        "#!/usr/bin/env node",
+        "const fs = require('node:fs');",
+        "fs.writeFileSync(process.env.HERMES_ARGV_CAPTURE, JSON.stringify(process.argv.slice(2)), 'utf8');",
+        "console.log('PAPERCLIP_HERMES_CODEX_ADAPTER_OK');",
+        "console.log('');",
+        "console.log('session_id: g26-openai-codex-session');",
+      ].join("\n"),
+      "utf8",
+    );
+    await chmod(fakeHermesPath, 0o755);
+
+    const logs: Array<{ stream: "stdout" | "stderr"; chunk: string }> = [];
+    const result = await execute({
+      agent: {
+        id: "agent-g26",
+        name: "Hermes Codex Agent",
+        companyId: "company-g26",
+      },
+      runId: "run-g26",
+      authToken: "test-token",
+      config: {
+        hermesCommand: fakeHermesPath,
+        provider: "openai-codex",
+        model: "gpt-5.5",
+        quiet: true,
+        toolsets: "terminal,file",
+        timeoutSec: 360,
+        maxTurnsPerRun: 10,
+        cwd: tempDir,
+        env: {
+          HERMES_ARGV_CAPTURE: argvCapturePath,
+        },
+      },
+      context: {
+        issueId: "issue-g26",
+        paperclipWake: {
+          reason: "issue_assigned",
+          issue: {
+            id: "issue-g26",
+            identifier: "PAP-G26",
+            title: "Verify Hermes-backed OpenAI Codex route",
+            status: "in_progress",
+            priority: "medium",
+            workMode: "standard",
+          },
+          checkedOutByHarness: true,
+          commentWindow: { requestedCount: 0, includedCount: 0, missingCount: 0 },
+          comments: [],
+          fallbackFetchNeeded: false,
+        },
+      },
+      runtime: {},
+      onLog: async (stream: "stdout" | "stderr", chunk: string) => {
+        logs.push({ stream, chunk });
+      },
+    } as any);
+
+    const argv = JSON.parse(await readFile(argvCapturePath, "utf8")) as string[];
+
+    expect(result.exitCode).toBe(0);
+    expect(result.timedOut).toBe(false);
+    expect(result.provider).toBe("openai-codex");
+    expect(result.model).toBe("gpt-5.5");
+    expect(result.summary).toBe("PAPERCLIP_HERMES_CODEX_ADAPTER_OK");
+    expect(result.sessionParams).toEqual({ sessionId: "g26-openai-codex-session" });
+
+    expect(argv[0]).toBe("chat");
+    expect(argv).toContain("-Q");
+    expect(argv).toContain("-m");
+    expect(argv[argv.indexOf("-m") + 1]).toBe("gpt-5.5");
+    expect(argv).toContain("--provider");
+    expect(argv[argv.indexOf("--provider") + 1]).toBe("openai-codex");
+    expect(argv).toContain("-t");
+    expect(argv[argv.indexOf("-t") + 1]).toBe("terminal,file");
+    expect(argv).toContain("--max-turns");
+    expect(argv[argv.indexOf("--max-turns") + 1]).toBe("10");
+    expect(argv).toContain("--source");
+    expect(argv[argv.indexOf("--source") + 1]).toBe("tool");
+    expect(argv).toContain("--yolo");
+
+    expect(logs.some((entry) => entry.chunk.includes("provider=openai-codex"))).toBe(true);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - This change is in the built-in Hermes adapter package, specifically the `hermes_local` route that shells out to the Hermes CLI for Paperclip-managed agent runs.
> - Hermes can hold provider authentication itself, including OpenAI Codex subscription/OAuth sessions, while the standalone Codex CLI uses a separate auth home.
> - Operators can therefore have `hermes chat --provider openai-codex` working even when `codex_local` is not the right Paperclip route.
> - The current Hermes adapter README documents local and gateway usage, but does not clearly show how to configure `hermes_local` for OpenAI Codex subscription/OAuth or how to avoid Codex CLI auth/token-copying mistakes.
> - This pull request documents that route and adds a focused adapter regression smoke proving Paperclip passes the explicit provider/model/toolset/max-turn configuration through to Hermes.
> - The benefit is a safer, clearer path for OpenAI Codex subscription users to run Paperclip agents through Hermes without copying OAuth tokens or invoking Codex CLI auth flows.

## Linked Issues or Issue Description

Refs #5707.

Inline adapter/documentation issue description:

### Summary

`hermes_local` can use Hermes-managed OpenAI Codex subscription/OAuth sessions, but the adapter docs do not currently make that route explicit. This can lead operators to try `codex_local`, Codex CLI login/logout/device-code flows, or token copying even when Hermes is already the authorized runtime.

### Why this matters

Hermes and the standalone Codex CLI use different auth homes. If `hermes chat --provider openai-codex` succeeds but standalone Codex CLI auth is absent or intentionally unmanaged, Paperclip should be configured to invoke Hermes with `provider: "openai-codex"` rather than treating this as a `codex_local` setup problem.

### Expected behavior

The Hermes adapter documentation should show the safe route:

- verify Hermes directly with `hermes chat --provider openai-codex`
- configure a `hermes_local` agent with explicit provider/model/toolsets
- avoid Codex login/logout/device-code auth as part of this route
- avoid copying Hermes OAuth tokens into Codex CLI auth files

The adapter test suite should also pin the important CLI arguments sent for this route.

## What Changed

- Added an `OpenAI Codex through Hermes subscription OAuth` section to `packages/adapters/hermes/README.md`.
- Documented a direct Hermes smoke command using `--provider openai-codex`, `--model gpt-5.5`, explicit `terminal,file` toolsets, and quiet mode.
- Documented an explicit `hermes_local` Paperclip agent configuration for OpenAI Codex subscription/OAuth usage.
- Added guidance not to run Codex CLI login/logout/device-code auth or copy Hermes OAuth tokens for this route.
- Added `src/server/openai-codex-config.test.ts`, a fake-Hermes CLI regression smoke that verifies the adapter passes the expected CLI arguments and preserves provider/model/session metadata.

## Verification

From a clean branch based on `origin/master`:

```bash
pnpm install --frozen-lockfile
pnpm --filter @paperclipai/hermes-paperclip-adapter test
pnpm --filter @paperclipai/hermes-paperclip-adapter typecheck
```

Results:

```text
Test Files  8 passed (8)
Tests       56 passed (56)
```

```text
@paperclipai/hermes-paperclip-adapter typecheck: tsc --noEmit
exit code: 0
```

Also checked:

- `ROADMAP.md` — this is a docs/test clarification for an existing adapter route, not overlapping planned core feature work.
- GitHub issue/PR search for `Hermes Codex openai-codex hermes_local`; related context is linked above.
- Added-line leak scan for token/API-key patterns passed locally.

## Risks

Low risk:

- Runtime adapter behavior is unchanged.
- The new test uses a temporary fake Hermes CLI and does not require real provider credentials.
- The README examples use placeholders and explicit non-auth guidance; no secrets are introduced.
- The docs clarify a safe route but do not solve every multi-agent Codex refresh-token isolation issue tracked in #5707.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

OpenAI Codex, GPT-5.5, tool-enabled coding session with repository inspection, shell execution, local focused test execution, local typecheck execution, and GitHub CLI assistance.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
