### PR TITLE
test: cover company deletion routine cleanup

### DIFF
--- a/server/src/__tests__/companies-service.test.ts
+++ b/server/src/__tests__/companies-service.test.ts
@@ -125,6 +125,25 @@ describeEmbeddedPostgres("companyService", () => {
     expect(afterReconcileRows.filter((row) => readBuiltInAgentMarker(row.metadata)?.key === "reflection-coach")).toHaveLength(1);
   });
 
+  it("deletes built-in routines before their assigned agents during company removal", async () => {
+    const created = await companyService(db).create({
+      name: "Delete Routine Company",
+    });
+
+    const [routineBeforeDelete] = await db
+      .select({ id: routines.id, assigneeAgentId: routines.assigneeAgentId })
+      .from(routines)
+      .where(eq(routines.companyId, created.id));
+    expect(routineBeforeDelete?.assigneeAgentId).toBeTruthy();
+
+    const removed = await companyService(db).remove(created.id);
+
+    expect(removed?.id).toBe(created.id);
+    await expect(db.select().from(companies).where(eq(companies.id, created.id))).resolves.toHaveLength(0);
+    await expect(db.select().from(routines).where(eq(routines.companyId, created.id))).resolves.toHaveLength(0);
+    await expect(db.select().from(agents).where(eq(agents.companyId, created.id))).resolves.toHaveLength(0);
+  });
+
   it("archives companies by pausing runnable agents and cancelling active runs", async () => {
     const companyId = randomUUID();
     const runningAgentId = randomUUID();


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Companies are isolated environments, each with built-in agents and routines; routines are assigned to agents via a foreign-key (`routines.assigneeAgentId → agents.id`)
> - When a company is deleted, all its resources must be removed in dependency order to avoid FK constraint violations — routines must be deleted before the agents they reference
> - During e2e teardown a deletion failure was observed caused by this FK constraint; no automated test existed to guard the cleanup order
> - This pull request adds a regression test that creates a company (triggering built-in routine + agent creation), deletes it, and asserts that all three resource tables are empty afterward
> - The benefit is that any future regression in deletion ordering will be caught by the test suite rather than discovered in production teardown

## Linked Issues or Issue Description

No public GitHub issue tracks this exact gap. Bug description inline:

**Bug:** Company deletion fails with a FK constraint violation when the company owns at least one routine assigned to a built-in agent.

- **What happened:** Deleting a company via the service layer triggered a foreign-key violation because `routines.assigneeAgentId` references `agents.id` with `ON DELETE NO ACTION`. If `agents` rows are deleted before (or in the same statement batch as) their referenced `routines`, the DB rejects the operation.
- **Expected behaviour:** Company deletion completes cleanly, removing all routines before the agents they reference.
- **Related PR:** Refs #1660 (fixes deletion order in `companyService.remove`; this PR adds regression coverage for that path)
- **Also related:** Refs #9572 (e2e teardown fix that surfaced this gap)

## What Changed

- Added one test case to `server/src/__tests__/companies-service.test.ts`:
  - Creates a fresh company (automatically seeds built-in routine + assigned agent)
  - Asserts that the routine has a non-null `assigneeAgentId` (proves the FK dependency exists before deletion)
  - Calls `companyService(db).remove()` and asserts success
  - Asserts the `companies`, `routines`, and `agents` tables are all empty for that company ID after removal

## Verification

```sh
pnpm exec vitest run server/src/__tests__/companies-service.test.ts \
  -t "deletes built-in routines before their assigned agents during company removal"
```

```sh
pnpm --filter @paperclipai/server typecheck
```

Both pass locally.

## Risks

Low risk — test-only change. No production code is modified; no schema changes; no new dependencies.

## Model Used

- **Provider:** Anthropic
- **Model:** Claude Sonnet 4.6 (`claude-sonnet-4-6`)
- **Context window:** 200K tokens
- **Capabilities used:** Tool use, code execution, extended reasoning

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
