### PR TITLE
fix(cli): cold-quarantine worktree seeds

### DIFF
--- a/cli/src/__tests__/worktree.test.ts
+++ b/cli/src/__tests__/worktree.test.ts
@@ -575,10 +575,10 @@ describe("worktree helpers", () => {
         .update(instanceSettings)
         .set({
           experimental: {
-          enableWorktreeRunExecution: true,
-          worktreeRunExecutionActivatedAt: "2026-07-16T12:00:00.000Z",
-          worktreeRunExecutionActivationInstanceId: "source-instance",
-          enableSmokeLab: true,
+            enableWorktreeRunExecution: true,
+            worktreeRunExecutionActivatedAt: "2026-07-16T12:00:00.000Z",
+            worktreeRunExecutionActivationInstanceId: "source-instance",
+            enableSmokeLab: true,
           },
         })
         .where(eq(instanceSettings.singletonKey, "default"));

--- a/cli/src/__tests__/worktree.test.ts
+++ b/cli/src/__tests__/worktree.test.ts
@@ -4,13 +4,16 @@ import path from "node:path";
 import { execFileSync } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { createServer } from "node:net";
-import { eq } from "drizzle-orm";
+import { eq, inArray } from "drizzle-orm";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  agentWakeupRequests,
   agents,
   authUsers,
   companies,
   createDb,
+  heartbeatRuns,
+  instanceSettings,
   issueComments,
   issues,
   projects,
@@ -22,6 +25,7 @@ import {
   copySeededSecretsKey,
   pauseSeededScheduledRoutines,
   quarantineSeededWorktreeExecutionState,
+  resetSeededWorktreeRunExecutionActivation,
   readSourceAttachmentBody,
   rebindWorkspaceCwd,
   resolveSourceConfigPath,
@@ -359,6 +363,11 @@ describe("worktree helpers", () => {
     const todoIssueId = randomUUID();
     const reviewIssueId = randomUUID();
     const userIssueId = randomUUID();
+    const wakeupId = randomUUID();
+    const completedWakeupId = randomUUID();
+    const queuedRunId = randomUUID();
+    const runningRunId = randomUUID();
+    const succeededRunId = randomUUID();
 
     try {
       await db.insert(companies).values({
@@ -406,6 +415,11 @@ describe("worktree helpers", () => {
           identifier: "WTQ-1",
           executionAgentNameKey: "codexcoder",
           executionLockedAt: new Date("2026-04-18T00:00:00.000Z"),
+          monitorNextCheckAt: new Date("2026-04-18T00:01:00.000Z"),
+          monitorWakeRequestedAt: new Date("2026-04-18T00:00:30.000Z"),
+          monitorLastTriggeredAt: new Date("2026-04-18T00:00:00.000Z"),
+          monitorAttemptCount: 2,
+          monitorNotes: "copied monitor state",
         },
         {
           id: todoIssueId,
@@ -438,8 +452,53 @@ describe("worktree helpers", () => {
           identifier: "WTQ-4",
         },
       ]);
+      await db.insert(agentWakeupRequests).values([
+        {
+          id: wakeupId,
+          companyId,
+          agentId,
+          source: "system",
+          status: "queued",
+        },
+        {
+          id: completedWakeupId,
+          companyId,
+          agentId,
+          source: "system",
+          status: "completed",
+        },
+      ]);
+      await db.insert(heartbeatRuns).values([
+        {
+          id: queuedRunId,
+          companyId,
+          agentId,
+          status: "queued",
+          wakeupRequestId: wakeupId,
+          processPid: 1234,
+          processGroupId: 1234,
+        },
+        {
+          id: runningRunId,
+          companyId,
+          agentId,
+          status: "running",
+          processPid: 5678,
+          processGroupId: 5678,
+        },
+        {
+          id: succeededRunId,
+          companyId,
+          agentId,
+          status: "succeeded",
+          wakeupRequestId: completedWakeupId,
+        },
+      ]);
 
       await expect(quarantineSeededWorktreeExecutionState(tempDb.connectionString)).resolves.toEqual({
+        cancelledHeartbeatRuns: 2,
+        deletedPendingWakeups: 1,
+        clearedIssueMonitors: 1,
         disabledTimerHeartbeats: 1,
         resetRunningAgents: 1,
         quarantinedInProgressIssues: 1,
@@ -459,6 +518,32 @@ describe("worktree helpers", () => {
       expect(inProgressIssue?.assigneeAgentId).toBeNull();
       expect(inProgressIssue?.executionAgentNameKey).toBeNull();
       expect(inProgressIssue?.executionLockedAt).toBeNull();
+      expect(inProgressIssue?.monitorNextCheckAt).toBeNull();
+      expect(inProgressIssue?.monitorWakeRequestedAt).toBeNull();
+      expect(inProgressIssue?.monitorLastTriggeredAt).toBeNull();
+      expect(inProgressIssue?.monitorAttemptCount).toBe(0);
+      expect(inProgressIssue?.monitorNotes).toBeNull();
+
+      const quarantinedRuns = await db
+        .select()
+        .from(heartbeatRuns)
+        .where(inArray(heartbeatRuns.id, [queuedRunId, runningRunId]));
+      expect(quarantinedRuns).toHaveLength(2);
+      for (const run of quarantinedRuns) {
+        expect(run.status).toBe("cancelled");
+        expect(run.errorCode).toBe("worktree_seed_quarantine");
+        expect(run.processPid).toBeNull();
+        expect(run.processGroupId).toBeNull();
+        expect(run.finishedAt).toBeInstanceOf(Date);
+      }
+
+      const [succeededRun] = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.id, succeededRunId));
+      expect(succeededRun?.status).toBe("succeeded");
+      expect(succeededRun?.wakeupRequestId).toBe(completedWakeupId);
+
+      const wakeups = await db.select().from(agentWakeupRequests);
+      expect(wakeups).toHaveLength(1);
+      expect(wakeups[0]?.id).toBe(completedWakeupId);
 
       const [todoIssue] = await db.select().from(issues).where(eq(issues.id, todoIssueId));
       expect(todoIssue?.status).toBe("todo");
@@ -475,6 +560,38 @@ describe("worktree helpers", () => {
       const comments = await db.select().from(issueComments).where(eq(issueComments.issueId, inProgressIssueId));
       expect(comments).toHaveLength(1);
       expect(comments[0]?.body).toContain("Quarantined during worktree seed");
+    } finally {
+      await db.$client?.end?.({ timeout: 5 }).catch(() => undefined);
+      await tempDb.cleanup();
+    }
+  }, 20_000);
+
+  itEmbeddedPostgres("always disarms copied worktree run execution settings", async () => {
+    const tempDb = await startEmbeddedPostgresTestDatabase("paperclip-worktree-activation-reset-");
+    const db = createDb(tempDb.connectionString);
+
+    try {
+      await db
+        .update(instanceSettings)
+        .set({
+          experimental: {
+          enableWorktreeRunExecution: true,
+          worktreeRunExecutionActivatedAt: "2026-07-16T12:00:00.000Z",
+          worktreeRunExecutionActivationInstanceId: "source-instance",
+          enableSmokeLab: true,
+          },
+        })
+        .where(eq(instanceSettings.singletonKey, "default"));
+
+      await expect(resetSeededWorktreeRunExecutionActivation(tempDb.connectionString)).resolves.toBe(1);
+
+      const [settings] = await db.select().from(instanceSettings);
+      expect(settings?.experimental).toMatchObject({
+        enableWorktreeRunExecution: false,
+        worktreeRunExecutionActivatedAt: null,
+        worktreeRunExecutionActivationInstanceId: null,
+        enableSmokeLab: true,
+      });
     } finally {
       await db.$client?.end?.({ timeout: 5 }).catch(() => undefined);
       await tempDb.cleanup();

--- a/cli/src/commands/worktree.ts
+++ b/cli/src/commands/worktree.ts
@@ -22,6 +22,7 @@ import pc from "picocolors";
 import { and, eq, inArray, sql } from "drizzle-orm";
 import {
   applyPendingMigrations,
+  agentWakeupRequests,
   agents,
   assets,
   companies,
@@ -32,6 +33,7 @@ import {
   formatDatabaseBackupResult,
   goals,
   heartbeatRuns,
+  instanceSettings,
   inspectMigrations,
   issueAttachments,
   issueComments,
@@ -195,6 +197,9 @@ type SeedWorktreeDatabaseResult = {
 };
 
 export type SeededWorktreeExecutionQuarantineSummary = {
+  cancelledHeartbeatRuns: number;
+  deletedPendingWakeups: number;
+  clearedIssueMonitors: number;
   disabledTimerHeartbeats: number;
   resetRunningAgents: number;
   quarantinedInProgressIssues: number;
@@ -218,6 +223,9 @@ function formatSeededWorktreeExecutionQuarantineSummary(
   summary: SeededWorktreeExecutionQuarantineSummary,
 ): string {
   return [
+    `cancelled heartbeat runs: ${summary.cancelledHeartbeatRuns}`,
+    `deleted pending wakeups: ${summary.deletedPendingWakeups}`,
+    `cleared issue monitors: ${summary.clearedIssueMonitors}`,
     `disabled timer heartbeats: ${summary.disabledTimerHeartbeats}`,
     `reset running agents: ${summary.resetRunningAgents}`,
     `quarantined in-progress issues: ${summary.quarantinedInProgressIssues}`,
@@ -1149,6 +1157,9 @@ export async function pauseSeededScheduledRoutines(connectionString: string): Pr
 }
 
 const EMPTY_SEEDED_WORKTREE_EXECUTION_QUARANTINE_SUMMARY: SeededWorktreeExecutionQuarantineSummary = {
+  cancelledHeartbeatRuns: 0,
+  deletedPendingWakeups: 0,
+  clearedIssueMonitors: 0,
   disabledTimerHeartbeats: 0,
   resetRunningAgents: 0,
   quarantinedInProgressIssues: 0,
@@ -1192,6 +1203,63 @@ export async function quarantineSeededWorktreeExecutionState(
   const summary = { ...EMPTY_SEEDED_WORKTREE_EXECUTION_QUARANTINE_SUMMARY };
   try {
     await db.transaction(async (tx) => {
+      const now = new Date();
+      const pendingWakeups = await tx
+        .select({ id: agentWakeupRequests.id })
+        .from(agentWakeupRequests)
+        .where(inArray(agentWakeupRequests.status, ["queued", "deferred_issue_execution", "claimed"]));
+      const pendingWakeupIds = pendingWakeups.map((row) => row.id);
+
+      if (pendingWakeupIds.length > 0) {
+        await tx
+          .update(heartbeatRuns)
+          .set({ wakeupRequestId: null, updatedAt: now })
+          .where(inArray(heartbeatRuns.wakeupRequestId, pendingWakeupIds));
+      }
+
+      const cancelledRuns = await tx
+        .update(heartbeatRuns)
+        .set({
+          status: "cancelled",
+          errorCode: "worktree_seed_quarantine",
+          processPid: null,
+          processGroupId: null,
+          scheduledRetryAt: null,
+          finishedAt: now,
+          updatedAt: now,
+        })
+        .where(inArray(heartbeatRuns.status, ["queued", "running", "scheduled_retry"]))
+        .returning({ id: heartbeatRuns.id });
+      summary.cancelledHeartbeatRuns = cancelledRuns.length;
+
+      if (pendingWakeupIds.length > 0) {
+        const deletedWakeups = await tx
+          .delete(agentWakeupRequests)
+          .where(inArray(agentWakeupRequests.id, pendingWakeupIds))
+          .returning({ id: agentWakeupRequests.id });
+        summary.deletedPendingWakeups = deletedWakeups.length;
+      }
+
+      const clearedMonitors = await tx
+        .update(issues)
+        .set({
+          monitorNextCheckAt: null,
+          monitorWakeRequestedAt: null,
+          monitorLastTriggeredAt: null,
+          monitorAttemptCount: 0,
+          monitorNotes: null,
+          updatedAt: now,
+        })
+        .where(sql`
+          ${issues.monitorNextCheckAt} is not null
+          or ${issues.monitorWakeRequestedAt} is not null
+          or ${issues.monitorLastTriggeredAt} is not null
+          or ${issues.monitorAttemptCount} <> 0
+          or ${issues.monitorNotes} is not null
+        `)
+        .returning({ id: issues.id });
+      summary.clearedIssueMonitors = clearedMonitors.length;
+
       const seededAgents = await tx
         .select({
           id: agents.id,
@@ -1215,7 +1283,7 @@ export async function quarantineSeededWorktreeExecutionState(
             .set({
               runtimeConfig: normalized.runtimeConfig,
               status: nextStatus,
-              updatedAt: new Date(),
+              updatedAt: now,
             })
             .where(eq(agents.id, agent.id));
         }
@@ -1248,7 +1316,7 @@ export async function quarantineSeededWorktreeExecutionState(
             executionAgentNameKey: null,
             executionLockedAt: null,
             executionWorkspaceId: null,
-            updatedAt: new Date(),
+            updatedAt: now,
           })
           .where(eq(issues.id, issue.id));
 
@@ -1270,6 +1338,31 @@ export async function quarantineSeededWorktreeExecutionState(
     });
 
     return summary;
+  } finally {
+    await db.$client?.end?.({ timeout: 5 }).catch(() => undefined);
+  }
+}
+
+export async function resetSeededWorktreeRunExecutionActivation(connectionString: string): Promise<number> {
+  const db = createDb(connectionString);
+  try {
+    const rows = await db.select({ id: instanceSettings.id, experimental: instanceSettings.experimental }).from(instanceSettings);
+    let resetCount = 0;
+    for (const row of rows) {
+      const experimental = isRecord(row.experimental) ? row.experimental : {};
+      const nextExperimental = {
+        ...experimental,
+        enableWorktreeRunExecution: false,
+        worktreeRunExecutionActivatedAt: null,
+        worktreeRunExecutionActivationInstanceId: null,
+      };
+      await db
+        .update(instanceSettings)
+        .set({ experimental: nextExperimental, updatedAt: new Date() })
+        .where(eq(instanceSettings.id, row.id));
+      resetCount += 1;
+    }
+    return resetCount;
   } finally {
     await db.$client?.end?.({ timeout: 5 }).catch(() => undefined);
   }
@@ -1334,6 +1427,7 @@ async function seedWorktreeDatabase(input: {
       backupFile: backup.backupFile,
     });
     await applyPendingMigrations(targetConnectionString);
+    await resetSeededWorktreeRunExecutionActivation(targetConnectionString);
     const executionQuarantine = input.preserveLiveWork
       ? { ...EMPTY_SEEDED_WORKTREE_EXECUTION_QUARANTINE_SUMMARY }
       : await quarantineSeededWorktreeExecutionState(targetConnectionString);
@@ -3094,7 +3188,7 @@ export async function worktreeMergeHistoryCommand(sourceArg: string | undefined,
 }
 
 async function runWorktreeReseed(opts: WorktreeReseedOptions): Promise<void> {
-  const seedMode = opts.seedMode ?? "full";
+  const seedMode = opts.seedMode ?? "minimal";
   if (!isWorktreeSeedMode(seedMode)) {
     throw new Error(`Unsupported seed mode "${seedMode}". Expected one of: minimal, full.`);
   }
@@ -3290,7 +3384,7 @@ export function registerWorktreeCommands(program: Command): void {
     .option("--server-port <port>", "Preferred server port", (value) => Number(value))
     .option("--db-port <port>", "Preferred embedded Postgres port", (value) => Number(value))
     .option("--seed-mode <mode>", "Seed profile: minimal or full (default: minimal)", "minimal")
-    .option("--preserve-live-work", "Do not quarantine copied agent timers or assigned open issues in the seeded worktree", false)
+    .option("--preserve-live-work", "Preserve copied runs, wakeups, monitors, agent timers, and assigned open issues", false)
     .option("--no-seed", "Skip database seeding from the source instance")
     .option("--force", "Replace existing repo-local config and isolated instance data", false)
     .action(worktreeMakeCommand);
@@ -3307,7 +3401,7 @@ export function registerWorktreeCommands(program: Command): void {
     .option("--server-port <port>", "Preferred server port", (value) => Number(value))
     .option("--db-port <port>", "Preferred embedded Postgres port", (value) => Number(value))
     .option("--seed-mode <mode>", "Seed profile: minimal or full (default: minimal)", "minimal")
-    .option("--preserve-live-work", "Do not quarantine copied agent timers or assigned open issues in the seeded worktree", false)
+    .option("--preserve-live-work", "Preserve copied runs, wakeups, monitors, agent timers, and assigned open issues", false)
     .option("--no-seed", "Skip database seeding from the source instance")
     .option("--force", "Replace existing repo-local config and isolated instance data", false)
     .action(worktreeInitCommand);
@@ -3346,8 +3440,8 @@ export function registerWorktreeCommands(program: Command): void {
     .option("--from-config <path>", "Source config.json to seed from")
     .option("--from-data-dir <path>", "Source PAPERCLIP_HOME used when deriving the source config")
     .option("--from-instance <id>", "Source instance id when deriving the source config")
-    .option("--seed-mode <mode>", "Seed profile: minimal or full (default: full)", "full")
-    .option("--preserve-live-work", "Do not quarantine copied agent timers or assigned open issues in the seeded worktree", false)
+    .option("--seed-mode <mode>", "Seed profile: minimal or full (default: minimal)", "minimal")
+    .option("--preserve-live-work", "Preserve copied runs, wakeups, monitors, agent timers, and assigned open issues", false)
     .option("--yes", "Skip the destructive confirmation prompt", false)
     .option("--allow-live-target", "Override the guard that requires the target worktree DB to be stopped first", false)
     .action(worktreeReseedCommand);
@@ -3361,7 +3455,7 @@ export function registerWorktreeCommands(program: Command): void {
     .option("--from-data-dir <path>", "Source PAPERCLIP_HOME used when deriving the source config")
     .option("--from-instance <id>", "Source instance id when deriving the source config (default: default)")
     .option("--seed-mode <mode>", "Seed profile: minimal or full (default: minimal)", "minimal")
-    .option("--preserve-live-work", "Do not quarantine copied agent timers or assigned open issues in the seeded worktree", false)
+    .option("--preserve-live-work", "Preserve copied runs, wakeups, monitors, agent timers, and assigned open issues", false)
     .option("--no-seed", "Repair metadata only and skip reseeding when bootstrapping a missing worktree config", false)
     .option("--allow-live-target", "Override the guard that requires the target worktree DB to be stopped first", false)
     .action(worktreeRepairCommand);

--- a/doc/DEVELOPING.md
+++ b/doc/DEVELOPING.md
@@ -404,6 +404,7 @@ eval "$(paperclipai worktree env)"
 | `--server-port <port>` | Preferred server port |
 | `--db-port <port>` | Preferred embedded Postgres port |
 | `--seed-mode <mode>` | Seed profile: `minimal` or `full` (default: `minimal`) |
+| `--preserve-live-work` | Explicitly bypass seed quarantine for copied runs, wakeups, monitors, agent timers, and assigned open issues. The worktree run-execution toggle is still reset. |
 | `--no-seed` | Skip database seeding from the source instance |
 | `--force` | Replace existing repo-local config and isolated instance data |
 
@@ -440,6 +441,7 @@ For an already-created worktree where you want the CLI to decide whether to rebu
 | `--from-data-dir <path>` | Source `PAPERCLIP_HOME` used when deriving the source config |
 | `--from-instance <id>` | Source instance id when deriving the source config (default: `default`) |
 | `--seed-mode <mode>` | Seed profile: `minimal` or `full` (default: `minimal`) |
+| `--preserve-live-work` | Explicitly bypass seed quarantine for copied runs, wakeups, monitors, agent timers, and assigned open issues. The worktree run-execution toggle is still reset. |
 | `--no-seed` | Repair metadata only when bootstrapping a missing worktree config |
 | `--allow-live-target` | Override the guard that requires the target worktree DB to be stopped first |
 
@@ -466,7 +468,8 @@ For an already-created worktree where you want to keep the existing repo-local c
 | `--from-config <path>` | Source config.json to seed from |
 | `--from-data-dir <path>` | Source `PAPERCLIP_HOME` used when deriving the source config |
 | `--from-instance <id>` | Source instance id when deriving the source config |
-| `--seed-mode <mode>` | Seed profile: `minimal` or `full` (default: `full`) |
+| `--seed-mode <mode>` | Seed profile: `minimal` or `full` (default: `minimal`) |
+| `--preserve-live-work` | Explicitly bypass seed quarantine for copied runs, wakeups, monitors, agent timers, and assigned open issues. The worktree run-execution toggle is still reset. |
 | `--yes` | Skip the destructive confirmation prompt |
 | `--allow-live-target` | Override the guard that requires the target worktree DB to be stopped first |
 
@@ -484,8 +487,7 @@ pnpm paperclipai worktree reseed \
 # From inside a worktree, reseed it from the default instance config.
 cd /path/to/paperclip/.paperclip/worktrees/PAP-1132-assistant-ui-pap-1131-make-issues-comments-be-like-a-chat
 pnpm paperclipai worktree reseed \
-  --from-instance default \
-  --seed-mode full
+  --from-instance default
 ```
 
 **`pnpm paperclipai worktree:make <name> [options]`** — Create `~/NAME` as a git worktree, then initialize an isolated Paperclip instance inside it. This combines `git worktree add` with `worktree init` in a single step.
@@ -501,6 +503,7 @@ pnpm paperclipai worktree reseed \
 | `--server-port <port>` | Preferred server port |
 | `--db-port <port>` | Preferred embedded Postgres port |
 | `--seed-mode <mode>` | Seed profile: `minimal` or `full` (default: `minimal`) |
+| `--preserve-live-work` | Explicitly bypass seed quarantine for copied runs, wakeups, monitors, agent timers, and assigned open issues. The worktree run-execution toggle is still reset. |
 | `--no-seed` | Skip database seeding from the source instance |
 | `--force` | Replace existing repo-local config and isolated instance data |
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Worktree instances provide isolated databases for developing and testing Paperclip changes safely
> - Seed and reseed operations can copy live execution records and scheduling state from the source instance
> - A copied queued or running record can look active and may become executable if a worktree inherits an armed execution toggle
> - Worktree seeds therefore need to be cold by construction rather than relying only on runtime scheduling gates
> - This pull request quarantines copied execution state in the shared seed pipeline and always disarms worktree run execution after restore
> - The benefit is that init, reseed, and repair paths cannot accidentally resume source-instance work unless an operator explicitly preserves the copied state and then separately re-arms execution

## Linked Issues or Issue Description

No duplicate public issue or pull request was found in the repository search performed on July 16, 2026.

### What happened?

Full worktree seeds could copy queued or running heartbeat records, pending wakeup requests, due issue-monitor scheduling state, and an armed worktree execution setting. A newly initialized, repaired, or reseeded worktree could therefore appear live and retain state capable of resuming source-instance work.

### Expected behavior

Seeded worktree databases start cold across minimal and full seed modes: no non-terminal heartbeat runs, pending wakeups, or due monitors remain, and run execution is disarmed. Preserving copied live records requires an explicit `--preserve-live-work` flag, while activation still resets unconditionally.

### Steps to reproduce

1. Create source-instance execution state containing a queued or running heartbeat run, a pending wakeup, a due issue monitor, and an activated worktree execution toggle.
2. Initialize or reseed a worktree database from that source using a full seed.
3. Start the seeded instance and inspect the copied execution state.
4. Before this change, copied live state remained present and the activation toggle could remain armed.

### Paperclip version or commit

Reproduced on `master` before commit `d16b2c02f6d1e95978b9d5b1bd7464d23041c694`.

### Deployment mode

Local development from source using isolated worktree instances and embedded Postgres.
## What Changed

- Cancel copied non-terminal heartbeat runs with `worktree_seed_quarantine` and clear copied process identifiers.
- Delete pending wakeup requests and clear persisted issue monitor scheduling state during seed quarantine.
- Always reset worktree run-execution activation after database restore, including when `--preserve-live-work` is used.
- Change `worktree reseed` to default to the minimal seed profile while retaining full seeds as an explicit option.
- Expand focused CLI regression coverage and document the preservation bypass for init, make, repair, and reseed commands.

## Verification

- `pnpm exec vitest run cli/src/__tests__/worktree.test.ts`
- `pnpm --dir packages/plugins/sdk build`
- `pnpm --dir cli typecheck`
- `git diff --check`

## Risks

- Existing scripts that relied on `worktree reseed` implicitly using the full profile now need `--seed-mode full`.
- `--preserve-live-work` keeps copied execution records, wakeups, monitors, agent timers, and assignments, but the execution toggle is intentionally still disarmed and must be re-enabled explicitly.
- Low migration risk: this changes post-restore cleanup behavior only and does not alter the database schema.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex using the GPT-5.4 coding model with reasoning and terminal/tool execution; context-window size is not exposed by this runtime.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge