### PR TITLE
Preserve board-owned blocker recovery ownership

### DIFF
--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -4416,13 +4416,17 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(comments[0]?.body).toContain("Next action:");
   });
 
-  it("assigns open unassigned blockers back to their creator agent", async () => {
+  async function seedUnassignedBlockingIssueFixture(input: {
+    blockerResponsibleUserId: string | null;
+    blockerStatus?: "todo" | "blocked";
+  }) {
     const companyId = randomUUID();
     const creatorAgentId = randomUUID();
     const blockedAssigneeAgentId = randomUUID();
     const blockerIssueId = randomUUID();
     const blockedIssueId = randomUUID();
     const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+
     await db.insert(companies).values({
       id: companyId,
       name: "Paperclip",
@@ -4459,10 +4463,10 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
         id: blockerIssueId,
         companyId,
         title: "Fix blocker",
-        status: "todo",
+        status: input.blockerStatus ?? "todo",
         priority: "high",
         createdByAgentId: creatorAgentId,
-        responsibleUserId: "responsible-user",
+        responsibleUserId: input.blockerResponsibleUserId,
         issueNumber: 1,
         identifier: `${issuePrefix}-1`,
       },
@@ -4485,6 +4489,75 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       type: "blocks",
       createdByAgentId: creatorAgentId,
     });
+
+    return {
+      companyId,
+      creatorAgentId,
+      blockerIssueId,
+      blockedIssueId,
+      issuePrefix,
+    };
+  }
+
+  it("leaves board-owned open unassigned blockers for board review", async () => {
+    const { companyId, blockerIssueId, issuePrefix } = await seedUnassignedBlockingIssueFixture({
+      blockerResponsibleUserId: "responsible-user",
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+
+    expect(result.orphanBlockersAssigned).toBe(0);
+    expect(result.issueIds).not.toContain(blockerIssueId);
+
+    const blocker = await db
+      .select()
+      .from(issues)
+      .where(eq(issues.id, blockerIssueId))
+      .then((rows) => rows[0] ?? null);
+    expect(blocker?.assigneeAgentId).toBeNull();
+    expect(blocker?.assigneeUserId).toBeNull();
+
+    const comments = await db.select().from(issueComments).where(eq(issueComments.issueId, blockerIssueId));
+    expect(comments).toHaveLength(1);
+    expect(comments[0]?.body).toContain("Board-Owned Blocker");
+    expect(comments[0]?.body).toContain("Awaiting Board Review");
+    expect(comments[0]?.body).toContain(`[${issuePrefix}-2](/${issuePrefix}/issues/${issuePrefix}-2)`);
+
+    const wakeups = await db.select().from(agentWakeupRequests).where(eq(agentWakeupRequests.companyId, companyId));
+    expect(wakeups).toEqual([]);
+  });
+
+  it("does not enqueue agent wakeups for board-owned unassigned blockers", async () => {
+    const { companyId, blockerIssueId } = await seedUnassignedBlockingIssueFixture({
+      blockerResponsibleUserId: "responsible-user",
+      blockerStatus: "blocked",
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+
+    expect(result.orphanBlockersAssigned).toBe(0);
+
+    const blocker = await db
+      .select()
+      .from(issues)
+      .where(eq(issues.id, blockerIssueId))
+      .then((rows) => rows[0] ?? null);
+    expect(blocker?.assigneeAgentId).toBeNull();
+
+    const comments = await db.select().from(issueComments).where(eq(issueComments.issueId, blockerIssueId));
+    expect(comments[0]?.body).toContain("Board-Owned Blocker");
+    expect(comments[0]?.body).toContain("responsibleUserId");
+
+    const wakeups = await db.select().from(agentWakeupRequests).where(eq(agentWakeupRequests.companyId, companyId));
+    expect(wakeups).toEqual([]);
+  });
+
+  it("assigns plain open unassigned blockers back to their creator agent", async () => {
+    const { creatorAgentId, blockerIssueId, issuePrefix } = await seedUnassignedBlockingIssueFixture({
+      blockerResponsibleUserId: null,
+    });
     const heartbeat = heartbeatService(db);
 
     const result = await heartbeat.reconcileStrandedAssignedIssues();
@@ -4498,6 +4571,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       .where(eq(issues.id, blockerIssueId))
       .then((rows) => rows[0] ?? null);
     expect(blocker?.assigneeAgentId).toBe(creatorAgentId);
+    expect(blocker?.responsibleUserId).toBeNull();
 
     const comments = await db.select().from(issueComments).where(eq(issueComments.issueId, blockerIssueId));
     expect(comments[0]?.body).toContain("Assigned Orphan Blocker");

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -936,6 +936,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         identifier: issues.identifier,
         status: issues.status,
         createdByAgentId: issues.createdByAgentId,
+        responsibleUserId: issues.responsibleUserId,
       })
       .from(issueRelations)
       .innerJoin(issues, eq(issueRelations.issueId, issues.id))
@@ -965,6 +966,26 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       if (seen.has(candidate.id)) continue;
       seen.add(candidate.id);
 
+      const relations = await issuesSvc.getRelationSummaries(candidate.id);
+      const blockingLinks = formatIssueLinksForComment(relations.blocks);
+      if (candidate.responsibleUserId != null) {
+        await issuesSvc.addComment(
+          candidate.id,
+          [
+            "## Board-Owned Blocker - Awaiting Board Review",
+            "",
+            `This issue is blocking ${blockingLinks} but has no agent assignee.`,
+            "",
+            "- It has a `responsibleUserId` set, so it is board/human-owned.",
+            "- It will not be auto-assigned to an agent.",
+            "- Action required: the responsible board owner should resolve or reassign this blocker.",
+          ].join("\n"),
+          {},
+        );
+        skipped += 1;
+        continue;
+      }
+
       const creatorAgentId = candidate.createdByAgentId;
       if (!creatorAgentId) {
         skipped += 1;
@@ -976,8 +997,6 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         continue;
       }
 
-      const relations = await issuesSvc.getRelationSummaries(candidate.id);
-      const blockingLinks = formatIssueLinksForComment(relations.blocks);
       const updated = await issuesSvc.update(candidate.id, {
         assigneeAgentId: creatorAgent.id,
         assigneeUserId: null,


### PR DESCRIPTION
## Thinking Path

> - Paperclip manages AI agents that collaborate on work items; agents create "blocker" issues to gate their own tasks on unresolved dependencies.
> - The orphan-blocker recovery service (`server/src/services/recovery/service.ts`) re-assigns unassigned blockers back to the creating agent so stalled work can resume.
> - Some blockers are "board-owned" — they carry a `responsibleUserId`, meaning a human board member is the intended resolver, not an agent.
> - When a board-owned blocker lost its agent assignee, the recovery service was unconditionally re-assigning it to the creating agent anyway, bypassing the board's ownership intent and creating a loop where agents were woken up for work they could not perform.
> - This PR adds a guard: if the orphaned blocker has `responsibleUserId` set, skip agent auto-assignment and post a board-review comment instead; blockers without `responsibleUserId` continue to be assigned back to `createdByAgentId` with the existing wakeup behaviour.
> - Two test cases are added: one asserting board-owned blockers are left for the board (no agent assign, board-review comment, no agent wakeup) and one confirming plain orphan blockers still assign back to their creator as before.
> - The benefit is that board-owned blockers remain visible on the board's radar and never silently redirect to agents that are not equipped to resolve them.

## Linked Issues or Issue Description

No public GitHub issue tracks this defect. Inline bug report:

### What happened?

`reconcileStrandedAssignedIssues()` queried `responsibleUserId` but did not act on it — all unassigned blockers were unconditionally re-assigned to `createdByAgentId`, regardless of whether the blocker was board-owned.

### Expected behavior

Blockers with `responsibleUserId` set should be skipped by agent auto-assignment. The recovery service should post a board-review comment and leave the blocker's ownership with the board instead.

### Steps to reproduce

1. Create a blocker issue with `responsibleUserId` set (board-owned) and no agent assignee.
2. Trigger `reconcileStrandedAssignedIssues()` (e.g. via the heartbeat recovery loop).
3. Observe: the blocker is incorrectly re-assigned to the `createdByAgentId` agent.

### Paperclip version or commit

tip of `master` immediately before this PR.

### Deployment mode

All modes.

## What Changed

- **`server/src/services/recovery/service.ts`** — Selected `responsibleUserId` in the orphan-blocker query; added a guard before the existing agent-assign block: when `responsibleUserId != null`, post a board-review comment, increment `skipped`, and `continue` — leaving the blocker unassigned and not enqueuing an agent wakeup. Moved the `getRelationSummaries` / `formatIssueLinksForComment` calls before this guard so both paths share them.
- **`server/src/__tests__/heartbeat-process-recovery.test.ts`** — Extracted `seedUnassignedBlockingIssueFixture()` helper (parameterised on `blockerResponsibleUserId` and optional `blockerStatus`). Added two new `it` blocks:
  - `"leaves board-owned open unassigned blockers for board review"` — asserts no agent assign, correct board-review comment, no wakeup enqueued.
  - `"does not enqueue agent wakeups for board-owned unassigned blockers"` — same guard for `blocked`-status board-owned blockers.
  - Renamed the surviving plain-blocker test to `"assigns plain open unassigned blockers back to their creator agent"` and added a `responsibleUserId: null` assertion.

## Verification

```bash
# Targeted Vitest suite — 3 passed / 83 skipped:
env NODE_ENV=test pnpm --filter @paperclipai/server exec vitest run \
  src/__tests__/heartbeat-process-recovery.test.ts \
  -t "board-owned|plain open unassigned blockers"

# Server typecheck:
env NODE_ENV=development pnpm --filter @paperclipai/server typecheck
```

Both passed locally before submit.

## Risks

Low risk. The change is a new conditional branch *before* the existing assignment block — it does not touch the agent-assign code path at all. The only behavioural difference is for blockers that already had `responsibleUserId` set (board-owned), which were previously mis-assigned; they now receive a comment and stay unassigned instead. No schema migrations, no API surface changes, no changes to how plain orphan blockers are handled.

## Model Used

Provider: Anthropic  
Model ID: `claude-sonnet-4-6`  
Context window: 200 000 tokens  
Mode: tool use (agentic, multi-turn Paperclip agent session)  
Role: code author and test author

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge