### PR TITLE
Draft - pending human review before merge

### DIFF
--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -792,14 +792,11 @@ describe("agent issue mutation checkout ownership", () => {
     expect(mockIssueService.update).not.toHaveBeenCalled();
   });
 
-  it.each([
-    ["manager", "allow_manager_comment"],
-    ["legacy creator", "allow_legacy_creator_comment"],
-  ])("allows authorized %s agents to add PATCH comments without checkout ownership", async (_label, reason) => {
+  it("allows authorized manager agents to add PATCH comments without checkout ownership", async () => {
     mockAccessService.decide.mockImplementation(async (input: { action: string }) => ({
       allowed: input.action === "issue:comment",
       action: input.action,
-      reason: input.action === "issue:comment" ? reason : "deny_missing_grant",
+      reason: input.action === "issue:comment" ? "allow_manager_comment" : "deny_missing_grant",
       explanation:
         input.action === "issue:comment"
           ? "Allowed by comment-only route policy."
@@ -817,6 +814,38 @@ describe("agent issue mutation checkout ownership", () => {
     expect(mockIssueService.addComment).toHaveBeenCalledWith(
       issueId,
       "Comment-only PATCH should match POST comment auth.",
+      expect.any(Object),
+      expect.any(Object),
+    );
+  });
+
+  it("allows authorized legacy creator agents to add PATCH comments without checkout ownership", async () => {
+    mockIssueService.getById.mockResolvedValue(makeIssue({
+      assigneeAgentId: ownerAgentId,
+      createdByAgentId: peerAgentId,
+      createdByUserId: null,
+    }));
+    mockAccessService.decide.mockImplementation(async (input: { action: string }) => ({
+      allowed: input.action === "issue:comment",
+      action: input.action,
+      reason: input.action === "issue:comment" ? "allow_legacy_creator_comment" : "deny_missing_grant",
+      explanation:
+        input.action === "issue:comment"
+          ? "Allowed by legacy creator comment policy."
+          : "Missing permission.",
+    }));
+
+    const res = await request(await createApp(peerActor()))
+      .patch(`/api/issues/${issueId}`)
+      .send({ comment: "Legacy creator PATCH comment should match POST comment auth." });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(mockAccessService.decide).toHaveBeenCalledWith(expect.objectContaining({ action: "issue:comment" }));
+    expect(mockAccessService.decide).not.toHaveBeenCalledWith(expect.objectContaining({ action: "issue:mutate" }));
+    expect(mockIssueService.assertCheckoutOwner).not.toHaveBeenCalled();
+    expect(mockIssueService.addComment).toHaveBeenCalledWith(
+      issueId,
+      "Legacy creator PATCH comment should match POST comment auth.",
       expect.any(Object),
       expect.any(Object),
     );

--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -792,6 +792,54 @@ describe("agent issue mutation checkout ownership", () => {
     expect(mockIssueService.update).not.toHaveBeenCalled();
   });
 
+  it.each([
+    ["manager", "allow_manager_comment"],
+    ["legacy creator", "allow_legacy_creator_comment"],
+  ])("allows authorized %s agents to add PATCH comments without checkout ownership", async (_label, reason) => {
+    mockAccessService.decide.mockImplementation(async (input: { action: string }) => ({
+      allowed: input.action === "issue:comment",
+      action: input.action,
+      reason: input.action === "issue:comment" ? reason : "deny_missing_grant",
+      explanation:
+        input.action === "issue:comment"
+          ? "Allowed by comment-only route policy."
+          : "Missing permission.",
+    }));
+
+    const res = await request(await createApp(peerActor()))
+      .patch(`/api/issues/${issueId}`)
+      .send({ comment: "Comment-only PATCH should match POST comment auth." });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(mockAccessService.decide).toHaveBeenCalledWith(expect.objectContaining({ action: "issue:comment" }));
+    expect(mockAccessService.decide).not.toHaveBeenCalledWith(expect.objectContaining({ action: "issue:mutate" }));
+    expect(mockIssueService.assertCheckoutOwner).not.toHaveBeenCalled();
+    expect(mockIssueService.addComment).toHaveBeenCalledWith(
+      issueId,
+      "Comment-only PATCH should match POST comment auth.",
+      expect.any(Object),
+      expect.any(Object),
+    );
+  });
+
+  it("rejects unauthorized same-company agents from PATCH comments", async () => {
+    mockAccessService.decide.mockImplementation(async (input: { action: string }) => ({
+      allowed: input.action === "issue:read",
+      action: input.action,
+      reason: input.action === "issue:read" ? "allow_explicit_grant" : "deny_missing_grant",
+      explanation: input.action === "issue:read" ? "Allowed by test read grant." : "Missing permission.",
+    }));
+
+    const res = await request(await createApp(peerActor()))
+      .patch(`/api/issues/${issueId}`)
+      .send({ comment: "I should not be able to comment." });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(403);
+    expect(res.body.error).toBe("Issue is outside this actor's authorization boundary");
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+    expect(mockIssueService.addComment).not.toHaveBeenCalled();
+  });
+
   it("rejects non-mentioned peer agents from posting comments", async () => {
     mockAccessService.decide.mockImplementation(async (input: { action: string }) => ({
       allowed: input.action === "issue:read",
@@ -914,6 +962,69 @@ describe("agent issue mutation checkout ownership", () => {
     expect(res.status, JSON.stringify(res.body)).toBe(403);
     expect(res.body.error).toBe("Agent cannot mutate another agent's issue");
     expect(mockIssueService.update).not.toHaveBeenCalled();
+  });
+
+  it("does not widen PATCH issue mutation authority for comment-bearing updates", async () => {
+    mockAccessService.decide.mockImplementation(async (input: { action: string }) => ({
+      allowed: input.action === "issue:comment",
+      action: input.action,
+      reason: input.action === "issue:comment" ? "allow_manager_comment" : "deny_missing_grant",
+      explanation:
+        input.action === "issue:comment"
+          ? "Allowed by comment-only route policy."
+          : "Missing permission.",
+    }));
+
+    const res = await request(await createApp(peerActor()))
+      .patch(`/api/issues/${issueId}`)
+      .send({ title: "Unauthorized mutation", comment: "Manager note." });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(403);
+    expect(res.body.error).toBe("Issue is outside this actor's authorization boundary");
+    expect(mockAccessService.decide).toHaveBeenCalledWith(expect.objectContaining({ action: "issue:comment" }));
+    expect(mockAccessService.decide).toHaveBeenCalledWith(expect.objectContaining({ action: "issue:mutate" }));
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+    expect(mockIssueService.addComment).not.toHaveBeenCalled();
+  });
+
+  it("does not treat manager PATCH comments as review decisions without mutation authority", async () => {
+    mockIssueService.getById.mockResolvedValue(makeIssue({ status: "in_review", assigneeAgentId: ownerAgentId }));
+    mockAccessService.decide.mockImplementation(async (input: { action: string }) => ({
+      allowed: input.action === "issue:comment",
+      action: input.action,
+      reason: input.action === "issue:comment" ? "allow_manager_comment" : "deny_missing_grant",
+      explanation:
+        input.action === "issue:comment"
+          ? "Allowed by comment-only route policy."
+          : "Missing permission.",
+    }));
+
+    const commentOnly = await request(await createApp(peerActor()))
+      .patch(`/api/issues/${issueId}`)
+      .send({ comment: "Manager non-decision note." });
+
+    expect(commentOnly.status, JSON.stringify(commentOnly.body)).toBe(200);
+    expect(mockIssueService.addComment).toHaveBeenCalledWith(
+      issueId,
+      "Manager non-decision note.",
+      expect.any(Object),
+      expect.any(Object),
+    );
+
+    mockIssueService.update.mockClear();
+    mockIssueService.addComment.mockClear();
+    mockAccessService.decide.mockClear();
+
+    const decisionAttempt = await request(await createApp(peerActor()))
+      .patch(`/api/issues/${issueId}`)
+      .send({ status: "done", comment: "Approve." });
+
+    expect(decisionAttempt.status, JSON.stringify(decisionAttempt.body)).toBe(403);
+    expect(decisionAttempt.body.error).toBe("Issue is outside this actor's authorization boundary");
+    expect(mockAccessService.decide).toHaveBeenCalledWith(expect.objectContaining({ action: "issue:comment" }));
+    expect(mockAccessService.decide).toHaveBeenCalledWith(expect.objectContaining({ action: "issue:mutate" }));
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+    expect(mockIssueService.addComment).not.toHaveBeenCalled();
   });
 
   it("denies cross-company agents before comment authorization is evaluated", async () => {

--- a/server/src/__tests__/issue-comment-reopen-routes.test.ts
+++ b/server/src/__tests__/issue-comment-reopen-routes.test.ts
@@ -1338,8 +1338,14 @@ describe.sequential("issue comment reopen routes", () => {
     );
   });
 
-  it("rejects non-assignee agent PATCH comments on closed issues", async () => {
+  it("allows mention-granted non-assignee agent PATCH comments on closed issues without reopening", async () => {
     mockIssueService.getById.mockResolvedValue(makeIssue("done"));
+    mockAccessService.decide.mockImplementation(async (input: { action?: string }) => ({
+      allowed: input.action === "issue:comment",
+      action: input.action,
+      reason: input.action === "issue:comment" ? "allow_issue_mention_grant" : "deny_missing_grant",
+      explanation: input.action === "issue:comment" ? "Allowed by mention grant." : "Missing permission.",
+    }));
     mockIssueService.addComment.mockResolvedValue({
       id: "comment-1",
       issueId: "11111111-1111-4111-8111-111111111111",
@@ -1365,8 +1371,75 @@ describe.sequential("issue comment reopen routes", () => {
       .patch("/api/issues/11111111-1111-4111-8111-111111111111")
       .send({ comment: "hello" });
 
-    expect(res.status).toBe(403);
-    expect(res.body.error).toBe("Agent cannot mutate another agent's issue");
+    // Mention-granting access is intentionally allowed here, while explicit
+    // comment-only checks must still avoid mutation authority.
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(mockIssueService.update).toHaveBeenCalledWith(
+      "11111111-1111-4111-8111-111111111111",
+      {
+        actorAgentId: "33333333-3333-4333-8333-333333333333",
+        actorUserId: null,
+      },
+    );
+    expect(mockIssueService.update).not.toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ status: expect.any(String) }),
+    );
+    expect(mockIssueService.addComment).toHaveBeenCalled();
+    expect(mockAccessService.decide).not.toHaveBeenCalledWith(expect.objectContaining({ action: "issue:mutate" }));
+    expect(mockHeartbeatService.wakeup).not.toHaveBeenCalled();
+  });
+
+  it("rejects non-mentioned non-assignee agent PATCH comments on closed issues without mutation authority", async () => {
+    mockIssueService.getById.mockResolvedValue(makeIssue("done"));
+    mockAccessService.decide.mockImplementation(async (input: { action?: string }) => ({
+      allowed: input.action === "issue:comment",
+      action: input.action,
+      reason: input.action === "issue:comment" ? "allow_issue_comment" : "deny_missing_grant",
+      explanation: input.action === "issue:comment" ? "Allowed by issue comment grant." : "Missing permission.",
+    }));
+
+    const res = await request(await installActor(createApp(), {
+      type: "agent",
+      agentId: "33333333-3333-4333-8333-333333333333",
+      companyId: "company-1",
+      source: "agent_key",
+      runId: "88888888-8888-4888-8888-888888888888",
+    }))
+      .patch("/api/issues/11111111-1111-4111-8111-111111111111")
+      .send({ comment: "hello" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(403);
+    expect(res.body.error).toBe("Issue is outside this actor's authorization boundary");
+    expect(mockAccessService.decide).toHaveBeenCalledWith(expect.objectContaining({ action: "issue:comment" }));
+    expect(mockAccessService.decide).toHaveBeenCalledWith(expect.objectContaining({ action: "issue:mutate" }));
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+    expect(mockIssueService.addComment).not.toHaveBeenCalled();
+    expect(mockHeartbeatService.wakeup).not.toHaveBeenCalled();
+  });
+
+  it("rejects unauthorized non-assignee agent PATCH comments on closed issues", async () => {
+    mockIssueService.getById.mockResolvedValue(makeIssue("done"));
+    mockAccessService.decide.mockImplementation(async (input: { action?: string }) => ({
+      allowed: input.action === "issue:read",
+      action: input.action,
+      reason: input.action === "issue:read" ? "allow_explicit_grant" : "deny_missing_grant",
+      explanation: input.action === "issue:read" ? "Allowed by test read grant." : "Missing permission.",
+    }));
+
+    const res = await request(await installActor(createApp(), {
+      type: "agent",
+      agentId: "33333333-3333-4333-8333-333333333333",
+      companyId: "company-1",
+      source: "agent_key",
+      runId: "88888888-8888-4888-8888-888888888888",
+    }))
+      .patch("/api/issues/11111111-1111-4111-8111-111111111111")
+      .send({ comment: "hello" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(403);
+    expect(res.body.error).toBe("Issue is outside this actor's authorization boundary");
+    expect(mockAccessService.decide).toHaveBeenCalledWith(expect.objectContaining({ action: "issue:comment" }));
     expect(mockIssueService.update).not.toHaveBeenCalled();
     expect(mockIssueService.addComment).not.toHaveBeenCalled();
     expect(mockHeartbeatService.wakeup).not.toHaveBeenCalled();

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -7627,7 +7627,29 @@ export function issueRoutes(
     const existing = await getAccessibleResource(req, res, svc.getById(id), "Issue not found");
     if (!existing) return;
     assertNoAgentHostWorkspaceCommandMutation(req, collectIssueWorkspaceCommandPaths(req.body));
-    if (!(await assertAgentIssueMutationAllowed(req, res, existing))) return;
+    const {
+      comment: commentBody,
+      reviewRequest,
+      reopen: reopenRequested,
+      resume: resumeRequested,
+      interrupt: interruptRequested,
+      hiddenAt: hiddenAtRaw,
+      ...updateFields
+    } = req.body;
+    const issueMutationRequested =
+      Object.keys(updateFields).length > 0 ||
+      reviewRequest !== undefined ||
+      reopenRequested === true ||
+      resumeRequested === true ||
+      interruptRequested === true ||
+      hiddenAtRaw !== undefined;
+    if (commentBody) {
+      const commentAccessDecision = await assertAgentIssueCommentAllowed(req, res, existing);
+      if (!commentAccessDecision) return;
+      if (issueMutationRequested && !(await assertAgentIssueMutationAllowed(req, res, existing))) return;
+    } else if (!(await assertAgentIssueMutationAllowed(req, res, existing))) {
+      return;
+    }
     if (!(await assertCheapRecoveryIssueAssigneeProfileAllowed(req, res, existing, req.body))) return;
 
     const actor = getActorInfo(req);
@@ -7642,15 +7664,6 @@ export function issueRoutes(
       Array.isArray(req.body.blockedByIssueIds)
         ? await svc.getRelationSummaries(existing.id)
         : null;
-    const {
-      comment: commentBody,
-      reviewRequest,
-      reopen: reopenRequested,
-      resume: resumeRequested,
-      interrupt: interruptRequested,
-      hiddenAt: hiddenAtRaw,
-      ...updateFields
-    } = req.body;
     const shouldCancelActiveRunForCancelledStatus =
       existing.status !== "cancelled" && updateFields.status === "cancelled";
     if (resumeRequested === true && !commentBody) {

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -7646,6 +7646,18 @@ export function issueRoutes(
     if (commentBody) {
       const commentAccessDecision = await assertAgentIssueCommentAllowed(req, res, existing);
       if (!commentAccessDecision) return;
+      const isClosedForCommentAuth = isClosedIssueStatus(existing.status);
+      if (
+        isClosedForCommentAuth &&
+        req.actor.type === "agent" &&
+        existing.assigneeAgentId !== null &&
+        existing.assigneeAgentId !== req.actor.agentId &&
+        !isIssueMentionGrantDecision(commentAccessDecision)
+      ) {
+        if (!(await assertAgentIssueMutationAllowed(req, res, existing))) return;
+      }
+      // Unlike POST comments, PATCH keeps mixed comment+lifecycle payloads
+      // fail-closed by requiring mutation authority instead of clamping fields.
       if (issueMutationRequested && !(await assertAgentIssueMutationAllowed(req, res, existing))) return;
     } else if (!(await assertAgentIssueMutationAllowed(req, res, existing))) {
       return;


### PR DESCRIPTION
## Thinking Path

> - The app coordinates issue work, comments, and agent activity through the server API.
> - The issue routes have separate paths for adding a comment and updating an issue with an optional comment.
> - The direct comment path already enforced a narrower comment authorization boundary.
> - The update path could reach comment creation after using mutation-oriented authorization checks.
> - This pull request makes comment-only updates reuse the same authorization semantics as direct comments.
> - The benefit is consistent fail-closed behavior without widening mutation or review-decision authority.

## Linked Issues or Issue Description

Refs #8066

Bug: issue updates that only add a comment should authorize like direct issue comments. Actors allowed to leave scoped comments should be able to do so through either API shape, while actors without comment authority must be denied and comment-bearing mutations must still require mutation authority.

## What Changed

- Shared the comment authorization path between direct comments and comment-only issue updates.
- Kept status/review-decision updates on the stricter mutation and decision authorization paths.
- Added focused regression coverage for authorized manager comments, authorized legacy creator comments, unauthorized same-organization denial, cross-organization denial, mutation non-widening, and review-decision non-widening.

## Verification

- `pnpm exec vitest run server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts`
- `pnpm --filter @paperclipai/server typecheck`

## Risks

Low risk. The change is constrained to comment-only update authorization and adds regression tests around the adjacent mutation and review-decision boundaries.

## Model Used

OpenAI GPT-5 Codex with code execution and repository tool use.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change and contains no internal ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All required CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge

