### PR TITLE
fix: publish database backups atomically

### DIFF
--- a/packages/db/src/backup-lib.test.ts
+++ b/packages/db/src/backup-lib.test.ts
@@ -76,6 +76,42 @@ describe("createBufferedTextFileWriter", () => {
 
 describeEmbeddedPostgres("runDatabaseBackup", () => {
   it(
+    "does not publish an archive when pg_dump fails after producing output",
+    async () => {
+      const connectionString = await createTempDatabase();
+      const backupDir = createTempDir("paperclip-db-atomic-backup-");
+      const scriptDir = createTempDir("paperclip-failing-pg-dump-");
+      const fakePgDump = path.join(scriptDir, "pg_dump");
+      fs.writeFileSync(
+        fakePgDump,
+        "#!/bin/sh\nprintf '%s\\n' '-- interrupted database dump'\nexit 17\n",
+        { mode: 0o755 },
+      );
+      const originalPgDumpPath = process.env.PAPERCLIP_PG_DUMP_PATH;
+      process.env.PAPERCLIP_PG_DUMP_PATH = fakePgDump;
+
+      try {
+        await expect(runDatabaseBackup({
+          connectionString,
+          backupDir,
+          retention: { dailyDays: 7, weeklyWeeks: 4, monthlyMonths: 1 },
+          filenamePrefix: "paperclip-atomic-test",
+          backupEngine: "pg_dump",
+        })).rejects.toThrow("exit code 17");
+
+        expect(fs.readdirSync(backupDir)).toEqual([]);
+      } finally {
+        if (originalPgDumpPath === undefined) {
+          delete process.env.PAPERCLIP_PG_DUMP_PATH;
+        } else {
+          process.env.PAPERCLIP_PG_DUMP_PATH = originalPgDumpPath;
+        }
+      }
+    },
+    20_000,
+  );
+
+  it(
     "backs up and restores large table payloads without materializing one giant string",
     async () => {
       const sourceConnectionString = await createTempDatabase();

--- a/packages/db/src/backup-lib.ts
+++ b/packages/db/src/backup-lib.ts
@@ -354,8 +354,13 @@ async function runPgDumpBackup(opts: {
     pipeline(child.stdout, createGzip(), createWriteStream(opts.outputFile)),
     waitForChildExit(child, pgDumpBin),
   ]);
-  const failure = results.find((result): result is PromiseRejectedResult => result.status === "rejected");
-  if (failure) throw failure.reason;
+  const failures = results
+    .filter((result): result is PromiseRejectedResult => result.status === "rejected")
+    .map((result) => result.reason);
+  if (failures.length === 1) throw failures[0];
+  if (failures.length > 1) {
+    throw new AggregateError(failures, `${pgDumpBin} backup failed in multiple ways`);
+  }
 }
 
 async function restoreWithPsql(opts: RunDatabaseRestoreOptions, connectTimeout: number): Promise<void> {

--- a/packages/db/src/backup-lib.ts
+++ b/packages/db/src/backup-lib.ts
@@ -1,4 +1,14 @@
-import { createReadStream, createWriteStream, existsSync, mkdirSync, readdirSync, statSync, unlinkSync } from "node:fs";
+import {
+  createReadStream,
+  createWriteStream,
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  renameSync,
+  statSync,
+  unlinkSync,
+} from "node:fs";
+import { randomUUID } from "node:crypto";
 import { basename, resolve } from "node:path";
 import { createInterface } from "node:readline";
 import { spawn } from "node:child_process";
@@ -313,7 +323,7 @@ async function waitForChildExit(child: ReturnType<typeof spawn>, label: string):
 
 async function runPgDumpBackup(opts: {
   connectionString: string;
-  backupFile: string;
+  outputFile: string;
   connectTimeout: number;
 }): Promise<void> {
   const pgDumpBin = process.env.PAPERCLIP_PG_DUMP_PATH || "pg_dump";
@@ -340,10 +350,12 @@ async function runPgDumpBackup(opts: {
     throw new Error("pg_dump did not expose stdout");
   }
 
-  await Promise.all([
-    pipeline(child.stdout, createGzip(), createWriteStream(opts.backupFile)),
+  const results = await Promise.allSettled([
+    pipeline(child.stdout, createGzip(), createWriteStream(opts.outputFile)),
     waitForChildExit(child, pgDumpBin),
   ]);
+  const failure = results.find((result): result is PromiseRejectedResult => result.status === "rejected");
+  if (failure) throw failure.reason;
 }
 
 async function restoreWithPsql(opts: RunDatabaseRestoreOptions, connectTimeout: number): Promise<void> {
@@ -534,8 +546,10 @@ export async function runDatabaseBackup(opts: RunDatabaseBackupOptions): Promise
     await sql.end();
   };
   mkdirSync(opts.backupDir, { recursive: true });
-  const sqlFile = resolve(opts.backupDir, `${filenamePrefix}-${timestamp()}.sql`);
-  const backupFile = `${sqlFile}.gz`;
+  const backupFile = resolve(opts.backupDir, `${filenamePrefix}-${timestamp()}.sql.gz`);
+  const temporarySuffix = randomUUID();
+  const sqlFile = resolve(opts.backupDir, `.${basename(backupFile)}.${temporarySuffix}.sql.tmp`);
+  const compressedFile = resolve(opts.backupDir, `.${basename(backupFile)}.${temporarySuffix}.tmp`);
   const writer = createBufferedTextFileWriter(sqlFile);
 
   try {
@@ -545,9 +559,10 @@ export async function runDatabaseBackup(opts: RunDatabaseBackupOptions): Promise
         await closeSql();
         await runPgDumpBackup({
           connectionString: opts.connectionString,
-          backupFile,
+          outputFile: compressedFile,
           connectTimeout,
         });
+        renameSync(compressedFile, backupFile);
         await writer.abort();
         const sizeBytes = statSync(backupFile).size;
         const prunedCount = pruneOldBackups(opts.backupDir, retention, filenamePrefix);
@@ -557,8 +572,8 @@ export async function runDatabaseBackup(opts: RunDatabaseBackupOptions): Promise
           prunedCount,
         };
       } catch (error) {
-        if (existsSync(backupFile)) {
-          try { unlinkSync(backupFile); } catch { /* ignore */ }
+        if (existsSync(compressedFile)) {
+          try { unlinkSync(compressedFile); } catch { /* ignore */ }
         }
         if (backupEngine === "pg_dump") {
           throw error;
@@ -957,9 +972,10 @@ export async function runDatabaseBackup(opts: RunDatabaseBackupOptions): Promise
 
     // Compress the SQL file with gzip
     const sqlReadStream = createReadStream(sqlFile);
-    const gzWriteStream = createWriteStream(backupFile);
+    const gzWriteStream = createWriteStream(compressedFile);
     await pipeline(sqlReadStream, createGzip(), gzWriteStream);
     unlinkSync(sqlFile);
+    renameSync(compressedFile, backupFile);
 
     const sizeBytes = statSync(backupFile).size;
     const prunedCount = pruneOldBackups(opts.backupDir, retention, filenamePrefix);
@@ -971,8 +987,8 @@ export async function runDatabaseBackup(opts: RunDatabaseBackupOptions): Promise
     };
   } catch (error) {
     await writer.abort();
-    if (existsSync(backupFile)) {
-      try { unlinkSync(backupFile); } catch { /* ignore */ }
+    if (existsSync(compressedFile)) {
+      try { unlinkSync(compressedFile); } catch { /* ignore */ }
     }
     if (existsSync(sqlFile)) {
       try { unlinkSync(sqlFile); } catch { /* ignore */ }

--- a/server/src/__tests__/health.test.ts
+++ b/server/src/__tests__/health.test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { gzipSync } from "node:zlib";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import express from "express";
 import request from "supertest";
@@ -166,6 +167,34 @@ describe("GET /health", () => {
       ],
     });
     expect(res.body.warnings).toEqual(res.body.databaseBackup.warnings);
+  });
+
+  it("surfaces a dedicated warning for a valid empty gzip backup", async () => {
+    const backupDir = fs.mkdtempSync(path.join(os.tmpdir(), "paperclip-health-empty-backup-"));
+    const backupFile = path.join(backupDir, "paperclip-20260706-031702.sql.gz");
+    fs.writeFileSync(backupFile, gzipSync(""));
+    const app = createApp(createHealthyDb(), testServerInfo, {
+      enabled: true,
+      backupDir,
+      maxAgeHours: 26,
+      now: new Date(),
+    });
+
+    const res = await request(app).get("/health");
+
+    expect(res.status).toBe(200);
+    expect(res.body.databaseBackup).toMatchObject({
+      status: "warning",
+      latestBackup: {
+        name: "paperclip-20260706-031702.sql.gz",
+      },
+      warnings: [
+        {
+          code: "database_backup_empty",
+          message: "Latest database backup is a valid gzip archive with no uncompressed data.",
+        },
+      ],
+    });
   });
 
   it("surfaces database backup failure markers in full health details", async () => {

--- a/server/src/routes/health.ts
+++ b/server/src/routes/health.ts
@@ -38,6 +38,7 @@ function hasDevServerStatusToken(providedToken: string | undefined) {
 function redactedDatabaseBackupWarning(warning: DatabaseBackupHealthWarning): DatabaseBackupHealthWarning {
   const messages: Record<DatabaseBackupHealthWarning["code"], string> = {
     database_backup_check_failed: "Database backup health check failed.",
+    database_backup_empty: "Latest database backup contains no data.",
     database_backup_last_failure: "Database backup failure marker is present.",
     database_backup_missing: "No recent database backup was found.",
     database_backup_stale: "Latest database backup is stale.",

--- a/server/src/services/database-backup-health.ts
+++ b/server/src/services/database-backup-health.ts
@@ -1,8 +1,10 @@
-import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { closeSync, existsSync, openSync, readFileSync, readSync, readdirSync, statSync } from "node:fs";
 import { basename, join, resolve } from "node:path";
+import { gunzipSync } from "node:zlib";
 
 export type DatabaseBackupHealthWarningCode =
   | "database_backup_check_failed"
+  | "database_backup_empty"
   | "database_backup_last_failure"
   | "database_backup_missing"
   | "database_backup_stale";
@@ -102,6 +104,25 @@ function findLatestBackup(backupDir: string, nowMs: number) {
   };
 }
 
+function isValidEmptyGzip(filePath: string, sizeBytes: number): boolean {
+  if (sizeBytes < 18) return false;
+
+  const trailer = Buffer.allocUnsafe(4);
+  const fd = openSync(filePath, "r");
+  try {
+    readSync(fd, trailer, 0, trailer.length, sizeBytes - trailer.length);
+  } finally {
+    closeSync(fd);
+  }
+  if (trailer.readUInt32LE(0) !== 0) return false;
+
+  try {
+    return gunzipSync(readFileSync(filePath), { maxOutputLength: 1 }).length === 0;
+  } catch {
+    return false;
+  }
+}
+
 export function inspectDatabaseBackupHealth(
   opts: InspectDatabaseBackupHealthOptions,
 ): DatabaseBackupHealthStatus {
@@ -121,11 +142,19 @@ export function inspectDatabaseBackupHealth(
         code: "database_backup_missing",
         message: `No .sql.gz database backups found in ${opts.backupDir}.`,
       });
-    } else if (latestBackup.ageHours > maxAgeHours) {
-      warnings.push({
-        code: "database_backup_stale",
-        message: `Latest database backup is ${latestBackup.ageHours}h old, exceeding ${maxAgeHours}h.`,
-      });
+    } else {
+      if (isValidEmptyGzip(latestBackup.path, latestBackup.sizeBytes)) {
+        warnings.push({
+          code: "database_backup_empty",
+          message: "Latest database backup is a valid gzip archive with no uncompressed data.",
+        });
+      }
+      if (latestBackup.ageHours > maxAgeHours) {
+        warnings.push({
+          code: "database_backup_stale",
+          message: `Latest database backup is ${latestBackup.ageHours}h old, exceeding ${maxAgeHours}h.`,
+        });
+      }
     }
 
     if (lastFailure) {


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source control plane people use to manage AI-agent companies
> - Reliable logical database backups protect the control-plane state those companies depend on
> - Backup generation currently writes directly to the final `.sql.gz` path while compression is still running
> - A failed or interrupted producer can therefore leave an incomplete archive that looks published
> - Health checks also treat a valid gzip containing zero uncompressed bytes as healthy when it is fresh
> - This pull request stages both backup engines in unique same-directory files, atomically renames only completed output, and adds a dedicated empty-backup warning
> - The benefit is that operators and retention logic only see completed archives and can distinguish empty backup artifacts immediately

## Linked Issues or Issue Description

### What happened?

Interrupted `pg_dump` or JavaScript compression can expose a partial final archive; a valid empty gzip is not identified as unusable.

### Expected behavior

Final backup filenames appear only after successful compression and process exit, temporary output is removed on handled failures, and empty valid gzip archives produce a dedicated warning.

### Steps to reproduce

Start a backup with a dump producer that writes partial stdout and exits non-zero, then inspect the backup directory; separately place `gzipSync(\"\")` at the newest `.sql.gz` path and query health.

### Paperclip version or commit

`master` at `5d42382d`.

### Deployment mode

All modes using logical database backups.
- GitHub duplicate search found no related open issue or pull request.

## What Changed

- Stage gzip output for both `pg_dump` and JavaScript backup engines in unique files beside the destination, then rename after successful completion.
- Wait for both the `pg_dump` child and compression pipeline to settle and clean staged output on failure without deleting an existing final archive.
- Detect syntactically valid gzip archives with zero uncompressed bytes and expose `database_backup_empty`, including redacted health output.
- Add regressions for failed `pg_dump` publication and valid empty-gzip health classification.

## Verification

- `pnpm exec vitest run packages/db/src/backup-lib.test.ts server/src/__tests__/health.test.ts`
- Result: 2 test files passed; 19 tests passed.

## Risks

- Low risk. Final filenames, retention matching, and restore format remain unchanged. Atomic rename depends on staging in the destination directory, which this change guarantees.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI GPT-5.6 Sol with tool-assisted reasoning and code execution; context-window size is not exposed by the runtime.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

Made with [Cursor](https://cursor.com)