### PR TITLE
fix(hermes): do not fail successful runs on stderr keywords

### DIFF
--- a/packages/adapters/hermes/src/server/execute.stderr-classification.test.ts
+++ b/packages/adapters/hermes/src/server/execute.stderr-classification.test.ts
@@ -90,4 +90,19 @@ describe("hermes-local stderr classification", () => {
     expect(result.exitCode).toBe(1);
     expect(result.errorMessage).toContain("git gc");
   });
+
+  it("preserves stderr diagnostics when the Hermes child times out", async () => {
+    runChildProcessMock.mockResolvedValueOnce({
+      exitCode: null,
+      signal: "SIGTERM",
+      timedOut: true,
+      stdout: "",
+      stderr: recoverableCheckpointError,
+    });
+
+    const result = await execute(makeCtx() as any);
+
+    expect(result.timedOut).toBe(true);
+    expect(result.errorMessage).toContain("git gc");
+  });
 });

--- a/packages/adapters/hermes/src/server/execute.stderr-classification.test.ts
+++ b/packages/adapters/hermes/src/server/execute.stderr-classification.test.ts
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const runChildProcessMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@paperclipai/adapter-utils/server-utils", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@paperclipai/adapter-utils/server-utils")>();
+  return {
+    ...actual,
+    runChildProcess: runChildProcessMock,
+  };
+});
+
+vi.mock("node:fs/promises", () => ({
+  default: {
+    readFile: vi.fn(async () => ""),
+  },
+  readFile: vi.fn(async () => ""),
+}));
+
+import { execute } from "./execute.js";
+
+function makeCtx() {
+  return {
+    runId: "test-run-stderr",
+    agent: {
+      id: "agent-1",
+      companyId: "company-1",
+      name: "Hermes",
+      adapterType: "hermes_local",
+      adapterConfig: {},
+    },
+    runtime: {
+      sessionId: null,
+      sessionParams: null,
+      sessionDisplayId: null,
+      taskKey: null,
+    },
+    config: {
+      command: "/usr/bin/hermes",
+      timeoutSec: 60,
+      graceSec: 5,
+    },
+    context: {
+      issueId: "issue-1",
+      wakeReason: "manual",
+      paperclipWake: null,
+    },
+    onLog: vi.fn(async () => undefined),
+    onMeta: vi.fn(async () => undefined),
+    onSpawn: vi.fn(async () => undefined),
+  };
+}
+
+const recoverableCheckpointError =
+  "tools.checkpoint_manager - ERROR - Git command failed: git gc --prune=now --quiet " +
+  "(rc=128) stderr=fatal: gc is already running";
+
+describe("hermes-local stderr classification", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("does not fail an exit-code-0 run because a recoverable tool error was logged", async () => {
+    runChildProcessMock.mockResolvedValueOnce({
+      exitCode: 0,
+      signal: null,
+      timedOut: false,
+      stdout: "Work completed successfully.\n",
+      stderr: recoverableCheckpointError,
+    });
+
+    const result = await execute(makeCtx() as any);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.errorMessage).toBeUndefined();
+    expect(result.summary).toContain("Work completed successfully");
+  });
+
+  it("preserves stderr diagnostics when the Hermes child actually fails", async () => {
+    runChildProcessMock.mockResolvedValueOnce({
+      exitCode: 1,
+      signal: null,
+      timedOut: false,
+      stdout: "",
+      stderr: recoverableCheckpointError,
+    });
+
+    const result = await execute(makeCtx() as any);
+
+    expect(result.exitCode).toBe(1);
+    expect(result.errorMessage).toContain("git gc");
+  });
+});

--- a/packages/adapters/hermes/src/server/execute.ts
+++ b/packages/adapters/hermes/src/server/execute.ts
@@ -553,7 +553,12 @@ export async function execute(
     model,
   };
 
-  if (parsed.errorMessage) {
+  // Hermes may log recoverable tool/checkpoint errors to stderr and still
+  // finish the requested run successfully. Treating any such line as an
+  // adapter failure turns an exit-code-0 run into a false red Paperclip run.
+  // Preserve fatal diagnostics only when the child itself failed or timed
+  // out; successful runs are authoritative.
+  if (parsed.errorMessage && (result.exitCode !== 0 || result.timedOut)) {
     executionResult.errorMessage = parsed.errorMessage;
   }
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip manages agent processes through adapters and reports each run's terminal status.
> - The Hermes adapter parses stdout and stderr to build that terminal result.
> - Hermes uses stderr for structured logs, including recoverable tool errors and assistant progress text, even when the process completes successfully.
> - The adapter currently copies any stderr line containing an error keyword into `errorMessage`, regardless of the child exit status.
> - Paperclip therefore records exit-code-0 Hermes runs as `adapter_failed`, which can trigger misleading inbox failures and unnecessary retries.
> - This pull request makes the child process exit status authoritative while retaining stderr diagnostics for actual failures and timeouts.
> - The benefit is accurate run status without hiding real Hermes failures.

## Linked Issues or Issue Description

No matching public issue or open pull request was found. Inline bug report:

### Pre-submission checklist

- [x] I searched existing open and closed issues and this is not a duplicate.
- [x] I reproduced the defect on current `master`.
- [x] I confirmed the incorrect classification originates in the Paperclip Hermes adapter.

### What happened?

A Hermes run completed its task and exited `0`, but a recoverable checkpoint log on stderr contained `ERROR` and `git gc`. The adapter returned that line as `errorMessage`, so Paperclip classified the run as `adapter_failed` despite `exitCode: 0`.

### Expected behavior

An exit-code-0, non-timeout Hermes process should remain successful. Stderr diagnostics should remain fatal when the child exits nonzero or times out.

### Steps to reproduce

1. Configure a `hermes_local` agent.
2. Have the Hermes child emit a line containing `ERROR` on stderr, emit a normal result on stdout, and exit `0`.
3. Observe that the current adapter returns both `exitCode: 0` and `errorMessage`, causing a failed Paperclip run.

### Paperclip version or commit

`2026.714.0-canary.1`; also reproduced in `master` source at `5d42382`.

### Deployment mode

Self-hosted local-trusted server.

### Installation method

npm installation.

### Agent adapter(s) involved

Hermes (`hermes_local`).

### Database mode

Not database-related.

### Access context

Agent execution.

### Node.js version

`v25.8.1`

### Operating system

macOS 26.5.1 arm64.

### Relevant logs or output

```text
exitCode: 0
errorCode: adapter_failed
error: tools.checkpoint_manager - ERROR - Git command failed: git gc --prune=now --quiet ... fatal: gc is already running
```

### Privacy checklist

- [x] I reviewed the pasted output and removed local usernames, paths, credentials, tokens, company names, and task content.

## What Changed

- Only attach parsed stderr `errorMessage` when the Hermes child exits nonzero or times out.
- Add regression coverage proving recoverable stderr does not fail an exit-code-0 run.
- Add companion coverage proving stderr diagnostics remain available when the child actually fails.

## Verification

- Executed the built adapter against a synthetic Hermes command that emitted a checkpoint `ERROR` to stderr and exited `0`; result was `exitCode: 0`, no `errorMessage`, and the successful summary was preserved.
- Executed the same command with exit `1`; result retained the `git gc` stderr diagnostic in `errorMessage`.
- `node --check` passed for the built adapter with the equivalent local patch.
- The new Vitest regression is included for CI. A clean workspace dependency install was not run locally, so repository CI remains the authoritative full-suite check.

## Risks

Low risk. A Hermes child that exits `0` can no longer be marked failed solely because stderr contains an error keyword. Nonzero exits and timeouts retain existing diagnostics. Stderr is still streamed to logs, so recoverable warnings remain observable.

## Model Used

OpenAI Codex `gpt-5.6-sol`, with reasoning, tool use, filesystem inspection, code execution, and live adapter-process verification.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this targeted adapter bug fix does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links
- [x] My branch name describes the change and contains no internal Paperclip ticket id
- [x] I have run focused local runtime verification and it passes
- [x] I have added or updated tests where applicable
- [x] Documentation changes are not applicable to this internal correctness fix
- [x] I have considered and documented risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
