### PR TITLE
fix(plugin-llm-wiki): bump to 0.1.1 to republish with gitignore.template fix

### DIFF
--- a/packages/plugins/plugin-llm-wiki/package.json
+++ b/packages/plugins/plugin-llm-wiki/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paperclipai/plugin-llm-wiki",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "private": true,
   "description": "Local-file LLM Wiki plugin for source ingestion, wiki browsing, query, lint, and maintenance workflows.",

--- a/packages/plugins/plugin-llm-wiki/tests/npm-package-safety.spec.ts
+++ b/packages/plugins/plugin-llm-wiki/tests/npm-package-safety.spec.ts
@@ -1,0 +1,24 @@
+import { readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const TEMPLATES_DIR = join(__dirname, "..", "templates");
+
+function walk(dir: string): string[] {
+  return readdirSync(dir).flatMap((entry) => {
+    const full = join(dir, entry);
+    return statSync(full).isDirectory() ? walk(full) : [full];
+  });
+}
+
+describe("npm package safety", () => {
+  // npm rewrites any packaged file named `.gitignore` to `.npmignore` inside the
+  // published tarball, so a runtime-required template with that name silently
+  // vanishes after publish (0.1.0 shipped broken because of this). Templates
+  // that represent ignore files must use a non-dot name like `gitignore.template`.
+  it("ships no template file that npm would rename or drop", () => {
+    const hazardous = walk(TEMPLATES_DIR)
+      .filter((path) => /\.(git|npm)ignore$/.test(path.split("/").pop()!));
+    expect(hazardous).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Its plugin system distributes optional capabilities (like the LLM Wiki plugin) as npm packages that instances install via GUI or CLI
> - The published `@paperclipai/plugin-llm-wiki@0.1.0` tarball is uninstallable: its build shipped the bootstrap template as `templates/.gitignore`, and npm renames `.gitignore` → `.npmignore` inside published tarballs, so `dist/manifest.js` throws `ENOENT` reading `templates/.gitignore` at import time and `POST /api/plugins/install` returns 400
> - The source fix (rename to `templates/gitignore.template`, eb38b226 / PR #6010) already landed on master, but the package was never republished — the registry still serves only the broken 0.1.0 and every npm-based install of the plugin fails
> - This pull request bumps the package to 0.1.1 so a fixed build can be published, and adds a regression test asserting no template file uses a name npm would rename or drop
> - The benefit is that once 0.1.1 is published, `npm install @paperclipai/plugin-llm-wiki` works again on every instance, and the dot-name packaging hazard cannot silently reappear

## Linked Issues or Issue Description

Fixes: #5986
Refs #5818
Refs #7262

## What Changed

- `packages/plugins/plugin-llm-wiki/package.json`: version `0.1.0` → `0.1.1`
- New test `packages/plugins/plugin-llm-wiki/tests/npm-package-safety.spec.ts`: walks `templates/` and fails if any file is named `.gitignore`/`.npmignore` (names npm rewrites inside published tarballs)

## Verification

- `cd packages/plugins/plugin-llm-wiki && pnpm build && npm pack`, then `tar tzf` the tarball: it contains `package/templates/gitignore.template` and no `.gitignore`/`.npmignore` under `templates/`
- Extracted the tarball and ran `node -e "import('<extracted>/package/dist/manifest.js')"` — imports cleanly (the published 0.1.0 throws `ENOENT ... templates/.gitignore` on the same step)
- `npx vitest run --config ./vitest.config.ts tests/npm-package-safety.spec.ts` — passes
- After merge, a maintainer with `@paperclipai` npm scope access needs to run the publish (e.g. `pnpm build && npm publish` in `packages/plugins/plugin-llm-wiki`) since 0.1.1 only exists once pushed to the registry

## Risks

- Low risk: version bump plus a read-only test; no runtime code changes. The template rename it depends on is already on master (eb38b226).
- The registry fix is only complete once a maintainer publishes 0.1.1; until then npm installs keep fetching broken 0.1.0.

## Model Used

Claude Fable 5 (Anthropic, model ID `claude-fable-5`), agentic coding session via Claude Code with tool use (bash, file edits); no extended-context or special modes beyond default reasoning.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
