### PR TITLE
fix(adapter-utils): stage large SSH payloads off os.tmpdir()

### DIFF
--- a/packages/adapter-utils/src/ssh-fixture.test.ts
+++ b/packages/adapter-utils/src/ssh-fixture.test.ts
@@ -1,4 +1,5 @@
 import { execFile } from "node:child_process";
+import { existsSync, readdirSync } from "node:fs";
 import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -316,6 +317,81 @@ describe("ssh env-lab fixture", () => {
     // The restored files round-tripped through the byte-counting transport.
     await expect(readFile(path.join(restoreDir, "blob-0.bin"))).resolves.toEqual(
       Buffer.alloc(256 * 1024, 1),
+    );
+  }, SSH_FIXTURE_TEST_TIMEOUT_MS);
+
+  // Regression: LUC-733. Sync-back staged its whole-workspace tar in os.tmpdir(),
+  // which on the fleet is a quota-capped RAM tmpfs, so a large workspace exhausted
+  // the quota and made unrelated writes (the SSH key) fail with EDQUOT. Staging must
+  // land beside the destination workspace instead.
+  it("stages the sync-back tar beside the workspace, not in os.tmpdir()", async () => {
+    const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-ssh-fixture-"));
+    cleanupDirs.push(rootDir);
+    const statePath = path.join(rootDir, "state.json");
+    const localDir = path.join(rootDir, "sync-source");
+    // Restoring into runRoot/workspace means staging must appear in runRoot/.
+    const runRoot = path.join(rootDir, "run");
+    const restoreDir = path.join(runRoot, "workspace");
+    // os.tmpdir() is resolved from TMPDIR on every call, so pointing it at a private
+    // directory isolates this assertion from staging done by any concurrent test.
+    const privateTmp = path.join(rootDir, "private-tmp");
+
+    await mkdir(localDir, { recursive: true });
+    await mkdir(restoreDir, { recursive: true });
+    await mkdir(privateTmp, { recursive: true });
+    for (let index = 0; index < 8; index += 1) {
+      await writeFile(path.join(localDir, `blob-${index}.bin`), Buffer.alloc(1024 * 1024, index + 1));
+    }
+
+    const started = await startSshEnvLabFixtureOrSkip(statePath, "SSH staging directory test");
+    if (!started) return;
+    const config = await buildSshEnvLabFixtureConfig(started);
+    const spec = { ...config, remoteCwd: started.workspaceDir } as const;
+    const remoteDir = path.posix.join(started.workspaceDir, "staging-source");
+
+    await syncDirectoryToSsh({ spec, localDir, remoteDir });
+
+    // Poll both candidate roots during the transfer: the staging dir is removed once
+    // the sync completes, so it can only be observed while it is in flight.
+    const stagedIn = { tmpdir: false, besideWorkspace: false };
+    const scan = () => {
+      const roots: Array<[keyof typeof stagedIn, string]> = [
+        ["tmpdir", privateTmp],
+        ["besideWorkspace", path.join(runRoot, ".paperclip-staging")],
+      ];
+      for (const [key, dir] of roots) {
+        // The staging root may not exist yet on early ticks.
+        let entries: string[] = [];
+        try {
+          entries = readdirSync(dir);
+        } catch {
+          continue;
+        }
+        if (entries.some((entry) => entry.startsWith("paperclip-ssh-sync-back-"))) {
+          stagedIn[key] = true;
+        }
+      }
+    };
+    const poller = setInterval(scan, 10);
+
+    const previousTmpdir = process.env.TMPDIR;
+    process.env.TMPDIR = privateTmp;
+    try {
+      await syncDirectoryFromSsh({ spec, remoteDir, localDir: restoreDir });
+    } finally {
+      clearInterval(poller);
+      if (previousTmpdir === undefined) delete process.env.TMPDIR;
+      else process.env.TMPDIR = previousTmpdir;
+    }
+
+    expect(stagedIn.tmpdir).toBe(false);
+    expect(stagedIn.besideWorkspace).toBe(true);
+    // The staging root itself is created (not the mkdtemp child, which is cleaned up),
+    // so this holds even if every poll tick missed the transfer window.
+    expect(existsSync(path.join(runRoot, ".paperclip-staging"))).toBe(true);
+    // Staging off tmpdir must not change what lands in the workspace.
+    await expect(readFile(path.join(restoreDir, "blob-0.bin"))).resolves.toEqual(
+      Buffer.alloc(1024 * 1024, 1),
     );
   }, SSH_FIXTURE_TEST_TIMEOUT_MS);
 

--- a/packages/adapter-utils/src/ssh.ts
+++ b/packages/adapter-utils/src/ssh.ts
@@ -349,6 +349,35 @@ async function resolveCommandPath(command: string): Promise<string | null> {
   }
 }
 
+// Multi-GB payloads (workspace tars, git bundles) must not be staged in
+// os.tmpdir(): it is conventionally small, frequently RAM-backed, and often
+// quota-capped, so a large stage there can exhaust the quota and make even a
+// few-hundred-byte SSH key write fail with EDQUOT. Stage beside the workspace
+// the payload belongs to instead, which is disk-backed and also turns the
+// staging -> workspace move into a rename rather than a cross-device copy.
+// PAPERCLIP_STAGING_DIR overrides; os.tmpdir() remains the last-resort fallback.
+async function resolveStagingRoot(localDir: string | undefined): Promise<string> {
+  const candidates: string[] = [];
+  const configured = process.env.PAPERCLIP_STAGING_DIR?.trim();
+  if (configured) {
+    candidates.push(configured);
+  }
+  if (localDir) {
+    candidates.push(path.join(path.dirname(path.resolve(localDir)), ".paperclip-staging"));
+  }
+  for (const candidate of candidates) {
+    try {
+      await fs.mkdir(candidate, { recursive: true });
+      return candidate;
+    } catch {
+      // Unwritable or missing parent - fall through to the next candidate.
+    }
+  }
+  return os.tmpdir();
+}
+
+// Deliberately stays on os.tmpdir(): the payload is a few hundred bytes (an SSH
+// key or known-hosts entry), and it must not depend on a workspace path.
 async function withTempFile(
   prefix: string,
   contents: string,
@@ -761,7 +790,9 @@ async function importGitWorkspaceToSsh(input: {
   snapshot: LocalGitWorkspaceSnapshot;
   onProgress?: RuntimeProgressSink;
 }): Promise<void> {
-  const bundleDir = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-ssh-bundle-"));
+  const bundleDir = await fs.mkdtemp(
+    path.join(await resolveStagingRoot(input.localDir), "paperclip-ssh-bundle-"),
+  );
   const bundlePath = path.join(bundleDir, "workspace.bundle");
   // Per-import unique ref so concurrent imports against the same local repo
   // can't race on `update-ref` between this run's update and bundle create.
@@ -836,7 +867,9 @@ async function exportGitWorkspaceFromSsh(input: {
   resetLocalWorkspace?: boolean;
   onProgress?: RuntimeProgressSink;
 }): Promise<string> {
-  const bundleDir = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-ssh-bundle-"));
+  const bundleDir = await fs.mkdtemp(
+    path.join(await resolveStagingRoot(input.localDir), "paperclip-ssh-bundle-"),
+  );
   const bundlePath = path.join(bundleDir, "workspace.bundle");
   const importedRef = input.importedRef ?? `refs/paperclip/ssh-sync/imported/${randomUUID()}`;
 
@@ -1382,7 +1415,9 @@ export async function syncDirectoryFromSsh(input: {
   progressLabel?: string;
 }): Promise<void> {
   const auth = await createSshAuthArgs(input.spec);
-  const stagingDir = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-ssh-sync-back-"));
+  const stagingDir = await fs.mkdtemp(
+    path.join(await resolveStagingRoot(input.localDir), "paperclip-ssh-sync-back-"),
+  );
   const remoteTarScript = [
     `cd ${shellQuote(input.remoteDir)}`,
     `tar ${[...tarExcludeArgs(input.exclude).map(shellQuote), "-cf", "-", "."].join(" ")}`,
@@ -1548,7 +1583,9 @@ export async function restoreWorkspaceFromSshExecution(input: {
 }): Promise<void> {
   const remoteDir = input.remoteDir ?? input.spec.remoteCwd;
   if (input.baselineSnapshot) {
-    const stagingDir = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-ssh-sync-back-"));
+    const stagingDir = await fs.mkdtemp(
+      path.join(await resolveStagingRoot(input.localDir), "paperclip-ssh-sync-back-"),
+    );
     const importedRef = input.restoreGitHistory
       ? `refs/paperclip/ssh-sync/imported/${randomUUID()}`
       : null;


### PR DESCRIPTION
## Problem

Four SSH sync sites in `packages/adapter-utils/src/ssh.ts` stage multi-GB payloads under `os.tmpdir()`:

| Site | Payload |
|---|---|
| `syncDirectoryFromSsh` | whole-workspace sync-back tar |
| `restoreWorkspaceFromSshExecution` | whole-workspace sync-back tar |
| `importGitWorkspaceToSsh` | git bundle, full history |
| `exportGitWorkspaceFromSsh` | git bundle, full history |

`os.tmpdir()` is conventionally small, frequently RAM-backed (`tmpfs`), and often quota-capped. Staging a large workspace there can exhaust the quota — and the resulting `EDQUOT` then surfaces on an unrelated write. On our fleet it landed on the few-hundred-byte SSH key write in `withTempFile()`, which failed with `errno 122 (EDQUOT)` and took the whole run down. The key write was the *victim*, not the cause, which made this hard to diagnose.

Any git-backed workspace can reach the bug through the two bundle sites, not just large-workspace sync-back.

## Fix

Add `resolveStagingRoot(localDir)` and point all four staging sites at it. Precedence:

1. `PAPERCLIP_STAGING_DIR`, if set
2. `<parent-of-workspace>/.paperclip-staging` — disk-backed and on the same filesystem as the destination, so staging → workspace becomes a **rename instead of a cross-device copy**
3. `os.tmpdir()` — last-resort fallback

`withTempFile()` deliberately **stays** on `os.tmpdir()`: its payload is a few hundred bytes and must not depend on a workspace path.

## Test

Adds a regression test to the SSH env-lab fixture suite (`ssh-fixture.test.ts`). It runs a real sync-back through the package's own real `sshd` fixture, polls both candidate staging roots during the transfer, and asserts the tar lands beside the workspace and **not** in `os.tmpdir()` — with `TMPDIR` pointed at a private directory so the assertion can't be contaminated by concurrent tests.

Verification:

- New test **fails** against the pre-fix code (`expected true to be false` — it catches the tar in `os.tmpdir()`) and passes with the fix.
- Full `packages/adapter-utils` suite: **213 passed / 213**, including the git round-trip tests that exercise both bundle sites.
- `tsc --noEmit` clean.