### PR TITLE
fix(server): scale stale-backup health threshold to the backup interval

### DIFF
--- a/doc/DEVELOPING.md
+++ b/doc/DEVELOPING.md
@@ -662,7 +662,9 @@ Environment overrides:
 - `PAPERCLIP_DB_BACKUP_RETENTION_DAYS=<days>`
 - `PAPERCLIP_DB_BACKUP_DIR=/absolute/or/~/path`
 - `PAPERCLIP_DB_BACKUP_MAX_AGE_HOURS=<hours>` controls the `/api/health`
-  stale-backup warning threshold
+  stale-backup warning threshold. It defaults to one missed backup plus a grace
+  period (at least 1h of grace, at least 2h in total), so the hourly default
+  interval warns after 2h rather than after a full day
 - `PAPERCLIP_DB_BACKUP_ALERT_FILE=/path/to/failure-marker` lets external cron
   wrappers surface the last failed backup in `/api/health`
 

--- a/server/src/__tests__/health.test.ts
+++ b/server/src/__tests__/health.test.ts
@@ -6,6 +6,7 @@ import express from "express";
 import request from "supertest";
 import type { Db } from "@paperclipai/db";
 import { healthRoutes } from "../routes/health.js";
+import { defaultDatabaseBackupMaxAgeHours } from "../services/database-backup-health.js";
 import * as devServerStatus from "../dev-server-status.js";
 import { serverVersion } from "../version.js";
 
@@ -422,5 +423,19 @@ describe("GET /health", () => {
       },
       serverInfo: testServerInfo,
     });
+  });
+});
+
+describe("defaultDatabaseBackupMaxAgeHours", () => {
+  it("scales with the configured backup interval", () => {
+    expect(defaultDatabaseBackupMaxAgeHours(60)).toBe(2);
+    expect(defaultDatabaseBackupMaxAgeHours(90)).toBe(3);
+    expect(defaultDatabaseBackupMaxAgeHours(6 * 60)).toBe(7);
+    expect(defaultDatabaseBackupMaxAgeHours(24 * 60)).toBe(27);
+  });
+
+  it("keeps a floor of two hours for very short intervals", () => {
+    expect(defaultDatabaseBackupMaxAgeHours(5)).toBe(2);
+    expect(defaultDatabaseBackupMaxAgeHours(0)).toBe(2);
   });
 });

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -55,6 +55,7 @@ import {
   parseAdapterRegistryEnv,
   reconcileAdapterAvailability,
 } from "./services/adapter-registry-bootstrap.js";
+import { defaultDatabaseBackupMaxAgeHours } from "./services/database-backup-health.js";
 import { createFeedbackTraceShareClientFromConfig } from "./services/feedback-share-client.js";
 import { buildRuntimeApiCandidateUrls, choosePrimaryRuntimeApiUrl } from "./runtime-api.js";
 import { createPluginWorkerManager } from "./services/plugin-worker-manager.js";
@@ -594,7 +595,7 @@ export async function startServer(): Promise<StartedServer> {
   const databaseBackupMaxAgeHours = Math.max(
     1,
     Number(process.env.PAPERCLIP_DB_BACKUP_MAX_AGE_HOURS) ||
-      Math.max(26, Math.ceil((config.databaseBackupIntervalMinutes / 60) * 2)),
+      defaultDatabaseBackupMaxAgeHours(config.databaseBackupIntervalMinutes),
   );
   const databaseBackupAlertFile =
     process.env.PAPERCLIP_DB_BACKUP_ALERT_FILE ||

--- a/server/src/services/database-backup-health.ts
+++ b/server/src/services/database-backup-health.ts
@@ -45,6 +45,21 @@ function roundHours(value: number): number {
   return Math.round(value * 10) / 10;
 }
 
+/**
+ * Stale-backup threshold for `/api/health`, derived from the configured backup
+ * interval: one missed backup plus a 10% grace period (at least an hour of
+ * grace, and at least 2h in total so very short intervals do not flap).
+ *
+ * The threshold has to scale with the interval — a fixed floor tuned for daily
+ * backups is 25x too lenient for the hourly default, which lets backups stop
+ * for a full day while health still reports no warning.
+ */
+export function defaultDatabaseBackupMaxAgeHours(intervalMinutes: number): number {
+  const intervalHours = Math.max(0, intervalMinutes) / 60;
+  const graceHours = Math.max(1, Math.ceil(intervalHours * 0.1));
+  return Math.max(2, Math.ceil(intervalHours) + graceHours);
+}
+
 function alertFileCandidates(opts: InspectDatabaseBackupHealthOptions) {
   return [...new Set([
     opts.alertFile,


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Self-hosted instances rely on the server's built-in scheduled `pg_dump` backup, which runs every 60 minutes by default (`databaseBackupIntervalMinutes`)
> - #9147 added a stale-backup warning to `/api/health` so operators find out when backups silently stop, gated on `databaseBackupMaxAgeHours`
> - That threshold defaults to `Math.max(26, Math.ceil(intervalHours * 2))`. The `26` floor encodes "one daily backup + 2h grace", but it is applied regardless of the configured interval
> - On the default hourly interval the threshold is therefore 26h: backups can miss 25 consecutive runs and `/api/health` still reports no warning. We hit exactly this — a hung backup wedged the scheduler for 4h20m and health stayed clean the whole time
> - This pull request derives the default from the configured interval instead: one missed backup plus a grace period, floored at 2h
> - The benefit is that the health signal is proportional to how often backups are actually supposed to run, instead of being 26x too lenient for the shipped default

## Linked Issues or Issue Description

Refs #9289 — the hang that this stale threshold hid. That issue's root cause (the `databaseBackupInFlight` mutex never clearing when the dump hangs) is **not** addressed here; it is already covered by #8139, #8318 and #8517. This PR is deliberately scoped to the separate, uncovered problem: the health threshold that let the outage go unnoticed. None of those three PRs touch `databaseBackupMaxAgeHours`.

Related: #9147 (merged — introduced the threshold), #9113 (open — also touches backup health surfacing).

## What Changed

- Add `defaultDatabaseBackupMaxAgeHours(intervalMinutes)` in `server/src/services/database-backup-health.ts`: `max(2, ceil(intervalHours) + max(1, ceil(intervalHours * 0.1)))`.
- Use it in `server/src/index.ts` in place of the hardcoded `Math.max(26, ...)`. `PAPERCLIP_DB_BACKUP_MAX_AGE_HOURS` keeps overriding it, unchanged.
- Add unit tests for the threshold across interval sizes.
- Document the default in `doc/DEVELOPING.md`.

Resulting defaults: hourly (shipped default) 26h → **2h**; 90min → 3h; 6h → 7h; daily 26h → 27h.

## Verification

```
npx vitest run server/src/__tests__/health.test.ts   # 13 passed (2 new)
pnpm --filter @paperclipai/server typecheck          # clean
```

The new tests pin the threshold for 5min / 60min / 90min / 6h / 24h intervals.

## Risks

Low. Behavior change is limited to the *default* stale-backup warning threshold; `PAPERCLIP_DB_BACKUP_MAX_AGE_HOURS` still wins when set, and nothing about the backup or scheduling path changes. The warning is surfaced in `databaseBackup.status` / `warnings[]` — top-level `/api/health` `status` is hardcoded `"ok"` and is untouched, so this cannot flip a liveness probe.

Instances on sub-daily intervals with backups that are already stale/failing will start seeing a `database_backup_stale` warning that the 26h floor was suppressing. That is the intent, but it does mean a previously quiet health payload can become noisy — which is the correct signal, not a regression. Daily-interval instances are effectively unaffected (26h → 27h).

## Model Used

Claude Opus 4.8 (`claude-opus-4-8`) via Claude Code, extended thinking with tool use.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
