### PR TITLE
Harden workspace branch reconciliation

### DIFF
--- a/cli/src/__tests__/company.test.ts
+++ b/cli/src/__tests__/company.test.ts
@@ -1,4 +1,7 @@
 import { Command } from "commander";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { CompanyPortabilityPreviewResult } from "@paperclipai/shared";
 import {
@@ -16,6 +19,19 @@ import {
 
 const ORIGINAL_ENV = { ...process.env };
 const COMPANY_ID = "22222222-2222-4222-8222-222222222222";
+
+function clearPaperclipEnv() {
+  for (const key of Object.keys(process.env)) {
+    if (key.startsWith("PAPERCLIP_")) {
+      delete process.env[key];
+    }
+  }
+}
+
+function createTempContextPath(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "paperclip-cli-company-"));
+  return path.join(dir, "context.json");
+}
 
 function makeProgram(): Command {
   const program = new Command();
@@ -71,9 +87,8 @@ describe("company CLI commands", () => {
 
   beforeEach(() => {
     process.env = { ...ORIGINAL_ENV };
-    delete process.env.PAPERCLIP_API_URL;
-    delete process.env.PAPERCLIP_API_KEY;
-    delete process.env.PAPERCLIP_COMPANY_ID;
+    clearPaperclipEnv();
+    process.env.PAPERCLIP_CONTEXT = createTempContextPath();
     fetchMock = vi.fn();
     vi.stubGlobal("fetch", fetchMock);
     logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);

--- a/cli/src/__tests__/prompt.test.ts
+++ b/cli/src/__tests__/prompt.test.ts
@@ -7,6 +7,14 @@ import { runAgentPrompt } from "../commands/client/prompt.js";
 
 const ORIGINAL_ENV = { ...process.env };
 
+function clearPaperclipEnv() {
+  for (const key of Object.keys(process.env)) {
+    if (key.startsWith("PAPERCLIP_")) {
+      delete process.env[key];
+    }
+  }
+}
+
 function createTempContextPath(): string {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "paperclip-cli-prompt-"));
   return path.join(dir, "context.json");
@@ -27,7 +35,7 @@ function agent(overrides: Record<string, unknown> = {}) {
 describe("prompt handoff", () => {
   beforeEach(() => {
     process.env = { ...ORIGINAL_ENV };
-    delete process.env.PAPERCLIP_API_KEY;
+    clearPaperclipEnv();
     vi.restoreAllMocks();
   });
 
@@ -58,18 +66,21 @@ describe("prompt handoff", () => {
   });
 
   it("fails when the supplied agent key belongs to a different agent", async () => {
+    const contextPath = createTempContextPath();
     const fetchMock = vi.fn().mockResolvedValue(
       new Response(JSON.stringify(agent()), { status: 200 }),
     );
     vi.stubGlobal("fetch", fetchMock);
 
     await expect(runAgentPrompt("other-agent", "Do the work", {
+      context: contextPath,
       apiBase: "http://localhost:3100",
       apiKey: "agent-token",
     })).rejects.toThrow(/Agent key belongs to Worker/);
   });
 
   it("creates an assigned issue and wakes the authenticated agent", async () => {
+    const contextPath = createTempContextPath();
     const fetchMock = vi
       .fn()
       .mockResolvedValueOnce(new Response(JSON.stringify(agent()), { status: 200 }))
@@ -85,6 +96,7 @@ describe("prompt handoff", () => {
     vi.stubGlobal("fetch", fetchMock);
 
     const result = await runAgentPrompt("worker", "Investigate queue lag", {
+      context: contextPath,
       apiBase: "http://localhost:3100",
       apiKey: "agent-token",
     });

--- a/cli/src/__tests__/telemetry.test.ts
+++ b/cli/src/__tests__/telemetry.test.ts
@@ -6,6 +6,14 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 const ORIGINAL_ENV = { ...process.env };
 const CI_ENV_VARS = ["CI", "CONTINUOUS_INTEGRATION", "BUILD_NUMBER", "GITHUB_ACTIONS", "GITLAB_CI"];
 
+function clearPaperclipEnv() {
+  for (const key of Object.keys(process.env)) {
+    if (key.startsWith("PAPERCLIP_")) {
+      delete process.env[key];
+    }
+  }
+}
+
 function makeConfigPath(root: string, enabled: boolean): string {
   const configPath = path.join(root, ".paperclip", "config.json");
   fs.mkdirSync(path.dirname(configPath), { recursive: true });
@@ -71,6 +79,8 @@ function makeConfigPath(root: string, enabled: boolean): string {
 describe("cli telemetry", () => {
   beforeEach(() => {
     process.env = { ...ORIGINAL_ENV };
+    clearPaperclipEnv();
+    delete process.env.DO_NOT_TRACK;
     for (const key of CI_ENV_VARS) {
       delete process.env[key];
     }

--- a/packages/skills-catalog/src/packaged-artifacts.test.ts
+++ b/packages/skills-catalog/src/packaged-artifacts.test.ts
@@ -13,11 +13,22 @@ function readPackMetadata(packDestination: string) {
     cwd: packageRoot,
     encoding: "utf8",
   });
-  const metadata = JSON.parse(output);
+  const metadata = normalizePackMetadata(JSON.parse(output));
   if (!Array.isArray(metadata) || metadata.length === 0 || typeof metadata[0]?.filename !== "string") {
     throw new Error(`Unexpected npm pack output from ${packageRoot}: ${output}`);
   }
   return metadata[0] as { filename: string; files: Array<{ path: string }> };
+}
+
+function normalizePackMetadata(metadata: unknown): unknown[] {
+  if (Array.isArray(metadata)) return metadata;
+  if (metadata && typeof metadata === "object") {
+    const entries = Object.values(metadata);
+    if (entries.every((entry) => entry && typeof entry === "object" && "filename" in entry)) {
+      return entries;
+    }
+  }
+  return [];
 }
 
 describe("skills catalog package artifacts", () => {

--- a/packages/skills-catalog/src/packaged-artifacts.test.ts
+++ b/packages/skills-catalog/src/packaged-artifacts.test.ts
@@ -8,6 +8,8 @@ import { afterEach, describe, expect, it } from "vitest";
 
 const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 
+type PackMetadata = { filename: string; files: Array<{ path: string }> };
+
 function readPackMetadata(packDestination: string) {
   const output = execFileSync("npm", ["pack", "--json", "--pack-destination", packDestination], {
     cwd: packageRoot,
@@ -17,18 +19,22 @@ function readPackMetadata(packDestination: string) {
   if (!Array.isArray(metadata) || metadata.length === 0 || typeof metadata[0]?.filename !== "string") {
     throw new Error(`Unexpected npm pack output from ${packageRoot}: ${output}`);
   }
-  return metadata[0] as { filename: string; files: Array<{ path: string }> };
+  return metadata[0] as PackMetadata;
 }
 
-function normalizePackMetadata(metadata: unknown): unknown[] {
-  if (Array.isArray(metadata)) return metadata;
+function normalizePackMetadata(metadata: unknown): PackMetadata[] {
+  if (Array.isArray(metadata)) return metadata.filter(isPackMetadata);
   if (metadata && typeof metadata === "object") {
     const entries = Object.values(metadata);
-    if (entries.every((entry) => entry && typeof entry === "object" && "filename" in entry)) {
+    if (entries.every(isPackMetadata)) {
       return entries;
     }
   }
   return [];
+}
+
+function isPackMetadata(entry: unknown): entry is PackMetadata {
+  return Boolean(entry && typeof entry === "object" && "filename" in entry);
 }
 
 describe("skills catalog package artifacts", () => {

--- a/server/src/__tests__/execution-workspaces-service.test.ts
+++ b/server/src/__tests__/execution-workspaces-service.test.ts
@@ -1351,6 +1351,90 @@ describeEmbeddedPostgres("executionWorkspaceService.getCloseReadiness", () => {
     expect(comments).toHaveLength(0);
   }, 20_000);
 
+  it("rejects forward reconciliation for a dirty registered branch when the recorded branch is missing", async () => {
+    const repoRoot = await createTempRepo();
+    tempDirs.add(repoRoot);
+    const worktreePath = path.join(path.dirname(repoRoot), `paperclip-dirty-missing-recorded-${randomUUID()}`);
+    tempDirs.add(worktreePath);
+
+    await runGit(repoRoot, ["branch", "feature/recorded"]);
+    await runGit(repoRoot, ["worktree", "add", "-b", "feature/current", worktreePath, "feature/recorded"]);
+    await runGit(repoRoot, ["branch", "-D", "feature/recorded"]);
+    await fs.writeFile(path.join(worktreePath, "dirty.txt"), "not safe to reconcile\n", "utf8");
+
+    const companyId = randomUUID();
+    const projectId = randomUUID();
+    const issueId = randomUUID();
+    const executionWorkspaceId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: "PAP",
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(projects).values({
+      id: projectId,
+      companyId,
+      name: "Branch reconcile",
+      status: "in_progress",
+    });
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      projectId,
+      title: "Source task",
+      status: "blocked",
+      priority: "medium",
+    });
+    await db.insert(executionWorkspaces).values({
+      id: executionWorkspaceId,
+      companyId,
+      projectId,
+      sourceIssueId: issueId,
+      mode: "isolated_workspace",
+      strategyType: "git_worktree",
+      name: "feature/recorded",
+      status: "idle",
+      providerType: "git_worktree",
+      cwd: worktreePath,
+      providerRef: worktreePath,
+      branchName: "feature/recorded",
+      baseRef: "main",
+    });
+
+    await expect(svc.reconcileExecutionWorkspaceBranch(executionWorkspaceId, {
+      mode: "forward",
+      reason: "recorded branch was deleted",
+      actor: {
+        actorType: "user",
+        actorId: "local-board",
+        agentId: null,
+        runId: null,
+      },
+    })).rejects.toMatchObject({
+      status: 422,
+      message: "Forward branch reconciliation requires the recorded branch to be an ancestor of the checked-out branch or a missing recorded branch with a registered checked-out worktree branch",
+      details: {
+        inspection: expect.objectContaining({
+          cleanliness: "dirty",
+          statusEntryCount: 1,
+          fromBranch: "feature/recorded",
+          toBranch: "feature/current",
+          fromSha: null,
+          registeredPathFound: true,
+          registeredBranchMatchesHead: true,
+        }),
+      },
+    });
+
+    const [workspace] = await db
+      .select()
+      .from(executionWorkspaces)
+      .where(eq(executionWorkspaces.id, executionWorkspaceId));
+    expect(workspace?.branchName).toBe("feature/recorded");
+  }, 20_000);
+
   it("rejects branch reconciliation while the workspace lifecycle is active", async () => {
     const repoRoot = await createTempRepo();
     tempDirs.add(repoRoot);
@@ -2042,7 +2126,7 @@ describeEmbeddedPostgres("executionWorkspaceService.getCloseReadiness", () => {
     expect(comments).toHaveLength(0);
   }, 20_000);
 
-  it("rejects forward branch reconciliation when branch ancestry is unknown", async () => {
+  it("allows forward reconciliation when a clean registered branch replaces a missing recorded branch", async () => {
     const repoRoot = await createTempRepo();
     tempDirs.add(repoRoot);
     const worktreePath = path.join(path.dirname(repoRoot), `paperclip-unknown-${randomUUID()}`);
@@ -2092,7 +2176,7 @@ describeEmbeddedPostgres("executionWorkspaceService.getCloseReadiness", () => {
       baseRef: "main",
     });
 
-    await expect(svc.reconcileExecutionWorkspaceBranch(executionWorkspaceId, {
+    const result = await svc.reconcileExecutionWorkspaceBranch(executionWorkspaceId, {
       mode: "forward",
       reason: null,
       actor: {
@@ -2101,20 +2185,20 @@ describeEmbeddedPostgres("executionWorkspaceService.getCloseReadiness", () => {
         agentId: null,
         runId: null,
       },
-    })).rejects.toMatchObject({
-      status: 422,
-      details: {
-        inspection: expect.objectContaining({
-          ancestryVerdict: "unknown",
-          fromBranch: "feature/missing-recorded",
-          toBranch: "feature/current",
-          fromSha: null,
-        }),
-      },
+    });
+    expect(result.workspace.branchName).toBe("feature/current");
+    expect(result.inspection).toMatchObject({
+      ancestryVerdict: "unknown",
+      cleanliness: "clean",
+      fromBranch: "feature/missing-recorded",
+      toBranch: "feature/current",
+      fromSha: null,
+      registeredPathFound: true,
+      registeredBranchMatchesHead: true,
     });
 
     const comments = await db.select().from(issueComments).where(eq(issueComments.issueId, issueId));
-    expect(comments).toHaveLength(0);
+    expect(comments).toHaveLength(1);
   }, 20_000);
 
   it("returns a bounded company-scoped workspace overview with service and linked issue summaries", async () => {

--- a/server/src/__tests__/heartbeat-workspace-branch-containment.test.ts
+++ b/server/src/__tests__/heartbeat-workspace-branch-containment.test.ts
@@ -145,6 +145,7 @@ async function createForwardBranchMismatch(input: {
   expectedBranch: string;
   actualBranch: string;
   divergeRecordedBranch?: boolean;
+  deleteRecordedBranch?: boolean;
 }) {
   await mkdir(path.dirname(input.worktreePath), { recursive: true });
   await runGit(input.repoRoot, ["branch", input.expectedBranch]);
@@ -158,6 +159,9 @@ async function createForwardBranchMismatch(input: {
   await writeFile(path.join(input.worktreePath, "actual-branch.txt"), "actual branch work\n", "utf8");
   await runGit(input.worktreePath, ["add", "actual-branch.txt"]);
   await runGit(input.worktreePath, ["commit", "-m", "Add actual branch work"]);
+  if (input.deleteRecordedBranch) {
+    await runGit(input.repoRoot, ["branch", "-D", input.expectedBranch]);
+  }
 }
 
 async function waitForRunToFinish(heartbeat: Heartbeat, runId: string, timeoutMs = 10_000) {
@@ -313,7 +317,7 @@ async function seedBranchContainmentRun(
   db: Db,
   repoRoot: string,
   callSite: BranchContainmentCallSite,
-  opts: { enableWorkspaceBranchReconcileForward?: boolean } = {},
+  opts: { enableWorkspaceBranchReconcileForward?: boolean; deleteRecordedBranch?: boolean } = {},
 ) {
   const companyId = randomUUID();
   const projectId = randomUUID();
@@ -401,6 +405,7 @@ async function seedBranchContainmentRun(
       expectedBranch,
       actualBranch,
       divergeRecordedBranch: opts.enableWorkspaceBranchReconcileForward !== true,
+      deleteRecordedBranch: opts.deleteRecordedBranch === true,
     });
   }
 
@@ -719,6 +724,7 @@ async function expectForwardBranchReconciled(input: {
   worktreePath: string;
   expectsExistingRecordUpdate: boolean;
   expectedResolvedRecoveryActionFingerprint?: string | null;
+  expectedReconcileAncestryVerdict?: "ancestor" | "unknown";
 }) {
   const finishedRun = await waitForRunToFinish(input.heartbeat, input.runId, 10_000);
   expect(finishedRun).toMatchObject({
@@ -796,6 +802,7 @@ async function expectForwardBranchReconciled(input: {
   }
 
   if (input.expectsExistingRecordUpdate) {
+    const expectedAncestryVerdict = input.expectedReconcileAncestryVerdict ?? "ancestor";
     const [updatedWorkspace] = await input.db
       .select({
         name: executionWorkspaces.name,
@@ -850,7 +857,7 @@ async function expectForwardBranchReconciled(input: {
             mode: "forward",
             fromBranch: input.expectedBranch,
             toBranch: input.actualBranch,
-            ancestryVerdict: "ancestor",
+            ancestryVerdict: expectedAncestryVerdict,
           }),
         }),
       ]),
@@ -1105,7 +1112,7 @@ describeEmbeddedPostgres("heartbeat workspace branch containment", () => {
   }, 30_000);
 
   it.each([
-    ["workspace-runtime fresh worktree reuse", "fresh_realize" as const, false],
+    ["workspace-runtime fresh worktree reuse", "fresh_realize" as const, true],
     ["workspace-runtime persisted restore", "persisted_restore" as const, true],
     ["heartbeat finalization", "finalize" as const, false],
   ])("auto-reconciles forward branch divergence at %s when the flag is enabled", async (_name, callSite, expectsExistingRecordUpdate) => {
@@ -1209,6 +1216,59 @@ describeEmbeddedPostgres("heartbeat workspace branch containment", () => {
       worktreePath: seeded.worktreePath,
       expectsExistingRecordUpdate,
       expectedResolvedRecoveryActionFingerprint,
+    });
+    expect(adapterExecute).toHaveBeenCalledTimes(1);
+  }, 30_000);
+
+  it("reuses a persisted registered worktree branch when the recorded branch was deleted", async () => {
+    const repoRoot = await createGitRepo();
+    tempRoots.push(repoRoot);
+    const seeded = await seedBranchContainmentRun(db, repoRoot, "persisted_restore", {
+      enableWorkspaceBranchReconcileForward: true,
+      deleteRecordedBranch: true,
+    });
+
+    const expectedWorktreeStateAfterReconcile = {
+      head: await readGit(seeded.worktreePath, ["rev-parse", "HEAD"]),
+      status: await readGit(seeded.worktreePath, ["status", "--porcelain", "--untracked-files=all"]),
+    };
+
+    adapterExecute.mockImplementationOnce(async () => {
+      await db
+        .update(issues)
+        .set({
+          status: "done",
+          completedAt: new Date(),
+          checkoutRunId: null,
+          executionRunId: null,
+          updatedAt: new Date(),
+        })
+        .where(eq(issues.id, seeded.sourceIssueId));
+      return {
+        exitCode: 0,
+        signal: null,
+        timedOut: false,
+        summary: "Adapter completed after registered branch reconciliation.",
+        provider: "test",
+        model: "test-model",
+      };
+    });
+
+    const heartbeat = heartbeatService(db);
+    await heartbeat.resumeQueuedRuns();
+
+    await expectForwardBranchReconciled({
+      db,
+      heartbeat,
+      runId: seeded.runId,
+      sourceIssueId: seeded.sourceIssueId,
+      sourceExecutionWorkspaceId: seeded.sourceExecutionWorkspaceId,
+      expectedBranch: seeded.expectedBranch,
+      actualBranch: seeded.actualBranch,
+      expectedWorktreeStateAfterReconcile,
+      worktreePath: seeded.worktreePath,
+      expectsExistingRecordUpdate: true,
+      expectedReconcileAncestryVerdict: "unknown",
     });
     expect(adapterExecute).toHaveBeenCalledTimes(1);
   }, 30_000);

--- a/server/src/__tests__/heartbeat-workspace-branch-containment.test.ts
+++ b/server/src/__tests__/heartbeat-workspace-branch-containment.test.ts
@@ -1106,7 +1106,7 @@ describeEmbeddedPostgres("heartbeat workspace branch containment", () => {
 
   it.each([
     ["workspace-runtime fresh worktree reuse", "fresh_realize" as const, false],
-    ["workspace-runtime persisted restore", "persisted_restore" as const, false],
+    ["workspace-runtime persisted restore", "persisted_restore" as const, true],
     ["heartbeat finalization", "finalize" as const, false],
   ])("auto-reconciles forward branch divergence at %s when the flag is enabled", async (_name, callSite, expectsExistingRecordUpdate) => {
     const repoRoot = await createGitRepo();

--- a/server/src/__tests__/heartbeat-workspace-branch-containment.test.ts
+++ b/server/src/__tests__/heartbeat-workspace-branch-containment.test.ts
@@ -606,7 +606,13 @@ async function expectContainedWorkspaceBranchFailure(input: {
   sourceExecutionWorkspaceId?: string | null;
   expectedBranch: string;
   actualBranch: string;
+  expectedAncestryVerdict?: "diverged" | "unknown";
+  expectedSafeRepairReason?: string;
+  expectedPlainLanguageReason?: string;
 }) {
+  const expectedAncestryVerdict = input.expectedAncestryVerdict ?? "diverged";
+  const expectedSafeRepairReason = input.expectedSafeRepairReason ?? "expected branch and current HEAD differ";
+  const expectedPlainLanguageReason = input.expectedPlainLanguageReason ?? "cannot prove a forward-only reconciliation";
   const finishedRun = await waitForRunToFinish(input.heartbeat, input.runId, 10_000);
   expect(finishedRun).toMatchObject({
     status: "failed",
@@ -625,7 +631,7 @@ async function expectContainedWorkspaceBranchFailure(input: {
       eligible: false,
       attempted: false,
       succeeded: false,
-      reason: "expected branch and current HEAD differ",
+      reason: expectedSafeRepairReason,
     }),
   });
   if (input.sourceExecutionWorkspaceId !== undefined) {
@@ -635,15 +641,19 @@ async function expectContainedWorkspaceBranchFailure(input: {
   expect(provenance).toMatchObject({
     expectedBranchRef: `refs/heads/${input.expectedBranch}`,
     actualBranchRef: `refs/heads/${input.actualBranch}`,
-    expectedBranchExists: true,
+    expectedBranchExists: expectedAncestryVerdict === "unknown" ? false : true,
     actualBranchExists: true,
     sameHead: false,
-    ancestryVerdict: "diverged",
+    ancestryVerdict: expectedAncestryVerdict,
   });
-  expect(provenance.expectedHeadSha).toEqual(expect.stringMatching(/^[a-f0-9]{40}$/));
+  if (expectedAncestryVerdict === "unknown") {
+    expect(provenance.expectedHeadSha).toBeNull();
+  } else {
+    expect(provenance.expectedHeadSha).toEqual(expect.stringMatching(/^[a-f0-9]{40}$/));
+  }
   expect(provenance.actualHeadSha).toEqual(expect.stringMatching(/^[a-f0-9]{40}$/));
   expect(provenance.expectedHeadSha).not.toBe(provenance.actualHeadSha);
-  expect(provenance.plainLanguageReason).toEqual(expect.stringContaining("cannot prove a forward-only reconciliation"));
+  expect(provenance.plainLanguageReason).toEqual(expect.stringContaining(expectedPlainLanguageReason));
 
   const { issueRows, actionRows, comments } = await waitForContainmentSideEffects({
     db: input.db,
@@ -691,7 +701,7 @@ async function expectContainedWorkspaceBranchFailure(input: {
         provenance: expect.objectContaining({
           expectedHeadSha: provenance.expectedHeadSha,
           actualHeadSha: provenance.actualHeadSha,
-          ancestryVerdict: "diverged",
+          ancestryVerdict: expectedAncestryVerdict,
           plainLanguageReason: provenance.plainLanguageReason,
         }),
       }),
@@ -1220,7 +1230,7 @@ describeEmbeddedPostgres("heartbeat workspace branch containment", () => {
     expect(adapterExecute).toHaveBeenCalledTimes(1);
   }, 30_000);
 
-  it("reuses a persisted registered worktree branch when the recorded branch was deleted", async () => {
+  it("contains a persisted registered worktree branch when the recorded branch was deleted", async () => {
     const repoRoot = await createGitRepo();
     tempRoots.push(repoRoot);
     const seeded = await seedBranchContainmentRun(db, repoRoot, "persisted_restore", {
@@ -1228,48 +1238,24 @@ describeEmbeddedPostgres("heartbeat workspace branch containment", () => {
       deleteRecordedBranch: true,
     });
 
-    const expectedWorktreeStateAfterReconcile = {
-      head: await readGit(seeded.worktreePath, ["rev-parse", "HEAD"]),
-      status: await readGit(seeded.worktreePath, ["status", "--porcelain", "--untracked-files=all"]),
-    };
-
-    adapterExecute.mockImplementationOnce(async () => {
-      await db
-        .update(issues)
-        .set({
-          status: "done",
-          completedAt: new Date(),
-          checkoutRunId: null,
-          executionRunId: null,
-          updatedAt: new Date(),
-        })
-        .where(eq(issues.id, seeded.sourceIssueId));
-      return {
-        exitCode: 0,
-        signal: null,
-        timedOut: false,
-        summary: "Adapter completed after registered branch reconciliation.",
-        provider: "test",
-        model: "test-model",
-      };
-    });
-
     const heartbeat = heartbeatService(db);
     await heartbeat.resumeQueuedRuns();
 
-    await expectForwardBranchReconciled({
+    await expectContainedWorkspaceBranchFailure({
       db,
       heartbeat,
       runId: seeded.runId,
+      companyId: seeded.companyId,
       sourceIssueId: seeded.sourceIssueId,
+      sameWorkspaceSiblingId: seeded.sameWorkspaceSiblingId,
+      otherWorkspaceSiblingId: seeded.otherWorkspaceSiblingId,
       sourceExecutionWorkspaceId: seeded.sourceExecutionWorkspaceId,
       expectedBranch: seeded.expectedBranch,
       actualBranch: seeded.actualBranch,
-      expectedWorktreeStateAfterReconcile,
-      worktreePath: seeded.worktreePath,
-      expectsExistingRecordUpdate: true,
-      expectedReconcileAncestryVerdict: "unknown",
+      expectedAncestryVerdict: "unknown",
+      expectedSafeRepairReason: "expected branch does not exist",
+      expectedPlainLanguageReason: "missing a resolvable HEAD commit",
     });
-    expect(adapterExecute).toHaveBeenCalledTimes(1);
+    expect(adapterExecute).not.toHaveBeenCalled();
   }, 30_000);
 });

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -2918,6 +2918,94 @@ describeEmbeddedPostgres("issueService.create workspace inheritance", () => {
     });
   });
 
+  it("does not inherit parent workspace linkage when an issue targets a different project", async () => {
+    const companyId = randomUUID();
+    const parentProjectId = randomUUID();
+    const runtimeProjectId = randomUUID();
+    const parentIssueId = randomUUID();
+    const parentProjectWorkspaceId = randomUUID();
+    const runtimeProjectWorkspaceId = randomUUID();
+    const parentExecutionWorkspaceId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await instanceSettingsService(db).updateExperimental({ enableIsolatedWorkspaces: true });
+
+    await db.insert(projects).values([
+      {
+        id: parentProjectId,
+        companyId,
+        name: "Parent project",
+        status: "in_progress",
+      },
+      {
+        id: runtimeProjectId,
+        companyId,
+        name: "Runtime project",
+        status: "in_progress",
+      },
+    ]);
+
+    await db.insert(projectWorkspaces).values([
+      {
+        id: parentProjectWorkspaceId,
+        companyId,
+        projectId: parentProjectId,
+        name: "Parent workspace",
+        isPrimary: true,
+      },
+      {
+        id: runtimeProjectWorkspaceId,
+        companyId,
+        projectId: runtimeProjectId,
+        name: "Runtime workspace",
+        isPrimary: true,
+      },
+    ]);
+
+    await db.insert(executionWorkspaces).values({
+      id: parentExecutionWorkspaceId,
+      companyId,
+      projectId: parentProjectId,
+      projectWorkspaceId: parentProjectWorkspaceId,
+      mode: "isolated_workspace",
+      strategyType: "git_worktree",
+      name: "Parent worktree",
+      status: "active",
+      providerType: "git_worktree",
+    });
+
+    await db.insert(issues).values({
+      id: parentIssueId,
+      companyId,
+      projectId: parentProjectId,
+      projectWorkspaceId: parentProjectWorkspaceId,
+      title: "Parent issue",
+      status: "in_progress",
+      priority: "medium",
+      executionWorkspaceId: parentExecutionWorkspaceId,
+      executionWorkspacePreference: "reuse_existing",
+      executionWorkspaceSettings: {
+        mode: "isolated_workspace",
+      },
+    });
+
+    const child = await svc.create(companyId, {
+      parentId: parentIssueId,
+      projectId: runtimeProjectId,
+      title: "Runtime child issue",
+    });
+
+    expect(child.projectId).toBe(runtimeProjectId);
+    expect(child.projectWorkspaceId).toBe(runtimeProjectWorkspaceId);
+    expect(child.executionWorkspaceId).toBeNull();
+    expect(child.executionWorkspacePreference).toBeNull();
+  });
+
   it("inherits workspace linkage from an explicit source issue without creating a parent-child relationship", async () => {
     const companyId = randomUUID();
     const projectId = randomUUID();

--- a/server/src/__tests__/tool-gateway.test.ts
+++ b/server/src/__tests__/tool-gateway.test.ts
@@ -3514,7 +3514,7 @@ rl.on("line", (line) => {
       "mcp-stdio-fixture:increment_counter",
       "mcp-stdio-fixture:runtime_status",
     ]);
-    const gateway = createTestToolGatewayService(db, { runtimeSupervisor: { idleTtlMs: 25 } });
+    const gateway = createTestToolGatewayService(db, { runtimeSupervisor: { idleTtlMs: 250 } });
     const session = await gateway.createSession({
       companyId: company.id,
       agentId: agent.id,
@@ -3551,7 +3551,7 @@ rl.on("line", (line) => {
       resourceLimits: expect.objectContaining({ memoryCeilingSupported: expect.any(Boolean) }),
     });
 
-    await new Promise((resolve) => setTimeout(resolve, 35));
+    await new Promise((resolve) => setTimeout(resolve, 275));
     await expect(gateway.listRuntimeSlots(company.id)).resolves.toEqual([]);
     const [stoppedSlot] = await db.select().from(toolRuntimeSlots).where(eq(toolRuntimeSlots.id, idleSlot.id));
     expect(stoppedSlot).toMatchObject({

--- a/server/src/__tests__/workspace-runtime.test.ts
+++ b/server/src/__tests__/workspace-runtime.test.ts
@@ -31,6 +31,7 @@ import {
   ensureRuntimeServicesForRun,
   listConfiguredRuntimeServiceEntries,
   normalizeAdapterManagedRuntimeServices,
+  reconcilePendingForwardBranchAfterPersistence,
   reconcilePersistedRuntimeServicesOnStartup,
   realizeExecutionWorkspace,
   releaseRuntimeServicesForRun,
@@ -2664,6 +2665,70 @@ describe("realizeExecutionWorkspace", () => {
     await expect(readGit(worktreePath, ["branch", "--show-current"])).resolves.toBe(publicBranch);
   }, 15_000);
 
+  it("fails closed without database audit access when the recorded branch is missing but the worktree is on a registered public branch", async () => {
+    const repoRoot = await createTempRepo();
+    const recordedBranch = "internal-review-provenance";
+    const publicBranch = "fix/review-workspace-recovery";
+    const worktreePath = path.join(repoRoot, ".paperclip", "worktrees", recordedBranch);
+    await fs.mkdir(path.dirname(worktreePath), { recursive: true });
+    await runGit(repoRoot, ["branch", recordedBranch]);
+    await runGit(repoRoot, ["worktree", "add", "-b", publicBranch, worktreePath, recordedBranch]);
+    await runGit(repoRoot, ["branch", "-D", recordedBranch]);
+
+    await expect(ensurePersistedExecutionWorkspaceAvailable({
+      base: {
+        baseCwd: repoRoot,
+        source: "project_primary",
+        projectId: "project-1",
+        workspaceId: "workspace-1",
+        repoUrl: null,
+        repoRef: "HEAD",
+      },
+      workspace: {
+        id: "execution-workspace-deleted-recorded-public",
+        mode: "isolated_workspace",
+        strategyType: "git_worktree",
+        cwd: worktreePath,
+        providerRef: worktreePath,
+        projectId: "project-1",
+        projectWorkspaceId: "workspace-1",
+        repoUrl: null,
+        baseRef: "HEAD",
+        branchName: recordedBranch,
+      },
+      issue: {
+        id: "issue-deleted-recorded-public",
+        identifier: "PAP-PUBLIC-DELETED",
+        title: "Review public branch recovery",
+      },
+      agent: {
+        id: "agent-1",
+        name: "Codex Coder",
+        companyId: "company-1",
+      },
+      enableWorkspaceBranchReconcileForward: true,
+    })).rejects.toMatchObject({
+      code: "workspace_validation_failed",
+      resultJson: {
+        workspaceValidation: expect.objectContaining({
+          reason: "git_worktree_branch_incoherence",
+          expectedBranch: recordedBranch,
+          actualBranch: publicBranch,
+          cleanliness: "clean",
+          provenance: expect.objectContaining({
+            expectedBranchExists: false,
+            actualBranchExists: true,
+            registeredPathFound: true,
+            registeredBranchMatchesHead: true,
+          }),
+          safeRepair: expect.objectContaining({
+            reason: "forward reconciliation adoption requires database access to audit after workspace realization",
+          }),
+        }),
+      },
+    });
+  }, 15_000);
+
   it("classifies persisted git worktree branch incoherence as diverged when the checked-out branch is not forward", async () => {
     const repoRoot = await createTempRepo();
     const expectedBranch = "PAP-457-recorded-work";
@@ -2809,16 +2874,18 @@ describe("realizeExecutionWorkspace", () => {
           provenance: expect.objectContaining({
             expectedBranchExists: false,
             actualBranchExists: true,
+            registeredPathFound: true,
+            registeredBranchMatchesHead: true,
             expectedHeadSha: null,
             sameHead: false,
             ancestryVerdict: "unknown",
             plainLanguageReason: expect.stringContaining("missing a resolvable HEAD commit"),
           }),
           safeRepair: expect.objectContaining({
-            eligible: false,
+            eligible: true,
             attempted: false,
             succeeded: false,
-            reason: "expected branch does not exist",
+            reason: "forward reconciliation adoption requires database access to audit after workspace realization",
           }),
         }),
       },
@@ -4643,6 +4710,100 @@ describeEmbeddedPostgres("workspace dirty quarantine branch repair", () => {
       recorder: input.recorder ?? null,
     });
   }
+
+  it("persists review recovery branch adoption when the recorded branch was deleted but the checked-out branch is registered", async () => {
+    const repoRoot = await createTempRepo();
+    const recordedBranch = "internal-review-provenance";
+    const publicBranch = "fix/review-workspace-recovery";
+    const worktreePath = path.join(repoRoot, ".paperclip", "worktrees", recordedBranch);
+    await fs.mkdir(path.dirname(worktreePath), { recursive: true });
+    await runGit(repoRoot, ["branch", recordedBranch]);
+    await runGit(repoRoot, ["worktree", "add", "-b", publicBranch, worktreePath, recordedBranch]);
+    await runGit(repoRoot, ["branch", "-D", recordedBranch]);
+    const ids = await seedDirtyQuarantineRecords({
+      repoRoot,
+      worktreePath,
+      expectedBranch: recordedBranch,
+      actualBranch: publicBranch,
+      sourceIdentifier: "PAP-PUBLIC-DELETED",
+      claimant: "none",
+    });
+    const { recorder, operations } = createWorkspaceOperationRecorderDouble();
+
+    const restored = await ensurePersistedExecutionWorkspaceAvailable({
+      db,
+      base: {
+        baseCwd: repoRoot,
+        source: "project_primary",
+        projectId: ids.projectId,
+        workspaceId: ids.projectWorkspaceId,
+        repoUrl: null,
+        repoRef: "HEAD",
+      },
+      workspace: {
+        id: ids.sourceWorkspaceId,
+        mode: "isolated_workspace",
+        strategyType: "git_worktree",
+        cwd: worktreePath,
+        providerRef: worktreePath,
+        projectId: ids.projectId,
+        projectWorkspaceId: ids.projectWorkspaceId,
+        repoUrl: null,
+        baseRef: "HEAD",
+        branchName: recordedBranch,
+      },
+      issue: {
+        id: ids.sourceIssueId,
+        identifier: "PAP-PUBLIC-DELETED",
+        title: "Review public branch recovery",
+      },
+      agent: {
+        id: ids.agentId,
+        name: "Codex Coder",
+        companyId: ids.companyId,
+      },
+      heartbeatRunId: ids.runId,
+      enableWorkspaceBranchReconcileForward: true,
+      recorder,
+    });
+
+    expect(restored?.branchName).toBe(publicBranch);
+    expect(restored?.pendingForwardBranchReconcile).toMatchObject({
+      recordedBranchName: recordedBranch,
+      adoptedBranchName: publicBranch,
+    });
+
+    await reconcilePendingForwardBranchAfterPersistence({
+      db,
+      executionWorkspaceId: ids.sourceWorkspaceId,
+      pending: restored!.pendingForwardBranchReconcile!,
+      heartbeatRunId: ids.runId,
+      reconcileOperationPhase: "worktree_prepare",
+      recorder,
+    });
+
+    const [workspace] = await db
+      .select({ branchName: executionWorkspaces.branchName })
+      .from(executionWorkspaces)
+      .where(eq(executionWorkspaces.id, ids.sourceWorkspaceId));
+    expect(workspace?.branchName).toBe(publicBranch);
+
+    const comments = await db
+      .select({ body: issueComments.body })
+      .from(issueComments)
+      .where(eq(issueComments.issueId, ids.sourceIssueId));
+    expect(comments.some((comment) =>
+      comment.body.includes("Execution workspace branch reconciled.") &&
+      comment.body.includes(`- From branch: \`${recordedBranch}\``) &&
+      comment.body.includes(`- To branch: \`${publicBranch}\``) &&
+      comment.body.includes("- From SHA: `unknown`")
+    )).toBe(true);
+    expect(operations.some((operation) =>
+      operation.metadata?.reconcileMode === "adopt_for_realize" &&
+      operation.metadata?.expectedBranchName === recordedBranch &&
+      operation.metadata?.actualBranchName === publicBranch
+    )).toBe(true);
+  }, 15_000);
 
   it("quarantines dirty foreign-branch work into a rescue branch before restoring the recorded branch", async () => {
     const expectedBranch = "PAP-455-recorded";

--- a/server/src/__tests__/workspace-runtime.test.ts
+++ b/server/src/__tests__/workspace-runtime.test.ts
@@ -2616,7 +2616,7 @@ describe("realizeExecutionWorkspace", () => {
       recordedBranch: "LP-1119-internal-provenance",
       publicBranch: "fix/public-safe-lp-1119",
     },
-  ])("adopts $identifier public-safe branch when it matches the recorded provenance HEAD", async ({
+  ])("stages pending audited reconciliation for $identifier public-safe branch when it matches the recorded provenance HEAD", async ({
     identifier,
     recordedBranch,
     publicBranch,
@@ -2628,6 +2628,7 @@ describe("realizeExecutionWorkspace", () => {
     await runGit(repoRoot, ["worktree", "add", "-b", publicBranch, worktreePath, recordedBranch]);
 
     const restored = await ensurePersistedExecutionWorkspaceAvailable({
+      db: {} as ReturnType<typeof createDb>,
       base: {
         baseCwd: repoRoot,
         source: "project_primary",
@@ -2648,11 +2649,7 @@ describe("realizeExecutionWorkspace", () => {
         baseRef: "HEAD",
         branchName: recordedBranch,
       },
-      issue: {
-        id: `issue-${identifier.toLowerCase()}`,
-        identifier,
-        title: "Publish public-safe branch",
-      },
+      issue: null,
       agent: {
         id: "agent-1",
         name: "Codex Coder",
@@ -2663,6 +2660,12 @@ describe("realizeExecutionWorkspace", () => {
 
     expect(restored?.branchName).toBe(publicBranch);
     expect(restored?.warnings).toEqual([]);
+    expect(restored?.pendingForwardBranchReconcile).toEqual(expect.objectContaining({
+      recordedBranchName: recordedBranch,
+      adoptedBranchName: publicBranch,
+      prePersistenceFingerprint: expect.stringMatching(/^workspace_incoherence:v1:sha256:/),
+      reason: "Automatic branch provenance reconciliation: recorded branch and checked-out branch resolve to the same commit.",
+    }));
     await expect(readGit(worktreePath, ["branch", "--show-current"])).resolves.toBe(publicBranch);
   }, 15_000);
 

--- a/server/src/__tests__/workspace-runtime.test.ts
+++ b/server/src/__tests__/workspace-runtime.test.ts
@@ -2607,14 +2607,14 @@ describe("realizeExecutionWorkspace", () => {
 
   it.each([
     {
-      identifier: "LP-1083",
-      recordedBranch: "LP-1083-internal-provenance",
-      publicBranch: "fix/public-safe-lp-1083",
+      identifier: "TASK-101",
+      recordedBranch: "task-101-recorded-provenance",
+      publicBranch: "fix/public-safe-task-101",
     },
     {
-      identifier: "LP-1119",
-      recordedBranch: "LP-1119-internal-provenance",
-      publicBranch: "fix/public-safe-lp-1119",
+      identifier: "TASK-202",
+      recordedBranch: "task-202-recorded-provenance",
+      publicBranch: "fix/public-safe-task-202",
     },
   ])("stages pending audited reconciliation for $identifier public-safe branch when it matches the recorded provenance HEAD", async ({
     identifier,
@@ -2726,7 +2726,10 @@ describe("realizeExecutionWorkspace", () => {
             registeredBranchMatchesHead: true,
           }),
           safeRepair: expect.objectContaining({
-            reason: "forward reconciliation adoption requires database access to audit after workspace realization",
+            eligible: false,
+            attempted: false,
+            succeeded: false,
+            reason: "expected branch does not exist",
           }),
         }),
       },
@@ -2936,10 +2939,10 @@ describe("realizeExecutionWorkspace", () => {
             plainLanguageReason: expect.stringContaining("missing a resolvable HEAD commit"),
           }),
           safeRepair: expect.objectContaining({
-            eligible: true,
+            eligible: false,
             attempted: false,
             succeeded: false,
-            reason: "forward reconciliation adoption requires database access to audit after workspace realization",
+            reason: "expected branch does not exist",
           }),
         }),
       },
@@ -4765,7 +4768,7 @@ describeEmbeddedPostgres("workspace dirty quarantine branch repair", () => {
     });
   }
 
-  it("persists review recovery branch adoption when the recorded branch was deleted but the checked-out branch is registered", async () => {
+  it("fails closed when the recorded branch was deleted even if the checked-out branch is registered", async () => {
     const repoRoot = await createTempRepo();
     const recordedBranch = "internal-review-provenance";
     const publicBranch = "fix/review-workspace-recovery";
@@ -4779,12 +4782,11 @@ describeEmbeddedPostgres("workspace dirty quarantine branch repair", () => {
       worktreePath,
       expectedBranch: recordedBranch,
       actualBranch: publicBranch,
-      sourceIdentifier: "PAP-PUBLIC-DELETED",
+      sourceIdentifier: "TASK-PUBLIC-DELETED",
       claimant: "none",
     });
-    const { recorder, operations } = createWorkspaceOperationRecorderDouble();
 
-    const restored = await ensurePersistedExecutionWorkspaceAvailable({
+    await expect(ensurePersistedExecutionWorkspaceAvailable({
       db,
       base: {
         baseCwd: repoRoot,
@@ -4808,7 +4810,7 @@ describeEmbeddedPostgres("workspace dirty quarantine branch repair", () => {
       },
       issue: {
         id: ids.sourceIssueId,
-        identifier: "PAP-PUBLIC-DELETED",
+        identifier: "TASK-PUBLIC-DELETED",
         title: "Review public branch recovery",
       },
       agent: {
@@ -4818,45 +4820,32 @@ describeEmbeddedPostgres("workspace dirty quarantine branch repair", () => {
       },
       heartbeatRunId: ids.runId,
       enableWorkspaceBranchReconcileForward: true,
-      recorder,
+    })).rejects.toMatchObject({
+      code: "workspace_validation_failed",
+      resultJson: {
+        workspaceValidation: expect.objectContaining({
+          reason: "git_worktree_branch_incoherence",
+          expectedBranch: recordedBranch,
+          actualBranch: publicBranch,
+          cleanliness: "clean",
+          provenance: expect.objectContaining({
+            expectedBranchExists: false,
+            actualBranchExists: true,
+            registeredPathFound: true,
+            registeredBranchMatchesHead: true,
+            expectedHeadSha: null,
+            sameHead: false,
+            ancestryVerdict: "unknown",
+          }),
+          safeRepair: expect.objectContaining({
+            eligible: false,
+            attempted: false,
+            succeeded: false,
+            reason: "expected branch does not exist",
+          }),
+        }),
+      },
     });
-
-    expect(restored?.branchName).toBe(publicBranch);
-    expect(restored?.pendingForwardBranchReconcile).toMatchObject({
-      recordedBranchName: recordedBranch,
-      adoptedBranchName: publicBranch,
-    });
-
-    await reconcilePendingForwardBranchAfterPersistence({
-      db,
-      executionWorkspaceId: ids.sourceWorkspaceId,
-      pending: restored!.pendingForwardBranchReconcile!,
-      heartbeatRunId: ids.runId,
-      reconcileOperationPhase: "worktree_prepare",
-      recorder,
-    });
-
-    const [workspace] = await db
-      .select({ branchName: executionWorkspaces.branchName })
-      .from(executionWorkspaces)
-      .where(eq(executionWorkspaces.id, ids.sourceWorkspaceId));
-    expect(workspace?.branchName).toBe(publicBranch);
-
-    const comments = await db
-      .select({ body: issueComments.body })
-      .from(issueComments)
-      .where(eq(issueComments.issueId, ids.sourceIssueId));
-    expect(comments.some((comment) =>
-      comment.body.includes("Execution workspace branch reconciled.") &&
-      comment.body.includes(`- From branch: \`${recordedBranch}\``) &&
-      comment.body.includes(`- To branch: \`${publicBranch}\``) &&
-      comment.body.includes("- From SHA: `unknown`")
-    )).toBe(true);
-    expect(operations.some((operation) =>
-      operation.metadata?.reconcileMode === "adopt_for_realize" &&
-      operation.metadata?.expectedBranchName === recordedBranch &&
-      operation.metadata?.actualBranchName === publicBranch
-    )).toBe(true);
   }, 15_000);
 
   it("quarantines dirty foreign-branch work into a rescue branch before restoring the recorded branch", async () => {

--- a/server/src/__tests__/workspace-runtime.test.ts
+++ b/server/src/__tests__/workspace-runtime.test.ts
@@ -2603,6 +2603,67 @@ describe("realizeExecutionWorkspace", () => {
     await expect(readGit(initial.cwd, ["branch", "--show-current"])).resolves.toBe(actualBranch);
   }, 15_000);
 
+  it.each([
+    {
+      identifier: "LP-1083",
+      recordedBranch: "LP-1083-internal-provenance",
+      publicBranch: "fix/public-safe-lp-1083",
+    },
+    {
+      identifier: "LP-1119",
+      recordedBranch: "LP-1119-internal-provenance",
+      publicBranch: "fix/public-safe-lp-1119",
+    },
+  ])("adopts $identifier public-safe branch when it matches the recorded provenance HEAD", async ({
+    identifier,
+    recordedBranch,
+    publicBranch,
+  }) => {
+    const repoRoot = await createTempRepo();
+    const worktreePath = path.join(repoRoot, ".paperclip", "worktrees", recordedBranch);
+    await fs.mkdir(path.dirname(worktreePath), { recursive: true });
+    await runGit(repoRoot, ["branch", recordedBranch]);
+    await runGit(repoRoot, ["worktree", "add", "-b", publicBranch, worktreePath, recordedBranch]);
+
+    const restored = await ensurePersistedExecutionWorkspaceAvailable({
+      base: {
+        baseCwd: repoRoot,
+        source: "project_primary",
+        projectId: "project-1",
+        workspaceId: "workspace-1",
+        repoUrl: null,
+        repoRef: "HEAD",
+      },
+      workspace: {
+        id: `execution-workspace-${identifier.toLowerCase()}`,
+        mode: "isolated_workspace",
+        strategyType: "git_worktree",
+        cwd: worktreePath,
+        providerRef: worktreePath,
+        projectId: "project-1",
+        projectWorkspaceId: "workspace-1",
+        repoUrl: null,
+        baseRef: "HEAD",
+        branchName: recordedBranch,
+      },
+      issue: {
+        id: `issue-${identifier.toLowerCase()}`,
+        identifier,
+        title: "Publish public-safe branch",
+      },
+      agent: {
+        id: "agent-1",
+        name: "Codex Coder",
+        companyId: "company-1",
+      },
+      enableWorkspaceBranchReconcileForward: true,
+    });
+
+    expect(restored?.branchName).toBe(publicBranch);
+    expect(restored?.warnings).toEqual([]);
+    await expect(readGit(worktreePath, ["branch", "--show-current"])).resolves.toBe(publicBranch);
+  }, 15_000);
+
   it("classifies persisted git worktree branch incoherence as diverged when the checked-out branch is not forward", async () => {
     const repoRoot = await createTempRepo();
     const expectedBranch = "PAP-457-recorded-work";

--- a/server/src/__tests__/workspace-runtime.test.ts
+++ b/server/src/__tests__/workspace-runtime.test.ts
@@ -27,6 +27,7 @@ import {
   buildWorkspaceRuntimeDesiredStatePatch,
   cleanupExecutionWorkspaceArtifacts,
   ensurePersistedExecutionWorkspaceAvailable,
+  ensureGitWorktreeBranchCoherent,
   ensureServerWorkspaceLinksCurrent,
   ensureRuntimeServicesForRun,
   listConfiguredRuntimeServiceEntries,
@@ -2723,6 +2724,56 @@ describe("realizeExecutionWorkspace", () => {
           }),
           safeRepair: expect.objectContaining({
             reason: "forward reconciliation adoption requires database access to audit after workspace realization",
+          }),
+        }),
+      },
+    });
+  }, 15_000);
+
+  it("rejects deleted recorded-branch adoption when the registered worktree branch does not match HEAD", async () => {
+    const repoRoot = await createTempRepo();
+    const recordedBranch = "internal-review-provenance-mismatch";
+    const registeredBranch = "fix/registered-worktree-branch";
+    const actualBranch = "fix/current-worktree-head";
+    const worktreePath = path.join(repoRoot, ".paperclip", "worktrees", recordedBranch);
+    await fs.mkdir(path.dirname(worktreePath), { recursive: true });
+    await runGit(repoRoot, ["branch", recordedBranch]);
+    await runGit(repoRoot, ["branch", actualBranch, recordedBranch]);
+    await runGit(repoRoot, ["worktree", "add", "-b", registeredBranch, worktreePath, recordedBranch]);
+    await runGit(repoRoot, ["branch", "-D", recordedBranch]);
+
+    await expect(ensureGitWorktreeBranchCoherent({
+      repoRoot,
+      worktreePath,
+      expectedBranchName: recordedBranch,
+      actualBranchName: actualBranch,
+      sourceIssue: {
+        id: "issue-deleted-recorded-registration-mismatch",
+        identifier: "PAP-PUBLIC-MISMATCH",
+        title: "Reject mismatched worktree registration",
+      },
+      executionWorkspaceId: "execution-workspace-deleted-recorded-registration-mismatch",
+      enableWorkspaceBranchReconcileForward: true,
+    })).rejects.toMatchObject({
+      code: "workspace_validation_failed",
+      resultJson: {
+        workspaceValidation: expect.objectContaining({
+          reason: "git_worktree_branch_incoherence",
+          expectedBranch: recordedBranch,
+          actualBranch,
+          cleanliness: "clean",
+          provenance: expect.objectContaining({
+            expectedBranchExists: false,
+            actualBranchExists: true,
+            registeredPathFound: true,
+            registeredBranchRef: `refs/heads/${registeredBranch}`,
+            registeredBranchMatchesHead: false,
+          }),
+          safeRepair: expect.objectContaining({
+            eligible: false,
+            attempted: false,
+            succeeded: false,
+            reason: "registered worktree branch does not match HEAD",
           }),
         }),
       },

--- a/server/src/services/execution-workspaces.ts
+++ b/server/src/services/execution-workspaces.ts
@@ -67,6 +67,9 @@ export type ExecutionWorkspaceBranchReconcileInspection = {
   ancestryVerdict: GitWorktreeBranchAncestryVerdict;
   cleanliness: "clean" | "dirty" | "unknown";
   statusEntryCount: number | null;
+  registeredBranchRef: string | null;
+  registeredPathFound: boolean;
+  registeredBranchMatchesHead: boolean;
   plainLanguageReason: string;
 };
 
@@ -304,6 +307,8 @@ async function inspectExecutionWorkspaceBranchForReconcile(
     expectedHeadSha: fromSha,
     actualHeadSha: toSha,
   });
+  const registeredBranchRef = await readRegisteredGitWorktreeBranchRef(repoRoot, worktreePath);
+  const toBranchRef = `refs/heads/${toBranch}`;
 
   return {
     fingerprint: fingerprintWorkspaceBranchIncoherence({
@@ -325,6 +330,9 @@ async function inspectExecutionWorkspaceBranchForReconcile(
     ancestryVerdict,
     cleanliness,
     statusEntryCount: statusLines?.length ?? null,
+    registeredBranchRef,
+    registeredPathFound: registeredBranchRef !== null,
+    registeredBranchMatchesHead: registeredBranchRef === toBranchRef,
     plainLanguageReason: explainGitWorktreeBranchReconcileInspection({
       fromBranch,
       toBranch,
@@ -333,6 +341,40 @@ async function inspectExecutionWorkspaceBranchForReconcile(
       ancestryVerdict,
     }),
   };
+}
+
+async function readRegisteredGitWorktreeBranchRef(repoRoot: string, worktreePath: string): Promise<string | null> {
+  const raw = await readGitStdout(["worktree", "list", "--porcelain"], repoRoot).catch(() => null);
+  if (!raw) return null;
+
+  const expectedPath = await resolvePathForWorktreeComparison(worktreePath);
+  let currentWorktree: string | null = null;
+  for (const line of raw.split(/\r?\n/)) {
+    if (line.startsWith("worktree ")) {
+      currentWorktree = await resolvePathForWorktreeComparison(line.slice("worktree ".length));
+      continue;
+    }
+    if (line.startsWith("branch ") && currentWorktree === expectedPath) {
+      return line.slice("branch ".length);
+    }
+    if (line === "") currentWorktree = null;
+  }
+  return null;
+}
+
+async function resolvePathForWorktreeComparison(value: string): Promise<string> {
+  const resolved = path.resolve(value);
+  return fs.realpath(resolved).then((realPath) => path.resolve(realPath)).catch(() => resolved);
+}
+
+function isForwardBranchReconcileInspectionSafe(inspection: ExecutionWorkspaceBranchReconcileInspection) {
+  if (inspection.ancestryVerdict === "ancestor") return true;
+  return Boolean(
+    !inspection.fromSha &&
+      inspection.toSha &&
+      inspection.registeredPathFound &&
+      inspection.registeredBranchMatchesHead,
+  );
 }
 
 function formatBranchReconcileAuditComment(input: {
@@ -1627,9 +1669,9 @@ export function executionWorkspaceService(db: Db) {
       }
 
       const inspection = await inspectExecutionWorkspaceBranchForReconcile(existing);
-      if (input.mode === "forward" && inspection.ancestryVerdict !== "ancestor") {
+      if (input.mode === "forward" && !isForwardBranchReconcileInspectionSafe(inspection)) {
         throw unprocessable(
-          "Forward branch reconciliation requires the recorded branch to be an ancestor of the checked-out branch",
+          "Forward branch reconciliation requires the recorded branch to be an ancestor of the checked-out branch or a missing recorded branch with a registered checked-out worktree branch",
           { inspection },
         );
       }

--- a/server/src/services/execution-workspaces.ts
+++ b/server/src/services/execution-workspaces.ts
@@ -370,7 +370,8 @@ async function resolvePathForWorktreeComparison(value: string): Promise<string> 
 function isForwardBranchReconcileInspectionSafe(inspection: ExecutionWorkspaceBranchReconcileInspection) {
   if (inspection.ancestryVerdict === "ancestor") return true;
   return Boolean(
-    !inspection.fromSha &&
+    inspection.cleanliness === "clean" &&
+      !inspection.fromSha &&
       inspection.toSha &&
       inspection.registeredPathFound &&
       inspection.registeredBranchMatchesHead,

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -126,6 +126,7 @@ import {
   formatManagedGitWorktreeBranchInspection,
   inspectManagedGitWorktreeBranch,
   persistAdapterManagedRuntimeServices,
+  reconcilePendingForwardBranchAfterPersistence,
   realizeExecutionWorkspace,
   releaseRuntimeServicesForRun,
   type ExecutionWorkspaceInput,
@@ -12673,6 +12674,17 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       throw error;
     }
     await workspaceOperationRecorder.attachExecutionWorkspaceId(persistedExecutionWorkspace?.id ?? null);
+    if (persistedExecutionWorkspace && pendingForwardBranchReconcile) {
+      const reconcileResult = await reconcilePendingForwardBranchAfterPersistence({
+        db,
+        executionWorkspaceId: persistedExecutionWorkspace.id,
+        pending: pendingForwardBranchReconcile,
+        heartbeatRunId: run.id,
+        reconcileOperationPhase: "worktree_prepare",
+        recorder: workspaceOperationRecorder,
+      });
+      persistedExecutionWorkspace = reconcileResult.workspace;
+    }
     await recordWorkspaceConfigFreshnessOperation({
       recorder: workspaceOperationRecorder,
       runId: run.id,

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -4176,7 +4176,11 @@ export function issueService(db: Db) {
     if (!workspace) throw notFound("Project workspace not found");
     if (workspace.companyId !== companyId) throw unprocessable("Project workspace must belong to same company");
     if (projectId && workspace.projectId !== projectId) {
-      throw unprocessable("Project workspace must belong to the selected project");
+      throw unprocessable("Project workspace must belong to the selected project", {
+        selectedProjectId: projectId,
+        projectWorkspaceId,
+        workspaceProjectId: workspace.projectId,
+      });
     }
     return workspace;
   }
@@ -4199,7 +4203,11 @@ export function issueService(db: Db) {
     if (!workspace) throw notFound("Execution workspace not found");
     if (workspace.companyId !== companyId) throw unprocessable("Execution workspace must belong to same company");
     if (projectId && workspace.projectId !== projectId) {
-      throw unprocessable("Execution workspace must belong to the selected project");
+      throw unprocessable("Execution workspace must belong to the selected project", {
+        selectedProjectId: projectId,
+        executionWorkspaceId,
+        workspaceProjectId: workspace.projectId,
+      });
     }
     return workspace;
   }
@@ -5791,11 +5799,13 @@ export function issueService(db: Db) {
         inheritStrategyOnly && !hasExplicitExecutionWorkspaceOverride
           ? buildPreRealizationExecutionWorkspaceSettings(parent.executionWorkspaceSettings)
           : null;
+      const childProjectId = issueData.projectId ?? parent.projectId;
+      const canInheritParentProjectWorkspace = childProjectId == null || childProjectId === parent.projectId;
       let child = await issueService(db).create(parent.companyId, {
         ...issueData,
         parentId: parent.id,
-        projectId: issueData.projectId ?? parent.projectId,
-        projectWorkspaceId: issueData.projectWorkspaceId ?? (inheritStrategyOnly ? parent.projectWorkspaceId : undefined),
+        projectId: childProjectId,
+        projectWorkspaceId: issueData.projectWorkspaceId ?? (inheritStrategyOnly && canInheritParentProjectWorkspace ? parent.projectWorkspaceId : undefined),
         goalId: issueData.goalId ?? parent.goalId,
         actorResponsibleUserId: issueData.actorResponsibleUserId ?? null,
         trustExplicitResponsibleUserId: issueData.trustExplicitResponsibleUserId === true,
@@ -5803,7 +5813,7 @@ export function issueService(db: Db) {
           Math.max(clampIssueRequestDepth(parent.requestDepth) + 1, issueData.requestDepth ?? 0),
         ),
         description: appendAcceptanceCriteriaToDescription(issueData.description, acceptanceCriteria),
-        ...(inheritedPreRealizationWorkspaceSettings
+        ...(inheritedPreRealizationWorkspaceSettings && canInheritParentProjectWorkspace
           ? { executionWorkspaceSettings: inheritedPreRealizationWorkspaceSettings }
           : {}),
         ...(inheritStrategyOnly
@@ -6228,10 +6238,15 @@ export function issueService(db: Db) {
           if (issueData.projectId == null && workspaceSource.projectId) {
             issueData.projectId = workspaceSource.projectId;
           }
-          if (projectWorkspaceId == null && workspaceSource.projectWorkspaceId) {
+          const canInheritWorkspaceLinkage =
+            issueData.projectId == null ||
+            workspaceSource.projectId == null ||
+            issueData.projectId === workspaceSource.projectId;
+          if (canInheritWorkspaceLinkage && projectWorkspaceId == null && workspaceSource.projectWorkspaceId) {
             projectWorkspaceId = workspaceSource.projectWorkspaceId;
           }
           if (
+            canInheritWorkspaceLinkage &&
             isolatedWorkspacesEnabled &&
             !hasExplicitExecutionWorkspaceOverride &&
             workspaceSource.executionWorkspaceId

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -141,6 +141,13 @@ const ISSUE_CREATE_IDEMPOTENCY_KEY_CLEANUP_BATCH_SIZE = 500;
 const DELETED_ISSUE_COMMENT_BODY = "";
 const ISSUE_WAKE_DIAGNOSTICS_ACTIVITY_ACTIONS = ["issue.tree_hold_wakeup_deferred"] as const;
 
+function canInheritWorkspaceLinkageForProject(
+  targetProjectId: string | null | undefined,
+  sourceProjectId: string | null | undefined,
+) {
+  return targetProjectId == null || sourceProjectId == null || targetProjectId === sourceProjectId;
+}
+
 function wakeRequestTargetsIssue(issueId: string) {
   return sql`(
     ${agentWakeupRequests.payload} ->> 'issueId' = ${issueId}
@@ -5800,7 +5807,7 @@ export function issueService(db: Db) {
           ? buildPreRealizationExecutionWorkspaceSettings(parent.executionWorkspaceSettings)
           : null;
       const childProjectId = issueData.projectId ?? parent.projectId;
-      const canInheritParentProjectWorkspace = childProjectId == null || childProjectId === parent.projectId;
+      const canInheritParentProjectWorkspace = canInheritWorkspaceLinkageForProject(childProjectId, parent.projectId);
       let child = await issueService(db).create(parent.companyId, {
         ...issueData,
         parentId: parent.id,
@@ -6238,10 +6245,10 @@ export function issueService(db: Db) {
           if (issueData.projectId == null && workspaceSource.projectId) {
             issueData.projectId = workspaceSource.projectId;
           }
-          const canInheritWorkspaceLinkage =
-            issueData.projectId == null ||
-            workspaceSource.projectId == null ||
-            issueData.projectId === workspaceSource.projectId;
+          const canInheritWorkspaceLinkage = canInheritWorkspaceLinkageForProject(
+            issueData.projectId,
+            workspaceSource.projectId,
+          );
           if (canInheritWorkspaceLinkage && projectWorkspaceId == null && workspaceSource.projectWorkspaceId) {
             projectWorkspaceId = workspaceSource.projectWorkspaceId;
           }

--- a/server/src/services/workspace-runtime.ts
+++ b/server/src/services/workspace-runtime.ts
@@ -1015,14 +1015,25 @@ async function inspectGitWorktreeBranchIncoherence(input: {
     ancestryVerdict === "ancestor" &&
     !sameHead &&
     registeredBranchMatchesHead;
+  const canAdoptRegisteredActualBranchWhenRecordedBranchMissing =
+    cleanliness === "clean" &&
+    !expectedBranchExists &&
+    input.actualBranchName !== null &&
+    actualBranchExists === true &&
+    registeredBranchMatchesHead;
   const eligible =
-    canCheckoutRecordedBranch || canAdoptForwardActualBranch || canAttachRecordedBranchToDetachedHead;
+    canCheckoutRecordedBranch ||
+    canAdoptForwardActualBranch ||
+    canAttachRecordedBranchToDetachedHead ||
+    canAdoptRegisteredActualBranchWhenRecordedBranchMissing;
   const safeRepairReason = eligible
     ? canCheckoutRecordedBranch
       ? "clean worktree and expected branch points at the current HEAD"
       : canAdoptForwardActualBranch
         ? "clean worktree and checked-out branch is forward of the recorded branch"
-        : "clean detached worktree HEAD is forward of the recorded branch"
+        : canAttachRecordedBranchToDetachedHead
+          ? "clean detached worktree HEAD is forward of the recorded branch"
+          : "clean worktree is on a registered branch and the recorded branch no longer exists"
     : cleanliness !== "clean"
       ? inProgressOperation
         ? `worktree is not clean and a git ${GIT_IN_PROGRESS_OPERATION_LABELS[inProgressOperation]} is in progress`
@@ -1746,11 +1757,20 @@ export async function ensureGitWorktreeBranchCoherent(input: {
 
   if (
     input.enableWorkspaceBranchReconcileForward === true &&
-    evidence.provenance.ancestryVerdict === "ancestor" &&
+    (
+      evidence.provenance.ancestryVerdict === "ancestor" ||
+      (
+        !evidence.provenance.expectedBranchExists &&
+        evidence.provenance.actualBranchExists === true &&
+        evidence.provenance.registeredBranchMatchesHead
+      )
+    ) &&
     evidence.cleanliness === "clean" &&
     currentBranch
   ) {
-    const reason = evidence.provenance.sameHead
+    const reason = !evidence.provenance.expectedBranchExists
+      ? "Automatic branch provenance reconciliation: recorded branch is missing and the checked-out branch is the registered worktree branch."
+      : evidence.provenance.sameHead
       ? "Automatic branch provenance reconciliation: recorded branch and checked-out branch resolve to the same commit."
       : "Automatic forward reconciliation: recorded branch is an ancestor of the checked-out branch.";
     if (input.executionWorkspaceId && input.persistForwardReconcile !== false) {

--- a/server/src/services/workspace-runtime.ts
+++ b/server/src/services/workspace-runtime.ts
@@ -1747,11 +1747,12 @@ export async function ensureGitWorktreeBranchCoherent(input: {
   if (
     input.enableWorkspaceBranchReconcileForward === true &&
     evidence.provenance.ancestryVerdict === "ancestor" &&
-    !evidence.provenance.sameHead &&
     evidence.cleanliness === "clean" &&
     currentBranch
   ) {
-    const reason = "Automatic forward reconciliation: recorded branch is an ancestor of the checked-out branch.";
+    const reason = evidence.provenance.sameHead
+      ? "Automatic branch provenance reconciliation: recorded branch and checked-out branch resolve to the same commit."
+      : "Automatic forward reconciliation: recorded branch is an ancestor of the checked-out branch.";
     if (input.executionWorkspaceId && input.persistForwardReconcile !== false) {
       if (!input.db) {
         evidence.safeRepair.reason = "forward reconciliation requires database access to update the execution workspace record";
@@ -1815,6 +1816,15 @@ export async function ensureGitWorktreeBranchCoherent(input: {
     }
 
     if (!input.db) {
+      if (evidence.provenance.sameHead) {
+        evidence.safeRepair.succeeded = true;
+        evidence.safeRepair.reason = "clean worktree adopted the checked-out branch because it matches the recorded branch HEAD";
+        return {
+          branchName: currentBranch,
+          reconciledForward: true,
+          warnings: [],
+        };
+      }
       evidence.safeRepair.reason = "forward reconciliation adoption requires database access to audit after workspace realization";
       throw branchIncoherenceValidationFailure(evidence);
     }

--- a/server/src/services/workspace-runtime.ts
+++ b/server/src/services/workspace-runtime.ts
@@ -1015,25 +1015,16 @@ async function inspectGitWorktreeBranchIncoherence(input: {
     ancestryVerdict === "ancestor" &&
     !sameHead &&
     registeredBranchMatchesHead;
-  const canAdoptRegisteredActualBranchWhenRecordedBranchMissing =
-    cleanliness === "clean" &&
-    !expectedBranchExists &&
-    input.actualBranchName !== null &&
-    actualBranchExists === true &&
-    registeredBranchMatchesHead;
   const eligible =
     canCheckoutRecordedBranch ||
     canAdoptForwardActualBranch ||
-    canAttachRecordedBranchToDetachedHead ||
-    canAdoptRegisteredActualBranchWhenRecordedBranchMissing;
+    canAttachRecordedBranchToDetachedHead;
   const safeRepairReason = eligible
     ? canCheckoutRecordedBranch
       ? "clean worktree and expected branch points at the current HEAD"
       : canAdoptForwardActualBranch
         ? "clean worktree and checked-out branch is forward of the recorded branch"
-        : canAttachRecordedBranchToDetachedHead
-          ? "clean detached worktree HEAD is forward of the recorded branch"
-          : "clean worktree is on a registered branch and the recorded branch no longer exists"
+        : "clean detached worktree HEAD is forward of the recorded branch"
     : cleanliness !== "clean"
       ? inProgressOperation
         ? `worktree is not clean and a git ${GIT_IN_PROGRESS_OPERATION_LABELS[inProgressOperation]} is in progress`
@@ -1757,20 +1748,15 @@ export async function ensureGitWorktreeBranchCoherent(input: {
 
   if (
     input.enableWorkspaceBranchReconcileForward === true &&
+    evidence.provenance.ancestryVerdict === "ancestor" &&
     (
-      evidence.provenance.ancestryVerdict === "ancestor" ||
-      (
-        !evidence.provenance.expectedBranchExists &&
-        evidence.provenance.actualBranchExists === true &&
-        evidence.provenance.registeredBranchMatchesHead
-      )
+      !evidence.provenance.sameHead ||
+      input.reconcileOperationPhase !== "workspace_finalize"
     ) &&
     evidence.cleanliness === "clean" &&
     currentBranch
   ) {
-    const reason = !evidence.provenance.expectedBranchExists
-      ? "Automatic branch provenance reconciliation: recorded branch is missing and the checked-out branch is the registered worktree branch."
-      : evidence.provenance.sameHead
+    const reason = evidence.provenance.sameHead
       ? "Automatic branch provenance reconciliation: recorded branch and checked-out branch resolve to the same commit."
       : "Automatic forward reconciliation: recorded branch is an ancestor of the checked-out branch.";
     if (input.executionWorkspaceId && input.persistForwardReconcile !== false) {

--- a/server/src/services/workspace-runtime.ts
+++ b/server/src/services/workspace-runtime.ts
@@ -1836,15 +1836,6 @@ export async function ensureGitWorktreeBranchCoherent(input: {
     }
 
     if (!input.db) {
-      if (evidence.provenance.sameHead) {
-        evidence.safeRepair.succeeded = true;
-        evidence.safeRepair.reason = "clean worktree adopted the checked-out branch because it matches the recorded branch HEAD";
-        return {
-          branchName: currentBranch,
-          reconciledForward: true,
-          warnings: [],
-        };
-      }
       evidence.safeRepair.reason = "forward reconciliation adoption requires database access to audit after workspace realization";
       throw branchIncoherenceValidationFailure(evidence);
     }


### PR DESCRIPTION
## Thinking Path

> - This project coordinates AI agents through execution workspaces and audited task state.
> - Workspace branch metadata must stay coherent with the git worktree an agent actually uses.
> - Public-safe branch names can differ from originally recorded workspace branch names.
> - Automatic reconciliation is safe only when the system can prove same-head metadata drift or forward-only ancestry.
> - Deleted recorded branches remove the source commit needed to prove ancestry.
> - This pull request tightens automatic reconciliation so unknown ancestry fails closed while explicit audited reconciliation remains available.
> - The benefit is safer workspace recovery without silently legitimizing an unproven checked-out branch.

## Linked Issues or Issue Description

Related public pull requests: Refs #9806, Refs #9808.

This fixes a branch-provenance safety bug: when a recorded workspace branch is missing, the runtime must not automatically adopt the current checked-out branch unless ancestry is provable or a separate audited operator action records the decision.

## What Changed

- Fail closed for automatic runtime reconciliation when the recorded branch is deleted and ancestry is unknown.
- Preserve same-head reconciliation during workspace preparation, but restore the recorded branch during finalization when an adapter temporarily creates a same-head publish branch.
- Consolidate workspace-linkage inheritance through a shared project-compatibility helper.
- Replace local/private-looking test fixtures with neutral task fixtures.
- Make CLI/package-artifact tests hermetic against inherited runtime context and npm pack metadata shape differences.
- Add and update tests for unknown ancestry containment, same-head reconciliation, finalization repair, explicit reconciliation, and workspace inheritance.

## Verification

Local verification at candidate commit `6cb36d2a2a1cb75c830aee9e201a4cc72b4785ec`:

- PR head was re-fetched before mutation and matched the observed starting SHA.
- Public metadata scan passed for the pushed commit range.
- The metadata rewrite and review-retrigger commit were tree-identical to the previously verified tree.
- Docker dependency stage check passed.
- Git-push guard and guard unit tests passed.
- Stable-shard script unit tests passed.
- Release verification workflow unit tests passed.
- Standalone build concurrency unit tests passed.
- Release package map check passed.
- Build-gap typecheck passed.
- Release-registry tests passed.
- Full workspace build passed.
- General server shards 1/3, 2/3, and 3/3 passed.
- General workspace shards A and B passed.
- Serialized server shards 1/4, 2/4, 3/4, and 4/4 passed.
- End-to-end suite passed with 41 tests passing and 2 skipped.
- Canary dry-run was not run locally because its workflow intentionally checks out the base branch name, which conflicts with this managed worktree's no-branch-switch constraint.

Remote checks are green for the pushed SHA.

## Risks

- Reconciliation is intentionally stricter for deleted recorded branches, so some previously auto-repaired workspaces now require explicit recovery.
- Same-head behavior is phase-sensitive: preparation can record audited metadata drift, while finalization restores the recorded branch to avoid persisting transient publish branches.
- No schema or migration changes.

## Model Used

OpenAI GPT-5 Codex, tool-using coding agent.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either linked existing public issues/PRs or described the issue in-PR
- [x] I have not referenced internal or instance-local issues or links
- [x] My branch name describes the change and contains no private ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] Remote CI gates are green
- [x] External automated review is complete with no open blocking findings
- [ ] I will address all reviewer comments before requesting merge
