### PR TITLE
fix(security): keep bridge credentials out of remote argv

### DIFF
--- a/packages/adapter-utils/src/sandbox-callback-bridge.test.ts
+++ b/packages/adapter-utils/src/sandbox-callback-bridge.test.ts
@@ -114,7 +114,7 @@ describe("sandbox callback bridge", () => {
     }
   });
 
-  it("round-trips localhost bridge requests over the sandbox queue without forwarding the bridge token", async () => {
+  it("round-trips bridge requests without putting the bridge credential in spawned argv", async () => {
     const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-bridge-runtime-"));
     cleanupDirs.push(rootDir);
 
@@ -124,7 +124,14 @@ describe("sandbox callback bridge", () => {
     await mkdir(remoteWorkspaceDir, { recursive: true });
     await writeFile(path.join(localWorkspaceDir, "README.md"), "bridge test\n", "utf8");
 
-    const runner = createExecRunner();
+    const delegateRunner = createExecRunner();
+    const runnerInputs: Array<Parameters<typeof delegateRunner.execute>[0]> = [];
+    const runner = {
+      execute: async (input: Parameters<typeof delegateRunner.execute>[0]) => {
+        runnerInputs.push(input);
+        return await delegateRunner.execute(input);
+      },
+    };
 
     const bridgeAsset = await createSandboxCallbackBridgeAsset();
     cleanupFns.push(bridgeAsset.cleanup);
@@ -147,7 +154,7 @@ describe("sandbox callback bridge", () => {
 
     const queueDir = path.posix.join(prepared.runtimeRootDir, "paperclip-bridge");
     const directories = sandboxCallbackBridgeDirectories(queueDir);
-    const bridgeToken = createSandboxCallbackBridgeToken();
+    const bridgeToken = "paperclip-bridge-argv-sentinel";
     const seenRequests: Array<{
       method: string;
       path: string;
@@ -199,6 +206,13 @@ describe("sandbox callback bridge", () => {
     cleanupFns.push(async () => {
       await bridge.stop();
     });
+
+    const bridgeStartInput = runnerInputs.find((input) => input.stdin === `${bridgeToken}\n`);
+    expect(bridgeStartInput).toBeDefined();
+    expect(JSON.stringify([bridgeStartInput!.command, ...(bridgeStartInput!.args ?? [])])).not.toContain(
+      bridgeToken,
+    );
+    expect(JSON.stringify(bridgeStartInput!.env ?? {})).not.toContain(bridgeToken);
 
     const okResponse = await fetch(`${bridge.baseUrl}/api/agents/me?view=compact`, {
       headers: {

--- a/packages/adapter-utils/src/sandbox-callback-bridge.ts
+++ b/packages/adapter-utils/src/sandbox-callback-bridge.ts
@@ -912,6 +912,7 @@ export async function startSandboxCallbackBridgeServer(input: {
     maxQueueDepth: input.maxQueueDepth,
     maxBodyBytes: input.maxBodyBytes,
   });
+  delete env.PAPERCLIP_BRIDGE_TOKEN;
   const nodeCommand = input.nodeCommand?.trim() || "node";
   const startResult = await input.runner.execute({
     command: shellCommand,
@@ -919,6 +920,8 @@ export async function startSandboxCallbackBridgeServer(input: {
       [
         `mkdir -p ${shellQuote(directories.requestsDir)} ${shellQuote(directories.responsesDir)} ${shellQuote(directories.logsDir)}`,
         `rm -f ${shellQuote(directories.readyFile)} ${shellQuote(directories.pidFile)}`,
+        "IFS= read -r PAPERCLIP_BRIDGE_TOKEN",
+        "export PAPERCLIP_BRIDGE_TOKEN",
         `nohup ${shellQuote(nodeCommand)} ${shellQuote(remoteEntrypoint)} ` +
           `>> ${shellQuote(directories.logFile)} 2>&1 < /dev/null &`,
         "pid=$!",
@@ -931,6 +934,7 @@ export async function startSandboxCallbackBridgeServer(input: {
       [SANDBOX_EXEC_CHANNEL_ENV]: SANDBOX_EXEC_CHANNEL_BRIDGE,
       ...env,
     },
+    stdin: `${input.bridgeToken}\n`,
     timeoutMs,
   });
   requireSuccessfulResult("start sandbox callback bridge", startResult);


### PR DESCRIPTION
## Summary
- deliver the per-bridge credential to the remote launcher over stdin instead of the command runner environment
- export it only inside the remote shell so the detached bridge inherits authorization without exposing the value in spawned argv
- add a sentinel regression assertion while preserving bridge authorization and teardown coverage

## Test plan
- [x] `npx --yes pnpm@9.15.4 exec vitest run packages/adapter-utils/src/sandbox-callback-bridge.test.ts`
- [x] `npx --yes pnpm@9.15.4 --filter @paperclipai/adapter-utils typecheck`

Made with [Cursor](https://cursor.com)