### PR TITLE
test(adapter-utils): isolate env fingerprint assertions

### DIFF
--- a/packages/adapter-utils/src/acpx-engine/execute.test.ts
+++ b/packages/adapter-utils/src/acpx-engine/execute.test.ts
@@ -723,7 +723,7 @@ describe("shared ACPX engine runtime behavior", () => {
   it("busts the session fingerprint when resolved adapter env changes but not across wakes", async () => {
     const root = await makeTempRoot();
     const stateDir = path.join(root, "state");
-    const baseConfig = { agentCommand: "node ./fake-acp.js", stateDir };
+    const baseConfig = { agent: "custom", agentCommand: "node ./fake-acp.js", stateDir };
 
     const first = await runExecutor(
       { ...baseConfig, env: { OPENROUTER_API_KEY: "value-1" } },
@@ -753,7 +753,7 @@ describe("shared ACPX engine runtime behavior", () => {
   it("busts the session fingerprint when a stable configured PAPERCLIP_* value rotates", async () => {
     const root = await makeTempRoot();
     const stateDir = path.join(root, "state");
-    const baseConfig = { agentCommand: "node ./fake-acp.js", stateDir };
+    const baseConfig = { agent: "custom", agentCommand: "node ./fake-acp.js", stateDir };
 
     // A configured PAPERCLIP_*-named value the harness does not assign (e.g. a
     // cloud provider token binding) is stable per-run config: rotating it must


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Adapter sessions use a fingerprint so reusable ACPX sessions are invalidated when meaningful adapter environment configuration changes
> - The fingerprint regression tests exercised a fake custom ACP command but did not explicitly select the custom agent
> - Host Claude adapter detection could therefore influence those tests and perturb session identity for reasons unrelated to environment hashing
> - This pull request pins both environment fingerprint tests to the custom ACP agent
> - The benefit is deterministic coverage of adapter environment hashing without interference from host-specific Claude configuration

## Linked Issues or Issue Description

- Refs #9620, which merged the related project-skill import stack while this focused test isolation commit remained outside that PR.
- **What happened:** Adapter environment fingerprint tests could inherit host Claude adapter detection even though they execute a fake custom ACP command, making session identity assertions environment-dependent.
- **Expected behavior:** The tests should exercise only the custom ACP agent path so changes in host Claude settings cannot affect the fingerprint under test.
- **Steps to reproduce:** Run `packages/adapter-utils/src/acpx-engine/execute.test.ts` in an environment where Claude adapter detection/configuration is available while other Claude settings tests run; the two environment fingerprint cases can observe unrelated session identity inputs.
- **Paperclip version or commit:** `aed4478c81` (`master` after final rebase).
- **Deployment/install context:** Built from source; test-only issue; not database-related.
- **Adapter involved:** Custom ACP test agent, with unintended Claude Code host detection.

## What Changed

- Set `agent: "custom"` in the shared config for both adapter environment fingerprint regression tests.
- Keep the assertions focused on forwarded adapter environment hashing rather than host adapter discovery.

## Verification

- `pnpm exec vitest run packages/adapter-utils/src/acpx-engine/execute.test.ts` — 80 tests passed.
- `git diff --check origin/master...HEAD` — passed.

## Risks

- Low risk: test-only configuration change with no production runtime behavior changes.
- The tests now intentionally bypass Claude-specific detection, matching their fake custom ACP command setup.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex, exact model ID `gpt-5.3-codex`; context-window size is not exposed by this runtime; medium reasoning with repository, shell, Git, GitHub CLI, and code-execution tools.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes (no documentation change is required for this test-only isolation fix)
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge