### PR TITLE
fix(recovery): stop assigned-todo liveness dispatch looping on dependency-blocked issues

### DIFF
--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -5171,6 +5171,112 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(runs).toHaveLength(0);
   });
 
+  it("normalizes a dependency-blocked assigned todo issue to blocked instead of looping the liveness dispatch", async () => {
+    const { companyId, agentId, issueId } = await seedAssignedTodoNoRunFixture();
+    const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+    const blockerIssueId = randomUUID();
+    await db.insert(issues).values({
+      id: blockerIssueId,
+      companyId,
+      title: "Parked blocker that will not resolve on its own",
+      status: "backlog",
+      priority: "medium",
+      responsibleUserId: "responsible-user",
+      issueNumber: 2,
+      identifier: `${issuePrefix}-2`,
+    });
+    await db.insert(issueRelations).values({
+      companyId,
+      issueId: blockerIssueId,
+      relatedIssueId: issueId,
+      type: "blocks",
+    });
+    const heartbeat = heartbeatService(db);
+
+    const first = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(first.dependencyBlockedNormalized).toBe(1);
+    expect(first.assignmentDispatched).toBe(0);
+    expect(first.dispatchRequeued).toBe(0);
+    expect(first.escalated).toBe(0);
+    expect(first.issueIds).toEqual([issueId]);
+
+    // No wake is enqueued for work that would only be skipped as
+    // issue_dependencies_blocked, and no run is spawned.
+    const wakeups = await db.select().from(agentWakeupRequests).where(eq(agentWakeupRequests.agentId, agentId));
+    expect(wakeups).toHaveLength(0);
+    const runs = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.agentId, agentId));
+    expect(runs).toHaveLength(0);
+
+    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(issue?.status).toBe("blocked");
+    // The existing blocker relation is preserved so issue_blockers_resolved can
+    // wake the issue when the blocker completes.
+    await expect(sourceBlockerIssueIds(companyId, issueId)).resolves.toEqual([blockerIssueId]);
+
+    const comments = await db.select().from(issueComments).where(eq(issueComments.issueId, issueId));
+    expect(comments).toHaveLength(1);
+    expect(comments[0]?.authorType).toBe("system");
+    expect(comments[0]?.body).toContain(`${issuePrefix}-2`);
+
+    // The normalized issue leaves the todo candidate set entirely: a second
+    // sweep neither re-normalizes nor enqueues a wake, so the fixed-cadence
+    // skip loop cannot restart.
+    const second = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(second.dependencyBlockedNormalized).toBe(0);
+    expect(second.assignmentDispatched).toBe(0);
+    expect(second.issueIds).toEqual([]);
+    await expect(
+      db.select().from(agentWakeupRequests).where(eq(agentWakeupRequests.agentId, agentId)),
+    ).resolves.toHaveLength(0);
+  });
+
+  it("still dispatches an assigned todo issue whose blockers are all done", async () => {
+    const { companyId, agentId, issueId } = await seedAssignedTodoNoRunFixture();
+    const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+    const blockerIssueId = randomUUID();
+    await db.insert(issues).values({
+      id: blockerIssueId,
+      companyId,
+      title: "Blocker that already finished",
+      status: "done",
+      priority: "medium",
+      responsibleUserId: "responsible-user",
+      issueNumber: 2,
+      identifier: `${issuePrefix}-2`,
+    });
+    await db.insert(issueRelations).values({
+      companyId,
+      issueId: blockerIssueId,
+      relatedIssueId: issueId,
+      type: "blocks",
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(result.dependencyBlockedNormalized).toBe(0);
+    expect(result.assignmentDispatched).toBe(1);
+    expect(result.issueIds).toEqual([issueId]);
+
+    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(issue?.status).toBe("todo");
+
+    const wakeups = await db.select().from(agentWakeupRequests).where(eq(agentWakeupRequests.agentId, agentId));
+    expect(wakeups).toHaveLength(1);
+    expect(wakeups[0]).toMatchObject({
+      reason: "issue_assigned",
+      payload: expect.objectContaining({
+        issueId,
+        mutation: "assigned_todo_liveness_dispatch",
+      }),
+    });
+
+    const runs = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.agentId, agentId));
+    expect(runs).toHaveLength(1);
+    if (runs[0]?.id) {
+      await waitForRunToSettle(heartbeat, runs[0].id);
+    }
+  });
+
   it("skips budget-blocked assigned todo work with no prior run and continues the sweep", async () => {
     const blocked = await seedAssignedTodoNoRunFixture();
     const unblocked = await seedAssignedTodoNoRunFixture();

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -3273,6 +3273,58 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     return existingUnresolvedBlockerIssues(companyId, issueId).then((rows) => rows.map((row) => row.id));
   }
 
+  // A `todo` issue with unresolved blockers can never be dispatched: every wake
+  // is skipped as `issue_dependencies_blocked` before it becomes a run, so the
+  // liveness sweep would re-enqueue it on the next pass and loop at the sweep
+  // cadence until the blocker resolves — indefinitely when the blocker is
+  // parked. Normalize the issue to `blocked` (its correct state) so it leaves
+  // the dispatch candidate set; the existing blocker relations are preserved and
+  // `issue_blockers_resolved` wakes it when the final blocker completes.
+  async function normalizeDependencyBlockedTodoIssue(
+    issue: typeof issues.$inferSelect,
+    unresolvedBlockerIssueIds: string[],
+  ) {
+    const updated = await issuesSvc.update(issue.id, { status: "blocked" });
+    if (!updated) return null;
+
+    const blockers = unresolvedBlockerIssueIds.length > 0
+      ? await db
+        .select({ id: issues.id, identifier: issues.identifier })
+        .from(issues)
+        .where(and(eq(issues.companyId, issue.companyId), inArray(issues.id, unresolvedBlockerIssueIds)))
+      : [];
+    const waitingOn = blockers.length > 0
+      ? formatIssueLinksForComment(blockers)
+      : "its unresolved blockers";
+    await issuesSvc.addComment(
+      issue.id,
+      `This task is waiting on ${waitingOn} to finish. ` +
+        "It will continue automatically when that work is done — there's nothing you need to do. " +
+        "(It was still marked `todo` while blocked, which kept the liveness dispatcher retrying " +
+        "and skipping it; Paperclip moved it to `blocked` so it waits quietly instead.)",
+      {},
+      { authorType: "system" },
+    );
+    await logActivity(db, {
+      companyId: issue.companyId,
+      actorType: "system",
+      actorId: "system",
+      agentId: null,
+      runId: null,
+      action: "issue.updated",
+      entityType: "issue",
+      entityId: issue.id,
+      details: {
+        identifier: issue.identifier,
+        status: "blocked",
+        previousStatus: issue.status,
+        source: "recovery.reconcile_dependency_blocked_todo",
+        unresolvedBlockerIssueIds,
+      },
+    });
+    return updated;
+  }
+
   async function openChildIssues(issue: typeof issues.$inferSelect) {
     return db
       .select({ id: issues.id, identifier: issues.identifier })
@@ -4694,6 +4746,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       productiveContinuationObserved: 0,
       successfulContinuationObserved: 0,
       orphanBlockersAssigned: 0,
+      dependencyBlockedNormalized: 0,
       successfulRunHandoffEscalated: 0,
       reviewParticipantRequeued: 0,
       escalated: 0,
@@ -5110,6 +5163,28 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       }
 
       if (issue.status === "todo") {
+        // Dispatcher guard: never enqueue a wake the heartbeat would only skip.
+        // This uses the same readiness check as the heartbeat's
+        // issue_dependencies_blocked skip path (including the
+        // workspace-finalize barrier) so the two can never disagree.
+        const dependencyReadiness = await issuesSvc.listDependencyReadiness(
+          issue.companyId,
+          [issue.id],
+        ).then((rows) => rows.get(issue.id) ?? null);
+        if (dependencyReadiness && !dependencyReadiness.isDependencyReady) {
+          const normalized = await normalizeDependencyBlockedTodoIssue(
+            issue,
+            dependencyReadiness.unresolvedBlockerIssueIds,
+          );
+          if (normalized) {
+            result.dependencyBlockedNormalized += 1;
+            result.issueIds.push(issue.id);
+          } else {
+            result.skipped += 1;
+          }
+          continue;
+        }
+
         if (!latestRun) {
           if (await hasQueuedIssueWake(issue.companyId, issue.id)) {
             result.skipped += 1;


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The heartbeat/recovery subsystem keeps assigned work live: `reconcileStrandedAssignedIssues()` sweeps assigned `todo` issues and (re)dispatches a liveness wake when no execution path exists
> - An issue can sit in status `todo` while it still has unresolved `blocks` relations — the sweep dispatches it, but the heartbeat wake path skips every such wake as `issue_dependencies_blocked` before it ever becomes a run
> - A skipped wake leaves no queued wake and no run behind, so the next sweep re-enqueues the same issue — a fixed-cadence loop that never terminates while the blocker is parked (e.g. `backlog`) or long-lived (`in_review`)
> - In one active org this produced ~52,900 skipped `issue_dependencies_blocked` wake rows in 7 days (~8/min, 24/7) from just four blocked-but-`todo` issues — no model-token cost, but a perpetual DB/queue write stream
> - This pull request makes the dispatcher enforce the state invariant instead: a `todo` candidate that is not dependency-ready is normalized to `blocked` (its correct state) rather than dispatched
> - The benefit is that one stuck issue can no longer generate an unbounded skipped-wakeup stream, and blocked-but-`todo` issues self-heal into the state where `issue_blockers_resolved` wakes them automatically

## Linked Issues or Issue Description

No existing issue describes this exact loop; related reports and in-flight work, for context (none of them normalize blocked-but-`todo` state at the dispatcher):

- Refs #9208 — same sweep generating guaranteed-no-op wakes for a different skip reason (daily run cap)
- Refs #8102 — coalesces repeated `issue_dependencies_blocked` wakeups (complementary churn reduction for issues that legitimately reach the skip path)
- Refs #8104 — suppresses adapter auto-retry for issues already in `blocked` with unresolved blockers

**Bug report (no pre-existing issue):**

- **What happened:** `agent_wakeup_requests` rows with `reason=issue_dependencies_blocked`, `status=skipped` accumulate at a fixed rate (~8/min sustained, ~52.9k over 7 days in one org) for assigned issues that are `status=todo` but have unresolved `blocks` relations. Payload sample: `{"mutation":"assigned_todo_liveness_dispatch","issueId":"…","unresolvedBlockerIssueIds":["…"]}`.
- **Expected behavior:** work that cannot dispatch because of unresolved blockers should not be re-enqueued every sweep; a blocked issue should wait quietly until `issue_blockers_resolved` wakes it.
- **Steps to reproduce:** create issue A (assigned, `todo`) blocked by issue B (`backlog`); let the recovery sweep run. Every pass enqueues a liveness wake for A that the heartbeat immediately records as a skipped `issue_dependencies_blocked` row, forever. The new test `normalizes a dependency-blocked assigned todo issue to blocked instead of looping the liveness dispatch` is a minimal reproduction: on master its second-sweep assertions fail (the sweep re-dispatches every pass); with this fix the issue leaves the candidate set after one pass.
- **Version/commit:** reproduced on master at `90f85a7d1`; also observed in production on `@paperclipai/server` 2026.6xx.
- **Deployment mode:** self-hosted local server.

## What Changed

- `server/src/services/recovery/service.ts`
  - `reconcileStrandedAssignedIssues()`: before dispatching a `todo` candidate, resolve its dependency readiness via `issuesSvc.listDependencyReadiness` — the exact same check (including the workspace-finalize barrier) the heartbeat skip path uses, so dispatcher and heartbeat can never disagree about readiness.
  - New `normalizeDependencyBlockedTodoIssue()`: transitions the not-ready `todo` issue to `blocked` (status-only update; existing `blocks` relations are deliberately left untouched so `issue_blockers_resolved` wakes it exactly as before), posts a system comment naming the blockers it is waiting on, and writes an `issue.updated` activity entry with `source: "recovery.reconcile_dependency_blocked_todo"`.
  - New `dependencyBlockedNormalized` counter in the sweep result.
- `server/src/__tests__/heartbeat-process-recovery.test.ts`
  - Reproduction/regression test: a dependency-blocked assigned `todo` issue is normalized to `blocked` with no wake and no run; a second sweep is a no-op (the loop cannot restart); the blocker relation and a single system comment are asserted.
  - Guard-scope test: a `todo` issue whose blockers are all `done` still dispatches normally.

## Verification

- `node_modules/.bin/vitest run server/src/__tests__/heartbeat-process-recovery.test.ts` — 86/86 pass (embedded Postgres), including the two new tests.
- New reproduction test fails on master without the service change (sweep result has no normalization and the issue is re-dispatched every pass) and passes with it.
- `pnpm --filter @paperclipai/server typecheck` — clean.
- Production-side verification query for anyone hitting this: `SELECT date_trunc('minute', created_at), count(*) FROM agent_wakeup_requests WHERE reason='issue_dependencies_blocked' GROUP BY 1 ORDER BY 1 DESC` — after the fix the fixed-rate stream from blocked-but-`todo` issues drops to zero (transient one-off skips from other wake sources remain, as intended).

## Risks

- Behavioral shift: assigned `todo` issues with unresolved blockers are now auto-moved to `blocked` by the recovery sweep. This is the state the rest of the system already assumes (dependents are woken by `issue_blockers_resolved`, which targets non-`backlog`/`done`/`cancelled` dependents, so `blocked` issues are woken exactly like `todo` ones would be). Boards that relied on manually holding a blocked issue in `todo` will see it re-labeled `blocked`, with a system comment explaining why.
- The transition is status-only — no `blockedByIssueIds` rewrite — so no `blocks` relations are added or removed.
- One extra readiness query per `todo` candidate per sweep; in line with the per-candidate queries the sweep already performs, and it replaces an enqueue + skipped-row write loop that ran indefinitely.
- Scope note: this intentionally does not add generic backoff for *transient* skipped wakes from other wake sources — #8102 covers coalescing those; this PR removes the one generator that was unbounded.

## Model Used

- Claude Fable 5 (Anthropic, model ID `claude-fable-5`), extended thinking enabled, agentic tool use (Claude Code CLI); TDD workflow — reproduction test written and confirmed failing before the fix.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes (no docs describe this internal sweep; comments added in-code)
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green (will confirm once CI runs on this PR)
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups (will address once it reviews)
- [x] I will address all Greptile and reviewer comments before requesting merge
