### PR TITLE
Pin pending confirmations by composer

### DIFF
--- a/ui/src/components/IssueChatThread.test.tsx
+++ b/ui/src/components/IssueChatThread.test.tsx
@@ -286,6 +286,35 @@ function createExpiredRequestConfirmationInteraction(
   };
 }
 
+function createPendingRequestConfirmationInteraction(
+  overrides: Partial<RequestConfirmationInteraction> = {},
+): RequestConfirmationInteraction {
+  return {
+    id: "interaction-confirmation-pending",
+    companyId: "company-1",
+    issueId: "issue-1",
+    kind: "request_confirmation",
+    title: "Approve the plan",
+    status: "pending",
+    continuationPolicy: "wake_assignee_on_accept",
+    createdByAgentId: "agent-1",
+    createdByUserId: null,
+    resolvedByAgentId: null,
+    resolvedByUserId: null,
+    createdAt: new Date("2026-04-06T12:04:00.000Z"),
+    updatedAt: new Date("2026-04-06T12:04:00.000Z"),
+    resolvedAt: null,
+    payload: {
+      version: 1,
+      prompt: "Approve the plan and let the assignee start implementation?",
+      acceptLabel: "Approve plan",
+      rejectLabel: "Request revisions",
+    },
+    result: null,
+    ...overrides,
+  };
+}
+
 function createFileDragEvent(type: string, files: File[]) {
   const event = new Event(type, { bubbles: true, cancelable: true }) as Event & {
     dataTransfer: {
@@ -2440,6 +2469,74 @@ describe("IssueChatThread", () => {
 
     expect(container.textContent).toContain("Approve the plan");
     expect(container.textContent).toContain("Confirmation expired after comment");
+
+    act(() => {
+      root.unmount();
+    });
+  });
+
+  it("pins pending confirmations above the composer instead of burying them in the timeline", () => {
+    const root = createRoot(container);
+
+    act(() => {
+      root.render(
+        <MemoryRouter>
+          <IssueChatThread
+            comments={[]}
+            interactions={[createPendingRequestConfirmationInteraction()]}
+            linkedRuns={[]}
+            timelineEvents={[]}
+            liveRuns={[]}
+            onAdd={async () => {}}
+            enableLiveTranscriptPolling={false}
+          />
+        </MemoryRouter>,
+      );
+    });
+
+    const decisionRegion = container.querySelector(
+      '[data-testid="issue-chat-pending-confirmations"]',
+    );
+    const composerDock = container.querySelector('[data-testid="issue-chat-composer-dock"]');
+    const threadViewport = container.querySelector('[data-testid="thread-viewport"]');
+
+    expect(decisionRegion).not.toBeNull();
+    expect(composerDock?.contains(decisionRegion)).toBe(true);
+    expect(decisionRegion?.textContent).toContain("Decision required");
+    expect(decisionRegion?.textContent).toContain("Approve the plan and let the assignee start implementation?");
+    expect(threadViewport?.textContent).not.toContain("Approve the plan and let the assignee start implementation?");
+
+    act(() => {
+      root.unmount();
+    });
+  });
+
+  it("keeps pending confirmations in the timeline when the composer is hidden", () => {
+    const root = createRoot(container);
+
+    act(() => {
+      root.render(
+        <MemoryRouter>
+          <IssueChatThread
+            comments={[]}
+            interactions={[createPendingRequestConfirmationInteraction()]}
+            linkedRuns={[]}
+            timelineEvents={[]}
+            liveRuns={[]}
+            onAdd={async () => {}}
+            showComposer={false}
+            enableLiveTranscriptPolling={false}
+          />
+        </MemoryRouter>,
+      );
+    });
+
+    const threadViewport = container.querySelector('[data-testid="thread-viewport"]');
+
+    expect(container.querySelector('[data-testid="issue-chat-pending-confirmations"]')).toBeNull();
+    expect(threadViewport?.textContent).toContain(
+      "Approve the plan and let the assignee start implementation?",
+    );
 
     act(() => {
       root.unmount();

--- a/ui/src/components/IssueChatThread.tsx
+++ b/ui/src/components/IssueChatThread.tsx
@@ -2281,6 +2281,16 @@ function isIssueCommentPresentation(value: unknown): value is IssueCommentPresen
   return v.kind === "system_notice" || v.kind === "message";
 }
 
+function isPendingConfirmationInteraction(
+  interaction: IssueThreadInteraction,
+): interaction is RequestConfirmationInteraction | RequestCheckboxConfirmationInteraction {
+  return interaction.status === "pending"
+    && (
+      interaction.kind === "request_confirmation"
+      || interaction.kind === "request_checkbox_confirmation"
+    );
+}
+
 function isIssueCommentMetadata(value: unknown): value is IssueCommentMetadata {
   if (!value || typeof value !== "object") return false;
   const v = value as Record<string, unknown>;
@@ -4294,11 +4304,21 @@ export function IssueChatThread({
   });
   const resolvedTranscriptByRun = transcriptsByRunId ?? transcriptByRun;
   const resolvedHasOutputForRun = hasOutputForRunOverride ?? hasOutputForRun;
+  const pendingConfirmationInteractions = useMemo(
+    () => interactions.filter(isPendingConfirmationInteraction),
+    [interactions],
+  );
+  const timelineInteractions = useMemo(
+    () => showComposer
+      ? interactions.filter((interaction) => !isPendingConfirmationInteraction(interaction))
+      : interactions,
+    [interactions, showComposer],
+  );
   const rawMessages = useMemo(
     () =>
       buildIssueChatMessages({
         comments,
-        interactions,
+        interactions: timelineInteractions,
         timelineEvents,
         linkedRuns,
         liveRuns,
@@ -4314,7 +4334,7 @@ export function IssueChatThread({
       }),
     [
       comments,
-      interactions,
+      timelineInteractions,
       timelineEvents,
       linkedRuns,
       liveRuns,
@@ -4930,6 +4950,44 @@ export function IssueChatThread({
             data-testid="issue-chat-composer-dock"
             className="sticky bottom-[calc(env(safe-area-inset-bottom)+20px)] z-20 space-y-2 bg-gradient-to-t from-background via-background/95 to-background/0 pt-6"
           >
+            {pendingConfirmationInteractions.length > 0 ? (
+              <section
+                aria-label="Pending confirmation"
+                data-testid="issue-chat-pending-confirmations"
+                className="rounded-2xl border-2 border-violet-500/70 bg-background p-3 shadow-lg shadow-violet-500/10"
+              >
+                <div className="mb-2 flex items-center justify-between gap-3 px-1">
+                  <div className="flex items-center gap-2">
+                    <AlertTriangle className="h-4 w-4 text-violet-600 dark:text-violet-300" />
+                    <div>
+                      <p className="text-sm font-semibold text-foreground">Decision required</p>
+                      <p className="text-xs text-muted-foreground">
+                        Approve or request changes before this task can continue.
+                      </p>
+                    </div>
+                  </div>
+                  {pendingConfirmationInteractions.length > 1 ? (
+                    <span className="shrink-0 rounded-full bg-violet-500/10 px-2 py-0.5 text-xs font-medium text-violet-800 dark:text-violet-200">
+                      {pendingConfirmationInteractions.length} pending
+                    </span>
+                  ) : null}
+                </div>
+                <div className="max-h-[min(48vh,32rem)] space-y-2 overflow-y-auto overscroll-contain">
+                  {pendingConfirmationInteractions.map((interaction) => (
+                    <IssueThreadInteractionCard
+                      key={interaction.id}
+                      interaction={interaction}
+                      agentMap={agentMap}
+                      currentUserId={currentUserId}
+                      userLabelMap={userLabelMap}
+                      onAcceptInteraction={stableOnAcceptInteraction}
+                      onRejectInteraction={stableOnRejectInteraction}
+                      externalReferences={externalReferences}
+                    />
+                  ))}
+                </div>
+              </section>
+            ) : null}
             <IssueChatComposer
               ref={composerRef}
               onImageUpload={imageUploadHandler}

--- a/ui/src/components/IssueChatThread.tsx
+++ b/ui/src/components/IssueChatThread.tsx
@@ -4304,16 +4304,29 @@ export function IssueChatThread({
   });
   const resolvedTranscriptByRun = transcriptsByRunId ?? transcriptByRun;
   const resolvedHasOutputForRun = hasOutputForRunOverride ?? hasOutputForRun;
-  const pendingConfirmationInteractions = useMemo(
-    () => interactions.filter(isPendingConfirmationInteraction),
-    [interactions],
-  );
-  const timelineInteractions = useMemo(
-    () => showComposer
-      ? interactions.filter((interaction) => !isPendingConfirmationInteraction(interaction))
-      : interactions,
-    [interactions, showComposer],
-  );
+  const { pendingConfirmationInteractions, timelineInteractions } = useMemo(() => {
+    if (!showComposer) {
+      return {
+        pendingConfirmationInteractions: [],
+        timelineInteractions: interactions,
+      };
+    }
+
+    const pending: Array<RequestConfirmationInteraction | RequestCheckboxConfirmationInteraction> = [];
+    const timeline: IssueThreadInteraction[] = [];
+    for (const interaction of interactions) {
+      if (isPendingConfirmationInteraction(interaction)) {
+        pending.push(interaction);
+      } else {
+        timeline.push(interaction);
+      }
+    }
+
+    return {
+      pendingConfirmationInteractions: pending,
+      timelineInteractions: timeline,
+    };
+  }, [interactions, showComposer]);
   const rawMessages = useMemo(
     () =>
       buildIssueChatMessages({


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open-source control plane people use to manage AI agents and their work.
> - The issue thread is the board operator's primary place for following work and responding to agents.
> - Confirmation interactions are actionable workflow gates, but they were displayed only at their chronological position in the thread.
> - Long threads could therefore bury the control needed to unblock the current task.
> - The composer dock is the stable location where the operator already looks to respond.
> - This pull request pins pending confirmations there while retaining resolved confirmations in history.
> - The benefit is a clearer, faster approval path without changing confirmation authorization or resolution behavior.

## Linked Issues or Issue Description

No matching public issue or pull request was found.

### What happened?

Pending confirmation and checkbox-confirmation controls appeared at the interaction's chronological position in the issue thread. In a long conversation, the current approval gate could be far above the reply composer and difficult to find.

### Expected behavior

When an issue has a pending confirmation, the decision control should remain prominent beside the operator's response area until resolved. It should not be duplicated in the historical timeline, and timeline-only embedded views must continue to show it.

### Steps to reproduce

1. Open an issue with a long comment history.
2. Have an agent request a confirmation before continuing.
3. Scroll to the bottom of the issue.
4. Observe that the confirmation control is located at its earlier chronological position instead of beside the composer.

### Environment

- Paperclip commit: `c48feee`
- Deployment mode: Docker, authenticated/private
- Installation method: built from source
- Access context: board human operator
- Adapter involvement: not adapter-specific; core UI behavior

## What Changed

- Added a type guard for pending confirmation and checkbox-confirmation interactions.
- Partition pending and historical interactions in one memoized pass when the composer is visible.
- Render pending decisions in a prominent, scrollable `Decision required` section above the sticky composer.
- Keep pending confirmations in the normal timeline when the composer is intentionally hidden.
- Added focused tests for both composer-visible and composer-hidden behavior.

## Verification

- `pnpm exec vitest run ui/src/components/IssueChatThread.test.tsx --reporter=dot` — 69 tests passed.
- `pnpm --filter @paperclipai/ui typecheck` — passed.
- `pnpm --filter @paperclipai/ui build` — passed.
- `git diff --check` — passed.
- Rebuilt the Docker image and confirmed `GET /api/health` returns HTTP 200.
- Confirmed the production bundle contains the `Decision required` interface.

## Risks

- Low risk: the change is isolated to issue-thread presentation and does not alter confirmation authorization, persistence, or resolution APIs.
- A tall pending-decision card could consume viewport space; the card list is capped and scrollable.
- Embedded views without a composer retain the prior timeline behavior to avoid hiding actionable interactions.

## Model Used

OpenAI Codex using GPT-5 with reasoning, tool use, local code execution, test execution, Docker, and GitHub CLI access.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes — no user-facing documentation change is needed for this presentation fix
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is green with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
