### PR TITLE
feat(server): make agent hires durably idempotent

### DIFF
--- a/docs/api/agents.md
+++ b/docs/api/agents.md
@@ -67,6 +67,41 @@ POST /api/companies/{companyId}/agents
 }
 ```
 
+## Hire Agent Safely
+
+```
+POST /api/companies/{companyId}/agent-hires
+Idempotency-Key: <caller-generated-key>
+```
+
+Send a stable `Idempotency-Key` for every logical hire and reuse it when a
+request times out or disconnects. Keys are scoped to the company and
+authenticated user or agent. Concurrent submissions with the same scoped key
+create at most one agent. Reusing a key with a different request body returns
+`422`.
+
+The operation is persisted before skill resolution, configuration
+normalization, agent creation, instruction materialization, approvals, grants,
+or activity logging. If the operation completes within the request budget, the
+route returns `201` with `{ "agent": ..., "approval": ... }`. Otherwise it
+returns `202`:
+
+```json
+{
+  "operationId": "8ebf4f8e-5b12-4c38-8557-efaf22960dc8",
+  "status": "pending",
+  "stage": "config_normalization",
+  "statusUrl": "/api/companies/company-1/agent-hire-operations/8ebf4f8e-5b12-4c38-8557-efaf22960dc8"
+}
+```
+
+Query `statusUrl` as the same authenticated principal. It returns
+`pending`, `succeeded`, or `failed`, coarse per-stage timings, and either the
+redacted completed hire response or bounded error metadata. Operation records
+store only a request hash; raw request payloads and credentials are not stored.
+A same-key replay after completion returns the original response with
+`Idempotency-Key-Replay: true`.
+
 ## Update Agent
 
 ```

--- a/docs/api/agents.md
+++ b/docs/api/agents.md
@@ -98,7 +98,8 @@ returns `202`:
 Query `statusUrl` as the same authenticated principal. It returns
 `pending`, `succeeded`, or `failed`, coarse per-stage timings, and either the
 redacted completed hire response or bounded error metadata. Operation records
-store only a request hash; raw request payloads and credentials are not stored.
+store only hashes of the idempotency key and request; raw keys, request payloads,
+and credentials are not stored.
 A same-key replay after completion returns the original response with
 `Idempotency-Key-Replay: true`.
 

--- a/packages/db/src/migrations/0182_durable-agent-hire-operations.sql
+++ b/packages/db/src/migrations/0182_durable-agent-hire-operations.sql
@@ -1,0 +1,34 @@
+CREATE TABLE IF NOT EXISTS "agent_hire_operations" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "company_id" uuid NOT NULL REFERENCES "companies"("id") ON DELETE CASCADE,
+  "principal_type" text NOT NULL,
+  "principal_id" text NOT NULL,
+  "idempotency_key" text NOT NULL,
+  "request_hash" text NOT NULL,
+  "status" text DEFAULT 'pending' NOT NULL,
+  "stage" text DEFAULT 'queued' NOT NULL,
+  "agent_id" uuid NOT NULL,
+  "response" jsonb,
+  "error" jsonb,
+  "stage_timings" jsonb DEFAULT '{}'::jsonb NOT NULL,
+  "lease_token" text,
+  "lease_expires_at" timestamp with time zone,
+  "attempt_count" integer DEFAULT 0 NOT NULL,
+  "started_at" timestamp with time zone,
+  "completed_at" timestamp with time zone,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+  CONSTRAINT "agent_hire_operations_status_check"
+    CHECK ("status" IN ('pending', 'succeeded', 'failed'))
+);--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "agent_hire_operations_scoped_key_uq"
+  ON "agent_hire_operations" USING btree (
+    "company_id",
+    "principal_type",
+    "principal_id",
+    "idempotency_key"
+  );--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "agent_hire_operations_company_operation_idx"
+  ON "agent_hire_operations" USING btree ("company_id", "id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "agent_hire_operations_pending_lease_idx"
+  ON "agent_hire_operations" USING btree ("status", "lease_expires_at");

--- a/packages/db/src/migrations/0182_durable-agent-hire-operations.sql
+++ b/packages/db/src/migrations/0182_durable-agent-hire-operations.sql
@@ -3,7 +3,7 @@ CREATE TABLE IF NOT EXISTS "agent_hire_operations" (
   "company_id" uuid NOT NULL REFERENCES "companies"("id") ON DELETE CASCADE,
   "principal_type" text NOT NULL,
   "principal_id" text NOT NULL,
-  "idempotency_key" text NOT NULL,
+  "idempotency_key_hash" text NOT NULL,
   "request_hash" text NOT NULL,
   "status" text DEFAULT 'pending' NOT NULL,
   "stage" text DEFAULT 'queued' NOT NULL,
@@ -26,7 +26,7 @@ CREATE UNIQUE INDEX IF NOT EXISTS "agent_hire_operations_scoped_key_uq"
     "company_id",
     "principal_type",
     "principal_id",
-    "idempotency_key"
+    "idempotency_key_hash"
   );--> statement-breakpoint
 CREATE INDEX IF NOT EXISTS "agent_hire_operations_company_operation_idx"
   ON "agent_hire_operations" USING btree ("company_id", "id");--> statement-breakpoint

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -1261,6 +1261,13 @@
       "when": 1784231633059,
       "tag": "0181_decision_training_retention_policy",
       "breakpoints": true
+    },
+    {
+      "idx": 182,
+      "version": "7",
+      "when": 1784346079489,
+      "tag": "0182_durable-agent-hire-operations",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/agent_hire_operations.ts
+++ b/packages/db/src/schema/agent_hire_operations.ts
@@ -28,7 +28,7 @@ export const agentHireOperations = pgTable(
     companyId: uuid("company_id").notNull().references(() => companies.id, { onDelete: "cascade" }),
     principalType: text("principal_type").notNull(),
     principalId: text("principal_id").notNull(),
-    idempotencyKey: text("idempotency_key").notNull(),
+    idempotencyKeyHash: text("idempotency_key_hash").notNull(),
     requestHash: text("request_hash").notNull(),
     status: text("status").notNull().default("pending"),
     stage: text("stage").notNull().default("queued"),
@@ -49,7 +49,7 @@ export const agentHireOperations = pgTable(
       table.companyId,
       table.principalType,
       table.principalId,
-      table.idempotencyKey,
+      table.idempotencyKeyHash,
     ),
     companyOperationIdx: index("agent_hire_operations_company_operation_idx").on(
       table.companyId,

--- a/packages/db/src/schema/agent_hire_operations.ts
+++ b/packages/db/src/schema/agent_hire_operations.ts
@@ -1,0 +1,63 @@
+import {
+  index,
+  integer,
+  jsonb,
+  pgTable,
+  text,
+  timestamp,
+  uniqueIndex,
+  uuid,
+} from "drizzle-orm/pg-core";
+import { companies } from "./companies.js";
+
+export type AgentHireOperationResponse = {
+  agent: Record<string, unknown>;
+  approval: Record<string, unknown> | null;
+};
+
+export type AgentHireOperationError = {
+  code: string;
+  message: string;
+  statusCode: number;
+};
+
+export const agentHireOperations = pgTable(
+  "agent_hire_operations",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    companyId: uuid("company_id").notNull().references(() => companies.id, { onDelete: "cascade" }),
+    principalType: text("principal_type").notNull(),
+    principalId: text("principal_id").notNull(),
+    idempotencyKey: text("idempotency_key").notNull(),
+    requestHash: text("request_hash").notNull(),
+    status: text("status").notNull().default("pending"),
+    stage: text("stage").notNull().default("queued"),
+    agentId: uuid("agent_id").notNull(),
+    response: jsonb("response").$type<AgentHireOperationResponse>(),
+    error: jsonb("error").$type<AgentHireOperationError>(),
+    stageTimings: jsonb("stage_timings").$type<Record<string, number>>().notNull().default({}),
+    leaseToken: text("lease_token"),
+    leaseExpiresAt: timestamp("lease_expires_at", { withTimezone: true }),
+    attemptCount: integer("attempt_count").notNull().default(0),
+    startedAt: timestamp("started_at", { withTimezone: true }),
+    completedAt: timestamp("completed_at", { withTimezone: true }),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    scopedKeyIdx: uniqueIndex("agent_hire_operations_scoped_key_uq").on(
+      table.companyId,
+      table.principalType,
+      table.principalId,
+      table.idempotencyKey,
+    ),
+    companyOperationIdx: index("agent_hire_operations_company_operation_idx").on(
+      table.companyId,
+      table.id,
+    ),
+    pendingLeaseIdx: index("agent_hire_operations_pending_lease_idx").on(
+      table.status,
+      table.leaseExpiresAt,
+    ),
+  }),
+);

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -6,6 +6,11 @@ export { cloudUpstreamConnections, cloudUpstreamRuns } from "./cloud_upstreams.j
 export { instanceUserRoles } from "./instance_user_roles.js";
 export { userSidebarPreferences } from "./user_sidebar_preferences.js";
 export { agents } from "./agents.js";
+export {
+  agentHireOperations,
+  type AgentHireOperationError,
+  type AgentHireOperationResponse,
+} from "./agent_hire_operations.js";
 export { builtInManagedResources } from "./built_in_managed_resources.js";
 export { agentMemberships } from "./agent_memberships.js";
 export { boardApiKeys } from "./board_api_keys.js";

--- a/server/src/__tests__/agent-hire-idempotency-routes.test.ts
+++ b/server/src/__tests__/agent-hire-idempotency-routes.test.ts
@@ -1,0 +1,123 @@
+import express from "express";
+import request from "supertest";
+import { randomUUID } from "node:crypto";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import {
+  agentHireOperations,
+  agents,
+  companies,
+  createDb,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import { actorMiddleware } from "../middleware/auth.js";
+import { errorHandler } from "../middleware/index.js";
+import { agentRoutes } from "../routes/agents.js";
+
+vi.mock("acpx/runtime", () => ({
+  createAcpRuntime: vi.fn(),
+  createAgentRegistry: vi.fn(),
+  createRuntimeStore: vi.fn(),
+  isAcpRuntimeError: vi.fn(() => false),
+}));
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+describeEmbeddedPostgres("agent hire idempotency routes", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+  let companyId: string;
+  const previousBudget = process.env.PAPERCLIP_AGENT_HIRE_REQUEST_BUDGET_MS;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-agent-hire-idempotency-routes-");
+    db = createDb(tempDb.connectionString);
+    companyId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `R${companyId.replace(/-/g, "").slice(0, 5).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    process.env.PAPERCLIP_AGENT_HIRE_REQUEST_BUDGET_MS = "0";
+  }, 20_000);
+
+  afterAll(async () => {
+    if (previousBudget === undefined) delete process.env.PAPERCLIP_AGENT_HIRE_REQUEST_BUDGET_MS;
+    else process.env.PAPERCLIP_AGENT_HIRE_REQUEST_BUDGET_MS = previousBudget;
+    await tempDb?.cleanup();
+  });
+
+  function createApp() {
+    const app = express();
+    app.use(express.json());
+    app.use(actorMiddleware(db, { deploymentMode: "local_trusted" }));
+    app.use("/api", agentRoutes(db));
+    app.use(errorHandler);
+    return app;
+  }
+
+  it("returns a queryable 202, creates one agent concurrently, and replays the result", async () => {
+    const app = createApp();
+    const key = "route-concurrent-hire";
+    const payload = {
+      name: "Durable Builder",
+      role: "engineer",
+      adapterType: "process",
+      adapterConfig: {},
+    };
+
+    const responses = await Promise.all([
+      request(app)
+        .post(`/api/companies/${companyId}/agent-hires`)
+        .set("Idempotency-Key", key)
+        .send(payload),
+      request(app)
+        .post(`/api/companies/${companyId}/agent-hires`)
+        .set("Idempotency-Key", key)
+        .send(payload),
+    ]);
+    expect(responses.every((response) => response.status === 201 || response.status === 202)).toBe(true);
+
+    const [operation] = await db.select().from(agentHireOperations);
+    expect(operation).toBeDefined();
+    let statusResponse = await request(app)
+      .get(`/api/companies/${companyId}/agent-hire-operations/${operation!.id}`)
+      .expect(200);
+    for (let attempt = 0; statusResponse.body.status === "pending" && attempt < 100; attempt += 1) {
+      await new Promise((resolve) => setTimeout(resolve, 25));
+      statusResponse = await request(app)
+        .get(`/api/companies/${companyId}/agent-hire-operations/${operation!.id}`)
+        .expect(200);
+    }
+    expect(statusResponse.body.status).toBe("succeeded");
+    expect(statusResponse.body.stageTimings).toEqual(expect.objectContaining({
+      desired_skill_resolution: expect.any(Number),
+      config_normalization: expect.any(Number),
+      agent_creation: expect.any(Number),
+      instruction_materialization: expect.any(Number),
+      approval_linking: expect.any(Number),
+      grants: expect.any(Number),
+      activity_logging: expect.any(Number),
+    }));
+
+    const replay = await request(app)
+      .post(`/api/companies/${companyId}/agent-hires`)
+      .set("Idempotency-Key", key)
+      .send(payload)
+      .expect(201);
+    expect(replay.headers["idempotency-key-replay"]).toBe("true");
+    expect(replay.body.agent.id).toBe(operation!.agentId);
+    expect(await db.select().from(agents)).toHaveLength(1);
+
+    const mismatch = await request(app)
+      .post(`/api/companies/${companyId}/agent-hires`)
+      .set("Idempotency-Key", key)
+      .send({ ...payload, name: "Different Builder" })
+      .expect(422);
+    expect(mismatch.body.details?.code).toBe("idempotency_key_payload_mismatch");
+  }, 20_000);
+});

--- a/server/src/__tests__/agent-hire-operations.test.ts
+++ b/server/src/__tests__/agent-hire-operations.test.ts
@@ -177,11 +177,12 @@ describeEmbeddedPostgres("durable agent hire operations", () => {
     const companyId = await seedCompany();
     const service = agentHireOperationService(db);
     const secret = "sk-test-never-store";
+    const idempotencyKey = `hire-secret-${randomUUID()}`;
     const reservation = await service.reserve({
       companyId,
       principalType: "user",
       principalId: "board-user",
-      idempotencyKey: "hire-secret",
+      idempotencyKey,
       requestHash: hashAgentHireRequest({
         name: "Builder",
         adapterConfig: { apiKey: secret },
@@ -199,6 +200,8 @@ describeEmbeddedPostgres("durable agent hire operations", () => {
     const stored = await service.getById(reservation.operation.id);
     const serialized = JSON.stringify(stored);
     expect(serialized.includes(secret)).toBe(false);
+    expect(serialized.includes(idempotencyKey)).toBe(false);
+    expect(stored?.idempotencyKeyHash).toMatch(/^[a-f0-9]{64}$/);
     expect(serialized).toContain("***REDACTED***");
     expect(stored).not.toHaveProperty("requestPayload");
   });

--- a/server/src/__tests__/agent-hire-operations.test.ts
+++ b/server/src/__tests__/agent-hire-operations.test.ts
@@ -1,0 +1,205 @@
+import { randomUUID } from "node:crypto";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import {
+  agentHireOperations,
+  agents,
+  companies,
+  createDb,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import {
+  AgentHireIdempotencyConflictError,
+  agentHireOperationService,
+  hashAgentHireRequest,
+} from "../services/agent-hire-operations.js";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+describeEmbeddedPostgres("durable agent hire operations", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-agent-hire-operations-");
+    db = createDb(tempDb.connectionString);
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.delete(agentHireOperations);
+    await db.delete(agents);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  async function seedCompany(name = "Paperclip") {
+    const id = randomUUID();
+    await db.insert(companies).values({
+      id,
+      name,
+      issuePrefix: `H${id.replace(/-/g, "").slice(0, 5).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    return id;
+  }
+
+  it("allows only one concurrent worker and one agent for a scoped key", async () => {
+    const companyId = await seedCompany();
+    const service = agentHireOperationService(db);
+    const input = {
+      companyId,
+      principalType: "user" as const,
+      principalId: "board-user",
+      idempotencyKey: "hire-concurrent",
+      requestHash: hashAgentHireRequest({ name: "Builder", adapterConfig: {} }),
+    };
+
+    const reservations = await Promise.all(
+      Array.from({ length: 8 }, () => service.reserve(input)),
+    );
+    expect(new Set(reservations.map(({ operation }) => operation.id))).toHaveLength(1);
+
+    const operationId = reservations[0]!.operation.id;
+    const claims = await Promise.all(
+      Array.from({ length: 8 }, () => service.claim(operationId)),
+    );
+    const winners = claims.filter((claim) => claim !== null);
+    expect(winners).toHaveLength(1);
+
+    const winner = winners[0]!;
+    await db.insert(agents).values({
+      id: winner.operation.agentId,
+      companyId,
+      name: "Builder",
+      role: "engineer",
+      adapterType: "process",
+      adapterConfig: {},
+      runtimeConfig: {},
+    });
+    await service.succeed(operationId, winner.leaseToken, {
+      agent: { id: winner.operation.agentId, name: "Builder" },
+      approval: null,
+    });
+
+    expect(await db.select().from(agents)).toHaveLength(1);
+    expect((await service.getById(operationId))?.status).toBe("succeeded");
+  });
+
+  it("queries a bounded pending operation to completion and replays its result", async () => {
+    const companyId = await seedCompany();
+    const service = agentHireOperationService(db);
+    const input = {
+      companyId,
+      principalType: "user" as const,
+      principalId: "board-user",
+      idempotencyKey: "hire-timeout",
+      requestHash: hashAgentHireRequest({ name: "Slow Builder" }),
+    };
+    const reservation = await service.reserve(input);
+    const claim = await service.claim(reservation.operation.id);
+    expect(claim).not.toBeNull();
+
+    const completion = new Promise<void>((resolve) => {
+      setTimeout(() => {
+        void service.succeed(reservation.operation.id, claim!.leaseToken, {
+          agent: { id: claim!.operation.agentId, name: "Slow Builder" },
+          approval: null,
+        }).then(() => resolve());
+      }, 20);
+    });
+
+    expect((await service.waitForTerminal(reservation.operation.id, 0))?.status).toBe("pending");
+    const completed = await service.waitForTerminal(reservation.operation.id, 1_000);
+    await completion;
+    expect(completed?.status).toBe("succeeded");
+
+    const replay = await service.reserve(input);
+    expect(replay.created).toBe(false);
+    expect(replay.operation.id).toBe(reservation.operation.id);
+    expect(replay.operation.response).toEqual(completed?.response);
+  });
+
+  it("rejects a materially different payload for the same scoped key", async () => {
+    const companyId = await seedCompany();
+    const service = agentHireOperationService(db);
+    const scope = {
+      companyId,
+      principalType: "user" as const,
+      principalId: "board-user",
+      idempotencyKey: "hire-mismatch",
+    };
+    await service.reserve({ ...scope, requestHash: hashAgentHireRequest({ name: "Builder" }) });
+
+    await expect(
+      service.reserve({ ...scope, requestHash: hashAgentHireRequest({ name: "Different" }) }),
+    ).rejects.toBeInstanceOf(AgentHireIdempotencyConflictError);
+  });
+
+  it("isolates identical keys by company and authenticated principal", async () => {
+    const firstCompanyId = await seedCompany("First");
+    const secondCompanyId = await seedCompany("Second");
+    const service = agentHireOperationService(db);
+    const common = {
+      idempotencyKey: "shared-key",
+      requestHash: hashAgentHireRequest({ name: "Builder" }),
+    };
+    const reservations = await Promise.all([
+      service.reserve({
+        ...common,
+        companyId: firstCompanyId,
+        principalType: "user",
+        principalId: "user-a",
+      }),
+      service.reserve({
+        ...common,
+        companyId: firstCompanyId,
+        principalType: "agent",
+        principalId: randomUUID(),
+      }),
+      service.reserve({
+        ...common,
+        companyId: secondCompanyId,
+        principalType: "user",
+        principalId: "user-a",
+      }),
+    ]);
+
+    expect(new Set(reservations.map(({ operation }) => operation.id))).toHaveLength(3);
+  });
+
+  it("never persists raw credentials in operation payloads or results", async () => {
+    const companyId = await seedCompany();
+    const service = agentHireOperationService(db);
+    const secret = "sk-test-never-store";
+    const reservation = await service.reserve({
+      companyId,
+      principalType: "user",
+      principalId: "board-user",
+      idempotencyKey: "hire-secret",
+      requestHash: hashAgentHireRequest({
+        name: "Builder",
+        adapterConfig: { apiKey: secret },
+      }),
+    });
+    const claim = await service.claim(reservation.operation.id);
+    await service.succeed(reservation.operation.id, claim!.leaseToken, {
+      agent: {
+        id: claim!.operation.agentId,
+        adapterConfig: { apiKey: secret, nested: { accessToken: secret } },
+      },
+      approval: { payload: { credential: secret } },
+    });
+
+    const stored = await service.getById(reservation.operation.id);
+    const serialized = JSON.stringify(stored);
+    expect(serialized.includes(secret)).toBe(false);
+    expect(serialized).toContain("***REDACTED***");
+    expect(stored).not.toHaveProperty("requestPayload");
+  });
+});

--- a/server/src/__tests__/agent-hire-operations.test.ts
+++ b/server/src/__tests__/agent-hire-operations.test.ts
@@ -11,6 +11,7 @@ import {
   startEmbeddedPostgresTestDatabase,
 } from "./helpers/embedded-postgres.js";
 import {
+  AGENT_HIRE_TERMINAL_POLL_INTERVAL_MS,
   AgentHireIdempotencyConflictError,
   agentHireOperationService,
   hashAgentHireRequest,
@@ -92,6 +93,7 @@ describeEmbeddedPostgres("durable agent hire operations", () => {
   });
 
   it("queries a bounded pending operation to completion and replays its result", async () => {
+    expect(AGENT_HIRE_TERMINAL_POLL_INTERVAL_MS).toBeGreaterThanOrEqual(100);
     const companyId = await seedCompany();
     const service = agentHireOperationService(db);
     const input = {
@@ -111,7 +113,7 @@ describeEmbeddedPostgres("durable agent hire operations", () => {
           agent: { id: claim!.operation.agentId, name: "Slow Builder" },
           approval: null,
         }).then(() => resolve());
-      }, 20);
+      }, AGENT_HIRE_TERMINAL_POLL_INTERVAL_MS + 20);
     });
 
     expect((await service.waitForTerminal(reservation.operation.id, 0))?.status).toBe("pending");

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -53,6 +53,12 @@ import {
   syncInstructionsBundleConfigFromFilePath,
   workspaceOperationService,
 } from "../services/index.js";
+import {
+  agentHireOperationService,
+  AgentHireIdempotencyConflictError,
+  hashAgentHireRequest,
+  publicAgentHireOperation,
+} from "../services/agent-hire-operations.js";
 import { conflict, forbidden, HttpError, notFound, unprocessable } from "../errors.js";
 import { assertBoard, assertCompanyAccess, assertInstanceAdmin, getAccessibleResource, getActorInfo, hasCompanyAccess } from "./authz.js";
 import {
@@ -114,6 +120,28 @@ import {
 
 const RUN_LOG_DEFAULT_LIMIT_BYTES = 256_000;
 const RUN_LOG_MAX_LIMIT_BYTES = 1024 * 1024;
+const AGENT_HIRE_IDEMPOTENCY_KEY_MAX_LENGTH = 255;
+const DEFAULT_AGENT_HIRE_REQUEST_BUDGET_MS = 5_000;
+
+function parseAgentHireIdempotencyKey(req: Request) {
+  const value = req.get("Idempotency-Key");
+  if (value === undefined) return null;
+  if (
+    value.length === 0 ||
+    value.length > AGENT_HIRE_IDEMPOTENCY_KEY_MAX_LENGTH ||
+    value !== value.trim() ||
+    !/^[\x21-\x7E]+$/.test(value)
+  ) {
+    throw unprocessable("Idempotency-Key must be 1-255 visible ASCII characters without surrounding whitespace");
+  }
+  return value;
+}
+
+function agentHireRequestBudgetMs() {
+  const configured = Number(process.env.PAPERCLIP_AGENT_HIRE_REQUEST_BUDGET_MS);
+  if (!Number.isFinite(configured)) return DEFAULT_AGENT_HIRE_REQUEST_BUDGET_MS;
+  return Math.max(0, Math.min(30_000, Math.trunc(configured)));
+}
 
 function readRunLogLimitBytes(value: unknown) {
   const parsed = Number(value ?? RUN_LOG_DEFAULT_LIMIT_BYTES);
@@ -180,6 +208,7 @@ export function agentRoutes(
 
   const router = Router();
   const svc = agentService(db);
+  const agentHireOperations = agentHireOperationService(db);
   const access = accessService(db);
   const approvalsSvc = approvalService(db);
   const budgets = budgetService(db);
@@ -2342,7 +2371,28 @@ export function agentRoutes(
   router.post("/companies/:companyId/agent-hires", validate(createAgentHireSchema), async (req, res) => {
     const companyId = req.params.companyId as string;
     await assertCanCreateAgentsForCompany(req, companyId);
-    const sourceIssueIds = parseSourceIssueIds(req.body);
+    const idempotencyKey = parseAgentHireIdempotencyKey(req);
+    const actor = getActorInfo(req);
+
+    const performAgentHire = async (
+      reservedAgentId?: string,
+      operationLease?: { id: string; leaseToken: string },
+    ) => {
+      async function timeHireStage<T>(stage: string, work: () => Promise<T>): Promise<T> {
+        const startedAt = Date.now();
+        const result = await work();
+        if (operationLease) {
+          await agentHireOperations.recordStage(
+            operationLease.id,
+            operationLease.leaseToken,
+            stage,
+            Date.now() - startedAt,
+          );
+        }
+        return result;
+      }
+
+      const sourceIssueIds = parseSourceIssueIds(req.body);
     const {
       desiredSkills: requestedDesiredSkills,
       instructionsBundle,
@@ -2358,7 +2408,7 @@ export function agentRoutes(
     );
     assertNoAgentAdapterConfigMutation(req, rawHireAdapterConfig);
     assertNoAgentRuntimeConfigAdapterConfigMutation(req, hireInput.runtimeConfig);
-    const hiredAgentId = randomUUID();
+    const hiredAgentId = reservedAgentId ?? randomUUID();
     const requestedAdapterConfig = applyCodexLocalKeyIsolation(
       companyId,
       hiredAgentId,
@@ -2368,22 +2418,34 @@ export function agentRoutes(
         rawHireAdapterConfig,
       ),
     );
-    const desiredSkillAssignment = await resolveDesiredSkillAssignment(
-      companyId,
-      hireInput.adapterType,
-      requestedAdapterConfig,
-      normalizeDesiredSkillSelections(Array.isArray(requestedDesiredSkills) ? requestedDesiredSkills : undefined),
+    const desiredSkillAssignment = await timeHireStage(
+      "desired_skill_resolution",
+      () => resolveDesiredSkillAssignment(
+        companyId,
+        hireInput.adapterType,
+        requestedAdapterConfig,
+        normalizeDesiredSkillSelections(Array.isArray(requestedDesiredSkills) ? requestedDesiredSkills : undefined),
+      ),
     );
-    const normalizedAdapterConfig = await normalizeMediatedAdapterConfigForPersistence({
-      companyId,
-      adapterType: hireInput.adapterType,
-      adapterConfig: desiredSkillAssignment.adapterConfig,
-    });
-    const normalizedRuntimeConfig = await normalizeRuntimeConfigAdapterConfigsForPersistence(
-      companyId,
-      hireInput.adapterType,
-      normalizeNewAgentRuntimeConfig(hireInput.runtimeConfig),
-      normalizedAdapterConfig,
+    const { normalizedAdapterConfig, normalizedRuntimeConfig } = await timeHireStage(
+      "config_normalization",
+      async () => {
+        const adapterConfig = await normalizeMediatedAdapterConfigForPersistence({
+          companyId,
+          adapterType: hireInput.adapterType,
+          adapterConfig: desiredSkillAssignment.adapterConfig,
+        });
+        const runtimeConfig = await normalizeRuntimeConfigAdapterConfigsForPersistence(
+          companyId,
+          hireInput.adapterType,
+          normalizeNewAgentRuntimeConfig(hireInput.runtimeConfig),
+          adapterConfig,
+        );
+        return {
+          normalizedAdapterConfig: adapterConfig,
+          normalizedRuntimeConfig: runtimeConfig,
+        };
+      },
     );
     const normalizedHireInput = {
       ...hireInput,
@@ -2397,25 +2459,36 @@ export function agentRoutes(
       .where(eq(companies.id, companyId))
       .then((rows) => rows[0] ?? null);
     if (!company) {
-      res.status(404).json({ error: "Company not found" });
-      return;
+      throw notFound("Company not found");
     }
 
     const requiresApproval = company.requireBoardApprovalForNewAgents;
     const status = requiresApproval ? "pending_approval" : "idle";
-    const createdAgent = await svc.create(companyId, {
-      id: hiredAgentId,
-      ...normalizedHireInput,
-      status,
-      spentMonthlyCents: 0,
-      lastHeartbeatAt: null,
+    const createdAgent = await timeHireStage("agent_creation", async () => {
+      const existing = reservedAgentId ? await svc.getById(hiredAgentId) : null;
+      if (existing) {
+        if (existing.companyId !== companyId) throw conflict("Reserved agent id belongs to another company");
+        return existing;
+      }
+      return svc.create(companyId, {
+        id: hiredAgentId,
+        ...normalizedHireInput,
+        status,
+        spentMonthlyCents: 0,
+        lastHeartbeatAt: null,
+      });
     });
-    const agent = await materializeDefaultInstructionsBundleForNewAgent(createdAgent, instructionsBundle);
+    const agent = await timeHireStage(
+      "instruction_materialization",
+      () => materializeDefaultInstructionsBundleForNewAgent(createdAgent, instructionsBundle),
+    );
 
-    let approval: Awaited<ReturnType<typeof approvalsSvc.getById>> | null = null;
-    const actor = getActorInfo(req);
-
-    if (requiresApproval) {
+    const approval = await timeHireStage("approval_linking", async () => {
+      if (!requiresApproval) return null;
+      const existingApproval = reservedAgentId
+        ? await approvalsSvc.findOpenHireApprovalForAgent(companyId, agent.id)
+        : null;
+      if (existingApproval) return existingApproval;
       const requestedAdapterType = normalizedHireInput.adapterType ?? agent.adapterType;
       const requestedAdapterConfig =
         redactEventPayload(
@@ -2429,7 +2502,7 @@ export function agentRoutes(
         redactEventPayload(
           ((normalizedHireInput.metadata ?? agent.metadata ?? {}) as Record<string, unknown>),
         ) ?? {};
-      approval = await approvalsSvc.create(companyId, {
+      const createdApproval = await approvalsSvc.create(companyId, {
         type: "hire_agent",
         requestedByAgentId: actor.actorType === "agent" ? actor.actorId : null,
         requestedByUserId: actor.actorType === "user" ? actor.actorId : null,
@@ -2466,14 +2539,15 @@ export function agentRoutes(
       });
 
       if (sourceIssueIds.length > 0) {
-        await issueApprovalsSvc.linkManyForApproval(approval.id, sourceIssueIds, {
+        await issueApprovalsSvc.linkManyForApproval(createdApproval.id, sourceIssueIds, {
           agentId: actor.actorType === "agent" ? actor.actorId : null,
           userId: actor.actorType === "user" ? actor.actorId : null,
         });
       }
-    }
+      return createdApproval;
+    });
 
-    await logActivity(db, {
+    await timeHireStage("activity_logging", () => logActivity(db, {
       companyId,
       actorType: actor.actorType,
       actorId: actor.actorId,
@@ -2491,16 +2565,19 @@ export function agentRoutes(
         issueIds: sourceIssueIds,
         desiredSkills: desiredSkillAssignment.desiredSkills,
       },
-    });
+    }));
     const telemetryClient = getTelemetryClient();
     if (telemetryClient) {
       trackAgentCreated(telemetryClient, { agentRole: agent.role, agentId: agent.id });
     }
 
-    await applyDefaultAgentTaskAssignGrant(
-      companyId,
-      agent.id,
-      actor.actorType === "user" ? actor.actorId : null,
+    await timeHireStage(
+      "grants",
+      () => applyDefaultAgentTaskAssignGrant(
+        companyId,
+        agent.id,
+        actor.actorType === "user" ? actor.actorId : null,
+      ),
     );
 
     if (approval) {
@@ -2518,7 +2595,121 @@ export function agentRoutes(
       });
     }
 
-    res.status(201).json({ agent, approval });
+      return { agent, approval };
+    };
+
+    if (!idempotencyKey) {
+      const result = await performAgentHire();
+      res.status(201).json(result);
+      return;
+    }
+
+    const statusUrlFor = (operationId: string) =>
+      `/api/companies/${companyId}/agent-hire-operations/${operationId}`;
+    const sendOperation = (
+      operation: NonNullable<Awaited<ReturnType<typeof agentHireOperations.getById>>>,
+      replay: boolean,
+    ) => {
+      if (replay) res.setHeader("Idempotency-Key-Replay", "true");
+      if (operation.status === "succeeded" && operation.response) {
+        res.status(201).json(operation.response);
+        return;
+      }
+      if (operation.status === "failed") {
+        res.status(operation.error?.statusCode ?? 500).json({
+          operationId: operation.id,
+          status: "failed",
+          error: {
+            code: operation.error?.code ?? "agent_hire_failed",
+            message: operation.error?.message ?? "Agent hire failed",
+          },
+        });
+        return;
+      }
+      const statusUrl = statusUrlFor(operation.id);
+      res
+        .status(202)
+        .location(statusUrl)
+        .json({
+          operationId: operation.id,
+          status: "pending",
+          stage: operation.stage,
+          statusUrl,
+        });
+    };
+
+    let reservation: Awaited<ReturnType<typeof agentHireOperations.reserve>>;
+    try {
+      reservation = await agentHireOperations.reserve({
+        companyId,
+        principalType: actor.actorType,
+        principalId: actor.actorId,
+        idempotencyKey,
+        requestHash: hashAgentHireRequest(req.body),
+      });
+    } catch (error) {
+      if (error instanceof AgentHireIdempotencyConflictError) {
+        throw unprocessable(error.message, { code: "idempotency_key_payload_mismatch" });
+      }
+      throw error;
+    }
+
+    if (reservation.operation.status !== "pending") {
+      sendOperation(reservation.operation, !reservation.created);
+      return;
+    }
+
+    const claim = await agentHireOperations.claim(reservation.operation.id);
+    if (claim) {
+      void performAgentHire(claim.operation.agentId, {
+        id: claim.operation.id,
+        leaseToken: claim.leaseToken,
+      })
+        .then(async (result) => {
+          const publicResponse = redactEventPayload(result) as {
+            agent: Record<string, unknown>;
+            approval: Record<string, unknown> | null;
+          } | null | undefined;
+          if (!publicResponse) throw new Error("Failed to serialize agent hire response");
+          await agentHireOperations.succeed(claim.operation.id, claim.leaseToken, publicResponse);
+        })
+        .catch(async (error: unknown) => {
+          const statusCode = error instanceof HttpError ? error.status : 500;
+          const redacted = redactEventPayload({
+            message: error instanceof Error ? error.message : "Agent hire failed",
+          }) as { message?: unknown };
+          await agentHireOperations.fail(claim.operation.id, claim.leaseToken, {
+            code: error instanceof HttpError ? `http_${statusCode}` : "agent_hire_failed",
+            message: typeof redacted.message === "string" ? redacted.message : "Agent hire failed",
+            statusCode,
+          });
+        })
+        .catch(() => undefined);
+    }
+
+    const operation = await agentHireOperations.waitForTerminal(
+      reservation.operation.id,
+      agentHireRequestBudgetMs(),
+    );
+    if (!operation) throw new Error("Agent hire operation disappeared");
+    sendOperation(operation, !reservation.created);
+  });
+
+  router.get("/companies/:companyId/agent-hire-operations/:operationId", async (req, res) => {
+    const companyId = req.params.companyId as string;
+    assertCompanyAccess(req, companyId);
+    const actor = getActorInfo(req);
+    const operation = await agentHireOperations.getForPrincipal({
+      id: req.params.operationId as string,
+      companyId,
+      principalType: actor.actorType,
+      principalId: actor.actorId,
+    });
+    if (!operation) {
+      res.status(404).json({ error: "Agent hire operation not found" });
+      return;
+    }
+    res.json(publicAgentHireOperation(operation));
   });
 
   router.post("/companies/:companyId/agents", validate(createAgentSchema), async (req, res) => {

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -2373,6 +2373,12 @@ export function agentRoutes(
     await assertCanCreateAgentsForCompany(req, companyId);
     const idempotencyKey = parseAgentHireIdempotencyKey(req);
     const actor = getActorInfo(req);
+    const hireRequestBody = structuredClone(req.body);
+    const validatedAdapterType = assertKnownAdapterType(hireRequestBody.adapterType);
+    const preflightAdapterConfig = (hireRequestBody.adapterConfig ?? {}) as Record<string, unknown>;
+    assertNoNewAgentLegacyPromptTemplate(validatedAdapterType, preflightAdapterConfig);
+    assertNoAgentAdapterConfigMutation(req, preflightAdapterConfig);
+    assertNoAgentRuntimeConfigAdapterConfigMutation(req, hireRequestBody.runtimeConfig);
 
     const performAgentHire = async (
       reservedAgentId?: string,
@@ -2392,22 +2398,16 @@ export function agentRoutes(
         return result;
       }
 
-      const sourceIssueIds = parseSourceIssueIds(req.body);
+      const sourceIssueIds = parseSourceIssueIds(hireRequestBody);
     const {
       desiredSkills: requestedDesiredSkills,
       instructionsBundle,
       sourceIssueId: _sourceIssueId,
       sourceIssueIds: _sourceIssueIds,
       ...hireInput
-    } = req.body;
-    hireInput.adapterType = assertKnownAdapterType(hireInput.adapterType);
+    } = hireRequestBody;
+    hireInput.adapterType = validatedAdapterType;
     const rawHireAdapterConfig = (hireInput.adapterConfig ?? {}) as Record<string, unknown>;
-    assertNoNewAgentLegacyPromptTemplate(
-      hireInput.adapterType,
-      rawHireAdapterConfig,
-    );
-    assertNoAgentAdapterConfigMutation(req, rawHireAdapterConfig);
-    assertNoAgentRuntimeConfigAdapterConfigMutation(req, hireInput.runtimeConfig);
     const hiredAgentId = reservedAgentId ?? randomUUID();
     const requestedAdapterConfig = applyCodexLocalKeyIsolation(
       companyId,
@@ -2645,7 +2645,7 @@ export function agentRoutes(
         principalType: actor.actorType,
         principalId: actor.actorId,
         idempotencyKey,
-        requestHash: hashAgentHireRequest(req.body),
+        requestHash: hashAgentHireRequest(hireRequestBody),
       });
     } catch (error) {
       if (error instanceof AgentHireIdempotencyConflictError) {

--- a/server/src/routes/openapi.ts
+++ b/server/src/routes/openapi.ts
@@ -1459,7 +1459,24 @@ registry.registerPath({
     params: z.object({ companyId: z.string() }),
     body: jsonBody(createAgentHireSchema),
   },
-  responses: { 200: r.ok(), 400: r.badRequest, 401: r.unauthorized },
+  responses: {
+    201: r.ok(),
+    202: r.ok(),
+    400: r.badRequest,
+    401: r.unauthorized,
+    422: r.unprocessable,
+  },
+});
+
+registry.registerPath({
+  method: "get",
+  path: "/api/companies/{companyId}/agent-hire-operations/{operationId}",
+  tags: ["agents"],
+  summary: "Get a durable agent hire operation",
+  request: {
+    params: z.object({ companyId: z.string(), operationId: z.string().uuid() }),
+  },
+  responses: { 200: r.ok(), 401: r.unauthorized, 403: r.forbidden, 404: r.notFound },
 });
 
 registry.registerPath({

--- a/server/src/services/agent-hire-operations.ts
+++ b/server/src/services/agent-hire-operations.ts
@@ -9,6 +9,7 @@ import { and, eq, isNull, lt, or, sql } from "drizzle-orm";
 import { redactEventPayload, redactSensitiveText } from "../redaction.js";
 
 const DEFAULT_LEASE_MS = 15 * 60 * 1000;
+export const AGENT_HIRE_TERMINAL_POLL_INTERVAL_MS = 150;
 
 export class AgentHireIdempotencyConflictError extends Error {
   constructor() {
@@ -262,7 +263,10 @@ export function agentHireOperationService(db: Db) {
         const operation = await getById(id);
         if (!operation || operation.status !== "pending") return operation;
         if (Date.now() >= deadline) return operation;
-        await new Promise((resolve) => setTimeout(resolve, Math.min(25, Math.max(1, deadline - Date.now()))));
+        await new Promise((resolve) => setTimeout(
+          resolve,
+          Math.min(AGENT_HIRE_TERMINAL_POLL_INTERVAL_MS, Math.max(1, deadline - Date.now())),
+        ));
       } while (true);
     },
   };

--- a/server/src/services/agent-hire-operations.ts
+++ b/server/src/services/agent-hire-operations.ts
@@ -1,0 +1,255 @@
+import { createHash, randomUUID } from "node:crypto";
+import type { Db } from "@paperclipai/db";
+import {
+  agentHireOperations,
+  type AgentHireOperationError,
+  type AgentHireOperationResponse,
+} from "@paperclipai/db";
+import { and, eq, isNull, lt, or, sql } from "drizzle-orm";
+import { redactEventPayload, redactSensitiveText } from "../redaction.js";
+
+const DEFAULT_LEASE_MS = 15 * 60 * 1000;
+
+export class AgentHireIdempotencyConflictError extends Error {
+  constructor() {
+    super("Idempotency-Key was already used with a different agent hire payload");
+  }
+}
+
+function stableStringify(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map((entry) => stableStringify(entry)).join(",")}]`;
+  }
+  if (value && typeof value === "object") {
+    const record = value as Record<string, unknown>;
+    return `{${Object.keys(record)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${stableStringify(record[key])}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+export function hashAgentHireRequest(value: unknown): string {
+  return createHash("sha256").update(stableStringify(value)).digest("hex");
+}
+
+export type AgentHireOperation = typeof agentHireOperations.$inferSelect;
+
+export type PublicAgentHireOperation = Pick<
+  AgentHireOperation,
+  | "id"
+  | "status"
+  | "stage"
+  | "agentId"
+  | "response"
+  | "error"
+  | "stageTimings"
+  | "startedAt"
+  | "completedAt"
+  | "createdAt"
+  | "updatedAt"
+>;
+
+export function publicAgentHireOperation(operation: AgentHireOperation): PublicAgentHireOperation {
+  return {
+    id: operation.id,
+    status: operation.status,
+    stage: operation.stage,
+    agentId: operation.agentId,
+    response: operation.response,
+    error: operation.error,
+    stageTimings: operation.stageTimings,
+    startedAt: operation.startedAt,
+    completedAt: operation.completedAt,
+    createdAt: operation.createdAt,
+    updatedAt: operation.updatedAt,
+  };
+}
+
+export function agentHireOperationService(db: Db) {
+  async function getById(id: string) {
+    return db
+      .select()
+      .from(agentHireOperations)
+      .where(eq(agentHireOperations.id, id))
+      .then((rows) => rows[0] ?? null);
+  }
+
+  async function getScoped(input: {
+    companyId: string;
+    principalType: "agent" | "user";
+    principalId: string;
+    idempotencyKey: string;
+  }) {
+    return db
+      .select()
+      .from(agentHireOperations)
+      .where(and(
+        eq(agentHireOperations.companyId, input.companyId),
+        eq(agentHireOperations.principalType, input.principalType),
+        eq(agentHireOperations.principalId, input.principalId),
+        eq(agentHireOperations.idempotencyKey, input.idempotencyKey),
+      ))
+      .then((rows) => rows[0] ?? null);
+  }
+
+  return {
+    getById,
+
+    getForPrincipal: (input: {
+      id: string;
+      companyId: string;
+      principalType: "agent" | "user";
+      principalId: string;
+    }) =>
+      db
+        .select()
+        .from(agentHireOperations)
+        .where(and(
+          eq(agentHireOperations.id, input.id),
+          eq(agentHireOperations.companyId, input.companyId),
+          eq(agentHireOperations.principalType, input.principalType),
+          eq(agentHireOperations.principalId, input.principalId),
+        ))
+        .then((rows) => rows[0] ?? null),
+
+    reserve: async (input: {
+      companyId: string;
+      principalType: "agent" | "user";
+      principalId: string;
+      idempotencyKey: string;
+      requestHash: string;
+    }) => {
+      const inserted = await db
+        .insert(agentHireOperations)
+        .values({
+          ...input,
+          agentId: randomUUID(),
+        })
+        .onConflictDoNothing({
+          target: [
+            agentHireOperations.companyId,
+            agentHireOperations.principalType,
+            agentHireOperations.principalId,
+            agentHireOperations.idempotencyKey,
+          ],
+        })
+        .returning()
+        .then((rows) => rows[0] ?? null);
+      const operation = inserted ?? await getScoped(input);
+      if (!operation) throw new Error("Failed to reserve agent hire operation");
+      if (operation.requestHash !== input.requestHash) {
+        throw new AgentHireIdempotencyConflictError();
+      }
+      return { operation, created: Boolean(inserted) };
+    },
+
+    claim: async (id: string, leaseMs = DEFAULT_LEASE_MS) => {
+      const now = new Date();
+      const leaseToken = randomUUID();
+      const operation = await db
+        .update(agentHireOperations)
+        .set({
+          leaseToken,
+          leaseExpiresAt: new Date(now.getTime() + leaseMs),
+          startedAt: sql`coalesce(${agentHireOperations.startedAt}, now())`,
+          attemptCount: sql`${agentHireOperations.attemptCount} + 1`,
+          updatedAt: now,
+        })
+        .where(and(
+          eq(agentHireOperations.id, id),
+          eq(agentHireOperations.status, "pending"),
+          or(
+            isNull(agentHireOperations.leaseToken),
+            isNull(agentHireOperations.leaseExpiresAt),
+            lt(agentHireOperations.leaseExpiresAt, now),
+          ),
+        ))
+        .returning()
+        .then((rows) => rows[0] ?? null);
+      return operation ? { operation, leaseToken } : null;
+    },
+
+    recordStage: async (id: string, leaseToken: string, stage: string, durationMs: number) => {
+      const now = new Date();
+      return db
+        .update(agentHireOperations)
+        .set({
+          stage,
+          stageTimings: sql`${agentHireOperations.stageTimings} || ${JSON.stringify({
+            [stage]: Math.max(0, Math.round(durationMs)),
+          })}::jsonb`,
+          updatedAt: now,
+        })
+        .where(and(
+          eq(agentHireOperations.id, id),
+          eq(agentHireOperations.leaseToken, leaseToken),
+          eq(agentHireOperations.status, "pending"),
+        ))
+        .returning()
+        .then((rows) => rows[0] ?? null);
+    },
+
+    succeed: async (id: string, leaseToken: string, response: AgentHireOperationResponse) => {
+      const now = new Date();
+      const sanitizedResponse = redactEventPayload(response) as AgentHireOperationResponse;
+      return db
+        .update(agentHireOperations)
+        .set({
+          status: "succeeded",
+          stage: "completed",
+          response: sanitizedResponse,
+          error: null,
+          leaseToken: null,
+          leaseExpiresAt: null,
+          completedAt: now,
+          updatedAt: now,
+        })
+        .where(and(
+          eq(agentHireOperations.id, id),
+          eq(agentHireOperations.leaseToken, leaseToken),
+          eq(agentHireOperations.status, "pending"),
+        ))
+        .returning()
+        .then((rows) => rows[0] ?? null);
+    },
+
+    fail: async (id: string, leaseToken: string, error: AgentHireOperationError) => {
+      const now = new Date();
+      const sanitizedError = {
+        ...error,
+        message: redactSensitiveText(error.message),
+      };
+      return db
+        .update(agentHireOperations)
+        .set({
+          status: "failed",
+          stage: "failed",
+          response: null,
+          error: sanitizedError,
+          leaseToken: null,
+          leaseExpiresAt: null,
+          completedAt: now,
+          updatedAt: now,
+        })
+        .where(and(
+          eq(agentHireOperations.id, id),
+          eq(agentHireOperations.leaseToken, leaseToken),
+          eq(agentHireOperations.status, "pending"),
+        ))
+        .returning()
+        .then((rows) => rows[0] ?? null);
+    },
+
+    waitForTerminal: async (id: string, budgetMs: number) => {
+      const deadline = Date.now() + Math.max(0, budgetMs);
+      do {
+        const operation = await getById(id);
+        if (!operation || operation.status !== "pending") return operation;
+        if (Date.now() >= deadline) return operation;
+        await new Promise((resolve) => setTimeout(resolve, Math.min(25, Math.max(1, deadline - Date.now()))));
+      } while (true);
+    },
+  };
+}

--- a/server/src/services/agent-hire-operations.ts
+++ b/server/src/services/agent-hire-operations.ts
@@ -34,6 +34,10 @@ export function hashAgentHireRequest(value: unknown): string {
   return createHash("sha256").update(stableStringify(value)).digest("hex");
 }
 
+function hashIdempotencyKey(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
 export type AgentHireOperation = typeof agentHireOperations.$inferSelect;
 
 export type PublicAgentHireOperation = Pick<
@@ -80,7 +84,7 @@ export function agentHireOperationService(db: Db) {
     companyId: string;
     principalType: "agent" | "user";
     principalId: string;
-    idempotencyKey: string;
+    idempotencyKeyHash: string;
   }) {
     return db
       .select()
@@ -89,7 +93,7 @@ export function agentHireOperationService(db: Db) {
         eq(agentHireOperations.companyId, input.companyId),
         eq(agentHireOperations.principalType, input.principalType),
         eq(agentHireOperations.principalId, input.principalId),
-        eq(agentHireOperations.idempotencyKey, input.idempotencyKey),
+        eq(agentHireOperations.idempotencyKeyHash, input.idempotencyKeyHash),
       ))
       .then((rows) => rows[0] ?? null);
   }
@@ -121,10 +125,15 @@ export function agentHireOperationService(db: Db) {
       idempotencyKey: string;
       requestHash: string;
     }) => {
+      const idempotencyKeyHash = hashIdempotencyKey(input.idempotencyKey);
       const inserted = await db
         .insert(agentHireOperations)
         .values({
-          ...input,
+          companyId: input.companyId,
+          principalType: input.principalType,
+          principalId: input.principalId,
+          idempotencyKeyHash,
+          requestHash: input.requestHash,
           agentId: randomUUID(),
         })
         .onConflictDoNothing({
@@ -132,12 +141,17 @@ export function agentHireOperationService(db: Db) {
             agentHireOperations.companyId,
             agentHireOperations.principalType,
             agentHireOperations.principalId,
-            agentHireOperations.idempotencyKey,
+            agentHireOperations.idempotencyKeyHash,
           ],
         })
         .returning()
         .then((rows) => rows[0] ?? null);
-      const operation = inserted ?? await getScoped(input);
+      const operation = inserted ?? await getScoped({
+        companyId: input.companyId,
+        principalType: input.principalType,
+        principalId: input.principalId,
+        idempotencyKeyHash,
+      });
       if (!operation) throw new Error("Failed to reserve agent hire operation");
       if (operation.requestHash !== input.requestHash) {
         throw new AgentHireIdempotencyConflictError();

--- a/server/src/services/index.ts
+++ b/server/src/services/index.ts
@@ -8,6 +8,12 @@ export { companySkillPolicyService, normalizeSkillPolicySourceType } from "./com
 export { folderService } from "./folders.js";
 export { agentService, deduplicateAgentName } from "./agents.js";
 export {
+  agentHireOperationService,
+  AgentHireIdempotencyConflictError,
+  hashAgentHireRequest,
+  publicAgentHireOperation,
+} from "./agent-hire-operations.js";
+export {
   builtInAgentService,
   deriveBuiltInAgentStatus,
   getBuiltInAgentDefinition,

--- a/ui/src/api/agents.test.ts
+++ b/ui/src/api/agents.test.ts
@@ -60,7 +60,16 @@ describe("agent hire reconciliation", () => {
   });
 
   it("stops reconciliation when the caller aborts", async () => {
-    fetchMock.mockResolvedValue(jsonResponse(pendingResponse));
+    fetchMock.mockImplementation(
+      (_input: RequestInfo | URL, init?: RequestInit) =>
+        new Promise((_resolve, reject) => {
+          init?.signal?.addEventListener(
+            "abort",
+            () => reject(new DOMException("The operation was aborted.", "AbortError")),
+            { once: true },
+          );
+        }),
+    );
     const controller = new AbortController();
 
     const resultPromise = agentsApi.hire(
@@ -93,5 +102,35 @@ describe("agent hire reconciliation", () => {
 
     await rejection;
     expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("aborts an in-flight request at its finite deadline", async () => {
+    vi.useFakeTimers();
+    fetchMock.mockImplementation(
+      (_input: RequestInfo | URL, init?: RequestInit) =>
+        new Promise((_resolve, reject) => {
+          init?.signal?.addEventListener(
+            "abort",
+            () => reject(new DOMException("The operation was aborted.", "AbortError")),
+            { once: true },
+          );
+        }),
+    );
+
+    const resultPromise = agentsApi.hire(
+      "company-123",
+      { name: "Builder" },
+      { idempotencyKey: "stalled-request-key", timeoutMs: 500 },
+    );
+    const rejection = expect(resultPromise).rejects.toMatchObject({
+      name: "AgentHireTimeoutError",
+      idempotencyKey: "stalled-request-key",
+      timeoutMs: 500,
+    } satisfies Partial<AgentHireTimeoutError>);
+    await vi.advanceTimersByTimeAsync(500);
+
+    await rejection;
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect((fetchMock.mock.calls[0]![1] as RequestInit).signal?.aborted).toBe(true);
   });
 });

--- a/ui/src/api/agents.test.ts
+++ b/ui/src/api/agents.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  AgentHireTimeoutError,
+  agentsApi,
+  createOrReuseAgentHireAttempt,
+} from "./agents";
+
+function jsonResponse(body: unknown) {
+  return { ok: true, status: 200, json: async () => body } as unknown as Response;
+}
+
+const pendingResponse = {
+  operationId: "operation-123",
+  status: "pending",
+  stage: "creating",
+  statusUrl: "/agent-hire-operations/operation-123",
+};
+
+const fetchMock = vi.fn();
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+describe("agent hire reconciliation", () => {
+  it("reuses a caller attempt for an explicit retry of the same payload", () => {
+    const first = createOrReuseAgentHireAttempt(null, { name: "Builder", role: "engineer" });
+    const retry = createOrReuseAgentHireAttempt(first, { name: "Builder", role: "engineer" });
+    const changed = createOrReuseAgentHireAttempt(first, { name: "Different", role: "engineer" });
+
+    expect(retry).toBe(first);
+    expect(changed.idempotencyKey).not.toBe(first.idempotencyKey);
+  });
+
+  it("reuses the caller-owned idempotency key across polls", async () => {
+    vi.useFakeTimers();
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(pendingResponse))
+      .mockResolvedValueOnce(jsonResponse({ agent: { id: "agent-123" }, approval: null }));
+
+    const resultPromise = agentsApi.hire(
+      "company-123",
+      { name: "Builder" },
+      { idempotencyKey: "caller-owned-key" },
+    );
+    await vi.advanceTimersByTimeAsync(250);
+
+    await expect(resultPromise).resolves.toMatchObject({ agent: { id: "agent-123" } });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    for (const call of fetchMock.mock.calls) {
+      const headers = new Headers((call[1] as RequestInit).headers);
+      expect(headers.get("Idempotency-Key")).toBe("caller-owned-key");
+    }
+  });
+
+  it("stops reconciliation when the caller aborts", async () => {
+    fetchMock.mockResolvedValue(jsonResponse(pendingResponse));
+    const controller = new AbortController();
+
+    const resultPromise = agentsApi.hire(
+      "company-123",
+      { name: "Builder" },
+      { idempotencyKey: "abort-key", signal: controller.signal },
+    );
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    controller.abort();
+
+    await expect(resultPromise).rejects.toMatchObject({ name: "AbortError" });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("stops reconciliation at its finite deadline", async () => {
+    vi.useFakeTimers();
+    fetchMock.mockResolvedValue(jsonResponse(pendingResponse));
+
+    const resultPromise = agentsApi.hire(
+      "company-123",
+      { name: "Builder" },
+      { idempotencyKey: "deadline-key", timeoutMs: 500 },
+    );
+    const rejection = expect(resultPromise).rejects.toMatchObject({
+      name: "AgentHireTimeoutError",
+      idempotencyKey: "deadline-key",
+      timeoutMs: 500,
+    } satisfies Partial<AgentHireTimeoutError>);
+    await vi.advanceTimersByTimeAsync(500);
+
+    await rejection;
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/ui/src/api/agents.ts
+++ b/ui/src/api/agents.ts
@@ -76,11 +76,68 @@ export interface AgentHirePendingResponse {
   statusUrl: string;
 }
 
-function createAgentHireIdempotencyKey() {
+export interface AgentHireOptions {
+  /** Caller-owned key. Reuse it when retrying the same logical hire. */
+  idempotencyKey: string;
+  signal?: AbortSignal;
+  timeoutMs?: number;
+}
+
+export interface AgentHireAttempt {
+  idempotencyKey: string;
+  payloadFingerprint: string;
+}
+
+export class AgentHireTimeoutError extends Error {
+  constructor(
+    readonly idempotencyKey: string,
+    readonly timeoutMs: number,
+  ) {
+    super(`Agent hire did not finish within ${timeoutMs} ms`);
+    this.name = "AgentHireTimeoutError";
+  }
+}
+
+const AGENT_HIRE_POLL_INTERVAL_MS = 250;
+const DEFAULT_AGENT_HIRE_TIMEOUT_MS = 30_000;
+
+export function createAgentHireIdempotencyKey() {
   if (typeof globalThis.crypto?.randomUUID === "function") {
     return globalThis.crypto.randomUUID();
   }
   return `hire-${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+}
+
+export function createOrReuseAgentHireAttempt(
+  previous: AgentHireAttempt | null,
+  data: Record<string, unknown>,
+): AgentHireAttempt {
+  const payloadFingerprint = JSON.stringify(data);
+  if (previous?.payloadFingerprint === payloadFingerprint) return previous;
+  return {
+    idempotencyKey: createAgentHireIdempotencyKey(),
+    payloadFingerprint,
+  };
+}
+
+function abortError(): DOMException {
+  return new DOMException("The operation was aborted.", "AbortError");
+}
+
+function waitForAgentHirePoll(delayMs: number, signal?: AbortSignal): Promise<void> {
+  if (signal?.aborted) return Promise.reject(abortError());
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      signal?.removeEventListener("abort", onAbort);
+      resolve();
+    }, delayMs);
+    const onAbort = () => {
+      clearTimeout(timer);
+      signal?.removeEventListener("abort", onAbort);
+      reject(abortError());
+    };
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
 }
 
 export interface AgentPermissionUpdate {
@@ -151,15 +208,24 @@ export const agentsApi = {
     api.post<Agent>(agentPath(id, companyId, `/config-revisions/${revisionId}/rollback`), {}),
   create: (companyId: string, data: Record<string, unknown>) =>
     api.post<Agent>(`/companies/${companyId}/agents`, data),
-  hire: async (companyId: string, data: Record<string, unknown>) => {
-    const idempotencyKey = createAgentHireIdempotencyKey();
+  hire: async (companyId: string, data: Record<string, unknown>, options: AgentHireOptions) => {
+    const timeoutMs = Math.max(0, options.timeoutMs ?? DEFAULT_AGENT_HIRE_TIMEOUT_MS);
+    const deadline = Date.now() + timeoutMs;
     const path = `/companies/${companyId}/agent-hires`;
     while (true) {
+      if (options.signal?.aborted) throw abortError();
+      if (Date.now() >= deadline) {
+        throw new AgentHireTimeoutError(options.idempotencyKey, timeoutMs);
+      }
       const response = await api.post<AgentHireResponse | AgentHirePendingResponse>(path, data, {
-        headers: { "Idempotency-Key": idempotencyKey },
+        headers: { "Idempotency-Key": options.idempotencyKey },
+        signal: options.signal,
       });
       if ("agent" in response) return response;
-      await new Promise((resolve) => setTimeout(resolve, 250));
+      await waitForAgentHirePoll(
+        Math.min(AGENT_HIRE_POLL_INTERVAL_MS, Math.max(0, deadline - Date.now())),
+        options.signal,
+      );
     }
   },
   update: (id: string, data: Record<string, unknown>, companyId?: string) =>

--- a/ui/src/api/agents.ts
+++ b/ui/src/api/agents.ts
@@ -69,6 +69,20 @@ export interface AgentHireResponse {
   approval: Approval | null;
 }
 
+export interface AgentHirePendingResponse {
+  operationId: string;
+  status: "pending";
+  stage: string;
+  statusUrl: string;
+}
+
+function createAgentHireIdempotencyKey() {
+  if (typeof globalThis.crypto?.randomUUID === "function") {
+    return globalThis.crypto.randomUUID();
+  }
+  return `hire-${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+}
+
 export interface AgentPermissionUpdate {
   canCreateAgents: boolean;
   canCreateSkills: boolean;
@@ -137,8 +151,17 @@ export const agentsApi = {
     api.post<Agent>(agentPath(id, companyId, `/config-revisions/${revisionId}/rollback`), {}),
   create: (companyId: string, data: Record<string, unknown>) =>
     api.post<Agent>(`/companies/${companyId}/agents`, data),
-  hire: (companyId: string, data: Record<string, unknown>) =>
-    api.post<AgentHireResponse>(`/companies/${companyId}/agent-hires`, data),
+  hire: async (companyId: string, data: Record<string, unknown>) => {
+    const idempotencyKey = createAgentHireIdempotencyKey();
+    const path = `/companies/${companyId}/agent-hires`;
+    while (true) {
+      const response = await api.post<AgentHireResponse | AgentHirePendingResponse>(path, data, {
+        headers: { "Idempotency-Key": idempotencyKey },
+      });
+      if ("agent" in response) return response;
+      await new Promise((resolve) => setTimeout(resolve, 250));
+    }
+  },
   update: (id: string, data: Record<string, unknown>, companyId?: string) =>
     api.patch<Agent>(agentPath(id, companyId), data),
   updatePermissions: (id: string, data: AgentPermissionUpdate, companyId?: string) =>

--- a/ui/src/api/agents.ts
+++ b/ui/src/api/agents.ts
@@ -212,20 +212,40 @@ export const agentsApi = {
     const timeoutMs = Math.max(0, options.timeoutMs ?? DEFAULT_AGENT_HIRE_TIMEOUT_MS);
     const deadline = Date.now() + timeoutMs;
     const path = `/companies/${companyId}/agent-hires`;
-    while (true) {
+    const requestController = new AbortController();
+    let deadlineExpired = false;
+    const onCallerAbort = () => requestController.abort();
+    options.signal?.addEventListener("abort", onCallerAbort, { once: true });
+    const deadlineTimer = setTimeout(() => {
+      deadlineExpired = true;
+      requestController.abort();
+    }, timeoutMs);
+
+    try {
+      while (true) {
+        if (options.signal?.aborted) throw abortError();
+        if (deadlineExpired || Date.now() >= deadline) {
+          throw new AgentHireTimeoutError(options.idempotencyKey, timeoutMs);
+        }
+        const response = await api.post<AgentHireResponse | AgentHirePendingResponse>(path, data, {
+          headers: { "Idempotency-Key": options.idempotencyKey },
+          signal: requestController.signal,
+        });
+        if ("agent" in response) return response;
+        await waitForAgentHirePoll(
+          Math.min(AGENT_HIRE_POLL_INTERVAL_MS, Math.max(0, deadline - Date.now())),
+          requestController.signal,
+        );
+      }
+    } catch (error) {
       if (options.signal?.aborted) throw abortError();
-      if (Date.now() >= deadline) {
+      if (deadlineExpired || Date.now() >= deadline) {
         throw new AgentHireTimeoutError(options.idempotencyKey, timeoutMs);
       }
-      const response = await api.post<AgentHireResponse | AgentHirePendingResponse>(path, data, {
-        headers: { "Idempotency-Key": options.idempotencyKey },
-        signal: options.signal,
-      });
-      if ("agent" in response) return response;
-      await waitForAgentHirePoll(
-        Math.min(AGENT_HIRE_POLL_INTERVAL_MS, Math.max(0, deadline - Date.now())),
-        options.signal,
-      );
+      throw error;
+    } finally {
+      clearTimeout(deadlineTimer);
+      options.signal?.removeEventListener("abort", onCallerAbort);
     }
   },
   update: (id: string, data: Record<string, unknown>, companyId?: string) =>

--- a/ui/src/api/client.test.ts
+++ b/ui/src/api/client.test.ts
@@ -77,6 +77,21 @@ describe("in-tab GET coalescing", () => {
   });
 });
 
+describe("mutation headers", () => {
+  it("keeps JSON content type when a caller supplies an idempotency key", async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ ok: true }));
+
+    await api.post("/agent-hires", { name: "Builder" }, {
+      headers: { "Idempotency-Key": "hire-123" },
+    });
+
+    const init = fetchMock.mock.calls[0]?.[1] as RequestInit;
+    const headers = new Headers(init.headers);
+    expect(headers.get("Content-Type")).toBe("application/json");
+    expect(headers.get("Idempotency-Key")).toBe("hire-123");
+  });
+});
+
 describe("per-caller abort semantics", () => {
   it("aborting one caller rejects only that caller, not the shared fetch", async () => {
     const d = deferred<Response>();

--- a/ui/src/api/client.test.ts
+++ b/ui/src/api/client.test.ts
@@ -90,6 +90,18 @@ describe("mutation headers", () => {
     expect(headers.get("Content-Type")).toBe("application/json");
     expect(headers.get("Idempotency-Key")).toBe("hire-123");
   });
+
+  it("recognizes headers-only DELETE options instead of serializing them as a body", async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ ok: true }));
+
+    await api.delete("/agent-hires/operation-123", {
+      headers: { "Idempotency-Key": "hire-123" },
+    });
+
+    const init = fetchMock.mock.calls[0]?.[1] as RequestInit;
+    expect(init.body).toBeUndefined();
+    expect(new Headers(init.headers).get("Idempotency-Key")).toBe("hire-123");
+  });
 });
 
 describe("per-caller abort semantics", () => {

--- a/ui/src/api/client.ts
+++ b/ui/src/api/client.ts
@@ -17,6 +17,8 @@ export class ApiError extends Error {
 export interface RequestOptions {
   /** Abort signal wired through to `fetch` and coalescing (per-caller). */
   signal?: AbortSignal;
+  /** Additional request headers merged with the client's defaults. */
+  headers?: HeadersInit;
 }
 
 function abortError(): DOMException {
@@ -45,9 +47,9 @@ async function request<T>(path: string, init?: RequestInit): Promise<T> {
   applyObservabilityHeaders(headers);
 
   const res = await fetch(`${BASE}${path}`, {
+    ...init,
     headers,
     credentials: "include",
-    ...init,
   });
   if (!res.ok) {
     const errorBody = await res.json().catch(() => null);
@@ -146,18 +148,43 @@ function isRequestOptions(value: unknown): value is RequestOptions {
 export const api = {
   get: <T>(path: string, options?: RequestOptions) => coalescedGet<T>(path, options),
   post: <T>(path: string, body: unknown, options?: RequestOptions) =>
-    request<T>(path, { method: "POST", body: JSON.stringify(body), signal: options?.signal }),
+    request<T>(path, {
+      method: "POST",
+      body: JSON.stringify(body),
+      signal: options?.signal,
+      headers: options?.headers,
+    }),
   postForm: <T>(path: string, body: FormData, options?: RequestOptions) =>
-    request<T>(path, { method: "POST", body, signal: options?.signal }),
+    request<T>(path, { method: "POST", body, signal: options?.signal, headers: options?.headers }),
   put: <T>(path: string, body: unknown, options?: RequestOptions) =>
-    request<T>(path, { method: "PUT", body: JSON.stringify(body), signal: options?.signal }),
+    request<T>(path, {
+      method: "PUT",
+      body: JSON.stringify(body),
+      signal: options?.signal,
+      headers: options?.headers,
+    }),
   patch: <T>(path: string, body: unknown, options?: RequestOptions) =>
-    request<T>(path, { method: "PATCH", body: JSON.stringify(body), signal: options?.signal }),
+    request<T>(path, {
+      method: "PATCH",
+      body: JSON.stringify(body),
+      signal: options?.signal,
+      headers: options?.headers,
+    }),
   delete: <T>(path: string, bodyOrOptions?: unknown, options?: RequestOptions) => {
     const requestOptions = isRequestOptions(bodyOrOptions) ? bodyOrOptions : options;
     const body = bodyOrOptions === undefined || isRequestOptions(bodyOrOptions) ? undefined : JSON.stringify(bodyOrOptions);
-    return request<T>(path, { method: "DELETE", ...(body === undefined ? {} : { body }), signal: requestOptions?.signal });
+    return request<T>(path, {
+      method: "DELETE",
+      ...(body === undefined ? {} : { body }),
+      signal: requestOptions?.signal,
+      headers: requestOptions?.headers,
+    });
   },
   deleteWithBody: <T>(path: string, body: unknown, options?: RequestOptions) =>
-    request<T>(path, { method: "DELETE", body: JSON.stringify(body), signal: options?.signal }),
+    request<T>(path, {
+      method: "DELETE",
+      body: JSON.stringify(body),
+      signal: options?.signal,
+      headers: options?.headers,
+    }),
 };

--- a/ui/src/api/client.ts
+++ b/ui/src/api/client.ts
@@ -142,7 +142,11 @@ export function __inflightGetCount(): number {
 }
 
 function isRequestOptions(value: unknown): value is RequestOptions {
-  return typeof value === "object" && value !== null && "signal" in value;
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    ("signal" in value || "headers" in value)
+  );
 }
 
 export const api = {

--- a/ui/src/components/AgentActionButtons.tsx
+++ b/ui/src/components/AgentActionButtons.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState, type ReactNode } from "react";
+import { useCallback, useRef, useState, type ReactNode } from "react";
 import { useNavigate } from "@/lib/router";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import {
@@ -29,7 +29,11 @@ import {
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
 import { AgentStatusBadge } from "./StatusBadge";
-import { agentsApi } from "../api/agents";
+import {
+  agentsApi,
+  createOrReuseAgentHireAttempt,
+  type AgentHireAttempt,
+} from "../api/agents";
 import { ApiError } from "../api/client";
 import { queryKeys } from "../lib/queryKeys";
 import { agentRouteRef } from "../lib/utils";
@@ -201,6 +205,7 @@ export function AgentActionButtons({
   const queryClient = useQueryClient();
   const { openNewIssue } = useDialogActions();
   const { pushToast } = useToastActions();
+  const duplicateHireAttemptRef = useRef<AgentHireAttempt | null>(null);
   const [moreOpen, setMoreOpen] = useState(false);
   const [pauseConfirmOpen, setPauseConfirmOpen] = useState(false);
 
@@ -266,7 +271,12 @@ export function AgentActionButtons({
         return await agentsApi.create(resolvedCompanyId, payload);
       } catch (error) {
         if (error instanceof ApiError && error.status === 409 && error.message.includes("requires board approval")) {
-          const hire = await agentsApi.hire(resolvedCompanyId, payload);
+          const attempt = createOrReuseAgentHireAttempt(duplicateHireAttemptRef.current, payload);
+          duplicateHireAttemptRef.current = attempt;
+          const hire = await agentsApi.hire(resolvedCompanyId, payload, {
+            idempotencyKey: attempt.idempotencyKey,
+          });
+          duplicateHireAttemptRef.current = null;
           return hire.agent;
         }
         throw error;

--- a/ui/src/components/OnboardingWizard.tsx
+++ b/ui/src/components/OnboardingWizard.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useMemo } from "react";
+import { useEffect, useState, useMemo, useRef } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import type { AdapterEnvironmentTestResult } from "@paperclipai/shared";
 import { useLocation, useNavigate, useParams } from "@/lib/router";
@@ -6,7 +6,11 @@ import { useDialog } from "../context/DialogContext";
 import { useCompany } from "../context/CompanyContext";
 import { companiesApi } from "../api/companies";
 import { goalsApi } from "../api/goals";
-import { agentsApi } from "../api/agents";
+import {
+  agentsApi,
+  createOrReuseAgentHireAttempt,
+  type AgentHireAttempt,
+} from "../api/agents";
 import { approvalsApi } from "../api/approvals";
 import { issuesApi } from "../api/issues";
 import { projectsApi } from "../api/projects";
@@ -101,6 +105,7 @@ function loadSavedState(): Record<string, unknown> | null {
 }
 
 export function OnboardingWizard() {
+  const agentHireAttemptRef = useRef<AgentHireAttempt | null>(null);
   const {
     onboardingOpen,
     onboardingOptions,
@@ -625,13 +630,19 @@ export function OnboardingWizard() {
         if (!result) return;
       }
 
-      const hire = await agentsApi.hire(createdCompanyId, {
+      const hirePayload = {
         name: agentName.trim(),
         role: "ceo",
         adapterType,
         adapterConfig: buildAdapterConfig(),
         runtimeConfig: buildNewAgentRuntimeConfig()
+      };
+      const hireAttempt = createOrReuseAgentHireAttempt(agentHireAttemptRef.current, hirePayload);
+      agentHireAttemptRef.current = hireAttempt;
+      const hire = await agentsApi.hire(createdCompanyId, hirePayload, {
+        idempotencyKey: hireAttempt.idempotencyKey,
       });
+      agentHireAttemptRef.current = null;
       if (hire.approval) {
         await approvalsApi.approve(
           hire.approval.id,

--- a/ui/src/pages/NewAgent.tsx
+++ b/ui/src/pages/NewAgent.tsx
@@ -1,9 +1,13 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useNavigate, useSearchParams } from "@/lib/router";
 import { useCompany } from "../context/CompanyContext";
 import { useBreadcrumbs } from "../context/BreadcrumbContext";
-import { agentsApi } from "../api/agents";
+import {
+  agentsApi,
+  createOrReuseAgentHireAttempt,
+  type AgentHireAttempt,
+} from "../api/agents";
 import { companySkillsApi } from "../api/companySkills";
 import { issuesApi } from "../api/issues";
 import { projectsApi } from "../api/projects";
@@ -58,6 +62,7 @@ function createValuesForAdapterType(
 
 export function NewAgent() {
   const { selectedCompanyId } = useCompany();
+  const agentHireAttemptRef = useRef<AgentHireAttempt | null>(null);
   const { setBreadcrumbs } = useBreadcrumbs();
   const queryClient = useQueryClient();
   const navigate = useNavigate();
@@ -141,9 +146,15 @@ export function NewAgent() {
   }, [presetAdapterType]);
 
   const createAgent = useMutation({
-    mutationFn: (data: Record<string, unknown>) =>
-      agentsApi.hire(selectedCompanyId!, data),
+    mutationFn: ({
+      data,
+      idempotencyKey,
+    }: {
+      data: Record<string, unknown>;
+      idempotencyKey: string;
+    }) => agentsApi.hire(selectedCompanyId!, data, { idempotencyKey }),
     onSuccess: (result) => {
+      agentHireAttemptRef.current = null;
       queryClient.invalidateQueries({ queryKey: queryKeys.agents.list(selectedCompanyId!) });
       queryClient.invalidateQueries({ queryKey: queryKeys.approvals.list(selectedCompanyId!) });
       navigate(agentUrl(result.agent));
@@ -167,8 +178,7 @@ export function NewAgent() {
         return;
       }
     }
-    createAgent.mutate(
-      buildNewAgentHirePayload({
+    const data = buildNewAgentHirePayload({
         name,
         effectiveRole,
         title,
@@ -177,8 +187,13 @@ export function NewAgent() {
         configValues,
         adapterConfig: buildAdapterConfig(),
         permissions,
-      }),
-    );
+      });
+    const attempt = createOrReuseAgentHireAttempt(agentHireAttemptRef.current, data);
+    agentHireAttemptRef.current = attempt;
+    createAgent.mutate({
+      data,
+      idempotencyKey: attempt.idempotencyKey,
+    });
   }
 
   const availableSkills = (companySkills ?? []).filter((skill) => !skill.key.startsWith("paperclipai/paperclip/"));


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the control plane that coordinates autonomous companies and their agent workforces.
> - Hiring is a high-impact mutation because it creates an identity, materializes configuration and instructions, grants permissions, and may open an approval.
> - A caller can time out while that work continues, then retry without knowing whether an agent was already created.
> - Process-local response caches cannot reconcile that ambiguity after a restart or across multiple server processes.
> - This pull request records a company-and-principal-scoped operation before side effects, elects one database-leased worker, and gives callers a bounded response plus a durable status route.
> - The benefit is retry-safe agent creation with inspectable progress, coarse timing data, and no raw credentials in operation records.

## Linked Issues or Issue Description

Agent-hire callers currently cannot safely retry after a timeout or disconnect. A repeated `POST /api/companies/{companyId}/agent-hires` can create multiple agents because the server has no durable operation identity. This is particularly risky when skill resolution, configuration normalization, or instruction materialization makes the request exceed a caller's timeout.

Related: #6586 adds an in-process TTL cache. This PR addresses the same failure mode with a database-backed operation because an in-memory cache does not survive restart or coordinate multiple server processes.

## What Changed

- Added an `agent_hire_operations` migration and schema with a unique company/principal/key scope, request hash, preallocated agent ID, lease, terminal response/error, and stage timings.
- Reserved operations before expensive work, rejected same-key payload mismatches, elected one worker with an atomic lease, and reconciled retries to the same agent.
- Added bounded `202` responses and `GET /api/companies/{companyId}/agent-hire-operations/{operationId}` for `pending`, `succeeded`, and `failed` status.
- Redacted persisted results and errors; operation rows store a request hash rather than the raw hire payload.
- Added UI idempotency headers and retry reconciliation while preserving JSON content-type headers.
- Documented the durable hire contract and added focused concurrency, replay, timeout, isolation, mismatch, timing, and secret-redaction coverage.

## Verification

- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/agent-hire-operations.test.ts src/__tests__/agent-hire-idempotency-routes.test.ts` — 6 passed.
- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/agent-skills-routes.test.ts src/__tests__/agent-permissions-routes.test.ts` — 73 passed.
- `pnpm --filter @paperclipai/ui exec vitest run src/api/client.test.ts` — 8 passed.
- `pnpm --filter @paperclipai/shared typecheck`, `pnpm --filter @paperclipai/db typecheck`, `pnpm --filter @paperclipai/server typecheck`, and `pnpm --filter @paperclipai/ui typecheck` — passed.
- `pnpm --filter @paperclipai/db check:migrations` — passed.
- Deployment check: apply migration `0182`, submit two concurrent identical hires with one `Idempotency-Key`, verify one operation/agent, force a zero request budget to observe `202`, query the returned status URL to `succeeded`, and replay the POST to confirm the original agent ID and `Idempotency-Key-Replay: true`.

## Risks

- The migration adds one table and three indexes. Existing no-key callers retain synchronous behavior; keyed callers may now receive `202` after the bounded wait.
- A crashed worker remains leased for up to 15 minutes before a same-key retry can reclaim it. This favors duplicate prevention over aggressive takeover.
- Rollback: deploy the previous server/UI so idempotency headers revert to legacy synchronous route behavior, then drop `agent_hire_operations` only after accepting loss of in-flight reconciliation records. The new status route becomes unavailable after code rollback.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI GPT-5.6 Sol with reasoning, repository tool use, code execution, and test execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

Made with [Cursor](https://cursor.com)