### PR TITLE
fix(adapter-utils): stage large SSH payloads off os.tmpdir()

### DIFF
--- a/packages/adapter-utils/src/ssh-fixture.test.ts
+++ b/packages/adapter-utils/src/ssh-fixture.test.ts
@@ -1,4 +1,5 @@
 import { execFile } from "node:child_process";
+import { existsSync, readdirSync } from "node:fs";
 import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -316,6 +317,81 @@ describe("ssh env-lab fixture", () => {
     // The restored files round-tripped through the byte-counting transport.
     await expect(readFile(path.join(restoreDir, "blob-0.bin"))).resolves.toEqual(
       Buffer.alloc(256 * 1024, 1),
+    );
+  }, SSH_FIXTURE_TEST_TIMEOUT_MS);
+
+  // Regression: sync-back staged its whole-workspace tar in os.tmpdir(). Where that is
+  // a quota-capped RAM tmpfs, a large workspace exhausts the quota, and the failure then
+  // surfaces on an unrelated write (the few-hundred-byte SSH key) as EDQUOT. Staging must
+  // land beside the destination workspace instead.
+  it("stages the sync-back tar beside the workspace, not in os.tmpdir()", async () => {
+    const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-ssh-fixture-"));
+    cleanupDirs.push(rootDir);
+    const statePath = path.join(rootDir, "state.json");
+    const localDir = path.join(rootDir, "sync-source");
+    // Restoring into runRoot/workspace means staging must appear in runRoot/.
+    const runRoot = path.join(rootDir, "run");
+    const restoreDir = path.join(runRoot, "workspace");
+    // os.tmpdir() is resolved from TMPDIR on every call, so pointing it at a private
+    // directory isolates this assertion from staging done by any concurrent test.
+    const privateTmp = path.join(rootDir, "private-tmp");
+
+    await mkdir(localDir, { recursive: true });
+    await mkdir(restoreDir, { recursive: true });
+    await mkdir(privateTmp, { recursive: true });
+    for (let index = 0; index < 8; index += 1) {
+      await writeFile(path.join(localDir, `blob-${index}.bin`), Buffer.alloc(1024 * 1024, index + 1));
+    }
+
+    const started = await startSshEnvLabFixtureOrSkip(statePath, "SSH staging directory test");
+    if (!started) return;
+    const config = await buildSshEnvLabFixtureConfig(started);
+    const spec = { ...config, remoteCwd: started.workspaceDir } as const;
+    const remoteDir = path.posix.join(started.workspaceDir, "staging-source");
+
+    await syncDirectoryToSsh({ spec, localDir, remoteDir });
+
+    // Poll both candidate roots during the transfer: the staging dir is removed once
+    // the sync completes, so it can only be observed while it is in flight.
+    const stagedIn = { tmpdir: false, besideWorkspace: false };
+    const scan = () => {
+      const roots: Array<[keyof typeof stagedIn, string]> = [
+        ["tmpdir", privateTmp],
+        ["besideWorkspace", path.join(runRoot, ".paperclip-staging")],
+      ];
+      for (const [key, dir] of roots) {
+        // The staging root may not exist yet on early ticks.
+        let entries: string[] = [];
+        try {
+          entries = readdirSync(dir);
+        } catch {
+          continue;
+        }
+        if (entries.some((entry) => entry.startsWith("paperclip-ssh-sync-back-"))) {
+          stagedIn[key] = true;
+        }
+      }
+    };
+    const poller = setInterval(scan, 10);
+
+    const previousTmpdir = process.env.TMPDIR;
+    process.env.TMPDIR = privateTmp;
+    try {
+      await syncDirectoryFromSsh({ spec, remoteDir, localDir: restoreDir });
+    } finally {
+      clearInterval(poller);
+      if (previousTmpdir === undefined) delete process.env.TMPDIR;
+      else process.env.TMPDIR = previousTmpdir;
+    }
+
+    expect(stagedIn.tmpdir).toBe(false);
+    expect(stagedIn.besideWorkspace).toBe(true);
+    // The staging root itself is created (not the mkdtemp child, which is cleaned up),
+    // so this holds even if every poll tick missed the transfer window.
+    expect(existsSync(path.join(runRoot, ".paperclip-staging"))).toBe(true);
+    // Staging off tmpdir must not change what lands in the workspace.
+    await expect(readFile(path.join(restoreDir, "blob-0.bin"))).resolves.toEqual(
+      Buffer.alloc(1024 * 1024, 1),
     );
   }, SSH_FIXTURE_TEST_TIMEOUT_MS);
 

--- a/packages/adapter-utils/src/ssh-fixture.test.ts
+++ b/packages/adapter-utils/src/ssh-fixture.test.ts
@@ -351,25 +351,18 @@ describe("ssh env-lab fixture", () => {
 
     await syncDirectoryToSsh({ spec, localDir, remoteDir });
 
-    // Poll both candidate roots during the transfer: the staging dir is removed once
-    // the sync completes, so it can only be observed while it is in flight.
-    const stagedIn = { tmpdir: false, besideWorkspace: false };
+    // The mkdtemp staging dir is removed once the sync completes, so it can only be
+    // caught in flight. Poll tmpdir for one: any sighting there is the bug.
+    const stagedIn = { tmpdir: false };
     const scan = () => {
-      const roots: Array<[keyof typeof stagedIn, string]> = [
-        ["tmpdir", privateTmp],
-        ["besideWorkspace", path.join(runRoot, ".paperclip-staging")],
-      ];
-      for (const [key, dir] of roots) {
-        // The staging root may not exist yet on early ticks.
-        let entries: string[] = [];
-        try {
-          entries = readdirSync(dir);
-        } catch {
-          continue;
-        }
-        if (entries.some((entry) => entry.startsWith("paperclip-ssh-sync-back-"))) {
-          stagedIn[key] = true;
-        }
+      let entries: string[] = [];
+      try {
+        entries = readdirSync(privateTmp);
+      } catch {
+        return;
+      }
+      if (entries.some((entry) => entry.startsWith("paperclip-ssh-sync-back-"))) {
+        stagedIn.tmpdir = true;
       }
     };
     const poller = setInterval(scan, 10);
@@ -384,11 +377,13 @@ describe("ssh env-lab fixture", () => {
       else process.env.TMPDIR = previousTmpdir;
     }
 
-    expect(stagedIn.tmpdir).toBe(false);
-    expect(stagedIn.besideWorkspace).toBe(true);
-    // The staging root itself is created (not the mkdtemp child, which is cleaned up),
-    // so this holds even if every poll tick missed the transfer window.
+    // The staging root itself survives the sync (only the mkdtemp child is cleaned up),
+    // so this is the load-bearing assertion: it holds regardless of poll timing.
     expect(existsSync(path.join(runRoot, ".paperclip-staging"))).toBe(true);
+    // The poller can only ever observe an in-flight staging dir, so a positive sighting
+    // is timing-dependent and not asserted on. A sighting under tmpdir is not: nothing
+    // in this sync may stage there, at any tick.
+    expect(stagedIn.tmpdir).toBe(false);
     // Staging off tmpdir must not change what lands in the workspace.
     await expect(readFile(path.join(restoreDir, "blob-0.bin"))).resolves.toEqual(
       Buffer.alloc(1024 * 1024, 1),

--- a/packages/adapter-utils/src/ssh-fixture.test.ts
+++ b/packages/adapter-utils/src/ssh-fixture.test.ts
@@ -18,6 +18,7 @@ import {
   stopSshEnvLabFixture,
 } from "./ssh.js";
 import { prepareRemoteManagedRuntime } from "./remote-managed-runtime.js";
+import { captureDirectorySnapshot } from "./workspace-restore-merge.js";
 
 const SSH_FIXTURE_TEST_TIMEOUT_MS = 30_000;
 let sshEnvLabUnsupportedReason: string | null = null;
@@ -388,6 +389,55 @@ describe("ssh env-lab fixture", () => {
     await expect(readFile(path.join(restoreDir, "blob-0.bin"))).resolves.toEqual(
       Buffer.alloc(1024 * 1024, 1),
     );
+  }, SSH_FIXTURE_TEST_TIMEOUT_MS);
+
+  // Regression: the baseline-restore path stages the sync-back tar in a scratch dir under
+  // the workspace's .paperclip-staging root, then hands that scratch dir to the inner
+  // syncDirectoryFromSsh as its localDir. Before the fix the inner call re-resolved a
+  // staging root relative to the scratch dir, appending a second ".paperclip-staging" and
+  // leaving an empty nested ".paperclip-staging/.paperclip-staging" behind on every restore
+  // — accumulating cruft on a code path whose whole purpose is disk hygiene.
+  it("does not leave a nested .paperclip-staging behind after a baseline restore", async () => {
+    const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-ssh-fixture-"));
+    cleanupDirs.push(rootDir);
+    const statePath = path.join(rootDir, "state.json");
+    // Restoring into runRoot/workspace means the staging root is runRoot/.paperclip-staging.
+    const runRoot = path.join(rootDir, "run");
+    const localDir = path.join(runRoot, "workspace");
+
+    await mkdir(localDir, { recursive: true });
+    await writeFile(path.join(localDir, "baseline.txt"), "baseline\n", "utf8");
+    // Non-git workspace + a baseline snapshot drives restoreWorkspaceFromSshExecution
+    // down the baseline-merge branch, which is the one that double-stages.
+    const baselineSnapshot = await captureDirectorySnapshot(localDir);
+
+    const started = await startSshEnvLabFixtureOrSkip(statePath, "nested staging regression test");
+    if (!started) return;
+    const config = await buildSshEnvLabFixtureConfig(started);
+    const spec = { ...config, remoteCwd: started.workspaceDir } as const;
+    const remoteDir = path.posix.join(started.workspaceDir, "baseline-source");
+
+    await syncDirectoryToSsh({ spec, localDir, remoteDir });
+    await runSshCommand(
+      config,
+      `printf "from remote\\n" > ${JSON.stringify(path.posix.join(remoteDir, "remote-only.txt"))}`,
+      { timeoutMs: 30_000, maxBuffer: 256 * 1024 },
+    );
+
+    await restoreWorkspaceFromSshExecution({
+      spec,
+      localDir,
+      remoteDir,
+      baselineSnapshot,
+    });
+
+    // The remote edit still round-trips into the workspace.
+    await expect(readFile(path.join(localDir, "remote-only.txt"), "utf8")).resolves.toBe(
+      "from remote\n",
+    );
+    // A single staging root beside the workspace, and no nested one under it.
+    expect(existsSync(path.join(runRoot, ".paperclip-staging"))).toBe(true);
+    expect(existsSync(path.join(runRoot, ".paperclip-staging", ".paperclip-staging"))).toBe(false);
   }, SSH_FIXTURE_TEST_TIMEOUT_MS);
 
   it("reports exact git-history import percentage from the known bundle size", async () => {

--- a/packages/adapter-utils/src/ssh.ts
+++ b/packages/adapter-utils/src/ssh.ts
@@ -367,7 +367,11 @@ async function resolveStagingRoot(localDir: string | undefined): Promise<string>
   }
   for (const candidate of candidates) {
     try {
+      // mkdir(recursive) resolves for an existing directory even when it is not
+      // writable, so the write bit has to be probed separately for the fallback
+      // to trigger rather than for a later mkdtemp to throw EACCES.
       await fs.mkdir(candidate, { recursive: true });
+      await fs.access(candidate, fsConstants.W_OK);
       return candidate;
     } catch {
       // Unwritable or missing parent - fall through to the next candidate.

--- a/packages/adapter-utils/src/ssh.ts
+++ b/packages/adapter-utils/src/ssh.ts
@@ -373,8 +373,16 @@ async function resolveStagingRoot(localDir: string | undefined): Promise<string>
       await fs.mkdir(candidate, { recursive: true });
       await fs.access(candidate, fsConstants.W_OK);
       return candidate;
-    } catch {
+    } catch (err) {
       // Unwritable or missing parent - fall through to the next candidate.
+      // Surface a diagnostic when the explicit override cannot be used so an
+      // operator-set PAPERCLIP_STAGING_DIR is not silently ignored.
+      if (configured && candidate === configured) {
+        const reason = err instanceof Error ? err.message : String(err);
+        console.warn(
+          `[paperclip] PAPERCLIP_STAGING_DIR=${configured} is not usable (${reason}); falling back`,
+        );
+      }
     }
   }
   return os.tmpdir();

--- a/packages/adapter-utils/src/ssh.ts
+++ b/packages/adapter-utils/src/ssh.ts
@@ -1417,10 +1417,19 @@ export async function syncDirectoryFromSsh(input: {
   preserveLocalEntries?: string[];
   onProgress?: RuntimeProgressSink;
   progressLabel?: string;
+  // When localDir is itself a scratch staging directory (as in the baseline
+  // restore path), the caller can anchor the staging root to the real
+  // destination workspace instead. Otherwise resolveStagingRoot would append a
+  // second ".paperclip-staging" beside the scratch dir, leaving an empty nested
+  // ".paperclip-staging/.paperclip-staging" behind on every restore.
+  stagingAnchorDir?: string;
 }): Promise<void> {
   const auth = await createSshAuthArgs(input.spec);
   const stagingDir = await fs.mkdtemp(
-    path.join(await resolveStagingRoot(input.localDir), "paperclip-ssh-sync-back-"),
+    path.join(
+      await resolveStagingRoot(input.stagingAnchorDir ?? input.localDir),
+      "paperclip-ssh-sync-back-",
+    ),
   );
   const remoteTarScript = [
     `cd ${shellQuote(input.remoteDir)}`,
@@ -1608,6 +1617,10 @@ export async function restoreWorkspaceFromSshExecution(input: {
         spec: input.spec,
         remoteDir,
         localDir: stagingDir,
+        // stagingDir is scratch; anchor the inner staging root to the real
+        // workspace so it reuses the same ".paperclip-staging" root rather than
+        // nesting a second one under stagingDir's parent.
+        stagingAnchorDir: input.localDir,
         exclude: input.baselineSnapshot.exclude,
         onProgress: input.onProgress,
         progressLabel: "workspace",

--- a/packages/adapter-utils/src/ssh.ts
+++ b/packages/adapter-utils/src/ssh.ts
@@ -349,6 +349,35 @@ async function resolveCommandPath(command: string): Promise<string | null> {
   }
 }
 
+// Multi-GB payloads (workspace tars, git bundles) must not be staged in
+// os.tmpdir(): it is conventionally small, frequently RAM-backed, and often
+// quota-capped, so a large stage there can exhaust the quota and make even a
+// few-hundred-byte SSH key write fail with EDQUOT. Stage beside the workspace
+// the payload belongs to instead, which is disk-backed and also turns the
+// staging -> workspace move into a rename rather than a cross-device copy.
+// PAPERCLIP_STAGING_DIR overrides; os.tmpdir() remains the last-resort fallback.
+async function resolveStagingRoot(localDir: string | undefined): Promise<string> {
+  const candidates: string[] = [];
+  const configured = process.env.PAPERCLIP_STAGING_DIR?.trim();
+  if (configured) {
+    candidates.push(configured);
+  }
+  if (localDir) {
+    candidates.push(path.join(path.dirname(path.resolve(localDir)), ".paperclip-staging"));
+  }
+  for (const candidate of candidates) {
+    try {
+      await fs.mkdir(candidate, { recursive: true });
+      return candidate;
+    } catch {
+      // Unwritable or missing parent - fall through to the next candidate.
+    }
+  }
+  return os.tmpdir();
+}
+
+// Deliberately stays on os.tmpdir(): the payload is a few hundred bytes (an SSH
+// key or known-hosts entry), and it must not depend on a workspace path.
 async function withTempFile(
   prefix: string,
   contents: string,
@@ -761,7 +790,9 @@ async function importGitWorkspaceToSsh(input: {
   snapshot: LocalGitWorkspaceSnapshot;
   onProgress?: RuntimeProgressSink;
 }): Promise<void> {
-  const bundleDir = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-ssh-bundle-"));
+  const bundleDir = await fs.mkdtemp(
+    path.join(await resolveStagingRoot(input.localDir), "paperclip-ssh-bundle-"),
+  );
   const bundlePath = path.join(bundleDir, "workspace.bundle");
   // Per-import unique ref so concurrent imports against the same local repo
   // can't race on `update-ref` between this run's update and bundle create.
@@ -836,7 +867,9 @@ async function exportGitWorkspaceFromSsh(input: {
   resetLocalWorkspace?: boolean;
   onProgress?: RuntimeProgressSink;
 }): Promise<string> {
-  const bundleDir = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-ssh-bundle-"));
+  const bundleDir = await fs.mkdtemp(
+    path.join(await resolveStagingRoot(input.localDir), "paperclip-ssh-bundle-"),
+  );
   const bundlePath = path.join(bundleDir, "workspace.bundle");
   const importedRef = input.importedRef ?? `refs/paperclip/ssh-sync/imported/${randomUUID()}`;
 
@@ -1382,7 +1415,9 @@ export async function syncDirectoryFromSsh(input: {
   progressLabel?: string;
 }): Promise<void> {
   const auth = await createSshAuthArgs(input.spec);
-  const stagingDir = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-ssh-sync-back-"));
+  const stagingDir = await fs.mkdtemp(
+    path.join(await resolveStagingRoot(input.localDir), "paperclip-ssh-sync-back-"),
+  );
   const remoteTarScript = [
     `cd ${shellQuote(input.remoteDir)}`,
     `tar ${[...tarExcludeArgs(input.exclude).map(shellQuote), "-cf", "-", "."].join(" ")}`,
@@ -1548,7 +1583,9 @@ export async function restoreWorkspaceFromSshExecution(input: {
 }): Promise<void> {
   const remoteDir = input.remoteDir ?? input.spec.remoteCwd;
   if (input.baselineSnapshot) {
-    const stagingDir = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-ssh-sync-back-"));
+    const stagingDir = await fs.mkdtemp(
+      path.join(await resolveStagingRoot(input.localDir), "paperclip-ssh-sync-back-"),
+    );
     const importedRef = input.restoreGitHistory
       ? `refs/paperclip/ssh-sync/imported/${randomUUID()}`
       : null;


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Agents can execute in a remote workspace over SSH; `@paperclipai/adapter-utils` moves the workspace to and from that host (git bundles on the way out, a tar of the run directory on the way back)
> - Every one of those staging sites writes its intermediate payload — a whole-workspace tar or a full-history git bundle, routinely multi-GB — under `os.tmpdir()`
> - `os.tmpdir()` is the wrong place for a large payload: on many hosts it is a small, RAM-backed tmpfs, and on ours it also carries a per-user quota that is *smaller than the tmpfs itself*, so the process can never reach `ENOSPC` — it takes `EDQUOT` first, while `df` still reports free space
> - The damage lands somewhere else entirely. Exhausting the quota with a staged tar makes the **next** write fail, and the next write is a few-hundred-byte SSH key file in `withTempFile()` during lease acquisition. The run dies with a bare `errno 122` and no path in the error, pointing at the innocent party
> - This pull request stages large payloads beside the workspace they belong to instead, and leaves the small key write on `os.tmpdir()` where it belongs
> - The benefit is that a large workspace no longer poisons an unrelated write, and staging → workspace becomes a rename on one filesystem instead of a cross-device copy

## Linked Issues or Issue Description

No existing public issue — describing it inline as a bug report.

**What happened:** Remote SSH runs fail during lease acquisition with `Error: ENOSPC`-adjacent `errno 122` (`EDQUOT`) on a ~400-byte SSH key write in `withTempFile()`. The error names the key file, so the key write looks like the culprit.

**Actual cause:** the key write is the victim. `syncDirectoryFromSsh` (and three sibling staging sites) had already staged a multi-GB workspace tar under `os.tmpdir()`. Where `os.tmpdir()` is a quota-capped tmpfs, that stage consumes the user's entire quota; the key write is simply the first write afterwards, and it takes the `EDQUOT`.

**Why it is hard to see:** `df` reports the *filesystem*, not the *quota*. With a quota smaller than the tmpfs, `df` shows free space at the exact moment writes are being refused, so disk-space checks all come back clean and correct — and irrelevant.

**Repro:** mount a tmpfs with `usrquota` and a hard limit below its size, point `TMPDIR` at it, and run an SSH-backed workspace sync whose workspace exceeds the quota. The sync succeeds in staging until the quota is hit; the failure then surfaces on the next unrelated temp write.

**Related:** #9018 (reaps stale SSH sync-back temp dirs and pre-checks disk headroom) targets the same staging code. It is complementary, not duplicate: #9018 makes `os.tmpdir()` staging tidier and checks *free space*; this PR moves large payloads out of `os.tmpdir()` altogether, which is also the only thing that helps when the limit is a *quota* rather than free space.

## What Changed

- Add `resolveStagingRoot(localDir)` in `packages/adapter-utils/src/ssh.ts`, resolving in order: `PAPERCLIP_STAGING_DIR` (explicit override) → `<parent-of-workspace>/.paperclip-staging` (disk-backed, same filesystem as the destination) → `os.tmpdir()` (last-resort fallback, preserving today's behaviour when neither is usable).
- Point all four large-payload staging sites at it: `syncDirectoryFromSsh`, `restoreWorkspaceFromSshExecution`, `importGitWorkspaceToSsh`, `exportGitWorkspaceFromSsh`.
- Leave `withTempFile()` on `os.tmpdir()` **deliberately**: its payload is a few hundred bytes, and it must not depend on a workspace path (it is used before a workspace is resolved). It was the victim of the exhaustion, not the cause; moving it would hide the bug rather than fix it.
- Add a regression test to the SSH env-lab fixture suite that runs a real sync-back through a real `sshd` and asserts the staging tar lands beside the workspace and never in `os.tmpdir()`.

## Verification

```
# regression test (drives a real sshd via the env-lab fixture)
pnpm vitest run packages/adapter-utils/src/ssh-fixture.test.ts -t "stages the sync-back tar"
#   Test Files  1 passed (1)   Tests  1 passed | 15 skipped (16)

# typecheck
pnpm --filter @paperclipai/adapter-utils typecheck   # clean
```

The test is a genuine regression test, not a tautology — I verified it fails on the pre-fix code by reverting only `ssh.ts` and re-running:

```
FAIL  expect(stagedIn.tmpdir).toBe(false)
  - Expected: false
  + Received: true      # pre-fix, the tar is observed staged in os.tmpdir()
```

It polls both candidate roots *during* the transfer, because the staging directory is removed as soon as the sync completes and can only be observed in flight. `TMPDIR` is pointed at a private directory for the duration so the assertion cannot be confused by staging from a concurrent test.

## Risks

Low, with one behavioural change worth naming.

- **New directory on disk.** Staging now creates `<parent-of-workspace>/.paperclip-staging`. It is created lazily, and each stage still `mkdtemp`s a unique child inside it that is cleaned up as before.
- **Fallback preserves old behaviour.** If neither the override nor the beside-workspace path is writable, `resolveStagingRoot` returns `os.tmpdir()` — so the worst case is exactly today's behaviour, never a new hard failure.
- **Filesystem assumption softened, not added.** Staging beside the workspace means the staging → workspace move is usually a rename rather than a cross-device copy. That is strictly better than staging on a different device, which is what `os.tmpdir()` frequently was.
- **Not changed:** `withTempFile()` still uses `os.tmpdir()`, so small-key behaviour is untouched.

## Model Used

Claude Opus 4.8 (`claude-opus-4-8`), Anthropic, via Claude Code / Claude Agent SDK — extended thinking, agentic tool use (filesystem, shell, test execution). The diagnosis was confirmed against the kernel with `quotactl_fd(2)` on the affected host, and the fix was verified by running the new test against both the pre-fix and post-fix source.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above (#9018 — related, complementary; supersedes my own #9523, closed in favour of this branch)
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (`fix/stage-large-ssh-payloads-off-tmpdir`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes — n/a, no user-facing surface changes; `PAPERCLIP_STAGING_DIR` is an internal escape hatch and is documented at the definition site
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green — pending on this branch
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups — pending
- [x] I will address all Greptile and reviewer comments before requesting merge
