### PR TITLE
feat: add folder organization for routines and skills

### DIFF
--- a/packages/db/src/migrations/0171_folders.sql
+++ b/packages/db/src/migrations/0171_folders.sql
@@ -1,4 +1,4 @@
-CREATE TABLE "folders" (
+CREATE TABLE IF NOT EXISTS "folders" (
 	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
 	"company_id" uuid NOT NULL,
 	"kind" text NOT NULL,
@@ -9,20 +9,38 @@ CREATE TABLE "folders" (
 	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
 );
 --> statement-breakpoint
-ALTER TABLE "company_skills" ADD COLUMN "folder_id" uuid;
+ALTER TABLE "company_skills" ADD COLUMN IF NOT EXISTS "folder_id" uuid;
 --> statement-breakpoint
-ALTER TABLE "routines" ADD COLUMN "folder_id" uuid;
+ALTER TABLE "routines" ADD COLUMN IF NOT EXISTS "folder_id" uuid;
 --> statement-breakpoint
-ALTER TABLE "folders" ADD CONSTRAINT "folders_company_id_companies_id_fk" FOREIGN KEY ("company_id") REFERENCES "public"."companies"("id") ON DELETE cascade ON UPDATE no action;
+DO $$ BEGIN
+	IF NOT EXISTS (
+		SELECT 1 FROM "pg_constraint" WHERE "conname" = 'folders_company_id_companies_id_fk'
+	) THEN
+		ALTER TABLE "folders" ADD CONSTRAINT "folders_company_id_companies_id_fk" FOREIGN KEY ("company_id") REFERENCES "public"."companies"("id") ON DELETE cascade ON UPDATE no action;
+	END IF;
+END $$;
 --> statement-breakpoint
-ALTER TABLE "company_skills" ADD CONSTRAINT "company_skills_folder_id_folders_id_fk" FOREIGN KEY ("folder_id") REFERENCES "public"."folders"("id") ON DELETE set null ON UPDATE no action;
+DO $$ BEGIN
+	IF NOT EXISTS (
+		SELECT 1 FROM "pg_constraint" WHERE "conname" = 'company_skills_folder_id_folders_id_fk'
+	) THEN
+		ALTER TABLE "company_skills" ADD CONSTRAINT "company_skills_folder_id_folders_id_fk" FOREIGN KEY ("folder_id") REFERENCES "public"."folders"("id") ON DELETE set null ON UPDATE no action;
+	END IF;
+END $$;
 --> statement-breakpoint
-ALTER TABLE "routines" ADD CONSTRAINT "routines_folder_id_folders_id_fk" FOREIGN KEY ("folder_id") REFERENCES "public"."folders"("id") ON DELETE set null ON UPDATE no action;
+DO $$ BEGIN
+	IF NOT EXISTS (
+		SELECT 1 FROM "pg_constraint" WHERE "conname" = 'routines_folder_id_folders_id_fk'
+	) THEN
+		ALTER TABLE "routines" ADD CONSTRAINT "routines_folder_id_folders_id_fk" FOREIGN KEY ("folder_id") REFERENCES "public"."folders"("id") ON DELETE set null ON UPDATE no action;
+	END IF;
+END $$;
 --> statement-breakpoint
-CREATE INDEX "folders_company_kind_position_idx" ON "folders" USING btree ("company_id","kind","position","name");
+CREATE INDEX IF NOT EXISTS "folders_company_kind_position_idx" ON "folders" USING btree ("company_id","kind","position","name");
 --> statement-breakpoint
-CREATE UNIQUE INDEX "folders_company_kind_name_uq" ON "folders" USING btree ("company_id","kind","name");
+CREATE UNIQUE INDEX IF NOT EXISTS "folders_company_kind_name_uq" ON "folders" USING btree ("company_id","kind","name");
 --> statement-breakpoint
-CREATE INDEX "company_skills_company_folder_idx" ON "company_skills" USING btree ("company_id","folder_id");
+CREATE INDEX IF NOT EXISTS "company_skills_company_folder_idx" ON "company_skills" USING btree ("company_id","folder_id");
 --> statement-breakpoint
-CREATE INDEX "routines_company_folder_idx" ON "routines" USING btree ("company_id","folder_id");
+CREATE INDEX IF NOT EXISTS "routines_company_folder_idx" ON "routines" USING btree ("company_id","folder_id");

--- a/packages/db/src/migrations/0171_folders.sql
+++ b/packages/db/src/migrations/0171_folders.sql
@@ -1,0 +1,28 @@
+CREATE TABLE "folders" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"company_id" uuid NOT NULL,
+	"kind" text NOT NULL,
+	"name" text NOT NULL,
+	"color" text,
+	"position" integer DEFAULT 0 NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "company_skills" ADD COLUMN "folder_id" uuid;
+--> statement-breakpoint
+ALTER TABLE "routines" ADD COLUMN "folder_id" uuid;
+--> statement-breakpoint
+ALTER TABLE "folders" ADD CONSTRAINT "folders_company_id_companies_id_fk" FOREIGN KEY ("company_id") REFERENCES "public"."companies"("id") ON DELETE cascade ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "company_skills" ADD CONSTRAINT "company_skills_folder_id_folders_id_fk" FOREIGN KEY ("folder_id") REFERENCES "public"."folders"("id") ON DELETE set null ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "routines" ADD CONSTRAINT "routines_folder_id_folders_id_fk" FOREIGN KEY ("folder_id") REFERENCES "public"."folders"("id") ON DELETE set null ON UPDATE no action;
+--> statement-breakpoint
+CREATE INDEX "folders_company_kind_position_idx" ON "folders" USING btree ("company_id","kind","position","name");
+--> statement-breakpoint
+CREATE UNIQUE INDEX "folders_company_kind_name_uq" ON "folders" USING btree ("company_id","kind","name");
+--> statement-breakpoint
+CREATE INDEX "company_skills_company_folder_idx" ON "company_skills" USING btree ("company_id","folder_id");
+--> statement-breakpoint
+CREATE INDEX "routines_company_folder_idx" ON "routines" USING btree ("company_id","folder_id");

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -1184,6 +1184,13 @@
       "when": 1784037600000,
       "tag": "0170_company_skill_policies",
       "breakpoints": true
+    },
+    {
+      "idx": 171,
+      "version": "7",
+      "when": 1784037601000,
+      "tag": "0171_folders",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/company_skills.ts
+++ b/packages/db/src/schema/company_skills.ts
@@ -13,12 +13,14 @@ import type { CompanySkillFileInventoryEntry, CompanySkillSharingScope } from "@
 import { agents } from "./agents.js";
 import { companies } from "./companies.js";
 import { issues } from "./issues.js";
+import { folders } from "./folders.js";
 
 export const companySkills = pgTable(
   "company_skills",
   {
     id: uuid("id").primaryKey().defaultRandom(),
     companyId: uuid("company_id").notNull().references(() => companies.id),
+    folderId: uuid("folder_id").references(() => folders.id, { onDelete: "set null" }),
     key: text("key").notNull(),
     slug: text("slug").notNull(),
     name: text("name").notNull(),
@@ -51,6 +53,7 @@ export const companySkills = pgTable(
   (table) => ({
     companyKeyUniqueIdx: uniqueIndex("company_skills_company_key_idx").on(table.companyId, table.key),
     companyNameIdx: index("company_skills_company_name_idx").on(table.companyId, table.name),
+    companyFolderIdx: index("company_skills_company_folder_idx").on(table.companyId, table.folderId),
     companyCategoriesIdx: index("company_skills_company_categories_idx").using("gin", table.categories),
     companySharingScopeIdx: index("company_skills_company_sharing_scope_idx").on(table.companyId, table.sharingScope),
     companyCurrentVersionIdx: index("company_skills_company_current_version_idx").on(table.companyId, table.currentVersionId),

--- a/packages/db/src/schema/folders.ts
+++ b/packages/db/src/schema/folders.ts
@@ -1,0 +1,38 @@
+import {
+  index,
+  integer,
+  pgTable,
+  text,
+  timestamp,
+  uniqueIndex,
+  uuid,
+} from "drizzle-orm/pg-core";
+import { companies } from "./companies.js";
+import type { FolderKind } from "@paperclipai/shared";
+
+export const folders = pgTable(
+  "folders",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    companyId: uuid("company_id").notNull().references(() => companies.id, { onDelete: "cascade" }),
+    kind: text("kind").$type<FolderKind>().notNull(),
+    name: text("name").notNull(),
+    color: text("color"),
+    position: integer("position").notNull().default(0),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    companyKindPositionIdx: index("folders_company_kind_position_idx").on(
+      table.companyId,
+      table.kind,
+      table.position,
+      table.name,
+    ),
+    companyKindNameUniqueIdx: uniqueIndex("folders_company_kind_name_uq").on(
+      table.companyId,
+      table.kind,
+      table.name,
+    ),
+  }),
+);

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -35,6 +35,7 @@ export { workspaceOperations } from "./workspace_operations.js";
 export { workspaceRuntimeServices } from "./workspace_runtime_services.js";
 export { projectGoals } from "./project_goals.js";
 export { goals } from "./goals.js";
+export { folders } from "./folders.js";
 export { issues } from "./issues.js";
 export { issueWatchdogs } from "./issue_watchdogs.js";
 export { issuePlanDecompositions } from "./issue_plan_decompositions.js";

--- a/packages/db/src/schema/routines.ts
+++ b/packages/db/src/schema/routines.ts
@@ -17,6 +17,7 @@ import { issues } from "./issues.js";
 import { projects } from "./projects.js";
 import { goals } from "./goals.js";
 import { heartbeatRuns } from "./heartbeat_runs.js";
+import { folders } from "./folders.js";
 import type { RoutineEnvConfig, RoutineRevisionSnapshotV1, RoutineVariable } from "@paperclipai/shared";
 
 export const routines = pgTable(
@@ -25,6 +26,7 @@ export const routines = pgTable(
     id: uuid("id").primaryKey().defaultRandom(),
     companyId: uuid("company_id").notNull().references(() => companies.id, { onDelete: "cascade" }),
     projectId: uuid("project_id").references(() => projects.id, { onDelete: "cascade" }),
+    folderId: uuid("folder_id").references(() => folders.id, { onDelete: "set null" }),
     goalId: uuid("goal_id").references(() => goals.id, { onDelete: "set null" }),
     parentIssueId: uuid("parent_issue_id").references(() => issues.id, { onDelete: "set null" }),
     title: text("title").notNull(),
@@ -56,6 +58,7 @@ export const routines = pgTable(
     companyStatusIdx: index("routines_company_status_idx").on(table.companyId, table.status),
     companyAssigneeIdx: index("routines_company_assignee_idx").on(table.companyId, table.assigneeAgentId),
     companyProjectIdx: index("routines_company_project_idx").on(table.companyId, table.projectId),
+    companyFolderIdx: index("routines_company_folder_idx").on(table.companyId, table.folderId),
     companyResponsibleUserIdx: index("routines_company_responsible_user_idx").on(table.companyId, table.responsibleUserId),
     companyOriginIdx: index("routines_company_origin_idx").on(table.companyId, table.originKind, table.originId),
   }),

--- a/packages/shared/src/api.ts
+++ b/packages/shared/src/api.ts
@@ -3,6 +3,10 @@ export const API_PREFIX = "/api";
 export const API = {
   health: `${API_PREFIX}/health`,
   companies: `${API_PREFIX}/companies`,
+  companyFolders: `${API_PREFIX}/companies/:companyId/folders`,
+  companyFolder: `${API_PREFIX}/companies/:companyId/folders/:folderId`,
+  companyFolderMove: `${API_PREFIX}/companies/:companyId/folders/:folderId/move`,
+  companyFolderItemMove: `${API_PREFIX}/companies/:companyId/folders/items/move`,
   agents: `${API_PREFIX}/agents`,
   projects: `${API_PREFIX}/projects`,
   environments: `${API_PREFIX}/environments`,

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -2079,12 +2079,36 @@ export type {
 } from "./environment-support.js";
 
 export type { AdapterRegistryEntry } from "./types/adapter-registry.js";
+export type {
+  FolderKind,
+  Folder,
+  FolderListItem,
+  FolderListResult,
+  CreateFolderRequest,
+  UpdateFolderRequest,
+  MoveFolderRequest,
+  MoveFolderItemRequest,
+} from "./types/folder.js";
 
 export {
   adapterRegistryEntrySchema,
   adapterRegistrySchema,
   type AdapterRegistryEntryParsed,
 } from "./validators/adapter-registry.js";
+export {
+  folderKindSchema,
+  folderSchema,
+  folderListItemSchema,
+  folderListResultSchema,
+  createFolderSchema,
+  updateFolderSchema,
+  moveFolderSchema,
+  moveFolderItemSchema,
+  type CreateFolder,
+  type UpdateFolder,
+  type MoveFolder,
+  type MoveFolderItem,
+} from "./validators/folder.js";
 
 export {
   environmentCustomImageTemplateKindSchema,

--- a/packages/shared/src/types/company-skill.ts
+++ b/packages/shared/src/types/company-skill.ts
@@ -34,6 +34,7 @@ export interface CompanySkillVersionFileInventoryEntry extends CompanySkillFileI
 export interface CompanySkill {
   id: string;
   companyId: string;
+  folderId?: string | null;
   key: string;
   slug: string;
   name: string;
@@ -67,6 +68,7 @@ export interface CompanySkill {
 export interface CompanySkillListItem {
   id: string;
   companyId: string;
+  folderId?: string | null;
   key: string;
   slug: string;
   name: string;

--- a/packages/shared/src/types/folder.ts
+++ b/packages/shared/src/types/folder.ts
@@ -1,0 +1,46 @@
+export type FolderKind = "routine" | "skill";
+
+export interface Folder {
+  id: string;
+  companyId: string;
+  kind: FolderKind;
+  name: string;
+  color: string | null;
+  position: number;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface FolderListItem extends Folder {
+  itemCount: number;
+}
+
+export interface FolderListResult {
+  kind: FolderKind;
+  folders: FolderListItem[];
+  allCount: number;
+  unfiledCount: number;
+}
+
+export interface CreateFolderRequest {
+  kind: FolderKind;
+  name: string;
+  color?: string | null;
+  position?: number | null;
+}
+
+export interface UpdateFolderRequest {
+  name?: string;
+  color?: string | null;
+  position?: number;
+}
+
+export interface MoveFolderRequest {
+  position: number;
+}
+
+export interface MoveFolderItemRequest {
+  kind: FolderKind;
+  itemId: string;
+  folderId?: string | null;
+}

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -162,6 +162,16 @@ export type {
   CompanySkillInstallCatalogResult,
 } from "./company-skill.js";
 export type {
+  FolderKind,
+  Folder,
+  FolderListItem,
+  FolderListResult,
+  CreateFolderRequest,
+  UpdateFolderRequest,
+  MoveFolderRequest,
+  MoveFolderItemRequest,
+} from "./folder.js";
+export type {
   CatalogTeamKind,
   CatalogTeamTrustLevel,
   CatalogTeamCompatibility,

--- a/packages/shared/src/types/routine.ts
+++ b/packages/shared/src/types/routine.ts
@@ -71,6 +71,7 @@ export interface Routine {
   id: string;
   companyId: string;
   projectId: string | null;
+  folderId?: string | null;
   goalId: string | null;
   parentIssueId: string | null;
   title: string;

--- a/packages/shared/src/validators/company-skill.ts
+++ b/packages/shared/src/validators/company-skill.ts
@@ -20,6 +20,7 @@ export const companySkillVersionFileInventoryEntrySchema = companySkillFileInven
 export const companySkillSchema = z.object({
   id: z.string().uuid(),
   companyId: z.string().uuid(),
+  folderId: z.string().uuid().nullable().optional(),
   key: z.string().min(1),
   slug: z.string().min(1),
   name: z.string().min(1),

--- a/packages/shared/src/validators/folder.ts
+++ b/packages/shared/src/validators/folder.ts
@@ -1,0 +1,55 @@
+import { z } from "zod";
+
+export const folderKindSchema = z.enum(["routine", "skill"]);
+
+export const folderSchema = z.object({
+  id: z.string().uuid(),
+  companyId: z.string().uuid(),
+  kind: folderKindSchema,
+  name: z.string().min(1),
+  color: z.string().nullable(),
+  position: z.number().int(),
+  createdAt: z.coerce.date(),
+  updatedAt: z.coerce.date(),
+});
+
+export const folderListItemSchema = folderSchema.extend({
+  itemCount: z.number().int().nonnegative(),
+});
+
+export const folderListResultSchema = z.object({
+  kind: folderKindSchema,
+  folders: z.array(folderListItemSchema),
+  allCount: z.number().int().nonnegative(),
+  unfiledCount: z.number().int().nonnegative(),
+});
+
+export const createFolderSchema = z.object({
+  kind: folderKindSchema,
+  name: z.string().trim().min(1).max(120),
+  color: z.string().trim().min(1).max(80).optional().nullable(),
+  position: z.number().int().min(0).optional().nullable(),
+});
+
+export const updateFolderSchema = z.object({
+  name: z.string().trim().min(1).max(120).optional(),
+  color: z.string().trim().min(1).max(80).optional().nullable(),
+  position: z.number().int().min(0).optional(),
+}).refine((value) => Object.keys(value).length > 0, {
+  message: "At least one folder field is required",
+});
+
+export const moveFolderSchema = z.object({
+  position: z.number().int().min(0),
+});
+
+export const moveFolderItemSchema = z.object({
+  kind: folderKindSchema,
+  itemId: z.string().uuid(),
+  folderId: z.string().uuid().optional().nullable(),
+});
+
+export type CreateFolder = z.infer<typeof createFolderSchema>;
+export type UpdateFolder = z.infer<typeof updateFolderSchema>;
+export type MoveFolder = z.infer<typeof moveFolderSchema>;
+export type MoveFolderItem = z.infer<typeof moveFolderItemSchema>;

--- a/packages/shared/src/validators/index.ts
+++ b/packages/shared/src/validators/index.ts
@@ -195,6 +195,20 @@ export {
   type CompanySkillReset,
 } from "./company-skill.js";
 export {
+  folderKindSchema,
+  folderSchema,
+  folderListItemSchema,
+  folderListResultSchema,
+  createFolderSchema,
+  updateFolderSchema,
+  moveFolderSchema,
+  moveFolderItemSchema,
+  type CreateFolder,
+  type UpdateFolder,
+  type MoveFolder,
+  type MoveFolderItem,
+} from "./folder.js";
+export {
   catalogTeamKindSchema,
   catalogTeamTrustLevelSchema,
   catalogTeamCompatibilitySchema,

--- a/packages/shared/src/validators/routine.ts
+++ b/packages/shared/src/validators/routine.ts
@@ -61,6 +61,7 @@ export const routineVariableSchema = z.object({
 
 export const createRoutineSchema = z.object({
   projectId: z.string().uuid().optional().nullable(),
+  folderId: z.string().uuid().optional().nullable(),
   goalId: z.string().uuid().optional().nullable(),
   parentIssueId: z.string().uuid().optional().nullable(),
   title: z.string().trim().min(1).max(200),
@@ -85,6 +86,7 @@ export const routineRevisionSnapshotRoutineV1Schema = z.object({
   id: z.string().uuid(),
   companyId: z.string().uuid(),
   projectId: z.string().uuid().nullable(),
+  folderId: z.string().uuid().nullable().optional(),
   goalId: z.string().uuid().nullable(),
   parentIssueId: z.string().uuid().nullable(),
   title: z.string().trim().min(1).max(200),

--- a/server/src/__tests__/folders-routes.test.ts
+++ b/server/src/__tests__/folders-routes.test.ts
@@ -1,0 +1,74 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockFolderService = vi.hoisted(() => ({
+  list: vi.fn(),
+  create: vi.fn(),
+  update: vi.fn(),
+  moveFolder: vi.fn(),
+  moveItem: vi.fn(),
+  deleteFolder: vi.fn(),
+}));
+
+const mockLogActivity = vi.hoisted(() => vi.fn());
+
+vi.mock("../services/index.js", () => ({
+  folderService: () => mockFolderService,
+  logActivity: mockLogActivity,
+}));
+
+async function createApp() {
+  vi.resetModules();
+  const [{ errorHandler }, { folderRoutes }] = await Promise.all([
+    import("../middleware/index.js") as Promise<typeof import("../middleware/index.js")>,
+    import("../routes/folders.js") as Promise<typeof import("../routes/folders.js")>,
+  ]);
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as any).actor = {
+      type: "board",
+      userId: "user-1",
+      companyIds: ["company-1"],
+      source: "session",
+      isInstanceAdmin: false,
+    };
+    next();
+  });
+  app.use("/api", folderRoutes({} as any));
+  app.use(errorHandler);
+  return app;
+}
+
+describe("folder routes", () => {
+  beforeEach(() => {
+    for (const mock of Object.values(mockFolderService)) mock.mockReset();
+    mockLogActivity.mockReset();
+  });
+
+  it("routes item moves to the item move handler before the folder reorder route", async () => {
+    mockFolderService.moveItem.mockResolvedValue({
+      kind: "routine",
+      itemId: "11111111-1111-4111-8111-111111111111",
+      folderId: "22222222-2222-4222-8222-222222222222",
+    });
+
+    const app = await createApp();
+    const res = await request(app)
+      .post("/api/companies/company-1/folders/items/move")
+      .send({
+        kind: "routine",
+        itemId: "11111111-1111-4111-8111-111111111111",
+        folderId: "22222222-2222-4222-8222-222222222222",
+      });
+
+    expect(res.status).toBe(200);
+    expect(mockFolderService.moveItem).toHaveBeenCalledWith("company-1", {
+      kind: "routine",
+      itemId: "11111111-1111-4111-8111-111111111111",
+      folderId: "22222222-2222-4222-8222-222222222222",
+    });
+    expect(mockFolderService.moveFolder).not.toHaveBeenCalled();
+  });
+});

--- a/server/src/__tests__/folders-service.test.ts
+++ b/server/src/__tests__/folders-service.test.ts
@@ -1,0 +1,172 @@
+import { randomUUID } from "node:crypto";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { eq } from "drizzle-orm";
+import {
+  companies,
+  companySkills,
+  createDb,
+  folders,
+  routines,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import { folderService } from "../services/folders.js";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+describeEmbeddedPostgres("folder service", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-folders-");
+    db = createDb(tempDb.connectionString);
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.delete(companySkills);
+    await db.delete(routines);
+    await db.delete(folders);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  async function seedCompany() {
+    const companyId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+      defaultResponsibleUserId: "responsible-user",
+    });
+    return companyId;
+  }
+
+  async function seedRoutine(companyId: string, title: string, folderId?: string | null) {
+    const [routine] = await db
+      .insert(routines)
+      .values({
+        companyId,
+        title,
+        folderId: folderId ?? null,
+        responsibleUserId: "responsible-user",
+      })
+      .returning();
+    return routine!;
+  }
+
+  async function seedSkill(companyId: string, slug: string, folderId?: string | null) {
+    const [skill] = await db
+      .insert(companySkills)
+      .values({
+        companyId,
+        folderId: folderId ?? null,
+        key: `company/${companyId}/${slug}`,
+        slug,
+        name: slug,
+        markdown: `# ${slug}`,
+      })
+      .returning();
+    return skill!;
+  }
+
+  it("creates, updates, reorders, and lists routine folders with counts", async () => {
+    const companyId = await seedCompany();
+    const svc = folderService(db);
+
+    const reporting = await svc.create(companyId, {
+      kind: "routine",
+      name: "Reporting",
+      color: "green",
+    });
+    const cleanup = await svc.create(companyId, {
+      kind: "routine",
+      name: "Cleanup",
+      color: null,
+    });
+    await seedRoutine(companyId, "Filed", reporting.id);
+    await seedRoutine(companyId, "Unfiled");
+
+    const renamed = await svc.update(companyId, cleanup.id, { name: "Ops", color: "cyan" });
+    expect(renamed).toMatchObject({ id: cleanup.id, name: "Ops", color: "cyan" });
+
+    const movedFolder = await svc.moveFolder(companyId, reporting.id, { position: 10 });
+    expect(movedFolder).toMatchObject({ id: reporting.id, position: 10 });
+
+    const listed = await svc.list(companyId, "routine");
+    expect(listed.allCount).toBe(2);
+    expect(listed.unfiledCount).toBe(1);
+    expect(listed.folders).toEqual([
+      expect.objectContaining({ id: cleanup.id, name: "Ops", itemCount: 0 }),
+      expect.objectContaining({ id: reporting.id, name: "Reporting", itemCount: 1 }),
+    ]);
+  });
+
+  it("moves routines and skills to folders and back to virtual Unfiled", async () => {
+    const companyId = await seedCompany();
+    const svc = folderService(db);
+    const routineFolder = await svc.create(companyId, { kind: "routine", name: "Reports" });
+    const skillFolder = await svc.create(companyId, { kind: "skill", name: "Runtime" });
+    const routine = await seedRoutine(companyId, "Daily report");
+    const skill = await seedSkill(companyId, "review");
+
+    await expect(svc.moveItem(companyId, {
+      kind: "routine",
+      itemId: routine.id,
+      folderId: routineFolder.id,
+    })).resolves.toEqual({ kind: "routine", itemId: routine.id, folderId: routineFolder.id });
+    await expect(svc.moveItem(companyId, {
+      kind: "skill",
+      itemId: skill.id,
+      folderId: skillFolder.id,
+    })).resolves.toEqual({ kind: "skill", itemId: skill.id, folderId: skillFolder.id });
+
+    await expect(svc.moveItem(companyId, {
+      kind: "routine",
+      itemId: routine.id,
+      folderId: null,
+    })).resolves.toEqual({ kind: "routine", itemId: routine.id, folderId: null });
+
+    const [updatedRoutine] = await db.select().from(routines).where(eq(routines.id, routine.id));
+    const [updatedSkill] = await db.select().from(companySkills).where(eq(companySkills.id, skill.id));
+    expect(updatedRoutine?.folderId).toBeNull();
+    expect(updatedSkill?.folderId).toBe(skillFolder.id);
+  });
+
+  it("rejects moving an item into a folder of the wrong kind", async () => {
+    const companyId = await seedCompany();
+    const svc = folderService(db);
+    const skillFolder = await svc.create(companyId, { kind: "skill", name: "Runtime" });
+    const routine = await seedRoutine(companyId, "Daily report");
+
+    await expect(svc.moveItem(companyId, {
+      kind: "routine",
+      itemId: routine.id,
+      folderId: skillFolder.id,
+    })).rejects.toMatchObject({
+      status: 422,
+      message: "Folder kind must match item kind",
+    });
+  });
+
+  it("deletes folders without deleting contents by moving items to Unfiled", async () => {
+    const companyId = await seedCompany();
+    const svc = folderService(db);
+    const folder = await svc.create(companyId, { kind: "routine", name: "Reports" });
+    const routine = await seedRoutine(companyId, "Daily report", folder.id);
+
+    const deleted = await svc.deleteFolder(companyId, folder.id);
+    expect(deleted).toMatchObject({ id: folder.id, name: "Reports" });
+
+    const [updatedRoutine] = await db.select().from(routines).where(eq(routines.id, routine.id));
+    expect(updatedRoutine?.folderId).toBeNull();
+    expect(await db.select().from(folders).where(eq(folders.id, folder.id))).toHaveLength(0);
+  });
+});

--- a/server/src/__tests__/openapi-routes.test.ts
+++ b/server/src/__tests__/openapi-routes.test.ts
@@ -30,6 +30,7 @@ const apiPrefixes: Record<string, string> = {
   "environments.ts": "/api",
   "execution-workspaces.ts": "/api",
   "file-resources.ts": "/api",
+  "folders.ts": "/api",
   "goals.ts": "/api",
   "health.ts": "/api/health",
   "inbox-dismissals.ts": "/api",
@@ -171,6 +172,10 @@ describe("openapi routes", () => {
         name: { type: "string" },
       },
     });
+    expect(res.body.paths["/api/companies/{companyId}/folders"].post.responses["201"]).toBeDefined();
+    expect(res.body.paths["/api/companies/{companyId}/folders/items/move"].post.summary).toBe(
+      "Move an item into or out of a folder",
+    );
     expect(JSON.stringify(res.body.paths["/api/tool-gateway/tools"].get)).not.toContain("sessionToken");
     expect(JSON.stringify(res.body.paths["/api/tool-gateway/tools/call"].post)).not.toContain("sessionToken");
   });

--- a/server/src/__tests__/routines-service.test.ts
+++ b/server/src/__tests__/routines-service.test.ts
@@ -12,6 +12,7 @@ import {
   documentRevisions,
   documents,
   executionWorkspaces,
+  folders,
   heartbeatRuns,
   instanceSettings,
   issueInboxArchives,
@@ -68,6 +69,7 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
     await db.delete(routineRuns);
     await db.delete(routineTriggers);
     await db.delete(routines);
+    await db.delete(folders);
     await db.delete(routineDocuments);
     await db.delete(documents);
     await db.delete(documentRevisions);
@@ -269,6 +271,38 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
 
     expect(projectRoutines.map((entry) => entry.id)).toEqual([routine.id]);
     expect(allRoutines.map((entry) => entry.id)).toEqual(expect.arrayContaining([routine.id, otherRoutine.id]));
+  });
+
+  it("does not reveal folders owned by another company", async () => {
+    const { companyId, agentId, projectId, svc } = await seedFixture();
+    const otherCompanyId = randomUUID();
+    await db.insert(companies).values({
+      id: otherCompanyId,
+      name: "Other company",
+      issuePrefix: `T${otherCompanyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      defaultResponsibleUserId: randomUUID(),
+      requireBoardApprovalForNewAgents: false,
+    });
+    const [otherFolder] = await db.insert(folders).values({
+      companyId: otherCompanyId,
+      kind: "routine",
+      name: "Private folder",
+      position: 0,
+    }).returning();
+
+    await expect(svc.create(companyId, {
+      projectId,
+      folderId: otherFolder!.id,
+      goalId: null,
+      parentIssueId: null,
+      title: "cross-company folder probe",
+      description: null,
+      assigneeAgentId: agentId,
+      priority: "medium",
+      status: "active",
+      concurrencyPolicy: "coalesce_if_active",
+      catchUpPolicy: "skip_missed",
+    }, {})).rejects.toMatchObject({ status: 404, message: "Folder not found" });
   });
 
   it("defaults activity gates to always at company scope", async () => {

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -16,6 +16,7 @@ import { companyRoutes } from "./routes/companies.js";
 import { companySkillRoutes } from "./routes/company-skills.js";
 import { companySkillPolicyRoutes } from "./routes/company-skill-policy.js";
 import { builtInAgentRoutes } from "./routes/built-in-agents.js";
+import { folderRoutes } from "./routes/folders.js";
 import { teamsCatalogRoutes } from "./routes/teams-catalog.js";
 import { agentRoutes } from "./routes/agents.js";
 import { projectRoutes } from "./routes/projects.js";
@@ -235,6 +236,7 @@ export async function createApp(
   api.use(openApiRoutes());
   api.use("/companies", companyRoutes(db, opts.storageService));
   api.use(llmRoutes(db));
+  api.use(folderRoutes(db));
   api.use(companySkillRoutes(db));
   api.use(companySkillPolicyRoutes(db));
   api.use(builtInAgentRoutes(db));

--- a/server/src/routes/folders.ts
+++ b/server/src/routes/folders.ts
@@ -71,6 +71,25 @@ export function folderRoutes(db: Db) {
     res.json(updated);
   });
 
+  router.post("/companies/:companyId/folders/items/move", validate(moveFolderItemSchema), async (req, res) => {
+    const companyId = req.params.companyId as string;
+    assertCompanyAccess(req, companyId);
+    const moved = await svc.moveItem(companyId, req.body);
+    const actor = getActorInfo(req);
+    await logActivity(db, {
+      companyId,
+      actorType: actor.actorType,
+      actorId: actor.actorId,
+      agentId: actor.agentId,
+      runId: actor.runId,
+      action: "folder.item_moved",
+      entityType: req.body.kind === "routine" ? "routine" : "company_skill",
+      entityId: moved.itemId,
+      details: { kind: moved.kind, folderId: moved.folderId },
+    });
+    res.json(moved);
+  });
+
   router.post("/companies/:companyId/folders/:folderId/move", validate(moveFolderSchema), async (req, res) => {
     const companyId = req.params.companyId as string;
     const folderId = req.params.folderId as string;
@@ -93,25 +112,6 @@ export function folderRoutes(db: Db) {
       details: { kind: updated.kind, position: updated.position },
     });
     res.json(updated);
-  });
-
-  router.post("/companies/:companyId/folders/items/move", validate(moveFolderItemSchema), async (req, res) => {
-    const companyId = req.params.companyId as string;
-    assertCompanyAccess(req, companyId);
-    const moved = await svc.moveItem(companyId, req.body);
-    const actor = getActorInfo(req);
-    await logActivity(db, {
-      companyId,
-      actorType: actor.actorType,
-      actorId: actor.actorId,
-      agentId: actor.agentId,
-      runId: actor.runId,
-      action: "folder.item_moved",
-      entityType: req.body.kind === "routine" ? "routine" : "company_skill",
-      entityId: moved.itemId,
-      details: { kind: moved.kind, folderId: moved.folderId },
-    });
-    res.json(moved);
   });
 
   router.delete("/companies/:companyId/folders/:folderId", async (req, res) => {

--- a/server/src/routes/folders.ts
+++ b/server/src/routes/folders.ts
@@ -1,0 +1,142 @@
+import { Router } from "express";
+import type { Db } from "@paperclipai/db";
+import {
+  createFolderSchema,
+  folderKindSchema,
+  moveFolderItemSchema,
+  moveFolderSchema,
+  updateFolderSchema,
+} from "@paperclipai/shared";
+import { validate } from "../middleware/validate.js";
+import { badRequest } from "../errors.js";
+import { folderService, logActivity } from "../services/index.js";
+import { assertCompanyAccess, getActorInfo } from "./authz.js";
+
+export function folderRoutes(db: Db) {
+  const router = Router();
+  const svc = folderService(db);
+
+  function parseKind(value: unknown) {
+    const result = folderKindSchema.safeParse(value);
+    if (!result.success) throw badRequest("Folder kind query parameter is required");
+    return result.data;
+  }
+
+  router.get("/companies/:companyId/folders", async (req, res) => {
+    const companyId = req.params.companyId as string;
+    assertCompanyAccess(req, companyId);
+    res.json(await svc.list(companyId, parseKind(req.query.kind)));
+  });
+
+  router.post("/companies/:companyId/folders", validate(createFolderSchema), async (req, res) => {
+    const companyId = req.params.companyId as string;
+    assertCompanyAccess(req, companyId);
+    const created = await svc.create(companyId, req.body);
+    const actor = getActorInfo(req);
+    await logActivity(db, {
+      companyId,
+      actorType: actor.actorType,
+      actorId: actor.actorId,
+      agentId: actor.agentId,
+      runId: actor.runId,
+      action: "folder.created",
+      entityType: "folder",
+      entityId: created.id,
+      details: { kind: created.kind, name: created.name, position: created.position },
+    });
+    res.status(201).json(created);
+  });
+
+  router.patch("/companies/:companyId/folders/:folderId", validate(updateFolderSchema), async (req, res) => {
+    const companyId = req.params.companyId as string;
+    const folderId = req.params.folderId as string;
+    assertCompanyAccess(req, companyId);
+    const updated = await svc.update(companyId, folderId, req.body);
+    if (!updated) {
+      res.status(404).json({ error: "Folder not found" });
+      return;
+    }
+    const actor = getActorInfo(req);
+    await logActivity(db, {
+      companyId,
+      actorType: actor.actorType,
+      actorId: actor.actorId,
+      agentId: actor.agentId,
+      runId: actor.runId,
+      action: "folder.updated",
+      entityType: "folder",
+      entityId: updated.id,
+      details: { kind: updated.kind, name: updated.name, position: updated.position },
+    });
+    res.json(updated);
+  });
+
+  router.post("/companies/:companyId/folders/:folderId/move", validate(moveFolderSchema), async (req, res) => {
+    const companyId = req.params.companyId as string;
+    const folderId = req.params.folderId as string;
+    assertCompanyAccess(req, companyId);
+    const updated = await svc.moveFolder(companyId, folderId, req.body);
+    if (!updated) {
+      res.status(404).json({ error: "Folder not found" });
+      return;
+    }
+    const actor = getActorInfo(req);
+    await logActivity(db, {
+      companyId,
+      actorType: actor.actorType,
+      actorId: actor.actorId,
+      agentId: actor.agentId,
+      runId: actor.runId,
+      action: "folder.moved",
+      entityType: "folder",
+      entityId: updated.id,
+      details: { kind: updated.kind, position: updated.position },
+    });
+    res.json(updated);
+  });
+
+  router.post("/companies/:companyId/folders/items/move", validate(moveFolderItemSchema), async (req, res) => {
+    const companyId = req.params.companyId as string;
+    assertCompanyAccess(req, companyId);
+    const moved = await svc.moveItem(companyId, req.body);
+    const actor = getActorInfo(req);
+    await logActivity(db, {
+      companyId,
+      actorType: actor.actorType,
+      actorId: actor.actorId,
+      agentId: actor.agentId,
+      runId: actor.runId,
+      action: "folder.item_moved",
+      entityType: req.body.kind === "routine" ? "routine" : "company_skill",
+      entityId: moved.itemId,
+      details: { kind: moved.kind, folderId: moved.folderId },
+    });
+    res.json(moved);
+  });
+
+  router.delete("/companies/:companyId/folders/:folderId", async (req, res) => {
+    const companyId = req.params.companyId as string;
+    const folderId = req.params.folderId as string;
+    assertCompanyAccess(req, companyId);
+    const deleted = await svc.deleteFolder(companyId, folderId);
+    if (!deleted) {
+      res.status(404).json({ error: "Folder not found" });
+      return;
+    }
+    const actor = getActorInfo(req);
+    await logActivity(db, {
+      companyId,
+      actorType: actor.actorType,
+      actorId: actor.actorId,
+      agentId: actor.agentId,
+      runId: actor.runId,
+      action: "folder.deleted",
+      entityType: "folder",
+      entityId: deleted.id,
+      details: { kind: deleted.kind, name: deleted.name },
+    });
+    res.json({ deleted });
+  });
+
+  return router;
+}

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -3,6 +3,7 @@ export { companyRoutes } from "./companies.js";
 export { companySkillRoutes } from "./company-skills.js";
 export { companySkillPolicyRoutes } from "./company-skill-policy.js";
 export { builtInAgentRoutes } from "./built-in-agents.js";
+export { folderRoutes } from "./folders.js";
 export { teamsCatalogRoutes } from "./teams-catalog.js";
 export { agentRoutes } from "./agents.js";
 export { projectRoutes } from "./projects.js";

--- a/server/src/routes/openapi.ts
+++ b/server/src/routes/openapi.ts
@@ -47,6 +47,12 @@ import {
   updateRoutineTriggerSchema,
   rotateRoutineTriggerSecretSchema,
   runRoutineSchema,
+  // Folders
+  createFolderSchema,
+  folderKindSchema,
+  moveFolderItemSchema,
+  moveFolderSchema,
+  updateFolderSchema,
   // Goal
   createGoalSchema,
   updateGoalSchema,
@@ -861,6 +867,7 @@ const CREATED_OPERATIONS = new Set([
   "POST /api/companies/{companyId}/projects",
   "POST /api/projects/{id}/workspaces",
   "POST /api/companies/{companyId}/routines",
+  "POST /api/companies/{companyId}/folders",
   "POST /api/routines/{id}/triggers",
   "POST /api/companies/{companyId}/secrets",
   "POST /api/companies/{companyId}/user-secret-definitions",
@@ -5150,6 +5157,53 @@ for (const route of [
     summary: route[2],
   });
 }
+
+registerCurrentRoute({
+  method: "get",
+  path: "/api/companies/{companyId}/folders",
+  tags: ["folders"],
+  summary: "List folders for a company item kind",
+  query: z.object({ kind: folderKindSchema }),
+});
+
+registerCurrentRoute({
+  method: "post",
+  path: "/api/companies/{companyId}/folders",
+  tags: ["folders"],
+  summary: "Create a folder",
+  body: createFolderSchema,
+});
+
+registerCurrentRoute({
+  method: "patch",
+  path: "/api/companies/{companyId}/folders/{folderId}",
+  tags: ["folders"],
+  summary: "Update a folder",
+  body: updateFolderSchema,
+});
+
+registerCurrentRoute({
+  method: "post",
+  path: "/api/companies/{companyId}/folders/items/move",
+  tags: ["folders"],
+  summary: "Move an item into or out of a folder",
+  body: moveFolderItemSchema,
+});
+
+registerCurrentRoute({
+  method: "post",
+  path: "/api/companies/{companyId}/folders/{folderId}/move",
+  tags: ["folders"],
+  summary: "Reorder a folder",
+  body: moveFolderSchema,
+});
+
+registerCurrentRoute({
+  method: "delete",
+  path: "/api/companies/{companyId}/folders/{folderId}",
+  tags: ["folders"],
+  summary: "Delete a folder",
+});
 
 registerCurrentRoute({
   method: "get",

--- a/server/src/services/company-skills.ts
+++ b/server/src/services/company-skills.ts
@@ -118,6 +118,7 @@ type CompanySkillListDbRow = Pick<
   CompanySkillRow,
   | "id"
   | "companyId"
+  | "folderId"
   | "key"
   | "slug"
   | "name"
@@ -150,6 +151,7 @@ type CompanySkillListRow = Pick<
   CompanySkill,
   | "id"
   | "companyId"
+  | "folderId"
   | "key"
   | "slug"
   | "name"
@@ -375,6 +377,7 @@ function selectCompanySkillColumns() {
   return {
     id: companySkills.id,
     companyId: companySkills.companyId,
+    folderId: companySkills.folderId,
     key: companySkills.key,
     slug: companySkills.slug,
     name: companySkills.name,
@@ -2518,6 +2521,7 @@ function toCompanySkillListItem(skill: CompanySkillListRow, attachedAgentCount: 
   return {
     id: skill.id,
     companyId: skill.companyId,
+    folderId: skill.folderId,
     key: skill.key,
     slug: skill.slug,
     name: skill.name,
@@ -2783,6 +2787,7 @@ export function companySkillService(db: Db) {
       .select({
         id: companySkills.id,
         companyId: companySkills.companyId,
+        folderId: companySkills.folderId,
         key: companySkills.key,
         slug: companySkills.slug,
         name: companySkills.name,

--- a/server/src/services/folders.ts
+++ b/server/src/services/folders.ts
@@ -1,0 +1,229 @@
+import { and, asc, eq, max, sql } from "drizzle-orm";
+import type { Db } from "@paperclipai/db";
+import { companySkills, folders, routines } from "@paperclipai/db";
+import type {
+  CreateFolder,
+  Folder,
+  FolderKind,
+  FolderListResult,
+  MoveFolder,
+  MoveFolderItem,
+  UpdateFolder,
+} from "@paperclipai/shared";
+import { conflict, notFound, unprocessable } from "../errors.js";
+
+type FolderRow = typeof folders.$inferSelect;
+
+function mapFolder(row: FolderRow): Folder {
+  return {
+    ...row,
+    color: row.color ?? null,
+  };
+}
+
+function normalizeName(name: string) {
+  return name.trim();
+}
+
+function normalizeColor(color: string | null | undefined) {
+  if (color === undefined) return undefined;
+  const trimmed = color?.trim() ?? "";
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+export function folderService(db: Db) {
+  async function getFolder(companyId: string, folderId: string) {
+    return db
+      .select()
+      .from(folders)
+      .where(and(eq(folders.companyId, companyId), eq(folders.id, folderId)))
+      .then((rows) => rows[0] ?? null);
+  }
+
+  async function assertNoNameConflict(companyId: string, kind: FolderKind, name: string, excludeFolderId?: string) {
+    const existing = await db
+      .select({ id: folders.id })
+      .from(folders)
+      .where(and(eq(folders.companyId, companyId), eq(folders.kind, kind), eq(folders.name, name)))
+      .then((rows) => rows[0] ?? null);
+    if (existing && existing.id !== excludeFolderId) {
+      throw conflict("Folder name already exists for this kind");
+    }
+  }
+
+  async function nextPosition(companyId: string, kind: FolderKind) {
+    const row = await db
+      .select({ value: max(folders.position) })
+      .from(folders)
+      .where(and(eq(folders.companyId, companyId), eq(folders.kind, kind)))
+      .then((rows) => rows[0] ?? null);
+    return Number(row?.value ?? -1) + 1;
+  }
+
+  async function routineCounts(companyId: string) {
+    return db
+      .select({
+        folderId: routines.folderId,
+        count: sql<number>`count(*)::int`,
+      })
+      .from(routines)
+      .where(eq(routines.companyId, companyId))
+      .groupBy(routines.folderId);
+  }
+
+  async function skillCounts(companyId: string) {
+    return db
+      .select({
+        folderId: companySkills.folderId,
+        count: sql<number>`count(*)::int`,
+      })
+      .from(companySkills)
+      .where(eq(companySkills.companyId, companyId))
+      .groupBy(companySkills.folderId);
+  }
+
+  async function list(companyId: string, kind: FolderKind): Promise<FolderListResult> {
+    const [folderRows, countRows] = await Promise.all([
+      db
+        .select()
+        .from(folders)
+        .where(and(eq(folders.companyId, companyId), eq(folders.kind, kind)))
+        .orderBy(asc(folders.position), asc(folders.name), asc(folders.id)),
+      kind === "routine" ? routineCounts(companyId) : skillCounts(companyId),
+    ]);
+
+    const countsByFolderId = new Map<string | null, number>();
+    for (const row of countRows) {
+      countsByFolderId.set(row.folderId ?? null, Number(row.count ?? 0));
+    }
+
+    return {
+      kind,
+      folders: folderRows.map((row) => ({
+        ...mapFolder(row),
+        itemCount: countsByFolderId.get(row.id) ?? 0,
+      })),
+      allCount: Array.from(countsByFolderId.values()).reduce((sum, count) => sum + count, 0),
+      unfiledCount: countsByFolderId.get(null) ?? 0,
+    };
+  }
+
+  async function create(companyId: string, input: CreateFolder): Promise<Folder> {
+    const name = normalizeName(input.name);
+    await assertNoNameConflict(companyId, input.kind, name);
+    const position = input.position ?? await nextPosition(companyId, input.kind);
+    const row = await db
+      .insert(folders)
+      .values({
+        companyId,
+        kind: input.kind,
+        name,
+        color: normalizeColor(input.color) ?? null,
+        position,
+      })
+      .returning()
+      .then((rows) => rows[0] ?? null);
+    if (!row) throw notFound("Failed to create folder");
+    return mapFolder(row);
+  }
+
+  async function update(companyId: string, folderId: string, patch: UpdateFolder): Promise<Folder | null> {
+    const existing = await getFolder(companyId, folderId);
+    if (!existing) return null;
+    const nextName = patch.name === undefined ? existing.name : normalizeName(patch.name);
+    if (nextName !== existing.name) {
+      await assertNoNameConflict(companyId, existing.kind, nextName, folderId);
+    }
+    const row = await db
+      .update(folders)
+      .set({
+        name: nextName,
+        color: patch.color === undefined ? existing.color : normalizeColor(patch.color),
+        position: patch.position ?? existing.position,
+        updatedAt: new Date(),
+      })
+      .where(and(eq(folders.companyId, companyId), eq(folders.id, folderId)))
+      .returning()
+      .then((rows) => rows[0] ?? null);
+    return row ? mapFolder(row) : null;
+  }
+
+  async function moveFolder(companyId: string, folderId: string, input: MoveFolder): Promise<Folder | null> {
+    const row = await db
+      .update(folders)
+      .set({ position: input.position, updatedAt: new Date() })
+      .where(and(eq(folders.companyId, companyId), eq(folders.id, folderId)))
+      .returning()
+      .then((rows) => rows[0] ?? null);
+    return row ? mapFolder(row) : null;
+  }
+
+  async function deleteFolder(companyId: string, folderId: string): Promise<Folder | null> {
+    return db.transaction(async (tx) => {
+      const txDb = tx as unknown as Db;
+      const folder = await txDb
+        .select()
+        .from(folders)
+        .where(and(eq(folders.companyId, companyId), eq(folders.id, folderId)))
+        .then((rows) => rows[0] ?? null);
+      if (!folder) return null;
+
+      if (folder.kind === "routine") {
+        await txDb
+          .update(routines)
+          .set({ folderId: null, updatedAt: new Date() })
+          .where(and(eq(routines.companyId, companyId), eq(routines.folderId, folderId)));
+      } else {
+        await txDb
+          .update(companySkills)
+          .set({ folderId: null, updatedAt: new Date() })
+          .where(and(eq(companySkills.companyId, companyId), eq(companySkills.folderId, folderId)));
+      }
+
+      await txDb
+        .delete(folders)
+        .where(and(eq(folders.companyId, companyId), eq(folders.id, folderId)));
+      return mapFolder(folder);
+    });
+  }
+
+  async function assertTargetFolder(companyId: string, kind: FolderKind, folderId: string | null | undefined) {
+    if (!folderId) return null;
+    const folder = await getFolder(companyId, folderId);
+    if (!folder) throw notFound("Folder not found");
+    if (folder.kind !== kind) throw unprocessable("Folder kind must match item kind");
+    return folder;
+  }
+
+  async function moveItem(companyId: string, input: MoveFolderItem) {
+    const targetFolder = await assertTargetFolder(companyId, input.kind, input.folderId ?? null);
+    if (input.kind === "routine") {
+      const row = await db
+        .update(routines)
+        .set({ folderId: targetFolder?.id ?? null, updatedAt: new Date() })
+        .where(and(eq(routines.companyId, companyId), eq(routines.id, input.itemId)))
+        .returning({ id: routines.id, folderId: routines.folderId })
+        .then((rows) => rows[0] ?? null);
+      if (!row) throw notFound("Routine not found");
+      return { kind: input.kind, itemId: row.id, folderId: row.folderId ?? null };
+    }
+
+    const row = await db
+      .update(companySkills)
+      .set({ folderId: targetFolder?.id ?? null, updatedAt: new Date() })
+      .where(and(eq(companySkills.companyId, companyId), eq(companySkills.id, input.itemId)))
+      .returning({ id: companySkills.id, folderId: companySkills.folderId })
+      .then((rows) => rows[0] ?? null);
+    if (!row) throw notFound("Skill not found");
+    return { kind: input.kind, itemId: row.id, folderId: row.folderId ?? null };
+  }
+
+  return {
+    list,
+    create,
+    update,
+    moveFolder,
+    deleteFolder,
+    moveItem,
+  };
+}

--- a/server/src/services/index.ts
+++ b/server/src/services/index.ts
@@ -4,6 +4,7 @@ export { companySearchService } from "./company-search.js";
 export { feedbackService } from "./feedback.js";
 export { companySkillService } from "./company-skills.js";
 export { companySkillPolicyService, normalizeSkillPolicySourceType } from "./company-skill-policy.js";
+export { folderService } from "./folders.js";
 export { agentService, deduplicateAgentName } from "./agents.js";
 export {
   builtInAgentService,

--- a/server/src/services/routines.ts
+++ b/server/src/services/routines.ts
@@ -12,6 +12,7 @@ import {
   documentRevisions,
   documents,
   executionWorkspaces,
+  folders,
   goals,
   heartbeatRuns,
   issueInboxArchives,
@@ -956,6 +957,18 @@ export function routineService(
       .then((rows) => rows[0] ?? null);
     if (!parentIssue) throw notFound("Parent issue not found");
     if (parentIssue.companyId !== companyId) throw unprocessable("Parent issue must belong to same company");
+  }
+
+  async function assertRoutineFolder(companyId: string, folderId: string | null | undefined) {
+    if (!folderId) return;
+    const folder = await db
+      .select({ id: folders.id, companyId: folders.companyId, kind: folders.kind })
+      .from(folders)
+      .where(eq(folders.id, folderId))
+      .then((rows) => rows[0] ?? null);
+    if (!folder) throw notFound("Folder not found");
+    if (folder.companyId !== companyId) throw unprocessable("Folder must belong to same company");
+    if (folder.kind !== "routine") throw unprocessable("Folder kind must match routine");
   }
 
   async function listTriggersForRoutineIds(companyId: string, routineIds: string[]) {
@@ -2047,6 +2060,7 @@ export function routineService(
 
     create: async (companyId: string, input: CreateRoutine, actor: Actor): Promise<Routine> => {
       await assertProject(companyId, input.projectId ?? null);
+      await assertRoutineFolder(companyId, input.folderId ?? null);
       await assertAssignableAgent(db, companyId, input.assigneeAgentId ?? null, { kind: "routine" });
       if (input.goalId) await assertGoal(companyId, input.goalId);
       if (input.parentIssueId) await assertParentIssue(companyId, input.parentIssueId);
@@ -2073,6 +2087,7 @@ export function routineService(
           .values({
             companyId,
             projectId: input.projectId ?? null,
+            folderId: input.folderId ?? null,
             goalId: input.goalId ?? null,
             parentIssueId: input.parentIssueId ?? null,
             title: input.title,
@@ -2111,6 +2126,7 @@ export function routineService(
       const existing = await getRoutineById(id);
       if (!existing) return null;
       const nextProjectId = patch.projectId === undefined ? existing.projectId : patch.projectId;
+      const nextFolderId = patch.folderId === undefined ? existing.folderId : patch.folderId;
       const nextAssigneeAgentId = patch.assigneeAgentId === undefined ? existing.assigneeAgentId : patch.assigneeAgentId;
       const nextTitle = patch.title ?? existing.title;
       const nextDescription = patch.description === undefined ? existing.description : patch.description;
@@ -2134,6 +2150,7 @@ export function routineService(
         patch.variables === undefined ? existing.variables : sanitizeRoutineVariableInputs(patch.variables),
       );
       if (patch.projectId !== undefined) await assertProject(existing.companyId, nextProjectId);
+      if (patch.folderId !== undefined) await assertRoutineFolder(existing.companyId, nextFolderId);
       if (patch.assigneeAgentId !== undefined || patch.status === "active") {
         await assertAssignableAgent(db, existing.companyId, nextAssigneeAgentId, { kind: "routine" });
       }
@@ -2183,6 +2200,7 @@ export function routineService(
         const candidate: RoutineRow = {
           ...locked,
           projectId: nextProjectId,
+          folderId: nextFolderId,
           goalId: patch.goalId === undefined ? locked.goalId : patch.goalId,
           parentIssueId: patch.parentIssueId === undefined ? locked.parentIssueId : patch.parentIssueId,
           title: nextTitle,
@@ -2199,8 +2217,20 @@ export function routineService(
           updatedByUserId: actor.userId ?? null,
         };
 
+        const folderChanged = patch.folderId !== undefined && locked.folderId !== candidate.folderId;
         if (locked.latestRevisionId && routineCurrentFieldsMatch(locked, candidate)) {
-          return locked;
+          if (!folderChanged) return locked;
+          const [updated] = await txDb
+            .update(routines)
+            .set({
+              folderId: candidate.folderId,
+              updatedByAgentId: actor.agentId ?? null,
+              updatedByUserId: actor.userId ?? null,
+              updatedAt: new Date(),
+            })
+            .where(eq(routines.id, id))
+            .returning();
+          return updated ?? locked;
         }
 
         const nextSnapshot = await buildRoutineRevisionSnapshot(txDb, candidate);
@@ -2233,6 +2263,7 @@ export function routineService(
           .update(routines)
           .set({
             projectId: candidate.projectId,
+            folderId: candidate.folderId,
             goalId: candidate.goalId,
             parentIssueId: candidate.parentIssueId,
             title: candidate.title,

--- a/server/src/services/routines.ts
+++ b/server/src/services/routines.ts
@@ -962,12 +962,11 @@ export function routineService(
   async function assertRoutineFolder(companyId: string, folderId: string | null | undefined) {
     if (!folderId) return;
     const folder = await db
-      .select({ id: folders.id, companyId: folders.companyId, kind: folders.kind })
+      .select({ id: folders.id, kind: folders.kind })
       .from(folders)
-      .where(eq(folders.id, folderId))
+      .where(and(eq(folders.companyId, companyId), eq(folders.id, folderId)))
       .then((rows) => rows[0] ?? null);
     if (!folder) throw notFound("Folder not found");
-    if (folder.companyId !== companyId) throw unprocessable("Folder must belong to same company");
     if (folder.kind !== "routine") throw unprocessable("Folder kind must match routine");
   }
 

--- a/ui/src/api/folders.ts
+++ b/ui/src/api/folders.ts
@@ -1,0 +1,36 @@
+import type {
+  CreateFolderRequest,
+  Folder,
+  FolderKind,
+  FolderListResult,
+  MoveFolderItemRequest,
+  MoveFolderRequest,
+  UpdateFolderRequest,
+} from "@paperclipai/shared";
+import { api } from "./client";
+
+export const foldersApi = {
+  list: (companyId: string, kind: FolderKind) =>
+    api.get<FolderListResult>(`/companies/${encodeURIComponent(companyId)}/folders?kind=${kind}`),
+  create: (companyId: string, payload: CreateFolderRequest) =>
+    api.post<Folder>(`/companies/${encodeURIComponent(companyId)}/folders`, payload),
+  update: (companyId: string, folderId: string, payload: UpdateFolderRequest) =>
+    api.patch<Folder>(
+      `/companies/${encodeURIComponent(companyId)}/folders/${encodeURIComponent(folderId)}`,
+      payload,
+    ),
+  moveFolder: (companyId: string, folderId: string, payload: MoveFolderRequest) =>
+    api.post<Folder>(
+      `/companies/${encodeURIComponent(companyId)}/folders/${encodeURIComponent(folderId)}/move`,
+      payload,
+    ),
+  moveItem: (companyId: string, payload: MoveFolderItemRequest) =>
+    api.post<MoveFolderItemRequest>(
+      `/companies/${encodeURIComponent(companyId)}/folders/items/move`,
+      payload,
+    ),
+  delete: (companyId: string, folderId: string) =>
+    api.delete<{ deleted: Folder }>(
+      `/companies/${encodeURIComponent(companyId)}/folders/${encodeURIComponent(folderId)}`,
+    ),
+};

--- a/ui/src/components/RoutineList.tsx
+++ b/ui/src/components/RoutineList.tsx
@@ -64,6 +64,10 @@ export function RoutineListRow<TRoutine extends RoutineListRowItem>({
   disableToggle = false,
   hideArchiveAction = false,
   divider = true,
+  selected = false,
+  selectMode = false,
+  extraMenuItems,
+  onSelectChange,
   onRunNow,
   onToggleEnabled,
   onToggleArchived,
@@ -83,6 +87,10 @@ export function RoutineListRow<TRoutine extends RoutineListRowItem>({
   hideArchiveAction?: boolean;
   /** Render a bottom divider between consecutive rows. Off when the group is its own card. */
   divider?: boolean;
+  selected?: boolean;
+  selectMode?: boolean;
+  extraMenuItems?: ReactNode;
+  onSelectChange?: (routine: TRoutine, selected: boolean) => void;
   onRunNow: (routine: TRoutine) => void;
   onToggleEnabled: (routine: TRoutine, enabled: boolean) => void;
   onToggleArchived?: (routine: TRoutine) => void;
@@ -102,6 +110,23 @@ export function RoutineListRow<TRoutine extends RoutineListRowItem>({
         divider ? " border-b border-border last:border-b-0" : ""
       }`}
     >
+      {selectMode ? (
+        <div
+          className="flex items-start pt-0.5 sm:pt-1"
+          onClick={(event) => {
+            event.preventDefault();
+            event.stopPropagation();
+          }}
+        >
+          <input
+            type="checkbox"
+            className="h-4 w-4 rounded border-border"
+            checked={selected}
+            aria-label={`Select ${routine.title}`}
+            onChange={(event) => onSelectChange?.(routine, event.target.checked)}
+          />
+        </div>
+      ) : null}
       <div className="min-w-0 flex-1 space-y-1.5">
         <div className="flex flex-wrap items-center gap-2">
           <span className="truncate text-sm font-medium">{routine.title}</span>
@@ -178,6 +203,12 @@ export function RoutineListRow<TRoutine extends RoutineListRowItem>({
             >
               {runningRoutineId === routine.id ? "Running..." : "Run now"}
             </DropdownMenuItem>
+            {extraMenuItems ? (
+              <>
+                <DropdownMenuSeparator />
+                {extraMenuItems}
+              </>
+            ) : null}
             <DropdownMenuSeparator />
             <DropdownMenuItem
               onClick={() => onToggleEnabled(routine, enabled)}

--- a/ui/src/components/folders/FolderControls.test.tsx
+++ b/ui/src/components/folders/FolderControls.test.tsx
@@ -1,0 +1,110 @@
+// @vitest-environment jsdom
+
+import { flushSync } from "react-dom";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { FolderListResult } from "@paperclipai/shared";
+import {
+  FolderRail,
+  folderSearchValue,
+  normalizeFolderSelection,
+} from "./FolderControls";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+function act(callback: () => void | Promise<void>) {
+  let result: void | Promise<void> | undefined;
+  flushSync(() => {
+    result = callback();
+  });
+  return result;
+}
+
+const folderResult: FolderListResult = {
+  kind: "routine",
+  allCount: 4,
+  unfiledCount: 1,
+  folders: [
+    {
+      id: "folder-reporting",
+      companyId: "company-1",
+      kind: "routine",
+      name: "Reporting",
+      color: "#6366f1",
+      position: 0,
+      itemCount: 3,
+      createdAt: new Date("2026-07-01T00:00:00.000Z"),
+      updatedAt: new Date("2026-07-01T00:00:00.000Z"),
+    },
+  ],
+};
+
+describe("FolderControls", () => {
+  let container: HTMLDivElement;
+  let root: Root | null;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = null;
+  });
+
+  afterEach(() => {
+    if (root) {
+      act(() => {
+        root?.unmount();
+      });
+    }
+    container.remove();
+    document.body.innerHTML = "";
+  });
+
+  it("normalizes URL selection values for folder persistence", () => {
+    expect(normalizeFolderSelection(null)).toBe("all");
+    expect(normalizeFolderSelection("unfiled")).toBe("unfiled");
+    expect(normalizeFolderSelection("folder-reporting")).toBe("folder-reporting");
+    expect(folderSearchValue("all")).toBe("");
+    expect(folderSearchValue("unfiled")).toBe("unfiled");
+    expect(folderSearchValue("folder-reporting")).toBe("folder-reporting");
+  });
+
+  it("renders All, user folders, and Unfiled with counts and selection callbacks", () => {
+    const onSelect = vi.fn();
+    root = createRoot(container);
+
+    act(() => {
+      root?.render(
+        <FolderRail
+          result={folderResult}
+          selection="all"
+          itemLabelPlural="routines"
+          allLabel="All routines"
+          onSelect={onSelect}
+          onCreate={vi.fn()}
+          onRename={vi.fn()}
+          onEdit={vi.fn()}
+          onDelete={vi.fn()}
+        />,
+      );
+    });
+
+    expect(container.textContent).toContain("All routines");
+    expect(container.textContent).toContain("Reporting");
+    expect(container.textContent).toContain("Unfiled");
+    expect(container.textContent).toContain("4");
+    expect(container.textContent).toContain("3");
+    expect(container.textContent).toContain("1");
+
+    const reportingButton = Array.from(container.querySelectorAll("button")).find((button) =>
+      button.textContent?.includes("Reporting"),
+    );
+    expect(reportingButton).toBeTruthy();
+
+    act(() => {
+      reportingButton?.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+    });
+
+    expect(onSelect).toHaveBeenCalledWith("folder-reporting");
+  });
+});

--- a/ui/src/components/folders/FolderControls.test.tsx
+++ b/ui/src/components/folders/FolderControls.test.tsx
@@ -5,13 +5,34 @@ import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { FolderListResult } from "@paperclipai/shared";
 import {
+  AllUnfiledBanner,
+  DeleteFolderDialog,
+  FolderFormDialog,
   FolderRail,
+  MobileFolderSheet,
+  MoveToMenu,
   folderSearchValue,
   normalizeFolderSelection,
 } from "./FolderControls";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+if (!globalThis.PointerEvent) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (globalThis as any).PointerEvent = MouseEvent;
+}
+if (!Element.prototype.hasPointerCapture) {
+  Element.prototype.hasPointerCapture = () => false;
+}
+if (!Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = () => undefined;
+}
 
 function act(callback: () => void | Promise<void>) {
   let result: void | Promise<void> | undefined;
@@ -106,5 +127,264 @@ describe("FolderControls", () => {
     });
 
     expect(onSelect).toHaveBeenCalledWith("folder-reporting");
+  });
+
+  it("marks the active row with aria-current, including virtual Unfiled", () => {
+    root = createRoot(container);
+    act(() => {
+      root?.render(
+        <FolderRail
+          result={folderResult}
+          selection="unfiled"
+          itemLabelPlural="routines"
+          allLabel="All routines"
+          onSelect={vi.fn()}
+          onCreate={vi.fn()}
+          onRename={vi.fn()}
+          onEdit={vi.fn()}
+          onDelete={vi.fn()}
+        />,
+      );
+    });
+
+    const current = container.querySelector('[aria-current="page"]');
+    expect(current?.textContent).toContain("Unfiled");
+  });
+
+  it("renames a folder inline via double-click and Enter", () => {
+    const onRename = vi.fn();
+    root = createRoot(container);
+    act(() => {
+      root?.render(
+        <FolderRail
+          result={folderResult}
+          selection="all"
+          itemLabelPlural="routines"
+          allLabel="All routines"
+          onSelect={vi.fn()}
+          onCreate={vi.fn()}
+          onRename={onRename}
+          onEdit={vi.fn()}
+          onDelete={vi.fn()}
+        />,
+      );
+    });
+
+    const nameButton = Array.from(container.querySelectorAll("button")).find((button) =>
+      button.textContent?.includes("Reporting"),
+    );
+    act(() => {
+      nameButton?.dispatchEvent(new MouseEvent("dblclick", { bubbles: true, cancelable: true }));
+    });
+
+    const input = container.querySelector<HTMLInputElement>("input");
+    expect(input).toBeTruthy();
+    expect(input?.value).toBe("Reporting");
+
+    act(() => {
+      if (!input) return;
+      const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")?.set;
+      setter?.call(input, "Monthly reports");
+      input.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+    act(() => {
+      input?.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+    });
+
+    expect(onRename).toHaveBeenCalledWith(folderResult.folders[0], "Monthly reports");
+  });
+
+  it("moves via MoveToMenu: Unfiled, a folder, and new-folder chaining", () => {
+    const onMove = vi.fn();
+    const onCreateAndMove = vi.fn();
+    root = createRoot(container);
+    act(() => {
+      root?.render(
+        <DropdownMenu open modal={false}>
+          <DropdownMenuTrigger asChild>
+            <button type="button">Row actions</button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent>
+            <MoveToMenu
+              folders={folderResult.folders}
+              currentFolderId={null}
+              onMove={onMove}
+              onCreateAndMove={onCreateAndMove}
+            />
+          </DropdownMenuContent>
+        </DropdownMenu>,
+      );
+    });
+
+    const subTrigger = Array.from(document.querySelectorAll("[data-radix-collection-item]")).find(
+      (element) => element.textContent?.includes("Move to"),
+    );
+    expect(subTrigger).toBeTruthy();
+    act(() => {
+      subTrigger?.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true }));
+    });
+
+    const menuItems = Array.from(document.querySelectorAll('[role="menuitem"]'));
+    const unfiledItem = menuItems.find((element) => element.textContent?.includes("Unfiled"));
+    const folderItem = menuItems.find((element) => element.textContent?.includes("Reporting"));
+    const newFolderItem = menuItems.find((element) => element.textContent?.includes("New folder"));
+    expect(unfiledItem).toBeTruthy();
+    expect(folderItem).toBeTruthy();
+    expect(newFolderItem).toBeTruthy();
+
+    act(() => {
+      unfiledItem?.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+    });
+    expect(onMove).toHaveBeenCalledWith(null);
+
+    act(() => {
+      folderItem?.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+    });
+    expect(onMove).toHaveBeenCalledWith("folder-reporting");
+
+    act(() => {
+      newFolderItem?.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+    });
+    expect(onCreateAndMove).toHaveBeenCalled();
+  });
+
+  it("creates a folder through FolderFormDialog and disables submit on empty name", () => {
+    const onSubmit = vi.fn();
+    root = createRoot(container);
+    act(() => {
+      root?.render(
+        <FolderFormDialog
+          open
+          kind="routine"
+          folder={null}
+          onOpenChange={vi.fn()}
+          onSubmit={onSubmit}
+        />,
+      );
+    });
+
+    const submit = Array.from(document.querySelectorAll("button")).find(
+      (button) => button.textContent === "Create folder",
+    ) as HTMLButtonElement | undefined;
+    expect(submit).toBeTruthy();
+    expect(submit?.disabled).toBe(true);
+
+    const nameInput = document.querySelector<HTMLInputElement>("#folder-name");
+    act(() => {
+      if (!nameInput) return;
+      const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")?.set;
+      setter?.call(nameInput, "Reporting");
+      nameInput.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+
+    expect(submit?.disabled).toBe(false);
+    act(() => {
+      submit?.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+    });
+    expect(onSubmit).toHaveBeenCalledWith({ name: "Reporting", color: expect.any(String) });
+  });
+
+  it("states the forgiving delete behavior and confirms", () => {
+    const onConfirm = vi.fn();
+    root = createRoot(container);
+    act(() => {
+      root?.render(
+        <DeleteFolderDialog
+          open
+          folder={folderResult.folders[0]!}
+          itemLabelPlural="routines"
+          onOpenChange={vi.fn()}
+          onConfirm={onConfirm}
+        />,
+      );
+    });
+
+    expect(document.body.textContent).toContain("3 routines in this folder won't be deleted");
+    expect(document.body.textContent).toContain("They'll move to Unfiled");
+
+    const confirmButton = Array.from(document.querySelectorAll("button")).find(
+      (button) => button.textContent === "Delete folder",
+    );
+    act(() => {
+      confirmButton?.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+    });
+    expect(onConfirm).toHaveBeenCalled();
+  });
+
+  it("selects a folder from the mobile sheet and dismisses", () => {
+    const onSelect = vi.fn();
+    const onOpenChange = vi.fn();
+    root = createRoot(container);
+    act(() => {
+      root?.render(
+        <MobileFolderSheet
+          open
+          onOpenChange={onOpenChange}
+          result={folderResult}
+          selection="all"
+          allLabel="All routines"
+          itemLabelPlural="Routines"
+          onSelect={onSelect}
+          onCreate={vi.fn()}
+        />,
+      );
+    });
+
+    expect(document.body.textContent).toContain("All routines");
+    expect(document.body.textContent).toContain("Unfiled");
+
+    const reportingRow = Array.from(document.querySelectorAll("button")).find(
+      (button) => button.textContent?.includes("Reporting"),
+    );
+    act(() => {
+      reportingRow?.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+    });
+
+    expect(onSelect).toHaveBeenCalledWith("folder-reporting");
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("persists AllUnfiledBanner dismissal across mounts", () => {
+    const storageKey = "paperclip:test-folder-nudge";
+    window.localStorage.removeItem(storageKey);
+    const onCreateFolder = vi.fn();
+    root = createRoot(container);
+    act(() => {
+      root?.render(
+        <AllUnfiledBanner
+          storageKey={storageKey}
+          itemLabelPlural="routines"
+          onCreateFolder={onCreateFolder}
+        />,
+      );
+    });
+
+    expect(container.textContent).toContain("Create your first folder");
+
+    const dismissButton = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Dismiss folder suggestion"]',
+    );
+    act(() => {
+      dismissButton?.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+    });
+
+    expect(container.textContent).not.toContain("Create your first folder");
+    expect(window.localStorage.getItem(storageKey)).toBe("1");
+
+    act(() => {
+      root?.unmount();
+    });
+    root = createRoot(container);
+    act(() => {
+      root?.render(
+        <AllUnfiledBanner
+          storageKey={storageKey}
+          itemLabelPlural="routines"
+          onCreateFolder={onCreateFolder}
+        />,
+      );
+    });
+    expect(container.textContent).not.toContain("Create your first folder");
+    window.localStorage.removeItem(storageKey);
   });
 });

--- a/ui/src/components/folders/FolderControls.test.tsx
+++ b/ui/src/components/folders/FolderControls.test.tsx
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { FolderListResult } from "@paperclipai/shared";
 import {
   AllUnfiledBanner,
+  BulkBar,
   DeleteFolderDialog,
   FolderFormDialog,
   FolderRail,

--- a/ui/src/components/folders/FolderControls.test.tsx
+++ b/ui/src/components/folders/FolderControls.test.tsx
@@ -52,7 +52,7 @@ const folderResult: FolderListResult = {
       companyId: "company-1",
       kind: "routine",
       name: "Reporting",
-      color: "#6366f1",
+      color: "indigo",
       position: 0,
       itemCount: 3,
       createdAt: new Date("2026-07-01T00:00:00.000Z"),

--- a/ui/src/components/folders/FolderControls.tsx
+++ b/ui/src/components/folders/FolderControls.tsx
@@ -59,7 +59,7 @@ export const FOLDER_COLORS = [
   "slate",
 ];
 
-const FOLDER_COLOR_VALUES: Record<string, string> = {
+const FOLDER_COLOR_VALUES: Record<(typeof FOLDER_COLORS)[number], string> = {
   indigo: "var(--folder-color-indigo)",
   violet: "var(--folder-color-violet)",
   emerald: "var(--folder-color-emerald)",
@@ -470,6 +470,32 @@ export function MoveToMenu({
   onMove: (folderId: string | null) => void;
   onCreateAndMove: () => void;
 }) {
+  return (
+    <DropdownMenuSub>
+      <DropdownMenuSubTrigger>Move to...</DropdownMenuSubTrigger>
+      <DropdownMenuSubContent className="w-56">
+        <MoveToMenuItems
+          folders={folders}
+          currentFolderId={currentFolderId}
+          onMove={onMove}
+          onCreateAndMove={onCreateAndMove}
+        />
+      </DropdownMenuSubContent>
+    </DropdownMenuSub>
+  );
+}
+
+function MoveToMenuItems({
+  folders,
+  currentFolderId,
+  onMove,
+  onCreateAndMove,
+}: {
+  folders: FolderListItem[];
+  currentFolderId: string | null | undefined;
+  onMove: (folderId: string | null) => void;
+  onCreateAndMove: () => void;
+}) {
   const [query, setQuery] = useState("");
   const visibleFolders = useMemo(() => {
     const lowered = query.trim().toLowerCase();
@@ -478,9 +504,7 @@ export function MoveToMenu({
   }, [folders, query]);
 
   return (
-    <DropdownMenuSub>
-      <DropdownMenuSubTrigger>Move to...</DropdownMenuSubTrigger>
-      <DropdownMenuSubContent className="w-56">
+    <>
         <div className="flex items-center gap-2 px-2 py-1.5">
           <Search className="h-3.5 w-3.5 text-muted-foreground" />
           <input
@@ -512,8 +536,7 @@ export function MoveToMenu({
           <Plus className="h-3.5 w-3.5" />
           New folder...
         </DropdownMenuItem>
-      </DropdownMenuSubContent>
-    </DropdownMenuSub>
+    </>
   );
 }
 
@@ -576,7 +599,7 @@ export function FolderFormDialog({
                     "h-7 w-7 rounded-md border border-border",
                     color === swatch && "ring-2 ring-ring ring-offset-2 ring-offset-background",
                   )}
-                  style={{ backgroundColor: swatch }}
+                  style={{ backgroundColor: FOLDER_COLOR_VALUES[swatch] }}
                   onClick={() => setColor(swatch)}
                 />
               ))}
@@ -671,8 +694,8 @@ export function BulkBar({
         <DropdownMenuTrigger asChild>
           <Button size="sm" variant="outline">Move to...</Button>
         </DropdownMenuTrigger>
-        <DropdownMenuContent align="end">
-          <MoveToMenu
+        <DropdownMenuContent align="end" className="w-56">
+          <MoveToMenuItems
             folders={folders}
             currentFolderId={undefined}
             onMove={onMove}

--- a/ui/src/components/folders/FolderControls.tsx
+++ b/ui/src/components/folders/FolderControls.tsx
@@ -1,0 +1,583 @@
+import { useEffect, useMemo, useState, type ReactNode } from "react";
+import {
+  Check,
+  ChevronDown,
+  Folder as FolderIcon,
+  MoreHorizontal,
+  Plus,
+  Search,
+  Trash2,
+} from "lucide-react";
+import type { FolderKind, FolderListItem, FolderListResult } from "@paperclipai/shared";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Input } from "@/components/ui/input";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import { cn } from "@/lib/utils";
+
+export type FolderSelection = "all" | "unfiled" | string;
+
+export const FOLDER_COLORS = [
+  "#6366f1",
+  "#8b5cf6",
+  "#10b981",
+  "#06b6d4",
+  "#f59e0b",
+  "#64748b",
+];
+
+export function normalizeFolderSelection(value: string | null | undefined): FolderSelection {
+  if (!value) return "all";
+  if (value === "unfiled") return "unfiled";
+  return value;
+}
+
+export function folderSearchValue(selection: FolderSelection): string {
+  return selection === "all" ? "" : selection === "unfiled" ? "unfiled" : selection;
+}
+
+export function selectedFolderFromList(
+  folders: FolderListItem[],
+  selection: FolderSelection,
+): FolderListItem | null {
+  if (selection === "all" || selection === "unfiled") return null;
+  return folders.find((folder) => folder.id === selection) ?? null;
+}
+
+export function FolderSwatch({
+  color,
+  className,
+}: {
+  color: string | null | undefined;
+  className?: string;
+}) {
+  return (
+    <span
+      aria-hidden="true"
+      className={cn("h-2.5 w-2.5 shrink-0 rounded-[3px] border border-border/40", className)}
+      style={{ backgroundColor: color || "#64748b" }}
+    />
+  );
+}
+
+function selectionLabel({
+  folders,
+  selection,
+  allLabel,
+}: {
+  folders: FolderListItem[];
+  selection: FolderSelection;
+  allLabel: string;
+}) {
+  if (selection === "all") return allLabel;
+  if (selection === "unfiled") return "Unfiled";
+  return folders.find((folder) => folder.id === selection)?.name ?? allLabel;
+}
+
+function selectionCount(result: FolderListResult | null | undefined, selection: FolderSelection) {
+  if (!result) return 0;
+  if (selection === "all") return result.allCount;
+  if (selection === "unfiled") return result.unfiledCount;
+  return result.folders.find((folder) => folder.id === selection)?.itemCount ?? 0;
+}
+
+export function FolderChip({
+  result,
+  selection,
+  allLabel,
+  onClick,
+}: {
+  result: FolderListResult | null | undefined;
+  selection: FolderSelection;
+  allLabel: string;
+  onClick: () => void;
+}) {
+  const folder = result ? selectedFolderFromList(result.folders, selection) : null;
+  return (
+    <Button variant="outline" size="sm" className="max-w-full justify-start" onClick={onClick}>
+      {selection === "all" ? <FolderIcon className="mr-2 h-3.5 w-3.5" /> : <FolderSwatch color={folder?.color} className="mr-2" />}
+      <span className="truncate">{selectionLabel({ folders: result?.folders ?? [], selection, allLabel })}</span>
+      <span className="ml-2 text-xs text-muted-foreground">{selectionCount(result, selection)}</span>
+      <ChevronDown className="ml-1 h-3.5 w-3.5 shrink-0" />
+    </Button>
+  );
+}
+
+export function FolderRail({
+  result,
+  selection,
+  itemLabelPlural,
+  allLabel,
+  loading = false,
+  onSelect,
+  onCreate,
+  onRename,
+  onEdit,
+  onDelete,
+}: {
+  result: FolderListResult | null | undefined;
+  selection: FolderSelection;
+  itemLabelPlural: string;
+  allLabel: string;
+  loading?: boolean;
+  onSelect: (selection: FolderSelection) => void;
+  onCreate: () => void;
+  onRename: (folder: FolderListItem, name: string) => void;
+  onEdit: (folder: FolderListItem) => void;
+  onDelete: (folder: FolderListItem) => void;
+}) {
+  const folders = result?.folders ?? [];
+  const [renamingFolderId, setRenamingFolderId] = useState<string | null>(null);
+  const [renameDraft, setRenameDraft] = useState("");
+
+  useEffect(() => {
+    if (!renamingFolderId) return;
+    const folder = folders.find((entry) => entry.id === renamingFolderId);
+    if (!folder) setRenamingFolderId(null);
+  }, [folders, renamingFolderId]);
+
+  function startRename(folder: FolderListItem) {
+    setRenamingFolderId(folder.id);
+    setRenameDraft(folder.name);
+  }
+
+  function commitRename(folder: FolderListItem) {
+    const name = renameDraft.trim();
+    if (name && name !== folder.name) onRename(folder, name);
+    setRenamingFolderId(null);
+  }
+
+  function renderVirtualRow(
+    key: FolderSelection,
+    label: string,
+    count: number,
+    icon: ReactNode,
+  ) {
+    const active = selection === key;
+    return (
+      <button
+        type="button"
+        className={cn(
+          "grid w-full grid-cols-[1rem_minmax(0,1fr)_auto] items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm transition-colors hover:bg-accent/40",
+          active ? "bg-accent/60 text-foreground" : "text-muted-foreground",
+        )}
+        aria-current={active ? "page" : undefined}
+        onClick={() => onSelect(key)}
+      >
+        <span className="h-4 w-4">{icon}</span>
+        <span className="truncate">{label}</span>
+        <span className="text-xs text-muted-foreground">{count}</span>
+      </button>
+    );
+  }
+
+  return (
+    <nav aria-label={`${itemLabelPlural} folders`} className="hidden w-[13.25rem] shrink-0 border-r border-border pr-3 md:block">
+      <div className="mb-2 flex items-center justify-between gap-2">
+        <div className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">Folders</div>
+        <Button variant="ghost" size="icon-sm" title="New folder" onClick={onCreate}>
+          <Plus className="h-3.5 w-3.5" />
+        </Button>
+      </div>
+      {loading ? (
+        <div className="space-y-2">
+          <div className="h-7 rounded-md bg-muted/60" />
+          <div className="h-7 rounded-md bg-muted/40" />
+          <div className="h-7 rounded-md bg-muted/30" />
+        </div>
+      ) : (
+        <div className="space-y-0.5">
+          {renderVirtualRow("all", allLabel, result?.allCount ?? 0, <FolderIcon className="h-3.5 w-3.5" />)}
+          {folders.map((folder) => {
+            const active = selection === folder.id;
+            const isRenaming = renamingFolderId === folder.id;
+            return (
+              <div
+                key={folder.id}
+                className={cn(
+                  "group grid grid-cols-[1rem_minmax(0,1fr)_auto_auto] items-center gap-2 rounded-md px-2 py-1 text-sm transition-colors hover:bg-accent/40",
+                  active ? "bg-accent/60 text-foreground" : "text-muted-foreground",
+                )}
+              >
+                <span className="h-4 w-4" />
+                <button
+                  type="button"
+                  className="flex min-w-0 items-center gap-2 text-left"
+                  aria-current={active ? "page" : undefined}
+                  onClick={() => onSelect(folder.id)}
+                  onDoubleClick={() => startRename(folder)}
+                >
+                  <FolderSwatch color={folder.color} />
+                  {isRenaming ? (
+                    <input
+                      value={renameDraft}
+                      onChange={(event) => setRenameDraft(event.target.value)}
+                      onClick={(event) => event.stopPropagation()}
+                      onKeyDown={(event) => {
+                        if (event.key === "Enter") commitRename(folder);
+                        if (event.key === "Escape") setRenamingFolderId(null);
+                      }}
+                      onBlur={() => commitRename(folder)}
+                      className="h-6 min-w-0 flex-1 rounded-sm border border-border bg-background px-1 text-sm outline-none"
+                      autoFocus
+                    />
+                  ) : (
+                    <span className="truncate">{folder.name}</span>
+                  )}
+                </button>
+                <span className="text-xs text-muted-foreground">{folder.itemCount}</span>
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button
+                      variant="ghost"
+                      size="icon-sm"
+                      className="h-6 w-6 opacity-0 group-hover:opacity-100 data-[state=open]:opacity-100"
+                      aria-label={`Folder actions for ${folder.name}`}
+                    >
+                      <MoreHorizontal className="h-3.5 w-3.5" />
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end">
+                    <DropdownMenuItem onSelect={() => startRename(folder)}>Rename</DropdownMenuItem>
+                    <DropdownMenuItem onSelect={() => onEdit(folder)}>Edit color</DropdownMenuItem>
+                    <DropdownMenuSeparator />
+                    <DropdownMenuItem variant="destructive" onSelect={() => onDelete(folder)}>
+                      <Trash2 className="h-3.5 w-3.5" />
+                      Delete
+                    </DropdownMenuItem>
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              </div>
+            );
+          })}
+          <div className="px-2 pb-1 pt-3 text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+            System
+          </div>
+          {renderVirtualRow("unfiled", "Unfiled", result?.unfiledCount ?? 0, <FolderSwatch color={null} className="mt-0.5" />)}
+        </div>
+      )}
+    </nav>
+  );
+}
+
+export function MobileFolderSheet({
+  open,
+  onOpenChange,
+  result,
+  selection,
+  allLabel,
+  itemLabelPlural,
+  onSelect,
+  onCreate,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  result: FolderListResult | null | undefined;
+  selection: FolderSelection;
+  allLabel: string;
+  itemLabelPlural: string;
+  onSelect: (selection: FolderSelection) => void;
+  onCreate: () => void;
+}) {
+  function select(next: FolderSelection) {
+    onSelect(next);
+    onOpenChange(false);
+  }
+
+  const folders = result?.folders ?? [];
+  const rows = [
+    { id: "all" as FolderSelection, label: allLabel, count: result?.allCount ?? 0, color: null },
+    ...folders.map((folder) => ({ id: folder.id, label: folder.name, count: folder.itemCount, color: folder.color })),
+    { id: "unfiled" as FolderSelection, label: "Unfiled", count: result?.unfiledCount ?? 0, color: null },
+  ];
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent side="bottom" className="max-h-[80dvh] rounded-t-lg pb-4">
+        <SheetHeader className="border-b border-border px-4 py-3">
+          <SheetTitle>{itemLabelPlural} folders</SheetTitle>
+        </SheetHeader>
+        <div className="overflow-y-auto px-3">
+          {rows.map((row) => (
+            <button
+              key={row.id}
+              type="button"
+              className="flex w-full items-center gap-2 rounded-md px-2 py-2 text-left text-sm hover:bg-accent/50"
+              onClick={() => select(row.id)}
+            >
+              {row.id === "all" ? <FolderIcon className="h-3.5 w-3.5 text-muted-foreground" /> : <FolderSwatch color={row.color} />}
+              <span className="min-w-0 flex-1 truncate">{row.label}</span>
+              <span className="text-xs text-muted-foreground">{row.count}</span>
+              {selection === row.id ? <Check className="h-3.5 w-3.5" /> : null}
+            </button>
+          ))}
+        </div>
+        <div className="border-t border-border px-4 pt-3">
+          <Button size="sm" variant="outline" className="w-full" onClick={onCreate}>
+            <Plus className="mr-2 h-3.5 w-3.5" />
+            New folder
+          </Button>
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+}
+
+export function MoveToMenu({
+  folders,
+  currentFolderId,
+  onMove,
+  onCreateAndMove,
+}: {
+  folders: FolderListItem[];
+  currentFolderId: string | null | undefined;
+  onMove: (folderId: string | null) => void;
+  onCreateAndMove: () => void;
+}) {
+  const [query, setQuery] = useState("");
+  const visibleFolders = useMemo(() => {
+    const lowered = query.trim().toLowerCase();
+    if (!lowered) return folders;
+    return folders.filter((folder) => folder.name.toLowerCase().includes(lowered));
+  }, [folders, query]);
+
+  return (
+    <DropdownMenuSub>
+      <DropdownMenuSubTrigger>Move to...</DropdownMenuSubTrigger>
+      <DropdownMenuSubContent className="w-56">
+        <div className="flex items-center gap-2 px-2 py-1.5">
+          <Search className="h-3.5 w-3.5 text-muted-foreground" />
+          <input
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            onKeyDown={(event) => event.stopPropagation()}
+            placeholder="Search folders"
+            className="h-7 min-w-0 flex-1 bg-transparent text-sm outline-none placeholder:text-muted-foreground"
+          />
+        </div>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem onSelect={() => onMove(null)}>
+          <FolderSwatch color={null} />
+          Unfiled
+          {currentFolderId == null ? <Check className="ml-auto h-3.5 w-3.5" /> : null}
+        </DropdownMenuItem>
+        {visibleFolders.map((folder) => (
+          <DropdownMenuItem key={folder.id} onSelect={() => onMove(folder.id)}>
+            <FolderSwatch color={folder.color} />
+            <span className="min-w-0 flex-1 truncate">{folder.name}</span>
+            {currentFolderId === folder.id ? <Check className="ml-auto h-3.5 w-3.5" /> : null}
+          </DropdownMenuItem>
+        ))}
+        {visibleFolders.length === 0 ? (
+          <div className="px-2 py-2 text-xs text-muted-foreground">No folders match.</div>
+        ) : null}
+        <DropdownMenuSeparator />
+        <DropdownMenuItem onSelect={onCreateAndMove}>
+          <Plus className="h-3.5 w-3.5" />
+          New folder...
+        </DropdownMenuItem>
+      </DropdownMenuSubContent>
+    </DropdownMenuSub>
+  );
+}
+
+export function FolderFormDialog({
+  open,
+  kind,
+  folder,
+  onOpenChange,
+  onSubmit,
+  pending = false,
+}: {
+  open: boolean;
+  kind: FolderKind;
+  folder: FolderListItem | null;
+  onOpenChange: (open: boolean) => void;
+  onSubmit: (payload: { name: string; color: string | null }) => void;
+  pending?: boolean;
+}) {
+  const [name, setName] = useState("");
+  const [color, setColor] = useState<string | null>(FOLDER_COLORS[0] ?? null);
+  const isEdit = Boolean(folder);
+
+  useEffect(() => {
+    if (!open) return;
+    setName(folder?.name ?? "");
+    setColor(folder?.color ?? FOLDER_COLORS[0] ?? null);
+  }, [folder, open]);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>{isEdit ? "Edit folder" : "Create folder"}</DialogTitle>
+          <DialogDescription>
+            {kind === "routine" ? "Organize routines in this company." : "Organize installed company skills."}
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-4">
+          <div className="space-y-2">
+            <label className="text-sm font-medium" htmlFor="folder-name">Name</label>
+            <Input
+              id="folder-name"
+              value={name}
+              onChange={(event) => setName(event.target.value)}
+              autoFocus
+              onKeyDown={(event) => {
+                if (event.key === "Enter" && name.trim()) onSubmit({ name: name.trim(), color });
+              }}
+            />
+          </div>
+          <div className="space-y-2">
+            <div className="text-sm font-medium">Color</div>
+            <div className="flex flex-wrap gap-2">
+              {FOLDER_COLORS.map((swatch) => (
+                <button
+                  key={swatch}
+                  type="button"
+                  aria-label={`Use folder color ${swatch}`}
+                  className={cn(
+                    "h-7 w-7 rounded-md border border-border",
+                    color === swatch && "ring-2 ring-ring ring-offset-2 ring-offset-background",
+                  )}
+                  style={{ backgroundColor: swatch }}
+                  onClick={() => setColor(swatch)}
+                />
+              ))}
+              <button
+                type="button"
+                className={cn(
+                  "h-7 rounded-md border border-border px-2 text-xs text-muted-foreground",
+                  color == null && "ring-2 ring-ring ring-offset-2 ring-offset-background",
+                )}
+                onClick={() => setColor(null)}
+              >
+                None
+              </button>
+            </div>
+          </div>
+        </div>
+        <DialogFooter>
+          <Button variant="ghost" onClick={() => onOpenChange(false)} disabled={pending}>
+            Cancel
+          </Button>
+          <Button onClick={() => onSubmit({ name: name.trim(), color })} disabled={pending || !name.trim()}>
+            {pending ? "Saving..." : isEdit ? "Save" : "Create folder"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export function DeleteFolderDialog({
+  open,
+  folder,
+  itemLabelPlural,
+  onOpenChange,
+  onConfirm,
+  pending = false,
+}: {
+  open: boolean;
+  folder: FolderListItem | null;
+  itemLabelPlural: string;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: () => void;
+  pending?: boolean;
+}) {
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Delete folder</AlertDialogTitle>
+          <AlertDialogDescription>
+            The {folder?.itemCount ?? 0} {itemLabelPlural} in this folder won't be deleted. They'll move to Unfiled.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={pending}>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            disabled={pending || !folder}
+            onClick={(event) => {
+              event.preventDefault();
+              onConfirm();
+            }}
+          >
+            {pending ? "Deleting..." : "Delete folder"}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}
+
+export function BulkBar({
+  selectedCount,
+  folders,
+  onMove,
+  onCreateAndMove,
+  onClear,
+  onDone,
+}: {
+  selectedCount: number;
+  folders: FolderListItem[];
+  onMove: (folderId: string | null) => void;
+  onCreateAndMove: () => void;
+  onClear: () => void;
+  onDone: () => void;
+}) {
+  if (selectedCount === 0) return null;
+  return (
+    <div className="sticky top-2 z-10 flex flex-wrap items-center gap-2 rounded-md border border-border bg-background/95 px-3 py-2 shadow-sm backdrop-blur">
+      <span className="mr-auto text-sm text-muted-foreground">{selectedCount} selected</span>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button size="sm" variant="outline">Move to...</Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <MoveToMenu
+            folders={folders}
+            currentFolderId={undefined}
+            onMove={onMove}
+            onCreateAndMove={onCreateAndMove}
+          />
+        </DropdownMenuContent>
+      </DropdownMenu>
+      <Button size="sm" variant="ghost" onClick={onClear}>Deselect all</Button>
+      <Button size="sm" onClick={onDone}>Done</Button>
+    </div>
+  );
+}

--- a/ui/src/components/folders/FolderControls.tsx
+++ b/ui/src/components/folders/FolderControls.tsx
@@ -51,13 +51,22 @@ import { cn } from "@/lib/utils";
 export type FolderSelection = "all" | "unfiled" | string;
 
 export const FOLDER_COLORS = [
-  "#6366f1",
-  "#8b5cf6",
-  "#10b981",
-  "#06b6d4",
-  "#f59e0b",
-  "#64748b",
+  "indigo",
+  "violet",
+  "emerald",
+  "cyan",
+  "amber",
+  "slate",
 ];
+
+const FOLDER_COLOR_VALUES: Record<string, string> = {
+  indigo: "var(--folder-color-indigo)",
+  violet: "var(--folder-color-violet)",
+  emerald: "var(--folder-color-emerald)",
+  cyan: "var(--folder-color-cyan)",
+  amber: "var(--folder-color-amber)",
+  slate: "var(--folder-color-slate)",
+};
 
 export function normalizeFolderSelection(value: string | null | undefined): FolderSelection {
   if (!value) return "all";
@@ -84,11 +93,14 @@ export function FolderSwatch({
   color: string | null | undefined;
   className?: string;
 }) {
+  const backgroundColor = color
+    ? (FOLDER_COLOR_VALUES[color] ?? color)
+    : "var(--folder-color-slate)";
   return (
     <span
       aria-hidden="true"
-      className={cn("h-2.5 w-2.5 shrink-0 rounded-[3px] border border-border/40", className)}
-      style={{ backgroundColor: color || "#64748b" }}
+      className={cn("h-2.5 w-2.5 shrink-0 rounded-sm border border-border/40", className)}
+      style={{ backgroundColor }}
     />
   );
 }
@@ -191,7 +203,7 @@ export function FolderRail({
       <button
         type="button"
         className={cn(
-          "grid w-full grid-cols-[1rem_minmax(0,1fr)_auto] items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm transition-colors hover:bg-accent/40",
+          "grid w-full grid-cols-(--gtc-folder-row) items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm transition-colors hover:bg-accent/40",
           active ? "bg-accent/60 text-foreground" : "text-muted-foreground",
         )}
         aria-current={active ? "page" : undefined}
@@ -205,9 +217,9 @@ export function FolderRail({
   }
 
   return (
-    <nav aria-label={`${itemLabelPlural} folders`} className="hidden w-[13.25rem] shrink-0 border-r border-border pr-3 md:block">
+    <nav aria-label={`${itemLabelPlural} folders`} className="hidden w-(--sz-folder-rail) shrink-0 border-r border-border pr-3 md:block">
       <div className="mb-2 flex items-center justify-between gap-2">
-        <div className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">Folders</div>
+        <div className="text-(length:--text-micro) font-medium uppercase tracking-wide text-muted-foreground">Folders</div>
         <Button variant="ghost" size="icon-sm" title="New folder" onClick={onCreate}>
           <Plus className="h-3.5 w-3.5" />
         </Button>
@@ -237,7 +249,7 @@ export function FolderRail({
               onDelete={() => onDelete(folder)}
             />
           ))}
-          <div className="px-2 pb-1 pt-3 text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+          <div className="px-2 pb-1 pt-3 text-(length:--text-micro) font-medium uppercase tracking-wide text-muted-foreground">
             System
           </div>
           {renderVirtualRow("unfiled", "Unfiled", result?.unfiledCount ?? 0, <FolderSwatch color={null} className="mt-0.5" />)}
@@ -280,7 +292,7 @@ export function FolderRailItem({
   return (
     <div
       className={cn(
-        "group grid grid-cols-[1rem_minmax(0,1fr)_auto_auto] items-center gap-2 rounded-md px-2 py-1 text-sm transition-colors hover:bg-accent/40",
+        "group grid grid-cols-(--gtc-folder-row-actions) items-center gap-2 rounded-md px-2 py-1 text-sm transition-colors hover:bg-accent/40",
         active ? "bg-accent/60 text-foreground" : "text-muted-foreground",
       )}
     >
@@ -417,7 +429,7 @@ export function MobileFolderSheet({
 
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
-      <SheetContent side="bottom" className="max-h-[80dvh] rounded-t-lg pb-4">
+      <SheetContent side="bottom" className="max-h-(--sz-folder-sheet-max) rounded-t-lg pb-4">
         <SheetHeader className="border-b border-border px-4 py-3">
           <SheetTitle>{itemLabelPlural} folders</SheetTitle>
         </SheetHeader>

--- a/ui/src/components/folders/FolderControls.tsx
+++ b/ui/src/components/folders/FolderControls.tsx
@@ -7,6 +7,7 @@ import {
   Plus,
   Search,
   Trash2,
+  X,
 } from "lucide-react";
 import type { FolderKind, FolderListItem, FolderListResult } from "@paperclipai/shared";
 import { Button } from "@/components/ui/button";
@@ -220,68 +221,22 @@ export function FolderRail({
       ) : (
         <div className="space-y-0.5">
           {renderVirtualRow("all", allLabel, result?.allCount ?? 0, <FolderIcon className="h-3.5 w-3.5" />)}
-          {folders.map((folder) => {
-            const active = selection === folder.id;
-            const isRenaming = renamingFolderId === folder.id;
-            return (
-              <div
-                key={folder.id}
-                className={cn(
-                  "group grid grid-cols-[1rem_minmax(0,1fr)_auto_auto] items-center gap-2 rounded-md px-2 py-1 text-sm transition-colors hover:bg-accent/40",
-                  active ? "bg-accent/60 text-foreground" : "text-muted-foreground",
-                )}
-              >
-                <span className="h-4 w-4" />
-                <button
-                  type="button"
-                  className="flex min-w-0 items-center gap-2 text-left"
-                  aria-current={active ? "page" : undefined}
-                  onClick={() => onSelect(folder.id)}
-                  onDoubleClick={() => startRename(folder)}
-                >
-                  <FolderSwatch color={folder.color} />
-                  {isRenaming ? (
-                    <input
-                      value={renameDraft}
-                      onChange={(event) => setRenameDraft(event.target.value)}
-                      onClick={(event) => event.stopPropagation()}
-                      onKeyDown={(event) => {
-                        if (event.key === "Enter") commitRename(folder);
-                        if (event.key === "Escape") setRenamingFolderId(null);
-                      }}
-                      onBlur={() => commitRename(folder)}
-                      className="h-6 min-w-0 flex-1 rounded-sm border border-border bg-background px-1 text-sm outline-none"
-                      autoFocus
-                    />
-                  ) : (
-                    <span className="truncate">{folder.name}</span>
-                  )}
-                </button>
-                <span className="text-xs text-muted-foreground">{folder.itemCount}</span>
-                <DropdownMenu>
-                  <DropdownMenuTrigger asChild>
-                    <Button
-                      variant="ghost"
-                      size="icon-sm"
-                      className="h-6 w-6 opacity-0 group-hover:opacity-100 data-[state=open]:opacity-100"
-                      aria-label={`Folder actions for ${folder.name}`}
-                    >
-                      <MoreHorizontal className="h-3.5 w-3.5" />
-                    </Button>
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent align="end">
-                    <DropdownMenuItem onSelect={() => startRename(folder)}>Rename</DropdownMenuItem>
-                    <DropdownMenuItem onSelect={() => onEdit(folder)}>Edit color</DropdownMenuItem>
-                    <DropdownMenuSeparator />
-                    <DropdownMenuItem variant="destructive" onSelect={() => onDelete(folder)}>
-                      <Trash2 className="h-3.5 w-3.5" />
-                      Delete
-                    </DropdownMenuItem>
-                  </DropdownMenuContent>
-                </DropdownMenu>
-              </div>
-            );
-          })}
+          {folders.map((folder) => (
+            <FolderRailItem
+              key={folder.id}
+              folder={folder}
+              active={selection === folder.id}
+              renaming={renamingFolderId === folder.id}
+              renameDraft={renameDraft}
+              onRenameDraftChange={setRenameDraft}
+              onRenameCommit={() => commitRename(folder)}
+              onRenameCancel={() => setRenamingFolderId(null)}
+              onSelect={() => onSelect(folder.id)}
+              onStartRename={() => startRename(folder)}
+              onEdit={() => onEdit(folder)}
+              onDelete={() => onDelete(folder)}
+            />
+          ))}
           <div className="px-2 pb-1 pt-3 text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
             System
           </div>
@@ -289,6 +244,143 @@ export function FolderRail({
         </div>
       )}
     </nav>
+  );
+}
+
+/**
+ * One selectable rail row. The leading 1rem grid column is the reserved
+ * disclosure/indent slot so nested folders can slot in later without relayout
+ * (ux-spec §3.1/§3.2 "nesting-ready").
+ */
+export function FolderRailItem({
+  folder,
+  active,
+  renaming,
+  renameDraft,
+  onRenameDraftChange,
+  onRenameCommit,
+  onRenameCancel,
+  onSelect,
+  onStartRename,
+  onEdit,
+  onDelete,
+}: {
+  folder: FolderListItem;
+  active: boolean;
+  renaming: boolean;
+  renameDraft: string;
+  onRenameDraftChange: (value: string) => void;
+  onRenameCommit: () => void;
+  onRenameCancel: () => void;
+  onSelect: () => void;
+  onStartRename: () => void;
+  onEdit: () => void;
+  onDelete: () => void;
+}) {
+  return (
+    <div
+      className={cn(
+        "group grid grid-cols-[1rem_minmax(0,1fr)_auto_auto] items-center gap-2 rounded-md px-2 py-1 text-sm transition-colors hover:bg-accent/40",
+        active ? "bg-accent/60 text-foreground" : "text-muted-foreground",
+      )}
+    >
+      <span className="h-4 w-4" />
+      <button
+        type="button"
+        className="flex min-w-0 items-center gap-2 text-left"
+        aria-current={active ? "page" : undefined}
+        onClick={onSelect}
+        onDoubleClick={onStartRename}
+      >
+        <FolderSwatch color={folder.color} />
+        {renaming ? (
+          <input
+            value={renameDraft}
+            onChange={(event) => onRenameDraftChange(event.target.value)}
+            onClick={(event) => event.stopPropagation()}
+            onKeyDown={(event) => {
+              if (event.key === "Enter") onRenameCommit();
+              if (event.key === "Escape") onRenameCancel();
+            }}
+            onBlur={onRenameCommit}
+            className="h-6 min-w-0 flex-1 rounded-sm border border-border bg-background px-1 text-sm outline-none"
+            autoFocus
+          />
+        ) : (
+          <span className="truncate">{folder.name}</span>
+        )}
+      </button>
+      <span className="text-xs text-muted-foreground">{folder.itemCount}</span>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            className="h-6 w-6 opacity-0 group-hover:opacity-100 data-[state=open]:opacity-100"
+            aria-label={`Folder actions for ${folder.name}`}
+          >
+            <MoreHorizontal className="h-3.5 w-3.5" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DropdownMenuItem onSelect={onStartRename}>Rename</DropdownMenuItem>
+          <DropdownMenuItem onSelect={onEdit}>Edit color</DropdownMenuItem>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem variant="destructive" onSelect={onDelete}>
+            <Trash2 className="h-3.5 w-3.5" />
+            Delete
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  );
+}
+
+/**
+ * Dismissible nudge shown when items exist but no folders do (ux-spec §6.3).
+ * Dismissal persists per storage key.
+ */
+export function AllUnfiledBanner({
+  storageKey,
+  itemLabelPlural,
+  onCreateFolder,
+}: {
+  storageKey: string;
+  itemLabelPlural: string;
+  onCreateFolder: () => void;
+}) {
+  const [dismissed, setDismissed] = useState(() => {
+    try {
+      return window.localStorage.getItem(storageKey) === "1";
+    } catch {
+      return false;
+    }
+  });
+
+  if (dismissed) return null;
+
+  function dismiss() {
+    setDismissed(true);
+    try {
+      window.localStorage.setItem(storageKey, "1");
+    } catch {
+      // Ignore storage failures; the banner just reappears next visit.
+    }
+  }
+
+  return (
+    <div className="mb-3 flex flex-wrap items-center gap-2 rounded-md border border-border bg-muted/40 px-3 py-2 text-sm">
+      <FolderIcon className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+      <span className="min-w-0 flex-1 text-muted-foreground">
+        Group these {itemLabelPlural} into folders to keep things tidy.
+      </span>
+      <Button size="sm" variant="outline" onClick={onCreateFolder}>
+        Create your first folder
+      </Button>
+      <Button size="icon-sm" variant="ghost" aria-label="Dismiss folder suggestion" onClick={dismiss}>
+        <X className="h-3.5 w-3.5" />
+      </Button>
+    </div>
   );
 }
 

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -182,6 +182,17 @@
   --status-task-icon-blocked: var(--status-task-blocked);         /* #dc2626 both modes */
   --status-task-icon-cancelled: #52585d;
   --status-task-icon-in_queue: var(--status-task-in_progress);    /* blocked shape, blue */
+
+  --folder-color-indigo: #6366f1;
+  --folder-color-violet: #8b5cf6;
+  --folder-color-emerald: #10b981;
+  --folder-color-cyan: #06b6d4;
+  --folder-color-amber: #f59e0b;
+  --folder-color-slate: #64748b;
+  --gtc-folder-row: 1rem minmax(0, 1fr) auto;
+  --gtc-folder-row-actions: 1rem minmax(0, 1fr) auto auto;
+  --sz-folder-rail: 13.25rem;
+  --sz-folder-sheet-max: 80dvh;
 }
 
 .dark {

--- a/ui/src/lib/queryKeys.ts
+++ b/ui/src/lib/queryKeys.ts
@@ -193,6 +193,9 @@ export const queryKeys = {
     documentAnnotations: (routineId: string, key: "description", status: "open" | "resolved" | "all" = "all") =>
       ["routines", "document-annotations", routineId, key, status] as const,
   },
+  folders: {
+    list: (companyId: string, kind: string) => ["folders", companyId, kind] as const,
+  },
   pipelines: {
     list: (companyId: string) => ["pipelines", companyId] as const,
     detail: (pipelineId: string) => ["pipelines", "detail", pipelineId] as const,

--- a/ui/src/pages/CompanySkills.test.tsx
+++ b/ui/src/pages/CompanySkills.test.tsx
@@ -51,6 +51,9 @@ vi.mock("@/components/ui/dropdown-menu", () => ({
     <button type="button" onClick={onSelect}>{children}</button>
   ),
   DropdownMenuSeparator: () => <hr />,
+  DropdownMenuSub: ({ children }: { children: ReactNode }) => <>{children}</>,
+  DropdownMenuSubContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DropdownMenuSubTrigger: ({ children }: { children: ReactNode }) => <button type="button">{children}</button>,
   DropdownMenuTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
 }));
 
@@ -325,6 +328,47 @@ describe("DiscoveryGrid Studio entry points", () => {
     await click(buttonsNamed(node, "Create a skill")[0] as HTMLButtonElement);
 
     expect(onCreate).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not open a skill when keyboard-activating its actions button", async () => {
+    const onOpenCard = vi.fn();
+    const card = {
+      key: "demo-skill",
+      skillId: "skill-1",
+      folderId: null,
+      catalogRef: null,
+      name: "Demo Skill",
+      slug: "demo-skill",
+      author: "Paperclip",
+      version: null,
+      tagline: null,
+      description: null,
+      categories: [],
+      iconUrl: null,
+      color: null,
+      starCount: 0,
+      agentCount: 0,
+      forkCount: 0,
+      installed: true,
+      required: false,
+      forkedFrom: false,
+      updatedAt: 0,
+    };
+    const node = await renderDiscoveryGrid({
+      cards: [card],
+      totalCount: 1,
+      onOpenCard,
+      folderResult: { kind: "skill", folders: [], allCount: 1, unfiledCount: 1 },
+      onMoveCard: vi.fn(),
+      onCreateFolderAndMoveCard: vi.fn(),
+    });
+    const actionsButton = node.querySelector<HTMLButtonElement>('[aria-label="More actions for Demo Skill"]');
+
+    await act(async () => {
+      actionsButton?.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+    });
+
+    expect(onOpenCard).not.toHaveBeenCalled();
   });
 });
 

--- a/ui/src/pages/CompanySkills.tsx
+++ b/ui/src/pages/CompanySkills.tsx
@@ -4583,6 +4583,30 @@ export function CompanySkills() {
     : "Create an editable company skill in the Paperclip workspace.";
   const skillFolderResult = skillFoldersQuery.data ?? null;
   const showInstalledFolders = isDiscovery && discoveryTab === "installed";
+  // Rail counts reflect the current category/search scope, never the folder
+  // filter itself (ux-spec §5.3).
+  const railSkillFolderResult = useMemo(() => {
+    if (!skillFolderResult || discoveryTab !== "installed") return skillFolderResult;
+    const scoped = discoveryTabCards.filter((card) => {
+      if (discoveryCategory && !card.categories.includes(discoveryCategory)) return false;
+      return discoveryMatchesSearch(card, discoverySearch.trim());
+    });
+    const counts = new Map<string, number>();
+    let unfiled = 0;
+    for (const card of scoped) {
+      if (card.folderId) counts.set(card.folderId, (counts.get(card.folderId) ?? 0) + 1);
+      else unfiled += 1;
+    }
+    return {
+      ...skillFolderResult,
+      allCount: scoped.length,
+      unfiledCount: unfiled,
+      folders: skillFolderResult.folders.map((folder) => ({
+        ...folder,
+        itemCount: counts.get(folder.id) ?? 0,
+      })),
+    };
+  }, [skillFolderResult, discoveryTab, discoveryTabCards, discoveryCategory, discoverySearch]);
 
   return (
     <>
@@ -4777,7 +4801,7 @@ export function CompanySkills() {
       <MobileFolderSheet
         open={mobileFoldersOpen}
         onOpenChange={setMobileFoldersOpen}
-        result={skillFolderResult}
+        result={railSkillFolderResult}
         selection={folderSelection}
         allLabel="All skills"
         itemLabelPlural="Skills"
@@ -4840,7 +4864,7 @@ export function CompanySkills() {
           onScan={() => scanProjects.mutate()}
           scanPending={scanProjects.isPending}
           scanStatus={scanStatusMessage}
-          folderResult={showInstalledFolders ? skillFolderResult : null}
+          folderResult={showInstalledFolders ? railSkillFolderResult : null}
           folderSelection={folderSelection}
           foldersLoading={skillFoldersQuery.isLoading}
           selectMode={showInstalledFolders && selectMode}

--- a/ui/src/pages/CompanySkills.tsx
+++ b/ui/src/pages/CompanySkills.tsx
@@ -91,11 +91,13 @@ import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Badge } from "@/components/ui/badge";
 import {
+  AllUnfiledBanner,
   BulkBar,
   DeleteFolderDialog,
   FolderChip,
   FolderFormDialog,
   FolderRail,
+  FolderSwatch,
   MobileFolderSheet,
   MoveToMenu,
   folderSearchValue,
@@ -753,6 +755,7 @@ function SkillCard({
   folders,
   selected = false,
   selectMode = false,
+  showFolderBadge = false,
   onOpen,
   onSelectChange,
   onMove,
@@ -762,11 +765,16 @@ function SkillCard({
   folders?: FolderListItem[];
   selected?: boolean;
   selectMode?: boolean;
+  /** Show the card's folder so search results reveal where an item lives (user story 5). */
+  showFolderBadge?: boolean;
   onOpen: (card: DiscoveryCard) => void;
   onSelectChange?: (card: DiscoveryCard, selected: boolean) => void;
   onMove?: (card: DiscoveryCard, folderId: string | null) => void;
   onCreateFolderAndMove?: (card: DiscoveryCard) => void;
 }) {
+  const badgeFolder = showFolderBadge && card.installed
+    ? (card.folderId ? folders?.find((folder) => folder.id === card.folderId) ?? null : null)
+    : undefined;
   return (
     <div
       onClick={() => onOpen(card)}
@@ -802,6 +810,12 @@ function SkillCard({
           <div className="truncate text-xs text-muted-foreground">
             by {card.author}{card.version ? ` · ${card.version}` : ""}
           </div>
+          {badgeFolder !== undefined ? (
+            <div className="mt-1 flex min-w-0 items-center gap-1.5 text-xs text-muted-foreground">
+              <FolderSwatch color={badgeFolder?.color} className="h-2 w-2" />
+              <span className="truncate">{badgeFolder ? badgeFolder.name : "Unfiled"}</span>
+            </div>
+          ) : null}
         </div>
         {/* Where the skill came from (PAP-10907 E); native title gives a hover hint. */}
         {(() => {
@@ -978,6 +992,7 @@ export function DiscoveryGrid({
   onCreateFolderAndMoveSelected,
   onClearSelected,
   onOpenMobileFolders,
+  folderNudgeStorageKey,
 }: {
   tab: DiscoveryTab;
   tabCounts: Record<DiscoveryTab, number>;
@@ -1019,6 +1034,8 @@ export function DiscoveryGrid({
   onCreateFolderAndMoveSelected?: () => void;
   onClearSelected?: () => void;
   onOpenMobileFolders?: () => void;
+  /** When set and no folders exist yet, show the dismissible all-unfiled nudge (ux-spec §6.3). */
+  folderNudgeStorageKey?: string;
 }) {
   // Source filter (github / skills.sh / local / …) lives in the grid so it
   // narrows whatever the parent already filtered by tab/category/search (PAP-10907 E).
@@ -1250,6 +1267,13 @@ export function DiscoveryGrid({
         {/* Grid body */}
         <div className="min-h-0 flex-1 overflow-auto p-4">
           {scanStatus ? <p className="mb-3 text-xs text-muted-foreground">{scanStatus}</p> : null}
+          {folderNudgeStorageKey && onCreateFolder && folderResult && folderResult.folders.length === 0 && !loading && cards.length > 0 ? (
+            <AllUnfiledBanner
+              storageKey={folderNudgeStorageKey}
+              itemLabelPlural="skills"
+              onCreateFolder={onCreateFolder}
+            />
+          ) : null}
           {selectMode && onMoveSelected && onCreateFolderAndMoveSelected && onClearSelected ? (
             <div className="mb-3">
               <BulkBar
@@ -1317,6 +1341,7 @@ export function DiscoveryGrid({
                     folders={folderResult?.folders}
                     selected={selectedSkillIds.includes(card.skillId ?? "")}
                     selectMode={selectMode}
+                    showFolderBadge={Boolean(folderResult && search.trim())}
                     onOpen={onOpenCard}
                     onSelectChange={onSelectCard}
                     onMove={onMoveCard}
@@ -4227,17 +4252,20 @@ export function CompanySkills() {
       .map(([slug, count]) => ({ slug, count }))
       .sort((a, b) => b.count - a.count || a.slug.localeCompare(b.slug));
   }, [discoveryTabCards]);
+  const discoverySearchActive = discoverySearch.trim().length > 0;
   const visibleDiscoveryCards = useMemo(() => {
     const filtered = discoveryTabCards.filter((card) => {
       if (discoveryCategory && !card.categories.includes(discoveryCategory)) return false;
-      if (discoveryTab === "installed") {
+      // Search spans all folders (user story 5): the folder filter only
+      // narrows when the user is browsing, never when searching.
+      if (discoveryTab === "installed" && !discoverySearchActive) {
         if (folderSelection === "unfiled" && card.folderId) return false;
         if (folderSelection !== "all" && folderSelection !== "unfiled" && card.folderId !== folderSelection) return false;
       }
       return discoveryMatchesSearch(card, discoverySearch.trim());
     });
     return sortDiscoveryCards(filtered, discoverySort, discoveryTab !== "bundled");
-  }, [discoveryTabCards, discoveryCategory, discoverySearch, discoverySort, discoveryTab, folderSelection]);
+  }, [discoveryTabCards, discoveryCategory, discoverySearch, discoverySearchActive, discoverySort, discoveryTab, folderSelection]);
 
   const selectedCatalogSkill = catalogDetailQuery.data
     ?? (catalogListQuery.data ?? []).find((entry) => entry.id === selectedCatalogRef || entry.key === selectedCatalogRef)
@@ -4840,13 +4868,19 @@ export function CompanySkills() {
           } : undefined}
           onMoveCard={showInstalledFolders ? (card, folderId) => {
             if (!card.skillId) return;
-            moveSkillToFolder.mutate({ itemId: card.skillId, folderId });
+            const skillId = card.skillId;
+            const previousFolderId = card.folderId ?? null;
+            moveSkillToFolder.mutate({ itemId: skillId, folderId });
             pushToast({
               tone: "success",
               title: "Skill moved",
               body: folderId
-                ? `Moved to ${skillFolderResult?.folders.find((folder) => folder.id === folderId)?.name ?? "folder"}.`
-                : "Moved to Unfiled.",
+                ? `Moved "${card.name}" to ${skillFolderResult?.folders.find((folder) => folder.id === folderId)?.name ?? "folder"}.`
+                : `Moved "${card.name}" to Unfiled.`,
+              action: {
+                label: "Undo",
+                onClick: () => moveSkillToFolder.mutate({ itemId: skillId, folderId: previousFolderId }),
+              },
             });
           } : undefined}
           onCreateFolderAndMoveCard={showInstalledFolders ? (card) => {
@@ -4855,6 +4889,7 @@ export function CompanySkills() {
           onMoveSelected={showInstalledFolders ? (folderId) => void moveSelectedSkills(folderId) : undefined}
           onCreateFolderAndMoveSelected={showInstalledFolders ? () => openCreateFolder(selectedSkillIds) : undefined}
           onClearSelected={showInstalledFolders ? () => setSelectedSkillIds([]) : undefined}
+          folderNudgeStorageKey={showInstalledFolders ? `paperclip:skills-folder-nudge:${selectedCompanyId ?? "none"}` : undefined}
         />
       ) : activeView === "installed" && selectedSkillId ? (
         <SkillDetailPage

--- a/ui/src/pages/CompanySkills.tsx
+++ b/ui/src/pages/CompanySkills.tsx
@@ -779,6 +779,7 @@ function SkillCard({
     <div
       onClick={() => onOpen(card)}
       onKeyDown={(event) => {
+        if (event.target !== event.currentTarget) return;
         if (event.key === "Enter" || event.key === " ") {
           event.preventDefault();
           onOpen(card);

--- a/ui/src/pages/CompanySkills.tsx
+++ b/ui/src/pages/CompanySkills.tsx
@@ -4538,6 +4538,33 @@ export function CompanySkills() {
     },
   });
 
+  const skillFolderResult = skillFoldersQuery.data ?? null;
+  const showInstalledFolders = isDiscovery && discoveryTab === "installed";
+  // Rail counts reflect the current category/search scope, never the folder
+  // filter itself (ux-spec §5.3).
+  const railSkillFolderResult = useMemo(() => {
+    if (!skillFolderResult || discoveryTab !== "installed") return skillFolderResult;
+    const scoped = discoveryTabCards.filter((card) => {
+      if (discoveryCategory && !card.categories.includes(discoveryCategory)) return false;
+      return discoveryMatchesSearch(card, discoverySearch.trim());
+    });
+    const counts = new Map<string, number>();
+    let unfiled = 0;
+    for (const card of scoped) {
+      if (card.folderId) counts.set(card.folderId, (counts.get(card.folderId) ?? 0) + 1);
+      else unfiled += 1;
+    }
+    return {
+      ...skillFolderResult,
+      allCount: scoped.length,
+      unfiledCount: unfiled,
+      folders: skillFolderResult.folders.map((folder) => ({
+        ...folder,
+        itemCount: counts.get(folder.id) ?? 0,
+      })),
+    };
+  }, [skillFolderResult, discoveryTab, discoveryTabCards, discoveryCategory, discoverySearch]);
+
   if (!selectedCompanyId) {
     return <EmptyState icon={Boxes} message="Select a company to manage skills." />;
   }
@@ -4581,33 +4608,6 @@ export function CompanySkills() {
   const studioDescription = studioForkFromId
     ? "Review the fork metadata and create an editable company copy."
     : "Create an editable company skill in the Paperclip workspace.";
-  const skillFolderResult = skillFoldersQuery.data ?? null;
-  const showInstalledFolders = isDiscovery && discoveryTab === "installed";
-  // Rail counts reflect the current category/search scope, never the folder
-  // filter itself (ux-spec §5.3).
-  const railSkillFolderResult = useMemo(() => {
-    if (!skillFolderResult || discoveryTab !== "installed") return skillFolderResult;
-    const scoped = discoveryTabCards.filter((card) => {
-      if (discoveryCategory && !card.categories.includes(discoveryCategory)) return false;
-      return discoveryMatchesSearch(card, discoverySearch.trim());
-    });
-    const counts = new Map<string, number>();
-    let unfiled = 0;
-    for (const card of scoped) {
-      if (card.folderId) counts.set(card.folderId, (counts.get(card.folderId) ?? 0) + 1);
-      else unfiled += 1;
-    }
-    return {
-      ...skillFolderResult,
-      allCount: scoped.length,
-      unfiledCount: unfiled,
-      folders: skillFolderResult.folders.map((folder) => ({
-        ...folder,
-        itemCount: counts.get(folder.id) ?? 0,
-      })),
-    };
-  }, [skillFolderResult, discoveryTab, discoveryTabCards, discoveryCategory, discoverySearch]);
-
   return (
     <>
       {policyDenial.denial ? (

--- a/ui/src/pages/CompanySkills.tsx
+++ b/ui/src/pages/CompanySkills.tsx
@@ -22,6 +22,7 @@ import type {
   CompanySkillVersion,
 } from "@paperclipai/shared";
 import { companySkillsApi } from "../api/companySkills";
+import { foldersApi } from "../api/folders";
 import { agentsApi } from "../api/agents";
 import { useCompany } from "../context/CompanyContext";
 import { useBreadcrumbs } from "../context/BreadcrumbContext";
@@ -90,6 +91,18 @@ import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Badge } from "@/components/ui/badge";
 import {
+  BulkBar,
+  DeleteFolderDialog,
+  FolderChip,
+  FolderFormDialog,
+  FolderRail,
+  MobileFolderSheet,
+  MoveToMenu,
+  folderSearchValue,
+  normalizeFolderSelection,
+  type FolderSelection,
+} from "../components/folders/FolderControls";
+import {
   AlertTriangle,
   ArrowUpCircle,
   Boxes,
@@ -114,6 +127,7 @@ import {
   Lock,
   ExternalLink,
   FlaskConical,
+  MoreHorizontal,
   Paperclip,
   Pause,
   Pencil,
@@ -131,6 +145,7 @@ import {
   History,
   XOctagon,
 } from "lucide-react";
+import type { FolderListItem, FolderListResult } from "@paperclipai/shared";
 
 type SkillTreeNode = {
   name: string;
@@ -537,6 +552,7 @@ const DISCOVERY_SORTS: DiscoverySort[] = ["agents", "stars", "forks", "recent", 
 export type DiscoveryCard = {
   key: string;
   skillId: string | null;
+  folderId?: string | null;
   catalogRef: string | null;
   name: string;
   slug: string;
@@ -610,6 +626,7 @@ function buildDiscoveryCards(
     cards.push({
       key: skill.key,
       skillId: skill.id,
+      folderId: skill.folderId ?? null,
       catalogRef: catalogMatch ? catalogMatch.id : null,
       name: skill.name,
       slug: skill.slug,
@@ -638,6 +655,7 @@ function buildDiscoveryCards(
     cards.push({
       key: entry.key,
       skillId: null,
+      folderId: null,
       catalogRef: entry.id,
       name: entry.name,
       slug: entry.slug,
@@ -730,11 +748,36 @@ function SkillCategoryChip({ label }: { label: string }) {
   );
 }
 
-function SkillCard({ card, onOpen }: { card: DiscoveryCard; onOpen: (card: DiscoveryCard) => void }) {
+function SkillCard({
+  card,
+  folders,
+  selected = false,
+  selectMode = false,
+  onOpen,
+  onSelectChange,
+  onMove,
+  onCreateFolderAndMove,
+}: {
+  card: DiscoveryCard;
+  folders?: FolderListItem[];
+  selected?: boolean;
+  selectMode?: boolean;
+  onOpen: (card: DiscoveryCard) => void;
+  onSelectChange?: (card: DiscoveryCard, selected: boolean) => void;
+  onMove?: (card: DiscoveryCard, folderId: string | null) => void;
+  onCreateFolderAndMove?: (card: DiscoveryCard) => void;
+}) {
   return (
-    <button
-      type="button"
+    <div
       onClick={() => onOpen(card)}
+      onKeyDown={(event) => {
+        if (event.key === "Enter" || event.key === " ") {
+          event.preventDefault();
+          onOpen(card);
+        }
+      }}
+      role="button"
+      tabIndex={0}
       className={cn(
         // Quiet interactive-card affordance (DECISION-SHEET: one recipe for
         // clickable cards): pointer cursor, border darkens, slight lift.
@@ -743,6 +786,16 @@ function SkillCard({ card, onOpen }: { card: DiscoveryCard; onOpen: (card: Disco
       )}
     >
       <div className="flex items-start gap-3">
+        {selectMode && card.installed ? (
+          <input
+            type="checkbox"
+            className="mt-1 h-4 w-4 rounded border-border"
+            checked={selected}
+            aria-label={`Select ${card.name}`}
+            onClick={(event) => event.stopPropagation()}
+            onChange={(event) => onSelectChange?.(card, event.target.checked)}
+          />
+        ) : null}
         <SkillCardIcon card={card} />
         <div className="min-w-0 flex-1">
           <div className="truncate font-mono text-sm font-medium text-foreground">{card.name}</div>
@@ -760,6 +813,29 @@ function SkillCard({ card, onOpen }: { card: DiscoveryCard; onOpen: (card: Disco
             </span>
           );
         })()}
+        {card.installed && folders && onMove && onCreateFolderAndMove ? (
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                className="-mr-1 -mt-1 opacity-70 group-hover:opacity-100"
+                aria-label={`More actions for ${card.name}`}
+                onClick={(event) => event.stopPropagation()}
+              >
+                <MoreHorizontal className="h-4 w-4" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" onClick={(event) => event.stopPropagation()}>
+              <MoveToMenu
+                folders={folders}
+                currentFolderId={card.folderId}
+                onMove={(folderId) => onMove(card, folderId)}
+                onCreateAndMove={() => onCreateFolderAndMove(card)}
+              />
+            </DropdownMenuContent>
+          </DropdownMenu>
+        ) : null}
       </div>
 
       {card.forkedFrom ? (
@@ -813,7 +889,7 @@ function SkillCard({ card, onOpen }: { card: DiscoveryCard; onOpen: (card: Disco
           ) : null}
         </div>
       </div>
-    </button>
+    </div>
   );
 }
 
@@ -884,6 +960,24 @@ export function DiscoveryGrid({
   onScan,
   scanPending,
   scanStatus,
+  folderResult,
+  folderSelection = "all",
+  foldersLoading = false,
+  selectMode = false,
+  selectedSkillIds = [],
+  onFolderSelect,
+  onCreateFolder,
+  onRenameFolder,
+  onEditFolder,
+  onDeleteFolder,
+  onToggleSelectMode,
+  onSelectCard,
+  onMoveCard,
+  onCreateFolderAndMoveCard,
+  onMoveSelected,
+  onCreateFolderAndMoveSelected,
+  onClearSelected,
+  onOpenMobileFolders,
 }: {
   tab: DiscoveryTab;
   tabCounts: Record<DiscoveryTab, number>;
@@ -907,6 +1001,24 @@ export function DiscoveryGrid({
   onScan: () => void;
   scanPending: boolean;
   scanStatus: string | null;
+  folderResult?: FolderListResult | null;
+  folderSelection?: FolderSelection;
+  foldersLoading?: boolean;
+  selectMode?: boolean;
+  selectedSkillIds?: string[];
+  onFolderSelect?: (selection: FolderSelection) => void;
+  onCreateFolder?: () => void;
+  onRenameFolder?: (folder: FolderListItem, name: string) => void;
+  onEditFolder?: (folder: FolderListItem) => void;
+  onDeleteFolder?: (folder: FolderListItem) => void;
+  onToggleSelectMode?: () => void;
+  onSelectCard?: (card: DiscoveryCard, selected: boolean) => void;
+  onMoveCard?: (card: DiscoveryCard, folderId: string | null) => void;
+  onCreateFolderAndMoveCard?: (card: DiscoveryCard) => void;
+  onMoveSelected?: (folderId: string | null) => void;
+  onCreateFolderAndMoveSelected?: () => void;
+  onClearSelected?: () => void;
+  onOpenMobileFolders?: () => void;
 }) {
   // Source filter (github / skills.sh / local / …) lives in the grid so it
   // narrows whatever the parent already filtered by tab/category/search (PAP-10907 E).
@@ -926,15 +1038,33 @@ export function DiscoveryGrid({
     [cards, sourceBadgeFilter],
   );
   const sourceFilterActive = sourceBadgeFilter !== "all";
+  const showFolderRail = Boolean(folderResult && folderResult.folders.length > 0 && onFolderSelect);
+  const folderActionsReady = Boolean(onCreateFolder && onRenameFolder && onEditFolder && onDeleteFolder);
 
   return (
     // On desktop the store is bounded to the viewport so the category sidebar
     // and the results pane each scroll independently (PAP-10907). Mobile keeps
     // the natural page flow.
     <div className="flex min-h-(--sz-calc-30) md:h-(--sz-calc-33) md:min-h-0 md:overflow-hidden">
+      {showFolderRail && folderActionsReady ? (
+        <div className="hidden shrink-0 pl-4 pt-4 md:block">
+          <FolderRail
+            result={folderResult}
+            selection={folderSelection}
+            itemLabelPlural="skills"
+            allLabel="All skills"
+            loading={foldersLoading}
+            onSelect={onFolderSelect!}
+            onCreate={onCreateFolder!}
+            onRename={onRenameFolder!}
+            onEdit={onEditFolder!}
+            onDelete={onDeleteFolder!}
+          />
+        </div>
+      ) : null}
       {/* Secondary category sidebar — the main app nav collapses to a rail while
           this is present (handled in Layout). */}
-      <aside className="hidden w-60 shrink-0 flex-col overflow-hidden border-r border-border md:flex">
+      <aside className={cn("hidden w-60 shrink-0 flex-col overflow-hidden border-r border-border md:flex", showFolderRail && "md:hidden")}>
         <div className="border-b border-border px-4 py-4">
           <h2 className="text-sm font-semibold text-foreground">Skills Store</h2>
           <p className="text-xs text-muted-foreground">Discover, install, fork, share</p>
@@ -1043,6 +1173,27 @@ export function DiscoveryGrid({
               </DropdownMenuItem>
             </DropdownMenuContent>
           </DropdownMenu>
+          {folderResult && onFolderSelect ? (
+            <div className="w-full md:hidden">
+              <FolderChip
+                result={folderResult}
+                selection={folderSelection}
+                allLabel="All skills"
+                onClick={onOpenMobileFolders ?? (() => undefined)}
+              />
+            </div>
+          ) : null}
+          {onCreateFolder ? (
+            <Button variant="outline" size="sm" onClick={onCreateFolder}>
+              <Plus className="mr-1 h-3.5 w-3.5" />
+              New folder
+            </Button>
+          ) : null}
+          {onToggleSelectMode ? (
+            <Button variant="ghost" size="sm" onClick={onToggleSelectMode}>
+              {selectMode ? "Done" : "Select"}
+            </Button>
+          ) : null}
         </div>
 
         {/* Mobile category selector (sidebar is hidden below md) */}
@@ -1099,6 +1250,18 @@ export function DiscoveryGrid({
         {/* Grid body */}
         <div className="min-h-0 flex-1 overflow-auto p-4">
           {scanStatus ? <p className="mb-3 text-xs text-muted-foreground">{scanStatus}</p> : null}
+          {selectMode && onMoveSelected && onCreateFolderAndMoveSelected && onClearSelected ? (
+            <div className="mb-3">
+              <BulkBar
+                selectedCount={selectedSkillIds.length}
+                folders={folderResult?.folders ?? []}
+                onMove={onMoveSelected}
+                onCreateAndMove={onCreateFolderAndMoveSelected}
+                onClear={onClearSelected}
+                onDone={onToggleSelectMode ?? onClearSelected}
+              />
+            </div>
+          ) : null}
           {loading ? (
             <PageSkeleton variant="list" />
           ) : error ? (
@@ -1148,7 +1311,17 @@ export function DiscoveryGrid({
               </p>
               <div className="grid gap-3 [grid-template-columns:repeat(auto-fill,minmax(19rem,1fr))]">
                 {sourceFilteredCards.map((card) => (
-                  <SkillCard key={card.key} card={card} onOpen={onOpenCard} />
+                  <SkillCard
+                    key={card.key}
+                    card={card}
+                    folders={folderResult?.folders}
+                    selected={selectedSkillIds.includes(card.skillId ?? "")}
+                    selectMode={selectMode}
+                    onOpen={onOpenCard}
+                    onSelectChange={onSelectCard}
+                    onMove={onMoveCard}
+                    onCreateFolderAndMove={onCreateFolderAndMoveCard}
+                  />
                 ))}
               </div>
             </>
@@ -3541,6 +3714,13 @@ export function CompanySkills() {
   const [discoverySort, setDiscoverySort] = useState<DiscoverySort>("agents");
   const [createError, setCreateError] = useState<string | null>(null);
   const [importDialogOpen, setImportDialogOpen] = useState(false);
+  const [folderDialogOpen, setFolderDialogOpen] = useState(false);
+  const [folderDialogTarget, setFolderDialogTarget] = useState<FolderListItem | null>(null);
+  const [deleteFolderTarget, setDeleteFolderTarget] = useState<FolderListItem | null>(null);
+  const [mobileFoldersOpen, setMobileFoldersOpen] = useState(false);
+  const [selectMode, setSelectMode] = useState(false);
+  const [selectedSkillIds, setSelectedSkillIds] = useState<string[]>([]);
+  const [moveAfterCreateSkillIds, setMoveAfterCreateSkillIds] = useState<string[]>([]);
   const parsedRoute = useMemo(() => parseSkillRoute(routePath), [routePath]);
   const isStudioNew = routePath === "studio/new";
   const routeSkillToken = isStudioNew ? null : parsedRoute.skillToken;
@@ -3566,6 +3746,7 @@ export function CompanySkills() {
   // Discovery grid owns `/skills` whenever no specific skill or catalog entry is
   // selected; selecting either drops into the existing master/detail surfaces.
   const isDiscovery = !isStudioNew && !routeSkillToken && !selectedCatalogRef;
+  const folderSelection = normalizeFolderSelection(searchParams.get("folder"));
 
   function setDiscoveryTab(tab: DiscoveryTab) {
     setSearchParams((current) => {
@@ -3573,8 +3754,27 @@ export function CompanySkills() {
       if (tab === "all") params.delete("tab");
       else params.set("tab", tab);
       params.delete("category");
+      if (tab !== "installed") params.delete("folder");
       return params;
     });
+  }
+
+  function setFolderSelection(selection: FolderSelection) {
+    setSearchParams((current) => {
+      const params = new URLSearchParams(current);
+      params.set("tab", "installed");
+      params.delete("category");
+      const value = folderSearchValue(selection);
+      if (value) params.set("folder", value);
+      else params.delete("folder");
+      return params;
+    });
+  }
+
+  function openCreateFolder(moveSkillIds: string[] = []) {
+    setMoveAfterCreateSkillIds(moveSkillIds);
+    setFolderDialogTarget(null);
+    setFolderDialogOpen(true);
   }
 
   function setDetailTab(tab: SkillDetailTab) {
@@ -3645,6 +3845,11 @@ export function CompanySkills() {
     queryKey: queryKeys.companySkills.list(selectedCompanyId ?? ""),
     queryFn: () => companySkillsApi.list(selectedCompanyId!),
     enabled: Boolean(selectedCompanyId),
+  });
+  const skillFoldersQuery = useQuery({
+    queryKey: queryKeys.folders.list(selectedCompanyId ?? "", "skill"),
+    queryFn: () => foldersApi.list(selectedCompanyId!, "skill"),
+    enabled: Boolean(selectedCompanyId && isDiscovery && discoveryTab === "installed"),
   });
 
   const installedSkills = skillsQuery.data ?? [];
@@ -4025,10 +4230,14 @@ export function CompanySkills() {
   const visibleDiscoveryCards = useMemo(() => {
     const filtered = discoveryTabCards.filter((card) => {
       if (discoveryCategory && !card.categories.includes(discoveryCategory)) return false;
+      if (discoveryTab === "installed") {
+        if (folderSelection === "unfiled" && card.folderId) return false;
+        if (folderSelection !== "all" && folderSelection !== "unfiled" && card.folderId !== folderSelection) return false;
+      }
       return discoveryMatchesSearch(card, discoverySearch.trim());
     });
     return sortDiscoveryCards(filtered, discoverySort, discoveryTab !== "bundled");
-  }, [discoveryTabCards, discoveryCategory, discoverySearch, discoverySort, discoveryTab]);
+  }, [discoveryTabCards, discoveryCategory, discoverySearch, discoverySort, discoveryTab, folderSelection]);
 
   const selectedCatalogSkill = catalogDetailQuery.data
     ?? (catalogListQuery.data ?? []).find((entry) => entry.id === selectedCatalogRef || entry.key === selectedCatalogRef)
@@ -4096,6 +4305,87 @@ export function CompanySkills() {
       policyDenial.capture(error, "Installing this skill");
     },
   });
+  const createFolder = useMutation({
+    mutationFn: (payload: { name: string; color: string | null }) =>
+      foldersApi.create(selectedCompanyId!, { kind: "skill", ...payload }),
+    onSuccess: async (folder) => {
+      setFolderDialogOpen(false);
+      setFolderDialogTarget(null);
+      await queryClient.invalidateQueries({ queryKey: queryKeys.folders.list(selectedCompanyId!, "skill") });
+      if (moveAfterCreateSkillIds.length > 0) {
+        const ids = moveAfterCreateSkillIds;
+        setMoveAfterCreateSkillIds([]);
+        await Promise.all(ids.map((itemId) =>
+          foldersApi.moveItem(selectedCompanyId!, { kind: "skill", itemId, folderId: folder.id })
+        ));
+        await Promise.all([
+          queryClient.invalidateQueries({ queryKey: queryKeys.companySkills.list(selectedCompanyId!) }),
+          queryClient.invalidateQueries({ queryKey: queryKeys.folders.list(selectedCompanyId!, "skill") }),
+        ]);
+      } else {
+        setFolderSelection(folder.id);
+      }
+      pushToast({ tone: "success", title: "Folder created", body: folder.name });
+    },
+    onError: (error) => {
+      pushToast({
+        tone: "error",
+        title: "Folder save failed",
+        body: error instanceof Error ? error.message : "Failed to save folder.",
+      });
+    },
+  });
+  const updateFolder = useMutation({
+    mutationFn: ({ folderId, payload }: { folderId: string; payload: { name?: string; color?: string | null } }) =>
+      foldersApi.update(selectedCompanyId!, folderId, payload),
+    onSuccess: async () => {
+      setFolderDialogOpen(false);
+      setFolderDialogTarget(null);
+      await queryClient.invalidateQueries({ queryKey: queryKeys.folders.list(selectedCompanyId!, "skill") });
+    },
+  });
+  const deleteFolder = useMutation({
+    mutationFn: (folderId: string) => foldersApi.delete(selectedCompanyId!, folderId),
+    onSuccess: async (_, folderId) => {
+      if (folderSelection === folderId) setFolderSelection("all");
+      setDeleteFolderTarget(null);
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: queryKeys.companySkills.list(selectedCompanyId!) }),
+        queryClient.invalidateQueries({ queryKey: queryKeys.folders.list(selectedCompanyId!, "skill") }),
+      ]);
+      pushToast({ tone: "success", title: "Folder deleted", body: "Skills moved to Unfiled." });
+    },
+  });
+  const moveSkillToFolder = useMutation({
+    mutationFn: ({ itemId, folderId }: { itemId: string; folderId: string | null }) =>
+      foldersApi.moveItem(selectedCompanyId!, { kind: "skill", itemId, folderId }),
+    onSuccess: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: queryKeys.companySkills.list(selectedCompanyId!) }),
+        queryClient.invalidateQueries({ queryKey: queryKeys.folders.list(selectedCompanyId!, "skill") }),
+      ]);
+    },
+    onError: (error) => {
+      pushToast({
+        tone: "error",
+        title: "Move failed",
+        body: error instanceof Error ? error.message : "Failed to move skill.",
+      });
+    },
+  });
+
+  async function moveSelectedSkills(folderId: string | null) {
+    const ids = selectedSkillIds;
+    if (ids.length === 0) return;
+    await Promise.all(ids.map((itemId) => foldersApi.moveItem(selectedCompanyId!, { kind: "skill", itemId, folderId })));
+    setSelectedSkillIds([]);
+    setSelectMode(false);
+    await Promise.all([
+      queryClient.invalidateQueries({ queryKey: queryKeys.companySkills.list(selectedCompanyId!) }),
+      queryClient.invalidateQueries({ queryKey: queryKeys.folders.list(selectedCompanyId!, "skill") }),
+    ]);
+    pushToast({ tone: "success", title: "Skills moved", body: `${ids.length} skill${ids.length === 1 ? "" : "s"} filed.` });
+  }
 
   const eligibleAgentsForAttach = useMemo(() => {
     const data = agentsQuery.data ?? [];
@@ -4263,6 +4553,8 @@ export function CompanySkills() {
   const studioDescription = studioForkFromId
     ? "Review the fork metadata and create an editable company copy."
     : "Create an editable company skill in the Paperclip workspace.";
+  const skillFolderResult = skillFoldersQuery.data ?? null;
+  const showInstalledFolders = isDiscovery && discoveryTab === "installed";
 
   return (
     <>
@@ -4431,6 +4723,40 @@ export function CompanySkills() {
         </DialogContent>
       </Dialog>
 
+      <FolderFormDialog
+        open={folderDialogOpen}
+        kind="skill"
+        folder={folderDialogTarget}
+        pending={createFolder.isPending || updateFolder.isPending}
+        onOpenChange={setFolderDialogOpen}
+        onSubmit={(payload) => {
+          if (folderDialogTarget) updateFolder.mutate({ folderId: folderDialogTarget.id, payload });
+          else createFolder.mutate(payload);
+        }}
+      />
+      <DeleteFolderDialog
+        open={deleteFolderTarget !== null}
+        folder={deleteFolderTarget}
+        itemLabelPlural="skills"
+        pending={deleteFolder.isPending}
+        onOpenChange={(open) => {
+          if (!open) setDeleteFolderTarget(null);
+        }}
+        onConfirm={() => {
+          if (deleteFolderTarget) deleteFolder.mutate(deleteFolderTarget.id);
+        }}
+      />
+      <MobileFolderSheet
+        open={mobileFoldersOpen}
+        onOpenChange={setMobileFoldersOpen}
+        result={skillFolderResult}
+        selection={folderSelection}
+        allLabel="All skills"
+        itemLabelPlural="Skills"
+        onSelect={setFolderSelection}
+        onCreate={() => openCreateFolder()}
+      />
+
       {isStudioNew ? (
         <div className="min-h-(--sz-calc-30)">
           <div className="border-b border-border px-4 py-5">
@@ -4486,6 +4812,49 @@ export function CompanySkills() {
           onScan={() => scanProjects.mutate()}
           scanPending={scanProjects.isPending}
           scanStatus={scanStatusMessage}
+          folderResult={showInstalledFolders ? skillFolderResult : null}
+          folderSelection={folderSelection}
+          foldersLoading={skillFoldersQuery.isLoading}
+          selectMode={showInstalledFolders && selectMode}
+          selectedSkillIds={selectedSkillIds}
+          onFolderSelect={showInstalledFolders ? setFolderSelection : undefined}
+          onOpenMobileFolders={showInstalledFolders ? () => setMobileFoldersOpen(true) : undefined}
+          onCreateFolder={showInstalledFolders ? () => openCreateFolder() : undefined}
+          onRenameFolder={showInstalledFolders ? (folder, name) => updateFolder.mutate({ folderId: folder.id, payload: { name } }) : undefined}
+          onEditFolder={showInstalledFolders ? (folder) => {
+            setFolderDialogTarget(folder);
+            setFolderDialogOpen(true);
+          } : undefined}
+          onDeleteFolder={showInstalledFolders ? setDeleteFolderTarget : undefined}
+          onToggleSelectMode={showInstalledFolders ? () => {
+            setSelectMode((current) => !current);
+            if (selectMode) setSelectedSkillIds([]);
+          } : undefined}
+          onSelectCard={showInstalledFolders ? (card, selected) => {
+            if (!card.skillId) return;
+            setSelectedSkillIds((current) =>
+              selected
+                ? Array.from(new Set([...current, card.skillId!]))
+                : current.filter((id) => id !== card.skillId)
+            );
+          } : undefined}
+          onMoveCard={showInstalledFolders ? (card, folderId) => {
+            if (!card.skillId) return;
+            moveSkillToFolder.mutate({ itemId: card.skillId, folderId });
+            pushToast({
+              tone: "success",
+              title: "Skill moved",
+              body: folderId
+                ? `Moved to ${skillFolderResult?.folders.find((folder) => folder.id === folderId)?.name ?? "folder"}.`
+                : "Moved to Unfiled.",
+            });
+          } : undefined}
+          onCreateFolderAndMoveCard={showInstalledFolders ? (card) => {
+            if (card.skillId) openCreateFolder([card.skillId]);
+          } : undefined}
+          onMoveSelected={showInstalledFolders ? (folderId) => void moveSelectedSkills(folderId) : undefined}
+          onCreateFolderAndMoveSelected={showInstalledFolders ? () => openCreateFolder(selectedSkillIds) : undefined}
+          onClearSelected={showInstalledFolders ? () => setSelectedSkillIds([]) : undefined}
         />
       ) : activeView === "installed" && selectedSkillId ? (
         <SkillDetailPage

--- a/ui/src/pages/CompanySkills.tsx
+++ b/ui/src/pages/CompanySkills.tsx
@@ -4343,13 +4343,22 @@ export function CompanySkills() {
       if (moveAfterCreateSkillIds.length > 0) {
         const ids = moveAfterCreateSkillIds;
         setMoveAfterCreateSkillIds([]);
-        await Promise.all(ids.map((itemId) =>
-          foldersApi.moveItem(selectedCompanyId!, { kind: "skill", itemId, folderId: folder.id })
-        ));
-        await Promise.all([
-          queryClient.invalidateQueries({ queryKey: queryKeys.companySkills.list(selectedCompanyId!) }),
-          queryClient.invalidateQueries({ queryKey: queryKeys.folders.list(selectedCompanyId!, "skill") }),
-        ]);
+        try {
+          await Promise.all(ids.map((itemId) =>
+            foldersApi.moveItem(selectedCompanyId!, { kind: "skill", itemId, folderId: folder.id })
+          ));
+          await Promise.all([
+            queryClient.invalidateQueries({ queryKey: queryKeys.companySkills.list(selectedCompanyId!) }),
+            queryClient.invalidateQueries({ queryKey: queryKeys.folders.list(selectedCompanyId!, "skill") }),
+          ]);
+        } catch (moveError) {
+          pushToast({
+            tone: "error",
+            title: "Folder created, move failed",
+            body: moveError instanceof Error ? moveError.message : "Failed to move the selected skills.",
+          });
+          return;
+        }
       } else {
         setFolderSelection(folder.id);
       }
@@ -4419,14 +4428,22 @@ export function CompanySkills() {
   async function moveSelectedSkills(folderId: string | null) {
     const ids = selectedSkillIds;
     if (ids.length === 0) return;
-    await Promise.all(ids.map((itemId) => foldersApi.moveItem(selectedCompanyId!, { kind: "skill", itemId, folderId })));
-    setSelectedSkillIds([]);
-    setSelectMode(false);
-    await Promise.all([
-      queryClient.invalidateQueries({ queryKey: queryKeys.companySkills.list(selectedCompanyId!) }),
-      queryClient.invalidateQueries({ queryKey: queryKeys.folders.list(selectedCompanyId!, "skill") }),
-    ]);
-    pushToast({ tone: "success", title: "Skills moved", body: `${ids.length} skill${ids.length === 1 ? "" : "s"} filed.` });
+    try {
+      await Promise.all(ids.map((itemId) => foldersApi.moveItem(selectedCompanyId!, { kind: "skill", itemId, folderId })));
+      setSelectedSkillIds([]);
+      setSelectMode(false);
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: queryKeys.companySkills.list(selectedCompanyId!) }),
+        queryClient.invalidateQueries({ queryKey: queryKeys.folders.list(selectedCompanyId!, "skill") }),
+      ]);
+      pushToast({ tone: "success", title: "Skills moved", body: `${ids.length} skill${ids.length === 1 ? "" : "s"} filed.` });
+    } catch (moveError) {
+      pushToast({
+        tone: "error",
+        title: "Failed to move skills",
+        body: moveError instanceof Error ? moveError.message : "Failed to move the selected skills.",
+      });
+    }
   }
 
   const eligibleAgentsForAttach = useMemo(() => {

--- a/ui/src/pages/CompanySkills.tsx
+++ b/ui/src/pages/CompanySkills.tsx
@@ -4371,6 +4371,13 @@ export function CompanySkills() {
       setFolderDialogTarget(null);
       await queryClient.invalidateQueries({ queryKey: queryKeys.folders.list(selectedCompanyId!, "skill") });
     },
+    onError: (error) => {
+      pushToast({
+        tone: "error",
+        title: "Folder save failed",
+        body: error instanceof Error ? error.message : "Failed to update folder.",
+      });
+    },
   });
   const deleteFolder = useMutation({
     mutationFn: (folderId: string) => foldersApi.delete(selectedCompanyId!, folderId),
@@ -4382,6 +4389,13 @@ export function CompanySkills() {
         queryClient.invalidateQueries({ queryKey: queryKeys.folders.list(selectedCompanyId!, "skill") }),
       ]);
       pushToast({ tone: "success", title: "Folder deleted", body: "Skills moved to Unfiled." });
+    },
+    onError: (error) => {
+      pushToast({
+        tone: "error",
+        title: "Folder delete failed",
+        body: error instanceof Error ? error.message : "Failed to delete folder.",
+      });
     },
   });
   const moveSkillToFolder = useMutation({

--- a/ui/src/pages/Routines.test.tsx
+++ b/ui/src/pages/Routines.test.tsx
@@ -286,6 +286,7 @@ function createRoutine(overrides: Partial<RoutineListItem>): RoutineListItem {
     triggers: [],
     lastRun: null,
     activeIssue: null,
+    folderId: null,
     ...overrides,
   };
 }
@@ -578,7 +579,6 @@ describe("Routines page", () => {
       }),
     ]);
     issuesListMock.mockResolvedValue([]);
-
     const root = createRoot(container);
     const queryClient = new QueryClient({
       defaultOptions: {
@@ -608,6 +608,99 @@ describe("Routines page", () => {
 
     await act(async () => {
       root.unmount();
+    });
+  });
+
+  it("filters to Unfiled and shows the empty-folder state with a create CTA", async () => {
+    foldersListMock.mockResolvedValue({
+      kind: "routine",
+      allCount: 2,
+      unfiledCount: 1,
+      folders: [
+        {
+          id: "folder-reporting",
+          companyId: "company-1",
+          kind: "routine",
+          name: "Reporting",
+          color: "#6366f1",
+          position: 0,
+          itemCount: 1,
+          createdAt: new Date("2026-07-01T00:00:00.000Z"),
+          updatedAt: new Date("2026-07-01T00:00:00.000Z"),
+        },
+        {
+          id: "folder-empty",
+          companyId: "company-1",
+          kind: "routine",
+          name: "Empty folder",
+          color: null,
+          position: 1,
+          itemCount: 0,
+          createdAt: new Date("2026-07-01T00:00:00.000Z"),
+          updatedAt: new Date("2026-07-01T00:00:00.000Z"),
+        },
+      ],
+    });
+    routinesListMock.mockResolvedValue([
+      createRoutine({ id: "routine-1", title: "Filed digest", folderId: "folder-reporting" }),
+      createRoutine({ id: "routine-2", title: "Loose routine", folderId: null }),
+    ]);
+    issuesListMock.mockResolvedValue([]);
+
+    currentSearch = "folder=unfiled";
+    const root = createRoot(container);
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+      },
+    });
+
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <Routines />
+        </QueryClientProvider>,
+      );
+      await flush();
+    });
+    for (let attempts = 0; attempts < 5 && !container.textContent?.includes("Loose routine"); attempts += 1) {
+      await act(async () => {
+        await flush();
+      });
+    }
+
+    // Unfiled filter: only the folderless routine renders; the rail still lists folders.
+    expect(container.textContent).toContain("Loose routine");
+    expect(container.textContent).not.toContain("Filed digest");
+    expect(container.textContent).toContain("Reporting");
+    expect(container.textContent).toContain("Empty folder");
+
+    await act(async () => {
+      root.unmount();
+    });
+
+    // Remount filtered to the empty folder: empty state + create-into-folder CTA.
+    currentSearch = "folder=folder-empty";
+    const secondRoot = createRoot(container);
+    await act(async () => {
+      secondRoot.render(
+        <QueryClientProvider client={queryClient}>
+          <Routines />
+        </QueryClientProvider>,
+      );
+      await flush();
+    });
+    for (let attempts = 0; attempts < 5 && !container.textContent?.includes("This folder is empty"); attempts += 1) {
+      await act(async () => {
+        await flush();
+      });
+    }
+
+    expect(container.textContent).toContain("This folder is empty");
+    expect(container.textContent).toContain("New routine in this folder");
+
+    await act(async () => {
+      secondRoot.unmount();
     });
   });
 

--- a/ui/src/pages/Routines.test.tsx
+++ b/ui/src/pages/Routines.test.tsx
@@ -602,7 +602,6 @@ describe("Routines page", () => {
     }
 
     const text = container.textContent ?? "";
-    expect(text.indexOf("Project Alpha")).toBeLessThan(text.indexOf("Morning sync"));
     expect(text.indexOf("Morning sync")).toBeLessThan(text.indexOf("Built-in routines"));
     expect(text.indexOf("Built-in routines")).toBeLessThan(text.indexOf("Reflection review"));
 

--- a/ui/src/pages/Routines.test.tsx
+++ b/ui/src/pages/Routines.test.tsx
@@ -4,7 +4,7 @@ import type { AnchorHTMLAttributes, ReactNode } from "react";
 import { flushSync } from "react-dom";
 import { createRoot } from "react-dom/client";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import type { Issue, RoutineListItem } from "@paperclipai/shared";
+import type { FolderListResult, Issue, RoutineListItem } from "@paperclipai/shared";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Routines, buildRoutineGroups, buildRoutineSections, sortRoutines } from "./Routines";
 
@@ -20,6 +20,7 @@ async function act(callback: () => void | Promise<void>) {
 
 const navigateMock = vi.fn();
 const routinesListMock = vi.fn<(companyId: string) => Promise<RoutineListItem[]>>();
+const foldersListMock = vi.fn<(companyId: string, kind: string) => Promise<FolderListResult>>();
 const issuesListMock = vi.fn<(companyId: string, filters?: Record<string, unknown>) => Promise<Issue[]>>();
 const markdownEditorRenderMock = vi.fn((props: { mentions?: Array<{ id: string; name: string }> }) => props);
 const issuesListRenderMock = vi.fn(({ issues }: { issues: Issue[] }) => (
@@ -55,6 +56,16 @@ vi.mock("../api/routines", () => ({
     create: vi.fn(),
     update: vi.fn(),
     run: vi.fn(),
+  },
+}));
+
+vi.mock("../api/folders", () => ({
+  foldersApi: {
+    list: (companyId: string, kind: string) => foldersListMock(companyId, kind),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    moveItem: vi.fn(),
   },
 }));
 
@@ -343,6 +354,13 @@ describe("Routines page", () => {
     currentSearch = "";
     navigateMock.mockReset();
     routinesListMock.mockReset();
+    foldersListMock.mockReset();
+    foldersListMock.mockResolvedValue({
+      kind: "routine",
+      folders: [],
+      allCount: 0,
+      unfiledCount: 0,
+    });
     issuesListMock.mockReset();
     markdownEditorRenderMock.mockClear();
     issuesListRenderMock.mockClear();
@@ -396,6 +414,22 @@ describe("Routines page", () => {
     expect(groups.map((group) => group.label)).toEqual(["Project Alpha", "Built-in routines"]);
     expect(groups[0]?.items.map((item) => item.title)).toEqual(["Morning sync"]);
     expect(groups[1]?.items.map((item) => item.title)).toEqual(["Reflection review"]);
+  });
+
+  it("uses a flat group when Folder grouping is active", () => {
+    const routines = [
+      createRoutine({ id: "routine-1", title: "Morning sync", projectId: "project-1" }),
+      createRoutine({ id: "routine-2", title: "Weekly digest", projectId: "project-2" }),
+    ];
+
+    const groups = buildRoutineGroups(
+      routines,
+      "folder",
+      new Map(),
+      new Map(),
+    );
+
+    expect(groups).toEqual([{ key: "__all", label: null, items: routines }]);
   });
 
   it("sorts routines by selected field and direction without mutating the source list", () => {
@@ -489,7 +523,7 @@ describe("Routines page", () => {
     });
   });
 
-  it("defaults the routines list to project groups sorted by title", async () => {
+  it("defaults the routines list to folder mode without rendering project groups", async () => {
     routinesListMock.mockResolvedValue([
       createRoutine({ id: "routine-1", title: "Weekly digest", projectId: "project-1" }),
       createRoutine({ id: "routine-2", title: "Morning sync", projectId: "project-1" }),
@@ -513,17 +547,15 @@ describe("Routines page", () => {
       await flush();
     });
 
-    for (let attempts = 0; attempts < 5 && !container.textContent?.includes("Project Alpha"); attempts += 1) {
+    for (let attempts = 0; attempts < 5 && !container.textContent?.includes("Morning sync"); attempts += 1) {
       await act(async () => {
         await flush();
       });
     }
 
     const text = container.textContent ?? "";
-    expect(text.indexOf("Project Alpha")).toBeLessThan(text.indexOf("Project Beta"));
     expect(text.indexOf("Morning sync")).toBeLessThan(text.indexOf("Weekly digest"));
-    expect(text.indexOf("Project Alpha")).toBeLessThan(text.indexOf("Morning sync"));
-    expect(text.indexOf("Weekly digest")).toBeLessThan(text.indexOf("Project Beta"));
+    expect(text).toContain("New folder");
 
     await act(async () => {
       root.unmount();

--- a/ui/src/pages/Routines.tsx
+++ b/ui/src/pages/Routines.tsx
@@ -50,6 +50,7 @@ import { Tabs, TabsContent } from "@/components/ui/tabs";
 import type { RoutineListItem, RoutineVariable } from "@paperclipai/shared";
 import type { FolderListItem } from "@paperclipai/shared";
 import {
+  AllUnfiledBanner,
   BulkBar,
   DeleteFolderDialog,
   FolderChip,
@@ -1170,6 +1171,13 @@ export function Routines() {
               )}
             </div>
           ) : null}
+          {routineViewState.groupBy === "folder" && !hasRoutineFolders && !foldersLoading && visibleRoutines.length > 0 ? (
+            <AllUnfiledBanner
+              storageKey={`paperclip:routines-folder-nudge:${selectedCompanyId ?? "none"}`}
+              itemLabelPlural="routines"
+              onCreateFolder={() => openCreateFolder()}
+            />
+          ) : null}
           {selectMode ? (
             <BulkBar
               selectedCount={selectedRoutineIds.length}
@@ -1257,13 +1265,18 @@ export function Routines() {
                               folders={routineFolders?.folders ?? []}
                               currentFolderId={routine.folderId ?? null}
                               onMove={(folderId) => {
+                                const previousFolderId = routine.folderId ?? null;
                                 moveRoutineToFolder.mutate({ itemId: routine.id, folderId });
                                 pushToast({
                                   title: "Routine moved",
                                   body: folderId
-                                    ? `Moved to ${routineFolders?.folders.find((folder) => folder.id === folderId)?.name ?? "folder"}.`
-                                    : "Moved to Unfiled.",
+                                    ? `Moved "${routine.title}" to ${routineFolders?.folders.find((folder) => folder.id === folderId)?.name ?? "folder"}.`
+                                    : `Moved "${routine.title}" to Unfiled.`,
                                   tone: "success",
+                                  action: {
+                                    label: "Undo",
+                                    onClick: () => moveRoutineToFolder.mutate({ itemId: routine.id, folderId: previousFolderId }),
+                                  },
                                 });
                               }}
                               onCreateAndMove={() => openCreateFolder([routine.id])}

--- a/ui/src/pages/Routines.tsx
+++ b/ui/src/pages/Routines.tsx
@@ -466,6 +466,13 @@ export function Routines() {
       setFolderDialogTarget(null);
       await queryClient.invalidateQueries({ queryKey: queryKeys.folders.list(selectedCompanyId!, "routine") });
     },
+    onError: (mutationError) => {
+      pushToast({
+        title: "Folder save failed",
+        body: mutationError instanceof Error ? mutationError.message : "Paperclip could not update the folder.",
+        tone: "error",
+      });
+    },
   });
   const deleteFolder = useMutation({
     mutationFn: (folderId: string) => foldersApi.delete(selectedCompanyId!, folderId),
@@ -477,6 +484,13 @@ export function Routines() {
         queryClient.invalidateQueries({ queryKey: queryKeys.folders.list(selectedCompanyId!, "routine") }),
       ]);
       pushToast({ title: "Folder deleted", body: "Items moved to Unfiled.", tone: "success" });
+    },
+    onError: (mutationError) => {
+      pushToast({
+        title: "Folder delete failed",
+        body: mutationError instanceof Error ? mutationError.message : "Paperclip could not delete the folder.",
+        tone: "error",
+      });
     },
   });
   const moveRoutineToFolder = useMutation({

--- a/ui/src/pages/Routines.tsx
+++ b/ui/src/pages/Routines.tsx
@@ -3,6 +3,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link, useNavigate, useSearchParams } from "@/lib/router";
 import { ArrowUpDown, Check, ChevronDown, ChevronRight, Layers, Plus, Repeat } from "lucide-react";
 import { routinesApi } from "../api/routines";
+import { foldersApi } from "../api/folders";
 import { agentsApi } from "../api/agents";
 import { projectsApi } from "../api/projects";
 import { issuesApi } from "../api/issues";
@@ -12,6 +13,7 @@ import { useCompany } from "../context/CompanyContext";
 import { useBreadcrumbs } from "../context/BreadcrumbContext";
 import { useToastActions } from "../context/ToastContext";
 import { buildMarkdownMentionOptions } from "../lib/company-members";
+import { cn } from "../lib/utils";
 import { queryKeys } from "../lib/queryKeys";
 import { groupBy } from "../lib/groupBy";
 import { createIssueDetailLocationState } from "../lib/issueDetailBreadcrumb";
@@ -46,6 +48,21 @@ import {
 } from "@/components/ui/select";
 import { Tabs, TabsContent } from "@/components/ui/tabs";
 import type { RoutineListItem, RoutineVariable } from "@paperclipai/shared";
+import type { FolderListItem } from "@paperclipai/shared";
+import {
+  BulkBar,
+  DeleteFolderDialog,
+  FolderChip,
+  FolderFormDialog,
+  FolderRail,
+  FolderSwatch,
+  MobileFolderSheet,
+  MoveToMenu,
+  folderSearchValue,
+  normalizeFolderSelection,
+  selectedFolderFromList,
+  type FolderSelection,
+} from "../components/folders/FolderControls";
 
 const concurrencyPolicies = ["coalesce_if_active", "always_enqueue", "skip_if_active"];
 const catchUpPolicies = ["skip_missed", "enqueue_missed_with_cap"];
@@ -66,7 +83,7 @@ function autoResizeTextarea(element: HTMLTextAreaElement | null) {
 }
 
 type RoutinesTab = "routines" | "runs";
-type RoutineGroupBy = "none" | "project" | "assignee";
+type RoutineGroupBy = "folder" | "none" | "project" | "assignee";
 type RoutineSortField = "updated" | "created" | "title" | "lastRun";
 type RoutineSortDir = "asc" | "desc";
 
@@ -88,7 +105,7 @@ const builtInRoutineGroupKey = "__built_in_routines";
 const defaultRoutineViewState: RoutineViewState = {
   sortField: "title",
   sortDir: "asc",
-  groupBy: "project",
+  groupBy: "folder",
   collapsedGroups: [],
 };
 
@@ -120,6 +137,7 @@ function buildRoutineMutationPayload(input: {
   title: string;
   description: string;
   projectId: string;
+  folderId: string | null;
   assigneeAgentId: string;
   priority: string;
   concurrencyPolicy: string;
@@ -130,6 +148,7 @@ function buildRoutineMutationPayload(input: {
     ...input,
     description: input.description.trim() || null,
     projectId: input.projectId || null,
+    folderId: input.folderId || null,
     assigneeAgentId: input.assigneeAgentId || null,
   };
 }
@@ -140,7 +159,7 @@ export function buildRoutineGroups(
   projectById: Map<string, { name: string }>,
   agentById: Map<string, { name: string }>,
 ): RoutineGroup[] {
-  if (groupByValue === "none") {
+  if (groupByValue === "none" || groupByValue === "folder") {
     return [{ key: "__all", label: null, items: routines }];
   }
 
@@ -267,12 +286,19 @@ export function Routines() {
   const { setBreadcrumbs } = useBreadcrumbs();
   const queryClient = useQueryClient();
   const navigate = useNavigate();
-  const [searchParams] = useSearchParams();
+  const [searchParams, setSearchParams] = useSearchParams();
   const { pushToast } = useToastActions();
   const descriptionEditorRef = useRef<MarkdownEditorRef>(null);
   const titleInputRef = useRef<HTMLTextAreaElement | null>(null);
   const assigneeSelectorRef = useRef<HTMLButtonElement | null>(null);
   const projectSelectorRef = useRef<HTMLButtonElement | null>(null);
+  const [folderDialogOpen, setFolderDialogOpen] = useState(false);
+  const [folderDialogTarget, setFolderDialogTarget] = useState<FolderListItem | null>(null);
+  const [deleteFolderTarget, setDeleteFolderTarget] = useState<FolderListItem | null>(null);
+  const [mobileFoldersOpen, setMobileFoldersOpen] = useState(false);
+  const [selectMode, setSelectMode] = useState(false);
+  const [selectedRoutineIds, setSelectedRoutineIds] = useState<string[]>([]);
+  const [moveAfterCreateIds, setMoveAfterCreateIds] = useState<string[]>([]);
   const [runningRoutineId, setRunningRoutineId] = useState<string | null>(null);
   const [statusMutationRoutineId, setStatusMutationRoutineId] = useState<string | null>(null);
   const [runDialogRoutine, setRunDialogRoutine] = useState<RoutineListItem | null>(null);
@@ -283,6 +309,7 @@ export function Routines() {
     title: string;
     description: string;
     projectId: string;
+    folderId: string | null;
     assigneeAgentId: string;
     priority: string;
     concurrencyPolicy: string;
@@ -292,6 +319,7 @@ export function Routines() {
     title: "",
     description: "",
     projectId: "",
+    folderId: null,
     assigneeAgentId: "",
     priority: "medium",
     concurrencyPolicy: "coalesce_if_active",
@@ -302,6 +330,7 @@ export function Routines() {
     ? `paperclip:routines-view:${selectedCompanyId}`
     : "paperclip:routines-view";
   const [routineViewState, setRoutineViewState] = useState<RoutineViewState>(() => getRoutineViewState(routineViewStateKey));
+  const folderSelection = normalizeFolderSelection(searchParams.get("folder"));
 
   useEffect(() => {
     setBreadcrumbs([{ label: "Routines" }]);
@@ -315,6 +344,11 @@ export function Routines() {
     queryKey: queryKeys.routines.list(selectedCompanyId!),
     queryFn: () => routinesApi.list(selectedCompanyId!),
     enabled: !!selectedCompanyId,
+  });
+  const { data: routineFolders, isLoading: foldersLoading } = useQuery({
+    queryKey: queryKeys.folders.list(selectedCompanyId!, "routine"),
+    queryFn: () => foldersApi.list(selectedCompanyId!, "routine"),
+    enabled: !!selectedCompanyId && activeTab === "routines",
   });
   const { data: agents } = useQuery({
     queryKey: queryKeys.agents.list(selectedCompanyId!),
@@ -373,6 +407,7 @@ export function Routines() {
         title: "",
         description: "",
         projectId: "",
+        folderId: null,
         assigneeAgentId: "",
         priority: "medium",
         concurrencyPolicy: "coalesce_if_active",
@@ -390,6 +425,74 @@ export function Routines() {
         tone: "success",
       });
       navigate(`/routines/${routine.id}?tab=triggers`);
+    },
+  });
+  const createFolder = useMutation({
+    mutationFn: (payload: { name: string; color: string | null }) =>
+      foldersApi.create(selectedCompanyId!, { kind: "routine", ...payload }),
+    onSuccess: async (folder) => {
+      setFolderDialogOpen(false);
+      setFolderDialogTarget(null);
+      await queryClient.invalidateQueries({ queryKey: queryKeys.folders.list(selectedCompanyId!, "routine") });
+      if (moveAfterCreateIds.length > 0) {
+        const ids = moveAfterCreateIds;
+        setMoveAfterCreateIds([]);
+        await Promise.all(ids.map((itemId) =>
+          foldersApi.moveItem(selectedCompanyId!, { kind: "routine", itemId, folderId: folder.id })
+        ));
+        await Promise.all([
+          queryClient.invalidateQueries({ queryKey: queryKeys.routines.list(selectedCompanyId!) }),
+          queryClient.invalidateQueries({ queryKey: queryKeys.folders.list(selectedCompanyId!, "routine") }),
+        ]);
+      } else {
+        setFolderSelection(folder.id);
+      }
+      pushToast({ title: "Folder created", body: folder.name, tone: "success" });
+    },
+    onError: (mutationError) => {
+      pushToast({
+        title: "Failed to save folder",
+        body: mutationError instanceof Error ? mutationError.message : "Paperclip could not save the folder.",
+        tone: "error",
+      });
+    },
+  });
+  const updateFolder = useMutation({
+    mutationFn: ({ folderId, payload }: { folderId: string; payload: { name?: string; color?: string | null } }) =>
+      foldersApi.update(selectedCompanyId!, folderId, payload),
+    onSuccess: async () => {
+      setFolderDialogOpen(false);
+      setFolderDialogTarget(null);
+      await queryClient.invalidateQueries({ queryKey: queryKeys.folders.list(selectedCompanyId!, "routine") });
+    },
+  });
+  const deleteFolder = useMutation({
+    mutationFn: (folderId: string) => foldersApi.delete(selectedCompanyId!, folderId),
+    onSuccess: async (_, folderId) => {
+      if (folderSelection === folderId) setFolderSelection("all");
+      setDeleteFolderTarget(null);
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: queryKeys.routines.list(selectedCompanyId!) }),
+        queryClient.invalidateQueries({ queryKey: queryKeys.folders.list(selectedCompanyId!, "routine") }),
+      ]);
+      pushToast({ title: "Folder deleted", body: "Items moved to Unfiled.", tone: "success" });
+    },
+  });
+  const moveRoutineToFolder = useMutation({
+    mutationFn: ({ itemId, folderId }: { itemId: string; folderId: string | null }) =>
+      foldersApi.moveItem(selectedCompanyId!, { kind: "routine", itemId, folderId }),
+    onSuccess: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: queryKeys.routines.list(selectedCompanyId!) }),
+        queryClient.invalidateQueries({ queryKey: queryKeys.folders.list(selectedCompanyId!, "routine") }),
+      ]);
+    },
+    onError: (mutationError) => {
+      pushToast({
+        title: "Move failed",
+        body: mutationError instanceof Error ? mutationError.message : "Paperclip could not move the routine.",
+        tone: "error",
+      });
     },
   });
   const updateIssue = useMutation({
@@ -494,9 +597,15 @@ export function Routines() {
     () => (routines ?? []).filter((routine) => routine.status !== "archived"),
     [routines],
   );
+  const folderFilteredRoutines = useMemo(() => {
+    if (routineViewState.groupBy !== "folder") return visibleRoutines;
+    if (folderSelection === "all") return visibleRoutines;
+    if (folderSelection === "unfiled") return visibleRoutines.filter((routine) => !routine.folderId);
+    return visibleRoutines.filter((routine) => routine.folderId === folderSelection);
+  }, [folderSelection, routineViewState.groupBy, visibleRoutines]);
   const sortedRoutines = useMemo(
-    () => sortRoutines(visibleRoutines, routineViewState.sortField, routineViewState.sortDir),
-    [routineViewState.sortDir, routineViewState.sortField, visibleRoutines],
+    () => sortRoutines(folderFilteredRoutines, routineViewState.sortField, routineViewState.sortDir),
+    [folderFilteredRoutines, routineViewState.sortDir, routineViewState.sortField],
   );
   const routineSections = useMemo(
     () => buildRoutineSections(sortedRoutines, routineViewState.groupBy, projectById, agentById),
@@ -513,6 +622,9 @@ export function Routines() {
   );
   const currentAssignee = draft.assigneeAgentId ? agentById.get(draft.assigneeAgentId) ?? null : null;
   const currentProject = draft.projectId ? projectById.get(draft.projectId) ?? null : null;
+  const activeFolder = selectedFolderFromList(routineFolders?.folders ?? [], folderSelection);
+  const hasRoutineFolders = (routineFolders?.folders.length ?? 0) > 0;
+  const showFolderRail = activeTab === "routines" && routineViewState.groupBy === "folder" && hasRoutineFolders;
 
   function updateRoutineView(patch: Partial<RoutineViewState>) {
     setRoutineViewState((current) => {
@@ -527,6 +639,43 @@ export function Routines() {
     startTransition(() => {
       navigate(buildRoutinesTabHref(nextTab));
     });
+  }
+
+  function setFolderSelection(selection: FolderSelection) {
+    setSearchParams((current) => {
+      const params = new URLSearchParams(current);
+      const value = folderSearchValue(selection);
+      if (value) params.set("folder", value);
+      else params.delete("folder");
+      return params;
+    });
+  }
+
+  function openCreateFolder(moveItemIds: string[] = []) {
+    setMoveAfterCreateIds(moveItemIds);
+    setFolderDialogTarget(null);
+    setFolderDialogOpen(true);
+  }
+
+  function openCreateRoutine() {
+    setDraft((current) => ({
+      ...current,
+      folderId: folderSelection === "all" || folderSelection === "unfiled" ? null : folderSelection,
+    }));
+    setComposerOpen(true);
+  }
+
+  async function moveSelectedRoutines(folderId: string | null) {
+    const ids = selectedRoutineIds;
+    if (ids.length === 0) return;
+    await Promise.all(ids.map((itemId) => foldersApi.moveItem(selectedCompanyId!, { kind: "routine", itemId, folderId })));
+    setSelectedRoutineIds([]);
+    setSelectMode(false);
+    await Promise.all([
+      queryClient.invalidateQueries({ queryKey: queryKeys.routines.list(selectedCompanyId!) }),
+      queryClient.invalidateQueries({ queryKey: queryKeys.folders.list(selectedCompanyId!, "routine") }),
+    ]);
+    pushToast({ title: "Routines moved", body: `${ids.length} routine${ids.length === 1 ? "" : "s"} filed.`, tone: "success" });
   }
 
   function handleRunNow(routine: RoutineListItem) {
@@ -574,7 +723,7 @@ export function Routines() {
             Recurring work definitions that materialize into auditable execution tasks.
           </p>
         </div>
-        <Button onClick={() => setComposerOpen(true)}>
+        <Button onClick={openCreateRoutine}>
           <Plus className="mr-2 h-4 w-4" />
           Create routine
         </Button>
@@ -647,6 +796,7 @@ export function Routines() {
                 <PopoverContent align="end" className="w-44 p-0">
                   <div className="p-2 space-y-0.5">
                     {([
+                      ["folder", "Folder"],
                       ["project", "Project"],
                       ["assignee", "Agent"],
                       ["none", "None"],
@@ -667,8 +817,29 @@ export function Routines() {
                   </div>
                 </PopoverContent>
               </Popover>
+              {routineViewState.groupBy === "folder" && !hasRoutineFolders ? (
+                <Button variant="outline" size="sm" onClick={() => openCreateFolder()}>
+                  <Plus className="mr-2 h-3.5 w-3.5" />
+                  New folder
+                </Button>
+              ) : null}
+              {showFolderRail ? (
+                <Button variant="ghost" size="sm" className="text-xs" onClick={() => setSelectMode((current) => !current)}>
+                  {selectMode ? "Done" : "Select"}
+                </Button>
+              ) : null}
             </div>
           </div>
+          {routineViewState.groupBy === "folder" ? (
+            <div className="md:hidden">
+              <FolderChip
+                result={routineFolders}
+                selection={folderSelection}
+                allLabel="All routines"
+                onClick={() => setMobileFoldersOpen(true)}
+              />
+            </div>
+          ) : null}
         </TabsContent>
         <TabsContent value="runs">
           <IssuesList
@@ -843,6 +1014,26 @@ export function Routines() {
                       );
                     }}
                   />
+                  <span>filed in</span>
+                  <Select
+                    value={draft.folderId ?? "__unfiled"}
+                    onValueChange={(value) => setDraft((current) => ({
+                      ...current,
+                      folderId: value === "__unfiled" ? null : value,
+                    }))}
+                  >
+                    <SelectTrigger className="h-8 w-auto min-w-32 border-0 bg-muted/50 px-2 shadow-none">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="__unfiled">Unfiled</SelectItem>
+                      {(routineFolders?.folders ?? []).map((folder) => (
+                        <SelectItem key={folder.id} value={folder.id}>
+                          {folder.name}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
                 </div>
               </div>
             </div>
@@ -949,13 +1140,70 @@ export function Routines() {
       ) : null}
 
       {activeTab === "routines" ? (
-        <div>
+        <div className={cn(showFolderRail && "flex gap-4")}>
+          {showFolderRail ? (
+            <FolderRail
+              result={routineFolders}
+              selection={folderSelection}
+              allLabel="All routines"
+              itemLabelPlural="routines"
+              loading={foldersLoading}
+              onSelect={setFolderSelection}
+              onCreate={() => openCreateFolder()}
+              onRename={(folder, name) => updateFolder.mutate({ folderId: folder.id, payload: { name } })}
+              onEdit={(folder) => {
+                setFolderDialogTarget(folder);
+                setFolderDialogOpen(true);
+              }}
+              onDelete={setDeleteFolderTarget}
+            />
+          ) : null}
+          <div className="min-w-0 flex-1">
+          {routineViewState.groupBy === "folder" && hasRoutineFolders ? (
+            <div className="mb-3 flex flex-wrap items-center gap-2">
+              {folderSelection === "all" ? <FolderIconHeader label="All routines" count={sortedRoutines.length} /> : (
+                <div className="flex min-w-0 items-center gap-2 text-sm">
+                  <FolderSwatch color={activeFolder?.color} />
+                  <span className="truncate font-medium">{folderSelection === "unfiled" ? "Unfiled" : activeFolder?.name ?? "Folder"}</span>
+                  <span className="text-muted-foreground">{sortedRoutines.length} routine{sortedRoutines.length === 1 ? "" : "s"}</span>
+                </div>
+              )}
+            </div>
+          ) : null}
+          {selectMode ? (
+            <BulkBar
+              selectedCount={selectedRoutineIds.length}
+              folders={routineFolders?.folders ?? []}
+              onMove={(folderId) => void moveSelectedRoutines(folderId)}
+              onCreateAndMove={() => openCreateFolder(selectedRoutineIds)}
+              onClear={() => setSelectedRoutineIds([])}
+              onDone={() => {
+                setSelectMode(false);
+                setSelectedRoutineIds([]);
+              }}
+            />
+          ) : null}
           {visibleRoutines.length === 0 ? (
             <div className="py-12">
               <EmptyState
                 icon={Repeat}
                 message="No active routines. Use Create routine to define the first recurring workflow."
               />
+            </div>
+          ) : sortedRoutines.length === 0 ? (
+            <div className="py-12">
+              <EmptyState
+                icon={Repeat}
+                message={folderSelection === "all" ? "No routines match this view." : "This folder is empty."}
+              />
+              {folderSelection !== "all" ? (
+                <div className="mt-3 flex justify-center">
+                  <Button size="sm" onClick={openCreateRoutine}>
+                    <Plus className="mr-2 h-3.5 w-3.5" />
+                    New routine in this folder
+                  </Button>
+                </div>
+              ) : null}
             </div>
           ) : (
             <div className="flex flex-col gap-3">
@@ -995,6 +1243,32 @@ export function Routines() {
                           onRunNow={handleRunNow}
                           onToggleEnabled={handleToggleEnabled}
                           onToggleArchived={handleToggleArchived}
+                          selectMode={selectMode}
+                          selected={selectedRoutineIds.includes(routine.id)}
+                          onSelectChange={(selectedRoutine, selected) => {
+                            setSelectedRoutineIds((current) =>
+                              selected
+                                ? Array.from(new Set([...current, selectedRoutine.id]))
+                                : current.filter((id) => id !== selectedRoutine.id)
+                            );
+                          }}
+                          extraMenuItems={
+                            <MoveToMenu
+                              folders={routineFolders?.folders ?? []}
+                              currentFolderId={routine.folderId ?? null}
+                              onMove={(folderId) => {
+                                moveRoutineToFolder.mutate({ itemId: routine.id, folderId });
+                                pushToast({
+                                  title: "Routine moved",
+                                  body: folderId
+                                    ? `Moved to ${routineFolders?.folders.find((folder) => folder.id === folderId)?.name ?? "folder"}.`
+                                    : "Moved to Unfiled.",
+                                  tone: "success",
+                                });
+                              }}
+                              onCreateAndMove={() => openCreateFolder([routine.id])}
+                            />
+                          }
                         />
                       ))}
                     </CollapsibleContent>
@@ -1003,8 +1277,43 @@ export function Routines() {
               })}
             </div>
           )}
+          </div>
         </div>
       ) : null}
+
+      <FolderFormDialog
+        open={folderDialogOpen}
+        kind="routine"
+        folder={folderDialogTarget}
+        pending={createFolder.isPending || updateFolder.isPending}
+        onOpenChange={setFolderDialogOpen}
+        onSubmit={(payload) => {
+          if (folderDialogTarget) updateFolder.mutate({ folderId: folderDialogTarget.id, payload });
+          else createFolder.mutate(payload);
+        }}
+      />
+      <DeleteFolderDialog
+        open={deleteFolderTarget !== null}
+        folder={deleteFolderTarget}
+        itemLabelPlural="routines"
+        pending={deleteFolder.isPending}
+        onOpenChange={(open) => {
+          if (!open) setDeleteFolderTarget(null);
+        }}
+        onConfirm={() => {
+          if (deleteFolderTarget) deleteFolder.mutate(deleteFolderTarget.id);
+        }}
+      />
+      <MobileFolderSheet
+        open={mobileFoldersOpen}
+        onOpenChange={setMobileFoldersOpen}
+        result={routineFolders}
+        selection={folderSelection}
+        allLabel="All routines"
+        itemLabelPlural="Routines"
+        onSelect={setFolderSelection}
+        onCreate={() => openCreateFolder()}
+      />
 
       <RoutineRunVariablesDialog
         open={runDialogRoutine !== null}
@@ -1024,6 +1333,16 @@ export function Routines() {
           runRoutine.mutate({ id: runDialogRoutine.id, data });
         }}
       />
+    </div>
+  );
+}
+
+function FolderIconHeader({ label, count }: { label: string; count: number }) {
+  return (
+    <div className="flex min-w-0 items-center gap-2 text-sm">
+      <Repeat className="h-3.5 w-3.5 text-muted-foreground" />
+      <span className="truncate font-medium">{label}</span>
+      <span className="text-muted-foreground">{count} routine{count === 1 ? "" : "s"}</span>
     </div>
   );
 }

--- a/ui/src/pages/Routines.tsx
+++ b/ui/src/pages/Routines.tsx
@@ -604,6 +604,26 @@ export function Routines() {
     if (folderSelection === "unfiled") return visibleRoutines.filter((routine) => !routine.folderId);
     return visibleRoutines.filter((routine) => routine.folderId === folderSelection);
   }, [folderSelection, routineViewState.groupBy, visibleRoutines]);
+  // Rail counts reflect the page's visible scope (archived hidden), not raw DB
+  // counts (ux-spec §5.3).
+  const railFolderResult = useMemo(() => {
+    if (!routineFolders) return routineFolders;
+    const counts = new Map<string, number>();
+    let unfiled = 0;
+    for (const routine of visibleRoutines) {
+      if (routine.folderId) counts.set(routine.folderId, (counts.get(routine.folderId) ?? 0) + 1);
+      else unfiled += 1;
+    }
+    return {
+      ...routineFolders,
+      allCount: visibleRoutines.length,
+      unfiledCount: unfiled,
+      folders: routineFolders.folders.map((folder) => ({
+        ...folder,
+        itemCount: counts.get(folder.id) ?? 0,
+      })),
+    };
+  }, [routineFolders, visibleRoutines]);
   const sortedRoutines = useMemo(
     () => sortRoutines(folderFilteredRoutines, routineViewState.sortField, routineViewState.sortDir),
     [folderFilteredRoutines, routineViewState.sortDir, routineViewState.sortField],
@@ -834,7 +854,7 @@ export function Routines() {
           {routineViewState.groupBy === "folder" ? (
             <div className="md:hidden">
               <FolderChip
-                result={routineFolders}
+                result={railFolderResult}
                 selection={folderSelection}
                 allLabel="All routines"
                 onClick={() => setMobileFoldersOpen(true)}
@@ -1144,7 +1164,7 @@ export function Routines() {
         <div className={cn(showFolderRail && "flex gap-4")}>
           {showFolderRail ? (
             <FolderRail
-              result={routineFolders}
+              result={railFolderResult}
               selection={folderSelection}
               allLabel="All routines"
               itemLabelPlural="routines"
@@ -1320,7 +1340,7 @@ export function Routines() {
       <MobileFolderSheet
         open={mobileFoldersOpen}
         onOpenChange={setMobileFoldersOpen}
-        result={routineFolders}
+        result={railFolderResult}
         selection={folderSelection}
         allLabel="All routines"
         itemLabelPlural="Routines"

--- a/ui/src/pages/Routines.tsx
+++ b/ui/src/pages/Routines.tsx
@@ -438,13 +438,22 @@ export function Routines() {
       if (moveAfterCreateIds.length > 0) {
         const ids = moveAfterCreateIds;
         setMoveAfterCreateIds([]);
-        await Promise.all(ids.map((itemId) =>
-          foldersApi.moveItem(selectedCompanyId!, { kind: "routine", itemId, folderId: folder.id })
-        ));
-        await Promise.all([
-          queryClient.invalidateQueries({ queryKey: queryKeys.routines.list(selectedCompanyId!) }),
-          queryClient.invalidateQueries({ queryKey: queryKeys.folders.list(selectedCompanyId!, "routine") }),
-        ]);
+        try {
+          await Promise.all(ids.map((itemId) =>
+            foldersApi.moveItem(selectedCompanyId!, { kind: "routine", itemId, folderId: folder.id })
+          ));
+          await Promise.all([
+            queryClient.invalidateQueries({ queryKey: queryKeys.routines.list(selectedCompanyId!) }),
+            queryClient.invalidateQueries({ queryKey: queryKeys.folders.list(selectedCompanyId!, "routine") }),
+          ]);
+        } catch (moveError) {
+          pushToast({
+            title: "Folder created, move failed",
+            body: moveError instanceof Error ? moveError.message : "Paperclip could not move the selected routines.",
+            tone: "error",
+          });
+          return;
+        }
       } else {
         setFolderSelection(folder.id);
       }
@@ -703,14 +712,22 @@ export function Routines() {
   async function moveSelectedRoutines(folderId: string | null) {
     const ids = selectedRoutineIds;
     if (ids.length === 0) return;
-    await Promise.all(ids.map((itemId) => foldersApi.moveItem(selectedCompanyId!, { kind: "routine", itemId, folderId })));
-    setSelectedRoutineIds([]);
-    setSelectMode(false);
-    await Promise.all([
-      queryClient.invalidateQueries({ queryKey: queryKeys.routines.list(selectedCompanyId!) }),
-      queryClient.invalidateQueries({ queryKey: queryKeys.folders.list(selectedCompanyId!, "routine") }),
-    ]);
-    pushToast({ title: "Routines moved", body: `${ids.length} routine${ids.length === 1 ? "" : "s"} filed.`, tone: "success" });
+    try {
+      await Promise.all(ids.map((itemId) => foldersApi.moveItem(selectedCompanyId!, { kind: "routine", itemId, folderId })));
+      setSelectedRoutineIds([]);
+      setSelectMode(false);
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: queryKeys.routines.list(selectedCompanyId!) }),
+        queryClient.invalidateQueries({ queryKey: queryKeys.folders.list(selectedCompanyId!, "routine") }),
+      ]);
+      pushToast({ title: "Routines moved", body: `${ids.length} routine${ids.length === 1 ? "" : "s"} filed.`, tone: "success" });
+    } catch (moveError) {
+      pushToast({
+        title: "Failed to move routines",
+        body: moveError instanceof Error ? moveError.message : "Paperclip could not move the selected routines.",
+        tone: "error",
+      });
+    }
   }
 
   function handleRunNow(routine: RoutineListItem) {


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Skills and scheduled routines are established core capabilities, but their management pages remain flat as companies accumulate more automation
> - Flat lists make related routines and skills harder to scan, filter, and maintain at scale
> - A lightweight company-scoped grouping primitive solves that navigation problem without changing the existing single-item ownership model
> - The prior implementation in #9026 became stale and conflicted with current `master`
> - This pull request rebases and updates that folders foundation against current contracts, migrations, and UI design tokens
> - The benefit is consistent folder organization across routines and skills, with safe unfiling behavior and shared controls

## Linked Issues or Issue Description

Supersedes: #9026

No public GitHub issue exists for this feature; the feature request context is included here.

**Subsystem affected**

Cross-cutting: `packages/db`, `packages/shared`, `server`, and `ui`.

**Problem or motivation**

The Routines and Skills pages render flat collections. As a company accumulates automations and reusable skills, operators cannot group related items or focus a page on one organizational area. Naming conventions and search help only partially because they do not provide a durable canonical grouping.

**Proposed solution**

Add flat folders scoped by company and item kind (`routine` or `skill`). Operators can create and rename folders, filter desktop and mobile lists, and move items individually or in bulk. Deleting a folder leaves its items available in the system-defined Unfiled bucket. Folder counts follow the items visible on each page, and skills search continues across folders while identifying each result's folder.

**Alternatives considered**

- Tags alone: useful for cross-cutting metadata, but not a canonical one-folder location.
- Naming prefixes: require manual conventions and do not provide first-class filtering or move actions.
- Nested folders: add substantial hierarchy and drag/drop complexity; flat folders cover the immediate organization need and leave room for a later nesting model.

**Roadmap alignment**

`ROADMAP.md` identifies Skills Manager and Scheduled Routines as established capabilities but does not include a competing organization initiative. This change extends those existing surfaces rather than duplicating planned core work.

**Additional context**

This is the current-master replacement for the stale, conflicting implementation in #9026. The replacement also incorporates current UI token requirements and fixes the asynchronous company-context hooks ordering issue found during rebase verification.

## What Changed

- Add migration `0171_folders.sql`, a company-scoped `folders` table, and nullable folder references on routines and company skills.
- Add shared folder types, validators, API paths, server routes, services, company-boundary checks, and activity logging for folder CRUD and item moves.
- Add shared folder controls for desktop and mobile, folder-aware routine and skill lists, move/undo interactions, Unfiled states, and visible-item counts.
- Add focused server and UI coverage for folder services/routes, dialogs, filtering, moving, empty states, and routines integration.
- Update the rebased UI implementation to use the current design-token layer and preserve React hook ordering while company context resolves.

## Verification

- `cd server && pnpm exec vitest run src/__tests__/folders-service.test.ts src/__tests__/folders-routes.test.ts` — 5 tests passed.
- `cd ui && pnpm exec vitest run src/components/folders/FolderControls.test.tsx src/pages/Routines.test.tsx` — 21 tests passed.
- `pnpm --filter @paperclipai/db typecheck`
- `pnpm --filter @paperclipai/shared typecheck`
- `pnpm --filter @paperclipai/server typecheck`
- `pnpm --filter @paperclipai/ui typecheck`
- `pnpm check:token-gates` — all token gates clean.
- `pnpm exec vitest run server/src/__tests__/openapi-routes.test.ts` — folder routes match the generated OpenAPI document.
- `pnpm --filter @paperclipai/ui build` — production bundle completed.
- Fresh isolated embedded-Postgres database: `PAPERCLIP_CONFIG=<isolated-config> DATABASE_URL= pnpm --filter @paperclipai/db migrate` — all 169 pending migrations applied successfully, including `0171_folders.sql`.

## Risks

- The migration adds a table and nullable foreign keys; existing routines and skills remain Unfiled, so no backfill or destructive rewrite occurs.
- Folder deletion can change list organization, but nullable references and Unfiled behavior preserve the underlying items.
- The UI touches two established management pages; focused component/page tests, package typechecks, and token gates reduce regression risk.
- Flat folders intentionally defer nesting; future hierarchy work must preserve the current company and kind scoping contracts.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex CLI — `gpt-5.4`, reasoning mode with terminal/tool use and code execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge


