### PR TITLE
Fix blocked mention-wake execution lock handling

### DIFF
--- a/server/src/__tests__/issue-blocked-interaction-lock-routes.test.ts
+++ b/server/src/__tests__/issue-blocked-interaction-lock-routes.test.ts
@@ -682,6 +682,117 @@ describeEmbeddedPostgres("blocked interaction wakes do not claim issue execution
     );
   });
 
+  it("keeps deferred blocked mention wake promotions unlocked", async () => {
+    const { assigneeAgentId, issueId } = await seedScenario();
+    const firstRun = await startBlockedInteractionWake(assigneeAgentId, issueId, "issue_commented");
+    const commentId = randomUUID();
+
+    await db
+      .update(issues)
+      .set({
+        executionRunId: firstRun.id,
+        executionAgentNameKey: "qaeng",
+        executionLockedAt: new Date(),
+      })
+      .where(eq(issues.id, issueId));
+
+    const deferredRun = await heartbeat.wakeup(assigneeAgentId, {
+      source: "automation",
+      triggerDetail: "system",
+      reason: "issue_comment_mentioned",
+      payload: { issueId, commentId },
+      contextSnapshot: {
+        issueId,
+        taskId: issueId,
+        commentId,
+        wakeCommentId: commentId,
+        wakeReason: "issue_comment_mentioned",
+        source: "comment.mention",
+      },
+      requestedByActorType: "user",
+      requestedByActorId: "local-board",
+    });
+    expect(deferredRun).toBeNull();
+
+    await waitForCondition(async () =>
+      db
+        .select({ status: agentWakeupRequests.status })
+        .from(agentWakeupRequests)
+        .where(eq(agentWakeupRequests.agentId, assigneeAgentId))
+        .then((rows) => rows.some((row) => row.status === "deferred_issue_execution"))
+    );
+
+    adapterControl.release();
+
+    await waitForCondition(async () =>
+      db
+        .select({
+          runId: agentWakeupRequests.runId,
+          status: agentWakeupRequests.status,
+          reason: agentWakeupRequests.reason,
+        })
+        .from(agentWakeupRequests)
+        .where(eq(agentWakeupRequests.agentId, assigneeAgentId))
+        .then((rows) => rows.some((row) => row.reason === "issue_execution_promoted" && Boolean(row.runId))),
+    );
+
+    const promotedWake = await db
+      .select({
+        runId: agentWakeupRequests.runId,
+        status: agentWakeupRequests.status,
+        reason: agentWakeupRequests.reason,
+      })
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.agentId, assigneeAgentId))
+      .then((rows) => rows.find((row) => row.reason === "issue_execution_promoted" && row.runId) ?? null);
+    expect(promotedWake?.reason).toBe("issue_execution_promoted");
+    expect(["queued", "claimed", "running"]).toContain(promotedWake?.status ?? "");
+
+    const promotedIssueRow = await db
+      .select({
+        status: issues.status,
+        checkoutRunId: issues.checkoutRunId,
+        executionRunId: issues.executionRunId,
+        executionLockedAt: issues.executionLockedAt,
+      })
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+    expect(promotedIssueRow).toEqual({
+      status: "blocked",
+      checkoutRunId: null,
+      executionRunId: null,
+      executionLockedAt: null,
+    });
+
+    adapterControl.release();
+
+    await waitForCondition(async () =>
+      db
+        .select({ status: heartbeatRuns.status })
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.agentId, assigneeAgentId))
+        .then((rows) => rows.filter((row) => row.status === "succeeded").length === 2)
+    );
+
+    const finalIssueRow = await db
+      .select({
+        status: issues.status,
+        checkoutRunId: issues.checkoutRunId,
+        executionRunId: issues.executionRunId,
+        executionLockedAt: issues.executionLockedAt,
+      })
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+    expect(finalIssueRow).toEqual({
+      status: "blocked",
+      checkoutRunId: null,
+      executionRunId: null,
+      executionLockedAt: null,
+    });
+  });
+
   it("keeps cancelled dependency-blocked mention wakes comment-only and unlocked", async () => {
     const { companyId, assigneeAgentId, foreignAgentId, issueId } = await seedScenario("cancelled");
     await db.insert(issueComments).values({

--- a/server/src/__tests__/issue-blocked-interaction-lock-routes.test.ts
+++ b/server/src/__tests__/issue-blocked-interaction-lock-routes.test.ts
@@ -89,6 +89,9 @@ if (!embeddedPostgresSupport.supported) {
   );
 }
 
+const ACTIVE_HEARTBEAT_RUN_STATUSES = new Set(["queued", "running", "scheduled_retry"]);
+const ACTIVE_WAKEUP_REQUEST_STATUSES = new Set(["queued", "deferred_issue_execution", "claimed"]);
+
 async function waitForCondition(fn: () => Promise<boolean>, timeoutMs = 3_000) {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
@@ -98,18 +101,24 @@ async function waitForCondition(fn: () => Promise<boolean>, timeoutMs = 3_000) {
   return fn();
 }
 
-async function waitForHeartbeatSideEffectsToSettle(db: ReturnType<typeof createDb>, timeoutMs = 10_000) {
+async function waitForHeartbeatSideEffectsToSettle(db: ReturnType<typeof createDb>, timeoutMs = 20_000) {
   let lastSnapshot: string | null = null;
   let stableSince = 0;
 
   return waitForCondition(async () => {
-    const [runRows, runEventRows, activityRows, commentRows] = await Promise.all([
+    const [runRows, wakeRows, runEventRows, activityRows, commentRows] = await Promise.all([
       db.select({ status: heartbeatRuns.status }).from(heartbeatRuns),
+      db.select({ status: agentWakeupRequests.status }).from(agentWakeupRequests),
       db.select({ id: heartbeatRunEvents.id }).from(heartbeatRunEvents),
       db.select({ id: activityLog.id }).from(activityLog),
       db.select({ id: issueComments.id }).from(issueComments),
     ]);
-    if (runRows.some((row) => row.status === "queued" || row.status === "running")) {
+    if (runRows.some((row) => ACTIVE_HEARTBEAT_RUN_STATUSES.has(row.status))) {
+      lastSnapshot = null;
+      stableSince = 0;
+      return false;
+    }
+    if (wakeRows.some((row) => ACTIVE_WAKEUP_REQUEST_STATUSES.has(row.status))) {
       lastSnapshot = null;
       stableSince = 0;
       return false;
@@ -117,6 +126,8 @@ async function waitForHeartbeatSideEffectsToSettle(db: ReturnType<typeof createD
 
     const snapshot = [
       runRows.length,
+      wakeRows.length,
+      wakeRows.map((row) => row.status).sort().join(","),
       runEventRows.length,
       activityRows.length,
       commentRows.length,
@@ -159,7 +170,7 @@ describeEmbeddedPostgres("blocked interaction wakes do not claim issue execution
     await db.delete(agents);
     await db.delete(companySkills);
     await db.delete(companies);
-  });
+  }, 30_000);
 
   afterAll(async () => {
     await tempDb?.cleanup();

--- a/server/src/__tests__/issue-blocked-interaction-lock-routes.test.ts
+++ b/server/src/__tests__/issue-blocked-interaction-lock-routes.test.ts
@@ -1,0 +1,331 @@
+import { randomUUID } from "node:crypto";
+import express from "express";
+import request from "supertest";
+import { eq } from "drizzle-orm";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import {
+  activityLog,
+  agents,
+  agentRuntimeState,
+  agentWakeupRequests,
+  companies,
+  companySkills,
+  createDb,
+  heartbeatRunEvents,
+  heartbeatRuns,
+  issueComments,
+  issueRelations,
+  issues,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import { runningProcesses } from "../adapters/index.ts";
+import { errorHandler } from "../middleware/index.js";
+import { issueRoutes } from "../routes/issues.js";
+import { heartbeatService } from "../services/heartbeat.ts";
+
+const adapterControl = vi.hoisted(() => {
+  let releaseCurrentRun: (() => void) | null = null;
+  let startedResolver: (() => void) | null = null;
+  let startedPromise = new Promise<void>((resolve) => {
+    startedResolver = resolve;
+  });
+
+  const reset = () => {
+    releaseCurrentRun = null;
+    startedPromise = new Promise<void>((resolve) => {
+      startedResolver = resolve;
+    });
+  };
+
+  return {
+    execute: vi.fn(async () => {
+      startedResolver?.();
+      await new Promise<void>((resolve) => {
+        releaseCurrentRun = resolve;
+      });
+      return {
+        exitCode: 0,
+        signal: null,
+        timedOut: false,
+        errorMessage: null,
+        summary: "Blocked interaction wake completed.",
+        provider: "test",
+        model: "test-model",
+      };
+    }),
+    waitForStart: () => startedPromise,
+    release: () => releaseCurrentRun?.(),
+    reset,
+  };
+});
+
+vi.mock("../adapters/index.ts", async () => {
+  const actual = await vi.importActual<typeof import("../adapters/index.ts")>("../adapters/index.ts");
+  return {
+    ...actual,
+    getServerAdapter: vi.fn(() => ({
+      supportsLocalAgentJwt: false,
+      execute: adapterControl.execute,
+    })),
+  };
+});
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping blocked interaction lock route tests on this host: ${
+      embeddedPostgresSupport.reason ?? "unsupported environment"
+    }`,
+  );
+}
+
+async function waitForCondition(fn: () => Promise<boolean>, timeoutMs = 3_000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await fn()) return true;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  return fn();
+}
+
+describeEmbeddedPostgres("blocked interaction wakes do not claim issue execution locks", () => {
+  let db!: ReturnType<typeof createDb>;
+  let heartbeat!: ReturnType<typeof heartbeatService>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-blocked-interaction-lock-routes-");
+    db = createDb(tempDb.connectionString);
+    heartbeat = heartbeatService(db);
+  }, 20_000);
+
+  afterEach(async () => {
+    adapterControl.release();
+    await waitForCondition(async () => {
+      const rows = await db.select({ status: heartbeatRuns.status }).from(heartbeatRuns);
+      return rows.every((row) => row.status !== "queued" && row.status !== "running");
+    }, 10_000);
+    adapterControl.reset();
+    runningProcesses.clear();
+    await db.delete(issueComments);
+    await db.delete(issueRelations);
+    await db.delete(activityLog);
+    await db.delete(issues);
+    await db.delete(heartbeatRunEvents);
+    await db.delete(heartbeatRuns);
+    await db.delete(agentWakeupRequests);
+    await db.delete(agentRuntimeState);
+    await db.delete(agents);
+    await db.delete(companySkills);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  function createApp(actor: Express.Request["actor"]) {
+    const app = express();
+    app.use(express.json());
+    app.use((req, _res, next) => {
+      req.actor = actor;
+      next();
+    });
+    app.use("/api", issueRoutes(db, {} as any));
+    app.use(errorHandler);
+    return app;
+  }
+
+  function agentActor(companyId: string, agentId: string): Express.Request["actor"] {
+    return {
+      type: "agent",
+      agentId,
+      companyId,
+      source: "agent_jwt",
+    };
+  }
+
+  async function seedScenario() {
+    const companyId = randomUUID();
+    const assigneeAgentId = randomUUID();
+    const foreignAgentId = randomUUID();
+    const blockerIssueId = randomUUID();
+    const issueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values([
+      {
+        id: assigneeAgentId,
+        companyId,
+        name: "QAEng",
+        role: "engineer",
+        status: "active",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+      {
+        id: foreignAgentId,
+        companyId,
+        name: "CEO",
+        role: "executive",
+        status: "active",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+    ]);
+
+    await db.insert(issues).values([
+      {
+        id: blockerIssueId,
+        companyId,
+        title: "Live blocker",
+        status: "blocked",
+        priority: "high",
+        assigneeAgentId: foreignAgentId,
+        responsibleUserId: "local-board",
+      },
+      {
+        id: issueId,
+        companyId,
+        title: "Blocked QA issue",
+        status: "blocked",
+        priority: "high",
+        assigneeAgentId,
+        responsibleUserId: "local-board",
+      },
+    ]);
+
+    await db.insert(issueRelations).values({
+      companyId,
+      issueId: blockerIssueId,
+      relatedIssueId: issueId,
+      type: "blocks",
+    });
+
+    return { companyId, assigneeAgentId, foreignAgentId, issueId };
+  }
+
+  async function startBlockedInteractionWake(agentId: string, issueId: string) {
+    const commentId = randomUUID();
+    const run = await heartbeat.wakeup(agentId, {
+      source: "automation",
+      triggerDetail: "system",
+      reason: "issue_comment_mentioned",
+      payload: { issueId, commentId },
+      contextSnapshot: {
+        issueId,
+        taskId: issueId,
+        commentId,
+        wakeCommentId: commentId,
+        wakeReason: "issue_comment_mentioned",
+        source: "comment.mention",
+      },
+      requestedByActorType: "user",
+      requestedByActorId: "local-board",
+    });
+
+    expect(run).not.toBeNull();
+    await adapterControl.waitForStart();
+    await waitForCondition(async () =>
+      db
+        .select({ status: heartbeatRuns.status })
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.id, run!.id))
+        .then((rows) => rows[0]?.status === "running")
+    );
+    return run!;
+  }
+
+  it("keeps the issue unlocked for same-assignee blocked interaction wakes", async () => {
+    const { companyId, assigneeAgentId, issueId } = await seedScenario();
+    const run = await startBlockedInteractionWake(assigneeAgentId, issueId);
+
+    const row = await db
+      .select({
+        checkoutRunId: issues.checkoutRunId,
+        executionRunId: issues.executionRunId,
+        executionLockedAt: issues.executionLockedAt,
+      })
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+    expect(row).toEqual({
+      checkoutRunId: null,
+      executionRunId: null,
+      executionLockedAt: null,
+    });
+
+    const issueRes = await request(createApp(agentActor(companyId, assigneeAgentId))).get(`/api/issues/${issueId}`);
+    expect(issueRes.status, JSON.stringify(issueRes.body)).toBe(200);
+    expect(issueRes.body).toMatchObject({
+      id: issueId,
+      checkoutRunId: null,
+      executionRunId: null,
+      executionLockedAt: null,
+    });
+    expect(issueRes.body).not.toHaveProperty("activeRun");
+
+    adapterControl.release();
+    await waitForCondition(async () =>
+      db
+        .select({ status: heartbeatRuns.status })
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.id, run.id))
+        .then((rows) => rows[0]?.status === "succeeded")
+    );
+  });
+
+  it("keeps the issue unlocked for foreign mention wakes on blocked issues", async () => {
+    const { companyId, foreignAgentId, issueId } = await seedScenario();
+    const run = await startBlockedInteractionWake(foreignAgentId, issueId);
+
+    const row = await db
+      .select({
+        checkoutRunId: issues.checkoutRunId,
+        executionRunId: issues.executionRunId,
+        executionLockedAt: issues.executionLockedAt,
+      })
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+    expect(row).toEqual({
+      checkoutRunId: null,
+      executionRunId: null,
+      executionLockedAt: null,
+    });
+
+    const issueRes = await request(createApp(agentActor(companyId, foreignAgentId))).get(`/api/issues/${issueId}`);
+    expect(issueRes.status, JSON.stringify(issueRes.body)).toBe(200);
+    expect(issueRes.body).toMatchObject({
+      id: issueId,
+      checkoutRunId: null,
+      executionRunId: null,
+      executionLockedAt: null,
+    });
+    expect(issueRes.body).not.toHaveProperty("activeRun");
+
+    adapterControl.release();
+    await waitForCondition(async () =>
+      db
+        .select({ status: heartbeatRuns.status })
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.id, run.id))
+        .then((rows) => rows[0]?.status === "succeeded")
+    );
+  });
+});

--- a/server/src/__tests__/issue-blocked-interaction-lock-routes.test.ts
+++ b/server/src/__tests__/issue-blocked-interaction-lock-routes.test.ts
@@ -326,6 +326,23 @@ describeEmbeddedPostgres("blocked interaction wakes do not claim issue execution
         .where(eq(heartbeatRuns.id, run.id))
         .then((rows) => rows[0]?.status === "succeeded")
     );
+
+    const rowAfterRun = await db
+      .select({
+        status: issues.status,
+        checkoutRunId: issues.checkoutRunId,
+        executionRunId: issues.executionRunId,
+        executionLockedAt: issues.executionLockedAt,
+      })
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+    expect(rowAfterRun).toEqual({
+      status: "blocked",
+      checkoutRunId: null,
+      executionRunId: null,
+      executionLockedAt: null,
+    });
   });
 
   it("keeps the issue unlocked for foreign mention wakes on blocked issues", async () => {
@@ -356,6 +373,80 @@ describeEmbeddedPostgres("blocked interaction wakes do not claim issue execution
       executionLockedAt: null,
     });
     expect(issueRes.body).not.toHaveProperty("activeRun");
+
+    adapterControl.release();
+    await waitForCondition(async () =>
+      db
+        .select({ status: heartbeatRuns.status })
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.id, run.id))
+        .then((rows) => rows[0]?.status === "succeeded")
+    );
+
+    const rowAfterRun = await db
+      .select({
+        status: issues.status,
+        checkoutRunId: issues.checkoutRunId,
+        executionRunId: issues.executionRunId,
+        executionLockedAt: issues.executionLockedAt,
+      })
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+    expect(rowAfterRun).toEqual({
+      status: "blocked",
+      checkoutRunId: null,
+      executionRunId: null,
+      executionLockedAt: null,
+    });
+  });
+
+  it("keeps the issue unlocked after a foreign blocked mention wake posts a comment-only triage", async () => {
+    const { companyId, assigneeAgentId, foreignAgentId, issueId } = await seedScenario();
+    await db.insert(issueComments).values({
+      id: randomUUID(),
+      companyId,
+      issueId,
+      body: `For visibility: [@CEO](agent://${foreignAgentId})`,
+      authorAgentId: assigneeAgentId,
+    });
+    const run = await startBlockedInteractionWake(foreignAgentId, issueId);
+
+    const commentRes = await request(createApp(agentActor(companyId, foreignAgentId, run.id)))
+      .post(`/api/issues/${issueId}/comments`)
+      .send({
+        body: "Triage only: the blocker is still unresolved, so I am not checking this issue out.",
+      });
+    expect(commentRes.status, JSON.stringify(commentRes.body)).toBe(201);
+
+    const issueRes = await request(createApp(agentActor(companyId, foreignAgentId, run.id)))
+      .get(`/api/issues/${issueId}`);
+    expect(issueRes.status, JSON.stringify(issueRes.body)).toBe(200);
+    expect(issueRes.body).toMatchObject({
+      id: issueId,
+      status: "blocked",
+      checkoutRunId: null,
+      executionRunId: null,
+      executionLockedAt: null,
+    });
+    expect(issueRes.body).not.toHaveProperty("activeRun");
+
+    const row = await db
+      .select({
+        status: issues.status,
+        checkoutRunId: issues.checkoutRunId,
+        executionRunId: issues.executionRunId,
+        executionLockedAt: issues.executionLockedAt,
+      })
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+    expect(row).toEqual({
+      status: "blocked",
+      checkoutRunId: null,
+      executionRunId: null,
+      executionLockedAt: null,
+    });
 
     adapterControl.release();
     await waitForCondition(async () =>

--- a/server/src/__tests__/issue-blocked-interaction-lock-routes.test.ts
+++ b/server/src/__tests__/issue-blocked-interaction-lock-routes.test.ts
@@ -27,14 +27,14 @@ import { issueRoutes } from "../routes/issues.js";
 import { heartbeatService } from "../services/heartbeat.ts";
 
 const adapterControl = vi.hoisted(() => {
-  let releaseCurrentRun: (() => void) | null = null;
+  const releaseCurrentRuns: Array<() => void> = [];
   let startedResolver: (() => void) | null = null;
   let startedPromise = new Promise<void>((resolve) => {
     startedResolver = resolve;
   });
 
   const reset = () => {
-    releaseCurrentRun = null;
+    releaseCurrentRuns.length = 0;
     startedPromise = new Promise<void>((resolve) => {
       startedResolver = resolve;
     });
@@ -44,7 +44,7 @@ const adapterControl = vi.hoisted(() => {
     execute: vi.fn(async () => {
       startedResolver?.();
       await new Promise<void>((resolve) => {
-        releaseCurrentRun = resolve;
+        releaseCurrentRuns.push(resolve);
       });
       return {
         exitCode: 0,
@@ -57,7 +57,12 @@ const adapterControl = vi.hoisted(() => {
       };
     }),
     waitForStart: () => startedPromise,
-    release: () => releaseCurrentRun?.(),
+    release: () => releaseCurrentRuns.shift()?.(),
+    releaseAll: () => {
+      while (releaseCurrentRuns.length > 0) {
+        releaseCurrentRuns.shift()?.();
+      }
+    },
     reset,
   };
 });
@@ -139,7 +144,7 @@ describeEmbeddedPostgres("blocked interaction wakes do not claim issue execution
   }, 20_000);
 
   afterEach(async () => {
-    adapterControl.release();
+    adapterControl.releaseAll();
     await waitForHeartbeatSideEffectsToSettle(db);
     adapterControl.reset();
     runningProcesses.clear();
@@ -258,20 +263,25 @@ describeEmbeddedPostgres("blocked interaction wakes do not claim issue execution
     return { companyId, assigneeAgentId, foreignAgentId, issueId };
   }
 
-  async function startBlockedInteractionWake(agentId: string, issueId: string) {
+  async function startBlockedInteractionWake(
+    agentId: string,
+    issueId: string,
+    wakeReason: "issue_commented" | "issue_comment_mentioned" = "issue_comment_mentioned",
+  ) {
     const commentId = randomUUID();
+    const source = wakeReason === "issue_commented" ? "issue.comment" : "comment.mention";
     const run = await heartbeat.wakeup(agentId, {
       source: "automation",
       triggerDetail: "system",
-      reason: "issue_comment_mentioned",
+      reason: wakeReason,
       payload: { issueId, commentId },
       contextSnapshot: {
         issueId,
         taskId: issueId,
         commentId,
         wakeCommentId: commentId,
-        wakeReason: "issue_comment_mentioned",
-        source: "comment.mention",
+        wakeReason,
+        source,
       },
       requestedByActorType: "user",
       requestedByActorId: "local-board",
@@ -449,6 +459,220 @@ describeEmbeddedPostgres("blocked interaction wakes do not claim issue execution
     });
 
     adapterControl.release();
+    await waitForCondition(async () =>
+      db
+        .select({ status: heartbeatRuns.status })
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.id, run.id))
+        .then((rows) => rows[0]?.status === "succeeded")
+    );
+  });
+
+  it("stays unlocked after a blocked comment wake gets a 422 checkout and then posts triage", async () => {
+    const { companyId, assigneeAgentId, foreignAgentId, issueId } = await seedScenario();
+    const run = await startBlockedInteractionWake(assigneeAgentId, issueId, "issue_commented");
+
+    const checkoutRes = await request(createApp(agentActor(companyId, assigneeAgentId, run.id)))
+      .post(`/api/issues/${issueId}/checkout`)
+      .send({
+        agentId: assigneeAgentId,
+        expectedStatuses: ["todo", "backlog", "blocked", "in_review"],
+      });
+    expect(checkoutRes.status, JSON.stringify(checkoutRes.body)).toBe(422);
+    expect(checkoutRes.body).toMatchObject({
+      error: "Issue is blocked by unresolved blockers",
+    });
+
+    const commentRes = await request(createApp(agentActor(companyId, assigneeAgentId, run.id)))
+      .post(`/api/issues/${issueId}/comments`)
+      .send({
+        body: `Still blocked after checkout triage. [@CEO](agent://${foreignAgentId}) for visibility.`,
+      });
+    expect(commentRes.status, JSON.stringify(commentRes.body)).toBe(201);
+
+    const issueRes = await request(createApp(agentActor(companyId, assigneeAgentId, run.id)))
+      .get(`/api/issues/${issueId}`);
+    expect(issueRes.status, JSON.stringify(issueRes.body)).toBe(200);
+    expect(issueRes.body).toMatchObject({
+      id: issueId,
+      status: "blocked",
+      checkoutRunId: null,
+      executionRunId: null,
+      executionLockedAt: null,
+    });
+    expect(issueRes.body).not.toHaveProperty("activeRun");
+
+    const contextRes = await request(createApp(agentActor(companyId, assigneeAgentId, run.id)))
+      .get(`/api/issues/${issueId}/heartbeat-context`);
+    expect(contextRes.status, JSON.stringify(contextRes.body)).toBe(200);
+    expect(contextRes.body.issue).toMatchObject({
+      id: issueId,
+      status: "blocked",
+    });
+
+    const row = await db
+      .select({
+        status: issues.status,
+        checkoutRunId: issues.checkoutRunId,
+        executionRunId: issues.executionRunId,
+        executionLockedAt: issues.executionLockedAt,
+      })
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+    expect(row).toEqual({
+      status: "blocked",
+      checkoutRunId: null,
+      executionRunId: null,
+      executionLockedAt: null,
+    });
+
+    adapterControl.release();
+    await waitForCondition(async () =>
+      db
+        .select({ status: heartbeatRuns.status })
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.id, run.id))
+        .then((rows) => rows[0]?.status === "succeeded")
+    );
+  });
+
+  it("stays unlocked after a blocked comment wake gets a 422 checkout and then patches blocked triage", async () => {
+    const { companyId, assigneeAgentId, foreignAgentId, issueId } = await seedScenario();
+    const run = await startBlockedInteractionWake(assigneeAgentId, issueId, "issue_commented");
+
+    const checkoutRes = await request(createApp(agentActor(companyId, assigneeAgentId, run.id)))
+      .post(`/api/issues/${issueId}/checkout`)
+      .send({
+        agentId: assigneeAgentId,
+        expectedStatuses: ["todo", "backlog", "blocked", "in_review"],
+      });
+    expect(checkoutRes.status, JSON.stringify(checkoutRes.body)).toBe(422);
+    expect(checkoutRes.body).toMatchObject({
+      error: "Issue is blocked by unresolved blockers",
+    });
+
+    const patchRes = await request(createApp(agentActor(companyId, assigneeAgentId, run.id)))
+      .patch(`/api/issues/${issueId}`)
+      .send({
+        status: "blocked",
+        comment: `Still blocked after checkout triage. [@CEO](agent://${foreignAgentId}) for visibility.`,
+      });
+    expect(patchRes.status, JSON.stringify(patchRes.body)).toBe(200);
+    expect(patchRes.body).toMatchObject({
+      id: issueId,
+      status: "blocked",
+      checkoutRunId: null,
+      executionRunId: null,
+      executionLockedAt: null,
+    });
+
+    const issueRes = await request(createApp(agentActor(companyId, assigneeAgentId, run.id)))
+      .get(`/api/issues/${issueId}`);
+    expect(issueRes.status, JSON.stringify(issueRes.body)).toBe(200);
+    expect(issueRes.body).toMatchObject({
+      id: issueId,
+      status: "blocked",
+      checkoutRunId: null,
+      executionRunId: null,
+      executionLockedAt: null,
+    });
+    expect(issueRes.body).not.toHaveProperty("activeRun");
+
+    const contextRes = await request(createApp(agentActor(companyId, assigneeAgentId, run.id)))
+      .get(`/api/issues/${issueId}/heartbeat-context`);
+    expect(contextRes.status, JSON.stringify(contextRes.body)).toBe(200);
+    expect(contextRes.body.issue).toMatchObject({
+      id: issueId,
+      status: "blocked",
+    });
+
+    const row = await db
+      .select({
+        status: issues.status,
+        checkoutRunId: issues.checkoutRunId,
+        executionRunId: issues.executionRunId,
+        executionLockedAt: issues.executionLockedAt,
+      })
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+    expect(row).toEqual({
+      status: "blocked",
+      checkoutRunId: null,
+      executionRunId: null,
+      executionLockedAt: null,
+    });
+
+    adapterControl.releaseAll();
+    await waitForCondition(async () =>
+      db
+        .select({ status: heartbeatRuns.status })
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.id, run.id))
+        .then((rows) => rows[0]?.status === "succeeded")
+    );
+  });
+
+  it("stays unlocked after a blocked foreign mention wake gets a 422 checkout and then posts triage", async () => {
+    const { companyId, assigneeAgentId, foreignAgentId, issueId } = await seedScenario();
+    await db.insert(issueComments).values({
+      id: randomUUID(),
+      companyId,
+      issueId,
+      body: `For visibility: [@CEO](agent://${foreignAgentId})`,
+      authorAgentId: assigneeAgentId,
+    });
+    const run = await startBlockedInteractionWake(foreignAgentId, issueId, "issue_comment_mentioned");
+
+    const checkoutRes = await request(createApp(agentActor(companyId, foreignAgentId, run.id)))
+      .post(`/api/issues/${issueId}/checkout`)
+      .send({
+        agentId: foreignAgentId,
+        expectedStatuses: ["todo", "backlog", "blocked", "in_review"],
+      });
+    expect(checkoutRes.status, JSON.stringify(checkoutRes.body)).toBe(422);
+    expect(checkoutRes.body).toMatchObject({
+      error: "Issue is blocked by unresolved blockers",
+    });
+
+    const commentRes = await request(createApp(agentActor(companyId, foreignAgentId, run.id)))
+      .post(`/api/issues/${issueId}/comments`)
+      .send({
+        body: "Triage only. The blockers are still unresolved, so I am not checking this issue out.",
+      });
+    expect(commentRes.status, JSON.stringify(commentRes.body)).toBe(201);
+
+    const issueRes = await request(createApp(agentActor(companyId, foreignAgentId, run.id)))
+      .get(`/api/issues/${issueId}`);
+    expect(issueRes.status, JSON.stringify(issueRes.body)).toBe(200);
+    expect(issueRes.body).toMatchObject({
+      id: issueId,
+      status: "blocked",
+      checkoutRunId: null,
+      executionRunId: null,
+      executionLockedAt: null,
+    });
+    expect(issueRes.body).not.toHaveProperty("activeRun");
+
+    const row = await db
+      .select({
+        status: issues.status,
+        checkoutRunId: issues.checkoutRunId,
+        executionRunId: issues.executionRunId,
+        executionLockedAt: issues.executionLockedAt,
+      })
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+    expect(row).toEqual({
+      status: "blocked",
+      checkoutRunId: null,
+      executionRunId: null,
+      executionLockedAt: null,
+    });
+
+    adapterControl.releaseAll();
     await waitForCondition(async () =>
       db
         .select({ status: heartbeatRuns.status })

--- a/server/src/__tests__/issue-blocked-interaction-lock-routes.test.ts
+++ b/server/src/__tests__/issue-blocked-interaction-lock-routes.test.ts
@@ -93,6 +93,40 @@ async function waitForCondition(fn: () => Promise<boolean>, timeoutMs = 3_000) {
   return fn();
 }
 
+async function waitForHeartbeatSideEffectsToSettle(db: ReturnType<typeof createDb>, timeoutMs = 10_000) {
+  let lastSnapshot: string | null = null;
+  let stableSince = 0;
+
+  return waitForCondition(async () => {
+    const [runRows, runEventRows, activityRows, commentRows] = await Promise.all([
+      db.select({ status: heartbeatRuns.status }).from(heartbeatRuns),
+      db.select({ id: heartbeatRunEvents.id }).from(heartbeatRunEvents),
+      db.select({ id: activityLog.id }).from(activityLog),
+      db.select({ id: issueComments.id }).from(issueComments),
+    ]);
+    if (runRows.some((row) => row.status === "queued" || row.status === "running")) {
+      lastSnapshot = null;
+      stableSince = 0;
+      return false;
+    }
+
+    const snapshot = [
+      runRows.length,
+      runEventRows.length,
+      activityRows.length,
+      commentRows.length,
+    ].join(":");
+    const now = Date.now();
+    if (snapshot !== lastSnapshot) {
+      lastSnapshot = snapshot;
+      stableSince = now;
+      return false;
+    }
+
+    return stableSince > 0 && now - stableSince >= 150;
+  }, timeoutMs);
+}
+
 describeEmbeddedPostgres("blocked interaction wakes do not claim issue execution locks", () => {
   let db!: ReturnType<typeof createDb>;
   let heartbeat!: ReturnType<typeof heartbeatService>;
@@ -106,10 +140,7 @@ describeEmbeddedPostgres("blocked interaction wakes do not claim issue execution
 
   afterEach(async () => {
     adapterControl.release();
-    await waitForCondition(async () => {
-      const rows = await db.select({ status: heartbeatRuns.status }).from(heartbeatRuns);
-      return rows.every((row) => row.status !== "queued" && row.status !== "running");
-    }, 10_000);
+    await waitForHeartbeatSideEffectsToSettle(db);
     adapterControl.reset();
     runningProcesses.clear();
     await db.delete(issueComments);

--- a/server/src/__tests__/issue-blocked-interaction-lock-routes.test.ts
+++ b/server/src/__tests__/issue-blocked-interaction-lock-routes.test.ts
@@ -141,16 +141,17 @@ describeEmbeddedPostgres("blocked interaction wakes do not claim issue execution
     return app;
   }
 
-  function agentActor(companyId: string, agentId: string): Express.Request["actor"] {
+  function agentActor(companyId: string, agentId: string, runId?: string): Express.Request["actor"] {
     return {
       type: "agent",
       agentId,
       companyId,
+      ...(runId ? { runId } : {}),
       source: "agent_jwt",
     };
   }
 
-  async function seedScenario() {
+  async function seedScenario(issueStatus: "blocked" | "cancelled" = "blocked") {
     const companyId = randomUUID();
     const assigneeAgentId = randomUUID();
     const foreignAgentId = randomUUID();
@@ -203,7 +204,7 @@ describeEmbeddedPostgres("blocked interaction wakes do not claim issue execution
         id: issueId,
         companyId,
         title: "Blocked QA issue",
-        status: "blocked",
+        status: issueStatus,
         priority: "high",
         assigneeAgentId,
         responsibleUserId: "local-board",
@@ -318,6 +319,74 @@ describeEmbeddedPostgres("blocked interaction wakes do not claim issue execution
       executionLockedAt: null,
     });
     expect(issueRes.body).not.toHaveProperty("activeRun");
+
+    adapterControl.release();
+    await waitForCondition(async () =>
+      db
+        .select({ status: heartbeatRuns.status })
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.id, run.id))
+        .then((rows) => rows[0]?.status === "succeeded")
+    );
+  });
+
+  it("keeps cancelled dependency-blocked mention wakes comment-only and unlocked", async () => {
+    const { companyId, assigneeAgentId, foreignAgentId, issueId } = await seedScenario("cancelled");
+    await db.insert(issueComments).values({
+      id: randomUUID(),
+      companyId,
+      issueId,
+      body: `For visibility: [@CEO](agent://${foreignAgentId})`,
+      authorAgentId: assigneeAgentId,
+    });
+    const run = await startBlockedInteractionWake(foreignAgentId, issueId);
+
+    const checkoutRes = await request(createApp(agentActor(companyId, foreignAgentId, run.id)))
+      .post(`/api/issues/${issueId}/checkout`)
+      .send({
+        agentId: foreignAgentId,
+        expectedStatuses: ["todo", "backlog", "blocked", "in_review", "cancelled"],
+      });
+    expect(checkoutRes.status, JSON.stringify(checkoutRes.body)).toBe(422);
+    expect(checkoutRes.body).toMatchObject({
+      error: "Issue is blocked by unresolved blockers",
+    });
+
+    const commentRes = await request(createApp(agentActor(companyId, foreignAgentId, run.id)))
+      .post(`/api/issues/${issueId}/comments`)
+      .send({
+        body: "Acknowledged. The dependency is still unresolved, so I am leaving this cancelled.",
+      });
+    expect(commentRes.status, JSON.stringify(commentRes.body)).toBe(201);
+
+    const issueRes = await request(createApp(agentActor(companyId, foreignAgentId, run.id)))
+      .get(`/api/issues/${issueId}`);
+    expect(issueRes.status, JSON.stringify(issueRes.body)).toBe(200);
+    expect(issueRes.body).toMatchObject({
+      id: issueId,
+      status: "cancelled",
+      checkoutRunId: null,
+      executionRunId: null,
+      executionLockedAt: null,
+    });
+    expect(issueRes.body).not.toHaveProperty("activeRun");
+
+    const row = await db
+      .select({
+        status: issues.status,
+        checkoutRunId: issues.checkoutRunId,
+        executionRunId: issues.executionRunId,
+        executionLockedAt: issues.executionLockedAt,
+      })
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+    expect(row).toEqual({
+      status: "cancelled",
+      checkoutRunId: null,
+      executionRunId: null,
+      executionLockedAt: null,
+    });
 
     adapterControl.release();
     await waitForCondition(async () =>

--- a/server/src/__tests__/issue-blocked-interaction-lock-routes.test.ts
+++ b/server/src/__tests__/issue-blocked-interaction-lock-routes.test.ts
@@ -151,12 +151,16 @@ describeEmbeddedPostgres("blocked interaction wakes do not claim issue execution
     };
   }
 
-  async function seedScenario(issueStatus: "blocked" | "cancelled" = "blocked") {
+  async function seedScenario(
+    issueStatus: "blocked" | "cancelled" = "blocked",
+    options?: { includeBlockerRelation?: boolean },
+  ) {
     const companyId = randomUUID();
     const assigneeAgentId = randomUUID();
     const foreignAgentId = randomUUID();
     const blockerIssueId = randomUUID();
     const issueId = randomUUID();
+    const includeBlockerRelation = options?.includeBlockerRelation ?? true;
 
     await db.insert(companies).values({
       id: companyId,
@@ -211,12 +215,14 @@ describeEmbeddedPostgres("blocked interaction wakes do not claim issue execution
       },
     ]);
 
-    await db.insert(issueRelations).values({
-      companyId,
-      issueId: blockerIssueId,
-      relatedIssueId: issueId,
-      type: "blocks",
-    });
+    if (includeBlockerRelation) {
+      await db.insert(issueRelations).values({
+        companyId,
+        issueId: blockerIssueId,
+        relatedIssueId: issueId,
+        type: "blocks",
+      });
+    }
 
     return { companyId, assigneeAgentId, foreignAgentId, issueId };
   }
@@ -387,6 +393,49 @@ describeEmbeddedPostgres("blocked interaction wakes do not claim issue execution
       executionRunId: null,
       executionLockedAt: null,
     });
+
+    adapterControl.release();
+    await waitForCondition(async () =>
+      db
+        .select({ status: heartbeatRuns.status })
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.id, run.id))
+        .then((rows) => rows[0]?.status === "succeeded")
+    );
+  });
+
+  it("keeps same-assignee comment-only mention wakes unlocked on blocked issues without first-class blockers", async () => {
+    const { companyId, assigneeAgentId, issueId } = await seedScenario("blocked", {
+      includeBlockerRelation: false,
+    });
+    const run = await startBlockedInteractionWake(assigneeAgentId, issueId);
+
+    const row = await db
+      .select({
+        checkoutRunId: issues.checkoutRunId,
+        executionRunId: issues.executionRunId,
+        executionLockedAt: issues.executionLockedAt,
+      })
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+    expect(row).toEqual({
+      checkoutRunId: null,
+      executionRunId: null,
+      executionLockedAt: null,
+    });
+
+    const issueRes = await request(createApp(agentActor(companyId, assigneeAgentId)))
+      .get(`/api/issues/${issueId}`);
+    expect(issueRes.status, JSON.stringify(issueRes.body)).toBe(200);
+    expect(issueRes.body).toMatchObject({
+      id: issueId,
+      status: "blocked",
+      checkoutRunId: null,
+      executionRunId: null,
+      executionLockedAt: null,
+    });
+    expect(issueRes.body).not.toHaveProperty("activeRun");
 
     adapterControl.release();
     await waitForCondition(async () =>

--- a/server/src/__tests__/issue-stale-execution-lock-routes.test.ts
+++ b/server/src/__tests__/issue-stale-execution-lock-routes.test.ts
@@ -795,4 +795,191 @@ describeEmbeddedPostgres("stale issue execution lock routes", () => {
       executionLockedAt: null,
     });
   }, 15_000);
+
+  it("does not stamp executionRunId when a mention-granted peer agent comments on a done issue", async () => {
+    const { companyId, agentId: assigneeAgentId, currentRunId: assigneeRunId } = await seedCompanyAgentAndRuns();
+    const mentionedAgentId = randomUUID();
+    const mentionedRunId = randomUUID();
+    const issueId = randomUUID();
+    const mentionCommentId = randomUUID();
+
+    await db.insert(agents).values({
+      id: mentionedAgentId,
+      companyId,
+      name: "CoCEOReporter",
+      role: "executive",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    await db.insert(heartbeatRuns).values({
+      id: mentionedRunId,
+      companyId,
+      agentId: mentionedAgentId,
+      status: "running",
+      invocationSource: "manual",
+      startedAt: new Date(),
+    });
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Done issue with mention follow-up",
+      status: "done",
+      priority: "high",
+      responsibleUserId: "local-board",
+      assigneeAgentId,
+      checkoutRunId: null,
+      executionRunId: null,
+      executionAgentNameKey: null,
+      executionLockedAt: null,
+      completedAt: new Date(),
+    });
+    await db.insert(issueComments).values({
+      id: mentionCommentId,
+      companyId,
+      issueId,
+      authorAgentId: assigneeAgentId,
+      authorUserId: null,
+      authorType: "agent",
+      createdByRunId: null,
+      body: `[@CoCEOReporter](agent://${mentionedAgentId}) please verify the closeout.`,
+    });
+
+    const res = await request(createApp(agentActor(companyId, mentionedAgentId, mentionedRunId)))
+      .post(`/api/issues/${issueId}/comments`)
+      .send({ body: "Verified. No reopen needed." });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(201);
+
+    const row = await db
+      .select({
+        status: issues.status,
+        checkoutRunId: issues.checkoutRunId,
+        executionRunId: issues.executionRunId,
+        executionLockedAt: issues.executionLockedAt,
+      })
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+    expect(row).toEqual({
+      status: "done",
+      checkoutRunId: null,
+      executionRunId: null,
+      executionLockedAt: null,
+    });
+
+    const issueRes = await request(createApp(agentActor(companyId, assigneeAgentId, assigneeRunId)))
+      .get(`/api/issues/${issueId}`);
+    expect(issueRes.status, JSON.stringify(issueRes.body)).toBe(200);
+    expect(issueRes.body).toMatchObject({
+      id: issueId,
+      status: "done",
+      checkoutRunId: null,
+      executionRunId: null,
+      executionLockedAt: null,
+    });
+
+    const contextRes = await request(createApp(agentActor(companyId, assigneeAgentId, assigneeRunId)))
+      .get(`/api/issues/${issueId}/heartbeat-context`);
+    expect(contextRes.status, JSON.stringify(contextRes.body)).toBe(200);
+    expect(contextRes.body.issue).toMatchObject({
+      id: issueId,
+      status: "done",
+    });
+  });
+
+  it("does not backfill executionRunId onto a done issue from a same-scope running wake", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const issueId = randomUUID();
+    const runId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "CodexCoder",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Done issue should not claim execution",
+      status: "done",
+      priority: "high",
+      responsibleUserId: "local-board",
+      assigneeAgentId: agentId,
+      checkoutRunId: null,
+      executionRunId: null,
+      executionAgentNameKey: null,
+      executionLockedAt: null,
+      completedAt: new Date(),
+    });
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId,
+      agentId,
+      status: "running",
+      invocationSource: "assignment",
+      triggerDetail: "system",
+      startedAt: new Date(),
+      contextSnapshot: {
+        issueId,
+        taskId: issueId,
+        wakeReason: "issue_assigned",
+        source: "assignment",
+      },
+    });
+
+    const run = await heartbeat.wakeup(agentId, {
+      source: "assignment",
+      triggerDetail: "system",
+      reason: "issue_assigned",
+      payload: {
+        issueId,
+        mutation: "comment",
+      },
+      contextSnapshot: {
+        issueId,
+        taskId: issueId,
+        wakeReason: "issue_assigned",
+        source: "assignment",
+      },
+      requestedByActorType: "system",
+      requestedByActorId: null,
+    });
+
+    expect(run).not.toBeNull();
+
+    const row = await db
+      .select({
+        status: issues.status,
+        checkoutRunId: issues.checkoutRunId,
+        executionRunId: issues.executionRunId,
+        executionAgentNameKey: issues.executionAgentNameKey,
+        executionLockedAt: issues.executionLockedAt,
+      })
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+    expect(row).toEqual({
+      status: "done",
+      checkoutRunId: null,
+      executionRunId: null,
+      executionAgentNameKey: null,
+      executionLockedAt: null,
+    });
+  });
 });

--- a/server/src/__tests__/issue-stale-execution-lock-routes.test.ts
+++ b/server/src/__tests__/issue-stale-execution-lock-routes.test.ts
@@ -262,6 +262,53 @@ describeEmbeddedPostgres("stale issue execution lock routes", () => {
     });
   });
 
+  it("self-heals a stale executionRunId on GET /api/issues/:identifier after the owning run is gone", async () => {
+    const { companyId, agentId, failedRunId, currentRunId } = await seedCompanyAgentAndRuns();
+    const issueId = randomUUID();
+    const identifier = "MOD-1127";
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Blocked helper residue",
+      identifier,
+      status: "blocked",
+      priority: "high",
+      assigneeAgentId: agentId,
+      checkoutRunId: null,
+      executionRunId: failedRunId,
+      executionAgentNameKey: "codexcoder",
+      executionLockedAt: new Date(),
+    });
+
+    const res = await request(createApp(agentActor(companyId, agentId, currentRunId)))
+      .get(`/api/issues/${identifier}`);
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(res.body).toMatchObject({
+      id: issueId,
+      identifier,
+      status: "blocked",
+      checkoutRunId: null,
+      executionRunId: null,
+      executionLockedAt: null,
+    });
+
+    const row = await db
+      .select({
+        checkoutRunId: issues.checkoutRunId,
+        executionRunId: issues.executionRunId,
+        executionLockedAt: issues.executionLockedAt,
+      })
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0]);
+    expect(row).toEqual({
+      checkoutRunId: null,
+      executionRunId: null,
+      executionLockedAt: null,
+    });
+  });
+
   it("still returns 409 when a different live checkout owner is active", async () => {
     const { companyId, agentId, failedRunId } = await seedCompanyAgentAndRuns();
     const liveOwnerRunId = randomUUID();

--- a/server/src/__tests__/issue-stale-execution-lock-routes.test.ts
+++ b/server/src/__tests__/issue-stale-execution-lock-routes.test.ts
@@ -1,14 +1,17 @@
 import { randomUUID } from "node:crypto";
 import express from "express";
 import request from "supertest";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import {
   activityLog,
   agents,
+  agentRuntimeState,
   agentWakeupRequests,
   companies,
+  companySkills,
   createDb,
+  heartbeatRunEvents,
   heartbeatRuns,
   issueComments,
   issueRelations,
@@ -33,6 +36,15 @@ if (!embeddedPostgresSupport.supported) {
   );
 }
 
+async function waitForCondition(fn: () => Promise<boolean>, timeoutMs = 3_000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await fn()) return true;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  return fn();
+}
+
 describeEmbeddedPostgres("stale issue execution lock routes", () => {
   let db!: ReturnType<typeof createDb>;
   let heartbeat!: ReturnType<typeof heartbeatService>;
@@ -49,9 +61,12 @@ describeEmbeddedPostgres("stale issue execution lock routes", () => {
     await db.delete(issueRelations);
     await db.delete(activityLog);
     await db.delete(issues);
-    await db.delete(agentWakeupRequests);
+    await db.delete(heartbeatRunEvents);
     await db.delete(heartbeatRuns);
+    await db.delete(agentWakeupRequests);
+    await db.delete(agentRuntimeState);
     await db.delete(agents);
+    await db.delete(companySkills);
     await db.delete(companies);
   });
 
@@ -657,4 +672,127 @@ describeEmbeddedPostgres("stale issue execution lock routes", () => {
       executionLockedAt: null,
     });
   });
+
+  it("does not restore executionRunId after a blocked helper comment mentions another agent", async () => {
+    const { companyId, agentId: assigneeAgentId, currentRunId } = await seedCompanyAgentAndRuns();
+    const foreignAgentId = randomUUID();
+    const blockerIssueId = randomUUID();
+    const issueId = randomUUID();
+
+    await db.insert(agents).values({
+      id: foreignAgentId,
+      companyId,
+      name: "CoCEOReporter",
+      role: "executive",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    await db.insert(issues).values([
+      {
+        id: blockerIssueId,
+        companyId,
+        title: "Live blocker",
+        status: "todo",
+        priority: "high",
+        responsibleUserId: "local-board",
+      },
+      {
+        id: issueId,
+        companyId,
+        title: "Blocked helper residue after mention",
+        status: "blocked",
+        priority: "high",
+        responsibleUserId: "local-board",
+        assigneeAgentId,
+        checkoutRunId: null,
+        executionRunId: null,
+        executionAgentNameKey: null,
+        executionLockedAt: null,
+      },
+    ]);
+    await db.insert(issueRelations).values({
+      companyId,
+      issueId: blockerIssueId,
+      relatedIssueId: issueId,
+      type: "blocks",
+    });
+    await db
+      .update(heartbeatRuns)
+      .set({
+        contextSnapshot: {
+          issueId,
+          taskId: issueId,
+          wakeReason: "issue_comment_mentioned",
+          source: "comment.mention",
+          dependencyBlockedInteraction: true,
+        },
+      })
+      .where(eq(heartbeatRuns.id, currentRunId));
+
+    await db
+      .update(issues)
+      .set({
+        status: "in_progress",
+        checkoutRunId: currentRunId,
+        executionRunId: currentRunId,
+        executionAgentNameKey: "codexcoder",
+        executionLockedAt: new Date(),
+      })
+      .where(eq(issues.id, issueId));
+
+    const patchRes = await request(createApp(agentActor(companyId, assigneeAgentId, currentRunId)))
+      .patch(`/api/issues/${issueId}`)
+      .send({
+        status: "blocked",
+        comment: `Still blocked. [@CoCEOReporter](agent://${foreignAgentId}) for visibility.`,
+      });
+    expect(patchRes.status, JSON.stringify(patchRes.body)).toBe(200);
+    expect(patchRes.body).toMatchObject({
+      id: issueId,
+      status: "blocked",
+      checkoutRunId: null,
+      executionRunId: null,
+      executionLockedAt: null,
+    });
+
+    const mentionWakeCreated = await waitForCondition(async () => {
+      const wake = await db
+        .select({
+          status: agentWakeupRequests.status,
+          runId: agentWakeupRequests.runId,
+        })
+        .from(agentWakeupRequests)
+        .where(
+          and(
+            eq(agentWakeupRequests.companyId, companyId),
+            eq(agentWakeupRequests.agentId, foreignAgentId),
+          ),
+        )
+        .then((rows) => rows[0] ?? null);
+      return wake?.status === "deferred_issue_execution" || wake?.status === "queued" || wake?.runId != null;
+    }, 5_000);
+    expect(mentionWakeCreated).toBe(true);
+
+    const issueAfterMentionWake = await db
+      .select({
+        status: issues.status,
+        checkoutRunId: issues.checkoutRunId,
+        executionRunId: issues.executionRunId,
+        executionAgentNameKey: issues.executionAgentNameKey,
+        executionLockedAt: issues.executionLockedAt,
+      })
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+    expect(issueAfterMentionWake).toEqual({
+      status: "blocked",
+      checkoutRunId: null,
+      executionRunId: null,
+      executionAgentNameKey: null,
+      executionLockedAt: null,
+    });
+  }, 15_000);
 });

--- a/server/src/__tests__/issue-stale-execution-lock-routes.test.ts
+++ b/server/src/__tests__/issue-stale-execution-lock-routes.test.ts
@@ -6,6 +6,7 @@ import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import {
   activityLog,
   agents,
+  agentWakeupRequests,
   companies,
   createDb,
   heartbeatRuns,
@@ -19,6 +20,7 @@ import {
 } from "./helpers/embedded-postgres.js";
 import { errorHandler } from "../middleware/index.js";
 import { issueRoutes } from "../routes/issues.js";
+import { heartbeatService } from "../services/heartbeat.ts";
 
 const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
 const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
@@ -33,11 +35,13 @@ if (!embeddedPostgresSupport.supported) {
 
 describeEmbeddedPostgres("stale issue execution lock routes", () => {
   let db!: ReturnType<typeof createDb>;
+  let heartbeat!: ReturnType<typeof heartbeatService>;
   let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
 
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-stale-execution-lock-routes-");
     db = createDb(tempDb.connectionString);
+    heartbeat = heartbeatService(db);
   }, 20_000);
 
   afterEach(async () => {
@@ -45,6 +49,7 @@ describeEmbeddedPostgres("stale issue execution lock routes", () => {
     await db.delete(issueRelations);
     await db.delete(activityLog);
     await db.delete(issues);
+    await db.delete(agentWakeupRequests);
     await db.delete(heartbeatRuns);
     await db.delete(agents);
     await db.delete(companies);
@@ -480,6 +485,129 @@ describeEmbeddedPostgres("stale issue execution lock routes", () => {
       assigneeAgentId: otherAgentId,
       checkoutRunId: currentRunId,
       executionRunId: currentRunId,
+    });
+  });
+
+  it("does not backfill a blocked issue's execution lock from a foreign running report wake", async () => {
+    const { companyId, agentId: assigneeAgentId, currentRunId } = await seedCompanyAgentAndRuns();
+    const foreignAgentId = randomUUID();
+    const foreignRunId = randomUUID();
+    const blockerIssueId = randomUUID();
+    const issueId = randomUUID();
+
+    await db.insert(agents).values({
+      id: foreignAgentId,
+      companyId,
+      name: "CoCEOReporter",
+      role: "executive",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    await db.insert(issues).values([
+      {
+        id: blockerIssueId,
+        companyId,
+        title: "Live blocker",
+        status: "todo",
+        priority: "high",
+      },
+      {
+        id: issueId,
+        companyId,
+        title: "Blocked issue under cross-agent report",
+        status: "blocked",
+        priority: "high",
+        assigneeAgentId,
+        checkoutRunId: null,
+        executionRunId: null,
+        executionAgentNameKey: null,
+        executionLockedAt: null,
+      },
+    ]);
+    await db.insert(issueRelations).values({
+      companyId,
+      issueId: blockerIssueId,
+      relatedIssueId: issueId,
+      type: "blocks",
+    });
+    await db.insert(heartbeatRuns).values({
+      id: foreignRunId,
+      companyId,
+      agentId: foreignAgentId,
+      status: "running",
+      invocationSource: "automation",
+      triggerDetail: "system",
+      startedAt: new Date(),
+      contextSnapshot: {
+        issueId,
+        taskId: issueId,
+        wakeReason: "issue_comment_mentioned",
+        source: "comment.mention",
+      },
+    });
+
+    const wake = await heartbeat.wakeup(assigneeAgentId, {
+      source: "automation",
+      triggerDetail: "system",
+      reason: "issue_assigned",
+      payload: { issueId },
+      contextSnapshot: {
+        issueId,
+        taskId: issueId,
+        wakeReason: "issue_assigned",
+      },
+      requestedByActorType: "system",
+      requestedByActorId: null,
+    });
+
+    expect(wake).toBeNull();
+
+    const row = await db
+      .select({
+        checkoutRunId: issues.checkoutRunId,
+        executionRunId: issues.executionRunId,
+        executionLockedAt: issues.executionLockedAt,
+      })
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0]);
+    expect(row).toEqual({
+      checkoutRunId: null,
+      executionRunId: null,
+      executionLockedAt: null,
+    });
+
+    const issueRes = await request(createApp(agentActor(companyId, assigneeAgentId, currentRunId)))
+      .get(`/api/issues/${issueId}`);
+    expect(issueRes.status, JSON.stringify(issueRes.body)).toBe(200);
+    expect(issueRes.body).toMatchObject({
+      id: issueId,
+      checkoutRunId: null,
+      executionRunId: null,
+      executionLockedAt: null,
+    });
+
+    const contextRes = await request(createApp(agentActor(companyId, assigneeAgentId, currentRunId)))
+      .get(`/api/issues/${issueId}/heartbeat-context`);
+    expect(contextRes.status, JSON.stringify(contextRes.body)).toBe(200);
+    expect(contextRes.body.issue).toMatchObject({ id: issueId, status: "blocked" });
+
+    const rowAfterHeartbeatContext = await db
+      .select({
+        checkoutRunId: issues.checkoutRunId,
+        executionRunId: issues.executionRunId,
+        executionLockedAt: issues.executionLockedAt,
+      })
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0]);
+    expect(rowAfterHeartbeatContext).toEqual({
+      checkoutRunId: null,
+      executionRunId: null,
+      executionLockedAt: null,
     });
   });
 });

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -4105,6 +4105,14 @@ export function shouldAutoCheckoutIssueForWake(input: {
   return true;
 }
 
+function shouldWakeOwnIssueExecutionLock(contextSnapshot: Record<string, unknown> | null | undefined) {
+  if (contextSnapshot?.dependencyBlockedInteraction === true) return false;
+  const wakeReason = readNonEmptyString(contextSnapshot?.wakeReason);
+  if (wakeReason === "issue_comment_mentioned") return false;
+  if (wakeReason === "source_scoped_recovery_action") return false;
+  return true;
+}
+
 function shouldQueueFollowupForRunningIssueWake(input: {
   contextSnapshot: Record<string, unknown> | null | undefined;
   wakeCommentId: string | null;
@@ -10374,9 +10382,8 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     // not at queue time. Guard is idempotent — safe if called more than once.
     const claimedContext = parseObject(claimed.contextSnapshot);
     const claimedIssueId = readNonEmptyString(claimedContext.issueId);
-    const claimedWakeReason = readNonEmptyString(claimedContext.wakeReason);
-    const dependencyBlockedInteraction = claimedContext.dependencyBlockedInteraction === true;
-    if (claimedIssueId && claimedWakeReason !== "source_scoped_recovery_action" && !dependencyBlockedInteraction) {
+    const wakeOwnsExecutionLock = shouldWakeOwnIssueExecutionLock(claimedContext);
+    if (claimedIssueId && wakeOwnsExecutionLock) {
       const claimedAgent = await getAgent(claimed.agentId);
       await db
         .update(issues)
@@ -10396,7 +10403,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             or(isNull(issues.executionRunId), eq(issues.executionRunId, claimed.id)),
           ),
         );
-    } else if (claimedIssueId && dependencyBlockedInteraction) {
+    } else if (claimedIssueId) {
       await db
         .update(issues)
         .set({
@@ -15300,8 +15307,9 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
               sql`case when ${heartbeatRuns.status} = 'running' then 0 else 1 end`,
               asc(heartbeatRuns.createdAt),
             )
-            .limit(1)
-            .then((rows) => rows[0] ?? null);
+            .then((rows) =>
+              rows.find((row) => shouldWakeOwnIssueExecutionLock(parseObject(row.contextSnapshot))) ?? null
+            );
 
           if (legacyRun) {
             if (await cancelStaleScheduledRetry(legacyRun)) {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -14348,7 +14348,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           })
           .where(eq(agentWakeupRequests.id, deferred.id));
 
-        if (promotedContextSnapshot.dependencyBlockedInteraction !== true) {
+        if (shouldWakeOwnIssueExecutionLock(promotedContextSnapshot)) {
           await tx
             .update(issues)
             .set({

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -10375,7 +10375,8 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     const claimedContext = parseObject(claimed.contextSnapshot);
     const claimedIssueId = readNonEmptyString(claimedContext.issueId);
     const claimedWakeReason = readNonEmptyString(claimedContext.wakeReason);
-    if (claimedIssueId && claimedWakeReason !== "source_scoped_recovery_action") {
+    const dependencyBlockedInteraction = claimedContext.dependencyBlockedInteraction === true;
+    if (claimedIssueId && claimedWakeReason !== "source_scoped_recovery_action" && !dependencyBlockedInteraction) {
       const claimedAgent = await getAgent(claimed.agentId);
       await db
         .update(issues)
@@ -10393,6 +10394,22 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             // owns the issue execution lock shown as the active run.
             eq(issues.assigneeAgentId, claimed.agentId),
             or(isNull(issues.executionRunId), eq(issues.executionRunId, claimed.id)),
+          ),
+        );
+    } else if (claimedIssueId && dependencyBlockedInteraction) {
+      await db
+        .update(issues)
+        .set({
+          executionRunId: null,
+          executionAgentNameKey: null,
+          executionLockedAt: null,
+          updatedAt: claimedAt,
+        })
+        .where(
+          and(
+            eq(issues.id, claimedIssueId),
+            eq(issues.companyId, claimed.companyId),
+            eq(issues.executionRunId, claimed.id),
           ),
         );
     }
@@ -14323,16 +14340,18 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           })
           .where(eq(agentWakeupRequests.id, deferred.id));
 
-        await tx
-          .update(issues)
-          .set({
-            executionRunId: newRun.id,
-            executionAgentNameKey: normalizeAgentNameKey(deferredAgent.name),
-            executionLockedAt: now,
-            updatedAt: now,
-          })
-          // Promoted mention wakes are issue-scoped, not issue ownership transfers.
-          .where(and(eq(issues.id, issue.id), eq(issues.assigneeAgentId, deferredAgent.id)));
+        if (promotedContextSnapshot.dependencyBlockedInteraction !== true) {
+          await tx
+            .update(issues)
+            .set({
+              executionRunId: newRun.id,
+              executionAgentNameKey: normalizeAgentNameKey(deferredAgent.name),
+              executionLockedAt: now,
+              updatedAt: now,
+            })
+            // Promoted mention wakes are issue-scoped, not issue ownership transfers.
+            .where(and(eq(issues.id, issue.id), eq(issues.assigneeAgentId, deferredAgent.id)));
+        }
 
         return {
           kind: "promoted" as const,

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -4086,15 +4086,7 @@ export function shouldAutoCheckoutIssueForWake(input: {
   const executionState = parseIssueExecutionState(input.issueExecutionState);
   if (executionState?.status === "pending") return false;
 
-  const issueStatus = readNonEmptyString(input.issueStatus);
-  if (
-    issueStatus !== "todo" &&
-    issueStatus !== "backlog" &&
-    issueStatus !== "blocked" &&
-    issueStatus !== "in_progress"
-  ) {
-    return false;
-  }
+  if (!issueStatusOwnsExecutionLock(input.issueStatus)) return false;
 
   const wakeReason = readNonEmptyString(input.contextSnapshot?.wakeReason);
   if (!wakeReason) return false;
@@ -4103,6 +4095,14 @@ export function shouldAutoCheckoutIssueForWake(input: {
   if (wakeReason.startsWith("execution_")) return false;
 
   return true;
+}
+
+function issueStatusOwnsExecutionLock(status: string | null | undefined) {
+  const issueStatus = readNonEmptyString(status);
+  return issueStatus === "todo" ||
+    issueStatus === "backlog" ||
+    issueStatus === "blocked" ||
+    issueStatus === "in_progress";
 }
 
 function shouldWakeOwnIssueExecutionLock(contextSnapshot: Record<string, unknown> | null | undefined) {
@@ -10397,6 +10397,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           and(
             eq(issues.id, claimedIssueId),
             eq(issues.companyId, claimed.companyId),
+            inArray(issues.status, ["todo", "backlog", "blocked", "in_progress"]),
             // Mention/context runs can touch an issue, but only the current assignee
             // owns the issue execution lock shown as the active run.
             eq(issues.assigneeAgentId, claimed.agentId),
@@ -15287,7 +15288,12 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           );
         }
 
-        if (!activeExecutionRun && issue.assigneeAgentId && !blockedInteractionWake) {
+        if (
+          !activeExecutionRun &&
+          issue.assigneeAgentId &&
+          !blockedInteractionWake &&
+          issueStatusOwnsExecutionLock(issue.status)
+        ) {
           // Legacy backfill must honor the same assignee-only ownership boundary as
           // claimQueuedRun(); otherwise a blocked interaction wake can re-stamp a
           // helper run as the active execution owner immediately after the helper

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -15235,13 +15235,17 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             .where(eq(issues.id, issue.id));
         }
 
-        if (!activeExecutionRun) {
+        if (!activeExecutionRun && issue.assigneeAgentId) {
+          // Legacy backfill must honor the same assignee-only ownership boundary as
+          // claimQueuedRun(); otherwise a foreign mention/comment wake can re-stamp
+          // executionRunId on blocked issues during follow-up wakes.
           const legacyRun = await tx
             .select()
             .from(heartbeatRuns)
             .where(
               and(
                 eq(heartbeatRuns.companyId, issue.companyId),
+                eq(heartbeatRuns.agentId, issue.assigneeAgentId),
                 inArray(heartbeatRuns.status, [...EXECUTION_PATH_HEARTBEAT_RUN_STATUSES]),
                 sql`${heartbeatRuns.contextSnapshot} ->> 'issueId' = ${issue.id}`,
               ),

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -15254,10 +15254,37 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             .where(eq(issues.id, issue.id));
         }
 
-        if (!activeExecutionRun && issue.assigneeAgentId) {
+        const dependencyReadiness = await issuesSvc.listDependencyReadiness(
+          issue.companyId,
+          [issue.id],
+          tx,
+        ).then((rows) => rows.get(issue.id) ?? null);
+
+        // Blocked descendants should stay idle until the final blocker resolves.
+        // Human comment/mention wakes are the exception: they may run in a
+        // bounded interaction mode so the assignee can answer or triage.
+        const blockedInteractionWake =
+          dependencyReadiness &&
+          !dependencyReadiness.isDependencyReady &&
+          allowsIssueInteractionWake(enrichedContextSnapshot);
+
+        if (blockedInteractionWake) {
+          enrichedContextSnapshot.dependencyBlockedInteraction = true;
+          enrichedContextSnapshot.unresolvedBlockerIssueIds = dependencyReadiness.unresolvedBlockerIssueIds;
+          enrichedContextSnapshot.unresolvedBlockerCount = dependencyReadiness.unresolvedBlockerCount;
+          enrichedContextSnapshot.unresolvedBlockerSummaries = await listUnresolvedBlockerSummaries(
+            tx,
+            issue.companyId,
+            issue.id,
+            dependencyReadiness.unresolvedBlockerIssueIds,
+          );
+        }
+
+        if (!activeExecutionRun && issue.assigneeAgentId && !blockedInteractionWake) {
           // Legacy backfill must honor the same assignee-only ownership boundary as
-          // claimQueuedRun(); otherwise a foreign mention/comment wake can re-stamp
-          // executionRunId on blocked issues during follow-up wakes.
+          // claimQueuedRun(); otherwise a blocked interaction wake can re-stamp a
+          // helper run as the active execution owner immediately after the helper
+          // has already returned the issue to blocked/unlocked state.
           const legacyRun = await tx
             .select()
             .from(heartbeatRuns)
@@ -15297,32 +15324,6 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
                 .where(eq(issues.id, issue.id));
             }
           }
-        }
-
-        const dependencyReadiness = await issuesSvc.listDependencyReadiness(
-          issue.companyId,
-          [issue.id],
-          tx,
-        ).then((rows) => rows.get(issue.id) ?? null);
-
-        // Blocked descendants should stay idle until the final blocker resolves.
-        // Human comment/mention wakes are the exception: they may run in a
-        // bounded interaction mode so the assignee can answer or triage.
-        const blockedInteractionWake =
-          dependencyReadiness &&
-          !dependencyReadiness.isDependencyReady &&
-          allowsIssueInteractionWake(enrichedContextSnapshot);
-
-        if (blockedInteractionWake) {
-          enrichedContextSnapshot.dependencyBlockedInteraction = true;
-          enrichedContextSnapshot.unresolvedBlockerIssueIds = dependencyReadiness.unresolvedBlockerIssueIds;
-          enrichedContextSnapshot.unresolvedBlockerCount = dependencyReadiness.unresolvedBlockerCount;
-          enrichedContextSnapshot.unresolvedBlockerSummaries = await listUnresolvedBlockerSummaries(
-            tx,
-            issue.companyId,
-            issue.id,
-            dependencyReadiness.unresolvedBlockerIssueIds,
-          );
         }
 
         if (!activeExecutionRun && dependencyReadiness && !dependencyReadiness.isDependencyReady && !blockedInteractionWake) {

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -3644,15 +3644,41 @@ export function issueService(db: Db) {
     return title.trim().replace(/\s+/g, " ").toLowerCase();
   }
 
+  async function materializeReadableIssue(row: typeof issues.$inferSelect | null) {
+    if (!row) return null;
+
+    // Read paths should not surface orphaned lock pointers after the owning
+    // heartbeat run has already finished or disappeared.
+    const clearedCheckout =
+      row.checkoutRunId
+        ? await clearCheckoutRunIfTerminal(row.id)
+        : false;
+    const clearedExecution =
+      !clearedCheckout && row.executionRunId && (row.checkoutRunId == null || row.executionRunId === row.checkoutRunId)
+        ? await clearExecutionRunIfTerminal(row.id)
+        : false;
+
+    const stableRow =
+      clearedCheckout || clearedExecution
+        ? await db
+          .select()
+          .from(issues)
+          .where(eq(issues.id, row.id))
+          .then((rows) => rows[0] ?? null)
+        : row;
+    if (!stableRow) return null;
+
+    const [enriched] = await withIssueLabels(db, [stableRow]);
+    return enriched;
+  }
+
   async function getIssueByUuid(id: string) {
     const row = await db
       .select()
       .from(issues)
       .where(eq(issues.id, id))
       .then((rows) => rows[0] ?? null);
-    if (!row) return null;
-    const [enriched] = await withIssueLabels(db, [row]);
-    return enriched;
+    return materializeReadableIssue(row);
   }
 
   async function getIssueByIdentifier(identifier: string) {
@@ -3661,9 +3687,7 @@ export function issueService(db: Db) {
       .from(issues)
       .where(eq(issues.identifier, identifier.toUpperCase()))
       .then((rows) => rows[0] ?? null);
-    if (!row) return null;
-    const [enriched] = await withIssueLabels(db, [row]);
-    return enriched;
+    return materializeReadableIssue(row);
   }
 
   async function getCurrentScheduledRetryForIssue(issueId: string, companyId: string): Promise<IssueScheduledRetryRow | null> {

--- a/tests/e2e/applications-crud.spec.ts
+++ b/tests/e2e/applications-crud.spec.ts
@@ -1,4 +1,6 @@
 import { expect, test, type APIRequestContext, type Page } from "@playwright/test";
+import { createServer, type Server } from "node:http";
+import { listenOnFetchAllowedPort } from "./fetch-allowed-port";
 
 // Current Apps lifecycle coverage. The legacy Tools -> Applications CRUD table
 // was retired; old links now redirect to /apps. Keep this harness focused on
@@ -9,8 +11,55 @@ type SeedResult = {
   prefix: string;
 };
 
+type MockMcpServer = {
+  url: string;
+  close: () => Promise<void>;
+};
+
 const SCREENSHOT_DIR = "test-results";
 const APP_PREFIX = `QA 10820 ${Date.now().toString(36)}`;
+
+async function startMockMcp(): Promise<MockMcpServer> {
+  const server: Server = createServer(async (req, res) => {
+    const chunks: Buffer[] = [];
+    for await (const chunk of req) chunks.push(chunk as Buffer);
+
+    let payload: { id?: string | number; method?: string } = {};
+    try {
+      payload = JSON.parse(Buffer.concat(chunks).toString("utf8") || "{}");
+    } catch {
+      // Ignore non-JSON requests from the connect wizard probes.
+    }
+
+    if (payload.method === "tools/list") {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({
+        jsonrpc: "2.0",
+        id: payload.id ?? null,
+        result: {
+          tools: [
+            {
+              name: "list_widgets",
+              title: "List widgets",
+              description: "Read-only listing of widgets.",
+              inputSchema: { type: "object", properties: {}, additionalProperties: false },
+            },
+          ],
+        },
+      }));
+      return;
+    }
+
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ jsonrpc: "2.0", id: payload.id ?? null, result: {} }));
+  });
+
+  const port = await listenOnFetchAllowedPort(server);
+  return {
+    url: `http://127.0.0.1:${port}`,
+    close: () => new Promise((resolve) => server.close(() => resolve())),
+  };
+}
 
 async function discoverCompany(request: APIRequestContext): Promise<SeedResult> {
   const res = await request.post("/api/companies", {
@@ -41,19 +90,27 @@ async function createApplication(
 async function createConnection(
   request: APIRequestContext,
   companyId: string,
-  data: { applicationName?: string; applicationId?: string; name: string; transport?: string; config?: object },
+  mock: MockMcpServer,
+  data: { name: string },
 ): Promise<{ id: string; applicationId: string; name: string }> {
-  const res = await request.post(`/api/companies/${companyId}/tools/connections`, {
+  const res = await request.post(`/api/companies/${companyId}/tools/apps/connect`, {
     data: {
-      transport: "remote_http",
-      config: { url: "https://fixture.example/mcp" },
-      enabled: true,
-      status: "active",
+      link: mock.url,
+      credentialValues: { "credentials.authorization": "qa-token" },
       ...data,
     },
   });
   if (!res.ok()) throw new Error(`create connection failed ${res.status()}: ${await res.text()}`);
-  return res.json();
+  const body = await res.json();
+  const activate = await request.patch(`/api/tool-connections/${body.connectionId as string}`, {
+    data: { enabled: true, status: "active" },
+  });
+  if (!activate.ok()) throw new Error(`activate connection failed ${activate.status()}: ${await activate.text()}`);
+  return {
+    id: body.connectionId as string,
+    applicationId: body.application.id as string,
+    name: body.application.name as string,
+  };
 }
 
 async function gotoApps(page: Page, prefix: string) {
@@ -63,12 +120,15 @@ async function gotoApps(page: Page, prefix: string) {
 
 test.describe.serial("applications lifecycle", () => {
   let seed: SeedResult;
+  let mock: MockMcpServer;
 
   test.beforeAll(async ({ request }) => {
+    mock = await startMockMcp();
     seed = await discoverCompany(request);
   });
 
   test.afterAll(async ({ request }) => {
+    await mock?.close();
     if (!seed?.companyId) return;
     await request.delete(`/api/companies/${seed.companyId}`).catch(() => undefined);
   });
@@ -76,8 +136,7 @@ test.describe.serial("applications lifecycle", () => {
   test("Connections list surfaces connected and not-connected apps", async ({ page, request }) => {
     const connectedName = `${APP_PREFIX}-connected`;
     const notConnectedName = `${APP_PREFIX}-not-connected`;
-    const connected = await createConnection(request, seed.companyId, {
-      applicationName: connectedName,
+    const connected = await createConnection(request, seed.companyId, mock, {
       name: connectedName,
     });
     const notConnected = await createApplication(request, seed.companyId, { name: notConnectedName });
@@ -106,8 +165,7 @@ test.describe.serial("applications lifecycle", () => {
   test("connected app detail supports pause, rename, and removal", async ({ page, request }) => {
     const appName = `${APP_PREFIX}-detail-app`;
     const renamed = `${APP_PREFIX}-renamed-app`;
-    const connection = await createConnection(request, seed.companyId, {
-      applicationName: appName,
+    const connection = await createConnection(request, seed.companyId, mock, {
       name: appName,
     });
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip coordinates autonomous agent work by pairing issue assignment with heartbeat-driven execution and lock ownership.
> - The heartbeat service is the subsystem that decides whether a wake should claim an issue's execution lock or leave the issue purely informational.
> - Blocked issues can still receive mention/comment wakes that should notify the assignee without turning that wake into the active execution run.
> - If those wakes backfill `executionRunId` or surface as `activeRun`, the issue looks live even though no checkout/execution should exist.
> - The recent fixes in this area already addressed stale cross-agent backfill and blocked-issue execution-lock reads, but the same-assignee comment-only mention path on blocked issues still needed explicit lock-ownership gating and regression coverage.
> - This pull request centralizes the wake-types-claim-lock decision and applies it consistently when claiming or adopting execution locks.
> - The benefit is that blocked comment-only mention wakes stay visible to the assignee without mutating issue execution ownership.

## Linked Issues or Issue Description

No public GitHub issue exists for this regression.

### What happened

A blocked issue hit by a comment-only mention wake could retain or expose execution-lock state even though that wake should not own the issue execution path.

### Expected behavior

Comment-only mention wakes on blocked issues should leave `checkoutRunId`, `executionRunId`, and `executionLockedAt` unset, and `GET /api/issues/:id` should not report an `activeRun` for that wake.

### Steps to reproduce

1. Create a blocked issue without first-class blocker relations.
2. Enqueue a same-assignee comment-only mention wake.
3. Inspect the issue row and API response.
4. Observe that the wake must remain visible without claiming execution ownership.

### Paperclip version or commit

Tested against PR head `0baadc4884baa6560689163b4eed5158c6b8ae12` on current `master`.

### Deployment mode

Control-plane/server runtime in the standard Paperclip application deployment path.

## What Changed

- Added `shouldWakeOwnIssueExecutionLock` in `server/src/services/heartbeat.ts` to centralize which wake contexts are allowed to claim issue execution ownership.
- Reused that helper when claiming the current run's lock and when selecting a legacy run whose lock can be adopted, so mention-only and dependency-blocked wakes stay lock-free.
- Extended `server/src/__tests__/issue-blocked-interaction-lock-routes.test.ts` with a blocked same-assignee comment-only mention case that has no first-class blocker relation and must keep execution fields null.
- Rebased the execution-lock fix stack onto current `origin/master` and opened an upstream PR from a fork for review.

## Verification

- `npx -y pnpm@9.15.4 vitest run server/src/__tests__/issue-blocked-interaction-lock-routes.test.ts server/src/__tests__/issue-stale-execution-lock-routes.test.ts`
- GitHub PR workflow rerun on head `0baadc4884baa6560689163b4eed5158c6b8ae12`: `Build`, all four serialized server suites, all three general server shards, `e2e`, `verify`, and `Canary Dry Run` passed.

## Risks

- Low risk. The change is isolated to wake types that should already avoid checkout/execution ownership, but a misclassified wake reason here could suppress a legitimate execution lock claim.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex on GPT-5 with local shell/tool execution for git, tests, and PR preparation.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [ ] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
