### PR TITLE
fix(heartbeat): pause agent on a permanent adapter setup failure

### DIFF
--- a/server/src/__tests__/non-retryable-adapter-setup-failure.test.ts
+++ b/server/src/__tests__/non-retryable-adapter-setup-failure.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { isNonRetryableAdapterSetupFailure } from "../services/heartbeat.js";
+
+describe("isNonRetryableAdapterSetupFailure (pause instead of retry-storming)", () => {
+  it("matches the k8s-lease adapter-registry failure (the process-agent storm)", () => {
+    const err = new Error(
+      'Failed to acquire lease for environment "Kubernetes Sandbox" (sandbox): Adapter "process" is not in the configured adapter registry',
+    );
+    expect(isNonRetryableAdapterSetupFailure(err)).toBe(true);
+  });
+
+  it("matches a plain string message too", () => {
+    expect(isNonRetryableAdapterSetupFailure('Adapter "foo" is not in the configured adapter registry')).toBe(true);
+  });
+
+  it("does NOT match transient/other setup failures (those should keep retrying)", () => {
+    expect(isNonRetryableAdapterSetupFailure(new Error("spawn ENOENT"))).toBe(false);
+    expect(isNonRetryableAdapterSetupFailure(new Error("connection reset by peer"))).toBe(false);
+    expect(isNonRetryableAdapterSetupFailure(new Error("Unknown setup failure"))).toBe(false);
+    expect(isNonRetryableAdapterSetupFailure(null)).toBe(false);
+    expect(isNonRetryableAdapterSetupFailure(undefined)).toBe(false);
+  });
+});

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -484,6 +484,16 @@ function isSpawnLikeFailureMessage(value: unknown) {
   return /failed to start command|spawn\b|\bENOENT\b/i.test(value);
 }
 
+// A permanent, non-retryable setup failure: the agent's adapter is not runnable in
+// this environment (e.g. a legacy "process" agent in a sandbox-only cloud company,
+// which fails to acquire the k8s lease with "Adapter ... is not in the configured
+// adapter registry"). Re-invoking such an agent every heartbeat produces a
+// setup_failed retry storm, so it must pause the agent instead of looping.
+export function isNonRetryableAdapterSetupFailure(err: unknown): boolean {
+  const message = err instanceof Error ? err.message : typeof err === "string" ? err : "";
+  return /is not in the configured adapter registry/i.test(message);
+}
+
 function isRetryableInteractionContinuationInfrastructureFailure(
   run: Pick<typeof heartbeatRuns.$inferSelect, "error" | "errorCode" | "resultJson">,
 ) {
@@ -14185,6 +14195,33 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             }
             const failedAgent = setupFailureAgent ?? await getAgent(run.agentId).catch(() => null);
             if (failedAgent) {
+              // Permanent setup failure (adapter not runnable in this environment):
+              // pause the agent so the heartbeat stops re-invoking it every interval
+              // (which otherwise produces a setup_failed retry storm), and surface the
+              // reason so it routes to a human to reconfigure the adapter.
+              if (
+                isNonRetryableAdapterSetupFailure(outerErr) &&
+                failedAgent.status !== "paused" &&
+                failedAgent.status !== "terminated"
+              ) {
+                await db
+                  .update(agents)
+                  .set({
+                    status: "paused",
+                    pauseReason: truncateAgentErrorReason(
+                      `Paused after a non-retryable setup failure: ${message} Reconfigure the agent's adapter/runtime, then resume.`,
+                    ),
+                    pausedAt: new Date(),
+                    updatedAt: new Date(),
+                  })
+                  .where(eq(agents.id, failedAgent.id))
+                  .catch((pauseErr) => {
+                    logger.warn(
+                      { err: pauseErr, agentId: failedAgent.id, runId },
+                      "failed to pause agent after non-retryable setup failure",
+                    );
+                  });
+              }
               await refreshContinuationSummaryForRun(livenessRun, failedAgent).catch(() => undefined);
               if (!isWorkspaceValidationFailedRun(livenessRun) && !isConfigurationIncompleteFailedRun(livenessRun)) {
                 await finalizeIssueCommentPolicy(livenessRun, failedAgent).catch(() => undefined);

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -948,6 +948,16 @@ function isSandboxProviderWorkerUnavailableFailureMessage(value: unknown) {
   );
 }
 
+// A permanent, non-retryable setup failure: the agent's adapter is not runnable in
+// this environment (e.g. a legacy "process" agent in a sandbox-only cloud company,
+// which fails to acquire the k8s lease with "Adapter ... is not in the configured
+// adapter registry"). Re-invoking such an agent every heartbeat produces a
+// setup_failed retry storm, so it must pause the agent instead of looping.
+export function isNonRetryableAdapterSetupFailure(err: unknown): boolean {
+  const message = err instanceof Error ? err.message : typeof err === "string" ? err : "";
+  return /is not in the configured adapter registry/i.test(message);
+}
+
 function isRetryableInteractionContinuationInfrastructureFailure(
   run: Pick<
     typeof heartbeatRuns.$inferSelect,
@@ -22721,6 +22731,33 @@ export function heartbeatService(
             setupFailureAgent ??
             (await getAgent(run.agentId).catch(() => null));
           if (failedAgent) {
+            // Permanent setup failure (adapter not runnable in this environment):
+            // pause the agent so the heartbeat stops re-invoking it every interval
+            // (which otherwise produces a setup_failed retry storm), and surface the
+            // reason so it routes to a human to reconfigure the adapter.
+            if (
+              isNonRetryableAdapterSetupFailure(outerErr) &&
+              failedAgent.status !== "paused" &&
+              failedAgent.status !== "terminated"
+            ) {
+              await db
+                .update(agents)
+                .set({
+                  status: "paused",
+                  pauseReason: truncateAgentErrorReason(
+                    `Paused after a non-retryable setup failure: ${message} Reconfigure the agent's adapter/runtime, then resume.`,
+                  ),
+                  pausedAt: new Date(),
+                  updatedAt: new Date(),
+                })
+                .where(eq(agents.id, failedAgent.id))
+                .catch((pauseErr) => {
+                  logger.warn(
+                    { err: pauseErr, agentId: failedAgent.id, runId },
+                    "failed to pause agent after non-retryable setup failure",
+                  );
+                });
+            }
             await refreshContinuationSummaryForRun(
               livenessRun,
               failedAgent,


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Agents execute runs through adapters; a run begins with a setup phase that acquires an environment lease for the agent's adapter.
> - When an agent's adapter is not runnable in its environment at all (for example a legacy `process` agent in a sandbox-only company, whose lease acquisition fails with `Adapter "process" is not in the configured adapter registry`), the failure is permanent: no retry can ever succeed without human reconfiguration.
> - Previously this permanent condition was recorded as a generic `setup_failed` and the issue was released for re-pick, so the heartbeat re-invoked the agent every interval, failing setup again, indefinitely.
> - This pull request classifies that specific non-retryable adapter setup failure and pauses the agent with an actionable reason instead of letting it loop.
> - The benefit is that a permanently misconfigured agent surfaces as a clear paused state routed to a human, instead of an infinite `setup_failed` retry storm that burns compute and delivers nothing.

## Linked Issues or Issue Description

No public issue exists; the underlying bug is described inline below, following the bug report template.

**What happened**

A run whose setup failed because the agent's adapter is not in the configured adapter registry was recorded as a generic `setup_failed` and retried by the heartbeat every interval, forever.

**Expected behavior**

A permanent, non-retryable adapter setup failure pauses the agent with a human-readable `pauseReason` so a human can reconfigure the adapter or runtime and resume; transient setup failures keep their existing retry behavior.

**Steps to reproduce**

1. Create an agent whose adapter type is absent from the environment's configured adapter registry (for example a `process` agent in a sandbox-only company).
2. Assign it an issue and let the heartbeat run it.
3. Observe the lease acquisition fail with `Adapter "process" is not in the configured adapter registry`, the run recorded as `setup_failed`, and the same failure repeat on every heartbeat interval indefinitely.

## What Changed

- server: `isNonRetryableAdapterSetupFailure` detects the permanent adapter-registry setup failure (matches the environment-lease registry error thrown as an Error or a plain string; rejects transient, unknown, and null inputs).
- server: the heartbeat's setup-failure handler pauses the agent with a human-readable `pauseReason` when the failure is non-retryable, instead of releasing the issue for endless re-pick.
- The pause is guarded (skips agents already `paused` or `terminated`) and best-effort (a failed pause update is logged, not thrown).
- Transient and other setup failures are unchanged and keep their existing retry behavior.

## Verification

- `server/src/__tests__/non-retryable-adapter-setup-failure.test.ts` passes 3/3: the environment-lease registry error (Error and plain-string forms) classifies as non-retryable; transient, unknown, and null failures do not.
- Server typecheck clean.

## Risks

Low. The only behavioral change is for the specific non-retryable adapter-registry failure, which today loops forever and never succeeds; it now pauses with an actionable reason. All other setup failures retain their current retry semantics. The pause write is status-guarded and best-effort, so it cannot flip a concurrently terminated agent or fail the handler.

## Model Used

Claude (Anthropic), model ID `claude-fable-5`, extended reasoning, with tool use / code execution in an agentic harness.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [x] I will address all Greptile and reviewer comments before requesting merge

Related: #9854 classifies permanent auth failures in the same heartbeat handler; both add a pause branch there, so whichever merges second will rebase (this PR's classification is adapter-registry setup failures, #9854's is provider auth rejections and identical-failure storms).
