### PR TITLE
fix(heartbeat): preserve exit-zero Hermes completions

### DIFF
--- a/packages/adapters/hermes/src/server/execute.test.ts
+++ b/packages/adapters/hermes/src/server/execute.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+
+import { parseHermesOutput } from "./execute.js";
+
+describe("parseHermesOutput", () => {
+  it("does not turn successful terminal narration into an adapter error", () => {
+    const narration =
+      "The live checks are conclusive: JAC-3307 is done. I am closing the incident now.";
+
+    const parsed = parseHermesOutput(
+      `${narration}\n\nsession_id: session-1\n`,
+      `Captured reasoning: ${narration}\n`,
+      false,
+    );
+
+    expect(parsed.response).toContain("JAC-3307 is done");
+    expect(parsed.errorMessage).toBeUndefined();
+  });
+
+  it("retains stderr failure diagnostics for a nonzero process", () => {
+    const parsed = parseHermesOutput("", "ERROR: provider unavailable\n", true);
+
+    expect(parsed.errorMessage).toBe("ERROR: provider unavailable");
+  });
+});

--- a/packages/adapters/hermes/src/server/execute.ts
+++ b/packages/adapters/hermes/src/server/execute.ts
@@ -267,7 +267,11 @@ function cleanResponse(raw: string): string {
 // Output parsing
 // ---------------------------------------------------------------------------
 
-function parseHermesOutput(stdout: string, stderr: string): ParsedOutput {
+export function parseHermesOutput(
+  stdout: string,
+  stderr: string,
+  processFailed = true,
+): ParsedOutput {
   const combined = stdout + "\n" + stderr;
   const result: ParsedOutput = {};
 
@@ -312,8 +316,11 @@ function parseHermesOutput(stdout: string, stderr: string): ParsedOutput {
     result.costUsd = parseFloat(costMatch[1]);
   }
 
-  // Check for error patterns in stderr
-  if (stderr.trim()) {
+  // Hermes writes diagnostic logs (including the model's final narration) to
+  // stderr even when the child completed successfully. Only treat heuristic
+  // stderr text as an adapter error when the process itself failed. This
+  // keeps ordinary completion prose from becoming the heartbeat's error.
+  if (processFailed && stderr.trim()) {
     const errorLines = stderr
       .split("\n")
       .filter((line) => /error|exception|traceback|failed/i.test(line))
@@ -542,7 +549,11 @@ export async function execute(
   });
 
   // ── Parse output ───────────────────────────────────────────────────────
-  const parsed = parseHermesOutput(result.stdout || "", result.stderr || "");
+  const processFailed =
+    result.timedOut ||
+    result.signal !== null ||
+    (result.exitCode ?? 1) !== 0;
+  const parsed = parseHermesOutput(result.stdout || "", result.stderr || "", processFailed);
 
   await ctx.onLog(
     "stdout",

--- a/server/src/__tests__/heartbeat-run-outcome.test.ts
+++ b/server/src/__tests__/heartbeat-run-outcome.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveHeartbeatRunOutcome } from "../services/heartbeat.ts";
+
+describe("heartbeat run outcome finalization", () => {
+  it("succeeds for exit 0 terminal completion after the linked issue is done", () => {
+    expect(
+      resolveHeartbeatRunOutcome({
+        latestStatus: "running",
+        timedOut: false,
+        exitCode: 0,
+        signal: null,
+        errorMessage: null,
+      }),
+    ).toBe("succeeded");
+  });
+
+  it("preserves genuine structured failure metadata", () => {
+    expect(
+      resolveHeartbeatRunOutcome({
+        latestStatus: "running",
+        timedOut: false,
+        exitCode: 0,
+        signal: null,
+        errorMessage: "provider unavailable",
+      }),
+    ).toBe("failed");
+  });
+});

--- a/server/src/__tests__/heartbeat-run-outcome.test.ts
+++ b/server/src/__tests__/heartbeat-run-outcome.test.ts
@@ -26,4 +26,52 @@ describe("heartbeat run outcome finalization", () => {
       }),
     ).toBe("failed");
   });
+
+  it("returns timed_out when the adapter timed out", () => {
+    expect(
+      resolveHeartbeatRunOutcome({
+        latestStatus: "running",
+        timedOut: true,
+        exitCode: 0,
+        signal: null,
+        errorMessage: null,
+      }),
+    ).toBe("timed_out");
+  });
+
+  it("returns failed when the process was signaled", () => {
+    expect(
+      resolveHeartbeatRunOutcome({
+        latestStatus: "running",
+        timedOut: false,
+        exitCode: 0,
+        signal: "SIGTERM",
+        errorMessage: null,
+      }),
+    ).toBe("failed");
+  });
+
+  it("passes through an already-terminal latestStatus", () => {
+    expect(
+      resolveHeartbeatRunOutcome({
+        latestStatus: "cancelled",
+        timedOut: false,
+        exitCode: 0,
+        signal: null,
+        errorMessage: null,
+      }),
+    ).toBe("cancelled");
+  });
+
+  it("treats null exitCode as failure (consistent with execute.ts)", () => {
+    expect(
+      resolveHeartbeatRunOutcome({
+        latestStatus: "running",
+        timedOut: false,
+        exitCode: null,
+        signal: null,
+        errorMessage: null,
+      }),
+    ).toBe("failed");
+  });
 });

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -6417,7 +6417,7 @@ export function resolveHeartbeatRunOutcome(input: {
   if (isHeartbeatRunTerminalStatus(input.latestStatus)) return input.latestStatus;
   if (input.timedOut) return "timed_out";
   if (
-    (input.exitCode ?? 0) === 0 &&
+    (input.exitCode ?? 1) === 0 &&
     input.signal === null &&
     !input.errorMessage
   ) {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -6407,6 +6407,25 @@ export function normalizeSessionParams(params: Record<string, unknown> | null | 
 
 type RunSessionOutcome = "succeeded" | "interrupted" | "failed" | "cancelled" | "timed_out";
 
+export function resolveHeartbeatRunOutcome(input: {
+  latestStatus?: string | null;
+  timedOut: boolean;
+  exitCode: number | null;
+  signal: string | null;
+  errorMessage?: string | null;
+}): RunSessionOutcome {
+  if (isHeartbeatRunTerminalStatus(input.latestStatus)) return input.latestStatus;
+  if (input.timedOut) return "timed_out";
+  if (
+    (input.exitCode ?? 0) === 0 &&
+    input.signal === null &&
+    !input.errorMessage
+  ) {
+    return "succeeded";
+  }
+  return "failed";
+}
+
 type SkillTestHeartbeatCompletion = {
   outcome: "failed" | "cancelled";
   error: string | null;
@@ -16015,17 +16034,14 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           }
         }
       }
-      let outcome: RunSessionOutcome;
       const latestRun = await getRun(run.id);
-      if (isHeartbeatRunTerminalStatus(latestRun?.status)) {
-        outcome = latestRun.status;
-      } else if (adapterResult.timedOut) {
-        outcome = "timed_out";
-      } else if ((adapterResult.exitCode ?? 0) === 0 && !adapterResult.errorMessage) {
-        outcome = "succeeded";
-      } else {
-        outcome = "failed";
-      }
+      const outcome = resolveHeartbeatRunOutcome({
+        latestStatus: latestRun?.status,
+        timedOut: adapterResult.timedOut,
+        exitCode: adapterResult.exitCode,
+        signal: adapterResult.signal,
+        errorMessage: adapterResult.errorMessage,
+      });
 
       const nextSessionState = resolveNextSessionState({
         adapterType: agent.adapterType,


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The Hermes adapter and heartbeat finalization pipeline classify run outcomes (succeeded/failed/timed_out) based on adapter process results
> - A regression existed where exit-code 0 runs with normal assistant narration on stderr were persisted as failed with errorCode=adapter_failed, because stderr heuristic text was copied into errorMessage regardless of process exit status
> - This caused completed heartbeat runs that successfully closed linked issues to appear as failures in the Paperclip board
> - This pull request gates stderr-error heuristics on actual process failure and centralizes outcome resolution logic
> - The benefit is that successful Hermes completions are correctly classified as succeeded, and only genuine structured failures produce error metadata

## Linked Issues or Issue Description

No public GitHub issue exists; described inline per the bug report template.

**What happened?**

Hermes adapter runs that exited cleanly (exit code 0) with normal assistant completion narration on stderr were misclassified as `failed` with `errorCode=adapter_failed`. The stderr heuristic in `parseHermesOutput` scanned for error-like words regardless of whether the process actually failed, so ordinary model output containing words like "failed" or "error" in narrative context was copied into `errorMessage`.

## Expected behavior

Exit code 0 with no structured error should be classified as `succeeded`.

## Steps to reproduce

1. Run a Hermes heartbeat that completes normally (exit 0) with assistant narration on stderr
2. Observe the persisted run status is `failed` with `errorCode=adapter_failed` and the error field contains normal assistant prose

## Paperclip version or commit

`ce7dedf33` (master at time of fix)

## Deployment mode

Self-hosted, Hermes local adapter

## What Changed

- `packages/adapters/hermes/src/server/execute.ts`: Added `processFailed` parameter to `parseHermesOutput`; stderr is only scanned for error patterns when the process actually failed (timed out, signaled, or nonzero exit)
- `server/src/services/heartbeat.ts`: Extracted `resolveHeartbeatRunOutcome` helper for testable outcome resolution; added `signal` to the failure condition; fixed null exitCode default from `?? 0` to `?? 1` for consistency with execute.ts
- `packages/adapters/hermes/src/server/execute.test.ts`: New test file covering exit-0 narration not becoming an error + nonzero process retaining stderr diagnostics
- `server/src/__tests__/heartbeat-run-outcome.test.ts`: New test file with 6 cases covering all outcome branches: exit-0 success, errorMessage failure, timedOut, signal, terminal status passthrough, and null exitCode

## Verification

- `npx vitest run server/src/__tests__/heartbeat-run-outcome.test.ts` — 6/6 passed
- `npx vitest run packages/adapters/hermes/src/server/execute.test.ts` — 2/2 passed
- Hermes adapter TypeScript check: passed
- Full server typecheck blocked by pre-existing missing plugin SDK build artifacts (unrelated)

## Risks

- Low risk. The outcome resolution logic is extracted but behavior-preserving for the normal path. The only behavioral change is that stderr heuristic errors are now gated on process failure, which is the intended fix.
- The null exitCode default change (`?? 0` -> `?? 1`) aligns heartbeat resolution with adapter execution logic; a null exitCode means the process was never spawned, so treating it as failure is correct.

## Model Used

- GLM-5.2 (custom Ollama provider) — Hermes Agent on Aegis, 128K context, tool use and code execution capabilities

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge