### PR TITLE
feat: download all issue attachments as a ZIP

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -79,6 +79,7 @@
     "sharp": "^0.35.3",
     "ssh2": "^1.17.0",
     "ws": "^8.21.1",
+    "zip-stream": "^7.0.5",
     "zod": "^3.24.2"
   },
   "devDependencies": {
@@ -90,6 +91,7 @@
     "@types/sharp": "^0.32.0",
     "@types/supertest": "^6.0.2",
     "@types/ws": "^8.18.1",
+    "@types/zip-stream": "^7.0.0",
     "cross-env": "^10.1.0",
     "supertest": "^7.0.0",
     "tsx": "^4.23.1",

--- a/server/src/__tests__/issue-attachment-routes.test.ts
+++ b/server/src/__tests__/issue-attachment-routes.test.ts
@@ -415,6 +415,30 @@ describe("issue attachment routes", () => {
     expect(res.body.error).toBe("Internal server error");
   });
 
+  it("terminates the archive response when an attachment stream fails", async () => {
+    const storage = createStorageService();
+    mockIssueService.listAttachments.mockResolvedValue([makeAttachment("text/plain", "report.txt")]);
+    vi.mocked(storage.getObject).mockResolvedValue({
+      stream: new Readable({
+        read() {
+          this.push("partial");
+          queueMicrotask(() => this.destroy(new Error("stream failed")));
+        },
+      }),
+      contentLength: 7,
+    });
+    const app = await createApp(storage);
+
+    const result = await Promise.race([
+      request(app)
+        .get("/api/issues/11111111-1111-4111-8111-111111111111/attachments/archive")
+        .then(() => "completed", () => "aborted"),
+      new Promise<string>((resolve) => setTimeout(() => resolve("timed-out"), 1_000)),
+    ]);
+
+    expect(result).toBe("aborted");
+  });
+
   it("rejects cross-company issue archive reads before loading entries", async () => {
     const storage = createStorageService();
     const app = await createApp(storage, { companyIds: ["company-2"], source: "session" });

--- a/server/src/__tests__/issue-attachment-routes.test.ts
+++ b/server/src/__tests__/issue-attachment-routes.test.ts
@@ -1,5 +1,6 @@
 import { Readable } from "node:stream";
 import type { IncomingMessage } from "node:http";
+import { inflateRawSync } from "node:zlib";
 import express from "express";
 import request from "supertest";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -10,6 +11,10 @@ const mockIssueService = vi.hoisted(() => ({
   getByIdentifier: vi.fn(),
   createAttachment: vi.fn(),
   getAttachmentById: vi.fn(),
+  listAttachments: vi.fn(),
+}));
+const mockDocumentService = vi.hoisted(() => ({
+  listIssueDocuments: vi.fn(),
 }));
 const mockCompanyService = vi.hoisted(() => ({
   getById: vi.fn(),
@@ -56,7 +61,7 @@ function registerRouteMocks() {
     companySkillService: () => ({}),
     companyService: () => mockCompanyService,
     documentAnnotationService: () => ({ remapOpenThreadsForDocument: async () => [] }),
-    documentService: () => ({}),
+    documentService: () => mockDocumentService,
     executionWorkspaceService: () => ({}),
     feedbackService: () => ({
       listIssueVotesForUser: vi.fn(async () => []),
@@ -204,6 +209,33 @@ function parseBinaryResponse(res: IncomingMessage, callback: (error: Error | nul
   res.on("error", callback);
 }
 
+function readZipEntries(buffer: Buffer): Map<string, Buffer> {
+  const endOfCentralDirectory = buffer.lastIndexOf(Buffer.from([0x50, 0x4b, 0x05, 0x06]));
+  if (endOfCentralDirectory < 0) throw new Error("ZIP end-of-central-directory record not found");
+  const entryCount = buffer.readUInt16LE(endOfCentralDirectory + 10);
+  let centralOffset = buffer.readUInt32LE(endOfCentralDirectory + 16);
+  const entries = new Map<string, Buffer>();
+
+  for (let index = 0; index < entryCount; index += 1) {
+    if (buffer.readUInt32LE(centralOffset) !== 0x02014b50) throw new Error("Invalid ZIP central directory entry");
+    const compressionMethod = buffer.readUInt16LE(centralOffset + 10);
+    const compressedSize = buffer.readUInt32LE(centralOffset + 20);
+    const filenameLength = buffer.readUInt16LE(centralOffset + 28);
+    const extraLength = buffer.readUInt16LE(centralOffset + 30);
+    const commentLength = buffer.readUInt16LE(centralOffset + 32);
+    const localOffset = buffer.readUInt32LE(centralOffset + 42);
+    const filename = buffer.subarray(centralOffset + 46, centralOffset + 46 + filenameLength).toString("utf8");
+    const localFilenameLength = buffer.readUInt16LE(localOffset + 26);
+    const localExtraLength = buffer.readUInt16LE(localOffset + 28);
+    const dataOffset = localOffset + 30 + localFilenameLength + localExtraLength;
+    const compressed = buffer.subarray(dataOffset, dataOffset + compressedSize);
+    entries.set(filename, compressionMethod === 0 ? compressed : inflateRawSync(compressed));
+    centralOffset += 46 + filenameLength + extraLength + commentLength;
+  }
+
+  return entries;
+}
+
 describe("normalizeIssueAttachmentMaxBytes", () => {
   it("keeps the process-level attachment cap as the final cap", async () => {
     const previous = process.env.PAPERCLIP_ATTACHMENT_MAX_BYTES;
@@ -253,6 +285,8 @@ describe("issue attachment routes", () => {
       assigneeUserId: null,
       identifier: "PAP-1",
     });
+    mockIssueService.listAttachments.mockResolvedValue([]);
+    mockDocumentService.listIssueDocuments.mockResolvedValue([]);
     mockCompanyService.getById.mockResolvedValue({
       id: "company-1",
       attachmentMaxBytes: 1024 * 1024 * 1024,
@@ -260,6 +294,148 @@ describe("issue attachment routes", () => {
     mockWorkProductService.createForIssue.mockReset();
     mockWorkProductService.getById.mockReset();
     mockWorkProductService.update.mockReset();
+  });
+
+  it("streams attachments and visible documents in a private ZIP archive", async () => {
+    const storage = createStorageService();
+    const firstAttachment = {
+      ...makeAttachment("application/octet-stream", "report.txt"),
+      id: "attachment-a",
+      objectKey: "issues/issue-1/report-a.txt",
+      issueCommentId: "comment-1",
+    };
+    const duplicateAttachment = {
+      ...makeAttachment("application/octet-stream", "report.txt"),
+      id: "attachment-b",
+      objectKey: "issues/issue-1/report-b.txt",
+    };
+    const unnamedAttachment = {
+      ...makeAttachment("image/png", "ignored.png"),
+      id: "attachment-c",
+      objectKey: "issues/issue-1/unnamed",
+      originalFilename: null,
+    };
+    mockIssueService.listAttachments.mockResolvedValue([
+      duplicateAttachment,
+      unnamedAttachment,
+      firstAttachment,
+    ]);
+    mockDocumentService.listIssueDocuments.mockImplementation(async (_issueId, options) => options?.includeSystem
+      ? [
+          { key: "plan", body: "# Plan\n", updatedAt: new Date("2026-01-02T00:00:00.000Z") },
+          { key: "continuation-summary", body: "internal", updatedAt: new Date("2026-01-02T00:00:00.000Z") },
+        ]
+      : [{ key: "plan", body: "# Plan\n", updatedAt: new Date("2026-01-02T00:00:00.000Z") }]);
+    vi.mocked(storage.getObject).mockImplementation(async (_companyId, objectKey) => ({
+      stream: Readable.from({
+        "issues/issue-1/report-a.txt": Buffer.from([0x00, 0x01, 0xff]),
+        "issues/issue-1/report-b.txt": Buffer.from("second"),
+        "issues/issue-1/unnamed": Buffer.from([0x89, 0x50, 0x4e, 0x47]),
+      }[objectKey] ?? Buffer.alloc(0)),
+      contentLength: 0,
+    }));
+
+    const app = await createApp(storage);
+    const res = await request(app)
+      .get("/api/issues/11111111-1111-4111-8111-111111111111/attachments/archive")
+      .buffer(true)
+      .parse(parseBinaryResponse);
+
+    expect(res.status).toBe(200);
+    expect(res.headers["content-type"]).toContain("application/zip");
+    expect(res.headers["content-disposition"]).toBe('attachment; filename="attachments-PAP-1.zip"');
+    expect(res.headers["cache-control"]).toBe("private, no-store, no-transform");
+    expect(res.headers["x-content-type-options"]).toBe("nosniff");
+    expect(res.headers["content-length"]).toBeUndefined();
+    expect(res.headers["transfer-encoding"]).toBe("chunked");
+
+    const entries = readZipEntries(Buffer.from(res.body));
+    expect([...entries.keys()].sort()).toEqual([
+      "attachments/attachment-attachment-c.png",
+      "attachments/report-2.txt",
+      "attachments/report.txt",
+      "documents/plan.md",
+    ]);
+    expect(entries.get("attachments/report.txt")).toEqual(Buffer.from([0x00, 0x01, 0xff]));
+    expect(entries.get("attachments/report-2.txt")?.toString("utf8")).toBe("second");
+    expect(entries.get("documents/plan.md")?.toString("utf8")).toBe("# Plan\n");
+    expect(entries.has("documents/continuation-summary.md")).toBe(false);
+    expect(mockDocumentService.listIssueDocuments).toHaveBeenCalledWith("11111111-1111-4111-8111-111111111111");
+    expect(storage.getObject).toHaveBeenCalledTimes(3);
+  });
+
+  it("sanitizes traversal and control characters in archive entry names", async () => {
+    const storage = createStorageService(Buffer.from("safe"));
+    mockIssueService.listAttachments.mockResolvedValue([{
+      ...makeAttachment("text/plain", "../folder\\bad\u0000.txt"),
+      id: "attachment-safe",
+    }]);
+
+    const app = await createApp(storage);
+    const res = await request(app)
+      .get("/api/issues/11111111-1111-4111-8111-111111111111/attachments/archive")
+      .buffer(true)
+      .parse(parseBinaryResponse);
+
+    expect(res.status).toBe(200);
+    const [entryName] = readZipEntries(Buffer.from(res.body)).keys();
+    expect(entryName).toMatch(/^attachments\//);
+    expect(entryName).not.toContain("..");
+    expect(entryName).not.toContain("\\");
+    expect(entryName).not.toContain("\u0000");
+  });
+
+  it("returns 422 when an issue has no exportable archive entries", async () => {
+    const app = await createApp(createStorageService());
+    const res = await request(app)
+      .get("/api/issues/11111111-1111-4111-8111-111111111111/attachments/archive");
+
+    expect(res.status).toBe(422);
+    expect(res.body.error).toBe("Issue has no exportable attachments or documents");
+  });
+
+  it("returns 404 for a missing issue archive", async () => {
+    mockIssueService.getById.mockResolvedValue(null);
+    const app = await createApp(createStorageService());
+    const res = await request(app).get("/api/issues/missing/attachments/archive");
+
+    expect(res.status).toBe(404);
+  });
+
+  it("returns the normal server error response when storage fails before streaming", async () => {
+    const storage = createStorageService();
+    mockIssueService.listAttachments.mockResolvedValue([makeAttachment("text/plain", "report.txt")]);
+    vi.mocked(storage.getObject).mockRejectedValue(new Error("storage unavailable"));
+    const app = await createApp(storage);
+    const res = await request(app)
+      .get("/api/issues/11111111-1111-4111-8111-111111111111/attachments/archive");
+
+    expect(res.status).toBe(500);
+    expect(res.headers["content-disposition"]).toBeUndefined();
+    expect(res.body.error).toBe("Internal server error");
+  });
+
+  it("rejects cross-company issue archive reads before loading entries", async () => {
+    const storage = createStorageService();
+    const app = await createApp(storage, { companyIds: ["company-2"], source: "session" });
+    const res = await request(app)
+      .get("/api/issues/11111111-1111-4111-8111-111111111111/attachments/archive");
+
+    expect(res.status).toBe(403);
+    expect(mockIssueService.listAttachments).not.toHaveBeenCalled();
+    expect(storage.getObject).not.toHaveBeenCalled();
+  });
+
+  it("rejects issue archive reads outside the task boundary", async () => {
+    const storage = createStorageService();
+    mockAccessService.decide.mockResolvedValue({ allowed: false, explanation: "Denied by test mock" });
+    const app = await createApp(storage);
+    const res = await request(app)
+      .get("/api/issues/11111111-1111-4111-8111-111111111111/attachments/archive");
+
+    expect(res.status).toBe(403);
+    expect(mockIssueService.listAttachments).not.toHaveBeenCalled();
+    expect(storage.getObject).not.toHaveBeenCalled();
   });
 
   it("accepts zip uploads for issue attachments", async () => {

--- a/server/src/__tests__/issue-attachment-routes.test.ts
+++ b/server/src/__tests__/issue-attachment-routes.test.ts
@@ -445,7 +445,8 @@ describe("issue attachment routes", () => {
     const res = await request(app)
       .get("/api/issues/11111111-1111-4111-8111-111111111111/attachments/archive");
 
-    expect(res.status).toBe(403);
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ error: "Issue not found" });
     expect(mockIssueService.listAttachments).not.toHaveBeenCalled();
     expect(storage.getObject).not.toHaveBeenCalled();
   });

--- a/server/src/issue-attachment-archive.ts
+++ b/server/src/issue-attachment-archive.ts
@@ -1,0 +1,88 @@
+import { extname } from "node:path";
+
+type AttachmentArchiveInput = {
+  id: string;
+  contentType: string;
+  originalFilename: string | null;
+};
+
+type DocumentArchiveInput = {
+  key: string;
+};
+
+const CONTENT_TYPE_EXTENSIONS: Readonly<Record<string, string>> = {
+  "application/json": ".json",
+  "application/pdf": ".pdf",
+  "application/zip": ".zip",
+  "image/gif": ".gif",
+  "image/jpeg": ".jpg",
+  "image/jpg": ".jpg",
+  "image/png": ".png",
+  "image/svg+xml": ".svg",
+  "image/webp": ".webp",
+  "text/csv": ".csv",
+  "text/html": ".html",
+  "text/markdown": ".md",
+  "text/plain": ".txt",
+  "video/mp4": ".mp4",
+  "video/quicktime": ".mov",
+  "video/webm": ".webm",
+  "video/x-m4v": ".m4v",
+};
+
+export function sanitizeArchivePathSegment(value: string, fallback: string): string {
+  const sanitized = value
+    .normalize("NFKC")
+    .replace(/[\\/]/g, "-")
+    .replace(/[\u0000-\u001f\u007f]/g, "")
+    .replace(/\.{2,}/g, ".")
+    .replace(/^\.+/, "")
+    .trim();
+  return sanitized || fallback;
+}
+
+function inferredAttachmentExtension(contentType: string): string {
+  return CONTENT_TYPE_EXTENSIONS[contentType.split(";", 1)[0]?.trim().toLowerCase() ?? ""] ?? "";
+}
+
+function suffixDuplicateFilename(filename: string, suffix: number): string {
+  const extension = extname(filename);
+  const stem = extension ? filename.slice(0, -extension.length) : filename;
+  return `${stem}-${suffix}${extension}`;
+}
+
+function allocateUniquePath(directory: string, filename: string, usedPaths: Set<string>): string {
+  let candidate = `${directory}/${filename}`;
+  let suffix = 2;
+  while (usedPaths.has(candidate.toLowerCase())) {
+    candidate = `${directory}/${suffixDuplicateFilename(filename, suffix)}`;
+    suffix += 1;
+  }
+  usedPaths.add(candidate.toLowerCase());
+  return candidate;
+}
+
+export function buildAttachmentArchivePaths(attachments: AttachmentArchiveInput[]): Map<string, string> {
+  const usedPaths = new Set<string>();
+  const paths = new Map<string, string>();
+  const sorted = [...attachments].sort((left, right) => left.id.localeCompare(right.id));
+
+  for (const attachment of sorted) {
+    const fallbackBase = sanitizeArchivePathSegment(`attachment-${attachment.id}`, "attachment");
+    const fallback = `${fallbackBase}${inferredAttachmentExtension(attachment.contentType)}`;
+    const filename = sanitizeArchivePathSegment(attachment.originalFilename ?? "", fallback);
+    paths.set(attachment.id, allocateUniquePath("attachments", filename, usedPaths));
+  }
+
+  return paths;
+}
+
+export function buildDocumentArchivePath(document: DocumentArchiveInput): string {
+  const key = sanitizeArchivePathSegment(document.key, "document");
+  return `documents/${key.toLowerCase().endsWith(".md") ? key : `${key}.md`}`;
+}
+
+export function buildIssueAttachmentArchiveFilename(identifier: string): string {
+  const safeIdentifier = sanitizeArchivePathSegment(identifier, "task").replace(/[";=]/g, "-");
+  return `attachments-${safeIdentifier}.zip`;
+}

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -12646,11 +12646,20 @@ export function issueRoutes(
       return;
     }
 
-    const archive = new ZipStream({ zlib: { level: 9 } });
+    const archive = new ZipStream({ zlib: { level: 1 } });
     const attachmentPaths = buildAttachmentArchivePaths(attachments);
     const appendEntry = (source: Buffer | Readable, name: string, date: Date) =>
       new Promise<void>((resolve, reject) => {
-        archive.entry(source, { name, date }, (err) => err ? reject(err) : resolve());
+        let settled = false;
+        const settle = (err?: Error | null) => {
+          if (settled) return;
+          settled = true;
+          if (!Buffer.isBuffer(source)) source.off("error", settle);
+          if (err) reject(err);
+          else resolve();
+        };
+        if (!Buffer.isBuffer(source)) source.once("error", settle);
+        archive.entry(source, { name, date }, settle);
       });
     let handledError = false;
     const handleArchiveError = (err: unknown, context: Record<string, unknown>) => {
@@ -12694,17 +12703,20 @@ export function issueRoutes(
           );
           throw err;
         }
-        object.stream.on("error", (err) => {
-          logger.error(
-            { err, issueId: issue.id, attachmentId: attachment.id, objectKey: attachment.objectKey },
-            "attachment stream failed while streaming issue archive",
+        try {
+          await appendEntry(
+            object.stream,
+            attachmentPaths.get(attachment.id) ?? `attachments/attachment-${attachment.id}`,
+            attachment.createdAt,
           );
-        });
-        await appendEntry(
-          object.stream,
-          attachmentPaths.get(attachment.id) ?? `attachments/attachment-${attachment.id}`,
-          attachment.createdAt,
-        );
+        } catch (err) {
+          handleArchiveError(err, {
+            stage: "attachment-stream",
+            attachmentId: attachment.id,
+            objectKey: attachment.objectKey,
+          });
+          throw err;
+        }
       }
 
       for (const document of issueDocuments) {

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -1,6 +1,8 @@
 import { createHash, randomUUID } from "node:crypto";
+import type { Readable } from "node:stream";
 import { Router, type Request, type Response } from "express";
 import multer from "multer";
+import ZipStream from "zip-stream";
 import { z } from "zod";
 import { and, asc, desc, eq, inArray, isNull, notInArray } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
@@ -248,6 +250,11 @@ import {
   observeCrossIssueInfluence,
   type CrossIssueInfluenceKind,
 } from "../services/cross-issue-influence-limit.js";
+import {
+  buildAttachmentArchivePaths,
+  buildDocumentArchivePath,
+  buildIssueAttachmentArchiveFilename,
+} from "../issue-attachment-archive.js";
 
 const MAX_ISSUE_COMMENT_LIMIT = 500;
 const updateIssueRouteSchema = updateIssueSchema.extend({
@@ -12618,6 +12625,99 @@ export function issueRoutes(
     if (!(await assertIssueReadAllowed(req, res, issue))) return;
     const attachments = await svc.listAttachments(issueId);
     res.json(attachments.map(withContentPath));
+  });
+
+  router.get("/issues/:id/attachments/archive", async (req, res, next) => {
+    const issueId = req.params.id as string;
+    const issue = await svc.getById(issueId);
+    if (!issue) {
+      res.status(404).json({ error: "Issue not found" });
+      return;
+    }
+    assertCompanyAccess(req, issue.companyId);
+    if (!(await assertIssueReadAllowed(req, res, issue))) return;
+
+    const [attachments, issueDocuments] = await Promise.all([
+      svc.listAttachments(issue.id),
+      documentsSvc.listIssueDocuments(issue.id),
+    ]);
+    if (attachments.length === 0 && issueDocuments.length === 0) {
+      res.status(422).json({ error: "Issue has no exportable attachments or documents" });
+      return;
+    }
+
+    const archive = new ZipStream({ zlib: { level: 9 } });
+    const attachmentPaths = buildAttachmentArchivePaths(attachments);
+    const appendEntry = (source: Buffer | Readable, name: string, date: Date) =>
+      new Promise<void>((resolve, reject) => {
+        archive.entry(source, { name, date }, (err) => err ? reject(err) : resolve());
+      });
+    let handledError = false;
+    const handleArchiveError = (err: unknown, context: Record<string, unknown>) => {
+      if (handledError) return;
+      handledError = true;
+      logger.error({ err, issueId: issue.id, ...context }, "failed to stream issue attachment archive");
+      const error = err instanceof Error ? err : new Error(String(err));
+      if (!res.headersSent) {
+        archive.unpipe();
+        res.removeHeader("Content-Type");
+        res.removeHeader("Content-Disposition");
+        res.removeHeader("Cache-Control");
+        res.removeHeader("X-Content-Type-Options");
+        archive.destroy();
+        next(error);
+      } else if (!res.destroyed) {
+        archive.destroy(error);
+        res.destroy(error);
+      }
+    };
+
+    archive.on("error", (err) => handleArchiveError(err, { stage: "archive" }));
+    res.on("close", () => {
+      if (!res.writableEnded && !archive.destroyed) archive.destroy();
+    });
+    res.setHeader("Content-Type", "application/zip");
+    res.setHeader("Content-Disposition", `attachment; filename="${buildIssueAttachmentArchiveFilename(issue.identifier ?? issue.id)}"`);
+    res.setHeader("Cache-Control", "private, no-store, no-transform");
+    res.setHeader("X-Content-Type-Options", "nosniff");
+    archive.pipe(res);
+
+    try {
+      for (const attachment of attachments) {
+        let object;
+        try {
+          object = await storage.getObject(attachment.companyId, attachment.objectKey);
+        } catch (err) {
+          logger.error(
+            { err, issueId: issue.id, attachmentId: attachment.id, objectKey: attachment.objectKey },
+            "failed to read attachment while streaming issue archive",
+          );
+          throw err;
+        }
+        object.stream.on("error", (err) => {
+          logger.error(
+            { err, issueId: issue.id, attachmentId: attachment.id, objectKey: attachment.objectKey },
+            "attachment stream failed while streaming issue archive",
+          );
+        });
+        await appendEntry(
+          object.stream,
+          attachmentPaths.get(attachment.id) ?? `attachments/attachment-${attachment.id}`,
+          attachment.createdAt,
+        );
+      }
+
+      for (const document of issueDocuments) {
+        await appendEntry(
+          Buffer.from(document.body ?? "", "utf8"),
+          buildDocumentArchivePath(document),
+          document.updatedAt,
+        );
+      }
+      archive.finalize();
+    } catch (err) {
+      handleArchiveError(err, { stage: "entry" });
+    }
   });
 
   router.post("/companies/:companyId/issues/:issueId/attachments", async (req, res) => {

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -12629,12 +12629,8 @@ export function issueRoutes(
 
   router.get("/issues/:id/attachments/archive", async (req, res, next) => {
     const issueId = req.params.id as string;
-    const issue = await svc.getById(issueId);
-    if (!issue) {
-      res.status(404).json({ error: "Issue not found" });
-      return;
-    }
-    assertCompanyAccess(req, issue.companyId);
+    const issue = await getAccessibleResource(req, res, svc.getById(issueId), "Issue not found");
+    if (!issue) return;
     if (!(await assertIssueReadAllowed(req, res, issue))) return;
 
     const [attachments, issueDocuments] = await Promise.all([

--- a/server/src/routes/openapi.ts
+++ b/server/src/routes/openapi.ts
@@ -2657,6 +2657,20 @@ registry.registerPath({
 
 registry.registerPath({
   method: "get",
+  path: "/api/issues/{id}/attachments/archive",
+  tags: ["assets"],
+  summary: "Download issue attachments and documents as a ZIP archive",
+  request: { params: z.object({ id: z.string() }) },
+  responses: {
+    200: { description: "ZIP archive content" },
+    401: r.unauthorized,
+    404: r.notFound,
+    422: r.unprocessable,
+  },
+});
+
+registry.registerPath({
+  method: "get",
   path: "/api/companies/{companyId}/labels",
   tags: ["issues"],
   summary: "List labels in a company",

--- a/ui/src/components/IssueAttachmentsSection.test.tsx
+++ b/ui/src/components/IssueAttachmentsSection.test.tsx
@@ -33,6 +33,10 @@ vi.mock("@/components/ui/button", () => ({
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+if (!globalThis.PointerEvent) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (globalThis as any).PointerEvent = MouseEvent;
+}
 
 async function act(callback: () => void | Promise<void>) {
   let result: void | Promise<void> = undefined;
@@ -140,6 +144,116 @@ describe("IssueAttachmentsSection", () => {
     expect(downloadAll?.getAttribute("title")).toBe("Download all attachments");
     expect(downloadAll?.getAttribute("target")).toBeNull();
     expect(container.querySelector('button[aria-label="Upload attachment"]')).toBeTruthy();
+  });
+
+  it("offers individual downloads for images, markdown, videos, and generic files", async () => {
+    const attachments = [
+      makeAttachment({
+        id: "image-attachment",
+        originalFilename: "diagram.png",
+        contentType: "image/png",
+        contentPath: "/api/attachments/image-attachment/content",
+      }),
+      makeAttachment({
+        id: "markdown-attachment",
+        originalFilename: "notes.md",
+        contentType: "text/markdown",
+        contentPath: "/api/attachments/markdown-attachment/content",
+      }),
+      makeAttachment({
+        id: "video-attachment",
+        originalFilename: "demo.mp4",
+        contentType: "video/mp4",
+        contentPath: "/api/attachments/video-attachment/content",
+      }),
+      makeAttachment({
+        id: "generic-attachment",
+        originalFilename: "report.pdf",
+        contentType: "application/pdf",
+        contentPath: "/api/attachments/generic-attachment/content",
+      }),
+    ];
+
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <IssueAttachmentsSection
+            attachments={attachments}
+            onDelete={vi.fn()}
+            onImageClick={vi.fn()}
+          />
+        </QueryClientProvider>,
+      );
+    });
+    await flushReact();
+
+    for (const attachment of attachments) {
+      const filename = attachment.originalFilename!;
+      expect(container.querySelector(`a[aria-label="Download ${filename}"]`)?.getAttribute("href")).toBe(
+        `${attachment.contentPath}?download=1`,
+      );
+    }
+  });
+
+  it("downloads images from the hover action and keeps confirmed deletion in the kebab menu", async () => {
+    const attachment = makeAttachment({
+      id: "image-attachment",
+      originalFilename: "diagram.png",
+      contentType: "image/png",
+      contentPath: "/api/attachments/image-attachment/content",
+    });
+    const onDelete = vi.fn();
+    const onImageClick = vi.fn();
+
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <IssueAttachmentsSection
+            attachments={[attachment]}
+            onDelete={onDelete}
+            onImageClick={onImageClick}
+          />
+        </QueryClientProvider>,
+      );
+    });
+    await flushReact();
+
+    const download = container.querySelector<HTMLAnchorElement>('a[aria-label="Download diagram.png"]');
+    expect(download?.getAttribute("href")).toBe("/api/attachments/image-attachment/content?download=1");
+
+    await act(async () => {
+      download?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    expect(onImageClick).not.toHaveBeenCalled();
+
+    const menuTrigger = container.querySelector<HTMLButtonElement>('button[aria-label="More actions for diagram.png"]');
+    expect(menuTrigger).toBeTruthy();
+    expect(container.querySelector('button[title="Delete attachment"]')).toBeNull();
+
+    await act(async () => {
+      menuTrigger?.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true, button: 0 }));
+    });
+    await flushReact();
+
+    const deleteItem = Array.from(document.body.querySelectorAll<HTMLElement>('[data-slot="dropdown-menu-item"]'))
+      .find((item) => item.textContent?.trim() === "Delete");
+    expect(deleteItem).toBeTruthy();
+
+    await act(async () => {
+      deleteItem?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    await flushReact();
+
+    expect(container.textContent).toContain("Delete?");
+    expect(onDelete).not.toHaveBeenCalled();
+
+    const confirmButton = Array.from(container.querySelectorAll<HTMLButtonElement>("button"))
+      .find((button) => button.textContent === "Yes");
+    await act(async () => {
+      confirmButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(onDelete).toHaveBeenCalledWith("image-attachment");
   });
 
   it("renders markdown attachments with the document markdown presentation", async () => {
@@ -374,7 +488,7 @@ describe("IssueAttachmentsSection", () => {
     expect(container.textContent).toContain("stored-report.pdf");
     expect(container.querySelector('a[aria-label="Open stored-report.pdf"]')).toBeTruthy();
     expect(container.querySelector('a[aria-label="Download stored-report.pdf"]')).toBeTruthy();
-    expect(container.querySelector('button[title="Delete attachment"]')).toBeNull();
+    expect(container.querySelector('button[aria-label="More actions for stored-report.pdf"]')).toBeNull();
     expect(container.textContent).not.toContain("Delete this attachment?");
   });
 });

--- a/ui/src/components/IssueAttachmentsSection.test.tsx
+++ b/ui/src/components/IssueAttachmentsSection.test.tsx
@@ -116,6 +116,32 @@ describe("IssueAttachmentsSection", () => {
     vi.unstubAllGlobals();
   });
 
+  it("renders download-all beside upload with a direct archive link", async () => {
+    const attachment = makeAttachment();
+
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <IssueAttachmentsSection
+            attachments={[attachment]}
+            downloadAllHref="/api/issues/issue-1/attachments/archive"
+            uploadButton={<button type="button" aria-label="Upload attachment">Upload</button>}
+            onImageClick={vi.fn()}
+          />
+        </QueryClientProvider>,
+      );
+    });
+    await flushReact();
+
+    const downloadAll = container.querySelector<HTMLAnchorElement>(
+      'a[aria-label="Download all attachments"]',
+    );
+    expect(downloadAll?.getAttribute("href")).toBe("/api/issues/issue-1/attachments/archive");
+    expect(downloadAll?.getAttribute("title")).toBe("Download all attachments");
+    expect(downloadAll?.getAttribute("target")).toBeNull();
+    expect(container.querySelector('button[aria-label="Upload attachment"]')).toBeTruthy();
+  });
+
   it("renders markdown attachments with the document markdown presentation", async () => {
     const attachment = makeAttachment({
       id: "markdown-attachment",

--- a/ui/src/components/IssueAttachmentsSection.tsx
+++ b/ui/src/components/IssueAttachmentsSection.tsx
@@ -1,8 +1,14 @@
 import { useMemo, useState, type DragEvent, type ReactNode } from "react";
 import { useQuery } from "@tanstack/react-query";
 import type { IssueAttachment } from "@paperclipai/shared";
-import { Download, ExternalLink, FileText, Maximize2, Paperclip, Trash2 } from "lucide-react";
+import { Download, ExternalLink, FileText, Maximize2, MoreHorizontal, Paperclip, Trash2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { FoldCurtain } from "./FoldCurtain";
 import { MarkdownBody } from "./MarkdownBody";
 import { OutputFileTile } from "./issue-output/OutputFileTile";
@@ -81,16 +87,25 @@ function AttachmentActions({
         </a>
       </Button>
       {onDelete ? (
-        <Button
-          variant="ghost"
-          size="icon-sm"
-          title="Delete attachment"
-          className="text-muted-foreground hover:text-destructive"
-          onClick={() => onDelete(attachment.id)}
-          disabled={deletePending}
-        >
-          <Trash2 className="h-4 w-4" />
-        </Button>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon-sm"
+              title="Attachment actions"
+              aria-label={`More actions for ${filename}`}
+              disabled={deletePending}
+            >
+              <MoreHorizontal className="h-4 w-4" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuItem variant="destructive" onSelect={() => onDelete(attachment.id)}>
+              <Trash2 className="h-4 w-4" />
+              Delete
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
       ) : null}
     </div>
   );
@@ -337,19 +352,45 @@ export function IssueAttachmentsSection({
                     </button>
                   </div>
                 </div>
-              ) : onDelete ? (
-                <button
-                  type="button"
-                  className="absolute right-1.5 top-1.5 rounded-md bg-black/50 p-1 text-white opacity-0 transition-opacity hover:bg-destructive group-hover:opacity-100"
-                  onClick={(event) => {
-                    event.stopPropagation();
-                    requestDelete(attachment.id);
-                  }}
-                  title="Delete attachment"
+              ) : (
+                <div
+                  className="absolute right-1.5 top-1.5 flex items-center gap-1 opacity-0 transition-opacity group-hover:opacity-100 focus-within:opacity-100"
+                  onClick={(event) => event.stopPropagation()}
                 >
-                  <Trash2 className="h-3.5 w-3.5" />
-                </button>
-              ) : null}
+                  <a
+                    href={attachmentDownloadPath(attachment)}
+                    className="rounded-md bg-black/50 p-1 text-white hover:bg-black/70"
+                    aria-label={`Download ${attachmentFilename(attachment)}`}
+                    title="Download"
+                  >
+                    <Download className="h-3.5 w-3.5" />
+                  </a>
+                  {onDelete ? (
+                    <DropdownMenu>
+                      <DropdownMenuTrigger asChild>
+                        <button
+                          type="button"
+                          className="rounded-md bg-black/50 p-1 text-white hover:bg-black/70"
+                          aria-label={`More actions for ${attachmentFilename(attachment)}`}
+                          title="Attachment actions"
+                          disabled={deletePending}
+                        >
+                          <MoreHorizontal className="h-3.5 w-3.5" />
+                        </button>
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent align="end">
+                        <DropdownMenuItem
+                          variant="destructive"
+                          onSelect={() => requestDelete(attachment.id)}
+                        >
+                          <Trash2 className="h-4 w-4" />
+                          Delete
+                        </DropdownMenuItem>
+                      </DropdownMenuContent>
+                    </DropdownMenu>
+                  ) : null}
+                </div>
+              )}
             </div>
           ))}
         </div>

--- a/ui/src/components/IssueAttachmentsSection.tsx
+++ b/ui/src/components/IssueAttachmentsSection.tsx
@@ -22,6 +22,7 @@ import { Card } from "@/components/ui/card";
 
 interface IssueAttachmentsSectionProps {
   attachments: IssueAttachment[];
+  downloadAllHref?: string;
   uploadButton?: ReactNode;
   error?: string | null;
   dragActive?: boolean;
@@ -212,6 +213,7 @@ function GenericAttachmentRow({
 
 export function IssueAttachmentsSection({
   attachments,
+  downloadAllHref,
   uploadButton,
   error,
   dragActive = false,
@@ -269,7 +271,20 @@ export function IssueAttachmentsSection({
           <h3 className="text-sm font-medium text-muted-foreground">Attachments</h3>
           <span className="text-xs text-muted-foreground">{attachments.length}</span>
         </div>
-        {uploadButton}
+        <div className="flex items-center gap-1">
+          {downloadAllHref ? (
+            <Button asChild variant="ghost" size="icon-sm">
+              <a
+                href={downloadAllHref}
+                aria-label="Download all attachments"
+                title="Download all attachments"
+              >
+                <Download className="h-4 w-4" />
+              </a>
+            </Button>
+          ) : null}
+          {uploadButton}
+        </div>
       </div>
 
       {error && (

--- a/ui/src/pages/IssueDetail.tsx
+++ b/ui/src/pages/IssueDetail.tsx
@@ -5124,6 +5124,7 @@ export function IssueDetail() {
       ) : hasAttachments ? (
         <IssueAttachmentsSection
           attachments={attachmentList}
+          downloadAllHref={`/api/issues/${issue.id}/attachments/archive`}
           uploadButton={attachmentUploadButton}
           error={attachmentError}
           dragActive={attachmentDragActive}


### PR DESCRIPTION
<!-- Write all pull request text in Simplified Technical English (ASD-STE100): short sentences, one instruction per sentence, simple approved vocabulary, and the active voice. -->

## Thinking Path

> - Paperclip is the control plane where operators inspect and manage issue work.
> - Issue threads can contain many attached files and documents.
> - Operators must currently download each attachment one at a time.
> - A bulk download must keep company access checks and use bounded memory.
> - Archive entries also need safe and unique filenames.
> - This pull request adds a streamed ZIP endpoint and consistent download controls.
> - The benefit is a faster and predictable way to retrieve all issue artifacts.

## Linked Issues or Issue Description

### Subsystem affected

This change affects the `server/` REST API and the `ui/` issue detail page.

### Problem or motivation

Downloading all files from an issue requires a separate action for each attachment. Image, markdown, video, and generic attachment views also expose download actions in different ways.

### Proposed solution

Add a company-scoped endpoint that streams issue attachments and visible documents as a ZIP archive. Add issue detail actions that download the archive or one attachment directly.

### Alternatives considered

Client-side ZIP generation would fetch every attachment into browser memory. A fully buffered server archive would also use memory in proportion to archive size. The selected endpoint streams entries in sequence.

### Roadmap alignment

`ROADMAP.md` has no overlapping attachment download initiative. This is a focused issue artifact improvement.

### Additional context

A GitHub search found no duplicate or related public issue or pull request.

## What Changed

- Added a company-scoped issue archive endpoint that streams ZIP entries from asset storage.
- Added safe and deterministic archive filenames, collision handling, and content-type extension fallbacks.
- Added a Download all action and direct download actions for every attachment presentation.
- Added route and component tests for authorization, archive contents, failures, filenames, and UI actions.
- Kept cross-company archive reads private with the standard not-found response.

## Verification

- `pnpm exec vitest run server/src/__tests__/issue-attachment-routes.test.ts server/src/__tests__/openapi-routes.test.ts ui/src/components/IssueAttachmentsSection.test.tsx` — 45 tests passed after the rebase.
- `pnpm --filter @paperclipai/server typecheck` — passed after the rebase.
- `pnpm --filter @paperclipai/ui typecheck` — passed after the rebase.
- `pnpm check:token-gates` — passed with all gates clean.
- Chromium QA from the original implementation verified each attachment view, hover and focus actions, archive contents, and individual downloads.

## Risks

- Low-to-moderate risk: ZIP streaming adds a dependency and a long-lived response path.
- Tests cover empty issues, access boundaries, duplicate and sanitized names, and storage failures.
- Entries are read in sequence. Large archives can take time, but the server does not buffer the complete ZIP.
- This change has no database migration and does not change an existing successful API response.

> For core feature work, `ROADMAP.md` was checked and no duplicate planned capability was found.

## Model Used

- OpenAI Codex using `gpt-5.6-sol` with reasoning, repository tools, terminal execution, code analysis, and test execution. The runtime does not expose a reliable context-window size.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
