### PR TITLE
fix(hermes): preload managed Paperclip skills per run

### DIFF
--- a/packages/adapters/hermes/src/index.test.ts
+++ b/packages/adapters/hermes/src/index.test.ts
@@ -1,4 +1,8 @@
-import { expect, test } from "vitest";
+import { afterEach, expect, test } from "vitest";
+
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 
 import {
   createHermesGatewayServerAdapter,
@@ -7,6 +11,12 @@ import {
   hermesGatewayType,
 } from "./index.js";
 import { createServerAdapter as createGatewayServerAdapterFromSubpath } from "./gateway/index.js";
+
+const tempRoots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempRoots.splice(0).map((root) => fs.rm(root, { recursive: true, force: true })));
+});
 
 test("root package export exposes Paperclip external adapter entrypoint", () => {
   const adapter = createServerAdapter();
@@ -60,4 +70,29 @@ test("Hermes adapter exposes bundled Paperclip task bridge skill", async () => {
   });
 
   expect(snapshot?.entries.some((entry) => entry.runtimeName === "paperclip-task-bridge")).toBe(true);
+});
+
+test("Hermes snapshot reports a desired source without SKILL.md as missing", async () => {
+  const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-hermes-snapshot-"));
+  tempRoots.push(tempRoot);
+  const source = path.join(tempRoot, "paperclip");
+  await fs.mkdir(source, { recursive: true });
+  const adapter = createServerAdapter();
+
+  const snapshot = await adapter.listSkills?.({
+    adapterType: "hermes_local",
+    agentId: "11111111-1111-4111-8111-111111111111",
+    companyId: "22222222-2222-4222-8222-222222222222",
+    config: {
+      paperclipRuntimeSkills: [
+        { key: "paperclipai/paperclip/paperclip", runtimeName: "paperclip", source },
+      ],
+      paperclipSkillSync: { desiredSkills: ["paperclipai/paperclip/paperclip"] },
+    },
+  });
+
+  expect(snapshot?.entries.find((entry) => entry.key === "paperclipai/paperclip/paperclip")).toMatchObject({
+    state: "missing",
+  });
+  expect(snapshot?.warnings).toContainEqual(expect.stringContaining("missing SKILL.md"));
 });

--- a/packages/adapters/hermes/src/server/execute.onspawn.test.ts
+++ b/packages/adapters/hermes/src/server/execute.onspawn.test.ts
@@ -38,6 +38,14 @@ vi.mock("node:fs/promises", () => ({
   stat: vi.fn(async () => ({ isFile: () => true, isDirectory: () => false })),
 }));
 
+vi.mock("./managed-skills.js", () => ({
+  prepareHermesManagedSkills: vi.fn(async () => ({
+    runtimeRoot: "/tmp/hermes skills/.paperclip-runtime/test-run-1",
+    skillNames: [".paperclip-runtime/test-run-1/paperclip"],
+    cleanup: vi.fn(async () => undefined),
+  })),
+}));
+
 import { execute } from "./execute.js";
 import * as serverUtils from "@paperclipai/adapter-utils/server-utils";
 
@@ -102,6 +110,18 @@ describe("hermes-local adapter onSpawn forwarding", () => {
     const lastCall = mocked.mock.calls[mocked.mock.calls.length - 1];
     const opts = lastCall[3] as Record<string, unknown>;
     expect(opts.onSpawn).toBe(onSpawn);
+  });
+
+  it("preloads prepared managed skills through argv-safe --skills pairs", async () => {
+    const { ctx } = makeCtx();
+
+    await execute(ctx as any);
+
+    const mocked = vi.mocked(serverUtils.runChildProcess);
+    const args = mocked.mock.calls.at(-1)?.[2] as string[];
+    const skillFlag = args.indexOf("--skills");
+    expect(skillFlag).toBeGreaterThan(-1);
+    expect(args[skillFlag + 1]).toBe(".paperclip-runtime/test-run-1/paperclip");
   });
 
   it("runChildProcess opts type includes onSpawn", () => {

--- a/packages/adapters/hermes/src/server/execute.ts
+++ b/packages/adapters/hermes/src/server/execute.ts
@@ -19,6 +19,7 @@
  */
 
 import fs from "node:fs/promises";
+import { randomUUID } from "node:crypto";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -419,7 +420,7 @@ export async function execute(
   const preparedManagedSkills = await prepareHermesManagedSkills({
     config,
     moduleDir: __moduleDir,
-    runId: ctx.runId || `paperclip-${Date.now()}`,
+    runId: ctx.runId || `paperclip-${randomUUID()}`,
   });
 
   // ── Build command args ─────────────────────────────────────────────────

--- a/packages/adapters/hermes/src/server/execute.ts
+++ b/packages/adapters/hermes/src/server/execute.ts
@@ -20,6 +20,7 @@
 
 import fs from "node:fs/promises";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 import type {
   AdapterExecutionContext,
@@ -51,6 +52,9 @@ import {
   detectModel,
   resolveProvider,
 } from "./detect-model.js";
+import { prepareHermesManagedSkills } from "./managed-skills.js";
+
+const __moduleDir = path.dirname(fileURLToPath(import.meta.url));
 
 // ---------------------------------------------------------------------------
 // Config helpers
@@ -408,6 +412,16 @@ export async function execute(
     prompt = agentInstructions + "\n\n---\n\n" + prompt;
   }
 
+  // ── Prepare Paperclip-managed skills ───────────────────────────────────
+  // Hermes only accepts skill identifiers via --skills. Materialize the
+  // desired managed sources under the active profile's skills directory for
+  // this run, then preload those categorized paths explicitly.
+  const preparedManagedSkills = await prepareHermesManagedSkills({
+    config,
+    moduleDir: __moduleDir,
+    runId: ctx.runId || `paperclip-${Date.now()}`,
+  });
+
   // ── Build command args ─────────────────────────────────────────────────
   // Use -Q (quiet) to get clean output: just response + session_id line
   const useQuiet = cfgBoolean(config.quiet) === true; // default false
@@ -426,6 +440,10 @@ export async function execute(
 
   if (toolsets) {
     args.push("-t", toolsets);
+  }
+
+  for (const skillName of preparedManagedSkills.skillNames) {
+    args.push("--skills", skillName);
   }
 
   if (maxTurns && maxTurns > 0) {
@@ -524,14 +542,19 @@ export async function execute(
     return ctx.onLog(stream, chunk);
   };
 
-  const result = await runChildProcess(ctx.runId, hermesCmd, args, {
-    cwd,
-    env,
-    timeoutSec,
-    graceSec,
-    onLog: wrappedOnLog,
-    onSpawn: ctx.onSpawn,
-  });
+  let result;
+  try {
+    result = await runChildProcess(ctx.runId, hermesCmd, args, {
+      cwd,
+      env,
+      timeoutSec,
+      graceSec,
+      onLog: wrappedOnLog,
+      onSpawn: ctx.onSpawn,
+    });
+  } finally {
+    await preparedManagedSkills.cleanup();
+  }
 
   // ── Parse output ───────────────────────────────────────────────────────
   const parsed = parseHermesOutput(result.stdout || "", result.stderr || "");

--- a/packages/adapters/hermes/src/server/managed-skills.test.ts
+++ b/packages/adapters/hermes/src/server/managed-skills.test.ts
@@ -1,0 +1,125 @@
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { prepareHermesManagedSkills } from "./managed-skills.js";
+
+async function writeSkill(root: string, name: string): Promise<string> {
+  const skillDir = path.join(root, name);
+  await fs.mkdir(skillDir, { recursive: true });
+  await fs.writeFile(
+    path.join(skillDir, "SKILL.md"),
+    `---\nname: ${name}\ndescription: Test skill\n---\n\n# ${name}\n`,
+    "utf8",
+  );
+  await fs.writeFile(path.join(skillDir, "script.ts"), "export {};\n", "utf8");
+  return skillDir;
+}
+
+describe("Hermes managed runtime skills", () => {
+  let tempRoot: string;
+
+  beforeEach(async () => {
+    tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-hermes-managed-skills-"));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempRoot, { recursive: true, force: true });
+  });
+
+  test("materializes only desired skills in the active profile and cleans them up", async () => {
+    const hermesHome = path.join(tempRoot, "Hermes Home");
+    const paperclip = await writeSkill(path.join(tempRoot, "runtime skills"), "paperclip");
+    const unselected = await writeSkill(path.join(tempRoot, "runtime skills"), "unselected");
+
+    const prepared = await prepareHermesManagedSkills({
+      config: {
+        env: { HERMES_HOME: hermesHome },
+        extraArgs: ["--profile", "isolated-profile"],
+        paperclipRuntimeSkills: [
+          { key: "paperclipai/paperclip/paperclip", runtimeName: "paperclip", source: paperclip },
+          { key: "paperclipai/paperclip/unselected", runtimeName: "unselected", source: unselected },
+        ],
+        paperclipSkillSync: { desiredSkills: ["paperclipai/paperclip/paperclip"] },
+      },
+      moduleDir: tempRoot,
+      runId: "run with spaces",
+    });
+
+    expect(prepared.skillNames).toEqual([".paperclip-runtime/run-with-spaces/paperclip"]);
+    await expect(
+      fs.readFile(
+        path.join(
+          hermesHome,
+          "profiles",
+          "isolated-profile",
+          "skills",
+          ".paperclip-runtime",
+          "run-with-spaces",
+          "paperclip",
+          "SKILL.md",
+        ),
+        "utf8",
+      ),
+    ).resolves.toContain("name: paperclip");
+    await expect(
+      fs.stat(
+        path.join(
+          hermesHome,
+          "profiles",
+          "isolated-profile",
+          "skills",
+          ".paperclip-runtime",
+          "run-with-spaces",
+          "unselected",
+        ),
+      ),
+    ).rejects.toMatchObject({ code: "ENOENT" });
+
+    await prepared.cleanup();
+    await expect(fs.stat(prepared.runtimeRoot)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  test("fails closed when a desired source path is missing", async () => {
+    await expect(
+      prepareHermesManagedSkills({
+        config: {
+          env: { HERMES_HOME: path.join(tempRoot, "hermes") },
+          paperclipRuntimeSkills: [
+            {
+              key: "paperclipai/paperclip/paperclip",
+              runtimeName: "paperclip",
+              source: path.join(tempRoot, "does not exist"),
+              sourceStatus: "missing",
+              missingDetail: "Managed source was not materialized",
+            },
+          ],
+          paperclipSkillSync: { desiredSkills: ["paperclipai/paperclip/paperclip"] },
+        },
+        moduleDir: tempRoot,
+        runId: "missing-source",
+      }),
+    ).rejects.toThrow("Managed source was not materialized");
+  });
+
+  test("rejects profile traversal and preserves argv-safe paths with spaces", async () => {
+    const source = await writeSkill(path.join(tempRoot, "runtime skills"), "paperclip");
+
+    await expect(
+      prepareHermesManagedSkills({
+        config: {
+          env: { HERMES_HOME: path.join(tempRoot, "Hermes Home") },
+          extraArgs: ["--profile", "../../outside"],
+          paperclipRuntimeSkills: [
+            { key: "paperclip", runtimeName: "paperclip", source },
+          ],
+          paperclipSkillSync: { desiredSkills: ["paperclip"] },
+        },
+        moduleDir: tempRoot,
+        runId: "unsafe-profile",
+      }),
+    ).rejects.toThrow("Invalid Hermes profile name");
+  });
+});

--- a/packages/adapters/hermes/src/server/managed-skills.test.ts
+++ b/packages/adapters/hermes/src/server/managed-skills.test.ts
@@ -104,6 +104,87 @@ describe("Hermes managed runtime skills", () => {
     ).rejects.toThrow("Managed source was not materialized");
   });
 
+  test("fails closed when the desired source directory is a symlink", async () => {
+    const realSource = await writeSkill(path.join(tempRoot, "runtime skills"), "paperclip-real");
+    const linkedSource = path.join(tempRoot, "paperclip-linked");
+    await fs.symlink(realSource, linkedSource);
+
+    await expect(
+      prepareHermesManagedSkills({
+        config: {
+          env: { HERMES_HOME: path.join(tempRoot, "hermes") },
+          paperclipRuntimeSkills: [
+            { key: "paperclip", runtimeName: "paperclip", source: linkedSource },
+          ],
+          paperclipSkillSync: { desiredSkills: ["paperclip"] },
+        },
+        moduleDir: tempRoot,
+        runId: "symlink-source",
+      }),
+    ).rejects.toThrow("must not be a symbolic link");
+  });
+
+  test("fails closed when the desired SKILL.md is a symlink", async () => {
+    const source = path.join(tempRoot, "runtime skills", "paperclip");
+    await fs.mkdir(source, { recursive: true });
+    const externalSkillMd = path.join(tempRoot, "external-SKILL.md");
+    await fs.writeFile(externalSkillMd, "---\nname: paperclip\n---\n", "utf8");
+    await fs.symlink(externalSkillMd, path.join(source, "SKILL.md"));
+
+    await expect(
+      prepareHermesManagedSkills({
+        config: {
+          env: { HERMES_HOME: path.join(tempRoot, "hermes") },
+          paperclipRuntimeSkills: [
+            { key: "paperclip", runtimeName: "paperclip", source },
+          ],
+          paperclipSkillSync: { desiredSkills: ["paperclip"] },
+        },
+        moduleDir: tempRoot,
+        runId: "symlink-skill-md",
+      }),
+    ).rejects.toThrow("SKILL.md must be a regular file and not a symbolic link");
+  });
+
+  test.each([
+    ["HERMES_HOME", "relative-hermes-home"],
+    ["HOME", "relative-home"],
+  ])("rejects a relative %s runtime root", async (envKey, unsafeValue) => {
+    const source = await writeSkill(path.join(tempRoot, "runtime skills"), "paperclip");
+
+    await expect(
+      prepareHermesManagedSkills({
+        config: {
+          env: { [envKey]: unsafeValue },
+          paperclipRuntimeSkills: [
+            { key: "paperclip", runtimeName: "paperclip", source },
+          ],
+          paperclipSkillSync: { desiredSkills: ["paperclip"] },
+        },
+        moduleDir: tempRoot,
+        runId: "relative-runtime-root",
+      }),
+    ).rejects.toThrow(`${envKey} must be an absolute path`);
+  });
+
+  test.each(["HERMES_HOME", "HOME"])("rejects traversal components in %s", async (envKey) => {
+    const source = await writeSkill(path.join(tempRoot, "runtime skills"), "paperclip");
+
+    await expect(
+      prepareHermesManagedSkills({
+        config: {
+          env: { [envKey]: `${tempRoot}/safe/../outside` },
+          paperclipRuntimeSkills: [
+            { key: "paperclip", runtimeName: "paperclip", source },
+          ],
+          paperclipSkillSync: { desiredSkills: ["paperclip"] },
+        },
+        moduleDir: tempRoot,
+        runId: "traversal-runtime-root",
+      }),
+    ).rejects.toThrow(`${envKey} must not contain traversal components`);
+  });
+
   test("rejects profile traversal and preserves argv-safe paths with spaces", async () => {
     const source = await writeSkill(path.join(tempRoot, "runtime skills"), "paperclip");
 

--- a/packages/adapters/hermes/src/server/managed-skills.ts
+++ b/packages/adapters/hermes/src/server/managed-skills.ts
@@ -13,7 +13,7 @@ interface PreparedHermesManagedSkills {
   cleanup: () => Promise<void>;
 }
 
-const HERMES_PROFILE_NAME_RE = /^[a-z0-9][a-z0-9_-]{0,63}$/;
+const HERMES_PROFILE_NAME_RE = /^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$/;
 const SAFE_SEGMENT_RE = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
 
 function configEnv(config: Record<string, unknown>): Record<string, unknown> {
@@ -56,13 +56,22 @@ function readProfile(extraArgs: unknown): string | null {
   return null;
 }
 
+function absoluteEnvPath(value: string | null, label: "HERMES_HOME" | "HOME"): string | null {
+  if (!value) return null;
+  if (!path.isAbsolute(value)) throw new Error(`${label} must be an absolute path.`);
+  if (value.split(/[\\/]+/).includes("..")) {
+    throw new Error(`${label} must not contain traversal components.`);
+  }
+  return path.normalize(value);
+}
+
 function resolveHermesSkillsHome(config: Record<string, unknown>): string {
   const env = configEnv(config);
-  const explicitHermesHome = envString(env.HERMES_HOME);
-  const home = envString(env.HOME);
+  const explicitHermesHome = absoluteEnvPath(envString(env.HERMES_HOME), "HERMES_HOME");
+  const home = absoluteEnvPath(envString(env.HOME), "HOME");
   const hermesHome = explicitHermesHome
-    ? path.resolve(explicitHermesHome)
-    : path.join(home ? path.resolve(home) : os.homedir(), ".hermes");
+    ? explicitHermesHome
+    : path.join(home ?? os.homedir(), ".hermes");
   const profile = readProfile(config.extraArgs);
   if (profile && !HERMES_PROFILE_NAME_RE.test(profile)) {
     throw new Error(`Invalid Hermes profile name ${JSON.stringify(profile)}.`);
@@ -85,7 +94,10 @@ function safeRunSegment(runId: string): string {
 
 async function copySkillDirectory(source: string, target: string): Promise<void> {
   const sourceRoot = path.resolve(source);
-  const stat = await fs.stat(sourceRoot);
+  const stat = await fs.lstat(sourceRoot);
+  if (stat.isSymbolicLink()) {
+    throw new Error(`Managed skill source must not be a symbolic link: ${sourceRoot}`);
+  }
   if (!stat.isDirectory()) throw new Error(`Managed skill source is not a directory: ${sourceRoot}`);
   await fs.mkdir(path.dirname(target), { recursive: true });
   await fs.cp(sourceRoot, target, {
@@ -115,9 +127,16 @@ export async function prepareHermesManagedSkills(input: {
     if (entry.sourceStatus === "missing") {
       throw new Error(entry.missingDetail || `Managed Hermes skill source is missing: ${entry.source}`);
     }
-    await fs.stat(path.join(entry.source, "SKILL.md")).catch(() => {
+    const skillMdPath = path.join(entry.source, "SKILL.md");
+    const skillMdStat = await fs.lstat(skillMdPath).catch(() => null);
+    if (!skillMdStat) {
       throw new Error(`Managed Hermes skill source is missing SKILL.md: ${entry.source}`);
-    });
+    }
+    if (skillMdStat.isSymbolicLink() || !skillMdStat.isFile()) {
+      throw new Error(
+        `Managed Hermes skill SKILL.md must be a regular file and not a symbolic link: ${skillMdPath}`,
+      );
+    }
   }
 
   const skillsHome = resolveHermesSkillsHome(input.config);

--- a/packages/adapters/hermes/src/server/managed-skills.ts
+++ b/packages/adapters/hermes/src/server/managed-skills.ts
@@ -1,0 +1,148 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import {
+  readPaperclipRuntimeSkillEntries,
+  resolvePaperclipDesiredSkillNames,
+} from "@paperclipai/adapter-utils/server-utils";
+
+interface PreparedHermesManagedSkills {
+  runtimeRoot: string;
+  skillNames: string[];
+  cleanup: () => Promise<void>;
+}
+
+const HERMES_PROFILE_NAME_RE = /^[a-z0-9][a-z0-9_-]{0,63}$/;
+const SAFE_SEGMENT_RE = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
+
+function configEnv(config: Record<string, unknown>): Record<string, unknown> {
+  return typeof config.env === "object" && config.env !== null && !Array.isArray(config.env)
+    ? (config.env as Record<string, unknown>)
+    : {};
+}
+
+function envString(value: unknown): string | null {
+  if (typeof value === "string" && value.trim()) return value.trim();
+  if (
+    typeof value === "object" &&
+    value !== null &&
+    !Array.isArray(value) &&
+    typeof (value as { value?: unknown }).value === "string" &&
+    (value as { value: string }).value.trim()
+  ) {
+    return (value as { value: string }).value.trim();
+  }
+  return null;
+}
+
+function stringArray(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((entry): entry is string => typeof entry === "string")
+    : [];
+}
+
+function readProfile(extraArgs: unknown): string | null {
+  const args = stringArray(extraArgs);
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index]!.trim();
+    const combined = arg.match(/^(?:--profile|-p)\s+(.+)$/);
+    if (combined) return combined[1]!.trim() || null;
+    if (arg === "--profile" || arg === "-p") return args[index + 1]?.trim() || null;
+    if (arg.startsWith("--profile=") || arg.startsWith("-p=")) {
+      return arg.slice(arg.indexOf("=") + 1).trim() || null;
+    }
+  }
+  return null;
+}
+
+function resolveHermesSkillsHome(config: Record<string, unknown>): string {
+  const env = configEnv(config);
+  const explicitHermesHome = envString(env.HERMES_HOME);
+  const home = envString(env.HOME);
+  const hermesHome = explicitHermesHome
+    ? path.resolve(explicitHermesHome)
+    : path.join(home ? path.resolve(home) : os.homedir(), ".hermes");
+  const profile = readProfile(config.extraArgs);
+  if (profile && !HERMES_PROFILE_NAME_RE.test(profile)) {
+    throw new Error(`Invalid Hermes profile name ${JSON.stringify(profile)}.`);
+  }
+  return profile ? path.join(hermesHome, "profiles", profile, "skills") : path.join(hermesHome, "skills");
+}
+
+function safeSegment(value: string, label: string): string {
+  const normalized = value.trim();
+  if (!SAFE_SEGMENT_RE.test(normalized) || normalized.includes("..")) {
+    throw new Error(`Invalid ${label} ${JSON.stringify(value)}.`);
+  }
+  return normalized;
+}
+
+function safeRunSegment(runId: string): string {
+  const normalized = runId.trim().replace(/[^A-Za-z0-9._-]+/g, "-").replace(/^-+|-+$/g, "");
+  return safeSegment(normalized || "run", "Hermes runtime skill run id");
+}
+
+async function copySkillDirectory(source: string, target: string): Promise<void> {
+  const sourceRoot = path.resolve(source);
+  const stat = await fs.stat(sourceRoot);
+  if (!stat.isDirectory()) throw new Error(`Managed skill source is not a directory: ${sourceRoot}`);
+  await fs.mkdir(path.dirname(target), { recursive: true });
+  await fs.cp(sourceRoot, target, {
+    recursive: true,
+    force: false,
+    errorOnExist: true,
+    filter: async (candidate) => !(await fs.lstat(candidate)).isSymbolicLink(),
+  });
+}
+
+export async function prepareHermesManagedSkills(input: {
+  config: Record<string, unknown>;
+  moduleDir: string;
+  runId: string;
+}): Promise<PreparedHermesManagedSkills> {
+  const available = await readPaperclipRuntimeSkillEntries(input.config, input.moduleDir);
+  const desiredNames = resolvePaperclipDesiredSkillNames(input.config, available);
+  const desiredSet = new Set(desiredNames);
+  if (desiredSet.size === 0) {
+    return { runtimeRoot: "", skillNames: [], cleanup: async () => undefined };
+  }
+
+  const availableByKey = new Map(available.map((entry) => [entry.key, entry]));
+  for (const desired of desiredNames) {
+    const entry = availableByKey.get(desired);
+    if (!entry) throw new Error(`Desired managed Hermes skill ${JSON.stringify(desired)} is unavailable.`);
+    if (entry.sourceStatus === "missing") {
+      throw new Error(entry.missingDetail || `Managed Hermes skill source is missing: ${entry.source}`);
+    }
+    await fs.stat(path.join(entry.source, "SKILL.md")).catch(() => {
+      throw new Error(`Managed Hermes skill source is missing SKILL.md: ${entry.source}`);
+    });
+  }
+
+  const skillsHome = resolveHermesSkillsHome(input.config);
+  const runtimeRelativeRoot = path.posix.join(".paperclip-runtime", safeRunSegment(input.runId));
+  const runtimeRoot = path.join(skillsHome, ...runtimeRelativeRoot.split("/"));
+  await fs.rm(runtimeRoot, { recursive: true, force: true });
+
+  const skillNames: string[] = [];
+  try {
+    for (const entry of available) {
+      if (!desiredSet.has(entry.key)) continue;
+      const runtimeName = safeSegment(entry.runtimeName, "Hermes managed skill runtime name");
+      await copySkillDirectory(entry.source, path.join(runtimeRoot, runtimeName));
+      skillNames.push(path.posix.join(runtimeRelativeRoot, runtimeName));
+    }
+  } catch (error) {
+    await fs.rm(runtimeRoot, { recursive: true, force: true }).catch(() => undefined);
+    throw error;
+  }
+
+  return {
+    runtimeRoot,
+    skillNames,
+    cleanup: async () => {
+      await fs.rm(runtimeRoot, { recursive: true, force: true });
+    },
+  };
+}

--- a/packages/adapters/hermes/src/server/skills.ts
+++ b/packages/adapters/hermes/src/server/skills.ts
@@ -147,25 +147,32 @@ async function buildHermesSkillSnapshot(config: Record<string, unknown>): Promis
   // Paperclip-managed skills
   for (const entry of paperclipEntries) {
     const desired = desiredSet.has(entry.key);
-    const sourceMissing = entry.sourceStatus === "missing";
-    if (desired && sourceMissing) {
-      warnings.push(
-        entry.missingDetail || `Desired managed skill "${entry.key}" has no executable source path.`,
-      );
+    const skillMdPath = path.join(entry.source, "SKILL.md");
+    const skillMdStat = desired ? await fs.lstat(skillMdPath).catch(() => null) : null;
+    const sourceMissing = entry.sourceStatus === "missing" || (desired && !skillMdStat);
+    const sourceInvalid = desired && !!skillMdStat && (skillMdStat.isSymbolicLink() || !skillMdStat.isFile());
+    const sourceUnavailable = sourceMissing || sourceInvalid;
+    const unavailableDetail = entry.sourceStatus === "missing"
+      ? entry.missingDetail || `Desired managed skill "${entry.key}" has no executable source path.`
+      : sourceInvalid
+        ? `Desired managed skill "${entry.key}" SKILL.md must be a regular file and not a symbolic link.`
+        : `Desired managed skill "${entry.key}" is missing SKILL.md.`;
+    if (desired && sourceUnavailable) {
+      warnings.push(unavailableDetail);
     }
     entries.push({
       key: entry.key,
       runtimeName: entry.runtimeName,
       desired,
       managed: true,
-      state: desired && sourceMissing ? "missing" : desired ? "configured" : "available",
+      state: desired && sourceUnavailable ? "missing" : desired ? "configured" : "available",
       origin: "company_managed",
       originLabel: "Managed by Paperclip",
       readOnly: false,
       sourcePath: entry.source,
       targetPath: null,
-      detail: desired && sourceMissing
-        ? entry.missingDetail || "The managed skill source is unavailable; execution will fail closed."
+      detail: desired && sourceUnavailable
+        ? `${unavailableDetail} Execution will fail closed.`
         : desired
           ? "Will be materialized ephemerally and preloaded with Hermes --skills on the next run."
           : null,

--- a/packages/adapters/hermes/src/server/skills.ts
+++ b/packages/adapters/hermes/src/server/skills.ts
@@ -147,20 +147,28 @@ async function buildHermesSkillSnapshot(config: Record<string, unknown>): Promis
   // Paperclip-managed skills
   for (const entry of paperclipEntries) {
     const desired = desiredSet.has(entry.key);
+    const sourceMissing = entry.sourceStatus === "missing";
+    if (desired && sourceMissing) {
+      warnings.push(
+        entry.missingDetail || `Desired managed skill "${entry.key}" has no executable source path.`,
+      );
+    }
     entries.push({
       key: entry.key,
       runtimeName: entry.runtimeName,
       desired,
       managed: true,
-      state: desired ? "configured" : "available",
+      state: desired && sourceMissing ? "missing" : desired ? "configured" : "available",
       origin: "company_managed",
       originLabel: "Managed by Paperclip",
       readOnly: false,
       sourcePath: entry.source,
       targetPath: null,
-      detail: desired
-        ? "Will be available on the next run via Hermes skill loading."
-        : null,
+      detail: desired && sourceMissing
+        ? entry.missingDetail || "The managed skill source is unavailable; execution will fail closed."
+        : desired
+          ? "Will be materialized ephemerally and preloaded with Hermes --skills on the next run."
+          : null,
     });
   }
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source control plane people use to manage AI agents for work
> - The Hermes local adapter translates Paperclip heartbeat configuration into a Hermes CLI invocation
> - Managed Paperclip lifecycle skills were reported as configured, but the execute path neither materialized their app-shipped source nor passed Hermes `--skills`
> - That allowed a heartbeat to run without the lifecycle contract that Paperclip expected it to have
> - Hermes supports explicit skill preloading by identifier, while profile-local skills remain isolated under the active `HERMES_HOME`
> - This pull request materializes only the desired managed sources in a per-run profile-local namespace and preloads those paths explicitly
> - The benefit is fail-closed, profile-isolated runtime skill injection without a registry install, scanner bypass, or persistent unowned copy

## Linked Issues or Issue Description

Refs #2316
Related: #9426

Bug description:
- Expected: desired app-shipped Paperclip skills are executable in the Hermes heartbeat that follows skill configuration.
- Actual: the snapshot said `configured`, but Hermes received no `--skills` arguments and could not see the managed lifecycle skill.
- Reproduction: configure `paperclipSkillSync.desiredSkills`, compare the adapter snapshot with `hermes skills list`, then inspect the spawned argv.

## What Changed

- Resolve the active Hermes profile skills directory from `HERMES_HOME`, `HOME`, and `--profile` / `-p` arguments.
- Validate profile, run, and runtime skill path segments before writing.
- Fail closed when a desired managed source is unavailable or lacks `SKILL.md`.
- Copy only desired app-shipped skill directories into a per-run `.paperclip-runtime/<run>/` namespace, skipping symlinks.
- Add argv-safe repeated `--skills <categorized-path>` pairs and remove the ephemeral namespace after the child exits.
- Update the skill snapshot detail so `configured` explicitly means ephemeral materialization plus Hermes preloading; missing sources report `missing` with warnings.
- Add focused tests for desired-only injection, isolation, cleanup, missing sources, path spaces, profile traversal, and spawned argv.

## Verification

- `npx --yes pnpm@9.15.4 --filter @paperclipai/hermes-paperclip-adapter test -- src/server/managed-skills.test.ts src/server/execute.onspawn.test.ts --run`
  - 2 files passed, 6 tests passed.
- `npx --yes pnpm@9.15.4 --filter @paperclipai/hermes-paperclip-adapter typecheck`
- `npx --yes pnpm@9.15.4 --filter @paperclipai/hermes-paperclip-adapter build`
- `git diff --check`
- Runtime proof with an isolated profile-local `.paperclip-runtime/.../paperclip` materialization:
  - `hermes --profile surge-lab-executor skills list` displayed `paperclip` in category `.paperclip-runtime`.
  - `hermes ... --skills '.paperclip-runtime/sura348-proof/paperclip'` returned `PAPERCLIP_SKILL_VISIBLE`.
  - The proof directory was removed after the command.

## Risks

- Moderate adapter-local filesystem risk: each desired managed skill is copied for the duration of a heartbeat. Writes are constrained beneath the active profile's `skills/.paperclip-runtime/<run>/` directory, validated path segments are used, symlinks are skipped, missing sources fail closed, and cleanup runs in `finally`.
- Concurrent runs are isolated by run ID.
- A process crash before `finally` can leave an orphaned hidden run directory; it is not added to user config or installed through the registry and can be cleaned separately.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

OpenAI GPT-5.6 Sol with extended reasoning, repository inspection, shell execution, and code-editing tools.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant behavior text to reflect the changes
- [x] I have considered and documented risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
