### PR TITLE
Draft - pending human review before merge

### DIFF
--- a/server/src/__tests__/authorization-service.test.ts
+++ b/server/src/__tests__/authorization-service.test.ts
@@ -1219,6 +1219,129 @@ describeEmbeddedPostgres("authorization service", () => {
     })).resolves.toMatchObject({ allowed: false, reason: "deny_low_trust_boundary" });
   });
 
+  it("allows same-company QA agents to comment on CTO-owned issues without granting mutation", async () => {
+    const company = await createCompany(db, "QaReviewComment");
+    const ctoAgent = await createAgent(db, company.id, { role: "cto" });
+    const qaAgent = await createAgent(db, company.id, {
+      role: "qa",
+      permissions: {
+        trustPreset: LOW_TRUST_REVIEW_PRESET,
+        authorizationPolicy: {
+          trustBoundary: {
+            mode: LOW_TRUST_REVIEW_PRESET,
+            companyId: company.id,
+            projectIds: [randomUUID()],
+          },
+        },
+      },
+    });
+    const issue = await createIssue(db, company.id, {
+      title: "CTO-owned review target",
+      assigneeAgentId: ctoAgent.id,
+    });
+    const resource = {
+      type: "issue" as const,
+      companyId: company.id,
+      issueId: issue.id,
+      assigneeAgentId: ctoAgent.id,
+      status: issue.status,
+    };
+
+    await expect(authorizationService(db).decide({
+      actor: { type: "agent", agentId: qaAgent.id, companyId: company.id, source: "agent_key" },
+      action: "issue:comment",
+      resource,
+    })).resolves.toMatchObject({
+      allowed: true,
+      reason: "allow_same_company_review_comment",
+    });
+
+    await expect(authorizationService(db).decide({
+      actor: { type: "agent", agentId: qaAgent.id, companyId: company.id, source: "agent_key" },
+      action: "issue:mutate",
+      resource,
+    })).resolves.toMatchObject({
+      allowed: false,
+      reason: "deny_low_trust_boundary",
+    });
+  });
+
+  it("allows ProjectManager same-company grooming scope without granting broad issue mutation", async () => {
+    const company = await createCompany(db, "PmGrooming");
+    const ctoAgent = await createAgent(db, company.id, { role: "cto" });
+    const pmAgent = await createAgent(db, company.id, { role: "ProjectManager" });
+    const issue = await createIssue(db, company.id, {
+      title: "PM grooming target",
+      assigneeAgentId: ctoAgent.id,
+    });
+    const actor = { type: "agent" as const, agentId: pmAgent.id, companyId: company.id, source: "agent_key" as const };
+    const resource = {
+      type: "issue" as const,
+      companyId: company.id,
+      issueId: issue.id,
+      assigneeAgentId: ctoAgent.id,
+      status: issue.status,
+    };
+
+    await expect(authorizationService(db).decide({
+      actor,
+      action: "issue:mutate",
+      resource,
+      scope: { pmGrooming: true },
+    })).resolves.toMatchObject({
+      allowed: true,
+      reason: "allow_same_company_pm_grooming",
+    });
+
+    await expect(authorizationService(db).decide({
+      actor,
+      action: "issue:mutate",
+      resource,
+      scope: { pmGrooming: false },
+    })).resolves.toMatchObject({
+      allowed: false,
+      reason: "deny_missing_grant",
+    });
+  });
+
+  it("keeps QA and ProjectManager same-company carve-outs inside the company boundary", async () => {
+    const company = await createCompany(db, "RoleBoundary");
+    const otherCompany = await createCompany(db, "RoleBoundaryOther");
+    const qaAgent = await createAgent(db, company.id, { role: "qa" });
+    const pmAgent = await createAgent(db, company.id, { role: "project_manager" });
+    const ownerAgent = await createAgent(db, otherCompany.id, { role: "founding_engineer" });
+    const issue = await createIssue(db, otherCompany.id, {
+      title: "Other company issue",
+      assigneeAgentId: ownerAgent.id,
+    });
+    const resource = {
+      type: "issue" as const,
+      companyId: otherCompany.id,
+      issueId: issue.id,
+      assigneeAgentId: ownerAgent.id,
+      status: issue.status,
+    };
+
+    await expect(authorizationService(db).decide({
+      actor: { type: "agent", agentId: qaAgent.id, companyId: company.id, source: "agent_key" },
+      action: "issue:comment",
+      resource,
+    })).resolves.toMatchObject({
+      allowed: false,
+      reason: "deny_company_boundary",
+    });
+
+    await expect(authorizationService(db).decide({
+      actor: { type: "agent", agentId: pmAgent.id, companyId: company.id, source: "agent_key" },
+      action: "issue:mutate",
+      resource,
+      scope: { pmGrooming: true },
+    })).resolves.toMatchObject({
+      allowed: false,
+      reason: "deny_company_boundary",
+    });
+  });
+
   it("allows a mentioned non-assignee to comment when the mention author is the issue assignee", async () => {
     const company = await createCompany(db, "MentionCommentAssigneeGrant");
     const allowedProject = await createProject(db, company.id, "MentionAssigneeAllowed");

--- a/server/src/__tests__/authorization-service.test.ts
+++ b/server/src/__tests__/authorization-service.test.ts
@@ -1334,6 +1334,33 @@ describeEmbeddedPostgres("authorization service", () => {
     });
   });
 
+  it("does not grant ProjectManager peer comments through the grooming carve-out", async () => {
+    const company = await createCompany(db, "PmGroomingComment");
+    const ctoAgent = await createAgent(db, company.id, { role: "cto" });
+    const pmAgent = await createAgent(db, company.id, { role: "ProjectManager" });
+    const issue = await createIssue(db, company.id, {
+      title: "PM grooming comment target",
+      assigneeAgentId: ctoAgent.id,
+    });
+    const actor = { type: "agent" as const, agentId: pmAgent.id, companyId: company.id, source: "agent_key" as const };
+    const resource = {
+      type: "issue" as const,
+      companyId: company.id,
+      issueId: issue.id,
+      assigneeAgentId: ctoAgent.id,
+      status: issue.status,
+    };
+
+    await expect(authorizationService(db).decide({
+      actor,
+      action: "issue:comment",
+      resource,
+    })).resolves.toMatchObject({
+      allowed: false,
+      reason: "deny_missing_grant",
+    });
+  });
+
   it("keeps QA and ProjectManager same-company carve-outs inside the company boundary", async () => {
     const company = await createCompany(db, "RoleBoundary");
     const otherCompany = await createCompany(db, "RoleBoundaryOther");

--- a/server/src/__tests__/authorization-service.test.ts
+++ b/server/src/__tests__/authorization-service.test.ts
@@ -1219,22 +1219,10 @@ describeEmbeddedPostgres("authorization service", () => {
     })).resolves.toMatchObject({ allowed: false, reason: "deny_low_trust_boundary" });
   });
 
-  it("allows same-company QA agents to comment on CTO-owned issues without granting mutation", async () => {
+  it("allows same-company standard QA agents to comment on CTO-owned issues without granting mutation", async () => {
     const company = await createCompany(db, "QaReviewComment");
     const ctoAgent = await createAgent(db, company.id, { role: "cto" });
-    const qaAgent = await createAgent(db, company.id, {
-      role: "qa",
-      permissions: {
-        trustPreset: LOW_TRUST_REVIEW_PRESET,
-        authorizationPolicy: {
-          trustBoundary: {
-            mode: LOW_TRUST_REVIEW_PRESET,
-            companyId: company.id,
-            projectIds: [randomUUID()],
-          },
-        },
-      },
-    });
+    const qaAgent = await createAgent(db, company.id, { role: "qa" });
     const issue = await createIssue(db, company.id, {
       title: "CTO-owned review target",
       assigneeAgentId: ctoAgent.id,
@@ -1259,6 +1247,48 @@ describeEmbeddedPostgres("authorization service", () => {
     await expect(authorizationService(db).decide({
       actor: { type: "agent", agentId: qaAgent.id, companyId: company.id, source: "agent_key" },
       action: "issue:mutate",
+      resource,
+    })).resolves.toMatchObject({
+      allowed: false,
+      reason: "deny_missing_grant",
+    });
+  });
+
+  it("keeps low-trust QA review comments inside the configured project boundary", async () => {
+    const company = await createCompany(db, "QaLowTrustReviewBoundary");
+    const allowedProject = await createProject(db, company.id, "QaAllowedProject");
+    const targetProject = await createProject(db, company.id, "QaTargetProject");
+    const ctoAgent = await createAgent(db, company.id, { role: "cto" });
+    const qaAgent = await createAgent(db, company.id, {
+      role: "qa",
+      permissions: {
+        trustPreset: LOW_TRUST_REVIEW_PRESET,
+        authorizationPolicy: {
+          trustBoundary: {
+            mode: LOW_TRUST_REVIEW_PRESET,
+            companyId: company.id,
+            projectIds: [allowedProject.id],
+          },
+        },
+      },
+    });
+    const issue = await createIssue(db, company.id, {
+      title: "Out-of-project CTO-owned review target",
+      projectId: targetProject.id,
+      assigneeAgentId: ctoAgent.id,
+    });
+    const resource = {
+      type: "issue" as const,
+      companyId: company.id,
+      issueId: issue.id,
+      projectId: issue.projectId,
+      assigneeAgentId: ctoAgent.id,
+      status: issue.status,
+    };
+
+    await expect(authorizationService(db).decide({
+      actor: { type: "agent", agentId: qaAgent.id, companyId: company.id, source: "agent_key" },
+      action: "issue:comment",
       resource,
     })).resolves.toMatchObject({
       allowed: false,

--- a/server/src/__tests__/authorization-service.test.ts
+++ b/server/src/__tests__/authorization-service.test.ts
@@ -1357,7 +1357,7 @@ describeEmbeddedPostgres("authorization service", () => {
       resource,
     })).resolves.toMatchObject({
       allowed: true,
-      reason: "allow_same_company_pm_grooming",
+      reason: "allow_same_company_pm_comment",
     });
 
     for (const status of ["done", "cancelled"] as const) {

--- a/server/src/__tests__/authorization-service.test.ts
+++ b/server/src/__tests__/authorization-service.test.ts
@@ -1334,7 +1334,7 @@ describeEmbeddedPostgres("authorization service", () => {
     });
   });
 
-  it("does not grant ProjectManager peer comments through the grooming carve-out", async () => {
+  it("allows ProjectManager same-company comments on peer-owned non-terminal issues only", async () => {
     const company = await createCompany(db, "PmGroomingComment");
     const ctoAgent = await createAgent(db, company.id, { role: "cto" });
     const pmAgent = await createAgent(db, company.id, { role: "ProjectManager" });
@@ -1356,9 +1356,20 @@ describeEmbeddedPostgres("authorization service", () => {
       action: "issue:comment",
       resource,
     })).resolves.toMatchObject({
-      allowed: false,
-      reason: "deny_missing_grant",
+      allowed: true,
+      reason: "allow_same_company_pm_grooming",
     });
+
+    for (const status of ["done", "cancelled"] as const) {
+      await expect(authorizationService(db).decide({
+        actor,
+        action: "issue:comment",
+        resource: { ...resource, status },
+      })).resolves.toMatchObject({
+        allowed: false,
+        reason: "deny_missing_grant",
+      });
+    }
   });
 
   it("keeps QA and ProjectManager same-company carve-outs inside the company boundary", async () => {

--- a/server/src/__tests__/heartbeat-retry-scheduling.test.ts
+++ b/server/src/__tests__/heartbeat-retry-scheduling.test.ts
@@ -127,7 +127,15 @@ describeEmbeddedPostgres("heartbeat bounded retry scheduling", () => {
     await db.delete(executionWorkspaces);
     await db.delete(projects);
     await cleanupHeartbeatRunDependents();
-    await db.delete(heartbeatRuns);
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      await cleanupHeartbeatRunDependents();
+      try {
+        await db.delete(heartbeatRuns);
+        break;
+      } catch (err) {
+        if (attempt === 2) throw err;
+      }
+    }
     await db.delete(agentWakeupRequests);
     await db.delete(agentRuntimeState);
     await db.delete(budgetPolicies);

--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -988,6 +988,41 @@ describe("agent issue mutation checkout ownership", () => {
     }));
   });
 
+  it.each(["done", "cancelled"] as const)(
+    "keeps ProjectManager grooming patches from reopening another agent's %s issue",
+    async (status) => {
+      mockIssueService.getById.mockResolvedValue(makeIssue({ status, assigneeAgentId: ownerAgentId }));
+      mockAccessService.decide.mockImplementation(async (input: { action: string; scope?: Record<string, unknown> }) => ({
+        allowed: input.action === "issue:mutate" && input.scope?.pmGrooming === true,
+        action: input.action,
+        reason:
+          input.action === "issue:mutate" && input.scope?.pmGrooming === true
+            ? "allow_same_company_pm_grooming"
+            : "deny_missing_grant",
+        explanation:
+          input.action === "issue:mutate" && input.scope?.pmGrooming === true
+            ? "Allowed for same-company ProjectManager delivery grooming."
+            : "Missing permission.",
+      }));
+
+      const res = await request(await createApp(peerActor()))
+        .patch(`/api/issues/${issueId}`)
+        .send({
+          comment: "Reopen after grooming.",
+          status: "todo",
+        });
+
+      expect(res.status, JSON.stringify(res.body)).toBe(403);
+      expect(res.body.error).toBe("Agent cannot mutate another agent's issue");
+      expect(mockIssueService.assertCheckoutOwner).not.toHaveBeenCalled();
+      expect(mockIssueService.update).not.toHaveBeenCalled();
+      expect(mockAccessService.decide).toHaveBeenCalledWith(expect.objectContaining({
+        action: "issue:mutate",
+        scope: expect.objectContaining({ pmGrooming: true }),
+      }));
+    },
+  );
+
   it("does not treat assignee changes as ProjectManager grooming patches", async () => {
     mockIssueService.getById.mockResolvedValue(makeIssue({ status: "todo", assigneeAgentId: ownerAgentId }));
     mockAccessService.decide.mockImplementation(async (input: { action: string; scope?: Record<string, unknown> }) => ({

--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -916,6 +916,71 @@ describe("agent issue mutation checkout ownership", () => {
     expect(mockIssueService.update).not.toHaveBeenCalled();
   });
 
+  it("allows ProjectManager-scoped grooming patches on another same-company agent's issue", async () => {
+    mockIssueService.getById.mockResolvedValue(makeIssue({ status: "todo", assigneeAgentId: ownerAgentId }));
+    mockAccessService.decide.mockImplementation(async (input: { action: string; scope?: Record<string, unknown> }) => ({
+      allowed: input.action === "issue:mutate" && input.scope?.pmGrooming === true,
+      action: input.action,
+      reason:
+        input.action === "issue:mutate" && input.scope?.pmGrooming === true
+          ? "allow_same_company_pm_grooming"
+          : "deny_missing_grant",
+      explanation:
+        input.action === "issue:mutate" && input.scope?.pmGrooming === true
+          ? "Allowed for same-company ProjectManager delivery grooming."
+          : "Missing permission.",
+    }));
+
+    const res = await request(await createApp(peerActor()))
+      .patch(`/api/issues/${issueId}`)
+      .send({
+        comment: "Grooming dependency state.",
+        status: "blocked",
+        priority: "high",
+        blockedByIssueIds: ["88888888-8888-4888-8888-888888888888"],
+      });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(mockIssueService.assertCheckoutOwner).not.toHaveBeenCalled();
+    expect(mockIssueService.update).toHaveBeenCalledWith(
+      issueId,
+      expect.objectContaining({
+        status: "blocked",
+        priority: "high",
+        blockedByIssueIds: ["88888888-8888-4888-8888-888888888888"],
+      }),
+    );
+    expect(mockAccessService.decide).toHaveBeenCalledWith(expect.objectContaining({
+      action: "issue:mutate",
+      scope: expect.objectContaining({ pmGrooming: true }),
+    }));
+  });
+
+  it("does not treat assignee changes as ProjectManager grooming patches", async () => {
+    mockIssueService.getById.mockResolvedValue(makeIssue({ status: "todo", assigneeAgentId: ownerAgentId }));
+    mockAccessService.decide.mockImplementation(async (input: { action: string; scope?: Record<string, unknown> }) => ({
+      allowed: input.action === "issue:mutate",
+      action: input.action,
+      reason:
+        input.action === "issue:mutate" && input.scope?.pmGrooming === true
+          ? "allow_same_company_pm_grooming"
+          : "allow_explicit_grant",
+      explanation: "Allowed by test boundary default.",
+    }));
+
+    const res = await request(await createApp(peerActor()))
+      .patch(`/api/issues/${issueId}`)
+      .send({ assigneeAgentId: peerAgentId });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(403);
+    expect(res.body.error).toBe("Agent cannot mutate another agent's issue");
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+    expect(mockAccessService.decide).toHaveBeenCalledWith(expect.objectContaining({
+      action: "issue:mutate",
+      scope: expect.objectContaining({ pmGrooming: false }),
+    }));
+  });
+
   it("denies cross-company agents before comment authorization is evaluated", async () => {
     const res = await request(await createApp(peerActor({ companyId: "99999999-9999-4999-8999-999999999999" })))
       .post(`/api/issues/${issueId}/comments`)

--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -1009,10 +1009,10 @@ describe("agent issue mutation checkout ownership", () => {
     mockAccessService.decide.mockImplementation(async (input: { action: string }) => ({
       allowed: input.action === "issue:comment",
       action: input.action,
-      reason: input.action === "issue:comment" ? "allow_same_company_pm_grooming" : "deny_missing_grant",
+      reason: input.action === "issue:comment" ? "allow_same_company_pm_comment" : "deny_missing_grant",
       explanation:
         input.action === "issue:comment"
-          ? "Allowed for same-company ProjectManager delivery grooming."
+          ? "Allowed for same-company ProjectManager delivery grooming comments."
           : "Missing permission.",
     }));
 
@@ -1042,7 +1042,9 @@ describe("agent issue mutation checkout ownership", () => {
         action: input.action,
         reason:
           input.action === "issue:comment" || (input.action === "issue:mutate" && input.scope?.pmGrooming === true)
-            ? "allow_same_company_pm_grooming"
+            ? input.action === "issue:comment"
+              ? "allow_same_company_pm_comment"
+              : "allow_same_company_pm_grooming"
             : "deny_missing_grant",
         explanation:
           input.action === "issue:comment" || (input.action === "issue:mutate" && input.scope?.pmGrooming === true)
@@ -1083,8 +1085,10 @@ describe("agent issue mutation checkout ownership", () => {
     const res = await request(await createApp(peerActor()))
       .patch(`/api/issues/${issueId}`)
       .send({
-        comment: "Closing after grooming.",
-        status: "done",
+        comment: "Grooming dependency state.",
+        status: "blocked",
+        priority: "high",
+        blockedByIssueIds: ["88888888-8888-4888-8888-888888888888"],
       });
 
     expect(res.status, JSON.stringify(res.body)).toBe(409);
@@ -1094,6 +1098,66 @@ describe("agent issue mutation checkout ownership", () => {
     expect(mockAccessService.decide).toHaveBeenCalledWith(expect.objectContaining({
       action: "issue:mutate",
       scope: expect.objectContaining({ pmGrooming: true }),
+    }));
+  });
+
+  it("does not treat status done as a ProjectManager grooming patch", async () => {
+    mockIssueService.getById.mockResolvedValue(makeIssue({ status: "todo", assigneeAgentId: ownerAgentId }));
+    mockAccessService.decide.mockImplementation(async (input: { action: string; scope?: Record<string, unknown> }) => ({
+      allowed: input.action === "issue:mutate" && input.scope?.pmGrooming === true,
+      action: input.action,
+      reason:
+        input.action === "issue:mutate" && input.scope?.pmGrooming === true
+          ? "allow_same_company_pm_grooming"
+          : "deny_missing_grant",
+      explanation:
+        input.action === "issue:mutate" && input.scope?.pmGrooming === true
+          ? "Allowed for same-company ProjectManager delivery grooming."
+          : "Missing permission.",
+    }));
+
+    const res = await request(await createApp(peerActor()))
+      .patch(`/api/issues/${issueId}`)
+      .send({
+        comment: "Closing after grooming.",
+        status: "done",
+      });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(403);
+    expect(res.body.error).toBe("Issue is outside this actor's authorization boundary");
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+    expect(mockAccessService.decide).toHaveBeenCalledWith(expect.objectContaining({
+      action: "issue:mutate",
+      scope: expect.objectContaining({ pmGrooming: false }),
+    }));
+  });
+
+  it("does not treat JSON-body issue deletes as ProjectManager grooming", async () => {
+    mockIssueService.getById.mockResolvedValue(makeIssue({ status: "todo", assigneeAgentId: ownerAgentId }));
+    mockAccessService.decide.mockImplementation(async (input: { action: string; scope?: Record<string, unknown> }) => ({
+      allowed: input.action === "issue:mutate" && input.scope?.pmGrooming === true,
+      action: input.action,
+      reason:
+        input.action === "issue:mutate" && input.scope?.pmGrooming === true
+          ? "allow_same_company_pm_grooming"
+          : "deny_missing_grant",
+      explanation:
+        input.action === "issue:mutate" && input.scope?.pmGrooming === true
+          ? "Allowed for same-company ProjectManager delivery grooming."
+          : "Missing permission.",
+    }));
+
+    const res = await request(await createApp(peerActor()))
+      .delete(`/api/issues/${issueId}`)
+      .set("Content-Type", "application/json")
+      .send({});
+
+    expect(res.status, JSON.stringify(res.body)).toBe(403);
+    expect(res.body.error).toBe("Issue is outside this actor's authorization boundary");
+    expect(mockIssueService.remove).not.toHaveBeenCalled();
+    expect(mockAccessService.decide).toHaveBeenCalledWith(expect.objectContaining({
+      action: "issue:mutate",
+      scope: expect.objectContaining({ pmGrooming: false }),
     }));
   });
 

--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -792,6 +792,54 @@ describe("agent issue mutation checkout ownership", () => {
     expect(mockIssueService.update).not.toHaveBeenCalled();
   });
 
+  it("allows same-company QA review comments on another agent's actively checked-out issue", async () => {
+    mockIssueService.getById.mockResolvedValue(makeIssue({ status: "in_progress", assigneeAgentId: ownerAgentId }));
+    mockAccessService.decide.mockImplementation(async (input: { action: string }) => ({
+      allowed: input.action === "issue:comment",
+      action: input.action,
+      reason: input.action === "issue:comment" ? "allow_same_company_review_comment" : "deny_missing_grant",
+      explanation:
+        input.action === "issue:comment"
+          ? "Allowed for same-company QA review evidence comments."
+          : "Missing permission.",
+    }));
+
+    const res = await request(await createApp(peerActor()))
+      .post(`/api/issues/${issueId}/comments`)
+      .send({ body: "QA review evidence: verified on the current build." });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(201);
+    expect(mockIssueService.assertCheckoutOwner).not.toHaveBeenCalled();
+    expect(mockIssueService.addComment).toHaveBeenCalledWith(
+      issueId,
+      "QA review evidence: verified on the current build.",
+      expect.any(Object),
+      expect.any(Object),
+    );
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+  });
+
+  it("does not let a same-company QA review comment grant issue mutation", async () => {
+    mockIssueService.getById.mockResolvedValue(makeIssue({ status: "todo", assigneeAgentId: ownerAgentId }));
+    mockAccessService.decide.mockImplementation(async (input: { action: string }) => ({
+      allowed: input.action === "issue:comment",
+      action: input.action,
+      reason: input.action === "issue:comment" ? "allow_same_company_review_comment" : "deny_missing_grant",
+      explanation:
+        input.action === "issue:comment"
+          ? "Allowed for same-company QA review evidence comments."
+          : "Missing permission.",
+    }));
+
+    const res = await request(await createApp(peerActor()))
+      .patch(`/api/issues/${issueId}`)
+      .send({ status: "done", comment: "QA closing this out." });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(403);
+    expect(res.body.error).toBe("Issue is outside this actor's authorization boundary");
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+  });
+
   it("rejects non-mentioned peer agents from posting comments", async () => {
     mockAccessService.decide.mockImplementation(async (input: { action: string }) => ({
       allowed: input.action === "issue:read",
@@ -955,6 +1003,67 @@ describe("agent issue mutation checkout ownership", () => {
       scope: expect.objectContaining({ pmGrooming: true }),
     }));
   });
+
+  it("allows ProjectManager same-company comments on another agent's non-terminal issue", async () => {
+    mockIssueService.getById.mockResolvedValue(makeIssue({ status: "in_progress", assigneeAgentId: ownerAgentId }));
+    mockAccessService.decide.mockImplementation(async (input: { action: string }) => ({
+      allowed: input.action === "issue:comment",
+      action: input.action,
+      reason: input.action === "issue:comment" ? "allow_same_company_pm_grooming" : "deny_missing_grant",
+      explanation:
+        input.action === "issue:comment"
+          ? "Allowed for same-company ProjectManager delivery grooming."
+          : "Missing permission.",
+    }));
+
+    const res = await request(await createApp(peerActor()))
+      .post(`/api/issues/${issueId}/comments`)
+      .send({ body: "Grooming context for the active owner." });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(201);
+    expect(mockIssueService.addComment).toHaveBeenCalledWith(
+      issueId,
+      "Grooming context for the active owner.",
+      expect.objectContaining({ agentId: peerAgentId }),
+      expect.objectContaining({ authorType: "agent" }),
+    );
+    expect(mockAccessService.decide).toHaveBeenCalledWith(expect.objectContaining({ action: "issue:comment" }));
+    expect(mockAccessService.decide).not.toHaveBeenCalledWith(expect.objectContaining({ action: "issue:mutate" }));
+  });
+
+  it.each(["done", "cancelled"] as const)(
+    "keeps ProjectManager same-company comments from reopening another agent's %s issue",
+    async (status) => {
+      mockIssueService.getById.mockResolvedValue(makeIssue({ status, assigneeAgentId: ownerAgentId }));
+      mockAccessService.decide.mockImplementation(async (input: { action: string; scope?: Record<string, unknown> }) => ({
+        allowed:
+          input.action === "issue:comment" ||
+          (input.action === "issue:mutate" && input.scope?.pmGrooming === true),
+        action: input.action,
+        reason:
+          input.action === "issue:comment" || (input.action === "issue:mutate" && input.scope?.pmGrooming === true)
+            ? "allow_same_company_pm_grooming"
+            : "deny_missing_grant",
+        explanation:
+          input.action === "issue:comment" || (input.action === "issue:mutate" && input.scope?.pmGrooming === true)
+            ? "Allowed for same-company ProjectManager delivery grooming."
+            : "Missing permission.",
+      }));
+
+      const res = await request(await createApp(peerActor()))
+        .post(`/api/issues/${issueId}/comments`)
+        .send({ body: "Terminal grooming context." });
+
+      expect(res.status, JSON.stringify(res.body)).toBe(403);
+      expect(res.body.error).toBe("Issue is in a terminal state and does not accept agent mutations");
+      expect(mockIssueService.addComment).not.toHaveBeenCalled();
+      expect(mockAccessService.decide).toHaveBeenCalledWith(expect.objectContaining({ action: "issue:comment" }));
+      expect(mockAccessService.decide).toHaveBeenCalledWith(expect.objectContaining({
+        action: "issue:mutate",
+        scope: expect.objectContaining({ pmGrooming: false }),
+      }));
+    },
+  );
 
   it("keeps ProjectManager grooming patches from mutating another agent's active checkout", async () => {
     mockIssueService.getById.mockResolvedValue(makeIssue({ status: "in_progress", assigneeAgentId: ownerAgentId }));

--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -956,6 +956,38 @@ describe("agent issue mutation checkout ownership", () => {
     }));
   });
 
+  it("keeps ProjectManager grooming patches from mutating another agent's active checkout", async () => {
+    mockIssueService.getById.mockResolvedValue(makeIssue({ status: "in_progress", assigneeAgentId: ownerAgentId }));
+    mockAccessService.decide.mockImplementation(async (input: { action: string; scope?: Record<string, unknown> }) => ({
+      allowed: input.action === "issue:mutate" && input.scope?.pmGrooming === true,
+      action: input.action,
+      reason:
+        input.action === "issue:mutate" && input.scope?.pmGrooming === true
+          ? "allow_same_company_pm_grooming"
+          : "deny_missing_grant",
+      explanation:
+        input.action === "issue:mutate" && input.scope?.pmGrooming === true
+          ? "Allowed for same-company ProjectManager delivery grooming."
+          : "Missing permission.",
+    }));
+
+    const res = await request(await createApp(peerActor()))
+      .patch(`/api/issues/${issueId}`)
+      .send({
+        comment: "Closing after grooming.",
+        status: "done",
+      });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(409);
+    expect(res.body.error).toBe("Issue is checked out by another agent");
+    expect(mockIssueService.assertCheckoutOwner).not.toHaveBeenCalled();
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+    expect(mockAccessService.decide).toHaveBeenCalledWith(expect.objectContaining({
+      action: "issue:mutate",
+      scope: expect.objectContaining({ pmGrooming: true }),
+    }));
+  });
+
   it("does not treat assignee changes as ProjectManager grooming patches", async () => {
     mockIssueService.getById.mockResolvedValue(makeIssue({ status: "todo", assigneeAgentId: ownerAgentId }));
     mockAccessService.decide.mockImplementation(async (input: { action: string; scope?: Record<string, unknown> }) => ({

--- a/server/src/__tests__/issue-comment-reopen-routes.test.ts
+++ b/server/src/__tests__/issue-comment-reopen-routes.test.ts
@@ -635,7 +635,10 @@ describe.sequential("issue comment reopen routes", () => {
         .send({ body: "Please continue this closed issue.", ...intent });
 
       expect(res.status, JSON.stringify(res.body)).toBe(403);
-      expect(res.body).toEqual({ error: "Issue is outside this actor's authorization boundary" });
+      expect(res.body).toEqual({
+        error: "Issue is in a terminal state and does not accept agent mutations",
+      });
+      expect(res.body.error).not.toBe("Issue is outside this actor's authorization boundary");
       expect(mockAccessService.decide).toHaveBeenCalledWith(expect.objectContaining({ action: "issue:comment" }));
       expect(mockAccessService.decide).toHaveBeenCalledWith(expect.objectContaining({ action: "issue:mutate" }));
       expect(mockIssueService.update).not.toHaveBeenCalled();

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -193,6 +193,8 @@ import {
 } from "../services/trust-preset-resolver.js";
 import { externalObjectService } from "../services/external-objects.js";
 
+const ISSUE_AUTHORIZATION_BOUNDARY_ERROR = "Issue is outside this actor's authorization boundary";
+const TERMINAL_ISSUE_AGENT_MUTATION_ERROR = "Issue is in a terminal state and does not accept agent mutations";
 const MAX_ISSUE_COMMENT_LIMIT = 500;
 const updateIssueRouteSchema = updateIssueSchema.extend({
   interrupt: z.boolean().optional(),
@@ -3566,7 +3568,12 @@ export function issueRoutes(
       { pmGrooming: isPmGroomingIssuePatchBody(req.body) },
     );
     if (!boundaryDecision.allowed) {
-      res.status(403).json({ error: "Issue is outside this actor's authorization boundary" });
+      res.status(403).json({
+        error:
+          issue.status === "done" || issue.status === "cancelled"
+            ? TERMINAL_ISSUE_AGENT_MUTATION_ERROR
+            : ISSUE_AUTHORIZATION_BOUNDARY_ERROR,
+      });
       return false;
     }
     if (issue.assigneeAgentId === null) {

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -3376,6 +3376,10 @@ export function issueRoutes(
     await assertCanAssignTasks(req, companyId, assignmentScope);
   }
 
+  type IssueAccessExtraScope = {
+    pmGrooming?: boolean;
+  };
+
   async function decideIssueAccess(
     req: Request,
     issue: {
@@ -3388,7 +3392,7 @@ export function issueRoutes(
       status: string;
     },
     action: "issue:comment" | "issue:read" | "issue:mutate",
-    extraScope: Record<string, unknown> = {},
+    extraScope: IssueAccessExtraScope = {},
   ) {
     return access.decide({
       actor: req.actor,
@@ -3404,12 +3408,12 @@ export function issueRoutes(
         status: issue.status,
       },
       scope: {
+        ...extraScope,
         issueId: issue.id,
         projectId: issue.projectId,
         parentIssueId: issue.parentId,
         assigneeAgentId: issue.assigneeAgentId,
         assigneeUserId: issue.assigneeUserId,
-        ...extraScope,
       },
     });
   }
@@ -3569,7 +3573,12 @@ export function issueRoutes(
       return true;
     }
     if (issue.assigneeAgentId !== actorAgentId) {
-      if (boundaryDecision.reason === "allow_same_company_pm_grooming" && issue.status !== "in_progress") {
+      if (
+        boundaryDecision.reason === "allow_same_company_pm_grooming" &&
+        issue.status !== "in_progress" &&
+        issue.status !== "done" &&
+        issue.status !== "cancelled"
+      ) {
         return true;
       }
       if (await hasActiveCheckoutManagementOverride(actorAgentId, issue.companyId, issue.assigneeAgentId)) {

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -3569,7 +3569,7 @@ export function issueRoutes(
       return true;
     }
     if (issue.assigneeAgentId !== actorAgentId) {
-      if (boundaryDecision.reason === "allow_same_company_pm_grooming") {
+      if (boundaryDecision.reason === "allow_same_company_pm_grooming" && issue.status !== "in_progress") {
         return true;
       }
       if (await hasActiveCheckoutManagementOverride(actorAgentId, issue.companyId, issue.assigneeAgentId)) {

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -3388,6 +3388,7 @@ export function issueRoutes(
       status: string;
     },
     action: "issue:comment" | "issue:read" | "issue:mutate",
+    extraScope: Record<string, unknown> = {},
   ) {
     return access.decide({
       actor: req.actor,
@@ -3408,8 +3409,20 @@ export function issueRoutes(
         parentIssueId: issue.parentId,
         assigneeAgentId: issue.assigneeAgentId,
         assigneeUserId: issue.assigneeUserId,
+        ...extraScope,
       },
     });
+  }
+
+  function isPmGroomingIssuePatchBody(body: unknown) {
+    if (!body || typeof body !== "object" || Array.isArray(body)) return false;
+    const record = body as Record<string, unknown>;
+    const allowedKeys = new Set(["comment", "status", "priority", "blockedByIssueIds"]);
+    if (Object.keys(record).some((key) => !allowedKeys.has(key))) return false;
+    if (typeof record.status === "string" && (record.status === "in_progress" || record.status === "cancelled")) {
+      return false;
+    }
+    return true;
   }
 
   async function assertIssueReadAllowed(req: Request, res: Response, issue: Parameters<typeof decideIssueAccess>[1]) {
@@ -3542,7 +3555,12 @@ export function issueRoutes(
       }
       return assertFreshTaskWatchdogSourceMutation(res, watchdogScope, issue);
     }
-    const boundaryDecision = await decideIssueAccess(req, issue, "issue:mutate");
+    const boundaryDecision = await decideIssueAccess(
+      req,
+      issue,
+      "issue:mutate",
+      { pmGrooming: isPmGroomingIssuePatchBody(req.body) },
+    );
     if (!boundaryDecision.allowed) {
       res.status(403).json({ error: "Issue is outside this actor's authorization boundary" });
       return false;
@@ -3551,6 +3569,9 @@ export function issueRoutes(
       return true;
     }
     if (issue.assigneeAgentId !== actorAgentId) {
+      if (boundaryDecision.reason === "allow_same_company_pm_grooming") {
+        return true;
+      }
       if (await hasActiveCheckoutManagementOverride(actorAgentId, issue.companyId, issue.assigneeAgentId)) {
         return true;
       }

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -3424,10 +3424,13 @@ export function issueRoutes(
     if (!body || typeof body !== "object" || Array.isArray(body)) return false;
     const record = body as Record<string, unknown>;
     const allowedKeys = new Set(["comment", "status", "priority", "blockedByIssueIds"]);
-    if (Object.keys(record).some((key) => !allowedKeys.has(key))) return false;
+    const keys = Object.keys(record);
+    if (keys.length === 0) return false;
+    if (keys.some((key) => !allowedKeys.has(key))) return false;
     if (typeof record.status === "string" && (record.status === "in_progress" || record.status === "cancelled")) {
       return false;
     }
+    if (record.status === "done") return false;
     return true;
   }
 
@@ -3531,6 +3534,7 @@ export function issueRoutes(
       assigneeAgentId: string | null;
       assigneeUserId: string | null;
     },
+    options: { pmGrooming?: boolean } = {},
   ) {
     if (req.actor.type !== "agent") return true;
     const actorAgentId = req.actor.agentId;
@@ -3565,7 +3569,7 @@ export function issueRoutes(
       req,
       issue,
       "issue:mutate",
-      { pmGrooming: isPmGroomingIssuePatchBody(req.body) },
+      { pmGrooming: options.pmGrooming === true },
     );
     if (!boundaryDecision.allowed) {
       res.status(403).json({
@@ -7662,7 +7666,9 @@ export function issueRoutes(
     const existing = await getAccessibleResource(req, res, svc.getById(id), "Issue not found");
     if (!existing) return;
     assertNoAgentHostWorkspaceCommandMutation(req, collectIssueWorkspaceCommandPaths(req.body));
-    if (!(await assertAgentIssueMutationAllowed(req, res, existing))) return;
+    if (!(await assertAgentIssueMutationAllowed(req, res, existing, {
+      pmGrooming: isPmGroomingIssuePatchBody(req.body),
+    }))) return;
     if (!(await assertCheapRecoveryIssueAssigneeProfileAllowed(req, res, existing, req.body))) return;
 
     const actor = getActorInfo(req);

--- a/server/src/services/authorization.ts
+++ b/server/src/services/authorization.ts
@@ -102,6 +102,8 @@ export type AuthorizationDecision = {
     | "allow_consented_change"
     | "allow_legacy_agent_creator"
     | "allow_issue_mention_grant"
+    | "allow_same_company_review_comment"
+    | "allow_same_company_pm_grooming"
     | "allow_self"
     | "allow_company_agent"
     | "allow_company_member"
@@ -159,6 +161,19 @@ function canCreateAgentsLegacy(agent: { role: string; permissions: unknown }) {
   if (agent.role === "ceo") return true;
   if (!agent.permissions || typeof agent.permissions !== "object") return false;
   return Boolean((agent.permissions as Record<string, unknown>).canCreateAgents);
+}
+
+function normalizedAgentRole(role: string | null | undefined) {
+  return (role ?? "").toLowerCase().replace(/[^a-z0-9]/g, "");
+}
+
+function isQaRole(role: string | null | undefined) {
+  return normalizedAgentRole(role) === "qa";
+}
+
+function isProjectManagerRole(role: string | null | undefined) {
+  const normalized = normalizedAgentRole(role);
+  return normalized === "pm" || normalized === "projectmanager";
 }
 
 function scopeValueList(value: unknown): string[] {
@@ -895,7 +910,7 @@ export function authorizationService(db: Db) {
   }
 
   async function decideLowTrustAccess(input: {
-    actorAgentId: string;
+    actorAgent: AgentAuthorizationRow;
     action: AuthorizationAction;
     resource: AuthorizationResource;
     resolution: TrustPresetResolution;
@@ -941,7 +956,7 @@ export function authorizationService(db: Db) {
       if (input.resource.type !== "agent") {
         return lowTrustDeny("Low-trust agent action is missing an agent resource.");
       }
-      return agentWithinLowTrustBoundary(boundary, input.actorAgentId, input.resource.agentId)
+      return agentWithinLowTrustBoundary(boundary, input.actorAgent.id, input.resource.agentId)
         ? lowTrustAllow("Allowed inside the low-trust agent boundary.")
         : lowTrustDeny("Agent is outside this low-trust boundary.");
     }
@@ -973,10 +988,17 @@ export function authorizationService(db: Db) {
           companyId: boundary.companyId,
           issueId: input.resource.issueId,
           issueAssigneeAgentId: input.resource.assigneeAgentId ?? null,
-          actorAgentId: input.actorAgentId,
+          actorAgentId: input.actorAgent.id,
         })
       ) {
         return allowIssueMentionGrant(input.action);
+      }
+      if (input.action === "issue:comment" && isQaRole(input.actorAgent.role)) {
+        return allow({
+          action: input.action,
+          reason: "allow_same_company_review_comment",
+          explanation: "Allowed for same-company QA review evidence comments.",
+        });
       }
       return lowTrustDeny("Issue is outside this low-trust boundary.");
     }
@@ -993,7 +1015,7 @@ export function authorizationService(db: Db) {
       }
       if (
         input.resource.assigneeAgentId &&
-        !agentWithinLowTrustBoundary(boundary, input.actorAgentId, input.resource.assigneeAgentId)
+        !agentWithinLowTrustBoundary(boundary, input.actorAgent.id, input.resource.assigneeAgentId)
       ) {
         return lowTrustDeny("Assignee agent is outside this low-trust boundary.");
       }
@@ -1683,7 +1705,7 @@ export function authorizationService(db: Db) {
     }
 
     const lowTrustDecision = await decideLowTrustAccess({
-      actorAgentId,
+      actorAgent,
       action: input.action,
       resource: input.resource,
       resolution: await resolveActorTrust({
@@ -1887,6 +1909,24 @@ export function authorizationService(db: Db) {
           action: input.action,
           reason: "allow_company_agent",
           explanation: "Allowed because the issue has no agent assignee.",
+        });
+      }
+      if (input.action === "issue:comment" && isQaRole(actorAgent.role)) {
+        return allow({
+          action: input.action,
+          reason: "allow_same_company_review_comment",
+          explanation: "Allowed for same-company QA review evidence comments.",
+        });
+      }
+      if (
+        input.action === "issue:mutate" &&
+        isProjectManagerRole(actorAgent.role) &&
+        scopeBoolean(input.scope, "pmGrooming")
+      ) {
+        return allow({
+          action: input.action,
+          reason: "allow_same_company_pm_grooming",
+          explanation: "Allowed for same-company ProjectManager delivery grooming.",
         });
       }
       if (

--- a/server/src/services/authorization.ts
+++ b/server/src/services/authorization.ts
@@ -993,13 +993,6 @@ export function authorizationService(db: Db) {
       ) {
         return allowIssueMentionGrant(input.action);
       }
-      if (input.action === "issue:comment" && isQaRole(input.actorAgent.role)) {
-        return allow({
-          action: input.action,
-          reason: "allow_same_company_review_comment",
-          explanation: "Allowed for same-company QA review evidence comments.",
-        });
-      }
       return lowTrustDeny("Issue is outside this low-trust boundary.");
     }
 

--- a/server/src/services/authorization.ts
+++ b/server/src/services/authorization.ts
@@ -176,6 +176,10 @@ function isProjectManagerRole(role: string | null | undefined) {
   return normalized === "pm" || normalized === "projectmanager";
 }
 
+function isTerminalIssueStatus(status: string | null | undefined) {
+  return status === "done" || status === "cancelled";
+}
+
 function scopeValueList(value: unknown): string[] {
   if (typeof value === "string" && value.trim()) return [value.trim()];
   if (!Array.isArray(value)) return [];
@@ -1909,6 +1913,17 @@ export function authorizationService(db: Db) {
           action: input.action,
           reason: "allow_same_company_review_comment",
           explanation: "Allowed for same-company QA review evidence comments.",
+        });
+      }
+      if (
+        input.action === "issue:comment" &&
+        isProjectManagerRole(actorAgent.role) &&
+        !isTerminalIssueStatus(resource.status)
+      ) {
+        return allow({
+          action: input.action,
+          reason: "allow_same_company_pm_grooming",
+          explanation: "Allowed for same-company ProjectManager delivery grooming.",
         });
       }
       if (

--- a/server/src/services/authorization.ts
+++ b/server/src/services/authorization.ts
@@ -103,6 +103,7 @@ export type AuthorizationDecision = {
     | "allow_legacy_agent_creator"
     | "allow_issue_mention_grant"
     | "allow_same_company_review_comment"
+    | "allow_same_company_pm_comment"
     | "allow_same_company_pm_grooming"
     | "allow_self"
     | "allow_company_agent"
@@ -1922,8 +1923,8 @@ export function authorizationService(db: Db) {
       ) {
         return allow({
           action: input.action,
-          reason: "allow_same_company_pm_grooming",
-          explanation: "Allowed for same-company ProjectManager delivery grooming.",
+          reason: "allow_same_company_pm_comment",
+          explanation: "Allowed for same-company ProjectManager delivery grooming comments.",
         });
       }
       if (


### PR DESCRIPTION
## Thinking Path

> - This open source app coordinates AI workers around tasks, comments, assignments, and review handoffs.
> - The affected subsystem is server-side authorization for task comments and narrow task updates.
> - Review evidence and delivery grooming can be blocked when the target task is owned by another same-company worker.
> - That failure mode leaves legitimate review and coordination work stranded even though it should remain inside the company boundary.
> - This pull request adds scoped same-company role carve-outs for review comments and delivery grooming while keeping owner-only execution and high-risk mutations constrained.
> - The benefit is that reviewers and delivery coordinators can complete their accountability loop without broadening cross-company, low-trust project, terminal-state, or active-ownership-protected access.

## Linked Issues or Issue Description

No public issue exists.

### What happened?

Same-company reviewer and delivery-coordinator workers can receive a forbidden response when posting review evidence or status-hygiene updates to another same-company worker's task.

### Expected behavior

Review comments and narrow delivery grooming writes are allowed inside the same company boundary. Low-trust reviewer project boundaries, cross-company denial, active-ownership protection, ownership transfer protection, and terminal-state protection remain enforced.

### Steps to reproduce

1. Create two same-company workers where one owns an assigned task.
2. Authenticate as a same-company reviewer-style worker and post review evidence to that task.
3. Authenticate as a same-company delivery-coordinator-style worker and patch only delivery-grooming fields on a non-active peer task.
4. Repeat against a cross-company task, an active peer ownership, a terminal peer task, an assignee-transfer patch, and a low-trust reviewer outside its configured project boundary.

### App version or commit

Reproduced on `master` before this branch.

### Deployment mode

Local dev / test environment.

Additional bug-report fields:

- Installation method: Built from source.
- Worker adapter(s) involved: Not adapter-specific; core authorization behavior.
- Database mode: Embedded test database.
- Access context: Worker bearer API key authorization.
- Privacy checklist: No secrets, tokens, private task links, or patient data are included.

## What Changed

- Added scoped same-company review-comment authorization for standard reviewer-style roles.
- Kept low-trust reviewer comments inside the configured low-trust project/issue boundary.
- Added scoped same-company delivery-grooming authorization for narrow task patch bodies.
- Kept grooming patches from bypassing another worker's active ownership or reopening `done` / `cancelled` tasks.
- Narrowed route-level extra authorization scope to the explicit `pmGrooming` key so future call sites cannot shadow issue-derived security fields.
- Added allowed and denied tests for review comments, grooming patches, low-trust project-boundary denial, company-boundary denial, ownership transfer denial, active-ownership denial, terminal-state denial, done-status grooming denial, empty-body denial, and grooming-comment isolation.

## Verification

- `pnpm vitest run server/src/__tests__/authorization-service.test.ts server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts`
- `pnpm vitest run server/src/__tests__/heartbeat-retry-scheduling.test.ts`
- Result: authorization run passed 2 test files / 132 tests; retry-scheduling run passed 1 test file / 28 tests.
- Covered: same-company standard review comment path, low-trust reviewer project-boundary denial, delivery grooming path, denied broad mutation path, terminal-state denial, cross-company denial, active-ownership guard preservation, done-status grooming denial, empty-body denial, separate grooming-comment authorization, and retry-scheduling cleanup stability.

## Risks

- Medium authorization-risk change because it intentionally widens two same-company write paths.
- Blast radius is constrained by explicit route-level allowlists, same-company checks, low-trust boundary preservation, terminal-state protection, and active-ownership protection.
- No database migration.

## Model Used

OpenAI GPT-5 Codex, coding-agent mode with repository inspection, shell command execution, git operations, and targeted test execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used with version and capability details
- [x] I have checked `ROADMAP.md` and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either linked existing public issues or described the issue in this PR
- [x] I have not referenced internal or instance-local task links
- [x] My branch name describes the change and contains no internal task id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes, or confirmed no docs are needed
- [x] I have considered and documented risks above
- [ ] All CI gates are green
- [ ] Automated code review is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all reviewer comments before requesting merge



