### PR TITLE
fix(orchestration): bind runtime identity and routine policy

### DIFF
--- a/doc/DATABASE.md
+++ b/doc/DATABASE.md
@@ -204,6 +204,8 @@ responsible user.
 
 Secret-aware env bindings are supported by agents, projects, and routines. Routine env lives in `routines.env`, is captured in `routine_revisions.snapshot`, and routine dispatches store `routine_runs.routine_revision_id` so runtime secret resolution uses the env snapshot that existed when the run was created. Routine secret refs bind with `target_type = 'routine'`, `target_id = routines.id`, and `config_path` values under `env.*`.
 
+Routine-created issues can also carry an issue execution policy. The normalized policy lives in `routines.execution_policy`, is captured in every routine revision (legacy snapshots read it as `null`), is applied to each dispatched issue, and participates in the dispatch fingerprint so runs with different effective policies cannot coalesce.
+
 For local/default installs, the active provider is `local_encrypted`:
 
 - Secret material is encrypted at rest with a local master key.

--- a/doc/SPEC-implementation.md
+++ b/doc/SPEC-implementation.md
@@ -849,7 +849,8 @@ Behavior:
   `PAPERCLIP_RUN_ID`; when the wake carries a task (`context.taskId`) or is
   issue-backed (`context.issueId`), also inject `PAPERCLIP_TASK_ID` from the
   wake context (`taskId` takes priority). Adapter-configured env cannot
-  override these identity fields.
+  override these identity fields, and an adapter-configured
+  `PAPERCLIP_TASK_ID` is removed when the wake carries neither value.
 - stream stdout/stderr to run logs
 - mark run status on exit code/timeout
 - cancel sends SIGTERM then SIGKILL after grace

--- a/doc/SPEC-implementation.md
+++ b/doc/SPEC-implementation.md
@@ -845,6 +845,10 @@ Config shape:
 Behavior:
 
 - spawn child process
+- inject runtime-owned `PAPERCLIP_AGENT_ID`, `PAPERCLIP_COMPANY_ID`, and
+  `PAPERCLIP_RUN_ID`; when the wake is issue-backed, also inject
+  `PAPERCLIP_TASK_ID` from the wake context. Adapter-configured env cannot
+  override these identity fields.
 - stream stdout/stderr to run logs
 - mark run status on exit code/timeout
 - cancel sends SIGTERM then SIGKILL after grace

--- a/doc/SPEC-implementation.md
+++ b/doc/SPEC-implementation.md
@@ -846,8 +846,9 @@ Behavior:
 
 - spawn child process
 - inject runtime-owned `PAPERCLIP_AGENT_ID`, `PAPERCLIP_COMPANY_ID`, and
-  `PAPERCLIP_RUN_ID`; when the wake is issue-backed, also inject
-  `PAPERCLIP_TASK_ID` from the wake context. Adapter-configured env cannot
+  `PAPERCLIP_RUN_ID`; when the wake carries a task (`context.taskId`) or is
+  issue-backed (`context.issueId`), also inject `PAPERCLIP_TASK_ID` from the
+  wake context (`taskId` takes priority). Adapter-configured env cannot
   override these identity fields.
 - stream stdout/stderr to run logs
 - mark run status on exit code/timeout

--- a/packages/db/src/migrations/0148_routine_execution_policy.sql
+++ b/packages/db/src/migrations/0148_routine_execution_policy.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "routines" ADD COLUMN IF NOT EXISTS "execution_policy" jsonb;

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -1023,6 +1023,13 @@
       "when": 1783953514660,
       "tag": "0147_cost_event_status",
       "breakpoints": true
+    },
+    {
+      "idx": 148,
+      "version": "7",
+      "when": 1784000176196,
+      "tag": "0148_routine_execution_policy",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/routines.ts
+++ b/packages/db/src/schema/routines.ts
@@ -17,7 +17,12 @@ import { issues } from "./issues.js";
 import { projects } from "./projects.js";
 import { goals } from "./goals.js";
 import { heartbeatRuns } from "./heartbeat_runs.js";
-import type { RoutineEnvConfig, RoutineRevisionSnapshotV1, RoutineVariable } from "@paperclipai/shared";
+import type {
+  IssueExecutionPolicy,
+  RoutineEnvConfig,
+  RoutineRevisionSnapshotV1,
+  RoutineVariable,
+} from "@paperclipai/shared";
 
 export const routines = pgTable(
   "routines",
@@ -40,6 +45,7 @@ export const routines = pgTable(
     originId: text("origin_id"),
     variables: jsonb("variables").$type<RoutineVariable[]>().notNull().default([]),
     env: jsonb("env").$type<RoutineEnvConfig>(),
+    executionPolicy: jsonb("execution_policy").$type<IssueExecutionPolicy>(),
     latestRevisionId: uuid("latest_revision_id"),
     latestRevisionNumber: integer("latest_revision_number").notNull().default(1),
     createdByAgentId: uuid("created_by_agent_id").references(() => agents.id, { onDelete: "set null" }),

--- a/packages/shared/src/types/routine.ts
+++ b/packages/shared/src/types/routine.ts
@@ -9,6 +9,7 @@ import type {
   RoutineVariableType,
 } from "../constants.js";
 import type { EnvBinding } from "./secrets.js";
+import type { IssueExecutionPolicy } from "./issue.js";
 import type { ExecutionWorkspaceMode, IssueExecutionWorkspaceSettings } from "./workspace-runtime.js";
 
 export interface RoutineDescriptionDocument {
@@ -84,6 +85,7 @@ export interface Routine {
   originId?: string | null;
   variables: RoutineVariable[];
   env?: RoutineEnvConfig | null;
+  executionPolicy?: IssueExecutionPolicy | null;
   latestRevisionId: string | null;
   latestRevisionNumber: number;
   createdByAgentId: string | null;
@@ -127,6 +129,7 @@ export interface RoutineRevisionSnapshotRoutineV1 {
   originId?: string | null;
   variables: RoutineVariable[];
   env: RoutineEnvConfig | null;
+  executionPolicy: IssueExecutionPolicy | null;
   responsibleUserId: string | null;
 }
 

--- a/packages/shared/src/validators/routine.test.ts
+++ b/packages/shared/src/validators/routine.test.ts
@@ -28,6 +28,8 @@ describe("routine validators", () => {
         status: "active",
         concurrencyPolicy: "coalesce_if_active",
         catchUpPolicy: "skip_missed",
+        originKind: "pipeline_automation",
+        originId: "pipeline-stage-123",
         variables: [],
       },
       triggers: [{
@@ -44,6 +46,8 @@ describe("routine validators", () => {
     });
 
     expect(parsed.triggers[0]?.publicId).toBe("routine_webhook_123");
+    expect(parsed.routine.originKind).toBe("pipeline_automation");
+    expect(parsed.routine.originId).toBe("pipeline-stage-123");
     expect(parsed.routine.executionPolicy).toBeNull();
   });
 

--- a/packages/shared/src/validators/routine.test.ts
+++ b/packages/shared/src/validators/routine.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  createRoutineSchema,
   routineRevisionSnapshotV1Schema,
   routineVariableSchema,
   updateRoutineSchema,
@@ -43,6 +44,44 @@ describe("routine validators", () => {
     });
 
     expect(parsed.triggers[0]?.publicId).toBe("routine_webhook_123");
+    expect(parsed.routine.executionPolicy).toBeNull();
+  });
+
+  it("accepts comment-optional routine policies and defaults legacy snapshots to null", () => {
+    const created = createRoutineSchema.parse({
+      title: "Autonomous triage",
+      executionPolicy: {
+        mode: "normal",
+        commentRequired: false,
+        stages: [],
+      },
+    });
+    expect(created.executionPolicy).toEqual({
+      mode: "normal",
+      commentRequired: false,
+      stages: [],
+    });
+
+    const legacy = routineRevisionSnapshotV1Schema.parse({
+      version: 1,
+      routine: {
+        id: routineId,
+        companyId,
+        projectId: null,
+        goalId: null,
+        parentIssueId: null,
+        title: "Legacy routine",
+        description: null,
+        assigneeAgentId: null,
+        priority: "medium",
+        status: "active",
+        concurrencyPolicy: "coalesce_if_active",
+        catchUpPolicy: "skip_missed",
+        variables: [],
+      },
+      triggers: [],
+    });
+    expect(legacy.routine.executionPolicy).toBeNull();
   });
 
   it("rejects secret-bearing trigger fields in routine revision snapshots", () => {

--- a/packages/shared/src/validators/routine.ts
+++ b/packages/shared/src/validators/routine.ts
@@ -96,6 +96,8 @@ export const routineRevisionSnapshotRoutineV1Schema = z.object({
   status: z.enum(ROUTINE_STATUSES),
   concurrencyPolicy: z.enum(ROUTINE_CONCURRENCY_POLICIES),
   catchUpPolicy: z.enum(ROUTINE_CATCH_UP_POLICIES),
+  originKind: z.string().optional(),
+  originId: z.string().optional().nullable(),
   variables: z.array(routineVariableSchema),
   env: envConfigSchema.nullable().default(null),
   executionPolicy: issueExecutionPolicySchema.nullable().default(null),

--- a/packages/shared/src/validators/routine.ts
+++ b/packages/shared/src/validators/routine.ts
@@ -10,6 +10,7 @@ import {
 } from "../constants.js";
 import {
   ISSUE_EXECUTION_WORKSPACE_PREFERENCES,
+  issueExecutionPolicySchema,
   issueExecutionWorkspaceSettingsSchema,
 } from "./issue.js";
 import { envConfigSchema } from "./secret.js";
@@ -72,6 +73,7 @@ export const createRoutineSchema = z.object({
   catchUpPolicy: z.enum(ROUTINE_CATCH_UP_POLICIES).optional().default("skip_missed"),
   variables: z.array(routineVariableSchema).optional().default([]),
   env: envConfigSchema.optional().nullable(),
+  executionPolicy: issueExecutionPolicySchema.optional().nullable(),
 });
 
 export type CreateRoutine = z.infer<typeof createRoutineSchema>;
@@ -96,6 +98,7 @@ export const routineRevisionSnapshotRoutineV1Schema = z.object({
   catchUpPolicy: z.enum(ROUTINE_CATCH_UP_POLICIES),
   variables: z.array(routineVariableSchema),
   env: envConfigSchema.nullable().default(null),
+  executionPolicy: issueExecutionPolicySchema.nullable().default(null),
   responsibleUserId: z.string().nullable().default(null),
 }).strict();
 

--- a/server/src/__tests__/issue-execution-policy.test.ts
+++ b/server/src/__tests__/issue-execution-policy.test.ts
@@ -76,14 +76,26 @@ describe("normalizeIssueExecutionPolicy", () => {
     expect(result!.stages[0].participants[0].id).toBeDefined();
   });
 
-  it("always sets commentRequired to true", () => {
+  it("preserves an explicit commentRequired false value", () => {
     const result = normalizeIssueExecutionPolicy({
       commentRequired: false,
       stages: [
         { type: "review", participants: [{ type: "agent", agentId: qaAgentId }] },
       ],
     });
-    expect(result!.commentRequired).toBe(true);
+    expect(result!.commentRequired).toBe(false);
+  });
+
+  it("keeps a comment-optional policy without stages", () => {
+    expect(normalizeIssueExecutionPolicy({
+      mode: "normal",
+      commentRequired: false,
+      stages: [],
+    })).toEqual({
+      mode: "normal",
+      commentRequired: false,
+      stages: [],
+    });
   });
 
   it("defaults mode to normal", () => {
@@ -93,6 +105,7 @@ describe("normalizeIssueExecutionPolicy", () => {
       ],
     });
     expect(result!.mode).toBe("normal");
+    expect(result!.commentRequired).toBe(true);
   });
 
   it("rejects approvalsNeeded values above 1", () => {

--- a/server/src/__tests__/process-adapter-context.test.ts
+++ b/server/src/__tests__/process-adapter-context.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import { execute } from "../adapters/process/execute.js";
+import type { AdapterExecutionContext } from "../adapters/types.js";
+
+const AGENT = {
+  id: "11111111-1111-4111-8111-111111111111",
+  companyId: "22222222-2222-4222-8222-222222222222",
+  name: "deterministic-controller",
+  adapterType: "process",
+  adapterConfig: {},
+};
+
+function context(overrides: Partial<AdapterExecutionContext> = {}): AdapterExecutionContext {
+  return {
+    runId: "33333333-3333-4333-8333-333333333333",
+    agent: AGENT,
+    runtime: {
+      sessionId: null,
+      sessionParams: null,
+      sessionDisplayId: null,
+      taskKey: null,
+    },
+    config: {
+      command: process.execPath,
+      args: [
+        "-e",
+        "process.stdout.write(JSON.stringify(Object.fromEntries(Object.entries(process.env).filter(([key]) => key.startsWith('PAPERCLIP_')))))",
+      ],
+      cwd: process.cwd(),
+      timeoutSec: 10,
+      graceSec: 1,
+    },
+    context: {},
+    onLog: async () => undefined,
+    ...overrides,
+  };
+}
+
+function output(result: Awaited<ReturnType<typeof execute>>): Record<string, string> {
+  expect(result.exitCode).toBe(0);
+  const stdout = result.resultJson?.stdout;
+  expect(typeof stdout).toBe("string");
+  return JSON.parse(String(stdout)) as Record<string, string>;
+}
+
+describe("process adapter Paperclip context", () => {
+  it("injects runtime-owned run and task identity after configured env", async () => {
+    const result = await execute(context({
+      context: { taskId: " 44444444-4444-4444-8444-444444444444 " },
+      config: {
+        ...context().config,
+        env: {
+          PAPERCLIP_AGENT_ID: "spoofed-agent",
+          PAPERCLIP_COMPANY_ID: "spoofed-company",
+          PAPERCLIP_RUN_ID: "spoofed-run",
+          PAPERCLIP_TASK_ID: "spoofed-task",
+          PAPERCLIP_API_URL: "http://127.0.0.1:19001",
+        },
+      },
+    }));
+
+    expect(output(result)).toMatchObject({
+      PAPERCLIP_AGENT_ID: AGENT.id,
+      PAPERCLIP_COMPANY_ID: AGENT.companyId,
+      PAPERCLIP_RUN_ID: "33333333-3333-4333-8333-333333333333",
+      PAPERCLIP_TASK_ID: "44444444-4444-4444-8444-444444444444",
+      PAPERCLIP_API_URL: "http://127.0.0.1:19001",
+    });
+  });
+
+  it("falls back to issueId and removes an untrusted task id when no wake task exists", async () => {
+    const withIssue = output(await execute(context({
+      context: { issueId: "55555555-5555-4555-8555-555555555555" },
+    })));
+    expect(withIssue.PAPERCLIP_TASK_ID).toBe("55555555-5555-4555-8555-555555555555");
+
+    const withoutIssue = output(await execute(context({
+      config: {
+        ...context().config,
+        env: { PAPERCLIP_TASK_ID: "spoofed-task" },
+      },
+    })));
+    expect(withoutIssue).not.toHaveProperty("PAPERCLIP_TASK_ID");
+    expect(withoutIssue.PAPERCLIP_RUN_ID).toBe("33333333-3333-4333-8333-333333333333");
+  });
+});

--- a/server/src/__tests__/routines-routes.test.ts
+++ b/server/src/__tests__/routines-routes.test.ts
@@ -648,4 +648,40 @@ describe("routine routes", () => {
     });
     expect(mockTrackRoutineCreated).toHaveBeenCalledWith(expect.anything());
   });
+
+  it("round-trips a comment-optional execution policy through the create API", async () => {
+    const executionPolicy = {
+      mode: "normal",
+      commentRequired: false,
+      stages: [],
+    };
+    mockRoutineService.create.mockResolvedValue({
+      ...routine,
+      executionPolicy,
+    });
+    const app = await createApp({
+      type: "board",
+      userId: "board-user",
+      source: "session",
+      isInstanceAdmin: true,
+      companyIds: [companyId],
+    });
+
+    const res = await request(app)
+      .post(`/api/companies/${companyId}/routines`)
+      .send({
+        projectId,
+        title: "Autonomous routine",
+        assigneeAgentId: agentId,
+        executionPolicy,
+      });
+
+    expect(res.status).toBe(201);
+    expect(mockRoutineService.create).toHaveBeenCalledWith(
+      companyId,
+      expect.objectContaining({ executionPolicy }),
+      expect.anything(),
+    );
+    expect(res.body.executionPolicy).toEqual(executionPolicy);
+  });
 });

--- a/server/src/__tests__/routines-service.test.ts
+++ b/server/src/__tests__/routines-service.test.ts
@@ -1,5 +1,5 @@
 import { createHmac, randomUUID } from "node:crypto";
-import { eq } from "drizzle-orm";
+import { eq, sql } from "drizzle-orm";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import {
   activityLog,
@@ -20,6 +20,7 @@ import {
   projectWorkspaces,
   projects,
   routineDocuments,
+  routineRevisions,
   routineRuns,
   routines,
   routineTriggers,
@@ -682,6 +683,83 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
     const runAfter = await svc.runRoutine(routine.id, { source: "manual" });
     expect(runAfter.routineRevisionId).toBe(updated?.latestRevisionId);
     expect(runAfter.dispatchFingerprint).not.toBe(runBefore.dispatchFingerprint);
+  });
+
+  it("stores routine execution policy, applies it to issues, and binds it into the dispatch fingerprint", async () => {
+    const { agentId, companyId, projectId, svc } = await seedFixture();
+    const executionPolicy = {
+      mode: "normal" as const,
+      commentRequired: false,
+      stages: [],
+    };
+    const routine = await svc.create(
+      companyId,
+      {
+        projectId,
+        goalId: null,
+        parentIssueId: null,
+        title: "comment-optional routine",
+        description: null,
+        assigneeAgentId: agentId,
+        priority: "medium",
+        status: "active",
+        concurrencyPolicy: "always_enqueue",
+        catchUpPolicy: "skip_missed",
+        executionPolicy,
+      },
+      {},
+    );
+
+    expect(routine.executionPolicy).toEqual(executionPolicy);
+    const [revision] = await svc.listRevisions(routine.id);
+    expect(revision?.snapshot.routine.executionPolicy).toEqual(executionPolicy);
+
+    const firstRun = await svc.runRoutine(routine.id, { source: "manual" });
+    const firstIssue = await db
+      .select({ executionPolicy: issues.executionPolicy })
+      .from(issues)
+      .where(eq(issues.id, firstRun.linkedIssueId!))
+      .then((rows) => rows[0] ?? null);
+    expect(firstIssue?.executionPolicy).toEqual(executionPolicy);
+
+    // A fingerprint must bind effective policy content, not only the revision id.
+    // Simulate out-of-band drift while leaving latestRevisionId unchanged.
+    await db
+      .update(routines)
+      .set({ executionPolicy: null })
+      .where(eq(routines.id, routine.id));
+    const secondRun = await svc.runRoutine(routine.id, { source: "manual" });
+    expect(secondRun.routineRevisionId).toBe(firstRun.routineRevisionId);
+    expect(secondRun.dispatchFingerprint).not.toBe(firstRun.dispatchFingerprint);
+  });
+
+  it("restores routine execution policy and treats legacy snapshots without it as null", async () => {
+    const { routine, svc } = await seedFixture();
+    const legacyRevisionId = routine.latestRevisionId!;
+    const executionPolicy = {
+      mode: "normal" as const,
+      commentRequired: false,
+      stages: [],
+    };
+    await svc.update(routine.id, { executionPolicy }, {});
+
+    await db.execute(sql`
+      update ${routineRevisions}
+      set snapshot = jsonb_set(
+        ${routineRevisions.snapshot},
+        '{routine}',
+        (${routineRevisions.snapshot} -> 'routine') - 'executionPolicy'
+      )
+      where ${routineRevisions.id} = ${legacyRevisionId}
+    `);
+
+    const legacyRevision = (await svc.listRevisions(routine.id))
+      .find((entry) => entry.id === legacyRevisionId);
+    expect(legacyRevision?.snapshot.routine.executionPolicy).toBeNull();
+
+    const restored = await svc.restoreRevision(routine.id, legacyRevisionId, {});
+    expect(restored.routine.executionPolicy).toBeNull();
+    expect(restored.revision.snapshot.routine.executionPolicy).toBeNull();
   });
 
   it("rejects stale routine baseRevisionId updates", async () => {

--- a/server/src/__tests__/routines-service.test.ts
+++ b/server/src/__tests__/routines-service.test.ts
@@ -602,6 +602,22 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
     expect(revisions[1]?.snapshot.routine.description).toBe("Run the frog routine");
   });
 
+  it("reconciles out-of-band row drift when the desired state matches the latest revision", async () => {
+    const { routine, svc } = await seedFixture();
+
+    await db
+      .update(routines)
+      .set({ title: "DRIFTED BY TEST" })
+      .where(eq(routines.id, routine.id));
+
+    const reconciled = await svc.update(routine.id, { title: routine.title }, {});
+
+    expect(reconciled?.title).toBe(routine.title);
+    expect(reconciled?.latestRevisionId).toBe(routine.latestRevisionId);
+    expect(reconciled?.latestRevisionNumber).toBe(routine.latestRevisionNumber);
+    expect(await svc.listRevisions(routine.id)).toHaveLength(1);
+  });
+
   it("stores routine env in revisions, syncs routine secret bindings, and stamps runs with the dispatch revision", async () => {
     const { agentId, companyId, projectId, svc } = await seedFixture();
     const secrets = secretService(db);

--- a/server/src/adapters/process/execute.ts
+++ b/server/src/adapters/process/execute.ts
@@ -12,7 +12,7 @@ import {
 } from "../utils.js";
 
 export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExecutionResult> {
-  const { runId, agent, config, onLog, onMeta } = ctx;
+  const { runId, agent, config, context, onLog, onMeta } = ctx;
   const command = asString(config.command, "");
   if (!command) throw new Error("Process adapter missing command");
 
@@ -23,6 +23,19 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   for (const [k, v] of Object.entries(envConfig)) {
     if (typeof v === "string") env[k] = v;
   }
+
+  // Process adapters are first-class agent runtimes, so they need the same
+  // authenticated run/task identity that local CLI adapters receive. Keep
+  // these values runtime-owned: adapterConfig.env must not be able to spoof a
+  // different agent, company, run, or wake task. PAPERCLIP_API_URL remains
+  // configurable so an operator can route a low-trust process through a local
+  // method/path allowlist proxy.
+  env.PAPERCLIP_AGENT_ID = agent.id;
+  env.PAPERCLIP_COMPANY_ID = agent.companyId;
+  env.PAPERCLIP_RUN_ID = runId;
+  delete env.PAPERCLIP_TASK_ID;
+  const wakeTaskId = readNonEmptyString(context.taskId) ?? readNonEmptyString(context.issueId);
+  if (wakeTaskId) env.PAPERCLIP_TASK_ID = wakeTaskId;
   const runtimeEnv = ensurePathInEnv({ ...process.env, ...env });
   const resolvedCommand = await resolveCommandForLogs(command, cwd, runtimeEnv);
   const loggedEnv = buildInvocationEnvForLogs(env, {
@@ -84,4 +97,8 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       stderr: proc.stderr,
     },
   };
+}
+
+function readNonEmptyString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
 }

--- a/server/src/services/issue-execution-policy.ts
+++ b/server/src/services/issue-execution-policy.ts
@@ -390,11 +390,12 @@ export function normalizeIssueExecutionPolicy(input: unknown): IssueExecutionPol
   const reviewPreset = parsed.data.reviewPreset;
   const authorizationPolicy = parsed.data.authorizationPolicy;
 
-  if (stages.length === 0 && !monitor && !reviewPreset && !authorizationPolicy) return null;
+  const hasNonDefaultBasePolicy = parsed.data.mode !== "normal" || parsed.data.commentRequired === false;
+  if (stages.length === 0 && !monitor && !reviewPreset && !authorizationPolicy && !hasNonDefaultBasePolicy) return null;
 
   return {
     mode: parsed.data.mode ?? "normal",
-    commentRequired: true,
+    commentRequired: parsed.data.commentRequired,
     stages,
     ...(monitor ? { monitor } : {}),
     ...(reviewPreset ? { reviewPreset } : {}),

--- a/server/src/services/pipelines.ts
+++ b/server/src/services/pipelines.ts
@@ -1178,6 +1178,7 @@ function routineRevisionSnapshotRoutine(routine: typeof routines.$inferSelect): 
     originId: routine.originId,
     variables: routine.variables ?? [],
     env: routine.env ?? null,
+    executionPolicy: routine.executionPolicy ?? null,
     responsibleUserId: routine.responsibleUserId ?? null,
   };
 }

--- a/server/src/services/routines.ts
+++ b/server/src/services/routines.ts
@@ -29,6 +29,7 @@ import {
 import type {
   CreateRoutine,
   CreateRoutineTrigger,
+  IssueExecutionPolicy,
   Routine,
   RoutineDetail,
   RoutineDescriptionDocument,
@@ -53,6 +54,7 @@ import {
   pluginOperationIssueOriginKind,
   stringifyRoutineVariableValue,
   syncRoutineVariablesWithTemplate,
+  routineRevisionSnapshotSchema,
 } from "@paperclipai/shared";
 import { trackRoutineRun } from "@paperclipai/shared/telemetry";
 import { conflict, forbidden, notFound, unauthorized, unprocessable } from "../errors.js";
@@ -74,6 +76,7 @@ import {
 } from "./instance-settings.js";
 import { queueIssueAssignmentWakeup, type IssueAssignmentWakeupDeps } from "./issue-assignment-wakeup.js";
 import { logActivity } from "./activity-log.js";
+import { normalizeIssueExecutionPolicy } from "./issue-execution-policy.js";
 import type { PluginWorkerManager } from "./plugin-worker-manager.js";
 
 const OPEN_ISSUE_STATUSES = ["backlog", "todo", "in_progress", "in_review", "blocked"];
@@ -461,6 +464,7 @@ function createRoutineDispatchFingerprint(input: {
   assigneeAgentId: string | null;
   routineRevisionId: string | null;
   routineEnvFingerprint: string | null;
+  executionPolicy: IssueExecutionPolicy | null;
   executionWorkspaceId?: string | null;
   executionWorkspacePreference?: string | null;
   executionWorkspaceSettings?: Record<string, unknown> | null;
@@ -507,6 +511,7 @@ function routineRevisionSnapshotRoutine(routine: RoutineRow): RoutineRevisionSna
     catchUpPolicy: routine.catchUpPolicy as RoutineRevisionSnapshotV1["routine"]["catchUpPolicy"],
     variables: routine.variables ?? [],
     env: routine.env ?? null,
+    executionPolicy: routine.executionPolicy ?? null,
     responsibleUserId: routine.responsibleUserId ?? null,
   };
 }
@@ -557,10 +562,20 @@ function routineCurrentFieldsMatch(left: RoutineRow, right: RoutineRow) {
   );
 }
 
+function parseRoutineRevisionSnapshot(value: unknown): RoutineRevisionSnapshotV1 {
+  const parsed = routineRevisionSnapshotSchema.safeParse(value);
+  if (!parsed.success) {
+    throw unprocessable("Invalid routine revision snapshot", parsed.error.flatten());
+  }
+  // The runtime schema intentionally accepts legacy variable entries whose
+  // optional presentation fields predate the stricter public interface.
+  return parsed.data as unknown as RoutineRevisionSnapshotV1;
+}
+
 function mapRoutineRevision(row: typeof routineRevisions.$inferSelect): RoutineRevision {
   return {
     ...row,
-    snapshot: row.snapshot as RoutineRevisionSnapshotV1,
+    snapshot: parseRoutineRevisionSnapshot(row.snapshot),
   };
 }
 
@@ -1641,6 +1656,7 @@ export function routineService(
       : "routine_execution";
     const issueOriginId = managedIssueTemplate?.originId ?? input.routine.id;
     const issueBillingCode = managedIssueTemplate?.billingCode ?? null;
+    const executionPolicy = normalizeIssueExecutionPolicy(input.routine.executionPolicy ?? null);
     const dispatchFingerprint = createRoutineDispatchFingerprint({
       payload: triggerPayload,
       projectId,
@@ -1648,6 +1664,7 @@ export function routineService(
       assigneeAgentId,
       routineRevisionId: input.routine.latestRevisionId,
       routineEnvFingerprint: createRoutineEnvFingerprint(input.routine.env),
+      executionPolicy,
       executionWorkspaceId: input.executionWorkspaceId ?? null,
       executionWorkspacePreference: input.executionWorkspacePreference ?? null,
       executionWorkspaceSettings: input.executionWorkspaceSettings ?? null,
@@ -1695,7 +1712,7 @@ export function routineService(
             ))
             .then((rows) => {
               const row = rows[0] ?? null;
-              const snapshot = row?.snapshot as RoutineRevisionSnapshotV1 | undefined;
+              const snapshot = row ? parseRoutineRevisionSnapshot(row.snapshot) : undefined;
               return row?.responsibleUserId ?? snapshot?.routine.responsibleUserId ?? null;
             })
         : null;
@@ -1775,6 +1792,7 @@ export function routineService(
             originRunId: createdRun.id,
             originFingerprint: dispatchFingerprint,
             billingCode: issueBillingCode,
+            executionPolicy: executionPolicy as Record<string, unknown> | null,
             executionWorkspaceId: input.executionWorkspaceId ?? null,
             executionWorkspacePreference: input.executionWorkspacePreference ?? null,
             executionWorkspaceSettings: input.executionWorkspaceSettings ?? null,
@@ -2056,6 +2074,7 @@ export function routineService(
             strictMode: process.env.PAPERCLIP_SECRETS_STRICT_MODE === "true",
             fieldPath: "env",
           });
+      const executionPolicy = normalizeIssueExecutionPolicy(input.executionPolicy ?? null);
       const variables = syncRoutineVariablesWithTemplate(
         [input.title, input.description],
         sanitizeRoutineVariableInputs(input.variables),
@@ -2084,6 +2103,7 @@ export function routineService(
             catchUpPolicy: input.catchUpPolicy,
             variables,
             env,
+            executionPolicy,
             responsibleUserId,
             createdByAgentId: actor.agentId ?? null,
             createdByUserId: actor.userId ?? null,
@@ -2122,6 +2142,9 @@ export function routineService(
               strictMode: process.env.PAPERCLIP_SECRETS_STRICT_MODE === "true",
               fieldPath: "env",
             });
+      const nextExecutionPolicy = patch.executionPolicy === undefined
+        ? existing.executionPolicy
+        : normalizeIssueExecutionPolicy(patch.executionPolicy ?? null);
       const requestedStatus = patch.status ?? existing.status;
       if (patch.status === "active") {
         assertRoutineCanEnable(patch.status, nextAssigneeAgentId);
@@ -2194,6 +2217,7 @@ export function routineService(
           catchUpPolicy: patch.catchUpPolicy ?? locked.catchUpPolicy,
           variables: nextVariables,
           env: nextEnv,
+          executionPolicy: nextExecutionPolicy,
           responsibleUserId: locked.responsibleUserId ?? responsibleUserId,
           updatedByAgentId: actor.agentId ?? null,
           updatedByUserId: actor.userId ?? null,
@@ -2216,7 +2240,7 @@ export function routineService(
               ),
             )
             .then((rows) => rows[0] ?? null);
-          if (latestRevision && snapshotsMatch(nextSnapshot, latestRevision.snapshot as RoutineRevisionSnapshotV1)) {
+          if (latestRevision && snapshotsMatch(nextSnapshot, parseRoutineRevisionSnapshot(latestRevision.snapshot))) {
             if (patch.env !== undefined) {
               await secretsSvc.syncEnvBindingsForTarget(
                 locked.companyId,
@@ -2244,6 +2268,7 @@ export function routineService(
             catchUpPolicy: candidate.catchUpPolicy,
             variables: candidate.variables,
             env: candidate.env,
+            executionPolicy: candidate.executionPolicy,
             responsibleUserId: candidate.responsibleUserId,
             updatedByAgentId: actor.agentId ?? null,
             updatedByUserId: actor.userId ?? null,
@@ -2523,7 +2548,7 @@ export function routineService(
         .then((rows) => rows[0] ?? null);
       if (!targetRevision) throw notFound("Routine revision not found");
 
-      const snapshot = targetRevision.snapshot as RoutineRevisionSnapshotV1;
+      const snapshot = parseRoutineRevisionSnapshot(targetRevision.snapshot);
       const routineSnapshot = snapshot.routine;
       await assertRestorableAssignee(existingRoutine.companyId, routineSnapshot.assigneeAgentId, actor);
 
@@ -2580,6 +2605,7 @@ export function routineService(
             catchUpPolicy: routineSnapshot.catchUpPolicy,
             variables: routineSnapshot.variables,
             env: routineSnapshot.env,
+            executionPolicy: routineSnapshot.executionPolicy ?? null,
             updatedByAgentId: actor.agentId ?? null,
             updatedByUserId: actor.userId ?? null,
             updatedAt: now,

--- a/server/src/services/routines.ts
+++ b/server/src/services/routines.ts
@@ -2241,6 +2241,29 @@ export function routineService(
             )
             .then((rows) => rows[0] ?? null);
           if (latestRevision && snapshotsMatch(nextSnapshot, parseRoutineRevisionSnapshot(latestRevision.snapshot))) {
+            const [reconciled] = await txDb
+              .update(routines)
+              .set({
+                projectId: candidate.projectId,
+                goalId: candidate.goalId,
+                parentIssueId: candidate.parentIssueId,
+                title: candidate.title,
+                description: candidate.description,
+                assigneeAgentId: candidate.assigneeAgentId,
+                priority: candidate.priority,
+                status: candidate.status,
+                concurrencyPolicy: candidate.concurrencyPolicy,
+                catchUpPolicy: candidate.catchUpPolicy,
+                variables: candidate.variables,
+                env: candidate.env,
+                executionPolicy: candidate.executionPolicy,
+                responsibleUserId: candidate.responsibleUserId,
+                updatedByAgentId: actor.agentId ?? null,
+                updatedByUserId: actor.userId ?? null,
+                updatedAt: new Date(),
+              })
+              .where(eq(routines.id, id))
+              .returning();
             if (patch.env !== undefined) {
               await secretsSvc.syncEnvBindingsForTarget(
                 locked.companyId,
@@ -2249,7 +2272,7 @@ export function routineService(
                 { db: tx },
               );
             }
-            return locked;
+            return reconciled ?? null;
           }
         }
 

--- a/ui/src/components/RoutineHistoryTab.test.tsx
+++ b/ui/src/components/RoutineHistoryTab.test.tsx
@@ -100,6 +100,7 @@ function snapshotV1(overrides?: Partial<RoutineRevisionSnapshotV1["routine"]>): 
       variables: [],
       env: null,
       ...overrides,
+      executionPolicy: overrides?.executionPolicy ?? null,
     },
     triggers: [],
   };

--- a/ui/storybook/stories/routine-secrets.stories.tsx
+++ b/ui/storybook/stories/routine-secrets.stories.tsx
@@ -159,6 +159,7 @@ function makeSnapshot(env: RoutineEnvConfig | null): RoutineRevisionSnapshotV1 {
       catchUpPolicy: "skip_missed",
       variables: [],
       env,
+      executionPolicy: null,
     },
     triggers: [],
   };


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the control plane that schedules and supervises autonomous agent work.
> - Process adapters are an execution boundary, while routines are the durable source for recurring issue dispatch.
> - Both boundaries must bind execution to canonical control-plane state rather than adapter-supplied or transient values.
> - Process children previously lacked canonical run/task identity and could inherit spoofed or stale identity fields.
> - Issue-policy normalization also overwrote an explicit `commentRequired: false`, and routines could not persist, revise, restore, or dispatch an issue execution policy.
> - This pull request makes runtime identity server-owned and makes routine issue policy a normalized, revisioned, fingerprint-bound contract.
> - The benefit is deterministic, auditable dispatch for local controllers and autonomous recurring work.

## Linked Issues or Issue Description

Refs #7975. Related process-adapter alternatives: #7924 and #5995.

This also fixes a routine/API bug without a separate public issue: `normalizeIssueExecutionPolicy` forced `commentRequired` to `true`, discarded a comment-optional policy with no stages, and routines had no field through which to carry an issue execution policy to generated issues.

The process-adapter behavior intentionally differs from #7924: agent, company, run, and task identity are runtime-owned and cannot be overridden by adapter config. It does not inject a Paperclip API credential; credential scope remains an independent operator decision.

## What Changed

- Inject canonical `PAPERCLIP_AGENT_ID`, `PAPERCLIP_COMPANY_ID`, and `PAPERCLIP_RUN_ID` into every process-adapter child.
- Inject `PAPERCLIP_TASK_ID` from the wake task or issue, and remove an adapter-supplied stale value when neither exists.
- Preserve explicit `commentRequired: false`; omitted values still default to `true`, and a default empty policy still normalizes to `null`.
- Add nullable `routines.execution_policy` via migration `0148`, shared API/types, and OpenAPI-backed validators.
- Normalize and store routine policies on create/update, include them in immutable revision snapshots, default legacy snapshots to `null`, and restore them append-only.
- Apply the effective policy to every routine-created issue and bind its canonical content into the routine dispatch fingerprint.
- Update pipeline-authored routine snapshots, UI fixtures, database documentation, and regression coverage.

## Verification

- `pnpm exec vitest run ui/src/components/RoutineHistoryTab.test.tsx packages/shared/src/validators/routine.test.ts server/src/__tests__/issue-execution-policy.test.ts server/src/__tests__/routines-routes.test.ts server/src/__tests__/routines-service.test.ts` — 133/133 passed.
- `pnpm --filter @paperclipai/shared typecheck` — passed.
- `pnpm --filter @paperclipai/db typecheck` — passed, including migration numbering/safety.
- `pnpm --filter @paperclipai/server typecheck` — passed.
- `pnpm --filter @paperclipai/ui typecheck` — passed.
- `pnpm --filter @paperclipai/shared build && pnpm --filter @paperclipai/db build && pnpm --filter @paperclipai/server build` — passed.
- The published tree is byte-identical to the post-rebase tree verified above; the branch was advanced without force-pushing.

## Risks

- The database change is additive and nullable. Existing routines and legacy revision snapshots resolve to `executionPolicy: null`; rollback leaves an unused nullable column.
- Explicit `commentRequired: false` now survives normalization. This corrects the API contract but changes behavior for callers that relied on the prior forced-true bug.
- Policy content now affects the dispatch fingerprint, so an open run with a different effective policy will not be treated as the same coalescing identity.
- Process adapters that deliberately configured one of the four identity variables now receive the canonical runtime value. This is the intended security property.
- No API credential, secret value, UI control, or live deployment behavior is added by this PR.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex, GPT-5-class coding model (exact runtime model id/context window not exposed), extended reasoning with repository tools and code execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
