### PR TITLE
fix: classify permanent auth failures and break identical-failure retry storms

### DIFF
--- a/packages/adapters/claude-local/src/server/execute.auth-classification.test.ts
+++ b/packages/adapters/claude-local/src/server/execute.auth-classification.test.ts
@@ -1,0 +1,169 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const {
+  runChildProcess,
+  ensureCommandResolvable,
+  resolveCommandForLogs,
+} = vi.hoisted(() => ({
+  runChildProcess: vi.fn(async () => ({
+    exitCode: 1,
+    signal: null,
+    timedOut: false,
+    stdout: "",
+    stderr: "",
+    pid: 123,
+    startedAt: new Date().toISOString(),
+  })),
+  ensureCommandResolvable: vi.fn(async () => undefined),
+  resolveCommandForLogs: vi.fn(async () => "/usr/local/bin/claude"),
+}));
+
+vi.mock("@paperclipai/adapter-utils/server-utils", async () => {
+  const actual = await vi.importActual<typeof import("@paperclipai/adapter-utils/server-utils")>(
+    "@paperclipai/adapter-utils/server-utils",
+  );
+  return {
+    ...actual,
+    ensureCommandResolvable,
+    resolveCommandForLogs,
+    runChildProcess,
+  };
+});
+
+import { execute } from "./execute.js";
+
+function claudeFailureStdout(result: string): string {
+  return [
+    JSON.stringify({ type: "system", subtype: "init", session_id: "6a3f8f61-1111-4a2b-9c3d-2e4f5a6b7c8d", model: "claude-sonnet" }),
+    JSON.stringify({
+      type: "result",
+      subtype: "success",
+      is_error: true,
+      session_id: "6a3f8f61-1111-4a2b-9c3d-2e4f5a6b7c8d",
+      result,
+      usage: { input_tokens: 1, cache_read_input_tokens: 0, output_tokens: 1 },
+    }),
+  ].join("\n");
+}
+
+describe("claude execute auth failure classification", () => {
+  const cleanupDirs: string[] = [];
+
+  afterEach(async () => {
+    vi.clearAllMocks();
+    while (cleanupDirs.length > 0) {
+      const dir = cleanupDirs.pop();
+      if (!dir) continue;
+      await rm(dir, { recursive: true, force: true }).catch(() => undefined);
+    }
+  });
+
+  async function runExecuteWithProcResult(proc: {
+    exitCode: number;
+    stdout: string;
+    stderr: string;
+  }) {
+    const workspaceDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-claude-auth-"));
+    cleanupDirs.push(workspaceDir);
+    runChildProcess.mockResolvedValue({
+      exitCode: proc.exitCode,
+      signal: null,
+      timedOut: false,
+      stdout: proc.stdout,
+      stderr: proc.stderr,
+      pid: 123,
+      startedAt: new Date().toISOString(),
+    });
+
+    return await execute({
+      runId: "run-auth-1",
+      agent: {
+        id: "agent-1",
+        companyId: "company-1",
+        name: "Claude Coder",
+        adapterType: "claude_local",
+        adapterConfig: {},
+      },
+      runtime: {
+        sessionId: null,
+        sessionParams: null,
+        sessionDisplayId: null,
+        taskKey: null,
+      },
+      config: {
+        command: "claude",
+        engine: "cli",
+        cwd: workspaceDir,
+      },
+      context: {},
+      onLog: async () => {},
+    });
+  }
+
+  it("classifies a 401 invalid bearer token failure as claude_auth_required with a plain message", async () => {
+    const result = await runExecuteWithProcResult({
+      exitCode: 1,
+      stdout: claudeFailureStdout("Failed to authenticate. API Error: 401 Invalid bearer token"),
+      stderr: "",
+    });
+
+    expect(result.errorCode).toBe("claude_auth_required");
+    expect(result.errorMessage).toBe(
+      "Claude rejected the connected credential. Reconnect a valid Claude credential, then resume.",
+    );
+    expect(result.errorFamily ?? null).toBeNull();
+  });
+
+  it("classifies a 401 invalid OAuth access token failure as claude_auth_required", async () => {
+    const result = await runExecuteWithProcResult({
+      exitCode: 1,
+      stdout: claudeFailureStdout("Failed to authenticate. API Error: 401 OAuth access token is invalid."),
+      stderr: "",
+    });
+
+    expect(result.errorCode).toBe("claude_auth_required");
+    expect(result.errorMessage).toBe(
+      "Claude rejected the connected credential. Reconnect a valid Claude credential, then resume.",
+    );
+  });
+
+  it("classifies an unparsed 401 authentication_error on stderr as claude_auth_required", async () => {
+    const result = await runExecuteWithProcResult({
+      exitCode: 1,
+      stdout: "",
+      stderr: 'API Error: 401 {"type":"error","error":{"type":"authentication_error","message":"invalid x-api-key"}}',
+    });
+
+    expect(result.errorCode).toBe("claude_auth_required");
+    expect(result.errorMessage).toBe(
+      "Claude rejected the connected credential. Reconnect a valid Claude credential, then resume.",
+    );
+  });
+
+  it("keeps the existing 'Not logged in' login flow classification intact", async () => {
+    const result = await runExecuteWithProcResult({
+      exitCode: 1,
+      stdout: "",
+      stderr: "Not logged in. Please run `claude login` to authenticate.",
+    });
+
+    expect(result.errorCode).toBe("claude_auth_required");
+    // The login path keeps its existing message shape (not the invalid-credential copy).
+    expect(result.errorMessage).not.toBe(
+      "Claude rejected the connected credential. Reconnect a valid Claude credential, then resume.",
+    );
+  });
+
+  it("does not classify unrelated failures as auth failures", async () => {
+    const result = await runExecuteWithProcResult({
+      exitCode: 1,
+      stdout: claudeFailureStdout("API Error: 500 internal server error"),
+      stderr: "",
+    });
+
+    expect(result.errorCode).not.toBe("claude_auth_required");
+  });
+});

--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -65,6 +65,7 @@ import {
   isClaudeUnknownSessionError,
   isClaudePoisonedPreviousMessageIdError,
   isClaudeImageProcessingError,
+  isClaudeInvalidCredentialError,
   isClaudeModelNotFoundError,
 } from "./parse.js";
 import {
@@ -88,6 +89,9 @@ import {
 
 const __moduleDir = path.dirname(fileURLToPath(import.meta.url));
 const executeClaudeAcp = createClaudeAcpExecutor();
+
+const CLAUDE_INVALID_CREDENTIAL_MESSAGE =
+  "Claude rejected the connected credential. Reconnect a valid Claude credential, then resume.";
 
 interface ClaudeExecutionInput {
   runId: string;
@@ -957,8 +961,18 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
 
     if (!parsed) {
       const fallbackErrorMessage = parseFallbackErrorMessage(proc);
+      const invalidCredential =
+        !loginMeta.requiresLogin &&
+        (proc.exitCode ?? 0) !== 0 &&
+        isClaudeInvalidCredentialError({
+          parsed: null,
+          stdout: proc.stdout,
+          stderr: proc.stderr,
+          errorMessage: fallbackErrorMessage,
+        });
       const providerQuota =
         !loginMeta.requiresLogin &&
+        !invalidCredential &&
         (proc.exitCode ?? 0) !== 0 &&
         isClaudeProviderQuotaError({
           parsed: null,
@@ -968,6 +982,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         });
       const transientUpstream =
         !loginMeta.requiresLogin &&
+        !invalidCredential &&
         !providerQuota &&
         (proc.exitCode ?? 0) !== 0 &&
         isClaudeTransientUpstreamError({
@@ -984,7 +999,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
             errorMessage: fallbackErrorMessage,
           })
         : null;
-      const errorCode = loginMeta.requiresLogin
+      const errorCode = loginMeta.requiresLogin || invalidCredential
         ? "claude_auth_required"
         : isClaudeModelNotFoundError({
           parsed: null,
@@ -1003,7 +1018,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         exitCode: proc.exitCode,
         signal: proc.signal,
         timedOut: false,
-        errorMessage: fallbackErrorMessage,
+        errorMessage: invalidCredential ? CLAUDE_INVALID_CREDENTIAL_MESSAGE : fallbackErrorMessage,
         errorCode,
         errorFamily,
         retryNotBefore: transientRetryNotBefore ? transientRetryNotBefore.toISOString() : null,
@@ -1083,23 +1098,39 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         ...(workspaceRepoRef ? { repoRef: workspaceRepoRef } : {}),
       } as Record<string, unknown>)
       : null;
-    const errorMessage = failed
+    const rawErrorMessage = failed
       ? describeClaudeFailure(parsed) ?? `Claude exited with code ${proc.exitCode ?? -1}`
       : null;
+    const invalidCredential =
+      failed &&
+      !loginMeta.requiresLogin &&
+      !clearSessionForMaxTurns &&
+      !poisonedPreviousMessageId &&
+      isClaudeInvalidCredentialError({
+        parsed,
+        stdout: proc.stdout,
+        stderr: proc.stderr,
+        errorMessage: rawErrorMessage,
+      });
+    // The raw CLI text stays in resultJson; the surfaced message must tell the
+    // user what to do, not echo the provider's 401.
+    const errorMessage = invalidCredential ? CLAUDE_INVALID_CREDENTIAL_MESSAGE : rawErrorMessage;
     const providerQuota =
       failed &&
       !loginMeta.requiresLogin &&
+      !invalidCredential &&
       !clearSessionForMaxTurns &&
       !poisonedPreviousMessageId &&
       isClaudeProviderQuotaError({
         parsed,
         stdout: proc.stdout,
         stderr: proc.stderr,
-        errorMessage,
+        errorMessage: rawErrorMessage,
       });
     const transientUpstream =
       failed &&
       !loginMeta.requiresLogin &&
+      !invalidCredential &&
       !clearSessionForMaxTurns &&
       !poisonedPreviousMessageId &&
       !providerQuota &&
@@ -1107,23 +1138,23 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         parsed,
         stdout: proc.stdout,
         stderr: proc.stderr,
-        errorMessage,
+        errorMessage: rawErrorMessage,
       });
     const transientRetryNotBefore = providerQuota || transientUpstream
       ? extractClaudeRetryNotBefore({
           parsed,
           stdout: proc.stdout,
           stderr: proc.stderr,
-          errorMessage,
+          errorMessage: rawErrorMessage,
         })
       : null;
-    const resolvedErrorCode = loginMeta.requiresLogin
+    const resolvedErrorCode = loginMeta.requiresLogin || invalidCredential
       ? "claude_auth_required"
       : failed && isClaudeModelNotFoundError({
         parsed,
         stdout: proc.stdout,
         stderr: proc.stderr,
-        errorMessage,
+        errorMessage: rawErrorMessage,
       })
       ? "model_not_found"
       : failed && clearSessionForMaxTurns

--- a/packages/adapters/claude-local/src/server/parse.test.ts
+++ b/packages/adapters/claude-local/src/server/parse.test.ts
@@ -102,6 +102,34 @@ describe("isClaudeInvalidCredentialError", () => {
       errorMessage: "You've hit your session limit - resets at 4pm",
     })).toBe(false);
   });
+
+  it("does not classify a generic non-credential 'authentication error' phrase", () => {
+    // Regression (PR #9854 review): the whitespace prose form "authentication
+    // error" must not classify a downstream service's unrelated failure as an
+    // invalid provider credential. Only the snake_case API error TYPE token, or
+    // the phrase alongside a 401 / auth-domain keyword, is a real signal.
+    expect(isClaudeInvalidCredentialError({
+      errorMessage: "authentication error while contacting billing service",
+    })).toBe(false);
+    expect(isClaudeInvalidCredentialError({
+      stderr: "An authentication error occurred in the webhook dispatcher",
+    })).toBe(false);
+  });
+
+  it("still classifies the API error-type token and 401-anchored authentication errors", () => {
+    // The snake_case type token is a genuine signal on its own.
+    expect(isClaudeInvalidCredentialError({
+      errorMessage: "Claude exited with code 1: authentication_error",
+    })).toBe(true);
+    // The whitespace phrase counts when a 401 co-occurs.
+    expect(isClaudeInvalidCredentialError({
+      stderr: "API Error: 401 authentication error: check your key",
+    })).toBe(true);
+    // ...or when an auth-domain keyword co-occurs.
+    expect(isClaudeInvalidCredentialError({
+      errorMessage: "authentication error: api key is invalid",
+    })).toBe(true);
+  });
 });
 
 describe("isClaudeTransientUpstreamError", () => {

--- a/packages/adapters/claude-local/src/server/parse.test.ts
+++ b/packages/adapters/claude-local/src/server/parse.test.ts
@@ -11,6 +11,7 @@ import {
   isClaudeUnknownSessionError,
   isClaudeImageProcessingError,
   isClaudeModelNotFoundError,
+  isClaudeInvalidCredentialError,
 } from "./parse.js";
 
 describe("detectClaudeLoginRequired", () => {
@@ -50,6 +51,55 @@ describe("isClaudeModelNotFoundError", () => {
   it("does not classify unrelated provider failures as model resolution errors", () => {
     expect(isClaudeModelNotFoundError({
       errorMessage: "API Error: 503 service unavailable",
+    })).toBe(false);
+  });
+});
+
+describe("isClaudeInvalidCredentialError", () => {
+  it("detects the 401 invalid bearer token failure from the CLI result", () => {
+    expect(isClaudeInvalidCredentialError({
+      parsed: {
+        subtype: "success",
+        is_error: true,
+        result: "Failed to authenticate. API Error: 401 Invalid bearer token",
+      },
+    })).toBe(true);
+  });
+
+  it("detects the 401 invalid OAuth access token failure", () => {
+    expect(isClaudeInvalidCredentialError({
+      parsed: {
+        subtype: "success",
+        is_error: true,
+        result: "Failed to authenticate. API Error: 401 OAuth access token is invalid.",
+      },
+    })).toBe(true);
+  });
+
+  it("detects invalid x-api-key and authentication_error payloads from fallback output", () => {
+    expect(isClaudeInvalidCredentialError({
+      stderr: "API Error: 401 {\"type\":\"error\",\"error\":{\"type\":\"authentication_error\",\"message\":\"invalid x-api-key\"}}",
+    })).toBe(true);
+    expect(isClaudeInvalidCredentialError({
+      errorMessage: "Claude exited with code 1: authentication_error",
+    })).toBe(true);
+  });
+
+  it("requires a 401 alongside a bare 'failed to authenticate' message", () => {
+    expect(isClaudeInvalidCredentialError({
+      errorMessage: "Failed to authenticate. API Error: 401",
+    })).toBe(true);
+    expect(isClaudeInvalidCredentialError({
+      errorMessage: "Failed to authenticate because the network dropped",
+    })).toBe(false);
+  });
+
+  it("does not classify unrelated failures or quota errors as invalid credentials", () => {
+    expect(isClaudeInvalidCredentialError({
+      errorMessage: "API Error: 503 service unavailable",
+    })).toBe(false);
+    expect(isClaudeInvalidCredentialError({
+      errorMessage: "You've hit your session limit - resets at 4pm",
     })).toBe(false);
   });
 });

--- a/packages/adapters/claude-local/src/server/parse.ts
+++ b/packages/adapters/claude-local/src/server/parse.ts
@@ -15,6 +15,12 @@ const CLAUDE_PROVIDER_QUOTA_RE =
   /(?:you(?:'|’)ve\s+hit\s+your\s+session\s+limit|session\s+limit\s+(?:reached|exceeded)|out\s+of\s+extra\s+usage|extra\s+usage\b|claude\s+usage\s+limit\s+reached|5[-\s]?hour\s+limit\s+reached|weekly\s+limit\s+reached|usage\s+limit\s+reached|usage\s+cap\s+reached|servicequotaexceededexception)/i;
 const CLAUDE_MODEL_NOT_FOUND_RE =
   /(?:\b404\b[\s\S]{0,120})?(?:model[\s_-]*(?:not[\s_-]*found|does not exist|unknown|invalid)|unknown[\s_-]*model)/i;
+// A connected-but-rejected credential (expired OAuth token, revoked API key).
+// Distinct from CLAUDE_AUTH_REQUIRED_RE, which detects the CLI's interactive
+// "run /login" prompt; both resolve to errorCode "claude_auth_required" so the
+// heartbeat's permanent-auth pause covers them.
+const CLAUDE_INVALID_CREDENTIAL_RE =
+  /(?:failed\s+to\s+authenticate[\s\S]{0,200}?\b401\b|\b401\b[\s\S]{0,200}?failed\s+to\s+authenticate|invalid\s+bearer\s+token|oauth\s+(?:access\s+)?token\s+is\s+(?:invalid|expired|revoked)|invalid\s+x-api-key|authentication[\s_]error)/i;
 const CLAUDE_EXTRA_USAGE_RESET_RE =
   /(?:you(?:'|’)ve\s+hit\s+your\s+session\s+limit|session\s+limit\s+(?:reached|exceeded)|out\s+of\s+extra\s+usage|extra\s+usage|usage\s+limit\s+reached|usage\s+cap\s+reached|5[-\s]?hour\s+limit\s+reached|weekly\s+limit\s+reached|claude\s+usage\s+limit\s+reached)[\s\S]{0,120}?\bresets?\s+(?:at\s+)?([^\n()]+?)(?:\s*\(([^)]+)\))?(?:[.!]|\n|$)/i;
 
@@ -213,6 +219,23 @@ export function isClaudeModelNotFoundError(input: {
     ...(parsed ? extractClaudeErrorMessages(parsed) : []),
   ];
   return messages.some((message) => CLAUDE_MODEL_NOT_FOUND_RE.test(message));
+}
+
+export function isClaudeInvalidCredentialError(input: {
+  parsed?: Record<string, unknown> | null;
+  stdout?: string | null;
+  stderr?: string | null;
+  errorMessage?: string | null;
+}): boolean {
+  const parsed = input.parsed ?? null;
+  const messages = [
+    input.errorMessage ?? "",
+    input.stdout ?? "",
+    input.stderr ?? "",
+    parsed ? asString(parsed.result, "") : "",
+    ...(parsed ? extractClaudeErrorMessages(parsed) : []),
+  ];
+  return messages.some((message) => CLAUDE_INVALID_CREDENTIAL_RE.test(message));
 }
 
 export function isClaudeMaxTurnsResult(parsed: Record<string, unknown> | null | undefined): boolean {

--- a/packages/adapters/claude-local/src/server/parse.ts
+++ b/packages/adapters/claude-local/src/server/parse.ts
@@ -19,8 +19,16 @@ const CLAUDE_MODEL_NOT_FOUND_RE =
 // Distinct from CLAUDE_AUTH_REQUIRED_RE, which detects the CLI's interactive
 // "run /login" prompt; both resolve to errorCode "claude_auth_required" so the
 // heartbeat's permanent-auth pause covers them.
+// The trailing `authentication_error` token is Anthropic's snake_case API error
+// TYPE (as in `{"type":"authentication_error"}`) and is a genuine credential
+// signal on its own. The whitespace prose form "authentication error", by
+// contrast, appears in unrelated downstream failures (e.g. a billing service's
+// "authentication error while contacting ..."), so it only counts when it
+// co-occurs with a 401 status or an auth-domain keyword. Without that anchor it
+// used to false-positive any error string containing the words "authentication
+// error".
 const CLAUDE_INVALID_CREDENTIAL_RE =
-  /(?:failed\s+to\s+authenticate[\s\S]{0,200}?\b401\b|\b401\b[\s\S]{0,200}?failed\s+to\s+authenticate|invalid\s+bearer\s+token|oauth\s+(?:access\s+)?token\s+is\s+(?:invalid|expired|revoked)|invalid\s+x-api-key|authentication[\s_]error)/i;
+  /(?:failed\s+to\s+authenticate[\s\S]{0,200}?\b401\b|\b401\b[\s\S]{0,200}?failed\s+to\s+authenticate|invalid\s+bearer\s+token|oauth\s+(?:access\s+)?token\s+is\s+(?:invalid|expired|revoked)|invalid\s+x-api-key|authentication_error|authentication\s+error[\s\S]{0,160}?(?:\b401\b|invalid|expired|revoked|credential|token|bearer|api[\s_-]?key)|(?:\b401\b|invalid|expired|revoked|credential|bearer|api[\s_-]?key)[\s\S]{0,160}?authentication\s+error)/i;
 const CLAUDE_EXTRA_USAGE_RESET_RE =
   /(?:you(?:'|’)ve\s+hit\s+your\s+session\s+limit|session\s+limit\s+(?:reached|exceeded)|out\s+of\s+extra\s+usage|extra\s+usage|usage\s+limit\s+reached|usage\s+cap\s+reached|5[-\s]?hour\s+limit\s+reached|weekly\s+limit\s+reached|claude\s+usage\s+limit\s+reached)[\s\S]{0,120}?\bresets?\s+(?:at\s+)?([^\n()]+?)(?:\s*\(([^)]+)\))?(?:[.!]|\n|$)/i;
 

--- a/packages/adapters/opencode-local/src/server/credential-preflight.test.ts
+++ b/packages/adapters/opencode-local/src/server/credential-preflight.test.ts
@@ -32,11 +32,50 @@ describe("evaluateOpenCodeCredentialPreflight", () => {
     };
   }
 
-  it("is not ready when no provider credential exists anywhere", async () => {
+  it("is not ready when no provider credential exists anywhere (local execution blocks)", async () => {
     const env = await emptyIsolatedEnv();
     const result = await evaluateOpenCodeCredentialPreflight({ env });
     expect(result.ready).toBe(false);
     expect(result.source).toBeNull();
+  });
+
+  it("still blocks a local execution target with no detectable credential", async () => {
+    const env = await emptyIsolatedEnv();
+    const result = await evaluateOpenCodeCredentialPreflight({ env, executionIsRemote: false });
+    expect(result.ready).toBe(false);
+    expect(result.source).toBeNull();
+  });
+
+  it("fails OPEN for a remote execution target with no host-local credential", async () => {
+    // Regression (PR #9854 review): the host `auth.json` / `opencode.json`
+    // checks only describe a LOCAL OpenCode process. A remote (SSH) target may
+    // authenticate via `opencode auth login` on the server with no env keys, so
+    // the preflight must NOT block it merely because the host filesystem is
+    // empty. It fails open, preserving pre-preflight behaviour.
+    const env = await emptyIsolatedEnv();
+    const result = await evaluateOpenCodeCredentialPreflight({ env, executionIsRemote: true });
+    expect(result.ready).toBe(true);
+    expect(result.source).toBe("remote_unverified");
+  });
+
+  it("still recognises an env key on a remote target (env is forwarded to the remote)", async () => {
+    const env = await emptyIsolatedEnv();
+    env.ANTHROPIC_API_KEY = "test-key";
+    const result = await evaluateOpenCodeCredentialPreflight({ env, executionIsRemote: true });
+    expect(result.ready).toBe(true);
+    expect(result.source).toBe("env");
+  });
+
+  it("does not consult host auth files for a remote target even when present", async () => {
+    // A stale host auth.json on the orchestrator must not be mistaken for the
+    // remote's credential state: remote resolution is via env/gateway or fail-open.
+    const env = await emptyIsolatedEnv();
+    const authPath = resolveOpenCodeHostAuthPath(env);
+    await mkdir(path.dirname(authPath), { recursive: true });
+    await writeFile(authPath, JSON.stringify({ anthropic: { type: "oauth", access: "a" } }), "utf8");
+    const result = await evaluateOpenCodeCredentialPreflight({ env, executionIsRemote: true });
+    expect(result.ready).toBe(true);
+    expect(result.source).toBe("remote_unverified");
   });
 
   it("is ready for each documented provider env key", async () => {

--- a/packages/adapters/opencode-local/src/server/credential-preflight.test.ts
+++ b/packages/adapters/opencode-local/src/server/credential-preflight.test.ts
@@ -1,0 +1,124 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  OPENCODE_MISSING_CREDENTIAL_MESSAGE,
+  OPENCODE_PROVIDER_CREDENTIAL_ENV_KEYS,
+  evaluateOpenCodeCredentialPreflight,
+  resolveOpenCodeHostAuthPath,
+} from "./credential-preflight.js";
+
+describe("evaluateOpenCodeCredentialPreflight", () => {
+  const cleanupDirs: string[] = [];
+
+  afterEach(async () => {
+    while (cleanupDirs.length > 0) {
+      const dir = cleanupDirs.pop();
+      if (!dir) continue;
+      await rm(dir, { recursive: true, force: true }).catch(() => undefined);
+    }
+  });
+
+  async function emptyIsolatedEnv(): Promise<Record<string, string>> {
+    // Point every host-filesystem lookup at empty temp dirs so the host state of
+    // the machine running the tests cannot leak into the result.
+    const dataHome = await mkdtemp(path.join(os.tmpdir(), "paperclip-opencode-data-"));
+    const configHome = await mkdtemp(path.join(os.tmpdir(), "paperclip-opencode-config-"));
+    cleanupDirs.push(dataHome, configHome);
+    return {
+      XDG_DATA_HOME: dataHome,
+      XDG_CONFIG_HOME: configHome,
+    };
+  }
+
+  it("is not ready when no provider credential exists anywhere", async () => {
+    const env = await emptyIsolatedEnv();
+    const result = await evaluateOpenCodeCredentialPreflight({ env });
+    expect(result.ready).toBe(false);
+    expect(result.source).toBeNull();
+  });
+
+  it("is ready for each documented provider env key", async () => {
+    for (const key of OPENCODE_PROVIDER_CREDENTIAL_ENV_KEYS) {
+      const env = await emptyIsolatedEnv();
+      env[key] = "test-key";
+      const result = await evaluateOpenCodeCredentialPreflight({ env });
+      expect(result.ready, `expected ${key} to satisfy the preflight`).toBe(true);
+      expect(result.source).toBe("env");
+    }
+  });
+
+  it("ignores empty and whitespace-only env values", async () => {
+    const env = await emptyIsolatedEnv();
+    env.ANTHROPIC_API_KEY = "   ";
+    env.OPENAI_API_KEY = "";
+    const result = await evaluateOpenCodeCredentialPreflight({ env });
+    expect(result.ready).toBe(false);
+  });
+
+  it("treats a configured OpenAI-compatible base URL as a connected provider", async () => {
+    const env = await emptyIsolatedEnv();
+    env.OPENAI_API_BASE = "http://127.0.0.1:11434/v1";
+    const result = await evaluateOpenCodeCredentialPreflight({ env });
+    expect(result.ready).toBe(true);
+    expect(result.source).toBe("env");
+  });
+
+  it("treats injected gateway providers (PAPERCLIP_OPENCODE_PROVIDERS) as credentials", async () => {
+    const env = await emptyIsolatedEnv();
+    env.PAPERCLIP_OPENCODE_PROVIDERS = JSON.stringify({
+      "eu-gateway": { options: { baseURL: "https://gateway.example/v1", apiKey: "vk-123" }, models: {} },
+    });
+    const result = await evaluateOpenCodeCredentialPreflight({ env });
+    expect(result.ready).toBe(true);
+    expect(result.source).toBe("custom_providers");
+  });
+
+  it("does not treat malformed PAPERCLIP_OPENCODE_PROVIDERS as credentials", async () => {
+    const env = await emptyIsolatedEnv();
+    env.PAPERCLIP_OPENCODE_PROVIDERS = "{not json";
+    const result = await evaluateOpenCodeCredentialPreflight({ env });
+    expect(result.ready).toBe(false);
+  });
+
+  it("treats host-level opencode auth (auth.json in the data dir) as credentials", async () => {
+    const env = await emptyIsolatedEnv();
+    const authPath = resolveOpenCodeHostAuthPath(env);
+    await mkdir(path.dirname(authPath), { recursive: true });
+    await writeFile(authPath, JSON.stringify({ anthropic: { type: "oauth", refresh: "r", access: "a" } }), "utf8");
+    const result = await evaluateOpenCodeCredentialPreflight({ env });
+    expect(result.ready).toBe(true);
+    expect(result.source).toBe("host_auth");
+  });
+
+  it("ignores an empty or unparseable host auth.json", async () => {
+    const env = await emptyIsolatedEnv();
+    const authPath = resolveOpenCodeHostAuthPath(env);
+    await mkdir(path.dirname(authPath), { recursive: true });
+    await writeFile(authPath, "{}", "utf8");
+    expect((await evaluateOpenCodeCredentialPreflight({ env })).ready).toBe(false);
+    await writeFile(authPath, "not json", "utf8");
+    expect((await evaluateOpenCodeCredentialPreflight({ env })).ready).toBe(false);
+  });
+
+  it("treats provider blocks in the host opencode config as credentials", async () => {
+    const env = await emptyIsolatedEnv();
+    const configPath = path.join(env.XDG_CONFIG_HOME!, "opencode", "opencode.json");
+    await mkdir(path.dirname(configPath), { recursive: true });
+    await writeFile(
+      configPath,
+      JSON.stringify({ provider: { local: { options: { baseURL: "http://127.0.0.1:8080/v1" } } } }),
+      "utf8",
+    );
+    const result = await evaluateOpenCodeCredentialPreflight({ env });
+    expect(result.ready).toBe(true);
+    expect(result.source).toBe("host_config");
+  });
+
+  it("keeps the missing-credential message plain and actionable", () => {
+    expect(OPENCODE_MISSING_CREDENTIAL_MESSAGE).toBe(
+      "No model provider credential is connected for this agent. Connect a provider key, then resume.",
+    );
+  });
+});

--- a/packages/adapters/opencode-local/src/server/credential-preflight.test.ts
+++ b/packages/adapters/opencode-local/src/server/credential-preflight.test.ts
@@ -49,6 +49,20 @@ describe("evaluateOpenCodeCredentialPreflight", () => {
     }
   });
 
+  it("is ready for an env-only credential from a provider beyond the connect UI's three", async () => {
+    // Regression: OpenCode supports many providers, but preflight used to only
+    // recognise Anthropic/OpenAI/OpenRouter, so a valid key for another
+    // provider set directly in the env false-failed as inference_auth_invalid.
+    for (const key of ["GEMINI_API_KEY", "GOOGLE_API_KEY", "MISTRAL_API_KEY", "GROQ_API_KEY", "AWS_ACCESS_KEY_ID", "AZURE_OPENAI_API_KEY"]) {
+      const env = await emptyIsolatedEnv();
+      env[key] = "test-key";
+      const result = await evaluateOpenCodeCredentialPreflight({ env });
+      expect(result.ready, `expected ${key} to satisfy the preflight`).toBe(true);
+      expect(result.source).toBe("env");
+      expect(result.detail).toBe(key);
+    }
+  });
+
   it("ignores empty and whitespace-only env values", async () => {
     const env = await emptyIsolatedEnv();
     env.ANTHROPIC_API_KEY = "   ";

--- a/packages/adapters/opencode-local/src/server/credential-preflight.ts
+++ b/packages/adapters/opencode-local/src/server/credential-preflight.ts
@@ -1,0 +1,124 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+// ---------------------------------------------------------------------------
+// OpenCode credential preflight
+//
+// An OpenCode run with no model-provider credential fails with the opaque
+// "Unexpected server error. Check server logs for details.", which classifies
+// as a transient upstream error and feeds an endless automation retry storm.
+// This preflight detects the no-credential state BEFORE launching OpenCode so
+// the run can fail fast with the permanent errorCode `inference_auth_invalid`
+// (which the heartbeat pauses on).
+//
+// It must never fail a run that could authenticate: env keys, injected gateway
+// providers, host-level `opencode auth login` state, and host config provider
+// blocks all count as credentials. When in doubt it reports ready and lets
+// OpenCode itself decide (the status quo), mirroring how codex-local's
+// credential readiness check treats external overrides as self-managed.
+// ---------------------------------------------------------------------------
+
+/**
+ * Env keys opencode-local documents for provider credentials (see
+ * `ui/credential-setup.ts`), plus base-URL overrides: a configured
+ * OpenAI-compatible endpoint (e.g. a local proxy or an EU gateway) may
+ * intentionally require no key, so its presence counts as a connected provider.
+ */
+export const OPENCODE_PROVIDER_CREDENTIAL_ENV_KEYS = [
+  "ANTHROPIC_API_KEY",
+  "OPENAI_API_KEY",
+  "OPENROUTER_API_KEY",
+  "OPENAI_API_BASE",
+  "OPENAI_BASE_URL",
+  "ANTHROPIC_BASE_URL",
+] as const;
+
+export const OPENCODE_MISSING_CREDENTIAL_MESSAGE =
+  "No model provider credential is connected for this agent. Connect a provider key, then resume.";
+
+export interface OpenCodeCredentialPreflight {
+  ready: boolean;
+  source: "env" | "custom_providers" | "host_config" | "host_auth" | null;
+  /** The env key or file path that satisfied the preflight, for run-log diagnostics. */
+  detail: string | null;
+}
+
+function nonEmpty(value: string | undefined): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** Host path where `opencode auth login` stores credentials. */
+export function resolveOpenCodeHostAuthPath(env: Record<string, string>): string {
+  const dataHome = nonEmpty(env.XDG_DATA_HOME) ?? path.join(os.homedir(), ".local", "share");
+  return path.join(dataHome, "opencode", "auth.json");
+}
+
+/** Host path of the user's own opencode config (may carry provider blocks). */
+export function resolveOpenCodeHostConfigPath(env: Record<string, string>): string {
+  const configHome = nonEmpty(env.XDG_CONFIG_HOME) ?? path.join(os.homedir(), ".config");
+  return path.join(configHome, "opencode", "opencode.json");
+}
+
+async function readJsonObject(filepath: string): Promise<Record<string, unknown> | null> {
+  try {
+    const raw = await fs.readFile(filepath, "utf8");
+    const parsed = JSON.parse(raw);
+    return isPlainObject(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function customProvidersConfigured(env: Record<string, string>): boolean {
+  const raw = nonEmpty(env.PAPERCLIP_OPENCODE_PROVIDERS);
+  if (!raw) return false;
+  try {
+    const parsed = JSON.parse(raw);
+    return isPlainObject(parsed) && Object.values(parsed).some(isPlainObject);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Decide whether an OpenCode run launched with `env` has any chance to
+ * authenticate against a model provider. Pure over `env` (callers pass the
+ * fully-merged run env, process env included) apart from the host filesystem
+ * lookups for `opencode auth login` state and the host config.
+ */
+export async function evaluateOpenCodeCredentialPreflight(input: {
+  env: Record<string, string>;
+}): Promise<OpenCodeCredentialPreflight> {
+  const { env } = input;
+
+  for (const key of OPENCODE_PROVIDER_CREDENTIAL_ENV_KEYS) {
+    if (nonEmpty(env[key])) {
+      return { ready: true, source: "env", detail: key };
+    }
+  }
+
+  if (customProvidersConfigured(env)) {
+    return { ready: true, source: "custom_providers", detail: "PAPERCLIP_OPENCODE_PROVIDERS" };
+  }
+
+  const hostConfigPath = resolveOpenCodeHostConfigPath(env);
+  const hostConfig = await readJsonObject(hostConfigPath);
+  if (hostConfig && isPlainObject(hostConfig.provider) && Object.keys(hostConfig.provider).length > 0) {
+    return { ready: true, source: "host_config", detail: hostConfigPath };
+  }
+
+  const hostAuthPath = resolveOpenCodeHostAuthPath(env);
+  const hostAuth = await readJsonObject(hostAuthPath);
+  if (hostAuth && Object.keys(hostAuth).length > 0) {
+    return { ready: true, source: "host_auth", detail: hostAuthPath };
+  }
+
+  return { ready: false, source: null, detail: null };
+}

--- a/packages/adapters/opencode-local/src/server/credential-preflight.ts
+++ b/packages/adapters/opencode-local/src/server/credential-preflight.ts
@@ -17,6 +17,17 @@ import path from "node:path";
 // blocks all count as credentials. When in doubt it reports ready and lets
 // OpenCode itself decide (the status quo), mirroring how codex-local's
 // credential readiness check treats external overrides as self-managed.
+//
+// Local vs remote: the host `auth.json` / `opencode.json` filesystem checks
+// only prove anything for a LOCAL OpenCode process. When execution targets a
+// REMOTE machine (SSH / sandbox), OpenCode authenticates against the remote's
+// own `opencode auth login` state, which this host cannot see. Probing the
+// host filesystem there would false-negative a remote agent that is perfectly
+// authenticated on the server. So for remote execution we only trust signals
+// that travel to the remote (env keys, injected gateway providers) and
+// otherwise fail OPEN (cannot verify locally -> do not block), preserving the
+// pre-preflight behaviour. Only a LOCAL run with no detectable credential is
+// blocked.
 // ---------------------------------------------------------------------------
 
 /**
@@ -60,7 +71,7 @@ export const OPENCODE_MISSING_CREDENTIAL_MESSAGE =
 
 export interface OpenCodeCredentialPreflight {
   ready: boolean;
-  source: "env" | "custom_providers" | "host_config" | "host_auth" | null;
+  source: "env" | "custom_providers" | "host_config" | "host_auth" | "remote_unverified" | null;
   /** The env key or file path that satisfied the preflight, for run-log diagnostics. */
   detail: string | null;
 }
@@ -113,12 +124,24 @@ function customProvidersConfigured(env: Record<string, string>): boolean {
  * authenticate against a model provider. Pure over `env` (callers pass the
  * fully-merged run env, process env included) apart from the host filesystem
  * lookups for `opencode auth login` state and the host config.
+ *
+ * `executionIsRemote` gates the host filesystem probes: they only describe a
+ * LOCAL OpenCode process, so on a remote (SSH / sandbox) execution target they
+ * are skipped and the preflight fails OPEN when no env-forwardable credential
+ * is found (the remote holds its own auth). Only a local run with no
+ * detectable credential is blocked. Defaults to local for backward
+ * compatibility.
  */
 export async function evaluateOpenCodeCredentialPreflight(input: {
   env: Record<string, string>;
+  executionIsRemote?: boolean;
 }): Promise<OpenCodeCredentialPreflight> {
   const { env } = input;
+  const executionIsRemote = input.executionIsRemote ?? false;
 
+  // Env keys and injected gateway providers travel to the remote (they are
+  // forwarded in the run env), so they are trustworthy signals in BOTH local
+  // and remote execution.
   for (const key of OPENCODE_PROVIDER_CREDENTIAL_ENV_KEYS) {
     if (nonEmpty(env[key])) {
       return { ready: true, source: "env", detail: key };
@@ -129,16 +152,29 @@ export async function evaluateOpenCodeCredentialPreflight(input: {
     return { ready: true, source: "custom_providers", detail: "PAPERCLIP_OPENCODE_PROVIDERS" };
   }
 
-  const hostConfigPath = resolveOpenCodeHostConfigPath(env);
-  const hostConfig = await readJsonObject(hostConfigPath);
-  if (hostConfig && isPlainObject(hostConfig.provider) && Object.keys(hostConfig.provider).length > 0) {
-    return { ready: true, source: "host_config", detail: hostConfigPath };
+  // Host filesystem auth/config only authenticates a LOCAL OpenCode process.
+  // For a remote target the remote host holds its own `opencode auth login`
+  // state, invisible from here, so these probes are meaningless there.
+  if (!executionIsRemote) {
+    const hostConfigPath = resolveOpenCodeHostConfigPath(env);
+    const hostConfig = await readJsonObject(hostConfigPath);
+    if (hostConfig && isPlainObject(hostConfig.provider) && Object.keys(hostConfig.provider).length > 0) {
+      return { ready: true, source: "host_config", detail: hostConfigPath };
+    }
+
+    const hostAuthPath = resolveOpenCodeHostAuthPath(env);
+    const hostAuth = await readJsonObject(hostAuthPath);
+    if (hostAuth && Object.keys(hostAuth).length > 0) {
+      return { ready: true, source: "host_auth", detail: hostAuthPath };
+    }
   }
 
-  const hostAuthPath = resolveOpenCodeHostAuthPath(env);
-  const hostAuth = await readJsonObject(hostAuthPath);
-  if (hostAuth && Object.keys(hostAuth).length > 0) {
-    return { ready: true, source: "host_auth", detail: hostAuthPath };
+  // Remote target with no env-forwardable credential: the remote may still be
+  // authenticated via `opencode auth login` with no env keys. We cannot verify
+  // that from here, so fail OPEN (do not block) to preserve pre-preflight
+  // behaviour for remote-execution setups. Blocking is reserved for local runs.
+  if (executionIsRemote) {
+    return { ready: true, source: "remote_unverified", detail: null };
   }
 
   return { ready: false, source: null, detail: null };

--- a/packages/adapters/opencode-local/src/server/credential-preflight.ts
+++ b/packages/adapters/opencode-local/src/server/credential-preflight.ts
@@ -20,18 +20,39 @@ import path from "node:path";
 // ---------------------------------------------------------------------------
 
 /**
- * Env keys opencode-local documents for provider credentials (see
- * `ui/credential-setup.ts`), plus base-URL overrides: a configured
- * OpenAI-compatible endpoint (e.g. a local proxy or an EU gateway) may
- * intentionally require no key, so its presence counts as a connected provider.
+ * Env keys that satisfy an OpenCode provider credential. OpenCode supports far
+ * more providers than the three we surface in our own connect UI, and a user
+ * may set any of these directly in `config.env` or the host env. Preflight must
+ * recognise every provider OpenCode itself authenticates from an env key, or it
+ * false-negatives a valid credential into `inference_auth_invalid` and pauses a
+ * runnable agent. Keys mirror the provider env names OpenCode reads (via the
+ * Vercel AI SDK / models.dev provider definitions). Base-URL overrides are also
+ * listed: a configured OpenAI-compatible endpoint (e.g. a local proxy or an EU
+ * gateway) may intentionally require no key, so its presence counts too.
  */
 export const OPENCODE_PROVIDER_CREDENTIAL_ENV_KEYS = [
+  // Anthropic
   "ANTHROPIC_API_KEY",
+  "ANTHROPIC_BASE_URL",
+  // OpenAI
   "OPENAI_API_KEY",
-  "OPENROUTER_API_KEY",
   "OPENAI_API_BASE",
   "OPENAI_BASE_URL",
-  "ANTHROPIC_BASE_URL",
+  // OpenRouter
+  "OPENROUTER_API_KEY",
+  // Google Gemini
+  "GOOGLE_API_KEY",
+  "GEMINI_API_KEY",
+  "GOOGLE_GENERATIVE_AI_API_KEY",
+  // Mistral
+  "MISTRAL_API_KEY",
+  // Groq
+  "GROQ_API_KEY",
+  // AWS Bedrock (AWS_SECRET_ACCESS_KEY and a region usually accompany it, but
+  // the access-key id is the credential signal we key on).
+  "AWS_ACCESS_KEY_ID",
+  // Azure OpenAI
+  "AZURE_OPENAI_API_KEY",
 ] as const;
 
 export const OPENCODE_MISSING_CREDENTIAL_MESSAGE =

--- a/packages/adapters/opencode-local/src/server/execute.credential-preflight.test.ts
+++ b/packages/adapters/opencode-local/src/server/execute.credential-preflight.test.ts
@@ -105,14 +105,78 @@ describe("opencode credential preflight in execute", () => {
     return env;
   }
 
-  it("fails fast with inference_auth_invalid when the run has no provider credential", async () => {
+  it("fails fast with inference_auth_invalid for a LOCAL run with no provider credential", async () => {
     const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-opencode-nocred-"));
     cleanupDirs.push(rootDir);
     const workspaceDir = path.join(rootDir, "workspace");
     await mkdir(workspaceDir, { recursive: true });
 
     const result = await execute({
-      runId: "run-nocred-1",
+      runId: "run-nocred-local-1",
+      agent: {
+        id: "agent-1",
+        companyId: "company-1",
+        name: "OpenCode Builder",
+        adapterType: "opencode_local",
+        adapterConfig: {},
+      },
+      runtime: {
+        sessionId: null,
+        sessionParams: null,
+        sessionDisplayId: null,
+        taskKey: null,
+      },
+      config: {
+        command: "opencode",
+        model: "anthropic/claude-sonnet-4-5",
+        env: await buildCredentiallessConfigEnv(),
+      },
+      context: {
+        paperclipWorkspace: {
+          cwd: workspaceDir,
+          source: "project_primary",
+        },
+      },
+      // No executionTransport => LOCAL execution: the host filesystem IS the
+      // credential store, so an empty one legitimately blocks.
+      onLog: async () => {},
+    });
+
+    expect(result.errorCode).toBe("inference_auth_invalid");
+    expect(result.errorMessage).toBe(
+      "No model provider credential is connected for this agent. Connect a provider key, then resume.",
+    );
+    expect(result.exitCode).not.toBe(0);
+    expect(result.timedOut).toBe(false);
+
+    // Fail FAST: no OpenCode process launch happened.
+    expect(runChildProcess).not.toHaveBeenCalled();
+  });
+
+  it("does NOT block a REMOTE run with no host-local credential (remote holds its own auth)", async () => {
+    // Regression (PR #9854 review): the preflight's host `auth.json` /
+    // `opencode.json` checks describe only a LOCAL OpenCode process. For a
+    // remote (SSH) target authenticated via `opencode auth login` on the
+    // server with no env keys, the preflight must fail OPEN and let execution
+    // proceed, not pause the agent with inference_auth_invalid.
+    const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-opencode-nocred-remote-"));
+    cleanupDirs.push(rootDir);
+    const workspaceDir = path.join(rootDir, "workspace");
+    await mkdir(workspaceDir, { recursive: true });
+    // With the preflight open, execution reaches the remote model probe; make
+    // it succeed so the run is not blocked for an unrelated reason.
+    runChildProcess.mockResolvedValue({
+      exitCode: 0,
+      signal: null,
+      timedOut: false,
+      stdout: "anthropic/claude-sonnet-4-5\n",
+      stderr: "",
+      pid: 123,
+      startedAt: new Date().toISOString(),
+    });
+
+    const result = await execute({
+      runId: "run-nocred-remote-1",
       agent: {
         id: "agent-1",
         companyId: "company-1",
@@ -152,16 +216,9 @@ describe("opencode credential preflight in execute", () => {
       onLog: async () => {},
     });
 
-    expect(result.errorCode).toBe("inference_auth_invalid");
-    expect(result.errorMessage).toBe(
-      "No model provider credential is connected for this agent. Connect a provider key, then resume.",
-    );
-    expect(result.exitCode).not.toBe(0);
-    expect(result.timedOut).toBe(false);
-
-    // Fail FAST: no workspace sync and no OpenCode process launch happened.
-    expect(prepareWorkspaceForSshExecution).not.toHaveBeenCalled();
-    expect(runChildProcess).not.toHaveBeenCalled();
+    // Not blocked by the credential preflight: execution proceeded.
+    expect(result.errorCode ?? null).not.toBe("inference_auth_invalid");
+    expect(runChildProcess).toHaveBeenCalled();
   });
 
   it("does not fail fast when a provider credential is present in the run env", async () => {

--- a/packages/adapters/opencode-local/src/server/execute.credential-preflight.test.ts
+++ b/packages/adapters/opencode-local/src/server/execute.credential-preflight.test.ts
@@ -1,0 +1,230 @@
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const {
+  runChildProcess,
+  ensureCommandResolvable,
+  resolveCommandForLogs,
+  prepareWorkspaceForSshExecution,
+  restoreWorkspaceFromSshExecution,
+  runSshCommand,
+  syncDirectoryToSsh,
+  startAdapterExecutionTargetPaperclipBridge,
+} = vi.hoisted(() => ({
+  runChildProcess: vi.fn(async () => ({
+    exitCode: 0,
+    signal: null,
+    timedOut: false,
+    stdout: "",
+    stderr: "",
+    pid: 123,
+    startedAt: new Date().toISOString(),
+  })),
+  ensureCommandResolvable: vi.fn(async () => undefined),
+  resolveCommandForLogs: vi.fn(async () => "ssh://fixture@127.0.0.1:2222/remote/workspace :: opencode"),
+  prepareWorkspaceForSshExecution: vi.fn(async () => ({ gitBacked: false })),
+  restoreWorkspaceFromSshExecution: vi.fn(async () => undefined),
+  runSshCommand: vi.fn(async () => ({ stdout: "/home/agent", stderr: "", exitCode: 0 })),
+  syncDirectoryToSsh: vi.fn(async () => undefined),
+  startAdapterExecutionTargetPaperclipBridge: vi.fn(async () => ({
+    env: {
+      PAPERCLIP_API_URL: "http://127.0.0.1:4310",
+      PAPERCLIP_API_KEY: "bridge-token",
+      PAPERCLIP_API_BRIDGE_MODE: "queue_v1",
+    },
+    stop: async () => {},
+  })),
+}));
+
+vi.mock("@paperclipai/adapter-utils/server-utils", async () => {
+  const actual = await vi.importActual<typeof import("@paperclipai/adapter-utils/server-utils")>(
+    "@paperclipai/adapter-utils/server-utils",
+  );
+  return {
+    ...actual,
+    ensureCommandResolvable,
+    resolveCommandForLogs,
+    runChildProcess,
+  };
+});
+
+vi.mock("@paperclipai/adapter-utils/ssh", async () => {
+  const actual = await vi.importActual<typeof import("@paperclipai/adapter-utils/ssh")>(
+    "@paperclipai/adapter-utils/ssh",
+  );
+  return {
+    ...actual,
+    prepareWorkspaceForSshExecution,
+    restoreWorkspaceFromSshExecution,
+    runSshCommand,
+    syncDirectoryToSsh,
+  };
+});
+
+vi.mock("@paperclipai/adapter-utils/execution-target", async () => {
+  const actual = await vi.importActual<typeof import("@paperclipai/adapter-utils/execution-target")>(
+    "@paperclipai/adapter-utils/execution-target",
+  );
+  return {
+    ...actual,
+    startAdapterExecutionTargetPaperclipBridge,
+  };
+});
+
+import { OPENCODE_PROVIDER_CREDENTIAL_ENV_KEYS } from "./credential-preflight.js";
+import { execute } from "./execute.js";
+
+describe("opencode credential preflight in execute", () => {
+  const cleanupDirs: string[] = [];
+
+  afterEach(async () => {
+    vi.clearAllMocks();
+    while (cleanupDirs.length > 0) {
+      const dir = cleanupDirs.pop();
+      if (!dir) continue;
+      await rm(dir, { recursive: true, force: true }).catch(() => undefined);
+    }
+  });
+
+  async function buildCredentiallessConfigEnv(): Promise<Record<string, string>> {
+    // Mask any credential the host machine running the tests may carry: the run
+    // env overrides process.env, and empty values do not count as credentials.
+    const dataHome = await mkdtemp(path.join(os.tmpdir(), "paperclip-opencode-data-"));
+    const configHome = await mkdtemp(path.join(os.tmpdir(), "paperclip-opencode-config-"));
+    cleanupDirs.push(dataHome, configHome);
+    const env: Record<string, string> = {
+      XDG_DATA_HOME: dataHome,
+      XDG_CONFIG_HOME: configHome,
+      PAPERCLIP_OPENCODE_PROVIDERS: "",
+    };
+    for (const key of OPENCODE_PROVIDER_CREDENTIAL_ENV_KEYS) {
+      env[key] = "";
+    }
+    return env;
+  }
+
+  it("fails fast with inference_auth_invalid when the run has no provider credential", async () => {
+    const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-opencode-nocred-"));
+    cleanupDirs.push(rootDir);
+    const workspaceDir = path.join(rootDir, "workspace");
+    await mkdir(workspaceDir, { recursive: true });
+
+    const result = await execute({
+      runId: "run-nocred-1",
+      agent: {
+        id: "agent-1",
+        companyId: "company-1",
+        name: "OpenCode Builder",
+        adapterType: "opencode_local",
+        adapterConfig: {},
+      },
+      runtime: {
+        sessionId: null,
+        sessionParams: null,
+        sessionDisplayId: null,
+        taskKey: null,
+      },
+      config: {
+        command: "opencode",
+        model: "anthropic/claude-sonnet-4-5",
+        env: await buildCredentiallessConfigEnv(),
+      },
+      context: {
+        paperclipWorkspace: {
+          cwd: workspaceDir,
+          source: "project_primary",
+        },
+      },
+      executionTransport: {
+        remoteExecution: {
+          host: "127.0.0.1",
+          port: 2222,
+          username: "fixture",
+          remoteWorkspacePath: "/remote/workspace",
+          remoteCwd: "/remote/workspace",
+          privateKey: "PRIVATE KEY",
+          knownHosts: "[127.0.0.1]:2222 ssh-ed25519 AAAA",
+          strictHostKeyChecking: true,
+        },
+      },
+      onLog: async () => {},
+    });
+
+    expect(result.errorCode).toBe("inference_auth_invalid");
+    expect(result.errorMessage).toBe(
+      "No model provider credential is connected for this agent. Connect a provider key, then resume.",
+    );
+    expect(result.exitCode).not.toBe(0);
+    expect(result.timedOut).toBe(false);
+
+    // Fail FAST: no workspace sync and no OpenCode process launch happened.
+    expect(prepareWorkspaceForSshExecution).not.toHaveBeenCalled();
+    expect(runChildProcess).not.toHaveBeenCalled();
+  });
+
+  it("does not fail fast when a provider credential is present in the run env", async () => {
+    const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-opencode-cred-"));
+    cleanupDirs.push(rootDir);
+    const workspaceDir = path.join(rootDir, "workspace");
+    await mkdir(workspaceDir, { recursive: true });
+    const env = await buildCredentiallessConfigEnv();
+    env.ANTHROPIC_API_KEY = "test-key";
+    // Keep the run local and cheap: with a credential present the preflight
+    // passes and execution proceeds to the model probe, which we make succeed.
+    runChildProcess.mockResolvedValue({
+      exitCode: 0,
+      signal: null,
+      timedOut: false,
+      stdout: "anthropic/claude-sonnet-4-5\n",
+      stderr: "",
+      pid: 123,
+      startedAt: new Date().toISOString(),
+    });
+
+    const result = await execute({
+      runId: "run-cred-1",
+      agent: {
+        id: "agent-1",
+        companyId: "company-1",
+        name: "OpenCode Builder",
+        adapterType: "opencode_local",
+        adapterConfig: {},
+      },
+      runtime: {
+        sessionId: null,
+        sessionParams: null,
+        sessionDisplayId: null,
+        taskKey: null,
+      },
+      config: {
+        command: "opencode",
+        model: "anthropic/claude-sonnet-4-5",
+        env,
+      },
+      context: {
+        paperclipWorkspace: {
+          cwd: workspaceDir,
+          source: "project_primary",
+        },
+      },
+      executionTransport: {
+        remoteExecution: {
+          host: "127.0.0.1",
+          port: 2222,
+          username: "fixture",
+          remoteWorkspacePath: "/remote/workspace",
+          remoteCwd: "/remote/workspace",
+          privateKey: "PRIVATE KEY",
+          knownHosts: "[127.0.0.1]:2222 ssh-ed25519 AAAA",
+          strictHostKeyChecking: true,
+        },
+      },
+      onLog: async () => {},
+    });
+
+    expect(result.errorCode ?? null).not.toBe("inference_auth_invalid");
+    expect(runChildProcess).toHaveBeenCalled();
+  });
+});

--- a/packages/adapters/opencode-local/src/server/execute.remote.test.ts
+++ b/packages/adapters/opencode-local/src/server/execute.remote.test.ts
@@ -149,6 +149,9 @@ describe("opencode remote execution", () => {
       config: {
         command: "opencode",
         model: "opencode/gpt-5-nano",
+        // Explicit credential so the preflight outcome never depends on the
+        // host machine running the tests.
+        env: { OPENAI_API_KEY: "test-preflight-key" },
       },
       context: {
         paperclipWorkspace: {
@@ -285,6 +288,7 @@ describe("opencode remote execution", () => {
         config: {
           command: "opencode",
           model: "opencode/gpt-5-nano",
+          env: { OPENAI_API_KEY: "test-preflight-key" },
         },
         context: {
           paperclipWorkspace: {
@@ -348,6 +352,9 @@ describe("opencode remote execution", () => {
       config: {
         command: "opencode",
         model: "opencode/gpt-5-nano",
+        // Explicit credential so the preflight outcome never depends on the
+        // host machine running the tests.
+        env: { OPENAI_API_KEY: "test-preflight-key" },
       },
       context: {
         paperclipWorkspace: {

--- a/packages/adapters/opencode-local/src/server/execute.ts
+++ b/packages/adapters/opencode-local/src/server/execute.ts
@@ -330,8 +330,13 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     // transient "Unexpected server error" and feeds an endless retry storm.
     // Host-level auth (`opencode auth login`), host config providers, injected
     // gateway providers, and env keys all pass, so self-hosted setups that
-    // authenticate on the host are unaffected.
-    const credentialPreflight = await evaluateOpenCodeCredentialPreflight({ env: runtimeEnv });
+    // authenticate on the host are unaffected. For a REMOTE execution target
+    // the host filesystem holds no relevant auth (the remote authenticates
+    // itself), so the preflight fails open there and only blocks local runs.
+    const credentialPreflight = await evaluateOpenCodeCredentialPreflight({
+      env: runtimeEnv,
+      executionIsRemote: executionTargetIsRemote,
+    });
     if (!credentialPreflight.ready) {
       await onLog("stderr", `[paperclip] ${OPENCODE_MISSING_CREDENTIAL_MESSAGE}\n`);
       return {

--- a/packages/adapters/opencode-local/src/server/execute.ts
+++ b/packages/adapters/opencode-local/src/server/execute.ts
@@ -45,6 +45,10 @@ import {
   readPaperclipIssueWorkModeFromContext,
   resolvePaperclipDesiredSkillNames,
 } from "@paperclipai/adapter-utils/server-utils";
+import {
+  OPENCODE_MISSING_CREDENTIAL_MESSAGE,
+  evaluateOpenCodeCredentialPreflight,
+} from "./credential-preflight.js";
 import { isOpenCodeUnknownSessionError, parseOpenCodeJsonl } from "./parse.js";
 import {
   ensureOpenCodeModelConfiguredAndAvailable,
@@ -319,6 +323,32 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         (entry): entry is [string, string] => typeof entry[1] === "string",
       ),
     );
+    // Credential preflight: a run with no chance to authenticate against any
+    // model provider must fail fast with the permanent errorCode
+    // `inference_auth_invalid` (the heartbeat pauses the agent on it) instead of
+    // launching OpenCode, which wraps the missing credential as an opaque
+    // transient "Unexpected server error" and feeds an endless retry storm.
+    // Host-level auth (`opencode auth login`), host config providers, injected
+    // gateway providers, and env keys all pass, so self-hosted setups that
+    // authenticate on the host are unaffected.
+    const credentialPreflight = await evaluateOpenCodeCredentialPreflight({ env: runtimeEnv });
+    if (!credentialPreflight.ready) {
+      await onLog("stderr", `[paperclip] ${OPENCODE_MISSING_CREDENTIAL_MESSAGE}\n`);
+      return {
+        exitCode: 1,
+        signal: null,
+        timedOut: false,
+        errorMessage: OPENCODE_MISSING_CREDENTIAL_MESSAGE,
+        errorCode: "inference_auth_invalid",
+        errorMeta: {
+          credentialPreflight: "missing_provider_credential",
+        },
+        resultJson: {
+          credentialPreflight: "missing_provider_credential",
+        },
+      };
+    }
+
     const timeoutSec = resolveAdapterExecutionTargetTimeoutSec(
       executionTarget,
       asNumber(config.timeoutSec, 0),

--- a/server/src/__tests__/heartbeat-retry-scheduling.test.ts
+++ b/server/src/__tests__/heartbeat-retry-scheduling.test.ts
@@ -25,6 +25,7 @@ import {
 import { registerServerAdapter, unregisterServerAdapter } from "../adapters/index.ts";
 import {
   BOUNDED_TRANSIENT_HEARTBEAT_RETRY_DELAYS_MS,
+  CONSECUTIVE_IDENTICAL_FAILURE_PAUSE_THRESHOLD,
   INTERACTION_CONTINUATION_INFRA_RETRY_REASON,
   INTERACTION_CONTINUATION_INFRA_WAKE_REASON,
   MAX_TURN_CONTINUATION_RETRY_REASON,
@@ -36,6 +37,8 @@ const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
 const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
 const PROVIDER_QUOTA_TEST_ADAPTER = "provider_quota_test";
 const AUTH_FAILURE_TEST_ADAPTER = "auth_failure_test";
+const IDENTICAL_FAILURE_TEST_ADAPTER = "identical_failure_test";
+const IDENTICAL_FAILURE_TEST_ERROR_CODE = "stuck_failure_test";
 
 if (!embeddedPostgresSupport.supported) {
   console.warn(
@@ -90,6 +93,23 @@ describeEmbeddedPostgres("heartbeat bounded retry scheduling", () => {
       }),
     });
     registerServerAdapter({
+      type: IDENTICAL_FAILURE_TEST_ADAPTER,
+      execute: async () => ({
+        exitCode: 1,
+        signal: null,
+        timedOut: false,
+        errorMessage: "Same failure every run.",
+        errorCode: IDENTICAL_FAILURE_TEST_ERROR_CODE,
+        resultJson: {},
+      }),
+      testEnvironment: async () => ({
+        adapterType: IDENTICAL_FAILURE_TEST_ADAPTER,
+        status: "pass",
+        checks: [],
+        testedAt: new Date().toISOString(),
+      }),
+    });
+    registerServerAdapter({
       type: AUTH_FAILURE_TEST_ADAPTER,
       execute: async () => ({
         exitCode: 1,
@@ -115,6 +135,7 @@ describeEmbeddedPostgres("heartbeat bounded retry scheduling", () => {
   afterAll(async () => {
     unregisterServerAdapter(PROVIDER_QUOTA_TEST_ADAPTER);
     unregisterServerAdapter(AUTH_FAILURE_TEST_ADAPTER);
+    unregisterServerAdapter(IDENTICAL_FAILURE_TEST_ADAPTER);
     await tempDb?.cleanup();
   });
 
@@ -348,6 +369,156 @@ describeEmbeddedPostgres("heartbeat bounded retry scheduling", () => {
       .where(eq(agents.id, agentId))
       .then((rows) => rows[0] ?? null);
     expect(pausedAgent?.pauseReason).toContain("Connect a model key");
+  });
+
+  async function seedIdenticalFailureFixture(input: {
+    companyId: string;
+    agentId: string;
+    priorRuns: Array<{ status: "failed" | "succeeded"; errorCode?: string | null }>;
+  }) {
+    await db.insert(companies).values({
+      id: input.companyId,
+      name: "Paperclip",
+      issuePrefix: `T${input.companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+      defaultResponsibleUserId: "responsible-user",
+    });
+
+    await db.insert(agents).values({
+      id: input.agentId,
+      companyId: input.companyId,
+      name: "Stuck Agent",
+      role: "engineer",
+      status: "idle",
+      adapterType: IDENTICAL_FAILURE_TEST_ADAPTER,
+      adapterConfig: {},
+      runtimeConfig: {
+        heartbeat: {
+          wakeOnDemand: true,
+          maxConcurrentRuns: 1,
+        },
+      },
+      permissions: {},
+    });
+
+    // Oldest first; each row gets an older createdAt so the newly invoked run is
+    // always the most recent one.
+    const base = Date.now() - input.priorRuns.length * 60_000;
+    for (const [index, prior] of input.priorRuns.entries()) {
+      const at = new Date(base + index * 60_000);
+      await db.insert(heartbeatRuns).values({
+        id: randomUUID(),
+        companyId: input.companyId,
+        agentId: input.agentId,
+        invocationSource: "assignment",
+        status: prior.status,
+        error: prior.status === "failed" ? "Same failure every run." : null,
+        errorCode: prior.status === "failed" ? (prior.errorCode ?? IDENTICAL_FAILURE_TEST_ERROR_CODE) : null,
+        finishedAt: at,
+        resultJson: {},
+        contextSnapshot: {},
+        createdAt: at,
+        updatedAt: at,
+      });
+    }
+  }
+
+  it("pauses an agent after N consecutive failed runs with the same error code", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    await seedIdenticalFailureFixture({
+      companyId,
+      agentId,
+      priorRuns: Array.from(
+        { length: CONSECUTIVE_IDENTICAL_FAILURE_PAUSE_THRESHOLD - 1 },
+        () => ({ status: "failed" as const }),
+      ),
+    });
+
+    const run = await heartbeat.invoke(agentId, "on_demand", {}, "manual");
+    expect(run).not.toBeNull();
+
+    const failedRun = await waitForRunToFinish(heartbeat, run!.id);
+    expect(failedRun?.status).toBe("failed");
+    expect(failedRun?.errorCode).toBe(IDENTICAL_FAILURE_TEST_ERROR_CODE);
+
+    await expect
+      .poll(
+        () =>
+          db
+            .select({ status: agents.status })
+            .from(agents)
+            .where(eq(agents.id, agentId))
+            .then((rows) => rows[0]?.status ?? null),
+        { timeout: 5_000, interval: 50 },
+      )
+      .toBe("paused");
+
+    const pausedAgent = await db
+      .select({ pauseReason: agents.pauseReason })
+      .from(agents)
+      .where(eq(agents.id, agentId))
+      .then((rows) => rows[0] ?? null);
+    expect(pausedAgent?.pauseReason).toContain(IDENTICAL_FAILURE_TEST_ERROR_CODE);
+    expect(pausedAgent?.pauseReason).toContain("then resume");
+  });
+
+  it("does not pause an agent whose identical-failure streak is below the threshold", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    await seedIdenticalFailureFixture({
+      companyId,
+      agentId,
+      priorRuns: Array.from(
+        { length: CONSECUTIVE_IDENTICAL_FAILURE_PAUSE_THRESHOLD - 2 },
+        () => ({ status: "failed" as const }),
+      ),
+    });
+
+    const run = await heartbeat.invoke(agentId, "on_demand", {}, "manual");
+    expect(run).not.toBeNull();
+
+    const failedRun = await waitForRunToFinish(heartbeat, run!.id);
+    expect(failedRun?.status).toBe("failed");
+
+    // Give the finalize pipeline time to (wrongly) pause before asserting.
+    await new Promise((resolve) => setTimeout(resolve, 700));
+    const agentStatus = await db
+      .select({ status: agents.status })
+      .from(agents)
+      .where(eq(agents.id, agentId))
+      .then((rows) => rows[0]?.status ?? null);
+    expect(agentStatus).not.toBe("paused");
+  });
+
+  it("does not pause an agent when a success or a different error code breaks the streak", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    await seedIdenticalFailureFixture({
+      companyId,
+      agentId,
+      priorRuns: [
+        { status: "failed" },
+        { status: "failed" },
+        { status: "succeeded" },
+        { status: "failed" },
+        { status: "failed", errorCode: "some_other_code" },
+      ],
+    });
+
+    const run = await heartbeat.invoke(agentId, "on_demand", {}, "manual");
+    expect(run).not.toBeNull();
+
+    const failedRun = await waitForRunToFinish(heartbeat, run!.id);
+    expect(failedRun?.status).toBe("failed");
+
+    await new Promise((resolve) => setTimeout(resolve, 700));
+    const agentStatus = await db
+      .select({ status: agents.status })
+      .from(agents)
+      .where(eq(agents.id, agentId))
+      .then((rows) => rows[0]?.status ?? null);
+    expect(agentStatus).not.toBe("paused");
   });
 
   async function seedMaxTurnFixture(input?: {

--- a/server/src/__tests__/heartbeat-retry-scheduling.test.ts
+++ b/server/src/__tests__/heartbeat-retry-scheduling.test.ts
@@ -39,6 +39,10 @@ const PROVIDER_QUOTA_TEST_ADAPTER = "provider_quota_test";
 const AUTH_FAILURE_TEST_ADAPTER = "auth_failure_test";
 const IDENTICAL_FAILURE_TEST_ADAPTER = "identical_failure_test";
 const IDENTICAL_FAILURE_TEST_ERROR_CODE = "stuck_failure_test";
+// Adapter that terminates its own agent mid-run to simulate an external
+// termination racing the storm-breaker pause. Its execute reads the mutable
+// target so a single registration serves every race test.
+const RACE_TERMINATE_TEST_ADAPTER = "race_terminate_test";
 
 if (!embeddedPostgresSupport.supported) {
   console.warn(
@@ -64,6 +68,12 @@ describeEmbeddedPostgres("heartbeat bounded retry scheduling", () => {
   let db!: ReturnType<typeof createDb>;
   let heartbeat!: ReturnType<typeof heartbeatService>;
   let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+  // When set, RACE_TERMINATE_TEST_ADAPTER flips this agent to "terminated" while
+  // its run executes, then fails with the given errorCode. The heartbeat holds an
+  // in-memory agent snapshot from before execution, so the storm-breaker pause
+  // must rely on its UPDATE ... WHERE status guard (not the stale snapshot) to
+  // avoid resurrecting a terminated agent as paused.
+  let raceTerminateTarget: { agentId: string; errorCode: string } | null = null;
 
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-heartbeat-retry-scheduling-");
@@ -126,9 +136,36 @@ describeEmbeddedPostgres("heartbeat bounded retry scheduling", () => {
         testedAt: new Date().toISOString(),
       }),
     });
+    registerServerAdapter({
+      type: RACE_TERMINATE_TEST_ADAPTER,
+      execute: async () => {
+        const target = raceTerminateTarget;
+        if (target) {
+          await db
+            .update(agents)
+            .set({ status: "terminated", updatedAt: new Date() })
+            .where(eq(agents.id, target.agentId));
+        }
+        return {
+          exitCode: 1,
+          signal: null,
+          timedOut: false,
+          errorMessage: "Failure racing an external termination.",
+          errorCode: target?.errorCode ?? "claude_auth_required",
+          resultJson: {},
+        };
+      },
+      testEnvironment: async () => ({
+        adapterType: RACE_TERMINATE_TEST_ADAPTER,
+        status: "pass",
+        checks: [],
+        testedAt: new Date().toISOString(),
+      }),
+    });
   }, 20_000);
 
   afterEach(async () => {
+    raceTerminateTarget = null;
     await cleanupRetryFixture();
   });
 
@@ -136,6 +173,7 @@ describeEmbeddedPostgres("heartbeat bounded retry scheduling", () => {
     unregisterServerAdapter(PROVIDER_QUOTA_TEST_ADAPTER);
     unregisterServerAdapter(AUTH_FAILURE_TEST_ADAPTER);
     unregisterServerAdapter(IDENTICAL_FAILURE_TEST_ADAPTER);
+    unregisterServerAdapter(RACE_TERMINATE_TEST_ADAPTER);
     await tempDb?.cleanup();
   });
 
@@ -519,6 +557,101 @@ describeEmbeddedPostgres("heartbeat bounded retry scheduling", () => {
       .where(eq(agents.id, agentId))
       .then((rows) => rows[0]?.status ?? null);
     expect(agentStatus).not.toBe("paused");
+  });
+
+  async function seedRaceTerminateAgent(companyId: string, agentId: string) {
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+      defaultResponsibleUserId: "responsible-user",
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Race Agent",
+      role: "engineer",
+      status: "idle",
+      adapterType: RACE_TERMINATE_TEST_ADAPTER,
+      adapterConfig: {},
+      runtimeConfig: {
+        heartbeat: {
+          wakeOnDemand: true,
+          maxConcurrentRuns: 1,
+        },
+      },
+      permissions: {},
+    });
+  }
+
+  it("does not resurrect an externally-terminated agent as paused via the permanent-auth pause", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    await seedRaceTerminateAgent(companyId, agentId);
+    // The run's execute flips the agent to terminated; the heartbeat's in-memory
+    // snapshot still reads runnable, so only the UPDATE ... WHERE status guard
+    // prevents the permanent-auth pause from resurrecting it.
+    raceTerminateTarget = { agentId, errorCode: "claude_auth_required" };
+
+    const run = await heartbeat.invoke(agentId, "on_demand", {}, "manual");
+    expect(run).not.toBeNull();
+    const failedRun = await waitForRunToFinish(heartbeat, run!.id);
+    expect(failedRun?.status).toBe("failed");
+    expect(failedRun?.errorCode).toBe("claude_auth_required");
+
+    // Give the finalize pipeline time to (wrongly) flip the agent before asserting.
+    await new Promise((resolve) => setTimeout(resolve, 700));
+    const finalAgent = await db
+      .select({ status: agents.status, pauseReason: agents.pauseReason })
+      .from(agents)
+      .where(eq(agents.id, agentId))
+      .then((rows) => rows[0] ?? null);
+    expect(finalAgent?.status).toBe("terminated");
+    expect(finalAgent?.pauseReason ?? null).toBeNull();
+  });
+
+  it("does not resurrect an externally-terminated agent as paused via the identical-failure storm breaker", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    await seedRaceTerminateAgent(companyId, agentId);
+
+    // Seed the streak so the incoming run is the Nth identical failure that would
+    // trip the storm breaker were the agent not concurrently terminated.
+    const base = Date.now() - CONSECUTIVE_IDENTICAL_FAILURE_PAUSE_THRESHOLD * 60_000;
+    for (let index = 0; index < CONSECUTIVE_IDENTICAL_FAILURE_PAUSE_THRESHOLD - 1; index++) {
+      const at = new Date(base + index * 60_000);
+      await db.insert(heartbeatRuns).values({
+        id: randomUUID(),
+        companyId,
+        agentId,
+        invocationSource: "assignment",
+        status: "failed",
+        error: "Same failure every run.",
+        errorCode: IDENTICAL_FAILURE_TEST_ERROR_CODE,
+        finishedAt: at,
+        resultJson: {},
+        contextSnapshot: {},
+        createdAt: at,
+        updatedAt: at,
+      });
+    }
+    raceTerminateTarget = { agentId, errorCode: IDENTICAL_FAILURE_TEST_ERROR_CODE };
+
+    const run = await heartbeat.invoke(agentId, "on_demand", {}, "manual");
+    expect(run).not.toBeNull();
+    const failedRun = await waitForRunToFinish(heartbeat, run!.id);
+    expect(failedRun?.status).toBe("failed");
+    expect(failedRun?.errorCode).toBe(IDENTICAL_FAILURE_TEST_ERROR_CODE);
+
+    await new Promise((resolve) => setTimeout(resolve, 700));
+    const finalAgent = await db
+      .select({ status: agents.status, pauseReason: agents.pauseReason })
+      .from(agents)
+      .where(eq(agents.id, agentId))
+      .then((rows) => rows[0] ?? null);
+    expect(finalAgent?.status).toBe("terminated");
+    expect(finalAgent?.pauseReason ?? null).toBeNull();
   });
 
   async function seedMaxTurnFixture(input?: {

--- a/server/src/__tests__/heartbeat-retry-scheduling.test.ts
+++ b/server/src/__tests__/heartbeat-retry-scheduling.test.ts
@@ -35,6 +35,7 @@ import {
 const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
 const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
 const PROVIDER_QUOTA_TEST_ADAPTER = "provider_quota_test";
+const AUTH_FAILURE_TEST_ADAPTER = "auth_failure_test";
 
 if (!embeddedPostgresSupport.supported) {
   console.warn(
@@ -88,6 +89,23 @@ describeEmbeddedPostgres("heartbeat bounded retry scheduling", () => {
         testedAt: new Date().toISOString(),
       }),
     });
+    registerServerAdapter({
+      type: AUTH_FAILURE_TEST_ADAPTER,
+      execute: async () => ({
+        exitCode: 1,
+        signal: null,
+        timedOut: false,
+        errorMessage: "Claude authentication required. Connect a provider credential.",
+        errorCode: "claude_auth_required",
+        resultJson: {},
+      }),
+      testEnvironment: async () => ({
+        adapterType: AUTH_FAILURE_TEST_ADAPTER,
+        status: "pass",
+        checks: [],
+        testedAt: new Date().toISOString(),
+      }),
+    });
   }, 20_000);
 
   afterEach(async () => {
@@ -96,6 +114,7 @@ describeEmbeddedPostgres("heartbeat bounded retry scheduling", () => {
 
   afterAll(async () => {
     unregisterServerAdapter(PROVIDER_QUOTA_TEST_ADAPTER);
+    unregisterServerAdapter(AUTH_FAILURE_TEST_ADAPTER);
     await tempDb?.cleanup();
   });
 
@@ -265,6 +284,70 @@ describeEmbeddedPostgres("heartbeat bounded retry scheduling", () => {
         { timeout: 5_000, interval: 50 },
       )
       .toEqual({ status: "idle", errorReason: null });
+  });
+
+  it("pauses an agent whose run fails with a permanent auth error instead of re-running it", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+      defaultResponsibleUserId: "responsible-user",
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Keyless Agent",
+      role: "engineer",
+      status: "idle",
+      adapterType: AUTH_FAILURE_TEST_ADAPTER,
+      adapterConfig: {},
+      runtimeConfig: {
+        heartbeat: {
+          wakeOnDemand: true,
+          maxConcurrentRuns: 1,
+        },
+      },
+      permissions: {},
+    });
+
+    const run = await heartbeat.invoke(agentId, "on_demand", {}, "manual");
+    expect(run).not.toBeNull();
+
+    const failedRun = await waitForRunToFinish(heartbeat, run!.id);
+    expect(failedRun?.status).toBe("failed");
+    expect(failedRun?.errorCode).toBe("claude_auth_required");
+
+    await expect
+      .poll(
+        () =>
+          db
+            .select({ status: agents.status })
+            .from(agents)
+            .where(eq(agents.id, agentId))
+            .then((rows) => rows[0]?.status ?? null),
+        { timeout: 5_000, interval: 50 },
+      )
+      .toBe("paused");
+
+    // No retry run is scheduled for a permanent auth failure.
+    const retryCount = await db
+      .select({ id: heartbeatRuns.id })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.retryOfRunId, run!.id))
+      .then((rows) => rows.length);
+    expect(retryCount).toBe(0);
+
+    const pausedAgent = await db
+      .select({ pauseReason: agents.pauseReason })
+      .from(agents)
+      .where(eq(agents.id, agentId))
+      .then((rows) => rows[0] ?? null);
+    expect(pausedAgent?.pauseReason).toContain("Connect a model key");
   });
 
   async function seedMaxTurnFixture(input?: {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -11117,7 +11117,10 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         pausedAt: new Date(),
         updatedAt: new Date(),
       })
-      .where(eq(agents.id, agent.id))
+      // Guard on the persisted status, not just the in-memory snapshot: an agent
+      // externally terminated (or already paused) between the snapshot above and
+      // this update must not be flipped back to paused.
+      .where(and(eq(agents.id, agent.id), notInArray(agents.status, ["paused", "terminated"])))
       .catch((pauseErr) => {
         logger.warn(
           { err: pauseErr, agentId: agent.id, runId: run.id },
@@ -13998,7 +14001,10 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
               pausedAt: new Date(),
               updatedAt: new Date(),
             })
-            .where(eq(agents.id, agent.id))
+            // Guard on the persisted status, not just the in-memory snapshot: an
+            // agent externally terminated (or already paused) between the check
+            // above and this update must not be flipped back to paused.
+            .where(and(eq(agents.id, agent.id), notInArray(agents.status, ["paused", "terminated"])))
             .catch((pauseErr) => {
               logger.warn(
                 { err: pauseErr, agentId: agent.id, runId: livenessRun.id },

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -493,6 +493,14 @@ function isPermanentAuthFailureRun(run: { errorCode: string | null }): boolean {
   return run.errorCode != null && PERMANENT_AUTH_FAILURE_CODES.has(run.errorCode);
 }
 
+// Generic failure-storm breaker: when this many consecutive terminal runs of an
+// agent all failed with the same errorCode (no success in between), the agent is
+// not making progress and every further automated re-invocation burns the same
+// failure again. Pause it and route the reason to a human. This is the fallback
+// for failure shapes that no dedicated branch (transient retry contracts, the
+// permanent-auth pause) already handles.
+export const CONSECUTIVE_IDENTICAL_FAILURE_PAUSE_THRESHOLD = 6;
+
 function isRetryableInteractionContinuationInfrastructureFailure(
   run: Pick<typeof heartbeatRuns.$inferSelect, "error" | "errorCode" | "resultJson">,
 ) {
@@ -11061,6 +11069,63 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     return trimmed.length > 500 ? `${trimmed.slice(0, 499)}…` : trimmed;
   }
 
+  // Failure-storm breaker (see CONSECUTIVE_IDENTICAL_FAILURE_PAUSE_THRESHOLD):
+  // pause the agent when its most recent terminal runs, including the run that
+  // just finalized, all failed with the same errorCode. Dedicated branches
+  // (transient retry contracts, permanent-auth) run before this and take
+  // precedence.
+  async function maybePauseAgentForRepeatedIdenticalFailure(
+    agent: Pick<typeof agents.$inferSelect, "id" | "status">,
+    run: Pick<typeof heartbeatRuns.$inferSelect, "id" | "errorCode">,
+  ) {
+    const errorCode = readNonEmptyString(run.errorCode);
+    if (!errorCode) return;
+    if (agent.status === "paused" || agent.status === "terminated") return;
+
+    const recentTerminalRuns = await db
+      .select({ status: heartbeatRuns.status, errorCode: heartbeatRuns.errorCode })
+      .from(heartbeatRuns)
+      .where(
+        and(
+          eq(heartbeatRuns.agentId, agent.id),
+          inArray(heartbeatRuns.status, [...HEARTBEAT_RUN_TERMINAL_STATUSES]),
+        ),
+      )
+      .orderBy(desc(heartbeatRuns.createdAt))
+      .limit(CONSECUTIVE_IDENTICAL_FAILURE_PAUSE_THRESHOLD)
+      .catch((queryErr) => {
+        logger.warn(
+          { err: queryErr, agentId: agent.id, runId: run.id },
+          "failed to evaluate repeated identical failure streak",
+        );
+        return null;
+      });
+    if (!recentTerminalRuns || recentTerminalRuns.length < CONSECUTIVE_IDENTICAL_FAILURE_PAUSE_THRESHOLD) {
+      return;
+    }
+    if (!recentTerminalRuns.every((recent) => recent.status === "failed" && recent.errorCode === errorCode)) {
+      return;
+    }
+
+    await db
+      .update(agents)
+      .set({
+        status: "paused",
+        pauseReason: truncateAgentErrorReason(
+          `Paused after ${CONSECUTIVE_IDENTICAL_FAILURE_PAUSE_THRESHOLD} consecutive failed runs with the same error (${errorCode}). Fix the underlying issue, then resume.`,
+        ),
+        pausedAt: new Date(),
+        updatedAt: new Date(),
+      })
+      .where(eq(agents.id, agent.id))
+      .catch((pauseErr) => {
+        logger.warn(
+          { err: pauseErr, agentId: agent.id, runId: run.id },
+          "failed to pause agent after repeated identical failures",
+        );
+      });
+  }
+
   async function finalizeAgentStatus(
     agentId: string,
     outcome: "succeeded" | "interrupted" | "failed" | "cancelled" | "timed_out",
@@ -13940,6 +14005,9 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
                 "failed to pause agent after permanent auth failure",
               );
             });
+        } else if (outcome === "failed") {
+          // Fallback storm breaker for failure codes no dedicated branch handles.
+          await maybePauseAgentForRepeatedIdenticalFailure(agent, livenessRun);
         }
         const issueCommentPolicyResult = await finalizeIssueCommentPolicy(livenessRun, agent);
         await releaseIssueExecutionAndPromote(livenessRun);
@@ -14113,6 +14181,9 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           await finalizeIssueCommentPolicy(livenessRun, agent);
         }
         await scheduleInteractionContinuationInfrastructureRetryIfEligible(livenessRun, agent);
+        // Thrown adapter failures never reach the finalize chain above, so the
+        // storm breaker also runs here for repeated identical failure codes.
+        await maybePauseAgentForRepeatedIdenticalFailure(agent, livenessRun);
         await releaseIssueExecutionAndPromote(livenessRun);
 
         await updateRuntimeState(agent, livenessRun, {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -484,6 +484,15 @@ function isSpawnLikeFailureMessage(value: unknown) {
   return /failed to start command|spawn\b|\bENOENT\b/i.test(value);
 }
 
+// A permanent authentication failure: the agent has no valid provider credential
+// (e.g. an agent activated without connecting a model key), so every heartbeat
+// run completes with `outcome:"failed"` + this errorCode and will keep failing
+// until a human wires up a credential. Pause the agent instead of looping.
+const PERMANENT_AUTH_FAILURE_CODES = new Set(["claude_auth_required", "inference_auth_invalid"]);
+function isPermanentAuthFailureRun(run: { errorCode: string | null }): boolean {
+  return run.errorCode != null && PERMANENT_AUTH_FAILURE_CODES.has(run.errorCode);
+}
+
 function isRetryableInteractionContinuationInfrastructureFailure(
   run: Pick<typeof heartbeatRuns.$inferSelect, "error" | "errorCode" | "resultJson">,
 ) {
@@ -13905,6 +13914,32 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           }
         } else if (outcome === "failed" && readTransientRecoveryContractFromRun(livenessRun)) {
           await scheduleBoundedRetryForRun(livenessRun, agent);
+        } else if (
+          outcome === "failed" &&
+          isPermanentAuthFailureRun(livenessRun) &&
+          agent.status !== "paused" &&
+          agent.status !== "terminated"
+        ) {
+          // No valid provider credential: pause the agent so its heartbeat stops
+          // re-running (and failing auth) every interval, and surface the reason so
+          // a human connects a model key and resumes.
+          await db
+            .update(agents)
+            .set({
+              status: "paused",
+              pauseReason: truncateAgentErrorReason(
+                "Connect a model key to run this agent. Paused after an authentication failure. Add a provider credential in the agent's adapter config, then resume.",
+              ),
+              pausedAt: new Date(),
+              updatedAt: new Date(),
+            })
+            .where(eq(agents.id, agent.id))
+            .catch((pauseErr) => {
+              logger.warn(
+                { err: pauseErr, agentId: agent.id, runId: livenessRun.id },
+                "failed to pause agent after permanent auth failure",
+              );
+            });
         }
         const issueCommentPolicyResult = await finalizeIssueCommentPolicy(livenessRun, agent);
         await releaseIssueExecutionAndPromote(livenessRun);


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Agents run on BYOK provider credentials; when a credential is rejected by the provider, the run fails at the adapter layer.
> - Previously a rejected/invalid credential was classified as a generic failure, so the heartbeat kept re-running the agent in a tight loop against the same dead credential (a retry storm) instead of surfacing an actionable state.
> - Repeated identical failures burn provider calls and never converge; the operator/user gets no clear "reconnect your credential" signal.
> - This pull request classifies permanent auth failures explicitly, fails opencode preflight fast when no provider credential is present, and pauses an agent (rather than looping) on a permanent auth failure or an identical-failure storm.
> - The benefit is that a bad/dead credential produces a clear paused state with an actionable reason instead of an infinite, cost-burning retry loop.

## Linked Issues or Issue Description

No public issue exists; the underlying bug is described inline below, following the bug report template.

**What happened**

Runs failing with a permanent provider auth rejection (401 / invalid credential) were retried indefinitely instead of surfacing an actionable state, and opencode runs with no provider key surfaced generic failures late in execution.

**Expected behavior**

Permanent auth failures are classified (`claude_auth_required` / `inference_auth_invalid`) and the agent is paused with an actionable "reconnect your credential" reason instead of looping; identical-failure storms are broken after a bounded threshold.

**Steps to reproduce**

1. Connect an invalid/dead provider credential to an agent.
2. Let the heartbeat run the agent.
3. Observe the run fails with a 401/auth rejection and is retried in a tight loop, burning provider calls, with no clear paused/reconnect signal.

## What Changed

- claude-local: classify rejected credentials as `claude_auth_required` (`parse.ts`, `execute.ts`).
- server: pause agents on permanent auth failures instead of looping, with a status-guarded update.
- opencode-local: credential preflight fails fast with `inference_auth_invalid` only when NO recognized provider credential is present; the recognized provider env-key set now covers Gemini/Mistral/Groq/Bedrock/Azure in addition to Anthropic/OpenAI/OpenRouter (fixes false positives for env-only setups of those providers).
- server: pause agents stuck in identical-failure storms after a bounded threshold.
- Hardened both pause UPDATEs with a `notInArray(status, ["paused","terminated"])` WHERE guard so a concurrently-terminated agent is never flipped back to paused.

## Verification

- `pnpm --filter opencode-local test credential-preflight` — env-only `GEMINI_API_KEY` / `MISTRAL_API_KEY` pass preflight (no false `inference_auth_invalid`).
- `pnpm --filter claude-local test parse execute.auth-classification` — rejected-credential strings classify as `claude_auth_required`.
- `pnpm --filter server test heartbeat-retry-scheduling` — permanent-auth and identical-failure paths pause the agent; the status-guarded WHERE prevents flipping a terminated agent to paused.

## Risks

Low-to-moderate. The pause behavior is a deliberate behavioral shift for permanent-auth/storm cases (agents pause instead of loop) — intended and surfaced to the user with an actionable reason. Preflight now recognizes more provider keys, which strictly reduces false positives. The WHERE status guards make the pause writes safe under concurrent termination.

## Model Used

Claude (Anthropic), model ID `claude-fable-5`, extended reasoning, with tool use / code execution in an agentic harness.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
