### PR TITLE
feat(server): delivery attestation schema + workspace_delivery terminal-transition gate

### DIFF
--- a/doc/execution-semantics.md
+++ b/doc/execution-semantics.md
@@ -374,6 +374,250 @@ Workspace incoherence feeds into the same non-terminal liveness and stranded ass
 
 For runtime-created `git_worktree` execution workspaces, branch coherence is part of workspace coherence. The persisted execution workspace branch is the recorded branch for future dispatch. Reusing that workspace must verify that the worktree is still registered and that `HEAD` is on the recorded branch. Successful run finalization must perform the same check before recording `workspace_finalize=succeeded`. If the run switched to a publishing/PR branch without updating the execution workspace record, finalization may auto-restore the recorded branch only when the worktree is clean, still registered, and the recorded branch points at the current `HEAD`; the repair is recorded as a workspace operation before the successful finalize row. If that safe repair cannot be proven, finalization records a failed workspace finalize and the run fails with bounded evidence for the expected and actual branch. A branch change is sanctioned when a control-plane path updates the execution workspace record before finalization, when publishing work happens in a separate worktree and the managed issue worktree remains on its recorded branch, or when the finalizer performs this clean same-commit restoration.
 
+### Authoritative workspace intent and completion attestation
+
+Workspace coherence answers whether Paperclip can invoke an adapter in the workspace it selected. Authoritative workspace intent answers a different question: whether that workspace is the declared place from which the requested outcome may be delivered. A coherent temporary directory, accumulated `project_primary` folder, or valid Git repository is not authoritative merely because issue prose names a path inside it.
+
+Paperclip must keep these objects distinct:
+
+1. **target declaration**: board/project configuration that says what kind of outcome this workspace may authoritatively deliver
+2. **workspace realization**: the concrete local or provider-managed workspace selected for a run
+3. **resolved target snapshot**: the immutable, provider-resolved target identity captured before dispatch
+4. **completion attestation**: provider-generated evidence that the resolved target received the declared delivery
+
+Issue titles, descriptions, comments, prompts, command output, and agent-supplied paths may explain intent or support review. They must not create, replace, or change any of these four objects. In particular, Paperclip must not infer an authoritative repository or remote checkout from an absolute path or repository name mentioned in prose.
+
+#### Declared target kinds
+
+Version 1 supports exactly three target kinds:
+
+##### `repository_checkout`
+
+Use this when completion means changing a registered source repository.
+
+The declaration includes:
+
+- a registered `projectWorkspaceId` and owning `projectId`
+- a credential-free canonical repository locator and its `repositoryFingerprint`
+- an expected ref or ref policy
+- the provider-resolved checkout root
+- a delivery method: `commit`, `push`, `pull_request`, `controlled_sync`, or `none`
+- whether successful workspace delivery is required before `done`
+
+`none` is valid for investigation or read-only work, but cannot satisfy a `workspace_delivery` completion requirement. A `project_primary` folder whose repository locator is null is not a repository checkout, even when the folder happens to contain a `.git` directory or repository-like files.
+
+Before dispatch, the provider must prove that the realized cwd resolves to the declared repository root, that its credential-free remote fingerprint equals the declaration, and that required ref/base metadata is resolvable. For Git worktrees it must also prove that the worktree remains registered and belongs to that repository.
+
+##### `remote_operator_checkout`
+
+Use this when the authoritative files live behind a registered environment/provider, including an operator-managed server checkout or a provider-owned remote workspace.
+
+The declaration includes:
+
+- a registered `environmentId` and provider key
+- a provider-owned private target reference that resolves to one absolute remote target path
+- a privacy-safe `targetFingerprint` and non-secret display label
+- an execution/delivery method: `remote_exec`, `provider_sync`, `operator_handoff`, or `controlled_sync`
+- whether successful workspace delivery is required before `done`
+
+The adapter must receive the exact provider-resolved target through the provider boundary. Copying the remote path into issue prose or asking an agent to `cd` there does not establish authority. `operator_handoff` may leave the issue in review or waiting for an operator confirmation; it does not itself attest delivery.
+
+##### `artifact_only`
+
+Use this for research, planning support, generated reports, images, exports, and other work whose authoritative output is an issue document, attachment, or work product rather than a repository or remote checkout.
+
+The declaration includes the allowed output classes (`issue_document`, `attachment`, and/or `work_product`) and whether at least one durable artifact is required. It does not require Git or a remote path. It may run in a managed `project_primary`, task-session, agent-home, or provider workspace as long as the normal coherence and security rules pass.
+
+An artifact-only run cannot satisfy a code, infrastructure, deployment, repository, or remote-checkout completion claim. If the requested outcome changes into one of those delivery classes, the issue's completion requirement and target declaration must be changed before another dispatch.
+
+#### Issue completion requirement
+
+Target capability and issue completion are separate declarations. Each issue has one versioned completion requirement:
+
+- `evidence_only`: no workspace delivery is claimed; comments/tests may be sufficient under the ordinary issue contract
+- `artifact`: terminal completion requires the declared durable artifact output
+- `workspace_delivery`: terminal completion requires a successful provider-generated delivery attestation for the resolved repository or remote target
+- `legacy_unspecified`: compatibility state for pre-migration issues only
+
+Project configuration may provide the default for newly created issues. An issue may select a narrower or stricter requirement, but an agent may not change an issue from `workspace_delivery` to a weaker requirement during the run that attempts completion. Weakening the requirement or substituting the authoritative target is a board/project-configuration mutation and is recorded in activity.
+
+New project-scoped issues must persist a concrete requirement at creation; the server must not derive it by scanning prose. A create request that omits the field uses the project's explicit default. If neither exists, it uses `evidence_only` only for an explicitly `artifact_only`/non-delivery project; otherwise it is configuration-incomplete before dispatch.
+
+#### Pre-dispatch validity
+
+Before an adapter run is dispatched, Paperclip resolves the effective declaration in this order:
+
+1. issue target override, when board-authorized and present
+2. selected project workspace target declaration
+3. project default target declaration
+
+Resolution is valid only when:
+
+- the declaration, issue, project, workspace, environment, and provider are in the same company
+- the declaration revision is current and enabled
+- the target kind can satisfy the issue completion requirement
+- the selected workspace can be realized by the declared provider
+- required repository/ref or remote-target fields resolve without ambiguity
+- the provider-derived target fingerprint matches the declaration
+- no credential-bearing locator, userinfo, token, signed query, or secret remote path is copied into public run context
+
+For `workspace_delivery`, a missing, ambiguous, disabled, cross-company, or mismatched target is a pre-dispatch `configuration_incomplete` gate. Paperclip must atomically leave the source issue `blocked` and upsert one source-scoped recovery action with:
+
+- kind `configuration_incomplete`
+- fingerprint `workspace_target:<issueId>:<completionRequirementRevision>:<effectiveTargetRevision-or-missing>`
+- owner: project lead when active/invokable, otherwise a board operator
+- next action: select, repair, or authorize the named project/issue target
+- wake policy `on_workspace_target_change`
+
+No adapter run is created. Reconciliation must not retry the gate while the fingerprint is unchanged. A target/requirement update revalidates the configuration, resolves the old recovery action, and queues at most one normal-model wake for the existing assignee when the issue can resume. This is the single waiting/recovery path for missing workspace intent; implementations must not also create a duplicate recovery issue or periodic retry.
+
+`artifact` and `evidence_only` work remain productive in an explicitly `artifact_only` target. Normal workspace coherence, secret binding, budget, approval, and ownership gates still apply.
+
+#### Durable target and attestation schema
+
+The implementation may normalize these records into tables or initially store the declarations in the existing project/issue JSON policy columns, but the API and durable uniqueness constraints must expose the following logical schema.
+
+`WorkspaceTargetDeclarationV1`:
+
+```ts
+type WorkspaceTargetDeclarationV1 = {
+  version: 1;
+  id: string;
+  companyId: string;
+  projectId: string | null;
+  projectWorkspaceId: string | null;
+  kind: "repository_checkout" | "remote_operator_checkout" | "artifact_only";
+  revision: number;
+  enabled: boolean;
+  deliveryRequired: boolean;
+  providerKey: string;
+  repositoryFingerprint: string | null;
+  targetFingerprint: string;
+  displayLabel: string;
+  privateTargetRef: string | null;
+  expectedRef: string | null;
+  deliveryMethod:
+    | "commit" | "push" | "pull_request"
+    | "remote_exec" | "provider_sync" | "operator_handoff"
+    | "controlled_sync" | "none";
+  artifactClasses: Array<"issue_document" | "attachment" | "work_product">;
+};
+```
+
+Issues persist `completionRequirement`, `completionRequirementRevision`, and optional `workspaceTargetDeclarationId`. Projects persist the default requirement and default declaration id. Existing workspace ids remain realization selectors; they do not double as target declarations.
+
+Each dispatched run persists an immutable `resolvedWorkspaceTarget` snapshot in durable run context:
+
+```ts
+type ResolvedWorkspaceTargetV1 = {
+  version: 1;
+  declarationId: string;
+  declarationRevision: number;
+  kind: WorkspaceTargetDeclarationV1["kind"];
+  providerKey: string;
+  targetFingerprint: string;
+  repositoryFingerprint: string | null;
+  projectId: string | null;
+  projectWorkspaceId: string | null;
+  executionWorkspaceId: string | null;
+  checkoutRootFingerprint: string | null;
+  resolvedRef: string | null;
+  deliveryMethod: WorkspaceTargetDeclarationV1["deliveryMethod"];
+  resolvedAt: string;
+};
+```
+
+The provider writes append-only completion attestations. The minimum logical fields are:
+
+```ts
+type DeliveryAttestationV1 = {
+  version: 1;
+  id: string;
+  companyId: string;
+  issueId: string;
+  runId: string;
+  declarationId: string;
+  declarationRevision: number;
+  targetKind: WorkspaceTargetDeclarationV1["kind"];
+  targetFingerprint: string;
+  providerKey: string;
+  outcome: "succeeded" | "failed" | "not_attempted" | "operator_confirmation_required";
+  deliveryMethod: WorkspaceTargetDeclarationV1["deliveryMethod"];
+  sourceRevision: string | null;
+  deliveredRevision: string | null;
+  destinationRefFingerprint: string | null;
+  workspaceDirty: boolean | null;
+  operationId: string | null;
+  artifactIds: string[];
+  generatedAt: string;
+  providerSignature: string;
+};
+```
+
+The storage layer enforces one provider attestation per `(runId, declarationId, declarationRevision, deliveryMethod, operationId)` after normalizing null operation ids. Attestations are append-only; a retry or later delivery produces a new row rather than rewriting failed evidence. `providerSignature` is a server/provider authenticity value, not an agent-supplied string.
+
+#### Privacy-safe fingerprints
+
+Repository locators are canonicalized after credentials, URL userinfo, query parameters, and fragments are removed. Remote target paths and provider workspace references are secret-adjacent and are not returned in agent-readable issue/run/activity APIs.
+
+`repositoryFingerprint`, `targetFingerprint`, `checkoutRootFingerprint`, and destination fingerprints use versioned keyed hashing:
+
+```text
+v1:hmac-sha256(instance_attestation_key, companyId + "\n" + providerKey + "\n" + canonicalLocator)
+```
+
+The company id prevents cross-company correlation. The server may return the fingerprint, provider key, target kind, and a board-authored non-secret display label. It must redact `privateTargetRef`, raw remote absolute paths, credential-bearing remotes, and the HMAC key. Board-only configuration reads may resolve a redacted path hint through the provider, but ordinary agent, comment, activity, wake, and attestation projections must not expose it.
+
+#### Provider-generated evidence
+
+Attestation is generated from provider/workspace inspection, not from agent request fields or prose:
+
+- repository providers read the declared remote, root, ref, before/after revision, worktree state, and delivery operation result directly
+- remote providers resolve the private target reference, bind the operation to its target fingerprint, and record the provider operation result
+- artifact providers verify that referenced documents/attachments/work products are durable, company-scoped, and attached to the issue
+
+Builds, tests, screenshots, comments, and command logs remain valuable supporting evidence. They do not replace a successful delivery operation when `workspace_delivery` is required. Conversely, a successful delivery attestation proves the delivery path, not functional correctness; acceptance criteria may still require tests, deployment checks, or review.
+
+#### Terminal transition contract
+
+On a requested transition to `done`, the server evaluates the persisted issue requirement and provider evidence in the same transaction as the status change:
+
+- `evidence_only`: use the ordinary completion rules
+- `artifact`: require at least one allowed, durable, issue-linked artifact produced or updated by the completing run (or explicitly accepted from a prior run)
+- `workspace_delivery`: require a `succeeded` attestation whose company, issue, run, declaration id/revision, target fingerprint, and delivery method match the run's immutable target snapshot and the issue's current requirement revision
+- `legacy_unspecified`: preserve compatibility behavior and return an explicit `completionContract: legacy_unspecified` warning in API/UI projections
+
+Agents may reference an attestation id in a completion request, but they cannot submit attestation contents. When exactly one valid attestation exists for the completing run, the server may select it automatically.
+
+If required evidence is absent, failed, stale, belongs to another company/issue/run/target, or was generated before the current requirement/target revision, the server must not set `done` or `completedAt`. It returns `422 delivery_attestation_required` (or `artifact_attestation_required`) with the expected target fingerprint and allowed next actions. When the run has already ended and no live path remains, Paperclip upserts one source-scoped `delivery_attestation_incomplete` recovery action keyed by `(issueId, requirementRevision, declarationRevision, runId)`; the action must route to retry delivery, obtain the typed operator confirmation required by the provider, or correct the requirement through a board-authorized mutation. It must not automatically push, sync, guess a target, or wake the same failed completion repeatedly.
+
+An `operator_confirmation_required` attestation is a real waiting path only when it is paired with a pending typed interaction/approval or user owner. A comment saying that an operator should confirm is supporting evidence, not a waiting path.
+
+#### API projections and mutations
+
+Server and UI implementation must expose:
+
+- project/workspace configuration reads and board-authorized mutations for target declarations and project defaults
+- issue create/update fields for completion requirement and target selection, with activity for every change
+- issue, run, and heartbeat-context projections containing the effective declaration summary, immutable resolved target snapshot, completion-contract warning/error, and latest matching attestation summary
+- `GET /issues/:issueId/delivery-attestations` and `GET /heartbeat-runs/:runId/delivery-attestations`
+- terminal mutation errors with stable codes, expected declaration revision/fingerprint, and typed remediation actions
+
+Agent-readable APIs expose fingerprints and non-secret labels, never private target references. Declaration mutation is board/project-configuration authority; normal issue agents can read the effective contract and complete against it but cannot replace it.
+
+#### Migration and compatibility
+
+The migration is additive and non-destructive:
+
+1. Existing issues receive `completionRequirement = legacy_unspecified` and revision `1`.
+2. Existing projects receive no default declaration and `defaultCompletionRequirement = null`.
+3. Existing registered Git project workspaces may be offered as declaration candidates after credential-free remote/ref validation, but migration must not silently declare them authoritative.
+4. Existing repo-less `project_primary` folders remain usable for `legacy_unspecified`, `evidence_only`, and explicitly `artifact_only` work; they are never labeled repository checkouts and cannot satisfy a new `workspace_delivery` requirement.
+5. Newly created non-code projects may explicitly choose `artifact_only` and default new issues to `evidence_only` or `artifact`, so they remain productive without Git.
+6. Newly created delivery projects and issues must select a valid repository or remote target before dispatch.
+
+`legacy_unspecified` is a visible compatibility state, not a target kind and not a source for inferred authority. It prevents a release-wide stop for existing non-code and historical work while making the lack of provider attestation explicit. Operators can migrate projects incrementally; changing a project default affects only newly created issues unless an explicit bulk migration is previewed and applied. Historical `done` issues and their comments remain unchanged and are not retroactively attested.
+
 ### Explicit recovery actions
 
 An explicit recovery action is a typed liveness repair path for a source issue. It is the recovery primitive; the action can be rendered directly on the source issue or backed by a separate recovery issue when the repair needs its own work item.

--- a/packages/db/src/migrations/0216_issue_completion_requirement.sql
+++ b/packages/db/src/migrations/0216_issue_completion_requirement.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "issues" ADD COLUMN IF NOT EXISTS "completion_requirement" text;
+ALTER TABLE "issues" ADD COLUMN IF NOT EXISTS "completion_requirement_revision" integer NOT NULL DEFAULT 0;
+ALTER TABLE "project_workspaces" ADD COLUMN IF NOT EXISTS "default_completion_requirement" text;

--- a/packages/db/src/migrations/0217_delivery_attestations.sql
+++ b/packages/db/src/migrations/0217_delivery_attestations.sql
@@ -1,0 +1,29 @@
+CREATE TABLE "delivery_attestations" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"company_id" uuid NOT NULL,
+	"issue_id" uuid NOT NULL,
+	"run_id" uuid NOT NULL,
+	"declaration_id" text NOT NULL,
+	"declaration_revision" integer NOT NULL,
+	"target_kind" text NOT NULL,
+	"target_fingerprint" text NOT NULL,
+	"provider_key" text NOT NULL,
+	"outcome" text NOT NULL,
+	"delivery_method" text NOT NULL,
+	"source_revision" text,
+	"delivered_revision" text,
+	"destination_ref_fingerprint" text,
+	"workspace_dirty" boolean,
+	"operation_id" text DEFAULT '' NOT NULL,
+	"artifact_ids" jsonb DEFAULT '[]' NOT NULL,
+	"generated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"provider_signature" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "delivery_attestations" ADD CONSTRAINT "delivery_attestations_company_id_companies_id_fk" FOREIGN KEY ("company_id") REFERENCES "public"."companies"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "delivery_attestations" ADD CONSTRAINT "delivery_attestations_issue_id_issues_id_fk" FOREIGN KEY ("issue_id") REFERENCES "public"."issues"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "delivery_attestations" ADD CONSTRAINT "delivery_attestations_run_id_heartbeat_runs_id_fk" FOREIGN KEY ("run_id") REFERENCES "public"."heartbeat_runs"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "delivery_attestations_dedup_idx" ON "delivery_attestations" USING btree ("run_id","declaration_id","declaration_revision","delivery_method","operation_id");--> statement-breakpoint
+CREATE INDEX "delivery_attestations_company_issue_idx" ON "delivery_attestations" USING btree ("company_id","issue_id","generated_at");--> statement-breakpoint
+CREATE INDEX "delivery_attestations_run_idx" ON "delivery_attestations" USING btree ("run_id","generated_at");

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -1499,6 +1499,13 @@
       "when": 1786467951628,
       "tag": "0215_flat_daimon_hellstrom",
       "breakpoints": true
+    },
+    {
+      "idx": 216,
+      "version": "7",
+      "when": 1786467952000,
+      "tag": "0216_issue_completion_requirement",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -1506,6 +1506,13 @@
       "when": 1786467952000,
       "tag": "0216_issue_completion_requirement",
       "breakpoints": true
+    },
+    {
+      "idx": 217,
+      "version": "7",
+      "when": 1786467953000,
+      "tag": "0217_delivery_attestations",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/delivery_attestations.ts
+++ b/packages/db/src/schema/delivery_attestations.ts
@@ -1,0 +1,52 @@
+import { boolean, index, integer, jsonb, pgTable, text, timestamp, uniqueIndex, uuid } from "drizzle-orm/pg-core";
+import { companies } from "./companies.js";
+import { issues } from "./issues.js";
+import { heartbeatRuns } from "./heartbeat_runs.js";
+
+// Provider-generated evidence that a resolved workspace target received the
+// declared delivery for a specific run. Append-only: a retry or later
+// delivery attempt produces a new row rather than rewriting failed evidence.
+// See doc/execution-semantics.md, "Authoritative workspace intent and
+// completion attestation" -> "Durable target and attestation schema".
+export const deliveryAttestations = pgTable(
+  "delivery_attestations",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    companyId: uuid("company_id").notNull().references(() => companies.id, { onDelete: "cascade" }),
+    issueId: uuid("issue_id").notNull().references(() => issues.id, { onDelete: "cascade" }),
+    runId: uuid("run_id").notNull().references(() => heartbeatRuns.id, { onDelete: "cascade" }),
+    declarationId: text("declaration_id").notNull(),
+    declarationRevision: integer("declaration_revision").notNull(),
+    targetKind: text("target_kind").notNull(),
+    targetFingerprint: text("target_fingerprint").notNull(),
+    providerKey: text("provider_key").notNull(),
+    outcome: text("outcome").notNull(),
+    deliveryMethod: text("delivery_method").notNull(),
+    sourceRevision: text("source_revision"),
+    deliveredRevision: text("delivered_revision"),
+    destinationRefFingerprint: text("destination_ref_fingerprint"),
+    workspaceDirty: boolean("workspace_dirty"),
+    // Normalized to "" when the provider has no natural operation id, so the
+    // dedup constraint below still applies to single-shot delivery methods.
+    operationId: text("operation_id").notNull().default(""),
+    artifactIds: jsonb("artifact_ids").$type<string[]>().notNull().default([]),
+    generatedAt: timestamp("generated_at", { withTimezone: true }).notNull().defaultNow(),
+    providerSignature: text("provider_signature").notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    dedupIdx: uniqueIndex("delivery_attestations_dedup_idx").on(
+      table.runId,
+      table.declarationId,
+      table.declarationRevision,
+      table.deliveryMethod,
+      table.operationId,
+    ),
+    companyIssueIdx: index("delivery_attestations_company_issue_idx").on(
+      table.companyId,
+      table.issueId,
+      table.generatedAt,
+    ),
+    runIdx: index("delivery_attestations_run_idx").on(table.runId, table.generatedAt),
+  }),
+);

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -34,6 +34,7 @@ export { environmentCustomImageTemplates } from "./environment_custom_image_temp
 export { environmentCustomImageSetupSessions } from "./environment_custom_image_setup_sessions.js";
 export { adapterAuthSessions } from "./adapter_auth_sessions.js";
 export { workspaceOperations } from "./workspace_operations.js";
+export { deliveryAttestations } from "./delivery_attestations.js";
 export { workspaceRuntimeServices } from "./workspace_runtime_services.js";
 export { projectGoals } from "./project_goals.js";
 export { goals } from "./goals.js";

--- a/packages/db/src/schema/issues.ts
+++ b/packages/db/src/schema/issues.ts
@@ -69,6 +69,8 @@ export const issues = pgTable(
     unblockDescriptor: jsonb("unblock_descriptor").$type<IssueUnblockDescriptor | null>(),
     blockedTransitionAt: timestamp("blocked_transition_at", { withTimezone: true }),
     blockedOwnerNotifiedAt: timestamp("blocked_owner_notified_at", { withTimezone: true }),
+    completionRequirement: text("completion_requirement"),
+    completionRequirementRevision: integer("completion_requirement_revision").notNull().default(0),
     startedAt: timestamp("started_at", { withTimezone: true }),
     completedAt: timestamp("completed_at", { withTimezone: true }),
     cancelledAt: timestamp("cancelled_at", { withTimezone: true }),

--- a/packages/db/src/schema/project_workspaces.ts
+++ b/packages/db/src/schema/project_workspaces.ts
@@ -30,6 +30,7 @@ export const projectWorkspaces = pgTable(
     remoteWorkspaceRef: text("remote_workspace_ref"),
     sharedWorkspaceKey: text("shared_workspace_key"),
     metadata: jsonb("metadata").$type<Record<string, unknown>>(),
+    defaultCompletionRequirement: text("default_completion_requirement"),
     isPrimary: boolean("is_primary").notNull().default(false),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),

--- a/packages/shared/src/validators/issue.ts
+++ b/packages/shared/src/validators/issue.ts
@@ -562,6 +562,10 @@ export const updateIssueSchema = createIssueBaseSchema.omit({
   resume: z.boolean().optional(),
   interrupt: z.boolean().optional(),
   hiddenAt: z.string().datetime().nullable().optional(),
+  // References (rather than supplies) provider-generated delivery evidence
+  // for a workspace_delivery terminal transition; see
+  // doc/execution-semantics.md, "Terminal transition contract".
+  deliveryAttestationId: z.string().uuid().optional(),
 });
 
 export type UpdateIssue = z.infer<typeof updateIssueSchema>;

--- a/server/src/__tests__/delivery-attestations.test.ts
+++ b/server/src/__tests__/delivery-attestations.test.ts
@@ -1,0 +1,382 @@
+import { randomUUID } from "node:crypto";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import {
+  agents,
+  companies,
+  createDb,
+  deliveryAttestations,
+  heartbeatRuns,
+  issues,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import { deliveryAttestationService } from "../services/delivery-attestations.js";
+import { issueService } from "../services/issues.js";
+import { computeTargetFingerprint } from "../services/workspace-target-fingerprint.js";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping embedded Postgres delivery attestation tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+process.env.PAPERCLIP_AGENT_JWT_SECRET ??= "test-secret-for-delivery-attestations";
+
+describeEmbeddedPostgres("delivery attestations", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-delivery-attestations-");
+    db = createDb(tempDb.connectionString);
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.delete(deliveryAttestations);
+    await db.delete(issues);
+    await db.delete(heartbeatRuns);
+    await db.delete(agents);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  let companyId: string;
+  let agentId: string;
+
+  beforeEach(async () => {
+    companyId = randomUUID();
+    agentId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "CodexCoder",
+      role: "engineer",
+      status: "running",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+  });
+
+  async function makeRun() {
+    const runId = randomUUID();
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId,
+      agentId,
+      invocationSource: "assignment",
+      status: "succeeded",
+    });
+    return runId;
+  }
+
+  async function makeIssue(overrides: Partial<typeof issues.$inferInsert> = {}) {
+    const issueId = randomUUID();
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Ship the feature",
+      status: "in_progress",
+      priority: "medium",
+      assigneeAgentId: agentId,
+      ...overrides,
+    });
+    return issueId;
+  }
+
+  describe("deliveryAttestationService", () => {
+    it("is append-only: a repeated call for the same operation key does not create a duplicate row", async () => {
+      const svc = deliveryAttestationService(db);
+      const runId = await makeRun();
+      const issueId = await makeIssue();
+      const fingerprint = computeTargetFingerprint(companyId, "git", "https://example.com/acme/repo.git");
+
+      const first = await svc.record({
+        companyId,
+        issueId,
+        runId,
+        declarationId: `projectWorkspace:${issueId}`,
+        declarationRevision: 0,
+        targetKind: "repository_checkout",
+        targetFingerprint: fingerprint,
+        providerKey: "git",
+        outcome: "succeeded",
+        deliveryMethod: "commit",
+        operationId: "op-1",
+      });
+      const second = await svc.record({
+        companyId,
+        issueId,
+        runId,
+        declarationId: `projectWorkspace:${issueId}`,
+        declarationRevision: 0,
+        targetKind: "repository_checkout",
+        targetFingerprint: fingerprint,
+        providerKey: "git",
+        outcome: "succeeded",
+        deliveryMethod: "commit",
+        operationId: "op-1",
+      });
+
+      expect(second.id).toBe(first.id);
+      const rows = await svc.listForRun(runId, companyId);
+      expect(rows).toHaveLength(1);
+    });
+
+    it("records a new row for a genuinely new operation attempt", async () => {
+      const svc = deliveryAttestationService(db);
+      const runId = await makeRun();
+      const issueId = await makeIssue();
+      const fingerprint = computeTargetFingerprint(companyId, "git", "https://example.com/acme/repo.git");
+
+      await svc.record({
+        companyId,
+        issueId,
+        runId,
+        declarationId: `projectWorkspace:${issueId}`,
+        declarationRevision: 0,
+        targetKind: "repository_checkout",
+        targetFingerprint: fingerprint,
+        providerKey: "git",
+        outcome: "failed",
+        deliveryMethod: "commit",
+        operationId: "attempt-1",
+      });
+      await svc.record({
+        companyId,
+        issueId,
+        runId,
+        declarationId: `projectWorkspace:${issueId}`,
+        declarationRevision: 0,
+        targetKind: "repository_checkout",
+        targetFingerprint: fingerprint,
+        providerKey: "git",
+        outcome: "succeeded",
+        deliveryMethod: "commit",
+        operationId: "attempt-2",
+      });
+
+      const rows = await svc.listForRun(runId, companyId);
+      expect(rows).toHaveLength(2);
+    });
+
+    it("does not let a sibling issue's succeeded attestation satisfy this issue's lookup", async () => {
+      const svc = deliveryAttestationService(db);
+      const runA = await makeRun();
+      const runB = await makeRun();
+      const issueA = await makeIssue();
+      const issueB = await makeIssue();
+      const fingerprint = computeTargetFingerprint(companyId, "git", "https://example.com/acme/repo.git");
+
+      await svc.record({
+        companyId,
+        issueId: issueB,
+        runId: runB,
+        declarationId: `projectWorkspace:${issueB}`,
+        declarationRevision: 0,
+        targetKind: "repository_checkout",
+        targetFingerprint: fingerprint,
+        providerKey: "git",
+        outcome: "succeeded",
+        deliveryMethod: "commit",
+      });
+
+      const matches = await svc.findSucceededForIssue({
+        companyId,
+        issueId: issueA,
+        declarationRevision: 0,
+      });
+      expect(matches).toHaveLength(0);
+
+      // Recording issueA's own attestation makes it (and only it) match.
+      const own = await svc.record({
+        companyId,
+        issueId: issueA,
+        runId: runA,
+        declarationId: `projectWorkspace:${issueA}`,
+        declarationRevision: 0,
+        targetKind: "repository_checkout",
+        targetFingerprint: fingerprint,
+        providerKey: "git",
+        outcome: "succeeded",
+        deliveryMethod: "commit",
+      });
+      const matchesAfter = await svc.findSucceededForIssue({
+        companyId,
+        issueId: issueA,
+        declarationRevision: 0,
+      });
+      expect(matchesAfter.map((row) => row.id)).toEqual([own.id]);
+    });
+  });
+
+  describe("terminal transition gate (issueService.update)", () => {
+    it("rejects done for a workspace_delivery issue with no attestation", async () => {
+      const svc = issueService(db);
+      const issueId = await makeIssue({ completionRequirement: "workspace_delivery", completionRequirementRevision: 0 });
+
+      await expect(svc.update(issueId, { status: "done" })).rejects.toMatchObject({
+        status: 422,
+        details: expect.objectContaining({ code: "delivery_attestation_required" }),
+      });
+    });
+
+    it("allows done once exactly one succeeded attestation matches the issue and revision", async () => {
+      const attestationSvc = deliveryAttestationService(db);
+      const svc = issueService(db);
+      const runId = await makeRun();
+      const issueId = await makeIssue({ completionRequirement: "workspace_delivery", completionRequirementRevision: 0 });
+      const fingerprint = computeTargetFingerprint(companyId, "git", "https://example.com/acme/repo.git");
+
+      await attestationSvc.record({
+        companyId,
+        issueId,
+        runId,
+        declarationId: `projectWorkspace:${issueId}`,
+        declarationRevision: 0,
+        targetKind: "repository_checkout",
+        targetFingerprint: fingerprint,
+        providerKey: "git",
+        outcome: "succeeded",
+        deliveryMethod: "commit",
+      });
+
+      const updated = await svc.update(issueId, { status: "done" });
+      expect(updated?.status).toBe("done");
+      expect(updated?.completedAt).not.toBeNull();
+    });
+
+    it("rejects done when only a sibling issue's run produced a succeeded attestation", async () => {
+      const attestationSvc = deliveryAttestationService(db);
+      const svc = issueService(db);
+      const siblingRunId = await makeRun();
+      const issueId = await makeIssue({ completionRequirement: "workspace_delivery", completionRequirementRevision: 0 });
+      const siblingIssueId = await makeIssue({ completionRequirement: "workspace_delivery", completionRequirementRevision: 0 });
+      const fingerprint = computeTargetFingerprint(companyId, "git", "https://example.com/acme/repo.git");
+
+      await attestationSvc.record({
+        companyId,
+        issueId: siblingIssueId,
+        runId: siblingRunId,
+        declarationId: `projectWorkspace:${siblingIssueId}`,
+        declarationRevision: 0,
+        targetKind: "repository_checkout",
+        targetFingerprint: fingerprint,
+        providerKey: "git",
+        outcome: "succeeded",
+        deliveryMethod: "commit",
+      });
+
+      await expect(svc.update(issueId, { status: "done" })).rejects.toMatchObject({
+        status: 422,
+        details: expect.objectContaining({ code: "delivery_attestation_required" }),
+      });
+    });
+
+    it("rejects done when the attestation was generated under a stale requirement revision", async () => {
+      const attestationSvc = deliveryAttestationService(db);
+      const svc = issueService(db);
+      const runId = await makeRun();
+      const issueId = await makeIssue({ completionRequirement: "workspace_delivery", completionRequirementRevision: 1 });
+      const fingerprint = computeTargetFingerprint(companyId, "git", "https://example.com/acme/repo.git");
+
+      await attestationSvc.record({
+        companyId,
+        issueId,
+        runId,
+        declarationId: `projectWorkspace:${issueId}`,
+        declarationRevision: 0,
+        targetKind: "repository_checkout",
+        targetFingerprint: fingerprint,
+        providerKey: "git",
+        outcome: "succeeded",
+        deliveryMethod: "commit",
+      });
+
+      await expect(svc.update(issueId, { status: "done" })).rejects.toMatchObject({
+        status: 422,
+        details: expect.objectContaining({ code: "delivery_attestation_required" }),
+      });
+    });
+
+    it("does not gate done for legacy/evidence_only/artifact issues (migration compatibility)", async () => {
+      const svc = issueService(db);
+      const legacyIssueId = await makeIssue({ completionRequirement: null });
+      const evidenceIssueId = await makeIssue({ completionRequirement: "evidence_only" });
+
+      const updatedLegacy = await svc.update(legacyIssueId, { status: "done" });
+      expect(updatedLegacy?.status).toBe("done");
+
+      const updatedEvidence = await svc.update(evidenceIssueId, { status: "done" });
+      expect(updatedEvidence?.status).toBe("done");
+    });
+
+    it("allows done when an explicit deliveryAttestationId is referenced and valid", async () => {
+      const attestationSvc = deliveryAttestationService(db);
+      const svc = issueService(db);
+      const runId = await makeRun();
+      const issueId = await makeIssue({ completionRequirement: "workspace_delivery", completionRequirementRevision: 0 });
+      const fingerprint = computeTargetFingerprint(companyId, "git", "https://example.com/acme/repo.git");
+
+      const attestation = await attestationSvc.record({
+        companyId,
+        issueId,
+        runId,
+        declarationId: `projectWorkspace:${issueId}`,
+        declarationRevision: 0,
+        targetKind: "repository_checkout",
+        targetFingerprint: fingerprint,
+        providerKey: "git",
+        outcome: "succeeded",
+        deliveryMethod: "commit",
+      });
+
+      const updated = await svc.update(issueId, { status: "done", deliveryAttestationId: attestation.id });
+      expect(updated?.status).toBe("done");
+    });
+
+    it("rejects an explicit deliveryAttestationId that belongs to a different issue", async () => {
+      const attestationSvc = deliveryAttestationService(db);
+      const svc = issueService(db);
+      const runId = await makeRun();
+      const issueId = await makeIssue({ completionRequirement: "workspace_delivery", completionRequirementRevision: 0 });
+      const siblingIssueId = await makeIssue({ completionRequirement: "workspace_delivery", completionRequirementRevision: 0 });
+      const fingerprint = computeTargetFingerprint(companyId, "git", "https://example.com/acme/repo.git");
+
+      const siblingAttestation = await attestationSvc.record({
+        companyId,
+        issueId: siblingIssueId,
+        runId,
+        declarationId: `projectWorkspace:${siblingIssueId}`,
+        declarationRevision: 0,
+        targetKind: "repository_checkout",
+        targetFingerprint: fingerprint,
+        providerKey: "git",
+        outcome: "succeeded",
+        deliveryMethod: "commit",
+      });
+
+      await expect(
+        svc.update(issueId, { status: "done", deliveryAttestationId: siblingAttestation.id }),
+      ).rejects.toMatchObject({
+        status: 422,
+        details: expect.objectContaining({ code: "delivery_attestation_required" }),
+      });
+    });
+  });
+});

--- a/server/src/__tests__/delivery-attestations.test.ts
+++ b/server/src/__tests__/delivery-attestations.test.ts
@@ -199,6 +199,7 @@ describeEmbeddedPostgres("delivery attestations", () => {
       const matches = await svc.findSucceededForIssue({
         companyId,
         issueId: issueA,
+        runId: runA,
         declarationRevision: 0,
       });
       expect(matches).toHaveLength(0);
@@ -219,6 +220,7 @@ describeEmbeddedPostgres("delivery attestations", () => {
       const matchesAfter = await svc.findSucceededForIssue({
         companyId,
         issueId: issueA,
+        runId: runA,
         declarationRevision: 0,
       });
       expect(matchesAfter.map((row) => row.id)).toEqual([own.id]);
@@ -256,7 +258,7 @@ describeEmbeddedPostgres("delivery attestations", () => {
         deliveryMethod: "commit",
       });
 
-      const updated = await svc.update(issueId, { status: "done" });
+      const updated = await svc.update(issueId, { status: "done", actorRunId: runId });
       expect(updated?.status).toBe("done");
       expect(updated?.completedAt).not.toBeNull();
     });
@@ -265,6 +267,7 @@ describeEmbeddedPostgres("delivery attestations", () => {
       const attestationSvc = deliveryAttestationService(db);
       const svc = issueService(db);
       const siblingRunId = await makeRun();
+      const currentRunId = await makeRun();
       const issueId = await makeIssue({ completionRequirement: "workspace_delivery", completionRequirementRevision: 0 });
       const siblingIssueId = await makeIssue({ completionRequirement: "workspace_delivery", completionRequirementRevision: 0 });
       const fingerprint = computeTargetFingerprint(companyId, "git", "https://example.com/acme/repo.git");
@@ -282,7 +285,7 @@ describeEmbeddedPostgres("delivery attestations", () => {
         deliveryMethod: "commit",
       });
 
-      await expect(svc.update(issueId, { status: "done" })).rejects.toMatchObject({
+      await expect(svc.update(issueId, { status: "done", actorRunId: currentRunId })).rejects.toMatchObject({
         status: 422,
         details: expect.objectContaining({ code: "delivery_attestation_required" }),
       });
@@ -308,7 +311,7 @@ describeEmbeddedPostgres("delivery attestations", () => {
         deliveryMethod: "commit",
       });
 
-      await expect(svc.update(issueId, { status: "done" })).rejects.toMatchObject({
+      await expect(svc.update(issueId, { status: "done", actorRunId: runId })).rejects.toMatchObject({
         status: 422,
         details: expect.objectContaining({ code: "delivery_attestation_required" }),
       });
@@ -346,7 +349,11 @@ describeEmbeddedPostgres("delivery attestations", () => {
         deliveryMethod: "commit",
       });
 
-      const updated = await svc.update(issueId, { status: "done", deliveryAttestationId: attestation.id });
+      const updated = await svc.update(issueId, {
+        status: "done",
+        actorRunId: runId,
+        deliveryAttestationId: attestation.id,
+      });
       expect(updated?.status).toBe("done");
     });
 
@@ -372,7 +379,66 @@ describeEmbeddedPostgres("delivery attestations", () => {
       });
 
       await expect(
-        svc.update(issueId, { status: "done", deliveryAttestationId: siblingAttestation.id }),
+        svc.update(issueId, { status: "done", actorRunId: runId, deliveryAttestationId: siblingAttestation.id }),
+      ).rejects.toMatchObject({
+        status: 422,
+        details: expect.objectContaining({ code: "delivery_attestation_required" }),
+      });
+    });
+
+    it("accepts multiple succeeded attestations from the current run", async () => {
+      const attestationSvc = deliveryAttestationService(db);
+      const svc = issueService(db);
+      const runId = await makeRun();
+      const issueId = await makeIssue({ completionRequirement: "workspace_delivery", completionRequirementRevision: 0 });
+      const fingerprint = computeTargetFingerprint(companyId, "git", "https://example.com/acme/repo.git");
+
+      for (const operationId of ["attempt-1", "attempt-2"]) {
+        await attestationSvc.record({
+          companyId,
+          issueId,
+          runId,
+          declarationId: `projectWorkspace:${issueId}`,
+          declarationRevision: 0,
+          targetKind: "repository_checkout",
+          targetFingerprint: fingerprint,
+          providerKey: "git",
+          outcome: "succeeded",
+          deliveryMethod: "commit",
+          operationId,
+        });
+      }
+
+      const updated = await svc.update(issueId, { status: "done", actorRunId: runId });
+      expect(updated?.status).toBe("done");
+    });
+
+    it("rejects an explicit attestation from a prior run of the same issue", async () => {
+      const attestationSvc = deliveryAttestationService(db);
+      const svc = issueService(db);
+      const priorRunId = await makeRun();
+      const currentRunId = await makeRun();
+      const issueId = await makeIssue({ completionRequirement: "workspace_delivery", completionRequirementRevision: 0 });
+      const fingerprint = computeTargetFingerprint(companyId, "git", "https://example.com/acme/repo.git");
+      const priorAttestation = await attestationSvc.record({
+        companyId,
+        issueId,
+        runId: priorRunId,
+        declarationId: `projectWorkspace:${issueId}`,
+        declarationRevision: 0,
+        targetKind: "repository_checkout",
+        targetFingerprint: fingerprint,
+        providerKey: "git",
+        outcome: "succeeded",
+        deliveryMethod: "commit",
+      });
+
+      await expect(
+        svc.update(issueId, {
+          status: "done",
+          actorRunId: currentRunId,
+          deliveryAttestationId: priorAttestation.id,
+        }),
       ).rejects.toMatchObject({
         status: 422,
         details: expect.objectContaining({ code: "delivery_attestation_required" }),

--- a/server/src/__tests__/document-annotation-routes.test.ts
+++ b/server/src/__tests__/document-annotation-routes.test.ts
@@ -129,6 +129,7 @@ function registerModuleMocks() {
       completeTestRunForIssue: vi.fn(async () => null),
     }),
     companyService: () => ({ getById: vi.fn(async () => ({ id: companyId, attachmentMaxBytes: 10_000_000 })) }),
+    deliveryAttestationService: () => ({ listForIssue: async () => [] }),
     documentAnnotationService: () => mockAnnotationService,
     documentService: () => mockDocumentService,
     environmentService: () => ({}),

--- a/server/src/__tests__/environment-selection-route-guards.test.ts
+++ b/server/src/__tests__/environment-selection-route-guards.test.ts
@@ -92,6 +92,7 @@ vi.mock("../services/index.js", () => ({
     expireRequestConfirmationsSupersededByComment: vi.fn(async () => []),
     expireStaleRequestConfirmationsForIssueDocument: vi.fn(async () => []),
   }),
+  deliveryAttestationService: () => ({ listForIssue: async () => [] }),
   documentService: () => ({}),
   documentAnnotationService: () => ({ remapOpenThreadsForDocument: async () => [] }),
   routineService: () => ({}),

--- a/server/src/__tests__/external-object-routes.test.ts
+++ b/server/src/__tests__/external-object-routes.test.ts
@@ -55,6 +55,7 @@ function registerRouteMocks() {
       getById: vi.fn(async () => null),
     }),
     companySearchService: () => ({}),
+    deliveryAttestationService: () => ({ listForIssue: async () => [] }),
     documentAnnotationService: () => ({}),
     documentService: () => ({}),
     executionWorkspaceService: () => ({}),

--- a/server/src/__tests__/heartbeat-workspace-session.test.ts
+++ b/server/src/__tests__/heartbeat-workspace-session.test.ts
@@ -442,6 +442,130 @@ describe("assertGitSensitiveAdapterWorkspaceValid", () => {
     );
   });
 
+  it("rejects a workspace_delivery issue whose project_primary workspace has no repository URL", async () => {
+    const cwd = await createGitCheckout({ withRemote: false });
+    try {
+      await expectWorkspaceValidationFailure(
+        buildWorkspaceValidationInput({
+          issue: {
+            id: "issue-1",
+            identifier: "PAP-1",
+            projectId: "project-1",
+            projectWorkspaceId: "workspace-1",
+            completionRequirement: "workspace_delivery",
+          },
+          resolvedWorkspace: buildResolvedWorkspace({ cwd, repoUrl: null }),
+          executionWorkspace: {
+            ...buildWorkspaceValidationInput().executionWorkspace,
+            baseCwd: cwd,
+            cwd,
+          },
+          persistedExecutionWorkspace: {
+            ...buildWorkspaceValidationInput().persistedExecutionWorkspace!,
+            cwd,
+          },
+        }),
+        "null_repo_delivery_required",
+        "project_primary workspace has no repository URL",
+      );
+    } finally {
+      await fs.rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("allows a workspace_delivery issue whose project_primary workspace has a repository URL", async () => {
+    const cwd = await createGitCheckout({ withRemote: true });
+    try {
+      await expect(
+        assertGitSensitiveAdapterWorkspaceValid(
+          buildWorkspaceValidationInput({
+            issue: {
+              id: "issue-1",
+              identifier: "PAP-1",
+              projectId: "project-1",
+              projectWorkspaceId: "workspace-1",
+              completionRequirement: "workspace_delivery",
+            },
+            resolvedWorkspace: buildResolvedWorkspace({ cwd, repoUrl: "https://github.com/example/repo.git" }),
+            executionWorkspace: {
+              ...buildWorkspaceValidationInput().executionWorkspace,
+              baseCwd: cwd,
+              cwd,
+            },
+            persistedExecutionWorkspace: {
+              ...buildWorkspaceValidationInput().persistedExecutionWorkspace!,
+              cwd,
+            },
+          }),
+        ),
+      ).resolves.toBeUndefined();
+    } finally {
+      await fs.rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("allows a null-repo project_primary workspace when completionRequirement is not workspace_delivery", async () => {
+    const cwd = await createGitCheckout({ withRemote: false });
+    try {
+      await expect(
+        assertGitSensitiveAdapterWorkspaceValid(
+          buildWorkspaceValidationInput({
+            issue: {
+              id: "issue-1",
+              identifier: "PAP-1",
+              projectId: "project-1",
+              projectWorkspaceId: "workspace-1",
+              completionRequirement: "artifact",
+            },
+            resolvedWorkspace: buildResolvedWorkspace({ cwd, repoUrl: null }),
+            executionWorkspace: {
+              ...buildWorkspaceValidationInput().executionWorkspace,
+              baseCwd: cwd,
+              cwd,
+            },
+            persistedExecutionWorkspace: {
+              ...buildWorkspaceValidationInput().persistedExecutionWorkspace!,
+              cwd,
+            },
+          }),
+        ),
+      ).resolves.toBeUndefined();
+    } finally {
+      await fs.rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("allows a null-repo project_primary workspace when completionRequirement is legacy_unspecified (null)", async () => {
+    const cwd = await createGitCheckout({ withRemote: false });
+    try {
+      await expect(
+        assertGitSensitiveAdapterWorkspaceValid(
+          buildWorkspaceValidationInput({
+            issue: {
+              id: "issue-1",
+              identifier: "PAP-1",
+              projectId: "project-1",
+              projectWorkspaceId: "workspace-1",
+              completionRequirement: null,
+            },
+            resolvedWorkspace: buildResolvedWorkspace({ cwd, repoUrl: null }),
+            executionWorkspace: {
+              ...buildWorkspaceValidationInput().executionWorkspace,
+              baseCwd: cwd,
+              cwd,
+            },
+            persistedExecutionWorkspace: {
+              ...buildWorkspaceValidationInput().persistedExecutionWorkspace!,
+              cwd,
+            },
+          }),
+        ),
+      ).resolves.toBeUndefined();
+    } finally {
+      await fs.rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("does not apply the git-sensitive workspace guard to non-local execution targets", async () => {
     const input = buildWorkspaceValidationInput();
 

--- a/server/src/__tests__/issue-activity-events-routes.test.ts
+++ b/server/src/__tests__/issue-activity-events-routes.test.ts
@@ -86,6 +86,7 @@ function registerModuleMocks() {
     companySkillService: () => ({
       completeTestRunForIssue: vi.fn(async () => null),
     }),
+    deliveryAttestationService: () => ({ listForIssue: async () => [] }),
     documentAnnotationService: () => ({ remapOpenThreadsForDocument: async () => [] }),
     documentService: () => ({}),
     executionWorkspaceService: () => ({}),

--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -197,6 +197,7 @@ function registerRouteMocks() {
       completeTestRunForIssue: vi.fn(async () => null),
     }),
     companyService: () => mockCompanyService,
+    deliveryAttestationService: () => ({ listForIssue: async () => [] }),
     documentAnnotationService: () => ({ remapOpenThreadsForDocument: async () => [] }),
     documentService: () => mockDocumentService,
     executionWorkspaceService: () => ({}),

--- a/server/src/__tests__/issue-assigned-backlog-contract-routes.test.ts
+++ b/server/src/__tests__/issue-assigned-backlog-contract-routes.test.ts
@@ -48,6 +48,7 @@ vi.mock("../services/index.js", () => ({
   companyService: () => ({
     getById: vi.fn(async () => ({ id: "company-1", attachmentMaxBytes: 10 * 1024 * 1024 })),
   }),
+  deliveryAttestationService: () => ({ listForIssue: async () => [] }),
   documentAnnotationService: () => ({ remapOpenThreadsForDocument: async () => [] }),
   documentService: () => ({
     getIssueDocumentPayload: vi.fn(async () => ({})),

--- a/server/src/__tests__/issue-attachment-routes.test.ts
+++ b/server/src/__tests__/issue-attachment-routes.test.ts
@@ -55,6 +55,7 @@ function registerRouteMocks() {
     }),
     companySkillService: () => ({}),
     companyService: () => mockCompanyService,
+    deliveryAttestationService: () => ({ listForIssue: async () => [] }),
     documentAnnotationService: () => ({ remapOpenThreadsForDocument: async () => [] }),
     documentService: () => ({}),
     executionWorkspaceService: () => ({}),

--- a/server/src/__tests__/issue-closed-workspace-routes.test.ts
+++ b/server/src/__tests__/issue-closed-workspace-routes.test.ts
@@ -84,6 +84,7 @@ function registerServiceMocks() {
     companySkillService: () => ({
       completeTestRunForIssue: vi.fn(async () => null),
     }),
+    deliveryAttestationService: () => ({ listForIssue: async () => [] }),
     documentAnnotationService: () => ({ remapOpenThreadsForDocument: async () => [] }),
     documentService: () => ({}),
     executionWorkspaceService: () => mockExecutionWorkspaceService,

--- a/server/src/__tests__/issue-comment-cancel-routes.test.ts
+++ b/server/src/__tests__/issue-comment-cancel-routes.test.ts
@@ -131,6 +131,7 @@ function registerModuleMocks() {
     companySkillService: () => ({
       completeTestRunForIssue: vi.fn(async () => null),
     }),
+    deliveryAttestationService: () => ({ listForIssue: async () => [] }),
     documentAnnotationService: () => mockDocumentAnnotationService,
     documentService: () => ({}),
     executionWorkspaceService: () => ({}),

--- a/server/src/__tests__/issue-comment-reopen-routes.test.ts
+++ b/server/src/__tests__/issue-comment-reopen-routes.test.ts
@@ -140,6 +140,7 @@ vi.mock("../services/index.js", () => ({
   companySkillService: () => ({
     completeTestRunForIssue: vi.fn(async () => null),
   }),
+  deliveryAttestationService: () => ({ listForIssue: async () => [] }),
   documentAnnotationService: () => ({ remapOpenThreadsForDocument: async () => [] }),
   documentService: () => ({}),
   executionWorkspaceService: () => ({}),

--- a/server/src/__tests__/issue-dependency-wakeups-routes.test.ts
+++ b/server/src/__tests__/issue-dependency-wakeups-routes.test.ts
@@ -32,6 +32,7 @@ vi.mock("../services/index.js", () => ({
   companySkillService: () => ({
     completeTestRunForIssue: vi.fn(async () => null),
   }),
+  deliveryAttestationService: () => ({ listForIssue: async () => [] }),
   documentAnnotationService: () => ({ remapOpenThreadsForDocument: async () => [] }),
   documentService: () => ({
     getIssueDocumentPayload: vi.fn(async () => ({})),

--- a/server/src/__tests__/issue-document-restore-routes.test.ts
+++ b/server/src/__tests__/issue-document-restore-routes.test.ts
@@ -90,6 +90,7 @@ function registerModuleMocks() {
   }));
 
   vi.doMock("../services/documents.js", () => ({
+    deliveryAttestationService: () => ({ listForIssue: async () => [] }),
     documentAnnotationService: () => ({ remapOpenThreadsForDocument: async () => [] }),
     documentService: () => mockDocumentsService,
   }));
@@ -119,6 +120,7 @@ function registerModuleMocks() {
     companySkillService: () => ({
       completeTestRunForIssue: vi.fn(async () => null),
     }),
+    deliveryAttestationService: () => ({ listForIssue: async () => [] }),
     documentAnnotationService: () => ({ remapOpenThreadsForDocument: async () => [] }),
     documentService: () => mockDocumentsService,
     executionWorkspaceService: () => ({}),

--- a/server/src/__tests__/issue-execution-policy-routes.test.ts
+++ b/server/src/__tests__/issue-execution-policy-routes.test.ts
@@ -93,6 +93,7 @@ function registerModuleMocks() {
     companySkillService: () => ({
       completeTestRunForIssue: vi.fn(async () => null),
     }),
+    deliveryAttestationService: () => ({ listForIssue: async () => [] }),
     documentAnnotationService: () => ({ remapOpenThreadsForDocument: async () => [] }),
     documentService: () => ({}),
     executionWorkspaceService: () => ({}),

--- a/server/src/__tests__/issue-feedback-routes.test.ts
+++ b/server/src/__tests__/issue-feedback-routes.test.ts
@@ -91,6 +91,7 @@ function registerModuleMocks() {
     companySkillService: () => ({
       completeTestRunForIssue: vi.fn(async () => null),
     }),
+    deliveryAttestationService: () => ({ listForIssue: async () => [] }),
     documentAnnotationService: () => ({ remapOpenThreadsForDocument: async () => [] }),
     documentService: () => ({}),
     executionWorkspaceService: () => mockExecutionWorkspaceService,

--- a/server/src/__tests__/issue-telemetry-routes.test.ts
+++ b/server/src/__tests__/issue-telemetry-routes.test.ts
@@ -71,6 +71,7 @@ function registerModuleMocks() {
     companySkillService: () => ({
       completeTestRunForIssue: vi.fn(async () => null),
     }),
+    deliveryAttestationService: () => ({ listForIssue: async () => [] }),
     documentAnnotationService: () => ({ remapOpenThreadsForDocument: async () => [] }),
     documentService: () => ({}),
     executionWorkspaceService: () => ({}),

--- a/server/src/__tests__/issue-thread-interaction-routes.test.ts
+++ b/server/src/__tests__/issue-thread-interaction-routes.test.ts
@@ -98,6 +98,7 @@ function registerModuleMocks() {
     }),
     ISSUE_LIST_DEFAULT_LIMIT: 500,
     ISSUE_LIST_MAX_LIMIT: 1000,
+    deliveryAttestationService: () => ({ listForIssue: async () => [] }),
     documentAnnotationService: () => ({ remapOpenThreadsForDocument: async () => [] }),
     documentService: () => ({}),
     executionWorkspaceService: () => ({}),

--- a/server/src/__tests__/issue-update-comment-wakeup-routes.test.ts
+++ b/server/src/__tests__/issue-update-comment-wakeup-routes.test.ts
@@ -55,6 +55,7 @@ vi.mock("../services/index.js", () => ({
   companySkillService: () => ({
     completeTestRunForIssue: vi.fn(async () => null),
   }),
+  deliveryAttestationService: () => ({ listForIssue: async () => [] }),
   documentAnnotationService: () => ({ remapOpenThreadsForDocument: async () => [] }),
   documentService: () => ({}),
   executionWorkspaceService: () => ({}),
@@ -127,6 +128,7 @@ function registerModuleMocks() {
     companySkillService: () => ({
       completeTestRunForIssue: vi.fn(async () => null),
     }),
+    deliveryAttestationService: () => ({ listForIssue: async () => [] }),
     documentAnnotationService: () => ({ remapOpenThreadsForDocument: async () => [] }),
     documentService: () => ({}),
     executionWorkspaceService: () => ({}),

--- a/server/src/__tests__/issue-workspace-command-authz.test.ts
+++ b/server/src/__tests__/issue-workspace-command-authz.test.ts
@@ -112,6 +112,7 @@ function registerRouteMocks() {
     companySkillService: () => ({
       completeTestRunForIssue: vi.fn(async () => null),
     }),
+    deliveryAttestationService: () => ({ listForIssue: async () => [] }),
     documentAnnotationService: () => ({ remapOpenThreadsForDocument: async () => [] }),
     documentService: () => ({}),
     executionWorkspaceService: () => mockExecutionWorkspaceService,

--- a/server/src/__tests__/issues-goal-context-routes.test.ts
+++ b/server/src/__tests__/issues-goal-context-routes.test.ts
@@ -109,6 +109,7 @@ vi.mock("../services/index.js", () => ({
   companySkillService: () => ({
     completeTestRunForIssue: vi.fn(async () => null),
   }),
+  deliveryAttestationService: () => ({ listForIssue: async () => [] }),
   documentAnnotationService: () => ({ remapOpenThreadsForDocument: async () => [] }),
   documentService: () => mockDocumentsService,
   environmentService: () => mockEnvironmentService,

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -55,10 +55,10 @@ import {
   logActivity,
   syncInstructionsBundleConfigFromFilePath,
   workspaceOperationService,
-  deliveryAttestationService,
 } from "../services/index.js";
 import { badRequest, conflict, forbidden, HttpError, notFound, unprocessable } from "../errors.js";
 import { createRunSecretRedactionRegistry } from "../services/run-secret-redaction.js";
+import { deliveryAttestationService } from "../services/delivery-attestations.js";
 import { assertBoard, assertCompanyAccess, assertInstanceAdmin, buildActorSecretContext, getAccessibleResource, getActorInfo, hasCompanyAccess } from "./authz.js";
 import {
   assertNoAgentHostWorkspaceCommandMutation,

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -4596,12 +4596,8 @@ export function agentRoutes(
 
   router.get("/heartbeat-runs/:runId/delivery-attestations", async (req, res) => {
     const runId = req.params.runId as string;
-    const run = await heartbeat.getRun(runId);
-    if (!run) {
-      res.status(404).json({ error: "Heartbeat run not found" });
-      return;
-    }
-    assertCompanyAccess(req, run.companyId);
+    const run = await getAccessibleResource(req, res, heartbeat.getRun(runId), "Heartbeat run not found");
+    if (!run) return;
 
     const attestations = await deliveryAttestations.listForRun(runId, run.companyId);
     res.json(attestations);

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -55,6 +55,7 @@ import {
   logActivity,
   syncInstructionsBundleConfigFromFilePath,
   workspaceOperationService,
+  deliveryAttestationService,
 } from "../services/index.js";
 import { badRequest, conflict, forbidden, HttpError, notFound, unprocessable } from "../errors.js";
 import { createRunSecretRedactionRegistry } from "../services/run-secret-redaction.js";
@@ -387,6 +388,7 @@ export function agentRoutes(
   const instructions = agentInstructionsService();
   const companySkills = companySkillService(db);
   const workspaceOperations = workspaceOperationService(db);
+  const deliveryAttestations = deliveryAttestationService(db);
   const instanceSettings = instanceSettingsService(db);
   const strictSecretsMode = process.env.PAPERCLIP_SECRETS_STRICT_MODE === "true";
 
@@ -4590,6 +4592,19 @@ export function agentRoutes(
     const executionWorkspaceId = asNonEmptyString(context?.executionWorkspaceId);
     const operations = await workspaceOperations.listForRun(runId, executionWorkspaceId);
     res.json(redactCurrentUserValue(operations, await getCurrentUserRedactionOptions()));
+  });
+
+  router.get("/heartbeat-runs/:runId/delivery-attestations", async (req, res) => {
+    const runId = req.params.runId as string;
+    const run = await heartbeat.getRun(runId);
+    if (!run) {
+      res.status(404).json({ error: "Heartbeat run not found" });
+      return;
+    }
+    assertCompanyAccess(req, run.companyId);
+
+    const attestations = await deliveryAttestations.listForRun(runId, run.companyId);
+    res.json(attestations);
   });
 
   router.get("/workspace-operations/:operationId/log", async (req, res) => {

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -135,6 +135,7 @@ import {
   projectService,
   routineService,
   workProductService,
+  deliveryAttestationService,
 } from "../services/index.js";
 import { buildPlanReviewContext } from "../services/plan-review-context.js";
 import {
@@ -2739,6 +2740,7 @@ export function issueRoutes(
   const recoveryActionsSvc = issueRecoveryActionService(db);
   const executionWorkspacesSvc = executionWorkspaceServiceDirect(db);
   const workProductsSvc = workProductService(db);
+  const deliveryAttestationsSvc = deliveryAttestationService(db);
   const documentsSvc = documentService(db);
   const companySkillsSvc = companySkillService(db);
   const documentAnnotationsSvc = documentAnnotationService(db);
@@ -6407,6 +6409,19 @@ export function issueRoutes(
     if (!(await assertIssueReadAllowed(req, res, issue))) return;
     const workProducts = await workProductsSvc.listForIssue(issue.id);
     res.json(workProducts);
+  });
+
+  router.get("/issues/:id/delivery-attestations", async (req, res) => {
+    const id = req.params.id as string;
+    const issue = await svc.getById(id);
+    if (!issue) {
+      res.status(404).json({ error: "Issue not found" });
+      return;
+    }
+    assertCompanyAccess(req, issue.companyId);
+    if (!(await assertIssueReadAllowed(req, res, issue))) return;
+    const attestations = await deliveryAttestationsSvc.listForIssue(issue.id, issue.companyId);
+    res.json(attestations);
   });
 
   router.get("/issues/:id/external-objects", async (req, res) => {

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -135,8 +135,8 @@ import {
   projectService,
   routineService,
   workProductService,
-  deliveryAttestationService,
 } from "../services/index.js";
+import { deliveryAttestationService } from "../services/delivery-attestations.js";
 import { buildPlanReviewContext } from "../services/plan-review-context.js";
 import {
   decideIssueReviewPathRecovery,

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -6413,12 +6413,8 @@ export function issueRoutes(
 
   router.get("/issues/:id/delivery-attestations", async (req, res) => {
     const id = req.params.id as string;
-    const issue = await svc.getById(id);
-    if (!issue) {
-      res.status(404).json({ error: "Issue not found" });
-      return;
-    }
-    assertCompanyAccess(req, issue.companyId);
+    const issue = await getAccessibleResource(req, res, svc.getById(id), "Issue not found");
+    if (!issue) return;
     if (!(await assertIssueReadAllowed(req, res, issue))) return;
     const attestations = await deliveryAttestationsSvc.listForIssue(issue.id, issue.companyId);
     res.json(attestations);

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -9016,7 +9016,7 @@ export function issueRoutes(
       ...updateFields,
       actorAgentId: actor.agentId ?? null,
       actorUserId: actor.actorType === "user" ? actor.actorId : null,
-      actorRunId: actor.runId ?? null,
+      ...(actor.runId ? { actorRunId: actor.runId } : {}),
     };
     const shouldCollectCompletionPublication =
       actor.actorType === "user" && existing.status !== "done" && updateFields.status === "done";

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -9016,6 +9016,7 @@ export function issueRoutes(
       ...updateFields,
       actorAgentId: actor.agentId ?? null,
       actorUserId: actor.actorType === "user" ? actor.actorId : null,
+      actorRunId: actor.runId ?? null,
     };
     const shouldCollectCompletionPublication =
       actor.actorType === "user" && existing.status !== "done" && updateFields.status === "done";

--- a/server/src/routes/openapi.ts
+++ b/server/src/routes/openapi.ts
@@ -2267,6 +2267,15 @@ registry.registerPath({
 
 registry.registerPath({
   method: "get",
+  path: "/api/issues/{id}/delivery-attestations",
+  tags: ["issues"],
+  summary: "List delivery attestations for an issue",
+  request: { params: z.object({ id: z.string() }) },
+  responses: { 200: r.ok(), 401: r.unauthorized, 404: r.notFound },
+});
+
+registry.registerPath({
+  method: "get",
   path: "/api/issues/{id}/work-products",
   tags: ["issues"],
   summary: "List issue work products",
@@ -4439,6 +4448,15 @@ registry.registerPath({
   summary: "Get log for a heartbeat run",
   request: { params: z.object({ runId: z.string() }) },
   responses: { 200: r.ok(), 401: r.unauthorized },
+});
+
+registry.registerPath({
+  method: "get",
+  path: "/api/heartbeat-runs/{runId}/delivery-attestations",
+  tags: ["runs"],
+  summary: "List delivery attestations for a heartbeat run",
+  request: { params: z.object({ runId: z.string() }) },
+  responses: { 200: r.ok(), 401: r.unauthorized, 404: r.notFound },
 });
 
 registry.registerPath({

--- a/server/src/services/delivery-attestations.ts
+++ b/server/src/services/delivery-attestations.ts
@@ -1,0 +1,253 @@
+import { createHmac, randomUUID } from "node:crypto";
+import type { Db } from "@paperclipai/db";
+import { deliveryAttestations } from "@paperclipai/db";
+import { and, desc, eq } from "drizzle-orm";
+
+export type DeliveryAttestationTargetKind = "repository_checkout" | "remote_operator_checkout" | "artifact_only";
+
+export type DeliveryAttestationDeliveryMethod =
+  | "commit"
+  | "push"
+  | "pull_request"
+  | "remote_exec"
+  | "provider_sync"
+  | "operator_handoff"
+  | "controlled_sync"
+  | "none";
+
+export type DeliveryAttestationOutcome = "succeeded" | "failed" | "not_attempted" | "operator_confirmation_required";
+
+export interface DeliveryAttestationRow {
+  id: string;
+  companyId: string;
+  issueId: string;
+  runId: string;
+  declarationId: string;
+  declarationRevision: number;
+  targetKind: DeliveryAttestationTargetKind;
+  targetFingerprint: string;
+  providerKey: string;
+  outcome: DeliveryAttestationOutcome;
+  deliveryMethod: DeliveryAttestationDeliveryMethod;
+  sourceRevision: string | null;
+  deliveredRevision: string | null;
+  destinationRefFingerprint: string | null;
+  workspaceDirty: boolean | null;
+  operationId: string | null;
+  artifactIds: string[];
+  generatedAt: Date;
+  providerSignature: string;
+}
+
+type DeliveryAttestationInsert = Omit<DeliveryAttestationRow, "id" | "providerSignature" | "generatedAt"> & {
+  operationId?: string | null;
+  artifactIds?: string[];
+};
+
+function toRow(row: typeof deliveryAttestations.$inferSelect): DeliveryAttestationRow {
+  return {
+    id: row.id,
+    companyId: row.companyId,
+    issueId: row.issueId,
+    runId: row.runId,
+    declarationId: row.declarationId,
+    declarationRevision: row.declarationRevision,
+    targetKind: row.targetKind as DeliveryAttestationTargetKind,
+    targetFingerprint: row.targetFingerprint,
+    providerKey: row.providerKey,
+    outcome: row.outcome as DeliveryAttestationOutcome,
+    deliveryMethod: row.deliveryMethod as DeliveryAttestationDeliveryMethod,
+    sourceRevision: row.sourceRevision ?? null,
+    deliveredRevision: row.deliveredRevision ?? null,
+    destinationRefFingerprint: row.destinationRefFingerprint ?? null,
+    workspaceDirty: row.workspaceDirty ?? null,
+    operationId: row.operationId || null,
+    artifactIds: (row.artifactIds as string[] | null) ?? [],
+    generatedAt: row.generatedAt,
+    providerSignature: row.providerSignature,
+  };
+}
+
+/**
+ * providerSignature is server-generated authenticity evidence, not an
+ * agent-supplied string (doc/execution-semantics.md, "Durable target and
+ * attestation schema"). It is an HMAC over the immutable identity fields of
+ * the attestation, domain-separated from other HMAC uses of the same master
+ * secret the same way computeTargetFingerprint and the agent JWT signer are.
+ */
+function computeProviderSignature(input: {
+  companyId: string;
+  issueId: string;
+  runId: string;
+  declarationId: string;
+  declarationRevision: number;
+  targetFingerprint: string;
+  outcome: string;
+  deliveryMethod: string;
+  operationId: string;
+  generatedAt: Date;
+}): string {
+  const masterSecret = process.env.PAPERCLIP_AGENT_JWT_SECRET?.trim() || process.env.BETTER_AUTH_SECRET?.trim();
+  if (!masterSecret) {
+    throw new Error("Cannot sign delivery attestation: no signing secret configured");
+  }
+  const signingKey = createHmac("sha256", masterSecret).update("delivery-attestation-signature:v1").digest();
+  const payload = [
+    input.companyId,
+    input.issueId,
+    input.runId,
+    input.declarationId,
+    String(input.declarationRevision),
+    input.targetFingerprint,
+    input.outcome,
+    input.deliveryMethod,
+    input.operationId,
+    input.generatedAt.toISOString(),
+  ].join("\n");
+  return `v1:${createHmac("sha256", signingKey).update(payload).digest("hex")}`;
+}
+
+export function deliveryAttestationService(db: Db) {
+  return {
+    /**
+     * Records provider-generated delivery evidence. Append-only: a repeated
+     * call for the exact same (runId, declarationId, declarationRevision,
+     * deliveryMethod, operationId) tuple is a no-op — callers reporting a new
+     * attempt must mint a new operationId rather than overwrite prior evidence.
+     */
+    async record(input: DeliveryAttestationInsert): Promise<DeliveryAttestationRow> {
+      const id = randomUUID();
+      const generatedAt = new Date();
+      const operationId = input.operationId ?? "";
+      const providerSignature = computeProviderSignature({
+        companyId: input.companyId,
+        issueId: input.issueId,
+        runId: input.runId,
+        declarationId: input.declarationId,
+        declarationRevision: input.declarationRevision,
+        targetFingerprint: input.targetFingerprint,
+        outcome: input.outcome,
+        deliveryMethod: input.deliveryMethod,
+        operationId,
+        generatedAt,
+      });
+
+      const inserted = await db
+        .insert(deliveryAttestations)
+        .values({
+          id,
+          companyId: input.companyId,
+          issueId: input.issueId,
+          runId: input.runId,
+          declarationId: input.declarationId,
+          declarationRevision: input.declarationRevision,
+          targetKind: input.targetKind,
+          targetFingerprint: input.targetFingerprint,
+          providerKey: input.providerKey,
+          outcome: input.outcome,
+          deliveryMethod: input.deliveryMethod,
+          sourceRevision: input.sourceRevision ?? null,
+          deliveredRevision: input.deliveredRevision ?? null,
+          destinationRefFingerprint: input.destinationRefFingerprint ?? null,
+          workspaceDirty: input.workspaceDirty ?? null,
+          operationId,
+          artifactIds: input.artifactIds ?? [],
+          generatedAt,
+          providerSignature,
+        })
+        .onConflictDoNothing({
+          target: [
+            deliveryAttestations.runId,
+            deliveryAttestations.declarationId,
+            deliveryAttestations.declarationRevision,
+            deliveryAttestations.deliveryMethod,
+            deliveryAttestations.operationId,
+          ],
+        })
+        .returning()
+        .then((rows) => rows[0] ?? null);
+
+      if (inserted) return toRow(inserted);
+
+      // Already recorded under this exact operation key — return the existing row.
+      const existing = await db
+        .select()
+        .from(deliveryAttestations)
+        .where(
+          and(
+            eq(deliveryAttestations.runId, input.runId),
+            eq(deliveryAttestations.declarationId, input.declarationId),
+            eq(deliveryAttestations.declarationRevision, input.declarationRevision),
+            eq(deliveryAttestations.deliveryMethod, input.deliveryMethod),
+            eq(deliveryAttestations.operationId, operationId),
+          ),
+        )
+        .then((rows) => rows[0] ?? null);
+      if (!existing) throw new Error("Failed to record or locate delivery attestation");
+      return toRow(existing);
+    },
+
+    async getById(id: string, scope: { companyId: string; issueId: string }): Promise<DeliveryAttestationRow | null> {
+      const row = await db
+        .select()
+        .from(deliveryAttestations)
+        .where(
+          and(
+            eq(deliveryAttestations.id, id),
+            eq(deliveryAttestations.companyId, scope.companyId),
+            eq(deliveryAttestations.issueId, scope.issueId),
+          ),
+        )
+        .then((rows) => rows[0] ?? null);
+      return row ? toRow(row) : null;
+    },
+
+    async listForIssue(issueId: string, companyId: string): Promise<DeliveryAttestationRow[]> {
+      const rows = await db
+        .select()
+        .from(deliveryAttestations)
+        .where(and(eq(deliveryAttestations.issueId, issueId), eq(deliveryAttestations.companyId, companyId)))
+        .orderBy(desc(deliveryAttestations.generatedAt));
+      return rows.map(toRow);
+    },
+
+    async listForRun(runId: string, companyId: string): Promise<DeliveryAttestationRow[]> {
+      const rows = await db
+        .select()
+        .from(deliveryAttestations)
+        .where(and(eq(deliveryAttestations.runId, runId), eq(deliveryAttestations.companyId, companyId)))
+        .orderBy(desc(deliveryAttestations.generatedAt));
+      return rows.map(toRow);
+    },
+
+    /**
+     * Finds attestations that could satisfy a workspace_delivery terminal
+     * transition for the given issue at its current requirement revision.
+     * Scoping strictly by companyId + issueId + declarationRevision + outcome
+     * is what prevents an unrelated sibling run (different issueId, or the
+     * same issue's stale/prior-revision run) from satisfying this issue's
+     * completion — a sibling's rows simply never match this filter.
+     */
+    async findSucceededForIssue(input: {
+      companyId: string;
+      issueId: string;
+      declarationRevision: number;
+    }): Promise<DeliveryAttestationRow[]> {
+      const rows = await db
+        .select()
+        .from(deliveryAttestations)
+        .where(
+          and(
+            eq(deliveryAttestations.companyId, input.companyId),
+            eq(deliveryAttestations.issueId, input.issueId),
+            eq(deliveryAttestations.declarationRevision, input.declarationRevision),
+            eq(deliveryAttestations.outcome, "succeeded"),
+          ),
+        )
+        .orderBy(desc(deliveryAttestations.generatedAt));
+      return rows.map(toRow);
+    },
+  };
+}
+
+export type DeliveryAttestationService = ReturnType<typeof deliveryAttestationService>;

--- a/server/src/services/delivery-attestations.ts
+++ b/server/src/services/delivery-attestations.ts
@@ -231,6 +231,7 @@ export function deliveryAttestationService(db: Db) {
     async findSucceededForIssue(input: {
       companyId: string;
       issueId: string;
+      runId: string;
       declarationRevision: number;
     }): Promise<DeliveryAttestationRow[]> {
       const rows = await db
@@ -240,6 +241,7 @@ export function deliveryAttestationService(db: Db) {
           and(
             eq(deliveryAttestations.companyId, input.companyId),
             eq(deliveryAttestations.issueId, input.issueId),
+            eq(deliveryAttestations.runId, input.runId),
             eq(deliveryAttestations.declarationRevision, input.declarationRevision),
             eq(deliveryAttestations.outcome, "succeeded"),
           ),

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -2013,6 +2013,7 @@ export async function assertGitSensitiveAdapterWorkspaceValid(input: {
     identifier: string | null;
     projectId: string | null;
     projectWorkspaceId: string | null;
+    completionRequirement?: string | null;
   } | null;
   resolvedWorkspace: ResolvedWorkspaceForRun;
   executionWorkspace: RealizedExecutionWorkspace;
@@ -2175,6 +2176,21 @@ export async function assertGitSensitiveAdapterWorkspaceValid(input: {
         { managedGitWorktreeBranch: formatManagedGitWorktreeBranchInspection(inspection) },
       );
     }
+  }
+
+  if (
+    workspaceExpectation &&
+    !input.resolvedWorkspace.repoUrl &&
+    input.resolvedWorkspace.source === "project_primary" &&
+    issue.completionRequirement === "workspace_delivery"
+  ) {
+    fail(
+      "null_repo_delivery_required",
+      `Issue ${issue.identifier ?? issue.id} requires workspace delivery but the project_primary workspace has no repository URL. ` +
+      `A project_primary folder without a repository locator cannot be an authoritative repository checkout. ` +
+      `Set a repository URL on the project workspace or change the issue completion requirement to evidence_only or artifact.`,
+      { completionRequirement: issue.completionRequirement, resolvedWorkspaceSource: input.resolvedWorkspace.source },
+    );
   }
 }
 
@@ -7093,6 +7109,8 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         originId: issues.originId,
         originRunId: issues.originRunId,
         updatedAt: issues.updatedAt,
+        completionRequirement: issues.completionRequirement,
+        completionRequirementRevision: issues.completionRequirementRevision,
       })
       .from(issues)
       .where(and(eq(issues.id, issueId), eq(issues.companyId, companyId)))
@@ -13809,6 +13827,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           projectWorkspaceId: issueContext.projectWorkspaceId,
           executionWorkspaceId: issueContext.executionWorkspaceId,
           executionWorkspacePreference: issueContext.executionWorkspacePreference,
+          completionRequirement: issueContext.completionRequirement,
         }
       : null;
     const continuationSummary = issueRef
@@ -15257,6 +15276,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
               identifier: issueRef.identifier,
               projectId: issueRef.projectId,
               projectWorkspaceId: issueRef.projectWorkspaceId,
+              completionRequirement: issueRef.completionRequirement,
             }
           : null,
         resolvedWorkspace,

--- a/server/src/services/index.ts
+++ b/server/src/services/index.ts
@@ -158,6 +158,7 @@ export {
 } from "./environment-custom-image-terminal-sessions.js";
 export { executionWorkspaceService } from "./execution-workspaces.js";
 export { workspaceOperationService } from "./workspace-operations.js";
+export { deliveryAttestationService, type DeliveryAttestationRow } from "./delivery-attestations.js";
 export { workspaceFileResourceService } from "./workspace-file-resources.js";
 export { workProductService } from "./work-products.js";
 export {

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -129,6 +129,7 @@ import {
   type ActivityPublication,
 } from "./activity-log.js";
 import { buildIssueChanges } from "./issue-change-receipt.js";
+import { deliveryAttestationService } from "./delivery-attestations.js";
 
 const ALL_ISSUE_STATUSES = ["backlog", "todo", "in_progress", "in_review", "blocked", "done", "cancelled"];
 const MAX_ISSUE_COMMENT_PAGE_LIMIT = 500;
@@ -3136,6 +3137,8 @@ const issueListSelect = {
   unblockDescriptor: issues.unblockDescriptor,
   blockedTransitionAt: issues.blockedTransitionAt,
   blockedOwnerNotifiedAt: issues.blockedOwnerNotifiedAt,
+  completionRequirement: issues.completionRequirement,
+  completionRequirementRevision: issues.completionRequirementRevision,
   startedAt: issues.startedAt,
   completedAt: issues.completedAt,
   cancelledAt: issues.cancelledAt,
@@ -4345,6 +4348,7 @@ async function countBlockedInboxIssues(dbOrTx: any, companyId: string, filters?:
 export function issueService(db: Db) {
   const instanceSettings = instanceSettingsService(db);
   const treeControlSvc = issueTreeControlService(db);
+  const deliveryAttestations = deliveryAttestationService(db);
 
   function normalizeCreateIssueTitle(title: string) {
     return title.trim().replace(/\s+/g, " ").toLowerCase();
@@ -5395,6 +5399,53 @@ export function issueService(db: Db) {
       })
       .returning();
     return row;
+  /**
+   * Terminal `done`-transition gate for `workspace_delivery` issues
+   * (doc/execution-semantics.md, "Terminal transition contract"). Requires a
+   * `succeeded` delivery attestation scoped to this exact company + issue +
+   * completion-requirement revision. Scoping by issueId (rather than, say,
+   * just companyId or providerKey) is what prevents an unrelated sibling
+   * run's attestation from satisfying this issue's completion.
+   */
+  async function assertDeliveryAttestationSatisfied(input: {
+    companyId: string;
+    issueId: string;
+    completionRequirement: string | null;
+    completionRequirementRevision: number;
+    deliveryAttestationId?: string;
+  }) {
+    if (input.completionRequirement !== "workspace_delivery") return;
+
+    if (input.deliveryAttestationId) {
+      const attestation = await deliveryAttestations.getById(input.deliveryAttestationId, {
+        companyId: input.companyId,
+        issueId: input.issueId,
+      });
+      if (
+        attestation &&
+        attestation.outcome === "succeeded" &&
+        attestation.declarationRevision === input.completionRequirementRevision
+      ) {
+        return;
+      }
+      throw unprocessable("Delivery attestation is required to complete this issue", {
+        code: "delivery_attestation_required",
+        completionRequirementRevision: input.completionRequirementRevision,
+      });
+    }
+
+    const candidates = await deliveryAttestations.findSucceededForIssue({
+      companyId: input.companyId,
+      issueId: input.issueId,
+      declarationRevision: input.completionRequirementRevision,
+    });
+    if (candidates.length === 1) return;
+
+    throw unprocessable("Delivery attestation is required to complete this issue", {
+      code: "delivery_attestation_required",
+      completionRequirementRevision: input.completionRequirementRevision,
+      matchingAttestationCount: candidates.length,
+    });
   }
 
   return {
@@ -7472,6 +7523,7 @@ export function issueService(db: Db) {
         blockedByIssueIds?: string[];
         actorAgentId?: string | null;
         actorUserId?: string | null;
+        deliveryAttestationId?: string;
       },
       dbOrTx: any = db,
       postCommitActivityPublications?: ActivityPublication[],
@@ -7490,6 +7542,7 @@ export function issueService(db: Db) {
         blockedByIssueIds,
         actorAgentId,
         actorUserId,
+        deliveryAttestationId,
         ...issueData
       } = data;
       const isolatedWorkspacesEnabled = (await instanceSettings.getExperimental()).enableIsolatedWorkspaces;
@@ -7608,6 +7661,16 @@ export function issueService(db: Db) {
           executionWorkspaceId: nextExecutionWorkspaceId ?? null,
           executionWorkspacePreference: nextExecutionWorkspacePreference ?? null,
           executionWorkspaceSettings: issueData.executionWorkspaceSettings,
+        });
+      }
+
+      if (patch.status === "done" && existing.status !== "done") {
+        await assertDeliveryAttestationSatisfied({
+          companyId: existing.companyId,
+          issueId: existing.id,
+          completionRequirement: existing.completionRequirement,
+          completionRequirementRevision: existing.completionRequirementRevision,
+          deliveryAttestationId,
         });
       }
 

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -5414,9 +5414,18 @@ export function issueService(db: Db) {
     issueId: string;
     completionRequirement: string | null;
     completionRequirementRevision: number;
+    expectedRunId: string | null;
     deliveryAttestationId?: string;
   }) {
     if (input.completionRequirement !== "workspace_delivery") return;
+
+    if (!input.expectedRunId) {
+      throw unprocessable("Delivery attestation is required to complete this issue", {
+        code: "delivery_attestation_required",
+        completionRequirementRevision: input.completionRequirementRevision,
+        reason: "delivery_run_required",
+      });
+    }
 
     if (input.deliveryAttestationId) {
       const attestation = await deliveryAttestations.getById(input.deliveryAttestationId, {
@@ -5426,6 +5435,7 @@ export function issueService(db: Db) {
       if (
         attestation &&
         attestation.outcome === "succeeded" &&
+        attestation.runId === input.expectedRunId &&
         attestation.declarationRevision === input.completionRequirementRevision
       ) {
         return;
@@ -5439,9 +5449,10 @@ export function issueService(db: Db) {
     const candidates = await deliveryAttestations.findSucceededForIssue({
       companyId: input.companyId,
       issueId: input.issueId,
+      runId: input.expectedRunId,
       declarationRevision: input.completionRequirementRevision,
     });
-    if (candidates.length === 1) return;
+    if (candidates.length > 0) return;
 
     throw unprocessable("Delivery attestation is required to complete this issue", {
       code: "delivery_attestation_required",
@@ -7525,6 +7536,7 @@ export function issueService(db: Db) {
         blockedByIssueIds?: string[];
         actorAgentId?: string | null;
         actorUserId?: string | null;
+        actorRunId?: string | null;
         deliveryAttestationId?: string;
       },
       dbOrTx: any = db,
@@ -7544,6 +7556,7 @@ export function issueService(db: Db) {
         blockedByIssueIds,
         actorAgentId,
         actorUserId,
+        actorRunId,
         deliveryAttestationId,
         ...issueData
       } = data;
@@ -7672,6 +7685,7 @@ export function issueService(db: Db) {
           issueId: existing.id,
           completionRequirement: existing.completionRequirement,
           completionRequirementRevision: existing.completionRequirementRevision,
+          expectedRunId: actorRunId ?? existing.executionRunId,
           deliveryAttestationId,
         });
       }

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -5399,6 +5399,8 @@ export function issueService(db: Db) {
       })
       .returning();
     return row;
+  }
+
   /**
    * Terminal `done`-transition gate for `workspace_delivery` issues
    * (doc/execution-semantics.md, "Terminal transition contract"). Requires a

--- a/server/src/services/workspace-target-fingerprint.ts
+++ b/server/src/services/workspace-target-fingerprint.ts
@@ -1,0 +1,45 @@
+import { createHmac } from "node:crypto";
+
+/**
+ * Derives the versioned keyed-hash fingerprint used to identify a workspace
+ * target (repository, remote path, etc.) without exposing the underlying
+ * locator. See doc/execution-semantics.md, "Privacy-safe fingerprints":
+ *
+ *   v1:hmac-sha256(instance_attestation_key, companyId + "\n" + providerKey + "\n" + canonicalLocator)
+ *
+ * The key is derived from the shared agent JWT master secret, domain-separated
+ * with a "workspace-target-fingerprint:" prefix so it cannot be confused with
+ * or reused as the JWT signing key (see agent-auth-jwt.ts for the same pattern).
+ */
+export function computeTargetFingerprint(companyId: string, providerKey: string, canonicalLocator: string): string {
+  const masterSecret = process.env.PAPERCLIP_AGENT_JWT_SECRET?.trim() || process.env.BETTER_AUTH_SECRET?.trim();
+  if (!masterSecret) {
+    throw new Error("Cannot compute workspace target fingerprint: no signing secret configured");
+  }
+  const instanceKey = createHmac("sha256", masterSecret).update("workspace-target-fingerprint:v1").digest();
+  const digest = createHmac("sha256", instanceKey)
+    .update(`${companyId}\n${providerKey}\n${canonicalLocator}`)
+    .digest("hex");
+  return `v1:${digest}`;
+}
+
+/**
+ * Canonicalizes a repository/remote locator before fingerprinting: strips
+ * credentials, userinfo, query parameters, and fragments so the fingerprint
+ * never depends on (or leaks) secret-bearing parts of the locator.
+ */
+export function canonicalizeRepositoryLocator(rawLocator: string): string {
+  const trimmed = rawLocator.trim();
+  try {
+    const url = new URL(trimmed);
+    url.username = "";
+    url.password = "";
+    url.search = "";
+    url.hash = "";
+    return `${url.protocol}//${url.host}${url.pathname.replace(/\/+$/, "")}`.toLowerCase();
+  } catch {
+    // Not a URL (e.g. an scp-style git remote or bare path) — strip any
+    // userinfo-like "user@" prefix and trailing slashes, lowercase for stability.
+    return trimmed.replace(/^[^@/\s]+@/, "").replace(/\/+$/, "").toLowerCase();
+  }
+}


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The workspace dispatch and issue completion subsystem is involved
> - Agents dispatched to a `project_primary` workspace with `repoUrl=null` can self-report `done` without any verifiable delivery — the existing git-sensitive workspace guard does not fire for this shape
> - This allows false completions where no code ever landed on the real target repo, undermining trust in agent-reported status
> - This pull request adds a server-side delivery attestation requirement and gates the terminal `done`-transition on it, rejecting null-repo `project_primary` dispatch when `workspace_delivery` is required
> - The benefit is that agents can no longer falsely report completion without verifiable workspace delivery evidence

## Linked Issues or Issue Description

No public GitHub issue exists for this. Describing the bug inline per the bug report template:

**What happened?**
Agents dispatched to a `project_primary` workspace with `repoUrl=null`, no git remote, and no sync target can build unrelated accumulated files and self-report `done` without any delivery evidence. The existing git-sensitive workspace guard (`assertGitSensitiveAdapterWorkspaceValid`) does not fire for the plain-project-primary shape (`source === "project_primary"` with null repo), allowing the `done` transition to succeed with no target-bound attestation.

**Expected behavior**
When an issue has `completionRequirement === "workspace_delivery"`, the server should reject dispatch to null-repo `project_primary` workspaces and gate the terminal `done`-transition on a server-signed, append-only delivery attestation scoped to the completing run.

**Steps to reproduce**
1. Create a project with a `project_primary` workspace (`repoUrl=null`, `source="project_primary"`)
2. Create an issue with `completionRequirement` not set (current behavior — no enforcement)
3. Dispatch an agent to the workspace
4. Agent builds unrelated files in the workspace and self-reports `done`
5. Issue transitions to `done` with no delivery evidence — no git commit, no push, no attestation

**Paperclip version or commit**
Branch `paperclip-try-715-delivery-attestation` at `922957f345e5`

**Deployment mode**
Self-hosted server

**Installation method**
Built from source (pnpm dev / pnpm build)

Refs: #9803 (related docs PR codifying the terminal delivery contract), #10149 (related enforcement PR)

## What Changed

- **Schema**: Added `completionRequirement` and `completionRequirementRevision` columns to `issues` table
- **Schema**: Added `defaultCompletionRequirement` column to `project_workspaces` table
- **Migration**: `0125_issue_completion_requirement.sql` with journal entry
- **Server**: `heartbeat.ts` — `assertGitSensitiveAdapterWorkspaceValid` now rejects dispatch when `completionRequirement === "workspace_delivery"` and the resolved workspace has `source === "project_primary"` with no `repoUrl` (`null_repo_delivery_required`)
- **Tests**: 92 tests passing in `heartbeat-workspace-session.test.ts`

## Verification

- `pnpm vitest run server/src/__tests__/heartbeat-workspace-session.test.ts` — 92/92 passing
- Confirmed the guard rejects null-repo `project_primary` dispatch for `workspace_delivery` issues
- Confirmed valid registered targets remain productive (no false blocks)

## Risks

- **Low**: Existing issues without `completionRequirement` set are unaffected (null = no enforcement)
- **Low**: Migration is additive (new columns, no data loss)
- **Medium**: Projects relying on non-git `project_primary` workspaces for delivery will need to register a proper workspace or opt out explicitly

## Model Used

Atlas (CTO agent, gpt-5.6-sol) via Paperclip on Odin. Extended thinking mode enabled. 128K context window. Tool use and code execution capabilities active.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above (Refs: #9803, #10149)
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs: #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [ ] My branch name describes the change and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge