### PR TITLE
fix: suppress run-authored self comment wakes

### DIFF
--- a/server/src/__tests__/issue-update-comment-wakeup-routes.test.ts
+++ b/server/src/__tests__/issue-update-comment-wakeup-routes.test.ts
@@ -24,9 +24,19 @@ const mockHeartbeatService = vi.hoisted(() => ({
   getActiveRunForAgent: vi.fn(async () => null),
   cancelRun: vi.fn(async () => null),
 }));
+const mockLogger = vi.hoisted(() => ({
+  debug: vi.fn(),
+  error: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+}));
 const mockIssueThreadInteractionService = vi.hoisted(() => ({
   expireRequestConfirmationsSupersededByComment: vi.fn(async () => []),
   expireStaleRequestConfirmationsForIssueDocument: vi.fn(async () => []),
+}));
+
+vi.mock("../middleware/logger.js", () => ({
+  logger: mockLogger,
 }));
 
 vi.mock("../services/index.js", () => ({
@@ -613,6 +623,77 @@ describe("issue update comment wakeups", () => {
     await vi.waitFor(() => expect(mockHeartbeatService.getRun).toHaveBeenCalled());
     expect(mockHeartbeatService.getRun).toHaveBeenCalledWith("aaaaaaaa-0000-4000-8000-000000000003");
     expect(mockHeartbeatService.wakeup).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["unknown run", null],
+    ["cross-company run", { companyId: "company-2", agentId: ASSIGNEE_AGENT_ID, contextSnapshot: { issueId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa" } }],
+    ["cross-issue run", { companyId: "company-1", agentId: ASSIGNEE_AGENT_ID, contextSnapshot: { issueId: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb" } }],
+    ["mismatched-agent run", { companyId: "company-1", agentId: PREVIOUS_AGENT_ID, contextSnapshot: { issueId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa" } }],
+  ])("fails closed and wakes for a board-shaped top-level comment with an %s", async (_label, run) => {
+    const existing = makeIssue({
+      assigneeAgentId: ASSIGNEE_AGENT_ID,
+      assigneeUserId: null,
+      status: "in_progress",
+    });
+    mockIssueService.getById.mockResolvedValue(existing);
+    mockIssueService.addComment.mockResolvedValue({
+      id: "comment-invalid-run-post",
+      issueId: existing.id,
+      companyId: existing.companyId,
+      body: "board feedback",
+    });
+    mockHeartbeatService.getRun.mockResolvedValue(run as never);
+
+    const res = await request(await createApp())
+      .post(`/api/issues/${existing.id}/comments`)
+      .set("X-Paperclip-Run-Id", "aaaaaaaa-0000-4000-8000-000000000004")
+      .send({ body: "board feedback" });
+
+    expect(res.status).toBe(201);
+    await vi.waitFor(() => expect(mockHeartbeatService.wakeup).toHaveBeenCalledTimes(1));
+    expect(mockHeartbeatService.getRun).toHaveBeenCalledWith("aaaaaaaa-0000-4000-8000-000000000004");
+    expect(mockHeartbeatService.wakeup).toHaveBeenCalledWith(
+      ASSIGNEE_AGENT_ID,
+      expect.objectContaining({ reason: "issue_commented" }),
+    );
+  });
+
+  it("fails open and wakes for a top-level comment when run attribution lookup rejects", async () => {
+    const existing = makeIssue({
+      assigneeAgentId: ASSIGNEE_AGENT_ID,
+      assigneeUserId: null,
+      status: "in_progress",
+    });
+    const lookupError = new Error("run lookup failed");
+    mockIssueService.getById.mockResolvedValue(existing);
+    mockIssueService.addComment.mockResolvedValue({
+      id: "comment-rejected-run-post",
+      issueId: existing.id,
+      companyId: existing.companyId,
+      body: "board feedback after lookup failure",
+    });
+    mockHeartbeatService.getRun.mockRejectedValue(lookupError);
+
+    const res = await request(await createApp())
+      .post(`/api/issues/${existing.id}/comments`)
+      .set("X-Paperclip-Run-Id", "aaaaaaaa-0000-4000-8000-000000000005")
+      .send({ body: "board feedback after lookup failure" });
+
+    expect(res.status).toBe(201);
+    await vi.waitFor(() => expect(mockHeartbeatService.wakeup).toHaveBeenCalledTimes(1));
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      {
+        err: lookupError,
+        issueId: existing.id,
+        runId: "aaaaaaaa-0000-4000-8000-000000000005",
+      },
+      "failed to resolve run attribution for issue comment wake",
+    );
+    expect(mockHeartbeatService.wakeup).toHaveBeenCalledWith(
+      ASSIGNEE_AGENT_ID,
+      expect.objectContaining({ reason: "issue_commented" }),
+    );
   });
 
   it("does not route a plain-text agent name on a human-owned issue comment", async () => {

--- a/server/src/__tests__/issue-update-comment-wakeup-routes.test.ts
+++ b/server/src/__tests__/issue-update-comment-wakeup-routes.test.ts
@@ -187,6 +187,7 @@ async function createApp() {
       companyIds: ["company-1"],
       source: "local_implicit",
       isInstanceAdmin: false,
+      runId: req.header("x-paperclip-run-id") ?? undefined,
     };
     next();
   });
@@ -474,6 +475,71 @@ describe("issue update comment wakeups", () => {
     );
   });
 
+  it("does not wake the assignee for board-shaped issue update comments attributed to its run", async () => {
+    const existing = makeIssue({
+      assigneeAgentId: ASSIGNEE_AGENT_ID,
+      assigneeUserId: null,
+      status: "in_progress",
+    });
+    mockIssueService.getById.mockResolvedValue(existing);
+    mockIssueService.update.mockResolvedValue({ ...existing });
+    mockIssueService.addComment.mockResolvedValue({
+      id: "comment-run-patch",
+      issueId: existing.id,
+      companyId: existing.companyId,
+      body: "run-authored progress update",
+    });
+    mockHeartbeatService.getRun.mockResolvedValue({
+      id: "aaaaaaaa-0000-4000-8000-000000000001",
+      companyId: existing.companyId,
+      agentId: ASSIGNEE_AGENT_ID,
+      contextSnapshot: { issueId: existing.id },
+    } as never);
+
+    const res = await request(await createApp())
+      .patch(`/api/issues/${existing.id}`)
+      .set("X-Paperclip-Run-Id", "aaaaaaaa-0000-4000-8000-000000000001")
+      .send({ comment: "run-authored progress update" });
+
+    expect(res.status).toBe(200);
+    expect(mockHeartbeatService.getRun).toHaveBeenCalledWith("aaaaaaaa-0000-4000-8000-000000000001");
+    expect(mockHeartbeatService.wakeup).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["unknown run", null],
+    ["cross-company run", { companyId: "company-2", agentId: ASSIGNEE_AGENT_ID, contextSnapshot: { issueId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa" } }],
+    ["cross-issue run", { companyId: "company-1", agentId: ASSIGNEE_AGENT_ID, contextSnapshot: { issueId: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb" } }],
+    ["mismatched-agent run", { companyId: "company-1", agentId: PREVIOUS_AGENT_ID, contextSnapshot: { issueId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa" } }],
+  ])("fails closed and wakes for a board-shaped comment with an %s", async (_label, run) => {
+    const existing = makeIssue({
+      assigneeAgentId: ASSIGNEE_AGENT_ID,
+      assigneeUserId: null,
+      status: "in_progress",
+    });
+    mockIssueService.getById.mockResolvedValue(existing);
+    mockIssueService.update.mockResolvedValue({ ...existing });
+    mockIssueService.addComment.mockResolvedValue({
+      id: "comment-invalid-run",
+      issueId: existing.id,
+      companyId: existing.companyId,
+      body: "board feedback",
+    });
+    mockHeartbeatService.getRun.mockResolvedValue(run as never);
+
+    const res = await request(await createApp())
+      .patch(`/api/issues/${existing.id}`)
+      .set("X-Paperclip-Run-Id", "aaaaaaaa-0000-4000-8000-000000000002")
+      .send({ comment: "board feedback" });
+
+    expect(res.status).toBe(200);
+    expect(mockHeartbeatService.wakeup).toHaveBeenCalledTimes(1);
+    expect(mockHeartbeatService.wakeup).toHaveBeenCalledWith(
+      ASSIGNEE_AGENT_ID,
+      expect.objectContaining({ reason: "issue_commented" }),
+    );
+  });
+
   it("wakes the assignee on top-level board issue comments", async () => {
     const existing = makeIssue({
       assigneeAgentId: ASSIGNEE_AGENT_ID,
@@ -516,6 +582,37 @@ describe("issue update comment wakeups", () => {
         }),
       }),
     );
+  });
+
+  it("does not wake the assignee for board-shaped top-level comments attributed to its run", async () => {
+    const existing = makeIssue({
+      assigneeAgentId: ASSIGNEE_AGENT_ID,
+      assigneeUserId: null,
+      status: "in_progress",
+    });
+    mockIssueService.getById.mockResolvedValue(existing);
+    mockIssueService.addComment.mockResolvedValue({
+      id: "comment-run-post",
+      issueId: existing.id,
+      companyId: existing.companyId,
+      body: "run-authored closeout",
+    });
+    mockHeartbeatService.getRun.mockResolvedValue({
+      id: "aaaaaaaa-0000-4000-8000-000000000003",
+      companyId: existing.companyId,
+      agentId: ASSIGNEE_AGENT_ID,
+      contextSnapshot: { taskId: existing.id },
+    } as never);
+
+    const res = await request(await createApp())
+      .post(`/api/issues/${existing.id}/comments`)
+      .set("X-Paperclip-Run-Id", "aaaaaaaa-0000-4000-8000-000000000003")
+      .send({ body: "run-authored closeout" });
+
+    expect(res.status).toBe(201);
+    await vi.waitFor(() => expect(mockHeartbeatService.getRun).toHaveBeenCalled());
+    expect(mockHeartbeatService.getRun).toHaveBeenCalledWith("aaaaaaaa-0000-4000-8000-000000000003");
+    expect(mockHeartbeatService.wakeup).not.toHaveBeenCalled();
   });
 
   it("does not route a plain-text agent name on a human-owned issue comment", async () => {

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -2546,6 +2546,32 @@ export function issueRoutes(
     return resolveActorSourceTrustForIssue({ db, issue, actor });
   }
 
+  async function isCommentAttributedToAssigneeRun(
+    issue: { id: string; companyId: string; assigneeAgentId?: string | null },
+    actor: ReturnType<typeof getActorInfo>,
+  ) {
+    if (!actor.runId || !issue.assigneeAgentId) return false;
+
+    const run = await heartbeat.getRun(actor.runId).catch((err) => {
+      logger.warn(
+        { err, issueId: issue.id, runId: actor.runId },
+        "failed to resolve run attribution for issue comment wake",
+      );
+      return null;
+    });
+    if (
+      !run ||
+      run.companyId !== issue.companyId ||
+      run.agentId !== issue.assigneeAgentId
+    ) return false;
+
+    const context = run.contextSnapshot && typeof run.contextSnapshot === "object"
+      ? run.contextSnapshot as Record<string, unknown>
+      : null;
+    const runIssueId = readNonEmptyString(context?.issueId) ?? readNonEmptyString(context?.taskId);
+    return runIssueId === issue.id;
+  }
+
   function hasExplicitIssueWorkspaceCreateSelection(input: Record<string, unknown>) {
     return input.parentId !== undefined ||
       input.inheritExecutionWorkspaceFromIssueId !== undefined ||
@@ -8500,7 +8526,9 @@ export function issueRoutes(
       if (commentBody && comment) {
         const assigneeId = issue.assigneeAgentId;
         const actorIsAgent = actor.actorType === "agent";
-        const selfComment = actorIsAgent && actor.actorId === assigneeId;
+        const selfComment =
+          (actorIsAgent && actor.actorId === assigneeId) ||
+          await isCommentAttributedToAssigneeRun(issue, actor);
         const skipAssigneeCommentWake = selfComment || isClosed;
 
         if (assigneeId && !assigneeChanged && (reopened || !skipAssigneeCommentWake)) {
@@ -10027,7 +10055,9 @@ export function issueRoutes(
 
       const assigneeId = currentIssue.assigneeAgentId;
       const actorIsAgent = actor.actorType === "agent";
-      const selfComment = actorIsAgent && actor.actorId === assigneeId;
+      const selfComment =
+        (actorIsAgent && actor.actorId === assigneeId) ||
+        await isCommentAttributedToAssigneeRun(currentIssue, actor);
       // Re-derive closed-ness from the post-mutation issue so the auto-approval
       // transition (in_review -> done) suppresses a stale `issue_commented` wake
       // to the returnAssignee for an already-completed issue.


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the control plane that coordinates AI-agent work through issues, comments, and heartbeat runs.
> - Issue comment routes persist audit attribution and may enqueue an `issue_commented` wake for the current assignee.
> - Local-trusted requests can carry a valid run ID while retaining the board-shaped `local-board` transport identity.
> - The existing self-comment guard checked only the transport actor type/id, so these run-authored comments looked like fresh board input and re-woke their own assignee.
> - Suppression must be fail-closed so forged, stale, cross-company, cross-issue, or mismatched-agent run IDs never hide genuine operator feedback.
> - This pull request resolves the run and verifies company, assignee agent, and issue context before suppressing only the redundant assignee comment wake.
> - The benefit is fewer self-derived heartbeat loops without changing persisted attribution, response contracts, board feedback wakes, or interaction continuations.

## Linked Issues or Issue Description

Bug description:

- What happened: a comment posted through local-trusted board transport with a valid heartbeat-run ID could immediately enqueue a new run for the same issue and assignee.
- Expected behavior: a comment attributable to the current assignee's run for the same company and issue should persist normally but should not emit a fresh `issue_commented` wake to that assignee.
- Safety boundary: missing, unknown, cross-company, cross-issue, or mismatched-agent runs must retain the normal wake.
- Affected endpoints: `PATCH /api/issues/:id` with `comment` and `POST /api/issues/:id/comments`.

Related PR/issue search: no matching issue or PR was found in this fork.

## What Changed

- Added one shared route helper that resolves run attribution and validates run existence, company, assignee agent, and `issueId`/`taskId` context.
- Applied the helper to both issue-comment wake paths while preserving the existing direct agent self-comment and closed/reopened behavior.
- Added regression coverage for both comment endpoints, genuine local-board comments without a run, and unknown/cross-company/cross-issue/mismatched run IDs.
- Kept interaction accept/reject policy tests in the targeted verification set.

## Verification

- `TMPDIR="$PWD/.tmp" pnpm exec vitest run server/src/__tests__/issue-update-comment-wakeup-routes.test.ts server/src/__tests__/issue-thread-interaction-routes.test.ts --reporter=verbose` — 2 files passed, 32 tests passed.
- `pnpm --filter @paperclipai/server typecheck` — passed.
- `git diff --check` — passed.
- Synthetic route evidence: both board-shaped, same-assignee run-attributed comment tests assert zero `heartbeat.wakeup` calls; genuine board comments and all fail-closed invalid-run cases assert the expected wake.

## Risks

- Low behavioral risk: only assignee comment wake scheduling changes; comment persistence, audit attribution, response payloads, mentions, reopened-comment wakes, and interaction routes are unchanged.
- Run lookup errors deliberately fail open for liveness (the genuine comment wake is retained) and emit a warning.
- No database migration, shared schema, dependency, UI, or public API response change.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

OpenAI Codex, `gpt-5.6-sol`, tool-using software-engineering mode with repository, test, typecheck, git, and GitHub CLI access. Runtime context-window size was not exposed.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [ ] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes (not applicable: no user-facing contract or command changed)
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge


