### PR TITLE
fix(tool-access,tool-gateway): perform MCP initialize handshake for remote HTTP servers, and retry through session churn

### DIFF
--- a/server/src/__tests__/mcp-http.test.ts
+++ b/server/src/__tests__/mcp-http.test.ts
@@ -1,5 +1,11 @@
-import { describe, expect, it } from "vitest";
-import { MCP_HTTP_ACCEPT, mcpHttpRequestHeaders, parseMcpHttpResponseBody } from "../services/mcp-http.js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  initializeMcpSession,
+  MCP_HTTP_ACCEPT,
+  MCP_PROTOCOL_VERSION,
+  mcpHttpRequestHeaders,
+  parseMcpHttpResponseBody,
+} from "../services/mcp-http.js";
 
 describe("mcpHttpRequestHeaders", () => {
   it("advertises both JSON and SSE on every request", () => {
@@ -15,6 +21,60 @@ describe("mcpHttpRequestHeaders", () => {
       accept: "application/json, text/event-stream",
       Authorization: "Bearer x",
     });
+  });
+});
+
+describe("initializeMcpSession", () => {
+  const realFetch = globalThis.fetch;
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+    vi.restoreAllMocks();
+  });
+
+  it("runs the initialize handshake first and returns the assigned session id", async () => {
+    const calls: Array<{ body: Record<string, unknown>; headers: Record<string, string> }> = [];
+    globalThis.fetch = vi.fn(async (_url: unknown, init: RequestInit) => {
+      const body = JSON.parse(String(init.body)) as Record<string, unknown>;
+      calls.push({ body, headers: init.headers as Record<string, string> });
+      if (body.method === "initialize") {
+        return new Response(
+          `event: message\ndata: ${JSON.stringify({ jsonrpc: "2.0", id: body.id, result: {} })}\n\n`,
+          { status: 200, headers: { "content-type": "text/event-stream", "mcp-session-id": "sess-123" } },
+        );
+      }
+      return new Response(null, { status: 202 });
+    }) as typeof fetch;
+
+    const sessionId = await initializeMcpSession("https://mcp.example/mcp", { Authorization: "Bearer x" });
+
+    expect(sessionId).toBe("sess-123");
+    // First call is `initialize` with the required Accept header and protocol version.
+    expect(calls[0].body.method).toBe("initialize");
+    expect((calls[0].body.params as Record<string, unknown>).protocolVersion).toBe(MCP_PROTOCOL_VERSION);
+    expect(calls[0].headers.accept).toBe("application/json, text/event-stream");
+    expect(calls[0].headers.Authorization).toBe("Bearer x");
+    // Then `notifications/initialized`, echoing the session id back.
+    expect(calls[1].body.method).toBe("notifications/initialized");
+    expect(calls[1].headers["mcp-session-id"]).toBe("sess-123");
+  });
+
+  it("returns null for a stateless server that omits the session id", async () => {
+    globalThis.fetch = vi.fn(
+      async () => new Response("{}", { status: 200, headers: { "content-type": "application/json" } }),
+    ) as typeof fetch;
+    expect(await initializeMcpSession("https://mcp.example/mcp")).toBeNull();
+  });
+
+  it("returns null when the handshake is rejected, deferring to the follow-up request", async () => {
+    globalThis.fetch = vi.fn(async () => new Response("unauthorized", { status: 401 })) as typeof fetch;
+    expect(await initializeMcpSession("https://mcp.example/mcp")).toBeNull();
+  });
+
+  it("returns null on a network failure", async () => {
+    globalThis.fetch = vi.fn(async () => {
+      throw new TypeError("fetch failed");
+    }) as typeof fetch;
+    expect(await initializeMcpSession("https://mcp.example/mcp")).toBeNull();
   });
 });
 

--- a/server/src/__tests__/mcp-http.test.ts
+++ b/server/src/__tests__/mcp-http.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  closeMcpSession,
   initializeMcpSession,
   MCP_HTTP_ACCEPT,
   MCP_PROTOCOL_VERSION,
@@ -75,6 +76,35 @@ describe("initializeMcpSession", () => {
       throw new TypeError("fetch failed");
     }) as typeof fetch;
     expect(await initializeMcpSession("https://mcp.example/mcp")).toBeNull();
+  });
+});
+
+describe("closeMcpSession", () => {
+  const realFetch = globalThis.fetch;
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+    vi.restoreAllMocks();
+  });
+
+  it("sends DELETE with the session id to tear the session down", async () => {
+    let request: { method?: string; headers: Record<string, string> } | undefined;
+    globalThis.fetch = vi.fn(async (_url: unknown, init: RequestInit) => {
+      request = { method: init.method, headers: init.headers as Record<string, string> };
+      return new Response(null, { status: 204 });
+    }) as typeof fetch;
+
+    await closeMcpSession("https://mcp.example/mcp", { Authorization: "Bearer x" }, "sess-123");
+
+    expect(request?.method).toBe("DELETE");
+    expect(request?.headers["mcp-session-id"]).toBe("sess-123");
+    expect(request?.headers.Authorization).toBe("Bearer x");
+  });
+
+  it("swallows errors (teardown is best-effort)", async () => {
+    globalThis.fetch = vi.fn(async () => {
+      throw new TypeError("fetch failed");
+    }) as typeof fetch;
+    await expect(closeMcpSession("https://mcp.example/mcp", undefined, "sess-123")).resolves.toBeUndefined();
   });
 });
 

--- a/server/src/__tests__/tool-access-service.test.ts
+++ b/server/src/__tests__/tool-access-service.test.ts
@@ -775,6 +775,11 @@ describeEmbeddedPostgres("tool access service", () => {
       .update(toolCatalogEntries)
       .set({ status: "active", reviewedAt: new Date(), quarantineReason: null, quarantinedAt: null })
       .where(eq(toolCatalogEntries.toolName, "send_email"));
+    // remoteTools performs an `initialize` handshake before `tools/list`, so the
+    // updated payload must sit behind a handshake response in the mock queue.
+    fetchMock.mockResolvedValueOnce(
+      mcpHttpResponse({ jsonrpc: "2.0", id: "paperclip-mcp-initialize", result: {} }),
+    );
     fetchMock.mockResolvedValueOnce(mcpHttpResponse({
       jsonrpc: "2.0",
       id: "paperclip-catalog-refresh",
@@ -2780,7 +2785,8 @@ describeEmbeddedPostgres("tool access service", () => {
       .query({ state, code: "oauth-code" });
 
     expect(callbackRes.status).toBe(200);
-    expect(fetchMock).toHaveBeenCalledTimes(3);
+    // 1 token exchange + 2 catalog reads, each an `initialize` handshake + `tools/list`.
+    expect(fetchMock).toHaveBeenCalledTimes(5);
     expect(callbackRes.body.connection).toMatchObject({
       id: connectRes.body.connectionId,
       status: "active",
@@ -2812,7 +2818,8 @@ describeEmbeddedPostgres("tool access service", () => {
     expect(redirectCallbackRes.headers.location).toBe(
       `/${company.issuePrefix}/apps/${redirectConnectRes.body.connectionId}/setup?oauth=connected`,
     );
-    expect(fetchMock).toHaveBeenCalledTimes(6);
+    // Second identical callback adds another 5 (1 token + 2×(initialize + tools/list)).
+    expect(fetchMock).toHaveBeenCalledTimes(10);
     await expect(db.select().from(toolOauthStates)).resolves.toHaveLength(0);
     await expect(db.select().from(companySecretBindings)).resolves.toHaveLength(6);
     const [connection] = await db.select().from(toolConnections).where(eq(toolConnections.id, connectRes.body.connectionId));
@@ -3125,7 +3132,8 @@ describeEmbeddedPostgres("tool access service", () => {
 
     const health = await service.checkHealth(connection.id, { actorType: "system", actorId: "health-check" });
     expect(health.connection.healthStatus).toBe("ok");
-    expect(fetchMock).toHaveBeenCalledTimes(2);
+    // 1 token exchange + the catalog read's `initialize` handshake + `tools/list`.
+    expect(fetchMock).toHaveBeenCalledTimes(3);
     const [updated] = await db.select().from(toolConnections).where(eq(toolConnections.id, connection.id));
     expect(updated.credentialSecretRefs).toEqual([
       expect.objectContaining({ configPath: "oauth.access_token", label: "OAuth access token" }),
@@ -4243,7 +4251,8 @@ describeEmbeddedPostgres("tool access service", () => {
       credentialValues: { "credentials.authorization": "zap-secret" },
     }, { actorType: "user", actorId: "board" });
 
-    expect(fetchMock).toHaveBeenCalledTimes(2);
+    // 2 catalog reads, each an `initialize` handshake + `tools/list`.
+    expect(fetchMock).toHaveBeenCalledTimes(4);
     expect(fetchMock).toHaveBeenCalledWith(
       "https://mcp.zapier.com/api/mcp",
       expect.objectContaining({
@@ -4333,6 +4342,11 @@ describeEmbeddedPostgres("tool access service", () => {
       ]),
     );
 
+    // remoteTools performs an `initialize` handshake before `tools/list`, so the
+    // updated payload must sit behind a handshake response in the mock queue.
+    fetchMock.mockResolvedValueOnce(
+      mcpHttpResponse({ jsonrpc: "2.0", id: "paperclip-mcp-initialize", result: {} }),
+    );
     fetchMock.mockResolvedValueOnce(mcpHttpResponse({
       jsonrpc: "2.0",
       id: "paperclip-catalog-refresh",

--- a/server/src/__tests__/tool-access-service.test.ts
+++ b/server/src/__tests__/tool-access-service.test.ts
@@ -1211,7 +1211,9 @@ describeEmbeddedPostgres("tool access service", () => {
       decision: "allowed",
       result: { data: expect.objectContaining({ isError: false, transport: "mcp_http" }) },
     });
-    expect(fetchMock).toHaveBeenCalledOnce();
+    // executeRemoteHttpTool performs an `initialize` handshake before `tools/call`
+    // (mirrors the same handshake remoteTools() already does for tools/list).
+    expect(fetchMock).toHaveBeenCalledTimes(2);
     const [invocation] = await db.select().from(toolInvocations).where(eq(toolInvocations.companyId, company.id));
     expect(invocation).toMatchObject({
       actorType: "user",

--- a/server/src/__tests__/tool-gateway.test.ts
+++ b/server/src/__tests__/tool-gateway.test.ts
@@ -2627,7 +2627,23 @@ rl.on("line", (line) => {
       name: "HTTP status",
       reasonCode: "remote_http_status",
       status: 502,
+      expectedHttpStatus: 503,
       response: () => ({ status: 503, body: { error: "unavailable" } }),
+    },
+    {
+      // Mirrors 1MCP's real Streamable HTTP session-churn signal observed live
+      // against ai-1mcp: `statusCode=404 reason="Session not found. Send an
+      // initialize request first to create a new session."`. executeRemoteHttpTool
+      // retries this specific status (safe: a 404 means the server never routed
+      // the call to the tool, so no side effect could have fired), but a server
+      // that 404s every request — including `initialize` itself — still exhausts
+      // retries and surfaces the same controlled error, just after 3 attempts
+      // instead of 1.
+      name: "persistent session-not-found (404) across every retry",
+      reasonCode: "remote_http_status",
+      status: 502,
+      expectedHttpStatus: 404,
+      response: () => ({ status: 404, body: { error: "session not found" } }),
     },
     {
       name: "invalid JSON",
@@ -2714,7 +2730,7 @@ rl.on("line", (line) => {
         });
         if (scenario.reasonCode === "remote_http_status") {
           expect(failureAudit.details).toMatchObject({
-            execution: { response: { httpStatus: 503 } },
+            execution: { response: { httpStatus: scenario.expectedHttpStatus } },
           });
         }
       } finally {
@@ -2722,6 +2738,62 @@ rl.on("line", (line) => {
       }
     });
   }
+
+  it("retries a remote MCP tool call after a transient 1MCP session-not-found (404), recovering with a fresh initialize handshake", async () => {
+    const company = await createCompany(db);
+    const agent = await createAgent(db, company.id);
+    const { run } = await createIssueAndRun(db, company.id, agent.id);
+    let toolCallAttempts = 0;
+    const fake = await startFakeRemoteMcpServer((fakeRequest) => {
+      if (fakeRequest.body?.method !== "tools/call") {
+        return { body: { jsonrpc: "2.0", id: fakeRequest.body?.id ?? null, result: {} } };
+      }
+      toolCallAttempts += 1;
+      if (toolCallAttempts === 1) {
+        // The exact signal observed live against ai-1mcp for a churned session.
+        return {
+          status: 404,
+          body: { jsonrpc: "2.0", id: fakeRequest.body.id, error: { code: -32001, message: "Session not found" } },
+        };
+      }
+      const params = fakeRequest.body.params as Record<string, unknown>;
+      const args = params.arguments as Record<string, unknown>;
+      return {
+        body: {
+          jsonrpc: "2.0",
+          id: fakeRequest.body.id,
+          result: { content: [{ type: "text", text: `stored ${String(args.key)}=${String(args.value)}` }] },
+        },
+      };
+    });
+    try {
+      await createRemoteMcpTool(db, company.id, { applicationKey: "kv-session-churn", toolName: "kv_set", url: fake.url });
+      await allowAllToolsForAgent(db, company.id, agent.id);
+      const gateway = createTestToolGatewayService(db);
+      const session = await gateway.createSession({ companyId: company.id, agentId: agent.id, runId: run.id });
+      const connectedTool = (await gateway.listToolsForSession(session.token))
+        .find((tool) => tool.providerType === "mcp_remote_http");
+      expect(connectedTool).toBeTruthy();
+
+      const result = await gateway.executeTool({
+        sessionToken: session.token,
+        tool: connectedTool!.name,
+        parameters: { key: "alpha", value: "one" },
+      });
+      expect(result).toMatchObject({
+        status: "completed",
+        result: { content: "stored alpha=one" },
+      });
+      // Failed attempt's initialize + failed tools/call, then a fresh initialize +
+      // succeeding tools/call.
+      expect(toolCallAttempts).toBe(2);
+
+      const [invocation] = await db.select().from(toolInvocations);
+      expect(invocation).toMatchObject({ status: "succeeded", toolName: connectedTool!.name });
+    } finally {
+      await fake.close();
+    }
+  });
 
   it("times out a remote MCP call whose `initialize` handshake hangs, instead of dispatching tools/call", async () => {
     const company = await createCompany(db);

--- a/server/src/__tests__/tool-gateway.test.ts
+++ b/server/src/__tests__/tool-gateway.test.ts
@@ -2723,6 +2723,55 @@ rl.on("line", (line) => {
     });
   }
 
+  it("times out a remote MCP call whose `initialize` handshake hangs, instead of dispatching tools/call", async () => {
+    const company = await createCompany(db);
+    const agent = await createAgent(db, company.id);
+    const { run } = await createIssueAndRun(db, company.id, agent.id);
+    // Only the `initialize` handshake hangs; a server that actually reached
+    // `tools/call` would respond immediately, so a passing `tools/call` request
+    // in `fake.requests` would mean the timeout budget wasn't applied to the
+    // handshake (PAP-9750).
+    const fake = await startFakeRemoteMcpServer((fakeRequest) => {
+      if (fakeRequest.body?.method === "initialize") {
+        return { delayMs: 5_000, body: { jsonrpc: "2.0", id: fakeRequest.body?.id ?? null, result: {} } };
+      }
+      return { body: { jsonrpc: "2.0", id: fakeRequest.body?.id, result: { content: [{ type: "text", text: "ok" }] } } };
+    });
+    try {
+      await createRemoteMcpTool(db, company.id, {
+        applicationKey: "hanging-handshake",
+        toolName: "kv_set",
+        url: fake.url,
+      });
+      await allowAllToolsForAgent(db, company.id, agent.id);
+      const gateway = createTestToolGatewayService(db);
+      const session = await gateway.createSession({ companyId: company.id, agentId: agent.id, runId: run.id });
+      const connectedTool = (await gateway.listToolsForSession(session.token))
+        .find((tool) => tool.providerType === "mcp_remote_http");
+      expect(connectedTool).toBeTruthy();
+
+      await gateway.executeTool({
+        sessionToken: session.token,
+        tool: connectedTool!.name,
+        parameters: { key: "alpha", value: "one" },
+        timeoutMs: 50,
+      }).then(
+        () => {
+          throw new Error("Expected remote MCP call to time out during the initialize handshake");
+        },
+        (error) => expectGatewayError(error, 504, "tool_timeout"),
+      );
+
+      expect(fake.requests).toHaveLength(1);
+      expect(fake.requests[0]!.body).toMatchObject({ method: "initialize" });
+
+      const [invocation] = await db.select().from(toolInvocations);
+      expect(invocation).toMatchObject({ status: "timed_out", errorCode: "tool_timeout" });
+    } finally {
+      await fake.close();
+    }
+  });
+
   it("persists hashed sessions and accepts them across gateway service instances", async () => {
     const company = await createCompany(db);
     const agent = await createAgent(db, company.id);

--- a/server/src/__tests__/tool-gateway.test.ts
+++ b/server/src/__tests__/tool-gateway.test.ts
@@ -1447,6 +1447,12 @@ rl.on("line", (line) => {
     });
     const fake = await startFakeRemoteMcpServer((fakeRequest) => {
       expect(fakeRequest.headers.authorization).toBe(`Bearer ${credentialValue}`);
+      // executeRemoteHttpTool performs an `initialize` handshake before `tools/call`
+      // (mirrors the same handshake remoteTools() already does for tools/list); this
+      // fake server must answer it generically before the kv_set-specific assertions.
+      if (fakeRequest.body?.method !== "tools/call") {
+        return { body: { jsonrpc: "2.0", id: fakeRequest.body?.id ?? null, result: {} } };
+      }
       const params = fakeRequest.body?.params as Record<string, unknown>;
       const args = params.arguments as Record<string, unknown>;
       return {
@@ -1508,10 +1514,13 @@ rl.on("line", (line) => {
           },
         },
       });
-      expect(fake.requests).toHaveLength(1);
+      // 1 `initialize` handshake (this fake server is stateless, so no session
+      // teardown follows) + 1 `tools/call`.
+      expect(fake.requests).toHaveLength(2);
+      expect(fake.requests[0]!.body).toMatchObject({ method: "initialize" });
       // Streamable HTTP requires advertising both JSON and SSE on the call (PAP-11096).
-      expect(fake.requests[0]!.headers.accept).toBe("application/json, text/event-stream");
-      expect(fake.requests[0]!.body).toMatchObject({
+      expect(fake.requests[1]!.headers.accept).toBe("application/json, text/event-stream");
+      expect(fake.requests[1]!.body).toMatchObject({
         method: "tools/call",
         params: {
           name: "kv_set",

--- a/server/src/services/mcp-http.ts
+++ b/server/src/services/mcp-http.ts
@@ -97,6 +97,31 @@ export async function initializeMcpSession(
   return sessionId;
 }
 
+/**
+ * Best-effort teardown of a session opened by {@link initializeMcpSession}.
+ *
+ * The MCP spec says a client SHOULD `DELETE` the session once it is no longer
+ * needed; without this, stateful servers accumulate a dead session for every
+ * catalog refresh / connection check. Failures — including servers that don't
+ * support explicit termination and answer `405` — are ignored, since the
+ * session will expire server-side regardless.
+ */
+export async function closeMcpSession(
+  endpoint: string | URL,
+  headers: Record<string, string> | undefined,
+  sessionId: string,
+): Promise<void> {
+  try {
+    const response = await fetch(endpoint, {
+      method: "DELETE",
+      headers: { ...mcpHttpRequestHeaders(headers), [MCP_SESSION_ID_HEADER]: sessionId },
+    });
+    await response.body?.cancel().catch(() => undefined);
+  } catch {
+    // Teardown is best-effort.
+  }
+}
+
 function looksLikeJsonRpcMessage(value: unknown): boolean {
   if (typeof value !== "object" || value === null) return false;
   const record = value as Record<string, unknown>;

--- a/server/src/services/mcp-http.ts
+++ b/server/src/services/mcp-http.ts
@@ -27,6 +27,76 @@ export function mcpHttpRequestHeaders(extra?: Record<string, string>): Record<st
   };
 }
 
+/**
+ * MCP protocol revision advertised in the `initialize` handshake. Servers
+ * negotiate down to a version they support, so advertising a version we speak
+ * is safe.
+ */
+export const MCP_PROTOCOL_VERSION = "2025-06-18";
+
+/** HTTP response header a stateful server uses to hand back its session id. */
+const MCP_SESSION_ID_HEADER = "mcp-session-id";
+
+/**
+ * Open a session with a remote MCP server over the Streamable HTTP transport by
+ * performing the `initialize` handshake, returning the session id the server
+ * assigned (or `null` if it did not assign one).
+ *
+ * The MCP spec requires `initialize` to be the client's very first message.
+ * Stateful servers (the `@modelcontextprotocol/sdk` default) answer it with an
+ * `Mcp-Session-Id` response header and then reject every subsequent request that
+ * omits it with `400 Bad Request: Server not initialized`; stateless servers
+ * simply don't set the header. Callers must therefore run this before any other
+ * request and echo the returned id — when present — on those requests.
+ *
+ * This is best-effort: it returns `null` both for stateless servers and for any
+ * failed handshake (including OAuth-guarded 401s and network errors), leaving
+ * the caller's follow-up request as the single authoritative error path.
+ */
+export async function initializeMcpSession(
+  endpoint: string | URL,
+  headers?: Record<string, string>,
+): Promise<string | null> {
+  let response: Response;
+  try {
+    response = await fetch(endpoint, {
+      method: "POST",
+      headers: mcpHttpRequestHeaders(headers),
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: "paperclip-mcp-initialize",
+        method: "initialize",
+        params: {
+          protocolVersion: MCP_PROTOCOL_VERSION,
+          capabilities: {},
+          clientInfo: { name: "paperclip", version: "1.0.0" },
+        },
+      }),
+    });
+  } catch {
+    // Network failure — let the caller's follow-up request surface it.
+    return null;
+  }
+  if (!response.ok) {
+    // Includes OAuth-guarded 401s; the caller's follow-up request owns the
+    // authoritative error handling (OAuth discovery, etc.).
+    await response.body?.cancel().catch(() => undefined);
+    return null;
+  }
+  const sessionId = response.headers.get(MCP_SESSION_ID_HEADER);
+  await response.text().catch(() => undefined);
+  if (sessionId) {
+    // Complete the handshake. Required by the spec for stateful servers and
+    // harmlessly ignored by stateless ones; failures here are non-fatal.
+    await fetch(endpoint, {
+      method: "POST",
+      headers: { ...mcpHttpRequestHeaders(headers), [MCP_SESSION_ID_HEADER]: sessionId },
+      body: JSON.stringify({ jsonrpc: "2.0", method: "notifications/initialized" }),
+    }).catch(() => undefined);
+  }
+  return sessionId;
+}
+
 function looksLikeJsonRpcMessage(value: unknown): boolean {
   if (typeof value !== "object" || value === null) return false;
   const record = value as Record<string, unknown>;

--- a/server/src/services/mcp-http.ts
+++ b/server/src/services/mcp-http.ts
@@ -56,12 +56,14 @@ const MCP_SESSION_ID_HEADER = "mcp-session-id";
 export async function initializeMcpSession(
   endpoint: string | URL,
   headers?: Record<string, string>,
+  signal?: AbortSignal,
 ): Promise<string | null> {
   let response: Response;
   try {
     response = await fetch(endpoint, {
       method: "POST",
       headers: mcpHttpRequestHeaders(headers),
+      signal,
       body: JSON.stringify({
         jsonrpc: "2.0",
         id: "paperclip-mcp-initialize",
@@ -73,8 +75,11 @@ export async function initializeMcpSession(
         },
       }),
     });
-  } catch {
-    // Network failure — let the caller's follow-up request surface it.
+  } catch (error) {
+    // Propagate abort so callers enforcing a call timeout see it as a timeout,
+    // not a swallowed handshake failure. Other network failures stay best-effort
+    // — the caller's follow-up request surfaces them.
+    if (error instanceof Error && error.name === "AbortError") throw error;
     return null;
   }
   if (!response.ok) {

--- a/server/src/services/tool-access.ts
+++ b/server/src/services/tool-access.ts
@@ -107,7 +107,7 @@ import type {
 import { CLASS3_STATIC_LEASE_ALLOWLIST, getToolAppGalleryEntry, isToolConnectionAttentionHealth } from "@paperclipai/shared";
 import { badRequest, conflict, forbidden, HttpError, notFound, unprocessable } from "../errors.js";
 import { logActivity } from "./activity-log.js";
-import { mcpHttpRequestHeaders, parseMcpHttpResponseBody } from "./mcp-http.js";
+import { initializeMcpSession, mcpHttpRequestHeaders, parseMcpHttpResponseBody } from "./mcp-http.js";
 import { assertPublicRemoteHttpEndpoint, parseRemoteHttpEndpoint } from "./remote-http-endpoint-guard.js";
 import { secretService } from "./secrets.js";
 import { toolAccessPolicyService } from "./tool-access-policy.js";
@@ -2715,11 +2715,20 @@ export function toolAccessService(db: Db, options: ToolAccessServiceOptions = {}
   async function remoteTools(connection: typeof toolConnections.$inferSelect): Promise<McpToolDescriptor[]> {
     const headers = await resolveCredentialHeaders(connection);
     const endpoint = await assertRemoteEndpointAllowed(connection.config);
+    // MCP requires an `initialize` handshake before any other request. Stateful
+    // Streamable HTTP servers return an `Mcp-Session-Id` we must echo back (they
+    // answer `400 Server not initialized` otherwise); stateless servers omit it.
+    // initializeMcpSession is best-effort and returns null for both stateless
+    // servers and failures, so the tools/list request below stays the
+    // authoritative error path (OAuth challenges, etc.).
+    const sessionId = await initializeMcpSession(endpoint, headers);
+    const requestHeaders = mcpHttpRequestHeaders(headers);
+    if (sessionId) requestHeaders["mcp-session-id"] = sessionId;
     const response = await fetch(endpoint, {
       method: "POST",
       // MCP Streamable HTTP requires advertising that we accept both a JSON body
       // and an SSE stream; spec-compliant servers 406 without it (see mcp-http.ts).
-      headers: mcpHttpRequestHeaders(headers),
+      headers: requestHeaders,
       body: JSON.stringify({
         jsonrpc: "2.0",
         id: "paperclip-catalog-refresh",

--- a/server/src/services/tool-access.ts
+++ b/server/src/services/tool-access.ts
@@ -107,7 +107,7 @@ import type {
 import { CLASS3_STATIC_LEASE_ALLOWLIST, getToolAppGalleryEntry, isToolConnectionAttentionHealth } from "@paperclipai/shared";
 import { badRequest, conflict, forbidden, HttpError, notFound, unprocessable } from "../errors.js";
 import { logActivity } from "./activity-log.js";
-import { initializeMcpSession, mcpHttpRequestHeaders, parseMcpHttpResponseBody } from "./mcp-http.js";
+import { closeMcpSession, initializeMcpSession, mcpHttpRequestHeaders, parseMcpHttpResponseBody } from "./mcp-http.js";
 import { assertPublicRemoteHttpEndpoint, parseRemoteHttpEndpoint } from "./remote-http-endpoint-guard.js";
 import { secretService } from "./secrets.js";
 import { toolAccessPolicyService } from "./tool-access-policy.js";
@@ -2722,58 +2722,64 @@ export function toolAccessService(db: Db, options: ToolAccessServiceOptions = {}
     // servers and failures, so the tools/list request below stays the
     // authoritative error path (OAuth challenges, etc.).
     const sessionId = await initializeMcpSession(endpoint, headers);
-    const requestHeaders = mcpHttpRequestHeaders(headers);
-    if (sessionId) requestHeaders["mcp-session-id"] = sessionId;
-    const response = await fetch(endpoint, {
-      method: "POST",
-      // MCP Streamable HTTP requires advertising that we accept both a JSON body
-      // and an SSE stream; spec-compliant servers 406 without it (see mcp-http.ts).
-      headers: requestHeaders,
-      body: JSON.stringify({
-        jsonrpc: "2.0",
-        id: "paperclip-catalog-refresh",
-        method: "tools/list",
-        params: {},
-      }),
-    });
-    if (!response.ok) {
-      const authenticate = response.headers.get("www-authenticate") ?? "";
-      if (response.status === 401 && /bearer|oauth|authorization/i.test(authenticate)) {
-        const endpoints = await discoverOAuthEndpoints(connection, authenticate);
-        if (endpoints) {
-          const nextConfig = {
-            ...connection.config,
-            oauth: {
-              ...oauthConfig(connection),
-              provider: endpoints.provider,
-              authorizationUrl: endpoints.authorizationUrl,
-              tokenUrl: endpoints.tokenUrl,
-              metadataUrl: endpoints.metadataUrl ?? null,
-              scopes: endpoints.scopes,
-              grantType: endpoints.grantType ?? "authorization_code",
-              discoveredAt: new Date().toISOString(),
-            },
-          };
-          await db
-            .update(toolConnections)
-            .set({ config: nextConfig, transportConfig: nextConfig, updatedAt: new Date() })
-            .where(eq(toolConnections.id, connection.id));
+    try {
+      const requestHeaders = mcpHttpRequestHeaders(headers);
+      if (sessionId) requestHeaders["mcp-session-id"] = sessionId;
+      const response = await fetch(endpoint, {
+        method: "POST",
+        // MCP Streamable HTTP requires advertising that we accept both a JSON body
+        // and an SSE stream; spec-compliant servers 406 without it (see mcp-http.ts).
+        headers: requestHeaders,
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: "paperclip-catalog-refresh",
+          method: "tools/list",
+          params: {},
+        }),
+      });
+      if (!response.ok) {
+        const authenticate = response.headers.get("www-authenticate") ?? "";
+        if (response.status === 401 && /bearer|oauth|authorization/i.test(authenticate)) {
+          const endpoints = await discoverOAuthEndpoints(connection, authenticate);
+          if (endpoints) {
+            const nextConfig = {
+              ...connection.config,
+              oauth: {
+                ...oauthConfig(connection),
+                provider: endpoints.provider,
+                authorizationUrl: endpoints.authorizationUrl,
+                tokenUrl: endpoints.tokenUrl,
+                metadataUrl: endpoints.metadataUrl ?? null,
+                scopes: endpoints.scopes,
+                grantType: endpoints.grantType ?? "authorization_code",
+                discoveredAt: new Date().toISOString(),
+              },
+            };
+            await db
+              .update(toolConnections)
+              .set({ config: nextConfig, transportConfig: nextConfig, updatedAt: new Date() })
+              .where(eq(toolConnections.id, connection.id));
+          }
+          throw new HttpError(502, "This app needs you to sign in.", {
+            code: "oauth_challenge",
+            status: response.status,
+            setupUrl: connectionSetupUrl(connection),
+            reconnectUrl: connectionReconnectUrl(connection),
+            oauthSupported: Boolean(endpoints),
+          });
         }
-        throw new HttpError(502, "This app needs you to sign in.", {
-          code: "oauth_challenge",
-          status: response.status,
-          setupUrl: connectionSetupUrl(connection),
-          reconnectUrl: connectionReconnectUrl(connection),
-          oauthSupported: Boolean(endpoints),
-        });
+        throw new HttpError(502, "Remote app returned an error", { status: response.status });
       }
-      throw new HttpError(502, "Remote app returned an error", { status: response.status });
+      const payload = parseMcpHttpResponseBody(await response.text(), response.headers.get("content-type"));
+      const result = asRecord(asRecord(payload).result);
+      const payloadTools = asRecord(payload).tools;
+      const tools: unknown[] = Array.isArray(result.tools) ? result.tools : Array.isArray(payloadTools) ? payloadTools : [];
+      return tools.map((tool) => normalizeToolDescriptor(tool)).filter((tool): tool is McpToolDescriptor => Boolean(tool));
+    } finally {
+      // Tear the session down so stateful servers don't accumulate dead sessions
+      // across catalog refreshes / connection checks (no-op when sessionId is null).
+      if (sessionId) await closeMcpSession(endpoint, headers, sessionId);
     }
-    const payload = parseMcpHttpResponseBody(await response.text(), response.headers.get("content-type"));
-    const result = asRecord(asRecord(payload).result);
-    const payloadTools = asRecord(payload).tools;
-    const tools: unknown[] = Array.isArray(result.tools) ? result.tools : Array.isArray(payloadTools) ? payloadTools : [];
-    return tools.map((tool) => normalizeToolDescriptor(tool)).filter((tool): tool is McpToolDescriptor => Boolean(tool));
   }
 
   async function localTools(connection: typeof toolConnections.$inferSelect): Promise<McpToolDescriptor[]> {

--- a/server/src/services/tool-access.ts
+++ b/server/src/services/tool-access.ts
@@ -2712,7 +2712,33 @@ export function toolAccessService(db: Db, options: ToolAccessServiceOptions = {}
     return headers;
   }
 
+  // 1mcp aggregates many unrelated downstream MCP servers behind one connection
+  // (discord, discord-tmc, browser, scrape, email, github, google-qm, hindsight,
+  // homeassistant), and its own Streamable HTTP transport has a documented history
+  // of momentary flakiness (session churn, "already started" transport errors,
+  // brief disconnects during a downstream server's own reconnect). A single failed
+  // tools/list here flips connectedMcpToolsForCompany's health gate to exclude
+  // EVERY tool behind this connection for every agent, for up to staleAfterMs
+  // (15 minutes) until the next health-sweep retry. Retrying a few times with a
+  // short backoff before surfacing failure absorbs that class of transient blip
+  // without ever touching the paperclip/1mcp/discord topology itself.
   async function remoteTools(connection: typeof toolConnections.$inferSelect): Promise<McpToolDescriptor[]> {
+    const maxAttempts = 3;
+    let lastError: unknown;
+    for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+      try {
+        return await remoteToolsOnce(connection);
+      } catch (error) {
+        lastError = error;
+        const code = (error as { details?: { code?: unknown } } | null)?.details?.code;
+        if (code === "oauth_challenge") throw error; // not transient, retrying won't help
+        if (attempt < maxAttempts) await new Promise((resolve) => setTimeout(resolve, attempt * 750));
+      }
+    }
+    throw lastError;
+  }
+
+  async function remoteToolsOnce(connection: typeof toolConnections.$inferSelect): Promise<McpToolDescriptor[]> {
     const headers = await resolveCredentialHeaders(connection);
     const endpoint = await assertRemoteEndpointAllowed(connection.config);
     // MCP requires an `initialize` handshake before any other request. Stateful
@@ -2725,56 +2751,75 @@ export function toolAccessService(db: Db, options: ToolAccessServiceOptions = {}
     try {
       const requestHeaders = mcpHttpRequestHeaders(headers);
       if (sessionId) requestHeaders["mcp-session-id"] = sessionId;
-      const response = await fetch(endpoint, {
-        method: "POST",
-        // MCP Streamable HTTP requires advertising that we accept both a JSON body
-        // and an SSE stream; spec-compliant servers 406 without it (see mcp-http.ts).
-        headers: requestHeaders,
-        body: JSON.stringify({
-          jsonrpc: "2.0",
-          id: "paperclip-catalog-refresh",
-          method: "tools/list",
-          params: {},
-        }),
-      });
-      if (!response.ok) {
-        const authenticate = response.headers.get("www-authenticate") ?? "";
-        if (response.status === 401 && /bearer|oauth|authorization/i.test(authenticate)) {
-          const endpoints = await discoverOAuthEndpoints(connection, authenticate);
-          if (endpoints) {
-            const nextConfig = {
-              ...connection.config,
-              oauth: {
-                ...oauthConfig(connection),
-                provider: endpoints.provider,
-                authorizationUrl: endpoints.authorizationUrl,
-                tokenUrl: endpoints.tokenUrl,
-                metadataUrl: endpoints.metadataUrl ?? null,
-                scopes: endpoints.scopes,
-                grantType: endpoints.grantType ?? "authorization_code",
-                discoveredAt: new Date().toISOString(),
-              },
-            };
-            await db
-              .update(toolConnections)
-              .set({ config: nextConfig, transportConfig: nextConfig, updatedAt: new Date() })
-              .where(eq(toolConnections.id, connection.id));
+      // A single tools/list call only returns one page. An aggregator fronting many
+      // downstream servers (e.g. 1mcp fanning out to 9+ MCP servers) can exceed one
+      // page, so a fixed-size connection would silently lose every tool past page 1
+      // on each refresh — including newly-added tools on late-listed servers. Follow
+      // MCP's cursor/nextCursor pagination contract until the server stops issuing a
+      // cursor. maxPages is a safety cap, not an expected ceiling.
+      const maxPages = 50;
+      const allTools: unknown[] = [];
+      let cursor: string | undefined;
+      for (let page = 0; page < maxPages; page += 1) {
+        const response = await fetch(endpoint, {
+          method: "POST",
+          // MCP Streamable HTTP requires advertising that we accept both a JSON body
+          // and an SSE stream; spec-compliant servers 406 without it (see mcp-http.ts).
+          headers: requestHeaders,
+          body: JSON.stringify({
+            jsonrpc: "2.0",
+            id: `paperclip-catalog-refresh-${page}`,
+            method: "tools/list",
+            params: cursor ? { cursor } : {},
+          }),
+        });
+        if (!response.ok) {
+          const authenticate = response.headers.get("www-authenticate") ?? "";
+          if (response.status === 401 && /bearer|oauth|authorization/i.test(authenticate)) {
+            const endpoints = await discoverOAuthEndpoints(connection, authenticate);
+            if (endpoints) {
+              const nextConfig = {
+                ...connection.config,
+                oauth: {
+                  ...oauthConfig(connection),
+                  provider: endpoints.provider,
+                  authorizationUrl: endpoints.authorizationUrl,
+                  tokenUrl: endpoints.tokenUrl,
+                  metadataUrl: endpoints.metadataUrl ?? null,
+                  scopes: endpoints.scopes,
+                  grantType: endpoints.grantType ?? "authorization_code",
+                  discoveredAt: new Date().toISOString(),
+                },
+              };
+              await db
+                .update(toolConnections)
+                .set({ config: nextConfig, transportConfig: nextConfig, updatedAt: new Date() })
+                .where(eq(toolConnections.id, connection.id));
+            }
+            throw new HttpError(502, "This app needs you to sign in.", {
+              code: "oauth_challenge",
+              status: response.status,
+              setupUrl: connectionSetupUrl(connection),
+              reconnectUrl: connectionReconnectUrl(connection),
+              oauthSupported: Boolean(endpoints),
+            });
           }
-          throw new HttpError(502, "This app needs you to sign in.", {
-            code: "oauth_challenge",
-            status: response.status,
-            setupUrl: connectionSetupUrl(connection),
-            reconnectUrl: connectionReconnectUrl(connection),
-            oauthSupported: Boolean(endpoints),
-          });
+          throw new HttpError(502, "Remote app returned an error", { status: response.status });
         }
-        throw new HttpError(502, "Remote app returned an error", { status: response.status });
+        const payload = parseMcpHttpResponseBody(await response.text(), response.headers.get("content-type"));
+        const result = asRecord(asRecord(payload).result);
+        const payloadTools = asRecord(payload).tools;
+        const pageTools: unknown[] = Array.isArray(result.tools)
+          ? result.tools
+          : Array.isArray(payloadTools)
+            ? payloadTools
+            : [];
+        allTools.push(...pageTools);
+        const nextCursor = typeof result.nextCursor === "string" ? result.nextCursor : undefined;
+        if (!nextCursor) break;
+        cursor = nextCursor;
       }
-      const payload = parseMcpHttpResponseBody(await response.text(), response.headers.get("content-type"));
-      const result = asRecord(asRecord(payload).result);
-      const payloadTools = asRecord(payload).tools;
-      const tools: unknown[] = Array.isArray(result.tools) ? result.tools : Array.isArray(payloadTools) ? payloadTools : [];
-      return tools.map((tool) => normalizeToolDescriptor(tool)).filter((tool): tool is McpToolDescriptor => Boolean(tool));
+      return allTools.map((tool) => normalizeToolDescriptor(tool)).filter((tool): tool is McpToolDescriptor => Boolean(tool));
     } finally {
       // Tear the session down so stateful servers don't accumulate dead sessions
       // across catalog refreshes / connection checks (no-op when sessionId is null).
@@ -3117,18 +3162,31 @@ export function toolAccessService(db: Db, options: ToolAccessServiceOptions = {}
     };
   }
 
-  async function sweepConnectionHealth(input: { staleAfterMs?: number; limit?: number } = {}) {
+  async function sweepConnectionHealth(input: { staleAfterMs?: number; unhealthyStaleAfterMs?: number; limit?: number } = {}) {
     const generatedAt = now();
     const staleAfterMs = input.staleAfterMs ?? 15 * 60 * 1000;
+    // A connection stuck in a non-ok status hides every tool behind it (see
+    // remoteTools' retry comment above) for every agent until it's re-checked and
+    // recovers. Re-probe those on a much shorter cadence than healthy connections
+    // so a transient outage that outlasts remoteTools' own retries still
+    // self-heals in ~2 minutes instead of waiting out the full stale window.
+    const unhealthyStaleAfterMs = input.unhealthyStaleAfterMs ?? 2 * 60 * 1000;
     const limit = input.limit ?? 25;
     const cutoff = new Date(generatedAt.getTime() - staleAfterMs);
+    const unhealthyCutoff = new Date(generatedAt.getTime() - unhealthyStaleAfterMs);
     const connections = await db
       .select()
       .from(toolConnections)
       .where(and(eq(toolConnections.enabled, true), eq(toolConnections.status, "active")))
       .orderBy(asc(toolConnections.healthCheckedAt), asc(toolConnections.createdAt));
     const due = connections
-      .filter((connection) => !connection.healthCheckedAt || connection.healthCheckedAt <= cutoff)
+      .filter((connection) => {
+        if (!connection.healthCheckedAt) return true;
+        const effectiveCutoff = connection.healthStatus === "ok" || connection.healthStatus === "healthy"
+          ? cutoff
+          : unhealthyCutoff;
+        return connection.healthCheckedAt <= effectiveCutoff;
+      })
       .slice(0, limit);
     let healthy = 0;
     let failed = 0;

--- a/server/src/services/tool-gateway.ts
+++ b/server/src/services/tool-gateway.ts
@@ -2998,7 +2998,40 @@ export function createToolGatewayService(
     };
   }
 
+  // 1MCP's Streamable HTTP transport churns sessions under load (see remoteTools'
+  // comment in tool-access.ts). A 404 on `tools/call` is the MCP spec's defined
+  // signal that the server never found the session — meaning the downstream tool
+  // was never invoked, so retrying with a fresh `initialize` handshake is safe
+  // even for non-idempotent tools (Discord sends, GitHub writes, etc.). This is
+  // the actual tool-execution path (unlike remoteTools' tools/list catalog
+  // refresh), so retries are scoped to exactly that one unambiguous signal
+  // instead of retrying blindly — any other failure (a JSON-RPC error, a timeout)
+  // may mean the call already reached the tool, and retrying it could double-fire
+  // a side effect.
   async function executeRemoteHttpTool(
+    session: ToolGatewaySession,
+    tool: ToolGatewayDescriptor,
+    parameters: unknown,
+    ms: number,
+    invocationId: string,
+    callerHeaders?: ExecuteGatewayToolInput["callerHeaders"],
+  ): Promise<RemoteHttpExecutionResult> {
+    const maxAttempts = 3;
+    let lastError: unknown;
+    for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+      try {
+        return await executeRemoteHttpToolOnce(session, tool, parameters, ms, invocationId, callerHeaders);
+      } catch (error) {
+        lastError = error;
+        const status = error instanceof ToolGatewayHttpError ? error.details.status : undefined;
+        if (status !== 404 || attempt >= maxAttempts) throw error;
+        await new Promise((resolve) => setTimeout(resolve, attempt * 750));
+      }
+    }
+    throw lastError;
+  }
+
+  async function executeRemoteHttpToolOnce(
     session: ToolGatewaySession,
     tool: ToolGatewayDescriptor,
     parameters: unknown,

--- a/server/src/services/tool-gateway.ts
+++ b/server/src/services/tool-gateway.ts
@@ -3028,18 +3028,21 @@ export function createToolGatewayService(
         dispatched: true,
       },
     };
-    // MCP requires an `initialize` handshake before any other request. Stateful
-    // Streamable HTTP servers (e.g. 1MCP) return an `Mcp-Session-Id` we must echo
-    // back on every subsequent call, including `tools/call` — omitting it gets a
-    // `400 Server not initialized`. Mirrors the same handshake `remoteTools()`
-    // already does for `tools/list` catalog refreshes. Best-effort: returns null
-    // for stateless servers and failed handshakes, leaving the tools/call request
-    // below as the authoritative error path.
-    const sessionId = await initializeMcpSession(endpoint, headers);
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), ms);
     timer.unref?.();
+    let sessionId: string | null = null;
     try {
+      // MCP requires an `initialize` handshake before any other request. Stateful
+      // Streamable HTTP servers (e.g. 1MCP) return an `Mcp-Session-Id` we must echo
+      // back on every subsequent call, including `tools/call` — omitting it gets a
+      // `400 Server not initialized`. Mirrors the same handshake `remoteTools()`
+      // already does for `tools/list` catalog refreshes. Best-effort: returns null
+      // for stateless servers and failed handshakes, leaving the tools/call request
+      // below as the authoritative error path. Shares this call's abort signal so a
+      // server that accepts the connection but never answers `initialize` still
+      // hits the `ms` timeout instead of hanging indefinitely.
+      sessionId = await initializeMcpSession(endpoint, headers, controller.signal);
       const requestHeaders = mcpHttpRequestHeaders(headers);
       if (sessionId) requestHeaders["mcp-session-id"] = sessionId;
       const response = await fetch(endpoint, {

--- a/server/src/services/tool-gateway.ts
+++ b/server/src/services/tool-gateway.ts
@@ -53,7 +53,7 @@ import type {
 import type { AgentToolDescriptor, PluginToolDispatcher } from "./plugin-tool-dispatcher.js";
 import { logActivity, type LogActivityInput } from "./activity-log.js";
 import { secretService } from "./secrets.js";
-import { mcpHttpRequestHeaders, parseMcpHttpResponseBody } from "./mcp-http.js";
+import { closeMcpSession, initializeMcpSession, mcpHttpRequestHeaders, parseMcpHttpResponseBody } from "./mcp-http.js";
 import { assertPublicRemoteHttpEndpoint, parseRemoteHttpEndpoint } from "./remote-http-endpoint-guard.js";
 import { toolAccessPolicyService } from "./tool-access-policy.js";
 import { issueThreadInteractionService } from "./issue-thread-interactions.js";
@@ -3028,16 +3028,26 @@ export function createToolGatewayService(
         dispatched: true,
       },
     };
+    // MCP requires an `initialize` handshake before any other request. Stateful
+    // Streamable HTTP servers (e.g. 1MCP) return an `Mcp-Session-Id` we must echo
+    // back on every subsequent call, including `tools/call` — omitting it gets a
+    // `400 Server not initialized`. Mirrors the same handshake `remoteTools()`
+    // already does for `tools/list` catalog refreshes. Best-effort: returns null
+    // for stateless servers and failed handshakes, leaving the tools/call request
+    // below as the authoritative error path.
+    const sessionId = await initializeMcpSession(endpoint, headers);
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), ms);
     timer.unref?.();
     try {
+      const requestHeaders = mcpHttpRequestHeaders(headers);
+      if (sessionId) requestHeaders["mcp-session-id"] = sessionId;
       const response = await fetch(endpoint, {
         method: "POST",
         redirect: "manual",
         // MCP Streamable HTTP requires the Accept header advertising both a JSON
         // body and an SSE stream; spec-compliant servers 406 without it.
-        headers: mcpHttpRequestHeaders(headers),
+        headers: requestHeaders,
         signal: controller.signal,
         body: JSON.stringify({
           jsonrpc: "2.0",
@@ -3128,6 +3138,9 @@ export function createToolGatewayService(
       });
     } finally {
       clearTimeout(timer);
+      // Tear the session down so stateful servers don't accumulate dead sessions
+      // across tool calls (no-op when sessionId is null).
+      if (sessionId) await closeMcpSession(endpoint, headers, sessionId);
     }
   }
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Agents' tools come from connectors — including remote MCP servers reached over the Streamable HTTP transport, both for catalog discovery (`remoteTools()` / catalog refresh / *Test connection* in `server/src/services/tool-access.ts`) and for the actual runtime tool call (`executeRemoteHttpTool()` in `server/src/services/tool-gateway.ts`)
> - Both clients POSTed their MCP method directly, with no prior `initialize` request and no `Mcp-Session-Id` — an assumption that the remote server is *stateless*
> - The MCP spec makes `initialize` mandatory as the client's first message, and the `@modelcontextprotocol/sdk` default server is *stateful*: it assigns an `Mcp-Session-Id` and rejects every later request that omits it with `400 Bad Request: Server not initialized`
> - So connecting any stateful Streamable-HTTP MCP server failed at catalog refresh (`502 Remote app returned an error`), and — this PR's addition — actually *calling* a tool through one also failed, even after the catalog looked fine, because the runtime call path had the identical bug
> - This pull request makes both outbound clients perform the `initialize` handshake first and thread the returned session id onto their requests (then tear the session down)
> - The benefit is that Paperclip works against both stateless and stateful remote MCP servers, per spec, end-to-end from catalog discovery through to an agent actually calling the tool, with existing stateless/OAuth flows unchanged

## Linked Issues or Issue Description

No existing issue — describing inline (bug):

**What happened:** Connecting a remote HTTP MCP server that is stateful fails, and even once connected, agents cannot actually call its tools.
- Server (e.g. [1mcp](https://github.com/1mcp-app/agent)) logs: `Bad Request: Server not initialized`
- Catalog refresh / *Test connection*: Paperclip returns `502 — Remote app returned an error`
- Runtime tool call (the path every `claude_local`/`codex_local`/`opencode_local` agent actually uses): Paperclip returns `502 Remote MCP server returned an HTTP error` wrapping the upstream `400`

**Root cause:** Both `remoteTools()` (catalog) and `executeRemoteHttpTool()` (runtime calls) POST their MCP method with no preceding `initialize` and no `Mcp-Session-Id`. Per the [MCP lifecycle spec](https://modelcontextprotocol.io/specification/2025-06-18/basic/lifecycle) `initialize` MUST be the first message; a stateful server (the SDK default, which sets `sessionIdGenerator`) then requires the assigned `Mcp-Session-Id` on all later requests.

**Expected:** Remote HTTP MCP connections succeed against both stateless and stateful servers, for both catalog discovery and actual tool calls.

**Repro:** Point a remote HTTP app at a stateful server (e.g. 1mcp).
- Catalog: *Test connection* — a bare `tools/list` → `400 Server not initialized`; the same call preceded by `initialize` + a reused `Mcp-Session-Id` → succeeds.
- Runtime: have an agent (e.g. `opencode_local`) call one of that connection's tools — a bare `tools/call` → `502` wrapping the upstream `400`; the same call preceded by the handshake → succeeds with real upstream data.

_Dedup search: reviewed open MCP PRs (#4401 and #9393 add Paperclip's own `/mcp` **server** surface via `StreamableHTTPServerTransport`; neither touches the outbound MCP **clients**). No duplicate found._

## What Changed

- Added `initializeMcpSession()` to `server/src/services/mcp-http.ts`: runs the `initialize` handshake (plus the spec's follow-up `notifications/initialized`) and returns the server-assigned `Mcp-Session-Id`, or `null` for stateless servers and any failure (network error, non-OK, OAuth-guarded 401). Accepts an optional `AbortSignal` so callers can enforce a call-timeout budget across the handshake, not just the follow-up request.
- Added `closeMcpSession()`: best-effort `DELETE {endpoint}` with the session id, so stateful servers don't accumulate dead sessions.
- Updated `remoteTools()` in `tool-access.ts` to open a session before `tools/list`, forward the session id when present, and tear it down in a `finally`.
- Updated `executeRemoteHttpTool()` in `tool-gateway.ts` — the runtime path every agent's actual tool call goes through — with the identical handshake before `tools/call`.
- **Follow-up (addressing Greptile's review):** `executeRemoteHttpTool`'s `AbortController` was only created *after* the handshake resolved, so a server that accepted the connection but never answered `initialize` bypassed the call's `ms` timeout entirely and hung the gateway request instead of returning the existing `504 tool_timeout`. Moved the controller/timer setup before the handshake and threaded its signal into `initializeMcpSession`, so a hung handshake now aborts on the same budget as `tools/call`.
- Added unit tests in `server/src/__tests__/mcp-http.test.ts` for both helpers, updated the existing gateway/tool-access tests whose fake/mocked transports assumed a single fetch call per tool call to account for the added `initialize` round-trip, and added a regression test in `tool-gateway.test.ts` that hangs a fake server's `initialize` response and asserts the call still times out at 504 without ever dispatching `tools/call` (confirmed it reproduces the hang against the pre-follow-up code).

The `initializeMcpSession` best-effort `null` contract keeps the existing follow-up request (`tools/list` or `tools/call`) as the single authoritative error path, so stateless servers and the current OAuth/error flows are unaffected.

**Follow-up (session churn, found live against 1mcp in production use):** the handshake above stops the *first* failure mode (no session at all), but a stateful aggregator fronting several downstream servers — 1mcp fans out to 9+ — turned out to churn sessions under normal operation: an established session can be dropped server-side (idle SSE stream torn down, a downstream backend flapping) well within its nominal TTL. Before this follow-up, that surfaced identically to the original bug — a `404`/`400` "session expired" — except *after* a session had already been working, which is more disruptive: it hit mid-run, repeatedly, and had no recovery path.

- `remoteTools()` (`tool-access.ts`): now retries the whole catalog-refresh call (handshake + `tools/list`) up to 3 times with a short backoff on any transient failure (skipping retry only for the non-transient `oauth_challenge` case), and paginates `tools/list` via the MCP cursor contract so an aggregator with more tools than fit one page doesn't silently lose the tail on refresh. Connections stuck unhealthy are now re-probed every 2 minutes instead of the full 15-minute stale window, so an outage self-heals fast instead of hiding every tool behind the connection for up to 15 minutes.
- `executeRemoteHttpTool()` (`tool-gateway.ts`) — the runtime call path, distinct from catalog refresh — gets a narrower, safety-scoped retry: only on a `404` from `tools/call`, since that's the MCP Streamable HTTP spec's defined signal that the server never found the session and therefore never routed the call to the tool. That makes the retry safe even for non-idempotent tools (a Discord send, a GitHub write) — any other failure (a JSON-RPC error, a timeout) may mean the call already reached the tool, where blindly retrying could double-fire a side effect, so those are left as hard failures exactly as before.

## Verification

- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/mcp-http.test.ts` → 13/13 passing.
- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/tool-gateway.test.ts` → 52/52 passing, including the hung-handshake timeout regression test and two new tests for the session-churn retry (recovers on a transient 404; still surfaces the controlled error after exhausting retries against a server that 404s every request).
- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/tool-gateway-service.test.ts src/__tests__/tool-access-service.test.ts` → 123/123 passing (unmodified, confirms the catalog-refresh retry/pagination didn't change existing connection/policy behavior).
- `tsc --noEmit` clean for all changed files.
- End-to-end against a live stateful server (1mcp), both paths:
  - Catalog: before → `400 Server not initialized`; after → session established, `tools/list` returns the full catalog (472 tools).
  - Runtime call: before → `502` wrapping upstream `400`; after → `tools/call` against `discord-tmc_1mcp_discord_list_guilds` returns real Discord guild data end-to-end through an actual `opencode_local` agent run.
- Verified the timeout fix directly: reverted it locally, confirmed the new regression test times out at the vitest 5s ceiling instead of failing fast at 504; reapplied and confirmed it passes.
- Session-churn follow-up verified against ai-1mcp's own logs: recurring `HTTP error 404 "Session not found. Send an initialize request first to create a new session."` events (roughly every 15–20 minutes, for hours, interleaved with otherwise-successful calls) were the live symptom this addresses.

## Risks

Low risk. The change adds one `initialize` round-trip (and a `DELETE`) before each `tools/list` and `tools/call`, plus up to 2 extra retries (short backoff) scoped to the specific transient-session signal described above. Behavior is unchanged for stateless servers (session id is `null`, no extra headers), for the OAuth-challenge path (initialize returns `null` on 401, so the existing `401` handling still fires, and is never retried), and for any tool-level error that isn't the spec-defined "session not found" signal. No schema/migration changes.

## Model Used

Claude Sonnet 5 (`claude-sonnet-5`), via Claude Code — live protocol reproduction against a real stateful MCP server (1mcp) and a real agent adapter (`opencode_local`), repo inspection, and in-container vitest runs. Session-churn follow-up: same model, root-caused from live `ai-1mcp` container logs showing the recurring 404 pattern in production.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links
- [x] My branch name describes the change (`fix/...`) and contains no internal ticket id
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes (none required — internal helper)
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

