### PR TITLE
fix: run database backup after startup

### DIFF
--- a/server/src/__tests__/database-backup-scheduler.test.ts
+++ b/server/src/__tests__/database-backup-scheduler.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createDatabaseBackupCoordinator,
+  startDatabaseBackupScheduler,
+} from "../services/database-backup-scheduler.js";
+
+describe("database backup startup scheduling", () => {
+  it("queues one startup backup and preserves the configured interval", async () => {
+    let startupCallback: (() => void) | undefined;
+    let intervalCallback: (() => void) | undefined;
+    const run = vi.fn().mockResolvedValue(undefined);
+
+    startDatabaseBackupScheduler({
+      intervalMs: 60 * 60 * 1000,
+      run,
+      queueStartup: (callback) => {
+        startupCallback = callback;
+      },
+      setInterval: (callback, intervalMs) => {
+        intervalCallback = callback;
+        expect(intervalMs).toBe(60 * 60 * 1000);
+        return 1 as unknown as ReturnType<typeof setInterval>;
+      },
+    });
+
+    expect(run).not.toHaveBeenCalled();
+    startupCallback?.();
+    await Promise.resolve();
+    expect(run).toHaveBeenNthCalledWith(1, "startup");
+
+    intervalCallback?.();
+    await Promise.resolve();
+    expect(run).toHaveBeenNthCalledWith(2, "scheduled");
+  });
+
+  it("keeps interval scheduling alive when the startup backup fails", async () => {
+    let startupCallback: (() => void) | undefined;
+    let intervalCallback: (() => void) | undefined;
+    const run = vi.fn()
+      .mockRejectedValueOnce(new Error("pg_dump failed"))
+      .mockResolvedValueOnce(undefined);
+
+    startDatabaseBackupScheduler({
+      intervalMs: 1000,
+      run,
+      queueStartup: (callback) => {
+        startupCallback = callback;
+      },
+      setInterval: (callback) => {
+        intervalCallback = callback;
+        return 1 as unknown as ReturnType<typeof setInterval>;
+      },
+    });
+
+    startupCallback?.();
+    await Promise.resolve();
+    await Promise.resolve();
+    intervalCallback?.();
+    await Promise.resolve();
+
+    expect(run.mock.calls).toEqual([["startup"], ["scheduled"]]);
+  });
+});
+
+describe("database backup overlap protection", () => {
+  it("skips automated overlap and rejects manual overlap", async () => {
+    let release!: () => void;
+    const execute = vi.fn(() => new Promise<string>((resolve) => {
+      release = () => resolve("complete");
+    }));
+    const onAutomatedOverlap = vi.fn();
+    const coordinator = createDatabaseBackupCoordinator({ execute, onAutomatedOverlap });
+
+    const startup = coordinator.run("startup");
+    await expect(coordinator.run("scheduled")).resolves.toBeNull();
+    await expect(coordinator.run("manual")).rejects.toMatchObject({ status: 409 });
+    expect(onAutomatedOverlap).toHaveBeenCalledWith("scheduled");
+    expect(execute).toHaveBeenCalledTimes(1);
+
+    release();
+    await expect(startup).resolves.toBe("complete");
+  });
+
+  it("releases the overlap guard after a failed backup", async () => {
+    const execute = vi.fn()
+      .mockRejectedValueOnce(new Error("pg_dump failed"))
+      .mockResolvedValueOnce("recovered");
+    const coordinator = createDatabaseBackupCoordinator({
+      execute,
+      onAutomatedOverlap: vi.fn(),
+    });
+
+    await expect(coordinator.run("startup")).rejects.toThrow("pg_dump failed");
+    await expect(coordinator.run("scheduled")).resolves.toBe("recovered");
+  });
+});

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -58,6 +58,10 @@ import {
 import { createFeedbackTraceShareClientFromConfig } from "./services/feedback-share-client.js";
 import { buildRuntimeApiCandidateUrls, choosePrimaryRuntimeApiUrl } from "./runtime-api.js";
 import { createPluginWorkerManager } from "./services/plugin-worker-manager.js";
+import {
+  createDatabaseBackupCoordinator,
+  startDatabaseBackupScheduler,
+} from "./services/database-backup-scheduler.js";
 import { createStorageServiceFromConfig } from "./storage/index.js";
 import { printStartupBanner } from "./startup-banner.js";
 import { getBoardClaimWarningUrl, initializeBoardClaimChallenge } from "./board-claim.js";
@@ -605,64 +609,62 @@ export async function startServer(): Promise<StartedServer> {
     resolve(config.databaseBackupDir, "db-backup-to-s3.failure"),
     resolve(config.databaseBackupDir, "..", "db-backup-to-s3.failure"),
   ];
-  let databaseBackupInFlight = false;
-  const runServerDatabaseBackup = async (
-    trigger: InstanceDatabaseBackupTrigger,
-  ): Promise<InstanceDatabaseBackupRunResult | null> => {
-    if (databaseBackupInFlight) {
-      const message = "Database backup already in progress";
-      if (trigger === "scheduled") {
-        logger.warn("Skipping scheduled database backup because a previous backup is still running");
-        return null;
-      }
-      throw conflict(message);
-    }
+  const databaseBackupCoordinator = createDatabaseBackupCoordinator<InstanceDatabaseBackupRunResult>({
+    onAutomatedOverlap: (trigger) => {
+      logger.warn(
+        { trigger },
+        `Skipping ${trigger} database backup because a previous backup is still running`,
+      );
+    },
+    execute: async (trigger) => {
+      const startedAt = new Date();
+      const startedAtMs = Date.now();
+      const label = trigger === "manual" ? "Manual" : "Automatic";
+      try {
+        logger.info({ backupDir: config.databaseBackupDir, trigger }, `${label} database backup starting`);
+        // Read retention from Instance Settings (DB) so changes take effect without restart.
+        const generalSettings = await backupSettingsSvc.getGeneral();
+        const retention = generalSettings.backupRetention;
 
-    databaseBackupInFlight = true;
-    const startedAt = new Date();
-    const startedAtMs = Date.now();
-    const label = trigger === "scheduled" ? "Automatic" : "Manual";
-    try {
-      logger.info({ backupDir: config.databaseBackupDir, trigger }, `${label} database backup starting`);
-      // Read retention from Instance Settings (DB) so changes take effect without restart.
-      const generalSettings = await backupSettingsSvc.getGeneral();
-      const retention = generalSettings.backupRetention;
-
-      const result = await runDatabaseBackup({
-        connectionString: activeDatabaseConnectionString,
-        backupDir: config.databaseBackupDir,
-        retention,
-        filenamePrefix: "paperclip",
-      });
-      const finishedAt = new Date();
-      const response: InstanceDatabaseBackupRunResult = {
-        ...result,
-        trigger,
-        backupDir: config.databaseBackupDir,
-        retention,
-        startedAt: startedAt.toISOString(),
-        finishedAt: finishedAt.toISOString(),
-        durationMs: Date.now() - startedAtMs,
-      };
-      logger.info(
-        {
-          backupFile: result.backupFile,
-          sizeBytes: result.sizeBytes,
-          prunedCount: result.prunedCount,
+        const result = await runDatabaseBackup({
+          connectionString: activeDatabaseConnectionString,
           backupDir: config.databaseBackupDir,
           retention,
+          filenamePrefix: "paperclip",
+        });
+        const finishedAt = new Date();
+        const response: InstanceDatabaseBackupRunResult = {
+          ...result,
           trigger,
-          durationMs: response.durationMs,
-        },
-        `${label} database backup complete: ${formatDatabaseBackupResult(result)}`,
-      );
-      return response;
-    } catch (err) {
-      logger.error({ err, backupDir: config.databaseBackupDir, trigger }, `${label} database backup failed`);
-      throw err;
-    } finally {
-      databaseBackupInFlight = false;
-    }
+          backupDir: config.databaseBackupDir,
+          retention,
+          startedAt: startedAt.toISOString(),
+          finishedAt: finishedAt.toISOString(),
+          durationMs: Date.now() - startedAtMs,
+        };
+        logger.info(
+          {
+            backupFile: result.backupFile,
+            sizeBytes: result.sizeBytes,
+            prunedCount: result.prunedCount,
+            backupDir: config.databaseBackupDir,
+            retention,
+            trigger,
+            durationMs: response.durationMs,
+          },
+          `${label} database backup complete: ${formatDatabaseBackupResult(result)}`,
+        );
+        return response;
+      } catch (err) {
+        logger.error({ err, backupDir: config.databaseBackupDir, trigger }, `${label} database backup failed`);
+        throw err;
+      }
+    },
+  });
+  const runServerDatabaseBackup = (
+    trigger: InstanceDatabaseBackupTrigger,
+  ): Promise<InstanceDatabaseBackupRunResult | null> => {
+    return databaseBackupCoordinator.run(trigger);
   };
   const pluginWorkerManager = createPluginWorkerManager();
   const app = await createApp(db as any, {
@@ -1100,23 +1102,7 @@ export async function startServer(): Promise<StartedServer> {
     }, config.heartbeatSchedulerIntervalMs);
   }
   
-  if (config.databaseBackupEnabled) {
-    const backupIntervalMs = config.databaseBackupIntervalMinutes * 60 * 1000;
-
-    logger.info(
-      {
-        intervalMinutes: config.databaseBackupIntervalMinutes,
-        retentionSource: "instance-settings-db",
-        backupDir: config.databaseBackupDir,
-      },
-      "Automatic database backups enabled",
-    );
-    setInterval(() => {
-      void runServerDatabaseBackup("scheduled").catch(() => {
-        // runServerDatabaseBackup already logs the failure with context.
-      });
-    }, backupIntervalMs);
-  }
+  let databaseBackupInterval: ReturnType<typeof setInterval> | null = null;
   
   // Wait for external adapters to finish loading before accepting requests.
   // Without this, adapter type validation (assertKnownAdapterType) would
@@ -1196,9 +1182,30 @@ export async function startServer(): Promise<StartedServer> {
       resolveListen();
     });
   });
+
+  if (config.databaseBackupEnabled) {
+    const backupIntervalMs = config.databaseBackupIntervalMinutes * 60 * 1000;
+    logger.info(
+      {
+        intervalMinutes: config.databaseBackupIntervalMinutes,
+        retentionSource: "instance-settings-db",
+        backupDir: config.databaseBackupDir,
+        startupBackup: true,
+      },
+      "Automatic database backups enabled",
+    );
+    databaseBackupInterval = startDatabaseBackupScheduler({
+      intervalMs: backupIntervalMs,
+      run: runServerDatabaseBackup,
+    });
+  }
   
   {
     const shutdown = async (signal: "SIGINT" | "SIGTERM") => {
+      if (databaseBackupInterval) {
+        clearInterval(databaseBackupInterval);
+        databaseBackupInterval = null;
+      }
       heartbeatSchedulerStopped = true;
       if (heartbeatSchedulerInterval) {
         clearInterval(heartbeatSchedulerInterval);

--- a/server/src/routes/instance-database-backups.ts
+++ b/server/src/routes/instance-database-backups.ts
@@ -2,7 +2,7 @@ import { Router } from "express";
 import type { BackupRetentionPolicy, RunDatabaseBackupResult } from "@paperclipai/db";
 import { assertInstanceAdmin } from "./authz.js";
 
-export type InstanceDatabaseBackupTrigger = "manual" | "scheduled";
+export type InstanceDatabaseBackupTrigger = "manual" | "scheduled" | "startup";
 
 export type InstanceDatabaseBackupRunResult = RunDatabaseBackupResult & {
   trigger: InstanceDatabaseBackupTrigger;

--- a/server/src/services/database-backup-scheduler.ts
+++ b/server/src/services/database-backup-scheduler.ts
@@ -1,0 +1,50 @@
+import { conflict } from "../errors.js";
+import type { InstanceDatabaseBackupTrigger } from "../routes/instance-database-backups.js";
+
+type BackupTimer = ReturnType<typeof setInterval>;
+
+export type DatabaseBackupCoordinator<T> = {
+  run(trigger: InstanceDatabaseBackupTrigger): Promise<T | null>;
+};
+
+export function createDatabaseBackupCoordinator<T>(opts: {
+  execute(trigger: InstanceDatabaseBackupTrigger): Promise<T>;
+  onAutomatedOverlap(trigger: Exclude<InstanceDatabaseBackupTrigger, "manual">): void;
+}): DatabaseBackupCoordinator<T> {
+  let inFlight = false;
+
+  return {
+    async run(trigger) {
+      if (inFlight) {
+        if (trigger === "manual") {
+          throw conflict("Database backup already in progress");
+        }
+        opts.onAutomatedOverlap(trigger);
+        return null;
+      }
+
+      inFlight = true;
+      try {
+        return await opts.execute(trigger);
+      } finally {
+        inFlight = false;
+      }
+    },
+  };
+}
+
+export function startDatabaseBackupScheduler(opts: {
+  intervalMs: number;
+  run(trigger: Exclude<InstanceDatabaseBackupTrigger, "manual">): Promise<unknown>;
+  queueStartup?: (callback: () => void) => void;
+  setInterval?: (callback: () => void, intervalMs: number) => BackupTimer;
+}): BackupTimer {
+  const invoke = (trigger: Exclude<InstanceDatabaseBackupTrigger, "manual">) => {
+    void opts.run(trigger).catch(() => {
+      // The shared backup execution path records failures with full context.
+    });
+  };
+
+  (opts.queueStartup ?? queueMicrotask)(() => invoke("startup"));
+  return (opts.setInterval ?? setInterval)(() => invoke("scheduled"), opts.intervalMs);
+}


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Self-hosted PostgreSQL deployments rely on the built-in automatic backup scheduler for recoverability
> - The scheduler currently waits for the full interval before its first backup, and every restart resets that wait
> - Repeated restarts can therefore leave the newest backup older than the configured health threshold
> - The existing manual and scheduled paths already provide retention, logging, and overlap protection that should remain authoritative
> - This pull request queues one guarded backup after the server starts listening and keeps the existing interval intact
> - The benefit is prompt post-restart recovery coverage without overlapping backups or making backup failure block server availability

## Linked Issues or Issue Description

No matching public GitHub issue or pull request was found. Inline bug report:

### Pre-submission checklist

- [x] I searched open and closed issues and found no duplicate.
- [x] This reproduces on `master`.
- [x] The behavior originates in Paperclip core, not an adapter, provider, or local configuration.

### What happened?

With automatic database backups enabled, restarting Paperclip resets the interval timer and no backup runs until the entire interval elapses. Repeated restarts can leave backup health stale even though scheduling is enabled.

### Expected behavior

After the server begins listening, Paperclip should promptly attempt one automatic backup, then continue the configured interval. Startup, scheduled, and manual attempts must share overlap protection, and a startup backup failure must not stop the server or future scheduled attempts.

### Steps to reproduce

1. Enable PostgreSQL backups with a non-trivial interval.
2. Restart Paperclip after clearing or aging the backup directory.
3. Observe that the first new dump is not created until the interval expires.

### Paperclip version or commit

`master` at `936215693`.

### Deployment mode

Self-hosted server.

### Database mode

External Postgres.

### Agent adapters involved

Not adapter-specific (core bug).

### Privacy checklist

- [x] I reviewed this description for PII and secrets; none are included.

## What Changed

- Added a shared coordinator for startup, scheduled, and manual backups so all triggers use the same no-overlap guard.
- Queued one startup backup after the server starts listening while retaining the configured recurring interval.
- Isolated startup failures through the existing logging path and clear the recurring timer during shutdown.
- Added focused tests for startup scheduling, failure isolation, automated overlap, manual conflict behavior, and guard release after failure.

## Verification

- `pnpm exec vitest run server/src/__tests__/database-backup-scheduler.test.ts server/src/__tests__/instance-database-backups-routes.test.ts` — 2 files passed, 9 tests passed.
- `pnpm --filter @paperclipai/server typecheck` — passed.
- Controlled restart evidence from the implementation run: a fresh compressed dump was created about four seconds after process start, and `/api/health` reported backup status `ok`, age `0h`, and no warnings.

## Risks

- A backup now starts shortly after listen and can add brief database/disk load during warm-up.
- The shared coordinator limits blast radius by skipping overlapping automated attempts and returning conflict for overlapping manual requests.
- Backup failures remain logged and isolated from server availability; the recurring interval remains registered.
- Rollback is limited to removing the queued `startup` invocation while retaining interval registration and the existing backup path.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- Initial implementation: Cursor `auto` model selection (underlying provider/model ID and context window were not exposed), with repository tool use and code execution.
- Recovery, rebase, and verification: OpenAI GPT-5.6 Sol (`gpt-5.6-sol-medium`), with reasoning, repository tool use, and code execution; context window size was not exposed.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes (no documentation change required for this internal scheduling behavior)
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

Made with [Cursor](https://cursor.com)