### PR TITLE
fix(pr-gardening): report truncated issue matches

### DIFF
--- a/.agents/skills/pr-gardening/scripts/find-candidates.mjs
+++ b/.agents/skills/pr-gardening/scripts/find-candidates.mjs
@@ -33,7 +33,7 @@ export async function findCandidates(options) {
   const matchesPerIssue = 200;
   const issueMap = new Map();
   let offset = 0;
-  let truncated = false;
+  const truncatedIssues = [];
 
   while (true) {
     const query = new URLSearchParams({
@@ -47,12 +47,16 @@ export async function findCandidates(options) {
     });
     const page = await getPaperclip(`/companies/${companyId}/search/extract?${query}`, { apiUrl, apiKey });
     for (const issue of page.results) issueMap.set(issue.issueId, issue);
-    truncated ||= page.results.some((issue) => issue.matchesTruncated);
+    for (const issue of page.results) {
+      if (issue.matchesTruncated) truncatedIssues.push({ issueId: issue.issueId, identifier: issue.identifier });
+    }
     if (!page.hasMore) break;
     offset += limit;
     if (offset > 5000) throw new Error("Extract-search pagination exceeded the supported 5000 issue offset");
   }
-  if (truncated) throw new Error("Extract-search truncated one or more issue match sets; refusing an incomplete candidate report");
+  if (truncatedIssues.length > 0) {
+    console.warn(`Warning: ${truncatedIssues.length} issue(s) had truncated match sets (>${matchesPerIssue} PR URL matches). These issues may contribute incomplete PR discovery: ${truncatedIssues.map((i) => i.identifier ?? i.issueId).join(", ")}. Proceeding with available data.`);
+  }
 
   const pullRequests = new Map();
   for (const issue of issueMap.values()) {
@@ -148,7 +152,8 @@ export async function findCandidates(options) {
       openPullRequestCount: candidates.length,
       droppedClosedPullRequests: closed,
       droppedUnavailablePullRequests: unavailable,
-      truncated: false,
+      truncatedIssues,
+      truncated: truncatedIssues.length > 0,
     },
     candidates,
   };

--- a/.agents/skills/pr-gardening/scripts/find-candidates.mjs
+++ b/.agents/skills/pr-gardening/scripts/find-candidates.mjs
@@ -33,7 +33,7 @@ export async function findCandidates(options) {
   const matchesPerIssue = 200;
   const issueMap = new Map();
   let offset = 0;
-  const truncatedIssues = [];
+  const truncatedIssueMap = new Map();
 
   while (true) {
     const query = new URLSearchParams({
@@ -46,14 +46,17 @@ export async function findCandidates(options) {
       matchesPerIssue: String(matchesPerIssue),
     });
     const page = await getPaperclip(`/companies/${companyId}/search/extract?${query}`, { apiUrl, apiKey });
-    for (const issue of page.results) issueMap.set(issue.issueId, issue);
     for (const issue of page.results) {
-      if (issue.matchesTruncated) truncatedIssues.push({ issueId: issue.issueId, identifier: issue.identifier });
+      issueMap.set(issue.issueId, issue);
+      if (issue.matchesTruncated) {
+        truncatedIssueMap.set(issue.issueId, { issueId: issue.issueId, identifier: issue.identifier });
+      }
     }
     if (!page.hasMore) break;
     offset += limit;
     if (offset > 5000) throw new Error("Extract-search pagination exceeded the supported 5000 issue offset");
   }
+  const truncatedIssues = [...truncatedIssueMap.values()];
   if (truncatedIssues.length > 0) {
     console.warn(`Warning: ${truncatedIssues.length} issue(s) had truncated match sets (>${matchesPerIssue} PR URL matches). These issues may contribute incomplete PR discovery: ${truncatedIssues.map((i) => i.identifier ?? i.issueId).join(", ")}. Proceeding with available data.`);
   }

--- a/.agents/skills/pr-gardening/scripts/pr-gardening.test.mjs
+++ b/.agents/skills/pr-gardening/scripts/pr-gardening.test.mjs
@@ -94,6 +94,55 @@ test("candidate discovery deduplicates mentions and drops closed PRs", async () 
   assert.deepEqual(result.source.droppedUnavailablePullRequests.map((pullRequest) => pullRequest.number), [3]);
 });
 
+test("candidate discovery reports truncated issue matches without discarding the report", async () => {
+  const warnings = [];
+  const originalWarn = console.warn;
+  console.warn = (message) => warnings.push(message);
+
+  try {
+    const result = await findCandidates({
+      repo: "paperclipai/paperclip",
+      api_url: "http://paperclip.test",
+      api_key: "test-key",
+      company_id: "company-1",
+      paperclip_get: async (path) => {
+        if (path.includes("search/extract")) {
+          return {
+            hasMore: false,
+            results: [
+              {
+                issueId: "issue-truncated",
+                identifier: "PAP-TRUNCATED",
+                title: "Large PR thread",
+                status: "done",
+                assigneeAgentId: "agent-1",
+                updatedAt: "2026-07-13T00:00:00Z",
+                matchesTruncated: true,
+                matches: [],
+              },
+            ],
+          };
+        }
+        throw new Error(`Unexpected Paperclip path: ${path}`);
+      },
+      gh_json: async () => {
+        throw new Error("GitHub should not be queried without discovered pull requests");
+      },
+    });
+
+    assert.equal(result.source.truncated, true);
+    assert.deepEqual(result.source.truncatedIssues, [
+      { issueId: "issue-truncated", identifier: "PAP-TRUNCATED" },
+    ]);
+    assert.deepEqual(result.candidates, []);
+    assert.equal(warnings.length, 1);
+    assert.match(warnings[0], /PAP-TRUNCATED/);
+    assert.match(warnings[0], /Proceeding with available data/);
+  } finally {
+    console.warn = originalWarn;
+  }
+});
+
 test("missing-PR detection matches only deleted/nonexistent PR signals", () => {
   // gh's real signals for a deleted/nonexistent PR: GraphQL resolution failure and REST 404.
   assert.equal(isMissingPullRequestError(new Error("GraphQL: Could not resolve to a PullRequest with the number of 3")), true);

--- a/.agents/skills/pr-gardening/scripts/pr-gardening.test.mjs
+++ b/.agents/skills/pr-gardening/scripts/pr-gardening.test.mjs
@@ -120,6 +120,16 @@ test("candidate discovery reports truncated issue matches without discarding the
                 matchesTruncated: true,
                 matches: [],
               },
+              {
+                issueId: "issue-truncated",
+                identifier: "PAP-TRUNCATED",
+                title: "Large PR thread",
+                status: "done",
+                assigneeAgentId: "agent-1",
+                updatedAt: "2026-07-13T00:00:00Z",
+                matchesTruncated: true,
+                matches: [],
+              },
             ],
           };
         }


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Maintainers use the PR-gardening skill to discover referenced pull requests and assess their readiness
> - Extract search caps the number of URL matches returned for any one issue
> - The candidate finder treated any capped issue as fatal and discarded the complete candidate report
> - This pull request preserves the available report while identifying every issue whose matches were truncated
> - The benefit is that maintainers can continue gardening unaffected PRs while seeing exactly where discovery may be incomplete

## Linked Issues or Issue Description

- **Problem:** PR-gardening candidate discovery aborted whenever extract search reported more than 200 matching PR URLs on an issue, so one unusually large thread prevented all candidates from being reported.
- **Expected behavior:** Return the candidates found from available extract-search data and clearly identify issues whose match sets were truncated.
- **Reproduction:** Run the candidate finder against an extract-search response where `matchesTruncated` is `true`; before this change it throws instead of producing a report.
- **Version/deployment:** Current `master`; applies to the repository-local PR-gardening skill in any deployment using it.

## What Changed

- Collect truncated issue IDs and identifiers instead of failing the entire candidate scan.
- Emit a warning that names affected issues and explains that discovery may be incomplete.
- Include `truncated` and `truncatedIssues` metadata in the returned report.
- Add a regression test proving truncated matches preserve the available report and warning.

## Verification

- `node --test .agents/skills/pr-gardening/scripts/pr-gardening.test.mjs`
- Confirmed all 10 focused tests pass, including the new truncation regression case.

## Risks

- Low risk: the change only relaxes a fatal guard into explicit report metadata and a warning. Reports may remain incomplete for named high-volume issues, but unaffected candidates are no longer discarded.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex CLI coding agent (runtime model ID not exposed), with reasoning, repository tool use, and code execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
