### PR TITLE
fix(adapter-utils): quote ACPX wrapper paths

### DIFF
--- a/packages/adapter-utils/src/acpx-engine/execute.test.ts
+++ b/packages/adapter-utils/src/acpx-engine/execute.test.ts
@@ -663,6 +663,21 @@ describe("shared ACPX engine runtime behavior", () => {
     expect(env).not.toContain("old-key");
   });
 
+  it("quotes ACPX wrapper paths that contain spaces", async () => {
+    const root = await makeTempRoot();
+    const stateDir = path.join(root, "state with spaces");
+
+    const { runtimeOptions } = await runExecutor({
+      agent: "custom",
+      agentCommand: "node ./fake-acp.js",
+      stateDir,
+    });
+
+    const registry = runtimeOptions[0]?.agentRegistry as AcpRuntimeOptions["agentRegistry"];
+    const command = registry.resolve("custom");
+    expect(command).toMatch(/^'.*\/state with spaces\/wrappers\/custom-[a-f0-9]+\.sh'$/);
+  });
+
   it("forwards resolved adapter env (plain + secret) to the wrapper without overriding runtime vars", async () => {
     const root = await makeTempRoot();
     const stateDir = path.join(root, "state");

--- a/packages/adapter-utils/src/acpx-engine/execute.ts
+++ b/packages/adapter-utils/src/acpx-engine/execute.ts
@@ -1267,7 +1267,9 @@ async function buildRuntime(input: {
     await paperclipBridge?.stop().catch(() => {});
     throw err;
   }
-  const overrideCommand = processSessionBridge?.agentCommand ?? wrapperPath;
+  const overrideCommandPath = processSessionBridge?.agentCommand ?? wrapperPath;
+  // ACPX parses overrides as command lines, so generated executable paths must be quoted.
+  const overrideCommand = overrideCommandPath ? shellQuote(overrideCommandPath) : null;
   const overrides = overrideCommand ? { [acpxAgent]: overrideCommand } : undefined;
   const agentRegistry = createAgentRegistry({ overrides });
   const fingerprint = shortHash({

--- a/packages/adapter-utils/src/mcp-isolation.integration.test.ts
+++ b/packages/adapter-utils/src/mcp-isolation.integration.test.ts
@@ -16,6 +16,7 @@ import {
   writeClaudeMcpConfig,
   writeCodexMcpConfig,
 } from "./test-support/mcp-isolation-harness.js";
+import { shellQuote } from "./ssh.js";
 
 const repoRoot = fileURLToPath(new URL("../../..", import.meta.url));
 const stdioFixturePath = path.join(repoRoot, "scripts/mcp-fixtures/servers/stdio-fixture.mjs");
@@ -54,7 +55,7 @@ async function runAcpxFixtureSession(
     sessionStore: createRuntimeStore({ stateDir: path.join(root, `acpx-${sessionName}`) }),
     agentRegistry: createAgentRegistry({
       overrides: {
-        isolation_fixture: `${process.execPath} ${acpFixturePath}`,
+        isolation_fixture: `${shellQuote(process.execPath)} ${shellQuote(acpFixturePath)}`,
       },
     }),
     mcpServers,


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source control plane people use to organize and run AI-agent companies.
> - ACPX-backed local adapters launch agents through generated wrapper or process-session proxy executables.
> - Paperclip registered those generated executable paths as unquoted command strings.
> - ACPX parses registry overrides as command lines, so a space in the Paperclip state or checkout path split the executable path into multiple tokens.
> - The resulting agent run failed during session initialization with a truncated `spawn ... ENOENT` path.
> - This pull request quotes generated executable paths before registering them with ACPX and adds regression coverage for paths containing spaces.
> - The benefit is that ACPX-backed agents start reliably from valid directories whose names contain spaces, without changing configured agent commands.

## Linked Issues or Issue Description

No matching public issue or pull request was found after searching open and closed GitHub results for ACPX space-path and spawn-ENOENT variants.

### What happened?

When an ACPX-backed local agent used a Paperclip state or checkout directory containing a space, Paperclip passed its generated wrapper path to ACPX without quoting it. ACPX split the string at the space and attempted to spawn the truncated prefix.

Sanitized failure shape:

```shell
Failed to spawn agent command: /tmp/paperclip repro/.../wrappers/codex-<hash>.sh
spawn /tmp/paperclip ENOENT
```

### Expected behavior

Generated ACPX wrapper and process-session proxy paths should be treated as one executable path, including when parent directory names contain spaces.

### Steps to reproduce

1. Check out Paperclip `master` into a directory whose path contains a space.
2. Install dependencies.
3. Run the ACPX MCP-isolation fixture or invoke an ACPX-backed local agent.
4. Observe session initialization fail because the executable path is truncated at the first space.

### Environment

- Paperclip base commit: `0094101`
- Deployment: local development, built from source
- Adapter area: ACPX-backed local adapters (reproduced with the custom ACP fixture)
- Database: not related
- Node.js: `v24.16.0`
- OS: macOS / Darwin 25.5.0 arm64
- Privacy: all paths and output above are sanitized; no credentials or private instance identifiers are included

## What Changed

- Shell-quote generated wrapper and process-session proxy executable paths before adding them to the ACPX agent registry.
- Quote both executable arguments used by the ACPX MCP-isolation fixture so the integration test also works from checkouts containing spaces.
- Add a focused unit regression test that verifies the generated ACPX wrapper command remains a single quoted path.

## Verification

- `PAPERCLIP_HOME=/tmp/paperclip-test-home ./node_modules/.bin/vitest run packages/adapter-utils/src/acpx-engine/execute.test.ts packages/adapter-utils/src/mcp-isolation.integration.test.ts -t 'quotes ACPX wrapper paths that contain spaces|passes disjoint MCP server sets through acpx session/new and tools/list' --reporter=verbose`
  - Result: 2 passed, 57 skipped by the focused test-name filter.
- `./packages/adapter-utils/node_modules/.bin/tsc --noEmit -p packages/adapter-utils/tsconfig.json`
  - Result: passed.
- `git diff --check origin/master...HEAD`
  - Result: passed.

## Risks

Low risk. The change only quotes Paperclip-generated executable paths before ACPX parses them. User-configured multi-token agent commands are still written into the wrapper unchanged. Regression coverage exercises both registry construction and a real ACPX session startup.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex / `gpt-5.6-sol`; context size not exposed by the desktop runtime; high-reasoning agent mode with local shell execution, repository inspection, test execution, and GitHub CLI tooling.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes (no documentation change was required because this restores the documented path behavior)
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
