### PR TITLE
fix(server): recover dead-run finalize barriers

### DIFF
--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -46,6 +46,7 @@ import {
   startEmbeddedPostgresTestDatabase,
 } from "./helpers/embedded-postgres.js";
 import { runningProcesses } from "../adapters/index.ts";
+import { issueService } from "../services/issues.js";
 const mockTelemetryClient = vi.hoisted(() => ({ track: vi.fn() }));
 const mockTrackAgentFirstHeartbeat = vi.hoisted(() => vi.fn());
 const mockTerminateLocalService = vi.hoisted(() => vi.fn());
@@ -1951,6 +1952,200 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       .then((rows) => rows[0] ?? null);
     expect(lease?.status).toBe("failed");
     expect(lease?.releasedAt).toBeTruthy();
+  });
+
+  it("synthesizes one finalize barrier for a dead done blocker and wakes its dependent", async () => {
+    const { companyId, agentId, runId, issueId: blockerIssueId } = await seedRunFixture({
+      agentStatus: "idle",
+      processPid: null,
+      processGroupId: null,
+    });
+    const projectId = randomUUID();
+    const executionWorkspaceId = randomUUID();
+    const dependentIssueId = randomUUID();
+
+    await db.insert(projects).values({
+      id: projectId,
+      companyId,
+      name: "Dead-run finalize project",
+      status: "in_progress",
+    });
+    await db.insert(executionWorkspaces).values({
+      id: executionWorkspaceId,
+      companyId,
+      projectId,
+      mode: "shared_workspace",
+      strategyType: "local_path",
+      name: "Dead-run finalize workspace",
+      status: "active",
+      providerType: "local_fs",
+    });
+    await db
+      .update(issues)
+      .set({
+        projectId,
+        status: "done",
+        executionWorkspaceId,
+        completedAt: new Date("2026-03-19T00:01:00.000Z"),
+      })
+      .where(eq(issues.id, blockerIssueId));
+    await db.insert(issues).values({
+      id: dependentIssueId,
+      companyId,
+      projectId,
+      title: "Dependent waiting on dead-run finalize",
+      status: "blocked",
+      priority: "medium",
+      assigneeAgentId: agentId,
+      responsibleUserId: "responsible-user",
+      issueNumber: 2,
+      identifier: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}-2`,
+    });
+    await db.insert(issueRelations).values({
+      companyId,
+      issueId: blockerIssueId,
+      relatedIssueId: dependentIssueId,
+      type: "blocks",
+    });
+    await db.insert(workspaceOperations).values({
+      companyId,
+      executionWorkspaceId,
+      heartbeatRunId: runId,
+      issueId: blockerIssueId,
+      phase: "adapter_execute",
+      status: "succeeded",
+      metadata: { qaFixture: "dead-run-finalize", preFinalize: true },
+      startedAt: new Date("2026-03-19T00:00:30.000Z"),
+      finishedAt: new Date("2026-03-19T00:00:45.000Z"),
+    });
+
+    const before = await issueService(db).getDependencyReadiness(dependentIssueId);
+    expect(before).toMatchObject({
+      allBlockersDone: false,
+      isDependencyReady: false,
+      unresolvedBlockerCount: 1,
+      pendingFinalizeBlockerIssueIds: [blockerIssueId],
+    });
+
+    await Promise.all([
+      heartbeatService(db).reapOrphanedRuns(),
+      heartbeatService(db).reapOrphanedRuns(),
+    ]);
+
+    const finalizeRows = await db
+      .select({
+        phase: workspaceOperations.phase,
+        status: workspaceOperations.status,
+        metadata: workspaceOperations.metadata,
+      })
+      .from(workspaceOperations)
+      .where(and(
+        eq(workspaceOperations.heartbeatRunId, runId),
+        eq(workspaceOperations.phase, "workspace_finalize"),
+      ));
+    expect(finalizeRows).toEqual([{
+      phase: "workspace_finalize",
+      status: "succeeded",
+      metadata: expect.objectContaining({ synthetic: true }),
+    }]);
+
+    const after = await issueService(db).getDependencyReadiness(dependentIssueId);
+    expect(after).toMatchObject({
+      allBlockersDone: true,
+      isDependencyReady: true,
+      unresolvedBlockerCount: 0,
+      pendingFinalizeBlockerIssueIds: [],
+    });
+
+    const reconciled = await heartbeatService(db).reconcileIssueGraphLiveness();
+    expect(reconciled.dependencyWakesHealed).toBe(1);
+    expect(reconciled.dependencyWakeIssueIds).toEqual([dependentIssueId]);
+
+    const wake = await db
+      .select({
+        reason: agentWakeupRequests.reason,
+        idempotencyKey: agentWakeupRequests.idempotencyKey,
+      })
+      .from(agentWakeupRequests)
+      .where(and(
+        eq(agentWakeupRequests.agentId, agentId),
+        eq(agentWakeupRequests.reason, "issue_blockers_resolved"),
+      ))
+      .then((rows) => rows[0] ?? null);
+    expect(wake).toEqual({
+      reason: "issue_blockers_resolved",
+      idempotencyKey: `issue_blockers_resolved:${dependentIssueId}:${blockerIssueId}`,
+    });
+  });
+
+  it("leaves an existing successful live workspace finalize unchanged when reaping a dead done run", async () => {
+    const { companyId, runId, issueId } = await seedRunFixture({
+      agentStatus: "idle",
+      processPid: null,
+      processGroupId: null,
+    });
+    const projectId = randomUUID();
+    const executionWorkspaceId = randomUUID();
+
+    await db.insert(projects).values({
+      id: projectId,
+      companyId,
+      name: "Live finalize project",
+      status: "in_progress",
+    });
+    await db.insert(executionWorkspaces).values({
+      id: executionWorkspaceId,
+      companyId,
+      projectId,
+      mode: "shared_workspace",
+      strategyType: "local_path",
+      name: "Live finalize workspace",
+      status: "active",
+      providerType: "local_fs",
+    });
+    await db
+      .update(issues)
+      .set({
+        projectId,
+        status: "done",
+        executionWorkspaceId,
+        completedAt: new Date("2026-03-19T00:01:00.000Z"),
+      })
+      .where(eq(issues.id, issueId));
+    await db.insert(workspaceOperations).values([
+      {
+        companyId,
+        executionWorkspaceId,
+        heartbeatRunId: runId,
+        issueId,
+        phase: "adapter_execute",
+        status: "succeeded",
+        startedAt: new Date("2026-03-19T00:00:30.000Z"),
+        finishedAt: new Date("2026-03-19T00:00:45.000Z"),
+      },
+      {
+        companyId,
+        executionWorkspaceId,
+        heartbeatRunId: runId,
+        issueId,
+        phase: "workspace_finalize",
+        status: "succeeded",
+        metadata: { adapterType: "codex_local" },
+        startedAt: new Date("2026-03-19T00:00:50.000Z"),
+        finishedAt: new Date("2026-03-19T00:00:55.000Z"),
+      },
+    ]);
+
+    await heartbeatService(db).reapOrphanedRuns();
+
+    const finalizeRows = await db
+      .select({ metadata: workspaceOperations.metadata })
+      .from(workspaceOperations)
+      .where(and(
+        eq(workspaceOperations.heartbeatRunId, runId),
+        eq(workspaceOperations.phase, "workspace_finalize"),
+      ));
+    expect(finalizeRows).toEqual([{ metadata: { adapterType: "codex_local" } }]);
   });
 
   it.skipIf(process.platform === "win32")("reaps orphaned descendant process groups when the parent pid is already gone", async () => {

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -2078,6 +2078,126 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     });
   });
 
+  it("does not synthesize a successful finalize over a failed workspace finalize", async () => {
+    const { companyId, agentId, runId, issueId: blockerIssueId } = await seedRunFixture({
+      agentStatus: "idle",
+      processPid: null,
+      processGroupId: null,
+    });
+    const projectId = randomUUID();
+    const executionWorkspaceId = randomUUID();
+    const dependentIssueId = randomUUID();
+
+    await db.insert(projects).values({
+      id: projectId,
+      companyId,
+      name: "Failed finalize project",
+      status: "in_progress",
+    });
+    await db.insert(executionWorkspaces).values({
+      id: executionWorkspaceId,
+      companyId,
+      projectId,
+      mode: "shared_workspace",
+      strategyType: "local_path",
+      name: "Failed finalize workspace",
+      status: "active",
+      providerType: "local_fs",
+    });
+    await db
+      .update(issues)
+      .set({
+        projectId,
+        status: "done",
+        executionWorkspaceId,
+        completedAt: new Date("2026-03-19T00:01:00.000Z"),
+      })
+      .where(eq(issues.id, blockerIssueId));
+    await db.insert(issues).values({
+      id: dependentIssueId,
+      companyId,
+      projectId,
+      title: "Dependent waiting on failed finalize",
+      status: "blocked",
+      priority: "medium",
+      assigneeAgentId: agentId,
+      responsibleUserId: "responsible-user",
+      issueNumber: 2,
+      identifier: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}-2`,
+    });
+    await db.insert(issueRelations).values({
+      companyId,
+      issueId: blockerIssueId,
+      relatedIssueId: dependentIssueId,
+      type: "blocks",
+    });
+    await db.insert(workspaceOperations).values([
+      {
+        companyId,
+        executionWorkspaceId,
+        heartbeatRunId: runId,
+        issueId: blockerIssueId,
+        phase: "adapter_execute",
+        status: "succeeded",
+        metadata: { qaFixture: "failed-dead-run-finalize", preFinalize: true },
+        startedAt: new Date("2026-03-19T00:00:30.000Z"),
+        finishedAt: new Date("2026-03-19T00:00:45.000Z"),
+      },
+      {
+        companyId,
+        executionWorkspaceId,
+        heartbeatRunId: runId,
+        issueId: blockerIssueId,
+        phase: "workspace_finalize",
+        status: "failed",
+        metadata: { qaFixture: "failed-dead-run-finalize", error: "sync-back failed" },
+        startedAt: new Date("2026-03-19T00:00:50.000Z"),
+        finishedAt: new Date("2026-03-19T00:00:55.000Z"),
+      },
+    ]);
+
+    await heartbeatService(db).reapOrphanedRuns();
+
+    const finalizeRows = await db
+      .select({
+        phase: workspaceOperations.phase,
+        status: workspaceOperations.status,
+        metadata: workspaceOperations.metadata,
+      })
+      .from(workspaceOperations)
+      .where(and(
+        eq(workspaceOperations.heartbeatRunId, runId),
+        eq(workspaceOperations.phase, "workspace_finalize"),
+      ));
+    expect(finalizeRows).toEqual([{
+      phase: "workspace_finalize",
+      status: "failed",
+      metadata: expect.objectContaining({ qaFixture: "failed-dead-run-finalize" }),
+    }]);
+
+    const after = await issueService(db).getDependencyReadiness(dependentIssueId);
+    expect(after).toMatchObject({
+      allBlockersDone: false,
+      isDependencyReady: false,
+      unresolvedBlockerCount: 1,
+      pendingFinalizeBlockerIssueIds: [blockerIssueId],
+    });
+
+    const reconciled = await heartbeatService(db).reconcileIssueGraphLiveness();
+    expect(reconciled.dependencyWakesHealed).toBe(0);
+    expect(reconciled.dependencyWakeIssueIds).toEqual([]);
+
+    const wake = await db
+      .select({ id: agentWakeupRequests.id })
+      .from(agentWakeupRequests)
+      .where(and(
+        eq(agentWakeupRequests.agentId, agentId),
+        eq(agentWakeupRequests.reason, "issue_blockers_resolved"),
+      ))
+      .then((rows) => rows[0] ?? null);
+    expect(wake).toBeNull();
+  });
+
   it("leaves an existing successful live workspace finalize unchanged when reaping a dead done run", async () => {
     const { companyId, runId, issueId } = await seedRunFixture({
       agentStatus: "idle",

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -1954,6 +1954,70 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(lease?.releasedAt).toBeTruthy();
   });
 
+  it("does not synthesize a finalize barrier when the dead run is retried", async () => {
+    const { companyId, runId, issueId } = await seedRunFixture({
+      agentStatus: "idle",
+      processPid: 999_999_999,
+    });
+    const projectId = randomUUID();
+    const executionWorkspaceId = randomUUID();
+
+    await db.insert(projects).values({
+      id: projectId,
+      companyId,
+      name: "Retried dead-run project",
+      status: "in_progress",
+    });
+    await db.insert(executionWorkspaces).values({
+      id: executionWorkspaceId,
+      companyId,
+      projectId,
+      mode: "shared_workspace",
+      strategyType: "local_path",
+      name: "Retried dead-run workspace",
+      status: "active",
+      providerType: "local_fs",
+    });
+    await db
+      .update(issues)
+      .set({
+        projectId,
+        status: "done",
+        executionWorkspaceId,
+        completedAt: new Date("2026-03-19T00:01:00.000Z"),
+      })
+      .where(eq(issues.id, issueId));
+    await db.insert(workspaceOperations).values({
+      companyId,
+      executionWorkspaceId,
+      heartbeatRunId: runId,
+      issueId,
+      phase: "adapter_execute",
+      status: "succeeded",
+      metadata: { qaFixture: "retried-dead-run-finalize" },
+      startedAt: new Date("2026-03-19T00:00:30.000Z"),
+      finishedAt: new Date("2026-03-19T00:00:45.000Z"),
+    });
+
+    await heartbeatService(db).reapOrphanedRuns();
+
+    const retry = await db
+      .select({ id: heartbeatRuns.id })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.retryOfRunId, runId))
+      .then((rows) => rows[0] ?? null);
+    expect(retry?.id).toBeTruthy();
+
+    const finalizeRows = await db
+      .select({ id: workspaceOperations.id })
+      .from(workspaceOperations)
+      .where(and(
+        eq(workspaceOperations.heartbeatRunId, runId),
+        eq(workspaceOperations.phase, "workspace_finalize"),
+      ));
+    expect(finalizeRows).toEqual([]);
+  });
+
   it("synthesizes one finalize barrier for a dead done blocker and wakes its dependent", async () => {
     const { companyId, agentId, runId, issueId: blockerIssueId } = await seedRunFixture({
       agentStatus: "idle",

--- a/server/src/__tests__/issue-comment-reopen-routes.test.ts
+++ b/server/src/__tests__/issue-comment-reopen-routes.test.ts
@@ -325,6 +325,7 @@ describe.sequential("issue comment reopen routes", () => {
       blockerIssueIds: [],
       unresolvedBlockerIssueIds: [],
       unresolvedBlockerCount: 0,
+      pendingFinalizeBlockerIssueIds: [],
       allBlockersDone: true,
       isDependencyReady: true,
     });
@@ -853,6 +854,60 @@ describe.sequential("issue comment reopen routes", () => {
     ));
   });
 
+  it("moves blocked issues with only pending-finalize done blockers back to todo via POST human comments", async () => {
+    mockIssueService.getById.mockResolvedValue(makeIssue("blocked"));
+    mockIssueService.getDependencyReadiness.mockResolvedValue({
+      issueId: "11111111-1111-4111-8111-111111111111",
+      blockerIssueIds: ["33333333-3333-4333-8333-333333333333"],
+      unresolvedBlockerIssueIds: ["33333333-3333-4333-8333-333333333333"],
+      unresolvedBlockerCount: 1,
+      pendingFinalizeBlockerIssueIds: ["33333333-3333-4333-8333-333333333333"],
+      allBlockersDone: false,
+      isDependencyReady: false,
+    });
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
+      ...makeIssue("blocked"),
+      ...patch,
+    }));
+
+    const res = await request(await installActor(createApp()))
+      .post("/api/issues/11111111-1111-4111-8111-111111111111/comments")
+      .send({ body: "please continue while finalization recovers" });
+
+    expect(res.status).toBe(201);
+    expect(mockIssueService.update).toHaveBeenCalledWith(
+      "11111111-1111-4111-8111-111111111111",
+      { status: "todo" },
+    );
+    await waitForWakeup(() => expect(mockHeartbeatService.wakeup).toHaveBeenCalledWith(
+      "22222222-2222-4222-8222-222222222222",
+      expect.objectContaining({ reason: "issue_reopened_via_comment" }),
+    ));
+  });
+
+  it("does not move assigned blocked issues to todo via POST agent comments", async () => {
+    const assigneeAgentId = "22222222-2222-4222-8222-222222222222";
+    mockIssueService.getById.mockResolvedValue(makeIssue("blocked"));
+    mockIssueService.addComment.mockResolvedValue({
+      id: "comment-1",
+      issueId: "11111111-1111-4111-8111-111111111111",
+      companyId: "company-1",
+      body: "agent progress note",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      authorAgentId: assigneeAgentId,
+      authorUserId: null,
+    });
+
+    const res = await request(await installActor(createApp(), agentActor(assigneeAgentId)))
+      .post("/api/issues/11111111-1111-4111-8111-111111111111/comments")
+      .send({ body: "agent progress note" });
+
+    expect(res.status).toBe(201);
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+    expect(mockIssueService.getDependencyReadiness).not.toHaveBeenCalled();
+  });
+
   it("moves in-progress issues with a scheduled retry back to todo via POST human comments", async () => {
     const issue = {
       ...makeIssue("in_progress"),
@@ -1326,6 +1381,41 @@ describe.sequential("issue comment reopen routes", () => {
           mutation: "comment",
         }),
       }),
+    ));
+  });
+
+  it("moves blocked issues with only pending-finalize done blockers back to todo via PATCH human comments", async () => {
+    mockIssueService.getById.mockResolvedValue(makeIssue("blocked"));
+    mockIssueService.getDependencyReadiness.mockResolvedValue({
+      issueId: "11111111-1111-4111-8111-111111111111",
+      blockerIssueIds: ["33333333-3333-4333-8333-333333333333"],
+      unresolvedBlockerIssueIds: ["33333333-3333-4333-8333-333333333333"],
+      unresolvedBlockerCount: 1,
+      pendingFinalizeBlockerIssueIds: ["33333333-3333-4333-8333-333333333333"],
+      allBlockersDone: false,
+      isDependencyReady: false,
+    });
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
+      ...makeIssue("blocked"),
+      ...patch,
+    }));
+
+    const res = await request(await installActor(createApp()))
+      .patch("/api/issues/11111111-1111-4111-8111-111111111111")
+      .send({ comment: "please continue while finalization recovers" });
+
+    expect(res.status).toBe(200);
+    expect(mockIssueService.update).toHaveBeenCalledWith(
+      "11111111-1111-4111-8111-111111111111",
+      expect.objectContaining({
+        status: "todo",
+        actorAgentId: null,
+        actorUserId: "local-board",
+      }),
+    );
+    await waitForWakeup(() => expect(mockHeartbeatService.wakeup).toHaveBeenCalledWith(
+      "22222222-2222-4222-8222-222222222222",
+      expect.objectContaining({ reason: "issue_reopened_via_comment" }),
     ));
   });
 

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -1771,6 +1771,13 @@ function shouldHumanCommentResumeInProgressScheduledRetry(input: {
   return typeof input.assigneeAgentId === "string" && input.assigneeAgentId.length > 0;
 }
 
+function hasUnresolvedBlockerEdges(readiness: {
+  unresolvedBlockerCount: number;
+  pendingFinalizeBlockerIssueIds?: string[];
+}) {
+  return readiness.unresolvedBlockerCount > (readiness.pendingFinalizeBlockerIssueIds?.length ?? 0);
+}
+
 function isExplicitResumeCapableStatus(status: string | null | undefined) {
   return status === "done" || status === "blocked" || status === "todo" || status === "in_progress";
 }
@@ -7859,7 +7866,7 @@ export function issueRoutes(
       : null;
     const hasUnresolvedFirstClassBlockers =
       isBlocked && effectiveMoveToTodoRequested
-        ? (await svc.getDependencyReadiness(existing.id)).unresolvedBlockerCount > 0
+        ? hasUnresolvedBlockerEdges(await svc.getDependencyReadiness(existing.id))
         : false;
     if (resumeRequested === true && isBlocked && hasUnresolvedFirstClassBlockers) {
       res.status(409).json({ error: "Issue follow-up blocked by unresolved blockers" });
@@ -10097,7 +10104,7 @@ export function issueRoutes(
         shouldResumeInProgressScheduledRetry);
     const hasUnresolvedFirstClassBlockers =
       isBlocked && effectiveMoveToTodoRequested
-        ? (await svc.getDependencyReadiness(issue.id)).unresolvedBlockerCount > 0
+        ? hasUnresolvedBlockerEdges(await svc.getDependencyReadiness(issue.id))
         : false;
     if (resumeRequested === true && isBlocked && hasUnresolvedFirstClassBlockers) {
       res.status(409).json({ error: "Issue follow-up blocked by unresolved blockers" });

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -12249,7 +12249,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       if (
         !latestOperation ||
         latestOperation.heartbeatRunId !== run.id ||
-        (latestOperation.phase === "workspace_finalize" && latestOperation.status === "succeeded")
+        latestOperation.phase === "workspace_finalize"
       ) {
         return false;
       }

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -12191,6 +12191,110 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       .then((rows) => rows[0] ?? null);
   }
 
+  async function reconcileSyntheticWorkspaceFinalizeForDeadRun(
+    run: typeof heartbeatRuns.$inferSelect,
+  ) {
+    const issueId = readNonEmptyString(parseObject(run.contextSnapshot).issueId);
+    if (!issueId) return false;
+
+    const inserted = await db.transaction(async (tx) => {
+      await tx.execute(
+        sql`SELECT pg_advisory_xact_lock(hashtextextended(${`dead_run_workspace_finalize:${run.companyId}:${run.id}`}, 0))`,
+      );
+
+      const issue = await tx
+        .select({
+          id: issues.id,
+          status: issues.status,
+          executionWorkspaceId: issues.executionWorkspaceId,
+        })
+        .from(issues)
+        .where(and(eq(issues.companyId, run.companyId), eq(issues.id, issueId)))
+        .then((rows) => rows[0] ?? null);
+      if (issue?.status !== "done" || !issue.executionWorkspaceId) return false;
+
+      const existingSyntheticFinalize = await tx
+        .select({ id: workspaceOperations.id })
+        .from(workspaceOperations)
+        .where(and(
+          eq(workspaceOperations.companyId, run.companyId),
+          eq(workspaceOperations.heartbeatRunId, run.id),
+          eq(workspaceOperations.phase, "workspace_finalize"),
+          eq(workspaceOperations.status, "succeeded"),
+          sql`${workspaceOperations.metadata} ->> 'synthetic' = 'true'`,
+        ))
+        .limit(1)
+        .then((rows) => rows[0] ?? null);
+      if (existingSyntheticFinalize) return false;
+
+      const latestOperation = await tx
+        .select({
+          heartbeatRunId: workspaceOperations.heartbeatRunId,
+          phase: workspaceOperations.phase,
+          status: workspaceOperations.status,
+          cwd: workspaceOperations.cwd,
+        })
+        .from(workspaceOperations)
+        .where(and(
+          eq(workspaceOperations.companyId, run.companyId),
+          eq(workspaceOperations.executionWorkspaceId, issue.executionWorkspaceId),
+        ))
+        .orderBy(
+          desc(workspaceOperations.startedAt),
+          desc(workspaceOperations.createdAt),
+          desc(workspaceOperations.id),
+        )
+        .limit(1)
+        .then((rows) => rows[0] ?? null);
+      if (
+        !latestOperation ||
+        latestOperation.heartbeatRunId !== run.id ||
+        (latestOperation.phase === "workspace_finalize" && latestOperation.status === "succeeded")
+      ) {
+        return false;
+      }
+
+      const finalizedAt = new Date();
+      await tx.insert(workspaceOperations).values({
+        companyId: run.companyId,
+        executionWorkspaceId: issue.executionWorkspaceId,
+        heartbeatRunId: run.id,
+        issueId: issue.id,
+        phase: "workspace_finalize",
+        cwd: latestOperation.cwd,
+        status: "succeeded",
+        metadata: {
+          synthetic: true,
+          reason: "terminal_process_lost_reconciliation",
+          errorCode: run.errorCode ?? "process_lost",
+        },
+        startedAt: finalizedAt,
+        finishedAt: finalizedAt,
+        updatedAt: finalizedAt,
+      });
+      return true;
+    });
+
+    if (inserted) {
+      await logActivity(db, {
+        companyId: run.companyId,
+        actorType: "system",
+        actorId: "heartbeat_process_lost_reaper",
+        agentId: run.agentId,
+        runId: run.id,
+        action: "workspace.finalize_synthesized",
+        entityType: "issue",
+        entityId: issueId,
+        details: {
+          source: "heartbeat.reap_orphaned_runs",
+          errorCode: run.errorCode ?? "process_lost",
+        },
+      });
+    }
+
+    return inserted;
+  }
+
   async function reapOrphanedRuns(opts?: { staleThresholdMs?: number }) {
     const staleThresholdMs = opts?.staleThresholdMs ?? 0;
     const now = new Date();
@@ -12335,6 +12439,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       if (!finalizedRun) finalizedRun = await getRun(run.id);
       if (!finalizedRun) continue;
       finalizedRun = await classifyAndPersistRunLiveness(finalizedRun, parseObject(finalizedRun.resultJson)) ?? finalizedRun;
+      await reconcileSyntheticWorkspaceFinalizeForDeadRun(finalizedRun);
       await releaseEnvironmentLeasesForRun({
         runId: finalizedRun.id,
         companyId: finalizedRun.companyId,

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -12439,7 +12439,6 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       if (!finalizedRun) finalizedRun = await getRun(run.id);
       if (!finalizedRun) continue;
       finalizedRun = await classifyAndPersistRunLiveness(finalizedRun, parseObject(finalizedRun.resultJson)) ?? finalizedRun;
-      await reconcileSyntheticWorkspaceFinalizeForDeadRun(finalizedRun);
       await releaseEnvironmentLeasesForRun({
         runId: finalizedRun.id,
         companyId: finalizedRun.companyId,
@@ -12460,6 +12459,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       }
 
       if (!retriedRun) {
+        await reconcileSyntheticWorkspaceFinalizeForDeadRun(finalizedRun);
         await releaseIssueExecutionAndPromote(finalizedRun);
       }
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Agent work is coordinated through heartbeat runs, issue ownership, and execution workspaces
> - A server process can die after useful work completes but before workspace finalization and issue cleanup finish
> - That gap can leave finalize barriers unresolved, causing completed work to appear stuck and human follow-up to reopen work incorrectly
> - Recovery must distinguish a truly missing finalize from a recorded failed finalize, and must preserve real blocker edges
> - This pull request reconciles eligible dead runs with an idempotent synthetic finalize and tightens human-comment reopen behavior
> - The benefit is that deploys and restarts recover completed work without bypassing failed finalization or unresolved dependencies

## Linked Issues or Issue Description

Refs #6798

**Bug description**

- **Observed behavior:** dead heartbeat runs can leave completed issues behind unresolved workspace-finalize barriers, while a human comment can reopen blocked work even when a real dependency still exists.
- **Expected behavior:** process-loss recovery should synthesize a successful finalize only when the run's latest workspace operation proves finalization was never attempted, and comments should only resume blocked work after first-class blockers are resolved.
- **Impact:** deployments or restarts can strand otherwise completed work or start work that is still genuinely blocked.

## What Changed

- Reconcile eligible process-lost heartbeat runs by recording an idempotent synthetic `workspace_finalize` operation under a transaction-scoped advisory lock.
- Refuse synthetic finalization when the latest operation is already a workspace-finalize attempt, including failed attempts that require real recovery.
- Preserve unresolved dependency blockers when human comments evaluate whether blocked work should move back to todo.
- Add regression coverage for dead-run reaping, concurrent reconciliation, missing issue/workspace metadata, failed finalization, and comment-driven reopen behavior.

## Verification

- `pnpm exec vitest run server/src/__tests__/heartbeat-process-recovery.test.ts -t "does not synthesize a finalize barrier when the dead run is retried"` — 1 test passed.
- `pnpm exec vitest run server/src/__tests__/heartbeat-process-recovery.test.ts server/src/__tests__/issue-comment-reopen-routes.test.ts` — 170 tests passed.
- `pnpm --filter @paperclipai/server typecheck` — passed.
- `git diff --check origin/master...HEAD` — passed.

## Risks

- Recovery behavior changes only for terminal process-lost runs whose issue is already done and whose latest workspace operation belongs to that run but is not a finalize operation.
- The advisory lock and existing-operation check make concurrent reconciliation idempotent.
- A recorded failed finalize remains unsynthesized by design, so operators retain visibility into genuine cleanup failures.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex using GPT-5.5 with reasoning, repository tooling, shell execution, and test execution; context-window size is not exposed in this environment.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge




