### PR TITLE
fix(claude-local): extract retry-not-before from session limit errors

### DIFF
--- a/packages/adapters/claude-local/src/server/parse.test.ts
+++ b/packages/adapters/claude-local/src/server/parse.test.ts
@@ -48,6 +48,22 @@ describe("isClaudeTransientUpstreamError", () => {
     ).toBe(true);
   });
 
+  it("classifies the 'session limit' wording as transient", () => {
+    expect(
+      isClaudeTransientUpstreamError({
+        errorMessage: "You've hit your session limit · resets 3:10pm (America/New_York)",
+      }),
+    ).toBe(true);
+    expect(
+      isClaudeTransientUpstreamError({
+        parsed: {
+          is_error: true,
+          result: "You've hit your session limit · resets 3:10pm (America/New_York)",
+        },
+      }),
+    ).toBe(true);
+  });
+
   it("classifies Anthropic API rate_limit_error and overloaded_error as transient", () => {
     expect(
       isClaudeTransientUpstreamError({
@@ -326,5 +342,29 @@ describe("extractClaudeRetryNotBefore", () => {
     expect(
       extractClaudeRetryNotBefore({ errorMessage: "Overloaded. Try again later." }, new Date()),
     ).toBeNull();
+  });
+
+  it("parses the 'session limit' reset hint with explicit timezone", () => {
+    const now = new Date("2026-07-15T18:00:00.000Z");
+    const extracted = extractClaudeRetryNotBefore(
+      { errorMessage: "You've hit your session limit · resets 3:10pm (America/New_York)" },
+      now,
+    );
+    // 3:10pm America/New_York = 19:10 UTC
+    expect(extracted?.toISOString()).toBe("2026-07-15T19:10:00.000Z");
+  });
+
+  it("parses the session limit reset hint from the parsed result field", () => {
+    const now = new Date("2026-07-15T18:00:00.000Z");
+    const extracted = extractClaudeRetryNotBefore(
+      {
+        parsed: {
+          is_error: true,
+          result: "You've hit your session limit · resets 3:10pm (America/New_York)",
+        },
+      },
+      now,
+    );
+    expect(extracted?.toISOString()).toBe("2026-07-15T19:10:00.000Z");
   });
 });

--- a/packages/adapters/claude-local/src/server/parse.ts
+++ b/packages/adapters/claude-local/src/server/parse.ts
@@ -10,9 +10,9 @@ const CLAUDE_AUTH_REQUIRED_RE = /(?:not\s+logged\s+in|please\s+log\s+in|please\s
 const URL_RE = /(https?:\/\/[^\s'"`<>()[\]{};,!?]+[^\s'"`<>()[\]{};,!.?:]+)/gi;
 
 const CLAUDE_TRANSIENT_UPSTREAM_RE =
-  /(?:rate[-\s]?limit(?:ed)?|rate_limit_error|too\s+many\s+requests|\b429\b|overloaded(?:_error)?|server\s+overloaded|service\s+unavailable|\b503\b|\b529\b|high\s+demand|try\s+again\s+later|temporarily\s+unavailable|throttl(?:ed|ing)|throttlingexception|servicequotaexceededexception|out\s+of\s+extra\s+usage|extra\s+usage\b|claude\s+usage\s+limit\s+reached|5[-\s]?hour\s+limit\s+reached|weekly\s+limit\s+reached|usage\s+limit\s+reached|usage\s+cap\s+reached)/i;
+  /(?:rate[-\s]?limit(?:ed)?|rate_limit_error|too\s+many\s+requests|\b429\b|overloaded(?:_error)?|server\s+overloaded|service\s+unavailable|\b503\b|\b529\b|high\s+demand|try\s+again\s+later|temporarily\s+unavailable|throttl(?:ed|ing)|throttlingexception|servicequotaexceededexception|out\s+of\s+extra\s+usage|extra\s+usage\b|claude\s+usage\s+limit\s+reached|5[-\s]?hour\s+limit\s+reached|weekly\s+limit\s+reached|usage\s+limit\s+reached|usage\s+cap\s+reached|session\s+limit)/i;
 const CLAUDE_EXTRA_USAGE_RESET_RE =
-  /(?:out\s+of\s+extra\s+usage|extra\s+usage|usage\s+limit\s+reached|usage\s+cap\s+reached|5[-\s]?hour\s+limit\s+reached|weekly\s+limit\s+reached|claude\s+usage\s+limit\s+reached)[\s\S]{0,80}?\bresets?\s+(?:at\s+)?([^\n()]+?)(?:\s*\(([^)]+)\))?(?:[.!]|\n|$)/i;
+  /(?:out\s+of\s+extra\s+usage|extra\s+usage|usage\s+limit\s+reached|usage\s+cap\s+reached|5[-\s]?hour\s+limit\s+reached|weekly\s+limit\s+reached|claude\s+usage\s+limit\s+reached|session\s+limit)[\s\S]{0,80}?\bresets?\s+(?:at\s+)?([^\n()]+?)(?:\s*\(([^)]+)\))?(?:[.!]|\n|$)/i;
 
 export function parseClaudeStreamJson(stdout: string) {
   let sessionId: string | null = null;


### PR DESCRIPTION
## Summary

- Adds `session limit` to `CLAUDE_TRANSIENT_UPSTREAM_RE` so Claude's "You've hit your session limit" messages are correctly classified as transient upstream errors.
- Adds `session limit` to `CLAUDE_EXTRA_USAGE_RESET_RE` so the reset time (e.g. `resets 3:10pm (America/New_York)`) is extracted and propagated as `retryNotBefore` on the run result.
- Without this fix, the bounded retry scheduler used the default backoff and fired before the reset time; now it respects the quoted reset time (BRO-1206).

## Test plan

- [x] `pnpm exec vitest run src/server/parse.test.ts` — all 35 tests pass, including two new tests that specifically verify `isClaudeTransientUpstreamError` and `extractClaudeRetryNotBefore` handle the `session limit` wording.
- [x] The `heartbeat-retry-scheduling.test.ts` suite already covers the `scheduleBoundedRetry` path that honors `retryNotBefore`; this fix feeds the correct timestamp into that path.

Closes BRO-1206

🤖 Generated with [Claude Code](https://claude.com/claude-code)