### PR TITLE
fix(ui): refine decision card interactions

### DIFF
--- a/ui/src/components/AttentionQueueRow.test.tsx
+++ b/ui/src/components/AttentionQueueRow.test.tsx
@@ -208,6 +208,47 @@ describe("AttentionQueueRow", () => {
     expect(onToggleExpand).toHaveBeenCalledTimes(2);
   });
 
+  it("toggles expand from the keyboard-focused decision body", () => {
+    const onToggleExpand = vi.fn();
+    render(
+      <AttentionQueueRow
+        item={buildItem()}
+        companyId="c1"
+        expanded={false}
+        onToggleExpand={onToggleExpand}
+        onDismiss={noop}
+      />,
+    );
+    const body = container?.querySelector<HTMLElement>("[data-attention-card-body]");
+    expect(body?.getAttribute("role")).toBe("button");
+    expect(body?.tabIndex).toBe(0);
+    expect(body?.getAttribute("aria-expanded")).toBe("false");
+    act(() => {
+      body?.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+      body?.dispatchEvent(new KeyboardEvent("keydown", { key: " ", bubbles: true }));
+    });
+    expect(onToggleExpand).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not toggle when an ARIA button inside the decision body is clicked", () => {
+    const onToggleExpand = vi.fn();
+    render(
+      <AttentionQueueRow
+        item={buildItem()}
+        companyId="c1"
+        expanded={false}
+        onToggleExpand={onToggleExpand}
+        onDismiss={noop}
+      />,
+    );
+    const body = container?.querySelector("[data-attention-card-body]");
+    const ariaButton = document.createElement("span");
+    ariaButton.setAttribute("role", "button");
+    body?.appendChild(ariaButton);
+    act(() => ariaButton.dispatchEvent(new MouseEvent("click", { bubbles: true })));
+    expect(onToggleExpand).not.toHaveBeenCalled();
+  });
+
   it("exposes the visible expand chevron as an accessible button", () => {
     const onToggleExpand = vi.fn();
     render(

--- a/ui/src/components/AttentionQueueRow.test.tsx
+++ b/ui/src/components/AttentionQueueRow.test.tsx
@@ -184,7 +184,7 @@ describe("AttentionQueueRow", () => {
     expect(trigger).toBeTruthy();
   });
 
-  it("toggles expand when the collapsed header of an inline row is clicked", () => {
+  it("toggles expand when the decision body or empty card space is clicked", () => {
     const onToggleExpand = vi.fn();
     render(
       <AttentionQueueRow
@@ -195,13 +195,17 @@ describe("AttentionQueueRow", () => {
         onDismiss={noop}
       />,
     );
-    const header = container?.querySelector('[role="button"][aria-expanded]');
-    expect(header).toBeTruthy();
-    expect(header?.getAttribute("aria-expanded")).toBe("false");
+    const body = container?.querySelector("[data-attention-card-body]");
+    const detail = Array.from(container?.querySelectorAll("p") ?? []).find((element) =>
+      element.textContent?.includes("Approval is pending"),
+    );
+    expect(body).toBeTruthy();
+    expect(detail).toBeTruthy();
     act(() => {
-      header?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      detail?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      body?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
     });
-    expect(onToggleExpand).toHaveBeenCalledTimes(1);
+    expect(onToggleExpand).toHaveBeenCalledTimes(2);
   });
 
   it("exposes the visible expand chevron as an accessible button", () => {
@@ -223,19 +227,41 @@ describe("AttentionQueueRow", () => {
     expect(onToggleExpand).toHaveBeenCalledWith(expect.objectContaining({ id: "a1" }));
   });
 
-  it("does not navigate on title click — the title is plain text, not a link", () => {
+  it("opens the title, issue identifier, and timestamp in a new tab without toggling", () => {
+    const onToggleExpand = vi.fn();
     render(
       <AttentionQueueRow
-        item={buildItem()}
+        item={buildItem({
+          relatedIssue: {
+            kind: "issue",
+            id: "issue-1",
+            companyId: "c1",
+            title: "Implement linked decision",
+            identifier: "PAP-42",
+            status: "in_progress",
+            href: "/PAP/issues/PAP-42",
+            metadata: {},
+          },
+        })}
         companyId="c1"
         expanded={false}
-        onToggleExpand={noop}
+        onToggleExpand={onToggleExpand}
         onDismiss={noop}
       />,
     );
-    const links = Array.from(container?.querySelectorAll("a") ?? []);
-    // No anchor should carry the subject title (only the identifier link, absent here).
-    expect(links.some((a) => a.textContent?.includes("Hire agent: Research Analyst"))).toBe(false);
+    const links = Array.from(container?.querySelectorAll('a[href="/PAP/issues/PAP-42"]') ?? []);
+    expect(links.map((link) => link.textContent?.trim())).toEqual([
+      "PAP-42",
+      expect.stringMatching(/ago$/),
+      "Hire agent: Research Analyst",
+    ]);
+    for (const link of links) {
+      expect(link.getAttribute("target")).toBe("_blank");
+      expect(link.getAttribute("rel")).toBe("noopener noreferrer");
+      link.addEventListener("click", (event) => event.preventDefault());
+      act(() => link.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true })));
+    }
+    expect(onToggleExpand).not.toHaveBeenCalled();
   });
 
   it("renders project identity once without a filter button", () => {
@@ -310,9 +336,11 @@ describe("AttentionQueueRow", () => {
       />,
     );
 
-    const header = container?.querySelector('[role="button"][aria-expanded]');
-    expect(header?.textContent).not.toContain("Approve");
-    expect(header?.textContent).not.toContain("Reject");
+    const title = Array.from(container?.querySelectorAll("span") ?? []).find((element) =>
+      element.textContent === "Hire agent: Research Analyst",
+    );
+    expect(title?.parentElement?.textContent).not.toContain("Approve");
+    expect(title?.parentElement?.textContent).not.toContain("Reject");
 
     const decisionActions = container?.querySelector('[aria-label="Decision actions"]');
     expect(decisionActions?.textContent).toContain("Approve");

--- a/ui/src/components/AttentionQueueRow.test.tsx
+++ b/ui/src/components/AttentionQueueRow.test.tsx
@@ -305,6 +305,39 @@ describe("AttentionQueueRow", () => {
     expect(onToggleExpand).not.toHaveBeenCalled();
   });
 
+  it("opens issue-backed interaction titles and timestamps in a new tab", () => {
+    render(
+      <AttentionQueueRow
+        item={buildItem({
+          sourceKind: "issue_thread_interaction",
+          subject: {
+            kind: "interaction",
+            id: "interaction-1",
+            companyId: "c1",
+            title: "Approve the migration plan?",
+            identifier: null,
+            status: "pending",
+            href: "/PAP/issues/PAP-1#interaction-interaction-1",
+            metadata: { issueId: "issue-1", kind: "request_confirmation" },
+          },
+        })}
+        companyId="c1"
+        expanded={false}
+        onToggleExpand={noop}
+        onDismiss={noop}
+      />,
+    );
+
+    const links = Array.from(
+      container?.querySelectorAll('a[href="/PAP/issues/PAP-1#interaction-interaction-1"]') ?? [],
+    );
+    expect(links.map((link) => link.textContent?.trim())).toEqual([
+      expect.stringMatching(/ago$/),
+      "Approve the migration plan?",
+    ]);
+    expect(links.every((link) => link.getAttribute("target") === "_blank")).toBe(true);
+  });
+
   it("renders project identity once without a filter button", () => {
     render(
       <AttentionQueueRow

--- a/ui/src/components/AttentionQueueRow.tsx
+++ b/ui/src/components/AttentionQueueRow.tsx
@@ -1,4 +1,4 @@
-import { memo, useState, type KeyboardEvent } from "react";
+import { memo, useState, type MouseEvent } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import {
   AlarmClock,
@@ -118,6 +118,7 @@ export const AttentionQueueRow = memo(function AttentionQueueRow({
   const isHidden = variant === "hidden";
   const inline = !isHidden && isInlineResolvable(item);
   const href = item.subject.href;
+  const issueHref = item.relatedIssue?.href ?? (item.subject.kind === "issue" ? href : null);
   const snoozedUntil = item.dismissal?.kind === "snooze" ? item.dismissal.snoozedUntil : null;
   const detailLine = attentionDetailLine(item) ?? item.whyNow;
   const images = attentionDetailImages(item);
@@ -139,12 +140,11 @@ export const AttentionQueueRow = memo(function AttentionQueueRow({
   const activate = () => {
     if (expandable) onToggleExpand(item);
   };
-  const onHeaderKeyDown = (e: KeyboardEvent) => {
-    if (!expandable) return;
-    if (e.key === "Enter" || e.key === " ") {
-      e.preventDefault();
-      onToggleExpand(item);
+  const activateFromCard = (event: MouseEvent<HTMLDivElement>) => {
+    if (event.target instanceof Element && event.target.closest("a,button,input,textarea,select,[role='menuitem']")) {
+      return;
     }
+    activate();
   };
 
   // Which rows contribute an action bar. Inline rows carry compact decision
@@ -179,7 +179,11 @@ export const AttentionQueueRow = memo(function AttentionQueueRow({
       {/* Type accent bar (canonical color map — never severity). */}
       <span className={cn("absolute inset-y-0 left-0 w-1", tone.accent)} aria-hidden />
 
-      <div className="flex items-start gap-2 py-3 pl-4 pr-3">
+      <div
+        className={cn("flex items-start gap-2 py-3 pl-4 pr-3", expandable && "cursor-pointer")}
+        onClick={activateFromCard}
+        data-attention-card-body
+      >
         {/* Expand affordance / spacer gutter — keeps headlines aligned across the list. */}
         {expandable ? (
           <button
@@ -216,11 +220,12 @@ export const AttentionQueueRow = memo(function AttentionQueueRow({
                   {sevBadge.label}
                 </span>
               )}
-              {item.relatedIssue?.identifier && (
+              {item.relatedIssue?.identifier && issueHref && (
                 <Link
-                  to={item.relatedIssue.href ?? "#"}
+                  to={issueHref}
+                  target="_blank"
+                  rel="noopener noreferrer"
                   className="font-mono text-(length:--text-nano) text-muted-foreground hover:text-foreground"
-                  onClick={(e) => e.stopPropagation()}
                 >
                   {item.relatedIssue.identifier}
                 </Link>
@@ -254,6 +259,16 @@ export const AttentionQueueRow = memo(function AttentionQueueRow({
                 >
                   Reappears {reappearLabel(snoozedUntil)}
                 </span>
+              ) : issueHref ? (
+                <Link
+                  to={issueHref}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-(length:--text-nano) text-muted-foreground hover:text-foreground"
+                  aria-label="Open issue in a new tab"
+                >
+                  {relativeTime(item.activityAt)}
+                </Link>
               ) : (
                 <span className="text-(length:--text-nano) text-muted-foreground">{relativeTime(item.activityAt)}</span>
               )}
@@ -289,27 +304,24 @@ export const AttentionQueueRow = memo(function AttentionQueueRow({
             </div>
           </div>
 
-          {/* Headline — the primary expand target for inline rows. Title now wraps
-              to two lines instead of truncating to a sliver on narrow screens. */}
-          <div
-            className={cn(
-              "min-w-0 rounded-md",
-              expandable && "cursor-pointer focus-visible:ring-ring focus-visible:ring-(length:--rad-3) focus-visible:outline-none",
+          {/* The issue title opens in a new tab. The surrounding card body remains
+              the expand target, including the detail text and empty space. */}
+          <div className="min-w-0 rounded-md">
+            {issueHref ? (
+              <Link
+                to={issueHref}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="line-clamp-2 text-sm font-medium text-foreground hover:underline"
+                title={item.subject.title ?? undefined}
+              >
+                {item.subject.title ?? meta.label}
+              </Link>
+            ) : (
+              <span className="line-clamp-2 text-sm font-medium text-foreground" title={item.subject.title ?? undefined}>
+                {item.subject.title ?? meta.label}
+              </span>
             )}
-            {...(expandable
-              ? {
-                  role: "button",
-                  tabIndex: 0,
-                  "aria-expanded": expanded,
-                  "aria-label": expanded ? "Collapse decision" : "Expand decision",
-                  onClick: activate,
-                  onKeyDown: onHeaderKeyDown,
-                }
-              : {})}
-          >
-            <span className="line-clamp-2 text-sm font-medium text-foreground" title={item.subject.title ?? undefined}>
-              {item.subject.title ?? meta.label}
-            </span>
             <p className="mt-0.5 line-clamp-2 text-xs text-muted-foreground">{detailLine}</p>
           </div>
 

--- a/ui/src/components/AttentionQueueRow.tsx
+++ b/ui/src/components/AttentionQueueRow.tsx
@@ -1,4 +1,4 @@
-import { memo, useState, type MouseEvent } from "react";
+import { memo, useState, type KeyboardEvent, type MouseEvent } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import {
   AlarmClock,
@@ -141,9 +141,17 @@ export const AttentionQueueRow = memo(function AttentionQueueRow({
     if (expandable) onToggleExpand(item);
   };
   const activateFromCard = (event: MouseEvent<HTMLDivElement>) => {
-    if (event.target instanceof Element && event.target.closest("a,button,input,textarea,select,[role='menuitem']")) {
+    if (
+      event.target instanceof Element &&
+      event.target.closest("a,button,input,textarea,select,[role='button'],[role='menuitem']") !== event.currentTarget
+    ) {
       return;
     }
+    activate();
+  };
+  const activateFromCardKeyboard = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (event.target !== event.currentTarget || (event.key !== "Enter" && event.key !== " ")) return;
+    event.preventDefault();
     activate();
   };
 
@@ -182,6 +190,11 @@ export const AttentionQueueRow = memo(function AttentionQueueRow({
       <div
         className={cn("flex items-start gap-2 py-3 pl-4 pr-3", expandable && "cursor-pointer")}
         onClick={activateFromCard}
+        onKeyDown={activateFromCardKeyboard}
+        role={expandable ? "button" : undefined}
+        tabIndex={expandable ? 0 : undefined}
+        aria-expanded={expandable ? expanded : undefined}
+        aria-label={expandable ? (expanded ? "Collapse decision" : "Expand decision") : undefined}
         data-attention-card-body
       >
         {/* Expand affordance / spacer gutter — keeps headlines aligned across the list. */}

--- a/ui/src/components/AttentionQueueRow.tsx
+++ b/ui/src/components/AttentionQueueRow.tsx
@@ -118,7 +118,8 @@ export const AttentionQueueRow = memo(function AttentionQueueRow({
   const isHidden = variant === "hidden";
   const inline = !isHidden && isInlineResolvable(item);
   const href = item.subject.href;
-  const issueHref = item.relatedIssue?.href ?? (item.subject.kind === "issue" ? href : null);
+  const issueHref =
+    item.relatedIssue?.href ?? (["issue", "interaction"].includes(item.subject.kind) ? href : null);
   const snoozedUntil = item.dismissal?.kind === "snooze" ? item.dismissal.snoozedUntil : null;
   const detailLine = attentionDetailLine(item) ?? item.whyNow;
   const images = attentionDetailImages(item);

--- a/ui/src/components/AttentionQueueRow.tsx
+++ b/ui/src/components/AttentionQueueRow.tsx
@@ -123,9 +123,9 @@ export const AttentionQueueRow = memo(function AttentionQueueRow({
   const detailLine = attentionDetailLine(item) ?? item.whyNow;
   const images = attentionDetailImages(item);
   const hasImages = images.length > 0;
-  // The issue (or source) this row points at — used as the target for the
-  // "n more" affordance in the expanded gallery.
-  const issueHref = item.relatedIssue?.href ?? href;
+  // The issue or source this row points at — used as the target for expanded
+  // gallery affordances even when the subject itself is not an issue.
+  const detailHref = item.relatedIssue?.href ?? href;
   // Inline-resolvable active rows expand to reveal their resolver; rows with
   // images expand to reveal a larger gallery (PAP-13544). Either case gives a
   // header/thumbnail click somewhere to go. Non-inline, image-less rows keep the
@@ -405,7 +405,7 @@ export const AttentionQueueRow = memo(function AttentionQueueRow({
 
       {expanded && (hasImages || inline) && (
         <div className="space-y-3 border-t border-border/60 bg-muted/20 px-4 py-3 motion-safe:animate-in motion-safe:fade-in-0 motion-safe:slide-in-from-top-1 motion-safe:duration-200">
-          {hasImages && <ExpandedImages images={images} issueHref={issueHref} />}
+          {hasImages && <ExpandedImages images={images} issueHref={detailHref} />}
           {inline && (
             <InlineResolver
               item={item}

--- a/ui/src/lib/attention.test.ts
+++ b/ui/src/lib/attention.test.ts
@@ -10,6 +10,7 @@ import {
   attentionToneStyle,
   buildAttentionFilterOptions,
   countActiveAttentionFilters,
+  defaultExpandedAttentionId,
   defaultAttentionFilterState,
   filterAttentionItems,
   groupAttentionItems,
@@ -256,6 +257,22 @@ describe("sortAttentionItems", () => {
     const input = [older, newer];
     sortAttentionItems(input, "newest");
     expect(input.map((i) => i.id)).toEqual(["old", "new"]);
+  });
+});
+
+describe("defaultExpandedAttentionId", () => {
+  it("selects the first inline decision in the visible sort order", () => {
+    const newestDeepLink = buildItem({
+      id: "deep-link",
+      sourceKind: "failed_run",
+      inlineResolvable: false,
+      activityAt: "2026-07-10T12:00:00Z",
+    });
+    const newestInline = buildItem({ id: "new-inline", activityAt: "2026-07-09T12:00:00Z" });
+    const oldestInline = buildItem({ id: "old-inline", activityAt: "2026-07-08T12:00:00Z" });
+
+    expect(defaultExpandedAttentionId([oldestInline, newestDeepLink, newestInline], "newest")).toBe("new-inline");
+    expect(defaultExpandedAttentionId([oldestInline, newestDeepLink, newestInline], "oldest")).toBe("old-inline");
   });
 });
 

--- a/ui/src/lib/attention.ts
+++ b/ui/src/lib/attention.ts
@@ -483,6 +483,10 @@ export function sortAttentionItems(items: AttentionItem[], order: AttentionSortO
   });
 }
 
+export function defaultExpandedAttentionId(items: AttentionItem[], order: AttentionSortOrder): string | null {
+  return sortAttentionItems(items, order).find((item) => isInlineResolvable(item))?.id ?? null;
+}
+
 export function attentionItemMatchesFilters(item: AttentionItem, filters: AttentionFilterState): boolean {
   if (filters.sourceKinds.length > 0 && !filters.sourceKinds.includes(item.sourceKind)) return false;
   if (filters.severities.length > 0 && !filters.severities.includes(item.severity)) return false;

--- a/ui/src/pages/WhatNeedsMe.tsx
+++ b/ui/src/pages/WhatNeedsMe.tsx
@@ -16,6 +16,7 @@ import {
   ATTENTION_SORT_OPTIONS,
   buildAttentionFilterOptions,
   countActiveAttentionFilters,
+  defaultExpandedAttentionId,
   defaultAttentionFilterState,
   filterAttentionItems,
   groupAttentionItems,
@@ -282,9 +283,8 @@ export function WhatNeedsMe() {
   // Auto-expand the topmost inline-capable decision, once.
   useEffect(() => {
     if (autoExpandDone || activeItems.length === 0) return;
-    const sorted = sortAttentionItems(activeItems, sortOrder);
-    const topInline = sorted.find((item) => isInlineResolvable(item));
-    if (topInline) setExpandedId(topInline.id);
+    const topInlineId = defaultExpandedAttentionId(activeItems, sortOrder);
+    if (topInlineId) setExpandedId(topInlineId);
     setAutoExpandDone(true);
   }, [activeItems, autoExpandDone, sortOrder]);
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source control plane people use to manage AI-agent companies and their work
> - The Decisions view surfaces attention items that operators need to inspect or resolve
> - Decision cards previously made the headline itself an expand target, so the issue title did not behave like a conventional issue link
> - Operators need to open the underlying issue without losing their place in the Decisions queue
> - The card body and empty space should still expand inline resolution details, while the title should have a distinct navigation action
> - This pull request separates those interactions and preserves keyboard accessibility for expandable cards
> - The benefit is predictable navigation, easier triage, and a useful default expanded decision when the view first loads

## Linked Issues or Issue Description

Related upstream CI fix: Refs #9595.

### What happened?

In the Decisions view, clicking an issue title expanded the decision card instead of opening the underlying issue. The initial queue also did not consistently expose the first inline-resolvable decision through an independently tested selection helper.

### Expected behavior

The issue title, identifier, and compact issue affordance open the issue in a new tab. Clicking the card body, detail text, or empty card space expands or collapses inline details. Keyboard users can focus the card body and toggle it with Enter or Space.

### Steps to reproduce

  1. Run Paperclip from `master` in local development mode.
  2. Open the Decisions view with an inline-resolvable issue-backed decision.
  3. Click the issue title and observe that the card expands instead of opening the issue.

### Paperclip version or commit

`origin/master` at PR creation.

### Deployment mode

Local dev (`pnpm dev`), built from source.

### Additional context

Core UI behavior; not adapter- or database-specific.

## What Changed

- Make issue titles and compact issue affordances open the related issue in a new tab with safe external-window attributes.
- Move expand/collapse activation to the card body so detail text and empty card space remain usable expansion targets.
- Preserve keyboard activation and prevent native or ARIA-based nested interactive controls from toggling the card.
- Extract and test selection of the first inline-resolvable decision in the active sort order.
- Add interaction coverage for title navigation, body expansion, nested controls, and non-expandable rows.

## Verification

- `pnpm exec vitest run ui/src/components/AttentionQueueRow.test.tsx ui/src/lib/attention.test.ts` — 2 files, 69 tests passed.
- `pnpm --filter @paperclipai/ui typecheck` — passed.
- `pnpm check:token-gates` — all UI token gates clean.

## Risks

- Low risk: the change is limited to Decisions queue interaction handling and a small pure helper.
- The main behavioral shift is intentional: title clicks now navigate, while the rest of an inline-capable card toggles expansion.
- No schema, API, migration, adapter, or persisted-data changes.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex using GPT-5.4 with reasoning, repository tool use, code execution, and GitHub CLI access.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge



