### PR TITLE
fix(server): add productivity review reconciliation toggle

### DIFF
--- a/doc/DEVELOPING.md
+++ b/doc/DEVELOPING.md
@@ -45,6 +45,13 @@ This starts:
 
 Issue execution may also use project execution workspace policies and workspace runtime services for per-project worktrees, preview servers, and managed dev commands. Configure those through the project workspace/runtime surfaces rather than starting long-running unmanaged processes when a task needs a reusable service.
 
+### Productivity review reconciliation
+
+Automatic productivity-review reconciliation is enabled by default. Set
+`PRODUCTIVITY_REVIEW_ENABLED=false` to skip both the startup and periodic
+productivity-review passes while keeping the general heartbeat scheduler,
+routines, recovery, and watchdog work enabled.
+
 ## Storybook
 
 The board UI Storybook keeps stories and Storybook config under `ui/storybook/` so component review files stay out of the app source routes.

--- a/server/src/__tests__/productivity-review-service.test.ts
+++ b/server/src/__tests__/productivity-review-service.test.ts
@@ -21,6 +21,7 @@ import {
   DEFAULT_PRODUCTIVITY_REVIEW_REFRESH_INTERVAL_MS,
   PRODUCTIVITY_REVIEW_REFRESH_COMMENT_PREFIX,
   PRODUCTIVITY_REVIEW_ORIGIN_KIND,
+  reconcileProductivityReviewsIfEnabled,
   productivityReviewService,
 } from "../services/productivity-review.ts";
 
@@ -482,7 +483,10 @@ describeEmbeddedPostgres("productivity review service", () => {
     expect(await listProductivityReviews(seeded.companyId)).toHaveLength(4);
   });
 
-  it("creates a long-active review without enabling a continuation hold", async () => {
+  it.each([
+    ["by default", undefined],
+    ["when explicitly enabled", true],
+  ])("creates a long-active review %s without enabling a continuation hold", async (_label, enabled) => {
     const now = new Date("2026-04-28T12:00:00.000Z");
     const seeded = await seedAssignedIssue({
       status: "in_progress",
@@ -490,7 +494,10 @@ describeEmbeddedPostgres("productivity review service", () => {
     });
     const service = productivityReviewService(db);
 
-    const result = await service.reconcileProductivityReviews({ now, companyId: seeded.companyId });
+    const result = await reconcileProductivityReviewsIfEnabled(
+      enabled,
+      () => service.reconcileProductivityReviews({ now, companyId: seeded.companyId }),
+    );
     const hold = await service.isProductivityReviewContinuationHoldActive({
       companyId: seeded.companyId,
       issueId: seeded.issueId,
@@ -498,11 +505,28 @@ describeEmbeddedPostgres("productivity review service", () => {
       now,
     });
 
-    expect(result.created).toBe(1);
+    expect(result?.created).toBe(1);
     const [review] = await listProductivityReviews(seeded.companyId);
     expect(review?.description).toContain("Primary trigger: `long_active_duration`");
     expect(review?.priority).toBe("medium");
     expect(hold.held).toBe(false);
+  });
+
+  it("does not create a review for assigned work older than six hours when disabled", async () => {
+    const now = new Date("2026-04-28T12:00:00.000Z");
+    const seeded = await seedAssignedIssue({
+      status: "in_progress",
+      startedAt: new Date(now.getTime() - 7 * 60 * 60 * 1000),
+    });
+    const service = productivityReviewService(db);
+
+    const result = await reconcileProductivityReviewsIfEnabled(
+      false,
+      () => service.reconcileProductivityReviews({ now, companyId: seeded.companyId }),
+    );
+
+    expect(result).toBeNull();
+    expect(await listProductivityReviews(seeded.companyId)).toHaveLength(0);
   });
 
   it("creates a high-churn review even when every sampled run has a progress comment", async () => {

--- a/server/src/__tests__/server-startup-feedback-export.test.ts
+++ b/server/src/__tests__/server-startup-feedback-export.test.ts
@@ -139,6 +139,7 @@ function buildTestConfig(overrides: Record<string, unknown> = {}) {
     feedbackExportBackendToken: "telemetry-token",
     heartbeatSchedulerEnabled: false,
     heartbeatSchedulerIntervalMs: 30000,
+    productivityReviewEnabled: true,
     companyDeletionEnabled: false,
     ...overrides,
   };
@@ -235,6 +236,10 @@ vi.mock("../services/index.js", () => ({
     duplicates: 0,
   })),
   reconcilePersistedRuntimeServicesOnStartup: vi.fn(async () => ({ reconciled: 0 })),
+  reconcileProductivityReviewsIfEnabled: vi.fn(
+    async (enabled: boolean | undefined, reconcile: () => Promise<unknown>) =>
+      enabled === false ? null : reconcile(),
+  ),
   resolveHeartbeatSchedulingSuppression: resolveHeartbeatSchedulingSuppressionMock,
   routineService: routineServiceFactoryMock,
   toolAccessService: vi.fn(() => ({
@@ -355,6 +360,37 @@ describe("startServer feedback export wiring", () => {
 
     expect(heartbeatServiceMock.reconcileHotRestartAdoption).toHaveBeenCalledTimes(1);
     expect(heartbeatServiceMock.reapOrphanedRuns).toHaveBeenCalledTimes(2);
+  });
+
+  it.each([
+    ["enabled", true, 2],
+    ["disabled", false, 0],
+  ])("keeps startup and periodic productivity reconciliation %s", async (_label, enabled, expectedCalls) => {
+    loadConfigMock.mockReturnValue(buildTestConfig({
+      heartbeatSchedulerEnabled: true,
+      heartbeatSchedulerIntervalMs: 30000,
+      productivityReviewEnabled: enabled,
+    }));
+    let intervalCallback: (() => void) | null = null;
+    const setIntervalSpy = vi
+      .spyOn(globalThis, "setInterval")
+      .mockImplementation(((callback: () => void) => {
+        intervalCallback = callback;
+        return 1 as unknown as ReturnType<typeof setInterval>;
+      }) as typeof setInterval);
+
+    try {
+      await startServer();
+      expect(intervalCallback).not.toBeNull();
+      intervalCallback?.();
+      await vi.waitFor(() => {
+        expect(heartbeatServiceMock.reapOrphanedRuns).toHaveBeenCalledTimes(2);
+      });
+
+      expect(heartbeatServiceMock.reconcileProductivityReviews).toHaveBeenCalledTimes(expectedCalls);
+    } finally {
+      setIntervalSpy.mockRestore();
+    }
   });
 
   it("refuses authenticated public startup without an external database URL", async () => {

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -85,6 +85,7 @@ export interface Config {
   feedbackExportBackendToken: string | undefined;
   heartbeatSchedulerEnabled: boolean;
   heartbeatSchedulerIntervalMs: number;
+  productivityReviewEnabled: boolean;
   companyDeletionEnabled: boolean;
   telemetryEnabled: boolean;
 }
@@ -331,6 +332,7 @@ export function loadConfig(): Config {
     feedbackExportBackendToken,
     heartbeatSchedulerEnabled: process.env.HEARTBEAT_SCHEDULER_ENABLED !== "false",
     heartbeatSchedulerIntervalMs: Math.max(10000, Number(process.env.HEARTBEAT_SCHEDULER_INTERVAL_MS) || 30000),
+    productivityReviewEnabled: process.env.PRODUCTIVITY_REVIEW_ENABLED !== "false",
     companyDeletionEnabled,
     telemetryEnabled: fileConfig?.telemetry?.enabled ?? true,
   };

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -47,6 +47,7 @@ import {
   reconcileCloudUpstreamRunsOnStartup,
   reconcileCodexLocalManagedHomesOnStartup,
   reconcilePersistedRuntimeServicesOnStartup,
+  reconcileProductivityReviewsIfEnabled,
   routineService,
   toolAccessService,
 } from "./services/index.js";
@@ -954,8 +955,11 @@ export async function startServer(): Promise<StartedServer> {
           logger.warn({ ...swept }, "startup stale-lock sweeper cleared issue locks");
         }
 
-        const reviewed = await heartbeat.reconcileProductivityReviews();
-        if (reviewed.created > 0 || reviewed.updated > 0 || reviewed.failed > 0) {
+        const reviewed = await reconcileProductivityReviewsIfEnabled(
+          config.productivityReviewEnabled,
+          () => heartbeat.reconcileProductivityReviews(),
+        );
+        if (reviewed && (reviewed.created > 0 || reviewed.updated > 0 || reviewed.failed > 0)) {
           logger.warn({ ...reviewed }, "startup productivity reconciliation created or updated review work");
         }
       })().catch((err) => {
@@ -1087,8 +1091,11 @@ export async function startServer(): Promise<StartedServer> {
               }
             })
             .then(async () => {
-              const reviewed = await heartbeat.reconcileProductivityReviews();
-              if (reviewed.created > 0 || reviewed.updated > 0 || reviewed.failed > 0) {
+              const reviewed = await reconcileProductivityReviewsIfEnabled(
+                config.productivityReviewEnabled,
+                () => heartbeat.reconcileProductivityReviews(),
+              );
+              if (reviewed && (reviewed.created > 0 || reviewed.updated > 0 || reviewed.failed > 0)) {
                 logger.warn({ ...reviewed }, "periodic productivity reconciliation created or updated review work");
               }
             })

--- a/server/src/services/index.ts
+++ b/server/src/services/index.ts
@@ -83,6 +83,7 @@ export { costService } from "./costs.js";
 export { financeService } from "./finance.js";
 export { heartbeatService, resolveHeartbeatSchedulingSuppression } from "./heartbeat.js";
 export {
+  reconcileProductivityReviewsIfEnabled,
   productivityReviewService,
   PRODUCTIVITY_REVIEW_ORIGIN_KIND,
 } from "./productivity-review.js";

--- a/server/src/services/productivity-review.ts
+++ b/server/src/services/productivity-review.ts
@@ -96,6 +96,14 @@ type EnqueueWakeup = (
   },
 ) => Promise<unknown | null>;
 
+export async function reconcileProductivityReviewsIfEnabled<T>(
+  enabled: boolean | undefined,
+  reconcile: () => Promise<T>,
+): Promise<T | null> {
+  if (enabled === false) return null;
+  return reconcile();
+}
+
 function productivityReviewFingerprint(sourceIssueId: string) {
   return `productivity-review:${sourceIssueId}`;
 }


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI-agent work through the heartbeat scheduler and its recovery passes
> - That scheduler also reconciles productivity reviews at startup and on each periodic tick
> - Productivity reviews are useful by default, but operators currently cannot pause only their automatic creation and refresh
> - The existing `HEARTBEAT_SCHEDULER_ENABLED=false` switch is too broad because it also pauses timers, routines, recovery, liveness checks, and watchdogs
> - A stale, conflicted implementation exists in #6235, but it has not tracked current `master` and does not include deterministic disabled-path coverage
> - This pull request adds a narrow, default-on environment flag around only the two productivity-review reconciliation entrypoints
> - The benefit is an operator kill switch for review noise without degrading normal heartbeat scheduling or recovery behavior

## Linked Issues or Issue Description

Refs #5897.

Supersedes #6235, which is currently conflicted with `master`; this replacement is based on current `master` and adds deterministic service and scheduler coverage.

- **Subsystem affected:** `server/` orchestration services
- **Problem or motivation:** Operators need to stop automatic `Review productivity` issue creation and refresh without disabling the general heartbeat scheduler.
- **Proposed solution:** Parse `PRODUCTIVITY_REVIEW_ENABLED` as a default-on boolean and skip only startup and periodic productivity-review reconciliation when it is exactly `false`.
- **Alternatives considered:** Disabling the whole heartbeat scheduler would also stop unrelated, required scheduling and recovery work. Raising thresholds changes policy but does not provide a reliable off switch.
- **Roadmap alignment:** No matching planned core work appears in `ROADMAP.md`.

## What Changed

- Added `productivityReviewEnabled` to server config, with `PRODUCTIVITY_REVIEW_ENABLED=false` as the opt-out and existing behavior preserved by default.
- Routed both startup and periodic productivity-review reconciliation through one narrow guard; general timers, routines, recovery, liveness, and watchdog paths are unchanged.
- Added database-backed coverage proving a seven-hour-old assigned issue creates no productivity review when disabled, while unset and explicit `true` retain existing behavior.
- Added startup/scheduler coverage for both enabled and disabled paths and documented the operator flag.

## Verification

- `pnpm exec vitest run server/src/__tests__/server-startup-feedback-export.test.ts --reporter=verbose` — 13 tests passed.
- `node node_modules/vitest/vitest.mjs run server/src/__tests__/productivity-review-service.test.ts --reporter=verbose` — 17 tests passed.
- `pnpm typecheck` — passed across all workspaces.
- `node scripts/run-vitest-stable.mjs` — the full general server lane passed (269 files; 2,711 tests passed, 1 skipped), along with UI, CLI, shared, database, adapter, and plugin workspace lanes.
- Stable serialized server matrix — all 117 selected suites passed. On the validation host, setup-heavy route tests that crossed Vitest's 5-second per-test ceiling passed with `--testTimeout=15000`; one heartbeat-liveness suite passed 22/22 when rerun alone after a disposable test-database teardown race in the sequential harness.
- `pnpm build` — passed across all workspaces.

## Risks

Low risk. The default remains enabled, so existing deployments retain current behavior. Setting the flag to `false` intentionally pauses automatic creation and refresh of productivity-review issues; it does not delete or close existing reviews and does not disable the rest of the heartbeat scheduler. No database migration or API shape changes are involved.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex, GPT-5 (exact runtime model ID and context-window size are not exposed), with reasoning, tool use, and code execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
