### PR TITLE
fix(server): narrow inbox archive resurface triggers

### DIFF
--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -1790,6 +1790,7 @@ describeEmbeddedPostgres("issueService.list participantAgentId", () => {
       done: randomUUID(),
       humanComment: randomUUID(),
       mention: randomUUID(),
+      derivedAgentMention: randomUUID(),
       selfMention: randomUUID(),
       unarchived: randomUUID(),
     };
@@ -1872,6 +1873,16 @@ describeEmbeddedPostgres("issueService.list participantAgentId", () => {
         createdAt: new Date("2026-03-26T13:00:00.000Z"),
         updatedAt: new Date("2026-03-26T13:00:00.000Z"),
       },
+      {
+        companyId,
+        issueId: issueIds.derivedAgentMention,
+        authorUserId: "local-board",
+        derivedAuthorAgentId: agentId,
+        derivedAuthorSource: "run_log_comment_post",
+        body: "Agent progress needs [Viewer](user://user-1)",
+        createdAt: new Date("2026-03-26T13:00:00.000Z"),
+        updatedAt: new Date("2026-03-26T13:00:00.000Z"),
+      },
     ]);
 
     await db.insert(issueThreadInteractions).values({
@@ -1932,6 +1943,7 @@ describeEmbeddedPostgres("issueService.list participantAgentId", () => {
       issueIds.done,
       issueIds.humanComment,
       issueIds.mention,
+      issueIds.derivedAgentMention,
       issueIds.unarchived,
     ]);
     await expect(listVisibleIds()).resolves.toEqual(expectedVisible);

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -1790,6 +1790,7 @@ describeEmbeddedPostgres("issueService.list participantAgentId", () => {
       done: randomUUID(),
       humanComment: randomUUID(),
       mention: randomUUID(),
+      selfMention: randomUUID(),
       unarchived: randomUUID(),
     };
 
@@ -1860,6 +1861,14 @@ describeEmbeddedPostgres("issueService.list participantAgentId", () => {
         issueId: issueIds.mention,
         authorAgentId: agentId,
         body: "Please review this, [Viewer](user://user-1)",
+        createdAt: new Date("2026-03-26T13:00:00.000Z"),
+        updatedAt: new Date("2026-03-26T13:00:00.000Z"),
+      },
+      {
+        companyId,
+        issueId: issueIds.selfMention,
+        authorUserId: userId,
+        body: "Note to self, [Viewer](user://user-1)",
         createdAt: new Date("2026-03-26T13:00:00.000Z"),
         updatedAt: new Date("2026-03-26T13:00:00.000Z"),
       },

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1471,7 +1471,10 @@ function inboxVisibleForUserCondition(companyId: string, userId: string) {
                   AND ${issueComments.authorAgentId} IS NULL
                   AND ${issueComments.derivedAuthorAgentId} IS NULL
                 )
-                OR POSITION(${`](user://${userId})`} IN ${issueComments.body}) > 0
+                OR (
+                  ${issueComments.authorUserId} IS DISTINCT FROM ${userId}
+                  AND POSITION(${`](user://${userId})`} IN ${issueComments.body}) > 0
+                )
               )
           )
         )


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the control plane operators use to manage AI-agent companies and work needing their attention
> - The inbox archive state lets operators dismiss work until a meaningful event requires renewed attention
> - The core archive-resurface narrowing has now landed on `master`, but two mention edge cases remain on this branch
> - A user's own comment mentioning themselves should not immediately undo their archive action
> - A derived-agent comment that explicitly mentions the viewing user should still request that user's attention
> - This pull request preserves those two distinctions and locks them down with regression coverage
> - The benefit is stable archive behavior without losing explicit agent-to-human attention signals

## Linked Issues or Issue Description

- **What happened:** After the core archive visibility fix landed, self-authored mentions could still resurface an archived issue, while the derived-agent mention behavior needed explicit regression coverage.
- **Expected behavior:** A user's own mention remains archived; an agent-authored/derived comment explicitly mentioning that user resurfaces the issue.
- **Steps to reproduce:** Archive an inbox issue, then either (1) post a board comment that mentions yourself or (2) have the assigned agent post a derived comment mentioning you. Only case (2) should resurface.
- **Environment:** Current `master`, local development, embedded PGlite/Postgres-compatible query path, board access, Node.js `v22.22.2`.
- Related: #9659 adds agent archive workflows but does not define these mention edge cases.

## What Changed

- Require explicit user mentions to come from a different author before resurfacing an archived issue.
- Add visibility-matrix coverage proving self-mentions stay hidden and derived-agent mentions resurface.

## Verification

- `pnpm vitest run server/src/__tests__/issues-service.test.ts -t "archived inbox issues|user-attention events"` — 2 passed.
- `pnpm --filter @paperclipai/server typecheck` — passed.
- `git diff --check origin/master...HEAD` — passed.

## Risks

- Low risk: no schema, migration, API contract, or UI changes.
- Behavior is limited to archived inbox visibility for explicit mentions.
- The query adds only an author inequality condition to an existing correlated comment check.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex coding agent; the runtime did not expose the exact model ID or context-window size. Reasoning, terminal tool use, code execution, and GitHub integration were enabled.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes (no documentation changes were required)
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge