### PR TITLE
fix(ui): let human reviewers resolve execution stages

### DIFF
--- a/server/src/__tests__/issue-comment-reopen-routes.test.ts
+++ b/server/src/__tests__/issue-comment-reopen-routes.test.ts
@@ -1907,6 +1907,96 @@ describe.sequential("issue comment reopen routes", () => {
     );
   });
 
+  it("advances a board-user review stage from an approved comment", async () => {
+    const approvalAgentId = "33333333-3333-4333-8333-333333333333";
+    const policy = await normalizePolicy({
+      stages: [
+        {
+          id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+          type: "review",
+          participants: [{ type: "user", userId: "local-board" }],
+        },
+        {
+          id: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+          type: "approval",
+          participants: [{ type: "agent", agentId: approvalAgentId }],
+        },
+      ],
+    })!;
+    const issue = {
+      ...makeIssue("todo"),
+      status: "in_review",
+      assigneeAgentId: null,
+      assigneeUserId: "local-board",
+      executionPolicy: policy,
+      executionState: {
+        status: "pending",
+        currentStageId: policy.stages[0].id,
+        currentStageIndex: 0,
+        currentStageType: "review",
+        currentParticipant: { type: "user", userId: "local-board" },
+        returnAssignee: { type: "agent", agentId: "22222222-2222-4222-8222-222222222222" },
+        completedStageIds: [],
+        lastDecisionId: null,
+        lastDecisionOutcome: null,
+      },
+    };
+    const reviewBody = "## Review: APPROVED\n\nReady for approval.";
+    mockIssueService.getById.mockResolvedValue(issue);
+    mockIssueService.addComment.mockResolvedValue({
+      id: "comment-board-review-1",
+      issueId: issue.id,
+      companyId: issue.companyId,
+      body: reviewBody,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      authorAgentId: null,
+      authorUserId: "local-board",
+    });
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>, tx?: unknown) => ({
+      ...issue,
+      ...patch,
+      executionState: patch.executionState,
+      updatedAt: new Date(),
+      _tx: tx,
+    }));
+
+    const res = await request(await installActor(createApp()))
+      .post("/api/issues/11111111-1111-4111-8111-111111111111/comments")
+      .send({ body: reviewBody });
+
+    expect(res.status).toBe(201);
+    expect(mockIssueService.update).toHaveBeenCalledWith(
+      issue.id,
+      expect.objectContaining({
+        status: "in_review",
+        assigneeAgentId: approvalAgentId,
+        assigneeUserId: null,
+        actorAgentId: null,
+        actorUserId: "local-board",
+        executionState: expect.objectContaining({
+          status: "pending",
+          currentStageIndex: 1,
+          currentStageType: "approval",
+          currentParticipant: expect.objectContaining({ type: "agent", agentId: approvalAgentId }),
+          completedStageIds: [policy.stages[0].id],
+          lastDecisionOutcome: "approved",
+        }),
+      }),
+      mockTx,
+    );
+    expect(mockTxInsertValues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        issueId: issue.id,
+        stageId: policy.stages[0].id,
+        actorAgentId: null,
+        actorUserId: "local-board",
+        outcome: "approved",
+        body: reviewBody,
+      }),
+    );
+  });
+
   it("auto-approves a reviewer comment with structured review metadata", async () => {
     const reviewerAgentId = "33333333-3333-4333-8333-333333333333";
     const policy = await normalizePolicy({

--- a/ui/src/components/ExecutionPolicyGate.test.tsx
+++ b/ui/src/components/ExecutionPolicyGate.test.tsx
@@ -1,0 +1,121 @@
+// @vitest-environment jsdom
+
+import { act, type ReactElement } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ExecutionPolicyGate } from "./ExecutionPolicyGate";
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let root: ReturnType<typeof createRoot> | null = null;
+let container: HTMLDivElement | null = null;
+
+afterEach(() => {
+  if (root) act(() => root?.unmount());
+  root = null;
+  container?.remove();
+  container = null;
+});
+
+function render(element: ReactElement) {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => root?.render(element));
+  return container;
+}
+
+function setTextareaValue(textarea: HTMLTextAreaElement, value: string) {
+  const valueSetter = Object.getOwnPropertyDescriptor(
+    window.HTMLTextAreaElement.prototype,
+    "value",
+  )?.set;
+  const previous = textarea.value;
+  valueSetter?.call(textarea, value);
+  (textarea as HTMLTextAreaElement & { _valueTracker?: { setValue: (value: string) => void } })
+    ._valueTracker?.setValue(previous);
+  textarea.dispatchEvent(new Event("input", { bubbles: true }));
+}
+
+async function flushPromises() {
+  await act(async () => Promise.resolve());
+}
+
+describe("ExecutionPolicyGate", () => {
+  it("renders an explicit note and both decisions for the active viewer", () => {
+    const node = render(
+      <ExecutionPolicyGate
+        stageLabel="Review"
+        onSubmitDecision={vi.fn()}
+      />,
+    );
+
+    expect(node.textContent).toContain("Review pending with you");
+    expect(node.querySelector("textarea")?.getAttribute("aria-required")).toBe("true");
+    expect(node.querySelector("[data-testid=execution-gate-approve]")).not.toBeNull();
+    expect(node.querySelector("[data-testid=execution-gate-request-changes]")).not.toBeNull();
+  });
+
+  it("keeps both decisions disabled until a note is entered", () => {
+    const node = render(
+      <ExecutionPolicyGate
+        stageLabel="Approval"
+        onSubmitDecision={vi.fn()}
+      />,
+    );
+    const approve = node.querySelector("[data-testid=execution-gate-approve]") as HTMLButtonElement;
+    expect(approve.disabled).toBe(true);
+
+    act(() => setTextareaValue(node.querySelector("textarea")!, "ship it"));
+    expect(approve.disabled).toBe(false);
+  });
+
+  it("submits approve with the trimmed note", async () => {
+    const onSubmitDecision = vi.fn().mockResolvedValue(undefined);
+    const node = render(
+      <ExecutionPolicyGate
+        stageLabel="Review"
+        onSubmitDecision={onSubmitDecision}
+      />,
+    );
+    act(() => setTextareaValue(node.querySelector("textarea")!, "  looks good  "));
+    act(() => (node.querySelector("[data-testid=execution-gate-approve]") as HTMLButtonElement).click());
+    await flushPromises();
+
+    expect(onSubmitDecision).toHaveBeenCalledWith({ status: "done", comment: "looks good" });
+  });
+
+  it("submits request changes with the note", async () => {
+    const onSubmitDecision = vi.fn().mockResolvedValue(undefined);
+    const node = render(
+      <ExecutionPolicyGate
+        stageLabel="Review"
+        onSubmitDecision={onSubmitDecision}
+      />,
+    );
+    act(() => setTextareaValue(node.querySelector("textarea")!, "fix the failure"));
+    act(() => (node.querySelector("[data-testid=execution-gate-request-changes]") as HTMLButtonElement).click());
+    await flushPromises();
+
+    expect(onSubmitDecision).toHaveBeenCalledWith({
+      status: "in_progress",
+      comment: "fix the failure",
+    });
+  });
+
+  it("preserves the note and shows the server error when a decision fails", async () => {
+    const node = render(
+      <ExecutionPolicyGate
+        stageLabel="Review"
+        onSubmitDecision={vi.fn().mockRejectedValue(new Error("Stage changed"))}
+      />,
+    );
+    const textarea = node.querySelector("textarea") as HTMLTextAreaElement;
+    act(() => setTextareaValue(textarea, "keep this"));
+    act(() => (node.querySelector("[data-testid=execution-gate-approve]") as HTMLButtonElement).click());
+    await flushPromises();
+
+    expect(textarea.value).toBe("keep this");
+    expect(node.querySelector("[role=alert]")?.textContent).toContain("Stage changed");
+  });
+});

--- a/ui/src/components/ExecutionPolicyGate.tsx
+++ b/ui/src/components/ExecutionPolicyGate.tsx
@@ -1,0 +1,101 @@
+import { useId, useState, type ChangeEvent } from "react";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { cn } from "@/lib/utils";
+
+interface ExecutionPolicyGateProps {
+  stageLabel: "Review" | "Approval";
+  onSubmitDecision: (input: {
+    status: "done" | "in_progress";
+    comment: string;
+  }) => Promise<unknown> | unknown;
+  className?: string;
+}
+
+export function ExecutionPolicyGate({
+  stageLabel,
+  onSubmitDecision,
+  className,
+}: ExecutionPolicyGateProps) {
+  const [comment, setComment] = useState("");
+  const [pendingStatus, setPendingStatus] = useState<"done" | "in_progress" | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const helperId = useId();
+  const errorId = useId();
+
+  const trimmedComment = comment.trim();
+  const pending = pendingStatus !== null;
+  const canSubmit = trimmedComment.length > 0 && !pending;
+
+  const handleChange = (event: ChangeEvent<HTMLTextAreaElement>) => {
+    setComment(event.target.value);
+    if (error) setError(null);
+  };
+
+  const submit = async (status: "done" | "in_progress") => {
+    if (!trimmedComment || pending) return;
+    setPendingStatus(status);
+    setError(null);
+    try {
+      await onSubmitDecision({ status, comment: trimmedComment });
+      setComment("");
+    } catch (err) {
+      setError(err instanceof Error && err.message ? err.message : "Decision failed. Try again.");
+    } finally {
+      setPendingStatus(null);
+    }
+  };
+
+  return (
+    <div
+      className={cn("flex flex-col gap-2 rounded-md border border-border bg-card/50 p-3", className)}
+      aria-busy={pending || undefined}
+      data-testid="execution-gate-self"
+    >
+      <div className="text-xs font-medium text-muted-foreground">
+        {stageLabel} pending with you
+      </div>
+      <Textarea
+        value={comment}
+        onChange={handleChange}
+        placeholder={stageLabel === "Review" ? "Add a review note…" : "Add an approval note…"}
+        aria-label={`${stageLabel} note`}
+        aria-required="true"
+        aria-describedby={error ? `${helperId} ${errorId}` : helperId}
+        data-testid="execution-gate-comment"
+      />
+      <div id={helperId} className="text-xs text-muted-foreground">
+        A note is required.
+      </div>
+      {error ? (
+        <div id={errorId} className="text-xs text-destructive" role="alert" data-testid="execution-gate-error">
+          {error}
+        </div>
+      ) : null}
+      <div className="flex flex-wrap items-center gap-2">
+        <Button
+          type="button"
+          size="sm"
+          className="disabled:bg-muted disabled:text-muted-foreground disabled:opacity-100"
+          disabled={!canSubmit}
+          onClick={() => void submit("done")}
+          data-testid="execution-gate-approve"
+        >
+          {pendingStatus === "done" ? "Approving…" : "Approve"}
+        </Button>
+        <Button
+          type="button"
+          size="sm"
+          variant="outline"
+          className="disabled:bg-muted disabled:text-muted-foreground disabled:opacity-100"
+          disabled={!canSubmit}
+          onClick={() => void submit("in_progress")}
+          data-testid="execution-gate-request-changes"
+        >
+          {pendingStatus === "in_progress" ? "Requesting…" : "Request changes"}
+        </Button>
+      </div>
+      {pending ? <span className="sr-only" role="status">Saving decision…</span> : null}
+    </div>
+  );
+}

--- a/ui/src/components/IssueProperties.test.tsx
+++ b/ui/src/components/IssueProperties.test.tsx
@@ -399,11 +399,7 @@ function createExecutionState(overrides: Partial<IssueExecutionState> = {}): Iss
   };
 }
 
-type IssuePropertiesTestProps = Omit<ComponentProps<typeof IssueProperties>, "onSubmitExecutionDecision"> & {
-  onSubmitExecutionDecision?: ComponentProps<typeof IssueProperties>["onSubmitExecutionDecision"];
-};
-
-function renderPropertiesWithQueryClient(container: HTMLDivElement, props: IssuePropertiesTestProps) {
+function renderPropertiesWithQueryClient(container: HTMLDivElement, props: ComponentProps<typeof IssueProperties>) {
   const queryClient = new QueryClient({
     defaultOptions: {
       queries: { retry: false },
@@ -413,17 +409,14 @@ function renderPropertiesWithQueryClient(container: HTMLDivElement, props: Issue
   act(() => {
     root.render(
       <QueryClientProvider client={queryClient}>
-        <IssueProperties
-          {...props}
-          onSubmitExecutionDecision={props.onSubmitExecutionDecision ?? vi.fn()}
-        />
+        <IssueProperties {...props} />
       </QueryClientProvider>,
     );
   });
   return { root, queryClient };
 }
 
-function renderProperties(container: HTMLDivElement, props: IssuePropertiesTestProps) {
+function renderProperties(container: HTMLDivElement, props: ComponentProps<typeof IssueProperties>) {
   const { root } = renderPropertiesWithQueryClient(container, props);
   return root;
 }
@@ -1198,7 +1191,6 @@ describe("IssueProperties", () => {
             issue={createIssue({ id: "issue-a", blockedBy })}
             childIssues={[]}
             onUpdate={vi.fn()}
-            onSubmitExecutionDecision={vi.fn()}
             inline
           />
         </QueryClientProvider>,
@@ -1223,7 +1215,6 @@ describe("IssueProperties", () => {
             issue={createIssue({ id: "issue-b", blockedBy })}
             childIssues={[]}
             onUpdate={vi.fn()}
-            onSubmitExecutionDecision={vi.fn()}
             inline
           />
         </QueryClientProvider>,

--- a/ui/src/components/IssueProperties.test.tsx
+++ b/ui/src/components/IssueProperties.test.tsx
@@ -399,7 +399,11 @@ function createExecutionState(overrides: Partial<IssueExecutionState> = {}): Iss
   };
 }
 
-function renderPropertiesWithQueryClient(container: HTMLDivElement, props: ComponentProps<typeof IssueProperties>) {
+type IssuePropertiesTestProps = Omit<ComponentProps<typeof IssueProperties>, "onSubmitExecutionDecision"> & {
+  onSubmitExecutionDecision?: ComponentProps<typeof IssueProperties>["onSubmitExecutionDecision"];
+};
+
+function renderPropertiesWithQueryClient(container: HTMLDivElement, props: IssuePropertiesTestProps) {
   const queryClient = new QueryClient({
     defaultOptions: {
       queries: { retry: false },
@@ -409,14 +413,17 @@ function renderPropertiesWithQueryClient(container: HTMLDivElement, props: Compo
   act(() => {
     root.render(
       <QueryClientProvider client={queryClient}>
-        <IssueProperties {...props} />
+        <IssueProperties
+          {...props}
+          onSubmitExecutionDecision={props.onSubmitExecutionDecision ?? vi.fn()}
+        />
       </QueryClientProvider>,
     );
   });
   return { root, queryClient };
 }
 
-function renderProperties(container: HTMLDivElement, props: ComponentProps<typeof IssueProperties>) {
+function renderProperties(container: HTMLDivElement, props: IssuePropertiesTestProps) {
   const { root } = renderPropertiesWithQueryClient(container, props);
   return root;
 }
@@ -1191,6 +1198,7 @@ describe("IssueProperties", () => {
             issue={createIssue({ id: "issue-a", blockedBy })}
             childIssues={[]}
             onUpdate={vi.fn()}
+            onSubmitExecutionDecision={vi.fn()}
             inline
           />
         </QueryClientProvider>,
@@ -1215,6 +1223,7 @@ describe("IssueProperties", () => {
             issue={createIssue({ id: "issue-b", blockedBy })}
             childIssues={[]}
             onUpdate={vi.fn()}
+            onSubmitExecutionDecision={vi.fn()}
             inline
           />
         </QueryClientProvider>,
@@ -1941,6 +1950,57 @@ describe("IssueProperties", () => {
 
     expect(container.textContent).not.toContain("Run review now");
     expect(container.textContent).not.toContain("Run approval now");
+
+    act(() => root.unmount());
+  });
+
+  it("lets the active board reviewer submit an explicit decision with a note", async () => {
+    const onSubmitExecutionDecision = vi.fn().mockResolvedValue(undefined);
+    const root = renderProperties(container, {
+      issue: createIssue({
+        status: "in_review",
+        executionPolicy: createExecutionPolicy({
+          stages: [
+            {
+              id: "review-stage",
+              type: "review",
+              approvalsNeeded: 1,
+              participants: [{ id: "participant-1", type: "user", agentId: null, userId: "user-1" }],
+            },
+          ],
+        }),
+        executionState: createExecutionState({
+          status: "pending",
+          currentStageType: "review",
+          currentParticipant: { type: "user", agentId: null, userId: "user-1" },
+          lastDecisionOutcome: null,
+        }),
+      }),
+      childIssues: [],
+      onUpdate: vi.fn(),
+      onSubmitExecutionDecision,
+    });
+    await flush();
+
+    await waitForAssertion(() => {
+      expect(container.textContent).toContain("Review pending with you");
+    });
+    const note = container.querySelector('textarea[aria-label="Review note"]') as HTMLTextAreaElement;
+    await act(async () => {
+      const setter = Object.getOwnPropertyDescriptor(window.HTMLTextAreaElement.prototype, "value")!.set!;
+      setter.call(note, "Ship it");
+      note.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+    const approve = Array.from(container.querySelectorAll("button"))
+      .find((button) => button.textContent?.includes("Approve"));
+    await act(async () => {
+      approve!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(onSubmitExecutionDecision).toHaveBeenCalledWith({
+      status: "done",
+      comment: "Ship it",
+    });
 
     act(() => root.unmount());
   });

--- a/ui/src/components/StatusIcon.disabledStatuses.test.tsx
+++ b/ui/src/components/StatusIcon.disabledStatuses.test.tsx
@@ -1,0 +1,56 @@
+// @vitest-environment jsdom
+
+import { act, type ReactElement } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { StatusIcon } from "./StatusIcon";
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let root: ReturnType<typeof createRoot> | null = null;
+let container: HTMLDivElement | null = null;
+
+afterEach(() => {
+  if (root) act(() => root?.unmount());
+  root = null;
+  container?.remove();
+  container = null;
+});
+
+function render(element: ReactElement) {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => root?.render(element));
+  return container;
+}
+
+describe("StatusIcon disabled statuses", () => {
+  it("disables stage-advancing choices while leaving other statuses available", () => {
+    const onChange = vi.fn();
+    const node = render(
+      <StatusIcon
+        status="in_review"
+        onChange={onChange}
+        showLabel
+        disabledStatuses={["done", "in_progress"]}
+        disabledStatusReason="Use the review form."
+      />,
+    );
+
+    act(() => (node.querySelector("button") as HTMLButtonElement).click());
+    const buttons = Array.from(document.body.querySelectorAll("button"));
+    const done = buttons.find((button) => button.textContent?.includes("Done"))!;
+    const blocked = buttons.find((button) => button.textContent?.includes("Blocked"))!;
+
+    expect(done.getAttribute("aria-disabled")).toBe("true");
+    expect(done.title).toBe("Use the review form.");
+    expect(blocked.disabled).toBe(false);
+
+    act(() => done.click());
+    expect(onChange).not.toHaveBeenCalled();
+
+    act(() => blocked.click());
+    expect(onChange).toHaveBeenCalledWith("blocked");
+  });
+});

--- a/ui/src/components/StatusIcon.tsx
+++ b/ui/src/components/StatusIcon.tsx
@@ -4,6 +4,7 @@ import { cn } from "../lib/utils";
 import { StatusGlyph, type StatusGlyphSize } from "./StatusGlyph";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Button } from "@/components/ui/button";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 
 const allStatuses = ["backlog", "todo", "in_progress", "in_review", "done", "cancelled", "blocked"];
 
@@ -17,6 +18,10 @@ interface StatusIconProps {
   onChange?: (status: string) => void;
   className?: string;
   showLabel?: boolean;
+  /** Status transitions handled by a more specific workflow on the current surface. */
+  disabledStatuses?: readonly string[];
+  /** Explanation exposed on disabled status choices. */
+  disabledStatusReason?: string;
   /** Glyph size (PAP-243a). Default `md` (16px); lists/detail/mentions use `lg` (20px). */
   size?: StatusGlyphSize;
 }
@@ -75,7 +80,16 @@ function blockedAttentionLabel(blockerAttention: IssueBlockerAttention | null | 
  * glyph — the blocked shape recoloured blue — while the full blocked reason
  * still rides on the accessible label.
  */
-export function StatusIcon({ status, blockerAttention, onChange, className, showLabel, size = "md" }: StatusIconProps) {
+export function StatusIcon({
+  status,
+  blockerAttention,
+  onChange,
+  className,
+  showLabel,
+  size = "md",
+  disabledStatuses,
+  disabledStatusReason,
+}: StatusIconProps) {
   const [open, setOpen] = useState(false);
   const isCoveredBlocked = status === "blocked" && blockerAttention?.state === "covered";
   const ariaLabel = status === "blocked" ? blockedAttentionLabel(blockerAttention) : statusLabel(status);
@@ -114,21 +128,40 @@ export function StatusIcon({ status, blockerAttention, onChange, className, show
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>{trigger}</PopoverTrigger>
       <PopoverContent className="w-40 p-1" align="start">
-        {allStatuses.map((s) => (
-          <Button
-            key={s}
-            variant="ghost"
-            size="sm"
-            className={cn("w-full justify-start gap-2 text-xs", s === status && "bg-accent")}
-            onClick={() => {
-              onChange(s);
-              setOpen(false);
-            }}
-          >
-            <StatusIcon status={s} size="lg" />
-            {statusLabel(s)}
-          </Button>
-        ))}
+        <TooltipProvider>
+          {allStatuses.map((s) => {
+            const disabled = disabledStatuses?.includes(s) ?? false;
+            const option = (
+              <Button
+                variant="ghost"
+                size="sm"
+                aria-disabled={disabled || undefined}
+                title={disabled ? disabledStatusReason : undefined}
+                className={cn(
+                  "w-full justify-start gap-2 text-xs",
+                  s === status && "bg-accent",
+                  disabled && "cursor-not-allowed opacity-50",
+                )}
+                onClick={() => {
+                  if (disabled) return;
+                  onChange(s);
+                  setOpen(false);
+                }}
+              >
+                <StatusIcon status={s} size="lg" />
+                {statusLabel(s)}
+              </Button>
+            );
+            return disabled && disabledStatusReason ? (
+              <Tooltip key={s}>
+                <TooltipTrigger asChild>{option}</TooltipTrigger>
+                <TooltipContent side="left">{disabledStatusReason}</TooltipContent>
+              </Tooltip>
+            ) : (
+              <div key={s}>{option}</div>
+            );
+          })}
+        </TooltipProvider>
       </PopoverContent>
     </Popover>
   );

--- a/ui/src/components/issue-properties/IssueProperties.tsx
+++ b/ui/src/components/issue-properties/IssueProperties.tsx
@@ -26,6 +26,7 @@ import { getRecentProjectIds, trackRecentProject } from "../../lib/recent-projec
 import { orderItemsBySelectedAndRecent } from "../../lib/recent-selections";
 import { formatAssigneeUserLabel, formatUserLabel } from "../../lib/assignees";
 import { buildExecutionPolicy, stageParticipantValues } from "../../lib/issue-execution-policy";
+import { executionDecisionStageForViewer } from "../../lib/issue-execution-state";
 import { formatMonitorOffset } from "../../lib/issue-monitor";
 import { extractProviderIdWithFallback } from "../../lib/model-utils";
 import { formatRetryReason } from "../../lib/runRetryState";
@@ -76,6 +77,7 @@ import { PropertyChip, PropertyRow, PropertySection } from "./primitives";
 import { IssueCasesPanel } from "../IssueCasesPanel";
 import { ExpandRelationListButton, RemovableIssueReferencePill } from "./relation-controls";
 import { Badge } from "@/components/ui/badge";
+import { ExecutionPolicyGate } from "../ExecutionPolicyGate";
 
 function TruncatedCopyable({ value, icon: Icon }: { value: string; icon: ComponentType<{ className?: string }> }) {
   const [copied, setCopied] = useState(false);
@@ -117,6 +119,10 @@ interface IssuePropertiesProps {
   childIssues?: Issue[];
   onAddSubIssue?: () => void;
   onUpdate: (data: Record<string, unknown>) => void;
+  onSubmitExecutionDecision?: (input: {
+    status: "done" | "in_progress";
+    comment: string;
+  }) => Promise<unknown>;
   inline?: boolean;
   /** Whether an agent run is currently in flight on this issue, so the assignee
    * picker can warn that reassigning will interrupt it. */
@@ -135,6 +141,7 @@ export function IssueProperties({
   childIssues = [],
   onAddSubIssue,
   onUpdate,
+  onSubmitExecutionDecision,
   inline,
   hasActiveRun = false,
   externalObjects,
@@ -745,6 +752,13 @@ export function IssueProperties({
     }
     return `${stageLabel} pending${participantLabel ? ` with ${participantLabel}` : ""}`;
   })();
+  const executionDecisionStage = onSubmitExecutionDecision
+    ? executionDecisionStageForViewer({
+        issueStatus: issue.status,
+        executionState: issue.executionState,
+        currentUserId: currentUserId ?? null,
+      })
+    : null;
   useEffect(() => {
     setMonitorAtInput(toDateTimeLocalValue(issue.executionPolicy?.monitor?.nextCheckAt));
     setMonitorNotesInput(issue.executionPolicy?.monitor?.notes ?? "");
@@ -1883,6 +1897,8 @@ export function IssueProperties({
             size="lg"
             blockerAttention={issue.blockerAttention}
             onChange={(status) => onUpdate({ status })}
+            disabledStatuses={executionDecisionStage ? ["done", "in_progress"] : undefined}
+            disabledStatusReason="Use the execution decision form below."
             showLabel
           />
         </PropertyRow>
@@ -2131,11 +2147,18 @@ export function IssueProperties({
         </PropertyPicker>
         {nextRunnableExecutionStage === "approval" && approverValues.length > 0 ? runExecutionButton("approval") : null}
 
-        {currentExecutionLabel && (
+        {executionDecisionStage && onSubmitExecutionDecision ? (
+          <div className="py-1.5">
+            <ExecutionPolicyGate
+              stageLabel={executionDecisionStage.stageLabel}
+              onSubmitDecision={onSubmitExecutionDecision}
+            />
+          </div>
+        ) : currentExecutionLabel ? (
           <PropertyRow label="Execution">
             <span className="text-sm truncate min-w-0" title={currentExecutionLabel}>{currentExecutionLabel}</span>
           </PropertyRow>
-        )}
+        ) : null}
 
         {showScheduledRetryRow && scheduledRetryContent ? (
           <PropertyPicker

--- a/ui/src/lib/assignees.test.ts
+++ b/ui/src/lib/assignees.test.ts
@@ -67,7 +67,7 @@ describe("assignee selection helpers", () => {
           { authorUserId: "board-user" },
           { authorAgentId: "agent-123" },
         ],
-        "board-user",
+        { currentUserId: "board-user" },
       ),
     ).toBe("agent:agent-123");
   });
@@ -77,7 +77,7 @@ describe("assignee selection helpers", () => {
       suggestedCommentAssigneeValue(
         { assigneeUserId: "board-user" },
         [{ authorUserId: "board-user" }],
-        "board-user",
+        { currentUserId: "board-user" },
       ),
     ).toBe("user:board-user");
   });
@@ -91,9 +91,18 @@ describe("assignee selection helpers", () => {
           { authorAgentId: "agent-self" },
           { authorAgentId: "agent-123" },
         ],
-        null,
-        "agent-self",
+        { currentAgentId: "agent-self" },
       ),
     ).toBe("agent:agent-123");
+  });
+
+  it("preserves the current assignee when a workflow owns the next transition", () => {
+    expect(
+      suggestedCommentAssigneeValue(
+        { assigneeUserId: "local-board" },
+        [{ authorUserId: "ceo-user" }],
+        { currentUserId: "local-board", preserveCurrentAssignee: true },
+      ),
+    ).toBe("user:local-board");
   });
 });

--- a/ui/src/lib/assignees.ts
+++ b/ui/src/lib/assignees.ts
@@ -28,9 +28,14 @@ export function assigneeValueFromSelection(selection: Partial<AssigneeSelection>
 export function suggestedCommentAssigneeValue(
   issue: CommentAssigneeSuggestionInput,
   comments: CommentAssigneeSuggestionComment[] | null | undefined,
-  currentUserId: string | null | undefined,
-  currentAgentId?: string | null | undefined,
+  context: {
+    currentUserId?: string | null;
+    currentAgentId?: string | null;
+    preserveCurrentAssignee?: boolean;
+  },
 ): string {
+  if (context.preserveCurrentAssignee) return assigneeValueFromSelection(issue);
+  const { currentUserId, currentAgentId } = context;
   if (comments && comments.length > 0 && (currentUserId || currentAgentId)) {
     for (let i = comments.length - 1; i >= 0; i--) {
       const comment = comments[i];

--- a/ui/src/lib/issue-execution-state.test.ts
+++ b/ui/src/lib/issue-execution-state.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import type { IssueExecutionState } from "@paperclipai/shared";
+import { executionDecisionStageForViewer } from "./issue-execution-state";
+
+function pendingState(overrides: Partial<IssueExecutionState> = {}): IssueExecutionState {
+  return {
+    status: "pending",
+    currentStageId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+    currentStageIndex: 0,
+    currentStageType: "review",
+    currentParticipant: { type: "user", userId: "local-board" },
+    returnAssignee: { type: "agent", agentId: "agent-1" },
+    reviewRequest: null,
+    completedStageIds: [],
+    lastDecisionId: null,
+    lastDecisionOutcome: null,
+    monitor: null,
+    ...overrides,
+  };
+}
+
+describe("executionDecisionStageForViewer", () => {
+  it("returns the active board review stage", () => {
+    expect(executionDecisionStageForViewer({
+      issueStatus: "in_review",
+      executionState: pendingState(),
+      currentUserId: "local-board",
+    })).toEqual({ stageLabel: "Review" });
+  });
+
+  it("returns the active board approval stage", () => {
+    expect(executionDecisionStageForViewer({
+      issueStatus: "in_review",
+      executionState: pendingState({ currentStageType: "approval" }),
+      currentUserId: "local-board",
+    })).toEqual({ stageLabel: "Approval" });
+  });
+
+  it("returns null for a different participant or inactive stage", () => {
+    expect(executionDecisionStageForViewer({
+      issueStatus: "in_review",
+      executionState: pendingState(),
+      currentUserId: "user-2",
+    })).toBeNull();
+    expect(executionDecisionStageForViewer({
+      issueStatus: "done",
+      executionState: pendingState(),
+      currentUserId: "local-board",
+    })).toBeNull();
+    expect(executionDecisionStageForViewer({
+      issueStatus: "in_review",
+      executionState: pendingState({ status: "completed" }),
+      currentUserId: "local-board",
+    })).toBeNull();
+  });
+});

--- a/ui/src/lib/issue-execution-state.ts
+++ b/ui/src/lib/issue-execution-state.ts
@@ -1,0 +1,30 @@
+import type { IssueExecutionState } from "@paperclipai/shared";
+
+export interface ExecutionDecisionStage {
+  stageLabel: "Review" | "Approval";
+}
+
+const STAGE_LABELS = {
+  review: "Review",
+  approval: "Approval",
+} as const;
+
+export function executionDecisionStageForViewer(input: {
+  issueStatus: string;
+  executionState: IssueExecutionState | null | undefined;
+  currentUserId: string | null;
+}): ExecutionDecisionStage | null {
+  if (input.issueStatus !== "in_review") return null;
+  const state = input.executionState;
+  if (state?.status !== "pending") return null;
+  if (state.currentStageType !== "review" && state.currentStageType !== "approval") return null;
+  const participant = state.currentParticipant;
+  if (
+    participant?.type !== "user" ||
+    !input.currentUserId ||
+    participant.userId !== input.currentUserId
+  ) {
+    return null;
+  }
+  return { stageLabel: STAGE_LABELS[state.currentStageType] };
+}

--- a/ui/src/pages/IssueDetail.test.tsx
+++ b/ui/src/pages/IssueDetail.test.tsx
@@ -982,6 +982,7 @@ describe("IssueDetail", () => {
       enableExternalObjects: false,
     });
     mockIssuesApi.listAcceptedPlanDecompositions.mockResolvedValue([]);
+    mockIssuesApi.update.mockClear();
     mockIssuesListRender.mockClear();
     mockIssueChatThreadRender.mockClear();
     mockImageGalleryRender.mockClear();
@@ -1026,6 +1027,84 @@ describe("IssueDetail", () => {
         String(call[0]).includes("React has detected a change in the order of Hooks"),
       ),
     ).toBe(false);
+  });
+
+  it("adds an execution decision note to the visible comment thread", async () => {
+    const issue = createIssue({
+      status: "in_review",
+      executionState: {
+        status: "pending",
+        currentStageId: "stage-1",
+        currentStageIndex: 0,
+        currentStageType: "review",
+        currentParticipant: { type: "user", userId: "user-1" },
+        returnAssignee: { type: "agent", agentId: "agent-1" },
+        reviewRequest: null,
+        completedStageIds: [],
+        lastDecisionId: null,
+        lastDecisionOutcome: null,
+        monitor: null,
+      },
+    });
+    const existingComment = createIssueComment();
+    const decisionComment = createIssueComment({
+      id: "comment-decision",
+      body: "Approved after verification.",
+      createdAt: new Date("2026-04-21T00:00:10.000Z"),
+      updatedAt: new Date("2026-04-21T00:00:10.000Z"),
+    });
+    mockIssuesApi.get.mockResolvedValue(issue);
+    mockIssuesApi.listComments.mockResolvedValue([existingComment]);
+    mockAuthApi.getSession.mockResolvedValue({
+      session: { userId: "user-1" },
+      user: { id: "user-1" },
+    });
+    mockIssuesApi.update.mockResolvedValue({
+      ...issue,
+      status: "done",
+      executionState: null,
+      comment: decisionComment,
+    });
+
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <IssueDetail />
+        </QueryClientProvider>,
+      );
+    });
+    await flushReact();
+    await flushReact();
+
+    const propertiesPanel = mockOpenPanel.mock.calls.at(-1)?.[0] as {
+      props?: {
+        onSubmitExecutionDecision?: (input: {
+          status: "done" | "in_progress";
+          comment: string;
+        }) => Promise<unknown>;
+      };
+    };
+    expect(propertiesPanel.props?.onSubmitExecutionDecision).toBeTypeOf("function");
+
+    await act(async () => {
+      await propertiesPanel.props?.onSubmitExecutionDecision?.({
+        status: "done",
+        comment: "Approved after verification.",
+      });
+    });
+    await flushReact();
+
+    expect(mockIssuesApi.update).toHaveBeenCalledWith("PAP-1", {
+      status: "done",
+      comment: "Approved after verification.",
+    });
+    const threadProps = mockIssueChatThreadRender.mock.calls.at(-1)?.[0] as {
+      comments?: IssueComment[];
+    };
+    expect(threadProps.comments?.map((comment) => comment.id)).toEqual([
+      "comment-1",
+      "comment-decision",
+    ]);
   });
 
   it("removes an inbox-origin archived issue from cached inbox variants before navigating back", async () => {

--- a/ui/src/pages/IssueDetail.tsx
+++ b/ui/src/pages/IssueDetail.tsx
@@ -5,7 +5,7 @@ import { useInfiniteQuery, useQuery, useMutation, useQueryClient, type InfiniteD
 import { useVisibilityRefetchInterval } from "@/lib/polling";
 import { usePublishSharedQueryData, useSharedPollingQuery } from "@/hooks/useSharedPolling";
 import { ApiError } from "../api/client";
-import { issuesApi } from "../api/issues";
+import { issuesApi, type IssueUpdateResponse } from "../api/issues";
 import { approvalsApi } from "../api/approvals";
 import { activityApi, type RunForIssue } from "../api/activity";
 import { heartbeatsApi, type ActiveRunForIssue, type LiveRunForIssue } from "../api/heartbeats";
@@ -26,6 +26,7 @@ import { useSidebar } from "../context/SidebarContext";
 import { useToastActions } from "../context/ToastContext";
 import { useBreadcrumbs } from "../context/BreadcrumbContext";
 import { assigneeValueFromSelection, formatAssigneeUserLabel, formatUserLabel, suggestedCommentAssigneeValue } from "../lib/assignees";
+import { executionDecisionStageForViewer } from "../lib/issue-execution-state";
 import { buildCompanyUserInlineOptions, buildCompanyUserLabelMap, buildCompanyUserProfileMap, buildMarkdownMentionOptions, isAgentTaskTarget } from "../lib/company-members";
 import { extractIssueTimelineEvents } from "../lib/issue-timeline-events";
 import { queryKeys } from "../lib/queryKeys";
@@ -244,6 +245,7 @@ const FEEDBACK_TERMS_URL = import.meta.env.VITE_FEEDBACK_TERMS_URL?.trim() || "h
 const ISSUE_COMMENT_PAGE_SIZE = 50;
 const ISSUE_COMMENT_AUTOLOAD_LIMIT = ISSUE_COMMENT_PAGE_SIZE * 3;
 const JUMP_TO_LATEST_MAX_COMMENT_PAGES = 10;
+const EXECUTION_GATE_DISABLED_STATUSES = ["done", "in_progress"] as const;
 const TREE_CONTROL_MODE_LABEL: Record<IssueTreeControlMode, string> = {
   pause: "Pause subtree",
   resume: "Resume subtree",
@@ -1923,14 +1925,22 @@ export function IssueDetail() {
     [issue],
   );
 
+  const viewerIsActiveExecutionParticipant = Boolean(executionDecisionStageForViewer({
+    issueStatus: issue?.status ?? "",
+    executionState: issue?.executionState,
+    currentUserId,
+  }));
+
   const suggestedAssigneeValue = useMemo(
-    () =>
-      suggestedCommentAssigneeValue(
-        issue ?? {},
-        mergeIssueComments(comments ?? [], optimisticComments),
+    () => suggestedCommentAssigneeValue(
+      issue ?? {},
+      mergeIssueComments(comments ?? [], optimisticComments),
+      {
         currentUserId,
-      ),
-    [issue, comments, optimisticComments, currentUserId],
+        preserveCurrentAssignee: viewerIsActiveExecutionParticipant,
+      },
+    ),
+    [issue, comments, optimisticComments, currentUserId, viewerIsActiveExecutionParticipant],
   );
 
   const threadComments = useMemo(
@@ -2091,6 +2101,15 @@ export function IssueDetail() {
     },
   });
 
+  const handleIssueUpdateSuccess = useCallback((response: IssueUpdateResponse) => {
+    const { comment: _comment, ...nextIssue } = response;
+    const issueRefs = new Set<string>([issueId!, nextIssue.id]);
+    if (nextIssue.identifier) issueRefs.add(nextIssue.identifier);
+    mergeIssueResponseIntoCaches(issueRefs, nextIssue);
+    queryClient.invalidateQueries({ queryKey: queryKeys.issues.activity(issueId!) });
+    invalidateIssueCollections();
+  }, [invalidateIssueCollections, issueId, mergeIssueResponseIntoCaches, queryClient]);
+
   const updateIssue = useMutation({
     mutationFn: (data: Record<string, unknown>) => issuesApi.update(issueId!, data),
     onMutate: async (data) => {
@@ -2115,13 +2134,7 @@ export function IssueDetail() {
 
       return { previousDetailQueries, previousList, selectedCompanyId };
     },
-    onSuccess: ({ comment: _comment, ...nextIssue }) => {
-      const issueRefs = new Set<string>([issueId!, nextIssue.id]);
-      if (nextIssue.identifier) issueRefs.add(nextIssue.identifier);
-      mergeIssueResponseIntoCaches(issueRefs, nextIssue);
-      queryClient.invalidateQueries({ queryKey: queryKeys.issues.activity(issueId!) });
-      invalidateIssueCollections();
-    },
+    onSuccess: handleIssueUpdateSuccess,
     onError: (err, _variables, context) => {
       for (const [queryKey, previousIssue] of context?.previousDetailQueries ?? []) {
         queryClient.setQueryData(queryKey, previousIssue);
@@ -2135,6 +2148,17 @@ export function IssueDetail() {
         tone: "error",
       });
     },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.issues.detail(issueId!) });
+      if (selectedCompanyId) {
+        queryClient.invalidateQueries({ queryKey: queryKeys.issues.list(selectedCompanyId) });
+      }
+    },
+  });
+  const submitExecutionDecision = useMutation({
+    mutationFn: (input: { status: "done" | "in_progress"; comment: string }) =>
+      issuesApi.update(issueId!, input),
+    onSuccess: handleIssueUpdateSuccess,
     onSettled: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.issues.detail(issueId!) });
       if (selectedCompanyId) {
@@ -2332,7 +2356,6 @@ export function IssueDetail() {
   const handleIssuePropertiesUpdate = useCallback((data: Record<string, unknown>) => {
     updateIssue.mutate(data);
   }, [updateIssue.mutate]);
-
   const updateChildIssue = useMutation({
     mutationFn: ({ id, data }: { id: string; data: Record<string, unknown> }) => issuesApi.update(id, data),
     onSuccess: () => {
@@ -3159,6 +3182,7 @@ export function IssueDetail() {
         childIssues={panelChildIssues}
         onAddSubIssue={openNewSubIssue}
         onUpdate={handleIssuePropertiesUpdate}
+        onSubmitExecutionDecision={submitExecutionDecision.mutateAsync}
         hasActiveRun={resolvedHasActiveRun}
         externalObjects={externalObjectsState.isEnabled ? externalObjectsState.groups : undefined}
         externalObjectsLoading={externalObjectsState.isEnabled ? externalObjectsState.isLoading : undefined}
@@ -3176,6 +3200,7 @@ export function IssueDetail() {
     panelChildIssues,
     panelIssue,
     resolvedHasActiveRun,
+    submitExecutionDecision.mutateAsync,
     externalObjectsState.isEnabled,
     externalObjectsState.groups,
     externalObjectsState.isLoading,
@@ -4151,6 +4176,8 @@ export function IssueDetail() {
             size="lg"
             blockerAttention={issue.blockerAttention}
             onChange={(status) => updateIssue.mutate({ status })}
+            disabledStatuses={viewerIsActiveExecutionParticipant ? EXECUTION_GATE_DISABLED_STATUSES : undefined}
+            disabledStatusReason="Use the execution decision form in properties."
           />
           <PriorityIcon
             priority={issue.priority}
@@ -5019,6 +5046,7 @@ export function IssueDetail() {
                 childIssues={childIssues}
                 onAddSubIssue={openNewSubIssue}
                 onUpdate={(data) => updateIssue.mutate(data)}
+                onSubmitExecutionDecision={submitExecutionDecision.mutateAsync}
                 inline
                 hasActiveRun={resolvedHasActiveRun}
                 externalObjects={externalObjectsState.isEnabled ? externalObjectsState.groups : undefined}

--- a/ui/src/pages/IssueDetail.tsx
+++ b/ui/src/pages/IssueDetail.tsx
@@ -2025,13 +2025,22 @@ export function IssueDetail() {
     for (const ref of issueCacheRefs) {
       queryClient.setQueryData<InfiniteData<IssueComment[], string | null> | undefined>(
         queryKeys.issues.comments(ref),
-        (current) => current ? {
-          ...current,
-          pages: upsertIssueCommentInPages(current.pages, comment),
-        } : current,
+        (current) => {
+          if (current) {
+            return {
+              ...current,
+              pages: upsertIssueCommentInPages(current.pages, comment),
+            };
+          }
+          if (ref !== issueId) return current;
+          return {
+            pageParams: [null],
+            pages: upsertIssueCommentInPages(undefined, comment),
+          };
+        },
       );
     }
-  }, [issueCacheRefs, queryClient]);
+  }, [issueCacheRefs, issueId, queryClient]);
 
   const restoreQueuedCommentDraft = useCallback((body: string) => {
     commentComposerRef.current?.restoreDraft(body);
@@ -2102,13 +2111,14 @@ export function IssueDetail() {
   });
 
   const handleIssueUpdateSuccess = useCallback((response: IssueUpdateResponse) => {
-    const { comment: _comment, ...nextIssue } = response;
+    const { comment, ...nextIssue } = response;
     const issueRefs = new Set<string>([issueId!, nextIssue.id]);
     if (nextIssue.identifier) issueRefs.add(nextIssue.identifier);
     mergeIssueResponseIntoCaches(issueRefs, nextIssue);
+    if (comment) upsertCommentInCache(comment);
     queryClient.invalidateQueries({ queryKey: queryKeys.issues.activity(issueId!) });
     invalidateIssueCollections();
-  }, [invalidateIssueCollections, issueId, mergeIssueResponseIntoCaches, queryClient]);
+  }, [invalidateIssueCollections, issueId, mergeIssueResponseIntoCaches, queryClient, upsertCommentInCache]);
 
   const updateIssue = useMutation({
     mutationFn: (data: Record<string, unknown>) => issuesApi.update(issueId!, data),

--- a/ui/src/pages/Pipelines.tsx
+++ b/ui/src/pages/Pipelines.tsx
@@ -2174,7 +2174,7 @@ export function PipelineItemDetailView({ pipelineId, caseId }: { pipelineId: str
       suggestedCommentAssigneeValue(
         starterAssigneeValue ? parseAssigneeValue(starterAssigneeValue) : activeConversationIssue ?? {},
         conversationComments,
-        currentUserId,
+        { currentUserId },
       ),
     [activeConversationIssue, conversationComments, currentUserId, starterAssigneeValue],
   );

--- a/ui/storybook/stories/forms-editors.stories.tsx
+++ b/ui/storybook/stories/forms-editors.stories.tsx
@@ -4,6 +4,7 @@ import type { Agent, CompanySecret, EnvBinding, Project, RoutineVariable } from 
 import { Code2, FileText, ListPlus, RotateCcw, Table2 } from "lucide-react";
 import { EnvironmentVariablesEditor } from "@/components/environment-variables-editor";
 import { ExecutionParticipantPicker } from "@/components/ExecutionParticipantPicker";
+import { ExecutionPolicyGate } from "@/components/ExecutionPolicyGate";
 import { FoldCurtain } from "@/components/FoldCurtain";
 import { InlineEditor } from "@/components/InlineEditor";
 import { InlineEntitySelector, type InlineEntityOption } from "@/components/InlineEntitySelector";
@@ -817,4 +818,37 @@ function FoldCurtainStory() {
 export const FoldCurtainShowcase: Story = {
   name: "Fold Curtain",
   render: () => <FoldCurtainStory />,
+};
+
+function ExecutionPolicyDecisionStory() {
+  const [lastDecision, setLastDecision] = useState<string | null>(null);
+
+  return (
+    <StoryShell>
+      <Section
+        eyebrow="Execution policy"
+        title="Active reviewer decision"
+        description="The current human reviewer records a required note and resolves the stage without leaving task properties."
+      >
+        <div className="max-w-sm">
+          <ExecutionPolicyGate
+            stageLabel="Review"
+            onSubmitDecision={async ({ status, comment }) => {
+              setLastDecision(`${status}: ${comment}`);
+            }}
+          />
+          {lastDecision ? (
+            <div className="mt-3 text-xs text-muted-foreground" role="status">
+              {lastDecision}
+            </div>
+          ) : null}
+        </div>
+      </Section>
+    </StoryShell>
+  );
+}
+
+export const ExecutionPolicyDecision: Story = {
+  name: "Execution Policy Decision",
+  render: () => <ExecutionPolicyDecisionStory />,
 };


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Execution policies pause issue progress at human or agent review and approval stages
> - The server already accepts an active human participant's approve or request-changes decision as one status-plus-comment mutation
> - The issue UI exposed only the generic status picker and comment composer, which could silently reassign the issue before the decision reached the server
> - Active human reviewers therefore had no reliable UI path to resolve their stage, while passive participants still needed to remain read-only
> - This pull request adds a focused decision form, protects the generic status controls, and preserves assignment when the active participant comments
> - The benefit is a review flow that follows the server's existing policy semantics without weakening authorization or inferring decisions from prose

## Linked Issues or Issue Description

- Fixes: #4143
- Refs: #3921
- Builds on the interaction direction in #5487, reworked for the current issue UI and execution-policy model. Credit to Robin van Duiven for the earlier proposal.

## What Changed

- Show active human reviewers and approvers a required-note decision form with explicit approve and request-changes actions.
- Submit the decision atomically as one status-plus-comment update and preserve the note if the request fails.
- Keep passive participants read-only and direct active participants away from the ambiguous generic status actions.
- Prevent ordinary comments by the active execution participant from silently reassigning the issue.
- Add UI, helper, and server route coverage for active/passive visibility, disabled status actions, assignment preservation, error recovery, and multi-stage advancement.
- Add a Storybook state for the decision form.

## Verification

- `pnpm --filter @paperclipai/ui test --run ui/src/components/ExecutionPolicyGate.test.tsx ui/src/components/StatusIcon.disabledStatuses.test.tsx ui/src/components/IssueProperties.test.tsx ui/src/lib/assignees.test.ts ui/src/lib/issue-execution-state.test.ts` — 63 tests passed.
- `pnpm --filter @paperclipai/server test --run server/src/__tests__/issue-comment-reopen-routes.test.ts` — 73 tests passed.
- UI and server TypeScript checks passed.
- `pnpm build` passed.
- Design-token gates and `git diff --check` passed.
- Verified in an isolated running Paperclip instance at desktop and 320 px widths: active and passive participants, empty/filled/in-flight/error form states, guarded status tooltip, request changes, and multi-stage approval.
- Storybook static build is currently blocked on the base branch by a `storybook@10.4.6` / `@storybook/addon-docs@10.5.0` export mismatch; the added story typechecks and the production UI build passes.

## Risks

- Low risk. The new UI path is limited to the matching human participant on a pending review or approval stage. The server remains authoritative for authorization and stage transitions.
- No database, API contract, or execution-policy migration is introduced.
- The generic status picker is guarded only for the two actions represented by the decision form; other issue transitions retain their existing behavior.

> This is a scoped bug fix in the completed reviews-and-approvals roadmap area; it does not duplicate planned core work.

## Model Used

- OpenAI Codex based on GPT-5, with reasoning, tool use, and code execution. The exact runtime model ID and context-window size were not exposed to the session.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
