### PR TITLE
fix(heartbeat): promote parked scheduled retries when a human comment wake coalesces into them

### DIFF
--- a/server/src/__tests__/heartbeat-human-comment-wake-promotes-retry.test.ts
+++ b/server/src/__tests__/heartbeat-human-comment-wake-promotes-retry.test.ts
@@ -1,0 +1,371 @@
+import { randomUUID } from "node:crypto";
+import { and, eq } from "drizzle-orm";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import {
+  activityLog,
+  agentRuntimeState,
+  agentTaskSessions,
+  agentWakeupRequests,
+  agents,
+  budgetPolicies,
+  companies,
+  companySkills,
+  createDb,
+  executionWorkspaces,
+  heartbeatRunEvents,
+  heartbeatRuns,
+  issueComments,
+  issues,
+  workspaceOperations,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import { heartbeatService } from "../services/heartbeat.ts";
+
+const adapterExecute = vi.hoisted(() => vi.fn(async () => ({
+  exitCode: 0,
+  signal: null,
+  timedOut: false,
+  sessionParams: { sessionId: "fresh-session" },
+  sessionDisplayId: "fresh-session",
+  summary: "Human comment wake promotion test run.",
+  provider: "test",
+  model: "test-model",
+})));
+
+vi.mock("../adapters/index.js", () => ({
+  getServerAdapter: () => ({
+    type: "codex_local",
+    execute: adapterExecute,
+    supportsLocalAgentJwt: false,
+  }),
+  findActiveServerAdapter: () => ({
+    type: "codex_local",
+    execute: adapterExecute,
+    supportsLocalAgentJwt: false,
+  }),
+  listAdapterModelProfiles: async () => [],
+  runningProcesses: new Map(),
+}));
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping embedded Postgres human comment wake promotion tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+describeEmbeddedPostgres("human comment wake promotes parked scheduled retries", () => {
+  let db!: ReturnType<typeof createDb>;
+  let heartbeat!: ReturnType<typeof heartbeatService>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-heartbeat-human-wake-promote-");
+    db = createDb(tempDb.connectionString);
+    heartbeat = heartbeatService(db);
+  }, 20_000);
+
+  afterEach(async () => {
+    adapterExecute.mockClear();
+    let idlePolls = 0;
+    for (let attempt = 0; attempt < 100; attempt += 1) {
+      const runs = await db
+        .select({ status: heartbeatRuns.status })
+        .from(heartbeatRuns);
+      const hasActiveRun = runs.some((run) => run.status === "queued" || run.status === "running");
+      if (!hasActiveRun) {
+        idlePolls += 1;
+        if (idlePolls >= 5) break;
+      } else {
+        idlePolls = 0;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+    await db.delete(agentTaskSessions);
+    await db.delete(executionWorkspaces);
+    await db.delete(issueComments);
+    await db.delete(issues);
+    for (let attempt = 0; attempt < 5; attempt += 1) {
+      await db.delete(activityLog);
+      await db.delete(heartbeatRunEvents);
+      try {
+        await db.delete(heartbeatRuns);
+        break;
+      } catch (error) {
+        if (attempt === 4) throw error;
+        await new Promise((resolve) => setTimeout(resolve, 50));
+      }
+    }
+    await db.delete(agentWakeupRequests);
+    await db.delete(agentRuntimeState);
+    await db.delete(budgetPolicies);
+    await db.delete(agents);
+    await db.delete(workspaceOperations);
+    await db.delete(companySkills);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  async function seedAgent() {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "CodexCoder",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {
+        heartbeat: {
+          wakeOnDemand: true,
+          maxConcurrentRuns: 1,
+        },
+      },
+      permissions: {},
+    });
+
+    return { companyId, agentId };
+  }
+
+  // Session-limit failure on an issue-scoped run: the bounded retry parks a
+  // scheduled_retry run whose backoff can outlive the underlying limit by
+  // hours. This mirrors the production incident where a comment posted
+  // seconds after the limit reset was absorbed into the parked run.
+  async function seedIssueScopedParkedRetry(issueStatus: "in_review" | "in_progress" = "in_review") {
+    const { companyId, agentId } = await seedAgent();
+    const issueId = randomUUID();
+    const sourceRunId = randomUUID();
+    const now = new Date();
+    const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+
+    await db.insert(heartbeatRuns).values({
+      id: sourceRunId,
+      companyId,
+      agentId,
+      invocationSource: "automation",
+      triggerDetail: "system",
+      status: "failed",
+      responsibleUserId: "responsible-user",
+      error: "You've hit your session limit.",
+      errorCode: "codex_transient_upstream",
+      finishedAt: now,
+      resultJson: { errorFamily: "transient_upstream" },
+      contextSnapshot: { issueId, taskId: issueId, wakeReason: "issue_commented" },
+      updatedAt: now,
+      createdAt: now,
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Respond to the board once the session limit lifts",
+      status: issueStatus,
+      priority: "medium",
+      responsibleUserId: "responsible-user",
+      assigneeAgentId: agentId,
+      issueNumber: 1,
+      identifier: `${issuePrefix}-1`,
+    });
+
+    const scheduled = await heartbeat.scheduleBoundedRetry(sourceRunId, {
+      now,
+      random: () => 0.5,
+    });
+    expect(scheduled.outcome).toBe("scheduled");
+    if (scheduled.outcome !== "scheduled") throw new Error("expected scheduled retry");
+    expect(scheduled.dueAt.getTime()).toBeGreaterThan(Date.now());
+
+    return { companyId, agentId, issueId, retryRunId: scheduled.run.id };
+  }
+
+  function commentWakeOptions(input: {
+    issueId: string;
+    commentId: string;
+    requestedByActorType: "user" | "agent";
+    requestedByActorId: string;
+  }) {
+    // Shape of the assignee wake enqueued by POST /api/issues/{id}/comments.
+    return {
+      source: "automation" as const,
+      triggerDetail: "system" as const,
+      reason: "issue_commented",
+      payload: {
+        issueId: input.issueId,
+        commentId: input.commentId,
+        mutation: "comment",
+      },
+      requestedByActorType: input.requestedByActorType,
+      requestedByActorId: input.requestedByActorId,
+      contextSnapshot: {
+        issueId: input.issueId,
+        taskId: input.issueId,
+        commentId: input.commentId,
+        wakeCommentId: input.commentId,
+        source: "issue.comment",
+        wakeReason: "issue_commented",
+      },
+    };
+  }
+
+  it("keeps the retry parked when an agent comment wake coalesces into it", async () => {
+    const { agentId, issueId, retryRunId } = await seedIssueScopedParkedRetry();
+
+    const returned = await heartbeat.wakeup(agentId, commentWakeOptions({
+      issueId,
+      commentId: randomUUID(),
+      requestedByActorType: "agent",
+      requestedByActorId: randomUUID(),
+    }));
+    expect(returned?.id).toBe(retryRunId);
+
+    const parked = await db
+      .select({ status: heartbeatRuns.status })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, retryRunId))
+      .then((rows) => rows[0] ?? null);
+    expect(parked?.status).toBe("scheduled_retry");
+    expect(adapterExecute).not.toHaveBeenCalled();
+  });
+
+  it("promotes the parked retry when a human comment wake coalesces into it", async () => {
+    const { agentId, issueId, retryRunId } = await seedIssueScopedParkedRetry("in_review");
+    const commentId = randomUUID();
+
+    const returned = await heartbeat.wakeup(agentId, commentWakeOptions({
+      issueId,
+      commentId,
+      requestedByActorType: "user",
+      requestedByActorId: "board-operator",
+    }));
+    expect(returned?.id).toBe(retryRunId);
+    expect(returned?.status).not.toBe("scheduled_retry");
+
+    const wakeupRow = await db
+      .select({
+        status: agentWakeupRequests.status,
+        runId: agentWakeupRequests.runId,
+      })
+      .from(agentWakeupRequests)
+      .where(
+        and(
+          eq(agentWakeupRequests.agentId, agentId),
+          eq(agentWakeupRequests.status, "coalesced"),
+        ),
+      )
+      .then((rows) => rows[0] ?? null);
+    expect(wakeupRow).toMatchObject({ status: "coalesced", runId: retryRunId });
+
+    // The comment lands in the promoted run's context so the agent sees it.
+    const promotedSnapshot = await db
+      .select({ contextSnapshot: heartbeatRuns.contextSnapshot })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, retryRunId))
+      .then((rows) => rows[0]?.contextSnapshot as Record<string, unknown> | null);
+    expect(promotedSnapshot?.wakeCommentId).toBe(commentId);
+
+    // The run leaves scheduled_retry immediately and executes to completion.
+    await vi.waitFor(async () => {
+      const latest = await db
+        .select({ status: heartbeatRuns.status })
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.id, retryRunId))
+        .then((rows) => rows[0] ?? null);
+      expect(latest?.status).toBe("succeeded");
+    }, { timeout: 10_000 });
+    expect(adapterExecute).toHaveBeenCalledTimes(1);
+
+    const eventMessages = await db
+      .select({ message: heartbeatRunEvents.message })
+      .from(heartbeatRunEvents)
+      .where(eq(heartbeatRunEvents.runId, retryRunId))
+      .then((rows) => rows.map((row) => row.message));
+    expect(eventMessages).toContain("Scheduled retry was promoted by a human-initiated wake");
+  });
+
+  it("promotes an agent-scoped parked retry when a human wake coalesces into it", async () => {
+    const { companyId, agentId } = await seedAgent();
+    const sourceRunId = randomUUID();
+    const now = new Date();
+
+    await db.insert(heartbeatRuns).values({
+      id: sourceRunId,
+      companyId,
+      agentId,
+      invocationSource: "automation",
+      triggerDetail: "system",
+      status: "failed",
+      responsibleUserId: "responsible-user",
+      error: "You've hit your usage limit.",
+      errorCode: "codex_transient_upstream",
+      finishedAt: now,
+      resultJson: { errorFamily: "transient_upstream" },
+      contextSnapshot: { wakeReason: "heartbeat" },
+      updatedAt: now,
+      createdAt: now,
+    });
+
+    const scheduled = await heartbeat.scheduleBoundedRetry(sourceRunId, {
+      now,
+      random: () => 0.5,
+    });
+    expect(scheduled.outcome).toBe("scheduled");
+    if (scheduled.outcome !== "scheduled") throw new Error("expected scheduled retry");
+    const retryRunId = scheduled.run.id;
+
+    const returned = await heartbeat.wakeup(agentId, {
+      source: "automation",
+      triggerDetail: "system",
+      reason: "issue_commented",
+      requestedByActorType: "user",
+      requestedByActorId: "board-operator",
+    });
+    expect(returned?.id).toBe(retryRunId);
+    expect(returned?.status).not.toBe("scheduled_retry");
+
+    await vi.waitFor(async () => {
+      const latest = await db
+        .select({ status: heartbeatRuns.status })
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.id, retryRunId))
+        .then((rows) => rows[0] ?? null);
+      expect(latest?.status).toBe("succeeded");
+    }, { timeout: 10_000 });
+    expect(adapterExecute).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not re-promote when the retry was already promoted to queued", async () => {
+    const { agentId, issueId, retryRunId } = await seedIssueScopedParkedRetry();
+
+    await db
+      .update(heartbeatRuns)
+      .set({ status: "queued", updatedAt: new Date() })
+      .where(eq(heartbeatRuns.id, retryRunId));
+
+    const returned = await heartbeat.wakeup(agentId, commentWakeOptions({
+      issueId,
+      commentId: randomUUID(),
+      requestedByActorType: "user",
+      requestedByActorId: "board-operator",
+    }));
+    expect(returned?.id).toBe(retryRunId);
+    expect(returned?.status).toBe("queued");
+  });
+});

--- a/server/src/__tests__/heartbeat-human-comment-wake-promotes-retry.test.ts
+++ b/server/src/__tests__/heartbeat-human-comment-wake-promotes-retry.test.ts
@@ -281,6 +281,23 @@ describeEmbeddedPostgres("human comment wake promotes parked scheduled retries",
       .then((rows) => rows[0]?.contextSnapshot as Record<string, unknown> | null);
     expect(promotedSnapshot?.wakeCommentId).toBe(commentId);
 
+    // The retry run's original wakeup request is stamped with the
+    // pull-forward, mirroring retryScheduledRetryNow, so support tooling
+    // reading agentWakeupRequests.payload can explain the promotion.
+    const retryWakeupRequestId = await db
+      .select({ wakeupRequestId: heartbeatRuns.wakeupRequestId })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, retryRunId))
+      .then((rows) => rows[0]?.wakeupRequestId ?? null);
+    expect(retryWakeupRequestId).toBeTruthy();
+    const stampedPayload = await db
+      .select({ payload: agentWakeupRequests.payload })
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.id, retryWakeupRequestId!))
+      .then((rows) => rows[0]?.payload as Record<string, unknown> | null);
+    expect(typeof stampedPayload?.retryNowRequestedAt).toBe("string");
+    expect(typeof stampedPayload?.scheduledRetryAt).toBe("string");
+
     // The run leaves scheduled_retry immediately and executes to completion.
     await vi.waitFor(async () => {
       const latest = await db

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -15118,6 +15118,73 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     const agent = await getAgent(agentId);
     if (!agent) throw notFound("Agent not found");
 
+    // A human commenting on (or otherwise updating) an issue whose run is
+    // parked in scheduled_retry expects the agent to respond now, not when
+    // the backoff expires. Comment wakes are enqueued with source
+    // "automation", so absorbing them into the parked run merges the new
+    // wakeCommentId into its context but keeps the original schedule: the
+    // message becomes a silent no-op until the retry fires, which can be
+    // hours away. Pull the retry forward and promote it through the standard
+    // gate instead, mirroring retryScheduledRetryNow. Agent- and
+    // system-initiated wakes still coalesce without promotion so bounded
+    // retry backoff keeps protecting against wake storms.
+    const promoteScheduledRetryForHumanWake = async (
+      run: typeof heartbeatRuns.$inferSelect,
+    ): Promise<typeof heartbeatRuns.$inferSelect | null> => {
+      if (opts.requestedByActorType !== "user" || run.status !== "scheduled_retry") return null;
+      const promoteNow = new Date();
+      const pulled = await db
+        .update(heartbeatRuns)
+        .set({
+          scheduledRetryAt: promoteNow,
+          contextSnapshot: {
+            ...parseObject(run.contextSnapshot),
+            scheduledRetryAt: promoteNow.toISOString(),
+            retryNowRequestedAt: promoteNow.toISOString(),
+            retryNowRequestedByActorType: opts.requestedByActorType ?? null,
+            retryNowRequestedByActorId: opts.requestedByActorId ?? null,
+          },
+          updatedAt: promoteNow,
+        })
+        .where(and(eq(heartbeatRuns.id, run.id), eq(heartbeatRuns.status, "scheduled_retry")))
+        .returning()
+        .then((rows) => rows[0] ?? null);
+      const rereadRun = () =>
+        db
+          .select()
+          .from(heartbeatRuns)
+          .where(eq(heartbeatRuns.id, run.id))
+          .then((rows) => rows[0] ?? null);
+      if (!pulled) {
+        // Lost the race with the scheduler or a concurrent wake; re-read so
+        // the caller reports the run's real status, not the parked snapshot.
+        return rereadRun();
+      }
+      await appendRunEvent(pulled, await nextRunEventSeq(pulled.id), {
+        eventType: "lifecycle",
+        stream: "system",
+        level: "info",
+        message: "Scheduled retry was promoted by a human-initiated wake",
+        payload: {
+          scheduledRetryAttempt: pulled.scheduledRetryAttempt,
+          scheduledRetryAt: pulled.scheduledRetryAt ? new Date(pulled.scheduledRetryAt).toISOString() : null,
+          scheduledRetryReason: pulled.scheduledRetryReason,
+          wakeSource: source,
+          wakeReason: reason,
+          requestedByActorType: opts.requestedByActorType ?? null,
+          requestedByActorId: opts.requestedByActorId ?? null,
+        },
+      });
+      // Fresh timestamp: a concurrent wake may have re-pulled scheduledRetryAt
+      // a few ms later than promoteNow, and promotion's lte(scheduledRetryAt,
+      // now) guard must still see the retry as due. Callers own the
+      // startNextQueuedRunForAgent kick after this returns.
+      const promotion = await promoteScheduledRetryRun(pulled, new Date());
+      if (promotion.outcome === "promoted") return promotion.run;
+      if (promotion.run) return promotion.run;
+      return rereadRun();
+    };
+
     const writeSkippedRequest = async (
       skipReason: string,
       patch: Partial<typeof agentWakeupRequests.$inferInsert> = {},
@@ -16154,8 +16221,9 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
 
       if (outcome.kind === "deferred" || outcome.kind === "skipped") return null;
       if (outcome.kind === "coalesced") {
+        const promotedRun = await promoteScheduledRetryForHumanWake(outcome.run);
         await startNextQueuedRunForAgent(agent.id);
-        return outcome.run;
+        return promotedRun ?? outcome.run;
       }
 
       const newRun = outcome.run;
@@ -16234,6 +16302,12 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         runId: mergedRun.id,
         finishedAt: new Date(),
       });
+
+      const promotedRun = await promoteScheduledRetryForHumanWake(mergedRun);
+      if (promotedRun) {
+        await startNextQueuedRunForAgent(agent.id);
+        return promotedRun;
+      }
       return mergedRun;
     }
 

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -15130,25 +15130,58 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     // retry backoff keeps protecting against wake storms.
     const promoteScheduledRetryForHumanWake = async (
       run: typeof heartbeatRuns.$inferSelect,
+      mergedContextSnapshot?: Record<string, unknown>,
     ): Promise<typeof heartbeatRuns.$inferSelect | null> => {
       if (opts.requestedByActorType !== "user" || run.status !== "scheduled_retry") return null;
       const promoteNow = new Date();
-      const pulled = await db
-        .update(heartbeatRuns)
-        .set({
-          scheduledRetryAt: promoteNow,
-          contextSnapshot: {
-            ...parseObject(run.contextSnapshot),
+      // When the caller coalesced this wake into the run, it hands us the
+      // merged snapshot so the merge and the pull-forward land in one guarded
+      // UPDATE. Writing the merge separately and spreading the in-memory
+      // result here would clobber any snapshot write that landed in between.
+      const baseContextSnapshot = mergedContextSnapshot ?? parseObject(run.contextSnapshot);
+      const pulled = await db.transaction(async (tx) => {
+        const row = await tx
+          .update(heartbeatRuns)
+          .set({
+            scheduledRetryAt: promoteNow,
+            contextSnapshot: {
+              ...baseContextSnapshot,
+              scheduledRetryAt: promoteNow.toISOString(),
+              retryNowRequestedAt: promoteNow.toISOString(),
+              retryNowRequestedByActorType: opts.requestedByActorType ?? null,
+              retryNowRequestedByActorId: opts.requestedByActorId ?? null,
+            },
+            updatedAt: promoteNow,
+          })
+          .where(and(eq(heartbeatRuns.id, run.id), eq(heartbeatRuns.status, "scheduled_retry")))
+          .returning()
+          .then((rows) => rows[0] ?? null);
+        if (!row) return null;
+        if (row.wakeupRequestId) {
+          // Mirror retryScheduledRetryNow: stamp the original wakeup request
+          // so support tooling reading agentWakeupRequests.payload can see
+          // the retry was pulled forward.
+          const wakeupPayload = {
+            ...parseObject(
+              await tx
+                .select({ payload: agentWakeupRequests.payload })
+                .from(agentWakeupRequests)
+                .where(eq(agentWakeupRequests.id, row.wakeupRequestId))
+                .then((rows) => rows[0]?.payload ?? null),
+            ),
             scheduledRetryAt: promoteNow.toISOString(),
             retryNowRequestedAt: promoteNow.toISOString(),
-            retryNowRequestedByActorType: opts.requestedByActorType ?? null,
-            retryNowRequestedByActorId: opts.requestedByActorId ?? null,
-          },
-          updatedAt: promoteNow,
-        })
-        .where(and(eq(heartbeatRuns.id, run.id), eq(heartbeatRuns.status, "scheduled_retry")))
-        .returning()
-        .then((rows) => rows[0] ?? null);
+          };
+          await tx
+            .update(agentWakeupRequests)
+            .set({
+              payload: wakeupPayload,
+              updatedAt: promoteNow,
+            })
+            .where(eq(agentWakeupRequests.id, row.wakeupRequestId));
+        }
+        return row;
+      });
       const rereadRun = () =>
         db
           .select()
@@ -15156,8 +15189,16 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           .where(eq(heartbeatRuns.id, run.id))
           .then((rows) => rows[0] ?? null);
       if (!pulled) {
-        // Lost the race with the scheduler or a concurrent wake; re-read so
-        // the caller reports the run's real status, not the parked snapshot.
+        // Lost the race with the scheduler or a concurrent wake. Still
+        // persist the coalesced snapshot so the wake isn't dropped, then
+        // re-read so the caller reports the run's real status, not the
+        // parked snapshot.
+        if (mergedContextSnapshot) {
+          await db
+            .update(heartbeatRuns)
+            .set({ contextSnapshot: mergedContextSnapshot, updatedAt: new Date() })
+            .where(eq(heartbeatRuns.id, run.id));
+        }
         return rereadRun();
       }
       await appendRunEvent(pulled, await nextRunEventSeq(pulled.id), {
@@ -16277,15 +16318,26 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         coalescedTargetRun.contextSnapshot,
         enrichedContextSnapshot,
       );
-      const mergedRun = await db
-        .update(heartbeatRuns)
-        .set({
-          contextSnapshot: mergedContextSnapshot,
-          updatedAt: new Date(),
-        })
-        .where(eq(heartbeatRuns.id, coalescedTargetRun.id))
-        .returning()
-        .then((rows) => rows[0] ?? coalescedTargetRun);
+      // Promotion owns the snapshot write for human wakes into a parked
+      // scheduled_retry: it folds the merged snapshot and the retry
+      // pull-forward into a single guarded UPDATE so no concurrent snapshot
+      // mutation can land between two writes and get clobbered. When the
+      // wake isn't promotable the merge is written here as before.
+      const promotedRun = await promoteScheduledRetryForHumanWake(
+        coalescedTargetRun,
+        mergedContextSnapshot,
+      );
+      const mergedRun: typeof heartbeatRuns.$inferSelect =
+        promotedRun ??
+        (await db
+          .update(heartbeatRuns)
+          .set({
+            contextSnapshot: mergedContextSnapshot,
+            updatedAt: new Date(),
+          })
+          .where(eq(heartbeatRuns.id, coalescedTargetRun.id))
+          .returning()
+          .then((rows) => rows[0] ?? coalescedTargetRun));
 
       await db.insert(agentWakeupRequests).values({
         companyId: agent.companyId,
@@ -16303,7 +16355,6 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         finishedAt: new Date(),
       });
 
-      const promotedRun = await promoteScheduledRetryForHumanWake(mergedRun);
       if (promotedRun) {
         await startNextQueuedRunForAgent(agent.id);
         return promotedRun;


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The server heartbeat service queues, coalesces, retries, and dispatches agent runs; failed runs with transient errors are parked as `scheduled_retry` rows with bounded exponential backoff (2m/10m/30m/2h with jitter)
> - Issue comment wakes are enqueued with `source: "automation"`, so `enqueueWakeup` coalesces them into any active same-scope run, including a parked `scheduled_retry`
> - When that happens, the comment's `wakeCommentId` is merged into the parked run's context but the retry keeps its original schedule, so the person who messaged the agent gets no response until the backoff expires, which can be hours after the underlying failure (for example a Claude session limit) has cleared
> - From the operator's point of view the agent is completely unresponsive: commenting on the issue does nothing visible and only the on-demand "Run Heartbeat" button unsticks it
> - This pull request promotes a parked scheduled retry through the standard retry gate whenever the wake that coalesced into it was requested by a human (`requestedByActorType: "user"`), mirroring `retryScheduledRetryNow`
> - Agent- and system-initiated wakes keep the existing coalesce-without-promotion behavior, so bounded retry backoff still protects against automated wake storms
> - The benefit is that messaging an agent always gets it moving again as soon as a human asks, instead of leaving them staring at a silent, hours-long backoff

## Linked Issues or Issue Description

Refs #9730 (this PR fixes the second half of that report: "commenting on the issue does not wake the agent while a run sits in scheduled_retry"; the first half, backoff ignoring the provider-reported reset time, is addressed by #9626 and #8692)

Related PRs found while searching for duplicates:

- #9013 adds the same promotion mechanic but only for `source === "on_demand"` wakes (the "Run Heartbeat" button); comment wakes arrive with `source: "automation"` and are not covered by it. This PR follows the same implementation pattern so the two compose cleanly if both land; the promotion is guarded by run status, so double promotion is a no-op.
- #9294 adds a quota circuit breaker; it does not change comment wake coalescing.

Incident evidence (from a production instance on `@paperclipai/server 2026.707.0`, full timeline in #9730): an agent hit a provider session limit and its retry was parked for 2h13m. A user comment posted 9 seconds after the limit reset was coalesced into the parked run (its `contextSnapshot.wakeCommentId` was updated) but the run kept its schedule, more than two hours away. Clicking "Run Heartbeat" one minute later dispatched a run instantly, proving capacity was back. The issue was in `in_review` at the time, so the existing route-level path that cancels a scheduled retry when a human comments (`shouldHumanCommentResumeInProgressScheduledRetry`) did not apply; that path only covers `in_progress` issues, and the wake was swallowed at the heartbeat layer instead.

## What Changed

- `server/src/services/heartbeat.ts`: added `promoteScheduledRetryForHumanWake` inside `enqueueWakeup`. When a wake with `requestedByActorType: "user"` coalesces into a `scheduled_retry` run (either coalesce path: the issue-execution transaction path or the same-scope active-run path), the retry's `scheduledRetryAt` is pulled forward to now, a lifecycle run event is recorded, and the run is promoted through the standard `promoteScheduledRetryRun` gate (budget, invokability, issue state), then dispatched via `startNextQueuedRunForAgent`.
- Review follow-up (5f38458): the same-scope coalesce path no longer writes the merged context snapshot and the retry pull-forward as two separate updates. `promoteScheduledRetryForHumanWake` now receives the merged snapshot and folds the merge plus the `scheduledRetryAt` pull-forward into a single `UPDATE` guarded by `status = 'scheduled_retry'`, so a concurrent snapshot write can no longer land between the two writes and be clobbered. If the guarded update loses the race, the merged snapshot is still persisted so the coalesced wake is not dropped.
- Review follow-up (5f38458): mirroring `retryScheduledRetryNow`, the promotion now also stamps the retry run's original `agentWakeupRequests.payload` with `scheduledRetryAt` and `retryNowRequestedAt` inside the same transaction, closing the observability gap for support tooling that reads the wakeup request to explain a promotion.
- `server/src/__tests__/heartbeat-human-comment-wake-promotes-retry.test.ts`: embedded-postgres coverage for the new behavior: an agent comment wake keeps the retry parked; a human comment wake on an `in_review` issue (the incident shape) promotes and executes the parked run with the comment merged into its context; a human wake promotes an agent-scoped parked retry; an already-promoted (queued) run is not re-promoted.

## Verification

- `pnpm exec vitest run src/__tests__/heartbeat-human-comment-wake-promotes-retry.test.ts` in `server/`: 4 tests pass (run twice to confirm stability)
- `pnpm exec vitest run src/__tests__/heartbeat-retry-scheduling.test.ts src/__tests__/heartbeat-comment-wake-batching.test.ts` in `server/`: 39 tests pass, no regressions in the adjacent retry and comment-wake suites
- `tsc --noEmit` in `server/` passes
- The human-promotion test now also asserts the `agentWakeupRequests.payload` stamp; that assertion fails against the pre-fix code and passes after the fix, shown below.

Full suite passing at 5f38458 (after the review fixes):

![vitest run: 4 tests passing after the review fixes](https://raw.githubusercontent.com/hawikk/paperclip/assets/human-wake-promotion-evidence/pr9732-tests-passing-after-fix.png)

Same test file run against the pre-fix `heartbeat.ts` (8c31865): the new payload-stamp assertion fails with `retryNowRequestedAt` missing, proving the regression coverage is real:

![vitest run: new payload-stamp assertion fails against pre-fix code](https://raw.githubusercontent.com/hawikk/paperclip/assets/human-wake-promotion-evidence/pr9732-regression-test-fails-before-fix.png)

## Risks

- Behavioral shift: a human comment (or any human-attributed wake) now front-runs the retry backoff. This is intentional and scoped: the promotion still goes through `evaluateScheduledRetryGate`, so budget blocks, agent invokability, terminal issue states, pause holds, and review-participant checks all still suppress it. Attempt counting is unchanged, so a promoted retry that fails again re-parks with the next bounded backoff step and retries stay finite.
- Local-CLI agents that authenticate as users are treated as human here, matching how the rest of the codebase interprets `requestedByActorType: "user"`. Worst case they pull a retry forward that would have fired later anyway, still bounded by max attempts.
- No schema changes, no migrations, no telemetry changes.

## Model Used

Claude Fable 5 (Anthropic, model ID `claude-fable-5`), running in Claude Code / Claude Agent SDK with extended thinking and tool use. The change and tests were authored by the model and reviewed by the account owner.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes (no docs affected)
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green (will confirm once CI runs on this PR)
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups (pending automated review)
- [x] I will address all Greptile and reviewer comments before requesting merge

## Relationship to the existing resume path

There is already a route-layer resume path for this scenario: `cancelScheduledRetrySupersededByComment` (`server/src/routes/issues.ts`), gated by `shouldHumanCommentResumeInProgressScheduledRetry`. That gate fires only when the comment actor is human, the run's `agentId` matches the current assignee, **and the issue status is `in_progress`** (`issues.ts:1748-1758`). On fire it moves the issue to `todo` and cancels + requeues the parked retry.

This PR is deliberately not a duplicate of that path. It covers the cases that gate excludes:

- **`in_review` and other non-terminal statuses.** The incident parked while the issue was `in_review`, so the route gate short-circuits and `issue_comment_scheduled_retry_superseded` never logs. The comment wake still enqueues (`in_review` is not closed) and coalesces into the parked `scheduled_retry` run, but without promotion it just merges `wakeCommentId` and keeps the ~2h backoff. That coalesce-without-promotion is the silent no-op this PR fixes.
- **Agent-scoped parked retries** that never flow through the issue-comment route at all.

Promotion is placed in `heartbeat.wakeup` because that is the single chokepoint for every human wake source (comment, interaction, agent-scoped) and it does not mutate issue status as a side effect. An alternative would be to widen the route gate to accept `in_review`; open to that if reviewers prefer keeping resume logic at the route layer.

The ~2h backoff for session-limit failures is tracked separately as #9730; this PR does not change backoff length, only lets a human comment jump the queue on an already-parked retry.
