### PR TITLE
feat(ui): boot-truth worktree run engine — inherited-inactive runs, suppression/armed banner, toggle identity

### DIFF
--- a/cli/src/__tests__/worktree.test.ts
+++ b/cli/src/__tests__/worktree.test.ts
@@ -576,6 +576,7 @@ describe("worktree helpers", () => {
         .set({
           experimental: {
             enableWorktreeRunExecution: true,
+            worktreeRunExecutionInstanceNonce: "9ed115ac-9e93-4fe9-a4f1-eb4ea2b0fb24",
             worktreeRunExecutionActivatedAt: "2026-07-16T12:00:00.000Z",
             worktreeRunExecutionActivationInstanceId: "source-instance",
             enableSmokeLab: true,
@@ -588,6 +589,7 @@ describe("worktree helpers", () => {
       const [settings] = await db.select().from(instanceSettings);
       expect(settings?.experimental).toMatchObject({
         enableWorktreeRunExecution: false,
+        worktreeRunExecutionInstanceNonce: null,
         worktreeRunExecutionActivatedAt: null,
         worktreeRunExecutionActivationInstanceId: null,
         enableSmokeLab: true,

--- a/cli/src/__tests__/worktree.test.ts
+++ b/cli/src/__tests__/worktree.test.ts
@@ -575,10 +575,10 @@ describe("worktree helpers", () => {
         .update(instanceSettings)
         .set({
           experimental: {
-          enableWorktreeRunExecution: true,
-          worktreeRunExecutionActivatedAt: "2026-07-16T12:00:00.000Z",
-          worktreeRunExecutionActivationInstanceId: "source-instance",
-          enableSmokeLab: true,
+            enableWorktreeRunExecution: true,
+            worktreeRunExecutionActivatedAt: "2026-07-16T12:00:00.000Z",
+            worktreeRunExecutionActivationInstanceId: "source-instance",
+            enableSmokeLab: true,
           },
         })
         .where(eq(instanceSettings.singletonKey, "default"));

--- a/cli/src/__tests__/worktree.test.ts
+++ b/cli/src/__tests__/worktree.test.ts
@@ -4,13 +4,16 @@ import path from "node:path";
 import { execFileSync } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { createServer } from "node:net";
-import { eq } from "drizzle-orm";
+import { eq, inArray } from "drizzle-orm";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  agentWakeupRequests,
   agents,
   authUsers,
   companies,
   createDb,
+  heartbeatRuns,
+  instanceSettings,
   issueComments,
   issues,
   projects,
@@ -22,6 +25,7 @@ import {
   copySeededSecretsKey,
   pauseSeededScheduledRoutines,
   quarantineSeededWorktreeExecutionState,
+  resetSeededWorktreeRunExecutionActivation,
   readSourceAttachmentBody,
   rebindWorkspaceCwd,
   resolveSourceConfigPath,
@@ -359,6 +363,11 @@ describe("worktree helpers", () => {
     const todoIssueId = randomUUID();
     const reviewIssueId = randomUUID();
     const userIssueId = randomUUID();
+    const wakeupId = randomUUID();
+    const completedWakeupId = randomUUID();
+    const queuedRunId = randomUUID();
+    const runningRunId = randomUUID();
+    const succeededRunId = randomUUID();
 
     try {
       await db.insert(companies).values({
@@ -406,6 +415,11 @@ describe("worktree helpers", () => {
           identifier: "WTQ-1",
           executionAgentNameKey: "codexcoder",
           executionLockedAt: new Date("2026-04-18T00:00:00.000Z"),
+          monitorNextCheckAt: new Date("2026-04-18T00:01:00.000Z"),
+          monitorWakeRequestedAt: new Date("2026-04-18T00:00:30.000Z"),
+          monitorLastTriggeredAt: new Date("2026-04-18T00:00:00.000Z"),
+          monitorAttemptCount: 2,
+          monitorNotes: "copied monitor state",
         },
         {
           id: todoIssueId,
@@ -438,8 +452,53 @@ describe("worktree helpers", () => {
           identifier: "WTQ-4",
         },
       ]);
+      await db.insert(agentWakeupRequests).values([
+        {
+          id: wakeupId,
+          companyId,
+          agentId,
+          source: "system",
+          status: "queued",
+        },
+        {
+          id: completedWakeupId,
+          companyId,
+          agentId,
+          source: "system",
+          status: "completed",
+        },
+      ]);
+      await db.insert(heartbeatRuns).values([
+        {
+          id: queuedRunId,
+          companyId,
+          agentId,
+          status: "queued",
+          wakeupRequestId: wakeupId,
+          processPid: 1234,
+          processGroupId: 1234,
+        },
+        {
+          id: runningRunId,
+          companyId,
+          agentId,
+          status: "running",
+          processPid: 5678,
+          processGroupId: 5678,
+        },
+        {
+          id: succeededRunId,
+          companyId,
+          agentId,
+          status: "succeeded",
+          wakeupRequestId: completedWakeupId,
+        },
+      ]);
 
       await expect(quarantineSeededWorktreeExecutionState(tempDb.connectionString)).resolves.toEqual({
+        cancelledHeartbeatRuns: 2,
+        deletedPendingWakeups: 1,
+        clearedIssueMonitors: 1,
         disabledTimerHeartbeats: 1,
         resetRunningAgents: 1,
         quarantinedInProgressIssues: 1,
@@ -459,6 +518,32 @@ describe("worktree helpers", () => {
       expect(inProgressIssue?.assigneeAgentId).toBeNull();
       expect(inProgressIssue?.executionAgentNameKey).toBeNull();
       expect(inProgressIssue?.executionLockedAt).toBeNull();
+      expect(inProgressIssue?.monitorNextCheckAt).toBeNull();
+      expect(inProgressIssue?.monitorWakeRequestedAt).toBeNull();
+      expect(inProgressIssue?.monitorLastTriggeredAt).toBeNull();
+      expect(inProgressIssue?.monitorAttemptCount).toBe(0);
+      expect(inProgressIssue?.monitorNotes).toBeNull();
+
+      const quarantinedRuns = await db
+        .select()
+        .from(heartbeatRuns)
+        .where(inArray(heartbeatRuns.id, [queuedRunId, runningRunId]));
+      expect(quarantinedRuns).toHaveLength(2);
+      for (const run of quarantinedRuns) {
+        expect(run.status).toBe("cancelled");
+        expect(run.errorCode).toBe("worktree_seed_quarantine");
+        expect(run.processPid).toBeNull();
+        expect(run.processGroupId).toBeNull();
+        expect(run.finishedAt).toBeInstanceOf(Date);
+      }
+
+      const [succeededRun] = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.id, succeededRunId));
+      expect(succeededRun?.status).toBe("succeeded");
+      expect(succeededRun?.wakeupRequestId).toBe(completedWakeupId);
+
+      const wakeups = await db.select().from(agentWakeupRequests);
+      expect(wakeups).toHaveLength(1);
+      expect(wakeups[0]?.id).toBe(completedWakeupId);
 
       const [todoIssue] = await db.select().from(issues).where(eq(issues.id, todoIssueId));
       expect(todoIssue?.status).toBe("todo");
@@ -475,6 +560,38 @@ describe("worktree helpers", () => {
       const comments = await db.select().from(issueComments).where(eq(issueComments.issueId, inProgressIssueId));
       expect(comments).toHaveLength(1);
       expect(comments[0]?.body).toContain("Quarantined during worktree seed");
+    } finally {
+      await db.$client?.end?.({ timeout: 5 }).catch(() => undefined);
+      await tempDb.cleanup();
+    }
+  }, 20_000);
+
+  itEmbeddedPostgres("always disarms copied worktree run execution settings", async () => {
+    const tempDb = await startEmbeddedPostgresTestDatabase("paperclip-worktree-activation-reset-");
+    const db = createDb(tempDb.connectionString);
+
+    try {
+      await db
+        .update(instanceSettings)
+        .set({
+          experimental: {
+          enableWorktreeRunExecution: true,
+          worktreeRunExecutionActivatedAt: "2026-07-16T12:00:00.000Z",
+          worktreeRunExecutionActivationInstanceId: "source-instance",
+          enableSmokeLab: true,
+          },
+        })
+        .where(eq(instanceSettings.singletonKey, "default"));
+
+      await expect(resetSeededWorktreeRunExecutionActivation(tempDb.connectionString)).resolves.toBe(1);
+
+      const [settings] = await db.select().from(instanceSettings);
+      expect(settings?.experimental).toMatchObject({
+        enableWorktreeRunExecution: false,
+        worktreeRunExecutionActivatedAt: null,
+        worktreeRunExecutionActivationInstanceId: null,
+        enableSmokeLab: true,
+      });
     } finally {
       await db.$client?.end?.({ timeout: 5 }).catch(() => undefined);
       await tempDb.cleanup();

--- a/cli/src/commands/worktree.ts
+++ b/cli/src/commands/worktree.ts
@@ -22,6 +22,7 @@ import pc from "picocolors";
 import { and, eq, inArray, sql } from "drizzle-orm";
 import {
   applyPendingMigrations,
+  agentWakeupRequests,
   agents,
   assets,
   companies,
@@ -32,6 +33,7 @@ import {
   formatDatabaseBackupResult,
   goals,
   heartbeatRuns,
+  instanceSettings,
   inspectMigrations,
   issueAttachments,
   issueComments,
@@ -195,6 +197,9 @@ type SeedWorktreeDatabaseResult = {
 };
 
 export type SeededWorktreeExecutionQuarantineSummary = {
+  cancelledHeartbeatRuns: number;
+  deletedPendingWakeups: number;
+  clearedIssueMonitors: number;
   disabledTimerHeartbeats: number;
   resetRunningAgents: number;
   quarantinedInProgressIssues: number;
@@ -218,6 +223,9 @@ function formatSeededWorktreeExecutionQuarantineSummary(
   summary: SeededWorktreeExecutionQuarantineSummary,
 ): string {
   return [
+    `cancelled heartbeat runs: ${summary.cancelledHeartbeatRuns}`,
+    `deleted pending wakeups: ${summary.deletedPendingWakeups}`,
+    `cleared issue monitors: ${summary.clearedIssueMonitors}`,
     `disabled timer heartbeats: ${summary.disabledTimerHeartbeats}`,
     `reset running agents: ${summary.resetRunningAgents}`,
     `quarantined in-progress issues: ${summary.quarantinedInProgressIssues}`,
@@ -1149,6 +1157,9 @@ export async function pauseSeededScheduledRoutines(connectionString: string): Pr
 }
 
 const EMPTY_SEEDED_WORKTREE_EXECUTION_QUARANTINE_SUMMARY: SeededWorktreeExecutionQuarantineSummary = {
+  cancelledHeartbeatRuns: 0,
+  deletedPendingWakeups: 0,
+  clearedIssueMonitors: 0,
   disabledTimerHeartbeats: 0,
   resetRunningAgents: 0,
   quarantinedInProgressIssues: 0,
@@ -1192,6 +1203,63 @@ export async function quarantineSeededWorktreeExecutionState(
   const summary = { ...EMPTY_SEEDED_WORKTREE_EXECUTION_QUARANTINE_SUMMARY };
   try {
     await db.transaction(async (tx) => {
+      const now = new Date();
+      const pendingWakeups = await tx
+        .select({ id: agentWakeupRequests.id })
+        .from(agentWakeupRequests)
+        .where(inArray(agentWakeupRequests.status, ["queued", "deferred_issue_execution", "claimed"]));
+      const pendingWakeupIds = pendingWakeups.map((row) => row.id);
+
+      if (pendingWakeupIds.length > 0) {
+        await tx
+          .update(heartbeatRuns)
+          .set({ wakeupRequestId: null, updatedAt: now })
+          .where(inArray(heartbeatRuns.wakeupRequestId, pendingWakeupIds));
+      }
+
+      const cancelledRuns = await tx
+        .update(heartbeatRuns)
+        .set({
+          status: "cancelled",
+          errorCode: "worktree_seed_quarantine",
+          processPid: null,
+          processGroupId: null,
+          scheduledRetryAt: null,
+          finishedAt: now,
+          updatedAt: now,
+        })
+        .where(inArray(heartbeatRuns.status, ["queued", "running", "scheduled_retry"]))
+        .returning({ id: heartbeatRuns.id });
+      summary.cancelledHeartbeatRuns = cancelledRuns.length;
+
+      if (pendingWakeupIds.length > 0) {
+        const deletedWakeups = await tx
+          .delete(agentWakeupRequests)
+          .where(inArray(agentWakeupRequests.id, pendingWakeupIds))
+          .returning({ id: agentWakeupRequests.id });
+        summary.deletedPendingWakeups = deletedWakeups.length;
+      }
+
+      const clearedMonitors = await tx
+        .update(issues)
+        .set({
+          monitorNextCheckAt: null,
+          monitorWakeRequestedAt: null,
+          monitorLastTriggeredAt: null,
+          monitorAttemptCount: 0,
+          monitorNotes: null,
+          updatedAt: now,
+        })
+        .where(sql`
+          ${issues.monitorNextCheckAt} is not null
+          or ${issues.monitorWakeRequestedAt} is not null
+          or ${issues.monitorLastTriggeredAt} is not null
+          or ${issues.monitorAttemptCount} <> 0
+          or ${issues.monitorNotes} is not null
+        `)
+        .returning({ id: issues.id });
+      summary.clearedIssueMonitors = clearedMonitors.length;
+
       const seededAgents = await tx
         .select({
           id: agents.id,
@@ -1215,7 +1283,7 @@ export async function quarantineSeededWorktreeExecutionState(
             .set({
               runtimeConfig: normalized.runtimeConfig,
               status: nextStatus,
-              updatedAt: new Date(),
+              updatedAt: now,
             })
             .where(eq(agents.id, agent.id));
         }
@@ -1248,7 +1316,7 @@ export async function quarantineSeededWorktreeExecutionState(
             executionAgentNameKey: null,
             executionLockedAt: null,
             executionWorkspaceId: null,
-            updatedAt: new Date(),
+            updatedAt: now,
           })
           .where(eq(issues.id, issue.id));
 
@@ -1270,6 +1338,31 @@ export async function quarantineSeededWorktreeExecutionState(
     });
 
     return summary;
+  } finally {
+    await db.$client?.end?.({ timeout: 5 }).catch(() => undefined);
+  }
+}
+
+export async function resetSeededWorktreeRunExecutionActivation(connectionString: string): Promise<number> {
+  const db = createDb(connectionString);
+  try {
+    const rows = await db.select({ id: instanceSettings.id, experimental: instanceSettings.experimental }).from(instanceSettings);
+    let resetCount = 0;
+    for (const row of rows) {
+      const experimental = isRecord(row.experimental) ? row.experimental : {};
+      const nextExperimental = {
+        ...experimental,
+        enableWorktreeRunExecution: false,
+        worktreeRunExecutionActivatedAt: null,
+        worktreeRunExecutionActivationInstanceId: null,
+      };
+      await db
+        .update(instanceSettings)
+        .set({ experimental: nextExperimental, updatedAt: new Date() })
+        .where(eq(instanceSettings.id, row.id));
+      resetCount += 1;
+    }
+    return resetCount;
   } finally {
     await db.$client?.end?.({ timeout: 5 }).catch(() => undefined);
   }
@@ -1334,6 +1427,7 @@ async function seedWorktreeDatabase(input: {
       backupFile: backup.backupFile,
     });
     await applyPendingMigrations(targetConnectionString);
+    await resetSeededWorktreeRunExecutionActivation(targetConnectionString);
     const executionQuarantine = input.preserveLiveWork
       ? { ...EMPTY_SEEDED_WORKTREE_EXECUTION_QUARANTINE_SUMMARY }
       : await quarantineSeededWorktreeExecutionState(targetConnectionString);
@@ -3094,7 +3188,7 @@ export async function worktreeMergeHistoryCommand(sourceArg: string | undefined,
 }
 
 async function runWorktreeReseed(opts: WorktreeReseedOptions): Promise<void> {
-  const seedMode = opts.seedMode ?? "full";
+  const seedMode = opts.seedMode ?? "minimal";
   if (!isWorktreeSeedMode(seedMode)) {
     throw new Error(`Unsupported seed mode "${seedMode}". Expected one of: minimal, full.`);
   }
@@ -3290,7 +3384,7 @@ export function registerWorktreeCommands(program: Command): void {
     .option("--server-port <port>", "Preferred server port", (value) => Number(value))
     .option("--db-port <port>", "Preferred embedded Postgres port", (value) => Number(value))
     .option("--seed-mode <mode>", "Seed profile: minimal or full (default: minimal)", "minimal")
-    .option("--preserve-live-work", "Do not quarantine copied agent timers or assigned open issues in the seeded worktree", false)
+    .option("--preserve-live-work", "Preserve copied runs, wakeups, monitors, agent timers, and assigned open issues", false)
     .option("--no-seed", "Skip database seeding from the source instance")
     .option("--force", "Replace existing repo-local config and isolated instance data", false)
     .action(worktreeMakeCommand);
@@ -3307,7 +3401,7 @@ export function registerWorktreeCommands(program: Command): void {
     .option("--server-port <port>", "Preferred server port", (value) => Number(value))
     .option("--db-port <port>", "Preferred embedded Postgres port", (value) => Number(value))
     .option("--seed-mode <mode>", "Seed profile: minimal or full (default: minimal)", "minimal")
-    .option("--preserve-live-work", "Do not quarantine copied agent timers or assigned open issues in the seeded worktree", false)
+    .option("--preserve-live-work", "Preserve copied runs, wakeups, monitors, agent timers, and assigned open issues", false)
     .option("--no-seed", "Skip database seeding from the source instance")
     .option("--force", "Replace existing repo-local config and isolated instance data", false)
     .action(worktreeInitCommand);
@@ -3346,8 +3440,8 @@ export function registerWorktreeCommands(program: Command): void {
     .option("--from-config <path>", "Source config.json to seed from")
     .option("--from-data-dir <path>", "Source PAPERCLIP_HOME used when deriving the source config")
     .option("--from-instance <id>", "Source instance id when deriving the source config")
-    .option("--seed-mode <mode>", "Seed profile: minimal or full (default: full)", "full")
-    .option("--preserve-live-work", "Do not quarantine copied agent timers or assigned open issues in the seeded worktree", false)
+    .option("--seed-mode <mode>", "Seed profile: minimal or full (default: minimal)", "minimal")
+    .option("--preserve-live-work", "Preserve copied runs, wakeups, monitors, agent timers, and assigned open issues", false)
     .option("--yes", "Skip the destructive confirmation prompt", false)
     .option("--allow-live-target", "Override the guard that requires the target worktree DB to be stopped first", false)
     .action(worktreeReseedCommand);
@@ -3361,7 +3455,7 @@ export function registerWorktreeCommands(program: Command): void {
     .option("--from-data-dir <path>", "Source PAPERCLIP_HOME used when deriving the source config")
     .option("--from-instance <id>", "Source instance id when deriving the source config (default: default)")
     .option("--seed-mode <mode>", "Seed profile: minimal or full (default: minimal)", "minimal")
-    .option("--preserve-live-work", "Do not quarantine copied agent timers or assigned open issues in the seeded worktree", false)
+    .option("--preserve-live-work", "Preserve copied runs, wakeups, monitors, agent timers, and assigned open issues", false)
     .option("--no-seed", "Repair metadata only and skip reseeding when bootstrapping a missing worktree config", false)
     .option("--allow-live-target", "Override the guard that requires the target worktree DB to be stopped first", false)
     .action(worktreeRepairCommand);

--- a/cli/src/commands/worktree.ts
+++ b/cli/src/commands/worktree.ts
@@ -1353,6 +1353,7 @@ export async function resetSeededWorktreeRunExecutionActivation(connectionString
       const nextExperimental = {
         ...experimental,
         enableWorktreeRunExecution: false,
+        worktreeRunExecutionInstanceNonce: null,
         worktreeRunExecutionActivatedAt: null,
         worktreeRunExecutionActivationInstanceId: null,
       };

--- a/doc/DEVELOPING.md
+++ b/doc/DEVELOPING.md
@@ -404,6 +404,7 @@ eval "$(paperclipai worktree env)"
 | `--server-port <port>` | Preferred server port |
 | `--db-port <port>` | Preferred embedded Postgres port |
 | `--seed-mode <mode>` | Seed profile: `minimal` or `full` (default: `minimal`) |
+| `--preserve-live-work` | Explicitly bypass seed quarantine for copied runs, wakeups, monitors, agent timers, and assigned open issues. The worktree run-execution toggle is still reset. |
 | `--no-seed` | Skip database seeding from the source instance |
 | `--force` | Replace existing repo-local config and isolated instance data |
 
@@ -440,6 +441,7 @@ For an already-created worktree where you want the CLI to decide whether to rebu
 | `--from-data-dir <path>` | Source `PAPERCLIP_HOME` used when deriving the source config |
 | `--from-instance <id>` | Source instance id when deriving the source config (default: `default`) |
 | `--seed-mode <mode>` | Seed profile: `minimal` or `full` (default: `minimal`) |
+| `--preserve-live-work` | Explicitly bypass seed quarantine for copied runs, wakeups, monitors, agent timers, and assigned open issues. The worktree run-execution toggle is still reset. |
 | `--no-seed` | Repair metadata only when bootstrapping a missing worktree config |
 | `--allow-live-target` | Override the guard that requires the target worktree DB to be stopped first |
 
@@ -466,7 +468,8 @@ For an already-created worktree where you want to keep the existing repo-local c
 | `--from-config <path>` | Source config.json to seed from |
 | `--from-data-dir <path>` | Source `PAPERCLIP_HOME` used when deriving the source config |
 | `--from-instance <id>` | Source instance id when deriving the source config |
-| `--seed-mode <mode>` | Seed profile: `minimal` or `full` (default: `full`) |
+| `--seed-mode <mode>` | Seed profile: `minimal` or `full` (default: `minimal`) |
+| `--preserve-live-work` | Explicitly bypass seed quarantine for copied runs, wakeups, monitors, agent timers, and assigned open issues. The worktree run-execution toggle is still reset. |
 | `--yes` | Skip the destructive confirmation prompt |
 | `--allow-live-target` | Override the guard that requires the target worktree DB to be stopped first |
 
@@ -484,8 +487,7 @@ pnpm paperclipai worktree reseed \
 # From inside a worktree, reseed it from the default instance config.
 cd /path/to/paperclip/.paperclip/worktrees/PAP-1132-assistant-ui-pap-1131-make-issues-comments-be-like-a-chat
 pnpm paperclipai worktree reseed \
-  --from-instance default \
-  --seed-mode full
+  --from-instance default
 ```
 
 **`pnpm paperclipai worktree:make <name> [options]`** — Create `~/NAME` as a git worktree, then initialize an isolated Paperclip instance inside it. This combines `git worktree add` with `worktree init` in a single step.
@@ -501,6 +503,7 @@ pnpm paperclipai worktree reseed \
 | `--server-port <port>` | Preferred server port |
 | `--db-port <port>` | Preferred embedded Postgres port |
 | `--seed-mode <mode>` | Seed profile: `minimal` or `full` (default: `minimal`) |
+| `--preserve-live-work` | Explicitly bypass seed quarantine for copied runs, wakeups, monitors, agent timers, and assigned open issues. The worktree run-execution toggle is still reset. |
 | `--no-seed` | Skip database seeding from the source instance |
 | `--force` | Replace existing repo-local config and isolated instance data |
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -633,6 +633,9 @@ export type {
   InstanceSettings,
   IssueGraphLivenessAutoRecoveryPreview,
   IssueGraphLivenessAutoRecoveryPreviewItem,
+  WorktreeRunExecutionSuppressedReason,
+  WorktreeRunExecutionActivationState,
+  WorktreeRunEngineStatus,
   BackupRetentionPolicy,
   Agent,
   AgentAccessState,
@@ -1303,6 +1306,7 @@ export {
   DEFAULT_ISSUE_GRAPH_LIVENESS_AUTO_RECOVERY_LOOKBACK_HOURS,
   MIN_ISSUE_GRAPH_LIVENESS_AUTO_RECOVERY_LOOKBACK_HOURS,
   MAX_ISSUE_GRAPH_LIVENESS_AUTO_RECOVERY_LOOKBACK_HOURS,
+  WORKTREE_SEED_QUARANTINE_ERROR_CODE,
 } from "./types/instance.js";
 
 export type {

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -47,7 +47,11 @@ export type {
   BackupRetentionPolicy,
   IssueGraphLivenessAutoRecoveryPreview,
   IssueGraphLivenessAutoRecoveryPreviewItem,
+  WorktreeRunExecutionSuppressedReason,
+  WorktreeRunExecutionActivationState,
+  WorktreeRunEngineStatus,
 } from "./instance.js";
+export { WORKTREE_SEED_QUARANTINE_ERROR_CODE } from "./instance.js";
 export type {
   SmokeLabServiceStatus,
   SmokeRun,

--- a/packages/shared/src/types/instance.ts
+++ b/packages/shared/src/types/instance.ts
@@ -74,13 +74,18 @@ export interface InstanceExperimentalSettings {
    */
   enableWorktreeRunExecution: boolean;
   /**
+   * Server-managed random identity for this worktree database. Seed/reset flows
+   * clear it so the first boot stamps a fresh value.
+   */
+  worktreeRunExecutionInstanceNonce: string | null;
+  /**
    * Server-managed cutoff recorded when worktree run execution is enabled in
    * this instance. Client PATCH payloads must not control this value.
    */
   worktreeRunExecutionActivatedAt: string | null;
   /**
-   * Server-managed instance id captured with the cutoff so copied settings rows
-   * from another instance fail closed.
+   * Server-managed instance nonce captured with the cutoff so copied activation
+   * state from another instance fails closed.
    */
   worktreeRunExecutionActivationInstanceId: string | null;
   issueGraphLivenessAutoRecoveryLookbackHours: number;

--- a/packages/shared/src/types/instance.ts
+++ b/packages/shared/src/types/instance.ts
@@ -91,6 +91,59 @@ export interface InstanceExperimentalSettings {
   issueGraphLivenessAutoRecoveryLookbackHours: number;
 }
 
+/**
+ * Error code stamped on heartbeat runs that were copied into a worktree seed and
+ * quarantined (cancelled, inert) so they never execute in the preview instance.
+ * Owned by the CLI worktree seed flow (cli/src/commands/worktree.ts) and surfaced
+ * in the UI as "inherited — inactive" runs.
+ */
+export const WORKTREE_SEED_QUARANTINE_ERROR_CODE = "worktree_seed_quarantine";
+
+/**
+ * Why the worktree run engine is suppressed. Mirrors the server's fail-closed
+ * ladder in `resolveWorktreeRunExecutionActivation`.
+ */
+export type WorktreeRunExecutionSuppressedReason =
+  | "not_worktree_runtime"
+  | "flag_disabled"
+  | "missing_cutoff"
+  | "missing_instance_id"
+  | "instance_id_mismatch"
+  | "settings_read_error";
+
+/**
+ * Resolved worktree run-engine activation. `armed` means the scheduler executes
+ * runs created after `cutoff`; otherwise `reason` explains the suppression.
+ */
+export type WorktreeRunExecutionActivationState =
+  | {
+      armed: true;
+      cutoff: string;
+      activationInstanceId: string;
+      reason: null;
+    }
+  | {
+      armed: false;
+      cutoff: null;
+      activationInstanceId: string | null;
+      reason: WorktreeRunExecutionSuppressedReason;
+    };
+
+/**
+ * Authoritative boot-truth for the worktree run engine, served to the UI so a
+ * preview user can tell "inherited, inert" state from live execution at a glance.
+ */
+export interface WorktreeRunEngineStatus {
+  /** True when the server runtime is a worktree preview (`PAPERCLIP_IN_WORKTREE`). */
+  inWorktree: boolean;
+  /** Activation resolved server-side (mirrors the scheduler gate). */
+  activation: WorktreeRunExecutionActivationState;
+  /** Current boot's server-managed instance identity (nonce), if stamped. */
+  instanceNonce: string | null;
+  /** Count of inherited heartbeat runs quarantined at seed time (durable evidence). */
+  quarantinedRunCount: number;
+}
+
 export interface InstanceSettings {
   id: string;
   defaultEnvironmentId: string | null;

--- a/packages/shared/src/validators/instance.ts
+++ b/packages/shared/src/validators/instance.ts
@@ -61,6 +61,7 @@ export const instanceExperimentalSettingsSchema = z.object({
   enableWorkspaceBranchReconcileForward: z.boolean().default(true),
   enableWorkspaceDirtyQuarantineRepair: z.boolean().default(true),
   enableWorktreeRunExecution: z.boolean().default(false),
+  worktreeRunExecutionInstanceNonce: z.string().uuid().nullable().default(null),
   worktreeRunExecutionActivatedAt: z.string().datetime().nullable().default(null),
   worktreeRunExecutionActivationInstanceId: z.string().min(1).nullable().default(null),
   issueGraphLivenessAutoRecoveryLookbackHours: z
@@ -73,6 +74,7 @@ export const instanceExperimentalSettingsSchema = z.object({
 
 export const patchInstanceExperimentalSettingsSchema = instanceExperimentalSettingsSchema
   .omit({
+    worktreeRunExecutionInstanceNonce: true,
     worktreeRunExecutionActivatedAt: true,
     worktreeRunExecutionActivationInstanceId: true,
   })

--- a/server/src/__tests__/dev-runner-worktree.test.ts
+++ b/server/src/__tests__/dev-runner-worktree.test.ts
@@ -31,7 +31,7 @@ describe("dev-runner worktree env bootstrap", () => {
     expect(isLinkedGitWorktreeCheckout(root)).toBe(true);
   });
 
-  it("loads repo-local Paperclip env for initialized worktrees without overriding explicit env", () => {
+  it("loads repo-local Paperclip env and overrides inherited identity keys", () => {
     const root = createTempRoot("paperclip-dev-runner-worktree-env-");
     fs.mkdirSync(path.join(root, ".paperclip"), { recursive: true });
     fs.writeFileSync(path.join(root, ".git"), "gitdir: /tmp/paperclip/.git/worktrees/feature\n", "utf8");
@@ -49,7 +49,9 @@ describe("dev-runner worktree env bootstrap", () => {
     );
 
     const env: NodeJS.ProcessEnv = {
+      PAPERCLIP_HOME: "/shared/paperclip-home",
       PAPERCLIP_INSTANCE_ID: "already-set",
+      PAPERCLIP_WORKTREE_NAME: "explicit-name",
     };
     const result = bootstrapDevRunnerWorktreeEnv(root, env);
 
@@ -58,8 +60,9 @@ describe("dev-runner worktree env bootstrap", () => {
       missingEnv: false,
     });
     expect(env.PAPERCLIP_HOME).toBe("/tmp/paperclip-worktrees");
-    expect(env.PAPERCLIP_INSTANCE_ID).toBe("already-set");
+    expect(env.PAPERCLIP_INSTANCE_ID).toBe("feature-worktree");
     expect(env.PAPERCLIP_IN_WORKTREE).toBe("true");
+    expect(env.PAPERCLIP_WORKTREE_NAME).toBe("explicit-name");
     expect(env.PAPERCLIP_OPTIONAL).toBe("");
   });
 

--- a/server/src/__tests__/heartbeat-worktree-suppression.test.ts
+++ b/server/src/__tests__/heartbeat-worktree-suppression.test.ts
@@ -143,6 +143,24 @@ describeEmbeddedPostgres("heartbeat worktree suppression", () => {
     }).updateExperimental({ enableWorktreeRunExecution: true });
   }
 
+  it("stamps and reuses a server-managed nonce on first worktree settings read", async () => {
+    const generatedNonce = "9ed115ac-9e93-4fe9-a4f1-eb4ea2b0fb24";
+    const settings = instanceSettingsService(db, {
+      runtimeEnv: {
+        PAPERCLIP_IN_WORKTREE: "true",
+        PAPERCLIP_INSTANCE_ID: "injected-shared-instance-id",
+      },
+      generateInstanceNonce: () => generatedNonce,
+    });
+
+    await expect(settings.getExperimental()).resolves.toMatchObject({
+      worktreeRunExecutionInstanceNonce: generatedNonce,
+    });
+    await expect(settings.getExperimental()).resolves.toMatchObject({
+      worktreeRunExecutionInstanceNonce: generatedNonce,
+    });
+  });
+
   async function waitForCompletedRun(runId: string, agentId: string) {
     let latestStatus: string | null = null;
     let latestLastRunId: string | null = null;
@@ -259,7 +277,7 @@ describeEmbeddedPostgres("heartbeat worktree suppression", () => {
     const heartbeat = heartbeatService(db, {
       runtimeEnv: {
         PAPERCLIP_IN_WORKTREE: "true",
-        PAPERCLIP_INSTANCE_ID: "test-worktree",
+        PAPERCLIP_INSTANCE_ID: "different-injected-instance-id",
       },
     });
 

--- a/server/src/__tests__/instance-settings-service.test.ts
+++ b/server/src/__tests__/instance-settings-service.test.ts
@@ -6,6 +6,8 @@ import {
   resolveWorktreeRunExecutionActivationState,
 } from "../services/instance-settings.js";
 
+const INSTANCE_NONCE = "9ed115ac-9e93-4fe9-a4f1-eb4ea2b0fb24";
+
 describe("instance settings service", () => {
   it("ignores retired experimental flags without resetting current settings", () => {
     expect(normalizeExperimentalSettings({
@@ -48,6 +50,7 @@ describe("instance settings service", () => {
       enableWorkspaceBranchReconcileForward: true,
       enableWorkspaceDirtyQuarantineRepair: false,
       enableWorktreeRunExecution: false,
+      worktreeRunExecutionInstanceNonce: null,
       worktreeRunExecutionActivatedAt: null,
       worktreeRunExecutionActivationInstanceId: null,
       issueGraphLivenessAutoRecoveryLookbackHours: 48,
@@ -153,7 +156,10 @@ describe("instance settings service", () => {
     const activatedAt = new Date("2026-07-10T12:00:00.000Z");
 
     const next = applyExperimentalSettingsPatch(
-      { enableWorktreeRunExecution: false },
+      {
+        enableWorktreeRunExecution: false,
+        worktreeRunExecutionInstanceNonce: INSTANCE_NONCE,
+      },
       { enableWorktreeRunExecution: true },
       {
         now: () => activatedAt,
@@ -166,15 +172,16 @@ describe("instance settings service", () => {
 
     expect(next.enableWorktreeRunExecution).toBe(true);
     expect(next.worktreeRunExecutionActivatedAt).toBe("2026-07-10T12:00:00.000Z");
-    expect(next.worktreeRunExecutionActivationInstanceId).toBe("worktree-instance");
+    expect(next.worktreeRunExecutionActivationInstanceId).toBe(INSTANCE_NONCE);
   });
 
   it("clears worktree run execution activation fields on a true to false transition", () => {
     const next = applyExperimentalSettingsPatch(
       {
         enableWorktreeRunExecution: true,
+        worktreeRunExecutionInstanceNonce: INSTANCE_NONCE,
         worktreeRunExecutionActivatedAt: "2026-07-10T12:00:00.000Z",
-        worktreeRunExecutionActivationInstanceId: "worktree-instance",
+        worktreeRunExecutionActivationInstanceId: INSTANCE_NONCE,
       },
       { enableWorktreeRunExecution: false },
       {
@@ -192,7 +199,10 @@ describe("instance settings service", () => {
 
   it("refreshes the activation cutoff when worktree run execution is re-toggled", () => {
     const firstActivation = applyExperimentalSettingsPatch(
-      { enableWorktreeRunExecution: false },
+      {
+        enableWorktreeRunExecution: false,
+        worktreeRunExecutionInstanceNonce: INSTANCE_NONCE,
+      },
       { enableWorktreeRunExecution: true },
       {
         now: () => new Date("2026-07-10T12:00:00.000Z"),
@@ -236,6 +246,7 @@ describe("instance settings service", () => {
       { enableWorktreeRunExecution: false },
       {
         enableWorktreeRunExecution: false,
+        worktreeRunExecutionInstanceNonce: "e7904e84-5d6a-44af-bd5f-1c93d9636bc3",
         worktreeRunExecutionActivatedAt: "2026-07-10T12:00:00.000Z",
         worktreeRunExecutionActivationInstanceId: "copied-instance",
       },
@@ -249,13 +260,15 @@ describe("instance settings service", () => {
 
     expect(next.worktreeRunExecutionActivatedAt).toBeNull();
     expect(next.worktreeRunExecutionActivationInstanceId).toBeNull();
+    expect(next.worktreeRunExecutionInstanceNonce).toBeNull();
   });
 
   it("resolves worktree run execution as armed only when the cutoff matches the current instance", async () => {
     const experimental = normalizeExperimentalSettings({
       enableWorktreeRunExecution: true,
+      worktreeRunExecutionInstanceNonce: INSTANCE_NONCE,
       worktreeRunExecutionActivatedAt: "2026-07-10T12:00:00.000Z",
-      worktreeRunExecutionActivationInstanceId: "worktree-instance",
+      worktreeRunExecutionActivationInstanceId: INSTANCE_NONCE,
     });
 
     await expect(
@@ -263,13 +276,13 @@ describe("instance settings service", () => {
         getExperimental: async () => experimental,
         runtimeEnv: {
           PAPERCLIP_IN_WORKTREE: "true",
-          PAPERCLIP_INSTANCE_ID: "worktree-instance",
+          PAPERCLIP_INSTANCE_ID: "injected-shared-instance-id",
         },
       }),
     ).resolves.toEqual({
       armed: true,
       cutoff: "2026-07-10T12:00:00.000Z",
-      activationInstanceId: "worktree-instance",
+      activationInstanceId: INSTANCE_NONCE,
       reason: null,
     });
   });
@@ -277,7 +290,8 @@ describe("instance settings service", () => {
   it("fails closed when worktree run execution is missing a cutoff", async () => {
     const experimental = normalizeExperimentalSettings({
       enableWorktreeRunExecution: true,
-      worktreeRunExecutionActivationInstanceId: "worktree-instance",
+      worktreeRunExecutionInstanceNonce: INSTANCE_NONCE,
+      worktreeRunExecutionActivationInstanceId: INSTANCE_NONCE,
     });
 
     await expect(
@@ -298,8 +312,9 @@ describe("instance settings service", () => {
   it("fails closed when worktree run execution was activated by another instance", async () => {
     const experimental = normalizeExperimentalSettings({
       enableWorktreeRunExecution: true,
+      worktreeRunExecutionInstanceNonce: INSTANCE_NONCE,
       worktreeRunExecutionActivatedAt: "2026-07-10T12:00:00.000Z",
-      worktreeRunExecutionActivationInstanceId: "source-instance",
+      worktreeRunExecutionActivationInstanceId: "f6690751-2ed0-4113-9403-241c2cc3ace9",
     });
 
     await expect(
@@ -313,7 +328,7 @@ describe("instance settings service", () => {
     ).resolves.toMatchObject({
       armed: false,
       cutoff: null,
-      activationInstanceId: "source-instance",
+      activationInstanceId: "f6690751-2ed0-4113-9403-241c2cc3ace9",
       reason: "instance_id_mismatch",
     });
   });

--- a/server/src/__tests__/routines-service.test.ts
+++ b/server/src/__tests__/routines-service.test.ts
@@ -211,10 +211,10 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
     instanceId = "00000000-0000-4000-8000-000000000001",
   ) {
     const experimental = {
-        enableWorktreeRunExecution: true,
-        worktreeRunExecutionInstanceNonce: instanceId,
-        worktreeRunExecutionActivatedAt: cutoff.toISOString(),
-        worktreeRunExecutionActivationInstanceId: instanceId,
+      enableWorktreeRunExecution: true,
+      worktreeRunExecutionInstanceNonce: instanceId,
+      worktreeRunExecutionActivatedAt: cutoff.toISOString(),
+      worktreeRunExecutionActivationInstanceId: instanceId,
     };
     await db
       .insert(instanceSettings)

--- a/server/src/__tests__/routines-service.test.ts
+++ b/server/src/__tests__/routines-service.test.ts
@@ -206,16 +206,23 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
     return { companyId, agentId, issueSvc, projectId, routine, svc, wakeups };
   }
 
-  async function armWorktreeExecution(cutoff: Date, instanceId = "worktree-routines-test") {
-    await db.insert(instanceSettings).values({
-      singletonKey: "default",
-      general: {},
-      experimental: {
+  async function armWorktreeExecution(
+    cutoff: Date,
+    instanceId = "00000000-0000-4000-8000-000000000001",
+  ) {
+    const experimental = {
         enableWorktreeRunExecution: true,
+        worktreeRunExecutionInstanceNonce: instanceId,
         worktreeRunExecutionActivatedAt: cutoff.toISOString(),
         worktreeRunExecutionActivationInstanceId: instanceId,
-      },
-    });
+    };
+    await db
+      .insert(instanceSettings)
+      .values({ singletonKey: "default", general: {}, experimental })
+      .onConflictDoUpdate({
+        target: instanceSettings.singletonKey,
+        set: { experimental },
+      });
   }
 
   async function insertDispatchedRun(input: {

--- a/server/src/__tests__/server-startup-feedback-export.test.ts
+++ b/server/src/__tests__/server-startup-feedback-export.test.ts
@@ -209,6 +209,7 @@ vi.mock("../services/index.js", () => ({
   environmentCustomImageService: environmentCustomImagesServiceFactoryMock,
   heartbeatService: heartbeatServiceFactoryMock,
   instanceSettingsService: vi.fn(() => ({
+    getExperimental: vi.fn(async () => ({})),
     getGeneral: vi.fn(async () => ({
       backupRetention: {
         dailyDays: 7,

--- a/server/src/__tests__/workspace-runtime.test.ts
+++ b/server/src/__tests__/workspace-runtime.test.ts
@@ -38,6 +38,7 @@ import {
   resolveWorkspaceRuntimeReadinessTimeoutSec,
   resolveShell,
   sanitizeRuntimeServiceBaseEnv,
+  stripRuntimeServiceIdentityEnvOverrides,
   startRuntimeServicesForWorkspaceControl,
   stopRuntimeServicesForExecutionWorkspace,
   type RealizedExecutionWorkspace,
@@ -368,6 +369,14 @@ describe("sanitizeRuntimeServiceBaseEnv", () => {
     expect(sanitized.npm_config_tailscale_auth).toBeUndefined();
     expect(sanitized.npm_config_authenticated_private).toBeUndefined();
     expect(sanitized.HOST).toBe("0.0.0.0");
+  });
+
+  it("removes Paperclip identity overrides from managed runtime-service env", () => {
+    expect(stripRuntimeServiceIdentityEnvOverrides({
+      PAPERCLIP_HOME: "/shared/paperclip-home",
+      PAPERCLIP_INSTANCE_ID: "project-primary-runtime",
+      PORT: "3101",
+    })).toEqual({ PORT: "3101" });
   });
 });
 
@@ -3525,7 +3534,7 @@ describe("ensureRuntimeServicesForRun", () => {
       worktreePath: worktreeWorkspaceRoot,
     };
     const serviceCommand =
-      "node -e \"require('node:http').createServer((req,res)=>res.end(process.env.PAPERCLIP_HOME)).listen(Number(process.env.PORT), '127.0.0.1')\"";
+      "node -e \"require('node:http').createServer((req,res)=>res.end(process.env.WORKSPACE_MARKER)).listen(Number(process.env.PORT), '127.0.0.1')\"";
     const config = {
       workspaceRuntime: {
         services: [
@@ -3534,7 +3543,7 @@ describe("ensureRuntimeServicesForRun", () => {
             command: serviceCommand,
             cwd: ".",
             env: {
-              PAPERCLIP_HOME: "{{workspace.cwd}}/.paperclip/runtime-services",
+              WORKSPACE_MARKER: "{{workspace.cwd}}/.paperclip/runtime-services",
             },
             port: { type: "auto" },
             readiness: {

--- a/server/src/dev-runner-worktree.ts
+++ b/server/src/dev-runner-worktree.ts
@@ -42,6 +42,8 @@ type WorktreeEnvBootstrapResult =
   | { envPath: string; missingEnv: true }
   | { envPath: string; missingEnv: false };
 
+const WORKTREE_IDENTITY_ENV_KEYS = new Set(["PAPERCLIP_HOME", "PAPERCLIP_INSTANCE_ID"]);
+
 export function isLinkedGitWorktreeCheckout(rootDir: string): boolean {
   const gitMetadataPath = path.join(rootDir, ".git");
   if (!existsSync(gitMetadataPath)) return false;
@@ -120,7 +122,11 @@ export function bootstrapDevRunnerWorktreeEnv(
     env,
   );
   for (const [key, value] of Object.entries(entries)) {
-    if (typeof env[key] === "string" && env[key]!.trim().length > 0) continue;
+    if (
+      !WORKTREE_IDENTITY_ENV_KEYS.has(key) &&
+      typeof env[key] === "string" &&
+      env[key]!.trim().length > 0
+    ) continue;
     env[key] = value;
   }
 

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -591,7 +591,8 @@ export async function startServer(): Promise<StartedServer> {
   const feedback = feedbackService(db as any, {
     shareClient: createFeedbackTraceShareClientFromConfig(config),
   });
-  const backupSettingsSvc = instanceSettingsService(db);
+  const serverInstanceSettings = instanceSettingsService(db);
+  await serverInstanceSettings.getExperimental();
   const databaseBackupMaxAgeHours = Math.max(
     1,
     Number(process.env.PAPERCLIP_DB_BACKUP_MAX_AGE_HOURS) ||
@@ -625,7 +626,7 @@ export async function startServer(): Promise<StartedServer> {
     try {
       logger.info({ backupDir: config.databaseBackupDir, trigger }, `${label} database backup starting`);
       // Read retention from Instance Settings (DB) so changes take effect without restart.
-      const generalSettings = await backupSettingsSvc.getGeneral();
+      const generalSettings = await serverInstanceSettings.getGeneral();
       const retention = generalSettings.backupRetention;
 
       const result = await runDatabaseBackup({
@@ -862,6 +863,8 @@ export async function startServer(): Promise<StartedServer> {
       {
         state: worktreeRunExecutionActivation.armed ? "armed" : "disarmed",
         cutoff: worktreeRunExecutionActivation.cutoff,
+        reason: worktreeRunExecutionActivation.reason,
+        activationInstanceId: worktreeRunExecutionActivation.activationInstanceId,
       },
       "worktree run-execution cutoff state",
     );

--- a/server/src/routes/instance-settings.ts
+++ b/server/src/routes/instance-settings.ts
@@ -146,6 +146,14 @@ export function instanceSettingsRoutes(db: Db) {
     },
   );
 
+  router.get("/instance/settings/experimental/worktree-run-engine", async (req, res) => {
+    // Boot-truth for the worktree run engine (PAP-14312). Readable by any
+    // authenticated org member or instance admin so the persistent banner and
+    // inherited-run surfaces render for everyone viewing a preview instance.
+    assertBoardOrgAccess(req);
+    res.json(await svc.getWorktreeRunEngineStatus());
+  });
+
   router.post(
     "/instance/settings/experimental/issue-graph-liveness-auto-recovery/preview",
     validate(issueGraphLivenessAutoRecoveryRequestSchema),

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -5413,7 +5413,6 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     try {
       const activation = resolveWorktreeRunExecutionActivation(
         await instanceSettings.getExperimental(),
-        runtimeEnv.PAPERCLIP_INSTANCE_ID?.trim() || null,
       );
       const cutoff = activation.armed ? new Date(activation.cutoff) : null;
       cachedWorktreeRunExecutionOverride = {

--- a/server/src/services/instance-settings.ts
+++ b/server/src/services/instance-settings.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import type { Db } from "@paperclipai/db";
 import { companies, instanceSettings } from "@paperclipai/db";
 import {
@@ -13,7 +14,7 @@ import {
   type PatchInstanceSettings,
   type PatchInstanceExperimentalSettings,
 } from "@paperclipai/shared";
-import { eq } from "drizzle-orm";
+import { and, eq, sql } from "drizzle-orm";
 
 const DEFAULT_SINGLETON_KEY = "default";
 const instanceGeneralSettingsStorageSchema = instanceGeneralSettingsSchema.strip();
@@ -23,6 +24,7 @@ const TRUTHY_RUNTIME_ENV_VALUES = new Set(["1", "true", "yes", "on"]);
 interface InstanceSettingsServiceOptions {
   runtimeEnv?: Record<string, string | undefined>;
   now?: () => Date;
+  generateInstanceNonce?: () => string;
 }
 
 type WorktreeRunExecutionSuppressedReason =
@@ -51,15 +53,11 @@ export function isTruthyRuntimeEnvValue(value: string | undefined) {
   return typeof value === "string" && TRUTHY_RUNTIME_ENV_VALUES.has(value.trim().toLowerCase());
 }
 
-function getRuntimeInstanceId(env: Record<string, string | undefined>) {
-  const instanceId = env.PAPERCLIP_INSTANCE_ID?.trim();
-  return instanceId ? instanceId : null;
-}
-
 function stripServerManagedExperimentalPatchFields(
   patch: PatchInstanceExperimentalSettings | Record<string, unknown>,
 ): PatchInstanceExperimentalSettings {
   const {
+    worktreeRunExecutionInstanceNonce: _ignoredInstanceNonce,
     worktreeRunExecutionActivatedAt: _ignoredActivatedAt,
     worktreeRunExecutionActivationInstanceId: _ignoredActivationInstanceId,
     ...patchable
@@ -107,7 +105,7 @@ export function applyExperimentalSettingsPatch(
   return {
     ...nextExperimental,
     worktreeRunExecutionActivatedAt: (options.now ?? (() => new Date()))().toISOString(),
-    worktreeRunExecutionActivationInstanceId: getRuntimeInstanceId(runtimeEnv),
+    worktreeRunExecutionActivationInstanceId: nextExperimental.worktreeRunExecutionInstanceNonce,
   };
 }
 
@@ -125,7 +123,6 @@ function suppressWorktreeRunExecution(
 
 export function resolveWorktreeRunExecutionActivation(
   experimental: InstanceExperimentalSettings,
-  currentInstanceId: string | null | undefined,
 ): WorktreeRunExecutionActivationState {
   if (experimental.enableWorktreeRunExecution !== true) {
     return suppressWorktreeRunExecution(
@@ -139,13 +136,16 @@ export function resolveWorktreeRunExecutionActivation(
       experimental.worktreeRunExecutionActivationInstanceId,
     );
   }
-  if (!currentInstanceId) {
+  if (!experimental.worktreeRunExecutionInstanceNonce) {
     return suppressWorktreeRunExecution(
       "missing_instance_id",
       experimental.worktreeRunExecutionActivationInstanceId,
     );
   }
-  if (experimental.worktreeRunExecutionActivationInstanceId !== currentInstanceId) {
+  if (
+    experimental.worktreeRunExecutionActivationInstanceId !==
+    experimental.worktreeRunExecutionInstanceNonce
+  ) {
     return suppressWorktreeRunExecution(
       "instance_id_mismatch",
       experimental.worktreeRunExecutionActivationInstanceId,
@@ -154,7 +154,7 @@ export function resolveWorktreeRunExecutionActivation(
   return {
     armed: true,
     cutoff: experimental.worktreeRunExecutionActivatedAt,
-    activationInstanceId: currentInstanceId,
+    activationInstanceId: experimental.worktreeRunExecutionInstanceNonce,
     reason: null,
   };
 }
@@ -168,10 +168,7 @@ export async function resolveWorktreeRunExecutionActivationState(options: {
     return suppressWorktreeRunExecution("not_worktree_runtime");
   }
   try {
-    return resolveWorktreeRunExecutionActivation(
-      await options.getExperimental(),
-      getRuntimeInstanceId(runtimeEnv),
-    );
+    return resolveWorktreeRunExecutionActivation(await options.getExperimental());
   } catch {
     return suppressWorktreeRunExecution("settings_read_error");
   }
@@ -224,6 +221,7 @@ export function normalizeExperimentalSettings(raw: unknown): InstanceExperimenta
       enableWorkspaceBranchReconcileForward: parsed.data.enableWorkspaceBranchReconcileForward ?? true,
       enableWorkspaceDirtyQuarantineRepair: parsed.data.enableWorkspaceDirtyQuarantineRepair ?? true,
       enableWorktreeRunExecution: parsed.data.enableWorktreeRunExecution ?? false,
+      worktreeRunExecutionInstanceNonce: parsed.data.worktreeRunExecutionInstanceNonce ?? null,
       worktreeRunExecutionActivatedAt: parsed.data.worktreeRunExecutionActivatedAt ?? null,
       worktreeRunExecutionActivationInstanceId:
         parsed.data.worktreeRunExecutionActivationInstanceId ?? null,
@@ -255,6 +253,7 @@ export function normalizeExperimentalSettings(raw: unknown): InstanceExperimenta
     enableWorkspaceBranchReconcileForward: true,
     enableWorkspaceDirtyQuarantineRepair: true,
     enableWorktreeRunExecution: false,
+    worktreeRunExecutionInstanceNonce: null,
     worktreeRunExecutionActivatedAt: null,
     worktreeRunExecutionActivationInstanceId: null,
     issueGraphLivenessAutoRecoveryLookbackHours:
@@ -274,13 +273,47 @@ function toInstanceSettings(row: typeof instanceSettings.$inferSelect): Instance
 }
 
 export function instanceSettingsService(db: Db, options: InstanceSettingsServiceOptions = {}) {
+  const runtimeEnv = options.runtimeEnv ?? process.env;
+
+  async function ensureWorktreeInstanceNonce(row: typeof instanceSettings.$inferSelect) {
+    if (!isTruthyRuntimeEnvValue(runtimeEnv.PAPERCLIP_IN_WORKTREE)) return row;
+    if (normalizeExperimentalSettings(row.experimental).worktreeRunExecutionInstanceNonce) return row;
+
+    const now = new Date();
+    const instanceNonce = (options.generateInstanceNonce ?? randomUUID)();
+    const experimental = typeof row.experimental === "object" && row.experimental !== null
+      ? row.experimental
+      : {};
+    const [updated] = await db
+      .update(instanceSettings)
+      .set({
+        experimental: {
+          ...experimental,
+          worktreeRunExecutionInstanceNonce: instanceNonce,
+        },
+        updatedAt: now,
+      })
+      .where(and(
+        eq(instanceSettings.id, row.id),
+        sql`${instanceSettings.experimental} ->> 'worktreeRunExecutionInstanceNonce' is null`,
+      ))
+      .returning();
+    if (updated) return updated;
+
+    return await db
+      .select()
+      .from(instanceSettings)
+      .where(eq(instanceSettings.id, row.id))
+      .then((rows) => rows[0] ?? row);
+  }
+
   async function getOrCreateRow() {
     const existing = await db
       .select()
       .from(instanceSettings)
       .where(eq(instanceSettings.singletonKey, DEFAULT_SINGLETON_KEY))
       .then((rows) => rows[0] ?? null);
-    if (existing) return existing;
+    if (existing) return await ensureWorktreeInstanceNonce(existing);
 
     const now = new Date();
     const [created] = await db
@@ -300,14 +333,14 @@ export function instanceSettingsService(db: Db, options: InstanceSettingsService
       })
       .returning();
 
-    if (created) return created;
+    if (created) return await ensureWorktreeInstanceNonce(created);
 
     const raced = await db
       .select()
       .from(instanceSettings)
       .where(eq(instanceSettings.singletonKey, DEFAULT_SINGLETON_KEY))
       .then((rows) => rows[0] ?? null);
-    if (raced) return raced;
+    if (raced) return await ensureWorktreeInstanceNonce(raced);
 
     throw new Error("Failed to initialize instance settings row");
   }

--- a/server/src/services/instance-settings.ts
+++ b/server/src/services/instance-settings.ts
@@ -1,10 +1,11 @@
 import { randomUUID } from "node:crypto";
 import type { Db } from "@paperclipai/db";
-import { companies, instanceSettings } from "@paperclipai/db";
+import { companies, heartbeatRuns, instanceSettings } from "@paperclipai/db";
 import {
   DEFAULT_FEEDBACK_DATA_SHARING_PREFERENCE,
   DEFAULT_BACKUP_RETENTION,
   DEFAULT_ISSUE_GRAPH_LIVENESS_AUTO_RECOVERY_LOOKBACK_HOURS,
+  WORKTREE_SEED_QUARANTINE_ERROR_CODE,
   instanceGeneralSettingsSchema,
   type InstanceGeneralSettings,
   instanceExperimentalSettingsSchema,
@@ -13,6 +14,9 @@ import {
   type InstanceSettings,
   type PatchInstanceSettings,
   type PatchInstanceExperimentalSettings,
+  type WorktreeRunExecutionSuppressedReason,
+  type WorktreeRunExecutionActivationState,
+  type WorktreeRunEngineStatus,
 } from "@paperclipai/shared";
 import { and, eq, sql } from "drizzle-orm";
 
@@ -27,27 +31,10 @@ interface InstanceSettingsServiceOptions {
   generateInstanceNonce?: () => string;
 }
 
-type WorktreeRunExecutionSuppressedReason =
-  | "not_worktree_runtime"
-  | "flag_disabled"
-  | "missing_cutoff"
-  | "missing_instance_id"
-  | "instance_id_mismatch"
-  | "settings_read_error";
-
-export type WorktreeRunExecutionActivationState =
-  | {
-      armed: true;
-      cutoff: string;
-      activationInstanceId: string;
-      reason: null;
-    }
-  | {
-      armed: false;
-      cutoff: null;
-      activationInstanceId: string | null;
-      reason: WorktreeRunExecutionSuppressedReason;
-    };
+export type {
+  WorktreeRunExecutionSuppressedReason,
+  WorktreeRunExecutionActivationState,
+} from "@paperclipai/shared";
 
 export function isTruthyRuntimeEnvValue(value: string | undefined) {
   return typeof value === "string" && TRUTHY_RUNTIME_ENV_VALUES.has(value.trim().toLowerCase());
@@ -405,6 +392,31 @@ export function instanceSettingsService(db: Db, options: InstanceSettingsService
         .where(eq(instanceSettings.id, current.id))
         .returning();
       return toInstanceSettings(updated ?? current);
+    },
+
+    getWorktreeRunEngineStatus: async (): Promise<WorktreeRunEngineStatus> => {
+      const experimental = normalizeExperimentalSettings((await getOrCreateRow()).experimental);
+      const inWorktree = isTruthyRuntimeEnvValue(runtimeEnv.PAPERCLIP_IN_WORKTREE);
+      const activation = await resolveWorktreeRunExecutionActivationState({
+        getExperimental: async () => experimental,
+        runtimeEnv,
+      });
+      // Only quarantined-run rows survive a seed (P1 deletes the wakeups/monitors
+      // it clears), so this count is the durable evidence of what was neutralized.
+      let quarantinedRunCount = 0;
+      if (inWorktree) {
+        const [row] = await db
+          .select({ count: sql<number>`count(*)::int` })
+          .from(heartbeatRuns)
+          .where(eq(heartbeatRuns.errorCode, WORKTREE_SEED_QUARANTINE_ERROR_CODE));
+        quarantinedRunCount = row?.count ?? 0;
+      }
+      return {
+        inWorktree,
+        activation,
+        instanceNonce: experimental.worktreeRunExecutionInstanceNonce,
+        quarantinedRunCount,
+      };
     },
 
     listCompanyIds: async (): Promise<string[]> =>

--- a/server/src/services/workspace-runtime.ts
+++ b/server/src/services/workspace-runtime.ts
@@ -3357,6 +3357,15 @@ function renderRuntimeServiceEnv(input: {
   return rendered;
 }
 
+export function stripRuntimeServiceIdentityEnvOverrides(env: Record<string, string>) {
+  const {
+    PAPERCLIP_HOME: _ignoredPaperclipHome,
+    PAPERCLIP_INSTANCE_ID: _ignoredPaperclipInstanceId,
+    ...allowedEnv
+  } = env;
+  return allowedEnv;
+}
+
 function resolveRuntimeServiceReuseIdentity(input: {
   service: Record<string, unknown>;
   workspace: RealizedExecutionWorkspace;
@@ -3392,10 +3401,10 @@ function resolveRuntimeServiceReuseIdentity(input: {
     port: identityPort,
   });
   const serviceCwd = resolveConfiguredPath(renderTemplate(serviceCwdTemplate, templateData), input.workspace.cwd);
-  const renderedEnv = renderRuntimeServiceEnv({
+  const renderedEnv = stripRuntimeServiceIdentityEnvOverrides(renderRuntimeServiceEnv({
     envConfig,
     templateData,
-  });
+  }));
   const envFingerprint = createHash("sha256").update(stableStringify(renderedEnv)).digest("hex");
   const reuseKey =
     lifecycle === "shared"
@@ -3902,7 +3911,10 @@ async function spawnLocalRuntimeService(input: StartLocalRuntimeServiceInput): P
     ...sanitizeRuntimeServiceBaseEnv(process.env),
     ...input.adapterEnv,
   } as Record<string, string>;
-  for (const [key, value] of Object.entries(renderRuntimeServiceEnv({ envConfig, templateData }))) {
+  for (const [key, value] of Object.entries(stripRuntimeServiceIdentityEnvOverrides(renderRuntimeServiceEnv({
+    envConfig,
+    templateData,
+  })))) {
     env[key] = value;
   }
   if (port) {

--- a/ui/src/api/instanceSettings.ts
+++ b/ui/src/api/instanceSettings.ts
@@ -6,6 +6,7 @@ import type {
   PatchInstanceSettings,
   PatchInstanceGeneralSettings,
   PatchInstanceExperimentalSettings,
+  WorktreeRunEngineStatus,
 } from "@paperclipai/shared";
 import { api } from "./client";
 
@@ -22,6 +23,8 @@ export const instanceSettingsApi = {
     api.get<InstanceExperimentalSettings>("/instance/settings/experimental"),
   updateExperimental: (patch: PatchInstanceExperimentalSettings) =>
     api.patch<InstanceExperimentalSettings>("/instance/settings/experimental", patch),
+  getWorktreeRunEngine: () =>
+    api.get<WorktreeRunEngineStatus>("/instance/settings/experimental/worktree-run-engine"),
   previewIssueGraphLivenessAutoRecovery: (input: { lookbackHours?: number }) =>
     api.post<IssueGraphLivenessAutoRecoveryPreview>(
       "/instance/settings/experimental/issue-graph-liveness-auto-recovery/preview",

--- a/ui/src/components/IssueRunLedger.test.tsx
+++ b/ui/src/components/IssueRunLedger.test.tsx
@@ -607,4 +607,21 @@ describe("IssueRunLedger", () => {
 
     expect(container.querySelector('[data-testid="responsible-user-denial-notice"]')).toBeNull();
   });
+
+  it("marks worktree-seed quarantined runs as inherited and inactive", () => {
+    renderLedger({
+      runs: [
+        createRun({
+          runId: "run-inherited-1",
+          status: "cancelled",
+          livenessState: null,
+          errorCode: "worktree_seed_quarantine",
+        }),
+      ],
+    });
+
+    expect(container.textContent).toContain("Inherited · inactive");
+    // The inherited badge replaces the noisy liveness classification.
+    expect(container.textContent).not.toContain("No liveness data");
+  });
 });

--- a/ui/src/components/IssueRunLedger.tsx
+++ b/ui/src/components/IssueRunLedger.tsx
@@ -1,6 +1,10 @@
 import { useMemo, useState, type ReactNode } from "react";
 import type { ActivityEvent, Issue, Agent } from "@paperclipai/shared";
-import { isResponsibleUserDenialCode, responsibleUserLabel } from "@paperclipai/shared";
+import {
+  isResponsibleUserDenialCode,
+  responsibleUserLabel,
+  WORKTREE_SEED_QUARANTINE_ERROR_CODE,
+} from "@paperclipai/shared";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link } from "@/lib/router";
 import { accessApi, type CurrentBoardAccess } from "../api/access";
@@ -290,6 +294,15 @@ function statusLabel(status: string) {
 
 function isActiveRun(run: Pick<LedgerRun, "status" | "isLive">) {
   return run.isLive || ACTIVE_RUN_STATUSES.has(run.status);
+}
+
+/**
+ * PAP-14312: runs copied into a worktree seed are quarantined (cancelled +
+ * `worktree_seed_quarantine`) so they never execute in the preview. Render them
+ * as "inherited — inactive" instead of a scary failed/cancelled run.
+ */
+function isInheritedInactiveRun(run: Pick<RunForIssue, "errorCode">) {
+  return run.errorCode === WORKTREE_SEED_QUARANTINE_ERROR_CODE;
 }
 
 function runSummary(run: LedgerRun, agentMap: ReadonlyMap<string, Pick<Agent, "name">>) {
@@ -696,6 +709,7 @@ export function IssueRunLedgerContent({
               return <div key={`activity:${item.id}`}>{renderActivityEvent?.(item.event)}</div>;
             }
             const run = item.run;
+            const inheritedInactive = isInheritedInactiveRun(run);
             const liveness = livenessCopyForRun(run);
             const stopReason = stopReasonLabel(run);
             const duration = formatDuration(run.startedAt, run.finishedAt);
@@ -734,21 +748,31 @@ export function IssueRunLedgerContent({
                   <span className="rounded-md border border-border px-1.5 py-0.5 text-(length:--text-micro) capitalize text-muted-foreground">
                     {statusLabel(run.status)}
                   </span>
+                  {inheritedInactive ? (
+                    <span
+                      className="rounded-md border border-slate-400/40 bg-slate-400/10 px-1.5 py-0.5 text-(length:--text-micro) font-medium text-slate-600 dark:text-slate-300"
+                      title="Copied from another instance when this worktree was seeded. It never executed here."
+                    >
+                      Inherited · inactive
+                    </span>
+                  ) : null}
                   {run.isLive ? (
                     <span className="inline-flex items-center gap-1 rounded-md border border-blue-500/30 bg-blue-500/10 px-1.5 py-0.5 text-(length:--text-micro) text-blue-700 dark:text-blue-300">
                       <span className="h-1.5 w-1.5 rounded-full bg-blue-500" />
                       live
                     </span>
                   ) : null}
-                  <span
-                    className={cn(
-                      "rounded-md border px-1.5 py-0.5 text-(length:--text-micro) font-medium",
-                      liveness.tone,
-                    )}
-                    title={liveness.description}
-                  >
-                    {liveness.label}
-                  </span>
+                  {inheritedInactive ? null : (
+                    <span
+                      className={cn(
+                        "rounded-md border px-1.5 py-0.5 text-(length:--text-micro) font-medium",
+                        liveness.tone,
+                      )}
+                      title={liveness.description}
+                    >
+                      {liveness.label}
+                    </span>
+                  )}
                   {exhausted ? (
                     <span className="rounded-md border border-red-500/30 bg-red-500/10 px-1.5 py-0.5 text-(length:--text-micro) font-medium text-red-700 dark:text-red-300">
                       Exhausted

--- a/ui/src/components/Layout.tsx
+++ b/ui/src/components/Layout.tsx
@@ -17,6 +17,7 @@ import { KeyboardShortcutsCheatsheet } from "./KeyboardShortcutsCheatsheet";
 import { ToastViewport } from "./ToastViewport";
 import { MobileBottomNav } from "./MobileBottomNav";
 import { WorktreeBanner } from "./WorktreeBanner";
+import { WorktreeRunEngineBanner } from "./WorktreeRunEngineBanner";
 import { DevRestartBanner } from "./DevRestartBanner";
 import { StandaloneBrowserControls } from "./StandaloneBrowserControls";
 import { RouteErrorBoundary } from "./RouteErrorBoundary";
@@ -551,6 +552,7 @@ export function Layout() {
         Skip to Main Content
       </a>
       <WorktreeBanner />
+      <WorktreeRunEngineBanner variant="strip" />
       <DevRestartBanner devServer={health?.devServer} />
       <div className={cn("min-h-0 flex-1", isMobile ? "w-full" : "flex overflow-clip")}>
         {isMobile && sidebarOpen && (

--- a/ui/src/components/WorktreeRunEngineBanner.test.tsx
+++ b/ui/src/components/WorktreeRunEngineBanner.test.tsx
@@ -131,4 +131,24 @@ describe("WorktreeRunEngineBanner", () => {
     const strip = container.querySelector('[data-testid="worktree-run-engine-strip"]');
     expect(strip?.textContent).toContain("5 inherited runs inactive");
   });
+
+  // PAP-14415: the strip supplies its own bold "Run engine" subject, so the
+  // suppressed predicate must not restate it (no "Run engine run engine off").
+  it("does not stutter the run-engine subject in the suppressed strip", () => {
+    const container = mount(suppressed("flag_disabled", { quarantinedRunCount: 4 }), "strip");
+    const text = container
+      .querySelector('[data-testid="worktree-run-engine-strip"]')
+      ?.textContent?.replace(/\s+/g, " ");
+    expect(text).toContain("Run engine off");
+    expect(text).not.toMatch(/run engine run engine/i);
+  });
+
+  it("uses a bare predicate for a mismatched-identity strip", () => {
+    const container = mount(suppressed("instance_id_mismatch"), "strip");
+    const text = container
+      .querySelector('[data-testid="worktree-run-engine-strip"]')
+      ?.textContent?.replace(/\s+/g, " ");
+    expect(text).toContain("Run engine inactive — bound to another instance");
+    expect(text).not.toMatch(/run engine toggle inactive/i);
+  });
 });

--- a/ui/src/components/WorktreeRunEngineBanner.test.tsx
+++ b/ui/src/components/WorktreeRunEngineBanner.test.tsx
@@ -1,0 +1,134 @@
+// @vitest-environment jsdom
+
+import { flushSync } from "react-dom";
+import { createRoot, type Root } from "react-dom/client";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { WorktreeRunEngineStatus } from "@paperclipai/shared";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { WorktreeRunEngineBanner } from "./WorktreeRunEngineBanner";
+
+function render(status: WorktreeRunEngineStatus | undefined, variant: "strip" | "detail" = "detail") {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  flushSync(() => {
+    root.render(
+      <QueryClientProvider client={queryClient}>
+        <WorktreeRunEngineBanner variant={variant} status={status} />
+      </QueryClientProvider>,
+    );
+  });
+  return { container, root };
+}
+
+function armed(overrides: Partial<WorktreeRunEngineStatus> = {}): WorktreeRunEngineStatus {
+  return {
+    inWorktree: true,
+    activation: {
+      armed: true,
+      cutoff: "2026-07-10T18:34:00.000Z",
+      activationInstanceId: "nonce-aaaaaaaa1111",
+      reason: null,
+    },
+    instanceNonce: "nonce-aaaaaaaa1111",
+    quarantinedRunCount: 0,
+    ...overrides,
+  };
+}
+
+function suppressed(
+  reason: Extract<WorktreeRunEngineStatus["activation"], { armed: false }>["reason"],
+  overrides: Partial<WorktreeRunEngineStatus> = {},
+): WorktreeRunEngineStatus {
+  return {
+    inWorktree: true,
+    activation: {
+      armed: false,
+      cutoff: null,
+      activationInstanceId: reason === "instance_id_mismatch" ? "nonce-oldoldold9999" : null,
+      reason,
+    },
+    instanceNonce: "nonce-current0000",
+    quarantinedRunCount: 0,
+    ...overrides,
+  };
+}
+
+describe("WorktreeRunEngineBanner", () => {
+  let roots: Root[] = [];
+
+  beforeEach(() => {
+    roots = [];
+  });
+
+  afterEach(() => {
+    flushSync(() => {
+      roots.forEach((root) => root.unmount());
+    });
+    document.body.innerHTML = "";
+  });
+
+  function mount(status: WorktreeRunEngineStatus | undefined, variant: "strip" | "detail" = "detail") {
+    const { container, root } = render(status, variant);
+    roots.push(root);
+    return container;
+  }
+
+  it("renders nothing outside a worktree runtime", () => {
+    const container = mount({
+      inWorktree: false,
+      activation: { armed: false, cutoff: null, activationInstanceId: null, reason: "not_worktree_runtime" },
+      instanceNonce: null,
+      quarantinedRunCount: 0,
+    });
+    expect(container.textContent).toBe("");
+  });
+
+  it("renders nothing while the query has no data", () => {
+    const container = mount(undefined);
+    expect(container.textContent).toBe("");
+  });
+
+  it("shows the armed cutoff and a matching identity when armed", () => {
+    const container = mount(armed({ quarantinedRunCount: 3 }));
+    expect(container.textContent).toContain("Run engine armed since");
+    expect(container.textContent).toContain("matches");
+    expect(container.textContent).not.toContain("mismatch");
+    expect(container.textContent).toContain("3 inherited runs were quarantined");
+  });
+
+  it("reads an identity mismatch as bound to another instance", () => {
+    const container = mount(suppressed("instance_id_mismatch"));
+    expect(container.textContent).toContain("bound to another instance");
+    expect(container.textContent).toContain("mismatch");
+    // Both identities are surfaced so the mismatch is legible.
+    expect(container.textContent).toContain("nonce-ol");
+    expect(container.textContent).toContain("nonce-cu");
+  });
+
+  it("explains a missing activation cutoff", () => {
+    const container = mount(suppressed("missing_cutoff"));
+    expect(container.textContent).toContain("missing activation cutoff");
+    expect(container.textContent).toContain("Toggle it off and back on");
+  });
+
+  it("explains a flag-disabled run engine", () => {
+    const container = mount(suppressed("flag_disabled"));
+    expect(container.textContent).toContain("Run engine off");
+  });
+
+  it("renders a dense single-line strip variant", () => {
+    const container = mount(armed(), "strip");
+    const strip = container.querySelector('[data-testid="worktree-run-engine-strip"]');
+    expect(strip).not.toBeNull();
+    expect(strip?.textContent).toContain("Run engine");
+    expect(strip?.textContent).toContain("armed since");
+  });
+
+  it("surfaces quarantined counts in the strip when suppressed", () => {
+    const container = mount(suppressed("flag_disabled", { quarantinedRunCount: 5 }), "strip");
+    const strip = container.querySelector('[data-testid="worktree-run-engine-strip"]');
+    expect(strip?.textContent).toContain("5 inherited runs inactive");
+  });
+});

--- a/ui/src/components/WorktreeRunEngineBanner.tsx
+++ b/ui/src/components/WorktreeRunEngineBanner.tsx
@@ -201,6 +201,9 @@ export function WorktreeRunEngineBanner({
   }
 
   const copy = suppressionCopy(activation, instanceNonce);
+  // The identity binding is only meaningful when it's the reason execution is
+  // suppressed; showing a "mismatch" badge on a plainly-off engine reads as noise.
+  const showIdentity = activation.reason === "instance_id_mismatch";
   return (
     <div
       role="status"
@@ -214,7 +217,7 @@ export function WorktreeRunEngineBanner({
           <p className="text-muted-foreground">{copy.detail}</p>
         </div>
       </div>
-      <IdentityLine activation={activation} instanceNonce={instanceNonce} />
+      {showIdentity ? <IdentityLine activation={activation} instanceNonce={instanceNonce} /> : null}
       <QuarantineLine count={quarantinedRunCount} />
     </div>
   );

--- a/ui/src/components/WorktreeRunEngineBanner.tsx
+++ b/ui/src/components/WorktreeRunEngineBanner.tsx
@@ -19,7 +19,14 @@ function shortIdentity(value: string | null | undefined): string {
   return value.length > 8 ? value.slice(0, 8) : value;
 }
 
-type SuppressionCopy = { headline: string; detail: string };
+/**
+ * `headline`/`detail` drive the fuller detail banner. `stripLabel` is the bare
+ * predicate the dense strip appends after its own bold "Run engine" subject —
+ * the detail headlines each restate that subject, so reusing them there stutters
+ * ("Run engine run engine off"). Keeping a dedicated field stops the two copies
+ * from drifting.
+ */
+type SuppressionCopy = { headline: string; detail: string; stripLabel: string };
 
 /**
  * Human-readable copy for each fail-closed reason. `instance_id_mismatch` is
@@ -35,18 +42,21 @@ function suppressionCopy(
         headline: "Run engine off",
         detail:
           "The scheduler will not execute tasks in this worktree. Inherited tasks stay parked. Turn on “Run tasks in this worktree” to arm execution.",
+        stripLabel: "off",
       };
     case "missing_cutoff":
       return {
         headline: "Execution suppressed — missing activation cutoff",
         detail:
           "This setting has no activation cutoff, so no tasks run automatically. Toggle it off and back on to arm execution for tasks created here.",
+        stripLabel: "suppressed — missing cutoff",
       };
     case "missing_instance_id":
       return {
         headline: "Execution suppressed — no instance identity",
         detail:
           "This worktree has not stamped an instance identity yet, so execution fails closed. Toggle off and back on to arm execution.",
+        stripLabel: "suppressed — no identity",
       };
     case "instance_id_mismatch":
       return {
@@ -56,18 +66,21 @@ function suppressionCopy(
         )} and copied here; this boot is ${shortIdentity(
           instanceNonce,
         )}. No tasks run automatically. Toggle off and back on to re-arm execution for this instance.`,
+        stripLabel: "inactive — bound to another instance",
       };
     case "settings_read_error":
       return {
         headline: "Execution suppressed — settings unavailable",
         detail:
           "The run engine could not read its settings, so it fails closed and no tasks run automatically.",
+        stripLabel: "suppressed — settings unavailable",
       };
     case "not_worktree_runtime":
     default:
       return {
         headline: "Execution suppressed",
         detail: "No tasks run automatically in this instance.",
+        stripLabel: "suppressed",
       };
   }
 }
@@ -166,7 +179,7 @@ export function WorktreeRunEngineBanner({
           {armed ? (
             <>armed since {formatActivationTimestamp(activation.cutoff)}</>
           ) : (
-            <>{suppressionCopy(activation, instanceNonce).headline.toLowerCase()}</>
+            <>{suppressionCopy(activation, instanceNonce).stripLabel}</>
           )}
           {quarantinedRunCount > 0 ? (
             <span className="text-muted-foreground">
@@ -191,7 +204,7 @@ export function WorktreeRunEngineBanner({
           <span>
             Run engine armed since{" "}
             <span className="font-medium">{formatActivationTimestamp(activation.cutoff)}</span>. Tasks
-            created after this run automatically.
+            created after this point run automatically.
           </span>
         </div>
         <IdentityLine activation={activation} instanceNonce={instanceNonce} />

--- a/ui/src/components/WorktreeRunEngineBanner.tsx
+++ b/ui/src/components/WorktreeRunEngineBanner.tsx
@@ -1,0 +1,221 @@
+import { useQuery } from "@tanstack/react-query";
+import { AlertTriangle, Fingerprint, Pause, Play } from "lucide-react";
+import type {
+  WorktreeRunEngineStatus,
+  WorktreeRunExecutionActivationState,
+} from "@paperclipai/shared";
+import { instanceSettingsApi } from "@/api/instanceSettings";
+import { queryKeys } from "../lib/queryKeys";
+import { cn } from "../lib/utils";
+
+function formatActivationTimestamp(iso: string): string {
+  const parsed = new Date(iso);
+  if (Number.isNaN(parsed.getTime())) return iso;
+  return parsed.toLocaleString(undefined, { dateStyle: "medium", timeStyle: "short" });
+}
+
+function shortIdentity(value: string | null | undefined): string {
+  if (!value) return "—";
+  return value.length > 8 ? value.slice(0, 8) : value;
+}
+
+type SuppressionCopy = { headline: string; detail: string };
+
+/**
+ * Human-readable copy for each fail-closed reason. `instance_id_mismatch` is
+ * handled separately because it interpolates the two identities.
+ */
+function suppressionCopy(
+  activation: Extract<WorktreeRunExecutionActivationState, { armed: false }>,
+  instanceNonce: string | null,
+): SuppressionCopy {
+  switch (activation.reason) {
+    case "flag_disabled":
+      return {
+        headline: "Run engine off",
+        detail:
+          "The scheduler will not execute tasks in this worktree. Inherited tasks stay parked. Turn on “Run tasks in this worktree” to arm execution.",
+      };
+    case "missing_cutoff":
+      return {
+        headline: "Execution suppressed — missing activation cutoff",
+        detail:
+          "This setting has no activation cutoff, so no tasks run automatically. Toggle it off and back on to arm execution for tasks created here.",
+      };
+    case "missing_instance_id":
+      return {
+        headline: "Execution suppressed — no instance identity",
+        detail:
+          "This worktree has not stamped an instance identity yet, so execution fails closed. Toggle off and back on to arm execution.",
+      };
+    case "instance_id_mismatch":
+      return {
+        headline: "Toggle inactive — bound to another instance",
+        detail: `This setting was armed against instance ${shortIdentity(
+          activation.activationInstanceId,
+        )} and copied here; this boot is ${shortIdentity(
+          instanceNonce,
+        )}. No tasks run automatically. Toggle off and back on to re-arm execution for this instance.`,
+      };
+    case "settings_read_error":
+      return {
+        headline: "Execution suppressed — settings unavailable",
+        detail:
+          "The run engine could not read its settings, so it fails closed and no tasks run automatically.",
+      };
+    case "not_worktree_runtime":
+    default:
+      return {
+        headline: "Execution suppressed",
+        detail: "No tasks run automatically in this instance.",
+      };
+  }
+}
+
+function QuarantineLine({ count }: { count: number }) {
+  if (count <= 0) return null;
+  return (
+    <p className="text-xs text-muted-foreground">
+      {count} inherited {count === 1 ? "run was" : "runs were"} quarantined at seed time and remain
+      inactive. Cleared wakeups and monitors are not retained.
+    </p>
+  );
+}
+
+function IdentityLine({
+  activation,
+  instanceNonce,
+}: {
+  activation: WorktreeRunExecutionActivationState;
+  instanceNonce: string | null;
+}) {
+  const matches =
+    activation.armed || activation.activationInstanceId === instanceNonce;
+  return (
+    <p className="flex flex-wrap items-center gap-1.5 text-xs text-muted-foreground">
+      <Fingerprint className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+      <span>
+        Bound to <span className="font-mono text-foreground">{shortIdentity(activation.activationInstanceId)}</span>
+      </span>
+      <span aria-hidden="true">·</span>
+      <span>
+        this boot <span className="font-mono text-foreground">{shortIdentity(instanceNonce)}</span>
+      </span>
+      <span
+        className={cn(
+          "rounded-md border px-1.5 py-0.5 text-(length:--text-micro) font-medium",
+          matches
+            ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300"
+            : "border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-300",
+        )}
+      >
+        {matches ? "matches" : "mismatch"}
+      </span>
+    </p>
+  );
+}
+
+/**
+ * PAP-14312: persistent boot-truth for the worktree run engine. Renders nothing
+ * outside a worktree runtime. Otherwise it reports whether the scheduler is armed
+ * or suppressed (and why), which instance identity the toggle is bound to, and how
+ * many inherited runs were quarantined at seed time.
+ *
+ * `variant="strip"` is a single dense line for the app shell; `variant="detail"`
+ * is the fuller block used on the Experimental Settings page.
+ */
+export function WorktreeRunEngineBanner({
+  variant = "detail",
+  status: statusOverride,
+}: {
+  variant?: "strip" | "detail";
+  /** Injected in tests/stories to bypass the network query. */
+  status?: WorktreeRunEngineStatus;
+}) {
+  const query = useQuery({
+    queryKey: queryKeys.instance.worktreeRunEngine,
+    queryFn: () => instanceSettingsApi.getWorktreeRunEngine(),
+    enabled: statusOverride === undefined,
+  });
+
+  const status = statusOverride ?? query.data;
+  if (!status || !status.inWorktree) return null;
+
+  const { activation, instanceNonce, quarantinedRunCount } = status;
+  const armed = activation.armed;
+
+  if (variant === "strip") {
+    return (
+      <div
+        role="status"
+        data-testid="worktree-run-engine-strip"
+        className={cn(
+          "flex items-center gap-2 border-b px-3 py-1.5 text-xs",
+          armed
+            ? "border-emerald-500/30 bg-emerald-500/5 text-foreground"
+            : "border-amber-500/30 bg-amber-500/5 text-foreground",
+        )}
+      >
+        {armed ? (
+          <Play className="h-3.5 w-3.5 shrink-0 text-emerald-600" aria-hidden="true" />
+        ) : (
+          <Pause className="h-3.5 w-3.5 shrink-0 text-amber-700" aria-hidden="true" />
+        )}
+        <span className="min-w-0 truncate">
+          <span className="font-medium">Run engine</span>{" "}
+          {armed ? (
+            <>armed since {formatActivationTimestamp(activation.cutoff)}</>
+          ) : (
+            <>{suppressionCopy(activation, instanceNonce).headline.toLowerCase()}</>
+          )}
+          {quarantinedRunCount > 0 ? (
+            <span className="text-muted-foreground">
+              {" · "}
+              {quarantinedRunCount} inherited {quarantinedRunCount === 1 ? "run" : "runs"} inactive
+            </span>
+          ) : null}
+        </span>
+      </div>
+    );
+  }
+
+  if (armed) {
+    return (
+      <div
+        role="status"
+        data-testid="worktree-run-engine-banner"
+        className="space-y-2 rounded-md border border-emerald-500/30 bg-emerald-500/5 px-3 py-2.5 text-sm text-foreground"
+      >
+        <div className="flex items-center gap-2">
+          <Play className="h-4 w-4 shrink-0 text-emerald-600" aria-hidden="true" />
+          <span>
+            Run engine armed since{" "}
+            <span className="font-medium">{formatActivationTimestamp(activation.cutoff)}</span>. Tasks
+            created after this run automatically.
+          </span>
+        </div>
+        <IdentityLine activation={activation} instanceNonce={instanceNonce} />
+        <QuarantineLine count={quarantinedRunCount} />
+      </div>
+    );
+  }
+
+  const copy = suppressionCopy(activation, instanceNonce);
+  return (
+    <div
+      role="status"
+      data-testid="worktree-run-engine-banner"
+      className="space-y-2 rounded-md border border-amber-500/30 bg-amber-500/5 px-3 py-2.5 text-sm"
+    >
+      <div className="flex items-start gap-2">
+        <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-700" aria-hidden="true" />
+        <div className="space-y-0.5">
+          <p className="font-medium text-foreground">{copy.headline}</p>
+          <p className="text-muted-foreground">{copy.detail}</p>
+        </div>
+      </div>
+      <IdentityLine activation={activation} instanceNonce={instanceNonce} />
+      <QuarantineLine count={quarantinedRunCount} />
+    </div>
+  );
+}

--- a/ui/src/lib/queryKeys.ts
+++ b/ui/src/lib/queryKeys.ts
@@ -314,6 +314,7 @@ export const queryKeys = {
     generalSettings: ["instance", "general-settings"] as const,
     schedulerHeartbeats: ["instance", "scheduler-heartbeats"] as const,
     experimentalSettings: ["instance", "experimental-settings"] as const,
+    worktreeRunEngine: ["instance", "worktree-run-engine"] as const,
   },
   cloudUpstreams: (companyId: string) => ["cloud-upstreams", companyId] as const,
   health: ["health"] as const,

--- a/ui/src/pages/InstanceExperimentalSettings.test.tsx
+++ b/ui/src/pages/InstanceExperimentalSettings.test.tsx
@@ -13,6 +13,7 @@ import { InstanceExperimentalSettings } from "./InstanceExperimentalSettings";
 const mockInstanceSettingsApi = vi.hoisted(() => ({
   getExperimental: vi.fn(),
   updateExperimental: vi.fn(),
+  getWorktreeRunEngine: vi.fn(),
   previewIssueGraphLivenessAutoRecovery: vi.fn(),
   runIssueGraphLivenessAutoRecovery: vi.fn(),
 }));
@@ -165,6 +166,20 @@ describe("InstanceExperimentalSettings — Conference Room Chat card (PAP-11233)
     mockInstanceSettingsApi.updateExperimental.mockImplementation(async (patch) => {
       currentExperimentalSettings = { ...currentExperimentalSettings, ...patch };
       return { ...currentExperimentalSettings };
+    });
+    // Boot-truth banner (PAP-14312) has its own coverage in
+    // WorktreeRunEngineBanner.test.tsx; here it defaults to not-in-worktree so
+    // the page tests focus on the toggle and delegation.
+    mockInstanceSettingsApi.getWorktreeRunEngine.mockResolvedValue({
+      inWorktree: false,
+      activation: {
+        armed: false,
+        cutoff: null,
+        activationInstanceId: null,
+        reason: "not_worktree_runtime",
+      },
+      instanceNonce: null,
+      quarantinedRunCount: 0,
     });
   });
 
@@ -364,59 +379,30 @@ describe("InstanceExperimentalSettings — Conference Room Chat card (PAP-11233)
       "Only tasks created after enabling will run automatically",
     );
     expect(container.textContent).toContain("Toggling off and on resets the cutoff.");
-    // Off => no armed banner and no fail-closed hint.
-    expect(container.textContent).not.toContain("Running tasks created after");
-    expect(container.textContent).not.toContain("Execution is suppressed");
   });
 
-  it("shows the armed timestamp when the flag matches the current instance", async () => {
+  // The armed/suppressed/identity boot-truth states now live in the
+  // WorktreeRunEngineBanner (PAP-14312); the settings card only delegates to it.
+  // Full state coverage lives in WorktreeRunEngineBanner.test.tsx.
+  it("renders the run-engine boot-truth banner inside the worktree card", async () => {
     setWorktreeRuntimeMeta(true);
-    setWorktreeInstanceIdMeta("inst-current");
-    currentExperimentalSettings = {
-      ...currentExperimentalSettings,
-      enableWorktreeRunExecution: true,
-      worktreeRunExecutionActivatedAt: "2026-07-10T18:34:00.000Z",
-      worktreeRunExecutionActivationInstanceId: "inst-current",
-    };
+    mockInstanceSettingsApi.getWorktreeRunEngine.mockResolvedValue({
+      inWorktree: true,
+      activation: {
+        armed: true,
+        cutoff: "2026-07-10T18:34:00.000Z",
+        activationInstanceId: "nonce-current",
+        reason: null,
+      },
+      instanceNonce: "nonce-current",
+      quarantinedRunCount: 2,
+    });
     await renderPage();
 
-    expect(container.textContent).toContain("Running tasks created after");
-    expect(container.textContent).not.toContain("Execution is suppressed");
-    const toggle = container.querySelector<HTMLButtonElement>(WORKTREE_RUN_EXECUTION_TOGGLE_SELECTOR);
-    expect(toggle?.getAttribute("aria-checked")).toBe("true");
-  });
-
-  it("fails closed with a re-enable hint when the flag was armed in another instance", async () => {
-    setWorktreeRuntimeMeta(true);
-    setWorktreeInstanceIdMeta("inst-current");
-    currentExperimentalSettings = {
-      ...currentExperimentalSettings,
-      enableWorktreeRunExecution: true,
-      worktreeRunExecutionActivatedAt: "2026-07-10T18:34:00.000Z",
-      worktreeRunExecutionActivationInstanceId: "inst-other",
-    };
-    await renderPage();
-
-    expect(container.textContent).toContain("Execution is suppressed");
-    expect(container.textContent).toContain("armed in a different instance");
-    expect(container.textContent).toContain("Toggle it off and back on");
-    expect(container.textContent).not.toContain("Running tasks created after");
-  });
-
-  it("fails closed with a re-enable hint when the activation cutoff is missing", async () => {
-    setWorktreeRuntimeMeta(true);
-    setWorktreeInstanceIdMeta("inst-current");
-    currentExperimentalSettings = {
-      ...currentExperimentalSettings,
-      enableWorktreeRunExecution: true,
-      worktreeRunExecutionActivatedAt: null,
-      worktreeRunExecutionActivationInstanceId: null,
-    };
-    await renderPage();
-
-    expect(container.textContent).toContain("Execution is suppressed");
-    expect(container.textContent).toContain("missing its activation cutoff");
-    expect(container.textContent).not.toContain("Running tasks created after");
+    const banner = container.querySelector('[data-testid="worktree-run-engine-banner"]');
+    expect(banner).not.toBeNull();
+    expect(banner?.textContent).toContain("Run engine armed since");
+    expect(banner?.textContent).toContain("2 inherited runs were quarantined");
   });
 
   it("renders and patches the Built-in Agents experimental toggle", async () => {

--- a/ui/src/pages/InstanceExperimentalSettings.test.tsx
+++ b/ui/src/pages/InstanceExperimentalSettings.test.tsx
@@ -82,9 +82,10 @@ function defaultExperimentalSettings(): InstanceExperimentalSettingsPayload {
     enableIssueGraphLivenessAutoRecovery: false,
     issueGraphLivenessAutoRecoveryLookbackHours: 24,
     enableWorkspaceBranchReconcileForward: true,
-    enableWorkspaceDirtyQuarantineRepair: true,
-    enableWorktreeRunExecution: false,
-    worktreeRunExecutionActivatedAt: null,
+  enableWorkspaceDirtyQuarantineRepair: true,
+  enableWorktreeRunExecution: false,
+  worktreeRunExecutionInstanceNonce: null,
+  worktreeRunExecutionActivatedAt: null,
     worktreeRunExecutionActivationInstanceId: null,
   };
 }

--- a/ui/src/pages/InstanceExperimentalSettings.test.tsx
+++ b/ui/src/pages/InstanceExperimentalSettings.test.tsx
@@ -82,10 +82,10 @@ function defaultExperimentalSettings(): InstanceExperimentalSettingsPayload {
     enableIssueGraphLivenessAutoRecovery: false,
     issueGraphLivenessAutoRecoveryLookbackHours: 24,
     enableWorkspaceBranchReconcileForward: true,
-  enableWorkspaceDirtyQuarantineRepair: true,
-  enableWorktreeRunExecution: false,
-  worktreeRunExecutionInstanceNonce: null,
-  worktreeRunExecutionActivatedAt: null,
+    enableWorkspaceDirtyQuarantineRepair: true,
+    enableWorktreeRunExecution: false,
+    worktreeRunExecutionInstanceNonce: null,
+    worktreeRunExecutionActivatedAt: null,
     worktreeRunExecutionActivationInstanceId: null,
   };
 }

--- a/ui/src/pages/InstanceExperimentalSettings.tsx
+++ b/ui/src/pages/InstanceExperimentalSettings.tsx
@@ -7,7 +7,8 @@ import type {
   PatchInstanceExperimentalSettings,
 } from "@paperclipai/shared";
 import { instanceSettingsApi } from "@/api/instanceSettings";
-import { getWorktreeInstanceId, isWorktreeRuntime } from "../lib/worktree-branding";
+import { isWorktreeRuntime } from "../lib/worktree-branding";
+import { WorktreeRunEngineBanner } from "@/components/WorktreeRunEngineBanner";
 import { useBreadcrumbs } from "../context/BreadcrumbContext";
 import { queryKeys } from "../lib/queryKeys";
 import { ToggleSwitch } from "@/components/ui/toggle-switch";
@@ -32,43 +33,6 @@ function issueHref(identifier: string | null, issueId: string) {
 
 function formatRecoveryState(state: string) {
   return state.replace(/_/g, " ");
-}
-
-type WorktreeRunExecutionDisplayState =
-  | { kind: "off" }
-  | { kind: "armed"; activatedAt: string }
-  | { kind: "fail_closed"; reason: "missing_cutoff" | "missing_instance_id" | "instance_mismatch" };
-
-/**
- * Mirror of the server's `resolveWorktreeRunExecutionActivation` fail-closed
- * ladder (server/src/services/instance-settings.ts) so the card never claims a
- * copied/legacy row is arming execution. The derived fields are display-only —
- * the PATCH the toggle sends still writes just the boolean.
- */
-function resolveWorktreeRunExecutionDisplayState(
-  settings:
-    | Pick<
-        InstanceExperimentalSettings,
-        | "enableWorktreeRunExecution"
-        | "worktreeRunExecutionActivatedAt"
-        | "worktreeRunExecutionActivationInstanceId"
-      >
-    | undefined,
-  currentInstanceId: string | null,
-): WorktreeRunExecutionDisplayState {
-  if (settings?.enableWorktreeRunExecution !== true) return { kind: "off" };
-  if (!settings.worktreeRunExecutionActivatedAt) return { kind: "fail_closed", reason: "missing_cutoff" };
-  if (!currentInstanceId) return { kind: "fail_closed", reason: "missing_instance_id" };
-  if (settings.worktreeRunExecutionActivationInstanceId !== currentInstanceId) {
-    return { kind: "fail_closed", reason: "instance_mismatch" };
-  }
-  return { kind: "armed", activatedAt: settings.worktreeRunExecutionActivatedAt };
-}
-
-function formatActivationTimestamp(iso: string): string {
-  const parsed = new Date(iso);
-  if (Number.isNaN(parsed.getTime())) return iso;
-  return parsed.toLocaleString(undefined, { dateStyle: "medium", timeStyle: "short" });
 }
 
 // PAP-11233: keep Conference Room code intact, but hide the user-facing opt-in for now.
@@ -214,6 +178,7 @@ export function InstanceExperimentalSettings() {
       queryClient.setQueryData(queryKeys.instance.experimentalSettings, updatedSettings);
       await Promise.all([
         queryClient.invalidateQueries({ queryKey: queryKeys.instance.experimentalSettings }),
+        queryClient.invalidateQueries({ queryKey: queryKeys.instance.worktreeRunEngine }),
         queryClient.invalidateQueries({ queryKey: ["built-in-agents"] }),
         queryClient.invalidateQueries({ queryKey: queryKeys.health }),
       ]);
@@ -278,10 +243,6 @@ export function InstanceExperimentalSettings() {
 
   const inWorktree = isWorktreeRuntime();
   const enableWorktreeRunExecution = experimentalQuery.data?.enableWorktreeRunExecution === true;
-  const worktreeRunExecutionState = resolveWorktreeRunExecutionDisplayState(
-    experimentalQuery.data,
-    getWorktreeInstanceId(),
-  );
   const enableEnvironments = experimentalQuery.data?.enableEnvironments === true;
   const enableIsolatedWorkspaces = experimentalQuery.data?.enableIsolatedWorkspaces === true;
   const enableApps = experimentalQuery.data?.enableApps === true;
@@ -397,33 +358,7 @@ export function InstanceExperimentalSettings() {
               />
             </div>
 
-            {worktreeRunExecutionState.kind === "armed" ? (
-              <div className="flex items-center gap-2 rounded-md border border-emerald-500/30 bg-emerald-500/5 px-3 py-2 text-sm text-foreground">
-                <Play className="h-4 w-4 shrink-0 text-emerald-600" />
-                <span>
-                  Running tasks created after{" "}
-                  <span className="font-medium">
-                    {formatActivationTimestamp(worktreeRunExecutionState.activatedAt)}
-                  </span>
-                  .
-                </span>
-              </div>
-            ) : null}
-
-            {worktreeRunExecutionState.kind === "fail_closed" ? (
-              <div className="flex items-start gap-2 rounded-md border border-amber-500/30 bg-amber-500/5 px-3 py-2 text-sm">
-                <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-700" />
-                <div className="space-y-0.5">
-                  <p className="font-medium text-foreground">Execution is suppressed — effectively off.</p>
-                  <p className="text-muted-foreground">
-                    {worktreeRunExecutionState.reason === "instance_mismatch"
-                      ? "This setting was armed in a different instance and copied here, so no tasks run automatically."
-                      : "This setting is missing its activation cutoff, so no tasks run automatically."}{" "}
-                    Toggle it off and back on to arm execution for tasks created here.
-                  </p>
-                </div>
-              </div>
-            ) : null}
+            <WorktreeRunEngineBanner variant="detail" />
           </div>
         </Card>
       ) : null}


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Preview/CI **git worktrees** boot from a copy of a live instance's database, so they inherit its in-flight heartbeat runs, wakeups, and monitors. A worktree run engine exists precisely so those inherited runs do **not** silently execute against the wrong instance.
> - The neutralizing machinery works, but it is invisible in the UI: inherited-but-inert runs looked identical to live/failed ones, and the arming toggle could be bound to a different instance's identity and do nothing — with no on-screen signal.
> - A worktree operator therefore could not tell "inherited, inert" state from real execution at a glance, and a dead toggle read as a silently-broken feature.
> - This pull request surfaces boot-time truth: it renders neutralized runs as "inherited · inactive", adds a persistent run-engine banner (suppressed / armed-since) with counts of what was neutralized, and shows the toggle's activation identity only when it is actually mismatched.
> - The benefit is that a worktree boot is legible — you can trust what is and isn't running, and a dead toggle is visible instead of silent.

## Linked Issues or Issue Description

This PR is part of a stack that makes worktree boots truthful about inherited run state:

- Depends on #9703 (cold-quarantine worktree seeds — stamps neutralized runs with a `worktree_seed_quarantine` error code) and #9711 (bind worktree activation to a per-instance nonce). This branch is stacked on top of #9711 and should merge after both.

**Problem (feature):** When a Paperclip instance runs inside a git worktree seeded from another instance's database, it inherits heartbeat runs, wakeups, and monitors. The server already neutralizes these at seed time and gates execution behind an activation toggle bound to the instance's identity nonce — but none of this is visible in the UI. Inherited-inert runs are indistinguishable from live ones, and if the activation toggle is bound to a different instance's nonce it silently does nothing. Operators cannot tell what is actually executing, and a dead toggle looks broken rather than intentionally inert.

## What Changed

- **Shared types**: added `WorktreeRunEngineStatus`, the `WorktreeRunExecutionActivationState` discriminated union, `WorktreeRunExecutionSuppressedReason`, and the `WORKTREE_SEED_QUARANTINE_ERROR_CODE` constant to `@paperclipai/shared` (server re-exports for back-compat).
- **Server**: new `GET /instance/settings/experimental/worktree-run-engine` endpoint that resolves activation server-side through the same gate the scheduler uses, and counts `heartbeat_runs` neutralized at seed time (the only durable evidence — cleared wakeups/monitors are deleted).
- **UI — inherited runs**: `IssueRunLedger` renders quarantined runs as a slate "Inherited · inactive" badge and suppresses their liveness badge, so they read distinctly from live/failed runs.
- **UI — run-engine banner**: new `WorktreeRunEngineBanner` with a compact app-shell strip variant and a detailed Experimental Settings variant, reporting "suppressed"/"armed since &lt;time&gt;" plus counts of what was neutralized at seed time.
- **UI — toggle identity**: the activation identity binding (both nonces + a match/mismatch chip) is shown only on an actual mismatch, so an identity-bound-to-another-instance toggle reads "inactive: bound to another instance" instead of silently doing nothing.
- **Tests**: component tests for the banner states and the inherited-inactive ledger rendering; updated Experimental Settings tests.

## Verification

- `cd ui && npx vitest run src/components/WorktreeRunEngineBanner.test.tsx src/components/IssueRunLedger.test.tsx` → 29 passed
- `cd ui && npx vitest run src/pages/InstanceExperimentalSettings.test.tsx` → 17 passed
- Manual: screenshots of each state (disarmed worktree with quarantined data → banner + inherited-inactive runs; armed worktree → "armed since"; identity-mismatched toggle → mismatch) were produced and design-reviewed.

## Risks

- Low risk. Additive UI + one read-only GET endpoint. No schema changes, no migrations. The banner and endpoint no-op outside worktree runtimes (`inWorktree=false`), so behavior in normal instances is unchanged. Type moves to `@paperclipai/shared` are re-exported server-side for back-compat.

## Model Used

- Claude Opus 4.8 (`claude-opus-4-8`), extended thinking, with tool use / code execution via the Paperclip ACPX harness.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
