### PR TITLE
fix(heartbeat): reclaim issue execution lock on transient_failure_retry (MAS-702)

### DIFF
--- a/server/src/__tests__/heartbeat-retry-scheduling.test.ts
+++ b/server/src/__tests__/heartbeat-retry-scheduling.test.ts
@@ -449,6 +449,102 @@ describeEmbeddedPostgres("heartbeat bounded retry scheduling", () => {
     expect(promotedRun?.status).toBe("queued");
   });
 
+  it("transfers the issue execution lock to the retry run and clears the stale checkout on a transient_failure_retry", async () => {
+    // Regression for the transient-retry orphan bug: when a run fails on a
+    // transient upstream error, scheduleBoundedRetry moves the issue execution
+    // lock to the new scheduled_retry run. It must ALSO clear the stale
+    // checkoutRunId (which still points at the now-terminal failed run), exactly
+    // like the confirmed-dead-child retry path. Otherwise the issue stays pinned
+    // to the dead run and every run-guarded mutation 409s against it.
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const sourceRunId = randomUUID();
+    const issueId = randomUUID();
+    const now = new Date("2026-04-20T12:00:00.000Z");
+    const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix,
+      requireBoardApprovalForNewAgents: false,
+      defaultResponsibleUserId: "responsible-user",
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "CodexCoder",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {
+        heartbeat: {
+          wakeOnDemand: true,
+          maxConcurrentRuns: 1,
+        },
+      },
+      permissions: {},
+    });
+    await db.insert(heartbeatRuns).values({
+      id: sourceRunId,
+      companyId,
+      agentId,
+      invocationSource: "assignment",
+      status: "failed",
+      error: "upstream overload",
+      errorCode: "adapter_failed",
+      finishedAt: now,
+      contextSnapshot: {
+        issueId,
+        wakeReason: "issue_assigned",
+      },
+      updatedAt: now,
+      createdAt: now,
+    });
+    // Issue pinned to the failed run on BOTH lock columns — the shape produced
+    // by a live checkout that then died on a transient upstream failure.
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Transient retry orphan",
+      status: "in_progress",
+      priority: "high",
+      assigneeAgentId: agentId,
+      checkoutRunId: sourceRunId,
+      executionRunId: sourceRunId,
+      executionAgentNameKey: "codexcoder",
+      executionLockedAt: now,
+      issueNumber: 1,
+      identifier: `${issuePrefix}-1`,
+    });
+
+    const scheduled = await heartbeat.scheduleBoundedRetry(sourceRunId, {
+      now,
+      random: () => 0.5,
+    });
+
+    expect(scheduled.outcome).toBe("scheduled");
+    if (scheduled.outcome !== "scheduled") return;
+
+    const issueAfter = await db
+      .select({
+        checkoutRunId: issues.checkoutRunId,
+        executionRunId: issues.executionRunId,
+        executionAgentNameKey: issues.executionAgentNameKey,
+        executionLockedAt: issues.executionLockedAt,
+      })
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+
+    // Execution lock moved to the new scheduled_retry run; stale checkout cleared.
+    expect(issueAfter?.executionRunId).toBe(scheduled.run.id);
+    expect(issueAfter?.checkoutRunId).toBeNull();
+    expect(issueAfter?.executionAgentNameKey).toBe("codexcoder");
+    expect(issueAfter?.executionLockedAt).not.toBeNull();
+  });
+
   it("schedules max-turn continuations with distinct retry metadata", async () => {
     const { runId, now } = await seedMaxTurnFixture();
 

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -9348,6 +9348,13 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         await tx
           .update(issues)
           .set({
+            // Clear the stale checkout so the retry run can re-checkout cleanly.
+            // Mirrors the confirmed-dead-child retry path (enqueueProcessLossRetry)
+            // so both orphan paths leave the issue in an identical, self-healing
+            // shape. Without this the checkout lock stays pinned to the now-terminal
+            // run and every run-guarded mutation (PATCH/release/DELETE comments) 409s
+            // against the dead run (root cause of the transient-retry orphan bug).
+            checkoutRunId: null,
             executionRunId: scheduledRun.id,
             executionAgentNameKey: normalizeAgentNameKey(agent.name),
             executionLockedAt: now,


### PR DESCRIPTION
## What & why

Root cause of the MAS-700 orphaned-lock bug that blocks the MAS-697 hourly CR-review routine.

When a run fails on a transient upstream error, `scheduleBoundedRetryForRun` (server/src/services/heartbeat.ts) transfers the issue's `executionRunId` to the new `scheduled_retry` run — but it left `checkoutRunId` pinned at the now-terminal failed run. Because the agent `/checkout` route and every run-guarded mutation key ownership on `checkoutRunId`, the retried agent could never reclaim the issue: `PATCH`, `/release`, and `DELETE /comments` all 409'd against the dead run, while only the un-guarded `POST /comments` succeeded — matching the MAS-700 report exactly.

## Change

Clear `checkoutRunId` in the same transaction that transfers the execution lock, mirroring the confirmed-dead-child retry path (`enqueueProcessLossRetry`) so both orphan paths leave the issue in an identical, self-healing shape. The existing `eq(issues.executionRunId, run.id)` guard ensures we only reclaim from the run being retried — never from a live run of another agent.

The checkout-side reclaim hardening (edit #2 in the ticket) **already exists on master**: `clearCheckoutRunIfTerminal` + `adoptStaleCheckoutRun` + terminal execution-lock adoption in `IssueService.checkout`, covered by the "Fix B path" and live-owner-409 cases in `issue-stale-execution-lock-routes.test.ts`. So this PR completes the one remaining gap (edit #1). Combined with that machinery, the next MAS-697 fire self-heals on checkout after redeploy — no board-only force-release needed.

## Tests

- New regression in `heartbeat-retry-scheduling.test.ts`: seeds an issue pinned to a failed run on both lock columns, schedules a transient retry, asserts `executionRunId` moves to the retry run and `checkoutRunId` is cleared. Verified it **fails without** the one-line fix (`checkoutRunId` stays pinned to the terminal run).
- `pnpm typecheck` (server) — green.
- Suites green (42 tests): `heartbeat-retry-scheduling`, `execution-lock-orphan-cleanup`, `issue-stale-execution-lock-routes`. The pre-existing live-owner-409 case is preserved.

Fixes MAS-702. Unblocks MAS-700 / MAS-697.
