### PR TITLE
Secure release deploy relay token transport

### DIFF
--- a/docs/api/release-candidates.md
+++ b/docs/api/release-candidates.md
@@ -1,0 +1,43 @@
+# Release Candidate Deploy Relay
+
+The deploy relay token is a one-time secret. Relay consumers must never put it in
+the URL, argv, shell history, or JSON body.
+
+## Header Contract
+
+Send the token only in this request header:
+
+```http
+X-Paperclip-Deploy-Token: pcdeploy_...
+```
+
+The `authorizationId` may remain a path or query identifier because it is not the
+secret.
+
+## Secure Calls
+
+Approved lease lookup:
+
+```http
+GET /api/release-candidates/approved-lease?authorizationId={authorizationId}
+X-Paperclip-Deploy-Token: pcdeploy_...
+```
+
+Stage relay artifact:
+
+```http
+POST /api/release-deploy-authorizations/{authorizationId}/stage-relay-artifact
+X-Paperclip-Deploy-Token: pcdeploy_...
+Content-Type: application/json
+```
+
+Deploy record submission:
+
+```http
+POST /api/release-candidates/deploy-records
+X-Paperclip-Deploy-Token: pcdeploy_...
+Content-Type: application/json
+```
+
+The secure JSON bodies do not include a `token` field. Query-string and body
+token transport are rejected.

--- a/packages/db/src/migrations/0125_company_search_lower_expression_indexes.sql
+++ b/packages/db/src/migrations/0125_company_search_lower_expression_indexes.sql
@@ -1,0 +1,15 @@
+CREATE INDEX IF NOT EXISTS "issues_company_identifier_lower_visible_idx"
+  ON "issues" ("company_id", lower(coalesce("identifier", '')))
+  WHERE "hidden_at" IS NULL AND "identifier" IS NOT NULL;--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "issues_title_lower_search_idx"
+  ON "issues" USING gin (lower("title") gin_trgm_ops);--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "issues_identifier_lower_search_idx"
+  ON "issues" USING gin (lower(coalesce("identifier", '')) gin_trgm_ops);--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "issues_description_lower_search_idx"
+  ON "issues" USING gin (lower(coalesce("description", '')) gin_trgm_ops);--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "issue_comments_body_lower_search_idx"
+  ON "issue_comments" USING gin (lower("body") gin_trgm_ops);--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "documents_title_lower_search_idx"
+  ON "documents" USING gin (lower(coalesce("title", '')) gin_trgm_ops);--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "documents_latest_body_lower_search_idx"
+  ON "documents" USING gin (lower("latest_body") gin_trgm_ops);

--- a/packages/db/src/migrations/0127_release_candidate_approval_relay.sql
+++ b/packages/db/src/migrations/0127_release_candidate_approval_relay.sql
@@ -1,0 +1,109 @@
+CREATE TABLE "release_candidates" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"company_id" uuid NOT NULL,
+	"source_issue_id" uuid NOT NULL,
+	"created_by_agent_id" uuid,
+	"created_by_run_id" uuid,
+	"commit_sha" text NOT NULL,
+	"image_digest" text NOT NULL,
+	"signature_bundle_ref" text NOT NULL,
+	"provenance_ref" text NOT NULL,
+	"sbom_hash" text NOT NULL,
+	"workflow_run_url" text NOT NULL,
+	"environment" text NOT NULL,
+	"target_host" text NOT NULL,
+	"sequence" integer NOT NULL,
+	"document_revision_id" text,
+	"status" text DEFAULT 'candidate_created' NOT NULL,
+	"approval_interaction_id" uuid,
+	"approved_by_user_id" text,
+	"approved_at" timestamp with time zone,
+	"staged_artifact_asset_id" uuid,
+	"staged_artifact_sha256" text,
+	"staged_at" timestamp with time zone,
+	"metadata" jsonb DEFAULT '{}'::jsonb NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "release_deploy_authorizations" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"company_id" uuid NOT NULL,
+	"candidate_id" uuid NOT NULL,
+	"approval_interaction_id" uuid NOT NULL,
+	"token_hash" text NOT NULL,
+	"token_prefix" text NOT NULL,
+	"target_host" text NOT NULL,
+	"image_digest" text NOT NULL,
+	"environment" text NOT NULL,
+	"sequence" integer NOT NULL,
+	"expires_at" timestamp with time zone NOT NULL,
+	"used_at" timestamp with time zone,
+	"lease_artifact_asset_id" uuid,
+	"lease_issued_at" timestamp with time zone,
+	"created_by_user_id" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "release_candidate_audit_events" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"company_id" uuid NOT NULL,
+	"candidate_id" uuid NOT NULL,
+	"authorization_id" uuid,
+	"issue_id" uuid,
+	"actor_agent_id" uuid,
+	"actor_user_id" text,
+	"event_type" text NOT NULL,
+	"payload" jsonb DEFAULT '{}'::jsonb NOT NULL,
+	"redacted" boolean DEFAULT true NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "release_candidates" ADD CONSTRAINT "release_candidates_company_id_companies_id_fk" FOREIGN KEY ("company_id") REFERENCES "public"."companies"("id") ON DELETE no action ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "release_candidates" ADD CONSTRAINT "release_candidates_source_issue_id_issues_id_fk" FOREIGN KEY ("source_issue_id") REFERENCES "public"."issues"("id") ON DELETE restrict ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "release_candidates" ADD CONSTRAINT "release_candidates_created_by_agent_id_agents_id_fk" FOREIGN KEY ("created_by_agent_id") REFERENCES "public"."agents"("id") ON DELETE set null ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "release_candidates" ADD CONSTRAINT "release_candidates_created_by_run_id_heartbeat_runs_id_fk" FOREIGN KEY ("created_by_run_id") REFERENCES "public"."heartbeat_runs"("id") ON DELETE set null ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "release_candidates" ADD CONSTRAINT "release_candidates_approval_interaction_id_issue_thread_interactions_id_fk" FOREIGN KEY ("approval_interaction_id") REFERENCES "public"."issue_thread_interactions"("id") ON DELETE restrict ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "release_candidates" ADD CONSTRAINT "release_candidates_staged_artifact_asset_id_assets_id_fk" FOREIGN KEY ("staged_artifact_asset_id") REFERENCES "public"."assets"("id") ON DELETE set null ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "release_deploy_authorizations" ADD CONSTRAINT "release_deploy_authorizations_company_id_companies_id_fk" FOREIGN KEY ("company_id") REFERENCES "public"."companies"("id") ON DELETE no action ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "release_deploy_authorizations" ADD CONSTRAINT "release_deploy_authorizations_candidate_id_release_candidates_id_fk" FOREIGN KEY ("candidate_id") REFERENCES "public"."release_candidates"("id") ON DELETE restrict ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "release_deploy_authorizations" ADD CONSTRAINT "release_deploy_authorizations_approval_interaction_id_issue_thread_interactions_id_fk" FOREIGN KEY ("approval_interaction_id") REFERENCES "public"."issue_thread_interactions"("id") ON DELETE restrict ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "release_deploy_authorizations" ADD CONSTRAINT "release_deploy_authorizations_lease_artifact_asset_id_assets_id_fk" FOREIGN KEY ("lease_artifact_asset_id") REFERENCES "public"."assets"("id") ON DELETE set null ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "release_candidate_audit_events" ADD CONSTRAINT "release_candidate_audit_events_company_id_companies_id_fk" FOREIGN KEY ("company_id") REFERENCES "public"."companies"("id") ON DELETE no action ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "release_candidate_audit_events" ADD CONSTRAINT "release_candidate_audit_events_candidate_id_release_candidates_id_fk" FOREIGN KEY ("candidate_id") REFERENCES "public"."release_candidates"("id") ON DELETE restrict ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "release_candidate_audit_events" ADD CONSTRAINT "release_candidate_audit_events_authorization_id_release_deploy_authorizations_id_fk" FOREIGN KEY ("authorization_id") REFERENCES "public"."release_deploy_authorizations"("id") ON DELETE set null ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "release_candidate_audit_events" ADD CONSTRAINT "release_candidate_audit_events_issue_id_issues_id_fk" FOREIGN KEY ("issue_id") REFERENCES "public"."issues"("id") ON DELETE set null ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "release_candidate_audit_events" ADD CONSTRAINT "release_candidate_audit_events_actor_agent_id_agents_id_fk" FOREIGN KEY ("actor_agent_id") REFERENCES "public"."agents"("id") ON DELETE set null ON UPDATE no action;
+--> statement-breakpoint
+CREATE INDEX "release_candidates_company_created_idx" ON "release_candidates" USING btree ("company_id","created_at");
+--> statement-breakpoint
+CREATE INDEX "release_candidates_source_issue_idx" ON "release_candidates" USING btree ("source_issue_id");
+--> statement-breakpoint
+CREATE UNIQUE INDEX "release_candidates_company_target_sequence_uq" ON "release_candidates" USING btree ("company_id","environment","target_host","sequence");
+--> statement-breakpoint
+CREATE UNIQUE INDEX "release_candidates_company_digest_uq" ON "release_candidates" USING btree ("company_id","image_digest");
+--> statement-breakpoint
+CREATE INDEX "release_candidates_approval_interaction_idx" ON "release_candidates" USING btree ("approval_interaction_id") WHERE "release_candidates"."approval_interaction_id" IS NOT NULL;
+--> statement-breakpoint
+CREATE INDEX "release_deploy_authorizations_company_candidate_idx" ON "release_deploy_authorizations" USING btree ("company_id","candidate_id");
+--> statement-breakpoint
+CREATE UNIQUE INDEX "release_deploy_authorizations_token_hash_uq" ON "release_deploy_authorizations" USING btree ("token_hash");
+--> statement-breakpoint
+CREATE INDEX "release_candidate_audit_events_candidate_created_idx" ON "release_candidate_audit_events" USING btree ("candidate_id","created_at");
+--> statement-breakpoint
+CREATE INDEX "release_candidate_audit_events_company_created_idx" ON "release_candidate_audit_events" USING btree ("company_id","created_at");

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -883,6 +883,20 @@
       "when": 1782440100000,
       "tag": "0125_company_search_lower_expression_indexes",
       "breakpoints": true
+    },
+    {
+      "idx": 126,
+      "version": "7",
+      "when": 1782440200000,
+      "tag": "0126_ceo_idle_packet_window_dedupe",
+      "breakpoints": true
+    },
+    {
+      "idx": 127,
+      "version": "7",
+      "when": 1783971000000,
+      "tag": "0127_release_candidate_approval_relay",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -876,6 +876,13 @@
       "when": 1782440000000,
       "tag": "0124_agent_api_key_scope_config",
       "breakpoints": true
+    },
+    {
+      "idx": 125,
+      "version": "7",
+      "when": 1782440100000,
+      "tag": "0125_company_search_lower_expression_indexes",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -65,6 +65,11 @@ export { feedbackVotes } from "./feedback_votes.js";
 export { feedbackExports } from "./feedback_exports.js";
 export { issueReadStates } from "./issue_read_states.js";
 export { assets } from "./assets.js";
+export {
+  releaseCandidates,
+  releaseDeployAuthorizations,
+  releaseCandidateAuditEvents,
+} from "./release_candidates.js";
 export { issueAttachments } from "./issue_attachments.js";
 export { documents } from "./documents.js";
 export { documentRevisions } from "./document_revisions.js";

--- a/packages/db/src/schema/release_candidates.ts
+++ b/packages/db/src/schema/release_candidates.ts
@@ -1,0 +1,101 @@
+import { sql } from "drizzle-orm";
+import { boolean, index, integer, jsonb, pgTable, text, timestamp, uniqueIndex, uuid } from "drizzle-orm/pg-core";
+import { agents } from "./agents.js";
+import { assets } from "./assets.js";
+import { companies } from "./companies.js";
+import { heartbeatRuns } from "./heartbeat_runs.js";
+import { issueThreadInteractions } from "./issue_thread_interactions.js";
+import { issues } from "./issues.js";
+
+export const releaseCandidates = pgTable(
+  "release_candidates",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    companyId: uuid("company_id").notNull().references(() => companies.id),
+    sourceIssueId: uuid("source_issue_id").notNull().references(() => issues.id, { onDelete: "restrict" }),
+    createdByAgentId: uuid("created_by_agent_id").references(() => agents.id, { onDelete: "set null" }),
+    createdByRunId: uuid("created_by_run_id").references(() => heartbeatRuns.id, { onDelete: "set null" }),
+    commitSha: text("commit_sha").notNull(),
+    imageDigest: text("image_digest").notNull(),
+    signatureBundleRef: text("signature_bundle_ref").notNull(),
+    provenanceRef: text("provenance_ref").notNull(),
+    sbomHash: text("sbom_hash").notNull(),
+    workflowRunUrl: text("workflow_run_url").notNull(),
+    environment: text("environment").notNull(),
+    targetHost: text("target_host").notNull(),
+    sequence: integer("sequence").notNull(),
+    documentRevisionId: text("document_revision_id"),
+    status: text("status").notNull().default("candidate_created"),
+    approvalInteractionId: uuid("approval_interaction_id").references(() => issueThreadInteractions.id, {
+      onDelete: "restrict",
+    }),
+    approvedByUserId: text("approved_by_user_id"),
+    approvedAt: timestamp("approved_at", { withTimezone: true }),
+    stagedArtifactAssetId: uuid("staged_artifact_asset_id").references(() => assets.id, { onDelete: "set null" }),
+    stagedArtifactSha256: text("staged_artifact_sha256"),
+    stagedAt: timestamp("staged_at", { withTimezone: true }),
+    metadata: jsonb("metadata").$type<Record<string, unknown>>().notNull().default({}),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    companyCreatedIdx: index("release_candidates_company_created_idx").on(table.companyId, table.createdAt),
+    sourceIssueIdx: index("release_candidates_source_issue_idx").on(table.sourceIssueId),
+    companyTargetSequenceUq: uniqueIndex("release_candidates_company_target_sequence_uq")
+      .on(table.companyId, table.environment, table.targetHost, table.sequence),
+    companyDigestUq: uniqueIndex("release_candidates_company_digest_uq").on(table.companyId, table.imageDigest),
+    immutableAfterApprovalIdx: index("release_candidates_approval_interaction_idx")
+      .on(table.approvalInteractionId)
+      .where(sql`${table.approvalInteractionId} IS NOT NULL`),
+  }),
+);
+
+export const releaseDeployAuthorizations = pgTable(
+  "release_deploy_authorizations",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    companyId: uuid("company_id").notNull().references(() => companies.id),
+    candidateId: uuid("candidate_id").notNull().references(() => releaseCandidates.id, { onDelete: "restrict" }),
+    approvalInteractionId: uuid("approval_interaction_id").notNull().references(() => issueThreadInteractions.id, {
+      onDelete: "restrict",
+    }),
+    tokenHash: text("token_hash").notNull(),
+    tokenPrefix: text("token_prefix").notNull(),
+    targetHost: text("target_host").notNull(),
+    imageDigest: text("image_digest").notNull(),
+    environment: text("environment").notNull(),
+    sequence: integer("sequence").notNull(),
+    expiresAt: timestamp("expires_at", { withTimezone: true }).notNull(),
+    usedAt: timestamp("used_at", { withTimezone: true }),
+    leaseArtifactAssetId: uuid("lease_artifact_asset_id").references(() => assets.id, { onDelete: "set null" }),
+    leaseIssuedAt: timestamp("lease_issued_at", { withTimezone: true }),
+    createdByUserId: text("created_by_user_id"),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    companyCandidateIdx: index("release_deploy_authorizations_company_candidate_idx").on(table.companyId, table.candidateId),
+    tokenHashUq: uniqueIndex("release_deploy_authorizations_token_hash_uq").on(table.tokenHash),
+  }),
+);
+
+export const releaseCandidateAuditEvents = pgTable(
+  "release_candidate_audit_events",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    companyId: uuid("company_id").notNull().references(() => companies.id),
+    candidateId: uuid("candidate_id").notNull().references(() => releaseCandidates.id, { onDelete: "restrict" }),
+    authorizationId: uuid("authorization_id").references(() => releaseDeployAuthorizations.id, { onDelete: "set null" }),
+    issueId: uuid("issue_id").references(() => issues.id, { onDelete: "set null" }),
+    actorAgentId: uuid("actor_agent_id").references(() => agents.id, { onDelete: "set null" }),
+    actorUserId: text("actor_user_id"),
+    eventType: text("event_type").notNull(),
+    payload: jsonb("payload").$type<Record<string, unknown>>().notNull().default({}),
+    redacted: boolean("redacted").notNull().default(true),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    candidateCreatedIdx: index("release_candidate_audit_events_candidate_created_idx").on(table.candidateId, table.createdAt),
+    companyCreatedIdx: index("release_candidate_audit_events_company_created_idx").on(table.companyId, table.createdAt),
+  }),
+);

--- a/server/src/__tests__/company-search-service.test.ts
+++ b/server/src/__tests__/company-search-service.test.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import { performance } from "node:perf_hooks";
 import { sql } from "drizzle-orm";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import {
@@ -149,6 +150,69 @@ describeEmbeddedPostgres("companySearchService", () => {
 
     expect(result.results[0]?.id).toBe(exactId);
     expect(result.results[0]?.matchedFields).toContain("identifier");
+  });
+
+  it("uses a fast exact identifier path on populated issue/comment/document data", async () => {
+    const companyId = await createCompany();
+    const exactId = await createIssue(companyId, {
+      identifier: "TST-9535",
+      title: "Company search latency target",
+    });
+    const noiseIssueValues: Array<typeof issues.$inferInsert> = [];
+    const noiseCommentValues: Array<typeof issueComments.$inferInsert> = [];
+    const noiseDocumentValues: Array<typeof documents.$inferInsert> = [];
+    const noiseIssueDocumentValues: Array<typeof issueDocuments.$inferInsert> = [];
+
+    for (let index = 0; index < 700; index += 1) {
+      const issueId = randomUUID();
+      const documentId = randomUUID();
+      noiseIssueValues.push({
+        id: issueId,
+        companyId,
+        identifier: `TST-${10_000 + index}`,
+        title: `Noisy search issue ${index}`,
+        description: `Long issue description with generic search latency words ${index}`,
+        status: "todo",
+        priority: "medium",
+      });
+      noiseCommentValues.push({
+        companyId,
+        issueId,
+        body: `Noisy comment body with company search words and document branch terms ${index}`,
+      });
+      noiseDocumentValues.push({
+        id: documentId,
+        companyId,
+        title: `Noisy document ${index}`,
+        latestBody: `Noisy document body with company search latency words ${index}`,
+        format: "markdown",
+      });
+      noiseIssueDocumentValues.push({
+        companyId,
+        issueId,
+        documentId,
+        key: `noise-${index}`,
+      });
+    }
+
+    await db.insert(issues).values(noiseIssueValues);
+    await db.insert(issueComments).values(noiseCommentValues);
+    await db.insert(documents).values(noiseDocumentValues);
+    await db.insert(issueDocuments).values(noiseIssueDocumentValues);
+
+    await svc.search(companyId, companySearchQuerySchema.parse({ q: "TST-9535", scope: "all", limit: "10" }));
+
+    const timings: number[] = [];
+    for (let index = 0; index < 5; index += 1) {
+      const startedAt = performance.now();
+      const result = await svc.search(companyId, companySearchQuerySchema.parse({ q: "TST-9535", scope: "all", limit: "10" }));
+      timings.push(performance.now() - startedAt);
+      expect(result.results.map((row) => row.id)).toEqual([exactId]);
+      expect(result.results[0]?.matchedFields).toEqual(["identifier"]);
+    }
+
+    const p95 = timings.toSorted((left, right) => left - right)[Math.floor((timings.length - 1) * 0.95)] ?? Infinity;
+    expect(p95).toBeLessThan(500);
   });
 
   it("matches multiple tokens across the same issue thread and returns comment snippets", async () => {

--- a/server/src/__tests__/company-search-service.test.ts
+++ b/server/src/__tests__/company-search-service.test.ts
@@ -215,6 +215,89 @@ describeEmbeddedPostgres("companySearchService", () => {
     expect(p95).toBeLessThan(500);
   });
 
+  it("keeps broad issue/comment/document search bounded on populated data", async () => {
+    const companyId = await createCompany();
+    const targetIssueId = await createIssue(companyId, {
+      identifier: "TST-9600",
+      title: "Latency candidate routing",
+      description: "Broad search should preselect candidates before scoring snippets.",
+    });
+    const targetDocumentId = randomUUID();
+    await db.insert(issueComments).values({
+      companyId,
+      issueId: targetIssueId,
+      body: "The broad-search latency target needs candidate preselection evidence.",
+    });
+    await db.insert(documents).values({
+      id: targetDocumentId,
+      companyId,
+      title: "Broad search latency plan",
+      latestBody: "Candidate preselection should keep issue, comment, and document branches bounded.",
+      format: "markdown",
+    });
+    await db.insert(issueDocuments).values({
+      companyId,
+      issueId: targetIssueId,
+      documentId: targetDocumentId,
+      key: "latency-plan",
+    });
+
+    const noiseIssueValues: Array<typeof issues.$inferInsert> = [];
+    const noiseCommentValues: Array<typeof issueComments.$inferInsert> = [];
+    const noiseDocumentValues: Array<typeof documents.$inferInsert> = [];
+    const noiseIssueDocumentValues: Array<typeof issueDocuments.$inferInsert> = [];
+    for (let index = 0; index < 700; index += 1) {
+      const issueId = randomUUID();
+      const documentId = randomUUID();
+      noiseIssueValues.push({
+        id: issueId,
+        companyId,
+        identifier: `TST-${20_000 + index}`,
+        title: `Candidate routing noise ${index}`,
+        description: `Broad search latency noise description ${index}`,
+        status: "todo",
+        priority: "medium",
+      });
+      noiseCommentValues.push({
+        companyId,
+        issueId,
+        body: `Broad search latency noisy comment branch ${index}`,
+      });
+      noiseDocumentValues.push({
+        id: documentId,
+        companyId,
+        title: `Broad search latency noise document ${index}`,
+        latestBody: `Candidate preselection noisy document branch ${index}`,
+        format: "markdown",
+      });
+      noiseIssueDocumentValues.push({
+        companyId,
+        issueId,
+        documentId,
+        key: `broad-noise-${index}`,
+      });
+    }
+    await db.insert(issues).values(noiseIssueValues);
+    await db.insert(issueComments).values(noiseCommentValues);
+    await db.insert(documents).values(noiseDocumentValues);
+    await db.insert(issueDocuments).values(noiseIssueDocumentValues);
+
+    const parsedQuery = companySearchQuerySchema.parse({ q: "broad search latency", scope: "all", limit: "10" });
+    await svc.search(companyId, parsedQuery);
+
+    const timings: number[] = [];
+    for (let index = 0; index < 5; index += 1) {
+      const startedAt = performance.now();
+      const result = await svc.search(companyId, parsedQuery);
+      timings.push(performance.now() - startedAt);
+      expect(result.results.length).toBeGreaterThan(0);
+      expect(result.results.some((row) => row.matchedFields.includes("comment") || row.matchedFields.includes("document"))).toBe(true);
+    }
+
+    const p95 = timings.toSorted((left, right) => left - right)[Math.floor((timings.length - 1) * 0.95)] ?? Infinity;
+    expect(p95).toBeLessThan(2_000);
+  }, 20_000);
+
   it("matches multiple tokens across the same issue thread and returns comment snippets", async () => {
     const companyId = await createCompany();
     const issueId = await createIssue(companyId, {

--- a/server/src/__tests__/redact-sensitive.test.ts
+++ b/server/src/__tests__/redact-sensitive.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it } from "vitest";
+import { HTTP_LOG_REDACT_PATHS } from "../middleware/logger.js";
 import { redactSensitive } from "../middleware/redact-sensitive.js";
 
 describe("redactSensitive", () => {
+  it("redacts deploy relay token headers from request logs", () => {
+    expect(HTTP_LOG_REDACT_PATHS).toContain("req.headers.x-paperclip-deploy-token");
+  });
+
   it("redacts a plaintext password field on a sign-in body", () => {
     const body = { email: "user@example.com", password: "founding6gomez6croaking" };
 

--- a/server/src/__tests__/release-candidates-routes.test.ts
+++ b/server/src/__tests__/release-candidates-routes.test.ts
@@ -1,0 +1,248 @@
+import { createHash } from "node:crypto";
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { errorHandler } from "../middleware/index.js";
+import { releaseCandidateRoutes } from "../routes/release-candidates.js";
+
+const mockAssetService = vi.hoisted(() => ({
+  create: vi.fn(),
+}));
+
+const mockReleaseCandidateService = vi.hoisted(() => ({
+  getApprovedLease: vi.fn(),
+  recordDeployEvent: vi.fn(),
+  verifyRelayAuthorization: vi.fn(),
+  stageRelayArtifact: vi.fn(),
+}));
+
+vi.mock("../services/release-candidates.js", async () => {
+  const actual = await vi.importActual<typeof import("../services/release-candidates.js")>(
+    "../services/release-candidates.js",
+  );
+  return {
+    ...actual,
+    releaseCandidateService: () => mockReleaseCandidateService,
+  };
+});
+
+vi.mock("../services/assets.js", () => ({
+  assetService: () => mockAssetService,
+}));
+
+const companyId = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+
+function createApp(beforeRoutes?: express.RequestHandler) {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    req.actor = {
+      type: "agent",
+      source: "agent_jwt",
+      agentId: "dddddddd-dddd-4ddd-8ddd-dddddddddddd",
+      companyId,
+      runId: "eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee",
+    };
+    next();
+  });
+  if (beforeRoutes) app.use(beforeRoutes);
+  app.use("/api", releaseCandidateRoutes({} as never, {} as never));
+  app.use(errorHandler);
+  return app;
+}
+
+describe("release candidate routes", () => {
+  beforeEach(() => {
+    mockReleaseCandidateService.getApprovedLease.mockReset();
+    mockReleaseCandidateService.recordDeployEvent.mockReset();
+    mockReleaseCandidateService.verifyRelayAuthorization.mockReset();
+    mockReleaseCandidateService.stageRelayArtifact.mockReset();
+    mockAssetService.create.mockReset();
+  });
+
+  it("returns staged artifact digest fields and approval interaction id for approved leases", async () => {
+    const authorizationId = "99999999-9999-4999-8999-999999999999";
+    const approvalInteractionId = "ffffffff-ffff-4fff-8fff-ffffffffffff";
+    const stagedArtifactSha256 = "4444444444444444444444444444444444444444444444444444444444444444";
+    mockReleaseCandidateService.getApprovedLease.mockResolvedValue({
+      authorization: {
+        id: authorizationId,
+        candidateId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+        approvalInteractionId,
+        targetHost: "srv1749248",
+        imageDigest: "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+        environment: "production",
+        sequence: 42,
+        expiresAt: new Date("2026-07-14T14:00:00.000Z"),
+        leaseArtifactAssetId: "77777777-7777-4777-8777-777777777777",
+      },
+      candidate: {
+        id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+        companyId,
+        sourceIssueId: "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+        commitSha: "abc1234567890",
+        imageDigest: "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+        signatureBundleRef: "oci://registry.example/scanner/signature",
+        provenanceRef: "https://github.example/workflows/1/provenance",
+        sbomHash: "2222222222222222222222222222222222222222222222222222222222222222",
+        workflowRunUrl: "https://github.example/workflows/1",
+        stagedArtifactSha256,
+      },
+    });
+
+    const res = await request(createApp())
+      .get(`/api/release-candidates/approved-lease?authorizationId=${authorizationId}`)
+      .set("X-Paperclip-Deploy-Token", "pcdeploy_test-token");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      authorizationId,
+      approvalInteractionId,
+      stagedArtifactPath: "/api/assets/77777777-7777-4777-8777-777777777777/content",
+      stagedArtifactSha256,
+      tarballSha256: stagedArtifactSha256,
+    });
+    expect(res.body).not.toHaveProperty("token");
+    expect(mockReleaseCandidateService.getApprovedLease).toHaveBeenCalledWith(authorizationId, "pcdeploy_test-token");
+  });
+
+  it("rejects approved lease callers that omit the deploy token header", async () => {
+    const authorizationId = "99999999-9999-4999-8999-999999999999";
+
+    const res = await request(createApp())
+      .get(`/api/release-candidates/approved-lease?authorizationId=${authorizationId}`);
+
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBe("Missing deploy authorization token header");
+    expect(mockReleaseCandidateService.getApprovedLease).not.toHaveBeenCalled();
+  });
+
+  it("rejects deprecated query-string deploy tokens before service access", async () => {
+    const authorizationId = "99999999-9999-4999-8999-999999999999";
+
+    const res = await request(createApp())
+      .get(`/api/release-candidates/approved-lease?authorizationId=${authorizationId}&token=pcdeploy_query-token`)
+      .set("X-Paperclip-Deploy-Token", "pcdeploy_header-token");
+
+    expect(res.status).toBe(400);
+    expect(mockReleaseCandidateService.getApprovedLease).not.toHaveBeenCalled();
+  });
+
+  it("passes deploy-record tokens only from the header and keeps the request target token-free", async () => {
+    const authorizationId = "99999999-9999-4999-8999-999999999999";
+    const requestTargets: string[] = [];
+    mockReleaseCandidateService.recordDeployEvent.mockResolvedValue({
+      eventType: "deploy_started",
+      authorization: { id: authorizationId },
+      candidate: {
+        id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+        companyId,
+        sourceIssueId: "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+      },
+    });
+    const app = createApp((req, _res, next) => {
+      requestTargets.push(req.originalUrl);
+      next();
+    });
+
+    const res = await request(app)
+      .post("/api/release-candidates/deploy-records")
+      .set("X-Paperclip-Deploy-Token", "pcdeploy_header-token")
+      .send({ authorizationId, status: "started", commitSha: "abc1234567" });
+
+    expect(res.status).toBe(201);
+    expect(mockReleaseCandidateService.recordDeployEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ authorizationId, status: "started", token: "pcdeploy_header-token" }),
+      expect.any(Object),
+    );
+    expect(requestTargets).toEqual(["/api/release-candidates/deploy-records"]);
+    expect(JSON.stringify(requestTargets)).not.toContain("pcdeploy_header-token");
+  });
+
+  it("rejects deprecated body deploy tokens for deploy records", async () => {
+    const authorizationId = "99999999-9999-4999-8999-999999999999";
+
+    const res = await request(createApp())
+      .post("/api/release-candidates/deploy-records")
+      .set("X-Paperclip-Deploy-Token", "pcdeploy_header-token")
+      .send({ authorizationId, token: "pcdeploy_body-token", status: "started" });
+
+    expect(res.status).toBe(400);
+    expect(mockReleaseCandidateService.recordDeployEvent).not.toHaveBeenCalled();
+  });
+
+  it("passes stage-relay artifact tokens only from the header", async () => {
+    const authorizationId = "99999999-9999-4999-8999-999999999999";
+    const tarball = Buffer.from("scanner relay artifact");
+    const tarballSha256 = `sha256:${createHash("sha256").update(tarball).digest("hex")}`;
+    mockReleaseCandidateService.verifyRelayAuthorization.mockResolvedValue({
+      authorization: { id: authorizationId },
+      candidate: {
+        id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+        companyId,
+        sourceIssueId: "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+      },
+    });
+    mockAssetService.create.mockResolvedValue({ id: "77777777-7777-4777-8777-777777777777" });
+    mockReleaseCandidateService.stageRelayArtifact.mockResolvedValue({
+      id: authorizationId,
+      candidateId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      leaseArtifactAssetId: "77777777-7777-4777-8777-777777777777",
+      targetHost: "srv1749248",
+      imageDigest: "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+      environment: "production",
+      sequence: 42,
+      leaseIssuedAt: new Date("2026-07-14T14:00:00.000Z"),
+    });
+    const storage = {
+      putFile: vi.fn().mockResolvedValue({
+        provider: "local_disk",
+        objectKey: "release-candidates/artifact.tar",
+        contentType: "application/x-tar",
+        byteSize: tarball.length,
+        sha256: tarballSha256.replace(/^sha256:/, ""),
+        originalFilename: "scanner-release-candidate.tar",
+      }),
+    };
+    const app = express();
+    app.use(express.json());
+    app.use((req, _res, next) => {
+      req.actor = {
+        type: "agent",
+        source: "agent_jwt",
+        agentId: "dddddddd-dddd-4ddd-8ddd-dddddddddddd",
+        companyId,
+        runId: "eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee",
+      };
+      next();
+    });
+    app.use("/api", releaseCandidateRoutes({} as never, storage as never));
+    app.use(errorHandler);
+
+    const res = await request(app)
+      .post(`/api/release-deploy-authorizations/${authorizationId}/stage-relay-artifact`)
+      .set("X-Paperclip-Deploy-Token", "pcdeploy_header-token")
+      .send({
+        imageDigest: "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+        sbomHash: "2222222222222222222222222222222222222222222222222222222222222222",
+        signatureVerified: true,
+        sbomVerified: true,
+        tarballSha256,
+        tarballBase64: tarball.toString("base64"),
+      });
+
+    expect(res.status).toBe(201);
+    expect(mockReleaseCandidateService.verifyRelayAuthorization).toHaveBeenCalledWith(
+      authorizationId,
+      "pcdeploy_header-token",
+      expect.objectContaining({ tarballSha256: tarballSha256.replace(/^sha256:/, "") }),
+    );
+    expect(mockReleaseCandidateService.stageRelayArtifact).toHaveBeenCalledWith(
+      authorizationId,
+      "pcdeploy_header-token",
+      expect.any(Object),
+      "77777777-7777-4777-8777-777777777777",
+      expect.any(Object),
+    );
+  });
+});

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -44,6 +44,7 @@ import {
 import { llmRoutes } from "./routes/llms.js";
 import { authRoutes } from "./routes/auth.js";
 import { assetRoutes } from "./routes/assets.js";
+import { releaseCandidateRoutes } from "./routes/release-candidates.js";
 import { accessRoutes } from "./routes/access.js";
 import { pluginRoutes } from "./routes/plugins.js";
 import { adapterRoutes } from "./routes/adapters.js";
@@ -225,6 +226,7 @@ export async function createApp(
   api.use(teamsCatalogRoutes(db));
   api.use(agentRoutes(db, { pluginWorkerManager: workerManager }));
   api.use(assetRoutes(db, opts.storageService));
+  api.use(releaseCandidateRoutes(db, opts.storageService));
   api.use(projectRoutes(db));
   api.use(issueRoutes(db, opts.storageService, {
     feedbackExportService: opts.feedbackExportService,

--- a/server/src/middleware/logger.ts
+++ b/server/src/middleware/logger.ts
@@ -28,9 +28,11 @@ const sharedOpts = {
   singleLine: true,
 };
 
+export const HTTP_LOG_REDACT_PATHS = ["req.headers.authorization", "req.headers.x-paperclip-deploy-token"];
+
 export const logger = pino({
   level: "debug",
-  redact: ["req.headers.authorization"],
+  redact: HTTP_LOG_REDACT_PATHS,
 }, pino.transport({
   targets: [
     {

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -5,6 +5,7 @@ export { teamsCatalogRoutes } from "./teams-catalog.js";
 export { agentRoutes } from "./agents.js";
 export { projectRoutes } from "./projects.js";
 export { issueRoutes } from "./issues.js";
+export { releaseCandidateRoutes } from "./release-candidates.js";
 export { issueTreeControlRoutes } from "./issue-tree-control.js";
 export { fileResourceRoutes, createFileResourceLimiter } from "./file-resources.js";
 export { routineRoutes } from "./routines.js";

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -152,6 +152,7 @@ import {
   type TrustPresetResolution,
 } from "../services/trust-preset-resolver.js";
 import { externalObjectService } from "../services/external-objects.js";
+import { releaseCandidateService } from "../services/release-candidates.js";
 
 const MAX_ISSUE_COMMENT_LIMIT = 500;
 const updateIssueRouteSchema = updateIssueSchema.extend({
@@ -7138,6 +7139,31 @@ export function issueRoutes(
         forceFreshSession: acceptedPlanConfirmation,
         workspaceRefreshReason: acceptedPlanConfirmation ? "accepted_plan_confirmation" : null,
       });
+
+      const deployAuthorization = await releaseCandidateService(db).handleAcceptedInteraction(issue.id, interaction, {
+        agentId: actor.agentId,
+        userId: actor.actorType === "user" ? actor.actorId : null,
+        runId: actor.runId,
+      });
+
+      if (deployAuthorization) {
+        res.json({
+          interaction,
+          deployAuthorization: {
+            id: deployAuthorization.authorization.id,
+            candidateId: deployAuthorization.authorization.candidateId,
+            token: deployAuthorization.token,
+            tokenReturnedOnce: deployAuthorization.token !== null,
+            alreadyIssued: deployAuthorization.alreadyIssued,
+            targetHost: deployAuthorization.authorization.targetHost,
+            imageDigest: deployAuthorization.authorization.imageDigest,
+            environment: deployAuthorization.authorization.environment,
+            sequence: deployAuthorization.authorization.sequence,
+            expiresAt: deployAuthorization.authorization.expiresAt,
+          },
+        });
+        return;
+      }
 
       res.json(interaction);
     },

--- a/server/src/routes/release-candidates.ts
+++ b/server/src/routes/release-candidates.ts
@@ -1,0 +1,275 @@
+import { createHash } from "node:crypto";
+import { Router } from "express";
+import type { Request } from "express";
+import { z } from "zod";
+import type { Db } from "@paperclipai/db";
+import type { StorageService } from "../storage/types.js";
+import { validate } from "../middleware/validate.js";
+import { badRequest, notFound, unauthorized } from "../errors.js";
+import { assertCompanyAccess, getActorInfo } from "./authz.js";
+import { assetService } from "../services/assets.js";
+import { issueService } from "../services/issues.js";
+import { issueThreadInteractionService } from "../services/issue-thread-interactions.js";
+import { releaseCandidateService } from "../services/release-candidates.js";
+
+const digestSchema = z.string().trim().min(12).max(300);
+const sha256Schema = z.string().trim().regex(/^(sha256:)?[a-fA-F0-9]{64}$/, "Expected SHA-256 hash");
+
+const createReleaseCandidateSchema = z.object({
+  sourceIssueId: z.string().uuid(),
+  commitSha: z.string().trim().min(7).max(80),
+  imageDigest: digestSchema,
+  signatureBundleRef: z.string().trim().min(1).max(2000),
+  provenanceRef: z.string().trim().min(1).max(2000),
+  sbomHash: sha256Schema,
+  workflowRunUrl: z.string().trim().url().max(2000),
+  environment: z.string().trim().min(1).max(120),
+  targetHost: z.string().trim().min(1).max(255),
+  sequence: z.number().int().positive(),
+  documentRevisionId: z.string().trim().min(1).max(255).nullable().optional(),
+  metadata: z.record(z.unknown()).optional(),
+}).strict();
+
+const updateReleaseCandidateSchema = z.object({
+  signatureBundleRef: z.string().trim().min(1).max(2000).optional(),
+  provenanceRef: z.string().trim().min(1).max(2000).optional(),
+  workflowRunUrl: z.string().trim().url().max(2000).optional(),
+  documentRevisionId: z.string().trim().min(1).max(255).nullable().optional(),
+  metadata: z.record(z.unknown()).optional(),
+}).strict();
+
+const createApprovalInteractionSchema = z.object({}).strict();
+const DEPLOY_TOKEN_HEADER = "x-paperclip-deploy-token";
+
+const approvedLeaseQuerySchema = z.object({
+  authorizationId: z.string().uuid(),
+}).strict();
+
+const stageRelayArtifactSchema = z.object({
+  imageDigest: digestSchema,
+  sbomHash: sha256Schema,
+  signatureVerified: z.boolean(),
+  sbomVerified: z.boolean(),
+  tarballSha256: sha256Schema,
+  tarballBase64: z.string().trim().min(1),
+  originalFilename: z.string().trim().min(1).max(255).nullable().optional(),
+}).strict();
+
+const deployRecordSchema = z.object({
+  authorizationId: z.string().uuid(),
+  status: z.enum(["started", "succeeded", "failed", "rolled_back"]),
+  message: z.string().trim().max(2000).nullable().optional(),
+  commitSha: z.string().trim().min(7).max(80).nullable().optional(),
+  healthStatus: z.string().trim().max(200).nullable().optional(),
+  rollbackReason: z.string().trim().max(2000).nullable().optional(),
+  metadata: z.record(z.unknown()).optional(),
+}).strict();
+
+function readDeployTokenHeader(req: Request) {
+  const token = req.header(DEPLOY_TOKEN_HEADER)?.trim();
+  if (!token) throw unauthorized("Missing deploy authorization token header");
+  return token;
+}
+
+export function releaseCandidateRoutes(db: Db, storage: StorageService) {
+  const router = Router();
+  const candidates = releaseCandidateService(db);
+
+  router.post(
+    "/companies/:companyId/release-candidates",
+    validate(createReleaseCandidateSchema),
+    async (req, res) => {
+      const companyId = req.params.companyId as string;
+      assertCompanyAccess(req, companyId);
+      const actor = getActorInfo(req);
+      const sourceIssue = await issueService(db).getById(req.body.sourceIssueId);
+      if (!sourceIssue || sourceIssue.companyId !== companyId) {
+        throw notFound("Source issue not found");
+      }
+      const candidate = await candidates.create({
+        ...req.body,
+        companyId,
+      }, {
+        agentId: actor.agentId,
+        userId: actor.actorType === "user" ? actor.actorId : null,
+        runId: actor.runId,
+      });
+      res.status(201).json(candidate);
+    },
+  );
+
+  router.get("/release-candidates/approved-lease", async (req, res) => {
+    const query = approvedLeaseQuerySchema.parse(req.query);
+    const token = readDeployTokenHeader(req);
+    const { authorization, candidate } = await candidates.getApprovedLease(query.authorizationId, token);
+    assertCompanyAccess(req, candidate.companyId);
+    res.json({
+      authorizationId: authorization.id,
+      candidateId: candidate.id,
+      sourceIssueId: candidate.sourceIssueId,
+      commitSha: candidate.commitSha,
+      imageDigest: candidate.imageDigest,
+      signatureBundleRef: candidate.signatureBundleRef,
+      provenanceRef: candidate.provenanceRef,
+      sbomHash: candidate.sbomHash,
+      workflowRunUrl: candidate.workflowRunUrl,
+      targetHost: authorization.targetHost,
+      environment: authorization.environment,
+      sequence: authorization.sequence,
+      expiresAt: authorization.expiresAt,
+      stageRelayArtifactPath: `/api/release-deploy-authorizations/${authorization.id}/stage-relay-artifact`,
+      deployRecordPath: "/api/release-candidates/deploy-records",
+      stagedArtifactPath: authorization.leaseArtifactAssetId
+        ? `/api/assets/${authorization.leaseArtifactAssetId}/content`
+        : null,
+      stagedArtifactSha256: candidate.stagedArtifactSha256,
+      tarballSha256: candidate.stagedArtifactSha256,
+      approvalInteractionId: authorization.approvalInteractionId,
+    });
+  });
+
+  router.post(
+    "/release-candidates/deploy-records",
+    validate(deployRecordSchema),
+    async (req, res) => {
+      const actor = getActorInfo(req);
+      const token = readDeployTokenHeader(req);
+      const result = await candidates.recordDeployEvent({ ...req.body, token }, {
+        agentId: actor.agentId,
+        userId: actor.actorType === "user" ? actor.actorId : null,
+        runId: actor.runId,
+      });
+      assertCompanyAccess(req, result.candidate.companyId);
+      res.status(201).json({
+        ok: true,
+        eventType: result.eventType,
+        authorizationId: result.authorization.id,
+        candidateId: result.candidate.id,
+        sourceIssueId: result.candidate.sourceIssueId,
+      });
+    },
+  );
+
+  router.get("/release-candidates/:candidateId", async (req, res) => {
+    const candidate = await candidates.getById(req.params.candidateId as string);
+    if (!candidate) throw notFound("Release candidate not found");
+    assertCompanyAccess(req, candidate.companyId);
+    res.json(candidate);
+  });
+
+  router.patch(
+    "/release-candidates/:candidateId",
+    validate(updateReleaseCandidateSchema),
+    async (req, res) => {
+      const candidate = await candidates.getById(req.params.candidateId as string);
+      if (!candidate) throw notFound("Release candidate not found");
+      assertCompanyAccess(req, candidate.companyId);
+      const actor = getActorInfo(req);
+      const updated = await candidates.updateMutable(candidate.id, req.body, {
+        agentId: actor.agentId,
+        userId: actor.actorType === "user" ? actor.actorId : null,
+        runId: actor.runId,
+      });
+      res.json(updated);
+    },
+  );
+
+  router.post(
+    "/release-candidates/:candidateId/approval-interaction",
+    validate(createApprovalInteractionSchema),
+    async (req, res) => {
+      const candidate = await candidates.getById(req.params.candidateId as string);
+      if (!candidate) throw notFound("Release candidate not found");
+      assertCompanyAccess(req, candidate.companyId);
+      const actor = getActorInfo(req);
+      const sourceIssue = await issueService(db).getById(candidate.sourceIssueId);
+      if (!sourceIssue) throw notFound("Source issue not found");
+      const interactionInput = candidates.buildApprovalInteractionInput(candidate);
+      const interaction = await issueThreadInteractionService(db).create(sourceIssue, interactionInput, {
+        agentId: actor.agentId,
+        userId: actor.actorType === "user" ? actor.actorId : null,
+      });
+      const updated = await candidates.markApprovalInteractionCreated(candidate.id, interaction, {
+        agentId: actor.agentId,
+        userId: actor.actorType === "user" ? actor.actorId : null,
+        runId: actor.runId,
+      });
+      res.status(201).json({ candidate: updated, interaction });
+    },
+  );
+
+  router.post(
+    "/release-deploy-authorizations/:authorizationId/stage-relay-artifact",
+    validate(stageRelayArtifactSchema),
+    async (req, res) => {
+      const body = req.body as z.infer<typeof stageRelayArtifactSchema>;
+      const token = readDeployTokenHeader(req);
+      const tarballBytes = Buffer.from(body.tarballBase64, "base64");
+      if (tarballBytes.length <= 0) throw badRequest("tarballBase64 decoded to an empty artifact");
+      const actualTarballSha = createHash("sha256").update(tarballBytes).digest("hex");
+      const expectedTarballSha = body.tarballSha256.replace(/^sha256:/, "").toLowerCase();
+      if (actualTarballSha !== expectedTarballSha) throw badRequest("tarballBase64 does not match tarballSha256");
+
+      const actor = getActorInfo(req);
+      const { candidate } = await candidates.verifyRelayAuthorization(req.params.authorizationId as string, token, {
+        imageDigest: body.imageDigest,
+        sbomHash: body.sbomHash,
+        signatureVerified: body.signatureVerified,
+        sbomVerified: body.sbomVerified,
+        tarballSha256: expectedTarballSha,
+      });
+      assertCompanyAccess(req, candidate.companyId);
+      const stored = await storage.putFile({
+        companyId: candidate.companyId,
+        namespace: "release-candidates",
+        originalFilename: body.originalFilename ?? "scanner-release-candidate.tar",
+        contentType: "application/x-tar",
+        body: tarballBytes,
+      });
+      const asset = await assetService(db).create(candidate.companyId, {
+        provider: stored.provider,
+        objectKey: stored.objectKey,
+        contentType: stored.contentType,
+        byteSize: stored.byteSize,
+        sha256: stored.sha256,
+        originalFilename: stored.originalFilename,
+        createdByAgentId: actor.agentId,
+        createdByUserId: actor.actorType === "user" ? actor.actorId : null,
+      });
+      const authorization = await candidates.stageRelayArtifact(
+        req.params.authorizationId as string,
+        token,
+        {
+          imageDigest: body.imageDigest,
+          sbomHash: body.sbomHash,
+          signatureVerified: body.signatureVerified,
+          sbomVerified: body.sbomVerified,
+          tarballSha256: expectedTarballSha,
+          tarballBytes,
+          originalFilename: body.originalFilename ?? null,
+        },
+        asset.id,
+        {
+          agentId: actor.agentId,
+          userId: actor.actorType === "user" ? actor.actorId : null,
+          runId: actor.runId,
+        },
+      );
+      res.status(201).json({
+        authorizationId: authorization.id,
+        candidateId: authorization.candidateId,
+        lease: {
+          assetId: authorization.leaseArtifactAssetId,
+          artifactPath: `/api/assets/${authorization.leaseArtifactAssetId}/content`,
+          targetHost: authorization.targetHost,
+          imageDigest: authorization.imageDigest,
+          environment: authorization.environment,
+          sequence: authorization.sequence,
+          leaseIssuedAt: authorization.leaseIssuedAt,
+        },
+      });
+    },
+  );
+
+  return router;
+}

--- a/server/src/services/company-search.ts
+++ b/server/src/services/company-search.ts
@@ -33,6 +33,7 @@ const FUZZY_PAIR_SHORT_MAX_EDITS = 0;
 const FUZZY_IDENTIFIER_SIMILARITY_THRESHOLD = 0.45;
 const SNIPPET_MAX_CHARS = 240;
 const ISSUE_IDENTIFIER_QUERY_PATTERN = /^[a-z][a-z0-9]*-\d+$/i;
+const COMPANY_SEARCH_MAX_ISSUE_CANDIDATES = 1000;
 export const COMPANY_SEARCH_BRANCH_FETCH_LIMIT = COMPANY_SEARCH_MAX_OFFSET + COMPANY_SEARCH_MAX_LIMIT + 1;
 
 type IssueSearchRow = {
@@ -99,6 +100,16 @@ function tokenMatchExpression(textExpression: SQL, tokenArray: SQL) {
       FROM unnest(${tokenArray}) AS search_token(value)
       WHERE lower(coalesce(${textExpression}, '')) LIKE '%' || search_token.value || '%' ESCAPE '\\'
     )
+  `;
+}
+
+function lowerLikeAnyExpression(textExpression: SQL, patterns: string[], options: { coalesce?: boolean } = {}) {
+  if (patterns.length === 0) return noMatchSql();
+  const lowered = options.coalesce
+    ? sql`lower(coalesce(${textExpression}, ''))`
+    : sql`lower(${textExpression})`;
+  return sql<boolean>`
+    (${sql.join(patterns.map((pattern) => sql`${lowered} LIKE ${pattern} ESCAPE '\\'`), sql` OR `)})
   `;
 }
 
@@ -391,6 +402,9 @@ export function companySearchService(db: Db) {
       const escapedQuery = escapeLikePattern(normalizedQuery);
       const containsPattern = `%${escapedQuery}%`;
       const startsWithPattern = `${escapedQuery}%`;
+      const tokenContainsPatterns = escapedTokens.map((token) => `%${token}%`);
+      const textSearchPatterns = [containsPattern, ...tokenContainsPatterns]
+        .filter((pattern, index, patterns) => patterns.indexOf(pattern) === index);
       const fuzzyEnabled = normalizedQuery.length >= MIN_FUZZY_QUERY_LENGTH && !/[\\%_]/.test(normalizedQuery);
       const fuzzyTokensEnabled = fuzzyEnabled && fuzzyTokens.length > 0;
 
@@ -447,9 +461,9 @@ export function companySearchService(db: Db) {
       const identifierPhraseMatch = sql<boolean>`lower(coalesce(${issues.identifier}, '')) LIKE ${containsPattern} ESCAPE '\\'`;
       const identifierStartsWith = sql<boolean>`lower(coalesce(${issues.identifier}, '')) LIKE ${startsWithPattern} ESCAPE '\\'`;
       const descriptionPhraseMatch = sql<boolean>`lower(coalesce(${issues.description}, '')) LIKE ${containsPattern} ESCAPE '\\'`;
-      const titleTokenMatch = tokenMatchExpression(sql`${issues.title}`, tokenArray);
-      const identifierTokenMatch = tokenMatchExpression(sql`${issues.identifier}`, tokenArray);
-      const descriptionTokenMatch = tokenMatchExpression(sql`${issues.description}`, tokenArray);
+      const titleTokenMatch = lowerLikeAnyExpression(sql`${issues.title}`, tokenContainsPatterns);
+      const identifierTokenMatch = lowerLikeAnyExpression(sql`${issues.identifier}`, tokenContainsPatterns, { coalesce: true });
+      const descriptionTokenMatch = lowerLikeAnyExpression(sql`${issues.description}`, tokenContainsPatterns, { coalesce: true });
       const issueTextMatch = sql<boolean>`
         ${titlePhraseMatch}
         OR ${identifierPhraseMatch}
@@ -466,8 +480,7 @@ export function companySearchService(db: Db) {
             AND search_comments.issue_id = issues.id
             AND search_comments.deleted_at IS NULL
             AND (
-              lower(search_comments.body) LIKE ${containsPattern} ESCAPE '\\'
-              OR ${tokenMatchExpression(sql`search_comments.body`, tokenArray)}
+              ${lowerLikeAnyExpression(sql`search_comments.body`, textSearchPatterns)}
             )
         )
       `;
@@ -481,10 +494,8 @@ export function companySearchService(db: Db) {
             AND search_documents.company_id = ${companyId}
             AND search_issue_documents.issue_id = issues.id
             AND (
-              lower(coalesce(search_documents.title, '')) LIKE ${containsPattern} ESCAPE '\\'
-              OR lower(search_documents.latest_body) LIKE ${containsPattern} ESCAPE '\\'
-              OR ${tokenMatchExpression(sql`search_documents.title`, tokenArray)}
-              OR ${tokenMatchExpression(sql`search_documents.latest_body`, tokenArray)}
+              ${lowerLikeAnyExpression(sql`search_documents.title`, textSearchPatterns, { coalesce: true })}
+              OR ${lowerLikeAnyExpression(sql`search_documents.latest_body`, textSearchPatterns)}
             )
         )
       `;
@@ -582,6 +593,86 @@ export function companySearchService(db: Db) {
           CASE WHEN ${documentMatch} THEN 'document' END
         ], NULL)::text[]
       `;
+      const candidateLimit = Math.min(COMPANY_SEARCH_MAX_ISSUE_CANDIDATES, Math.max(fetchLimit * 8, fetchLimit));
+      const candidateFuzzyTokenTitleMatch = fuzzyTokensEnabled
+        ? sql<boolean>`
+          coalesce((
+            SELECT bool_and(
+              EXISTS (
+                SELECT 1
+                FROM regexp_split_to_table(lower(candidate_issues.title), '[^a-z0-9]+') AS title_word(value)
+                WHERE length(title_word.value) >= ${fuzzyMinTitleWordLengthExpr}
+                  AND levenshtein_less_equal(qt.value, title_word.value, ${fuzzyMaxEditsExpr}) <= ${fuzzyMaxEditsExpr}
+              )
+            )
+            FROM unnest(${fuzzyTokenArray}) AS qt(value)
+          ), false)
+        `
+        : noMatchSql();
+      const candidateFuzzyIdentifierMatch = fuzzyEnabled
+        ? sql<boolean>`similarity(lower(coalesce(candidate_issues.identifier, '')), ${normalizedQuery}) >= ${FUZZY_IDENTIFIER_SIMILARITY_THRESHOLD}`
+        : noMatchSql();
+      const issueTextCandidateMatch = sql<boolean>`
+        ${lowerLikeAnyExpression(sql`candidate_issues.title`, textSearchPatterns)}
+        OR ${lowerLikeAnyExpression(sql`candidate_issues.identifier`, textSearchPatterns, { coalesce: true })}
+        OR ${lowerLikeAnyExpression(sql`candidate_issues.description`, textSearchPatterns, { coalesce: true })}
+        OR ${candidateFuzzyTokenTitleMatch}
+        OR ${candidateFuzzyIdentifierMatch}
+      `;
+      const commentCandidateMatch = lowerLikeAnyExpression(sql`candidate_comments.body`, textSearchPatterns);
+      const documentCandidateMatch = sql<boolean>`
+        ${lowerLikeAnyExpression(sql`candidate_documents.title`, textSearchPatterns, { coalesce: true })}
+        OR ${lowerLikeAnyExpression(sql`candidate_documents.latest_body`, textSearchPatterns)}
+      `;
+      const candidateSelects: SQL[] = [];
+      if (scope === "all" || scope === "issues") {
+        candidateSelects.push(sql`
+          SELECT candidate_issues.id AS issue_id
+          FROM issues candidate_issues
+          WHERE candidate_issues.company_id = ${companyId}
+            AND candidate_issues.hidden_at IS NULL
+            AND (${issueTextCandidateMatch})
+          ORDER BY candidate_issues.updated_at DESC, candidate_issues.id DESC
+          LIMIT ${candidateLimit}
+        `);
+      }
+      if (scope === "all" || scope === "comments") {
+        candidateSelects.push(sql`
+          SELECT candidate_comments.issue_id
+          FROM issue_comments candidate_comments
+          INNER JOIN issues candidate_comment_issues
+            ON candidate_comment_issues.id = candidate_comments.issue_id
+          WHERE candidate_comments.company_id = ${companyId}
+            AND candidate_comments.deleted_at IS NULL
+            AND candidate_comment_issues.company_id = ${companyId}
+            AND candidate_comment_issues.hidden_at IS NULL
+            AND (${commentCandidateMatch})
+          GROUP BY candidate_comments.issue_id
+          ORDER BY max(candidate_comments.updated_at) DESC, candidate_comments.issue_id DESC
+          LIMIT ${candidateLimit}
+        `);
+      }
+      if (scope === "all" || scope === "documents") {
+        candidateSelects.push(sql`
+          SELECT candidate_issue_documents.issue_id
+          FROM issue_documents candidate_issue_documents
+          INNER JOIN documents candidate_documents
+            ON candidate_documents.id = candidate_issue_documents.document_id
+          INNER JOIN issues candidate_document_issues
+            ON candidate_document_issues.id = candidate_issue_documents.issue_id
+          WHERE candidate_issue_documents.company_id = ${companyId}
+            AND candidate_documents.company_id = ${companyId}
+            AND candidate_document_issues.company_id = ${companyId}
+            AND candidate_document_issues.hidden_at IS NULL
+            AND (${documentCandidateMatch})
+          GROUP BY candidate_issue_documents.issue_id
+          ORDER BY max(candidate_documents.updated_at) DESC, candidate_issue_documents.issue_id DESC
+          LIMIT ${candidateLimit}
+        `);
+      }
+      const candidateIssueFilter = candidateSelects.length > 0
+        ? sql<boolean>`${issues.id} IN (${sql.join(candidateSelects.map((candidateSelect) => sql`(${candidateSelect})`), sql` UNION `)})`
+        : noMatchSql();
 
       const issueRows = scopeIncludesIssues(scope)
         ? await db
@@ -606,8 +697,7 @@ export function companySearchService(db: Db) {
                   AND search_comments.issue_id = issues.id
                   AND search_comments.deleted_at IS NULL
                   AND (
-                    lower(search_comments.body) LIKE ${containsPattern} ESCAPE '\\'
-                    OR ${tokenMatchExpression(sql`search_comments.body`, tokenArray)}
+                    ${lowerLikeAnyExpression(sql`search_comments.body`, textSearchPatterns)}
                   )
                 ORDER BY
                   CASE WHEN lower(search_comments.body) LIKE ${containsPattern} ESCAPE '\\' THEN 0 ELSE 1 END,
@@ -624,8 +714,7 @@ export function companySearchService(db: Db) {
                   AND search_comments.issue_id = issues.id
                   AND search_comments.deleted_at IS NULL
                   AND (
-                    lower(search_comments.body) LIKE ${containsPattern} ESCAPE '\\'
-                    OR ${tokenMatchExpression(sql`search_comments.body`, tokenArray)}
+                    ${lowerLikeAnyExpression(sql`search_comments.body`, textSearchPatterns)}
                   )
                 ORDER BY
                   CASE WHEN lower(search_comments.body) LIKE ${containsPattern} ESCAPE '\\' THEN 0 ELSE 1 END,
@@ -644,10 +733,8 @@ export function companySearchService(db: Db) {
                   AND search_documents.company_id = ${companyId}
                   AND search_issue_documents.issue_id = issues.id
                   AND (
-                    lower(coalesce(search_documents.title, '')) LIKE ${containsPattern} ESCAPE '\\'
-                    OR lower(search_documents.latest_body) LIKE ${containsPattern} ESCAPE '\\'
-                    OR ${tokenMatchExpression(sql`search_documents.title`, tokenArray)}
-                    OR ${tokenMatchExpression(sql`search_documents.latest_body`, tokenArray)}
+                    ${lowerLikeAnyExpression(sql`search_documents.title`, textSearchPatterns, { coalesce: true })}
+                    OR ${lowerLikeAnyExpression(sql`search_documents.latest_body`, textSearchPatterns)}
                   )
                 ORDER BY
                   CASE
@@ -670,10 +757,8 @@ export function companySearchService(db: Db) {
                   AND search_documents.company_id = ${companyId}
                   AND search_issue_documents.issue_id = issues.id
                   AND (
-                    lower(coalesce(search_documents.title, '')) LIKE ${containsPattern} ESCAPE '\\'
-                    OR lower(search_documents.latest_body) LIKE ${containsPattern} ESCAPE '\\'
-                    OR ${tokenMatchExpression(sql`search_documents.title`, tokenArray)}
-                    OR ${tokenMatchExpression(sql`search_documents.latest_body`, tokenArray)}
+                    ${lowerLikeAnyExpression(sql`search_documents.title`, textSearchPatterns, { coalesce: true })}
+                    OR ${lowerLikeAnyExpression(sql`search_documents.latest_body`, textSearchPatterns)}
                   )
                 ORDER BY search_documents.updated_at DESC, search_documents.id DESC
                 LIMIT 1
@@ -689,10 +774,8 @@ export function companySearchService(db: Db) {
                   AND search_documents.company_id = ${companyId}
                   AND search_issue_documents.issue_id = issues.id
                   AND (
-                    lower(coalesce(search_documents.title, '')) LIKE ${containsPattern} ESCAPE '\\'
-                    OR lower(search_documents.latest_body) LIKE ${containsPattern} ESCAPE '\\'
-                    OR ${tokenMatchExpression(sql`search_documents.title`, tokenArray)}
-                    OR ${tokenMatchExpression(sql`search_documents.latest_body`, tokenArray)}
+                    ${lowerLikeAnyExpression(sql`search_documents.title`, textSearchPatterns, { coalesce: true })}
+                    OR ${lowerLikeAnyExpression(sql`search_documents.latest_body`, textSearchPatterns)}
                   )
                 ORDER BY search_documents.updated_at DESC, search_documents.id DESC
                 LIMIT 1
@@ -703,6 +786,7 @@ export function companySearchService(db: Db) {
           .where(and(
             eq(issues.companyId, companyId),
             isNull(issues.hiddenAt),
+            candidateIssueFilter,
             issueSearchCondition(scope, { issueTextMatch, commentMatch, documentMatch, fuzzyMatch }),
           ))
           .orderBy(desc(score), desc(issues.updatedAt), desc(issues.id))

--- a/server/src/services/company-search.ts
+++ b/server/src/services/company-search.ts
@@ -32,6 +32,7 @@ const FUZZY_PAIR_MEDIUM_MAX_EDITS = 1;
 const FUZZY_PAIR_SHORT_MAX_EDITS = 0;
 const FUZZY_IDENTIFIER_SIMILARITY_THRESHOLD = 0.45;
 const SNIPPET_MAX_CHARS = 240;
+const ISSUE_IDENTIFIER_QUERY_PATTERN = /^[a-z][a-z0-9]*-\d+$/i;
 export const COMPANY_SEARCH_BRANCH_FETCH_LIMIT = COMPANY_SEARCH_MAX_OFFSET + COMPANY_SEARCH_MAX_LIMIT + 1;
 
 type IssueSearchRow = {
@@ -200,6 +201,10 @@ function makeCounts(results: CompanySearchResult[]) {
 
 function scopeIncludesIssues(scope: CompanySearchScope) {
   return scope === "all" || scope === "issues" || scope === "comments" || scope === "documents";
+}
+
+function scopeAllowsIdentifierFastPath(scope: CompanySearchScope) {
+  return scope === "all" || scope === "issues";
 }
 
 function scopeIncludesAgents(scope: CompanySearchScope) {
@@ -388,6 +393,54 @@ export function companySearchService(db: Db) {
       const startsWithPattern = `${escapedQuery}%`;
       const fuzzyEnabled = normalizedQuery.length >= MIN_FUZZY_QUERY_LENGTH && !/[\\%_]/.test(normalizedQuery);
       const fuzzyTokensEnabled = fuzzyEnabled && fuzzyTokens.length > 0;
+
+      if (scopeAllowsIdentifierFastPath(scope) && ISSUE_IDENTIFIER_QUERY_PATTERN.test(normalizedQuery)) {
+        const exactIdentifierRows = await db
+          .select({
+            id: issues.id,
+            identifier: issues.identifier,
+            title: issues.title,
+            description: issues.description,
+            status: issues.status,
+            priority: issues.priority,
+            assigneeAgentId: issues.assigneeAgentId,
+            assigneeUserId: issues.assigneeUserId,
+            projectId: issues.projectId,
+            updatedAt: issues.updatedAt,
+          })
+          .from(issues)
+          .where(and(
+            eq(issues.companyId, companyId),
+            isNull(issues.hiddenAt),
+            sql<boolean>`lower(coalesce(${issues.identifier}, '')) = ${normalizedQuery}`,
+          ))
+          .orderBy(desc(issues.updatedAt), desc(issues.id))
+          .limit(offset + limit + 1);
+
+        if (exactIdentifierRows.length > 0) {
+          const exactIssueRows: IssueSearchRow[] = exactIdentifierRows.map((row) => ({
+            ...row,
+            score: 2000,
+            matchedFields: ["identifier"],
+            commentSnippet: null,
+            commentId: null,
+            documentSnippet: null,
+            documentTitle: null,
+            documentKey: null,
+          }));
+          const paged = exactIssueRows.slice(offset, offset + limit);
+          return {
+            query: query.q,
+            normalizedQuery,
+            scope,
+            limit,
+            offset,
+            results: paged.map((row) => issueResult(row, prefix, normalizedQuery, tokens)),
+            countsByType: { ...emptyCounts, issue: exactIssueRows.length },
+            hasMore: exactIssueRows.length > offset + limit,
+          };
+        }
+      }
 
       const titlePhraseMatch = sql<boolean>`lower(${issues.title}) LIKE ${containsPattern} ESCAPE '\\'`;
       const titleStartsWith = sql<boolean>`lower(${issues.title}) LIKE ${startsWithPattern} ESCAPE '\\'`;

--- a/server/src/services/release-candidates.test.ts
+++ b/server/src/services/release-candidates.test.ts
@@ -1,0 +1,316 @@
+import { createHash } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { HttpError } from "../errors.js";
+import { releaseCandidateService, verifyRelayArtifact } from "./release-candidates.js";
+
+const candidate = {
+  id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+  companyId: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+  sourceIssueId: "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+  createdByAgentId: "dddddddd-dddd-4ddd-8ddd-dddddddddddd",
+  createdByRunId: "eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee",
+  commitSha: "abc1234567890",
+  imageDigest: "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+  signatureBundleRef: "oci://registry.example/scanner/signature",
+  provenanceRef: "https://github.example/workflows/1/provenance",
+  sbomHash: "2222222222222222222222222222222222222222222222222222222222222222",
+  workflowRunUrl: "https://github.example/workflows/1",
+  environment: "production",
+  targetHost: "srv1749248",
+  sequence: 42,
+  documentRevisionId: "doc-rev-1",
+  status: "candidate_created",
+  approvalInteractionId: null,
+  approvedByUserId: null,
+  approvedAt: null,
+  stagedArtifactAssetId: null,
+  stagedArtifactSha256: null,
+  stagedAt: null,
+  metadata: {},
+  createdAt: new Date("2026-07-13T00:00:00.000Z"),
+  updatedAt: new Date("2026-07-13T00:00:00.000Z"),
+};
+
+function makeDb(selectRows: unknown[][] = []) {
+  const inserted: unknown[] = [];
+  const updated: unknown[] = [];
+  const db = {
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          then: (resolve: (rows: unknown[]) => unknown) => resolve(selectRows.shift() ?? []),
+        }),
+      }),
+    }),
+    insert: () => ({
+      values: (value: unknown) => {
+        inserted.push(value);
+        return {
+          returning: async () => [value],
+        };
+      },
+    }),
+    update: () => ({
+      set: (value: unknown) => {
+        updated.push(value);
+        return {
+          where: () => ({
+            returning: async () => [{ ...candidate, ...(value as Record<string, unknown>) }],
+          }),
+        };
+      },
+    }),
+  };
+  return { db: db as never, inserted, updated };
+}
+
+describe("release candidate approval relay", () => {
+  it("builds Founder confirmation target bound to candidate id and image digest", () => {
+    const { db } = makeDb();
+    const input = releaseCandidateService(db).buildApprovalInteractionInput(candidate);
+    expect(input.kind).toBe("request_confirmation");
+    expect(input.payload.target).toMatchObject({
+      type: "custom",
+      key: `release_candidate:${candidate.id}`,
+      revisionId: candidate.imageDigest,
+    });
+    expect(input.payload.detailsMarkdown).toContain(candidate.sbomHash);
+  });
+
+  it("blocks candidate mutation after approval interaction creation", async () => {
+    const immutableCandidate = {
+      ...candidate,
+      status: "approval_requested",
+      approvalInteractionId: "ffffffff-ffff-4fff-8fff-ffffffffffff",
+    };
+    const { db } = makeDb([[immutableCandidate]]);
+    await expect(
+      releaseCandidateService(db).updateMutable(candidate.id, { workflowRunUrl: "https://github.example/new" }, {}),
+    ).rejects.toMatchObject({
+      status: 409,
+      message: "Release candidate is immutable after approval interaction creation",
+    });
+  });
+
+  it("rejects accepted confirmations whose target digest does not match the candidate", async () => {
+    const { db } = makeDb([[{
+      ...candidate,
+      status: "approval_requested",
+      approvalInteractionId: "ffffffff-ffff-4fff-8fff-ffffffffffff",
+    }]]);
+
+    await expect(
+      releaseCandidateService(db).handleAcceptedInteraction(candidate.sourceIssueId, {
+        id: "ffffffff-ffff-4fff-8fff-ffffffffffff",
+        companyId: candidate.companyId,
+        issueId: candidate.sourceIssueId,
+        kind: "request_confirmation",
+        status: "accepted",
+        continuationPolicy: "wake_assignee",
+        idempotencyKey: null,
+        sourceCommentId: null,
+        sourceRunId: null,
+        title: null,
+        summary: null,
+        payload: {
+          version: 1,
+          prompt: "approve",
+          target: {
+            type: "custom",
+            key: `release_candidate:${candidate.id}`,
+            revisionId: "sha256:9999999999999999999999999999999999999999999999999999999999999999",
+          },
+        },
+        result: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      }, { userId: "founder" }),
+    ).rejects.toMatchObject({
+      status: 422,
+      message: "Release candidate approval digest does not match candidate record",
+    });
+  });
+
+  it("issues a token scoped to target host, digest, environment, sequence and stores only its hash", async () => {
+    const approvedCandidate = {
+      ...candidate,
+      status: "approval_requested",
+      approvalInteractionId: "ffffffff-ffff-4fff-8fff-ffffffffffff",
+    };
+    const { db, inserted } = makeDb([[approvedCandidate], []]);
+    const result = await releaseCandidateService(db).handleAcceptedInteraction(candidate.sourceIssueId, {
+      id: "ffffffff-ffff-4fff-8fff-ffffffffffff",
+      companyId: candidate.companyId,
+      issueId: candidate.sourceIssueId,
+      kind: "request_confirmation",
+      status: "accepted",
+      continuationPolicy: "wake_assignee",
+      idempotencyKey: null,
+      sourceCommentId: null,
+      sourceRunId: null,
+      title: null,
+      summary: null,
+      payload: {
+        version: 1,
+        prompt: "approve",
+        target: {
+          type: "custom",
+          key: `release_candidate:${candidate.id}`,
+          revisionId: candidate.imageDigest,
+        },
+      },
+      result: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    }, { userId: "founder" });
+
+    expect(result?.token).toMatch(/^pcdeploy_/);
+    expect(result?.authorization).toMatchObject({
+      targetHost: candidate.targetHost,
+      imageDigest: candidate.imageDigest,
+      environment: candidate.environment,
+      sequence: candidate.sequence,
+    });
+    const authInsert = inserted.find((value) =>
+      typeof value === "object"
+      && value !== null
+      && "tokenHash" in value
+    ) as Record<string, unknown>;
+    expect(authInsert.tokenHash).toEqual(expect.any(String));
+    expect(authInsert).not.toHaveProperty("token");
+    expect(authInsert).not.toHaveProperty("secret");
+  });
+
+  it("resolves approved leases and records deploy audit events through the token scope", async () => {
+    const authorization = {
+      id: "99999999-9999-4999-8999-999999999999",
+      companyId: candidate.companyId,
+      candidateId: candidate.id,
+      approvalInteractionId: "ffffffff-ffff-4fff-8fff-ffffffffffff",
+      tokenHash: "ignored-in-test",
+      tokenPrefix: "pcdeploy_sample",
+      targetHost: candidate.targetHost,
+      imageDigest: candidate.imageDigest,
+      environment: candidate.environment,
+      sequence: candidate.sequence,
+      expiresAt: new Date(Date.now() + 60_000),
+      usedAt: null,
+      leaseArtifactAssetId: null,
+      leaseIssuedAt: null,
+      createdByUserId: "founder",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    const { db, inserted } = makeDb([[authorization], [candidate], [authorization], [candidate]]);
+    const service = releaseCandidateService(db);
+    const token = "pcdeploy_test-token";
+    authorization.tokenHash = createHash("sha256").update(token).digest("hex");
+
+    await expect(service.getApprovedLease(authorization.id, token)).resolves.toMatchObject({
+      authorization: { id: authorization.id },
+      candidate: { id: candidate.id },
+    });
+
+    await expect(service.recordDeployEvent({
+      authorizationId: authorization.id,
+      token,
+      status: "succeeded",
+      commitSha: candidate.commitSha,
+      healthStatus: "ok",
+    }, { agentId: candidate.createdByAgentId })).resolves.toMatchObject({
+      eventType: "deploy_succeeded",
+    });
+
+    expect(inserted).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        eventType: "deploy_succeeded",
+        redacted: true,
+      }),
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          sections: expect.arrayContaining([
+            expect.objectContaining({ title: "Release Candidate Audit" }),
+          ]),
+        }),
+      }),
+    ]));
+    expect(JSON.stringify(inserted)).not.toContain(token);
+  });
+
+  it("rejects wrong, expired, replayed, and wrong-scope relay authorization tokens", async () => {
+    const token = "pcdeploy_test-token";
+    const tokenHash = createHash("sha256").update(token).digest("hex");
+    const artifact = {
+      imageDigest: candidate.imageDigest,
+      sbomHash: candidate.sbomHash,
+      signatureVerified: true,
+      sbomVerified: true,
+      tarballSha256: "4444444444444444444444444444444444444444444444444444444444444444",
+    };
+    const baseAuthorization = {
+      id: "99999999-9999-4999-8999-999999999999",
+      companyId: candidate.companyId,
+      candidateId: candidate.id,
+      approvalInteractionId: "ffffffff-ffff-4fff-8fff-ffffffffffff",
+      tokenHash,
+      tokenPrefix: "pcdeploy_sample",
+      targetHost: candidate.targetHost,
+      imageDigest: candidate.imageDigest,
+      environment: candidate.environment,
+      sequence: candidate.sequence,
+      expiresAt: new Date(Date.now() + 60_000),
+      usedAt: null,
+      leaseArtifactAssetId: null,
+      leaseIssuedAt: null,
+      createdByUserId: "founder",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+
+    await expect(
+      releaseCandidateService(makeDb([[baseAuthorization], [candidate]]).db)
+        .verifyRelayAuthorization(baseAuthorization.id, "pcdeploy_wrong-token", artifact),
+    ).rejects.toMatchObject({ status: 401, message: "Deploy authorization token is invalid" });
+
+    await expect(
+      releaseCandidateService(makeDb([[{ ...baseAuthorization, expiresAt: new Date(Date.now() - 1_000) }], [candidate]]).db)
+        .verifyRelayAuthorization(baseAuthorization.id, token, artifact),
+    ).rejects.toMatchObject({ status: 401, message: "Deploy authorization token is expired" });
+
+    await expect(
+      releaseCandidateService(makeDb([[{ ...baseAuthorization, usedAt: new Date() }], [candidate]]).db)
+        .verifyRelayAuthorization(baseAuthorization.id, token, artifact),
+    ).rejects.toMatchObject({ status: 409, message: "Deploy authorization token has already been used" });
+
+    await expect(
+      releaseCandidateService(makeDb([[{ ...baseAuthorization, targetHost: "other-host" }], [candidate]]).db)
+        .verifyRelayAuthorization(baseAuthorization.id, token, artifact),
+    ).rejects.toMatchObject({ status: 409, message: "Deploy authorization scope no longer matches release candidate" });
+  });
+
+  it("refuses relay artifacts with wrong digest, wrong SBOM, or missing signature verification", () => {
+    expect(() => verifyRelayArtifact(candidate, {
+      imageDigest: "sha256:3333333333333333333333333333333333333333333333333333333333333333",
+      sbomHash: candidate.sbomHash,
+      signatureVerified: true,
+      sbomVerified: true,
+      tarballSha256: "4444444444444444444444444444444444444444444444444444444444444444",
+    })).toThrow(HttpError);
+
+    expect(() => verifyRelayArtifact(candidate, {
+      imageDigest: candidate.imageDigest,
+      sbomHash: "5555555555555555555555555555555555555555555555555555555555555555",
+      signatureVerified: true,
+      sbomVerified: true,
+      tarballSha256: "4444444444444444444444444444444444444444444444444444444444444444",
+    })).toThrow("Relay artifact SBOM hash does not match approved candidate");
+
+    expect(() => verifyRelayArtifact(candidate, {
+      imageDigest: candidate.imageDigest,
+      sbomHash: candidate.sbomHash,
+      signatureVerified: false,
+      sbomVerified: true,
+      tarballSha256: "4444444444444444444444444444444444444444444444444444444444444444",
+    })).toThrow("Relay artifact signature is not verified");
+  });
+});

--- a/server/src/services/release-candidates.ts
+++ b/server/src/services/release-candidates.ts
@@ -1,0 +1,522 @@
+import { createHash, randomBytes, timingSafeEqual } from "node:crypto";
+import { and, eq } from "drizzle-orm";
+import type { Db } from "@paperclipai/db";
+import {
+  issueComments,
+  issueThreadInteractions,
+  releaseCandidateAuditEvents,
+  releaseCandidates,
+  releaseDeployAuthorizations,
+} from "@paperclipai/db";
+import type { IssueCommentMetadata, IssueThreadInteraction } from "@paperclipai/shared";
+import { conflict, notFound, unauthorized, unprocessable } from "../errors.js";
+
+export const RELEASE_CANDIDATE_CONFIRMATION_TARGET_PREFIX = "release_candidate:";
+const DEPLOY_AUTH_TOKEN_BYTES = 32;
+const DEFAULT_AUTH_TTL_MS = 15 * 60 * 1000;
+
+type Actor = {
+  agentId?: string | null;
+  userId?: string | null;
+  runId?: string | null;
+};
+
+type CandidateRow = typeof releaseCandidates.$inferSelect;
+type AuthorizationRow = typeof releaseDeployAuthorizations.$inferSelect;
+
+export type CreateReleaseCandidateInput = Pick<
+  typeof releaseCandidates.$inferInsert,
+  | "companyId"
+  | "sourceIssueId"
+  | "commitSha"
+  | "imageDigest"
+  | "signatureBundleRef"
+  | "provenanceRef"
+  | "sbomHash"
+  | "workflowRunUrl"
+  | "environment"
+  | "targetHost"
+  | "sequence"
+> & {
+  documentRevisionId?: string | null;
+  metadata?: Record<string, unknown>;
+};
+
+export type UpdateReleaseCandidateInput = Partial<Pick<
+  typeof releaseCandidates.$inferInsert,
+  "signatureBundleRef" | "provenanceRef" | "workflowRunUrl" | "documentRevisionId" | "metadata"
+>>;
+
+export type RelayArtifactInput = {
+  imageDigest: string;
+  sbomHash: string;
+  signatureVerified: boolean;
+  sbomVerified: boolean;
+  tarballSha256: string;
+  tarballBytes: Buffer;
+  originalFilename?: string | null;
+};
+
+export type RelayArtifactVerificationInput = Omit<RelayArtifactInput, "tarballBytes" | "originalFilename">;
+
+export type DeployRecordInput = {
+  authorizationId: string;
+  token: string;
+  status: "started" | "succeeded" | "failed" | "rolled_back";
+  message?: string | null;
+  commitSha?: string | null;
+  healthStatus?: string | null;
+  rollbackReason?: string | null;
+  metadata?: Record<string, unknown>;
+};
+
+function sha256(value: string) {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function generateDeployToken() {
+  const secret = `pcdeploy_${randomBytes(DEPLOY_AUTH_TOKEN_BYTES).toString("base64url")}`;
+  return {
+    secret,
+    hash: sha256(secret),
+    prefix: secret.slice(0, 18),
+  };
+}
+
+function tokenHashMatches(left: string, right: string) {
+  const leftBuffer = Buffer.from(left, "hex");
+  const rightBuffer = Buffer.from(right, "hex");
+  if (leftBuffer.length !== rightBuffer.length) return false;
+  return timingSafeEqual(leftBuffer, rightBuffer);
+}
+
+function assertCandidateMutable(candidate: CandidateRow) {
+  if (candidate.approvalInteractionId || candidate.status !== "candidate_created") {
+    throw conflict("Release candidate is immutable after approval interaction creation", {
+      code: "release_candidate_immutable",
+      candidateId: candidate.id,
+      status: candidate.status,
+    });
+  }
+}
+
+function candidateTargetKey(candidateId: string) {
+  return `${RELEASE_CANDIDATE_CONFIRMATION_TARGET_PREFIX}${candidateId}`;
+}
+
+function buildAuditComment(eventType: string, candidate: CandidateRow, extra: Record<string, unknown> = {}) {
+  const lines = [
+    `Deploy-control audit: ${eventType}`,
+    "",
+    `- candidate_id: ${candidate.id}`,
+    `- image_digest: ${candidate.imageDigest}`,
+    `- environment: ${candidate.environment}`,
+    `- target_host: ${candidate.targetHost}`,
+    `- sequence: ${candidate.sequence}`,
+  ];
+  for (const [key, value] of Object.entries(extra)) {
+    if (value == null) continue;
+    lines.push(`- ${key}: ${String(value)}`);
+  }
+  return lines.join("\n");
+}
+
+function buildAuditMetadata(eventType: string, candidate: CandidateRow): IssueCommentMetadata {
+  return {
+    version: 1,
+    sections: [{
+      title: "Release Candidate Audit",
+      rows: [
+        { type: "key_value", label: "Event", value: eventType },
+        { type: "key_value", label: "Candidate", value: candidate.id },
+        { type: "key_value", label: "Secret fields", value: "omitted" },
+      ],
+    }],
+  };
+}
+
+async function appendAudit(db: Db, args: {
+  candidate: CandidateRow;
+  eventType: string;
+  actor: Actor;
+  authorizationId?: string | null;
+  payload?: Record<string, unknown>;
+  commentExtra?: Record<string, unknown>;
+}) {
+  await db.insert(releaseCandidateAuditEvents).values({
+    companyId: args.candidate.companyId,
+    candidateId: args.candidate.id,
+    authorizationId: args.authorizationId ?? null,
+    issueId: args.candidate.sourceIssueId,
+    actorAgentId: args.actor.agentId ?? null,
+    actorUserId: args.actor.userId ?? null,
+    eventType: args.eventType,
+    payload: args.payload ?? {},
+    redacted: true,
+  });
+
+  await db.insert(issueComments).values({
+    companyId: args.candidate.companyId,
+    issueId: args.candidate.sourceIssueId,
+    authorAgentId: args.actor.agentId ?? null,
+    authorUserId: args.actor.userId ?? null,
+    authorType: args.actor.agentId ? "agent" : args.actor.userId ? "user" : "system",
+    createdByRunId: args.actor.runId ?? null,
+    body: buildAuditComment(args.eventType, args.candidate, args.commentExtra),
+    metadata: buildAuditMetadata(args.eventType, args.candidate),
+  });
+}
+
+export function verifyRelayArtifact(candidate: CandidateRow, artifact: RelayArtifactVerificationInput) {
+  if (artifact.imageDigest !== candidate.imageDigest) {
+    throw unprocessable("Relay artifact digest does not match approved candidate", {
+      code: "release_candidate_wrong_digest",
+    });
+  }
+  if (artifact.sbomHash !== candidate.sbomHash) {
+    throw unprocessable("Relay artifact SBOM hash does not match approved candidate", {
+      code: "release_candidate_wrong_sbom",
+    });
+  }
+  if (!artifact.signatureVerified) {
+    throw unprocessable("Relay artifact signature is not verified", {
+      code: "release_candidate_unsigned",
+    });
+  }
+  if (!artifact.sbomVerified) {
+    throw unprocessable("Relay artifact SBOM is not verified", {
+      code: "release_candidate_unverified_sbom",
+    });
+  }
+  if (!/^[a-f0-9]{64}$/i.test(artifact.tarballSha256.replace(/^sha256:/i, ""))) {
+    throw unprocessable("Relay artifact tarball SHA-256 is invalid", {
+      code: "release_candidate_invalid_tarball_sha",
+    });
+  }
+}
+
+export function releaseCandidateService(db: Db) {
+  async function getById(id: string) {
+    return db.select().from(releaseCandidates).where(eq(releaseCandidates.id, id)).then((rows) => rows[0] ?? null);
+  }
+
+  async function getAuthorizationById(id: string) {
+    return db
+      .select()
+      .from(releaseDeployAuthorizations)
+      .where(eq(releaseDeployAuthorizations.id, id))
+      .then((rows) => rows[0] ?? null);
+  }
+
+  return {
+    getById,
+
+    create: async (input: CreateReleaseCandidateInput, actor: Actor) => {
+      const [candidate] = await db.insert(releaseCandidates).values({
+        ...input,
+        createdByAgentId: actor.agentId ?? null,
+        createdByRunId: actor.runId ?? null,
+        documentRevisionId: input.documentRevisionId ?? null,
+        metadata: input.metadata ?? {},
+      }).returning();
+      if (!candidate) throw conflict("Failed to create release candidate");
+      await appendAudit(db, {
+        candidate,
+        actor,
+        eventType: "candidate_created",
+        payload: {
+          digest: candidate.imageDigest,
+          environment: candidate.environment,
+          targetHost: candidate.targetHost,
+          sequence: candidate.sequence,
+        },
+      });
+      return candidate;
+    },
+
+    updateMutable: async (candidateId: string, data: UpdateReleaseCandidateInput, actor: Actor) => {
+      const candidate = await getById(candidateId);
+      if (!candidate) throw notFound("Release candidate not found");
+      assertCandidateMutable(candidate);
+      const [updated] = await db.update(releaseCandidates).set({
+        ...data,
+        documentRevisionId: data.documentRevisionId ?? candidate.documentRevisionId,
+        metadata: data.metadata ?? candidate.metadata,
+        updatedAt: new Date(),
+      }).where(eq(releaseCandidates.id, candidateId)).returning();
+      if (!updated) throw conflict("Failed to update release candidate");
+      await appendAudit(db, { candidate: updated, actor, eventType: "candidate_updated" });
+      return updated;
+    },
+
+    markApprovalInteractionCreated: async (candidateId: string, interaction: IssueThreadInteraction, actor: Actor) => {
+      const candidate = await getById(candidateId);
+      if (!candidate) throw notFound("Release candidate not found");
+      assertCandidateMutable(candidate);
+      if (interaction.kind !== "request_confirmation") {
+        throw unprocessable("Release candidate approval must use request_confirmation");
+      }
+      const target = interaction.payload.target;
+      if (
+        !target
+        || target.type !== "custom"
+        || target.key !== candidateTargetKey(candidate.id)
+        || target.revisionId !== candidate.imageDigest
+      ) {
+        throw unprocessable("Release candidate approval target must bind the candidate id and image digest");
+      }
+      const [updated] = await db.update(releaseCandidates).set({
+        approvalInteractionId: interaction.id,
+        status: "approval_requested",
+        updatedAt: new Date(),
+      }).where(eq(releaseCandidates.id, candidateId)).returning();
+      if (!updated) throw conflict("Failed to bind release candidate approval interaction");
+      await appendAudit(db, {
+        candidate: updated,
+        actor,
+        eventType: "approval_requested",
+        payload: {
+          interactionId: interaction.id,
+          digest: updated.imageDigest,
+          documentRevisionId: updated.documentRevisionId,
+        },
+        commentExtra: {
+          interaction_id: interaction.id,
+          document_revision_id: updated.documentRevisionId,
+        },
+      });
+      return updated;
+    },
+
+    buildApprovalInteractionInput: (candidate: CandidateRow) => ({
+      kind: "request_confirmation" as const,
+      idempotencyKey: `release-candidate:${candidate.id}:approval:${candidate.imageDigest}`,
+      title: `Approve scanner release ${candidate.sequence}`,
+      summary: `Founder approval for ${candidate.targetHost} ${candidate.environment} digest ${candidate.imageDigest}`,
+      continuationPolicy: "wake_assignee" as const,
+      payload: {
+        version: 1 as const,
+        prompt: `Approve scanner deploy candidate ${candidate.sequence} for ${candidate.environment} on ${candidate.targetHost}?`,
+        acceptLabel: "Approve deploy",
+        rejectLabel: "Reject",
+        allowDeclineReason: true,
+        detailsMarkdown: [
+          `Candidate: ${candidate.id}`,
+          `Commit: ${candidate.commitSha}`,
+          `Image digest: ${candidate.imageDigest}`,
+          `SBOM hash: ${candidate.sbomHash}`,
+          `Signature bundle: ${candidate.signatureBundleRef}`,
+          `Provenance: ${candidate.provenanceRef}`,
+          `Workflow: ${candidate.workflowRunUrl}`,
+          `Document revision: ${candidate.documentRevisionId ?? "not set"}`,
+        ].join("\n\n"),
+        target: {
+          type: "custom" as const,
+          key: candidateTargetKey(candidate.id),
+          revisionId: candidate.imageDigest,
+          label: "Release candidate digest",
+        },
+      },
+    }),
+
+    handleAcceptedInteraction: async (issueId: string, interaction: IssueThreadInteraction, actor: Actor, ttlMs = DEFAULT_AUTH_TTL_MS) => {
+      if (interaction.kind !== "request_confirmation" || interaction.status !== "accepted") return null;
+      const target = interaction.payload.target;
+      if (!target || target.type !== "custom" || !target.key.startsWith(RELEASE_CANDIDATE_CONFIRMATION_TARGET_PREFIX)) {
+        return null;
+      }
+      const candidateId = target.key.slice(RELEASE_CANDIDATE_CONFIRMATION_TARGET_PREFIX.length);
+      const candidate = await getById(candidateId);
+      if (!candidate || candidate.sourceIssueId !== issueId) {
+        throw unprocessable("Release candidate approval target does not match the source issue");
+      }
+      if (candidate.approvalInteractionId !== interaction.id) {
+        throw unprocessable("Release candidate approval interaction does not match candidate record");
+      }
+      if (target.revisionId !== candidate.imageDigest) {
+        throw unprocessable("Release candidate approval digest does not match candidate record");
+      }
+      const existing = await db
+        .select()
+        .from(releaseDeployAuthorizations)
+        .where(and(
+          eq(releaseDeployAuthorizations.candidateId, candidate.id),
+          eq(releaseDeployAuthorizations.approvalInteractionId, interaction.id),
+        ))
+        .then((rows) => rows[0] ?? null);
+      if (existing) {
+        return {
+          authorization: existing,
+          token: null,
+          alreadyIssued: true,
+        };
+      }
+
+      const token = generateDeployToken();
+      const expiresAt = new Date(Date.now() + ttlMs);
+      const [authorization] = await db.insert(releaseDeployAuthorizations).values({
+        companyId: candidate.companyId,
+        candidateId: candidate.id,
+        approvalInteractionId: interaction.id,
+        tokenHash: token.hash,
+        tokenPrefix: token.prefix,
+        targetHost: candidate.targetHost,
+        imageDigest: candidate.imageDigest,
+        environment: candidate.environment,
+        sequence: candidate.sequence,
+        expiresAt,
+        createdByUserId: actor.userId ?? null,
+      }).returning();
+      if (!authorization) throw conflict("Failed to create deploy authorization");
+
+      const [updated] = await db.update(releaseCandidates).set({
+        status: "approved",
+        approvedByUserId: actor.userId ?? null,
+        approvedAt: new Date(),
+        updatedAt: new Date(),
+      }).where(eq(releaseCandidates.id, candidate.id)).returning();
+      const approvedCandidate = updated ?? candidate;
+      await appendAudit(db, {
+        candidate: approvedCandidate,
+        actor,
+        authorizationId: authorization.id,
+        eventType: "deploy_authorization_issued",
+        payload: {
+          authorizationId: authorization.id,
+          tokenPrefix: token.prefix,
+          targetHost: authorization.targetHost,
+          digest: authorization.imageDigest,
+          environment: authorization.environment,
+          sequence: authorization.sequence,
+          expiresAt: authorization.expiresAt.toISOString(),
+        },
+        commentExtra: {
+          authorization_id: authorization.id,
+          token_prefix: token.prefix,
+          expires_at: authorization.expiresAt.toISOString(),
+        },
+      });
+      return { authorization, token: token.secret, alreadyIssued: false };
+    },
+
+    verifyRelayAuthorization: async (authorizationId: string, token: string, artifact: RelayArtifactVerificationInput) => {
+      const authorization = await getAuthorizationById(authorizationId);
+      if (!authorization) throw notFound("Deploy authorization not found");
+      const candidate = await getById(authorization.candidateId);
+      if (!candidate) throw notFound("Release candidate not found");
+      const providedHash = sha256(token);
+      if (!tokenHashMatches(providedHash, authorization.tokenHash)) {
+        throw unauthorized("Deploy authorization token is invalid");
+      }
+      if (authorization.expiresAt.getTime() <= Date.now()) {
+        throw unauthorized("Deploy authorization token is expired");
+      }
+      if (authorization.usedAt) {
+        throw conflict("Deploy authorization token has already been used", {
+          code: "release_candidate_token_used",
+        });
+      }
+      if (
+        authorization.targetHost !== candidate.targetHost
+        || authorization.imageDigest !== candidate.imageDigest
+        || authorization.environment !== candidate.environment
+        || authorization.sequence !== candidate.sequence
+      ) {
+        throw conflict("Deploy authorization scope no longer matches release candidate");
+      }
+      verifyRelayArtifact(candidate, artifact);
+      return { authorization, candidate };
+    },
+
+    getApprovedLease: async (authorizationId: string, token: string) => {
+      const authorization = await getAuthorizationById(authorizationId);
+      if (!authorization) throw notFound("Deploy authorization not found");
+      const candidate = await getById(authorization.candidateId);
+      if (!candidate) throw notFound("Release candidate not found");
+      const providedHash = sha256(token);
+      if (!tokenHashMatches(providedHash, authorization.tokenHash)) {
+        throw unauthorized("Deploy authorization token is invalid");
+      }
+      if (authorization.expiresAt.getTime() <= Date.now()) {
+        throw unauthorized("Deploy authorization token is expired");
+      }
+      if (
+        authorization.targetHost !== candidate.targetHost
+        || authorization.imageDigest !== candidate.imageDigest
+        || authorization.environment !== candidate.environment
+        || authorization.sequence !== candidate.sequence
+      ) {
+        throw conflict("Deploy authorization scope no longer matches release candidate");
+      }
+      return { authorization, candidate };
+    },
+
+    stageRelayArtifact: async (authorizationId: string, token: string, artifact: RelayArtifactInput, assetId: string, actor: Actor) => {
+      const { authorization, candidate } = await releaseCandidateService(db).verifyRelayAuthorization(authorizationId, token, artifact);
+      const now = new Date();
+      const [updatedAuth] = await db.update(releaseDeployAuthorizations).set({
+        usedAt: now,
+        leaseArtifactAssetId: assetId,
+        leaseIssuedAt: now,
+        updatedAt: now,
+      }).where(and(
+        eq(releaseDeployAuthorizations.id, authorization.id),
+        eq(releaseDeployAuthorizations.tokenHash, authorization.tokenHash),
+      )).returning();
+      if (!updatedAuth) throw conflict("Failed to consume deploy authorization");
+      const [updatedCandidate] = await db.update(releaseCandidates).set({
+        status: "staged",
+        stagedArtifactAssetId: assetId,
+        stagedArtifactSha256: artifact.tarballSha256,
+        stagedAt: now,
+        updatedAt: now,
+      }).where(eq(releaseCandidates.id, candidate.id)).returning();
+      await appendAudit(db, {
+        candidate: updatedCandidate ?? candidate,
+        actor,
+        authorizationId: authorization.id,
+        eventType: "relay_artifact_staged",
+        payload: {
+          authorizationId: authorization.id,
+          assetId,
+          tarballSha256: artifact.tarballSha256,
+          digest: artifact.imageDigest,
+          sbomHash: artifact.sbomHash,
+        },
+        commentExtra: {
+          authorization_id: authorization.id,
+          asset_id: assetId,
+          tarball_sha256: artifact.tarballSha256,
+        },
+      });
+      return updatedAuth as AuthorizationRow;
+    },
+
+    recordDeployEvent: async (input: DeployRecordInput, actor: Actor) => {
+      const { authorization, candidate } = await releaseCandidateService(db).getApprovedLease(input.authorizationId, input.token);
+      const eventType = `deploy_${input.status}`;
+      await appendAudit(db, {
+        candidate,
+        actor,
+        authorizationId: authorization.id,
+        eventType,
+        payload: {
+          status: input.status,
+          commitSha: input.commitSha ?? candidate.commitSha,
+          healthStatus: input.healthStatus ?? null,
+          rollbackReason: input.rollbackReason ?? null,
+          metadata: input.metadata ?? {},
+        },
+        commentExtra: {
+          authorization_id: authorization.id,
+          status: input.status,
+          commit_sha: input.commitSha ?? candidate.commitSha,
+          health_status: input.healthStatus ?? null,
+          rollback_reason: input.rollbackReason ?? null,
+          message: input.message ?? null,
+        },
+      });
+      return { authorization, candidate, eventType };
+    },
+  };
+}


### PR DESCRIPTION
## Summary\n\nSecures the release-candidate deploy relay by moving one-time pcdeploy_... secrets out of URL queries and JSON bodies into the X-Paperclip-Deploy-Token header, while preserving the non-secret authorization id as request metadata.\n\n- reject deprecated query/body token transport\n- redact the deploy-token header from server HTTP logs\n- cover missing, wrong, expired, replayed, and wrong-scope tokens\n- document the scanner deploy-agent header contract\n\n## Verification\n\n- pnpm exec vitest run server/src/__tests__/release-candidates-routes.test.ts server/src/services/release-candidates.test.ts server/src/__tests__/redact-sensitive.test.ts\n- 3 test files passed; 23 tests passed\n\n## Safety\n\nNo production deploy token was minted, no real release approval was accepted, and no scanner deployment was performed.\n\nTracking: BEAAA-14665 / BEAAA-14668.