### PR TITLE
fix(server): bind worktree activation to per-instance nonce

### DIFF
--- a/cli/src/__tests__/worktree.test.ts
+++ b/cli/src/__tests__/worktree.test.ts
@@ -576,6 +576,7 @@ describe("worktree helpers", () => {
         .set({
           experimental: {
             enableWorktreeRunExecution: true,
+            worktreeRunExecutionInstanceNonce: "9ed115ac-9e93-4fe9-a4f1-eb4ea2b0fb24",
             worktreeRunExecutionActivatedAt: "2026-07-16T12:00:00.000Z",
             worktreeRunExecutionActivationInstanceId: "source-instance",
             enableSmokeLab: true,
@@ -588,6 +589,7 @@ describe("worktree helpers", () => {
       const [settings] = await db.select().from(instanceSettings);
       expect(settings?.experimental).toMatchObject({
         enableWorktreeRunExecution: false,
+        worktreeRunExecutionInstanceNonce: null,
         worktreeRunExecutionActivatedAt: null,
         worktreeRunExecutionActivationInstanceId: null,
         enableSmokeLab: true,

--- a/cli/src/__tests__/worktree.test.ts
+++ b/cli/src/__tests__/worktree.test.ts
@@ -575,10 +575,10 @@ describe("worktree helpers", () => {
         .update(instanceSettings)
         .set({
           experimental: {
-          enableWorktreeRunExecution: true,
-          worktreeRunExecutionActivatedAt: "2026-07-16T12:00:00.000Z",
-          worktreeRunExecutionActivationInstanceId: "source-instance",
-          enableSmokeLab: true,
+            enableWorktreeRunExecution: true,
+            worktreeRunExecutionActivatedAt: "2026-07-16T12:00:00.000Z",
+            worktreeRunExecutionActivationInstanceId: "source-instance",
+            enableSmokeLab: true,
           },
         })
         .where(eq(instanceSettings.singletonKey, "default"));

--- a/cli/src/__tests__/worktree.test.ts
+++ b/cli/src/__tests__/worktree.test.ts
@@ -4,13 +4,16 @@ import path from "node:path";
 import { execFileSync } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { createServer } from "node:net";
-import { eq } from "drizzle-orm";
+import { eq, inArray } from "drizzle-orm";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  agentWakeupRequests,
   agents,
   authUsers,
   companies,
   createDb,
+  heartbeatRuns,
+  instanceSettings,
   issueComments,
   issues,
   projects,
@@ -22,6 +25,7 @@ import {
   copySeededSecretsKey,
   pauseSeededScheduledRoutines,
   quarantineSeededWorktreeExecutionState,
+  resetSeededWorktreeRunExecutionActivation,
   readSourceAttachmentBody,
   rebindWorkspaceCwd,
   resolveSourceConfigPath,
@@ -359,6 +363,11 @@ describe("worktree helpers", () => {
     const todoIssueId = randomUUID();
     const reviewIssueId = randomUUID();
     const userIssueId = randomUUID();
+    const wakeupId = randomUUID();
+    const completedWakeupId = randomUUID();
+    const queuedRunId = randomUUID();
+    const runningRunId = randomUUID();
+    const succeededRunId = randomUUID();
 
     try {
       await db.insert(companies).values({
@@ -406,6 +415,11 @@ describe("worktree helpers", () => {
           identifier: "WTQ-1",
           executionAgentNameKey: "codexcoder",
           executionLockedAt: new Date("2026-04-18T00:00:00.000Z"),
+          monitorNextCheckAt: new Date("2026-04-18T00:01:00.000Z"),
+          monitorWakeRequestedAt: new Date("2026-04-18T00:00:30.000Z"),
+          monitorLastTriggeredAt: new Date("2026-04-18T00:00:00.000Z"),
+          monitorAttemptCount: 2,
+          monitorNotes: "copied monitor state",
         },
         {
           id: todoIssueId,
@@ -438,8 +452,53 @@ describe("worktree helpers", () => {
           identifier: "WTQ-4",
         },
       ]);
+      await db.insert(agentWakeupRequests).values([
+        {
+          id: wakeupId,
+          companyId,
+          agentId,
+          source: "system",
+          status: "queued",
+        },
+        {
+          id: completedWakeupId,
+          companyId,
+          agentId,
+          source: "system",
+          status: "completed",
+        },
+      ]);
+      await db.insert(heartbeatRuns).values([
+        {
+          id: queuedRunId,
+          companyId,
+          agentId,
+          status: "queued",
+          wakeupRequestId: wakeupId,
+          processPid: 1234,
+          processGroupId: 1234,
+        },
+        {
+          id: runningRunId,
+          companyId,
+          agentId,
+          status: "running",
+          processPid: 5678,
+          processGroupId: 5678,
+        },
+        {
+          id: succeededRunId,
+          companyId,
+          agentId,
+          status: "succeeded",
+          wakeupRequestId: completedWakeupId,
+        },
+      ]);
 
       await expect(quarantineSeededWorktreeExecutionState(tempDb.connectionString)).resolves.toEqual({
+        cancelledHeartbeatRuns: 2,
+        deletedPendingWakeups: 1,
+        clearedIssueMonitors: 1,
         disabledTimerHeartbeats: 1,
         resetRunningAgents: 1,
         quarantinedInProgressIssues: 1,
@@ -459,6 +518,32 @@ describe("worktree helpers", () => {
       expect(inProgressIssue?.assigneeAgentId).toBeNull();
       expect(inProgressIssue?.executionAgentNameKey).toBeNull();
       expect(inProgressIssue?.executionLockedAt).toBeNull();
+      expect(inProgressIssue?.monitorNextCheckAt).toBeNull();
+      expect(inProgressIssue?.monitorWakeRequestedAt).toBeNull();
+      expect(inProgressIssue?.monitorLastTriggeredAt).toBeNull();
+      expect(inProgressIssue?.monitorAttemptCount).toBe(0);
+      expect(inProgressIssue?.monitorNotes).toBeNull();
+
+      const quarantinedRuns = await db
+        .select()
+        .from(heartbeatRuns)
+        .where(inArray(heartbeatRuns.id, [queuedRunId, runningRunId]));
+      expect(quarantinedRuns).toHaveLength(2);
+      for (const run of quarantinedRuns) {
+        expect(run.status).toBe("cancelled");
+        expect(run.errorCode).toBe("worktree_seed_quarantine");
+        expect(run.processPid).toBeNull();
+        expect(run.processGroupId).toBeNull();
+        expect(run.finishedAt).toBeInstanceOf(Date);
+      }
+
+      const [succeededRun] = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.id, succeededRunId));
+      expect(succeededRun?.status).toBe("succeeded");
+      expect(succeededRun?.wakeupRequestId).toBe(completedWakeupId);
+
+      const wakeups = await db.select().from(agentWakeupRequests);
+      expect(wakeups).toHaveLength(1);
+      expect(wakeups[0]?.id).toBe(completedWakeupId);
 
       const [todoIssue] = await db.select().from(issues).where(eq(issues.id, todoIssueId));
       expect(todoIssue?.status).toBe("todo");
@@ -475,6 +560,38 @@ describe("worktree helpers", () => {
       const comments = await db.select().from(issueComments).where(eq(issueComments.issueId, inProgressIssueId));
       expect(comments).toHaveLength(1);
       expect(comments[0]?.body).toContain("Quarantined during worktree seed");
+    } finally {
+      await db.$client?.end?.({ timeout: 5 }).catch(() => undefined);
+      await tempDb.cleanup();
+    }
+  }, 20_000);
+
+  itEmbeddedPostgres("always disarms copied worktree run execution settings", async () => {
+    const tempDb = await startEmbeddedPostgresTestDatabase("paperclip-worktree-activation-reset-");
+    const db = createDb(tempDb.connectionString);
+
+    try {
+      await db
+        .update(instanceSettings)
+        .set({
+          experimental: {
+          enableWorktreeRunExecution: true,
+          worktreeRunExecutionActivatedAt: "2026-07-16T12:00:00.000Z",
+          worktreeRunExecutionActivationInstanceId: "source-instance",
+          enableSmokeLab: true,
+          },
+        })
+        .where(eq(instanceSettings.singletonKey, "default"));
+
+      await expect(resetSeededWorktreeRunExecutionActivation(tempDb.connectionString)).resolves.toBe(1);
+
+      const [settings] = await db.select().from(instanceSettings);
+      expect(settings?.experimental).toMatchObject({
+        enableWorktreeRunExecution: false,
+        worktreeRunExecutionActivatedAt: null,
+        worktreeRunExecutionActivationInstanceId: null,
+        enableSmokeLab: true,
+      });
     } finally {
       await db.$client?.end?.({ timeout: 5 }).catch(() => undefined);
       await tempDb.cleanup();

--- a/cli/src/commands/worktree.ts
+++ b/cli/src/commands/worktree.ts
@@ -22,6 +22,7 @@ import pc from "picocolors";
 import { and, eq, inArray, sql } from "drizzle-orm";
 import {
   applyPendingMigrations,
+  agentWakeupRequests,
   agents,
   assets,
   companies,
@@ -32,6 +33,7 @@ import {
   formatDatabaseBackupResult,
   goals,
   heartbeatRuns,
+  instanceSettings,
   inspectMigrations,
   issueAttachments,
   issueComments,
@@ -195,6 +197,9 @@ type SeedWorktreeDatabaseResult = {
 };
 
 export type SeededWorktreeExecutionQuarantineSummary = {
+  cancelledHeartbeatRuns: number;
+  deletedPendingWakeups: number;
+  clearedIssueMonitors: number;
   disabledTimerHeartbeats: number;
   resetRunningAgents: number;
   quarantinedInProgressIssues: number;
@@ -218,6 +223,9 @@ function formatSeededWorktreeExecutionQuarantineSummary(
   summary: SeededWorktreeExecutionQuarantineSummary,
 ): string {
   return [
+    `cancelled heartbeat runs: ${summary.cancelledHeartbeatRuns}`,
+    `deleted pending wakeups: ${summary.deletedPendingWakeups}`,
+    `cleared issue monitors: ${summary.clearedIssueMonitors}`,
     `disabled timer heartbeats: ${summary.disabledTimerHeartbeats}`,
     `reset running agents: ${summary.resetRunningAgents}`,
     `quarantined in-progress issues: ${summary.quarantinedInProgressIssues}`,
@@ -1149,6 +1157,9 @@ export async function pauseSeededScheduledRoutines(connectionString: string): Pr
 }
 
 const EMPTY_SEEDED_WORKTREE_EXECUTION_QUARANTINE_SUMMARY: SeededWorktreeExecutionQuarantineSummary = {
+  cancelledHeartbeatRuns: 0,
+  deletedPendingWakeups: 0,
+  clearedIssueMonitors: 0,
   disabledTimerHeartbeats: 0,
   resetRunningAgents: 0,
   quarantinedInProgressIssues: 0,
@@ -1192,6 +1203,63 @@ export async function quarantineSeededWorktreeExecutionState(
   const summary = { ...EMPTY_SEEDED_WORKTREE_EXECUTION_QUARANTINE_SUMMARY };
   try {
     await db.transaction(async (tx) => {
+      const now = new Date();
+      const pendingWakeups = await tx
+        .select({ id: agentWakeupRequests.id })
+        .from(agentWakeupRequests)
+        .where(inArray(agentWakeupRequests.status, ["queued", "deferred_issue_execution", "claimed"]));
+      const pendingWakeupIds = pendingWakeups.map((row) => row.id);
+
+      if (pendingWakeupIds.length > 0) {
+        await tx
+          .update(heartbeatRuns)
+          .set({ wakeupRequestId: null, updatedAt: now })
+          .where(inArray(heartbeatRuns.wakeupRequestId, pendingWakeupIds));
+      }
+
+      const cancelledRuns = await tx
+        .update(heartbeatRuns)
+        .set({
+          status: "cancelled",
+          errorCode: "worktree_seed_quarantine",
+          processPid: null,
+          processGroupId: null,
+          scheduledRetryAt: null,
+          finishedAt: now,
+          updatedAt: now,
+        })
+        .where(inArray(heartbeatRuns.status, ["queued", "running", "scheduled_retry"]))
+        .returning({ id: heartbeatRuns.id });
+      summary.cancelledHeartbeatRuns = cancelledRuns.length;
+
+      if (pendingWakeupIds.length > 0) {
+        const deletedWakeups = await tx
+          .delete(agentWakeupRequests)
+          .where(inArray(agentWakeupRequests.id, pendingWakeupIds))
+          .returning({ id: agentWakeupRequests.id });
+        summary.deletedPendingWakeups = deletedWakeups.length;
+      }
+
+      const clearedMonitors = await tx
+        .update(issues)
+        .set({
+          monitorNextCheckAt: null,
+          monitorWakeRequestedAt: null,
+          monitorLastTriggeredAt: null,
+          monitorAttemptCount: 0,
+          monitorNotes: null,
+          updatedAt: now,
+        })
+        .where(sql`
+          ${issues.monitorNextCheckAt} is not null
+          or ${issues.monitorWakeRequestedAt} is not null
+          or ${issues.monitorLastTriggeredAt} is not null
+          or ${issues.monitorAttemptCount} <> 0
+          or ${issues.monitorNotes} is not null
+        `)
+        .returning({ id: issues.id });
+      summary.clearedIssueMonitors = clearedMonitors.length;
+
       const seededAgents = await tx
         .select({
           id: agents.id,
@@ -1215,7 +1283,7 @@ export async function quarantineSeededWorktreeExecutionState(
             .set({
               runtimeConfig: normalized.runtimeConfig,
               status: nextStatus,
-              updatedAt: new Date(),
+              updatedAt: now,
             })
             .where(eq(agents.id, agent.id));
         }
@@ -1248,7 +1316,7 @@ export async function quarantineSeededWorktreeExecutionState(
             executionAgentNameKey: null,
             executionLockedAt: null,
             executionWorkspaceId: null,
-            updatedAt: new Date(),
+            updatedAt: now,
           })
           .where(eq(issues.id, issue.id));
 
@@ -1270,6 +1338,31 @@ export async function quarantineSeededWorktreeExecutionState(
     });
 
     return summary;
+  } finally {
+    await db.$client?.end?.({ timeout: 5 }).catch(() => undefined);
+  }
+}
+
+export async function resetSeededWorktreeRunExecutionActivation(connectionString: string): Promise<number> {
+  const db = createDb(connectionString);
+  try {
+    const rows = await db.select({ id: instanceSettings.id, experimental: instanceSettings.experimental }).from(instanceSettings);
+    let resetCount = 0;
+    for (const row of rows) {
+      const experimental = isRecord(row.experimental) ? row.experimental : {};
+      const nextExperimental = {
+        ...experimental,
+        enableWorktreeRunExecution: false,
+        worktreeRunExecutionActivatedAt: null,
+        worktreeRunExecutionActivationInstanceId: null,
+      };
+      await db
+        .update(instanceSettings)
+        .set({ experimental: nextExperimental, updatedAt: new Date() })
+        .where(eq(instanceSettings.id, row.id));
+      resetCount += 1;
+    }
+    return resetCount;
   } finally {
     await db.$client?.end?.({ timeout: 5 }).catch(() => undefined);
   }
@@ -1334,6 +1427,7 @@ async function seedWorktreeDatabase(input: {
       backupFile: backup.backupFile,
     });
     await applyPendingMigrations(targetConnectionString);
+    await resetSeededWorktreeRunExecutionActivation(targetConnectionString);
     const executionQuarantine = input.preserveLiveWork
       ? { ...EMPTY_SEEDED_WORKTREE_EXECUTION_QUARANTINE_SUMMARY }
       : await quarantineSeededWorktreeExecutionState(targetConnectionString);
@@ -3094,7 +3188,7 @@ export async function worktreeMergeHistoryCommand(sourceArg: string | undefined,
 }
 
 async function runWorktreeReseed(opts: WorktreeReseedOptions): Promise<void> {
-  const seedMode = opts.seedMode ?? "full";
+  const seedMode = opts.seedMode ?? "minimal";
   if (!isWorktreeSeedMode(seedMode)) {
     throw new Error(`Unsupported seed mode "${seedMode}". Expected one of: minimal, full.`);
   }
@@ -3290,7 +3384,7 @@ export function registerWorktreeCommands(program: Command): void {
     .option("--server-port <port>", "Preferred server port", (value) => Number(value))
     .option("--db-port <port>", "Preferred embedded Postgres port", (value) => Number(value))
     .option("--seed-mode <mode>", "Seed profile: minimal or full (default: minimal)", "minimal")
-    .option("--preserve-live-work", "Do not quarantine copied agent timers or assigned open issues in the seeded worktree", false)
+    .option("--preserve-live-work", "Preserve copied runs, wakeups, monitors, agent timers, and assigned open issues", false)
     .option("--no-seed", "Skip database seeding from the source instance")
     .option("--force", "Replace existing repo-local config and isolated instance data", false)
     .action(worktreeMakeCommand);
@@ -3307,7 +3401,7 @@ export function registerWorktreeCommands(program: Command): void {
     .option("--server-port <port>", "Preferred server port", (value) => Number(value))
     .option("--db-port <port>", "Preferred embedded Postgres port", (value) => Number(value))
     .option("--seed-mode <mode>", "Seed profile: minimal or full (default: minimal)", "minimal")
-    .option("--preserve-live-work", "Do not quarantine copied agent timers or assigned open issues in the seeded worktree", false)
+    .option("--preserve-live-work", "Preserve copied runs, wakeups, monitors, agent timers, and assigned open issues", false)
     .option("--no-seed", "Skip database seeding from the source instance")
     .option("--force", "Replace existing repo-local config and isolated instance data", false)
     .action(worktreeInitCommand);
@@ -3346,8 +3440,8 @@ export function registerWorktreeCommands(program: Command): void {
     .option("--from-config <path>", "Source config.json to seed from")
     .option("--from-data-dir <path>", "Source PAPERCLIP_HOME used when deriving the source config")
     .option("--from-instance <id>", "Source instance id when deriving the source config")
-    .option("--seed-mode <mode>", "Seed profile: minimal or full (default: full)", "full")
-    .option("--preserve-live-work", "Do not quarantine copied agent timers or assigned open issues in the seeded worktree", false)
+    .option("--seed-mode <mode>", "Seed profile: minimal or full (default: minimal)", "minimal")
+    .option("--preserve-live-work", "Preserve copied runs, wakeups, monitors, agent timers, and assigned open issues", false)
     .option("--yes", "Skip the destructive confirmation prompt", false)
     .option("--allow-live-target", "Override the guard that requires the target worktree DB to be stopped first", false)
     .action(worktreeReseedCommand);
@@ -3361,7 +3455,7 @@ export function registerWorktreeCommands(program: Command): void {
     .option("--from-data-dir <path>", "Source PAPERCLIP_HOME used when deriving the source config")
     .option("--from-instance <id>", "Source instance id when deriving the source config (default: default)")
     .option("--seed-mode <mode>", "Seed profile: minimal or full (default: minimal)", "minimal")
-    .option("--preserve-live-work", "Do not quarantine copied agent timers or assigned open issues in the seeded worktree", false)
+    .option("--preserve-live-work", "Preserve copied runs, wakeups, monitors, agent timers, and assigned open issues", false)
     .option("--no-seed", "Repair metadata only and skip reseeding when bootstrapping a missing worktree config", false)
     .option("--allow-live-target", "Override the guard that requires the target worktree DB to be stopped first", false)
     .action(worktreeRepairCommand);

--- a/cli/src/commands/worktree.ts
+++ b/cli/src/commands/worktree.ts
@@ -1353,6 +1353,7 @@ export async function resetSeededWorktreeRunExecutionActivation(connectionString
       const nextExperimental = {
         ...experimental,
         enableWorktreeRunExecution: false,
+        worktreeRunExecutionInstanceNonce: null,
         worktreeRunExecutionActivatedAt: null,
         worktreeRunExecutionActivationInstanceId: null,
       };

--- a/doc/DEVELOPING.md
+++ b/doc/DEVELOPING.md
@@ -404,6 +404,7 @@ eval "$(paperclipai worktree env)"
 | `--server-port <port>` | Preferred server port |
 | `--db-port <port>` | Preferred embedded Postgres port |
 | `--seed-mode <mode>` | Seed profile: `minimal` or `full` (default: `minimal`) |
+| `--preserve-live-work` | Explicitly bypass seed quarantine for copied runs, wakeups, monitors, agent timers, and assigned open issues. The worktree run-execution toggle is still reset. |
 | `--no-seed` | Skip database seeding from the source instance |
 | `--force` | Replace existing repo-local config and isolated instance data |
 
@@ -440,6 +441,7 @@ For an already-created worktree where you want the CLI to decide whether to rebu
 | `--from-data-dir <path>` | Source `PAPERCLIP_HOME` used when deriving the source config |
 | `--from-instance <id>` | Source instance id when deriving the source config (default: `default`) |
 | `--seed-mode <mode>` | Seed profile: `minimal` or `full` (default: `minimal`) |
+| `--preserve-live-work` | Explicitly bypass seed quarantine for copied runs, wakeups, monitors, agent timers, and assigned open issues. The worktree run-execution toggle is still reset. |
 | `--no-seed` | Repair metadata only when bootstrapping a missing worktree config |
 | `--allow-live-target` | Override the guard that requires the target worktree DB to be stopped first |
 
@@ -466,7 +468,8 @@ For an already-created worktree where you want to keep the existing repo-local c
 | `--from-config <path>` | Source config.json to seed from |
 | `--from-data-dir <path>` | Source `PAPERCLIP_HOME` used when deriving the source config |
 | `--from-instance <id>` | Source instance id when deriving the source config |
-| `--seed-mode <mode>` | Seed profile: `minimal` or `full` (default: `full`) |
+| `--seed-mode <mode>` | Seed profile: `minimal` or `full` (default: `minimal`) |
+| `--preserve-live-work` | Explicitly bypass seed quarantine for copied runs, wakeups, monitors, agent timers, and assigned open issues. The worktree run-execution toggle is still reset. |
 | `--yes` | Skip the destructive confirmation prompt |
 | `--allow-live-target` | Override the guard that requires the target worktree DB to be stopped first |
 
@@ -484,8 +487,7 @@ pnpm paperclipai worktree reseed \
 # From inside a worktree, reseed it from the default instance config.
 cd /path/to/paperclip/.paperclip/worktrees/PAP-1132-assistant-ui-pap-1131-make-issues-comments-be-like-a-chat
 pnpm paperclipai worktree reseed \
-  --from-instance default \
-  --seed-mode full
+  --from-instance default
 ```
 
 **`pnpm paperclipai worktree:make <name> [options]`** — Create `~/NAME` as a git worktree, then initialize an isolated Paperclip instance inside it. This combines `git worktree add` with `worktree init` in a single step.
@@ -501,6 +503,7 @@ pnpm paperclipai worktree reseed \
 | `--server-port <port>` | Preferred server port |
 | `--db-port <port>` | Preferred embedded Postgres port |
 | `--seed-mode <mode>` | Seed profile: `minimal` or `full` (default: `minimal`) |
+| `--preserve-live-work` | Explicitly bypass seed quarantine for copied runs, wakeups, monitors, agent timers, and assigned open issues. The worktree run-execution toggle is still reset. |
 | `--no-seed` | Skip database seeding from the source instance |
 | `--force` | Replace existing repo-local config and isolated instance data |
 

--- a/packages/shared/src/types/instance.ts
+++ b/packages/shared/src/types/instance.ts
@@ -74,13 +74,18 @@ export interface InstanceExperimentalSettings {
    */
   enableWorktreeRunExecution: boolean;
   /**
+   * Server-managed random identity for this worktree database. Seed/reset flows
+   * clear it so the first boot stamps a fresh value.
+   */
+  worktreeRunExecutionInstanceNonce: string | null;
+  /**
    * Server-managed cutoff recorded when worktree run execution is enabled in
    * this instance. Client PATCH payloads must not control this value.
    */
   worktreeRunExecutionActivatedAt: string | null;
   /**
-   * Server-managed instance id captured with the cutoff so copied settings rows
-   * from another instance fail closed.
+   * Server-managed instance nonce captured with the cutoff so copied activation
+   * state from another instance fails closed.
    */
   worktreeRunExecutionActivationInstanceId: string | null;
   issueGraphLivenessAutoRecoveryLookbackHours: number;

--- a/packages/shared/src/validators/instance.ts
+++ b/packages/shared/src/validators/instance.ts
@@ -61,6 +61,7 @@ export const instanceExperimentalSettingsSchema = z.object({
   enableWorkspaceBranchReconcileForward: z.boolean().default(true),
   enableWorkspaceDirtyQuarantineRepair: z.boolean().default(true),
   enableWorktreeRunExecution: z.boolean().default(false),
+  worktreeRunExecutionInstanceNonce: z.string().uuid().nullable().default(null),
   worktreeRunExecutionActivatedAt: z.string().datetime().nullable().default(null),
   worktreeRunExecutionActivationInstanceId: z.string().min(1).nullable().default(null),
   issueGraphLivenessAutoRecoveryLookbackHours: z
@@ -73,6 +74,7 @@ export const instanceExperimentalSettingsSchema = z.object({
 
 export const patchInstanceExperimentalSettingsSchema = instanceExperimentalSettingsSchema
   .omit({
+    worktreeRunExecutionInstanceNonce: true,
     worktreeRunExecutionActivatedAt: true,
     worktreeRunExecutionActivationInstanceId: true,
   })

--- a/server/src/__tests__/dev-runner-worktree.test.ts
+++ b/server/src/__tests__/dev-runner-worktree.test.ts
@@ -31,7 +31,7 @@ describe("dev-runner worktree env bootstrap", () => {
     expect(isLinkedGitWorktreeCheckout(root)).toBe(true);
   });
 
-  it("loads repo-local Paperclip env for initialized worktrees without overriding explicit env", () => {
+  it("loads repo-local Paperclip env and overrides inherited identity keys", () => {
     const root = createTempRoot("paperclip-dev-runner-worktree-env-");
     fs.mkdirSync(path.join(root, ".paperclip"), { recursive: true });
     fs.writeFileSync(path.join(root, ".git"), "gitdir: /tmp/paperclip/.git/worktrees/feature\n", "utf8");
@@ -49,7 +49,9 @@ describe("dev-runner worktree env bootstrap", () => {
     );
 
     const env: NodeJS.ProcessEnv = {
+      PAPERCLIP_HOME: "/shared/paperclip-home",
       PAPERCLIP_INSTANCE_ID: "already-set",
+      PAPERCLIP_WORKTREE_NAME: "explicit-name",
     };
     const result = bootstrapDevRunnerWorktreeEnv(root, env);
 
@@ -58,8 +60,9 @@ describe("dev-runner worktree env bootstrap", () => {
       missingEnv: false,
     });
     expect(env.PAPERCLIP_HOME).toBe("/tmp/paperclip-worktrees");
-    expect(env.PAPERCLIP_INSTANCE_ID).toBe("already-set");
+    expect(env.PAPERCLIP_INSTANCE_ID).toBe("feature-worktree");
     expect(env.PAPERCLIP_IN_WORKTREE).toBe("true");
+    expect(env.PAPERCLIP_WORKTREE_NAME).toBe("explicit-name");
     expect(env.PAPERCLIP_OPTIONAL).toBe("");
   });
 

--- a/server/src/__tests__/heartbeat-worktree-suppression.test.ts
+++ b/server/src/__tests__/heartbeat-worktree-suppression.test.ts
@@ -143,6 +143,24 @@ describeEmbeddedPostgres("heartbeat worktree suppression", () => {
     }).updateExperimental({ enableWorktreeRunExecution: true });
   }
 
+  it("stamps and reuses a server-managed nonce on first worktree settings read", async () => {
+    const generatedNonce = "9ed115ac-9e93-4fe9-a4f1-eb4ea2b0fb24";
+    const settings = instanceSettingsService(db, {
+      runtimeEnv: {
+        PAPERCLIP_IN_WORKTREE: "true",
+        PAPERCLIP_INSTANCE_ID: "injected-shared-instance-id",
+      },
+      generateInstanceNonce: () => generatedNonce,
+    });
+
+    await expect(settings.getExperimental()).resolves.toMatchObject({
+      worktreeRunExecutionInstanceNonce: generatedNonce,
+    });
+    await expect(settings.getExperimental()).resolves.toMatchObject({
+      worktreeRunExecutionInstanceNonce: generatedNonce,
+    });
+  });
+
   async function waitForCompletedRun(runId: string, agentId: string) {
     let latestStatus: string | null = null;
     let latestLastRunId: string | null = null;
@@ -259,7 +277,7 @@ describeEmbeddedPostgres("heartbeat worktree suppression", () => {
     const heartbeat = heartbeatService(db, {
       runtimeEnv: {
         PAPERCLIP_IN_WORKTREE: "true",
-        PAPERCLIP_INSTANCE_ID: "test-worktree",
+        PAPERCLIP_INSTANCE_ID: "different-injected-instance-id",
       },
     });
 

--- a/server/src/__tests__/instance-settings-service.test.ts
+++ b/server/src/__tests__/instance-settings-service.test.ts
@@ -6,6 +6,8 @@ import {
   resolveWorktreeRunExecutionActivationState,
 } from "../services/instance-settings.js";
 
+const INSTANCE_NONCE = "9ed115ac-9e93-4fe9-a4f1-eb4ea2b0fb24";
+
 describe("instance settings service", () => {
   it("ignores retired experimental flags without resetting current settings", () => {
     expect(normalizeExperimentalSettings({
@@ -48,6 +50,7 @@ describe("instance settings service", () => {
       enableWorkspaceBranchReconcileForward: true,
       enableWorkspaceDirtyQuarantineRepair: false,
       enableWorktreeRunExecution: false,
+      worktreeRunExecutionInstanceNonce: null,
       worktreeRunExecutionActivatedAt: null,
       worktreeRunExecutionActivationInstanceId: null,
       issueGraphLivenessAutoRecoveryLookbackHours: 48,
@@ -153,7 +156,10 @@ describe("instance settings service", () => {
     const activatedAt = new Date("2026-07-10T12:00:00.000Z");
 
     const next = applyExperimentalSettingsPatch(
-      { enableWorktreeRunExecution: false },
+      {
+        enableWorktreeRunExecution: false,
+        worktreeRunExecutionInstanceNonce: INSTANCE_NONCE,
+      },
       { enableWorktreeRunExecution: true },
       {
         now: () => activatedAt,
@@ -166,15 +172,16 @@ describe("instance settings service", () => {
 
     expect(next.enableWorktreeRunExecution).toBe(true);
     expect(next.worktreeRunExecutionActivatedAt).toBe("2026-07-10T12:00:00.000Z");
-    expect(next.worktreeRunExecutionActivationInstanceId).toBe("worktree-instance");
+    expect(next.worktreeRunExecutionActivationInstanceId).toBe(INSTANCE_NONCE);
   });
 
   it("clears worktree run execution activation fields on a true to false transition", () => {
     const next = applyExperimentalSettingsPatch(
       {
         enableWorktreeRunExecution: true,
+        worktreeRunExecutionInstanceNonce: INSTANCE_NONCE,
         worktreeRunExecutionActivatedAt: "2026-07-10T12:00:00.000Z",
-        worktreeRunExecutionActivationInstanceId: "worktree-instance",
+        worktreeRunExecutionActivationInstanceId: INSTANCE_NONCE,
       },
       { enableWorktreeRunExecution: false },
       {
@@ -192,7 +199,10 @@ describe("instance settings service", () => {
 
   it("refreshes the activation cutoff when worktree run execution is re-toggled", () => {
     const firstActivation = applyExperimentalSettingsPatch(
-      { enableWorktreeRunExecution: false },
+      {
+        enableWorktreeRunExecution: false,
+        worktreeRunExecutionInstanceNonce: INSTANCE_NONCE,
+      },
       { enableWorktreeRunExecution: true },
       {
         now: () => new Date("2026-07-10T12:00:00.000Z"),
@@ -236,6 +246,7 @@ describe("instance settings service", () => {
       { enableWorktreeRunExecution: false },
       {
         enableWorktreeRunExecution: false,
+        worktreeRunExecutionInstanceNonce: "e7904e84-5d6a-44af-bd5f-1c93d9636bc3",
         worktreeRunExecutionActivatedAt: "2026-07-10T12:00:00.000Z",
         worktreeRunExecutionActivationInstanceId: "copied-instance",
       },
@@ -249,13 +260,15 @@ describe("instance settings service", () => {
 
     expect(next.worktreeRunExecutionActivatedAt).toBeNull();
     expect(next.worktreeRunExecutionActivationInstanceId).toBeNull();
+    expect(next.worktreeRunExecutionInstanceNonce).toBeNull();
   });
 
   it("resolves worktree run execution as armed only when the cutoff matches the current instance", async () => {
     const experimental = normalizeExperimentalSettings({
       enableWorktreeRunExecution: true,
+      worktreeRunExecutionInstanceNonce: INSTANCE_NONCE,
       worktreeRunExecutionActivatedAt: "2026-07-10T12:00:00.000Z",
-      worktreeRunExecutionActivationInstanceId: "worktree-instance",
+      worktreeRunExecutionActivationInstanceId: INSTANCE_NONCE,
     });
 
     await expect(
@@ -263,13 +276,13 @@ describe("instance settings service", () => {
         getExperimental: async () => experimental,
         runtimeEnv: {
           PAPERCLIP_IN_WORKTREE: "true",
-          PAPERCLIP_INSTANCE_ID: "worktree-instance",
+          PAPERCLIP_INSTANCE_ID: "injected-shared-instance-id",
         },
       }),
     ).resolves.toEqual({
       armed: true,
       cutoff: "2026-07-10T12:00:00.000Z",
-      activationInstanceId: "worktree-instance",
+      activationInstanceId: INSTANCE_NONCE,
       reason: null,
     });
   });
@@ -277,7 +290,8 @@ describe("instance settings service", () => {
   it("fails closed when worktree run execution is missing a cutoff", async () => {
     const experimental = normalizeExperimentalSettings({
       enableWorktreeRunExecution: true,
-      worktreeRunExecutionActivationInstanceId: "worktree-instance",
+      worktreeRunExecutionInstanceNonce: INSTANCE_NONCE,
+      worktreeRunExecutionActivationInstanceId: INSTANCE_NONCE,
     });
 
     await expect(
@@ -298,8 +312,9 @@ describe("instance settings service", () => {
   it("fails closed when worktree run execution was activated by another instance", async () => {
     const experimental = normalizeExperimentalSettings({
       enableWorktreeRunExecution: true,
+      worktreeRunExecutionInstanceNonce: INSTANCE_NONCE,
       worktreeRunExecutionActivatedAt: "2026-07-10T12:00:00.000Z",
-      worktreeRunExecutionActivationInstanceId: "source-instance",
+      worktreeRunExecutionActivationInstanceId: "f6690751-2ed0-4113-9403-241c2cc3ace9",
     });
 
     await expect(
@@ -313,7 +328,7 @@ describe("instance settings service", () => {
     ).resolves.toMatchObject({
       armed: false,
       cutoff: null,
-      activationInstanceId: "source-instance",
+      activationInstanceId: "f6690751-2ed0-4113-9403-241c2cc3ace9",
       reason: "instance_id_mismatch",
     });
   });

--- a/server/src/__tests__/routines-service.test.ts
+++ b/server/src/__tests__/routines-service.test.ts
@@ -211,10 +211,10 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
     instanceId = "00000000-0000-4000-8000-000000000001",
   ) {
     const experimental = {
-        enableWorktreeRunExecution: true,
-        worktreeRunExecutionInstanceNonce: instanceId,
-        worktreeRunExecutionActivatedAt: cutoff.toISOString(),
-        worktreeRunExecutionActivationInstanceId: instanceId,
+      enableWorktreeRunExecution: true,
+      worktreeRunExecutionInstanceNonce: instanceId,
+      worktreeRunExecutionActivatedAt: cutoff.toISOString(),
+      worktreeRunExecutionActivationInstanceId: instanceId,
     };
     await db
       .insert(instanceSettings)

--- a/server/src/__tests__/routines-service.test.ts
+++ b/server/src/__tests__/routines-service.test.ts
@@ -206,16 +206,23 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
     return { companyId, agentId, issueSvc, projectId, routine, svc, wakeups };
   }
 
-  async function armWorktreeExecution(cutoff: Date, instanceId = "worktree-routines-test") {
-    await db.insert(instanceSettings).values({
-      singletonKey: "default",
-      general: {},
-      experimental: {
+  async function armWorktreeExecution(
+    cutoff: Date,
+    instanceId = "00000000-0000-4000-8000-000000000001",
+  ) {
+    const experimental = {
         enableWorktreeRunExecution: true,
+        worktreeRunExecutionInstanceNonce: instanceId,
         worktreeRunExecutionActivatedAt: cutoff.toISOString(),
         worktreeRunExecutionActivationInstanceId: instanceId,
-      },
-    });
+    };
+    await db
+      .insert(instanceSettings)
+      .values({ singletonKey: "default", general: {}, experimental })
+      .onConflictDoUpdate({
+        target: instanceSettings.singletonKey,
+        set: { experimental },
+      });
   }
 
   async function insertDispatchedRun(input: {

--- a/server/src/__tests__/server-startup-feedback-export.test.ts
+++ b/server/src/__tests__/server-startup-feedback-export.test.ts
@@ -209,6 +209,7 @@ vi.mock("../services/index.js", () => ({
   environmentCustomImageService: environmentCustomImagesServiceFactoryMock,
   heartbeatService: heartbeatServiceFactoryMock,
   instanceSettingsService: vi.fn(() => ({
+    getExperimental: vi.fn(async () => ({})),
     getGeneral: vi.fn(async () => ({
       backupRetention: {
         dailyDays: 7,

--- a/server/src/__tests__/workspace-runtime.test.ts
+++ b/server/src/__tests__/workspace-runtime.test.ts
@@ -38,6 +38,7 @@ import {
   resolveWorkspaceRuntimeReadinessTimeoutSec,
   resolveShell,
   sanitizeRuntimeServiceBaseEnv,
+  stripRuntimeServiceIdentityEnvOverrides,
   startRuntimeServicesForWorkspaceControl,
   stopRuntimeServicesForExecutionWorkspace,
   type RealizedExecutionWorkspace,
@@ -368,6 +369,14 @@ describe("sanitizeRuntimeServiceBaseEnv", () => {
     expect(sanitized.npm_config_tailscale_auth).toBeUndefined();
     expect(sanitized.npm_config_authenticated_private).toBeUndefined();
     expect(sanitized.HOST).toBe("0.0.0.0");
+  });
+
+  it("removes Paperclip identity overrides from managed runtime-service env", () => {
+    expect(stripRuntimeServiceIdentityEnvOverrides({
+      PAPERCLIP_HOME: "/shared/paperclip-home",
+      PAPERCLIP_INSTANCE_ID: "project-primary-runtime",
+      PORT: "3101",
+    })).toEqual({ PORT: "3101" });
   });
 });
 
@@ -3525,7 +3534,7 @@ describe("ensureRuntimeServicesForRun", () => {
       worktreePath: worktreeWorkspaceRoot,
     };
     const serviceCommand =
-      "node -e \"require('node:http').createServer((req,res)=>res.end(process.env.PAPERCLIP_HOME)).listen(Number(process.env.PORT), '127.0.0.1')\"";
+      "node -e \"require('node:http').createServer((req,res)=>res.end(process.env.WORKSPACE_MARKER)).listen(Number(process.env.PORT), '127.0.0.1')\"";
     const config = {
       workspaceRuntime: {
         services: [
@@ -3534,7 +3543,7 @@ describe("ensureRuntimeServicesForRun", () => {
             command: serviceCommand,
             cwd: ".",
             env: {
-              PAPERCLIP_HOME: "{{workspace.cwd}}/.paperclip/runtime-services",
+              WORKSPACE_MARKER: "{{workspace.cwd}}/.paperclip/runtime-services",
             },
             port: { type: "auto" },
             readiness: {

--- a/server/src/dev-runner-worktree.ts
+++ b/server/src/dev-runner-worktree.ts
@@ -42,6 +42,8 @@ type WorktreeEnvBootstrapResult =
   | { envPath: string; missingEnv: true }
   | { envPath: string; missingEnv: false };
 
+const WORKTREE_IDENTITY_ENV_KEYS = new Set(["PAPERCLIP_HOME", "PAPERCLIP_INSTANCE_ID"]);
+
 export function isLinkedGitWorktreeCheckout(rootDir: string): boolean {
   const gitMetadataPath = path.join(rootDir, ".git");
   if (!existsSync(gitMetadataPath)) return false;
@@ -120,7 +122,11 @@ export function bootstrapDevRunnerWorktreeEnv(
     env,
   );
   for (const [key, value] of Object.entries(entries)) {
-    if (typeof env[key] === "string" && env[key]!.trim().length > 0) continue;
+    if (
+      !WORKTREE_IDENTITY_ENV_KEYS.has(key) &&
+      typeof env[key] === "string" &&
+      env[key]!.trim().length > 0
+    ) continue;
     env[key] = value;
   }
 

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -591,7 +591,8 @@ export async function startServer(): Promise<StartedServer> {
   const feedback = feedbackService(db as any, {
     shareClient: createFeedbackTraceShareClientFromConfig(config),
   });
-  const backupSettingsSvc = instanceSettingsService(db);
+  const serverInstanceSettings = instanceSettingsService(db);
+  await serverInstanceSettings.getExperimental();
   const databaseBackupMaxAgeHours = Math.max(
     1,
     Number(process.env.PAPERCLIP_DB_BACKUP_MAX_AGE_HOURS) ||
@@ -625,7 +626,7 @@ export async function startServer(): Promise<StartedServer> {
     try {
       logger.info({ backupDir: config.databaseBackupDir, trigger }, `${label} database backup starting`);
       // Read retention from Instance Settings (DB) so changes take effect without restart.
-      const generalSettings = await backupSettingsSvc.getGeneral();
+      const generalSettings = await serverInstanceSettings.getGeneral();
       const retention = generalSettings.backupRetention;
 
       const result = await runDatabaseBackup({
@@ -862,6 +863,8 @@ export async function startServer(): Promise<StartedServer> {
       {
         state: worktreeRunExecutionActivation.armed ? "armed" : "disarmed",
         cutoff: worktreeRunExecutionActivation.cutoff,
+        reason: worktreeRunExecutionActivation.reason,
+        activationInstanceId: worktreeRunExecutionActivation.activationInstanceId,
       },
       "worktree run-execution cutoff state",
     );

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -5413,7 +5413,6 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     try {
       const activation = resolveWorktreeRunExecutionActivation(
         await instanceSettings.getExperimental(),
-        runtimeEnv.PAPERCLIP_INSTANCE_ID?.trim() || null,
       );
       const cutoff = activation.armed ? new Date(activation.cutoff) : null;
       cachedWorktreeRunExecutionOverride = {

--- a/server/src/services/instance-settings.ts
+++ b/server/src/services/instance-settings.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import type { Db } from "@paperclipai/db";
 import { companies, instanceSettings } from "@paperclipai/db";
 import {
@@ -13,7 +14,7 @@ import {
   type PatchInstanceSettings,
   type PatchInstanceExperimentalSettings,
 } from "@paperclipai/shared";
-import { eq } from "drizzle-orm";
+import { and, eq, sql } from "drizzle-orm";
 
 const DEFAULT_SINGLETON_KEY = "default";
 const instanceGeneralSettingsStorageSchema = instanceGeneralSettingsSchema.strip();
@@ -23,6 +24,7 @@ const TRUTHY_RUNTIME_ENV_VALUES = new Set(["1", "true", "yes", "on"]);
 interface InstanceSettingsServiceOptions {
   runtimeEnv?: Record<string, string | undefined>;
   now?: () => Date;
+  generateInstanceNonce?: () => string;
 }
 
 type WorktreeRunExecutionSuppressedReason =
@@ -51,15 +53,11 @@ export function isTruthyRuntimeEnvValue(value: string | undefined) {
   return typeof value === "string" && TRUTHY_RUNTIME_ENV_VALUES.has(value.trim().toLowerCase());
 }
 
-function getRuntimeInstanceId(env: Record<string, string | undefined>) {
-  const instanceId = env.PAPERCLIP_INSTANCE_ID?.trim();
-  return instanceId ? instanceId : null;
-}
-
 function stripServerManagedExperimentalPatchFields(
   patch: PatchInstanceExperimentalSettings | Record<string, unknown>,
 ): PatchInstanceExperimentalSettings {
   const {
+    worktreeRunExecutionInstanceNonce: _ignoredInstanceNonce,
     worktreeRunExecutionActivatedAt: _ignoredActivatedAt,
     worktreeRunExecutionActivationInstanceId: _ignoredActivationInstanceId,
     ...patchable
@@ -107,7 +105,7 @@ export function applyExperimentalSettingsPatch(
   return {
     ...nextExperimental,
     worktreeRunExecutionActivatedAt: (options.now ?? (() => new Date()))().toISOString(),
-    worktreeRunExecutionActivationInstanceId: getRuntimeInstanceId(runtimeEnv),
+    worktreeRunExecutionActivationInstanceId: nextExperimental.worktreeRunExecutionInstanceNonce,
   };
 }
 
@@ -125,7 +123,6 @@ function suppressWorktreeRunExecution(
 
 export function resolveWorktreeRunExecutionActivation(
   experimental: InstanceExperimentalSettings,
-  currentInstanceId: string | null | undefined,
 ): WorktreeRunExecutionActivationState {
   if (experimental.enableWorktreeRunExecution !== true) {
     return suppressWorktreeRunExecution(
@@ -139,13 +136,16 @@ export function resolveWorktreeRunExecutionActivation(
       experimental.worktreeRunExecutionActivationInstanceId,
     );
   }
-  if (!currentInstanceId) {
+  if (!experimental.worktreeRunExecutionInstanceNonce) {
     return suppressWorktreeRunExecution(
       "missing_instance_id",
       experimental.worktreeRunExecutionActivationInstanceId,
     );
   }
-  if (experimental.worktreeRunExecutionActivationInstanceId !== currentInstanceId) {
+  if (
+    experimental.worktreeRunExecutionActivationInstanceId !==
+    experimental.worktreeRunExecutionInstanceNonce
+  ) {
     return suppressWorktreeRunExecution(
       "instance_id_mismatch",
       experimental.worktreeRunExecutionActivationInstanceId,
@@ -154,7 +154,7 @@ export function resolveWorktreeRunExecutionActivation(
   return {
     armed: true,
     cutoff: experimental.worktreeRunExecutionActivatedAt,
-    activationInstanceId: currentInstanceId,
+    activationInstanceId: experimental.worktreeRunExecutionInstanceNonce,
     reason: null,
   };
 }
@@ -168,10 +168,7 @@ export async function resolveWorktreeRunExecutionActivationState(options: {
     return suppressWorktreeRunExecution("not_worktree_runtime");
   }
   try {
-    return resolveWorktreeRunExecutionActivation(
-      await options.getExperimental(),
-      getRuntimeInstanceId(runtimeEnv),
-    );
+    return resolveWorktreeRunExecutionActivation(await options.getExperimental());
   } catch {
     return suppressWorktreeRunExecution("settings_read_error");
   }
@@ -224,6 +221,7 @@ export function normalizeExperimentalSettings(raw: unknown): InstanceExperimenta
       enableWorkspaceBranchReconcileForward: parsed.data.enableWorkspaceBranchReconcileForward ?? true,
       enableWorkspaceDirtyQuarantineRepair: parsed.data.enableWorkspaceDirtyQuarantineRepair ?? true,
       enableWorktreeRunExecution: parsed.data.enableWorktreeRunExecution ?? false,
+      worktreeRunExecutionInstanceNonce: parsed.data.worktreeRunExecutionInstanceNonce ?? null,
       worktreeRunExecutionActivatedAt: parsed.data.worktreeRunExecutionActivatedAt ?? null,
       worktreeRunExecutionActivationInstanceId:
         parsed.data.worktreeRunExecutionActivationInstanceId ?? null,
@@ -255,6 +253,7 @@ export function normalizeExperimentalSettings(raw: unknown): InstanceExperimenta
     enableWorkspaceBranchReconcileForward: true,
     enableWorkspaceDirtyQuarantineRepair: true,
     enableWorktreeRunExecution: false,
+    worktreeRunExecutionInstanceNonce: null,
     worktreeRunExecutionActivatedAt: null,
     worktreeRunExecutionActivationInstanceId: null,
     issueGraphLivenessAutoRecoveryLookbackHours:
@@ -274,13 +273,47 @@ function toInstanceSettings(row: typeof instanceSettings.$inferSelect): Instance
 }
 
 export function instanceSettingsService(db: Db, options: InstanceSettingsServiceOptions = {}) {
+  const runtimeEnv = options.runtimeEnv ?? process.env;
+
+  async function ensureWorktreeInstanceNonce(row: typeof instanceSettings.$inferSelect) {
+    if (!isTruthyRuntimeEnvValue(runtimeEnv.PAPERCLIP_IN_WORKTREE)) return row;
+    if (normalizeExperimentalSettings(row.experimental).worktreeRunExecutionInstanceNonce) return row;
+
+    const now = new Date();
+    const instanceNonce = (options.generateInstanceNonce ?? randomUUID)();
+    const experimental = typeof row.experimental === "object" && row.experimental !== null
+      ? row.experimental
+      : {};
+    const [updated] = await db
+      .update(instanceSettings)
+      .set({
+        experimental: {
+          ...experimental,
+          worktreeRunExecutionInstanceNonce: instanceNonce,
+        },
+        updatedAt: now,
+      })
+      .where(and(
+        eq(instanceSettings.id, row.id),
+        sql`${instanceSettings.experimental} ->> 'worktreeRunExecutionInstanceNonce' is null`,
+      ))
+      .returning();
+    if (updated) return updated;
+
+    return await db
+      .select()
+      .from(instanceSettings)
+      .where(eq(instanceSettings.id, row.id))
+      .then((rows) => rows[0] ?? row);
+  }
+
   async function getOrCreateRow() {
     const existing = await db
       .select()
       .from(instanceSettings)
       .where(eq(instanceSettings.singletonKey, DEFAULT_SINGLETON_KEY))
       .then((rows) => rows[0] ?? null);
-    if (existing) return existing;
+    if (existing) return await ensureWorktreeInstanceNonce(existing);
 
     const now = new Date();
     const [created] = await db
@@ -300,14 +333,14 @@ export function instanceSettingsService(db: Db, options: InstanceSettingsService
       })
       .returning();
 
-    if (created) return created;
+    if (created) return await ensureWorktreeInstanceNonce(created);
 
     const raced = await db
       .select()
       .from(instanceSettings)
       .where(eq(instanceSettings.singletonKey, DEFAULT_SINGLETON_KEY))
       .then((rows) => rows[0] ?? null);
-    if (raced) return raced;
+    if (raced) return await ensureWorktreeInstanceNonce(raced);
 
     throw new Error("Failed to initialize instance settings row");
   }

--- a/server/src/services/workspace-runtime.ts
+++ b/server/src/services/workspace-runtime.ts
@@ -3357,6 +3357,15 @@ function renderRuntimeServiceEnv(input: {
   return rendered;
 }
 
+export function stripRuntimeServiceIdentityEnvOverrides(env: Record<string, string>) {
+  const {
+    PAPERCLIP_HOME: _ignoredPaperclipHome,
+    PAPERCLIP_INSTANCE_ID: _ignoredPaperclipInstanceId,
+    ...allowedEnv
+  } = env;
+  return allowedEnv;
+}
+
 function resolveRuntimeServiceReuseIdentity(input: {
   service: Record<string, unknown>;
   workspace: RealizedExecutionWorkspace;
@@ -3392,10 +3401,10 @@ function resolveRuntimeServiceReuseIdentity(input: {
     port: identityPort,
   });
   const serviceCwd = resolveConfiguredPath(renderTemplate(serviceCwdTemplate, templateData), input.workspace.cwd);
-  const renderedEnv = renderRuntimeServiceEnv({
+  const renderedEnv = stripRuntimeServiceIdentityEnvOverrides(renderRuntimeServiceEnv({
     envConfig,
     templateData,
-  });
+  }));
   const envFingerprint = createHash("sha256").update(stableStringify(renderedEnv)).digest("hex");
   const reuseKey =
     lifecycle === "shared"
@@ -3902,7 +3911,10 @@ async function spawnLocalRuntimeService(input: StartLocalRuntimeServiceInput): P
     ...sanitizeRuntimeServiceBaseEnv(process.env),
     ...input.adapterEnv,
   } as Record<string, string>;
-  for (const [key, value] of Object.entries(renderRuntimeServiceEnv({ envConfig, templateData }))) {
+  for (const [key, value] of Object.entries(stripRuntimeServiceIdentityEnvOverrides(renderRuntimeServiceEnv({
+    envConfig,
+    templateData,
+  })))) {
     env[key] = value;
   }
   if (port) {

--- a/ui/src/pages/InstanceExperimentalSettings.test.tsx
+++ b/ui/src/pages/InstanceExperimentalSettings.test.tsx
@@ -82,9 +82,10 @@ function defaultExperimentalSettings(): InstanceExperimentalSettingsPayload {
     enableIssueGraphLivenessAutoRecovery: false,
     issueGraphLivenessAutoRecoveryLookbackHours: 24,
     enableWorkspaceBranchReconcileForward: true,
-    enableWorkspaceDirtyQuarantineRepair: true,
-    enableWorktreeRunExecution: false,
-    worktreeRunExecutionActivatedAt: null,
+  enableWorkspaceDirtyQuarantineRepair: true,
+  enableWorktreeRunExecution: false,
+  worktreeRunExecutionInstanceNonce: null,
+  worktreeRunExecutionActivatedAt: null,
     worktreeRunExecutionActivationInstanceId: null,
   };
 }

--- a/ui/src/pages/InstanceExperimentalSettings.test.tsx
+++ b/ui/src/pages/InstanceExperimentalSettings.test.tsx
@@ -82,10 +82,10 @@ function defaultExperimentalSettings(): InstanceExperimentalSettingsPayload {
     enableIssueGraphLivenessAutoRecovery: false,
     issueGraphLivenessAutoRecoveryLookbackHours: 24,
     enableWorkspaceBranchReconcileForward: true,
-  enableWorkspaceDirtyQuarantineRepair: true,
-  enableWorktreeRunExecution: false,
-  worktreeRunExecutionInstanceNonce: null,
-  worktreeRunExecutionActivatedAt: null,
+    enableWorkspaceDirtyQuarantineRepair: true,
+    enableWorktreeRunExecution: false,
+    worktreeRunExecutionInstanceNonce: null,
+    worktreeRunExecutionActivatedAt: null,
     worktreeRunExecutionActivationInstanceId: null,
   };
 }


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Worktree instances must stay execution-isolated even when they are seeded from another Paperclip database
> - The worktree execution toggle was bound to `PAPERCLIP_INSTANCE_ID`, but managed runtime configuration can inject the same value into multiple worktrees
> - A shared identity can transfer an armed toggle to the wrong worktree, while a persisted per-worktree identity can be overwritten and make a legitimate toggle silently stop working
> - The activation therefore needs a server-owned identity that cannot be supplied by runtime-service environment configuration
> - This pull request stamps a per-instance nonce in worktree settings, binds activation to it, and makes persisted worktree identity variables authoritative
> - The benefit is that managed restarts preserve legitimate activation without allowing copied databases or shared environment values to arm another instance

## Linked Issues or Issue Description

Refs #9703

### What happened?

Managed worktree runtime services could inject the same `PAPERCLIP_INSTANCE_ID` into every worktree. Worktree run-execution activation used that environment-provided value as its identity, so copied settings could arm the wrong instance and persisted per-worktree identities could be ignored on restart.

### Expected behavior

Each worktree should have a server-managed activation identity that survives its own restart, is regenerated for a freshly seeded database, and cannot be overridden through runtime-service environment configuration.

### Steps to reproduce

1. Configure a managed runtime service with a shared `PAPERCLIP_INSTANCE_ID`.
2. Enable worktree run execution in one worktree and restart it through the managed runtime path.
3. Seed or copy the database into another worktree, or compare the managed environment with the persisted `.paperclip/.env` identity.
4. Observe that activation identity can be shared across worktrees or mismatched against the persisted worktree identity.

### Environment

- Paperclip commit: current `master` before this change
- Deployment: local dev managed worktrees
- Installation: built from source
- Adapter: not adapter-specific
- Database: embedded PGlite or external Postgres
- Access context: board operator

## What Changed

- Stamp a random, server-managed instance nonce into experimental settings on first worktree boot and keep nonce fields read-only to clients.
- Bind worktree run-execution activation and mismatch suppression to the nonce instead of process-provided `PAPERCLIP_INSTANCE_ID`.
- Prefer persisted `.paperclip/.env` values for `PAPERCLIP_HOME` and `PAPERCLIP_INSTANCE_ID`, and strip runtime-service overrides for those identity keys.
- Clear the nonce and activation metadata when a source database is seeded into a new worktree so the destination starts disarmed with a fresh identity.
- Add focused regression coverage across settings, heartbeat suppression, dev-runner bootstrap, runtime services, CLI seed reset, and UI fixtures.

### Operational Mitigation

The Paperclip project workspace metadata may currently set `PAPERCLIP_INSTANCE_ID=project-primary-runtime` in the `paperclip-dev` service environment. This change makes that override inert. Before upgrading, operators can cheaply mitigate the issue by removing `PAPERCLIP_INSTANCE_ID` from the workspace runtime-service configuration.

## Verification

- `cd server && pnpm exec vitest run src/__tests__/instance-settings-service.test.ts src/__tests__/heartbeat-worktree-suppression.test.ts src/__tests__/dev-runner-worktree.test.ts src/__tests__/workspace-runtime.test.ts` — 127 tests passed.
- `cd cli && pnpm exec vitest run src/__tests__/worktree.test.ts -t "always disarms copied worktree run execution settings"` — 1 test passed.
- `cd server && pnpm exec vitest run src/__tests__/server-startup-feedback-export.test.ts` — 11 tests passed.
- `cd server && pnpm exec vitest run src/__tests__/routines-service.test.ts -t "dispatches only post-cutoff scheduled routines in an armed worktree"` — 1 test passed.
- `cd server && pnpm exec vitest run src/__tests__/heartbeat-process-recovery.test.ts -t "schedules bounded retries for failed accepted interaction continuation wakes"` — 1 test passed; confirmed the earlier unrelated CI shard failure was transient.
- `pnpm --filter @paperclipai/shared typecheck`
- `pnpm --filter @paperclipai/server typecheck`
- `pnpm --filter paperclipai typecheck`
- `pnpm --filter @paperclipai/ui typecheck`

## Risks

- Existing worktree settings receive a nonce lazily on first settings access after boot; concurrent first access is guarded by a conditional update and reread.
- Runtime-service values for `PAPERCLIP_HOME` and `PAPERCLIP_INSTANCE_ID` are intentionally ignored, which changes behavior for configurations that relied on overriding Paperclip identity through service metadata.
- This PR is stacked on #9703 while that prerequisite remains open; merge #9703 first or rebase this branch after it lands.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex `gpt-5.6-sol`, high reasoning effort, context window size not exposed by the runtime, with repository/tool use and code execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge