### PR TITLE
fix: refuse duplicate control planes on one Paperclip instance

### DIFF
--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import type { AdapterExecutionContext, AdapterExecutionResult } from "@paperclipai/adapter-utils";
@@ -322,7 +323,7 @@ async function buildClaudeRuntimeConfig(input: ClaudeExecutionInput): Promise<Cl
   const resolvedCommand = await resolveAdapterExecutionTargetCommandForLogs(command, executionTarget, cwd, runtimeEnv);
   const loggedEnv = buildInvocationEnvForLogs(env, {
     runtimeEnv,
-    includeRuntimeKeys: ["HOME", "CLAUDE_CONFIG_DIR"],
+    includeRuntimeKeys: ["HOME", "USER", "LOGNAME", "CLAUDE_CONFIG_DIR"],
     resolvedCommand,
   });
 
@@ -473,6 +474,17 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       (entry): entry is [string, string] => typeof entry[1] === "string",
     ),
   );
+  // Claude CLI keychain auth on macOS fails when USER is absent from the child
+  // environment (reproducible with `env -i HOME=...`). Ensure it survives even
+  // when an adapter/runtime sanitizes process.env.
+  if (!effectiveEnv.USER?.trim()) {
+    try {
+      effectiveEnv.USER = os.userInfo().username;
+    } catch {
+      const fallback = effectiveEnv.LOGNAME?.trim() || process.env.LOGNAME?.trim();
+      if (fallback) effectiveEnv.USER = fallback;
+    }
+  }
   const billingType = resolveClaudeBillingType(effectiveEnv);
   const claudeSkillEntries = await readPaperclipRuntimeSkillEntries(config, __moduleDir);
   const desiredSkillNames = new Set(resolveClaudeDesiredSkillNames(config, claudeSkillEntries));
@@ -681,7 +693,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       const runtimeEnv = ensurePathInEnv({ ...process.env, ...env });
       loggedEnv = buildInvocationEnvForLogs(env, {
         runtimeEnv,
-        includeRuntimeKeys: ["HOME", "CLAUDE_CONFIG_DIR"],
+        includeRuntimeKeys: ["HOME", "USER", "LOGNAME", "CLAUDE_CONFIG_DIR"],
         resolvedCommand,
       });
       if (remoteClaudeConfigDir) {
@@ -936,6 +948,16 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       stdout: proc.stdout,
       stderr: proc.stderr,
     });
+    if (loginMeta.requiresLogin) {
+      void onLog(
+        "stderr",
+        `[paperclip] Claude auth diagnostic (login_required): ` +
+          `USER=${effectiveEnv.USER ?? "<unset>"} ` +
+          `LOGNAME=${effectiveEnv.LOGNAME ?? "<unset>"} ` +
+          `HOME=${effectiveEnv.HOME ?? "<unset>"} ` +
+          `CLAUDE_CONFIG_DIR=${effectiveEnv.CLAUDE_CONFIG_DIR ?? "<unset>"}\n`,
+      );
+    }
     const errorMeta =
       loginMeta.loginUrl != null
         ? {

--- a/server/src/__tests__/instance-control-plane-lock.test.ts
+++ b/server/src/__tests__/instance-control-plane-lock.test.ts
@@ -1,0 +1,81 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  acquireControlPlaneLock,
+  resolveControlPlaneLockPath,
+} from "../instance-control-plane-lock.ts";
+
+describe("instance control-plane lock", () => {
+  const dirs: string[] = [];
+
+  afterEach(() => {
+    for (const dir of dirs.splice(0)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  function tempInstanceRoot(): string {
+    const dir = mkdtempSync(join(tmpdir(), "paperclip-cp-lock-"));
+    dirs.push(dir);
+    return dir;
+  }
+
+  it("acquires and releases an exclusive lock", () => {
+    const instanceRoot = tempInstanceRoot();
+    const lock = acquireControlPlaneLock({ instanceRoot, env: {} });
+    expect(lock).not.toBeNull();
+    const lockPath = resolveControlPlaneLockPath(instanceRoot);
+    expect(JSON.parse(readFileSync(lockPath, "utf8")).pid).toBe(process.pid);
+    lock!.release();
+    expect(() => readFileSync(lockPath, "utf8")).toThrow();
+  });
+
+  it("refuses a second live holder", () => {
+    const instanceRoot = tempInstanceRoot();
+    const first = acquireControlPlaneLock({ instanceRoot, env: {}, pid: process.pid });
+    expect(first).not.toBeNull();
+    expect(() =>
+      acquireControlPlaneLock({
+        instanceRoot,
+        env: {},
+        // Use a different fake "other" pid that is still alive: parent shell is alive.
+        pid: process.ppid > 1 ? process.ppid : 1,
+      }),
+    ).toThrow(/Another Paperclip control plane already holds this instance/);
+    first!.release();
+  });
+
+  it("replaces a stale lock from a dead pid", () => {
+    const instanceRoot = tempInstanceRoot();
+    const lockPath = resolveControlPlaneLockPath(instanceRoot);
+    mkdirSync(dirname(lockPath), { recursive: true });
+    writeFileSync(
+      lockPath,
+      `${JSON.stringify({
+        pid: 99999999,
+        startedAt: "2020-01-01T00:00:00.000Z",
+        instanceId: "default",
+        instanceRoot,
+        argv0: "stale",
+        allowSharedEnv: "0",
+      })}\n`,
+      "utf8",
+    );
+
+    const lock = acquireControlPlaneLock({ instanceRoot, env: {} });
+    expect(lock).not.toBeNull();
+    expect(JSON.parse(readFileSync(lockPath, "utf8")).pid).toBe(process.pid);
+    lock!.release();
+  });
+
+  it("skips locking when PAPERCLIP_ALLOW_SHARED_INSTANCE is set", () => {
+    const instanceRoot = tempInstanceRoot();
+    const lock = acquireControlPlaneLock({
+      instanceRoot,
+      env: { PAPERCLIP_ALLOW_SHARED_INSTANCE: "1" },
+    });
+    expect(lock).toBeNull();
+  });
+});

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -65,6 +65,8 @@ import { maybePersistWorktreeRuntimePorts } from "./worktree-config.js";
 import { initTelemetry, getTelemetryClient } from "./telemetry.js";
 import { conflict } from "./errors.js";
 import { coordinateHeartbeatSchedulerShutdown } from "./shutdown.js";
+import { acquireControlPlaneLock } from "./instance-control-plane-lock.js";
+import { resolvePaperclipInstanceRoot } from "./home-paths.js";
 import type {
   InstanceDatabaseBackupRunResult,
   InstanceDatabaseBackupTrigger,
@@ -121,6 +123,27 @@ export async function startServer(): Promise<StartedServer> {
   }
   if (process.env.PAPERCLIP_SECRETS_MASTER_KEY_FILE === undefined) {
     process.env.PAPERCLIP_SECRETS_MASTER_KEY_FILE = config.secretsMasterKeyFilePath;
+  }
+
+  // Refuse a second control plane against the same instance directory. Reusing
+  // an already-running embedded Postgres without this guard starts duplicate
+  // schedulers/sweepers and can strand agent runs.
+  const controlPlaneLock = acquireControlPlaneLock({
+    instanceRoot: resolvePaperclipInstanceRoot(),
+  });
+  if (controlPlaneLock) {
+    logger.info(
+      {
+        lockPath: controlPlaneLock.lockPath,
+        pid: controlPlaneLock.payload.pid,
+        instanceRoot: controlPlaneLock.payload.instanceRoot,
+      },
+      "Acquired Paperclip control-plane instance lock",
+    );
+  } else if (/^(1|true|yes)$/i.test(process.env.PAPERCLIP_ALLOW_SHARED_INSTANCE?.trim() ?? "")) {
+    logger.warn(
+      "PAPERCLIP_ALLOW_SHARED_INSTANCE is set — skipping control-plane lock (duplicate schedulers possible)",
+    );
   }
   
   type MigrationSummary =
@@ -408,6 +431,14 @@ export async function startServer(): Promise<StartedServer> {
   
     const runningPid = getRunningPid();
     if (runningPid) {
+      // Reusing postgres is fine only when THIS process holds the control-plane
+      // lock (or shared mode is explicitly allowed). Without that, a second
+      // server would attach schedulers to another instance's database.
+      if (!controlPlaneLock && !/^(1|true|yes)$/i.test(process.env.PAPERCLIP_ALLOW_SHARED_INSTANCE?.trim() ?? "")) {
+        throw new Error(
+          `Embedded PostgreSQL is already running (pid=${runningPid}, port=${port}) but this process could not claim the instance control-plane lock. Another Paperclip server is likely already serving this instance. Stop the other process or set PAPERCLIP_ALLOW_SHARED_INSTANCE=1.`,
+        );
+      }
       logger.warn(`Embedded PostgreSQL already running; reusing existing process (pid=${runningPid}, port=${port})`);
     } else {
       const configuredAdminConnectionString = `postgres://paperclip:paperclip@127.0.0.1:${configuredPort}/postgres`;
@@ -1248,6 +1279,12 @@ export async function startServer(): Promise<StartedServer> {
         } catch (err) {
           logger.error({ err }, "Failed to stop embedded PostgreSQL cleanly");
         }
+      }
+
+      try {
+        controlPlaneLock?.release();
+      } catch (err) {
+        logger.error({ err }, "Failed to release control-plane lock cleanly");
       }
 
       // Flush buffered OTel spans before the process goes away; without this

--- a/server/src/instance-control-plane-lock.ts
+++ b/server/src/instance-control-plane-lock.ts
@@ -1,0 +1,197 @@
+import {
+  existsSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  rmSync,
+  writeSync,
+  closeSync,
+} from "node:fs";
+import { dirname, resolve } from "node:path";
+import { resolvePaperclipInstanceId, resolvePaperclipInstanceRoot } from "./home-paths.js";
+
+export const CONTROL_PLANE_LOCK_BASENAME = "control-plane.lock.json";
+
+export type ControlPlaneLockPayload = {
+  pid: number;
+  startedAt: string;
+  instanceId: string;
+  instanceRoot: string;
+  argv0: string;
+  allowSharedEnv: string;
+};
+
+export type AcquiredControlPlaneLock = {
+  lockPath: string;
+  payload: ControlPlaneLockPayload;
+  release: () => void;
+};
+
+function isPidRunning(pid: number): boolean {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    // EPERM = process exists but we lack permission to signal it (still running).
+    // ESRCH = process does not exist (stale lock).
+    return (err as NodeJS.ErrnoException).code === "EPERM";
+  }
+}
+
+function parseLockPayload(raw: string): ControlPlaneLockPayload | null {
+  try {
+    const parsed = JSON.parse(raw) as Partial<ControlPlaneLockPayload>;
+    if (typeof parsed.pid !== "number" || !Number.isInteger(parsed.pid)) return null;
+    if (typeof parsed.instanceRoot !== "string" || parsed.instanceRoot.trim().length === 0) return null;
+    return {
+      pid: parsed.pid,
+      startedAt: typeof parsed.startedAt === "string" ? parsed.startedAt : "",
+      instanceId: typeof parsed.instanceId === "string" ? parsed.instanceId : "",
+      instanceRoot: parsed.instanceRoot,
+      argv0: typeof parsed.argv0 === "string" ? parsed.argv0 : "",
+      allowSharedEnv: typeof parsed.allowSharedEnv === "string" ? parsed.allowSharedEnv : "",
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function resolveControlPlaneLockPath(instanceRoot = resolvePaperclipInstanceRoot()): string {
+  return resolve(instanceRoot, "runtime", CONTROL_PLANE_LOCK_BASENAME);
+}
+
+export function readControlPlaneLock(lockPath: string): ControlPlaneLockPayload | null {
+  if (!existsSync(lockPath)) return null;
+  try {
+    return parseLockPayload(readFileSync(lockPath, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+function formatHeldLockError(lockPath: string, holder: ControlPlaneLockPayload): Error {
+  return new Error(
+    [
+      `Another Paperclip control plane already holds this instance (pid=${holder.pid}, startedAt=${holder.startedAt || "unknown"}).`,
+      `Lock: ${lockPath}`,
+      `Instance: ${holder.instanceRoot}`,
+      "Two control planes against one instance share schedulers/sweepers and can strand agent runs.",
+      "Stop the other process, or set PAPERCLIP_ALLOW_SHARED_INSTANCE=1 only if you intentionally want shared mode.",
+    ].join(" "),
+  );
+}
+
+/**
+ * Exclusive control-plane lock for a Paperclip instance directory.
+ *
+ * Prevents a second `paperclipai run` / `pnpm dev` from attaching to the same
+ * instance DB and running duplicate schedulers/sweepers.
+ *
+ * Bypass: PAPERCLIP_ALLOW_SHARED_INSTANCE=1|true|yes
+ */
+export function acquireControlPlaneLock(opts: {
+  instanceRoot?: string;
+  env?: NodeJS.ProcessEnv;
+  pid?: number;
+  now?: () => Date;
+}): AcquiredControlPlaneLock | null {
+  const env = opts.env ?? process.env;
+  const allowShared = /^(1|true|yes)$/i.test(env.PAPERCLIP_ALLOW_SHARED_INSTANCE?.trim() ?? "");
+  if (allowShared) {
+    return null;
+  }
+
+  const instanceRoot = resolve(opts.instanceRoot ?? resolvePaperclipInstanceRoot());
+  const lockPath = resolveControlPlaneLockPath(instanceRoot);
+  const pid = opts.pid ?? process.pid;
+  const now = opts.now ?? (() => new Date());
+  const payload: ControlPlaneLockPayload = {
+    pid,
+    startedAt: now().toISOString(),
+    instanceId: resolvePaperclipInstanceId(),
+    instanceRoot,
+    argv0: process.argv.slice(0, 2).join(" "),
+    allowSharedEnv: "0",
+  };
+
+  mkdirSync(dirname(lockPath), { recursive: true });
+
+  for (let attempt = 0; attempt < 5; attempt += 1) {
+    try {
+      const fd = openSync(lockPath, "wx");
+      try {
+        writeSync(fd, `${JSON.stringify(payload, null, 2)}\n`, 0, "utf8");
+      } finally {
+        closeSync(fd);
+      }
+
+      let released = false;
+      const release = () => {
+        if (released) return;
+        released = true;
+        try {
+          const current = readControlPlaneLock(lockPath);
+          if (current?.pid === pid) {
+            rmSync(lockPath, { force: true });
+          }
+        } catch {
+          // best-effort cleanup
+        }
+      };
+
+      return { lockPath, payload, release };
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException | undefined)?.code;
+      if (code !== "EEXIST") throw err;
+
+      const holder = readControlPlaneLock(lockPath);
+      if (holder && holder.pid === pid) {
+        // Same process already owns the lock (tests / nested start).
+        return {
+          lockPath,
+          payload: holder,
+          release: () => {
+            try {
+              const current = readControlPlaneLock(lockPath);
+              if (current?.pid === pid) rmSync(lockPath, { force: true });
+            } catch {
+              // ignore
+            }
+          },
+        };
+      }
+
+      if (holder && isPidRunning(holder.pid)) {
+        throw formatHeldLockError(lockPath, holder);
+      }
+
+      // Stale or unreadable lock. Re-read immediately before unlink to shrink the
+      // TOCTOU window where another process could replace the file after our PID check.
+      const confirmed = readControlPlaneLock(lockPath);
+      if (confirmed && isPidRunning(confirmed.pid)) {
+        throw formatHeldLockError(lockPath, confirmed);
+      }
+      if (
+        confirmed &&
+        holder &&
+        confirmed.pid === holder.pid &&
+        !isPidRunning(confirmed.pid)
+      ) {
+        try {
+          rmSync(lockPath, { force: true });
+        } catch {
+          // Contended remove — loop and retry exclusive create.
+        }
+      } else if (!confirmed) {
+        try {
+          rmSync(lockPath, { force: true });
+        } catch {
+          // Contended remove — loop and retry exclusive create.
+        }
+      }
+    }
+  }
+
+  throw new Error(`Failed to acquire Paperclip control-plane lock at ${lockPath}`);
+}


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The server boots a control plane (API, heartbeat schedulers, stale-lock sweepers) against an instance directory and its embedded Postgres
> - Two processes can currently attach to the same instance root (e.g. `npx paperclipai run` on one port and `pnpm dev` via launchd on another) and run duplicate schedulers/sweepers against one DB
> - That race strands agent runs and confuses recovery because both processes believe they own the instance
> - This pull request adds an exclusive file lock under `~/.paperclip/instances/<id>/runtime/control-plane.lock.json` and refuses silent embedded-Postgres reuse without it
> - It also ensures the Claude local adapter child env always has `USER` so macOS keychain auth does not fail
> - The benefit is a loud single-owner guarantee for each instance, with an explicit `PAPERCLIP_ALLOW_SHARED_INSTANCE` escape hatch

## Linked Issues or Issue Description

No public GitHub issue exists for this bug. Inline description:

### Bug Report
**Describe the bug**
Starting a second Paperclip server against the same instance directory (same embedded Postgres) silently shares schedulers and stale-lock sweepers. Both processes act as control planes for one DB, which can strand agent runs and produce conflicting recovery behavior.

**To Reproduce**
1. Start `npx paperclipai run` (or equivalent) against `~/.paperclip/instances/default` on port A.
2. Start a second server (`pnpm dev` / another `paperclipai run`) against the same instance root on port B.
3. Observe both processes schedule heartbeats/routines and sweep locks against the shared DB.

**Expected behavior**
The second start should fail loudly unless `PAPERCLIP_ALLOW_SHARED_INSTANCE=1` is set.

**Environment**
- macOS host running Paperclip via `npx` and/or launchd `pnpm dev`
- Embedded Postgres owned by the first process

## What Changed

- Add `server/src/instance-control-plane-lock.ts` with exclusive `openSync("wx")` lock, stale-PID replacement, and `PAPERCLIP_ALLOW_SHARED_INSTANCE` bypass
- Acquire/release the lock from `server/src/index.ts`; block embedded-Postgres reuse when the lock is not held
- Claude local adapter: ensure `USER` is present in the child env and log `USER`/`HOME`/`CLAUDE_CONFIG_DIR` on `login_required`
- Treat `EPERM` from `process.kill(pid, 0)` as "still running" so foreign-user locks are not overwritten
- Re-confirm lock contents before unlinking a stale lock to shrink TOCTOU races
- Unit tests for acquire/release, live refusal, stale replacement, and shared-mode bypass

## Verification

- [x] `pnpm --filter @paperclipai/server exec vitest run src/__tests__/instance-control-plane-lock.test.ts`
- [ ] Start one server against an instance; confirm second start fails with a clear lock error
- [ ] With `PAPERCLIP_ALLOW_SHARED_INSTANCE=1`, confirm second start is allowed (warns)
- [ ] Kill a locked process uncleanly; confirm next start replaces the stale lock

## Risks

- Medium: hosts that intentionally run two servers against one instance must set `PAPERCLIP_ALLOW_SHARED_INSTANCE=1` or the second start will fail (intentional breaking change for unsafe dual-start)
- Low: stale-lock cleanup still has a narrow race under extreme concurrent starts; mitigated by re-read-before-unlink and exclusive `wx` create
- Low: Claude adapter env change only fills missing `USER` / expands diagnostics

## Model Used

Cursor agent router (Composer) with tool use; assisted edits and PR body refresh for landing this guard.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge