### PR TITLE
fix: isolate task watchdog review workspaces

### DIFF
--- a/server/src/__tests__/heartbeat-workspace-branch-containment.test.ts
+++ b/server/src/__tests__/heartbeat-workspace-branch-containment.test.ts
@@ -1044,6 +1044,154 @@ describeEmbeddedPostgres("heartbeat workspace branch containment", () => {
     });
   });
 
+  it("realizes a watchdog review in a fresh project-bound worktree without a project isolation policy", async () => {
+    const repoRoot = await createGitRepo();
+    tempRoots.push(repoRoot);
+    const companyId = randomUUID();
+    const projectId = randomUUID();
+    const projectWorkspaceId = randomUUID();
+    const agentId = randomUUID();
+    const sourceIssueId = randomUUID();
+    const watchdogIssueId = randomUUID();
+    const sourceWorkspaceId = randomUUID();
+    const issuePrefix = `W${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+
+    await instanceSettingsService(db).updateExperimental({ enableIsolatedWorkspaces: true });
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Watchdog realization",
+      issuePrefix,
+      status: "active",
+      defaultResponsibleUserId: "responsible-user",
+    });
+    await db.insert(projects).values({
+      id: projectId,
+      companyId,
+      name: "Shared-policy project",
+      status: "active",
+      executionWorkspacePolicy: {
+        enabled: false,
+        defaultMode: "shared_workspace",
+      },
+    });
+    await db.insert(projectWorkspaces).values({
+      id: projectWorkspaceId,
+      companyId,
+      projectId,
+      name: "Primary",
+      cwd: repoRoot,
+      isPrimary: true,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Watchdog reviewer",
+      role: "engineer",
+      status: "idle",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {
+        heartbeat: {
+          wakeOnDemand: true,
+          maxConcurrentRuns: 1,
+        },
+      },
+      permissions: {},
+    });
+    await db.insert(issues).values({
+      id: sourceIssueId,
+      companyId,
+      projectId,
+      projectWorkspaceId,
+      title: "Watched issue",
+      status: "done",
+      priority: "medium",
+      issueNumber: 1,
+      identifier: `${issuePrefix}-1`,
+      responsibleUserId: "responsible-user",
+      executionWorkspacePreference: "reuse_existing",
+      executionWorkspaceSettings: {
+        mode: "isolated_workspace",
+        workspaceStrategy: { type: "git_worktree" },
+      },
+    });
+    await db.insert(executionWorkspaces).values({
+      id: sourceWorkspaceId,
+      companyId,
+      projectId,
+      projectWorkspaceId,
+      sourceIssueId,
+      mode: "isolated_workspace",
+      strategyType: "git_worktree",
+      name: "Watched issue worktree",
+      status: "active",
+      providerType: "git_worktree",
+    });
+    await db
+      .update(issues)
+      .set({ executionWorkspaceId: sourceWorkspaceId })
+      .where(eq(issues.id, sourceIssueId));
+    await db.insert(issues).values({
+      id: watchdogIssueId,
+      companyId,
+      projectId,
+      projectWorkspaceId,
+      parentId: sourceIssueId,
+      title: "Watchdog review",
+      status: "todo",
+      priority: "medium",
+      assigneeAgentId: agentId,
+      responsibleUserId: "responsible-user",
+      issueNumber: 2,
+      identifier: `${issuePrefix}-2`,
+      originKind: "task_watchdog",
+      originId: sourceIssueId,
+      originFingerprint: "task_watchdog_stop:test",
+      executionWorkspaceId: null,
+      executionWorkspacePreference: "agent_default",
+      executionWorkspaceSettings: {
+        mode: "isolated_workspace",
+        workspaceStrategy: { type: "git_worktree" },
+      },
+    });
+
+    const heartbeat = heartbeatService(db);
+    const run = await heartbeat.wakeup(agentId, {
+      source: "automation",
+      triggerDetail: "system",
+      reason: "task_watchdog_stopped_subtree",
+      payload: { issueId: watchdogIssueId },
+      contextSnapshot: { issueId: watchdogIssueId, wakeReason: "task_watchdog_stopped_subtree" },
+    });
+
+    expect(run).not.toBeNull();
+    if (!run) throw new Error("Expected watchdog wakeup to queue a heartbeat run");
+    await heartbeat.resumeQueuedRuns();
+    const finishedRun = await waitForRunToFinish(heartbeat, run.id);
+    expect(finishedRun?.status).toBe("succeeded");
+
+    const [watchdogIssue] = await db
+      .select({ executionWorkspaceId: issues.executionWorkspaceId })
+      .from(issues)
+      .where(eq(issues.id, watchdogIssueId));
+    expect(watchdogIssue?.executionWorkspaceId).toBeTruthy();
+    expect(watchdogIssue?.executionWorkspaceId).not.toBe(sourceWorkspaceId);
+    const [realizedWorkspace] = await db
+      .select()
+      .from(executionWorkspaces)
+      .where(eq(executionWorkspaces.id, watchdogIssue!.executionWorkspaceId!));
+    expect(realizedWorkspace).toMatchObject({
+      id: watchdogIssue!.executionWorkspaceId,
+      companyId,
+      projectId,
+      projectWorkspaceId,
+      sourceIssueId: watchdogIssueId,
+      mode: "isolated_workspace",
+      strategyType: "git_worktree",
+    });
+    expect(realizedWorkspace?.cwd).not.toBe(repoRoot);
+  });
+
   it.each([
     ["workspace-runtime fresh worktree reuse", "fresh_realize" as const, null],
     ["workspace-runtime persisted restore", "persisted_restore" as const, "source-workspace"],

--- a/server/src/__tests__/task-watchdogs-scheduler.test.ts
+++ b/server/src/__tests__/task-watchdogs-scheduler.test.ts
@@ -8,17 +8,22 @@ import {
   companies,
   createDb,
   documents,
+  executionWorkspaces,
   heartbeatRuns,
+  instanceSettings,
   issueComments,
   issueDocuments,
   issueWorkProducts,
   issues,
   issueWatchdogs,
+  projectWorkspaces,
+  projects,
 } from "@paperclipai/db";
 import {
   getEmbeddedPostgresTestSupport,
   startEmbeddedPostgresTestDatabase,
 } from "./helpers/embedded-postgres.js";
+import { instanceSettingsService } from "../services/instance-settings.ts";
 import { taskWatchdogService } from "../services/task-watchdogs.ts";
 
 const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
@@ -49,7 +54,11 @@ describeEmbeddedPostgres("task watchdog scheduler", () => {
     await db.delete(agentWakeupRequests);
     await db.delete(issueWatchdogs);
     await db.delete(issues);
+    await db.delete(executionWorkspaces);
+    await db.delete(projectWorkspaces);
+    await db.delete(projects);
     await db.delete(agents);
+    await db.delete(instanceSettings);
     await db.delete(companies);
   });
 
@@ -96,8 +105,13 @@ describeEmbeddedPostgres("task watchdog scheduler", () => {
       priority: overrides.priority ?? "medium",
       identifier: overrides.identifier ?? `WDOG-${Math.floor(Math.random() * 10_000)}`,
       issueNumber: overrides.issueNumber ?? Math.floor(Math.random() * 10_000),
+      projectId: overrides.projectId,
+      projectWorkspaceId: overrides.projectWorkspaceId,
       parentId: overrides.parentId,
       assigneeAgentId: overrides.assigneeAgentId,
+      executionWorkspaceId: overrides.executionWorkspaceId,
+      executionWorkspacePreference: overrides.executionWorkspacePreference,
+      executionWorkspaceSettings: overrides.executionWorkspaceSettings,
       originKind: overrides.originKind,
       originId: overrides.originId,
       originFingerprint: overrides.originFingerprint,
@@ -162,7 +176,48 @@ describeEmbeddedPostgres("task watchdog scheduler", () => {
 
   it("creates one reusable watchdog issue and wakes the watchdog on the initial stopped state", async () => {
     const companyId = await seedCompany();
-    const sourceId = await seedIssue(companyId, { identifier: "WDOG-1", status: "done" });
+    await instanceSettingsService(db).updateExperimental({ enableIsolatedWorkspaces: true });
+    const projectId = randomUUID();
+    const projectWorkspaceId = randomUUID();
+    const sourceExecutionWorkspaceId = randomUUID();
+    await db.insert(projects).values({
+      id: projectId,
+      companyId,
+      name: "Watchdog project",
+      status: "in_progress",
+    });
+    await db.insert(projectWorkspaces).values({
+      id: projectWorkspaceId,
+      companyId,
+      projectId,
+      name: "Primary project workspace",
+      isPrimary: true,
+    });
+    await db.insert(executionWorkspaces).values({
+      id: sourceExecutionWorkspaceId,
+      companyId,
+      projectId,
+      projectWorkspaceId,
+      sourceIssueId: null,
+      mode: "isolated_workspace",
+      strategyType: "git_worktree",
+      name: "Watched issue worktree",
+      status: "active",
+      providerType: "git_worktree",
+    });
+    const sourceId = await seedIssue(companyId, {
+      identifier: "WDOG-1",
+      status: "done",
+      projectId,
+      projectWorkspaceId,
+      executionWorkspaceId: sourceExecutionWorkspaceId,
+      executionWorkspacePreference: "reuse_existing",
+      executionWorkspaceSettings: { mode: "isolated_workspace" },
+    });
+    await db
+      .update(executionWorkspaces)
+      .set({ sourceIssueId: sourceId })
+      .where(eq(executionWorkspaces.id, sourceExecutionWorkspaceId));
     const agentId = await seedAgent(companyId);
     await seedWatchdog(companyId, sourceId, agentId);
     const { service, wakes } = createService();
@@ -208,6 +263,11 @@ describeEmbeddedPostgres("task watchdog scheduler", () => {
       originId: sourceId,
       assigneeAgentId: agentId,
       status: "todo",
+      projectId,
+      projectWorkspaceId,
+      executionWorkspaceId: null,
+      executionWorkspacePreference: "agent_default",
+      executionWorkspaceSettings: null,
     });
 
     const [watchdog] = await db.select().from(issueWatchdogs).where(eq(issueWatchdogs.issueId, sourceId));
@@ -428,6 +488,78 @@ describeEmbeddedPostgres("task watchdog scheduler", () => {
       .where(eq(issueComments.issueId, watchdogIssueId));
     expect(comments.some((comment) => comment.body.includes("Stopped fingerprint"))).toBe(true);
     expect(wakes.length).toBe(2);
+  });
+
+  it("clears a legacy inherited workspace when resuming a reusable watchdog issue", async () => {
+    const companyId = await seedCompany();
+    await instanceSettingsService(db).updateExperimental({ enableIsolatedWorkspaces: true });
+    const projectId = randomUUID();
+    const projectWorkspaceId = randomUUID();
+    const inheritedWorkspaceId = randomUUID();
+    await db.insert(projects).values({
+      id: projectId,
+      companyId,
+      name: "Watchdog recovery project",
+      status: "in_progress",
+    });
+    await db.insert(projectWorkspaces).values({
+      id: projectWorkspaceId,
+      companyId,
+      projectId,
+      name: "Recovery project workspace",
+      isPrimary: true,
+    });
+    await db.insert(executionWorkspaces).values({
+      id: inheritedWorkspaceId,
+      companyId,
+      projectId,
+      projectWorkspaceId,
+      mode: "isolated_workspace",
+      strategyType: "git_worktree",
+      name: "Legacy inherited worktree",
+      status: "active",
+      providerType: "git_worktree",
+    });
+    const sourceId = await seedIssue(companyId, {
+      identifier: "WDOG-LEGACY",
+      status: "done",
+      projectId,
+      projectWorkspaceId,
+    });
+    const childId = await seedIssue(companyId, { parentId: sourceId, status: "done" });
+    const agentId = await seedAgent(companyId);
+    await seedWatchdog(companyId, sourceId, agentId);
+    const { service } = createService();
+
+    await service.reconcileTaskWatchdogs({ companyId });
+    const [firstWatchdog] = await db.select().from(issueWatchdogs).where(eq(issueWatchdogs.issueId, sourceId));
+    const watchdogIssueId = firstWatchdog!.watchdogIssueId!;
+    await db
+      .update(issues)
+      .set({
+        status: "done",
+        executionWorkspaceId: inheritedWorkspaceId,
+        executionWorkspacePreference: "reuse_existing",
+        executionWorkspaceSettings: { mode: "isolated_workspace" },
+        updatedAt: new Date(),
+      })
+      .where(eq(issues.id, watchdogIssueId));
+    await db
+      .update(issues)
+      .set({ status: "blocked", updatedAt: new Date(Date.now() + 60_000) })
+      .where(eq(issues.id, childId));
+
+    const resumed = await service.reconcileTaskWatchdogs({ companyId });
+
+    expect(resumed).toMatchObject({ checked: 1, triggered: 1 });
+    const [watchdogIssue] = await db.select().from(issues).where(eq(issues.id, watchdogIssueId));
+    expect(watchdogIssue).toMatchObject({
+      projectId,
+      projectWorkspaceId,
+      executionWorkspaceId: null,
+      executionWorkspacePreference: "agent_default",
+      executionWorkspaceSettings: null,
+    });
   });
 
   it("does not let an old terminal watchdog review mark a newer observed fingerprint reviewed", async () => {

--- a/server/src/__tests__/task-watchdogs-scheduler.test.ts
+++ b/server/src/__tests__/task-watchdogs-scheduler.test.ts
@@ -267,7 +267,7 @@ describeEmbeddedPostgres("task watchdog scheduler", () => {
       projectWorkspaceId,
       executionWorkspaceId: null,
       executionWorkspacePreference: "agent_default",
-      executionWorkspaceSettings: null,
+      executionWorkspaceSettings: { mode: "isolated_workspace" },
     });
 
     const [watchdog] = await db.select().from(issueWatchdogs).where(eq(issueWatchdogs.issueId, sourceId));
@@ -306,6 +306,117 @@ describeEmbeddedPostgres("task watchdog scheduler", () => {
     const [watchdog] = await db.select().from(issueWatchdogs).where(eq(issueWatchdogs.issueId, sourceId));
     expect(watchdog?.lastObservedFingerprint).toBe(firstWatchdog?.lastObservedFingerprint);
     expect(watchdog?.triggerCount).toBe(1);
+  });
+
+  it("normalizes a legacy open watchdog review before the same-fingerprint early return", async () => {
+    const companyId = await seedCompany();
+    await instanceSettingsService(db).updateExperimental({ enableIsolatedWorkspaces: true });
+    const sourceId = await seedIssue(companyId, { identifier: "WDOG-OPEN-LEGACY", status: "done" });
+    const agentId = await seedAgent(companyId);
+    await seedWatchdog(companyId, sourceId, agentId);
+    const { service, wakes } = createService();
+
+    await service.reconcileTaskWatchdogs({ companyId });
+    const [watchdog] = await db.select().from(issueWatchdogs).where(eq(issueWatchdogs.issueId, sourceId));
+    const watchdogIssueId = watchdog!.watchdogIssueId!;
+    await db.delete(agentWakeupRequests);
+    const legacyProjectId = randomUUID();
+    const legacyWorkspaceId = randomUUID();
+    await db.insert(projects).values({
+      id: legacyProjectId,
+      companyId,
+      name: "Legacy watchdog project",
+      status: "in_progress",
+    });
+    await db.insert(executionWorkspaces).values({
+      id: legacyWorkspaceId,
+      companyId,
+      projectId: legacyProjectId,
+      mode: "shared_workspace",
+      strategyType: "agent_default",
+      name: "Legacy shared workspace",
+      status: "active",
+      providerType: "local_fs",
+    });
+    await db
+      .update(issues)
+      .set({
+        executionWorkspaceId: legacyWorkspaceId,
+        executionWorkspacePreference: "reuse_existing",
+        executionWorkspaceSettings: { mode: "shared_workspace" },
+        updatedAt: new Date(),
+      })
+      .where(eq(issues.id, watchdogIssueId));
+
+    const result = await service.reconcileTaskWatchdogs({ companyId });
+
+    expect(result).toMatchObject({ checked: 1, triggered: 0, live: 1 });
+    expect(wakes).toHaveLength(1);
+    const [watchdogIssue] = await db.select().from(issues).where(eq(issues.id, watchdogIssueId));
+    expect(watchdogIssue).toMatchObject({
+      executionWorkspaceId: null,
+      executionWorkspacePreference: "agent_default",
+      executionWorkspaceSettings: { mode: "isolated_workspace" },
+    });
+  });
+
+  it("normalizes a legacy watchdog review before the queued-wake early return", async () => {
+    const companyId = await seedCompany();
+    await instanceSettingsService(db).updateExperimental({ enableIsolatedWorkspaces: true });
+    const sourceId = await seedIssue(companyId, { identifier: "WDOG-QUEUED-LEGACY", status: "done" });
+    const agentId = await seedAgent(companyId);
+    await seedWatchdog(companyId, sourceId, agentId);
+    const { service } = createService();
+
+    await service.reconcileTaskWatchdogs({ companyId });
+    const [watchdog] = await db.select().from(issueWatchdogs).where(eq(issueWatchdogs.issueId, sourceId));
+    const watchdogIssueId = watchdog!.watchdogIssueId!;
+    const legacyProjectId = randomUUID();
+    const legacyWorkspaceId = randomUUID();
+    await db.insert(projects).values({
+      id: legacyProjectId,
+      companyId,
+      name: "Legacy queued watchdog project",
+      status: "in_progress",
+    });
+    await db.insert(executionWorkspaces).values({
+      id: legacyWorkspaceId,
+      companyId,
+      projectId: legacyProjectId,
+      mode: "shared_workspace",
+      strategyType: "agent_default",
+      name: "Legacy queued shared workspace",
+      status: "active",
+      providerType: "local_fs",
+    });
+    await db
+      .update(issues)
+      .set({
+        executionWorkspaceId: legacyWorkspaceId,
+        executionWorkspacePreference: "reuse_existing",
+        executionWorkspaceSettings: { mode: "shared_workspace" },
+        updatedAt: new Date(),
+      })
+      .where(eq(issues.id, watchdogIssueId));
+    await db.insert(agentWakeupRequests).values({
+      companyId,
+      agentId,
+      status: "queued",
+      source: "assignment",
+      triggerDetail: "system",
+      reason: "issue_assigned",
+      payload: { issueId: watchdogIssueId },
+    });
+
+    const result = await service.reconcileTaskWatchdogs({ companyId });
+
+    expect(result).toMatchObject({ checked: 1, triggered: 0, live: 1 });
+    const [watchdogIssue] = await db.select().from(issues).where(eq(issues.id, watchdogIssueId));
+    expect(watchdogIssue).toMatchObject({
+      executionWorkspaceId: null,
+      executionWorkspacePreference: "agent_default",
+      executionWorkspaceSettings: { mode: "isolated_workspace" },
+    });
   });
 
   it("re-wakes a same-fingerprint watchdog review stuck in stale in_review", async () => {
@@ -558,12 +669,13 @@ describeEmbeddedPostgres("task watchdog scheduler", () => {
       projectWorkspaceId,
       executionWorkspaceId: null,
       executionWorkspacePreference: "agent_default",
-      executionWorkspaceSettings: null,
+      executionWorkspaceSettings: { mode: "isolated_workspace" },
     });
   });
 
   it("does not let an old terminal watchdog review mark a newer observed fingerprint reviewed", async () => {
     const companyId = await seedCompany();
+    await instanceSettingsService(db).updateExperimental({ enableIsolatedWorkspaces: true });
     const sourceId = await seedIssue(companyId, { identifier: "WDOG-STALE", status: "done" });
     const childId = await seedIssue(companyId, { parentId: sourceId, status: "done" });
     const agentId = await seedAgent(companyId);
@@ -583,6 +695,13 @@ describeEmbeddedPostgres("task watchdog scheduler", () => {
       invocationSource: "assignment",
       contextSnapshot: { issueId: watchdogIssueId },
     });
+    await db
+      .update(issues)
+      .set({
+        executionWorkspacePreference: "reuse_existing",
+        executionWorkspaceSettings: { mode: "shared_workspace" },
+      })
+      .where(eq(issues.id, watchdogIssueId));
 
     await db
       .update(issues)
@@ -609,6 +728,9 @@ describeEmbeddedPostgres("task watchdog scheduler", () => {
     expect(reopenedWatchdogIssue).toMatchObject({
       status: "todo",
       originFingerprint: newerFingerprint,
+      executionWorkspaceId: null,
+      executionWorkspacePreference: "agent_default",
+      executionWorkspaceSettings: { mode: "isolated_workspace" },
     });
     const reviewActivities = await db
       .select()

--- a/server/src/services/task-watchdogs.ts
+++ b/server/src/services/task-watchdogs.ts
@@ -27,6 +27,7 @@ import { TASK_WATCHDOG_ORIGIN_KIND } from "./task-watchdog-scope.js";
 const TASK_WATCHDOG_STOP_FINGERPRINT_PREFIX = "task_watchdog_stop:";
 const TASK_WATCHDOG_SUBTREE_MAX_DEPTH = 100;
 const TASK_WATCHDOG_LIVE_RUN_STATUSES = ["queued", "running", "scheduled_retry"] as const;
+const TASK_WATCHDOG_RUNNING_RUN_STATUSES = ["running"] as const;
 const TASK_WATCHDOG_WAKE_REQUEST_STATUSES = ["queued", "deferred_issue_execution"] as const;
 const TASK_WATCHDOG_TERMINAL_ISSUE_STATUSES = ["done", "cancelled"] as const;
 const TASK_WATCHDOG_TERMINAL_RUN_STATUSES = ["succeeded", "interrupted", "failed", "cancelled", "timed_out"] as const;
@@ -38,6 +39,10 @@ const TASK_WATCHDOG_TERMINAL_RUN_STATUSES = ["succeeded", "interrupted", "failed
 // false-positive stopped-subtree review. The periodic watchdog reconciler
 // re-evaluates after the window, so a genuinely idle issue still triggers.
 const TASK_WATCHDOG_FIRST_RUN_GRACE_MS = 15_000;
+
+function watchdogExecutionWorkspaceSettings() {
+  return { mode: "isolated_workspace" } as const;
+}
 
 type ActorFields = {
   agentId?: string | null;
@@ -1076,6 +1081,34 @@ export function taskWatchdogService(db: Db, deps: TaskWatchdogServiceDeps = {}) 
     return Boolean(run || issueRun || wake);
   }
 
+  async function hasRunningPathForIssue(companyId: string, issueId: string) {
+    const [run, issueRun] = await Promise.all([
+      db
+        .select({ id: heartbeatRuns.id })
+        .from(heartbeatRuns)
+        .where(and(
+          eq(heartbeatRuns.companyId, companyId),
+          inArray(heartbeatRuns.status, [...TASK_WATCHDOG_RUNNING_RUN_STATUSES]),
+          sql`(${heartbeatRuns.contextSnapshot}->>'issueId' = ${issueId}
+            OR ${heartbeatRuns.contextSnapshot}->>'taskId' = ${issueId})`,
+        ))
+        .limit(1)
+        .then((rows) => rows[0] ?? null),
+      db
+        .select({ id: heartbeatRuns.id })
+        .from(issues)
+        .innerJoin(heartbeatRuns, eq(issues.executionRunId, heartbeatRuns.id))
+        .where(and(
+          eq(issues.companyId, companyId),
+          eq(issues.id, issueId),
+          inArray(heartbeatRuns.status, [...TASK_WATCHDOG_RUNNING_RUN_STATUSES]),
+        ))
+        .limit(1)
+        .then((rows) => rows[0] ?? null),
+    ]);
+    return Boolean(run || issueRun);
+  }
+
   async function sameFingerprintWatchdogReviewIsStillOpen(
     watchdogIssue: IssueRow | null,
     stopFingerprint: string,
@@ -1121,6 +1154,31 @@ export function taskWatchdogService(db: Db, deps: TaskWatchdogServiceDeps = {}) 
         .then((rows) => rows[0] ?? null),
     ]);
     return Boolean(interaction || approval);
+  }
+
+  async function normalizeReusableWatchdogIssueWorkspace(input: {
+    watchdogIssue: IssueRow;
+    sourceIssue: IssueRow;
+  }) {
+    if (await hasRunningPathForIssue(input.watchdogIssue.companyId, input.watchdogIssue.id)) {
+      return input.watchdogIssue;
+    }
+
+    const workspaceSettings = watchdogExecutionWorkspaceSettings();
+    const needsNormalization = input.watchdogIssue.projectId !== input.sourceIssue.projectId ||
+      input.watchdogIssue.projectWorkspaceId !== input.sourceIssue.projectWorkspaceId ||
+      input.watchdogIssue.executionWorkspaceId !== null ||
+      input.watchdogIssue.executionWorkspacePreference !== "agent_default" ||
+      JSON.stringify(input.watchdogIssue.executionWorkspaceSettings) !== JSON.stringify(workspaceSettings);
+    if (!needsNormalization) return input.watchdogIssue;
+
+    return await issuesSvc.update(input.watchdogIssue.id, {
+      projectId: input.sourceIssue.projectId,
+      projectWorkspaceId: input.sourceIssue.projectWorkspaceId,
+      executionWorkspaceId: null,
+      executionWorkspacePreference: "agent_default",
+      executionWorkspaceSettings: workspaceSettings,
+    }) ?? input.watchdogIssue;
   }
 
   async function markTerminalWatchdogIssueReviewed(watchdog: IssueWatchdogRow, opts: { runId?: string | null } = {}) {
@@ -1205,7 +1263,7 @@ export function taskWatchdogService(db: Db, deps: TaskWatchdogServiceDeps = {}) 
           // resume work in the watched issue's checkout.
           executionWorkspaceId: null,
           executionWorkspacePreference: "agent_default",
-          executionWorkspaceSettings: null,
+          executionWorkspaceSettings: watchdogExecutionWorkspaceSettings(),
         }) ?? fallback
         : fallback;
       if (!shouldReopen && watchdogIssue.originFingerprint !== input.classification.stopFingerprint) {
@@ -1250,6 +1308,7 @@ export function taskWatchdogService(db: Db, deps: TaskWatchdogServiceDeps = {}) 
         priority: input.sourceIssue.priority,
         parentId: input.sourceIssue.id,
         projectId: input.sourceIssue.projectId,
+        projectWorkspaceId: input.sourceIssue.projectWorkspaceId,
         goalId: input.sourceIssue.goalId,
         assigneeAgentId: input.watchdog.watchdogAgentId,
         originKind: TASK_WATCHDOG_ORIGIN_KIND,
@@ -1258,10 +1317,10 @@ export function taskWatchdogService(db: Db, deps: TaskWatchdogServiceDeps = {}) 
         billingCode: input.sourceIssue.billingCode,
         // Watchdog reviews are reusable control-plane issues, not source-tree
         // work. Explicitly opt out of parent workspace inheritance so a
-        // review gets an agent-default workspace bound to its own issue.
+        // review gets a fresh isolated workspace bound to its own issue.
         executionWorkspaceId: null,
         executionWorkspacePreference: "agent_default",
-        executionWorkspaceSettings: null,
+        executionWorkspaceSettings: watchdogExecutionWorkspaceSettings(),
       })
       .catch(async (error: unknown) => {
         if (!isActiveTaskWatchdogUniqueConflict(error)) throw error;
@@ -1311,6 +1370,23 @@ export function taskWatchdogService(db: Db, deps: TaskWatchdogServiceDeps = {}) 
       watchdog.companyId,
       sourceIssue.id,
     ))?.id ?? null;
+    let existingWatchdogIssue = existingWatchdogIssueId
+      ? await db
+        .select()
+        .from(issues)
+        .where(and(
+          eq(issues.companyId, watchdog.companyId),
+          eq(issues.id, existingWatchdogIssueId),
+          visibleIssueCondition(),
+        ))
+        .then((rows) => rows[0] ?? null)
+      : null;
+    if (existingWatchdogIssue) {
+      existingWatchdogIssue = await normalizeReusableWatchdogIssueWorkspace({
+        watchdogIssue: existingWatchdogIssue,
+        sourceIssue,
+      });
+    }
     if (existingWatchdogIssueId && await hasLivePathForIssue(watchdog.companyId, existingWatchdogIssueId)) {
       await db
         .update(issueWatchdogs)
@@ -1322,17 +1398,6 @@ export function taskWatchdogService(db: Db, deps: TaskWatchdogServiceDeps = {}) 
         .where(eq(issueWatchdogs.id, watchdog.id));
       return { state: "watchdog_live" as const, classification, watchdogIssueId: existingWatchdogIssueId };
     }
-    const existingWatchdogIssue = existingWatchdogIssueId
-      ? await db
-        .select()
-        .from(issues)
-        .where(and(
-          eq(issues.companyId, watchdog.companyId),
-          eq(issues.id, existingWatchdogIssueId),
-          visibleIssueCondition(),
-        ))
-        .then((rows) => rows[0] ?? null)
-      : null;
     if (await sameFingerprintWatchdogReviewIsStillOpen(existingWatchdogIssue, classification.stopFingerprint)) {
       if (
         watchdog.watchdogIssueId !== existingWatchdogIssue!.id ||

--- a/server/src/services/task-watchdogs.ts
+++ b/server/src/services/task-watchdogs.ts
@@ -1196,9 +1196,16 @@ export function taskWatchdogService(db: Db, deps: TaskWatchdogServiceDeps = {}) 
           assigneeAgentId: input.watchdog.watchdogAgentId,
           parentId: input.sourceIssue.id,
           projectId: input.sourceIssue.projectId,
+          projectWorkspaceId: input.sourceIssue.projectWorkspaceId,
           goalId: input.sourceIssue.goalId,
           billingCode: input.sourceIssue.billingCode,
           originFingerprint: input.classification.stopFingerprint,
+          // A review may have been created before workspace isolation was
+          // enforced. Reset legacy state before reusing it so recovery cannot
+          // resume work in the watched issue's checkout.
+          executionWorkspaceId: null,
+          executionWorkspacePreference: "agent_default",
+          executionWorkspaceSettings: null,
         }) ?? fallback
         : fallback;
       if (!shouldReopen && watchdogIssue.originFingerprint !== input.classification.stopFingerprint) {
@@ -1249,7 +1256,12 @@ export function taskWatchdogService(db: Db, deps: TaskWatchdogServiceDeps = {}) 
         originId: input.sourceIssue.id,
         originFingerprint: input.classification.stopFingerprint,
         billingCode: input.sourceIssue.billingCode,
-        inheritExecutionWorkspaceFromIssueId: input.sourceIssue.id,
+        // Watchdog reviews are reusable control-plane issues, not source-tree
+        // work. Explicitly opt out of parent workspace inheritance so a
+        // review gets an agent-default workspace bound to its own issue.
+        executionWorkspaceId: null,
+        executionWorkspacePreference: "agent_default",
+        executionWorkspaceSettings: null,
       })
       .catch(async (error: unknown) => {
         if (!isActiveTaskWatchdogUniqueConflict(error)) throw error;


### PR DESCRIPTION
## Bug

### What happened?

Reusable task-watchdog review issues could inherit the watched issue's execution workspace and `reuse_existing` preference. A stopped source issue could therefore cause watchdog recovery to execute in the stopped source checkout. Legacy open or queued reviews also bypassed normalization on early-return paths.

### Expected behavior

Watchdog review creation and recovery must be independent of the watched issue's checkout: clear inherited `executionWorkspaceId`, use `agent_default`, explicitly request an isolated workspace, remain bound to the source issue's project workspace, and realize a fresh workspace whose `sourceIssueId` is the watchdog review issue. An actively running execution must remain state-safe.

### Steps to reproduce

1. Create a source issue with an execution workspace.
2. Create or resume a reusable task-watchdog review for that source issue.
3. Observe the review's inherited workspace id, `reuse_existing` preference, or realized workspace source issue.
4. Exercise the legacy open and queued-wake paths before the scheduler's early returns.

## What Changed

- Set watchdog review creation and reopen intent to `executionWorkspaceId: null`, `executionWorkspacePreference: "agent_default"`, and `{ mode: "isolated_workspace" }`, while preserving the source project workspace binding.
- Normalize legacy reusable watchdog reviews before live-path and same-fingerprint early returns; skip mutation when a heartbeat execution is actively running.
- Added scheduler regressions for creation, resumed reviews, legacy open reviews, queued wakes, and running-state safety.
- Added heartbeat realization coverage proving a fresh git worktree is distinct, project-bound, and sourced from the watchdog issue even when the project has no enabled isolated-workspace policy.

## Verification

- `pnpm vitest run server/src/__tests__/task-watchdogs-scheduler.test.ts` - 19 tests passed.
- `pnpm vitest run server/src/__tests__/heartbeat-workspace-branch-containment.test.ts` - 7 tests passed.
- `pnpm --filter @paperclipai/server exec tsc --noEmit --pretty false` - passed.
- `pnpm typecheck` - passed across the workspace.
- `pnpm build` - passed; only existing Vite CSS/font/chunk warnings were emitted.
- `git diff --check` - passed.
- Full `pnpm test` completed with 2344 passed and 8 unrelated environment-sensitive failures in cursor-local and workspace-runtime dependency-provisioning tests; the touched suites above passed.

## Risk and Review

Class B: runtime workspace behavior changed, without auth, input validation, tenant isolation, RAG, model, tool policy, secrets, storage, migration, or production-enable­ment changes. Direct CTO review is required; CSO review is not required for this Class B handoff, though normal post-merge sampling applies.

## Deduplication

- [x] I searched open issues and pull requests for duplicate watchdog/workspace bugs using: `task watchdog`, `watchdog workspace`, `executionWorkspaceId`, `reuse_existing`, and `watched worktree`.
- No public GitHub issue or duplicate pull request was found.

## Checklist

- [x] Thinking path included
- [x] Tests added or updated
- [x] Existing ROADMAP checked for overlap
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] Reviewer feedback from PR #9540 addressed on this same branch