### PR TITLE
feat(authz): add scoped agent error remediation

### DIFF
--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -916,6 +916,7 @@ export type JoinRequestStatus = (typeof JOIN_REQUEST_STATUSES)[number];
 
 export const PERMISSION_KEYS = [
   "agents:create",
+  "agents:clear_error",
   "agents:configure",
   "agents:suggest-changes",
   "skills:create",

--- a/server/src/__tests__/agent-cross-tenant-authz-routes.test.ts
+++ b/server/src/__tests__/agent-cross-tenant-authz-routes.test.ts
@@ -420,7 +420,7 @@ describe.sequential("agent cross-tenant route authorization", () => {
     expect(mockAgentService.revokeKey).not.toHaveBeenCalled();
   });
 
-  it("requires board access before clearing an agent error", async () => {
+  it("denies an agent without the clear-error grant", async () => {
     const app = await createApp({
       type: "agent",
       agentId,
@@ -433,8 +433,61 @@ describe.sequential("agent cross-tenant route authorization", () => {
     );
 
     expect(res.status).toBe(403);
-    expect(res.body.error).toContain("Board access required");
+    expect(res.body.error).toContain("Missing permission: agents:clear_error");
     expect(mockAgentService.clearError).not.toHaveBeenCalled();
+  });
+
+  it("allows only the granted agent mutation and records agent/run audit identity", async () => {
+    currentAccessCanUser = true;
+    const errorAgent = {
+      ...baseAgent,
+      status: "error",
+      pauseReason: "system",
+      pausedAt: new Date("2026-04-11T00:02:00.000Z"),
+    };
+    mockAgentService.getById.mockImplementation(async () => ({ ...errorAgent }));
+    mockAgentService.clearError.mockImplementation(async () => ({
+      ...errorAgent,
+      status: "idle",
+      pauseReason: null,
+      pausedAt: null,
+    }));
+    const app = await createApp({
+      type: "agent",
+      agentId,
+      companyId,
+      runId: "run-1",
+    });
+
+    const clear = await requestApp(app, (baseUrl) =>
+      request(baseUrl).post(`/api/agents/${agentId}/clear-error`).send({}),
+    );
+    const unrelatedBoardMutation = await requestApp(app, (baseUrl) =>
+      request(baseUrl).post(`/api/agents/${agentId}/pause`).send({}),
+    );
+
+    expect(clear.status).toBe(200);
+    expect(clear.body.status).toBe("idle");
+    expect(mockAccessService.decide).toHaveBeenCalledWith({
+      actor: expect.objectContaining({ type: "agent", agentId, companyId, runId: "run-1" }),
+      action: "agents:clear_error",
+      resource: { type: "agent", companyId, agentId },
+    });
+    expect(mockLogActivity).toHaveBeenCalledWith(expect.anything(), {
+      companyId,
+      actorType: "agent",
+      actorId: agentId,
+      agentId,
+      runId: "run-1",
+      agentApiKeyId: undefined,
+      action: "agent.error_cleared",
+      entityType: "agent",
+      entityId: agentId,
+      details: { agentId, runId: "run-1" },
+    });
+    expect(unrelatedBoardMutation.status).toBe(403);
+    expect(unrelatedBoardMutation.body.error).toContain("Board access required");
+    expect(mockAgentService.pause).not.toHaveBeenCalled();
   });
 
   it("clears error agents and records a distinct audit action", async () => {

--- a/server/src/__tests__/agent-cross-tenant-authz-routes.test.ts
+++ b/server/src/__tests__/agent-cross-tenant-authz-routes.test.ts
@@ -437,6 +437,23 @@ describe.sequential("agent cross-tenant route authorization", () => {
     expect(mockAgentService.clearError).not.toHaveBeenCalled();
   });
 
+  it("denies a non-board, non-agent actor even with company access", async () => {
+    const app = await createApp({
+      type: "user",
+      userId: "future-user",
+      companyIds: [companyId],
+      source: "session",
+    });
+
+    const res = await requestApp(app, (baseUrl) =>
+      request(baseUrl).post(`/api/agents/${agentId}/clear-error`).send({}),
+    );
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toContain("Board access required");
+    expect(mockAgentService.clearError).not.toHaveBeenCalled();
+  });
+
   it("allows only the granted agent mutation and records agent/run audit identity", async () => {
     currentAccessCanUser = true;
     const errorAgent = {
@@ -533,6 +550,7 @@ describe.sequential("agent cross-tenant route authorization", () => {
       entityType: "agent",
       entityId: agentId,
     }));
+    expect(mockLogActivity.mock.calls.at(-1)?.[1]).not.toHaveProperty("details");
   });
 
   it("returns 409 and does not mutate when the agent org chain is invalid", async () => {

--- a/server/src/__tests__/agent-cross-tenant-authz-routes.test.ts
+++ b/server/src/__tests__/agent-cross-tenant-authz-routes.test.ts
@@ -451,6 +451,7 @@ describe.sequential("agent cross-tenant route authorization", () => {
 
     expect(res.status).toBe(403);
     expect(res.body.error).toContain("Board access required");
+    expect(mockAccessService.decide).not.toHaveBeenCalled();
     expect(mockAgentService.clearError).not.toHaveBeenCalled();
   });
 

--- a/server/src/__tests__/authorization-service.test.ts
+++ b/server/src/__tests__/authorization-service.test.ts
@@ -451,6 +451,43 @@ describeEmbeddedPostgres("authorization service", () => {
     });
   });
 
+  it("allows responsible-user JWT agents with only the clear-error grant to remediate a peer", async () => {
+    const company = await createCompany(db, "ResponsibleUserClearErrorGrant");
+    const actorAgent = await createAgent(db, company.id);
+    const targetAgent = await createAgent(db, company.id);
+    const responsibleUserId = await createUser(db);
+    await grantAgentPermission(db, company.id, actorAgent.id, "agents:clear_error");
+    await db.insert(companyMemberships).values({
+      companyId: company.id,
+      principalType: "user",
+      principalId: responsibleUserId,
+      status: "active",
+      membershipRole: "operator",
+    });
+
+    const decision = await authorizationService(db).decide({
+      actor: {
+        type: "agent",
+        agentId: actorAgent.id,
+        companyId: company.id,
+        onBehalfOfUserId: responsibleUserId,
+        source: "agent_jwt",
+      },
+      action: "agents:clear_error",
+      resource: { type: "agent", companyId: company.id, agentId: targetAgent.id },
+    });
+
+    expect(decision).toMatchObject({
+      allowed: true,
+      reason: "allow_explicit_grant",
+      grant: {
+        principalType: "agent",
+        principalId: actorAgent.id,
+        permissionKey: "agents:clear_error",
+      },
+    });
+  });
+
   it("keeps responsible-user skill mutations denied for viewer memberships", async () => {
     const company = await createCompany(db, "ResponsibleUserSkillViewerDenied");
     const actorAgent = await createAgent(db, company.id);

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -3155,6 +3155,8 @@ export function agentRoutes(
       if (!decision.allowed) {
         throw forbidden(decision.explanation, authorizationDeniedDetails(decision));
       }
+    } else {
+      assertBoard(req);
     }
     if (existing.orgChainHealth?.status === "invalid_org_chain") {
       res.status(409).json({
@@ -3180,10 +3182,14 @@ export function agentRoutes(
       action: "agent.error_cleared",
       entityType: "agent",
       entityId: agent.id,
-      details: {
-        agentId: actor.agentId,
-        runId: actor.runId,
-      },
+      ...(actor.actorType === "agent"
+        ? {
+            details: {
+              agentId: actor.agentId,
+              runId: actor.runId,
+            },
+          }
+        : {}),
     });
 
     res.json(agent);

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -3141,11 +3141,20 @@ export function agentRoutes(
   });
 
   router.post("/agents/:id/clear-error", async (req, res) => {
-    assertBoard(req);
     const id = req.params.id as string;
     const existing = await getAccessibleAgent(req, res, id);
     if (!existing) {
       return;
+    }
+    if (req.actor.type === "agent") {
+      const decision = await access.decide({
+        actor: req.actor,
+        action: "agents:clear_error",
+        resource: { type: "agent", companyId: existing.companyId, agentId: existing.id },
+      });
+      if (!decision.allowed) {
+        throw forbidden(decision.explanation, authorizationDeniedDetails(decision));
+      }
     }
     if (existing.orgChainHealth?.status === "invalid_org_chain") {
       res.status(409).json({
@@ -3160,13 +3169,21 @@ export function agentRoutes(
       return;
     }
 
+    const actor = getActorInfo(req);
     await logActivity(db, {
       companyId: agent.companyId,
-      actorType: "user",
-      actorId: req.actor.userId ?? "board",
+      actorType: actor.actorType,
+      actorId: actor.actorId,
+      agentId: actor.agentId,
+      runId: actor.runId,
+      agentApiKeyId: actor.agentApiKeyId,
       action: "agent.error_cleared",
       entityType: "agent",
       entityId: agent.id,
+      details: {
+        agentId: actor.agentId,
+        runId: actor.runId,
+      },
     });
 
     res.json(agent);

--- a/server/src/services/authorization.ts
+++ b/server/src/services/authorization.ts
@@ -487,23 +487,32 @@ function activeResponsibleUserCanAuthorizeIssueAction(
   );
 }
 
-function activeResponsibleUserCanAuthorizeAgentGrantedSkillChange(
+function activeResponsibleUserCanAuthorizeAgentGrantedAction(
   action: AuthorizationAction,
   membership: ResponsibleUserSnapshot["activeMembership"],
   agentDecision: AuthorizationDecision,
   actorAgentId: string | null | undefined,
 ) {
   return Boolean(
-    action === "skill_config:update" &&
     membership &&
     membership.status === "active" &&
     membership.membershipRole !== "viewer" &&
     agentDecision.allowed &&
-    (agentDecision.reason === "allow_direct_change" || agentDecision.reason === "allow_consented_change") &&
     agentDecision.grant?.principalType === "agent" &&
     agentDecision.grant.principalId === actorAgentId &&
-    (agentDecision.grant.permissionKey === "skills:create" ||
-      agentDecision.grant.permissionKey === "skills:suggest-changes"),
+    (
+      (
+        action === "skill_config:update" &&
+        (agentDecision.reason === "allow_direct_change" || agentDecision.reason === "allow_consented_change") &&
+        (agentDecision.grant.permissionKey === "skills:create" ||
+          agentDecision.grant.permissionKey === "skills:suggest-changes")
+      ) ||
+      (
+        action === "agents:clear_error" &&
+        agentDecision.reason === "allow_explicit_grant" &&
+        agentDecision.grant.permissionKey === "agents:clear_error"
+      )
+    ),
   );
 }
 
@@ -2018,14 +2027,14 @@ export function authorizationService(db: Db) {
         : "RESPONSIBLE_USER_UNAVAILABLE";
 
     if (
-      activeResponsibleUserCanAuthorizeAgentGrantedSkillChange(
+      activeResponsibleUserCanAuthorizeAgentGrantedAction(
         input.action,
         snapshot.activeMembership,
         agentDecision,
         input.actor.agentId,
       )
     ) {
-      // Skill mutations are governed by the agent's explicit skill-change
+      // Narrow agent-granted mutations are governed by the agent's explicit
       // grant. The responsible-user intersection still requires an active
       // non-viewer user, but does not require duplicating that grant on the
       // responsible user's board account for standard heartbeat JWTs.


### PR DESCRIPTION
## Thinking Path

> - Paperclip manages AI agents that execute company work under explicit authorization boundaries.
> - Agent state recovery is exposed through the server's agent mutation routes and shared permission registry.
> - Clearing an agent error previously required board access, forcing operators to choose between blocked recovery and overbroad authority.
> - The authorization system already supports explicit principal grants and responsible-user intersection checks.
> - This pull request adds one narrowly scoped `agents:clear_error` capability, preserves board behavior, and fails closed for every other actor type.
> - The benefit is recoverability with a small blast radius and a revoke-only rollback.

## Linked Issues or Issue Description

**Subsystem affected:** Cross-cutting (`server/` REST authorization and `packages/shared` permission constants).

**Problem or motivation:** An operations agent may need to clear another agent's error state, but granting board access for that single recovery action is excessive. The clear-error route needs a least-privilege path that does not authorize unrelated agent mutations.

**Proposed solution:** Add `agents:clear_error` as an explicit principal permission. Permit same-company agent callers only when the authorization service allows that exact action; retain the existing board path; deny ungranted, cross-company, anonymous, and future non-board actor types. Record agent/run identity only for agent-originated audit events.

**Alternatives considered:** Broad board access and the broader capability proposed by #8168 were rejected because they increase blast radius. #9726 documents the former board-only contract; this PR intentionally supersedes that behavior with a narrower explicit grant while retaining board compatibility.

**Roadmap alignment:** `ROADMAP.md` has no overlapping clear-error or agent-remediation item. This is a bounded authorization improvement rather than a new core product surface.

## What Changed

- Added `agents:clear_error` to the shared permission registry and responsible-user grant intersection.
- Authorized same-company agent actors only through an explicit `agents:clear_error` decision while preserving board access.
- Added an explicit `assertBoard(req)` fallback so unknown non-agent actors fail closed.
- Recorded agent/run audit context only for agent-originated clears; board audit entries retain their prior shape.
- Added focused coverage for board allow, granted-agent allow, ungranted deny, cross-company deny, unrelated mutation denial, future non-board actor denial, and audit identity.

## Verification

- `pnpm exec vitest run server/src/__tests__/agent-cross-tenant-authz-routes.test.ts --testTimeout=15000` — 7 passed.
- `pnpm exec vitest run server/src/__tests__/authorization-service.test.ts` — 50 passed as part of the focused two-suite run.
- `pnpm --filter @paperclipai/server typecheck` — passed.
- Updated-head CI passed all typecheck, build, server test, serialized test, e2e, security, policy, and canary dry-run checks.

## Risks

- **Authorization regression:** Low and covered by route tests for board, agent-grant, cross-company, and unknown-actor paths.
- **Behavioral shift:** An agent can clear errors only when it holds the exact same-company grant; no board or unrelated mutation authority is implied.
- **Migration safety:** No schema migration or data rewrite.
- **Rollback:** Revoke the single `agents:clear_error` grant to remove delegated access immediately; reverting the code restores board-only behavior.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI GPT-5.6 Sol, with reasoning, repository tool use, code execution, and test execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [ ] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge