### PR TITLE
GST-51: paperclipGetInteraction (get-by-id) + read-interaction test coverage

### DIFF
--- a/packages/mcp-server/src/tools.test.ts
+++ b/packages/mcp-server/src/tools.test.ts
@@ -348,6 +348,60 @@ describe("paperclip MCP tools", () => {
     });
   });
 
+  it("lists issue-thread interactions for an issue", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      mockJsonResponse([{ id: "interaction-1", kind: "suggest_tasks", status: "pending" }]),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const tool = getTool("paperclipListIssueInteractions");
+    const response = await tool.execute({ issueId: "PAP-1135" });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(String(url)).toBe("http://localhost:3100/api/issues/PAP-1135/interactions");
+    expect(init.method).toBe("GET");
+    expect(response.content[0]?.text).toContain("interaction-1");
+  });
+
+  it("gets a single issue-thread interaction by id", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      mockJsonResponse({
+        id: "33333333-3333-4333-8333-333333333333",
+        kind: "suggest_tasks",
+        status: "accepted",
+        result: { version: 1, createdTasks: [] },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const tool = getTool("paperclipGetInteraction");
+    const response = await tool.execute({
+      issueId: "PAP-1135",
+      interactionId: "33333333-3333-4333-8333-333333333333",
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(String(url)).toBe(
+      "http://localhost:3100/api/issues/PAP-1135/interactions/33333333-3333-4333-8333-333333333333",
+    );
+    expect(init.method).toBe("GET");
+    expect(response.content[0]?.text).toContain("createdTasks");
+  });
+
+  it("rejects a non-uuid interactionId for paperclipGetInteraction", async () => {
+    vi.stubGlobal("fetch", vi.fn());
+
+    const tool = getTool("paperclipGetInteraction");
+    const response = await tool.execute({
+      issueId: "PAP-1135",
+      interactionId: "not-a-uuid",
+    });
+
+    expect(response.content[0]?.text).toContain("uuid");
+  });
+
   it("creates approvals with the expected company-scoped payload", async () => {
     const fetchMock = vi.fn().mockResolvedValue(
       mockJsonResponse({ id: "approval-1" }),

--- a/packages/mcp-server/src/tools.ts
+++ b/packages/mcp-server/src/tools.ts
@@ -57,6 +57,7 @@ const issueIdSchema = z.string().min(1);
 const projectIdSchema = z.string().min(1);
 const goalIdSchema = z.string().uuid();
 const approvalIdSchema = z.string().uuid();
+const interactionIdSchema = z.string().uuid();
 const documentKeySchema = z.string().trim().min(1).max(64);
 
 const listIssuesSchema = z.object({
@@ -540,6 +541,23 @@ export function createToolDefinitions(client: PaperclipApiClient): ToolDefinitio
             ...body,
           },
         }),
+    ),
+    makeTool(
+      "paperclipListIssueInteractions",
+      "List issue-thread interactions on an issue",
+      z.object({ issueId: issueIdSchema }),
+      async ({ issueId }) =>
+        client.requestJson("GET", `/issues/${encodeURIComponent(issueId)}/interactions`),
+    ),
+    makeTool(
+      "paperclipGetInteraction",
+      "Get a single issue-thread interaction by id, including its hydrated result/answers",
+      z.object({ issueId: issueIdSchema, interactionId: interactionIdSchema }),
+      async ({ issueId, interactionId }) =>
+        client.requestJson(
+          "GET",
+          `/issues/${encodeURIComponent(issueId)}/interactions/${encodeURIComponent(interactionId)}`,
+        ),
     ),
     makeTool(
       "paperclipUpsertIssueDocument",

--- a/server/src/__tests__/issue-thread-interaction-routes.test.ts
+++ b/server/src/__tests__/issue-thread-interaction-routes.test.ts
@@ -11,6 +11,7 @@ const mockIssueService = vi.hoisted(() => ({
 
 const mockInteractionService = vi.hoisted(() => ({
   listForIssue: vi.fn(),
+  getById: vi.fn(),
   create: vi.fn(),
   acceptInteraction: vi.fn(),
   acceptSuggestedTasks: vi.fn(),
@@ -185,6 +186,7 @@ describe.sequential("issue thread interaction routes", () => {
     vi.clearAllMocks();
     mockIssueService.getById.mockResolvedValue(createIssue());
     mockInteractionService.listForIssue.mockResolvedValue([]);
+    mockInteractionService.getById.mockResolvedValue(null);
     mockInteractionService.expireRequestConfirmationsSupersededByHistoricalComments.mockResolvedValue([]);
     mockInteractionService.create.mockResolvedValue({
       id: "interaction-1",
@@ -434,6 +436,90 @@ describe.sequential("issue thread interaction routes", () => {
         }),
       }),
     );
+  });
+
+  it("gets a single interaction by id with hydrated result", async () => {
+    mockInteractionService.getById.mockResolvedValue({
+      id: "interaction-1",
+      companyId: "company-1",
+      issueId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      kind: "suggest_tasks",
+      status: "accepted",
+      continuationPolicy: "wake_assignee",
+      idempotencyKey: null,
+      sourceCommentId: "comment-1",
+      sourceRunId: "run-1",
+      payload: {
+        version: 1,
+        tasks: [{ clientKey: "task-1", title: "One" }],
+      },
+      result: {
+        version: 1,
+        createdTasks: [{ clientKey: "task-1", issueId: "child-1" }],
+        skippedClientKeys: [],
+      },
+      createdAt: "2026-04-20T12:00:00.000Z",
+      updatedAt: "2026-04-20T12:05:00.000Z",
+    });
+    const app = await createApp();
+
+    const res = await request(app).get(
+      "/api/issues/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa/interactions/interaction-1",
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(
+      expect.objectContaining({
+        id: "interaction-1",
+        kind: "suggest_tasks",
+        status: "accepted",
+        result: expect.objectContaining({
+          createdTasks: [{ clientKey: "task-1", issueId: "child-1" }],
+        }),
+      }),
+    );
+    expect(mockInteractionService.getById).toHaveBeenCalledWith("interaction-1");
+  });
+
+  it("404s getting an interaction that belongs to a different issue", async () => {
+    mockInteractionService.getById.mockResolvedValue({
+      id: "interaction-1",
+      issueId: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+      kind: "suggest_tasks",
+      status: "pending",
+    });
+    const app = await createApp();
+
+    const res = await request(app).get(
+      "/api/issues/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa/interactions/interaction-1",
+    );
+
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ error: "Interaction not found" });
+  });
+
+  it("404s getting an unknown interaction id", async () => {
+    mockInteractionService.getById.mockResolvedValue(null);
+    const app = await createApp();
+
+    const res = await request(app).get(
+      "/api/issues/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa/interactions/does-not-exist",
+    );
+
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ error: "Interaction not found" });
+  });
+
+  it("404s getting an interaction on an inaccessible issue", async () => {
+    mockIssueService.getById.mockResolvedValueOnce(null);
+    const app = await createApp();
+
+    const res = await request(app).get(
+      "/api/issues/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa/interactions/interaction-1",
+    );
+
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ error: "Issue not found" });
   });
 
   it("accepts suggested tasks and wakes created assignees plus the current assignee", async () => {

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -9021,6 +9021,20 @@ export function issueRoutes(
     res.json(interactions);
   });
 
+  router.get("/issues/:id/interactions/:interactionId", async (req, res) => {
+    const id = req.params.id as string;
+    const interactionId = req.params.interactionId as string;
+    const issue = await getAccessibleResource(req, res, svc.getById(id), "Issue not found");
+    if (!issue) return;
+    if (!(await assertIssueReadAllowed(req, res, issue))) return;
+
+    const interaction = await issueThreadInteractionService(db).getById(interactionId);
+    if (!interaction || interaction.issueId !== id) {
+      return res.status(404).json({ error: "Interaction not found" });
+    }
+    res.json(interaction);
+  });
+
   router.post("/issues/:id/interactions", validate(createIssueThreadInteractionSchema), async (req, res) => {
     const id = req.params.id as string;
     const issue = await getAccessibleResource(req, res, svc.getById(id), "Issue not found");


### PR DESCRIPTION
## Summary
- New route GET /issues/:id/interactions/:interactionId (found/404/auth)
- New MCP tool paperclipGetInteraction (issueId+interactionId as z.string().uuid())
- Test coverage for both new tool and previously-uncovered paperclipListIssueInteractions

Closes remaining GST-16 scope (follow-up to #9810).

## Test plan
- [x] issue-thread-interaction-routes.test.ts (found/404/auth)
- [x] tools.test.ts covers both paperclipGetInteraction and paperclipListIssueInteractions