### PR TITLE
fix(heartbeat): don't flip agent to error when a max-turn run's deliverable already landed

### DIFF
--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -13834,6 +13834,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       });
 
       const finalizedRun = persistedRun ?? (await getRun(run.id));
+      let maxTurnAgentErrorSuppressed = false;
       if (finalizedRun) {
         await appendRunEvent(finalizedRun, seq++, {
           eventType: "lifecycle",
@@ -13885,12 +13886,16 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         if (outcome === "failed" && isMaxTurnExhaustionRun(livenessRun)) {
           const policy = parseMaxTurnContinuationPolicy(agent);
           if (policy.enabled && policy.maxAttempts > 0) {
-            await scheduleBoundedRetryForRun(livenessRun, agent, {
+            const retryResult = await scheduleBoundedRetryForRun(livenessRun, agent, {
               retryReason: MAX_TURN_CONTINUATION_RETRY_REASON,
               wakeReason: MAX_TURN_CONTINUATION_WAKE_REASON,
               maxAttempts: policy.maxAttempts,
               delayMs: policy.delayMs,
             });
+            // A bounded continuation is already in flight to pick this run back
+            // up, so a hard agent-level error would just require a manual
+            // clear-error for a condition the platform is already self-healing.
+            maxTurnAgentErrorSuppressed = retryResult.outcome === "scheduled";
           } else {
             await appendRunEvent(livenessRun, await nextRunEventSeq(livenessRun.id), {
               eventType: "lifecycle",
@@ -13905,6 +13910,19 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           }
         } else if (outcome === "failed" && readTransientRecoveryContractFromRun(livenessRun)) {
           await scheduleBoundedRetryForRun(livenessRun, agent);
+        }
+        if (outcome === "failed" && isMaxTurnExhaustionRun(livenessRun) && !maxTurnAgentErrorSuppressed && issueId) {
+          // The run's deliverable can land (issue marked done, comment posted)
+          // moments before the process itself exhausts its turn budget. That's
+          // a completed run, not an operator-facing agent error.
+          const [issueRow] = await db
+            .select({ status: issues.status })
+            .from(issues)
+            .where(eq(issues.id, issueId))
+            .limit(1);
+          if (issueRow && (issueRow.status === "done" || issueRow.status === "cancelled")) {
+            maxTurnAgentErrorSuppressed = true;
+          }
         }
         const issueCommentPolicyResult = await finalizeIssueCommentPolicy(livenessRun, agent);
         await releaseIssueExecutionAndPromote(livenessRun);
@@ -13983,7 +14001,8 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         {
           keepIdleOnFailure:
             outcome === "failed" &&
-            (finalizedRun ? readHeartbeatRunErrorFamily(finalizedRun) === "provider_quota" : runErrorCode === "provider_quota"),
+            (maxTurnAgentErrorSuppressed ||
+              (finalizedRun ? readHeartbeatRunErrorFamily(finalizedRun) === "provider_quota" : runErrorCode === "provider_quota")),
         },
       );
     } catch (err) {


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The heartbeat service (`server/src/services/heartbeat.ts`) runs each agent turn and, on failure, `finalizeAgentStatus` decides whether the agent lands in `idle` or a hard `error` state
> - When a run exhausts `maxTurnsPerRun`, the agent is flipped to `error` even when the platform just scheduled a bounded max-turn continuation, or when the run's issue already reached `done`/`cancelled` — i.e. the deliverable landed moments before the turn budget ran out
> - An errored agent blocks all new assignments until a manual board-level `POST /api/agents/{id}/clear-error`, so a self-healing (or already-successful) condition turns into an operator incident; in our 13-agent production deployment this recurs during upstream API slowdowns, most recently stranding an agent in `error` for 33 hours
> - `keepIdleOnFailure` (added on master) covers `provider_quota` failures but not this case
> - This pull request suppresses the error flip in exactly those two provably-benign cases, leaving genuine max-turn failures flipping to `error` unchanged
> - The benefit is fewer false operator incidents and no silently blocked assignment chains after runs that actually succeeded or that the platform is already recovering

## Linked Issues or Issue Description

Refs #9150 — same "phantom failure" family (runs/agents surfaced as failed after work actually landed), but #9150 covers run-status persistence on recovered 529 retries, while this PR covers agent-status finalization on max-turn exhaustion. No duplicate PR found (searched open/closed issues and PRs for `max_turns_exhausted`, `finalizeAgentStatus`, `agent error status`). Describing the underlying bug per the bug template:

- **What happened:** An agent whose run ended with `max_turns_exhausted` is set to `status=error` even though (a) the platform scheduled a bounded continuation for that same run, or (b) the run's issue was already `done`/`cancelled` (work completed before the cap hit). The `error` status blocks new assignments until a manual board-level `clear-error`.
- **Expected:** A run whose work landed, or that the platform is already self-healing via a scheduled continuation, should not leave the agent in a hard `error` state requiring manual intervention.
- **Reproduction:** Give an agent a task it completes and marks `done` just before exhausting `maxTurnsPerRun` (easiest with a low cap, e.g. 5). The run ends `failed / max_turns_exhausted`; the agent flips to `error` and rejects assignments despite the finished deliverable.
- **Environment:** Observed on published npm builds `2026.609.0` → `2026.707.0`, `claude_local` adapter, macOS, local deployment.

## What Changed

- `server/src/services/heartbeat.ts`: new `maxTurnAgentErrorSuppressed` flag, set when either
  - `scheduleBoundedRetryForRun` returns `outcome: "scheduled"` for a max-turn continuation (platform is already self-healing the run), or
  - the max-turn run's issue is already `done`/`cancelled` (deliverable landed; not an operator-facing agent failure).
- The existing `keepIdleOnFailure` option at the `finalizeAgentStatus` call site now also honors that flag.
- Genuine max-turn failures — no continuation scheduled and the issue not terminal — still flip the agent to `error` exactly as before.

## Verification

- Manual, case (b): set an agent's `maxTurnsPerRun` low (e.g. 5), assign a task it can finish and mark `done` within the cap's final turn. Before this patch the agent lands in `status=error` after the run; with it, the agent stays `idle` and accepts the next assignment. Confirm via `GET /api/companies/{companyId}/agents`.
- Manual, case (a): induce a max-turn exhaustion mid-task (task too large for the cap) so a bounded continuation is scheduled; the agent should stay `idle` while the continuation chain proceeds.
- Negative control: a max-turn exhaustion with no scheduled continuation and a non-terminal issue must still set `status=error` (unchanged behavior).
- Note: I could not run a clean local typecheck/test pass against current master (stale local workspace deps produce ~1,800 unrelated import errors); relying on CI here. Happy to adjust if CI flags anything or if you'd prefer the suppression folded into `readHeartbeatRunErrorFamily`.

## Risks

- Low. The change is scoped to one call path and only *suppresses* an agent-status flip in two narrowly-detected cases; no schema, API, or migration changes.
- Behavioral shift: operators who relied on `error` status to notice max-turn exhaustions will no longer see it for runs that completed their issue or got a continuation — the run record itself still shows `failed / max_turns_exhausted`, so run-level monitoring is unaffected.
- The issue-status check adds one `issues.status` select in the suppression path; reviewer feedback suggests merging it with the adjacent dependency-wake re-check query, which I'll fold in.

## Model Used

- Claude (Anthropic) via Claude Code CLI — `claude-fable-5` (extended thinking, tool use) authored this port against master; the original patch against v2026.513.0 was also authored with Claude Code and reviewed on our side before upstreaming.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [ ] I have run tests locally and they pass (blocked by stale local workspace deps — relying on CI; see Verification)
- [ ] I have added or updated tests where applicable (none added yet; can add a heartbeat finalization test if maintainers point me at the preferred harness)
- [x] I have updated relevant documentation to reflect my changes (no doc surface for this internal behavior)
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green (pending re-run after this description fix)
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups (one open suggestion — merging the duplicate `issues.status` query — will address)
- [x] I will address all Greptile and reviewer comments before requesting merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
