### PR TITLE
Use env vars for Codex managed MCP tokens

### DIFF
--- a/packages/adapters/codex-local/src/server/codex-home.test.ts
+++ b/packages/adapters/codex-local/src/server/codex-home.test.ts
@@ -712,7 +712,7 @@ describe("evaluateCodexCredentialReadiness", () => {
     try {
       const alphaHome = path.join(root, "agent-alpha");
       const zeroHome = path.join(root, "agent-zero");
-      await writeManagedCodexMcpConfig({
+      const alphaResult = await writeManagedCodexMcpConfig({
         codexHome: alphaHome,
         apiBaseUrl: "https://paperclip.example",
         gateways: [{
@@ -739,7 +739,9 @@ describe("evaluateCodexCredentialReadiness", () => {
       const alpha = await fs.readFile(path.join(alphaHome, "config.toml"), "utf8");
       const zero = await fs.readFile(path.join(zeroHome, "config.toml"), "utf8");
       expect(alpha).toContain('[mcp_servers."alpha"]');
-      expect(alpha).toContain('Authorization = "Bearer alpha-token"');
+      expect(alpha).toContain('bearer_token_env_var = "PAPERCLIP_MCP_GATEWAY_TOKEN_ALPHA"');
+      expect(alpha).not.toContain("alpha-token");
+      expect(alphaResult.env).toEqual({ PAPERCLIP_MCP_GATEWAY_TOKEN_ALPHA: "alpha-token" });
       expect(zero).not.toContain("mcp_servers.");
       expect(zero).not.toContain("stale-token");
       expect(alphaHome).not.toBe(zeroHome);
@@ -761,6 +763,40 @@ describe("evaluateCodexCredentialReadiness", () => {
       });
 
       expect((await fs.stat(configPath)).mode & 0o777).toBe(0o600);
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps managed MCP token env vars distinct after env-name sanitization", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-codex-mcp-config-"));
+    try {
+      const result = await writeManagedCodexMcpConfig({
+        codexHome: root,
+        apiBaseUrl: "https://paperclip.example",
+        gateways: [
+          {
+            name: "foo-bar",
+            endpointPath: "/api/tool-gateway/gateways/foo-bar/mcp",
+            bearerToken: "hyphen-token",
+          },
+          {
+            name: "foo_bar",
+            endpointPath: "/api/tool-gateway/gateways/foo_bar/mcp",
+            bearerToken: "underscore-token",
+          },
+        ],
+      });
+
+      const config = await fs.readFile(path.join(root, "config.toml"), "utf8");
+      expect(config).toContain('bearer_token_env_var = "PAPERCLIP_MCP_GATEWAY_TOKEN_FOO_BAR"');
+      expect(config).toContain('bearer_token_env_var = "PAPERCLIP_MCP_GATEWAY_TOKEN_FOO_BAR_2"');
+      expect(config).not.toContain("hyphen-token");
+      expect(config).not.toContain("underscore-token");
+      expect(result.env).toEqual({
+        PAPERCLIP_MCP_GATEWAY_TOKEN_FOO_BAR: "hyphen-token",
+        PAPERCLIP_MCP_GATEWAY_TOKEN_FOO_BAR_2: "underscore-token",
+      });
     } finally {
       await fs.rm(root, { recursive: true, force: true });
     }

--- a/packages/adapters/codex-local/src/server/codex-home.ts
+++ b/packages/adapters/codex-local/src/server/codex-home.ts
@@ -16,6 +16,12 @@ export type ManagedCodexMcpGateway = {
   bearerToken: string;
 };
 
+export type ManagedCodexMcpConfig = {
+  configPath: string;
+  env: Record<string, string>;
+  warnings: string[];
+};
+
 export function mergeManagedCodexMcpGateways(
   primary: ManagedCodexMcpGateway[],
   secondary: ManagedCodexMcpGateway[],
@@ -228,6 +234,28 @@ function sanitizeMcpServerName(value: string, fallback: string): string {
     .slice(0, 80) || fallback;
 }
 
+function mcpTokenEnvVarName(value: string, fallback: string): string {
+  const tokenName = value
+    .trim()
+    .toUpperCase()
+    .replace(/[^A-Z0-9_]+/g, "_")
+    .replace(/^_+|_+$/g, "")
+    .slice(0, 80) || fallback;
+  return `PAPERCLIP_MCP_GATEWAY_TOKEN_${tokenName}`;
+}
+
+function uniqueMcpTokenEnvVarName(value: string, fallback: string, used: Set<string>): string {
+  const base = mcpTokenEnvVarName(value, fallback);
+  let candidate = base;
+  let suffix = 2;
+  while (used.has(candidate)) {
+    candidate = `${base}_${suffix}`;
+    suffix += 1;
+  }
+  used.add(candidate);
+  return candidate;
+}
+
 function stripManagedMcpBlock(config: string): string {
   const start = config.indexOf(MANAGED_MCP_BLOCK_START);
   if (start < 0) return config.trimEnd();
@@ -249,9 +277,11 @@ function buildManagedMcpBlock(input: {
   gateways: ManagedCodexMcpGateway[];
   apiBaseUrl: string;
   existingNames: Set<string>;
-}): { block: string; warnings: string[] } {
+}): { block: string; env: Record<string, string>; warnings: string[] } {
+  const env: Record<string, string> = {};
   const warnings: string[] = [];
   const usedNames = new Set<string>();
+  const usedEnvVars = new Set<string>();
   const lines = [
     MANAGED_MCP_BLOCK_START,
     "# Written by Paperclip for governed MCP gateway access. Do not edit this block by hand.",
@@ -272,22 +302,24 @@ function buildManagedMcpBlock(input: {
       );
     }
     const url = new URL(gateway.endpointPath, input.apiBaseUrl).toString();
+    const tokenEnvVar = uniqueMcpTokenEnvVarName(managedName, `GATEWAY_${index + 1}`, usedEnvVars);
+    env[tokenEnvVar] = gateway.bearerToken;
     lines.push(
       "",
       `[mcp_servers.${tomlString(managedName)}]`,
       `url = ${tomlString(url)}`,
-      `headers = { Authorization = ${tomlString(`Bearer ${gateway.bearerToken}`)} }`,
+      `bearer_token_env_var = ${tomlString(tokenEnvVar)}`,
     );
   });
   lines.push(MANAGED_MCP_BLOCK_END);
-  return { block: lines.join("\n"), warnings };
+  return { block: lines.join("\n"), env, warnings };
 }
 
 export async function writeManagedCodexMcpConfig(input: {
   codexHome: string;
   apiBaseUrl: string;
   gateways: ManagedCodexMcpGateway[];
-}): Promise<{ configPath: string; warnings: string[] }> {
+}): Promise<ManagedCodexMcpConfig> {
   const configPath = path.join(input.codexHome, "config.toml");
   await fs.mkdir(input.codexHome, { recursive: true });
   const existing = await fs.readFile(configPath, "utf8").catch((error) => {
@@ -295,7 +327,7 @@ export async function writeManagedCodexMcpConfig(input: {
     throw error;
   });
   const unmanagedConfig = stripManagedMcpBlock(existing);
-  const { block, warnings } = buildManagedMcpBlock({
+  const { block, env, warnings } = buildManagedMcpBlock({
     gateways: input.gateways,
     apiBaseUrl: input.apiBaseUrl,
     existingNames: readCodexMcpServerNames(unmanagedConfig),
@@ -305,7 +337,7 @@ export async function writeManagedCodexMcpConfig(input: {
     : `${unmanagedConfig}${unmanagedConfig ? "\n" : ""}`;
   await fs.writeFile(configPath, next, { mode: 0o600 });
   await fs.chmod(configPath, 0o600);
-  return { configPath, warnings };
+  return { configPath, env, warnings };
 }
 
 /**

--- a/packages/adapters/codex-local/src/server/execute.ts
+++ b/packages/adapters/codex-local/src/server/execute.ts
@@ -755,6 +755,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       env.PAPERCLIP_RUNTIME_PRIMARY_URL = runtimePrimaryUrl;
     }
     env.CODEX_HOME = remoteCodexHome ?? effectiveCodexHome;
+    Object.assign(env, managedMcp.env);
     if (!hasExplicitApiKey && authToken) {
       env.PAPERCLIP_API_KEY = authToken;
     }

--- a/server/src/__tests__/codex-local-execute.test.ts
+++ b/server/src/__tests__/codex-local-execute.test.ts
@@ -24,6 +24,9 @@ const payload = {
   paperclipEnvKeys: Object.keys(process.env)
     .filter((key) => key.startsWith("PAPERCLIP_"))
     .sort(),
+  managedMcpTokenEnv: Object.fromEntries(Object.entries(process.env)
+    .filter(([key]) => key.startsWith("PAPERCLIP_MCP_GATEWAY_TOKEN_"))
+    .sort(([left], [right]) => left.localeCompare(right))),
 };
 if (capturePath) {
   fs.writeFileSync(capturePath, JSON.stringify(payload), "utf8");
@@ -55,6 +58,7 @@ type CapturePayload = {
   paperclipApiKey?: string | null;
   paperclipApiBridgeMode?: string | null;
   paperclipEnvKeys: string[];
+  managedMcpTokenEnv?: Record<string, string>;
 };
 
 type LogEntry = {
@@ -311,7 +315,11 @@ describe("codex execute", () => {
       expect(configText).toContain("[mcp_servers.github]");
       expect(configText).toContain("[mcp_servers.\"paperclip-github\"]");
       expect(configText).toContain('url = "http://paperclip.local:3100/api/tool-gateway/gateways/gateway-1/mcp"');
-      expect(configText).toContain('Authorization = "Bearer pcgw_secret-managed-token"');
+      expect(configText).toContain('bearer_token_env_var = "PAPERCLIP_MCP_GATEWAY_TOKEN_PAPERCLIP_GITHUB"');
+      expect(configText).not.toContain("pcgw_secret-managed-token");
+      expect(capture.managedMcpTokenEnv).toEqual({
+        PAPERCLIP_MCP_GATEWAY_TOKEN_PAPERCLIP_GITHUB: "pcgw_secret-managed-token",
+      });
       expect(logs).toEqual(
         expect.arrayContaining([
           expect.objectContaining({


### PR DESCRIPTION
## Thinking Path

> - This repository provides a control plane for AI agent work.
> - Local CLI adapters prepare runtime configuration for each spawned agent process.
> - Managed remote MCP gateways need bearer authentication to reach governed gateway endpoints.
> - Codex CLI 0.144.1 reads remote HTTP bearer auth from `bearer_token_env_var` metadata.
> - Persisting inline Authorization header values in `config.toml` is both incompatible with that CLI behavior and unnecessary secret exposure.
> - This pull request moves managed gateway bearer values into the child process environment while leaving only metadata in config.
> - The benefit is restored connector discovery with a smaller credential persistence surface.

## Linked Issues or Issue Description

- Bug: managed Codex remote MCP gateway config used inline bearer headers where the current CLI expects a bearer-token environment variable reference. That could prevent gateway metadata loading and left bearer material in the generated config file.

## What Changed

- Write managed Codex MCP entries with `bearer_token_env_var` instead of inline Authorization headers.
- Return the generated token environment map from the managed config writer and inject it into the spawned Codex process environment.
- Ensure env var names stay unique after sanitization so similarly named gateways do not share a token variable.
- Update focused unit and execution tests to assert that token values are passed through env and not persisted in config/logs.

## Verification

- `pnpm exec vitest run packages/adapters/codex-local/src/server/codex-home.test.ts`
- `pnpm exec vitest run server/src/__tests__/codex-local-execute.test.ts`
- `pnpm exec vitest run server/src/__tests__/heartbeat-runtime-mcp-servers.test.ts`
- `pnpm --filter @paperclipai/adapter-codex-local typecheck`
- `pnpm --filter @paperclipai/server typecheck`
- `codex --version` -> `codex-cli 0.144.1`
- Dummy-token smoke: generated a throwaway Codex home, ran `codex mcp list`, confirmed the CLI displayed the bearer token env var and the dummy token was not persisted to config.

## Risks

- Low migration risk: this only changes generated managed config blocks and process env for Codex local runs.
- Rollback is simple: revert this commit to restore the previous inline-header config writer.
- Main compatibility risk is older Codex CLI versions that may not understand `bearer_token_env_var`; this change targets the current CLI behavior verified above.

## Model Used

- OpenAI GPT-5, Codex coding agent, tool-enabled coding session.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used with version and capability details
- [x] I have checked `ROADMAP.md` and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above when found
- [x] I have either linked existing public issues or described the issue in-PR following the relevant issue template
- [x] I have not referenced internal or instance-local issues or links
- [x] My branch name describes the change and contains no internal ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes, or confirmed none was needed
- [x] I have considered and documented risks above
- [ ] CI gates are pending on this draft PR
- [ ] External automated review is pending on this draft PR
- [x] I will address automated and human reviewer comments before requesting merge
