### PR TITLE
Harden timer wake issue execution race

### DIFF
--- a/server/src/__tests__/heartbeat-dependency-scheduling.test.ts
+++ b/server/src/__tests__/heartbeat-dependency-scheduling.test.ts
@@ -415,6 +415,126 @@ describeEmbeddedPostgres("heartbeat dependency-aware queued run selection", () =
     expect(noActiveRuns).toBe(true);
   });
 
+  it("skips generic timer wakes while the same agent has an active issue execution", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const issueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+      defaultResponsibleUserId: "responsible-user",
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Argus",
+      role: "reviewer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {
+        heartbeat: {
+          enabled: true,
+          wakeOnDemand: true,
+          maxConcurrentRuns: 16,
+          skipTimerWhenNoActionableWork: true,
+        },
+      },
+      permissions: {},
+    });
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Review PR marker",
+      status: "in_progress",
+      priority: "high",
+      assigneeAgentId: agentId,
+      responsibleUserId: "responsible-user",
+    });
+
+    let finishAssignmentRun!: () => void;
+    const assignmentRunCanFinish = new Promise<void>((resolve) => {
+      finishAssignmentRun = resolve;
+    });
+    mockAdapterExecute.mockImplementationOnce(async () => {
+      await assignmentRunCanFinish;
+      return {
+        exitCode: 0,
+        signal: null,
+        timedOut: false,
+        errorMessage: null,
+        summary: "Assignment run complete.",
+        provider: "test",
+        model: "test-model",
+      };
+    });
+
+    const assignmentWake = await heartbeat.wakeup(agentId, {
+      source: "assignment",
+      triggerDetail: "system",
+      reason: "issue_assigned",
+      payload: { issueId },
+      contextSnapshot: { issueId, wakeReason: "issue_assigned" },
+    });
+    expect(assignmentWake).not.toBeNull();
+
+    const assignmentIsRunning = await waitForCondition(async () => {
+      const run = await db
+        .select({ status: heartbeatRuns.status })
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.id, assignmentWake!.id))
+        .then((rows) => rows[0] ?? null);
+      return run?.status === "running";
+    });
+    expect(assignmentIsRunning).toBe(true);
+
+    const timerWake = await heartbeat.wakeup(agentId, {
+      source: "timer",
+      triggerDetail: "interval",
+      reason: "heartbeat_timer",
+      payload: {},
+      contextSnapshot: {},
+    });
+    expect(timerWake).toBeNull();
+
+    const runCountAfterTimer = await db
+      .select({ count: sql<number>`count(*)::int` })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.agentId, agentId))
+      .then((rows) => rows[0]?.count ?? 0);
+    expect(runCountAfterTimer).toBe(1);
+
+    const skippedTimerWake = await db
+      .select({
+        status: agentWakeupRequests.status,
+        reason: agentWakeupRequests.reason,
+      })
+      .from(agentWakeupRequests)
+      .where(and(
+        eq(agentWakeupRequests.agentId, agentId),
+        eq(agentWakeupRequests.source, "timer"),
+      ))
+      .then((rows) => rows[0] ?? null);
+    expect(skippedTimerWake).toEqual({
+      status: "skipped",
+      reason: "heartbeat.timer.issue_execution_active",
+    });
+
+    finishAssignmentRun();
+    await waitForCondition(async () => {
+      const run = await db
+        .select({ status: heartbeatRuns.status })
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.id, assignmentWake!.id))
+        .then((rows) => rows[0] ?? null);
+      return run?.status === "succeeded";
+    });
+    expect(mockAdapterExecute).toHaveBeenCalledTimes(1);
+  });
+
   it("defers issue_blockers_resolved as a follow-up when the same issue is already running", async () => {
     const companyId = randomUUID();
     const agentId = randomUUID();

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -9860,6 +9860,23 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     return Boolean(row);
   }
 
+  async function hasActiveIssueExecutionForAgent(agent: typeof agents.$inferSelect) {
+    const row = await db
+      .select({ id: heartbeatRuns.id })
+      .from(heartbeatRuns)
+      .where(
+        and(
+          eq(heartbeatRuns.companyId, agent.companyId),
+          eq(heartbeatRuns.agentId, agent.id),
+          inArray(heartbeatRuns.status, [...EXECUTION_PATH_HEARTBEAT_RUN_STATUSES]),
+          sql`coalesce(${heartbeatRuns.contextSnapshot} ->> 'issueId', '') <> ''`,
+        ),
+      )
+      .limit(1)
+      .then((rows) => rows[0] ?? null);
+    return Boolean(row);
+  }
+
   async function markTimerHeartbeatChecked(agentId: string, source: WakeupOptions["source"]) {
     if (source !== "timer") return;
     await db
@@ -14526,6 +14543,13 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       !wakeCommentId &&
       !readNonEmptyString(enrichedContextSnapshot.taskId) &&
       !readNonEmptyString(enrichedContextSnapshot.taskKey);
+    if (genericTimerWake && await hasActiveIssueExecutionForAgent(agent)) {
+      await writeSkippedHeartbeatRequest("heartbeat.timer.issue_execution_active", {
+        reason: "Agent already has an active issue-scoped execution; skipping generic timer wake to avoid racing assignment ownership.",
+      });
+      await markTimerHeartbeatChecked(agentId, source);
+      return null;
+    }
     if (policy.skipTimerWhenNoActionableWork && genericTimerWake && !(await hasActionableTimerWork(agent))) {
       await writeSkippedHeartbeatRequest("heartbeat.timer.no_actionable_work", {
         reason: "No assigned todo or in_progress issue requires this agent before timer adapter invocation.",


### PR DESCRIPTION
## Summary
- skip generic timer wake dispatch when the same agent already has an active issue-scoped execution
- cover the same-agent timer/assignment race observed with `heartbeat.maxConcurrentRuns=16`

## Verification
- pnpm --filter @paperclipai/server test -- --run server/src/__tests__/heartbeat-dependency-scheduling.test.ts
- pnpm --filter @paperclipai/server typecheck
- git diff --check
- gitleaks protect --staged --redact --config .gitleaks.toml