### PR TITLE
Classify restart-induced process losses in run activity

### DIFF
--- a/server/src/__tests__/dashboard-service.test.ts
+++ b/server/src/__tests__/dashboard-service.test.ts
@@ -237,4 +237,70 @@ describeEmbeddedPostgres("dashboard service", () => {
     // process_lost kills that recovered must not leak into the failed breakdown.
     expect(bucket?.failedByErrorCode.process_lost).toBeUndefined();
   });
+
+  it("breaks unrecovered restart-induced process loss into a distinct safe failure bucket", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const day = utcDay(-1);
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "CodexCoder",
+      role: "engineer",
+      status: "running",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    await db.insert(heartbeatRuns).values([
+      {
+        id: randomUUID(),
+        companyId,
+        agentId,
+        invocationSource: "assignment",
+        status: "failed",
+        errorCode: "process_lost",
+        resultJson: {
+          stopReason: "process_lost",
+          stopReasonDetail: "restart_induced_process_supervisor_loss",
+          restartRecovery: {
+            classification: "restart_induced_process_supervisor_loss",
+            mode: "startup_orphan_reap",
+          },
+        },
+        createdAt: day,
+      },
+      {
+        id: randomUUID(),
+        companyId,
+        agentId,
+        invocationSource: "assignment",
+        status: "failed",
+        errorCode: "process_lost",
+        resultJson: { stopReason: "process_lost" },
+        createdAt: day,
+      },
+    ]);
+
+    const summary = await dashboardService(db).summary(companyId);
+    const bucket = summary.runActivity.find((b) => b.date === utcDateKey(day));
+
+    expect(bucket).toMatchObject({
+      failed: 2,
+      failedByErrorCode: {
+        restart_induced_process_supervisor_loss: 1,
+        process_lost: 1,
+      },
+    });
+  });
 });

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -1389,7 +1389,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     });
   });
 
-  it("does not retry a lost monitor dispatch while another monitor wake remains scheduled", async () => {
+  it("keeps a steady-state pidless gateway loss as plain process_lost when another monitor wake remains scheduled", async () => {
     const { companyId, runId, issueId } = await seedRunFixture({
       adapterType: "openclaw_gateway",
       agentStatus: "idle",
@@ -1415,17 +1415,44 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       .then((rows) => rows[0] ?? null);
     expect(failedRun?.resultJson).toMatchObject({
       stopReason: "process_lost",
+    });
+    expect(failedRun?.resultJson as Record<string, unknown>).not.toHaveProperty("stopReasonDetail");
+    expect(failedRun?.resultJson as Record<string, unknown>).not.toHaveProperty("restartRecovery");
+    const retries = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(and(eq(heartbeatRuns.companyId, companyId), eq(heartbeatRuns.retryOfRunId, runId)));
+    expect(retries).toHaveLength(0);
+  });
+
+  it("classifies pidless orphan reaping as restart-induced only during startup recovery", async () => {
+    const { runId } = await seedRunFixture({
+      adapterType: "openclaw_gateway",
+      agentStatus: "idle",
+      processPid: null,
+      processGroupId: null,
+      contextSnapshot: {
+        wakeReason: "issue_assigned",
+      },
+    });
+
+    const heartbeat = heartbeatService(db);
+    const result = await heartbeat.reapOrphanedRuns({ startupOrphanReap: true });
+
+    expect(result).toEqual({ reaped: 1, runIds: [runId] });
+    const failedRun = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, runId))
+      .then((rows) => rows[0] ?? null);
+    expect(failedRun?.resultJson).toMatchObject({
+      stopReason: "process_lost",
       stopReasonDetail: "restart_induced_process_supervisor_loss",
       restartRecovery: {
         classification: "restart_induced_process_supervisor_loss",
         mode: "startup_orphan_reap",
       },
     });
-    const retries = await db
-      .select()
-      .from(heartbeatRuns)
-      .where(and(eq(heartbeatRuns.companyId, companyId), eq(heartbeatRuns.retryOfRunId, runId)));
-    expect(retries).toHaveLength(0);
   });
 
   async function withTempPaperclipHome<T>(fn: (home: string) => Promise<T>): Promise<T> {

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -1652,6 +1652,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
   it("interrupts running runs on graceful shutdown and queues restart recovery without recording a failure", async () => {
     const { agentId, runId, issueId, wakeupRequestId } = await seedRunFixture({
       agentStatus: "running",
+      processPid: 999_999_999,
       contextSnapshot: {
         modelProfile: "cheap",
         allowDeliverableWork: false,
@@ -1719,6 +1720,49 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       .then((rows) => rows[0] ?? null);
     expect(issue?.checkoutRunId).toBeNull();
     expect(issue?.executionRunId).toBe(retryRun?.id);
+  });
+
+  it("does not stamp restart-recovery detail on graceful shutdown for runs without a local process", async () => {
+    const { agentId, runId } = await seedRunFixture({
+      agentStatus: "running",
+      processPid: null,
+      processGroupId: null,
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.drainRunningRunsForShutdown(
+      "SIGTERM",
+      new Date("2026-03-19T00:06:00.000Z"),
+    );
+    expect(result.interruptedRunIds).toEqual([runId]);
+
+    const interruptedRun = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, runId))
+      .then((rows) => rows[0] ?? null);
+    expect(interruptedRun).toMatchObject({
+      status: "interrupted",
+      errorCode: "server_shutdown_interrupted",
+      signal: "SIGTERM",
+    });
+    expect(interruptedRun?.resultJson).toMatchObject({
+      stopReason: "interrupted",
+      timeoutConfigured: false,
+      timeoutFired: false,
+    });
+    expect(interruptedRun?.resultJson as Record<string, unknown>).not.toHaveProperty("stopReasonDetail");
+    expect(interruptedRun?.resultJson as Record<string, unknown>).not.toHaveProperty("restartRecovery");
+
+    const retryRun = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(and(eq(heartbeatRuns.agentId, agentId), eq(heartbeatRuns.retryOfRunId, runId)))
+      .then((rows) => rows[0] ?? null);
+    expect(retryRun).toMatchObject({
+      status: "queued",
+      processLossRetryCount: 1,
+    });
   });
 
   it("does not overwrite a run that is no longer running during graceful shutdown drain", async () => {

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -1286,6 +1286,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       timeoutConfigured: false,
       timeoutFired: false,
     });
+    expect(failedRun?.resultJson as Record<string, unknown>).not.toHaveProperty("stopReasonDetail");
     expect(["queued", "running"]).toContain(retryRun?.status);
     expect(retryRun?.retryOfRunId).toBe(runId);
     expect(retryRun?.processLossRetryCount).toBe(1);
@@ -1407,6 +1408,19 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     const result = await heartbeat.reapOrphanedRuns();
 
     expect(result).toEqual({ reaped: 1, runIds: [runId] });
+    const failedRun = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, runId))
+      .then((rows) => rows[0] ?? null);
+    expect(failedRun?.resultJson).toMatchObject({
+      stopReason: "process_lost",
+      stopReasonDetail: "restart_induced_process_supervisor_loss",
+      restartRecovery: {
+        classification: "restart_induced_process_supervisor_loss",
+        mode: "startup_orphan_reap",
+      },
+    });
     const retries = await db
       .select()
       .from(heartbeatRuns)
@@ -1643,6 +1657,13 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     });
     expect(interruptedRun?.resultJson).toMatchObject({
       stopReason: "interrupted",
+      stopReasonDetail: "restart_induced_process_supervisor_loss",
+      restartRecovery: {
+        classification: "restart_induced_process_supervisor_loss",
+        mode: "graceful_shutdown_interruption",
+        occurredAt: "2026-03-19T00:06:00.000Z",
+        signal: "SIGTERM",
+      },
       timeoutConfigured: false,
       timeoutFired: false,
     });

--- a/server/src/__tests__/heartbeat-retry-scheduling.test.ts
+++ b/server/src/__tests__/heartbeat-retry-scheduling.test.ts
@@ -107,7 +107,12 @@ describeEmbeddedPostgres("heartbeat bounded retry scheduling", () => {
     await db.delete(executionWorkspaces);
     await db.delete(projects);
     await db.delete(heartbeatRunEvents);
-    await db.delete(heartbeatRuns);
+    try {
+      await db.delete(heartbeatRuns);
+    } catch {
+      await db.delete(heartbeatRunEvents);
+      await db.delete(heartbeatRuns);
+    }
     await db.delete(agentWakeupRequests);
     await db.delete(agentRuntimeState);
     await db.delete(budgetPolicies);

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -893,7 +893,7 @@ export async function startServer(): Promise<StartedServer> {
 
         for (let attempt = 1; attempt <= 2; attempt++) {
           try {
-            const result = await heartbeat.reapOrphanedRuns();
+            const result = await heartbeat.reapOrphanedRuns({ startupOrphanReap: true });
             logger.info(
               { reaped: result.reaped, runIds: result.runIds },
               "startup reap of orphaned heartbeat runs complete",

--- a/server/src/services/dashboard.ts
+++ b/server/src/services/dashboard.ts
@@ -118,13 +118,27 @@ export function dashboardService(db: Db) {
         SELECT
           to_char(run.created_at AT TIME ZONE 'UTC', 'YYYY-MM-DD') AS date,
           run.status AS status,
-          run.error_code AS error_code,
+          CASE
+            WHEN run.error_code = 'process_lost'
+              AND run.result_json->>'stopReasonDetail' = 'restart_induced_process_supervisor_loss'
+            THEN run.result_json->>'stopReasonDetail'
+            ELSE run.error_code
+          END AS error_code,
           (run.id IN (SELECT id FROM recovered_runs)) AS recovered,
           count(*)::double precision AS count
         FROM ${heartbeatRuns} AS run
         WHERE run.company_id = ${companyId}
           AND run.created_at >= ${runActivityStart.toISOString()}::timestamptz
-        GROUP BY date, run.status, run.error_code, recovered
+        GROUP BY
+          date,
+          run.status,
+          CASE
+            WHEN run.error_code = 'process_lost'
+              AND run.result_json->>'stopReasonDetail' = 'restart_induced_process_supervisor_loss'
+            THEN run.result_json->>'stopReasonDetail'
+            ELSE run.error_code
+          END,
+          recovered
       `)) as unknown as Iterable<{
         date: string;
         status: string;

--- a/server/src/services/heartbeat-stop-metadata.test.ts
+++ b/server/src/services/heartbeat-stop-metadata.test.ts
@@ -76,6 +76,33 @@ describe("heartbeat stop metadata", () => {
     ).toBe("interrupted");
   });
 
+  it("preserves restart-induced supervisor loss detail when merging stop metadata", () => {
+    const result = mergeHeartbeatRunStopMetadata(
+      {
+        stopReasonDetail: "restart_induced_process_supervisor_loss",
+        restartRecovery: {
+          classification: "restart_induced_process_supervisor_loss",
+          mode: "graceful_shutdown_interruption",
+        },
+      },
+      buildHeartbeatRunStopMetadata({
+        adapterType: "codex_local",
+        adapterConfig: {},
+        outcome: "interrupted",
+        errorCode: "server_shutdown_interrupted",
+      }),
+    );
+
+    expect(result).toMatchObject({
+      stopReason: "interrupted",
+      stopReasonDetail: "restart_induced_process_supervisor_loss",
+      restartRecovery: {
+        classification: "restart_induced_process_supervisor_loss",
+        mode: "graceful_shutdown_interruption",
+      },
+    });
+  });
+
   it("normalizes max-turn exhaustion stop reasons", () => {
     expect(
       buildHeartbeatRunStopMetadata({

--- a/server/src/services/heartbeat-stop-metadata.ts
+++ b/server/src/services/heartbeat-stop-metadata.ts
@@ -12,6 +12,9 @@ export type HeartbeatRunStopReason =
   | "unmanaged_background_task_stopped"
   | "adapter_failed";
 
+export type HeartbeatRunStopReasonDetail =
+  | "restart_induced_process_supervisor_loss";
+
 export interface HeartbeatRunTimeoutPolicy {
   effectiveTimeoutSec: number | null;
   effectiveTimeoutMs?: number | null;
@@ -21,6 +24,7 @@ export interface HeartbeatRunTimeoutPolicy {
 
 export interface HeartbeatRunStopMetadata extends HeartbeatRunTimeoutPolicy {
   stopReason: HeartbeatRunStopReason;
+  stopReasonDetail?: HeartbeatRunStopReasonDetail;
   timeoutFired: boolean;
 }
 
@@ -124,6 +128,7 @@ export function mergeHeartbeatRunStopMetadata(
   return {
     ...(resultJson ?? {}),
     stopReason: existingMaxTurnStopReason ?? metadata.stopReason,
+    ...(metadata.stopReasonDetail ? { stopReasonDetail: metadata.stopReasonDetail } : {}),
     effectiveTimeoutSec: metadata.effectiveTimeoutSec,
     timeoutConfigured: metadata.timeoutConfigured,
     timeoutSource: metadata.timeoutSource,

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -9099,19 +9099,24 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       }
 
       const message = `Interrupted by graceful server shutdown (${signal}); retry queued for restart recovery`;
+      const hasLocalProcessHandle = Boolean(running || run.processPid || run.processGroupId);
+      const existingResultJson = parseObject(run.resultJson);
+      const shutdownResultJson = hasLocalProcessHandle
+        ? mergeRestartRecoveryResultJson(existingResultJson, {
+            mode: "graceful_shutdown_interruption",
+            occurredAt: now,
+            signal,
+            processPid: run.processPid ?? null,
+            processGroupId: run.processGroupId ?? null,
+          })
+        : existingResultJson;
       const interruptedStatus = await setRunStatusIfRunning(run.id, "interrupted", {
         finishedAt: now,
         error: message,
         errorCode: "server_shutdown_interrupted",
         signal,
         resultJson: mergeRunStopMetadataForAgent(agent, "interrupted", {
-          resultJson: mergeRestartRecoveryResultJson(parseObject(run.resultJson), {
-            mode: "graceful_shutdown_interruption",
-            occurredAt: now,
-            signal,
-            processPid: run.processPid ?? null,
-            processGroupId: run.processGroupId ?? null,
-          }),
+          resultJson: shutdownResultJson,
           errorCode: "server_shutdown_interrupted",
           errorMessage: message,
         }),

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -5073,20 +5073,38 @@ async function terminateHeartbeatRunProcess(input: {
   );
 }
 
+type ProcessLossCause =
+  | "descendant_process_group_alive"
+  | "child_pid_exited"
+  | "process_group_exited"
+  | "missing_supervisor_state";
+
 function buildProcessLossMessage(run: {
   processPid: number | null;
   processGroupId: number | null;
 }, options?: { descendantOnly?: boolean }) {
   if (options?.descendantOnly && run.processGroupId) {
-    return `Process lost -- parent pid ${run.processPid ?? "unknown"} exited, but descendant process group ${run.processGroupId} was still alive and was terminated`;
+    return {
+      message: `Process lost -- parent pid ${run.processPid ?? "unknown"} exited, but descendant process group ${run.processGroupId} was still alive and was terminated`,
+      cause: "descendant_process_group_alive" as const,
+    };
   }
   if (run.processPid) {
-    return `Process lost -- child pid ${run.processPid} is no longer running`;
+    return {
+      message: `Process lost -- child pid ${run.processPid} is no longer running`,
+      cause: "child_pid_exited" as const,
+    };
   }
   if (run.processGroupId) {
-    return `Process lost -- process group ${run.processGroupId} is no longer running`;
+    return {
+      message: `Process lost -- process group ${run.processGroupId} is no longer running`,
+      cause: "process_group_exited" as const,
+    };
   }
-  return "Process lost -- server may have restarted";
+  return {
+    message: "Process lost -- server may have restarted",
+    cause: "missing_supervisor_state" as const,
+  };
 }
 
 function readHotRestartAdoptionMetadata(resultJson: Record<string, unknown> | null | undefined) {
@@ -11361,7 +11379,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       .then((rows) => rows[0] ?? null);
   }
 
-  async function reapOrphanedRuns(opts?: { staleThresholdMs?: number }) {
+  async function reapOrphanedRuns(opts?: { staleThresholdMs?: number; startupOrphanReap?: boolean }) {
     const staleThresholdMs = opts?.staleThresholdMs ?? 0;
     const now = new Date();
 
@@ -11463,7 +11481,8 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         (tracksLocalChild && (!!run.processPid || !!run.processGroupId)) ||
         monitorDispatchLostWithoutFutureWake
       );
-      const baseMessage = buildProcessLossMessage(run, descendantOnlyCleanup ? { descendantOnly: true } : undefined);
+      const processLoss = buildProcessLossMessage(run, descendantOnlyCleanup ? { descendantOnly: true } : undefined);
+      const baseMessage = processLoss.message;
       const unmanagedBackgroundTaskEvidence = descendantOnlyCleanup
         ? {
           kind: "orphaned_process_group_cleanup",
@@ -11489,7 +11508,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
               errorMessage: shouldRetry ? `${baseMessage}; retrying once` : baseMessage,
             },
           );
-          const resultWithRestartRecovery = baseMessage === "Process lost -- server may have restarted"
+          const resultWithRestartRecovery = opts?.startupOrphanReap === true && processLoss.cause === "missing_supervisor_state"
             ? mergeRestartRecoveryResultJson(result, {
               mode: "startup_orphan_reap",
               occurredAt: now,

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -5126,6 +5126,33 @@ function mergeHotRestartAdoptionResultJson(
   };
 }
 
+function mergeRestartRecoveryResultJson(
+  resultJson: Record<string, unknown> | null | undefined,
+  input: {
+    mode: "startup_orphan_reap" | "graceful_shutdown_interruption";
+    occurredAt: Date;
+    signal?: "SIGINT" | "SIGTERM";
+    processPid: number | null;
+    processGroupId: number | null;
+  },
+) {
+  const result = parseObject(resultJson);
+  const existing = parseObject(result.restartRecovery);
+  return {
+    ...result,
+    stopReasonDetail: "restart_induced_process_supervisor_loss",
+    restartRecovery: {
+      ...existing,
+      classification: "restart_induced_process_supervisor_loss",
+      mode: input.mode,
+      occurredAt: input.occurredAt.toISOString(),
+      ...(input.signal ? { signal: input.signal } : {}),
+      processPid: input.processPid,
+      processGroupId: input.processGroupId,
+    },
+  };
+}
+
 function truncateDisplayId(value: string | null | undefined, max = 128) {
   if (!value) return null;
   return value.length > max ? value.slice(0, max) : value;
@@ -9060,7 +9087,13 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         errorCode: "server_shutdown_interrupted",
         signal,
         resultJson: mergeRunStopMetadataForAgent(agent, "interrupted", {
-          resultJson: parseObject(run.resultJson),
+          resultJson: mergeRestartRecoveryResultJson(parseObject(run.resultJson), {
+            mode: "graceful_shutdown_interruption",
+            occurredAt: now,
+            signal,
+            processPid: run.processPid ?? null,
+            processGroupId: run.processGroupId ?? null,
+          }),
           errorCode: "server_shutdown_interrupted",
           errorMessage: message,
         }),
@@ -11456,13 +11489,21 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
               errorMessage: shouldRetry ? `${baseMessage}; retrying once` : baseMessage,
             },
           );
+          const resultWithRestartRecovery = baseMessage === "Process lost -- server may have restarted"
+            ? mergeRestartRecoveryResultJson(result, {
+              mode: "startup_orphan_reap",
+              occurredAt: now,
+              processPid: run.processPid ?? null,
+              processGroupId: run.processGroupId ?? null,
+            })
+            : result;
           return unmanagedBackgroundTaskEvidence
             ? {
-              ...result,
+              ...resultWithRestartRecovery,
               stopReason: UNMANAGED_BACKGROUND_TASK_STOP_REASON,
               unmanagedBackgroundTask: unmanagedBackgroundTaskEvidence,
             }
-            : result;
+            : resultWithRestartRecovery;
         })(),
       });
       await setWakeupStatus(run.wakeupRequestId, "failed", {

--- a/ui/src/components/ActivityCharts.test.tsx
+++ b/ui/src/components/ActivityCharts.test.tsx
@@ -132,4 +132,54 @@ describe("ActivityCharts", () => {
     const dayCell = container.querySelector("[title*='recovered: 4']");
     expect(dayCell).not.toBeNull();
   });
+
+  it("uses restart-induced supervisor loss labels for aggregate dashboard activity", () => {
+    render(
+      <RunActivityChart
+        activity={[
+          {
+            date: "2026-04-20",
+            succeeded: 0,
+            failed: 1,
+            recovered: 0,
+            other: 0,
+            total: 1,
+            failedByErrorCode: { restart_induced_process_supervisor_loss: 1 },
+          },
+        ]}
+      />,
+    );
+
+    const dayCell = container.querySelector("[title*='restart-induced supervisor loss: 1']");
+    expect(dayCell).not.toBeNull();
+    expect(dayCell?.getAttribute("title")).not.toContain("restart_induced_process_supervisor_loss");
+  });
+
+  it("separates restart-induced supervisor loss from plain process_lost in raw run lists", () => {
+    render(
+      <RunActivityChart
+        runs={[
+          createRun({
+            id: "run-restart-loss",
+            status: "failed",
+            errorCode: "process_lost",
+            resultJson: {
+              stopReason: "process_lost",
+              stopReasonDetail: "restart_induced_process_supervisor_loss",
+            },
+          }),
+          createRun({
+            id: "run-plain-loss",
+            status: "failed",
+            errorCode: "process_lost",
+            resultJson: { stopReason: "process_lost" },
+          }),
+        ]}
+      />,
+    );
+
+    const dayCell = container.querySelector("[title^='2026-04-20: 2 runs']");
+    expect(dayCell?.getAttribute("title")).toContain("restart-induced supervisor loss: 1");
+    expect(dayCell?.getAttribute("title")).toContain("process_lost: 1");
+  });
 });

--- a/ui/src/components/ActivityCharts.test.tsx
+++ b/ui/src/components/ActivityCharts.test.tsx
@@ -108,7 +108,8 @@ describe("ActivityCharts", () => {
     // Tooltip now carries the per-day breakdown (incl. failure error codes).
     const dayCell = container.querySelector("[title^='2026-04-20: 2 runs']");
     expect(dayCell).not.toBeNull();
-    expect(dayCell?.getAttribute("title")).toContain("provider_quota: 1");
+    expect(dayCell?.getAttribute("title")).toContain("provider quota: 1");
+    expect(dayCell?.getAttribute("title")).not.toContain("provider_quota");
   });
 
   it("renders a distinct recovered segment and legend for recovered restart kills", () => {
@@ -180,6 +181,7 @@ describe("ActivityCharts", () => {
 
     const dayCell = container.querySelector("[title^='2026-04-20: 2 runs']");
     expect(dayCell?.getAttribute("title")).toContain("restart-induced supervisor loss: 1");
-    expect(dayCell?.getAttribute("title")).toContain("process_lost: 1");
+    expect(dayCell?.getAttribute("title")).toContain("process lost: 1");
+    expect(dayCell?.getAttribute("title")).not.toContain("process_lost");
   });
 });

--- a/ui/src/components/ActivityCharts.tsx
+++ b/ui/src/components/ActivityCharts.tsx
@@ -1,4 +1,5 @@
 import type { DashboardRunActivityDay, HeartbeatRun } from "@paperclipai/shared";
+import { formatRunFailureCode, resolveRunFailureCode } from "@/lib/runFailureLabels";
 
 /* ---- Utilities ---- */
 
@@ -34,7 +35,7 @@ function runDayTooltip(entry: DashboardRunActivityDay): string {
   if (entry.failed > 0) {
     lines.push(`  failed: ${entry.failed}`);
     const codes = Object.entries(entry.failedByErrorCode ?? {}).sort((a, b) => b[1] - a[1]);
-    for (const [code, count] of codes) lines.push(`    ${code}: ${count}`);
+    for (const [code, count] of codes) lines.push(`    ${formatRunFailureCode(code)}: ${count}`);
   }
   if (entry.other > 0) lines.push(`  other: ${entry.other}`);
   return lines.join("\n");
@@ -102,7 +103,7 @@ function aggregateRuns(runs: readonly HeartbeatRun[] = []): DashboardRunActivity
       // here (the company dashboard computes it server-side). Attribute the
       // failure to its error class so the breakdown still renders.
       entry.failed++;
-      const code = run.errorCode && run.errorCode.length > 0 ? run.errorCode : "unknown";
+      const code = resolveRunFailureCode(run);
       entry.failedByErrorCode[code] = (entry.failedByErrorCode[code] ?? 0) + 1;
     } else {
       entry.other++;

--- a/ui/src/components/IssueRunLedger.test.tsx
+++ b/ui/src/components/IssueRunLedger.test.tsx
@@ -395,6 +395,22 @@ describe("IssueRunLedger", () => {
     expect(container.textContent).toContain("paused by board");
   });
 
+  it("does not let restart detail override unrelated stop reasons", () => {
+    renderLedger({
+      runs: [
+        createRun({
+          resultJson: {
+            stopReason: "adapter_failed",
+            stopReasonDetail: "restart_induced_process_supervisor_loss",
+          },
+        }),
+      ],
+    });
+
+    expect(container.textContent).toContain("adapter failed");
+    expect(container.textContent).not.toContain("restart-induced supervisor loss");
+  });
+
   it("surfaces active and completed child issue summaries", () => {
     renderLedger({
       childIssues: [

--- a/ui/src/components/IssueRunLedger.tsx
+++ b/ui/src/components/IssueRunLedger.tsx
@@ -323,7 +323,10 @@ function stopReasonLabel(run: RunForIssue) {
   if (stopReason === "budget_paused") return "budget paused";
   if (stopReason === "cancelled") return "cancelled";
   if (stopReason === "paused") return "paused by board";
-  if (stopReasonDetail === RESTART_INDUCED_SUPERVISOR_LOSS) return formatRunFailureCode(stopReasonDetail);
+  if (
+    (stopReason === "process_lost" || stopReason === "interrupted") &&
+    stopReasonDetail === RESTART_INDUCED_SUPERVISOR_LOSS
+  ) return formatRunFailureCode(stopReasonDetail);
   if (stopReason === "process_lost") return "process lost";
   if (stopReason === "unmanaged_background_task_stopped") return "unmanaged background task stopped";
   if (stopReason === "adapter_failed") return "adapter failed";

--- a/ui/src/components/IssueRunLedger.tsx
+++ b/ui/src/components/IssueRunLedger.tsx
@@ -16,6 +16,7 @@ import { useToastActions } from "../context/ToastContext";
 import { cn, relativeTime } from "../lib/utils";
 import { queryKeys } from "../lib/queryKeys";
 import { keepPreviousDataForSameQueryTail } from "../lib/query-placeholder-data";
+import { formatRunFailureCode, RESTART_INDUCED_SUPERVISOR_LOSS } from "../lib/runFailureLabels";
 import { describeRunRetryState } from "../lib/runRetryState";
 import { readSourceResolvedWatchdogFold } from "../lib/source-resolved-watchdog-fold";
 import { SourceResolvedFoldBadge } from "./SourceResolvedFoldBadge";
@@ -322,7 +323,7 @@ function stopReasonLabel(run: RunForIssue) {
   if (stopReason === "budget_paused") return "budget paused";
   if (stopReason === "cancelled") return "cancelled";
   if (stopReason === "paused") return "paused by board";
-  if (stopReasonDetail === "restart_induced_process_supervisor_loss") return "restart-induced supervisor loss";
+  if (stopReasonDetail === RESTART_INDUCED_SUPERVISOR_LOSS) return formatRunFailureCode(stopReasonDetail);
   if (stopReason === "process_lost") return "process lost";
   if (stopReason === "unmanaged_background_task_stopped") return "unmanaged background task stopped";
   if (stopReason === "adapter_failed") return "adapter failed";

--- a/ui/src/components/IssueRunLedger.tsx
+++ b/ui/src/components/IssueRunLedger.tsx
@@ -309,6 +309,7 @@ function livenessCopyForRun(run: LedgerRun) {
 function stopReasonLabel(run: RunForIssue) {
   const result = asRecord(run.resultJson);
   const stopReason = readString(result?.stopReason);
+  const stopReasonDetail = readString(result?.stopReasonDetail);
   const timeoutFired = result?.timeoutFired === true;
   const effectiveTimeoutSec = readNumber(result?.effectiveTimeoutSec);
   const timeoutText =
@@ -321,6 +322,7 @@ function stopReasonLabel(run: RunForIssue) {
   if (stopReason === "budget_paused") return "budget paused";
   if (stopReason === "cancelled") return "cancelled";
   if (stopReason === "paused") return "paused by board";
+  if (stopReasonDetail === "restart_induced_process_supervisor_loss") return "restart-induced supervisor loss";
   if (stopReason === "process_lost") return "process lost";
   if (stopReason === "unmanaged_background_task_stopped") return "unmanaged background task stopped";
   if (stopReason === "adapter_failed") return "adapter failed";

--- a/ui/src/lib/runFailureLabels.ts
+++ b/ui/src/lib/runFailureLabels.ts
@@ -24,5 +24,5 @@ export function resolveRunFailureCode(run: {
 
 export function formatRunFailureCode(code: string): string {
   if (code === RESTART_INDUCED_SUPERVISOR_LOSS) return "restart-induced supervisor loss";
-  return code;
+  return code.replace(/_/g, " ");
 }

--- a/ui/src/lib/runFailureLabels.ts
+++ b/ui/src/lib/runFailureLabels.ts
@@ -1,0 +1,28 @@
+export const RESTART_INDUCED_SUPERVISOR_LOSS = "restart_induced_process_supervisor_loss";
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null;
+}
+
+function readString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+export function resolveRunFailureCode(run: {
+  errorCode?: string | null;
+  resultJson?: unknown;
+}): string {
+  const result = asRecord(run.resultJson);
+  const stopReasonDetail = readString(result?.stopReasonDetail);
+  if (run.errorCode === "process_lost" && stopReasonDetail === RESTART_INDUCED_SUPERVISOR_LOSS) {
+    return RESTART_INDUCED_SUPERVISOR_LOSS;
+  }
+  return run.errorCode && run.errorCode.length > 0 ? run.errorCode : "unknown";
+}
+
+export function formatRunFailureCode(code: string): string {
+  if (code === RESTART_INDUCED_SUPERVISOR_LOSS) return "restart-induced supervisor loss";
+  return code;
+}


### PR DESCRIPTION
## Thinking Path

> - This is the open source app people use to manage AI agents for work.
> - Runtime runs can end because a local worker process disappears.
> - Some process losses are caused by deliberate local restarts, while others are unexplained failures.
> - Restart-induced process loss should be labeled distinctly so operators can tell expected restart recovery apart from real child loss.
> - Run activity charts and ledgers also need the same readable labels, including for unknown fallback codes.
> - This pull request records restart-induced process losses and renders run failure labels as readable text.
> - The benefit is clearer runtime diagnostics without exposing raw internal slugs in user-facing hover text.

## Linked Issues or Issue Description

Bug report:

- What happened: local restart-induced process losses could be grouped with unexplained process loss, and unknown run failure codes could render as raw snake_case in activity tooltips.
- Expected behavior: restart-induced process loss gets a distinct label, and fallback failure codes render as readable words.
- Steps to reproduce: inspect run activity or ledger output for a restart-induced child process loss or an unknown fallback failure code.
- Version/commit: current `master` before this branch.
- Deployment mode: local runtime.

Related public work found during duplicate search: #1293, #9288.

## What Changed

- Persist restart-induced process-loss metadata when local heartbeat recovery observes a restart-related child loss.
- Collapse restart-induced process-loss runs into a distinct dashboard bucket.
- Render run activity and ledger labels through shared failure-label helpers.
- Add fallback formatting so unknown failure codes display as plain words instead of raw snake_case.
- Add focused server and UI tests for the classification and display behavior.

## Verification

- `pnpm vitest run ui/src/components/ActivityCharts.test.tsx` passes: 1 file, 5 tests.
- Existing branch verification before this handoff covered the restart-classification server tests and rendered UI checks for desktop and mobile tooltips.

## Risks

- Low risk: the change is scoped to runtime failure classification and display labels.
- The main behavioral shift is that restart-induced local process loss now appears as its own bucket instead of being indistinguishable from unexplained process loss.

## Model Used

OpenAI GPT-5 Codex, tool-using coding agent with repository command execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local issues or links (only public GitHub `#NNN` / public repository URLs)
- [x] My branch name describes the change and contains no private task id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All CI gates are green
- [x] Automated review is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all automated-review and reviewer comments before requesting merge