### PR TITLE
fix(server): apply issue list query filters

### DIFF
--- a/server/src/__tests__/issue-list-assignee-filter-routes.test.ts
+++ b/server/src/__tests__/issue-list-assignee-filter-routes.test.ts
@@ -2,7 +2,7 @@ import { randomUUID } from "node:crypto";
 import express from "express";
 import request from "supertest";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
-import { activityLog, agents, companies, companyMemberships, createDb, heartbeatRuns, issues, principalPermissionGrants } from "@paperclipai/db";
+import { activityLog, agents, companies, companyMemberships, createDb, goals, heartbeatRuns, issues, principalPermissionGrants } from "@paperclipai/db";
 import {
   getEmbeddedPostgresTestSupport,
   startEmbeddedPostgresTestDatabase,
@@ -41,6 +41,7 @@ describeEmbeddedPostgres("issue list routes assigneeAgentId filter", () => {
     await db.delete(heartbeatRuns);
     await db.delete(activityLog);
     await db.delete(agents);
+    await db.delete(goals);
     await db.delete(principalPermissionGrants);
     await db.delete(companyMemberships);
     await db.delete(companies);
@@ -575,6 +576,137 @@ describeEmbeddedPostgres("issue list routes assigneeAgentId filter", () => {
     expect(res.body).toMatchObject({
       error: "assigneeAgentId must be a UUID or 'null'",
     });
+  });
+
+  /**
+   * Regression test: the route accepted `priority`, `goalId`, and
+   * `createdByAgentId` query params (Express parsed them into `req.query`
+   * fine) but never forwarded them into the `svc.list()` filters object, so
+   * every value — including one matching no row — fell through to the
+   * unfiltered default list. Exercises the full HTTP route (not just the
+   * service function `issues-service.test.ts` covers) to prove the
+   * route→service wiring itself is fixed, not just the service in isolation.
+   */
+  it("filters by priority, goalId, and createdByAgentId query params", async () => {
+    const companyId = randomUUID();
+    const creatorAgentId = randomUUID();
+    const otherAgentId = randomUUID();
+    const goalId = randomUUID();
+    const matchingIssueId = randomUUID();
+    const otherPriorityIssueId = randomUUID();
+    const otherGoalIssueId = randomUUID();
+    const otherCreatorIssueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: uniqueIssuePrefix(),
+      requireBoardApprovalForNewAgents: false,
+    });
+    await seedCloudTenantMember(companyId);
+    await db.insert(goals).values({
+      id: goalId,
+      companyId,
+      title: "Target goal",
+      level: "task",
+      status: "active",
+    });
+    await db.insert(agents).values([
+      {
+        id: creatorAgentId,
+        companyId,
+        name: "Creator",
+        role: "engineer",
+        status: "active",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+      {
+        id: otherAgentId,
+        companyId,
+        name: "Other",
+        role: "engineer",
+        status: "active",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+    ]);
+    await db.insert(issues).values([
+      {
+        id: matchingIssueId,
+        companyId,
+        goalId,
+        title: "Matches all three filters",
+        status: "todo",
+        priority: "low",
+        createdByAgentId: creatorAgentId,
+      },
+      {
+        id: otherPriorityIssueId,
+        companyId,
+        goalId,
+        title: "Wrong priority",
+        status: "todo",
+        priority: "critical",
+        createdByAgentId: creatorAgentId,
+      },
+      {
+        id: otherGoalIssueId,
+        companyId,
+        title: "No goal",
+        status: "todo",
+        priority: "low",
+        createdByAgentId: creatorAgentId,
+      },
+      {
+        id: otherCreatorIssueId,
+        companyId,
+        goalId,
+        title: "Wrong creator",
+        status: "todo",
+        priority: "low",
+        createdByAgentId: otherAgentId,
+      },
+    ]);
+
+    const app = createApp(companyId);
+
+    const byPriority = await request(app)
+      .get(`/api/companies/${companyId}/issues`)
+      .query({ status: "todo", priority: "low", limit: "20" });
+    expect(byPriority.status, JSON.stringify(byPriority.body)).toBe(200);
+    expect(byPriority.body.map((issue: { id: string }) => issue.id).sort()).toEqual(
+      [matchingIssueId, otherGoalIssueId, otherCreatorIssueId].sort(),
+    );
+
+    const byGoal = await request(app)
+      .get(`/api/companies/${companyId}/issues`)
+      .query({ status: "todo", goalId, limit: "20" });
+    expect(byGoal.status, JSON.stringify(byGoal.body)).toBe(200);
+    expect(byGoal.body.map((issue: { id: string }) => issue.id).sort()).toEqual(
+      [matchingIssueId, otherPriorityIssueId, otherCreatorIssueId].sort(),
+    );
+
+    const byCreator = await request(app)
+      .get(`/api/companies/${companyId}/issues`)
+      .query({ status: "todo", createdByAgentId: creatorAgentId, limit: "20" });
+    expect(byCreator.status, JSON.stringify(byCreator.body)).toBe(200);
+    expect(byCreator.body.map((issue: { id: string }) => issue.id).sort()).toEqual(
+      [matchingIssueId, otherPriorityIssueId, otherGoalIssueId].sort(),
+    );
+
+    // Bogus goalId (matching no real row) must return zero rows, not the
+    // unfiltered default list — the exact contrast the original bug
+    // report used to distinguish "ignored" from "working".
+    const bogusGoal = await request(app)
+      .get(`/api/companies/${companyId}/issues`)
+      .query({ status: "todo", goalId: "00000000-0000-0000-0000-000000000000", limit: "20" });
+    expect(bogusGoal.status, JSON.stringify(bogusGoal.body)).toBe(200);
+    expect(bogusGoal.body).toEqual([]);
   });
 
   it("returns opt-in live descendant counts for offscreen live descendants only", async () => {

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -837,6 +837,142 @@ describeEmbeddedPostgres("issueService.list participantAgentId", () => {
     ).rejects.toThrow(/assigneeAgentId/i);
   });
 
+  /**
+   * Regression test: `priority`, `goalId`, and `createdByAgentId`
+   * were accepted as query params by the route handler but never threaded
+   * into `IssueFilters` or the `WHERE` clause, so they silently no-opped —
+   * any value (including a bogus one matching no row) returned the same
+   * unfiltered, default-sorted list. Verifies all three now genuinely narrow
+   * results, using the same bogus-value contrast the original bug report used.
+   */
+  it("filters by priority, goalId, and createdByAgentId", async () => {
+    const companyId = randomUUID();
+    const creatorAgentId = randomUUID();
+    const otherAgentId = randomUUID();
+    const goalId = randomUUID();
+    const otherGoalId = randomUUID();
+    const matchingIssueId = randomUUID();
+    const otherPriorityIssueId = randomUUID();
+    const otherGoalIssueId = randomUUID();
+    const otherCreatorIssueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values([
+      {
+        id: creatorAgentId,
+        companyId,
+        name: "Creator",
+        role: "engineer",
+        status: "active",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+      {
+        id: otherAgentId,
+        companyId,
+        name: "Other",
+        role: "engineer",
+        status: "active",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+    ]);
+
+    await db.insert(goals).values([
+      { id: goalId, companyId, title: "Target goal", level: "task", status: "active" },
+      { id: otherGoalId, companyId, title: "Other goal", level: "task", status: "active" },
+    ]);
+
+    await db.insert(issues).values([
+      {
+        id: matchingIssueId,
+        companyId,
+        goalId,
+        title: "Matches all three filters",
+        status: "todo",
+        priority: "low",
+        createdByAgentId: creatorAgentId,
+      },
+      {
+        id: otherPriorityIssueId,
+        companyId,
+        goalId,
+        title: "Wrong priority",
+        status: "todo",
+        priority: "critical",
+        createdByAgentId: creatorAgentId,
+      },
+      {
+        id: otherGoalIssueId,
+        companyId,
+        goalId: otherGoalId,
+        title: "Wrong goal",
+        status: "todo",
+        priority: "low",
+        createdByAgentId: creatorAgentId,
+      },
+      {
+        id: otherCreatorIssueId,
+        companyId,
+        goalId,
+        title: "Wrong creator",
+        status: "todo",
+        priority: "low",
+        createdByAgentId: otherAgentId,
+      },
+    ]);
+
+    // priority: a real, non-default-sort-order value must narrow to only that priority.
+    const byPriority = await svc.list(companyId, { priority: "low" });
+    expect(byPriority.map((issue) => issue.id).sort()).toEqual(
+      [matchingIssueId, otherGoalIssueId, otherCreatorIssueId].sort(),
+    );
+    expect(byPriority.map((issue) => issue.id)).not.toContain(otherPriorityIssueId);
+
+    // priority: comma-separated and repeated-key shapes both work, matching `status`'s contract.
+    const byPriorityCsv = await svc.list(companyId, { priority: "low,critical" });
+    expect(byPriorityCsv.map((issue) => issue.id).sort()).toEqual(
+      [matchingIssueId, otherPriorityIssueId, otherGoalIssueId, otherCreatorIssueId].sort(),
+    );
+
+    // goalId: a real value must narrow to only that goal.
+    const byGoal = await svc.list(companyId, { goalId });
+    expect(byGoal.map((issue) => issue.id).sort()).toEqual(
+      [matchingIssueId, otherPriorityIssueId, otherCreatorIssueId].sort(),
+    );
+    expect(byGoal.map((issue) => issue.id)).not.toContain(otherGoalIssueId);
+
+    // createdByAgentId: a real value must narrow to only that creator.
+    const byCreator = await svc.list(companyId, { createdByAgentId: creatorAgentId });
+    expect(byCreator.map((issue) => issue.id).sort()).toEqual(
+      [matchingIssueId, otherPriorityIssueId, otherGoalIssueId].sort(),
+    );
+    expect(byCreator.map((issue) => issue.id)).not.toContain(otherCreatorIssueId);
+
+    // Combined, all three narrow to exactly the one issue matching every filter.
+    const combined = await svc.list(companyId, { priority: "low", goalId, createdByAgentId: creatorAgentId });
+    expect(combined.map((issue) => issue.id)).toEqual([matchingIssueId]);
+
+    // Bogus values (matching no real row) must return zero rows, not the
+    // unfiltered default list — this is the exact contrast the original
+    // bug report used to distinguish "ignored" from "working".
+    const bogusId = "00000000-0000-0000-0000-000000000000";
+    await expect(svc.list(companyId, { goalId: bogusId })).resolves.toEqual([]);
+    await expect(svc.list(companyId, { createdByAgentId: bogusId })).resolves.toEqual([]);
+    const byBogusPriority = await svc.list(companyId, { priority: "bogus-priority-value" });
+    expect(byBogusPriority).toEqual([]);
+  });
+
   it("counts only unassigned issues for assigneeAgentId='null'", async () => {
     const companyId = randomUUID();
     const assigneeAgentId = randomUUID();

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -4705,6 +4705,9 @@ export function issueRoutes(
       originKind: req.query.originKind as string | undefined,
       originKindPrefix: req.query.originKindPrefix as string | undefined,
       originId: req.query.originId as string | undefined,
+      goalId: req.query.goalId as string | undefined,
+      createdByAgentId: req.query.createdByAgentId as string | undefined,
+      priority: req.query.priority as string | string[] | undefined,
       includeRoutineExecutions:
         req.query.includeRoutineExecutions === "true" || req.query.includeRoutineExecutions === "1",
       excludeRoutineExecutions:
@@ -4897,6 +4900,9 @@ export function issueRoutes(
       originKind: req.query.originKind as string | undefined,
       originKindPrefix: req.query.originKindPrefix as string | undefined,
       originId: req.query.originId as string | undefined,
+      goalId: req.query.goalId as string | undefined,
+      createdByAgentId: req.query.createdByAgentId as string | undefined,
+      priority: req.query.priority as string | string[] | undefined,
       includeRoutineExecutions:
         req.query.includeRoutineExecutions === "true" || req.query.includeRoutineExecutions === "1",
       excludeRoutineExecutions:

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -472,6 +472,18 @@ export interface IssueFilters {
   originKind?: string;
   originKindPrefix?: string;
   originId?: string;
+  /**
+   * Filter by issue priority (`critical`/`high`/`medium`/`low`). Accepts the
+   * same shapes as `status` (single value, comma-separated, or repeated query
+   * key) via the same `parseStatusFilter` normalizer — unrecognized values
+   * simply match zero rows rather than erroring, matching `status`'s existing
+   * looseness.
+   */
+  priority?: string | readonly string[];
+  /** Filter by the goal an issue belongs to (exact UUID match). */
+  goalId?: string;
+  /** Filter by the agent that originally created the issue (exact UUID match). */
+  createdByAgentId?: string;
   includeRoutineExecutions?: boolean;
   excludeRoutineExecutions?: boolean;
   includePluginOperations?: boolean;
@@ -3450,6 +3462,11 @@ async function blockedInboxIssueConditions(
   if (filters?.originKind) conditions.push(eq(issues.originKind, filters.originKind));
   if (filters?.originKindPrefix) conditions.push(like(issues.originKind, `${filters.originKindPrefix}%`));
   if (filters?.originId) conditions.push(eq(issues.originId, filters.originId));
+  if (filters?.goalId) conditions.push(eq(issues.goalId, filters.goalId));
+  if (filters?.createdByAgentId) conditions.push(eq(issues.createdByAgentId, filters.createdByAgentId));
+  const inboxPriorities = parseStatusFilter(filters?.priority);
+  if (inboxPriorities.length === 1) conditions.push(eq(issues.priority, inboxPriorities[0]!));
+  else if (inboxPriorities.length > 1) conditions.push(inArray(issues.priority, inboxPriorities));
   if (filters?.hasPlanDocument !== undefined) {
     conditions.push(hasPlanDocumentCondition(companyId, filters.hasPlanDocument));
   }
@@ -4702,6 +4719,14 @@ export function issueService(db: Db) {
       if (filters?.originKind) conditions.push(eq(issues.originKind, filters.originKind));
       if (filters?.originKindPrefix) conditions.push(like(issues.originKind, `${filters.originKindPrefix}%`));
       if (filters?.originId) conditions.push(eq(issues.originId, filters.originId));
+      if (filters?.goalId) conditions.push(eq(issues.goalId, filters.goalId));
+      if (filters?.createdByAgentId) conditions.push(eq(issues.createdByAgentId, filters.createdByAgentId));
+      const priorities = parseStatusFilter(filters?.priority);
+      if (priorities.length === 1) {
+        conditions.push(eq(issues.priority, priorities[0]!));
+      } else if (priorities.length > 1) {
+        conditions.push(inArray(issues.priority, priorities));
+      }
       if (filters?.hasPlanDocument !== undefined) {
         conditions.push(hasPlanDocumentCondition(companyId, filters.hasPlanDocument));
       }
@@ -4875,6 +4900,11 @@ export function issueService(db: Db) {
       if (filters?.originKind) conditions.push(eq(issues.originKind, filters.originKind));
       if (filters?.originKindPrefix) conditions.push(like(issues.originKind, `${filters.originKindPrefix}%`));
       if (filters?.originId) conditions.push(eq(issues.originId, filters.originId));
+      if (filters?.goalId) conditions.push(eq(issues.goalId, filters.goalId));
+      if (filters?.createdByAgentId) conditions.push(eq(issues.createdByAgentId, filters.createdByAgentId));
+      const countPriorities = parseStatusFilter(filters?.priority);
+      if (countPriorities.length === 1) conditions.push(eq(issues.priority, countPriorities[0]!));
+      else if (countPriorities.length > 1) conditions.push(inArray(issues.priority, countPriorities));
       if (filters?.hasPlanDocument !== undefined) {
         conditions.push(hasPlanDocumentCondition(companyId, filters.hasPlanDocument));
       }


### PR DESCRIPTION
## Thinking Path

> - Paperclip exposes company issue-list endpoints used by boards, agents, and SDK consumers.
> - Those routes accept query parameters and pass a normalized filter object into the issue service.
> - priority, goalId, and createdByAgentId were accepted by Express but omitted from that handoff and from service conditions.
> - Requests using those parameters therefore returned the same records as an unfiltered request.
> - This pull request wires all three filters through list and count routes and applies them consistently to list, count, and blocked-inbox projections.
> - The benefit is reliable server-side filtering with regression coverage at both route and service boundaries.

## Linked Issues or Issue Description

No public issue exists.

Related prior work: #7414 and #5855 are older, currently conflicting priority-only variants. This rebased change covers priority together with the two other silently ignored query parameters and keeps list/count projections aligned.

**Bug:** GET issue-list requests that include priority, goalId, or createdByAgentId silently ignore those values.

**Expected:** Each parameter narrows results, combinations compose, and a valid UUID that matches no record returns an empty list.

**Actual:** Matching and non-matching values return the same default list.

## What Changed

- Forwarded priority, goalId, and createdByAgentId from both issue-list route projections.
- Added the filters to the issue service list, count, and blocked-inbox conditions.
- Added service-level coverage for individual, combined, comma-separated, and no-match filters.
- Added full HTTP route coverage proving each query parameter reaches the service.

## Verification

- pnpm --filter @paperclipai/server typecheck — passed.
- Targeted route/service suites passed on the original Linux branch before rebasing.
- pnpm exec vitest run server/src/__tests__/issue-list-assignee-filter-routes.test.ts server/src/__tests__/issues-service.test.ts — 7 passed locally; embedded-Postgres cases were skipped because the local macOS helper is unsupported. CI will execute them on Linux.

## Risks

- Low risk and additive. Requests without these parameters retain existing behavior.
- Priority values remain intentionally permissive like status values: unknown values match no rows instead of producing a validation error.

## Model Used

- Anthropic Claude Sonnet 5 produced the implementation and regression tests with tool use and code execution.
- OpenAI GPT-5.6 Sol (gpt-5.6-sol) reviewed, sanitized, rebased, and validated the upstream contribution with tool use and code execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either linked existing issues or described the issue in-PR following the relevant issue template
- [x] I have not referenced internal or instance-local issues or links
- [x] My branch name describes the change and contains no internal identifiers
- [x] I have run tests locally and documented the platform-specific skip
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation where applicable
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge