### PR TITLE
Implement least-privilege and purge/retention controls for Paperclip run output

### DIFF
--- a/server/src/__tests__/agent-live-run-routes.test.ts
+++ b/server/src/__tests__/agent-live-run-routes.test.ts
@@ -219,6 +219,7 @@ describe("agent live run routes", () => {
     mockHeartbeatService.getRunLogAccess.mockResolvedValue({
       id: "run-1",
       companyId: "company-1",
+      agentId: routeAgentId,
       logStore: "local_file",
       logRef: "logs/run-1.ndjson",
     });
@@ -352,6 +353,7 @@ describe("agent live run routes", () => {
     expect(mockHeartbeatService.readLog).toHaveBeenCalledWith({
       id: "run-1",
       companyId: "company-1",
+      agentId: routeAgentId,
       logStore: "local_file",
       logRef: "logs/run-1.ndjson",
     }, {

--- a/server/src/__tests__/heartbeat-run-log.test.ts
+++ b/server/src/__tests__/heartbeat-run-log.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { compactRunLogChunk } from "../services/heartbeat.js";
+import { redactRunOutputValue } from "../redaction.js";
 
 describe("compactRunLogChunk", () => {
   it("redacts inline base64 image data from structured log chunks", () => {
@@ -39,5 +40,17 @@ describe("compactRunLogChunk", () => {
     expect(compacted).not.toContain("refresh-token-fixture-secret");
     expect(compacted).not.toContain("paperclip-json-secret");
     expect(compacted).not.toContain("paperclip-flag-secret");
+  });
+
+  it("redacts an unmanaged sentinel credential in result and resumable-session values", () => {
+    const sentinel = "unmanaged-sentinel-credential-9d2f5a";
+    const redacted = redactRunOutputValue({
+      summary: `adapter echoed ${sentinel}`,
+      nested: { sessionState: sentinel },
+      values: [sentinel],
+    }, [sentinel]);
+
+    expect(JSON.stringify(redacted)).not.toContain(sentinel);
+    expect(JSON.stringify(redacted)).toContain("***REDACTED***");
   });
 });

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -47,7 +47,9 @@ import {
   reconcileCloudUpstreamRunsOnStartup,
   reconcileCodexLocalManagedHomesOnStartup,
   reconcilePersistedRuntimeServicesOnStartup,
+  readRunOutputRetentionDays,
   routineService,
+  startHeartbeatRunOutputRetention,
   toolAccessService,
 } from "./services/index.js";
 import { resolveWorktreeRunExecutionActivationState } from "./services/instance-settings.js";
@@ -826,6 +828,12 @@ export async function startServer(): Promise<StartedServer> {
   let prepareHotRestartShutdown: ((signal: "SIGINT" | "SIGTERM") => Promise<{ skipDrain: boolean }>) | null = null;
   let heartbeatSchedulerStopped = false;
   let heartbeatSchedulerInterval: ReturnType<typeof setInterval> | null = null;
+  let stopRunOutputRetention: (() => void) | null = null;
+  const runOutputRetentionDays = readRunOutputRetentionDays();
+  if (runOutputRetentionDays !== null) {
+    stopRunOutputRetention = startHeartbeatRunOutputRetention(db as any);
+    logger.info({ retentionDays: runOutputRetentionDays }, "heartbeat run output retention enabled");
+  }
   const heartbeatSchedulerInFlight = new Set<Promise<void>>();
   const trackHeartbeatSchedulerWork = (work: Promise<unknown>) => {
     let tracked: Promise<void>;
@@ -1200,6 +1208,8 @@ export async function startServer(): Promise<StartedServer> {
   {
     const shutdown = async (signal: "SIGINT" | "SIGTERM") => {
       heartbeatSchedulerStopped = true;
+      stopRunOutputRetention?.();
+      stopRunOutputRetention = null;
       if (heartbeatSchedulerInterval) {
         clearInterval(heartbeatSchedulerInterval);
         heartbeatSchedulerInterval = null;

--- a/server/src/redaction.ts
+++ b/server/src/redaction.ts
@@ -39,6 +39,20 @@ const SECRET_TEXT_HINTS = [
 ] as const;
 export const REDACTED_EVENT_VALUE = "***REDACTED***";
 
+function uniqueSecretValues(values: readonly string[]) {
+  return [...new Set(values.map((value) => value.trim()).filter((value) => value.length >= 4))]
+    .sort((left, right) => right.length - left.length);
+}
+
+/** Redact concrete resolved secrets, including values with no recognizable token shape. */
+export function redactKnownSecretValues(input: string, values: readonly string[]) {
+  let result = input;
+  for (const value of uniqueSecretValues(values)) {
+    result = result.split(value).join(REDACTED_EVENT_VALUE);
+  }
+  return result;
+}
+
 function maybeContainsSecretText(input: string) {
   const lower = input.toLowerCase();
   return SECRET_TEXT_HINTS.some((hint) => lower.includes(hint)) || input.includes(".");
@@ -141,4 +155,26 @@ export function redactSensitiveText(input: string): string {
       .replace(ESCAPED_JSON_SECRET_FIELD_TEXT_RE, `$1${REDACTED_EVENT_VALUE}$2`),
     REDACTED_EVENT_VALUE,
   );
+}
+
+/**
+ * Recursive persistence boundary for adapter output. String values are scanned
+ * even when their JSON key is innocuous, so an unmanaged credential echoed in
+ * `summary`, `result`, or session metadata cannot bypass key-name redaction.
+ */
+export function redactRunOutputValue<T>(value: T, knownSecretValues: readonly string[] = []): T {
+  if (typeof value === "string") {
+    return redactKnownSecretValues(redactSensitiveText(value), knownSecretValues) as T;
+  }
+  if (Array.isArray(value)) {
+    return value.map((entry) => redactRunOutputValue(entry, knownSecretValues)) as T;
+  }
+  if (!isPlainObject(value)) return value;
+  const result: Record<string, unknown> = {};
+  for (const [key, entry] of Object.entries(value)) {
+    result[key] = SECRET_PAYLOAD_KEY_RE.test(key)
+      ? REDACTED_EVENT_VALUE
+      : redactRunOutputValue(entry, knownSecretValues);
+  }
+  return result as T;
 }

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -50,6 +50,7 @@ import {
   issueRecoveryActionService,
   issueService,
   logActivity,
+  purgeHeartbeatRunOutput,
   syncInstructionsBundleConfigFromFilePath,
   workspaceOperationService,
 } from "../services/index.js";
@@ -934,6 +935,29 @@ export function agentRoutes(
     if (decision.allowed) return;
 
     throw forbidden(decision.explanation, authorizationDeniedDetails(decision));
+  }
+
+  async function hasPrivilegedRunOutputAccess(req: Request, companyId: string) {
+    if (req.actor.type === "board") return true;
+    if (req.actor.type !== "agent") return false;
+    const decision = await access.decide({
+      actor: req.actor,
+      // Reuse the existing explicit supervisory/security grant ladder rather
+      // than treating company membership as permission to inspect transcripts.
+      action: "agent_config:read",
+      resource: { type: "company", companyId },
+    });
+    return decision.allowed;
+  }
+
+  async function assertCanReadHeartbeatRunOutput(
+    req: Request,
+    run: { companyId: string; agentId: string },
+  ) {
+    assertCompanyAccess(req, run.companyId);
+    if (req.actor.type === "board" || req.actor.agentId === run.agentId) return;
+    if (await hasPrivilegedRunOutputAccess(req, run.companyId)) return;
+    throw forbidden("Heartbeat run output is restricted to the owning agent or an authorized supervisor");
   }
 
   function assertKnownAdapterType(type: string | null | undefined): string {
@@ -3575,7 +3599,12 @@ export function agentRoutes(
   router.get("/companies/:companyId/heartbeat-runs", async (req, res) => {
     const companyId = req.params.companyId as string;
     assertCompanyAccess(req, companyId);
-    const agentId = req.query.agentId as string | undefined;
+    const requestedAgentId = req.query.agentId as string | undefined;
+    const privileged = await hasPrivilegedRunOutputAccess(req, companyId);
+    if (req.actor.type === "agent" && requestedAgentId && requestedAgentId !== req.actor.agentId && !privileged) {
+      throw forbidden("Heartbeat run output is restricted to the owning agent or an authorized supervisor");
+    }
+    const agentId = req.actor.type === "agent" && !privileged ? req.actor.agentId ?? undefined : requestedAgentId;
     const limitParam = req.query.limit as string | undefined;
     const limit = limitParam ? Math.max(1, Math.min(1000, parseInt(limitParam, 10) || 200)) : undefined;
     const summary = req.query.summary === "true" || req.query.summary === "1";
@@ -3586,6 +3615,7 @@ export function agentRoutes(
   router.get("/companies/:companyId/live-runs", async (req, res) => {
     const companyId = req.params.companyId as string;
     assertCompanyAccess(req, companyId);
+    const privileged = await hasPrivilegedRunOutputAccess(req, companyId);
 
     // `minCount` is a padding floor for callers that want a minimum number of
     // recent runs to render (e.g. dashboard cards). It must default to 0 so
@@ -3631,6 +3661,7 @@ export function agentRoutes(
         and(
           eq(heartbeatRuns.companyId, companyId),
           inArray(heartbeatRuns.status, ["queued", "running"]),
+          req.actor.type === "agent" && !privileged ? eq(heartbeatRuns.agentId, req.actor.agentId ?? "") : undefined,
         ),
       )
       .orderBy(desc(heartbeatRuns.createdAt));
@@ -3649,6 +3680,7 @@ export function agentRoutes(
             eq(heartbeatRuns.companyId, companyId),
             not(inArray(heartbeatRuns.status, ["queued", "running"])),
             ...(activeIds.length > 0 ? [not(inArray(heartbeatRuns.id, activeIds))] : []),
+            req.actor.type === "agent" && !privileged ? eq(heartbeatRuns.agentId, req.actor.agentId ?? "") : undefined,
           ),
         )
         .orderBy(desc(heartbeatRuns.createdAt))
@@ -3672,6 +3704,7 @@ export function agentRoutes(
     const runId = req.params.runId as string;
     const run = await getAccessibleResource(req, res, heartbeat.getRun(runId), "Heartbeat run not found");
     if (!run) return;
+    await assertCanReadHeartbeatRunOutput(req, run);
     const retryExhaustedReason = await heartbeat.getRetryExhaustedReason(runId);
     const decoratedRun = heartbeat.decorateActiveRunStatus(run);
     res.json(
@@ -3702,6 +3735,36 @@ export function agentRoutes(
     }
 
     res.json(run);
+  });
+
+  // Raw run output can contain customer data and credentials even after
+  // redaction. Purge is deliberately board-only and preserves the run's audit
+  // identity/status/usage while removing every content-bearing copy.
+  router.post("/heartbeat-runs/:runId/purge-output", async (req, res) => {
+    assertBoard(req);
+    const runId = req.params.runId as string;
+    const existing = await getAccessibleResource(req, res, heartbeat.getRunLogAccess(runId), "Heartbeat run not found");
+    if (!existing) return;
+
+    const result = await purgeHeartbeatRunOutput(db, runId);
+    if (!result) {
+      res.status(404).json({ error: "Heartbeat run not found" });
+      return;
+    }
+    await logActivity(db, {
+      companyId: result.companyId,
+      actorType: "user",
+      actorId: req.actor.userId ?? "board",
+      runId: result.runId,
+      action: "heartbeat.run_output_purged",
+      entityType: "heartbeat_run",
+      entityId: result.runId,
+      details: {
+        alreadyPurged: result.alreadyPurged,
+        clearedSessionArtifacts: result.clearedSessionArtifacts,
+      },
+    });
+    res.json({ ...result, purged: true });
   });
 
   router.post("/heartbeat-runs/:runId/watchdog-decisions", async (req, res) => {
@@ -3740,6 +3803,7 @@ export function agentRoutes(
     const runId = req.params.runId as string;
     const run = await getAccessibleResource(req, res, heartbeat.getRun(runId), "Heartbeat run not found");
     if (!run) return;
+    await assertCanReadHeartbeatRunOutput(req, run);
 
     const afterSeq = Number(req.query.afterSeq ?? 0);
     const limit = Number(req.query.limit ?? 200);
@@ -3758,6 +3822,7 @@ export function agentRoutes(
     const runId = req.params.runId as string;
     const run = await getAccessibleResource(req, res, heartbeat.getRunLogAccess(runId), "Heartbeat run not found");
     if (!run) return;
+    await assertCanReadHeartbeatRunOutput(req, run);
 
     const offset = Number(req.query.offset ?? 0);
     const limitBytes = readRunLogLimitBytes(req.query.limitBytes);

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -225,7 +225,7 @@ import {
   redactCurrentUserValue,
   type CurrentUserRedactionOptions,
 } from "../log-redaction.js";
-import { redactEventPayload, redactSensitiveText } from "../redaction.js";
+import { redactEventPayload, redactKnownSecretValues, redactRunOutputValue, redactSensitiveText } from "../redaction.js";
 import {
   hasSessionCompactionThresholds,
   resolveSessionCompactionPolicy,
@@ -1886,6 +1886,7 @@ const heartbeatRunSqlAsciiSafeColumns = {
 const heartbeatRunLogAccessColumns = {
   id: heartbeatRuns.id,
   companyId: heartbeatRuns.companyId,
+  agentId: heartbeatRuns.agentId,
   logStore: heartbeatRuns.logStore,
   logRef: heartbeatRuns.logRef,
 } as const;
@@ -12813,6 +12814,17 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         cwd: executionWorkspace.cwd,
       },
     });
+    const runOutputSecretValues = [
+      ...Object.entries(parseObject(resolvedConfig.env))
+        .filter(([key, value]) => typeof value === "string" && (secretKeys.has(key) || /(?:secret|token|key|password|credential|auth)/i.test(key)))
+        .map(([, value]) => value as string),
+      ...String(process.env.PAPERCLIP_RUN_OUTPUT_REDACTION_VALUES ?? "").split(","),
+    ];
+    const redactRunOutputText = (value: string, currentUserRedactionOptions: CurrentUserRedactionOptions) =>
+      redactKnownSecretValues(
+        redactSensitiveText(redactCurrentUserText(value, currentUserRedactionOptions)),
+        runOutputSecretValues,
+      );
     const runtimeSessionParams = runtimeSessionResolution.sessionParams;
     const runtimeWorkspaceWarnings = [
       ...resolvedWorkspace.warnings,
@@ -13089,7 +13101,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       const currentUserRedactionOptions = await getCurrentUserRedactionOptions();
       const onLog = async (stream: "stdout" | "stderr", chunk: string) => {
         const sanitizedChunk = compactRunLogChunk(
-          redactCurrentUserText(chunk, currentUserRedactionOptions),
+          redactRunOutputText(chunk, currentUserRedactionOptions),
         );
         if (stream === "stdout") stdoutExcerpt = appendExcerpt(stdoutExcerpt, sanitizedChunk);
         if (stream === "stderr") stderrExcerpt = appendExcerpt(stderrExcerpt, sanitizedChunk);
@@ -13740,6 +13752,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         }),
         adapterResult.summary ?? null,
       );
+      const sanitizedPersistedResultJson = redactRunOutputValue(persistedResultJson, runOutputSecretValues);
 
       const persistedRunWrite = await setRunStatusIfRunning(run.id, status, {
         finishedAt: new Date(),
@@ -13748,10 +13761,10 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         exitCode: adapterResult.exitCode,
         signal: adapterResult.signal,
         usageJson,
-        resultJson: persistedResultJson,
+        resultJson: sanitizedPersistedResultJson,
         sessionIdAfter: nextSessionState.displayId ?? nextSessionState.legacySessionId,
-        stdoutExcerpt,
-        stderrExcerpt,
+        stdoutExcerpt: redactRunOutputText(stdoutExcerpt, currentUserRedactionOptions),
+        stderrExcerpt: redactRunOutputText(stderrExcerpt, currentUserRedactionOptions),
         logBytes: logSummary?.bytes,
         logSha256: logSummary?.sha256,
         logCompressed: logSummary?.compressed ?? false,
@@ -13815,7 +13828,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           try {
             const existingRunComment = await findRunIssueComment(livenessRun.id, livenessRun.companyId, issueId);
             if (!existingRunComment) {
-              const issueComment = buildHeartbeatRunIssueComment(persistedResultJson);
+              const issueComment = buildHeartbeatRunIssueComment(sanitizedPersistedResultJson);
               if (issueComment) {
                 await issuesSvc.addComment(issueId, issueComment, { agentId: agent.id, runId: livenessRun.id });
               }
@@ -13909,11 +13922,11 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
               agentId: agent.id,
               adapterType: agent.adapterType,
               taskKey,
-              sessionParamsJson: attachPaperclipSessionMetadataToSessionParams(
+              sessionParamsJson: redactRunOutputValue(attachPaperclipSessionMetadataToSessionParams(
                 nextSessionState.params,
                 configuredModel,
                 sessionConfigMetadata,
-              ),
+              ), runOutputSecretValues),
               sessionDisplayId: nextSessionState.displayId,
               lastRunId: finalizedRun.id,
               lastError: outcome === "succeeded" ? null : (adapterResult.errorMessage ?? "run_failed"),

--- a/server/src/services/index.ts
+++ b/server/src/services/index.ts
@@ -81,6 +81,12 @@ export { costService } from "./costs.js";
 export { financeService } from "./finance.js";
 export { heartbeatService, resolveHeartbeatSchedulingSuppression } from "./heartbeat.js";
 export {
+  purgeHeartbeatRunOutput,
+  pruneExpiredHeartbeatRunOutput,
+  readRunOutputRetentionDays,
+  startHeartbeatRunOutputRetention,
+} from "./run-output-retention.js";
+export {
   productivityReviewService,
   PRODUCTIVITY_REVIEW_ORIGIN_KIND,
 } from "./productivity-review.js";

--- a/server/src/services/run-log-store.test.ts
+++ b/server/src/services/run-log-store.test.ts
@@ -66,6 +66,32 @@ describe("createDurableRunLogStore", () => {
     expect(handle.store).toBe("local_file");
   });
 
+  it("creates private directories and files even with a permissive umask", async () => {
+    const previous = process.umask(0o000);
+    try {
+      const store = createDurableRunLogStore({ basePath: baseDir });
+      const handle = await store.begin(begin);
+      const fileMode = (await fs.stat(path.join(baseDir, handle.logRef))).mode & 0o777;
+      const directoryMode = (await fs.stat(path.dirname(path.join(baseDir, handle.logRef)))).mode & 0o777;
+      expect(fileMode).toBe(0o600);
+      expect(directoryMode).toBe(0o700);
+    } finally {
+      process.umask(previous);
+    }
+  });
+
+  it("removes both local and mirrored output idempotently", async () => {
+    const { provider, objects } = createMemoryProvider();
+    const store = createDurableRunLogStore({ basePath: baseDir, s3: { provider, keyPrefix: "run-logs" } });
+    const handle = await store.begin(begin);
+    await store.append(handle, { stream: "stdout", chunk: "sensitive output", ts: "t1" });
+    await store.finalize(handle);
+    await store.remove(handle);
+    await store.remove(handle);
+    await expect(store.read(handle)).rejects.toThrow(/not found/i);
+    expect(objects.has(`run-logs/${handle.logRef}`)).toBe(false);
+  });
+
   it("appends locally and reads back during a run WITHOUT hitting S3 (fast live tail)", async () => {
     const { provider, calls } = createMemoryProvider();
     const store = createDurableRunLogStore({ basePath: baseDir, s3: { provider } });

--- a/server/src/services/run-log-store.ts
+++ b/server/src/services/run-log-store.ts
@@ -37,6 +37,7 @@ export interface RunLogStore {
   ): Promise<number>;
   finalize(handle: RunLogHandle): Promise<RunLogFinalizeSummary>;
   read(handle: RunLogHandle, opts?: RunLogReadOptions): Promise<RunLogReadResult>;
+  remove(handle: RunLogHandle): Promise<void>;
 }
 
 function safeSegments(...segments: string[]) {
@@ -86,7 +87,11 @@ export function createDurableRunLogStore(options: DurableRunLogStoreOptions): Ru
 
   async function ensureDir(relativeDir: string) {
     const dir = resolveWithin(basePath, relativeDir);
-    await fs.mkdir(dir, { recursive: true });
+    // Explicit modes are required here: recursive mkdir otherwise inherits the
+    // host umask and can leave one agent's transcript directory readable by
+    // another local user.
+    await fs.mkdir(dir, { recursive: true, mode: 0o700 });
+    await fs.chmod(dir, 0o700);
   }
 
   async function readLocalRange(
@@ -164,7 +169,10 @@ export function createDurableRunLogStore(options: DurableRunLogStoreOptions): Ru
       const relPath = path.join(relDir, `${runId}.ndjson`);
       await ensureDir(relDir);
       const absPath = resolveWithin(basePath, relPath);
-      await fs.writeFile(absPath, "", "utf8");
+      // chmod after write is intentional. writeFile does not change an
+      // existing file mode, and a retry must repair a permissive stale file.
+      await fs.writeFile(absPath, "", { encoding: "utf8", mode: 0o600 });
+      await fs.chmod(absPath, 0o600);
       return { store: "local_file", logRef: relPath };
     },
 
@@ -230,6 +238,21 @@ export function createDurableRunLogStore(options: DurableRunLogStoreOptions): Ru
       if (local) return local;
       // Local file gone (pod rolled) -> serve from the S3 mirror if configured.
       return readS3Range(handle.logRef, offset, limitBytes);
+    },
+
+    async remove(handle) {
+      if (handle.store !== "local_file") return;
+      const absPath = resolveWithin(basePath, handle.logRef);
+      await fs.unlink(absPath).catch((err: NodeJS.ErrnoException) => {
+        if (err.code !== "ENOENT") throw err;
+      });
+      if (s3) {
+        await s3.provider.deleteObject({ objectKey: s3Key(handle.logRef) }).catch((err: NodeJS.ErrnoException) => {
+          // S3 DELETE is normally idempotent. Some compatible providers do
+          // return a not-found error though, which must not make a purge fail.
+          if (err.code !== "ENOENT" && err.name !== "NoSuchKey" && err.name !== "NotFound") throw err;
+        });
+      }
     },
   };
 }

--- a/server/src/services/run-output-retention.ts
+++ b/server/src/services/run-output-retention.ts
@@ -1,0 +1,122 @@
+import { and, eq, inArray, lt } from "drizzle-orm";
+import type { Db } from "@paperclipai/db";
+import {
+  agentRuntimeState,
+  agentTaskSessions,
+  heartbeatRunEvents,
+  heartbeatRuns,
+} from "@paperclipai/db";
+import { getRunLogStore } from "./run-log-store.js";
+
+const TERMINAL_RUN_STATUSES = ["succeeded", "failed", "cancelled", "timed_out"];
+
+export type RunOutputPurgeResult = {
+  runId: string;
+  companyId: string;
+  alreadyPurged: boolean;
+  clearedSessionArtifacts: number;
+};
+
+/**
+ * Remove content-bearing run data while retaining the row that proves the run
+ * happened. This intentionally keeps status, timestamps, usage and event
+ * identity/ordering, but clears the text/payload attached to those events.
+ */
+export async function purgeHeartbeatRunOutput(db: Db, runId: string): Promise<RunOutputPurgeResult | null> {
+  const run = await db
+    .select()
+    .from(heartbeatRuns)
+    .where(eq(heartbeatRuns.id, runId))
+    .then((rows) => rows[0] ?? null);
+  if (!run) return null;
+
+  const alreadyPurged = !run.logRef && !run.logStore && !run.resultJson &&
+    !run.stdoutExcerpt && !run.stderrExcerpt && !run.error &&
+    !run.sessionIdBefore && !run.sessionIdAfter;
+
+  // Delete physical content before clearing its reference. A transient storage
+  // failure leaves the database retryable rather than falsely claiming a purge.
+  if (run.logStore && run.logRef) {
+    await getRunLogStore().remove({ store: run.logStore as "local_file", logRef: run.logRef });
+  }
+
+  const now = new Date();
+  const clearedSessions = await db.transaction(async (tx) => {
+    await tx
+      .update(heartbeatRunEvents)
+      .set({ message: null, payload: null })
+      .where(eq(heartbeatRunEvents.runId, run.id));
+
+    await tx
+      .update(heartbeatRuns)
+      .set({
+        error: null,
+        resultJson: null,
+        sessionIdBefore: null,
+        sessionIdAfter: null,
+        logStore: null,
+        logRef: null,
+        logBytes: null,
+        logSha256: null,
+        logCompressed: false,
+        stdoutExcerpt: null,
+        stderrExcerpt: null,
+        updatedAt: now,
+      })
+      .where(eq(heartbeatRuns.id, run.id));
+
+    const sessions = await tx
+      .delete(agentTaskSessions)
+      .where(and(eq(agentTaskSessions.companyId, run.companyId), eq(agentTaskSessions.lastRunId, run.id)))
+      .returning({ id: agentTaskSessions.id });
+
+    await tx
+      .update(agentRuntimeState)
+      .set({ sessionId: null, stateJson: {}, lastError: null, updatedAt: now })
+      .where(and(eq(agentRuntimeState.companyId, run.companyId), eq(agentRuntimeState.lastRunId, run.id)));
+
+    return sessions.length;
+  });
+
+  return {
+    runId: run.id,
+    companyId: run.companyId,
+    alreadyPurged,
+    clearedSessionArtifacts: clearedSessions,
+  };
+}
+
+export function readRunOutputRetentionDays(value = process.env.HEARTBEAT_RUN_OUTPUT_RETENTION_DAYS): number | null {
+  if (value === undefined || value.trim() === "") return null;
+  const days = Number(value);
+  if (!Number.isFinite(days) || days < 0) return null;
+  return Math.floor(days);
+}
+
+export async function pruneExpiredHeartbeatRunOutput(
+  db: Db,
+  retentionDays: number | null = readRunOutputRetentionDays(),
+  now = new Date(),
+): Promise<number> {
+  if (retentionDays === null) return 0;
+  const cutoff = new Date(now.getTime() - retentionDays * 24 * 60 * 60 * 1000);
+  const candidates = await db
+    .select({ id: heartbeatRuns.id })
+    .from(heartbeatRuns)
+    .where(and(inArray(heartbeatRuns.status, TERMINAL_RUN_STATUSES), lt(heartbeatRuns.finishedAt, cutoff)))
+    .limit(250);
+
+  let pruned = 0;
+  for (const candidate of candidates) {
+    const result = await purgeHeartbeatRunOutput(db, candidate.id);
+    if (result && !result.alreadyPurged) pruned += 1;
+  }
+  return pruned;
+}
+
+export function startHeartbeatRunOutputRetention(db: Db, intervalMs = 60 * 60 * 1_000) {
+  const sweep = () => pruneExpiredHeartbeatRunOutput(db).catch(() => undefined);
+  sweep();
+  const timer = setInterval(sweep, intervalMs);
+  return () => clearInterval(timer);
+}


### PR DESCRIPTION
## Summary

- restrict heartbeat run metadata, event, and raw-log access to the owning agent plus authorized board, supervisory, and security paths
- add an audited, idempotent board-only purge operation and configurable output-retention pruning
- remove persisted output from local/S3 logs, result/excerpt/error fields, event content, and matching resumable sessions while preserving lifecycle/audit metadata
- enforce `0700` log-directory and `0600` log-file modes independent of umask
- strengthen pre-persistence redaction, including unmanaged sentinel credentials

## Validation

- focused Vitest suite: 24 passing
- `@paperclipai/server` typecheck: passing

## Security notes

The purge operation deliberately preserves non-content run status, timestamps, usage, and audit events. Purged raw-log reads return 404, and repeated purge requests are safe and audited.

Paperclip task: AIG-700
Head SHA: `11de56758b4acd727e0d20a9d4586264f830643a`
