### PR TITLE
docs(release): v2026.715.0 changelog

### DIFF
--- a/releases/v2026.715.0.md
+++ b/releases/v2026.715.0.md
@@ -1,0 +1,67 @@
+# Paperclip v2026.715.0
+
+> Released: 2026-07-15
+
+## Highlights
+
+- **MCP Tool Gateway & Apps** — Paperclip now has a first-class, governed way to connect Model Context Protocol tools. A named MCP gateway brokers every tool call, governed access contracts and a tool-access policy decide which agents and profiles may use which tools, and the new Tools, Profiles, and Apps surfaces let you wire up, install, and smoke-test connections from the UI. ([#9556](https://github.com/paperclipai/paperclip/pull/9556), [#9557](https://github.com/paperclipai/paperclip/pull/9557), [#9558](https://github.com/paperclipai/paperclip/pull/9558), [#9559](https://github.com/paperclipai/paperclip/pull/9559), [#9560](https://github.com/paperclipai/paperclip/pull/9560), [#9561](https://github.com/paperclipai/paperclip/pull/9561), [#9562](https://github.com/paperclipai/paperclip/pull/9562), [#9563](https://github.com/paperclipai/paperclip/pull/9563))
+- **Skill Studio** — A three-pane skill IDE with sandboxed test runs, so you can author, edit, and try out skills without leaving Paperclip. Company skill forks now run prechecks before they land, and markdown edits get proper dirty-tracking and save. ([#9241](https://github.com/paperclipai/paperclip/pull/9241), [#9235](https://github.com/paperclipai/paperclip/pull/9235), [#9356](https://github.com/paperclipai/paperclip/pull/9356))
+- **Attention queue & Decisions** — A new attention queue and Decisions surface bring everything that needs your input into one place, with faster scrolling and readable, mobile-friendly decision rows. ([#9380](https://github.com/paperclipai/paperclip/pull/9380), [#9468](https://github.com/paperclipai/paperclip/pull/9468), [#9472](https://github.com/paperclipai/paperclip/pull/9472))
+- **Better search** — Search gains filters, sorting, and operators, with command-palette parity so you can find issues and entities the same way everywhere. ([#9327](https://github.com/paperclipai/paperclip/pull/9327))
+- **Sandbox execution** — ACP sessions can now run in sandbox execution targets, with sandbox support for the Grok local adapter, custom-image snapshots applied across config tests and saves, and a sandbox wall-clock backstop raised to four hours for long-running work. ([#9390](https://github.com/paperclipai/paperclip/pull/9390), [#9338](https://github.com/paperclipai/paperclip/pull/9338), [#9385](https://github.com/paperclipai/paperclip/pull/9385), [#9232](https://github.com/paperclipai/paperclip/pull/9232))
+- **Tougher, self-healing runs** — Run restart recovery, workspace self-heal, quota-aware retries, and failed-run metrics mean your instance tries harder before it involves you. Plan-approval continuations and external-wait liveness are now durable across failed wakes, and resolved blockers reliably wake the tasks that depend on them. ([#9183](https://github.com/paperclipai/paperclip/pull/9183), [#9331](https://github.com/paperclipai/paperclip/pull/9331), [#9373](https://github.com/paperclipai/paperclip/pull/9373), [#9229](https://github.com/paperclipai/paperclip/pull/9229))
+- **Cases (experimental)** — A new first-class Case object gives you a structured, document-backed record for things like releases and social threads. Enable it in experimental settings. ([#9198](https://github.com/paperclipai/paperclip/pull/9198))
+
+## Improvements
+
+- **Design-system convergence** — Single-source design tokens, a visual regression suite, and a retuned theme, plus broad Card/Badge adoption, a multiplicative radius ladder, and unified list surfaces. Task status glyphs now use Lucide icons. ([#9134](https://github.com/paperclipai/paperclip/pull/9134), [#9240](https://github.com/paperclipai/paperclip/pull/9240), [#9395](https://github.com/paperclipai/paperclip/pull/9395))
+- **Activity-gated routines** — Scheduled runs can be gated on external activity, so routines only fire when there's real work to do. ([#9436](https://github.com/paperclipai/paperclip/pull/9436))
+- **ACP is the default engine for local adapters** — Local coding adapters now run through ACP by default, with local coding processes confined for safety. ([#9238](https://github.com/paperclipai/paperclip/pull/9238), [#9504](https://github.com/paperclipai/paperclip/pull/9504))
+- **Spend & cost telemetry** — ACP-lane usage and cost now flow into spend telemetry, unpriced CLI usage is recorded, and credential-health retention is documented. ([#9471](https://github.com/paperclipai/paperclip/pull/9471), [#9505](https://github.com/paperclipai/paperclip/pull/9505), [#9248](https://github.com/paperclipai/paperclip/pull/9248))
+- **Durable run logs** — Run logs are now mirrored to a durable object-storage-backed store. ([#8984](https://github.com/paperclipai/paperclip/pull/8984), @stubbi)
+- **Codex & model updates** — Updated Codex adapter GPT-5.6 defaults and added `gpt-5.4-mini` to Codex/OpenCode selection (plus `openai/gpt-5.5` to OpenCode). ([#9352](https://github.com/paperclipai/paperclip/pull/9352), [#4357](https://github.com/paperclipai/paperclip/pull/4357), @supertaz)
+- **Ship ripgrep in the agent runtime image** — `rg` is now available out of the box in the base agent image. ([#8976](https://github.com/paperclipai/paperclip/pull/8976), @stubbi)
+- **Fewer redundant wakes** — Redundant issue re-wakes are throttled and the execution contract is injected once per fresh heartbeat, cutting duplicate token spend. ([#9470](https://github.com/paperclipai/paperclip/pull/9470), [#9469](https://github.com/paperclipai/paperclip/pull/9469))
+- **Show source SHA for unreleased builds** — Builds that aren't on a formal release now surface their source SHA. ([#9508](https://github.com/paperclipai/paperclip/pull/9508))
+- **Prose editor for agent instructions** — Markdown agent instructions now use the prose editor. ([#9332](https://github.com/paperclipai/paperclip/pull/9332))
+- **Health-gated dev services** — Paperclip dev services now require health readiness before they're considered up. ([#9269](https://github.com/paperclipai/paperclip/pull/9269))
+- **Harder environment deletion** — Environment deletion is hardened and now shows its delete blast radius. ([#9250](https://github.com/paperclipai/paperclip/pull/9250), @nickyleach)
+- **Faster release verification** — The release verify workflow is parallelized and npm registry version queries are batched. ([#9168](https://github.com/paperclipai/paperclip/pull/9168), [#9202](https://github.com/paperclipai/paperclip/pull/9202))
+
+## Fixes
+
+- **Cross-tenant existence oracle closed** — The API now returns `404` instead of `403` so it no longer leaks whether another tenant's resource exists. ([#3967](https://github.com/paperclipai/paperclip/pull/3967), @stubbi)
+- **Stronger public invites** — Invite-token entropy is widened and public invite endpoints are rate-limited. ([#8979](https://github.com/paperclipai/paperclip/pull/8979), @stubbi)
+- **apiCompression no longer corrupts auth** — Fixed gzip clients getting corrupted or dropped Better Auth responses. ([#9381](https://github.com/paperclipai/paperclip/pull/9381))
+- **Decision cards survive machine comments** — Machine-authored comments no longer supersede decision cards. ([#9015](https://github.com/paperclipai/paperclip/pull/9015), @nsollazzo)
+- **PID persistence for adapters** — `onSpawn` is forwarded to the Hermes and process adapters so PIDs persist. ([#8722](https://github.com/paperclipai/paperclip/pull/8722), @machjesusmoto)
+- **Reliable process teardown** — `runChildProcess` now escalates to `SIGKILL` on liveness rather than trusting `child.killed`. ([#8598](https://github.com/paperclipai/paperclip/pull/8598), @justinltodd)
+- **System comments show as "You"** — System-authored comments now display as "You" instead of "Paperclip". ([#6330](https://github.com/paperclipai/paperclip/pull/6330), @BorClaw)
+- **Correct heartbeat activity attribution** — Heartbeat invoke/resume now uses `run.id` for the activity log. ([#3424](https://github.com/paperclipai/paperclip/pull/3424), @tmartin2113)
+- **Tolerate empty profile names** — Empty-string user names in profile/session parsing no longer break. ([#8986](https://github.com/paperclipai/paperclip/pull/8986), @stubbi)
+- **Codex auth hardening** — Refresh auth failures are classified, and a host-unusable Codex auth merge now fails closed. ([#9598](https://github.com/paperclipai/paperclip/pull/9598), [#9276](https://github.com/paperclipai/paperclip/pull/9276), @nickyleach)
+- **Worktree repair** — Dirty and foreign-branch execution worktrees are repaired, target attestation is required before repair, and worktree execution only starts after activation. ([#9297](https://github.com/paperclipai/paperclip/pull/9297), [#9414](https://github.com/paperclipai/paperclip/pull/9414), [#9374](https://github.com/paperclipai/paperclip/pull/9374))
+- **Workspace branch reconciliation** — Added auto-forward execution-workspace branch reconciliation and its route, and avoided freezing an accepted-plan workspace branch before child realization. ([#9172](https://github.com/paperclipai/paperclip/pull/9172), [#9170](https://github.com/paperclipai/paperclip/pull/9170), [#9233](https://github.com/paperclipai/paperclip/pull/9233), @nickyleach)
+- **Request-storm and polling fixes** — Fixed a request-storm polling loop, issue-list coalescing, and bounded the shared polling cache. ([#9190](https://github.com/paperclipai/paperclip/pull/9190), [#9406](https://github.com/paperclipai/paperclip/pull/9406))
+- **Live-run readability & memory** — Live run streaming text is more readable and live agent-run transcript buffers are capped to bound tab memory. ([#9330](https://github.com/paperclipai/paperclip/pull/9330), [#9569](https://github.com/paperclipai/paperclip/pull/9569))
+- **Threads stay put** — Issue threads no longer jump to the latest comment while you're reading. ([#9354](https://github.com/paperclipai/paperclip/pull/9354))
+- **Markdown rendering fixes** — Rendered markdown list markers stay visible and numbered lists are no longer cut off on the left. ([#9359](https://github.com/paperclipai/paperclip/pull/9359))
+- **Mobile & layout polish** — Agent names stay visible on the mobile agents index; inbox/task list nesting, hover perf, and routine detail were tidied; and the inbox unread badge no longer indents the row. ([#9236](https://github.com/paperclipai/paperclip/pull/9236), [#9317](https://github.com/paperclipai/paperclip/pull/9317), [#9383](https://github.com/paperclipai/paperclip/pull/9383))
+- **Environment edit is a routed page** — Editing an environment is now its own route, with a detailed unsaved-changes banner that guards against draft loss. ([#9386](https://github.com/paperclipai/paperclip/pull/9386), [#9391](https://github.com/paperclipai/paperclip/pull/9391))
+- **Experiments auto-recovery dialog** — Enabling an experiment no longer leaves the UI dimmed and locked. ([#9513](https://github.com/paperclipai/paperclip/pull/9513))
+- **Custom image setup** — Custom-image setup gets proper company context, and custom-image snapshots stay applied to probes and saves. ([#9028](https://github.com/paperclipai/paperclip/pull/9028), [#9385](https://github.com/paperclipai/paperclip/pull/9385))
+- **Reflection Coach & built-in assets** — Startup no longer crashes when Reflection Coach assets are missing, and built-in agent assets are preserved in server builds. ([#9351](https://github.com/paperclipai/paperclip/pull/9351), [#9339](https://github.com/paperclipai/paperclip/pull/9339))
+- **Skip user-secret resolution for skills routes** — Skills routes no longer attempt to resolve user secrets.
+- **Timeouts self-describe** — `acpx_local` timeouts are now self-describing. ([#9232](https://github.com/paperclipai/paperclip/pull/9232))
+- **Sandbox network resilience** — Stalled Daytona Git network commands now fail fast.
+
+## Upgrade Guide
+
+- This release adds a large batch of additive database migrations for the new MCP Tool Gateway, tool access policy, OAuth state, connection installs, and Smoke Lab tables. Migrations run automatically on startup — no manual action is required.
+- The MCP Tool Gateway, Cases, and Sandbox execution are gated behind experimental settings. Enable them under experimental settings to try them out.
+
+## Contributors
+
+This release has 135 commits from 11 contributors. Thank you to everyone who contributed to this release!
+
+@BorClaw, @justinltodd, @machjesusmoto, @nickyleach, @nsollazzo, @stubbi, @supertaz, @tmartin2113


### PR DESCRIPTION
## Summary

Stable release changelog for **v2026.715.0** (released 2026-07-15), generated per `.agents/skills/release-changelog/SKILL.md`.

- Range: `v2026.707.0..origin/master`
- **135 commits from 11 contributors**
- Adds `releases/v2026.715.0.md`

## Highlights covered

- MCP Tool Gateway & Apps (splits #9556–#9563)
- Skill Studio (three-pane skill IDE with sandboxed test runs)
- Attention queue & Decisions surface
- Better search (filters, sorting, operators, command-palette parity)
- Sandbox execution for ACP sessions
- Tougher, self-healing runs (restart recovery, durable continuations)
- Cases (experimental)

## Notes

- No `BREAKING:` commit signals; DB migrations are additive/feature-internal (MCP tool gateway, tool access policy, OAuth state, Smoke Lab) and run automatically on startup. Captured in the Upgrade Guide.
- Contributor list excludes bots and Paperclip founders per the skill; GitHub usernames resolved via merged-PR authors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)