### PR TITLE
fix(adapter-utils): fail sandbox bridge runs when the host drain wedges

### DIFF
--- a/packages/adapter-utils/src/execution-target.ts
+++ b/packages/adapter-utils/src/execution-target.ts
@@ -108,6 +108,12 @@ export interface AdapterExecutionTargetProcessOptions {
    * onLog is suppressed and incremental chunks flow through `onLog` instead.
    */
   runLogTail?: SandboxRunLogTailFactory | null;
+  /**
+   * When provided, raced against the child process. Resolving this promise
+   * (typically `paperclipBridge.workerFatalError`) aborts the run so a wedged
+   * host-side bridge drain cannot leave the agent burning budget blind.
+   */
+  cancelPromise?: Promise<Error> | null;
 }
 
 export interface AdapterExecutionTargetShellOptions {
@@ -126,6 +132,12 @@ export interface AdapterExecutionTargetPaperclipBridgeHandle {
    * `runAdapterExecutionTargetProcess` via `options.runLogTail`.
    */
   runLogTail?: SandboxRunLogTailFactory | null;
+  /**
+   * Settles when the host-side bridge worker fails fatally. Pass to
+   * `runAdapterExecutionTargetProcess` as `cancelPromise` so a wedged drain
+   * fails the adapter run (and triggers retry) instead of leaving it blind.
+   */
+  workerFatalError: Promise<Error>;
   stop(): Promise<void>;
 }
 
@@ -543,7 +555,7 @@ export async function runAdapterExecutionTargetProcess(
       runLogTail.start(options.onLog);
     }
     try {
-      const result = await runner.execute({
+      const executePromise = runner.execute({
         command: execCommand,
         args: execArgs,
         cwd: target.remoteCwd,
@@ -557,6 +569,14 @@ export async function runAdapterExecutionTargetProcess(
           ? async (meta) => options.onSpawn?.({ ...meta, processGroupId: null })
           : undefined,
       });
+      const result = options.cancelPromise
+        ? await Promise.race([
+            executePromise,
+            options.cancelPromise.then((error) => {
+              throw error;
+            }),
+          ])
+        : await executePromise;
       if (runLogTail) {
         await runLogTail.finish({ stdout: result.stdout, stderr: result.stderr });
       }
@@ -574,7 +594,7 @@ export async function runAdapterExecutionTargetProcess(
       ? sanitizeRemoteExecutionEnv(options.env)
       : options.env;
 
-  return await runChildProcess(runId, command, args, {
+  const childPromise = runChildProcess(runId, command, args, {
     cwd: options.cwd,
     env,
     stdin: options.stdin,
@@ -585,6 +605,15 @@ export async function runAdapterExecutionTargetProcess(
     terminalResultCleanup: options.terminalResultCleanup,
     remoteExecution: adapterExecutionTargetToRemoteSpec(target),
   });
+  if (!options.cancelPromise) {
+    return await childPromise;
+  }
+  return await Promise.race([
+    childPromise,
+    options.cancelPromise.then((error) => {
+      throw error;
+    }),
+  ]);
 }
 
 export async function runAdapterExecutionTargetShellCommand(
@@ -1690,6 +1719,12 @@ export async function startAdapterExecutionTargetPaperclipBridge(input: {
       client,
       queueDir,
       maxBodyBytes,
+      onFatalError: async (error) => {
+        await onLog(
+          "stderr",
+          `[paperclip] ALARM bridge-worker-fatal: ${error.message}\n`,
+        );
+      },
       handleRequest: async (request) => {
         const method = request.method.trim().toUpperCase() || "GET";
         if (bridgeDebugEnabled) {
@@ -1763,6 +1798,7 @@ export async function startAdapterExecutionTargetPaperclipBridge(input: {
       PAPERCLIP_BRIDGE_QUEUE_DIR: queueDir,
     },
     runLogTail,
+    workerFatalError: worker!.workerFatalError,
     stop: async () => {
       await Promise.allSettled([
         server?.stop(),

--- a/packages/adapter-utils/src/sandbox-callback-bridge.test.ts
+++ b/packages/adapter-utils/src/sandbox-callback-bridge.test.ts
@@ -469,6 +469,67 @@ describe("sandbox callback bridge", () => {
     }
   });
 
+  it("fails loudly when a single request file wedges the drain loop", async () => {
+    const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-bridge-stuck-request-"));
+    cleanupDirs.push(rootDir);
+
+    const queueDir = path.posix.join(rootDir, "queue");
+    const directories = sandboxCallbackBridgeDirectories(queueDir);
+    await mkdir(directories.requestsDir, { recursive: true });
+    await mkdir(directories.responsesDir, { recursive: true });
+
+    await writeFile(
+      path.posix.join(directories.requestsDir, "00-stuck.json"),
+      `${JSON.stringify({
+        id: "stuck",
+        method: "GET",
+        path: "/api/agents/me",
+        query: "",
+        headers: {},
+        body: "",
+        createdAt: new Date().toISOString(),
+      })}\n`,
+      "utf8",
+    );
+    await writeFile(
+      path.posix.join(directories.requestsDir, "01-after.json"),
+      `${JSON.stringify({
+        id: "after",
+        method: "GET",
+        path: "/api/agents/me",
+        query: "",
+        headers: {},
+        body: "",
+        createdAt: new Date().toISOString(),
+      })}\n`,
+      "utf8",
+    );
+
+    const worker = await startSandboxCallbackBridgeWorker({
+      client: createFileSystemSandboxCallbackBridgeQueueClient(),
+      queueDir,
+      authorizeRequest: async () => null,
+      requestTimeoutMs: 40,
+      handleRequest: async (request) => {
+        if (request.id === "stuck") {
+          await new Promise(() => undefined); // never resolves
+        }
+        return { status: 200, body: "ok" };
+      },
+    });
+    cleanupFns.push(async () => {
+      await worker.stop();
+    });
+
+    const fatal = await worker.workerFatalError;
+    expect(fatal.message).toMatch(/timed out processing 00-stuck\.json/);
+
+    // Pending (including the never-reached follow-up) must be aborted with 503.
+    const afterResponse = await readFile(path.posix.join(directories.responsesDir, "01-after.json"), "utf8");
+    expect(afterResponse).toContain("timed out processing 00-stuck.json");
+    await expect(readdir(directories.requestsDir)).resolves.toEqual([]);
+  });
+
   it("serializes remote response writes so stop does not recreate a late orphaned response", async () => {
     const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-bridge-response-lock-"));
     cleanupDirs.push(rootDir);

--- a/packages/adapter-utils/src/sandbox-callback-bridge.ts
+++ b/packages/adapter-utils/src/sandbox-callback-bridge.ts
@@ -13,6 +13,12 @@ const DEFAULT_BRIDGE_RESPONSE_TIMEOUT_MS = 30_000;
 const DEFAULT_BRIDGE_STOP_TIMEOUT_MS = 2_000;
 const DEFAULT_BRIDGE_MAX_QUEUE_DEPTH = 64;
 const DEFAULT_BRIDGE_MAX_BODY_BYTES = 256 * 1024;
+// Per-request host-side processing budget. The agent-side bridge server
+// abandons unanswered calls after responseTimeoutMs (30s default); the host
+// worker should not sit wedged on a single file for minutes/hours while the
+// run burns budget blind. Exceeding this fails pending requests and surfaces
+// a fatal worker error so the adapter run can exit and be retried.
+const DEFAULT_BRIDGE_REQUEST_TIMEOUT_MS = 60_000;
 const REMOTE_WRITE_BASE64_CHUNK_SIZE = 32 * 1024;
 const SANDBOX_CALLBACK_BRIDGE_ENTRYPOINT = "paperclip-bridge-server.mjs";
 const SANDBOX_EXEC_CHANNEL_ENV = "PAPERCLIP_SANDBOX_EXEC_CHANNEL";
@@ -165,6 +171,12 @@ export interface SandboxCallbackBridgeQueueClient {
 
 export interface SandboxCallbackBridgeWorkerHandle {
   stop(options?: { drainTimeoutMs?: number }): Promise<void>;
+  /**
+   * Resolves with the fatal error when the worker loop exits abnormally.
+   * Does not settle on a clean `stop()`. Callers race this against the
+   * adapter process so a wedged/dead host drain fails the run loudly.
+   */
+  workerFatalError: Promise<Error>;
 }
 
 export interface StartedSandboxCallbackBridgeServer {
@@ -602,9 +614,16 @@ export async function startSandboxCallbackBridgeWorker(input: {
     body?: string;
   }>;
   maxBodyBytes?: number | null;
+  /**
+   * Hard deadline for processing a single request file (read → handle → write).
+   * Defaults to 60s. Use a smaller value in tests.
+   */
+  requestTimeoutMs?: number | null;
+  onFatalError?: (error: Error) => void | Promise<void>;
 }): Promise<SandboxCallbackBridgeWorkerHandle> {
   const pollIntervalMs = normalizeTimeoutMs(input.pollIntervalMs, DEFAULT_BRIDGE_POLL_INTERVAL_MS);
   const maxBodyBytes = normalizeTimeoutMs(input.maxBodyBytes, DEFAULT_BRIDGE_MAX_BODY_BYTES);
+  const requestTimeoutMs = normalizeTimeoutMs(input.requestTimeoutMs, DEFAULT_BRIDGE_REQUEST_TIMEOUT_MS);
   const directories = sandboxCallbackBridgeDirectories(input.queueDir);
   await input.client.makeDir(directories.rootDir);
   await input.client.makeDir(directories.requestsDir);
@@ -614,15 +633,27 @@ export async function startSandboxCallbackBridgeWorker(input: {
   let stopping = false;
   let inFlight = 0;
   let settled = false;
+  let failedFatally = false;
   let stopDeadline = Number.POSITIVE_INFINITY;
   let settleResolve: (() => void) | null = null;
   const settledPromise = new Promise<void>((resolve) => {
     settleResolve = resolve;
   });
+  let resolveFatalError: ((error: Error) => void) | null = null;
+  const workerFatalError = new Promise<Error>((resolve) => {
+    resolveFatalError = resolve;
+  });
   const authorizeRequest = input.authorizeRequest ??
     ((request: SandboxCallbackBridgeRequest) => authorizeSandboxCallbackBridgeRequestWithRoutes(request));
   const buildWorkerFailureMessage = (error: unknown) =>
     `Sandbox callback bridge worker failed: ${error instanceof Error ? error.message : String(error)}`;
+
+  const signalFatalError = (error: Error) => {
+    if (failedFatally) return;
+    failedFatally = true;
+    resolveFatalError?.(error);
+    void Promise.resolve(input.onFatalError?.(error)).catch(() => undefined);
+  };
 
   const processRequestFile = async (fileName: string) => {
     const requestPath = path.posix.join(directories.requestsDir, fileName);
@@ -732,7 +763,23 @@ export async function startSandboxCallbackBridgeWorker(input: {
           if (stopping && Date.now() >= stopDeadline) break;
           inFlight += 1;
           try {
-            await processRequestFile(fileName);
+            let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+            try {
+              await Promise.race([
+                processRequestFile(fileName),
+                new Promise<never>((_, reject) => {
+                  timeoutHandle = setTimeout(() => {
+                    reject(
+                      new Error(
+                        `Bridge worker timed out processing ${fileName} after ${requestTimeoutMs}ms — queue drain is wedged.`,
+                      ),
+                    );
+                  }, requestTimeoutMs);
+                }),
+              ]);
+            } finally {
+              if (timeoutHandle) clearTimeout(timeoutHandle);
+            }
           } finally {
             inFlight -= 1;
           }
@@ -751,6 +798,9 @@ export async function startSandboxCallbackBridgeWorker(input: {
           `[paperclip] sandbox callback bridge failed to abort queued requests after worker failure: ${failPendingError instanceof Error ? failPendingError.message : String(failPendingError)}`,
         );
       }
+      if (!stopping) {
+        signalFatalError(error instanceof Error ? error : new Error(message));
+      }
     } finally {
       settled = true;
       if (settleResolve) {
@@ -762,6 +812,7 @@ export async function startSandboxCallbackBridgeWorker(input: {
   void loop;
 
   return {
+    workerFatalError,
     stop: async (options = {}) => {
       stopping = true;
       const drainMs = normalizeTimeoutMs(options.drainTimeoutMs, DEFAULT_BRIDGE_STOP_TIMEOUT_MS);

--- a/packages/adapters/claude-local/src/server/execute.remote.test.ts
+++ b/packages/adapters/claude-local/src/server/execute.remote.test.ts
@@ -31,6 +31,7 @@ const {
   restoreWorkspaceFromSshExecution: vi.fn(async () => undefined),
   syncDirectoryToSsh: vi.fn(async () => undefined),
   startAdapterExecutionTargetPaperclipBridge: vi.fn(async () => ({
+    workerFatalError: new Promise(() => {}),
     env: {
       PAPERCLIP_API_URL: "http://127.0.0.1:4310",
       PAPERCLIP_API_KEY: "bridge-token",

--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -819,6 +819,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       onRuntimeProgress: ctx.onRuntimeProgress,
       onLog,
       runLogTail: paperclipBridge?.runLogTail,
+      cancelPromise: paperclipBridge?.workerFatalError,
       terminalResultCleanup: {
         graceMs: terminalResultCleanupGraceMs,
         hasTerminalResult: ({ stdout }) => parseClaudeStreamJson(stdout).resultJson !== null,

--- a/packages/adapters/codex-local/src/server/execute.remote.test.ts
+++ b/packages/adapters/codex-local/src/server/execute.remote.test.ts
@@ -27,6 +27,7 @@ const {
   restoreWorkspaceFromSshExecution: vi.fn(async () => undefined),
   syncDirectoryToSsh: vi.fn(async () => undefined),
   startAdapterExecutionTargetPaperclipBridge: vi.fn(async () => ({
+    workerFatalError: new Promise(() => {}),
     env: {
       PAPERCLIP_API_URL: "http://127.0.0.1:4310",
       PAPERCLIP_API_KEY: "bridge-token",

--- a/packages/adapters/codex-local/src/server/execute.ts
+++ b/packages/adapters/codex-local/src/server/execute.ts
@@ -923,6 +923,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
             await onLog(stream, cleaned);
           },
           runLogTail: paperclipBridge?.runLogTail,
+          cancelPromise: paperclipBridge?.workerFatalError,
         });
         const cleanedStderr = stripCodexRolloutNoise(proc.stderr);
         return {

--- a/packages/adapters/cursor-local/src/server/execute.remote.test.ts
+++ b/packages/adapters/cursor-local/src/server/execute.remote.test.ts
@@ -37,6 +37,7 @@ const {
   })),
   syncDirectoryToSsh: vi.fn(async () => undefined),
   startAdapterExecutionTargetPaperclipBridge: vi.fn(async () => ({
+    workerFatalError: new Promise(() => {}),
     env: {
       PAPERCLIP_API_URL: "http://127.0.0.1:4310",
       PAPERCLIP_API_KEY: "bridge-token",

--- a/packages/adapters/cursor-local/src/server/execute.ts
+++ b/packages/adapters/cursor-local/src/server/execute.ts
@@ -646,6 +646,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         await flushStdoutChunk(chunk);
       },
       runLogTail: paperclipBridge?.runLogTail,
+      cancelPromise: paperclipBridge?.workerFatalError,
     });
     await flushStdoutChunk("", true);
 

--- a/packages/adapters/gemini-local/src/server/execute.remote.test.ts
+++ b/packages/adapters/gemini-local/src/server/execute.remote.test.ts
@@ -42,6 +42,7 @@ const {
   })),
   syncDirectoryToSsh: vi.fn(async () => undefined),
   startAdapterExecutionTargetPaperclipBridge: vi.fn(async () => ({
+    workerFatalError: new Promise(() => {}),
     env: {
       PAPERCLIP_API_URL: "http://127.0.0.1:4310",
       PAPERCLIP_API_KEY: "bridge-token",

--- a/packages/adapters/gemini-local/src/server/execute.ts
+++ b/packages/adapters/gemini-local/src/server/execute.ts
@@ -618,6 +618,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       onRuntimeProgress: ctx.onRuntimeProgress,
       onLog,
       runLogTail: paperclipBridge?.runLogTail,
+      cancelPromise: paperclipBridge?.workerFatalError,
     });
     return {
       proc,

--- a/packages/adapters/opencode-local/src/server/execute.remote.test.ts
+++ b/packages/adapters/opencode-local/src/server/execute.remote.test.ts
@@ -54,6 +54,7 @@ const {
   })),
   syncDirectoryToSsh: vi.fn(async () => undefined),
   startAdapterExecutionTargetPaperclipBridge: vi.fn(async () => ({
+    workerFatalError: new Promise(() => {}),
     env: {
       PAPERCLIP_API_URL: "http://127.0.0.1:4310",
       PAPERCLIP_API_KEY: "bridge-token",

--- a/packages/adapters/opencode-local/src/server/execute.ts
+++ b/packages/adapters/opencode-local/src/server/execute.ts
@@ -607,6 +607,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         onRuntimeProgress: ctx.onRuntimeProgress,
         onLog,
         runLogTail: paperclipBridge?.runLogTail,
+        cancelPromise: paperclipBridge?.workerFatalError,
       });
       return {
         proc,

--- a/packages/adapters/pi-local/src/server/execute.remote.test.ts
+++ b/packages/adapters/pi-local/src/server/execute.remote.test.ts
@@ -46,6 +46,7 @@ const {
   })),
   syncDirectoryToSsh: vi.fn(async () => undefined),
   startAdapterExecutionTargetPaperclipBridge: vi.fn(async () => ({
+    workerFatalError: new Promise(() => {}),
     env: {
       PAPERCLIP_API_URL: "http://127.0.0.1:4310",
       PAPERCLIP_API_KEY: "bridge-token",

--- a/packages/adapters/pi-local/src/server/execute.ts
+++ b/packages/adapters/pi-local/src/server/execute.ts
@@ -713,6 +713,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         onRuntimeProgress: ctx.onRuntimeProgress,
         onLog: bufferedOnLog,
         runLogTail: paperclipBridge?.runLogTail,
+        cancelPromise: paperclipBridge?.workerFatalError,
       });
 
       // Flush any remaining buffer content


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Sandbox/SSH adapters reach the control plane through a reverse file queue drained by a host-side worker in `@paperclipai/adapter-utils`.
> - If that worker wedges on a single request (stuck SSH op / hung handler), the agent keeps getting 502s while the adapter process stays alive and burns budget with no retry.
> - There was no per-request processing deadline and no signal from a dead worker back into adapter process execution.
> - This pull request caps host-side request processing, surfaces a fatal worker error, and races it against the adapter child process so a wedged drain fails the run.
> - The benefit is silent severances become loud failures that hit the existing retry path instead of multi-hour blind runs.

## Linked Issues or Issue Description

No public GitHub issue exists for this reliability gap, so the bug is described inline below.

### What happened?

The host-side sandbox callback bridge worker could sit forever inside `processRequestFile` (for example on a hung SSH `read`/`write` or a never-resolving handler). While that happened:

1. New requests piled up unanswered.
2. The agent-side bridge server timed out calls with 502.
3. The adapter process continued running with no host-side failure signal, so the control plane never marked the run failed / retried.

Observed operationally as queues that stayed polled or occupied while steps 2–4 of the drain never completed, leaving agents blind for hours.

### Expected behavior

A wedged host drain should:
- Bound per-request processing time.
- Abort pending queue entries with 503.
- Surface a fatal worker error that aborts the adapter process so the run fails and can be retried.

### Steps to reproduce

1. Start a sandbox callback bridge worker whose `handleRequest` never resolves for a given request file.
2. Place that request (and a follow-up) in `queue/requests/`.
3. Observe the worker hangs indefinitely and the parent adapter run does not fail.

### Version / commit

`master` at the merge base of this PR; reproduced via the new unit test with `requestTimeoutMs: 40`.

### Deployment mode

Affects sandbox / SSH remote execution that uses `PAPERCLIP_API_BRIDGE_MODE=queue_v1`.

## What Changed

- Added a default **60s per-request processing timeout** in `startSandboxCallbackBridgeWorker` (`requestTimeoutMs` override for tests).
- On timeout / unexpected worker failure, pending requests are aborted with 503 and `workerFatalError` resolves.
- Exposed `workerFatalError` on the Paperclip bridge handle and added `cancelPromise` to `runAdapterExecutionTargetProcess`.
- Wired local adapters (cursor/claude/codex/gemini/opencode/pi) to race the adapter process against `paperclipBridge.workerFatalError`.
- Added a regression test that wedges a handler and asserts fatal error + pending abort + empty request dir.

## Verification

```bash
./node_modules/.bin/vitest run --project @paperclipai/adapter-utils \
  packages/adapter-utils/src/sandbox-callback-bridge.test.ts
```

Result on this branch: **14/14 passed**, including the new `"fails loudly when a single request file wedges the drain loop"` case.

## Risks

- **False-positive timeouts:** legitimate host-side bridge calls that exceed 60s will now fail the run. Mitigated because the agent-side server already abandons callers at `responseTimeoutMs` (30s default); a host op lasting >60s is already beyond useful reply time.
- **Behavioral shift:** adapter processes now exit when the host drain dies, instead of lingering. That is intentional (fail loud → retry).
- Low migration risk: no protocol / schema change; pure host-side timeout + plumbing.

## Model Used

Cursor agent (Composer) via Paperclip local heartbeat run on agent-runner-00001.

## Checklist

- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I followed the PR template (Thinking Path, What Changed, Verification, Risks, Model Used)
- [x] No internal/instance-local ticket ids or private URLs appear in the title, body, or commits
- [x] Tests cover the change (or this is a docs-only change)

Made with [Cursor](https://cursor.com)