### PR TITLE
feat: add safe heartbeat run detail endpoint

### DIFF
--- a/server/src/__tests__/agent-live-run-routes.test.ts
+++ b/server/src/__tests__/agent-live-run-routes.test.ts
@@ -233,7 +233,6 @@ describe("agent live run routes", () => {
     mockHeartbeatService.listRunDetails.mockResolvedValue([
       {
         id: "run-1",
-        companyId: "company-1",
         agent: {
           id: "agent-1",
           name: "Builder",
@@ -250,17 +249,8 @@ describe("agent live run routes", () => {
         createdAt: new Date("2026-04-10T09:29:59.000Z"),
         updatedAt: new Date("2026-04-10T09:31:00.000Z"),
         durationMs: 60_000,
-        invocationSource: "assignment",
-        triggerDetail: "issue_assigned",
-        wakeReason: "issue_assigned",
-        livenessState: null,
-        livenessReason: null,
-        exitCode: 1,
-        signal: null,
-        failure: {
-          failureClass: "adapter",
-          safeReasonSummary: "Run failed with safe error code adapter_failed.",
-        },
+        failureClass: "adapter",
+        safeReasonSummary: "Run failed with safe error code adapter_failed.",
       },
     ]);
     mockHeartbeatService.wakeup.mockResolvedValue({
@@ -425,15 +415,22 @@ describe("agent live run routes", () => {
           linkedEntityId: "issue-1",
           status: "failed",
           durationMs: 60_000,
-          failure: {
-            failureClass: "adapter",
-            safeReasonSummary: "Run failed with safe error code adapter_failed.",
-          },
+          failureClass: "adapter",
+          safeReasonSummary: "Run failed with safe error code adapter_failed.",
         },
       ],
     });
     expect(JSON.stringify(res.body)).not.toContain("resultJson");
     expect(JSON.stringify(res.body)).not.toContain("logRef");
+    expect(res.body.runs[0]).not.toHaveProperty("companyId");
+    expect(res.body.runs[0]).not.toHaveProperty("invocationSource");
+    expect(res.body.runs[0]).not.toHaveProperty("triggerDetail");
+    expect(res.body.runs[0]).not.toHaveProperty("wakeReason");
+    expect(res.body.runs[0]).not.toHaveProperty("livenessState");
+    expect(res.body.runs[0]).not.toHaveProperty("livenessReason");
+    expect(res.body.runs[0]).not.toHaveProperty("exitCode");
+    expect(res.body.runs[0]).not.toHaveProperty("signal");
+    expect(res.body.runs[0]).not.toHaveProperty("failure");
   });
 
   it("rejects non-ISO heartbeat run detail windows", async () => {

--- a/server/src/__tests__/agent-live-run-routes.test.ts
+++ b/server/src/__tests__/agent-live-run-routes.test.ts
@@ -436,6 +436,18 @@ describe("agent live run routes", () => {
     expect(JSON.stringify(res.body)).not.toContain("logRef");
   });
 
+  it("rejects non-ISO heartbeat run detail windows", async () => {
+    const res = await requestApp(
+      await createApp(),
+      (baseUrl) => request(baseUrl).get(
+        "/api/companies/company-1/heartbeat-runs/details?start=July%2018%202026&end=2026-04-11T00:00:00.000Z",
+      ),
+    );
+
+    expect(res.status, JSON.stringify(res.body)).toBe(400);
+    expect(mockHeartbeatService.listRunDetails).not.toHaveBeenCalled();
+  });
+
   it("caps company live run polling by default", async () => {
     const rows = Array.from({ length: 75 }, (_, index) => ({
       id: `run-${index}`,

--- a/server/src/__tests__/agent-live-run-routes.test.ts
+++ b/server/src/__tests__/agent-live-run-routes.test.ts
@@ -12,6 +12,7 @@ const mockHeartbeatService = vi.hoisted(() => ({
   getRunIssueSummary: vi.fn(),
   getActiveRunIssueSummaryForAgent: vi.fn(),
   getRunLogAccess: vi.fn(),
+  listRunDetails: vi.fn(),
   readLog: vi.fn(),
   wakeup: vi.fn(),
 }));
@@ -229,6 +230,39 @@ describe("agent live run routes", () => {
       content: "chunk",
       nextOffset: 5,
     });
+    mockHeartbeatService.listRunDetails.mockResolvedValue([
+      {
+        id: "run-1",
+        companyId: "company-1",
+        agent: {
+          id: "agent-1",
+          name: "Builder",
+          role: "engineer",
+          title: null,
+          status: "running",
+          adapterType: "codex_local",
+        },
+        linkedEntityId: "issue-1",
+        linkedIssue: null,
+        status: "failed",
+        startedAt: new Date("2026-04-10T09:30:00.000Z"),
+        endedAt: new Date("2026-04-10T09:31:00.000Z"),
+        createdAt: new Date("2026-04-10T09:29:59.000Z"),
+        updatedAt: new Date("2026-04-10T09:31:00.000Z"),
+        durationMs: 60_000,
+        invocationSource: "assignment",
+        triggerDetail: "issue_assigned",
+        wakeReason: "issue_assigned",
+        livenessState: null,
+        livenessReason: null,
+        exitCode: 1,
+        signal: null,
+        failure: {
+          failureClass: "adapter",
+          safeReasonSummary: "Run failed with safe error code adapter_failed.",
+        },
+      },
+    ]);
     mockHeartbeatService.wakeup.mockResolvedValue({
       id: "run-1",
       companyId: "company-1",
@@ -365,6 +399,41 @@ describe("agent live run routes", () => {
       content: "chunk",
       nextOffset: 5,
     });
+  });
+
+  it("returns safe heartbeat run details for an explicit window", async () => {
+    const res = await requestApp(
+      await createApp(),
+      (baseUrl) => request(baseUrl).get(
+        "/api/companies/company-1/heartbeat-runs/details?start=2026-04-10T00:00:00.000Z&end=2026-04-11T00:00:00.000Z&limit=25&status=failed",
+      ),
+    );
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(mockHeartbeatService.listRunDetails).toHaveBeenCalledWith("company-1", {
+      start: new Date("2026-04-10T00:00:00.000Z"),
+      end: new Date("2026-04-11T00:00:00.000Z"),
+      agentId: null,
+      status: "failed",
+      limit: 25,
+    });
+    expect(res.body).toMatchObject({
+      runs: [
+        {
+          id: "run-1",
+          agent: { id: "agent-1", name: "Builder" },
+          linkedEntityId: "issue-1",
+          status: "failed",
+          durationMs: 60_000,
+          failure: {
+            failureClass: "adapter",
+            safeReasonSummary: "Run failed with safe error code adapter_failed.",
+          },
+        },
+      ],
+    });
+    expect(JSON.stringify(res.body)).not.toContain("resultJson");
+    expect(JSON.stringify(res.body)).not.toContain("logRef");
   });
 
   it("caps company live run polling by default", async () => {

--- a/server/src/__tests__/heartbeat-list.test.ts
+++ b/server/src/__tests__/heartbeat-list.test.ts
@@ -288,6 +288,7 @@ describeEmbeddedPostgres("heartbeat list", () => {
     const issueId = randomUUID();
     const failedRunId = randomUUID();
     const missingIssueRunId = randomUUID();
+    const signalRunId = randomUUID();
     const outsideRunId = randomUUID();
 
     await db.insert(companies).values({
@@ -359,6 +360,20 @@ describeEmbeddedPostgres("heartbeat list", () => {
         },
       },
       {
+        id: signalRunId,
+        companyId,
+        agentId,
+        invocationSource: "assignment",
+        status: "failed",
+        startedAt: new Date("2026-07-18T10:30:00.000Z"),
+        finishedAt: new Date("2026-07-18T10:31:00.000Z"),
+        errorCode: null,
+        signal: "SIGKILL",
+        contextSnapshot: {
+          issueId,
+        },
+      },
+      {
         id: outsideRunId,
         companyId,
         agentId,
@@ -378,9 +393,17 @@ describeEmbeddedPostgres("heartbeat list", () => {
       limit: 10,
     });
 
-    expect(details.map((run) => run.id)).toEqual([missingIssueRunId, failedRunId]);
+    expect(details.map((run) => run.id)).toEqual([missingIssueRunId, signalRunId, failedRunId]);
 
     expect(details[1]).toMatchObject({
+      id: signalRunId,
+      failure: {
+        failureClass: "runtime_process",
+        safeReasonSummary: "Run was terminated by a process signal.",
+      },
+    });
+
+    expect(details[2]).toMatchObject({
       id: failedRunId,
       agent: {
         id: agentId,

--- a/server/src/__tests__/heartbeat-list.test.ts
+++ b/server/src/__tests__/heartbeat-list.test.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
-import { agents, companies, createDb, heartbeatRuns } from "@paperclipai/db";
+import { agents, companies, createDb, heartbeatRuns, issues } from "@paperclipai/db";
 import {
   getEmbeddedPostgresTestSupport,
   startEmbeddedPostgresTestDatabase,
@@ -27,6 +27,7 @@ describeEmbeddedPostgres("heartbeat list", () => {
 
   afterEach(async () => {
     await db.delete(heartbeatRuns);
+    await db.delete(issues);
     await db.delete(agents);
     await db.delete(companies);
   });
@@ -279,6 +280,150 @@ describeEmbeddedPostgres("heartbeat list", () => {
     expect(typeof result?.stdout).toBe("string");
     expect((result?.stdout as string).length).toBeLessThan(oversizedStdout.length);
     expect(result).not.toHaveProperty("nestedHuge");
+  });
+
+  it("lists safe run details for a caller-specified time window", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const issueId = randomUUID();
+    const failedRunId = randomUUID();
+    const missingIssueRunId = randomUUID();
+    const outsideRunId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "CodexCoder",
+      role: "engineer",
+      title: "Founding Engineer",
+      status: "running",
+      adapterType: "codex_local",
+      adapterConfig: { secret: "must-not-leak" },
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Fix the failing run",
+      status: "in_progress",
+      priority: "medium",
+      assigneeAgentId: agentId,
+      identifier: "PC-123",
+    });
+
+    await db.insert(heartbeatRuns).values([
+      {
+        id: failedRunId,
+        companyId,
+        agentId,
+        invocationSource: "assignment",
+        triggerDetail: "issue_assigned",
+        status: "failed",
+        startedAt: new Date("2026-07-18T10:00:00.000Z"),
+        finishedAt: new Date("2026-07-18T10:05:00.000Z"),
+        createdAt: new Date("2026-07-18T09:59:00.000Z"),
+        error: "Raw stack with token sk-secret and patient data must not leak",
+        stdoutExcerpt: "transcript must not leak",
+        stderrExcerpt: "stderr must not leak",
+        resultJson: {
+          error: "raw adapter error must not leak",
+          stdout: "raw stdout must not leak",
+        },
+        errorCode: "provider_quota",
+        contextSnapshot: {
+          issueId,
+          wakeReason: "issue_assigned",
+        },
+      },
+      {
+        id: missingIssueRunId,
+        companyId,
+        agentId,
+        invocationSource: "assignment",
+        status: "timed_out",
+        startedAt: new Date("2026-07-18T11:00:00.000Z"),
+        finishedAt: new Date("2026-07-18T11:30:00.000Z"),
+        errorCode: null,
+        contextSnapshot: {
+          issueId: randomUUID(),
+          taskKey: "external-task-1",
+        },
+      },
+      {
+        id: outsideRunId,
+        companyId,
+        agentId,
+        invocationSource: "assignment",
+        status: "failed",
+        startedAt: new Date("2026-07-17T11:00:00.000Z"),
+        errorCode: "adapter_failed",
+        contextSnapshot: {
+          issueId,
+        },
+      },
+    ]);
+
+    const details = await heartbeatService(db).listRunDetails(companyId, {
+      start: new Date("2026-07-18T00:00:00.000Z"),
+      end: new Date("2026-07-19T00:00:00.000Z"),
+      limit: 10,
+    });
+
+    expect(details.map((run) => run.id)).toEqual([missingIssueRunId, failedRunId]);
+
+    expect(details[1]).toMatchObject({
+      id: failedRunId,
+      agent: {
+        id: agentId,
+        name: "CodexCoder",
+        role: "engineer",
+        title: "Founding Engineer",
+        status: "running",
+        adapterType: "codex_local",
+      },
+      linkedEntityId: issueId,
+      linkedIssue: {
+        id: issueId,
+        identifier: "PC-123",
+        title: "Fix the failing run",
+        status: "in_progress",
+      },
+      status: "failed",
+      durationMs: 300_000,
+      wakeReason: "issue_assigned",
+      failure: {
+        failureClass: "provider_quota",
+        safeReasonSummary: "Run failed with safe error code provider_quota.",
+      },
+    });
+
+    expect(details[0]).toMatchObject({
+      id: missingIssueRunId,
+      linkedIssue: null,
+      status: "timed_out",
+      durationMs: 1_800_000,
+      failure: {
+        failureClass: "timeout",
+        safeReasonSummary: "Run timed out.",
+      },
+    });
+
+    const serialized = JSON.stringify(details);
+    expect(serialized).not.toContain("Raw stack");
+    expect(serialized).not.toContain("transcript");
+    expect(serialized).not.toContain("stderr must not leak");
+    expect(serialized).not.toContain("raw adapter error");
+    expect(serialized).not.toContain("secret");
+    expect(serialized).not.toContain("sk-secret");
   });
 });
 

--- a/server/src/__tests__/heartbeat-list.test.ts
+++ b/server/src/__tests__/heartbeat-list.test.ts
@@ -397,10 +397,8 @@ describeEmbeddedPostgres("heartbeat list", () => {
 
     expect(details[1]).toMatchObject({
       id: signalRunId,
-      failure: {
-        failureClass: "runtime_process",
-        safeReasonSummary: "Run was terminated by a process signal.",
-      },
+      failureClass: "runtime_process",
+      safeReasonSummary: "Run was terminated by a process signal.",
     });
 
     expect(details[2]).toMatchObject({
@@ -422,11 +420,8 @@ describeEmbeddedPostgres("heartbeat list", () => {
       },
       status: "failed",
       durationMs: 300_000,
-      wakeReason: "issue_assigned",
-      failure: {
-        failureClass: "provider_quota",
-        safeReasonSummary: "Run failed with safe error code provider_quota.",
-      },
+      failureClass: "provider_quota",
+      safeReasonSummary: "Run failed with safe error code provider_quota.",
     });
 
     expect(details[0]).toMatchObject({
@@ -434,13 +429,20 @@ describeEmbeddedPostgres("heartbeat list", () => {
       linkedIssue: null,
       status: "timed_out",
       durationMs: 1_800_000,
-      failure: {
-        failureClass: "timeout",
-        safeReasonSummary: "Run timed out.",
-      },
+      failureClass: "timeout",
+      safeReasonSummary: "Run timed out.",
     });
 
     const serialized = JSON.stringify(details);
+    expect(details[2]).not.toHaveProperty("companyId");
+    expect(details[2]).not.toHaveProperty("invocationSource");
+    expect(details[2]).not.toHaveProperty("triggerDetail");
+    expect(details[2]).not.toHaveProperty("wakeReason");
+    expect(details[2]).not.toHaveProperty("livenessState");
+    expect(details[2]).not.toHaveProperty("livenessReason");
+    expect(details[2]).not.toHaveProperty("exitCode");
+    expect(details[2]).not.toHaveProperty("signal");
+    expect(details[2]).not.toHaveProperty("failure");
     expect(serialized).not.toContain("Raw stack");
     expect(serialized).not.toContain("transcript");
     expect(serialized).not.toContain("stderr must not leak");

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -128,6 +128,17 @@ function readLiveRunsQueryInt(value: unknown, max: number, fallback = 0) {
   return Math.min(max, Math.trunc(parsed));
 }
 
+function readRequiredIsoDate(value: unknown, name: string) {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new HttpError(400, `${name} is required`);
+  }
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    throw new HttpError(400, `${name} must be a valid ISO datetime`);
+  }
+  return date;
+}
+
 function readRunIssueId(context: Record<string, unknown> | null) {
   const directIssueId = context?.issueId;
   if (typeof directIssueId === "string" && isUuidLike(directIssueId)) return directIssueId;
@@ -3592,6 +3603,32 @@ export function agentRoutes(
     const summary = req.query.summary === "true" || req.query.summary === "1";
     const runs = await heartbeat.list(companyId, agentId, limit, { summary });
     res.json(runs);
+  });
+
+  router.get("/companies/:companyId/heartbeat-runs/details", async (req, res) => {
+    const companyId = req.params.companyId as string;
+    assertCompanyAccess(req, companyId);
+    const start = readRequiredIsoDate(req.query.start, "start");
+    const end = readRequiredIsoDate(req.query.end, "end");
+    if (end <= start) {
+      throw new HttpError(400, "end must be after start");
+    }
+    const limit = readLiveRunsQueryInt(req.query.limit, 1000, 200);
+    const agentId = typeof req.query.agentId === "string" && req.query.agentId.trim().length > 0
+      ? req.query.agentId.trim()
+      : null;
+    const status = typeof req.query.status === "string" && req.query.status.trim().length > 0
+      ? req.query.status.trim()
+      : null;
+
+    const runs = await heartbeat.listRunDetails(companyId, {
+      start,
+      end,
+      agentId,
+      status,
+      limit,
+    });
+    res.json({ runs });
   });
 
   router.get("/companies/:companyId/live-runs", async (req, res) => {

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -114,6 +114,7 @@ import {
 
 const RUN_LOG_DEFAULT_LIMIT_BYTES = 256_000;
 const RUN_LOG_MAX_LIMIT_BYTES = 1024 * 1024;
+const ISO_DATETIME_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(:\d{2}(\.\d+)?)?(Z|[+-]\d{2}:?\d{2})$/;
 
 function readRunLogLimitBytes(value: unknown) {
   const parsed = Number(value ?? RUN_LOG_DEFAULT_LIMIT_BYTES);
@@ -132,7 +133,11 @@ function readRequiredIsoDate(value: unknown, name: string) {
   if (typeof value !== "string" || value.trim().length === 0) {
     throw new HttpError(400, `${name} is required`);
   }
-  const date = new Date(value);
+  const trimmed = value.trim();
+  if (!ISO_DATETIME_RE.test(trimmed)) {
+    throw new HttpError(400, `${name} must be a valid ISO datetime`);
+  }
+  const date = new Date(trimmed);
   if (Number.isNaN(date.getTime())) {
     throw new HttpError(400, `${name} must be a valid ISO datetime`);
   }

--- a/server/src/routes/openapi.ts
+++ b/server/src/routes/openapi.ts
@@ -3561,6 +3561,24 @@ registry.registerPath({
 
 registry.registerPath({
   method: "get",
+  path: "/api/companies/{companyId}/heartbeat-runs/details",
+  tags: ["runs"],
+  summary: "List safe heartbeat run details for a time window",
+  request: {
+    params: z.object({ companyId: z.string() }),
+    query: z.object({
+      start: z.string().datetime(),
+      end: z.string().datetime(),
+      agentId: z.string().optional(),
+      status: z.string().optional(),
+      limit: z.string().optional(),
+    }),
+  },
+  responses: { 200: r.ok(), 400: r.badRequest, 401: r.unauthorized },
+});
+
+registry.registerPath({
+  method: "get",
   path: "/api/companies/{companyId}/live-runs",
   tags: ["runs"],
   summary: "List live runs for a company",

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -1983,6 +1983,9 @@ function classifySafeHeartbeatRunFailure(input: {
 
   const code = input.errorCode?.trim() || null;
   if (!code) {
+    if (input.signal) {
+      return { failureClass: "runtime_process", safeReasonSummary: "Run was terminated by a process signal." };
+    }
     return {
       failureClass: "unknown",
       safeReasonSummary: `Run ended with status ${input.status}; no safe error code was recorded.`,

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -1918,6 +1918,102 @@ const heartbeatRunIssueSummaryColumns = {
   issueId: sql<string | null>`${heartbeatRuns.contextSnapshot} ->> 'issueId'`.as("issueId"),
 } as const;
 
+const heartbeatRunDetailColumns = {
+  id: heartbeatRuns.id,
+  companyId: heartbeatRuns.companyId,
+  agentId: heartbeatRuns.agentId,
+  agentName: agents.name,
+  agentRole: agents.role,
+  agentTitle: agents.title,
+  agentStatus: agents.status,
+  adapterType: agents.adapterType,
+  status: heartbeatRuns.status,
+  startedAt: heartbeatRuns.startedAt,
+  finishedAt: heartbeatRuns.finishedAt,
+  createdAt: heartbeatRuns.createdAt,
+  updatedAt: heartbeatRuns.updatedAt,
+  errorCode: heartbeatRuns.errorCode,
+  exitCode: heartbeatRuns.exitCode,
+  signal: heartbeatRuns.signal,
+  livenessState: heartbeatRuns.livenessState,
+  livenessReason: heartbeatRuns.livenessReason,
+  invocationSource: heartbeatRuns.invocationSource,
+  triggerDetail: heartbeatRuns.triggerDetail,
+  contextIssueId: sql<string | null>`${heartbeatRuns.contextSnapshot} ->> 'issueId'`.as("contextIssueId"),
+  contextTaskId: sql<string | null>`${heartbeatRuns.contextSnapshot} ->> 'taskId'`.as("contextTaskId"),
+  contextTaskKey: sql<string | null>`${heartbeatRuns.contextSnapshot} ->> 'taskKey'`.as("contextTaskKey"),
+  contextWakeReason: sql<string | null>`${heartbeatRuns.contextSnapshot} ->> 'wakeReason'`.as("contextWakeReason"),
+  issueId: issues.id,
+  issueIdentifier: issues.identifier,
+  issueTitle: issues.title,
+  issueStatus: issues.status,
+} as const;
+
+type HeartbeatRunFailureClass =
+  | "none"
+  | "adapter"
+  | "configuration"
+  | "provider_quota"
+  | "workspace"
+  | "timeout"
+  | "cancelled"
+  | "interrupted"
+  | "runtime_process"
+  | "responsible_user"
+  | "unknown";
+
+function classifySafeHeartbeatRunFailure(input: {
+  status: string;
+  errorCode: string | null;
+  signal: string | null;
+}): { failureClass: HeartbeatRunFailureClass; safeReasonSummary: string | null } {
+  if (input.status === "succeeded") return { failureClass: "none", safeReasonSummary: null };
+  if (input.status === "cancelled") {
+    return { failureClass: "cancelled", safeReasonSummary: "Run was cancelled." };
+  }
+  if (input.status === "interrupted") {
+    return { failureClass: "interrupted", safeReasonSummary: "Run was interrupted." };
+  }
+  if (input.status === "timed_out") {
+    return { failureClass: "timeout", safeReasonSummary: "Run timed out." };
+  }
+  if (!["failed", "cancelled", "interrupted", "timed_out"].includes(input.status)) {
+    return { failureClass: "none", safeReasonSummary: null };
+  }
+
+  const code = input.errorCode?.trim() || null;
+  if (!code) {
+    return {
+      failureClass: "unknown",
+      safeReasonSummary: `Run ended with status ${input.status}; no safe error code was recorded.`,
+    };
+  }
+
+  if (code.includes("quota") || code.includes("rate_limit")) {
+    return { failureClass: "provider_quota", safeReasonSummary: `Run failed with safe error code ${code}.` };
+  }
+  if (code.includes("workspace")) {
+    return { failureClass: "workspace", safeReasonSummary: `Run failed with safe error code ${code}.` };
+  }
+  if (code.includes("timeout") || code === "max_turns_exhausted") {
+    return { failureClass: "timeout", safeReasonSummary: `Run failed with safe error code ${code}.` };
+  }
+  if (code.includes("configuration") || code.includes("credential") || code.includes("missing")) {
+    return { failureClass: "configuration", safeReasonSummary: `Run failed with safe error code ${code}.` };
+  }
+  if (code.includes("responsible_user")) {
+    return { failureClass: "responsible_user", safeReasonSummary: `Run failed with safe error code ${code}.` };
+  }
+  if (code.includes("process") || code.includes("shutdown") || input.signal) {
+    return { failureClass: "runtime_process", safeReasonSummary: `Run failed with safe error code ${code}.` };
+  }
+  if (code.includes("adapter") || code.includes("setup")) {
+    return { failureClass: "adapter", safeReasonSummary: `Run failed with safe error code ${code}.` };
+  }
+
+  return { failureClass: "unknown", safeReasonSummary: `Run failed with safe error code ${code}.` };
+}
+
 function appendExcerpt(prev: string, chunk: string) {
   return appendWithByteCap(prev, chunk, MAX_EXCERPT_BYTES);
 }
@@ -16737,6 +16833,92 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
                 costUsd: resultCostUsd,
                 costUsdCamel: resultCostUsdCamel,
               }),
+        };
+      });
+    },
+
+    listRunDetails: async (
+      companyId: string,
+      options: {
+        start: Date;
+        end: Date;
+        agentId?: string | null;
+        status?: string | null;
+        limit?: number;
+      },
+    ) => {
+      const runWindowAt = sql<Date>`coalesce(${heartbeatRuns.startedAt}, ${heartbeatRuns.createdAt})`;
+      const conditions = [
+        eq(heartbeatRuns.companyId, companyId),
+        sql`${runWindowAt} >= ${options.start.toISOString()}::timestamptz`,
+        sql`${runWindowAt} < ${options.end.toISOString()}::timestamptz`,
+      ];
+      if (options.agentId) conditions.push(eq(heartbeatRuns.agentId, options.agentId));
+      if (options.status) conditions.push(eq(heartbeatRuns.status, options.status));
+
+      const rows = await db
+        .select(heartbeatRunDetailColumns)
+        .from(heartbeatRuns)
+        .innerJoin(agents, eq(heartbeatRuns.agentId, agents.id))
+        .leftJoin(
+          issues,
+          and(
+            eq(issues.companyId, heartbeatRuns.companyId),
+            sql`cast(${issues.id} as text) = coalesce(
+              nullif(${heartbeatRuns.contextSnapshot} ->> 'issueId', ''),
+              nullif(${heartbeatRuns.contextSnapshot} ->> 'taskId', '')
+            )`,
+          ),
+        )
+        .where(and(...conditions))
+        .orderBy(desc(runWindowAt), desc(heartbeatRuns.createdAt), desc(heartbeatRuns.id))
+        .limit(Math.max(1, Math.min(1000, options.limit ?? 200)));
+
+      return rows.map((row) => {
+        const startedAt = row.startedAt ?? row.createdAt;
+        const endedAt = row.finishedAt ?? null;
+        const durationMs = endedAt && startedAt ? Math.max(0, endedAt.getTime() - startedAt.getTime()) : null;
+        const failure = classifySafeHeartbeatRunFailure({
+          status: row.status,
+          errorCode: row.errorCode,
+          signal: row.signal,
+        });
+        const linkedEntityId = row.contextIssueId ?? row.contextTaskId ?? row.contextTaskKey ?? null;
+
+        return {
+          id: row.id,
+          companyId: row.companyId,
+          agent: {
+            id: row.agentId,
+            name: row.agentName,
+            role: row.agentRole,
+            title: row.agentTitle,
+            status: row.agentStatus,
+            adapterType: row.adapterType,
+          },
+          linkedEntityId,
+          linkedIssue: row.issueId
+            ? {
+                id: row.issueId,
+                identifier: row.issueIdentifier,
+                title: row.issueTitle,
+                status: row.issueStatus,
+              }
+            : null,
+          status: row.status,
+          startedAt: row.startedAt,
+          endedAt,
+          createdAt: row.createdAt,
+          updatedAt: row.updatedAt,
+          durationMs,
+          invocationSource: row.invocationSource,
+          triggerDetail: row.triggerDetail,
+          wakeReason: row.contextWakeReason,
+          livenessState: row.livenessState,
+          livenessReason: row.livenessReason,
+          exitCode: row.exitCode,
+          signal: row.signal,
+          failure,
         };
       });
     },

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -16890,7 +16890,6 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
 
         return {
           id: row.id,
-          companyId: row.companyId,
           agent: {
             id: row.agentId,
             name: row.agentName,
@@ -16914,14 +16913,8 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           createdAt: row.createdAt,
           updatedAt: row.updatedAt,
           durationMs,
-          invocationSource: row.invocationSource,
-          triggerDetail: row.triggerDetail,
-          wakeReason: row.contextWakeReason,
-          livenessState: row.livenessState,
-          livenessReason: row.livenessReason,
-          exitCode: row.exitCode,
-          signal: row.signal,
-          failure,
+          failureClass: failure.failureClass,
+          safeReasonSummary: failure.safeReasonSummary,
         };
       });
     },


### PR DESCRIPTION
## Thinking Path

> - This app is a control plane for coordinating AI workers and their task runs.
> - The heartbeat run API is the subsystem involved.
> - Operators can list runs, but troubleshooting a selected run needs a narrower read-only details endpoint.
> - The endpoint must expose only safe metadata and reject malformed windows with typed client errors.
> - This pull request adds that route and service support with focused coverage.
> - The benefit is safer drill-down without exposing raw execution logs or sensitive run payloads.

## Linked Issues or Issue Description

### What happened?

Callers that need safe details for a selected heartbeat-run time window currently have no company-scoped read-only route, so the request returns `404` instead of a safe detail payload or typed validation error.

### Expected behavior

Valid requests should return run id, status, timestamps, duration, safe agent metadata, linked issue metadata, linked entity id, and safe failure classification only. Malformed or missing window parameters should return `400`.

### Steps to reproduce

1. Start the server.
2. Call `GET /api/companies/{companyId}/heartbeat-runs/details` with a valid `start` and `end` window.
3. Repeat with a malformed `start` value.

### Paperclip version or commit

Current `master` before this branch.

### Deployment mode

Self-hosted server or local dev.

### Additional context

This is not adapter-specific and does not require raw logs, tokens, secrets, or customer content to reproduce.

## What Changed

- Added a company-scoped heartbeat run details route with strict start/end/limit/status validation.
- Added safe failure classification and summary fields while keeping raw logs and payload data out of the response.
- Documented the new route in the generated OpenAPI registry.
- Added focused server tests for valid, filtered, invalid, and signal-terminated cases.

## Verification

- `pnpm vitest run server/src/__tests__/agent-live-run-routes.test.ts server/src/__tests__/heartbeat-list.test.ts server/src/__tests__/openapi-routes.test.ts`
- Result: 3 files passed, 21 tests passed.

## Risks

- Low migration risk: no schema changes.
- Main risk is response-shape drift for callers; covered by focused route tests.
- The endpoint is read-only and keeps raw log fields out of the response.

## Model Used

- OpenAI GPT-5 Codex, tool-enabled coding agent session.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above when applicable
- [x] I have either linked existing public issues or described the issue in-PR
- [x] I have not referenced internal instance-local issues or links
- [x] My branch name describes the change and contains no internal ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All CI gates are green
- [ ] Automated review is clear with no open high-priority findings
- [ ] I will address reviewer comments before requesting merge
