### PR TITLE
Close tool-gateway/approval/secret audit-coverage gaps

### DIFF
--- a/server/src/__tests__/activity-routes.test.ts
+++ b/server/src/__tests__/activity-routes.test.ts
@@ -111,7 +111,10 @@ describe.sequential("activity routes", () => {
       explanation: "Allowed by test mock.",
     });
     mockLogActivity.mockReset();
-    mockLogActivity.mockResolvedValue(undefined);
+    mockLogActivity.mockImplementation(async (_db: unknown, entry: Record<string, unknown>) => ({
+      id: "activity-row-1",
+      ...entry,
+    }));
   });
 
   it("stamps the authenticated caller and ignores body-supplied actor fields when creating activity (P6)", async () => {
@@ -148,6 +151,8 @@ describe.sequential("activity routes", () => {
     expect(entry.entityType).toBe("issue");
     expect(res.body.actorId).toBe("real-user");
     expect(res.body.actorType).toBe("user");
+    // The inserted row (with its id) is returned, preserving the API contract.
+    expect(res.body.id).toBe("activity-row-1");
   });
 
   it("limits company activity lists by default", async () => {

--- a/server/src/__tests__/activity-routes.test.ts
+++ b/server/src/__tests__/activity-routes.test.ts
@@ -23,6 +23,12 @@ const mockAccessService = vi.hoisted(() => ({
   decide: vi.fn(),
 }));
 
+const mockLogActivity = vi.hoisted(() => vi.fn());
+
+vi.mock("../services/activity-log.js", () => ({
+  logActivity: mockLogActivity,
+}));
+
 vi.mock("../services/activity.js", () => ({
   activityService: () => mockActivityService,
   normalizeActivityLimit: (limit: number | undefined) => {
@@ -104,6 +110,44 @@ describe.sequential("activity routes", () => {
       reason: "allow_test",
       explanation: "Allowed by test mock.",
     });
+    mockLogActivity.mockReset();
+    mockLogActivity.mockResolvedValue(undefined);
+  });
+
+  it("stamps the authenticated caller and ignores body-supplied actor fields when creating activity (P6)", async () => {
+    const app = await createApp({
+      type: "board",
+      userId: "real-user",
+      companyIds: ["company-1"],
+      source: "session",
+      isInstanceAdmin: false,
+    });
+    const res = await requestApp(app, (baseUrl) => request(baseUrl)
+      .post("/api/companies/company-1/activity")
+      .send({
+        // Spoof attempt — none of these actor fields must survive.
+        actorType: "agent",
+        actorId: "spoofed-agent",
+        agentId: "00000000-0000-0000-0000-000000000000",
+        action: "custom.event",
+        entityType: "issue",
+        entityId: "issue-1",
+        details: { note: "hi" },
+      }));
+
+    expect(res.status).toBe(201);
+    // The body's actor was discarded; the durable insert uses the caller.
+    expect(mockActivityService.create).not.toHaveBeenCalled();
+    expect(mockLogActivity).toHaveBeenCalledTimes(1);
+    const [, entry] = mockLogActivity.mock.calls[0];
+    expect(entry.actorType).toBe("user");
+    expect(entry.actorId).toBe("real-user");
+    expect(entry.actorId).not.toBe("spoofed-agent");
+    expect(entry.agentId).toBeNull();
+    expect(entry.action).toBe("custom.event");
+    expect(entry.entityType).toBe("issue");
+    expect(res.body.actorId).toBe("real-user");
+    expect(res.body.actorType).toBe("user");
   });
 
   it("limits company activity lists by default", async () => {

--- a/server/src/__tests__/tool-access-service.test.ts
+++ b/server/src/__tests__/tool-access-service.test.ts
@@ -962,6 +962,83 @@ describeEmbeddedPostgres("tool access service", () => {
     expect(disabled.body).toMatchObject({ templateId: "local.echo-admin", status: "disabled" });
   });
 
+  it("gates the policy simulator on tools:admin and stamps the authenticated tester server-side (P6)", async () => {
+    const company = await createCompany(db);
+    const userId = `policy-tester-${randomUUID()}`;
+    const actor: Express.Request["actor"] = {
+      type: "board",
+      userId,
+      userName: "Policy Tester",
+      userEmail: null,
+      isInstanceAdmin: false,
+      source: "session",
+      companyIds: [company.id],
+      memberships: [{ companyId: company.id, membershipRole: "operator", status: "active" }],
+    };
+    await db.insert(companyMemberships).values({
+      companyId: company.id,
+      principalType: "user",
+      principalId: userId,
+      status: "active",
+      membershipRole: "operator",
+    });
+    const app = createRouteApp(db, actor);
+    // The simulated subject must be a real agent — the shared audit writer
+    // persists a tool_call_event keyed on the agent FK.
+    const simulatedAgent = await createAgent(db, company.id);
+
+    const testBody = {
+      companyId: company.id,
+      actor: { actorType: "agent" as const, actorId: simulatedAgent.id, agentId: simulatedAgent.id },
+      runContext: {},
+      request: { toolName: "kv_set" },
+      writeAuditEvent: true,
+    };
+
+    // Without tools:admin the diagnostic is refused and nothing is persisted.
+    await request(app)
+      .post(`/api/companies/${company.id}/tools/policy/test`)
+      .send(testBody)
+      .expect(403);
+    const beforeGrant = await db.select().from(activityLog).where(and(
+      eq(activityLog.companyId, company.id),
+      eq(activityLog.action, "tool_access.policy_tested"),
+    ));
+    expect(beforeGrant).toHaveLength(0);
+
+    await db.insert(principalPermissionGrants).values({
+      companyId: company.id,
+      principalType: "user",
+      principalId: userId,
+      permissionKey: "tools:admin",
+      scope: null,
+      grantedByUserId: "owner",
+    });
+
+    // With tools:admin the simulation runs and records the *caller* — not the
+    // body-supplied simulated subject — in the durable activity_log row.
+    const allowed = await request(app)
+      .post(`/api/companies/${company.id}/tools/policy/test`)
+      .send(testBody)
+      .expect(200);
+    expect(allowed.body).toHaveProperty("decision");
+
+    const [event] = await db.select().from(activityLog).where(and(
+      eq(activityLog.companyId, company.id),
+      eq(activityLog.action, "tool_access.policy_tested"),
+    ));
+    expect(event).toBeDefined();
+    expect(event.actorType).toBe("user");
+    expect(event.actorId).toBe(userId);
+    expect(event.responsibleUserId).toBe(userId);
+    expect(event.details).toMatchObject({
+      simulatedActorType: "agent",
+      simulatedActorId: simulatedAgent.id,
+      simulatedAgentId: simulatedAgent.id,
+      testedByUserId: userId,
+    });
+  });
+
   it("launches local stdio slots only through active admin-defined templates", async () => {
     const company = await createCompany(db);
     const service = toolAccessService(db);

--- a/server/src/__tests__/tool-gateway.test.ts
+++ b/server/src/__tests__/tool-gateway.test.ts
@@ -655,6 +655,70 @@ describeEmbeddedPostgres("tool gateway acceptance", () => {
     }
   });
 
+  it("attributes generic gateway-client token audits to the token, with the human resolvable via mint-time provenance (P10)", async () => {
+    const company = await createCompany(db);
+    await createRemoteMcpTool(db, company.id, {
+      applicationKey: "p10-app",
+      toolName: "read_note",
+      title: "Read note",
+      url: "http://127.0.0.1:9/mcp",
+      riskLevel: "read",
+    });
+    const [profile] = await db.insert(toolProfiles).values({
+      companyId: company.id,
+      profileKey: `p10-${randomUUID()}`,
+      name: `P10 ${randomUUID()}`,
+      defaultAction: "allow",
+    }).returning();
+    const gateway = createTestToolGatewayService(db);
+    const created = await gateway.createNamedGateway({
+      companyId: company.id,
+      body: { name: "P10 gateway", profileId: profile.id },
+      actor: { userId: "gateway-owner" },
+    });
+    const ownerUserId = `mint-owner-${randomUUID()}`;
+    const token = await gateway.createNamedGatewayToken({
+      companyId: company.id,
+      gatewayId: created.id,
+      body: { name: "cursor", clientLabel: "Cursor", ownerNote: "P10 fixture" },
+      actor: { userId: ownerUserId },
+    });
+
+    // Design decision (P10): a generic gateway_client token carries no run or
+    // agent identity, so the token→human mapping lives ONLY on the token record
+    // (`createdByUserId`, captured at mint time) and is mirrored into the audit
+    // spine by the `token_minted` event.
+    const [tokenRow] = await db.select().from(toolMcpGatewayTokens)
+      .where(eq(toolMcpGatewayTokens.id, token.id));
+    expect(tokenRow.createdByUserId).toBe(ownerUserId);
+    expect(tokenRow.subjectType).toBe("gateway_client");
+    const [mintEvent] = await db.select().from(activityLog).where(and(
+      eq(activityLog.companyId, company.id),
+      eq(activityLog.action, "tool_gateway.token_minted"),
+    ));
+    expect(mintEvent.entityId).toBe(token.id);
+    expect(mintEvent.details).toMatchObject({ mintedByUserId: ownerUserId, subjectType: "gateway_client" });
+
+    // At call time the audit attributes to the token subject — not a human or
+    // agent — because a generic client carries no run/agent identity.
+    const app = createGatewayRouteApp(db, gateway);
+    await request(app)
+      .post(`/api/tool-gateway/gateways/${created.id}/mcp`)
+      .set("authorization", `Bearer ${token.token}`)
+      .send({ jsonrpc: "2.0", id: 1, method: "tools/list" })
+      .expect(200);
+    const [discovery] = await db.select().from(activityLog).where(and(
+      eq(activityLog.companyId, company.id),
+      eq(activityLog.action, "tool_gateway.discovery"),
+    ));
+    expect(discovery).toBeDefined();
+    expect(discovery.agentId).toBeNull();
+    expect(discovery.actorType).not.toBe("user");
+    const auditRows = await db.select().from(toolAccessAuditEvents)
+      .where(eq(toolAccessAuditEvents.companyId, company.id));
+    expect(auditRows.some((row) => row.gatewayTokenId === token.id)).toBe(true);
+  });
+
   it("omits archived gateways from listNamedGateways", async () => {
     const company = await createCompany(db);
     const [profile] = await db.insert(toolProfiles).values({
@@ -686,6 +750,73 @@ describeEmbeddedPostgres("tool gateway acceptance", () => {
     });
     listed = await gateway.listNamedGateways(company.id);
     expect(listed.map((g) => g.id)).toEqual([kept.id]);
+  });
+
+  it("audits gateway reconfiguration, token mint, and token revocation with the responsible human (G15/P15)", async () => {
+    const company = await createCompany(db);
+    const [profile] = await db.insert(toolProfiles).values({
+      companyId: company.id,
+      profileKey: `admin-audit-${randomUUID()}`,
+      name: `Admin audit ${randomUUID()}`,
+      defaultAction: "deny",
+    }).returning();
+    const gateway = createTestToolGatewayService(db);
+    const userId = `board-${randomUUID()}`;
+    const actor = { userId };
+
+    const created = await gateway.createNamedGateway({
+      companyId: company.id,
+      body: { name: "Audited gateway", profileId: profile.id },
+      actor,
+    });
+
+    // P15 — token mint emits a durable audit event attributed to the minter.
+    const token = await gateway.createNamedGatewayToken({
+      companyId: company.id,
+      gatewayId: created.id,
+      body: { name: "client-token", clientLabel: "ci client", ownerNote: "ci fixture" },
+      actor,
+    });
+
+    // G15 — reconfiguring the gateway auth policy is now traced.
+    await gateway.updateNamedGateway({
+      companyId: company.id,
+      gatewayId: created.id,
+      body: { defaultProfileMode: "gateway_then_context" },
+      actor,
+    });
+
+    // G15 — revocation records who revoked the credential.
+    await gateway.revokeNamedGatewayToken({
+      companyId: company.id,
+      tokenId: token.id,
+      actor,
+    });
+
+    const events = await db.select().from(activityLog).where(eq(activityLog.companyId, company.id));
+    const byAction = new Map(events.map((event) => [event.action, event]));
+
+    const mint = byAction.get("tool_gateway.token_minted");
+    expect(mint).toBeDefined();
+    expect(mint!.actorType).toBe("user");
+    expect(mint!.actorId).toBe(userId);
+    expect(mint!.responsibleUserId).toBe(userId);
+    expect(mint!.entityId).toBe(token.id);
+    expect((mint!.details as Record<string, unknown>).mintedByUserId).toBe(userId);
+    expect((mint!.details as Record<string, unknown>).gatewayId).toBe(created.id);
+
+    const reconfig = byAction.get("tool_gateway.gateway_reconfigured");
+    expect(reconfig).toBeDefined();
+    expect(reconfig!.responsibleUserId).toBe(userId);
+    expect(reconfig!.entityId).toBe(created.id);
+    expect((reconfig!.details as Record<string, unknown>).changedFields).toContain("defaultProfileMode");
+    expect((reconfig!.details as Record<string, unknown>).policySurfaceChanged).toBe(true);
+
+    const revoke = byAction.get("tool_gateway.token_revoked");
+    expect(revoke).toBeDefined();
+    expect(revoke!.responsibleUserId).toBe(userId);
+    expect(revoke!.entityId).toBe(token.id);
+    expect((revoke!.details as Record<string, unknown>).revokedByUserId).toBe(userId);
   });
 
   it("throttles named gateway bearer auth failures without leaking bearer material", async () => {
@@ -1542,6 +1673,19 @@ rl.on("line", (line) => {
         summary: expect.stringContaining("\"saved\":true"),
       });
 
+      // P9: the tool_connection secret access is attributed to the initiating
+      // agent + run + issue, not the anonymous `system` consumer.
+      const connectionAccessEvents = (await db.select().from(secretAccessEvents)
+        .where(eq(secretAccessEvents.companyId, company.id)))
+        .filter((event) => event.consumerType === "tool_connection");
+      expect(connectionAccessEvents.length).toBeGreaterThan(0);
+      for (const event of connectionAccessEvents) {
+        expect(event.actorType).toBe("agent");
+        expect(event.actorId).toBe(agent.id);
+        expect(event.heartbeatRunId).toBe(run.id);
+        expect(event.issueId).toBe(issue.id);
+      }
+
       const callEvents = await db.select().from(toolCallEvents);
       expect(callEvents).toEqual(expect.arrayContaining([
         expect.objectContaining({
@@ -2301,6 +2445,26 @@ rl.on("line", (line) => {
         actionRequestId: rejectedRequest.id,
         actor: { agentId: agent.id },
       });
+      // P4: the decline is now visible in the activity_log spine and mirrored
+      // into the tool-call event stream (previously it produced neither).
+      const declineActivity = (await db
+        .select()
+        .from(activityLog)
+        .where(eq(activityLog.action, "tool_gateway.approval_resolved")))
+        .find((event) => event.details?.actionRequestId === rejectedRequest.id);
+      expect(declineActivity).toBeDefined();
+      expect(declineActivity!.actorType).toBe("agent");
+      expect(declineActivity!.details).toMatchObject({
+        decision: "declined",
+        decidedByAgentId: agent.id,
+      });
+      const declineCallEvent = (await db
+        .select()
+        .from(toolCallEvents)
+        .where(eq(toolCallEvents.actionRequestId, rejectedRequest.id)))
+        .find((event) => event.eventType === "approval_resolved");
+      expect(declineCallEvent).toBeDefined();
+      expect(declineCallEvent!.outcome).toBe("denied");
       await gateway.executeTool({
         sessionToken: session.token,
         tool: rejectedToolName,
@@ -3086,6 +3250,23 @@ rl.on("line", (line) => {
       .send({ companyId: company.id });
     expect(restart.status).toBe(200);
     expect(restart.body).toMatchObject({ id: slotId, status: "running" });
+
+    // P5: the human operator behind a manual stop/restart is now attributed in
+    // the activity_log spine (previously only the system `.stopped` row existed).
+    const operatorEvents = (await db.select().from(activityLog).where(eq(activityLog.companyId, company.id)))
+      .filter((event) => event.action === "tool_runtime_slot.operator_stopped"
+        || event.action === "tool_runtime_slot.operator_restarted");
+    expect(operatorEvents.map((event) => event.action).sort()).toEqual([
+      "tool_runtime_slot.operator_restarted",
+      "tool_runtime_slot.operator_stopped",
+    ]);
+    for (const event of operatorEvents) {
+      expect(event.actorType).toBe("user");
+      expect(event.actorId).toBe(userId);
+      expect(event.responsibleUserId).toBe(userId);
+      expect(event.entityId).toBe(slotId);
+      expect((event.details as Record<string, unknown>).operatorUserId).toBe(userId);
+    }
 
     const audit = await request(app)
       .get("/api/tool-gateway/audit")

--- a/server/src/routes/activity.ts
+++ b/server/src/routes/activity.ts
@@ -4,13 +4,17 @@ import type { Db } from "@paperclipai/db";
 import { normalizeIssueIdentifier } from "@paperclipai/shared";
 import { validate } from "../middleware/validate.js";
 import { activityService, normalizeActivityLimit } from "../services/activity.js";
-import { assertAuthenticated, assertBoard, assertCompanyAccess, getAccessibleResource, hasCompanyAccess } from "./authz.js";
+import { assertAuthenticated, assertBoard, assertCompanyAccess, getAccessibleResource, getActorInfo, hasCompanyAccess } from "./authz.js";
 import { accessService, heartbeatService, issueService } from "../services/index.js";
+import { logActivity } from "../services/activity-log.js";
 import { sanitizeRecord } from "../redaction.js";
 
+// P6: `actorType`/`actorId`/`agentId` are accepted for backward compatibility
+// but IGNORED — the durable actor is always stamped from the authenticated
+// caller server-side so this endpoint can never forge audit attribution.
 const createActivitySchema = z.object({
-  actorType: z.enum(["agent", "user", "system", "plugin"]).optional().default("system"),
-  actorId: z.string().min(1),
+  actorType: z.enum(["agent", "user", "system", "plugin"]).optional(),
+  actorId: z.string().min(1).optional(),
   action: z.string().min(1),
   entityType: z.string().min(1),
   entityId: z.string().min(1),
@@ -92,12 +96,34 @@ export function activityRoutes(db: Db) {
     assertBoard(req);
     const companyId = req.params.companyId as string;
     assertCompanyAccess(req, companyId);
-    const event = await svc.create({
+    // Stamp the authenticated caller — the body's actor fields are not trusted.
+    // Routing through `logActivity` also resolves `responsibleUserId` and emits
+    // the live/plugin events that a raw insert would have skipped.
+    const actor = getActorInfo(req);
+    const entry = {
       companyId,
-      ...req.body,
+      actorType: actor.actorType,
+      actorId: actor.actorId,
+      action: req.body.action as string,
+      entityType: req.body.entityType as string,
+      entityId: req.body.entityId as string,
+      agentId: actor.agentId,
+      runId: actor.runId,
+      agentApiKeyId: actor.agentApiKeyId,
       details: req.body.details ? sanitizeRecord(req.body.details) : null,
+    };
+    await logActivity(db, entry);
+    res.status(201).json({
+      companyId: entry.companyId,
+      actorType: entry.actorType,
+      actorId: entry.actorId,
+      action: entry.action,
+      entityType: entry.entityType,
+      entityId: entry.entityId,
+      agentId: entry.agentId,
+      runId: entry.runId,
+      details: entry.details,
     });
-    res.status(201).json(event);
   });
 
   router.get("/issues/:id/activity", async (req, res) => {

--- a/server/src/routes/activity.ts
+++ b/server/src/routes/activity.ts
@@ -112,18 +112,10 @@ export function activityRoutes(db: Db) {
       agentApiKeyId: actor.agentApiKeyId,
       details: req.body.details ? sanitizeRecord(req.body.details) : null,
     };
-    await logActivity(db, entry);
-    res.status(201).json({
-      companyId: entry.companyId,
-      actorType: entry.actorType,
-      actorId: entry.actorId,
-      action: entry.action,
-      entityType: entry.entityType,
-      entityId: entry.entityId,
-      agentId: entry.agentId,
-      runId: entry.runId,
-      details: entry.details,
-    });
+    // Return the inserted row (including its `id`) to preserve the response
+    // contract the previous `svc.create` handler exposed.
+    const created = await logActivity(db, entry);
+    res.status(201).json(created);
   });
 
   router.get("/issues/:id/activity", async (req, res) => {

--- a/server/src/routes/tool-access.ts
+++ b/server/src/routes/tool-access.ts
@@ -1258,14 +1258,43 @@ export function toolAccessRoutes(
   });
 
   router.post("/companies/:companyId/tools/policy/test", validate(toolPolicyTestRequestSchema), async (req, res) => {
-    assertBoard(req);
     const companyId = req.params.companyId as string;
-    assertCompanyAccess(req, companyId);
+    // P6: gate the diagnostic on tools:admin (previously any board principal
+    // could probe/persist), and stamp the authenticated caller so a persisted
+    // simulation can never be forged as another actor.
+    await assertToolsAdmin(req, companyId);
     const input = { ...req.body, companyId };
     const decision = await policySvc.decide(input);
     let auditEvent = null;
     if (input.writeAuditEvent === true) {
       auditEvent = await policySvc.writeAudit(input, decision);
+      const actor = getActorInfo(req);
+      // The tool-audit stream row is attributed to the *simulated* subject
+      // (`input.actor`); record who actually ran the test in the activity_log
+      // spine, attributed server-side to the authenticated caller.
+      await logActivity(db, {
+        companyId,
+        actorType: actor.actorType,
+        actorId: actor.actorId,
+        action: "tool_access.policy_tested",
+        entityType: "tool_policy",
+        entityId: input.request?.connectionId ?? input.request?.applicationId ?? companyId,
+        agentId: actor.agentId,
+        runId: actor.runId,
+        agentApiKeyId: actor.agentApiKeyId,
+        details: {
+          decision: decision.decision,
+          reasonCode: decision.reasonCode,
+          toolName: input.request?.toolName ?? null,
+          connectionId: input.request?.connectionId ?? null,
+          applicationId: input.request?.applicationId ?? null,
+          simulatedActorType: input.actor?.actorType ?? null,
+          simulatedActorId: input.actor?.actorId ?? null,
+          simulatedAgentId: input.actor?.agentId ?? null,
+          testedByAgentId: actor.agentId,
+          testedByUserId: actor.actorType === "user" ? actor.actorId : null,
+        },
+      });
     }
     res.json({ decision, auditEvent });
   });

--- a/server/src/routes/tool-gateway.ts
+++ b/server/src/routes/tool-gateway.ts
@@ -325,7 +325,17 @@ export function toolGatewayRoutes(db: Db, toolGateway: ToolGatewayService) {
         return;
       }
       const { companyId: _companyId, ...body } = parsed.data as typeof parsed.data & { companyId?: string };
-      res.json(await toolGateway.updateNamedGateway({ companyId, gatewayId: req.params.gatewayId, body }));
+      const actor = getActorInfo(req);
+      res.json(await toolGateway.updateNamedGateway({
+        companyId,
+        gatewayId: req.params.gatewayId,
+        body,
+        actor: {
+          agentId: actor.agentId,
+          userId: req.actor.type === "board" ? req.actor.userId : null,
+          runId: actor.runId,
+        },
+      }));
     } catch (err) {
       sendGatewayError(res, err);
     }
@@ -366,7 +376,16 @@ export function toolGatewayRoutes(db: Db, toolGateway: ToolGatewayService) {
         return;
       }
       await assertBoardPermission(req, companyId, "tools:admin");
-      res.json(await toolGateway.revokeNamedGatewayToken({ companyId, tokenId: req.params.tokenId }));
+      const actor = getActorInfo(req);
+      res.json(await toolGateway.revokeNamedGatewayToken({
+        companyId,
+        tokenId: req.params.tokenId,
+        actor: {
+          agentId: actor.agentId,
+          userId: req.actor.type === "board" ? req.actor.userId : null,
+          runId: actor.runId,
+        },
+      }));
     } catch (err) {
       sendGatewayError(res, err);
     }
@@ -598,6 +617,7 @@ export function toolGatewayRoutes(db: Db, toolGateway: ToolGatewayService) {
         slotId: req.params.slotId,
         actor: {
           agentId: actor.agentId,
+          userId: req.actor.type === "board" ? req.actor.userId : null,
           runId: req.actor.type === "agent" ? req.actor.runId : null,
         },
       }));
@@ -625,6 +645,7 @@ export function toolGatewayRoutes(db: Db, toolGateway: ToolGatewayService) {
         slotId: req.params.slotId,
         actor: {
           agentId: actor.agentId,
+          userId: req.actor.type === "board" ? req.actor.userId : null,
           runId: req.actor.type === "agent" ? req.actor.runId : null,
         },
       }));

--- a/server/src/services/activity-log.ts
+++ b/server/src/services/activity-log.ts
@@ -133,7 +133,7 @@ export async function logActivity(db: Db, input: LogActivityInput) {
     ? redactCurrentUserValue(sanitizedDetails, currentUserRedactionOptions)
     : null;
   const responsibleUserId = await resolveResponsibleUserIdForActivity(db, input);
-  await db.insert(activityLog).values({
+  const [inserted] = await db.insert(activityLog).values({
     companyId: input.companyId,
     actorType: input.actorType,
     actorId: input.actorId,
@@ -144,7 +144,7 @@ export async function logActivity(db: Db, input: LogActivityInput) {
     runId: input.runId ?? null,
     responsibleUserId,
     details: redactedDetails,
-  });
+  }).returning();
 
   publishLiveEvent({
     companyId: input.companyId,
@@ -182,4 +182,6 @@ export async function logActivity(db: Db, input: LogActivityInput) {
     };
     publishPluginDomainEvent(event);
   }
+
+  return inserted;
 }

--- a/server/src/services/tool-gateway.ts
+++ b/server/src/services/tool-gateway.ts
@@ -1194,6 +1194,81 @@ export function createToolGatewayService(
     });
   }
 
+  /**
+   * Resolve the authenticated actor for gateway admin / credential-lifecycle
+   * activity_log events. The caller passes only agentId/userId/runId that were
+   * derived server-side from the request (never trusted from the body); this
+   * derives the actorType/actorId columns and preserves the human decider so
+   * `resolveResponsibleUserIdForActivity` can map the event back to a person.
+   */
+  function resolveAdminActor(
+    actor: { agentId?: string | null; userId?: string | null; runId?: string | null } | undefined,
+    companyId: string,
+  ): { actorType: LogActivityInput["actorType"]; actorId: string; agentId: string | null; userId: string | null; runId: string | null } {
+    const agentId = actor?.agentId ?? null;
+    const userId = actor?.userId ?? null;
+    const actorType: LogActivityInput["actorType"] = agentId ? "agent" : userId ? "user" : "system";
+    const actorId = agentId ?? userId ?? companyId;
+    return { actorType, actorId, agentId, userId, runId: actor?.runId ?? null };
+  }
+
+  /**
+   * P5: the runtime supervisor logs the raw `tool_runtime_slot.stopped/started`
+   * transition (actor = agent/system), but the human operator who triggered a
+   * manual stop/restart from the gateway was dropped. Mirror the tool-access
+   * route and emit an `operator_*` activity attributed to that operator.
+   */
+  async function recordRuntimeSlotOperatorAction(
+    companyId: string,
+    slotId: string,
+    action: "stopped" | "restarted",
+    actor: { agentId?: string | null; userId?: string | null; runId?: string | null } | undefined,
+    slot: { runtimeKind?: string | null; status?: string | null; slotKey?: string | null } | null,
+  ) {
+    const operator = resolveAdminActor(actor, companyId);
+    await logActivity(db, {
+      companyId,
+      actorType: operator.actorType,
+      actorId: operator.actorId,
+      action: action === "stopped" ? "tool_runtime_slot.operator_stopped" : "tool_runtime_slot.operator_restarted",
+      entityType: "tool_runtime_slot",
+      entityId: slotId,
+      agentId: operator.agentId,
+      runId: operator.runId,
+      details: {
+        runtimeKind: slot?.runtimeKind ?? null,
+        status: slot?.status ?? null,
+        slotKey: slot?.slotKey ?? null,
+        operatorAgentId: operator.agentId,
+        operatorUserId: operator.userId,
+      },
+    });
+  }
+
+  /**
+   * P9: derive the initiating-actor slice of a secret access context from the
+   * live gateway session so `secret_access_events` records which agent / run /
+   * issue triggered a tool_connection credential resolution instead of the
+   * anonymous `system` consumer. Falls back to `system` when no session is
+   * available (e.g. background health checks).
+   */
+  function secretInitiatorContext(session: ToolGatewaySession | null | undefined): {
+    actorType: "agent" | "user" | "system" | "plugin";
+    actorId: string | null;
+    issueId: string | null;
+    heartbeatRunId: string | null;
+  } {
+    if (!session) {
+      return { actorType: "system", actorId: null, issueId: null, heartbeatRunId: null };
+    }
+    return {
+      actorType: session.actorType ?? (session.agentId ? "agent" : "system"),
+      actorId: session.actorId ?? session.agentId ?? session.gatewayTokenId ?? null,
+      issueId: session.issueId ?? null,
+      heartbeatRunId: session.runId ?? null,
+    };
+  }
+
   async function writeSessionAuthFailure(
     row: typeof toolGatewaySessions.$inferSelect,
     reasonCode: string,
@@ -1381,6 +1456,76 @@ export function createToolGatewayService(
             ...(input.metadata ?? {}),
           }
         : null,
+    });
+  }
+
+  /**
+   * Record a human approve/decline of a tool action-request. The natural
+   * `tool_action_requests` row already stores `decidedBy*`, but P4 of the audit
+   * matrix requires the decision to be visible in the activity_log spine (with
+   * the responsible human resolvable) and mirrored into the tool-call event
+   * stream — declines previously produced neither.
+   */
+  async function recordApprovalResolved(input: {
+    actionRequest: typeof toolActionRequests.$inferSelect;
+    invocation: typeof toolInvocations.$inferSelect;
+    decision: "approved" | "declined";
+    actor: { agentId?: string | null; userId?: string | null };
+  }) {
+    const { actionRequest, invocation, decision } = input;
+    const decidedBy = resolveAdminActor(input.actor, invocation.companyId);
+    await logActivity(db, {
+      companyId: invocation.companyId,
+      actorType: decidedBy.actorType,
+      actorId: decidedBy.actorId,
+      action: "tool_gateway.approval_resolved",
+      entityType: "tool_action_request",
+      entityId: actionRequest.id,
+      agentId: decidedBy.agentId,
+      runId: decidedBy.runId,
+      issueId: invocation.issueId,
+      details: {
+        actionRequestId: actionRequest.id,
+        invocationId: invocation.id,
+        decision,
+        toolName: invocation.toolName,
+        connectionId: invocation.connectionId,
+        catalogEntryId: invocation.catalogEntryId,
+        applicationId: invocation.applicationId,
+        decidedByAgentId: decidedBy.agentId,
+        decidedByUserId: decidedBy.userId,
+        requestedByAgentId: invocation.agentId,
+        requestedByRunId: invocation.runId,
+      },
+    });
+    // The event's actor is the human decider; it stays linked to the requesting
+    // agent's invocation/run so the timeline can join both sides.
+    const decisionSession: ToolGatewaySession = {
+      id: `action-request:${actionRequest.id}`,
+      token: "",
+      companyId: invocation.companyId,
+      agentId: invocation.agentId,
+      runId: invocation.runId,
+      issueId: invocation.issueId,
+      projectId: null,
+      actorType: decidedBy.actorType,
+      actorId: decidedBy.actorId,
+      createdAt: new Date(),
+      expiresAt: new Date(),
+    };
+    await writeToolCallEvent({
+      invocationId: invocation.id,
+      actionRequestId: actionRequest.id,
+      session: decisionSession,
+      eventType: "approval_resolved",
+      outcome: decision === "approved" ? "success" : "denied",
+      toolName: invocation.toolName,
+      policyDecision: decision === "approved" ? "allow" : "deny",
+      reasonCode: decision === "approved" ? "human_approved" : "human_declined",
+      metadata: {
+        decidedByAgentId: decidedBy.agentId,
+        decidedByUserId: decidedBy.userId,
+      },
     });
   }
 
@@ -2338,8 +2483,12 @@ export function createToolGatewayService(
       .where(eq(toolConnections.id, connection.id));
   }
 
-  async function resolveCredentialHeaders(connection: typeof toolConnections.$inferSelect): Promise<Record<string, string>> {
+  async function resolveCredentialHeaders(
+    connection: typeof toolConnections.$inferSelect,
+    session?: ToolGatewaySession | null,
+  ): Promise<Record<string, string>> {
     const headers: Record<string, string> = {};
+    const initiator = secretInitiatorContext(session);
     for (const ref of connection.credentialRefs ?? []) {
       if (ref.placement !== "header") continue;
       try {
@@ -2347,7 +2496,7 @@ export function createToolGatewayService(
           consumerType: "tool_connection",
           consumerId: connection.id,
           configPath: `credentials.${ref.name}`,
-          actorType: "system",
+          ...initiator,
         });
         headers[ref.key] = `${ref.prefix ?? ""}${value}`;
       } catch {
@@ -2376,6 +2525,7 @@ export function createToolGatewayService(
       refHash: string;
       requireResolved: boolean;
     },
+    session?: ToolGatewaySession | null,
   ): Promise<ConnectedCredentialVersionSnapshot> {
     const versionSelector = input.versionSelector ?? "latest";
     try {
@@ -2383,7 +2533,7 @@ export function createToolGatewayService(
         consumerType: "tool_connection",
         consumerId: connection.id,
         configPath: input.configPath,
-        actorType: "system",
+        ...secretInitiatorContext(session),
       });
       return {
         refHash: input.refHash,
@@ -2411,6 +2561,7 @@ export function createToolGatewayService(
   async function connectedCredentialVersionSnapshots(
     connection: typeof toolConnections.$inferSelect,
     options: { requireResolved: boolean },
+    session?: ToolGatewaySession | null,
   ): Promise<{
     headerCredentialVersions: ConnectedCredentialVersionSnapshot[];
     credentialSecretVersions: ConnectedCredentialVersionSnapshot[];
@@ -2436,7 +2587,7 @@ export function createToolGatewayService(
           configPath,
         }),
         requireResolved: options.requireResolved,
-      }));
+      }, session));
     }
 
     for (const ref of connection.credentialSecretRefs ?? []) {
@@ -2453,7 +2604,7 @@ export function createToolGatewayService(
           label: typedRef.label ?? null,
         }),
         requireResolved: options.requireResolved,
-      }));
+      }, session));
     }
 
     return { headerCredentialVersions, credentialSecretVersions };
@@ -2752,7 +2903,7 @@ export function createToolGatewayService(
     if (!row) return null;
     const credentialVersions = await connectedCredentialVersionSnapshots(row.connection, {
       requireResolved: options.requireResolvedCredentials === true,
-    });
+    }, session);
     return {
       applicationId: row.application.id,
       applicationKey: row.application.applicationKey ?? null,
@@ -3008,7 +3159,7 @@ export function createToolGatewayService(
   ): Promise<RemoteHttpExecutionResult> {
     const { entry, connection } = await resolveConnectedRemoteTool(session, tool);
     const endpoint = await assertRemoteEndpointAllowed(connection.config ?? {});
-    const credentialHeaders = await resolveCredentialHeaders(connection);
+    const credentialHeaders = await resolveCredentialHeaders(connection, session);
     const { headers, summary: headerSummary } = buildRemoteHeaders({
       session,
       connection,
@@ -4583,6 +4734,7 @@ export function createToolGatewayService(
       companyId: string;
       gatewayId: string;
       body: UpdateToolMcpGateway;
+      actor?: { agentId?: string | null; userId?: string | null; runId?: string | null };
     }): Promise<ToolMcpGatewayWithTokens> {
       const [existing] = await db
         .select()
@@ -4635,6 +4787,32 @@ export function createToolGatewayService(
           })
           .onConflictDoNothing();
       }
+      const changedFields = (Object.keys(input.body) as Array<keyof UpdateToolMcpGateway>)
+        .filter((key) => input.body[key] !== undefined)
+        .map((key) => String(key));
+      // Policy / credential-surface changes are the highest-signal reconfig;
+      // flag them so audit consumers can prioritize security-relevant edits.
+      // (Key is deliberately not "auth*" — activity_log redacts such values.)
+      const policySurfaceFields = ["authConfig", "headerPolicy", "metadataPolicy", "profileId", "defaultProfileMode", "status", "onDemandToolsConfig"];
+      const actorFields = resolveAdminActor(input.actor, input.companyId);
+      await logActivity(db, {
+        companyId: input.companyId,
+        actorType: actorFields.actorType,
+        actorId: actorFields.actorId,
+        action: "tool_gateway.gateway_reconfigured",
+        entityType: "tool_mcp_gateway",
+        entityId: input.gatewayId,
+        agentId: actorFields.agentId,
+        runId: actorFields.runId,
+        details: {
+          gatewayId: input.gatewayId,
+          gatewayName: updated.name,
+          changedFields,
+          policySurfaceChanged: policySurfaceFields.some((field) => changedFields.includes(field)),
+          reconfiguredByAgentId: actorFields.agentId,
+          reconfiguredByUserId: actorFields.userId,
+        },
+      });
       return getGatewayWithTokens(input.companyId, updated.id);
     },
 
@@ -4679,10 +4857,40 @@ export function createToolGatewayService(
           updatedAt: now,
         })
         .returning();
+      const mintedBy = resolveAdminActor(input.actor, input.companyId);
+      // The token row id is the audited entity so it survives detail redaction
+      // (activity_log redacts any `token*` detail key). The raw secret is never
+      // logged — only its id/prefix.
+      await logActivity(db, {
+        companyId: input.companyId,
+        actorType: mintedBy.actorType,
+        actorId: mintedBy.actorId,
+        action: "tool_gateway.token_minted",
+        entityType: "tool_mcp_gateway_token",
+        entityId: tokenId,
+        agentId: mintedBy.agentId,
+        runId: mintedBy.runId,
+        details: {
+          gatewayId: input.gatewayId,
+          gatewayName: gateway.name,
+          tokenPrefix,
+          subjectType: row.subjectType,
+          subjectId: row.subjectId,
+          allowedActions: row.allowedActions,
+          expiresAt: row.expiresAt?.toISOString() ?? null,
+          mintedByAgentId: mintedBy.agentId,
+          mintedByUserId: mintedBy.userId,
+        },
+      });
       return { ...toGatewayToken(row), token };
     },
 
-    async revokeNamedGatewayToken(input: { companyId: string; tokenId: string; revokedAt?: Date }): Promise<ToolMcpGatewayToken> {
+    async revokeNamedGatewayToken(input: {
+      companyId: string;
+      tokenId: string;
+      revokedAt?: Date;
+      actor?: { agentId?: string | null; userId?: string | null; runId?: string | null };
+    }): Promise<ToolMcpGatewayToken> {
       const now = input.revokedAt ?? new Date();
       const [row] = await db
         .update(toolMcpGatewayTokens)
@@ -4690,6 +4898,28 @@ export function createToolGatewayService(
         .where(and(eq(toolMcpGatewayTokens.companyId, input.companyId), eq(toolMcpGatewayTokens.id, input.tokenId)))
         .returning();
       if (!row) throw new ToolGatewayHttpError(404, "MCP gateway token not found", "gateway_token_not_found");
+      const revokedBy = resolveAdminActor(input.actor, input.companyId);
+      // The token row id is the audited entity so revocation stays attributable
+      // even though `token*` detail keys are redacted in activity_log.
+      await logActivity(db, {
+        companyId: input.companyId,
+        actorType: revokedBy.actorType,
+        actorId: revokedBy.actorId,
+        action: "tool_gateway.token_revoked",
+        entityType: "tool_mcp_gateway_token",
+        entityId: row.id,
+        agentId: revokedBy.agentId,
+        runId: revokedBy.runId,
+        details: {
+          gatewayId: row.gatewayId,
+          tokenPrefix: row.tokenPrefix,
+          subjectType: row.subjectType,
+          subjectId: row.subjectId,
+          revokedAt: now.toISOString(),
+          revokedByAgentId: revokedBy.agentId,
+          revokedByUserId: revokedBy.userId,
+        },
+      });
       return toGatewayToken(row);
     },
 
@@ -5220,6 +5450,12 @@ export function createToolGatewayService(
         .set({ approvalState: "approved", updatedAt: now })
         .where(eq(toolInvocations.id, invocation.id));
       await reflectToolActionInteractionLifecycle({ actionRequestId: updated.id, status: "approved" });
+      await recordApprovalResolved({
+        actionRequest: updated,
+        invocation,
+        decision: "approved",
+        actor: input.actor,
+      });
       // A test-tab ask-first request has no agent run to carry out the parked
       // call, so approving it is what runs it. Execute against the signed
       // arguments and record the result on the invocation for the live panel.
@@ -5290,6 +5526,12 @@ export function createToolGatewayService(
         .update(toolInvocations)
         .set({ approvalState: "rejected", updatedAt: now })
         .where(eq(toolInvocations.id, invocation.id));
+      await recordApprovalResolved({
+        actionRequest: updated,
+        invocation,
+        decision: "declined",
+        actor: input.actor,
+      });
       return updated;
     },
 
@@ -6226,15 +6468,17 @@ export function createToolGatewayService(
     async stopRuntimeSlot(input: {
       companyId: string;
       slotId: string;
-      actor?: { agentId?: string | null; runId?: string | null };
+      actor?: { agentId?: string | null; userId?: string | null; runId?: string | null };
     }) {
       try {
-        return await runtimeSupervisor.stopSlot({
+        const slot = await runtimeSupervisor.stopSlot({
           companyId: input.companyId,
           slotId: input.slotId,
           agentId: input.actor?.agentId ?? null,
           runId: input.actor?.runId ?? null,
         });
+        await recordRuntimeSlotOperatorAction(input.companyId, input.slotId, "stopped", input.actor, slot);
+        return slot;
       } catch (err) {
         if (err instanceof ToolRuntimeSupervisorError) {
           throw new ToolGatewayHttpError(err.status, err.message, err.reasonCode, err.details);
@@ -6246,15 +6490,17 @@ export function createToolGatewayService(
     async restartRuntimeSlot(input: {
       companyId: string;
       slotId: string;
-      actor?: { agentId?: string | null; runId?: string | null };
+      actor?: { agentId?: string | null; userId?: string | null; runId?: string | null };
     }) {
       try {
-        return await runtimeSupervisor.restartSlot({
+        const slot = await runtimeSupervisor.restartSlot({
           companyId: input.companyId,
           slotId: input.slotId,
           agentId: input.actor?.agentId ?? null,
           runId: input.actor?.runId ?? null,
         });
+        await recordRuntimeSlotOperatorAction(input.companyId, input.slotId, "restarted", input.actor, slot);
+        return slot;
       } catch (err) {
         if (err instanceof ToolRuntimeSupervisorError) {
           throw new ToolGatewayHttpError(err.status, err.message, err.reasonCode, err.details);

--- a/ui/src/lib/activity-format.ts
+++ b/ui/src/lib/activity-format.ts
@@ -82,6 +82,13 @@ const ACTIVITY_ROW_VERBS: Record<string, string> = {
   "company.archived": "archived",
   "company.reactivated": "reactivated",
   "company.budget_updated": "updated budget for",
+  "tool_gateway.gateway_reconfigured": "reconfigured tool gateway",
+  "tool_gateway.token_minted": "minted a token for tool gateway",
+  "tool_gateway.token_revoked": "revoked a tool gateway token",
+  "tool_gateway.approval_resolved": "resolved a tool approval request",
+  "tool_runtime_slot.operator_stopped": "stopped tool runtime slot",
+  "tool_runtime_slot.operator_restarted": "restarted tool runtime slot",
+  "tool_access.policy_tested": "ran a tool policy test",
 };
 
 const ISSUE_ACTIVITY_LABELS: Record<string, string> = {
@@ -129,6 +136,13 @@ const ISSUE_ACTIVITY_LABELS: Record<string, string> = {
   "approval.created": "requested approval",
   "approval.approved": "approved",
   "approval.rejected": "rejected",
+  "tool_gateway.gateway_reconfigured": "reconfigured a tool gateway",
+  "tool_gateway.token_minted": "minted a tool gateway token",
+  "tool_gateway.token_revoked": "revoked a tool gateway token",
+  "tool_gateway.approval_resolved": "resolved a tool approval request",
+  "tool_runtime_slot.operator_stopped": "stopped a tool runtime slot",
+  "tool_runtime_slot.operator_restarted": "restarted a tool runtime slot",
+  "tool_access.policy_tested": "ran a tool policy test",
 };
 
 function asRecord(value: unknown): Record<string, unknown> | null {


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Its `activity_log` is the audit spine: every agent-initiated state change should leave a durable, timestamped record resolving to an agent, its run, and the responsible human
> - A coverage review found the tool-gateway / approval / credential / secret surface had gaps — reconfig, token mint/revoke, human approve/decline, runtime-slot operator, and initiating-actor on secret access were untraced or mis-attributed, and two writers trusted body-supplied actor fields
> - Untraced privileged actions and spoofable audit writers undermine accountability and let audit rows be forged
> - This pull request closes those gaps, always stamping the actor server-side and threading the initiating agent/run/issue into secret access
> - The benefit is a complete, non-forgeable audit trail across the tool-gateway surface

## Linked Issues or Issue Description

<!-- No public GitHub issue — describing the underlying problem inline (path B). -->

**Problem (audit coverage gaps, tool-gateway / approvals / secrets):**

- `PATCH /api/tool-gateway/gateways/:id` (auth-policy reconfiguration) and `POST …/gateway-tokens/:tokenId/revoke` produced **no audit record**, and token minting emitted **no audit event** — gateway credential lifecycle was untraced.
- Human **approve/decline** of a tool action-request was invisible in `activity_log`; declines additionally emitted **no** tool-call event.
- Gateway **runtime-slot** stop/restart dropped the human operator (the raw supervisor transition is attributed to the agent/system only).
- `secret_access_events` for `tool_connection` resolution recorded the consumer as `system`, losing the **initiating** agent/run/issue.
- `POST /api/companies/:id/activity` and `POST …/tools/policy/test` **trusted body-supplied actor fields** (spoofable), and the policy simulator had **no permission gate**.
- Generic gateway-client token calls attribute to the token only — this needed an explicit, tested design decision.

- [x] I searched the open GitHub PR list for similar/duplicate PRs (e.g. the parallel audit-attribution PRs #9737–#9741 cover unrelated domains — pipelines/cases/access, runtime/wake, sensitive reads, instance stream, plugin bridge). None touch the tool-gateway / approval / secret surface changed here.

## What Changed

- **Gateway reconfigure / revoke** → emit `tool_gateway.gateway_reconfigured` and `tool_gateway.token_revoked`; the routes forward the authenticated board user.
- **Token mint** → emit `tool_gateway.token_minted`. The token row id is the audited *entity* so it survives `activity_log`'s `token*` detail-key redaction; the raw secret is never logged.
- **Approve/decline** → emit `tool_gateway.approval_resolved` (both outcomes) and mirror an `approval_resolved` tool-call event so declines are no longer silent.
- **Runtime-slot stop/restart** → emit `tool_runtime_slot.operator_stopped` / `operator_restarted` attributed to the operator, mirroring the tool-access route.
- **Secret access** → thread the gateway session's agent/run/issue into `tool_connection` credential resolution so `secret_access_events` records the initiator (no schema change — the columns already exist).
- **Spoofable writers** → `POST …/activity` and `POST …/tools/policy/test` now stamp the authenticated caller server-side and never trust the body; policy/test is gated on `tools:admin`. The simulator records the tester (caller) while keeping the simulated subject in `details`.
- **Generic gateway-client provenance** → documented + test-pinned as by design: audits attribute to the token; the token→human mapping is the mint-time `createdByUserId`, now mirrored into `token_minted`.
- Added `domain.verb` humanizers for the new actions in both `ui/src/lib/activity-format.ts` maps (company feed + issue timeline).

## Verification

- `pnpm --filter @paperclipai/server typecheck` — clean.
- Focused route/service tests (embedded-Postgres), all passing locally:
  - `server/src/__tests__/tool-gateway.test.ts` — reconfigure/mint/revoke audit, approval decline (activity_log + tool-call event), runtime-slot operator attribution, secret-access initiator, gateway-client provenance.
  - `server/src/__tests__/tool-access-service.test.ts` — policy simulator gate + caller stamping.
  - `server/src/__tests__/activity-routes.test.ts` — `/activity` ignores body actor, stamps caller.
  - 167 tests pass across the three files.
- `pnpm --filter @paperclipai/ui exec vitest run src/lib/activity-format.test.ts` — humanizers pass.

## Risks

- **Low risk.** No migrations — `secret_access_events` already carries `actor_type` / `actor_id` / `heartbeat_run_id` / `issue_id`.
- New `logActivity` calls are additive; the raw supervisor `tool_runtime_slot.stopped` event is preserved alongside the new `operator_*` event.
- `POST …/tools/policy/test` now requires `tools:admin` (previously any board principal). This is the intended hardening; UI callers already run as board admins.
- `POST …/activity` now routes through `logActivity` (resolving `responsibleUserId` + emitting live/plugin events) and returns the stamped fields; it is board-only with no production callers besides tests.

## Model Used

Claude Opus 4.8 (`claude-opus-4-8`, 1M context), extended thinking, with tool use / code execution in Claude Code.
