### PR TITLE
feat: add OpenTelemetry custom spans and metrics for Paperclip execution paths

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -44,6 +44,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.888.0",
+    "@opentelemetry/api": "^1.9.0",
     "@paperclipai/adapter-claude-local": "workspace:*",
     "@paperclipai/adapter-codex-local": "workspace:*",
     "@paperclipai/adapter-cursor-local": "workspace:*",

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -9,6 +9,7 @@ import { httpLogger, errorHandler } from "./middleware/index.js";
 import { actorMiddleware } from "./middleware/auth.js";
 import { boardMutationGuard } from "./middleware/board-mutation-guard.js";
 import { privateHostnameGuard, resolvePrivateHostnameAllowSet } from "./middleware/private-hostname-guard.js";
+import { otelHttpMetrics } from "./otel/middleware.js";
 import { healthRoutes } from "./routes/health.js";
 import { companyRoutes } from "./routes/companies.js";
 import { companySkillRoutes } from "./routes/company-skills.js";
@@ -144,6 +145,7 @@ export async function createApp(
       (req as unknown as { rawBody: Buffer }).rawBody = buf;
     },
   }));
+  app.use(otelHttpMetrics());
   app.use(httpLogger);
   const privateHostnameGateEnabled = shouldEnablePrivateHostnameGuard({
     deploymentMode: opts.deploymentMode,

--- a/server/src/otel/metrics.ts
+++ b/server/src/otel/metrics.ts
@@ -1,0 +1,61 @@
+/**
+ * OpenTelemetry metric definitions for Paperclip server.
+ *
+ * Uses the OTel Metrics API so counters/histograms are no-ops when no
+ * MeterProvider is registered (i.e. when tracing-only or OTel is off).
+ * All metrics use the `paperclip_` prefix for easy identification.
+ */
+import { metrics } from "@opentelemetry/api";
+
+const meter = metrics.getMeter("paperclip-server");
+
+// --- HTTP metrics ---
+
+export const httpRequestsTotal = meter.createCounter("paperclip_http_requests_total", {
+  description: "Total number of HTTP requests",
+});
+
+export const httpRequestDuration = meter.createHistogram("paperclip_http_request_duration_seconds", {
+  description: "HTTP request duration in seconds",
+  unit: "s",
+});
+
+// --- Heartbeat metrics ---
+
+export const heartbeatActive = meter.createUpDownCounter("paperclip_heartbeat_active", {
+  description: "Number of currently active heartbeat executions",
+});
+
+export const heartbeatDuration = meter.createHistogram("paperclip_heartbeat_duration_seconds", {
+  description: "Heartbeat execution duration in seconds",
+  unit: "s",
+});
+
+export const heartbeatRunsTotal = meter.createCounter("paperclip_heartbeat_runs_total", {
+  description: "Total number of heartbeat runs by outcome",
+});
+
+// --- Plugin tool call metrics ---
+
+export const toolCallsTotal = meter.createCounter("paperclip_tool_calls_total", {
+  description: "Total number of plugin tool calls",
+});
+
+export const toolCallDuration = meter.createHistogram("paperclip_tool_call_duration_seconds", {
+  description: "Plugin tool call duration in seconds",
+  unit: "s",
+});
+
+// --- LLM / adapter metrics ---
+
+export const llmCallsTotal = meter.createCounter("paperclip_llm_calls_total", {
+  description: "Total number of LLM adapter invocations",
+});
+
+export const llmTokensTotal = meter.createCounter("paperclip_llm_tokens_total", {
+  description: "Total LLM tokens consumed",
+});
+
+export const costCentsTotal = meter.createCounter("paperclip_cost_cents_total", {
+  description: "Total cost in cents across all providers",
+});

--- a/server/src/otel/middleware.ts
+++ b/server/src/otel/middleware.ts
@@ -1,0 +1,29 @@
+/**
+ * Express middleware for OpenTelemetry HTTP metrics collection.
+ *
+ * Records request count and duration. Metrics are no-ops when no
+ * MeterProvider is registered (i.e. when OTel is off).
+ */
+import type { Request, Response, NextFunction, RequestHandler } from "express";
+import { httpRequestsTotal, httpRequestDuration } from "./metrics.js";
+
+/**
+ * Middleware that records HTTP request metrics (count + duration).
+ */
+export function otelHttpMetrics(): RequestHandler {
+  return (req: Request, res: Response, next: NextFunction) => {
+    const startTime = performance.now();
+
+    res.on("finish", () => {
+      const durationSec = (performance.now() - startTime) / 1000;
+      const method = req.method;
+      const route = (req as any).route?.path ?? req.path;
+      const status = String(res.statusCode);
+
+      httpRequestsTotal.add(1, { method, route, status });
+      httpRequestDuration.record(durationSec, { method, route });
+    });
+
+    next();
+  };
+}

--- a/server/src/otel/spans.ts
+++ b/server/src/otel/spans.ts
@@ -1,0 +1,278 @@
+/**
+ * Span helper wrappers for instrumenting Paperclip execution paths.
+ *
+ * Each function creates a named span, runs the provided callback within it,
+ * records attributes, and properly handles errors. Uses the OTel API tracer
+ * directly — spans are no-ops when no TracerProvider is registered (i.e.
+ * when OTEL_EXPORTER_OTLP_ENDPOINT is unset).
+ *
+ * Works with the existing instrumentation.ts auto-instrumentation: custom
+ * spans nest inside the auto-generated HTTP/Express spans.
+ */
+import { SpanStatusCode, trace } from "@opentelemetry/api";
+import type { Span } from "@opentelemetry/api";
+import {
+  heartbeatActive,
+  heartbeatDuration,
+  heartbeatRunsTotal,
+  toolCallsTotal,
+  toolCallDuration,
+  llmCallsTotal,
+  llmTokensTotal,
+  costCentsTotal,
+} from "./metrics.js";
+
+const TRACER_NAME = "paperclip-server";
+
+function getTracer() {
+  return trace.getTracer(TRACER_NAME);
+}
+
+/**
+ * Wrap the entire heartbeat executeRun() call in a root span.
+ */
+export async function withHeartbeatSpan<T>(
+  attrs: {
+    runId: string;
+    agentId: string;
+    agentName?: string;
+    issueId?: string | null;
+    companyId?: string;
+  },
+  fn: (span: Span) => Promise<T>,
+): Promise<T> {
+  return getTracer().startActiveSpan("heartbeat.execute", async (span) => {
+    const startTime = performance.now();
+    heartbeatActive.add(1);
+
+    span.setAttributes({
+      "heartbeat.run_id": attrs.runId,
+      "heartbeat.agent_id": attrs.agentId,
+      ...(attrs.agentName ? { "heartbeat.agent_name": attrs.agentName } : {}),
+      ...(attrs.issueId ? { "heartbeat.issue_id": attrs.issueId } : {}),
+      ...(attrs.companyId ? { "heartbeat.company_id": attrs.companyId } : {}),
+    });
+
+    let outcome = "succeeded";
+    try {
+      return await fn(span);
+    } catch (err) {
+      outcome = "failed";
+      span.setStatus({ code: SpanStatusCode.ERROR, message: err instanceof Error ? err.message : String(err) });
+      span.recordException(err instanceof Error ? err : new Error(String(err)));
+      throw err;
+    } finally {
+      const durationSec = (performance.now() - startTime) / 1000;
+      heartbeatActive.add(-1);
+      heartbeatDuration.record(durationSec, { agent_id: attrs.agentId, status: outcome });
+      heartbeatRunsTotal.add(1, { agent_id: attrs.agentId, status: outcome });
+      span.end();
+    }
+  });
+}
+
+/**
+ * Create a child span for a sub-phase of heartbeat execution.
+ */
+export async function withHeartbeatChildSpan<T>(
+  name: string,
+  attrs: Record<string, string | number | boolean>,
+  fn: (span: Span) => Promise<T>,
+): Promise<T> {
+  return getTracer().startActiveSpan(name, async (span) => {
+    span.setAttributes(attrs);
+    try {
+      return await fn(span);
+    } catch (err) {
+      span.setStatus({ code: SpanStatusCode.ERROR, message: err instanceof Error ? err.message : String(err) });
+      span.recordException(err instanceof Error ? err : new Error(String(err)));
+      throw err;
+    } finally {
+      span.end();
+    }
+  });
+}
+
+/**
+ * Wrap adapter.execute() in a span and record LLM metrics.
+ */
+export async function withAdapterSpan<T>(
+  attrs: {
+    adapterType: string;
+    agentId: string;
+    runId: string;
+  },
+  fn: (span: Span) => Promise<T>,
+): Promise<T> {
+  return getTracer().startActiveSpan("adapter.execute", async (span) => {
+    span.setAttributes({
+      "adapter.type": attrs.adapterType,
+      "adapter.agent_id": attrs.agentId,
+      "adapter.run_id": attrs.runId,
+    });
+
+    try {
+      return await fn(span);
+    } catch (err) {
+      span.setStatus({ code: SpanStatusCode.ERROR, message: err instanceof Error ? err.message : String(err) });
+      span.recordException(err instanceof Error ? err : new Error(String(err)));
+      throw err;
+    } finally {
+      span.end();
+    }
+  });
+}
+
+/**
+ * Record LLM result metrics after adapter execution completes.
+ * Call this inside the adapter span after getting the result.
+ */
+export function recordAdapterResult(
+  span: Span,
+  result: {
+    provider?: string | null;
+    model?: string | null;
+    inputTokens?: number | null;
+    cachedInputTokens?: number | null;
+    outputTokens?: number | null;
+    costUsd?: number | null;
+    billingType?: string | null;
+  },
+): void {
+  const provider = result.provider ?? "unknown";
+  const model = result.model ?? "unknown";
+
+  span.setAttributes({
+    "llm.provider": provider,
+    "llm.model": model,
+    ...(result.inputTokens != null ? { "llm.tokens.input": result.inputTokens } : {}),
+    ...(result.outputTokens != null ? { "llm.tokens.output": result.outputTokens } : {}),
+    ...(result.costUsd != null ? { "llm.cost_usd": result.costUsd } : {}),
+  });
+
+  llmCallsTotal.add(1, { provider, model });
+
+  if (result.inputTokens != null && result.inputTokens > 0) {
+    llmTokensTotal.add(result.inputTokens, { provider, model, type: "input" });
+  }
+  if (result.cachedInputTokens != null && result.cachedInputTokens > 0) {
+    llmTokensTotal.add(result.cachedInputTokens, { provider, model, type: "cached_input" });
+  }
+  if (result.outputTokens != null && result.outputTokens > 0) {
+    llmTokensTotal.add(result.outputTokens, { provider, model, type: "output" });
+  }
+  if (result.costUsd != null && result.costUsd > 0) {
+    const costCents = Math.round(result.costUsd * 100);
+    costCentsTotal.add(costCents, { provider, billing_type: result.billingType ?? "unknown" });
+  }
+}
+
+/**
+ * Wrap a plugin tool execution in a span.
+ */
+export async function withToolCallSpan<T>(
+  attrs: {
+    toolName: string;
+    pluginId?: string;
+    agentId?: string;
+    runId?: string;
+  },
+  fn: (span: Span) => Promise<T>,
+): Promise<T> {
+  return getTracer().startActiveSpan("plugin.tool.execute", async (span) => {
+    const startTime = performance.now();
+
+    span.setAttributes({
+      "tool.name": attrs.toolName,
+      ...(attrs.pluginId ? { "tool.plugin_id": attrs.pluginId } : {}),
+      ...(attrs.agentId ? { "tool.agent_id": attrs.agentId } : {}),
+      ...(attrs.runId ? { "tool.run_id": attrs.runId } : {}),
+    });
+
+    let status = "success";
+    try {
+      return await fn(span);
+    } catch (err) {
+      status = "error";
+      span.setStatus({ code: SpanStatusCode.ERROR, message: err instanceof Error ? err.message : String(err) });
+      span.recordException(err instanceof Error ? err : new Error(String(err)));
+      throw err;
+    } finally {
+      const durationSec = (performance.now() - startTime) / 1000;
+      toolCallsTotal.add(1, { tool: attrs.toolName, status });
+      toolCallDuration.record(durationSec, { tool: attrs.toolName });
+      span.end();
+    }
+  });
+}
+
+/**
+ * Wrap an approval state transition in a span.
+ */
+export async function withApprovalSpan<T>(
+  name: string,
+  attrs: Record<string, string | number | boolean>,
+  fn: (span: Span) => Promise<T>,
+): Promise<T> {
+  return getTracer().startActiveSpan(name, async (span) => {
+    span.setAttributes(attrs);
+    try {
+      return await fn(span);
+    } catch (err) {
+      span.setStatus({ code: SpanStatusCode.ERROR, message: err instanceof Error ? err.message : String(err) });
+      span.recordException(err instanceof Error ? err : new Error(String(err)));
+      throw err;
+    } finally {
+      span.end();
+    }
+  });
+}
+
+/**
+ * Wrap a cost event recording in a span.
+ */
+export async function withCostEventSpan<T>(
+  attrs: {
+    provider: string;
+    model: string;
+    costCents: number;
+    billingType: string;
+  },
+  fn: (span: Span) => Promise<T>,
+): Promise<T> {
+  return getTracer().startActiveSpan("cost.record_event", async (span) => {
+    span.setAttributes({
+      "cost.provider": attrs.provider,
+      "cost.model": attrs.model,
+      "cost.cents": attrs.costCents,
+      "cost.billing_type": attrs.billingType,
+    });
+    try {
+      return await fn(span);
+    } catch (err) {
+      span.setStatus({ code: SpanStatusCode.ERROR, message: err instanceof Error ? err.message : String(err) });
+      span.recordException(err instanceof Error ? err : new Error(String(err)));
+      throw err;
+    } finally {
+      span.end();
+    }
+  });
+}
+
+/**
+ * Get the current trace context for propagation to child processes.
+ * Returns W3C Trace Context headers (traceparent, tracestate).
+ */
+export function getTraceContextHeaders(): Record<string, string> {
+  const headers: Record<string, string> = {};
+  const activeSpan = trace.getActiveSpan();
+  if (activeSpan) {
+    const spanContext = activeSpan.spanContext();
+    const traceFlags = spanContext.traceFlags.toString(16).padStart(2, "0");
+    headers["traceparent"] = `00-${spanContext.traceId}-${spanContext.spanId}-${traceFlags}`;
+    if (spanContext.traceState) {
+      headers["tracestate"] = spanContext.traceState.serialize();
+    }
+  }
+  return headers;
+}

--- a/server/src/services/approvals.ts
+++ b/server/src/services/approvals.ts
@@ -3,6 +3,7 @@ import type { Db } from "@paperclipai/db";
 import { approvalComments, approvals } from "@paperclipai/db";
 import { notFound, unprocessable } from "../errors.js";
 import { redactCurrentUserText } from "../log-redaction.js";
+import { withApprovalSpan } from "../otel/spans.js";
 import { agentService } from "./agents.js";
 import { budgetService } from "./budgets.js";
 import { notifyHireApproved } from "./hire-hook.js";
@@ -40,41 +41,47 @@ export function approvalService(db: Db) {
     decidedByUserId: string,
     decisionNote: string | null | undefined,
   ): Promise<ResolutionResult> {
-    const existing = await getExistingApproval(id);
-    if (!canResolveStatuses.has(existing.status)) {
-      if (existing.status === targetStatus) {
-        return { approval: existing, applied: false };
-      }
-      throw unprocessable(
-        `Only pending or revision requested approvals can be ${targetStatus === "approved" ? "approved" : "rejected"}`,
-      );
-    }
+    return withApprovalSpan(
+      "approval.resolve",
+      { "approval.id": id, "approval.target_status": targetStatus },
+      async () => {
+        const existing = await getExistingApproval(id);
+        if (!canResolveStatuses.has(existing.status)) {
+          if (existing.status === targetStatus) {
+            return { approval: existing, applied: false };
+          }
+          throw unprocessable(
+            `Only pending or revision requested approvals can be ${targetStatus === "approved" ? "approved" : "rejected"}`,
+          );
+        }
 
-    const now = new Date();
-    const updated = await db
-      .update(approvals)
-      .set({
-        status: targetStatus,
-        decidedByUserId,
-        decisionNote: decisionNote ?? null,
-        decidedAt: now,
-        updatedAt: now,
-      })
-      .where(and(eq(approvals.id, id), inArray(approvals.status, resolvableStatuses)))
-      .returning()
-      .then((rows) => rows[0] ?? null);
+        const now = new Date();
+        const updated = await db
+          .update(approvals)
+          .set({
+            status: targetStatus,
+            decidedByUserId,
+            decisionNote: decisionNote ?? null,
+            decidedAt: now,
+            updatedAt: now,
+          })
+          .where(and(eq(approvals.id, id), inArray(approvals.status, resolvableStatuses)))
+          .returning()
+          .then((rows) => rows[0] ?? null);
 
-    if (updated) {
-      return { approval: updated, applied: true };
-    }
+        if (updated) {
+          return { approval: updated, applied: true };
+        }
 
-    const latest = await getExistingApproval(id);
-    if (latest.status === targetStatus) {
-      return { approval: latest, applied: false };
-    }
+        const latest = await getExistingApproval(id);
+        if (latest.status === targetStatus) {
+          return { approval: latest, applied: false };
+        }
 
-    throw unprocessable(
-      `Only pending or revision requested approvals can be ${targetStatus === "approved" ? "approved" : "rejected"}`,
+        throw unprocessable(
+          `Only pending or revision requested approvals can be ${targetStatus === "approved" ? "approved" : "rejected"}`,
+        );
+      },
     );
   }
 

--- a/server/src/services/costs.ts
+++ b/server/src/services/costs.ts
@@ -4,6 +4,7 @@ import type { Db } from "@paperclipai/db";
 import { activityLog, agents, companies, costEvents, issues, projects } from "@paperclipai/db";
 import { notFound, unprocessable } from "../errors.js";
 import { budgetService, type BudgetServiceHooks } from "./budgets.js";
+import { withCostEventSpan } from "../otel/spans.js";
 
 export interface CostDateRange {
   from?: Date;
@@ -52,53 +53,63 @@ export function costService(db: Db, budgetHooks: BudgetServiceHooks = {}) {
   const budgets = budgetService(db, budgetHooks);
   return {
     createEvent: async (companyId: string, data: Omit<typeof costEvents.$inferInsert, "companyId">) => {
-      const agent = await db
-        .select()
-        .from(agents)
-        .where(eq(agents.id, data.agentId))
-        .then((rows) => rows[0] ?? null);
-
-      if (!agent) throw notFound("Agent not found");
-      if (agent.companyId !== companyId) {
-        throw unprocessable("Agent does not belong to company");
-      }
-
-      const event = await db
-        .insert(costEvents)
-        .values({
-          ...data,
-          companyId,
-          biller: data.biller ?? data.provider,
+      return withCostEventSpan(
+        {
+          provider: data.provider ?? "unknown",
+          model: data.model ?? "unknown",
+          costCents: data.costCents ?? 0,
           billingType: data.billingType ?? "unknown",
-          cachedInputTokens: data.cachedInputTokens ?? 0,
-        })
-        .returning()
-        .then((rows) => rows[0]);
+        },
+        async () => {
+          const agent = await db
+            .select()
+            .from(agents)
+            .where(eq(agents.id, data.agentId))
+            .then((rows) => rows[0] ?? null);
 
-      const [agentMonthSpend, companyMonthSpend] = await Promise.all([
-        getMonthlySpendTotal(db, { companyId, agentId: event.agentId }),
-        getMonthlySpendTotal(db, { companyId }),
-      ]);
+          if (!agent) throw notFound("Agent not found");
+          if (agent.companyId !== companyId) {
+            throw unprocessable("Agent does not belong to company");
+          }
 
-      await db
-        .update(agents)
-        .set({
-          spentMonthlyCents: agentMonthSpend,
-          updatedAt: new Date(),
-        })
-        .where(eq(agents.id, event.agentId));
+          const event = await db
+            .insert(costEvents)
+            .values({
+              ...data,
+              companyId,
+              biller: data.biller ?? data.provider,
+              billingType: data.billingType ?? "unknown",
+              cachedInputTokens: data.cachedInputTokens ?? 0,
+            })
+            .returning()
+            .then((rows) => rows[0]);
 
-      await db
-        .update(companies)
-        .set({
-          spentMonthlyCents: companyMonthSpend,
-          updatedAt: new Date(),
-        })
-        .where(eq(companies.id, companyId));
+          const [agentMonthSpend, companyMonthSpend] = await Promise.all([
+            getMonthlySpendTotal(db, { companyId, agentId: event.agentId }),
+            getMonthlySpendTotal(db, { companyId }),
+          ]);
 
-      await budgets.evaluateCostEvent(event);
+          await db
+            .update(agents)
+            .set({
+              spentMonthlyCents: agentMonthSpend,
+              updatedAt: new Date(),
+            })
+            .where(eq(agents.id, event.agentId));
 
-      return event;
+          await db
+            .update(companies)
+            .set({
+              spentMonthlyCents: companyMonthSpend,
+              updatedAt: new Date(),
+            })
+            .where(eq(companies.id, companyId));
+
+          await budgets.evaluateCostEvent(event);
+
+          return event;
+        },
+      );
     },
 
     summary: async (companyId: string, range?: CostDateRange) => {

--- a/server/src/services/plugin-tool-dispatcher.ts
+++ b/server/src/services/plugin-tool-dispatcher.ts
@@ -39,6 +39,7 @@ import {
 } from "./plugin-tool-registry.js";
 import { pluginRegistryService } from "./plugin-registry.js";
 import { logger } from "../middleware/logger.js";
+import { withToolCallSpan } from "../otel/spans.js";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -407,10 +408,24 @@ export function createPluginToolDispatcher(
         "dispatching tool execution",
       );
 
-      const result = await registry.executeTool(
-        namespacedName,
-        parameters,
-        runContext,
+      const result = await withToolCallSpan(
+        {
+          toolName: namespacedName,
+          agentId: runContext.agentId,
+          runId: runContext.runId,
+        },
+        async (span) => {
+          const res = await registry.executeTool(
+            namespacedName,
+            parameters,
+            runContext,
+          );
+          span.setAttribute("tool.plugin_id", res.pluginId);
+          if (res.result.error) {
+            span.setAttribute("tool.error", true);
+          }
+          return res;
+        },
       );
 
       log.debug(


### PR DESCRIPTION
## Summary

- Adds manual OTel instrumentation on top of existing auto-instrumentation in `instrumentation.ts`
- Uses `@opentelemetry/api` directly so spans and metrics are no-ops when no SDK is registered
- Adds span helpers for heartbeat, adapter, tool call, approval, and cost paths
- Adds Prometheus-compatible metric definitions (HTTP, heartbeat, tool, LLM, cost)
- Adds HTTP metrics middleware to Express pipeline
- Wraps approval resolution, cost event creation, and tool dispatch in spans

## Files changed

- `server/package.json` — adds `@opentelemetry/api` dependency
- `server/src/otel/metrics.ts` — metric definitions
- `server/src/otel/spans.ts` — span helper functions
- `server/src/otel/middleware.ts` — HTTP metrics middleware
- `server/src/app.ts` — registers OTel HTTP metrics middleware
- `server/src/services/approvals.ts` — wraps approval resolution in spans
- `server/src/services/costs.ts` — wraps cost event creation in spans
- `server/src/services/plugin-tool-dispatcher.ts` — wraps tool dispatch in spans

## Notes

Supersedes PR #9618 (which was blocked by merge conflicts from the fork being behind upstream). This version cherry-picks only the OTel commit onto the fork's current master to avoid workflow scope issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>