### PR TITLE
fix(recovery): enforce successful-run disposition

### DIFF
--- a/packages/adapter-utils/src/server-utils.test.ts
+++ b/packages/adapter-utils/src/server-utils.test.ts
@@ -774,6 +774,9 @@ describe("renderPaperclipWakePrompt", () => {
     ]) {
       expect(prompt).toContain("Execution contract: take concrete action in this heartbeat");
       expect(prompt).toContain("clear final disposition");
+      expect(prompt).toContain("Immediately before returning, verify that Paperclip records one of those dispositions");
+      expect(prompt).toContain("a successful process exit or final response is not sufficient");
+      expect(prompt).toContain("If no valid disposition is recorded, record it now and do not end the run");
       expect(prompt).toContain("evidence, not valid liveness paths by themselves");
       expect(prompt).toContain("Use child issues for long or parallel delegated work instead of polling");
       expect(prompt).toContain("named unblock owner/action");

--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -1381,7 +1381,7 @@ export function renderPaperclipWakePrompt(
       ]
     : includeExecutionContract
       ? [
-        "Execution contract: take concrete action in this heartbeat when the issue is actionable; do not stop at a plan unless planning was requested. Leave durable progress and then give the issue a clear final disposition before ending the heartbeat: `done`, `in_review` with a real reviewer/approval/interaction path, `blocked` with first-class blockers or a named unblock owner/action, delegated follow-up issues with blockers, or `in_progress` only when a live continuation path exists. Use child issues for long or parallel delegated work instead of polling. Comments, documents, screenshots, work products, and `Remaining` bullets are evidence, not valid liveness paths by themselves.",
+        "Execution contract: take concrete action in this heartbeat when the issue is actionable; do not stop at a plan unless planning was requested. Leave durable progress and then give the issue a clear final disposition before ending the heartbeat: `done`, `in_review` with a real reviewer/approval/interaction path, `blocked` with first-class blockers or a named unblock owner/action, delegated follow-up issues with blockers, or `in_progress` only when a live continuation path exists. Immediately before returning, verify that Paperclip records one of those dispositions; a successful process exit or final response is not sufficient. If no valid disposition is recorded, record it now and do not end the run. Use child issues for long or parallel delegated work instead of polling. Comments, documents, screenshots, work products, and `Remaining` bullets are evidence, not valid liveness paths by themselves.",
         "",
       ]
       : [];

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -8023,7 +8023,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         .where(eq(heartbeatRuns.id, run.id));
     }
 
-    const handoffRun = await enqueueWakeup(run.agentId, {
+    const handoffRun = await enqueueWakeup(decision.targetAgentId, {
       source: "automation",
       triggerDetail: "system",
       reason: FINISH_SUCCESSFUL_RUN_HANDOFF_REASON,

--- a/server/src/services/recovery/successful-run-handoff.test.ts
+++ b/server/src/services/recovery/successful-run-handoff.test.ts
@@ -62,11 +62,12 @@ function decide(overrides: Partial<Parameters<typeof decideSuccessfulRunHandoff>
 }
 
 describe("successful run handoff decision", () => {
-  it("queues one corrective handoff wake for a successful progress run without a visible next action", () => {
+  it("queues one status-only corrective wake to the original agent when a successful run has no disposition", () => {
     const decision = decide();
 
     expect(decision.kind).toBe("enqueue");
     if (decision.kind !== "enqueue") return;
+    expect(decision.targetAgentId).toBe(run.agentId);
     expect(decision.idempotencyKey).toBe("finish_successful_run_handoff:issue-1:run-1:1");
     expect(decision.payload).toMatchObject({
       issueId: "issue-1",
@@ -91,6 +92,9 @@ describe("successful run handoff decision", () => {
       allowDocumentUpdates: false,
       resumeRequiresNormalModel: true,
     });
+    expect(decision.instruction).toContain(
+      "This is a status-only retry to the original agent. Record a disposition; do not start new work.",
+    );
     expect(decision.instruction).toContain("Resolve the missing disposition before creating or revising any new artifacts");
     expect(decision.instruction).toContain("Choose **exactly one** outcome");
     expect(decision.instruction).toContain("record an explicit continuation path");

--- a/server/src/services/recovery/successful-run-handoff.ts
+++ b/server/src/services/recovery/successful-run-handoff.ts
@@ -77,6 +77,7 @@ export function noticeMetadataReferencesRecoveryAction(
 export type SuccessfulRunHandoffDecision =
   | {
       kind: "enqueue";
+      targetAgentId: string;
       idempotencyKey: string;
       payload: Record<string, unknown>;
       contextSnapshot: Record<string, unknown>;
@@ -319,6 +320,8 @@ export function buildSuccessfulRunHandoffInstruction(input: {
   return [
     `Your previous run on ${issueLabel} succeeded, but the issue is still in \`in_progress\` and Paperclip cannot identify a valid issue disposition.`,
     "",
+    "This is a status-only retry to the original agent. Record a disposition; do not start new work.",
+    "",
     "Resolve the missing disposition before creating or revising any new artifacts. Choose **exactly one** outcome and perform the matching Paperclip action:",
     "",
     "**Is the issue finished?**",
@@ -423,6 +426,7 @@ export function decideSuccessfulRunHandoff(input: {
 
   return {
     kind: "enqueue",
+    targetAgentId: run.agentId,
     idempotencyKey: buildFinishSuccessfulRunHandoffIdempotencyKey({
       issueId: issue.id,
       sourceRunId: run.id,


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The heartbeat and recovery subsystems keep issue state aligned with agent execution outcomes
> - A successful run can still leave its issue in `in_progress` without a valid disposition
> - The cause-keyed recovery work in #9634 adds a cheap status-only path for this bookkeeping failure
> - That path should always return to the original agent and must never become new deliverable work
> - The normal execution contract should also make the disposition check explicit before an agent ends its run
> - This pull request makes same-agent targeting explicit, strengthens the status-only instruction, and adds regression coverage
> - The benefit is fewer missing-disposition recoveries and a deterministic low-cost correction when one still occurs

## Linked Issues or Issue Description

- Refs #9634
- Related but not duplicated: #8831 adds a fail-closed heartbeat guard, while #9370 focuses on disposition freshness. This stacked PR specifically makes the #9634 status-only retry target explicit and strengthens the rendered agent contract.

## What Changed

- Added an explicit `targetAgentId` to successful-run handoff decisions and used it when enqueueing the corrective wake.
- Added a direct status-only instruction to record a disposition and not start new work.
- Strengthened the rendered execution contract with a final pre-return disposition verification requirement.
- Added focused tests for same-agent targeting, cheap status-only guards, no-new-work wording, and rendered contract enforcement.

## Verification

- `pnpm exec vitest run server/src/services/recovery/successful-run-handoff.test.ts packages/adapter-utils/src/server-utils.test.ts`
  - 2 test files passed; 88 tests passed.
- `pnpm --filter @paperclipai/adapter-utils typecheck`
  - Passed.
- `pnpm --filter @paperclipai/server typecheck`
  - Not usable in the isolated worktree with the shared dependency install because existing workspace symlinks resolve packages from another worktree and load conflicting Drizzle versions; the focused server tests compile and pass the touched path.

## Risks

- Low risk: the runtime behavior remains the existing one-wake cheap recovery flow; the change makes its target explicit and tightens prompt text.
- The stronger contract depends on agents following rendered instructions, while the existing successful-run handoff remains the enforcement backstop.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex with model ID `gpt-5.4`, using reasoning, tool use, and code execution. The runtime does not expose its configured context-window size.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
