### PR TITLE
fix(acpx): configure Codex models at startup

### DIFF
--- a/packages/adapter-utils/src/acpx-engine/execute.test.ts
+++ b/packages/adapter-utils/src/acpx-engine/execute.test.ts
@@ -194,6 +194,7 @@ describe("shared ACPX engine runtime behavior", () => {
       String((meta[0]?.env as Record<string, string>).CODEX_CONFIG),
     ) as Record<string, unknown>;
     expect(codexConfig.model).toBe(arbitraryModel);
+    expect(codexConfig.model_reasoning_effort).toBe("xhigh");
     expect(configOptions).toEqual([]);
   });
 
@@ -216,6 +217,22 @@ describe("shared ACPX engine runtime behavior", () => {
       approval_policy: "never",
       service_tier: "fast",
       features: { experimental_feature: true, fast_mode: true },
+    });
+  });
+
+  it("warns when runtime settings replace malformed user CODEX_CONFIG", async () => {
+    const { logs, meta } = await runExecutor({
+      agent: "codex",
+      model: "gpt-runtime",
+      env: { CODEX_CONFIG: "not-json" },
+    });
+
+    expect(JSON.parse(String((meta[0]?.env as Record<string, string>).CODEX_CONFIG))).toEqual({
+      model: "gpt-runtime",
+    });
+    expect(logs).toContainEqual({
+      stream: "stderr",
+      text: "[paperclip] Ignoring invalid user CODEX_CONFIG while applying runtime Codex settings; expected a JSON object.\n",
     });
   });
 

--- a/packages/adapter-utils/src/acpx-engine/execute.test.ts
+++ b/packages/adapter-utils/src/acpx-engine/execute.test.ts
@@ -91,7 +91,9 @@ function createLocalSandboxRunner(
   };
 }
 
-function buildRuntime() {
+function buildRuntime(
+  onSetConfigOption?: (input: { key: string; value: string }) => void,
+) {
   return {
     ensureSession: async () => ({
       backendSessionId: "backend-session",
@@ -105,6 +107,9 @@ function buildRuntime() {
       result: Promise.resolve({ status: "completed", stopReason: "end_turn" }),
       cancel: async () => {},
     }),
+    setConfigOption: async (input: { key: string; value: string }) => {
+      onSetConfigOption?.(input);
+    },
     close: async () => {},
   };
 }
@@ -120,12 +125,13 @@ async function runExecutor(
   } = {},
 ) {
   const runtimeOptions: Record<string, unknown>[] = [];
+  const configOptions: Array<{ key: string; value: string }> = [];
   const meta: Record<string, unknown>[] = [];
   const logs: Array<{ stream: string; text: string }> = [];
   const execute = createAcpxEngineExecutor({
     createRuntime: (options) => {
       runtimeOptions.push(options as unknown as Record<string, unknown>);
-      return buildRuntime() as never;
+      return buildRuntime(({ key, value }) => configOptions.push({ key, value })) as never;
     },
   });
 
@@ -151,10 +157,93 @@ async function runExecutor(
   } as never);
 
   expect(result.exitCode).toBe(0);
-  return { logs, meta, runtimeOptions, result };
+  return { logs, meta, runtimeOptions, configOptions, result };
 }
 
 describe("shared ACPX engine runtime behavior", () => {
+  it("sets Codex model, effort, and fast mode through CODEX_CONFIG without session config calls", async () => {
+    const { configOptions, meta } = await runExecutor({
+      agent: "codex",
+      model: "gpt-5.6-sol",
+      modelReasoningEffort: "high",
+      fastMode: true,
+    });
+
+    expect(JSON.parse(String((meta[0]?.env as Record<string, string>).CODEX_CONFIG))).toEqual({
+      model: "gpt-5.6-sol",
+      model_reasoning_effort: "high",
+      service_tier: "fast",
+      features: { fast_mode: true },
+    });
+    expect(configOptions).toEqual([]);
+    expect(meta[0]?.commandNotes).toContain(
+      "Requested ACPX model: gpt-5.6-sol (set via CODEX_CONFIG at startup).",
+    );
+  });
+
+  it("forwards arbitrary Codex model IDs verbatim without picker-dependent session config", async () => {
+    const arbitraryModel = "gpt-999-test-does-not-exist";
+    const { configOptions, meta } = await runExecutor({
+      agent: "codex",
+      model: arbitraryModel,
+      reasoningEffort: "xhigh",
+      fastMode: true,
+    });
+
+    const codexConfig = JSON.parse(
+      String((meta[0]?.env as Record<string, string>).CODEX_CONFIG),
+    ) as Record<string, unknown>;
+    expect(codexConfig.model).toBe(arbitraryModel);
+    expect(configOptions).toEqual([]);
+  });
+
+  it("merges user CODEX_CONFIG while runtime model settings win", async () => {
+    const { meta } = await runExecutor({
+      agent: "codex",
+      model: "gpt-runtime",
+      fastMode: true,
+      env: {
+        CODEX_CONFIG: JSON.stringify({
+          model: "gpt-user",
+          approval_policy: "never",
+          features: { experimental_feature: true, fast_mode: false },
+        }),
+      },
+    });
+
+    expect(JSON.parse(String((meta[0]?.env as Record<string, string>).CODEX_CONFIG))).toEqual({
+      model: "gpt-runtime",
+      approval_policy: "never",
+      service_tier: "fast",
+      features: { experimental_feature: true, fast_mode: true },
+    });
+  });
+
+  it("keeps Claude startup model handling and Gemini session config handling unchanged", async () => {
+    const claude = await runExecutor({ agent: "claude", model: "claude-opus-4-7" });
+    expect((claude.meta[0]?.env as Record<string, string>).ANTHROPIC_MODEL).toBe(
+      "claude-opus-4-7",
+    );
+    expect(claude.configOptions).toEqual([]);
+
+    const gemini = await runExecutor({
+      agent: "gemini",
+      model: "gemini-2.5-pro",
+      thinkingEffort: "high",
+    });
+    expect(gemini.configOptions).toEqual([
+      { key: "model", value: "gemini-2.5-pro" },
+      { key: "effort", value: "high" },
+    ]);
+  });
+
+  it("does not inject CODEX_CONFIG or session config when Codex overrides are absent", async () => {
+    const { configOptions, meta } = await runExecutor({ agent: "codex" });
+
+    expect((meta[0]?.env as Record<string, string>).CODEX_CONFIG).toBeUndefined();
+    expect(configOptions).toEqual([]);
+  });
+
   it("includes Paperclip env and API access notes in the ACPX prompt without leaking the token", async () => {
     const { meta } = await runExecutor(
       { agent: "custom", agentCommand: "node ./fake-acp.js" },

--- a/packages/adapter-utils/src/acpx-engine/execute.ts
+++ b/packages/adapter-utils/src/acpx-engine/execute.ts
@@ -729,37 +729,42 @@ function buildCodexStartupConfig(input: {
   requestedModel: string;
   requestedThinkingEffort: string;
   fastMode: boolean;
-}): string | null {
+}): { value: string | null; invalidExistingConfig: boolean } {
   const hasRuntimeConfig = Boolean(
     input.requestedModel || input.requestedThinkingEffort || input.fastMode,
   );
-  if (!hasRuntimeConfig) return null;
+  if (!hasRuntimeConfig) return { value: null, invalidExistingConfig: false };
 
   let existing: Record<string, unknown> = {};
+  let invalidExistingConfig = false;
   if (input.existingConfig) {
     try {
       existing = parseObject(JSON.parse(input.existingConfig));
     } catch {
+      invalidExistingConfig = true;
       existing = {};
     }
   }
 
-  return JSON.stringify({
-    ...existing,
-    ...(input.requestedModel ? { model: input.requestedModel } : {}),
-    ...(input.requestedThinkingEffort
-      ? { model_reasoning_effort: input.requestedThinkingEffort }
-      : {}),
-    ...(input.fastMode
-      ? {
-          service_tier: "fast",
-          features: {
-            ...parseObject(existing.features),
-            fast_mode: true,
-          },
-        }
-      : {}),
-  });
+  return {
+    value: JSON.stringify({
+      ...existing,
+      ...(input.requestedModel ? { model: input.requestedModel } : {}),
+      ...(input.requestedThinkingEffort
+        ? { model_reasoning_effort: input.requestedThinkingEffort }
+        : {}),
+      ...(input.fastMode
+        ? {
+            service_tier: "fast",
+            features: {
+              ...parseObject(existing.features),
+              fast_mode: true,
+            },
+          }
+        : {}),
+    }),
+    invalidExistingConfig,
+  };
 }
 
 function isCompatibleSession(
@@ -1119,7 +1124,13 @@ async function buildRuntime(input: {
       requestedThinkingEffort,
       fastMode,
     });
-    if (codexStartupConfig) env.CODEX_CONFIG = codexStartupConfig;
+    if (codexStartupConfig.invalidExistingConfig) {
+      await input.ctx.onLog(
+        "stderr",
+        "[paperclip] Ignoring invalid user CODEX_CONFIG while applying runtime Codex settings; expected a JSON object.\n",
+      );
+    }
+    if (codexStartupConfig.value) env.CODEX_CONFIG = codexStartupConfig.value;
   }
 
   let skillPromptInstructions = "";

--- a/packages/adapter-utils/src/acpx-engine/execute.ts
+++ b/packages/adapter-utils/src/acpx-engine/execute.ts
@@ -724,6 +724,44 @@ function normalizeRequestedThinkingEffort(config: Record<string, unknown>): stri
   ).trim();
 }
 
+function buildCodexStartupConfig(input: {
+  existingConfig: string | undefined;
+  requestedModel: string;
+  requestedThinkingEffort: string;
+  fastMode: boolean;
+}): string | null {
+  const hasRuntimeConfig = Boolean(
+    input.requestedModel || input.requestedThinkingEffort || input.fastMode,
+  );
+  if (!hasRuntimeConfig) return null;
+
+  let existing: Record<string, unknown> = {};
+  if (input.existingConfig) {
+    try {
+      existing = parseObject(JSON.parse(input.existingConfig));
+    } catch {
+      existing = {};
+    }
+  }
+
+  return JSON.stringify({
+    ...existing,
+    ...(input.requestedModel ? { model: input.requestedModel } : {}),
+    ...(input.requestedThinkingEffort
+      ? { model_reasoning_effort: input.requestedThinkingEffort }
+      : {}),
+    ...(input.fastMode
+      ? {
+          service_tier: "fast",
+          features: {
+            ...parseObject(existing.features),
+            fast_mode: true,
+          },
+        }
+      : {}),
+  });
+}
+
 function isCompatibleSession(
   params: Record<string, unknown>,
   runtime: Pick<AcpxPreparedRuntime, "fingerprint" | "sessionKey" | "cwd" | "mode" | "acpxAgent" | "remoteExecutionIdentity">,
@@ -1074,6 +1112,15 @@ async function buildRuntime(input: {
   if (requestedModel && acpxAgent === "claude" && !env.ANTHROPIC_MODEL) {
     env.ANTHROPIC_MODEL = requestedModel;
   }
+  if (acpxAgent === "codex") {
+    const codexStartupConfig = buildCodexStartupConfig({
+      existingConfig: env.CODEX_CONFIG,
+      requestedModel,
+      requestedThinkingEffort,
+      fastMode,
+    });
+    if (codexStartupConfig) env.CODEX_CONFIG = codexStartupConfig;
+  }
 
   let skillPromptInstructions = "";
   let skillsIdentity: Record<string, unknown> = { mode: "unsupported" };
@@ -1289,19 +1336,23 @@ async function buildRuntime(input: {
 
 function sessionConfigOptions(prepared: AcpxPreparedRuntime): Array<{ key: string; value: string }> {
   const options: Array<{ key: string; value: string }> = [];
-  // Model for the claude agent is pre-set via ANTHROPIC_MODEL env var at
-  // startup; skip set_config_option to avoid ACP-server model-name validation
-  // that rejects bare IDs like "claude-opus-4-7" in some runtime versions.
-  if (prepared.requestedModel && prepared.acpxAgent !== "claude") {
+  // Claude and Codex runtime config is pre-set via startup env vars; skip
+  // set_config_option to avoid ACP-server picker validation rejecting valid
+  // backend model IDs that are not advertised by the local ACP server.
+  if (
+    prepared.requestedModel &&
+    prepared.acpxAgent !== "claude" &&
+    prepared.acpxAgent !== "codex"
+  ) {
     options.push({ key: "model", value: prepared.requestedModel });
   }
-  if (prepared.requestedThinkingEffort) {
+  if (prepared.requestedThinkingEffort && prepared.acpxAgent !== "codex") {
     options.push({
-      key: prepared.acpxAgent === "codex" ? "reasoning_effort" : "effort",
+      key: "effort",
       value: prepared.requestedThinkingEffort,
     });
   }
-  if (prepared.fastMode) {
+  if (prepared.fastMode && prepared.acpxAgent !== "codex") {
     options.push(
       { key: "service_tier", value: "fast" },
       { key: "features.fast_mode", value: "true" },
@@ -2059,6 +2110,8 @@ export function createAcpxEngineExecutor(deps: AcpxEngineExecutorOptions = {}) {
             ? [
                 prepared.acpxAgent === "claude"
                   ? `Requested ACPX model: ${prepared.requestedModel} (set via ANTHROPIC_MODEL env at startup).`
+                  : prepared.acpxAgent === "codex"
+                    ? `Requested ACPX model: ${prepared.requestedModel} (set via CODEX_CONFIG at startup).`
                   : `Requested ACPX model: ${prepared.requestedModel}.`,
               ]
             : []),

--- a/packages/adapters/codex-local/src/server/acp.test.ts
+++ b/packages/adapters/codex-local/src/server/acp.test.ts
@@ -477,14 +477,15 @@ describe("codex_local ACP lane", () => {
       mode: "persistent",
       cwd: root,
     });
-    expect(runtimes[0]?.setConfigInputs.map((input) => [input.key, input.value])).toEqual([
-      ["model", "gpt-5.5"],
-      ["reasoning_effort", "high"],
-      ["service_tier", "fast"],
-      ["features.fast_mode", "true"],
-    ]);
+    expect(runtimes[0]?.setConfigInputs).toEqual([]);
     expect(meta[0]?.commandNotes?.join("\n")).toContain("Prepared ACPX Codex skill home");
     expect(meta[0]?.env?.CODEX_HOME).toBe(path.join(root, "codex-home"));
+    expect(JSON.parse(String(meta[0]?.env?.CODEX_CONFIG))).toEqual({
+      model: "gpt-5.5",
+      model_reasoning_effort: "high",
+      service_tier: "fast",
+      features: { fast_mode: true },
+    });
   });
 
   it("classifies ACP refresh-token auth failures", async () => {


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - ACPX adapters launch provider agents and configure their sessions before turns begin
> - The Codex ACP server validates `session/set_config_option` model values against its advertised picker list
> - Valid backend model IDs that are not advertised therefore fail during session setup, even though the Codex CLI accepts them
> - Codex already supports startup configuration through `CODEX_CONFIG`, which bypasses picker-only validation
> - This pull request moves Codex model, reasoning effort, and fast-mode configuration to startup and skips those session config calls unconditionally
> - The benefit is that current, future, and custom-gateway model IDs work without a Paperclip redeploy or model allowlist update

## Linked Issues or Issue Description

### Pre-submission checklist

- [x] I searched existing open and closed issues and pull requests. Related work: #9355 handles rejected ACP session configuration generally, while #9342 adds specific model options; neither provides arbitrary-model startup pass-through.
- [x] I can reproduce this behavior on `master` at commit `a04a77c9d3`.
- [x] I confirmed the failure originates in Paperclip's ACPX session configuration path rather than provider credentials or local configuration.

### What happened?

When an ACPX Codex agent is configured with a backend-valid model ID that is absent from the Codex ACP server's advertised picker, Paperclip sends the model through `session/set_config_option`. The ACP server rejects it with `-32602` before the first turn, although the same model can be passed through the Codex CLI startup path.

### Expected behavior

Paperclip should forward any configured Codex model ID, reasoning effort, and fast-mode setting at process startup without validating the model against a release-time allowlist. Invalid IDs may fail at the backend on the first turn, matching the Codex CLI behavior.

### Steps to reproduce

1. Configure a Paperclip ACPX Codex agent with a model ID not advertised by the local Codex ACP `model/list`, such as `gpt-999-test-does-not-exist`.
2. Start an agent run.
3. Observe Paperclip call `session/set_config_option` for the model and fail session setup with ACP `-32602` before the first turn.

### Paperclip version or commit

`a04a77c9d3` (`master` when reproduced)

### Deployment mode

Local dev (`pnpm dev`)

### Installation method

Built from source (`pnpm dev` / `pnpm build`)

### Agent adapter(s) involved

- [x] Codex

### Database mode

Not database-related

### Access context

Unclear / not applicable

### Relevant logs or output

ACP session setup rejects the unadvertised model with error code `-32602` before the first agent turn.

### Additional context

The zero-allowlist behavior is intentional so future OpenAI releases and custom-gateway model IDs do not require a Paperclip release. Runtime settings should override conflicting keys in user-provided `CODEX_CONFIG` while preserving unrelated keys.

### Privacy checklist

- [x] I reviewed the description for PII and secrets; none are included.

## What Changed

- Merge Paperclip's Codex model, reasoning effort, and fast-mode settings into the `CODEX_CONFIG` startup environment, preserving unrelated user configuration while runtime settings win conflicts.
- Skip Codex model, effort, and fast-mode `session/set_config_option` calls unconditionally.
- Add regression coverage for arbitrary model pass-through, user config merging, empty config behavior, and unchanged Claude/Gemini handling.
- Update ACPX run metadata to identify `CODEX_CONFIG` as the Codex model configuration path.

## Verification

- `pnpm exec vitest run packages/adapters/codex-local/src/server/acp.test.ts packages/adapter-utils/src/acpx-engine/execute.test.ts` — 70 tests passed.
- `pnpm --filter @paperclipai/adapter-utils typecheck` — passed.

## Risks

- Low risk: the change is isolated to Codex ACPX startup/session configuration.
- Invalid model IDs now reach the backend and fail on the first turn rather than during ACP session setup; this intentionally matches the existing Codex CLI pass-through behavior.
- Malformed user-provided `CODEX_CONFIG` cannot be merged and is replaced only when Paperclip has runtime Codex settings to apply; untouched configurations remain unchanged when no runtime setting is present.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex, exact model ID `gpt-5.6-sol`, high reasoning effort, with repository tool use and code execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes: #` / `Refs: #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
