### PR TITLE
fix(server): mark clear-error OpenAPI contract as board-only

### DIFF
--- a/docs/api/agents.md
+++ b/docs/api/agents.md
@@ -101,6 +101,7 @@ POST /api/agents/{agentId}/clear-error
 
 Moves an agent from `error` back to `idle` without deleting run history or runtime diagnostics.
 Only agents currently in `error` can be cleared.
+This endpoint requires board operator authentication; agent API keys and agent JWTs are rejected.
 
 ## Terminate Agent
 

--- a/server/src/__tests__/openapi-routes.test.ts
+++ b/server/src/__tests__/openapi-routes.test.ts
@@ -216,6 +216,13 @@ describe("openapi routes", () => {
       actor: "board",
       instanceAdmin: true,
     });
+    expect(spec.paths["/api/agents/{id}/clear-error"].post.security).toEqual([
+      { BoardSessionAuth: [] },
+      { BoardApiKeyAuth: [] },
+    ]);
+    expect(spec.paths["/api/agents/{id}/clear-error"].post["x-paperclip-authorization"]).toEqual({
+      actor: "board",
+    });
     expect(spec.paths["/api/execution-workspaces/{id}/reconcile-branch"].post.security).toEqual([
       { BoardSessionAuth: [] },
       { BoardApiKeyAuth: [] },

--- a/server/src/routes/openapi.ts
+++ b/server/src/routes/openapi.ts
@@ -717,6 +717,7 @@ const BOARD_ONLY_OPERATIONS = new Set([
   "POST /api/companies/{companyId}/members/{memberId}/archive",
   "PATCH /api/companies/{companyId}/members/{memberId}/permissions",
   "GET /api/companies/{companyId}/user-directory",
+  "POST /api/agents/{id}/clear-error",
   "POST /api/execution-workspaces/{id}/reconcile-branch",
   "GET /api/board-api-keys",
   "POST /api/board-api-keys",


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Control-plane agent lifecycle APIs include `POST /api/agents/{id}/clear-error`, which resets an agent from `error` to `idle`
> - Generated OpenAPI previously advertised `AgentBearerAuth` / `board_or_agent` for that route, but the runtime handler still begins with `assertBoard(req)` and rejects agent credentials with `403 Board access required`
> - That contract mismatch misleads operators and agent clients into attempting an unauthorized recovery path
> - This pull request keeps the secure board-only runtime unchanged and corrects OpenAPI + operator docs so the advertised auth matches reality
> - The benefit is an honest, least-privilege contract with no permission broadening and a one-line rollback path

## Linked Issues or Issue Description

No public GitHub issue. Duplicate searches for `clear-error` OpenAPI / board-only auth mismatches returned related lifecycle PRs (#8168, #6208, #8905) but nothing that corrects this contract.

### Pre-submission checklist
- [x] I have searched existing open and closed issues and this is not a duplicate.
- [x] I am on the latest released version of Paperclip (or can reproduce on `master`).
- [x] I have confirmed the error originates in Paperclip itself — not in my agent adapter, API provider, or local configuration.

**What happened?** Generated OpenAPI for `POST /api/agents/{id}/clear-error` advertises agent bearer auth (`AgentBearerAuth`) and `x-paperclip-authorization.actor=board_or_agent`. The Express route still enforces board-only access via `assertBoard(req)`, so agent API key / agent JWT callers receive `403 {"error":"Board access required"}` despite following the published contract.

**Expected behavior:** Spec and runtime agree. Because the handler is board-only, OpenAPI should advertise only `BoardSessionAuth` / `BoardApiKeyAuth` with `actor: board`, and operator docs should state that agent credentials are rejected.

**Steps to reproduce:**
1. Fetch `/api/openapi.json` from a current `master` server and inspect `paths["/api/agents/{id}/clear-error"].post.security` and `x-paperclip-authorization`.
2. Authenticate as an agent and `POST /api/agents/{id}/clear-error`.
3. Observe `403 Board access required` even though OpenAPI advertised agent auth.

**Paperclip version or commit:** Reproduced against current `master` (`89af58b` tip at branch cut).

**Deployment mode:** Local/self-hosted control-plane API (built from source).

**Agent adapter(s) involved:** Not adapter-specific (core OpenAPI/auth contract bug).

**Database mode:** Not database-related.

**Access context:** Agent API key / agent JWT vs board operator session.

## What Changed

- Added `POST /api/agents/{id}/clear-error` to `BOARD_ONLY_OPERATIONS` so generated OpenAPI emits board session/API-key security and `x-paperclip-authorization.actor=board`
- Extended OpenAPI route regression tests to assert board-only security for clear-error
- Documented in `docs/api/agents.md` that agent API keys and agent JWTs are rejected

## Verification

```sh
pnpm exec vitest run server/src/__tests__/openapi-routes.test.ts --testTimeout=20000
# Test Files 1 passed (1); Tests 3 passed (3)

pnpm exec vitest run server/src/__tests__/agent-cross-tenant-authz-routes.test.ts \
  -t "requires board access before clearing an agent error|clears error agents and records a distinct audit action" \
  --testTimeout=20000
# Test Files 1 passed (1); Tests 2 passed | 3 skipped (5)
```

## Risks

Low risk. Runtime authorization is unchanged; this only corrects the published OpenAPI contract and docs. Rollback: revert the single `BOARD_ONLY_OPERATIONS` entry, its regression assertion, and the docs sentence.

> Scoped contract/docs bug fix. `ROADMAP.md` was checked; no duplicate planned capability.

## Model Used

Cursor Auto / Composer (agent coding assistant with tool use, repository inspection, shell execution, and test execution). Exact underlying model ID is not exposed by the router.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge