### PR TITLE
perf(issues): make q= issue search index-usable via UNION of match sets

### DIFF
--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -1148,6 +1148,78 @@ describeEmbeddedPostgres("issueService.list participantAgentId", () => {
     expect(result.map((issue) => issue.id)).toEqual([commentMatchId, descriptionMatchId]);
   });
 
+  it("keeps search match semantics when matching via the UNION of per-column id sets", async () => {
+    // The `q=` predicate is a UNION of per-column id sets rather than a flat OR, so
+    // each branch can use its own trigram index. This pins the three behaviors that
+    // rewrite could plausibly have broken: comment-only matches still surface, soft
+    // deleted comments still do not, and LIKE metacharacters are still literal.
+    const companyId = randomUUID();
+    const commentOnlyId = randomUUID();
+    const deletedCommentId = randomUUID();
+    const metacharacterId = randomUUID();
+    const wildcardDecoyId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(issues).values([
+      {
+        id: commentOnlyId,
+        companyId,
+        title: "No keyword here",
+        description: "No keyword here either",
+        status: "todo",
+        priority: "medium",
+      },
+      {
+        id: deletedCommentId,
+        companyId,
+        title: "Also no keyword",
+        status: "todo",
+        priority: "medium",
+      },
+      {
+        id: metacharacterId,
+        companyId,
+        title: "Coverage is 90% complete",
+        status: "todo",
+        priority: "medium",
+      },
+      {
+        id: wildcardDecoyId,
+        companyId,
+        // Only matches "90%" if `%` is treated as a wildcard rather than a literal.
+        title: "Coverage is 90 percent complete",
+        status: "todo",
+        priority: "medium",
+      },
+    ]);
+
+    await db.insert(issueComments).values([
+      {
+        companyId,
+        issueId: commentOnlyId,
+        body: "The regression traces back to zephyrine handling",
+      },
+      {
+        companyId,
+        issueId: deletedCommentId,
+        body: "zephyrine was mentioned here before this comment was retracted",
+        deletedAt: new Date(),
+      },
+    ]);
+
+    const commentMatches = await svc.list(companyId, { q: "zephyrine" });
+    expect(commentMatches.map((issue) => issue.id)).toEqual([commentOnlyId]);
+
+    const literalMatches = await svc.list(companyId, { q: "90%" });
+    expect(literalMatches.map((issue) => issue.id)).toEqual([metacharacterId]);
+  });
+
   it("filters issue lists to the full descendant tree for a root issue", async () => {
     const companyId = randomUUID();
     const rootId = randomUUID();

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -4739,6 +4739,34 @@ export function issueService(db: Db) {
             AND ${issueComments.body} ILIKE ${containsPattern} ESCAPE '\\'
         )
       `;
+      // Search matching is expressed as a UNION of per-column id sets rather than a flat
+      // OR of the predicates above. Semantically identical, but the OR form is not
+      // index-usable: one branch is a subquery over issue_comments, so Postgres cannot
+      // build a BitmapOr and falls back to scanning every issue in the company and
+      // evaluating all four predicates per row. Splitting into a UNION lets each branch
+      // use its own gin_trgm_ops index (migration 0051). Measured on prod at ~22k issues,
+      // q=dockerfile: predicate alone 1117ms -> 216ms, full list shape including the
+      // searchOrder ranking ladder 1849ms -> 53ms. Result sets verified identical.
+      const searchIdMatch = sql<boolean>`
+        ${issues.id} IN (
+            SELECT ${issues.id} FROM ${issues}
+            WHERE ${issues.companyId} = ${companyId}
+              AND ${issues.title} ILIKE ${containsPattern} ESCAPE '\\'
+          UNION
+            SELECT ${issues.id} FROM ${issues}
+            WHERE ${issues.companyId} = ${companyId}
+              AND ${issues.identifier} ILIKE ${containsPattern} ESCAPE '\\'
+          UNION
+            SELECT ${issues.id} FROM ${issues}
+            WHERE ${issues.companyId} = ${companyId}
+              AND ${issues.description} ILIKE ${containsPattern} ESCAPE '\\'
+          UNION
+            SELECT ${issueComments.issueId} FROM ${issueComments}
+            WHERE ${issueComments.companyId} = ${companyId}
+              AND ${issueComments.deletedAt} IS NULL
+              AND ${issueComments.body} ILIKE ${containsPattern} ESCAPE '\\'
+        )
+      `;
       if (filters?.descendantOf) {
         conditions.push(sql<boolean>`
           ${issues.id} IN (
@@ -4814,14 +4842,7 @@ export function issueService(db: Db) {
         conditions.push(inArray(issues.id, labeledIssueIds.map((row) => row.issueId)));
       }
       if (hasSearch) {
-        conditions.push(
-          or(
-            titleContainsMatch,
-            identifierContainsMatch,
-            descriptionContainsMatch,
-            commentContainsMatch,
-          )!,
-        );
+        conditions.push(searchIdMatch);
       }
       if (filters?.excludeRoutineExecutions && !filters?.originKind && !filters?.originId) {
         conditions.push(ne(issues.originKind, "routine_execution"));


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Agents and humans both find work through issue search — `GET /api/companies/:id/issues?q=…`, which matches title, identifier, description and comment bodies and ranks the results
> - That one route took ~2s while every other route on the same instance answered in 0.12–0.19s, so the cost was specific to the search path rather than a degraded control-plane
> - `EXPLAIN ANALYZE` on a ~22k-issue instance showed a full company-scoped scan: 22,163 rows examined to return 33, with all four trigram GIN indexes (added in migration `0051_young_korg.sql`) unused
> - The reason is query shape, not a missing index: one branch of the `OR` is a subquery over `issue_comments`, and Postgres cannot build a `BitmapOr` across an `OR` containing a subquery, so it discards **all four** index paths
> - This pull request expresses the same match as `issues.id IN (<UNION of per-column id sets>)`, so each branch is independently index-usable
> - The benefit is search that stays fast as issue and comment volume grows, with no schema change, no migration, and no change to ranking or result sets

## Linked Issues or Issue Description

No existing GitHub issue — describing it here per CONTRIBUTING.md → "Link Issues or Describe Them In-PR", following `.github/ISSUE_TEMPLATE/bug_report.yml`.

**What happened**

`GET /api/companies/:companyId/issues?q=<term>` takes ~2s on an instance with ~22k issues. Other routes on the same instance are fast: `GET /api/agents/me` 0.12s, `GET /api/issues/:id` 0.13s, `GET /api/companies/:id/issues?status=todo` 0.35–0.80s. So the instance is not globally degraded — the cost is specific to the search path.

**Expected behavior**

Search latency comparable to the other list routes. The searched columns already carry `gin_trgm_ops` indexes from migration `0051_young_korg.sql`, so index scans should be available to this query.

**Steps to reproduce**

1. Populate a company with a realistic issue and comment volume (reproduced at ~22k issues).
2. `GET /api/companies/:companyId/issues?q=dockerfile` — observe ~2s.
3. `GET /api/companies/:companyId/issues?status=todo` on the same instance — observe 0.35–0.80s.
4. Run `EXPLAIN ANALYZE` on the search query: a full company-scoped scan, 22,163 rows examined to return 33, with all four trigram indexes unused.

**Root cause**

`issueService.list` built the search predicate as a flat `or(titleContainsMatch, identifierContainsMatch, descriptionContainsMatch, commentContainsMatch)`. `commentContainsMatch` is an `EXISTS` subquery over `issue_comments`. Postgres cannot combine `OR` branches into a `BitmapOr` when any branch contains a subquery, so it abandons the index paths for the other three branches too and sequentially scans the company's issues, evaluating all four predicates per row.

Worth noting for anyone who reads the symptom and suspects comment volume: the comment subquery is not the bottleneck. Postgres hashes it and it uses its own index in ~86ms. The `OR` wrapped around it is what costs — so this does not degrade with comment growth, it degrades with issue count.

**Paperclip version or commit**

Reproduced against `master` at `936215693`; the predicate has this shape in `server/src/services/issues.ts` on current `master`.

**Deployment mode**

Self-hosted, Postgres with `pg_trgm` GIN indexes from migration `0051_young_korg.sql`, ~22k issues in a single company.

## What Changed

- `server/src/services/issues.ts`: the `q=` search condition is now `issues.id IN (SELECT … UNION SELECT … UNION SELECT … UNION SELECT …)` — one branch per searched column (title, identifier, description, and non-deleted comment bodies), each independently index-usable.
- Each UNION branch keeps the original branch's own filters verbatim: same `ILIKE … ESCAPE '\'` patterns, same `companyId` scoping, and the comment branch keeps `deleted_at IS NULL`.
- The four original predicate fragments are retained unchanged — they still drive the `searchOrder` ranking `CASE` in `ORDER BY`, so relevance ordering is untouched.
- The outer `WHERE` is unchanged, so `companyId`, `visibleIssueCondition()`, and every other filter still apply on top of the UNION.
- Added a regression test in `server/src/__tests__/issues-service.test.ts` pinning the match semantics the rewrite could plausibly have changed.

## Verification

**Correctness — old vs new against production data**, run across 8 patterns: comment-only match, identifier match, title match, description match, zero-match term, escaped literal `%`, `_` wildcard, and a pathological all-match term. Identical row counts in every case, and a symmetric `EXCEPT` returned 0 rows in both directions for each.

**Performance** (same instance, ~22k issues, `q=dockerfile`):

| | before | after |
|---|---|---|
| predicate alone | 1117 ms | 216 ms |
| full list shape incl. ranking | 1849 ms | 53 ms |

**Tests:**

```
npx vitest run server/src/__tests__/issues-service.test.ts        # 105 passed
npx vitest run server/src/__tests__/issues-list-query-parsing.test.ts \
  server/src/__tests__/issue-list-assignee-filter-routes.test.ts \
  server/src/__tests__/multilingual-issues-routes.test.ts \
  server/src/__tests__/issue-comment-redaction.test.ts
pnpm typecheck                                                    # clean
```

On the added test: the fix is a performance change, and query latency is not something a unit test can assert stably. What the new test pins is the *equivalence* the rewrite has to preserve — comment-only matches still surface, soft-deleted comments still don't, and LIKE metacharacters (`%`) are still escaped to literals rather than acting as wildcards. Those are the three ways a future edit to the UNION branches would silently change behavior.

## Risks

Low. No schema change, no migration, no API surface change, and ranking is untouched because the original predicates still feed `searchOrder`.

The one thing to look at when reviewing is that each UNION branch reproduces its original branch's filters exactly — in particular that the comment branch still carries both `companyId` and `deleted_at IS NULL`. It does, and the new test covers the soft-delete case. Result-set equivalence was additionally checked against production data with `EXCEPT` in both directions across the 8 patterns above.

`IN (SELECT …)` materializes matching ids before the outer filters apply. On a search term matching a very large fraction of a company's issues that set is larger than the final result, but the pathological all-match term was one of the 8 verified patterns and stayed well inside budget.

## Model Used

Claude Opus 4.8 (`claude-opus-4-8`), via Claude Code with extended thinking, tool use, and shell execution. Query plans, timings, and old-vs-new equivalence checks were produced by running `EXPLAIN ANALYZE` and both query forms directly against the live database; the numbers above are measured, not estimated.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above (searched open PRs for issue-search / trigram / `q=` performance work — none found)
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [ ] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details — **not met, flagging rather than silently checking:** the **branch name** carries an internal tracker id (`blu-22232`). The commit subjects did too, and those I've since scrubbed — they're now clean. The branch name I can't fix in place: GitHub won't let a PR's head branch be renamed, so it means closing this PR and reopening from a clean branch. Happy to do that if maintainers prefer; say the word and I'll reopen as `fix/issue-search-index-usable-union`.
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes (the rewrite carries an inline comment explaining why the shape matters; no user-facing docs describe the predicate)
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
