### PR TITLE
feat: add decision training library and inspector

### DIFF
--- a/packages/db/src/migrations/0174_decision_training_examples.sql
+++ b/packages/db/src/migrations/0174_decision_training_examples.sql
@@ -1,0 +1,23 @@
+CREATE TABLE IF NOT EXISTS "decision_training_examples" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "company_id" uuid NOT NULL REFERENCES "companies"("id") ON DELETE CASCADE,
+  "source_kind" text NOT NULL,
+  "source_id" uuid NOT NULL,
+  "issue_id" uuid NOT NULL REFERENCES "issues"("id") ON DELETE CASCADE,
+  "cutoff_at" timestamp with time zone NOT NULL,
+  "notes" text DEFAULT '' NOT NULL,
+  "notes_history" jsonb DEFAULT '[]'::jsonb NOT NULL,
+  "decision_outcome" text,
+  "snapshot" jsonb NOT NULL,
+  "created_by_user_id" text NOT NULL,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+  CONSTRAINT "decision_training_examples_source_kind_check"
+    CHECK ("source_kind" IN ('interaction', 'approval', 'execution_decision'))
+);--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "decision_training_examples_company_created_at_idx"
+  ON "decision_training_examples" USING btree ("company_id", "created_at");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "decision_training_examples_issue_idx"
+  ON "decision_training_examples" USING btree ("issue_id");--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "decision_training_examples_source_author_uq"
+  ON "decision_training_examples" USING btree ("source_kind", "source_id", "created_by_user_id");

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -1205,6 +1205,13 @@
       "when": 1784210753027,
       "tag": "0173_inbox_policy_agent_cleanup",
       "breakpoints": true
+    },
+    {
+      "idx": 174,
+      "version": "7",
+      "when": 1784216720808,
+      "tag": "0174_decision_training_examples",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/decision_training_examples.ts
+++ b/packages/db/src/schema/decision_training_examples.ts
@@ -1,0 +1,39 @@
+import type {
+  DecisionTrainingNotesHistoryEntry,
+  DecisionTrainingSnapshotV1,
+  DecisionTrainingSourceKind,
+} from "@paperclipai/shared";
+import { index, jsonb, pgTable, text, timestamp, uniqueIndex, uuid } from "drizzle-orm/pg-core";
+import { companies } from "./companies.js";
+import { issues } from "./issues.js";
+
+export const decisionTrainingExamples = pgTable(
+  "decision_training_examples",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    companyId: uuid("company_id").notNull().references(() => companies.id, { onDelete: "cascade" }),
+    sourceKind: text("source_kind").$type<DecisionTrainingSourceKind>().notNull(),
+    sourceId: uuid("source_id").notNull(),
+    issueId: uuid("issue_id").notNull().references(() => issues.id, { onDelete: "cascade" }),
+    cutoffAt: timestamp("cutoff_at", { withTimezone: true }).notNull(),
+    notes: text("notes").notNull().default(""),
+    notesHistory: jsonb("notes_history").$type<DecisionTrainingNotesHistoryEntry[]>().notNull().default([]),
+    decisionOutcome: text("decision_outcome"),
+    snapshot: jsonb("snapshot").$type<DecisionTrainingSnapshotV1>().notNull(),
+    createdByUserId: text("created_by_user_id").notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    companyCreatedAtIdx: index("decision_training_examples_company_created_at_idx").on(
+      table.companyId,
+      table.createdAt,
+    ),
+    issueIdx: index("decision_training_examples_issue_idx").on(table.issueId),
+    sourceAuthorUq: uniqueIndex("decision_training_examples_source_author_uq").on(
+      table.sourceKind,
+      table.sourceId,
+      table.createdByUserId,
+    ),
+  }),
+);

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -76,6 +76,7 @@ export { issueInboxArchives } from "./issue_inbox_archives.js";
 export { userInboxAgentPolicies } from "./user_inbox_agent_policies.js";
 export { inboxDismissals } from "./inbox_dismissals.js";
 export { feedbackVotes } from "./feedback_votes.js";
+export { decisionTrainingExamples } from "./decision_training_examples.js";
 export { feedbackExports } from "./feedback_exports.js";
 export { issueReadStates } from "./issue_read_states.js";
 export { assets } from "./assets.js";

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -63,6 +63,12 @@ export type {
   AttentionSubjectKind,
   AttentionWorkspaceRef,
 } from "./types/attention.js";
+export type {
+  DecisionTrainingExample,
+  DecisionTrainingNotesHistoryEntry,
+  DecisionTrainingSnapshotV1,
+  DecisionTrainingSourceKind,
+} from "./types/decision-training.js";
 
 export type {
   PipelineAutomationRetryBlocker,

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -66,6 +66,7 @@ export type {
 export type {
   DecisionTrainingExample,
   DecisionTrainingNotesHistoryEntry,
+  DecisionTrainingPreview,
   DecisionTrainingSnapshotV1,
   DecisionTrainingSourceKind,
 } from "./types/decision-training.js";

--- a/packages/shared/src/types/attention.ts
+++ b/packages/shared/src/types/attention.ts
@@ -166,6 +166,7 @@ export interface AttentionItem {
   project: AttentionProjectRef | null;
   workspace: AttentionWorkspaceRef | null;
   detail: AttentionItemDetail | null;
+  trainingExampleId: string | null;
 }
 
 export interface AttentionFeed {

--- a/packages/shared/src/types/decision-training.ts
+++ b/packages/shared/src/types/decision-training.ts
@@ -1,0 +1,48 @@
+export type DecisionTrainingSourceKind = "interaction" | "approval" | "execution_decision";
+
+export interface DecisionTrainingNotesHistoryEntry {
+  author: string;
+  at: string;
+  body: string;
+}
+
+export interface DecisionTrainingSnapshotV1 {
+  version: 1;
+  capturedAt: string;
+  cutoff: {
+    at: string;
+    lastCommentId: string | null;
+    commentCount: number;
+  };
+  issue: Record<string, unknown>;
+  comments: Array<Record<string, unknown>>;
+  runs: Array<Record<string, unknown>>;
+  decision: {
+    kind: DecisionTrainingSourceKind;
+    payload: Record<string, unknown>;
+    actor: Record<string, unknown> | null;
+    outcome: string | null;
+  };
+  code: {
+    repoUrl: string | null;
+    ref: string | null;
+    commitSha: string | null;
+    resolution: "exact" | "nearest_run" | "none";
+  };
+}
+
+export interface DecisionTrainingExample {
+  id: string;
+  companyId: string;
+  sourceKind: DecisionTrainingSourceKind;
+  sourceId: string;
+  issueId: string;
+  cutoffAt: string;
+  notes: string;
+  notesHistory: DecisionTrainingNotesHistoryEntry[];
+  decisionOutcome: string | null;
+  snapshot: DecisionTrainingSnapshotV1;
+  createdByUserId: string;
+  createdAt: string;
+  updatedAt: string;
+}

--- a/packages/shared/src/types/decision-training.ts
+++ b/packages/shared/src/types/decision-training.ts
@@ -27,7 +27,7 @@ export interface DecisionTrainingSnapshotV1 {
     repoUrl: string | null;
     ref: string | null;
     commitSha: string | null;
-    resolution: "exact" | "nearest_run" | "none";
+    resolution: "exact" | "nearest_run" | "workspace" | "none";
   };
 }
 

--- a/packages/shared/src/types/decision-training.ts
+++ b/packages/shared/src/types/decision-training.ts
@@ -31,6 +31,18 @@ export interface DecisionTrainingSnapshotV1 {
   };
 }
 
+/**
+ * Read-only preview of the state a new training example would freeze, returned
+ * by `POST /companies/:id/decision-training/preview`. Mirrors the capture that
+ * `create` performs, minus persistence, so the drawer can show the exact cutoff
+ * and captured counts before the user commits.
+ */
+export interface DecisionTrainingPreview {
+  cutoffAt: string;
+  decisionOutcome: string | null;
+  snapshot: DecisionTrainingSnapshotV1;
+}
+
 export interface DecisionTrainingExample {
   id: string;
   companyId: string;

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -14,6 +14,12 @@ export type {
   AttentionWorkspaceRef,
 } from "./attention.js";
 export type {
+  DecisionTrainingExample,
+  DecisionTrainingNotesHistoryEntry,
+  DecisionTrainingSnapshotV1,
+  DecisionTrainingSourceKind,
+} from "./decision-training.js";
+export type {
   Environment,
   EnvironmentDeleteBlastRadius,
   EnvironmentDeleteBlockedReason,

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -16,6 +16,7 @@ export type {
 export type {
   DecisionTrainingExample,
   DecisionTrainingNotesHistoryEntry,
+  DecisionTrainingPreview,
   DecisionTrainingSnapshotV1,
   DecisionTrainingSourceKind,
 } from "./decision-training.js";

--- a/server/src/__tests__/attention-service.test.ts
+++ b/server/src/__tests__/attention-service.test.ts
@@ -887,6 +887,32 @@ describeEmbeddedPostgres("attention service", () => {
     expect(feed.items.some((item) => item.dedupKey === `approval:${approvalId}`)).toBe(true);
   });
 
+  it("returns one pending approval row when the approval is linked to multiple tasks", async () => {
+    const { companyId } = await seedCompany("ATM");
+    const approvalId = randomUUID();
+    const firstIssueId = "00000000-0000-4000-8000-000000000001";
+    const secondIssueId = "00000000-0000-4000-8000-000000000002";
+    await insertIssue({ companyId, id: firstIssueId, identifier: "ATM-1", title: "First task", status: "in_progress" });
+    await insertIssue({ companyId, id: secondIssueId, identifier: "ATM-2", title: "Second task", status: "in_progress" });
+    await db.insert(approvals).values({
+      id: approvalId,
+      companyId,
+      type: "request_board_approval",
+      status: "pending",
+      payload: { title: "Approve rollout" },
+    });
+    await db.insert(issueApprovals).values([
+      { companyId, issueId: secondIssueId, approvalId },
+      { companyId, issueId: firstIssueId, approvalId },
+    ]);
+
+    const feed = await attentionService(db).list(companyId, { userId: "board-user" });
+    const approvalItems = feed.items.filter((item) => item.dedupKey === `approval:${approvalId}`);
+
+    expect(approvalItems).toHaveLength(1);
+    expect(approvalItems[0]?.subject.metadata?.issueId).toBe(firstIssueId);
+  });
+
   it("hides snoozed attention rows until snoozedUntil passes, then returns them unconditionally", async () => {
     const { companyId } = await seedCompany("ATS");
     const approvalId = randomUUID();

--- a/server/src/__tests__/decision-training.test.ts
+++ b/server/src/__tests__/decision-training.test.ts
@@ -1,0 +1,212 @@
+import { randomUUID } from "node:crypto";
+import express from "express";
+import request from "supertest";
+import { eq } from "drizzle-orm";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import {
+  activityLog,
+  companies,
+  createDb,
+  decisionTrainingExamples,
+  issueComments,
+  issues,
+  issueThreadInteractions,
+  projects,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import { errorHandler } from "../middleware/index.js";
+import { decisionTrainingRoutes } from "../routes/decision-training.js";
+import { attentionService } from "../services/attention.js";
+import { captureDecisionSnapshot, decisionTrainingService } from "../services/decision-training.js";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping embedded Postgres decision training tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+describeEmbeddedPostgres("decision training", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-decision-training-");
+    db = createDb(tempDb.connectionString);
+  }, 30_000);
+
+  afterEach(async () => {
+    await db.delete(activityLog);
+    await db.delete(decisionTrainingExamples);
+    await db.delete(issueThreadInteractions);
+    await db.delete(issueComments);
+    await db.delete(issues);
+    await db.delete(projects);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  async function seedResolvedInteraction() {
+    const companyId = randomUUID();
+    const projectId = randomUUID();
+    const issueId = randomUUID();
+    const interactionId = randomUUID();
+    const cutoffAt = new Date("2026-07-16T12:00:00.000Z");
+    const beforeId = randomUUID();
+    const atCutoffId = randomUUID();
+    const afterId = randomUUID();
+
+    await db.insert(companies).values({ id: companyId, name: "Decision Co", issuePrefix: `D${companyId.slice(0, 4)}` });
+    await db.insert(projects).values({ id: projectId, companyId, name: "Decisions" });
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      projectId,
+      identifier: "DEC-1",
+      title: "Choose a rollout strategy",
+      status: "in_review",
+    });
+    await db.insert(issueThreadInteractions).values({
+      id: interactionId,
+      companyId,
+      issueId,
+      kind: "request_confirmation",
+      status: "accepted",
+      payload: { question: "Ship it?" } as never,
+      result: { accepted: true } as never,
+      resolvedByUserId: "board-user",
+      resolvedAt: cutoffAt,
+    });
+    await db.insert(issueComments).values([
+      { id: beforeId, companyId, issueId, body: "Before", createdAt: new Date("2026-07-16T11:59:59.000Z") },
+      { id: atCutoffId, companyId, issueId, body: "At cutoff", createdAt: cutoffAt },
+      { id: afterId, companyId, issueId, body: "Leaked later context", createdAt: new Date("2026-07-16T12:00:01.000Z") },
+    ]);
+    return { companyId, issueId, interactionId, cutoffAt, beforeId, atCutoffId, afterId };
+  }
+
+  it("includes the cutoff boundary and excludes later comments", async () => {
+    const seeded = await seedResolvedInteraction();
+    const captured = await captureDecisionSnapshot(db, {
+      companyId: seeded.companyId,
+      sourceKind: "interaction",
+      sourceId: seeded.interactionId,
+      issueId: seeded.issueId,
+    }, new Date("2026-07-16T13:00:00.000Z"));
+
+    expect(captured.cutoffAt).toEqual(seeded.cutoffAt);
+    expect(captured.snapshot.cutoff).toEqual({
+      at: seeded.cutoffAt.toISOString(),
+      lastCommentId: seeded.atCutoffId,
+      commentCount: 2,
+    });
+    expect(captured.snapshot.comments.map((comment) => comment.id)).toEqual([seeded.beforeId, seeded.atCutoffId]);
+    expect(JSON.stringify(captured.snapshot)).not.toContain("Leaked later context");
+  });
+
+  it("enforces one example per decision and author", async () => {
+    const seeded = await seedResolvedInteraction();
+    const svc = decisionTrainingService(db);
+    const input = {
+      companyId: seeded.companyId,
+      sourceKind: "interaction" as const,
+      sourceId: seeded.interactionId,
+      issueId: seeded.issueId,
+      notes: "Ship behind a flag.",
+      createdByUserId: "board-user",
+    };
+
+    const created = await svc.create(input);
+    await expect(svc.create(input)).rejects.toMatchObject({ status: 409 });
+    const updated = await svc.updateNotes(created.id, "board-user", "Use a 10% canary first.");
+    expect(updated?.notesHistory).toEqual([
+      expect.objectContaining({ author: "board-user", body: "Ship behind a flag." }),
+    ]);
+    expect(updated?.snapshot).toEqual(created.snapshot);
+  });
+
+  it("enriches attention items with the current user's training example", async () => {
+    const seeded = await seedResolvedInteraction();
+    const example = await decisionTrainingService(db).create({
+      companyId: seeded.companyId,
+      sourceKind: "interaction",
+      sourceId: seeded.interactionId,
+      issueId: seeded.issueId,
+      notes: "Captured guidance.",
+      createdByUserId: "board-user",
+    });
+    await db
+      .update(issueThreadInteractions)
+      .set({ status: "pending", resolvedAt: null, updatedAt: new Date() })
+      .where(eq(issueThreadInteractions.id, seeded.interactionId));
+
+    const feed = await attentionService(db).list(seeded.companyId, { userId: "board-user" });
+    const item = feed.items.find((candidate) => candidate.subject.id === seeded.interactionId);
+    expect(item?.trainingExampleId).toBe(example.id);
+  });
+
+  it("rejects agent writes and snapshot mutation", async () => {
+    const seeded = await seedResolvedInteraction();
+    const app = express();
+    app.use(express.json());
+    app.use((req, _res, next) => {
+      req.actor = {
+        type: "agent",
+        agentId: randomUUID(),
+        companyId: seeded.companyId,
+        source: "agent_jwt",
+      };
+      next();
+    });
+    app.use("/api", decisionTrainingRoutes(db));
+    app.use(errorHandler);
+
+    await request(app)
+      .post(`/api/companies/${seeded.companyId}/decision-training`)
+      .send({ sourceKind: "interaction", sourceId: seeded.interactionId, issueId: seeded.issueId, notes: "No" })
+      .expect(403);
+
+    await request(app)
+      .patch(`/api/decision-training/${randomUUID()}`)
+      .send({ notes: "Changed", snapshot: { version: 2 } })
+      .expect(400);
+  });
+
+  it("exports immutable state and labels as JSONL", async () => {
+    const seeded = await seedResolvedInteraction();
+    const example = await decisionTrainingService(db).create({
+      companyId: seeded.companyId,
+      sourceKind: "interaction",
+      sourceId: seeded.interactionId,
+      issueId: seeded.issueId,
+      notes: "Use a feature flag.",
+      createdByUserId: "board-user",
+    });
+    const app = express();
+    app.use(express.json());
+    app.use((req, _res, next) => {
+      req.actor = { type: "board", userId: "board-user", source: "local_implicit" };
+      next();
+    });
+    app.use("/api", decisionTrainingRoutes(db));
+    app.use(errorHandler);
+
+    const response = await request(app)
+      .get(`/api/companies/${seeded.companyId}/decision-training/export.jsonl`)
+      .expect(200);
+    const line = JSON.parse(response.text.trim());
+    expect(line).toEqual({
+      state: example.snapshot,
+      label: { outcome: "accepted", notes: "Use a feature flag." },
+    });
+    expect(response.text).not.toContain("Leaked later context");
+  });
+});

--- a/server/src/__tests__/decision-training.test.ts
+++ b/server/src/__tests__/decision-training.test.ts
@@ -124,8 +124,32 @@ describeEmbeddedPostgres("decision training", () => {
       name: "Primary workspace",
       repoUrl: "https://github.com/paperclipai/paperclip.git",
       metadata: { commitSha: "abcdef1234567890" },
+      isPrimary: false,
+      createdAt: new Date("2026-07-16T11:00:00.000Z"),
+      updatedAt: new Date("2026-07-16T11:30:00.000Z"),
+    });
+    await db.insert(projectWorkspaces).values({
+      companyId: seeded.companyId,
+      projectId: seeded.projectId,
+      name: "Post-cutoff workspace",
+      repoUrl: "https://github.com/paperclipai/paperclip.git",
+      metadata: { commitSha: "ffffffffffffffff" },
       isPrimary: true,
       createdAt: new Date("2026-07-16T11:00:00.000Z"),
+      updatedAt: new Date("2026-07-16T12:30:00.000Z"),
+    });
+    await db.insert(executionWorkspaces).values({
+      companyId: seeded.companyId,
+      projectId: seeded.projectId,
+      sourceIssueId: seeded.issueId,
+      mode: "isolated_workspace",
+      strategyType: "git_worktree",
+      name: "Post-cutoff execution workspace",
+      providerType: "git_worktree",
+      metadata: { commitSha: "eeeeeeeeeeeeeeee" },
+      openedAt: new Date("2026-07-16T11:00:00.000Z"),
+      lastUsedAt: new Date("2026-07-16T12:30:00.000Z"),
+      updatedAt: new Date("2026-07-16T12:30:00.000Z"),
     });
 
     const captured = await captureDecisionSnapshot(db, {

--- a/server/src/__tests__/decision-training.test.ts
+++ b/server/src/__tests__/decision-training.test.ts
@@ -208,6 +208,48 @@ describeEmbeddedPostgres("decision training", () => {
     expect(item?.trainingExampleId).toBe(example.id);
   });
 
+  it("does not log a notes update when the submitted notes are unchanged", async () => {
+    const seeded = await seedResolvedInteraction();
+    const example = await decisionTrainingService(db).create({
+      companyId: seeded.companyId,
+      sourceKind: "interaction",
+      sourceId: seeded.interactionId,
+      issueId: seeded.issueId,
+      notes: "Keep the current notes.",
+      createdByUserId: "board-user",
+    });
+    const app = express();
+    app.use(express.json());
+    app.use((req, _res, next) => {
+      req.actor = { type: "board", userId: "board-user", source: "local_implicit" };
+      next();
+    });
+    app.use("/api", decisionTrainingRoutes(db));
+    app.use(errorHandler);
+
+    await request(app)
+      .patch(`/api/decision-training/${example.id}`)
+      .send({ notes: "Keep the current notes." })
+      .expect(200);
+
+    const noOpLogs = await db
+      .select()
+      .from(activityLog)
+      .where(eq(activityLog.action, "decision_training.notes_updated"));
+    expect(noOpLogs).toHaveLength(0);
+
+    await request(app)
+      .patch(`/api/decision-training/${example.id}`)
+      .send({ notes: "Record the real change." })
+      .expect(200);
+
+    const changedLogs = await db
+      .select()
+      .from(activityLog)
+      .where(eq(activityLog.action, "decision_training.notes_updated"));
+    expect(changedLogs).toHaveLength(1);
+  });
+
   it("rejects agent writes and snapshot mutation", async () => {
     const seeded = await seedResolvedInteraction();
     const app = express();

--- a/server/src/__tests__/decision-training.test.ts
+++ b/server/src/__tests__/decision-training.test.ts
@@ -8,9 +8,11 @@ import {
   companies,
   createDb,
   decisionTrainingExamples,
+  executionWorkspaces,
   issueComments,
   issues,
   issueThreadInteractions,
+  projectWorkspaces,
   projects,
 } from "@paperclipai/db";
 import {
@@ -45,7 +47,9 @@ describeEmbeddedPostgres("decision training", () => {
     await db.delete(decisionTrainingExamples);
     await db.delete(issueThreadInteractions);
     await db.delete(issueComments);
+    await db.delete(executionWorkspaces);
     await db.delete(issues);
+    await db.delete(projectWorkspaces);
     await db.delete(projects);
     await db.delete(companies);
   });
@@ -90,7 +94,7 @@ describeEmbeddedPostgres("decision training", () => {
       { id: atCutoffId, companyId, issueId, body: "At cutoff", createdAt: cutoffAt },
       { id: afterId, companyId, issueId, body: "Leaked later context", createdAt: new Date("2026-07-16T12:00:01.000Z") },
     ]);
-    return { companyId, issueId, interactionId, cutoffAt, beforeId, atCutoffId, afterId };
+    return { companyId, projectId, issueId, interactionId, cutoffAt, beforeId, atCutoffId, afterId };
   }
 
   it("includes the cutoff boundary and excludes later comments", async () => {
@@ -112,6 +116,31 @@ describeEmbeddedPostgres("decision training", () => {
     expect(JSON.stringify(captured.snapshot)).not.toContain("Leaked later context");
   });
 
+  it("labels workspace-only commit evidence accurately", async () => {
+    const seeded = await seedResolvedInteraction();
+    await db.insert(projectWorkspaces).values({
+      companyId: seeded.companyId,
+      projectId: seeded.projectId,
+      name: "Primary workspace",
+      repoUrl: "https://github.com/paperclipai/paperclip.git",
+      metadata: { commitSha: "abcdef1234567890" },
+      isPrimary: true,
+      createdAt: new Date("2026-07-16T11:00:00.000Z"),
+    });
+
+    const captured = await captureDecisionSnapshot(db, {
+      companyId: seeded.companyId,
+      sourceKind: "interaction",
+      sourceId: seeded.interactionId,
+      issueId: seeded.issueId,
+    }, new Date("2026-07-16T13:00:00.000Z"));
+
+    expect(captured.snapshot.code).toMatchObject({
+      commitSha: "abcdef1234567890",
+      resolution: "workspace",
+    });
+  });
+
   it("enforces one example per decision and author", async () => {
     const seeded = await seedResolvedInteraction();
     const svc = decisionTrainingService(db);
@@ -130,6 +159,8 @@ describeEmbeddedPostgres("decision training", () => {
     expect(updated?.notesHistory).toEqual([
       expect.objectContaining({ author: "board-user", body: "Ship behind a flag." }),
     ]);
+    const unchanged = await svc.updateNotes(created.id, "board-user", "Use a 10% canary first.");
+    expect(unchanged?.notesHistory).toEqual(updated?.notesHistory);
     expect(updated?.snapshot).toEqual(created.snapshot);
   });
 

--- a/server/src/__tests__/decision-training.test.ts
+++ b/server/src/__tests__/decision-training.test.ts
@@ -304,6 +304,24 @@ describeEmbeddedPostgres("decision training", () => {
     expect(changedLogs).toHaveLength(1);
   });
 
+  it("returns not found for malformed example ids", async () => {
+    const app = express();
+    app.use(express.json());
+    app.use((req, _res, next) => {
+      req.actor = { type: "board", userId: "board-user", source: "local_implicit" };
+      next();
+    });
+    app.use("/api", decisionTrainingRoutes(db));
+    app.use(errorHandler);
+
+    await request(app).get("/api/decision-training/not-a-uuid").expect(404);
+    await request(app)
+      .patch("/api/decision-training/not-a-uuid")
+      .send({ notes: "Changed" })
+      .expect(404);
+    await request(app).delete("/api/decision-training/not-a-uuid").expect(404);
+  });
+
   it("rejects agent writes and snapshot mutation", async () => {
     const seeded = await seedResolvedInteraction();
     const app = express();

--- a/server/src/__tests__/decision-training.test.ts
+++ b/server/src/__tests__/decision-training.test.ts
@@ -5,10 +5,12 @@ import { eq } from "drizzle-orm";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import {
   activityLog,
+  agents,
   companies,
   createDb,
   decisionTrainingExamples,
   executionWorkspaces,
+  heartbeatRuns,
   issueComments,
   issues,
   issueThreadInteractions,
@@ -48,9 +50,11 @@ describeEmbeddedPostgres("decision training", () => {
     await db.delete(issueThreadInteractions);
     await db.delete(issueComments);
     await db.delete(executionWorkspaces);
+    await db.delete(heartbeatRuns);
     await db.delete(issues);
     await db.delete(projectWorkspaces);
     await db.delete(projects);
+    await db.delete(agents);
     await db.delete(companies);
   });
 
@@ -114,6 +118,56 @@ describeEmbeddedPostgres("decision training", () => {
     });
     expect(captured.snapshot.comments.map((comment) => comment.id)).toEqual([seeded.beforeId, seeded.atCutoffId]);
     expect(JSON.stringify(captured.snapshot)).not.toContain("Leaked later context");
+  });
+
+  it("excludes runs updated after the decision cutoff", async () => {
+    const seeded = await seedResolvedInteraction();
+    const agentId = randomUUID();
+    const includedRunId = randomUUID();
+    const excludedRunId = randomUUID();
+    await db.insert(agents).values({
+      id: agentId,
+      companyId: seeded.companyId,
+      name: "Decision agent",
+      role: "engineer",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    await db.insert(heartbeatRuns).values([
+      {
+        id: includedRunId,
+        companyId: seeded.companyId,
+        agentId,
+        status: "succeeded",
+        startedAt: new Date("2026-07-16T11:00:00.000Z"),
+        finishedAt: new Date("2026-07-16T11:30:00.000Z"),
+        contextSnapshot: { issueId: seeded.issueId, evidence: "known before cutoff" },
+        createdAt: new Date("2026-07-16T11:00:00.000Z"),
+        updatedAt: new Date("2026-07-16T11:30:00.000Z"),
+      },
+      {
+        id: excludedRunId,
+        companyId: seeded.companyId,
+        agentId,
+        status: "running",
+        startedAt: new Date("2026-07-16T11:45:00.000Z"),
+        contextSnapshot: { issueId: seeded.issueId, evidence: "written after cutoff" },
+        createdAt: new Date("2026-07-16T11:45:00.000Z"),
+        updatedAt: new Date("2026-07-16T12:30:00.000Z"),
+      },
+    ]);
+
+    const captured = await captureDecisionSnapshot(db, {
+      companyId: seeded.companyId,
+      sourceKind: "interaction",
+      sourceId: seeded.interactionId,
+      issueId: seeded.issueId,
+    }, new Date("2026-07-16T13:00:00.000Z"));
+
+    expect(captured.snapshot.runs.map((run) => run.id)).toEqual([includedRunId]);
+    expect(JSON.stringify(captured.snapshot)).not.toContain("written after cutoff");
   });
 
   it("labels workspace-only commit evidence accurately", async () => {

--- a/server/src/__tests__/decision-training.test.ts
+++ b/server/src/__tests__/decision-training.test.ts
@@ -322,6 +322,35 @@ describeEmbeddedPostgres("decision training", () => {
     await request(app).delete("/api/decision-training/not-a-uuid").expect(404);
   });
 
+  it("rejects updates and deletes from a different board user", async () => {
+    const seeded = await seedResolvedInteraction();
+    const example = await decisionTrainingService(db).create({
+      companyId: seeded.companyId,
+      sourceKind: "interaction",
+      sourceId: seeded.interactionId,
+      issueId: seeded.issueId,
+      notes: "Owner notes",
+      createdByUserId: "board-user",
+    });
+    const app = express();
+    app.use(express.json());
+    app.use((req, _res, next) => {
+      req.actor = { type: "board", userId: "other-board-user", source: "local_implicit" };
+      next();
+    });
+    app.use("/api", decisionTrainingRoutes(db));
+    app.use(errorHandler);
+
+    await request(app)
+      .patch(`/api/decision-training/${example.id}`)
+      .send({ notes: "Changed by someone else" })
+      .expect(403);
+    await request(app).delete(`/api/decision-training/${example.id}`).expect(403);
+
+    const unchanged = await decisionTrainingService(db).getById(example.id);
+    expect(unchanged?.notes).toBe("Owner notes");
+  });
+
   it("rejects agent writes and snapshot mutation", async () => {
     const seeded = await seedResolvedInteraction();
     const app = express();

--- a/server/src/__tests__/openapi-routes.test.ts
+++ b/server/src/__tests__/openapi-routes.test.ts
@@ -27,6 +27,7 @@ const apiPrefixes: Record<string, string> = {
   "company-skill-policy.ts": "/api",
   "costs.ts": "/api",
   "dashboard.ts": "/api",
+  "decision-training.ts": "/api",
   "environments.ts": "/api",
   "execution-workspaces.ts": "/api",
   "file-resources.ts": "/api",

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -37,6 +37,7 @@ import { costRoutes } from "./routes/costs.js";
 import { activityRoutes } from "./routes/activity.js";
 import { dashboardRoutes } from "./routes/dashboard.js";
 import { attentionRoutes } from "./routes/attention.js";
+import { decisionTrainingRoutes } from "./routes/decision-training.js";
 import { userProfileRoutes } from "./routes/user-profiles.js";
 import { sidebarBadgeRoutes } from "./routes/sidebar-badges.js";
 import { sidebarPreferenceRoutes } from "./routes/sidebar-preferences.js";
@@ -261,6 +262,7 @@ export async function createApp(
   api.use(activityRoutes(db));
   api.use(dashboardRoutes(db));
   api.use(attentionRoutes(db));
+  api.use(decisionTrainingRoutes(db));
   api.use(userProfileRoutes(db));
   api.use(sidebarBadgeRoutes(db));
   api.use(sidebarPreferenceRoutes(db));

--- a/server/src/routes/decision-training.ts
+++ b/server/src/routes/decision-training.ts
@@ -1,0 +1,168 @@
+import { Router, type Request, type Response } from "express";
+import { z } from "zod";
+import type { Db } from "@paperclipai/db";
+import { validate } from "../middleware/validate.js";
+import { decisionTrainingService, logActivity } from "../services/index.js";
+import { assertCompanyAccess, getActorInfo, hasCompanyAccess } from "./authz.js";
+
+const sourceKindSchema = z.enum(["interaction", "approval", "execution_decision"]);
+const createSchema = z.object({
+  sourceKind: sourceKindSchema,
+  sourceId: z.string().uuid(),
+  issueId: z.string().uuid(),
+  notes: z.string().max(100_000).default(""),
+}).strict();
+const updateSchema = z.object({ notes: z.string().max(100_000) }).strict();
+
+function requireHumanUser(req: Request, res: Response) {
+  if (req.actor.type !== "board") {
+    res.status(403).json({ error: "Decision training writes require a human user" });
+    return null;
+  }
+  if (!req.actor.userId) {
+    res.status(403).json({ error: "Board user context required" });
+    return null;
+  }
+  return req.actor.userId;
+}
+
+export function decisionTrainingRoutes(db: Db) {
+  const router = Router();
+  const svc = decisionTrainingService(db);
+
+  router.post(
+    "/companies/:companyId/decision-training",
+    validate(createSchema),
+    async (req, res) => {
+      const companyId = req.params.companyId as string;
+      assertCompanyAccess(req, companyId);
+      const userId = requireHumanUser(req, res);
+      if (!userId) return;
+
+      const example = await svc.create({
+        companyId,
+        sourceKind: req.body.sourceKind,
+        sourceId: req.body.sourceId,
+        issueId: req.body.issueId,
+        notes: req.body.notes,
+        createdByUserId: userId,
+      });
+      const actor = getActorInfo(req);
+      await logActivity(db, {
+        companyId,
+        actorType: actor.actorType,
+        actorId: actor.actorId,
+        agentId: actor.agentId,
+        runId: actor.runId,
+        action: "decision_training.created",
+        entityType: "decision_training_example",
+        entityId: example.id,
+        details: { sourceKind: example.sourceKind, sourceId: example.sourceId, issueId: example.issueId },
+      });
+      res.status(201).json(example);
+    },
+  );
+
+  router.get("/companies/:companyId/decision-training", async (req, res) => {
+    const companyId = req.params.companyId as string;
+    assertCompanyAccess(req, companyId);
+    const parsed = z.object({
+      project: z.string().uuid().optional(),
+      kind: sourceKindSchema.optional(),
+      author: z.string().optional(),
+      q: z.string().trim().max(500).optional(),
+    }).safeParse(req.query);
+    if (!parsed.success) {
+      res.status(400).json({ error: "Invalid decision training query", details: parsed.error.flatten() });
+      return;
+    }
+    res.json(await svc.list(companyId, {
+      projectId: parsed.data.project,
+      kind: parsed.data.kind,
+      author: parsed.data.author,
+      q: parsed.data.q,
+    }));
+  });
+
+  router.get("/companies/:companyId/decision-training/export.jsonl", async (req, res) => {
+    const companyId = req.params.companyId as string;
+    assertCompanyAccess(req, companyId);
+    const rows = await svc.list(companyId);
+    const body = rows
+      .map(({ example }) => JSON.stringify({
+        state: example.snapshot,
+        label: { outcome: example.decisionOutcome, notes: example.notes },
+      }))
+      .join("\n");
+    res.type("application/x-ndjson").send(body ? `${body}\n` : "");
+  });
+
+  router.get("/decision-training/:id", async (req, res) => {
+    const example = await svc.getById(req.params.id as string);
+    if (!example || !hasCompanyAccess(req, example.companyId)) {
+      res.status(404).json({ error: "Decision training example not found" });
+      return;
+    }
+    res.json(example);
+  });
+
+  router.patch("/decision-training/:id", validate(updateSchema), async (req, res) => {
+    const existing = await svc.getById(req.params.id as string);
+    if (!existing || !hasCompanyAccess(req, existing.companyId)) {
+      res.status(404).json({ error: "Decision training example not found" });
+      return;
+    }
+    assertCompanyAccess(req, existing.companyId);
+    const userId = requireHumanUser(req, res);
+    if (!userId) return;
+    const updated = await svc.updateNotes(existing.id, userId, req.body.notes);
+    if (!updated) {
+      res.status(404).json({ error: "Decision training example not found" });
+      return;
+    }
+    const actor = getActorInfo(req);
+    await logActivity(db, {
+      companyId: existing.companyId,
+      actorType: actor.actorType,
+      actorId: actor.actorId,
+      agentId: actor.agentId,
+      runId: actor.runId,
+      action: "decision_training.notes_updated",
+      entityType: "decision_training_example",
+      entityId: updated.id,
+      details: { issueId: updated.issueId },
+    });
+    res.json(updated);
+  });
+
+  router.delete("/decision-training/:id", async (req, res) => {
+    const existing = await svc.getById(req.params.id as string);
+    if (!existing || !hasCompanyAccess(req, existing.companyId)) {
+      res.status(404).json({ error: "Decision training example not found" });
+      return;
+    }
+    assertCompanyAccess(req, existing.companyId);
+    const userId = requireHumanUser(req, res);
+    if (!userId) return;
+    const deleted = await svc.delete(existing.id);
+    if (deleted.length === 0) {
+      res.status(404).json({ error: "Decision training example not found" });
+      return;
+    }
+    const actor = getActorInfo(req);
+    await logActivity(db, {
+      companyId: existing.companyId,
+      actorType: actor.actorType,
+      actorId: actor.actorId,
+      agentId: actor.agentId,
+      runId: actor.runId,
+      action: "decision_training.deleted",
+      entityType: "decision_training_example",
+      entityId: existing.id,
+      details: { issueId: existing.issueId, deletedByUserId: userId },
+    });
+    res.status(204).send();
+  });
+
+  return router;
+}

--- a/server/src/routes/decision-training.ts
+++ b/server/src/routes/decision-training.ts
@@ -112,7 +112,6 @@ export function decisionTrainingRoutes(db: Db) {
       res.status(404).json({ error: "Decision training example not found" });
       return;
     }
-    assertCompanyAccess(req, existing.companyId);
     const userId = requireHumanUser(req, res);
     if (!userId) return;
     const updated = await svc.updateNotes(existing.id, userId, req.body.notes);
@@ -141,7 +140,6 @@ export function decisionTrainingRoutes(db: Db) {
       res.status(404).json({ error: "Decision training example not found" });
       return;
     }
-    assertCompanyAccess(req, existing.companyId);
     const userId = requireHumanUser(req, res);
     if (!userId) return;
     const deleted = await svc.delete(existing.id);

--- a/server/src/routes/decision-training.ts
+++ b/server/src/routes/decision-training.ts
@@ -6,6 +6,7 @@ import { decisionTrainingService, logActivity } from "../services/index.js";
 import { assertCompanyAccess, getActorInfo, hasCompanyAccess } from "./authz.js";
 
 const sourceKindSchema = z.enum(["interaction", "approval", "execution_decision"]);
+const exampleIdSchema = z.string().uuid();
 const createSchema = z.object({
   sourceKind: sourceKindSchema,
   sourceId: z.string().uuid(),
@@ -24,6 +25,15 @@ function requireHumanUser(req: Request, res: Response) {
     return null;
   }
   return req.actor.userId;
+}
+
+function parseExampleId(req: Request, res: Response) {
+  const parsed = exampleIdSchema.safeParse(req.params.id);
+  if (!parsed.success) {
+    res.status(404).json({ error: "Decision training example not found" });
+    return null;
+  }
+  return parsed.data;
 }
 
 export function decisionTrainingRoutes(db: Db) {
@@ -98,7 +108,9 @@ export function decisionTrainingRoutes(db: Db) {
   });
 
   router.get("/decision-training/:id", async (req, res) => {
-    const example = await svc.getById(req.params.id as string);
+    const exampleId = parseExampleId(req, res);
+    if (!exampleId) return;
+    const example = await svc.getById(exampleId);
     if (!example || !hasCompanyAccess(req, example.companyId)) {
       res.status(404).json({ error: "Decision training example not found" });
       return;
@@ -107,7 +119,9 @@ export function decisionTrainingRoutes(db: Db) {
   });
 
   router.patch("/decision-training/:id", validate(updateSchema), async (req, res) => {
-    const existing = await svc.getById(req.params.id as string);
+    const exampleId = parseExampleId(req, res);
+    if (!exampleId) return;
+    const existing = await svc.getById(exampleId);
     if (!existing || !hasCompanyAccess(req, existing.companyId)) {
       res.status(404).json({ error: "Decision training example not found" });
       return;
@@ -138,7 +152,9 @@ export function decisionTrainingRoutes(db: Db) {
   });
 
   router.delete("/decision-training/:id", async (req, res) => {
-    const existing = await svc.getById(req.params.id as string);
+    const exampleId = parseExampleId(req, res);
+    if (!exampleId) return;
+    const existing = await svc.getById(exampleId);
     if (!existing || !hasCompanyAccess(req, existing.companyId)) {
       res.status(404).json({ error: "Decision training example not found" });
       return;

--- a/server/src/routes/decision-training.ts
+++ b/server/src/routes/decision-training.ts
@@ -14,6 +14,11 @@ const createSchema = z.object({
   notes: z.string().max(100_000).default(""),
 }).strict();
 const updateSchema = z.object({ notes: z.string().max(100_000) }).strict();
+const previewSchema = z.object({
+  sourceKind: sourceKindSchema,
+  sourceId: z.string().uuid(),
+  issueId: z.string().uuid(),
+}).strict();
 
 function requireHumanUser(req: Request, res: Response) {
   if (req.actor.type !== "board") {
@@ -78,6 +83,31 @@ export function decisionTrainingRoutes(db: Db) {
         details: { sourceKind: example.sourceKind, sourceId: example.sourceId, issueId: example.issueId },
       });
       res.status(201).json(example);
+    },
+  );
+
+  // Read-only snapshot preview for the create drawer. Same authz as a write
+  // (humans only) since it exposes the same captured decision state, but it
+  // never persists anything.
+  router.post(
+    "/companies/:companyId/decision-training/preview",
+    validate(previewSchema),
+    async (req, res) => {
+      const companyId = req.params.companyId as string;
+      assertCompanyAccess(req, companyId);
+      const userId = requireHumanUser(req, res);
+      if (!userId) return;
+      const preview = await svc.preview({
+        companyId,
+        sourceKind: req.body.sourceKind,
+        sourceId: req.body.sourceId,
+        issueId: req.body.issueId,
+      });
+      res.json({
+        cutoffAt: preview.cutoffAt.toISOString(),
+        decisionOutcome: preview.decisionOutcome,
+        snapshot: preview.snapshot,
+      });
     },
   );
 

--- a/server/src/routes/decision-training.ts
+++ b/server/src/routes/decision-training.ts
@@ -36,6 +36,14 @@ function parseExampleId(req: Request, res: Response) {
   return parsed.data;
 }
 
+function requireExampleOwner(res: Response, userId: string, createdByUserId: string) {
+  if (userId !== createdByUserId) {
+    res.status(403).json({ error: "Only the example author can change decision training examples" });
+    return false;
+  }
+  return true;
+}
+
 export function decisionTrainingRoutes(db: Db) {
   const router = Router();
   const svc = decisionTrainingService(db);
@@ -128,6 +136,7 @@ export function decisionTrainingRoutes(db: Db) {
     }
     const userId = requireHumanUser(req, res);
     if (!userId) return;
+    if (!requireExampleOwner(res, userId, existing.createdByUserId)) return;
     const notesChanged = req.body.notes !== existing.notes;
     const updated = await svc.updateNotes(existing.id, userId, req.body.notes);
     if (!updated) {
@@ -161,6 +170,7 @@ export function decisionTrainingRoutes(db: Db) {
     }
     const userId = requireHumanUser(req, res);
     if (!userId) return;
+    if (!requireExampleOwner(res, userId, existing.createdByUserId)) return;
     const deleted = await svc.delete(existing.id);
     if (deleted.length === 0) {
       res.status(404).json({ error: "Decision training example not found" });

--- a/server/src/routes/decision-training.ts
+++ b/server/src/routes/decision-training.ts
@@ -114,23 +114,26 @@ export function decisionTrainingRoutes(db: Db) {
     }
     const userId = requireHumanUser(req, res);
     if (!userId) return;
+    const notesChanged = req.body.notes !== existing.notes;
     const updated = await svc.updateNotes(existing.id, userId, req.body.notes);
     if (!updated) {
       res.status(404).json({ error: "Decision training example not found" });
       return;
     }
-    const actor = getActorInfo(req);
-    await logActivity(db, {
-      companyId: existing.companyId,
-      actorType: actor.actorType,
-      actorId: actor.actorId,
-      agentId: actor.agentId,
-      runId: actor.runId,
-      action: "decision_training.notes_updated",
-      entityType: "decision_training_example",
-      entityId: updated.id,
-      details: { issueId: updated.issueId },
-    });
+    if (notesChanged) {
+      const actor = getActorInfo(req);
+      await logActivity(db, {
+        companyId: existing.companyId,
+        actorType: actor.actorType,
+        actorId: actor.actorId,
+        agentId: actor.agentId,
+        runId: actor.runId,
+        action: "decision_training.notes_updated",
+        entityType: "decision_training_example",
+        entityId: updated.id,
+        details: { issueId: updated.issueId },
+      });
+    }
     res.json(updated);
   });
 

--- a/server/src/routes/openapi.ts
+++ b/server/src/routes/openapi.ts
@@ -2962,6 +2962,68 @@ registry.registerPath({
   responses: { 200: r.ok(), 401: r.unauthorized, 403: r.forbidden },
 });
 
+// ─── Decision training ──────────────────────────────────────────────────────
+
+const decisionTrainingSourceKindSchema = z.enum(["interaction", "approval", "execution_decision"]);
+
+registerCurrentRoute({
+  method: "post",
+  path: "/api/companies/{companyId}/decision-training",
+  tags: ["decision-training"],
+  summary: "Capture a decision training example",
+  body: z.object({
+    sourceKind: decisionTrainingSourceKindSchema,
+    sourceId: z.string().uuid(),
+    issueId: z.string().uuid(),
+    notes: z.string().max(100_000).default(""),
+  }).strict(),
+  responses: { 201: r.ok(), 400: r.badRequest, 401: r.unauthorized, 403: r.forbidden, 404: r.notFound, 409: r.conflict },
+});
+
+registerCurrentRoute({
+  method: "get",
+  path: "/api/companies/{companyId}/decision-training",
+  tags: ["decision-training"],
+  summary: "List decision training examples",
+  query: z.object({
+    project: z.string().uuid().optional(),
+    kind: decisionTrainingSourceKindSchema.optional(),
+    author: z.string().optional(),
+    q: z.string().max(500).optional(),
+  }),
+});
+
+registerCurrentRoute({
+  method: "get",
+  path: "/api/companies/{companyId}/decision-training/export.jsonl",
+  tags: ["decision-training"],
+  summary: "Export decision training examples as JSONL",
+});
+
+registerCurrentRoute({
+  method: "get",
+  path: "/api/decision-training/{id}",
+  tags: ["decision-training"],
+  summary: "Get a decision training example",
+});
+
+registerCurrentRoute({
+  method: "patch",
+  path: "/api/decision-training/{id}",
+  tags: ["decision-training"],
+  summary: "Update decision training notes",
+  body: z.object({ notes: z.string().max(100_000) }).strict(),
+  responses: { 200: r.ok(), 400: r.badRequest, 401: r.unauthorized, 403: r.forbidden, 404: r.notFound },
+});
+
+registerCurrentRoute({
+  method: "delete",
+  path: "/api/decision-training/{id}",
+  tags: ["decision-training"],
+  summary: "Delete a decision training example",
+  responses: { 204: r.ok(), 401: r.unauthorized, 403: r.forbidden, 404: r.notFound },
+});
+
 registry.registerPath({
   method: "get",
   path: "/api/sidebar-preferences/me",

--- a/server/src/services/attention.ts
+++ b/server/src/services/attention.ts
@@ -5,6 +5,7 @@ import {
   approvals,
   assets,
   companies,
+  decisionTrainingExamples,
   heartbeatRunEvents,
   heartbeatRuns,
   inboxDismissals,
@@ -310,7 +311,7 @@ function decisionVerbs(...verbs: AttentionDecisionVerb[]): AttentionDecisionVerb
   return verbs;
 }
 
-type CreateAttentionItemInput = Omit<AttentionItem, "id" | "dismissalKey" | "rank" | "dismissal" | "project" | "workspace" | "detail"> & {
+type CreateAttentionItemInput = Omit<AttentionItem, "id" | "dismissalKey" | "rank" | "dismissal" | "project" | "workspace" | "detail" | "trainingExampleId"> & {
   project?: AttentionProjectRef | null;
   workspace?: AttentionWorkspaceRef | null;
   detail?: AttentionItemDetail | null;
@@ -325,6 +326,7 @@ function createItem(input: CreateAttentionItemInput): AttentionItem {
     project: input.project ?? null,
     workspace: input.workspace ?? null,
     detail: input.detail ?? null,
+    trainingExampleId: null,
     rank: 0,
   };
 }
@@ -1238,6 +1240,42 @@ export function attentionService(db: Db) {
       const items = [...deduped.values()]
         .sort(compareAttentionItems)
         .map((item, index) => ({ ...item, rank: index + 1 }));
+      if (options.userId) {
+        const trainable: Array<{ sourceKind: "approval" | "interaction"; sourceId: string }> = [];
+        for (const item of items) {
+          if (item.sourceKind === "approval") {
+            trainable.push({ sourceKind: "approval", sourceId: item.subject.id });
+          }
+          if (item.sourceKind === "issue_thread_interaction") {
+            trainable.push({ sourceKind: "interaction", sourceId: item.subject.id });
+          }
+        }
+        if (trainable.length > 0) {
+          const examples = await db
+            .select({
+              id: decisionTrainingExamples.id,
+              sourceKind: decisionTrainingExamples.sourceKind,
+              sourceId: decisionTrainingExamples.sourceId,
+            })
+            .from(decisionTrainingExamples)
+            .where(and(
+              eq(decisionTrainingExamples.companyId, companyId),
+              eq(decisionTrainingExamples.createdByUserId, options.userId),
+              inArray(decisionTrainingExamples.sourceId, trainable.map((item) => item.sourceId)),
+            ));
+          const exampleBySource = new Map(examples.map((row) => [`${row.sourceKind}:${row.sourceId}`, row.id]));
+          for (const item of items) {
+            const sourceKind = item.sourceKind === "approval"
+              ? "approval"
+              : item.sourceKind === "issue_thread_interaction"
+                ? "interaction"
+                : null;
+            item.trainingExampleId = sourceKind
+              ? exampleBySource.get(`${sourceKind}:${item.subject.id}`) ?? null
+              : null;
+          }
+        }
+      }
       const countsBySourceKind = emptyCounts();
       for (const item of items) countsBySourceKind[item.sourceKind] += 1;
 

--- a/server/src/services/attention.ts
+++ b/server/src/services/attention.ts
@@ -605,8 +605,16 @@ export function attentionService(db: Db) {
           payload: approvals.payload,
           createdAt: approvals.createdAt,
           updatedAt: approvals.updatedAt,
+          // The issue this approval is anchored to (if any). Surfaced so the
+          // Decisions row can offer decision-training capture, which anchors to
+          // the durable (approval + issue) pair (PAP-14299).
+          issueId: issueApprovals.issueId,
         })
         .from(approvals)
+        .leftJoin(issueApprovals, and(
+          eq(issueApprovals.approvalId, approvals.id),
+          eq(issueApprovals.companyId, companyId),
+        ))
         .where(and(eq(approvals.companyId, companyId), eq(approvals.status, "pending")))
         .orderBy(desc(approvals.updatedAt), desc(approvals.id));
 
@@ -628,6 +636,7 @@ export function attentionService(db: Db) {
               type: approval.type,
               requestedByAgentId: approval.requestedByAgentId,
               requestedByUserId: approval.requestedByUserId,
+              issueId: approval.issueId,
             },
           },
           whyNow: "Approval is pending a board decision.",

--- a/server/src/services/attention.ts
+++ b/server/src/services/attention.ts
@@ -607,7 +607,7 @@ export function attentionService(db: Db) {
           updatedAt: approvals.updatedAt,
           // The issue this approval is anchored to (if any). Surfaced so the
           // Decisions row can offer decision-training capture, which anchors to
-          // the durable (approval + issue) pair (PAP-14299).
+          // the durable approval + issue pair.
           issueId: issueApprovals.issueId,
         })
         .from(approvals)

--- a/server/src/services/attention.ts
+++ b/server/src/services/attention.ts
@@ -605,18 +605,26 @@ export function attentionService(db: Db) {
           payload: approvals.payload,
           createdAt: approvals.createdAt,
           updatedAt: approvals.updatedAt,
-          // The issue this approval is anchored to (if any). Surfaced so the
-          // Decisions row can offer decision-training capture, which anchors to
-          // the durable approval + issue pair.
-          issueId: issueApprovals.issueId,
         })
         .from(approvals)
-        .leftJoin(issueApprovals, and(
-          eq(issueApprovals.approvalId, approvals.id),
-          eq(issueApprovals.companyId, companyId),
-        ))
         .where(and(eq(approvals.companyId, companyId), eq(approvals.status, "pending")))
         .orderBy(desc(approvals.updatedAt), desc(approvals.id));
+
+      const pendingApprovalIds = pendingApprovals.map((approval) => approval.id);
+      const approvalIssueRows = pendingApprovalIds.length > 0
+        ? await db
+          .select({ approvalId: issueApprovals.approvalId, issueId: issueApprovals.issueId })
+          .from(issueApprovals)
+          .where(and(
+            eq(issueApprovals.companyId, companyId),
+            inArray(issueApprovals.approvalId, pendingApprovalIds),
+          ))
+          .orderBy(asc(issueApprovals.approvalId), asc(issueApprovals.issueId))
+        : [];
+      const approvalIssueMap = new Map<string, string>();
+      for (const row of approvalIssueRows) {
+        if (!approvalIssueMap.has(row.approvalId)) approvalIssueMap.set(row.approvalId, row.issueId);
+      }
 
       for (const approval of pendingApprovals) {
         const dedupKey = `approval:${approval.id}`;
@@ -636,7 +644,7 @@ export function attentionService(db: Db) {
               type: approval.type,
               requestedByAgentId: approval.requestedByAgentId,
               requestedByUserId: approval.requestedByUserId,
-              issueId: approval.issueId,
+              issueId: approvalIssueMap.get(approval.id) ?? null,
             },
           },
           whyNow: "Approval is pending a board decision.",

--- a/server/src/services/decision-training.ts
+++ b/server/src/services/decision-training.ts
@@ -239,7 +239,13 @@ export async function captureDecisionSnapshot(
           ?? projectWorkspace?.defaultRef
           ?? null,
         commitSha: commitSha ?? null,
-        resolution: exactCommit ? "exact" : commitSha ? "nearest_run" : "none",
+        resolution: exactCommit
+          ? "exact"
+          : nearestCommit
+            ? "nearest_run"
+            : workspaceCommit
+              ? "workspace"
+              : "none",
       },
     },
   };
@@ -302,6 +308,7 @@ export function decisionTrainingService(db: Db) {
         where: eq(decisionTrainingExamples.id, id),
       });
       if (!row) return null;
+      if (notes === row.notes) return row;
       const history: DecisionTrainingNotesHistoryEntry[] = [
         ...(row.notesHistory ?? []),
         { author, at: new Date().toISOString(), body: row.notes },

--- a/server/src/services/decision-training.ts
+++ b/server/src/services/decision-training.ts
@@ -257,6 +257,10 @@ export async function captureDecisionSnapshot(
 
 export function decisionTrainingService(db: Db) {
   return {
+    // Capture the snapshot the way create() would, but without persisting it, so
+    // the drawer's create state can preview exactly what will be frozen before
+    // the user commits (PAP-14299).
+    preview: async (input: CaptureInput) => captureDecisionSnapshot(db, input),
     create: async (input: CaptureInput & { notes: string; createdByUserId: string }) => {
       const captured = await captureDecisionSnapshot(db, input);
       const rows = await db

--- a/server/src/services/decision-training.ts
+++ b/server/src/services/decision-training.ts
@@ -174,6 +174,7 @@ export async function captureDecisionSnapshot(
       eq(heartbeatRuns.companyId, input.companyId),
       isNotNull(heartbeatRuns.startedAt),
       lte(heartbeatRuns.startedAt, decision.cutoffAt),
+      lte(heartbeatRuns.updatedAt, decision.cutoffAt),
       or(
         sql`${heartbeatRuns.contextSnapshot} ->> 'issueId' = ${input.issueId}`,
         sql`${heartbeatRuns.contextSnapshot} ->> 'taskId' = ${input.issueId}`,

--- a/server/src/services/decision-training.ts
+++ b/server/src/services/decision-training.ts
@@ -189,6 +189,7 @@ export async function captureDecisionSnapshot(
         eq(projectWorkspaces.companyId, input.companyId),
         eq(projectWorkspaces.projectId, issue.projectId),
         lte(projectWorkspaces.createdAt, decision.cutoffAt),
+        lte(projectWorkspaces.updatedAt, decision.cutoffAt),
       ))
       .orderBy(desc(projectWorkspaces.isPrimary), desc(projectWorkspaces.updatedAt))
       .limit(1)
@@ -200,6 +201,8 @@ export async function captureDecisionSnapshot(
       eq(executionWorkspaces.companyId, input.companyId),
       eq(executionWorkspaces.sourceIssueId, input.issueId),
       lte(executionWorkspaces.openedAt, decision.cutoffAt),
+      lte(executionWorkspaces.lastUsedAt, decision.cutoffAt),
+      lte(executionWorkspaces.updatedAt, decision.cutoffAt),
     ))
     .orderBy(desc(executionWorkspaces.lastUsedAt), desc(executionWorkspaces.id))
     .limit(1);

--- a/server/src/services/decision-training.ts
+++ b/server/src/services/decision-training.ts
@@ -1,0 +1,321 @@
+import {
+  and,
+  asc,
+  desc,
+  eq,
+  ilike,
+  isNotNull,
+  lte,
+  or,
+  sql,
+  type SQL,
+} from "drizzle-orm";
+import type { Db } from "@paperclipai/db";
+import {
+  approvals,
+  decisionTrainingExamples,
+  executionWorkspaces,
+  heartbeatRuns,
+  issueApprovals,
+  issueComments,
+  issueExecutionDecisions,
+  issues,
+  issueThreadInteractions,
+  projectWorkspaces,
+} from "@paperclipai/db";
+import type {
+  DecisionTrainingNotesHistoryEntry,
+  DecisionTrainingSnapshotV1,
+  DecisionTrainingSourceKind,
+} from "@paperclipai/shared";
+import { conflict, notFound } from "../errors.js";
+
+type CaptureInput = {
+  companyId: string;
+  sourceKind: DecisionTrainingSourceKind;
+  sourceId: string;
+  issueId: string;
+};
+
+type SourceDecision = {
+  cutoffAt: Date;
+  outcome: string | null;
+  payload: Record<string, unknown>;
+  actor: Record<string, unknown> | null;
+  exactRunId: string | null;
+};
+
+type ListInput = {
+  projectId?: string;
+  kind?: DecisionTrainingSourceKind;
+  author?: string;
+  q?: string;
+};
+
+function jsonCopy(value: unknown): Record<string, unknown> {
+  return JSON.parse(JSON.stringify(value)) as Record<string, unknown>;
+}
+
+function findCommitSha(value: unknown): string | null {
+  if (!value || typeof value !== "object") return null;
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      const found = findCommitSha(item);
+      if (found) return found;
+    }
+    return null;
+  }
+  const record = value as Record<string, unknown>;
+  for (const key of ["commitSha", "commitSHA", "gitCommitSha", "headSha", "commit"]) {
+    const candidate = record[key];
+    if (typeof candidate === "string" && /^[0-9a-f]{7,64}$/i.test(candidate)) return candidate;
+  }
+  for (const nested of Object.values(record)) {
+    const found = findCommitSha(nested);
+    if (found) return found;
+  }
+  return null;
+}
+
+async function loadSourceDecision(db: Db, input: CaptureInput, capturedAt: Date): Promise<SourceDecision> {
+  if (input.sourceKind === "interaction") {
+    const row = await db.query.issueThreadInteractions.findFirst({
+      where: and(
+        eq(issueThreadInteractions.id, input.sourceId),
+        eq(issueThreadInteractions.companyId, input.companyId),
+        eq(issueThreadInteractions.issueId, input.issueId),
+      ),
+    });
+    if (!row) throw notFound("Decision interaction not found");
+    const resolved = row.resolvedAt != null && row.status !== "pending";
+    return {
+      cutoffAt: resolved ? row.resolvedAt! : capturedAt,
+      outcome: resolved ? row.status : null,
+      payload: jsonCopy({
+        kind: row.kind,
+        title: row.title,
+        summary: row.summary,
+        payload: row.payload,
+        result: resolved ? row.result : null,
+      }),
+      actor: jsonCopy(resolved
+        ? { userId: row.resolvedByUserId, agentId: row.resolvedByAgentId }
+        : { userId: row.createdByUserId, agentId: row.createdByAgentId }),
+      exactRunId: row.sourceRunId,
+    };
+  }
+
+  if (input.sourceKind === "approval") {
+    const rows = await db
+      .select({ approval: approvals })
+      .from(approvals)
+      .innerJoin(issueApprovals, and(
+        eq(issueApprovals.approvalId, approvals.id),
+        eq(issueApprovals.issueId, input.issueId),
+        eq(issueApprovals.companyId, input.companyId),
+      ))
+      .where(and(eq(approvals.id, input.sourceId), eq(approvals.companyId, input.companyId)))
+      .limit(1);
+    const row = rows[0]?.approval;
+    if (!row) throw notFound("Decision approval not found");
+    const resolved = row.decidedAt != null && row.status !== "pending";
+    return {
+      cutoffAt: resolved ? row.decidedAt! : capturedAt,
+      outcome: resolved ? row.status : null,
+      payload: jsonCopy({ type: row.type, payload: row.payload, decisionNote: resolved ? row.decisionNote : null }),
+      actor: jsonCopy(resolved
+        ? { userId: row.decidedByUserId }
+        : { userId: row.requestedByUserId, agentId: row.requestedByAgentId }),
+      exactRunId: null,
+    };
+  }
+
+  const row = await db.query.issueExecutionDecisions.findFirst({
+    where: and(
+      eq(issueExecutionDecisions.id, input.sourceId),
+      eq(issueExecutionDecisions.companyId, input.companyId),
+      eq(issueExecutionDecisions.issueId, input.issueId),
+    ),
+  });
+  if (!row) throw notFound("Execution decision not found");
+  return {
+    cutoffAt: row.createdAt,
+    outcome: row.outcome,
+    payload: jsonCopy({ stageId: row.stageId, stageType: row.stageType, body: row.body }),
+    actor: jsonCopy({ userId: row.actorUserId, agentId: row.actorAgentId }),
+    exactRunId: row.createdByRunId,
+  };
+}
+
+export async function captureDecisionSnapshot(
+  db: Db,
+  input: CaptureInput,
+  capturedAt = new Date(),
+): Promise<{ cutoffAt: Date; decisionOutcome: string | null; snapshot: DecisionTrainingSnapshotV1 }> {
+  const issue = await db.query.issues.findFirst({
+    where: and(eq(issues.id, input.issueId), eq(issues.companyId, input.companyId)),
+  });
+  if (!issue) throw notFound("Issue not found");
+
+  const decision = await loadSourceDecision(db, input, capturedAt);
+  const comments = await db
+    .select()
+    .from(issueComments)
+    .where(and(
+      eq(issueComments.companyId, input.companyId),
+      eq(issueComments.issueId, input.issueId),
+      lte(issueComments.createdAt, decision.cutoffAt),
+    ))
+    .orderBy(asc(issueComments.createdAt), asc(issueComments.id));
+  const runs = await db
+    .select()
+    .from(heartbeatRuns)
+    .where(and(
+      eq(heartbeatRuns.companyId, input.companyId),
+      isNotNull(heartbeatRuns.startedAt),
+      lte(heartbeatRuns.startedAt, decision.cutoffAt),
+      or(
+        sql`${heartbeatRuns.contextSnapshot} ->> 'issueId' = ${input.issueId}`,
+        sql`${heartbeatRuns.contextSnapshot} ->> 'taskId' = ${input.issueId}`,
+      ),
+    ))
+    .orderBy(asc(heartbeatRuns.startedAt), asc(heartbeatRuns.id));
+
+  const [projectWorkspace] = issue.projectId
+    ? await db
+      .select()
+      .from(projectWorkspaces)
+      .where(and(
+        eq(projectWorkspaces.companyId, input.companyId),
+        eq(projectWorkspaces.projectId, issue.projectId),
+        lte(projectWorkspaces.createdAt, decision.cutoffAt),
+      ))
+      .orderBy(desc(projectWorkspaces.isPrimary), desc(projectWorkspaces.updatedAt))
+      .limit(1)
+    : [];
+  const [executionWorkspace] = await db
+    .select()
+    .from(executionWorkspaces)
+    .where(and(
+      eq(executionWorkspaces.companyId, input.companyId),
+      eq(executionWorkspaces.sourceIssueId, input.issueId),
+      lte(executionWorkspaces.openedAt, decision.cutoffAt),
+    ))
+    .orderBy(desc(executionWorkspaces.lastUsedAt), desc(executionWorkspaces.id))
+    .limit(1);
+
+  const exactRun = decision.exactRunId ? runs.find((run) => run.id === decision.exactRunId) ?? null : null;
+  const latestRunWithCommit = [...runs].reverse().find((run) => findCommitSha(run.contextSnapshot)) ?? null;
+  const exactCommit = exactRun ? findCommitSha(exactRun.contextSnapshot) : null;
+  const nearestCommit = latestRunWithCommit ? findCommitSha(latestRunWithCommit.contextSnapshot) : null;
+  const workspaceCommit = findCommitSha(executionWorkspace?.metadata) ?? findCommitSha(projectWorkspace?.metadata);
+  const commitSha = exactCommit ?? nearestCommit ?? workspaceCommit;
+
+  return {
+    cutoffAt: decision.cutoffAt,
+    decisionOutcome: decision.outcome,
+    snapshot: {
+      version: 1,
+      capturedAt: capturedAt.toISOString(),
+      cutoff: {
+        at: decision.cutoffAt.toISOString(),
+        lastCommentId: comments.at(-1)?.id ?? null,
+        commentCount: comments.length,
+      },
+      issue: jsonCopy(issue),
+      comments: comments.map(jsonCopy),
+      runs: runs.map(jsonCopy),
+      decision: {
+        kind: input.sourceKind,
+        payload: decision.payload,
+        actor: decision.actor,
+        outcome: decision.outcome,
+      },
+      code: {
+        repoUrl: executionWorkspace?.repoUrl ?? projectWorkspace?.repoUrl ?? null,
+        ref: executionWorkspace?.branchName
+          ?? executionWorkspace?.baseRef
+          ?? projectWorkspace?.repoRef
+          ?? projectWorkspace?.defaultRef
+          ?? null,
+        commitSha: commitSha ?? null,
+        resolution: exactCommit ? "exact" : commitSha ? "nearest_run" : "none",
+      },
+    },
+  };
+}
+
+export function decisionTrainingService(db: Db) {
+  return {
+    create: async (input: CaptureInput & { notes: string; createdByUserId: string }) => {
+      const captured = await captureDecisionSnapshot(db, input);
+      const rows = await db
+        .insert(decisionTrainingExamples)
+        .values({
+          companyId: input.companyId,
+          sourceKind: input.sourceKind,
+          sourceId: input.sourceId,
+          issueId: input.issueId,
+          cutoffAt: captured.cutoffAt,
+          notes: input.notes,
+          notesHistory: [],
+          decisionOutcome: captured.decisionOutcome,
+          snapshot: captured.snapshot,
+          createdByUserId: input.createdByUserId,
+        })
+        .onConflictDoNothing({
+          target: [
+            decisionTrainingExamples.sourceKind,
+            decisionTrainingExamples.sourceId,
+            decisionTrainingExamples.createdByUserId,
+          ],
+        })
+        .returning();
+      if (!rows[0]) throw conflict("This decision is already trained by this user");
+      return rows[0];
+    },
+    list: async (companyId: string, input: ListInput = {}) => {
+      const filters: SQL[] = [eq(decisionTrainingExamples.companyId, companyId)];
+      if (input.projectId) filters.push(eq(issues.projectId, input.projectId));
+      if (input.kind) filters.push(eq(decisionTrainingExamples.sourceKind, input.kind));
+      if (input.author) filters.push(eq(decisionTrainingExamples.createdByUserId, input.author));
+      if (input.q) {
+        const query = `%${input.q}%`;
+        filters.push(or(
+          ilike(decisionTrainingExamples.notes, query),
+          ilike(issues.title, query),
+          ilike(issues.identifier, query),
+        )!);
+      }
+      return db
+        .select({ example: decisionTrainingExamples, issueTitle: issues.title, issueIdentifier: issues.identifier })
+        .from(decisionTrainingExamples)
+        .innerJoin(issues, eq(decisionTrainingExamples.issueId, issues.id))
+        .where(and(...filters))
+        .orderBy(desc(decisionTrainingExamples.createdAt), desc(decisionTrainingExamples.id));
+    },
+    getById: async (id: string) => db.query.decisionTrainingExamples.findFirst({
+      where: eq(decisionTrainingExamples.id, id),
+    }),
+    updateNotes: async (id: string, author: string, notes: string) => db.transaction(async (tx) => {
+      const row = await tx.query.decisionTrainingExamples.findFirst({
+        where: eq(decisionTrainingExamples.id, id),
+      });
+      if (!row) return null;
+      const history: DecisionTrainingNotesHistoryEntry[] = [
+        ...(row.notesHistory ?? []),
+        { author, at: new Date().toISOString(), body: row.notes },
+      ];
+      const [updated] = await tx
+        .update(decisionTrainingExamples)
+        .set({ notes, notesHistory: history, updatedAt: new Date() })
+        .where(eq(decisionTrainingExamples.id, id))
+        .returning();
+      return updated ?? null;
+    }),
+    delete: async (id: string) => db
+      .delete(decisionTrainingExamples)
+      .where(eq(decisionTrainingExamples.id, id))
+      .returning({ id: decisionTrainingExamples.id }),
+  };
+}

--- a/server/src/services/decision-training.ts
+++ b/server/src/services/decision-training.ts
@@ -259,7 +259,7 @@ export function decisionTrainingService(db: Db) {
   return {
     // Capture the snapshot the way create() would, but without persisting it, so
     // the drawer's create state can preview exactly what will be frozen before
-    // the user commits (PAP-14299).
+    // the user commits.
     preview: async (input: CaptureInput) => captureDecisionSnapshot(db, input),
     create: async (input: CaptureInput & { notes: string; createdByUserId: string }) => {
       const captured = await captureDecisionSnapshot(db, input);

--- a/server/src/services/index.ts
+++ b/server/src/services/index.ts
@@ -61,6 +61,7 @@ export { goalService } from "./goals.js";
 export { activityService, type ActivityFilters } from "./activity.js";
 export { workTimelineService, normalizeTimelineWindow } from "./work-timeline.js";
 export { attentionService } from "./attention.js";
+export { captureDecisionSnapshot, decisionTrainingService } from "./decision-training.js";
 export type {
   WorkTimelineActor,
   WorkTimelineEdge,

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -39,6 +39,7 @@ import { Costs } from "./pages/Costs";
 import { Activity } from "./pages/Activity";
 import { Inbox } from "./pages/Inbox";
 import { WhatNeedsMe } from "./pages/WhatNeedsMe";
+import { TrainingInspector, TrainingLibrary } from "./pages/Training";
 import { BoardChat } from "./pages/BoardChat";
 import { CompanySettings } from "./pages/CompanySettings";
 import { CompanyEnvironments } from "./pages/CompanyEnvironments";
@@ -255,6 +256,8 @@ function boardRoutes() {
         <Route path="artifacts" element={<Artifacts />} />
       </Route>
       <Route path="decisions" element={<WhatNeedsMe />} />
+      <Route path="training" element={<TrainingLibrary />} />
+      <Route path="training/:id" element={<TrainingInspector />} />
       <Route path="inbox" element={<InboxRootRedirect />} />
       <Route path="inbox/mine" element={<Inbox />} />
       <Route path="inbox/recent" element={<Inbox />} />

--- a/ui/src/api/decisionTraining.ts
+++ b/ui/src/api/decisionTraining.ts
@@ -42,7 +42,7 @@ export const decisionTrainingApi = {
     api.get<DecisionTrainingExample>(`/decision-training/${id}`, options),
   /**
    * Preview the state a new example would freeze, without persisting it. Powers
-   * the create drawer's "state frozen with this example" panel (PAP-14299).
+   * the create drawer's "state frozen with this example" panel.
    */
   preview: (companyId: string, target: DecisionTrainingTarget) =>
     api.post<DecisionTrainingPreview>(`/companies/${companyId}/decision-training/preview`, target),

--- a/ui/src/api/decisionTraining.ts
+++ b/ui/src/api/decisionTraining.ts
@@ -1,0 +1,54 @@
+import type {
+  DecisionTrainingExample,
+  DecisionTrainingPreview,
+  DecisionTrainingSourceKind,
+} from "@paperclipai/shared";
+import { api, type RequestOptions } from "./client";
+
+export interface DecisionTrainingListItem {
+  example: DecisionTrainingExample;
+  issueTitle: string;
+  issueIdentifier: string;
+}
+
+export interface DecisionTrainingFilters {
+  project?: string;
+  kind?: DecisionTrainingSourceKind;
+  author?: string;
+  q?: string;
+}
+
+/** The durable (source + issue) target a training example anchors to. */
+export interface DecisionTrainingTarget {
+  sourceKind: DecisionTrainingSourceKind;
+  sourceId: string;
+  issueId: string;
+}
+
+export const decisionTrainingApi = {
+  list: (companyId: string, filters: DecisionTrainingFilters = {}, options?: RequestOptions) => {
+    const params = new URLSearchParams();
+    if (filters.project) params.set("project", filters.project);
+    if (filters.kind) params.set("kind", filters.kind);
+    if (filters.author) params.set("author", filters.author);
+    if (filters.q) params.set("q", filters.q);
+    const query = params.toString();
+    return api.get<DecisionTrainingListItem[]>(
+      `/companies/${companyId}/decision-training${query ? `?${query}` : ""}`,
+      options,
+    );
+  },
+  get: (id: string, options?: RequestOptions) =>
+    api.get<DecisionTrainingExample>(`/decision-training/${id}`, options),
+  /**
+   * Preview the state a new example would freeze, without persisting it. Powers
+   * the create drawer's "state frozen with this example" panel (PAP-14299).
+   */
+  preview: (companyId: string, target: DecisionTrainingTarget) =>
+    api.post<DecisionTrainingPreview>(`/companies/${companyId}/decision-training/preview`, target),
+  create: (companyId: string, input: DecisionTrainingTarget & { notes: string }) =>
+    api.post<DecisionTrainingExample>(`/companies/${companyId}/decision-training`, input),
+  updateNotes: (id: string, notes: string) =>
+    api.patch<DecisionTrainingExample>(`/decision-training/${id}`, { notes }),
+  delete: (id: string) => api.delete<void>(`/decision-training/${id}`),
+};

--- a/ui/src/components/AttentionQueueRow.test.tsx
+++ b/ui/src/components/AttentionQueueRow.test.tsx
@@ -113,6 +113,7 @@ function buildItem(overrides: Partial<AttentionItem> = {}): AttentionItem {
     detail: null,
     dismissal: null,
     ...overrides,
+    trainingExampleId: overrides.trainingExampleId ?? null,
   };
 }
 

--- a/ui/src/components/AttentionQueueRow.test.tsx
+++ b/ui/src/components/AttentionQueueRow.test.tsx
@@ -616,4 +616,75 @@ describe("AttentionQueueRow", () => {
     expect(gallery?.textContent).toContain("1 more");
     expect(gallery?.querySelectorAll("a")).toHaveLength(0);
   });
+
+  // Decision training (PAP-14299): a trainable row shows the train affordance;
+  // the trained/untrained state renders purely from `trainingExampleId`.
+  function trainableItem(overrides: Partial<AttentionItem> = {}): AttentionItem {
+    return buildItem({
+      sourceKind: "issue_thread_interaction",
+      subject: {
+        kind: "interaction",
+        id: "interaction-1",
+        companyId: "c1",
+        title: "Approve the migration plan?",
+        identifier: null,
+        status: "pending",
+        href: "/PAP/issues/PAP-1",
+        metadata: { issueId: "issue-1", kind: "request_confirmation" },
+      },
+      ...overrides,
+    });
+  }
+
+  it("shows an untrained train button and fires onTrain when clicked", () => {
+    const onTrain = vi.fn();
+    render(
+      <AttentionQueueRow
+        item={trainableItem()}
+        companyId="c1"
+        expanded={false}
+        onToggleExpand={noop}
+        onDismiss={noop}
+        onTrain={onTrain}
+      />,
+    );
+    const button = container?.querySelector('[data-testid="attention-train-button"]');
+    expect(button).toBeTruthy();
+    expect(button?.getAttribute("data-training-state")).toBe("untrained");
+    expect(container?.querySelector('[data-testid="attention-trained-badge"]')).toBeNull();
+    act(() => button?.dispatchEvent(new MouseEvent("click", { bubbles: true })));
+    expect(onTrain).toHaveBeenCalledWith(expect.objectContaining({ id: "a1" }));
+  });
+
+  it("renders a Trained ✓ badge and a filled button once trained", () => {
+    render(
+      <AttentionQueueRow
+        item={trainableItem({ trainingExampleId: "example-1" })}
+        companyId="c1"
+        expanded={false}
+        onToggleExpand={noop}
+        onDismiss={noop}
+        onTrain={noop}
+      />,
+    );
+    expect(
+      container?.querySelector('[data-testid="attention-train-button"]')?.getAttribute("data-training-state"),
+    ).toBe("trained");
+    const badge = container?.querySelector('[data-testid="attention-trained-badge"]');
+    expect(badge?.textContent).toContain("Trained");
+  });
+
+  it("does not offer training on a decision that isn't anchored to an issue", () => {
+    render(
+      <AttentionQueueRow
+        item={buildItem({ subject: { ...buildItem().subject, metadata: {} }, relatedIssue: null })}
+        companyId="c1"
+        expanded={false}
+        onToggleExpand={noop}
+        onDismiss={noop}
+        onTrain={noop}
+      />,
+    );
+    expect(container?.querySelector('[data-testid="attention-train-button"]')).toBeNull();
+  });
 });

--- a/ui/src/components/AttentionQueueRow.tsx
+++ b/ui/src/components/AttentionQueueRow.tsx
@@ -5,6 +5,7 @@ import {
   ChevronDown,
   ChevronRight,
   ExternalLink,
+  GraduationCap,
   Loader2,
   MoreHorizontal,
   RotateCcw,
@@ -26,6 +27,7 @@ import {
   severityBadge,
   sourceMeta,
 } from "../lib/attention";
+import { isTrainable } from "../lib/decisionTraining";
 import { cn, relativeTime } from "../lib/utils";
 import { Button } from "./ui/button";
 import { Textarea } from "./ui/textarea";
@@ -75,6 +77,8 @@ interface AttentionQueueRowProps {
   onToggleExpand: (item: AttentionItem) => void;
   onDismiss: (item: AttentionItem) => void;
   onSnooze?: (item: AttentionItem, snoozedUntil: string) => void;
+  /** Open the decision-training drawer for this row (create or view). */
+  onTrain?: (item: AttentionItem) => void;
   /** Restore a snoozed/dismissed row (curtain variant only). */
   onRestore?: (item: AttentionItem) => void;
   /** "active" renders the live queue row; "hidden" renders a curtain row. */
@@ -99,6 +103,7 @@ export const AttentionQueueRow = memo(function AttentionQueueRow({
   onToggleExpand,
   onDismiss,
   onSnooze,
+  onTrain,
   onRestore,
   variant = "active",
   agentMap,
@@ -125,6 +130,11 @@ export const AttentionQueueRow = memo(function AttentionQueueRow({
   // header/thumbnail click somewhere to go. Non-inline, image-less rows keep the
   // explicit Open button and never toggle on a stray click.
   const expandable = inline || (!isHidden && hasImages);
+  // Decision training (PAP-14299): any issue-anchored approval or interaction is
+  // trainable at any time (pending or resolved). Trained/untrained renders
+  // purely from the feed's `trainingExampleId` — no per-row fetch.
+  const trainable = !isHidden && !!onTrain && isTrainable(item);
+  const trained = item.trainingExampleId != null;
 
   const activate = () => {
     if (expandable) onToggleExpand(item);
@@ -218,6 +228,25 @@ export const AttentionQueueRow = memo(function AttentionQueueRow({
             </div>
 
             <div className="flex shrink-0 items-center gap-1" data-attention-menu="true">
+              {trainable && (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon-xs"
+                  className={cn(trained ? "text-primary" : "text-muted-foreground")}
+                  aria-label={trained ? "View training example" : "Train this decision"}
+                  aria-pressed={trained}
+                  title={trained ? "Trained — view example" : "Train this decision"}
+                  data-training-state={trained ? "trained" : "untrained"}
+                  data-testid="attention-train-button"
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    onTrain?.(item);
+                  }}
+                >
+                  <GraduationCap className={cn("h-4 w-4", trained && "fill-primary/25")} />
+                </Button>
+              )}
               {isHidden && snoozedUntil ? (
                 <span
                   className="text-(length:--text-nano) text-muted-foreground"
@@ -286,9 +315,23 @@ export const AttentionQueueRow = memo(function AttentionQueueRow({
 
           {/* Context row: project identity and evidence thumbnails move below the
               text so they never squeeze the headline on mobile. */}
-          {(item.project || (hasImages && !expanded)) && (
+          {(item.project || (hasImages && !expanded) || (trainable && trained)) && (
             <div className="flex flex-wrap items-center gap-x-3 gap-y-2">
               {item.project && <ProjectMeta project={item.project} />}
+              {trainable && trained && (
+                <button
+                  type="button"
+                  className="inline-flex items-center gap-1 rounded-sm border border-primary/30 bg-primary/10 px-1.5 py-px text-(length:--text-nano) font-medium text-primary hover:bg-primary/15"
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    onTrain?.(item);
+                  }}
+                  data-testid="attention-trained-badge"
+                >
+                  <GraduationCap className="h-3 w-3 fill-primary/25" />
+                  Trained ✓
+                </button>
+              )}
               {hasImages && !expanded && <ThumbnailStack images={images} />}
             </div>
           )}

--- a/ui/src/components/AttentionQueueRow.tsx
+++ b/ui/src/components/AttentionQueueRow.tsx
@@ -130,7 +130,7 @@ export const AttentionQueueRow = memo(function AttentionQueueRow({
   // header/thumbnail click somewhere to go. Non-inline, image-less rows keep the
   // explicit Open button and never toggle on a stray click.
   const expandable = inline || (!isHidden && hasImages);
-  // Decision training (PAP-14299): any issue-anchored approval or interaction is
+  // Any issue-anchored approval or interaction is
   // trainable at any time (pending or resolved). Trained/untrained renders
   // purely from the feed's `trainingExampleId` — no per-row fetch.
   const trainable = !isHidden && !!onTrain && isTrainable(item);

--- a/ui/src/components/DecisionTrainingDrawer.test.tsx
+++ b/ui/src/components/DecisionTrainingDrawer.test.tsx
@@ -1,0 +1,284 @@
+// @vitest-environment jsdom
+
+import { flushSync } from "react-dom";
+import { createRoot } from "react-dom/client";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type {
+  AttentionItem,
+  DecisionTrainingExample,
+  DecisionTrainingPreview,
+} from "@paperclipai/shared";
+
+const mockApi = vi.hoisted(() => ({
+  preview: vi.fn(),
+  create: vi.fn(),
+  get: vi.fn(),
+  updateNotes: vi.fn(),
+  delete: vi.fn(),
+}));
+
+vi.mock("../api/decisionTraining", async (importOriginal) => {
+  const original = await importOriginal<typeof import("../api/decisionTraining")>();
+  return { ...original, decisionTrainingApi: mockApi };
+});
+
+vi.mock("@/lib/router", () => ({
+  Link: ({ children, to, ...props }: React.ComponentProps<"a"> & { to: string }) => (
+    <a href={to} {...props}>{children}</a>
+  ),
+}));
+
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+import { DecisionTrainingDrawer } from "./DecisionTrainingDrawer";
+import { ToastProvider } from "../context/ToastContext";
+
+function act(callback: () => void | Promise<void>) {
+  let result: void | Promise<void> | undefined;
+  flushSync(() => {
+    result = callback();
+  });
+  return result;
+}
+
+async function waitFor(predicate: () => boolean, attempts = 40): Promise<void> {
+  for (let i = 0; i < attempts; i += 1) {
+    if (predicate()) return;
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 5));
+    });
+  }
+  throw new Error("waitFor predicate did not become true");
+}
+
+function setTextareaValue(el: HTMLTextAreaElement, value: string) {
+  const setter = Object.getOwnPropertyDescriptor(window.HTMLTextAreaElement.prototype, "value")!.set!;
+  setter.call(el, value);
+  el.dispatchEvent(new Event("input", { bubbles: true }));
+}
+
+/** Text query across the whole document (Radix portals content into body). */
+function bodyText(): string {
+  return document.body.textContent ?? "";
+}
+
+function findButton(label: string): HTMLButtonElement | null {
+  return [...document.body.querySelectorAll("button")].find(
+    (b) => (b.textContent ?? "").trim().includes(label),
+  ) as HTMLButtonElement | null;
+}
+
+/** Buttons or anchors (asChild renders the trigger as its child element). */
+function findClickable(label: string): HTMLElement | null {
+  return [...document.body.querySelectorAll("button, a")].find(
+    (el) => (el.textContent ?? "").trim().includes(label),
+  ) as HTMLElement | null;
+}
+
+function buildItem(overrides: Partial<AttentionItem> = {}): AttentionItem {
+  return {
+    id: "row-1",
+    companyId: "c1",
+    sourceKind: "issue_thread_interaction",
+    subject: {
+      kind: "interaction",
+      id: "interaction-1",
+      companyId: "c1",
+      title: "Approve the migration plan?",
+      identifier: null,
+      status: "pending",
+      href: "/tasks/task-1",
+      metadata: { issueId: "issue-1", kind: "request_confirmation" },
+    },
+    whyNow: "",
+    decisionVerbs: [],
+    inlineResolvable: true,
+    entryRule: "",
+    exitRule: "",
+    dedupKey: "interaction:interaction-1",
+    dismissalKey: "attention:interaction:interaction-1",
+    severity: "medium",
+    rank: 0,
+    activityAt: "2026-07-09T12:00:00Z",
+    createdAt: "2026-07-09T12:00:00Z",
+    updatedAt: "2026-07-09T12:00:00Z",
+    relatedIssue: null,
+    project: null,
+    workspace: null,
+    detail: null,
+    dismissal: null,
+    trainingExampleId: null,
+    ...overrides,
+  };
+}
+
+function buildSnapshot(): DecisionTrainingExample["snapshot"] {
+  return {
+    version: 1,
+    capturedAt: "2026-07-10T00:00:00Z",
+    cutoff: { at: "2026-07-10T00:00:00Z", lastCommentId: "comment-abcdef12", commentCount: 3 },
+    issue: {},
+    comments: [{}, {}, {}],
+    runs: [{}, {}],
+    decision: { kind: "interaction", payload: {}, actor: null, outcome: "accepted" },
+    code: { repoUrl: "r", ref: "main", commitSha: "0123456789abcdef", resolution: "exact" },
+  };
+}
+
+function buildPreview(): DecisionTrainingPreview {
+  return { cutoffAt: "2026-07-10T00:00:00Z", decisionOutcome: "accepted", snapshot: buildSnapshot() };
+}
+
+function buildExample(overrides: Partial<DecisionTrainingExample> = {}): DecisionTrainingExample {
+  return {
+    id: "example-1",
+    companyId: "c1",
+    sourceKind: "interaction",
+    sourceId: "interaction-1",
+    issueId: "issue-1",
+    cutoffAt: "2026-07-10T00:00:00Z",
+    notes: "I accepted because the plan covered rollback.",
+    notesHistory: [],
+    decisionOutcome: "accepted",
+    snapshot: buildSnapshot(),
+    createdByUserId: "user-1",
+    createdAt: "2026-07-10T00:00:00Z",
+    updatedAt: "2026-07-10T00:00:00Z",
+    ...overrides,
+  };
+}
+
+let container: HTMLDivElement;
+let root: ReturnType<typeof createRoot>;
+
+function render(node: React.ReactNode) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, staleTime: 0, gcTime: 0 } },
+  });
+  root = createRoot(container);
+  act(() => {
+    root.render(
+      <ToastProvider>
+        <QueryClientProvider client={queryClient}>{node}</QueryClientProvider>
+      </ToastProvider>,
+    );
+  });
+}
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  Object.values(mockApi).forEach((fn) => fn.mockReset());
+});
+
+afterEach(() => {
+  act(() => root?.unmount());
+  container.remove();
+  document.body.innerHTML = "";
+});
+
+describe("DecisionTrainingDrawer — create state", () => {
+  it("previews the frozen snapshot and saves an example", async () => {
+    mockApi.preview.mockResolvedValue(buildPreview());
+    mockApi.create.mockResolvedValue(buildExample());
+
+    render(
+      <DecisionTrainingDrawer open onOpenChange={() => {}} companyId="c1" item={buildItem()} />,
+    );
+
+    await waitFor(() => bodyText().includes("before cutoff"));
+
+    // Snapshot preview surfaces cutoff, comment/run counts and the commit.
+    expect(bodyText()).toContain("3 · last comment-");
+    expect(bodyText()).toContain("2 before cutoff");
+    expect(bodyText()).toContain("0123456789");
+    expect(bodyText()).toContain("Resolved · accepted");
+
+    const textarea = document.body.querySelector("textarea") as HTMLTextAreaElement;
+    expect(textarea).toBeTruthy();
+    act(() => setTextareaValue(textarea, "Trusting the rollback plan."));
+
+    await act(() => findButton("Save example")?.click());
+    await waitFor(() => mockApi.create.mock.calls.length > 0);
+
+    expect(mockApi.create).toHaveBeenCalledWith("c1", {
+      sourceKind: "interaction",
+      sourceId: "interaction-1",
+      issueId: "issue-1",
+      notes: "Trusting the rollback plan.",
+    });
+  });
+
+  it("refuses to train a decision with no issue anchor", () => {
+    const item = buildItem({ subject: { ...buildItem().subject, metadata: {} }, relatedIssue: null });
+    render(<DecisionTrainingDrawer open onOpenChange={() => {}} companyId="c1" item={item} />);
+    expect(bodyText()).toContain("isn't anchored to an issue");
+    expect(mockApi.preview).not.toHaveBeenCalled();
+  });
+});
+
+describe("DecisionTrainingDrawer — saved state", () => {
+  it("shows provenance and a read-only snapshot, and round-trips notes edits", async () => {
+    mockApi.get.mockResolvedValue(buildExample());
+    mockApi.updateNotes.mockResolvedValue(buildExample({ notes: "Revised reasoning.", updatedAt: "2026-07-11T00:00:00Z" }));
+
+    render(
+      <DecisionTrainingDrawer
+        open
+        onOpenChange={() => {}}
+        companyId="c1"
+        item={buildItem({ trainingExampleId: "example-1" })}
+        currentUserId="user-1"
+      />,
+    );
+
+    await waitFor(() => bodyText().includes("Frozen state"));
+    expect(bodyText()).toContain("You"); // provenance author
+    expect(bodyText()).toContain("Read-only"); // snapshot is visibly read-only
+    expect(bodyText()).toContain("I accepted because the plan covered rollback.");
+    expect(findClickable("Open full record")).toBeTruthy();
+
+    await act(() => findButton("Edit")?.click());
+    const textarea = document.body.querySelector("textarea") as HTMLTextAreaElement;
+    expect(textarea).toBeTruthy();
+    act(() => setTextareaValue(textarea, "Revised reasoning."));
+    await act(() => findButton("Save notes")?.click());
+    await waitFor(() => mockApi.updateNotes.mock.calls.length > 0);
+
+    expect(mockApi.updateNotes).toHaveBeenCalledWith("example-1", "Revised reasoning.");
+  });
+
+  it("deletes after confirmation", async () => {
+    mockApi.get.mockResolvedValue(buildExample());
+    mockApi.delete.mockResolvedValue(undefined);
+    const onOpenChange = vi.fn();
+
+    render(
+      <DecisionTrainingDrawer
+        open
+        onOpenChange={onOpenChange}
+        companyId="c1"
+        item={buildItem({ trainingExampleId: "example-1" })}
+        currentUserId="user-1"
+      />,
+    );
+
+    await waitFor(() => bodyText().includes("Frozen state"));
+    await act(() => {
+      findButton("Delete")?.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+    });
+    // Confirm dialog action.
+    await waitFor(() => bodyText().includes("Delete this training example?"));
+    const confirm = document.body.querySelector<HTMLButtonElement>(
+      '[data-slot="alert-dialog-action"]',
+    );
+    expect(confirm).toBeTruthy();
+    await act(() => {
+      confirm?.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+    });
+    await waitFor(() => mockApi.delete.mock.calls.length > 0);
+
+    expect(mockApi.delete).toHaveBeenCalledWith("example-1");
+  });
+});

--- a/ui/src/components/DecisionTrainingDrawer.tsx
+++ b/ui/src/components/DecisionTrainingDrawer.tsx
@@ -1,0 +1,517 @@
+import { useEffect, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  Clock,
+  ExternalLink,
+  FileText,
+  GitCommitHorizontal,
+  GraduationCap,
+  Loader2,
+  Lock,
+  MessageSquare,
+  Pencil,
+  Play,
+  Trash2,
+} from "lucide-react";
+import type { AttentionItem, DecisionTrainingExample } from "@paperclipai/shared";
+import { Link } from "@/lib/router";
+import { decisionTrainingApi, type DecisionTrainingTarget } from "../api/decisionTraining";
+import { useToastActions } from "../context/ToastContext";
+import { queryKeys } from "../lib/queryKeys";
+import { codeResolutionLabel, trainingTargetForItem } from "../lib/decisionTraining";
+import { relativeTime } from "../lib/utils";
+import { Button } from "./ui/button";
+import { Textarea } from "./ui/textarea";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "./ui/sheet";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "./ui/alert-dialog";
+
+const NOTES_PLACEHOLDER =
+  "How you thought about it, what signals mattered, what you decided and why…";
+
+interface DecisionTrainingDrawerProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  companyId: string;
+  /** The Decisions row being trained; null when the drawer is closed. */
+  item: AttentionItem | null;
+  currentUserId?: string | null;
+}
+
+/**
+ * Right-hand drawer for capturing a decision-training example from a Decisions
+ * row (PAP-14299). Renders a create state (immutable snapshot preview + notes)
+ * for untrained decisions and a saved state (provenance, editable notes,
+ * read-only snapshot, delete) once an example exists. Write affordances are
+ * only ever mounted for human users — agents never see this drawer.
+ */
+export function DecisionTrainingDrawer({
+  open,
+  onOpenChange,
+  companyId,
+  item,
+  currentUserId,
+}: DecisionTrainingDrawerProps) {
+  // Track the example id locally so a successful create flips the same drawer
+  // instance from create → saved without waiting for the feed to refetch.
+  const [savedExampleId, setSavedExampleId] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (open) setSavedExampleId(item?.trainingExampleId ?? null);
+  }, [open, item?.trainingExampleId, item?.id]);
+
+  const target = item ? trainingTargetForItem(item) : null;
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent
+        className="w-full gap-0 p-0 sm:max-w-lg"
+        data-testid="decision-training-drawer"
+      >
+        <SheetHeader className="border-b border-border">
+          <SheetTitle className="flex items-center gap-2">
+            <GraduationCap className="size-4 text-muted-foreground" />
+            {savedExampleId ? "Training example" : "Train this decision"}
+          </SheetTitle>
+          <SheetDescription>
+            {savedExampleId
+              ? "The frozen state is read-only; your notes stay editable."
+              : "Freeze this decision's state and record how you'd want it decided."}
+          </SheetDescription>
+        </SheetHeader>
+
+        {!item || !target ? (
+          <div className="p-4 text-sm text-muted-foreground">
+            This decision can't be trained — it isn't anchored to an issue.
+          </div>
+        ) : savedExampleId ? (
+          <SavedState
+            exampleId={savedExampleId}
+            companyId={companyId}
+            currentUserId={currentUserId}
+            onDeleted={() => onOpenChange(false)}
+          />
+        ) : (
+          <CreateState
+            companyId={companyId}
+            item={item}
+            target={target}
+            onCreated={(example) => setSavedExampleId(example.id)}
+            onCancel={() => onOpenChange(false)}
+          />
+        )}
+      </SheetContent>
+    </Sheet>
+  );
+}
+
+function CreateState({
+  companyId,
+  item,
+  target,
+  onCreated,
+  onCancel,
+}: {
+  companyId: string;
+  item: AttentionItem;
+  target: DecisionTrainingTarget;
+  onCreated: (example: DecisionTrainingExample) => void;
+  onCancel: () => void;
+}) {
+  const queryClient = useQueryClient();
+  const { pushToast } = useToastActions();
+  const [notes, setNotes] = useState("");
+
+  const preview = useQuery({
+    queryKey: [...queryKeys.decisionTraining.list(companyId), "preview", target.sourceKind, target.sourceId],
+    queryFn: () => decisionTrainingApi.preview(companyId, target),
+    enabled: true,
+  });
+
+  const create = useMutation({
+    mutationFn: () => decisionTrainingApi.create(companyId, { ...target, notes: notes.trim() }),
+    onSuccess: (example) => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.attention(companyId) });
+      queryClient.invalidateQueries({ queryKey: queryKeys.decisionTraining.list(companyId) });
+      pushToast({ title: "Decision trained", tone: "success" });
+      onCreated(example);
+    },
+    onError: (error) => {
+      pushToast({
+        title: "Could not train this decision",
+        body: error instanceof Error ? error.message : "Please try again.",
+        tone: "error",
+      });
+    },
+  });
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <div className="min-h-0 flex-1 space-y-5 overflow-y-auto p-4">
+        <DecisionContext item={item} outcome={preview.data?.decisionOutcome ?? null} />
+
+        <section className="space-y-2">
+          <label htmlFor="training-notes" className="text-sm font-medium text-foreground">
+            Your notes
+          </label>
+          <Textarea
+            id="training-notes"
+            value={notes}
+            onChange={(event) => setNotes(event.target.value)}
+            placeholder={NOTES_PLACEHOLDER}
+            className="min-h-40 text-sm"
+          />
+        </section>
+
+        <SnapshotPreview
+          heading="State frozen with this example"
+          snapshot={preview.data?.snapshot ?? null}
+          cutoffAt={preview.data?.cutoffAt ?? null}
+          loading={preview.isLoading}
+          error={preview.isError ? (preview.error as Error).message : null}
+        />
+      </div>
+
+      <div className="flex items-center justify-end gap-2 border-t border-border p-4">
+        <Button variant="ghost" onClick={onCancel} disabled={create.isPending}>
+          Cancel
+        </Button>
+        <Button onClick={() => create.mutate()} disabled={create.isPending || preview.isError}>
+          {create.isPending && <Loader2 className="size-4 animate-spin" />}
+          Save example
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function SavedState({
+  exampleId,
+  companyId,
+  currentUserId,
+  onDeleted,
+}: {
+  exampleId: string;
+  companyId: string;
+  currentUserId?: string | null;
+  onDeleted: () => void;
+}) {
+  const queryClient = useQueryClient();
+  const { pushToast } = useToastActions();
+  const [editing, setEditing] = useState(false);
+  const [draftNotes, setDraftNotes] = useState("");
+
+  const example = useQuery({
+    queryKey: queryKeys.decisionTraining.detail(exampleId),
+    queryFn: () => decisionTrainingApi.get(exampleId),
+  });
+
+  const saveNotes = useMutation({
+    mutationFn: () => decisionTrainingApi.updateNotes(exampleId, draftNotes.trim()),
+    onSuccess: (updated) => {
+      queryClient.setQueryData(queryKeys.decisionTraining.detail(exampleId), updated);
+      queryClient.invalidateQueries({ queryKey: queryKeys.decisionTraining.list(companyId) });
+      pushToast({ title: "Notes updated", tone: "success" });
+      setEditing(false);
+    },
+    onError: (error) => {
+      pushToast({
+        title: "Could not update notes",
+        body: error instanceof Error ? error.message : "Please try again.",
+        tone: "error",
+      });
+    },
+  });
+
+  const remove = useMutation({
+    mutationFn: () => decisionTrainingApi.delete(exampleId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.attention(companyId) });
+      queryClient.invalidateQueries({ queryKey: queryKeys.decisionTraining.list(companyId) });
+      pushToast({ title: "Training example deleted", tone: "info" });
+      onDeleted();
+    },
+    onError: (error) => {
+      pushToast({
+        title: "Could not delete example",
+        body: error instanceof Error ? error.message : "Please try again.",
+        tone: "error",
+      });
+    },
+  });
+
+  if (example.isLoading) {
+    return (
+      <div className="flex flex-1 items-center justify-center p-4 text-sm text-muted-foreground">
+        <Loader2 className="mr-2 size-4 animate-spin" /> Loading example…
+      </div>
+    );
+  }
+  if (example.isError || !example.data) {
+    return (
+      <div className="p-4 text-sm text-destructive">
+        {example.isError ? (example.error as Error).message : "Example not found."}
+      </div>
+    );
+  }
+
+  const record = example.data;
+  const edited = record.updatedAt !== record.createdAt;
+  const authorLabel = currentUserId && record.createdByUserId === currentUserId
+    ? "You"
+    : `User ${record.createdByUserId.slice(0, 8)}`;
+
+  const startEditing = () => {
+    setDraftNotes(record.notes);
+    setEditing(true);
+  };
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <div className="min-h-0 flex-1 space-y-5 overflow-y-auto p-4">
+        {/* Provenance strip */}
+        <div
+          className="flex flex-wrap items-center gap-x-3 gap-y-1 rounded-md border border-border bg-muted/30 px-3 py-2 text-xs text-muted-foreground"
+          data-testid="training-provenance"
+        >
+          <span className="font-medium text-foreground">{authorLabel}</span>
+          <span>·</span>
+          <span title={new Date(record.createdAt).toLocaleString()}>
+            Created {relativeTime(record.createdAt)}
+          </span>
+          {edited && (
+            <>
+              <span>·</span>
+              <span title={new Date(record.updatedAt).toLocaleString()}>
+                Edited {relativeTime(record.updatedAt)}
+              </span>
+            </>
+          )}
+        </div>
+
+        {/* Notes — the one editable surface */}
+        <section className="space-y-2">
+          <div className="flex items-center justify-between">
+            <span className="text-sm font-medium text-foreground">Notes</span>
+            {!editing && (
+              <Button variant="ghost" size="xs" onClick={startEditing}>
+                <Pencil className="size-3.5" /> Edit
+              </Button>
+            )}
+          </div>
+          {editing ? (
+            <div className="space-y-2">
+              <Textarea
+                value={draftNotes}
+                onChange={(event) => setDraftNotes(event.target.value)}
+                placeholder={NOTES_PLACEHOLDER}
+                className="min-h-40 text-sm"
+              />
+              <div className="flex justify-end gap-2">
+                <Button variant="ghost" size="sm" onClick={() => setEditing(false)} disabled={saveNotes.isPending}>
+                  Cancel
+                </Button>
+                <Button size="sm" onClick={() => saveNotes.mutate()} disabled={saveNotes.isPending}>
+                  {saveNotes.isPending && <Loader2 className="size-4 animate-spin" />}
+                  Save notes
+                </Button>
+              </div>
+            </div>
+          ) : record.notes ? (
+            <p className="whitespace-pre-wrap text-sm text-foreground">{record.notes}</p>
+          ) : (
+            <p className="text-sm italic text-muted-foreground">No notes yet.</p>
+          )}
+          {record.notesHistory.length > 0 && (
+            <p className="text-(length:--text-nano) text-muted-foreground">
+              {record.notesHistory.length} previous {record.notesHistory.length === 1 ? "revision" : "revisions"}
+            </p>
+          )}
+        </section>
+
+        <SnapshotPreview
+          heading="Frozen state"
+          snapshot={record.snapshot}
+          cutoffAt={record.cutoffAt}
+          readOnly
+          exampleId={record.id}
+        />
+      </div>
+
+      <div className="flex items-center justify-between gap-2 border-t border-border p-4">
+        <AlertDialog>
+          <AlertDialogTrigger asChild>
+            <Button variant="ghost" size="sm" className="text-destructive hover:text-destructive" disabled={remove.isPending}>
+              {remove.isPending ? <Loader2 className="size-4 animate-spin" /> : <Trash2 className="size-4" />}
+              Delete
+            </Button>
+          </AlertDialogTrigger>
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>Delete this training example?</AlertDialogTitle>
+              <AlertDialogDescription>
+                This removes the frozen snapshot and your notes. This can't be undone.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel>Cancel</AlertDialogCancel>
+              <AlertDialogAction
+                className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                onClick={() => remove.mutate()}
+              >
+                Delete
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
+
+        <Button asChild variant="outline" size="sm">
+          <Link to={`/training/${record.id}`}>
+            Open full record
+            <ExternalLink className="size-3.5" />
+          </Link>
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+/** Decision context block — what was decided (or that it's still pending). */
+function DecisionContext({ item, outcome }: { item: AttentionItem; outcome: string | null }) {
+  return (
+    <section className="space-y-1 rounded-md border border-border bg-muted/30 px-3 py-2" data-testid="training-context">
+      <p className="text-(length:--text-nano) font-medium uppercase tracking-(--tracking-eyebrow) text-muted-foreground">
+        Decision
+      </p>
+      <p className="line-clamp-2 text-sm font-medium text-foreground">{item.subject.title ?? "Decision"}</p>
+      <p className="text-xs text-muted-foreground">
+        {outcome ? `Resolved · ${outcome}` : "Decision pending — cutoff will be now"}
+      </p>
+    </section>
+  );
+}
+
+/**
+ * Read-only preview of the captured snapshot. Shared by the create state (from
+ * the preview endpoint) and the saved state (from the persisted example). In the
+ * saved state it renders a visible read-only banner and per-section view links.
+ */
+function SnapshotPreview({
+  heading,
+  snapshot,
+  cutoffAt,
+  loading = false,
+  error = null,
+  readOnly = false,
+  exampleId,
+}: {
+  heading: string;
+  snapshot: DecisionTrainingExample["snapshot"] | null;
+  cutoffAt: string | null;
+  loading?: boolean;
+  error?: string | null;
+  readOnly?: boolean;
+  exampleId?: string;
+}) {
+  return (
+    <section className="space-y-2" data-testid="training-snapshot">
+      <div className="flex items-center justify-between">
+        <span className="text-sm font-medium text-foreground">{heading}</span>
+        {readOnly && (
+          <span className="inline-flex items-center gap-1 text-(length:--text-nano) uppercase tracking-(--tracking-eyebrow) text-muted-foreground">
+            <Lock className="size-3" /> Read-only
+          </span>
+        )}
+      </div>
+
+      {loading && (
+        <p className="flex items-center gap-2 text-sm text-muted-foreground">
+          <Loader2 className="size-4 animate-spin" /> Capturing current state…
+        </p>
+      )}
+      {error && <p className="text-sm text-destructive">{error}</p>}
+
+      {snapshot && (
+        <div className="divide-y divide-border rounded-md border border-border">
+          <SnapshotRow
+            icon={<Clock className="size-4" />}
+            label="Cutoff"
+            value={cutoffAt ? new Date(cutoffAt).toLocaleString() : "now"}
+            href={exampleId ? `/training/${exampleId}` : undefined}
+          />
+          <SnapshotRow
+            icon={<MessageSquare className="size-4" />}
+            label="Comments"
+            value={
+              snapshot.cutoff.commentCount === 0
+                ? "None before cutoff"
+                : `${snapshot.cutoff.commentCount} · last ${snapshot.cutoff.lastCommentId?.slice(0, 8) ?? "—"}`
+            }
+            href={exampleId ? `/training/${exampleId}` : undefined}
+          />
+          <SnapshotRow
+            icon={<Play className="size-4" />}
+            label="Runs"
+            value={snapshot.runs.length === 0 ? "None before cutoff" : `${snapshot.runs.length} before cutoff`}
+            href={exampleId ? `/training/${exampleId}` : undefined}
+          />
+          <SnapshotRow
+            icon={<GitCommitHorizontal className="size-4" />}
+            label="Commit"
+            value={
+              snapshot.code.commitSha
+                ? `${snapshot.code.commitSha.slice(0, 10)} · ${codeResolutionLabel(snapshot.code.resolution)}`
+                : codeResolutionLabel(snapshot.code.resolution)
+            }
+            href={exampleId ? `/training/${exampleId}` : undefined}
+          />
+        </div>
+      )}
+    </section>
+  );
+}
+
+function SnapshotRow({
+  icon,
+  label,
+  value,
+  href,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  value: string;
+  href?: string;
+}) {
+  return (
+    <div className="flex items-center gap-3 px-3 py-2">
+      <span className="text-muted-foreground">{icon}</span>
+      <div className="min-w-0 flex-1">
+        <p className="text-(length:--text-nano) uppercase tracking-(--tracking-eyebrow) text-muted-foreground">{label}</p>
+        <p className="truncate text-sm text-foreground">{value}</p>
+      </div>
+      {href && (
+        <Link
+          to={href}
+          className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
+        >
+          <FileText className="size-3.5" /> View
+        </Link>
+      )}
+    </div>
+  );
+}

--- a/ui/src/components/DecisionTrainingDrawer.tsx
+++ b/ui/src/components/DecisionTrainingDrawer.tsx
@@ -55,7 +55,7 @@ interface DecisionTrainingDrawerProps {
 
 /**
  * Right-hand drawer for capturing a decision-training example from a Decisions
- * row (PAP-14299). Renders a create state (immutable snapshot preview + notes)
+ * row. Renders a create state (immutable snapshot preview + notes)
  * for untrained decisions and a saved state (provenance, editable notes,
  * read-only snapshot, delete) once an example exists. Write affordances are
  * only ever mounted for human users — agents never see this drawer.

--- a/ui/src/lib/attention.test.ts
+++ b/ui/src/lib/attention.test.ts
@@ -48,6 +48,7 @@ function buildItem(overrides: Partial<AttentionItem> = {}): AttentionItem {
     detail: null,
     dismissal: null,
     ...overrides,
+    trainingExampleId: overrides.trainingExampleId ?? null,
   };
 }
 

--- a/ui/src/lib/decisionTraining.ts
+++ b/ui/src/lib/decisionTraining.ts
@@ -6,7 +6,7 @@ import type { DecisionTrainingTarget } from "../api/decisionTraining";
  * against, or `null` when the row is not trainable.
  *
  * v1 trains two source kinds — board approvals and issue-thread interactions —
- * and always anchors to the owning issue (board decisions, PAP-14236). An
+ * and always anchors to the owning issue. An
  * approval that is not linked to any issue has no durable anchor, so it is not
  * trainable and returns `null`.
  */

--- a/ui/src/lib/decisionTraining.ts
+++ b/ui/src/lib/decisionTraining.ts
@@ -1,0 +1,46 @@
+import type { AttentionItem, DecisionTrainingSnapshotV1 } from "@paperclipai/shared";
+import type { DecisionTrainingTarget } from "../api/decisionTraining";
+
+/**
+ * Resolve the durable (source + issue) target a Decisions row would train
+ * against, or `null` when the row is not trainable.
+ *
+ * v1 trains two source kinds — board approvals and issue-thread interactions —
+ * and always anchors to the owning issue (board decisions, PAP-14236). An
+ * approval that is not linked to any issue has no durable anchor, so it is not
+ * trainable and returns `null`.
+ */
+export function trainingTargetForItem(item: AttentionItem): DecisionTrainingTarget | null {
+  const metadataIssueId = typeof item.subject.metadata?.issueId === "string"
+    ? item.subject.metadata.issueId
+    : null;
+  const issueId = metadataIssueId ?? item.relatedIssue?.id ?? null;
+  if (!issueId) return null;
+
+  if (item.sourceKind === "issue_thread_interaction") {
+    return { sourceKind: "interaction", sourceId: item.subject.id, issueId };
+  }
+  if (item.sourceKind === "approval") {
+    return { sourceKind: "approval", sourceId: item.subject.id, issueId };
+  }
+  return null;
+}
+
+/** Whether a Decisions row should surface the train affordance at all. */
+export function isTrainable(item: AttentionItem): boolean {
+  return trainingTargetForItem(item) !== null;
+}
+
+/** Human label for how confidently a code commit was resolved for the snapshot. */
+export function codeResolutionLabel(resolution: DecisionTrainingSnapshotV1["code"]["resolution"]): string {
+  switch (resolution) {
+    case "exact":
+      return "exact (from the deciding run)";
+    case "nearest_run":
+      return "nearest run before cutoff";
+    case "workspace":
+      return "workspace default";
+    case "none":
+      return "no commit found";
+  }
+}

--- a/ui/src/lib/queryKeys.ts
+++ b/ui/src/lib/queryKeys.ts
@@ -334,6 +334,10 @@ export const queryKeys = {
   },
   dashboard: (companyId: string) => ["dashboard", companyId] as const,
   attention: (companyId: string) => ["attention", companyId] as const,
+  decisionTraining: {
+    list: (companyId: string) => ["decision-training", companyId] as const,
+    detail: (id: string) => ["decision-training", "detail", id] as const,
+  },
   workTimeline: (companyId: string, lens?: string) => ["work-timeline", companyId, lens ?? "all"] as const,
   userProfile: (companyId: string, userSlug: string) =>
     ["user-profile", companyId, userSlug] as const,

--- a/ui/src/pages/Training.test.tsx
+++ b/ui/src/pages/Training.test.tsx
@@ -1,0 +1,63 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import type { DecisionTrainingExample } from "@paperclipai/shared";
+import { describe, expect, it } from "vitest";
+import { TrainingThreadPanel, partitionTrainingThread } from "./Training";
+
+const example: DecisionTrainingExample = {
+  id: "training-1",
+  companyId: "company-1",
+  sourceKind: "interaction",
+  sourceId: "interaction-1",
+  issueId: "issue-1",
+  cutoffAt: "2026-07-16T13:02:00.000Z",
+  notes: "Use the smaller change.",
+  notesHistory: [],
+  decisionOutcome: "approved",
+  snapshot: {
+    version: 1,
+    capturedAt: "2026-07-16T13:10:00.000Z",
+    cutoff: { at: "2026-07-16T13:02:00.000Z", lastCommentId: "before-2", commentCount: 2 },
+    issue: {},
+    comments: [
+      { id: "before-1", body: "included", createdAt: "2026-07-16T12:00:00.000Z" },
+      { id: "before-2", body: "last visible", createdAt: "2026-07-16T13:00:00.000Z" },
+    ],
+    runs: [],
+    decision: { kind: "interaction", payload: {}, actor: null, outcome: "approved" },
+    code: { repoUrl: null, ref: null, commitSha: null, resolution: "none" },
+  },
+  createdByUserId: "local-board",
+  createdAt: "2026-07-16T13:10:00.000Z",
+  updatedAt: "2026-07-16T13:10:00.000Z",
+};
+
+const postCutoffComment = {
+  id: "after-1",
+  companyId: "company-1",
+  issueId: "issue-1",
+  body: "excluded tail",
+  authorType: "agent" as const,
+  authorAgentId: "agent-1",
+  authorUserId: null,
+  presentation: null,
+  metadata: null,
+  createdAt: new Date("2026-07-16T13:30:00.000Z"),
+  updatedAt: new Date("2026-07-16T13:30:00.000Z"),
+};
+
+describe("training cutoff rendering", () => {
+  it("keeps post-cutoff comments out of snapshot data and renders them ghosted for audit", () => {
+    const result = partitionTrainingThread(example.snapshot.comments, [...example.snapshot.comments, postCutoffComment], example.cutoffAt);
+    expect(result.included).toEqual(example.snapshot.comments);
+    expect(result.excluded).toEqual([postCutoffComment]);
+    expect(result.included).not.toContainEqual(postCutoffComment);
+
+    const markup = renderToStaticMarkup(<TrainingThreadPanel example={example} liveComments={[postCutoffComment]} />);
+
+    expect(markup).toContain("CUTOFF");
+    expect(markup).toContain("excluded tail");
+    expect(markup).toContain("Excluded from snapshot");
+    expect(markup).toContain('data-excluded-from-snapshot="true"');
+    expect(markup).toContain("opacity-50");
+  });
+});

--- a/ui/src/pages/Training.tsx
+++ b/ui/src/pages/Training.tsx
@@ -1,0 +1,193 @@
+import { useEffect, useMemo, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import type { DecisionTrainingExample, DecisionTrainingSourceKind, IssueComment, Project } from "@paperclipai/shared";
+import { ArrowLeft, Download, Search } from "lucide-react";
+import { useNavigate, useParams } from "@/lib/router";
+import { decisionTrainingApi, type DecisionTrainingFilters } from "@/api/decisionTraining";
+import { issuesApi } from "@/api/issues";
+import { projectsApi } from "@/api/projects";
+import { useBreadcrumbs } from "@/context/BreadcrumbContext";
+import { useCompany } from "@/context/CompanyContext";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Textarea } from "@/components/ui/textarea";
+import { cn, formatDate, formatDateTime } from "@/lib/utils";
+
+type SnapshotRecord = Record<string, unknown>;
+
+function stringValue(record: SnapshotRecord | undefined, ...keys: string[]) {
+  for (const key of keys) {
+    const value = record?.[key];
+    if (typeof value === "string" && value.trim()) return value;
+  }
+  return null;
+}
+
+function recordDate(record: SnapshotRecord) {
+  const value = record.createdAt ?? record.created_at;
+  if (value instanceof Date) return value.toISOString();
+  return typeof value === "string" ? value : "";
+}
+
+function recordId(record: SnapshotRecord) {
+  return stringValue(record, "id") ?? "";
+}
+
+export function partitionTrainingThread(
+  snapshotComments: SnapshotRecord[],
+  liveComments: Array<SnapshotRecord | IssueComment>,
+  cutoffAt: string,
+) {
+  const snapshotIds = new Set(snapshotComments.map(recordId).filter(Boolean));
+  const cutoffMs = new Date(cutoffAt).getTime();
+  const excluded = liveComments.filter((comment) => {
+    if (snapshotIds.has(recordId(comment as SnapshotRecord))) return false;
+    const createdMs = new Date(recordDate(comment as SnapshotRecord)).getTime();
+    return Number.isNaN(createdMs) || createdMs > cutoffMs;
+  });
+  return { included: snapshotComments, excluded };
+}
+
+function decisionTitle(example: DecisionTrainingExample, issueTitle?: string) {
+  const payload = example.snapshot.decision.payload;
+  return stringValue(payload, "title", "prompt", "summary", "action") ?? issueTitle ?? "Decision training example";
+}
+
+function outcomeLabel(value: string | null) {
+  if (!value) return "Pending at capture";
+  return value.replaceAll("_", " ");
+}
+
+function authorLabel(id: string) {
+  return id === "local-board" ? "Local board" : id.slice(0, 8);
+}
+
+function downloadExport(companyId: string) {
+  window.location.assign(`/api/companies/${companyId}/decision-training/export.jsonl`);
+}
+
+export function TrainingLibrary() {
+  const navigate = useNavigate();
+  const { selectedCompanyId } = useCompany();
+  const { setBreadcrumbs } = useBreadcrumbs();
+  const [q, setQ] = useState("");
+  const [project, setProject] = useState("all");
+  const [kind, setKind] = useState("all");
+  const [author, setAuthor] = useState("all");
+
+  useEffect(() => setBreadcrumbs([{ label: "Decisions", href: "/decisions" }, { label: "Training" }]), [setBreadcrumbs]);
+
+  const filters = useMemo<DecisionTrainingFilters>(() => ({
+    q: q.trim() || undefined,
+    project: project === "all" ? undefined : project,
+    kind: kind === "all" ? undefined : kind as DecisionTrainingSourceKind,
+    author: author === "all" ? undefined : author,
+  }), [author, kind, project, q]);
+  const recordsQuery = useQuery({
+    queryKey: ["decision-training", selectedCompanyId, filters],
+    queryFn: ({ signal }) => decisionTrainingApi.list(selectedCompanyId!, filters, { signal }),
+    enabled: Boolean(selectedCompanyId),
+  });
+  const projectsQuery = useQuery({
+    queryKey: ["projects", selectedCompanyId],
+    queryFn: () => projectsApi.list(selectedCompanyId!),
+    enabled: Boolean(selectedCompanyId),
+  });
+  const records = recordsQuery.data ?? [];
+  const projects = projectsQuery.data ?? [];
+  const projectNames = new Map(projects.map((item: Project) => [item.id, item.name]));
+  const authors = [...new Set(records.map((row) => row.example.createdByUserId))];
+
+  return (
+    <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-4 py-6 sm:px-6">
+      <header className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h1 className="text-xl font-bold">Training examples</h1>
+          <p className="mt-1 text-sm text-muted-foreground">Human decision traces with frozen state for future eval cases.</p>
+        </div>
+        <Button variant="outline" onClick={() => selectedCompanyId && downloadExport(selectedCompanyId)} disabled={!selectedCompanyId}>
+          <Download className="size-4" /> Export JSONL
+        </Button>
+      </header>
+
+      <div className="grid gap-3 md:grid-cols-4">
+        <div className="relative">
+          <Search className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+          <Input aria-label="Search training examples" value={q} onChange={(event) => setQ(event.target.value)} placeholder="Search notes, tasks…" className="pl-9" />
+        </div>
+        <Select value={project} onValueChange={setProject}><SelectTrigger aria-label="Filter by project"><SelectValue placeholder="Project: All" /></SelectTrigger><SelectContent><SelectItem value="all">Project: All</SelectItem>{projects.map((item: Project) => <SelectItem key={item.id} value={item.id}>{item.name}</SelectItem>)}</SelectContent></Select>
+        <Select value={kind} onValueChange={setKind}><SelectTrigger aria-label="Filter by decision kind"><SelectValue placeholder="Decision kind: All" /></SelectTrigger><SelectContent><SelectItem value="all">Decision kind: All</SelectItem><SelectItem value="interaction">Interaction</SelectItem><SelectItem value="approval">Approval</SelectItem><SelectItem value="execution_decision">Execution decision</SelectItem></SelectContent></Select>
+        <Select value={author} onValueChange={setAuthor}><SelectTrigger aria-label="Filter by author"><SelectValue placeholder="Author: All" /></SelectTrigger><SelectContent><SelectItem value="all">Author: All</SelectItem>{authors.map((userId) => <SelectItem key={userId} value={userId}>{authorLabel(userId)}</SelectItem>)}</SelectContent></Select>
+      </div>
+
+      {recordsQuery.isLoading ? <p className="text-sm text-muted-foreground">Loading training examples…</p> : null}
+      {recordsQuery.isError ? <p className="text-sm text-destructive">Could not load training examples.</p> : null}
+      {!recordsQuery.isLoading && records.length === 0 ? <p className="py-12 text-center text-sm text-muted-foreground">No training examples match these filters.</p> : null}
+
+      <div className="overflow-hidden rounded-lg border border-border">
+        <div className="hidden grid-cols-6 gap-4 bg-muted/40 px-4 py-2 text-xs font-medium text-muted-foreground md:grid">
+          <span>Decision</span><span>Outcome</span><span>Snapshot</span><span>Author</span><span>Created</span><span>Edited</span>
+        </div>
+        {records.map(({ example, issueIdentifier, issueTitle }) => {
+          const issue = example.snapshot.issue;
+          const projectName = projectNames.get(stringValue(issue, "projectId", "project_id") ?? "") ?? "No project";
+          const edited = example.updatedAt !== example.createdAt;
+          return (
+            <button key={example.id} type="button" onClick={() => navigate(`/training/${example.id}`)} className="grid w-full gap-3 border-t border-border px-4 py-4 text-left transition-colors first:border-t-0 hover:bg-muted/30 md:grid-cols-6 md:items-center md:gap-4">
+              <span className="min-w-0"><span className="block truncate text-sm font-medium">{decisionTitle(example, issueTitle)}</span><span className="mt-1 block truncate text-xs text-muted-foreground">{issueIdentifier} · {projectName} · {example.sourceKind.replaceAll("_", " ")}</span></span>
+              <span className="text-sm capitalize">{outcomeLabel(example.decisionOutcome)}</span>
+              <span className="font-mono text-xs text-muted-foreground">{example.snapshot.cutoff.commentCount} comments · {example.snapshot.runs.length} runs · {example.snapshot.code.commitSha?.slice(0, 9) ?? "no repo"}</span>
+              <span className="text-sm">{authorLabel(example.createdByUserId)}</span><span className="text-xs text-muted-foreground">{formatDate(example.createdAt)}</span><span className="text-xs text-muted-foreground">{edited ? formatDate(example.updatedAt) : "—"}</span>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function JsonPanel({ value }: { value: unknown }) {
+  return <pre className="overflow-auto whitespace-pre-wrap rounded-md bg-muted/40 p-4 font-mono text-xs leading-relaxed">{JSON.stringify(value, null, 2)}</pre>;
+}
+
+export function TrainingThreadPanel({ example, liveComments }: { example: DecisionTrainingExample; liveComments: IssueComment[] }) {
+  const { included, excluded } = partitionTrainingThread(example.snapshot.comments, liveComments, example.cutoffAt);
+  const renderComment = (comment: SnapshotRecord, ghosted = false) => (
+    <div key={recordId(comment) || `${recordDate(comment)}-${stringValue(comment, "body")}`} data-excluded-from-snapshot={ghosted ? "true" : undefined} className={cn("py-4", ghosted && "opacity-50")}>
+      <div className="font-mono text-xs text-muted-foreground">{stringValue(comment, "authorType", "author_type") ?? "Comment"} · {recordDate(comment) ? formatDateTime(recordDate(comment)) : "Unknown time"} · {recordId(comment).slice(0, 10)}</div>
+      <p className="mt-2 whitespace-pre-wrap text-sm">{stringValue(comment, "body") ?? ""}</p>
+      {ghosted ? <p className="mt-2 text-xs font-medium text-destructive">Excluded from snapshot · after cutoff</p> : null}
+    </div>
+  );
+  return <div className="divide-y divide-border">{included.map((comment) => renderComment(comment))}<div data-training-cutoff className="flex items-center gap-3 py-4"><span className="h-px flex-1 bg-destructive" /><span className="font-mono text-xs font-bold text-destructive">CUTOFF · {formatDateTime(example.cutoffAt)}</span><span className="h-px flex-1 bg-destructive" /></div>{excluded.map((comment) => renderComment(comment as SnapshotRecord, true))}</div>;
+}
+
+export function TrainingInspector() {
+  const { id = "" } = useParams();
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const { setBreadcrumbs } = useBreadcrumbs();
+  const [notes, setNotes] = useState("");
+  const [editing, setEditing] = useState(false);
+  const recordQuery = useQuery({ queryKey: ["decision-training", id], queryFn: ({ signal }) => decisionTrainingApi.get(id, { signal }), enabled: Boolean(id) });
+  const example = recordQuery.data;
+  const commentsQuery = useQuery({ queryKey: ["issues", example?.issueId, "comments", "training-audit"], queryFn: () => issuesApi.listComments(example!.issueId, { order: "asc" }), enabled: Boolean(example?.issueId) });
+  useEffect(() => { if (example) setNotes(example.notes); }, [example]);
+  useEffect(() => setBreadcrumbs([{ label: "Decisions", href: "/decisions" }, { label: "Training", href: "/training" }, { label: example ? decisionTitle(example) : "Example" }]), [example, setBreadcrumbs]);
+  const saveMutation = useMutation({ mutationFn: () => decisionTrainingApi.updateNotes(id, notes), onSuccess: (updated) => { queryClient.setQueryData(["decision-training", id], updated); setEditing(false); } });
+
+  if (recordQuery.isLoading) return <p className="p-6 text-sm text-muted-foreground">Loading training example…</p>;
+  if (!example) return <p className="p-6 text-sm text-destructive">Training example not found.</p>;
+  const issueIdentifier = stringValue(example.snapshot.issue, "identifier") ?? example.issueId.slice(0, 8);
+  return (
+    <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-4 py-6 sm:px-6">
+      <header className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between"><div className="min-w-0"><Button variant="ghost" size="sm" className="mb-2 -ml-2" onClick={() => navigate("/training")}><ArrowLeft className="size-4" /> Training</Button><h1 className="truncate text-xl font-bold">{decisionTitle(example)}</h1><p className="mt-1 text-sm text-muted-foreground">{issueIdentifier} · {outcomeLabel(example.decisionOutcome)} · cutoff {formatDateTime(example.cutoffAt)}</p></div><Button variant="outline" onClick={() => downloadExport(example.companyId)}><Download className="size-4" /> Export JSONL</Button></header>
+      <div className="grid gap-8 lg:grid-cols-2">
+        <section><div className="mb-3 flex items-center justify-between"><div><h2 className="text-sm font-semibold">Training notes</h2><p className="mt-1 text-xs text-muted-foreground">Last edited {formatDateTime(example.updatedAt)} · edits are versioned</p></div>{!editing ? <Button variant="ghost" size="sm" onClick={() => setEditing(true)}>Edit</Button> : null}</div>{editing ? <div className="space-y-3"><Textarea value={notes} onChange={(event) => setNotes(event.target.value)} className="min-h-72" /><div className="flex justify-end gap-2"><Button variant="ghost" onClick={() => { setNotes(example.notes); setEditing(false); }}>Cancel</Button><Button onClick={() => saveMutation.mutate()} disabled={saveMutation.isPending || notes === example.notes}>Save notes</Button></div>{saveMutation.isError ? <p className="text-xs text-destructive">Could not save notes.</p> : null}</div> : <p className="whitespace-pre-wrap text-sm leading-relaxed">{example.notes || "No notes recorded."}</p>}</section>
+        <section className="min-w-0"><div className="mb-3 flex items-center justify-between"><h2 className="text-sm font-semibold">Frozen state</h2><span className="font-mono text-xs text-muted-foreground">read-only</span></div><Tabs defaultValue="thread"><TabsList variant="line" className="w-full justify-start overflow-x-auto"><TabsTrigger value="thread">Thread</TabsTrigger><TabsTrigger value="issue">Issue</TabsTrigger><TabsTrigger value="runs">Runs</TabsTrigger><TabsTrigger value="code">Code</TabsTrigger><TabsTrigger value="decision">Decision</TabsTrigger></TabsList><TabsContent value="thread"><TrainingThreadPanel example={example} liveComments={commentsQuery.data ?? []} /></TabsContent><TabsContent value="issue"><JsonPanel value={example.snapshot.issue} /></TabsContent><TabsContent value="runs"><JsonPanel value={example.snapshot.runs} /></TabsContent><TabsContent value="code"><JsonPanel value={example.snapshot.code} /></TabsContent><TabsContent value="decision"><JsonPanel value={example.snapshot.decision} /></TabsContent></Tabs></section>
+      </div>
+    </div>
+  );
+}

--- a/ui/src/pages/Training.tsx
+++ b/ui/src/pages/Training.tsx
@@ -88,7 +88,7 @@ export function TrainingLibrary() {
     author: author === "all" ? undefined : author,
   }), [author, kind, project, q]);
   const recordsQuery = useQuery({
-    queryKey: ["decision-training", selectedCompanyId, filters],
+    queryKey: [...queryKeys.decisionTraining.list(selectedCompanyId ?? ""), filters],
     queryFn: ({ signal }) => decisionTrainingApi.list(selectedCompanyId!, filters, { signal }),
     enabled: Boolean(selectedCompanyId),
   });
@@ -199,6 +199,7 @@ export function TrainingInspector() {
   });
 
   if (recordQuery.isLoading) return <p className="p-6 text-sm text-muted-foreground">Loading training example…</p>;
+  if (recordQuery.isError) return <p className="p-6 text-sm text-destructive">Could not load training example.</p>;
   if (!example) return <p className="p-6 text-sm text-destructive">Training example not found.</p>;
   const issueIdentifier = stringValue(example.snapshot.issue, "identifier") ?? example.issueId.slice(0, 8);
   return (

--- a/ui/src/pages/Training.tsx
+++ b/ui/src/pages/Training.tsx
@@ -13,6 +13,7 @@ import { Input } from "@/components/ui/input";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Textarea } from "@/components/ui/textarea";
+import { queryKeys } from "@/lib/queryKeys";
 import { cn, formatDate, formatDateTime } from "@/lib/utils";
 
 type SnapshotRecord = Record<string, unknown>;
@@ -171,12 +172,12 @@ export function TrainingInspector() {
   const { setBreadcrumbs } = useBreadcrumbs();
   const [notes, setNotes] = useState("");
   const [editing, setEditing] = useState(false);
-  const recordQuery = useQuery({ queryKey: ["decision-training", id], queryFn: ({ signal }) => decisionTrainingApi.get(id, { signal }), enabled: Boolean(id) });
+  const recordQuery = useQuery({ queryKey: queryKeys.decisionTraining.detail(id), queryFn: ({ signal }) => decisionTrainingApi.get(id, { signal }), enabled: Boolean(id) });
   const example = recordQuery.data;
   const commentsQuery = useQuery({ queryKey: ["issues", example?.issueId, "comments", "training-audit"], queryFn: () => issuesApi.listComments(example!.issueId, { order: "asc" }), enabled: Boolean(example?.issueId) });
   useEffect(() => { if (example) setNotes(example.notes); }, [example]);
   useEffect(() => setBreadcrumbs([{ label: "Decisions", href: "/decisions" }, { label: "Training", href: "/training" }, { label: example ? decisionTitle(example) : "Example" }]), [example, setBreadcrumbs]);
-  const saveMutation = useMutation({ mutationFn: () => decisionTrainingApi.updateNotes(id, notes), onSuccess: (updated) => { queryClient.setQueryData(["decision-training", id], updated); setEditing(false); } });
+  const saveMutation = useMutation({ mutationFn: () => decisionTrainingApi.updateNotes(id, notes), onSuccess: (updated) => { queryClient.setQueryData(queryKeys.decisionTraining.detail(id), updated); setEditing(false); } });
 
   if (recordQuery.isLoading) return <p className="p-6 text-sm text-muted-foreground">Loading training example…</p>;
   if (!example) return <p className="p-6 text-sm text-destructive">Training example not found.</p>;

--- a/ui/src/pages/Training.tsx
+++ b/ui/src/pages/Training.tsx
@@ -175,9 +175,18 @@ export function TrainingInspector() {
   const recordQuery = useQuery({ queryKey: queryKeys.decisionTraining.detail(id), queryFn: ({ signal }) => decisionTrainingApi.get(id, { signal }), enabled: Boolean(id) });
   const example = recordQuery.data;
   const commentsQuery = useQuery({ queryKey: ["issues", example?.issueId, "comments", "training-audit"], queryFn: () => issuesApi.listComments(example!.issueId, { order: "asc" }), enabled: Boolean(example?.issueId) });
-  useEffect(() => { if (example) setNotes(example.notes); }, [example]);
+  useEffect(() => {
+    if (example && !editing) setNotes(example.notes);
+  }, [editing, example]);
   useEffect(() => setBreadcrumbs([{ label: "Decisions", href: "/decisions" }, { label: "Training", href: "/training" }, { label: example ? decisionTitle(example) : "Example" }]), [example, setBreadcrumbs]);
-  const saveMutation = useMutation({ mutationFn: () => decisionTrainingApi.updateNotes(id, notes), onSuccess: (updated) => { queryClient.setQueryData(queryKeys.decisionTraining.detail(id), updated); setEditing(false); } });
+  const saveMutation = useMutation({
+    mutationFn: () => decisionTrainingApi.updateNotes(id, notes),
+    onSuccess: (updated) => {
+      queryClient.setQueryData(queryKeys.decisionTraining.detail(id), updated);
+      queryClient.invalidateQueries({ queryKey: queryKeys.decisionTraining.list(updated.companyId) });
+      setEditing(false);
+    },
+  });
 
   if (recordQuery.isLoading) return <p className="p-6 text-sm text-muted-foreground">Loading training example…</p>;
   if (!example) return <p className="p-6 text-sm text-destructive">Training example not found.</p>;

--- a/ui/src/pages/Training.tsx
+++ b/ui/src/pages/Training.tsx
@@ -8,6 +8,7 @@ import { issuesApi } from "@/api/issues";
 import { projectsApi } from "@/api/projects";
 import { useBreadcrumbs } from "@/context/BreadcrumbContext";
 import { useCompany } from "@/context/CompanyContext";
+import { useToastActions } from "@/context/ToastContext";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
@@ -125,7 +126,7 @@ export function TrainingLibrary() {
 
       {recordsQuery.isLoading ? <p className="text-sm text-muted-foreground">Loading training examples…</p> : null}
       {recordsQuery.isError ? <p className="text-sm text-destructive">Could not load training examples.</p> : null}
-      {!recordsQuery.isLoading && records.length === 0 ? <p className="py-12 text-center text-sm text-muted-foreground">No training examples match these filters.</p> : null}
+      {!recordsQuery.isLoading && !recordsQuery.isError && records.length === 0 ? <p className="py-12 text-center text-sm text-muted-foreground">No training examples match these filters.</p> : null}
 
       <div className="overflow-hidden rounded-lg border border-border">
         <div className="hidden grid-cols-6 gap-4 bg-muted/40 px-4 py-2 text-xs font-medium text-muted-foreground md:grid">
@@ -170,6 +171,7 @@ export function TrainingInspector() {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const { setBreadcrumbs } = useBreadcrumbs();
+  const { pushToast } = useToastActions();
   const [notes, setNotes] = useState("");
   const [editing, setEditing] = useState(false);
   const recordQuery = useQuery({ queryKey: queryKeys.decisionTraining.detail(id), queryFn: ({ signal }) => decisionTrainingApi.get(id, { signal }), enabled: Boolean(id) });
@@ -184,7 +186,15 @@ export function TrainingInspector() {
     onSuccess: (updated) => {
       queryClient.setQueryData(queryKeys.decisionTraining.detail(id), updated);
       queryClient.invalidateQueries({ queryKey: queryKeys.decisionTraining.list(updated.companyId) });
+      pushToast({ title: "Notes updated", tone: "success" });
       setEditing(false);
+    },
+    onError: (error) => {
+      pushToast({
+        title: "Could not update notes",
+        body: error instanceof Error ? error.message : "Please try again.",
+        tone: "error",
+      });
     },
   });
 
@@ -195,7 +205,7 @@ export function TrainingInspector() {
     <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-4 py-6 sm:px-6">
       <header className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between"><div className="min-w-0"><Button variant="ghost" size="sm" className="mb-2 -ml-2" onClick={() => navigate("/training")}><ArrowLeft className="size-4" /> Training</Button><h1 className="truncate text-xl font-bold">{decisionTitle(example)}</h1><p className="mt-1 text-sm text-muted-foreground">{issueIdentifier} · {outcomeLabel(example.decisionOutcome)} · cutoff {formatDateTime(example.cutoffAt)}</p></div><Button variant="outline" onClick={() => downloadExport(example.companyId)}><Download className="size-4" /> Export JSONL</Button></header>
       <div className="grid gap-8 lg:grid-cols-2">
-        <section><div className="mb-3 flex items-center justify-between"><div><h2 className="text-sm font-semibold">Training notes</h2><p className="mt-1 text-xs text-muted-foreground">Last edited {formatDateTime(example.updatedAt)} · edits are versioned</p></div>{!editing ? <Button variant="ghost" size="sm" onClick={() => setEditing(true)}>Edit</Button> : null}</div>{editing ? <div className="space-y-3"><Textarea value={notes} onChange={(event) => setNotes(event.target.value)} className="min-h-72" /><div className="flex justify-end gap-2"><Button variant="ghost" onClick={() => { setNotes(example.notes); setEditing(false); }}>Cancel</Button><Button onClick={() => saveMutation.mutate()} disabled={saveMutation.isPending || notes === example.notes}>Save notes</Button></div>{saveMutation.isError ? <p className="text-xs text-destructive">Could not save notes.</p> : null}</div> : <p className="whitespace-pre-wrap text-sm leading-relaxed">{example.notes || "No notes recorded."}</p>}</section>
+        <section><div className="mb-3 flex items-center justify-between"><div><h2 className="text-sm font-semibold">Training notes</h2><p className="mt-1 text-xs text-muted-foreground">Last edited {formatDateTime(example.updatedAt)} · edits are versioned</p></div>{!editing ? <Button variant="ghost" size="sm" onClick={() => setEditing(true)}>Edit</Button> : null}</div>{editing ? <div className="space-y-3"><Textarea value={notes} onChange={(event) => setNotes(event.target.value)} className="min-h-72" /><div className="flex justify-end gap-2"><Button variant="ghost" onClick={() => { setNotes(example.notes); setEditing(false); }}>Cancel</Button><Button onClick={() => saveMutation.mutate()} disabled={saveMutation.isPending || notes === example.notes}>Save notes</Button></div></div> : <p className="whitespace-pre-wrap text-sm leading-relaxed">{example.notes || "No notes recorded."}</p>}</section>
         <section className="min-w-0"><div className="mb-3 flex items-center justify-between"><h2 className="text-sm font-semibold">Frozen state</h2><span className="font-mono text-xs text-muted-foreground">read-only</span></div><Tabs defaultValue="thread"><TabsList variant="line" className="w-full justify-start overflow-x-auto"><TabsTrigger value="thread">Thread</TabsTrigger><TabsTrigger value="issue">Issue</TabsTrigger><TabsTrigger value="runs">Runs</TabsTrigger><TabsTrigger value="code">Code</TabsTrigger><TabsTrigger value="decision">Decision</TabsTrigger></TabsList><TabsContent value="thread"><TrainingThreadPanel example={example} liveComments={commentsQuery.data ?? []} /></TabsContent><TabsContent value="issue"><JsonPanel value={example.snapshot.issue} /></TabsContent><TabsContent value="runs"><JsonPanel value={example.snapshot.runs} /></TabsContent><TabsContent value="code"><JsonPanel value={example.snapshot.code} /></TabsContent><TabsContent value="decision"><JsonPanel value={example.snapshot.decision} /></TabsContent></Tabs></section>
       </div>
     </div>

--- a/ui/src/pages/WhatNeedsMe.tsx
+++ b/ui/src/pages/WhatNeedsMe.tsx
@@ -84,7 +84,7 @@ export function WhatNeedsMe() {
   const [expandedId, setExpandedId] = useState<string | null>(null);
   const [selectedAttentionId, setSelectedAttentionId] = useState<string | null>(null);
   const [autoExpandDone, setAutoExpandDone] = useState(false);
-  // Decision-training drawer target (PAP-14299). `null` when closed.
+  // Decision-training drawer target. `null` when closed.
   const [trainingItem, setTrainingItem] = useState<AttentionItem | null>(null);
 
   // Toolbar preferences (persisted to localStorage, Inbox pattern).

--- a/ui/src/pages/WhatNeedsMe.tsx
+++ b/ui/src/pages/WhatNeedsMe.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { ArrowUpDown, Check, CheckCircle2, Inbox, Layers, ListFilter } from "lucide-react";
+import { ArrowUpDown, Check, CheckCircle2, GraduationCap, Inbox, Layers, ListFilter } from "lucide-react";
 import type { Agent, AttentionItem } from "@paperclipai/shared";
 import { useNavigate } from "@/lib/router";
 import { attentionApi } from "../api/attention";
@@ -40,6 +40,7 @@ import { cn } from "../lib/utils";
 import { hasBlockingShortcutDialog, resolveAttentionQueueKeyAction } from "../lib/keyboardShortcuts";
 import { PageSkeleton } from "../components/PageSkeleton";
 import { AttentionQueueRow } from "../components/AttentionQueueRow";
+import { DecisionTrainingDrawer } from "../components/DecisionTrainingDrawer";
 import { IssueGroupHeader } from "../components/IssueGroupHeader";
 import { Button } from "../components/ui/button";
 import { Checkbox } from "../components/ui/checkbox";
@@ -83,6 +84,8 @@ export function WhatNeedsMe() {
   const [expandedId, setExpandedId] = useState<string | null>(null);
   const [selectedAttentionId, setSelectedAttentionId] = useState<string | null>(null);
   const [autoExpandDone, setAutoExpandDone] = useState(false);
+  // Decision-training drawer target (PAP-14299). `null` when closed.
+  const [trainingItem, setTrainingItem] = useState<AttentionItem | null>(null);
 
   // Toolbar preferences (persisted to localStorage, Inbox pattern).
   const [groupBy, setGroupBy] = useState<AttentionGroupBy>(() => loadAttentionGroupBy());
@@ -358,6 +361,9 @@ export function WhatNeedsMe() {
     setSelectedAttentionId(item.id);
     setExpandedId((prev) => (prev === item.id ? null : item.id));
   }, []);
+  const handleTrain = useCallback((item: AttentionItem) => {
+    setTrainingItem(item);
+  }, []);
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
@@ -417,7 +423,12 @@ export function WhatNeedsMe() {
   return (
     <div ref={rootRef} className="max-w-3xl space-y-4">
       <div className="flex items-center justify-between gap-2">
-        <h1 className="text-xl font-bold">Decisions</h1>
+        <div className="flex items-center justify-between gap-4">
+          <h1 className="text-xl font-bold">Decisions</h1>
+          <Button variant="outline" size="sm" onClick={() => navigate("/training")}>
+            <GraduationCap className="size-4" /> Training
+          </Button>
+        </div>
         <div className="flex items-center gap-2">
           {visibleCount > 0 && (
             <span className="text-sm text-muted-foreground">
@@ -551,6 +562,7 @@ export function WhatNeedsMe() {
                           onToggleExpand={handleToggleExpand}
                           onDismiss={handleDismiss}
                           onSnooze={handleSnooze}
+                          onTrain={handleTrain}
                           agentMap={agentMap}
                           currentUserId={currentUserId}
                           selected={selectedAttentionId === item.id}

--- a/ui/src/pages/WhatNeedsMe.tsx
+++ b/ui/src/pages/WhatNeedsMe.tsx
@@ -624,6 +624,16 @@ export function WhatNeedsMe() {
           )}
         </div>
       )}
+
+      <DecisionTrainingDrawer
+        open={trainingItem !== null}
+        onOpenChange={(next) => {
+          if (!next) setTrainingItem(null);
+        }}
+        companyId={selectedCompanyId}
+        item={trainingItem}
+        currentUserId={currentUserId}
+      />
     </div>
   );
 }

--- a/ui/storybook/stories/what-needs-me.stories.tsx
+++ b/ui/storybook/stories/what-needs-me.stories.tsx
@@ -78,6 +78,7 @@ function item(
     detail: null,
     dismissal: null,
     ...overrides,
+    trainingExampleId: overrides.trainingExampleId ?? null,
   };
 }
 


### PR DESCRIPTION
## Thinking Path

- Paperclip is the control plane humans use to supervise agent work and make governed decisions.
- Those decisions are valuable future evaluation examples only if the available task, thread, run, code, and outcome state is frozen at the decision cutoff.
- The stacked API foundation in #9702 provides immutable decision-training snapshots, human-only writes, notes history, filtering, and JSONL export.
- Operators still need a practical way to capture examples from the Decisions queue and inspect the resulting dataset.
- This pull request adds the capture drawer, training library, and full record inspector so operators can build and audit that dataset without leaving the control plane.

Related PR: #9702

### Problem / Motivation

Paperclip records decisions and their surrounding execution history, but operators had no UI for turning that evidence into reusable training examples. Without a cutoff-aware capture and inspection flow, later comments or runs could be mistaken for evidence that was available when the original decision was made.

### Proposed Solution

Add a human-only training workflow to Decisions plus top-level library and inspector routes. Each example previews and freezes the source decision, owning task, thread cutoff, runs, code revision, outcome, and operator notes. Post-cutoff comments remain visible only as ghosted audit context and never enter the stored snapshot or JSONL export.

### Alternatives Considered

- Automatically train every resolved decision: rejected because operators need intentional labels and pending decisions can also be useful examples.
- Reconstruct state dynamically in the inspector: rejected because later activity would make training inputs non-reproducible.
- Put the library under Decisions: rejected in favor of a top-level dataset surface that can grow independently.

### Roadmap Alignment

This supports Paperclip's organizational-knowledge direction by turning completed work and decision patterns into inspectable, reusable evaluation data. It extends the focused snapshot foundation in #9702 rather than duplicating another planned core surface.

## Linked Issues or Issue Description

- Stacked on #9702, which provides the decision-training snapshot and API foundation.
- The operator problem, motivation, proposed solution, alternatives, and roadmap alignment are documented in the Thinking Path above.

## What Changed

- Added a Decisions-row training affordance and right-hand drawer for snapshot preview, notes capture, saved-example provenance, notes editing, deletion, and full-record navigation.
- Added a read-only preview endpoint and surfaced durable task anchors in attention data so captures use the same source + task identity as persisted examples.
- Added responsive `/training` library search, project/kind/author filters, snapshot digests, and JSONL export.
- Added `/training/:id` inspector with editable notes and Thread, Issue, Runs, Code, and Decision tabs.
- Added a hard cutoff marker and ghosted live comments explicitly excluded from frozen snapshot data.
- Added focused coverage for capture, editing, deletion, trainability, cutoff rendering, and attention-row state.

## Verification

- `pnpm exec vitest run ui/src/components/DecisionTrainingDrawer.test.tsx ui/src/pages/Training.test.tsx ui/src/components/AttentionQueueRow.test.tsx server/src/__tests__/decision-training.test.ts` — 34 tests passed.
- `pnpm --filter @paperclipai/shared typecheck` — passed.
- `pnpm --filter @paperclipai/server typecheck` — passed.
- `pnpm --filter @paperclipai/ui typecheck` — passed before the QA-only browser harness was added to the shared workspace; the PR-owned drawer test's subsequent TypeScript errors were fixed and its focused suite passes.
- `pnpm check:token-gates` — all token gates clean.
- Browser QA passed in Chromium at 1440×900 and 390×844; desktop/mobile library, filters, all inspector tabs, cutoff, ghosted tail, and notes editing screenshots are attached to the Paperclip task.
- Latest-head GitHub checks are green, including Greptile, commitperclip review, Socket, Snyk, and Superagent.

## Risks

- This is a stacked PR and requires #9702 to merge first.
- The preview endpoint performs the same snapshot assembly as create without persistence, adding read load when the drawer opens.
- Author labels fall back to stable shortened user IDs when profile data is unavailable in the list response.
- Post-cutoff comments are fetched live for audit display; focused coverage verifies they never enter frozen snapshot data.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex coding agent; exact model ID and context-window size are not exposed by this runtime. Tool-enabled repository editing, shell execution, API coordination, and automated test/build verification were used.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
