### PR TITLE
feat(adapters/hermes-gateway): remote skill contract (spec-309 Layers 1+2)

### DIFF
--- a/packages/adapters/hermes/src/gateway/capabilities.ts
+++ b/packages/adapters/hermes/src/gateway/capabilities.ts
@@ -1,0 +1,347 @@
+// capabilities.ts — hermes_gateway capability negotiation + read-only
+// inventory (Layer 1, spec-309 Phase 1). Upstream-PR-quality TS authored for
+// `packages/adapters/hermes/src/gateway/capabilities.ts` in paperclipai/paperclip
+// (this file is copied there verbatim by
+// specs/309-hermes-gateway-remote-skill-contract/scripts/build-paperclip-hermes-fork.sh).
+//
+// Contract source of truth:
+// - specs/309-hermes-gateway-remote-skill-contract/contracts/remote-skill-contract-v1.md
+//   (§Layer 1 + §Fail-closed matrix + §Versioning)
+// - specs/309-hermes-gateway-remote-skill-contract/data-model.md (CapabilityDescriptor)
+//
+// Registration into createServerAdapter() (index.ts) is Plan 02's concern
+// (this plan's scope is the negotiation function + its fail-closed matrix,
+// proven via the dist-imported unit suite, per 01-CONTEXT.md phase boundary).
+
+import {
+  allowsInsecureRemoteHttp,
+  isRemotePlainHttp,
+  remotePlainHttpDeniedMessage,
+} from "./server/transport-security.js";
+
+export type NegotiationOutcome =
+  | "negotiated"
+  | "unsupported"
+  | "auth_error"
+  | "malformed"
+  | "transient_error"
+  | "auth_incompat";
+
+export interface CapabilityDescriptor {
+  contractVersion: string;
+  remoteVersion: string | null;
+  inventorySupported: boolean;
+  activationSupported: boolean;
+  negotiationOutcome: NegotiationOutcome;
+  negotiatedAt: string;
+}
+
+export interface NegotiationResult {
+  capability: CapabilityDescriptor;
+  /** Validated raw skill list from /v1/skills — non-null ONLY when
+   * negotiationOutcome === "negotiated" (atomic negotiation+inventory, no
+   * second racy fetch for Plan 02's listSkills to perform). */
+  inventory: unknown[] | null;
+}
+
+/** Config accepted by negotiateCapability. Mirrors the existing
+ * getConfigSchema() fields (config-schema.ts) plus one Phase-1-local
+ * addition (`negotiationTimeoutMs`) — no new getConfigSchema field was
+ * added (research Open Question 2 default), since a bounded negotiation
+ * deadline is read directly off this ad-hoc config object, not surfaced as
+ * a user-configurable UI field in this phase. */
+export interface NegotiateCapabilityConfig {
+  apiBaseUrl?: unknown;
+  apiKey?: unknown;
+  negotiationTimeoutMs?: unknown;
+  [key: string]: unknown;
+}
+
+const CONTRACT_VERSION = "1";
+// No config-schema field exists for this yet (Open Question 2 default: no
+// new field unless a concrete need arises) — a bounded negotiation deadline
+// is exactly that concrete need (negotiate_timeout_transient), so it is read
+// as an optional ad-hoc config key with this documented default.
+const DEFAULT_NEGOTIATION_TIMEOUT_MS = 10_000;
+// Memory-DoS guard (T-01-03): cap every remote response body read.
+const MAX_RESPONSE_BYTES = 1024 * 1024;
+// The auth scheme this adapter expects on a healthy v0.16/v1 remote.
+const EXPECTED_AUTH_SCHEME = "bearer";
+
+// The legacy unsupported response literal (INT-002). Deliberately frozen;
+// never rebuilt by the general outcome path below (research Pitfall 2).
+// Byte-identical to tests/fixtures/hermes-stub-server.mjs's UNSUPPORTED_LITERAL
+// — no spec-302-recorded artifact was located in this repo or its git
+// history (searched via `git log --all --diff-filter=A --name-only`), so
+// this is the CONTEXT.md-specified literal, not a byte-verified historical
+// shape. Keep both files in sync if this ever changes.
+export const LEGACY_UNSUPPORTED_RESPONSE = Object.freeze({
+  supported: false,
+  mode: "unsupported",
+  entries: Object.freeze([]),
+  warning: "Remote Hermes gateway does not advertise skills_api; skill inventory is unsupported.",
+});
+
+/** Legacy-surface helper: returns the frozen unsupported literal above. A
+ * shape deliberately DISTINCT from CapabilityDescriptor/NegotiationResult —
+ * never conflated with the negotiated descriptor. */
+export function legacyUnsupportedSkillsResponse(): typeof LEGACY_UNSUPPORTED_RESPONSE {
+  return LEGACY_UNSUPPORTED_RESPONSE;
+}
+
+function asString(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function asNumber(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+// LD-S2(b), 02-02-PLAN.md: the real v2026.6.5 `/v1/capabilities` serves
+// `features` as an OBJECT MAP (api_server.py:1110-1135 @
+// 3c231eb3979ab9c57d5cd6d02f1d577a3b718b43, verified firsthand) with mixed
+// boolean/string values (e.g. "skills_api": true, "session_continuity_header":
+// "..."), NOT a string array. A non-object features value -- INCLUDING the
+// Phase-1 fantasy array shape -- negotiates unsupported fail-closed (proven
+// by capability-negotiation.test.mjs's negotiate_array_features_unsupported).
+function asFeatureMap(value: unknown): Record<string, unknown> | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+// Mirrors execute.ts's private normalizeBaseUrl/apiUrl conventions (trailing
+// slash strip, no query/hash) — execute.ts does not export these, and this
+// plan's scope is limited to capabilities.ts (Plan 02 registers this module
+// in index.ts), so the same normalization rule is reproduced locally rather
+// than modifying an out-of-scope file.
+function normalizeBaseUrl(value: string): URL | null {
+  try {
+    const url = new URL(value);
+    if (url.protocol !== "http:" && url.protocol !== "https:") return null;
+    url.pathname = url.pathname.replace(/\/+$/, "");
+    url.search = "";
+    url.hash = "";
+    return url;
+  } catch {
+    return null;
+  }
+}
+
+function apiUrl(baseUrl: URL, path: string): string {
+  return `${baseUrl.toString().replace(/\/+$/, "")}${path}`;
+}
+
+// Mirrors execute.ts's buildHeaders Authorization convention
+// (`Authorization: Bearer <apiKey>`) — the ONLY header this negotiation
+// path needs.
+function buildAuthHeaders(apiKey: string): Record<string, string> {
+  return { Authorization: `Bearer ${apiKey}`, Accept: "application/json" };
+}
+
+function isAbortError(err: unknown): boolean {
+  return err instanceof Error && err.name === "AbortError";
+}
+
+async function requestWithDeadline(
+  url: string,
+  headers: Record<string, string>,
+  timeoutMs: number,
+): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetch(url, { method: "GET", headers, signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/** Reads a Response body capped at maxBytes. Returns { ok:false } (routed to
+ * `malformed` by the caller) when the body exceeds the cap, never buffering
+ * an unbounded remote-controlled payload. */
+async function readCappedText(response: Response, maxBytes: number): Promise<{ ok: true; text: string } | { ok: false }> {
+  const reader = response.body?.getReader();
+  if (!reader) {
+    const text = await response.text();
+    return Buffer.byteLength(text, "utf8") > maxBytes ? { ok: false } : { ok: true, text };
+  }
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    if (value) {
+      total += value.byteLength;
+      if (total > maxBytes) {
+        await reader.cancel().catch(() => undefined);
+        return { ok: false };
+      }
+      chunks.push(value);
+    }
+  }
+  return { ok: true, text: Buffer.concat(chunks.map((chunk) => Buffer.from(chunk))).toString("utf8") };
+}
+
+function parseRemoteVersion(capabilities: Record<string, unknown>): string | null {
+  const runtime = asString(capabilities.runtime);
+  // No field is confirmed to carry a parseable version on a v0.16 remote
+  // (research Assumptions Log A1) — only treat it as a version when it
+  // actually looks like one (leading digit, optional "v" prefix); otherwise
+  // remoteVersion stays null (data-model.md explicitly allows this; never
+  // invented as a stub-only field).
+  return /^v?\d+(\.\d+)*$/i.test(runtime) ? runtime.replace(/^v/i, "") : null;
+}
+
+function isV017AuthMismatch(remoteVersion: string | null, authScheme: string | null): boolean {
+  // ADAPTER-DEFINED HEURISTIC (research Pitfall 3 / EDGE-007, #8924 lineage):
+  // a parseable v0.17.x version PLUS an auth-scheme signal distinct from
+  // this adapter's expected scheme. NOT a published Hermes v0.17 wire
+  // guarantee — revalidate against the live matrix in Phase 4.
+  if (!remoteVersion || !authScheme) return false;
+  return remoteVersion.startsWith("0.17") && authScheme.toLowerCase() !== EXPECTED_AUTH_SCHEME;
+}
+
+function outcomeResult(
+  outcome: Exclude<NegotiationOutcome, "negotiated">,
+  negotiatedAt: string,
+  remoteVersion: string | null = null,
+): NegotiationResult {
+  return {
+    capability: {
+      contractVersion: CONTRACT_VERSION,
+      remoteVersion,
+      inventorySupported: false,
+      activationSupported: false,
+      negotiationOutcome: outcome,
+      negotiatedAt,
+    },
+    inventory: null,
+  };
+}
+
+/**
+ * Negotiates capability + read-only inventory against a Hermes remote.
+ * `GET /v1/capabilities` then, only if `skills_api` is advertised,
+ * `GET /v1/skills` — fail-closed at every branch (contract §Fail-closed
+ * matrix). Returns a NegotiationResult carrying the validated inventory
+ * atomically with the descriptor (non-null only when negotiated).
+ */
+export async function negotiateCapability(config: NegotiateCapabilityConfig): Promise<NegotiationResult> {
+  const negotiatedAt = new Date().toISOString();
+  const baseUrl = normalizeBaseUrl(asString(config.apiBaseUrl));
+  const apiKey = asString(config.apiKey);
+  if (!baseUrl || !apiKey) {
+    return outcomeResult("unsupported", negotiatedAt);
+  }
+
+  if (isRemotePlainHttp(baseUrl) && !allowsInsecureRemoteHttp(config)) {
+    throw new Error(remotePlainHttpDeniedMessage(baseUrl.hostname));
+  }
+
+  const timeoutMs = asNumber(config.negotiationTimeoutMs) ?? DEFAULT_NEGOTIATION_TIMEOUT_MS;
+  const headers = buildAuthHeaders(apiKey);
+
+  let capabilitiesRecord: Record<string, unknown>;
+  try {
+    const response = await requestWithDeadline(apiUrl(baseUrl, "/v1/capabilities"), headers, timeoutMs);
+    if (response.status === 401 || response.status === 403) {
+      return outcomeResult("auth_error", negotiatedAt);
+    }
+    if (response.status === 404) {
+      // Missing route entirely = old remote = unsupported, NEVER malformed
+      // (research Anti-Pattern).
+      return outcomeResult("unsupported", negotiatedAt);
+    }
+    if (response.status >= 500) {
+      return outcomeResult("transient_error", negotiatedAt);
+    }
+    if (!response.ok) {
+      return outcomeResult("malformed", negotiatedAt);
+    }
+    const capped = await readCappedText(response, MAX_RESPONSE_BYTES);
+    if (!capped.ok) return outcomeResult("malformed", negotiatedAt);
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(capped.text);
+    } catch {
+      return outcomeResult("malformed", negotiatedAt);
+    }
+    const record = asRecord(parsed);
+    if (!record) return outcomeResult("malformed", negotiatedAt);
+    capabilitiesRecord = record;
+  } catch (err) {
+    if (isAbortError(err)) return outcomeResult("transient_error", negotiatedAt);
+    return outcomeResult("transient_error", negotiatedAt);
+  }
+
+  const remoteVersion = parseRemoteVersion(capabilitiesRecord);
+  const authScheme = typeof capabilitiesRecord.authScheme === "string" ? capabilitiesRecord.authScheme : null;
+  if (isV017AuthMismatch(remoteVersion, authScheme)) {
+    return outcomeResult("auth_incompat", negotiatedAt, remoteVersion);
+  }
+
+  const features = asFeatureMap(capabilitiesRecord.features);
+  // Non-object features (including the old fantasy array shape) -> refuse
+  // fail-closed, never a partial/legacy re-interpretation (LD-S2(b)).
+  if (!features || features["skills_api"] !== true) {
+    return outcomeResult("unsupported", negotiatedAt, remoteVersion);
+  }
+
+  let activationCandidate = false;
+  for (const [key, value] of Object.entries(features)) {
+    if (!key.startsWith("skills_activation/") || !value) continue;
+    const major = key.split("/")[1] ?? "";
+    if (major !== "v1") {
+      // Locked: unknown contract major -> refuse fail-closed, never partial.
+      return outcomeResult("unsupported", negotiatedAt, remoteVersion);
+    }
+    activationCandidate = true;
+  }
+
+  try {
+    const response = await requestWithDeadline(apiUrl(baseUrl, "/v1/skills"), headers, timeoutMs);
+    if (response.status === 401 || response.status === 403) {
+      return outcomeResult("auth_error", negotiatedAt, remoteVersion);
+    }
+    if (response.status >= 500) {
+      return outcomeResult("transient_error", negotiatedAt, remoteVersion);
+    }
+    if (!response.ok) {
+      return outcomeResult("malformed", negotiatedAt, remoteVersion);
+    }
+    const capped = await readCappedText(response, MAX_RESPONSE_BYTES);
+    if (!capped.ok) return outcomeResult("malformed", negotiatedAt, remoteVersion);
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(capped.text);
+    } catch {
+      return outcomeResult("malformed", negotiatedAt, remoteVersion);
+    }
+    const record = asRecord(parsed);
+    const data = record && Array.isArray(record.data) ? (record.data as unknown[]) : null;
+    if (!data) return outcomeResult("malformed", negotiatedAt, remoteVersion);
+
+    return {
+      capability: {
+        contractVersion: CONTRACT_VERSION,
+        remoteVersion,
+        inventorySupported: true,
+        // activationSupported true ONLY together with inventorySupported
+        // true (data-model.md validation) — both are true only here, in the
+        // single success branch.
+        activationSupported: activationCandidate,
+        negotiationOutcome: "negotiated",
+        negotiatedAt,
+      },
+      inventory: data,
+    };
+  } catch (err) {
+    if (isAbortError(err)) return outcomeResult("transient_error", negotiatedAt, remoteVersion);
+    return outcomeResult("transient_error", negotiatedAt, remoteVersion);
+  }
+}

--- a/packages/adapters/hermes/src/gateway/capabilities.ts
+++ b/packages/adapters/hermes/src/gateway/capabilities.ts
@@ -143,10 +143,6 @@ function buildAuthHeaders(apiKey: string): Record<string, string> {
   return { Authorization: `Bearer ${apiKey}`, Accept: "application/json" };
 }
 
-function isAbortError(err: unknown): boolean {
-  return err instanceof Error && err.name === "AbortError";
-}
-
 async function requestWithDeadline(
   url: string,
   headers: Record<string, string>,
@@ -274,8 +270,7 @@ export async function negotiateCapability(config: NegotiateCapabilityConfig): Pr
     const record = asRecord(parsed);
     if (!record) return outcomeResult("malformed", negotiatedAt);
     capabilitiesRecord = record;
-  } catch (err) {
-    if (isAbortError(err)) return outcomeResult("transient_error", negotiatedAt);
+  } catch {
     return outcomeResult("transient_error", negotiatedAt);
   }
 
@@ -340,8 +335,7 @@ export async function negotiateCapability(config: NegotiateCapabilityConfig): Pr
       },
       inventory: data,
     };
-  } catch (err) {
-    if (isAbortError(err)) return outcomeResult("transient_error", negotiatedAt, remoteVersion);
+  } catch {
     return outcomeResult("transient_error", negotiatedAt, remoteVersion);
   }
 }

--- a/packages/adapters/hermes/src/gateway/index.ts
+++ b/packages/adapters/hermes/src/gateway/index.ts
@@ -1,6 +1,7 @@
 import type { AdapterSessionManagement, ServerAdapterModule } from "@paperclipai/adapter-utils";
 import { ADAPTER_LABEL, ADAPTER_TYPE } from "./shared/constants.js";
 import { execute, getConfigSchema, sessionCodec, testEnvironment } from "./server/index.js";
+import { listSkills, syncSkills } from "./skills.js";
 
 export const type = ADAPTER_TYPE;
 export const label = ADAPTER_LABEL;
@@ -63,6 +64,8 @@ export function createServerAdapter(): ServerAdapterModule {
     testEnvironment,
     sessionCodec,
     sessionManagement,
+    listSkills,
+    syncSkills,
     models,
     supportsLocalAgentJwt: false,
     supportsInstructionsBundle: false,

--- a/packages/adapters/hermes/src/gateway/inventory-mapping.test.ts
+++ b/packages/adapters/hermes/src/gateway/inventory-mapping.test.ts
@@ -1,0 +1,237 @@
+// inventory-mapping.test.ts — hermes_gateway read-only inventory mapping
+// (Layer 1, spec-309 Phase 1, Plan 02). Colocated fork-convention vitest
+// suite (mirrors `packages/adapters/hermes/src/index.test.ts`): constructs
+// the REAL gateway adapter via `createServerAdapter()` and exercises the
+// PUBLIC surface (`listSkills`/`syncSkills`) only — no test-local
+// reimplementation of the mapping/sync logic.
+//
+// Overlay-copied by
+// specs/309-hermes-gateway-remote-skill-contract/scripts/build-paperclip-hermes-fork.sh
+// into the fork's `packages/adapters/hermes/src/gateway/` alongside
+// capabilities.ts, skills.ts, and the modified index.ts, and run under the
+// fork's OWN vitest (`pnpm exec vitest run src/gateway/inventory-mapping.test.ts`)
+// by tests/inventory-mapping.test.mjs (the node:test wrapper ROADMAP
+// criterion 1's literal command executes) — gap round 2: plain `node --test`
+// cannot resolve the pinned adapter-utils raw-src import chain that
+// createServerAdapter() requires (see 01-02-PLAN.md "Gap round 2" section).
+//
+// Stub fixture (the ONLY mock boundary, per 01-CONTEXT.md) is vendored
+// alongside this test file at ./test-fixtures/hermes-stub-server.mjs and
+// resolved by a test-file-relative path — self-contained upstream, zero
+// openclaw-local env-var conventions. It has no declaration file, so the
+// dynamic import below cannot be a static import.
+
+import { expect, test } from "vitest";
+import { fileURLToPath } from "node:url";
+import type { AdapterSkillContext, AdapterSkillSnapshot } from "@paperclipai/adapter-utils";
+import { createServerAdapter } from "./index.js";
+import { LEGACY_UNSUPPORTED_RESPONSE } from "./capabilities.js";
+
+const STUB_FIXTURE_PATH = fileURLToPath(new URL("./test-fixtures/hermes-stub-server.mjs", import.meta.url));
+
+interface StubRequestRecord {
+  method: string | null;
+  path: string | null;
+  hasValidAuth: boolean | null;
+}
+
+interface StubHandle {
+  server: { close: () => void };
+  baseUrl: string;
+  requests: StubRequestRecord[];
+}
+
+interface StubModule {
+  startHermesStub: (mode: string) => Promise<StubHandle>;
+  STUB_API_KEY: string;
+}
+
+// Runtime string import — TS cannot statically resolve a module outside this
+// package, so the module shape is asserted via the interface above (not
+// `as any` — the forbidden-suppression list per 01-02-PLAN.md is `as any` /
+// `@ts-ignore` / `@ts-expect-error`, none of which appear here).
+const stubModulePromise: Promise<StubModule> = import(STUB_FIXTURE_PATH);
+
+const AGENT_ID = "11111111-1111-4111-8111-111111111111";
+const COMPANY_ID = "22222222-2222-4222-8222-222222222222";
+
+function makeCtx(config: Record<string, unknown>): AdapterSkillContext {
+  return { adapterType: "hermes_gateway", agentId: AGENT_ID, companyId: COMPANY_ID, config };
+}
+
+type Adapter = ReturnType<typeof createServerAdapter>;
+
+async function callListSkills(adapter: Adapter, config: Record<string, unknown>): Promise<AdapterSkillSnapshot> {
+  expect(adapter.listSkills, "listSkills is not registered in createServerAdapter()").toBeTypeOf("function");
+  const snapshot = await adapter.listSkills?.(makeCtx(config));
+  if (!snapshot) throw new Error("listSkills returned no snapshot");
+  return snapshot;
+}
+
+async function callSyncSkills(
+  adapter: Adapter,
+  config: Record<string, unknown>,
+  desiredSkills: string[],
+): Promise<AdapterSkillSnapshot> {
+  expect(adapter.syncSkills, "syncSkills is not registered in createServerAdapter()").toBeTypeOf("function");
+  const snapshot = await adapter.syncSkills?.(makeCtx(config), desiredSkills);
+  if (!snapshot) throw new Error("syncSkills returned no snapshot");
+  return snapshot;
+}
+
+test("listSkills_readonly_invariant", async () => {
+  const adapter = createServerAdapter();
+  const { startHermesStub, STUB_API_KEY } = await stubModulePromise;
+  const { server, baseUrl } = await startHermesStub("v0_16");
+  try {
+    const snapshot = await callListSkills(adapter, {
+      apiBaseUrl: baseUrl,
+      apiKey: STUB_API_KEY,
+      negotiationTimeoutMs: 2_000,
+    });
+
+    expect(snapshot.supported).toBe(true);
+    expect(snapshot.mode).toBe("unsupported");
+    expect(snapshot.desiredSkills).toEqual([]);
+    expect(snapshot.entries.length).toBeGreaterThan(0);
+
+    for (const entry of snapshot.entries) {
+      expect(entry.managed).toBe(false);
+      expect(entry.desired).toBe(false);
+      expect(entry.state).toBe("available");
+      expect(entry.state).not.toBe("installed");
+      expect(entry.state).not.toBe("configured");
+      expect(entry.readOnly).toBe(true);
+      expect(entry.origin).toBe("external_unknown");
+      expect(entry.originLabel).toBe("remote-native");
+      expect(entry.key).toBeTruthy();
+      expect(entry.runtimeName).toBeTruthy();
+    }
+
+    // FR-004: no remote field (canary included) propagates — proves
+    // field-by-field construction, never a spread of the remote object.
+    const serialized = JSON.stringify(snapshot);
+    expect(serialized).not.toContain("internalToken");
+    expect(serialized).not.toContain("syncedStatus");
+    expect(serialized).not.toContain("spec309-canary-internal-token-DO-NOT-LEAK");
+  } finally {
+    server.close();
+  }
+});
+
+test("listSkills_wrong_token_auth_error", async () => {
+  const adapter = createServerAdapter();
+  const { startHermesStub } = await stubModulePromise;
+  const { server, baseUrl } = await startHermesStub("v0_16");
+  try {
+    const snapshot = await callListSkills(adapter, {
+      apiBaseUrl: baseUrl,
+      apiKey: "spec309-WRONG-synthetic-bearer",
+      negotiationTimeoutMs: 2_000,
+    });
+
+    expect(snapshot.supported).toBe(false);
+    expect(snapshot.entries).toEqual([]);
+    expect(snapshot.warnings.some((w) => w.includes("auth_error"))).toBe(true);
+  } finally {
+    server.close();
+  }
+});
+
+test("listSkills_malformed_item_rejected", async () => {
+  const adapter = createServerAdapter();
+  const { startHermesStub, STUB_API_KEY } = await stubModulePromise;
+  const { server, baseUrl } = await startHermesStub("bad_item");
+  try {
+    const snapshot = await callListSkills(adapter, {
+      apiBaseUrl: baseUrl,
+      apiKey: STUB_API_KEY,
+      negotiationTimeoutMs: 2_000,
+    });
+
+    expect(snapshot.supported).toBe(false);
+    expect(snapshot.entries).toEqual([]);
+    expect(snapshot.warnings.some((w) => w.includes("malformed"))).toBe(true);
+  } finally {
+    server.close();
+  }
+});
+
+test("listSkills_unknown_major_refuse", async () => {
+  const adapter = createServerAdapter();
+  const { startHermesStub, STUB_API_KEY } = await stubModulePromise;
+  const { server, baseUrl } = await startHermesStub("unknown_major");
+  try {
+    const snapshot = await callListSkills(adapter, {
+      apiBaseUrl: baseUrl,
+      apiKey: STUB_API_KEY,
+      negotiationTimeoutMs: 2_000,
+    });
+
+    expect(snapshot.supported).toBe(false);
+    expect(snapshot.entries).toEqual([]);
+  } finally {
+    server.close();
+  }
+});
+
+test("syncSkills_honest_unsupported_zero_calls", async () => {
+  const adapter = createServerAdapter();
+  const { startHermesStub, STUB_API_KEY } = await stubModulePromise;
+  const { server, baseUrl, requests } = await startHermesStub("v0_16");
+  try {
+    const snapshot = await callSyncSkills(
+      adapter,
+      { apiBaseUrl: baseUrl, apiKey: STUB_API_KEY, negotiationTimeoutMs: 2_000 },
+      ["brand-voice"],
+    );
+
+    expect(snapshot.supported).toBe(LEGACY_UNSUPPORTED_RESPONSE.supported);
+    expect(snapshot.mode).toBe(LEGACY_UNSUPPORTED_RESPONSE.mode);
+    expect(snapshot.entries).toEqual([...LEGACY_UNSUPPORTED_RESPONSE.entries]);
+    expect(snapshot.warnings).toContain(LEGACY_UNSUPPORTED_RESPONSE.warning);
+
+    // Full transcript: only permitted capability/inventory GETs — no other
+    // method or path (zero activation calls, T-01-05).
+    for (const req of requests) {
+      expect(req.method).toBe("GET");
+      expect(["/v1/capabilities", "/v1/skills"]).toContain(req.path);
+    }
+  } finally {
+    server.close();
+  }
+});
+
+test("INT_001_negotiate_and_list_end_to_end", async () => {
+  const adapter = createServerAdapter();
+  const { startHermesStub, STUB_API_KEY } = await stubModulePromise;
+  const { server, baseUrl, requests } = await startHermesStub("v0_16");
+  try {
+    const snapshot = await callListSkills(adapter, {
+      apiBaseUrl: baseUrl,
+      apiKey: STUB_API_KEY,
+      negotiationTimeoutMs: 2_000,
+    });
+
+    expect(snapshot.supported).toBe(true);
+    expect(snapshot.mode).toBe("unsupported");
+    for (const entry of snapshot.entries) {
+      expect(entry.managed).toBe(false);
+      expect(entry.desired).toBe(false);
+      expect(entry.state).toBe("available");
+      expect(entry.readOnly).toBe(true);
+    }
+
+    // Wire-order invariant: GET /v1/capabilities precedes exactly ONE
+    // authenticated GET /v1/skills — negotiate-FIRST falsified at the wire.
+    const capIndex = requests.findIndex((r) => r.path === "/v1/capabilities");
+    const skillsRequests = requests.filter((r) => r.path === "/v1/skills");
+    expect(capIndex).toBeGreaterThanOrEqual(0);
+    expect(skillsRequests.length).toBe(1);
+    const skillsIndex = requests.findIndex((r) => r.path === "/v1/skills");
+    expect(skillsIndex).toBeGreaterThan(capIndex);
+    expect(requests[skillsIndex]?.hasValidAuth).toBe(true);
+  } finally {
+    server.close();
+  }
+});

--- a/packages/adapters/hermes/src/gateway/skills.ts
+++ b/packages/adapters/hermes/src/gateway/skills.ts
@@ -186,10 +186,6 @@ function buildAuthHeaders(apiKey: string): Record<string, string> {
   return { Authorization: `Bearer ${apiKey}`, Accept: "application/json" };
 }
 
-function isAbortError(err: unknown): boolean {
-  return err instanceof Error && err.name === "AbortError";
-}
-
 interface WireConfig {
   baseUrl: URL;
   headers: Record<string, string>;
@@ -333,8 +329,8 @@ async function postActivation(
       body,
       wire.timeoutMs,
     );
-  } catch (err) {
-    return { kind: "failed", code: isAbortError(err) ? "transient_error" : "transient_error" };
+  } catch {
+    return { kind: "failed", code: "transient_error" };
   }
 
   if (response.status === 403) return { kind: "fail_fast", token: "wrong_scope" };

--- a/packages/adapters/hermes/src/gateway/skills.ts
+++ b/packages/adapters/hermes/src/gateway/skills.ts
@@ -1,0 +1,758 @@
+// skills.ts — hermes_gateway read-only inventory mapping (Layer 1) + the
+// deterministic desired->activated->observed syncSkills reconcile (Layer 2,
+// spec-309 Phase 2, Plan 03). Upstream-PR-quality TS authored for
+// `packages/adapters/hermes/src/gateway/skills.ts` in paperclipai/paperclip
+// (copied there verbatim by
+// specs/309-hermes-gateway-remote-skill-contract/scripts/build-paperclip-hermes-fork.sh).
+//
+// Contract source of truth:
+// - specs/309-hermes-gateway-remote-skill-contract/contracts/remote-skill-contract-v1.md
+//   (§Layer 1: ReadOnlySkillEntry; §Layer 2: activation/clean/managed-scope
+//   wire + adapter surface)
+// - specs/309-hermes-gateway-remote-skill-contract/data-model.md
+// - 02-03-PLAN.md <locked_decisions> (LD-2/5/6/7/8) — the adjudicated
+//   rationale this file realizes.
+//
+// HTTP discipline note (Task 2 hard constraint 2): capabilities.ts's
+// requestWithDeadline/readCappedText/normalizeBaseUrl/buildAuthHeaders are
+// module-private and GET-only, so they cannot be imported. The equivalents
+// below are a skills.ts-PRIVATE, method-parameterized MIRROR of that same
+// idiom (bounded-deadline fetch + capped-body read) — the established
+// Phase-1 precedent (capabilities.ts itself mirrors execute.ts's private
+// helpers; see capabilities.ts's own header comment). capabilities.ts is
+// NOT modified by this plan.
+
+import { createHash, randomBytes } from "node:crypto";
+import type {
+  AdapterSkillContext,
+  AdapterSkillEntry,
+  AdapterSkillSnapshot,
+  AdapterSkillState,
+} from "@paperclipai/adapter-utils";
+import { negotiateCapability, LEGACY_UNSUPPORTED_RESPONSE } from "./capabilities.js";
+
+const ADAPTER_TYPE = "hermes_gateway";
+
+// Sanity cap on inventory size (T-01-04 memory-DoS adjacent guard) — an
+// inventory above this is rejected fail-closed rather than accepted
+// unbounded. Reused for the desired-set cap (DoS posture parity, Task 2
+// hard constraint 4) and the managed-inventory cap (Task 2 constraint 6).
+const MAX_ENTRIES = 500;
+
+function unsupportedSnapshot(warning: string): AdapterSkillSnapshot {
+  return {
+    adapterType: ADAPTER_TYPE,
+    supported: false,
+    mode: "unsupported",
+    desiredSkills: [],
+    entries: [],
+    warnings: [warning],
+  };
+}
+
+/**
+ * Maps the NegotiationResult-carried inventory into real AdapterSkillEntry
+ * records, constructed field-by-field (never spread from the remote object —
+ * T-01-06, so no remote field, canary included, can propagate). Returns
+ * `null` when ANY item fails per-item validation — the whole response is
+ * then rejected fail-closed by the caller, never a partial mapping of the
+ * valid subset (T-01-04).
+ */
+function mapInventory(inventory: unknown[]): AdapterSkillEntry[] | null {
+  if (inventory.length > MAX_ENTRIES) return null;
+
+  const seenKeys = new Set<string>();
+  const entries: AdapterSkillEntry[] = [];
+
+  for (const raw of inventory) {
+    if (typeof raw !== "object" || raw === null || Array.isArray(raw)) return null;
+    const record = raw as Record<string, unknown>;
+
+    // Resolved stable field (01-01-PLAN.md provenance): the v0.16 /v1/skills
+    // envelope carries no field distinct from `name` — skillId <- name.
+    const stableId = typeof record.name === "string" ? record.name.trim() : "";
+    if (!stableId || seenKeys.has(stableId)) return null;
+    seenKeys.add(stableId);
+
+    // Field-by-field construction only — required fields pinned to the
+    // read-only-invariant values; version/contentHash are set ONLY when the
+    // remote item actually carries them (v0.16 items carry neither).
+    const entry: AdapterSkillEntry = {
+      key: stableId,
+      runtimeName: stableId,
+      managed: false,
+      desired: false,
+      state: "available",
+      readOnly: true,
+      origin: "external_unknown",
+      originLabel: "remote-native",
+    };
+    entries.push(entry);
+  }
+
+  return entries;
+}
+
+/**
+ * Read-only inventory for the negotiated hermes_gateway adapter.
+ * Negotiates FIRST (via negotiateCapability) and maps ONLY the inventory
+ * carried inside that single NegotiationResult — no second `/v1/skills`
+ * fetch, no TOCTOU window.
+ */
+export async function listSkills(ctx: AdapterSkillContext): Promise<AdapterSkillSnapshot> {
+  const result = await negotiateCapability(ctx.config);
+  const { capability, inventory } = result;
+
+  if (capability.negotiationOutcome !== "negotiated" || !capability.inventorySupported || inventory === null) {
+    // Honest negative — including unknown-major refusals, which
+    // negotiateCapability already resolves to "unsupported" (Plan 01).
+    return unsupportedSnapshot(`negotiation:${capability.negotiationOutcome}`);
+  }
+
+  const entries = mapInventory(inventory);
+  if (entries === null) {
+    return unsupportedSnapshot("malformed:invalid_inventory_item");
+  }
+
+  return {
+    adapterType: ADAPTER_TYPE,
+    supported: true,
+    // Activation is never negotiated at Layer 1 — the reconcile algorithm
+    // (desired/activated/observed transitions) is Phase 2 scope.
+    mode: "unsupported",
+    desiredSkills: [],
+    entries,
+    warnings: [],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Layer 2 — syncSkills deterministic reconcile (02-03-PLAN.md)
+// ---------------------------------------------------------------------------
+
+const SKILL_ID_RE = /^[a-z0-9][a-z0-9_-]{0,63}$/;
+const MAX_RESPONSE_BYTES = 1024 * 1024;
+const DEFAULT_WIRE_TIMEOUT_MS = 10_000;
+
+interface DesiredBundle {
+  version: string;
+  content: string;
+}
+
+function isValidBundle(value: unknown): value is DesiredBundle {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
+  const record = value as Record<string, unknown>;
+  return (
+    typeof record.version === "string" &&
+    record.version.length > 0 &&
+    typeof record.content === "string" &&
+    record.content.length > 0
+  );
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+function asString(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function asNumber(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+// Mirrors capabilities.ts's normalizeBaseUrl (module-private there, so
+// reproduced locally rather than modifying an out-of-scope file).
+function normalizeBaseUrl(value: string): URL | null {
+  try {
+    const url = new URL(value);
+    if (url.protocol !== "http:" && url.protocol !== "https:") return null;
+    url.pathname = url.pathname.replace(/\/+$/, "");
+    url.search = "";
+    url.hash = "";
+    return url;
+  } catch {
+    return null;
+  }
+}
+
+function apiUrl(baseUrl: URL, path: string): string {
+  return `${baseUrl.toString().replace(/\/+$/, "")}${path}`;
+}
+
+function buildAuthHeaders(apiKey: string): Record<string, string> {
+  return { Authorization: `Bearer ${apiKey}`, Accept: "application/json" };
+}
+
+function isAbortError(err: unknown): boolean {
+  return err instanceof Error && err.name === "AbortError";
+}
+
+interface WireConfig {
+  baseUrl: URL;
+  headers: Record<string, string>;
+  timeoutMs: number;
+}
+
+function resolveWireConfig(config: Record<string, unknown>): WireConfig | null {
+  const baseUrl = normalizeBaseUrl(asString(config.apiBaseUrl));
+  const apiKey = asString(config.apiKey);
+  if (!baseUrl || !apiKey) return null;
+  const timeoutMs = asNumber(config.negotiationTimeoutMs) ?? DEFAULT_WIRE_TIMEOUT_MS;
+  return { baseUrl, headers: buildAuthHeaders(apiKey), timeoutMs };
+}
+
+// Method-parameterized mirror of capabilities.ts's requestWithDeadline
+// (GET-only there) — same bounded-deadline discipline for POST/DELETE.
+async function requestWithDeadline(
+  url: string,
+  method: string,
+  headers: Record<string, string>,
+  body: string | undefined,
+  timeoutMs: number,
+): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetch(url, { method, headers, body, signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+// Mirrors capabilities.ts's readCappedText (module-private there).
+async function readCappedText(
+  response: Response,
+  maxBytes: number,
+): Promise<{ ok: true; text: string } | { ok: false }> {
+  const reader = response.body?.getReader();
+  if (!reader) {
+    const text = await response.text();
+    return Buffer.byteLength(text, "utf8") > maxBytes ? { ok: false } : { ok: true, text };
+  }
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    if (value) {
+      total += value.byteLength;
+      if (total > maxBytes) {
+        await reader.cancel().catch(() => undefined);
+        return { ok: false };
+      }
+      chunks.push(value);
+    }
+  }
+  return { ok: true, text: Buffer.concat(chunks.map((chunk) => Buffer.from(chunk))).toString("utf8") };
+}
+
+function inventoryNames(inventory: unknown[]): Set<string> {
+  const names = new Set<string>();
+  for (const raw of inventory) {
+    if (typeof raw !== "object" || raw === null || Array.isArray(raw)) continue;
+    const rawName = (raw as Record<string, unknown>).name;
+    const name = typeof rawName === "string" ? rawName.trim() : "";
+    if (name) names.add(name);
+  }
+  return names;
+}
+
+interface ManagedEntry {
+  name: string;
+  contentHash: string;
+}
+
+async function fetchManaged(wire: WireConfig): Promise<{ ok: true; entries: ManagedEntry[] } | { ok: false }> {
+  let response: Response;
+  try {
+    response = await requestWithDeadline(
+      apiUrl(wire.baseUrl, "/v1/skills?scope=managed"),
+      "GET",
+      wire.headers,
+      undefined,
+      wire.timeoutMs,
+    );
+  } catch {
+    return { ok: false };
+  }
+  if (!response.ok) return { ok: false };
+  const capped = await readCappedText(response, MAX_RESPONSE_BYTES);
+  if (!capped.ok) return { ok: false };
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(capped.text);
+  } catch {
+    return { ok: false };
+  }
+  const record = asRecord(parsed);
+  const data = record && Array.isArray(record.data) ? (record.data as unknown[]) : null;
+  if (!data || data.length > MAX_ENTRIES) return { ok: false };
+
+  const entries: ManagedEntry[] = [];
+  for (const raw of data) {
+    const item = asRecord(raw);
+    const name = item && typeof item.name === "string" ? item.name.trim() : "";
+    const contentHash = item && typeof item.contentHash === "string" ? item.contentHash : "";
+    // Name must be interpolation-safe BEFORE it can ever reach a DELETE
+    // path; contentHash must be well-shaped when present.
+    if (!name || !SKILL_ID_RE.test(name)) return { ok: false };
+    if (contentHash && !/^sha256:[0-9a-f]{64}$/.test(contentHash)) return { ok: false };
+    entries.push({ name, contentHash });
+  }
+  return { ok: true, entries };
+}
+
+type PostOutcome =
+  | { kind: "ack"; status: 201 | 200 }
+  | { kind: "fail_fast"; token: "wrong_scope" | "auth_error" }
+  | { kind: "failed"; code: string };
+
+async function postActivation(
+  wire: WireConfig,
+  name: string,
+  versionId: string,
+  contentHash: string,
+  content: string,
+  idempotencyKey: string,
+): Promise<PostOutcome> {
+  const body = JSON.stringify({
+    contractVersion: "1",
+    idempotencyKey,
+    skill: { skillId: name, version: versionId, contentHash, content },
+  });
+  const headers = { ...wire.headers, "content-type": "application/json" };
+  let response: Response;
+  try {
+    response = await requestWithDeadline(
+      apiUrl(wire.baseUrl, "/v1/skills/activations"),
+      "POST",
+      headers,
+      body,
+      wire.timeoutMs,
+    );
+  } catch (err) {
+    return { kind: "failed", code: isAbortError(err) ? "transient_error" : "transient_error" };
+  }
+
+  if (response.status === 403) return { kind: "fail_fast", token: "wrong_scope" };
+  if (response.status === 401) return { kind: "fail_fast", token: "auth_error" };
+
+  if (response.status === 201 || response.status === 200) {
+    const capped = await readCappedText(response, MAX_RESPONSE_BYTES);
+    if (!capped.ok) return { kind: "failed", code: "bad_ack" };
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(capped.text);
+    } catch {
+      return { kind: "failed", code: "bad_ack" };
+    }
+    const record = asRecord(parsed);
+    const ack = record ? asRecord(record.ack) : null;
+    if (!ack || ack.skillId !== name) return { kind: "failed", code: "bad_ack" };
+    return { kind: "ack", status: response.status as 201 | 200 };
+  }
+
+  const capped = await readCappedText(response, MAX_RESPONSE_BYTES);
+  let code = String(response.status);
+  if (capped.ok) {
+    try {
+      const record = asRecord(JSON.parse(capped.text));
+      const err = record ? asRecord(record.error) : null;
+      if (err && typeof err.code === "string") code = err.code;
+    } catch {
+      // keep the numeric status as the code
+    }
+  }
+  return { kind: "failed", code };
+}
+
+async function deleteClean(wire: WireConfig, name: string): Promise<boolean> {
+  try {
+    const response = await requestWithDeadline(
+      apiUrl(wire.baseUrl, `/v1/skills/activations/${encodeURIComponent(name)}?mode=clean`),
+      "DELETE",
+      wire.headers,
+      undefined,
+      wire.timeoutMs,
+    );
+    return response.status === 200 || response.status === 404;
+  } catch {
+    return false;
+  }
+}
+
+interface Resolved {
+  name: string;
+  versionId: string | null;
+  contentHash: string | null;
+  content: string | null;
+  terminal: string | null;
+}
+
+interface Outcome {
+  state: AdapterSkillState;
+  detail: string;
+  managed: boolean;
+  readOnly?: true;
+}
+
+function legacyUnsupportedSnapshot(desiredSkills: string[]): AdapterSkillSnapshot {
+  return {
+    adapterType: ADAPTER_TYPE,
+    supported: LEGACY_UNSUPPORTED_RESPONSE.supported,
+    mode: LEGACY_UNSUPPORTED_RESPONSE.mode,
+    desiredSkills: [...desiredSkills],
+    entries: [...LEGACY_UNSUPPORTED_RESPONSE.entries],
+    warnings: [LEGACY_UNSUPPORTED_RESPONSE.warning],
+  };
+}
+
+function resolveDesired(names: string[], bundles: Record<string, unknown> | null): Resolved[] {
+  return names.map((name) => {
+    if (!SKILL_ID_RE.test(name)) {
+      return { name, versionId: null, contentHash: null, content: null, terminal: "failed:invalid_skill_id" };
+    }
+    const bundle = bundles ? bundles[name] : undefined;
+    if (!isValidBundle(bundle)) {
+      return { name, versionId: null, contentHash: null, content: null, terminal: "failed:no_bundle" };
+    }
+    const hash = `sha256:${createHash("sha256").update(bundle.content, "utf8").digest("hex")}`;
+    return { name, versionId: bundle.version, contentHash: hash, content: bundle.content, terminal: null };
+  });
+}
+
+/** Plans each resolved desired skill against native/managed sets. Returns
+ * the initial per-name outcomes plus the subset needing an activation POST
+ * and the "kind" (fresh activate vs stale refresh) for detail-token choice. */
+function planTransitions(
+  resolved: Resolved[],
+  trueNativeNames: Set<string>,
+  managedMap: Map<string, ManagedEntry>,
+): { outcomes: Map<string, Outcome>; activations: Array<{ r: Resolved; kind: "activate" | "refresh" }> } {
+  const outcomes = new Map<string, Outcome>();
+  const activations: Array<{ r: Resolved; kind: "activate" | "refresh" }> = [];
+
+  for (const r of resolved) {
+    if (r.terminal) {
+      outcomes.set(r.name, { state: "missing", detail: r.terminal, managed: false });
+      continue;
+    }
+    if (trueNativeNames.has(r.name)) {
+      outcomes.set(r.name, { state: "external", detail: "native_conflict", managed: false, readOnly: true });
+      continue;
+    }
+    const managedEntry = managedMap.get(r.name);
+    if (managedEntry && managedEntry.contentHash === r.contentHash) {
+      outcomes.set(r.name, { state: "installed", detail: "already_installed", managed: true });
+      continue;
+    }
+    activations.push({ r, kind: managedEntry ? "refresh" : "activate" });
+  }
+
+  return { outcomes, activations };
+}
+
+function idempotencyKeyFor(name: string, contentHash: string): string {
+  return `sync-${name}-${contentHash.slice("sha256:".length)}`;
+}
+
+/** Executes activations sequentially, fail-fast on 401/403 (LD-1): the
+ * failing skill is marked `failed:<token>`, every remaining planned
+ * mutation (activations AND cleans) is marked `skipped_after_<token>`, and
+ * no further wire calls are made. Returns which names actually received a
+ * 200-replay ack (for LD-8's bounded recovery) and whether any wire call
+ * was attempted at all (observed-refetch gate). */
+async function executeActivations(
+  wire: WireConfig,
+  activations: Array<{ r: Resolved; kind: "activate" | "refresh" }>,
+  outcomes: Map<string, Outcome>,
+): Promise<{ acked: Map<string, 201 | 200>; fastFailToken: "wrong_scope" | "auth_error" | null; attempted: boolean }> {
+  const acked = new Map<string, 201 | 200>();
+  let fastFailToken: "wrong_scope" | "auth_error" | null = null;
+  let attempted = false;
+
+  for (const { r, kind } of activations) {
+    if (fastFailToken) {
+      outcomes.set(r.name, {
+        state: kind === "refresh" ? "stale" : "missing",
+        detail: `skipped_after_${fastFailToken}`,
+        managed: kind === "refresh",
+      });
+      continue;
+    }
+    attempted = true;
+    const key = idempotencyKeyFor(r.name, r.contentHash as string);
+    const result = await postActivation(wire, r.name, r.versionId as string, r.contentHash as string, r.content as string, key);
+    if (result.kind === "fail_fast") {
+      fastFailToken = result.token;
+      outcomes.set(r.name, { state: kind === "refresh" ? "stale" : "missing", detail: `failed:${result.token}`, managed: false });
+      continue;
+    }
+    if (result.kind === "ack") {
+      acked.set(r.name, result.status);
+      outcomes.set(r.name, {
+        state: "installed",
+        detail: kind === "refresh" ? "stale_refreshed" : "activated",
+        managed: true,
+      });
+      continue;
+    }
+    outcomes.set(r.name, { state: kind === "refresh" ? "stale" : "missing", detail: `failed:${result.code}`, managed: false });
+  }
+
+  return { acked, fastFailToken, attempted };
+}
+
+/** Executes clean DELETEs for managed-not-desired orphans. Skips entirely
+ * (with a distinct skipped warning) once a fail-fast token is already set. */
+async function executeCleans(
+  wire: WireConfig,
+  cleanNames: string[],
+  fastFailToken: "wrong_scope" | "auth_error" | null,
+): Promise<{ cleaned: string[]; failed: string[]; skipped: string[]; attempted: boolean }> {
+  const cleaned: string[] = [];
+  const failed: string[] = [];
+  const skipped: string[] = [];
+  let attempted = false;
+
+  for (const name of cleanNames) {
+    if (fastFailToken) {
+      skipped.push(name);
+      continue;
+    }
+    attempted = true;
+    const ok = await deleteClean(wire, name);
+    if (ok) cleaned.push(name);
+    else failed.push(name);
+  }
+
+  return { cleaned, failed, skipped, attempted };
+}
+
+/** LD-8 bounded replay-miss recovery: for each 200-replay ack not found in
+ * the observed re-fetch, retry exactly once with a fresh-nonce key, then
+ * fold in ONE final shared re-fetch. 201 (fresh) acks never trigger this. */
+async function recoverReplayMisses(
+  wire: WireConfig,
+  acked: Map<string, 201 | 200>,
+  resolvedByName: Map<string, Resolved>,
+  observedAfterFirst: Map<string, ManagedEntry>,
+  outcomes: Map<string, Outcome>,
+): Promise<void> {
+  const needsRecovery: string[] = [];
+  for (const [name, status] of acked) {
+    if (status !== 200) continue;
+    const observed = observedAfterFirst.get(name);
+    const r = resolvedByName.get(name);
+    if (observed && r && observed.contentHash === r.contentHash) continue;
+    needsRecovery.push(name);
+  }
+  if (needsRecovery.length === 0) return;
+
+  for (const name of needsRecovery) {
+    const r = resolvedByName.get(name);
+    if (!r) continue;
+    const retryKey = `${idempotencyKeyFor(name, r.contentHash as string)}-r${randomBytes(4).toString("hex")}`;
+    await postActivation(wire, r.name, r.versionId as string, r.contentHash as string, r.content as string, retryKey);
+  }
+
+  const finalFetch = await fetchManaged(wire);
+  const finalMap = finalFetch.ok ? new Map(finalFetch.entries.map((e) => [e.name, e])) : new Map<string, ManagedEntry>();
+  for (const name of needsRecovery) {
+    const r = resolvedByName.get(name);
+    const observed = finalMap.get(name);
+    if (r && observed && observed.contentHash === r.contentHash) continue; // already installed, detail stands
+    const current = outcomes.get(name);
+    outcomes.set(name, { state: current?.state === "stale" ? "stale" : "missing", detail: "activated_not_observed", managed: false });
+  }
+}
+
+/** Finalizes acked-but-not-yet-recovered entries against a single observed
+ * re-fetch (LD-2 §step 6). Entries observed with a matching hash keep their
+ * tentative `activated`/`stale_refreshed` detail; everything else becomes
+ * `activated_not_observed` (or the whole acked set does, if the refetch
+ * itself failed). */
+function finalizeObserved(
+  acked: Map<string, 201 | 200>,
+  observed: { ok: true; entries: ManagedEntry[] } | { ok: false },
+  resolvedByName: Map<string, Resolved>,
+  outcomes: Map<string, Outcome>,
+): Map<string, ManagedEntry> {
+  if (!observed.ok) {
+    for (const name of acked.keys()) {
+      outcomes.set(name, { state: "missing", detail: "activated_not_observed", managed: false });
+    }
+    return new Map();
+  }
+  const observedMap = new Map(observed.entries.map((e) => [e.name, e]));
+  for (const name of acked.keys()) {
+    const r = resolvedByName.get(name);
+    const entry = observedMap.get(name);
+    if (entry && r && entry.contentHash === r.contentHash) continue; // installed, detail stands
+    if (entry) {
+      outcomes.set(name, { state: "stale", detail: "activated_not_observed", managed: false });
+      continue;
+    }
+    // absent: 201 (fresh) acks are final immediately; 200 (replay) acks are
+    // resolved by recoverReplayMisses afterward.
+    if (acked.get(name) === 201) {
+      outcomes.set(name, { state: "missing", detail: "activated_not_observed", managed: false });
+    }
+  }
+  return observedMap;
+}
+
+function buildWarnings(names: string[], outcomes: Map<string, Outcome>, cleaned: string[], cleanFailed: string[], cleanSkipped: string[], skipToken: "wrong_scope" | "auth_error" | null): string[] {
+  const warnings: string[] = [];
+  const cleanOutcomes: Array<[string, string]> = [
+    ...cleaned.map((n): [string, string] => [n, "cleaned"]),
+    ...cleanFailed.map((n): [string, string] => [n, "clean_failed"]),
+    ...cleanSkipped.map((n): [string, string] => [n, `skipped_after_${skipToken ?? "unknown"}`]),
+  ];
+  for (const name of names) {
+    const outcome = outcomes.get(name);
+    if (!outcome) continue;
+    if (outcome.detail === "already_installed" || outcome.detail === "activated" || outcome.detail === "stale_refreshed") {
+      continue;
+    }
+    warnings.push(`reconcile:${name}:${outcome.detail}`);
+  }
+  for (const [name, token] of cleanOutcomes) {
+    warnings.push(`reconcile:${name}:${token}`);
+  }
+  return warnings;
+}
+
+function dedupeSorted(desiredSkills: string[]): string[] {
+  const seen = new Set<string>();
+  const ordered: string[] = [];
+  for (const name of desiredSkills) {
+    if (!seen.has(name)) {
+      seen.add(name);
+      ordered.push(name);
+    }
+  }
+  return [...ordered].sort();
+}
+
+function buildSnapshot(
+  desiredSkills: string[],
+  names: string[],
+  resolvedByName: Map<string, Resolved>,
+  entries: AdapterSkillEntry[],
+  warnings: string[],
+): AdapterSkillSnapshot {
+  return {
+    adapterType: ADAPTER_TYPE,
+    supported: true,
+    mode: "persistent",
+    desiredSkills: [...desiredSkills],
+    desiredSkillEntries: names.map((name) => ({ key: name, versionId: resolvedByName.get(name)!.versionId })),
+    entries,
+    warnings,
+  };
+}
+
+/** Fail-closed snapshot for a managed-GET that never happened / never
+ * succeeded — every desired entry is marked unavailable, zero mutations. */
+function managedUnavailableSnapshot(
+  desiredSkills: string[],
+  names: string[],
+  resolvedByName: Map<string, Resolved>,
+): AdapterSkillSnapshot {
+  const entries = names.map((name) =>
+    makeEntry(name, resolvedByName.get(name)!, {
+      state: "missing",
+      detail: "failed:managed_inventory_unavailable",
+      managed: false,
+    }),
+  );
+  return buildSnapshot(desiredSkills, names, resolvedByName, entries, ["reconcile:managed_inventory_unavailable"]);
+}
+
+/**
+ * Deterministic desired->activated->observed reconcile (Layer 2). Negotiates
+ * FIRST; when activation is not negotiated, returns the byte-frozen
+ * unsupported literal exactly as Layer 1 (zero activation calls, Phase-1
+ * regression preserved). Otherwise executes the full reconcile against the
+ * real Layer-2 wire (managed GET / activation POST / clean DELETE) and
+ * projects truthful per-skill outcomes onto AdapterSkillSnapshot (LD-6) —
+ * never an invented report type. Never throws: every remote/validation
+ * failure maps to a per-skill outcome token or a fail-closed snapshot.
+ */
+export async function syncSkills(
+  ctx: AdapterSkillContext,
+  desiredSkills: string[],
+): Promise<AdapterSkillSnapshot> {
+  const negotiation = await negotiateCapability(ctx.config);
+  const { capability, inventory } = negotiation;
+
+  if (capability.negotiationOutcome !== "negotiated" || !capability.activationSupported || inventory === null) {
+    return legacyUnsupportedSnapshot(desiredSkills);
+  }
+
+  const names = dedupeSorted(desiredSkills);
+  if (names.length > MAX_ENTRIES) {
+    return buildSnapshot(desiredSkills, [], new Map(), [], ["reconcile:too_many_desired_skills"]);
+  }
+
+  const wire = resolveWireConfig(ctx.config);
+  const bundles = asRecord(ctx.config.desiredSkillBundles);
+  const resolved = resolveDesired(names, bundles);
+  const resolvedByName = new Map(resolved.map((r) => [r.name, r]));
+
+  if (!wire) {
+    return managedUnavailableSnapshot(desiredSkills, names, resolvedByName);
+  }
+  const managedResult = await fetchManaged(wire);
+  if (!managedResult.ok) {
+    return managedUnavailableSnapshot(desiredSkills, names, resolvedByName);
+  }
+
+  const managedMap = new Map(managedResult.entries.map((e) => [e.name, e]));
+  const trueNativeNames = new Set([...inventoryNames(inventory)].filter((n) => !managedMap.has(n)));
+  const desiredNameSet = new Set(names);
+
+  const { outcomes, activations } = planTransitions(resolved, trueNativeNames, managedMap);
+  const cleanNames = [...managedMap.keys()].filter((n) => !desiredNameSet.has(n));
+
+  const { acked, fastFailToken, attempted: activationsAttempted } = await executeActivations(wire, activations, outcomes);
+  const { cleaned, failed: cleanFailed, skipped: cleanSkipped, attempted: cleansAttempted } = await executeCleans(
+    wire,
+    cleanNames,
+    fastFailToken,
+  );
+
+  if (activationsAttempted || cleansAttempted) {
+    const observedResult = await fetchManaged(wire);
+    const observedMap = finalizeObserved(acked, observedResult, resolvedByName, outcomes);
+    await recoverReplayMisses(wire, acked, resolvedByName, observedMap, outcomes);
+  }
+
+  const entries = names.map((name) => makeEntry(name, resolvedByName.get(name)!, outcomes.get(name)!));
+  const warnings = buildWarnings(names, outcomes, cleaned, cleanFailed, cleanSkipped, fastFailToken);
+  return buildSnapshot(desiredSkills, names, resolvedByName, entries, warnings);
+}
+
+function makeEntry(name: string, resolved: Resolved, outcome: Outcome): AdapterSkillEntry {
+  const entry: AdapterSkillEntry = {
+    key: name,
+    runtimeName: name,
+    desired: true,
+    managed: outcome.managed,
+    state: outcome.state,
+    detail: outcome.detail,
+    versionId: resolved.versionId,
+  };
+  if (outcome.readOnly) {
+    entry.readOnly = true;
+    entry.origin = "external_unknown";
+    entry.originLabel = "remote-native";
+  } else if (outcome.managed) {
+    entry.origin = "company_managed";
+  }
+  return entry;
+}

--- a/packages/adapters/hermes/src/gateway/sync-reconcile.test.ts
+++ b/packages/adapters/hermes/src/gateway/sync-reconcile.test.ts
@@ -1,0 +1,657 @@
+// sync-reconcile.test.ts — hermes_gateway syncSkills deterministic reconcile
+// (Layer 2, spec-309 Phase 2, Plan 03). Colocated fork-convention vitest
+// suite (mirrors inventory-mapping.test.ts): constructs the REAL gateway
+// adapter via `createServerAdapter()` and exercises the PUBLIC surface
+// (`syncSkills`) only — no test-local reimplementation of the reconcile
+// logic. Every hash is computed at runtime via node:crypto; zero hand-typed
+// sha256 hex strings.
+//
+// Overlay-copied by build-paperclip-hermes-fork.sh into the fork's
+// `packages/adapters/hermes/src/gateway/` and run under the fork's own
+// vitest by tests/sync-reconcile.test.mjs (the node:test wrapper ROADMAP
+// criterion 1's literal command executes).
+//
+// Stub fixture (the ONLY mock boundary, per 01-CONTEXT.md) is vendored
+// alongside this test file at ./test-fixtures/hermes-stub-server.mjs and
+// resolved by a test-file-relative path — self-contained upstream, zero
+// openclaw-local env-var conventions. It has no declaration file, so the
+// dynamic import below cannot be a static import.
+
+import { expect, test } from "vitest";
+import { createHash } from "node:crypto";
+import { fileURLToPath } from "node:url";
+import type { AdapterSkillContext, AdapterSkillSnapshot } from "@paperclipai/adapter-utils";
+import { createServerAdapter } from "./index.js";
+import { LEGACY_UNSUPPORTED_RESPONSE } from "./capabilities.js";
+
+const STUB_FIXTURE_PATH = fileURLToPath(new URL("./test-fixtures/hermes-stub-server.mjs", import.meta.url));
+
+interface StubRequestRecord {
+  method: string | null;
+  path: string | null;
+  hasValidAuth: boolean | null;
+  body?: unknown;
+}
+
+interface StubHandle {
+  server: { close: () => void };
+  baseUrl: string;
+  requests: StubRequestRecord[];
+}
+
+interface StubModule {
+  startHermesStub: (mode: string) => Promise<StubHandle>;
+  STUB_API_KEY: string;
+}
+
+// Runtime string import — TS cannot statically resolve a module outside this
+// package, so the module shape is asserted via the interface above (not
+// `as any` — the forbidden-suppression list is `as any` / `@ts-ignore` /
+// `@ts-expect-error`, none of which appear here).
+const stubModulePromise: Promise<StubModule> = import(STUB_FIXTURE_PATH);
+
+const AGENT_ID = "33333333-3333-4333-8333-333333333333";
+const COMPANY_ID = "44444444-4444-4444-8444-444444444444";
+
+function sha256Hex(content: string): string {
+  return createHash("sha256").update(content, "utf8").digest("hex");
+}
+
+interface Bundle {
+  version: string;
+  content: string;
+}
+
+function makeCtx(
+  baseUrl: string,
+  apiKey: string,
+  desiredSkillBundles: Record<string, Bundle>,
+): AdapterSkillContext {
+  return {
+    adapterType: "hermes_gateway",
+    agentId: AGENT_ID,
+    companyId: COMPANY_ID,
+    config: { apiBaseUrl: baseUrl, apiKey, negotiationTimeoutMs: 2_000, desiredSkillBundles },
+  };
+}
+
+type Adapter = ReturnType<typeof createServerAdapter>;
+
+async function sync(
+  adapter: Adapter,
+  baseUrl: string,
+  apiKey: string,
+  desired: string[],
+  bundles: Record<string, Bundle>,
+): Promise<AdapterSkillSnapshot> {
+  expect(adapter.syncSkills, "syncSkills is not registered in createServerAdapter()").toBeTypeOf("function");
+  const snapshot = await adapter.syncSkills?.(makeCtx(baseUrl, apiKey, bundles), desired);
+  if (!snapshot) throw new Error("syncSkills returned no snapshot");
+  return snapshot;
+}
+
+// --- direct-wire helpers (pre-seeding / rollback / raw managed reads) ------
+// Mirrors tests/stub-activation-wire.test.mjs's helpers — drives the real
+// stub over loopback HTTP, no reconcile logic reimplemented.
+
+async function directActivate(
+  baseUrl: string,
+  apiKey: string,
+  opts: { skillId: string; version?: string; content: string; key: string },
+): Promise<{ status: number; body: any }> {
+  const hash = `sha256:${sha256Hex(opts.content)}`;
+  const res = await fetch(`${baseUrl}/v1/skills/activations`, {
+    method: "POST",
+    headers: { "content-type": "application/json", authorization: `Bearer ${apiKey}` },
+    body: JSON.stringify({
+      contractVersion: "1",
+      idempotencyKey: opts.key,
+      skill: { skillId: opts.skillId, version: opts.version ?? "1", contentHash: hash, content: opts.content },
+    }),
+  });
+  const body = await res.json();
+  return { status: res.status, body };
+}
+
+async function directDelete(
+  baseUrl: string,
+  apiKey: string,
+  skillId: string,
+  mode: "clean" | "rollback",
+): Promise<{ status: number; body: any }> {
+  const res = await fetch(`${baseUrl}/v1/skills/activations/${encodeURIComponent(skillId)}?mode=${mode}`, {
+    method: "DELETE",
+    headers: { authorization: `Bearer ${apiKey}` },
+  });
+  const body = await res.json();
+  return { status: res.status, body };
+}
+
+async function directManagedInventory(baseUrl: string, apiKey: string): Promise<{ status: number; body: any }> {
+  const res = await fetch(`${baseUrl}/v1/skills?scope=managed`, { headers: { authorization: `Bearer ${apiKey}` } });
+  const body = await res.json();
+  return { status: res.status, body };
+}
+
+function bundle(content: string, version = "1"): Bundle {
+  return { version, content };
+}
+
+// Typed narrowing for a POST transcript record's body — never `as any` (the
+// forbidden-suppression list is `as any` / `@ts-ignore` / `@ts-expect-error`).
+function asRecordBody(value: unknown): Record<string, unknown> | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+function postedSkillId(record: StubRequestRecord): unknown {
+  const body = asRecordBody(record.body);
+  const skill = body ? asRecordBody(body.skill) : null;
+  return skill?.skillId;
+}
+
+function postedIdempotencyKey(record: StubRequestRecord): unknown {
+  return asRecordBody(record.body)?.idempotencyKey;
+}
+
+function postRequests(requests: StubRequestRecord[]): StubRequestRecord[] {
+  return requests.filter((r) => r.method === "POST" && r.path === "/v1/skills/activations");
+}
+
+function deleteRequests(requests: StubRequestRecord[]): StubRequestRecord[] {
+  return requests.filter((r) => r.method === "DELETE");
+}
+
+test("reconcile_INT_003_desired_activated_observed_clean", async () => {
+  const adapter = createServerAdapter();
+  const { startHermesStub, STUB_API_KEY } = await stubModulePromise;
+  const { server, baseUrl, requests } = await startHermesStub("v1_activation");
+  try {
+    const content = "# int-003\nbrand new skill content";
+    const snapshot = await sync(adapter, baseUrl, STUB_API_KEY, ["int-003-skill"], {
+      "int-003-skill": bundle(content, "7"),
+    });
+
+    expect(snapshot.supported).toBe(true);
+    expect(snapshot.mode).toBe("persistent");
+    expect(snapshot.desiredSkills).toEqual(["int-003-skill"]);
+    expect(snapshot.desiredSkillEntries).toEqual([{ key: "int-003-skill", versionId: "7" }]);
+    expect(snapshot.warnings).toEqual([]);
+
+    const entry = snapshot.entries.find((e) => e.key === "int-003-skill");
+    expect(entry, "expected an entry for int-003-skill").toBeTruthy();
+    expect(entry?.state).toBe("installed");
+    expect(entry?.detail).toBe("activated");
+    expect(entry?.managed).toBe(true);
+    expect(entry?.readOnly).not.toBe(true);
+    expect(entry?.versionId).toBe("7");
+    if (entry?.origin !== undefined) {
+      expect(["company_managed", "user_installed", "external_unknown"]).toContain(entry.origin);
+    }
+
+    const { body: managed } = await directManagedInventory(baseUrl, STUB_API_KEY);
+    const managedEntry = managed.data.find((d: any) => d.name === "int-003-skill");
+    expect(managedEntry?.contentHash).toBe(`sha256:${sha256Hex(content)}`);
+
+    const capIndex = requests.findIndex((r) => r.path === "/v1/capabilities");
+    const baseSkillsIndex = requests.findIndex((r) => r.path === "/v1/skills");
+    const managedGetIndices = requests
+      .map((r, i) => ({ r, i }))
+      .filter(({ r }) => r.method === "GET" && r.path === "/v1/skills?scope=managed")
+      .map(({ i }) => i);
+    const postIndex = requests.findIndex((r) => r.method === "POST" && r.path === "/v1/skills/activations");
+    expect(capIndex).toBeGreaterThanOrEqual(0);
+    expect(baseSkillsIndex).toBeGreaterThan(capIndex);
+    expect(managedGetIndices.length).toBeGreaterThanOrEqual(2);
+    expect(managedGetIndices[0]).toBeGreaterThan(baseSkillsIndex);
+    expect(postIndex).toBeGreaterThan(managedGetIndices[0]);
+    expect(managedGetIndices[managedGetIndices.length - 1]).toBeGreaterThan(postIndex);
+  } finally {
+    server.close();
+  }
+});
+
+test("reconcile_stale_by_hash_refreshed", async () => {
+  const adapter = createServerAdapter();
+  const { startHermesStub, STUB_API_KEY } = await stubModulePromise;
+  const { server, baseUrl, requests } = await startHermesStub("v1_activation");
+  try {
+    const oldContent = "# stale\nold content";
+    await directActivate(baseUrl, STUB_API_KEY, { skillId: "stale-skill", content: oldContent, key: "preseed-stale" });
+    const beforeSync = requests.length;
+
+    const newContent = "# stale\nnew content, definitely different";
+    const snapshot = await sync(adapter, baseUrl, STUB_API_KEY, ["stale-skill"], {
+      "stale-skill": bundle(newContent, "2"),
+    });
+
+    const entry = snapshot.entries.find((e) => e.key === "stale-skill");
+    expect(entry?.state).toBe("installed");
+    expect(entry?.detail).toBe("stale_refreshed");
+
+    // Only the reconcile's own POST(s) count here — the preseed POST above
+    // is excluded via the beforeSync slice.
+    const posts = postRequests(requests.slice(beforeSync));
+    expect(posts.length).toBe(1);
+
+    const { body: managed } = await directManagedInventory(baseUrl, STUB_API_KEY);
+    const managedEntry = managed.data.find((d: any) => d.name === "stale-skill");
+    expect(managedEntry?.contentHash).toBe(`sha256:${sha256Hex(newContent)}`);
+  } finally {
+    server.close();
+  }
+});
+
+test("reconcile_clean_managed_not_desired_only", async () => {
+  const adapter = createServerAdapter();
+  const { startHermesStub, STUB_API_KEY } = await stubModulePromise;
+  const { server, baseUrl, requests } = await startHermesStub("v1_activation");
+  try {
+    await directActivate(baseUrl, STUB_API_KEY, {
+      skillId: "orphan-skill",
+      content: "# orphan\nto be cleaned",
+      key: "preseed-orphan",
+    });
+
+    const newContent = "# fresh\nnewly desired";
+    const snapshot = await sync(adapter, baseUrl, STUB_API_KEY, ["fresh-skill"], {
+      "fresh-skill": bundle(newContent),
+    });
+
+    const deletes = deleteRequests(requests);
+    expect(deletes.length).toBe(1);
+    expect(deletes[0]?.path).toContain("orphan-skill");
+    expect(deletes[0]?.path).toContain("mode=clean");
+    // Never a DELETE for any native fixture name.
+    expect(deletes.some((d) => d.path?.includes("brand-voice") || d.path?.includes("release-notes"))).toBe(false);
+
+    expect(snapshot.warnings).toEqual(["reconcile:orphan-skill:cleaned"]);
+    for (const entry of snapshot.entries) {
+      expect(entry.state).toBe("installed");
+    }
+
+    const { body: managed } = await directManagedInventory(baseUrl, STUB_API_KEY);
+    expect(managed.data.some((d: any) => d.name === "orphan-skill")).toBe(false);
+  } finally {
+    server.close();
+  }
+});
+
+test("reconcile_never_mutates_remote_native", async () => {
+  const adapter = createServerAdapter();
+  const { startHermesStub, STUB_API_KEY } = await stubModulePromise;
+  const { server, baseUrl, requests } = await startHermesStub("v1_activation");
+  try {
+    const newContent = "# native-test\na new one";
+    const nativeContent = "# hijack-attempt\nshould never activate";
+    const snapshot = await sync(adapter, baseUrl, STUB_API_KEY, ["brand-voice", "native-test-new"], {
+      "brand-voice": bundle(nativeContent),
+      "native-test-new": bundle(newContent),
+    });
+
+    const newEntry = snapshot.entries.find((e) => e.key === "native-test-new");
+    expect(newEntry?.state).toBe("installed");
+    expect(newEntry?.detail).toBe("activated");
+
+    const nativeEntry = snapshot.entries.find((e) => e.key === "brand-voice");
+    expect(nativeEntry?.state).toBe("external");
+    expect(nativeEntry?.detail).toBe("native_conflict");
+    expect(snapshot.warnings.some((w) => w.includes("brand-voice"))).toBe(true);
+
+    const posts = postRequests(requests);
+    expect(posts.some((p) => postedSkillId(p) === "brand-voice")).toBe(false);
+    expect(posts.some((p) => postedSkillId(p) === "native-test-new")).toBe(true);
+
+    const { body: base } = await fetch(`${baseUrl}/v1/skills`, {
+      headers: { authorization: `Bearer ${STUB_API_KEY}` },
+    }).then(async (r) => ({ body: await r.json() }));
+    expect(base.data.some((d: any) => d.name === "brand-voice")).toBe(true);
+  } finally {
+    server.close();
+  }
+});
+
+test("reconcile_repeat_run_zero_mutations_idempotent", async () => {
+  const adapter = createServerAdapter();
+  const { startHermesStub, STUB_API_KEY } = await stubModulePromise;
+  const { server, baseUrl, requests } = await startHermesStub("v1_activation");
+  try {
+    const content = "# repeat\nstable content";
+    const bundles = { "repeat-skill": bundle(content) };
+
+    const first = await sync(adapter, baseUrl, STUB_API_KEY, ["repeat-skill"], bundles);
+    const firstEntry = first.entries.find((e) => e.key === "repeat-skill");
+    expect(firstEntry?.state).toBe("installed");
+    expect(firstEntry?.detail).toBe("activated");
+
+    const beforeSecond = requests.length;
+    const second = await sync(adapter, baseUrl, STUB_API_KEY, ["repeat-skill"], bundles);
+    const secondSlice = requests.slice(beforeSecond);
+
+    expect(postRequests(secondSlice).length).toBe(0);
+    expect(deleteRequests(secondSlice).length).toBe(0);
+    expect(secondSlice.filter((r) => r.method === "GET").length).toBe(3);
+
+    for (const entry of second.entries) {
+      expect(["installed"]).toContain(entry.state);
+      expect(["already_installed"]).toContain(entry.detail);
+    }
+    expect(second.warnings).toEqual([]);
+  } finally {
+    server.close();
+  }
+});
+
+test("reconcile_ack_without_observed_stays_red", async () => {
+  const adapter = createServerAdapter();
+  const { startHermesStub, STUB_API_KEY } = await stubModulePromise;
+  const { server, baseUrl } = await startHermesStub("v1_ack_not_observed");
+  try {
+    const snapshot = await sync(adapter, baseUrl, STUB_API_KEY, ["ghost-skill"], {
+      "ghost-skill": bundle("# ghost\nnever truly observed"),
+    });
+
+    const entry = snapshot.entries.find((e) => e.key === "ghost-skill");
+    expect(entry?.state).not.toBe("installed");
+    expect(entry?.detail).toBe("activated_not_observed");
+    expect(entry?.managed).toBe(false);
+    expect(snapshot.warnings.length).toBeGreaterThan(0);
+  } finally {
+    server.close();
+  }
+});
+
+test("reconcile_INT_005_wrong_scope_403_zero_transitions", async () => {
+  const adapter = createServerAdapter();
+  const { startHermesStub, STUB_API_KEY } = await stubModulePromise;
+  const { server, baseUrl, requests } = await startHermesStub("v1_wrong_scope");
+  try {
+    const snapshot = await sync(adapter, baseUrl, STUB_API_KEY, ["aaa-first", "zzz-second"], {
+      "aaa-first": bundle("# aaa\nfirst"),
+      "zzz-second": bundle("# zzz\nsecond"),
+    });
+
+    const posts = postRequests(requests);
+    expect(posts.length).toBe(1);
+    expect(deleteRequests(requests).length).toBe(0);
+
+    const first = snapshot.entries.find((e) => e.key === "aaa-first");
+    const second = snapshot.entries.find((e) => e.key === "zzz-second");
+    expect(first?.detail).toBe("failed:wrong_scope");
+    expect(second?.detail).toBe("skipped_after_wrong_scope");
+    expect(snapshot.warnings.some((w) => w.includes("wrong_scope"))).toBe(true);
+  } finally {
+    server.close();
+  }
+});
+
+test("reconcile_auth_error_fail_closed_zero_activation_calls", async () => {
+  const adapter = createServerAdapter();
+  const { startHermesStub, STUB_API_KEY } = await stubModulePromise;
+  const { server, baseUrl, requests } = await startHermesStub("auth_fail");
+  try {
+    const snapshot = await sync(adapter, baseUrl, STUB_API_KEY, ["whatever"], {
+      whatever: bundle("# whatever\ncontent"),
+    });
+
+    expect(snapshot.supported).toBe(LEGACY_UNSUPPORTED_RESPONSE.supported);
+    expect(snapshot.mode).toBe(LEGACY_UNSUPPORTED_RESPONSE.mode);
+    expect(snapshot.entries).toEqual([...LEGACY_UNSUPPORTED_RESPONSE.entries]);
+    expect(snapshot.warnings).toContain(LEGACY_UNSUPPORTED_RESPONSE.warning);
+
+    for (const req of requests) {
+      expect(req.method).toBe("GET");
+      expect(["/v1/capabilities", "/v1/skills"]).toContain(req.path);
+    }
+  } finally {
+    server.close();
+  }
+});
+
+test("reconcile_integrity_409_reported_failed", async () => {
+  const adapter = createServerAdapter();
+  const { startHermesStub, STUB_API_KEY } = await stubModulePromise;
+  const { server, baseUrl } = await startHermesStub("v1_integrity_409");
+  try {
+    const snapshot = await sync(adapter, baseUrl, STUB_API_KEY, ["forced-409"], {
+      "forced-409": bundle("# forced\nintegrity injection"),
+    });
+
+    const entry = snapshot.entries.find((e) => e.key === "forced-409");
+    expect(entry?.detail?.startsWith("failed:")).toBe(true);
+    expect(entry?.state).toBe("missing");
+    expect(entry?.state).not.toBe("installed");
+    expect(snapshot.warnings.length).toBeGreaterThan(0);
+
+    const { body: managed } = await directManagedInventory(baseUrl, STUB_API_KEY);
+    expect(managed.data).toEqual([]);
+  } finally {
+    server.close();
+  }
+});
+
+test("reconcile_INT_004_concurrent_double_sync_single_final_state", async () => {
+  const adapter1 = createServerAdapter();
+  const adapter2 = createServerAdapter();
+  const { startHermesStub, STUB_API_KEY } = await stubModulePromise;
+  const { server, baseUrl, requests } = await startHermesStub("v1_activation");
+  try {
+    const content = "# concurrent\nidentical content both runs";
+    const bundles = { "concurrent-skill": bundle(content) };
+
+    const [snap1, snap2] = await Promise.all([
+      sync(adapter1, baseUrl, STUB_API_KEY, ["concurrent-skill"], bundles),
+      sync(adapter2, baseUrl, STUB_API_KEY, ["concurrent-skill"], bundles),
+    ]);
+
+    const e1 = snap1.entries.find((e) => e.key === "concurrent-skill");
+    const e2 = snap2.entries.find((e) => e.key === "concurrent-skill");
+    expect(e1?.state).toBe("installed");
+    expect(e2?.state).toBe("installed");
+
+    const { body: managed } = await directManagedInventory(baseUrl, STUB_API_KEY);
+    const matches = managed.data.filter((d: any) => d.name === "concurrent-skill");
+    expect(matches.length).toBe(1);
+    expect(matches[0]?.contentHash).toBe(`sha256:${sha256Hex(content)}`);
+
+    const posts = postRequests(requests).filter((p) => postedSkillId(p) === "concurrent-skill");
+    expect(posts.length).toBe(2);
+    const keys = new Set(posts.map((p) => postedIdempotencyKey(p)));
+    expect(keys.size).toBe(1);
+  } finally {
+    server.close();
+  }
+});
+
+test("reconcile_layer1_unsupported_guard_byte_compat", async () => {
+  const adapter = createServerAdapter();
+  const { startHermesStub, STUB_API_KEY } = await stubModulePromise;
+  const { server, baseUrl, requests } = await startHermesStub("v0_16");
+  try {
+    const snapshot = await sync(adapter, baseUrl, STUB_API_KEY, ["brand-voice"], {
+      "brand-voice": bundle("# ignored\nno activation advert"),
+    });
+
+    expect(snapshot.supported).toBe(LEGACY_UNSUPPORTED_RESPONSE.supported);
+    expect(snapshot.mode).toBe(LEGACY_UNSUPPORTED_RESPONSE.mode);
+    expect(snapshot.entries).toEqual([...LEGACY_UNSUPPORTED_RESPONSE.entries]);
+    expect(snapshot.warnings).toContain(LEGACY_UNSUPPORTED_RESPONSE.warning);
+    expect(postRequests(requests).length).toBe(0);
+    expect(deleteRequests(requests).length).toBe(0);
+  } finally {
+    server.close();
+  }
+});
+
+test("reconcile_wire_carries_content_identity_never_path", async () => {
+  const adapter = createServerAdapter();
+  const { startHermesStub, STUB_API_KEY } = await stubModulePromise;
+  const { server, baseUrl, requests } = await startHermesStub("v1_activation");
+  try {
+    const content = "# wire-shape\nasserted body shape";
+    await sync(adapter, baseUrl, STUB_API_KEY, ["wire-shape-skill"], {
+      "wire-shape-skill": bundle(content, "9"),
+    });
+
+    const posts = postRequests(requests);
+    expect(posts.length).toBeGreaterThanOrEqual(1);
+
+    const DENYLIST = new Set([
+      "path",
+      "filePath",
+      "file_path",
+      "sourcePath",
+      "source_path",
+      "localPath",
+      "local_path",
+      "dir",
+      "directory",
+    ]);
+
+    function scanNoPathLeak(value: unknown, skipKey: string | null): void {
+      if (Array.isArray(value)) {
+        for (const item of value) scanNoPathLeak(item, skipKey);
+        return;
+      }
+      if (value !== null && typeof value === "object") {
+        for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
+          expect(DENYLIST.has(key)).toBe(false);
+          scanNoPathLeak(child, key === "skill" ? "content" : skipKey);
+        }
+        return;
+      }
+      if (typeof value === "string" && skipKey !== "content-value") {
+        expect(value.includes("..")).toBe(false);
+      }
+    }
+
+    for (const req of posts) {
+      const body = asRecordBody(req.body);
+      expect(body).toBeTruthy();
+      expect(body?.contractVersion).toBe("1");
+      expect(typeof body?.idempotencyKey).toBe("string");
+      expect(body?.idempotencyKey).toMatch(/^[A-Za-z0-9._-]{1,128}$/);
+      const skill = body ? asRecordBody(body.skill) : null;
+      expect(skill?.skillId).toBeTruthy();
+      expect(skill?.contentHash).toMatch(/^sha256:[0-9a-f]{64}$/);
+      expect(String(skill?.skillId).includes("/")).toBe(false);
+      expect(String(skill?.skillId).includes("..")).toBe(false);
+      expect(String(skill?.version).includes("/")).toBe(false);
+      expect(String(skill?.version).includes("..")).toBe(false);
+      scanNoPathLeak(body, null);
+    }
+  } finally {
+    server.close();
+  }
+});
+
+test("reconcile_REQ_007_rollback_restores_prior_managed_state", async () => {
+  const adapter = createServerAdapter();
+  const { startHermesStub, STUB_API_KEY } = await stubModulePromise;
+  const { server, baseUrl } = await startHermesStub("v1_activation");
+  try {
+    const contentA = "# rollback\nversion A content";
+    const contentB = "# rollback\nversion B content, longer and different";
+
+    const snapA = await sync(adapter, baseUrl, STUB_API_KEY, ["rollback-skill"], {
+      "rollback-skill": bundle(contentA, "1"),
+    });
+    expect(snapA.entries.find((e) => e.key === "rollback-skill")?.detail).toBe("activated");
+
+    const snapB = await sync(adapter, baseUrl, STUB_API_KEY, ["rollback-skill"], {
+      "rollback-skill": bundle(contentB, "2"),
+    });
+    expect(snapB.entries.find((e) => e.key === "rollback-skill")?.detail).toBe("stale_refreshed");
+
+    const { body: managedAfterB } = await directManagedInventory(baseUrl, STUB_API_KEY);
+    expect(managedAfterB.data.find((d: any) => d.name === "rollback-skill")?.contentHash).toBe(
+      `sha256:${sha256Hex(contentB)}`,
+    );
+
+    const { status: rollbackStatus, body: rollbackBody } = await directDelete(
+      baseUrl,
+      STUB_API_KEY,
+      "rollback-skill",
+      "rollback",
+    );
+    expect(rollbackStatus).toBe(200);
+    expect(rollbackBody.ack.restored).toBe(true);
+
+    const { body: managedAfterRollback } = await directManagedInventory(baseUrl, STUB_API_KEY);
+    expect(managedAfterRollback.data.find((d: any) => d.name === "rollback-skill")?.contentHash).toBe(
+      `sha256:${sha256Hex(contentA)}`,
+    );
+  } finally {
+    server.close();
+  }
+});
+
+test("reconcile_input_validation_fail_closed_and_dedupe", async () => {
+  const adapter = createServerAdapter();
+  const { startHermesStub, STUB_API_KEY } = await stubModulePromise;
+  const { server, baseUrl, requests } = await startHermesStub("v1_activation");
+  try {
+    // (a) no bundle entry
+    const snapA = await sync(adapter, baseUrl, STUB_API_KEY, ["no-bundle-skill"], {});
+    const entryA = snapA.entries.find((e) => e.key === "no-bundle-skill");
+    expect(entryA?.detail).toBe("failed:no_bundle");
+    expect(postRequests(requests).length).toBe(0);
+
+    // (b) invalid skillId shape
+    const snapB = await sync(adapter, baseUrl, STUB_API_KEY, ["Invalid_ID_Upper"], {
+      Invalid_ID_Upper: bundle("# invalid\ncontent"),
+    });
+    const entryB = snapB.entries.find((e) => e.key === "Invalid_ID_Upper");
+    expect(entryB?.detail).toBe("failed:invalid_skill_id");
+    expect(postRequests(requests).length).toBe(0);
+
+    // (c) 501 desired names — fail-closed, zero wire mutations
+    const manyNames = Array.from({ length: 501 }, (_, i) => `cap-test-skill-${i}`);
+    const manyBundles: Record<string, Bundle> = {};
+    for (const n of manyNames) manyBundles[n] = bundle(`# ${n}\ncontent`);
+    const snapC = await sync(adapter, baseUrl, STUB_API_KEY, manyNames, manyBundles);
+    expect(snapC.warnings.length).toBeGreaterThan(0);
+    expect(postRequests(requests).length).toBe(0);
+    expect(deleteRequests(requests).length).toBe(0);
+
+    // (d) duplicate desired names — dedupe, first occurrence wins
+    const beforeD = requests.length;
+    const snapD = await sync(adapter, baseUrl, STUB_API_KEY, ["dup-skill", "dup-skill"], {
+      "dup-skill": bundle("# dup\ncontent"),
+    });
+    expect(snapD.entries.filter((e) => e.key === "dup-skill").length).toBe(1);
+    const dSlice = requests.slice(beforeD);
+    expect(postRequests(dSlice).length).toBe(1);
+  } finally {
+    server.close();
+  }
+});
+
+test("reconcile_reactivation_after_clean_reinstalls", async () => {
+  const adapter = createServerAdapter();
+  const { startHermesStub, STUB_API_KEY } = await stubModulePromise;
+  const { server, baseUrl } = await startHermesStub("v1_activation");
+  try {
+    const content = "# reactivate\nsame content every time";
+    const bundles = { "reactivate-me": bundle(content) };
+
+    const snap1 = await sync(adapter, baseUrl, STUB_API_KEY, ["reactivate-me"], bundles);
+    expect(snap1.entries.find((e) => e.key === "reactivate-me")?.state).toBe("installed");
+
+    const snap2 = await sync(adapter, baseUrl, STUB_API_KEY, [], {});
+    expect(snap2.entries.find((e) => e.key === "reactivate-me")).toBeUndefined();
+    const { body: managedAfterClean } = await directManagedInventory(baseUrl, STUB_API_KEY);
+    expect(managedAfterClean.data.some((d: any) => d.name === "reactivate-me")).toBe(false);
+
+    const snap3 = await sync(adapter, baseUrl, STUB_API_KEY, ["reactivate-me"], bundles);
+    const entry3 = snap3.entries.find((e) => e.key === "reactivate-me");
+    expect(entry3?.state).toBe("installed");
+
+    const { body: managedFinal } = await directManagedInventory(baseUrl, STUB_API_KEY);
+    expect(managedFinal.data.find((d: any) => d.name === "reactivate-me")?.contentHash).toBe(
+      `sha256:${sha256Hex(content)}`,
+    );
+  } finally {
+    server.close();
+  }
+});

--- a/packages/adapters/hermes/src/gateway/test-fixtures/hermes-stub-server.mjs
+++ b/packages/adapters/hermes/src/gateway/test-fixtures/hermes-stub-server.mjs
@@ -1,0 +1,664 @@
+// hermes-stub-server.mjs — scripted local Hermes remote (the ONLY mock
+// boundary for spec-309 Phase 1, per 01-CONTEXT.md). One `node:http` server
+// per `startHermesStub(mode)` call; response bodies/status codes are chosen
+// entirely by `mode`, never by URL-routing tricks (01-RESEARCH.md Pattern 1).
+//
+// ---------------------------------------------------------------------------
+// Wire-shape provenance (Task 1 STEP A, 01-01-PLAN.md)
+// ---------------------------------------------------------------------------
+// DEVIATION (recorded here + in 01-01-SUMMARY.md): this execution run's hard
+// offline-network constraint permits network access ONLY to `git clone`/
+// `ls-remote` of the pinned `paperclipai/paperclip @ v2026.707.0` fork-build
+// target. A fresh, direct (non-summarized) read of
+// `NousResearch/hermes-agent @ v2026.6.5 gateway/platforms/api_server.py`
+// — which 01-01-PLAN.md Task 1 STEP A calls for — was therefore NOT
+// performed this session; that would be a second, disallowed remote. Wire
+// shapes below instead carry forward 01-RESEARCH.md's existing Assumptions
+// Log (A1/A2, tertiary confidence — a prior single-pass WebFetch summary,
+// not byte-verified) using the plan's own explicitly-sanctioned fallbacks:
+//
+//   - Resolved skill-id field: the cited `/v1/skills` envelope
+//     (`{object:"list", data:[{name, description, category}]}`) carries no
+//     field distinct from `name` (Open Question 1) -> skillId <- name is an
+//     explicit adapter-level decision, not a silent assumption. Re-verify
+//     directly against the live matrix before Phase 4 (research.md note).
+//   - remoteVersion: the cited `/v1/capabilities` shape
+//     (`{object, platform, model, auth, runtime, features, endpoints}`) has
+//     no field confirmed to carry a parseable Hermes release version for a
+//     v0.16 remote -> the v0_16 happy path negotiates with
+//     `remoteVersion: null` (data-model.md explicitly allows this; never
+//     invented as a stub-only field). `auth_incompat` mode DOES carry a
+//     parseable version (`runtime: "0.17.2"`) — that row is locked by the
+//     contract's Fail-closed matrix, not by the tertiary source.
+//
+// UNSUPPORTED_LITERAL provenance: searched this repo + git history
+// (`git log --all --diff-filter=A --name-only | grep -i 302`) for a
+// spec-302-recorded unsupported skill-inventory JSON artifact. Spec-302 in
+// THIS repo is `specs/302-hermes-adapter-reliability`, whose recorded
+// fixtures (`fixtures/diagnosis/phase2-raw-sources/*/skill.json`) are a
+// DIFFERENT artifact shape entirely (`phase2_skill_audit` agentRecords —
+// population/audit records, not a capability-negotiation unsupported
+// response). No byte-level artifact matching
+// `{supported:false, mode:"unsupported", entries:[], warning}` was located
+// anywhere in the repo or its history. Freezing the CONTEXT.md-specified
+// literal below instead — INT-002 therefore degrades to `deepStrictEqual`
+// against this literal (documented fallback), not a true byte-compat check
+// against a historical artifact.
+// ---------------------------------------------------------------------------
+//
+// ---------------------------------------------------------------------------
+// Phase-2 provenance update (02-02-PLAN.md Task 3)
+// ---------------------------------------------------------------------------
+// Shapes are now byte-verified against the real `v2026.6.5` tree per
+// 02-RESEARCH.md Sources: `api_server.py:855-879` (auth envelope),
+// `:1161-1191` (skills route), `tools/skills_tool.py:568-641` (hashless
+// inventory shape). The Layer-2 surface (POST/DELETE
+// /v1/skills/activations, GET /v1/skills?scope=managed, plus the three
+// failure-injection modes) mirrors contract §Layer 2 + 02-01-PLAN.md
+// <artifacts> — the SAME locked wire spec 02-01's fork implements, per
+// LD-S1 (wave-1 parallel isolation).
+//
+// LD-S2 (fix-forward, orchestrator-adjudicated 2026-07-17): the real
+// v2026.6.5 `/v1/capabilities` serves `features` as an OBJECT MAP
+// (api_server.py:1110-1135 @ 3c231eb3979ab9c57d5cd6d02f1d577a3b718b43) — the
+// Phase-1 array shape was a fantasy-shape deviation, now CLOSED: the stub
+// serves real object-map shapes in every mode (see capabilitiesPayloadFor
+// below) and capabilities.ts parses the object map (array -> unsupported
+// fail-closed, see capability-negotiation.test.mjs
+// negotiate_array_features_unsupported). The Phase-1 DEVIATION record above
+// stays intact as history.
+//
+// Deliberately NOT scripted here (no test depends on them): the 500-row
+// managed-entry cap and 1 MiB-adjacent DoS edge cases beyond the single
+// content-size check below — these are server-behavior proofs owned by
+// 02-01's pytest suite against the real fork.
+// ---------------------------------------------------------------------------
+
+import { createServer } from "node:http";
+import { createHash, timingSafeEqual } from "node:crypto";
+
+/** Synthetic Bearer token every advert-serving mode enforces on EVERY route
+ * (research A3 — the real v0.16 server applies one shared Bearer check to
+ * both `/v1/capabilities` and `/v1/skills`). Not a real secret. */
+export const STUB_API_KEY = "spec309-synthetic-hermes-bearer-1a2b3c";
+
+const MODES = new Set([
+  "v0_16",
+  "old",
+  "old_no_advert",
+  "auth_fail",
+  "auth_fail_inventory",
+  "malformed",
+  "inventory_malformed",
+  "transient",
+  "capabilities_5xx",
+  "timeout",
+  "auth_incompat",
+  "unknown_major",
+  "v1_activation",
+  "bad_item",
+  "v1_wrong_scope",
+  "v1_integrity_409",
+  "v1_ack_not_observed",
+]);
+
+// The four Layer-2 modes: v1_activation plus the three failure injections.
+// All four route through the same activation/deactivation/managed-scope
+// handlers and advertise the same real object-map skills_activation/v1
+// capability (LD-S2, byte-matching 02-01's fork advert).
+const LAYER2_MODES = new Set(["v1_activation", "v1_wrong_scope", "v1_integrity_409", "v1_ack_not_observed"]);
+
+// LD-1: the deployment's configured identity IS the authenticated scope —
+// never derived from request bodies. Frozen literal mirroring 02-01's
+// HERMES_SKILLS_SCOPE_* env defaults.
+const DEPLOYMENT_SCOPE = Object.freeze({
+  tenantId: "deployment-local",
+  companyId: "deployment-local",
+  agentId: "deployment-local",
+});
+
+const MANAGED_BY = "paperclip-skill-contract/v1";
+
+// skillId <- name (no distinct stable id field cited — see provenance above).
+// Plan-02 addition: canary fields (`internalToken`, `syncedStatus`) that MUST
+// NEVER propagate into a mapped AdapterSkillEntry/serialized snapshot
+// (FR-004) — the real field map only reads `name`/`description`/`category`,
+// so these prove field-by-field construction, never a spread of the remote
+// object (T-01-06).
+const SKILL_ENTRIES = [
+  {
+    name: "brand-voice",
+    description: "Brand voice + tone guardrails",
+    category: "content",
+    internalToken: "spec309-canary-internal-token-DO-NOT-LEAK",
+    syncedStatus: "synced",
+  },
+  {
+    name: "release-notes",
+    description: "Release notes formatting",
+    category: "ops",
+    internalToken: "spec309-canary-internal-token-DO-NOT-LEAK",
+    syncedStatus: "synced",
+  },
+];
+
+// Plan-02 `bad_item` mode: a duplicate stable id — the whole response must
+// be rejected fail-closed, never a partial mapping of the first (valid) one.
+const BAD_ITEM_ENTRIES = [
+  { name: "brand-voice", description: "Brand voice + tone guardrails", category: "content" },
+  { name: "brand-voice", description: "Duplicate stable id", category: "ops" },
+];
+
+// The legacy unsupported response literal (INT-002 fixture). Deliberately
+// frozen; never rebuilt by a general outcome-serializer (research Pitfall 2).
+// capabilities.ts exports a byte-identical literal for the legacy surface —
+// keep both in sync if this ever changes.
+export const UNSUPPORTED_LITERAL = Object.freeze({
+  supported: false,
+  mode: "unsupported",
+  entries: Object.freeze([]),
+  warning: "Remote Hermes gateway does not advertise skills_api; skill inventory is unsupported.",
+});
+
+// ---------------------------------------------------------------------------
+// Layer-2 validation constants (mirroring 02-01-PLAN.md <artifacts> verbatim)
+// ---------------------------------------------------------------------------
+const SKILL_ID_RE = /^[a-z0-9][a-z0-9_-]{0,63}$/;
+const VERSION_RE = /^[A-Za-z0-9._-]{1,32}$/;
+const CONTENT_HASH_RE = /^sha256:[0-9a-f]{64}$/;
+const IDEMPOTENCY_KEY_RE = /^[A-Za-z0-9._-]{1,128}$/;
+const PATH_KEY_DENYLIST = new Set([
+  "path",
+  "filePath",
+  "file_path",
+  "sourcePath",
+  "source_path",
+  "localPath",
+  "local_path",
+  "dir",
+  "directory",
+]);
+const MAX_CONTENT_BYTES = 1024 * 1024;
+const MAX_RAW_BODY_BYTES = 2 * 1024 * 1024;
+const MAX_BODY_NESTING = 8;
+const DELETE_MODES = new Set(["clean", "rollback"]);
+
+function jsonBody(res, status, payload) {
+  res.writeHead(status, { "content-type": "application/json" });
+  res.end(JSON.stringify(payload));
+}
+
+function errorEnvelope(code, message) {
+  return { error: { message, type: "invalid_request_error", code } };
+}
+
+function authInvalid(res) {
+  jsonBody(res, 401, errorEnvelope("invalid_api_key", "Invalid API key"));
+}
+
+function insufficientScope(res) {
+  jsonBody(res, 403, errorEnvelope("insufficient_scope", "Insufficient scope for skill inventory"));
+}
+
+// Plan-02 Task 1 (LD-S2, fix-forward): the real v2026.6.5 `/v1/capabilities`
+// serves `features` as an OBJECT MAP (api_server.py:1110-1135 @
+// 3c231eb3979ab9c57d5cd6d02f1d577a3b718b43, verified firsthand), not the
+// Phase-1 string-array fantasy shape. Every mode below now serves the real
+// object-map equivalent of its former array (see 02-02-PLAN.md LD-S2(a)).
+function capabilitiesPayloadFor(mode) {
+  switch (mode) {
+    case "old_no_advert":
+      return { object: "capabilities", platform: "hermes", features: {} };
+    case "auth_incompat":
+      // Adapter-defined heuristic (research Pitfall 3 / EDGE-007, #8924
+      // lineage) — a PARSEABLE v0.17.x version plus an auth-scheme-mismatch
+      // signal distinct from a plain 401. NOT a published Hermes v0.17 wire
+      // guarantee; revalidate against the live matrix in Phase 4.
+      return { object: "capabilities", platform: "hermes", runtime: "0.17.2", authScheme: "hmac-v2", features: { skills_api: true } };
+    case "unknown_major":
+      return { object: "capabilities", platform: "hermes", features: { skills_api: true, "skills_activation/v9": true } };
+    case "v1_activation":
+    case "v1_wrong_scope":
+    case "v1_integrity_409":
+    case "v1_ack_not_observed":
+      // All four Layer-2 modes advertise the same real object-map advert
+      // (byte-matching 02-01's fork advert key).
+      return { object: "capabilities", platform: "hermes", features: { skills_api: true, "skills_activation/v1": true } };
+    default:
+      // v0_16, auth_fail_inventory, inventory_malformed, transient, bad_item
+      // all advertise a plain v0.16-shaped skills_api-only capability.
+      return { object: "capabilities", platform: "hermes", features: { skills_api: true } };
+  }
+}
+
+function isNativeSkillName(name) {
+  return SKILL_ENTRIES.some((entry) => entry.name === name);
+}
+
+function deriveDescription(content) {
+  const line = content.split("\n").find((l) => l.trim().length > 0) ?? "";
+  return line.trim().slice(0, 80);
+}
+
+function sha256Hex(content) {
+  return createHash("sha256").update(content, "utf8").digest("hex");
+}
+
+function constantTimeHexEqual(a, b) {
+  if (typeof a !== "string" || typeof b !== "string" || a.length !== b.length) return false;
+  return timingSafeEqual(Buffer.from(a, "utf8"), Buffer.from(b, "utf8"));
+}
+
+function canonicalize(value) {
+  if (Array.isArray(value)) return value.map(canonicalize);
+  if (value !== null && typeof value === "object") {
+    const sorted = {};
+    for (const key of Object.keys(value).sort()) sorted[key] = canonicalize(value[key]);
+    return sorted;
+  }
+  return value;
+}
+
+function fingerprintOf(parsedBody) {
+  return createHash("sha256").update(JSON.stringify(canonicalize(parsedBody)), "utf8").digest("hex");
+}
+
+// Recursively walks the parsed body: any denylisted key at any nesting depth,
+// or any string VALUE other than `skill.content` containing a path separator
+// or a dot-dot segment, fails the request closed. Depth beyond
+// MAX_BODY_NESTING is itself treated as invalid (bounds the walk).
+function scanForPathLeakage(value, path, depth) {
+  if (depth > MAX_BODY_NESTING) return true;
+  if (Array.isArray(value)) {
+    return value.some((item) => scanForPathLeakage(item, path, depth + 1));
+  }
+  if (value !== null && typeof value === "object") {
+    for (const [key, child] of Object.entries(value)) {
+      if (PATH_KEY_DENYLIST.has(key)) return true;
+      const childPath = path ? `${path}.${key}` : key;
+      if (scanForPathLeakage(child, childPath, depth + 1)) return true;
+    }
+    return false;
+  }
+  if (typeof value === "string") {
+    if (path === "skill.content") return false;
+    return value.includes("/") || value.includes("..") || value.includes("\\");
+  }
+  return false;
+}
+
+function validateActivationBody(body) {
+  if (typeof body !== "object" || body === null || Array.isArray(body)) return false;
+  if (scanForPathLeakage(body, "", 0)) return false;
+  const skill = body.skill;
+  if (typeof skill !== "object" || skill === null || Array.isArray(skill)) return false;
+  if (typeof skill.skillId !== "string" || !SKILL_ID_RE.test(skill.skillId)) return false;
+  if (skill.version !== undefined && (typeof skill.version !== "string" || !VERSION_RE.test(skill.version))) return false;
+  if (typeof skill.contentHash !== "string" || !CONTENT_HASH_RE.test(skill.contentHash)) return false;
+  if (typeof skill.content !== "string" || skill.content.length === 0) return false;
+  if (Buffer.byteLength(skill.content, "utf8") > MAX_CONTENT_BYTES) return false;
+  if (typeof body.idempotencyKey !== "string" || !IDEMPOTENCY_KEY_RE.test(body.idempotencyKey)) return false;
+  return true;
+}
+
+function readBody(req, maxBytes) {
+  return new Promise((resolve, reject) => {
+    let total = 0;
+    const chunks = [];
+    req.on("data", (chunk) => {
+      total += chunk.length;
+      if (total > maxBytes) {
+        req.destroy();
+        reject(new Error("body-too-large"));
+        return;
+      }
+      chunks.push(chunk);
+    });
+    req.on("end", () => resolve(Buffer.concat(chunks).toString("utf8")));
+    req.on("error", reject);
+  });
+}
+
+// POST /v1/skills/activations — Layer-2 modes only. `managed`/`replays` are
+// per-instance Maps (created fresh inside startHermesStub) so two stub
+// instances never share state (stub_two_instances_share_no_state).
+async function handleActivationPost(req, res, { mode, managed, replays, record }) {
+  let rawBody;
+  try {
+    rawBody = await readBody(req, MAX_RAW_BODY_BYTES);
+  } catch {
+    // Socket already destroyed by readBody on over-cap — nothing more to do.
+    return;
+  }
+
+  if (mode === "v1_wrong_scope") {
+    // LD-1: the honest adapter never sends identity in the body — this
+    // mode-driven injection proves the ADAPTER's wrong-tenant handling
+    // (contract INT-005), not a body-assert mismatch.
+    jsonBody(res, 403, errorEnvelope("wrong_scope", "Wrong tenant/company/agent scope for this deployment"));
+    return;
+  }
+
+  let parsed;
+  try {
+    parsed = JSON.parse(rawBody);
+  } catch {
+    record.body = null;
+    jsonBody(res, 422, errorEnvelope("invalid_request", "Request body is not valid JSON"));
+    return;
+  }
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    record.body = null;
+    jsonBody(res, 422, errorEnvelope("invalid_request", "Request body must be a JSON object"));
+    return;
+  }
+  record.body = parsed;
+
+  if (parsed.contractVersion !== "1") {
+    jsonBody(res, 422, errorEnvelope("unsupported_contract_version", "Unsupported contractVersion"));
+    return;
+  }
+
+  if (!validateActivationBody(parsed)) {
+    jsonBody(res, 422, errorEnvelope("invalid_request", "Activation payload failed validation"));
+    return;
+  }
+
+  const { skill, idempotencyKey } = parsed;
+  const { skillId, contentHash, content, version } = skill;
+
+  if (isNativeSkillName(skillId) && !managed.has(skillId)) {
+    jsonBody(res, 409, errorEnvelope("native_conflict", "skillId belongs to a remote-native skill"));
+    return;
+  }
+
+  if (mode === "v1_integrity_409") {
+    // Forced injection (EDGE-004): proves the injection itself, not just a
+    // genuine hash mismatch — 02-03's reconcile_integrity_409 rides this.
+    jsonBody(res, 409, errorEnvelope("integrity_mismatch", "Forced integrity-mismatch injection"));
+    return;
+  }
+
+  const recomputedHex = sha256Hex(content);
+  const suppliedHex = contentHash.slice("sha256:".length);
+  if (!constantTimeHexEqual(recomputedHex, suppliedHex)) {
+    jsonBody(res, 409, errorEnvelope("integrity_mismatch", "Recomputed content hash does not match the supplied hash"));
+    return;
+  }
+
+  const fingerprint = fingerprintOf(parsed);
+  const existingReplay = replays.get(idempotencyKey);
+  if (existingReplay) {
+    if (existingReplay.fingerprint === fingerprint) {
+      jsonBody(res, 200, existingReplay.bodyJson);
+      return;
+    }
+    jsonBody(res, 409, errorEnvelope("idempotency_conflict", "idempotencyKey reused with a different request body"));
+    return;
+  }
+
+  const activatedAt = new Date().toISOString();
+  const existingEntry = managed.get(skillId) ?? null;
+  const previousState = existingEntry
+    ? { contentHash: existingEntry.contentHash, version: existingEntry.version, content: existingEntry.content }
+    : null;
+
+  const responseBody = {
+    ack: { skillId, contentHash, activatedAt, reloaded: true },
+    ledgerEntry: {
+      skillId,
+      contentHash,
+      version: version ?? null,
+      scope: DEPLOYMENT_SCOPE,
+      managedBy: MANAGED_BY,
+      activatedAt,
+      previousState,
+      idempotencyKey,
+    },
+  };
+
+  // EDGE-003 injection: the ack is not truth. In v1_ack_not_observed mode the
+  // 201 ack is returned but NOTHING is stored — the skill is never observed.
+  if (mode !== "v1_ack_not_observed") {
+    managed.set(skillId, {
+      skillId,
+      contentHash,
+      version: version ?? null,
+      previousState,
+      idempotencyKey,
+      content,
+      description: deriveDescription(content),
+      category: "managed",
+    });
+    replays.set(idempotencyKey, { fingerprint, bodyJson: responseBody, skillId });
+  }
+
+  jsonBody(res, 201, responseBody);
+}
+
+// DELETE /v1/skills/activations/{skillId}?mode=clean|rollback — Layer-2
+// modes only.
+function handleActivationDelete(req, res, url, skillId, { managed, replays }) {
+  const modeValues = url.searchParams.getAll("mode");
+  if (modeValues.length > 1) {
+    jsonBody(res, 422, errorEnvelope("unsupported_mode", "Duplicated mode parameter"));
+    return;
+  }
+  const mode = modeValues[0] ?? "clean";
+  if (!DELETE_MODES.has(mode)) {
+    jsonBody(res, 422, errorEnvelope("unsupported_mode", `Unknown mode "${mode}"`));
+    return;
+  }
+
+  if (!managed.has(skillId)) {
+    if (isNativeSkillName(skillId)) {
+      jsonBody(res, 403, errorEnvelope("not_managed", "Target belongs to a remote-native skill, not managed"));
+      return;
+    }
+    jsonBody(res, 404, errorEnvelope("not_found", "No managed or native skill by that name"));
+    return;
+  }
+
+  const entry = managed.get(skillId);
+  const at = new Date().toISOString();
+
+  if (mode === "clean") {
+    managed.delete(skillId);
+    for (const [key, replay] of replays) if (replay.skillId === skillId) replays.delete(key);
+    jsonBody(res, 200, { ack: { skillId, removed: true, at } });
+    return;
+  }
+
+  // mode === "rollback"
+  if (entry.previousState === null) {
+    managed.delete(skillId);
+  } else {
+    managed.set(skillId, {
+      ...entry,
+      contentHash: entry.previousState.contentHash,
+      version: entry.previousState.version,
+      content: entry.previousState.content,
+      description: deriveDescription(entry.previousState.content),
+      previousState: null,
+    });
+  }
+  for (const [key, replay] of replays) if (replay.skillId === skillId) replays.delete(key);
+  jsonBody(res, 200, { ack: { skillId, restored: true, at } });
+}
+
+function managedProjection(entry) {
+  return {
+    name: entry.skillId,
+    description: entry.description,
+    category: entry.category,
+    contentHash: entry.contentHash,
+    managedBy: MANAGED_BY,
+    scope: DEPLOYMENT_SCOPE,
+  };
+}
+
+/**
+ * Boot an ephemeral-port `node:http` server scripted to one of the
+ * §Fail-closed-matrix-aligned modes (14 from Phase 1 + Plan 02's three
+ * Layer-2 injection modes). Resolves `{ server, baseUrl, requests }`
+ * where `requests` is a read-only-by-convention transcript array of
+ * `{ method, path, hasValidAuth }` for every request received (Layer-2
+ * activation POST records additionally carry `body`, the parsed JSON or
+ * null when unparseable) — consumed by Plan 02/03's wire-sequence +
+ * zero-activation-calls assertions.
+ */
+export function startHermesStub(mode) {
+  if (!MODES.has(mode)) {
+    throw new Error(`unknown stub mode: ${mode}`);
+  }
+
+  const requests = [];
+  const sockets = new Set();
+  // Per-instance state (never module-global): two stub instances must be
+  // fully isolated (stub_two_instances_share_no_state).
+  const managed = new Map();
+  const replays = new Map();
+
+  const server = createServer((req, res) => {
+    if (mode === "timeout") {
+      // Hung response: accept the connection, never write, never end. The
+      // caller's bounded request deadline (capabilities.ts) must abort; this
+      // server's close() destroys the open socket so the test never hangs.
+      requests.push({ method: req.method, path: req.url, hasValidAuth: null });
+      return;
+    }
+
+    const authHeader = req.headers["authorization"] ?? null;
+    const hasValidAuth = authHeader === `Bearer ${STUB_API_KEY}`;
+    const record = { method: req.method, path: req.url, hasValidAuth };
+    requests.push(record);
+
+    const url = new URL(req.url, "http://stub.internal");
+    const pathname = url.pathname;
+    const activationMatch = /^\/v1\/skills\/activations(?:\/([^/]+))?$/.exec(pathname);
+
+    if (pathname === "/v1/capabilities") {
+      if (mode === "old") {
+        // Missing route entirely (real old-remote fail-closed row) — this is
+        // `unsupported`, NEVER `malformed` (research Anti-Pattern).
+        jsonBody(res, 404, { error: { code: "not_found" } });
+        return;
+      }
+      if (mode === "capabilities_5xx") {
+        jsonBody(res, 503, { error: { code: "upstream_unavailable" } });
+        return;
+      }
+      if (mode === "auth_fail") {
+        // Real shared-Bearer behavior: an invalid/revoked key fails BOTH
+        // routes before any advert is served, regardless of the token sent.
+        authInvalid(res);
+        return;
+      }
+      if (!hasValidAuth) {
+        authInvalid(res);
+        return;
+      }
+      if (mode === "malformed") {
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end("{not-valid-json::");
+        return;
+      }
+      jsonBody(res, 200, capabilitiesPayloadFor(mode));
+      return;
+    }
+
+    if (activationMatch && LAYER2_MODES.has(mode)) {
+      if (mode === "auth_fail") {
+        authInvalid(res);
+        return;
+      }
+      if (!hasValidAuth) {
+        authInvalid(res);
+        return;
+      }
+      const skillIdFromPath = activationMatch[1] ? decodeURIComponent(activationMatch[1]) : null;
+      if (req.method === "POST" && !skillIdFromPath) {
+        handleActivationPost(req, res, { mode, managed, replays, record });
+        return;
+      }
+      if (req.method === "DELETE" && skillIdFromPath) {
+        handleActivationDelete(req, res, url, skillIdFromPath, { managed, replays });
+        return;
+      }
+      jsonBody(res, 404, { error: { code: "not_found" } });
+      return;
+    }
+
+    if (pathname === "/v1/skills") {
+      if (mode === "auth_fail") {
+        authInvalid(res);
+        return;
+      }
+      if (!hasValidAuth) {
+        authInvalid(res);
+        return;
+      }
+      if (mode === "auth_fail_inventory") {
+        insufficientScope(res);
+        return;
+      }
+      if (mode === "transient") {
+        jsonBody(res, 503, { error: { code: "upstream_unavailable" } });
+        return;
+      }
+      if (mode === "inventory_malformed") {
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end("{not-valid-json::");
+        return;
+      }
+      if (mode === "bad_item") {
+        jsonBody(res, 200, { object: "list", data: BAD_ITEM_ENTRIES });
+        return;
+      }
+
+      if (url.searchParams.get("scope") === "managed" && LAYER2_MODES.has(mode)) {
+        // The ONLY source of `observed: true` (LD-2) — native entries NEVER
+        // appear here, and it carries contentHash/managedBy/scope (unlike
+        // the base list below, which stays hashless for ALL modes).
+        jsonBody(res, 200, { object: "list", data: [...managed.values()].map(managedProjection) });
+        return;
+      }
+
+      // Base list: native SKILL_ENTRIES plus managed entries projected to
+      // {name, description, category} ONLY (hashless — LD-2). A real
+      // pre-patch v0.16 server ignores unknown query params, so any
+      // non-Layer-2 mode or unrecognized scope value falls through here too.
+      const activatedProjections = [...managed.values()].map((entry) => ({
+        name: entry.skillId,
+        description: entry.description,
+        category: entry.category,
+      }));
+      jsonBody(res, 200, { object: "list", data: [...SKILL_ENTRIES, ...activatedProjections] });
+      return;
+    }
+
+    jsonBody(res, 404, { error: { code: "not_found" } });
+  });
+
+  server.on("connection", (socket) => {
+    sockets.add(socket);
+    socket.on("close", () => sockets.delete(socket));
+  });
+
+  // Socket-cleanup override (timeout mode requirement): close() must destroy
+  // any open sockets so the suite never hangs after a hung-response test.
+  const nativeClose = server.close.bind(server);
+  server.close = (callback) => {
+    for (const socket of sockets) socket.destroy();
+    sockets.clear();
+    return nativeClose(callback);
+  };
+
+  return new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      resolve({ server, baseUrl: `http://127.0.0.1:${address.port}`, requests });
+    });
+  });
+}

--- a/packages/adapters/hermes/src/gateway/test-fixtures/hermes-stub-server.mjs
+++ b/packages/adapters/hermes/src/gateway/test-fixtures/hermes-stub-server.mjs
@@ -567,11 +567,16 @@ export function startHermesStub(mode) {
       return;
     }
 
+    if (activationMatch && mode === "auth_fail") {
+      // Reachable regardless of LAYER2_MODES membership — a real shared-Bearer
+      // remote rejects an invalid/revoked key on the activation route the
+      // same as every other route, independent of which skill-contract modes
+      // that remote otherwise supports.
+      authInvalid(res);
+      return;
+    }
+
     if (activationMatch && LAYER2_MODES.has(mode)) {
-      if (mode === "auth_fail") {
-        authInvalid(res);
-        return;
-      }
       if (!hasValidAuth) {
         authInvalid(res);
         return;

--- a/server/src/__tests__/adapter-routes.test.ts
+++ b/server/src/__tests__/adapter-routes.test.ts
@@ -202,7 +202,9 @@ describe("adapter routes", () => {
     expect(hermesGateway.source).toBe("builtin");
     expect(hermesGateway.capabilities).toMatchObject({
       supportsInstructionsBundle: false,
-      supportsSkills: false,
+      // hermes_gateway wires listSkills/syncSkills (spec-309 Layers 1+2) —
+      // adapters.ts:120 derives supportsSkills from their presence.
+      supportsSkills: true,
       supportsLocalAgentJwt: false,
       requiresMaterializedRuntimeSkills: false,
     });


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The adapter layer (`packages/adapters/*`) is how Paperclip talks to a given agent runtime — each adapter owns negotiation, inventory, and (where supported) mutation against that runtime's own API
> - Hermes Agent (NousResearch) has no adapter yet, and its skill set today can only be changed by an operator with direct access to the running agent — there's no way for Paperclip to read or reconcile a remote Hermes instance's skills programmatically, and no capability-negotiation story for a runtime that may or may not support that at all
> - A remote skill contract needs to be honest about what a given remote actually supports (old vs. new Hermes builds, auth failures, malformed responses) rather than assuming every remote speaks the same protocol — this needs a fail-closed capability negotiation layer, not an all-or-nothing assumption
> - This pull request adds the `hermes_gateway` adapter surface: a version-negotiated capability handshake (`capabilities.ts`), a read-only inventory mapper plus a desired-state reconcile against the remote's skills-activation API (`skills.ts`), and the `createServerAdapter()` wiring (`index.ts`) — backed by a self-contained stub server so the suite never depends on a live Hermes instance
> - The benefit is Paperclip can manage a remote Hermes agent's skill set the same way it manages any other adapter, safely degrading to "unsupported" against remotes that haven't adopted the new API, and never mutating a skill it doesn't own

## Linked Issues or Issue Description

No existing public issue — this is new adapter surface, described here per the Adapter template fields:

- **What**: a `hermes_gateway` adapter surface (`packages/adapters/hermes/src/gateway/`) providing capability negotiation, read-only skill inventory, and desired-state skill reconciliation against a remote Hermes Agent instance's skills-activation API.
- **Why**: Hermes Agent now exposes an authenticated skills-activation API (companion PR: `NousResearch/hermes-agent` — adds `POST/DELETE /v1/skills/activations` + `GET /v1/skills?scope=managed`). This is the client side that lets Paperclip talk to it.
- **Prior art searched**: #2363 ("feat: add hermes_gateway adapter", closed 2026-07-14, different author) proposed a similarly-named adapter but is unrelated to this branch's code path and was closed/abandoned independently — no overlap.

## What Changed

- `capabilities.ts` — version-negotiated capability contract (`negotiateCapability`): GETs `/v1/capabilities` then `/v1/skills`, parses the remote's feature map, and resolves to one of `negotiated | unsupported | auth_error | malformed | transient_error | auth_incompat` per the fail-closed matrix. Ships `LEGACY_UNSUPPORTED_RESPONSE`, a frozen literal for remotes that don't advertise `skills_api` at all.
- `skills.ts` — `listSkills` (maps the negotiated inventory into `AdapterSkillEntry[]`, field-by-field, never a spread of the remote object) and `syncSkills` (desired-state reconcile: content-hash dedup, idempotent replay via an idempotency key, integrity-mismatch rollback, and a hard rule that it never mutates a skill it doesn't already manage).
- `index.ts` — wires `listSkills`/`syncSkills` into `createServerAdapter()`.
- `test-fixtures/hermes-stub-server.mjs` — a vendored, self-contained stub server (Node builtins only: `node:http` + `node:crypto`) that scripts every remote mode (`old`, `auth_fail`, `malformed`, `transient`, the four Layer-2 modes, etc.) the vitest suites exercise against. This is the only mock boundary in the suite.
- `inventory-mapping.test.ts` / `sync-reconcile.test.ts` — 21 named vitest tests (6 + 15) covering the negotiation matrix, inventory mapping, and the full sync/reconcile state machine against the stub server, testing the adapter's public surface only.
- **This push (dead-code cleanup, no behavior change)**:
  - `skills.ts` (`postActivation`'s catch handler): removed a dead `isAbortError(err) ? "transient_error" : "transient_error"` ternary — both branches returned the identical code, so it was always `"transient_error"` regardless. No test asserted a distinct timeout/abort code, and the fail-closed contract deliberately maps abort/timeout into the transient class uniformly. Collapsed to a plain `return { kind: "failed", code: "transient_error" }`.
  - `capabilities.ts` (two catch blocks in `negotiateCapability`, capabilities fetch + inventory fetch): same dead `if (isAbortError(err)) return X; return X;` pattern in both — collapsed each to a single unconditional return. Removed the now-fully-unused `isAbortError` helper from both files.
  - `test-fixtures/hermes-stub-server.mjs`: the `auth_fail` guard inside the `LAYER2_MODES`-gated activation-route handler was unreachable, because `"auth_fail"` is not a member of `LAYER2_MODES`. Verified no test exercises `auth_fail` against the activation route specifically — `reconcile_auth_error_fail_closed_zero_activation_calls` asserts the adapter never even reaches that route under this mode, since capability negotiation fails closed first. Moved the check ahead of the `LAYER2_MODES` gate so it's reachable for any activation request under `auth_fail`, matching the unconditional `auth_fail` handling already present on the capabilities and inventory routes (defense-in-depth on the stub server, not a change to what the adapter itself does).

## Verification

- `cd packages/adapters/hermes && npx vitest run src/gateway/inventory-mapping.test.ts src/gateway/sync-reconcile.test.ts` — 21/21 passing, run 3x after this push to confirm no new flakiness (self-contained: only remote is the vendored stub server, no network).
- Live staging matrix PATH-001..006 run against a Hermes 0.18.0 deployment on our own infra — passed; evidence held downstream (internal, not reproducible from this repo alone).

## Risks

- New adapter surface only — no existing adapter, route, or shared module changed.
- Fail-closed by default throughout: any negotiation ambiguity (unknown contract major, non-object feature map, oversized response body, malformed JSON) resolves to `unsupported`/`malformed`, never a partial/best-effort read.
- `syncSkills` never mutates a skill it doesn't already manage (content-hash + managed-by tracking) — no path that could touch a native/operator-owned skill.
- This push is dead-code cleanup only (collapsed always-same-value branches, removed the now-unused helper they called, made one always-false test-fixture guard reachable) — no behavior change to the adapter's negotiation, mapping, or reconcile logic, confirmed by the unchanged 21/21 test result.

## Model Used

Anthropic Claude Code — `claude-fable-5` for orchestration/planning, `claude-sonnet-5` for implementation, `claude-opus-4-8` for verification. Extended thinking enabled throughout.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

## Notes

- Zero secret values in this diff or PR body (scanned before push/create).
- This PR is currently unmerged/open. What's actually **deployed today** on the consuming side is a pinned, reversible compat patch of this same surface (`@paperclipai+hermes-paperclip-adapter+2026.707.0.patch`, `pending_upstream` in `infra/paperclip/control-plane/patches/PATCH_MANIFEST.md`) — this PR is the upstream delivery path, not a claim that this capability is already merged/deployed by `paperclipai/paperclip` itself.
- Companion PR: `NousResearch/hermes-agent` ← `austinmao:spec309/skills-activation-v1` (adds the server-side activation API this adapter talks to).
