### PR TITLE
Fix React error #185 (Maximum update depth exceeded) on Issues/Inbox with default config

### DIFF
--- a/ui/src/components/IssuesList.tsx
+++ b/ui/src/components/IssuesList.tsx
@@ -85,12 +85,17 @@ import { isSuccessfulRunHandoffRequired } from "../lib/successful-run-handoff";
 import { deriveOriginatingActor, ISSUE_STATUSES, type ExecutionWorkspaceSummary, type Issue, type IssueStatus, type Project } from "@paperclipai/shared";
 import { Badge } from "@/components/ui/badge";
 
-// Stable empty-array default: a disabled/loading `executionWorkspaces` query
-// returns undefined, and a fresh `[]` literal default would give it a new
-// identity every render, churning executionWorkspaceById -> issueFilterContext
-// -> `filtered` and driving the row-limit effect into an infinite render loop
-// (React error #185). A module-level constant keeps the reference stable.
+// Stable empty-array defaults. A disabled/loading query returns `data ===
+// undefined`, and a fresh `[]` literal default would give it a new identity
+// every render, churning executionWorkspaceById -> issueFilterContext ->
+// `filtered` and driving the row-limit effect into an infinite render loop
+// (React error #185). Module-level constants keep the references stable.
+// `executionWorkspaces` is disabled whenever isolated workspaces are off
+// (the default), so it is permanently unstable without this. `searchedIssues`
+// is disabled whenever there is no active search term, which is also the
+// common default state.
 const EMPTY_EXECUTION_WORKSPACES: ExecutionWorkspaceSummary[] = [];
+const EMPTY_SEARCHED_ISSUES: Issue[] = [];
 const ISSUE_SEARCH_DEBOUNCE_MS = 250;
 const ISSUE_SEARCH_RESULT_LIMIT = 200;
 const ISSUE_BOARD_COLUMN_RESULT_LIMIT = 200;
@@ -772,7 +777,7 @@ export function IssuesList({
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [issues]);
 
-  const { data: searchedIssues = [] } = useQuery({
+  const { data: searchedIssues = EMPTY_SEARCHED_ISSUES } = useQuery({
     queryKey: [
       ...queryKeys.issues.search(selectedCompanyId!, normalizedIssueSearch, projectId),
       searchFilters ?? {},

--- a/ui/src/components/IssuesList.tsx
+++ b/ui/src/components/IssuesList.tsx
@@ -82,8 +82,15 @@ import { buildSubIssueDefaultsForViewer } from "../lib/subIssueDefaults";
 import { statusBadge } from "../lib/status-colors";
 import { workflowSort } from "../lib/workflow-sort";
 import { isSuccessfulRunHandoffRequired } from "../lib/successful-run-handoff";
-import { deriveOriginatingActor, ISSUE_STATUSES, type Issue, type IssueStatus, type Project } from "@paperclipai/shared";
+import { deriveOriginatingActor, ISSUE_STATUSES, type ExecutionWorkspaceSummary, type Issue, type IssueStatus, type Project } from "@paperclipai/shared";
 import { Badge } from "@/components/ui/badge";
+
+// Stable empty-array default: a disabled/loading `executionWorkspaces` query
+// returns undefined, and a fresh `[]` literal default would give it a new
+// identity every render, churning executionWorkspaceById -> issueFilterContext
+// -> `filtered` and driving the row-limit effect into an infinite render loop
+// (React error #185). A module-level constant keeps the reference stable.
+const EMPTY_EXECUTION_WORKSPACES: ExecutionWorkspaceSummary[] = [];
 const ISSUE_SEARCH_DEBOUNCE_MS = 250;
 const ISSUE_SEARCH_RESULT_LIMIT = 200;
 const ISSUE_BOARD_COLUMN_RESULT_LIMIT = 200;
@@ -810,7 +817,7 @@ export function IssuesList({
       placeholderData: (previousData: Issue[] | undefined) => previousData,
     })),
   });
-  const { data: executionWorkspaces = [] } = useQuery({
+  const { data: executionWorkspaces = EMPTY_EXECUTION_WORKSPACES } = useQuery({
     queryKey: selectedCompanyId
       ? queryKeys.executionWorkspaces.summaryList(selectedCompanyId)
       : ["execution-workspaces", "__disabled__"],

--- a/ui/src/components/IssuesList.tsx
+++ b/ui/src/components/IssuesList.tsx
@@ -98,12 +98,17 @@ import { taskDateGroup, taskDateGroupSeparator, type TaskDateGroup } from "../li
 import { deriveOriginatingActor, ISSUE_STATUSES, type ExecutionWorkspaceSummary, type Issue, type IssueStatus, type Project } from "@paperclipai/shared";
 import { Badge } from "@/components/ui/badge";
 
-// Stable empty-array default: a disabled/loading `executionWorkspaces` query
-// returns undefined, and a fresh `[]` literal default would give it a new
-// identity every render, churning executionWorkspaceById -> issueFilterContext
-// -> `filtered` and driving the row-limit effect into an infinite render loop
-// (React error #185). A module-level constant keeps the reference stable.
+// Stable empty-array defaults. A disabled/loading query returns `data ===
+// undefined`, and a fresh `[]` literal default would give it a new identity
+// every render, churning executionWorkspaceById -> issueFilterContext ->
+// `filtered` and driving the row-limit effect into an infinite render loop
+// (React error #185). Module-level constants keep the references stable.
+// `executionWorkspaces` is disabled whenever isolated workspaces are off
+// (the default), so it is permanently unstable without this. `searchedIssues`
+// is disabled whenever there is no active search term, which is also the
+// common default state.
 const EMPTY_EXECUTION_WORKSPACES: ExecutionWorkspaceSummary[] = [];
+const EMPTY_SEARCHED_ISSUES: Issue[] = [];
 const ISSUE_SEARCH_DEBOUNCE_MS = 250;
 const ISSUE_SEARCH_RESULT_LIMIT = 200;
 const ISSUE_BOARD_COLUMN_RESULT_LIMIT = 200;
@@ -876,7 +881,7 @@ function StreamlinedIssuesList({
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [issues]);
 
-  const { data: searchedIssues = [] } = useQuery({
+  const { data: searchedIssues = EMPTY_SEARCHED_ISSUES } = useQuery({
     queryKey: [
       ...queryKeys.issues.search(selectedCompanyId!, normalizedIssueSearch, projectId),
       searchFilters ?? {},

--- a/ui/src/components/IssuesList.tsx
+++ b/ui/src/components/IssuesList.tsx
@@ -95,8 +95,15 @@ import {
   type TaskCollectionPreferenceLocation,
 } from "../lib/task-collection-preferences";
 import { taskDateGroup, taskDateGroupSeparator, type TaskDateGroup } from "../lib/task-date-groups";
-import { deriveOriginatingActor, ISSUE_STATUSES, type Issue, type IssueStatus, type Project } from "@paperclipai/shared";
+import { deriveOriginatingActor, ISSUE_STATUSES, type ExecutionWorkspaceSummary, type Issue, type IssueStatus, type Project } from "@paperclipai/shared";
 import { Badge } from "@/components/ui/badge";
+
+// Stable empty-array default: a disabled/loading `executionWorkspaces` query
+// returns undefined, and a fresh `[]` literal default would give it a new
+// identity every render, churning executionWorkspaceById -> issueFilterContext
+// -> `filtered` and driving the row-limit effect into an infinite render loop
+// (React error #185). A module-level constant keeps the reference stable.
+const EMPTY_EXECUTION_WORKSPACES: ExecutionWorkspaceSummary[] = [];
 const ISSUE_SEARCH_DEBOUNCE_MS = 250;
 const ISSUE_SEARCH_RESULT_LIMIT = 200;
 const ISSUE_BOARD_COLUMN_RESULT_LIMIT = 200;
@@ -914,7 +921,7 @@ function StreamlinedIssuesList({
       placeholderData: (previousData: Issue[] | undefined) => previousData,
     })),
   });
-  const { data: executionWorkspaces = [] } = useQuery({
+  const { data: executionWorkspaces = EMPTY_EXECUTION_WORKSPACES } = useQuery({
     queryKey: selectedCompanyId
       ? queryKeys.executionWorkspaces.summaryList(selectedCompanyId)
       : ["execution-workspaces", "__disabled__"],

--- a/ui/src/pages/Inbox.tsx
+++ b/ui/src/pages/Inbox.tsx
@@ -4,7 +4,7 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { deriveOriginatingActor, INBOX_MINE_ISSUE_STATUS_FILTER } from "@paperclipai/shared";
 import { usePublishSharedQueryData, useSharedPollingQuery } from "@/hooks/useSharedPolling";
 import { approvalsApi } from "../api/approvals";
-import { accessApi } from "../api/access";
+import { accessApi, type CompanyJoinRequest } from "../api/access";
 import { authApi } from "../api/auth";
 import { ApiError } from "../api/client";
 import { dashboardApi } from "../api/dashboard";
@@ -177,6 +177,11 @@ import { useDismissedInboxAlerts, useInboxDismissals, useReadInboxItems } from "
 // memo chain settles.
 const EMPTY_EXECUTION_WORKSPACES: ExecutionWorkspaceSummary[] = [];
 const EMPTY_ISSUES: Issue[] = [];
+// joinRequests feeds the same groupedSections -> flatNavItems chain via
+// joinRequestsForTab -> workItemsToRender. The query is always enabled, so
+// this instability is transient (it settles once the first response lands),
+// but it churns the same way during that initial-load window.
+const EMPTY_JOIN_REQUESTS: CompanyJoinRequest[] = [];
 
 const INBOX_HEARTBEAT_RUN_LIMIT = 200;
 const INBOX_ISSUE_LIST_LIMIT = 500;
@@ -813,7 +818,7 @@ export function Inbox() {
   });
 
   const {
-    data: joinRequests = [],
+    data: joinRequests = EMPTY_JOIN_REQUESTS,
     isLoading: isJoinRequestsLoading,
   } = useQuery({
     queryKey: queryKeys.access.joinRequests(selectedCompanyId!),

--- a/ui/src/pages/Inbox.tsx
+++ b/ui/src/pages/Inbox.tsx
@@ -118,7 +118,7 @@ import {
 } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { PageTabBar } from "../components/PageTabBar";
-import type { Approval, HeartbeatRun, Issue, JoinRequest } from "@paperclipai/shared";
+import type { Approval, ExecutionWorkspaceSummary, HeartbeatRun, Issue, JoinRequest } from "@paperclipai/shared";
 import {
   ACTIONABLE_APPROVAL_STATUSES,
   DEFAULT_INBOX_ISSUE_COLUMNS,
@@ -167,6 +167,16 @@ import {
   type InboxWorkItemGroupBy,
 } from "../lib/inbox";
 import { useDismissedInboxAlerts, useInboxDismissals, useReadInboxItems } from "../hooks/useInboxBadge";
+
+// Stable empty-array defaults. A `const { data = [] }` from a disabled or
+// still-loading useQuery hands back a FRESH `[]` on every render (data is
+// undefined), giving derived memos a new identity each render. In Inbox those
+// memos feed `groupedSections` -> `flatNavItems`, whose effect calls
+// setSelectedIndex every render -> infinite render loop crashing the page with
+// React error #185. Module-level constants keep the references stable so the
+// memo chain settles.
+const EMPTY_EXECUTION_WORKSPACES: ExecutionWorkspaceSummary[] = [];
+const EMPTY_ISSUES: Issue[] = [];
 
 const INBOX_HEARTBEAT_RUN_LIMIT = 200;
 const INBOX_ISSUE_LIST_LIMIT = 500;
@@ -765,7 +775,7 @@ export function Inbox() {
   });
   const isolatedWorkspacesEnabled = experimentalSettings?.enableIsolatedWorkspaces === true;
   const externalObjectsEnabled = experimentalSettings?.enableExternalObjects === true;
-  const { data: executionWorkspaces = [] } = useQuery({
+  const { data: executionWorkspaces = EMPTY_EXECUTION_WORKSPACES } = useQuery({
     queryKey: selectedCompanyId
       ? queryKeys.executionWorkspaces.summaryList(selectedCompanyId)
       : ["execution-workspaces", "__disabled__"],
@@ -856,7 +866,7 @@ export function Inbox() {
   });
   usePublishSharedQueryData(sharedInboxIssues, issues, issuesUpdatedAt);
   const {
-    data: mineIssuesRaw = [],
+    data: mineIssuesRaw = EMPTY_ISSUES,
     isLoading: isMineIssuesLoading,
     dataUpdatedAt: mineIssuesUpdatedAt,
   } = useQuery({
@@ -883,7 +893,7 @@ export function Inbox() {
   });
   usePublishSharedQueryData(sharedMineIssues, mineIssuesRaw, mineIssuesUpdatedAt);
   const {
-    data: touchedIssuesRaw = [],
+    data: touchedIssuesRaw = EMPTY_ISSUES,
     isLoading: isTouchedIssuesLoading,
     dataUpdatedAt: touchedIssuesUpdatedAt,
   } = useQuery({
@@ -955,7 +965,7 @@ export function Inbox() {
   const shouldUseIssueSearchSupplement =
     !!selectedCompanyId
     && normalizedSearchQuery.length > 0;
-  const { data: remoteIssueSearchResults = [] } = useQuery({
+  const { data: remoteIssueSearchResults = EMPTY_ISSUES } = useQuery({
     queryKey: [
       ...queryKeys.issues.search(selectedCompanyId!, normalizedSearchQuery, undefined, 25),
       "compact",

--- a/ui/src/pages/Inbox.tsx
+++ b/ui/src/pages/Inbox.tsx
@@ -4,7 +4,7 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { deriveOriginatingActor, INBOX_MINE_ISSUE_STATUS_FILTER } from "@paperclipai/shared";
 import { usePublishSharedQueryData, useSharedPollingQuery } from "@/hooks/useSharedPolling";
 import { approvalsApi } from "../api/approvals";
-import { accessApi } from "../api/access";
+import { accessApi, type CompanyJoinRequest } from "../api/access";
 import { authApi } from "../api/auth";
 import { ApiError } from "../api/client";
 import { dashboardApi } from "../api/dashboard";
@@ -198,6 +198,11 @@ import {
 // memo chain settles.
 const EMPTY_EXECUTION_WORKSPACES: ExecutionWorkspaceSummary[] = [];
 const EMPTY_ISSUES: Issue[] = [];
+// joinRequests feeds the same groupedSections -> flatNavItems chain via
+// joinRequestsForTab -> workItemsToRender. The query is always enabled, so
+// this instability is transient (it settles once the first response lands),
+// but it churns the same way during that initial-load window.
+const EMPTY_JOIN_REQUESTS: CompanyJoinRequest[] = [];
 
 const INBOX_HEARTBEAT_RUN_LIMIT = 200;
 const INBOX_ISSUE_LIST_LIMIT = 500;
@@ -921,7 +926,7 @@ function StreamlinedInbox() {
   });
 
   const {
-    data: joinRequests = [],
+    data: joinRequests = EMPTY_JOIN_REQUESTS,
     isLoading: isJoinRequestsLoading,
   } = useQuery({
     queryKey: queryKeys.access.joinRequests(selectedCompanyId!),

--- a/ui/src/pages/Inbox.tsx
+++ b/ui/src/pages/Inbox.tsx
@@ -123,7 +123,7 @@ import {
 } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { PageTabBar } from "../components/PageTabBar";
-import type { Approval, HeartbeatRun, Issue, JoinRequest } from "@paperclipai/shared";
+import type { Approval, ExecutionWorkspaceSummary, HeartbeatRun, Issue, JoinRequest } from "@paperclipai/shared";
 import {
   ACTIONABLE_APPROVAL_STATUSES,
   DEFAULT_INBOX_ISSUE_COLUMNS,
@@ -188,6 +188,16 @@ import {
   taskDateGroupSeparator,
   type TaskDateGroup,
 } from "../lib/task-date-groups";
+
+// Stable empty-array defaults. A `const { data = [] }` from a disabled or
+// still-loading useQuery hands back a FRESH `[]` on every render (data is
+// undefined), giving derived memos a new identity each render. In Inbox those
+// memos feed `groupedSections` -> `flatNavItems`, whose effect calls
+// setSelectedIndex every render -> infinite render loop crashing the page with
+// React error #185. Module-level constants keep the references stable so the
+// memo chain settles.
+const EMPTY_EXECUTION_WORKSPACES: ExecutionWorkspaceSummary[] = [];
+const EMPTY_ISSUES: Issue[] = [];
 
 const INBOX_HEARTBEAT_RUN_LIMIT = 200;
 const INBOX_ISSUE_LIST_LIMIT = 500;
@@ -870,7 +880,7 @@ function StreamlinedInbox() {
   });
   const isolatedWorkspacesEnabled = experimentalSettings?.enableIsolatedWorkspaces === true;
   const externalObjectsEnabled = experimentalSettings?.enableExternalObjects === true;
-  const { data: executionWorkspaces = [] } = useQuery({
+  const { data: executionWorkspaces = EMPTY_EXECUTION_WORKSPACES } = useQuery({
     queryKey: selectedCompanyId
       ? queryKeys.executionWorkspaces.summaryList(selectedCompanyId)
       : ["execution-workspaces", "__disabled__"],
@@ -964,7 +974,7 @@ function StreamlinedInbox() {
   });
   usePublishSharedQueryData(sharedInboxIssues, issues, issuesUpdatedAt);
   const {
-    data: mineIssuesRaw = [],
+    data: mineIssuesRaw = EMPTY_ISSUES,
     isLoading: isMineIssuesLoading,
     dataUpdatedAt: mineIssuesUpdatedAt,
   } = useQuery({
@@ -991,7 +1001,7 @@ function StreamlinedInbox() {
   });
   usePublishSharedQueryData(sharedMineIssues, mineIssuesRaw, mineIssuesUpdatedAt);
   const {
-    data: touchedIssuesRaw = [],
+    data: touchedIssuesRaw = EMPTY_ISSUES,
     isLoading: isTouchedIssuesLoading,
     dataUpdatedAt: touchedIssuesUpdatedAt,
   } = useQuery({
@@ -1079,7 +1089,7 @@ function StreamlinedInbox() {
   const shouldUseIssueSearchSupplement =
     !!selectedCompanyId
     && normalizedSearchQuery.length > 0;
-  const { data: remoteIssueSearchResults = [] } = useQuery({
+  const { data: remoteIssueSearchResults = EMPTY_ISSUES } = useQuery({
     queryKey: [
       ...queryKeys.issues.search(selectedCompanyId!, normalizedSearchQuery, undefined, 25),
       "compact",

--- a/ui/src/pages/stable-issue-query-defaults.regression.test.ts
+++ b/ui/src/pages/stable-issue-query-defaults.regression.test.ts
@@ -1,0 +1,75 @@
+// @vitest-environment node
+
+/**
+ * Regression guard for React error #185 ("Maximum update depth exceeded")
+ * on the Issues/Tasks and Inbox pages.
+ *
+ * Root cause: `const { data: foo = [] } = useQuery(...)` re-evaluates the
+ * `[]` literal on every render whenever `data` is `undefined` (a disabled
+ * or still-loading query), handing derived useMemo/useEffect chains a new
+ * array identity each render. On a default-config install (isolated
+ * workspaces off), executionWorkspaces is permanently *disabled*, and
+ * remoteIssueSearchResults is disabled until a search query is typed, so
+ * both permanently return this unstable default — churning
+ * filtered/groupedSections/flatNavItems and re-firing the row-limit /
+ * selection effects that depend on them every render.
+ *
+ * The fix is a stable module-level empty-array constant per file
+ * (EMPTY_EXECUTION_WORKSPACES / EMPTY_ISSUES) used as the useQuery
+ * default instead of an inline `[]` literal.
+ *
+ * The runtime consequence (the render-loop crash itself) needs multiple
+ * queries settling in the same synchronous update batch — a timing
+ * condition this project's jsdom/vitest render harness does not
+ * reproduce deterministically (confirmed while developing this fix: an
+ * end-to-end Inbox render with these queries permanently disabled showed
+ * identical React Profiler commit counts and identical
+ * buildInboxKeyboardNavEntries call counts with and without the fix,
+ * because vitest's mocked queries settle synchronously within a single
+ * `act()` flush rather than racing like real network/WebSocket
+ * responses). So this guard checks the fix at the source level instead:
+ * it fails if either file reintroduces a raw `= []` default for one of
+ * the five known query results that feed this crash, and it fails if the
+ * stable replacement constants are removed or stop being used.
+ */
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+function readSource(relativePath: string): string {
+  return readFileSync(join(here, relativePath), "utf8");
+}
+
+describe("stable useQuery defaults (regression guard for React error #185)", () => {
+  it("IssuesList.tsx does not default executionWorkspaces to a raw [] literal", () => {
+    const source = readSource("../components/IssuesList.tsx");
+
+    expect(source).not.toMatch(/data:\s*executionWorkspaces\s*=\s*\[\]/);
+    expect(source).toMatch(
+      /const EMPTY_EXECUTION_WORKSPACES:\s*ExecutionWorkspaceSummary\[\]\s*=\s*\[\];/,
+    );
+    expect(source).toMatch(/data:\s*executionWorkspaces\s*=\s*EMPTY_EXECUTION_WORKSPACES/);
+  });
+
+  it("Inbox.tsx does not default executionWorkspaces/mineIssuesRaw/touchedIssuesRaw/remoteIssueSearchResults to raw [] literals", () => {
+    const source = readSource("./Inbox.tsx");
+
+    expect(source).not.toMatch(/data:\s*executionWorkspaces\s*=\s*\[\]/);
+    expect(source).not.toMatch(/data:\s*mineIssuesRaw\s*=\s*\[\]/);
+    expect(source).not.toMatch(/data:\s*touchedIssuesRaw\s*=\s*\[\]/);
+    expect(source).not.toMatch(/data:\s*remoteIssueSearchResults\s*=\s*\[\]/);
+
+    expect(source).toMatch(
+      /const EMPTY_EXECUTION_WORKSPACES:\s*ExecutionWorkspaceSummary\[\]\s*=\s*\[\];/,
+    );
+    expect(source).toMatch(/const EMPTY_ISSUES:\s*Issue\[\]\s*=\s*\[\];/);
+
+    expect(source).toMatch(/data:\s*executionWorkspaces\s*=\s*EMPTY_EXECUTION_WORKSPACES/);
+    expect(source).toMatch(/data:\s*mineIssuesRaw\s*=\s*EMPTY_ISSUES/);
+    expect(source).toMatch(/data:\s*touchedIssuesRaw\s*=\s*EMPTY_ISSUES/);
+    expect(source).toMatch(/data:\s*remoteIssueSearchResults\s*=\s*EMPTY_ISSUES/);
+  });
+});

--- a/ui/src/pages/stable-issue-query-defaults.regression.test.ts
+++ b/ui/src/pages/stable-issue-query-defaults.regression.test.ts
@@ -9,14 +9,17 @@
  * or still-loading query), handing derived useMemo/useEffect chains a new
  * array identity each render. On a default-config install (isolated
  * workspaces off), executionWorkspaces is permanently *disabled*, and
- * remoteIssueSearchResults is disabled until a search query is typed, so
- * both permanently return this unstable default — churning
+ * remoteIssueSearchResults/searchedIssues are disabled until a search query
+ * is typed, so these permanently return this unstable default — churning
  * filtered/groupedSections/flatNavItems and re-firing the row-limit /
- * selection effects that depend on them every render.
+ * selection effects that depend on them every render. joinRequests is
+ * always enabled and eventually settles, but churns the same chain during
+ * the initial-load window before it does.
  *
  * The fix is a stable module-level empty-array constant per file
- * (EMPTY_EXECUTION_WORKSPACES / EMPTY_ISSUES) used as the useQuery
- * default instead of an inline `[]` literal.
+ * (EMPTY_EXECUTION_WORKSPACES / EMPTY_ISSUES / EMPTY_SEARCHED_ISSUES /
+ * EMPTY_JOIN_REQUESTS) used as the useQuery default instead of an inline
+ * `[]` literal.
  *
  * The runtime consequence (the render-loop crash itself) needs multiple
  * queries settling in the same synchronous update batch — a timing
@@ -29,7 +32,7 @@
  * `act()` flush rather than racing like real network/WebSocket
  * responses). So this guard checks the fix at the source level instead:
  * it fails if either file reintroduces a raw `= []` default for one of
- * the five known query results that feed this crash, and it fails if the
+ * the seven known query results that feed this crash, and it fails if the
  * stable replacement constants are removed or stop being used.
  */
 import { readFileSync } from "node:fs";
@@ -44,32 +47,40 @@ function readSource(relativePath: string): string {
 }
 
 describe("stable useQuery defaults (regression guard for React error #185)", () => {
-  it("IssuesList.tsx does not default executionWorkspaces to a raw [] literal", () => {
+  it("IssuesList.tsx does not default executionWorkspaces/searchedIssues to raw [] literals", () => {
     const source = readSource("../components/IssuesList.tsx");
 
     expect(source).not.toMatch(/data:\s*executionWorkspaces\s*=\s*\[\]/);
+    expect(source).not.toMatch(/data:\s*searchedIssues\s*=\s*\[\]/);
+
     expect(source).toMatch(
       /const EMPTY_EXECUTION_WORKSPACES:\s*ExecutionWorkspaceSummary\[\]\s*=\s*\[\];/,
     );
+    expect(source).toMatch(/const EMPTY_SEARCHED_ISSUES:\s*Issue\[\]\s*=\s*\[\];/);
+
     expect(source).toMatch(/data:\s*executionWorkspaces\s*=\s*EMPTY_EXECUTION_WORKSPACES/);
+    expect(source).toMatch(/data:\s*searchedIssues\s*=\s*EMPTY_SEARCHED_ISSUES/);
   });
 
-  it("Inbox.tsx does not default executionWorkspaces/mineIssuesRaw/touchedIssuesRaw/remoteIssueSearchResults to raw [] literals", () => {
+  it("Inbox.tsx does not default executionWorkspaces/mineIssuesRaw/touchedIssuesRaw/remoteIssueSearchResults/joinRequests to raw [] literals", () => {
     const source = readSource("./Inbox.tsx");
 
     expect(source).not.toMatch(/data:\s*executionWorkspaces\s*=\s*\[\]/);
     expect(source).not.toMatch(/data:\s*mineIssuesRaw\s*=\s*\[\]/);
     expect(source).not.toMatch(/data:\s*touchedIssuesRaw\s*=\s*\[\]/);
     expect(source).not.toMatch(/data:\s*remoteIssueSearchResults\s*=\s*\[\]/);
+    expect(source).not.toMatch(/data:\s*joinRequests\s*=\s*\[\]/);
 
     expect(source).toMatch(
       /const EMPTY_EXECUTION_WORKSPACES:\s*ExecutionWorkspaceSummary\[\]\s*=\s*\[\];/,
     );
     expect(source).toMatch(/const EMPTY_ISSUES:\s*Issue\[\]\s*=\s*\[\];/);
+    expect(source).toMatch(/const EMPTY_JOIN_REQUESTS:\s*CompanyJoinRequest\[\]\s*=\s*\[\];/);
 
     expect(source).toMatch(/data:\s*executionWorkspaces\s*=\s*EMPTY_EXECUTION_WORKSPACES/);
     expect(source).toMatch(/data:\s*mineIssuesRaw\s*=\s*EMPTY_ISSUES/);
     expect(source).toMatch(/data:\s*touchedIssuesRaw\s*=\s*EMPTY_ISSUES/);
     expect(source).toMatch(/data:\s*remoteIssueSearchResults\s*=\s*EMPTY_ISSUES/);
+    expect(source).toMatch(/data:\s*joinRequests\s*=\s*EMPTY_JOIN_REQUESTS/);
   });
 });


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The Issues/Tasks and Inbox pages are the primary daily-driver surfaces for managing that work, built on `useQuery` from `@tanstack/react-query` feeding memoized nav/filter chains
> - Both pages default several `useQuery` results to an inline `[]` literal (`const { data: foo = [] } = useQuery(...)`), which is re-evaluated to a brand-new array reference on every render whenever the query is disabled or still loading
> - On any default-config install (isolated workspaces off, the out-of-the-box setting), `executionWorkspaces` is permanently disabled and `remoteIssueSearchResults` is permanently disabled until a search is typed, so this unstable reference feeds the `filtered`/`groupedSections`/`flatNavItems` memo chains forever, which keeps re-firing the row-limit and selection effects that depend on them and can trip React error #185 ("Maximum update depth exceeded")
> - This pull request replaces the inline `[]` defaults with module-level stable constants (`EMPTY_EXECUTION_WORKSPACES`, `EMPTY_ISSUES`) in both files
> - The benefit is Issues/Tasks and Inbox no longer carry a standing crash risk on the default configuration, with no behavioral change to what's rendered

## Linked Issues or Issue Description

No existing public issue tracks this exact bug. Filing per the bug report template:

**What happened?** The Issues/Tasks list and Inbox pages can crash with React minified error #185 ("Maximum update depth exceeded") on a default-configuration install (isolated workspaces feature flag off, which is the out-of-the-box default).

**Expected behavior:** Issues/Tasks and Inbox render normally regardless of the isolated-workspaces setting.

**Steps to reproduce:**
1. Run Paperclip with a fresh/default instance config (isolated workspaces off).
2. Navigate to the Issues/Tasks page or the Inbox page.
3. Under load (multiple queries settling close together, e.g. shortly after sign-in with live agent activity), the page can throw React error #185 and render the error boundary.

Root cause detail is in "What Changed" below.

Refs: #6195 — a different, unrelated cause (a specific `_pcpPatch` breaking Web UI auth) that happened to also surface as React error #185; noting it here since it turned up in the duplicate search, not because it's the same bug.

## What Changed

- `ui/src/components/IssuesList.tsx`: added a module-level `EMPTY_EXECUTION_WORKSPACES: ExecutionWorkspaceSummary[] = []` constant and used it as the `useQuery` default for `executionWorkspaces` instead of an inline `[]` literal.
- `ui/src/pages/Inbox.tsx`: added module-level `EMPTY_EXECUTION_WORKSPACES` and `EMPTY_ISSUES: Issue[] = []` constants and used them as the `useQuery` defaults for `executionWorkspaces`, `mineIssuesRaw`, `touchedIssuesRaw`, and `remoteIssueSearchResults` instead of inline `[]` literals.
- `ui/src/pages/stable-issue-query-defaults.regression.test.ts` (new): a source-level regression guard — see "Verification" for why it's source-level rather than a full render/crash repro.

This is a pure reference-identity fix. Every consumer still receives an empty array when the query has no data; only the object identity is now stable across renders instead of being reallocated every time.

## Verification

- `pnpm --filter @paperclipai/ui exec tsc -b` — clean.
- `pnpm --filter @paperclipai/ui exec vitest run src/pages/Inbox.test.tsx src/components/IssuesList.test.tsx src/pages/stable-issue-query-defaults.regression.test.ts` — 52/52 pass.
- I confirmed the existing `IssuesList.test.tsx`/`Inbox.test.tsx` suites are behavior-neutral for this change (identical pass/fail results before and after).
- I attempted a full render-based regression test (render Inbox with the flag off, assert no "Maximum update depth exceeded"). I could not make it discriminate between the buggy and fixed code in this project's jsdom/vitest harness: I instrumented both a `<Profiler>` commit counter and a call-count/identity spy on `buildInboxKeyboardNavEntries` (the function that consumes `groupedSections`, the direct input to the crashing effect), covering both a "mount with several queries permanently disabled" scenario and a "force an unrelated re-render after mount" scenario. In every case, the patched and unpatched code produced identical commit counts / call counts / referential-identity results. The real crash needs several queries to settle within the same synchronous React update batch — a timing condition that doesn't occur with vitest's mocked queries, which resolve deterministically inside a single `act()` flush rather than racing like real network/WebSocket traffic. Given that, `stable-issue-query-defaults.regression.test.ts` instead asserts the fix at the source level (no raw `= []` default for any of the five affected query results, and the named stable constants are declared and used). I verified this test fails against the pre-fix source and passes against the fix, so it will catch a regression if the pattern is reintroduced.

## Risks

Low risk. The change only swaps an inline empty-array literal for a module-level constant empty array used in the exact same position (a `useQuery` destructure default); the value observed by every consumer is unchanged (still an empty array whenever the query has no data). No migration, no API, no behavioral branch touched.

## Model Used

Claude (Anthropic), model id `claude-sonnet-5` (Sonnet 5), standard reasoning mode, agentic tool use (file read/edit, local shell for install/build/test, `gh` CLI for repo search and PR management). No extended/chain-of-thought mode exposed to the harness beyond the model's default reasoning.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
