### PR TITLE
fix(recovery): bound stopped-work repair and recovery authority

### DIFF
--- a/doc/execution-semantics.md
+++ b/doc/execution-semantics.md
@@ -467,6 +467,18 @@ A blocker chain is covered only when its unresolved leaf is live or explicitly w
 
 A `blocked` issue is stalled when the unresolved blocker leaf has no active run, queued wake, typed participant, pending interaction or approval, user owner, external owner/action, or recovery action. In that case the parent should show the first stalled leaf instead of presenting the dependency as calmly covered.
 
+#### Stale blocked posture and terminal-blocker repair
+
+`blocked` is valid only while a real unresolved dependency or another explicit waiting path exists. A blocker that is already `done` is completion evidence, not a durable unresolved dependency. An issue that remains `blocked` after all blockers are done, or that has no blocker and no other waiting-path primitive, is stale and must be repaired rather than displayed as legitimately waiting.
+
+Repair must preserve the meaning of terminal blocker outcomes:
+
+- `done` blockers are satisfied and must be removed from the effective unresolved blocker set
+- `cancelled` blockers are not satisfied; the source issue remains explicitly blocked while a bounded recovery action names whether to replace, waive, or escalate that dependency
+- when no unresolved blocker remains and deliverable work is still open, Paperclip must queue a normal-model continuation such as `issue_blockers_resolved`, or open an explicit control-plane recovery action when it cannot safely identify or invoke the continuation owner
+
+A status-only recovery run may perform this control-plane repair: revalidate blocker state, clear the stale waiting posture, queue the normal-model continuation, or open the explicit recovery action. It must not perform the source deliverable, update persistent deliverable surfaces, or treat its own comment/run as the issue's continuing live path. Repair is bounded and non-recursive: a recovery action must not create or retain a dependency on itself, and repeated reconciliation must reuse the existing continuation or recovery action instead of deepening a recovery tree.
+
 ## 9. Crash and Restart Recovery
 
 Paperclip now treats crash/restart recovery as a stranded-assigned-work problem, not just a stranded-run problem.
@@ -523,6 +535,8 @@ This keeps the post-decomposition umbrella (§7) on a real waiting path instead 
 ### 9.3 Recovery model-profile lane
 
 Cheap model profiles are only for status-only operational recovery overhead. Paperclip may request `modelProfile: "cheap"` for bounded recovery-owner work that updates task liveness, clears bad status, records a disposition, or asks for human/manager intervention. Those wakes must carry guard context such as `allowDeliverableWork: false`, `allowDocumentUpdates: false`, and `resumeRequiresNormalModel: true`.
+
+`resumeRequiresNormalModel: true` is an execution contract, not an informational hint. Before a status-only recovery run finishes with source work remaining, it must leave either a queued normal-model continuation for the responsible worker or an explicit control-plane recovery action that names the owner and action required to create that continuation. Leaving the issue in stale `blocked`, writing a comment, or recording that normal-model work is needed does not satisfy the handoff.
 
 Automatic retries that can continue source work must use the original/normal model lane. This includes failed source-work retries, process-loss retries, transient/scheduled retries, max-turn continuations, source-assignee continuations, assigned-todo dispatch recovery, and any run that can update repo files, issue documents, plans, work products, or attachments. When a cheap status-only recovery determines that actual work remains, it must hand back to a normal-model worker run before source work or persistent deliverable updates resume. Cheap recovery hints must be scrubbed from copied retry, resume, child, and downstream source-work contexts.
 

--- a/server/src/__tests__/heartbeat-issue-liveness-escalation.test.ts
+++ b/server/src/__tests__/heartbeat-issue-liveness-escalation.test.ts
@@ -16,6 +16,7 @@ import {
   heartbeatRunEvents,
   heartbeatRuns,
   issueComments,
+  issueRecoveryActions,
   issueRelations,
   issueTreeHoldMembers,
   issueTreeHolds,
@@ -439,6 +440,48 @@ describeEmbeddedPostgres("heartbeat issue graph liveness escalation", () => {
       .where(and(eq(activityLog.companyId, companyId), eq(activityLog.action, "issue.blockers_resolved_wake_emitted")));
     expect(events).toHaveLength(1);
     expect(events[0]).toMatchObject({ entityId: blockedIssueId });
+
+    const remainingRelations = await db
+      .select()
+      .from(issueRelations)
+      .where(and(eq(issueRelations.companyId, companyId), eq(issueRelations.relatedIssueId, blockedIssueId)));
+    expect(remainingRelations).toHaveLength(0);
+
+    const repairActivity = await db
+      .select({ action: activityLog.action, entityId: activityLog.entityId, details: activityLog.details })
+      .from(activityLog)
+      .where(and(eq(activityLog.companyId, companyId), eq(activityLog.action, "issue.blockers.updated")));
+    expect(repairActivity).toEqual([
+      expect.objectContaining({
+        entityId: blockedIssueId,
+        details: expect.objectContaining({
+          source: "issue_graph_liveness.backstop",
+          removedBlockerIssueIds: [blockerIssueId],
+          remainingBlockerIssueIds: [],
+        }),
+      }),
+    ]);
+  });
+
+  it("keeps cancelled blockers unresolved instead of routing a normal continuation", async () => {
+    const { companyId, blockedIssueId, blockerIssueId } = await seedBlockedChain({ blockerStatus: "cancelled" });
+
+    const result = await heartbeatService(db).reconcileIssueGraphLiveness();
+
+    expect(result.dependencyWakesHealed).toBe(0);
+    expect(result.dependencyWakeNotReadySkipped).toBe(1);
+
+    const wakes = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.companyId, companyId));
+    expect(wakes).toHaveLength(0);
+
+    const remainingRelations = await db
+      .select()
+      .from(issueRelations)
+      .where(and(eq(issueRelations.companyId, companyId), eq(issueRelations.relatedIssueId, blockedIssueId)));
+    expect(remainingRelations.map((relation) => relation.issueId)).toEqual([blockerIssueId]);
   });
 
   it("reconciles a resolved blocked dependency after the assignee-null window closes", async () => {
@@ -636,10 +679,13 @@ describeEmbeddedPostgres("heartbeat issue graph liveness escalation", () => {
       .where(eq(agents.id, agentId));
 
     const result = await heartbeatService(db).reconcileIssueGraphLiveness();
+    const second = await heartbeatService(db).reconcileIssueGraphLiveness();
 
     expect(result.dependencyWakesHealed).toBe(0);
     expect(result.dependencyWakeDeferredOrFailed).toBe(1);
     expect(result.dependencyWakeEnqueueFailed).toBe(0);
+    expect(result.dependencyWakeRecoveryActionsCreated).toBe(1);
+    expect(second.dependencyWakeRecoveryActionsCreated).toBe(0);
 
     const skippedWake = await db
       .select({
@@ -652,6 +698,19 @@ describeEmbeddedPostgres("heartbeat issue graph liveness escalation", () => {
     expect(skippedWake).toMatchObject({
       status: "skipped",
       reason: "heartbeat.wakeOnDemand.disabled",
+    });
+
+    const actions = await db
+      .select()
+      .from(issueRecoveryActions)
+      .where(and(eq(issueRecoveryActions.companyId, companyId), eq(issueRecoveryActions.ownerAgentId, agentId)));
+    expect(actions).toHaveLength(1);
+    expect(actions[0]).toMatchObject({
+      status: "active",
+      kind: "issue_graph_liveness",
+      cause: "dependency_normal_continuation_unavailable",
+      attemptCount: 1,
+      maxAttempts: 3,
     });
   });
 

--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -1628,6 +1628,7 @@ describe("agent issue mutation checkout ownership", () => {
     );
     mockIssueRecoveryActionService.getActiveForIssue.mockResolvedValue({
       id: recoveryActionId,
+      ownerType: "agent",
       ownerAgentId,
     });
 
@@ -1641,6 +1642,29 @@ describe("agent issue mutation checkout ownership", () => {
 
     expect(res.status, JSON.stringify(res.body)).toBe(403);
     expect(res.body.error).toBe("Agent cannot resolve another owner's recovery action");
+    expect(mockIssueRecoveryActionService.resolveActiveForIssue).not.toHaveBeenCalled();
+  });
+
+  it("rejects the source assignee when a recovery action is board-owned without an agent owner", async () => {
+    mockIssueService.getById.mockResolvedValue(
+      makeIssue({ status: "blocked", assigneeAgentId: ownerAgentId, assigneeUserId: null }),
+    );
+    mockIssueRecoveryActionService.getActiveForIssue.mockResolvedValue({
+      id: recoveryActionId,
+      ownerType: "board",
+      ownerAgentId: null,
+    });
+
+    const res = await request(await createApp(ownerActor()))
+      .post(`/api/issues/${issueId}/recovery-actions/resolve`)
+      .send({
+        actionId: recoveryActionId,
+        outcome: "restored",
+        sourceIssueStatus: "done",
+      });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(403);
+    expect(res.body.error).toBe("Board-owned recovery action requires board resolution");
     expect(mockIssueRecoveryActionService.resolveActiveForIssue).not.toHaveBeenCalled();
   });
 

--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -1138,22 +1138,6 @@ describe("agent issue mutation checkout ownership", () => {
 
   it.each([
     [
-      "issue create",
-      (app: express.Express) =>
-        request(app).post(`/api/companies/${companyId}/issues`).send({
-          title: "Downstream source work",
-          assigneeAdapterOverrides: { modelProfile: "cheap" },
-        }),
-    ],
-    [
-      "child issue create",
-      (app: express.Express) =>
-        request(app).post(`/api/issues/${issueId}/children`).send({
-          title: "Downstream child source work",
-          assigneeAdapterOverrides: { modelProfile: "cheap" },
-        }),
-    ],
-    [
       "issue update",
       (app: express.Express) =>
         request(app).patch(`/api/issues/${issueId}`).send({
@@ -1179,6 +1163,53 @@ describe("agent issue mutation checkout ownership", () => {
     expect(mockIssueService.create).not.toHaveBeenCalled();
     expect(mockIssueService.createChild).not.toHaveBeenCalled();
     expect(mockIssueService.update).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    [
+      "top-level issue creation",
+      (app: express.Express) =>
+        request(app).post(`/api/companies/${companyId}/issues`).send({
+          title: "Executable recovery follow-up",
+        }),
+    ],
+    [
+      "child issue creation",
+      (app: express.Express) =>
+        request(app).post(`/api/issues/${issueId}/children`).send({
+          title: "Executable recovery child",
+        }),
+    ],
+    [
+      "accepted-plan decomposition",
+      (app: express.Express) =>
+        request(app).post(`/api/issues/${issueId}/accepted-plan-decompositions`).send({
+          acceptedPlanRevisionId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+          children: [
+            { title: "Executable accepted-plan child" },
+          ],
+        }),
+    ],
+  ])("blocks cheap status-only recovery runs from %s", async (_name, sendRequest) => {
+    const app = await createApp(
+      ownerActor(),
+      createRunContextDb({
+        modelProfile: "cheap",
+        recoveryIntent: "status_only",
+        allowDeliverableWork: false,
+        allowDocumentUpdates: false,
+        resumeRequiresNormalModel: true,
+      }),
+    );
+
+    const res = await sendRequest(app);
+
+    expect(res.status, JSON.stringify(res.body)).toBe(403);
+    expect(res.body.error).toContain("cannot create executable issues or accepted-plan decompositions");
+    expect(mockIssueService.create).not.toHaveBeenCalled();
+    expect(mockIssueService.createChild).not.toHaveBeenCalled();
+    expect(mockIssueService.decomposeAcceptedPlan).not.toHaveBeenCalled();
+    expect(mockHeartbeatService.wakeup).not.toHaveBeenCalled();
   });
 
   it("defaults agent-created root follow-up issues to inherit the current run workspace", async () => {

--- a/server/src/__tests__/issue-dependency-wakeups-routes.test.ts
+++ b/server/src/__tests__/issue-dependency-wakeups-routes.test.ts
@@ -206,6 +206,15 @@ describe("issue dependency wakeups in issue routes", () => {
         blockerIssueIds: ["issue-1", "issue-3"],
       },
     ]);
+    mockIssueService.getDependencyReadiness.mockResolvedValue({
+      issueId: "issue-2",
+      blockerIssueIds: ["issue-1", "issue-3"],
+      unresolvedBlockerIssueIds: [],
+      unresolvedBlockerCount: 0,
+      pendingFinalizeBlockerIssueIds: [],
+      allBlockersDone: true,
+      isDependencyReady: true,
+    });
 
     const res = await request(await createApp()).patch("/api/issues/issue-1").send({ status: "done" });
     expect(res.status).toBe(200);
@@ -221,6 +230,72 @@ describe("issue dependency wakeups in issue routes", () => {
         }),
       );
     });
+    expect(mockIssueService.update).toHaveBeenCalledWith(
+      "issue-2",
+      expect.objectContaining({ blockedByIssueIds: [] }),
+    );
+  });
+
+  it("preserves unresolved blockers when route-level readiness no longer confirms repair", async () => {
+    mockIssueService.getById.mockResolvedValue({
+      id: "issue-1",
+      companyId: "company-1",
+      identifier: "TASK-100",
+      title: "Finish blocker",
+      description: null,
+      status: "blocked",
+      priority: "medium",
+      parentId: null,
+      assigneeAgentId: "agent-1",
+      assigneeUserId: null,
+      createdByAgentId: null,
+      createdByUserId: null,
+      executionWorkspaceId: null,
+      labels: [],
+      labelIds: [],
+    });
+    mockIssueService.update.mockResolvedValue({
+      id: "issue-1",
+      companyId: "company-1",
+      identifier: "TASK-100",
+      title: "Finish blocker",
+      description: null,
+      status: "done",
+      priority: "medium",
+      parentId: null,
+      assigneeAgentId: "agent-1",
+      assigneeUserId: null,
+      createdByAgentId: null,
+      createdByUserId: null,
+      executionWorkspaceId: null,
+      labels: [],
+      labelIds: [],
+    });
+    mockIssueService.listWakeableBlockedDependents.mockResolvedValue([
+      {
+        id: "issue-2",
+        assigneeAgentId: "agent-2",
+        blockerIssueIds: ["issue-1", "issue-3"],
+      },
+    ]);
+    mockIssueService.getDependencyReadiness.mockResolvedValue({
+      issueId: "issue-2",
+      blockerIssueIds: ["issue-1", "issue-3"],
+      unresolvedBlockerIssueIds: ["issue-3"],
+      unresolvedBlockerCount: 1,
+      pendingFinalizeBlockerIssueIds: [],
+      allBlockersDone: false,
+      isDependencyReady: false,
+    });
+
+    const res = await request(await createApp()).patch("/api/issues/issue-1").send({ status: "done" });
+
+    expect(res.status).toBe(200);
+    expect(mockIssueService.update).not.toHaveBeenCalledWith(
+      "issue-2",
+      expect.objectContaining({ blockedByIssueIds: expect.any(Array) }),
+    );
+    expect(mockWakeup).not.toHaveBeenCalled();
   });
 
   it("wakes an assigned blocked issue when blockers are applied after the blocker is already done", async () => {

--- a/server/src/__tests__/issue-recovery-actions.test.ts
+++ b/server/src/__tests__/issue-recovery-actions.test.ts
@@ -1731,6 +1731,69 @@ describeEmbeddedPostgres("issue recovery actions", () => {
     });
   });
 
+  it("rejects the source assignee when a recovery action is board-owned without an agent owner", async () => {
+    const { companyId, coderId, sourceIssueId } = await seedCompany();
+    await db
+      .update(issues)
+      .set({ status: "blocked", assigneeAgentId: coderId, assigneeUserId: null })
+      .where(eq(issues.id, sourceIssueId));
+    const recoveryActionSvc = issueRecoveryActionService(db);
+    const action = await recoveryActionSvc.upsertSourceScoped({
+      companyId,
+      sourceIssueId,
+      kind: "issue_graph_liveness",
+      ownerType: "board",
+      ownerAgentId: null,
+      cause: "issue_graph_liveness",
+      fingerprint: "graph-liveness:board-owner-required",
+      evidence: { latestIssueStatus: "blocked" },
+      nextAction: "A board operator must choose the recovery disposition.",
+      wakePolicy: { type: "board_escalation" },
+    });
+    const runId = randomUUID();
+    const app = createApp({
+      type: "agent",
+      agentId: coderId,
+      companyId,
+      runId,
+      source: "agent_jwt",
+    });
+    await seedHeartbeatRun({
+      companyId,
+      agentId: coderId,
+      runId,
+      issueId: sourceIssueId,
+    });
+
+    await request(app)
+      .post(`/api/issues/${sourceIssueId}/recovery-actions/resolve`)
+      .send({
+        actionId: action.id,
+        outcome: "restored",
+        sourceIssueStatus: "done",
+        resolutionNote: "The stranded assignee should not be able to clear a board escalation.",
+      })
+      .expect(403);
+
+    const [sourceIssue] = await db.select().from(issues).where(eq(issues.id, sourceIssueId));
+    expect(sourceIssue).toMatchObject({
+      status: "blocked",
+      assigneeAgentId: coderId,
+      assigneeUserId: null,
+    });
+    const [actionRow] = await db
+      .select()
+      .from(issueRecoveryActions)
+      .where(eq(issueRecoveryActions.id, action.id));
+    expect(actionRow).toMatchObject({
+      status: "active",
+      ownerType: "board",
+      ownerAgentId: null,
+      outcome: null,
+      resolvedAt: null,
+    });
+  });
+
   it("allows the named recovery owner to resolve a board-owned source recovery action", async () => {
     const { companyId, managerId, sourceIssueId } = await seedCompany();
     await db

--- a/server/src/routes/approvals.ts
+++ b/server/src/routes/approvals.ts
@@ -1,6 +1,5 @@
 import { Router, type Request } from "express";
-import { eq } from "drizzle-orm";
-import { heartbeatRuns, type Db } from "@paperclipai/db";
+import type { Db } from "@paperclipai/db";
 import {
   addApprovalCommentSchema,
   createApprovalSchema,
@@ -21,22 +20,13 @@ import {
 import { assertBoard, assertCompanyAccess, getAccessibleResource, getActorInfo, hasCompanyAccess } from "./authz.js";
 import { redactEventPayload } from "../redaction.js";
 import type { PluginWorkerManager } from "../services/plugin-worker-manager.js";
+import { assertStatusOnlyRecoveryRunAllowsDeliverableMutation } from "./status-only-recovery-guard.js";
 
 function redactApprovalPayload<T extends { payload: Record<string, unknown> }>(approval: T): T {
   return {
     ...approval,
     payload: redactEventPayload(approval.payload) ?? {},
   };
-}
-
-function isStatusOnlyCheapRecoveryContext(contextSnapshot: unknown) {
-  if (!contextSnapshot || typeof contextSnapshot !== "object" || Array.isArray(contextSnapshot)) return false;
-  const context = contextSnapshot as Record<string, unknown>;
-  return context.modelProfile === "cheap" &&
-    context.recoveryIntent === "status_only" &&
-    context.allowDeliverableWork === false &&
-    context.allowDocumentUpdates === false &&
-    context.resumeRequiresNormalModel === true;
 }
 
 export function approvalRoutes(
@@ -74,34 +64,10 @@ export function approvalRoutes(
   }
 
   async function assertApprovalMutationAllowedByRunContext(req: Request, res: any, companyId: string) {
-    if (req.actor.type !== "agent") return true;
-    const runId = req.actor.runId?.trim();
-    if (!runId || !req.actor.agentId) return true;
-
-    const run = await db
-      .select({
-        id: heartbeatRuns.id,
-        companyId: heartbeatRuns.companyId,
-        agentId: heartbeatRuns.agentId,
-        contextSnapshot: heartbeatRuns.contextSnapshot,
-      })
-      .from(heartbeatRuns)
-      .where(eq(heartbeatRuns.id, runId))
-      .then((rows) => rows[0] ?? null);
-    if (!run || run.companyId !== companyId || run.agentId !== req.actor.agentId) return true;
-    if (!isStatusOnlyCheapRecoveryContext(run.contextSnapshot)) return true;
-
-    res.status(403).json({
+    return assertStatusOnlyRecoveryRunAllowsDeliverableMutation(db, req, res, {
       error: "Cheap status-only recovery runs cannot create or modify approvals",
-      details: {
-        companyId,
-        runId: run.id,
-        modelProfile: "cheap",
-        recoveryIntent: "status_only",
-        resumeRequiresNormalModel: true,
-      },
+      companyId,
     });
-    return false;
   }
 
   router.get("/companies/:companyId/approvals", async (req, res) => {

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -8686,9 +8686,20 @@ export function issueRoutes(
         blockerIssueIds: string[];
         source: string;
       }) => {
-        const nextBlockerIssueIds: string[] = [];
-        const removedBlockerIssueIds = [...new Set(input.blockerIssueIds.filter(Boolean))];
+        const currentBlockerIssueIds = [...new Set(input.blockerIssueIds.filter(Boolean))];
+        if (currentBlockerIssueIds.length === 0 || typeof dependencyReadinessSvc.getDependencyReadiness !== "function") {
+          return;
+        }
+        const readiness = await dependencyReadinessSvc.getDependencyReadiness(input.dependentIssueId);
+        if (!readiness.isDependencyReady) return;
+        const satisfiedBlockerIssueIds = new Set(readiness.blockerIssueIds.filter(Boolean));
+        const removedBlockerIssueIds = currentBlockerIssueIds.filter((blockerIssueId) =>
+          satisfiedBlockerIssueIds.has(blockerIssueId),
+        );
         if (removedBlockerIssueIds.length === 0) return;
+        const nextBlockerIssueIds = currentBlockerIssueIds.filter(
+          (blockerIssueId) => !satisfiedBlockerIssueIds.has(blockerIssueId),
+        );
         await svc.update(input.dependentIssueId, {
           blockedByIssueIds: nextBlockerIssueIds,
           actorAgentId: actor.actorType === "agent" ? actor.actorId : null,
@@ -8710,6 +8721,7 @@ export function issueRoutes(
             remainingBlockerIssueIds: nextBlockerIssueIds,
           },
         });
+        return { removedBlockerIssueIds, remainingBlockerIssueIds: nextBlockerIssueIds };
       };
 
       if (executionStageWakeup) {
@@ -8837,18 +8849,19 @@ export function issueRoutes(
       if (becameDone) {
         const dependents = await svc.listWakeableBlockedDependents(issue.id);
         for (const dependent of dependents) {
+          const blockerRepair = await repairSatisfiedDependencyBlockers({
+            dependentIssueId: dependent.id,
+            blockerIssueIds: dependent.blockerIssueIds,
+            source: "issue.blockers_resolved",
+          });
+          if (!blockerRepair) continue;
           await addDependencyResolvedWakeup({
             agentId: dependent.assigneeAgentId,
             dependentIssueId: dependent.id,
             resolvedBlockerIssueId: issue.id,
-            blockerIssueIds: dependent.blockerIssueIds,
+            blockerIssueIds: blockerRepair.removedBlockerIssueIds,
             source: "issue.blockers_resolved",
             mutation: "blocker_done",
-          });
-          await repairSatisfiedDependencyBlockers({
-            dependentIssueId: dependent.id,
-            blockerIssueIds: dependent.blockerIssueIds,
-            source: "issue.blockers_resolved",
           });
         }
       }

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -4189,6 +4189,22 @@ export function issueRoutes(
       res.status(403).json({ error: "Agent authentication required" });
       return false;
     }
+    if (activeRecoveryAction.ownerType === "board" && !activeRecoveryAction.ownerAgentId) {
+      res.status(403).json({
+        error: "Board-owned recovery action requires board resolution",
+        details: {
+          issueId: issue.id,
+          recoveryActionId: activeRecoveryAction.id,
+          actorAgentId,
+          assigneeAgentId: issue.assigneeAgentId,
+          recoveryOwnerType: activeRecoveryAction.ownerType,
+          recoveryOwnerAgentId: activeRecoveryAction.ownerAgentId,
+          source: input.source,
+          securityPrinciples: ["Least Privilege", "Complete Mediation", "Secure Defaults"],
+        },
+      });
+      return false;
+    }
     if (issue.assigneeAgentId === actorAgentId) return true;
     if (
       issue.assigneeAgentId &&

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -8693,6 +8693,36 @@ export function issueRoutes(
           },
         });
       };
+      const repairSatisfiedDependencyBlockers = async (input: {
+        dependentIssueId: string;
+        blockerIssueIds: string[];
+        source: string;
+      }) => {
+        const nextBlockerIssueIds: string[] = [];
+        const removedBlockerIssueIds = [...new Set(input.blockerIssueIds.filter(Boolean))];
+        if (removedBlockerIssueIds.length === 0) return;
+        await svc.update(input.dependentIssueId, {
+          blockedByIssueIds: nextBlockerIssueIds,
+          actorAgentId: actor.actorType === "agent" ? actor.actorId : null,
+          actorUserId: actor.actorType === "user" ? actor.actorId : null,
+        });
+        await logActivity(db, {
+          companyId: issue.companyId,
+          actorType: "system",
+          actorId: "issue_update",
+          agentId: null,
+          runId: actor.runId,
+          action: "issue.blockers.updated",
+          entityType: "issue",
+          entityId: input.dependentIssueId,
+          details: {
+            source: input.source,
+            resolvedBlockerIssueId: issue.id,
+            removedBlockerIssueIds,
+            remainingBlockerIssueIds: nextBlockerIssueIds,
+          },
+        });
+      };
 
       if (executionStageWakeup) {
         addWakeup(executionStageWakeup.agentId, executionStageWakeup.wakeup);
@@ -8826,6 +8856,11 @@ export function issueRoutes(
             blockerIssueIds: dependent.blockerIssueIds,
             source: "issue.blockers_resolved",
             mutation: "blocker_done",
+          });
+          await repairSatisfiedDependencyBlockers({
+            dependentIssueId: dependent.id,
+            blockerIssueIds: dependent.blockerIssueIds,
+            source: "issue.blockers_resolved",
           });
         }
       }

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -141,6 +141,12 @@ import {
 } from "./workspace-command-authz.js";
 import { shouldWakeAssigneeOnCheckout } from "./issues-checkout-wakeup.js";
 import {
+  assertStatusOnlyRecoveryRunAllowsDeliverableMutation,
+  assertStatusOnlyRecoveryRunAllowsIssueExpansion,
+  isStatusOnlyCheapRecoveryContext,
+  loadActorRunContext,
+} from "./status-only-recovery-guard.js";
+import {
   GENERIC_ATTACHMENT_CONTENT_TYPES,
   isInlineAttachmentContentType,
   normalizeIssueAttachmentMaxBytes,
@@ -3963,40 +3969,12 @@ export function issueRoutes(
     return { scope, discovery, sourceIssue, watchdogIssue };
   }
 
-  function isStatusOnlyCheapRecoveryContext(contextSnapshot: unknown) {
-    if (!contextSnapshot || typeof contextSnapshot !== "object" || Array.isArray(contextSnapshot)) return false;
-    const context = contextSnapshot as Record<string, unknown>;
-    return context.modelProfile === "cheap" &&
-      context.recoveryIntent === "status_only" &&
-      context.allowDeliverableWork === false &&
-      context.allowDocumentUpdates === false &&
-      context.resumeRequiresNormalModel === true;
-  }
-
   function requestsCheapIssueAssigneeModelProfile(input: { assigneeAdapterOverrides?: unknown }) {
     const overrides = input.assigneeAdapterOverrides;
     return !!overrides &&
       typeof overrides === "object" &&
       !Array.isArray(overrides) &&
       (overrides as Record<string, unknown>).modelProfile === "cheap";
-  }
-
-  async function loadActorRunContext(req: Request, companyId: string) {
-    if (req.actor.type !== "agent") return null;
-    const runId = req.actor.runId?.trim();
-    if (!runId) return null;
-    const run = await db
-      .select({
-        id: heartbeatRuns.id,
-        companyId: heartbeatRuns.companyId,
-        agentId: heartbeatRuns.agentId,
-        contextSnapshot: heartbeatRuns.contextSnapshot,
-      })
-      .from(heartbeatRuns)
-      .where(eq(heartbeatRuns.id, runId))
-      .then((rows) => rows[0] ?? null);
-    if (!run || run.companyId !== companyId || run.agentId !== req.actor.agentId) return null;
-    return run;
   }
 
   async function assertCheapRecoveryIssueAssigneeProfileAllowed(
@@ -4006,7 +3984,7 @@ export function issueRoutes(
     input: { assigneeAdapterOverrides?: unknown },
   ) {
     if (!requestsCheapIssueAssigneeModelProfile(input)) return true;
-    const run = await loadActorRunContext(req, issue.companyId);
+    const run = await loadActorRunContext(db, req, issue.companyId);
     if (!run || !isStatusOnlyCheapRecoveryContext(run.contextSnapshot)) return true;
 
     res.status(403).json({
@@ -4027,21 +4005,11 @@ export function issueRoutes(
     res: Response,
     issue: { id: string; companyId: string },
   ) {
-    const run = await loadActorRunContext(req, issue.companyId);
-    if (!run) return true;
-    if (!isStatusOnlyCheapRecoveryContext(run.contextSnapshot)) return true;
-
-    res.status(403).json({
+    return assertStatusOnlyRecoveryRunAllowsDeliverableMutation(db, req, res, {
       error: "Cheap status-only recovery runs cannot update issue documents, plans, or deliverable artifacts",
-      details: {
-        issueId: issue.id,
-        runId: run.id,
-        modelProfile: "cheap",
-        recoveryIntent: "status_only",
-        resumeRequiresNormalModel: true,
-      },
+      companyId: issue.companyId,
+      issueId: issue.id,
     });
-    return false;
   }
 
   async function assertApprovalMutationAllowedByRunContext(
@@ -4049,21 +4017,11 @@ export function issueRoutes(
     res: Response,
     issue: { id: string; companyId: string },
   ) {
-    const run = await loadActorRunContext(req, issue.companyId);
-    if (!run) return true;
-    if (!isStatusOnlyCheapRecoveryContext(run.contextSnapshot)) return true;
-
-    res.status(403).json({
+    return assertStatusOnlyRecoveryRunAllowsDeliverableMutation(db, req, res, {
       error: "Cheap status-only recovery runs cannot create or modify approvals",
-      details: {
-        issueId: issue.id,
-        runId: run.id,
-        modelProfile: "cheap",
-        recoveryIntent: "status_only",
-        resumeRequiresNormalModel: true,
-      },
+      companyId: issue.companyId,
+      issueId: issue.id,
     });
-    return false;
   }
 
   async function loadWorkProductRunAttribution(runId: string) {
@@ -6994,6 +6952,10 @@ export function issueRoutes(
       });
       return;
     }
+    if (!(await assertStatusOnlyRecoveryRunAllowsIssueExpansion(db, req, res, {
+      companyId,
+      surface: "issues.create",
+    }))) return;
     if (await assertLowTrustControlPlaneDenied(req, res, companyId, null)) return;
     assertNoAgentHostWorkspaceCommandMutation(req, collectIssueWorkspaceCommandPaths(req.body));
     const sanitizedBody = await sanitizeIssueCreateAttribution(db, req, res, companyId, req.body, {
@@ -7243,6 +7205,11 @@ export function issueRoutes(
     if (!isTaskBridgeKeyActor(req) && !(await assertIssueReadAllowed(req, res, parent))) return;
     if (!(await assertTaskWatchdogCreateIssueAllowed(req, res, parent.companyId, parent))) return;
     if (await assertLowTrustControlPlaneDenied(req, res, parent.companyId, parent)) return;
+    if (!(await assertStatusOnlyRecoveryRunAllowsIssueExpansion(db, req, res, {
+      companyId: parent.companyId,
+      issueId: parent.id,
+      surface: "issues.children.create",
+    }))) return;
     assertNoAgentHostWorkspaceCommandMutation(req, collectIssueWorkspaceCommandPaths(req.body));
     const sanitizedBody = await sanitizeIssueCreateAttribution(db, req, res, parent.companyId, req.body, {
       surface: "issues.children.create",
@@ -7417,6 +7384,11 @@ export function issueRoutes(
     const sourceIssue = await getAccessibleResource(req, res, svc.getById(sourceIssueId), "Issue not found");
     if (!sourceIssue) return;
     if (!(await assertAgentIssueMutationAllowed(req, res, sourceIssue))) return;
+    if (!(await assertStatusOnlyRecoveryRunAllowsIssueExpansion(db, req, res, {
+      companyId: sourceIssue.companyId,
+      issueId: sourceIssue.id,
+      surface: "issues.accepted_plan_decomposition",
+    }))) return;
 
     const requestedChildren = [];
     for (const child of req.body.children as Array<typeof req.body.children[number]>) {

--- a/server/src/routes/status-only-recovery-guard.ts
+++ b/server/src/routes/status-only-recovery-guard.ts
@@ -1,0 +1,80 @@
+import type { Request, Response } from "express";
+import { eq } from "drizzle-orm";
+import { heartbeatRuns, type Db } from "@paperclipai/db";
+
+export const STATUS_ONLY_RECOVERY_ISSUE_EXPANSION_ERROR =
+  "Cheap status-only recovery runs cannot create executable issues or accepted-plan decompositions";
+
+export function isStatusOnlyCheapRecoveryContext(contextSnapshot: unknown) {
+  if (!contextSnapshot || typeof contextSnapshot !== "object" || Array.isArray(contextSnapshot)) return false;
+  const context = contextSnapshot as Record<string, unknown>;
+  return context.modelProfile === "cheap" &&
+    context.recoveryIntent === "status_only" &&
+    context.allowDeliverableWork === false &&
+    context.allowDocumentUpdates === false &&
+    context.resumeRequiresNormalModel === true;
+}
+
+export async function loadActorRunContext(db: Db, req: Request, companyId: string) {
+  if (req.actor.type !== "agent") return null;
+  const runId = req.actor.runId?.trim();
+  if (!runId) return null;
+  const run = await db
+    .select({
+      id: heartbeatRuns.id,
+      companyId: heartbeatRuns.companyId,
+      agentId: heartbeatRuns.agentId,
+      contextSnapshot: heartbeatRuns.contextSnapshot,
+    })
+    .from(heartbeatRuns)
+    .where(eq(heartbeatRuns.id, runId))
+    .then((rows) => rows[0] ?? null);
+  if (!run || run.companyId !== companyId || run.agentId !== req.actor.agentId) return null;
+  return run;
+}
+
+export async function assertStatusOnlyRecoveryRunAllowsDeliverableMutation(
+  db: Db,
+  req: Request,
+  res: Response,
+  input: {
+    companyId: string;
+    error: string;
+    issueId?: string | null;
+    surface?: string;
+  },
+) {
+  const run = await loadActorRunContext(db, req, input.companyId);
+  if (!run) return true;
+  if (!isStatusOnlyCheapRecoveryContext(run.contextSnapshot)) return true;
+
+  res.status(403).json({
+    error: input.error,
+    details: {
+      companyId: input.companyId,
+      issueId: input.issueId ?? null,
+      runId: run.id,
+      modelProfile: "cheap",
+      recoveryIntent: "status_only",
+      resumeRequiresNormalModel: true,
+      ...(input.surface ? { surface: input.surface } : {}),
+    },
+  });
+  return false;
+}
+
+export async function assertStatusOnlyRecoveryRunAllowsIssueExpansion(
+  db: Db,
+  req: Request,
+  res: Response,
+  input: {
+    companyId: string;
+    issueId?: string | null;
+    surface: "issues.create" | "issues.children.create" | "issues.accepted_plan_decomposition";
+  },
+) {
+  return assertStatusOnlyRecoveryRunAllowsDeliverableMutation(db, req, res, {
+    ...input,
+    error: STATUS_ONLY_RECOVERY_ISSUE_EXPANSION_ERROR,
+  });
+}

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -3094,6 +3094,110 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     return existingUnresolvedBlockerIssues(companyId, issueId).then((rows) => rows.map((row) => row.id));
   }
 
+  async function repairSatisfiedBlockerRelations(input: {
+    issue: Pick<typeof issues.$inferSelect, "id" | "companyId" | "identifier" | "status">;
+    satisfiedBlockerIssueIds: string[];
+    source: string;
+    runId?: string | null;
+  }) {
+    const satisfiedBlockerIssueIds = [...new Set(input.satisfiedBlockerIssueIds.filter(Boolean))];
+    if (satisfiedBlockerIssueIds.length === 0) return null;
+
+    const currentBlockerIssueIds = await existingBlockerIssueIds(input.issue.companyId, input.issue.id);
+    const satisfied = new Set(satisfiedBlockerIssueIds);
+    const removedBlockerIssueIds = currentBlockerIssueIds.filter((blockerIssueId) => satisfied.has(blockerIssueId));
+    if (removedBlockerIssueIds.length === 0) return null;
+
+    const remainingBlockerIssueIds = currentBlockerIssueIds.filter((blockerIssueId) => !satisfied.has(blockerIssueId));
+    const updated = await issuesSvc.update(input.issue.id, {
+      blockedByIssueIds: remainingBlockerIssueIds,
+    });
+    if (!updated) return null;
+
+    await logActivity(db, {
+      companyId: input.issue.companyId,
+      actorType: "system",
+      actorId: "issue_graph_liveness_backstop",
+      agentId: null,
+      runId: input.runId ?? null,
+      action: "issue.blockers.updated",
+      entityType: "issue",
+      entityId: input.issue.id,
+      details: {
+        source: input.source,
+        identifier: input.issue.identifier,
+        previousStatus: input.issue.status,
+        status: updated.status,
+        removedBlockerIssueIds,
+        remainingBlockerIssueIds,
+      },
+    });
+
+    return {
+      updated,
+      removedBlockerIssueIds,
+      remainingBlockerIssueIds,
+    };
+  }
+
+  async function ensureNormalContinuationRecoveryAction(input: {
+    issue: Pick<typeof issues.$inferSelect, "id" | "companyId" | "identifier" | "assigneeAgentId">;
+    agentId: string;
+    blockerIssueIds: string[];
+    source: string;
+    reason: string;
+    runId?: string | null;
+  }) {
+    const existing = await recoveryActionsSvc.getActiveForIssue(input.issue.companyId, input.issue.id);
+    if (existing) return { action: existing, created: false };
+
+    const action = await recoveryActionsSvc.upsertSourceScoped({
+      companyId: input.issue.companyId,
+      sourceIssueId: input.issue.id,
+      kind: "issue_graph_liveness",
+      ownerType: "agent",
+      ownerAgentId: input.agentId,
+      previousOwnerAgentId: input.issue.assigneeAgentId,
+      returnOwnerAgentId: input.issue.assigneeAgentId,
+      cause: "dependency_normal_continuation_unavailable",
+      fingerprint: `dependency_normal_continuation_unavailable:${input.issue.companyId}:${input.issue.id}`,
+      evidence: {
+        source: input.source,
+        reason: input.reason,
+        blockerIssueIds: input.blockerIssueIds,
+      },
+      nextAction: "Restore or manually queue the normal-model continuation for the source issue after its blocker dependencies resolved.",
+      wakePolicy: {
+        type: "normal_model_continuation_required",
+        reason: input.reason,
+        ownerAgentId: input.agentId,
+      },
+      monitorPolicy: null,
+      maxAttempts: 3,
+      lastAttemptAt: new Date(),
+    });
+
+    await logActivity(db, {
+      companyId: input.issue.companyId,
+      actorType: "system",
+      actorId: "issue_graph_liveness_backstop",
+      agentId: input.agentId,
+      runId: input.runId ?? null,
+      action: "issue.recovery_action_created",
+      entityType: "issue_recovery_action",
+      entityId: action.id,
+      details: {
+        source: input.source,
+        issueId: input.issue.id,
+        identifier: input.issue.identifier,
+        reason: input.reason,
+        blockerIssueIds: input.blockerIssueIds,
+      },
+    });
+
+    return { action, created: true };
+  }
+
   async function resolveContinuationWaitingOnReview(issue: typeof issues.$inferSelect) {
     const existingBlockers = await existingUnresolvedBlockerIssues(issue.companyId, issue.id);
     const openChildren = await db
@@ -4940,6 +5044,9 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       candidateLimitSkipped: 0,
       deferredOrFailed: 0,
       enqueueFailed: 0,
+      blockerRelationsRepaired: 0,
+      recoveryActionsCreated: 0,
+      recoveryActionsPreserved: 0,
       issueIds: [] as string[],
     };
 
@@ -4973,6 +5080,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
             id: issues.id,
             companyId: issues.companyId,
             identifier: issues.identifier,
+            status: issues.status,
             assigneeAgentId: issues.assigneeAgentId,
             totalCount: sql<number>`count(*) over()::int`,
           })
@@ -4988,6 +5096,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
           id: issues.id,
           companyId: issues.companyId,
           identifier: issues.identifier,
+          status: issues.status,
           assigneeAgentId: issues.assigneeAgentId,
           totalCount: sql<number>`count(*) over()::int`,
         })
@@ -5054,6 +5163,14 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
           continue;
         }
 
+        const blockerRepair = await repairSatisfiedBlockerRelations({
+          issue: candidate,
+          satisfiedBlockerIssueIds: readiness.blockerIssueIds,
+          source,
+          runId: opts?.runId ?? null,
+        });
+        result.blockerRelationsRepaired += blockerRepair?.removedBlockerIssueIds.length ?? 0;
+
         const idempotencyKeys = readiness.blockerIssueIds.map((blockerIssueId) =>
           buildIssueBlockersResolvedWakeIdempotencyKey({
             dependentIssueId: candidate.id,
@@ -5119,6 +5236,19 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
             // such as disabled wake-on-demand or concurrency gating. That is
             // not an enqueue error, but the backstop still did not heal now.
             result.deferredOrFailed += 1;
+            const recoveryAction = await ensureNormalContinuationRecoveryAction({
+              issue: candidate,
+              agentId,
+              blockerIssueIds: readiness.blockerIssueIds,
+              source,
+              reason: "normal_dependency_wake_not_enqueued",
+              runId: opts?.runId ?? null,
+            });
+            if (recoveryAction.created) {
+              result.recoveryActionsCreated += 1;
+            } else {
+              result.recoveryActionsPreserved += 1;
+            }
             continue;
           }
 
@@ -5145,8 +5275,21 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         } catch (err) {
           result.deferredOrFailed += 1;
           result.enqueueFailed += 1;
+          const recoveryAction = await ensureNormalContinuationRecoveryAction({
+            issue: candidate,
+            agentId,
+            blockerIssueIds: readiness.blockerIssueIds,
+            source,
+            reason: "normal_dependency_wake_enqueue_failed",
+            runId: opts?.runId ?? null,
+          });
+          if (recoveryAction.created) {
+            result.recoveryActionsCreated += 1;
+          } else {
+            result.recoveryActionsPreserved += 1;
+          }
           logger.warn(
-            { err, issueId: candidate.id, agentId, idempotencyKey, source },
+            { err, issueId: candidate.id, agentId, idempotencyKey, source, recoveryActionId: recoveryAction.action.id },
             "failed to enqueue dependency wake from issue graph liveness backstop",
           );
         }
@@ -5230,6 +5373,9 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       dependencyWakeCandidateLimitSkipped: 0,
       dependencyWakeDeferredOrFailed: 0,
       dependencyWakeEnqueueFailed: 0,
+      dependencyWakeBlockerRelationsRepaired: 0,
+      dependencyWakeRecoveryActionsCreated: 0,
+      dependencyWakeRecoveryActionsPreserved: 0,
       dependencyWakeIssueIds: [] as string[],
       issueIds: [] as string[],
       escalationIssueIds: [] as string[],
@@ -5249,6 +5395,9 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     result.dependencyWakeCandidateLimitSkipped = dependencyWakeBackstop.candidateLimitSkipped;
     result.dependencyWakeDeferredOrFailed = dependencyWakeBackstop.deferredOrFailed;
     result.dependencyWakeEnqueueFailed = dependencyWakeBackstop.enqueueFailed;
+    result.dependencyWakeBlockerRelationsRepaired = dependencyWakeBackstop.blockerRelationsRepaired;
+    result.dependencyWakeRecoveryActionsCreated = dependencyWakeBackstop.recoveryActionsCreated;
+    result.dependencyWakeRecoveryActionsPreserved = dependencyWakeBackstop.recoveryActionsPreserved;
     result.dependencyWakeIssueIds = dependencyWakeBackstop.issueIds;
 
     if (!autoRecoveryEnabled) {

--- a/ui/src/components/BlockedReasonChip.test.tsx
+++ b/ui/src/components/BlockedReasonChip.test.tsx
@@ -1,11 +1,19 @@
 // @vitest-environment jsdom
 
-import { act } from "react";
+import { flushSync } from "react-dom";
 import { createRoot } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { BlockedReasonChip } from "./BlockedReasonChip";
 
 (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+// `react`'s bundled `act` is not resolvable in this test environment; use the
+// synchronous flushSync shim (mirrors IssueBlockedNotice.test.tsx).
+function act(callback: () => void): void {
+  flushSync(() => {
+    callback();
+  });
+}
 
 describe("BlockedReasonChip", () => {
   let container: HTMLDivElement;
@@ -32,6 +40,20 @@ describe("BlockedReasonChip", () => {
     expect(chip?.getAttribute("data-severity")).toBe("high");
     expect(chip?.getAttribute("aria-label")).toBe("Reason: Needs decision, severity high");
     expect(chip?.textContent).toContain("Needs decision");
+    act(() => {
+      root.unmount();
+    });
+  });
+
+  it("renders a cancelled dependency as the red cancelled_dependency variant, not a calm wait", () => {
+    const root = createRoot(container);
+    act(() => {
+      root.render(<BlockedReasonChip reason="blocked_by_cancelled_issue" severity="high" />);
+    });
+    const chip = container.querySelector('[data-testid="blocked-reason-chip"]');
+    expect(chip?.getAttribute("data-variant")).toBe("cancelled_dependency");
+    expect(chip?.textContent).toContain("Cancelled dependency");
+    expect(chip?.getAttribute("data-variant")).not.toBe("needs_attention");
     act(() => {
       root.unmount();
     });

--- a/ui/src/components/BlockedReasonChip.tsx
+++ b/ui/src/components/BlockedReasonChip.tsx
@@ -1,4 +1,4 @@
-import { AlertTriangle, Clock, Pause, User, Wrench } from "lucide-react";
+import { AlertOctagon, AlertTriangle, Clock, Pause, User, Wrench, XCircle } from "lucide-react";
 import type { ComponentType } from "react";
 import type { IssueBlockedInboxSeverity } from "@paperclipai/shared";
 import { cn } from "../lib/utils";
@@ -19,6 +19,10 @@ interface BlockedReasonChipProps {
 type IconComponent = ComponentType<{ className?: string; "aria-hidden"?: boolean | "true" | "false" }>;
 
 const VARIANT_STYLES: Record<BlockedReasonVariant, string> = {
+  unresolved:
+    "border-red-400/70 bg-red-100 text-red-900 dark:border-red-500/40 dark:bg-red-500/15 dark:text-red-200",
+  cancelled_dependency:
+    "border-red-300/70 bg-red-50 text-red-800 dark:border-red-500/30 dark:bg-red-500/10 dark:text-red-300",
   needs_decision:
     "border-violet-300/70 bg-violet-50 text-violet-800 dark:border-violet-500/30 dark:bg-violet-500/10 dark:text-violet-300",
   recovery_required:
@@ -34,6 +38,8 @@ const VARIANT_STYLES: Record<BlockedReasonVariant, string> = {
 };
 
 const VARIANT_ICONS: Record<BlockedReasonVariant, IconComponent> = {
+  unresolved: AlertOctagon,
+  cancelled_dependency: XCircle,
   needs_decision: Clock,
   recovery_required: Wrench,
   stalled: AlertTriangle,

--- a/ui/src/components/IssueBlockedNotice.test.tsx
+++ b/ui/src/components/IssueBlockedNotice.test.tsx
@@ -771,7 +771,7 @@ describe("IssueBlockedNotice", () => {
         ]}
       />,
     );
-    expect(node.textContent).toContain("Work on this task is blocked by the linked task");
+    expect(node.textContent).toContain("A message won’t restart this task yet");
     expect(node.querySelector('[data-testid="issue-blocked-notice-satisfied-row"]')?.textContent).toContain("TASK-145");
     expect(node.querySelector('[data-testid="issue-blocked-notice-cancelled-row"]')?.textContent).toContain("TASK-199");
   });

--- a/ui/src/components/IssueBlockedNotice.test.tsx
+++ b/ui/src/components/IssueBlockedNotice.test.tsx
@@ -629,4 +629,150 @@ describe("IssueBlockedNotice", () => {
     expect(indicator?.getAttribute("data-recovery-kind")).toBe("workspace_validation");
     expect(indicator?.textContent).toContain("Workspace recovery needed");
   });
+
+  it("renders the red state-6 notice for a blockerless blocked issue, naming the responsible owner", () => {
+    const node = render(
+      <IssueBlockedNotice
+        issueStatus="blocked"
+        blockers={[]}
+        allBlockers={[]}
+        responsibleAgentName="Senior Planning Engineer Pro"
+      />,
+    );
+
+    const notice = node.querySelector('[data-testid="issue-blocked-notice-stopped-no-reason"]');
+    expect(notice).not.toBeNull();
+    expect(notice?.getAttribute("role")).toBe("status");
+    expect(node.textContent).toContain("Stopped — no reason on record");
+    expect(node.textContent).toContain("Next step is owned by");
+    expect(node.textContent).toContain("Senior Planning Engineer Pro");
+    // Names the three dispositions.
+    expect(node.textContent).toContain("To do");
+    expect(node.textContent).toContain("recovery action");
+    expect(node.textContent).toContain("Cancelled");
+    // Never the old passive line, and not the amber notice.
+    expect(node.textContent).not.toContain("blocked until it is moved back to todo");
+    expect(node.querySelector('[data-blocker-attention-state]')).toBeNull();
+  });
+
+  it("falls back to 'the control plane' as the owner when no responsible agent is known", () => {
+    const node = render(<IssueBlockedNotice issueStatus="blocked" blockers={[]} allBlockers={[]} />);
+    expect(node.textContent).toContain("Stopped — no reason on record");
+    expect(node.textContent).toContain("the control plane");
+  });
+
+  it("routes an all-done blocker list to state 6 and lists the done leaves as Satisfied", () => {
+    const node = render(
+      <IssueBlockedNotice
+        issueStatus="blocked"
+        blockers={[]}
+        allBlockers={[
+          {
+            id: "done-1",
+            identifier: "TASK-145",
+            title: "live-tree hygiene",
+            status: "done",
+            priority: "medium",
+            assigneeAgentId: "agent-1",
+            assigneeUserId: null,
+          },
+        ]}
+        responsibleAgentName="QA"
+      />,
+    );
+    expect(node.querySelector('[data-testid="issue-blocked-notice-stopped-no-reason"]')).not.toBeNull();
+    const satisfied = node.querySelector('[data-testid="issue-blocked-notice-satisfied-row"]');
+    expect(satisfied).not.toBeNull();
+    expect(satisfied?.textContent).toContain("Satisfied");
+    expect(satisfied?.textContent).toContain("TASK-145");
+  });
+
+  it("renders a cancelled blocker as an unsatisfied decision, not a calm wait", () => {
+    const node = render(
+      <IssueBlockedNotice
+        issueStatus="blocked"
+        blockers={[]}
+        allBlockers={[
+          {
+            id: "cancelled-1",
+            identifier: "TASK-199",
+            title: "dropped dependency",
+            status: "cancelled",
+            priority: "medium",
+            assigneeAgentId: null,
+            assigneeUserId: null,
+          },
+        ]}
+      />,
+    );
+    const cancelledRow = node.querySelector('[data-testid="issue-blocked-notice-cancelled-row"]');
+    expect(cancelledRow).not.toBeNull();
+    expect(cancelledRow?.textContent).toContain("Cancelled — unsatisfied");
+    expect(cancelledRow?.textContent).toContain("TASK-199");
+    expect(cancelledRow?.textContent).toContain("Replace, waive, or escalate this dependency.");
+  });
+
+  it("suppresses the state-6 notice when an active recovery action already owns the state", () => {
+    const node = render(
+      <IssueBlockedNotice
+        issueStatus="blocked"
+        blockers={[]}
+        allBlockers={[]}
+        hasActiveRecovery
+        responsibleAgentName="QA"
+      />,
+    );
+    expect(node.textContent).toBe("");
+  });
+
+  it("shows terminal outcomes alongside an active blocker in the amber notice", () => {
+    const node = render(
+      <IssueBlockedNotice
+        issueStatus="blocked"
+        blockers={[
+          {
+            id: "active-1",
+            identifier: "TASK-151",
+            title: "QA validation",
+            status: "todo",
+            priority: "medium",
+            assigneeAgentId: "agent-1",
+            assigneeUserId: null,
+          },
+        ]}
+        allBlockers={[
+          {
+            id: "active-1",
+            identifier: "TASK-151",
+            title: "QA validation",
+            status: "todo",
+            priority: "medium",
+            assigneeAgentId: "agent-1",
+            assigneeUserId: null,
+          },
+          {
+            id: "done-1",
+            identifier: "TASK-145",
+            title: "live-tree hygiene",
+            status: "done",
+            priority: "medium",
+            assigneeAgentId: "agent-1",
+            assigneeUserId: null,
+          },
+          {
+            id: "cancelled-1",
+            identifier: "TASK-199",
+            title: "dropped dependency",
+            status: "cancelled",
+            priority: "medium",
+            assigneeAgentId: null,
+            assigneeUserId: null,
+          },
+        ]}
+      />,
+    );
+    expect(node.textContent).toContain("Work on this task is blocked by the linked task");
+    expect(node.querySelector('[data-testid="issue-blocked-notice-satisfied-row"]')?.textContent).toContain("TASK-145");
+    expect(node.querySelector('[data-testid="issue-blocked-notice-cancelled-row"]')?.textContent).toContain("TASK-199");
+  });
 });

--- a/ui/src/components/IssueBlockedNotice.tsx
+++ b/ui/src/components/IssueBlockedNotice.tsx
@@ -6,7 +6,7 @@ import type {
   SuccessfulRunHandoffState,
 } from "@paperclipai/shared";
 import type { ReactNode } from "react";
-import { AlertTriangle, CheckCircle2, Circle, Flag, Loader2, RotateCcw } from "lucide-react";
+import { AlertOctagon, AlertTriangle, CheckCircle2, Circle, Flag, Loader2, RotateCcw, XCircle } from "lucide-react";
 import { Link } from "@/lib/router";
 import { cn } from "../lib/utils";
 import { Button } from "@/components/ui/button";
@@ -350,6 +350,181 @@ function WaitingOnLiveWorkNotice({
   );
 }
 
+/**
+ * Collect distinct leaf blockers of a given terminal status (`done` /
+ * `cancelled`) from the full blocker chain (top-level + nested terminal
+ * blockers). Terminal outcomes are surfaced instead of silently collapsing:
+ * `done` = satisfied evidence, `cancelled` = an unsatisfied dependency the
+ * operator must replace, waive, or escalate (contract
+ * `doc/execution-semantics.md` — *Stale blocked posture and terminal-blocker repair*).
+ */
+function collectTerminalBlockers(
+  chain: IssueRelationIssueSummary[],
+  status: "done" | "cancelled",
+): IssueRelationIssueSummary[] {
+  const seen = new Set<string>();
+  const collected: IssueRelationIssueSummary[] = [];
+  for (const blocker of chain) {
+    for (const candidate of [blocker, ...(blocker.terminalBlockers ?? [])]) {
+      if (candidate.status !== status) continue;
+      if (seen.has(candidate.id)) continue;
+      seen.add(candidate.id);
+      collected.push(candidate);
+    }
+  }
+  return collected;
+}
+
+function TerminalOutcomeChip({
+  blocker,
+  tone,
+}: {
+  blocker: IssueRelationIssueSummary;
+  tone: "satisfied" | "cancelled";
+}) {
+  const issuePathId = blocker.identifier ?? blocker.id;
+  const Icon = tone === "satisfied" ? CheckCircle2 : XCircle;
+  const className =
+    tone === "satisfied"
+      ? "inline-flex max-w-full items-center gap-1 rounded-md border border-border bg-background/80 px-2 py-1 font-mono text-xs text-muted-foreground transition-colors hover:bg-accent hover:underline"
+      : "inline-flex max-w-full items-center gap-1 rounded-md border border-red-300/70 bg-background/80 px-2 py-1 font-mono text-xs text-red-800 transition-colors hover:border-red-500 hover:bg-red-100 hover:underline dark:border-red-500/40 dark:bg-background/40 dark:text-red-200 dark:hover:bg-red-500/15";
+  const iconClass =
+    tone === "satisfied"
+      ? "h-3 w-3 shrink-0 text-muted-foreground"
+      : "h-3 w-3 shrink-0 text-red-600 dark:text-red-400";
+  return (
+    <IssueLinkQuicklook
+      issuePathId={issuePathId}
+      to={createIssueDetailPath(issuePathId)}
+      className={className}
+    >
+      <Icon className={iconClass} aria-hidden />
+      <span>{blocker.identifier ?? blocker.id.slice(0, 8)}</span>
+      <span
+        className={cn(
+          "max-w-(--sz-18rem) truncate font-sans text-(length:--text-micro)",
+          tone === "satisfied" ? "text-muted-foreground" : "text-red-700 dark:text-red-300",
+        )}
+      >
+        {blocker.title}
+      </span>
+    </IssueLinkQuicklook>
+  );
+}
+
+/**
+ * Terminal-blocker outcome rows shared by the amber blocker-wait notice and the
+ * red state-6 notice: `done` leaves render muted "Satisfied" (never counted as
+ * waiting), `cancelled` leaves render a distinct red "Cancelled — unsatisfied"
+ * row that reads as a decision, not a passive wait.
+ */
+function TerminalOutcomeRows({
+  doneBlockers,
+  cancelledBlockers,
+}: {
+  doneBlockers: IssueRelationIssueSummary[];
+  cancelledBlockers: IssueRelationIssueSummary[];
+}) {
+  if (doneBlockers.length === 0 && cancelledBlockers.length === 0) return null;
+  return (
+    <>
+      {doneBlockers.length > 0 ? (
+        <div
+          data-testid="issue-blocked-notice-satisfied-row"
+          className="flex flex-wrap items-center gap-1.5 pt-0.5"
+        >
+          <span className="text-xs font-medium text-muted-foreground">Satisfied</span>
+          {doneBlockers.map((blocker) => (
+            <TerminalOutcomeChip key={blocker.id} blocker={blocker} tone="satisfied" />
+          ))}
+        </div>
+      ) : null}
+      {cancelledBlockers.length > 0 ? (
+        <div
+          data-testid="issue-blocked-notice-cancelled-row"
+          className="space-y-1 pt-0.5"
+        >
+          <span className="inline-flex items-center gap-1 text-xs font-medium text-red-700 dark:text-red-300">
+            <XCircle className="h-3 w-3" aria-hidden />
+            Cancelled — unsatisfied
+          </span>
+          <div className="flex flex-wrap items-center gap-1.5">
+            {cancelledBlockers.map((blocker) => (
+              <TerminalOutcomeChip key={blocker.id} blocker={blocker} tone="cancelled" />
+            ))}
+          </div>
+          <p className="text-xs leading-5 text-red-700 dark:text-red-300">
+            Replace, waive, or escalate this dependency.
+          </p>
+        </div>
+      ) : null}
+    </>
+  );
+}
+
+/**
+ * State 6 — "Stopped — no reason on record". A `blocked`
+ * issue with no unresolved blocker, no live wait, no decision, no recovery, and
+ * no successful-run handoff is stale: nothing will move it automatically. It is
+ * the odd-one-out — a red left-accent + {@link AlertOctagon} so it pops against
+ * the calm blue/amber/violet family instead of hiding among them. `role="status"`
+ * (not `alert`) — the operator did not cause it. Introduces no new mutation
+ * surface: the disposition affordances point at the existing status controls.
+ */
+function StoppedNoReasonNotice({
+  responsibleAgentName,
+  doneBlockers,
+  cancelledBlockers,
+}: {
+  responsibleAgentName?: string | null;
+  doneBlockers: IssueRelationIssueSummary[];
+  cancelledBlockers: IssueRelationIssueSummary[];
+}) {
+  const owner = responsibleAgentName?.trim() ? responsibleAgentName.trim() : "the control plane";
+  return (
+    <div
+      role="status"
+      data-testid="issue-blocked-notice-stopped-no-reason"
+      className="mb-3 rounded-md border border-red-300/70 border-l-2 border-l-red-500/70 bg-background px-3 py-2.5 text-sm text-foreground shadow-sm dark:border-red-500/40 dark:border-l-red-500/70"
+    >
+      <div className="flex items-start gap-2">
+        <AlertOctagon className="mt-0.5 h-4 w-4 shrink-0 text-red-600 dark:text-red-400" aria-hidden />
+        <div className="min-w-0 flex-1 space-y-1.5">
+          <p className="font-medium leading-5">Stopped — no reason on record</p>
+          <p className="leading-5">
+            This task is{" "}
+            <code className="rounded bg-muted px-1 py-0.5 text-xs">blocked</code> but has no
+            dependency, decision, or recovery action on record, so nothing will move it
+            automatically.
+          </p>
+          <p className="leading-5">
+            Next step is owned by{" "}
+            <span className="font-medium">{owner}</span>.
+          </p>
+          <ul className="list-disc space-y-1 pl-5 text-xs leading-5 text-foreground/90">
+            <li>
+              If work should continue → move it to <span className="font-medium">To do</span>{" "}
+              (queues a normal-model continuation).
+            </li>
+            <li>
+              If it is genuinely waiting → add a real <span className="font-medium">blocker</span> or
+              a <span className="font-medium">recovery action</span> with an owner.
+            </li>
+            <li>
+              Otherwise → mark it <span className="font-medium">Done</span> or{" "}
+              <span className="font-medium">Cancelled</span>.
+            </li>
+          </ul>
+          <TerminalOutcomeRows doneBlockers={doneBlockers} cancelledBlockers={cancelledBlockers} />
+          <p className="text-xs leading-5 text-muted-foreground">
+            Comments still wake the responsible for questions or triage.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 export function IssueBlockedNotice({
   issueId,
   issueStatus,
@@ -360,6 +535,8 @@ export function IssueBlockedNotice({
   successfulRunHandoff,
   scheduledRetry,
   agentName,
+  responsibleAgentName,
+  hasActiveRecovery = false,
 }: {
   issueId?: string | null;
   issueStatus?: string;
@@ -376,7 +553,12 @@ export function IssueBlockedNotice({
   blockerAttention?: IssueBlockerAttention | null;
   successfulRunHandoff?: SuccessfulRunHandoffState | null;
   scheduledRetry?: IssueScheduledRetry | null;
+  /** Handoff assignee name (successful-run handoff copy). */
   agentName?: string | null;
+  /** Issue's responsible/assignee agent name — named as owner of state 6. */
+  responsibleAgentName?: string | null;
+  /** An active recovery action is already surfaced (state 4) — suppress state 6. */
+  hasActiveRecovery?: boolean;
 }) {
   if (issueStatus === "done" || issueStatus === "cancelled") return null;
   const showSuccessfulRunHandoff = successfulRunHandoff?.required === true;
@@ -517,6 +699,37 @@ export function IssueBlockedNotice({
     );
   }
 
+  // Terminal-blocker outcomes: `done` = satisfied evidence (never counted as
+  // waiting), `cancelled` = an unsatisfied dependency the operator must resolve.
+  const doneBlockers = collectTerminalBlockers(chainBlockers, "done");
+  const cancelledBlockers = collectTerminalBlockers(chainBlockers, "cancelled");
+
+  // State 6 — "Stopped — no reason on record": a `blocked` issue with no
+  // unresolved blocker, no live wait, no decision, no recovery, and no
+  // successful-run handoff. The server does not emit a distinct signal, so we
+  // infer it from the empty unresolved-blocker set + `blocked` status (the
+  // sanctioned fallback in the UX spec). An active recovery action is already
+  // surfaced separately (state 4), so it suppresses this notice.
+  const isStoppedNoReason =
+    issueStatus === "blocked"
+    && blockers.length === 0
+    && !showSuccessfulRunHandoff
+    && !hasActiveRecovery;
+
+  if (isStoppedNoReason) {
+    return (
+      <StoppedNoReasonNotice
+        responsibleAgentName={responsibleAgentName}
+        doneBlockers={doneBlockers}
+        cancelledBlockers={cancelledBlockers}
+      />
+    );
+  }
+
+  // Nothing left to surface (e.g. an active recovery card owns the blockerless
+  // blocked state, or the issue is unblocked with no handoff).
+  if (!showSuccessfulRunHandoff && blockers.length === 0) return null;
+
   return (
     <div
       data-blocker-attention-state={blockerAttention?.state}
@@ -569,21 +782,19 @@ export function IssueBlockedNotice({
               ) : null}
             </>
           ) : null}
-          {showSuccessfulRunHandoff && (blockers.length > 0 || issueStatus === "blocked") ? (
+          {showSuccessfulRunHandoff && blockers.length > 0 ? (
             <div className="border-t border-amber-300/60 pt-1.5 dark:border-amber-500/30" />
           ) : null}
-          {blockers.length > 0 || issueStatus === "blocked" ? (
+          {blockers.length > 0 ? (
             <>
               <p className="leading-5">
-                {blockers.length > 0
-                  ? isStalled
-                    ? stalledLeafBlockers.length > 1
-                      ? <>Work on this task is blocked by {blockerLabel}, but the chain is stalled in review without a clear next step. Resolve the stalled reviews below or remove them as blockers.</>
-                      : <>Work on this task is blocked by {blockerLabel}, but the chain is stalled in review without a clear next step. Resolve the stalled review below or remove it as a blocker.</>
-                    : reopenSuppressed
-                      ? <>A message won&rsquo;t restart this task yet — it stays blocked by {blockerLabel} until {blockers.length === 1 ? "it is" : "they are"} done, then it reopens automatically. Comments still notify {responsibleName} for questions or triage in the meantime.</>
-                      : <>Work on this task is blocked by {blockerLabel} until {blockers.length === 1 ? "it is" : "they are"} complete. Comments still notify the assignee for questions or triage.</>
-                  : <>Work on this task is blocked until someone moves it back to To do. Comments still notify the assignee for questions or triage.</>}
+                {isStalled
+                  ? stalledLeafBlockers.length > 1
+                    ? <>Work on this task is blocked by {blockerLabel}, but the chain is stalled in review without a clear next step. Resolve the stalled reviews below or remove them as blockers.</>
+                    : <>Work on this task is blocked by {blockerLabel}, but the chain is stalled in review without a clear next step. Resolve the stalled review below or remove it as a blocker.</>
+                  : reopenSuppressed
+                    ? <>A message won&rsquo;t restart this task yet — it stays blocked by {blockerLabel} until {blockers.length === 1 ? "it is" : "they are"} done, then it reopens automatically. Comments still notify {responsibleName} for questions or triage in the meantime.</>
+                    : <>Work on this task is blocked by {blockerLabel} until {blockers.length === 1 ? "it is" : "they are"} complete. Comments still notify the assignee for questions or triage.</>}
               </p>
               {reopenSuppressed && reopenSuppressedLeafId ? (
                 <p
@@ -601,11 +812,9 @@ export function IssueBlockedNotice({
                   .
                 </p>
               ) : null}
-              {blockers.length > 0 ? (
-                <div className="flex flex-wrap gap-1.5">
-                  {blockers.map(renderBlockerChip)}
-                </div>
-              ) : null}
+              <div className="flex flex-wrap gap-1.5">
+                {blockers.map(renderBlockerChip)}
+              </div>
               {showStalledRow ? (
                 <div className="flex flex-wrap items-center gap-1.5 pt-0.5">
                   <span className="text-xs font-medium text-amber-800 dark:text-amber-200">
@@ -633,6 +842,7 @@ export function IssueBlockedNotice({
                   {parkedBlockers.map(renderBlockerChip)}
                 </div>
               ) : null}
+              <TerminalOutcomeRows doneBlockers={doneBlockers} cancelledBlockers={cancelledBlockers} />
             </>
           ) : null}
         </div>

--- a/ui/src/components/IssueChatThread.tsx
+++ b/ui/src/components/IssueChatThread.tsx
@@ -4984,6 +4984,8 @@ export function IssueChatThread({
                     blockerAttention={blockerAttention}
                     successfulRunHandoff={recoveryAction ? null : successfulRunHandoff}
                     scheduledRetry={scheduledRetry}
+                    hasActiveRecovery={Boolean(recoveryAction)}
+                    responsibleAgentName={assignedAgent?.name ?? null}
                     agentName={
                       successfulRunHandoff?.assigneeAgentId
                         ? agentMap?.get(successfulRunHandoff.assigneeAgentId)?.name ?? null

--- a/ui/src/components/StatusIcon.test.tsx
+++ b/ui/src/components/StatusIcon.test.tsx
@@ -67,6 +67,29 @@ describe("StatusIcon", () => {
     expect(html).not.toContain("var(--status-task-icon-in_queue)");
   });
 
+  it("labels a blockerless (state 6) blocked issue as stopped with no reason and keeps the red glyph", () => {
+    const html = renderToStaticMarkup(
+      <StatusIcon
+        status="blocked"
+        blockerAttention={{
+          state: "needs_attention",
+          reason: "attention_required",
+          unresolvedBlockerCount: 0,
+          coveredBlockerCount: 0,
+          stalledBlockerCount: 0,
+          attentionBlockerCount: 0,
+          sampleBlockerIdentifier: null,
+          sampleStalledBlockerIdentifier: null,
+        }}
+      />,
+    );
+    expect(html).toContain("Stopped — no reason on record");
+    expect(html).not.toContain("blockers need attention");
+    // State 6 keeps the red blocked glyph, never the blue in_queue.
+    expect(html).toContain("var(--status-task-icon-blocked)");
+    expect(html).not.toContain("var(--status-task-icon-in_queue)");
+  });
+
   it("surfaces stalled-review blocked copy on the accessible label", () => {
     const html = renderToStaticMarkup(
       <StatusIcon

--- a/ui/src/components/StatusIcon.tsx
+++ b/ui/src/components/StatusIcon.tsx
@@ -24,6 +24,19 @@ interface StatusIconProps {
 function blockedAttentionLabel(blockerAttention: IssueBlockerAttention | null | undefined) {
   if (!blockerAttention || blockerAttention.state === "none") return "Blocked";
 
+  // Blockerless / all-resolved blocked posture (state 6): the server emits
+  // `needs_attention` with every blocker count at zero. Surface it as the stale
+  // "Stopped — no reason on record" state, not a generic "N blockers need
+  // attention" — and keep the red glyph (never the blue `in_queue`).
+  if (
+    blockerAttention.unresolvedBlockerCount === 0
+    && blockerAttention.coveredBlockerCount === 0
+    && blockerAttention.stalledBlockerCount === 0
+    && blockerAttention.attentionBlockerCount === 0
+  ) {
+    return "Stopped — no reason on record";
+  }
+
   if (blockerAttention.reason === "active_child") {
     const count = blockerAttention.coveredBlockerCount;
     if (count === 1 && blockerAttention.sampleBlockerIdentifier) {

--- a/ui/src/lib/blockedInbox.test.ts
+++ b/ui/src/lib/blockedInbox.test.ts
@@ -114,6 +114,25 @@ describe("blockedInbox", () => {
     }
   });
 
+  it("maps a cancelled dependency to the red cancelled_dependency variant, not needs_attention", () => {
+    expect(blockedReasonVariant("blocked_by_cancelled_issue")).toBe("cancelled_dependency");
+    expect(blockedVariantLabel("cancelled_dependency")).toBe("Cancelled dependency");
+  });
+
+  it("defaults an unknown/unclassified blocked reason to the red unresolved variant", () => {
+    // A stopped reason with no explicit mapping must never read like an ordinary
+    // dependency wait — it falls through to "No reason on record".
+    const unknown = "some_future_reason" as never;
+    expect(blockedReasonVariant(unknown)).toBe("unresolved");
+    expect(blockedReasonLabel(unknown)).toBe("No reason on record");
+    expect(blockedVariantLabel("unresolved")).toBe("No reason on record");
+  });
+
+  it("orders the red urgency variants (unresolved, cancelled_dependency) first", () => {
+    expect(BLOCKED_REASON_VARIANT_ORDER[0]).toBe("unresolved");
+    expect(BLOCKED_REASON_VARIANT_ORDER[1]).toBe("cancelled_dependency");
+  });
+
   it("ranks severity critical first and low last", () => {
     const order: IssueBlockedInboxSeverity[] = ["critical", "high", "medium", "low"];
     const ranks = order.map((s) => blockedSeverityRank(s));

--- a/ui/src/lib/blockedInbox.ts
+++ b/ui/src/lib/blockedInbox.ts
@@ -6,6 +6,8 @@ import type {
 } from "@paperclipai/shared";
 
 export type BlockedReasonVariant =
+  | "unresolved"
+  | "cancelled_dependency"
   | "needs_decision"
   | "stalled"
   | "needs_attention"
@@ -20,7 +22,9 @@ const VARIANT_BY_REASON: Record<IssueBlockedInboxReason, BlockedReasonVariant> =
   blocked_chain_stalled: "stalled",
   blocked_by_unassigned_issue: "needs_attention",
   blocked_by_assigned_backlog_issue: "needs_attention",
-  blocked_by_cancelled_issue: "needs_attention",
+  // A cancelled dependency is not satisfied — it reads as a decision (replace,
+  // waive, or escalate), not a calm wait (contract: cancelled ≠ satisfied).
+  blocked_by_cancelled_issue: "cancelled_dependency",
   in_review_without_action_path: "needs_attention",
   invalid_review_participant: "needs_attention",
   open_recovery_issue: "recovery_required",
@@ -29,6 +33,10 @@ const VARIANT_BY_REASON: Record<IssueBlockedInboxReason, BlockedReasonVariant> =
 };
 
 export const BLOCKED_REASON_VARIANT_ORDER: BlockedReasonVariant[] = [
+  // Highest-attention, red variants first so a stale/anomalous stop pops instead
+  // of hiding among the calmer waits; state 6 must be the odd one out.
+  "unresolved",
+  "cancelled_dependency",
   "needs_decision",
   "stalled",
   "needs_attention",
@@ -38,6 +46,8 @@ export const BLOCKED_REASON_VARIANT_ORDER: BlockedReasonVariant[] = [
 ];
 
 export const BLOCKED_VARIANT_LABELS: Record<BlockedReasonVariant, string> = {
+  unresolved: "No reason on record",
+  cancelled_dependency: "Cancelled dependency",
   needs_decision: "Needs decision",
   stalled: "Blocked chain stalled",
   needs_attention: "Needs attention",
@@ -71,11 +81,13 @@ const SEVERITY_RANK: Record<IssueBlockedInboxSeverity, number> = {
 export type BlockedInboxBadgeTone = "muted" | "amber" | "red";
 
 export function blockedReasonVariant(reason: IssueBlockedInboxReason): BlockedReasonVariant {
-  return VARIANT_BY_REASON[reason] ?? "needs_attention";
+  // Default to the red "No reason on record" variant: an unclassified stopped
+  // reason must never read like an ordinary dependency wait.
+  return VARIANT_BY_REASON[reason] ?? "unresolved";
 }
 
 export function blockedReasonLabel(reason: IssueBlockedInboxReason): string {
-  return REASON_LABELS[reason] ?? "Stopped";
+  return REASON_LABELS[reason] ?? "No reason on record";
 }
 
 export function blockedVariantLabel(variant: BlockedReasonVariant): string {

--- a/ui/src/pages/DesignGuide.tsx
+++ b/ui/src/pages/DesignGuide.tsx
@@ -134,6 +134,10 @@ import { InlineEditor } from "@/components/InlineEditor";
 import { PageSkeleton } from "@/components/PageSkeleton";
 import { Identity } from "@/components/Identity";
 import { IssueReferencePill } from "@/components/IssueReferencePill";
+import { IssueBlockedNotice } from "@/components/IssueBlockedNotice";
+import { BlockedReasonChip } from "@/components/BlockedReasonChip";
+import { BLOCKED_REASON_VARIANT_ORDER, blockedReasonVariant } from "@/lib/blockedInbox";
+import type { IssueBlockedInboxReason } from "@paperclipai/shared";
 import { MembershipAction } from "@/components/MembershipAction";
 import { IssueOutputSection } from "@/components/issue-output/IssueOutputSection";
 import { EnvironmentVariablesEditor } from "@/components/environment-variables-editor";
@@ -364,6 +368,162 @@ function Swatch({ name, cssVar }: { name: string; cssVar: string }) {
         <p className="text-xs text-muted-foreground">{name}</p>
       </div>
     </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  Stopped-state surfacing                                            */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Rendered source of truth for the operator "stopped" states: every state has
+ * one tone, one icon family, a heading, and a named owner + next action. State 6
+ * ("Stopped — no reason on record") is the odd-one-out (red accent + AlertOctagon)
+ * so a stale/blockerless stop pops instead of hiding among the calm waits.
+ */
+function StoppedStatesShowcase() {
+  const liveBlocker = {
+    id: "sg-live-1",
+    identifier: "TASK-801",
+    title: "Dependency being worked",
+    status: "in_progress" as const,
+    priority: "medium" as const,
+    assigneeAgentId: "agent-1",
+    assigneeUserId: null,
+  };
+  const queuedBlocker = {
+    id: "sg-queued-1",
+    identifier: "TASK-802",
+    title: "Queued dependency",
+    status: "todo" as const,
+    priority: "medium" as const,
+    assigneeAgentId: "agent-1",
+    assigneeUserId: null,
+  };
+  const reviewBlocker = {
+    id: "sg-review-1",
+    identifier: "TASK-803",
+    title: "Stalled review",
+    status: "in_review" as const,
+    priority: "medium" as const,
+    assigneeAgentId: "agent-1",
+    assigneeUserId: null,
+  };
+  const doneBlocker = {
+    id: "sg-done-1",
+    identifier: "TASK-804",
+    title: "live-tree hygiene",
+    status: "done" as const,
+    priority: "medium" as const,
+    assigneeAgentId: "agent-1",
+    assigneeUserId: null,
+  };
+  const cancelledBlocker = {
+    id: "sg-cancelled-1",
+    identifier: "TASK-805",
+    title: "dropped dependency",
+    status: "cancelled" as const,
+    priority: "medium" as const,
+    assigneeAgentId: null,
+    assigneeUserId: null,
+  };
+  const attention = (over: Record<string, unknown>) => ({
+    state: "none" as const,
+    reason: null,
+    unresolvedBlockerCount: 0,
+    coveredBlockerCount: 0,
+    stalledBlockerCount: 0,
+    attentionBlockerCount: 0,
+    sampleBlockerIdentifier: null,
+    sampleStalledBlockerIdentifier: null,
+    ...over,
+  });
+
+  return (
+    <>
+      <SubSection title="Detail notice — the six stopped states">
+        <div className="grid gap-4 md:grid-cols-2">
+          <div>
+            <p className="mb-1 text-xs font-medium text-muted-foreground">1 · Waiting on live work (blue)</p>
+            <IssueBlockedNotice
+              issueStatus="blocked"
+              liveIssueIds={new Set([liveBlocker.id])}
+              blockers={[liveBlocker]}
+              allBlockers={[doneBlocker, liveBlocker]}
+              blockerAttention={attention({ state: "covered", reason: "active_dependency", unresolvedBlockerCount: 1, coveredBlockerCount: 2 })}
+            />
+          </div>
+          <div>
+            <p className="mb-1 text-xs font-medium text-muted-foreground">2 · Waiting on a blocker (amber)</p>
+            <IssueBlockedNotice
+              issueStatus="blocked"
+              blockers={[queuedBlocker]}
+              allBlockers={[queuedBlocker]}
+              blockerAttention={attention({ state: "needs_attention", reason: "attention_required", unresolvedBlockerCount: 1, attentionBlockerCount: 1 })}
+            />
+          </div>
+          <div>
+            <p className="mb-1 text-xs font-medium text-muted-foreground">5 · Stalled in review (amber-strong)</p>
+            <IssueBlockedNotice
+              issueStatus="blocked"
+              blockers={[reviewBlocker]}
+              allBlockers={[reviewBlocker]}
+              blockerAttention={attention({ state: "stalled", reason: "stalled_review", unresolvedBlockerCount: 1, stalledBlockerCount: 1, sampleStalledBlockerIdentifier: "TASK-803" })}
+            />
+          </div>
+          <div>
+            <p className="mb-1 text-xs font-medium text-muted-foreground">6 · Stopped — no reason on record (red) — NEW</p>
+            <IssueBlockedNotice
+              issueStatus="blocked"
+              blockers={[]}
+              allBlockers={[]}
+              responsibleAgentName="Senior Planning Engineer Pro"
+              blockerAttention={attention({ state: "needs_attention", reason: "attention_required" })}
+            />
+          </div>
+        </div>
+      </SubSection>
+
+      <SubSection title="Terminal-blocker outcomes — done (Satisfied) + cancelled (unsatisfied)">
+        <div className="max-w-xl">
+          <IssueBlockedNotice
+            issueStatus="blocked"
+            blockers={[queuedBlocker]}
+            allBlockers={[queuedBlocker, doneBlocker, cancelledBlocker]}
+            blockerAttention={attention({ state: "needs_attention", reason: "attention_required", unresolvedBlockerCount: 1, attentionBlockerCount: 1 })}
+          />
+        </div>
+      </SubSection>
+
+      <SubSection title="Blocked-inbox reason chips (red urgency variants first)">
+        <p className="text-xs text-muted-foreground">
+          A cancelled dependency and any unclassified stop now read as red decisions, not calm amber waits.
+        </p>
+        <div className="flex flex-wrap items-center gap-2">
+          {(
+            [
+              "blocked_by_cancelled_issue",
+              "pending_board_decision",
+              "blocked_chain_stalled",
+              "blocked_by_unassigned_issue",
+              "open_recovery_issue",
+              "external_owner_action",
+              "blocked_by_uninvokable_assignee",
+            ] as IssueBlockedInboxReason[]
+          )
+            .slice()
+            .sort(
+              (a, b) =>
+                BLOCKED_REASON_VARIANT_ORDER.indexOf(blockedReasonVariant(a)) -
+                BLOCKED_REASON_VARIANT_ORDER.indexOf(blockedReasonVariant(b)),
+            )
+            .map((reason) => (
+              <BlockedReasonChip key={reason} reason={reason} severity="high" />
+            ))}
+          <BlockedReasonChip reason={"blocked_without_reason" as IssueBlockedInboxReason} severity="critical" />
+        </div>
+      </SubSection>
+    </>
   );
 }
 
@@ -694,6 +854,19 @@ export function DesignGuide() {
             <IssueReferencePill strikethrough issue={{ id: "demo-5", identifier: "PAP-202", title: "Removed (strikethrough)", status: "todo" }} />
           </div>
         </SubSection>
+      </Section>
+
+      {/* ============================================================ */}
+      {/*  STOPPED-STATE SURFACING                                     */}
+      {/* ============================================================ */}
+      <Section title="Stopped-state surfacing">
+        <p className="text-sm text-muted-foreground max-w-prose">
+          Why a task is stopped — and who moves it next — at a glance, without reading run logs.
+          Every state names an owner and a next action. A stale, blockerless <code className="font-mono">blocked</code>{" "}
+          posture (state 6) must never read like an ordinary dependency wait, so it is the odd one out:
+          a red accent + <code className="font-mono">AlertOctagon</code>.
+        </p>
+        <StoppedStatesShowcase />
       </Section>
 
       {/* ============================================================ */}


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source control plane people use to coordinate AI-agent work.
> - Issue dependencies, heartbeat liveness, and recovery actions determine whether assigned work keeps moving or stops safely.
> - Resolved blockers could remain attached as unresolved dependencies, while status-only recovery could recursively create more recovery work instead of repairing the source issue.
> - Recovery ownership also crossed authorization boundaries inconsistently, and the operator UI did not clearly distinguish blockerless stopped work from an ordinary dependency wait.
> - This pull request adds bounded source-issue repair, prevents recursive status-only expansion, narrows recovery mutation authority to board-controlled paths, and surfaces stopped states clearly in the UI.
> - The benefit is a recovery flow that resumes productive work, stops only on real blockers or explicit decisions, and cannot grow an unbounded recovery tree.

## Linked Issues or Issue Description

- Refs #4643 — unbounded cascading recovery issues.
- Refs #6523 — repeated recovery wakes for blockerless blocked work.
- Refs #8109 — stale blocker cleanup authority for recovery owners.
- Refs #9201 — permanently blocked issues with no resumable path.
- Related PRs reviewed for overlap: #4671 and #8701. This change covers the broader source-repair contract, status-only expansion guard, operator UI, and board-owned authorization boundary.

## What Changed

- Repair stale dependency state by removing terminal blockers, deriving the correct source disposition, preserving recovery evidence, and bounding normal-model continuation.
- Reject status-only recovery attempts that try to expand the issue graph instead of repairing or explicitly escalating the source issue.
- Restrict recovery-action mutation authority to board-controlled routes while preserving audited recovery operations.
- Add stopped-state operator UI for blockerless blocked work, satisfied/cancelled dependencies, inbox classification, status accessibility, and the design guide.
- Document the execution semantics and add regression coverage across recovery service, routes, liveness escalation, and UI behavior.

## Verification

- `pnpm exec vitest run server/src/__tests__/heartbeat-issue-liveness-escalation.test.ts server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts server/src/__tests__/issue-recovery-actions.test.ts ui/src/components/BlockedReasonChip.test.tsx ui/src/components/IssueBlockedNotice.test.tsx ui/src/components/StatusIcon.test.tsx ui/src/lib/blockedInbox.test.ts` — 154 tests passed.
- `pnpm exec vitest run server/src/__tests__/issue-dependency-wakeups-routes.test.ts server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts server/src/__tests__/issue-recovery-actions.test.ts` — 95 tests passed after the security review fix.
- `pnpm --filter @paperclipai/server typecheck` — passed.
- `pnpm --filter @paperclipai/ui typecheck` — passed.
- `pnpm check:token-gates` — passed.
- `git diff --check public-gh/master...HEAD` — passed; 18 changed files and no guardrail-prohibited files.

## Risks

- Recovery disposition changes can wake or reclassify work incorrectly if terminal dependency state is interpreted too broadly; regression tests cover satisfied, cancelled, stale, and blockerless cases.
- Authorization changes could widen cross-assignee writes; the implementation keeps recovery edits on board-controlled routes and tests ordinary agent denial paths.
- The UI adds a new high-attention stopped state; token-gate and component tests cover styling, ordering, and accessible labels.
- No database schema changes or migrations.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex CLI using `gpt-5.6-sol`, high reasoning mode, with repository shell access, code editing, Git/GitHub tooling, and local test execution. Context-window size was not exposed by the runtime.
- Earlier commits also record assistance from Anthropic Claude Opus 4.8 where applicable.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
