### PR TITLE
fix(server): clear issue binders when archiving isolated workspaces

### DIFF
--- a/server/src/__tests__/execution-workspaces-service.test.ts
+++ b/server/src/__tests__/execution-workspaces-service.test.ts
@@ -2526,4 +2526,94 @@ describeEmbeddedPostgres("executionWorkspaceService.getCloseReadiness", () => {
       "git_branch_delete",
     ]));
   }, 20_000);
+
+  it("clears isolated-workspace issue binders and reuse_existing preference", async () => {
+    const companyId = randomUUID();
+    const projectId = randomUUID();
+    const executionWorkspaceId = randomUUID();
+    const boundIssueId = randomUUID();
+    const otherIssueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: "PAP",
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(projects).values({
+      id: projectId,
+      companyId,
+      name: "Workspaces",
+      status: "in_progress",
+      executionWorkspacePolicy: {
+        enabled: true,
+      },
+    });
+    await db.insert(executionWorkspaces).values({
+      id: executionWorkspaceId,
+      companyId,
+      projectId,
+      mode: "isolated_workspace",
+      strategyType: "git_worktree",
+      name: "Isolated binder fixture",
+      status: "archived",
+      providerType: "git_worktree",
+      cwd: "/tmp/isolated-binder",
+      providerRef: "/tmp/isolated-binder",
+      branchName: "PAP-612-clear-binders",
+      baseRef: "main",
+      closedAt: new Date(),
+    });
+    await db.insert(issues).values([
+      {
+        id: boundIssueId,
+        companyId,
+        projectId,
+        title: "Bound to archived isolated workspace",
+        status: "done",
+        priority: "medium",
+        executionWorkspaceId,
+        executionWorkspacePreference: "reuse_existing",
+      },
+      {
+        id: otherIssueId,
+        companyId,
+        projectId,
+        title: "Unrelated issue",
+        status: "todo",
+        priority: "medium",
+        executionWorkspaceId: null,
+        executionWorkspacePreference: "isolated_workspace",
+      },
+    ]);
+
+    const cleared = await svc.clearIssueBinders(companyId, executionWorkspaceId);
+    expect(cleared).toBe(1);
+
+    const bound = await db
+      .select({
+        executionWorkspaceId: issues.executionWorkspaceId,
+        executionWorkspacePreference: issues.executionWorkspacePreference,
+      })
+      .from(issues)
+      .where(eq(issues.id, boundIssueId))
+      .then((rows) => rows[0]);
+    const other = await db
+      .select({
+        executionWorkspaceId: issues.executionWorkspaceId,
+        executionWorkspacePreference: issues.executionWorkspacePreference,
+      })
+      .from(issues)
+      .where(eq(issues.id, otherIssueId))
+      .then((rows) => rows[0]);
+
+    expect(bound).toEqual({
+      executionWorkspaceId: null,
+      executionWorkspacePreference: null,
+    });
+    expect(other).toEqual({
+      executionWorkspaceId: null,
+      executionWorkspacePreference: "isolated_workspace",
+    });
+  });
 });

--- a/server/src/__tests__/heartbeat-workspace-session.test.ts
+++ b/server/src/__tests__/heartbeat-workspace-session.test.ts
@@ -1369,7 +1369,7 @@ describe("effective run execution workspace config freshness", () => {
   it.each([
     { name: "missing", status: null },
     { name: "archived", status: "archived" },
-  ])("fails loudly when the inherited workspace row is $name", async ({ status }) => {
+  ])("realizes a fresh workspace when the inherited workspace row is $name", async ({ status }) => {
     const reuseRequest = resolveExecutionWorkspaceReuseRequestForIssue({
       issueExecutionWorkspaceId: "workspace-old",
       issueExecutionWorkspacePreference: "reuse_existing",
@@ -1390,19 +1390,29 @@ describe("effective run execution workspace config freshness", () => {
       nextMetadata: metadata,
     });
     const realizeWorkspace = vi.fn(async () => ({ id: "fallback-workspace", warnings: [] }));
+    const restoreExistingWorkspace = vi.fn(async () => ({ id: "workspace-old", warnings: [] }));
 
     await expect(provisionExecutionWorkspaceForFreshnessDecision({
       requestedShouldReuseExisting: reuseRequest.requestedShouldReuseExisting,
       existingExecutionWorkspaceId: reuseRequest.requestedExecutionWorkspaceId,
+      existingExecutionWorkspaceAvailable: reuseRequest.existingExecutionWorkspaceAvailable,
       issueRef: { id: "issue-1", identifier: "PAP-42" },
       runId: "run-1",
       workspaceConfigFreshness: decision,
-      restoreExistingWorkspace: reuseRequest.existingExecutionWorkspaceAvailable
-        ? async () => ({ id: "workspace-old", warnings: [] })
-        : null,
+      restoreExistingWorkspace,
       realizeWorkspace,
-    })).rejects.toThrow(/could not be restored/);
-    expect(realizeWorkspace).not.toHaveBeenCalled();
+    })).resolves.toEqual({
+      executionWorkspace: { id: "fallback-workspace", warnings: [] },
+      reusedExecutionWorkspace: null,
+      policy: {
+        shouldRestoreExistingWorkspace: false,
+        shouldRefreshWorkspaceConfigSnapshot: false,
+        shouldPersistLatestWorkspaceConfigMetadata: true,
+      },
+      recoveredFromStaleBinder: true,
+    });
+    expect(realizeWorkspace).toHaveBeenCalledOnce();
+    expect(restoreExistingWorkspace).not.toHaveBeenCalled();
   });
 
   it("fails loudly when explicit reuse restore returns no workspace", async () => {

--- a/server/src/routes/execution-workspaces.ts
+++ b/server/src/routes/execution-workspaces.ts
@@ -1,7 +1,7 @@
 import { and, eq } from "drizzle-orm";
 import { Router, type Request, type Response } from "express";
 import type { Db } from "@paperclipai/db";
-import { issues, projects, projectWorkspaces } from "@paperclipai/db";
+import { projects, projectWorkspaces } from "@paperclipai/db";
 import {
   findWorkspaceCommandDefinition,
   matchWorkspaceRuntimeServiceToCommand,
@@ -641,20 +641,10 @@ export function executionWorkspaceRoutes(db: Db, opts: { pluginWorkerManager?: P
         failureReason: "execution_workspace_closed",
       });
 
-      if (existing.mode === "shared_workspace") {
-        await db
-          .update(issues)
-          .set({
-            executionWorkspaceId: null,
-            updatedAt: new Date(),
-          })
-          .where(
-            and(
-              eq(issues.companyId, existing.companyId),
-              eq(issues.executionWorkspaceId, existing.id),
-            ),
-          );
-      }
+      // Complete mediation: every mode (including isolated_workspace) must drop
+      // issue binders on archive. Leaving reuse_existing → dead id parks agents
+      // with workspace_validation_failed / 409 until an assignee-only PATCH.
+      await svc.clearIssueBinders(existing.companyId, existing.id);
 
       try {
         await stopRuntimeServicesForExecutionWorkspace({

--- a/server/src/services/execution-workspaces.ts
+++ b/server/src/services/execution-workspaces.ts
@@ -902,6 +902,40 @@ type WorkspaceOverviewIssueRow = WorkspaceOverviewLinkedIssue & {
   executionWorkspaceId: string;
 };
 
+/**
+ * Detach every issue still bound to an execution workspace that is leaving the
+ * active set (archive / quarantine). Clears `reuse_existing` preference so the
+ * next run provisions a fresh workspace instead of failing closed on a dead id.
+ */
+export async function clearIssueBindersForExecutionWorkspace(
+  db: Pick<Db, "update">,
+  input: {
+    companyId: string;
+    executionWorkspaceId: string;
+    updatedAt?: Date;
+  },
+): Promise<number> {
+  const updatedAt = input.updatedAt ?? new Date();
+  const cleared = await db
+    .update(issues)
+    .set({
+      executionWorkspaceId: null,
+      executionWorkspacePreference: sql`CASE
+        WHEN ${issues.executionWorkspacePreference} = 'reuse_existing' THEN NULL
+        ELSE ${issues.executionWorkspacePreference}
+      END`,
+      updatedAt,
+    })
+    .where(
+      and(
+        eq(issues.companyId, input.companyId),
+        eq(issues.executionWorkspaceId, input.executionWorkspaceId),
+      ),
+    )
+    .returning({ id: issues.id });
+  return cleared.length;
+}
+
 export function executionWorkspaceService(db: Db) {
   const recoveryActionsSvc = issueRecoveryActionService(db);
 
@@ -1436,6 +1470,10 @@ export function executionWorkspaceService(db: Db) {
 
       if (isSharedWorkspace) {
         warnings.push("This shared workspace session points at project workspace infrastructure. Archiving it only removes the session record.");
+      } else if (linkedIssueSummaries.length > 0) {
+        warnings.push(
+          "Archiving this isolated workspace will clear executionWorkspaceId binders on linked issues (and drop reuse_existing preference) so later checkouts provision a fresh workspace.",
+        );
       }
 
       if (runtimeServices.some((service) => service.status !== "stopped")) {
@@ -1479,7 +1517,8 @@ export function executionWorkspaceService(db: Db) {
         {
           kind: "archive_record",
           label: "Archive workspace record",
-          description: "Keep the execution workspace history and issue linkage, but remove it from active workspace lists.",
+          description:
+            "Keep the execution workspace history, clear issue binders (including reuse_existing), and remove it from active workspace lists.",
           command: null,
         },
       ];
@@ -1942,6 +1981,10 @@ export function executionWorkspaceService(db: Db) {
 
         return cleared;
       });
+    },
+
+    clearIssueBinders: async (companyId: string, executionWorkspaceId: string) => {
+      return clearIssueBindersForExecutionWorkspace(db, { companyId, executionWorkspaceId });
     },
   };
 }

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -3277,6 +3277,7 @@ function formatInheritedExecutionWorkspaceReuseFailure(input: {
 export async function provisionExecutionWorkspaceForFreshnessDecision<T extends { warnings?: string[] }>(input: {
   requestedShouldReuseExisting: boolean;
   existingExecutionWorkspaceId?: string | null;
+  existingExecutionWorkspaceAvailable?: boolean;
   issueRef: WorkspaceReuseIssueRef;
   runId: string;
   workspaceConfigFreshness: ExecutionWorkspaceConfigFreshnessDecision;
@@ -3286,6 +3287,7 @@ export async function provisionExecutionWorkspaceForFreshnessDecision<T extends 
   executionWorkspace: T;
   reusedExecutionWorkspace: T | null;
   policy: ExecutionWorkspaceReuseProvisioningPolicy;
+  recoveredFromStaleBinder: boolean;
 }> {
   const policy = resolveExecutionWorkspaceReuseProvisioningPolicy({
     requestedShouldReuseExisting: input.requestedShouldReuseExisting,
@@ -3298,6 +3300,23 @@ export async function provisionExecutionWorkspaceForFreshnessDecision<T extends 
       executionWorkspace,
       reusedExecutionWorkspace: null,
       policy,
+      recoveredFromStaleBinder: false,
+    };
+  }
+
+  // Fail securely + recover: reuse_existing against an archived/missing row must
+  // not park the run. Realize a fresh workspace; callers clear the stale binder.
+  if (input.existingExecutionWorkspaceAvailable === false) {
+    const executionWorkspace = await input.realizeWorkspace();
+    return {
+      executionWorkspace,
+      reusedExecutionWorkspace: null,
+      policy: {
+        ...policy,
+        shouldRestoreExistingWorkspace: false,
+        shouldRefreshWorkspaceConfigSnapshot: false,
+      },
+      recoveredFromStaleBinder: true,
     };
   }
 
@@ -3338,6 +3357,7 @@ export async function provisionExecutionWorkspaceForFreshnessDecision<T extends 
     executionWorkspace: restored,
     reusedExecutionWorkspace: restored,
     policy,
+    recoveredFromStaleBinder: false,
   };
 }
 
@@ -11634,10 +11654,36 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       issueExecutionWorkspacePreference: issueRef?.executionWorkspacePreference ?? null,
       existingExecutionWorkspaceStatus: existingExecutionWorkspace?.status ?? null,
     });
-    const requestedShouldReuseExisting = workspaceReuseRequest.requestedShouldReuseExisting;
-    const reusableExistingExecutionWorkspace = workspaceReuseRequest.existingExecutionWorkspaceAvailable
+    let requestedShouldReuseExisting = workspaceReuseRequest.requestedShouldReuseExisting;
+    let reusableExistingExecutionWorkspace = workspaceReuseRequest.existingExecutionWorkspaceAvailable
       ? existingExecutionWorkspace
       : null;
+    // Recoverable path for legacy stale binders (archive used to skip isolated_workspace).
+    if (
+      requestedShouldReuseExisting &&
+      !workspaceReuseRequest.existingExecutionWorkspaceAvailable &&
+      requestedExecutionWorkspaceId
+    ) {
+      await executionWorkspacesSvc.clearIssueBinders(agent.companyId, requestedExecutionWorkspaceId);
+      if (issueRef) {
+        issueRef.executionWorkspaceId = null;
+        if (issueRef.executionWorkspacePreference === "reuse_existing") {
+          issueRef.executionWorkspacePreference = null;
+        }
+      }
+      requestedShouldReuseExisting = false;
+      reusableExistingExecutionWorkspace = null;
+      logger.info(
+        {
+          runId: run.id,
+          issueId,
+          companyId: agent.companyId,
+          executionWorkspaceId: requestedExecutionWorkspaceId,
+          existingStatus: existingExecutionWorkspace?.status ?? null,
+        },
+        "Cleared stale reuse_existing binder to archived/missing execution workspace; provisioning fresh",
+      );
+    }
     const requestedReusableExecutionWorkspaceConfig = reusableExistingExecutionWorkspace?.config ?? null;
     const localEnvironment = await environmentsSvc.ensureLocalEnvironment(agent.companyId);
     const resolvedInstanceSettings = await instanceSettings.get();
@@ -12039,6 +12085,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       await provisionExecutionWorkspaceForFreshnessDecision<RealizedExecutionWorkspace>({
         requestedShouldReuseExisting,
         existingExecutionWorkspaceId: workspaceReuseRequest.requestedExecutionWorkspaceId,
+        existingExecutionWorkspaceAvailable: workspaceReuseRequest.existingExecutionWorkspaceAvailable,
         issueRef,
         runId: run.id,
         workspaceConfigFreshness,


### PR DESCRIPTION
## Summary
- On execution-workspace **archive**, clear `executionWorkspaceId` binders for **all** modes (not only `shared_workspace`), and null `reuse_existing` preference so the next run does not pin a dead id.
- On heartbeat, if `reuse_existing` points at an **archived/missing** workspace, auto-clear the binder and provision a fresh workspace instead of failing closed (`workspace_validation_failed` / stuck 409 class).
- Regression coverage: service binder clear for isolated archive + provision recovery for missing/archived inherited workspaces.

Fixes incomplete mediation on isolated-workspace lifecycle (Kyln [KYL-612](https://github.com/kyln-digital/paperclip-instance/issues) / agent 409 stuck-heartbeat class).

## Test plan
- [x] `vitest` focused: inherited missing/archived recovery + `clearIssueBinders` isolated fixture
- [ ] Archive an `isolated_workspace` with a terminal issue still bound → assert issue `executionWorkspaceId` is null and preference is not `reuse_existing`
- [ ] Leave a legacy binder to an archived id with `reuse_existing` → next heartbeat run provisions fresh without manual PATCH
- [ ] Confirm `shared_workspace` archive still clears binders (no regression)


Made with [Cursor](https://cursor.com)