### PR TITLE
test(adapter-utils): isolate env fingerprint assertions

### DIFF
--- a/packages/adapter-utils/src/acpx-engine/execute.test.ts
+++ b/packages/adapter-utils/src/acpx-engine/execute.test.ts
@@ -593,7 +593,7 @@ describe("shared ACPX engine runtime behavior", () => {
   it("busts the session fingerprint when resolved adapter env changes but not across wakes", async () => {
     const root = await makeTempRoot();
     const stateDir = path.join(root, "state");
-    const baseConfig = { agentCommand: "node ./fake-acp.js", stateDir };
+    const baseConfig = { agent: "custom", agentCommand: "node ./fake-acp.js", stateDir };
 
     const first = await runExecutor(
       { ...baseConfig, env: { OPENROUTER_API_KEY: "value-1" } },
@@ -623,7 +623,7 @@ describe("shared ACPX engine runtime behavior", () => {
   it("busts the session fingerprint when a stable configured PAPERCLIP_* value rotates", async () => {
     const root = await makeTempRoot();
     const stateDir = path.join(root, "state");
-    const baseConfig = { agentCommand: "node ./fake-acp.js", stateDir };
+    const baseConfig = { agent: "custom", agentCommand: "node ./fake-acp.js", stateDir };
 
     // An explicitly configured PAPERCLIP_API_KEY is stable per-run config (not a
     // per-wake runtime var): rotating it must invalidate a warm/resumable session


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Adapter sessions use configuration fingerprints to decide whether a warm ACPX session can be reused safely.
> - The fingerprint tests are intended to isolate changes in forwarded adapter environment values.
> - Without an explicit custom agent, host Claude adapter detection can add unrelated configuration and perturb the session identity under parallel or machine-specific test environments.
> - This pull request pins those assertions to the custom ACP agent used by their fake command.
> - The benefit is deterministic coverage of environment fingerprint behavior without changing production runtime behavior.

## Linked Issues or Issue Description

Refs #9620

**Bug:** Adapter environment fingerprint assertions can inherit host-specific Claude adapter detection because their fake ACP configuration does not name a custom agent. This makes tests depend on unrelated local CLI configuration and can produce nondeterministic session fingerprints.

**Expected behavior:** The tests should exercise only the fake custom ACP command and the environment values under assertion.

## What Changed

- Set `agent: "custom"` in the two adapter environment fingerprint test configurations.
- Preserve the existing fake ACP command and session-state assertions unchanged.

## Verification

- `pnpm exec vitest run packages/adapter-utils/src/acpx-engine/execute.test.ts` — 49 tests passed.
- `pnpm exec vitest run server/src/__tests__/company-skills-service.test.ts server/src/__tests__/company-skills-routes.test.ts ui/src/pages/skills/ImportSkillsFromProjectDialog.test.tsx` — 101 tests passed.
- `pnpm check:token-gates` — all gates clean.

## Risks

- Low risk: test-only configuration change; no production code, API contract, schema, or UI behavior changes.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex, `gpt-5.3-codex`, Codex CLI with reasoning, terminal tool use, code execution, and git/GitHub integration. Context window is managed by the Codex runtime.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge