### PR TITLE
fix(security): keep bridge credentials out of remote argv

### DIFF
--- a/packages/adapter-utils/src/sandbox-callback-bridge.test.ts
+++ b/packages/adapter-utils/src/sandbox-callback-bridge.test.ts
@@ -114,7 +114,7 @@ describe("sandbox callback bridge", () => {
     }
   });
 
-  it("round-trips localhost bridge requests over the sandbox queue without forwarding the bridge token", async () => {
+  it("round-trips bridge requests without putting the bridge credential in spawned argv", async () => {
     const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-bridge-runtime-"));
     cleanupDirs.push(rootDir);
 
@@ -124,7 +124,14 @@ describe("sandbox callback bridge", () => {
     await mkdir(remoteWorkspaceDir, { recursive: true });
     await writeFile(path.join(localWorkspaceDir, "README.md"), "bridge test\n", "utf8");
 
-    const runner = createExecRunner();
+    const delegateRunner = createExecRunner();
+    const runnerInputs: Array<Parameters<typeof delegateRunner.execute>[0]> = [];
+    const runner = {
+      execute: async (input: Parameters<typeof delegateRunner.execute>[0]) => {
+        runnerInputs.push(input);
+        return await delegateRunner.execute(input);
+      },
+    };
 
     const bridgeAsset = await createSandboxCallbackBridgeAsset();
     cleanupFns.push(bridgeAsset.cleanup);
@@ -147,7 +154,7 @@ describe("sandbox callback bridge", () => {
 
     const queueDir = path.posix.join(prepared.runtimeRootDir, "paperclip-bridge");
     const directories = sandboxCallbackBridgeDirectories(queueDir);
-    const bridgeToken = createSandboxCallbackBridgeToken();
+    const bridgeToken = "paperclip-bridge-argv-sentinel";
     const seenRequests: Array<{
       method: string;
       path: string;
@@ -199,6 +206,13 @@ describe("sandbox callback bridge", () => {
     cleanupFns.push(async () => {
       await bridge.stop();
     });
+
+    const bridgeStartInput = runnerInputs.find((input) => input.stdin === `${bridgeToken}\n`);
+    expect(bridgeStartInput).toBeDefined();
+    expect(JSON.stringify([bridgeStartInput!.command, ...(bridgeStartInput!.args ?? [])])).not.toContain(
+      bridgeToken,
+    );
+    expect(JSON.stringify(bridgeStartInput!.env ?? {})).not.toContain(bridgeToken);
 
     const okResponse = await fetch(`${bridge.baseUrl}/api/agents/me?view=compact`, {
       headers: {

--- a/packages/adapter-utils/src/sandbox-callback-bridge.ts
+++ b/packages/adapter-utils/src/sandbox-callback-bridge.ts
@@ -312,7 +312,7 @@ export function sandboxCallbackBridgeDirectories(rootDir: string): SandboxCallba
 
 export function buildSandboxCallbackBridgeEnv(input: {
   queueDir: string;
-  bridgeToken: string;
+  bridgeToken?: string;
   host?: string;
   port?: number | null;
   pollIntervalMs?: number | null;
@@ -323,7 +323,7 @@ export function buildSandboxCallbackBridgeEnv(input: {
   return {
     PAPERCLIP_API_BRIDGE_MODE: "queue_v1",
     PAPERCLIP_BRIDGE_QUEUE_DIR: input.queueDir,
-    PAPERCLIP_BRIDGE_TOKEN: input.bridgeToken,
+    ...(input.bridgeToken ? { PAPERCLIP_BRIDGE_TOKEN: input.bridgeToken } : {}),
     PAPERCLIP_BRIDGE_HOST: input.host?.trim() || "127.0.0.1",
     PAPERCLIP_BRIDGE_PORT: String(input.port && input.port > 0 ? Math.trunc(input.port) : 0),
     PAPERCLIP_BRIDGE_POLL_INTERVAL_MS: String(
@@ -904,7 +904,6 @@ export async function startSandboxCallbackBridgeServer(input: {
   }
   const env = buildSandboxCallbackBridgeEnv({
     queueDir: input.queueDir,
-    bridgeToken: input.bridgeToken,
     host: input.host,
     port: input.port,
     pollIntervalMs: input.pollIntervalMs,
@@ -912,7 +911,6 @@ export async function startSandboxCallbackBridgeServer(input: {
     maxQueueDepth: input.maxQueueDepth,
     maxBodyBytes: input.maxBodyBytes,
   });
-  delete env.PAPERCLIP_BRIDGE_TOKEN;
   const nodeCommand = input.nodeCommand?.trim() || "node";
   const startResult = await input.runner.execute({
     command: shellCommand,

--- a/packages/adapter-utils/src/sandbox-callback-bridge.ts
+++ b/packages/adapter-utils/src/sandbox-callback-bridge.ts
@@ -912,6 +912,7 @@ export async function startSandboxCallbackBridgeServer(input: {
     maxQueueDepth: input.maxQueueDepth,
     maxBodyBytes: input.maxBodyBytes,
   });
+  delete env.PAPERCLIP_BRIDGE_TOKEN;
   const nodeCommand = input.nodeCommand?.trim() || "node";
   const startResult = await input.runner.execute({
     command: shellCommand,
@@ -919,6 +920,8 @@ export async function startSandboxCallbackBridgeServer(input: {
       [
         `mkdir -p ${shellQuote(directories.requestsDir)} ${shellQuote(directories.responsesDir)} ${shellQuote(directories.logsDir)}`,
         `rm -f ${shellQuote(directories.readyFile)} ${shellQuote(directories.pidFile)}`,
+        "IFS= read -r PAPERCLIP_BRIDGE_TOKEN",
+        "export PAPERCLIP_BRIDGE_TOKEN",
         `nohup ${shellQuote(nodeCommand)} ${shellQuote(remoteEntrypoint)} ` +
           `>> ${shellQuote(directories.logFile)} 2>&1 < /dev/null &`,
         "pid=$!",
@@ -931,6 +934,7 @@ export async function startSandboxCallbackBridgeServer(input: {
       [SANDBOX_EXEC_CHANNEL_ENV]: SANDBOX_EXEC_CHANNEL_BRIDGE,
       ...env,
     },
+    stdin: `${input.bridgeToken}\n`,
     timeoutMs,
   });
   requireSuccessfulResult("start sandbox callback bridge", startResult);


### PR DESCRIPTION
## Thinking Path

> - Paperclip manages AI agents that may execute through remote sandbox providers
> - Remote bridge processes need a short-lived credential to authorize callbacks without receiving the host API token
> - Command-managed runners can serialize environment assignments into a shell command's process arguments
> - Passing the bridge credential in the runner environment can therefore expose it through process inspection and persisted command logs
> - This pull request delivers the credential over stdin and exports it only inside the remote launcher before spawning the bridge
> - The benefit is a smaller credential exposure surface without changing bridge authorization or lifecycle behavior

## Linked Issues or Issue Description

### What happened
Remote sandbox bridge startup passed its per-bridge credential through the command runner environment. SSH-style or provider-backed runners may serialize those environment values into process argv or command records.

### Expected behavior
No bearer, JWT, or bridge credential value should appear in local or remote process arguments. The detached bridge should still inherit its short-lived credential, authorize callback requests, and tear down normally.

### Steps to reproduce
1. Start a command-managed sandbox callback bridge with a sentinel bridge credential.
2. Inspect the command and argument vector passed to the runner.
3. On runners that serialize environment assignments, observe that the credential can become part of the launched command record.

### Version / deployment mode
Reproduced against `master` at `5d42382df` in command-managed remote sandbox bridge mode. The host API credential remains host-side; this change concerns only the per-bridge credential.

## What Changed

- Removed `PAPERCLIP_BRIDGE_TOKEN` from the command runner environment used for bridge startup.
- Sent the short-lived token over stdin, then read and exported it inside the remote shell before launching the detached bridge.
- Added a sentinel regression assertion proving the spawned command/arguments and runner environment do not contain the credential while the authorization round-trip and teardown test still pass.

## Verification

- `npx --yes pnpm@9.15.4 exec vitest run packages/adapter-utils/src/sandbox-callback-bridge.test.ts` — 13 tests passed.
- `npx --yes pnpm@9.15.4 --filter @paperclipai/adapter-utils typecheck` — passed.

## Risks

- Low risk: the change relies on the existing `CommandManagedRuntimeRunner.stdin` contract already implemented by sandbox providers.
- A provider that silently drops stdin will fail bridge readiness rather than start without authentication.
- No credential file is created, so there is no new cleanup or permissions surface.

## Model Used

- OpenAI GPT-5.6 Sol with reasoning, repository tool use, and code execution. Context window size was not disclosed by the runtime.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] Documentation impact considered; no public API or operator workflow changed
- [x] I have considered and documented risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

Made with [Cursor](https://cursor.com)