### PR TITLE
Allow manager-chain comments on review-held issues

### DIFF
--- a/server/src/__tests__/authorization-service.test.ts
+++ b/server/src/__tests__/authorization-service.test.ts
@@ -1699,6 +1699,54 @@ describeEmbeddedPostgres("authorization service", () => {
     });
   });
 
+  it("allows manager and CEO agents to comment on review-held subordinate issues without mutate authority", async () => {
+    const company = await createCompany(db, "ManagerComment");
+    const ceoAgent = await createAgent(db, company.id, { role: "ceo" });
+    const managerAgent = await createAgent(db, company.id, { reportsTo: ceoAgent.id });
+    const reviewerAgent = await createAgent(db, company.id, { reportsTo: managerAgent.id });
+    const peerAgent = await createAgent(db, company.id, { reportsTo: ceoAgent.id });
+    const issue = await createIssue(db, company.id, { assigneeAgentId: reviewerAgent.id });
+    const authz = authorizationService(db);
+    const resource = {
+      type: "issue" as const,
+      companyId: company.id,
+      issueId: issue.id,
+      assigneeAgentId: reviewerAgent.id,
+      status: "in_review",
+    };
+
+    for (const actorAgent of [managerAgent, ceoAgent]) {
+      const actor = {
+        type: "agent" as const,
+        agentId: actorAgent.id,
+        companyId: company.id,
+        source: "agent_key" as const,
+      };
+
+      await expect(authz.decide({ actor, action: "issue:comment", resource })).resolves.toMatchObject({
+        allowed: true,
+      });
+      await expect(authz.decide({ actor, action: "issue:mutate", resource })).resolves.toMatchObject({
+        allowed: false,
+        reason: "deny_missing_grant",
+      });
+    }
+
+    await expect(authz.decide({
+      actor: {
+        type: "agent" as const,
+        agentId: peerAgent.id,
+        companyId: company.id,
+        source: "agent_key" as const,
+      },
+      action: "issue:comment",
+      resource,
+    })).resolves.toMatchObject({
+      allowed: false,
+      reason: "deny_missing_grant",
+    });
+  });
+
   it("scopes task bridge keys away from company-wide reads and unrelated issue writes", async () => {
     const company = await createCompany(db, "TaskBridge");
     const bridgeAgent = await createAgent(db, company.id);

--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -792,6 +792,55 @@ describe("agent issue mutation checkout ownership", () => {
     expect(mockIssueService.update).not.toHaveBeenCalled();
   });
 
+  it("allows manager-chain agents to post non-decision comments without ownership of an active checkout", async () => {
+    mockAccessService.decide.mockImplementation(async (input: { action: string }) => ({
+      allowed: input.action === "issue:comment",
+      action: input.action,
+      reason: input.action === "issue:comment" ? "allow_manager_chain" : "deny_missing_grant",
+      explanation:
+        input.action === "issue:comment"
+          ? "Allowed because the actor manages the issue assignee in the reporting chain."
+          : "Missing permission.",
+    }));
+
+    const res = await request(await createApp(peerActor()))
+      .post(`/api/issues/${issueId}/comments`)
+      .send({ body: "Escalation note: review is blocked on product input." });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(201);
+    expect(mockIssueService.addComment).toHaveBeenCalledWith(
+      issueId,
+      "Escalation note: review is blocked on product input.",
+      expect.any(Object),
+      expect.any(Object),
+    );
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+    expect(mockIssueService.assertCheckoutOwner).not.toHaveBeenCalled();
+  });
+
+  it("keeps status decisions denied for manager-chain agents without issue mutation authority", async () => {
+    mockIssueService.getById.mockResolvedValue(makeIssue({ status: "in_review", assigneeAgentId: ownerAgentId }));
+    mockAccessService.decide.mockImplementation(async (input: { action: string }) => ({
+      allowed: input.action === "issue:comment",
+      action: input.action,
+      reason: input.action === "issue:comment" ? "allow_manager_chain" : "deny_missing_grant",
+      explanation:
+        input.action === "issue:comment"
+          ? "Allowed because the actor manages the issue assignee in the reporting chain."
+          : "Missing permission.",
+    }));
+
+    const res = await request(await createApp(peerActor()))
+      .patch(`/api/issues/${issueId}`)
+      .send({ status: "done", comment: "Approved." });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(403);
+    expect(res.body.error).toBe("Issue is outside this actor's authorization boundary");
+    expect(mockAccessService.decide).toHaveBeenCalledWith(expect.objectContaining({ action: "issue:mutate" }));
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+    expect(mockIssueService.addComment).not.toHaveBeenCalled();
+  });
+
   it("rejects non-mentioned peer agents from posting comments", async () => {
     mockAccessService.decide.mockImplementation(async (input: { action: string }) => ({
       allowed: input.action === "issue:read",

--- a/server/src/services/authorization.ts
+++ b/server/src/services/authorization.ts
@@ -1764,6 +1764,19 @@ export function authorizationService(db: Db) {
       }
       if (
         input.action === "issue:comment" &&
+        resource?.assigneeAgentId &&
+        (canCreateAgentsLegacy(actorAgent) || await isManagerOf(companyId, actorAgentId, resource.assigneeAgentId))
+      ) {
+        return allow({
+          action: input.action,
+          reason: canCreateAgentsLegacy(actorAgent) ? "allow_legacy_agent_creator" : "allow_manager_chain",
+          explanation: canCreateAgentsLegacy(actorAgent)
+            ? "Allowed by legacy agent creator authority."
+            : "Allowed because the actor manages the issue assignee in the reporting chain.",
+        });
+      }
+      if (
+        input.action === "issue:comment" &&
         resource?.issueId &&
         await agentHasMentionGrantOnIssue({
           action: input.action,

--- a/server/src/services/authorization.ts
+++ b/server/src/services/authorization.ts
@@ -1762,15 +1762,17 @@ export function authorizationService(db: Db) {
           explanation: "Allowed because the issue has no agent assignee.",
         });
       }
+      const isLegacyCreator = canCreateAgentsLegacy(actorAgent);
       if (
         input.action === "issue:comment" &&
         resource?.assigneeAgentId &&
-        (canCreateAgentsLegacy(actorAgent) || await isManagerOf(companyId, actorAgentId, resource.assigneeAgentId))
+        // Legacy agent creators are intentionally company-wide; manager grants are hierarchy-scoped.
+        (isLegacyCreator || await isManagerOf(companyId, actorAgentId, resource.assigneeAgentId))
       ) {
         return allow({
           action: input.action,
-          reason: canCreateAgentsLegacy(actorAgent) ? "allow_legacy_agent_creator" : "allow_manager_chain",
-          explanation: canCreateAgentsLegacy(actorAgent)
+          reason: isLegacyCreator ? "allow_legacy_agent_creator" : "allow_manager_chain",
+          explanation: isLegacyCreator
             ? "Allowed by legacy agent creator authority."
             : "Allowed because the actor manages the issue assignee in the reporting chain.",
         });


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The runtime authorization layer decides which agents may read, comment on, or mutate issues.
> - Review-held work often needs a manager or CEO to leave an escalation or coordination comment without taking over the task.
> - Before this change, that non-decision comment path could be denied at the review boundary, blocking legitimate managerial coordination.
> - The fix must stay narrow because review decisions and status changes are governed actions.
> - This pull request allows manager-chain and legacy agent-creator actors to perform `issue:comment` on assigned issues while leaving `issue:mutate` denied without a separate grant.
> - The benefit is that escalation comments can land during review without bypassing checkout ownership or approval/decision authorization.

## Linked Issues or Issue Description

Bug report inline because no related public GitHub issue was found in the pre-PR search for `manager comment review-held issue authz`.

### Pre-submission checklist

- [x] I have searched existing open and closed issues and this is not a duplicate.
- [x] I am on the latest released version of Paperclip (or can reproduce on `master`).
- [x] I have confirmed the error originates in Paperclip itself, not in my agent adapter, API provider, or local configuration.

### What happened?

When a manager-chain or CEO-style agent tried to post a non-decision escalation comment on an assigned review-held issue, the server authorization boundary could deny the comment request even though the actor needed only comment authority, not ownership or mutation authority.

### Expected behavior

Manager-chain and legacy agent-creator actors should be able to add coordination comments to assigned issues, including review-held issues, while status decisions and issue mutations remain denied unless the actor separately has `issue:mutate` authority.

### Steps to reproduce

1. Create an issue assigned to a subordinate agent and put it in review.
2. Authenticate as a manager-chain actor that does not own the active checkout and lacks broad issue mutation authority.
3. POST a non-decision comment to `/api/issues/:id/comments`.
4. Observe that the comment path can be denied before this fix.
5. Try PATCHing the same issue status as that actor and confirm mutation remains denied after this fix.

### Paperclip version or commit

Reproduced against `master` before `ead2748c2a4070aa5dadd40d8eb07cbe317cc7bc`.

### Deployment mode

Self-hosted server / local dev server API authorization path.

### Installation method

Built from source.

### Agent adapter(s) involved

Not adapter-specific (core bug).

### Database mode

Embedded PGlite in tests; authorization behavior is not database-engine-specific.

### Access context

Agent bearer API key.

### Node.js version

Not environment-specific.

### Operating system

Not environment-specific.

### Relevant logs or output

The focused regression tests in this PR cover the failure and expected behavior.

### Relevant config (if applicable)

Not applicable.

### Additional context

This is intentionally not an authorization broadening for review decisions: the route-level and service-level tests assert `issue:mutate` remains denied for manager-chain actors without mutation authority.

### Privacy checklist

- [x] I have reviewed all pasted output for PII, usernames, file paths, API keys, tokens, company names, and redacted where necessary.

## What Changed

- Added a narrow `issue:comment` authorization grant for legacy agent creators and manager-chain actors when an issue has an agent assignee.
- Preserved the existing denial for `issue:mutate` when the same actor lacks mutation authority.
- Added service-level authorization coverage for manager/CEO comment allowance, peer denial, and mutation denial.
- Added route-level coverage proving manager-chain actors can post non-decision comments without checkout ownership and still cannot make status decisions.

## Verification

- `pnpm run preflight:workspace-links && pnpm exec vitest run server/src/__tests__/authorization-service.test.ts server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts`
  - Result: 2 test files passed, 110 tests passed.

## Risks

- Low-to-moderate authorization risk because this changes access control behavior.
- The grant is intentionally limited to `issue:comment`; route and service tests assert `issue:mutate` remains denied for manager-chain actors without mutation authority.
- Rollback path: revert commit `ead2748c2a4070aa5dadd40d8eb07cbe317cc7bc`.
- CI and automated review are green on head `c9a28c95ff0509476b5f045563df9353fe0b4003`.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

OpenAI GPT-5 Codex in Codex CLI, with repository file access, shell command execution, GitHub CLI usage, and Paperclip control-plane API coordination.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
