### PR TITLE
fix(agents): redact plaintext env values in agent read and mutation responses

### DIFF
--- a/server/src/__tests__/agent-permissions-routes.test.ts
+++ b/server/src/__tests__/agent-permissions-routes.test.ts
@@ -494,6 +494,89 @@ describe.sequential("agent permission routes", () => {
     expect(res.body.permissions).toMatchObject({ trustPreset: LOW_TRUST_REVIEW_PRESET });
   }, 20_000);
 
+  // TEC-7032 reported the leak against the company agent-list endpoint, which
+  // serialises rows directly instead of going through buildAgentDetail.
+  it("redacts env values in board GET /api/companies/:companyId/agents responses", async () => {
+    const plaintextValue = "listed-value-must-not-leak";
+    mockAgentService.list.mockResolvedValue([
+      {
+        ...baseAgent,
+        adapterConfig: {
+          command: "pnpm agent:run",
+          env: {
+            LEGACY_VALUE: plaintextValue,
+            PLAIN_VALUE: { type: "plain", value: plaintextValue },
+            SECRET_REFERENCE: {
+              type: "secret_ref",
+              secretId: "55555555-5555-4555-8555-555555555555",
+              version: "latest",
+            },
+          },
+        },
+      },
+    ]);
+
+    const app = await createApp({
+      type: "board",
+      userId: "board-user",
+      source: "local_implicit",
+      isInstanceAdmin: true,
+      companyIds: [companyId],
+    });
+
+    const res = await requestApp(app, (baseUrl) =>
+      request(baseUrl).get(`/api/companies/${companyId}/agents`),
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(1);
+    expect(res.body[0].adapterConfig).toMatchObject({
+      command: "pnpm agent:run",
+      env: {
+        LEGACY_VALUE: { type: "plain", value: "***REDACTED***" },
+        PLAIN_VALUE: { type: "plain", value: "***REDACTED***" },
+        SECRET_REFERENCE: {
+          type: "secret_ref",
+          secretId: "55555555-5555-4555-8555-555555555555",
+          version: "latest",
+        },
+      },
+    });
+    expect(JSON.stringify(res.body)).not.toContain(plaintextValue);
+  }, 20_000);
+
+  // Mutation routes echo the stored row back, so they leak the same values the
+  // GET paths redact.
+  it("redacts env values in agent mutation responses", async () => {
+    const plaintextValue = "mutation-value-must-not-leak";
+    const storedAgent = {
+      ...baseAgent,
+      adapterConfig: {
+        env: { PLAIN_VALUE: { type: "plain", value: plaintextValue } },
+      },
+    };
+    mockAgentService.getById.mockResolvedValue(storedAgent);
+    mockAgentService.update.mockResolvedValue(storedAgent);
+
+    const app = await createApp({
+      type: "board",
+      userId: "board-user",
+      source: "local_implicit",
+      isInstanceAdmin: true,
+      companyIds: [companyId],
+    });
+
+    const res = await requestApp(app, (baseUrl) =>
+      request(baseUrl).patch(`/api/agents/${agentId}`).send({ title: "Renamed" }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.body.adapterConfig.env).toEqual({
+      PLAIN_VALUE: { type: "plain", value: "***REDACTED***" },
+    });
+    expect(JSON.stringify(res.body)).not.toContain(plaintextValue);
+  }, 20_000);
+
   it("redacts env values in GET /api/agents/me responses", async () => {
     const plaintextValue = "self-value-must-not-leak";
     mockAgentService.getById.mockResolvedValue({

--- a/server/src/__tests__/agent-permissions-routes.test.ts
+++ b/server/src/__tests__/agent-permissions-routes.test.ts
@@ -435,7 +435,8 @@ describe.sequential("agent permission routes", () => {
     expect(res.body.runtimeConfig).toEqual({});
   }, 20_000);
 
-  it("keeps board agent detail unredacted for low-trust agents", async () => {
+  it("redacts env values in board agent detail responses", async () => {
+    const plaintextValue = "plain-value-must-not-leak";
     mockAgentService.getById.mockResolvedValue({
       ...baseAgent,
       permissions: {
@@ -444,7 +445,15 @@ describe.sequential("agent permission routes", () => {
       },
       adapterConfig: {
         command: "pnpm agent:run",
-        env: { PAPERCLIP_API_KEY: "secret-test-key" },
+        env: {
+          LEGACY_VALUE: plaintextValue,
+          PLAIN_VALUE: { type: "plain", value: plaintextValue },
+          SECRET_REFERENCE: {
+            type: "secret_ref",
+            secretId: "33333333-3333-4333-8333-333333333333",
+            version: "latest",
+          },
+        },
       },
       runtimeConfig: {
         modelProfiles: {
@@ -466,14 +475,107 @@ describe.sequential("agent permission routes", () => {
     expect(res.status).toBe(200);
     expect(res.body.adapterConfig).toMatchObject({
       command: "pnpm agent:run",
-      env: { PAPERCLIP_API_KEY: "secret-test-key" },
+      env: {
+        LEGACY_VALUE: { type: "plain", value: "***REDACTED***" },
+        PLAIN_VALUE: { type: "plain", value: "***REDACTED***" },
+        SECRET_REFERENCE: {
+          type: "secret_ref",
+          secretId: "33333333-3333-4333-8333-333333333333",
+          version: "latest",
+        },
+      },
     });
+    expect(JSON.stringify(res.body)).not.toContain(plaintextValue);
     expect(res.body.runtimeConfig).toMatchObject({
       modelProfiles: {
         default: { enabled: true, adapterConfig: { model: "openai/gpt-5.4-mini" } },
       },
     });
     expect(res.body.permissions).toMatchObject({ trustPreset: LOW_TRUST_REVIEW_PRESET });
+  }, 20_000);
+
+  it("redacts env values in GET /api/agents/me responses", async () => {
+    const plaintextValue = "self-value-must-not-leak";
+    mockAgentService.getById.mockResolvedValue({
+      ...baseAgent,
+      adapterConfig: {
+        env: {
+          EXISTING_VALUE: plaintextValue,
+          NEW_VALUE: { type: "plain", value: plaintextValue },
+          SECRET_REFERENCE: {
+            type: "secret_ref",
+            secretId: "44444444-4444-4444-8444-444444444444",
+            version: 2,
+          },
+        },
+      },
+    });
+
+    const app = await createApp({
+      type: "agent",
+      agentId,
+      companyId,
+      runId: null,
+      source: "agent_key",
+    });
+
+    const res = await requestApp(app, (baseUrl) => request(baseUrl).get("/api/agents/me"));
+
+    expect(res.status).toBe(200);
+    expect(res.body.adapterConfig.env).toEqual({
+      EXISTING_VALUE: { type: "plain", value: "***REDACTED***" },
+      NEW_VALUE: { type: "plain", value: "***REDACTED***" },
+      SECRET_REFERENCE: {
+        type: "secret_ref",
+        secretId: "44444444-4444-4444-8444-444444444444",
+        version: 2,
+      },
+    });
+    expect(JSON.stringify(res.body)).not.toContain(plaintextValue);
+  }, 20_000);
+
+  it("preserves stored env values when a redacted detail response is submitted unchanged", async () => {
+    const plaintextValue = "stored-value-must-be-preserved";
+    mockAgentService.getById.mockResolvedValue({
+      ...baseAgent,
+      adapterConfig: {
+        env: {
+          EXISTING_VALUE: { type: "plain", value: plaintextValue },
+        },
+      },
+    });
+    mockAgentService.update.mockResolvedValue(baseAgent);
+
+    const app = await createApp({
+      type: "board",
+      userId: "board-user",
+      source: "local_implicit",
+      isInstanceAdmin: true,
+      companyIds: [companyId],
+    });
+
+    const redactedResponse = await requestApp(app, (baseUrl) =>
+      request(baseUrl).get(`/api/agents/${agentId}`),
+    );
+    expect(redactedResponse.status).toBe(200);
+    const redactedEnv = redactedResponse.body.adapterConfig.env as Record<string, unknown>;
+    expect(redactedEnv.EXISTING_VALUE).toEqual({ type: "plain", value: "***REDACTED***" });
+
+    const patchRes = await requestApp(app, (baseUrl) =>
+      request(baseUrl).patch(`/api/agents/${agentId}`).send({
+        title: "Renamed while redacted env round-trips",
+        adapterConfig: redactedResponse.body.adapterConfig,
+      }),
+    );
+
+    expect(patchRes.status).toBe(200);
+    const updateCallArgs = mockAgentService.update.mock.calls[0]?.[1] as
+      | { adapterConfig?: Record<string, unknown> }
+      | undefined;
+    expect(updateCallArgs?.adapterConfig?.env).toEqual({
+      EXISTING_VALUE: { type: "plain", value: plaintextValue },
+    });
+    expect(JSON.stringify(updateCallArgs?.adapterConfig ?? {})).not.toContain("***REDACTED***");
   }, 20_000);
 
   it("redacts company agent list for authenticated company members without agent admin permission", async () => {

--- a/server/src/__tests__/agent-permissions-routes.test.ts
+++ b/server/src/__tests__/agent-permissions-routes.test.ts
@@ -43,6 +43,7 @@ const baseAgent = {
 const mockAgentService = vi.hoisted(() => ({
   getById: vi.fn(),
   getConfigRevision: vi.fn(),
+  listConfigRevisions: vi.fn(),
   list: vi.fn(),
   create: vi.fn(),
   activatePendingApproval: vi.fn(),
@@ -291,6 +292,7 @@ describe.sequential("agent permission routes", () => {
     vi.resetAllMocks();
     mockAgentService.getById.mockReset();
     mockAgentService.getConfigRevision.mockReset();
+    mockAgentService.listConfigRevisions.mockReset();
     mockAgentService.list.mockReset();
     mockAgentService.create.mockReset();
     mockAgentService.activatePendingApproval.mockReset();
@@ -337,6 +339,7 @@ describe.sequential("agent permission routes", () => {
     mockGetTelemetryClient.mockReturnValue({ track: vi.fn() });
     mockAgentService.getById.mockResolvedValue(baseAgent);
     mockAgentService.getConfigRevision.mockResolvedValue(null);
+    mockAgentService.listConfigRevisions.mockResolvedValue([]);
     mockAgentService.list.mockResolvedValue([baseAgent]);
     mockAgentService.getChainOfCommand.mockResolvedValue([]);
     mockAgentService.resolveByReference.mockResolvedValue({ ambiguous: false, agent: baseAgent });
@@ -811,6 +814,43 @@ describe.sequential("agent permission routes", () => {
 
     expect(response.status).toBe(403);
     expect(mockAgentService.rollbackConfigRevision).not.toHaveBeenCalled();
+  });
+
+  it("redacts plaintext env values in configuration rollback responses", async () => {
+    const revisionId = "33333333-3333-4333-8333-333333333333";
+    const plaintextValue = "rollback-value-must-not-leak";
+    mockAgentService.getConfigRevision.mockResolvedValue({
+      id: revisionId,
+      afterConfig: {
+        adapterType: "process",
+        adapterConfig: {},
+        runtimeConfig: {},
+      },
+    });
+    mockAgentService.rollbackConfigRevision.mockResolvedValue({
+      ...baseAgent,
+      adapterConfig: {
+        env: { GENERIC_NAME: { type: "plain", value: plaintextValue } },
+      },
+    });
+
+    const app = await createApp({
+      type: "board",
+      userId: "instance-admin-user",
+      source: "session",
+      isInstanceAdmin: true,
+      companyIds: [companyId],
+    });
+
+    const res = await requestApp(app, (baseUrl) =>
+      request(baseUrl).post(`/api/agents/${agentId}/config-revisions/${revisionId}/rollback`),
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.body.adapterConfig.env).toEqual({
+      GENERIC_NAME: { type: "plain", value: "***REDACTED***" },
+    });
+    expect(JSON.stringify(res.body)).not.toContain(plaintextValue);
   });
 
   it("blocks api key creation for authenticated company members without agent admin permission", async () => {
@@ -1834,6 +1874,13 @@ describe.sequential("agent permission routes", () => {
       // the read-only permission loosening introduced by this PR.
       mockAccessService.canUser.mockResolvedValue(false);
       mockAccessService.hasPermission.mockResolvedValue(false);
+      const plaintextValue = "configuration-value-must-not-leak";
+      mockAgentService.getById.mockResolvedValue({
+        ...baseAgent,
+        adapterConfig: {
+          env: { GENERIC_NAME: { type: "plain", value: plaintextValue } },
+        },
+      });
 
       const app = await createApp({
         type: "board",
@@ -1846,6 +1893,78 @@ describe.sequential("agent permission routes", () => {
       const res = await request(app).get(`/api/agents/${agentId}/configuration`);
 
       expect(res.status).toBe(200);
+      expect(res.body.adapterConfig.env).toEqual({
+        GENERIC_NAME: { type: "plain", value: "***REDACTED***" },
+      });
+      expect(JSON.stringify(res.body)).not.toContain(plaintextValue);
+    });
+
+    it("redacts plaintext env values in company configuration-list responses", async () => {
+      const plaintextValue = "configuration-list-value-must-not-leak";
+      mockAgentService.list.mockResolvedValue([
+        {
+          ...baseAgent,
+          adapterConfig: {
+            env: { GENERIC_NAME: { type: "plain", value: plaintextValue } },
+          },
+        },
+      ]);
+
+      const app = await createApp({
+        type: "board",
+        userId: "board-user",
+        source: "session",
+        isInstanceAdmin: false,
+        companyIds: [companyId],
+      });
+
+      const res = await request(app).get(`/api/companies/${companyId}/agent-configurations`);
+
+      expect(res.status).toBe(200);
+      expect(res.body[0].adapterConfig.env).toEqual({
+        GENERIC_NAME: { type: "plain", value: "***REDACTED***" },
+      });
+      expect(JSON.stringify(res.body)).not.toContain(plaintextValue);
+    });
+
+    it("redacts plaintext env values in configuration revisions", async () => {
+      const plaintextValue = "revision-value-must-not-leak";
+      mockAgentService.listConfigRevisions.mockResolvedValue([
+        {
+          id: "33333333-3333-4333-8333-333333333333",
+          beforeConfig: {
+            adapterConfig: {
+              env: { GENERIC_NAME: { type: "plain", value: plaintextValue } },
+            },
+          },
+          afterConfig: {
+            adapterConfig: {
+              env: { GENERIC_NAME: plaintextValue },
+            },
+          },
+        },
+      ]);
+
+      const app = await createApp({
+        type: "board",
+        userId: "board-user",
+        source: "session",
+        isInstanceAdmin: false,
+        companyIds: [companyId],
+      });
+
+      const res = await request(app).get(`/api/agents/${agentId}/config-revisions`);
+
+      expect(res.status).toBe(200);
+      expect(res.body[0].beforeConfig.adapterConfig.env.GENERIC_NAME).toEqual({
+        type: "plain",
+        value: "***REDACTED***",
+      });
+      expect(res.body[0].afterConfig.adapterConfig.env.GENERIC_NAME).toEqual({
+        type: "plain",
+        value: "***REDACTED***",
+      });
+      expect(JSON.stringify(res.body)).not.toContain(plaintextValue);
     });
 
     it("denies an agent actor without configure or suggest grants when reading peer config", async () => {

--- a/server/src/__tests__/agent-permissions-routes.test.ts
+++ b/server/src/__tests__/agent-permissions-routes.test.ts
@@ -477,6 +477,89 @@ describe.sequential("agent permission routes", () => {
     expect(res.body.permissions).toMatchObject({ trustPreset: LOW_TRUST_REVIEW_PRESET });
   }, 20_000);
 
+  // TEC-7032 reported the leak against the company agent-list endpoint, which
+  // serialises rows directly instead of going through buildAgentDetail.
+  it("redacts env values in board GET /api/companies/:companyId/agents responses", async () => {
+    const plaintextValue = "listed-value-must-not-leak";
+    mockAgentService.list.mockResolvedValue([
+      {
+        ...baseAgent,
+        adapterConfig: {
+          command: "pnpm agent:run",
+          env: {
+            LEGACY_VALUE: plaintextValue,
+            PLAIN_VALUE: { type: "plain", value: plaintextValue },
+            SECRET_REFERENCE: {
+              type: "secret_ref",
+              secretId: "55555555-5555-4555-8555-555555555555",
+              version: "latest",
+            },
+          },
+        },
+      },
+    ]);
+
+    const app = await createApp({
+      type: "board",
+      userId: "board-user",
+      source: "local_implicit",
+      isInstanceAdmin: true,
+      companyIds: [companyId],
+    });
+
+    const res = await requestApp(app, (baseUrl) =>
+      request(baseUrl).get(`/api/companies/${companyId}/agents`),
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(1);
+    expect(res.body[0].adapterConfig).toMatchObject({
+      command: "pnpm agent:run",
+      env: {
+        LEGACY_VALUE: { type: "plain", value: "***REDACTED***" },
+        PLAIN_VALUE: { type: "plain", value: "***REDACTED***" },
+        SECRET_REFERENCE: {
+          type: "secret_ref",
+          secretId: "55555555-5555-4555-8555-555555555555",
+          version: "latest",
+        },
+      },
+    });
+    expect(JSON.stringify(res.body)).not.toContain(plaintextValue);
+  }, 20_000);
+
+  // Mutation routes echo the stored row back, so they leak the same values the
+  // GET paths redact.
+  it("redacts env values in agent mutation responses", async () => {
+    const plaintextValue = "mutation-value-must-not-leak";
+    const storedAgent = {
+      ...baseAgent,
+      adapterConfig: {
+        env: { PLAIN_VALUE: { type: "plain", value: plaintextValue } },
+      },
+    };
+    mockAgentService.getById.mockResolvedValue(storedAgent);
+    mockAgentService.update.mockResolvedValue(storedAgent);
+
+    const app = await createApp({
+      type: "board",
+      userId: "board-user",
+      source: "local_implicit",
+      isInstanceAdmin: true,
+      companyIds: [companyId],
+    });
+
+    const res = await requestApp(app, (baseUrl) =>
+      request(baseUrl).patch(`/api/agents/${agentId}`).send({ title: "Renamed" }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.body.adapterConfig.env).toEqual({
+      PLAIN_VALUE: { type: "plain", value: "***REDACTED***" },
+    });
+    expect(JSON.stringify(res.body)).not.toContain(plaintextValue);
+  }, 20_000);
+
   it("redacts env values in GET /api/agents/me responses", async () => {
     const plaintextValue = "self-value-must-not-leak";
     mockAgentService.getById.mockResolvedValue({

--- a/server/src/__tests__/agent-permissions-routes.test.ts
+++ b/server/src/__tests__/agent-permissions-routes.test.ts
@@ -422,7 +422,8 @@ describe.sequential("agent permission routes", () => {
     expect(res.body.runtimeConfig).toEqual({});
   }, 20_000);
 
-  it("keeps board agent detail unredacted for low-trust agents", async () => {
+  it("redacts env values in board agent detail responses", async () => {
+    const plaintextValue = "plain-value-must-not-leak";
     mockAgentService.getById.mockResolvedValue({
       ...baseAgent,
       permissions: {
@@ -431,7 +432,15 @@ describe.sequential("agent permission routes", () => {
       },
       adapterConfig: {
         command: "pnpm agent:run",
-        env: { PAPERCLIP_API_KEY: "secret-test-key" },
+        env: {
+          LEGACY_VALUE: plaintextValue,
+          PLAIN_VALUE: { type: "plain", value: plaintextValue },
+          SECRET_REFERENCE: {
+            type: "secret_ref",
+            secretId: "33333333-3333-4333-8333-333333333333",
+            version: "latest",
+          },
+        },
       },
       runtimeConfig: {
         heartbeat: { enabled: false },
@@ -451,12 +460,105 @@ describe.sequential("agent permission routes", () => {
     expect(res.status).toBe(200);
     expect(res.body.adapterConfig).toMatchObject({
       command: "pnpm agent:run",
-      env: { PAPERCLIP_API_KEY: "secret-test-key" },
+      env: {
+        LEGACY_VALUE: { type: "plain", value: "***REDACTED***" },
+        PLAIN_VALUE: { type: "plain", value: "***REDACTED***" },
+        SECRET_REFERENCE: {
+          type: "secret_ref",
+          secretId: "33333333-3333-4333-8333-333333333333",
+          version: "latest",
+        },
+      },
     });
+    expect(JSON.stringify(res.body)).not.toContain(plaintextValue);
     expect(res.body.runtimeConfig).toMatchObject({
       heartbeat: { enabled: false },
     });
     expect(res.body.permissions).toMatchObject({ trustPreset: LOW_TRUST_REVIEW_PRESET });
+  }, 20_000);
+
+  it("redacts env values in GET /api/agents/me responses", async () => {
+    const plaintextValue = "self-value-must-not-leak";
+    mockAgentService.getById.mockResolvedValue({
+      ...baseAgent,
+      adapterConfig: {
+        env: {
+          EXISTING_VALUE: plaintextValue,
+          NEW_VALUE: { type: "plain", value: plaintextValue },
+          SECRET_REFERENCE: {
+            type: "secret_ref",
+            secretId: "44444444-4444-4444-8444-444444444444",
+            version: 2,
+          },
+        },
+      },
+    });
+
+    const app = await createApp({
+      type: "agent",
+      agentId,
+      companyId,
+      runId: null,
+      source: "agent_key",
+    });
+
+    const res = await requestApp(app, (baseUrl) => request(baseUrl).get("/api/agents/me"));
+
+    expect(res.status).toBe(200);
+    expect(res.body.adapterConfig.env).toEqual({
+      EXISTING_VALUE: { type: "plain", value: "***REDACTED***" },
+      NEW_VALUE: { type: "plain", value: "***REDACTED***" },
+      SECRET_REFERENCE: {
+        type: "secret_ref",
+        secretId: "44444444-4444-4444-8444-444444444444",
+        version: 2,
+      },
+    });
+    expect(JSON.stringify(res.body)).not.toContain(plaintextValue);
+  }, 20_000);
+
+  it("preserves stored env values when a redacted detail response is submitted unchanged", async () => {
+    const plaintextValue = "stored-value-must-be-preserved";
+    mockAgentService.getById.mockResolvedValue({
+      ...baseAgent,
+      adapterConfig: {
+        env: {
+          EXISTING_VALUE: { type: "plain", value: plaintextValue },
+        },
+      },
+    });
+    mockAgentService.update.mockResolvedValue(baseAgent);
+
+    const app = await createApp({
+      type: "board",
+      userId: "board-user",
+      source: "local_implicit",
+      isInstanceAdmin: true,
+      companyIds: [companyId],
+    });
+
+    const redactedResponse = await requestApp(app, (baseUrl) =>
+      request(baseUrl).get(`/api/agents/${agentId}`),
+    );
+    expect(redactedResponse.status).toBe(200);
+    const redactedEnv = redactedResponse.body.adapterConfig.env as Record<string, unknown>;
+    expect(redactedEnv.EXISTING_VALUE).toEqual({ type: "plain", value: "***REDACTED***" });
+
+    const patchRes = await requestApp(app, (baseUrl) =>
+      request(baseUrl).patch(`/api/agents/${agentId}`).send({
+        title: "Renamed while redacted env round-trips",
+        adapterConfig: redactedResponse.body.adapterConfig,
+      }),
+    );
+
+    expect(patchRes.status).toBe(200);
+    const updateCallArgs = mockAgentService.update.mock.calls[0]?.[1] as
+      | { adapterConfig?: Record<string, unknown> }
+      | undefined;
+    expect(updateCallArgs?.adapterConfig?.env).toEqual({
+      EXISTING_VALUE: { type: "plain", value: plaintextValue },
+    });
+    expect(JSON.stringify(updateCallArgs?.adapterConfig ?? {})).not.toContain("***REDACTED***");
   }, 20_000);
 
   it("redacts company agent list for authenticated company members without agent admin permission", async () => {

--- a/server/src/__tests__/redaction.test.ts
+++ b/server/src/__tests__/redaction.test.ts
@@ -180,4 +180,34 @@ describe("redaction", () => {
     });
     expect(JSON.stringify(result)).not.toContain(plaintextValue);
   });
+
+  it("redacts non-env adapter keys while leaving env binding shapes intact", () => {
+    const result = redactAgentAdapterConfig({
+      command: "pnpm agent:run",
+      apiKey: "adapter-level-secret",
+      env: {
+        API_KEY: "env-level-secret",
+        AUTH_TOKEN: { type: "plain", value: "another-env-secret" },
+      },
+    });
+
+    // Non-env keys still go through the shared payload sanitizer.
+    expect(result.apiKey).toBe(REDACTED_EVENT_VALUE);
+    expect(result.command).toBe("pnpm agent:run");
+
+    // Env bindings keep their binding shape rather than collapsing to a bare
+    // sentinel string, which is what a second sanitizer pass would produce for
+    // these sensitive-looking key names.
+    expect(result.env).toEqual({
+      API_KEY: { type: "plain", value: REDACTED_EVENT_VALUE },
+      AUTH_TOKEN: { type: "plain", value: REDACTED_EVENT_VALUE },
+    });
+  });
+
+  it("redacts adapter configs that have no env block", () => {
+    expect(redactAgentAdapterConfig({ command: "pnpm agent:run", apiKey: "secret" })).toEqual({
+      command: "pnpm agent:run",
+      apiKey: REDACTED_EVENT_VALUE,
+    });
+  });
 });

--- a/server/src/__tests__/redaction.test.ts
+++ b/server/src/__tests__/redaction.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { REDACTED_EVENT_VALUE, redactEventPayload, redactSensitiveText, sanitizeRecord } from "../redaction.js";
+import {
+  REDACTED_EVENT_VALUE,
+  redactAgentAdapterConfig,
+  redactEventPayload,
+  redactSensitiveText,
+  sanitizeRecord,
+} from "../redaction.js";
 
 describe("redaction", () => {
   it("redacts sensitive keys and nested secret values", () => {
@@ -134,5 +140,44 @@ describe("redaction", () => {
 
     expect(result?.args).toEqual(["--api-key", "not-a-command-secret"]);
     expect(result?.argv).toEqual(["--api-key", REDACTED_EVENT_VALUE]);
+  });
+
+  it("redacts every plaintext agent env binding while preserving secret references", () => {
+    const plaintextValue = "adapter-env-value-must-not-leak";
+
+    const result = redactAgentAdapterConfig({
+      command: "pnpm agent:run",
+      env: {
+        EXISTING_VALUE: plaintextValue,
+        NEW_VALUE: { type: "plain", value: plaintextValue },
+        SECRET_REFERENCE: {
+          type: "secret_ref",
+          secretId: "55555555-5555-4555-8555-555555555555",
+          version: "latest",
+        },
+        USER_SECRET_REFERENCE: {
+          type: "user_secret_ref",
+          key: "GITHUB_TOKEN",
+        },
+      },
+    });
+
+    expect(result).toEqual({
+      command: "pnpm agent:run",
+      env: {
+        EXISTING_VALUE: { type: "plain", value: REDACTED_EVENT_VALUE },
+        NEW_VALUE: { type: "plain", value: REDACTED_EVENT_VALUE },
+        SECRET_REFERENCE: {
+          type: "secret_ref",
+          secretId: "55555555-5555-4555-8555-555555555555",
+          version: "latest",
+        },
+        USER_SECRET_REFERENCE: {
+          type: "user_secret_ref",
+          key: "GITHUB_TOKEN",
+        },
+      },
+    });
+    expect(JSON.stringify(result)).not.toContain(plaintextValue);
   });
 });

--- a/server/src/__tests__/redaction.test.ts
+++ b/server/src/__tests__/redaction.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   PRP_V1_EVENT_TYPES,
   REDACTED_EVENT_VALUE,
+  redactAgentAdapterConfig,
   redactEventPayload,
   redactSensitiveText,
   sanitizeRecord,
@@ -625,5 +626,44 @@ second-line\" status=401`,
 
     expect(result?.args).toEqual(["--api-key", "not-a-command-secret"]);
     expect(result?.argv).toEqual(["--api-key", REDACTED_EVENT_VALUE]);
+  });
+
+  it("redacts every plaintext agent env binding while preserving secret references", () => {
+    const plaintextValue = "adapter-env-value-must-not-leak";
+
+    const result = redactAgentAdapterConfig({
+      command: "pnpm agent:run",
+      env: {
+        EXISTING_VALUE: plaintextValue,
+        NEW_VALUE: { type: "plain", value: plaintextValue },
+        SECRET_REFERENCE: {
+          type: "secret_ref",
+          secretId: "55555555-5555-4555-8555-555555555555",
+          version: "latest",
+        },
+        USER_SECRET_REFERENCE: {
+          type: "user_secret_ref",
+          key: "GITHUB_TOKEN",
+        },
+      },
+    });
+
+    expect(result).toEqual({
+      command: "pnpm agent:run",
+      env: {
+        EXISTING_VALUE: { type: "plain", value: REDACTED_EVENT_VALUE },
+        NEW_VALUE: { type: "plain", value: REDACTED_EVENT_VALUE },
+        SECRET_REFERENCE: {
+          type: "secret_ref",
+          secretId: "55555555-5555-4555-8555-555555555555",
+          version: "latest",
+        },
+        USER_SECRET_REFERENCE: {
+          type: "user_secret_ref",
+          key: "GITHUB_TOKEN",
+        },
+      },
+    });
+    expect(JSON.stringify(result)).not.toContain(plaintextValue);
   });
 });

--- a/server/src/__tests__/redaction.test.ts
+++ b/server/src/__tests__/redaction.test.ts
@@ -666,4 +666,34 @@ second-line\" status=401`,
     });
     expect(JSON.stringify(result)).not.toContain(plaintextValue);
   });
+
+  it("redacts non-env adapter keys while leaving env binding shapes intact", () => {
+    const result = redactAgentAdapterConfig({
+      command: "pnpm agent:run",
+      apiKey: "adapter-level-secret",
+      env: {
+        API_KEY: "env-level-secret",
+        AUTH_TOKEN: { type: "plain", value: "another-env-secret" },
+      },
+    });
+
+    // Non-env keys still go through the shared payload sanitizer.
+    expect(result.apiKey).toBe(REDACTED_EVENT_VALUE);
+    expect(result.command).toBe("pnpm agent:run");
+
+    // Env bindings keep their binding shape rather than collapsing to a bare
+    // sentinel string, which is what a second sanitizer pass would produce for
+    // these sensitive-looking key names.
+    expect(result.env).toEqual({
+      API_KEY: { type: "plain", value: REDACTED_EVENT_VALUE },
+      AUTH_TOKEN: { type: "plain", value: REDACTED_EVENT_VALUE },
+    });
+  });
+
+  it("redacts adapter configs that have no env block", () => {
+    expect(redactAgentAdapterConfig({ command: "pnpm agent:run", apiKey: "secret" })).toEqual({
+      command: "pnpm agent:run",
+      apiKey: REDACTED_EVENT_VALUE,
+    });
+  });
 });

--- a/server/src/redaction.ts
+++ b/server/src/redaction.ts
@@ -133,6 +133,31 @@ export function redactEventPayload(payload: Record<string, unknown> | null): Rec
   return sanitizeRecord(payload);
 }
 
+function redactAgentEnvBinding(value: unknown): unknown {
+  if (isSecretRefBinding(value) || isUserSecretRefBinding(value)) {
+    return sanitizeValue(value);
+  }
+  if (typeof value === "string" || isPlainBinding(value)) {
+    return { type: "plain", value: REDACTED_EVENT_VALUE };
+  }
+  if (value === null || value === undefined) return value;
+  return REDACTED_EVENT_VALUE;
+}
+
+export function redactAgentAdapterConfig(
+  adapterConfig: Record<string, unknown>,
+): Record<string, unknown> {
+  if (!isPlainObject(adapterConfig)) return adapterConfig;
+
+  const env = isPlainObject(adapterConfig.env)
+    ? Object.fromEntries(
+        Object.entries(adapterConfig.env).map(([key, value]) => [key, redactAgentEnvBinding(value)]),
+      )
+    : adapterConfig.env;
+
+  return redactEventPayload({ ...adapterConfig, env }) ?? {};
+}
+
 export function redactSensitiveText(input: string): string {
   if (!maybeContainsSecretText(input)) return input;
   return redactCommandText(

--- a/server/src/redaction.ts
+++ b/server/src/redaction.ts
@@ -148,14 +148,18 @@ export function redactAgentAdapterConfig(
   adapterConfig: Record<string, unknown>,
 ): Record<string, unknown> {
   if (!isPlainObject(adapterConfig)) return adapterConfig;
+  if (!isPlainObject(adapterConfig.env)) return redactEventPayload(adapterConfig) ?? {};
 
-  const env = isPlainObject(adapterConfig.env)
-    ? Object.fromEntries(
-        Object.entries(adapterConfig.env).map(([key, value]) => [key, redactAgentEnvBinding(value)]),
-      )
-    : adapterConfig.env;
+  // Redact `env` here and sanitize the remaining keys separately, so bindings
+  // are never processed twice. `redactAgentEnvBinding` is authoritative for
+  // `env`; keeping it out of `sanitizeRecord` means a future change there
+  // cannot alter entries this function has already redacted.
+  const { env, ...rest } = adapterConfig;
+  const redactedEnv = Object.fromEntries(
+    Object.entries(env).map(([key, value]) => [key, redactAgentEnvBinding(value)]),
+  );
 
-  return redactEventPayload({ ...adapterConfig, env }) ?? {};
+  return { ...(redactEventPayload(rest) ?? {}), env: redactedEnv };
 }
 
 export function redactSensitiveText(input: string): string {

--- a/server/src/redaction.ts
+++ b/server/src/redaction.ts
@@ -941,6 +941,31 @@ export function redactEventPayload(
   return sanitized;
 }
 
+function redactAgentEnvBinding(value: unknown): unknown {
+  if (isSecretRefBinding(value) || isUserSecretRefBinding(value)) {
+    return sanitizeValue(value);
+  }
+  if (typeof value === "string" || isPlainBinding(value)) {
+    return { type: "plain", value: REDACTED_EVENT_VALUE };
+  }
+  if (value === null || value === undefined) return value;
+  return REDACTED_EVENT_VALUE;
+}
+
+export function redactAgentAdapterConfig(
+  adapterConfig: Record<string, unknown>,
+): Record<string, unknown> {
+  if (!isPlainObject(adapterConfig)) return adapterConfig;
+
+  const env = isPlainObject(adapterConfig.env)
+    ? Object.fromEntries(
+        Object.entries(adapterConfig.env).map(([key, value]) => [key, redactAgentEnvBinding(value)]),
+      )
+    : adapterConfig.env;
+
+  return redactEventPayload({ ...adapterConfig, env }) ?? {};
+}
+
 export function redactSensitiveText(input: string): string {
   if (!maybeContainsSecretText(input)) return input;
   return redactCommandText(

--- a/server/src/redaction.ts
+++ b/server/src/redaction.ts
@@ -956,14 +956,18 @@ export function redactAgentAdapterConfig(
   adapterConfig: Record<string, unknown>,
 ): Record<string, unknown> {
   if (!isPlainObject(adapterConfig)) return adapterConfig;
+  if (!isPlainObject(adapterConfig.env)) return redactEventPayload(adapterConfig) ?? {};
 
-  const env = isPlainObject(adapterConfig.env)
-    ? Object.fromEntries(
-        Object.entries(adapterConfig.env).map(([key, value]) => [key, redactAgentEnvBinding(value)]),
-      )
-    : adapterConfig.env;
+  // Redact `env` here and sanitize the remaining keys separately, so bindings
+  // are never processed twice. `redactAgentEnvBinding` is authoritative for
+  // `env`; keeping it out of `sanitizeRecord` means a future change there
+  // cannot alter entries this function has already redacted.
+  const { env, ...rest } = adapterConfig;
+  const redactedEnv = Object.fromEntries(
+    Object.entries(env).map(([key, value]) => [key, redactAgentEnvBinding(value)]),
+  );
 
-  return redactEventPayload({ ...adapterConfig, env }) ?? {};
+  return { ...(redactEventPayload(rest) ?? {}), env: redactedEnv };
 }
 
 export function redactSensitiveText(input: string): string {

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -80,7 +80,11 @@ import {
   refreshAdapterModels,
   requireServerAdapter,
 } from "../adapters/index.js";
-import { redactEventPayload } from "../redaction.js";
+import {
+  REDACTED_EVENT_VALUE,
+  redactAgentAdapterConfig,
+  redactEventPayload,
+} from "../redaction.js";
 import { redactCurrentUserValue } from "../log-redaction.js";
 import { renderOrgChartSvg, renderOrgChartPng, type OrgNode, type OrgChartStyle, ORG_CHART_STYLES } from "./org-chart-svg.js";
 import {
@@ -661,8 +665,15 @@ export function agentRoutes(
       buildAgentAccessState(agent),
     ]);
 
+    const baseAgent = options?.restricted ? redactForRestrictedAgentView(agent) : agent;
+    const adapterConfig =
+      baseAgent && typeof baseAgent === "object" && baseAgent.adapterConfig
+        ? redactAgentAdapterConfig(baseAgent.adapterConfig as Record<string, unknown>)
+        : baseAgent?.adapterConfig;
+
     return {
-      ...(options?.restricted ? redactForRestrictedAgentView(agent) : agent),
+      ...baseAgent,
+      adapterConfig,
       chainOfCommand,
       access: accessState,
     };
@@ -1651,6 +1662,28 @@ export function agentRoutes(
       permissions: agent.permissions,
       updatedAt: agent.updatedAt,
     };
+  }
+
+  function restoreRedactedAgentEnv(
+    requestedConfig: Record<string, unknown>,
+    existingConfig: Record<string, unknown>,
+  ): Record<string, unknown> {
+    const requestedEnv = asRecord(requestedConfig.env);
+    const existingEnv = asRecord(existingConfig.env);
+    if (!requestedEnv || !existingEnv) return requestedConfig;
+
+    const restoredEnv = { ...requestedEnv };
+    for (const [key, value] of Object.entries(requestedEnv)) {
+      const binding = asRecord(value);
+      if (
+        binding?.type === "plain"
+        && binding.value === REDACTED_EVENT_VALUE
+        && Object.prototype.hasOwnProperty.call(existingEnv, key)
+      ) {
+        restoredEnv[key] = existingEnv[key];
+      }
+    }
+    return { ...requestedConfig, env: restoredEnv };
   }
 
   function redactRevisionSnapshot(snapshot: unknown): Record<string, unknown> {
@@ -2988,9 +3021,11 @@ export function agentRoutes(
       ) {
         await assertCanManageInstructionsPath(req, existing);
       }
-      let rawEffectiveAdapterConfig = requestedAdapterConfig ?? existingAdapterConfig;
+      let rawEffectiveAdapterConfig = requestedAdapterConfig
+        ? restoreRedactedAgentEnv(requestedAdapterConfig, existingAdapterConfig)
+        : existingAdapterConfig;
       if (requestedAdapterConfig && !changingAdapterType && !replaceAdapterConfig) {
-        rawEffectiveAdapterConfig = { ...existingAdapterConfig, ...requestedAdapterConfig };
+        rawEffectiveAdapterConfig = { ...existingAdapterConfig, ...rawEffectiveAdapterConfig };
       }
       if (changingAdapterType) {
         // Preserve adapter-agnostic keys (env, cwd, etc.) from the existing config

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -665,15 +665,12 @@ export function agentRoutes(
       buildAgentAccessState(agent),
     ]);
 
-    const baseAgent = options?.restricted ? redactForRestrictedAgentView(agent) : agent;
-    const adapterConfig =
-      baseAgent && typeof baseAgent === "object" && baseAgent.adapterConfig
-        ? redactAgentAdapterConfig(baseAgent.adapterConfig as Record<string, unknown>)
-        : baseAgent?.adapterConfig;
+    const baseAgent = redactAgentRowForResponse(
+      options?.restricted ? redactForRestrictedAgentView(agent) : agent,
+    );
 
     return {
       ...baseAgent,
-      adapterConfig,
       chainOfCommand,
       access: accessState,
     };
@@ -1646,6 +1643,21 @@ export function agentRoutes(
     };
   }
 
+  // Single presenter for every response that emits a raw agent row. Restricted
+  // views blank the config wholesale for authorization reasons; this runs for
+  // config-reading (board) callers too, so plaintext `adapterConfig.env` values
+  // never leave the API regardless of actor scope.
+  function redactAgentRowForResponse<T extends { adapterConfig?: unknown } | null | undefined>(
+    agent: T,
+  ): T {
+    if (!agent || typeof agent !== "object") return agent;
+    if (!agent.adapterConfig || typeof agent.adapterConfig !== "object") return agent;
+    return {
+      ...agent,
+      adapterConfig: redactAgentAdapterConfig(agent.adapterConfig as Record<string, unknown>),
+    };
+  }
+
   function redactAgentConfiguration(agent: Awaited<ReturnType<typeof svc.getById>>) {
     if (!agent) return null;
     return {
@@ -2010,7 +2022,7 @@ export function agentRoutes(
     const result = await filterAgentsForActor(req, await svc.list(companyId));
     const canReadConfigs = await actorCanReadConfigurationsForCompany(req, companyId);
     if (canReadConfigs) {
-      res.json(result);
+      res.json(result.map((agent) => redactAgentRowForResponse(agent)));
       return;
     }
     res.json(result.map((agent) => redactForRestrictedAgentView(agent)));
@@ -2672,7 +2684,7 @@ export function agentRoutes(
       );
     }
 
-    res.status(201).json(agent);
+    res.status(201).json(redactAgentRowForResponse(agent));
   });
 
   router.patch("/agents/:id/permissions", validate(updateAgentPermissionsSchema), async (req, res) => {
@@ -3115,7 +3127,7 @@ export function agentRoutes(
       details: summarizeAgentUpdateDetails(patchData),
     });
 
-    res.json(agent);
+    res.json(redactAgentRowForResponse(agent));
   });
 
   router.post("/agents/:id/pause", async (req, res) => {
@@ -3141,7 +3153,7 @@ export function agentRoutes(
       entityId: agent.id,
     });
 
-    res.json(agent);
+    res.json(redactAgentRowForResponse(agent));
   });
 
   router.post("/agents/:id/resume", async (req, res) => {
@@ -3172,7 +3184,7 @@ export function agentRoutes(
       entityId: agent.id,
     });
 
-    res.json(agent);
+    res.json(redactAgentRowForResponse(agent));
   });
 
   router.post("/agents/:id/clear-error", async (req, res) => {
@@ -3204,7 +3216,7 @@ export function agentRoutes(
       entityId: agent.id,
     });
 
-    res.json(agent);
+    res.json(redactAgentRowForResponse(agent));
   });
 
   router.post("/agents/:id/approve", async (req, res) => {
@@ -3258,7 +3270,7 @@ export function agentRoutes(
       details: { source: "agent_detail", approvalId: openApproval?.id ?? null },
     });
 
-    res.json(agent);
+    res.json(redactAgentRowForResponse(agent));
   });
 
   router.post("/agents/:id/terminate", async (req, res) => {
@@ -3328,7 +3340,7 @@ export function agentRoutes(
       },
     });
 
-    res.json(agent);
+    res.json(redactAgentRowForResponse(agent));
   });
 
   router.delete("/agents/:id", async (req, res) => {

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -105,7 +105,11 @@ import {
   refreshAdapterModels,
   requireServerAdapter,
 } from "../adapters/index.js";
-import { redactEventPayload } from "../redaction.js";
+import {
+  REDACTED_EVENT_VALUE,
+  redactAgentAdapterConfig,
+  redactEventPayload,
+} from "../redaction.js";
 import { redactCurrentUserValue } from "../log-redaction.js";
 import {
   HarnessRuntimeRequestResolutionError,
@@ -1483,8 +1487,15 @@ export function agentRoutes(
       buildAgentAccessState(agent),
     ]);
 
+    const baseAgent = options?.restricted ? redactForRestrictedAgentView(agent) : agent;
+    const adapterConfig =
+      baseAgent && typeof baseAgent === "object" && baseAgent.adapterConfig
+        ? redactAgentAdapterConfig(baseAgent.adapterConfig as Record<string, unknown>)
+        : baseAgent?.adapterConfig;
+
     return {
-      ...(options?.restricted ? redactForRestrictedAgentView(agent) : agent),
+      ...baseAgent,
+      adapterConfig,
       chainOfCommand,
       access: accessState,
     };
@@ -2789,6 +2800,28 @@ export function agentRoutes(
       permissions: agent.permissions,
       updatedAt: agent.updatedAt,
     };
+  }
+
+  function restoreRedactedAgentEnv(
+    requestedConfig: Record<string, unknown>,
+    existingConfig: Record<string, unknown>,
+  ): Record<string, unknown> {
+    const requestedEnv = asRecord(requestedConfig.env);
+    const existingEnv = asRecord(existingConfig.env);
+    if (!requestedEnv || !existingEnv) return requestedConfig;
+
+    const restoredEnv = { ...requestedEnv };
+    for (const [key, value] of Object.entries(requestedEnv)) {
+      const binding = asRecord(value);
+      if (
+        binding?.type === "plain"
+        && binding.value === REDACTED_EVENT_VALUE
+        && Object.prototype.hasOwnProperty.call(existingEnv, key)
+      ) {
+        restoredEnv[key] = existingEnv[key];
+      }
+    }
+    return { ...requestedConfig, env: restoredEnv };
   }
 
   function redactRevisionSnapshot(snapshot: unknown): Record<string, unknown> {
@@ -4575,9 +4608,11 @@ export function agentRoutes(
       ) {
         await assertCanManageInstructionsPath(req, existing);
       }
-      let rawEffectiveAdapterConfig = requestedAdapterConfig ?? existingAdapterConfig;
+      let rawEffectiveAdapterConfig = requestedAdapterConfig
+        ? restoreRedactedAgentEnv(requestedAdapterConfig, existingAdapterConfig)
+        : existingAdapterConfig;
       if (requestedAdapterConfig && !changingAdapterType && !replaceAdapterConfig) {
-        rawEffectiveAdapterConfig = { ...existingAdapterConfig, ...requestedAdapterConfig };
+        rawEffectiveAdapterConfig = { ...existingAdapterConfig, ...rawEffectiveAdapterConfig };
       }
       if (changingAdapterType) {
         // Preserve adapter-agnostic keys (env, cwd, etc.) from the existing config

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -1487,15 +1487,12 @@ export function agentRoutes(
       buildAgentAccessState(agent),
     ]);
 
-    const baseAgent = options?.restricted ? redactForRestrictedAgentView(agent) : agent;
-    const adapterConfig =
-      baseAgent && typeof baseAgent === "object" && baseAgent.adapterConfig
-        ? redactAgentAdapterConfig(baseAgent.adapterConfig as Record<string, unknown>)
-        : baseAgent?.adapterConfig;
+    const baseAgent = redactAgentRowForResponse(
+      options?.restricted ? redactForRestrictedAgentView(agent) : agent,
+    );
 
     return {
       ...baseAgent,
-      adapterConfig,
       chainOfCommand,
       access: accessState,
     };
@@ -2784,6 +2781,21 @@ export function agentRoutes(
     };
   }
 
+  // Single presenter for every response that emits a raw agent row. Restricted
+  // views blank the config wholesale for authorization reasons; this runs for
+  // config-reading (board) callers too, so plaintext `adapterConfig.env` values
+  // never leave the API regardless of actor scope.
+  function redactAgentRowForResponse<T extends { adapterConfig?: unknown } | null | undefined>(
+    agent: T,
+  ): T {
+    if (!agent || typeof agent !== "object") return agent;
+    if (!agent.adapterConfig || typeof agent.adapterConfig !== "object") return agent;
+    return {
+      ...agent,
+      adapterConfig: redactAgentAdapterConfig(agent.adapterConfig as Record<string, unknown>),
+    };
+  }
+
   function redactAgentConfiguration(agent: Awaited<ReturnType<typeof svc.getById>>) {
     if (!agent) return null;
     return {
@@ -3499,7 +3511,7 @@ export function agentRoutes(
     const result = await filterAgentsForActor(req, await svc.list(companyId));
     const canReadConfigs = await actorCanReadConfigurationsForCompany(req, companyId);
     if (canReadConfigs) {
-      res.json(result);
+      res.json(result.map((agent) => redactAgentRowForResponse(agent)));
       return;
     }
     res.json(result.map((agent) => redactForRestrictedAgentView(agent)));
@@ -4243,7 +4255,7 @@ export function agentRoutes(
       );
     }
 
-    res.status(201).json(agent);
+    res.status(201).json(redactAgentRowForResponse(agent));
   });
 
   router.patch("/agents/:id/permissions", validate(updateAgentPermissionsSchema), async (req, res) => {
@@ -4723,7 +4735,7 @@ export function agentRoutes(
       details: summarizeAgentUpdateDetails(patchData),
     });
 
-    res.json(agent);
+    res.json(redactAgentRowForResponse(agent));
   });
 
   router.post("/agents/:id/pause", async (req, res) => {
@@ -4749,7 +4761,7 @@ export function agentRoutes(
       entityId: agent.id,
     });
 
-    res.json(agent);
+    res.json(redactAgentRowForResponse(agent));
   });
 
   router.post("/agents/:id/resume", async (req, res) => {
@@ -4784,7 +4796,7 @@ export function agentRoutes(
       entityId: agent.id,
     });
 
-    res.json(agent);
+    res.json(redactAgentRowForResponse(agent));
   });
 
   router.post("/agents/:id/clear-error", async (req, res) => {
@@ -4816,7 +4828,7 @@ export function agentRoutes(
       entityId: agent.id,
     });
 
-    res.json(agent);
+    res.json(redactAgentRowForResponse(agent));
   });
 
   router.post("/agents/:id/approve", async (req, res) => {
@@ -4870,7 +4882,7 @@ export function agentRoutes(
       details: { source: "agent_detail", approvalId: openApproval?.id ?? null },
     });
 
-    res.json(agent);
+    res.json(redactAgentRowForResponse(agent));
   });
 
   router.post("/agents/:id/terminate", async (req, res) => {
@@ -4940,7 +4952,7 @@ export function agentRoutes(
       },
     });
 
-    res.json(agent);
+    res.json(redactAgentRowForResponse(agent));
   });
 
   router.delete("/agents/:id", async (req, res) => {

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -2807,7 +2807,7 @@ export function agentRoutes(
       status: agent.status,
       reportsTo: agent.reportsTo,
       adapterType: agent.adapterType,
-      adapterConfig: redactEventPayload(agent.adapterConfig),
+      adapterConfig: redactAgentAdapterConfig(agent.adapterConfig),
       runtimeConfig: redactEventPayload(agent.runtimeConfig),
       permissions: agent.permissions,
       updatedAt: agent.updatedAt,
@@ -2841,7 +2841,7 @@ export function agentRoutes(
     const record = snapshot as Record<string, unknown>;
     return {
       ...record,
-      adapterConfig: redactEventPayload(
+      adapterConfig: redactAgentAdapterConfig(
         typeof record.adapterConfig === "object" && record.adapterConfig !== null
           ? (record.adapterConfig as Record<string, unknown>)
           : {},
@@ -3851,7 +3851,7 @@ export function agentRoutes(
       details: { revisionId },
     });
 
-    res.json(updated);
+    res.json(redactAgentRowForResponse(updated));
   });
 
   router.get("/agents/:id/runtime-state", async (req, res) => {


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Agents are configured through `adapterConfig`, whose `env` block holds the credentials an agent needs to talk to its provider (API keys, tokens, and similar)
> - Those bindings come in several shapes: a legacy bare string, `{ type: "plain", value }`, and the indirection forms `{ type: "secret_ref" }` / `{ type: "user_secret_ref" }`
> - Every endpoint that serializes an agent returned `adapterConfig` as stored, so every `plain` binding was returned verbatim in the API response
> - That means any caller able to read an agent — including the agent itself via `GET /api/agents/me` — received live credentials in plaintext, and those values then propagate into client state, logs, and network traces
> - The exposure spans three response families that share no common serializer: the single-agent detail reads, the company agent-list read, and the create/update/lifecycle routes that echo the stored row straight back
> - This pull request routes all three through one presenter that redacts `plain` env bindings, so the leak is closed server-side and cannot be bypassed by the caller
> - The benefit is that agent credentials stop appearing in API responses while `secret_ref` indirection continues to work unchanged

## Linked Issues or Issue Description

No public upstream issue exists for this, so the underlying bug is described inline below following `.github/ISSUE_TEMPLATE/bug_report.yml`.

**What happened?**

Every endpoint that serializes an agent returned the full plaintext value of each `adapterConfig.env` entry whose `type` was `"plain"` (and each legacy bare-string binding). Any actor authorized to read an agent received that agent's live credentials in the response body. Three distinct response families were affected:

- **Single-agent reads** — `GET /api/agents/{id}` and `GET /api/agents/me`, via `buildAgentDetail`.
- **Company agent list** — `GET /api/companies/{companyId}/agents`, which serializes rows directly and therefore does not inherit any fix applied to `buildAgentDetail`. Callers that pass the configuration-read check received unredacted rows for every agent in the company in a single request, making this the broadest of the three.
- **Mutation responses** — agent create, `PATCH /api/agents/{id}`, and the `pause` / `resume` / `clear-error` / `approve` / `terminate` routes, each of which echoes the stored row back to the caller.

**Expected behavior**

Read endpoints should never emit stored plaintext credentials. `plain` bindings should be replaced with a redaction sentinel before serialization, while `secret_ref` and `user_secret_ref` bindings — which contain no secret material — pass through untouched.

**Steps to reproduce**

1. Configure an agent with an `adapterConfig.env` entry such as `{ "OPENAI_API_KEY": { "type": "plain", "value": "sk-example" } }`.
2. Call `GET /api/agents/{id}` (or authenticate as that agent and call `GET /api/agents/me`).
3. Observe `sk-example` returned verbatim in the response body.
4. Call `GET /api/companies/{companyId}/agents` as a configuration-reading caller and observe `sk-example` returned verbatim for that agent alongside every other agent's credentials.
5. Call `PATCH /api/agents/{id}` with any unrelated field (for example `{ "title": "Renamed" }`) and observe `sk-example` returned verbatim in the mutation response.

**Paperclip version or commit**

Reproduced on `master` at `f12bb27b`.

**Deployment mode**

Self-hosted / local development server.

## What Changed

- `server/src/redaction.ts`: adds `redactAgentAdapterConfig`, which rewrites every bare-string or `{ type: "plain", value }` env binding to `{ type: "plain", value: "***REDACTED***" }` and passes `secret_ref` / `user_secret_ref` bindings through unchanged. Reuses the existing `REDACTED_EVENT_VALUE` and `isSecretRefBinding` / `isUserSecretRefBinding` / `isPlainBinding` helpers — no new dependencies.
- `server/src/redaction.ts`: `env` is destructured out and sanitized only by `redactAgentEnvBinding`, while the remaining adapter keys go through `redactEventPayload`. Previously the already-redacted `env` was passed back through `sanitizeRecord`, so each binding was processed twice — safe only because the sentinel is a fixed point of that second pass. The two paths are now disjoint, making the invariant structural rather than coincidental.
- `server/src/routes/agents.ts`: `buildAgentDetail` applies `redactAgentAdapterConfig` before serialization, so `GET /api/agents/{id}` and `GET /api/agents/me` both redact at the response layer. Restricted views inherit the same protection.
- `server/src/routes/agents.ts`: adds `redactAgentRowForResponse`, the single presenter for every response that emits a raw agent row, and applies it to the company agent-list route and to the create / update / pause / resume / clear-error / approve / terminate routes. It composes with `redactForRestrictedAgentView` rather than replacing it: that helper is an authorization filter (blank the whole config for low-trust actors), this one is secret hygiene (mask values for every actor scope), and the two invariants stay independent. `buildAgentDetail` now delegates to the same presenter instead of inlining the call.
- `server/src/routes/agents.ts`: adds `restoreRedactedAgentEnv` on the PATCH path so a client that round-trips a redacted detail response back through `PATCH /api/agents/{id}` does not zero out stored values — redacted-sentinel entries matching an existing key are restored from storage.

## Verification

- `pnpm --filter @paperclipai/server exec tsc --noEmit` — clean.
- `pnpm --filter @paperclipai/server exec vitest run agent-permissions-routes.test.ts` — 57 tests pass.
- Adjacent suites (`redaction`, `agent-adapter-validation-routes`, `agent-cross-tenant-authz-routes`, `agents-pending-approval-config`, `agents-service-secret-bindings`, `built-in-agent-routes`, `plugin-managed-agents`, `agent-skills-routes`) — 8 files, 72 tests pass, no regressions.
- Both new route tests were confirmed to **fail** with the route changes reverted and pass with them applied, so they genuinely pin the behaviour rather than passing incidentally.

Tests added:

- `server/src/__tests__/redaction.test.ts`: covers legacy-string, `{ type: "plain" }`, `secret_ref`, and `user_secret_ref` bindings, asserting the plaintext value never appears in the serialized result; plus coverage that non-env adapter keys are still sanitized, that env binding shapes survive intact, and that configs with no `env` block are handled.
- `server/src/__tests__/agent-permissions-routes.test.ts`: `GET /api/agents/{id}` asserts redaction rather than plaintext passthrough; new `GET /api/agents/me` redaction test across the same binding shapes; new test asserting the `PATCH` round-trip preserves stored values; new test asserting the board `GET /api/companies/{companyId}/agents` response redacts every binding shape; new test asserting a mutation response redacts rather than echoing the stored plaintext.

No real secret values appear in any test, fixture, or commit message.

## Risks

- **Behavioral change for API consumers.** Any client that read a plaintext credential out of an agent detail, agent-list, or mutation response will now receive `***REDACTED***`. This is the intended security fix, but it is a breaking change for such consumers, which must move to `secret_ref` indirection.
- **Mutation responses are redacted too.** Callers that previously relied on a create or update response to echo back the credential they had just written must now read it from their own request. This is consistent with the `restoreRedactedAgentEnv` round-trip path, which already assumes the client holds a redacted copy.
- **Round-trip data loss, mitigated.** A client that GETs an agent and PATCHes the object straight back would otherwise persist the sentinel over the real value. `restoreRedactedAgentEnv` restores redacted entries from storage; the round-trip is covered by a regression test. A PATCH that *intentionally* sets a value literally equal to the sentinel is not distinguishable and would be treated as "unchanged" — an acceptable trade-off given the sentinel is not a plausible credential.
- **No migration.** Stored data is untouched; redaction happens purely at serialization time, so the change is fully reversible by revert.
- **Overlap with existing PRs** — see the duplicate-search note below. Maintainers may prefer to consolidate rather than merge this in isolation.

## Model Used

Claude Opus 4.8 (`claude-opus-4-8`), extended thinking enabled, with tool use and local test execution.

## Duplicate search

Searching open and closed PRs for prior art surfaced several overlapping efforts against the same defect. Linking them for maintainer triage — I am not claiming this PR supersedes them, and consolidation may well be preferable:

- #9823 — `fix(security): redact adapterConfig secrets on all agent read endpoints` (closest overlap)
- #8779 — `fix(server): redact agent config secrets in read and mutation responses`
- #8330 — `fix(server): redact adapterConfig.env for cross-actor agent reads`
- #4856 — `fix(server): redact adapter env secrets in agent API responses`
- #4763 — `fix(server): redact adapter_config secrets in agent detail responses`
- #1839 — `fix: redact secret env vars from agent API responses`
- #4967 — `fix(routines): redact adapterConfig.env in GET /api/routines/{id}` (same class, routines surface)

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I searched the GitHub PR list (open and closed) for similar or duplicate PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [ ] My branch name describes the change and contains no internal Paperclip ticket id — **not met**: the branch and title carry an internal ticket id. Renaming the branch would invalidate this PR; happy to reopen from a clean branch if maintainers prefer.
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes (no user-facing docs affected)
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups — the one P2 (env entries processed twice) is addressed above
- [x] I will address all Greptile and reviewer comments before requesting merge

