### PR TITLE
fix(api): add bounded agent summary enumeration

### DIFF
--- a/docs/api/agents.md
+++ b/docs/api/agents.md
@@ -13,7 +13,18 @@ GET /api/companies/{companyId}/agents
 
 Returns all agents in the company.
 
-This route does not accept query filters. Unsupported query parameters return `400`.
+The unparameterized route preserves the full agent response for existing clients. For
+bounded fleet or org scans, request summary pages:
+
+```
+GET /api/companies/{companyId}/agents?view=summary&limit=100&offset=0
+```
+
+Summary pages contain only `id`, `companyId`, `name`, `urlKey`, `role`, `title`,
+`status`, and `reportsTo`. `limit` defaults to 100 and cannot exceed 100; `offset`
+defaults to 0. Continue until a page contains fewer than `limit` items.
+
+`limit` and `offset` require `view=summary`. Other query parameters return `400`.
 
 ## Get Agent
 

--- a/docs/api/agents.md
+++ b/docs/api/agents.md
@@ -25,6 +25,9 @@ Summary pages contain only `id`, `companyId`, `name`, `urlKey`, `role`, `title`,
 defaults to 0. Results are ordered by agent ID. Continue until a page contains
 fewer than `limit` items.
 
+Agent creation or deletion during a scan can shift offset boundaries. Callers
+that require a point-in-time snapshot should restart the scan after fleet changes.
+
 `limit` and `offset` require `view=summary`. Other query parameters return `400`.
 
 ## Get Agent

--- a/docs/api/agents.md
+++ b/docs/api/agents.md
@@ -22,7 +22,8 @@ GET /api/companies/{companyId}/agents?view=summary&limit=100&offset=0
 
 Summary pages contain only `id`, `companyId`, `name`, `urlKey`, `role`, `title`,
 `status`, and `reportsTo`. `limit` defaults to 100 and cannot exceed 100; `offset`
-defaults to 0. Continue until a page contains fewer than `limit` items.
+defaults to 0. Results are ordered by agent ID. Continue until a page contains
+fewer than `limit` items.
 
 `limit` and `offset` require `view=summary`. Other query parameters return `400`.
 

--- a/server/src/__tests__/agent-permissions-routes.test.ts
+++ b/server/src/__tests__/agent-permissions-routes.test.ts
@@ -958,6 +958,64 @@ describe.sequential("agent permission routes", () => {
     expect(mockAgentService.list).not.toHaveBeenCalled();
   });
 
+  it("returns a bounded summary page for fleet enumeration", async () => {
+    const secondAgent = {
+      ...baseAgent,
+      id: "33333333-3333-4333-8333-333333333333",
+      name: "Reviewer",
+      urlKey: "reviewer",
+      role: "manager",
+      title: "Review Manager",
+      reportsTo: agentId,
+      adapterConfig: { token: "must-not-be-returned" },
+      runtimeConfig: { prompt: "must-not-be-returned" },
+    };
+    mockAgentService.list.mockResolvedValueOnce([baseAgent, secondAgent]);
+    const app = await createApp({
+      type: "board",
+      userId: "board-user",
+      source: "local_implicit",
+      isInstanceAdmin: true,
+      companyIds: [companyId],
+    });
+
+    const res = await requestApp(app, (baseUrl) => request(baseUrl)
+      .get(`/api/companies/${companyId}/agents`)
+      .query({ view: "summary", limit: "1", offset: "1" }));
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([{
+      id: secondAgent.id,
+      companyId,
+      name: "Reviewer",
+      urlKey: "reviewer",
+      role: "manager",
+      title: "Review Manager",
+      status: "idle",
+      reportsTo: agentId,
+    }]);
+    expect(res.body[0]).not.toHaveProperty("adapterConfig");
+    expect(res.body[0]).not.toHaveProperty("runtimeConfig");
+  });
+
+  it("requires summary view for agent list pagination", async () => {
+    const app = await createApp({
+      type: "board",
+      userId: "board-user",
+      source: "local_implicit",
+      isInstanceAdmin: true,
+      companyIds: [companyId],
+    });
+
+    const res = await requestApp(app, (baseUrl) => request(baseUrl)
+      .get(`/api/companies/${companyId}/agents`)
+      .query({ limit: "25" }));
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain("view=summary");
+    expect(mockAgentService.list).not.toHaveBeenCalled();
+  });
+
   it("normalizes direct agent creation to disable timer heartbeats by default", async () => {
     const app = await createApp({
       type: "board",

--- a/server/src/__tests__/agent-permissions-routes.test.ts
+++ b/server/src/__tests__/agent-permissions-routes.test.ts
@@ -970,7 +970,7 @@ describe.sequential("agent permission routes", () => {
       adapterConfig: { token: "must-not-be-returned" },
       runtimeConfig: { prompt: "must-not-be-returned" },
     };
-    mockAgentService.list.mockResolvedValueOnce([baseAgent, secondAgent]);
+    mockAgentService.list.mockResolvedValueOnce([secondAgent, baseAgent]);
     const app = await createApp({
       type: "board",
       userId: "board-user",
@@ -996,6 +996,32 @@ describe.sequential("agent permission routes", () => {
     }]);
     expect(res.body[0]).not.toHaveProperty("adapterConfig");
     expect(res.body[0]).not.toHaveProperty("runtimeConfig");
+  });
+
+  it("defaults summary enumeration to the first 100 agents in stable id order", async () => {
+    const agents = Array.from({ length: 101 }, (_, index) => ({
+      ...baseAgent,
+      id: `00000000-0000-4000-8000-${String(index).padStart(12, "0")}`,
+      name: `Agent ${index}`,
+      urlKey: `agent-${index}`,
+    })).reverse();
+    mockAgentService.list.mockResolvedValueOnce(agents);
+    const app = await createApp({
+      type: "board",
+      userId: "board-user",
+      source: "local_implicit",
+      isInstanceAdmin: true,
+      companyIds: [companyId],
+    });
+
+    const res = await requestApp(app, (baseUrl) => request(baseUrl)
+      .get(`/api/companies/${companyId}/agents`)
+      .query({ view: "summary" }));
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(100);
+    expect(res.body[0].id).toBe("00000000-0000-4000-8000-000000000000");
+    expect(res.body[99].id).toBe("00000000-0000-4000-8000-000000000099");
   });
 
   it("requires summary view for agent list pagination", async () => {

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -1635,6 +1635,19 @@ export function agentRoutes(
     };
   }
 
+  function toAgentListSummary(agent: NonNullable<Awaited<ReturnType<typeof svc.getById>>>) {
+    return {
+      id: agent.id,
+      companyId: agent.companyId,
+      name: agent.name,
+      urlKey: agent.urlKey,
+      role: agent.role,
+      title: agent.title,
+      status: agent.status,
+      reportsTo: agent.reportsTo,
+    };
+  }
+
   function redactAgentConfiguration(agent: Awaited<ReturnType<typeof svc.getById>>) {
     if (!agent) return null;
     return {
@@ -1967,11 +1980,42 @@ export function agentRoutes(
   router.get("/companies/:companyId/agents", async (req, res) => {
     const companyId = req.params.companyId as string;
     assertCompanyAccess(req, companyId);
-    const unsupportedQueryParams = Object.keys(req.query).sort();
+    const supportedQueryParams = new Set(["view", "limit", "offset"]);
+    const unsupportedQueryParams = Object.keys(req.query)
+      .filter((key) => !supportedQueryParams.has(key))
+      .sort();
     if (unsupportedQueryParams.length > 0) {
       res.status(400).json({
         error: `Unsupported query parameter${unsupportedQueryParams.length === 1 ? "" : "s"}: ${unsupportedQueryParams.join(", ")}`,
       });
+      return;
+    }
+    const hasBoundedQuery = Object.keys(req.query).length > 0;
+    if (hasBoundedQuery) {
+      if (req.query.view !== "summary") {
+        res.status(400).json({
+          error: "Agent list pagination requires view=summary",
+        });
+        return;
+      }
+      const rawLimit = req.query.limit ?? "100";
+      const rawOffset = req.query.offset ?? "0";
+      const limit = typeof rawLimit === "string" && /^\d+$/.test(rawLimit)
+        ? Number.parseInt(rawLimit, 10)
+        : Number.NaN;
+      const offset = typeof rawOffset === "string" && /^\d+$/.test(rawOffset)
+        ? Number.parseInt(rawOffset, 10)
+        : Number.NaN;
+      if (!Number.isInteger(limit) || limit < 1 || limit > 100) {
+        res.status(400).json({ error: "limit must be an integer between 1 and 100" });
+        return;
+      }
+      if (!Number.isInteger(offset) || offset < 0) {
+        res.status(400).json({ error: "offset must be a non-negative integer" });
+        return;
+      }
+      const result = await filterAgentsForActor(req, await svc.list(companyId));
+      res.json(result.slice(offset, offset + limit).map((agent) => toAgentListSummary(agent)));
       return;
     }
     const result = await filterAgentsForActor(req, await svc.list(companyId));

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -1635,7 +1635,7 @@ export function agentRoutes(
     };
   }
 
-  function toAgentListSummary(agent: NonNullable<Awaited<ReturnType<typeof svc.getById>>>) {
+  function toAgentListSummary(agent: Awaited<ReturnType<typeof svc.list>>[number]) {
     return {
       id: agent.id,
       companyId: agent.companyId,
@@ -2015,6 +2015,7 @@ export function agentRoutes(
         return;
       }
       const result = await filterAgentsForActor(req, await svc.list(companyId));
+      result.sort((left, right) => left.id.localeCompare(right.id));
       res.json(result.slice(offset, offset + limit).map((agent) => toAgentListSummary(agent)));
       return;
     }

--- a/skills/paperclip/SKILL.md
+++ b/skills/paperclip/SKILL.md
@@ -473,6 +473,7 @@ If `plan` already exists, fetch the current document first and send its latest `
 | List / get / delete attachment        | `GET /api/issues/:issueId/attachments` • `GET\|DELETE /api/attachments/:attachmentId[/content]`                                 |
 | Execution workspace + runtime         | `GET /api/execution-workspaces/:id` • `POST …/runtime-services/:action`                                                         |
 | Set agent instructions path           | `PATCH /api/agents/:agentId/instructions-path`                                                                                  |
+| List agents (full records)            | `GET /api/companies/:companyId/agents`                                                                                          |
 | List agents (bounded fleet scan)      | `GET /api/companies/:companyId/agents?view=summary&limit=100&offset=0`                                                          |
 | Dashboard                             | `GET /api/companies/:companyId/dashboard`                                                                                       |
 

--- a/skills/paperclip/SKILL.md
+++ b/skills/paperclip/SKILL.md
@@ -473,7 +473,7 @@ If `plan` already exists, fetch the current document first and send its latest `
 | List / get / delete attachment        | `GET /api/issues/:issueId/attachments` • `GET\|DELETE /api/attachments/:attachmentId[/content]`                                 |
 | Execution workspace + runtime         | `GET /api/execution-workspaces/:id` • `POST …/runtime-services/:action`                                                         |
 | Set agent instructions path           | `PATCH /api/agents/:agentId/instructions-path`                                                                                  |
-| List agents                           | `GET /api/companies/:companyId/agents`                                                                                          |
+| List agents (bounded fleet scan)      | `GET /api/companies/:companyId/agents?view=summary&limit=100&offset=0`                                                          |
 | Dashboard                             | `GET /api/companies/:companyId/dashboard`                                                                                       |
 
 Full endpoint table (company imports/exports, OpenClaw invites, company skills, routines, etc.) lives in `references/api-reference.md`.

--- a/skills/paperclip/references/api-reference.md
+++ b/skills/paperclip/references/api-reference.md
@@ -605,7 +605,8 @@ Where `<prefix>` is the company prefix derived from the issue identifier (e.g., 
 
 For machine-authored comments, do not rely on raw `@AgentName` text. Raw text is unreliable for names containing spaces. Instead:
 
-1. Resolve the target agent with `GET /api/companies/{companyId}/agents`
+1. Resolve the target agent with bounded summary pages from
+   `GET /api/companies/{companyId}/agents?view=summary&limit=100&offset=0`
 2. Find the agent's exact display name and `id`
 3. Emit a structured markdown mention using the agent ID:
 
@@ -1171,7 +1172,7 @@ Terminal states: `done`, `cancelled`
 | GET    | `/api/agents/me`                   | Your agent record + chain of command |
 | GET    | `/api/agents/me/inbox/mine?userId=:userId` | Mine-tab issue list for a specific board user |
 | GET    | `/api/agents/:agentId`             | Agent details + chain of command     |
-| GET    | `/api/companies/:companyId/agents` | List all agents in company           |
+| GET    | `/api/companies/:companyId/agents?view=summary&limit=100&offset=0` | List a bounded summary page of agents |
 | POST   | `/api/companies/:companyId/agents` | Create agent directly (no approval)  |
 | PATCH  | `/api/agents/:agentId`             | Update agent config or budget        |
 | POST   | `/api/agents/:agentId/pause`       | Temporarily stop heartbeats          |

--- a/skills/paperclip/references/api-reference.md
+++ b/skills/paperclip/references/api-reference.md
@@ -1172,6 +1172,7 @@ Terminal states: `done`, `cancelled`
 | GET    | `/api/agents/me`                   | Your agent record + chain of command |
 | GET    | `/api/agents/me/inbox/mine?userId=:userId` | Mine-tab issue list for a specific board user |
 | GET    | `/api/agents/:agentId`             | Agent details + chain of command     |
+| GET    | `/api/companies/:companyId/agents` | List all agents in company           |
 | GET    | `/api/companies/:companyId/agents?view=summary&limit=100&offset=0` | List a bounded summary page of agents |
 | POST   | `/api/companies/:companyId/agents` | Create agent directly (no approval)  |
 | PATCH  | `/api/agents/:agentId`             | Update agent config or budget        |


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source control plane people use to manage AI-agent companies
> - Fleet automation needs to enumerate company agents through the company-scoped API
> - The existing route returns full agent records and rejects all query parameters
> - Large responses can exceed constrained bridge or adapter response limits
> - Existing clients still depend on the unparameterized full-list response
> - This pull request adds an opt-in, capped, deterministically ordered summary view while preserving that contract
> - The benefit is predictable response size and reliable page traversal without exposing runtime configuration

## Linked Issues or Issue Description

## What happened?
Large company agent-list responses can exceed constrained client response limits, while callers currently have no bounded enumeration contract.

## Steps to reproduce
1. Operate a company with enough agents for the full records to exceed a 262,144-byte bridge response cap.
2. Request `GET /api/companies/{companyId}/agents` through that bridge.
3. Attempt to add pagination parameters; the route rejects them.

## Expected behavior
Callers can request capped, stably ordered pages containing identity and reporting metadata only.

## Paperclip version or commit
`master` at base commit `5d42382d`.

## Deployment mode
Self-hosted server accessed through a run-scoped bridge.

## Actual behavior
The route rejects pagination parameters and returns every full agent record in one response.

## What Changed

- Added `view=summary` with validated `limit` and `offset`, capped at 100 records.
- Restricted summary responses to identity, role, status, and reporting fields.
- Ordered summary pages by agent ID so offset traversal cannot skip or duplicate stable fleet records.
- Preserved the existing unparameterized full-list response and documentation.
- Added focused coverage for projection, stable ordering, default values, and the 100-record boundary.

## Verification

- `pnpm exec vitest run server/src/__tests__/agent-permissions-routes.test.ts` — 56 tests passed.
- `pnpm --filter @paperclipai/server typecheck` — passed.
- `git diff --check` — passed.

## Risks

- Low compatibility risk because the existing no-query contract is unchanged.
- Concurrent agent creation or deletion can still shift offset boundaries; stable ID ordering removes nondeterministic database ordering but is not snapshot isolation.
- The service still obtains the company list before slicing, so this bounds serialized response size rather than database work.
- Rollback is removal of the opt-in query branch; legacy responses and database state are unchanged.

> This is a tightly scoped API reliability fix and does not overlap a listed roadmap milestone.

## Model Used

- OpenAI GPT-5.6 Sol, tool-enabled coding and test execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change and contains no internal ticket id
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

Made with [Cursor](https://cursor.com)