### PR TITLE
fix(heartbeat): persist Codex process identity before execution

### DIFF
--- a/packages/adapter-utils/src/acpx-engine/execute.test.ts
+++ b/packages/adapter-utils/src/acpx-engine/execute.test.ts
@@ -161,6 +161,74 @@ async function runExecutor(
 }
 
 describe("shared ACPX engine runtime behavior", () => {
+  it("reports the local ACP child before starting the first Codex turn", async () => {
+    const root = await makeTempRoot();
+    const stateDir = path.join(root, "state");
+    const processStartedAt = "2026-07-18T12:00:00.000Z";
+    const spawnEvents: Array<{
+      pid: number;
+      processGroupId: number | null;
+      startedAt: string;
+    }> = [];
+    let turnStartedAfterSpawn = false;
+    const execute = createAcpxEngineExecutor({
+      adapterType: "codex_local",
+      createRuntime: (options) => {
+        const loadSession = options.sessionStore.load.bind(options.sessionStore);
+        options.sessionStore.load = async (recordId) =>
+          recordId === "record-1"
+            ? ({ pid: process.pid, agentStartedAt: processStartedAt } as never)
+            : loadSession(recordId);
+        return {
+          ensureSession: async () => ({
+            sessionKey: "session-1",
+            acpxRecordId: "record-1",
+            backendSessionId: "backend-session",
+            agentSessionId: "agent-session",
+            runtimeSessionName: "runtime-session",
+          }),
+          startTurn: () => {
+            turnStartedAfterSpawn = spawnEvents.length === 1;
+            return {
+              events: (async function* () {
+                yield { type: "done", stopReason: "end_turn" };
+              })(),
+              result: Promise.resolve({ status: "completed", stopReason: "end_turn" }),
+              cancel: async () => {},
+            };
+          },
+          close: async () => {},
+        } as never;
+      },
+    });
+
+    const result = await execute({
+      runId: "run-codex-process-metadata",
+      agent: { id: "agent-1", companyId: "company-1" },
+      runtime: {},
+      config: { agent: "codex", stateDir, cwd: root, mode: "oneshot" },
+      context: {},
+      onLog: async () => {},
+      onSpawn: async (meta: {
+        pid: number;
+        processGroupId: number | null;
+        startedAt: string;
+      }) => {
+        spawnEvents.push(meta);
+      },
+    } as never);
+
+    expect(result.exitCode).toBe(0);
+    expect(spawnEvents).toEqual([
+      {
+        pid: process.pid,
+        processGroupId: null,
+        startedAt: processStartedAt,
+      },
+    ]);
+    expect(turnStartedAfterSpawn).toBe(true);
+  });
+
   it("sets Codex model, effort, and fast mode through CODEX_CONFIG without session config calls", async () => {
     const { configOptions, meta } = await runExecutor({
       agent: "codex",

--- a/packages/adapter-utils/src/acpx-engine/execute.ts
+++ b/packages/adapter-utils/src/acpx-engine/execute.ts
@@ -60,6 +60,7 @@ import {
   type AcpRuntimeEvent,
   type AcpRuntimeHandle,
   type AcpRuntimeOptions,
+  type AcpSessionStore,
   type AcpRuntimeStatus,
   type AcpRuntimeTurn,
   type AcpRuntimeTurnResult,
@@ -1927,6 +1928,21 @@ function warmHandleMatches(
   return entry !== undefined && entry.runtime === runtime && entry.handle === handle;
 }
 
+async function persistLocalAcpProcessMetadata(input: {
+  ctx: AdapterExecutionContext;
+  prepared: AcpxPreparedRuntime;
+  sessionStore: AcpSessionStore;
+  handle: AcpRuntimeHandle;
+}) {
+  if (!input.ctx.onSpawn || input.prepared.remoteExecutionIdentity) return;
+  const recordId = input.handle.acpxRecordId ?? input.handle.sessionKey;
+  const record = await input.sessionStore.load(recordId);
+  const pid = record?.pid;
+  if (typeof pid !== "number" || !Number.isInteger(pid) || pid <= 0) return;
+  const startedAt = record?.agentStartedAt ?? record?.createdAt ?? new Date().toISOString();
+  await input.ctx.onSpawn({ pid, processGroupId: null, startedAt });
+}
+
 export function createAcpxEngineExecutor(deps: AcpxEngineExecutorOptions = {}) {
   const createRuntime = deps.createRuntime ?? createAcpRuntime;
   const now = deps.now ?? (() => Date.now());
@@ -1961,9 +1977,10 @@ export function createAcpxEngineExecutor(deps: AcpxEngineExecutorOptions = {}) {
     const canResume = isCompatibleSession(previousParams, prepared);
     const resumeSessionId = canResume ? asString(previousParams.acpSessionId, "") || undefined : undefined;
     const cached = canResume ? warmHandles.get(prepared.sessionKey) : undefined;
+    const sessionStore = createRuntimeStore({ stateDir: prepared.stateDir });
     const runtimeOptions: AcpRuntimeOptions = {
       cwd: prepared.cwd,
-      sessionStore: createRuntimeStore({ stateDir: prepared.stateDir }),
+      sessionStore,
       agentRegistry: prepared.agentRegistry,
       permissionMode: prepared.permissionMode,
       nonInteractivePermissions: prepared.nonInteractivePermissions,
@@ -2051,6 +2068,12 @@ export function createAcpxEngineExecutor(deps: AcpxEngineExecutorOptions = {}) {
     }
     const sessionHandle = handle;
     try {
+      await persistLocalAcpProcessMetadata({
+        ctx,
+        prepared,
+        sessionStore,
+        handle: sessionHandle,
+      });
       await applySessionConfigOptions({
         runtime,
         handle: sessionHandle,

--- a/packages/adapter-utils/src/server-utils.test.ts
+++ b/packages/adapter-utils/src/server-utils.test.ts
@@ -467,6 +467,23 @@ describe("runChildProcess", () => {
     await expect(run).rejects.toThrow("database unavailable");
   });
 
+  it("rejects when a no-stdin child exits before onSpawn persistence fails", async () => {
+    const run = runChildProcess(randomUUID(), process.execPath, ["-e", ""], {
+      cwd: process.cwd(),
+      env: {},
+      timeoutSec: 5,
+      graceSec: 1,
+      onLog: async () => {},
+      onLogError: () => {},
+      onSpawn: async () => {
+        await new Promise((resolve) => setTimeout(resolve, 100));
+        throw new Error("database unavailable after exit");
+      },
+    });
+
+    await expect(run).rejects.toThrow("database unavailable after exit");
+  });
+
   it.skipIf(process.platform === "win32")("kills descendant processes on timeout via the process group", async () => {
     let descendantPid: number | null = null;
 

--- a/packages/adapter-utils/src/server-utils.test.ts
+++ b/packages/adapter-utils/src/server-utils.test.ts
@@ -442,6 +442,31 @@ describe("runChildProcess", () => {
     expect(finishedAt - startedAt).toBeGreaterThanOrEqual(spawnDelayMs);
   });
 
+  it("does not send stdin when onSpawn persistence fails", async () => {
+    const run = runChildProcess(
+      randomUUID(),
+      process.execPath,
+      [
+        "-e",
+        "process.stdin.on('data',()=>process.stdout.write('unexpected'));setInterval(()=>{},1000);",
+      ],
+      {
+        cwd: process.cwd(),
+        env: {},
+        stdin: "restart server",
+        timeoutSec: 5,
+        graceSec: 1,
+        onLog: async () => {},
+        onLogError: () => {},
+        onSpawn: async () => {
+          throw new Error("database unavailable");
+        },
+      },
+    );
+
+    await expect(run).rejects.toThrow("database unavailable");
+  });
+
   it.skipIf(process.platform === "win32")("kills descendant processes on timeout via the process group", async () => {
     let descendantPid: number | null = null;
 

--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -3182,16 +3182,20 @@ export async function runChildProcess(
           signalRunningProcess({ child, processGroupId }, "SIGKILL");
           reject(err instanceof Error ? err : new Error(String(err)));
         };
+        const spawnPersistSucceeded = spawnPersistPromise.then(
+          () => true,
+          (err) => {
+            handleSpawnPersistenceFailure(err);
+            return false;
+          },
+        );
         if (opts.stdin != null && stdin) {
-          void spawnPersistPromise
-            .then(() => {
-              if (child.killed || stdin.destroyed) return;
-              stdin.write(opts.stdin as string);
-              stdin.end();
-            })
-            .catch(handleSpawnPersistenceFailure);
-        } else {
-          void spawnPersistPromise.catch(handleSpawnPersistenceFailure);
+          void spawnPersistSucceeded.then((persisted) => {
+            if (!persisted) return;
+            if (child.killed || stdin.destroyed) return;
+            stdin.write(opts.stdin as string);
+            stdin.end();
+          });
         }
 
         child.on("error", (err: Error) => {
@@ -3217,30 +3221,33 @@ export async function runChildProcess(
           clearTerminalCleanupTimers();
           runningProcesses.delete(runId);
           void logChain.finally(() => {
-            void Promise.resolve()
-              .then(() => target.cleanup?.())
-              .finally(() => {
-              resolve({
-                exitCode: code,
-                signal,
-                timedOut,
-                stdout,
-                stderr,
-                pid: child.pid ?? null,
-                startedAt,
-                terminalResultCleanup: terminalCleanupStarted
-                  ? {
-                    kind: "terminal_result_cleanup",
-                    stopped: true,
-                    stopReason: UNMANAGED_BACKGROUND_TASK_STOP_REASON,
-                    reason: UNMANAGED_BACKGROUND_TASK_LIVENESS_REASON,
-                    terminalResultSeen,
-                    signal: terminalCleanupSignal,
-                    forceKilled: terminalCleanupForceKilled,
-                  }
-                  : null,
-              });
-              });
+            void spawnPersistSucceeded.then((persisted) => {
+              void Promise.resolve()
+                .then(() => target.cleanup?.())
+                .finally(() => {
+                  if (!persisted) return;
+                  resolve({
+                    exitCode: code,
+                    signal,
+                    timedOut,
+                    stdout,
+                    stderr,
+                    pid: child.pid ?? null,
+                    startedAt,
+                    terminalResultCleanup: terminalCleanupStarted
+                      ? {
+                        kind: "terminal_result_cleanup",
+                        stopped: true,
+                        stopReason: UNMANAGED_BACKGROUND_TASK_STOP_REASON,
+                        reason: UNMANAGED_BACKGROUND_TASK_LIVENESS_REASON,
+                        terminalResultSeen,
+                        signal: terminalCleanupSignal,
+                        forceKilled: terminalCleanupForceKilled,
+                      }
+                      : null,
+                  });
+                });
+            });
           });
         });
       })

--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -3069,9 +3069,7 @@ export async function runChildProcess(
 
         const spawnPersistPromise =
           typeof child.pid === "number" && child.pid > 0 && opts.onSpawn
-            ? opts.onSpawn({ pid: child.pid, processGroupId, startedAt }).catch((err) => {
-              onLogError(err, runId, "failed to record child process metadata");
-            })
+            ? opts.onSpawn({ pid: child.pid, processGroupId, startedAt })
             : Promise.resolve();
 
         runningProcesses.set(runId, { child, graceSec: opts.graceSec, processGroupId });
@@ -3179,12 +3177,21 @@ export async function runChildProcess(
         });
 
         const stdin = child.stdin;
+        const handleSpawnPersistenceFailure = (err: unknown) => {
+          onLogError(err, runId, "failed to record child process metadata");
+          signalRunningProcess({ child, processGroupId }, "SIGKILL");
+          reject(err instanceof Error ? err : new Error(String(err)));
+        };
         if (opts.stdin != null && stdin) {
-          void spawnPersistPromise.finally(() => {
-            if (child.killed || stdin.destroyed) return;
-            stdin.write(opts.stdin as string);
-            stdin.end();
-          });
+          void spawnPersistPromise
+            .then(() => {
+              if (child.killed || stdin.destroyed) return;
+              stdin.write(opts.stdin as string);
+              stdin.end();
+            })
+            .catch(handleSpawnPersistenceFailure);
+        } else {
+          void spawnPersistPromise.catch(handleSpawnPersistenceFailure);
         }
 
         child.on("error", (err: Error) => {

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -1555,6 +1555,97 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     });
   });
 
+  it("persists codex_local onSpawn metadata before hot-restart adoption", async () => {
+    const child = spawnAliveProcess();
+    childProcesses.add(child);
+    expect(child.pid).toBeGreaterThan(0);
+    const processStartedAt = "2026-03-19T00:05:30.000Z";
+    let releaseAdapter: (() => void) | null = null;
+    let markAdapterSpawned: (() => void) | null = null;
+    const adapterSpawned = new Promise<void>((resolve) => {
+      markAdapterSpawned = resolve;
+    });
+    const adapterRelease = new Promise<void>((resolve) => {
+      releaseAdapter = resolve;
+    });
+    mockAdapterExecute.mockImplementationOnce(async (ctx: {
+      onSpawn?: (meta: {
+        pid: number;
+        processGroupId: number | null;
+        startedAt: string;
+      }) => Promise<void>;
+    }) => {
+      await ctx.onSpawn?.({
+        pid: child.pid!,
+        processGroupId: null,
+        startedAt: processStartedAt,
+      });
+      markAdapterSpawned?.();
+      await adapterRelease;
+      return {
+        exitCode: 0,
+        signal: null,
+        timedOut: false,
+        errorMessage: null,
+        summary: "Codex run completed after hot-restart adoption.",
+        provider: "test",
+        model: "test-model",
+      };
+    });
+
+    const { runId } = await seedRunFixture({
+      adapterType: "codex_local",
+      agentStatus: "idle",
+      runStatus: "queued",
+      processPid: null,
+      processGroupId: null,
+      includeIssue: false,
+    });
+    const heartbeat = heartbeatService(db);
+
+    try {
+      await heartbeat.resumeQueuedRuns();
+      await adapterSpawned;
+
+      const running = await heartbeat.getRun(runId);
+      expect(running).toMatchObject({
+        status: "running",
+        processPid: child.pid,
+        processGroupId: null,
+      });
+      expect(running?.processStartedAt?.toISOString()).toBe(processStartedAt);
+
+      await withTempPaperclipHome(async () => {
+        await writeHotRestartIntent({
+          previousServerPid: process.pid,
+          previousServerVersion: "old-version",
+          requestedAt: new Date("2026-03-19T00:05:45.000Z"),
+        });
+        await heartbeat.prepareHotRestartShutdown(
+          "SIGTERM",
+          new Date("2026-03-19T00:06:00.000Z"),
+        );
+
+        const adoption = await heartbeat.reconcileHotRestartAdoption(
+          new Date("2026-03-19T00:07:00.000Z"),
+        );
+        expect(adoption).toMatchObject({
+          mode: "reported",
+          adoptedRunIds: [runId],
+          finalizedWhileDownRunIds: [],
+          lostRunIds: [],
+          skippedRunIds: [],
+        });
+      });
+
+      const adopted = await heartbeat.getRun(runId);
+      expect(adopted?.errorCode).not.toBe("process_lost");
+    } finally {
+      releaseAdapter?.();
+      await waitForRunToSettle(heartbeat, runId, 5_000);
+    }
+  });
+
   it.skipIf(process.platform === "win32")("keeps process-group-only hot-restart adoptions out of process_lost reaping", async () => {
     const orphan = await spawnOrphanedProcessGroup();
     cleanupPids.add(orphan.descendantPid);


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source control plane people use to manage AI agents for work
> - Local agent adapters launch child processes whose identity must remain observable across control-plane restarts
> - The Codex ACP execution lane did not report its spawned child through the adapter `onSpawn` callback
> - As a result, heartbeat rows could retain null PID and process-start metadata even while the Codex process was running
> - Hot-restart reconciliation then had no persisted identity to adopt and incorrectly classified the run as `process_lost`
> - This pull request reports the ACP child before the first turn and makes spawn-metadata persistence a prerequisite for prompt delivery
> - The benefit is that running Codex heartbeats survive Paperclip hot restarts through normal adoption rather than false loss recovery

## Linked Issues or Issue Description

### Pre-submission checklist

- [x] I searched existing open PRs and issues and found no direct duplicate.
- [x] The bug reproduces on the `master` execution path fixed by this branch.
- [x] The failure originates in Paperclip's Codex ACP spawn bridge and heartbeat persistence path.

### What happened?

A running `codex_local` heartbeat using the ACP lane could reach a server hot restart with `processPid`, `processGroupId`, and `processStartedAt` still unset. The ACP runtime launched the child process without invoking the adapter context's `onSpawn` callback, so the heartbeat service never persisted the process identity. Recovery therefore classified the still-running process as lost.

### Expected behavior

The adapter must persist the Codex child PID and start time, plus process-group identity when available, before sending the first agent turn. Hot-restart reconciliation should then adopt the eligible running heartbeat or finalize it from the persisted identity instead of marking it `process_lost`.

### Steps to reproduce

1. Start a `codex_local` heartbeat through the default ACP execution lane.
2. Trigger a Paperclip hot restart after the child process starts but before the run completes.
3. Inspect the running heartbeat row and the hot-restart adoption report.
4. Before this fix, the process identity can be null and the run appears in the lost classification; after this fix, metadata is present and the run appears in `adoptedRunIds`.

### Environment

- Paperclip commit: upstream `master` at PR creation
- Deployment mode: local dev / self-hosted server
- Installation method: built from source
- Adapter: Codex
- Database mode: embedded PGlite regression harness
- Access context: agent heartbeat execution
- Sensitive output: none included

## What Changed

- Bridge the ACP runtime store's spawned child into `ctx.onSpawn` before the first Codex turn begins.
- Await `onSpawn` in the generic child-process runner and stop stdin delivery when persistence fails.
- Add adapter regressions for ACP spawn ordering and failed spawn persistence.
- Add a heartbeat integration regression proving process metadata persistence and hot-restart adoption.

## Verification

- `../../../node_modules/.bin/vitest run packages/adapter-utils/src/acpx-engine/execute.test.ts packages/adapter-utils/src/server-utils.test.ts server/src/__tests__/heartbeat-process-recovery.test.ts -t 'reports the local ACP child before starting the first Codex turn|does not send stdin when onSpawn persistence fails|persists codex_local onSpawn metadata before hot-restart adoption'`
  - 3 test files passed
  - 3 targeted tests passed
- `git diff --check origin/master...HEAD`
- The full recovery test file also completed 219/220 tests; one unrelated existing retry-comment assertion failed, while all changed-path tests passed.

## Risks

- Low-to-moderate risk: spawn callbacks now participate in the pre-prompt critical path, so a persistence failure intentionally prevents the agent command from starting.
- ACP runtimes with no observable child continue without synthetic process metadata.
- No schema, migration, API, UI, workflow, or lockfile changes.

> This is a focused bug fix and does not overlap planned core feature work in `ROADMAP.md`.

## Model Used

- OpenAI Codex, exact runtime model ID `gpt-5.6-sol`, with reasoning, terminal tool use, code execution, and repository editing. The runtime did not expose authoritative context-window metadata.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change and contains no internal Paperclip ticket id
- [x] I have run targeted tests locally and the changed-path tests pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes (no documentation change is required for this internal correctness fix)
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
