### PR TITLE
fix(heartbeat): drop deferred system continuation wakes on monitor-parked or settled issues instead of promoting them

### DIFF
--- a/server/src/__tests__/heartbeat-deferred-continuation-monitor-guard.test.ts
+++ b/server/src/__tests__/heartbeat-deferred-continuation-monitor-guard.test.ts
@@ -1,0 +1,470 @@
+import { randomUUID } from "node:crypto";
+import { createServer } from "node:http";
+import { and, eq } from "drizzle-orm";
+import { WebSocketServer } from "ws";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import {
+  agents,
+  agentWakeupRequests,
+  companies,
+  createDb,
+  heartbeatRuns,
+  issueComments,
+  issues,
+} from "@paperclipai/db";
+import { runningProcesses } from "../adapters/index.js";
+import { heartbeatService } from "../services/heartbeat.ts";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.ts";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping embedded Postgres deferred continuation monitor guard tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+async function waitFor(condition: () => boolean | Promise<boolean>, timeoutMs = 10_000, intervalMs = 50) {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < timeoutMs) {
+    if (await condition()) return;
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  }
+  throw new Error("Timed out waiting for condition");
+}
+
+async function closeDbClient(db: ReturnType<typeof createDb> | undefined) {
+  await db?.$client?.end?.({ timeout: 0 });
+}
+
+async function createControlledGatewayServer() {
+  const server = createServer();
+  const wss = new WebSocketServer({ server });
+  const agentPayloads: Array<Record<string, unknown>> = [];
+  let firstWaitRelease: (() => void) | null = null;
+  let firstWaitGate = new Promise<void>((resolve) => {
+    firstWaitRelease = resolve;
+  });
+  let waitCount = 0;
+
+  wss.on("connection", (socket) => {
+    socket.send(
+      JSON.stringify({
+        type: "event",
+        event: "connect.challenge",
+        payload: { nonce: "nonce-123" },
+      }),
+    );
+
+    socket.on("message", async (raw) => {
+      const text = Buffer.isBuffer(raw) ? raw.toString("utf8") : String(raw);
+      const frame = JSON.parse(text) as {
+        type: string;
+        id: string;
+        method: string;
+        params?: Record<string, unknown>;
+      };
+
+      if (frame.type !== "req") return;
+
+      if (frame.method === "connect") {
+        socket.send(
+          JSON.stringify({
+            type: "res",
+            id: frame.id,
+            ok: true,
+            payload: {
+              type: "hello-ok",
+              protocol: 3,
+              server: { version: "test", connId: "conn-1" },
+              features: { methods: ["connect", "agent", "agent.wait"], events: ["agent"] },
+              snapshot: { version: 1, ts: Date.now() },
+              policy: { maxPayload: 1_000_000, maxBufferedBytes: 1_000_000, tickIntervalMs: 30_000 },
+            },
+          }),
+        );
+        return;
+      }
+
+      if (frame.method === "agent") {
+        agentPayloads.push((frame.params ?? {}) as Record<string, unknown>);
+        const runId =
+          typeof frame.params?.idempotencyKey === "string"
+            ? frame.params.idempotencyKey
+            : `run-${agentPayloads.length}`;
+
+        socket.send(
+          JSON.stringify({
+            type: "res",
+            id: frame.id,
+            ok: true,
+            payload: {
+              runId,
+              status: "accepted",
+              acceptedAt: Date.now(),
+            },
+          }),
+        );
+        return;
+      }
+
+      if (frame.method === "agent.wait") {
+        waitCount += 1;
+        if (waitCount === 1) {
+          await firstWaitGate;
+        }
+        socket.send(
+          JSON.stringify({
+            type: "res",
+            id: frame.id,
+            ok: true,
+            payload: {
+              runId: frame.params?.runId,
+              status: "ok",
+              startedAt: 1,
+              endedAt: 2,
+            },
+          }),
+        );
+      }
+    });
+  });
+
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", () => resolve());
+  });
+
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("Failed to resolve test server address");
+  }
+
+  return {
+    url: `ws://127.0.0.1:${address.port}`,
+    getAgentPayloads: () => agentPayloads,
+    releaseFirstWait: () => {
+      firstWaitRelease?.();
+      firstWaitRelease = null;
+      firstWaitGate = Promise.resolve();
+    },
+    close: async () => {
+      await new Promise<void>((resolve) => wss.close(() => resolve()));
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    },
+  };
+}
+
+describeEmbeddedPostgres("deferred continuation wake monitor guard", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    const started = await startEmbeddedPostgresTestDatabase("paperclip-heartbeat-continuation-guard-");
+    db = createDb(started.connectionString);
+    tempDb = started;
+  }, 120_000);
+
+  afterAll(async () => {
+    await closeDbClient(db);
+    await tempDb?.cleanup();
+  });
+
+  afterEach(() => {
+    runningProcesses.clear();
+  });
+
+  async function seedCompanyAgentIssue(gatewayUrl: string) {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const issueId = randomUUID();
+    const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix,
+      requireBoardApprovalForNewAgents: false,
+      defaultResponsibleUserId: "responsible-user",
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Gateway Agent",
+      role: "engineer",
+      status: "idle",
+      adapterType: "openclaw_gateway",
+      adapterConfig: {
+        url: gatewayUrl,
+        headers: {
+          "x-openclaw-token": "gateway-token",
+        },
+        payloadTemplate: {
+          message: "wake now",
+        },
+        waitTimeoutMs: 2_000,
+      },
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Monitor-parked issue",
+      status: "in_progress",
+      priority: "medium",
+      responsibleUserId: "responsible-user",
+      assigneeAgentId: agentId,
+      issueNumber: 1,
+      identifier: `${issuePrefix}-1`,
+    });
+
+    return { companyId, agentId, issueId };
+  }
+
+  async function startLiveRunViaCommentWake(
+    heartbeat: ReturnType<typeof heartbeatService>,
+    input: { companyId: string; agentId: string; issueId: string },
+  ) {
+    const comment = await db
+      .insert(issueComments)
+      .values({
+        companyId: input.companyId,
+        issueId: input.issueId,
+        authorUserId: "user-1",
+        body: "Start work",
+      })
+      .returning()
+      .then((rows) => rows[0]);
+
+    const run = await heartbeat.wakeup(input.agentId, {
+      source: "automation",
+      triggerDetail: "system",
+      reason: "issue_commented",
+      payload: { issueId: input.issueId, commentId: comment.id },
+      contextSnapshot: {
+        issueId: input.issueId,
+        taskId: input.issueId,
+        commentId: comment.id,
+        wakeReason: "issue_commented",
+      },
+      requestedByActorType: "user",
+      requestedByActorId: "user-1",
+    });
+    expect(run).not.toBeNull();
+    return run!;
+  }
+
+  function insertDeferredContinuationWake(input: {
+    companyId: string;
+    agentId: string;
+    issueId: string;
+    retryOfRunId: string;
+  }) {
+    return db
+      .insert(agentWakeupRequests)
+      .values({
+        companyId: input.companyId,
+        agentId: input.agentId,
+        source: "automation",
+        triggerDetail: "system",
+        reason: "issue_execution_deferred",
+        payload: {
+          issueId: input.issueId,
+          retryOfRunId: input.retryOfRunId,
+          _paperclipWakeContext: {
+            issueId: input.issueId,
+            taskId: input.issueId,
+            wakeReason: "issue_continuation_needed",
+            retryReason: "issue_continuation_needed",
+            source: "issue.productive_terminal_continuation_recovery",
+            retryOfRunId: input.retryOfRunId,
+          },
+        },
+        status: "deferred_issue_execution",
+        requestedByActorType: "system",
+        requestedByActorId: null,
+      })
+      .returning()
+      .then((rows) => rows[0]);
+  }
+
+  it("drops a deferred system continuation wake instead of promoting it while the issue is parked on a future monitor", async () => {
+    const gateway = await createControlledGatewayServer();
+    const heartbeat = heartbeatService(db);
+
+    try {
+      const seeded = await seedCompanyAgentIssue(gateway.url);
+      const firstRun = await startLiveRunViaCommentWake(heartbeat, seeded);
+      await waitFor(() => gateway.getAgentPayloads().length === 1);
+
+      const monitorNextCheckAt = new Date(Date.now() + 48 * 60 * 60_000);
+      await db
+        .update(issues)
+        .set({ monitorNextCheckAt, updatedAt: new Date() })
+        .where(eq(issues.id, seeded.issueId));
+
+      const deferred = await insertDeferredContinuationWake({
+        ...seeded,
+        retryOfRunId: firstRun.id,
+      });
+
+      await heartbeat.cancelRun(firstRun.id);
+
+      await waitFor(async () => {
+        const row = await db
+          .select({ status: agentWakeupRequests.status })
+          .from(agentWakeupRequests)
+          .where(eq(agentWakeupRequests.id, deferred.id))
+          .then((rows) => rows[0] ?? null);
+        return row?.status === "cancelled";
+      });
+
+      const suppressed = await db
+        .select()
+        .from(agentWakeupRequests)
+        .where(eq(agentWakeupRequests.id, deferred.id))
+        .then((rows) => rows[0]);
+      expect(suppressed.status).toBe("cancelled");
+      expect(suppressed.error).toContain("parked on a monitor");
+      expect(suppressed.error).toContain(monitorNextCheckAt.toISOString());
+
+      // No promoted run fired: the only run for this agent is the cancelled one.
+      const runs = await db
+        .select()
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.agentId, seeded.agentId));
+      expect(runs).toHaveLength(1);
+      expect(runs[0]?.id).toBe(firstRun.id);
+      expect(gateway.getAgentPayloads()).toHaveLength(1);
+
+      // The monitor stays armed so it still owns the next wake.
+      const issueRow = await db
+        .select({ monitorNextCheckAt: issues.monitorNextCheckAt })
+        .from(issues)
+        .where(eq(issues.id, seeded.issueId))
+        .then((rows) => rows[0]);
+      expect(issueRow.monitorNextCheckAt?.getTime()).toBe(monitorNextCheckAt.getTime());
+    } finally {
+      gateway.releaseFirstWait();
+      await gateway.close();
+    }
+  }, 120_000);
+
+  it("still promotes a deferred continuation wake when the issue has no armed monitor", async () => {
+    const gateway = await createControlledGatewayServer();
+    const heartbeat = heartbeatService(db);
+
+    try {
+      const seeded = await seedCompanyAgentIssue(gateway.url);
+      const firstRun = await startLiveRunViaCommentWake(heartbeat, seeded);
+      await waitFor(() => gateway.getAgentPayloads().length === 1);
+
+      const deferred = await insertDeferredContinuationWake({
+        ...seeded,
+        retryOfRunId: firstRun.id,
+      });
+
+      await heartbeat.cancelRun(firstRun.id);
+
+      await waitFor(() => gateway.getAgentPayloads().length === 2, 30_000);
+
+      const promoted = await db
+        .select()
+        .from(agentWakeupRequests)
+        .where(eq(agentWakeupRequests.id, deferred.id))
+        .then((rows) => rows[0]);
+      // The promoted run may already have claimed/finished the wake by the time
+      // we look, so assert the promotion happened rather than a specific stage.
+      expect(promoted.reason).toBe("issue_execution_promoted");
+      expect(["queued", "claimed", "completed"]).toContain(promoted.status);
+
+      gateway.releaseFirstWait();
+      await waitFor(async () => {
+        const runs = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.agentId, seeded.agentId));
+        return runs.length === 2 && runs.every((run) => ["cancelled", "succeeded"].includes(run.status));
+      }, 90_000);
+    } finally {
+      gateway.releaseFirstWait();
+      await gateway.close();
+    }
+  }, 120_000);
+
+  it("still promotes a deferred user comment wake while the issue is parked on a future monitor", async () => {
+    const gateway = await createControlledGatewayServer();
+    const heartbeat = heartbeatService(db);
+
+    try {
+      const seeded = await seedCompanyAgentIssue(gateway.url);
+      const firstRun = await startLiveRunViaCommentWake(heartbeat, seeded);
+      await waitFor(() => gateway.getAgentPayloads().length === 1);
+
+      await db
+        .update(issues)
+        .set({
+          monitorNextCheckAt: new Date(Date.now() + 48 * 60 * 60_000),
+          updatedAt: new Date(),
+        })
+        .where(eq(issues.id, seeded.issueId));
+
+      const followupComment = await db
+        .insert(issueComments)
+        .values({
+          companyId: seeded.companyId,
+          issueId: seeded.issueId,
+          authorUserId: "user-1",
+          body: "Queued follow-up",
+        })
+        .returning()
+        .then((rows) => rows[0]);
+
+      const followupRun = await heartbeat.wakeup(seeded.agentId, {
+        source: "automation",
+        triggerDetail: "system",
+        reason: "issue_commented",
+        payload: { issueId: seeded.issueId, commentId: followupComment.id },
+        contextSnapshot: {
+          issueId: seeded.issueId,
+          taskId: seeded.issueId,
+          commentId: followupComment.id,
+          wakeReason: "issue_commented",
+        },
+        requestedByActorType: "user",
+        requestedByActorId: "user-1",
+      });
+      expect(followupRun).toBeNull();
+
+      const deferredCommentWake = await db
+        .select()
+        .from(agentWakeupRequests)
+        .where(
+          and(
+            eq(agentWakeupRequests.companyId, seeded.companyId),
+            eq(agentWakeupRequests.agentId, seeded.agentId),
+            eq(agentWakeupRequests.status, "deferred_issue_execution"),
+          ),
+        )
+        .then((rows) => rows[0] ?? null);
+      expect(deferredCommentWake).not.toBeNull();
+
+      await heartbeat.cancelRun(firstRun.id);
+
+      await waitFor(() => gateway.getAgentPayloads().length === 2, 30_000);
+      expect(String(gateway.getAgentPayloads()[1]?.message ?? "")).toContain("Queued follow-up");
+
+      gateway.releaseFirstWait();
+      await waitFor(async () => {
+        const runs = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.agentId, seeded.agentId));
+        return runs.length === 2 && runs.every((run) => ["cancelled", "succeeded"].includes(run.status));
+      }, 90_000);
+    } finally {
+      gateway.releaseFirstWait();
+      await gateway.close();
+    }
+  }, 120_000);
+});

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -14509,6 +14509,44 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         }
         const deferredCommentIds = extractWakeCommentIds(deferredContextSeed);
         const deferredWakeReason = readNonEmptyString(deferredContextSeed.wakeReason);
+        // A system continuation wake promoted onto an issue that is parked on a
+        // future-dated monitor (or already settled) re-fires at every run end:
+        // the promoted run does a no-op state check, exits, and its own
+        // finalization promotes the next deferred continuation — a
+        // self-sustaining loop (~40 no-op runs/hr observed on one issue).
+        // The armed monitor owns the next wake, so drop the deferred
+        // continuation instead of promoting it. Event-carrying wakes
+        // (comments, interactions, user/agent-requested resumes) are never
+        // suppressed here.
+        const deferredRetryReason = readNonEmptyString(deferredContextSeed.retryReason);
+        const deferredIsSystemContinuation =
+          (deferred.requestedByActorType === "system" || deferred.requestedByActorType === null) &&
+          deferredCommentIds.length === 0 &&
+          deferredContextSeed.resumeIntent !== true &&
+          deferredContextSeed.followUpRequested !== true &&
+          (deferredWakeReason === "issue_continuation_needed" ||
+            deferredRetryReason === "issue_continuation_needed");
+        if (deferredIsSystemContinuation) {
+          const monitorParkedUntil =
+            issue.monitorNextCheckAt && issue.monitorNextCheckAt.getTime() > Date.now()
+              ? issue.monitorNextCheckAt
+              : null;
+          const issueSettled = issue.status === "done" || issue.status === "cancelled";
+          if (monitorParkedUntil || issueSettled) {
+            await tx
+              .update(agentWakeupRequests)
+              .set({
+                status: "cancelled",
+                finishedAt: new Date(),
+                error: monitorParkedUntil
+                  ? `Deferred continuation wake suppressed: issue is parked on a monitor scheduled for ${monitorParkedUntil.toISOString()}`
+                  : `Deferred continuation wake suppressed: issue reached settled status (${issue.status})`,
+                updatedAt: new Date(),
+              })
+              .where(eq(agentWakeupRequests.id, deferred.id));
+            continue;
+          }
+        }
         // Local-CLI agents post comments under user auth, so a self-comment from
         // the run that is now ending would otherwise look like a real human
         // comment and trigger a reopen on the very issue this run just closed.


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The heartbeat service owns run lifecycle: when a run finalizes, a promotion loop turns any `deferred_issue_execution` wake for that run's issue into an immediately-queued follow-up run
> - Issues can be deliberately parked on a future-dated monitor (`monitorNextCheckAt`) — the monitor is the durable wait path that owns the next wake
> - The promotion loop never rechecked that monitor (or terminal status): a system `issue_continuation_needed` wake deferred behind a live run was always promoted at run end
> - On a monitor-parked `in_progress` issue this is self-sustaining: the promoted run wakes the agent, the agent verifies the issue is parked and exits as a no-op, and that run's own finalization promotes the next deferred continuation — observed at ~40 full agent runs/hr on a single issue, with no natural stop until the monitor fired days later
> - This pull request adds a guard in the promotion loop: a system-requested continuation wake is dropped (cancelled with an explanatory error) instead of promoted when the issue is parked on a future monitor or already done/cancelled
> - Event-carrying wakes — user comments, interactions, explicit resumes — still promote, including on monitor-parked issues, so nothing a human sends gets swallowed
> - The benefit is eliminating unbounded compute burn from no-op continuation loops while keeping the monitor as the single owner of the next scheduled wake

## Linked Issues or Issue Description

No public GitHub issue exists; describing per the bug template. Related (non-duplicate) in-flight PRs found during dedup search: Refs #9318 (pre-enqueue wake suppression for terminal/reassigned/in-review issues — different layer, does not cover the deferred-wake promotion loop or monitor state), Refs #9119 (bounds the number of automatic continuations — complements this fix but still burns bounded no-op runs on monitor-parked issues), Refs #8191 (recovery-service exemption keyed on future monitorNextCheckAt — same signal, applied in the stranded-recovery scan rather than the promotion loop).

Bug description:

- **What happened:** An `in_progress` issue parked on a future-dated monitor (`monitorNextCheckAt` ~2 days out) produced ~36 consecutive `issue_continuation_needed` agent runs in 52 minutes (one every ~90s). Each run was a no-op state check; each run's finalization promoted the next deferred continuation wake, sustaining the loop. Extrapolated: ~2,000 wasted full agent sessions before the monitor's scheduled fire.
- **Expected behavior:** An issue parked on a scheduled monitor should stay quiet until the monitor fires (or a real event — comment, interaction, resume — arrives). System continuation wakes should not re-fire onto it at every run end.
- **Steps to reproduce:** Park an assigned issue `in_progress` with a future `monitorNextCheckAt`; start a run on it; enqueue a system `issue_continuation_needed` wake while the run is live (it defers); end the run. Before this fix the deferred wake is promoted and a new run fires immediately; the cycle repeats at run-duration cadence.
- **Deployment mode:** local instance, embedded server; reproduced against master.

## What Changed

- `server/src/services/heartbeat.ts` — in the run-finalization deferred-wake promotion loop, added a guard before promotion: if the deferred wake is a system-requested continuation (`wakeReason`/`retryReason` `issue_continuation_needed`, no batched comment ids, no `resumeIntent`/`followUpRequested`) and the issue has a future `monitorNextCheckAt` **or** is `done`/`cancelled`, the deferred wake is cancelled with an explanatory error and the loop continues to the next deferred wake instead of promoting.
- `server/src/__tests__/heartbeat-deferred-continuation-monitor-guard.test.ts` — new embedded-Postgres suite covering: (1) monitor-parked issue → continuation wake dropped, no promoted run, monitor left armed; (2) no monitor → continuation wake still promotes (guard is not over-broad); (3) monitor-parked issue → deferred **user comment** wake still promotes with its comment.

## Verification

- `cd server && pnpm exec vitest run src/__tests__/heartbeat-deferred-continuation-monitor-guard.test.ts` → 3/3 pass
- Adjacent promotion-path regression suites: `pnpm exec vitest run src/__tests__/heartbeat-comment-wake-batching.test.ts src/__tests__/heartbeat-stale-queue-invalidation.test.ts` → 34/34 pass
- `cd server && pnpm exec tsc --noEmit` → clean
- Root `pnpm build` → clean

## Risks

- Suppression is scoped tightly: only `system`/unattributed continuation-reason wakes with no comment ids and no resume intent are affected. User- or agent-requested wakes, comment wakes, interaction wakes, and approval/blocker follow-ups promote exactly as before (covered by tests 2–3 and the existing batching suite).
- A continuation wake deferred behind a live run on a monitor-parked issue is now dropped rather than delivered late. This is the intended behavior — the armed monitor owns the next wake — but any workflow that relied on a continuation wake as a side-channel to fire *before* the monitor will now wait for the monitor.
- Settled-state (`done`/`cancelled`) suppression only touches the same continuation class; human comment wakes on closed issues keep their existing reopen path.

## Model Used

- Provider: Anthropic (via Claude Code)
- Model: Claude Fable 5 (`claude-fable-5`)
- Capabilities: extended thinking, tool use (file editing, shell, test execution)

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
