### PR TITLE
Fail closed on invalid Paperclip config

### DIFF
--- a/server/src/__tests__/config-file.test.ts
+++ b/server/src/__tests__/config-file.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { readConfigFile } from "../config-file.js";
 
 describe("readConfigFile", () => {
@@ -15,6 +15,7 @@ describe("readConfigFile", () => {
   });
 
   afterEach(() => {
+    vi.restoreAllMocks();
     if (originalConfigPath === undefined) {
       delete process.env.PAPERCLIP_CONFIG;
     } else {
@@ -25,6 +26,27 @@ describe("readConfigFile", () => {
 
   it("returns null when the resolved config file does not exist", () => {
     expect(readConfigFile()).toBeNull();
+  });
+
+  it("throws a safe path-aware error when an existing config cannot be read", () => {
+    const configPath = process.env.PAPERCLIP_CONFIG!;
+    fs.writeFileSync(configPath, '{"secret":"do-not-leak"}');
+    const readError = new Error("permission denied: do-not-leak") as NodeJS.ErrnoException;
+    readError.code = "EACCES";
+    vi.spyOn(fs, "readFileSync").mockImplementationOnce(() => {
+      throw readError;
+    });
+
+    let thrown: unknown;
+    try {
+      readConfigFile();
+    } catch (error) {
+      thrown = error;
+    }
+    expect(thrown).toBeInstanceOf(Error);
+    expect(String(thrown)).toContain(`Failed to read Paperclip config at ${configPath}`);
+    expect(String(thrown)).not.toContain("do-not-leak");
+    expect((thrown as Error).cause).toBeUndefined();
   });
 
   it("throws a safe path-aware error for malformed JSON", () => {

--- a/server/src/__tests__/config-file.test.ts
+++ b/server/src/__tests__/config-file.test.ts
@@ -1,0 +1,79 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { readConfigFile } from "../config-file.js";
+
+describe("readConfigFile", () => {
+  let tempDir: string;
+  let originalConfigPath: string | undefined;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "paperclip-config-file-"));
+    originalConfigPath = process.env.PAPERCLIP_CONFIG;
+    process.env.PAPERCLIP_CONFIG = path.join(tempDir, "config.json");
+  });
+
+  afterEach(() => {
+    if (originalConfigPath === undefined) {
+      delete process.env.PAPERCLIP_CONFIG;
+    } else {
+      process.env.PAPERCLIP_CONFIG = originalConfigPath;
+    }
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("returns null when the resolved config file does not exist", () => {
+    expect(readConfigFile()).toBeNull();
+  });
+
+  it("throws a safe path-aware error for malformed JSON", () => {
+    const configPath = process.env.PAPERCLIP_CONFIG!;
+    fs.writeFileSync(configPath, '{"secret":"do-not-leak"');
+
+    expect(() => readConfigFile()).toThrow(`Invalid JSON in Paperclip config at ${configPath}`);
+    try {
+      readConfigFile();
+    } catch (error) {
+      expect(String(error)).not.toContain("do-not-leak");
+      expect((error as Error).cause).toBeUndefined();
+    }
+  });
+
+  it("throws a safe path-aware error for schema-invalid config", () => {
+    const configPath = process.env.PAPERCLIP_CONFIG!;
+    fs.writeFileSync(configPath, JSON.stringify({ secret: "do-not-leak" }));
+
+    expect(() => readConfigFile()).toThrow(
+      `Invalid Paperclip config schema at ${configPath}`,
+    );
+    try {
+      readConfigFile();
+    } catch (error) {
+      expect(String(error)).not.toContain("do-not-leak");
+      expect((error as Error).cause).toBeUndefined();
+    }
+  });
+
+  it("returns a parsed valid config", () => {
+    fs.writeFileSync(
+      process.env.PAPERCLIP_CONFIG!,
+      JSON.stringify({
+        $meta: {
+          version: 1,
+          updatedAt: "2026-07-18T00:00:00.000Z",
+          source: "configure",
+        },
+        database: { mode: "embedded-postgres" },
+        logging: { mode: "file" },
+        server: {},
+      }),
+    );
+
+    expect(readConfigFile()).toMatchObject({
+      $meta: { version: 1 },
+      database: { mode: "embedded-postgres" },
+      logging: { mode: "file" },
+    });
+  });
+});

--- a/server/src/config-file.ts
+++ b/server/src/config-file.ts
@@ -5,13 +5,18 @@ import { resolvePaperclipConfigPath } from "./paths.js";
 export function readConfigFile(): PaperclipConfig | null {
   const configPath = resolvePaperclipConfigPath();
 
-  if (!fs.existsSync(configPath)) return null;
-
   let contents: string;
   try {
     contents = fs.readFileSync(configPath, "utf-8");
   } catch (cause) {
-    throw new Error(`Failed to read Paperclip config at ${configPath}`, { cause });
+    if (
+      cause instanceof Error &&
+      "code" in cause &&
+      cause.code === "ENOENT"
+    ) {
+      return null;
+    }
+    throw new Error(`Failed to read Paperclip config at ${configPath}`);
   }
 
   let raw: unknown;

--- a/server/src/config-file.ts
+++ b/server/src/config-file.ts
@@ -7,10 +7,24 @@ export function readConfigFile(): PaperclipConfig | null {
 
   if (!fs.existsSync(configPath)) return null;
 
+  let contents: string;
   try {
-    const raw = JSON.parse(fs.readFileSync(configPath, "utf-8"));
-    return paperclipConfigSchema.parse(raw);
-  } catch {
-    return null;
+    contents = fs.readFileSync(configPath, "utf-8");
+  } catch (cause) {
+    throw new Error(`Failed to read Paperclip config at ${configPath}`, { cause });
   }
+
+  let raw: unknown;
+  try {
+    raw = JSON.parse(contents);
+  } catch {
+    throw new Error(`Invalid JSON in Paperclip config at ${configPath}`);
+  }
+
+  const parsed = paperclipConfigSchema.safeParse(raw);
+  if (!parsed.success) {
+    throw new Error(`Invalid Paperclip config schema at ${configPath}`);
+  }
+
+  return parsed.data;
 }


### PR DESCRIPTION
## What changed

- Treat only `ENOENT` as an intentionally missing Paperclip config.
- Fail closed for unreadable files, malformed JSON, and schema-invalid config.
- Keep public errors path-aware without exposing raw config content or nested causes.
- Add focused regression coverage for all five config outcomes.

## Why

The previous broad catch returned `null` for every read, JSON, or schema failure. `loadConfig()` interprets `null` as “no config,” so an invalid selected config could silently continue with the default instance and database. This patch prevents that unsafe fallback.

## Impact

Valid and genuinely absent config behavior is unchanged. Any existing invalid or unreadable config now stops startup before default instance/database initialization.

## Validation

- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/config-file.test.ts` — 1 file, 5 tests passed.
- `pnpm --filter @paperclipai/server typecheck` — passed.
- `git diff --check origin/master...HEAD` — clean.
- Independent QA Hunter review approved the patch under SQN-4190.

No migration, database mutation, or server restart is part of this PR.
