### PR TITLE
feat(security): quarantine credential-shaped transcript content

### DIFF
--- a/doc/DEVELOPING.md
+++ b/doc/DEVELOPING.md
@@ -706,6 +706,35 @@ PAPERCLIP_SECRETS_STRICT_MODE=true
 When strict mode is enabled, sensitive env keys (for example `*_API_KEY`, `*_TOKEN`, `*_SECRET`) must use secret references instead of inline plain values.
 Authenticated deployments default strict mode on unless explicitly overridden.
 
+### Transcript credential quarantine
+
+Paperclip scans heartbeat run logs, structured run events, and persisted run
+summaries for credential-shaped content before storage. Matches are replaced
+with explicit redaction markers, marked as quarantined in the safe persisted
+representation, and recorded as metadata-only
+`heartbeat_run.transcript_credential_quarantined` activity events. The event
+contains the boundary, detector version, disposition, match count, record type,
+and stream; it never contains the matched value. Run-detail, event, and log
+responses apply the same redaction again when rendering diagnostics so legacy
+records are covered.
+
+Treat a suspected false positive as a detector issue, not as permission to put
+the original value back into a transcript. Reproduce with a synthetic value,
+inspect the metadata-only activity event, and narrow the detector with a
+regression test. Quarantined source text is intentionally not retained, so it
+cannot be restored from Paperclip.
+
+Emergency rollback can disable quarantine markers while preserving mandatory
+capture-time redaction:
+
+```sh
+PAPERCLIP_TRANSCRIPT_CREDENTIAL_QUARANTINE=false
+```
+
+Restart the server after changing the setting. Remove the override after the
+false-positive detector fix is deployed. There is no supported switch that
+persists unredacted credential-shaped transcript content.
+
 CLI configuration support:
 
 - `pnpm paperclipai onboard` writes a default `secrets` config section (`local_encrypted`, strict mode off, key file path set) and creates a local key file when needed.

--- a/doc/TRANSCRIPT_RETENTION.md
+++ b/doc/TRANSCRIPT_RETENTION.md
@@ -1,0 +1,87 @@
+# Transcript retention operations
+
+Paperclip raw run logs, Cursor adapter transcripts, and transcript-derived
+database content have a seven-day primary-store retention period. Database
+backups remain restricted disaster-recovery copies for their separately
+approved 30-day window.
+
+## Safety model
+
+- The utility is a dry-run unless `--apply` is passed.
+- Only Paperclip runs with a recognized terminal status and an unambiguous
+  `finished_at` older than the single UTC cutoff are eligible.
+- Queued, running, scheduled-retry, held, and terminal runs without
+  `finished_at` are excluded.
+- An active Paperclip issue-tree hold protects runs linked to that issue.
+  Additional run IDs can be held with the comma-separated
+  `PAPERCLIP_TRANSCRIPT_RETENTION_HOLD_RUN_IDS` environment variable.
+- Cursor files are deleted only when their UUID matches an eligible run's
+  recorded session/external-run ID and no active, recent, held, or ambiguous
+  run references the same session.
+- A file whose modification time is newer than the cutoff fails closed: the
+  sweep reports a partial result and preserves that run's database content and
+  pointers for investigation.
+- Logs contain counts, bytes, cutoff, exclusions, and failures only. They never
+  contain transcript content.
+
+## Dry-run and enforcement
+
+From the repository root:
+
+```bash
+pnpm transcripts:retention
+pnpm transcripts:retention -- --apply
+```
+
+The apply operation first proves that the current service identity owns and can
+read/write each transcript root. It then changes sensitive ancestors and
+directories to `0700`, files to `0600`, and writes the prior modes to:
+
+```text
+~/.paperclip/instances/default/data/retention/permissions-rollback-*.json
+```
+
+Only after those checks does it delete approved old files and scrub
+`heartbeat_runs.result_json`, stdout/stderr excerpts, and run-event
+message/payload content. Status, timing, usage, cost, liveness, log size/hash,
+and event type metadata remain. Each database sweep appends a content-free
+`transcript_retention_sweep` activity record.
+
+## Verification
+
+Success output must show:
+
+- the exact cutoff and seven-day policy;
+- zero failures;
+- counts and bytes for deleted raw stores;
+- active, held, and ambiguous exclusions;
+- a permissions rollback file.
+
+Re-run the dry-run after apply. Successfully scrubbed runs are no longer
+eligible; any remaining eligible run indicates retained content or a partial
+operation and must be investigated before treating the sweep as complete.
+
+## Rollback and recovery
+
+Stop the timer before rollback:
+
+```bash
+systemctl --user disable --now paperclip-transcript-retention.timer
+```
+
+Permission changes are reversible:
+
+```bash
+pnpm transcripts:retention -- --restore-permissions \
+  ~/.paperclip/instances/default/data/retention/permissions-rollback-<timestamp>.json
+```
+
+Restore only the recorded modes. Do not broadly change files back to
+`0644/0755`.
+
+Deletion of primary transcript content is intentionally irreversible. A
+database disaster restore may reintroduce transcript-derived database fields
+from the restricted 30-day backup window. Keep the restored service isolated
+and owner-only, then run `pnpm transcripts:retention -- --apply` before normal
+service access resumes. Database backups do not restore deleted Paperclip raw
+logs or Cursor transcript files.

--- a/doc/TRANSCRIPT_RETENTION.md
+++ b/doc/TRANSCRIPT_RETENTION.md
@@ -9,7 +9,10 @@ approved 30-day window.
 
 - The utility is a dry-run unless `--apply` is passed.
 - Only Paperclip runs with a recognized terminal status and an unambiguous
-  `finished_at` older than the single UTC cutoff are eligible.
+  `finished_at` older than the single UTC cutoff are eligible. The database
+  query filters on those status and `finished_at` predicates before loading
+  candidate rows, and only pulls nullability / session metadata rather than
+  full `result_json` or `context_snapshot` payloads.
 - Queued, running, scheduled-retry, held, and terminal runs without
   `finished_at` are excluded.
 - An active Paperclip issue-tree hold protects runs linked to that issue.

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "db:migrate": "pnpm --filter @paperclipai/db migrate",
     "issue-references:backfill": "pnpm run preflight:workspace-links && tsx scripts/backfill-issue-reference-mentions.ts",
     "secrets:migrate-inline-env": "tsx scripts/migrate-inline-env-secrets.ts",
+    "transcripts:retention": "node server/node_modules/tsx/dist/cli.mjs scripts/transcript-retention.ts",
     "db:backup": "./scripts/backup-db.sh",
     "paperclipai": "node cli/node_modules/tsx/dist/cli.mjs cli/src/index.ts",
     "build:npm": "./scripts/build-npm.sh",

--- a/scripts/transcript-retention.ts
+++ b/scripts/transcript-retention.ts
@@ -1,0 +1,498 @@
+#!/usr/bin/env node
+import { randomUUID } from "node:crypto";
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { and, eq, inArray, isNotNull, or } from "../packages/db/node_modules/drizzle-orm/index.js";
+import {
+  activityLog,
+  createDb,
+  heartbeatRunEvents,
+  heartbeatRuns,
+  issueTreeHoldMembers,
+  issueTreeHolds,
+} from "../packages/db/src/index.ts";
+import { resolveMigrationConnection } from "../packages/db/src/migration-runtime.ts";
+
+const RETENTION_DAYS = 7;
+const TERMINAL_STATUSES = new Set(["succeeded", "interrupted", "failed", "cancelled", "timed_out"]);
+const LIVE_STATUSES = new Set(["queued", "running", "scheduled_retry"]);
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const APPLY = process.argv.includes("--apply");
+const RESTORE_INDEX = process.argv.indexOf("--restore-permissions");
+
+type ModeRecord = { path: string; mode: number; targetMode?: number };
+type RunRow = {
+  id: string;
+  companyId: string;
+  status: string;
+  finishedAt: Date | null;
+  logRef: string | null;
+  resultJson: Record<string, unknown> | null;
+  stdoutExcerpt: string | null;
+  stderrExcerpt: string | null;
+  sessionIdBefore: string | null;
+  sessionIdAfter: string | null;
+  externalRunId: string | null;
+  contextSnapshot: Record<string, unknown> | null;
+};
+
+function modeOf(mode: number) {
+  return mode & 0o777;
+}
+
+function issueIdFromContext(context: Record<string, unknown> | null) {
+  const candidate = context?.issueId ?? context?.taskId;
+  return typeof candidate === "string" && candidate.length > 0 ? candidate : null;
+}
+
+function sessionIds(run: RunRow) {
+  return [run.sessionIdBefore, run.sessionIdAfter, run.externalRunId].filter(
+    (value): value is string => typeof value === "string" && UUID.test(value),
+  );
+}
+
+function isWithin(root: string, candidate: string) {
+  const resolvedRoot = path.resolve(root);
+  const resolvedCandidate = path.resolve(candidate);
+  return resolvedCandidate === resolvedRoot || resolvedCandidate.startsWith(`${resolvedRoot}${path.sep}`);
+}
+
+async function walkFiles(root: string): Promise<string[]> {
+  const files: string[] = [];
+  const pending = [root];
+  while (pending.length > 0) {
+    const current = pending.pop()!;
+    const entries = await fs.readdir(current, { withFileTypes: true }).catch((error: NodeJS.ErrnoException) => {
+      if (error.code === "ENOENT") return [];
+      throw error;
+    });
+    for (const entry of entries) {
+      const candidate = path.join(current, entry.name);
+      if (entry.isSymbolicLink()) continue;
+      if (entry.isDirectory()) pending.push(candidate);
+      else if (entry.isFile()) files.push(candidate);
+    }
+  }
+  return files;
+}
+
+async function inventory(root: string, suffix?: string) {
+  const files = (await walkFiles(root)).filter((file) => !suffix || file.endsWith(suffix));
+  return summarizeFiles(files);
+}
+
+async function summarizeFiles(files: string[]) {
+  let bytes = 0;
+  let nonOwnerOnly = 0;
+  for (const file of files) {
+    const stat = await fs.stat(file);
+    bytes += stat.size;
+    if (modeOf(stat.mode) !== 0o600) nonOwnerOnly++;
+  }
+  return { files, count: files.length, bytes, nonOwnerOnly };
+}
+
+async function recordModeChange(candidate: string, desiredMode: number, rollback: ModeRecord[]) {
+  const stat = await fs.lstat(candidate).catch((error: NodeJS.ErrnoException) => {
+    if (error.code === "ENOENT") return null;
+    throw error;
+  });
+  if (!stat || stat.isSymbolicLink()) return;
+  const currentMode = modeOf(stat.mode);
+  if (currentMode === desiredMode) return;
+  rollback.push({ path: candidate, mode: currentMode, targetMode: desiredMode });
+}
+
+async function hardenTree(root: string, rollback: ModeRecord[]) {
+  const stat = await fs.lstat(root).catch(() => null);
+  if (!stat || stat.isSymbolicLink()) return;
+  await recordModeChange(root, 0o700, rollback);
+  const pending = [root];
+  while (pending.length > 0) {
+    const current = pending.pop()!;
+    for (const entry of await fs.readdir(current, { withFileTypes: true })) {
+      const candidate = path.join(current, entry.name);
+      if (entry.isSymbolicLink()) continue;
+      if (entry.isDirectory()) {
+        await recordModeChange(candidate, 0o700, rollback);
+        pending.push(candidate);
+      } else if (entry.isFile()) {
+        await recordModeChange(candidate, 0o600, rollback);
+      }
+    }
+  }
+}
+
+async function hardenAncestors(home: string, root: string, rollback: ModeRecord[]) {
+  if (!isWithin(home, root)) throw new Error(`Refusing to chmod path outside home: ${root}`);
+  let current = path.resolve(root);
+  const paths: string[] = [];
+  while (current !== path.resolve(home)) {
+    paths.push(current);
+    current = path.dirname(current);
+  }
+  for (const candidate of paths.reverse()) {
+    await recordModeChange(candidate, 0o700, rollback);
+  }
+}
+
+async function applyModePlan(rollback: ModeRecord[]) {
+  for (const entry of rollback) {
+    if (entry.targetMode !== 0o600 && entry.targetMode !== 0o700) {
+      throw new Error(`Invalid target mode for ${entry.path}`);
+    }
+    await fs.chmod(entry.path, entry.targetMode);
+  }
+}
+
+async function writeRollbackState(retentionRoot: string, rollback: ModeRecord[], cutoff: Date) {
+  await fs.mkdir(retentionRoot, { recursive: true, mode: 0o700 });
+  await fs.chmod(retentionRoot, 0o700);
+  const stamp = new Date().toISOString().replaceAll(":", "").replaceAll(".", "");
+  const target = path.join(retentionRoot, `permissions-rollback-${stamp}.json`);
+  const temporary = `${target}.tmp`;
+  await fs.writeFile(
+    temporary,
+    `${JSON.stringify({ version: 1, cutoff: cutoff.toISOString(), createdAt: new Date().toISOString(), entries: rollback }, null, 2)}\n`,
+    { encoding: "utf8", mode: 0o600 },
+  );
+  await fs.rename(temporary, target);
+  return target;
+}
+
+async function restorePermissions(file: string) {
+  const parsed = JSON.parse(await fs.readFile(file, "utf8")) as { entries?: ModeRecord[] };
+  if (!Array.isArray(parsed.entries)) throw new Error("Invalid permissions rollback file");
+  let restored = 0;
+  for (const entry of [...parsed.entries].reverse()) {
+    if (!entry || typeof entry.path !== "string" || typeof entry.mode !== "number") {
+      throw new Error("Invalid permissions rollback entry");
+    }
+    await fs.chmod(entry.path, entry.mode).catch((error: NodeJS.ErrnoException) => {
+      if (error.code !== "ENOENT") throw error;
+    });
+    restored++;
+  }
+  console.log(JSON.stringify({ mode: "restore-permissions", rollbackFile: file, restored }));
+}
+
+async function probeServiceAccess(roots: string[]) {
+  for (const root of roots) {
+    const stat = await fs.stat(root).catch(() => null);
+    if (!stat) continue;
+    if (typeof process.getuid === "function" && stat.uid !== process.getuid()) {
+      throw new Error(`Service identity does not own ${root}`);
+    }
+    const probe = path.join(root, `.retention-access-probe-${process.pid}-${randomUUID()}`);
+    await fs.writeFile(probe, "probe\n", { encoding: "utf8", mode: 0o600 });
+    await fs.readFile(probe, "utf8");
+    await fs.unlink(probe);
+  }
+}
+
+async function removeApprovedFile(file: string, root: string, cutoffMs: number) {
+  if (!isWithin(root, file)) throw new Error(`Refusing to delete path outside approved root: ${file}`);
+  const stat = await fs.lstat(file).catch((error: NodeJS.ErrnoException) => {
+    if (error.code === "ENOENT") return null;
+    throw error;
+  });
+  if (!stat) return { deleted: false, missing: true, bytes: 0 };
+  if (stat.isSymbolicLink()) throw new Error(`Refusing to delete symbolic link: ${file}`);
+  const [realRoot, realFile] = await Promise.all([fs.realpath(root), fs.realpath(file)]);
+  if (!isWithin(realRoot, realFile)) {
+    throw new Error(`Refusing to delete path outside real approved root: ${file}`);
+  }
+  if (stat.mtimeMs >= cutoffMs) return { deleted: false, missing: false, bytes: 0 };
+  await fs.unlink(file);
+  return { deleted: true, missing: false, bytes: stat.size };
+}
+
+async function runsWithPersistedEventContent(
+  db: ReturnType<typeof createDb>,
+  runIds: string[],
+) {
+  const result = new Set<string>();
+  for (let start = 0; start < runIds.length; start += 500) {
+    const batch = runIds.slice(start, start + 500);
+    const rows = await db
+      .select({ runId: heartbeatRunEvents.runId })
+      .from(heartbeatRunEvents)
+      .where(
+        and(
+          inArray(heartbeatRunEvents.runId, batch),
+          or(
+            isNotNull(heartbeatRunEvents.message),
+            isNotNull(heartbeatRunEvents.payload),
+          ),
+        ),
+      );
+    for (const row of rows) result.add(row.runId);
+  }
+  return result;
+}
+
+async function updateDatabase(
+  db: ReturnType<typeof createDb>,
+  runs: RunRow[],
+  cutoff: Date,
+  counts: Record<string, number>,
+) {
+  const ids = runs.map((run) => run.id);
+  for (let start = 0; start < ids.length; start += 500) {
+    const batch = ids.slice(start, start + 500);
+    await db.transaction(async (tx) => {
+      await tx
+        .update(heartbeatRuns)
+        .set({
+          resultJson: null,
+          stdoutExcerpt: null,
+          stderrExcerpt: null,
+          logStore: null,
+          logRef: null,
+          updatedAt: new Date(),
+        })
+        .where(inArray(heartbeatRuns.id, batch));
+      await tx
+        .update(heartbeatRunEvents)
+        .set({ message: null, payload: null })
+        .where(inArray(heartbeatRunEvents.runId, batch));
+    });
+  }
+
+  const byCompany = new Map<string, number>();
+  for (const run of runs) byCompany.set(run.companyId, (byCompany.get(run.companyId) ?? 0) + 1);
+  for (const [companyId, scrubbedRuns] of byCompany) {
+    await db.insert(activityLog).values({
+      companyId,
+      actorType: "system",
+      actorId: "transcript_retention",
+      action: "transcript_retention_sweep",
+      entityType: "company",
+      entityId: companyId,
+      details: {
+        cutoff: cutoff.toISOString(),
+        retentionDays: RETENTION_DAYS,
+        scrubbedRuns,
+        ...counts,
+        outcome: counts.failures > 0 ? "partial" : "succeeded",
+      },
+    });
+  }
+}
+
+async function main() {
+  if (RESTORE_INDEX >= 0) {
+    const rollbackFile = process.argv[RESTORE_INDEX + 1];
+    if (!rollbackFile) throw new Error("--restore-permissions requires a rollback file");
+    await restorePermissions(rollbackFile);
+    return;
+  }
+
+  const now = new Date();
+  const cutoff = new Date(now.getTime() - RETENTION_DAYS * 24 * 60 * 60 * 1_000);
+  const cutoffMs = cutoff.getTime();
+  const home = os.homedir();
+  const instanceRoot = path.resolve(
+    process.env.PAPERCLIP_INSTANCE_ROOT ?? path.join(home, ".paperclip", "instances", "default"),
+  );
+  const runLogRoot = path.join(instanceRoot, "data", "run-logs");
+  const backupRoot = path.join(instanceRoot, "data", "backups");
+  const retentionRoot = path.join(instanceRoot, "data", "retention");
+  const cursorProjectsRoot = path.join(home, ".cursor", "projects");
+
+  const connection = await resolveMigrationConnection();
+  const db = createDb(connection.connectionString);
+  try {
+    const runs = await db
+      .select({
+        id: heartbeatRuns.id,
+        companyId: heartbeatRuns.companyId,
+        status: heartbeatRuns.status,
+        finishedAt: heartbeatRuns.finishedAt,
+        logRef: heartbeatRuns.logRef,
+        resultJson: heartbeatRuns.resultJson,
+        stdoutExcerpt: heartbeatRuns.stdoutExcerpt,
+        stderrExcerpt: heartbeatRuns.stderrExcerpt,
+        sessionIdBefore: heartbeatRuns.sessionIdBefore,
+        sessionIdAfter: heartbeatRuns.sessionIdAfter,
+        externalRunId: heartbeatRuns.externalRunId,
+        contextSnapshot: heartbeatRuns.contextSnapshot,
+      })
+      .from(heartbeatRuns) as RunRow[];
+    const activeHoldMembers = await db
+      .select({ issueId: issueTreeHoldMembers.issueId })
+      .from(issueTreeHoldMembers)
+      .innerJoin(issueTreeHolds, eq(issueTreeHolds.id, issueTreeHoldMembers.holdId))
+      .where(and(eq(issueTreeHolds.status, "active"), eq(issueTreeHoldMembers.skipped, false)));
+    const heldIssueIds = new Set(activeHoldMembers.map((row) => row.issueId));
+    const explicitHeldRunIds = new Set(
+      (process.env.PAPERCLIP_TRANSCRIPT_RETENTION_HOLD_RUN_IDS ?? "")
+        .split(",")
+        .map((value) => value.trim())
+        .filter(Boolean),
+    );
+
+    const terminal = runs.filter((run) => TERMINAL_STATUSES.has(run.status));
+    const active = runs.filter((run) => LIVE_STATUSES.has(run.status));
+    const ambiguous = terminal.filter((run) => !run.finishedAt);
+    const oldTerminal = terminal.filter((run) => run.finishedAt && run.finishedAt.getTime() < cutoffMs);
+    const held = oldTerminal.filter(
+      (run) => explicitHeldRunIds.has(run.id) || heldIssueIds.has(issueIdFromContext(run.contextSnapshot) ?? ""),
+    );
+    const heldIds = new Set(held.map((run) => run.id));
+    const unheldOldTerminal = oldTerminal.filter((run) => !heldIds.has(run.id));
+    const eventContentRunIds = await runsWithPersistedEventContent(
+      db,
+      unheldOldTerminal.map((run) => run.id),
+    );
+
+    const [runLogs, cursorTranscripts, backups] = await Promise.all([
+      inventory(runLogRoot, ".ndjson"),
+      inventory(cursorProjectsRoot, ".jsonl"),
+      inventory(backupRoot),
+    ]);
+    const cursorTranscriptFiles = cursorTranscripts.files.filter((file) => {
+      const relative = path.relative(cursorProjectsRoot, file).split(path.sep);
+      return relative.length >= 4
+        && relative.at(-3) === "agent-transcripts"
+        && relative.at(-2) === path.basename(file, ".jsonl");
+    });
+    const cursorTranscriptInventory = await summarizeFiles(cursorTranscriptFiles);
+    const availableCursorSessionIds = new Set(
+      cursorTranscriptFiles.map((file) => path.basename(file, ".jsonl")),
+    );
+    const eligible = unheldOldTerminal.filter(
+      (run) =>
+        run.logRef !== null
+        || run.resultJson !== null
+        || run.stdoutExcerpt !== null
+        || run.stderrExcerpt !== null
+        || eventContentRunIds.has(run.id)
+        || sessionIds(run).some((sessionId) => availableCursorSessionIds.has(sessionId)),
+    );
+    const eligibleIds = new Set(eligible.map((run) => run.id));
+    const protectedSessions = new Set(runs.filter((run) => !eligibleIds.has(run.id)).flatMap(sessionIds));
+    const eligibleSessions = new Map<string, Set<string>>();
+    for (const run of eligible) {
+      for (const sessionId of sessionIds(run)) {
+        if (protectedSessions.has(sessionId)) continue;
+        const runIds = eligibleSessions.get(sessionId) ?? new Set<string>();
+        runIds.add(run.id);
+        eligibleSessions.set(sessionId, runIds);
+      }
+    }
+
+    const report = {
+      mode: APPLY ? "apply" : "dry-run",
+      cutoff: cutoff.toISOString(),
+      retentionDays: RETENTION_DAYS,
+      eligibleRuns: eligible.length,
+      excludedActiveRuns: active.length,
+      excludedHeldRuns: held.length,
+      excludedAmbiguousTerminalRuns: ambiguous.length,
+      runLogs: { count: runLogs.count, bytes: runLogs.bytes, nonOwnerOnly: runLogs.nonOwnerOnly },
+      cursorTranscripts: {
+        count: cursorTranscriptInventory.count,
+        bytes: cursorTranscriptInventory.bytes,
+        nonOwnerOnly: cursorTranscriptInventory.nonOwnerOnly,
+        approvedSessions: eligibleSessions.size,
+      },
+      backups: { count: backups.count, bytes: backups.bytes, nonOwnerOnly: backups.nonOwnerOnly },
+    };
+    if (!APPLY) {
+      console.log(JSON.stringify(report));
+      return;
+    }
+
+    const transcriptRoots = [runLogRoot, backupRoot];
+    const cursorTranscriptRoots = new Set(
+      cursorTranscriptFiles.map((file) => path.dirname(path.dirname(file))),
+    );
+    await probeServiceAccess([...transcriptRoots, ...cursorTranscriptRoots]);
+
+    const rollback: ModeRecord[] = [];
+    await hardenAncestors(home, runLogRoot, rollback);
+    await hardenAncestors(home, backupRoot, rollback);
+    await hardenTree(runLogRoot, rollback);
+    await hardenTree(backupRoot, rollback);
+    await hardenAncestors(home, cursorProjectsRoot, rollback);
+    for (const root of cursorTranscriptRoots) {
+      await hardenAncestors(home, root, rollback);
+      await hardenTree(root, rollback);
+    }
+    const rollbackFile = await writeRollbackState(retentionRoot, rollback, cutoff);
+    await applyModePlan(rollback);
+    await probeServiceAccess([...transcriptRoots, ...cursorTranscriptRoots]);
+
+    const failedRunIds = new Set<string>();
+    let deletedRunLogs = 0;
+    let deletedRunLogBytes = 0;
+    for (const run of eligible) {
+      if (!run.logRef) continue;
+      const file = path.resolve(runLogRoot, run.logRef);
+      try {
+        const result = await removeApprovedFile(file, runLogRoot, cutoffMs);
+        if (result.deleted) {
+          deletedRunLogs++;
+          deletedRunLogBytes += result.bytes;
+        } else if (!result.missing) {
+          failedRunIds.add(run.id);
+        }
+      } catch {
+        failedRunIds.add(run.id);
+      }
+    }
+
+    let deletedCursorTranscripts = 0;
+    let deletedCursorBytes = 0;
+    for (const file of cursorTranscriptFiles) {
+      const sessionId = path.basename(file, ".jsonl");
+      const associatedRunIds = eligibleSessions.get(sessionId);
+      if (!associatedRunIds) continue;
+      try {
+        const result = await removeApprovedFile(file, cursorProjectsRoot, cutoffMs);
+        if (result.deleted) {
+          deletedCursorTranscripts++;
+          deletedCursorBytes += result.bytes;
+        } else if (!result.missing) {
+          for (const runId of associatedRunIds) failedRunIds.add(runId);
+        }
+      } catch {
+        for (const runId of associatedRunIds) failedRunIds.add(runId);
+      }
+    }
+
+    const successfulRuns = eligible.filter((run) => !failedRunIds.has(run.id));
+    const counts = {
+      eligibleRuns: eligible.length,
+      scrubbedRuns: successfulRuns.length,
+      failures: failedRunIds.size,
+      deletedRunLogs,
+      deletedRunLogBytes,
+      deletedCursorTranscripts,
+      deletedCursorBytes,
+      excludedActiveRuns: active.length,
+      excludedHeldRuns: held.length,
+      excludedAmbiguousTerminalRuns: ambiguous.length,
+    };
+    await updateDatabase(db, successfulRuns, cutoff, counts);
+    console.log(JSON.stringify({ ...report, ...counts, rollbackFile }));
+    if (failedRunIds.size > 0) process.exitCode = 1;
+  } finally {
+    await (
+      db as unknown as { $client: { end(options?: { timeout?: number }): Promise<void> } }
+    ).$client.end({ timeout: 1 });
+    await connection.stop();
+  }
+}
+
+main().then(
+  () => {
+    if (process.exitCode && process.exitCode !== 0) process.exit(process.exitCode);
+  },
+  (error) => {
+    console.error(JSON.stringify({ outcome: "failed", error: error instanceof Error ? error.message : String(error) }));
+    process.exit(1);
+  },
+);

--- a/scripts/transcript-retention.ts
+++ b/scripts/transcript-retention.ts
@@ -164,14 +164,35 @@ async function writeRollbackState(retentionRoot: string, rollback: ModeRecord[],
 async function restorePermissions(file: string) {
   const parsed = JSON.parse(await fs.readFile(file, "utf8")) as { entries?: ModeRecord[] };
   if (!Array.isArray(parsed.entries)) throw new Error("Invalid permissions rollback file");
+  const home = path.resolve(os.homedir());
+  const realHome = await fs.realpath(home);
   let restored = 0;
   for (const entry of [...parsed.entries].reverse()) {
-    if (!entry || typeof entry.path !== "string" || typeof entry.mode !== "number") {
+    if (
+      !entry
+      || typeof entry.path !== "string"
+      || !Number.isInteger(entry.mode)
+      || entry.mode < 0
+    ) {
       throw new Error("Invalid permissions rollback entry");
     }
-    await fs.chmod(entry.path, entry.mode).catch((error: NodeJS.ErrnoException) => {
-      if (error.code !== "ENOENT") throw error;
+    const candidate = path.resolve(entry.path);
+    if (!isWithin(home, candidate)) {
+      throw new Error(`Refusing to restore permissions outside home: ${entry.path}`);
+    }
+    const stat = await fs.lstat(candidate).catch((error: NodeJS.ErrnoException) => {
+      if (error.code === "ENOENT") return null;
+      throw error;
     });
+    if (!stat) continue;
+    if (stat.isSymbolicLink()) {
+      throw new Error(`Refusing to restore permissions through symbolic link: ${entry.path}`);
+    }
+    const realCandidate = await fs.realpath(candidate);
+    if (!isWithin(realHome, realCandidate)) {
+      throw new Error(`Refusing to restore permissions outside real home: ${entry.path}`);
+    }
+    await fs.chmod(candidate, modeOf(entry.mode));
     restored++;
   }
   console.log(JSON.stringify({ mode: "restore-permissions", rollbackFile: file, restored }));

--- a/scripts/transcript-retention.ts
+++ b/scripts/transcript-retention.ts
@@ -3,7 +3,7 @@ import { randomUUID } from "node:crypto";
 import { promises as fs } from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { and, eq, inArray, isNotNull, or } from "../packages/db/node_modules/drizzle-orm/index.js";
+import { and, eq, inArray, isNotNull, lt, not, or, sql } from "../packages/db/node_modules/drizzle-orm/index.js";
 import {
   activityLog,
   createDb,
@@ -15,8 +15,10 @@ import {
 import { resolveMigrationConnection } from "../packages/db/src/migration-runtime.ts";
 
 const RETENTION_DAYS = 7;
-const TERMINAL_STATUSES = new Set(["succeeded", "interrupted", "failed", "cancelled", "timed_out"]);
-const LIVE_STATUSES = new Set(["queued", "running", "scheduled_retry"]);
+const TERMINAL_STATUSES = ["succeeded", "interrupted", "failed", "cancelled", "timed_out"] as const;
+const LIVE_STATUSES = ["queued", "running", "scheduled_retry"] as const;
+const TERMINAL_STATUS_SET = new Set<string>(TERMINAL_STATUSES);
+const LIVE_STATUS_SET = new Set<string>(LIVE_STATUSES);
 const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const APPLY = process.argv.includes("--apply");
 const RESTORE_INDEX = process.argv.indexOf("--restore-permissions");
@@ -28,28 +30,39 @@ type RunRow = {
   status: string;
   finishedAt: Date | null;
   logRef: string | null;
-  resultJson: Record<string, unknown> | null;
-  stdoutExcerpt: string | null;
-  stderrExcerpt: string | null;
+  hasResultJson: boolean;
+  hasStdoutExcerpt: boolean;
+  hasStderrExcerpt: boolean;
   sessionIdBefore: string | null;
   sessionIdAfter: string | null;
   externalRunId: string | null;
-  contextSnapshot: Record<string, unknown> | null;
+  contextIssueId: string | null;
+};
+type SessionRunRow = {
+  id: string;
+  status: string;
+  finishedAt: Date | null;
+  sessionIdBefore: string | null;
+  sessionIdAfter: string | null;
+  externalRunId: string | null;
 };
 
 function modeOf(mode: number) {
   return mode & 0o777;
 }
 
-function issueIdFromContext(context: Record<string, unknown> | null) {
-  const candidate = context?.issueId ?? context?.taskId;
-  return typeof candidate === "string" && candidate.length > 0 ? candidate : null;
-}
-
-function sessionIds(run: RunRow) {
+function sessionIds(run: Pick<RunRow, "sessionIdBefore" | "sessionIdAfter" | "externalRunId">) {
   return [run.sessionIdBefore, run.sessionIdAfter, run.externalRunId].filter(
     (value): value is string => typeof value === "string" && UUID.test(value),
   );
+}
+
+function oldTerminalPredicate(cutoff: Date) {
+  return and(
+    inArray(heartbeatRuns.status, [...TERMINAL_STATUSES]),
+    isNotNull(heartbeatRuns.finishedAt),
+    lt(heartbeatRuns.finishedAt, cutoff),
+  )!;
 }
 
 function isWithin(root: string, candidate: string) {
@@ -325,22 +338,35 @@ async function main() {
   const connection = await resolveMigrationConnection();
   const db = createDb(connection.connectionString);
   try {
-    const runs = await db
+    const oldTerminalWhere = oldTerminalPredicate(cutoff);
+    const oldTerminalRuns = await db
       .select({
         id: heartbeatRuns.id,
         companyId: heartbeatRuns.companyId,
         status: heartbeatRuns.status,
         finishedAt: heartbeatRuns.finishedAt,
         logRef: heartbeatRuns.logRef,
-        resultJson: heartbeatRuns.resultJson,
-        stdoutExcerpt: heartbeatRuns.stdoutExcerpt,
-        stderrExcerpt: heartbeatRuns.stderrExcerpt,
+        hasResultJson: sql<boolean>`(${heartbeatRuns.resultJson} is not null)`.mapWith(Boolean),
+        hasStdoutExcerpt: sql<boolean>`(${heartbeatRuns.stdoutExcerpt} is not null)`.mapWith(Boolean),
+        hasStderrExcerpt: sql<boolean>`(${heartbeatRuns.stderrExcerpt} is not null)`.mapWith(Boolean),
         sessionIdBefore: heartbeatRuns.sessionIdBefore,
         sessionIdAfter: heartbeatRuns.sessionIdAfter,
         externalRunId: heartbeatRuns.externalRunId,
-        contextSnapshot: heartbeatRuns.contextSnapshot,
+        contextIssueId: sql<string | null>`coalesce(${heartbeatRuns.contextSnapshot} ->> 'issueId', ${heartbeatRuns.contextSnapshot} ->> 'taskId')`,
       })
-      .from(heartbeatRuns) as RunRow[];
+      .from(heartbeatRuns)
+      .where(oldTerminalWhere) as RunRow[];
+    const protectiveSessionRuns = await db
+      .select({
+        id: heartbeatRuns.id,
+        status: heartbeatRuns.status,
+        finishedAt: heartbeatRuns.finishedAt,
+        sessionIdBefore: heartbeatRuns.sessionIdBefore,
+        sessionIdAfter: heartbeatRuns.sessionIdAfter,
+        externalRunId: heartbeatRuns.externalRunId,
+      })
+      .from(heartbeatRuns)
+      .where(not(oldTerminalWhere)) as SessionRunRow[];
     const activeHoldMembers = await db
       .select({ issueId: issueTreeHoldMembers.issueId })
       .from(issueTreeHoldMembers)
@@ -354,15 +380,15 @@ async function main() {
         .filter(Boolean),
     );
 
-    const terminal = runs.filter((run) => TERMINAL_STATUSES.has(run.status));
-    const active = runs.filter((run) => LIVE_STATUSES.has(run.status));
-    const ambiguous = terminal.filter((run) => !run.finishedAt);
-    const oldTerminal = terminal.filter((run) => run.finishedAt && run.finishedAt.getTime() < cutoffMs);
-    const held = oldTerminal.filter(
-      (run) => explicitHeldRunIds.has(run.id) || heldIssueIds.has(issueIdFromContext(run.contextSnapshot) ?? ""),
+    const active = protectiveSessionRuns.filter((run) => LIVE_STATUS_SET.has(run.status));
+    const ambiguous = protectiveSessionRuns.filter(
+      (run) => TERMINAL_STATUS_SET.has(run.status) && !run.finishedAt,
+    );
+    const held = oldTerminalRuns.filter(
+      (run) => explicitHeldRunIds.has(run.id) || heldIssueIds.has(run.contextIssueId ?? ""),
     );
     const heldIds = new Set(held.map((run) => run.id));
-    const unheldOldTerminal = oldTerminal.filter((run) => !heldIds.has(run.id));
+    const unheldOldTerminal = oldTerminalRuns.filter((run) => !heldIds.has(run.id));
     const eventContentRunIds = await runsWithPersistedEventContent(
       db,
       unheldOldTerminal.map((run) => run.id),
@@ -386,14 +412,17 @@ async function main() {
     const eligible = unheldOldTerminal.filter(
       (run) =>
         run.logRef !== null
-        || run.resultJson !== null
-        || run.stdoutExcerpt !== null
-        || run.stderrExcerpt !== null
+        || run.hasResultJson
+        || run.hasStdoutExcerpt
+        || run.hasStderrExcerpt
         || eventContentRunIds.has(run.id)
         || sessionIds(run).some((sessionId) => availableCursorSessionIds.has(sessionId)),
     );
     const eligibleIds = new Set(eligible.map((run) => run.id));
-    const protectedSessions = new Set(runs.filter((run) => !eligibleIds.has(run.id)).flatMap(sessionIds));
+    const protectedSessions = new Set([
+      ...protectiveSessionRuns.flatMap(sessionIds),
+      ...oldTerminalRuns.filter((run) => !eligibleIds.has(run.id)).flatMap(sessionIds),
+    ]);
     const eligibleSessions = new Map<string, Set<string>>();
     for (const run of eligible) {
       for (const sessionId of sessionIds(run)) {

--- a/server/src/__tests__/heartbeat-retry-scheduling.test.ts
+++ b/server/src/__tests__/heartbeat-retry-scheduling.test.ts
@@ -107,6 +107,9 @@ describeEmbeddedPostgres("heartbeat bounded retry scheduling", () => {
     await db.delete(executionWorkspaces);
     await db.delete(projects);
     await db.delete(heartbeatRunEvents);
+    // Late async writers (for example transcript-security audit rows) can land after
+    // the first activity_log wipe; clear again before deleting heartbeat_runs.
+    await db.delete(activityLog);
     await db.delete(heartbeatRuns);
     await db.delete(agentWakeupRequests);
     await db.delete(agentRuntimeState);

--- a/server/src/__tests__/redaction.test.ts
+++ b/server/src/__tests__/redaction.test.ts
@@ -135,4 +135,19 @@ describe("redaction", () => {
     expect(result?.args).toEqual(["--api-key", "not-a-command-secret"]);
     expect(result?.argv).toEqual(["--api-key", REDACTED_EVENT_VALUE]);
   });
+
+  it("preserves safe secret metadata without broadening generic string scanning", () => {
+    const message = "Authorization: Bearer synthetic-value";
+    const result = redactEventPayload({
+      message,
+      secretId: "11111111-1111-1111-1111-111111111111",
+      secretName: "unbound-runtime-secret",
+    });
+
+    expect(result).toEqual({
+      message,
+      secretId: "11111111-1111-1111-1111-111111111111",
+      secretName: "unbound-runtime-secret",
+    });
+  });
 });

--- a/server/src/__tests__/transcript-security.test.ts
+++ b/server/src/__tests__/transcript-security.test.ts
@@ -51,6 +51,24 @@ describe("transcript credential security boundaries", () => {
     expect(JSON.stringify(result.metadata)).not.toContain(SYNTHETIC_CREDENTIAL);
   });
 
+  it("preserves secret metadata identifiers while redacting credential-shaped values", () => {
+    const result = secureTranscriptPayload(
+      {
+        secretId: "11111111-1111-1111-1111-111111111111",
+        secretName: "unbound-runtime-secret",
+        output: SYNTHETIC_CREDENTIAL,
+      },
+      "run_summary",
+    );
+
+    expect(result.value).toMatchObject({
+      secretId: "11111111-1111-1111-1111-111111111111",
+      secretName: "unbound-runtime-secret",
+      output: "***REDACTED***",
+    });
+    expect(result.metadata?.matchCount).toBe(1);
+  });
+
   it("redacts legacy credential content at the normal diagnostic rendering boundary", () => {
     const rendered = redactTranscriptDiagnosticValue({
       error: `request failed with ${SYNTHETIC_CREDENTIAL}`,

--- a/server/src/__tests__/transcript-security.test.ts
+++ b/server/src/__tests__/transcript-security.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import {
+  TRANSCRIPT_QUARANTINE_MARKER,
+  redactTranscriptDiagnosticValue,
+  secureTranscriptPayload,
+  secureTranscriptText,
+  transcriptCredentialQuarantineEnabled,
+} from "../transcript-security.js";
+
+const SYNTHETIC_CREDENTIAL = "ghp_000000000000000000000000000000000000";
+
+describe("transcript credential security boundaries", () => {
+  it("redacts and marks credential-shaped run-log records before persistence", () => {
+    const result = secureTranscriptText(
+      `tool output token=${SYNTHETIC_CREDENTIAL}`,
+      "run_log",
+    );
+
+    expect(result.value).toContain(TRANSCRIPT_QUARANTINE_MARKER);
+    expect(result.value).toContain("***REDACTED***");
+    expect(result.value).not.toContain(SYNTHETIC_CREDENTIAL);
+    expect(result.metadata).toEqual({
+      disposition: "quarantined",
+      boundary: "run_log",
+      detectorVersion: 1,
+      matchCount: 1,
+    });
+    expect(JSON.stringify(result.metadata)).not.toContain(SYNTHETIC_CREDENTIAL);
+  });
+
+  it("emits metadata-only quarantine evidence for structured transcript records", () => {
+    const result = secureTranscriptPayload(
+      {
+        event: "tool_result",
+        output: `Authorization: Bearer ${SYNTHETIC_CREDENTIAL}`,
+      },
+      "run_event",
+    );
+
+    expect(JSON.stringify(result.value)).not.toContain(SYNTHETIC_CREDENTIAL);
+    expect(result.value).toMatchObject({
+      event: "tool_result",
+      _paperclipTranscriptSecurity: {
+        disposition: "quarantined",
+        boundary: "run_event",
+        detectorVersion: 1,
+        matchCount: 1,
+        marker: TRANSCRIPT_QUARANTINE_MARKER,
+      },
+    });
+    expect(JSON.stringify(result.metadata)).not.toContain(SYNTHETIC_CREDENTIAL);
+  });
+
+  it("redacts legacy credential content at the normal diagnostic rendering boundary", () => {
+    const rendered = redactTranscriptDiagnosticValue({
+      error: `request failed with ${SYNTHETIC_CREDENTIAL}`,
+      payload: {
+        apiKey: SYNTHETIC_CREDENTIAL,
+      },
+    });
+
+    expect(JSON.stringify(rendered)).not.toContain(SYNTHETIC_CREDENTIAL);
+    expect(JSON.stringify(rendered)).toContain("***REDACTED***");
+  });
+
+  it("allows quarantine rollback without disabling capture-time redaction", () => {
+    const result = secureTranscriptText(
+      `token=${SYNTHETIC_CREDENTIAL}`,
+      "run_log",
+      { quarantineEnabled: false },
+    );
+
+    expect(result.metadata?.disposition).toBe("redacted");
+    expect(result.value).not.toContain(TRANSCRIPT_QUARANTINE_MARKER);
+    expect(result.value).not.toContain(SYNTHETIC_CREDENTIAL);
+    expect(result.value).toContain("***REDACTED***");
+    expect(
+      transcriptCredentialQuarantineEnabled({
+        PAPERCLIP_TRANSCRIPT_CREDENTIAL_QUARANTINE: "false",
+      } as NodeJS.ProcessEnv),
+    ).toBe(false);
+  });
+});

--- a/server/src/redaction.ts
+++ b/server/src/redaction.ts
@@ -52,7 +52,6 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
 
 function sanitizeValue(value: unknown): unknown {
   if (value === null || value === undefined) return value;
-  if (typeof value === "string") return redactSensitiveText(value);
   if (Array.isArray(value)) return value.map(sanitizeValue);
   if (isSecretRefBinding(value)) return value;
   if (isUserSecretRefBinding(value)) return value;
@@ -100,6 +99,10 @@ export function sanitizeRecord(record: Record<string, unknown>): Record<string, 
       continue;
     }
     if (COMMAND_PAYLOAD_KEY_RE.test(key) && typeof value === "string") {
+      redacted[key] = redactSensitiveText(value);
+      continue;
+    }
+    if ((key === "secretId" || key === "secretName") && typeof value === "string") {
       redacted[key] = redactSensitiveText(value);
       continue;
     }

--- a/server/src/redaction.ts
+++ b/server/src/redaction.ts
@@ -52,6 +52,7 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
 
 function sanitizeValue(value: unknown): unknown {
   if (value === null || value === undefined) return value;
+  if (typeof value === "string") return redactSensitiveText(value);
   if (Array.isArray(value)) return value.map(sanitizeValue);
   if (isSecretRefBinding(value)) return value;
   if (isUserSecretRefBinding(value)) return value;
@@ -131,6 +132,47 @@ export function redactEventPayload(payload: Record<string, unknown> | null): Rec
   if (!payload) return null;
   if (!isPlainObject(payload)) return payload;
   return sanitizeRecord(payload);
+}
+
+function countOccurrences(input: string, needle: string) {
+  if (!needle) return 0;
+  let count = 0;
+  let offset = 0;
+  while ((offset = input.indexOf(needle, offset)) !== -1) {
+    count += 1;
+    offset += needle.length;
+  }
+  return count;
+}
+
+export interface CredentialRedactionResult<T> {
+  value: T;
+  matchCount: number;
+}
+
+export function redactSensitiveTextWithMetadata(input: string): CredentialRedactionResult<string> {
+  const value = redactSensitiveText(input);
+  const addedMarkers = countOccurrences(value, REDACTED_EVENT_VALUE)
+    - countOccurrences(input, REDACTED_EVENT_VALUE);
+  return {
+    value,
+    matchCount: value === input ? 0 : Math.max(1, addedMarkers),
+  };
+}
+
+export function redactEventPayloadWithMetadata(
+  payload: Record<string, unknown> | null,
+): CredentialRedactionResult<Record<string, unknown> | null> {
+  const value = redactEventPayload(payload);
+  if (!payload || !value) return { value, matchCount: 0 };
+  const inputJson = JSON.stringify(payload);
+  const valueJson = JSON.stringify(value);
+  const addedMarkers = countOccurrences(valueJson, REDACTED_EVENT_VALUE)
+    - countOccurrences(inputJson, REDACTED_EVENT_VALUE);
+  return {
+    value,
+    matchCount: valueJson === inputJson ? 0 : Math.max(1, addedMarkers),
+  };
 }
 
 export function redactSensitiveText(input: string): string {

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -82,6 +82,7 @@ import {
 } from "../adapters/index.js";
 import { redactEventPayload } from "../redaction.js";
 import { redactCurrentUserValue } from "../log-redaction.js";
+import { redactTranscriptDiagnosticValue } from "../transcript-security.js";
 import { renderOrgChartSvg, renderOrgChartPng, type OrgNode, type OrgChartStyle, ORG_CHART_STYLES } from "./org-chart-svg.js";
 import {
   instanceSettingsService,
@@ -3591,7 +3592,7 @@ export function agentRoutes(
     const limit = limitParam ? Math.max(1, Math.min(1000, parseInt(limitParam, 10) || 200)) : undefined;
     const summary = req.query.summary === "true" || req.query.summary === "1";
     const runs = await heartbeat.list(companyId, agentId, limit, { summary });
-    res.json(runs);
+    res.json(redactTranscriptDiagnosticValue(runs));
   });
 
   router.get("/companies/:companyId/live-runs", async (req, res) => {
@@ -3666,17 +3667,17 @@ export function agentRoutes(
         .limit(targetRunCount - liveRuns.length);
 
       const rows = [...liveRuns, ...recentRuns];
-      res.json(await Promise.all(rows.map(async (run) => ({
+      res.json(redactTranscriptDiagnosticValue(await Promise.all(rows.map(async (run) => ({
         ...heartbeat.decorateActiveRunStatus(run),
         outputSilence: await heartbeat.buildRunOutputSilence(run),
-      }))));
+      })))));
       return;
     }
 
-    res.json(await Promise.all(liveRuns.map(async (run) => ({
+    res.json(redactTranscriptDiagnosticValue(await Promise.all(liveRuns.map(async (run) => ({
       ...heartbeat.decorateActiveRunStatus(run),
       outputSilence: await heartbeat.buildRunOutputSilence(run),
-    }))));
+    })))));
   });
 
   router.get("/heartbeat-runs/:runId", async (req, res) => {
@@ -3686,9 +3687,11 @@ export function agentRoutes(
     const retryExhaustedReason = await heartbeat.getRetryExhaustedReason(runId);
     const decoratedRun = heartbeat.decorateActiveRunStatus(run);
     res.json(
-      redactCurrentUserValue(
-        { ...decoratedRun, retryExhaustedReason, outputSilence: await heartbeat.buildRunOutputSilence(run) },
-        await getCurrentUserRedactionOptions(),
+      redactTranscriptDiagnosticValue(
+        redactCurrentUserValue(
+          { ...decoratedRun, retryExhaustedReason, outputSilence: await heartbeat.buildRunOutputSilence(run) },
+          await getCurrentUserRedactionOptions(),
+        ),
       ),
     );
   });
@@ -3757,10 +3760,12 @@ export function agentRoutes(
     const events = await heartbeat.listEvents(runId, Number.isFinite(afterSeq) ? afterSeq : 0, Number.isFinite(limit) ? limit : 200);
     const currentUserRedactionOptions = await getCurrentUserRedactionOptions();
     const redactedEvents = events.map((event) =>
-      redactCurrentUserValue({
-        ...event,
-        payload: redactEventPayload(event.payload),
-      }, currentUserRedactionOptions),
+      redactTranscriptDiagnosticValue(
+        redactCurrentUserValue({
+          ...event,
+          payload: redactEventPayload(event.payload),
+        }, currentUserRedactionOptions),
+      ),
     );
     res.json(redactedEvents);
   });

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -228,7 +228,13 @@ import {
   redactCurrentUserValue,
   type CurrentUserRedactionOptions,
 } from "../log-redaction.js";
-import { redactEventPayload, redactSensitiveText } from "../redaction.js";
+import { redactSensitiveText } from "../redaction.js";
+import {
+  redactTranscriptDiagnosticValue,
+  secureTranscriptPayload,
+  secureTranscriptText,
+  type TranscriptSecurityMetadata,
+} from "../transcript-security.js";
 import {
   hasSessionCompactionThresholds,
   resolveSessionCompactionPolicy,
@@ -304,6 +310,8 @@ const HEARTBEAT_MAX_CONCURRENT_RUNS_MAX = 50;
 const LIVENESS_BOOKKEEPING_ACTIVITY_ACTIONS = [
   "environment.lease_acquired",
   "environment.lease_released",
+  "heartbeat_run.transcript_credential_quarantined",
+  "heartbeat_run.transcript_credential_redacted",
 ];
 const DEFERRED_WAKE_CONTEXT_KEY = "_paperclipWakeContext";
 const WAKE_COMMENT_IDS_KEY = "wakeCommentIds";
@@ -7535,19 +7543,60 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     return ensured;
   }
 
+  function secureRunStatusPatch(
+    patch?: Partial<typeof heartbeatRuns.$inferInsert>,
+  ): {
+    patch: Partial<typeof heartbeatRuns.$inferInsert> | undefined;
+    metadata: TranscriptSecurityMetadata | null;
+  } {
+    if (!patch) return { patch, metadata: null };
+    const secured = { ...patch };
+    const findings: TranscriptSecurityMetadata[] = [];
+    for (const key of ["error", "stdoutExcerpt", "stderrExcerpt"] as const) {
+      const value = secured[key];
+      if (typeof value !== "string") continue;
+      const result = secureTranscriptText(value, "run_summary");
+      secured[key] = result.value;
+      if (result.metadata) findings.push(result.metadata);
+    }
+    if (secured.resultJson && typeof secured.resultJson === "object" && !Array.isArray(secured.resultJson)) {
+      const result = secureTranscriptPayload(
+        secured.resultJson as Record<string, unknown>,
+        "run_summary",
+      );
+      secured.resultJson = result.value;
+      if (result.metadata) findings.push(result.metadata);
+    }
+    if (findings.length === 0) return { patch: secured, metadata: null };
+    return {
+      patch: secured,
+      metadata: {
+        ...findings[0]!,
+        matchCount: findings.reduce((total, finding) => total + finding.matchCount, 0),
+        disposition: findings.some((finding) => finding.disposition === "quarantined")
+          ? "quarantined"
+          : "redacted",
+      },
+    };
+  }
+
   async function setRunStatus(
     runId: string,
     status: string,
     patch?: Partial<typeof heartbeatRuns.$inferInsert>,
   ) {
+    const secured = secureRunStatusPatch(patch);
     const updated = await db
       .update(heartbeatRuns)
-      .set({ status, ...patch, updatedAt: new Date() })
+      .set({ status, ...secured.patch, updatedAt: new Date() })
       .where(eq(heartbeatRuns.id, runId))
       .returning()
       .then((rows) => rows[0] ?? null);
 
     if (updated) {
+      if (secured.metadata) {
+        await recordTranscriptSecurityEvent(updated, secured.metadata, "run_status", null);
+      }
       if (isHeartbeatRunTerminalStatus(updated.status)) {
         clearHeartbeatRunRuntimeStatus(updated.id);
       }
@@ -7577,14 +7626,18 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     status: string,
     patch?: Partial<typeof heartbeatRuns.$inferInsert>,
   ) {
+    const secured = secureRunStatusPatch(patch);
     const updated = await db
       .update(heartbeatRuns)
-      .set({ status, ...patch, updatedAt: new Date() })
+      .set({ status, ...secured.patch, updatedAt: new Date() })
       .where(and(eq(heartbeatRuns.id, runId), eq(heartbeatRuns.status, "running")))
       .returning()
       .then((rows) => rows[0] ?? null);
 
     if (updated) {
+      if (secured.metadata) {
+        await recordTranscriptSecurityEvent(updated, secured.metadata, "run_status", null);
+      }
       if (isHeartbeatRunTerminalStatus(updated.status)) {
         clearHeartbeatRunRuntimeStatus(updated.id);
       }
@@ -8155,6 +8208,32 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     });
   }
 
+  async function recordTranscriptSecurityEvent(
+    run: typeof heartbeatRuns.$inferSelect,
+    metadata: TranscriptSecurityMetadata,
+    recordType: string,
+    stream: string | null,
+  ) {
+    await logActivity(db, {
+      companyId: run.companyId,
+      actorType: "system",
+      actorId: "transcript-security",
+      agentId: run.agentId,
+      runId: run.id,
+      action: `heartbeat_run.transcript_credential_${metadata.disposition}`,
+      entityType: "heartbeat_run",
+      entityId: run.id,
+      details: {
+        boundary: metadata.boundary,
+        detectorVersion: metadata.detectorVersion,
+        disposition: metadata.disposition,
+        matchCount: metadata.matchCount,
+        recordType,
+        stream,
+      },
+    });
+  }
+
   async function appendRunEvent(
     run: typeof heartbeatRuns.$inferSelect,
     seq: number,
@@ -8169,16 +8248,27 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
   ) {
     const eventAt = new Date();
     const currentUserRedactionOptions = await getCurrentUserRedactionOptions();
-    const sanitizedMessage = event.message
-      ? redactCurrentUserText(event.message, currentUserRedactionOptions)
-      : event.message;
+    const messageSecurity = event.message
+      ? secureTranscriptText(
+        redactCurrentUserText(event.message, currentUserRedactionOptions),
+        "run_event",
+      )
+      : { value: event.message, metadata: null };
+    const sanitizedMessage = messageSecurity.value;
     const boundedPayload = event.payload
       ? boundHeartbeatRunEventPayloadForStorage(event.payload)
       : event.payload;
-    const secretSanitizedPayload = boundedPayload ? redactEventPayload(boundedPayload) : boundedPayload;
-    const sanitizedPayload = secretSanitizedPayload
-      ? redactCurrentUserValue(secretSanitizedPayload, currentUserRedactionOptions)
-      : secretSanitizedPayload;
+    const payloadSecurity = secureTranscriptPayload(boundedPayload ?? null, "run_event");
+    const sanitizedPayload = payloadSecurity.value
+      ? redactCurrentUserValue(payloadSecurity.value, currentUserRedactionOptions)
+      : payloadSecurity.value;
+    const securityMetadata =
+      messageSecurity.metadata && payloadSecurity.metadata
+        ? {
+          ...messageSecurity.metadata,
+          matchCount: messageSecurity.metadata.matchCount + payloadSecurity.metadata.matchCount,
+        }
+        : messageSecurity.metadata ?? payloadSecurity.metadata;
     const issueId = readRuntimeStatusIssueIdCandidate(run) ?? null;
     const progress = buildRunEventRuntimeProgress({
       eventType: event.eventType,
@@ -8199,6 +8289,14 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       message: sanitizedMessage,
       payload: sanitizedPayload,
     });
+    if (securityMetadata) {
+      await recordTranscriptSecurityEvent(
+        run,
+        securityMetadata,
+        event.eventType.slice(0, 120),
+        event.stream ?? null,
+      );
+    }
 
     publishLiveEvent({
       companyId: run.companyId,
@@ -13143,9 +13241,19 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
 
       const currentUserRedactionOptions = await getCurrentUserRedactionOptions();
       const onLog = async (stream: "stdout" | "stderr", chunk: string) => {
-        const sanitizedChunk = compactRunLogChunk(
+        const securedChunk = secureTranscriptText(
           redactCurrentUserText(chunk, currentUserRedactionOptions),
+          "run_log",
         );
+        const sanitizedChunk = compactRunLogChunk(securedChunk.value);
+        if (securedChunk.metadata) {
+          await recordTranscriptSecurityEvent(
+            currentRun,
+            securedChunk.metadata,
+            "stream_chunk",
+            stream,
+          );
+        }
         if (stream === "stdout") stdoutExcerpt = appendExcerpt(stdoutExcerpt, sanitizedChunk);
         if (stream === "stderr") stderrExcerpt = appendExcerpt(stderrExcerpt, sanitizedChunk);
         const ts = new Date().toISOString();
@@ -16868,9 +16976,8 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         store: run.logStore,
         logRef: run.logRef,
         ...result,
-        // Run-log chunks are already redacted before they are appended to the store.
-        // Rewriting the full chunk again on every poll creates avoidable string copies.
-        content: result.content,
+        // Defense in depth for legacy/imported logs that predate capture-time scanning.
+        content: redactTranscriptDiagnosticValue(result.content),
       };
     },
 

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -310,8 +310,6 @@ const HEARTBEAT_MAX_CONCURRENT_RUNS_MAX = 50;
 const LIVENESS_BOOKKEEPING_ACTIVITY_ACTIONS = [
   "environment.lease_acquired",
   "environment.lease_released",
-  "heartbeat_run.transcript_credential_quarantined",
-  "heartbeat_run.transcript_credential_redacted",
 ];
 const DEFERRED_WAKE_CONTEXT_KEY = "_paperclipWakeContext";
 const WAKE_COMMENT_IDS_KEY = "wakeCommentIds";
@@ -8267,6 +8265,11 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         ? {
           ...messageSecurity.metadata,
           matchCount: messageSecurity.metadata.matchCount + payloadSecurity.metadata.matchCount,
+          disposition:
+            messageSecurity.metadata.disposition === "quarantined" ||
+            payloadSecurity.metadata.disposition === "quarantined"
+              ? "quarantined" as const
+              : "redacted" as const,
         }
         : messageSecurity.metadata ?? payloadSecurity.metadata;
     const issueId = readRuntimeStatusIssueIdCandidate(run) ?? null;

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -13243,13 +13243,21 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         .where(eq(heartbeatRuns.id, runId));
 
       const currentUserRedactionOptions = await getCurrentUserRedactionOptions();
+      // One audit row per disposition for the stream path. Chunk cadence can be
+      // hundreds/sec; unbounded activity inserts would amplify a noisy or hostile
+      // credential-shaped stream into a database write DoS.
+      const streamSecurityAuditLogged = new Set<"redacted" | "quarantined">();
       const onLog = async (stream: "stdout" | "stderr", chunk: string) => {
         const securedChunk = secureTranscriptText(
           redactCurrentUserText(chunk, currentUserRedactionOptions),
           "run_log",
         );
         const sanitizedChunk = compactRunLogChunk(securedChunk.value);
-        if (securedChunk.metadata) {
+        if (
+          securedChunk.metadata
+          && !streamSecurityAuditLogged.has(securedChunk.metadata.disposition)
+        ) {
+          streamSecurityAuditLogged.add(securedChunk.metadata.disposition);
           await recordTranscriptSecurityEvent(
             currentRun,
             securedChunk.metadata,

--- a/server/src/transcript-security.ts
+++ b/server/src/transcript-security.ts
@@ -2,6 +2,7 @@ import {
   redactEventPayloadWithMetadata,
   redactSensitiveText,
   redactSensitiveTextWithMetadata,
+  type CredentialRedactionResult,
 } from "./redaction.js";
 
 export const TRANSCRIPT_QUARANTINE_MARKER =
@@ -24,6 +25,33 @@ export interface TranscriptSecurityMetadata {
 export interface TranscriptSecurityResult<T> {
   value: T;
   metadata: TranscriptSecurityMetadata | null;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+}
+
+function redactTranscriptStrings(value: unknown): CredentialRedactionResult<unknown> {
+  if (typeof value === "string") return redactSensitiveTextWithMetadata(value);
+  if (Array.isArray(value)) {
+    const entries = value.map(redactTranscriptStrings);
+    return {
+      value: entries.map((entry) => entry.value),
+      matchCount: entries.reduce((total, entry) => total + entry.matchCount, 0),
+    };
+  }
+  if (!isPlainObject(value)) return { value, matchCount: 0 };
+
+  const entries = Object.entries(value).map(([key, entry]) => [
+    key,
+    redactTranscriptStrings(entry),
+  ] as const);
+  return {
+    value: Object.fromEntries(entries.map(([key, entry]) => [key, entry.value])),
+    matchCount: entries.reduce((total, [, entry]) => total + entry.matchCount, 0),
+  };
 }
 
 export function transcriptCredentialQuarantineEnabled(env = process.env) {
@@ -69,7 +97,12 @@ export function secureTranscriptPayload(
   boundary: TranscriptSecurityBoundary,
   options?: { quarantineEnabled?: boolean },
 ): TranscriptSecurityResult<Record<string, unknown> | null> {
-  const result = redactEventPayloadWithMetadata(input);
+  const keyResult = redactEventPayloadWithMetadata(input);
+  const textResult = redactTranscriptStrings(keyResult.value);
+  const result = {
+    value: textResult.value as Record<string, unknown> | null,
+    matchCount: keyResult.matchCount + textResult.matchCount,
+  };
   const metadata = metadataFor(
     boundary,
     result.matchCount,
@@ -96,7 +129,7 @@ export function redactTranscriptDiagnosticValue<T>(value: T): T {
     return value.map((entry) => redactTranscriptDiagnosticValue(entry)) as T;
   }
   if (!value || typeof value !== "object") return value;
-  const proto = Object.getPrototypeOf(value);
-  if (proto !== Object.prototype && proto !== null) return value;
-  return redactEventPayloadWithMetadata(value as Record<string, unknown>).value as T;
+  if (!isPlainObject(value)) return value;
+  const keyRedacted = redactEventPayloadWithMetadata(value).value;
+  return redactTranscriptStrings(keyRedacted).value as T;
 }

--- a/server/src/transcript-security.ts
+++ b/server/src/transcript-security.ts
@@ -1,0 +1,102 @@
+import {
+  redactEventPayloadWithMetadata,
+  redactSensitiveText,
+  redactSensitiveTextWithMetadata,
+} from "./redaction.js";
+
+export const TRANSCRIPT_QUARANTINE_MARKER =
+  "[paperclip: credential-shaped transcript content quarantined]";
+export const TRANSCRIPT_CREDENTIAL_DETECTOR_VERSION = 1;
+
+export type TranscriptSecurityBoundary =
+  | "run_event"
+  | "run_log"
+  | "run_summary"
+  | "diagnostic_render";
+
+export interface TranscriptSecurityMetadata {
+  disposition: "quarantined" | "redacted";
+  boundary: TranscriptSecurityBoundary;
+  detectorVersion: number;
+  matchCount: number;
+}
+
+export interface TranscriptSecurityResult<T> {
+  value: T;
+  metadata: TranscriptSecurityMetadata | null;
+}
+
+export function transcriptCredentialQuarantineEnabled(env = process.env) {
+  return env.PAPERCLIP_TRANSCRIPT_CREDENTIAL_QUARANTINE?.trim().toLowerCase() !== "false";
+}
+
+function metadataFor(
+  boundary: TranscriptSecurityBoundary,
+  matchCount: number,
+  quarantineEnabled: boolean,
+): TranscriptSecurityMetadata | null {
+  if (matchCount <= 0) return null;
+  return {
+    disposition: quarantineEnabled ? "quarantined" : "redacted",
+    boundary,
+    detectorVersion: TRANSCRIPT_CREDENTIAL_DETECTOR_VERSION,
+    matchCount,
+  };
+}
+
+export function secureTranscriptText(
+  input: string,
+  boundary: TranscriptSecurityBoundary,
+  options?: { quarantineEnabled?: boolean },
+): TranscriptSecurityResult<string> {
+  const result = redactSensitiveTextWithMetadata(input);
+  const metadata = metadataFor(
+    boundary,
+    result.matchCount,
+    options?.quarantineEnabled ?? transcriptCredentialQuarantineEnabled(),
+  );
+  if (!metadata || metadata.disposition === "redacted") {
+    return { value: result.value, metadata };
+  }
+  return {
+    value: `${TRANSCRIPT_QUARANTINE_MARKER}\n${result.value}`,
+    metadata,
+  };
+}
+
+export function secureTranscriptPayload(
+  input: Record<string, unknown> | null,
+  boundary: TranscriptSecurityBoundary,
+  options?: { quarantineEnabled?: boolean },
+): TranscriptSecurityResult<Record<string, unknown> | null> {
+  const result = redactEventPayloadWithMetadata(input);
+  const metadata = metadataFor(
+    boundary,
+    result.matchCount,
+    options?.quarantineEnabled ?? transcriptCredentialQuarantineEnabled(),
+  );
+  if (!metadata || !result.value || metadata.disposition === "redacted") {
+    return { value: result.value, metadata };
+  }
+  return {
+    value: {
+      ...result.value,
+      _paperclipTranscriptSecurity: {
+        ...metadata,
+        marker: TRANSCRIPT_QUARANTINE_MARKER,
+      },
+    },
+    metadata,
+  };
+}
+
+export function redactTranscriptDiagnosticValue<T>(value: T): T {
+  if (typeof value === "string") return redactSensitiveText(value) as T;
+  if (Array.isArray(value)) {
+    return value.map((entry) => redactTranscriptDiagnosticValue(entry)) as T;
+  }
+  if (!value || typeof value !== "object") return value;
+  const proto = Object.getPrototypeOf(value);
+  if (proto !== Object.prototype && proto !== null) return value;
+  return redactEventPayloadWithMetadata(value as Record<string, unknown>).value as T;
+}


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source control plane people use to manage AI agents for work.
> - Heartbeat transcripts persist run logs, structured events, terminal summaries, and adapter transcript files for operator diagnostics.
> - Those boundaries can receive credential-shaped text emitted by agents and tools, so secure defaults require capture-time removal rather than relying only on display filtering.
> - Existing field-level redaction did not consistently classify matches, preserve quarantine evidence, protect legacy diagnostic reads, or bound retained raw transcript lifetime.
> - Security controls must fail closed: rollback may remove quarantine markers or restore file modes, but must never restore unredacted persistence or silently discard anomalously recent files.
> - This pull request adds capture-time quarantine, metadata-only audit evidence, defense-in-depth read redaction, and a hold-aware seven-day primary-store retention sweep.
> - The benefit is a smaller credential-exposure blast radius with inspectable evidence, explicit operational rollback seams, and bounded raw-data lifetime.

## Linked Issues or Issue Description

### What happened?

Heartbeat run logs, structured run events, persisted summaries, and adapter transcript files can receive bearer tokens, API keys, JWTs, or other credential-shaped values emitted by agents and tools. Existing sanitization did not consistently classify matches, produce quarantine evidence, protect legacy records when operators render diagnostics, or enforce a bounded primary-store lifetime.

### Expected behavior

Credential-shaped content is removed before transcript persistence, matches produce metadata-only security evidence, diagnostic reads redact legacy content, and terminal transcript content older than seven days can be swept without touching live, held, ambiguous, shared-session, or anomalously recent data.

### Steps to reproduce

1. Run an agent/tool that emits a synthetic credential such as a test-only GitHub-token shape in a log, event payload, or terminal summary.
2. Inspect the persisted heartbeat run/event/log representation and activity stream.
3. Before this change, observe inconsistent boundary coverage and no classified quarantine evidence; after this change, observe redacted content, a safe marker, and metadata-only activity.
4. Run the retention utility in dry-run mode, then apply it against a migrated instance and confirm only unheld terminal content older than the cutoff is scrubbed.

### Environment

- Paperclip version or commit: `5d42382df4c5724085967027485fcd39b91b01ae` (`master` at branch creation)
- Deployment mode: Local dev / built from source
- Installation method: pnpm workspace
- Agent adapters: Core capture is adapter-independent; raw Cursor transcript cleanup is session-ID constrained
- Database mode: PostgreSQL-compatible Paperclip database
- Access context: Board diagnostics and agent-generated transcript capture
- Privacy: all test values are synthetic; no live credentials, customer data, or private transcript content are included

## What Changed

- Added transcript security helpers that classify redaction matches and attach safe quarantine markers.
- Applied capture-time controls to run-log chunks, structured events, and persisted run summaries.
- Added metadata-only `heartbeat_run.transcript_credential_*` activity evidence without matched values and kept those security events visible in run activity counts.
- Confined deep string scanning to transcript boundaries while preserving safe secret identifiers required by recovery diagnostics.
- Added defense-in-depth redaction to run, event, and log diagnostic reads for legacy/imported records.
- Added a dry-run-by-default seven-day retention utility for terminal database content, Paperclip raw logs, and session-matched Cursor transcripts.
- Made retention hold-aware and fail-closed for active, ambiguous, shared-session, symlinked, path-escaping, or unexpectedly recent files; permission changes produce an owner-only rollback manifest.
- Documented false-positive handling, marker rollback, retention verification, legal holds, permission recovery, and irreversible deletion boundaries.
- Added synthetic-only tests for capture, evidence, legacy reads, rollback behavior, and safe metadata preservation.

## Verification

- `pnpm exec vitest run server/src/__tests__/transcript-security.test.ts server/src/__tests__/redaction.test.ts server/src/__tests__/heartbeat-run-log.test.ts` — 16 passed.
- `pnpm --filter @paperclipai/server typecheck` — passed after reconciling the existing PR head.
- `pnpm -r typecheck` — passed across all workspace packages.
- `pnpm build` — passed across the monorepo.
- `git diff --check master...HEAD` — passed.
- `pnpm test:run` — 2,671 passed, 1 skipped, 2 failed in pre-existing workspace-runtime auto-port reconciliation tests; both failures reproduce in isolation with `EADDRINUSE`/adoption behavior and are outside the transcript-security paths. The prior PR head passed the corresponding clean-environment GitHub test shards; latest-head CI is the authoritative gate after this push.
- Retention command failure path returns nonzero against this workspace's uninitialized default database rather than reporting a false success; apply-mode verification requires a migrated operator instance and is documented in `doc/TRANSCRIPT_RETENTION.md`.

## Risks

- Regex-based detection can produce false positives; the rollback switch disables markers only, while redaction remains mandatory.
- Emitting activity evidence per matching chunk can increase write volume for repeatedly noisy streams.
- Defense-in-depth rendering traverses diagnostic payloads and adds CPU proportional to response size.
- Streamed run-log detection is chunk-local; a provider that splits one credential across chunks may require follow-up hardening at the stream-framing boundary.
- Retention deletion is intentionally irreversible. Dry-run, issue-tree holds, shared-session protection, mtime checks, path containment, and permission rollback reduce the blast radius; operators must verify the post-apply dry-run before declaring success.
- No schema migration or production data rewrite is included; legacy records are protected at read time and removed only by the explicit retention command.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- Implementation: Cursor agent with tool use and code execution; exact underlying implementation model and context window were not present in the review handoff.
- Review, retention hardening, and PR preparation: OpenAI GPT-5.6 Sol (`gpt-5.6-sol-medium`; context-window size not exposed) with reasoning, repository inspection, GitHub tooling, and code execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge