### PR TITLE
feat(ui): guided per-adapter credential setup in onboarding and agent settings (BYOK connect)

### DIFF
--- a/packages/adapter-utils/src/index.ts
+++ b/packages/adapter-utils/src/index.ts
@@ -36,6 +36,8 @@ export type {
   StdoutLineParser,
   CLIAdapterModule,
   CreateConfigValues,
+  AdapterCredentialOption,
+  AdapterCredentialSetup,
 } from "./types.js";
 export type {
   SessionCompactionPolicy,

--- a/packages/adapter-utils/src/types.ts
+++ b/packages/adapter-utils/src/types.ts
@@ -555,3 +555,41 @@ export interface CreateConfigValues {
   headersJson?: string;
   password?: string;
 }
+
+// ---------------------------------------------------------------------------
+// Adapter credential setup — declarative UI descriptors for guided credential configuration
+// ---------------------------------------------------------------------------
+
+/**
+ * A single credential option that an adapter accepts.
+ *
+ * Describes how to configure one environment variable (e.g., an API key or token),
+ * with hints and optional setup commands/URLs to help users obtain and configure it.
+ */
+export interface AdapterCredentialOption {
+  /** The environment variable name (e.g., "ANTHROPIC_API_KEY") */
+  envKey: string;
+  /** The kind of credential */
+  kind: "api_key" | "subscription_token";
+  /** Display label for the credential (e.g., "Anthropic API key") */
+  label: string;
+  /** Optional hint text explaining what the credential is for and how to use it */
+  hint?: string;
+  /** Optional command users can run to set up this credential (e.g., "claude setup-token") */
+  setupCommand?: string;
+  /** Optional URL where users can obtain/manage this credential (e.g., console URL) */
+  setupUrl?: string;
+  /** Optional placeholder text for the input field (e.g., "sk-ant-…") */
+  placeholder?: string;
+}
+
+/**
+ * A complete credential setup descriptor for an adapter.
+ *
+ * Declares all environment variables an adapter accepts and provides
+ * UI-friendly guidance for each one.
+ */
+export interface AdapterCredentialSetup {
+  /** The list of credential options this adapter accepts */
+  options: AdapterCredentialOption[];
+}

--- a/packages/adapters/claude-local/src/ui/credential-setup.test.ts
+++ b/packages/adapters/claude-local/src/ui/credential-setup.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { claudeLocalCredentialSetup } from "./credential-setup.js";
+
+describe("claudeLocalCredentialSetup", () => {
+  it("exports credential options with correct envKeys", () => {
+    const envKeys = claudeLocalCredentialSetup.options.map(o => o.envKey);
+    expect(envKeys).toEqual(["ANTHROPIC_API_KEY", "CLAUDE_CODE_OAUTH_TOKEN"]);
+  });
+
+  it("configures subscription_token option with setupCommand", () => {
+    const tokenOption = claudeLocalCredentialSetup.options.find(o => o.envKey === "CLAUDE_CODE_OAUTH_TOKEN");
+    expect(tokenOption).toBeDefined();
+    expect(tokenOption?.kind).toBe("subscription_token");
+    expect(tokenOption?.setupCommand).toBe("claude setup-token");
+  });
+
+  it("includes hint text mentioning both quota and extra usage for subscription_token", () => {
+    const tokenOption = claudeLocalCredentialSetup.options.find(o => o.envKey === "CLAUDE_CODE_OAUTH_TOKEN");
+    expect(tokenOption?.hint).toContain("quota");
+    expect(tokenOption?.hint).toContain("extra usage");
+  });
+});

--- a/packages/adapters/claude-local/src/ui/credential-setup.ts
+++ b/packages/adapters/claude-local/src/ui/credential-setup.ts
@@ -1,0 +1,22 @@
+import type { AdapterCredentialSetup } from "@paperclipai/adapter-utils";
+
+export const claudeLocalCredentialSetup: AdapterCredentialSetup = {
+  options: [
+    {
+      envKey: "ANTHROPIC_API_KEY",
+      kind: "api_key",
+      label: "Anthropic API key",
+      hint: "Create a key in the Anthropic Console. Usage bills to your Anthropic API account.",
+      setupUrl: "https://console.anthropic.com/settings/keys",
+      placeholder: "sk-ant-…",
+    },
+    {
+      envKey: "CLAUDE_CODE_OAUTH_TOKEN",
+      kind: "subscription_token",
+      label: "Claude Pro/Max subscription token",
+      hint: "Mint a long-lived token with `claude setup-token` on a machine where Claude Code is logged in. Token-only auth has no usage/quota reporting, and subscription usage in third-party contexts may draw from your Anthropic \"extra usage\" credits.",
+      setupCommand: "claude setup-token",
+      placeholder: "sk-ant-oat01-…",
+    },
+  ],
+};

--- a/packages/adapters/claude-local/src/ui/index.ts
+++ b/packages/adapters/claude-local/src/ui/index.ts
@@ -1,2 +1,3 @@
 export { parseClaudeStdoutLine } from "./parse-stdout.js";
 export { buildClaudeLocalConfig } from "./build-config.js";
+export { claudeLocalCredentialSetup } from "./credential-setup.js";

--- a/packages/adapters/codex-local/src/ui/credential-setup.test.ts
+++ b/packages/adapters/codex-local/src/ui/credential-setup.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { codexLocalCredentialSetup } from "./credential-setup.js";
+
+describe("codexLocalCredentialSetup", () => {
+  it("exports credential options with correct envKeys", () => {
+    const envKeys = codexLocalCredentialSetup.options.map(o => o.envKey);
+    expect(envKeys).toEqual(["OPENAI_API_KEY"]);
+  });
+
+  it("configures api_key option with correct label and setupUrl", () => {
+    const apiKeyOption = codexLocalCredentialSetup.options.find(o => o.envKey === "OPENAI_API_KEY");
+    expect(apiKeyOption).toBeDefined();
+    expect(apiKeyOption?.kind).toBe("api_key");
+    expect(apiKeyOption?.label).toBe("OpenAI API key");
+    expect(apiKeyOption?.setupUrl).toBe("https://platform.openai.com/api-keys");
+    expect(apiKeyOption?.placeholder).toBe("sk-…");
+  });
+
+  it("includes hint mentioning codex login and CODEX_HOME sync as ChatGPT-subscription alternative", () => {
+    const apiKeyOption = codexLocalCredentialSetup.options.find(o => o.envKey === "OPENAI_API_KEY");
+    expect(apiKeyOption?.hint).toContain("codex login");
+    expect(apiKeyOption?.hint).toContain("CODEX_HOME");
+  });
+});

--- a/packages/adapters/codex-local/src/ui/credential-setup.ts
+++ b/packages/adapters/codex-local/src/ui/credential-setup.ts
@@ -1,0 +1,14 @@
+import type { AdapterCredentialSetup } from "@paperclipai/adapter-utils";
+
+export const codexLocalCredentialSetup: AdapterCredentialSetup = {
+  options: [
+    {
+      envKey: "OPENAI_API_KEY",
+      kind: "api_key",
+      label: "OpenAI API key",
+      hint: "Create a key in the OpenAI API console. Alternatively, you can log in with `codex login` locally and Paperclip's CODEX_HOME sync will ship the credential to remote runs.",
+      setupUrl: "https://platform.openai.com/api-keys",
+      placeholder: "sk-…",
+    },
+  ],
+};

--- a/packages/adapters/codex-local/src/ui/index.ts
+++ b/packages/adapters/codex-local/src/ui/index.ts
@@ -1,2 +1,3 @@
 export { parseCodexStdoutLine } from "./parse-stdout.js";
 export { buildCodexLocalConfig } from "./build-config.js";
+export { codexLocalCredentialSetup } from "./credential-setup.js";

--- a/packages/adapters/cursor-local/src/ui/credential-setup.test.ts
+++ b/packages/adapters/cursor-local/src/ui/credential-setup.test.ts
@@ -12,7 +12,7 @@ describe("cursorLocalCredentialSetup", () => {
     expect(apiKeyOption).toBeDefined();
     expect(apiKeyOption?.kind).toBe("api_key");
     expect(apiKeyOption?.label).toBe("Cursor API key");
-    expect(apiKeyOption?.setupUrl).toBe("https://cursor.com/settings");
+    expect(apiKeyOption?.setupUrl).toBe("https://cursor.com/dashboard");
     expect(apiKeyOption?.placeholder).toBe("key_…");
   });
 });

--- a/packages/adapters/cursor-local/src/ui/credential-setup.test.ts
+++ b/packages/adapters/cursor-local/src/ui/credential-setup.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { cursorLocalCredentialSetup } from "./credential-setup.js";
+
+describe("cursorLocalCredentialSetup", () => {
+  it("exports credential options with correct envKeys", () => {
+    const envKeys = cursorLocalCredentialSetup.options.map(o => o.envKey);
+    expect(envKeys).toEqual(["CURSOR_API_KEY"]);
+  });
+
+  it("configures api_key option with correct label and setupUrl", () => {
+    const apiKeyOption = cursorLocalCredentialSetup.options.find(o => o.envKey === "CURSOR_API_KEY");
+    expect(apiKeyOption).toBeDefined();
+    expect(apiKeyOption?.kind).toBe("api_key");
+    expect(apiKeyOption?.label).toBe("Cursor API key");
+    expect(apiKeyOption?.setupUrl).toBe("https://cursor.com/settings");
+    expect(apiKeyOption?.placeholder).toBe("key_…");
+  });
+});

--- a/packages/adapters/cursor-local/src/ui/credential-setup.ts
+++ b/packages/adapters/cursor-local/src/ui/credential-setup.ts
@@ -6,7 +6,7 @@ export const cursorLocalCredentialSetup: AdapterCredentialSetup = {
       envKey: "CURSOR_API_KEY",
       kind: "api_key",
       label: "Cursor API key",
-      setupUrl: "https://cursor.com/settings",
+      setupUrl: "https://cursor.com/dashboard",
       placeholder: "key_…",
     },
   ],

--- a/packages/adapters/cursor-local/src/ui/credential-setup.ts
+++ b/packages/adapters/cursor-local/src/ui/credential-setup.ts
@@ -1,0 +1,13 @@
+import type { AdapterCredentialSetup } from "@paperclipai/adapter-utils";
+
+export const cursorLocalCredentialSetup: AdapterCredentialSetup = {
+  options: [
+    {
+      envKey: "CURSOR_API_KEY",
+      kind: "api_key",
+      label: "Cursor API key",
+      setupUrl: "https://cursor.com/settings",
+      placeholder: "key_…",
+    },
+  ],
+};

--- a/packages/adapters/cursor-local/src/ui/index.ts
+++ b/packages/adapters/cursor-local/src/ui/index.ts
@@ -1,2 +1,3 @@
 export { parseCursorStdoutLine } from "./parse-stdout.js";
 export { buildCursorLocalConfig } from "./build-config.js";
+export { cursorLocalCredentialSetup } from "./credential-setup.js";

--- a/packages/adapters/gemini-local/src/ui/credential-setup.test.ts
+++ b/packages/adapters/gemini-local/src/ui/credential-setup.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { geminiLocalCredentialSetup } from "./credential-setup.js";
+
+describe("geminiLocalCredentialSetup", () => {
+  it("exports credential options with correct envKeys", () => {
+    const envKeys = geminiLocalCredentialSetup.options.map(o => o.envKey);
+    expect(envKeys).toEqual(["GEMINI_API_KEY"]);
+  });
+
+  it("configures api_key option with correct label and setupUrl", () => {
+    const apiKeyOption = geminiLocalCredentialSetup.options.find(o => o.envKey === "GEMINI_API_KEY");
+    expect(apiKeyOption).toBeDefined();
+    expect(apiKeyOption?.kind).toBe("api_key");
+    expect(apiKeyOption?.label).toBe("Gemini API key");
+    expect(apiKeyOption?.setupUrl).toBe("https://aistudio.google.com/apikey");
+    expect(apiKeyOption?.placeholder).toBe("AIza…");
+  });
+});

--- a/packages/adapters/gemini-local/src/ui/credential-setup.ts
+++ b/packages/adapters/gemini-local/src/ui/credential-setup.ts
@@ -1,0 +1,13 @@
+import type { AdapterCredentialSetup } from "@paperclipai/adapter-utils";
+
+export const geminiLocalCredentialSetup: AdapterCredentialSetup = {
+  options: [
+    {
+      envKey: "GEMINI_API_KEY",
+      kind: "api_key",
+      label: "Gemini API key",
+      setupUrl: "https://aistudio.google.com/apikey",
+      placeholder: "AIza…",
+    },
+  ],
+};

--- a/packages/adapters/gemini-local/src/ui/index.ts
+++ b/packages/adapters/gemini-local/src/ui/index.ts
@@ -1,2 +1,3 @@
 export { parseGeminiStdoutLine } from "./parse-stdout.js";
 export { buildGeminiLocalConfig } from "./build-config.js";
+export { geminiLocalCredentialSetup } from "./credential-setup.js";

--- a/packages/adapters/opencode-local/src/ui/credential-setup.test.ts
+++ b/packages/adapters/opencode-local/src/ui/credential-setup.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { openCodeLocalCredentialSetup } from "./credential-setup.js";
+
+describe("openCodeLocalCredentialSetup", () => {
+  it("exports credential options with correct envKeys in order", () => {
+    const envKeys = openCodeLocalCredentialSetup.options.map(o => o.envKey);
+    expect(envKeys).toEqual(["ANTHROPIC_API_KEY", "OPENAI_API_KEY", "OPENROUTER_API_KEY"]);
+  });
+
+  it("configures ANTHROPIC_API_KEY option with correct label", () => {
+    const anthropicOption = openCodeLocalCredentialSetup.options.find(o => o.envKey === "ANTHROPIC_API_KEY");
+    expect(anthropicOption).toBeDefined();
+    expect(anthropicOption?.kind).toBe("api_key");
+    expect(anthropicOption?.label).toBe("Anthropic API key");
+  });
+
+  it("configures OPENAI_API_KEY option with correct label", () => {
+    const openaiOption = openCodeLocalCredentialSetup.options.find(o => o.envKey === "OPENAI_API_KEY");
+    expect(openaiOption).toBeDefined();
+    expect(openaiOption?.kind).toBe("api_key");
+    expect(openaiOption?.label).toBe("OpenAI API key");
+  });
+
+  it("configures OPENROUTER_API_KEY option with correct label", () => {
+    const routerOption = openCodeLocalCredentialSetup.options.find(o => o.envKey === "OPENROUTER_API_KEY");
+    expect(routerOption).toBeDefined();
+    expect(routerOption?.kind).toBe("api_key");
+    expect(routerOption?.label).toBe("OpenRouter API key");
+  });
+
+  it("includes hint on first option noting OpenCode uses whichever provider key matches the selected model", () => {
+    const firstOption = openCodeLocalCredentialSetup.options[0];
+    expect(firstOption?.hint).toContain("model");
+  });
+});

--- a/packages/adapters/opencode-local/src/ui/credential-setup.ts
+++ b/packages/adapters/opencode-local/src/ui/credential-setup.ts
@@ -1,0 +1,22 @@
+import type { AdapterCredentialSetup } from "@paperclipai/adapter-utils";
+
+export const openCodeLocalCredentialSetup: AdapterCredentialSetup = {
+  options: [
+    {
+      envKey: "ANTHROPIC_API_KEY",
+      kind: "api_key",
+      label: "Anthropic API key",
+      hint: "OpenCode uses whichever provider API key matches the selected model.",
+    },
+    {
+      envKey: "OPENAI_API_KEY",
+      kind: "api_key",
+      label: "OpenAI API key",
+    },
+    {
+      envKey: "OPENROUTER_API_KEY",
+      kind: "api_key",
+      label: "OpenRouter API key",
+    },
+  ],
+};

--- a/packages/adapters/opencode-local/src/ui/index.ts
+++ b/packages/adapters/opencode-local/src/ui/index.ts
@@ -1,2 +1,3 @@
 export { parseOpenCodeStdoutLine } from "./parse-stdout.js";
 export { buildOpenCodeLocalConfig } from "./build-config.js";
+export { openCodeLocalCredentialSetup } from "./credential-setup.js";

--- a/packages/adapters/pi-local/src/ui/credential-setup.test.ts
+++ b/packages/adapters/pi-local/src/ui/credential-setup.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { piLocalCredentialSetup } from "./credential-setup.js";
+
+describe("piLocalCredentialSetup", () => {
+  it("exports credential options with correct envKeys", () => {
+    const envKeys = piLocalCredentialSetup.options.map(o => o.envKey);
+    expect(envKeys).toEqual(["ANTHROPIC_API_KEY"]);
+  });
+
+  it("configures api_key option with correct label and setupUrl", () => {
+    const apiKeyOption = piLocalCredentialSetup.options.find(o => o.envKey === "ANTHROPIC_API_KEY");
+    expect(apiKeyOption).toBeDefined();
+    expect(apiKeyOption?.kind).toBe("api_key");
+    expect(apiKeyOption?.label).toBe("Anthropic API key");
+    expect(apiKeyOption?.setupUrl).toBe("https://console.anthropic.com/settings/keys");
+    expect(apiKeyOption?.placeholder).toBe("sk-ant-…");
+  });
+});

--- a/packages/adapters/pi-local/src/ui/credential-setup.ts
+++ b/packages/adapters/pi-local/src/ui/credential-setup.ts
@@ -1,0 +1,13 @@
+import type { AdapterCredentialSetup } from "@paperclipai/adapter-utils";
+
+export const piLocalCredentialSetup: AdapterCredentialSetup = {
+  options: [
+    {
+      envKey: "ANTHROPIC_API_KEY",
+      kind: "api_key",
+      label: "Anthropic API key",
+      setupUrl: "https://console.anthropic.com/settings/keys",
+      placeholder: "sk-ant-…",
+    },
+  ],
+};

--- a/packages/adapters/pi-local/src/ui/index.ts
+++ b/packages/adapters/pi-local/src/ui/index.ts
@@ -1,2 +1,3 @@
 export { parsePiStdoutLine } from "./parse-stdout.js";
 export { buildPiLocalConfig } from "./build-config.js";
+export { piLocalCredentialSetup } from "./credential-setup.js";

--- a/ui/src/adapters/claude-local/index.ts
+++ b/ui/src/adapters/claude-local/index.ts
@@ -1,7 +1,7 @@
 import type { UIAdapterModule } from "../types";
 import { parseClaudeStdoutLine } from "@paperclipai/adapter-claude-local/ui";
 import { ClaudeLocalConfigFields } from "./config-fields";
-import { buildClaudeLocalConfig } from "@paperclipai/adapter-claude-local/ui";
+import { buildClaudeLocalConfig, claudeLocalCredentialSetup } from "@paperclipai/adapter-claude-local/ui";
 
 export const claudeLocalUIAdapter: UIAdapterModule = {
   type: "claude_local",
@@ -9,4 +9,5 @@ export const claudeLocalUIAdapter: UIAdapterModule = {
   parseStdoutLine: parseClaudeStdoutLine,
   ConfigFields: ClaudeLocalConfigFields,
   buildAdapterConfig: buildClaudeLocalConfig,
+  credentialSetup: claudeLocalCredentialSetup,
 };

--- a/ui/src/adapters/codex-local/index.ts
+++ b/ui/src/adapters/codex-local/index.ts
@@ -1,7 +1,7 @@
 import type { UIAdapterModule } from "../types";
 import { parseCodexStdoutLine } from "@paperclipai/adapter-codex-local/ui";
 import { CodexLocalConfigFields } from "./config-fields";
-import { buildCodexLocalConfig } from "@paperclipai/adapter-codex-local/ui";
+import { buildCodexLocalConfig, codexLocalCredentialSetup } from "@paperclipai/adapter-codex-local/ui";
 
 export const codexLocalUIAdapter: UIAdapterModule = {
   type: "codex_local",
@@ -9,4 +9,5 @@ export const codexLocalUIAdapter: UIAdapterModule = {
   parseStdoutLine: parseCodexStdoutLine,
   ConfigFields: CodexLocalConfigFields,
   buildAdapterConfig: buildCodexLocalConfig,
+  credentialSetup: codexLocalCredentialSetup,
 };

--- a/ui/src/adapters/credential-setup-wiring.test.ts
+++ b/ui/src/adapters/credential-setup-wiring.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { getUIAdapter } from "./registry";
+
+describe("adapter credential-setup wiring", () => {
+  it("exposes the claude_local credential-setup descriptor on the registry", () => {
+    const setup = getUIAdapter("claude_local")?.credentialSetup;
+    expect(setup).toBeDefined();
+    expect(setup?.options[0].envKey).toBe("ANTHROPIC_API_KEY");
+  });
+
+  it("exposes descriptors for the other built-in adapters that have one", () => {
+    for (const type of ["codex_local", "gemini_local", "opencode_local", "pi_local", "cursor"]) {
+      const setup = getUIAdapter(type)?.credentialSetup;
+      expect(setup, `expected credentialSetup for ${type}`).toBeDefined();
+      expect(setup?.options.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("resolves undefined for a registered adapter without a descriptor", () => {
+    expect(getUIAdapter("http")?.credentialSetup).toBeUndefined();
+  });
+});

--- a/ui/src/adapters/cursor/index.ts
+++ b/ui/src/adapters/cursor/index.ts
@@ -1,7 +1,7 @@
 import type { UIAdapterModule } from "../types";
 import { parseCursorStdoutLine } from "@paperclipai/adapter-cursor-local/ui";
 import { CursorLocalConfigFields } from "./config-fields";
-import { buildCursorLocalConfig } from "@paperclipai/adapter-cursor-local/ui";
+import { buildCursorLocalConfig, cursorLocalCredentialSetup } from "@paperclipai/adapter-cursor-local/ui";
 
 export const cursorLocalUIAdapter: UIAdapterModule = {
   type: "cursor",
@@ -9,4 +9,5 @@ export const cursorLocalUIAdapter: UIAdapterModule = {
   parseStdoutLine: parseCursorStdoutLine,
   ConfigFields: CursorLocalConfigFields,
   buildAdapterConfig: buildCursorLocalConfig,
+  credentialSetup: cursorLocalCredentialSetup,
 };

--- a/ui/src/adapters/gemini-local/index.ts
+++ b/ui/src/adapters/gemini-local/index.ts
@@ -1,7 +1,7 @@
 import type { UIAdapterModule } from "../types";
 import { parseGeminiStdoutLine } from "@paperclipai/adapter-gemini-local/ui";
 import { GeminiLocalConfigFields } from "./config-fields";
-import { buildGeminiLocalConfig } from "@paperclipai/adapter-gemini-local/ui";
+import { buildGeminiLocalConfig, geminiLocalCredentialSetup } from "@paperclipai/adapter-gemini-local/ui";
 
 export const geminiLocalUIAdapter: UIAdapterModule = {
   type: "gemini_local",
@@ -9,4 +9,5 @@ export const geminiLocalUIAdapter: UIAdapterModule = {
   parseStdoutLine: parseGeminiStdoutLine,
   ConfigFields: GeminiLocalConfigFields,
   buildAdapterConfig: buildGeminiLocalConfig,
+  credentialSetup: geminiLocalCredentialSetup,
 };

--- a/ui/src/adapters/opencode-local/index.ts
+++ b/ui/src/adapters/opencode-local/index.ts
@@ -1,7 +1,7 @@
 import type { UIAdapterModule } from "../types";
 import { parseOpenCodeStdoutLine } from "@paperclipai/adapter-opencode-local/ui";
 import { OpenCodeLocalConfigFields } from "./config-fields";
-import { buildOpenCodeLocalConfig } from "@paperclipai/adapter-opencode-local/ui";
+import { buildOpenCodeLocalConfig, openCodeLocalCredentialSetup } from "@paperclipai/adapter-opencode-local/ui";
 
 export const openCodeLocalUIAdapter: UIAdapterModule = {
   type: "opencode_local",
@@ -9,4 +9,5 @@ export const openCodeLocalUIAdapter: UIAdapterModule = {
   parseStdoutLine: parseOpenCodeStdoutLine,
   ConfigFields: OpenCodeLocalConfigFields,
   buildAdapterConfig: buildOpenCodeLocalConfig,
+  credentialSetup: openCodeLocalCredentialSetup,
 };

--- a/ui/src/adapters/pi-local/index.ts
+++ b/ui/src/adapters/pi-local/index.ts
@@ -1,7 +1,7 @@
 import type { UIAdapterModule } from "../types";
 import { parsePiStdoutLine } from "@paperclipai/adapter-pi-local/ui";
 import { PiLocalConfigFields } from "./config-fields";
-import { buildPiLocalConfig } from "@paperclipai/adapter-pi-local/ui";
+import { buildPiLocalConfig, piLocalCredentialSetup } from "@paperclipai/adapter-pi-local/ui";
 
 export const piLocalUIAdapter: UIAdapterModule = {
   type: "pi_local",
@@ -9,4 +9,5 @@ export const piLocalUIAdapter: UIAdapterModule = {
   parseStdoutLine: parsePiStdoutLine,
   ConfigFields: PiLocalConfigFields,
   buildAdapterConfig: buildPiLocalConfig,
+  credentialSetup: piLocalCredentialSetup,
 };

--- a/ui/src/adapters/types.ts
+++ b/ui/src/adapters/types.ts
@@ -1,5 +1,5 @@
 import type { ComponentType } from "react";
-import type { CreateConfigValues } from "@paperclipai/adapter-utils";
+import type { AdapterCredentialSetup, CreateConfigValues } from "@paperclipai/adapter-utils";
 
 // Re-export shared types so local consumers don't need to change imports
 export type { TranscriptEntry, StdoutLineParser, CreateConfigValues } from "@paperclipai/adapter-utils";
@@ -41,4 +41,6 @@ export interface UIAdapterModule extends TranscriptParserSource {
   label: string;
   ConfigFields: ComponentType<AdapterConfigFieldsProps>;
   buildAdapterConfig: (values: CreateConfigValues) => Record<string, unknown>;
+  /** Guided BYOK credential options; absent for adapters without one (e.g. external plugins). */
+  credentialSetup?: AdapterCredentialSetup;
 }

--- a/ui/src/components/AdapterCredentialConnect.test.tsx
+++ b/ui/src/components/AdapterCredentialConnect.test.tsx
@@ -1,0 +1,259 @@
+// @vitest-environment jsdom
+
+import { createRoot, type Root } from "react-dom/client";
+import { flushSync } from "react-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { AdapterCredentialSetup } from "@paperclipai/adapter-utils";
+import type { CompanySecret } from "@paperclipai/shared";
+
+const mockSecretsApi = vi.hoisted(() => ({
+  create: vi.fn(),
+}));
+
+vi.mock("../api/secrets", () => ({
+  secretsApi: mockSecretsApi,
+}));
+
+import { AdapterCredentialConnect } from "./AdapterCredentialConnect";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+async function act(callback: () => void | Promise<void>) {
+  let result: void | Promise<void> = undefined;
+  flushSync(() => {
+    result = callback();
+  });
+  await result;
+}
+
+async function flushReact() {
+  await act(async () => {
+    for (let i = 0; i < 4; i += 1) {
+      await Promise.resolve();
+      await new Promise((resolve) => window.setTimeout(resolve, 0));
+    }
+  });
+}
+
+function setInputValue(input: HTMLInputElement, value: string) {
+  const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")?.set;
+  setter?.call(input, value);
+  input.dispatchEvent(new Event("input", { bubbles: true }));
+}
+
+function makeSecret(overrides: Partial<CompanySecret> = {}): CompanySecret {
+  return {
+    id: "secret-1",
+    companyId: "company-1",
+    scope: "company",
+    ownerUserId: null,
+    userSecretDefinitionId: null,
+    key: "claude-local-anthropic-api-key",
+    name: "claude-local-anthropic-api-key",
+    provider: "local_encrypted",
+    status: "active",
+    managedMode: "paperclip_managed",
+    externalRef: null,
+    providerConfigId: null,
+    providerMetadata: null,
+    latestVersion: 1,
+    description: null,
+    lastResolvedAt: null,
+    lastRotatedAt: null,
+    deletedAt: null,
+    createdByAgentId: null,
+    createdByUserId: null,
+    createdAt: new Date(0),
+    updatedAt: new Date(0),
+    ...overrides,
+  } as CompanySecret;
+}
+
+const claudeLocalSetup: AdapterCredentialSetup = {
+  options: [
+    {
+      envKey: "ANTHROPIC_API_KEY",
+      kind: "api_key",
+      label: "Anthropic API key",
+      hint: "Create a key in the Anthropic Console.",
+      setupUrl: "https://console.anthropic.com/settings/keys",
+      placeholder: "sk-ant-…",
+    },
+    {
+      envKey: "CLAUDE_CODE_OAUTH_TOKEN",
+      kind: "subscription_token",
+      label: "Claude Pro/Max subscription token",
+      hint: "Mint a long-lived token with `claude setup-token`.",
+      setupCommand: "claude setup-token",
+      placeholder: "sk-ant-oat01-…",
+    },
+  ],
+};
+
+let container: HTMLDivElement;
+let root: Root | null = null;
+
+function render(props: Partial<React.ComponentProps<typeof AdapterCredentialConnect>> = {}) {
+  root = createRoot(container);
+  return act(() => {
+    root!.render(
+      <AdapterCredentialConnect
+        companyId={props.companyId ?? "company-1"}
+        adapterType={props.adapterType ?? "claude_local"}
+        setup={props.setup ?? claudeLocalSetup}
+        boundEnvKeys={props.boundEnvKeys ?? []}
+        onBind={props.onBind ?? vi.fn()}
+      />,
+    );
+  });
+}
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  mockSecretsApi.create.mockReset();
+});
+
+afterEach(async () => {
+  await act(() => root?.unmount());
+  root = null;
+  container.remove();
+});
+
+describe("AdapterCredentialConnect", () => {
+  it("renders the full card with option labels, hint, and setupCommand chip when nothing is bound", async () => {
+    await render({});
+
+    expect(container.textContent).toContain("Anthropic API key");
+    expect(container.textContent).toContain("Claude Pro/Max subscription token");
+    expect(container.textContent).toContain("Create a key in the Anthropic Console.");
+    // First option is active by default and has no setupCommand.
+    expect(container.querySelector('input[type="password"]')).not.toBeNull();
+  });
+
+  it("renders a compact connected summary naming the bound envKey when an option is bound", async () => {
+    await render({ boundEnvKeys: ["ANTHROPIC_API_KEY"] });
+
+    expect(container.textContent).toContain("ANTHROPIC_API_KEY");
+    expect(container.querySelector('input[type="password"]')).toBeNull();
+    const changeButton = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent === "Change",
+    );
+    expect(changeButton).not.toBeUndefined();
+
+    await act(() => {
+      changeButton!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(container.querySelector('input[type="password"]')).not.toBeNull();
+  });
+
+  it("switching the segmented control swaps the active option's hint and field", async () => {
+    await render({});
+
+    expect(container.textContent).toContain("Create a key in the Anthropic Console.");
+    expect(container.textContent).not.toContain("claude setup-token");
+
+    const tokenTab = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent === "Claude Pro/Max subscription token",
+    );
+    expect(tokenTab).not.toBeUndefined();
+
+    await act(() => {
+      tokenTab!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(container.textContent).toContain("Mint a long-lived token with");
+    expect(container.textContent).toContain("claude setup-token");
+    const input = container.querySelector<HTMLInputElement>('input[type="password"]');
+    expect(input?.placeholder).toBe("sk-ant-oat01-…");
+  });
+
+  it("submits, creates the secret with the derived name, and binds on success", async () => {
+    const onBind = vi.fn();
+    mockSecretsApi.create.mockResolvedValueOnce(makeSecret({ id: "secret-42" }));
+
+    await render({ onBind });
+
+    const input = container.querySelector<HTMLInputElement>('input[type="password"]')!;
+    await act(() => setInputValue(input, "sk-ant-test"));
+
+    const connectButton = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent?.includes("Connect"),
+    )!;
+    expect(connectButton.hasAttribute("disabled")).toBe(false);
+
+    await act(() => {
+      connectButton.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    await flushReact();
+
+    expect(mockSecretsApi.create).toHaveBeenCalledTimes(1);
+    expect(mockSecretsApi.create).toHaveBeenCalledWith("company-1", {
+      name: "claude-local-anthropic-api-key",
+      value: "sk-ant-test",
+    });
+    expect(onBind).toHaveBeenCalledWith("ANTHROPIC_API_KEY", "secret-42");
+
+    const clearedInput = container.querySelector<HTMLInputElement>('input[type="password"]');
+    expect(clearedInput?.value ?? "").toBe("");
+  });
+
+  it("retries once with a -2 suffix when the create call rejects, then binds on the retry", async () => {
+    const onBind = vi.fn();
+    mockSecretsApi.create
+      .mockRejectedValueOnce(new Error("a secret with this name already exists"))
+      .mockResolvedValueOnce(makeSecret({ id: "secret-retry" }));
+
+    await render({ onBind });
+
+    const input = container.querySelector<HTMLInputElement>('input[type="password"]')!;
+    await act(() => setInputValue(input, "sk-ant-test"));
+
+    const connectButton = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent?.includes("Connect"),
+    )!;
+    await act(() => {
+      connectButton.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    await flushReact();
+
+    expect(mockSecretsApi.create).toHaveBeenCalledTimes(2);
+    expect(mockSecretsApi.create).toHaveBeenNthCalledWith(1, "company-1", {
+      name: "claude-local-anthropic-api-key",
+      value: "sk-ant-test",
+    });
+    expect(mockSecretsApi.create).toHaveBeenNthCalledWith(2, "company-1", {
+      name: "claude-local-anthropic-api-key-2",
+      value: "sk-ant-test",
+    });
+    expect(onBind).toHaveBeenCalledWith("ANTHROPIC_API_KEY", "secret-retry");
+  });
+
+  it("shows an inline error and keeps the input when both the create and the retry reject", async () => {
+    const onBind = vi.fn();
+    mockSecretsApi.create
+      .mockRejectedValueOnce(new Error("first failure"))
+      .mockRejectedValueOnce(new Error("still conflicted"));
+
+    await render({ onBind });
+
+    const input = container.querySelector<HTMLInputElement>('input[type="password"]')!;
+    await act(() => setInputValue(input, "sk-ant-test"));
+
+    const connectButton = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent?.includes("Connect"),
+    )!;
+    await act(() => {
+      connectButton.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    await flushReact();
+
+    expect(mockSecretsApi.create).toHaveBeenCalledTimes(2);
+    expect(onBind).not.toHaveBeenCalled();
+    expect(container.textContent).toContain("still conflicted");
+    const keptInput = container.querySelector<HTMLInputElement>('input[type="password"]');
+    expect(keptInput?.value).toBe("sk-ant-test");
+  });
+});

--- a/ui/src/components/AdapterCredentialConnect.test.tsx
+++ b/ui/src/components/AdapterCredentialConnect.test.tsx
@@ -5,6 +5,7 @@ import { flushSync } from "react-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { AdapterCredentialSetup } from "@paperclipai/adapter-utils";
 import type { CompanySecret } from "@paperclipai/shared";
+import { ApiError } from "../api/client";
 
 const mockSecretsApi = vi.hoisted(() => ({
   create: vi.fn(),
@@ -200,10 +201,14 @@ describe("AdapterCredentialConnect", () => {
     expect(clearedInput?.value ?? "").toBe("");
   });
 
-  it("retries once with a -2 suffix when the create call rejects, then binds on the retry", async () => {
+  it("retries once with a -2 suffix when the create call rejects with a 409 name conflict, then binds on the retry", async () => {
     const onBind = vi.fn();
     mockSecretsApi.create
-      .mockRejectedValueOnce(new Error("a secret with this name already exists"))
+      .mockRejectedValueOnce(
+        new ApiError("a secret with this name already exists", 409, {
+          message: "a secret with this name already exists",
+        }),
+      )
       .mockResolvedValueOnce(makeSecret({ id: "secret-retry" }));
 
     await render({ onBind });
@@ -231,11 +236,11 @@ describe("AdapterCredentialConnect", () => {
     expect(onBind).toHaveBeenCalledWith("ANTHROPIC_API_KEY", "secret-retry");
   });
 
-  it("shows an inline error and keeps the input when both the create and the retry reject", async () => {
+  it("shows an inline error and keeps the input when both the create and the 409 retry reject", async () => {
     const onBind = vi.fn();
     mockSecretsApi.create
-      .mockRejectedValueOnce(new Error("first failure"))
-      .mockRejectedValueOnce(new Error("still conflicted"));
+      .mockRejectedValueOnce(new ApiError("first failure", 409, { message: "first failure" }))
+      .mockRejectedValueOnce(new ApiError("still conflicted", 409, { message: "still conflicted" }));
 
     await render({ onBind });
 
@@ -255,5 +260,109 @@ describe("AdapterCredentialConnect", () => {
     expect(container.textContent).toContain("still conflicted");
     const keptInput = container.querySelector<HTMLInputElement>('input[type="password"]');
     expect(keptInput?.value).toBe("sk-ant-test");
+  });
+
+  it("does not retry on a non-409 rejection and surfaces the error immediately", async () => {
+    const onBind = vi.fn();
+    mockSecretsApi.create.mockRejectedValueOnce(new Error("network error"));
+
+    await render({ onBind });
+
+    const input = container.querySelector<HTMLInputElement>('input[type="password"]')!;
+    await act(() => setInputValue(input, "sk-ant-test"));
+
+    const connectButton = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent?.includes("Connect"),
+    )!;
+    await act(() => {
+      connectButton.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    await flushReact();
+
+    expect(mockSecretsApi.create).toHaveBeenCalledTimes(1);
+    expect(onBind).not.toHaveBeenCalled();
+    expect(container.textContent).toContain("network error");
+    const keptInput = container.querySelector<HTMLInputElement>('input[type="password"]');
+    expect(keptInput?.value).toBe("sk-ant-test");
+  });
+
+  it("sends the trimmed value to secretsApi.create", async () => {
+    const onBind = vi.fn();
+    mockSecretsApi.create.mockResolvedValueOnce(makeSecret({ id: "secret-trim" }));
+
+    await render({ onBind });
+
+    const input = container.querySelector<HTMLInputElement>('input[type="password"]')!;
+    await act(() => setInputValue(input, "  sk-ant-test  "));
+
+    const connectButton = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent?.includes("Connect"),
+    )!;
+    await act(() => {
+      connectButton.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    await flushReact();
+
+    expect(mockSecretsApi.create).toHaveBeenCalledWith("company-1", {
+      name: "claude-local-anthropic-api-key",
+      value: "sk-ant-test",
+    });
+  });
+
+  it("submits on Enter in the password input", async () => {
+    const onBind = vi.fn();
+    mockSecretsApi.create.mockResolvedValueOnce(makeSecret({ id: "secret-enter" }));
+
+    await render({ onBind });
+
+    const input = container.querySelector<HTMLInputElement>('input[type="password"]')!;
+    await act(() => setInputValue(input, "sk-ant-test"));
+
+    await act(() => {
+      input.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Enter", bubbles: true, cancelable: true }),
+      );
+    });
+    await flushReact();
+
+    expect(mockSecretsApi.create).toHaveBeenCalledTimes(1);
+    expect(onBind).toHaveBeenCalledWith("ANTHROPIC_API_KEY", "secret-enter");
+  });
+
+  it("does not submit on Enter when the value is blank", async () => {
+    await render({});
+
+    const input = container.querySelector<HTMLInputElement>('input[type="password"]')!;
+    await act(() => {
+      input.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Enter", bubbles: true, cancelable: true }),
+      );
+    });
+    await flushReact();
+
+    expect(mockSecretsApi.create).not.toHaveBeenCalled();
+  });
+
+  it("associates the inline error with the input via aria-describedby and role=alert", async () => {
+    mockSecretsApi.create.mockRejectedValueOnce(new Error("boom"));
+
+    await render({});
+
+    const input = container.querySelector<HTMLInputElement>('input[type="password"]')!;
+    await act(() => setInputValue(input, "sk-ant-test"));
+
+    const connectButton = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent?.includes("Connect"),
+    )!;
+    await act(() => {
+      connectButton.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    await flushReact();
+
+    const errorEl = container.querySelector('[role="alert"]');
+    expect(errorEl).not.toBeNull();
+    expect(errorEl?.textContent).toBe("boom");
+    expect(errorEl?.id).toBeTruthy();
+    expect(input.getAttribute("aria-describedby")).toBe(errorEl?.id);
   });
 });

--- a/ui/src/components/AdapterCredentialConnect.tsx
+++ b/ui/src/components/AdapterCredentialConnect.tsx
@@ -1,0 +1,184 @@
+import { useEffect, useState } from "react";
+import { Check, Copy, ExternalLink, Loader2 } from "lucide-react";
+import type { AdapterCredentialSetup } from "@paperclipai/adapter-utils";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils";
+import { secretsApi } from "../api/secrets";
+import { CopyText } from "./CopyText";
+
+export interface AdapterCredentialConnectProps {
+  companyId: string;
+  adapterType: string;
+  setup: AdapterCredentialSetup;
+  boundEnvKeys: string[];
+  onBind: (envKey: string, secretId: string) => void;
+}
+
+function toKebab(value: string): string {
+  return value.toLowerCase().replace(/_/g, "-");
+}
+
+/**
+ * Guided BYOK credential setup for one adapter (spec §3.2).
+ *
+ * Renders a compact "connected" summary once any of the adapter's credential
+ * options is bound to a company secret, otherwise a full card: a segmented
+ * control across the adapter's credential options, setup guidance for the
+ * active option, and a one-shot "create secret + bind env" form.
+ */
+export function AdapterCredentialConnect({
+  companyId,
+  adapterType,
+  setup,
+  boundEnvKeys,
+  onBind,
+}: AdapterCredentialConnectProps) {
+  const [activeIndex, setActiveIndex] = useState(0);
+  const [value, setValue] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [forceShowForm, setForceShowForm] = useState(false);
+
+  const boundOption = setup.options.find((option) => boundEnvKeys.includes(option.envKey));
+
+  // Collapse back to the compact summary whenever the bound credential
+  // changes (e.g. a fresh successful bind) rather than lingering in the
+  // "Change" state from a previous option.
+  useEffect(() => {
+    setForceShowForm(false);
+  }, [boundOption?.envKey]);
+
+  if (boundOption && !forceShowForm) {
+    return (
+      <div className="flex items-center justify-between gap-2 rounded-md border border-border px-3 py-2">
+        <div className="flex min-w-0 items-center gap-2 text-sm">
+          <Badge variant="secondary" className="gap-1">
+            <Check className="h-3 w-3" />
+            Connected
+          </Badge>
+          <span className="min-w-0 truncate text-muted-foreground">
+            via <span className="font-mono text-xs text-foreground">{boundOption.envKey}</span>
+          </span>
+        </div>
+        <Button type="button" variant="ghost" size="sm" onClick={() => setForceShowForm(true)}>
+          Change
+        </Button>
+      </div>
+    );
+  }
+
+  const active = setup.options[activeIndex] ?? setup.options[0];
+
+  function selectOption(index: number) {
+    setActiveIndex(index);
+    setValue("");
+    setError(null);
+  }
+
+  async function handleConnect() {
+    const trimmed = value.trim();
+    if (!trimmed || submitting) return;
+
+    setSubmitting(true);
+    setError(null);
+    const envKey = active.envKey;
+    const baseName = `${toKebab(adapterType)}-${toKebab(envKey)}`;
+
+    try {
+      const created = await secretsApi.create(companyId, { name: baseName, value });
+      onBind(envKey, created.id);
+      setValue("");
+    } catch {
+      try {
+        const created = await secretsApi.create(companyId, { name: `${baseName}-2`, value });
+        onBind(envKey, created.id);
+        setValue("");
+      } catch (retryError) {
+        setError(retryError instanceof Error ? retryError.message : "Failed to create secret");
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="space-y-3 rounded-md border border-border p-3">
+      {setup.options.length > 1 ? (
+        <div className="flex gap-1 rounded-md border border-border bg-muted/30 p-0.5">
+          {setup.options.map((option, index) => (
+            <button
+              key={option.envKey}
+              type="button"
+              aria-pressed={index === activeIndex}
+              onClick={() => selectOption(index)}
+              className={cn(
+                "flex-1 rounded px-2 py-1 text-xs font-medium transition-colors",
+                index === activeIndex
+                  ? "bg-background text-foreground shadow-xs"
+                  : "text-muted-foreground hover:text-foreground",
+              )}
+            >
+              {option.label}
+            </button>
+          ))}
+        </div>
+      ) : (
+        <div className="text-sm font-medium text-foreground">{active.label}</div>
+      )}
+
+      {active.hint ? <p className="text-xs text-muted-foreground">{active.hint}</p> : null}
+
+      {active.setupCommand ? (
+        <div className="flex items-center gap-1.5 rounded-md border border-border bg-muted px-2 py-1 w-fit">
+          <code className="font-mono text-xs text-foreground">{active.setupCommand}</code>
+          <CopyText
+            text={active.setupCommand}
+            ariaLabel="Copy setup command"
+            className="text-muted-foreground hover:text-foreground"
+            copiedLabel="Command copied"
+          >
+            <Copy className="h-3 w-3" />
+          </CopyText>
+        </div>
+      ) : null}
+
+      {active.setupUrl ? (
+        <a
+          href={active.setupUrl}
+          target="_blank"
+          rel="noreferrer"
+          className="inline-flex items-center gap-1 text-xs text-primary hover:underline"
+        >
+          Open setup page
+          <ExternalLink className="h-3 w-3" />
+        </a>
+      ) : null}
+
+      <div className="flex items-center gap-2">
+        <Input
+          type="password"
+          placeholder={active.placeholder}
+          value={value}
+          aria-label={`${active.label} value`}
+          onChange={(event) => {
+            setValue(event.target.value);
+            if (error) setError(null);
+          }}
+        />
+        <Button
+          type="button"
+          size="sm"
+          disabled={!value.trim() || submitting}
+          onClick={() => void handleConnect()}
+        >
+          {submitting ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : null}
+          Connect
+        </Button>
+      </div>
+
+      {error ? <p className="text-xs text-destructive">{error}</p> : null}
+    </div>
+  );
+}

--- a/ui/src/components/AdapterCredentialConnect.tsx
+++ b/ui/src/components/AdapterCredentialConnect.tsx
@@ -1,10 +1,11 @@
-import { useEffect, useState } from "react";
+import { useEffect, useId, useState } from "react";
 import { Check, Copy, ExternalLink, Loader2 } from "lucide-react";
 import type { AdapterCredentialSetup } from "@paperclipai/adapter-utils";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
+import { ApiError } from "../api/client";
 import { secretsApi } from "../api/secrets";
 import { CopyText } from "./CopyText";
 
@@ -40,6 +41,7 @@ export function AdapterCredentialConnect({
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [forceShowForm, setForceShowForm] = useState(false);
+  const errorId = useId();
 
   const boundOption = setup.options.find((option) => boundEnvKeys.includes(option.envKey));
 
@@ -87,16 +89,23 @@ export function AdapterCredentialConnect({
     const baseName = `${toKebab(adapterType)}-${toKebab(envKey)}`;
 
     try {
-      const created = await secretsApi.create(companyId, { name: baseName, value });
+      const created = await secretsApi.create(companyId, { name: baseName, value: trimmed });
       onBind(envKey, created.id);
       setValue("");
-    } catch {
-      try {
-        const created = await secretsApi.create(companyId, { name: `${baseName}-2`, value });
-        onBind(envKey, created.id);
-        setValue("");
-      } catch (retryError) {
-        setError(retryError instanceof Error ? retryError.message : "Failed to create secret");
+    } catch (err) {
+      // Only retry on a name conflict (409). Any other failure (network,
+      // validation, auth, etc.) surfaces immediately — retrying under a new
+      // name would silently create a second secret for an unrelated error.
+      if (err instanceof ApiError && err.status === 409) {
+        try {
+          const created = await secretsApi.create(companyId, { name: `${baseName}-2`, value: trimmed });
+          onBind(envKey, created.id);
+          setValue("");
+        } catch (retryError) {
+          setError(retryError instanceof Error ? retryError.message : "Failed to create secret");
+        }
+      } else {
+        setError(err instanceof Error ? err.message : "Failed to create secret");
       }
     } finally {
       setSubmitting(false);
@@ -162,9 +171,16 @@ export function AdapterCredentialConnect({
           placeholder={active.placeholder}
           value={value}
           aria-label={`${active.label} value`}
+          aria-describedby={error ? errorId : undefined}
           onChange={(event) => {
             setValue(event.target.value);
             if (error) setError(null);
+          }}
+          onKeyDown={(event) => {
+            if (event.key !== "Enter") return;
+            event.preventDefault();
+            if (!value.trim() || submitting) return;
+            void handleConnect();
           }}
         />
         <Button
@@ -178,7 +194,11 @@ export function AdapterCredentialConnect({
         </Button>
       </div>
 
-      {error ? <p className="text-xs text-destructive">{error}</p> : null}
+      {error ? (
+        <p id={errorId} role="alert" className="text-xs text-destructive">
+          {error}
+        </p>
+      ) : null}
     </div>
   );
 }

--- a/ui/src/components/AgentConfigForm.render.test.tsx
+++ b/ui/src/components/AgentConfigForm.render.test.tsx
@@ -29,6 +29,7 @@ const mockInstanceSettingsApi = vi.hoisted(() => ({
 
 const mockSecretsApi = vi.hoisted(() => ({
   list: vi.fn(),
+  create: vi.fn(),
 }));
 
 vi.mock("../api/agents", () => ({
@@ -73,6 +74,20 @@ vi.mock("../adapters", () => ({
       model: values.model || undefined,
     }),
     parseStdoutLine: () => [],
+    credentialSetup:
+      type === "claude_local"
+        ? {
+            options: [
+              {
+                envKey: "ANTHROPIC_API_KEY",
+                kind: "api_key" as const,
+                label: "Anthropic API key",
+                hint: "Create a key in the Anthropic Console.",
+                placeholder: "sk-ant-…",
+              },
+            ],
+          }
+        : undefined,
   }),
 }));
 
@@ -601,5 +616,158 @@ describe("AgentConfigForm environment selector", () => {
 
     expect(mockAgentsApi.testEnvironment).toHaveBeenCalledTimes(1);
     expect(result.container.textContent).toContain("Network unavailable");
+  });
+});
+
+describe("AgentConfigForm guided credential connect", () => {
+  let roots: Root[] = [];
+
+  beforeEach(() => {
+    mockAgentsApi.adapterModelProfiles.mockResolvedValue([]);
+    mockAgentsApi.adapterModels.mockResolvedValue([]);
+    mockAgentsApi.detectModel.mockResolvedValue(null);
+    mockAgentsApi.list.mockResolvedValue([]);
+    mockInstanceSettingsApi.get.mockResolvedValue({ defaultEnvironmentId: null });
+    mockInstanceSettingsApi.getExperimental.mockResolvedValue({ enableEnvironments: true });
+    mockInstanceSettingsApi.getGeneral.mockResolvedValue({ executionMode: "any" });
+    mockSecretsApi.list.mockResolvedValue([]);
+  });
+
+  afterEach(async () => {
+    for (const root of roots) {
+      await act(async () => {
+        root.unmount();
+      });
+    }
+    roots = [];
+    document.body.innerHTML = "";
+    vi.clearAllMocks();
+  });
+
+  it("shows the guided credential connect card for an adapter with a descriptor and empty env", async () => {
+    const result = await renderForm(
+      [makeEnvironment({ id: "local-1", name: "Local", driver: "local" })],
+      { adapterType: "claude_local", adapterConfig: {} },
+    );
+    roots.push(result.root);
+
+    expect(result.container.textContent).toContain("Anthropic API key");
+    expect(
+      result.container.querySelector('input[aria-label="Anthropic API key value"]'),
+    ).toBeTruthy();
+    expect(result.container.textContent).not.toContain("Connected");
+  });
+
+  it("shows a connected summary when the env has a secret_ref binding for the descriptor's env key", async () => {
+    const result = await renderForm(
+      [makeEnvironment({ id: "local-1", name: "Local", driver: "local" })],
+      {
+        adapterType: "claude_local",
+        adapterConfig: {
+          env: {
+            ANTHROPIC_API_KEY: { type: "secret_ref", secretId: "11111111-1111-4111-8111-111111111111" },
+          },
+        },
+      },
+    );
+    roots.push(result.root);
+
+    expect(result.container.textContent).toContain("Connected");
+    expect(result.container.textContent).toContain("ANTHROPIC_API_KEY");
+    expect(
+      result.container.querySelector('input[aria-label="Anthropic API key value"]'),
+    ).toBeNull();
+  });
+
+  it("shows a connected summary when the env has a non-empty plain value for the descriptor's env key", async () => {
+    const result = await renderForm(
+      [makeEnvironment({ id: "local-1", name: "Local", driver: "local" })],
+      {
+        adapterType: "claude_local",
+        adapterConfig: {
+          env: { ANTHROPIC_API_KEY: { type: "plain", value: "sk-ant-existing" } },
+        },
+      },
+    );
+    roots.push(result.root);
+
+    expect(result.container.textContent).toContain("Connected");
+    expect(
+      result.container.querySelector('input[aria-label="Anthropic API key value"]'),
+    ).toBeNull();
+  });
+
+  it("does not show the credential connect card for an adapter type without a credential descriptor", async () => {
+    const result = await renderForm(
+      [makeEnvironment({ id: "local-1", name: "Local", driver: "local" })],
+      { adapterType: "codex_local" },
+    );
+    roots.push(result.root);
+
+    expect(result.container.textContent).not.toContain("Anthropic API key");
+    expect(
+      result.container.querySelector('input[aria-label="Anthropic API key value"]'),
+    ).toBeNull();
+  });
+
+  it("binds a new credential into the environment-variables editor state", async () => {
+    mockSecretsApi.create.mockResolvedValueOnce({
+      id: "secret-42",
+      companyId: "company-1",
+      scope: "company",
+      ownerUserId: null,
+      userSecretDefinitionId: null,
+      key: "claude-local-anthropic-api-key",
+      name: "claude-local-anthropic-api-key",
+      provider: "local_encrypted",
+      status: "active",
+      managedMode: "paperclip_managed",
+      externalRef: null,
+      providerConfigId: null,
+      providerMetadata: null,
+      latestVersion: 1,
+      description: null,
+      lastResolvedAt: null,
+      lastRotatedAt: null,
+      deletedAt: null,
+      createdByAgentId: null,
+      createdByUserId: null,
+      createdAt: new Date(0),
+      updatedAt: new Date(0),
+    });
+
+    const result = await renderForm(
+      [makeEnvironment({ id: "local-1", name: "Local", driver: "local" })],
+      { adapterType: "claude_local", adapterConfig: {} },
+    );
+    roots.push(result.root);
+
+    const valueInput = result.container.querySelector<HTMLInputElement>(
+      'input[aria-label="Anthropic API key value"]',
+    );
+    expect(valueInput).toBeTruthy();
+
+    await act(async () => {
+      setInputValue(valueInput!, "sk-ant-test");
+    });
+    await flushReact();
+
+    const connectButton = Array.from(result.container.querySelectorAll("button")).find(
+      (button) => button.textContent?.includes("Connect"),
+    );
+    expect(connectButton).toBeTruthy();
+
+    await act(async () => {
+      connectButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    await flushReact();
+
+    expect(mockSecretsApi.create).toHaveBeenCalledTimes(1);
+    expect(result.container.textContent).toContain("Connected");
+
+    const nameInputs = Array.from(
+      result.container.querySelectorAll<HTMLInputElement>('input[aria-label="Variable name"]'),
+    );
+    expect(nameInputs.some((input) => input.value === "ANTHROPIC_API_KEY")).toBe(true);
   });
 });

--- a/ui/src/components/AgentConfigForm.render.test.tsx
+++ b/ui/src/components/AgentConfigForm.render.test.tsx
@@ -770,4 +770,69 @@ describe("AgentConfigForm guided credential connect", () => {
     );
     expect(nameInputs.some((input) => input.value === "ANTHROPIC_API_KEY")).toBe(true);
   });
+
+  it("invalidates the company secrets list after binding so the picker doesn't show 'Missing secret'", async () => {
+    const createdSecret = {
+      id: "secret-42",
+      companyId: "company-1",
+      scope: "company" as const,
+      ownerUserId: null,
+      userSecretDefinitionId: null,
+      key: "claude-local-anthropic-api-key",
+      name: "claude-local-anthropic-api-key",
+      provider: "local_encrypted" as const,
+      status: "active" as const,
+      managedMode: "paperclip_managed" as const,
+      externalRef: null,
+      providerConfigId: null,
+      providerMetadata: null,
+      latestVersion: 1,
+      description: null,
+      lastResolvedAt: null,
+      lastRotatedAt: null,
+      deletedAt: null,
+      createdByAgentId: null,
+      createdByUserId: null,
+      createdAt: new Date(0),
+      updatedAt: new Date(0),
+    };
+    mockSecretsApi.create.mockResolvedValueOnce(createdSecret);
+    // Before the bind, the list query resolves empty. After the bind fires
+    // an invalidation, react-query refetches and this resolves with the
+    // freshly created secret — simulating the server now knowing about it.
+    mockSecretsApi.list.mockResolvedValueOnce([]).mockResolvedValue([createdSecret]);
+
+    const result = await renderForm(
+      [makeEnvironment({ id: "local-1", name: "Local", driver: "local" })],
+      { adapterType: "claude_local", adapterConfig: {} },
+    );
+    roots.push(result.root);
+
+    const valueInput = result.container.querySelector<HTMLInputElement>(
+      'input[aria-label="Anthropic API key value"]',
+    );
+    expect(valueInput).toBeTruthy();
+
+    await act(async () => {
+      setInputValue(valueInput!, "sk-ant-test");
+    });
+    await flushReact();
+
+    const connectButton = Array.from(result.container.querySelectorAll("button")).find(
+      (button) => button.textContent?.includes("Connect"),
+    );
+    expect(connectButton).toBeTruthy();
+
+    await act(async () => {
+      connectButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    await flushReact();
+
+    // The secrets list query was invalidated (and thus refetched) rather
+    // than left stale, so the picker resolves the bound secret instead of
+    // rendering the destructive "Missing secret" fallback.
+    expect(mockSecretsApi.list.mock.calls.length).toBeGreaterThan(1);
+    expect(result.container.textContent).not.toContain("Missing secret");
+    expect(result.container.textContent).toContain("claude-local-anthropic-api-key");
+  });
 });

--- a/ui/src/components/AgentConfigForm.tsx
+++ b/ui/src/components/AgentConfigForm.tsx
@@ -1402,6 +1402,7 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
 
               {credentialSetup && selectedCompanyId && (
                 <AdapterCredentialConnect
+                  key={adapterType}
                   companyId={selectedCompanyId}
                   adapterType={adapterType}
                   setup={credentialSetup}

--- a/ui/src/components/AgentConfigForm.tsx
+++ b/ui/src/components/AgentConfigForm.tsx
@@ -43,6 +43,7 @@ import { ToggleSwitch } from "@/components/ui/toggle-switch";
 import { defaultCreateValues } from "./agent-config-defaults";
 import { getUIAdapter } from "../adapters";
 import { ClaudeLocalAdvancedFields } from "../adapters/claude-local/config-fields";
+import { AdapterCredentialConnect } from "./AdapterCredentialConnect";
 import { MarkdownEditor } from "./MarkdownEditor";
 import { ChoosePathButton } from "./PathInstructionsModal";
 import { OpenCodeLogoIcon } from "./OpenCodeLogoIcon";
@@ -377,6 +378,7 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
   const showLegacyWorkingDirectoryField =
     isLocal && shouldShowLegacyWorkingDirectoryField({ isCreate, adapterConfig: config });
   const uiAdapter = useMemo(() => getUIAdapter(adapterType), [adapterType]);
+  const credentialSetup = uiAdapter.credentialSetup;
   const supportedEnvironmentDrivers = useMemo(
     () => new Set(supportedEnvironmentDriversForAdapter(adapterType)),
     [adapterType],
@@ -385,6 +387,40 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
   const set = isCreate
     ? (patch: Partial<CreateConfigValues>) => props.onChange(patch)
     : null;
+
+  // Env editor state: single source of truth shared by the environment
+  // variables editor and the guided credential-connect card, so a bind from
+  // either surface persists through the same save path.
+  const currentEnv = isCreate
+    ? ((val!.envBindings ?? EMPTY_ENV) as Record<string, EnvBinding>)
+    : (eff("adapterConfig", "env", (config.env ?? EMPTY_ENV) as Record<string, EnvBinding>));
+
+  function updateEnv(env: Record<string, EnvBinding> | undefined) {
+    if (isCreate) {
+      set!({ envBindings: env ?? {}, envVars: "" });
+    } else {
+      mark("adapterConfig", "env", env);
+    }
+  }
+
+  function isEnvValueBound(binding: EnvBinding | undefined): boolean {
+    if (binding === undefined) return false;
+    if (typeof binding === "string") return binding.trim().length > 0;
+    if (binding.type === "plain") return binding.value.trim().length > 0;
+    return binding.type === "secret_ref" || binding.type === "user_secret_ref";
+  }
+
+  const boundEnvKeys = useMemo(() => {
+    if (!credentialSetup) return [];
+    return credentialSetup.options
+      .map((option) => option.envKey)
+      .filter((envKey) => isEnvValueBound(currentEnv[envKey]));
+  }, [credentialSetup, currentEnv]);
+
+  function handleCredentialBind(envKey: string, secretId: string) {
+    updateEnv({ ...currentEnv, [envKey]: { type: "secret_ref", secretId } });
+  }
+
   const rawCurrentDefaultEnvironmentId = isCreate
     ? val!.defaultEnvironmentId ?? ""
     : eff("identity", "defaultEnvironmentId", props.agent.defaultEnvironmentId ?? "");
@@ -1358,26 +1394,27 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
                 />
               </Field>
 
+              {credentialSetup && selectedCompanyId && (
+                <AdapterCredentialConnect
+                  companyId={selectedCompanyId}
+                  adapterType={adapterType}
+                  setup={credentialSetup}
+                  boundEnvKeys={boundEnvKeys}
+                  onBind={handleCredentialBind}
+                />
+              )}
+
               <Field label="Environment variables" hint={help.envVars}>
                 <EnvironmentVariablesEditor
                   ref={environmentVariablesEditorRef}
-                  value={
-                    isCreate
-                      ? ((val!.envBindings ?? EMPTY_ENV) as Record<string, EnvBinding>)
-                      : ((eff("adapterConfig", "env", (config.env ?? EMPTY_ENV) as Record<string, EnvBinding>))
-                      )
-                  }
+                  value={currentEnv}
                   secrets={availableSecrets}
                   userSecretDefinitions={userSecretDefinitions}
                   onCreateSecret={async (name, value) => {
                     const created = await createSecret.mutateAsync({ name, value });
                     return created;
                   }}
-                  onChange={(env) =>
-                    isCreate
-                      ? set!({ envBindings: env ?? {}, envVars: "" })
-                      : mark("adapterConfig", "env", env)
-                  }
+                  onChange={updateEnv}
                 />
               </Field>
 

--- a/ui/src/components/AgentConfigForm.tsx
+++ b/ui/src/components/AgentConfigForm.tsx
@@ -419,6 +419,12 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
 
   function handleCredentialBind(envKey: string, secretId: string) {
     updateEnv({ ...currentEnv, [envKey]: { type: "secret_ref", secretId } });
+    // The newly created secret isn't in the company secrets list query cache
+    // yet, so without invalidating, SecretPicker would render this env row
+    // as "Missing secret (…)" until something else happens to refetch.
+    if (selectedCompanyId) {
+      queryClient.invalidateQueries({ queryKey: queryKeys.secrets.list(selectedCompanyId) });
+    }
   }
 
   const rawCurrentDefaultEnvironmentId = isCreate

--- a/ui/src/components/OnboardingWizard.test.tsx
+++ b/ui/src/components/OnboardingWizard.test.tsx
@@ -32,6 +32,19 @@ const mockCompany = vi.hoisted(() => ({
 const mockAdapterRegistry = vi.hoisted(() => ({
   list: [] as Array<{ type: string }>,
   disabled: new Set<string>(),
+  // Per-adapterType overrides for getUIAdapter(), keyed by adapterType. Tests
+  // that need a second adapter (e.g. to exercise credential-binding scoping
+  // across an adapter switch) populate this; anything not present falls back
+  // to the claude_local-shaped default below.
+  byType: {} as Record<
+    string,
+    {
+      buildAdapterConfig: () => Record<string, unknown>;
+      credentialSetup?: {
+        options: Array<{ envKey: string; label: string; placeholder?: string }>;
+      };
+    }
+  >,
 }));
 
 const mockAgentsApi = vi.hoisted(() => ({
@@ -69,18 +82,19 @@ vi.mock("../context/CompanyContext", () => ({
 }));
 vi.mock("../adapters", () => ({
   listUIAdapters: () => mockAdapterRegistry.list,
-  getUIAdapter: () => ({
-    buildAdapterConfig: () => ({}),
-    credentialSetup: {
-      options: [
-        {
-          envKey: "ANTHROPIC_API_KEY",
-          label: "Anthropic API key",
-          placeholder: "sk-ant-...",
-        },
-      ],
+  getUIAdapter: (type: string) =>
+    mockAdapterRegistry.byType[type] ?? {
+      buildAdapterConfig: () => ({}),
+      credentialSetup: {
+        options: [
+          {
+            envKey: "ANTHROPIC_API_KEY",
+            label: "Anthropic API key",
+            placeholder: "sk-ant-...",
+          },
+        ],
+      },
     },
-  }),
 }));
 vi.mock("../adapters/metadata", () => ({ isVisualAdapterChoice: () => true }));
 vi.mock("../adapters/adapter-display-registry", () => ({
@@ -175,6 +189,7 @@ describe("OnboardingWizard step 4 — guided credential connect", () => {
     mockCompany.companies = [{ id: "c1", name: "Test Co", issuePrefix: "TC" }];
     mockAdapterRegistry.list = [{ type: "claude_local" }];
     mockAdapterRegistry.disabled = new Set<string>();
+    mockAdapterRegistry.byType = {};
     mockAgentsApi.adapterModels.mockClear();
     mockAgentsApi.testEnvironment.mockClear();
     mockAgentsApi.hire.mockClear();
@@ -343,6 +358,142 @@ describe("OnboardingWizard step 4 — guided credential connect", () => {
     expect(hirePayload.adapterConfig.env?.ANTHROPIC_API_KEY).toEqual({
       type: "secret_ref",
       secretId: "sec-draft",
+    });
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  it("does not send a binding collected under a previously-selected adapter when hiring with a different adapter selected", async () => {
+    // gemini_local has its own credential option (GEMINI_API_KEY), disjoint
+    // from claude_local's ANTHROPIC_API_KEY.
+    mockAdapterRegistry.byType.gemini_local = {
+      buildAdapterConfig: () => ({}),
+      credentialSetup: {
+        options: [
+          {
+            envKey: "GEMINI_API_KEY",
+            label: "Gemini API key",
+            placeholder: "AIza...",
+          },
+        ],
+      },
+    };
+    window.localStorage.setItem(
+      ONBOARDING_STORAGE_KEY,
+      JSON.stringify({
+        step: 4,
+        agentName: "Chief of staff",
+        adapterType: "gemini_local",
+        // Stale binding left over from when claude_local was selected.
+        credentialBindings: {
+          ANTHROPIC_API_KEY: { type: "secret_ref", secretId: "sec-stale" },
+        },
+      }),
+    );
+
+    const { root } = await mount();
+
+    const heartbeatButton = findButtonByText(document.body, "Give it a heartbeat");
+    await act(async () => {
+      heartbeatButton.click();
+    });
+    await flushReact();
+
+    expect(mockAgentsApi.hire).toHaveBeenCalledTimes(1);
+    const hirePayload = mockAgentsApi.hire.mock.calls[0]?.[1] as {
+      adapterConfig: Record<string, unknown>;
+    };
+    // Filtered out entirely, and the base config has no env of its own, so
+    // the regression-guarded "no env key when nothing is bound" behavior
+    // holds even though credentialBindings isn't empty.
+    expect(hirePayload.adapterConfig).not.toHaveProperty("env");
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+});
+
+describe("mergeCredentialBindings", () => {
+  // Exercised indirectly above through the wizard's call sites; this
+  // isolates the merge/filter semantics themselves since the helper isn't
+  // exported (it's an internal implementation detail of the wizard), driven
+  // through the same "restore saved draft" + hire path used elsewhere in
+  // this file so the base-env-survives case doesn't need a real
+  // buildAdapterConfig() with forceUnset wiring.
+  beforeEach(() => {
+    window.localStorage.clear();
+    mockDialog.onboardingOpen = true;
+    mockDialog.onboardingOptions = { initialStep: 4, companyId: "c1" };
+    mockCompany.companies = [{ id: "c1", name: "Test Co", issuePrefix: "TC" }];
+    mockAdapterRegistry.list = [{ type: "claude_local" }];
+    mockAdapterRegistry.disabled = new Set<string>();
+    mockAdapterRegistry.byType = {};
+    mockAgentsApi.adapterModels.mockClear();
+    mockAgentsApi.testEnvironment.mockClear();
+    mockAgentsApi.hire.mockClear();
+    mockAgentsApi.instructionsBundle.mockClear();
+    mockAgentsApi.saveInstructionsFile.mockClear();
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+    vi.clearAllMocks();
+  });
+
+  it("merges a matching binding on top of the base config's own env instead of replacing it", async () => {
+    // Simulate buildAdapterConfig() already producing a base env entry (e.g.
+    // the forceUnsetAnthropicApiKey plain-value marker) by having the
+    // claude_local adapter's buildAdapterConfig stub return one.
+    mockAdapterRegistry.byType.claude_local = {
+      buildAdapterConfig: () => ({
+        env: { ANTHROPIC_API_KEY: { type: "plain", value: "" } },
+      }),
+      credentialSetup: {
+        options: [
+          {
+            envKey: "CLAUDE_CODE_OAUTH_TOKEN",
+            label: "Claude Pro/Max subscription token",
+            placeholder: "sk-ant-oat01-...",
+          },
+        ],
+      },
+    };
+    window.localStorage.setItem(
+      ONBOARDING_STORAGE_KEY,
+      JSON.stringify({
+        step: 4,
+        agentName: "Chief of staff",
+        adapterType: "claude_local",
+        credentialBindings: {
+          CLAUDE_CODE_OAUTH_TOKEN: { type: "secret_ref", secretId: "sec-token" },
+        },
+      }),
+    );
+
+    const { root } = await mount();
+
+    const heartbeatButton = findButtonByText(document.body, "Give it a heartbeat");
+    await act(async () => {
+      heartbeatButton.click();
+    });
+    await flushReact();
+
+    expect(mockAgentsApi.hire).toHaveBeenCalledTimes(1);
+    const hirePayload = mockAgentsApi.hire.mock.calls[0]?.[1] as {
+      adapterConfig: { env?: Record<string, unknown> };
+    };
+    // The base config's own env entry survives the merge...
+    expect(hirePayload.adapterConfig.env?.ANTHROPIC_API_KEY).toEqual({
+      type: "plain",
+      value: "",
+    });
+    // ...alongside the binding for the current adapter's credential option.
+    expect(hirePayload.adapterConfig.env?.CLAUDE_CODE_OAUTH_TOKEN).toEqual({
+      type: "secret_ref",
+      secretId: "sec-token",
     });
 
     await act(async () => {

--- a/ui/src/components/OnboardingWizard.test.tsx
+++ b/ui/src/components/OnboardingWizard.test.tsx
@@ -1,0 +1,352 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// --- Mocks (hoisted so vi.mock factories can close over them) ----------------
+
+const ONBOARDING_STORAGE_KEY = "paperclip-onboarding-state";
+
+const mockDialog = vi.hoisted(() => ({
+  onboardingOpen: true,
+  onboardingOptions: {} as { initialStep?: number; companyId?: string },
+  closeOnboarding: vi.fn(),
+  onboardingRouteDismissed: false,
+  setOnboardingRouteDismissed: vi.fn(),
+}));
+
+const mockCompany = vi.hoisted(() => ({
+  companies: [] as Array<{ id: string; name: string; issuePrefix: string }>,
+  setSelectedCompanyId: vi.fn(),
+  loading: false,
+}));
+
+// The real adapter registry eagerly imports every adapter package. The
+// model/harness picker internals are out of scope here, so stub the adapter
+// layer entirely and drive the grid through this knob. Every test in this
+// file uses claude_local, so getUIAdapter always reports its credential
+// setup descriptor (a single ANTHROPIC_API_KEY option) — that's the minimum
+// needed to exercise the step-4 connect card wiring.
+const mockAdapterRegistry = vi.hoisted(() => ({
+  list: [] as Array<{ type: string }>,
+  disabled: new Set<string>(),
+}));
+
+const mockAgentsApi = vi.hoisted(() => ({
+  adapterModels: vi.fn(async () => [] as Array<{ id: string; label: string }>),
+  testEnvironment: vi.fn(async () => ({
+    adapterType: "claude_local",
+    status: "pass" as const,
+    checks: [] as Array<{
+      code: string;
+      level: "info" | "warn" | "error";
+      message: string;
+      detail?: string | null;
+      hint?: string | null;
+    }>,
+    testedAt: new Date().toISOString(),
+  })),
+  hire: vi.fn(async (_companyId: string, _data: Record<string, unknown>) => ({
+    agent: { id: "agent-1" },
+    approval: null,
+  })),
+  instructionsBundle: vi.fn(async () => ({ entryFile: "AGENTS.md" })),
+  saveInstructionsFile: vi.fn(async () => ({})),
+}));
+
+vi.mock("@/lib/router", () => ({
+  useLocation: () => ({ pathname: "/", search: "", hash: "", state: null }),
+  useNavigate: () => vi.fn(),
+  useParams: () => ({}),
+}));
+vi.mock("../context/DialogContext", () => ({
+  useDialog: () => mockDialog,
+}));
+vi.mock("../context/CompanyContext", () => ({
+  useCompany: () => mockCompany,
+}));
+vi.mock("../adapters", () => ({
+  listUIAdapters: () => mockAdapterRegistry.list,
+  getUIAdapter: () => ({
+    buildAdapterConfig: () => ({}),
+    credentialSetup: {
+      options: [
+        {
+          envKey: "ANTHROPIC_API_KEY",
+          label: "Anthropic API key",
+          placeholder: "sk-ant-...",
+        },
+      ],
+    },
+  }),
+}));
+vi.mock("../adapters/metadata", () => ({ isVisualAdapterChoice: () => true }));
+vi.mock("../adapters/adapter-display-registry", () => ({
+  getAdapterDisplay: (type: string) => ({
+    type,
+    recommended: false,
+    label: type,
+    description: "",
+    icon: () => null,
+  }),
+}));
+vi.mock("../adapters/use-disabled-adapters", () => ({
+  useDisabledAdaptersSync: () => mockAdapterRegistry.disabled,
+}));
+vi.mock("../adapters/use-adapter-capabilities", () => ({
+  useAdapterCapabilities: () => () => ({
+    supportsInstructionsBundle: false,
+    supportsSkills: false,
+    supportsLocalAgentJwt: false,
+    requiresMaterializedRuntimeSkills: false,
+    supportsModelProfiles: false,
+  }),
+}));
+vi.mock("../api/agents", () => ({ agentsApi: mockAgentsApi }));
+// The credential-connect card itself is covered by its own test file
+// (AdapterCredentialConnect.test.tsx); here we only need to exercise the
+// wizard's wiring (rendering condition + onBind plumbing), so stub it down
+// to a single button that invokes onBind with fixed test values.
+vi.mock("./AdapterCredentialConnect", () => ({
+  AdapterCredentialConnect: (props: {
+    boundEnvKeys: string[];
+    onBind: (envKey: string, secretId: string) => void;
+  }) => (
+    <button
+      type="button"
+      data-testid="mock-credential-bind"
+      onClick={() => props.onBind("ANTHROPIC_API_KEY", "sec-1")}
+    >
+      bound:{props.boundEnvKeys.join(",")}
+    </button>
+  ),
+}));
+// Animation / canvas-ish children that add nothing to the logic under test.
+vi.mock("./AsciiArtAnimation", () => ({ AsciiArtAnimation: () => null }));
+vi.mock("./FrontDoor", () => ({ FrontDoor: () => null }));
+vi.mock("./AgentCapsule", () => ({ AgentCapsule: () => null }));
+
+import { OnboardingWizard } from "./OnboardingWizard";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+async function flushReact() {
+  await act(async () => {
+    await Promise.resolve();
+    await new Promise((resolve) => window.setTimeout(resolve, 0));
+  });
+}
+
+async function mount() {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  await act(async () => {
+    root.render(
+      <QueryClientProvider client={queryClient}>
+        <OnboardingWizard />
+      </QueryClientProvider>,
+    );
+  });
+  await flushReact();
+  return { container, root };
+}
+
+function findButtonByText(container: HTMLElement, text: string): HTMLButtonElement {
+  const buttons = Array.from(container.querySelectorAll("button"));
+  const match = buttons.find((btn) => btn.textContent?.includes(text));
+  if (!match) {
+    throw new Error(`No button found with text "${text}"`);
+  }
+  return match as HTMLButtonElement;
+}
+
+describe("OnboardingWizard step 4 — guided credential connect", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    mockDialog.onboardingOpen = true;
+    mockDialog.onboardingOptions = { initialStep: 4, companyId: "c1" };
+    mockCompany.companies = [{ id: "c1", name: "Test Co", issuePrefix: "TC" }];
+    mockAdapterRegistry.list = [{ type: "claude_local" }];
+    mockAdapterRegistry.disabled = new Set<string>();
+    mockAgentsApi.adapterModels.mockClear();
+    mockAgentsApi.testEnvironment.mockClear();
+    mockAgentsApi.hire.mockClear();
+    mockAgentsApi.instructionsBundle.mockClear();
+    mockAgentsApi.saveInstructionsFile.mockClear();
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+    vi.clearAllMocks();
+  });
+
+  it("renders the connect card on step 4 with a created company and empty bindings", async () => {
+    const { root } = await mount();
+
+    expect(
+      document.body.querySelector('[data-testid="mock-credential-bind"]'),
+    ).not.toBeNull();
+    // No bindings yet.
+    expect(
+      document.body.querySelector('[data-testid="mock-credential-bind"]')
+        ?.textContent,
+    ).toBe("bound:");
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  it("persists a binding to the draft and merges it into the hire payload", async () => {
+    const { root } = await mount();
+
+    const bindButton = findButtonByText(document.body, "bound:");
+    await act(async () => {
+      bindButton.click();
+    });
+    await flushReact();
+
+    const saved = JSON.parse(
+      window.localStorage.getItem(ONBOARDING_STORAGE_KEY) ?? "{}",
+    );
+    expect(saved.credentialBindings).toEqual({
+      ANTHROPIC_API_KEY: { type: "secret_ref", secretId: "sec-1" },
+    });
+
+    const heartbeatButton = findButtonByText(document.body, "Give it a heartbeat");
+    await act(async () => {
+      heartbeatButton.click();
+    });
+    await flushReact();
+
+    expect(mockAgentsApi.hire).toHaveBeenCalledTimes(1);
+    const hirePayload = mockAgentsApi.hire.mock.calls[0]?.[1] as {
+      adapterConfig: { env?: Record<string, unknown> };
+    };
+    expect(hirePayload.adapterConfig.env?.ANTHROPIC_API_KEY).toEqual({
+      type: "secret_ref",
+      secretId: "sec-1",
+    });
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  it("omits the env key from the hire payload when there are no bindings", async () => {
+    const { root } = await mount();
+
+    const heartbeatButton = findButtonByText(document.body, "Give it a heartbeat");
+    await act(async () => {
+      heartbeatButton.click();
+    });
+    await flushReact();
+
+    expect(mockAgentsApi.hire).toHaveBeenCalledTimes(1);
+    const hirePayload = mockAgentsApi.hire.mock.calls[0]?.[1] as {
+      adapterConfig: Record<string, unknown>;
+    };
+    expect(hirePayload.adapterConfig).not.toHaveProperty("env");
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  it("lists warn-level checks even when the overall status is pass", async () => {
+    mockAgentsApi.testEnvironment.mockResolvedValueOnce({
+      adapterType: "claude_local",
+      status: "pass",
+      checks: [
+        {
+          code: "claude_subscription_auth_code",
+          level: "warn",
+          message: "Using a short-lived auth code; re-run claude login soon.",
+        },
+      ],
+      testedAt: new Date().toISOString(),
+    });
+
+    const { root } = await mount();
+
+    const testButton = findButtonByText(document.body, "Test now");
+    await act(async () => {
+      testButton.click();
+    });
+    await flushReact();
+
+    const bodyText = document.body.textContent ?? "";
+    // Exactly one green "Passed" pill — the warn rows below must not repeat
+    // the pass banner.
+    expect(bodyText.match(/Passed/g)).toHaveLength(1);
+    expect(bodyText).toContain(
+      "Using a short-lived auth code; re-run claude login soon.",
+    );
+    // The warn rows render in the house amber warn styling, outside the
+    // green pass pill.
+    const warnMessageEl = Array.from(
+      document.body.querySelectorAll("div, p, span"),
+    )
+      .filter((el) =>
+        el.textContent?.includes(
+          "Using a short-lived auth code; re-run claude login soon.",
+        ),
+      )
+      .pop();
+    expect(warnMessageEl).toBeDefined();
+    expect(warnMessageEl?.closest('[class*="amber"]')).not.toBeNull();
+    expect(warnMessageEl?.closest('[class*="green"]')).toBeNull();
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  it("restores credentialBindings from a saved draft and merges them into the hire payload", async () => {
+    window.localStorage.setItem(
+      ONBOARDING_STORAGE_KEY,
+      JSON.stringify({
+        step: 4,
+        agentName: "Chief of staff",
+        adapterType: "claude_local",
+        credentialBindings: {
+          ANTHROPIC_API_KEY: { type: "secret_ref", secretId: "sec-draft" },
+        },
+      }),
+    );
+
+    const { root } = await mount();
+
+    // The restored binding surfaces as a bound env key on the connect card.
+    expect(
+      document.body.querySelector('[data-testid="mock-credential-bind"]')
+        ?.textContent,
+    ).toBe("bound:ANTHROPIC_API_KEY");
+
+    const heartbeatButton = findButtonByText(document.body, "Give it a heartbeat");
+    await act(async () => {
+      heartbeatButton.click();
+    });
+    await flushReact();
+
+    expect(mockAgentsApi.hire).toHaveBeenCalledTimes(1);
+    const hirePayload = mockAgentsApi.hire.mock.calls[0]?.[1] as {
+      adapterConfig: { env?: Record<string, unknown> };
+    };
+    expect(hirePayload.adapterConfig.env?.ANTHROPIC_API_KEY).toEqual({
+      type: "secret_ref",
+      secretId: "sec-draft",
+    });
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+});

--- a/ui/src/components/OnboardingWizard.tsx
+++ b/ui/src/components/OnboardingWizard.tsx
@@ -1523,6 +1523,7 @@ export function OnboardingWizard() {
 
                   {credentialSetup && createdCompanyId && (
                     <AdapterCredentialConnect
+                      key={adapterType}
                       companyId={createdCompanyId}
                       adapterType={adapterType}
                       setup={credentialSetup}

--- a/ui/src/components/OnboardingWizard.tsx
+++ b/ui/src/components/OnboardingWizard.tsx
@@ -4,6 +4,7 @@ import type {
   AdapterEnvironmentCheck,
   AdapterEnvironmentTestResult
 } from "@paperclipai/shared";
+import type { AdapterCredentialSetup } from "@paperclipai/adapter-utils";
 import { useLocation, useNavigate, useParams } from "@/lib/router";
 import { useDialog } from "../context/DialogContext";
 import { useCompany } from "../context/CompanyContext";
@@ -75,6 +76,52 @@ const MISSION_PROMPT_CHIPS = [
   "Scale a content business",
   "Launch a marketplace"
 ];
+
+type CredentialBinding = { type: "secret_ref"; secretId: string };
+
+/**
+ * Merges guided-credential-connect bindings into a base adapter config's
+ * `env`, scoped to the *current* adapter's credential-setup envKeys.
+ *
+ * `credentialBindings` accumulates across the whole wizard session (a user
+ * can pick claude_local, bind ANTHROPIC_API_KEY, then switch to
+ * gemini_local) — without filtering, a binding collected under a
+ * previously-selected adapter would leak into the config of whichever
+ * adapter the user ends up hiring. Only entries whose envKey appears in the
+ * current adapter's `credentialSetup` options survive the merge.
+ *
+ * Also merges on top of `baseConfig.env` (rather than replacing it) so
+ * unrelated env entries already produced by `buildAdapterConfig` — notably
+ * the `forceUnsetAnthropicApiKey` plain-value marker — survive alongside
+ * the bindings. If there's nothing to merge (no matching bindings and no
+ * base env), `env` is omitted entirely to preserve the existing
+ * regression-guarded "no env key when nothing is bound" behavior.
+ */
+function mergeCredentialBindings(
+  baseConfig: Record<string, unknown>,
+  bindings: Record<string, CredentialBinding>,
+  setup: AdapterCredentialSetup | undefined
+): Record<string, unknown> {
+  const allowedEnvKeys = new Set((setup?.options ?? []).map((option) => option.envKey));
+  const filteredBindings = Object.fromEntries(
+    Object.entries(bindings).filter(([envKey]) => allowedEnvKeys.has(envKey))
+  );
+  const baseEnv =
+    typeof baseConfig.env === "object" &&
+    baseConfig.env !== null &&
+    !Array.isArray(baseConfig.env)
+      ? (baseConfig.env as Record<string, unknown>)
+      : undefined;
+
+  if (Object.keys(filteredBindings).length === 0 && !baseEnv) {
+    return baseConfig;
+  }
+
+  return {
+    ...baseConfig,
+    env: { ...(baseEnv ?? {}), ...filteredBindings }
+  };
+}
 
 function buildMissionFromQuestionnaire(q1: string, q2: string, q3: string, q4: string): string {
   const parts: string[] = [];
@@ -535,12 +582,8 @@ export function OnboardingWizard() {
         adapterType,
         {
           adapterConfig:
-            adapterConfigOverride ?? {
-              ...buildAdapterConfig(),
-              ...(Object.keys(credentialBindings).length > 0
-                ? { env: { ...credentialBindings } }
-                : {})
-            }
+            adapterConfigOverride ??
+            mergeCredentialBindings(buildAdapterConfig(), credentialBindings, credentialSetup)
         }
       );
       setAdapterEnvResult(result);
@@ -566,10 +609,9 @@ export function OnboardingWizard() {
     };
     setCredentialBindings(nextBindings);
     setAdapterEnvResult(null);
-    void runAdapterEnvironmentTest({
-      ...buildAdapterConfig(),
-      env: { ...nextBindings }
-    });
+    void runAdapterEnvironmentTest(
+      mergeCredentialBindings(buildAdapterConfig(), nextBindings, credentialSetup)
+    );
   }
 
   // Step 2 → 3 ("Confirm mission"): create the company + its company-level
@@ -665,12 +707,7 @@ export function OnboardingWizard() {
         name: agentName.trim(),
         role: "ceo",
         adapterType,
-        adapterConfig: {
-          ...buildAdapterConfig(),
-          ...(Object.keys(credentialBindings).length > 0
-            ? { env: { ...credentialBindings } }
-            : {})
-        },
+        adapterConfig: mergeCredentialBindings(buildAdapterConfig(), credentialBindings, credentialSetup),
         runtimeConfig: buildNewAgentRuntimeConfig()
       });
       if (hire.approval) {

--- a/ui/src/components/OnboardingWizard.tsx
+++ b/ui/src/components/OnboardingWizard.tsx
@@ -1,6 +1,9 @@
 import { useEffect, useState, useMemo } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import type { AdapterEnvironmentTestResult } from "@paperclipai/shared";
+import type {
+  AdapterEnvironmentCheck,
+  AdapterEnvironmentTestResult
+} from "@paperclipai/shared";
 import { useLocation, useNavigate, useParams } from "@/lib/router";
 import { useDialog } from "../context/DialogContext";
 import { useCompany } from "../context/CompanyContext";
@@ -47,6 +50,7 @@ import { resolveRouteOnboardingOptions } from "../lib/onboarding-route";
 import { AsciiArtAnimation } from "./AsciiArtAnimation";
 import { FrontDoor } from "./FrontDoor";
 import { AgentCapsule } from "./AgentCapsule";
+import { AdapterCredentialConnect } from "./AdapterCredentialConnect";
 import { Badge } from "@/components/ui/badge";
 import {
   Building2,
@@ -178,6 +182,14 @@ export function OnboardingWizard() {
     useState(false);
   const [unsetAnthropicLoading, setUnsetAnthropicLoading] = useState(false);
   const [showMoreAdapters, setShowMoreAdapters] = useState(false);
+  const [credentialBindings, setCredentialBindings] = useState<
+    Record<string, { type: "secret_ref"; secretId: string }>
+  >(
+    (saved?.credentialBindings as Record<
+      string,
+      { type: "secret_ref"; secretId: string }
+    >) ?? {}
+  );
 
   // Created entity IDs — pre-populate from existing company when skipping step 1
   const [createdCompanyId, setCreatedCompanyId] = useState<string | null>(
@@ -236,6 +248,7 @@ export function OnboardingWizard() {
       createdCompanyId, createdCompanyPrefix, createdAgentId,
       createdCompanyGoalId, createdProjectId, createdIssueRef,
       onboardingPath, growWorkflows, growPainPoints, growAutomate,
+      credentialBindings,
     };
     localStorage.setItem(ONBOARDING_STORAGE_KEY, JSON.stringify(state));
   }, [
@@ -244,6 +257,7 @@ export function OnboardingWizard() {
     createdCompanyId, createdCompanyPrefix, createdAgentId,
     createdCompanyGoalId, createdProjectId, createdIssueRef,
     onboardingPath, growWorkflows, growPainPoints, growAutomate,
+    credentialBindings,
   ]);
 
   const {
@@ -275,6 +289,7 @@ export function OnboardingWizard() {
     adapterType === "opencode_local" ||
     adapterType === "pi_local" ||
     adapterType === "cursor";
+  const credentialSetup = getUIAdapter(adapterType)?.credentialSetup;
   // Build adapter grids dynamically from the UI registry + display metadata.
   // External/plugin adapters automatically appear with generic defaults, and
   // server-disabled types are filtered out.
@@ -519,7 +534,13 @@ export function OnboardingWizard() {
         createdCompanyId,
         adapterType,
         {
-          adapterConfig: adapterConfigOverride ?? buildAdapterConfig()
+          adapterConfig:
+            adapterConfigOverride ?? {
+              ...buildAdapterConfig(),
+              ...(Object.keys(credentialBindings).length > 0
+                ? { env: { ...credentialBindings } }
+                : {})
+            }
         }
       );
       setAdapterEnvResult(result);
@@ -532,6 +553,23 @@ export function OnboardingWizard() {
     } finally {
       setAdapterEnvLoading(false);
     }
+  }
+
+  // Guided BYOK credential connect (step 4): bind an env key to a freshly
+  // created company secret, then re-run the environment check with the
+  // fresh binding included (passed explicitly rather than relying on
+  // credentialBindings state, which wouldn't have re-rendered yet).
+  function handleCredentialBind(envKey: string, secretId: string) {
+    const nextBindings = {
+      ...credentialBindings,
+      [envKey]: { type: "secret_ref" as const, secretId }
+    };
+    setCredentialBindings(nextBindings);
+    setAdapterEnvResult(null);
+    void runAdapterEnvironmentTest({
+      ...buildAdapterConfig(),
+      env: { ...nextBindings }
+    });
   }
 
   // Step 2 → 3 ("Confirm mission"): create the company + its company-level
@@ -627,7 +665,12 @@ export function OnboardingWizard() {
         name: agentName.trim(),
         role: "ceo",
         adapterType,
-        adapterConfig: buildAdapterConfig(),
+        adapterConfig: {
+          ...buildAdapterConfig(),
+          ...(Object.keys(credentialBindings).length > 0
+            ? { env: { ...credentialBindings } }
+            : {})
+        },
         runtimeConfig: buildNewAgentRuntimeConfig()
       });
       if (hire.approval) {
@@ -1441,6 +1484,16 @@ export function OnboardingWizard() {
                     </div>
                   )}
 
+                  {credentialSetup && createdCompanyId && (
+                    <AdapterCredentialConnect
+                      companyId={createdCompanyId}
+                      adapterType={adapterType}
+                      setup={credentialSetup}
+                      boundEnvKeys={Object.keys(credentialBindings)}
+                      onBind={handleCredentialBind}
+                    />
+                  )}
+
                   {isLocalAdapter && (
                     <div className="space-y-2 rounded-md border border-border p-3">
                       <div className="flex items-center justify-between gap-2">
@@ -1470,12 +1523,27 @@ export function OnboardingWizard() {
                         </div>
                       )}
 
-                      {adapterEnvResult &&
-                      adapterEnvResult.status === "pass" ? (
-                        <div className="flex items-center gap-2 rounded-md border border-green-300 dark:border-green-500/40 bg-green-50 dark:bg-green-500/10 px-3 py-2 text-xs text-green-700 dark:text-green-300 animate-in fade-in slide-in-from-bottom-1 duration-300">
-                          <Check className="h-3.5 w-3.5 shrink-0" />
-                          <span className="font-medium">Passed</span>
-                        </div>
+                      {adapterEnvResult && adapterEnvResult.status === "pass" ? (
+                        <>
+                          <div className="flex items-center gap-2 rounded-md border border-green-300 dark:border-green-500/40 bg-green-50 dark:bg-green-500/10 px-3 py-2 text-xs text-green-700 dark:text-green-300 animate-in fade-in slide-in-from-bottom-1 duration-300">
+                            <Check className="h-3.5 w-3.5 shrink-0" />
+                            <span className="font-medium">Passed</span>
+                          </div>
+                          {adapterEnvResult.checks.some(
+                            (check) => check.level === "warn"
+                          ) && (
+                            <div className="rounded-md border border-amber-300 dark:border-amber-500/40 bg-amber-50 dark:bg-amber-500/10 px-2.5 py-2 text-(length:--text-micro) text-amber-700 dark:text-amber-300 space-y-1">
+                              {adapterEnvResult.checks
+                                .filter((check) => check.level === "warn")
+                                .map((check, idx) => (
+                                  <AdapterEnvironmentCheckRow
+                                    key={`${check.code}-${idx}`}
+                                    check={check}
+                                  />
+                                ))}
+                            </div>
+                          )}
+                        </>
                       ) : adapterEnvResult ? (
                         <AdapterEnvironmentResult result={adapterEnvResult} />
                       ) : null}
@@ -1760,28 +1828,38 @@ function AdapterEnvironmentResult({
       </div>
       <div className="mt-1.5 space-y-1">
         {result.checks.map((check, idx) => (
-          <div
+          <AdapterEnvironmentCheckRow
             key={`${check.code}-${idx}`}
-            className="leading-relaxed break-words"
-          >
-            <span className="font-medium uppercase tracking-wide opacity-80">
-              {check.level}
-            </span>
-            <span className="mx-1 opacity-60">·</span>
-            <span>{check.message}</span>
-            {check.detail && (
-              <span className="block opacity-75 break-all">
-                ({check.detail})
-              </span>
-            )}
-            {check.hint && (
-              <span className="block opacity-90 break-words">
-                Hint: {check.hint}
-              </span>
-            )}
-          </div>
+            check={check}
+          />
         ))}
       </div>
+    </div>
+  );
+}
+
+function AdapterEnvironmentCheckRow({
+  check
+}: {
+  check: AdapterEnvironmentCheck;
+}) {
+  return (
+    <div className="leading-relaxed break-words">
+      <span className="font-medium uppercase tracking-wide opacity-80">
+        {check.level}
+      </span>
+      <span className="mx-1 opacity-60">·</span>
+      <span>{check.message}</span>
+      {check.detail && (
+        <span className="block opacity-75 break-all">
+          ({check.detail})
+        </span>
+      )}
+      {check.hint && (
+        <span className="block opacity-90 break-words">
+          Hint: {check.hint}
+        </span>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## What

Every deployment without host-level provider env — cloud multi-tenant or plain self-hosted — needs the user to hand the product a model credential before their first agent works. Today that means leaving the product: figure out which env var the adapter wants, create a company secret, come back, and bind it as a `secret_ref` env row. Nothing in the wizard or agent settings names the env var or the setup command, and the wizard's environment check reports **Passed** for a credential-less Claude agent (the probe only runs `claude --version`), so the first run fails with the CLI's raw "Not logged in · Please run /login".

This PR makes credential setup a one-step, in-product action:

- **`AdapterCredentialSetup` descriptors** (new vendor-neutral types in `@paperclipai/adapter-utils`): each built-in local adapter exports, from its client-safe `/ui` entry, the credential options it accepts — env key, kind (`api_key` / `subscription_token`), label, hint, first-party setup command/URL, placeholder. Claude declares both `ANTHROPIC_API_KEY` and the `CLAUDE_CODE_OAUTH_TOKEN` minted by `claude setup-token` (hint covers the token-only quota-reporting limitation and the "extra usage" billing caveat); codex/gemini/opencode/pi/cursor declare their API keys. Exposed on the UI adapter registry as an optional `UIAdapterModule.credentialSetup` — external/plugin adapters simply have none.
- **`AdapterCredentialConnect`**: one card that renders the options (segmented), the copyable setup command, a password field — and on Connect creates the company secret and hands back the id for a `{type:"secret_ref"}` env binding in one action. Retry with a `-2` name suffix only on a 409 name conflict; other errors surface immediately (no blind retry that could duplicate a live credential after a client-side timeout).
- **Agent settings**: the card renders above the environment-variables editor whenever the adapter has a descriptor and none of its env keys are bound; binding appends a normal secret-ref row to the same editor state (single persistence path) and refreshes the secrets list.
- **Onboarding wizard step 4**: same card under the model picker; bindings persist in the wizard draft and merge into both the environment-test and hire payloads — filtered to the *selected* adapter's declared env keys (switching from Claude to Gemini never leaks an Anthropic binding into the Gemini agent) and merged on top of the config's own env (an explicit unset marker survives). No gating: agent creation works exactly as before with no binding.
- **Honest env check**: warn-level checks now render (in warn styling) even when the probe passes, instead of hiding behind the green "Passed" pill.

## What this deliberately does not do

- **No embedded provider OAuth.** Anthropic's authentication policy (Feb 2026) restricts consumer OAuth to Claude Code/Claude.ai with no third-party client registration, and OpenAI's ChatGPT sign-in is Codex-only — so the guided hand-off of a first-party-minted token is the durable design. The descriptor is shaped so an OAuth connector kind could slot in later if that changes.
- No descriptors for external/plugin adapters (would need server `AdapterInfo` plumbing; the optional field degrades cleanly).
- No blocking of agent creation on missing credentials — host env and sandbox-registry provisioning remain first-class.

Note: the check-surfacing renders warn-level checks; the claude subscription-token *info* check comes from #9488 and composes with this PR without depending on it.

## Tests

Descriptor unit tests per package; component tests (create+bind, 409-scoped retry, non-409 no-retry, trim, Enter-submit, connected-state); AgentConfigForm render tests (gating, bound-detection incl. plain values, editor-row append, secrets-list refresh); wizard tests (card gating, draft persist + restore, merge contract incl. no-`env`-when-empty regression guard, adapter-switch filtering, unset-marker survival, single-"Passed"-pill warn rendering). Full ui suite: 2551 passing (2 pre-existing env-sensitive failures untouched by this branch: a rolling-date bucket test and a locale-formatted number assertion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
