### PR TITLE
fix(adapter-utils): unlink abandoned bridge requests on timeout

### DIFF
--- a/packages/adapter-utils/src/sandbox-callback-bridge.test.ts
+++ b/packages/adapter-utils/src/sandbox-callback-bridge.test.ts
@@ -668,6 +668,7 @@ describe("sandbox callback bridge", () => {
     });
 
     const queueDir = path.posix.join(prepared.runtimeRootDir, "paperclip-bridge");
+    const directories = sandboxCallbackBridgeDirectories(queueDir);
     const bridgeToken = createSandboxCallbackBridgeToken();
     const bridge = await startSandboxCallbackBridgeServer({
       runner,
@@ -693,6 +694,84 @@ describe("sandbox callback bridge", () => {
     await expect(response.json()).resolves.toEqual({
       error: "Timed out waiting for host bridge response.",
     });
+    // Timed-out requests must not leave residue that permanently occupies a queue slot.
+    await expect(readdir(directories.requestsDir)).resolves.toEqual([]);
+    await expect(readdir(directories.responsesDir)).resolves.toEqual([]);
+  });
+
+  it("does not brick the run when unanswered calls exceed maxQueueDepth", async () => {
+    const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-bridge-ratchet-"));
+    cleanupDirs.push(rootDir);
+
+    const localWorkspaceDir = path.join(rootDir, "local-workspace");
+    const remoteWorkspaceDir = path.join(rootDir, "remote-workspace");
+    await mkdir(localWorkspaceDir, { recursive: true });
+    await mkdir(remoteWorkspaceDir, { recursive: true });
+    await writeFile(path.join(localWorkspaceDir, "README.md"), "bridge ratchet test\n", "utf8");
+
+    const runner = createExecRunner();
+    const bridgeAsset = await createSandboxCallbackBridgeAsset();
+    cleanupFns.push(bridgeAsset.cleanup);
+    const prepared = await prepareCommandManagedRuntime({
+      runner,
+      spec: {
+        remoteCwd: remoteWorkspaceDir,
+        timeoutMs: 30_000,
+      },
+      adapterKey: "codex",
+      workspaceLocalDir: localWorkspaceDir,
+      assets: [{ key: "bridge", localDir: bridgeAsset.localDir }],
+    });
+
+    const queueDir = path.posix.join(prepared.runtimeRootDir, "paperclip-bridge");
+    const directories = sandboxCallbackBridgeDirectories(queueDir);
+    const bridgeToken = createSandboxCallbackBridgeToken();
+    const bridge = await startSandboxCallbackBridgeServer({
+      runner,
+      remoteCwd: remoteWorkspaceDir,
+      assetRemoteDir: prepared.assetDirs.bridge,
+      queueDir,
+      bridgeToken,
+      timeoutMs: 30_000,
+      pollIntervalMs: 10,
+      responseTimeoutMs: 75,
+      maxQueueDepth: 4,
+    });
+    cleanupFns.push(async () => {
+      await bridge.stop();
+    });
+
+    // Burst of unanswered calls equal to maxQueueDepth — without unlink-on-abandon,
+    // every slot would remain occupied forever and the next call would 503.
+    const timedOut = await Promise.all(
+      Array.from({ length: 4 }, () =>
+        fetch(`${bridge.baseUrl}/api/agents/me`, {
+          headers: { authorization: `Bearer ${bridgeToken}` },
+        }),
+      ),
+    );
+    for (const response of timedOut) {
+      expect(response.status).toBe(502);
+    }
+    await expect(readdir(directories.requestsDir)).resolves.toEqual([]);
+
+    // A subsequent answered call must succeed — the queue must not be bricked.
+    const answeredPromise = fetch(`${bridge.baseUrl}/api/agents/me`, {
+      headers: { authorization: `Bearer ${bridgeToken}` },
+    });
+    const requestFile = await waitForJsonFile(directories.requestsDir);
+    await writeFile(
+      path.posix.join(directories.responsesDir, requestFile),
+      JSON.stringify({
+        status: 200,
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ ok: true }),
+      }),
+      "utf8",
+    );
+    const answered = await answeredPromise;
+    expect(answered.status).toBe(200);
+    await expect(answered.json()).resolves.toEqual({ ok: true });
   });
 
   it("returns a 502 for malformed host response files", async () => {

--- a/packages/adapter-utils/src/sandbox-callback-bridge.ts
+++ b/packages/adapter-utils/src/sandbox-callback-bridge.ts
@@ -1101,6 +1101,7 @@ async function waitForResponse(requestId) {
 }
 
 const server = createServer(async (req, res) => {
+  let requestPath;
   try {
     const auth = req.headers.authorization || "";
     const receivedToken = auth.startsWith("Bearer ") ? auth.slice("Bearer ".length) : "";
@@ -1137,7 +1138,7 @@ const server = createServer(async (req, res) => {
       body: requestBody,
       createdAt: new Date().toISOString(),
     };
-    const requestPath = path.posix.join(requestsDir, \`\${requestId}.json\`);
+    requestPath = path.posix.join(requestsDir, \`\${requestId}.json\`);
     const tempPath = \`\${requestPath}.tmp\`;
     await fs.writeFile(tempPath, \`\${JSON.stringify(payload)}\\n\`, "utf8");
     await fs.rename(tempPath, requestPath);
@@ -1150,6 +1151,16 @@ const server = createServer(async (req, res) => {
     }
     res.end(typeof response.body === "string" ? response.body : "");
   } catch (error) {
+    if (requestPath) {
+      // About to 502 the caller — nobody can consume an answer to this request.
+      // Unlink our request file (and any late response) so unanswered calls cannot
+      // permanently occupy a queue slot and ratchet queueDepth to maxQueueDepth,
+      // which rejects every further call and bricks the run. Safe by construction:
+      // the control-plane response-writer already no-ops when the request file is gone.
+      const abandonedResponsePath = path.posix.join(responsesDir, path.posix.basename(requestPath));
+      await fs.rm(requestPath, { force: true }).catch(() => undefined);
+      await fs.rm(abandonedResponsePath, { force: true }).catch(() => undefined);
+    }
     res.statusCode = 502;
     res.setHeader("content-type", "application/json");
     res.end(JSON.stringify({ error: error instanceof Error ? error.message : String(error) }));


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Remote/sandbox adapters talk back to the control plane through the sandbox callback bridge (`packages/adapter-utils`), which writes request JSON into a queue directory and waits for a host response
> - When the host does not answer within `responseTimeoutMs`, the bridge returns HTTP 502 — but it previously left its own `requests/<id>.json` file behind
> - Nothing else removes those abandoned files (the host only deletes a request after answering it), so every timeout permanently occupies a queue slot
> - At `maxQueueDepth` the server starts rejecting new writes with 503, which permanently bricks the run even after the host recovers
> - This pull request unlinks the abandoned request (and any late-written response) on the give-up path before the 502
> - The benefit is that a burst of unanswered calls can no longer ratchet the queue full of corpses; live traffic resumes as soon as the host can answer again

## Linked Issues or Issue Description

No existing public issue — describing it inline as a bug report.

**What happened:** The sandbox callback bridge HTTP server times out waiting for a host response and returns 502, but leaves the request JSON it wrote under `queue/requests/` in place. Abandoned request files accumulate until `queueDepth() >= maxQueueDepth`, after which every new call is rejected with 503 ("Bridge request queue is full") for the rest of the run — even once the host is healthy again.

**Expected behavior:** After the server gives up on a request and 502s the caller, that request must not continue to occupy a queue slot. Subsequent answered calls should succeed once the host is responding again.

**Steps to reproduce:**
1. Start the sandbox callback bridge with a small `PAPERCLIP_BRIDGE_MAX_QUEUE_DEPTH` and a short `PAPERCLIP_BRIDGE_RESPONSE_TIMEOUT_MS`.
2. Do not run a host drainer (leave requests unanswered).
3. Fire `maxQueueDepth` authenticated HTTP calls against the bridge.
4. Observe each call returns 502, and `queue/requests/` still contains that many JSON files.
5. Fire one more call — it returns 503 even though nothing is actually in flight.

**Paperclip version or commit:** reproducible on current `master` (`packages/adapter-utils` sandbox callback bridge server source template).

**Deployment mode:** Self-hosted server / any adapter runtime that materializes the bridge server from `getSandboxCallbackBridgeServerSource()`.

## What Changed

- On the bridge HTTP handler's catch/give-up path, unlink the request file (when one was written) and any late-written response for the same id before returning 502.
- Left auth / 415 / queue-full early returns alone — they never write a request file, so they never trigger cleanup.
- Extended the existing timeout test to assert `requests/` and `responses/` are empty after a 502.
- Added a regression test that fills the queue with unanswered calls, asserts zero residue, then successfully round-trips an answered call (proves the run is not bricked).
- Chose *not* to switch `maxQueueDepth` to drop-oldest: with self-cleaning abandoned requests, drop-oldest is unnecessary and riskier (it can evict a still-live in-flight request under genuine burst load).

## Verification

```
./node_modules/.bin/vitest run packages/adapter-utils/src/sandbox-callback-bridge.test.ts
# Test Files  1 passed (1)
# Tests  14 passed (14)
```

## Risks

Low. Single-file behavioral change on the already-failure path (502). Successful responses are unchanged. Host response writers that already check whether the request file still exists and no-op when it is gone remain correct; deleting an abandoned request is an explicit handled case.

## Model Used

Cursor agent (Composer / Auto agent router) with tool use and local test execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above (no duplicate open PR for this defect; related background: #4801 which introduced the sandbox callback bridge)
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (`fix/bridge-unlink-abandoned-requests`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes — n/a, no user-facing docs surface; behavior is covered by the regression test
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green — pending on this branch
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups — pending
- [x] I will address all Greptile and reviewer comments before requesting merge