### PR TITLE
fix(ui): onboarding wizard keeps an invisible disabled adapter selected

### DIFF
--- a/ui/src/components/OnboardingWizard.test.tsx
+++ b/ui/src/components/OnboardingWizard.test.tsx
@@ -1,0 +1,165 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// --- Mocks (hoisted so vi.mock factories can close over them) ----------------
+
+const ONBOARDING_STORAGE_KEY = "paperclip-onboarding-state";
+
+const mockDialog = vi.hoisted(() => ({
+  onboardingOpen: true,
+  onboardingOptions: {} as { initialStep?: number; companyId?: string },
+  closeOnboarding: vi.fn(),
+  onboardingRouteDismissed: false,
+  setOnboardingRouteDismissed: vi.fn(),
+}));
+
+const mockCompany = vi.hoisted(() => ({
+  companies: [] as Array<{ id: string; name: string; issuePrefix: string }>,
+  setSelectedCompanyId: vi.fn(),
+  loading: false,
+}));
+
+// The real adapter registry eagerly imports every adapter package. The
+// model/harness picker internals are out of scope here, so stub the adapter
+// layer entirely and drive the grid through these two knobs.
+const mockAdapterRegistry = vi.hoisted(() => ({
+  list: [] as Array<{ type: string }>,
+  disabled: new Set<string>(),
+}));
+
+vi.mock("@/lib/router", () => ({
+  useLocation: () => ({ pathname: "/", search: "", hash: "", state: null }),
+  useNavigate: () => vi.fn(),
+  useParams: () => ({}),
+}));
+vi.mock("../context/DialogContext", () => ({
+  useDialog: () => mockDialog,
+}));
+vi.mock("../context/CompanyContext", () => ({
+  useCompany: () => mockCompany,
+}));
+vi.mock("../adapters", () => ({
+  listUIAdapters: () => mockAdapterRegistry.list,
+  getUIAdapter: () => ({ buildAdapterConfig: () => ({}) }),
+}));
+vi.mock("../adapters/metadata", () => ({ isVisualAdapterChoice: () => true }));
+vi.mock("../adapters/adapter-display-registry", () => ({
+  getAdapterDisplay: (type: string) => ({
+    type,
+    recommended: false,
+    label: type,
+    description: "",
+    icon: () => null,
+  }),
+}));
+vi.mock("../adapters/use-disabled-adapters", () => ({
+  useDisabledAdaptersSync: () => mockAdapterRegistry.disabled,
+}));
+vi.mock("../adapters/use-adapter-capabilities", () => ({
+  useAdapterCapabilities: () => () => ({
+    supportsInstructionsBundle: false,
+    supportsSkills: false,
+    supportsLocalAgentJwt: false,
+    requiresMaterializedRuntimeSkills: false,
+    supportsModelProfiles: false,
+  }),
+}));
+// Animation / canvas-ish children that add nothing to the logic under test.
+vi.mock("./AsciiArtAnimation", () => ({ AsciiArtAnimation: () => null }));
+vi.mock("./FrontDoor", () => ({ FrontDoor: () => null }));
+vi.mock("./AgentCapsule", () => ({ AgentCapsule: () => null }));
+
+import { OnboardingWizard } from "./OnboardingWizard";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+async function flushReact() {
+  await act(async () => {
+    await Promise.resolve();
+    await new Promise((resolve) => window.setTimeout(resolve, 0));
+  });
+}
+
+async function mount() {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  await act(async () => {
+    root.render(
+      <QueryClientProvider client={queryClient}>
+        <OnboardingWizard />
+      </QueryClientProvider>,
+    );
+  });
+  await flushReact();
+  return { container, root };
+}
+
+describe("OnboardingWizard adapter selection", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    mockDialog.onboardingOpen = true;
+    mockDialog.onboardingOptions = {};
+    mockCompany.companies = [];
+    mockAdapterRegistry.list = [];
+    mockAdapterRegistry.disabled = new Set<string>();
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+    vi.clearAllMocks();
+  });
+
+  it("snaps a disabled default adapterType to the first enabled adapter", async () => {
+    // A deployment whose adapter registry omits claude_local disables it, so
+    // the wizard's claude_local default must not survive as an invisible
+    // selection (the created agent could never acquire a lease).
+    mockAdapterRegistry.list = [
+      { type: "claude_local" },
+      { type: "codex_local" },
+      { type: "opencode_local" },
+    ];
+    mockAdapterRegistry.disabled = new Set(["claude_local"]);
+
+    const { root } = await mount();
+
+    const saved = JSON.parse(
+      window.localStorage.getItem(ONBOARDING_STORAGE_KEY) ?? "{}",
+    );
+    expect(saved.adapterType).toBe("codex_local");
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  it("keeps an enabled saved adapterType untouched", async () => {
+    mockAdapterRegistry.list = [
+      { type: "claude_local" },
+      { type: "codex_local" },
+    ];
+    window.localStorage.setItem(
+      ONBOARDING_STORAGE_KEY,
+      JSON.stringify({ step: 0, adapterType: "claude_local" }),
+    );
+
+    const { root } = await mount();
+
+    const saved = JSON.parse(
+      window.localStorage.getItem(ONBOARDING_STORAGE_KEY) ?? "{}",
+    );
+    expect(saved.adapterType).toBe("claude_local");
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+});

--- a/ui/src/components/OnboardingWizard.tsx
+++ b/ui/src/components/OnboardingWizard.tsx
@@ -294,6 +294,34 @@ export function OnboardingWizard() {
     };
   }, [disabledTypes]);
 
+  // The default (or a saved) adapterType can name an adapter the server has
+  // since disabled — e.g. a cloud sandbox registry without claude_local. The
+  // grid hides it, so without this snap the wizard would silently keep an
+  // invisible selection and create an agent that can never acquire a lease.
+  useEffect(() => {
+    const visible = [...recommendedAdapters, ...moreAdapters].filter(
+      (a) => !a.comingSoon,
+    );
+    if (visible.length === 0) return;
+    if (visible.some((a) => a.type === adapterType)) return;
+    const next = visible[0].type as AdapterType;
+    setAdapterType(next);
+    if (next === "codex_local") return;
+    if (next === "opencode_local") {
+      setModel(DEFAULT_OPENCODE_LOCAL_MODEL);
+      return;
+    }
+    if (next === "gemini_local") {
+      setModel(DEFAULT_GEMINI_LOCAL_MODEL);
+      return;
+    }
+    if (next === "cursor") {
+      setModel(DEFAULT_CURSOR_LOCAL_MODEL);
+      return;
+    }
+    setModel("");
+  }, [recommendedAdapters, moreAdapters, adapterType]);
+
   const COMMAND_PLACEHOLDERS: Record<string, string> = {
     claude_local: "claude",
     codex_local: "codex",


### PR DESCRIPTION
## What

When the server's adapter registry disables the wizard's default adapter (`claude_local`) — e.g. a Kubernetes-sandbox deployment whose `PAPERCLIP_ADAPTERS` registry doesn't include it — the adapter grid hides the card, but the wizard silently keeps the invisible selection (the `useState` default, or a restored saved draft). "Give it a heartbeat" then creates an agent whose every run fails with:

```
Failed to acquire lease for environment "Kubernetes Sandbox" (sandbox):
Adapter "claude_local" is not in the configured adapter registry
```

…which is a broken first-run experience: the user never chose that adapter and can't see what's wrong.

This PR snaps the selection to the first visible adapter choice whenever the current one is hidden (server-disabled, filtered, or coming-soon), applying the same model defaults the grid's click handlers set.

Observed live on a cloud deployment: the wizard showed only Codex/Gemini/OpenCode/Pi, the environment check even reported "Passed", and the created team lead errored immediately.

## Tests

- `snaps a disabled default adapterType to the first enabled adapter`
- `keeps an enabled saved adapterType untouched`

(`OnboardingWizard.test.tsx` is new — there was no test file for the wizard; the adapter layer is stubbed so the suite doesn't drag in every adapter package.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
