### PR TITLE
feat(agents): hired/created agents inherit the company credential

### DIFF
--- a/server/src/__tests__/agent-credential-inheritance.test.ts
+++ b/server/src/__tests__/agent-credential-inheritance.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { mergeInheritedCredentialEnv } from "../routes/agents.js";
+
+describe("mergeInheritedCredentialEnv (hired agents inherit the company BYOK credential)", () => {
+  const donorCred = { type: "secret_ref", secretId: "sec-1", version: "latest" };
+
+  it("inherits a donor secret_ref the new agent does not have", () => {
+    expect(mergeInheritedCredentialEnv({ CLAUDE_CODE_OAUTH_TOKEN: donorCred }, {})).toEqual({
+      CLAUDE_CODE_OAUTH_TOKEN: { type: "secret_ref", secretId: "sec-1", version: "latest" },
+    });
+  });
+
+  it("never overrides an env key the request already set (even to a different value)", () => {
+    const requested = { CLAUDE_CODE_OAUTH_TOKEN: { type: "secret_ref", secretId: "own" } };
+    expect(mergeInheritedCredentialEnv({ CLAUDE_CODE_OAUTH_TOKEN: donorCred }, requested)).toEqual(requested);
+  });
+
+  it("only inherits secret_ref bindings (ignores plain/string/non-secret env)", () => {
+    const donorEnv = {
+      CLAUDE_CODE_OAUTH_TOKEN: donorCred,
+      SOME_FLAG: "plain-value",
+      OTHER: { type: "plain", value: "x" },
+    };
+    expect(mergeInheritedCredentialEnv(donorEnv, {})).toEqual({
+      CLAUDE_CODE_OAUTH_TOKEN: { type: "secret_ref", secretId: "sec-1", version: "latest" },
+    });
+  });
+
+  it("preserves projectionClass / projectionAllowlistKey / version verbatim", () => {
+    const donorEnv = {
+      ANTHROPIC_API_KEY: {
+        type: "secret_ref",
+        secretId: "sec-2",
+        version: 3,
+        projectionClass: "class3_static_lease",
+        projectionAllowlistKey: "allow-abc",
+      },
+    };
+    expect(mergeInheritedCredentialEnv(donorEnv, {})).toEqual({
+      ANTHROPIC_API_KEY: {
+        type: "secret_ref",
+        secretId: "sec-2",
+        version: 3,
+        projectionClass: "class3_static_lease",
+        projectionAllowlistKey: "allow-abc",
+      },
+    });
+  });
+
+  it("is a no-op when the donor has no secret_ref credentials", () => {
+    expect(mergeInheritedCredentialEnv({ FLAG: "x" }, { EXISTING: { type: "secret_ref", secretId: "e" } })).toEqual({
+      EXISTING: { type: "secret_ref", secretId: "e" },
+    });
+  });
+
+  it("keeps the new agent's own env alongside inherited credentials", () => {
+    const merged = mergeInheritedCredentialEnv(
+      { CLAUDE_CODE_OAUTH_TOKEN: donorCred },
+      { MY_VAR: { type: "plain", value: "keep" } },
+    );
+    expect(merged).toEqual({
+      MY_VAR: { type: "plain", value: "keep" },
+      CLAUDE_CODE_OAUTH_TOKEN: { type: "secret_ref", secretId: "sec-1", version: "latest" },
+    });
+  });
+});

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -136,6 +136,37 @@ function readRunIssueId(context: Record<string, unknown> | null) {
   return typeof nestedIssueId === "string" && isUuidLike(nestedIssueId) ? nestedIssueId : null;
 }
 
+/**
+ * Merge a donor agent's credential env bindings into a new agent's requested env,
+ * so hired/created agents inherit the company's BYOK credential. Only `secret_ref`
+ * bindings are inherited (the shape the credential-connect flow produces), any env
+ * key the request already set is left untouched, and the donor binding's
+ * projection semantics are preserved verbatim. Pure/testable.
+ */
+export function mergeInheritedCredentialEnv(
+  donorEnv: Record<string, unknown>,
+  requestedEnv: Record<string, unknown>,
+): Record<string, unknown> {
+  const merged: Record<string, unknown> = { ...requestedEnv };
+  for (const [envKey, binding] of Object.entries(donorEnv)) {
+    const parsed =
+      typeof binding === "object" && binding !== null && !Array.isArray(binding)
+        ? (binding as Record<string, unknown>)
+        : null;
+    if (!parsed || parsed.type !== "secret_ref" || typeof parsed.secretId !== "string") continue;
+    if (Object.prototype.hasOwnProperty.call(requestedEnv, envKey)) continue;
+    const inherited: Record<string, unknown> = {
+      type: "secret_ref",
+      secretId: parsed.secretId,
+      version: parsed.version ?? "latest",
+    };
+    if (typeof parsed.projectionClass === "string") inherited.projectionClass = parsed.projectionClass;
+    if (parsed.projectionAllowlistKey !== undefined) inherited.projectionAllowlistKey = parsed.projectionAllowlistKey;
+    merged[envKey] = inherited;
+  }
+  return merged;
+}
+
 export function agentRoutes(
   db: Db,
   options: { pluginWorkerManager?: PluginWorkerManager } = {},
@@ -1040,6 +1071,34 @@ export function agentRoutes(
   function asRecord(value: unknown): Record<string, unknown> | null {
     if (typeof value !== "object" || value === null || Array.isArray(value)) return null;
     return value as Record<string, unknown>;
+  }
+
+  // Inherit the company's BYOK credential env bindings onto a newly hired/created
+  // agent so it can authenticate without the user re-connecting a key for every
+  // agent. Copies each `secret_ref` env binding from an existing same-adapter
+  // company agent (preferring the CEO) into the new agent's `adapterConfig.env`,
+  // never overriding an env the request set explicitly. No-op when no donor agent
+  // of the same adapterType has a credential (no behavior change / no regression).
+  async function inheritCompanyCredentialEnv(
+    companyId: string,
+    adapterType: string,
+    requestedAdapterConfig: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    const requestedEnv = asRecord(requestedAdapterConfig.env) ?? {};
+    let donorRows: Array<{ role: string | null; adapterConfig: unknown }>;
+    try {
+      donorRows = await db
+        .select({ role: agentsTable.role, adapterConfig: agentsTable.adapterConfig })
+        .from(agentsTable)
+        .where(and(eq(agentsTable.companyId, companyId), eq(agentsTable.adapterType, adapterType)));
+    } catch {
+      return requestedAdapterConfig;
+    }
+    const donors = donorRows.filter((row) => asRecord(asRecord(row.adapterConfig)?.env));
+    const donor = donors.find((row) => row.role === "ceo") ?? donors[0];
+    if (!donor) return requestedAdapterConfig;
+    const donorEnv = asRecord(asRecord(donor.adapterConfig)?.env) ?? {};
+    return { ...requestedAdapterConfig, env: mergeInheritedCredentialEnv(donorEnv, requestedEnv) };
   }
 
   function asNonEmptyString(value: unknown): string | null {
@@ -2357,7 +2416,7 @@ export function agentRoutes(
     assertNoAgentAdapterConfigMutation(req, rawHireAdapterConfig);
     assertNoAgentRuntimeConfigAdapterConfigMutation(req, hireInput.runtimeConfig);
     const hiredAgentId = randomUUID();
-    const requestedAdapterConfig = applyCodexLocalKeyIsolation(
+    let requestedAdapterConfig = applyCodexLocalKeyIsolation(
       companyId,
       hiredAgentId,
       hireInput.adapterType,
@@ -2365,6 +2424,11 @@ export function agentRoutes(
         hireInput.adapterType,
         rawHireAdapterConfig,
       ),
+    );
+    requestedAdapterConfig = await inheritCompanyCredentialEnv(
+      companyId,
+      hireInput.adapterType,
+      requestedAdapterConfig,
     );
     const desiredSkillAssignment = await resolveDesiredSkillAssignment(
       companyId,
@@ -2550,7 +2614,7 @@ export function agentRoutes(
     assertNoAgentAdapterConfigMutation(req, rawCreateAdapterConfig);
     assertNoAgentRuntimeConfigAdapterConfigMutation(req, createInput.runtimeConfig);
     const agentId = randomUUID();
-    const requestedAdapterConfig = applyCodexLocalKeyIsolation(
+    let requestedAdapterConfig = applyCodexLocalKeyIsolation(
       companyId,
       agentId,
       createInput.adapterType,
@@ -2558,6 +2622,11 @@ export function agentRoutes(
         createInput.adapterType,
         rawCreateAdapterConfig,
       ),
+    );
+    requestedAdapterConfig = await inheritCompanyCredentialEnv(
+      companyId,
+      createInput.adapterType,
+      requestedAdapterConfig,
     );
     const desiredSkillAssignment = await resolveDesiredSkillAssignment(
       companyId,


### PR DESCRIPTION
## Problem
When an agent hires (or a user creates) a new agent, the new agent's `adapter_config.env` is empty, so its runs fail `claude_auth_required` ("Not logged in · Please run /login") until a credential is connected for that specific agent. The company already holds the credential as a `company_secret` bound to an existing agent's env (e.g. the CEO's `CLAUDE_CODE_OAUTH_TOKEN`). New agents should inherit it.

## Change
Before persisting a hired/created agent, copy each `secret_ref` env binding from an existing **same-adapter** company agent (preferring the CEO) into the new agent's `adapter_config.env`:
- only `secret_ref` bindings are inherited (the shape the credential-connect flow produces);
- an env key the request set explicitly is never overridden;
- the donor binding's `version` / `projectionClass` / `projectionAllowlistKey` are preserved verbatim;
- no-op when no same-adapter donor has a credential (no behavior change / no regression).

The injected `secret_ref` flows through the existing `normalizeEnvConfig` → `assertSecretInCompany` → `syncAgentSecretBindings` path, so it is validated and wired exactly like a user-supplied binding — no changes to the runtime/heartbeat path.

Wired into `POST /companies/:id/agent-hires` and `POST /companies/:id/agents`. `mergeInheritedCredentialEnv` is extracted as a pure helper and unit-tested (6 cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)