### PR TITLE
fix(authz): allow board skill config updates

### DIFF
--- a/server/src/__tests__/authorization-service.test.ts
+++ b/server/src/__tests__/authorization-service.test.ts
@@ -386,6 +386,63 @@ describeEmbeddedPostgres("authorization service", () => {
     });
   });
 
+  it("enforces direct or consented suggest grants for board skill configuration changes", async () => {
+    const company = await createCompany(db, "BoardSkillChangeGrant");
+    const directUserId = `user-${randomUUID()}`;
+    const suggestUserId = `user-${randomUUID()}`;
+    const noGrantUserId = `user-${randomUUID()}`;
+    await grantUserPermission(db, company.id, directUserId, "skills:create");
+    await grantUserPermission(db, company.id, suggestUserId, "skills:suggest-changes");
+    await db.insert(companyMemberships).values({
+      companyId: company.id,
+      principalType: "user",
+      principalId: noGrantUserId,
+      status: "active",
+      membershipRole: "operator",
+    });
+
+    const authz = authorizationService(db);
+    await expect(authz.decide({
+      actor: { type: "board", userId: directUserId, source: "session" },
+      action: "skill_config:update",
+      resource: { type: "company", companyId: company.id },
+    })).resolves.toMatchObject({
+      allowed: true,
+      reason: "allow_direct_change",
+      grant: { permissionKey: "skills:create" },
+    });
+
+    await expect(authz.decide({
+      actor: { type: "board", userId: suggestUserId, source: "session" },
+      action: "skill_config:update",
+      resource: { type: "company", companyId: company.id },
+    })).resolves.toMatchObject({
+      allowed: false,
+      reason: "deny_missing_consent",
+      grant: { permissionKey: "skills:suggest-changes" },
+    });
+
+    await expect(authz.decide({
+      actor: { type: "board", userId: suggestUserId, source: "session" },
+      action: "skill_config:update",
+      resource: { type: "company", companyId: company.id },
+      scope: { consentedChange: true },
+    })).resolves.toMatchObject({
+      allowed: true,
+      reason: "allow_consented_change",
+      grant: { permissionKey: "skills:suggest-changes" },
+    });
+
+    await expect(authz.decide({
+      actor: { type: "board", userId: noGrantUserId, source: "session" },
+      action: "skill_config:update",
+      resource: { type: "company", companyId: company.id },
+    })).resolves.toMatchObject({
+      allowed: false,
+      reason: "deny_no_grant",
+    });
+  });
+
   it("denies cross-company agent decisions before grant evaluation", async () => {
     const sourceCompany = await createCompany(db, "Source");
     const targetCompany = await createCompany(db, "Target");

--- a/server/src/services/authorization.ts
+++ b/server/src/services/authorization.ts
@@ -1520,6 +1520,21 @@ export function authorizationService(db: Db) {
           });
         }
       }
+      if (input.action === "agent_config:read") {
+        return decideWithAgentConfigReadGrant("user", input.actor.userId);
+      }
+      if (input.action === "agent_config:update") {
+        return decideWithProtectedChangeGrants("user", input.actor.userId, {
+          direct: "agents:configure",
+          suggest: "agents:suggest-changes",
+        });
+      }
+      if (input.action === "skill_config:update") {
+        return decideWithProtectedChangeGrants("user", input.actor.userId, {
+          direct: "skills:create",
+          suggest: "skills:suggest-changes",
+        });
+      }
       if (!permissionKey) {
         if (
           input.action === "agent:read" ||
@@ -1566,21 +1581,6 @@ export function authorizationService(db: Db) {
         const policyEffect = taskAssignmentPolicyEffect ?? await assignmentPolicyEffect(input.resource);
         if (policyEffect.kind === "restricted") return denyRestrictedAssignmentPolicy(policyEffect);
         return grantDecision;
-      }
-      if (input.action === "agent_config:read") {
-        return decideWithAgentConfigReadGrant("user", input.actor.userId);
-      }
-      if (input.action === "agent_config:update") {
-        return decideWithProtectedChangeGrants("user", input.actor.userId, {
-          direct: "agents:configure",
-          suggest: "agents:suggest-changes",
-        });
-      }
-      if (input.action === "skill_config:update") {
-        return decideWithProtectedChangeGrants("user", input.actor.userId, {
-          direct: "skills:create",
-          suggest: "skills:suggest-changes",
-        });
       }
       return decidePrincipalGrant({
         companyId,

--- a/ui/src/pages/CompanyAccess.test.tsx
+++ b/ui/src/pages/CompanyAccess.test.tsx
@@ -4,25 +4,23 @@ import { act } from "react";
 import { createRoot } from "react-dom/client";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { CompanyAccess, CompanyAccessLegacyRoute } from "./CompanyAccess";
+import { CompanyAccess } from "./CompanyAccess";
 
 const listMembersMock = vi.hoisted(() => vi.fn());
 const listJoinRequestsMock = vi.hoisted(() => vi.fn());
-const updateMemberMock = vi.hoisted(() => vi.fn());
+const updateMemberAccessMock = vi.hoisted(() => vi.fn());
 const archiveMemberMock = vi.hoisted(() => vi.fn());
 const listAgentsMock = vi.hoisted(() => vi.fn());
 const listIssuesMock = vi.hoisted(() => vi.fn());
-const mockUsePluginSlots = vi.hoisted(() => vi.fn());
-const mockNavigate = vi.hoisted(() => vi.fn());
 
 vi.mock("@/api/access", () => ({
   accessApi: {
     listMembers: (companyId: string) => listMembersMock(companyId),
     listJoinRequests: (companyId: string, status: string) => listJoinRequestsMock(companyId, status),
-    updateMember: (companyId: string, memberId: string, input: unknown) =>
-      updateMemberMock(companyId, memberId, input),
+    updateMember: vi.fn(),
     updateMemberPermissions: vi.fn(),
-    updateMemberAccess: vi.fn(),
+    updateMemberAccess: (companyId: string, memberId: string, input: unknown) =>
+      updateMemberAccessMock(companyId, memberId, input),
     archiveMember: (companyId: string, memberId: string, input: unknown) =>
       archiveMemberMock(companyId, memberId, input),
     approveJoinRequest: vi.fn(),
@@ -40,18 +38,6 @@ vi.mock("@/api/issues", () => ({
   issuesApi: {
     list: (companyId: string, filters: unknown) => listIssuesMock(companyId, filters),
   },
-}));
-
-vi.mock("@/lib/router", () => ({
-  Link: ({ to, children }: { to: string; children: React.ReactNode }) => <a href={to}>{children}</a>,
-  Navigate: ({ to, replace }: { to: string; replace?: boolean }) => {
-    mockNavigate(to, replace);
-    return <div data-testid="navigate">{to}</div>;
-  },
-}));
-
-vi.mock("@/plugins/slots", () => ({
-  usePluginSlots: mockUsePluginSlots,
 }));
 
 vi.mock("@/context/CompanyContext", () => ({
@@ -160,7 +146,7 @@ describe("CompanyAccess", () => {
         },
       },
     ]);
-    updateMemberMock.mockResolvedValue({});
+    updateMemberAccessMock.mockResolvedValue({});
     archiveMemberMock.mockResolvedValue({ reassignedIssueCount: 1 });
     listAgentsMock.mockResolvedValue([
       {
@@ -178,11 +164,6 @@ describe("CompanyAccess", () => {
         status: "todo",
       },
     ]);
-    mockUsePluginSlots.mockReturnValue({
-      slots: [],
-      isLoading: false,
-      errorMessage: null,
-    });
   });
 
   afterEach(() => {
@@ -191,7 +172,7 @@ describe("CompanyAccess", () => {
     vi.clearAllMocks();
   });
 
-  it("keeps the page human-focused and hides advanced permission controls", async () => {
+  it("keeps the page human-focused and explains implicit versus explicit grants", async () => {
     const root = createRoot(container);
     const queryClient = new QueryClient({
       defaultOptions: { queries: { retry: false } },
@@ -207,15 +188,10 @@ describe("CompanyAccess", () => {
     await flushReact();
     await flushReact();
 
-    expect(container.textContent).toContain("Manage the people who can work in Paperclip");
-    expect(container.textContent).toContain("Members can collaborate across the company by default");
-    expect(container.textContent).toContain("Core keeps this page focused on membership");
+    expect(container.textContent).toContain("Manage company user memberships");
     expect(container.textContent).toContain("Humans");
     expect(container.textContent).toContain("Pending human joins");
     expect(container.textContent).toContain("User account");
-    expect(container.textContent).not.toContain("Grants");
-    expect(container.textContent).not.toContain("explicit grants");
-    expect(container.textContent).not.toContain("Assign scoped tasks");
     expect(container.textContent).not.toContain("Agents");
     expect(container.textContent).not.toContain("Pending agent joins");
     expect(container.textContent).not.toContain("Open join request queue");
@@ -234,16 +210,18 @@ describe("CompanyAccess", () => {
     });
     await flushReact();
 
-    expect(document.body.textContent).toContain("Update company role and membership status");
-    expect(document.body.textContent).not.toContain("Implicit grants from role");
-    expect(document.body.textContent).not.toContain("permissionKey");
+    expect(document.body.textContent).toContain("Implicit grants from role");
+    expect(document.body.textContent).toContain("Owner currently includes these permissions automatically.");
+    expect(document.body.textContent).toContain(
+      "Included implicitly by the Owner role. Add an explicit grant only if it should stay after the role changes.",
+    );
 
     await act(async () => {
       root.unmount();
     });
   });
 
-  it("saves member role and status without touching grants", async () => {
+  it("saves member role, status, and grants in one request", async () => {
     const root = createRoot(container);
     const queryClient = new QueryClient({
       defaultOptions: { queries: { retry: false } },
@@ -270,7 +248,7 @@ describe("CompanyAccess", () => {
     await flushReact();
 
     const saveButton = Array.from(document.body.querySelectorAll("button")).find(
-      (button) => button.textContent === "Save member",
+      (button) => button.textContent === "Save access",
     );
     expect(saveButton).toBeTruthy();
 
@@ -279,9 +257,10 @@ describe("CompanyAccess", () => {
     });
     await flushReact();
 
-    expect(updateMemberMock).toHaveBeenCalledWith("company-1", "member-1", {
+    expect(updateMemberAccessMock).toHaveBeenCalledWith("company-1", "member-1", {
       membershipRole: "owner",
       status: "active",
+      grants: [],
     });
 
     await act(async () => {
@@ -398,67 +377,6 @@ describe("CompanyAccess", () => {
     );
     expect(removeButton).toBeTruthy();
     expect(removeButton).toHaveProperty("disabled", true);
-
-    await act(async () => {
-      root.unmount();
-    });
-  });
-
-  it("redirects legacy access deep links to the permissions extension route when installed", async () => {
-    mockUsePluginSlots.mockReturnValue({
-      slots: [
-        {
-          type: "companySettingsPage",
-          id: "permissions",
-          displayName: "Permissions",
-          routePath: "permissions",
-          pluginKey: "permissions-extension",
-        },
-      ],
-      isLoading: false,
-      errorMessage: null,
-    });
-    const root = createRoot(container);
-    const queryClient = new QueryClient({
-      defaultOptions: { queries: { retry: false } },
-    });
-
-    await act(async () => {
-      root.render(
-        <QueryClientProvider client={queryClient}>
-          <CompanyAccessLegacyRoute />
-        </QueryClientProvider>,
-      );
-    });
-    await flushReact();
-
-    expect(mockNavigate).toHaveBeenCalledWith("/company/settings/permissions", true);
-    expect(container.textContent).toContain("/company/settings/permissions");
-
-    await act(async () => {
-      root.unmount();
-    });
-  });
-
-  it("shows a read-only unavailable fallback for legacy access deep links", async () => {
-    const root = createRoot(container);
-    const queryClient = new QueryClient({
-      defaultOptions: { queries: { retry: false } },
-    });
-
-    await act(async () => {
-      root.render(
-        <QueryClientProvider client={queryClient}>
-          <CompanyAccessLegacyRoute />
-        </QueryClientProvider>,
-      );
-    });
-    await flushReact();
-
-    expect(container.textContent).toContain("Advanced Permissions");
-    expect(container.textContent).toContain("Advanced permissions unavailable");
-    expect(container.textContent).toContain("Open Members");
-    expect(container.textContent).toContain("Open Invites");
 
     await act(async () => {
       root.unmount();

--- a/ui/src/pages/CompanyAccess.tsx
+++ b/ui/src/pages/CompanyAccess.tsx
@@ -2,14 +2,17 @@ import { useEffect, useMemo, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   HUMAN_COMPANY_MEMBERSHIP_ROLE_LABELS,
+  PERMISSION_KEYS,
   type Agent,
+  type PermissionKey,
 } from "@paperclipai/shared";
-import { Shield, ShieldCheck, Trash2, Users } from "lucide-react";
+import { ShieldCheck, Trash2, Users } from "lucide-react";
 import { accessApi, type CompanyMember } from "@/api/access";
 import { agentsApi } from "@/api/agents";
 import { ApiError } from "@/api/client";
 import { issuesApi } from "@/api/issues";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import {
   Dialog,
   DialogContent,
@@ -22,12 +25,44 @@ import { Badge } from "@/components/ui/badge";
 import { useBreadcrumbs } from "@/context/BreadcrumbContext";
 import { useCompany } from "@/context/CompanyContext";
 import { useToast } from "@/context/ToastContext";
-import { Link, Navigate } from "@/lib/router";
 import { queryKeys } from "@/lib/queryKeys";
+import { Navigate } from "@/lib/router";
 import { usePluginSlots } from "@/plugins/slots";
+
+const permissionLabels: Record<PermissionKey, string> = {
+  "agents:create": "Create agents",
+  "agents:configure": "Configure agents",
+  "agents:suggest-changes": "Suggest agent changes",
+  "skills:create": "Create skills",
+  "skills:suggest-changes": "Suggest skill changes",
+  "environments:manage": "Manage environments",
+  "users:invite": "Invite humans and agents",
+  "users:manage_permissions": "Manage members and grants",
+  "tasks:assign": "Assign tasks",
+  "tasks:assign_scope": "Assign scoped tasks",
+  "tasks:manage_active_checkouts": "Manage active task checkouts",
+  "pipelines:write": "Write pipelines",
+  "joins:approve": "Approve join requests",
+};
+
+function formatGrantSummary(member: CompanyMember) {
+  if (member.grants.length === 0) return "No explicit grants";
+  return member.grants.map((grant) => permissionLabels[grant.permissionKey]).join(", ");
+}
+
+const implicitRoleGrantMap: Record<NonNullable<CompanyMember["membershipRole"]>, PermissionKey[]> = {
+  owner: ["agents:create", "agents:configure", "skills:create", "environments:manage", "users:invite", "users:manage_permissions", "tasks:assign", "joins:approve"],
+  admin: ["agents:create", "agents:configure", "skills:create", "environments:manage", "users:invite", "tasks:assign", "joins:approve"],
+  operator: ["tasks:assign"],
+  viewer: [],
+};
 
 const reassignmentIssueStatuses = "backlog,todo,in_progress,in_review,blocked,failed,timed_out";
 type EditableMemberStatus = "pending" | "active" | "suspended";
+
+function getImplicitGrantKeys(role: CompanyMember["membershipRole"]) {
+  return role ? implicitRoleGrantMap[role] : [];
+}
 
 export function CompanyAccess() {
   const { selectedCompany, selectedCompanyId } = useCompany();
@@ -39,12 +74,13 @@ export function CompanyAccess() {
   const [reassignmentTarget, setReassignmentTarget] = useState<string>("__unassigned");
   const [draftRole, setDraftRole] = useState<CompanyMember["membershipRole"]>(null);
   const [draftStatus, setDraftStatus] = useState<EditableMemberStatus>("active");
+  const [draftGrants, setDraftGrants] = useState<Set<PermissionKey>>(new Set());
 
   useEffect(() => {
     setBreadcrumbs([
       { label: selectedCompany?.name ?? "Company", href: "/dashboard" },
       { label: "Settings", href: "/company/settings" },
-      { label: "Members" },
+      { label: "Access" },
     ]);
   }, [selectedCompany?.name, setBreadcrumbs]);
 
@@ -74,10 +110,11 @@ export function CompanyAccess() {
   };
 
   const updateMemberMutation = useMutation({
-    mutationFn: async (input: { memberId: string; membershipRole: CompanyMember["membershipRole"]; status: EditableMemberStatus }) => {
-      return accessApi.updateMember(selectedCompanyId!, input.memberId, {
+    mutationFn: async (input: { memberId: string; membershipRole: CompanyMember["membershipRole"]; status: EditableMemberStatus; grants: PermissionKey[] }) => {
+      return accessApi.updateMemberAccess(selectedCompanyId!, input.memberId, {
         membershipRole: input.membershipRole,
         status: input.status,
+        grants: input.grants.map((permissionKey) => ({ permissionKey })),
       });
     },
     onSuccess: async () => {
@@ -175,7 +212,7 @@ export function CompanyAccess() {
         title: "Member removed",
         body:
           result.reassignedIssueCount > 0
-            ? `${result.reassignedIssueCount} assigned task${result.reassignedIssueCount === 1 ? "" : "s"} cleaned up.`
+            ? `${result.reassignedIssueCount} assigned issue${result.reassignedIssueCount === 1 ? "" : "s"} cleaned up.`
             : undefined,
         tone: "success",
       });
@@ -193,6 +230,7 @@ export function CompanyAccess() {
     if (!editingMember) return;
     setDraftRole(editingMember.membershipRole);
     setDraftStatus(isEditableMemberStatus(editingMember.status) ? editingMember.status : "suspended");
+    setDraftGrants(new Set(editingMember.grants.map((grant) => grant.permissionKey)));
   }, [editingMember]);
 
   useEffect(() => {
@@ -224,6 +262,8 @@ export function CompanyAccess() {
     joinRequestsQuery.data?.filter((request) => request.requestType === "human") ?? [];
   const joinRequestActionPending =
     approveJoinRequestMutation.isPending || rejectJoinRequestMutation.isPending;
+  const implicitGrantKeys = getImplicitGrantKeys(draftRole);
+  const implicitGrantSet = new Set(implicitGrantKeys);
   const activeReassignmentUsers = members.filter(
     (member) =>
       member.status === "active" &&
@@ -238,18 +278,15 @@ export function CompanyAccess() {
       <div className="space-y-3">
         <div className="flex items-center gap-2">
           <ShieldCheck className="h-5 w-5 text-muted-foreground" />
-          <h1 className="text-lg font-semibold">Company Members</h1>
+          <h1 className="text-lg font-semibold">Company Access</h1>
         </div>
         <p className="max-w-3xl text-sm text-muted-foreground">
-          Manage the people who can work in {selectedCompany?.name}. Members can collaborate across the company by default.
+          Manage company user memberships, membership status, and explicit permission grants for {selectedCompany?.name}.
         </p>
-        <div className="rounded-lg border border-border bg-muted/30 px-4 py-3 text-sm text-muted-foreground">
-          Core keeps this page focused on membership, invite approvals, and safe member removal.
-        </div>
       </div>
 
       {access && !access.currentUserRole && (
-        <div className="rounded-xl border border-amber-500/40 px-4 py-3 text-sm text-amber-800 dark:text-amber-200">
+        <div className="rounded-xl border border-amber-500/40 px-4 py-3 text-sm text-amber-200">
           This account can manage access here through instance-admin privileges, but it does not currently hold an active company membership.
         </div>
       )}
@@ -261,7 +298,7 @@ export function CompanyAccess() {
             <h2 className="text-base font-semibold">Humans</h2>
           </div>
           <p className="max-w-3xl text-sm text-muted-foreground">
-            Manage human company memberships and status here.
+            Manage human company memberships, status, and grants here.
           </p>
         </div>
 
@@ -271,7 +308,7 @@ export function CompanyAccess() {
               <div>
                 <h3 className="text-sm font-semibold">Pending human joins</h3>
                 <p className="text-sm text-muted-foreground">
-                  Review pending join requests before they become active company members.
+                  Review human join requests before they become active company members.
                 </p>
               </div>
               <Badge variant="outline">{pendingHumanJoinRequests.length} pending</Badge>
@@ -310,10 +347,11 @@ export function CompanyAccess() {
         ) : null}
 
         <div className="overflow-hidden rounded-xl border border-border">
-          <div className="grid grid-cols-(--gtc-24) gap-3 border-b border-border px-4 py-3 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+          <div className="grid grid-cols-[minmax(0,1.5fr)_120px_120px_minmax(0,1.2fr)_180px] gap-3 border-b border-border px-4 py-3 text-xs font-medium uppercase tracking-wide text-muted-foreground">
             <div>User account</div>
             <div>Role</div>
             <div>Status</div>
+            <div>Grants</div>
             <div className="text-right">Action</div>
           </div>
           {members.length === 0 ? (
@@ -325,7 +363,7 @@ export function CompanyAccess() {
               return (
                 <div
                   key={member.id}
-                  className="grid grid-cols-(--gtc-24) gap-3 border-b border-border px-4 py-3 last:border-b-0"
+                  className="grid grid-cols-[minmax(0,1.5fr)_120px_120px_minmax(0,1.2fr)_180px] gap-3 border-b border-border px-4 py-3 last:border-b-0"
                 >
                   <div className="min-w-0">
                     <div className="truncate font-medium">{member.user?.name?.trim() || member.user?.email || member.principalId}</div>
@@ -341,6 +379,7 @@ export function CompanyAccess() {
                       {member.status.replace("_", " ")}
                     </Badge>
                   </div>
+                  <div className="min-w-0 text-sm text-muted-foreground">{formatGrantSummary(member)}</div>
                   <div className="space-y-1 text-right">
                     <div className="flex justify-end gap-2">
                       <Button size="sm" variant="outline" onClick={() => setEditingMemberId(member.id)}>
@@ -373,7 +412,7 @@ export function CompanyAccess() {
           <DialogHeader>
             <DialogTitle>Edit member</DialogTitle>
             <DialogDescription>
-              Update company role and membership status for {editingMember?.user?.name || editingMember?.user?.email || editingMember?.principalId}.
+              Update company role, membership status, and explicit grants for {editingMember?.user?.name || editingMember?.user?.email || editingMember?.principalId}.
             </DialogDescription>
           </DialogHeader>
           {editingMember && (
@@ -411,6 +450,66 @@ export function CompanyAccess() {
                   </select>
                 </label>
               </div>
+
+              <div className="space-y-3">
+                <div>
+                  <h3 className="text-sm font-medium">Grants</h3>
+                  <p className="text-sm text-muted-foreground">
+                    Roles provide implicit grants automatically. Explicit grants below are only for overrides and extra access that should persist even if the role changes.
+                  </p>
+                </div>
+                <div className="rounded-lg border border-border px-3 py-3">
+                  <div className="text-sm font-medium">Implicit grants from role</div>
+                  <p className="mt-1 text-sm text-muted-foreground">
+                    {draftRole
+                      ? `${HUMAN_COMPANY_MEMBERSHIP_ROLE_LABELS[draftRole]} currently includes these permissions automatically.`
+                      : "No role is selected, so this member has no implicit grants right now."}
+                  </p>
+                  {implicitGrantKeys.length > 0 ? (
+                    <div className="mt-3 flex flex-wrap gap-2">
+                      {implicitGrantKeys.map((permissionKey) => (
+                        <Badge key={permissionKey} variant="outline">
+                          {permissionLabels[permissionKey]}
+                        </Badge>
+                      ))}
+                    </div>
+                  ) : null}
+                </div>
+                <div className="grid gap-3 md:grid-cols-2">
+                  {PERMISSION_KEYS.map((permissionKey) => (
+                    <label
+                      key={permissionKey}
+                      className="flex items-start gap-3 rounded-lg border border-border px-3 py-2"
+                    >
+                      <Checkbox
+                        checked={draftGrants.has(permissionKey)}
+                        onCheckedChange={(checked) => {
+                          setDraftGrants((current) => {
+                            const next = new Set(current);
+                            if (checked) next.add(permissionKey);
+                            else next.delete(permissionKey);
+                            return next;
+                          });
+                        }}
+                      />
+                      <span className="space-y-1">
+                        <span className="block text-sm font-medium">{permissionLabels[permissionKey]}</span>
+                        <span className="block text-xs text-muted-foreground">{permissionKey}</span>
+                        {implicitGrantSet.has(permissionKey) ? (
+                          <span className="block text-xs text-muted-foreground">
+                            Included implicitly by the {draftRole ? HUMAN_COMPANY_MEMBERSHIP_ROLE_LABELS[draftRole] : "selected"} role. Add an explicit grant only if it should stay after the role changes.
+                          </span>
+                        ) : null}
+                        {draftGrants.has(permissionKey) ? (
+                          <span className="block text-xs text-muted-foreground">
+                            Stored explicitly for this member.
+                          </span>
+                        ) : null}
+                      </span>
+                    </label>
+                  ))}
+                </div>
+              </div>
             </div>
           )}
           <DialogFooter>
@@ -424,11 +523,12 @@ export function CompanyAccess() {
                   memberId: editingMember.id,
                   membershipRole: draftRole,
                   status: draftStatus,
+                  grants: [...draftGrants],
                 });
               }}
               disabled={updateMemberMutation.isPending}
             >
-              {updateMemberMutation.isPending ? "Saving…" : "Save member"}
+              {updateMemberMutation.isPending ? "Saving…" : "Save access"}
             </Button>
           </DialogFooter>
         </DialogContent>
@@ -449,14 +549,14 @@ export function CompanyAccess() {
                 <div className="text-sm text-muted-foreground">{removingMember.user?.email || removingMember.principalId}</div>
                 <div className="mt-2 text-sm text-muted-foreground">
                   {assignedIssuesQuery.isLoading
-                    ? "Checking assigned tasks..."
-                    : `${assignedIssues.length} open assigned task${assignedIssues.length === 1 ? "" : "s"}`}
+                    ? "Checking assigned issues..."
+                    : `${assignedIssues.length} open assigned issue${assignedIssues.length === 1 ? "" : "s"}`}
                 </div>
               </div>
 
               {assignedIssues.length > 0 ? (
                 <div className="space-y-2">
-                  <div className="text-sm font-medium">Task reassignment</div>
+                  <div className="text-sm font-medium">Issue reassignment</div>
                   <select
                     className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm"
                     value={reassignmentTarget}
@@ -491,7 +591,7 @@ export function CompanyAccess() {
                     ))}
                     {assignedIssues.length > 6 ? (
                       <div className="px-3 py-2 text-sm text-muted-foreground">
-                        {assignedIssues.length - 6} more task{assignedIssues.length - 6 === 1 ? "" : "s"}
+                        {assignedIssues.length - 6} more issue{assignedIssues.length - 6 === 1 ? "" : "s"}
                       </div>
                     ) : null}
                   </div>
@@ -519,66 +619,6 @@ export function CompanyAccess() {
           </DialogFooter>
         </DialogContent>
       </Dialog>
-    </div>
-  );
-}
-
-export function CompanyAccessLegacyRoute() {
-  const { selectedCompanyId } = useCompany();
-  const { setBreadcrumbs } = useBreadcrumbs();
-  const { slots, isLoading, errorMessage } = usePluginSlots({
-    slotTypes: ["companySettingsPage"],
-    companyId: selectedCompanyId,
-    enabled: !!selectedCompanyId,
-  });
-
-  useEffect(() => {
-    setBreadcrumbs([
-      { label: "Settings", href: "/company/settings" },
-      { label: "Access" },
-    ]);
-  }, [setBreadcrumbs]);
-
-  const permissionsSlot = slots.find((slot) => slot.routePath === "permissions");
-  if (permissionsSlot) {
-    return <Navigate to="/company/settings/permissions" replace />;
-  }
-
-  if (isLoading) {
-    return <div className="text-sm text-muted-foreground">Checking for advanced permission extensions...</div>;
-  }
-
-  return (
-    <div className="max-w-2xl space-y-5">
-      <div className="space-y-3">
-        <div className="flex items-center gap-2">
-          <Shield className="h-5 w-5 text-muted-foreground" />
-          <h1 className="text-lg font-semibold">Advanced Permissions</h1>
-        </div>
-        <p className="text-sm text-muted-foreground">
-          Advanced access, scoped assignment, and explicit grant controls are provided by installed company settings extensions.
-        </p>
-      </div>
-
-      <div className="space-y-4 rounded-xl border border-border px-5 py-5">
-        <div className="space-y-2">
-          <h2 className="text-sm font-semibold">Advanced permissions unavailable</h2>
-          <p className="text-sm text-muted-foreground">
-            Core Paperclip keeps enforcing company boundaries and any existing restrictive policy data, but editing advanced permissions requires an installed extension.
-          </p>
-          {errorMessage ? (
-            <p className="text-sm text-destructive">Plugin extensions unavailable: {errorMessage}</p>
-          ) : null}
-        </div>
-        <div className="flex flex-wrap gap-2">
-          <Button asChild>
-            <Link to="/company/settings/members">Open Members</Link>
-          </Button>
-          <Button asChild variant="outline">
-            <Link to="/company/settings/invites">Open Invites</Link>
-          </Button>
-        </div>
-      </div>
     </div>
   );
 }
@@ -640,6 +680,38 @@ function PendingJoinRequestCard({
           </Button>
         </div>
       </div>
+    </div>
+  );
+}
+
+
+export function CompanyAccessLegacyRoute() {
+  const { selectedCompanyId } = useCompany();
+  const { setBreadcrumbs } = useBreadcrumbs();
+  const { slots, isLoading, errorMessage } = usePluginSlots({
+    slotTypes: ["companySettingsPage"],
+    companyId: selectedCompanyId,
+    enabled: !!selectedCompanyId,
+  });
+
+  useEffect(() => {
+    setBreadcrumbs([
+      { label: "Settings", href: "/company/settings" },
+      { label: "Access" },
+    ]);
+  }, [setBreadcrumbs]);
+
+  const permissionsSlot = slots.find((slot) => slot.routePath === "permissions");
+  if (permissionsSlot) {
+    return <Navigate to="/company/settings/permissions" replace />;
+  }
+
+  return (
+    <div className="max-w-3xl space-y-3 rounded-xl border border-border bg-card px-5 py-5 text-sm text-muted-foreground">
+      <h1 className="text-base font-semibold text-foreground">Access settings moved</h1>
+      <p>Manage company members from Settings &gt; Members.</p>
+      {isLoading ? <p>Checking installed access extensions...</p> : null}
+      {errorMessage ? <p className="text-destructive">{errorMessage}</p> : null}
     </div>
   );
 }


### PR DESCRIPTION
### Summary

Fixes #9601.

Board/user skill saves were denied with `No board permission mapping exists for skill_config:update` before the existing protected-change permission logic could run.

This changes the board-user authorization branch so `agent_config:read`, `agent_config:update`, and `skill_config:update` are handled before the generic `!permissionKey` unsupported-action fallback, matching the intended agent-side behavior.

### Test coverage

Adds a regression test for board/user skill configuration changes:

- `skills:create` allows direct update
- `skills:suggest-changes` denies without consent
- `skills:suggest-changes` allows with consent
- no grant returns `deny_no_grant` instead of the unsupported mapping error

### Validation

- `pnpm --filter @paperclipai/server typecheck`
