### PR TITLE
fix(recovery): whitelist Memory Keeper × Nightly Memory Sync from stale-active-run detector

### DIFF
--- a/server/src/__tests__/stale-active-run-watchdog-whitelist.test.ts
+++ b/server/src/__tests__/stale-active-run-watchdog-whitelist.test.ts
@@ -1,0 +1,344 @@
+import { randomUUID } from "node:crypto";
+import { eq, sql } from "drizzle-orm";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import {
+  agents,
+  companies,
+  createDb,
+  heartbeatRuns,
+  issues,
+  routineRuns,
+  routines,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import {
+  ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS,
+  ACTIVE_RUN_OUTPUT_CRITICAL_THRESHOLD_MS,
+  heartbeatService,
+} from "../services/heartbeat.ts";
+import {
+  STALE_ACTIVE_RUN_WATCHDOG_WHITELIST,
+} from "../services/recovery/service.ts";
+
+vi.mock("../telemetry.ts", () => ({
+  getTelemetryClient: () => ({ track: vi.fn() }),
+}));
+
+vi.mock("@paperclipai/shared/telemetry", async () => {
+  const actual = await vi.importActual<typeof import("@paperclipai/shared/telemetry")>(
+    "@paperclipai/shared/telemetry",
+  );
+  return {
+    ...actual,
+    trackAgentFirstHeartbeat: vi.fn(),
+  };
+});
+
+vi.mock("../adapters/index.ts", async () => {
+  const actual = await vi.importActual<typeof import("../adapters/index.ts")>("../adapters/index.ts");
+  return {
+    ...actual,
+    getServerAdapter: vi.fn(() => ({
+      supportsLocalAgentJwt: false,
+      execute: vi.fn(async () => ({
+        exitCode: 0,
+        signal: null,
+        timedOut: false,
+        errorMessage: null,
+        summary: "Acknowledged.",
+        provider: "test",
+        model: "test-model",
+      })),
+    })),
+  };
+});
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping stale-active-run whitelist tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+describeEmbeddedPostgres("stale-active-run watchdog whitelist", () => {
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+  let db: ReturnType<typeof createDb>;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-stale-active-run-whitelist-");
+    db = createDb(tempDb.connectionString);
+  }, 30_000);
+
+  afterEach(async () => {
+    await db.execute(sql.raw(`TRUNCATE TABLE "companies" CASCADE`));
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  type SeedOpts = {
+    now: Date;
+    ageMs: number;
+    routineId?: string;
+    agentId?: string;
+  };
+
+  async function seedRunningRunWithRoutine(opts: SeedOpts) {
+    const companyId = randomUUID();
+    const managerId = randomUUID();
+    const agentId = opts.agentId ?? randomUUID();
+    const issueId = randomUUID();
+    const runId = randomUUID();
+    const routineId = opts.routineId ?? randomUUID();
+    const issuePrefix = `WL${companyId.replace(/-/g, "").slice(0, 4).toUpperCase()}`;
+    const startedAt = new Date(opts.now.getTime() - opts.ageMs);
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Whitelist Co",
+      issuePrefix,
+      defaultResponsibleUserId: "responsible-user",
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values([
+      {
+        id: managerId,
+        companyId,
+        name: "CTO",
+        role: "cto",
+        status: "idle",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+      {
+        id: agentId,
+        companyId,
+        name: "Memory Keeper",
+        role: "engineer",
+        status: "running",
+        reportsTo: managerId,
+        adapterType: "opencode_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+    ]);
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Nightly Memory Sync",
+      status: "in_progress",
+      priority: "medium",
+      assigneeAgentId: agentId,
+      issueNumber: 1,
+      identifier: `${issuePrefix}-1`,
+      originKind: "routine",
+      updatedAt: startedAt,
+      createdAt: startedAt,
+    });
+    await db.insert(routines).values({
+      id: routineId,
+      companyId,
+      title: "Nightly Memory Sync",
+      description: "Read and write Obsidian vault nightly.",
+      assigneeAgentId: agentId,
+      priority: "medium",
+      status: "active",
+      concurrencyPolicy: "coalesce_if_active",
+      catchUpPolicy: "skip_missed",
+    });
+    await db.insert(routineRuns).values({
+      id: randomUUID(),
+      companyId,
+      routineId,
+      source: "schedule",
+      status: "issue_created",
+      linkedIssueId: issueId,
+    });
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId,
+      agentId,
+      status: "running",
+      invocationSource: "assignment",
+      triggerDetail: "system",
+      startedAt,
+      processStartedAt: startedAt,
+      lastOutputAt: null,
+      lastOutputSeq: 0,
+      contextSnapshot: { issueId },
+      logBytes: 0,
+    });
+    await db.update(issues).set({ executionRunId: runId }).where(eq(issues.id, issueId));
+    return { companyId, agentId, issueId, runId, routineId };
+  }
+
+  async function seedRunningRunWithoutRoutine(opts: { now: Date; ageMs: number; agentId?: string }) {
+    const companyId = randomUUID();
+    const managerId = randomUUID();
+    const agentId = opts.agentId ?? randomUUID();
+    const issueId = randomUUID();
+    const runId = randomUUID();
+    const issuePrefix = `WL${companyId.replace(/-/g, "").slice(0, 4).toUpperCase()}`;
+    const startedAt = new Date(opts.now.getTime() - opts.ageMs);
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Whitelist Co",
+      issuePrefix,
+      defaultResponsibleUserId: "responsible-user",
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values([
+      {
+        id: managerId,
+        companyId,
+        name: "CTO",
+        role: "cto",
+        status: "idle",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+      {
+        id: agentId,
+        companyId,
+        name: "Ad-hoc Worker",
+        role: "engineer",
+        status: "running",
+        reportsTo: managerId,
+        adapterType: "opencode_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+    ]);
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Some manual task",
+      status: "in_progress",
+      priority: "medium",
+      assigneeAgentId: agentId,
+      issueNumber: 1,
+      identifier: `${issuePrefix}-1`,
+      originKind: "manual",
+      updatedAt: startedAt,
+      createdAt: startedAt,
+    });
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId,
+      agentId,
+      status: "running",
+      invocationSource: "assignment",
+      triggerDetail: "system",
+      startedAt,
+      processStartedAt: startedAt,
+      lastOutputAt: null,
+      lastOutputSeq: 0,
+      contextSnapshot: { issueId },
+      logBytes: 0,
+    });
+    await db.update(issues).set({ executionRunId: runId }).where(eq(issues.id, issueId));
+    return { companyId, agentId, issueId, runId };
+  }
+
+  const [WHITELIST_ENTRY] = STALE_ACTIVE_RUN_WATCHDOG_WHITELIST;
+
+  it("whitelist constant contains at least one entry keyed on stable UUIDs", () => {
+    expect(STALE_ACTIVE_RUN_WATCHDOG_WHITELIST.length).toBeGreaterThan(0);
+    expect(WHITELIST_ENTRY).toBeDefined();
+    expect(WHITELIST_ENTRY?.agentId).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+    );
+    expect(WHITELIST_ENTRY?.routineId).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+    );
+  });
+
+  it("does NOT fire on the whitelisted (agentId, routineId) pair at suspicious silence threshold", async () => {
+    if (!WHITELIST_ENTRY) throw new Error("No whitelist entry to test against");
+    const now = new Date("2026-07-15T01:00:00.000Z");
+    const { companyId } = await seedRunningRunWithRoutine({
+      now,
+      ageMs: ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS + 5_000,
+      agentId: WHITELIST_ENTRY.agentId,
+      routineId: WHITELIST_ENTRY.routineId,
+    });
+    const heartbeat = heartbeatService(db);
+    const result = await heartbeat.scanSilentActiveRuns({ now, companyId });
+    expect(result.created, "should not create evaluation for whitelisted pair").toBe(0);
+    expect(result.skipped, "should count whitelisted run as skipped").toBe(1);
+  });
+
+  it("does NOT fire on the whitelisted (agentId, routineId) pair at critical silence threshold", async () => {
+    if (!WHITELIST_ENTRY) throw new Error("No whitelist entry to test against");
+    const now = new Date("2026-07-15T01:00:00.000Z");
+    const { companyId } = await seedRunningRunWithRoutine({
+      now,
+      ageMs: ACTIVE_RUN_OUTPUT_CRITICAL_THRESHOLD_MS + 5_000,
+      agentId: WHITELIST_ENTRY.agentId,
+      routineId: WHITELIST_ENTRY.routineId,
+    });
+    const heartbeat = heartbeatService(db);
+    const result = await heartbeat.scanSilentActiveRuns({ now, companyId });
+    expect(result.created, "should not create evaluation at critical threshold for whitelisted pair").toBe(0);
+    expect(result.skipped).toBe(1);
+  });
+
+  it("still fires on the whitelisted agent running a DIFFERENT routine (not the whitelisted routine)", async () => {
+    if (!WHITELIST_ENTRY) throw new Error("No whitelist entry to test against");
+    const now = new Date("2026-07-15T01:00:00.000Z");
+    const differentRoutineId = randomUUID();
+    const { companyId } = await seedRunningRunWithRoutine({
+      now,
+      ageMs: ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS + 5_000,
+      agentId: WHITELIST_ENTRY.agentId,
+      routineId: differentRoutineId,
+    });
+    const heartbeat = heartbeatService(db);
+    const result = await heartbeat.scanSilentActiveRuns({ now, companyId });
+    expect(result.created, "different routine on whitelisted agent should still fire").toBe(1);
+    expect(result.skipped).toBe(0);
+  });
+
+  it("still fires on a DIFFERENT agent running the whitelisted routine ID", async () => {
+    if (!WHITELIST_ENTRY) throw new Error("No whitelist entry to test against");
+    const now = new Date("2026-07-15T01:00:00.000Z");
+    const differentAgentId = randomUUID();
+    const { companyId } = await seedRunningRunWithRoutine({
+      now,
+      ageMs: ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS + 5_000,
+      agentId: differentAgentId,
+      routineId: WHITELIST_ENTRY.routineId,
+    });
+    const heartbeat = heartbeatService(db);
+    const result = await heartbeat.scanSilentActiveRuns({ now, companyId });
+    expect(result.created, "different agent running whitelisted routine should still fire").toBe(1);
+    expect(result.skipped).toBe(0);
+  });
+
+  it("still fires on the whitelisted agent running a non-routine (ad-hoc) issue", async () => {
+    if (!WHITELIST_ENTRY) throw new Error("No whitelist entry to test against");
+    const now = new Date("2026-07-15T01:00:00.000Z");
+    const { companyId } = await seedRunningRunWithoutRoutine({
+      now,
+      ageMs: ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS + 5_000,
+      agentId: WHITELIST_ENTRY.agentId,
+    });
+    const heartbeat = heartbeatService(db);
+    const result = await heartbeat.scanSilentActiveRuns({ now, companyId });
+    expect(result.created, "non-routine run on whitelisted agent should still fire").toBe(1);
+    expect(result.skipped).toBe(0);
+  });
+});

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -23,6 +23,7 @@ import {
   issueRelations,
   issueThreadInteractions,
   issues,
+  routineRuns,
 } from "@paperclipai/db";
 import { parseObject, asBoolean, asNumber } from "../../adapters/utils.js";
 import { runningProcesses } from "../../adapters/index.js";
@@ -78,6 +79,24 @@ export const ACTIVE_RUN_OUTPUT_CONTINUE_REARM_MS = 30 * 60 * 1000;
 const ACTIVE_RUN_OUTPUT_EVIDENCE_TAIL_BYTES = 8 * 1024;
 const STRANDED_ISSUE_RECOVERY_ORIGIN_KIND = RECOVERY_ORIGIN_KINDS.strandedIssueRecovery;
 const STALE_ACTIVE_RUN_EVALUATION_ORIGIN_KIND = RECOVERY_ORIGIN_KINDS.staleActiveRunEvaluation;
+
+// Whitelist of (agentId, routineId) pairs that are exempt from the stale-active-run
+// suspicious/critical silence detector. Entries here are for legitimately quiet routines
+// where long I/O pauses are expected and do not indicate a stalled run.
+//
+// Key on stable UUIDs — not names — so a rename never silently drops an exemption.
+// To add a new pair: append `{ agentId: "...", routineId: "..." }` here.
+export const STALE_ACTIVE_RUN_WATCHDOG_WHITELIST: ReadonlyArray<{
+  agentId: string;
+  routineId: string;
+}> = [
+  // Memory Keeper × Nightly Memory Sync — legitimately quiet during Obsidian I/O.
+  // Source: OPE-278 / OPE-276.
+  {
+    agentId: "97bf7323-02d2-4311-a7cc-04d4fdccc047",
+    routineId: "c61abe92-50f9-4646-ac5d-5a48ec8fc229",
+  },
+];
 const DEFERRED_WAKE_CONTEXT_KEY = "_paperclipWakeContext";
 const EXECUTION_REVIEW_PARTICIPANT_RECOVERY_REASON = "execution_review_participant_recovery";
 const RESOLVED_DEPENDENCY_WAKE_BACKSTOP_CANDIDATE_LIMIT = 500;
@@ -2009,6 +2028,37 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     return { kind: "created" as const, evaluationIssueId: evaluation.id };
   }
 
+  async function isRunWhitelistedFromSilenceDetector(
+    run: Pick<typeof heartbeatRuns.$inferSelect, "id" | "agentId" | "contextSnapshot">,
+  ): Promise<{ whitelisted: boolean; routineId: string | null }> {
+    if (STALE_ACTIVE_RUN_WATCHDOG_WHITELIST.length === 0) return { whitelisted: false, routineId: null };
+    const matchingAgentEntries = STALE_ACTIVE_RUN_WATCHDOG_WHITELIST.filter(
+      (entry) => entry.agentId === run.agentId,
+    );
+    if (matchingAgentEntries.length === 0) return { whitelisted: false, routineId: null };
+
+    const context = parseObject(run.contextSnapshot);
+    const issueId = typeof context.issueId === "string" && context.issueId.length > 0
+      ? context.issueId
+      : typeof context.taskId === "string" && context.taskId.length > 0
+        ? context.taskId
+        : null;
+    if (!issueId) return { whitelisted: false, routineId: null };
+
+    const routineRunRow = await db
+      .select({ routineId: routineRuns.routineId })
+      .from(routineRuns)
+      .where(eq(routineRuns.linkedIssueId, issueId))
+      .limit(1)
+      .then((rows) => rows[0] ?? null);
+    if (!routineRunRow) return { whitelisted: false, routineId: null };
+
+    const whitelisted = matchingAgentEntries.some(
+      (entry) => entry.routineId === routineRunRow.routineId,
+    );
+    return { whitelisted, routineId: routineRunRow.routineId };
+  }
+
   async function scanSilentActiveRuns(opts?: { now?: Date; companyId?: string; issueCreatedAtGte?: Date | null }) {
     const now = opts?.now ?? new Date();
     const suspicionBefore = new Date(now.getTime() - ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS);
@@ -2060,6 +2110,15 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     for (const run of candidates) {
       if (await latestActiveOutputQuietUntilDecision(run.companyId, run.id, now)) {
         result.snoozed += 1;
+        continue;
+      }
+      const whitelistCheck = await isRunWhitelistedFromSilenceDetector(run);
+      if (whitelistCheck.whitelisted) {
+        logger.info(
+          { runId: run.id, agentId: run.agentId, routineId: whitelistCheck.routineId },
+          "stale-active-run watchdog: skipping whitelisted (agentId, routineId) pair",
+        );
+        result.skipped += 1;
         continue;
       }
       const outcome = await createOrUpdateStaleRunEvaluation({ run, now });


### PR DESCRIPTION
## Summary

Adds a configurable `STALE_ACTIVE_RUN_WATCHDOG_WHITELIST` that exempts known-quiet `(agentId, routineId)` pairs from the suspicious/critical silence thresholds in `scanSilentActiveRuns`.

Seeded with **Memory Keeper × Nightly Memory Sync**: this routine legitimately runs quiet during long Obsidian I/O, producing one false-positive review issue per night for 9 consecutive nights (OPE-265 through OPE-275).

## Design

- Keyed on stable `(agentId, routineId)` UUIDs — renaming the agent or routine does not silently drop the exemption
- Exact-pair matching only: same agent on a different routine, or different agent on same routine, still fires
- Info-level log on every skipped run for auditability
- No schema migration — purely runtime config
- Future additions: append one object to the exported constant

## Changes

- `server/src/services/recovery/service.ts`: add `routineRuns` import, `STALE_ACTIVE_RUN_WATCHDOG_WHITELIST` constant, `isRunWhitelistedFromSilenceDetector` helper, whitelist check in the `scanSilentActiveRuns` per-run loop
- `server/src/__tests__/stale-active-run-watchdog-whitelist.test.ts`: 6 new tests (all passing)

## Tests (6/6 passing)

- Constant shape validates as UUID pairs
- Whitelisted pair: no evaluation at suspicious threshold
- Whitelisted pair: no evaluation at critical threshold  
- Different routine on same agent: still fires ✓
- Same routine on different agent: still fires ✓
- Non-routine (ad-hoc) run on whitelisted agent: still fires ✓

Ref: OPE-278, OPE-276