### PR TITLE
fix: prevent project environment values from leaking through API responses

### DIFF
--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -652,6 +652,8 @@ export type {
   ProjectBudgetSummary,
   ProjectCodebase,
   ProjectCodebaseOrigin,
+  ProjectEnvBindingMetadata,
+  ProjectEnvMetadata,
   ProjectGoalRef,
   ProjectManagedByPlugin,
   ProjectWorkspace,

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -246,7 +246,17 @@ export type {
   DocumentTextRange,
   UpdateDocumentAnnotationThreadRequest,
 } from "./document-annotation.js";
-export type { Project, ProjectBudgetSummary, ProjectCodebase, ProjectCodebaseOrigin, ProjectGoalRef, ProjectManagedByPlugin, ProjectWorkspace } from "./project.js";
+export type {
+  Project,
+  ProjectBudgetSummary,
+  ProjectCodebase,
+  ProjectCodebaseOrigin,
+  ProjectEnvBindingMetadata,
+  ProjectEnvMetadata,
+  ProjectGoalRef,
+  ProjectManagedByPlugin,
+  ProjectWorkspace,
+} from "./project.js";
 export type {
   CompanySearchCountType,
   CompanySearchFilterOptionCounts,

--- a/packages/shared/src/types/project.ts
+++ b/packages/shared/src/types/project.ts
@@ -75,6 +75,31 @@ export interface ProjectManagedByPlugin {
   updatedAt: Date;
 }
 
+export type ProjectEnvBindingMetadata =
+  | { type: "plain"; configured: true }
+  | {
+      type: "secret_ref";
+      configured: true;
+      secretId?: string;
+      version?: number | "latest";
+      projectionClass?: string;
+      projectionAllowlistKey?: string | null;
+    }
+  | {
+      type: "user_secret_ref";
+      configured: true;
+      key?: string;
+      version?: number | "latest";
+      required?: boolean;
+      allowMissingOverride?: boolean;
+    }
+  | { type: "unknown"; configured: true };
+
+export interface ProjectEnvMetadata {
+  keys: string[];
+  bindings: Record<string, ProjectEnvBindingMetadata>;
+}
+
 export interface Project {
   id: string;
   companyId: string;
@@ -91,6 +116,8 @@ export interface Project {
   color: string | null;
   icon: string | null;
   env: AgentEnvConfig | null;
+  /** Value-free metadata for configured project env bindings. */
+  envMetadata?: ProjectEnvMetadata | null;
   pauseReason: PauseReason | null;
   pausedAt: Date | null;
   executionWorkspacePolicy: ProjectExecutionWorkspacePolicy | null;

--- a/packages/shared/src/validators/project.ts
+++ b/packages/shared/src/validators/project.ts
@@ -113,6 +113,17 @@ const projectFields = {
   archivedAt: z.string().datetime().optional().nullable(),
 };
 
+const projectEnvPatchSchema = z
+  .object({
+    set: envConfigSchema.optional(),
+    remove: z.array(z.string().min(1)).optional(),
+  })
+  .strict()
+  .refine(
+    (patch) => Object.keys(patch.set ?? {}).length > 0 || (patch.remove?.length ?? 0) > 0,
+    "Environment patch must set or remove at least one binding.",
+  );
+
 export const createProjectSchema = z.object({
   ...projectFields,
   workspace: createProjectWorkspaceSchema.optional(),
@@ -120,7 +131,16 @@ export const createProjectSchema = z.object({
 
 export type CreateProject = z.infer<typeof createProjectSchema>;
 
-export const updateProjectSchema = z.object(projectFields).partial();
+export const updateProjectSchema = z
+  .object({
+    ...projectFields,
+    envPatch: projectEnvPatchSchema.optional(),
+  })
+  .partial()
+  .refine((update) => update.env === undefined || update.envPatch === undefined, {
+    message: "Use either env or envPatch, not both.",
+    path: ["envPatch"],
+  });
 
 export type UpdateProject = z.infer<typeof updateProjectSchema>;
 

--- a/server/src/__tests__/issues-goal-context-routes.test.ts
+++ b/server/src/__tests__/issues-goal-context-routes.test.ts
@@ -410,6 +410,11 @@ describe.sequential("issue goal context routes", () => {
 
     expect(res.status).toBe(200);
     expect(res.body.project.env).toBeNull();
+    expect(res.body.project.envMetadata).toEqual({
+      keys: ["API_KEY"],
+      bindings: { API_KEY: { type: "plain", configured: true } },
+    });
+    expect(JSON.stringify(res.body)).not.toContain("should-not-ship");
     expect(res.body.project.workspaces[0]).not.toHaveProperty("metadata");
     expect(res.body.project.workspaces[0]).not.toHaveProperty("runtimeServices");
     expect(res.body.project.primaryWorkspace).not.toHaveProperty("metadata");
@@ -422,6 +427,29 @@ describe.sequential("issue goal context routes", () => {
       url: "http://localhost:3100",
     });
     expect(res.body.currentExecutionWorkspace.runtimeServices[0]).not.toHaveProperty("metadata");
+  });
+
+  it("keeps mentioned-project embeds value-free", async () => {
+    const mentionedProjectId = "66666666-6666-4666-8666-666666666666";
+    const currentProject = await mockProjectService.getById();
+    mockIssueService.findMentionedProjectIds.mockResolvedValue([mentionedProjectId]);
+    mockProjectService.listByIds.mockResolvedValue([{
+      ...currentProject,
+      id: mentionedProjectId,
+      name: "Mentioned project",
+      env: { MENTIONED_TOKEN: { type: "plain", value: "mentioned-value-must-not-serialize" } },
+    }]);
+
+    const res = await request(createApp()).get("/api/issues/11111111-1111-4111-8111-111111111111");
+
+    expect(res.status).toBe(200);
+    expect(res.body.mentionedProjects).toHaveLength(1);
+    expect(res.body.mentionedProjects[0].env).toBeNull();
+    expect(res.body.mentionedProjects[0].envMetadata).toEqual({
+      keys: ["MENTIONED_TOKEN"],
+      bindings: { MENTIONED_TOKEN: { type: "plain", configured: true } },
+    });
+    expect(JSON.stringify(res.body)).not.toContain("mentioned-value-must-not-serialize");
   });
 
   it("surfaces the project goal from GET /issues/:id/heartbeat-context", async () => {

--- a/server/src/__tests__/project-routes-env.test.ts
+++ b/server/src/__tests__/project-routes-env.test.ts
@@ -165,6 +165,61 @@ describe("project env routes", () => {
     mockSecretService.normalizeEnvBindingsForPersistence.mockImplementation(async (_companyId, env) => env);
   });
 
+  it("returns only value-free env metadata from project list and detail reads", async () => {
+    const project = buildProject({
+      env: {
+        LEGACY_PLAIN: "legacy-value-must-not-serialize",
+        PLAIN: { type: "plain", value: "plain-value-must-not-serialize" },
+        SECRET: {
+          type: "secret_ref",
+          secretId: "11111111-1111-4111-8111-111111111111",
+          version: 3,
+        },
+        USER_SECRET: {
+          type: "user_secret_ref",
+          key: "USER_TOKEN",
+          version: "latest",
+          required: true,
+        },
+      },
+    });
+    mockProjectService.list.mockResolvedValue([project]);
+    mockProjectService.getById.mockResolvedValue(project);
+
+    const app = await createApp();
+    const [listRes, detailRes] = await Promise.all([
+      request(app).get("/api/companies/company-1/projects"),
+      request(app).get("/api/projects/project-1"),
+    ]);
+
+    expect(listRes.status, JSON.stringify(listRes.body)).toBe(200);
+    expect(detailRes.status, JSON.stringify(detailRes.body)).toBe(200);
+    for (const responseProject of [listRes.body[0], detailRes.body]) {
+      expect(responseProject.env).toBeNull();
+      expect(responseProject.envMetadata).toEqual({
+        keys: ["LEGACY_PLAIN", "PLAIN", "SECRET", "USER_SECRET"],
+        bindings: {
+          LEGACY_PLAIN: { type: "plain", configured: true },
+          PLAIN: { type: "plain", configured: true },
+          SECRET: {
+            type: "secret_ref",
+            configured: true,
+            secretId: "11111111-1111-4111-8111-111111111111",
+            version: 3,
+          },
+          USER_SECRET: {
+            type: "user_secret_ref",
+            configured: true,
+            key: "USER_TOKEN",
+            version: "latest",
+            required: true,
+          },
+        },
+      });
+      expect(JSON.stringify(responseProject)).not.toContain("value-must-not-serialize");
+    }
+  });
+
   it("normalizes env bindings on create and logs only env keys", async () => {
     const normalizedEnv = {
       API_KEY: {
@@ -202,6 +257,13 @@ describe("project env routes", () => {
         }),
       }),
     );
+    expect(res.body.env).toBeNull();
+    expect(res.body.envMetadata.bindings.API_KEY).toEqual({
+      type: "secret_ref",
+      configured: true,
+      secretId: "11111111-1111-4111-8111-111111111111",
+      version: "latest",
+    });
   });
 
   it("normalizes env bindings on update and avoids logging raw values", async () => {
@@ -229,5 +291,22 @@ describe("project env routes", () => {
         },
       }),
     );
+    expect(res.body.env).toBeNull();
+    expect(res.body.envMetadata.bindings.PLAIN_KEY).toEqual({ type: "plain", configured: true });
+    expect(JSON.stringify(res.body)).not.toContain("top-secret");
+  });
+
+  it("does not echo env values from project delete responses", async () => {
+    mockProjectService.getById.mockResolvedValue(buildProject());
+    mockProjectService.remove.mockResolvedValue(buildProject({
+      env: { DELETED_SECRET: { type: "plain", value: "deleted-value-must-not-serialize" } },
+    }));
+
+    const res = await request(await createApp()).delete("/api/projects/project-1");
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(res.body.env).toBeNull();
+    expect(res.body.envMetadata.bindings.DELETED_SECRET).toEqual({ type: "plain", configured: true });
+    expect(JSON.stringify(res.body)).not.toContain("deleted-value-must-not-serialize");
   });
 });

--- a/server/src/__tests__/project-routes-env.test.ts
+++ b/server/src/__tests__/project-routes-env.test.ts
@@ -296,6 +296,54 @@ describe("project env routes", () => {
     expect(JSON.stringify(res.body)).not.toContain("top-secret");
   });
 
+  it("patches write-only env bindings without returning or replacing untouched values", async () => {
+    const existingEnv = {
+      KEEP: { type: "plain", value: "untouched-value" },
+      REMOVE: { type: "plain", value: "removed-value" },
+      REPLACE: { type: "plain", value: "old-value" },
+    };
+    const patchSet = {
+      REPLACE: {
+        type: "secret_ref",
+        secretId: "11111111-1111-4111-8111-111111111111",
+        version: "latest",
+      },
+    };
+    const expectedEnv = {
+      KEEP: existingEnv.KEEP,
+      REPLACE: patchSet.REPLACE,
+    };
+    mockProjectService.getById.mockResolvedValue(buildProject({ env: existingEnv }));
+    mockSecretService.normalizeEnvBindingsForPersistence.mockResolvedValue(patchSet);
+    mockProjectService.update.mockResolvedValue(buildProject({ env: expectedEnv }));
+
+    const res = await request(await createApp())
+      .patch("/api/projects/project-1")
+      .send({ envPatch: { set: patchSet, remove: ["REMOVE"] } });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(mockSecretService.normalizeEnvBindingsForPersistence).toHaveBeenCalledWith(
+      "company-1",
+      patchSet,
+      expect.objectContaining({ fieldPath: "envPatch.set" }),
+    );
+    expect(mockProjectService.update).toHaveBeenCalledWith("project-1", { env: expectedEnv });
+    expect(mockLogActivity).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        details: {
+          changedKeys: ["envPatch"],
+          envKeys: ["KEEP", "REPLACE"],
+        },
+      }),
+    );
+    expect(res.body.env).toBeNull();
+    expect(res.body.envMetadata.keys).toEqual(["KEEP", "REPLACE"]);
+    expect(JSON.stringify(res.body)).not.toContain("untouched-value");
+    expect(JSON.stringify(res.body)).not.toContain("removed-value");
+    expect(JSON.stringify(res.body)).not.toContain("old-value");
+  });
+
   it("does not echo env values from project delete responses", async () => {
     mockProjectService.getById.mockResolvedValue(buildProject());
     mockProjectService.remove.mockResolvedValue(buildProject({

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -144,6 +144,7 @@ import {
   findExistingIssueBlockersResolvedWake,
 } from "../services/issue-dependency-wakeups.js";
 import { assertEnvironmentSelectionForCompany } from "./environment-selection.js";
+import { projectEnvMetadata } from "./project-response.js";
 import { executionWorkspaceService as executionWorkspaceServiceDirect } from "../services/execution-workspaces.js";
 import { feedbackService } from "../services/feedback.js";
 import { instanceSettingsService } from "../services/instance-settings.js";
@@ -4415,6 +4416,7 @@ export function issueRoutes(
       color: project.color,
       icon: project.icon,
       env: null,
+      envMetadata: projectEnvMetadata(project.env),
       pauseReason: project.pauseReason,
       pausedAt: project.pausedAt,
       executionWorkspacePolicy: project.executionWorkspacePolicy,
@@ -5368,7 +5370,7 @@ export function issueRoutes(
       ...documentPayload,
       project: compactIssueProject(project),
       goal: goal ?? null,
-      mentionedProjects,
+      mentionedProjects: mentionedProjects.map(compactIssueProject),
       currentExecutionWorkspace: compactIssueExecutionWorkspace(currentExecutionWorkspace),
       workProducts,
       linkedCases,

--- a/server/src/routes/project-response.ts
+++ b/server/src/routes/project-response.ts
@@ -1,0 +1,74 @@
+import type { ProjectEnvBindingMetadata, ProjectEnvMetadata } from "@paperclipai/shared";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function readVersion(value: unknown): number | "latest" | undefined {
+  return value === "latest" || (typeof value === "number" && Number.isInteger(value) && value > 0)
+    ? value
+    : undefined;
+}
+
+function bindingMetadata(binding: unknown): ProjectEnvBindingMetadata {
+  if (typeof binding === "string") {
+    return { type: "plain", configured: true };
+  }
+  if (!isRecord(binding)) {
+    return { type: "unknown", configured: true };
+  }
+  if (binding.type === "plain") {
+    return { type: "plain", configured: true };
+  }
+  if (binding.type === "secret_ref") {
+    const version = readVersion(binding.version);
+    return {
+      type: "secret_ref",
+      configured: true,
+      ...(typeof binding.secretId === "string" ? { secretId: binding.secretId } : {}),
+      ...(version !== undefined ? { version } : {}),
+      ...(typeof binding.projectionClass === "string"
+        ? { projectionClass: binding.projectionClass }
+        : {}),
+      ...(typeof binding.projectionAllowlistKey === "string" || binding.projectionAllowlistKey === null
+        ? { projectionAllowlistKey: binding.projectionAllowlistKey }
+        : {}),
+    };
+  }
+  if (binding.type === "user_secret_ref") {
+    const version = readVersion(binding.version);
+    return {
+      type: "user_secret_ref",
+      configured: true,
+      ...(typeof binding.key === "string" ? { key: binding.key } : {}),
+      ...(version !== undefined ? { version } : {}),
+      ...(typeof binding.required === "boolean" ? { required: binding.required } : {}),
+      ...(typeof binding.allowMissingOverride === "boolean"
+        ? { allowMissingOverride: binding.allowMissingOverride }
+        : {}),
+    };
+  }
+  return { type: "unknown", configured: true };
+}
+
+export function projectEnvMetadata(env: unknown): ProjectEnvMetadata | null {
+  if (!isRecord(env)) return null;
+  const keys = Object.keys(env).sort();
+  return {
+    keys,
+    bindings: Object.fromEntries(keys.map((key) => [key, bindingMetadata(env[key])])),
+  };
+}
+
+/**
+ * Project environment values are write-only control-plane inputs. Read and
+ * mutation responses expose binding metadata, while runtime resolution remains
+ * inside the authorized heartbeat execution path.
+ */
+export function projectForApi<T extends { env?: unknown }>(project: T) {
+  return {
+    ...project,
+    env: null,
+    envMetadata: projectEnvMetadata(project.env),
+  };
+}

--- a/server/src/routes/projects.ts
+++ b/server/src/routes/projects.ts
@@ -247,11 +247,30 @@ export function projectRoutes(db: Db) {
     if (typeof body.archivedAt === "string") {
       body.archivedAt = new Date(body.archivedAt);
     }
+    if (body.envPatch !== undefined) {
+      const normalizedSet = await secretsSvc.normalizeEnvBindingsForPersistence(
+        existing.companyId,
+        body.envPatch.set ?? {},
+        {
+          strictMode: strictSecretsMode,
+          fieldPath: "envPatch.set",
+        },
+      );
+      const nextEnv = { ...(existing.env ?? {}) };
+      for (const key of body.envPatch.remove ?? []) {
+        delete nextEnv[key];
+      }
+      Object.assign(nextEnv, normalizedSet ?? {});
+      body.env = Object.keys(nextEnv).length > 0 ? nextEnv : null;
+      delete body.envPatch;
+    }
     if (body.env !== undefined) {
-      body.env = await secretsSvc.normalizeEnvBindingsForPersistence(existing.companyId, body.env, {
-        strictMode: strictSecretsMode,
-        fieldPath: "env",
-      });
+      if (req.body.envPatch === undefined) {
+        body.env = await secretsSvc.normalizeEnvBindingsForPersistence(existing.companyId, body.env, {
+          strictMode: strictSecretsMode,
+          fieldPath: "env",
+        });
+      }
     }
     const project = await svc.update(id, body);
     if (!project) {

--- a/server/src/routes/projects.ts
+++ b/server/src/routes/projects.ts
@@ -36,6 +36,7 @@ import { appendWithCap } from "../adapters/utils.js";
 import { assertEnvironmentSelectionForCompany } from "./environment-selection.js";
 import { environmentService } from "../services/environments.js";
 import { secretService } from "../services/secrets.js";
+import { projectForApi } from "./project-response.js";
 
 const WORKSPACE_CONTROL_OUTPUT_MAX_CHARS = 256 * 1024;
 const SHARED_WORKSPACE_STOP_AND_RESTART_ACTIONS = new Set(["stop", "restart"]);
@@ -130,7 +131,8 @@ export function projectRoutes(db: Db) {
     const companyId = req.params.companyId as string;
     assertCompanyAccess(req, companyId);
     const result = await svc.list(companyId);
-    res.json(await filterProjectsForActor(req, result));
+    const visibleProjects = await filterProjectsForActor(req, result);
+    res.json(visibleProjects.map(projectForApi));
   });
 
   router.get("/projects/:id", async (req, res) => {
@@ -142,7 +144,7 @@ export function projectRoutes(db: Db) {
     }
     assertCompanyAccess(req, project.companyId);
     if (!(await assertProjectReadAllowed(req, res, project))) return;
-    res.json(project);
+    res.json(projectForApi(project));
   });
 
   router.get("/projects/:id/external-object-summary", async (req, res) => {
@@ -222,7 +224,7 @@ export function projectRoutes(db: Db) {
     if (telemetryClient) {
       trackProjectCreated(telemetryClient);
     }
-    res.status(201).json(hydratedProject ?? project);
+    res.status(201).json(projectForApi(hydratedProject ?? project));
   });
 
   router.patch("/projects/:id", validate(updateProjectSchema), async (req, res) => {
@@ -282,7 +284,7 @@ export function projectRoutes(db: Db) {
       },
     });
 
-    res.json(project);
+    res.json(projectForApi(project));
   });
 
   router.get("/projects/:id/workspaces", async (req, res) => {
@@ -717,7 +719,7 @@ export function projectRoutes(db: Db) {
       entityId: project.id,
     });
 
-    res.json(project);
+    res.json(projectForApi(project));
   });
 
   return router;

--- a/ui/src/components/NewIssueDialog.test.tsx
+++ b/ui/src/components/NewIssueDialog.test.tsx
@@ -514,8 +514,17 @@ describe("NewIssueDialog", () => {
         description: null,
         archivedAt: null,
         color: "#445566",
-        env: {
-          PROJECT_TOKEN: { type: "user_secret_ref", key: "project_token", required: true },
+        env: null,
+        envMetadata: {
+          keys: ["PROJECT_TOKEN"],
+          bindings: {
+            PROJECT_TOKEN: {
+              type: "user_secret_ref",
+              configured: true,
+              key: "project_token",
+              required: true,
+            },
+          },
         },
       },
     ]);

--- a/ui/src/components/NewIssueDialog.tsx
+++ b/ui/src/components/NewIssueDialog.tsx
@@ -1132,10 +1132,16 @@ export function NewIssueDialog() {
       if (!shouldWarnAboutRunUserSecrets(status, selectedAssigneeAgentId)) return [];
       return uniqueRequiredUserSecretKeys([
         isRecord(currentAssignee?.adapterConfig) ? currentAssignee.adapterConfig.env as Record<string, unknown> : null,
-        currentProject?.env ?? null,
+        currentProject?.envMetadata?.bindings ?? currentProject?.env ?? null,
       ]);
     },
-    [currentAssignee?.adapterConfig, currentProject?.env, selectedAssigneeAgentId, status],
+    [
+      currentAssignee?.adapterConfig,
+      currentProject?.env,
+      currentProject?.envMetadata?.bindings,
+      selectedAssigneeAgentId,
+      status,
+    ],
   );
   const currentProjectExecutionWorkspacePolicy =
     experimentalSettings?.enableIsolatedWorkspaces === true

--- a/ui/src/components/ProjectProperties.env.test.tsx
+++ b/ui/src/components/ProjectProperties.env.test.tsx
@@ -1,0 +1,168 @@
+// @vitest-environment jsdom
+
+import type { Project } from "@paperclipai/shared";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+import { flushSync } from "react-dom";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { TooltipProvider } from "@/components/ui/tooltip";
+
+let ProjectProperties: typeof import("./ProjectProperties")["ProjectProperties"];
+
+beforeAll(async () => {
+  const sheetProto = window.CSSStyleSheet.prototype;
+  const original = sheetProto.insertRule;
+  sheetProto.insertRule = function patched(rule: string, index?: number) {
+    try {
+      return original.call(this, rule, index);
+    } catch {
+      return original.call(this, ".project-properties-test-noop{}", index);
+    }
+  };
+  ({ ProjectProperties } = await import("./ProjectProperties"));
+});
+
+const mockGoalsApi = vi.hoisted(() => ({ list: vi.fn() }));
+const mockInstanceSettingsApi = vi.hoisted(() => ({ getExperimental: vi.fn() }));
+const mockSecretsApi = vi.hoisted(() => ({
+  list: vi.fn(),
+  listUserSecretDefinitions: vi.fn(),
+  create: vi.fn(),
+}));
+
+vi.mock("@/lib/router", () => ({
+  Link: ({ children }: { children?: ReactNode }) => <span>{children}</span>,
+}));
+vi.mock("../context/CompanyContext", () => ({
+  useCompany: () => ({ selectedCompanyId: "company-1" }),
+}));
+vi.mock("../api/goals", () => ({ goalsApi: mockGoalsApi }));
+vi.mock("../api/instanceSettings", () => ({ instanceSettingsApi: mockInstanceSettingsApi }));
+vi.mock("../api/secrets", () => ({ secretsApi: mockSecretsApi }));
+vi.mock("./PathInstructionsModal", () => ({ ChoosePathButton: () => null }));
+vi.mock("./environment-variables-editor", () => ({
+  EnvironmentVariablesEditor: ({ onChange }: { onChange: (env: Record<string, unknown>) => void }) => (
+    <button
+      type="button"
+      onClick={() => onChange({ EXISTING: { type: "plain", value: "replacement" } })}
+    >
+      Save replacement
+    </button>
+  ),
+}));
+
+function project(): Project {
+  const now = new Date("2026-07-14T00:00:00Z");
+  return {
+    id: "project-1",
+    companyId: "company-1",
+    urlKey: "project-1",
+    goalId: null,
+    goalIds: [],
+    goals: [],
+    name: "Project",
+    description: null,
+    status: "in_progress",
+    leadAgentId: null,
+    targetDate: null,
+    color: null,
+    icon: null,
+    env: null,
+    envMetadata: {
+      keys: ["EXISTING", "REMOVE_ME"],
+      bindings: {
+        EXISTING: { type: "plain", configured: true },
+        REMOVE_ME: { type: "plain", configured: true },
+      },
+    },
+    pauseReason: null,
+    pausedAt: null,
+    executionWorkspacePolicy: null,
+    codebase: {
+      workspaceId: null,
+      repoUrl: null,
+      repoRef: null,
+      defaultRef: null,
+      repoName: null,
+      localFolder: null,
+      managedFolder: "/tmp/project",
+      effectiveLocalFolder: "/tmp/project",
+      origin: "managed_checkout",
+    },
+    workspaces: [],
+    primaryWorkspace: null,
+    archivedAt: null,
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+describe("ProjectProperties write-only environment controls", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    mockGoalsApi.list.mockResolvedValue([]);
+    mockInstanceSettingsApi.getExperimental.mockResolvedValue({ enableEnvironments: false });
+    mockSecretsApi.list.mockResolvedValue([]);
+    mockSecretsApi.listUserSecretDefinitions.mockResolvedValue([]);
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    flushSync(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  it("removes one binding without requiring or exposing the others", () => {
+    const onFieldUpdate = vi.fn();
+    flushSync(() => {
+      root.render(
+        <QueryClientProvider client={new QueryClient()}>
+          <TooltipProvider>
+            <ProjectProperties project={project()} onFieldUpdate={onFieldUpdate} />
+          </TooltipProvider>
+        </QueryClientProvider>,
+      );
+    });
+
+    const removeButton = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Remove environment binding REMOVE_ME"]',
+    );
+    expect(removeButton).not.toBeNull();
+    flushSync(() => removeButton?.click());
+
+    expect(onFieldUpdate).toHaveBeenCalledWith("env", { envPatch: { remove: ["REMOVE_ME"] } });
+    expect(container.textContent).not.toContain("replacement");
+  });
+
+  it("submits an isolated replacement while preserving untouched bindings", () => {
+    const onFieldUpdate = vi.fn();
+    flushSync(() => {
+      root.render(
+        <QueryClientProvider client={new QueryClient()}>
+          <TooltipProvider>
+            <ProjectProperties project={project()} onFieldUpdate={onFieldUpdate} />
+          </TooltipProvider>
+        </QueryClientProvider>,
+      );
+    });
+
+    const openButton = [...container.querySelectorAll("button")].find(
+      (button) => button.textContent?.includes("Add or replace binding"),
+    );
+    flushSync(() => openButton?.click());
+    const saveButton = [...container.querySelectorAll("button")].find(
+      (button) => button.textContent === "Save replacement",
+    );
+    flushSync(() => saveButton?.click());
+
+    expect(onFieldUpdate).toHaveBeenCalledWith("env", {
+      envPatch: { set: { EXISTING: { type: "plain", value: "replacement" } } },
+    });
+  });
+});

--- a/ui/src/components/ProjectProperties.tsx
+++ b/ui/src/components/ProjectProperties.tsx
@@ -240,6 +240,8 @@ export function ProjectProperties({ project, onUpdate, onFieldUpdate, getFieldSa
     onUpdate?.(data);
   };
   const fieldState = (field: ProjectConfigFieldKey): ProjectFieldSaveState => getFieldSaveState?.(field) ?? "idle";
+  const configuredEnvKeys = project.envMetadata?.keys ?? [];
+  const envValuesAreWriteOnly = project.env === null && configuredEnvKeys.length > 0;
 
   const { data: allGoals } = useQuery({
     queryKey: queryKeys.goals.list(selectedCompanyId!),
@@ -632,16 +634,32 @@ export function ProjectProperties({ project, onUpdate, onFieldUpdate, getFieldSa
           valueClassName="space-y-2"
         >
           <div className="space-y-2">
-            <EnvironmentVariablesEditor
-              value={project.env ?? {}}
-              secrets={availableSecrets}
-              userSecretDefinitions={userSecretDefinitions}
-              onCreateSecret={async (name, value) => {
-                const created = await createSecret.mutateAsync({ name, value });
-                return created;
-              }}
-              onChange={(env) => commitField("env", { env: env ?? null })}
-            />
+            {envValuesAreWriteOnly ? (
+              <div className="space-y-2 rounded-md border border-border/70 p-3">
+                <div className="flex flex-wrap gap-1.5">
+                  {configuredEnvKeys.map((key) => (
+                    <Badge key={key} variant="outline" className="font-mono text-(length:--text-micro)">
+                      {key}
+                    </Badge>
+                  ))}
+                </div>
+                <p className="text-(length:--text-micro) text-muted-foreground">
+                  Values are write-only and are never returned by the control plane. Rotate or replace bindings through
+                  the company secrets workflow.
+                </p>
+              </div>
+            ) : (
+              <EnvironmentVariablesEditor
+                value={project.env ?? {}}
+                secrets={availableSecrets}
+                userSecretDefinitions={userSecretDefinitions}
+                onCreateSecret={async (name, value) => {
+                  const created = await createSecret.mutateAsync({ name, value });
+                  return created;
+                }}
+                onChange={(env) => commitField("env", { env: env ?? null })}
+              />
+            )}
             <p className="text-(length:--text-micro) text-muted-foreground">
               Applied to all runs for tasks in this project. Project values override agent env on key conflicts.
             </p>

--- a/ui/src/components/ProjectProperties.tsx
+++ b/ui/src/components/ProjectProperties.tsx
@@ -231,6 +231,7 @@ export function ProjectProperties({ project, onUpdate, onFieldUpdate, getFieldSa
   const [workspaceCwd, setWorkspaceCwd] = useState("");
   const [workspaceRepoUrl, setWorkspaceRepoUrl] = useState("");
   const [workspaceError, setWorkspaceError] = useState<string | null>(null);
+  const [envPatchEditorOpen, setEnvPatchEditorOpen] = useState(false);
 
   const commitField = (field: ProjectConfigFieldKey, data: Record<string, unknown>) => {
     if (onFieldUpdate) {
@@ -635,18 +636,57 @@ export function ProjectProperties({ project, onUpdate, onFieldUpdate, getFieldSa
         >
           <div className="space-y-2">
             {envValuesAreWriteOnly ? (
-              <div className="space-y-2 rounded-md border border-border/70 p-3">
+              <div className="space-y-3 rounded-md border border-border/70 p-3">
                 <div className="flex flex-wrap gap-1.5">
                   {configuredEnvKeys.map((key) => (
-                    <Badge key={key} variant="outline" className="font-mono text-(length:--text-micro)">
-                      {key}
-                    </Badge>
+                    <span key={key} className="inline-flex items-center rounded-md border border-border">
+                      <Badge variant="outline" className="border-0 font-mono text-(length:--text-micro)">
+                        {key}
+                      </Badge>
+                      {(onUpdate || onFieldUpdate) && (
+                        <button
+                          type="button"
+                          className="mr-1 rounded p-0.5 text-muted-foreground hover:bg-accent hover:text-foreground"
+                          aria-label={`Remove environment binding ${key}`}
+                          onClick={() => commitField("env", { envPatch: { remove: [key] } })}
+                        >
+                          <X className="h-3 w-3" />
+                        </button>
+                      )}
+                    </span>
                   ))}
                 </div>
                 <p className="text-(length:--text-micro) text-muted-foreground">
-                  Values are write-only and are never returned by the control plane. Rotate or replace bindings through
-                  the company secrets workflow.
+                  Values are write-only and are never returned by the control plane. Existing bindings can be removed
+                  above or replaced below without exposing their current values.
                 </p>
+                {(onUpdate || onFieldUpdate) && (
+                  envPatchEditorOpen ? (
+                    <div className="space-y-2 border-t border-border/70 pt-3">
+                      <EnvironmentVariablesEditor
+                        value={{}}
+                        secrets={availableSecrets}
+                        userSecretDefinitions={userSecretDefinitions}
+                        onCreateSecret={async (name, value) => createSecret.mutateAsync({ name, value })}
+                        onChange={(env) => {
+                          if (env && Object.keys(env).length > 0) {
+                            commitField("env", { envPatch: { set: env } });
+                            setEnvPatchEditorOpen(false);
+                          }
+                        }}
+                        footerHint="Add a new binding or enter an existing key to replace it. Unchanged bindings are preserved."
+                      />
+                      <Button type="button" variant="ghost" size="xs" onClick={() => setEnvPatchEditorOpen(false)}>
+                        Cancel
+                      </Button>
+                    </div>
+                  ) : (
+                    <Button type="button" variant="outline" size="xs" onClick={() => setEnvPatchEditorOpen(true)}>
+                      <Plus className="mr-1 h-3 w-3" />
+                      Add or replace binding
+                    </Button>
+                  )
+                )}
               </div>
             ) : (
               <EnvironmentVariablesEditor


### PR DESCRIPTION
## Thinking Path

> - Paperclip manages AI agents and projects can configure environment bindings resolved into agent processes at execution time.
> - Project and issue API reads returned those stored bindings as part of project objects.
> - Plain bindings could therefore expose credential values to readers that only need project or issue context.
> - Runtime resolution still needs the stored bindings, but control-plane read and mutation responses do not.
> - This pull request centralizes a value-free API projection, applies it to project and issue responses, and keeps only binding metadata visible.
> - Authorized task execution continues while routine control-plane reads can no longer serialize project environment plaintext.

## Bug Report

### Pre-submission checklist

- [x] Searched open and closed issues; no duplicate found.
- [x] Reproduced from the current `master` lineage.
- [x] Confirmed the exposure originates in Paperclip core, not an adapter or provider.

### What happened?

Authenticated project detail/list and issue detail responses can include the full stored project environment configuration, including plaintext bindings. This affects core project serialization and is not adapter-specific.

### Expected behavior

Project environment values remain write-only and are resolved only in the authorized task runtime path. API consumers receive configured-key and binding-type metadata, and operators can replace or remove bindings without first reading their current values.

### Steps to reproduce

1. Configure a project with a distinctive plain environment value.
2. Request `GET /api/projects/:id` or `GET /api/issues/:id`.
3. Inspect the project object in the JSON response; the configured plaintext is present.

### Paperclip version or commit

`f712cedbc` (`2026.707.0+126`).

### Deployment mode

Reproduced in local dev and a self-hosted server built from source.

### Installation method

Built from source with pnpm.

### Agent adapter(s) involved

Not adapter-specific (core bug).

### Database mode

External PostgreSQL.

### Access context

Reproduced with authenticated board and local-trusted access.

### Node.js version and operating system

Node.js v22.17.0 on Linux.

### Privacy checklist

- [x] Reviewed this report for usernames, private paths, credentials, tokens, project names, and other sensitive data.

## What Changed

- Added a shared project env metadata contract and a centralized server API projection that always returns `env: null` plus value-free `envMetadata`.
- Applied the projection to project list/detail/create/update/delete responses and current/mentioned project embeds on issue reads.
- Added an environment patch input so one binding can be added, replaced, or removed without returning or overwriting untouched values.
- Updated project configuration UI to render configured key badges, per-key removal, isolated add/replace controls, and a write-only notice.
- Preserved required user-secret warnings in the new-task dialog by reading safe binding metadata.
- Added regression tests covering project responses, issue embeds, full and patch mutation responses, runtime injection, and UI metadata consumers.

## Verification

- `pnpm exec vitest run server/src/__tests__/project-routes-env.test.ts server/src/__tests__/issues-goal-context-routes.test.ts server/src/__tests__/heartbeat-project-env.test.ts ui/src/components/ProjectProperties.env.test.tsx ui/src/components/NewIssueDialog.test.tsx ui/src/pages/ProjectDetail.test.tsx` — 6 files, 54 tests passed.
- `pnpm typecheck` — passed across 31 workspace projects.
- `pnpm build` — passed across 31 workspace projects; only pre-existing UI bundler warnings were emitted.
- Behavioral probe against an isolated seeded server compared all 10 source plaintext binding values in memory against both project and issue JSON: `env` was null, all 10 metadata keys remained present, and exact-value residue was zero.
- Manual browser smoke confirmed the project Configuration surface renders 10 configured-key badges and the write-only notice without exposing values.

## Risks

- Project env values are intentionally no longer readable through control-plane APIs. Existing consumers must use `envMetadata` for display and warnings, and use the value-free patch input for replacements or removals.
- Runtime secret resolution and task-scoped injection are unchanged; the existing heartbeat env-overlay tests cover that boundary.
- Historical logs produced before deployment are not rewritten by this code change and require credential revocation and operational containment.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex using GPT-5 with high-reasoning mode, repository/tool access, command execution, and browser automation. The runtime did not expose a more specific build identifier or context-window size.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either linked an existing public issue or described the issue in-PR using the bug report template
- [x] I have not referenced internal or instance-local Paperclip issues or links
- [x] My branch name describes the change and contains no internal ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have considered and documented risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge
