### PR TITLE
feat(adapters): add opt-in workspace filesystem sandbox

### DIFF
--- a/doc/spec/agent-runs.md
+++ b/doc/spec/agent-runs.md
@@ -251,6 +251,8 @@ Runs local `claude` CLI directly.
   "model": "optional-model-id",
   "maxTurnsPerRun": 1000,
   "dangerouslySkipPermissions": true,
+  "filesystemScope": "workspace",
+  "filesystemExtraPaths": ["/opt/toolchains", {"path": "/var/cache/pnpm", "access": "rw"}],
   "env": {"KEY": "VALUE"},
   "extraArgs": [],
   "timeoutSec": 1800,
@@ -288,6 +290,8 @@ Runs local `codex` CLI directly.
   "model": "optional-model-id",
   "search": false,
   "dangerouslyBypassApprovalsAndSandbox": true,
+  "filesystemScope": "workspace",
+  "filesystemExtraPaths": ["/opt/toolchains", {"path": "/var/cache/pnpm", "access": "rw"}],
   "env": {"KEY": "VALUE"},
   "extraArgs": [],
   "timeoutSec": 1800,
@@ -301,6 +305,8 @@ Runs local `codex` CLI directly.
 - Resume form: `codex exec --json resume <sessionId> <prompt>`
 - Unsandboxed mode: add `--dangerously-bypass-approvals-and-sandbox` when enabled
 - Optional search mode: add `--search`
+
+For Linux local coding adapters, `filesystemScope: "workspace"` adds host-level filesystem confinement around the CLI process. It is disabled by default and independent of the CLI's own approval or sandbox flags. Paperclip uses Bubblewrap to expose the active workspace and adapter-managed config/home, creates a private `/tmp`, and hides other host paths. `filesystemExtraPaths` can expose additional absolute paths read-only (string or `access: "ro"`) or writable (`access: "rw"`). Install `bwrap` on the Paperclip host before enabling the option. Auto engine selection uses the CLI lane while this scope is enabled; explicit ACP mode is rejected because ACP processes are not yet covered by the spawn wrapper.
 
 ### Output parsing
 

--- a/packages/adapter-utils/src/execution-target.ts
+++ b/packages/adapter-utils/src/execution-target.ts
@@ -38,6 +38,7 @@ import {
 import { sanitizeRemoteExecutionEnv } from "./remote-execution-env.js";
 import { preferredShellForSandbox, shellCommandArgs } from "./sandbox-shell.js";
 import type { RuntimeProgressSink, RuntimeStatusSink } from "./runtime-progress.js";
+import type { LocalProcessSandboxOptions } from "./local-process-sandbox.js";
 
 export type { RuntimeProgressSink } from "./runtime-progress.js";
 
@@ -108,6 +109,7 @@ export interface AdapterExecutionTargetProcessOptions {
    * onLog is suppressed and incremental chunks flow through `onLog` instead.
    */
   runLogTail?: SandboxRunLogTailFactory | null;
+  localProcessSandbox?: LocalProcessSandboxOptions | null;
 }
 
 export interface AdapterExecutionTargetShellOptions {
@@ -583,6 +585,7 @@ export async function runAdapterExecutionTargetProcess(
     onLog: options.onLog,
     onSpawn: options.onSpawn,
     terminalResultCleanup: options.terminalResultCleanup,
+    localProcessSandbox: target?.kind === "local" || !target ? options.localProcessSandbox : null,
     remoteExecution: adapterExecutionTargetToRemoteSpec(target),
   });
 }

--- a/packages/adapter-utils/src/local-process-sandbox.test.ts
+++ b/packages/adapter-utils/src/local-process-sandbox.test.ts
@@ -1,0 +1,82 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { buildLocalProcessSandboxSpawnTarget, parseLocalProcessSandboxExtraPaths } from "./local-process-sandbox.js";
+import { runChildProcess } from "./server-utils.js";
+
+const cleanup: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(cleanup.splice(0).map((candidate) => fs.rm(candidate, { recursive: true, force: true })));
+});
+
+describe("local process sandbox", () => {
+  it("parses read-only and writable extra paths", () => {
+    expect(parseLocalProcessSandboxExtraPaths(["/opt/cache", { path: "/var/lib/tool", access: "rw" }])).toEqual([
+      { path: "/opt/cache", access: "ro" },
+      { path: "/var/lib/tool", access: "rw" },
+    ]);
+    expect(() => parseLocalProcessSandboxExtraPaths(["relative"])).toThrow("must be an absolute path");
+  });
+
+  it("builds a fresh-root bubblewrap command with workspace access", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-fs-sandbox-"));
+    cleanup.push(root);
+    const workspace = path.join(root, "workspace");
+    const managedHome = path.join(root, "managed-home");
+    await fs.mkdir(workspace);
+    await fs.mkdir(managedHome);
+    const target = await buildLocalProcessSandboxSpawnTarget({
+      executable: process.execPath,
+      args: ["-e", "console.log('ok')"],
+      cwd: workspace,
+      options: { workspaceDir: workspace, managedPaths: [{ path: managedHome, access: "rw" }], homeDir: managedHome },
+    });
+    expect(target.command).toBe("bwrap");
+    expect(target.args).toContain("--tmpfs");
+    expect(target.args).toContain(workspace);
+    expect(target.args).toContain(managedHome);
+  });
+
+  it("fails clearly when Bubblewrap is unavailable", async () => {
+    const workspace = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-fs-sandbox-missing-"));
+    cleanup.push(workspace);
+    await expect(runChildProcess("filesystem-sandbox-missing", process.execPath, ["-e", "process.exit(0)"], {
+      cwd: workspace, env: {}, timeoutSec: 10, graceSec: 1, onLog: async () => {},
+      localProcessSandbox: { workspaceDir: workspace, command: path.join(workspace, "missing-bwrap") },
+    })).rejects.toThrow("requires Bubblewrap");
+  });
+
+  it.runIf(Boolean(process.env.PAPERCLIP_TEST_BWRAP))("blocks an outside canary and permits declared paths", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-fs-sandbox-integration-"));
+    cleanup.push(root);
+    const workspace = path.join(root, "workspace");
+    const outside = path.join(root, "canary.txt");
+    const allowed = path.join(root, "allowed.txt");
+    await fs.mkdir(workspace);
+    await fs.writeFile(outside, "host-secret", "utf8");
+    await fs.writeFile(allowed, "allowed-value", "utf8");
+    const script = [
+      "const fs = require('node:fs');",
+      `try { fs.readFileSync(${JSON.stringify(outside)}, 'utf8'); process.exit(9); } catch (error) { if (!['ENOENT', 'EACCES'].includes(error.code)) throw error; }`,
+      `if (fs.readFileSync(${JSON.stringify(allowed)}, 'utf8') !== 'allowed-value') process.exit(8);`,
+      "fs.writeFileSync('workspace-ok.txt', 'ok');",
+    ].join("\n");
+    const result = await runChildProcess("filesystem-sandbox-test", process.execPath, ["-e", script], {
+      cwd: workspace, env: {}, timeoutSec: 10, graceSec: 1, onLog: async () => {},
+      localProcessSandbox: { workspaceDir: workspace, extraPaths: [{ path: allowed, access: "ro" }], command: process.env.PAPERCLIP_TEST_BWRAP },
+    });
+    expect(result.exitCode, result.stderr).toBe(0);
+    await expect(fs.readFile(path.join(workspace, "workspace-ok.txt"), "utf8")).resolves.toBe("ok");
+  });
+
+  it.runIf(Boolean(process.env.PAPERCLIP_TEST_BWRAP && process.env.PAPERCLIP_TEST_SANDBOX_BUILD))("runs a TypeScript build inside the confined workspace", async () => {
+    const workspace = process.cwd();
+    const result = await runChildProcess("filesystem-sandbox-build-test", path.join(workspace, "node_modules", ".bin", "tsc"), ["--noEmit", "-p", "packages/adapter-utils/tsconfig.json"], {
+      cwd: workspace, env: {}, timeoutSec: 60, graceSec: 2, onLog: async () => {},
+      localProcessSandbox: { workspaceDir: workspace, command: process.env.PAPERCLIP_TEST_BWRAP },
+    });
+    expect(result.exitCode, result.stderr).toBe(0);
+  });
+});

--- a/packages/adapter-utils/src/local-process-sandbox.test.ts
+++ b/packages/adapter-utils/src/local-process-sandbox.test.ts
@@ -2,7 +2,11 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import { buildLocalProcessSandboxSpawnTarget, parseLocalProcessSandboxExtraPaths } from "./local-process-sandbox.js";
+import {
+  buildLocalProcessSandboxSpawnTarget,
+  parseLocalProcessSandboxExtraPaths,
+  resolveLocalProcessSandboxWorkspaceDir,
+} from "./local-process-sandbox.js";
 import { runChildProcess } from "./server-utils.js";
 
 const cleanup: string[] = [];
@@ -37,6 +41,45 @@ describe("local process sandbox", () => {
     expect(target.args).toContain("--tmpfs");
     expect(target.args).toContain(workspace);
     expect(target.args).toContain(managedHome);
+  });
+
+  it("keeps the realized workspace root when execution starts in a subdirectory", () => {
+    expect(resolveLocalProcessSandboxWorkspaceDir({
+      executionCwd: "/workspace/packages/server",
+      workspaceCwd: "/workspace/packages/server",
+      workspaceWorktreePath: "/workspace",
+    })).toBe("/workspace");
+  });
+
+  it("creates missing adapter-managed writable paths before mounting them", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-fs-sandbox-managed-"));
+    cleanup.push(root);
+    const workspace = path.join(root, "workspace");
+    const managedFile = path.join(root, "managed-home", ".tool.json");
+    await fs.mkdir(workspace);
+    const target = await buildLocalProcessSandboxSpawnTarget({
+      executable: process.execPath,
+      args: [],
+      cwd: workspace,
+      options: {
+        workspaceDir: workspace,
+        managedPaths: [{ path: managedFile, access: "rw", createIfMissing: "file" }],
+      },
+    });
+    await expect(fs.stat(managedFile)).resolves.toMatchObject({ size: 0 });
+    expect(target.args).toContain(managedFile);
+  });
+
+  it("rejects missing declared extra paths instead of silently omitting them", async () => {
+    const workspace = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-fs-sandbox-extra-"));
+    cleanup.push(workspace);
+    const missingPath = path.join(workspace, "missing");
+    await expect(buildLocalProcessSandboxSpawnTarget({
+      executable: process.execPath,
+      args: [],
+      cwd: workspace,
+      options: { workspaceDir: workspace, extraPaths: [{ path: missingPath, access: "rw" }] },
+    })).rejects.toThrow(`Sandbox path "${missingPath}" does not exist.`);
   });
 
   it("fails clearly when Bubblewrap is unavailable", async () => {

--- a/packages/adapter-utils/src/local-process-sandbox.ts
+++ b/packages/adapter-utils/src/local-process-sandbox.ts
@@ -6,6 +6,7 @@ export type LocalProcessSandboxAccess = "ro" | "rw";
 export interface LocalProcessSandboxPath {
   path: string;
   access: LocalProcessSandboxAccess;
+  createIfMissing?: "file" | "directory";
 }
 
 export interface LocalProcessSandboxOptions {
@@ -44,6 +45,16 @@ function normalizeAbsolutePath(candidate: string, label: string): string {
 
 async function pathExists(candidate: string): Promise<boolean> {
   return fs.lstat(candidate).then(() => true).catch(() => false);
+}
+
+async function createSandboxPath(candidate: string, kind: "file" | "directory"): Promise<void> {
+  if (kind === "directory") {
+    await fs.mkdir(candidate, { recursive: true });
+    return;
+  }
+  await fs.mkdir(path.dirname(candidate), { recursive: true });
+  const handle = await fs.open(candidate, "a");
+  await handle.close();
 }
 
 function parentDirectories(candidate: string): string[] {
@@ -104,9 +115,20 @@ export async function buildLocalProcessSandboxSpawnTarget(input: {
   ];
   const created = new Set<string>(["/", "/proc", "/dev", "/tmp"]);
   const mounted = new Set<string>();
-  const mount = async (source: string, access: LocalProcessSandboxAccess) => {
+  const mount = async (
+    source: string,
+    access: LocalProcessSandboxAccess,
+    options: { required?: boolean; createIfMissing?: "file" | "directory" } = {},
+  ) => {
     const normalized = normalizeAbsolutePath(source, "Sandbox path");
-    if (mounted.has(normalized) || !(await pathExists(normalized))) return;
+    if (mounted.has(normalized)) return;
+    if (!(await pathExists(normalized)) && options.createIfMissing) {
+      await createSandboxPath(normalized, options.createIfMissing);
+    }
+    if (!(await pathExists(normalized))) {
+      if (options.required) throw new Error(`Sandbox path "${normalized}" does not exist.`);
+      return;
+    }
     addParentDirectories(args, created, normalized);
     args.push(access === "rw" ? "--bind" : "--ro-bind", normalized, normalized);
     mounted.add(normalized);
@@ -115,11 +137,26 @@ export async function buildLocalProcessSandboxSpawnTarget(input: {
 
   for (const systemPath of SYSTEM_READ_PATHS) await mount(systemPath, "ro");
   for (const executablePath of await executableReadPaths(input.executable)) await mount(executablePath, "ro");
-  for (const managedPath of input.options.managedPaths ?? []) await mount(managedPath.path, managedPath.access);
-  for (const extraPath of input.options.extraPaths ?? []) await mount(extraPath.path, extraPath.access);
-  await mount(workspaceDir, "rw");
+  for (const managedPath of input.options.managedPaths ?? []) {
+    await mount(managedPath.path, managedPath.access, {
+      required: true,
+      createIfMissing: managedPath.createIfMissing,
+    });
+  }
+  for (const extraPath of input.options.extraPaths ?? []) {
+    await mount(extraPath.path, extraPath.access, { required: true });
+  }
+  await mount(workspaceDir, "rw", { required: true });
   args.push("--chdir", cwd, "--", input.executable, ...input.args);
   return { command: input.options.command?.trim() || "bwrap", args, cwd: "/" };
+}
+
+export function resolveLocalProcessSandboxWorkspaceDir(input: {
+  executionCwd: string;
+  workspaceCwd?: string | null;
+  workspaceWorktreePath?: string | null;
+}): string {
+  return input.workspaceWorktreePath?.trim() || input.workspaceCwd?.trim() || input.executionCwd;
 }
 
 export function parseLocalProcessSandboxExtraPaths(value: unknown): LocalProcessSandboxPath[] {

--- a/packages/adapter-utils/src/local-process-sandbox.ts
+++ b/packages/adapter-utils/src/local-process-sandbox.ts
@@ -1,0 +1,141 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+export type LocalProcessSandboxAccess = "ro" | "rw";
+
+export interface LocalProcessSandboxPath {
+  path: string;
+  access: LocalProcessSandboxAccess;
+}
+
+export interface LocalProcessSandboxOptions {
+  workspaceDir: string;
+  managedPaths?: LocalProcessSandboxPath[];
+  extraPaths?: LocalProcessSandboxPath[];
+  homeDir?: string | null;
+  command?: string;
+}
+
+export interface LocalProcessSandboxSpawnTarget {
+  command: string;
+  args: string[];
+  cwd: string;
+}
+
+const SYSTEM_READ_PATHS = [
+  "/usr",
+  "/etc/ca-certificates",
+  "/etc/ssl",
+  "/etc/resolv.conf",
+  "/etc/hosts",
+  "/etc/nsswitch.conf",
+  "/etc/passwd",
+  "/etc/group",
+  "/etc/localtime",
+  "/etc/timezone",
+  "/etc/gitconfig",
+] as const;
+
+function normalizeAbsolutePath(candidate: string, label: string): string {
+  const trimmed = candidate.trim();
+  if (!trimmed || !path.isAbsolute(trimmed)) throw new Error(`${label} must be an absolute path.`);
+  return path.resolve(trimmed);
+}
+
+async function pathExists(candidate: string): Promise<boolean> {
+  return fs.lstat(candidate).then(() => true).catch(() => false);
+}
+
+function parentDirectories(candidate: string): string[] {
+  const directories: string[] = [];
+  let current = path.dirname(candidate);
+  while (current !== path.dirname(current)) {
+    directories.push(current);
+    current = path.dirname(current);
+  }
+  return directories.reverse();
+}
+
+function addParentDirectories(args: string[], created: Set<string>, candidate: string): void {
+  for (const directory of parentDirectories(candidate)) {
+    if (created.has(directory)) continue;
+    args.push("--dir", directory);
+    created.add(directory);
+  }
+}
+
+async function nearestPackageRoot(candidate: string): Promise<string> {
+  let current = path.dirname(candidate);
+  while (current !== path.dirname(current)) {
+    if (await pathExists(path.join(current, "package.json"))) return current;
+    current = path.dirname(current);
+  }
+  return path.dirname(candidate);
+}
+
+async function executableReadPaths(command: string): Promise<string[]> {
+  const paths = new Set<string>([path.dirname(command)]);
+  const realCommand = await fs.realpath(command).catch(() => command);
+  paths.add(await nearestPackageRoot(realCommand));
+  return Array.from(paths);
+}
+
+export async function buildLocalProcessSandboxSpawnTarget(input: {
+  executable: string;
+  args: string[];
+  cwd: string;
+  options: LocalProcessSandboxOptions;
+}): Promise<LocalProcessSandboxSpawnTarget> {
+  if (process.platform !== "linux") {
+    throw new Error('filesystemScope="workspace" is currently supported only on Linux.');
+  }
+  const workspaceDir = normalizeAbsolutePath(input.options.workspaceDir, "Sandbox workspaceDir");
+  const cwd = normalizeAbsolutePath(input.cwd, "Sandbox cwd");
+  const relativeCwd = path.relative(workspaceDir, cwd);
+  if (relativeCwd.startsWith("..") || path.isAbsolute(relativeCwd)) {
+    throw new Error(`Sandbox cwd "${cwd}" must be inside workspaceDir "${workspaceDir}".`);
+  }
+
+  const args = [
+    "--die-with-parent", "--new-session", "--unshare-pid", "--unshare-ipc", "--unshare-uts",
+    "--tmpfs", "/", "--proc", "/proc", "--dev", "/dev", "--tmpfs", "/tmp",
+    "--symlink", "usr/bin", "/bin", "--symlink", "usr/sbin", "/sbin",
+    "--symlink", "usr/lib", "/lib", "--symlink", "usr/lib64", "/lib64",
+  ];
+  const created = new Set<string>(["/", "/proc", "/dev", "/tmp"]);
+  const mounted = new Set<string>();
+  const mount = async (source: string, access: LocalProcessSandboxAccess) => {
+    const normalized = normalizeAbsolutePath(source, "Sandbox path");
+    if (mounted.has(normalized) || !(await pathExists(normalized))) return;
+    addParentDirectories(args, created, normalized);
+    args.push(access === "rw" ? "--bind" : "--ro-bind", normalized, normalized);
+    mounted.add(normalized);
+    created.add(normalized);
+  };
+
+  for (const systemPath of SYSTEM_READ_PATHS) await mount(systemPath, "ro");
+  for (const executablePath of await executableReadPaths(input.executable)) await mount(executablePath, "ro");
+  for (const managedPath of input.options.managedPaths ?? []) await mount(managedPath.path, managedPath.access);
+  for (const extraPath of input.options.extraPaths ?? []) await mount(extraPath.path, extraPath.access);
+  await mount(workspaceDir, "rw");
+  args.push("--chdir", cwd, "--", input.executable, ...input.args);
+  return { command: input.options.command?.trim() || "bwrap", args, cwd: "/" };
+}
+
+export function parseLocalProcessSandboxExtraPaths(value: unknown): LocalProcessSandboxPath[] {
+  if (!Array.isArray(value)) return [];
+  return value.map((entry, index) => {
+    if (typeof entry === "string") {
+      return { path: normalizeAbsolutePath(entry, `filesystemExtraPaths[${index}]`), access: "ro" };
+    }
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+      throw new Error(`filesystemExtraPaths[${index}] must be an absolute path or { path, access } object.`);
+    }
+    const raw = entry as Record<string, unknown>;
+    const access = raw.access === "rw" ? "rw" : raw.access === "ro" || raw.access == null ? "ro" : null;
+    if (!access || typeof raw.path !== "string") {
+      throw new Error(`filesystemExtraPaths[${index}] must use access "ro" or "rw" and an absolute path.`);
+    }
+    return { path: normalizeAbsolutePath(raw.path, `filesystemExtraPaths[${index}].path`), access };
+  });
+}

--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -4,6 +4,10 @@ import { constants as fsConstants, promises as fs, type Dirent } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { sanitizeRemoteExecutionEnv } from "./remote-execution-env.js";
+import {
+  buildLocalProcessSandboxSpawnTarget,
+  type LocalProcessSandboxOptions,
+} from "./local-process-sandbox.js";
 import { buildSshSpawnTarget, type SshRemoteExecutionSpec } from "./ssh.js";
 import { redactCommandText } from "./command-redaction.js";
 import type {
@@ -2056,6 +2060,7 @@ async function resolveSpawnTarget(
   options: {
     remoteExecution?: RemoteExecutionSpec | null;
     remoteEnv?: Record<string, string> | null;
+    localProcessSandbox?: LocalProcessSandboxOptions | null;
   } = {},
 ): Promise<SpawnTarget> {
   const remote = options.remoteExecution ?? null;
@@ -2082,6 +2087,23 @@ async function resolveSpawnTarget(
 
   const resolved = await resolveCommandPath(command, cwd, env);
   const executable = resolved ?? command;
+
+  if (options.localProcessSandbox) {
+    if (!resolved) throw new Error(`Command not found in PATH: "${command}"`);
+    const sandboxTarget = await buildLocalProcessSandboxSpawnTarget({
+      executable,
+      args,
+      cwd,
+      options: options.localProcessSandbox,
+    });
+    const sandboxCommand = await resolveCommandPath(sandboxTarget.command, cwd, env);
+    if (!sandboxCommand) {
+      throw new Error(
+        `filesystemScope="workspace" requires Bubblewrap, but "${sandboxTarget.command}" was not found in PATH. Install bwrap or configure filesystemSandboxCommand.`,
+      );
+    }
+    return { ...sandboxTarget, command: sandboxCommand };
+  }
 
   if (process.platform !== "win32") {
     return { command: executable, args };
@@ -2898,6 +2920,7 @@ export async function runChildProcess(
     terminalResultCleanup?: TerminalResultCleanupOptions;
     stdin?: string;
     remoteExecution?: RemoteExecutionSpec | null;
+    localProcessSandbox?: LocalProcessSandboxOptions | null;
   },
 ): Promise<RunProcessResult> {
   const onLogError = opts.onLogError ?? ((err, id, msg) => console.warn({ err, runId: id }, msg));
@@ -2923,9 +2946,11 @@ export async function runChildProcess(
     }
 
     const mergedEnv = ensurePathInEnv(rawMerged);
+    if (opts.localProcessSandbox?.homeDir) mergedEnv.HOME = opts.localProcessSandbox.homeDir;
     void resolveSpawnTarget(command, args, opts.cwd, mergedEnv, {
       remoteExecution: opts.remoteExecution ?? null,
       remoteEnv: opts.remoteExecution ? opts.env : null,
+      localProcessSandbox: opts.localProcessSandbox ?? null,
     })
       .then((target) => {
         const child = spawn(target.command, target.args, {

--- a/packages/adapters/claude-local/src/index.ts
+++ b/packages/adapters/claude-local/src/index.ts
@@ -49,6 +49,9 @@ Core fields:
 - env (object, optional): KEY=VALUE environment variables
 - workspaceStrategy (object, optional): execution workspace strategy; currently supports { type: "git_worktree", baseRef?, branchTemplate?, worktreeParentDir? }
 - workspaceRuntime (object, optional): reserved for workspace runtime metadata; workspace runtime services are manually controlled from the workspace UI and are not auto-started by heartbeats
+- filesystemScope (string, optional): set to "workspace" to confine local CLI filesystem access with Bubblewrap. Off by default. The workspace and Claude config remain writable; other host paths are hidden.
+- filesystemExtraPaths (array, optional): additional absolute host paths exposed inside the workspace sandbox. String entries are read-only; object entries use { path: "/absolute/path", access: "ro" | "rw" }.
+- filesystemSandboxCommand (string, optional): Bubblewrap executable name or absolute path; defaults to "bwrap". Linux only.
 
 ACP fields (only when engine="acp"):
 - agentCommand (string, optional): override for the Claude ACP server command; defaults to the package-local claude-agent-acp binary
@@ -62,6 +65,7 @@ Operational fields:
 - graceSec (number, optional): SIGTERM grace period in seconds
 
 Notes:
+- filesystemScope="workspace" is spawn-level filesystem confinement and is orthogonal to Claude permission flags. It requires Bubblewrap on the host, uses an isolated /tmp, and selects the CLI engine in auto mode; engine="acp" is rejected because ACP confinement is not yet supported.
 - The Claude ACP lane requires Node >=22.12.0 and @agentclientprotocol/claude-agent-acp to be installed with this adapter package. Auto engine selection falls back to CLI when those prerequisites are unavailable; explicit engine="acp" fails loudly.
 - For ACP runs, model selection is passed through ANTHROPIC_MODEL at ACP server startup; Paperclip-managed Claude permissions and ephemeral skill materialization are handled by the shared ACP engine.
 - When Paperclip realizes a workspace/runtime for a run, it injects PAPERCLIP_WORKSPACE_* and PAPERCLIP_RUNTIME_* env vars for agent-side tooling.

--- a/packages/adapters/claude-local/src/server/acp.test.ts
+++ b/packages/adapters/claude-local/src/server/acp.test.ts
@@ -259,6 +259,11 @@ describe("claude_local ACP lane", () => {
     ).resolves.toEqual({ engine: "acp", explicit: true });
   });
 
+  it("selects the confined CLI lane for workspace filesystem scope", async () => {
+    await expect(resolveClaudeExecutionEngineForRun({ config: { filesystemScope: "workspace" }, executionTarget: null })).resolves.toMatchObject({ engine: "cli", explicit: false, fallbackReason: expect.stringContaining("spawn-level confinement") });
+    await expect(resolveClaudeExecutionEngineForRun({ config: { engine: "acp", filesystemScope: "workspace" }, executionTarget: null })).rejects.toThrow("ACP confinement is not supported");
+  });
+
   it("uses ACP for bridged sandbox auto runs when the ACP command is configured as a shell command", async () => {
     setNodeVersion("v22.12.0");
     await expect(

--- a/packages/adapters/claude-local/src/server/acp.ts
+++ b/packages/adapters/claude-local/src/server/acp.ts
@@ -65,6 +65,10 @@ export async function resolveClaudeExecutionEngineForRun(
   input: ClaudeEngineResolutionInput,
 ): Promise<ClaudeEngineSelection> {
   const selection = normalizeEngine(input.config.engine);
+  if (input.config.filesystemScope === "workspace") {
+    if (selection.explicit && selection.engine === "acp") throw new Error('filesystemScope="workspace" requires the Claude CLI engine; ACP confinement is not supported.');
+    return { engine: "cli", explicit: selection.explicit, ...(!selection.explicit ? { fallbackReason: 'filesystemScope="workspace" requires spawn-level confinement in the CLI lane.' } : {}) };
+  }
   if (selection.explicit || selection.engine !== "acp") return selection;
 
   const fallbackReason = await defaultClaudeAcpFallbackReason(input);

--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -46,6 +46,7 @@ import {
 } from "@paperclipai/adapter-utils/server-utils";
 import {
   parseLocalProcessSandboxExtraPaths,
+  resolveLocalProcessSandboxWorkspaceDir,
   type LocalProcessSandboxOptions,
 } from "@paperclipai/adapter-utils/local-process-sandbox";
 import {
@@ -497,13 +498,18 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     onLog,
   });
   const sharedClaudeConfigDir = resolveSharedClaudeConfigDir(process.env);
+  const localSandboxWorkspaceDir = resolveLocalProcessSandboxWorkspaceDir({
+    executionCwd: effectiveExecutionCwd,
+    workspaceCwd: effectiveWorkspaceCwd,
+    workspaceWorktreePath,
+  });
   const localProcessSandbox: LocalProcessSandboxOptions | null =
     config.filesystemScope === "workspace" && !executionTargetIsRemote
       ? {
-          workspaceDir: effectiveExecutionCwd,
+          workspaceDir: localSandboxWorkspaceDir,
           managedPaths: [
-            { path: sharedClaudeConfigDir, access: "rw" },
-            { path: path.join(path.dirname(sharedClaudeConfigDir), ".claude.json"), access: "rw" },
+            { path: sharedClaudeConfigDir, access: "rw", createIfMissing: "directory" },
+            { path: path.join(path.dirname(sharedClaudeConfigDir), ".claude.json"), access: "rw", createIfMissing: "file" },
             { path: promptBundle.addDir, access: "ro" },
           ],
           extraPaths: parseLocalProcessSandboxExtraPaths(config.filesystemExtraPaths),
@@ -515,7 +521,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     env.CLAUDE_CONFIG_DIR = sharedClaudeConfigDir;
     await onLog(
       "stdout",
-      `[paperclip] Confining Claude filesystem access to workspace "${effectiveExecutionCwd}" and declared adapter paths.\n`,
+      `[paperclip] Confining Claude filesystem access to workspace "${localSandboxWorkspaceDir}" and declared adapter paths.\n`,
     );
   }
   const useManagedRemoteClaudeConfig =

--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -45,6 +45,10 @@ import {
   DEFAULT_PAPERCLIP_AGENT_PROMPT_TEMPLATE,
 } from "@paperclipai/adapter-utils/server-utils";
 import {
+  parseLocalProcessSandboxExtraPaths,
+  type LocalProcessSandboxOptions,
+} from "@paperclipai/adapter-utils/local-process-sandbox";
+import {
   claudeModelUsageTotals,
   parseClaudeStreamJson,
   describeClaudeFailure,
@@ -492,6 +496,28 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     instructionsContents: combinedInstructionsContents,
     onLog,
   });
+  const sharedClaudeConfigDir = resolveSharedClaudeConfigDir(process.env);
+  const localProcessSandbox: LocalProcessSandboxOptions | null =
+    config.filesystemScope === "workspace" && !executionTargetIsRemote
+      ? {
+          workspaceDir: effectiveExecutionCwd,
+          managedPaths: [
+            { path: sharedClaudeConfigDir, access: "rw" },
+            { path: path.join(path.dirname(sharedClaudeConfigDir), ".claude.json"), access: "rw" },
+            { path: promptBundle.addDir, access: "ro" },
+          ],
+          extraPaths: parseLocalProcessSandboxExtraPaths(config.filesystemExtraPaths),
+          homeDir: path.dirname(sharedClaudeConfigDir),
+          command: asString(config.filesystemSandboxCommand, "bwrap"),
+        }
+      : null;
+  if (localProcessSandbox) {
+    env.CLAUDE_CONFIG_DIR = sharedClaudeConfigDir;
+    await onLog(
+      "stdout",
+      `[paperclip] Confining Claude filesystem access to workspace "${effectiveExecutionCwd}" and declared adapter paths.\n`,
+    );
+  }
   const useManagedRemoteClaudeConfig =
     executionTargetIsRemote &&
     adapterExecutionTargetUsesManagedHome(executionTarget) &&
@@ -823,6 +849,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         graceMs: terminalResultCleanupGraceMs,
         hasTerminalResult: ({ stdout }) => parseClaudeStreamJson(stdout).resultJson !== null,
       },
+      localProcessSandbox,
     });
 
     const parsedStream = parseClaudeStreamJson(proc.stdout);

--- a/packages/adapters/codex-local/src/index.ts
+++ b/packages/adapters/codex-local/src/index.ts
@@ -86,6 +86,9 @@ Core fields:
 - env (object, optional): KEY=VALUE environment variables
 - workspaceStrategy (object, optional): execution workspace strategy; currently supports { type: "git_worktree", baseRef?, branchTemplate?, worktreeParentDir? }
 - workspaceRuntime (object, optional): reserved for workspace runtime metadata; workspace runtime services are manually controlled from the workspace UI and are not auto-started by heartbeats
+- filesystemScope (string, optional): set to "workspace" to confine local CLI filesystem access with Bubblewrap. Off by default. The workspace and managed CODEX_HOME remain writable; other host paths are hidden.
+- filesystemExtraPaths (array, optional): additional absolute host paths exposed inside the workspace sandbox. String entries are read-only; object entries use { path: "/absolute/path", access: "ro" | "rw" }.
+- filesystemSandboxCommand (string, optional): Bubblewrap executable name or absolute path; defaults to "bwrap". Linux only.
 
 Operational fields:
 - timeoutSec (number, optional): run timeout in seconds
@@ -98,6 +101,7 @@ Operational fields:
 - warmHandleIdleMs (number, optional): warm ACP process idle timeout when engine="acp"; defaults to 0
 
 Notes:
+- filesystemScope="workspace" is spawn-level filesystem confinement and is orthogonal to Codex approval/sandbox flags. It requires Bubblewrap on the host, uses an isolated /tmp, and selects the CLI engine in auto mode; engine="acp" is rejected because ACP confinement is not yet supported.
 - Prompts are piped via stdin (Codex receives "-" prompt argument).
 - If instructionsFilePath is configured, Paperclip prepends that file's contents to the stdin prompt on every run.
 - Codex exec automatically applies repo-scoped AGENTS.md instructions from the active workspace. Paperclip cannot suppress that discovery in exec mode, so repo AGENTS.md files may still apply even when you only configured an explicit instructionsFilePath.

--- a/packages/adapters/codex-local/src/server/acp.test.ts
+++ b/packages/adapters/codex-local/src/server/acp.test.ts
@@ -246,6 +246,11 @@ describe("codex_local ACP lane", () => {
     ).resolves.toEqual({ engine: "acp", explicit: true });
   });
 
+  it("selects the confined CLI lane for workspace filesystem scope", async () => {
+    await expect(resolveCodexExecutionEngineForRun({ config: { filesystemScope: "workspace" }, executionTarget: null })).resolves.toMatchObject({ engine: "cli", explicit: false, fallbackReason: expect.stringContaining("spawn-level confinement") });
+    await expect(resolveCodexExecutionEngineForRun({ config: { engine: "acp", filesystemScope: "workspace" }, executionTarget: null })).rejects.toThrow("ACP confinement is not supported");
+  });
+
   it("uses ACP for bridged sandbox auto runs when the ACP command is configured as a shell command", async () => {
     setNodeVersion("v22.13.0");
     await expect(

--- a/packages/adapters/codex-local/src/server/acp.ts
+++ b/packages/adapters/codex-local/src/server/acp.ts
@@ -66,6 +66,10 @@ export async function resolveCodexExecutionEngineForRun(
   input: CodexEngineResolutionInput,
 ): Promise<CodexEngineSelection> {
   const selection = normalizeEngine(input.config.engine);
+  if (input.config.filesystemScope === "workspace") {
+    if (selection.explicit && selection.engine === "acp") throw new Error('filesystemScope="workspace" requires the Codex CLI engine; ACP confinement is not supported.');
+    return { engine: "cli", explicit: selection.explicit, ...(!selection.explicit ? { fallbackReason: 'filesystemScope="workspace" requires spawn-level confinement in the CLI lane.' } : {}) };
+  }
   if (selection.explicit || selection.engine !== "acp") return selection;
 
   const fallbackReason = await defaultCodexAcpFallbackReason(input);

--- a/packages/adapters/codex-local/src/server/execute.ts
+++ b/packages/adapters/codex-local/src/server/execute.ts
@@ -40,6 +40,7 @@ import {
 } from "@paperclipai/adapter-utils/server-utils";
 import {
   parseLocalProcessSandboxExtraPaths,
+  resolveLocalProcessSandboxWorkspaceDir,
   type LocalProcessSandboxOptions,
 } from "@paperclipai/adapter-utils/local-process-sandbox";
 import {
@@ -636,11 +637,16 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       ),
     );
     const billingType = resolveCodexBillingType(effectiveEnv);
+    const localSandboxWorkspaceDir = resolveLocalProcessSandboxWorkspaceDir({
+      executionCwd: effectiveExecutionCwd,
+      workspaceCwd: effectiveWorkspaceCwd,
+      workspaceWorktreePath,
+    });
     const localProcessSandbox: LocalProcessSandboxOptions | null =
       config.filesystemScope === "workspace" && !executionTargetIsRemote
         ? {
-            workspaceDir: effectiveExecutionCwd,
-            managedPaths: [{ path: effectiveCodexHome, access: "rw" }],
+            workspaceDir: localSandboxWorkspaceDir,
+            managedPaths: [{ path: effectiveCodexHome, access: "rw", createIfMissing: "directory" }],
             extraPaths: parseLocalProcessSandboxExtraPaths(config.filesystemExtraPaths),
             homeDir: effectiveCodexHome,
             command: asString(config.filesystemSandboxCommand, "bwrap"),
@@ -649,7 +655,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     if (localProcessSandbox) {
       await onLog(
         "stdout",
-        `[paperclip] Confining Codex filesystem access to workspace "${effectiveExecutionCwd}" and declared adapter paths.\n`,
+        `[paperclip] Confining Codex filesystem access to workspace "${localSandboxWorkspaceDir}" and declared adapter paths.\n`,
       );
     }
     const runtimeEnv = Object.fromEntries(

--- a/packages/adapters/codex-local/src/server/execute.ts
+++ b/packages/adapters/codex-local/src/server/execute.ts
@@ -39,6 +39,10 @@ import {
   joinPromptSections,
 } from "@paperclipai/adapter-utils/server-utils";
 import {
+  parseLocalProcessSandboxExtraPaths,
+  type LocalProcessSandboxOptions,
+} from "@paperclipai/adapter-utils/local-process-sandbox";
+import {
   parseCodexJsonl,
   extractCodexRetryNotBefore,
   isCodexProviderQuotaError,
@@ -632,6 +636,22 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       ),
     );
     const billingType = resolveCodexBillingType(effectiveEnv);
+    const localProcessSandbox: LocalProcessSandboxOptions | null =
+      config.filesystemScope === "workspace" && !executionTargetIsRemote
+        ? {
+            workspaceDir: effectiveExecutionCwd,
+            managedPaths: [{ path: effectiveCodexHome, access: "rw" }],
+            extraPaths: parseLocalProcessSandboxExtraPaths(config.filesystemExtraPaths),
+            homeDir: effectiveCodexHome,
+            command: asString(config.filesystemSandboxCommand, "bwrap"),
+          }
+        : null;
+    if (localProcessSandbox) {
+      await onLog(
+        "stdout",
+        `[paperclip] Confining Codex filesystem access to workspace "${effectiveExecutionCwd}" and declared adapter paths.\n`,
+      );
+    }
     const runtimeEnv = Object.fromEntries(
       Object.entries(ensurePathInEnv(effectiveEnv)).filter(
         (entry): entry is [string, string] => typeof entry[1] === "string",
@@ -923,6 +943,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
             await onLog(stream, cleaned);
           },
           runLogTail: paperclipBridge?.runLogTail,
+          localProcessSandbox,
         });
         const cleanedStderr = stripCodexRolloutNoise(proc.stderr);
         return {


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the control plane operators use to run autonomous agent companies
> - Local coding adapters launch third-party CLIs on the Paperclip host
> - CLI approval flags govern tool consent, but they do not define a host filesystem boundary
> - A local agent can therefore roam outside its assigned workspace and read unrelated host data
> - The boundary must be opt-in so existing installations keep their current behavior
> - This pull request adds a shared Bubblewrap spawn wrapper for `codex_local` and `claude_local`
> - The benefit is workspace-scoped host isolation without coupling it to each CLI's native approval policy

## Linked Issues or Issue Description

- **Security gap:** local Codex and Claude adapter processes can read arbitrary host files outside their assigned workspace.
- **Expected behavior:** operators can opt into a workspace-scoped filesystem view that exposes the active workspace, adapter-managed configuration, declared extra paths, a private `/tmp`, and the minimal read-only system runtime needed to launch the CLI.
- **Compatibility:** the option is disabled by default and currently requires Linux plus Bubblewrap.
- Related prior work: #2988 covers a broader all-adapter Bubblewrap approach, but is currently merge-conflicted; this PR is narrowly scoped to the two affected coding adapters, preserves default behavior, and adds an executable outside-canary plus confined-build test.

## What Changed

- Added a shared local process sandbox wrapper that launches through Bubblewrap with a fresh filesystem root.
- Added opt-in `filesystemScope: "workspace"`, declared read-only/read-write extra paths, and a configurable Bubblewrap command for `codex_local` and `claude_local`.
- Kept managed Codex/Claude configuration available while hiding unrelated host data paths and providing a private `/tmp`.
- Forced auto engine selection onto the confined CLI lane and rejected explicit ACP mode rather than silently bypassing confinement.
- Documented the adapter configuration and added focused unit/integration coverage.

## Verification

- `pnpm --filter @paperclipai/adapter-utils typecheck`
- `pnpm --filter @paperclipai/adapter-codex-local typecheck`
- `pnpm --filter @paperclipai/adapter-claude-local typecheck`
- `pnpm exec vitest run packages/adapter-utils/src/local-process-sandbox.test.ts packages/adapters/codex-local/src/server/acp.test.ts packages/adapters/claude-local/src/server/acp.test.ts` (31 passed; 2 environment-gated integration tests skipped on the host)
- Privileged disposable Linux container with Bubblewrap: sandbox test file passes all 5 tests, including an unreadable outside canary, a declared extra-path read, workspace writes, and an adapter-utils TypeScript build inside the confined view.

## Risks

- Bubblewrap availability and unprivileged user-namespace policy vary by Linux distribution; enabling the option fails clearly when the configured executable cannot be resolved.
- Some builds depend on host caches or toolchains outside the workspace; operators must declare those paths explicitly and choose read-only or read-write access.
- ACP is intentionally unsupported for this scope until its long-lived child process can use the same spawn boundary.
- No default behavior changes because filesystem confinement remains opt-in.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex, GPT-5.3-Codex, coding-optimized reasoning with terminal tool use and executable test validation.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change and contains no internal ticket id
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
