### PR TITLE
test(server): fix race in bounded-retry resumeFailure assertion (flaky test)

### DIFF
--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -1976,12 +1976,19 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       body: "Agent failed to resume after approval: `adapter_failed` — retrying (attempt 1/3)",
     });
 
-    const interaction = await db
-      .select({ result: issueThreadInteractions.result })
-      .from(issueThreadInteractions)
-      .where(eq(issueThreadInteractions.id, interactionId))
-      .then((rows) => rows[0] ?? null);
-    expect(interaction?.result).toMatchObject({
+    // The resumeFailure marker is the last write in the recovery flow (after
+    // the retry run is committed and the system comment is inserted), so poll
+    // for it instead of reading once.
+    const interactionResult = await waitForValue(async () => {
+      const row = await db
+        .select({ result: issueThreadInteractions.result })
+        .from(issueThreadInteractions)
+        .where(eq(issueThreadInteractions.id, interactionId))
+        .then((rows) => rows[0] ?? null);
+      const result = row?.result as { resumeFailure?: unknown } | null;
+      return result?.resumeFailure ? result : null;
+    });
+    expect(interactionResult).toMatchObject({
       version: 1,
       outcome: "accepted",
       resumeFailure: {


### PR DESCRIPTION
## What

`heartbeat-process-recovery.test.ts` > "schedules bounded retries for failed accepted interaction continuation wakes" is flaky: it reads `issueThreadInteractions.result` once, right after waiting for the retry-run row — but the recovery flow writes the `resumeFailure` marker **last**, after the retry run is committed and the system comment is inserted. Under CI load the one-shot read races the detached writer and sees `{ outcome: 'accepted', version: 1 }` without `resumeFailure`:

```
AssertionError: expected { outcome: 'accepted', version: 1 } to match object { version: 1, …(2) }
- "resumeFailure": { "attempt": 1, "errorCode": "adapter_failed", "maxAttempts": 3 }
```

We've had this single test fail on several unrelated PRs (introduced with cc81eefb6).

## Fix

Poll for the marker with the file's existing `waitForValue` helper instead of reading once — the same pattern the rest of the file uses for late writes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
