### PR TITLE
fix: validate embedded Postgres PID identity before reuse

### DIFF
--- a/cli/src/__tests__/worktree.test.ts
+++ b/cli/src/__tests__/worktree.test.ts
@@ -20,6 +20,7 @@ import {
 import {
   copyGitHooksToWorktreeGitDir,
   copySeededSecretsKey,
+  isEmbeddedPostgresUnsafeToOverwrite,
   pauseSeededScheduledRoutines,
   quarantineSeededWorktreeExecutionState,
   readSourceAttachmentBody,
@@ -165,6 +166,32 @@ function buildSourceConfig(): PaperclipConfig {
 }
 
 describe("worktree helpers", () => {
+  it("blocks both running and ambiguous embedded PostgreSQL overwrite targets", () => {
+    const base = {
+      pid: 4242,
+      port: 54330,
+      dataDir: "/tmp/worktree-db",
+      pidFile: "/tmp/worktree-db/postmaster.pid",
+      pidFileDataDir: "/tmp/worktree-db",
+    };
+
+    expect(isEmbeddedPostgresUnsafeToOverwrite({
+      ...base,
+      state: "running",
+      reason: "data_directory_match",
+    })).toBe(true);
+    expect(isEmbeddedPostgresUnsafeToOverwrite({
+      ...base,
+      state: "ambiguous",
+      reason: "identity_unverified",
+    })).toBe(true);
+    expect(isEmbeddedPostgresUnsafeToOverwrite({
+      ...base,
+      state: "stale",
+      reason: "dead_pid",
+    })).toBe(false);
+  });
+
   it("sanitizes instance ids", () => {
     expect(sanitizeWorktreeInstanceId("feature/worktree-support")).toBe("feature-worktree-support");
     expect(sanitizeWorktreeInstanceId("  ")).toBe("worktree");

--- a/cli/src/commands/routines.ts
+++ b/cli/src/commands/routines.ts
@@ -8,7 +8,9 @@ import {
   createDb,
   createEmbeddedPostgresLogBuffer,
   ensurePostgresDatabase,
+  formatEmbeddedPostgresLifecycleAmbiguity,
   formatEmbeddedPostgresError,
+  inspectEmbeddedPostgresLifecycle,
   prepareEmbeddedPostgresNativeRuntime,
   routines,
 } from "@paperclipai/db";
@@ -83,29 +85,6 @@ async function findAvailablePort(preferredPort: number): Promise<number> {
   return port;
 }
 
-function readPidFilePort(postmasterPidFile: string): number | null {
-  if (!fs.existsSync(postmasterPidFile)) return null;
-  try {
-    const lines = fs.readFileSync(postmasterPidFile, "utf8").split("\n");
-    const port = Number(lines[3]?.trim());
-    return Number.isInteger(port) && port > 0 ? port : null;
-  } catch {
-    return null;
-  }
-}
-
-function readRunningPostmasterPid(postmasterPidFile: string): number | null {
-  if (!fs.existsSync(postmasterPidFile)) return null;
-  try {
-    const pid = Number(fs.readFileSync(postmasterPidFile, "utf8").split("\n")[0]?.trim());
-    if (!Number.isInteger(pid) || pid <= 0) return null;
-    process.kill(pid, 0);
-    return pid;
-  } catch {
-    return null;
-  }
-}
-
 async function ensureEmbeddedPostgres(dataDir: string, preferredPort: number): Promise<EmbeddedPostgresHandle> {
   const moduleName = "embedded-postgres";
   let EmbeddedPostgres: EmbeddedPostgresCtor;
@@ -120,10 +99,16 @@ async function ensureEmbeddedPostgres(dataDir: string, preferredPort: number): P
   await prepareEmbeddedPostgresNativeRuntime();
 
   const postmasterPidFile = path.resolve(dataDir, "postmaster.pid");
-  const runningPid = readRunningPostmasterPid(postmasterPidFile);
-  if (runningPid) {
+  const lifecycle = await inspectEmbeddedPostgresLifecycle({
+    dataDir,
+    configuredPort: preferredPort,
+  });
+  if (lifecycle.state === "ambiguous") {
+    throw new Error(formatEmbeddedPostgresLifecycleAmbiguity(lifecycle));
+  }
+  if (lifecycle.state === "running") {
     return {
-      port: readPidFilePort(postmasterPidFile) ?? preferredPort,
+      port: lifecycle.port,
       startedByThisProcess: false,
       stop: async () => {},
     };
@@ -153,7 +138,10 @@ async function ensureEmbeddedPostgres(dataDir: string, preferredPort: number): P
     }
   }
 
-  if (fs.existsSync(postmasterPidFile)) {
+  if (lifecycle.state === "stale" && fs.existsSync(postmasterPidFile)) {
+    process.emitWarning(
+      `Removing stale embedded PostgreSQL PID file ${postmasterPidFile} (${lifecycle.reason}).`,
+    );
     fs.rmSync(postmasterPidFile, { force: true });
   }
 

--- a/cli/src/commands/worktree.ts
+++ b/cli/src/commands/worktree.ts
@@ -45,8 +45,11 @@ import {
   runDatabaseRestore,
   resetPostgresDatabase,
   createEmbeddedPostgresLogBuffer,
+  formatEmbeddedPostgresLifecycleAmbiguity,
   formatEmbeddedPostgresError,
+  inspectEmbeddedPostgresLifecycle,
   prepareEmbeddedPostgresNativeRuntime,
+  type EmbeddedPostgresLifecycleResult,
 } from "@paperclipai/db";
 import type { Command } from "commander";
 import { ensureAgentJwtSecret, loadPaperclipEnvFile, mergePaperclipEnvEntries, readPaperclipEnvEntries, resolvePaperclipEnvFile } from "../config/env.js";
@@ -476,29 +479,6 @@ export function resolveGitWorktreeAddArgs(input: {
   }
   const commitish = input.startPoint ?? "HEAD";
   return ["worktree", "add", "-b", input.branchName, input.targetPath, commitish];
-}
-
-function readPidFilePort(postmasterPidFile: string): number | null {
-  if (!existsSync(postmasterPidFile)) return null;
-  try {
-    const lines = readFileSync(postmasterPidFile, "utf8").split("\n");
-    const port = Number(lines[3]?.trim());
-    return Number.isInteger(port) && port > 0 ? port : null;
-  } catch {
-    return null;
-  }
-}
-
-function readRunningPostmasterPid(postmasterPidFile: string): number | null {
-  if (!existsSync(postmasterPidFile)) return null;
-  try {
-    const pid = Number(readFileSync(postmasterPidFile, "utf8").split("\n")[0]?.trim());
-    if (!Number.isInteger(pid) || pid <= 0) return null;
-    process.kill(pid, 0);
-    return pid;
-  } catch {
-    return null;
-  }
 }
 
 async function isPortAvailable(port: number): Promise<boolean> {
@@ -1065,10 +1045,16 @@ async function ensureEmbeddedPostgres(dataDir: string, preferredPort: number): P
   await prepareEmbeddedPostgresNativeRuntime();
 
   const postmasterPidFile = path.resolve(dataDir, "postmaster.pid");
-  const runningPid = readRunningPostmasterPid(postmasterPidFile);
-  if (runningPid) {
+  const lifecycle = await inspectEmbeddedPostgresLifecycle({
+    dataDir,
+    configuredPort: preferredPort,
+  });
+  if (lifecycle.state === "ambiguous") {
+    throw new Error(formatEmbeddedPostgresLifecycleAmbiguity(lifecycle));
+  }
+  if (lifecycle.state === "running") {
     return {
-      port: readPidFilePort(postmasterPidFile) ?? preferredPort,
+      port: lifecycle.port,
       startedByThisProcess: false,
       stop: async () => {},
     };
@@ -1097,7 +1083,10 @@ async function ensureEmbeddedPostgres(dataDir: string, preferredPort: number): P
       });
     }
   }
-  if (existsSync(postmasterPidFile)) {
+  if (lifecycle.state === "stale" && existsSync(postmasterPidFile)) {
+    process.emitWarning(
+      `Removing stale embedded PostgreSQL PID file ${postmasterPidFile} (${lifecycle.reason}).`,
+    );
     rmSync(postmasterPidFile, { force: true });
   }
   try {
@@ -2145,11 +2134,22 @@ function renderMergePlan(plan: Awaited<ReturnType<typeof collectMergePlan>>["pla
   return lines.join("\n");
 }
 
-function resolveRunningEmbeddedPostgresPid(config: PaperclipConfig): number | null {
+async function inspectConfiguredEmbeddedPostgres(
+  config: PaperclipConfig,
+): Promise<EmbeddedPostgresLifecycleResult | null> {
   if (config.database.mode !== "embedded-postgres") {
     return null;
   }
-  return readRunningPostmasterPid(path.resolve(config.database.embeddedPostgresDataDir, "postmaster.pid"));
+  return await inspectEmbeddedPostgresLifecycle({
+    dataDir: config.database.embeddedPostgresDataDir,
+    configuredPort: config.database.embeddedPostgresPort,
+  });
+}
+
+export function isEmbeddedPostgresUnsafeToOverwrite(
+  lifecycle: EmbeddedPostgresLifecycleResult | null,
+): boolean {
+  return lifecycle?.state === "running" || lifecycle?.state === "ambiguous";
 }
 
 async function collectMergePlan(input: {
@@ -3124,10 +3124,13 @@ async function runWorktreeReseed(opts: WorktreeReseedOptions): Promise<void> {
     configPath: targetEndpoint.configPath,
     rootPath: targetEndpoint.rootPath,
   });
-  const runningTargetPid = resolveRunningEmbeddedPostgresPid(targetConfig);
-  if (runningTargetPid && !opts.allowLiveTarget) {
+  const targetLifecycle = await inspectConfiguredEmbeddedPostgres(targetConfig);
+  const unsafeTargetLifecycle = isEmbeddedPostgresUnsafeToOverwrite(targetLifecycle)
+    ? targetLifecycle
+    : null;
+  if (unsafeTargetLifecycle && !opts.allowLiveTarget) {
     throw new Error(
-      `Target worktree database appears to be running (pid ${runningTargetPid}). Stop Paperclip in ${targetEndpoint.rootPath} before reseeding, or re-run with --allow-live-target if you want to override this guard.`,
+      `Target worktree database is unsafe to overwrite (state=${unsafeTargetLifecycle.state}, pid=${unsafeTargetLifecycle.pid ?? "unknown"}). Stop Paperclip in ${targetEndpoint.rootPath} and verify the embedded PostgreSQL state before reseeding, or re-run with --allow-live-target if you want to override this guard.`,
     );
   }
 
@@ -3142,8 +3145,10 @@ async function runWorktreeReseed(opts: WorktreeReseedOptions): Promise<void> {
     return;
   }
 
-  if (runningTargetPid && opts.allowLiveTarget) {
-    p.log.warning(`Proceeding even though the target embedded PostgreSQL appears to be running (pid ${runningTargetPid}).`);
+  if (unsafeTargetLifecycle && opts.allowLiveTarget) {
+    p.log.warning(
+      `Proceeding even though the target embedded PostgreSQL is unsafe to overwrite (state=${unsafeTargetLifecycle.state}, pid=${unsafeTargetLifecycle.pid ?? "unknown"}).`,
+    );
   }
 
   const spinner = p.spinner();
@@ -3246,14 +3251,25 @@ export async function worktreeRepairCommand(opts: WorktreeRepairOptions): Promis
     homeDir: resolveWorktreeHome(opts.home),
     instanceId: repairInstanceId,
   });
-  const runningTargetPid = readRunningPostmasterPid(path.resolve(repairPaths.embeddedPostgresDataDir, "postmaster.pid"));
-  if (runningTargetPid && !opts.allowLiveTarget) {
+  const targetLifecycle = await inspectEmbeddedPostgresLifecycle({
+    dataDir: repairPaths.embeddedPostgresDataDir,
+    configuredPort:
+      targetConfig?.database.mode === "embedded-postgres"
+        ? targetConfig.database.embeddedPostgresPort
+        : 54329,
+  });
+  const unsafeTargetLifecycle = isEmbeddedPostgresUnsafeToOverwrite(targetLifecycle)
+    ? targetLifecycle
+    : null;
+  if (unsafeTargetLifecycle && !opts.allowLiveTarget) {
     throw new Error(
-      `Target worktree database appears to be running (pid ${runningTargetPid}). Stop Paperclip in ${target.rootPath} before repairing, or re-run with --allow-live-target if you want to override this guard.`,
+      `Target worktree database is unsafe to overwrite (state=${unsafeTargetLifecycle.state}, pid=${unsafeTargetLifecycle.pid ?? "unknown"}). Stop Paperclip in ${target.rootPath} and verify the embedded PostgreSQL state before repairing, or re-run with --allow-live-target if you want to override this guard.`,
     );
   }
-  if (runningTargetPid && opts.allowLiveTarget) {
-    p.log.warning(`Proceeding even though the target embedded PostgreSQL appears to be running (pid ${runningTargetPid}).`);
+  if (unsafeTargetLifecycle && opts.allowLiveTarget) {
+    p.log.warning(
+      `Proceeding even though the target embedded PostgreSQL is unsafe to overwrite (state=${unsafeTargetLifecycle.state}, pid=${unsafeTargetLifecycle.pid ?? "unknown"}).`,
+    );
   }
 
   const originalCwd = process.cwd();

--- a/doc/plans/2026-07-17-embedded-postgres-pid-validation.md
+++ b/doc/plans/2026-07-17-embedded-postgres-pid-validation.md
@@ -1,0 +1,300 @@
+# Embedded PostgreSQL PID Validation and Safe Recovery
+
+Status: Proposed for review  
+Date: 2026-07-17  
+Branch: `fix/embedded-postgres-pid-validation`  
+Grounded in: `paperclipai/paperclip` `upstream/master` at `5d42382df4c5724085967027485fcd39b91b01ae`
+
+## Goal
+
+Prevent Paperclip from treating an unrelated process that reused a stale
+`postmaster.pid` PID as the embedded PostgreSQL server, while preserving safe
+reuse of the real embedded cluster and automatic recovery from PID files that
+are provably stale.
+
+Observable success means:
+
+- a pre-reboot `postmaster.pid` whose PID now belongs to another process is not
+  adopted as PostgreSQL;
+- Paperclip removes only a PID file that it can prove stale and starts the
+  embedded database normally;
+- a reachable PostgreSQL instance is reused only after its resolved
+  `data_directory` matches the configured embedded data directory;
+- an ambiguous live current-boot PID fails closed without removing the PID file
+  or starting a second postmaster against the same data directory;
+- server, migration, routine-maintenance, and worktree paths use the same
+  classification contract.
+
+## Incident Evidence
+
+On the Gimle iMac after a reboot, the persisted
+`~/.paperclip/instances/default/db/postmaster.pid` named PID `1406`, while PID
+`1406` belonged to an nginx worker and no PostgreSQL process or listener was
+present. The installed server accepted the PID because `process.kill(pid, 0)`
+succeeded, skipped embedded PostgreSQL startup, and repeatedly failed to connect
+to `127.0.0.1:54329`.
+
+Recovery required stopping the launchd jobs, independently confirming that no
+PostgreSQL process/listener existed, archiving the stale PID file, and starting
+Paperclip again. The live instance is healthy now and is explicitly outside the
+implementation workspace for this change.
+
+## Assumptions
+
+- PostgreSQL's `postmaster.pid` fields remain in their documented order: PID on
+  line 1, data directory on line 2, start epoch seconds on line 3, and port on
+  line 4.
+- `os.uptime()` provides a sufficiently accurate current-boot boundary when
+  compared with the PID-file start epoch using a small clock-skew tolerance.
+- A successful PostgreSQL query for `data_directory` is stronger cluster
+  identity evidence than a process name or PID alone.
+- A live current-boot PID that cannot be verified may represent a PostgreSQL
+  startup or failure in progress. Preserving the PID file and reporting an
+  actionable error is safer than deleting it.
+- The production iMac remains on the existing installed canary until this source
+  change is reviewed, tested, released, and separately approved for deployment.
+
+## Scope
+
+### In scope
+
+- Add one side-effect-free embedded PostgreSQL inspection/classification helper
+  in `@paperclipai/db`.
+- Parse and validate the relevant `postmaster.pid` fields once.
+- Distinguish absent, verified running, provably stale, and ambiguous states.
+- Prove a running cluster by connecting to the recorded port and matching
+  `SHOW data_directory`/`current_setting('data_directory')` to the expected
+  directory.
+- Treat invalid/dead PID files and files whose PostgreSQL start timestamp
+  predates the current OS boot as stale.
+- Preserve and surface ambiguous live current-boot PID files.
+- Apply the shared result in server startup, migration startup, routines, and
+  worktree startup/repair guards.
+- Add regression tests for the incident and for fail-closed behavior.
+
+### Out of scope
+
+- Modifying, restarting, upgrading, or deploying the live iMac Paperclip
+  instance during implementation.
+- Editing generated `dist/` or the globally installed npm package by hand.
+- Replacing embedded PostgreSQL, changing database credentials, or changing the
+  external `DATABASE_URL` path.
+- Automatically killing a process that happens to occupy the PID.
+- Automatically deleting a current-boot PID file when cluster identity remains
+  ambiguous.
+- Refactoring the duplicated embedded PostgreSQL constructors beyond sharing
+  classification and identity evidence.
+- Changing generic process-liveness helpers whose callers need only liveness,
+  not identity.
+
+## Classification Contract
+
+The shared inspector accepts the expected data directory and preferred port,
+reads `postmaster.pid` when present, and returns a discriminated result:
+
+| State | Evidence | Caller action |
+|---|---|---|
+| `absent` | No PID file | Preserve the existing configured-port adoption probe, then start if no matching cluster is reachable |
+| `running` | A PostgreSQL connection on the PID-file/configured fallback port whose resolved data directory matches; PID liveness alone is never sufficient | Reuse the reported PID (when valid) and port |
+| `stale` | No matching expected cluster is reachable, and the PID is invalid/dead, the PID-file start time is provably before the current OS boot, or supported process inspection definitively identifies a non-PostgreSQL command | Archive/log or remove only that PID file, then use the normal adoption/start path |
+| `ambiguous` | A live current-boot PID cannot otherwise be proven stale and PostgreSQL is unreachable, reports another data directory, or required identity fields cannot establish the expected cluster | Fail with PID, port, data directory, and recovery guidance; preserve the file and do not start another postmaster |
+
+The inspector does not delete files, start processes, or mutate the database.
+Each lifecycle owner performs its existing startup action only after consuming
+the classification.
+
+For compatibility, a missing or invalid PID-file port falls back to the
+configured port for probing, but successful reuse still requires a matching
+database data directory. A successfully parsed recorded port takes precedence
+over the configured port.
+
+## Affected Areas
+
+- `packages/db/src/embedded-postgres-lifecycle.ts` (new): parsing,
+  current-boot classification, database identity probe, and result types.
+- `packages/db/src/embedded-postgres-lifecycle.test.ts` (new): deterministic
+  lifecycle and incident regression coverage.
+- `packages/db/src/index.ts`: export the shared inspector and types.
+- `packages/db/src/migration-runtime.ts`: replace PID-only adoption and restrict
+  PID-file removal to `stale`.
+- `server/src/index.ts`: replace inline PID-only logic, honor the recorded port,
+  log stale recovery, and fail closed for ambiguous identity.
+- `server/src/__tests__/server-startup-feedback-export.test.ts`: consumer-level
+  reuse and ambiguity coverage using the existing startup test seam.
+- `cli/src/commands/routines.ts`: consume the shared classification before
+  maintenance startup.
+- `cli/src/commands/worktree.ts`: consume the shared classification for database
+  startup and make repair/reseed guards conservative for ambiguous live state.
+- CLI tests only where needed to prove the changed guard/consumer contract;
+  avoid duplicating the package classifier matrix.
+
+## Behavioral Details
+
+### Parsing and boot boundary
+
+- Reject non-integer/non-positive PIDs and ports as invalid fields.
+- Parse line 3 only as positive epoch seconds.
+- Estimate boot epoch as `Date.now() - os.uptime() * 1000`.
+- Apply a five-minute tolerance to avoid false stale classification from clock
+  resolution or ordinary wall-clock adjustments.
+- First allow a successful expected-cluster identity probe to produce `running`.
+  If that probe fails, classify a valid PID-file start time older than the
+  tolerated boot boundary as `stale` even if `process.kill(pid, 0)` succeeds.
+  This is the concrete reboot/PID reuse repair path.
+
+### Identity verification
+
+- `process.kill(pid, 0)` remains a liveness precheck only.
+- Probe the PID-file port (or configured fallback) using the existing
+  `getPostgresDataDirectory` utility.
+- Normalize both paths with `path.resolve` before comparison.
+- Reuse only on an exact normalized match.
+- A reachable PostgreSQL server using another directory is `ambiguous`, not a
+  free port and not an adoptable server.
+- On supported POSIX hosts, process command inspection may provide negative
+  evidence after the database probe fails: a command definitively unrelated to
+  PostgreSQL makes the PID file `stale`. An unavailable or inconclusive command
+  lookup remains `ambiguous`. Process names are never positive identity proof.
+- Distinguish `ESRCH` (dead) from `EPERM` (exists but inaccessible). `EPERM`
+  remains live/ambiguous unless pre-boot or definitive non-PostgreSQL evidence
+  proves the PID file stale.
+
+### Safe mutation
+
+- Only callers that receive `stale` may remove the PID file.
+- Removal remains immediately adjacent to the existing start path and is logged
+  with the stale reason.
+- `ambiguous` never removes or renames the file and never starts embedded
+  PostgreSQL.
+- No code sends signals to the PID from `postmaster.pid`.
+
+### Consumer consistency
+
+- Server and migration paths reuse the inspector's reported port.
+- Routines and worktree maintenance use the same startup contract.
+- Worktree repair/reseed guards treat both `running` and `ambiguous` as unsafe to
+  overwrite; only `absent` and `stale` permit the existing stopped-target path.
+- External PostgreSQL behavior is unchanged.
+
+## Analog Delta Matrix
+
+| Field | Required content |
+|---|---|
+| Analog family | Primary: `packages/db/src/migration-runtime.ts` plus `getPostgresDataDirectory`, which already adopts a PID-file-less server only after data-directory verification. Supporting: `findAdoptableLocalService`, which treats PID liveness as only one input and verifies command/cwd/config/port, with tests rejecting a live owner from another workspace. Rejected counterexample: the PID-only `getRunningPid`/`readRunningPostmasterPid` family in server, DB, and CLI. |
+| Coverage | Contract/implementation/composition/consumer/lifecycle/error come from the DB adoption and local-service adoption paths. Test behavior comes from the cross-workspace live-owner rejection tests. Trust and persistence boundaries are independently anchored at current HEAD. Palace/codebase-memory were unavailable, so all load-bearing evidence uses Serena plus targeted `rg` and git blame against `5d42382df`. |
+| Invariants to preserve | Persistent embedded data directory; existing external-Postgres path; configured-port adoption when PID file is absent; no second postmaster against an ambiguous live cluster; no process termination; existing initialization, migration, logging, and stop ownership. |
+| Required differences | Apply data-directory identity verification even when the PID is live; parse and honor PID-file port; recognize pre-boot PID files; expose one shared classification to all consumers; remove a PID file only after a `stale` result; fail closed for ambiguous live current-boot identity. |
+| Rejected differences | No launchd wrapper workaround as the primary fix; no process-name-only identity rule; no automatic kill; no broad embedded-PostgreSQL constructor refactor; no dependency update; no live iMac mutation. |
+| Failure modes | Wall-clock/uptime skew; malformed or partially written PID file; PID reuse before/after reboot; unavailable/inconclusive process inspection; PostgreSQL starting but not ready; wrong cluster on the port; recorded/configured port divergence; probe timeout/refusal; concurrent Paperclip starts; consumer accidentally deleting an ambiguous PID file. |
+| Tests before code | Reproduce with a live unrelated PID and a pre-boot PID-file timestamp; verify original classifier would call it running while the new classifier returns stale. Add current-boot non-PostgreSQL PID coverage, plus an inconclusive-inspection/unreachable-port case that returns ambiguous and preserves the file. |
+| Verification | Run focused DB classifier tests first, server startup consumer tests second, CLI worktree/routines tests third, then package typechecks, full Vitest, and build. Review the final diff against this matrix and verify no live iMac command was executed. |
+
+## Test Plan
+
+### Package classifier tests
+
+1. No `postmaster.pid` returns `absent`.
+2. Malformed or non-positive PID returns `stale` without signaling another
+   process.
+3. Dead PID returns `stale`.
+4. A live unrelated process combined with a pre-boot PostgreSQL start timestamp
+   returns `stale` (direct regression for the iMac incident).
+5. A live current-boot PID with a definitively non-PostgreSQL command and no
+   matching database returns `stale` on supported hosts.
+6. A live current-boot PID whose command inspection is unavailable or
+   inconclusive and whose database is unreachable returns `ambiguous`.
+7. `EPERM` is not treated as a dead PID and remains fail-closed without other
+   stale evidence.
+8. A reachable PostgreSQL reporting another data directory returns `ambiguous`
+   when the live PID cannot otherwise be proven stale.
+9. A reachable PostgreSQL reporting the expected normalized data directory
+   returns `running` and uses the PID-file port.
+10. Missing/invalid PID-file port uses the configured fallback for probing but
+   still requires the data-directory match.
+11. Boot-boundary tolerance does not classify a just-started cluster as stale.
+12. Inspection never modifies the PID file.
+
+Use narrow dependency injection for time, uptime, PID liveness/error codes,
+process command inspection, and the database probe so tests are deterministic
+and do not depend on the host's real boot time or a real production data
+directory. Keep production defaults internal to the helper.
+
+### Consumer tests
+
+- Server startup reuses the inspector's recorded port for the final admin and
+  application connection strings.
+- Server startup rejects `ambiguous` with an actionable error before creating
+  or starting an embedded PostgreSQL instance.
+- Migration startup removes a PID file only for `stale`; ambiguity propagates
+  without deletion.
+- Worktree repair/reseed treats ambiguity as a live-target safety block.
+- Existing routines/worktree happy-path tests continue to pass.
+
+### Verification commands
+
+Run narrow checks first:
+
+```sh
+pnpm exec vitest run packages/db/src/embedded-postgres-lifecycle.test.ts
+pnpm exec vitest run server/src/__tests__/server-startup-feedback-export.test.ts
+pnpm exec vitest run cli/src/__tests__/worktree.test.ts cli/src/__tests__/routines.test.ts
+pnpm --filter @paperclipai/db typecheck
+pnpm --filter @paperclipai/server typecheck
+pnpm --filter paperclipai typecheck
+```
+
+Then the repository PR-ready gates:
+
+```sh
+pnpm -r typecheck
+pnpm test:run
+pnpm build
+```
+
+No live iMac smoke is run during implementation. After a reviewed canary is
+published, deployment and reboot verification are a separate explicitly
+approved operational step with a backup and rollback plan.
+
+## Acceptance Criteria
+
+- [ ] PID occupancy alone cannot produce a `running` embedded PostgreSQL result.
+- [ ] The exact pre-reboot PID reuse incident classifies the PID file as stale.
+- [ ] Only a database whose normalized data directory matches is reused.
+- [ ] The recorded PID-file port is used for verified reuse.
+- [ ] Ambiguous live current-boot identity preserves the PID file and prevents a
+      second postmaster start.
+- [ ] Invalid/dead/pre-boot stale PID files permit the normal recovery path.
+- [ ] Server, migration, routines, and worktree consumers share one classifier.
+- [ ] Worktree destructive guards remain conservative for ambiguous state.
+- [ ] External PostgreSQL behavior is unchanged.
+- [ ] Targeted tests, package typechecks, full Vitest, and build pass, or any
+      unrun check is explicitly reported.
+- [ ] The implementation branch contains no generated `dist/` edits,
+      `pnpm-lock.yaml` change, or live iMac mutation.
+
+## Rollout and Rollback
+
+Implementation and validation occur only in the local source checkout. After
+review, merge, and canary publication, deployment to the iMac must be a separate
+operator-approved action:
+
+1. record the currently installed package version and service health;
+2. confirm current backups and preserve the installed package for rollback;
+3. install the reviewed canary;
+4. restart once during a maintenance window;
+5. verify `/api/health`, the embedded PostgreSQL PID/port/data directory, and
+   watchdog connectivity;
+6. perform a controlled reboot regression only with explicit approval.
+
+Rollback reinstalls the previous package version and does not alter the embedded
+database directory. The classifier contains no schema or migration change.
+
+## Open Questions
+
+- Should a later follow-up add bounded retry for a verified PostgreSQL process
+  that is still starting? This proposal intentionally fails closed instead of
+  adding startup timing policy to the PID fix.
+- Should stale PID files be archived rather than removed by all upstream
+  consumers? The current source removes stale files; this proposal keeps that
+  behavior but logs the classification reason. Archiving can be a separate
+  observability enhancement.

--- a/packages/db/src/embedded-postgres-lifecycle.test.ts
+++ b/packages/db/src/embedded-postgres-lifecycle.test.ts
@@ -1,0 +1,278 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  inspectEmbeddedPostgresLifecycle,
+  type EmbeddedPostgresLifecycleDependencies,
+} from "./embedded-postgres-lifecycle.js";
+
+const NOW_MS = Date.UTC(2026, 6, 17, 12, 0, 0);
+const UPTIME_SECONDS = 60 * 60;
+const CURRENT_BOOT_EPOCH_SECONDS = NOW_MS / 1000 - UPTIME_SECONDS;
+
+describe("embedded Postgres lifecycle inspection", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(() => {
+    for (const tempDir of tempDirs.splice(0)) {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  function createDataDir(): string {
+    const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "paperclip-embedded-pg-lifecycle-"));
+    tempDirs.push(dataDir);
+    return dataDir;
+  }
+
+  function writePidFile(input: {
+    dataDir: string;
+    pid?: string | number;
+    pidDataDir?: string;
+    startEpochSeconds?: string | number;
+    port?: string | number;
+  }): string {
+    const pidFile = path.join(input.dataDir, "postmaster.pid");
+    fs.writeFileSync(
+      pidFile,
+      [
+        input.pid ?? 4242,
+        input.pidDataDir ?? input.dataDir,
+        input.startEpochSeconds ?? CURRENT_BOOT_EPOCH_SECONDS + 60,
+        input.port ?? 54330,
+        "",
+      ].join("\n"),
+    );
+    return pidFile;
+  }
+
+  function dependencies(
+    overrides: Partial<EmbeddedPostgresLifecycleDependencies> = {},
+  ): EmbeddedPostgresLifecycleDependencies {
+    return {
+      now: () => NOW_MS,
+      uptimeSeconds: () => UPTIME_SECONDS,
+      checkPidLiveness: () => "alive",
+      inspectProcessCommand: async () => null,
+      probeDataDirectory: async () => null,
+      platform: "darwin",
+      ...overrides,
+    };
+  }
+
+  it("returns absent when postmaster.pid does not exist", async () => {
+    const dataDir = createDataDir();
+
+    const result = await inspectEmbeddedPostgresLifecycle(
+      { dataDir, configuredPort: 54329 },
+      dependencies(),
+    );
+
+    expect(result).toMatchObject({
+      state: "absent",
+      pid: null,
+      port: 54329,
+      dataDir: path.resolve(dataDir),
+    });
+  });
+
+  it.each(["not-a-pid", "0", "-1", "42.5"])(
+    "returns stale for malformed or non-positive PID %s without probing a process",
+    async (pid) => {
+      const dataDir = createDataDir();
+      writePidFile({ dataDir, pid });
+      const checkPidLiveness = vi.fn(() => "alive" as const);
+
+      const result = await inspectEmbeddedPostgresLifecycle(
+        { dataDir, configuredPort: 54329 },
+        dependencies({ checkPidLiveness }),
+      );
+
+      expect(result).toMatchObject({ state: "stale", pid: null, reason: "invalid_pid" });
+      expect(checkPidLiveness).not.toHaveBeenCalled();
+    },
+  );
+
+  it("returns stale for a dead PID", async () => {
+    const dataDir = createDataDir();
+    writePidFile({ dataDir });
+
+    const result = await inspectEmbeddedPostgresLifecycle(
+      { dataDir, configuredPort: 54329 },
+      dependencies({ checkPidLiveness: () => "dead" }),
+    );
+
+    expect(result).toMatchObject({ state: "stale", pid: 4242, reason: "dead_pid" });
+  });
+
+  it("returns stale when a pre-boot PID was reused by a live process", async () => {
+    const dataDir = createDataDir();
+    writePidFile({
+      dataDir,
+      pid: 1406,
+      startEpochSeconds: CURRENT_BOOT_EPOCH_SECONDS - 301,
+      port: 54330,
+    });
+
+    const result = await inspectEmbeddedPostgresLifecycle(
+      { dataDir, configuredPort: 54329 },
+      dependencies({
+        checkPidLiveness: () => "alive",
+        inspectProcessCommand: async () => "nginx: worker process",
+      }),
+    );
+
+    expect(result).toMatchObject({
+      state: "stale",
+      pid: 1406,
+      port: 54330,
+      reason: "pre_boot_pid_file",
+    });
+  });
+
+  it("returns stale for a live current-boot PID definitively owned by another command", async () => {
+    const dataDir = createDataDir();
+    writePidFile({ dataDir });
+
+    const result = await inspectEmbeddedPostgresLifecycle(
+      { dataDir, configuredPort: 54329 },
+      dependencies({ inspectProcessCommand: async () => "/usr/sbin/nginx" }),
+    );
+
+    expect(result).toMatchObject({
+      state: "stale",
+      pid: 4242,
+      reason: "non_postgres_process",
+    });
+  });
+
+  it("returns ambiguous for a live current-boot PID when identity evidence is unavailable", async () => {
+    const dataDir = createDataDir();
+    writePidFile({ dataDir });
+
+    const result = await inspectEmbeddedPostgresLifecycle(
+      { dataDir, configuredPort: 54329 },
+      dependencies(),
+    );
+
+    expect(result).toMatchObject({
+      state: "ambiguous",
+      pid: 4242,
+      port: 54330,
+      reason: "identity_unverified",
+    });
+  });
+
+  it("does not treat a PostgreSQL-looking process name as positive identity proof", async () => {
+    const dataDir = createDataDir();
+    writePidFile({ dataDir });
+
+    const result = await inspectEmbeddedPostgresLifecycle(
+      { dataDir, configuredPort: 54329 },
+      dependencies({ inspectProcessCommand: async () => "/Applications/My App/bin/postgres" }),
+    );
+
+    expect(result).toMatchObject({
+      state: "ambiguous",
+      pid: 4242,
+      reason: "identity_unverified",
+    });
+  });
+
+  it("treats EPERM-style inaccessible PID evidence as live and fails closed", async () => {
+    const dataDir = createDataDir();
+    writePidFile({ dataDir });
+
+    const result = await inspectEmbeddedPostgresLifecycle(
+      { dataDir, configuredPort: 54329 },
+      dependencies({ checkPidLiveness: () => "inaccessible" }),
+    );
+
+    expect(result).toMatchObject({
+      state: "ambiguous",
+      pid: 4242,
+      reason: "identity_unverified",
+    });
+  });
+
+  it("returns ambiguous when reachable PostgreSQL uses another data directory", async () => {
+    const dataDir = createDataDir();
+    writePidFile({ dataDir });
+
+    const result = await inspectEmbeddedPostgresLifecycle(
+      { dataDir, configuredPort: 54329 },
+      dependencies({ probeDataDirectory: async () => path.join(dataDir, "other") }),
+    );
+
+    expect(result).toMatchObject({
+      state: "ambiguous",
+      pid: 4242,
+      reason: "data_directory_mismatch",
+    });
+  });
+
+  it("returns running for a matching data directory and uses the recorded port", async () => {
+    const dataDir = createDataDir();
+    writePidFile({ dataDir, pidDataDir: `${dataDir}/.`, port: 55444 });
+    const probeDataDirectory = vi.fn(async () => `${dataDir}/.`);
+
+    const result = await inspectEmbeddedPostgresLifecycle(
+      { dataDir, configuredPort: 54329 },
+      dependencies({ probeDataDirectory }),
+    );
+
+    expect(result).toMatchObject({ state: "running", pid: 4242, port: 55444 });
+    expect(probeDataDirectory).toHaveBeenCalledWith(
+      "postgres://paperclip:paperclip@127.0.0.1:55444/postgres",
+    );
+  });
+
+  it.each(["", "not-a-port", "0", "-1", "54329.5"])(
+    "falls back to the configured port when PID-file port is invalid: %s",
+    async (port) => {
+      const dataDir = createDataDir();
+      writePidFile({ dataDir, port });
+      const probeDataDirectory = vi.fn(async () => dataDir);
+
+      const result = await inspectEmbeddedPostgresLifecycle(
+        { dataDir, configuredPort: 54329 },
+        dependencies({ probeDataDirectory }),
+      );
+
+      expect(result).toMatchObject({ state: "running", port: 54329 });
+      expect(probeDataDirectory).toHaveBeenCalledWith(
+        "postgres://paperclip:paperclip@127.0.0.1:54329/postgres",
+      );
+    },
+  );
+
+  it("keeps a PID-file timestamp within the boot tolerance ambiguous", async () => {
+    const dataDir = createDataDir();
+    writePidFile({ startEpochSeconds: CURRENT_BOOT_EPOCH_SECONDS - 299, dataDir });
+
+    const result = await inspectEmbeddedPostgresLifecycle(
+      { dataDir, configuredPort: 54329 },
+      dependencies(),
+    );
+
+    expect(result).toMatchObject({ state: "ambiguous", reason: "identity_unverified" });
+  });
+
+  it("does not modify postmaster.pid while inspecting it", async () => {
+    const dataDir = createDataDir();
+    const pidFile = writePidFile({
+      dataDir,
+      pid: 1406,
+      startEpochSeconds: CURRENT_BOOT_EPOCH_SECONDS - 301,
+    });
+    const before = fs.readFileSync(pidFile);
+
+    await inspectEmbeddedPostgresLifecycle(
+      { dataDir, configuredPort: 54329 },
+      dependencies({ inspectProcessCommand: async () => "nginx" }),
+    );
+
+    expect(fs.readFileSync(pidFile)).toEqual(before);
+  });
+});

--- a/packages/db/src/embedded-postgres-lifecycle.ts
+++ b/packages/db/src/embedded-postgres-lifecycle.ts
@@ -1,0 +1,215 @@
+import { execFile } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { getPostgresDataDirectory } from "./client.js";
+
+const BOOT_BOUNDARY_TOLERANCE_MS = 5 * 60 * 1000;
+
+export type EmbeddedPostgresPidLiveness = "alive" | "dead" | "inaccessible";
+
+export type EmbeddedPostgresLifecycleReason =
+  | "pid_file_missing"
+  | "pid_file_unreadable"
+  | "invalid_pid"
+  | "dead_pid"
+  | "pre_boot_pid_file"
+  | "non_postgres_process"
+  | "data_directory_mismatch"
+  | "invalid_start_time"
+  | "identity_unverified"
+  | "data_directory_match";
+
+type EmbeddedPostgresLifecycleBase = {
+  dataDir: string;
+  pidFile: string;
+  pidFileDataDir: string | null;
+  port: number;
+  reason: EmbeddedPostgresLifecycleReason;
+};
+
+export type EmbeddedPostgresLifecycleResult =
+  | (EmbeddedPostgresLifecycleBase & {
+      state: "absent";
+      pid: null;
+      reason: "pid_file_missing";
+    })
+  | (EmbeddedPostgresLifecycleBase & {
+      state: "running";
+      pid: number;
+      reason: "data_directory_match";
+    })
+  | (EmbeddedPostgresLifecycleBase & {
+      state: "stale";
+      pid: number | null;
+      reason: "invalid_pid" | "dead_pid" | "pre_boot_pid_file" | "non_postgres_process";
+    })
+  | (EmbeddedPostgresLifecycleBase & {
+      state: "ambiguous";
+      pid: number | null;
+      reason:
+        | "pid_file_unreadable"
+        | "data_directory_mismatch"
+        | "invalid_start_time"
+        | "identity_unverified";
+    });
+
+export type EmbeddedPostgresLifecycleDependencies = {
+  now: () => number;
+  uptimeSeconds: () => number;
+  checkPidLiveness: (pid: number) => EmbeddedPostgresPidLiveness;
+  inspectProcessCommand: (pid: number) => Promise<string | null>;
+  probeDataDirectory: (connectionString: string) => Promise<string | null>;
+  platform: NodeJS.Platform;
+};
+
+export function formatEmbeddedPostgresLifecycleAmbiguity(
+  result: Extract<EmbeddedPostgresLifecycleResult, { state: "ambiguous" }>,
+): string {
+  const pid = result.pid ?? "unknown";
+  const pidFileDataDir = result.pidFileDataDir ?? "unknown";
+  return (
+    `Embedded PostgreSQL identity is ambiguous (pid=${pid}, port=${result.port}, ` +
+    `expectedDataDir=${result.dataDir}, pidFileDataDir=${pidFileDataDir}, reason=${result.reason}). ` +
+    `Refusing to remove ${result.pidFile} or start another PostgreSQL process. ` +
+    "Stop Paperclip, verify that no PostgreSQL process uses this data directory, then archive or remove the PID file manually if it is stale."
+  );
+}
+
+function parsePositiveInteger(value: string | undefined): number | null {
+  if (!value || !/^\d+$/.test(value.trim())) return null;
+  const parsed = Number(value.trim());
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : null;
+}
+
+function checkPidLiveness(pid: number): EmbeddedPostgresPidLiveness {
+  try {
+    process.kill(pid, 0);
+    return "alive";
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === "ESRCH") return "dead";
+    return "inaccessible";
+  }
+}
+
+async function inspectProcessCommand(pid: number): Promise<string | null> {
+  return await new Promise((resolve) => {
+    execFile(
+      "ps",
+      ["-p", String(pid), "-o", "comm="],
+      { timeout: 1_000, maxBuffer: 16 * 1024 },
+      (error, stdout) => {
+        if (error) {
+          resolve(null);
+          return;
+        }
+        const command = stdout.trim();
+        resolve(command.length > 0 ? command : null);
+      },
+    );
+  });
+}
+
+const defaultDependencies: EmbeddedPostgresLifecycleDependencies = {
+  now: Date.now,
+  uptimeSeconds: os.uptime,
+  checkPidLiveness,
+  inspectProcessCommand,
+  probeDataDirectory: getPostgresDataDirectory,
+  platform: process.platform,
+};
+
+function isPossiblyPostgresCommand(command: string): boolean {
+  return /(?:^|[\\/])(?:postgres|postmaster)(?:$|[\s:])/i.test(command.trim());
+}
+
+export async function inspectEmbeddedPostgresLifecycle(
+  input: { dataDir: string; configuredPort: number },
+  dependencies: EmbeddedPostgresLifecycleDependencies = defaultDependencies,
+): Promise<EmbeddedPostgresLifecycleResult> {
+  const dataDir = path.resolve(input.dataDir);
+  const pidFile = path.resolve(dataDir, "postmaster.pid");
+  const configuredPort = parsePositiveInteger(String(input.configuredPort));
+  if (configuredPort === null) {
+    throw new Error(`Invalid embedded PostgreSQL configured port: ${input.configuredPort}`);
+  }
+
+  const base = {
+    dataDir,
+    pidFile,
+    pidFileDataDir: null,
+    port: configuredPort,
+  };
+
+  if (!existsSync(pidFile)) {
+    return { ...base, state: "absent", pid: null, reason: "pid_file_missing" };
+  }
+
+  let lines: string[];
+  try {
+    lines = readFileSync(pidFile, "utf8").split("\n");
+  } catch {
+    return { ...base, state: "ambiguous", pid: null, reason: "pid_file_unreadable" };
+  }
+
+  const pidFileDataDir = lines[1]?.trim() || null;
+  const pid = parsePositiveInteger(lines[0]);
+  const recordedPort = parsePositiveInteger(lines[3]);
+  const port = recordedPort ?? configuredPort;
+  const parsedBase = { ...base, pidFileDataDir, port };
+
+  if (pid === null) {
+    return { ...parsedBase, state: "stale", pid: null, reason: "invalid_pid" };
+  }
+
+  const adminConnectionString =
+    `postgres://paperclip:paperclip@127.0.0.1:${port}/postgres`;
+  let actualDataDir: string | null = null;
+  try {
+    actualDataDir = await dependencies.probeDataDirectory(adminConnectionString);
+  } catch {
+    actualDataDir = null;
+  }
+  if (typeof actualDataDir === "string" && path.resolve(actualDataDir) === dataDir) {
+    return { ...parsedBase, state: "running", pid, reason: "data_directory_match" };
+  }
+
+  let liveness: EmbeddedPostgresPidLiveness;
+  try {
+    liveness = dependencies.checkPidLiveness(pid);
+  } catch {
+    liveness = "inaccessible";
+  }
+  if (liveness === "dead") {
+    return { ...parsedBase, state: "stale", pid, reason: "dead_pid" };
+  }
+
+  const startEpochSeconds = parsePositiveInteger(lines[2]);
+  if (startEpochSeconds !== null) {
+    const bootEpochMs = dependencies.now() - dependencies.uptimeSeconds() * 1000;
+    if (startEpochSeconds * 1000 < bootEpochMs - BOOT_BOUNDARY_TOLERANCE_MS) {
+      return { ...parsedBase, state: "stale", pid, reason: "pre_boot_pid_file" };
+    }
+  }
+
+  if (dependencies.platform !== "win32") {
+    let command: string | null = null;
+    try {
+      command = await dependencies.inspectProcessCommand(pid);
+    } catch {
+      command = null;
+    }
+    if (command !== null && !isPossiblyPostgresCommand(command)) {
+      return { ...parsedBase, state: "stale", pid, reason: "non_postgres_process" };
+    }
+  }
+
+  if (actualDataDir !== null) {
+    return { ...parsedBase, state: "ambiguous", pid, reason: "data_directory_mismatch" };
+  }
+  if (startEpochSeconds === null) {
+    return { ...parsedBase, state: "ambiguous", pid, reason: "invalid_start_time" };
+  }
+  return { ...parsedBase, state: "ambiguous", pid, reason: "identity_unverified" };
+}

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -35,6 +35,14 @@ export {
   ensureLinuxSharedLibraryAliases,
   prepareEmbeddedPostgresNativeRuntime,
 } from "./embedded-postgres-native.js";
+export {
+  formatEmbeddedPostgresLifecycleAmbiguity,
+  inspectEmbeddedPostgresLifecycle,
+  type EmbeddedPostgresLifecycleDependencies,
+  type EmbeddedPostgresLifecycleReason,
+  type EmbeddedPostgresLifecycleResult,
+  type EmbeddedPostgresPidLiveness,
+} from "./embedded-postgres-lifecycle.js";
 export { issueRelations } from "./schema/issue_relations.js";
 export { issueReferenceMentions } from "./schema/issue_reference_mentions.js";
 export * from "./schema/index.js";

--- a/packages/db/src/migration-runtime.test.ts
+++ b/packages/db/src/migration-runtime.test.ts
@@ -1,0 +1,142 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  embeddedPostgresCtorMock,
+  embeddedPostgresInitialiseMock,
+  embeddedPostgresStartMock,
+  inspectEmbeddedPostgresLifecycleMock,
+  resolveDatabaseTargetMock,
+} = vi.hoisted(() => {
+  const embeddedPostgresInitialiseMock = vi.fn(async () => undefined);
+  const embeddedPostgresStartMock = vi.fn(async () => undefined);
+  const embeddedPostgresCtorMock = vi.fn(function EmbeddedPostgresMock() {
+    return {
+      initialise: embeddedPostgresInitialiseMock,
+      start: embeddedPostgresStartMock,
+      stop: vi.fn(async () => undefined),
+    };
+  });
+  return {
+    embeddedPostgresCtorMock,
+    embeddedPostgresInitialiseMock,
+    embeddedPostgresStartMock,
+    inspectEmbeddedPostgresLifecycleMock: vi.fn(),
+    resolveDatabaseTargetMock: vi.fn(),
+  };
+});
+
+vi.mock("embedded-postgres", () => ({ default: embeddedPostgresCtorMock }));
+
+vi.mock("node:net", () => ({
+  createServer: vi.fn(() => {
+    const server = {
+      unref: vi.fn(),
+      once: vi.fn(() => server),
+      listen: vi.fn((_port: number, _host: string, onListen: () => void) => {
+        onListen();
+        return server;
+      }),
+      close: vi.fn(),
+    };
+    return server;
+  }),
+}));
+
+vi.mock("./client.js", () => ({
+  ensurePostgresDatabase: vi.fn(async () => "exists"),
+  getPostgresDataDirectory: vi.fn(async () => null),
+}));
+
+vi.mock("./embedded-postgres-error.js", () => ({
+  createEmbeddedPostgresLogBuffer: vi.fn(() => ({
+    append: vi.fn(),
+    getRecentLogs: vi.fn(() => []),
+  })),
+  formatEmbeddedPostgresError: vi.fn((error: unknown) => error),
+}));
+
+vi.mock("./embedded-postgres-lifecycle.js", () => ({
+  formatEmbeddedPostgresLifecycleAmbiguity: vi.fn(
+    () => "ambiguous embedded PostgreSQL identity",
+  ),
+  inspectEmbeddedPostgresLifecycle: inspectEmbeddedPostgresLifecycleMock,
+}));
+
+vi.mock("./embedded-postgres-native.js", () => ({
+  prepareEmbeddedPostgresNativeRuntime: vi.fn(async () => undefined),
+}));
+
+vi.mock("./runtime-config.js", () => ({
+  resolveDatabaseTarget: resolveDatabaseTargetMock,
+}));
+
+import { resolveMigrationConnection } from "./migration-runtime.js";
+
+describe("migration embedded PostgreSQL lifecycle", () => {
+  const tempDirs: string[] = [];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    for (const tempDir of tempDirs.splice(0)) {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  function createTarget() {
+    const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "paperclip-migration-lifecycle-"));
+    tempDirs.push(dataDir);
+    const port = 65420;
+    resolveDatabaseTargetMock.mockReturnValue({ mode: "embedded-postgres", dataDir, port });
+    return { dataDir, port, pidFile: path.join(dataDir, "postmaster.pid") };
+  }
+
+  it("removes a PID file classified as stale immediately before startup", async () => {
+    const target = createTarget();
+    fs.writeFileSync(target.pidFile, "4242\n");
+    inspectEmbeddedPostgresLifecycleMock.mockResolvedValue({
+      state: "stale",
+      pid: 4242,
+      port: target.port,
+      dataDir: target.dataDir,
+      pidFile: target.pidFile,
+      pidFileDataDir: target.dataDir,
+      reason: "dead_pid",
+    });
+
+    const connection = await resolveMigrationConnection();
+
+    expect(fs.existsSync(target.pidFile)).toBe(false);
+    expect(embeddedPostgresStartMock).toHaveBeenCalledTimes(1);
+    expect(connection.connectionString).toBe(
+      `postgres://paperclip:paperclip@127.0.0.1:${target.port}/paperclip`,
+    );
+  });
+
+  it("preserves an ambiguous PID file and does not construct a second postmaster", async () => {
+    const target = createTarget();
+    fs.writeFileSync(target.pidFile, "4242\n");
+    inspectEmbeddedPostgresLifecycleMock.mockResolvedValue({
+      state: "ambiguous",
+      pid: 4242,
+      port: target.port,
+      dataDir: target.dataDir,
+      pidFile: target.pidFile,
+      pidFileDataDir: target.dataDir,
+      reason: "identity_unverified",
+    });
+
+    await expect(resolveMigrationConnection()).rejects.toThrow(
+      "ambiguous embedded PostgreSQL identity",
+    );
+
+    expect(fs.readFileSync(target.pidFile, "utf8")).toBe("4242\n");
+    expect(embeddedPostgresCtorMock).not.toHaveBeenCalled();
+    expect(embeddedPostgresStartMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/db/src/migration-runtime.ts
+++ b/packages/db/src/migration-runtime.ts
@@ -1,8 +1,12 @@
-import { existsSync, readFileSync, rmSync } from "node:fs";
+import { existsSync, rmSync } from "node:fs";
 import { createServer } from "node:net";
 import path from "node:path";
 import { ensurePostgresDatabase, getPostgresDataDirectory } from "./client.js";
 import { createEmbeddedPostgresLogBuffer, formatEmbeddedPostgresError } from "./embedded-postgres-error.js";
+import {
+  formatEmbeddedPostgresLifecycleAmbiguity,
+  inspectEmbeddedPostgresLifecycle,
+} from "./embedded-postgres-lifecycle.js";
 import { prepareEmbeddedPostgresNativeRuntime } from "./embedded-postgres-native.js";
 import { resolveDatabaseTarget } from "./runtime-config.js";
 
@@ -28,29 +32,6 @@ export type MigrationConnection = {
   source: string;
   stop: () => Promise<void>;
 };
-
-function readRunningPostmasterPid(postmasterPidFile: string): number | null {
-  if (!existsSync(postmasterPidFile)) return null;
-  try {
-    const pid = Number(readFileSync(postmasterPidFile, "utf8").split("\n")[0]?.trim());
-    if (!Number.isInteger(pid) || pid <= 0) return null;
-    process.kill(pid, 0);
-    return pid;
-  } catch {
-    return null;
-  }
-}
-
-function readPidFilePort(postmasterPidFile: string): number | null {
-  if (!existsSync(postmasterPidFile)) return null;
-  try {
-    const lines = readFileSync(postmasterPidFile, "utf8").split("\n");
-    const port = Number(lines[3]?.trim());
-    return Number.isInteger(port) && port > 0 ? port : null;
-  } catch {
-    return null;
-  }
-}
 
 async function isPortInUse(port: number): Promise<boolean> {
   return await new Promise((resolve) => {
@@ -94,15 +75,30 @@ async function ensureEmbeddedPostgresConnection(
 ): Promise<MigrationConnection> {
   const EmbeddedPostgres = await loadEmbeddedPostgresCtor();
   await prepareEmbeddedPostgresNativeRuntime();
-  const selectedPort = await findAvailablePort(preferredPort);
   const postmasterPidFile = path.resolve(dataDir, "postmaster.pid");
   const pgVersionFile = path.resolve(dataDir, "PG_VERSION");
-  const runningPid = readRunningPostmasterPid(postmasterPidFile);
-  const runningPort = readPidFilePort(postmasterPidFile);
+  const lifecycle = await inspectEmbeddedPostgresLifecycle({
+    dataDir,
+    configuredPort: preferredPort,
+  });
   const preferredAdminConnectionString = `postgres://paperclip:paperclip@127.0.0.1:${preferredPort}/postgres`;
   const logBuffer = createEmbeddedPostgresLogBuffer();
 
-  if (!runningPid && existsSync(pgVersionFile)) {
+  if (lifecycle.state === "ambiguous") {
+    throw new Error(formatEmbeddedPostgresLifecycleAmbiguity(lifecycle));
+  }
+
+  if (lifecycle.state === "running") {
+    const adminConnectionString = `postgres://paperclip:paperclip@127.0.0.1:${lifecycle.port}/postgres`;
+    await ensurePostgresDatabase(adminConnectionString, "paperclip");
+    return {
+      connectionString: `postgres://paperclip:paperclip@127.0.0.1:${lifecycle.port}/paperclip`,
+      source: `embedded-postgres@${lifecycle.port}`,
+      stop: async () => {},
+    };
+  }
+
+  if (existsSync(pgVersionFile)) {
     try {
       const actualDataDir = await getPostgresDataDirectory(preferredAdminConnectionString);
       const matchesDataDir =
@@ -125,17 +121,7 @@ async function ensureEmbeddedPostgresConnection(
     }
   }
 
-  if (runningPid) {
-    const port = runningPort ?? preferredPort;
-    const adminConnectionString = `postgres://paperclip:paperclip@127.0.0.1:${port}/postgres`;
-    await ensurePostgresDatabase(adminConnectionString, "paperclip");
-    return {
-      connectionString: `postgres://paperclip:paperclip@127.0.0.1:${port}/paperclip`,
-      source: `embedded-postgres@${port}`,
-      stop: async () => {},
-    };
-  }
-
+  const selectedPort = await findAvailablePort(preferredPort);
   const instance = new EmbeddedPostgres({
     databaseDir: dataDir,
     user: "paperclip",
@@ -158,7 +144,10 @@ async function ensureEmbeddedPostgresConnection(
       });
     }
   }
-  if (existsSync(postmasterPidFile)) {
+  if (lifecycle.state === "stale" && existsSync(postmasterPidFile)) {
+    process.emitWarning(
+      `Removing stale embedded PostgreSQL PID file ${postmasterPidFile} (${lifecycle.reason}).`,
+    );
     rmSync(postmasterPidFile, { force: true });
   }
   try {

--- a/server/src/__tests__/server-startup-feedback-export.test.ts
+++ b/server/src/__tests__/server-startup-feedback-export.test.ts
@@ -19,6 +19,9 @@ const {
   fakeServer,
   heartbeatServiceFactoryMock,
   heartbeatServiceMock,
+  ensurePostgresDatabaseMock,
+  formatEmbeddedPostgresLifecycleAmbiguityMock,
+  inspectEmbeddedPostgresLifecycleMock,
   loadConfigMock,
   resolveHeartbeatSchedulingSuppressionMock,
   routineServiceFactoryMock,
@@ -28,6 +31,11 @@ const {
   const createBetterAuthInstanceMock = vi.fn(() => ({}));
   const createDbMock = vi.fn(() => ({}) as never);
   const detectPortMock = vi.fn(async (port: number) => port);
+  const ensurePostgresDatabaseMock = vi.fn(async () => "exists");
+  const formatEmbeddedPostgresLifecycleAmbiguityMock = vi.fn(
+    () => "ambiguous embedded PostgreSQL identity",
+  );
+  const inspectEmbeddedPostgresLifecycleMock = vi.fn();
   const deriveAuthTrustedOriginsMock = vi.fn(() => []);
   const resolveHeartbeatSchedulingSuppressionMock = vi.fn(() => ({
     suppressed: false,
@@ -96,6 +104,9 @@ const {
     fakeServer,
     heartbeatServiceFactoryMock,
     heartbeatServiceMock,
+    ensurePostgresDatabaseMock,
+    formatEmbeddedPostgresLifecycleAmbiguityMock,
+    inspectEmbeddedPostgresLifecycleMock,
     loadConfigMock,
     resolveHeartbeatSchedulingSuppressionMock,
     routineServiceFactoryMock,
@@ -154,10 +165,18 @@ vi.mock("detect-port", () => ({
 
 vi.mock("@paperclipai/db", () => ({
   createDb: createDbMock,
-  ensurePostgresDatabase: vi.fn(),
+  createEmbeddedPostgresLogBuffer: vi.fn(() => ({
+    append: vi.fn(),
+    getRecentLogs: vi.fn(() => []),
+  })),
+  ensurePostgresDatabase: ensurePostgresDatabaseMock,
+  formatEmbeddedPostgresLifecycleAmbiguity: formatEmbeddedPostgresLifecycleAmbiguityMock,
+  formatEmbeddedPostgresError: vi.fn((error: unknown) => error),
   getPostgresDataDirectory: vi.fn(),
+  inspectEmbeddedPostgresLifecycle: inspectEmbeddedPostgresLifecycleMock,
   inspectMigrations: vi.fn(async () => ({ status: "upToDate" })),
   applyPendingMigrations: vi.fn(),
+  prepareEmbeddedPostgresNativeRuntime: vi.fn(),
   reconcilePendingMigrationHistory: vi.fn(async () => ({ repairedMigrations: [] })),
   formatDatabaseBackupResult: vi.fn(() => "ok"),
   runDatabaseBackup: vi.fn(),
@@ -384,6 +403,68 @@ describe("startServer feedback export wiring", () => {
       "authenticated public deployments require DATABASE_URL to be a postgres/postgresql connection string",
     );
     expect(createDbMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("startServer embedded PostgreSQL lifecycle", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    loadConfigMock.mockReturnValue(buildTestConfig({
+      databaseMode: "embedded-postgres",
+      databaseUrl: undefined,
+      embeddedPostgresDataDir: "/tmp/paperclip-test-db",
+      embeddedPostgresPort: 54329,
+    }));
+    resolveHeartbeatSchedulingSuppressionMock.mockReturnValue({
+      suppressed: false,
+      reason: null,
+    });
+    createBetterAuthInstanceMock.mockReturnValue({});
+    deriveAuthTrustedOriginsMock.mockReturnValue([]);
+    process.env.BETTER_AUTH_SECRET = "test-secret";
+  });
+
+  it("reuses the verified PID-file port for admin and application connections", async () => {
+    inspectEmbeddedPostgresLifecycleMock.mockResolvedValue({
+      state: "running",
+      pid: 4242,
+      port: 54330,
+      dataDir: "/tmp/paperclip-test-db",
+      pidFile: "/tmp/paperclip-test-db/postmaster.pid",
+      pidFileDataDir: "/tmp/paperclip-test-db",
+      reason: "data_directory_match",
+    });
+
+    await startServer();
+
+    expect(ensurePostgresDatabaseMock).toHaveBeenCalledWith(
+      "postgres://paperclip:paperclip@127.0.0.1:54330/postgres",
+      "paperclip",
+    );
+    expect(createDbMock).toHaveBeenCalledWith(
+      "postgres://paperclip:paperclip@127.0.0.1:54330/paperclip",
+    );
+    expect(detectPortMock).not.toHaveBeenCalledWith(54329);
+  });
+
+  it("fails closed on ambiguous identity before detecting a new database port", async () => {
+    const ambiguous = {
+      state: "ambiguous",
+      pid: 4242,
+      port: 54330,
+      dataDir: "/tmp/paperclip-test-db",
+      pidFile: "/tmp/paperclip-test-db/postmaster.pid",
+      pidFileDataDir: "/tmp/paperclip-test-db",
+      reason: "identity_unverified",
+    };
+    inspectEmbeddedPostgresLifecycleMock.mockResolvedValue(ambiguous);
+
+    await expect(startServer()).rejects.toThrow("ambiguous embedded PostgreSQL identity");
+
+    expect(formatEmbeddedPostgresLifecycleAmbiguityMock).toHaveBeenCalledWith(ambiguous);
+    expect(ensurePostgresDatabaseMock).not.toHaveBeenCalled();
+    expect(createDbMock).not.toHaveBeenCalled();
+    expect(detectPortMock).not.toHaveBeenCalledWith(54329);
   });
 });
 

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -4,7 +4,7 @@
 // instrumentationReady before opening DB connections or constructing the
 // HTTP server, so trace coverage does not depend on incidental timing.
 import { instrumentationReady, shutdownInstrumentation } from "./instrumentation.js";
-import { existsSync, readFileSync, rmSync } from "node:fs";
+import { existsSync, rmSync } from "node:fs";
 import { createServer } from "node:http";
 import { resolve } from "node:path";
 import { createInterface } from "node:readline/promises";
@@ -15,8 +15,10 @@ import { and, eq } from "drizzle-orm";
 import {
   createDb,
   ensurePostgresDatabase,
+  formatEmbeddedPostgresLifecycleAmbiguity,
   formatEmbeddedPostgresError,
   getPostgresDataDirectory,
+  inspectEmbeddedPostgresLifecycle,
   inspectMigrations,
   applyPendingMigrations,
   createEmbeddedPostgresLogBuffer,
@@ -384,31 +386,20 @@ export async function startServer(): Promise<StartedServer> {
     const clusterVersionFile = resolve(dataDir, "PG_VERSION");
     const clusterAlreadyInitialized = existsSync(clusterVersionFile);
     const postmasterPidFile = resolve(dataDir, "postmaster.pid");
-    const isPidRunning = (pid: number): boolean => {
-      try {
-        process.kill(pid, 0);
-        return true;
-      } catch {
-        return false;
-      }
-    };
-  
-    const getRunningPid = (): number | null => {
-      if (!existsSync(postmasterPidFile)) return null;
-      try {
-        const pidLine = readFileSync(postmasterPidFile, "utf8").split("\n")[0]?.trim();
-        const pid = Number(pidLine);
-        if (!Number.isInteger(pid) || pid <= 0) return null;
-        if (!isPidRunning(pid)) return null;
-        return pid;
-      } catch {
-        return null;
-      }
-    };
-  
-    const runningPid = getRunningPid();
-    if (runningPid) {
-      logger.warn(`Embedded PostgreSQL already running; reusing existing process (pid=${runningPid}, port=${port})`);
+    const lifecycle = await inspectEmbeddedPostgresLifecycle({
+      dataDir,
+      configuredPort,
+    });
+
+    if (lifecycle.state === "ambiguous") {
+      throw new Error(formatEmbeddedPostgresLifecycleAmbiguity(lifecycle));
+    }
+
+    if (lifecycle.state === "running") {
+      port = lifecycle.port;
+      logger.warn(
+        `Embedded PostgreSQL already running; reusing verified process (pid=${lifecycle.pid}, port=${port})`,
+      );
     } else {
       const configuredAdminConnectionString = `postgres://paperclip:paperclip@127.0.0.1:${configuredPort}/postgres`;
       try {
@@ -455,8 +446,10 @@ export async function startServer(): Promise<StartedServer> {
           logger.info(`Embedded PostgreSQL cluster already exists (${clusterVersionFile}); skipping init`);
         }
 
-        if (existsSync(postmasterPidFile)) {
-          logger.warn("Removing stale embedded PostgreSQL lock file");
+        if (lifecycle.state === "stale" && existsSync(postmasterPidFile)) {
+          logger.warn(
+            `Removing stale embedded PostgreSQL PID file (${postmasterPidFile}, reason=${lifecycle.reason})`,
+          );
           rmSync(postmasterPidFile, { force: true });
         }
         try {


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open-source app people use to manage AI agents for work.
> - Local installations can own a persistent embedded PostgreSQL cluster.
> - The cluster lifecycle currently treats PID occupancy from `postmaster.pid` as proof that PostgreSQL is running.
> - After a reboot, the OS can reuse that PID for an unrelated process while the PID file remains on disk.
> - Reusing that PID skips PostgreSQL startup and sends Paperclip into a database connection failure loop.
> - This pull request verifies the PostgreSQL data directory, recognizes provably stale PID files, and fails closed when identity remains ambiguous.
> - The benefit is automatic recovery from safe stale cases without risking a second postmaster against a live data directory.

## Linked Issues or Issue Description

No matching public issue or pull request was found.

### What happened?

After a macOS reboot, an embedded PostgreSQL `postmaster.pid` persisted while its PID was reassigned to an unrelated process. Paperclip accepted `process.kill(pid, 0)` as proof of PostgreSQL identity, skipped embedded database startup, and repeatedly failed to connect to its configured database port.

### Expected behavior

Paperclip should reuse embedded PostgreSQL only after querying the server and confirming that `data_directory` matches the configured embedded data directory. A PID file that is provably pre-boot, invalid, dead, or owned by a definitively unrelated process should be treated as stale. A live PID whose identity cannot be proved should block startup without deleting the PID file.

### Steps to reproduce

1. Initialize an embedded PostgreSQL Paperclip instance.
2. Stop it and retain `postmaster.pid`.
3. Simulate a reboot boundary by setting line 3 to a timestamp before the current boot.
4. Make line 1 name a live unrelated process and leave no matching PostgreSQL listener on the recorded port.
5. Start Paperclip from the previous implementation.
6. Observe that PID occupancy is accepted and database startup is skipped.

Reproduced against `master` commit `5d42382df4c5724085967027485fcd39b91b01ae` on macOS Apple Silicon. This is a core embedded-database bug and is not adapter-specific.

## What Changed

- Added a shared side-effect-free embedded PostgreSQL lifecycle classifier with `absent`, `running`, `stale`, and `ambiguous` results.
- Parse PID-file PID, data directory, start epoch, and recorded port; use a five-minute boot-boundary tolerance.
- Require a successful `data_directory` match for positive PostgreSQL identity.
- Distinguish dead `ESRCH` from inaccessible `EPERM`; use POSIX process inspection only as negative evidence.
- Applied the shared result to server startup, migration startup, routine maintenance, and worktree startup/overwrite guards.
- Added regression, consumer, and fail-closed tests, including the reboot/PID-reuse incident.

## Verification

- `pnpm exec vitest run packages/db/src/embedded-postgres-lifecycle.test.ts packages/db/src/migration-runtime.test.ts server/src/__tests__/server-startup-feedback-export.test.ts cli/src/__tests__/worktree.test.ts cli/src/__tests__/routines.test.ts` — 74 passed.
- `pnpm -r typecheck` — passed across 31 workspace projects.
- `pnpm build` — passed.
- `git diff --check` — passed.
- `pnpm test:run` — 2644 passed, 27 failed in three unrelated existing suites. Failures reproduce outside the changed paths and include a global installation missing `/opt/homebrew/lib/node_modules/paperclipai/dist/migrations`, macOS `/tmp` versus `/private/tmp` assertions, and cascading runtime-service timeouts. A representative provisioning failure reproduces alone with 95 unrelated tests skipped.

The live production instance was not restarted, upgraded, or otherwise mutated during implementation.

## Risks

- Ambiguous current-boot PID files now fail closed and require operator verification instead of being deleted automatically.
- Boot-boundary classification depends on wall-clock time and OS uptime, with a five-minute tolerance for skew.
- POSIX command inspection can prove only that a process is unrelated; a PostgreSQL-looking name never produces positive identity.
- No database schema, migration, dependency, lockfile, or external PostgreSQL behavior changed.

## Model Used

- OpenAI Codex based on GPT-5, with repository tools, terminal execution, and MCP-assisted code navigation.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links
- [x] My branch name describes the change and contains no internal Paperclip ticket id
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
