### PR TITLE
fix(routines): isolate per-firing dispatch failures in tickScheduledTriggers

### DIFF
--- a/server/src/__tests__/routine-run-telemetry.test.ts
+++ b/server/src/__tests__/routine-run-telemetry.test.ts
@@ -167,4 +167,25 @@ describeEmbeddedPostgres("routine run telemetry", () => {
       status: "issue_created",
     });
   });
+
+  it("does not fail an already-committed run when telemetry throws synchronously", async () => {
+    const { routine, svc } = await seedFixture();
+    mockTrackRoutineRun.mockImplementationOnce(() => {
+      throw new Error("telemetry state factory blew up");
+    });
+
+    // The run/issue transaction has already committed by the time telemetry runs. A throw
+    // there must not surface as a dispatch failure for a run that durably exists.
+    const run = await svc.runRoutine(routine.id, { source: "manual" });
+
+    expect(run.status).toBe("issue_created");
+
+    const runs = await db
+      .select()
+      .from(routineRuns)
+      .where(eq(routineRuns.routineId, routine.id));
+    expect(runs).toHaveLength(1);
+    expect(runs[0]?.status).toBe("issue_created");
+    expect(runs[0]?.failureReason).toBeNull();
+  });
 });

--- a/server/src/__tests__/routines-service.test.ts
+++ b/server/src/__tests__/routines-service.test.ts
@@ -1,5 +1,5 @@
 import { createHmac, randomUUID } from "node:crypto";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import {
   activityLog,
@@ -2350,5 +2350,519 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
     const run = await svc.firePublicTrigger(trigger.publicId!, { payload: { source: "test" } });
 
     expect(run).toMatchObject({ source: "webhook", status: "issue_created" });
+  });
+
+  async function seedSecondRoutineInSameCompany(
+    companyId: string,
+    projectId: string,
+    svc: Awaited<ReturnType<typeof seedFixture>>["svc"],
+    label: string,
+  ) {
+    const agentId = randomUUID();
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: label,
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    const routine = await svc.create(
+      companyId,
+      {
+        projectId,
+        goalId: null,
+        parentIssueId: null,
+        title: `${label} routine`,
+        description: `Run the ${label} routine`,
+        assigneeAgentId: agentId,
+        priority: "medium",
+        status: "active",
+        concurrencyPolicy: "coalesce_if_active",
+        catchUpPolicy: "skip_missed",
+      },
+      {},
+    );
+    return { agentId, routine };
+  }
+
+  it("keeps ticking the rest of a single-company batch, only after an earlier dispatch failure is durably recorded", async () => {
+    // Causal check (not incidental createdAt ordering): the healthy routine's own wakeup
+    // fires synchronously mid-dispatch, inside the same for-loop iteration that processes the
+    // whole due batch. If a future change ever parallelized that loop, the broken routine's
+    // failed run would not yet be committed when this fires, and the assertion below would
+    // catch it — a timestamp-only check after the tick completes could not.
+    let causalCheckRan = false;
+    let causalCheckPassed = false;
+
+    const { companyId, agentId, projectId, routine, svc } = await seedFixture({
+      wakeup: async (wakeupAgentId, wakeupOpts) => {
+        causalCheckRan = true;
+        const brokenFailedRuns = await db
+          .select()
+          .from(routineRuns)
+          .where(and(eq(routineRuns.routineId, routine.id), eq(routineRuns.status, "failed")));
+        causalCheckPassed = brokenFailedRuns.length === 1;
+
+        const issueId =
+          (typeof wakeupOpts.payload?.issueId === "string" && wakeupOpts.payload.issueId) ||
+          (typeof wakeupOpts.contextSnapshot?.issueId === "string" && wakeupOpts.contextSnapshot.issueId) ||
+          null;
+        if (!issueId) return null;
+        const queuedRunId = randomUUID();
+        await db.insert(heartbeatRuns).values({
+          id: queuedRunId,
+          companyId,
+          agentId: wakeupAgentId,
+          invocationSource: wakeupOpts.source ?? "assignment",
+          triggerDetail: wakeupOpts.triggerDetail ?? null,
+          status: "queued",
+          contextSnapshot: { ...(wakeupOpts.contextSnapshot ?? {}), issueId },
+        });
+        await db
+          .update(issues)
+          .set({ executionRunId: queuedRunId, executionLockedAt: new Date() })
+          .where(eq(issues.id, issueId));
+        return { id: queuedRunId };
+      },
+    });
+
+    const { routine: healthyRoutine } = await seedSecondRoutineInSameCompany(companyId, projectId, svc, "healthy");
+
+    const { trigger: brokenTrigger } = await svc.createTrigger(
+      routine.id,
+      { kind: "schedule", label: "daily", cronExpression: "0 0 * * *", timezone: "UTC" },
+      {},
+    );
+    const { trigger: healthyTrigger } = await svc.createTrigger(
+      healthyRoutine.id,
+      { kind: "schedule", label: "daily", cronExpression: "0 0 * * *", timezone: "UTC" },
+      {},
+    );
+
+    // Make the first routine's assignee unassignable so dispatchRoutineRun throws
+    // synchronously (assertAssignableAgent), before any routineRuns row is created.
+    await db.update(agents).set({ status: "terminated" }).where(eq(agents.id, agentId));
+
+    const pastDue = new Date("2020-01-01T00:00:00.000Z");
+    // Order matters: the broken trigger must be claimed/dispatched before the healthy one
+    // in the same tick to prove a throw doesn't abort the remaining batch.
+    await db
+      .update(routineTriggers)
+      .set({ nextRunAt: pastDue, createdAt: new Date("2019-12-31T00:00:00.000Z") })
+      .where(eq(routineTriggers.id, brokenTrigger.id));
+    await db
+      .update(routineTriggers)
+      .set({ nextRunAt: pastDue, createdAt: new Date("2019-12-31T00:00:01.000Z") })
+      .where(eq(routineTriggers.id, healthyTrigger.id));
+
+    const result = await svc.tickScheduledTriggers(new Date());
+
+    // Only the healthy routine actually dispatched; the broken one is recorded as failed, not counted.
+    expect(result.triggered).toBe(1);
+    expect(causalCheckRan).toBe(true);
+    expect(causalCheckPassed).toBe(true);
+
+    // The broken routine's schedule is still claimed/advanced (no tight retry loop), but the
+    // failure is recorded observably instead of vanishing.
+    const brokenRuns = await db
+      .select()
+      .from(routineRuns)
+      .where(eq(routineRuns.routineId, routine.id));
+    expect(brokenRuns).toHaveLength(1);
+    expect(brokenRuns[0]?.status).toBe("failed");
+    expect(brokenRuns[0]?.source).toBe("schedule");
+    expect(brokenRuns[0]?.linkedIssueId).toBeNull();
+    expect(brokenRuns[0]?.failureReason).toMatch(/terminated/i);
+    expect(brokenRuns[0]?.completedAt).not.toBeNull();
+
+    const brokenTriggerAfter = await db
+      .select()
+      .from(routineTriggers)
+      .where(eq(routineTriggers.id, brokenTrigger.id))
+      .then((rows) => rows[0]);
+    expect(brokenTriggerAfter?.nextRunAt).not.toBeNull();
+    expect(brokenTriggerAfter!.nextRunAt!.getTime()).toBeGreaterThan(pastDue.getTime());
+    expect(brokenTriggerAfter?.lastResult).toMatch(/failed/i);
+
+    // The second, healthy routine in the same tick must not be skipped by the first one's throw.
+    const healthyRuns = await db
+      .select()
+      .from(routineRuns)
+      .where(eq(routineRuns.routineId, healthyRoutine.id));
+    expect(healthyRuns).toHaveLength(1);
+    expect(healthyRuns[0]?.status).toBe("issue_created");
+
+    const healthyIssues = await db
+      .select()
+      .from(issues)
+      .where(eq(issues.companyId, companyId));
+    expect(healthyIssues).toHaveLength(1);
+  });
+
+  it("records one failed run per claimed catch-up firing, capped at MAX_CATCH_UP_RUNS, without aborting the tick", async () => {
+    const { companyId, agentId, projectId, svc } = await seedFixture();
+
+    // A routine with enqueue_missed_with_cap so a long-overdue trigger computes runCount > 1
+    // (capped at MAX_CATCH_UP_RUNS) inside a single tick.
+    const routine = await svc.create(
+      companyId,
+      {
+        projectId,
+        goalId: null,
+        parentIssueId: null,
+        title: "catch-up frog",
+        description: "Run the catch-up frog routine",
+        assigneeAgentId: agentId,
+        priority: "medium",
+        status: "active",
+        concurrencyPolicy: "coalesce_if_active",
+        catchUpPolicy: "enqueue_missed_with_cap",
+      },
+      {},
+    );
+    const { trigger } = await svc.createTrigger(
+      routine.id,
+      // Hourly, not sub-hourly: an every-minute cron would hit the scheduler's own
+      // sub-hourly catch-up guard (isSubHourlyCronExpression) and collapse to a single
+      // firing instead of the multi-firing batch this test needs.
+      { kind: "schedule", label: "hourly", cronExpression: "0 * * * *", timezone: "UTC" },
+      {},
+    );
+
+    // Make the assignee unassignable so every catch-up iteration's dispatch throws identically.
+    await db.update(agents).set({ status: "terminated" }).where(eq(agents.id, agentId));
+
+    // Far enough in the past that the capped catch-up loop computes runCount === MAX_CATCH_UP_RUNS.
+    const longOverdue = new Date("2020-01-01T00:00:00.000Z");
+    await db
+      .update(routineTriggers)
+      .set({ nextRunAt: longOverdue })
+      .where(eq(routineTriggers.id, trigger.id));
+
+    const result = await svc.tickScheduledTriggers(new Date());
+    expect(result.triggered).toBe(0);
+
+    // The CAS already advanced nextRunAt past every one of the MAX_CATCH_UP_RUNS claimed
+    // firings before dispatch, so each claimed firing must get its own recorded outcome —
+    // no claimed firing silently vanishes, and the batch is not aborted midway.
+    const runs = await db
+      .select()
+      .from(routineRuns)
+      .where(eq(routineRuns.routineId, routine.id));
+    // Mirrors the unexported MAX_CATCH_UP_RUNS in ../services/routines.ts.
+    const MAX_CATCH_UP_RUNS = 25;
+    expect(runs).toHaveLength(MAX_CATCH_UP_RUNS);
+    expect(runs.every((run) => run.status === "failed")).toBe(true);
+    expect(runs.every((run) => (run.failureReason ?? "").match(/terminated/i))).toBe(true);
+  });
+
+  it("keeps dispatching later routines in the batch when the failure recorder's own transaction throws", async () => {
+    const { companyId, agentId, projectId, routine, svc } = await seedFixture();
+    const { routine: healthyRoutine } = await seedSecondRoutineInSameCompany(companyId, projectId, svc, "healthy");
+
+    const { trigger: brokenTrigger } = await svc.createTrigger(
+      routine.id,
+      { kind: "schedule", label: "daily", cronExpression: "0 0 * * *", timezone: "UTC" },
+      {},
+    );
+    const { trigger: healthyTrigger } = await svc.createTrigger(
+      healthyRoutine.id,
+      { kind: "schedule", label: "daily", cronExpression: "0 0 * * *", timezone: "UTC" },
+      {},
+    );
+
+    await db.update(agents).set({ status: "terminated" }).where(eq(agents.id, agentId));
+
+    const pastDue = new Date("2020-01-01T00:00:00.000Z");
+    await db
+      .update(routineTriggers)
+      .set({ nextRunAt: pastDue, createdAt: new Date("2019-12-31T00:00:00.000Z") })
+      .where(eq(routineTriggers.id, brokenTrigger.id));
+    await db
+      .update(routineTriggers)
+      .set({ nextRunAt: pastDue, createdAt: new Date("2019-12-31T00:00:01.000Z") })
+      .where(eq(routineTriggers.id, healthyTrigger.id));
+
+    // Simulate a DB blip on the very first db.transaction call in this tick, which is
+    // recordFailedScheduleRun's own transaction for the broken routine (dispatchRoutineRun's
+    // early assignee-eligibility throw happens before it ever opens a transaction, so no
+    // other db.transaction call precedes it). vi.spyOn keeps the pass-through default for
+    // every call after the queued one-shot override.
+    const transactionSpy = vi
+      .spyOn(db, "transaction")
+      .mockImplementationOnce(() => Promise.reject(new Error("simulated recorder db blip")));
+
+    try {
+      const result = await svc.tickScheduledTriggers(new Date());
+
+      // The broken routine's own failure couldn't be durably recorded (its recorder's
+      // transaction rejected, caught by the recorder guard), but the batch must still reach
+      // the healthy routine rather than aborting the whole tick.
+      expect(result.triggered).toBe(1);
+
+      const brokenRuns = await db
+        .select()
+        .from(routineRuns)
+        .where(eq(routineRuns.routineId, routine.id));
+      expect(brokenRuns).toHaveLength(0);
+
+      const healthyRuns = await db
+        .select()
+        .from(routineRuns)
+        .where(eq(routineRuns.routineId, healthyRoutine.id));
+      expect(healthyRuns).toHaveLength(1);
+      expect(healthyRuns[0]?.status).toBe("issue_created");
+    } finally {
+      transactionSpy.mockRestore();
+    }
+  });
+
+  it("does not record a compensating failed run when dispatch's transaction durably commits but the caller sees it reject", async () => {
+    // The assignee stays healthy here: this reproduces an "ambiguous commit" — the DB driver
+    // actually commits dispatchRoutineRun's transaction, but the promise the scheduler is
+    // awaiting rejects anyway (a real class of failure: connection drop between COMMIT and
+    // acknowledgment, etc). That is a genuinely different failure mode than an assignee
+    // rejection, and it is the one the reconciliation check exists for.
+    const { companyId, projectId, routine, svc } = await seedFixture();
+    const { routine: healthyRoutine } = await seedSecondRoutineInSameCompany(
+      companyId,
+      projectId,
+      svc,
+      "healthy-after-ambiguous",
+    );
+
+    const { trigger: ambiguousTrigger } = await svc.createTrigger(
+      routine.id,
+      { kind: "schedule", label: "daily", cronExpression: "0 0 * * *", timezone: "UTC" },
+      {},
+    );
+    const { trigger: healthyTrigger } = await svc.createTrigger(
+      healthyRoutine.id,
+      { kind: "schedule", label: "daily", cronExpression: "0 0 * * *", timezone: "UTC" },
+      {},
+    );
+
+    const pastDue = new Date("2020-01-01T00:00:00.000Z");
+    await db
+      .update(routineTriggers)
+      .set({ nextRunAt: pastDue, createdAt: new Date("2019-12-31T00:00:00.000Z") })
+      .where(eq(routineTriggers.id, ambiguousTrigger.id));
+    await db
+      .update(routineTriggers)
+      .set({ nextRunAt: pastDue, createdAt: new Date("2019-12-31T00:00:01.000Z") })
+      .where(eq(routineTriggers.id, healthyTrigger.id));
+
+    // Let the very first db.transaction call in this tick (dispatchRoutineRun's own, for the
+    // "ambiguous" routine — it is processed first by due-order) actually run to completion
+    // via the real implementation, so the run row genuinely commits, then reject the promise
+    // the caller is awaiting anyway. Every later db.transaction call (including the healthy
+    // routine's own dispatch) falls through to the untouched real implementation.
+    const originalTransaction = db.transaction.bind(db) as typeof db.transaction;
+    const transactionSpy = vi
+      .spyOn(db, "transaction")
+      .mockImplementationOnce(async (...args: Parameters<typeof db.transaction>) => {
+        await originalTransaction(...args);
+        throw new Error("simulated ambiguous commit failure — driver reported failure after a real commit");
+      });
+
+    try {
+      const result = await svc.tickScheduledTriggers(new Date());
+
+      // The healthy routine's dispatch resolves cleanly and is counted; the "ambiguous"
+      // routine's own dispatch call appears (from the scheduler's point of view) to throw,
+      // so it is not counted here even though it truly committed.
+      expect(result.triggered).toBe(1);
+
+      // Exactly one run for the ambiguous routine — the real, durably committed one — and it
+      // reflects the actual dispatch outcome, not a compensating "failed" row next to it.
+      const ambiguousRuns = await db
+        .select()
+        .from(routineRuns)
+        .where(eq(routineRuns.routineId, routine.id));
+      expect(ambiguousRuns).toHaveLength(1);
+      expect(ambiguousRuns[0]?.status).toBe("issue_created");
+      expect(ambiguousRuns[0]?.linkedIssueId).not.toBeNull();
+      // Reconciliation matched on the deterministic per-attempt idempotency key, not on a
+      // clock/time-window comparison — assert the mechanism directly, not just the outcome.
+      expect(ambiguousRuns[0]?.idempotencyKey).toMatch(new RegExp(`^schedule:${ambiguousTrigger.id}:`));
+
+      // The later, healthy routine in the same tick still dispatched normally.
+      const healthyRuns = await db
+        .select()
+        .from(routineRuns)
+        .where(eq(routineRuns.routineId, healthyRoutine.id));
+      expect(healthyRuns).toHaveLength(1);
+      expect(healthyRuns[0]?.status).toBe("issue_created");
+    } finally {
+      transactionSpy.mockRestore();
+    }
+  });
+
+  it("does not let one catch-up firing's success suppress the next firing's genuine failure (distinct idempotency keys)", async () => {
+    // This is the direct regression for the timestamp-based design's zero-row hole: a
+    // same-tick catch-up iteration N that succeeds must not cause iteration N+1's own,
+    // genuinely different failure to be swallowed. A time-window reconciliation could mistake
+    // iteration N's just-committed success for iteration N+1's outcome if the two landed
+    // within the same createdAt-resolution window. Forcing that specific race deterministically
+    // against embedded Postgres's real async I/O (both rows must land in the exact same
+    // millisecond) is not practical to do reliably — vi.useFakeTimers stalls the driver's own
+    // I/O, and sub-millisecond timing races are inherently flaky to force from outside. So
+    // this test instead proves the mechanism directly: iteration 0 dispatches successfully,
+    // iteration 1's own dispatch call is made to fail (via a one-shot db.transaction
+    // rejection, exactly the same technique the ambiguous-commit test above uses — no
+    // assignability toggling required), and we assert each iteration produced its own outcome
+    // row under its own distinct, index-suffixed idempotency key. Because the reconciliation
+    // lookup matches on that exact key, iteration 0's row is structurally unable to satisfy
+    // iteration 1's lookup regardless of how close together in time they land — this is true
+    // by construction, not by getting lucky on timing, which is what makes the exact-key
+    // design correct where the time-window design was not.
+    const { companyId, agentId, projectId, routine, svc } = await seedFixture();
+
+    const routineWithCatchUp = await svc.create(
+      companyId,
+      {
+        projectId,
+        goalId: null,
+        parentIssueId: null,
+        title: "flaky catch-up frog",
+        description: "Run the flaky catch-up frog routine",
+        assigneeAgentId: agentId,
+        priority: "medium",
+        status: "active",
+        concurrencyPolicy: "always_enqueue",
+        catchUpPolicy: "enqueue_missed_with_cap",
+      },
+      {},
+    );
+    const { trigger } = await svc.createTrigger(
+      routineWithCatchUp.id,
+      // Hourly, not sub-hourly: an every-minute cron would hit the scheduler's own
+      // sub-hourly catch-up guard (isSubHourlyCronExpression) and collapse to a single
+      // firing instead of the two-firing batch this test needs.
+      { kind: "schedule", label: "hourly", cronExpression: "0 * * * *", timezone: "UTC" },
+      {},
+    );
+
+    // Exactly two missed firings, one hour apart, so runCount === 2.
+    const firstFiring = new Date("2020-01-01T00:00:00.000Z");
+    await db
+      .update(routineTriggers)
+      .set({ nextRunAt: firstFiring })
+      .where(eq(routineTriggers.id, trigger.id));
+    const now = new Date("2020-01-01T01:01:00.000Z");
+
+    // Let the first *top-level* db.transaction call in this tick (iteration 0's own dispatch)
+    // commit for real. Reject the second top-level call (iteration 1's own dispatch) outright,
+    // without calling through — a genuine, non-durable failure for that attempt specifically:
+    // no row is created for it at all, so recordFailedScheduleRun must be the one to create it.
+    // Nesting depth must be tracked explicitly: issueSvc.create opens its own nested
+    // db.transaction (a savepoint) from inside dispatchRoutineRun's already-open transaction,
+    // so a flat call counter can't tell an iteration boundary apart from that nested call.
+    const originalTransaction = db.transaction.bind(db) as typeof db.transaction;
+    let depth = 0;
+    let topLevelCallCount = 0;
+    const transactionSpy = vi.spyOn(db, "transaction").mockImplementation(
+      async (...args: Parameters<typeof db.transaction>) => {
+        const isTopLevel = depth === 0;
+        if (isTopLevel) {
+          topLevelCallCount += 1;
+          if (topLevelCallCount === 2) {
+            throw new Error("simulated genuine failure for the second catch-up iteration");
+          }
+        }
+        depth += 1;
+        try {
+          return await originalTransaction(...args);
+        } finally {
+          depth -= 1;
+        }
+      },
+    );
+
+    try {
+      const result = await svc.tickScheduledTriggers(now);
+
+      // Iteration 0 dispatched successfully and is counted; iteration 1 failed.
+      expect(result.triggered).toBe(1);
+
+      const runs = await db
+        .select()
+        .from(routineRuns)
+        .where(eq(routineRuns.routineId, routineWithCatchUp.id));
+      expect(runs).toHaveLength(2);
+
+      const successRun = runs.find((run) => run.status !== "failed");
+      const failedRun = runs.find((run) => run.status === "failed");
+      expect(successRun).toBeDefined();
+      expect(failedRun).toBeDefined();
+      expect(failedRun?.failureReason).toMatch(/simulated genuine failure/);
+
+      // The two runs used distinct, index-suffixed idempotency keys — the mechanism that
+      // makes iteration 0's success structurally unable to satisfy iteration 1's
+      // reconciliation lookup, regardless of how close together in time they land.
+      expect(successRun?.idempotencyKey).toMatch(/:0$/);
+      expect(failedRun?.idempotencyKey).toMatch(/:1$/);
+      expect(failedRun?.idempotencyKey).not.toBe(successRun?.idempotencyKey);
+    } finally {
+      transactionSpy.mockRestore();
+    }
+  });
+
+  it("does not duplicate a run that dispatchRoutineRun already recorded as failed internally, even under an ambiguous commit", async () => {
+    // dispatchRoutineRun has its own internal try/catch (around issue creation and wakeup
+    // queueing) that, on failure, finalizes the run with status "failed" and commits that
+    // within the SAME transaction as the run's own creation — a durable, real failed row that
+    // predates and is independent of the scheduler's compensating-insert logic entirely. If
+    // the outer db.transaction call *also* appears to throw afterward (the same ambiguous
+    // commit scenario as above), the scheduler's reconciliation must recognize the row that
+    // already exists under this attempt's idempotency key — regardless of its status — and
+    // must not insert a second "failed" row next to it.
+    const failure = new Error("simulated wakeup queueing failure");
+    const { routine, svc } = await seedFixture({
+      wakeup: async () => {
+        throw failure;
+      },
+    });
+
+    const { trigger } = await svc.createTrigger(
+      routine.id,
+      { kind: "schedule", label: "daily", cronExpression: "0 0 * * *", timezone: "UTC" },
+      {},
+    );
+    await db
+      .update(routineTriggers)
+      .set({ nextRunAt: new Date("2020-01-01T00:00:00.000Z") })
+      .where(eq(routineTriggers.id, trigger.id));
+
+    // Let the real transaction run to completion (issue creation fails internally via the
+    // throwing wakeup above, dispatchRoutineRun's own catch commits a real "failed" row), then
+    // reject the promise the scheduler is awaiting anyway.
+    const originalTransaction = db.transaction.bind(db) as typeof db.transaction;
+    const transactionSpy = vi
+      .spyOn(db, "transaction")
+      .mockImplementationOnce(async (...args: Parameters<typeof db.transaction>) => {
+        await originalTransaction(...args);
+        throw new Error("simulated ambiguous commit failure — driver reported failure after a real commit");
+      });
+
+    try {
+      await svc.tickScheduledTriggers(new Date());
+
+      // Exactly one failed run — the one dispatchRoutineRun itself durably committed — not a
+      // second, compensating one from the scheduler's catch.
+      const runs = await db
+        .select()
+        .from(routineRuns)
+        .where(eq(routineRuns.routineId, routine.id));
+      expect(runs).toHaveLength(1);
+      expect(runs[0]?.status).toBe("failed");
+      expect(runs[0]?.failureReason).toMatch(/simulated wakeup queueing failure/);
+    } finally {
+      transactionSpy.mockRestore();
+    }
   });
 });

--- a/server/src/services/routines.ts
+++ b/server/src/services/routines.ts
@@ -1395,6 +1395,71 @@ export function routineService(
     return run;
   }
 
+  // Records a scheduled firing whose dispatch threw before a routineRuns row could be created
+  // (e.g. dispatchRoutineRun's own assignee-eligibility check). The tick is still claimed and
+  // advanced upstream, same as the paused-project case, so a persistently broken routine logs
+  // loudly on every tick instead of retrying tightly or replaying missed firings on repair.
+  async function recordFailedScheduleRun(input: {
+    routine: typeof routines.$inferSelect;
+    trigger: typeof routineTriggers.$inferSelect;
+    error: unknown;
+    nextRunAt: Date | null;
+    idempotencyKey: string;
+  }) {
+    const triggeredAt = new Date();
+    const failureReason = input.error instanceof Error ? input.error.message : String(input.error);
+    const run = await db.transaction(async (tx) => {
+      const txDb = tx as unknown as Db;
+      const [createdRun] = await txDb
+        .insert(routineRuns)
+        .values({
+          companyId: input.routine.companyId,
+          routineId: input.routine.id,
+          triggerId: input.trigger.id,
+          source: "schedule",
+          status: "failed",
+          triggeredAt,
+          idempotencyKey: input.idempotencyKey,
+          failureReason,
+          completedAt: triggeredAt,
+          linkedIssueId: null,
+          routineRevisionId: input.routine.latestRevisionId,
+          responsibleUserId: input.routine.responsibleUserId ?? null,
+        })
+        .returning();
+      await updateRoutineTouchedState({
+        routineId: input.routine.id,
+        triggerId: input.trigger.id,
+        triggeredAt,
+        status: "failed",
+        nextRunAt: input.nextRunAt,
+      }, txDb);
+      return createdRun;
+    });
+
+    try {
+      await logActivity(db, {
+        companyId: input.routine.companyId,
+        actorType: "system",
+        actorId: "routine-scheduler",
+        action: "routine.run_failed",
+        entityType: "routine_run",
+        entityId: run.id,
+        details: {
+          routineId: input.routine.id,
+          triggerId: input.trigger.id,
+          source: "schedule",
+          status: "failed",
+          reason: failureReason,
+        },
+      });
+    } catch (err) {
+      logger.warn({ err, routineId: input.routine.id, runId: run.id }, "failed to log failed scheduled routine run");
+    }
+
+    return run;
+  }
+
   function routineExecutionFingerprintCondition(dispatchFingerprint?: string | null) {
     if (!dispatchFingerprint) return null;
     // The "default" arm preserves coalescing against pre-migration open issues.
@@ -1919,12 +1984,19 @@ export function routineService(
       }
     }
 
-    const telemetryClient = getTelemetryClient();
-    if (telemetryClient) {
-      trackRoutineRun(telemetryClient, {
-        source: run.source,
-        status: run.status,
-      });
+    try {
+      const telemetryClient = getTelemetryClient();
+      if (telemetryClient) {
+        trackRoutineRun(telemetryClient, {
+          source: run.source,
+          status: run.status,
+        });
+      }
+    } catch (err) {
+      // Telemetry runs after the run/issue transaction has already committed. A throw here
+      // must never bubble up as a dispatch failure — that would falsely record a durably
+      // created run as failed (and, for scheduled runs, spuriously drop the rest of the tick).
+      logger.warn({ err, routineId: input.routine.id, runId: run.id }, "failed to record routine run telemetry");
     }
 
     return run;
@@ -2983,6 +3055,10 @@ export function routineService(
 
         let runCount = 1;
         let claimedNextRunAt = nextCronTickInTimeZone(row.trigger.cronExpression, row.trigger.timezone, now);
+        // The scheduled firing time each runCount iteration is replaying — used below to build
+        // a deterministic per-attempt idempotency key. Single-firing (non-catch-up) ticks fire
+        // exactly the trigger's own due time.
+        let firingScheduledAts: Date[] = [row.trigger.nextRunAt];
 
         if (!projectPaused && !worktreeSuppressed && row.routine.catchUpPolicy === "enqueue_missed_with_cap") {
           if (isSubHourlyCronExpression(row.trigger.cronExpression, row.trigger.timezone, now)) {
@@ -2990,7 +3066,9 @@ export function routineService(
           } else {
             let cursor: Date | null = row.trigger.nextRunAt;
             runCount = 0;
+            firingScheduledAts = [];
             while (cursor && cursor <= now && runCount < MAX_CATCH_UP_RUNS) {
+              firingScheduledAts.push(cursor);
               runCount += 1;
               claimedNextRunAt = nextCronTickInTimeZone(row.trigger.cronExpression, row.trigger.timezone, cursor);
               cursor = claimedNextRunAt;
@@ -3047,14 +3125,121 @@ export function routineService(
           continue;
         }
 
+        let triggerFailureCount = 0;
         for (let i = 0; i < runCount; i += 1) {
-          await dispatchRoutineRun({
-            routine: row.routine,
-            trigger: row.trigger,
-            source: "schedule",
-            nextRunAtOverride: claimedNextRunAt,
-          });
-          triggered += 1;
+          // A deterministic, per-attempt identity: distinct for every claimed firing (the
+          // scheduled tick it replays, and its index) within this trigger. dispatchRoutineRun
+          // already dedupes on idempotencyKey (see the existing-run lookup inside its own
+          // transaction), and passing one here is what lets the reconciliation check below
+          // find the *exact* row this attempt is responsible for — no clock comparison, no
+          // risk of one iteration's outcome being mistaken for another's.
+          const firingScheduledAt = firingScheduledAts[i] ?? row.trigger.nextRunAt ?? now;
+          const idempotencyKey = `schedule:${row.trigger.id}:${firingScheduledAt.toISOString()}:${i}`;
+          try {
+            await dispatchRoutineRun({
+              routine: row.routine,
+              trigger: row.trigger,
+              source: "schedule",
+              nextRunAtOverride: claimedNextRunAt,
+              idempotencyKey,
+            });
+            triggered += 1;
+          } catch (err) {
+            // A single routine's dispatch failure (e.g. its assignee agent was archived or
+            // otherwise became unassignable) must not abort the rest of this tick's batch.
+            // The claim above already advanced nextRunAt past every one of the runCount
+            // firings claimed for this trigger, so each claimed firing gets its own dispatch
+            // attempt and its own recorded outcome — continuing (not breaking) here avoids
+            // silently discarding claimed catch-up firings on a transient error. Log the
+            // first failure loudly; downgrade repeats for the same trigger in this tick to
+            // avoid flooding the log when a persistently broken routine burns through its
+            // whole catch-up cap.
+            triggerFailureCount += 1;
+            if (triggerFailureCount === 1) {
+              logger.error(
+                { err, routineId: row.routine.id, triggerId: row.trigger.id, runCount },
+                "routine scheduled dispatch failed",
+              );
+            } else {
+              logger.warn(
+                { err, routineId: row.routine.id, triggerId: row.trigger.id, occurrence: triggerFailureCount, runCount },
+                "routine scheduled dispatch failed again in the same tick",
+              );
+            }
+
+            // dispatchRoutineRun's own transaction can, in principle, durably commit and still
+            // have the awaiting call throw (e.g. the driver reports an ambiguous failure after
+            // the COMMIT actually lands). Recording a "failed" row unconditionally in that case
+            // would sit right next to the real successful run and contradict it — a failure
+            // mode this patch itself would introduce, since the old code had no compensating
+            // insert here at all. Reconcile first, by the exact idempotencyKey this attempt
+            // used (any status): a matching row — success, coalesced, or even an internally
+            // recorded "failed" row from inside dispatchRoutineRun's own transaction — means
+            // this attempt already has a durable outcome, so skip the compensating insert. A
+            // createdAt/time-window based check was tried first and rejected: it's vulnerable
+            // to app/DB clock skew, to one catch-up iteration's row landing in the same
+            // millisecond as the next iteration's window (falsely suppressing a genuine
+            // failure with zero rows recorded for it), and excluding "failed" status by fiat
+            // still let an internally committed failed row get duplicated. Exact-key matching
+            // has none of those holes: distinct keys can't cross-match, and status is
+            // irrelevant because any row under this exact key is this attempt's own outcome.
+            let existingRun: typeof routineRuns.$inferSelect | null = null;
+            let reconciliationFailed = false;
+            try {
+              existingRun = await db
+                .select()
+                .from(routineRuns)
+                .where(
+                  and(
+                    eq(routineRuns.routineId, row.routine.id),
+                    eq(routineRuns.triggerId, row.trigger.id),
+                    eq(routineRuns.source, "schedule"),
+                    eq(routineRuns.idempotencyKey, idempotencyKey),
+                  ),
+                )
+                .limit(1)
+                .then((rows) => rows[0] ?? null);
+            } catch (reconcileErr) {
+              reconciliationFailed = true;
+              // Fallback direction flipped from an earlier draft: never contradict a possible
+              // real success. If we can't tell whether this attempt already has a durable
+              // outcome, skip the compensating insert rather than risk a duplicate — and log
+              // loudly (error, not warn) so the gap is observable instead of silently
+              // swallowed.
+              logger.error(
+                { err: reconcileErr, routineId: row.routine.id, triggerId: row.trigger.id, idempotencyKey },
+                "failed to reconcile dispatch outcome by idempotency key — skipping compensating failure record to avoid a possible duplicate",
+              );
+            }
+
+            if (existingRun) {
+              logger.warn(
+                {
+                  routineId: row.routine.id,
+                  triggerId: row.trigger.id,
+                  runId: existingRun.id,
+                  status: existingRun.status,
+                },
+                "dispatch threw but a run already exists for this attempt's idempotency key — skipping compensating failure record",
+              );
+            } else if (!reconciliationFailed) {
+              try {
+                await recordFailedScheduleRun({
+                  routine: row.routine,
+                  trigger: row.trigger,
+                  error: err,
+                  nextRunAt: claimedNextRunAt,
+                  idempotencyKey,
+                });
+              } catch (recordErr) {
+                // Recording the failure must not itself be able to abort the tick's batch.
+                logger.error(
+                  { err: recordErr, routineId: row.routine.id, triggerId: row.trigger.id },
+                  "failed to record failed scheduled routine run",
+                );
+              }
+            }
+          }
         }
       }
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Scheduled Routines are the cron-driven trigger mechanism (`routineService.tickScheduledTriggers`) that fires periodic agent work — the control plane claims due firings, advances `next_run_at` atomically, then dispatches each one
> - When `dispatchRoutineRun` throws synchronously for a claimed firing (e.g. the assignee agent was terminated or otherwise became unassignable), that specific firing has no per-row handling: `next_run_at` was already advanced past it, no `routineRuns` row is ever created, and the only trace is a generic log line at the call site — the firing is silently dropped
> - Worse, that thrown exception propagates out of the runCount loop for that trigger and aborts every other due routine still waiting in the same tick's batch, so one broken routine can stall an entire company's scheduled work until someone notices and fixes it by hand
> - This pull request wraps each claimed firing's dispatch in its own try/catch, records every failure as a durable `routineRuns` row via a new `recordFailedScheduleRun` helper, and reconciles by a deterministic per-firing `idempotencyKey` to avoid double-recording an ambiguous-commit case
> - The benefit is that a single misconfigured or unassignable routine degrades gracefully (loud logs, a queryable failure record per firing) instead of silently vanishing or freezing every other routine's schedule

## Linked Issues or Issue Description

Refs #5184, Refs #9445 — related but not identical: #5184 describes `next_run_at` never advancing at all (a different observable than this PR's target, which is firings that *do* get claimed/advanced but then have their dispatch outcome silently dropped on a synchronous throw). #9445 is symptomatically related (a routine that never accumulates `routineRuns` rows), which this PR's durable failure-recording directly helps diagnose.

### Relationship to #5238

While preparing this PR I found **#5238** ("fix(routines): isolate per-trigger errors so one bad cron does not freeze the batch"), which is open and targets an overlapping piece of the same loop. Flagging this explicitly rather than leaving it for review to discover:

- **Where we overlap:** #5238 also wraps each `dispatchRoutineRun` call inside the per-trigger `runCount` loop in its own try/catch, for the same reason this PR does — so one firing's dispatch failure can't unwind the loop and take the rest of the batch's due triggers down with it. That specific mechanism (per-dispatch-call isolation) is functionally the same idea in both PRs.
- **Where #5238 goes further than this PR:** #5238 *additionally* wraps the outer per-trigger block, so a corrupted `cronExpression`/timezone that makes `nextCronTickInTimeZone` throw is also isolated per-trigger. This PR does not touch that failure mode at all — it assumes the trigger's cron/timezone already validates and focuses only on the dispatch-time failure.
- **Where this PR goes further than #5238, on the overlapping dispatch-failure part:**
  1. **Durable, queryable failure records.** #5238 logs and increments a `failed` counter on a dispatch failure but never creates a `routineRuns` row for it — there's no persisted record of which firing failed or why. This PR's `recordFailedScheduleRun` inserts a `routineRuns` row with `status: "failed"` and a `failureReason`, so a failure is queryable and diagnosable after the fact, not just visible in logs at the moment it happened.
  2. **Ambiguous-commit reconciliation.** `dispatchRoutineRun`'s own transaction can, in principle, durably commit and still have the awaiting call throw (e.g. a driver reporting failure after the `COMMIT` actually landed). Neither the pre-existing code nor #5238 guards against this — a compensating "failed" row could end up recorded right next to a real successful run and contradict it. This PR passes a deterministic per-firing `idempotencyKey` (`schedule:<triggerId>:<firingScheduledAt>:<index>`) into `dispatchRoutineRun` and, on a caught error, reconciles by exact key match (any status) before inserting a compensating failed row — skipping the insert entirely if a row already exists under that key, and logging loudly (never inserting) if the reconciliation lookup itself errors.
  3. **Post-commit telemetry guard.** `dispatchRoutineRun`'s telemetry call happens after its own transaction commits; this PR guards that call so a telemetry throw can no longer be mistaken for a dispatch failure on an already-durably-committed run.

I'm happy to rebase this PR to build on top of #5238 once it merges (dropping the parts of my diff that duplicate its per-dispatch try/catch and keeping only the durable-recording + reconciliation delta), or to fold items 1–3 above into #5238 directly as review feedback there, whichever maintainers prefer. Opening this as a separate PR for now mainly so the durable-recording + reconciliation approach is visible and reviewable on its own, since it's a materially different failure-handling strategy (persisted state + idempotent reconciliation) rather than log-and-count.

## What Changed

- `server/src/services/routines.ts` (`tickScheduledTriggers`):
  - Each claimed firing's `dispatchRoutineRun` call (inside the per-trigger `runCount` loop, including multi-firing catch-up batches) is now wrapped in its own try/catch instead of being a bare `await` that, on throw, unwinds out of the whole tick.
  - A deterministic per-firing `idempotencyKey` (`schedule:<triggerId>:<firingScheduledAt ISO>:<index>`) is now passed into `dispatchRoutineRun`, which already accepted and stored that field. This gives the reconciliation check below an exact row to look for instead of a time-window guess.
  - On a caught dispatch error: log the first failure for a trigger in a tick at `error`, downgrade repeats for the same trigger to `warn` with an occurrence counter (bounds log volume for a persistently broken routine burning through its whole catch-up cap); then reconcile by exact `idempotencyKey` match (any status) to check whether the failed attempt actually committed a durable outcome despite throwing; only if no such row exists (and the reconciliation lookup itself didn't error) insert a compensating `routineRuns` row via the new `recordFailedScheduleRun` helper.
  - New `recordFailedScheduleRun` helper (modeled on the existing `recordSuppressedAutomaticRun` pattern used for paused-project/worktree-cutoff skips): inserts a `routineRuns` row with `status: "failed"` and `failureReason`, updates the trigger's touched-state, and best-effort logs an activity entry.
  - `dispatchRoutineRun`'s post-commit `trackRoutineRun` telemetry call is now guarded so a telemetry throw can't be mistaken for the run itself having failed.
- `server/src/__tests__/routines-service.test.ts` — five new regression tests: batch continuation across multiple due routines with a causal (not just timestamp) assertion that a later routine's dispatch isn't blocked by an earlier one's failure; one failed-run row recorded per claimed catch-up firing, capped at `MAX_CATCH_UP_RUNS`; the failure-recorder's own transaction erroring doesn't abort the rest of the tick's batch; an ambiguous-commit scenario (dispatch's transaction durably commits, caller still observes a throw) does not produce a duplicate/contradictory row; a catch-up iteration's genuine success does not suppress the very next iteration's genuine, distinct failure, verified via each row's distinct index-suffixed `idempotencyKey`.
- `server/src/__tests__/routine-run-telemetry.test.ts` — one new regression test: a synchronous throw from the telemetry call after a run has already committed does not flip that run's recorded status away from its real (successful) outcome.

## Verification

This branch is rebased onto current `master` (as of commit `5d42382`), which had already diverged from the `v2026.707.0` tag with an unrelated, substantial `routines.ts` rewrite (activity-gate suppression, worktree-execution-cutoff suppression, folder support, and a new sub-hourly catch-up coalescing guard via `isSubHourlyCronExpression`). That required real conflict resolution, not a clean apply — noting for reviewers:

- The tick loop's catch-up branch now needs both master's sub-hourly short-circuit *and* this PR's per-firing `firingScheduledAts` timestamp tracking; both are preserved.
- The dispatch loop now runs this PR's try/catch/idempotency logic *underneath* master's new activity-gate and worktree-suppression pre-checks (which run before any dispatch attempt and are unaffected by this PR), and also picks up master's `nextRunAtOverride` correctness fix for multi-firing catch-up batches (previously each loop iteration independently recomputed its own `nextRunAt`; master pins all iterations in a batch to the same claimed value).
- Two new tests originally used an every-minute cron (`* * * * *`) for catch-up scenarios; master's new sub-hourly guard now intentionally collapses such crons to a single firing instead of a full replay (to prevent catch-up floods), so those two tests were changed to an hourly cron with proportionally adjusted timestamps — same assertions, same `MAX_CATCH_UP_RUNS = 25` cap logic, just no longer sub-hourly.

Ran all 8 routine-related test files on this master-based branch:

```
npx vitest run \
  src/__tests__/plugin-managed-routines.test.ts \
  src/__tests__/qa-routine-secrets-e2e.test.ts \
  src/__tests__/routine-document-annotation-routes.test.ts \
  src/__tests__/routines-routes.test.ts \
  src/__tests__/routine-run-telemetry.test.ts \
  src/__tests__/routines-e2e.test.ts \
  src/__tests__/routines-service.test.ts \
  src/services/routines-formatter-cache.test.ts
# Test Files  8 passed (8)
#      Tests  97 passed (97)
```

`tsc --noEmit` on this branch reports 128 errors, all pre-existing `@paperclipai/plugin-sdk` module-resolution failures unrelated to this change (same category on a clean `master` checkout before this diff); zero errors in any file touched by this PR.

Every fix in this PR was demonstrated RED/GREEN during development by selective reversion (each piece — per-firing try/catch, idempotency reconciliation, telemetry guard — was temporarily removed to confirm its corresponding new test fails without it, then restored).

## Risks

- Low-to-moderate. This changes failure-path behavior only (the happy path — successful dispatch — is unchanged); a broken routine that previously silently vanished or froze the batch now produces a `routineRuns` row per failed firing and a log line, and no longer blocks other due routines in the same tick.
- `routineRuns.idempotencyKey` has no unique index today. The exact-key reconciliation lookup in this PR is strictly safer than the pre-existing code (which did no reconciliation at all), but a uniquely-enforced per-firing constraint would be a stronger guarantee than lookup-then-insert. Recommending that as explicit follow-up hardening; a schema migration felt out of scope for this PR.
- Pre-existing, untouched by this PR: a process crash between the `next_run_at` claim (CAS update) and the dispatch attempt still leaves a firing with no run row at all. This PR does not add crash-recovery for that window.
- A firing that both genuinely fails *and* simultaneously hits a reconciliation-query error produces no run row for that specific firing — this is deliberate (the failure is still observable via the loud `error`-level log line at that point), preferring "no row, but observable" over risking a row that might contradict a real, already-committed success.

## Model Used

Claude (Anthropic), Claude Opus/Fable-tier reasoning model accessed via Claude Code, with tool use (repository search, file edits, running `tsc`/`vitest` in a local checkout) and extended multi-step reasoning for the conflict resolution against `master`'s independent `routines.ts` changes. No separate research/reasoning model was used for this PR.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
