### PR TITLE
Add ctx.approvals.approve/reject plugin capability

### DIFF
--- a/packages/plugins/sdk/src/host-client-factory.ts
+++ b/packages/plugins/sdk/src/host-client-factory.ts
@@ -241,6 +241,12 @@ export interface HostServices {
     createInteraction(params: WorkerToHostMethods["issues.createInteraction"][0]): Promise<WorkerToHostMethods["issues.createInteraction"][1]>;
   };
 
+  /** Provides `approvals.approve`, `approvals.reject`. */
+  approvals: {
+    approve(params: WorkerToHostMethods["approvals.approve"][0]): Promise<WorkerToHostMethods["approvals.approve"][1]>;
+    reject(params: WorkerToHostMethods["approvals.reject"][0]): Promise<WorkerToHostMethods["approvals.reject"][1]>;
+  };
+
   /** Provides `issues.documents.list`, `issues.documents.get`, `issues.documents.upsert`, `issues.documents.delete`. */
   issueDocuments: {
     list(params: WorkerToHostMethods["issues.documents.list"][0]): Promise<WorkerToHostMethods["issues.documents.list"][1]>;
@@ -445,6 +451,10 @@ const METHOD_CAPABILITY_MAP: Record<WorkerToHostMethodName, PluginCapability | n
   "issues.listComments": "issue.comments.read",
   "issues.createComment": "issue.comments.create",
   "issues.createInteraction": "issue.interactions.create",
+
+  // Approvals
+  "approvals.approve": "approvals.resolve",
+  "approvals.reject": "approvals.resolve",
 
   // Issue Documents
   "issues.documents.list": "issue.documents.read",
@@ -886,6 +896,14 @@ export function createHostClientHandlers(
     }),
     "issues.createInteraction": gated("issues.createInteraction", async (params) => {
       return services.issues.createInteraction(params);
+    }),
+
+    // Approvals
+    "approvals.approve": gated("approvals.approve", async (params) => {
+      return services.approvals.approve(params);
+    }),
+    "approvals.reject": gated("approvals.reject", async (params) => {
+      return services.approvals.reject(params);
     }),
 
     // Issue Documents

--- a/packages/plugins/sdk/src/index.ts
+++ b/packages/plugins/sdk/src/index.ts
@@ -305,7 +305,11 @@ export type {
   HumanCompanyMembershipRole,
   MembershipStatus,
   EnvSecretRefBinding,
+  PluginApprovalsClient,
 } from "./types.js";
+
+// Approval type re-exported from @paperclipai/shared via types.js's import surface
+export type { Approval } from "@paperclipai/shared";
 
 // Manifest and constant types re-exported from @paperclipai/shared
 // Plugin authors import manifest types from here so they have a single

--- a/packages/plugins/sdk/src/protocol.ts
+++ b/packages/plugins/sdk/src/protocol.ts
@@ -25,6 +25,7 @@ import type {
   Project,
   Issue,
   IssueComment,
+  Approval,
   IssueDocument,
   IssueDocumentSummary,
   IssueAssigneeAdapterOverrides,
@@ -1280,6 +1281,26 @@ export interface WorkerToHostMethods {
       companyId: string;
     },
     result: Issue,
+  ];
+  "approvals.approve": [
+    params: {
+      approvalId: string;
+      companyId: string;
+      decidedByUserId: string;
+      decisionNote?: string | null;
+      actorAgentId?: string | null;
+    },
+    result: { approval: Approval; applied: boolean },
+  ];
+  "approvals.reject": [
+    params: {
+      approvalId: string;
+      companyId: string;
+      decidedByUserId: string;
+      decisionNote?: string | null;
+      actorAgentId?: string | null;
+    },
+    result: { approval: Approval; applied: boolean },
   ];
   "issues.relations.get": [
     params: { issueId: string; companyId: string },

--- a/packages/plugins/sdk/src/testing.ts
+++ b/packages/plugins/sdk/src/testing.ts
@@ -15,6 +15,7 @@ import type {
   RoutineRun,
   Issue,
   IssueComment,
+  Approval,
   IssueThreadInteraction,
   CreateIssueThreadInteraction,
   IssueDocument,
@@ -489,6 +490,7 @@ export function createTestHarness(options: TestHarnessOptions): TestHarness {
   const routines = new Map<string, Routine>();
   const routineRuns = new Map<string, RoutineRun>();
   const issues = new Map<string, Issue>();
+  const approvals = new Map<string, Approval>();
   const blockedByIssueIds = new Map<string, string[]>();
   const issueComments = new Map<string, IssueComment[]>();
   const issueInteractions = new Map<string, IssueThreadInteraction[]>();
@@ -1892,6 +1894,44 @@ export function createTestHarness(options: TestHarnessOptions): TestHarness {
             invocationBlocks: [],
           };
         },
+      },
+    },
+    approvals: {
+      async approve(approvalId, companyId, decidedByUserId, decisionNote) {
+        requireCapability(manifest, capabilitySet, "approvals.resolve");
+        const existing = approvals.get(approvalId);
+        if (!isInCompany(existing, companyId)) throw new Error("Approval not found");
+        if (existing.status !== "pending" && existing.status !== "revision_requested") {
+          return { approval: existing, applied: false };
+        }
+        const updated: Approval = {
+          ...existing,
+          status: "approved",
+          decidedByUserId,
+          decisionNote: decisionNote ?? null,
+          decidedAt: new Date(),
+          updatedAt: new Date(),
+        };
+        approvals.set(approvalId, updated);
+        return { approval: updated, applied: true };
+      },
+      async reject(approvalId, companyId, decidedByUserId, decisionNote) {
+        requireCapability(manifest, capabilitySet, "approvals.resolve");
+        const existing = approvals.get(approvalId);
+        if (!isInCompany(existing, companyId)) throw new Error("Approval not found");
+        if (existing.status !== "pending" && existing.status !== "revision_requested") {
+          return { approval: existing, applied: false };
+        }
+        const updated: Approval = {
+          ...existing,
+          status: "rejected",
+          decidedByUserId,
+          decisionNote: decisionNote ?? null,
+          decidedAt: new Date(),
+          updatedAt: new Date(),
+        };
+        approvals.set(approvalId, updated);
+        return { approval: updated, applied: true };
       },
     },
     agents: {

--- a/packages/plugins/sdk/src/types.ts
+++ b/packages/plugins/sdk/src/types.ts
@@ -19,6 +19,7 @@ import type {
   Project,
   Issue,
   IssueComment,
+  Approval,
   IssueDocument,
   IssueDocumentSummary,
   IssueRelationIssueSummary,
@@ -1479,6 +1480,43 @@ export interface PluginIssuesClient {
 }
 
 /**
+ * `ctx.approvals` — resolve pending board approvals from within a plugin.
+ *
+ * Requires `approvals.resolve` capability. Unlike the `/api/approvals/:id/approve`
+ * REST endpoint (which requires an authenticated board actor), this namespace is
+ * gated purely by the plugin's declared capability grant — it exists so plugins
+ * that surface approvals through a third-party UI (e.g. Slack interactive buttons)
+ * can resolve them without needing to hold board-level Paperclip credentials or
+ * make an outbound HTTP call back to the host (which the `http.outbound` SSRF guard
+ * would reject for any self-hosted, same-machine deployment).
+ *
+ * @see PLUGIN_SPEC.md §15 — Capability Model
+ */
+export interface PluginApprovalsClient {
+  /**
+   * Approve a pending or revision-requested approval.
+   *
+   * @param approvalId - The approval to resolve
+   * @param companyId - Company the approval belongs to (enforces in-company scoping)
+   * @param decidedByUserId - Free-text identity of who made the decision (e.g. `"slack:U123"`), stored for audit/display
+   * @param decisionNote - Optional note recorded alongside the decision
+   */
+  approve(
+    approvalId: string,
+    companyId: string,
+    decidedByUserId: string,
+    decisionNote?: string | null,
+  ): Promise<{ approval: Approval; applied: boolean }>;
+  /** Reject a pending or revision-requested approval. Same semantics as {@link approve}. */
+  reject(
+    approvalId: string,
+    companyId: string,
+    decidedByUserId: string,
+    decisionNote?: string | null,
+  ): Promise<{ approval: Approval; applied: boolean }>;
+}
+
+/**
  * `ctx.agents` — read and manage agents.
  *
  * Requires `agents.read` for reads; `agents.pause` / `agents.resume` /
@@ -1904,6 +1942,9 @@ export interface PluginContext {
 
   /** Read and write issues, comments, and documents. Requires issue capabilities. */
   issues: PluginIssuesClient;
+
+  /** Resolve pending board approvals. Requires `approvals.resolve`. */
+  approvals: PluginApprovalsClient;
 
   /** Read and manage agents. Requires `agents.read` for reads; `agents.pause` / `agents.resume` / `agents.invoke` for write ops. */
   agents: PluginAgentsClient;

--- a/packages/plugins/sdk/src/worker-rpc-host.ts
+++ b/packages/plugins/sdk/src/worker-rpc-host.ts
@@ -1015,6 +1015,16 @@ export function startWorkerRpcHost(options: WorkerRpcHostOptions): WorkerRpcHost
         },
       },
 
+      approvals: {
+        async approve(approvalId: string, companyId: string, decidedByUserId: string, decisionNote?: string | null) {
+          return callHost("approvals.approve", { approvalId, companyId, decidedByUserId, decisionNote });
+        },
+
+        async reject(approvalId: string, companyId: string, decidedByUserId: string, decisionNote?: string | null) {
+          return callHost("approvals.reject", { approvalId, companyId, decidedByUserId, decisionNote });
+        },
+      },
+
       agents: {
         async list(input) {
           return callHost("agents.list", {

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -1240,6 +1240,7 @@ export const PLUGIN_CAPABILITIES = [
   // Data Write
   "issues.create",
   "issues.update",
+  "approvals.resolve",
   "issue.relations.write",
   "issues.checkout",
   "issues.wakeup",

--- a/server/src/__tests__/plugin-host-services-approvals.test.ts
+++ b/server/src/__tests__/plugin-host-services-approvals.test.ts
@@ -1,0 +1,162 @@
+import { randomUUID } from "node:crypto";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { activityLog, agents, approvals, companies, createDb, heartbeatRuns } from "@paperclipai/db";
+import { buildHostServices } from "../services/plugin-host-services.js";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+const pluginId = "plugin-record-id";
+
+function createEventBusStub() {
+  return {
+    forPlugin() {
+      return {
+        emit: () => {},
+        subscribe: () => {},
+        clear: () => {},
+      };
+    },
+  } as any;
+}
+
+describeEmbeddedPostgres("plugin host services — approvals", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-plugin-host-approvals-");
+    db = createDb(tempDb.connectionString);
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.delete(activityLog);
+    await db.delete(heartbeatRuns);
+    await db.delete(approvals);
+    await db.delete(agents);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  async function createCompany(prefix: string) {
+    return db
+      .insert(companies)
+      .values({
+        name: `${prefix} ${randomUUID()}`,
+        issuePrefix: `${prefix}${randomUUID().slice(0, 6).toUpperCase()}`,
+      })
+      .returning()
+      .then((rows) => rows[0]!);
+  }
+
+  async function createApproval(companyId: string, requestedByAgentId?: string) {
+    return db
+      .insert(approvals)
+      .values({
+        companyId,
+        type: "request_board_approval",
+        status: "pending",
+        payload: { title: "Test approval" },
+        requestedByAgentId: requestedByAgentId ?? null,
+      })
+      .returning()
+      .then((rows) => rows[0]!);
+  }
+
+  it("approves a pending approval scoped to the calling company and logs plugin attribution", async () => {
+    const company = await createCompany("APX");
+    const approval = await createApproval(company.id);
+    const services = buildHostServices(db, pluginId, "slack", createEventBusStub());
+
+    const result = await services.approvals.approve({
+      approvalId: approval.id,
+      companyId: company.id,
+      decidedByUserId: "slack:U123",
+      decisionNote: "Approved via Slack button",
+    });
+
+    expect(result.applied).toBe(true);
+    expect(result.approval.status).toBe("approved");
+    expect(result.approval.decidedByUserId).toBe("slack:U123");
+
+    const [logRow] = await db.select().from(activityLog);
+    expect(logRow?.action).toBe("approval.approved");
+    expect(logRow?.actorType).toBe("plugin");
+    expect(logRow?.actorId).toBe(pluginId);
+    expect((logRow?.details as Record<string, unknown> | null)?.sourcePluginKey).toBe("slack");
+
+    services.dispose();
+  });
+
+  it("rejects a pending approval and does not queue a requester wakeup", async () => {
+    const company = await createCompany("APY");
+    const approval = await createApproval(company.id);
+    const services = buildHostServices(db, pluginId, "slack", createEventBusStub());
+
+    const result = await services.approvals.reject({
+      approvalId: approval.id,
+      companyId: company.id,
+      decidedByUserId: "slack:U456",
+    });
+
+    expect(result.applied).toBe(true);
+    expect(result.approval.status).toBe("rejected");
+
+    const runs = await db.select().from(heartbeatRuns);
+    expect(runs).toEqual([]);
+
+    services.dispose();
+  });
+
+  it("refuses to resolve an approval that belongs to a different company", async () => {
+    const targetCompany = await createCompany("APZ");
+    const otherCompany = await createCompany("APW");
+    const approval = await createApproval(otherCompany.id);
+    const services = buildHostServices(db, pluginId, "slack", createEventBusStub());
+
+    await expect(
+      services.approvals.approve({
+        approvalId: approval.id,
+        companyId: targetCompany.id,
+        decidedByUserId: "slack:U789",
+      }),
+    ).rejects.toThrow("Approval not found");
+
+    const [unchanged] = await db.select().from(approvals);
+    expect(unchanged?.status).toBe("pending");
+
+    services.dispose();
+  });
+
+  it("is a no-op on an already-resolved approval", async () => {
+    const company = await createCompany("APV");
+    const approval = await createApproval(company.id);
+    const services = buildHostServices(db, pluginId, "slack", createEventBusStub());
+
+    const first = await services.approvals.approve({
+      approvalId: approval.id,
+      companyId: company.id,
+      decidedByUserId: "slack:U1",
+    });
+    expect(first.applied).toBe(true);
+
+    const second = await services.approvals.approve({
+      approvalId: approval.id,
+      companyId: company.id,
+      decidedByUserId: "slack:U2",
+    });
+    expect(second.applied).toBe(false);
+    expect(second.approval.decidedByUserId).toBe("slack:U1");
+
+    const logRows = await db.select().from(activityLog);
+    expect(logRows).toHaveLength(1);
+
+    services.dispose();
+  });
+});

--- a/server/src/services/plugin-capability-validator.ts
+++ b/server/src/services/plugin-capability-validator.ts
@@ -85,6 +85,8 @@ const OPERATION_CAPABILITIES: Record<string, readonly PluginCapability[]> = {
   // Data write operations
   "issues.create": ["issues.create"],
   "issues.update": ["issues.update"],
+  "approvals.approve": ["approvals.resolve"],
+  "approvals.reject": ["approvals.resolve"],
   "issues.relations.setBlockedBy": ["issue.relations.write"],
   "issues.relations.addBlockers": ["issue.relations.write"],
   "issues.relations.removeBlockers": ["issue.relations.write"],

--- a/server/src/services/plugin-host-services.ts
+++ b/server/src/services/plugin-host-services.ts
@@ -25,6 +25,7 @@ import type {
   PluginIssueAssigneeSummary,
   PluginIssueOrchestrationSummary,
   PluginExecutionWorkspaceMetadata,
+  Approval,
 } from "@paperclipai/plugin-sdk";
 import type { CreateIssueThreadInteraction, InviteJoinType, IssueDocumentSummary, PermissionKey, PrincipalType } from "@paperclipai/shared";
 import { pluginOperationIssueOriginKind } from "@paperclipai/shared";
@@ -39,6 +40,7 @@ import { documentService } from "./documents.js";
 import { heartbeatService } from "./heartbeat.js";
 import { budgetService } from "./budgets.js";
 import { issueApprovalService } from "./issue-approvals.js";
+import { approvalService } from "./approvals.js";
 import { subscribeCompanyLiveEvents } from "./live-events.js";
 import { createHash, randomBytes, randomUUID } from "node:crypto";
 import path from "node:path";
@@ -543,6 +545,7 @@ export function buildHostServices(
   const authorization = authorizationService(db);
   const budgets = budgetService(db);
   const issueApprovals = issueApprovalService(db);
+  const approvals = approvalService(db);
   const scopedBus = eventBus.forPlugin(pluginKey);
 
   // Track active session event subscriptions for cleanup
@@ -2112,6 +2115,102 @@ export function buildHostServices(
             documentKey: params.key,
           },
         });
+      },
+    },
+
+    approvals: {
+      async approve(params) {
+        const companyId = ensureCompanyId(params.companyId);
+        await ensurePluginAvailableForCompany(companyId);
+        requireInCompany("Approval", await approvals.getById(params.approvalId), companyId);
+
+        const { approval, applied } = await approvals.approve(
+          params.approvalId,
+          params.decidedByUserId,
+          params.decisionNote,
+        );
+
+        if (applied) {
+          await logPluginActivity({
+            companyId: approval.companyId,
+            action: "approval.approved",
+            entityType: "approval",
+            entityId: approval.id,
+            details: {
+              type: approval.type,
+              requestedByAgentId: approval.requestedByAgentId,
+              decidedByUserId: params.decidedByUserId,
+            },
+          });
+
+          if (approval.requestedByAgentId) {
+            try {
+              const linkedIssues = await issueApprovals.listIssuesForApproval(approval.id);
+              const linkedIssueIds = linkedIssues.map((issue) => issue.id);
+              await heartbeat.wakeup(approval.requestedByAgentId, {
+                source: "automation",
+                triggerDetail: "system",
+                reason: "approval_approved",
+                payload: {
+                  approvalId: approval.id,
+                  approvalStatus: approval.status,
+                  issueId: linkedIssueIds[0] ?? null,
+                  issueIds: linkedIssueIds,
+                  pluginId,
+                  pluginKey,
+                },
+                requestedByActorType: "system",
+                requestedByActorId: pluginId,
+                contextSnapshot: {
+                  source: "approval.approved",
+                  approvalId: approval.id,
+                  approvalStatus: approval.status,
+                  issueId: linkedIssueIds[0] ?? null,
+                  issueIds: linkedIssueIds,
+                  taskId: linkedIssueIds[0] ?? null,
+                  wakeReason: "approval_approved",
+                  pluginId,
+                  pluginKey,
+                },
+              });
+            } catch (err) {
+              logger.warn(
+                { err, approvalId: approval.id, requestedByAgentId: approval.requestedByAgentId, pluginId, pluginKey },
+                "failed to queue requester wakeup after plugin approval",
+              );
+            }
+          }
+        }
+
+        return { approval: approval as Approval, applied };
+      },
+
+      async reject(params) {
+        const companyId = ensureCompanyId(params.companyId);
+        await ensurePluginAvailableForCompany(companyId);
+        requireInCompany("Approval", await approvals.getById(params.approvalId), companyId);
+
+        const { approval, applied } = await approvals.reject(
+          params.approvalId,
+          params.decidedByUserId,
+          params.decisionNote,
+        );
+
+        if (applied) {
+          await logPluginActivity({
+            companyId: approval.companyId,
+            action: "approval.rejected",
+            entityType: "approval",
+            entityId: approval.id,
+            details: {
+              type: approval.type,
+              requestedByAgentId: approval.requestedByAgentId,
+              decidedByUserId: params.decidedByUserId,
+            },
+          });
+        }
+
+        return { approval: approval as Approval, applied };
       },
     },
 


### PR DESCRIPTION
## Summary

Plugins that surface board approvals through a third-party channel (e.g. a Slack interactive button) currently have no way to resolve them. Found while debugging why the [paperclip-plugin-slack](https://github.com/paperclipai/paperclip) approval buttons render but don't resolve the approval in a self-hosted deployment:

- The REST endpoints (`/api/approvals/:id/approve|reject`) require an authenticated **board** actor (`assertBoard`). A plugin has no mechanism to hold or mint board credentials, so any call it makes is going to be rejected regardless of network path.
- Independent of that, calling those endpoints via `ctx.http.fetch` fails in any self-hosted / `local_trusted` deployment where the plugin worker and API host share a machine: the outbound-fetch SSRF guard (`validateAndResolveFetchUrl` in `plugin-host-services.ts`) rejects any hostname resolving to a private/loopback IP — which `localhost`/`127.0.0.1` always does. A persistent tunnel doesn't fix this either, since the auth problem above is still there.

This PR adds a new `approvals.resolve` capability and a `ctx.approvals.approve()`/`ctx.approvals.reject()` namespace, following the same pattern as the existing `ctx.issues`/`ctx.agents` namespaces: it's a worker→host JSON-RPC method gated by the plugin's declared capability grant (checked host-side against the plugin manifest), not an outbound HTTP request — so it needs neither board credentials nor a network path back into the host at all.

## Changes

- `packages/shared`: new `"approvals.resolve"` capability
- `packages/plugins/sdk`: `PluginApprovalsClient` type + `PluginContext.approvals`, worker-side RPC client (`worker-rpc-host.ts`), host-client-factory capability map + gated handler, in-memory `testing.ts` mock for plugin unit tests
- `server`: `plugin-host-services.ts` implementation — delegates to the same `approvalService` used by the REST routes, scopes by `companyId` (mirrors `requireInCompany` pattern used elsewhere in this file), and reproduces the REST handler's side effects (activity log + requester-agent wakeup on approve), but attributes the mutation via `logPluginActivity` (`actorType: "plugin"`, tagged with `sourcePluginId`/`sourcePluginKey`) instead of `"board"`/`"user"`, since there is no real board user behind the call
- `server`: new test suite (`plugin-host-services-approvals.test.ts`) covering company scoping (rejects cross-company approval ids), idempotent re-resolve (second `approve()` on an already-decided approval is a no-op), and activity-log attribution

## Why capability-gated RPC instead of a board-token workaround

An alternative would be minting the plugin some form of board-scoped API credential it could attach to a normal `ctx.http.fetch` call. I didn't go this way because:
1. It still doesn't solve the SSRF-guard-vs-self-call problem for self-hosted deployments.
2. It would require the host to hand out long-lived board-equivalent credentials to plugin processes, which is a bigger trust expansion than a narrowly-scoped, already-audited capability string checked per-call against the plugin's manifest (the existing model used for every other plugin→host mutation).

## Test plan

- [x] `pnpm --filter @paperclipai/shared typecheck`
- [x] `pnpm --filter @paperclipai/plugin-sdk typecheck`
- [x] `pnpm --filter @paperclipai/server typecheck`
- [x] `vitest run` — existing plugin-sdk/host-services/authz suites (26 tests) pass unmodified
- [x] `vitest run src/__tests__/plugin-host-services-approvals.test.ts` — 4 new tests pass
- [ ] Maintainer review of the trust-boundary reasoning above (this changes what a plugin can do to a board-gated resource, even though the mechanism follows an existing pattern)

🤖 Generated with [Claude Code](https://claude.com/claude-code)