### PR TITLE
fix: preserve callback bridge runtime PATH

### DIFF
--- a/packages/adapter-utils/src/execution-target.ts
+++ b/packages/adapter-utils/src/execution-target.ts
@@ -1624,6 +1624,7 @@ export async function startAdapterExecutionTargetPaperclipBridge(input: {
   runtimeRootDir: string | null | undefined;
   adapterKey: string;
   timeoutSec?: number | null;
+  runtimePath?: string | null;
   hostApiToken: string | null | undefined;
   hostApiUrl?: string | null;
   onLog?: (stream: "stdout" | "stderr", chunk: string) => Promise<void>;
@@ -1736,6 +1737,7 @@ export async function startAdapterExecutionTargetPaperclipBridge(input: {
       bridgeAsset,
       timeoutMs: bridgeTimeoutMs,
       maxBodyBytes,
+      runtimePath: input.runtimePath,
       shellCommand,
     });
   } catch (error) {

--- a/packages/adapter-utils/src/sandbox-callback-bridge.test.ts
+++ b/packages/adapter-utils/src/sandbox-callback-bridge.test.ts
@@ -114,6 +114,44 @@ describe("sandbox callback bridge", () => {
     }
   });
 
+  it("uses the explicit runtime PATH to launch the bridge Node process", async () => {
+    const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-bridge-runtime-path-"));
+    cleanupDirs.push(rootDir);
+
+    const remoteWorkspaceDir = path.join(rootDir, "remote-workspace");
+    const assetRemoteDir = path.join(remoteWorkspaceDir, "bridge-server");
+    const queueDir = path.join(remoteWorkspaceDir, "bridge-queue");
+    const versionedNodeBin = path.join(rootDir, "node-v22", "bin");
+    const markerFile = path.join(rootDir, "selected-node.txt");
+    await mkdir(remoteWorkspaceDir, { recursive: true });
+    await mkdir(versionedNodeBin, { recursive: true });
+
+    const quotedNodePath = process.execPath.replaceAll("'", "'\"'\"'");
+    await writeFile(
+      path.join(versionedNodeBin, "node"),
+      `#!/bin/sh\nprintf '%s\\n' versioned-node > "${markerFile}"\nexec '${quotedNodePath}' "$@"\n`,
+      { mode: 0o755 },
+    );
+
+    const bridgeAsset = await createSandboxCallbackBridgeAsset();
+    cleanupFns.push(bridgeAsset.cleanup);
+    const bridge = await startSandboxCallbackBridgeServer({
+      runner: createExecRunner(),
+      remoteCwd: remoteWorkspaceDir,
+      assetRemoteDir,
+      queueDir,
+      bridgeToken: createSandboxCallbackBridgeToken(),
+      bridgeAsset,
+      runtimePath: [versionedNodeBin, process.env.PATH ?? ""].filter(Boolean).join(path.delimiter),
+      timeoutMs: 30_000,
+    });
+    cleanupFns.push(async () => {
+      await bridge.stop();
+    });
+
+    expect(await readFile(markerFile, "utf8")).toBe("versioned-node\n");
+  });
+
   it("round-trips localhost bridge requests over the sandbox queue without forwarding the bridge token", async () => {
     const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-bridge-runtime-"));
     cleanupDirs.push(rootDir);

--- a/packages/adapter-utils/src/sandbox-callback-bridge.ts
+++ b/packages/adapter-utils/src/sandbox-callback-bridge.ts
@@ -883,6 +883,7 @@ export async function startSandboxCallbackBridgeServer(input: {
   responseTimeoutMs?: number | null;
   timeoutMs?: number | null;
   nodeCommand?: string;
+  runtimePath?: string | null;
   shellCommand?: "bash" | "sh" | null;
   maxQueueDepth?: number | null;
   maxBodyBytes?: number | null;
@@ -929,6 +930,7 @@ export async function startSandboxCallbackBridgeServer(input: {
     cwd: input.remoteCwd,
     env: {
       [SANDBOX_EXEC_CHANNEL_ENV]: SANDBOX_EXEC_CHANNEL_BRIDGE,
+      ...(input.runtimePath?.trim() ? { PATH: input.runtimePath } : {}),
       ...env,
     },
     timeoutMs,

--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -672,6 +672,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       runtimeRootDir: preparedExecutionTargetRuntime?.runtimeRootDir,
       adapterKey: "claude",
       timeoutSec,
+      runtimePath: env.PATH,
       hostApiToken: env.PAPERCLIP_API_KEY,
       onLog,
     });


### PR DESCRIPTION
## Thinking Path

> - Paperclip manages AI agents across local and remote execution environments.
> - Remote adapters use a sandbox callback bridge so agents can reach the Paperclip control plane.
> - Claude's sandbox preparation can install Node in a version-managed directory and expose it through the adapter runtime `PATH`.
> - Bridge startup discarded that prepared path and invoked `nohup node` against the sandbox's ambient environment.
> - This caused otherwise prepared Claude heartbeats to fail before the bridge became ready.
> - This pull request carries the prepared runtime `PATH` through bridge startup and verifies that the versioned Node shim is selected.
> - The benefit is deterministic callback-bridge startup without changing persisted data or non-Claude adapter behavior.

## Linked Issues or Issue Description

- Bug: a remote `claude_local` sandbox can successfully install and resolve a versioned Node runtime for the adapter process, while callback-bridge startup still fails with `nohup: failed to run command node` because bridge startup does not receive the adapter runtime `PATH`.
- Expected behavior: the callback bridge starts with the same explicit runtime path prepared for the Claude invocation.
- Actual behavior: bridge startup falls back to the sandbox runner's ambient path.

## What Changed

- Added optional runtime-path plumbing to callback-bridge startup.
- Passed Claude's prepared `PATH` into the remote callback bridge.
- Added a regression proving a versioned Node shim is selected from the explicit path.

## Verification

- `pnpm exec vitest run packages/adapter-utils/src/sandbox-callback-bridge.test.ts packages/adapter-utils/src/execution-target-sandbox.test.ts` — 40/40 passed.
- `pnpm --filter @paperclipai/adapter-utils typecheck` — passed.
- `pnpm --filter @paperclipai/adapter-claude-local typecheck` — passed.

## Risks

- Low risk: the new field is optional and only changes bridge process startup when Claude supplies an explicit path.
- A malformed configured `PATH` could still prevent Node resolution; rollback is reverting commit `38874536` and redeploying the previous artifact.
- No schema or persisted-data changes.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI GPT-5.6 Sol (`gpt-5.6-sol`), reasoning and tool-use mode with repository editing, shell execution, and test verification.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes (no operator-facing documentation change required)
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

Made with [Cursor](https://cursor.com)