### PR TITLE
fix(recovery): treat hermes_gateway_rate_limited as transient for continuation retry

### DIFF
--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -241,6 +241,12 @@ const TRANSIENT_INFRA_CONTINUATION_ERROR_CODES = new Set<string>([
   "adapter_failed",
   "codex_transient_upstream",
   "claude_transient_upstream",
+  // The hermes-gateway adapter classifies HTTP 429 from the Hermes API server as
+  // `hermes_gateway_rate_limited` (family transient_upstream, carrying retryNotBefore).
+  // Like the codex/claude upstream-throttle codes, it is transient infrastructure and the
+  // continuation should be retried honoring the backoff — not escalated to blocked after a
+  // single attempt. Without this, a rate-limited gateway strands its issue for a human.
+  "hermes_gateway_rate_limited",
   "provider_quota",
   "timeout",
 ]);


### PR DESCRIPTION
## Problem

The hermes-gateway adapter maps an HTTP 429 from the Hermes API server to `errorCode: "hermes_gateway_rate_limited"` with `family: "transient_upstream"` and a `retryNotBefore` derived from the `Retry-After` header (`packages/adapters/hermes/src/gateway/server/execute.ts:331`).

But the stranded-continuation classifier's `TRANSIENT_INFRA_CONTINUATION_ERROR_CODES` (`server/src/services/recovery/service.ts`) omits it — it lists `adapter_failed`, `codex_transient_upstream`, `claude_transient_upstream`, `provider_quota`, `timeout`, but not `hermes_gateway_rate_limited`.

Consequence: a rate-limited hermes-gateway run is treated as a **default** (single-attempt) continuation failure and its issue is escalated to `blocked` after one try, instead of being retried on the adapter's own backoff like every other transient upstream throttle. A transient 429 strands the issue for a human.

## Fix

Add `hermes_gateway_rate_limited` to `TRANSIENT_INFRA_CONTINUATION_ERROR_CODES`, alongside the codex/claude upstream-throttle codes it is analogous to.

## Context

Found running a Hermes-gateway agent under load: 20 concurrent runs briefly rate-limited the gateway; the surviving runs' issues escalated to `blocked` rather than retrying, and the scheduled retries that were created sat unpromoted because the classifier had already routed them to the blocked path. This one-line set membership makes the gateway 429 path consistent with the other adapters' transient handling.