### PR TITLE
fix(adapter-utils): stage SSH restores beside workspace

### DIFF
--- a/doc/plans/2026-07-18-ssh-sync-back-staging-adr.md
+++ b/doc/plans/2026-07-18-ssh-sync-back-staging-adr.md
@@ -1,0 +1,76 @@
+# SSH sync-back staging filesystem
+
+## Context
+
+SSH workspace restore downloads and fully extracts a remote tar before replacing
+the local workspace. That safety boundary prevents a failed transfer from
+destroying active local work, but the extraction directory was created under
+`os.tmpdir()`. On the Lucentworks host, `/tmp` has a roughly 5.01 GB per-user
+quota; a 4.74 GB workspace therefore consumed nearly the entire allowance and
+caused unrelated writes to fail with `EDQUOT`.
+
+Baseline-aware restores also allocated an outer merge stage and then called the
+general restore helper, which allocated an inner extraction stage. That path
+temporarily required two full snapshot copies before merge.
+
+## Options
+
+1. Continue using `/tmp` and reject restores based on a size/free-space preflight.
+   This avoids quota exhaustion but makes otherwise healthy large restores fail.
+2. Stream directly into the destination workspace. This removes staging capacity
+   but exposes active work to partial replacement when SSH or tar fails.
+3. Create one stage beside the destination workspace, reuse it for baseline
+   merge, and admit the transfer only after checking the stage filesystem. This
+   retains failure isolation, removes double staging, and charges extraction to
+   the workspace filesystem rather than the shared temporary-files quota.
+
+## Decision
+
+Choose option 3. Every full sync-back staging directory is created as a uniquely
+named sibling of its destination (`.paperclip-ssh-sync-back-*`). Direct restores
+own one stage; baseline-merge restores pass their existing stage into the
+transfer helper, eliminating the nested copy. Existing `finally` cleanup removes
+owned staging after success and failure.
+
+Before spawning SSH or tar, the restore probes the remote snapshot with `du`,
+checks free blocks on the selected staging filesystem with `statfs`, and requires
+the estimated snapshot size plus the greater of 10% or 512 MiB headroom. A
+missing size probe or insufficient capacity fails before transfer and leaves the
+destination untouched.
+
+This is a **Build for change** seam: allocation is centralized in
+`createSshSyncBackStagingDir`, so a future configurable staging volume or
+capacity admission policy does not need to alter transfer logic.
+
+## Consequences and blast radius
+
+- **Blast radius:** SSH sync-back only. Upload staging, small SSH auth files, git
+  bundle staging, local runtimes, and non-SSH workspace providers are unchanged.
+- A restore now consumes one temporary snapshot on the workspace filesystem.
+  The destination's parent must be writable and have enough free space for the
+  staged snapshot plus safety headroom.
+- Remotes must support the existing `du -sk` probe. Failing closed when size
+  cannot be measured trades compatibility with unusually minimal remotes for
+  predictable capacity admission.
+- The destination remains untouched until extraction completes, preserving active
+  work on transport or extraction failure.
+- Cleanup remains best-effort in `finally`. A process-level hard kill can still
+  leave a uniquely named sibling, as it could previously leave data in `/tmp`;
+  stale-directory scavenging is separate operational hardening.
+- No credentials or transfer contents are added to process arguments or logs.
+
+## Verification
+
+The bounded regression checks prove that the allocator selects the workspace
+parent, insufficient capacity is rejected with the required headroom, and
+integration restores remove workspace-local staging after successful, failed,
+and baseline-merge transfers. Existing SSH round-trip tests continue to prove
+staged content reaches the destination only after complete extraction.
+
+## Rollback path
+
+Revert the capacity assertion and optional caller-owned `stagingDir`, then revert
+the allocator call sites to `fs.mkdtemp(path.join(os.tmpdir(),
+"paperclip-ssh-sync-back-"))`. This is a code-only rollback with no data
+migration, but it reintroduces both nested staging and the `/tmp` quota failure;
+use it only while SSH restores are disabled or constrained below the host quota.

--- a/packages/adapter-utils/src/ssh-fixture.test.ts
+++ b/packages/adapter-utils/src/ssh-fixture.test.ts
@@ -1,11 +1,13 @@
 import { execFile } from "node:child_process";
-import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, readdir, rm, symlink, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
+  assertSshSyncBackCapacity,
   buildSshSpawnTarget,
   buildSshEnvLabFixtureConfig,
+  createSshSyncBackStagingDir,
   getSshEnvLabSupport,
   prepareWorkspaceForSshExecution,
   readSshEnvLabFixtureStatus,
@@ -89,6 +91,27 @@ describe("ssh env-lab fixture", () => {
       if (!dir) continue;
       await rm(dir, { recursive: true, force: true }).catch(() => undefined);
     }
+  });
+
+  it("allocates sync-back staging beside the workspace instead of in the host temp directory", async () => {
+    const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-ssh-staging-root-test-"));
+    cleanupDirs.push(rootDir);
+    const localDir = path.join(rootDir, "workspace");
+    await mkdir(localDir);
+
+    const stagingDir = await createSshSyncBackStagingDir(localDir);
+    expect(path.dirname(stagingDir)).toBe(rootDir);
+    expect(path.basename(stagingDir)).toMatch(/^\.paperclip-ssh-sync-back-/);
+
+    await rm(stagingDir, { recursive: true, force: true });
+  });
+
+  it("rejects sync-back before transfer when staging capacity lacks safe headroom", () => {
+    expect(() => assertSshSyncBackCapacity({
+      availableBytes: 5n * 1024n * 1024n * 1024n,
+      remoteBytes: 4_700n * 1024n * 1024n,
+      stagingDir: "/workspace/.paperclip-ssh-sync-back-test",
+    })).toThrow(/Insufficient capacity for SSH workspace restore.*5\.00 GiB available.*required/);
   });
 
   it("starts an isolated sshd fixture and executes commands through it", async () => {
@@ -309,14 +332,35 @@ describe("ssh env-lab fixture", () => {
     for (const line of lines) {
       expect(line.raw).toContain("Restoring workspace from ssh");
     }
-    // Terminal completion line: either an exact 100% (probe succeeded) or a
-    // final MB-received line (probe unavailable). Either is a valid terminal.
+    // The capacity preflight supplies a known estimate, so completion is exact.
     const last = lines.at(-1)!;
-    expect(last.percent === 100 || (last.percent === null && last.doneMb !== null)).toBe(true);
+    expect(last.percent).toBe(100);
     // The restored files round-tripped through the byte-counting transport.
     await expect(readFile(path.join(restoreDir, "blob-0.bin"))).resolves.toEqual(
       Buffer.alloc(256 * 1024, 1),
     );
+    expect((await readdir(rootDir)).filter((entry) => entry.startsWith(".paperclip-ssh-sync-back-"))).toEqual([]);
+  }, SSH_FIXTURE_TEST_TIMEOUT_MS);
+
+  it("removes workspace-local sync-back staging after a failed restore", async () => {
+    const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-ssh-fixture-"));
+    cleanupDirs.push(rootDir);
+    const statePath = path.join(rootDir, "state.json");
+    const restoreDir = path.join(rootDir, "restore-target");
+    await mkdir(restoreDir);
+
+    const started = await startSshEnvLabFixtureOrSkip(statePath, "SSH failed restore cleanup test");
+    if (!started) return;
+    const config = await buildSshEnvLabFixtureConfig(started);
+    const spec = { ...config, remoteCwd: started.workspaceDir } as const;
+
+    await expect(syncDirectoryFromSsh({
+      spec,
+      remoteDir: path.posix.join(started.workspaceDir, "missing-restore-source"),
+      localDir: restoreDir,
+    })).rejects.toThrow();
+
+    expect((await readdir(rootDir)).filter((entry) => entry.startsWith(".paperclip-ssh-sync-back-"))).toEqual([]);
   }, SSH_FIXTURE_TEST_TIMEOUT_MS);
 
   it("reports exact git-history import percentage from the known bundle size", async () => {
@@ -734,5 +778,6 @@ describe("ssh env-lab fixture", () => {
     const recentSubjects = await git(localRepo, ["log", "--pretty=%s", "-3"]);
     expect(recentSubjects).toContain("remote update a");
     expect(recentSubjects).toContain("remote update b");
+    expect((await readdir(rootDir)).filter((entry) => entry.startsWith(".paperclip-ssh-sync-back-"))).toEqual([]);
   }, SSH_FIXTURE_TEST_TIMEOUT_MS);
 });

--- a/packages/adapter-utils/src/ssh.ts
+++ b/packages/adapter-utils/src/ssh.ts
@@ -475,7 +475,7 @@ async function probeRemoteDirSize(input: {
       { timeoutMs: 15_000, maxBuffer: 16 * 1024 },
     );
     const kilobytes = Number.parseInt(result.stdout.trim(), 10);
-    return Number.isFinite(kilobytes) && kilobytes > 0 ? kilobytes * 1024 : null;
+    return Number.isFinite(kilobytes) && kilobytes >= 0 ? kilobytes * 1024 : null;
   } catch {
     return null;
   }
@@ -601,6 +601,50 @@ async function copyDirectoryContents(sourceDir: string, targetDir: string): Prom
       preserveTimestamps: true,
     });
   }));
+}
+
+export async function createSshSyncBackStagingDir(localDir: string): Promise<string> {
+  // Keep the complete pre-restore copy beside the workspace. SSH workspaces can
+  // be several gigabytes, while the host's shared /tmp may have a much smaller
+  // user quota. A sibling also stays on the workspace filesystem, preserving
+  // the existing "stage fully before replacing local state" safety boundary.
+  const stagingRoot = path.dirname(path.resolve(localDir));
+  await fs.mkdir(stagingRoot, { recursive: true });
+  return await fs.mkdtemp(path.join(stagingRoot, ".paperclip-ssh-sync-back-"));
+}
+
+const SSH_SYNC_BACK_MIN_HEADROOM_BYTES = 512n * 1024n * 1024n;
+
+export function assertSshSyncBackCapacity(input: {
+  availableBytes: bigint;
+  remoteBytes: bigint;
+  stagingDir: string;
+}): void {
+  const proportionalHeadroom = (input.remoteBytes + 9n) / 10n;
+  const headroomBytes = proportionalHeadroom > SSH_SYNC_BACK_MIN_HEADROOM_BYTES
+    ? proportionalHeadroom
+    : SSH_SYNC_BACK_MIN_HEADROOM_BYTES;
+  const requiredBytes = input.remoteBytes + headroomBytes;
+  if (input.availableBytes >= requiredBytes) return;
+
+  const formatGiB = (bytes: bigint) => (Number(bytes) / (1024 ** 3)).toFixed(2);
+  throw new Error(
+    `Insufficient capacity for SSH workspace restore on ${input.stagingDir}: ` +
+    `${formatGiB(input.availableBytes)} GiB available, ${formatGiB(requiredBytes)} GiB required ` +
+    `(${formatGiB(input.remoteBytes)} GiB snapshot plus safe headroom).`,
+  );
+}
+
+async function preflightSshSyncBackCapacity(input: {
+  stagingDir: string;
+  remoteBytes: number;
+}): Promise<void> {
+  const stats = await fs.statfs(input.stagingDir, { bigint: true });
+  assertSshSyncBackCapacity({
+    availableBytes: stats.bavail * stats.bsize,
+    remoteBytes: BigInt(input.remoteBytes),
+    stagingDir: input.stagingDir,
+  });
 }
 
 async function readLocalGitWorkspaceSnapshot(localDir: string): Promise<LocalGitWorkspaceSnapshot | null> {
@@ -1376,13 +1420,43 @@ export async function syncDirectoryFromSsh(input: {
   spec: SshRemoteExecutionSpec;
   remoteDir: string;
   localDir: string;
+  stagingDir?: string;
   exclude?: string[];
   preserveLocalEntries?: string[];
   onProgress?: RuntimeProgressSink;
   progressLabel?: string;
 }): Promise<void> {
   const auth = await createSshAuthArgs(input.spec);
-  const stagingDir = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-ssh-sync-back-"));
+  const ownsStagingDir = input.stagingDir == null;
+  let stagingDir: string;
+  try {
+    stagingDir = input.stagingDir ?? await createSshSyncBackStagingDir(input.localDir);
+  } catch (error) {
+    await auth.cleanup();
+    throw error;
+  }
+  const remoteBytes = await probeRemoteDirSize({
+    spec: input.spec,
+    remoteDir: input.remoteDir,
+  });
+  if (remoteBytes == null) {
+    await auth.cleanup();
+    if (ownsStagingDir) {
+      await fs.rm(stagingDir, { recursive: true, force: true }).catch(() => undefined);
+    }
+    throw new Error(
+      `Unable to determine SSH workspace size for capacity preflight: ${input.remoteDir}`,
+    );
+  }
+  try {
+    await preflightSshSyncBackCapacity({ stagingDir, remoteBytes });
+  } catch (error) {
+    await auth.cleanup();
+    if (ownsStagingDir) {
+      await fs.rm(stagingDir, { recursive: true, force: true }).catch(() => undefined);
+    }
+    throw error;
+  }
   const remoteTarScript = [
     `cd ${shellQuote(input.remoteDir)}`,
     `tar ${[...tarExcludeArgs(input.exclude).map(shellQuote), "-cf", "-", "."].join(" ")}`,
@@ -1395,17 +1469,15 @@ export async function syncDirectoryFromSsh(input: {
     `sh -c ${shellQuote(remoteTarScript)}`,
   ];
 
-  // The remote tar size isn't known locally, so probe the remote directory for
-  // an estimate (clamped to 99%). The probe runs concurrently with the transfer
-  // so its round-trip never delays the restore; when it is unavailable we report
-  // bytes received in MB mode with a terminal completion line.
+  // Capacity admission requires a size probe before the transfer starts. Reuse
+  // that conservative estimate for progress and clamp it to 99% until complete.
   const progress = input.onProgress
     ? createTransferProgress({
       onProgress: input.onProgress,
       phase: "Restoring",
       direction: "from",
       label: input.progressLabel,
-      totalBytes: probeRemoteDirSize({ spec: input.spec, remoteDir: input.remoteDir }),
+      totalBytes: remoteBytes,
       estimated: true,
     })
     : null;
@@ -1478,13 +1550,17 @@ export async function syncDirectoryFromSsh(input: {
     });
     await progress?.finish();
 
-    await clearLocalDirectory(input.localDir, input.preserveLocalEntries);
-    await copyDirectoryContents(stagingDir, input.localDir);
+    if (ownsStagingDir) {
+      await clearLocalDirectory(input.localDir, input.preserveLocalEntries);
+      await copyDirectoryContents(stagingDir, input.localDir);
+    }
   } catch (error) {
     await progress?.fail();
     throw error;
   } finally {
-    await fs.rm(stagingDir, { recursive: true, force: true }).catch(() => undefined);
+    if (ownsStagingDir) {
+      await fs.rm(stagingDir, { recursive: true, force: true }).catch(() => undefined);
+    }
     await auth.cleanup();
   }
 }
@@ -1548,7 +1624,7 @@ export async function restoreWorkspaceFromSshExecution(input: {
 }): Promise<void> {
   const remoteDir = input.remoteDir ?? input.spec.remoteCwd;
   if (input.baselineSnapshot) {
-    const stagingDir = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-ssh-sync-back-"));
+    const stagingDir = await createSshSyncBackStagingDir(input.localDir);
     const importedRef = input.restoreGitHistory
       ? `refs/paperclip/ssh-sync/imported/${randomUUID()}`
       : null;
@@ -1566,7 +1642,8 @@ export async function restoreWorkspaceFromSshExecution(input: {
       await syncDirectoryFromSsh({
         spec: input.spec,
         remoteDir,
-        localDir: stagingDir,
+        localDir: input.localDir,
+        stagingDir,
         exclude: input.baselineSnapshot.exclude,
         onProgress: input.onProgress,
         progressLabel: "workspace",


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Local adapters can execute workspaces over SSH and then restore the resulting files to the host
> - A restore must stage the complete remote snapshot before touching the active local workspace so an interrupted transfer cannot destroy local work
> - That stage previously lived under the host's shared `/tmp`, where a large workspace could exhaust a smaller per-user quota and make unrelated writes fail
> - Baseline-aware restores could also allocate two full snapshot stages at once
> - This pull request moves full restore staging beside the destination workspace, reuses the same stage for baseline merges, and checks capacity on the filesystem that will hold it
> - The benefit is that large SSH restores retain failure isolation without consuming the shared temporary-files quota or double-staging snapshots

## Linked Issues or Issue Description

No public GitHub issue exists for this bug. Related but distinct: #9018 addresses stale SSH temporary-directory cleanup and `/tmp` headroom; this PR changes where full restore snapshots are staged and removes nested staging.

**What happened?** SSH sync-back extracted a complete workspace snapshot under `os.tmpdir()`. On hosts where `/tmp` has a smaller per-user quota than the workspace filesystem, a large but otherwise valid restore could fail with `EDQUOT` and disrupt unrelated temporary-file writes. Baseline-aware restores could additionally allocate an outer merge stage and an inner extraction stage, temporarily requiring two full copies.

**Expected behavior:** A restore should stage one complete snapshot on the destination workspace filesystem, verify sufficient capacity before transfer, and leave the active workspace untouched if transfer or extraction fails.

**Steps to reproduce:**
1. Configure an SSH-backed local adapter whose remote workspace is close to the host's `/tmp` quota.
2. Trigger SSH sync-back to a destination filesystem with sufficient free space.
3. Observe the old implementation extracting under `/tmp` and failing with quota exhaustion before restore.
4. On the baseline-aware path, observe two full snapshot staging directories being allocated.

**Version / deployment:** Reproduced from `master`, built from source in a local development deployment. Adapter-specific to SSH-backed local execution. Database mode and access context are not applicable.

**Privacy:** No credentials, private paths, or internal issue references are included in this public description.

## What Changed

- Added a centralized allocator that creates uniquely named SSH sync-back staging directories beside the destination workspace.
- Added remote-size and local-filesystem capacity preflight requiring the snapshot size plus the greater of 10% or 512 MiB headroom.
- Reused the caller-owned stage for baseline-aware restores, eliminating the nested full snapshot copy.
- Added regression coverage for allocator placement, capacity rejection, cleanup after success/failure, and baseline-merge transfers.
- Added an ADR documenting the decision, blast radius, consequences, and rollback path.

## Verification

- [x] SSH fixture suite: 18/18 passed.
- [x] `@paperclipai/adapter-utils` typecheck passed.
- [x] `git diff --check` passed.
- [x] Fork branch resolves to commit `541d0d88d8992aa6981e43856b53d47184574b71`.

## Risks

- Blast radius is limited to SSH sync-back; upload staging, SSH auth files, git bundle staging, local runtimes, and non-SSH providers are unchanged.
- The destination parent must now be writable and have room for one staged snapshot plus safety headroom.
- Minimal remotes without the existing `du -sk` capability fail closed before transfer.
- A process-level hard kill can still leave a uniquely named sibling stage; stale-directory scavenging remains separate hardening in #9018.
- Rollback is code-only: revert the capacity assertion, caller-owned stage, and allocator call sites to `os.tmpdir()`; this reintroduces the quota and double-staging failure modes.

> This is focused reliability work in the SSH restore path. `ROADMAP.md` contains no overlapping SSH sync-back or adapter staging item.

## Model Used

OpenAI GPT-5.6 Sol (`gpt-5.6-sol-medium`) with reasoning and tool use assisted PR preparation, repository inspection, verification, and CI triage. The implementation commit was handed off from another automated agent; its exact model was not recorded in the public commit metadata.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change and contains no internal ticket id
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green — CI is currently running
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups — review is currently running
- [x] I will address all Greptile and reviewer comments before requesting merge