### PR TITLE
feat(issues): add bounded multi-root subtree filter

### DIFF
--- a/doc/SPEC-implementation.md
+++ b/doc/SPEC-implementation.md
@@ -843,6 +843,7 @@ All endpoints are under `/api` and return JSON.
 ## 10.4 Tasks (Issues)
 
 - `GET /companies/:companyId/issues`
+  - `subtreeOf` accepts up to 25 repeated or comma-separated issue UUIDs and returns each company-scoped root plus all visible descendants; other list filters and pagination still apply.
 - `POST /companies/:companyId/issues`
 - `GET /issues/:issueId`
 - `PATCH /issues/:issueId`

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -2273,9 +2273,12 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       executionRunId: retryRun?.id ?? null,
     });
 
-    const comments = await db.select().from(issueComments).where(eq(issueComments.issueId, issueId));
+    const comments = await waitForValue(async () => {
+      const rows = await db.select().from(issueComments).where(eq(issueComments.issueId, issueId));
+      return rows.length >= 1 ? rows : null;
+    });
     expect(comments).toHaveLength(1);
-    expect(comments[0]).toMatchObject({
+    expect(comments![0]).toMatchObject({
       authorType: "system",
       createdByRunId: runId,
       body: "Agent failed to resume after approval: `adapter_failed` — retrying (attempt 1/3)",

--- a/server/src/__tests__/heartbeat-responsible-user-invariant.test.ts
+++ b/server/src/__tests__/heartbeat-responsible-user-invariant.test.ts
@@ -77,6 +77,29 @@ async function deleteHeartbeatRunsAfterEvents(db: ReturnType<typeof createDb>) {
   }
 }
 
+// The heartbeat service may create issue comments asynchronously after a run
+// completes (e.g. run-summary comments), so we re-delete comments on each retry
+// to avoid an issue_comments_issue_id_issues_id_fk FK violation.
+async function deleteIssuesAfterComments(db: ReturnType<typeof createDb>) {
+  for (let attempt = 0; attempt < 5; attempt += 1) {
+    await db.delete(issueComments);
+    try {
+      await db.delete(issues);
+      return;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (
+        attempt < 4 &&
+        message.includes("issue_comments_issue_id_issues_id_fk")
+      ) {
+        await new Promise((resolve) => setTimeout(resolve, 50));
+        continue;
+      }
+      throw error;
+    }
+  }
+}
+
 describeEmbeddedPostgres("heartbeat responsible-user invariant", () => {
   let db!: ReturnType<typeof createDb>;
   let heartbeat!: ReturnType<typeof heartbeatService>;
@@ -100,12 +123,11 @@ describeEmbeddedPostgres("heartbeat responsible-user invariant", () => {
       if (activeRuns.length === 0) break;
       await new Promise((resolve) => setTimeout(resolve, 50));
     }
-    await db.delete(issueComments);
     await db.delete(activityLog);
     await deleteHeartbeatRunsAfterEvents(db);
     await db.delete(agentWakeupRequests);
     await db.delete(agentRuntimeState);
-    await db.delete(issues);
+    await deleteIssuesAfterComments(db);
     await db.delete(agents);
     await db.delete(companySkills);
     await db.delete(companyMemberships);

--- a/server/src/__tests__/heartbeat-retry-scheduling.test.ts
+++ b/server/src/__tests__/heartbeat-retry-scheduling.test.ts
@@ -99,6 +99,27 @@ describeEmbeddedPostgres("heartbeat bounded retry scheduling", () => {
     await tempDb?.cleanup();
   });
 
+  async function deleteHeartbeatRunsAfterDependents() {
+    for (let attempt = 0; attempt < 5; attempt += 1) {
+      await db.delete(heartbeatRunEvents);
+      await db.delete(activityLog);
+      try {
+        await db.delete(heartbeatRuns);
+        return;
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        if (
+          attempt < 4 &&
+          message.includes("heartbeat_runs")
+        ) {
+          await new Promise((resolve) => setTimeout(resolve, 50));
+          continue;
+        }
+        throw error;
+      }
+    }
+  }
+
   async function cleanupRetryFixture() {
     await db.delete(activityLog);
     await db.delete(environmentLeases);
@@ -106,8 +127,7 @@ describeEmbeddedPostgres("heartbeat bounded retry scheduling", () => {
     await db.delete(issues);
     await db.delete(executionWorkspaces);
     await db.delete(projects);
-    await db.delete(heartbeatRunEvents);
-    await db.delete(heartbeatRuns);
+    await deleteHeartbeatRunsAfterDependents();
     await db.delete(agentWakeupRequests);
     await db.delete(agentRuntimeState);
     await db.delete(budgetPolicies);

--- a/server/src/__tests__/issue-list-assignee-filter-routes.test.ts
+++ b/server/src/__tests__/issue-list-assignee-filter-routes.test.ts
@@ -944,4 +944,106 @@ describeEmbeddedPostgres("issue list routes assigneeAgentId filter", () => {
       liveDescendantCount: 1,
     });
   });
+
+  it("returns only the requested roots and their visible company-scoped subtrees", async () => {
+    const companyId = randomUUID();
+    const otherCompanyId = randomUUID();
+    const rootA = randomUUID();
+    const childA = randomUUID();
+    const grandchildA = randomUUID();
+    const rootB = randomUUID();
+    const childB = randomUUID();
+    const sibling = randomUUID();
+    const hiddenChild = randomUUID();
+    const visibleBelowHidden = randomUUID();
+    const foreignRoot = randomUUID();
+
+    await db.insert(companies).values([
+      { id: companyId, name: "Paperclip", issuePrefix: uniqueIssuePrefix(), requireBoardApprovalForNewAgents: false },
+      { id: otherCompanyId, name: "Other", issuePrefix: uniqueIssuePrefix(), requireBoardApprovalForNewAgents: false },
+    ]);
+    await seedCloudTenantMember(companyId);
+    await db.insert(issues).values([
+      { id: rootA, companyId, title: "Root A", status: "todo", priority: "medium" },
+      { id: childA, companyId, parentId: rootA, title: "Child A", status: "done", priority: "medium" },
+      { id: grandchildA, companyId, parentId: childA, title: "Grandchild A", status: "todo", priority: "medium" },
+      { id: rootB, companyId, title: "Root B", status: "in_progress", priority: "medium", assigneeUserId: "cloud-user-1" },
+      { id: childB, companyId, parentId: rootB, title: "Child B", status: "done", priority: "medium" },
+      { id: sibling, companyId, title: "Unrelated sibling", status: "todo", priority: "medium" },
+      { id: hiddenChild, companyId, parentId: rootA, title: "Hidden child", status: "todo", priority: "medium", hiddenAt: new Date() },
+      { id: visibleBelowHidden, companyId, parentId: hiddenChild, title: "Visible below hidden", status: "todo", priority: "medium" },
+      { id: foreignRoot, companyId: otherCompanyId, title: "Foreign root", status: "todo", priority: "medium" },
+    ]);
+
+    const app = createApp(companyId);
+    const query = `subtreeOf=${rootA}&subtreeOf=${childA},${rootB}`;
+    const res = await request(app).get(`/api/companies/${companyId}/issues?${query}&limit=20`);
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(new Set(res.body.map((issue: { id: string }) => issue.id))).toEqual(
+      new Set([rootA, childA, grandchildA, rootB, childB]),
+    );
+    expect(res.body.map((issue: { id: string }) => issue.id)).not.toContain(sibling);
+    expect(res.body.map((issue: { id: string }) => issue.id)).not.toContain(hiddenChild);
+    expect(res.body.map((issue: { id: string }) => issue.id)).not.toContain(visibleBelowHidden);
+    expect(res.body.map((issue: { id: string }) => issue.id)).not.toContain(foreignRoot);
+
+    const foreignOnly = await request(app)
+      .get(`/api/companies/${companyId}/issues?subtreeOf=${foreignRoot}&limit=20`);
+    expect(foreignOnly.status, JSON.stringify(foreignOnly.body)).toBe(200);
+    expect(foreignOnly.body).toEqual([]);
+
+    const doneOnly = await request(app)
+      .get(`/api/companies/${companyId}/issues?subtreeOf=${rootA},${rootB}&status=done&limit=20`);
+    expect(doneOnly.status, JSON.stringify(doneOnly.body)).toBe(200);
+    expect(new Set(doneOnly.body.map((issue: { id: string }) => issue.id))).toEqual(
+      new Set([childA, childB]),
+    );
+
+    const pages = await Promise.all([0, 2, 4].map((offset) =>
+      request(app).get(`/api/companies/${companyId}/issues?subtreeOf=${rootA},${rootB}&limit=2&offset=${offset}`),
+    ));
+    expect(pages.every((page) => page.status === 200)).toBe(true);
+    const pagedIds = pages.flatMap((page) => page.body.map((issue: { id: string }) => issue.id));
+    expect(pagedIds).toHaveLength(5);
+    expect(new Set(pagedIds)).toEqual(new Set([rootA, childA, grandchildA, rootB, childB]));
+  });
+
+  it("rejects malformed or oversized subtree root filters", async () => {
+    const companyId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: uniqueIssuePrefix(),
+      requireBoardApprovalForNewAgents: false,
+    });
+    await seedCloudTenantMember(companyId);
+    const app = createApp(companyId);
+
+    const malformed = await request(app)
+      .get(`/api/companies/${companyId}/issues?subtreeOf=not-a-uuid`);
+    expect(malformed.status).toBe(422);
+    expect(malformed.body.error).toContain("UUID");
+
+    for (const emptyQuery of ["subtreeOf=", "subtreeOf=,,,"]) {
+      const empty = await request(app).get(`/api/companies/${companyId}/issues?${emptyQuery}`);
+      expect(empty.status).toBe(422);
+      expect(empty.body.error).toContain("at least one UUID");
+    }
+
+    const oversizedQuery = Array.from({ length: 26 }, () => randomUUID())
+      .map((root) => `subtreeOf=${root}`)
+      .join("&");
+    const oversized = await request(app)
+      .get(`/api/companies/${companyId}/issues?${oversizedQuery}`);
+    expect(oversized.status).toBe(422);
+    expect(oversized.body.error).toContain("at most 25");
+
+    const maximumQuery = Array.from({ length: 25 }, () => randomUUID())
+      .map((root) => `subtreeOf=${root}`)
+      .join("&");
+    const maximum = await request(app)
+      .get(`/api/companies/${companyId}/issues?${maximumQuery}`);
+    expect(maximum.status, JSON.stringify(maximum.body)).toBe(200);
+  });
 });

--- a/server/src/__tests__/issues-list-query-parsing.test.ts
+++ b/server/src/__tests__/issues-list-query-parsing.test.ts
@@ -1,7 +1,8 @@
+import { randomUUID } from "node:crypto";
 import express from "express";
 import request from "supertest";
 import { describe, expect, it } from "vitest";
-import { parseStatusFilter } from "../services/issues.ts";
+import { parseIssueSubtreeRoots, parseStatusFilter } from "../services/issues.ts";
 
 /**
  * Regression test for https://github.com/paperclipai/paperclip/issues/4628
@@ -70,5 +71,15 @@ describe("issue list status query parsing", () => {
     const res = await request(buildApp()).get("/api/companies/c1/issues");
     expect(res.status).toBe(200);
     expect(res.body).toEqual({ statuses: [] });
+  });
+});
+
+describe("issue subtree query parsing", () => {
+  it("rejects present but structurally invalid values instead of dropping the filter", () => {
+    expect(() => parseIssueSubtreeRoots([])).toThrow("at least one UUID");
+    expect(() => parseIssueSubtreeRoots({ unexpected: "value" })).toThrow("repeated UUID");
+    expect(() => parseIssueSubtreeRoots([randomUUID(), { unexpected: "value" }])).toThrow(
+      "at least one UUID",
+    );
   });
 });

--- a/server/src/__tests__/openapi-routes.test.ts
+++ b/server/src/__tests__/openapi-routes.test.ts
@@ -189,6 +189,23 @@ describe("openapi routes", () => {
     expect(res.body.paths["/api/companies/{companyId}/folders/items/move"].post.summary).toBe(
       "Move an item into or out of a folder",
     );
+    const issueListSubtreeParameter = res.body.paths["/api/companies/{companyId}/issues"].get.parameters
+      .find((parameter: { name: string }) => parameter.name === "subtreeOf");
+    expect(issueListSubtreeParameter).toMatchObject({
+      name: "subtreeOf",
+      in: "query",
+      required: false,
+      style: "form",
+      explode: true,
+      schema: {
+        type: "array",
+        minItems: 1,
+        maxItems: 25,
+        items: { type: "string", format: "uuid" },
+      },
+    });
+    expect(issueListSubtreeParameter.description).toContain("Comma-separated UUIDs");
+    expect(res.body.paths["/api/companies/{companyId}/issues"].get.responses["422"]).toBeDefined();
     expect(JSON.stringify(res.body.paths["/api/tool-gateway/tools"].get)).not.toContain("sessionToken");
     expect(JSON.stringify(res.body.paths["/api/tool-gateway/tools/call"].post)).not.toContain("sessionToken");
   });

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -109,6 +109,7 @@ import {
   inboxAgentPolicyService,
   ISSUE_LIST_DEFAULT_LIMIT,
   ISSUE_LIST_MAX_LIMIT,
+  parseIssueSubtreeRoots,
   issueReferenceService,
   issueService,
   type IssueFilters,
@@ -4675,6 +4676,9 @@ export function issueRoutes(
     const compactView = view === "compact";
     const hasPlanDocument = parseOptionalBooleanQuery(req.query.hasPlanDocument);
     const includeLiveDescendantSummary = parseOptionalBooleanQuery(req.query.includeLiveDescendantSummary);
+    const subtreeOf = req.query.subtreeOf === undefined
+      ? []
+      : parseIssueSubtreeRoots(req.query.subtreeOf);
     const assigneeAgentFilterRaw = req.query.assigneeAgentId;
     let assigneeAgentId: string | null | undefined;
 
@@ -4744,6 +4748,15 @@ export function issueRoutes(
       }
     }
     const offset = parsedOffset ?? 0;
+    const subtreeCompanyScopeAccess = subtreeOf.length > 0
+      ? await actorCanReadCompanyScope(req, companyId)
+      : null;
+    if (subtreeCompanyScopeAccess === false) {
+      res.status(403).json({
+        error: "subtreeOf requires company-scoped issue read access so pagination cannot hide readable work",
+      });
+      return;
+    }
 
     const listFilters: IssueFilters = {
       attention: attention === "blocked" ? "blocked" : undefined,
@@ -4759,6 +4772,7 @@ export function issueRoutes(
       executionWorkspaceId: req.query.executionWorkspaceId as string | undefined,
       parentId: req.query.parentId as string | undefined,
       descendantOf: req.query.descendantOf as string | undefined,
+      subtreeOf: subtreeOf.length > 0 ? subtreeOf : undefined,
       labelId: req.query.labelId as string | undefined,
       originKind: req.query.originKind as string | undefined,
       originKindPrefix: req.query.originKindPrefix as string | undefined,
@@ -4796,7 +4810,9 @@ export function issueRoutes(
       diagnostics: opts.issueListDiagnostics,
       compute: async () => {
         const rawResult = await svc.list(companyId, listFilters);
-        const result = await actorCanReadCompanyScope(req, companyId)
+        const canReadCompanyScope = subtreeCompanyScopeAccess
+          ?? await actorCanReadCompanyScope(req, companyId);
+        const result = canReadCompanyScope
           ? rawResult
           : await filterIssuesForActor(req, rawResult);
         const issueIds = result.map((issue) => issue.id);

--- a/server/src/routes/openapi.ts
+++ b/server/src/routes/openapi.ts
@@ -310,7 +310,17 @@ function zodToOpenApiSchema(schema: z.ZodTypeAny): JsonSchema {
   }
 
   if (typeName === "ZodArray") {
-    return { type: "array", items: zodToOpenApiSchema(unwrapped._def.type) };
+    const jsonSchema: JsonSchema = {
+      type: "array",
+      items: zodToOpenApiSchema(unwrapped._def.type),
+    };
+    if (unwrapped._def.minLength?.value !== undefined) {
+      jsonSchema.minItems = unwrapped._def.minLength.value;
+    }
+    if (unwrapped._def.maxLength?.value !== undefined) {
+      jsonSchema.maxItems = unwrapped._def.maxLength.value;
+    }
+    return jsonSchema;
   }
 
   if (typeName === "ZodRecord") {
@@ -406,12 +416,21 @@ function parametersFromSchema(schema: z.ZodTypeAny, location: "path" | "query") 
   const objectSchema = unwrapSchema(schema);
   if (zodTypeName(objectSchema) !== "ZodObject") return [];
   const shape = objectSchema._def.shape();
-  return Object.entries(shape).map(([name, value]) => ({
-    name,
-    in: location,
-    required: location === "path" ? true : !isOptionalSchema(value as z.ZodTypeAny),
-    schema: zodToOpenApiSchema(value as z.ZodTypeAny),
-  }));
+  return Object.entries(shape).map(([name, value]) => {
+    const valueSchema = value as z.ZodTypeAny;
+    const unwrapped = unwrapSchema(valueSchema);
+    const isArrayQuery = location === "query" && zodTypeName(unwrapped) === "ZodArray";
+    return {
+      name,
+      in: location,
+      required: location === "path" ? true : !isOptionalSchema(valueSchema),
+      ...(valueSchema.description || unwrapped.description
+        ? { description: valueSchema.description ?? unwrapped.description }
+        : {}),
+      ...(isArrayQuery ? { style: "form", explode: true } : {}),
+      schema: zodToOpenApiSchema(valueSchema),
+    };
+  });
 }
 
 class OpenAPIRegistry {
@@ -1843,9 +1862,20 @@ registry.registerPath({
   description: "Use `view=compact` for the board issue-list row contract. The default response remains the broad compatibility contract.",
   request: {
     params: z.object({ companyId: z.string() }),
-    query: z.object({ view: z.enum(["compact"]).optional() }).passthrough(),
+    query: z.object({
+      view: z.enum(["compact"]).optional(),
+      subtreeOf: z.array(z.string().uuid()).min(1).max(25).optional().describe(
+        "Repeated issue UUID roots, including each visible root and all visible descendants; maximum 25 unique roots. Comma-separated UUIDs are accepted for compatibility.",
+      ),
+    }).passthrough(),
   },
-  responses: { 200: r.ok(), 304: { description: "Not Modified" }, 401: r.unauthorized },
+  responses: {
+    200: r.ok(),
+    304: { description: "Not Modified" },
+    401: r.unauthorized,
+    403: r.forbidden,
+    422: { description: "Invalid or excessive subtree roots" },
+  },
 });
 
 registry.registerPath({

--- a/server/src/services/index.ts
+++ b/server/src/services/index.ts
@@ -35,7 +35,9 @@ export {
   clampIssueListLimit,
   ISSUE_LIST_DEFAULT_LIMIT,
   ISSUE_LIST_MAX_LIMIT,
+  ISSUE_SUBTREE_ROOT_MAX,
   issueService,
+  parseIssueSubtreeRoots,
   type IssueFilters,
 } from "./issues.js";
 export { issueThreadInteractionService } from "./issue-thread-interactions.js";

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -113,6 +113,7 @@ const ALL_ISSUE_STATUSES = ["backlog", "todo", "in_progress", "in_review", "bloc
 const MAX_ISSUE_COMMENT_PAGE_LIMIT = 500;
 export const ISSUE_LIST_DEFAULT_LIMIT = 500;
 export const ISSUE_LIST_MAX_LIMIT = 1000;
+export const ISSUE_SUBTREE_ROOT_MAX = 25;
 export const ISSUE_BLOCKER_DIAGNOSTICS_MAX_BLOCKERS = 100;
 export const ISSUE_WAKE_DIAGNOSTICS_MAX_WAKE_REQUESTS = 50;
 export const ISSUE_WAKE_DIAGNOSTICS_MAX_ACTIVITY_RECORDS = 50;
@@ -473,6 +474,36 @@ export function parseStatusFilter(input: string | readonly string[] | undefined)
     .filter(Boolean);
 }
 
+export function parseIssueSubtreeRoots(
+  input: unknown,
+): string[] {
+  if (input === undefined) return [];
+  if (typeof input !== "string" && !Array.isArray(input)) {
+    throw unprocessable("subtreeOf must be a UUID or repeated UUID query parameter");
+  }
+  const entries = typeof input === "string" ? [input] : input;
+  if (entries.length === 0 || entries.some((entry) => typeof entry !== "string")) {
+    throw unprocessable("subtreeOf must contain at least one UUID issue ID");
+  }
+  const roots = [...new Set(
+    entries
+      .flatMap((entry) => entry.split(","))
+      .map((root) => root.trim())
+      .filter(Boolean),
+  )];
+
+  if (roots.length === 0) {
+    throw unprocessable("subtreeOf must contain at least one UUID issue ID");
+  }
+  if (roots.length > ISSUE_SUBTREE_ROOT_MAX) {
+    throw unprocessable(`subtreeOf accepts at most ${ISSUE_SUBTREE_ROOT_MAX} unique issue IDs`);
+  }
+  if (roots.some((root) => !isUuidLike(root))) {
+    throw unprocessable("subtreeOf must contain only UUID issue IDs");
+  }
+  return roots;
+}
+
 export interface IssueFilters {
   attention?: "blocked";
   status?: string | readonly string[];
@@ -496,6 +527,7 @@ export interface IssueFilters {
   executionWorkspaceId?: string;
   parentId?: string;
   descendantOf?: string;
+  subtreeOf?: readonly string[];
   labelId?: string;
   originKind?: string;
   originKindPrefix?: string;
@@ -3510,6 +3542,28 @@ function assertValidAssigneeAgentFilter(assigneeAgentFilter: string | null | und
   }
 }
 
+function issueSubtreeCondition(companyId: string, subtreeRoots: readonly string[]): SQL<boolean> | null {
+  if (subtreeRoots.length === 0) return null;
+  return sql<boolean>`
+    ${issues.id} IN (
+      WITH RECURSIVE subtree(id) AS (
+        SELECT ${issues.id}
+        FROM ${issues}
+        WHERE ${issues.companyId} = ${companyId}
+          AND ${visibleIssueCondition()}
+          AND ${inArray(issues.id, subtreeRoots)}
+        UNION
+        SELECT ${issues.id}
+        FROM ${issues}
+        JOIN subtree ON ${issues.parentId} = subtree.id
+        WHERE ${issues.companyId} = ${companyId}
+          AND ${visibleIssueCondition()}
+      )
+      SELECT id FROM subtree
+    )
+  `;
+}
+
 async function blockedInboxIssueConditions(
   dbOrTx: any,
   companyId: string,
@@ -4787,6 +4841,11 @@ export function issueService(db: Db) {
           )
         `);
       }
+      const subtreeCondition = issueSubtreeCondition(
+        companyId,
+        filters?.subtreeOf ?? [],
+      );
+      if (subtreeCondition) conditions.push(subtreeCondition);
       const lowTrustCondition = lowTrustBoundaryIssueCondition(companyId, filters?.lowTrustBoundary);
       if (lowTrustCondition) conditions.push(lowTrustCondition);
       const statuses = parseStatusFilter(filters?.status);

--- a/ui/src/api/issues.test.ts
+++ b/ui/src/api/issues.test.ts
@@ -35,6 +35,27 @@ describe("issuesApi.list", () => {
     );
   });
 
+  it("passes subtree roots as repeated query keys", async () => {
+    await issuesApi.list("company-1", {
+      subtreeOf: [
+        "00000000-0000-4000-8000-000000000001",
+        "00000000-0000-4000-8000-000000000002",
+      ],
+      limit: 25,
+    });
+
+    expect(mockApi.get).toHaveBeenCalledWith(
+      "/companies/company-1/issues?subtreeOf=00000000-0000-4000-8000-000000000001&subtreeOf=00000000-0000-4000-8000-000000000002&limit=25",
+    );
+  });
+
+  it("fails closed when an untyped caller supplies an empty subtree", () => {
+    expect(() => issuesApi.list("company-1", {
+      subtreeOf: [] as unknown as [string, ...string[]],
+    })).toThrow("subtreeOf requires at least one issue ID");
+    expect(mockApi.get).not.toHaveBeenCalled();
+  });
+
   it("passes generic workspaceId filters through to the company issues endpoint", async () => {
     await issuesApi.list("company-1", { workspaceId: "workspace-1", limit: 1000 });
 

--- a/ui/src/api/issues.ts
+++ b/ui/src/api/issues.ts
@@ -55,6 +55,7 @@ export type IssueListFilters = {
   originKindPrefix?: string;
   originId?: string;
   descendantOf?: string;
+  subtreeOf?: readonly [string, ...string[]];
   includeRoutineExecutions?: boolean;
   includeBlockedBy?: boolean;
   includeBlockedInboxAttention?: boolean;
@@ -86,6 +87,10 @@ function issueListSearchParams(filters?: IssueListFilters) {
   if (filters?.originKindPrefix) params.set("originKindPrefix", filters.originKindPrefix);
   if (filters?.originId) params.set("originId", filters.originId);
   if (filters?.descendantOf) params.set("descendantOf", filters.descendantOf);
+  if (filters?.subtreeOf) {
+    if (filters.subtreeOf.length === 0) throw new Error("subtreeOf requires at least one issue ID");
+    for (const rootId of filters.subtreeOf) params.append("subtreeOf", rootId);
+  }
   if (filters?.includeRoutineExecutions) params.set("includeRoutineExecutions", "true");
   if (filters?.includeBlockedBy) params.set("includeBlockedBy", "true");
   if (filters?.includeBlockedInboxAttention) params.set("includeBlockedInboxAttention", "true");


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the control plane that keeps autonomous company work scoped, inspectable, and governable.
> - Issue-list reads are a core data boundary used by board views and downstream clients.
> - The existing list supports one descendant-only root, while broad company reads are paginated and cannot safely represent several selected work trees.
> - Clients that approximate a multi-root scope from the first broad page can produce incomplete counts and leak unrelated work into scoped views.
> - The API therefore needs one bounded, company-scoped projection that includes selected roots and their descendants without changing the response envelope.
> - This pull request adds that projection to the existing compact-compatible issue list, validates it fail-closed, and synchronizes the server, UI client, OpenAPI, tests, and implementation spec.
> - The benefit is a reusable, paginated contract for mission/project-like consumers without introducing a second board-feed endpoint or loading an entire company into memory.

## Linked Issues or Issue Description

### Pre-submission checklist

- [x] I searched open and closed issues and pull requests for a duplicate.
- [x] I reproduced this on the current `master` branch.
- [x] I confirmed the behavior originates in Paperclip's core issue-list contract, not an adapter or provider.

### What happened?

Consumers needing several issue trees must request a broad company issue page and filter it locally, or make one request per root. Because the broad list is paginated, local filtering can silently produce incomplete scoped views: a selected root or descendant may lie beyond the page boundary, while unrelated issues occupy the response.

### Expected behavior

The existing issue-list endpoint should accept a bounded multi-root scope and return each visible selected root plus its visible descendants. It should exclude unrelated and cross-company work, compose with existing filters and pagination, and reject malformed or empty scope input instead of falling back to a broad company list.

### Steps to reproduce

1. Create more company issues than fit on one issue-list page, including two independent root trees.
2. Request the first broad company issue page and filter its response locally to those roots.
3. Observe that roots or descendants beyond the page boundary are absent even though the client presents the result as the complete scoped view.

### Paperclip version or commit

- Reproduced on the `master` commit from which this branch was created.

### Deployment mode

- Local dev (`pnpm dev`) / built from source.

### Agent adapter(s) involved

- Not adapter-specific (core bug).

### Database mode

- External Postgres in integration tests; the query uses the shared Drizzle/Postgres contract.

### Access context

- Board and agent company-scope authorization are covered by route tests.

### Privacy checklist

- [x] This description and the verification output contain no credentials, customer content, private company names, or local filesystem paths.

## What Changed

- Added repeated/comma-compatible `subtreeOf` parsing with UUID validation, deduplication, a 25-root ceiling, and fail-closed empty/malformed handling.
- Added a company-scoped recursive CTE that includes roots, stops at hidden/harness boundaries, deduplicates overlapping trees, and composes with existing filters and pagination.
- Required company-scope read authorization before using this projection so post-pagination visibility filtering cannot hide readable results.
- Added the typed UI API client contract and explicit OpenAPI array serialization, UUID, min/max, description, 403, and 422 metadata.
- Added route, parser, OpenAPI, client, visibility, overlap, pagination, cross-company, and filter-composition regression coverage.
- Documented the query contract in the V1 implementation spec.

## Verification

- `pnpm exec vitest run server/src/__tests__/issue-list-assignee-filter-routes.test.ts server/src/__tests__/issues-list-query-parsing.test.ts server/src/__tests__/openapi-routes.test.ts ui/src/api/issues.test.ts` — 36/36 passed.
- `pnpm exec vitest run server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts -t 'uses the company-scope fast path on the issue list route'` — passed; preserves the existing unscoped authorization fast path.
- `pnpm --filter @paperclipai/server typecheck` — passed.
- `pnpm --filter @paperclipai/ui typecheck` — passed.
- `pnpm build` — passed.
- `git diff --check` — passed.
- The repository-wide stable test runner exposed one unrelated baseline failure in `workspace-runtime.test.ts` (`adopts a live auto-port shared service after runtime state is reset`); the same test failed when rerun alone and no changed file is in that subsystem.

## Risks

- Recursive traversal materializes the selected subtrees before response pagination. The request is bounded to 25 roots and uses the existing `(company_id, parent_id)` index; no migration is required.
- Hidden or harness nodes stop traversal, intentionally failing closed instead of returning visible descendants through a non-visible intermediary.
- Restricted actors receive 403 for `subtreeOf`; this avoids incomplete pages caused by filtering authorization after SQL pagination.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex, GPT-5, with reasoning, tool use, local code execution, database-backed integration tests, and an independent hostile-review pass.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
