### PR TITLE
Add OpenAI-compatible runtime adapter

### DIFF
--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -41,6 +41,7 @@ export const AGENT_ADAPTER_TYPES = [
   "pi_local",
   "cursor",
   "openclaw_gateway",
+  "openai_compatible",
 ] as const;
 export type AgentAdapterType = (typeof AGENT_ADAPTER_TYPES)[number] | (string & {});
 

--- a/server/src/adapters/builtin-adapter-types.ts
+++ b/server/src/adapters/builtin-adapter-types.ts
@@ -11,6 +11,7 @@ export const BUILTIN_ADAPTER_TYPES = new Set([
   "grok_local",
   "hermes_gateway",
   "hermes_local",
+  "openai_compatible",
   "openclaw_gateway",
   "opencode_local",
   "pi_local",

--- a/server/src/adapters/openai-compatible/execute.test.ts
+++ b/server/src/adapters/openai-compatible/execute.test.ts
@@ -1,0 +1,146 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { execute } from "./execute.js";
+import type { AdapterExecutionContext } from "../types.js";
+
+function makeContext(config: Record<string, unknown>): AdapterExecutionContext {
+  return {
+    runId: "run-1",
+    agent: {
+      id: "agent-1",
+      companyId: "company-1",
+      name: "Pilot",
+      adapterType: "openai_compatible",
+      adapterConfig: {},
+    },
+    runtime: {
+      sessionId: null,
+      sessionParams: null,
+      sessionDisplayId: null,
+      taskKey: null,
+    },
+    config: {
+      baseUrl: "http://127.0.0.1:8080",
+      model: "local-model",
+      promptTemplate: "Issue: {{context.issue.identifier}}",
+      ...config,
+    },
+    context: {
+      issue: {
+        identifier: "TST-1",
+        title: "Synthetic task",
+      },
+    },
+    onLog: vi.fn(async () => {}),
+    onMeta: vi.fn(async () => {}),
+  };
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("openai_compatible adapter execute", () => {
+  it("captures assistant content from a synthetic OpenAI-compatible endpoint", async () => {
+    const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {
+      expect(JSON.parse(String(init?.body))).toMatchObject({
+        model: "local-model",
+        messages: [{ role: "user", content: "Issue: TST-1" }],
+      });
+      return new Response(JSON.stringify({
+        choices: [{ message: { content: "Captured answer" }, finish_reason: "stop" }],
+        usage: { prompt_tokens: 7, completion_tokens: 3 },
+      }), { status: 200 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await execute(makeContext({}));
+
+    expect(result.exitCode).toBe(0);
+    expect(result.summary).toBe("Captured answer");
+    expect(result.resultJson).toMatchObject({
+      summary: "Captured answer",
+      result: "Captured answer",
+      model: "local-model",
+      finishReason: "stop",
+    });
+    expect(result.usage).toEqual({ inputTokens: 7, outputTokens: 3 });
+  });
+
+  it("reports request timeout as a failed closed timed-out run", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((_url: string, init?: RequestInit) => new Promise((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => {
+          reject(new DOMException("Aborted", "AbortError"));
+        });
+      })),
+    );
+
+    const result = await execute(makeContext({ timeoutMs: 1 }));
+
+    expect(result.timedOut).toBe(true);
+    expect(result.errorCode).toBe("timeout");
+    expect(result.errorMessage).toContain("timed out after 1ms");
+  });
+
+  it("fails closed on empty assistant content", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => new Response(JSON.stringify({
+      choices: [{ message: { content: "" }, finish_reason: "stop" }],
+    }), { status: 200 })));
+
+    const result = await execute(makeContext({}));
+
+    expect(result.exitCode).toBe(1);
+    expect(result.errorCode).toBe("openai_compatible_empty_content");
+    expect(result.resultJson?.error).toContain("no assistant content");
+  });
+
+  it("fails closed on invalid endpoint JSON response", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => new Response("not json", { status: 200 })));
+
+    const result = await execute(makeContext({}));
+
+    expect(result.exitCode).toBe(1);
+    expect(result.errorCode).toBe("openai_compatible_invalid_response");
+    expect(result.resultJson?.error).toContain("invalid JSON response");
+  });
+
+  it("fails closed on non-JSON structured output", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => new Response(JSON.stringify({
+      choices: [{ message: { content: "not json" }, finish_reason: "stop" }],
+    }), { status: 200 })));
+
+    const result = await execute(makeContext({ structuredOutput: true }));
+
+    expect(result.exitCode).toBe(1);
+    expect(result.errorCode).toBe("openai_compatible_invalid_json");
+    expect(result.resultJson).toMatchObject({ summary: "not json" });
+  });
+
+  it("strips reasoning_content and validates final JSON content", async () => {
+    const log = vi.fn(async () => {});
+    vi.stubGlobal("fetch", vi.fn(async () => new Response(JSON.stringify({
+      choices: [{
+        message: {
+          reasoning_content: "private reasoning",
+          content: "{\"ok\":true}",
+        },
+        finish_reason: "stop",
+      }],
+    }), { status: 200 })));
+
+    const result = await execute({
+      ...makeContext({ structuredOutput: true }),
+      onLog: log,
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.summary).toBe("{\"ok\":true}");
+    expect(result.resultJson).toMatchObject({
+      hasReasoningContent: true,
+      structuredOutput: { ok: true },
+    });
+    expect(JSON.stringify(result.resultJson)).not.toContain("private reasoning");
+    expect(log).toHaveBeenCalledWith("stderr", expect.stringContaining("omitted reasoning_content"));
+  });
+});

--- a/server/src/adapters/openai-compatible/execute.test.ts
+++ b/server/src/adapters/openai-compatible/execute.test.ts
@@ -95,6 +95,31 @@ describe("openai_compatible adapter execute", () => {
     expect(result.resultJson?.error).toContain("no assistant content");
   });
 
+  it("fails closed and cancels the response body on endpoint HTTP errors", async () => {
+    const response = new Response("server unavailable", { status: 503 });
+    const cancel = vi.spyOn(response.body!, "cancel").mockResolvedValue(undefined);
+    vi.stubGlobal("fetch", vi.fn(async () => response));
+
+    const result = await execute(makeContext({}));
+
+    expect(result.exitCode).toBe(1);
+    expect(result.errorCode).toBe("openai_compatible_http_error");
+    expect(result.errorMessage).toContain("HTTP 503");
+    expect(cancel).toHaveBeenCalledOnce();
+  });
+
+  it("fails closed on network-level fetch errors", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => {
+      throw new TypeError("fetch failed");
+    }));
+
+    const result = await execute(makeContext({}));
+
+    expect(result.exitCode).toBe(1);
+    expect(result.errorCode).toBe("openai_compatible_network_error");
+    expect(result.resultJson?.error).toContain("network error");
+  });
+
   it("fails closed on invalid endpoint JSON response", async () => {
     vi.stubGlobal("fetch", vi.fn(async () => new Response("not json", { status: 200 })));
 

--- a/server/src/adapters/openai-compatible/execute.ts
+++ b/server/src/adapters/openai-compatible/execute.ts
@@ -170,6 +170,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     });
 
     if (!response.ok) {
+      await response.body?.cancel().catch(() => undefined);
       return failClosed({
         errorCode: "openai_compatible_http_error",
         errorMessage: `OpenAI-compatible endpoint returned HTTP ${response.status}`,
@@ -255,7 +256,10 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         },
       };
     }
-    throw err;
+    return failClosed({
+      errorCode: "openai_compatible_network_error",
+      errorMessage: "OpenAI-compatible endpoint request failed with a network error.",
+    });
   } finally {
     if (timer) clearTimeout(timer);
   }

--- a/server/src/adapters/openai-compatible/execute.ts
+++ b/server/src/adapters/openai-compatible/execute.ts
@@ -1,0 +1,262 @@
+import type {
+  AdapterExecutionContext,
+  AdapterExecutionResult,
+  UsageSummary,
+} from "../types.js";
+import {
+  asBoolean,
+  asNumber,
+  asString,
+  parseObject,
+  renderTemplate,
+} from "@paperclipai/adapter-utils/server-utils";
+
+type ChatMessage = {
+  role: "system" | "user" | "assistant";
+  content: string;
+};
+
+function normalizeUrl(config: Record<string, unknown>) {
+  const explicitUrl = asString(config.url, "").trim();
+  if (explicitUrl) return explicitUrl;
+
+  const baseUrl = asString(config.baseUrl, "").trim().replace(/\/+$/, "");
+  if (!baseUrl) {
+    throw new Error("OpenAI-compatible adapter missing baseUrl or url");
+  }
+  const endpointPath = asString(config.endpointPath, "/v1/chat/completions").trim() ||
+    "/v1/chat/completions";
+  return `${baseUrl}${endpointPath.startsWith("/") ? endpointPath : `/${endpointPath}`}`;
+}
+
+function buildMessages(ctx: AdapterExecutionContext): ChatMessage[] {
+  const templateData = {
+    agent: ctx.agent,
+    runId: ctx.runId,
+    context: ctx.context,
+  };
+  const configuredMessages = Array.isArray(ctx.config.messages) ? ctx.config.messages : [];
+  const messages: ChatMessage[] = [];
+
+  for (const item of configuredMessages) {
+    const candidate = parseObject(item);
+    const role = asString(candidate.role, "");
+    if (role !== "system" && role !== "user" && role !== "assistant") continue;
+    const content = renderTemplate(asString(candidate.content, ""), templateData).trim();
+    if (content) messages.push({ role, content });
+  }
+
+  if (messages.length > 0) return messages;
+
+  const systemPrompt = renderTemplate(asString(ctx.config.systemPrompt, ""), templateData).trim();
+  if (systemPrompt) messages.push({ role: "system", content: systemPrompt });
+
+  const defaultPrompt = [
+    "Run Paperclip heartbeat context for agent {{agent.name}}.",
+    "",
+    "{{context}}",
+  ].join("\n");
+  const promptTemplate = asString(ctx.config.promptTemplate, defaultPrompt);
+  const userPrompt = renderTemplate(promptTemplate, templateData).trim();
+  if (userPrompt) messages.push({ role: "user", content: userPrompt });
+
+  return messages;
+}
+
+function buildHeaders(config: Record<string, unknown>) {
+  const configuredHeaders = parseObject(config.headers);
+  const headers: Record<string, string> = {
+    "content-type": "application/json",
+  };
+  for (const [key, value] of Object.entries(configuredHeaders)) {
+    if (typeof value === "string" && key.trim()) headers[key] = value;
+  }
+  return headers;
+}
+
+function asUsage(value: unknown): UsageSummary | undefined {
+  const usage = parseObject(value);
+  const inputTokens = asNumber(usage.prompt_tokens ?? usage.inputTokens, Number.NaN);
+  const outputTokens = asNumber(usage.completion_tokens ?? usage.outputTokens, Number.NaN);
+  if (!Number.isFinite(inputTokens) || !Number.isFinite(outputTokens)) return undefined;
+  const cachedInputTokens = asNumber(
+    usage.prompt_tokens_details && parseObject(usage.prompt_tokens_details).cached_tokens,
+    Number.NaN,
+  );
+  return {
+    inputTokens,
+    outputTokens,
+    ...(Number.isFinite(cachedInputTokens) ? { cachedInputTokens } : {}),
+  };
+}
+
+function firstChoiceMessage(responseJson: unknown) {
+  const body = parseObject(responseJson);
+  const choices = Array.isArray(body.choices) ? body.choices : [];
+  const firstChoice = parseObject(choices[0]);
+  return {
+    body,
+    message: parseObject(firstChoice.message),
+    finishReason: asString(firstChoice.finish_reason ?? firstChoice.finishReason, ""),
+  };
+}
+
+function failClosed(input: {
+  errorCode: string;
+  errorMessage: string;
+  resultJson?: Record<string, unknown>;
+}): AdapterExecutionResult {
+  return {
+    exitCode: 1,
+    signal: null,
+    timedOut: false,
+    errorCode: input.errorCode,
+    errorMessage: input.errorMessage,
+    resultJson: {
+      error: input.errorMessage,
+      ...(input.resultJson ?? {}),
+    },
+  };
+}
+
+export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExecutionResult> {
+  const url = normalizeUrl(ctx.config);
+  const model = asString(ctx.config.model, "").trim();
+  if (!model) throw new Error("OpenAI-compatible adapter missing model");
+
+  const messages = buildMessages(ctx);
+  if (messages.length === 0) throw new Error("OpenAI-compatible adapter produced no messages");
+
+  const timeoutMs = asNumber(
+    ctx.config.timeoutMs,
+    asNumber(ctx.config.timeoutSec, 30) * 1000,
+  );
+  const structuredOutput = asBoolean(ctx.config.structuredOutput, false);
+  const headers = buildHeaders(ctx.config);
+  const responseFormat = structuredOutput ? { type: "json_object" } : parseObject(ctx.config.responseFormat);
+  const body: Record<string, unknown> = {
+    model,
+    messages,
+    ...(Object.keys(responseFormat).length > 0 ? { response_format: responseFormat } : {}),
+  };
+
+  for (const key of ["temperature", "max_tokens", "max_completion_tokens"]) {
+    if (typeof ctx.config[key] === "number") {
+      body[key] = ctx.config[key];
+    }
+  }
+
+  await ctx.onMeta?.({
+    adapterType: "openai_compatible",
+    command: "openai-compatible-chat-completions",
+    commandNotes: [`POST ${new URL(url).origin}${new URL(url).pathname}`],
+    context: {
+      model,
+      messageCount: messages.length,
+      structuredOutput,
+      timeoutMs,
+    },
+  });
+
+  const controller = new AbortController();
+  const timer = timeoutMs > 0 ? setTimeout(() => controller.abort(), timeoutMs) : null;
+
+  try {
+    const response = await fetch(url, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(body),
+      ...(timer ? { signal: controller.signal } : {}),
+    });
+
+    if (!response.ok) {
+      return failClosed({
+        errorCode: "openai_compatible_http_error",
+        errorMessage: `OpenAI-compatible endpoint returned HTTP ${response.status}`,
+      });
+    }
+
+    let responseJson: unknown;
+    try {
+      responseJson = await response.json();
+    } catch {
+      return failClosed({
+        errorCode: "openai_compatible_invalid_response",
+        errorMessage: "OpenAI-compatible endpoint returned an invalid JSON response.",
+      });
+    }
+
+    const { body: responseBody, message, finishReason } = firstChoiceMessage(responseJson);
+    const content = asString(message.content, "").trim();
+    const hasReasoningContent = asString(message.reasoning_content ?? message.reasoningContent, "").trim()
+      .length > 0;
+
+    if (hasReasoningContent) {
+      await ctx.onLog("stderr", "OpenAI-compatible adapter omitted reasoning_content from captured output.\n");
+    }
+
+    if (!content) {
+      return failClosed({
+        errorCode: "openai_compatible_empty_content",
+        errorMessage: "OpenAI-compatible endpoint returned no assistant content.",
+        resultJson: { finishReason, hasReasoningContent },
+      });
+    }
+
+    let parsedStructuredOutput: unknown;
+    if (structuredOutput) {
+      try {
+        parsedStructuredOutput = JSON.parse(content);
+      } catch {
+        return failClosed({
+          errorCode: "openai_compatible_invalid_json",
+          errorMessage: "OpenAI-compatible endpoint returned non-JSON assistant content.",
+          resultJson: { summary: content, finishReason, hasReasoningContent },
+        });
+      }
+      if (!parsedStructuredOutput || typeof parsedStructuredOutput !== "object" || Array.isArray(parsedStructuredOutput)) {
+        return failClosed({
+          errorCode: "openai_compatible_invalid_json_shape",
+          errorMessage: "OpenAI-compatible endpoint returned JSON that is not an object.",
+          resultJson: { summary: content, finishReason, hasReasoningContent },
+        });
+      }
+    }
+
+    return {
+      exitCode: 0,
+      signal: null,
+      timedOut: false,
+      provider: "openai_compatible",
+      model,
+      summary: content,
+      usage: asUsage(responseBody.usage),
+      usageBasis: "per_run",
+      resultJson: {
+        summary: content,
+        result: content,
+        model,
+        finishReason,
+        hasReasoningContent,
+        ...(structuredOutput ? { structuredOutput: parsedStructuredOutput } : {}),
+      },
+    };
+  } catch (err) {
+    if (err instanceof Error && err.name === "AbortError") {
+      return {
+        exitCode: null,
+        signal: null,
+        timedOut: true,
+        errorCode: "timeout",
+        errorMessage: `OpenAI-compatible endpoint timed out after ${timeoutMs}ms`,
+        resultJson: {
+          error: `OpenAI-compatible endpoint timed out after ${timeoutMs}ms`,
+          timeoutMs,
+        },
+      };
+    }
+    throw err;
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}

--- a/server/src/adapters/openai-compatible/index.ts
+++ b/server/src/adapters/openai-compatible/index.ts
@@ -1,0 +1,85 @@
+import type { AdapterConfigSchema, ServerAdapterModule } from "../types.js";
+import { execute } from "./execute.js";
+import { testEnvironment } from "./test.js";
+
+const openAiCompatibleConfigSchema: AdapterConfigSchema = {
+  fields: [
+    {
+      key: "baseUrl",
+      label: "Base URL",
+      type: "text",
+      default: "http://127.0.0.1:8080",
+      hint: "Base URL for the API server when `url` is not provided.",
+    },
+    {
+      key: "url",
+      label: "Endpoint URL",
+      type: "text",
+      hint: "Optional full chat-completions URL. If provided, Base URL is ignored.",
+    },
+    {
+      key: "endpointPath",
+      label: "Endpoint path",
+      type: "text",
+      default: "/v1/chat/completions",
+      hint: "Used with Base URL when Endpoint URL is empty.",
+    },
+    {
+      key: "model",
+      label: "Model",
+      type: "text",
+      required: true,
+      hint: "Model ID accepted by this endpoint.",
+    },
+    {
+      key: "systemPrompt",
+      label: "System prompt",
+      type: "textarea",
+      hint: "Optional custom system prompt for this run.",
+    },
+    {
+      key: "promptTemplate",
+      label: "Prompt template",
+      type: "textarea",
+      hint: "Template used for the user message. Supports `{{context}}`, `{{agent.*}}`, `{{runId}}`.",
+    },
+    {
+      key: "timeoutMs",
+      label: "Request timeout (ms)",
+      type: "number",
+      default: 30000,
+      hint: "Hard timeout passed to the request. 0 disables timeout.",
+    },
+  ],
+};
+
+export const openAiCompatibleAdapter: ServerAdapterModule = {
+  type: "openai_compatible",
+  execute,
+  testEnvironment,
+  getConfigSchema: () => openAiCompatibleConfigSchema,
+  models: [],
+  supportsLocalAgentJwt: false,
+  supportsInstructionsBundle: false,
+  requiresMaterializedRuntimeSkills: false,
+  agentConfigurationDoc: `# openai_compatible agent configuration
+
+Adapter: openai_compatible
+
+Runs one OpenAI-compatible chat completion request and captures the assistant
+message content as the Paperclip run result. Intended for local/self-hosted
+pilot endpoints such as llama.cpp-compatible servers.
+
+Core fields:
+- baseUrl (string, required unless url is set): endpoint base URL, for example http://127.0.0.1:8080
+- url (string, optional): full chat completions URL
+- endpointPath (string, optional): default /v1/chat/completions
+- model (string, required): model name to send to the endpoint
+- systemPrompt (string, optional): system message template
+- promptTemplate (string, optional): user message template; receives {{agent.*}}, {{runId}}, and {{context.*}}
+- timeoutMs (number, optional): request timeout in milliseconds
+
+Rollback: switch the pilot agent back to its previous adapter type/config or
+pause the agent. This adapter has no migrations or persistent runtime state.
+`,
+};

--- a/server/src/adapters/openai-compatible/test.ts
+++ b/server/src/adapters/openai-compatible/test.ts
@@ -1,0 +1,61 @@
+import type {
+  AdapterEnvironmentCheck,
+  AdapterEnvironmentTestContext,
+  AdapterEnvironmentTestResult,
+} from "../types.js";
+import { asString, parseObject } from "@paperclipai/adapter-utils/server-utils";
+
+function summarizeStatus(checks: AdapterEnvironmentCheck[]): AdapterEnvironmentTestResult["status"] {
+  return checks.some((check) => check.level === "error") ? "fail" : "pass";
+}
+
+export async function testEnvironment(
+  ctx: AdapterEnvironmentTestContext,
+): Promise<AdapterEnvironmentTestResult> {
+  const config = parseObject(ctx.config);
+  const checks: AdapterEnvironmentCheck[] = [];
+  const url = asString(config.url, "").trim();
+  const baseUrl = asString(config.baseUrl, "").trim();
+  const model = asString(config.model, "").trim();
+
+  try {
+    const target = url || baseUrl;
+    if (!target) throw new Error("Set adapterConfig.baseUrl or adapterConfig.url.");
+    const parsed = new URL(target);
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      throw new Error("URL must use http or https.");
+    }
+    checks.push({
+      code: "openai_compatible_url_valid",
+      level: "info",
+      message: `Configured endpoint origin: ${parsed.origin}`,
+    });
+  } catch (err) {
+    checks.push({
+      code: "openai_compatible_url_invalid",
+      level: "error",
+      message: err instanceof Error ? err.message : "Invalid OpenAI-compatible endpoint URL.",
+    });
+  }
+
+  if (!model) {
+    checks.push({
+      code: "openai_compatible_model_missing",
+      level: "error",
+      message: "OpenAI-compatible adapter requires adapterConfig.model.",
+    });
+  } else {
+    checks.push({
+      code: "openai_compatible_model_present",
+      level: "info",
+      message: `Configured model: ${model}`,
+    });
+  }
+
+  return {
+    adapterType: ctx.adapterType,
+    status: summarizeStatus(checks),
+    checks,
+    testedAt: new Date().toISOString(),
+  };
+}

--- a/server/src/adapters/registry.test.ts
+++ b/server/src/adapters/registry.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest";
+import { findServerAdapter, listServerAdapters } from "./registry.js";
+
+describe("built-in adapter registry", () => {
+  it("registers openai_compatible as a built-in adapter", () => {
+    const adapter = findServerAdapter("openai_compatible");
+    expect(adapter).not.toBeNull();
+    expect(adapter?.type).toBe("openai_compatible");
+    expect(listServerAdapters().map((candidate) => candidate.type)).toContain("openai_compatible");
+  });
+});

--- a/server/src/adapters/registry.ts
+++ b/server/src/adapters/registry.ts
@@ -107,6 +107,7 @@ import {
   agentConfigurationDoc as openclawGatewayAgentConfigurationDoc,
   models as openclawGatewayModels,
 } from "@paperclipai/adapter-openclaw-gateway";
+import { openAiCompatibleAdapter } from "./openai-compatible/index.js";
 import { listCodexModels, refreshCodexModels } from "./codex-models.js";
 import { listCursorModels } from "./cursor-models.js";
 import {
@@ -446,6 +447,7 @@ function registerBuiltInAdapters() {
     hermesGatewayAdapter,
     hermesLocalAdapter,
     openclawGatewayAdapter,
+    openAiCompatibleAdapter,
     processAdapter,
     httpAdapter,
   ]) {

--- a/ui/src/adapters/adapter-display-registry.test.ts
+++ b/ui/src/adapters/adapter-display-registry.test.ts
@@ -14,6 +14,7 @@ describe("adapter display registry", () => {
     expect(getAdapterLabel("hermes_gateway")).toBe("Hermes Gateway");
     expect(getAdapterLabel("opencode_local")).toBe("OpenCode");
     expect(getAdapterLabel("pi_local")).toBe("Pi");
+    expect(getAdapterLabel("openai_compatible")).toBe("OpenAI Compatible");
 
     expect(getAdapterLabels()).toMatchObject({
       codex_local: "Codex",
@@ -26,6 +27,7 @@ describe("adapter display registry", () => {
       hermes_gateway: "Hermes Gateway",
       opencode_local: "OpenCode",
       pi_local: "Pi",
+      openai_compatible: "OpenAI Compatible",
     });
   });
 

--- a/ui/src/adapters/adapter-display-registry.ts
+++ b/ui/src/adapters/adapter-display-registry.ts
@@ -128,6 +128,11 @@ const adapterDisplayMap: Record<string, AdapterDisplayInfo> = {
     disabledLabel: "Invite external agents from the add-agent modal",
     hideFromVisualSelection: true,
   },
+  openai_compatible: {
+    label: "OpenAI Compatible",
+    description: "OpenAI-compatible chat completions endpoint",
+    icon: Cpu,
+  },
   process: {
     label: "Process",
     description: "Internal process adapter",

--- a/ui/src/adapters/metadata.test.ts
+++ b/ui/src/adapters/metadata.test.ts
@@ -59,4 +59,27 @@ describe("adapter metadata", () => {
       },
     ]);
   });
+
+  it("shows openai_compatible as an available built-in adapter", () => {
+    expect(isEnabledAdapterType("openai_compatible")).toBe(true);
+    expect(isValidAdapterType("openai_compatible")).toBe(true);
+    expect(isVisualAdapterChoice("openai_compatible")).toBe(true);
+
+    expect(
+      listAdapterOptions((type) => type, [
+        {
+          ...externalAdapter,
+          type: "openai_compatible",
+        },
+      ]),
+    ).toEqual([
+      {
+        value: "openai_compatible",
+        label: "openai_compatible",
+        comingSoon: false,
+        hidden: false,
+        experimental: false,
+      },
+    ]);
+  });
 });

--- a/ui/src/adapters/openai-compatible/index.ts
+++ b/ui/src/adapters/openai-compatible/index.ts
@@ -1,0 +1,11 @@
+import type { UIAdapterModule } from "../types";
+import { parseProcessStdoutLine } from "../process/parse-stdout";
+import { SchemaConfigFields, buildSchemaAdapterConfig } from "../schema-config-fields";
+
+export const openAICompatibleUIAdapter: UIAdapterModule = {
+  type: "openai_compatible",
+  label: "OpenAI Compatible",
+  parseStdoutLine: parseProcessStdoutLine,
+  ConfigFields: SchemaConfigFields,
+  buildAdapterConfig: buildSchemaAdapterConfig,
+};

--- a/ui/src/adapters/registry.ts
+++ b/ui/src/adapters/registry.ts
@@ -7,6 +7,7 @@ import { geminiLocalUIAdapter } from "./gemini-local";
 import { grokLocalUIAdapter } from "./grok-local";
 import { hermesGatewayUIAdapter } from "./hermes-gateway";
 import { hermesLocalUIAdapter } from "./hermes-local";
+import { openAICompatibleUIAdapter } from "./openai-compatible";
 import { openCodeLocalUIAdapter } from "./opencode-local";
 import { piLocalUIAdapter } from "./pi-local";
 import { openClawGatewayUIAdapter } from "./openclaw-gateway";
@@ -59,6 +60,7 @@ function registerBuiltInUIAdapters() {
     grokLocalUIAdapter,
     hermesGatewayUIAdapter,
     hermesLocalUIAdapter,
+    openAICompatibleUIAdapter,
     openCodeLocalUIAdapter,
     piLocalUIAdapter,
     cursorLocalUIAdapter,

--- a/ui/src/adapters/use-adapter-capabilities.ts
+++ b/ui/src/adapters/use-adapter-capabilities.ts
@@ -25,6 +25,7 @@ const KNOWN_DEFAULTS: Record<string, AdapterCapabilities> = {
   opencode_local: { supportsInstructionsBundle: true, supportsSkills: true, supportsLocalAgentJwt: true, requiresMaterializedRuntimeSkills: true, supportsModelProfiles: true, supportsAcp: false },
   pi_local: { supportsInstructionsBundle: true, supportsSkills: true, supportsLocalAgentJwt: true, requiresMaterializedRuntimeSkills: true, supportsModelProfiles: false, supportsAcp: false },
   openclaw_gateway: ALL_FALSE,
+  openai_compatible: ALL_FALSE,
 };
 
 /**


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Agent adapters are the boundary between the control plane and the runtime that actually executes an agent heartbeat.
> - Operators increasingly use local or self-hosted endpoints that expose OpenAI-compatible chat completions APIs.
> - Those endpoints need a small built-in adapter path so agents can run against a configured base URL, model, and timeout without custom plugin plumbing.
> - This pull request adds an OpenAI-compatible runtime adapter and registers it across the server and UI adapter registries.
> - The benefit is a reviewable, fail-closed path for local and self-hosted chat-completions pilots.

## Linked Issues or Issue Description

Refs #7520
Refs #4344

## What Changed

- Added a built-in `openai_compatible` server adapter that sends one chat-completions request, captures assistant content, reports token usage when returned, and fails closed on timeout, invalid JSON, empty content, HTTP errors, or invalid structured output.
- Added environment/config validation for endpoint URL and required model fields.
- Registered the adapter in shared constants, server built-ins, UI built-ins, display metadata, and capability defaults.
- Added focused server and UI tests covering registration, metadata, execution behavior, timeouts, structured output validation, and reasoning-content omission.

## Verification

- `pnpm vitest run server/src/adapters/openai-compatible/execute.test.ts server/src/adapters/registry.test.ts ui/src/adapters/adapter-display-registry.test.ts ui/src/adapters/metadata.test.ts`
- `git diff --check`
- `pnpm --filter @paperclipai/shared typecheck`
- `pnpm --filter @paperclipai/server typecheck`
- `pnpm --filter @paperclipai/ui typecheck`

## Risks

- Low migration risk: no database or persistence changes.
- Runtime risk is limited to users selecting this new adapter type; request errors fail closed and do not expose response bodies in error messages.
- Endpoint metadata is intentionally limited to URL origin/path and config shape; operators should still avoid placing credentials directly in adapter headers when a secret-backed configuration is available.

## Model Used

OpenAI GPT-5 Codex, coding-agent environment with shell and repository access.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge
