### PR TITLE
fix(heartbeat): stop mis-coding successful Claude runs as claude_transient_upstream

### DIFF
--- a/packages/adapter-utils/src/types.ts
+++ b/packages/adapter-utils/src/types.ts
@@ -71,6 +71,15 @@ export interface AdapterExecutionResult {
   exitCode: number | null;
   signal: string | null;
   timedOut: boolean;
+  /**
+   * Explicit success signal from the adapter's structured output. `true` is
+   * authoritative: the run is treated as successful even if the process exit
+   * code is nonzero (e.g. the CLI was SIGTERMed by terminal-result cleanup
+   * after emitting a successful result). `false`/`null`/absent are advisory
+   * only — the outcome falls back to exitCode + errorMessage inference, so a
+   * failing adapter must still set errorMessage/exitCode to signal failure.
+   */
+  succeeded?: boolean | null;
   errorMessage?: string | null;
   errorCode?: string | null;
   errorFamily?: AdapterExecutionErrorFamily | null;

--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -57,6 +57,7 @@ import {
   isClaudeUnknownSessionError,
   isClaudePoisonedPreviousMessageIdError,
   isClaudeImageProcessingError,
+  stripClaudeStreamEventLines,
 } from "./parse.js";
 import {
   materializeRemoteClaudeConfig,
@@ -839,38 +840,47 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     opts: { fallbackSessionId: string | null; clearSessionOnMissingSession?: boolean },
   ): AdapterExecutionResult => {
     const { proc, parsedStream, parsed } = attempt;
-    const loginMeta = detectClaudeLoginRequired({
-      parsed,
-      stdout: proc.stdout,
-      stderr: proc.stderr,
-    });
-    const errorMeta =
-      loginMeta.loginUrl != null
-        ? {
-            loginUrl: loginMeta.loginUrl,
-          }
-        : undefined;
 
-    if (proc.timedOut) {
-      return {
-        exitCode: proc.exitCode,
-        signal: proc.signal,
-        timedOut: true,
-        errorMessage: `Timed out after ${timeoutSec}s`,
-        errorCode: "timeout",
-        errorMeta,
-        clearSession: Boolean(opts.clearSessionOnMissingSession),
-      };
-    }
+    if (proc.timedOut || !parsed) {
+      // Keyword classifiers (auth/quota/transient) must never scan the agent
+      // conversation: assistant text routinely discusses rate limits, auth, and
+      // retries, and matching it mis-coded runs as claude_transient_upstream /
+      // claude_auth_required, chaining full-cost retries. Without a
+      // structured result, only plain-text CLI output (non-stream-json lines)
+      // is eligible. Computed here so the common structured-result path skips
+      // this full stdout re-parse.
+      const stdoutForClassification = stripClaudeStreamEventLines(proc.stdout);
+      const loginMeta = detectClaudeLoginRequired({
+        parsed,
+        stdout: stdoutForClassification,
+        stderr: proc.stderr,
+      });
+      const errorMeta =
+        loginMeta.loginUrl != null
+          ? {
+              loginUrl: loginMeta.loginUrl,
+            }
+          : undefined;
 
-    if (!parsed) {
+      if (proc.timedOut) {
+        return {
+          exitCode: proc.exitCode,
+          signal: proc.signal,
+          timedOut: true,
+          errorMessage: `Timed out after ${timeoutSec}s`,
+          errorCode: "timeout",
+          errorMeta,
+          clearSession: Boolean(opts.clearSessionOnMissingSession),
+        };
+      }
+
       const fallbackErrorMessage = parseFallbackErrorMessage(proc);
       const providerQuota =
         !loginMeta.requiresLogin &&
         (proc.exitCode ?? 0) !== 0 &&
         isClaudeProviderQuotaError({
           parsed: null,
-          stdout: proc.stdout,
+          stdout: stdoutForClassification,
           stderr: proc.stderr,
           errorMessage: fallbackErrorMessage,
         });
@@ -880,14 +890,14 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         (proc.exitCode ?? 0) !== 0 &&
         isClaudeTransientUpstreamError({
           parsed: null,
-          stdout: proc.stdout,
+          stdout: stdoutForClassification,
           stderr: proc.stderr,
           errorMessage: fallbackErrorMessage,
         });
       const transientRetryNotBefore = providerQuota || transientUpstream
         ? extractClaudeRetryNotBefore({
             parsed: null,
-            stdout: proc.stdout,
+            stdout: stdoutForClassification,
             stderr: proc.stderr,
             errorMessage: fallbackErrorMessage,
           })
@@ -986,6 +996,16 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     const errorMessage = failed
       ? describeClaudeFailure(parsed) ?? `Claude exited with code ${proc.exitCode ?? -1}`
       : null;
+    // With a structured result available, classify failures only from that
+    // result (error text, structured errors) plus stderr — never from the
+    // stream stdout — and only when the run actually failed. Successful runs
+    // whose final message merely mentioned auth or rate limits were previously
+    // mis-coded claude_auth_required / claude_transient_upstream.
+    const loginMeta = failed
+      ? detectClaudeLoginRequired({ parsed, stdout: "", stderr: proc.stderr })
+      : { requiresLogin: false, loginUrl: null };
+    const errorMeta =
+      loginMeta.loginUrl != null ? { loginUrl: loginMeta.loginUrl } : undefined;
     const providerQuota =
       failed &&
       !loginMeta.requiresLogin &&
@@ -993,7 +1013,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       !poisonedPreviousMessageId &&
       isClaudeProviderQuotaError({
         parsed,
-        stdout: proc.stdout,
+        stdout: "",
         stderr: proc.stderr,
         errorMessage,
       });
@@ -1005,14 +1025,14 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       !providerQuota &&
       isClaudeTransientUpstreamError({
         parsed,
-        stdout: proc.stdout,
+        stdout: "",
         stderr: proc.stderr,
         errorMessage,
       });
     const transientRetryNotBefore = providerQuota || transientUpstream
       ? extractClaudeRetryNotBefore({
           parsed,
-          stdout: proc.stdout,
+          stdout: "",
           stderr: proc.stderr,
           errorMessage,
         })
@@ -1053,6 +1073,10 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       exitCode: proc.exitCode,
       signal: proc.signal,
       timedOut: false,
+      // Explicit success signal: a structured subtype=success / is_error=false
+      // result is authoritative even when the process exit code is nonzero
+      // (terminal-result cleanup SIGTERMs the CLI after a successful result).
+      succeeded: parsedSucceeded,
       errorMessage,
       errorCode: resolvedErrorCode,
       errorFamily,

--- a/packages/adapters/claude-local/src/server/parse.test.ts
+++ b/packages/adapters/claude-local/src/server/parse.test.ts
@@ -109,6 +109,31 @@ describe("isClaudeTransientUpstreamError", () => {
     ).toBe(true);
   });
 
+  it("classifies the Fable usage-credits limit wording as provider quota", () => {
+    const errorMessage =
+      "You've reached your Fable 5 limit. Run /usage-credits to continue or switch models with /model.";
+    expect(isClaudeProviderQuotaError({ errorMessage })).toBe(true);
+    expect(isClaudeTransientUpstreamError({ errorMessage })).toBe(false);
+  });
+
+  it("classifies mid-response connection failures as transient", () => {
+    expect(
+      isClaudeTransientUpstreamError({
+        errorMessage: "API Error: Connection closed mid-response. The response above may be incomplete.",
+      }),
+    ).toBe(true);
+    expect(
+      isClaudeTransientUpstreamError({
+        stderr: "fetch failed: ECONNRESET",
+      }),
+    ).toBe(true);
+    expect(
+      isClaudeTransientUpstreamError({
+        stderr: "request to https://api.anthropic.com failed: socket hang up",
+      }),
+    ).toBe(true);
+  });
+
   it("does not classify login/auth failures as transient", () => {
     expect(
       isClaudeTransientUpstreamError({

--- a/packages/adapters/claude-local/src/server/parse.ts
+++ b/packages/adapters/claude-local/src/server/parse.ts
@@ -10,9 +10,9 @@ const CLAUDE_AUTH_REQUIRED_RE = /(?:not\s+logged\s+in|please\s+log\s+in|please\s
 const URL_RE = /(https?:\/\/[^\s'"`<>()[\]{};,!?]+[^\s'"`<>()[\]{};,!.?:]+)/gi;
 
 const CLAUDE_TRANSIENT_UPSTREAM_RE =
-  /(?:rate[-\s]?limit(?:ed)?|rate_limit_error|too\s+many\s+requests|\b429\b|overloaded(?:_error)?|server\s+overloaded|service\s+unavailable|\b503\b|\b529\b|high\s+demand|try\s+again\s+later|temporarily\s+unavailable|throttl(?:ed|ing)|throttlingexception|servicequotaexceededexception|out\s+of\s+extra\s+usage|extra\s+usage\b|claude\s+usage\s+limit\s+reached|5[-\s]?hour\s+limit\s+reached|weekly\s+limit\s+reached|usage\s+limit\s+reached|usage\s+cap\s+reached)/i;
+  /(?:rate[-\s]?limit(?:ed)?|rate_limit_error|too\s+many\s+requests|\b429\b|overloaded(?:_error)?|server\s+overloaded|service\s+unavailable|\b503\b|\b529\b|high\s+demand|try\s+again\s+later|temporarily\s+unavailable|throttl(?:ed|ing)|throttlingexception|servicequotaexceededexception|out\s+of\s+extra\s+usage|extra\s+usage\b|claude\s+usage\s+limit\s+reached|5[-\s]?hour\s+limit\s+reached|weekly\s+limit\s+reached|usage\s+limit\s+reached|usage\s+cap\s+reached|connection\s+closed\s+mid-response|econnreset|econnrefused|etimedout|socket\s+hang\s+up)/i;
 const CLAUDE_PROVIDER_QUOTA_RE =
-  /(?:you(?:'|’)ve\s+hit\s+your\s+session\s+limit|session\s+limit\s+(?:reached|exceeded)|out\s+of\s+extra\s+usage|extra\s+usage\b|claude\s+usage\s+limit\s+reached|5[-\s]?hour\s+limit\s+reached|weekly\s+limit\s+reached|usage\s+limit\s+reached|usage\s+cap\s+reached|servicequotaexceededexception)/i;
+  /(?:you(?:'|’)ve\s+hit\s+your\s+session\s+limit|session\s+limit\s+(?:reached|exceeded)|out\s+of\s+extra\s+usage|extra\s+usage\b|claude\s+usage\s+limit\s+reached|5[-\s]?hour\s+limit\s+reached|weekly\s+limit\s+reached|usage\s+limit\s+reached|usage\s+cap\s+reached|servicequotaexceededexception|you(?:'|’)ve\s+reached\s+your\s+[^\n.!?]{0,60}\blimit\b|\/usage-credits\b)/i;
 const CLAUDE_EXTRA_USAGE_RESET_RE =
   /(?:you(?:'|’)ve\s+hit\s+your\s+session\s+limit|session\s+limit\s+(?:reached|exceeded)|out\s+of\s+extra\s+usage|extra\s+usage|usage\s+limit\s+reached|usage\s+cap\s+reached|5[-\s]?hour\s+limit\s+reached|weekly\s+limit\s+reached|claude\s+usage\s+limit\s+reached)[\s\S]{0,120}?\bresets?\s+(?:at\s+)?([^\n()]+?)(?:\s*\(([^)]+)\))?(?:[.!]|\n|$)/i;
 
@@ -268,6 +268,28 @@ export function isClaudeImageProcessingError(parsed: Record<string, unknown>): b
   return allMessages.some((msg) =>
     /could not process image/i.test(msg),
   );
+}
+
+/**
+ * Drops stream-json event lines (system/assistant/result/... objects) from raw
+ * CLI stdout, keeping only plain-text lines. Keyword classifiers must never
+ * see the agent conversation: assistant text routinely discusses rate limits,
+ * auth, and retries, and matching it mis-coded successful or unrelated runs as
+ * transient/auth failures.
+ */
+export function stripClaudeStreamEventLines(stdout: string | null | undefined): string {
+  if (!stdout) return "";
+  return stdout
+    .split(/\r?\n/)
+    .filter((line) => {
+      const trimmed = line.trim();
+      if (!trimmed) return false;
+      if (!trimmed.startsWith("{")) return true;
+      const event = parseJson(trimmed);
+      if (!event) return true;
+      return asString(event.type, "") === "";
+    })
+    .join("\n");
 }
 
 function buildClaudeTransientHaystack(input: {

--- a/server/src/__tests__/claude-local-execute.test.ts
+++ b/server/src/__tests__/claude-local-execute.test.ts
@@ -12,12 +12,20 @@ import {
 
 async function writeFailingClaudeCommand(
   commandPath: string,
-  options: { resultEvent: Record<string, unknown>; exitCode?: number },
+  options: {
+    resultEvent: Record<string, unknown>;
+    exitCode?: number;
+    streamEvents?: Array<Record<string, unknown>>;
+  },
 ): Promise<void> {
-  const payload = JSON.stringify(options.resultEvent);
+  const lines = [...(options.streamEvents ?? []), options.resultEvent].map((event) =>
+    JSON.stringify(event),
+  );
   const exit = options.exitCode ?? 1;
   const script = `#!/usr/bin/env node
-console.log(${JSON.stringify(payload)});
+for (const line of ${JSON.stringify(lines)}) {
+  console.log(line);
+}
 process.exit(${exit});
 `;
   await fs.writeFile(commandPath, script, "utf8");
@@ -40,6 +48,54 @@ process.exit(${exit});
 `;
   await fs.writeFile(commandPath, script, "utf8");
   await fs.chmod(commandPath, 0o755);
+}
+
+// Shared driver for the misclassification regression tests below: provisions a
+// temp workspace + fake claude command, runs execute() with the standard
+// fixture agent/config, and cleans up.
+async function executeWithClaudeCommand(
+  runId: string,
+  tmpPrefix: string,
+  commandWriter: (commandPath: string) => Promise<void>,
+) {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), tmpPrefix));
+  const workspace = path.join(root, "workspace");
+  const commandPath = path.join(root, "claude");
+  await fs.mkdir(workspace, { recursive: true });
+  await commandWriter(commandPath);
+  const previousHome = process.env.HOME;
+  process.env.HOME = root;
+  try {
+    return await execute({
+      runId,
+      agent: {
+        id: "agent-1",
+        companyId: "company-1",
+        name: "Claude Coder",
+        adapterType: "claude_local",
+        adapterConfig: { engine: "cli" },
+      },
+      runtime: {
+        sessionId: null,
+        sessionParams: null,
+        sessionDisplayId: null,
+        taskKey: null,
+      },
+      config: {
+        engine: "cli",
+        command: commandPath,
+        cwd: workspace,
+        promptTemplate: "Follow the paperclip heartbeat.",
+      },
+      context: {},
+      authToken: "run-jwt-token",
+      onLog: async () => {},
+    });
+  } finally {
+    if (previousHome === undefined) delete process.env.HOME;
+    else process.env.HOME = previousHome;
+    await fs.rm(root, { recursive: true, force: true });
+  }
 }
 
 async function writeFakeClaudeCommand(commandPath: string): Promise<void> {
@@ -1406,6 +1462,7 @@ describe("claude execute", () => {
       });
 
       expect(result.exitCode).toBe(1);
+      expect(result.succeeded).toBe(true);
       expect(result.errorMessage).toBeNull();
       expect(result.errorCode).toBeNull();
       expect(result.summary).toBe("Implemented the requested change.");
@@ -1414,6 +1471,160 @@ describe("claude execute", () => {
       else process.env.HOME = previousHome;
       await fs.rm(root, { recursive: true, force: true });
     }
+  });
+
+  it("does not mis-code a successful run whose conversation mentions rate limits or auth", async () => {
+    const sessionId = "aaaaaaaa-1111-4111-8111-aaaaaaaaaaaa";
+    const result = await executeWithClaudeCommand(
+      "run-claude-success-keywords",
+      "paperclip-claude-execute-success-keywords-",
+      (commandPath) =>
+        writeFailingClaudeCommand(commandPath, {
+          // Simulates the terminal-result-cleanup SIGTERM: successful structured
+          // result but a nonzero process exit (observed as exit 143 in prod).
+          exitCode: 143,
+          streamEvents: [
+            { type: "system", subtype: "init", session_id: sessionId, model: "claude-fable-5" },
+            {
+              type: "assistant",
+              session_id: sessionId,
+              message: {
+                content: [
+                  {
+                    type: "text",
+                    text: "The API returned 429 rate limit errors earlier; when unauthorized, users must run /login. If the service is overloaded, try again later.",
+                  },
+                ],
+              },
+            },
+          ],
+          resultEvent: {
+            type: "result",
+            subtype: "success",
+            session_id: sessionId,
+            is_error: false,
+            result: "Deployed the monitoring fix and verified the dashboard.",
+            usage: { input_tokens: 1, cache_read_input_tokens: 0, output_tokens: 1 },
+          },
+        }),
+    );
+
+    expect(result.succeeded).toBe(true);
+    expect(result.errorMessage).toBeNull();
+    expect(result.errorCode).toBeNull();
+    expect(result.errorFamily ?? null).toBeNull();
+  });
+
+  it("does not classify a failed run as transient from conversation keywords alone", async () => {
+    const sessionId = "bbbbbbbb-2222-4222-8222-bbbbbbbbbbbb";
+    const result = await executeWithClaudeCommand(
+      "run-claude-failed-keywords",
+      "paperclip-claude-execute-failed-keywords-",
+      (commandPath) =>
+        writeFailingClaudeCommand(commandPath, {
+          exitCode: 1,
+          streamEvents: [
+            { type: "system", subtype: "init", session_id: sessionId, model: "claude-fable-5" },
+            {
+              type: "assistant",
+              session_id: sessionId,
+              message: {
+                content: [
+                  {
+                    type: "text",
+                    text: "Investigating the 429 rate limit storm: the upstream was overloaded and clients should try again later.",
+                  },
+                ],
+              },
+            },
+          ],
+          resultEvent: {
+            type: "result",
+            subtype: "error_during_execution",
+            session_id: sessionId,
+            is_error: true,
+            result: "Something unrelated broke while writing the report.",
+          },
+        }),
+    );
+
+    expect(result.succeeded ?? false).toBe(false);
+    expect(result.errorCode).not.toBe("claude_transient_upstream");
+    expect(result.errorCode).not.toBe("provider_quota");
+    expect(result.errorCode).not.toBe("claude_auth_required");
+    expect(result.errorFamily ?? null).toBeNull();
+  });
+
+  it("classifies the Fable usage-credits limit message as provider quota", async () => {
+    const result = await executeWithClaudeCommand(
+      "run-claude-fable-limit",
+      "paperclip-claude-execute-fable-limit-",
+      (commandPath) =>
+        writeFailingClaudeCommand(commandPath, {
+          resultEvent: {
+            type: "result",
+            subtype: "success",
+            session_id: "cccccccc-3333-4333-8333-cccccccccccc",
+            is_error: true,
+            result: "You've reached your Fable 5 limit. Run /usage-credits to continue or switch models with /model.",
+          },
+        }),
+    );
+
+    expect(result.succeeded ?? false).toBe(false);
+    expect(result.errorCode).toBe("provider_quota");
+    expect(result.errorFamily).toBe("provider_quota");
+  });
+
+  it("classifies 'API Error: Connection closed mid-response' as transient", async () => {
+    const result = await executeWithClaudeCommand(
+      "run-claude-conn-closed",
+      "paperclip-claude-execute-conn-closed-",
+      (commandPath) =>
+        writeFailingClaudeCommand(commandPath, {
+          resultEvent: {
+            type: "result",
+            subtype: "success",
+            session_id: "dddddddd-4444-4444-8444-dddddddddddd",
+            is_error: true,
+            result: "API Error: Connection closed mid-response. The response above may be incomplete.",
+          },
+        }),
+    );
+
+    expect(result.succeeded ?? false).toBe(false);
+    expect(result.errorCode).toBe("claude_transient_upstream");
+    expect(result.errorFamily).toBe("transient_upstream");
+  });
+
+  it("does not classify a crashed stream (no result event) as transient from assistant text", async () => {
+    const sessionId = "eeeeeeee-5555-4555-8555-eeeeeeeeeeee";
+    const streamLines = [
+      JSON.stringify({ type: "system", subtype: "init", session_id: sessionId, model: "claude-fable-5" }),
+      JSON.stringify({
+        type: "assistant",
+        session_id: sessionId,
+        message: {
+          content: [
+            { type: "text", text: "Users hit 429 rate limit responses; the upstream is overloaded, try again later." },
+          ],
+        },
+      }),
+    ].join("\n");
+    const result = await executeWithClaudeCommand(
+      "run-claude-crash-keywords",
+      "paperclip-claude-execute-crash-keywords-",
+      (commandPath) =>
+        writeTextFailingClaudeCommand(commandPath, {
+          stdout: `${streamLines}\n`,
+          stderr: "claude: fatal: unexpected internal error\n",
+          exitCode: 1,
+        }),
+    );
+
+    expect(result.succeeded ?? false).toBe(false);
+    expect(result.errorCode).not.toBe("claude_transient_upstream");
+    expect(result.errorCode).not.toBe("provider_quota");
   });
 
   it("classifies rate-limit / overloaded failures without reset metadata as transient", async () => {

--- a/server/src/__tests__/heartbeat-retry-scheduling.test.ts
+++ b/server/src/__tests__/heartbeat-retry-scheduling.test.ts
@@ -2067,6 +2067,49 @@ describeEmbeddedPostgres("heartbeat bounded retry scheduling", () => {
     });
   });
 
+  it("does not schedule transient retries for runs whose adapter reported a successful result", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const runId = randomUUID();
+    const now = new Date("2026-04-20T18:00:00.000Z");
+
+    // Regression guard: successful Claude heartbeats (structured
+    // subtype=success, is_error=false) were mis-coded claude_transient_upstream
+    // and chained full-cost transient_failure retries.
+    await seedRetryFixture({
+      runId,
+      companyId,
+      agentId,
+      now,
+      adapterType: "claude_local",
+      errorCode: "claude_transient_upstream",
+      resultJson: {
+        subtype: "success",
+        is_error: false,
+        errorFamily: "transient_upstream",
+      },
+    });
+
+    const result = await heartbeat.scheduleBoundedRetry(runId, {
+      now,
+      random: () => 0.5,
+    });
+
+    expect(result?.outcome).toBe("not_scheduled");
+
+    const scheduledCount = await db
+      .select({ count: sql<number>`count(*)::int` })
+      .from(heartbeatRuns)
+      .where(
+        and(
+          eq(heartbeatRuns.companyId, companyId),
+          eq(heartbeatRuns.status, "scheduled_retry"),
+        ),
+      )
+      .then((rows) => rows[0]?.count ?? 0);
+    expect(scheduledCount).toBe(0);
+  });
+
   it("advances codex transient fallback stages across bounded retry attempts", async () => {
     const fallbackModes = [
       "same_session",

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -481,6 +481,22 @@ function isRetryableInteractionContinuationInfrastructureFailure(
   );
 }
 
+// A run whose structured adapter result reported success must never be
+// retried as a transient failure, regardless of how its error code/family was
+// labelled. Guards against classifier regressions that mis-coded successful
+// heartbeats claude_transient_upstream and chained full-cost retries.
+// Prefers the adapter-agnostic `adapterSucceeded` flag persisted at
+// finalization; falls back to the raw Claude result-event fields for rows
+// written before that flag existed.
+function isAdapterReportedSuccessRun(
+  run: Pick<typeof heartbeatRuns.$inferSelect, "resultJson">,
+) {
+  const resultJson = parseObject(run.resultJson);
+  if (resultJson.adapterSucceeded === true) return true;
+  const subtype = readNonEmptyString(resultJson.subtype)?.trim().toLowerCase();
+  return subtype === "success" && resultJson.is_error !== true && resultJson.is_error !== "true";
+}
+
 function mergeAdapterRecoveryMetadata(input: {
   resultJson: Record<string, unknown> | null | undefined;
   errorFamily?: string | null;
@@ -8826,6 +8842,26 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     const now = opts?.now ?? new Date();
     const retryReason = opts?.retryReason ?? BOUNDED_TRANSIENT_HEARTBEAT_RETRY_REASON;
     const wakeReason = opts?.wakeReason ?? BOUNDED_TRANSIENT_HEARTBEAT_RETRY_WAKE_REASON;
+    if (retryReason === BOUNDED_TRANSIENT_HEARTBEAT_RETRY_REASON && isAdapterReportedSuccessRun(run)) {
+      const reason =
+        "Transient retry suppressed because the adapter reported a successful structured result";
+      await appendRunEvent(run, await nextRunEventSeq(run.id), {
+        eventType: "lifecycle",
+        stream: "system",
+        level: "warn",
+        message: reason,
+        payload: {
+          retryReason,
+          errorCode: run.errorCode,
+        },
+      });
+      return {
+        outcome: "not_scheduled" as const,
+        reason,
+        errorCode: "adapter_reported_success" as const,
+        issueId: readNonEmptyString(parseObject(run.contextSnapshot).issueId),
+      };
+    }
     const maxAttempts = Math.max(0, Math.floor(opts?.maxAttempts ?? BOUNDED_TRANSIENT_HEARTBEAT_RETRY_MAX_ATTEMPTS));
     const nextAttempt = (run.scheduledRetryAttempt ?? 0) + 1;
     const computedBaseSchedule = opts?.delayMs != null
@@ -12895,7 +12931,13 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         outcome = latestRun.status;
       } else if (adapterResult.timedOut) {
         outcome = "timed_out";
-      } else if ((adapterResult.exitCode ?? 0) === 0 && !adapterResult.errorMessage) {
+      } else if (
+        !adapterResult.errorMessage &&
+        // Adapters that emit a structured result report success explicitly;
+        // trust it over the raw exit code so runs SIGTERMed by terminal-result
+        // cleanup after a successful result are not marked failed.
+        (adapterResult.succeeded === true || (adapterResult.exitCode ?? 0) === 0)
+      ) {
         outcome = "succeeded";
       } else {
         outcome = "failed";
@@ -13002,6 +13044,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
               resultJson: {
                 ...parseObject(adapterResult.resultJson),
                 configFreshness: configFreshnessResultMetadata,
+                ...(adapterResult.succeeded === true ? { adapterSucceeded: true } : {}),
               },
               errorFamily: adapterResult.errorFamily ?? null,
               retryNotBefore: adapterResult.retryNotBefore ?? null,


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The heartbeat scheduler runs each agent on an interval via provider adapters (claude-local here) and classifies every run's outcome to decide whether to retry
> - Runs that finish with a structured `subtype=success` result can still be marked failed and mis-coded `claude_transient_upstream` / `claude_auth_required`, because keyword classifiers scan the full stream-json stdout (including the agent's conversation) and the server infers failure from the raw exit code even when the CLI was SIGTERMed by cleanup after emitting a successful result
> - Every mis-coded run chains bounded `transient_failure` retries at full cost; on one production instance this produced 1,052 mis-coded runs in 14 days — the largest failed-bucket contributor — turning daily-interval agents into ~24 runs/day
> - This pull request restricts failure classification to structured results, stderr, and real API error signals, reports explicit adapter success, and refuses transient retries for structurally-successful runs
> - The benefit is that successful heartbeats are recorded as successes, retry storms stop, and genuine quota errors get reset-time-aware backoff instead of retry-now transient handling

## Linked Issues or Issue Description

Refs #5553 (same SIGTERM-after-success symptom in claude-local; this PR also covers classifier haystack contamination and the server-side retry guard), Refs #9288, Refs #4488 (adjacent quota/error-classification work), Refs #9294 (retry-storm guard).

**Describe the bug:** Successful Claude heartbeat runs (structured `subtype=success`, `is_error=false`) are marked `failed` with `error_code=claude_transient_upstream` or `claude_auth_required` whenever the agent's conversation text mentions rate limits, `/login`, retries, etc., or when the CLI exits nonzero after terminal-result cleanup (exit 143). Each such run schedules `scheduled_retry_reason=transient_failure` re-runs.

**Expected behavior:** A run whose adapter emitted a structured success result is recorded as succeeded and never retried as a transient failure. Only real API error signals (HTTP 429/503/529, connection errors, stderr, structured error text) drive transient/auth classification.

**Impact:** Measured over 14 days on one production instance: 1,052 mis-coded runs (980 transient + 72 auth) at full model cost; daily-interval agents re-ran ~24×/day.

## What Changed

- `adapter-claude-local`: with a structured result, classify failures only from the result's error text/structured errors + stderr — never conversation stdout; auth-required detection is failure-gated
- `adapter-claude-local`: without a structured result (timeout/CLI crash), strip stream-json event lines (`stripClaudeStreamEventLines`) from stdout before any keyword scan
- `adapter-claude-local`: emit explicit `succeeded: true` (new optional field on `AdapterExecutionResult`) for `subtype=success` / `is_error=false` results, so cleanup-kill exit codes no longer fail the run
- `parse`: classify `reached your … limit` / `/usage-credits` as `provider_quota`; `Connection closed mid-response` / ECONNRESET / ECONNREFUSED / ETIMEDOUT / socket hang up as transient
- `server`: run outcome trusts `adapterResult.succeeded === true` over the raw exit code; persists adapter-agnostic `adapterSucceeded` in `resultJson`
- `server`: `scheduleBoundedRetryForRun` refuses `transient_failure` retries for runs whose adapter reported structural success (checks `adapterSucceeded`, with raw Claude result fields as legacy fallback for pre-existing rows)
- The existing bounded retry cap (4 attempts, 2m/10m/30m/2h + jitter) is unchanged; the storm multiplier was per-wake mis-classification, which this removes

## Verification

- `npx vitest run src/server/parse.test.ts` in `packages/adapters/claude-local` — 39 passed
- `npx vitest run src/__tests__/claude-local-execute.test.ts src/__tests__/heartbeat-retry-scheduling.test.ts` in `server` — 57 passed
- `pnpm run typecheck` in `server` — clean
- New regression tests: successful run with rate-limit/auth conversation text + exit 143 → succeeded; failed run with conversation keywords → not transient/quota/auth; `/usage-credits` → `provider_quota`; connection-closed → transient; crashed stream with assistant keywords → not transient; structurally-successful run with `errorFamily=transient_upstream` schedules no retry
- Post-deploy: `SELECT error_code, count(*) FROM heartbeat_runs WHERE created_at > <deploy> GROUP BY 1` — the `claude_transient_upstream` count should collapse toward zero on affected agents

## Risks

- Behavioral shift: runs that previously (incorrectly) retried now finalize as succeeded — intended, but any dashboard keying on `claude_transient_upstream` volume will show a drop
- `succeeded` is optional and advisory when `false`/absent, so other adapters are unaffected until they opt in
- Legacy rows without `adapterSucceeded` fall back to raw Claude result fields; rows from other adapters keep existing behavior
- `codex-local` / `gemini-local` still feed full JSONL stdout into similar keyword classifiers and need the equivalent restriction (follow-up)

## Model Used

Claude Fable 5 (`claude-fable-5`), extended thinking enabled, agentic tool use via Claude Code CLI.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
