### PR TITLE
fix(server): ADR-GOV-17 board-only DELETE + soft-delete/archive restore (SAT-8302/8309)

### DIFF
--- a/packages/db/src/migrations/0177_issue_soft_delete_archive.sql
+++ b/packages/db/src/migrations/0177_issue_soft_delete_archive.sql
@@ -1,0 +1,6 @@
+ALTER TABLE "issues" ADD COLUMN IF NOT EXISTS "archived_at" timestamp with time zone;--> statement-breakpoint
+ALTER TABLE "issues" ADD COLUMN IF NOT EXISTS "archived_by_actor_type" text;--> statement-breakpoint
+ALTER TABLE "issues" ADD COLUMN IF NOT EXISTS "archived_by_actor_id" text;--> statement-breakpoint
+ALTER TABLE "issues" ADD COLUMN IF NOT EXISTS "archive_reason" text;--> statement-breakpoint
+ALTER TABLE "issues" ADD COLUMN IF NOT EXISTS "restore_manifest" jsonb;--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "issues_company_archived_at_idx" ON "issues" USING btree ("company_id","archived_at");

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -1226,6 +1226,13 @@
       "when": 1784211956161,
       "tag": "0176_issue_create_idempotency_key_expiry",
       "breakpoints": true
+    },
+    {
+      "idx": 177,
+      "version": "7",
+      "when": 1784246400000,
+      "tag": "0177_issue_soft_delete_archive",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/issues.ts
+++ b/packages/db/src/schema/issues.ts
@@ -69,11 +69,24 @@ export const issues = pgTable(
     completedAt: timestamp("completed_at", { withTimezone: true }),
     cancelledAt: timestamp("cancelled_at", { withTimezone: true }),
     hiddenAt: timestamp("hidden_at", { withTimezone: true }),
+    // Soft-delete / archive (ADR-GOV-17 D2 / SAT-8309). Distinct from per-user inbox archives.
+    archivedAt: timestamp("archived_at", { withTimezone: true }),
+    archivedByActorType: text("archived_by_actor_type"),
+    archivedByActorId: text("archived_by_actor_id"),
+    archiveReason: text("archive_reason"),
+    restoreManifest: jsonb("restore_manifest").$type<{
+      blocks?: Array<{
+        relatedIssueId: string;
+        createdByAgentId?: string | null;
+        createdByUserId?: string | null;
+      }>;
+    } | null>(),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => ({
     companyStatusIdx: index("issues_company_status_idx").on(table.companyId, table.status),
+    companyArchivedAtIdx: index("issues_company_archived_at_idx").on(table.companyId, table.archivedAt),
     companyHarnessKindIdx: index("issues_company_harness_kind_idx").on(table.companyId, table.harnessKind),
     assigneeStatusIdx: index("issues_company_assignee_status_idx").on(
       table.companyId,

--- a/packages/shared/src/types/issue.ts
+++ b/packages/shared/src/types/issue.ts
@@ -774,8 +774,19 @@ export interface Issue {
   lastExternalCommentAt?: Date | null;
   lastActivityAt?: Date | null;
   isUnreadForMe?: boolean;
+  /** Soft-delete timestamp (ADR-GOV-17 D2). Also reused by per-user inbox archive overlays. */
   archivedAt?: Date | null;
-  archivedByActorType?: "user" | "agent" | null;
+  archivedByActorType?: "board" | "user" | "agent" | null;
+  archivedByActorId?: string | null;
+  archiveReason?: string | null;
+  restoreManifest?: {
+    blocks?: Array<{
+      relatedIssueId: string;
+      createdByAgentId?: string | null;
+      createdByUserId?: string | null;
+    }>;
+  } | null;
+  /** Per-user inbox archive attribution (overlay; not issue soft-delete). */
   archivedByAgentId?: string | null;
   archivedByRunId?: string | null;
   createdAt: Date;
@@ -830,7 +841,9 @@ export type CompactIssue = Pick<
   lastActivityAt?: Date | null;
   isUnreadForMe?: boolean;
   archivedAt?: Date | null;
-  archivedByActorType?: "user" | "agent" | null;
+  archivedByActorType?: "board" | "user" | "agent" | null;
+  archivedByActorId?: string | null;
+  archiveReason?: string | null;
   archivedByAgentId?: string | null;
   archivedByRunId?: string | null;
   activeRecoveryAction: IssueRecoveryAction | null;

--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -13,21 +13,29 @@ const recoveryActionId = "77777777-7777-4777-8777-777777777777";
 const mockIssueService = vi.hoisted(() => ({
   addComment: vi.fn(),
   assertCheckoutOwner: vi.fn(),
+  archive: vi.fn(),
   create: vi.fn(),
   createChild: vi.fn(),
   decomposeAcceptedPlan: vi.fn(),
+  findMentionedProjectIds: vi.fn(),
+  getActiveInboxArchiveFields: vi.fn(),
+  getAncestors: vi.fn(),
   getAttachmentById: vi.fn(),
   getByIdentifier: vi.fn(),
   getById: vi.fn(),
   getComment: vi.fn(),
+  getCurrentScheduledRetry: vi.fn(),
   getRelationSummaries: vi.fn(),
   getWakeableParentAfterChildCompletion: vi.fn(),
   list: vi.fn(),
   listAttachments: vi.fn(),
+  listBlockerAttention: vi.fn(),
   listComments: vi.fn(),
+  listProductivityReviews: vi.fn(),
   listWakeableBlockedDependents: vi.fn(),
   remove: vi.fn(),
   removeAttachment: vi.fn(),
+  restore: vi.fn(),
   update: vi.fn(),
   findMentionedAgents: vi.fn(),
 }));
@@ -154,7 +162,14 @@ function registerRouteMocks() {
 
   vi.doMock("../services/documents.js", () => ({
     documentAnnotationService: () => ({ remapOpenThreadsForDocument: async () => [] }),
-    documentService: () => mockDocumentService,
+    documentService: () => ({
+      ...mockDocumentService,
+      getIssueDocumentPayload: vi.fn(async () => ({
+        planDocument: null,
+        documentSummaries: [],
+        legacyPlanDocument: null,
+      })),
+    }),
   }));
 
   vi.doMock("../services/issues.js", () => ({
@@ -184,7 +199,14 @@ function registerRouteMocks() {
     }),
     companyService: () => mockCompanyService,
     documentAnnotationService: () => ({ remapOpenThreadsForDocument: async () => [] }),
-    documentService: () => mockDocumentService,
+    documentService: () => ({
+      ...mockDocumentService,
+      getIssueDocumentPayload: vi.fn(async () => ({
+        planDocument: null,
+        documentSummaries: [],
+        legacyPlanDocument: null,
+      })),
+    }),
     executionWorkspaceService: () => ({}),
     feedbackService: () => ({
       listIssueVotesForUser: vi.fn(async () => []),
@@ -249,6 +271,11 @@ function makeIssue(overrides: Record<string, unknown> = {}) {
     executionPolicy: null,
     executionState: null,
     hiddenAt: null,
+    archivedAt: null,
+    archivedByActorType: null,
+    archivedByActorId: null,
+    archiveReason: null,
+    restoreManifest: null,
     ...overrides,
   };
 }
@@ -498,6 +525,8 @@ describe("agent issue mutation checkout ownership", () => {
     mockIssueApprovalService.listApprovalsForIssue.mockResolvedValue([]);
     mockIssueThreadInteractionService.listForIssue.mockReset();
     mockIssueThreadInteractionService.listForIssue.mockResolvedValue([]);
+    mockIssueService.archive.mockReset();
+    mockIssueService.restore.mockReset();
     mockIssueService.remove.mockReset();
     mockIssueService.removeAttachment.mockReset();
     mockIssueService.update.mockReset();
@@ -535,6 +564,13 @@ describe("agent issue mutation checkout ownership", () => {
     mockCompanyService.getById.mockResolvedValue({ id: companyId, issuePrefix: "PAP" });
     mockIssueService.getById.mockResolvedValue(makeIssue());
     mockIssueService.getByIdentifier.mockResolvedValue(null);
+    mockIssueService.getAncestors.mockResolvedValue([]);
+    mockIssueService.findMentionedProjectIds.mockResolvedValue([]);
+    mockIssueService.getRelationSummaries.mockResolvedValue({ blockedBy: [], blocks: [] });
+    mockIssueService.listBlockerAttention.mockResolvedValue(new Map());
+    mockIssueService.listProductivityReviews.mockResolvedValue(new Map());
+    mockIssueService.getCurrentScheduledRetry.mockResolvedValue(null);
+    mockIssueService.getActiveInboxArchiveFields.mockResolvedValue({});
     mockIssueService.getComment.mockResolvedValue({
       id: "comment-1",
       issueId,
@@ -609,6 +645,15 @@ describe("agent issue mutation checkout ownership", () => {
         body: "Mentioned reply context.",
       },
     ]);
+    mockIssueService.archive.mockResolvedValue(
+      makeIssue({
+        archivedAt: new Date("2026-07-17T00:00:00.000Z"),
+        archivedByActorType: "board",
+        archivedByActorId: "board-user",
+        restoreManifest: { blocks: [] },
+      }),
+    );
+    mockIssueService.restore.mockResolvedValue(makeIssue({ archivedAt: null, restoreManifest: null }));
     mockIssueService.remove.mockResolvedValue(makeIssue({ status: "cancelled" }));
     mockIssueService.getAttachmentById.mockResolvedValue({
       id: "attachment-1",
@@ -1665,6 +1710,7 @@ describe("agent issue mutation checkout ownership", () => {
         issueId,
         securityPrinciples: ["Least Privilege", "Complete Mediation"],
       });
+      expect(mockIssueService.archive).not.toHaveBeenCalled();
       expect(mockIssueService.remove).not.toHaveBeenCalled();
       return res;
     }
@@ -1769,15 +1815,155 @@ describe("agent issue mutation checkout ownership", () => {
       );
     });
 
-    it("allows board actor DELETE (Phase 1 hard delete)", async () => {
+    it("allows board actor DELETE as soft-archive (Phase 2)", async () => {
       mockIssueService.getById.mockResolvedValue(makeIssue());
-      mockIssueService.remove.mockResolvedValue(makeIssue({ status: "cancelled" }));
+      const archivedIssue = makeIssue({
+        archivedAt: new Date("2026-07-17T00:00:00.000Z"),
+        archivedByActorType: "board",
+        archivedByActorId: "board-user",
+        restoreManifest: { blocks: [] },
+      });
+      mockIssueService.archive.mockResolvedValue(archivedIssue);
 
       const res = await request(await createApp(boardActor())).delete(`/api/issues/${issueId}`);
 
       expect(res.status, JSON.stringify(res.body)).toBe(200);
+      expect(mockIssueService.archive).toHaveBeenCalledWith(
+        issueId,
+        { actorType: "board", actorId: "board-user" },
+        { reason: null },
+      );
+      expect(mockIssueService.remove).not.toHaveBeenCalled();
+      expect(res.body).toEqual(expect.objectContaining({ archived: true, issue: expect.objectContaining({ id: issueId }) }));
+    });
+  });
+
+  describe("ADR-GOV-17 Phase 2 soft-delete/archive + restore (SAT-8309)", () => {
+    const boardOnlyDeleteError = "DELETE /api/issues is restricted to board users (ADR-GOV-17)";
+    const boardOnlyRestoreError = "POST /api/issues/:id/restore is restricted to board users (ADR-GOV-17)";
+
+    it("rejects agent soft-delete, restore, and hard-delete", async () => {
+      mockIssueService.getById.mockResolvedValue(makeIssue());
+      const app = await createApp(ownerActor());
+
+      const soft = await request(app).delete(`/api/issues/${issueId}`);
+      expect(soft.status).toBe(403);
+      expect(soft.body.error).toBe(boardOnlyDeleteError);
+      expect(mockIssueService.archive).not.toHaveBeenCalled();
+
+      const restore = await request(app).post(`/api/issues/${issueId}/restore`);
+      expect(restore.status).toBe(403);
+      expect(restore.body.error).toBe(boardOnlyRestoreError);
+      expect(mockIssueService.restore).not.toHaveBeenCalled();
+
+      const hard = await request(app).delete(`/api/issues/${issueId}?hard=true`);
+      expect(hard.status).toBe(403);
+      expect(hard.body.error).toBe(boardOnlyDeleteError);
+      expect(mockIssueService.remove).not.toHaveBeenCalled();
+    });
+
+    it("board archive → restore round-trip preserves blocker edges via restoreManifest", async () => {
+      const dependentId = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee";
+      const live = makeIssue();
+      const archived = makeIssue({
+        archivedAt: new Date("2026-07-17T00:00:00.000Z"),
+        archivedByActorType: "board",
+        archivedByActorId: "board-user",
+        restoreManifest: {
+          blocks: [{ relatedIssueId: dependentId, createdByAgentId: null, createdByUserId: null }],
+        },
+      });
+      const restored = makeIssue({
+        archivedAt: null,
+        restoreManifest: null,
+      });
+
+      mockIssueService.getById.mockResolvedValue(live);
+      mockIssueService.archive.mockResolvedValue(archived);
+      mockIssueService.restore.mockResolvedValue(restored);
+
+      const app = await createApp(boardActor());
+      const archiveRes = await request(app).delete(`/api/issues/${issueId}`);
+      expect(archiveRes.status).toBe(200);
+      expect(archiveRes.body.archived).toBe(true);
+      expect(archiveRes.body.issue.restoreManifest).toEqual({
+        blocks: [{ relatedIssueId: dependentId, createdByAgentId: null, createdByUserId: null }],
+      });
+      expect(mockIssueService.archive).toHaveBeenCalled();
+
+      mockIssueService.getById.mockResolvedValue(archived);
+      const restoreRes = await request(app).post(`/api/issues/${issueId}/restore`);
+      expect(restoreRes.status).toBe(200);
+      expect(mockIssueService.restore).toHaveBeenCalledWith(issueId);
+      expect(restoreRes.body.archivedAt).toBeNull();
+    });
+
+    it("hard delete without prior archive returns 409; with archive succeeds + tombstone", async () => {
+      mockIssueService.getById.mockResolvedValue(makeIssue({ archivedAt: null }));
+      const app = await createApp(boardActor());
+
+      const rejected = await request(app).delete(`/api/issues/${issueId}?hard=true`);
+      expect(rejected.status, JSON.stringify(rejected.body)).toBe(409);
+      expect(rejected.body.error).toMatch(/archived first/i);
+      expect(mockIssueService.remove).not.toHaveBeenCalled();
+
+      const archivedAt = new Date("2026-07-17T00:00:00.000Z");
+      mockIssueService.getById.mockResolvedValue(
+        makeIssue({
+          archivedAt,
+          identifier: "PAP-1649",
+          title: "Owned active issue",
+        }),
+      );
+      mockIssueService.remove.mockResolvedValue(makeIssue({ status: "cancelled" }));
+
+      const ok = await request(app).delete(`/api/issues/${issueId}?hard=true`);
+      expect(ok.status, JSON.stringify(ok.body)).toBe(200);
       expect(mockIssueService.remove).toHaveBeenCalledWith(issueId);
-      expect(res.body).toEqual(expect.objectContaining({ id: issueId }));
+      expect(mockLogActivity).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          action: "issue.hard_deleted",
+          entityId: issueId,
+          details: expect.objectContaining({
+            id: issueId,
+            identifier: "PAP-1649",
+            title: "Owned active issue",
+          }),
+        }),
+      );
+    });
+
+    it("archived issues excluded from default list; board includeArchived=true includes them; agent GET is 404", async () => {
+      const archived = makeIssue({
+        archivedAt: new Date("2026-07-17T00:00:00.000Z"),
+        archivedByActorType: "board",
+        archivedByActorId: "board-user",
+      });
+
+      mockIssueService.list.mockResolvedValue([]);
+      const boardApp = await createApp(boardActor());
+      const defaultList = await request(boardApp).get(`/api/companies/${companyId}/issues`);
+      expect(defaultList.status).toBe(200);
+      expect(mockIssueService.list).toHaveBeenCalledWith(
+        companyId,
+        expect.objectContaining({ includeArchived: false }),
+      );
+
+      mockIssueService.list.mockResolvedValue([archived]);
+      const archivedList = await request(boardApp).get(
+        `/api/companies/${companyId}/issues?includeArchived=true`,
+      );
+      expect(archivedList.status).toBe(200);
+      expect(mockIssueService.list).toHaveBeenCalledWith(
+        companyId,
+        expect.objectContaining({ includeArchived: true }),
+      );
+
+      mockIssueService.getById.mockResolvedValue(archived);
+      const agentGet = await request(await createApp(ownerActor())).get(`/api/issues/${issueId}`);
+      expect(agentGet.status).toBe(404);
+      // Board GET is allowed past this gate (requireBoard); full enrichment is covered in GET suite.
     });
   });
 

--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -190,7 +190,10 @@ function registerRouteMocks() {
       listIssueVotesForUser: vi.fn(async () => []),
       saveIssueVote: vi.fn(async () => ({ vote: null, consentEnabledNow: false, sharingEnabled: false })),
     }),
-    goalService: () => ({}),
+    goalService: () => ({
+      getDefaultCompanyGoal: vi.fn(async () => null),
+      getById: vi.fn(async () => null),
+    }),
     heartbeatService: () => mockHeartbeatService,
     instanceSettingsService: () => ({
       get: vi.fn(async () => ({
@@ -727,7 +730,6 @@ describe("agent issue mutation checkout ownership", () => {
 
   it.each([
     ["patch", (app: express.Express) => request(app).patch(`/api/issues/${issueId}`).send({ title: "Blocked" })],
-    ["delete", (app: express.Express) => request(app).delete(`/api/issues/${issueId}`)],
     [
       "document upsert",
       (app: express.Express) =>
@@ -1650,6 +1652,133 @@ describe("agent issue mutation checkout ownership", () => {
       }),
     }));
     expect(mockIssueService.update).not.toHaveBeenCalled();
+  });
+
+  describe("ADR-GOV-17 board-only DELETE /api/issues/:id (SAT-8302)", () => {
+    const boardOnlyDeleteError = "DELETE /api/issues is restricted to board users (ADR-GOV-17)";
+
+    async function expectAgentDeleteForbidden(app: express.Express) {
+      const res = await request(app).delete(`/api/issues/${issueId}`);
+      expect(res.status, JSON.stringify(res.body)).toBe(403);
+      expect(res.body.error).toBe(boardOnlyDeleteError);
+      expect(res.body.details).toEqual({
+        issueId,
+        securityPrinciples: ["Least Privilege", "Complete Mediation"],
+      });
+      expect(mockIssueService.remove).not.toHaveBeenCalled();
+      return res;
+    }
+
+    it("rejects agent run-JWT DELETE on an unassigned issue and leaves the issue readable", async () => {
+      const unassigned = makeIssue({ assigneeAgentId: null, executionState: null });
+      mockIssueService.getById.mockResolvedValue(unassigned);
+
+      await expectAgentDeleteForbidden(await createApp(ownerActor()));
+
+      // Hard delete did not run — issue remains fetchable via the service.
+      await expect(mockIssueService.getById(issueId)).resolves.toEqual(
+        expect.objectContaining({ id: issueId, assigneeAgentId: null }),
+      );
+      expect(mockIssueService.remove).not.toHaveBeenCalled();
+    });
+
+    it("rejects agent run-JWT DELETE on an issue assigned to another agent", async () => {
+      mockIssueService.getById.mockResolvedValue(makeIssue({ assigneeAgentId: ownerAgentId }));
+      await expectAgentDeleteForbidden(await createApp(peerActor()));
+    });
+
+    it("rejects agent run-JWT DELETE even with self-created, self-assigned, active checkout", async () => {
+      mockIssueService.getById.mockResolvedValue(
+        makeIssue({
+          assigneeAgentId: ownerAgentId,
+          createdByAgentId: ownerAgentId,
+          executionState: { checkoutAgentId: ownerAgentId, checkoutRunId: ownerRunId },
+        }),
+      );
+      await expectAgentDeleteForbidden(await createApp(ownerActor()));
+    });
+
+    it("rejects agent DELETE even with task-watchdog scope over the subtree", async () => {
+      const watchdogRunId = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaab";
+      const watchdogReportIssueId = "cccccccc-cccc-4ccc-8ccc-cccccccccccd";
+      const runRows = [{
+        id: watchdogRunId,
+        companyId,
+        agentId: peerAgentId,
+        contextSnapshot: { taskWatchdog: { watchedIssueId: issueId, stopFingerprint: "task_watchdog_stop:test" } },
+      }];
+      const watchdogRows = [{
+        id: "dddddddd-dddd-4ddd-8ddd-ddddddddddde",
+        companyId,
+        issueId,
+        watchdogAgentId: peerAgentId,
+        watchdogIssueId: watchdogReportIssueId,
+        status: "active",
+      }];
+      const ancestryRows = [{ id: "ancestry", companyId, parentId: null }];
+      const rowsForSelection = (selection: Record<string, unknown>) => {
+        const keys = Object.keys(selection);
+        if (keys.includes("entityId")) return [];
+        if (keys.includes("contextSnapshot")) return runRows;
+        if (keys.includes("watchdogAgentId")) return watchdogRows;
+        if (keys.includes("parentId")) return ancestryRows;
+        if (keys.includes("status")) return [];
+        if (keys.includes("agentCompanyId")) return runRows;
+        return [{ id: peerAgentId, companyId, permissions: {}, role: "engineer", reportsTo: null }];
+      };
+      const buildQuery = (selection: Record<string, unknown>) => {
+        const whereResult = {
+          orderBy: vi.fn(async () => []),
+          then: async (resolve: (rows: unknown[]) => unknown) => resolve(rowsForSelection(selection)),
+        };
+        const query = {
+          innerJoin: vi.fn(() => query),
+          where: vi.fn(() => whereResult),
+        };
+        return query;
+      };
+      const watchdogDb = {
+        transaction: async (callback: (tx: Record<string, never>) => Promise<unknown>) => callback({}),
+        select: vi.fn((selection: Record<string, unknown> = {}) => ({
+          from: vi.fn(() => buildQuery(selection)),
+        })),
+      };
+
+      mockAccessService.decide.mockImplementation(async (input: { action: string }) => ({
+        allowed: input.action === "company_scope:read" || input.action === "issue:read" || input.action === "tasks:assign",
+        action: input.action,
+        reason:
+          input.action === "company_scope:read" || input.action === "issue:read" || input.action === "tasks:assign"
+            ? "allow_explicit_grant"
+            : "deny_missing_grant",
+        explanation: "Watchdog delete denial boundary.",
+      }));
+      mockIssueService.getById.mockResolvedValue(makeIssue({ assigneeAgentId: ownerAgentId }));
+
+      await expectAgentDeleteForbidden(
+        await createApp(
+          {
+            type: "agent",
+            agentId: peerAgentId,
+            companyId,
+            source: "agent_key",
+            runId: watchdogRunId,
+          },
+          watchdogDb,
+        ),
+      );
+    });
+
+    it("allows board actor DELETE (Phase 1 hard delete)", async () => {
+      mockIssueService.getById.mockResolvedValue(makeIssue());
+      mockIssueService.remove.mockResolvedValue(makeIssue({ status: "cancelled" }));
+
+      const res = await request(await createApp(boardActor())).delete(`/api/issues/${issueId}`);
+
+      expect(res.status, JSON.stringify(res.body)).toBe(200);
+      expect(mockIssueService.remove).toHaveBeenCalledWith(issueId);
+      expect(res.body).toEqual(expect.objectContaining({ id: issueId }));
+    });
   });
 
   describe("task watchdog scope grants", () => {

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -92,6 +92,7 @@ import {
 import { trackAgentTaskCompleted } from "@paperclipai/shared/telemetry";
 import { getTelemetryClient } from "../telemetry.js";
 import type { StorageService } from "../storage/types.js";
+import { requireBoard } from "../middleware/auth.js";
 import { validate } from "../middleware/validate.js";
 import * as serviceIndex from "../services/index.js";
 import {
@@ -8715,7 +8716,15 @@ export function issueRoutes(
     const id = req.params.id as string;
     const existing = await getAccessibleResource(req, res, svc.getById(id), "Issue not found");
     if (!existing) return;
-    if (!(await assertAgentIssueMutationAllowed(req, res, existing))) return;
+    // ADR-GOV-17 / SAT-8302: hard DELETE is board-only (allowlist). Agents — including
+    // self-owned checkouts and task-watchdog scope — must not hard-delete issues.
+    if (!requireBoard(req)) {
+      res.status(403).json({
+        error: "DELETE /api/issues is restricted to board users (ADR-GOV-17)",
+        details: { issueId: existing.id, securityPrinciples: ["Least Privilege", "Complete Mediation"] },
+      });
+      return;
+    }
     const attachments = await svc.listAttachments(id);
 
     const issue = await svc.remove(id);

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -4768,6 +4768,9 @@ export function issueRoutes(
       includeBlockedInboxAttention:
         req.query.includeBlockedInboxAttention === "true" || req.query.includeBlockedInboxAttention === "1",
       includeLiveDescendantSummary: includeLiveDescendantSummary === true,
+      includeArchived:
+        requireBoard(req) &&
+        (req.query.includeArchived === "true" || req.query.includeArchived === "1"),
       hasPlanDocument,
       q: req.query.q as string | undefined,
       limit,
@@ -5331,6 +5334,11 @@ export function issueRoutes(
     const id = req.params.id as string;
     const issue = await getAccessibleResource(req, res, svc.getById(id), "Issue not found");
     if (!issue) return;
+    // Soft-deleted issues: agents see 404; board retains GET with archived fields.
+    if (issue.archivedAt && !requireBoard(req)) {
+      res.status(404).json({ error: "Issue not found" });
+      return;
+    }
     if (!(await assertIssueReadAllowed(req, res, issue))) return;
     const inboxArchiveFieldsPromise = req.actor.type === "board" && req.actor.userId
       ? svc.getActiveInboxArchiveFields(issue, req.actor.userId)
@@ -8716,8 +8724,7 @@ export function issueRoutes(
     const id = req.params.id as string;
     const existing = await getAccessibleResource(req, res, svc.getById(id), "Issue not found");
     if (!existing) return;
-    // ADR-GOV-17 / SAT-8302: hard DELETE is board-only (allowlist). Agents — including
-    // self-owned checkouts and task-watchdog scope — must not hard-delete issues.
+    // ADR-GOV-17 / SAT-8302 + SAT-8309: archive/hard-delete are board-only (allowlist).
     if (!requireBoard(req)) {
       res.status(403).json({
         error: "DELETE /api/issues is restricted to board users (ADR-GOV-17)",
@@ -8725,8 +8732,56 @@ export function issueRoutes(
       });
       return;
     }
-    const attachments = await svc.listAttachments(id);
 
+    const hard =
+      req.query.hard === "true" ||
+      req.query.hard === "1" ||
+      req.query.mode === "hard";
+    const actor = getActorInfo(req);
+
+    if (!hard) {
+      // Phase 2 soft-delete / archive (idempotent).
+      const archived = await svc.archive(
+        id,
+        {
+          actorType: req.actor.type === "board" ? "board" : actor.actorType,
+          actorId: actor.actorId,
+        },
+        { reason: typeof req.query.reason === "string" ? req.query.reason : null },
+      );
+      if (!archived) {
+        res.status(404).json({ error: "Issue not found" });
+        return;
+      }
+      await logActivity(db, {
+        companyId: archived.companyId,
+        actorType: actor.actorType,
+        actorId: actor.actorId,
+        agentId: actor.agentId,
+        runId: actor.runId,
+        action: "issue.archived",
+        entityType: "issue",
+        entityId: archived.id,
+        details: {
+          identifier: archived.identifier,
+          title: archived.title,
+          restoreManifest: archived.restoreManifest ?? null,
+        },
+      });
+      await queueTaskWatchdogEvaluation(existing, actor.runId);
+      res.json({ archived: true, issue: archived });
+      return;
+    }
+
+    // Hard delete only after prior archive (two-step).
+    if (!existing.archivedAt) {
+      throw conflict("Hard delete requires the issue to be archived first", {
+        issueId: existing.id,
+        securityPrinciples: ["Fail Securely", "Complete Mediation"],
+      });
+    }
+
+    const attachments = await svc.listAttachments(id);
     const issue = await svc.remove(id);
     if (!issue) {
       res.status(404).json({ error: "Issue not found" });
@@ -8741,6 +8796,48 @@ export function issueRoutes(
       }
     }
 
+    await logActivity(db, {
+      companyId: issue.companyId,
+      actorType: actor.actorType,
+      actorId: actor.actorId,
+      agentId: actor.agentId,
+      runId: actor.runId,
+      action: "issue.hard_deleted",
+      entityType: "issue",
+      entityId: issue.id,
+      details: {
+        id: issue.id,
+        identifier: issue.identifier,
+        title: issue.title,
+        actorType: actor.actorType,
+        actorId: actor.actorId,
+        archivedAt: existing.archivedAt,
+        timestamp: new Date().toISOString(),
+      },
+    });
+
+    await queueTaskWatchdogEvaluation(existing, actor.runId);
+    res.json(issue);
+  });
+
+  router.post("/issues/:id/restore", async (req, res) => {
+    const id = req.params.id as string;
+    const existing = await getAccessibleResource(req, res, svc.getById(id), "Issue not found");
+    if (!existing) return;
+    if (!requireBoard(req)) {
+      res.status(403).json({
+        error: "POST /api/issues/:id/restore is restricted to board users (ADR-GOV-17)",
+        details: { issueId: existing.id, securityPrinciples: ["Least Privilege", "Complete Mediation"] },
+      });
+      return;
+    }
+
+    const issue = await svc.restore(id);
+    if (!issue) {
+      res.status(404).json({ error: "Issue not found" });
+      return;
+    }
+
     const actor = getActorInfo(req);
     await logActivity(db, {
       companyId: issue.companyId,
@@ -8748,9 +8845,13 @@ export function issueRoutes(
       actorId: actor.actorId,
       agentId: actor.agentId,
       runId: actor.runId,
-      action: "issue.deleted",
+      action: "issue.restored",
       entityType: "issue",
       entityId: issue.id,
+      details: {
+        identifier: issue.identifier,
+        title: issue.title,
+      },
     });
 
     await queueTaskWatchdogEvaluation(existing, actor.runId);

--- a/server/src/services/issue-visibility.ts
+++ b/server/src/services/issue-visibility.ts
@@ -1,10 +1,15 @@
 import { and, isNull, type SQL } from "drizzle-orm";
 import { issues } from "@paperclipai/db";
 
-export function visibleIssueCondition(): SQL {
-  return and(isNull(issues.hiddenAt), isNull(issues.harnessKind))!;
+export function visibleIssueCondition(options?: { includeArchived?: boolean }): SQL {
+  const parts: SQL[] = [isNull(issues.hiddenAt), isNull(issues.harnessKind)];
+  if (!options?.includeArchived) {
+    parts.push(isNull(issues.archivedAt));
+  }
+  return and(...parts)!;
 }
 
-export function visibleIssueSql(alias = "issues") {
-  return `"${alias}"."hidden_at" IS NULL AND "${alias}"."harness_kind" IS NULL`;
+export function visibleIssueSql(alias = "issues", options?: { includeArchived?: boolean }) {
+  const archivedClause = options?.includeArchived ? "" : ` AND "${alias}"."archived_at" IS NULL`;
+  return `"${alias}"."hidden_at" IS NULL AND "${alias}"."harness_kind" IS NULL${archivedClause}`;
 }

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -486,6 +486,8 @@ export interface IssueFilters {
   includeBlockedBy?: boolean;
   includeBlockedInboxAttention?: boolean;
   includeLiveDescendantSummary?: boolean;
+  /** Board-only: include soft-deleted/archived issues (ADR-GOV-17 D2). */
+  includeArchived?: boolean;
   hasPlanDocument?: boolean;
   lowTrustBoundary?: LowTrustBoundary & { companyId: string };
   q?: string;
@@ -2525,6 +2527,11 @@ const issueListSelect = {
   completedAt: issues.completedAt,
   cancelledAt: issues.cancelledAt,
   hiddenAt: issues.hiddenAt,
+  archivedAt: issues.archivedAt,
+  archivedByActorType: issues.archivedByActorType,
+  archivedByActorId: issues.archivedByActorId,
+  archiveReason: issues.archiveReason,
+  restoreManifest: issues.restoreManifest,
   createdAt: issues.createdAt,
   updatedAt: issues.updatedAt,
 };
@@ -4702,7 +4709,10 @@ export function issueService(db: Db) {
         });
       }
 
-      const conditions = [eq(issues.companyId, companyId), visibleIssueCondition()];
+      const conditions = [
+        eq(issues.companyId, companyId),
+        visibleIssueCondition({ includeArchived: filters?.includeArchived === true }),
+      ];
       const assigneeAgentFilter = parseIssueAssigneeAgentFilter(filters?.assigneeAgentId);
       assertValidAssigneeAgentFilter(assigneeAgentFilter);
       const limit = typeof filters?.limit === "number" && Number.isFinite(filters.limit)
@@ -4929,7 +4939,10 @@ export function issueService(db: Db) {
         ) ?? row.updatedAt;
         return {
           ...row,
-          ...activeInboxArchiveFields(archiveByIssueId.get(row.id), lastActivityAt),
+          // Soft-deleted issues own archivedAt; do not overlay per-user inbox archive fields.
+          ...(row.archivedAt
+            ? {}
+            : activeInboxArchiveFields(archiveByIssueId.get(row.id), lastActivityAt)),
           ...(includeBlockedBy ? { blockedBy: blockedByMap.get(row.id) ?? [] } : {}),
           lastActivityAt,
           ...(blockerAttentionByIssueId.has(row.id) ? { blockerAttention: blockerAttentionByIssueId.get(row.id) } : {}),
@@ -4952,7 +4965,10 @@ export function issueService(db: Db) {
         return countBlockedInboxIssues(db, companyId, filters);
       }
 
-      const conditions = [eq(issues.companyId, companyId), visibleIssueCondition()];
+      const conditions = [
+        eq(issues.companyId, companyId),
+        visibleIssueCondition({ includeArchived: filters?.includeArchived === true }),
+      ];
       const statuses = parseStatusFilter(filters?.status);
       if (statuses.length === 1) conditions.push(eq(issues.status, statuses[0]!));
       else if (statuses.length > 1) conditions.push(inArray(issues.status, statuses));
@@ -6712,6 +6728,157 @@ export function issueService(db: Db) {
 
       return cleared;
     },
+
+    /**
+     * Soft-delete / archive an issue (ADR-GOV-17 D2). Captures outbound "blocks"
+     * edges into restoreManifest and clears them in the same transaction so
+     * dependents are not stranded on an archived blocker.
+     */
+    archive: (
+      id: string,
+      actor: { actorType: string; actorId: string },
+      opts: { reason?: string | null } = {},
+    ) =>
+      db.transaction(async (tx) => {
+        const existing = await tx
+          .select()
+          .from(issues)
+          .where(eq(issues.id, id))
+          .then((rows) => rows[0] ?? null);
+        if (!existing) return null;
+        if (existing.archivedAt) {
+          const [enriched] = await withIssueLabels(tx, [existing]);
+          return enriched;
+        }
+
+        const blockEdges = await tx
+          .select({
+            relatedIssueId: issueRelations.relatedIssueId,
+            createdByAgentId: issueRelations.createdByAgentId,
+            createdByUserId: issueRelations.createdByUserId,
+          })
+          .from(issueRelations)
+          .where(
+            and(
+              eq(issueRelations.companyId, existing.companyId),
+              eq(issueRelations.issueId, id),
+              eq(issueRelations.type, "blocks"),
+            ),
+          );
+
+        if (blockEdges.length > 0) {
+          await tx
+            .delete(issueRelations)
+            .where(
+              and(
+                eq(issueRelations.companyId, existing.companyId),
+                eq(issueRelations.issueId, id),
+                eq(issueRelations.type, "blocks"),
+              ),
+            );
+        }
+
+        const now = new Date();
+        const restoreManifest = {
+          blocks: blockEdges.map((edge) => ({
+            relatedIssueId: edge.relatedIssueId,
+            createdByAgentId: edge.createdByAgentId ?? null,
+            createdByUserId: edge.createdByUserId ?? null,
+          })),
+        };
+
+        const updated = await tx
+          .update(issues)
+          .set({
+            archivedAt: now,
+            archivedByActorType: actor.actorType,
+            archivedByActorId: actor.actorId,
+            archiveReason: opts.reason ?? null,
+            restoreManifest,
+            checkoutRunId: null,
+            executionRunId: null,
+            executionLockedAt: null,
+            updatedAt: now,
+          })
+          .where(eq(issues.id, id))
+          .returning()
+          .then((rows) => rows[0] ?? null);
+
+        if (!updated) return null;
+        const [enriched] = await withIssueLabels(tx, [updated]);
+        return enriched;
+      }),
+
+    /**
+     * Restore a soft-deleted issue and re-link preserved blocker edges when both
+     * endpoints still exist.
+     */
+    restore: (id: string) =>
+      db.transaction(async (tx) => {
+        const existing = await tx
+          .select()
+          .from(issues)
+          .where(eq(issues.id, id))
+          .then((rows) => rows[0] ?? null);
+        if (!existing) return null;
+        if (!existing.archivedAt) {
+          const [enriched] = await withIssueLabels(tx, [existing]);
+          return enriched;
+        }
+
+        const manifest = (existing.restoreManifest ?? null) as {
+          blocks?: Array<{
+            relatedIssueId: string;
+            createdByAgentId?: string | null;
+            createdByUserId?: string | null;
+          }>;
+        } | null;
+        const blocks = Array.isArray(manifest?.blocks) ? manifest.blocks : [];
+
+        if (blocks.length > 0) {
+          const relatedIds = [...new Set(blocks.map((b) => b.relatedIssueId))];
+          const stillPresent = await tx
+            .select({ id: issues.id })
+            .from(issues)
+            .where(and(eq(issues.companyId, existing.companyId), inArray(issues.id, relatedIds)));
+          const presentIds = new Set(stillPresent.map((row) => row.id));
+          const toRestore = blocks.filter((edge) => presentIds.has(edge.relatedIssueId));
+          if (toRestore.length > 0) {
+            await tx
+              .insert(issueRelations)
+              .values(
+                toRestore.map((edge) => ({
+                  companyId: existing.companyId,
+                  issueId: id,
+                  relatedIssueId: edge.relatedIssueId,
+                  type: "blocks" as const,
+                  createdByAgentId: edge.createdByAgentId ?? null,
+                  createdByUserId: edge.createdByUserId ?? null,
+                })),
+              )
+              .onConflictDoNothing();
+          }
+        }
+
+        const now = new Date();
+        const updated = await tx
+          .update(issues)
+          .set({
+            archivedAt: null,
+            archivedByActorType: null,
+            archivedByActorId: null,
+            archiveReason: null,
+            restoreManifest: null,
+            updatedAt: now,
+          })
+          .where(eq(issues.id, id))
+          .returning()
+          .then((rows) => rows[0] ?? null);
+
+        if (!updated) return null;
+        const [enriched] = await withIssueLabels(tx, [updated]);
+        return enriched;
+      }),
 
     remove: (id: string) =>
       db.transaction(async (tx) => {


### PR DESCRIPTION
## Summary
- **Phase 1 (SAT-8302 / SAT-8308):** `DELETE /api/issues/:id` is board-only via `requireBoard` (blocks agent run-JWTs, including the SAT-8024 unassigned class).
- **Phase 2 (SAT-8309):** Soft-delete/archive with restore:
  - Schema migration `0177_issue_soft_delete_archive` (`archivedAt`, actor, reason, `restoreManifest`)
  - `DELETE` → archive (idempotent); `POST /api/issues/:id/restore` re-links preserved blocker edges
  - `DELETE ?hard=true` only when already archived; writes `issue.hard_deleted` tombstone
  - Default list/GET exclude archived; board `?includeArchived=true`; agent GET on archived → 404

## Test plan
- [x] `pnpm exec vitest run src/__tests__/issue-agent-mutation-ownership-routes.test.ts` — 74/74
- [ ] Apply migration `0177` on deploy
- [ ] Live board archive → restore round-trip with a blocker edge
- [ ] Live agent JWT still gets 403 on DELETE/restore/hard