### PR TITLE
fix(recovery): auto-repair mechanical workspace validation failures

### DIFF
--- a/server/src/__tests__/issue-recovery-actions.test.ts
+++ b/server/src/__tests__/issue-recovery-actions.test.ts
@@ -1234,6 +1234,106 @@ describeEmbeddedPostgres("issue recovery actions", () => {
     expect(enqueueWakeup).toHaveBeenCalledOnce();
   }, 15_000);
 
+  it("continues recovery escalation after repairing an issue with no agent assignee", async () => {
+    const { companyId, managerId, sourceIssue } = await seedCompany();
+    const repoRoot = await createGitRepo();
+    const expectedBranch = "repair/unassigned-expected";
+    const actualBranch = "repair/unassigned-actual";
+    const worktreePath = path.join(repoRoot, ".paperclip", "worktrees", "unassigned-branch");
+    await fs.mkdir(path.dirname(worktreePath), { recursive: true });
+    await runGit(repoRoot, ["branch", expectedBranch, "main"]);
+    await runGit(repoRoot, ["worktree", "add", "-b", actualBranch, worktreePath, "main"]);
+    const executionWorkspaceId = await seedExecutionWorkspace({
+      companyId,
+      sourceIssueId: sourceIssue.id,
+      repoRoot,
+      worktreePath,
+      branchName: expectedBranch,
+    });
+    const enqueueWakeup = vi.fn(async () => null);
+    const recovery = recoveryService(db, { enqueueWakeup });
+
+    await recovery.escalateStrandedAssignedIssue({
+      issue: { ...sourceIssue, assigneeAgentId: null },
+      previousStatus: "in_progress",
+      latestRun: {
+        id: randomUUID(),
+        agentId: null,
+        status: "failed",
+        error: "workspace branch mismatch",
+        errorCode: "workspace_validation_failed",
+        contextSnapshot: {},
+        livenessState: "failed",
+        resultJson: {
+          workspaceValidation: {
+            reason: "git_worktree_branch_incoherence",
+            executionWorkspaceId,
+          },
+        },
+      },
+      recoveryCause: "workspace_validation_failed",
+    });
+
+    expect(await runGit(worktreePath, ["branch", "--show-current"]).then((result) => result.stdout.trim())).toBe(expectedBranch);
+    const actions = await db.select().from(issueRecoveryActions).where(eq(issueRecoveryActions.sourceIssueId, sourceIssue.id));
+    expect(actions).toHaveLength(1);
+    expect(actions[0]).toMatchObject({
+      cause: "workspace_validation_failed",
+      ownerAgentId: managerId,
+    });
+    expect(enqueueWakeup).not.toHaveBeenCalled();
+  }, 15_000);
+
+  it("escalates when an auto-repair retry fails workspace validation again", async () => {
+    const { companyId, managerId, coderId, sourceIssue } = await seedCompany();
+    const repoRoot = await createGitRepo();
+    const expectedBranch = "repair/retry-expected";
+    const actualBranch = "repair/retry-actual";
+    const worktreePath = path.join(repoRoot, ".paperclip", "worktrees", "failed-retry");
+    await fs.mkdir(path.dirname(worktreePath), { recursive: true });
+    await runGit(repoRoot, ["branch", expectedBranch, "main"]);
+    await runGit(repoRoot, ["worktree", "add", "-b", actualBranch, worktreePath, "main"]);
+    const executionWorkspaceId = await seedExecutionWorkspace({
+      companyId,
+      sourceIssueId: sourceIssue.id,
+      repoRoot,
+      worktreePath,
+      branchName: expectedBranch,
+    });
+    const enqueueWakeup = vi.fn(async () => null);
+    const recovery = recoveryService(db, { enqueueWakeup });
+
+    await recovery.escalateStrandedAssignedIssue({
+      issue: sourceIssue,
+      previousStatus: "in_progress",
+      latestRun: {
+        id: randomUUID(),
+        agentId: coderId,
+        status: "failed",
+        error: "workspace branch mismatch after automatic repair",
+        errorCode: "workspace_validation_failed",
+        contextSnapshot: { retryReason: "workspace_validation_auto_repaired" },
+        livenessState: "failed",
+        resultJson: {
+          workspaceValidation: {
+            reason: "git_worktree_branch_incoherence",
+            executionWorkspaceId,
+          },
+        },
+      },
+      recoveryCause: "workspace_validation_failed",
+    });
+
+    expect(await runGit(worktreePath, ["branch", "--show-current"]).then((result) => result.stdout.trim())).toBe(actualBranch);
+    const actions = await db.select().from(issueRecoveryActions).where(eq(issueRecoveryActions.sourceIssueId, sourceIssue.id));
+    expect(actions).toHaveLength(1);
+    expect(actions[0]).toMatchObject({
+      cause: "workspace_validation_failed",
+      ownerAgentId: managerId,
+    });
+    expect(enqueueWakeup).not.toHaveBeenCalled();
+  }, 15_000);
+
   it("does not trust run-result repository paths for workspace repair", async () => {
     const { companyId, coderId, sourceIssue } = await seedCompany();
     const repoRoot = await createGitRepo();

--- a/server/src/__tests__/issue-recovery-actions.test.ts
+++ b/server/src/__tests__/issue-recovery-actions.test.ts
@@ -1234,6 +1234,56 @@ describeEmbeddedPostgres("issue recovery actions", () => {
     expect(enqueueWakeup).toHaveBeenCalledOnce();
   }, 15_000);
 
+  it("does not trust run-result repository paths for workspace repair", async () => {
+    const { companyId, coderId, sourceIssue } = await seedCompany();
+    const repoRoot = await createGitRepo();
+    const expectedBranch = "repair/untrusted-expected";
+    const actualBranch = "repair/untrusted-actual";
+    const worktreePath = path.join(repoRoot, ".paperclip", "worktrees", "untrusted-root");
+    await fs.mkdir(path.dirname(worktreePath), { recursive: true });
+    await runGit(repoRoot, ["branch", expectedBranch, "main"]);
+    await runGit(repoRoot, ["worktree", "add", "-b", actualBranch, worktreePath, "main"]);
+    const executionWorkspaceId = await seedExecutionWorkspace({
+      companyId,
+      sourceIssueId: sourceIssue.id,
+      repoRoot,
+      worktreePath,
+      branchName: expectedBranch,
+    });
+    await db
+      .update(executionWorkspaces)
+      .set({ projectWorkspaceId: null })
+      .where(eq(executionWorkspaces.id, executionWorkspaceId));
+    const enqueueWakeup = vi.fn(async () => null);
+    const recovery = recoveryService(db, { enqueueWakeup });
+
+    await recovery.escalateStrandedAssignedIssue({
+      issue: sourceIssue,
+      previousStatus: "in_progress",
+      latestRun: {
+        id: randomUUID(),
+        agentId: coderId,
+        status: "failed",
+        error: "workspace branch mismatch",
+        errorCode: "workspace_validation_failed",
+        contextSnapshot: {},
+        livenessState: "failed",
+        resultJson: {
+          workspaceValidation: {
+            reason: "git_worktree_branch_incoherence",
+            executionWorkspaceId,
+            repoRoot,
+          },
+        },
+      },
+      recoveryCause: "workspace_validation_failed",
+    });
+
+    expect(await runGit(worktreePath, ["branch", "--show-current"]).then((result) => result.stdout.trim())).toBe(actualBranch);
+    expect(await db.select().from(issueRecoveryActions).where(eq(issueRecoveryActions.sourceIssueId, sourceIssue.id))).toHaveLength(1);
+    expect(enqueueWakeup).not.toHaveBeenCalled();
+  }, 15_000);
+
   it("never discards dirty work and routes unrecoverable workspace repair to the CTO", async () => {
     const { companyId, managerId, coderId, sourceIssue } = await seedCompany();
     const repoRoot = await createGitRepo();

--- a/server/src/__tests__/issue-recovery-actions.test.ts
+++ b/server/src/__tests__/issue-recovery-actions.test.ts
@@ -1281,7 +1281,14 @@ describeEmbeddedPostgres("issue recovery actions", () => {
       cause: "workspace_validation_failed",
       ownerAgentId: managerId,
     });
-    expect(enqueueWakeup).not.toHaveBeenCalled();
+    expect(enqueueWakeup).toHaveBeenCalledOnce();
+    expect(enqueueWakeup).toHaveBeenCalledWith(
+      managerId,
+      expect.objectContaining({
+        reason: "source_scoped_recovery_action",
+        payload: expect.objectContaining({ recoveryCause: "workspace_validation_failed" }),
+      }),
+    );
   }, 15_000);
 
   it("escalates when an auto-repair retry fails workspace validation again", async () => {
@@ -1331,11 +1338,18 @@ describeEmbeddedPostgres("issue recovery actions", () => {
       cause: "workspace_validation_failed",
       ownerAgentId: managerId,
     });
-    expect(enqueueWakeup).not.toHaveBeenCalled();
+    expect(enqueueWakeup).toHaveBeenCalledOnce();
+    expect(enqueueWakeup).toHaveBeenCalledWith(
+      managerId,
+      expect.objectContaining({
+        reason: "source_scoped_recovery_action",
+        payload: expect.objectContaining({ recoveryCause: "workspace_validation_failed" }),
+      }),
+    );
   }, 15_000);
 
   it("does not trust run-result repository paths for workspace repair", async () => {
-    const { companyId, coderId, sourceIssue } = await seedCompany();
+    const { companyId, managerId, coderId, sourceIssue } = await seedCompany();
     const repoRoot = await createGitRepo();
     const expectedBranch = "repair/untrusted-expected";
     const actualBranch = "repair/untrusted-actual";
@@ -1381,7 +1395,14 @@ describeEmbeddedPostgres("issue recovery actions", () => {
 
     expect(await runGit(worktreePath, ["branch", "--show-current"]).then((result) => result.stdout.trim())).toBe(actualBranch);
     expect(await db.select().from(issueRecoveryActions).where(eq(issueRecoveryActions.sourceIssueId, sourceIssue.id))).toHaveLength(1);
-    expect(enqueueWakeup).not.toHaveBeenCalled();
+    expect(enqueueWakeup).toHaveBeenCalledOnce();
+    expect(enqueueWakeup).toHaveBeenCalledWith(
+      managerId,
+      expect.objectContaining({
+        reason: "source_scoped_recovery_action",
+        payload: expect.objectContaining({ recoveryCause: "workspace_validation_failed" }),
+      }),
+    );
   }, 15_000);
 
   it("never discards dirty work and routes unrecoverable workspace repair to the CTO", async () => {
@@ -1435,7 +1456,14 @@ describeEmbeddedPostgres("issue recovery actions", () => {
       ownerAgentId: managerId,
       nextAction: expect.stringContaining("git worktree branch incoherence"),
     });
-    expect(enqueueWakeup).not.toHaveBeenCalled();
+    expect(enqueueWakeup).toHaveBeenCalledOnce();
+    expect(enqueueWakeup).toHaveBeenCalledWith(
+      managerId,
+      expect.objectContaining({
+        reason: "source_scoped_recovery_action",
+        payload: expect.objectContaining({ recoveryCause: "workspace_validation_failed" }),
+      }),
+    );
   }, 15_000);
 
   it("keeps the source issue blocked when source-scoped wakeup is claimed synchronously", async () => {

--- a/server/src/__tests__/issue-recovery-actions.test.ts
+++ b/server/src/__tests__/issue-recovery-actions.test.ts
@@ -1405,6 +1405,67 @@ describeEmbeddedPostgres("issue recovery actions", () => {
     );
   }, 15_000);
 
+  it("does not repair an execution workspace without source issue ownership", async () => {
+    const { companyId, managerId, coderId, sourceIssue } = await seedCompany();
+    const repoRoot = await createGitRepo();
+    const expectedBranch = "repair/unowned-expected";
+    const actualBranch = "repair/unowned-actual";
+    const worktreePath = path.join(repoRoot, ".paperclip", "worktrees", "unowned-workspace");
+    await fs.mkdir(path.dirname(worktreePath), { recursive: true });
+    await runGit(repoRoot, ["branch", expectedBranch, "main"]);
+    await runGit(repoRoot, ["worktree", "add", "-b", actualBranch, worktreePath, "main"]);
+    const executionWorkspaceId = await seedExecutionWorkspace({
+      companyId,
+      sourceIssueId: sourceIssue.id,
+      repoRoot,
+      worktreePath,
+      branchName: expectedBranch,
+    });
+    await db
+      .update(executionWorkspaces)
+      .set({ sourceIssueId: null })
+      .where(eq(executionWorkspaces.id, executionWorkspaceId));
+    const enqueueWakeup = vi.fn(async () => null);
+    const recovery = recoveryService(db, { enqueueWakeup });
+
+    await recovery.escalateStrandedAssignedIssue({
+      issue: sourceIssue,
+      previousStatus: "in_progress",
+      latestRun: {
+        id: randomUUID(),
+        agentId: coderId,
+        status: "failed",
+        error: "workspace branch mismatch",
+        errorCode: "workspace_validation_failed",
+        contextSnapshot: {},
+        livenessState: "failed",
+        resultJson: {
+          workspaceValidation: {
+            reason: "git_worktree_branch_incoherence",
+            executionWorkspaceId,
+          },
+        },
+      },
+      recoveryCause: "workspace_validation_failed",
+    });
+
+    expect(await runGit(worktreePath, ["branch", "--show-current"]).then((result) => result.stdout.trim())).toBe(actualBranch);
+    const actions = await db.select().from(issueRecoveryActions).where(eq(issueRecoveryActions.sourceIssueId, sourceIssue.id));
+    expect(actions).toHaveLength(1);
+    expect(actions[0]).toMatchObject({
+      cause: "workspace_validation_failed",
+      ownerAgentId: managerId,
+    });
+    expect(enqueueWakeup).toHaveBeenCalledOnce();
+    expect(enqueueWakeup).toHaveBeenCalledWith(
+      managerId,
+      expect.objectContaining({
+        reason: "source_scoped_recovery_action",
+        payload: expect.objectContaining({ recoveryCause: "workspace_validation_failed" }),
+      }),
+    );
+  }, 15_000);
+
   it("never discards dirty work and routes unrecoverable workspace repair to the CTO", async () => {
     const { companyId, managerId, coderId, sourceIssue } = await seedCompany();
     const repoRoot = await createGitRepo();

--- a/server/src/__tests__/issue-recovery-actions.test.ts
+++ b/server/src/__tests__/issue-recovery-actions.test.ts
@@ -1,4 +1,9 @@
 import { randomUUID } from "node:crypto";
+import { execFile } from "node:child_process";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
 import express from "express";
 import request from "supertest";
 import { and, eq } from "drizzle-orm";
@@ -11,11 +16,14 @@ import {
   createDb,
   environmentLeases,
   environments,
+  executionWorkspaces,
   heartbeatRuns,
   issueComments,
   issueRecoveryActions,
   issueRelations,
   issues,
+  projects,
+  projectWorkspaces,
 } from "@paperclipai/db";
 import {
   getEmbeddedPostgresTestSupport,
@@ -29,6 +37,22 @@ import { recoveryService } from "../services/recovery/service.js";
 
 const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
 const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+const execFileAsync = promisify(execFile);
+
+async function runGit(cwd: string, args: string[]) {
+  return execFileAsync("git", ["-C", cwd, ...args], { cwd });
+}
+
+async function createGitRepo() {
+  const repoRoot = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-recovery-workspace-"));
+  await runGit(repoRoot, ["init", "-b", "main"]);
+  await runGit(repoRoot, ["config", "user.email", "tests@paperclip.local"]);
+  await runGit(repoRoot, ["config", "user.name", "Paperclip Tests"]);
+  await fs.writeFile(path.join(repoRoot, "README.md"), "initial\n", "utf8");
+  await runGit(repoRoot, ["add", "README.md"]);
+  await runGit(repoRoot, ["commit", "-m", "Initial commit"]);
+  return repoRoot;
+}
 
 function makeRecoveryActionRow(overrides: Record<string, unknown> = {}) {
   const now = new Date("2026-05-09T19:30:00.000Z");
@@ -135,6 +159,9 @@ describeEmbeddedPostgres("issue recovery actions", () => {
   afterEach(async () => {
     await db.delete(issueRecoveryActions);
     await db.delete(issueComments);
+    await db.delete(executionWorkspaces);
+    await db.delete(projectWorkspaces);
+    await db.delete(projects);
     await db.delete(environmentLeases);
     await db.delete(activityLog);
     await db.delete(heartbeatRuns);
@@ -198,6 +225,46 @@ describeEmbeddedPostgres("issue recovery actions", () => {
     });
     const [sourceIssue] = await db.select().from(issues).where(eq(issues.id, sourceIssueId));
     return { companyId, managerId, coderId, sourceIssueId, prefix, sourceIssue: sourceIssue! };
+  }
+
+  async function seedExecutionWorkspace(input: {
+    companyId: string;
+    sourceIssueId: string;
+    repoRoot: string;
+    worktreePath: string;
+    branchName: string;
+  }) {
+    const projectId = randomUUID();
+    const projectWorkspaceId = randomUUID();
+    const executionWorkspaceId = randomUUID();
+    await db.insert(projects).values({
+      id: projectId,
+      companyId: input.companyId,
+      name: "Recovery project",
+      status: "in_progress",
+    });
+    await db.insert(projectWorkspaces).values({
+      id: projectWorkspaceId,
+      companyId: input.companyId,
+      projectId,
+      name: "Primary",
+      cwd: input.repoRoot,
+      isPrimary: true,
+    });
+    await db.insert(executionWorkspaces).values({
+      id: executionWorkspaceId,
+      companyId: input.companyId,
+      projectId,
+      projectWorkspaceId,
+      sourceIssueId: input.sourceIssueId,
+      mode: "isolated_workspace",
+      strategyType: "git_worktree",
+      name: "Issue workspace",
+      cwd: input.worktreePath,
+      providerRef: input.worktreePath,
+      branchName: input.branchName,
+    });
+    return executionWorkspaceId;
   }
 
   async function seedHeartbeatRun(input: {
@@ -1071,6 +1138,155 @@ describeEmbeddedPostgres("issue recovery actions", () => {
       }),
     );
   });
+
+  it("repairs a stale git worktree link before creating a recovery action", async () => {
+    const { companyId, coderId, sourceIssue } = await seedCompany();
+    const repoRoot = await createGitRepo();
+    const expectedBranch = "repair/stale-link";
+    const originalWorktreePath = path.join(repoRoot, ".paperclip", "worktrees", "original");
+    const movedWorktreePath = path.join(repoRoot, ".paperclip", "worktrees", "moved");
+    await fs.mkdir(path.dirname(originalWorktreePath), { recursive: true });
+    await runGit(repoRoot, ["worktree", "add", "-b", expectedBranch, originalWorktreePath, "main"]);
+    await fs.rename(originalWorktreePath, movedWorktreePath);
+    const executionWorkspaceId = await seedExecutionWorkspace({
+      companyId,
+      sourceIssueId: sourceIssue.id,
+      repoRoot,
+      worktreePath: movedWorktreePath,
+      branchName: expectedBranch,
+    });
+    const enqueueWakeup = vi.fn(async () => null);
+    const recovery = recoveryService(db, { enqueueWakeup });
+
+    await recovery.escalateStrandedAssignedIssue({
+      issue: sourceIssue,
+      previousStatus: "in_progress",
+      latestRun: {
+        id: randomUUID(),
+        agentId: coderId,
+        status: "failed",
+        error: "workspace link is stale",
+        errorCode: "workspace_validation_failed",
+        contextSnapshot: {},
+        livenessState: "failed",
+        resultJson: {
+          workspaceValidation: {
+            reason: "git_worktree_branch_incoherence",
+            persistedExecutionWorkspaceId: executionWorkspaceId,
+            managedGitWorktreeBranch: {
+              repoRoot,
+              reasonCode: "not_registered",
+            },
+          },
+        },
+      },
+      recoveryCause: "workspace_validation_failed",
+    });
+
+    expect(await runGit(movedWorktreePath, ["status", "--porcelain"]).then((result) => result.stdout)).toBe("");
+    expect(await db.select().from(issueRecoveryActions).where(eq(issueRecoveryActions.sourceIssueId, sourceIssue.id))).toHaveLength(0);
+    expect(enqueueWakeup).toHaveBeenCalledOnce();
+  }, 15_000);
+
+  it("repairs a clean branch mismatch before creating a recovery action", async () => {
+    const { companyId, coderId, sourceIssue } = await seedCompany();
+    const repoRoot = await createGitRepo();
+    const expectedBranch = "repair/expected";
+    const actualBranch = "repair/actual";
+    const worktreePath = path.join(repoRoot, ".paperclip", "worktrees", "branch-mismatch");
+    await fs.mkdir(path.dirname(worktreePath), { recursive: true });
+    await runGit(repoRoot, ["branch", expectedBranch, "main"]);
+    await runGit(repoRoot, ["worktree", "add", "-b", actualBranch, worktreePath, "main"]);
+    const executionWorkspaceId = await seedExecutionWorkspace({
+      companyId,
+      sourceIssueId: sourceIssue.id,
+      repoRoot,
+      worktreePath,
+      branchName: expectedBranch,
+    });
+    const enqueueWakeup = vi.fn(async () => null);
+    const recovery = recoveryService(db, { enqueueWakeup });
+
+    await recovery.escalateStrandedAssignedIssue({
+      issue: sourceIssue,
+      previousStatus: "in_progress",
+      latestRun: {
+        id: randomUUID(),
+        agentId: coderId,
+        status: "failed",
+        error: "workspace branch mismatch",
+        errorCode: "workspace_validation_failed",
+        contextSnapshot: {},
+        livenessState: "failed",
+        resultJson: {
+          workspaceValidation: {
+            reason: "git_worktree_branch_incoherence",
+            executionWorkspaceId,
+            repoRoot,
+          },
+        },
+      },
+      recoveryCause: "workspace_validation_failed",
+    });
+
+    expect(await runGit(worktreePath, ["branch", "--show-current"]).then((result) => result.stdout.trim())).toBe(expectedBranch);
+    expect(await db.select().from(issueRecoveryActions).where(eq(issueRecoveryActions.sourceIssueId, sourceIssue.id))).toHaveLength(0);
+    expect(enqueueWakeup).toHaveBeenCalledOnce();
+  }, 15_000);
+
+  it("never discards dirty work and routes unrecoverable workspace repair to the CTO", async () => {
+    const { companyId, managerId, coderId, sourceIssue } = await seedCompany();
+    const repoRoot = await createGitRepo();
+    const expectedBranch = "repair/dirty-expected";
+    const actualBranch = "repair/dirty-actual";
+    const worktreePath = path.join(repoRoot, ".paperclip", "worktrees", "dirty-branch");
+    await fs.mkdir(path.dirname(worktreePath), { recursive: true });
+    await runGit(repoRoot, ["branch", expectedBranch, "main"]);
+    await runGit(repoRoot, ["worktree", "add", "-b", actualBranch, worktreePath, "main"]);
+    await fs.writeFile(path.join(worktreePath, "unsaved.txt"), "do not discard\n", "utf8");
+    const executionWorkspaceId = await seedExecutionWorkspace({
+      companyId,
+      sourceIssueId: sourceIssue.id,
+      repoRoot,
+      worktreePath,
+      branchName: expectedBranch,
+    });
+    const enqueueWakeup = vi.fn(async () => null);
+    const recovery = recoveryService(db, { enqueueWakeup });
+
+    await recovery.escalateStrandedAssignedIssue({
+      issue: sourceIssue,
+      previousStatus: "in_progress",
+      latestRun: {
+        id: randomUUID(),
+        agentId: coderId,
+        status: "failed",
+        error: "workspace branch mismatch",
+        errorCode: "workspace_validation_failed",
+        contextSnapshot: {},
+        livenessState: "failed",
+        resultJson: {
+          workspaceValidation: {
+            reason: "git_worktree_branch_incoherence",
+            executionWorkspaceId,
+            repoRoot,
+          },
+        },
+      },
+      recoveryCause: "workspace_validation_failed",
+    });
+
+    expect(await fs.readFile(path.join(worktreePath, "unsaved.txt"), "utf8")).toBe("do not discard\n");
+    expect(await runGit(worktreePath, ["branch", "--show-current"]).then((result) => result.stdout.trim())).toBe(actualBranch);
+    const actions = await db.select().from(issueRecoveryActions).where(eq(issueRecoveryActions.sourceIssueId, sourceIssue.id));
+    expect(actions).toHaveLength(1);
+    expect(actions[0]).toMatchObject({
+      cause: "workspace_validation_failed",
+      ownerAgentId: managerId,
+      nextAction: expect.stringContaining("git worktree branch incoherence"),
+    });
+    expect(enqueueWakeup).not.toHaveBeenCalled();
+  }, 15_000);
 
   it("keeps the source issue blocked when source-scoped wakeup is claimed synchronously", async () => {
     const { companyId, managerId, coderId, sourceIssue } = await seedCompany();

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -3161,7 +3161,11 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       });
     }
 
-    if (input.recoveryCause === "workspace_validation_failed") {
+    const latestRetryReason = readNonEmptyString(parseObject(input.latestRun?.contextSnapshot).retryReason);
+    if (
+      input.recoveryCause === "workspace_validation_failed" &&
+      latestRetryReason !== "workspace_validation_auto_repaired"
+    ) {
       const workspaceValidation = readWorkspaceValidationPayload(input.latestRun);
       if (workspaceValidation) {
         const repair = await attemptMechanicalWorkspaceValidationRepair({
@@ -3178,7 +3182,9 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
               `- Execution workspace: \`${repair.executionWorkspaceId ?? "unknown"}\``,
               `- Failed run: \`${input.latestRun?.id ?? "unknown"}\``,
               `- Repair result: ${repair.reason}`,
-              "- Next action: retry the source issue on the repaired workspace.",
+              input.issue.assigneeAgentId
+                ? "- Next action: retry the source issue on the repaired workspace."
+                : "- Next action: continue recovery escalation because the source issue has no agent assignee.",
             ].join("\n"),
             {},
             { authorType: "system" },
@@ -3223,8 +3229,8 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
                 executionWorkspaceId: repair.executionWorkspaceId,
               }, "normal_model"),
             });
+            return input.issue;
           }
-          return input.issue;
         }
       }
     }

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -74,6 +74,7 @@ import {
   withRecoveryModelProfileHint,
 } from "./model-profile-hint.js";
 import { isAutomaticRecoverySuppressedByPauseHold } from "./pause-hold-guard.js";
+import { attemptMechanicalWorkspaceValidationRepair } from "../workspace-runtime.js";
 
 const EXECUTION_PATH_HEARTBEAT_RUN_STATUSES = ["queued", "running", "scheduled_retry"] as const;
 const UNSUCCESSFUL_HEARTBEAT_RUN_TERMINAL_STATUSES = ["interrupted", "failed", "cancelled", "timed_out"] as const;
@@ -3158,6 +3159,74 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         previousStatus: input.previousStatus,
         latestRun: input.latestRun,
       });
+    }
+
+    if (input.recoveryCause === "workspace_validation_failed") {
+      const workspaceValidation = readWorkspaceValidationPayload(input.latestRun);
+      if (workspaceValidation) {
+        const repair = await attemptMechanicalWorkspaceValidationRepair({
+          db,
+          issue: input.issue,
+          workspaceValidation,
+        });
+        if (repair.repaired) {
+          await issuesSvc.addComment(
+            input.issue.id,
+            [
+              "Paperclip automatically repaired the execution workspace before recovery escalation.",
+              "",
+              `- Execution workspace: \`${repair.executionWorkspaceId ?? "unknown"}\``,
+              `- Failed run: \`${input.latestRun?.id ?? "unknown"}\``,
+              `- Repair result: ${repair.reason}`,
+              "- Next action: retry the source issue on the repaired workspace.",
+            ].join("\n"),
+            {},
+            { authorType: "system" },
+          );
+          await logActivity(db, {
+            companyId: input.issue.companyId,
+            actorType: "system",
+            actorId: "system",
+            agentId: null,
+            runId: null,
+            action: "execution_workspace.auto_repaired",
+            entityType: "execution_workspace",
+            entityId: repair.executionWorkspaceId ?? input.issue.id,
+            details: {
+              issueId: input.issue.id,
+              issueIdentifier: input.issue.identifier,
+              failedRunId: input.latestRun?.id ?? null,
+              recoveryCause: input.recoveryCause,
+              repairReason: repair.reason,
+            },
+          });
+          if (input.issue.assigneeAgentId) {
+            await deps.enqueueWakeup(input.issue.assigneeAgentId, {
+              source: "assignment",
+              triggerDetail: "system",
+              reason: "workspace_validation_auto_repaired",
+              idempotencyKey: `workspace_validation_auto_repaired:${input.issue.id}:${input.latestRun?.id ?? "unknown"}`,
+              payload: {
+                issueId: input.issue.id,
+                sourceIssueId: input.issue.id,
+                failedRunId: input.latestRun?.id ?? null,
+                executionWorkspaceId: repair.executionWorkspaceId,
+              },
+              requestedByActorType: "system",
+              requestedByActorId: null,
+              contextSnapshot: withRecoveryModelProfileHint({
+                issueId: input.issue.id,
+                taskId: input.issue.id,
+                wakeReason: "issue_continuation_needed",
+                retryReason: "workspace_validation_auto_repaired",
+                retryOfRunId: input.latestRun?.id ?? null,
+                executionWorkspaceId: repair.executionWorkspaceId,
+              }, "normal_model"),
+            });
+          }
+          return input.issue;
+        }
+      }
     }
 
     const recoveryCause = resolveStrandedRecoveryCause(input.latestRun, input.recoveryCause);

--- a/server/src/services/workspace-runtime.ts
+++ b/server/src/services/workspace-runtime.ts
@@ -2343,13 +2343,9 @@ export async function attemptMechanicalWorkspaceValidationRepair(input: {
       ))
       .limit(1)
     : [];
-  const evidenceRepoRoot =
-    asString(input.workspaceValidation.repoRoot, "").trim() ||
-    asString(managedBranch.repoRoot, "").trim() ||
-    null;
-  const repoRoot = asString(projectWorkspace?.cwd, "").trim() || evidenceRepoRoot;
+  const repoRoot = asString(projectWorkspace?.cwd, "").trim();
   if (!repoRoot || !await directoryExists(repoRoot)) {
-    return { repaired: false, executionWorkspaceId, reason: "source repository is missing" };
+    return { repaired: false, executionWorkspaceId, reason: "registered source repository is missing" };
   }
 
   let inspection = await inspectManagedGitWorktreeBranch({

--- a/server/src/services/workspace-runtime.ts
+++ b/server/src/services/workspace-runtime.ts
@@ -2283,6 +2283,132 @@ export async function inspectManagedGitWorktreeBranch(input: {
   };
 }
 
+export type MechanicalWorkspaceValidationRepairResult = {
+  repaired: boolean;
+  executionWorkspaceId: string | null;
+  reason: string;
+};
+
+export async function attemptMechanicalWorkspaceValidationRepair(input: {
+  db: Db;
+  issue: ExecutionWorkspaceIssueRef & { companyId: string };
+  workspaceValidation: Record<string, unknown>;
+}): Promise<MechanicalWorkspaceValidationRepairResult> {
+  const reason = asString(input.workspaceValidation.reason, "").trim();
+  if (reason !== GIT_WORKTREE_BRANCH_INCOHERENCE_REASON) {
+    return { repaired: false, executionWorkspaceId: null, reason: "workspace validation failure is not mechanically repairable" };
+  }
+
+  const managedBranch = parseObject(input.workspaceValidation.managedGitWorktreeBranch);
+  const executionWorkspaceId =
+    asString(input.workspaceValidation.executionWorkspaceId, "").trim() ||
+    asString(input.workspaceValidation.persistedExecutionWorkspaceId, "").trim() ||
+    asString(managedBranch.executionWorkspaceId, "").trim() ||
+    null;
+  if (!executionWorkspaceId) {
+    return { repaired: false, executionWorkspaceId: null, reason: "workspace validation evidence has no execution workspace id" };
+  }
+  if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(executionWorkspaceId)) {
+    return { repaired: false, executionWorkspaceId, reason: "workspace validation evidence has an invalid execution workspace id" };
+  }
+
+  const [workspace] = await input.db
+    .select()
+    .from(executionWorkspaces)
+    .where(and(
+      eq(executionWorkspaces.id, executionWorkspaceId),
+      eq(executionWorkspaces.companyId, input.issue.companyId),
+    ))
+    .limit(1);
+  if (!workspace) {
+    return { repaired: false, executionWorkspaceId, reason: "execution workspace no longer exists" };
+  }
+  if (workspace.sourceIssueId && workspace.sourceIssueId !== input.issue.id) {
+    return { repaired: false, executionWorkspaceId, reason: "execution workspace belongs to another issue" };
+  }
+
+  const worktreePath = asString(workspace.providerRef ?? workspace.cwd, "").trim();
+  const expectedBranchName = asString(workspace.branchName, "").trim();
+  if (!worktreePath || !expectedBranchName) {
+    return { repaired: false, executionWorkspaceId, reason: "execution workspace is missing its worktree path or recorded branch" };
+  }
+
+  const [projectWorkspace] = workspace.projectWorkspaceId
+    ? await input.db
+      .select({ cwd: projectWorkspaces.cwd })
+      .from(projectWorkspaces)
+      .where(and(
+        eq(projectWorkspaces.id, workspace.projectWorkspaceId),
+        eq(projectWorkspaces.companyId, input.issue.companyId),
+      ))
+      .limit(1)
+    : [];
+  const evidenceRepoRoot =
+    asString(input.workspaceValidation.repoRoot, "").trim() ||
+    asString(managedBranch.repoRoot, "").trim() ||
+    null;
+  const repoRoot = asString(projectWorkspace?.cwd, "").trim() || evidenceRepoRoot;
+  if (!repoRoot || !await directoryExists(repoRoot)) {
+    return { repaired: false, executionWorkspaceId, reason: "source repository is missing" };
+  }
+
+  let inspection = await inspectManagedGitWorktreeBranch({
+    repoRoot,
+    worktreePath,
+    expectedBranchName,
+  });
+
+  if (!inspection.valid && inspection.reasonCode === "not_registered") {
+    await runGit(["worktree", "repair", worktreePath], repoRoot).catch(() => null);
+    inspection = await inspectManagedGitWorktreeBranch({
+      repoRoot,
+      worktreePath,
+      expectedBranchName,
+    });
+  }
+
+  if (!inspection.valid && inspection.reasonCode === "branch_mismatch") {
+    try {
+      await ensureGitWorktreeBranchCoherent({
+        db: input.db,
+        repoRoot,
+        worktreePath,
+        expectedBranchName,
+        actualBranchName: inspection.actualBranchName,
+        sourceIssue: input.issue,
+        executionWorkspaceId,
+        enableWorkspaceBranchReconcileForward: true,
+        enableWorkspaceDirtyQuarantineRepair: false,
+        persistForwardReconcile: true,
+      });
+    } catch (error) {
+      return {
+        repaired: false,
+        executionWorkspaceId,
+        reason: error instanceof Error ? error.message : String(error),
+      };
+    }
+    const [updatedWorkspace] = await input.db
+      .select({ branchName: executionWorkspaces.branchName })
+      .from(executionWorkspaces)
+      .where(eq(executionWorkspaces.id, executionWorkspaceId))
+      .limit(1);
+    inspection = await inspectManagedGitWorktreeBranch({
+      repoRoot,
+      worktreePath,
+      expectedBranchName: updatedWorkspace?.branchName ?? expectedBranchName,
+    });
+  }
+
+  return inspection.valid
+    ? { repaired: true, executionWorkspaceId, reason: "workspace git metadata and branch now validate" }
+    : {
+        repaired: false,
+        executionWorkspaceId,
+        reason: inspection.reason ?? "workspace still fails validation after mechanical repair",
+      };
+}
+
 async function validateLinkedGitWorktree(input: {
   repoRoot: string;
   worktreePath: string;

--- a/server/src/services/workspace-runtime.ts
+++ b/server/src/services/workspace-runtime.ts
@@ -2323,7 +2323,7 @@ export async function attemptMechanicalWorkspaceValidationRepair(input: {
   if (!workspace) {
     return { repaired: false, executionWorkspaceId, reason: "execution workspace no longer exists" };
   }
-  if (workspace.sourceIssueId && workspace.sourceIssueId !== input.issue.id) {
+  if (!workspace.sourceIssueId || workspace.sourceIssueId !== input.issue.id) {
     return { repaired: false, executionWorkspaceId, reason: "execution workspace belongs to another issue" };
   }
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source control plane people use to manage AI-agent companies and their work.
> - Reliable execution depends on isolated git worktrees remaining linked to the source repository and coherent with the branch recorded for the execution workspace.
> - Workspace validation correctly stops execution when those invariants fail, but stale worktree links and clean branch mismatches are often mechanical faults rather than cases requiring human recovery.
> - Sending every mechanical validation failure to recovery creates avoidable operator work and delays otherwise safe continuations.
> - This pull request repairs only the mechanically provable cases before recovery escalation, while preserving the existing fail-closed path whenever the workspace is missing, ambiguous, or dirty.
> - The benefit is that safe workspace faults self-heal and retry automatically without ever risking uncommitted user work.

## Linked Issues or Issue Description

Refs #9538

**What happened?** A heartbeat that failed with `workspace_validation_failed` always created a recovery action, even when the failure was a stale git worktree registration or a clean, reconcilable branch mismatch.

**Expected behavior:** Paperclip should repair mechanically safe workspace metadata/branch cases and retry the source issue. Dirty or ambiguous workspaces must remain untouched and escalate through the existing recovery path.

**Steps to reproduce:**
1. Create an isolated execution workspace backed by a git worktree.
2. Either move the worktree so its git registration is stale, or check out a clean descendant branch while the execution workspace records the ancestor branch.
3. Process a failed run carrying `workspace_validation_failed` recovery evidence.
4. Before this change, observe a recovery action instead of an automatic repair and retry.

**Paperclip version or commit:** Reproduced against `origin/master` at `3ae2c30f2`.

**Deployment / installation:** Built from source; core server behavior; not adapter- or database-mode-specific.

## What Changed

- Added a company- and issue-scoped mechanical workspace repair helper for git worktree branch-incoherence evidence.
- Repairs stale worktree registrations with `git worktree repair`, then revalidates the managed workspace.
- Reuses the existing guarded branch-coherence reconciliation for clean forward-repair cases, with dirty quarantine explicitly disabled.
- Retries the source assignee after successful repair, records a system comment, and writes an activity event instead of creating a recovery action.
- Added focused coverage for stale-link repair, clean branch repair, and fail-closed dirty-work escalation to the CTO path.

## Verification

- `pnpm exec vitest run server/src/__tests__/issue-recovery-actions.test.ts --reporter=verbose` — 26 tests passed.
- `pnpm --filter @paperclipai/server typecheck` — passed.
- `git diff --check origin/master..HEAD` — passed.

## Risks

- Low-to-moderate behavioral risk: successful mechanical repairs now enqueue a retry instead of creating a recovery action.
- Repair eligibility is intentionally narrow: evidence must identify a company-scoped execution workspace owned by the source issue, the source repository must exist, and the final managed-worktree validation must pass.
- Dirty worktrees are never switched, reset, cleaned, or quarantined by this path; they retain their current branch and contents and continue to the governed recovery flow.
- No schema, migration, public API, or UI changes.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex coding agent. The runtime did not expose the exact backing model ID or context-window size; tool-enabled repository editing, shell execution, and code-review reasoning were used.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge