### PR TITLE
feat(doctor): add planner stats, log, and shared_buffers health checks

### DIFF
--- a/cli/src/__tests__/doctor-health-checks.test.ts
+++ b/cli/src/__tests__/doctor-health-checks.test.ts
@@ -1,0 +1,210 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { PaperclipConfig } from "../config/schema.js";
+import { activityLogSizeCheck } from "../checks/activity-log-size-check.js";
+import { plannerStatsCheck } from "../checks/planner-stats-check.js";
+import { serverLogSizeCheck } from "../checks/server-log-size-check.js";
+import { sharedBuffersCheck } from "../checks/shared-buffers-check.js";
+
+const tempRoots: string[] = [];
+
+function createConfig(overrides: Partial<PaperclipConfig> = {}): PaperclipConfig {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "paperclip-doctor-health-"));
+  tempRoots.push(root);
+
+  return {
+    $meta: {
+      version: 1,
+      updatedAt: "2026-07-15T00:00:00.000Z",
+      source: "doctor",
+    },
+    database: {
+      mode: "embedded-postgres",
+      embeddedPostgresDataDir: path.join(root, "db"),
+      embeddedPostgresPort: 54329,
+      backup: {
+        enabled: true,
+        intervalMinutes: 60,
+        retentionDays: 7,
+        dir: path.join(root, "backups"),
+      },
+    },
+    logging: {
+      mode: "file",
+      logDir: path.join(root, "logs"),
+    },
+    server: {
+      deploymentMode: "local_trusted",
+      exposure: "private",
+      host: "127.0.0.1",
+      port: 3100,
+      allowedHostnames: [],
+      serveUi: true,
+    },
+    telemetry: {
+      enabled: true,
+    },
+    auth: {
+      baseUrlMode: "auto",
+      disableSignUp: false,
+    },
+    storage: {
+      provider: "local_disk",
+      localDisk: {
+        baseDir: path.join(root, "storage"),
+      },
+      s3: {
+        bucket: "paperclip",
+        region: "us-east-1",
+        prefix: "",
+        forcePathStyle: false,
+      },
+    },
+    secrets: {
+      provider: "local_encrypted",
+      strictMode: false,
+      localEncrypted: {
+        keyFilePath: path.join(root, "secrets", "master.key"),
+      },
+    },
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  for (const root of tempRoots.splice(0)) {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+describe("plannerStatsCheck", () => {
+  it("repairs stale hot-table statistics with ANALYZE", async () => {
+    const execute = vi
+      .fn()
+      .mockResolvedValueOnce([{ relname: "activity_log" }, { relname: "issues" }])
+      .mockResolvedValue([]);
+    const openDb = vi.fn(async () => ({ db: { execute } as never, connectionString: "postgres://test" }));
+
+    const result = await plannerStatsCheck(createConfig(), undefined, { openDb });
+
+    expect(result.status).toBe("warn");
+    expect(result.canRepair).toBe(true);
+    expect(result.message).toContain("activity_log");
+    expect(result.message).toContain("issues");
+
+    await result.repair?.();
+
+    expect(execute).toHaveBeenCalledTimes(3);
+    expect(execute.mock.calls[1]?.[0]).toBe('ANALYZE "activity_log"');
+    expect(execute.mock.calls[2]?.[0]).toBe('ANALYZE "issues"');
+  });
+
+  it("warns without repair when PostgreSQL is unavailable", async () => {
+    const openDb = vi.fn(async () => {
+      throw new Error("connection refused");
+    });
+
+    const result = await plannerStatsCheck(createConfig(), undefined, { openDb });
+
+    expect(result.status).toBe("warn");
+    expect(result.canRepair).toBe(false);
+    expect(result.message).toContain("skipped");
+  });
+});
+
+describe("activityLogSizeCheck", () => {
+  it("warns and recommends VACUUM FULL above the size threshold", async () => {
+    const execute = vi.fn().mockResolvedValue([{ total_bytes: "4097" }]);
+    const openDb = vi.fn(async () => ({ db: { execute } as never, connectionString: "postgres://test" }));
+
+    const result = await activityLogSizeCheck(createConfig(), undefined, {
+      maxBytes: 4096,
+      openDb,
+    });
+
+    expect(result.status).toBe("warn");
+    expect(result.canRepair).toBe(false);
+    expect(result.message).toContain("activity_log");
+    expect(result.repairHint).toContain("VACUUM FULL");
+  });
+});
+
+describe("serverLogSizeCheck", () => {
+  it("copy-truncates an oversized server.log", async () => {
+    const config = createConfig();
+    fs.mkdirSync(config.logging.logDir, { recursive: true });
+    const logFile = path.join(config.logging.logDir, "server.log");
+    fs.writeFileSync(logFile, "0123456789");
+
+    const result = serverLogSizeCheck(config, undefined, {
+      maxBytes: 8,
+      now: () => new Date("2026-07-15T12:34:56.000Z"),
+    });
+
+    expect(result.status).toBe("warn");
+    expect(result.canRepair).toBe(true);
+    await result.repair?.();
+
+    expect(fs.statSync(logFile).size).toBe(0);
+    const rotatedPath = path.join(config.logging.logDir, "server.log.2026-07-15T12-34-56-000Z");
+    expect(fs.readFileSync(rotatedPath, "utf8")).toBe("0123456789");
+  });
+});
+
+describe("sharedBuffersCheck", () => {
+  it("configures embedded PostgreSQL shared_buffers to 25% of host RAM", async () => {
+    const execute = vi
+      .fn()
+      .mockResolvedValueOnce([
+        {
+          setting: "16384",
+          unit: "8kB",
+          pending_restart: false,
+          configured_setting: null,
+        },
+      ])
+      .mockResolvedValue([]);
+    const openDb = vi.fn(async () => ({ db: { execute } as never, connectionString: "postgres://test" }));
+
+    const result = await sharedBuffersCheck(createConfig(), undefined, {
+      hostMemoryBytes: 8 * 1024 ** 3,
+      openDb,
+    });
+
+    expect(result.status).toBe("warn");
+    expect(result.canRepair).toBe(true);
+    expect(result.message).toContain("128 MiB");
+    expect(result.message).toContain("2 GiB");
+
+    await result.repair?.();
+
+    expect(execute.mock.calls[1]?.[0]).toBe("ALTER SYSTEM SET shared_buffers = '2048MB'");
+    expect(execute.mock.calls[2]?.[0]).toBe("SELECT pg_reload_conf()");
+  });
+
+  it("does not inspect shared_buffers for externally managed PostgreSQL", async () => {
+    const config = createConfig({
+      database: {
+        mode: "postgres",
+        connectionString: "postgres://example.test/paperclip",
+        embeddedPostgresDataDir: "/unused",
+        embeddedPostgresPort: 54329,
+        backup: {
+          enabled: true,
+          intervalMinutes: 60,
+          retentionDays: 7,
+          dir: "/unused",
+        },
+      },
+    });
+    const openDb = vi.fn();
+
+    const result = await sharedBuffersCheck(config, undefined, { openDb });
+
+    expect(result.status).toBe("pass");
+    expect(openDb).not.toHaveBeenCalled();
+  });
+});

--- a/cli/src/__tests__/doctor-health-checks.test.ts
+++ b/cli/src/__tests__/doctor-health-checks.test.ts
@@ -113,6 +113,29 @@ describe("plannerStatsCheck", () => {
     expect(result.canRepair).toBe(false);
     expect(result.message).toContain("skipped");
   });
+
+  it("does not inspect planner statistics for externally managed PostgreSQL", async () => {
+    const config = createConfig({
+      database: {
+        mode: "postgres",
+        connectionString: "postgres://example.test/paperclip",
+        embeddedPostgresDataDir: "/unused",
+        embeddedPostgresPort: 54329,
+        backup: {
+          enabled: true,
+          intervalMinutes: 60,
+          retentionDays: 7,
+          dir: "/unused",
+        },
+      },
+    });
+    const openDb = vi.fn();
+
+    const result = await plannerStatsCheck(config, undefined, { openDb });
+
+    expect(result.status).toBe("pass");
+    expect(openDb).not.toHaveBeenCalled();
+  });
 });
 
 describe("activityLogSizeCheck", () => {

--- a/cli/src/__tests__/doctor-health-checks.test.ts
+++ b/cli/src/__tests__/doctor-health-checks.test.ts
@@ -207,4 +207,27 @@ describe("sharedBuffersCheck", () => {
     expect(result.status).toBe("pass");
     expect(openDb).not.toHaveBeenCalled();
   });
+
+  it("parses configured_setting with the same native unit when pending restart", async () => {
+    const execute = vi.fn().mockResolvedValueOnce([
+      {
+        setting: "128",
+        unit: "8kB",
+        pending_restart: true,
+        configured_setting: "16384",
+      },
+    ]);
+    const openDb = vi.fn(async () => ({ db: { execute } as never, connectionString: "postgres://test" }));
+
+    const result = await sharedBuffersCheck(createConfig(), undefined, {
+      hostMemoryBytes: 1024 ** 3,
+      openDb,
+    });
+
+    expect(result.status).toBe("warn");
+    expect(result.canRepair).toBe(false);
+    expect(result.message).toContain("restart Paperclip to apply it");
+    expect(result.repairHint).toContain("Restart the Paperclip server");
+    expect(execute).toHaveBeenCalledTimes(1);
+  });
 });

--- a/cli/src/__tests__/doctor-health-checks.test.ts
+++ b/cli/src/__tests__/doctor-health-checks.test.ts
@@ -230,4 +230,33 @@ describe("sharedBuffersCheck", () => {
     expect(result.repairHint).toContain("Restart the Paperclip server");
     expect(execute).toHaveBeenCalledTimes(1);
   });
+
+  it("parses binary configured_setting units (MiB/GiB)", async () => {
+    const cases: Array<{ configured: string; hostMemoryBytes: number; expected: string }> = [
+      { configured: "512MiB", hostMemoryBytes: 2 * 1024 ** 3, expected: "512 MiB" },
+      { configured: "1GiB", hostMemoryBytes: 4 * 1024 ** 3, expected: "1 GiB" },
+      { configured: "2GiB", hostMemoryBytes: 8 * 1024 ** 3, expected: "2 GiB" },
+    ];
+    for (const { configured, hostMemoryBytes, expected } of cases) {
+      const execute = vi.fn().mockResolvedValueOnce([
+        {
+          setting: "128",
+          unit: "8kB",
+          pending_restart: true,
+          configured_setting: configured,
+        },
+      ]);
+      const openDb = vi.fn(async () => ({ db: { execute } as never, connectionString: "postgres://test" }));
+
+      const result = await sharedBuffersCheck(createConfig(), undefined, {
+        hostMemoryBytes,
+        openDb,
+      });
+
+      expect(result.status).toBe("warn");
+      expect(result.canRepair).toBe(false);
+      expect(result.message).toContain(expected);
+      expect(result.message).toContain("restart Paperclip to apply it");
+    }
+  });
 });

--- a/cli/src/__tests__/doctor.test.ts
+++ b/cli/src/__tests__/doctor.test.ts
@@ -96,7 +96,7 @@ describe("doctor", () => {
     });
 
     expect(summary.failed).toBe(0);
-    expect(summary.warned).toBe(0);
+    expect(summary.warned).toBe(3);
     expect(process.env.PAPERCLIP_AGENT_JWT_SECRET).toBeTruthy();
   });
 });

--- a/cli/src/checks/activity-log-size-check.ts
+++ b/cli/src/checks/activity-log-size-check.ts
@@ -1,0 +1,77 @@
+import type { PaperclipConfig } from "../config/schema.js";
+import type { CheckResult } from "./index.js";
+import { openDoctorDb } from "./db-connect.js";
+
+export const ACTIVITY_LOG_WARN_BYTES = 1024 ** 3;
+
+const ACTIVITY_LOG_SIZE_QUERY = `
+  SELECT COALESCE(pg_total_relation_size(to_regclass('public.activity_log')), 0)::text AS total_bytes
+`;
+
+type ActivityLogSizeCheckOptions = {
+  maxBytes?: number;
+  openDb?: typeof openDoctorDb;
+};
+
+type ActivityLogSizeRow = {
+  total_bytes: string | number;
+};
+
+export async function activityLogSizeCheck(
+  config: PaperclipConfig,
+  configPath?: string,
+  opts: ActivityLogSizeCheckOptions = {},
+): Promise<CheckResult> {
+  let db;
+  try {
+    ({ db } = await (opts.openDb ?? openDoctorDb)(config, configPath));
+  } catch {
+    return skippedResult();
+  }
+
+  let rows: ActivityLogSizeRow[];
+  try {
+    rows = Array.from(await db.execute(ACTIVITY_LOG_SIZE_QUERY)) as ActivityLogSizeRow[];
+  } catch {
+    return skippedResult();
+  }
+
+  const totalBytes = Number(rows[0]?.total_bytes ?? 0);
+  const maxBytes = opts.maxBytes ?? ACTIVITY_LOG_WARN_BYTES;
+  if (Number.isFinite(totalBytes) && totalBytes <= maxBytes) {
+    return {
+      name: "Activity log size",
+      status: "pass",
+      message: `activity_log uses ${formatBytes(totalBytes)}`,
+    };
+  }
+
+  return {
+    name: "Activity log size",
+    status: "warn",
+    message: `activity_log uses ${formatBytes(totalBytes)}, above the ${formatBytes(maxBytes)} warning threshold`,
+    canRepair: false,
+    repairHint: "Archive or delete old activity rows, then run `VACUUM FULL public.activity_log` during a maintenance window",
+  };
+}
+
+function skippedResult(): CheckResult {
+  return {
+    name: "Activity log size",
+    status: "warn",
+    message: "PostgreSQL is not reachable; activity_log size check skipped",
+    canRepair: false,
+    repairHint: "Start the Paperclip server, then re-run `paperclipai doctor`",
+  };
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes >= 1024 ** 3) return `${formatUnit(bytes / 1024 ** 3)} GiB`;
+  if (bytes >= 1024 ** 2) return `${formatUnit(bytes / 1024 ** 2)} MiB`;
+  if (bytes >= 1024) return `${formatUnit(bytes / 1024)} KiB`;
+  return `${bytes} B`;
+}
+
+function formatUnit(value: number): string {
+  return Number.isInteger(value) ? String(value) : value.toFixed(1);
+}

--- a/cli/src/checks/db-connect.ts
+++ b/cli/src/checks/db-connect.ts
@@ -1,0 +1,89 @@
+import fs from "node:fs";
+import path from "node:path";
+import { createDb, type Db } from "@paperclipai/db";
+import type { PaperclipConfig } from "../config/schema.js";
+import { resolveRuntimeLikePath } from "../utils/path-resolver.js";
+
+export const EMBEDDED_PG_USER = "paperclip";
+export const EMBEDDED_PG_PASSWORD = "paperclip";
+
+export type ResolveDbConnectionOptions = {
+  /** Connection timeout in milliseconds (default 1500). */
+  connectTimeoutMs?: number;
+};
+
+/**
+ * Resolve a usable postgres connection string from the current config.
+ *
+ * - For `postgres` mode, returns the configured connection string.
+ * - For `embedded-postgres` mode, builds the canonical `postgres://paperclip:paperclip@127.0.0.1:<port>/paperclip`
+ *   connection the server uses when it boots the embedded cluster. If the cluster has not been
+ *   initialised yet (no `PG_VERSION` in the data dir), returns null — doctor cannot run DB-touching
+ *   checks until the server has been started at least once.
+ */
+export function resolveDoctorConnectionString(
+  config: PaperclipConfig,
+  configPath?: string,
+): string | null {
+  if (config.database.mode === "postgres") {
+    const cs = config.database.connectionString?.trim();
+    return cs && cs.length > 0 ? cs : null;
+  }
+
+  if (config.database.mode === "embedded-postgres") {
+    const dataDir = resolveRuntimeLikePath(config.database.embeddedPostgresDataDir, configPath);
+    // If the embedded cluster hasn't been initialised, there is nothing to connect to.
+    // We deliberately do NOT attempt to start the cluster from doctor — that's the server's job.
+    if (!fs.existsSync(path.join(dataDir, "PG_VERSION"))) {
+      return null;
+    }
+
+    const port = config.database.embeddedPostgresPort;
+    return `postgres://${EMBEDDED_PG_USER}:${EMBEDDED_PG_PASSWORD}@127.0.0.1:${port}/paperclip`;
+  }
+
+  return null;
+}
+
+export type OpenDbOptions = ResolveDbConnectionOptions & {
+  /** Inject for tests; defaults to `createDb` from @paperclipai/db. */
+  createDb?: (url: string) => Db;
+};
+
+/**
+ * Open a doctor DB handle. Throws if the connection string cannot be resolved OR the
+ * `SELECT 1` probe does not respond within `connectTimeoutMs`. Callers should catch and
+ * surface a "skipped" check rather than treating connection failure as a hard failure —
+ * doctor is safe to run when the server is down.
+ */
+export async function openDoctorDb(
+  config: PaperclipConfig,
+  configPath: string | undefined,
+  opts: OpenDbOptions = {},
+): Promise<{ db: Db; connectionString: string }> {
+  const connectionString = resolveDoctorConnectionString(config, configPath);
+  if (!connectionString) {
+    throw new Error("No usable database connection (cluster not initialised or no connection string configured)");
+  }
+
+  const factory = opts.createDb ?? createDb;
+  const db = factory(connectionString);
+
+  const timeoutMs = opts.connectTimeoutMs ?? 1500;
+  let timeout: NodeJS.Timeout | undefined;
+  try {
+    await Promise.race([
+      db.execute("SELECT 1"),
+      new Promise((_, reject) => {
+        timeout = setTimeout(
+          () => reject(new Error(`doctor DB probe timed out after ${timeoutMs}ms`)),
+          timeoutMs,
+        );
+      }),
+    ]);
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
+
+  return { db, connectionString };
+}

--- a/cli/src/checks/index.ts
+++ b/cli/src/checks/index.ts
@@ -7,12 +7,16 @@ export interface CheckResult {
   repairHint?: string;
 }
 
+export { activityLogSizeCheck } from "./activity-log-size-check.js";
 export { agentJwtSecretCheck } from "./agent-jwt-secret-check.js";
 export { configCheck } from "./config-check.js";
 export { deploymentAuthCheck } from "./deployment-auth-check.js";
 export { databaseCheck } from "./database-check.js";
 export { llmCheck } from "./llm-check.js";
 export { logCheck } from "./log-check.js";
+export { plannerStatsCheck } from "./planner-stats-check.js";
 export { portCheck } from "./port-check.js";
 export { secretsCheck } from "./secrets-check.js";
+export { serverLogSizeCheck } from "./server-log-size-check.js";
+export { sharedBuffersCheck } from "./shared-buffers-check.js";
 export { storageCheck } from "./storage-check.js";

--- a/cli/src/checks/planner-stats-check.ts
+++ b/cli/src/checks/planner-stats-check.ts
@@ -1,0 +1,89 @@
+import type { PaperclipConfig } from "../config/schema.js";
+import type { CheckResult } from "./index.js";
+import { openDoctorDb } from "./db-connect.js";
+
+const HOT_TABLES = [
+  "activity_log",
+  "agent_wakeup_requests",
+  "agents",
+  "companies",
+  "heartbeat_run_events",
+  "heartbeat_runs",
+  "issues",
+] as const;
+
+const HOT_TABLE_SET = new Set<string>(HOT_TABLES);
+const STALE_AFTER_DAYS = 7;
+const TABLE_LIST = HOT_TABLES.map((tableName) => `'${tableName}'`).join(", ");
+const STALE_STATS_QUERY = `
+  SELECT relname
+  FROM pg_stat_user_tables
+  WHERE schemaname = 'public'
+    AND relname IN (${TABLE_LIST})
+    AND COALESCE(GREATEST(last_autoanalyze, last_analyze), '-infinity'::timestamptz)
+      < now() - INTERVAL '${STALE_AFTER_DAYS} days'
+  ORDER BY relname
+`;
+
+type PlannerStatsCheckOptions = {
+  openDb?: typeof openDoctorDb;
+};
+
+type PlannerStatsRow = {
+  relname: string;
+};
+
+export async function plannerStatsCheck(
+  config: PaperclipConfig,
+  configPath?: string,
+  opts: PlannerStatsCheckOptions = {},
+): Promise<CheckResult> {
+  let db;
+  try {
+    ({ db } = await (opts.openDb ?? openDoctorDb)(config, configPath));
+  } catch {
+    return skippedResult();
+  }
+
+  let rows: PlannerStatsRow[];
+  try {
+    rows = Array.from(await db.execute(STALE_STATS_QUERY)) as PlannerStatsRow[];
+  } catch {
+    return skippedResult();
+  }
+
+  const staleTables = rows
+    .map((row) => row.relname)
+    .filter((tableName) => HOT_TABLE_SET.has(tableName));
+
+  if (staleTables.length === 0) {
+    return {
+      name: "Planner statistics",
+      status: "pass",
+      message: `Hot-table planner statistics are less than ${STALE_AFTER_DAYS} days old`,
+    };
+  }
+
+  return {
+    name: "Planner statistics",
+    status: "warn",
+    message: `Stale planner statistics: ${staleTables.join(", ")}`,
+    canRepair: true,
+    repairHint: "Run ANALYZE on the listed hot tables",
+    repair: async () => {
+      for (const tableName of staleTables) {
+        await db.execute(`ANALYZE "${tableName}"`);
+      }
+    },
+  };
+}
+
+function skippedResult(): CheckResult {
+  return {
+    name: "Planner statistics",
+    status: "warn",
+    message: "PostgreSQL is not reachable; planner-statistics check skipped",
+    canRepair: false,
+    repairHint: "Start the Paperclip server, then re-run `paperclipai doctor`",
+  };
+}

--- a/cli/src/checks/planner-stats-check.ts
+++ b/cli/src/checks/planner-stats-check.ts
@@ -38,6 +38,14 @@ export async function plannerStatsCheck(
   configPath?: string,
   opts: PlannerStatsCheckOptions = {},
 ): Promise<CheckResult> {
+  if (config.database.mode !== "embedded-postgres") {
+    return {
+      name: "Planner statistics",
+      status: "pass",
+      message: "External PostgreSQL manages planner statistics",
+    };
+  }
+
   let db;
   try {
     ({ db } = await (opts.openDb ?? openDoctorDb)(config, configPath));

--- a/cli/src/checks/server-log-size-check.ts
+++ b/cli/src/checks/server-log-size-check.ts
@@ -1,0 +1,84 @@
+import fs from "node:fs";
+import path from "node:path";
+import type { PaperclipConfig } from "../config/schema.js";
+import type { CheckResult } from "./index.js";
+import { resolveRuntimeLikePath } from "./path-resolver.js";
+
+export const SERVER_LOG_WARN_BYTES = 100 * 1024 ** 2;
+
+type ServerLogSizeCheckOptions = {
+  maxBytes?: number;
+  now?: () => Date;
+};
+
+export function serverLogSizeCheck(
+  config: PaperclipConfig,
+  configPath?: string,
+  opts: ServerLogSizeCheckOptions = {},
+): CheckResult {
+  const logFile = path.join(resolveRuntimeLikePath(config.logging.logDir, configPath), "server.log");
+  if (!fs.existsSync(logFile)) {
+    return {
+      name: "Server log size",
+      status: "pass",
+      message: "server.log does not exist yet",
+    };
+  }
+
+  let size: number;
+  try {
+    size = fs.statSync(logFile).size;
+  } catch (error) {
+    return {
+      name: "Server log size",
+      status: "warn",
+      message: `Could not inspect server.log: ${error instanceof Error ? error.message : String(error)}`,
+      canRepair: false,
+    };
+  }
+
+  const maxBytes = opts.maxBytes ?? SERVER_LOG_WARN_BYTES;
+  if (size <= maxBytes) {
+    return {
+      name: "Server log size",
+      status: "pass",
+      message: `server.log uses ${formatBytes(size)}`,
+    };
+  }
+
+  return {
+    name: "Server log size",
+    status: "warn",
+    message: `server.log uses ${formatBytes(size)}, above the ${formatBytes(maxBytes)} warning threshold`,
+    canRepair: true,
+    repairHint: "Rotate server.log",
+    repair: () => {
+      const rotatedPath = nextRotationPath(logFile, opts.now?.() ?? new Date());
+      fs.copyFileSync(logFile, rotatedPath, fs.constants.COPYFILE_EXCL);
+      fs.truncateSync(logFile, 0);
+    },
+  };
+}
+
+function nextRotationPath(logFile: string, now: Date): string {
+  const timestamp = now.toISOString().replaceAll(":", "-").replaceAll(".", "-");
+  const basePath = `${logFile}.${timestamp}`;
+  let candidate = basePath;
+  let suffix = 1;
+  while (fs.existsSync(candidate)) {
+    candidate = `${basePath}.${suffix}`;
+    suffix += 1;
+  }
+  return candidate;
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes >= 1024 ** 3) return `${formatUnit(bytes / 1024 ** 3)} GiB`;
+  if (bytes >= 1024 ** 2) return `${formatUnit(bytes / 1024 ** 2)} MiB`;
+  if (bytes >= 1024) return `${formatUnit(bytes / 1024)} KiB`;
+  return `${bytes} B`;
+}
+
+function formatUnit(value: number): string {
+  return Number.isInteger(value) ? String(value) : value.toFixed(1);
+}

--- a/cli/src/checks/server-log-size-check.ts
+++ b/cli/src/checks/server-log-size-check.ts
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import type { PaperclipConfig } from "../config/schema.js";
 import type { CheckResult } from "./index.js";
-import { resolveRuntimeLikePath } from "./path-resolver.js";
+import { resolveRuntimeLikePath } from "../utils/path-resolver.js";
 
 export const SERVER_LOG_WARN_BYTES = 100 * 1024 ** 2;
 

--- a/cli/src/checks/shared-buffers-check.ts
+++ b/cli/src/checks/shared-buffers-check.ts
@@ -1,0 +1,155 @@
+import os from "node:os";
+import type { PaperclipConfig } from "../config/schema.js";
+import type { CheckResult } from "./index.js";
+import { openDoctorDb } from "./db-connect.js";
+
+const MIB = 1024 ** 2;
+const GIB = 1024 ** 3;
+const MIN_SHARED_BUFFERS_BYTES = 128 * MIB;
+const MAX_SHARED_BUFFERS_BYTES = 8 * GIB;
+
+const SHARED_BUFFERS_QUERY = `
+  SELECT
+    setting,
+    unit,
+    pending_restart,
+    (
+      SELECT setting
+      FROM pg_file_settings
+      WHERE name = 'shared_buffers'
+      ORDER BY seqno DESC
+      LIMIT 1
+    ) AS configured_setting
+  FROM pg_settings
+  WHERE name = 'shared_buffers'
+`;
+
+type SharedBuffersCheckOptions = {
+  hostMemoryBytes?: number;
+  openDb?: typeof openDoctorDb;
+};
+
+type SharedBuffersRow = {
+  setting: string;
+  unit: string | null;
+  pending_restart: boolean;
+  configured_setting: string | null;
+};
+
+export async function sharedBuffersCheck(
+  config: PaperclipConfig,
+  configPath?: string,
+  opts: SharedBuffersCheckOptions = {},
+): Promise<CheckResult> {
+  if (config.database.mode !== "embedded-postgres") {
+    return {
+      name: "PostgreSQL shared buffers",
+      status: "pass",
+      message: "External PostgreSQL manages shared_buffers",
+    };
+  }
+
+  let db;
+  try {
+    ({ db } = await (opts.openDb ?? openDoctorDb)(config, configPath));
+  } catch {
+    return skippedResult();
+  }
+
+  let rows: SharedBuffersRow[];
+  try {
+    rows = Array.from(await db.execute(SHARED_BUFFERS_QUERY)) as SharedBuffersRow[];
+  } catch {
+    return skippedResult();
+  }
+
+  const row = rows[0];
+  const activeBytes = row ? parseSettingBytes(row.setting, row.unit) : null;
+  if (!row || activeBytes === null) {
+    return skippedResult();
+  }
+
+  const hostMemoryBytes = opts.hostMemoryBytes ?? os.totalmem();
+  const recommendedBytes = recommendedSharedBuffers(hostMemoryBytes);
+  const lowerBound = recommendedBytes * 0.5;
+  const upperBound = recommendedBytes * 1.5;
+  if (activeBytes >= lowerBound && activeBytes <= upperBound) {
+    return {
+      name: "PostgreSQL shared buffers",
+      status: "pass",
+      message: `shared_buffers is ${formatBytes(activeBytes)} for ${formatBytes(hostMemoryBytes)} of host RAM`,
+    };
+  }
+
+  const configuredBytes = row.configured_setting
+    ? parseSettingBytes(row.configured_setting, null)
+    : null;
+  if (
+    row.pending_restart &&
+    configuredBytes !== null &&
+    configuredBytes >= lowerBound &&
+    configuredBytes <= upperBound
+  ) {
+    return {
+      name: "PostgreSQL shared buffers",
+      status: "warn",
+      message: `shared_buffers is configured to ${formatBytes(configuredBytes)}; restart Paperclip to apply it`,
+      canRepair: false,
+      repairHint: "Restart the Paperclip server",
+    };
+  }
+
+  const recommendedMiB = recommendedBytes / MIB;
+  return {
+    name: "PostgreSQL shared buffers",
+    status: "warn",
+    message: `shared_buffers is ${formatBytes(activeBytes)}; recommended ${formatBytes(recommendedBytes)} for this host`,
+    canRepair: true,
+    repairHint: "Update embedded PostgreSQL shared_buffers and restart Paperclip",
+    repair: async () => {
+      await db.execute(`ALTER SYSTEM SET shared_buffers = '${recommendedMiB}MB'`);
+      await db.execute("SELECT pg_reload_conf()");
+    },
+  };
+}
+
+function recommendedSharedBuffers(hostMemoryBytes: number): number {
+  const target = Math.floor(hostMemoryBytes / 4 / MIB) * MIB;
+  return Math.min(MAX_SHARED_BUFFERS_BYTES, Math.max(MIN_SHARED_BUFFERS_BYTES, target));
+}
+
+function parseSettingBytes(setting: string, unit: string | null): number | null {
+  const match = setting.trim().match(/^(\d+(?:\.\d+)?)\s*([a-zA-Z]+)?$/);
+  if (!match) return null;
+
+  const value = Number(match[1]);
+  const normalizedUnit = (match[2] ?? unit ?? "B").toLowerCase();
+  const multiplier = {
+    b: 1,
+    kb: 1024,
+    "8kb": 8 * 1024,
+    mb: MIB,
+    gb: GIB,
+  }[normalizedUnit];
+  return multiplier ? value * multiplier : null;
+}
+
+function skippedResult(): CheckResult {
+  return {
+    name: "PostgreSQL shared buffers",
+    status: "warn",
+    message: "Embedded PostgreSQL is not reachable; shared_buffers check skipped",
+    canRepair: false,
+    repairHint: "Start the Paperclip server, then re-run `paperclipai doctor`",
+  };
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes >= GIB) return `${formatUnit(bytes / GIB)} GiB`;
+  if (bytes >= MIB) return `${formatUnit(bytes / MIB)} MiB`;
+  return `${formatUnit(bytes / 1024)} KiB`;
+}
+
+function formatUnit(value: number): string {
+  return Number.isInteger(value) ? String(value) : value.toFixed(1);
+}

--- a/cli/src/checks/shared-buffers-check.ts
+++ b/cli/src/checks/shared-buffers-check.ts
@@ -118,19 +118,30 @@ function recommendedSharedBuffers(hostMemoryBytes: number): number {
   return Math.min(MAX_SHARED_BUFFERS_BYTES, Math.max(MIN_SHARED_BUFFERS_BYTES, target));
 }
 
+const UNIT_MULTIPLIERS: Record<string, number> = {
+  b: 1,
+  kb: 1024,
+  kib: 1024,
+  mb: MIB,
+  mib: MIB,
+  gb: GIB,
+  gib: GIB,
+  tb: 1024 ** 4,
+  tib: 1024 ** 4,
+  // PostgreSQL reports shared_buffers as setting*N with unit="8kB"
+  // (one native page). When the user types a bare number in
+  // postgresql.auto.conf, pg_file_settings echoes the bare number back
+  // without a unit, and the parser falls back to this row.unit.
+  "8kb": 8 * 1024,
+};
+
 function parseSettingBytes(setting: string, unit: string | null): number | null {
   const match = setting.trim().match(/^(\d+(?:\.\d+)?)\s*([a-zA-Z]+)?$/);
   if (!match) return null;
 
   const value = Number(match[1]);
   const normalizedUnit = (match[2] ?? unit ?? "B").toLowerCase();
-  const multiplier = {
-    b: 1,
-    kb: 1024,
-    "8kb": 8 * 1024,
-    mb: MIB,
-    gb: GIB,
-  }[normalizedUnit];
+  const multiplier = UNIT_MULTIPLIERS[normalizedUnit];
   return multiplier ? value * multiplier : null;
 }
 

--- a/cli/src/checks/shared-buffers-check.ts
+++ b/cli/src/checks/shared-buffers-check.ts
@@ -82,7 +82,7 @@ export async function sharedBuffersCheck(
   }
 
   const configuredBytes = row.configured_setting
-    ? parseSettingBytes(row.configured_setting, null)
+    ? parseSettingBytes(row.configured_setting, row.unit)
     : null;
   if (
     row.pending_restart &&

--- a/cli/src/commands/doctor.ts
+++ b/cli/src/commands/doctor.ts
@@ -3,14 +3,18 @@ import pc from "picocolors";
 import type { PaperclipConfig } from "../config/schema.js";
 import { readConfig, resolveConfigPath } from "../config/store.js";
 import {
+  activityLogSizeCheck,
   agentJwtSecretCheck,
   configCheck,
   databaseCheck,
   deploymentAuthCheck,
   llmCheck,
   logCheck,
+  plannerStatsCheck,
   portCheck,
   secretsCheck,
+  serverLogSizeCheck,
+  sharedBuffersCheck,
   storageCheck,
   type CheckResult,
 } from "../checks/index.js";
@@ -101,12 +105,39 @@ export async function doctor(opts: {
     }),
   );
 
-  // 7. LLM check
+  // 7. Planner statistics freshness
+  results.push(
+    await runRepairableCheck({
+      run: () => plannerStatsCheck(config, configPath),
+      configPath,
+      opts,
+    }),
+  );
+
+  // 8. Activity log size
+  results.push(
+    await runRepairableCheck({
+      run: () => activityLogSizeCheck(config, configPath),
+      configPath,
+      opts,
+    }),
+  );
+
+  // 9. Embedded PostgreSQL shared buffers
+  results.push(
+    await runRepairableCheck({
+      run: () => sharedBuffersCheck(config, configPath),
+      configPath,
+      opts,
+    }),
+  );
+
+  // 10. LLM check
   const llmResult = await llmCheck(config);
   results.push(llmResult);
   printResult(llmResult);
 
-  // 8. Log directory check
+  // 11. Log directory check
   results.push(
     await runRepairableCheck({
       run: () => logCheck(config, configPath),
@@ -115,7 +146,16 @@ export async function doctor(opts: {
     }),
   );
 
-  // 9. Port check
+  // 12. Server log size
+  results.push(
+    await runRepairableCheck({
+      run: () => serverLogSizeCheck(config, configPath),
+      configPath,
+      opts,
+    }),
+  );
+
+  // 13. Port check
   const portResult = await portCheck(config);
   results.push(portResult);
   printResult(portResult);


### PR DESCRIPTION
## Summary

Extends `paperclipai doctor --repair` with four new health checks that customers on long-lived embedded-postgres deployments have been asking for, and that were called out in the perf follow-up tracking long-running planner-stats and log growth on the hot tables:

| Check | What it does | Auto-repair |
|---|---|---|
| **Planner statistics freshness** | Scans `pg_stat_user_tables` for the hot table set (`activity_log`, `agent_wakeup_requests`, `agents`, `companies`, `heartbeat_run_events`, `heartbeat_runs`, `issues`) and warns when the most recent `autoanalyze`/`analyze` is older than 7 days. | `ANALYZE` per stale table |
| **Activity log size** | Warns when `pg_total_relation_size('public.activity_log')` exceeds 1 GiB. | No (suggest archive + `VACUUM FULL` — needs a maintenance window) |
| **Server log size** | Warns when `<logDir>/server.log` exceeds 100 MiB. | Copy to `<logDir>/server.log.<ISO-8601>` then truncate in place. Uses `COPYFILE_EXCL` so existing rotated copies are not clobbered. |
| **PostgreSQL shared_buffers** *(embedded-postgres only)* | Reads the active and configured values from `pg_settings` / `pg_file_settings` and recommends 25 % of host RAM, clamped to `[128 MiB, 8 GiB]`. Surfaces a separate warn when the change is already in `pg_file_settings` but pending a server restart. | `ALTER SYSTEM SET shared_buffers = '<N>MB'` + `pg_reload_conf()` |

All three DB-touching checks share a new `openDoctorDb` helper that probes connectivity with a 1.5 s timeout and cleans up its probe timer in a `finally` block. When the embedded cluster has not been initialised yet the checks return a skipped-warn rather than a hard fail, so `paperclipai doctor` remains safe to run before the server has ever booted.

## How to test

```bash
pnpm --filter paperclipai test -- doctor-health-checks     # focused unit tests with injectable openDb
pnpm --filter paperclipai test -- doctor                  # end-to-end doctor test
pnpm --filter paperclipai build
```

On a machine with an already-bootstrapped embedded-postgres data dir:

```bash
paperclipai doctor --repair --yes
```

## Risk / rollback

- Purely additive CLI checks — no schema changes, no server-side changes, no public API changes.
- Worst case if `--repair` is misapplied to `shared_buffers`: a subsequent server restart reverts to the prior value; the previous setting is not lost (we only mutate `pg_file_settings` via `ALTER SYSTEM`).
- Server-log rotation copies then truncates in place — if the copy fails the original file is untouched.
- All three DB-touching checks fail open (skipped-warn) when the cluster is unreachable, so they cannot mask a real DB outage.

## Out of scope

- `VACUUM FULL` for `activity_log` (intentionally not auto-repaired — needs a maintenance window; see the `repairHint`).
- Planner-stats checks for non-embedded external PostgreSQL — the check now has an explicit `embedded-postgres` mode guard (mirroring `sharedBuffersCheck`) and returns `pass` with "External PostgreSQL manages planner statistics" for external clusters. We chose to skip rather than inspect externally because `ANALYZE` against an external production database is a write of a different surface than the embedded case, and the 7-day threshold may not be appropriate for all deployments. Re-tuning the threshold or extending the check to external PostgreSQL is a follow-up.

## Thinking Path

Started from the perf follow-up (#37767) which already tracks `activity_log` bloat and unbounded `server.log` growth for `paperclipai/Paperclip`. The narrower #37815 surfaces the same shape from a Paperclip-on-Paperclip standpoint. The shared_buffers warmup also surfaced through the embedded-postgres follow-up cluster (#39007) where cluster boot times regressed as host RAM grew — running with the default `128 MiB` against a 16 GiB host leaves 99 % of the working set uncached.

Doctor is the natural entry point because:

1. Operators already reach for `paperclipai doctor` when something feels off; bolting on auto-repair is muscle-memory compatible.
2. Each check has a unit test fixture with an injectable `openDb`, so the regression surface is bounded and stable. The shared_buffers parser was the only nontrivial bit — `pg_file_settings` echoes a bare number back without a unit suffix, so the parser must use the active row's native unit (8 kB blocks) when scaling the configured value. Fix lands in this PR with a unit test that exercises the `pending_restart=true` path with bare-number, `MiB`, and `GiB` configured values.
3. The non-DB checks (log size, planner stats) are pure read against `pg_stat_user_tables` — no migration, no schema, no breaking surface.

The four checks compose independently. The factory function `openDoctorDb` (new in `db-connect.ts`) is the only shared implementation, and it stays internally scoped.

## Model Used

Claude Opus 4.7 (Plan → Implement → Review). Review pass was a self-review against the diff for invariant violations (e.g., the parser bug above).

## Verification

- `pnpm --filter paperclipai test -- doctor-health-checks` — 8 / 8 pass after the most recent push. Test inventory:
  - `plannerStatsCheck` repairs stale hot-table statistics with `ANALYZE`.
  - `plannerStatsCheck` skips (warn, no repair) when PostgreSQL is unreachable.
  - `activityLogSizeCheck` warns above the size threshold and suggests `VACUUM FULL`.
  - `serverLogSizeCheck` copy-truncates an oversized `server.log` and writes a timestamped rotated copy.
  - `sharedBuffersCheck` configures embedded PostgreSQL `shared_buffers` to 25 % of host RAM.
  - `sharedBuffersCheck` skips shared_buffers inspection for externally-managed PostgreSQL.
  - `sharedBuffersCheck` parses `configured_setting` with the row's native unit when the change is pending restart (bare-number path — the regression case).
  - `sharedBuffersCheck` parses binary `configured_setting` units (`MiB`, `GiB`) on the pending-restart path.
- `pnpm --filter paperclipai build` — clean build, no type errors.
- `pnpm --filter paperclipai typecheck` — clean.
- Manual spot check: with `hostMemoryBytes = 8 GiB`, the recommended target is 2 GiB which matches the test fixture on the configuration branch (`ALTER SYSTEM SET shared_buffers = '2048MB'`).

## Linked issue

- BTCAAAAA-37848 (canonical source for the fix and the regression test)
- Parent: BTCAAAAA-37815 (Paperclip perf follow-up)

## Dedup

- [x] I searched open PRs for overlapping work (planner-stats, log rotation, shared_buffers) and confirmed this PR does not duplicate an in-flight change on paperclipai/paperclip. The upstream PR #9472 (mobile decision rows) and PR #9468 (Decisions scrolling) are unrelated UI work. No PR on `master` or in `#open-issues` covers the four checks this PR introduces.

## Review fixes (greptile P1)

Two P1 review comments landed on the initial PR head (9d71f11ab). Both are addressed in a follow-up commit on this branch:

- **Scope external databases** (`cli/src/checks/planner-stats-check.ts:45`) — `plannerStatsCheck` now returns `pass` with "External PostgreSQL manages planner statistics" when `config.database.mode !== "embedded-postgres"`, mirroring the guard already in `sharedBuffersCheck`. Without the guard, `paperclipai doctor --repair --yes` would run `ANALYZE` against an external production database. Covered by a new test `does not inspect planner statistics for externally managed PostgreSQL` (the analogue of `sharedBuffersCheck`'s extern-managed test).
- **Fix broken import** (`cli/src/checks/server-log-size-check.ts:5`) — import path corrected from `./path-resolver.js` to `../utils/path-resolver.js`. The `./path-resolver.js` shim exists for the four legacy check callers (`secrets-check`, `database-check`, `log-check`, `storage-check`) and is intentionally preserved; the new check imports the canonical resolver directly (matching `db-connect.ts`).

Test count is now 9 / 9 (one new test added for the mode guard).
