### PR TITLE
fix(company-skills): correct pending-materialization detail for post-hoc imported skills

### DIFF
--- a/server/src/__tests__/company-skills-service.test.ts
+++ b/server/src/__tests__/company-skills-service.test.ts
@@ -1628,6 +1628,60 @@ describeEmbeddedPostgres("companySkillService.list", () => {
     );
   });
 
+  it("reports a pending-materialization detail (not a mangled URL path) for github-sourced skills during read-only runtime listing", async () => {
+    const companyId = randomUUID();
+    const skillId = randomUUID();
+    const skillKey = `company/${companyId}/ad-creative`;
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(companySkills).values({
+      id: skillId,
+      companyId,
+      key: skillKey,
+      slug: "ad-creative",
+      name: "ad-creative",
+      description: null,
+      markdown: "# Ad Creative\n",
+      sourceType: "github",
+      sourceLocator: "https://github.com/coreyhaines31/marketingskills",
+      trustLevel: "markdown_only",
+      compatibility: "compatible",
+      fileInventory: [{ path: "SKILL.md", kind: "skill" }],
+      metadata: { sourceKind: "github" },
+    });
+    await db.insert(agents).values({
+      id: randomUUID(),
+      companyId,
+      name: "Ad Manager",
+      role: "engineer",
+      status: "active",
+      adapterType: "claude_local",
+      adapterConfig: {
+        paperclipSkillSync: {
+          desiredSkills: [skillKey],
+        },
+      },
+    });
+
+    // Post-hoc imported (github/skills_sh) skills never get a `missingSource`
+    // marker — that's only ever written for local_path skills — so, before the
+    // fix, the read-only (`materializeMissing: false`) path fell back to
+    // resolving the raw sourceLocator URL as a filesystem path.
+    const entries = await svc.listRuntimeSkillEntries(companyId, { materializeMissing: false });
+    const entry = entries.find((candidate) => candidate.key === skillKey);
+
+    expect(entry).toMatchObject({ key: skillKey, sourceStatus: "missing" });
+    expect(entry!.missingDetail).not.toContain("https:/github.com");
+    expect(entry!.missingDetail).toContain("__runtime__");
+    expect(entry!.missingDetail).toContain("next run");
+    expect(entry!.missingDetail).toContain(entry!.source);
+  });
+
   it("falls back to stored markdown when reading SKILL.md from a missing local source", async () => {
     const companyId = randomUUID();
     const skillId = randomUUID();

--- a/server/src/services/company-skills.ts
+++ b/server/src/services/company-skills.ts
@@ -2036,9 +2036,23 @@ async function resolveExistingSkillDirectory(skillDir: string | null) {
   return dirStat?.isDirectory() && skillFileStat?.isFile() ? skillDir : null;
 }
 
-function buildMissingRuntimeSourceDetail(skill: Pick<CompanySkill, "name" | "sourceLocator" | "metadata">) {
+function buildMissingRuntimeSourceDetail(
+  skill: Pick<CompanySkill, "name" | "sourceLocator" | "metadata" | "fileInventory">,
+  options: { expectedPath?: string | null } = {},
+) {
   const marker = getMissingSourceMarker(skill.metadata);
-  const sourcePath = asString(marker?.sourcePath) ?? normalizeSourceLocatorDirectory(skill.sourceLocator);
+  // The `missingSource` marker is only ever recorded for `local_path` skills
+  // (see reconcileLocalPathSkillSources), so for github/skills_sh-sourced
+  // skills we fall back to the actual on-disk runtime path instead of
+  // resolving the raw sourceLocator URL as if it were a filesystem path.
+  const sourcePath = asString(marker?.sourcePath) ?? options.expectedPath ?? normalizeSourceLocatorDirectory(skill.sourceLocator);
+  const hasStoredSkillFile = !marker
+    && skill.fileInventory.some((entry) => normalizePortablePath(entry.path) === "SKILL.md");
+  if (hasStoredSkillFile) {
+    return sourcePath
+      ? `Company skill "${skill.name}" is in the library and will be materialized at ${sourcePath} on the agent's next run.`
+      : `Company skill "${skill.name}" is in the library and will be materialized on the agent's next run.`;
+  }
   if (sourcePath) {
     return `Company skill "${skill.name}" is in the library, but Paperclip cannot find its local source at ${sourcePath}.`;
   }
@@ -4866,7 +4880,7 @@ export function companySkillService(db: Db) {
       return {
         status: "missing",
         source: materializedPath,
-        detail: buildMissingRuntimeSourceDetail(skill),
+        detail: buildMissingRuntimeSourceDetail(skill, { expectedPath: materializedPath }),
       };
     }
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Company skills are a shared skill library scoped to a company; skills can be installed into the library and then assigned ("synced") to individual agents independently of when the agent was created
> - When an agent's runtime skill bundle is listed read-only (no clone/materialize side effects), skills that haven't been cloned to disk yet report `status: "missing"` with a human-readable `detail` explaining why
> - For skills whose local clone genuinely disappeared (`local_path` sources), a `missingSource` marker records the last known path so the detail message is accurate. Skills sourced from `github` or `skills_sh` never get that marker, so the fallback in `buildMissingRuntimeSourceDetail()` treated the raw `sourceLocator` (a URL, not a path) as if it were a filesystem path, producing a mangled string like `/app/https:/github.com/org/repo`
> - This makes a completely normal, expected state (skill installed in the library and assigned to an agent, but not yet cloned to `__runtime__` because materialization is deferred to the agent's next run) look like a broken/unrecoverable error
> - This PR fixes `buildMissingRuntimeSourceDetail()` to use the already-resolved runtime materialization path as its fallback instead of mangling the source URL, and to distinguish "will materialize on next run" (skill content exists, nothing cloned yet) from "genuinely missing" (no recoverable source at all)
> - The benefit is accurate, non-alarming status detail for any company skill assigned to an agent after that agent was created, instead of a message that looks like a filesystem/permissions bug

## Linked Issues or Issue Description

No public GitHub issue exists yet for this. Describing it here per the bug report template:

**What happened?** After installing a company skill via the skills import API and assigning it to an existing agent via the skill sync API, `GET` on the agent's runtime skill listing (read-only mode, i.e. `materializeMissing: false`) reports the skill as `"status": "missing"` with a `detail` message containing a mangled path such as `/app/https:/github.com/coreyhaines31/marketingskills` — the raw `sourceLocator` URL with its scheme separator collapsed, prefixed by the runtime skills root. This reads as an unrecoverable filesystem error even though the skill's markdown/file content is fully present in the database and will clone normally on the agent's next run.

**Expected behavior:** The detail message should reference the actual (or expected) on-disk runtime path, and should clearly distinguish "content exists, will materialize on next run" from "no recoverable source."

**Steps to reproduce:**
1. Install a company skill with `sourceType: "github"` or `"skills_sh"` (not `local_path`) via the company skills import endpoint.
2. Assign ("sync") that skill to an agent that was created before the skill was installed.
3. Call the agent runtime skill listing endpoint in read-only mode (`materializeMissing: false`) before any process has cloned the skill to the `__runtime__` directory on disk.
4. Observe `status: "missing"` with a `detail` string containing the mangled `sourceLocator` (e.g. `.../https:/github.com/...`) instead of a real or expected local path.

**Paperclip version or commit:** master @ 634ae1298f

**Deployment mode:** Self-hosted server

**Database mode:** External Postgres

## What Changed

- `buildMissingRuntimeSourceDetail()` now accepts an `expectedPath` option and uses it as the fallback source path when no `missingSource` marker is present (previously it fell back to parsing the raw `sourceLocator` URL as a filesystem path).
- Added a `hasStoredSkillFile` check: when the skill has no marker but does have `SKILL.md` recorded in its `fileInventory`, the detail now reads `"...will be materialized at <path> on the agent's next run"` instead of an error-shaped "cannot find its local source" message.
- The one call site in the read-only runtime listing path now passes its already-computed `materializedPath` through as `expectedPath`, so the detail always names a real (or realistic expected) filesystem path.

## Verification

- Added a regression test in `server/src/__tests__/company-skills-service.test.ts` that installs a `github`-sourced company skill with no `missingSource` marker, assigns it to an agent, and asserts the read-only listing's `missingDetail` no longer contains the mangled `https:/github.com` fragment, references the `__runtime__` path, and mentions "next run".
- `pnpm vitest run server/src/__tests__/company-skills-service.test.ts` — 34/34 passing.
- Also ran the broader `company-skills*.test.ts` suite locally (59 additional tests) — all passing, no regressions.
- `tsc --noEmit` on the touched files shows no new type errors.

## Risks

Low risk. The change only affects the human-readable `detail` string returned for skills already in the `"missing"` runtime status — it does not change `status` values, materialization behavior, or any clone/sync side effects. No schema or API contract changes.

## Model Used

Claude (Anthropic), model id `claude-sonnet-5`, standard reasoning mode, agentic tool use (file edit, test execution, git) via Claude Code.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge