### PR TITLE
Fix Hermes issue workspace and released execution locks

### DIFF
--- a/packages/adapters/hermes/src/server/execute.onspawn.test.ts
+++ b/packages/adapters/hermes/src/server/execute.onspawn.test.ts
@@ -41,7 +41,10 @@ vi.mock("node:fs/promises", () => ({
 import { execute } from "./execute.js";
 import * as serverUtils from "@paperclipai/adapter-utils/server-utils";
 
-function makeCtx(overrides: Record<string, unknown> = {}) {
+function makeCtx(
+  overrides: Record<string, unknown> = {},
+  contextOverrides: Record<string, unknown> = {},
+) {
   const onSpawn = vi.fn(async () => undefined);
   return {
     ctx: {
@@ -69,6 +72,7 @@ function makeCtx(overrides: Record<string, unknown> = {}) {
         issueId: "issue-1",
         wakeReason: "manual",
         paperclipWake: null,
+        ...contextOverrides,
       },
       onLog: vi.fn(async () => undefined),
       onMeta: vi.fn(async () => undefined),
@@ -117,5 +121,56 @@ describe("hermes-local adapter onSpawn forwarding", () => {
       onSpawn: async () => undefined,
     };
     expect(opts.onSpawn).toBeDefined();
+  });
+
+  it("runs from the realized issue workspace before configured cwd fallbacks", async () => {
+    const issueWorkspace = "/tmp/paperclip-issue-workspace";
+    const { ctx } = makeCtx(
+      { cwd: "/tmp/configured-cwd" },
+      {
+        paperclipWorkspace: {
+          cwd: issueWorkspace,
+          source: "task_session",
+          agentHome: "/tmp/agent-home",
+        },
+      },
+    );
+
+    await execute(ctx as any);
+
+    const mocked = vi.mocked(serverUtils.runChildProcess);
+    const opts = mocked.mock.calls.at(-1)?.[3] as Record<string, unknown>;
+    expect(opts.cwd).toBe(issueWorkspace);
+  });
+
+  it("keeps configured cwd precedence over the generic agent-home workspace", async () => {
+    const configuredCwd = "/tmp/configured-cwd";
+    const { ctx } = makeCtx(
+      { cwd: configuredCwd },
+      {
+        paperclipWorkspace: {
+          cwd: "/tmp/agent-home",
+          source: "agent_home",
+          agentHome: "/tmp/agent-home",
+        },
+      },
+    );
+
+    await execute(ctx as any);
+
+    const mocked = vi.mocked(serverUtils.runChildProcess);
+    const opts = mocked.mock.calls.at(-1)?.[3] as Record<string, unknown>;
+    expect(opts.cwd).toBe(configuredCwd);
+  });
+
+  it("preserves workspaceDir as the legacy cwd fallback", async () => {
+    const workspaceDir = "/tmp/legacy-workspace-dir";
+    const { ctx } = makeCtx({ workspaceDir });
+
+    await execute(ctx as any);
+
+    const mocked = vi.mocked(serverUtils.runChildProcess);
+    const opts = mocked.mock.calls.at(-1)?.[3] as Record<string, unknown>;
+    expect(opts.cwd).toBe(workspaceDir);
   });
 });

--- a/packages/adapters/hermes/src/server/execute.ts
+++ b/packages/adapters/hermes/src/server/execute.ts
@@ -477,8 +477,18 @@ export async function execute(
   if (wakePayloadJson) env.PAPERCLIP_WAKE_PAYLOAD_JSON = wakePayloadJson;
 
   // ── Resolve working directory ──────────────────────────────────────────
-  const cwd =
-    cfgString(config.cwd) || cfgString(ctx.config?.workspaceDir) || ".";
+  const workspaceContext =
+    ctxContext.paperclipWorkspace && typeof ctxContext.paperclipWorkspace === "object"
+      ? ctxContext.paperclipWorkspace as Record<string, unknown>
+      : {};
+  const workspaceCwd = cfgString(workspaceContext.cwd);
+  const workspaceSource = cfgString(workspaceContext.source);
+  const agentHome = cfgString(workspaceContext.agentHome);
+  const configuredCwd = cfgString(config.cwd) || cfgString(ctx.config?.workspaceDir);
+  const effectiveWorkspaceCwd = workspaceSource === "agent_home" && configuredCwd
+    ? undefined
+    : workspaceCwd;
+  const cwd = effectiveWorkspaceCwd || configuredCwd || agentHome || ".";
   try {
     await ensureAbsoluteDirectory(cwd);
   } catch {

--- a/server/src/__tests__/heartbeat-lock-release-on-reassignment.test.ts
+++ b/server/src/__tests__/heartbeat-lock-release-on-reassignment.test.ts
@@ -74,7 +74,7 @@ describeEmbeddedPostgres("heartbeat lock release on cross-agent reassignment", (
         status: "idle",
         adapterType: "process",
         adapterConfig: {},
-        runtimeConfig: {},
+        runtimeConfig: { heartbeat: { maxConcurrentRuns: 1 } },
         permissions: {},
       },
       {
@@ -85,7 +85,7 @@ describeEmbeddedPostgres("heartbeat lock release on cross-agent reassignment", (
         status: "idle",
         adapterType: "process",
         adapterConfig: {},
-        runtimeConfig: {},
+        runtimeConfig: { heartbeat: { maxConcurrentRuns: 1 } },
         permissions: {},
       },
     ]);
@@ -116,6 +116,7 @@ describeEmbeddedPostgres("heartbeat lock release on cross-agent reassignment", (
       status: "in_review",
       priority: "medium",
       assigneeAgentId: reviewerAgentId,
+      responsibleUserId: "local-board",
       executionRunId: holderRunId,
       executionAgentNameKey: "coder",
       executionLockedAt: new Date(),
@@ -194,6 +195,106 @@ describeEmbeddedPostgres("heartbeat lock release on cross-agent reassignment", (
       .then((rows) => rows[0] ?? null);
 
     expect(issue?.executionRunId).toBe(holderRunId);
+  });
+
+  it("does not restore a released foreign run pointer when the assignee is re-woken", async () => {
+    const { companyId, coderAgentId, reviewerAgentId, issueId, holderRunId } =
+      await seedCrossAgentScenario({ holderStatus: "running" });
+
+    // Model an operator force-release after workspace configuration changes:
+    // the foreign recovery run is still alive, but it no longer owns this issue.
+    await db
+      .update(issues)
+      .set({
+        executionRunId: null,
+        executionAgentNameKey: null,
+        executionLockedAt: null,
+        updatedAt: new Date(),
+      })
+      .where(eq(issues.id, issueId));
+
+    // Keep the reviewer at its concurrency limit so this test observes the
+    // queued run deterministically without launching an adapter subprocess.
+    await db.insert(heartbeatRuns).values({
+      id: randomUUID(),
+      companyId,
+      agentId: reviewerAgentId,
+      invocationSource: "automation",
+      triggerDetail: "system",
+      status: "running",
+      responsibleUserId: "local-board",
+      contextSnapshot: { wakeReason: "test_concurrency_holder" },
+    });
+
+    const heartbeat = heartbeatService(db);
+    const freshRun = await heartbeat.wakeup(reviewerAgentId, {
+      source: "assignment",
+      triggerDetail: "system",
+      reason: "issue_assigned",
+      payload: { issueId },
+      contextSnapshot: { issueId, taskId: issueId, wakeReason: "issue_assigned" },
+      requestedByActorType: "user",
+      requestedByActorId: "local-board",
+    });
+
+    expect(freshRun).not.toBeNull();
+    expect(freshRun?.id).not.toBe(holderRunId);
+    expect(freshRun?.agentId).toBe(reviewerAgentId);
+    expect(freshRun?.status).toBe("queued");
+
+    const holder = await db
+      .select({ status: heartbeatRuns.status, agentId: heartbeatRuns.agentId })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, holderRunId))
+      .then((rows) => rows[0] ?? null);
+    expect(holder).toEqual({ status: "running", agentId: coderAgentId });
+
+    const issue = await db
+      .select({ executionRunId: issues.executionRunId })
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+    expect(issue?.executionRunId).not.toBe(holderRunId);
+  });
+
+  it("does not let the former owner reclaim a released run pointer on a later wake", async () => {
+    const { coderAgentId, issueId, holderRunId } =
+      await seedCrossAgentScenario({ holderStatus: "running" });
+
+    await db
+      .update(issues)
+      .set({
+        executionRunId: null,
+        executionAgentNameKey: null,
+        executionLockedAt: null,
+        updatedAt: new Date(),
+      })
+      .where(eq(issues.id, issueId));
+
+    const heartbeat = heartbeatService(db);
+    await heartbeat.wakeup(coderAgentId, {
+      source: "automation",
+      triggerDetail: "system",
+      reason: "manual",
+      payload: { issueId },
+      contextSnapshot: { issueId, taskId: issueId, wakeReason: "manual" },
+      requestedByActorType: "system",
+      requestedByActorId: "test",
+    });
+
+    const issue = await db
+      .select({ executionRunId: issues.executionRunId })
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+    expect(issue?.executionRunId).toBeNull();
+
+    const holder = await db
+      .select({ status: heartbeatRuns.status })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, holderRunId))
+      .then((rows) => rows[0] ?? null);
+    expect(holder?.status).toBe("running");
   });
 
   // Race-guard regression: the cancel UPDATE for the queued holder is pinned

--- a/server/src/__tests__/heartbeat-lock-release-on-reassignment.test.ts
+++ b/server/src/__tests__/heartbeat-lock-release-on-reassignment.test.ts
@@ -297,6 +297,64 @@ describeEmbeddedPostgres("heartbeat lock release on cross-agent reassignment", (
     expect(holder?.status).toBe("running");
   });
 
+  it("keeps a repeated same-owner queued wake lock-free until claim", async () => {
+    const { companyId, reviewerAgentId, issueId } =
+      await seedCrossAgentScenario({ holderStatus: "running" });
+
+    await db
+      .update(issues)
+      .set({
+        executionRunId: null,
+        executionAgentNameKey: null,
+        executionLockedAt: null,
+        updatedAt: new Date(),
+      })
+      .where(eq(issues.id, issueId));
+
+    // Saturate the current assignee so both wakes observe the issue run while
+    // it is still queued and therefore must not own the execution lock.
+    await db.insert(heartbeatRuns).values({
+      id: randomUUID(),
+      companyId,
+      agentId: reviewerAgentId,
+      invocationSource: "automation",
+      triggerDetail: "system",
+      status: "running",
+      responsibleUserId: "local-board",
+      contextSnapshot: { wakeReason: "test_concurrency_holder" },
+    });
+
+    const heartbeat = heartbeatService(db);
+    const wakeOptions = {
+      source: "assignment" as const,
+      triggerDetail: "system" as const,
+      reason: "issue_assigned",
+      payload: { issueId },
+      contextSnapshot: { issueId, taskId: issueId, wakeReason: "issue_assigned" },
+      requestedByActorType: "user" as const,
+      requestedByActorId: "local-board",
+    };
+
+    const queuedRun = await heartbeat.wakeup(reviewerAgentId, wakeOptions);
+    expect(queuedRun?.status).toBe("queued");
+
+    await heartbeat.wakeup(reviewerAgentId, wakeOptions);
+
+    const issue = await db
+      .select({ executionRunId: issues.executionRunId })
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+    expect(issue?.executionRunId).toBeNull();
+
+    const stillQueued = await db
+      .select({ status: heartbeatRuns.status })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, queuedRun!.id))
+      .then((rows) => rows[0] ?? null);
+    expect(stillQueued?.status).toBe("queued");
+  });
+
   // Race-guard regression: the cancel UPDATE for the queued holder is pinned
   // to the exact non-running status that was read just above it. If a worker
   // races in and flips the holder from `queued` → `running` between that

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -14846,22 +14846,28 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         }
 
         if (!activeExecutionRun) {
-          const legacyRun = await tx
-            .select()
-            .from(heartbeatRuns)
-            .where(
-              and(
-                eq(heartbeatRuns.companyId, issue.companyId),
-                inArray(heartbeatRuns.status, [...EXECUTION_PATH_HEARTBEAT_RUN_STATUSES]),
-                sql`${heartbeatRuns.contextSnapshot} ->> 'issueId' = ${issue.id}`,
-              ),
-            )
-            .orderBy(
-              sql`case when ${heartbeatRuns.status} = 'running' then 0 else 1 end`,
-              asc(heartbeatRuns.createdAt),
-            )
-            .limit(1)
-            .then((rows) => rows[0] ?? null);
+          // Only recover an unstamped legacy run for the agent being woken.
+          // After an operator releases a stale pointer or reassigns an issue,
+          // a still-live run from the former owner must not reclaim the issue.
+          const legacyRun = issue.assigneeAgentId === agentId
+            ? await tx
+              .select()
+              .from(heartbeatRuns)
+              .where(
+                and(
+                  eq(heartbeatRuns.companyId, issue.companyId),
+                  eq(heartbeatRuns.agentId, issue.assigneeAgentId),
+                  inArray(heartbeatRuns.status, [...EXECUTION_PATH_HEARTBEAT_RUN_STATUSES]),
+                  sql`${heartbeatRuns.contextSnapshot} ->> 'issueId' = ${issue.id}`,
+                ),
+              )
+              .orderBy(
+                sql`case when ${heartbeatRuns.status} = 'running' then 0 else 1 end`,
+                asc(heartbeatRuns.createdAt),
+              )
+              .limit(1)
+              .then((rows) => rows[0] ?? null)
+            : null;
 
           if (legacyRun) {
             if (await cancelStaleScheduledRetry(legacyRun)) {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -14846,7 +14846,9 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         }
 
         if (!activeExecutionRun) {
-          // Only recover an unstamped legacy run for the agent being woken.
+          // Only recover an unstamped lock-owning run for the agent being woken.
+          // Lazy queued runs do not own the issue lock until claimQueuedRun()
+          // transitions them to running, so repeated wakes must not stamp them.
           // After an operator releases a stale pointer or reassigns an issue,
           // a still-live run from the former owner must not reclaim the issue.
           const legacyRun = issue.assigneeAgentId === agentId
@@ -14857,7 +14859,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
                 and(
                   eq(heartbeatRuns.companyId, issue.companyId),
                   eq(heartbeatRuns.agentId, issue.assigneeAgentId),
-                  inArray(heartbeatRuns.status, [...EXECUTION_PATH_HEARTBEAT_RUN_STATUSES]),
+                  inArray(heartbeatRuns.status, ["running", "scheduled_retry"]),
                   sql`${heartbeatRuns.contextSnapshot} ->> 'issueId' = ${issue.id}`,
                 ),
               )


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source control plane people use to manage AI agents and their work
> - Reliable execution depends on launching each adapter inside the workspace realized for the assigned issue
> - The Hermes adapter skipped the run context workspace and fell back to static configuration or the server directory
> - Execution liveness also depends on a released run lock staying released when issue ownership changes
> - Legacy-run recovery could restore a former assignee run after an operator release and suppress the rightful assignee wake
> - This pull request aligns Hermes workspace precedence with other local adapters and scopes legacy-run recovery to the current assignee
> - The benefit is deterministic repository-backed Hermes launches without weakening workspace isolation or live same-owner recovery

## Linked Issues or Issue Description

No matching public issue was found, so the underlying bug is described inline.

### Pre-submission checklist

- [x] I searched open and closed issues and pull requests for duplicate Hermes workspace/run-lock fixes.
- [x] I reproduced the behavior on current `master` source and the latest local canary package.
- [x] I confirmed both defects originate in Paperclip adapter/control-plane code rather than provider configuration.

### What happened?

An issue-scoped Hermes run received a valid realized workspace in `context.paperclipWorkspace.cwd`, but the adapter ignored it and launched from static `cwd`, legacy `workspaceDir`, or `.`. Separately, after an operator released an issue execution pointer during reassignment/configuration repair, legacy-run recovery could rediscover an active run owned by the former assignee, repopulate `executionRunId`, and defer the current assignee wake.

### Expected behavior

Hermes should prefer a realized non-`agent_home` issue workspace, while preserving configured cwd precedence for generic agent-home launches. Once a foreign/former-owner pointer is released, only a legacy run belonging to the current assignee may be recovered.

### Steps to reproduce

1. Realize an isolated issue workspace and pass its cwd in the Hermes run context while the agent also has a configured cwd.
2. Launch Hermes and observe that the configured cwd is used instead of the issue workspace.
3. Assign an issue to a new agent while a former-owner run with the same issue context remains active, then clear the issue execution pointer.
4. Wake the current assignee or former owner and observe legacy recovery restoring the foreign run pointer or deferring the rightful wake.

### Environment

- Paperclip source: `90f85a7d11c517b1d09db90dbec97f4de7d96b83` (base), local canary package `0.3.1`
- Deployment: local self-hosted control plane
- Installation: npm/pnpm global package plus source checkout for the fix
- Adapters: Hermes and core heartbeat execution
- Database: external Postgres
- Access context: board release plus agent wake
- Node.js: `v25.8.1`
- Operating system: macOS 26.5.1, Apple Silicon
- Sensitive logs/config: not included; regression tests encode the redacted failure shape
- [x] I reviewed this description for secrets, credentials, private paths, and other sensitive data.

## What Changed

- Resolve Hermes cwd from a realized non-`agent_home` `paperclipWorkspace` before configured and generic fallbacks.
- Preserve configured `cwd`/legacy `workspaceDir` precedence for `agent_home` launches.
- Restrict unstamped legacy-run recovery to runs owned by the issue current assignee and only when that assignee is being woken.
- Add regressions for issue workspace precedence, legacy fallback compatibility, current-assignee re-wake, and former-owner reclaim attempts.

## Verification

- `pnpm --filter @paperclipai/hermes-paperclip-adapter test -- src/server/execute.onspawn.test.ts` — 5/5 passed.
- `pnpm --filter @paperclipai/hermes-paperclip-adapter typecheck` — passed.
- `pnpm exec vitest run server/src/__tests__/heartbeat-lock-release-on-reassignment.test.ts server/src/__tests__/issue-stale-execution-lock-routes.test.ts` — 11/11 passed.
- `pnpm --filter @paperclipai/server typecheck` — passed.
- Independent Codex source review found one pre-push ownership gap; it was fixed, covered by an inverse regression, and the re-review reported no remaining findings.

## Risks

Low and bounded. The cwd change only affects Hermes launches that carry a realized workspace and retains legacy/configured fallbacks. The lock change narrows heuristic legacy recovery to the current owner; explicit pointers, running same-owner recovery, claim-time ownership checks, authorization, workspace isolation, and cleanup paths are unchanged. No schema migration or documentation-facing contract change is required. Live canary verification is still required after merge/release/install.

## Model Used

OpenAI Codex `gpt-5.6-sol` with high-reasoning mode, repository/tool access, test execution, and an independent Codex review pass. Context window size was not surfaced by the runtime.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links
- [x] My branch name describes the change and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run focused tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation, or confirmed no user-facing documentation change is required
- [x] I have considered and documented risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

