### PR TITLE
feat(mcp): add document-annotation tools and includeAnnotationComments

### DIFF
--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -44,6 +44,8 @@ Read tools:
 - `paperclipListIssueApprovals`
 - `paperclipListDocuments`
 - `paperclipGetDocument`
+- `paperclipListDocumentAnnotations`
+- `paperclipGetDocumentAnnotation`
 - `paperclipListDocumentRevisions`
 - `paperclipListProjects`
 - `paperclipGetProject`

--- a/packages/mcp-server/src/tools.test.ts
+++ b/packages/mcp-server/src/tools.test.ts
@@ -374,6 +374,105 @@ describe("paperclip MCP tools", () => {
     });
   });
 
+  it("lists document annotations with default status and includeComments query params", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      mockJsonResponse([{ id: "thread-1" }]),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const tool = getTool("paperclipListDocumentAnnotations");
+    await tool.execute({
+      issueId: "PAP-1135",
+      key: "plan",
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url] = fetchMock.mock.calls[0] as [string];
+    expect(String(url)).toBe(
+      "http://localhost:3100/api/issues/PAP-1135/documents/plan/annotations?status=all&includeComments=true",
+    );
+  });
+
+  it("honors status and includeComments args when listing document annotations", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      mockJsonResponse([{ id: "thread-1", status: "open" }]),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const tool = getTool("paperclipListDocumentAnnotations");
+    await tool.execute({
+      issueId: "PAP-1135",
+      key: "plan",
+      status: "open",
+      includeComments: false,
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url] = fetchMock.mock.calls[0] as [string];
+    expect(String(url)).toBe(
+      "http://localhost:3100/api/issues/PAP-1135/documents/plan/annotations?status=open&includeComments=false",
+    );
+  });
+
+  it("gets a document annotation thread by id", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      mockJsonResponse({ id: "thread-1", comments: [] }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const tool = getTool("paperclipGetDocumentAnnotation");
+    await tool.execute({
+      issueId: "PAP-1135",
+      key: "plan",
+      threadId: "44444444-4444-4444-4444-444444444444",
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url] = fetchMock.mock.calls[0] as [string];
+    expect(String(url)).toBe(
+      "http://localhost:3100/api/issues/PAP-1135/documents/plan/annotations/44444444-4444-4444-4444-444444444444",
+    );
+  });
+
+  it("appends includeAnnotationComments query param when getting a document", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      mockJsonResponse({ key: "plan", body: "# Plan" }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const tool = getTool("paperclipGetDocument");
+    await tool.execute({
+      issueId: "PAP-1135",
+      key: "plan",
+      includeAnnotationComments: true,
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url] = fetchMock.mock.calls[0] as [string];
+    expect(String(url)).toBe(
+      "http://localhost:3100/api/issues/PAP-1135/documents/plan?includeAnnotationComments=true",
+    );
+  });
+
+  it("omits query string when getting a document without includeAnnotationComments", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      mockJsonResponse({ key: "plan", body: "# Plan" }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const tool = getTool("paperclipGetDocument");
+    await tool.execute({
+      issueId: "PAP-1135",
+      key: "plan",
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url] = fetchMock.mock.calls[0] as [string];
+    expect(String(url)).toBe(
+      "http://localhost:3100/api/issues/PAP-1135/documents/plan",
+    );
+  });
+
   it("rejects invalid generic request paths", async () => {
     vi.stubGlobal("fetch", vi.fn());
 

--- a/packages/mcp-server/src/tools.ts
+++ b/packages/mcp-server/src/tools.ts
@@ -85,6 +85,19 @@ const listCommentsSchema = z.object({
   limit: z.number().int().positive().max(500).optional(),
 });
 
+const listDocumentAnnotationsSchema = z.object({
+  issueId: issueIdSchema,
+  key: documentKeySchema,
+  status: z.enum(["open", "resolved", "all"]).optional().default("all"),
+  includeComments: z.boolean().optional().default(true),
+});
+
+const getDocumentToolSchema = z.object({
+  issueId: issueIdSchema,
+  key: documentKeySchema,
+  includeAnnotationComments: z.boolean().optional(),
+});
+
 const upsertDocumentToolSchema = z.object({
   issueId: issueIdSchema,
   key: documentKeySchema,
@@ -295,7 +308,7 @@ export function createToolDefinitions(client: PaperclipApiClient): ToolDefinitio
     ),
     makeTool(
       "paperclipListComments",
-      "List issue comments with incremental options",
+      "List issue-thread comments on an issue (general discussion), with incremental options. For inline highlight comments on issue documents, use paperclipListDocumentAnnotations instead.",
       listCommentsSchema,
       async ({ issueId, after, order, limit }) => {
         const params = new URLSearchParams();
@@ -328,9 +341,44 @@ export function createToolDefinitions(client: PaperclipApiClient): ToolDefinitio
     makeTool(
       "paperclipGetDocument",
       "Get one issue document by key",
-      z.object({ issueId: issueIdSchema, key: documentKeySchema }),
-      async ({ issueId, key }) =>
-        client.requestJson("GET", `/issues/${encodeURIComponent(issueId)}/documents/${encodeURIComponent(key)}`),
+      getDocumentToolSchema,
+      async ({ issueId, key, includeAnnotationComments }) => {
+        const params = new URLSearchParams();
+        if (includeAnnotationComments === true) params.set("includeAnnotationComments", "true");
+        const qs = params.toString();
+        return client.requestJson(
+          "GET",
+          `/issues/${encodeURIComponent(issueId)}/documents/${encodeURIComponent(key)}${qs ? `?${qs}` : ""}`,
+        );
+      },
+    ),
+    makeTool(
+      "paperclipListDocumentAnnotations",
+      "List a document's inline annotations (highlights) with their comment threads/content — read reviewer comments left on a document. Distinct from paperclipListComments (issue-thread comments).",
+      listDocumentAnnotationsSchema,
+      async ({ issueId, key, status, includeComments }) => {
+        const params = new URLSearchParams();
+        params.set("status", status);
+        params.set("includeComments", includeComments ? "true" : "false");
+        return client.requestJson(
+          "GET",
+          `/issues/${encodeURIComponent(issueId)}/documents/${encodeURIComponent(key)}/annotations?${params.toString()}`,
+        );
+      },
+    ),
+    makeTool(
+      "paperclipGetDocumentAnnotation",
+      "Get one document inline annotation thread by id, including its comment thread",
+      z.object({
+        issueId: issueIdSchema,
+        key: documentKeySchema,
+        threadId: z.string().uuid(),
+      }),
+      async ({ issueId, key, threadId }) =>
+        client.requestJson(
+          "GET",
+          `/issues/${encodeURIComponent(issueId)}/documents/${encodeURIComponent(key)}/annotations/${encodeURIComponent(threadId)}`,
+        ),
     ),
     makeTool(
       "paperclipListDocumentRevisions",


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Agents reach the board through the MCP tool surface — that curated set of tools is, in practice, the whole API an agent can discover and use
> - Document annotations are a first-class review channel: a human leaves inline comments on an issue document, and those threads carry the actual feedback
> - The MCP surface had no tool for reading them, so an agent could be reviewed but could not read its review — it had to hand-compose undocumented REST calls, which is exactly what the curated surface exists to prevent
> - This pull request adds two read tools for annotations and an opt-in flag on the existing document getter
> - The benefit is that agents can act on inline review feedback through the supported surface, closing a read/write asymmetry rather than adding new capability

## Linked Issues or Issue Description

Fixes #9674

## What Changed

- `packages/mcp-server/src/tools.ts`: new tool `paperclipListDocumentAnnotations(issueId, key, { status?, includeComments? })` → `GET /issues/:id/documents/:key/annotations`. Zod defaults are `status="all"` and `includeComments=true`, so both open and resolved threads come back with comment bodies unless the caller narrows it.
- `packages/mcp-server/src/tools.ts`: new tool `paperclipGetDocumentAnnotation` for fetching a single thread by id.
- `packages/mcp-server/src/tools.ts`: `paperclipGetDocument` gains an optional `includeAnnotationComments` boolean, passed through to the existing endpoint parameter.
- `packages/mcp-server/src/tools.ts`: clarified the `paperclipListComments` description — it returns issue-thread comments, not document annotations. The two were easy to confuse, which is part of how the gap went unnoticed.
- `packages/mcp-server/src/tools.test.ts`: coverage for the new tools and the pass-through flag.
- `packages/mcp-server/README.md`: documented the new tools.

## Verification

- `pnpm --filter @paperclipai/mcp-server test` → passes, including the added cases.
- Manually exercised against a live instance: an agent called `paperclipListDocumentAnnotations` on an issue document carrying nine inline review comments and received all nine threads with bodies. Before the change the same agent had no tool that returned them.
- The new parameters are additive; existing calls to `paperclipGetDocument` behave exactly as before when the flag is omitted.

## Risks

Low risk.

- Read-only tools: no writes, no schema change, no migration.
- The only change to existing behavior is a description string on `paperclipListComments`; the tool's contract is untouched.
- `includeComments=true` as a default means larger responses for annotation-heavy documents. That is the useful default for the read-the-feedback case, and callers can set it to `false`. If maintainers prefer a conservative default, that is a one-line change and I am happy to make it.
- Tool-surface additions increase the token cost of the tool list for every agent. Two tools is a small increment, but it is a real trade-off worth naming.

## Model Used

Claude Opus 4.6 (`claude-opus-4-6`) authored the original change; this description was written with Claude Opus 5 (`claude-opus-5`), 1M context, adaptive thinking, with tool use and local command execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub references)
- [x] My branch name describes the change and contains no internal ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes (`packages/mcp-server/README.md`)
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green — CI shows failures on this branch; I am working through them and will report back in this thread. Please do not spend review time until they are green.
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
