### PR TITLE
fix(ui): prevent mobile selector keyboard occlusion

### DIFF
--- a/ui/src/adapters/schema-config-fields.test.tsx
+++ b/ui/src/adapters/schema-config-fields.test.tsx
@@ -1,0 +1,222 @@
+// @vitest-environment jsdom
+
+import { createRoot, type Root } from "react-dom/client";
+import { flushSync } from "react-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SchemaConfigFields } from "./schema-config-fields";
+import { defaultCreateValues } from "../components/agent-config-defaults";
+import { TooltipProvider } from "../components/ui/tooltip";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+async function act(callback: () => void | Promise<void>) {
+  let result: void | Promise<void> = undefined;
+  flushSync(() => {
+    result = callback();
+  });
+  await result;
+}
+
+async function flushReact() {
+  await act(async () => {
+    await Promise.resolve();
+    await new Promise((resolve) => window.setTimeout(resolve, 0));
+  });
+}
+
+function mockMatchMedia(isCoarsePointer: boolean) {
+  window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+    matches: query === "(pointer: coarse)" ? isCoarsePointer : false,
+    media: query,
+    onchange: null,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }));
+}
+
+function mockMutablePointerMedia(initialIsCoarsePointer: boolean) {
+  let isCoarsePointer = initialIsCoarsePointer;
+  let changeHandler: (() => void) | null = null;
+  window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+    get matches() {
+      return query === "(pointer: coarse)" ? isCoarsePointer : false;
+    },
+    media: query,
+    onchange: null,
+    addEventListener: vi.fn((_type: string, handler: () => void) => {
+      changeHandler = handler;
+    }),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }));
+
+  return {
+    setCoarsePointer(next: boolean) {
+      isCoarsePointer = next;
+      changeHandler?.();
+    },
+  };
+}
+
+
+function defaultMatchMedia(query: string): MediaQueryList {
+  return {
+    matches: false,
+    media: query,
+    onchange: null,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  } as unknown as MediaQueryList;
+}
+
+describe("SchemaConfigFields combobox", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let originalFetch: typeof globalThis.fetch;
+  let originalMatchMedia: typeof window.matchMedia;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    originalFetch = globalThis.fetch;
+    originalMatchMedia = window.matchMedia;
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({
+        fields: [
+          {
+            key: "model",
+            label: "Model",
+            type: "combobox",
+            hint: "Select a model",
+            options: [
+              { label: "GPT 5", value: "gpt-5" },
+              { label: "GPT 5 Mini", value: "gpt-5-mini" },
+            ],
+          },
+        ],
+      }),
+    } as Response);
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    document.body.replaceChildren();
+    globalThis.fetch = originalFetch;
+    window.matchMedia = originalMatchMedia ?? defaultMatchMedia;
+    vi.restoreAllMocks();
+  });
+
+  it("does not focus or raise the keyboard for model combobox input on coarse pointers", async () => {
+    mockMatchMedia(true);
+
+    await act(async () => {
+      root.render(
+        <TooltipProvider>
+          <SchemaConfigFields
+            adapterType="test-adapter"
+            isCreate
+            values={{ ...defaultCreateValues, adapterSchemaValues: { model: "gpt-5" } }}
+            set={vi.fn()}
+            config={{}}
+            eff={(_scope, _key, fallback) => fallback}
+            mark={vi.fn()}
+          />
+        </TooltipProvider>,
+      );
+    });
+    await flushReact();
+
+    const modelInput = container.querySelector('input[value="gpt-5"]') as HTMLInputElement | null;
+    expect(modelInput).not.toBeNull();
+    expect(modelInput?.readOnly).toBe(true);
+    expect(modelInput?.inputMode).toBe("none");
+    expect(modelInput?.autocomplete).toBe("off");
+    expect(modelInput?.getAttribute("autocorrect")).toBe("off");
+    expect(modelInput?.getAttribute("autocapitalize")).toBe("off");
+    expect(modelInput?.getAttribute("spellcheck")).toBe("false");
+    expect(modelInput?.className).toContain("paperclip-mobile-control-font-size");
+
+    await act(async () => {
+      modelInput?.focus();
+    });
+
+    expect(document.activeElement).not.toBe(modelInput);
+  });
+
+  it("keeps model combobox typeable on fine pointers", async () => {
+    mockMatchMedia(false);
+
+    await act(async () => {
+      root.render(
+        <TooltipProvider>
+          <SchemaConfigFields
+            adapterType="test-adapter"
+            isCreate
+            values={{ ...defaultCreateValues, adapterSchemaValues: { model: "gpt-5" } }}
+            set={vi.fn()}
+            config={{}}
+            eff={(_scope, _key, fallback) => fallback}
+            mark={vi.fn()}
+          />
+        </TooltipProvider>,
+      );
+    });
+    await flushReact();
+
+    const modelInput = container.querySelector('input[value="gpt-5"]') as HTMLInputElement | null;
+    expect(modelInput).not.toBeNull();
+    expect(modelInput?.readOnly).toBe(false);
+    expect(modelInput?.inputMode).toBe("");
+    expect(modelInput?.className).toContain("paperclip-mobile-control-font-size");
+  });
+
+  it("blurs a focused model combobox input when pointer mode becomes coarse", async () => {
+    const pointer = mockMutablePointerMedia(false);
+
+    await act(async () => {
+      root.render(
+        <TooltipProvider>
+          <SchemaConfigFields
+            adapterType="test-adapter"
+            isCreate
+            values={{ ...defaultCreateValues, adapterSchemaValues: { model: "gpt-5" } }}
+            set={vi.fn()}
+            config={{}}
+            eff={(_scope, _key, fallback) => fallback}
+            mark={vi.fn()}
+          />
+        </TooltipProvider>,
+      );
+    });
+    await flushReact();
+
+    const modelInput = container.querySelector('input[value="gpt-5"]') as HTMLInputElement | null;
+    expect(modelInput).not.toBeNull();
+
+    await act(async () => {
+      modelInput?.focus();
+    });
+    expect(document.activeElement).toBe(modelInput);
+
+    await act(async () => {
+      pointer.setCoarsePointer(true);
+    });
+
+    expect(document.activeElement).not.toBe(modelInput);
+    expect(modelInput?.readOnly).toBe(true);
+    expect(modelInput?.inputMode).toBe("none");
+  });
+});

--- a/ui/src/adapters/schema-config-fields.tsx
+++ b/ui/src/adapters/schema-config-fields.tsx
@@ -12,6 +12,7 @@ import {
 } from "../components/agent-config-primitives";
 import { Popover, PopoverContent, PopoverTrigger } from "../components/ui/popover";
 import { ChevronDown } from "lucide-react";
+import { useCoarsePointer } from "@/hooks/useCoarsePointer";
 
 // ── Select field (extracted to keep hooks at component top level) ──────
 function SelectField({
@@ -75,11 +76,18 @@ function ComboboxField({
   const [open, setOpen] = useState(false);
   const [filter, setFilter] = useState("");
   const inputRef = useRef<HTMLInputElement>(null);
+  const isCoarsePointer = useCoarsePointer();
 
   // Sync filter with external value when it changes (e.g. provider switch resets model)
   useEffect(() => {
     setFilter("");
   }, [value]);
+
+  useEffect(() => {
+    if (!open) return;
+    if (isCoarsePointer) inputRef.current?.blur();
+    else inputRef.current?.focus();
+  }, [isCoarsePointer, open]);
 
   const filtered = options.filter((opt) => {
     if (!filter) return true;
@@ -136,9 +144,15 @@ function ComboboxField({
         <input
           ref={inputRef}
           type="text"
-          className="flex-1 rounded-l-md border border-r-0 border-border px-2.5 py-1.5 bg-transparent outline-none text-sm font-mono placeholder:text-muted-foreground/40 focus:z-10"
+          className="paperclip-mobile-control-font-size flex-1 rounded-l-md border border-r-0 border-border px-2.5 py-1.5 bg-transparent outline-none text-sm font-mono placeholder:text-muted-foreground/40 focus:z-10"
           value={displayValue}
           placeholder={placeholder ?? "Type or select..."}
+          readOnly={isCoarsePointer}
+          inputMode={isCoarsePointer ? "none" : undefined}
+          autoComplete="off"
+          autoCorrect="off"
+          autoCapitalize="off"
+          spellCheck={false}
           onChange={(e) => {
             setFilter(e.target.value);
             if (!open) setOpen(true);
@@ -147,8 +161,10 @@ function ComboboxField({
             if (!open) setOpen(true);
           }}
           onBlur={() => {
-            // Delay close to allow click on option to register
-            setTimeout(() => setOpen(false), 150);
+            if (!isCoarsePointer) {
+              // Delay close to allow click on option to register
+              setTimeout(() => setOpen(false), 150);
+            }
           }}
           onKeyDown={handleKeyDown}
         />

--- a/ui/src/components/AgentConfigForm.render.test.tsx
+++ b/ui/src/components/AgentConfigForm.render.test.tsx
@@ -188,6 +188,23 @@ function setInputValue(input: HTMLInputElement, value: string) {
   input.dispatchEvent(new Event("input", { bubbles: true }));
 }
 
+function mockMatchMedia(isCoarsePointer: boolean) {
+  Object.defineProperty(window.navigator, "maxTouchPoints", {
+    configurable: true,
+    value: isCoarsePointer ? 5 : 0,
+  });
+  window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+    matches: query === "(pointer: coarse)" ? isCoarsePointer : query === "(hover: none)" ? isCoarsePointer : false,
+    media: query,
+    onchange: null,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }));
+}
+
 async function renderForm(
   environments: Environment[],
   agentOverrides: Partial<Agent> = {},
@@ -271,10 +288,28 @@ async function renderCreateForm(
   return { container, root, onChange };
 }
 
+
+function defaultMatchMedia(query: string): MediaQueryList {
+  return {
+    matches: false,
+    media: query,
+    onchange: null,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  } as unknown as MediaQueryList;
+}
+
 describe("AgentConfigForm environment selector", () => {
   let roots: Root[] = [];
+  let originalMatchMedia: typeof window.matchMedia;
+  let originalMaxTouchPoints: number;
 
   beforeEach(() => {
+    originalMatchMedia = window.matchMedia;
+    originalMaxTouchPoints = window.navigator.maxTouchPoints;
     mockAgentsApi.adapterModelProfiles.mockResolvedValue([]);
     mockAgentsApi.adapterModels.mockResolvedValue([]);
     mockAgentsApi.detectModel.mockResolvedValue(null);
@@ -299,7 +334,70 @@ describe("AgentConfigForm environment selector", () => {
     }
     roots = [];
     document.body.innerHTML = "";
+    window.matchMedia = originalMatchMedia ?? defaultMatchMedia;
+    Object.defineProperty(window.navigator, "maxTouchPoints", {
+      configurable: true,
+      value: originalMaxTouchPoints,
+    });
     vi.clearAllMocks();
+  });
+
+  it("does not focus or raise the keyboard for the model search input on coarse pointers", async () => {
+    mockMatchMedia(true);
+    const result = await renderForm([
+      makeEnvironment({ id: "local-1", name: "Local", driver: "local" }),
+    ], {
+      adapterConfig: { model: "gpt-5.4" },
+    });
+    roots.push(result.root);
+
+    const modelButton = Array.from(result.container.querySelectorAll("button")).find(
+      (button) => button.textContent?.trim() === "gpt-5.4",
+    );
+    expect(modelButton).toBeTruthy();
+
+    await act(async () => {
+      modelButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    await flushReact();
+
+    const searchInput = document.body.querySelector<HTMLInputElement>('input[placeholder="Search models... (type to create)"]');
+    expect(searchInput).toBeTruthy();
+    expect(searchInput?.readOnly).toBe(true);
+    expect(searchInput?.inputMode).toBe("none");
+    expect(searchInput?.autocomplete).toBe("off");
+    expect(searchInput?.getAttribute("autocorrect")).toBe("off");
+    expect(searchInput?.getAttribute("autocapitalize")).toBe("off");
+    expect(searchInput?.getAttribute("spellcheck")).toBe("false");
+    expect(searchInput?.className).toContain("paperclip-mobile-control-font-size");
+    expect(document.activeElement).not.toBe(searchInput);
+  });
+
+  it("keeps the model search input typeable and focused on fine pointers", async () => {
+    mockMatchMedia(false);
+    const result = await renderForm([
+      makeEnvironment({ id: "local-1", name: "Local", driver: "local" }),
+    ], {
+      adapterConfig: { model: "gpt-5.4" },
+    });
+    roots.push(result.root);
+
+    const modelButton = Array.from(result.container.querySelectorAll("button")).find(
+      (button) => button.textContent?.trim() === "gpt-5.4",
+    );
+    expect(modelButton).toBeTruthy();
+
+    await act(async () => {
+      modelButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    await flushReact();
+
+    const searchInput = document.body.querySelector<HTMLInputElement>('input[placeholder="Search models... (type to create)"]');
+    expect(searchInput).toBeTruthy();
+    expect(searchInput?.readOnly).toBe(false);
+    expect(searchInput?.inputMode).toBe("");
+    expect(searchInput?.className).toContain("paperclip-mobile-control-font-size");
+    expect(document.activeElement).toBe(searchInput);
   });
 
   it("hides the environment override when Local is the only configured environment", async () => {

--- a/ui/src/components/AgentConfigForm.tsx
+++ b/ui/src/components/AgentConfigForm.tsx
@@ -61,6 +61,7 @@ import { useDisabledAdaptersSync } from "../adapters/use-disabled-adapters";
 import { buildAgentUpdatePatch, omitUndefinedEntries, type AgentConfigOverlay } from "../lib/agent-config-patch";
 import { useAdapterCapabilities } from "../adapters/use-adapter-capabilities";
 import { resolveForcedKubernetesEnvironment } from "../lib/forced-kubernetes-environment";
+import { useCoarsePointer } from "@/hooks/useCoarsePointer";
 
 /* ---- Create mode values ---- */
 
@@ -1726,7 +1727,9 @@ export function ModelDropdown({
   defaultLabel?: string;
 }) {
   const [modelSearch, setModelSearch] = useState("");
+  const modelSearchInputRef = useRef<HTMLInputElement>(null);
   const [detectingModel, setDetectingModel] = useState(false);
+  const isCoarsePointer = useCoarsePointer();
   const selected = models.find((m) => m.id === value);
   const manualModel = modelSearch.trim();
   const canCreateManualModel = Boolean(
@@ -1781,6 +1784,12 @@ export function ModelDropdown({
       }));
   }, [filteredModels, groupByProvider]);
 
+  useEffect(() => {
+    if (!open) return;
+    if (isCoarsePointer) modelSearchInputRef.current?.blur();
+    else modelSearchInputRef.current?.focus();
+  }, [isCoarsePointer, open]);
+
   async function handleDetectModel() {
     if (!onDetectModel) return;
     setDetectingModel(true);
@@ -1816,14 +1825,27 @@ export function ModelDropdown({
             <ChevronDown className="h-3 w-3 text-muted-foreground" />
           </button>
         </PopoverTrigger>
-        <PopoverContent className="w-(--radix-popover-trigger-width) p-1" align="start">
+        <PopoverContent
+          className="w-(--radix-popover-trigger-width) p-1"
+          align="start"
+          onOpenAutoFocus={(event) => {
+            event.preventDefault();
+            if (!isCoarsePointer) modelSearchInputRef.current?.focus();
+          }}
+        >
           <div className="relative mb-1">
             <input
-              className="w-full px-2 py-1.5 pr-6 text-xs bg-transparent outline-none border-b border-border placeholder:text-muted-foreground/50"
+              ref={modelSearchInputRef}
+              className="paperclip-mobile-control-font-size w-full px-2 py-1.5 pr-6 text-xs bg-transparent outline-none border-b border-border placeholder:text-muted-foreground/50"
               placeholder={creatable ? "Search models... (type to create)" : "Search models..."}
               value={modelSearch}
+              readOnly={isCoarsePointer}
+              inputMode={isCoarsePointer ? "none" : undefined}
+              autoComplete="off"
+              autoCorrect="off"
+              autoCapitalize="off"
+              spellCheck={false}
               onChange={(e) => setModelSearch(e.target.value)}
-              autoFocus
             />
             {modelSearch && (
               <button

--- a/ui/src/components/InlineEntitySelector.test.tsx
+++ b/ui/src/components/InlineEntitySelector.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { createRoot } from "react-dom/client";
+import { createRoot, type Root } from "react-dom/client";
 import { flushSync } from "react-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { InlineEntitySelector } from "./InlineEntitySelector";
@@ -16,24 +16,56 @@ async function act(callback: () => void | Promise<void>) {
   await result;
 }
 
+
+function defaultMatchMedia(query: string): MediaQueryList {
+  return {
+    matches: false,
+    media: query,
+    onchange: null,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  } as unknown as MediaQueryList;
+}
+
 describe("InlineEntitySelector", () => {
   let container: HTMLDivElement;
+  let roots: Root[] = [];
   let originalMatchMedia: typeof window.matchMedia;
+  let originalMaxTouchPoints: number;
 
   beforeEach(() => {
     originalMatchMedia = window.matchMedia;
+    originalMaxTouchPoints = window.navigator.maxTouchPoints;
     container = document.createElement("div");
     document.body.appendChild(container);
   });
 
-  afterEach(() => {
-    window.matchMedia = originalMatchMedia;
-    container.remove();
-    document.body.innerHTML = "";
+  afterEach(async () => {
+    for (const root of roots) {
+      await act(async () => {
+        root.unmount();
+      });
+    }
+    roots = [];
+    window.matchMedia = originalMatchMedia ?? defaultMatchMedia;
+    Object.defineProperty(window.navigator, "maxTouchPoints", {
+      configurable: true,
+      value: originalMaxTouchPoints,
+    });
+    document.body.replaceChildren();
   });
 
-  it("keeps handled search navigation keys inside the popover", async () => {
+  function createTestRoot() {
     const root = createRoot(container);
+    roots.push(root);
+    return root;
+  }
+
+  it("keeps handled search navigation keys inside the popover", async () => {
+    const root = createTestRoot();
     const onChange = vi.fn();
     const documentKeyDown = vi.fn();
     document.addEventListener("keydown", documentKeyDown);
@@ -83,13 +115,9 @@ describe("InlineEntitySelector", () => {
     expect(documentKeyDown).not.toHaveBeenCalled();
     expect(onChange).toHaveBeenCalledWith("agent:agent-1");
 
-    document.removeEventListener("keydown", documentKeyDown);
-    act(() => {
-      root.unmount();
-    });
-  });
+    document.removeEventListener("keydown", documentKeyDown);  });
 
-  it("focuses the search input when opened on coarse pointers", async () => {
+  it("does not focus or raise the keyboard for search input on coarse pointers", async () => {
     window.matchMedia = vi.fn().mockImplementation((query: string) => ({
       matches: query === "(pointer: coarse)",
       media: query,
@@ -101,7 +129,7 @@ describe("InlineEntitySelector", () => {
       dispatchEvent: vi.fn(),
     }));
 
-    const root = createRoot(container);
+    const root = createTestRoot();
 
     act(() => {
       root.render(
@@ -129,10 +157,216 @@ describe("InlineEntitySelector", () => {
 
     const searchInput = document.querySelector('input[placeholder="Search responsible..."]') as HTMLInputElement | null;
     expect(searchInput).not.toBeNull();
-    expect(document.activeElement).toBe(searchInput);
+    expect(document.activeElement).not.toBe(searchInput);
+    expect(searchInput?.readOnly).toBe(true);
+    expect(searchInput?.inputMode).toBe("none");
+    expect(searchInput?.autocomplete).toBe("off");
+    expect(searchInput?.getAttribute("autocorrect")).toBe("off");
+    expect(searchInput?.getAttribute("autocapitalize")).toBe("off");
+    expect(searchInput?.getAttribute("spellcheck")).toBe("false");
+    expect(searchInput?.className).toContain("paperclip-mobile-control-font-size");
+  });
+
+  it("treats touch-only devices as coarse even when the pointer media query is false", async () => {
+    Object.defineProperty(window.navigator, "maxTouchPoints", {
+      configurable: true,
+      value: 5,
+    });
+    window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+      matches: query === "(hover: none)",
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }));
+
+    const root = createTestRoot();
 
     act(() => {
-      root.unmount();
+      root.render(
+        <InlineEntitySelector
+          value=""
+          options={[{ id: "agent:agent-1", label: "CodexCoder" }]}
+          placeholder="Responsible"
+          noneLabel="No responsible"
+          searchPlaceholder="Search responsible..."
+          emptyMessage="No responsible found."
+          onChange={vi.fn()}
+        />,
+      );
     });
+
+    const trigger = container.querySelector("button") as HTMLButtonElement | null;
+    await act(async () => {
+      trigger?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    const searchInput = document.querySelector('input[placeholder="Search responsible..."]') as HTMLInputElement | null;
+    expect(searchInput).not.toBeNull();
+    expect(searchInput?.readOnly).toBe(true);
+    expect(searchInput?.inputMode).toBe("none");
+    expect(document.activeElement).not.toBe(searchInput);
+  });
+
+  it("keeps desktop search typeable and focused", async () => {
+    Object.defineProperty(window.navigator, "maxTouchPoints", {
+      configurable: true,
+      value: 0,
+    });
+    window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }));
+
+    const root = createTestRoot();
+
+    act(() => {
+      root.render(
+        <InlineEntitySelector
+          value=""
+          options={[
+            { id: "agent:agent-1", label: "CodexCoder" },
+            { id: "agent:agent-2", label: "DesignBot" },
+          ]}
+          placeholder="Responsible"
+          noneLabel="No responsible"
+          searchPlaceholder="Search responsible..."
+          emptyMessage="No responsible found."
+          onChange={vi.fn()}
+        />,
+      );
+    });
+
+    const trigger = container.querySelector("button") as HTMLButtonElement | null;
+    await act(async () => {
+      trigger?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    const searchInput = document.querySelector('input[placeholder="Search responsible..."]') as HTMLInputElement | null;
+    expect(searchInput).not.toBeNull();
+    expect(document.activeElement).toBe(searchInput);
+    expect(searchInput?.readOnly).toBe(false);
+    expect(searchInput?.inputMode).toBe("");
+    expect(searchInput?.className).toContain("paperclip-mobile-control-font-size");
+  });
+
+  it("keeps search typeable on touchscreen laptops with hover-capable primary input", async () => {
+    Object.defineProperty(window.navigator, "maxTouchPoints", {
+      configurable: true,
+      value: 5,
+    });
+    window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+      matches: query === "(any-hover: hover)",
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }));
+
+    const root = createTestRoot();
+
+    act(() => {
+      root.render(
+        <InlineEntitySelector
+          value=""
+          options={[{ id: "agent:agent-1", label: "CodexCoder" }]}
+          placeholder="Responsible"
+          noneLabel="No responsible"
+          searchPlaceholder="Search responsible..."
+          emptyMessage="No responsible found."
+          onChange={vi.fn()}
+        />,
+      );
+    });
+
+    const trigger = container.querySelector("button") as HTMLButtonElement | null;
+    await act(async () => {
+      trigger?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    const searchInput = document.querySelector('input[placeholder="Search responsible..."]') as HTMLInputElement | null;
+    expect(searchInput).not.toBeNull();
+    expect(searchInput?.readOnly).toBe(false);
+    expect(searchInput?.inputMode).toBe("");
+    expect(document.activeElement).toBe(searchInput);
+  });
+
+  it("reconciles search focus when pointer mode changes while open", async () => {
+    let isCoarsePointer = false;
+    const changeHandlers = new Map<string, () => void>();
+    window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+      get matches() {
+        return query === "(pointer: coarse)" ? isCoarsePointer : false;
+      },
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn((_type: string, handler: () => void) => {
+        changeHandlers.set(query, handler);
+      }),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }));
+
+    const root = createTestRoot();
+
+    act(() => {
+      root.render(
+        <InlineEntitySelector
+          value=""
+          options={[
+            { id: "agent:agent-1", label: "CodexCoder" },
+            { id: "agent:agent-2", label: "DesignBot" },
+          ]}
+          placeholder="Responsible"
+          noneLabel="No responsible"
+          searchPlaceholder="Search responsible..."
+          emptyMessage="No responsible found."
+          onChange={vi.fn()}
+        />,
+      );
+    });
+
+    const trigger = container.querySelector("button") as HTMLButtonElement | null;
+    await act(async () => {
+      trigger?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    const searchInput = document.querySelector('input[placeholder="Search responsible..."]') as HTMLInputElement | null;
+    expect(searchInput).not.toBeNull();
+    expect(document.activeElement).toBe(searchInput);
+
+    await act(async () => {
+      isCoarsePointer = true;
+      changeHandlers.get("(pointer: coarse)")?.();
+    });
+
+    expect(document.activeElement).not.toBe(searchInput);
+    expect(searchInput?.readOnly).toBe(true);
+    expect(searchInput?.inputMode).toBe("none");
+
+    await act(async () => {
+      isCoarsePointer = false;
+      changeHandlers.get("(pointer: coarse)")?.();
+    });
+
+    expect(document.activeElement).toBe(searchInput);
+    expect(searchInput?.readOnly).toBe(false);
+    expect(searchInput?.inputMode).toBe("");
+    expect(changeHandlers.has("(hover: none)")).toBe(true);
+    expect(changeHandlers.has("(any-hover: hover)")).toBe(true);
   });
 });

--- a/ui/src/components/InlineEntitySelector.tsx
+++ b/ui/src/components/InlineEntitySelector.tsx
@@ -1,6 +1,7 @@
 import { forwardRef, useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { Check } from "lucide-react";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { useCoarsePointer } from "@/hooks/useCoarsePointer";
 import { orderItemsBySelectedAndRecent } from "../lib/recent-selections";
 import { cn } from "../lib/utils";
 
@@ -58,6 +59,7 @@ export const InlineEntitySelector = forwardRef<HTMLButtonElement, InlineEntitySe
     const inputRef = useRef<HTMLInputElement>(null);
     const shouldPreventCloseAutoFocusRef = useRef(false);
     const isPointerDownRef = useRef(false);
+    const isCoarsePointer = useCoarsePointer();
 
     const allOptions = useMemo<InlineEntityOption[]>(() => {
       const baseOptions = [{ id: "", label: noneLabel, searchText: noneLabel }, ...options];
@@ -86,6 +88,15 @@ export const InlineEntitySelector = forwardRef<HTMLButtonElement, InlineEntitySe
       const selectedIndex = filteredOptions.findIndex((option) => option.id === value);
       setHighlightedIndexValue(selectedIndex >= 0 ? selectedIndex : 0);
     }, [filteredOptions, open, setHighlightedIndexValue, value]);
+
+    useEffect(() => {
+      if (!open) return;
+      if (isCoarsePointer) {
+        inputRef.current?.blur();
+        return;
+      }
+      inputRef.current?.focus();
+    }, [isCoarsePointer, open]);
 
     const commitSelection = (index: number, moveNext: boolean) => {
       const option = filteredOptions[index] ?? filteredOptions[0];
@@ -135,7 +146,7 @@ export const InlineEntitySelector = forwardRef<HTMLButtonElement, InlineEntitySe
           disablePortal={disablePortal}
           onOpenAutoFocus={(event) => {
             event.preventDefault();
-            inputRef.current?.focus();
+            if (!isCoarsePointer) inputRef.current?.focus();
           }}
           onCloseAutoFocus={(event) => {
             if (!shouldPreventCloseAutoFocusRef.current) return;
@@ -145,9 +156,15 @@ export const InlineEntitySelector = forwardRef<HTMLButtonElement, InlineEntitySe
         >
           <input
             ref={inputRef}
-            className="w-full border-b border-border bg-transparent px-2 py-1.5 text-sm outline-none placeholder:text-muted-foreground/60"
+            className="paperclip-mobile-control-font-size w-full border-b border-border bg-transparent px-2 py-1.5 text-sm outline-none placeholder:text-muted-foreground/60"
             placeholder={searchPlaceholder}
             value={query}
+            readOnly={isCoarsePointer}
+            inputMode={isCoarsePointer ? "none" : undefined}
+            autoComplete="off"
+            autoCorrect="off"
+            autoCapitalize="off"
+            spellCheck={false}
             onChange={(event) => {
               setQuery(event.target.value);
             }}

--- a/ui/src/hooks/useCoarsePointer.ts
+++ b/ui/src/hooks/useCoarsePointer.ts
@@ -1,0 +1,45 @@
+import { useEffect, useState } from "react";
+
+function getMediaQuery(query: string): MediaQueryList | null {
+  if (typeof window === "undefined" || typeof window.matchMedia !== "function") return null;
+  return window.matchMedia(query);
+}
+
+function isTouchOnlyPointer(): boolean {
+  const hoverNoneQuery = getMediaQuery("(hover: none)");
+  const anyHoverQuery = getMediaQuery("(any-hover: hover)");
+  return (
+    typeof navigator !== "undefined"
+    && navigator.maxTouchPoints > 0
+    && hoverNoneQuery?.matches === true
+    && anyHoverQuery?.matches !== true
+  );
+}
+
+function currentCoarsePointer(pointerQuery?: MediaQueryList | null): boolean {
+  return (pointerQuery ?? getMediaQuery("(pointer: coarse)"))?.matches === true || isTouchOnlyPointer();
+}
+
+export function useCoarsePointer(): boolean {
+  const [isCoarsePointer, setIsCoarsePointer] = useState(() => currentCoarsePointer());
+
+  useEffect(() => {
+    const pointerQuery = getMediaQuery("(pointer: coarse)");
+    const hoverNoneQuery = getMediaQuery("(hover: none)");
+    const anyHoverQuery = getMediaQuery("(any-hover: hover)");
+    if (!pointerQuery && !hoverNoneQuery && !anyHoverQuery) return;
+
+    const update = () => setIsCoarsePointer(currentCoarsePointer(pointerQuery));
+    update();
+    pointerQuery?.addEventListener("change", update);
+    hoverNoneQuery?.addEventListener("change", update);
+    anyHoverQuery?.addEventListener("change", update);
+    return () => {
+      pointerQuery?.removeEventListener("change", update);
+      hoverNoneQuery?.removeEventListener("change", update);
+      anyHoverQuery?.removeEventListener("change", update);
+    };
+  }, []);
+
+  return isCoarsePointer;
+}

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -282,6 +282,8 @@
   html {
     height: 100%;
     -webkit-tap-highlight-color: color-mix(in oklab, var(--foreground) 20%, transparent);
+    -webkit-text-size-adjust: 100%;
+    text-size-adjust: 100%;
     @apply font-sans;
   }
   body {
@@ -313,6 +315,19 @@
 }
 
 @media (pointer: coarse) {
+  html {
+    overflow-x: hidden;
+    overscroll-behavior-x: none;
+  }
+
+  body {
+    max-width: 100vw;
+  }
+
+  .paperclip-mobile-control-font-size {
+    font-size: max(var(--paperclip-mobile-control-font-size, 16px), 1em);
+  }
+
   button,
   [role="button"],
   input,


### PR DESCRIPTION
## Thinking Path

> - Paperclip’s mobile UI already uses a responsive viewport, but iOS Safari can still zoom/focus awkwardly when form controls are below Safari’s 16px focus threshold or when searchable dropdown inputs receive focus.
> - The two affected surfaces are core UI surfaces: the issue/comment composer assignee selector and the agent configuration model combobox.
> - Fixing this in core UI is preferable to a plugin workaround because the behavior belongs with the selector/combobox implementations themselves.
> - The change keeps desktop/fine-pointer search behavior intact while preventing coarse-pointer selector search inputs from raising the virtual keyboard over the option list.
> - Global mobile CSS adds viewport containment and 16px minimum control text on coarse pointers without disabling user zoom.

## Linked Issues or Issue Description

No public issue found for this exact mobile selector behavior.

Bug-style description:

- **Problem:** On mobile Safari, issue/detail pages can drift horizontally, and opening searchable selectors can focus the hidden/search input so the virtual keyboard covers the dropdown.
- **Expected behavior:** Mobile users should be able to open issue assignee selectors and agent config model selectors without the page zooming or the keyboard obscuring the option list.
- **Actual behavior:** Small form-control text and focused search inputs can trigger iOS focus zoom / keyboard occlusion.
- **Scope:** Core UI fix for mobile viewport containment and selector/combobox focus behavior; no plugin package or runtime injection.

Related mobile UI PRs found during duplicate search but not exact duplicates: #9606, #9467, #9399, #4055, #3495, #2872, #2216, #2128.

## What Changed

- Added a shared `useCoarsePointer` hook for `(pointer: coarse)` detection.
- Updated `InlineEntitySelector` so coarse-pointer popovers do not autofocus the search input and mark that input `readonly`/`inputMode="none"`, while desktop keeps focused type-to-filter behavior.
- Updated adapter schema comboboxes, including agent model selection, with the same coarse-pointer keyboard suppression while preserving desktop filtering.
- Added focus reconciliation when pointer mode changes while a selector is open.
- Added mobile CSS to contain horizontal viewport drift and keep mobile form controls/select triggers at a 16px minimum font size without disabling user zoom.
- Added tests for issue-style inline entity selectors and schema combobox behavior on coarse and fine pointers.

## Verification

- `npx --yes pnpm@9.15.4 install` locally, with `pnpm-lock.yaml` excluded from the commit per project policy
- `npx --yes pnpm@9.15.4 --filter @paperclipai/ui test -- InlineEntitySelector.test.tsx schema-config-fields.test.tsx`
- `npx --yes pnpm@9.15.4 --filter @paperclipai/ui typecheck`
- `npx --yes pnpm@9.15.4 --filter @paperclipai/ui build`
- `coderabbit review --agent -t uncommitted` — findings: 0 after fixes

## Risks

- On coarse pointers, searchable selector inputs are no longer typeable while the dropdown is open; users select from the visible list instead. Desktop/fine-pointer type-to-filter remains unchanged.
- The global 16px coarse-pointer CSS may slightly increase text size in dense mobile controls, but avoids iOS focus zoom without disabling browser/user zoom.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI GPT-5.5 via OpenRouter with tool use and code execution; CodeRabbit CLI review was also used for local review feedback.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge


## Greptile Follow-up Evidence

Addressed Greptile's 4/5 follow-up items:

- Removed the dead coarse-pointer branch in the schema combobox `onFocus` handler.
- Scoped horizontal viewport containment to `@media (pointer: coarse)` so desktop overflow behavior is unaffected.
- Replaced the broad `!important` mobile font-size override with opt-in `.paperclip-mobile-control-font-size` on the affected selector inputs.
- Added coverage for the real rendered agent model picker in `AgentConfigForm`, after mobile evidence showed that path was separate from the schema combobox.

Mobile visual/DOM evidence from iPhone-sized Playwright capture of the agent configuration model selector:

```json
{
  "maxTouchPoints": 5,
  "activeElement": { "tag": "BUTTON" },
  "popoverOpen": true,
  "bodyScrollWidth": 390,
  "viewportWidth": 390
}
```

This verifies the model selector popover opens while focus remains on the trigger button instead of the search input, avoiding the iOS keyboard overlay. Local before capture showed the search input focused at 14px; after capture shows the fixed trigger-focused state.


