### PR TITLE
feat(plugins): add mobile viewport guard plugin

### DIFF
--- a/packages/plugins/plugin-mobile-viewport-guard/README.md
+++ b/packages/plugins/plugin-mobile-viewport-guard/README.md
@@ -1,0 +1,34 @@
+# @paperclipai/plugin-mobile-viewport-guard
+
+Mobile Viewport Guard is a small first-party UI plugin for Paperclip deployments that need a host-level mobile usability patch without rebuilding the core app.
+
+It mounts an invisible same-origin `sidebarPanel` contribution and installs three mobile guards:
+
+- a viewport meta tag with `width=device-width`, `initial-scale=1`, and `viewport-fit=cover` while preserving user zoom;
+- mobile/coarse-pointer CSS that prevents horizontal viewport drift and keeps form controls at a 16px minimum font size to avoid iOS focus zoom;
+- selector/dropdown search input guarding (`inputmode=none` and `readonly`) so searchable selectors can open without the virtual keyboard covering the menu.
+
+The selector keyboard guard is intentionally narrow. It targets command-palette/listbox/combobox inputs inside dropdown-style surfaces and leaves ordinary text inputs and textareas editable.
+
+## Install
+
+```sh
+pnpm --filter @paperclipai/plugin-mobile-viewport-guard build
+pnpm paperclipai plugin install ./packages/plugins/plugin-mobile-viewport-guard
+```
+
+Or install it from the Paperclip plugin manager as a bundled first-party plugin once this repo is built.
+
+## Verify locally
+
+```sh
+pnpm --filter @paperclipai/plugin-mobile-viewport-guard typecheck
+pnpm --filter @paperclipai/plugin-mobile-viewport-guard test
+pnpm --filter @paperclipai/plugin-mobile-viewport-guard build
+```
+
+## Notes
+
+- This plugin is a pragmatic same-origin UI guard for private/trusted deployments.
+- It should not be installed on pages where pinch zoom is required for accessibility policy reasons.
+- If the core app later gets equivalent mobile viewport behavior, this plugin can be disabled or removed without data migration.

--- a/packages/plugins/plugin-mobile-viewport-guard/package.json
+++ b/packages/plugins/plugin-mobile-viewport-guard/package.json
@@ -1,0 +1,71 @@
+{
+  "name": "@paperclipai/plugin-mobile-viewport-guard",
+  "version": "0.1.0",
+  "description": "First-party UI plugin that prevents mobile viewport drift and selector keyboard occlusion",
+  "license": "MIT",
+  "homepage": "https://github.com/paperclipai/paperclip",
+  "bugs": {
+    "url": "https://github.com/paperclipai/paperclip/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/paperclipai/paperclip",
+    "directory": "packages/plugins/plugin-mobile-viewport-guard"
+  },
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    },
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "paperclipPlugin": {
+    "manifest": "./dist/manifest.js",
+    "worker": "./dist/worker.js",
+    "ui": "./dist/ui/"
+  },
+  "keywords": [
+    "paperclip",
+    "plugin",
+    "mobile",
+    "viewport",
+    "ios"
+  ],
+  "scripts": {
+    "prebuild": "pnpm --filter @paperclipai/plugin-sdk ensure-build-deps",
+    "build": "tsc && node ./scripts/build-ui.mjs",
+    "clean": "rm -rf dist",
+    "typecheck": "pnpm --filter @paperclipai/plugin-sdk ensure-build-deps && tsc --noEmit",
+    "test": "vitest run",
+    "prepack": "rm -f package.dev.json && cp package.json package.dev.json && node ../../../scripts/generate-plugin-package-json.mjs",
+    "postpack": "if [ -f package.dev.json ]; then mv package.dev.json package.json; fi"
+  },
+  "dependencies": {
+    "@paperclipai/plugin-sdk": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^22.19.21",
+    "@types/react": "^19.2.17",
+    "@types/react-dom": "^19.2.3",
+    "esbuild": "^0.28.1",
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7",
+    "typescript": "^5.7.3",
+    "vitest": "^4.1.8"
+  },
+  "peerDependencies": {
+    "react": ">=18",
+    "react-dom": ">=18"
+  }
+}

--- a/packages/plugins/plugin-mobile-viewport-guard/scripts/build-ui.mjs
+++ b/packages/plugins/plugin-mobile-viewport-guard/scripts/build-ui.mjs
@@ -1,0 +1,24 @@
+import esbuild from "esbuild";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const packageRoot = path.resolve(__dirname, "..");
+
+await esbuild.build({
+  entryPoints: [path.join(packageRoot, "src/ui/index.tsx")],
+  outfile: path.join(packageRoot, "dist/ui/index.js"),
+  bundle: true,
+  format: "esm",
+  platform: "browser",
+  target: ["es2022"],
+  sourcemap: true,
+  external: [
+    "react",
+    "react-dom",
+    "react/jsx-runtime",
+    "@paperclipai/plugin-sdk/ui",
+  ],
+  logLevel: "info",
+});

--- a/packages/plugins/plugin-mobile-viewport-guard/src/constants.ts
+++ b/packages/plugins/plugin-mobile-viewport-guard/src/constants.ts
@@ -1,0 +1,3 @@
+export const PLUGIN_ID = "paperclipai.mobile-viewport-guard";
+export const PLUGIN_VERSION = "0.1.0";
+export const SIDEBAR_PANEL_SLOT_ID = "mobile-viewport-guard-sidebar-panel";

--- a/packages/plugins/plugin-mobile-viewport-guard/src/index.ts
+++ b/packages/plugins/plugin-mobile-viewport-guard/src/index.ts
@@ -1,0 +1,12 @@
+export { default as manifest } from "./manifest.js";
+export { default as worker } from "./worker.js";
+export {
+  MOBILE_VIEWPORT_GUARD_META_CONTENT,
+  MOBILE_VIEWPORT_GUARD_STYLE_ID,
+  MOBILE_VIEWPORT_GUARD_META_MARKER,
+  MOBILE_DROPDOWN_INPUT_GUARD_MARKER,
+  MOBILE_DROPDOWN_INPUT_SELECTOR,
+  isGuardedMobileViewport,
+  shouldGuardDropdownKeyboard,
+  mobileViewportGuardCss,
+} from "./mobile-viewport-guard.js";

--- a/packages/plugins/plugin-mobile-viewport-guard/src/manifest.ts
+++ b/packages/plugins/plugin-mobile-viewport-guard/src/manifest.ts
@@ -1,0 +1,31 @@
+import type { PaperclipPluginManifestV1 } from "@paperclipai/plugin-sdk";
+import { PLUGIN_ID, PLUGIN_VERSION, SIDEBAR_PANEL_SLOT_ID } from "./constants.js";
+
+const manifest: PaperclipPluginManifestV1 = {
+  id: PLUGIN_ID,
+  apiVersion: 1,
+  version: PLUGIN_VERSION,
+  displayName: "Mobile Viewport Guard",
+  description:
+    "Installs a small same-origin UI guard that keeps Paperclip usable on mobile Safari by preventing page zoom, horizontal viewport drift, and selector keyboard occlusion.",
+  author: "PaperclipAI",
+  categories: ["ui"],
+  capabilities: ["ui.sidebar.register"],
+  entrypoints: {
+    worker: "./dist/worker.js",
+    ui: "./dist/ui",
+  },
+  ui: {
+    slots: [
+      {
+        type: "sidebarPanel",
+        id: SIDEBAR_PANEL_SLOT_ID,
+        displayName: "Mobile viewport guard",
+        exportName: "MobileViewportGuardSidebarPanel",
+        order: 10_000,
+      },
+    ],
+  },
+};
+
+export default manifest;

--- a/packages/plugins/plugin-mobile-viewport-guard/src/mobile-viewport-guard.ts
+++ b/packages/plugins/plugin-mobile-viewport-guard/src/mobile-viewport-guard.ts
@@ -1,0 +1,89 @@
+export const MOBILE_VIEWPORT_GUARD_META_CONTENT =
+  "width=device-width, initial-scale=1, viewport-fit=cover";
+export const MOBILE_VIEWPORT_GUARD_STYLE_ID = "paperclip-mobile-viewport-guard-style";
+export const MOBILE_VIEWPORT_GUARD_META_MARKER = "data-paperclip-mobile-viewport-guard";
+export const MOBILE_DROPDOWN_INPUT_GUARD_MARKER = "data-paperclip-mobile-dropdown-keyboard-guard";
+
+export const MOBILE_DROPDOWN_INPUT_SELECTOR = [
+  "[data-radix-popper-content-wrapper] input",
+  "[data-radix-select-content] input",
+  "[role=\"listbox\"] input",
+  "[role=\"dialog\"] input[cmdk-input]",
+  "[cmdk-root] input",
+  "[data-paperclip-mobile-dropdown-keyboard-guard-scope] input",
+].join(", ");
+
+export function isGuardedMobileViewport(width: number, pointerIsCoarse = false): boolean {
+  return (Number.isFinite(width) && width <= 820) || pointerIsCoarse;
+}
+
+function currentPointerIsCoarse(): boolean {
+  return globalThis.matchMedia?.("(pointer: coarse)").matches ?? false;
+}
+
+export function shouldGuardDropdownKeyboard(
+  input: Element,
+  viewportWidth = globalThis.innerWidth,
+  pointerIsCoarse = currentPointerIsCoarse(),
+): input is HTMLInputElement {
+  if (!(input instanceof HTMLInputElement)) return false;
+  if (!isGuardedMobileViewport(viewportWidth, pointerIsCoarse)) return false;
+  return input.matches(MOBILE_DROPDOWN_INPUT_SELECTOR);
+}
+
+export function mobileViewportGuardCss(): string {
+  return `
+@media (max-width: 820px), (pointer: coarse) {
+  html,
+  body,
+  #root {
+    width: 100%;
+    max-width: 100%;
+    min-width: 0;
+    overflow-x: clip;
+    overscroll-behavior-x: none;
+    touch-action: pan-y pinch-zoom;
+    -webkit-text-size-adjust: 100%;
+    text-size-adjust: 100%;
+  }
+
+  body {
+    position: relative;
+  }
+
+  input,
+  textarea,
+  select,
+  button,
+  [role="button"],
+  [role="combobox"],
+  [role="listbox"],
+  [data-radix-select-trigger],
+  [cmdk-input],
+  .select-trigger,
+  .combobox-trigger {
+    font-size: max(16px, 1em) !important;
+    -webkit-text-size-adjust: 100%;
+    text-size-adjust: 100%;
+  }
+
+  input,
+  textarea,
+  select {
+    transform: translateZ(0);
+  }
+
+  input[${MOBILE_DROPDOWN_INPUT_GUARD_MARKER}="true"] {
+    caret-color: transparent !important;
+    -webkit-user-select: none;
+    user-select: none;
+  }
+
+  [data-radix-popper-content-wrapper],
+  [data-radix-select-content],
+  [role="listbox"] {
+    max-width: min(96vw, 560px) !important;
+  }
+}
+`.trim();
+}

--- a/packages/plugins/plugin-mobile-viewport-guard/src/ui/index.tsx
+++ b/packages/plugins/plugin-mobile-viewport-guard/src/ui/index.tsx
@@ -1,0 +1,210 @@
+import { useEffect } from "react";
+import type { PluginSidebarProps } from "@paperclipai/plugin-sdk/ui";
+import {
+  MOBILE_DROPDOWN_INPUT_GUARD_MARKER,
+  MOBILE_VIEWPORT_GUARD_META_CONTENT,
+  MOBILE_VIEWPORT_GUARD_META_MARKER,
+  MOBILE_VIEWPORT_GUARD_STYLE_ID,
+  mobileViewportGuardCss,
+  shouldGuardDropdownKeyboard,
+} from "../mobile-viewport-guard.js";
+
+type AttributeSnapshot = Record<string, string | null>;
+
+const guardedInputAttributes = [
+  MOBILE_DROPDOWN_INPUT_GUARD_MARKER,
+  "inputmode",
+  "autocomplete",
+  "autocorrect",
+  "autocapitalize",
+  "spellcheck",
+  "readonly",
+];
+
+function snapshotAttributes(element: Element, attributes: string[]): AttributeSnapshot {
+  return Object.fromEntries(attributes.map((attribute) => [attribute, element.getAttribute(attribute)]));
+}
+
+function restoreAttributes(element: Element, snapshot: AttributeSnapshot): void {
+  for (const [attribute, value] of Object.entries(snapshot)) {
+    if (value === null) {
+      element.removeAttribute(attribute);
+    } else {
+      element.setAttribute(attribute, value);
+    }
+  }
+}
+
+function ensureViewportMeta(createdElements: Set<Element>, originalAttributes: WeakMap<Element, AttributeSnapshot>): HTMLMetaElement {
+  let meta = document.querySelector<HTMLMetaElement>('meta[name="viewport"]');
+  if (!meta) {
+    meta = document.createElement("meta");
+    meta.name = "viewport";
+    document.head.prepend(meta);
+    createdElements.add(meta);
+  }
+
+  if (!originalAttributes.has(meta)) {
+    originalAttributes.set(meta, snapshotAttributes(meta, ["content", MOBILE_VIEWPORT_GUARD_META_MARKER]));
+  }
+
+  meta.setAttribute("content", MOBILE_VIEWPORT_GUARD_META_CONTENT);
+  meta.setAttribute(MOBILE_VIEWPORT_GUARD_META_MARKER, "true");
+  return meta;
+}
+
+function ensureGuardStyle(
+  createdElements: Set<Element>,
+  originalAttributes: WeakMap<Element, AttributeSnapshot>,
+  originalTextContent: WeakMap<Element, string>,
+): HTMLStyleElement {
+  let style = document.getElementById(MOBILE_VIEWPORT_GUARD_STYLE_ID) as HTMLStyleElement | null;
+  if (!style) {
+    style = document.createElement("style");
+    style.id = MOBILE_VIEWPORT_GUARD_STYLE_ID;
+    style.setAttribute(MOBILE_VIEWPORT_GUARD_META_MARKER, "true");
+    document.head.appendChild(style);
+    createdElements.add(style);
+  }
+
+  if (!originalAttributes.has(style)) {
+    originalAttributes.set(style, snapshotAttributes(style, [MOBILE_VIEWPORT_GUARD_META_MARKER]));
+    originalTextContent.set(style, style.textContent ?? "");
+  }
+
+  style.textContent = mobileViewportGuardCss();
+  return style;
+}
+
+function guardDropdownInput(input: HTMLInputElement, originalAttributes: WeakMap<Element, AttributeSnapshot>): void {
+  if (!originalAttributes.has(input)) {
+    originalAttributes.set(input, snapshotAttributes(input, guardedInputAttributes));
+  }
+
+  input.setAttribute(MOBILE_DROPDOWN_INPUT_GUARD_MARKER, "true");
+  input.setAttribute("inputmode", "none");
+  input.setAttribute("autocomplete", "off");
+  input.setAttribute("autocorrect", "off");
+  input.setAttribute("autocapitalize", "off");
+  input.setAttribute("spellcheck", "false");
+  input.setAttribute("readonly", "true");
+}
+
+export function installMobileViewportGuard(): () => void {
+  if (typeof document === "undefined") return () => undefined;
+
+  const createdElements = new Set<Element>();
+  const originalAttributes = new WeakMap<Element, AttributeSnapshot>();
+  const originalTextContent = new WeakMap<Element, string>();
+  const guardedInputs = new Set<HTMLInputElement>();
+  const guardCss = mobileViewportGuardCss();
+
+  const guardAndTrackDropdownInput = (input: HTMLInputElement): void => {
+    guardDropdownInput(input, originalAttributes);
+    guardedInputs.add(input);
+  };
+
+  const unguardDropdownInput = (input: HTMLInputElement): void => {
+    const snapshot = originalAttributes.get(input);
+    if (snapshot) restoreAttributes(input, snapshot);
+    originalAttributes.delete(input);
+    guardedInputs.delete(input);
+  };
+
+  const guardAndTrackMobileDropdownInputs = (root: ParentNode = document): void => {
+    root.querySelectorAll("input").forEach((input) => {
+      if (shouldGuardDropdownKeyboard(input)) {
+        guardAndTrackDropdownInput(input);
+      }
+    });
+  };
+
+  const handleFocus = (event: FocusEvent | PointerEvent | TouchEvent): void => {
+    const target = event.target;
+    if (target instanceof HTMLInputElement) {
+      if (shouldGuardDropdownKeyboard(target)) {
+        guardAndTrackDropdownInput(target);
+      } else if (guardedInputs.has(target)) {
+        unguardDropdownInput(target);
+      }
+    }
+  };
+
+  ensureViewportMeta(createdElements, originalAttributes);
+  ensureGuardStyle(createdElements, originalAttributes, originalTextContent);
+  guardAndTrackMobileDropdownInputs();
+
+  const observer = new MutationObserver((mutations) => {
+    const meta = document.querySelector<HTMLMetaElement>('meta[name="viewport"]');
+    if (!meta || meta.getAttribute("content") !== MOBILE_VIEWPORT_GUARD_META_CONTENT) {
+      ensureViewportMeta(createdElements, originalAttributes);
+    }
+
+    const style = document.getElementById(MOBILE_VIEWPORT_GUARD_STYLE_ID);
+    if (!style || style.textContent !== guardCss) {
+      ensureGuardStyle(createdElements, originalAttributes, originalTextContent);
+    }
+
+    for (const mutation of mutations) {
+      for (const node of mutation.addedNodes) {
+        if (node instanceof HTMLInputElement && shouldGuardDropdownKeyboard(node)) {
+          guardAndTrackDropdownInput(node);
+        } else if (node instanceof Element) {
+          guardAndTrackMobileDropdownInputs(node);
+        }
+      }
+    }
+  });
+
+  observer.observe(document.documentElement, {
+    childList: true,
+    subtree: true,
+    attributes: true,
+    attributeFilter: ["content"],
+  });
+
+  document.addEventListener("focusin", handleFocus, true);
+  document.addEventListener("pointerdown", handleFocus, true);
+  document.addEventListener("touchstart", handleFocus, true);
+
+  return () => {
+    observer.disconnect();
+    document.removeEventListener("focusin", handleFocus, true);
+    document.removeEventListener("pointerdown", handleFocus, true);
+    document.removeEventListener("touchstart", handleFocus, true);
+
+    guardedInputs.forEach((input) => {
+      const snapshot = originalAttributes.get(input);
+      if (snapshot) restoreAttributes(input, snapshot);
+    });
+
+    const meta = document.querySelector<HTMLMetaElement>(`meta[${MOBILE_VIEWPORT_GUARD_META_MARKER}="true"]`);
+    if (meta) {
+      if (createdElements.has(meta)) {
+        meta.remove();
+      } else {
+        const snapshot = originalAttributes.get(meta);
+        if (snapshot) restoreAttributes(meta, snapshot);
+      }
+    }
+
+    const style = document.getElementById(MOBILE_VIEWPORT_GUARD_STYLE_ID);
+    if (style && createdElements.has(style)) {
+      style.remove();
+    } else if (style) {
+      const snapshot = originalAttributes.get(style);
+      if (snapshot) restoreAttributes(style, snapshot);
+      const text = originalTextContent.get(style);
+      if (text !== undefined) style.textContent = text;
+    }
+  };
+}
+
+function MobileViewportGuard() {
+  useEffect(() => installMobileViewportGuard(), []);
+  return <span hidden data-paperclip-mobile-viewport-guard="mounted" />;
+}
+
+export function MobileViewportGuardSidebarPanel(_props: PluginSidebarProps) {
+  return <MobileViewportGuard />;
+}

--- a/packages/plugins/plugin-mobile-viewport-guard/src/worker.ts
+++ b/packages/plugins/plugin-mobile-viewport-guard/src/worker.ts
@@ -1,0 +1,24 @@
+import { definePlugin, runWorker } from "@paperclipai/plugin-sdk";
+import { PLUGIN_ID } from "./constants.js";
+
+const plugin = definePlugin({
+  async setup(ctx) {
+    ctx.logger.info("Mobile Viewport Guard plugin registered", {
+      pluginId: PLUGIN_ID,
+      mode: "same-origin-ui-guard",
+    });
+  },
+
+  async onHealth() {
+    return {
+      status: "ok",
+      message: "Mobile Viewport Guard plugin is ready",
+      details: {
+        guard: "viewport meta, mobile form-control sizing, and selector keyboard suppression",
+      },
+    };
+  },
+});
+
+export default plugin;
+runWorker(plugin, import.meta.url);

--- a/packages/plugins/plugin-mobile-viewport-guard/tests/mobile-viewport-guard.test.ts
+++ b/packages/plugins/plugin-mobile-viewport-guard/tests/mobile-viewport-guard.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from "vitest";
+import {
+  MOBILE_DROPDOWN_INPUT_GUARD_MARKER,
+  MOBILE_DROPDOWN_INPUT_SELECTOR,
+  MOBILE_VIEWPORT_GUARD_META_MARKER,
+  MOBILE_VIEWPORT_GUARD_META_CONTENT,
+  MOBILE_VIEWPORT_GUARD_STYLE_ID,
+  isGuardedMobileViewport,
+  mobileViewportGuardCss,
+  shouldGuardDropdownKeyboard,
+} from "../src/mobile-viewport-guard.js";
+import { installMobileViewportGuard } from "../src/ui/index.js";
+
+describe("mobile viewport guard", () => {
+  it("sets mobile viewport width while preserving browser zoom", () => {
+    expect(MOBILE_VIEWPORT_GUARD_META_CONTENT).toContain("width=device-width");
+    expect(MOBILE_VIEWPORT_GUARD_META_CONTENT).toContain("initial-scale=1");
+    expect(MOBILE_VIEWPORT_GUARD_META_CONTENT).toContain("viewport-fit=cover");
+    expect(MOBILE_VIEWPORT_GUARD_META_CONTENT).not.toContain("maximum-scale");
+    expect(MOBILE_VIEWPORT_GUARD_META_CONTENT).not.toContain("user-scalable");
+  });
+
+  it("targets mobile/coarse-pointer form controls with a 16px minimum font size", () => {
+    const css = mobileViewportGuardCss();
+    expect(css).toContain("@media (max-width: 820px), (pointer: coarse)");
+    expect(css).toContain("input,");
+    expect(css).toContain("textarea,");
+    expect(css).toContain("select,");
+    expect(css).toContain('[role="combobox"]');
+    expect(css).toContain("font-size: max(16px, 1em) !important");
+  });
+
+  it("treats common phone/tablet widths and coarse pointers as guarded mobile viewports", () => {
+    expect(isGuardedMobileViewport(390)).toBe(true);
+    expect(isGuardedMobileViewport(820)).toBe(true);
+    expect(isGuardedMobileViewport(1024)).toBe(false);
+    expect(isGuardedMobileViewport(1200, true)).toBe(true);
+  });
+
+  it("targets dropdown search inputs for keyboard suppression without matching ordinary text fields", () => {
+    expect(MOBILE_DROPDOWN_INPUT_SELECTOR).toContain("[cmdk-root] input");
+    expect(MOBILE_DROPDOWN_INPUT_SELECTOR).not.toContain('input[role="combobox"]');
+    expect(MOBILE_DROPDOWN_INPUT_SELECTOR).not.toContain('input[role="searchbox"]');
+
+    const ordinary = document.createElement("input");
+    ordinary.type = "text";
+    expect(shouldGuardDropdownKeyboard(ordinary, 390, false)).toBe(false);
+
+    const standaloneCmdkInput = document.createElement("input");
+    standaloneCmdkInput.setAttribute("cmdk-input", "");
+    expect(shouldGuardDropdownKeyboard(standaloneCmdkInput, 390, false)).toBe(false);
+
+    const standaloneComboboxInput = document.createElement("input");
+    standaloneComboboxInput.setAttribute("role", "combobox");
+    expect(shouldGuardDropdownKeyboard(standaloneComboboxInput, 390, false)).toBe(false);
+
+    const standaloneSearchboxInput = document.createElement("input");
+    standaloneSearchboxInput.setAttribute("role", "searchbox");
+    expect(shouldGuardDropdownKeyboard(standaloneSearchboxInput, 390, false)).toBe(false);
+
+    const cmdkRoot = document.createElement("div");
+    cmdkRoot.setAttribute("cmdk-root", "");
+    const cmdkInput = document.createElement("input");
+    cmdkRoot.appendChild(cmdkInput);
+    document.body.appendChild(cmdkRoot);
+    expect(shouldGuardDropdownKeyboard(cmdkInput, 390, false)).toBe(true);
+    expect(shouldGuardDropdownKeyboard(cmdkInput, 1024, false)).toBe(false);
+    expect(shouldGuardDropdownKeyboard(cmdkInput, 1024, true)).toBe(true);
+    cmdkRoot.remove();
+
+    const listbox = document.createElement("div");
+    listbox.setAttribute("role", "listbox");
+    const listboxInput = document.createElement("input");
+    listbox.appendChild(listboxInput);
+    document.body.appendChild(listbox);
+    expect(shouldGuardDropdownKeyboard(listboxInput, 390, false)).toBe(true);
+    listbox.remove();
+
+    const explicitScope = document.createElement("div");
+    explicitScope.setAttribute("data-paperclip-mobile-dropdown-keyboard-guard-scope", "true");
+    const scopedInput = document.createElement("input");
+    explicitScope.appendChild(scopedInput);
+    document.body.appendChild(explicitScope);
+    expect(shouldGuardDropdownKeyboard(scopedInput, 390, false)).toBe(true);
+    explicitScope.remove();
+  });
+
+  it("includes CSS for visually neutralized guarded dropdown inputs", () => {
+    const css = mobileViewportGuardCss();
+    expect(css).toContain(`input[${MOBILE_DROPDOWN_INPUT_GUARD_MARKER}=\"true\"]`);
+    expect(css).toContain("caret-color: transparent");
+  });
+
+  it("installs, re-enforces, unguards, and cleans up DOM mutations", async () => {
+    const originalMatchMedia = globalThis.matchMedia;
+    Object.defineProperty(globalThis, "matchMedia", {
+      configurable: true,
+      value: () => ({ matches: true }),
+    });
+
+    const existingViewport = document.createElement("meta");
+    existingViewport.name = "viewport";
+    existingViewport.content = "width=980";
+    document.head.appendChild(existingViewport);
+
+    const existingStyle = document.createElement("style");
+    existingStyle.id = MOBILE_VIEWPORT_GUARD_STYLE_ID;
+    existingStyle.textContent = "/* existing */";
+    document.head.appendChild(existingStyle);
+
+    const scope = document.createElement("div");
+    scope.setAttribute("cmdk-root", "");
+    const dropdownInput = document.createElement("input");
+    dropdownInput.setAttribute("autocomplete", "on");
+    scope.appendChild(dropdownInput);
+    document.body.appendChild(scope);
+
+    const cleanup = installMobileViewportGuard();
+
+    expect(existingViewport.content).toBe(MOBILE_VIEWPORT_GUARD_META_CONTENT);
+    expect(existingViewport.getAttribute(MOBILE_VIEWPORT_GUARD_META_MARKER)).toBe("true");
+    expect(existingStyle.textContent).toBe(mobileViewportGuardCss());
+    expect(dropdownInput.getAttribute(MOBILE_DROPDOWN_INPUT_GUARD_MARKER)).toBe("true");
+    expect(dropdownInput.getAttribute("inputmode")).toBe("none");
+    expect(dropdownInput.hasAttribute("readonly")).toBe(true);
+
+    existingViewport.content = "width=320";
+    existingStyle.textContent = "/* clobbered */";
+    document.documentElement.appendChild(document.createElement("span"));
+    await Promise.resolve();
+
+    expect(existingViewport.content).toBe(MOBILE_VIEWPORT_GUARD_META_CONTENT);
+    expect(existingStyle.textContent).toBe(mobileViewportGuardCss());
+
+    scope.removeAttribute("cmdk-root");
+    dropdownInput.dispatchEvent(new FocusEvent("focusin", { bubbles: true }));
+    expect(dropdownInput.getAttribute("autocomplete")).toBe("on");
+    expect(dropdownInput.hasAttribute(MOBILE_DROPDOWN_INPUT_GUARD_MARKER)).toBe(false);
+    expect(dropdownInput.hasAttribute("readonly")).toBe(false);
+
+    scope.setAttribute("cmdk-root", "");
+    dropdownInput.dispatchEvent(new FocusEvent("focusin", { bubbles: true }));
+    expect(dropdownInput.getAttribute(MOBILE_DROPDOWN_INPUT_GUARD_MARKER)).toBe("true");
+
+    cleanup();
+
+    expect(existingViewport.content).toBe("width=980");
+    expect(existingViewport.hasAttribute(MOBILE_VIEWPORT_GUARD_META_MARKER)).toBe(false);
+    expect(existingStyle.textContent).toBe("/* existing */");
+    expect(existingStyle.hasAttribute(MOBILE_VIEWPORT_GUARD_META_MARKER)).toBe(false);
+    expect(dropdownInput.getAttribute("autocomplete")).toBe("on");
+    expect(dropdownInput.hasAttribute(MOBILE_DROPDOWN_INPUT_GUARD_MARKER)).toBe(false);
+    expect(dropdownInput.hasAttribute("readonly")).toBe(false);
+
+    Object.defineProperty(globalThis, "matchMedia", {
+      configurable: true,
+      value: originalMatchMedia,
+    });
+    document.head.replaceChildren();
+    document.body.replaceChildren();
+  });
+});

--- a/packages/plugins/plugin-mobile-viewport-guard/tsconfig.json
+++ b/packages/plugins/plugin-mobile-viewport-guard/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "jsx": "react-jsx",
+    "strict": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/packages/plugins/plugin-mobile-viewport-guard/vitest.config.ts
+++ b/packages/plugins/plugin-mobile-viewport-guard/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "jsdom",
+    include: ["tests/**/*.test.ts"],
+  },
+});

--- a/scripts/release-package-manifest.json
+++ b/scripts/release-package-manifest.json
@@ -90,6 +90,11 @@
     "publishFromCi": true
   },
   {
+    "dir": "packages/plugins/plugin-mobile-viewport-guard",
+    "name": "@paperclipai/plugin-mobile-viewport-guard",
+    "publishFromCi": true
+  },
+  {
     "dir": "server",
     "name": "@paperclipai/server",
     "publishFromCi": true

--- a/server/src/__tests__/plugin-routes-authz.test.ts
+++ b/server/src/__tests__/plugin-routes-authz.test.ts
@@ -162,11 +162,13 @@ describe.sequential("plugin install and upgrade authz", () => {
     expect(packageNames).toContain("@paperclipai/plugin-workspace-diff");
     expect(packageNames).toContain("@paperclipai/plugin-llm-wiki");
     expect(packageNames).toContain("@paperclipai/plugin-modal");
+    expect(packageNames).toContain("@paperclipai/plugin-mobile-viewport-guard");
     expect(packageNames).toContain("@paperclipai/plugin-authoring-smoke-example");
     expect(packageNames).not.toContain("@paperclipai/plugin-sdk");
     expect(byPackageName.get("@paperclipai/plugin-workspace-diff")?.experimental).toBe(true);
     expect(byPackageName.get("@paperclipai/plugin-llm-wiki")?.experimental).toBe(true);
     expect(byPackageName.get("@paperclipai/plugin-modal")?.experimental).toBe(true);
+    expect(byPackageName.get("@paperclipai/plugin-mobile-viewport-guard")?.experimental).toBe(false);
     expect(byPackageName.get("@paperclipai/plugin-authoring-smoke-example")?.experimental).toBe(false);
     expect(typeof byPackageName.get("@paperclipai/plugin-workspace-diff")?.hasBuiltEntrypoints).toBe("boolean");
   }, 20_000);


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Paperclip already has a plugin runtime that can mount trusted same-origin UI contributions without requiring core UI rebuilds.
> - Mobile Safari can still make Paperclip hard to use when viewport sizing drifts or searchable selector inputs raise the virtual keyboard over the menu.
> - A small first-party plugin is a narrow way to provide an opt-in guard for deployments that want this behavior now.
> - This pull request adds a bundled Mobile Viewport Guard plugin rather than changing every selector implementation in core UI.
> - The benefit is a reversible, installable mobile usability guard with tests and release metadata.

## Linked Issues or Issue Description

No public issue found for this exact pluginized mobile viewport guard.

Bug-style description:

- **Problem:** On mobile browsers, pages can drift horizontally or zoom around form controls, and searchable selector inputs can open the virtual keyboard over the dropdown menu.
- **Expected behavior:** Operators should be able to install an opt-in guard that keeps mobile pages within the viewport and lets selector dropdowns remain visible.
- **Actual behavior:** Without a guard, mobile browsers may resize/zoom the page or obscure selector menus with the keyboard.
- **Scope:** Adds a first-party plugin package; does not change core UI routes by default.

Related mobile UI PRs found during duplicate search but not exact duplicates: #9606, #9467, #9399, #4055, #3495, #2872, #2216, #2128.

## What Changed

- Added `@paperclipai/plugin-mobile-viewport-guard` as a first-party plugin package.
- Added an invisible sidebar-panel UI contribution that installs a mobile viewport/style guard.
- Preserved user zoom while setting `width=device-width`, `initial-scale=1`, and `viewport-fit=cover`.
- Added mobile/coarse-pointer CSS to prevent horizontal viewport drift and keep form controls at a 16px minimum font size.
- Added narrow dropdown-owned input guarding so selector search inputs can avoid virtual keyboard occlusion without making ordinary text fields read-only.
- Added cleanup logic to restore guard-owned document/input mutations on unmount.
- Added unit coverage for viewport content, mobile CSS, dropdown input targeting, and negative selector cases.
- Added release package metadata and bundled plugin catalog coverage.

## Verification

- `npx --yes pnpm@9.15.4 --filter @paperclipai/plugin-mobile-viewport-guard typecheck`
- `npx --yes pnpm@9.15.4 --filter @paperclipai/plugin-mobile-viewport-guard test`
- `npx --yes pnpm@9.15.4 --filter @paperclipai/plugin-mobile-viewport-guard build`
- `npx --yes pnpm@9.15.4 exec vitest run server/src/__tests__/plugin-routes-authz.test.ts`
- `coderabbit review --agent -t uncommitted` — findings: 0 after fixes

## Risks

- The plugin mutates document-level viewport/style state while mounted; cleanup snapshots restore guard-owned mutations on unmount.
- Selector keyboard suppression depends on known dropdown-owned input selectors and may need additional opt-in selectors as new selector implementations are added.
- This is opt-in plugin behavior rather than a default core UI change, so deployments must install/enable it to benefit.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI GPT-5.5 via OpenRouter with tool use and code execution; CodeRabbit CLI review was also used for local review feedback.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge
