### PR TITLE
fix: redirect manual failed-run retries to the issue's current assignee

### DIFF
--- a/server/src/__tests__/agent-wakeup-retry-redirect-routes.test.ts
+++ b/server/src/__tests__/agent-wakeup-retry-redirect-routes.test.ts
@@ -17,7 +17,7 @@ import {
 } from "./helpers/embedded-postgres.js";
 import { errorHandler } from "../middleware/index.js";
 import { agentRoutes } from "../routes/agents.js";
-import { runningProcesses } from "../adapters/index.ts";
+import { runningProcesses } from "../adapters/index.js";
 
 const mockAdapterExecute = vi.hoisted(() =>
   vi.fn(async () => ({
@@ -31,8 +31,8 @@ const mockAdapterExecute = vi.hoisted(() =>
   })),
 );
 
-vi.mock("../adapters/index.ts", async () => {
-  const actual = await vi.importActual<typeof import("../adapters/index.ts")>("../adapters/index.ts");
+vi.mock("../adapters/index.js", async () => {
+  const actual = await vi.importActual<typeof import("../adapters/index.js")>("../adapters/index.js");
   return {
     ...actual,
     getServerAdapter: vi.fn(() => ({

--- a/server/src/__tests__/agent-wakeup-retry-redirect-routes.test.ts
+++ b/server/src/__tests__/agent-wakeup-retry-redirect-routes.test.ts
@@ -1,0 +1,331 @@
+import { randomUUID } from "node:crypto";
+import express from "express";
+import request from "supertest";
+import { eq } from "drizzle-orm";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import {
+  activityLog,
+  agents,
+  companies,
+  createDb,
+  heartbeatRuns,
+  issues,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import { errorHandler } from "../middleware/index.js";
+import { agentRoutes } from "../routes/agents.js";
+import { runningProcesses } from "../adapters/index.ts";
+
+const mockAdapterExecute = vi.hoisted(() =>
+  vi.fn(async () => ({
+    exitCode: 0,
+    signal: null,
+    timedOut: false,
+    errorMessage: null,
+    summary: "Retry redirect test run.",
+    provider: "test",
+    model: "test-model",
+  })),
+);
+
+vi.mock("../adapters/index.ts", async () => {
+  const actual = await vi.importActual<typeof import("../adapters/index.ts")>("../adapters/index.ts");
+  return {
+    ...actual,
+    getServerAdapter: vi.fn(() => ({
+      supportsLocalAgentJwt: false,
+      execute: mockAdapterExecute,
+    })),
+  };
+});
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping embedded Postgres wakeup retry-redirect route tests on this host: ${
+      embeddedPostgresSupport.reason ?? "unsupported environment"
+    }`,
+  );
+}
+
+type Db = ReturnType<typeof createDb>;
+
+function boardActor(companyId: string): Express.Request["actor"] {
+  return {
+    type: "board",
+    userId: "board-user",
+    companyIds: [companyId],
+    memberships: [{ companyId, membershipRole: "operator", status: "active" }],
+    isInstanceAdmin: true,
+    source: "local_implicit",
+  };
+}
+
+function agentActor(companyId: string, agentId: string): Express.Request["actor"] {
+  return {
+    type: "agent",
+    agentId,
+    companyId,
+    runId: null,
+    source: "agent_jwt",
+  };
+}
+
+function createApp(db: Db, actor: Express.Request["actor"]) {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    req.actor = actor;
+    next();
+  });
+  app.use("/api", agentRoutes(db));
+  app.use(errorHandler);
+  return app;
+}
+
+describeEmbeddedPostgres("agent wakeup retry_failed_run redirect routes", () => {
+  let db!: Db;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-wakeup-retry-redirect-");
+    db = createDb(tempDb.connectionString);
+  }, 20_000);
+
+  afterEach(async () => {
+    // Let any background run execution drain before the next test / teardown.
+    for (let attempt = 0; attempt < 100; attempt += 1) {
+      const runs = await db.select({ status: heartbeatRuns.status }).from(heartbeatRuns);
+      if (!runs.some((run) => run.status === "queued" || run.status === "running")) break;
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+    runningProcesses.clear();
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  async function seedFixture(opts: {
+    assigneeAgent?: "original" | "other" | "terminated" | null;
+    assigneeUserId?: string | null;
+  } = {}) {
+    const companyId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      defaultResponsibleUserId: "responsible-user",
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    async function seedAgent(name: string, status: string) {
+      const id = randomUUID();
+      await db.insert(agents).values({
+        id,
+        companyId,
+        name,
+        role: "engineer",
+        status,
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {
+          heartbeat: { wakeOnDemand: true, maxConcurrentRuns: 1 },
+        },
+        permissions: {},
+      });
+      return id;
+    }
+
+    const originalAgentId = await seedAgent("Original Owner", "active");
+    const otherAgentId = await seedAgent("New Owner", "active");
+    const terminatedAgentId = await seedAgent("Terminated Owner", "terminated");
+
+    const assigneeAgent = opts.assigneeAgent === undefined ? "other" : opts.assigneeAgent;
+    const assigneeAgentId =
+      assigneeAgent === "original"
+        ? originalAgentId
+        : assigneeAgent === "other"
+          ? otherAgentId
+          : assigneeAgent === "terminated"
+            ? terminatedAgentId
+            : null;
+
+    const issueId = randomUUID();
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Reassigned work",
+      status: "todo",
+      priority: "high",
+      assigneeAgentId,
+      assigneeUserId: opts.assigneeUserId ?? null,
+    });
+
+    return { companyId, originalAgentId, otherAgentId, terminatedAgentId, issueId };
+  }
+
+  async function runsForAgent(agentId: string) {
+    return db
+      .select({ id: heartbeatRuns.id, agentId: heartbeatRuns.agentId })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.agentId, agentId));
+  }
+
+  it("redirects a retry_failed_run wake to the issue's current assignee agent", async () => {
+    const fixture = await seedFixture({ assigneeAgent: "other" });
+    const app = createApp(db, boardActor(fixture.companyId));
+
+    const res = await request(app)
+      .post(`/api/agents/${fixture.originalAgentId}/wakeup`)
+      .send({
+        source: "on_demand",
+        triggerDetail: "manual",
+        reason: "retry_failed_run",
+        payload: { issueId: fixture.issueId },
+      });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(202);
+    expect(res.body.id).toBeDefined();
+    expect(res.body.agentId).toBe(fixture.otherAgentId);
+
+    expect(await runsForAgent(fixture.originalAgentId)).toHaveLength(0);
+    expect(await runsForAgent(fixture.otherAgentId)).toHaveLength(1);
+
+    const logRows = await db
+      .select({ action: activityLog.action, details: activityLog.details })
+      .from(activityLog)
+      .where(eq(activityLog.runId, res.body.id));
+    const invoked = logRows.find((row) => row.action === "heartbeat.invoked");
+    expect(invoked).toBeDefined();
+    expect(invoked!.details).toMatchObject({
+      agentId: fixture.otherAgentId,
+      redirectedFromAgentId: fixture.originalAgentId,
+      issueId: fixture.issueId,
+    });
+  });
+
+  it("skips with an honest message when the issue is now assigned to a user", async () => {
+    const fixture = await seedFixture({ assigneeAgent: null, assigneeUserId: "user-1" });
+    const app = createApp(db, boardActor(fixture.companyId));
+
+    const res = await request(app)
+      .post(`/api/agents/${fixture.originalAgentId}/wakeup`)
+      .send({
+        source: "on_demand",
+        triggerDetail: "manual",
+        reason: "retry_failed_run",
+        payload: { issueId: fixture.issueId },
+      });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(202);
+    expect(res.body.id).toBeUndefined();
+    expect(res.body.status).toBe("skipped");
+    expect(res.body.message).toMatch(/assigned to a user/i);
+
+    expect(await runsForAgent(fixture.originalAgentId)).toHaveLength(0);
+    expect(await runsForAgent(fixture.otherAgentId)).toHaveLength(0);
+  });
+
+  it("skips with an honest message when the issue is now unassigned", async () => {
+    const fixture = await seedFixture({ assigneeAgent: null });
+    const app = createApp(db, boardActor(fixture.companyId));
+
+    const res = await request(app)
+      .post(`/api/agents/${fixture.originalAgentId}/wakeup`)
+      .send({
+        source: "on_demand",
+        triggerDetail: "manual",
+        reason: "retry_failed_run",
+        payload: { issueId: fixture.issueId },
+      });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(202);
+    expect(res.body.id).toBeUndefined();
+    expect(res.body.status).toBe("skipped");
+    expect(res.body.message).toMatch(/unassigned/i);
+
+    expect(await runsForAgent(fixture.originalAgentId)).toHaveLength(0);
+  });
+
+  it("skips instead of redirecting when the current assignee agent is terminated", async () => {
+    const fixture = await seedFixture({ assigneeAgent: "terminated" });
+    const app = createApp(db, boardActor(fixture.companyId));
+
+    const res = await request(app)
+      .post(`/api/agents/${fixture.originalAgentId}/wakeup`)
+      .send({
+        source: "on_demand",
+        triggerDetail: "manual",
+        reason: "retry_failed_run",
+        payload: { issueId: fixture.issueId },
+      });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(202);
+    expect(res.body.id).toBeUndefined();
+    expect(res.body.status).toBe("skipped");
+    expect(res.body.message).toContain("Terminated Owner");
+
+    expect(await runsForAgent(fixture.originalAgentId)).toHaveLength(0);
+    expect(await runsForAgent(fixture.terminatedAgentId)).toHaveLength(0);
+  });
+
+  it("wakes the addressed agent unchanged when the retry payload has no issueId", async () => {
+    const fixture = await seedFixture({ assigneeAgent: "other" });
+    const app = createApp(db, boardActor(fixture.companyId));
+
+    const res = await request(app)
+      .post(`/api/agents/${fixture.originalAgentId}/wakeup`)
+      .send({
+        source: "on_demand",
+        triggerDetail: "manual",
+        reason: "retry_failed_run",
+        payload: {},
+      });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(202);
+    expect(res.body.id).toBeDefined();
+    expect(res.body.agentId).toBe(fixture.originalAgentId);
+  });
+
+  it("wakes the addressed agent unchanged for reasons other than retry_failed_run", async () => {
+    const fixture = await seedFixture({ assigneeAgent: "other" });
+    const app = createApp(db, boardActor(fixture.companyId));
+
+    const res = await request(app)
+      .post(`/api/agents/${fixture.originalAgentId}/wakeup`)
+      .send({
+        source: "on_demand",
+        triggerDetail: "manual",
+        reason: "resume_process_lost_run",
+        payload: { issueId: fixture.issueId },
+      });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(202);
+    expect(res.body.id).toBeDefined();
+    expect(res.body.agentId).toBe(fixture.originalAgentId);
+  });
+
+  it("keeps agent self-invocation behavior unchanged for retry_failed_run", async () => {
+    const fixture = await seedFixture({ assigneeAgent: "other" });
+    const app = createApp(db, agentActor(fixture.companyId, fixture.originalAgentId));
+
+    const res = await request(app)
+      .post(`/api/agents/${fixture.originalAgentId}/wakeup`)
+      .send({
+        source: "on_demand",
+        triggerDetail: "manual",
+        reason: "retry_failed_run",
+        payload: { issueId: fixture.issueId },
+      });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(202);
+    expect(res.body.id).toBeDefined();
+    expect(res.body.agentId).toBe(fixture.originalAgentId);
+  });
+});

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -3,7 +3,7 @@ import { generateKeyPairSync, randomUUID } from "node:crypto";
 import path from "node:path";
 import type { Db } from "@paperclipai/db";
 import { agents as agentsTable, companies, heartbeatRuns, issues as issuesTable, projects as projectsTable } from "@paperclipai/db";
-import { and, desc, eq, inArray, not, sql } from "drizzle-orm";
+import { and, desc, eq, inArray, not, or, sql } from "drizzle-orm";
 import {
   agentSkillSyncSchema,
   agentMineInboxQuerySchema,
@@ -3425,14 +3425,88 @@ export function agentRoutes(
     } else {
       await assertBoardCanManageAgentsForCompany(req, agent.companyId);
     }
-    if (agent.orgChainHealth?.status === "invalid_org_chain") {
+
+    // A manual "retry failed run" wake targets the failed run's agent, but the
+    // issue may have been reassigned since the failure. Without redirection
+    // the queued run is dead on arrival: the queued-run staleness gate cancels
+    // it at claim time (issue_assignee_changed) and nothing wakes the new
+    // owner, so the user's retry is a silent no-op. Redirect the wake to the
+    // issue's current assignee agent instead, and answer honestly when there
+    // is no wakeable assignee (user-assigned, unassigned, or a terminated /
+    // missing assignee agent). Agent actors keep the existing behavior: they
+    // can only invoke themselves.
+    let targetAgent = agent;
+    let retryRedirect: { redirectedFromAgentId: string; issueId: string } | null = null;
+    if (req.actor.type !== "agent" && req.body.reason === "retry_failed_run") {
+      const rawIssueId = (req.body.payload as Record<string, unknown> | null | undefined)?.issueId;
+      const issueRef = typeof rawIssueId === "string" && rawIssueId.trim() ? rawIssueId.trim() : null;
+      if (issueRef) {
+        // Accept UUID or human identifier, always scoped to the agent's
+        // company (mirrors enqueueWakeup's issue lookup). Guard the UUID arm:
+        // issues.id is a Postgres uuid column and a non-UUID value would fail
+        // with a cast error before the OR is evaluated.
+        const idMatch = isUuidLike(issueRef)
+          ? or(eq(issuesTable.id, issueRef), eq(issuesTable.identifier, issueRef.toUpperCase()))
+          : eq(issuesTable.identifier, issueRef.toUpperCase());
+        const issue = await db
+          .select({
+            id: issuesTable.id,
+            assigneeAgentId: issuesTable.assigneeAgentId,
+            assigneeUserId: issuesTable.assigneeUserId,
+          })
+          .from(issuesTable)
+          .where(and(eq(issuesTable.companyId, agent.companyId), idMatch))
+          .then((rows) => rows[0] ?? null);
+        // A missing issue keeps the existing behavior: the queued-run
+        // staleness gate already cancels that run with issue_not_found.
+        if (issue && issue.assigneeAgentId !== agent.id) {
+          const respondRetrySkipped = async (message: string) => {
+            const base = await opts.skippedResponse(agent);
+            res.status(202).json({
+              ...(base && typeof base === "object" ? base : {}),
+              reason: "issue_reassigned",
+              message,
+            });
+          };
+          if (issue.assigneeAgentId) {
+            const assignee = await svc.getById(issue.assigneeAgentId);
+            if (!assignee || assignee.companyId !== agent.companyId) {
+              await respondRetrySkipped(
+                "This issue is now assigned to an agent that no longer exists; no run was started.",
+              );
+              return;
+            }
+            if (assignee.status === "terminated") {
+              await respondRetrySkipped(
+                `This issue is now assigned to ${assignee.name}, which has been terminated; no run was started.`,
+              );
+              return;
+            }
+            targetAgent = assignee;
+            retryRedirect = { redirectedFromAgentId: agent.id, issueId: issue.id };
+          } else if (issue.assigneeUserId) {
+            await respondRetrySkipped(
+              "This issue is now assigned to a user; no run was started.",
+            );
+            return;
+          } else {
+            await respondRetrySkipped(
+              "This issue is now unassigned; assign it to an agent before retrying.",
+            );
+            return;
+          }
+        }
+      }
+    }
+
+    if (targetAgent.orgChainHealth?.status === "invalid_org_chain") {
       res.status(409).json({
-        error: agent.orgChainHealth?.repairGuidance ?? "Repair this agent's reporting chain before starting runs",
+        error: targetAgent.orgChainHealth?.repairGuidance ?? "Repair this agent's reporting chain before starting runs",
       });
       return;
     }
 
-    const run = await heartbeat.wakeup(id, {
+    const run = await heartbeat.wakeup(targetAgent.id, {
       source: opts.source,
       triggerDetail: req.body.triggerDetail ?? "manual",
       reason: req.body.reason ?? null,
@@ -3448,13 +3522,13 @@ export function agentRoutes(
     });
 
     if (!run) {
-      res.status(202).json(await opts.skippedResponse(agent));
+      res.status(202).json(await opts.skippedResponse(targetAgent));
       return;
     }
 
     const actor = getActorInfo(req);
     await logActivity(db, {
-      companyId: agent.companyId,
+      companyId: targetAgent.companyId,
       actorType: actor.actorType,
       actorId: actor.actorId,
       agentId: actor.agentId,
@@ -3462,7 +3536,9 @@ export function agentRoutes(
       action: "heartbeat.invoked",
       entityType: "heartbeat_run",
       entityId: run.id,
-      details: { agentId: id },
+      details: retryRedirect
+        ? { agentId: targetAgent.id, redirectedFromAgentId: retryRedirect.redirectedFromAgentId, issueId: retryRedirect.issueId }
+        : { agentId: id },
     });
 
     res.status(202).json(run);

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -4,7 +4,7 @@ import { rm } from "node:fs/promises";
 import path from "node:path";
 import type { Db } from "@paperclipai/db";
 import { agents as agentsTable, companies, heartbeatRuns, issues as issuesTable, projects as projectsTable } from "@paperclipai/db";
-import { and, desc, eq, inArray, not, sql } from "drizzle-orm";
+import { and, desc, eq, inArray, not, or, sql } from "drizzle-orm";
 import {
   agentSkillSyncSchema,
   agentMineInboxQuerySchema,
@@ -5194,14 +5194,90 @@ export function agentRoutes(
     if (req.body.debug?.providerTrace === "raw") {
       assertInstanceAdmin(req);
     }
-    if (agent.orgChainHealth?.status === "invalid_org_chain") {
+
+    // A manual "retry failed run" wake targets the failed run's agent, but the
+    // issue may have been reassigned since the failure. Without redirection
+    // the queued run is dead on arrival: the queued-run staleness gate cancels
+    // it at claim time (issue_assignee_changed) and nothing wakes the new
+    // owner, so the user's retry is a silent no-op. Redirect the wake to the
+    // issue's current assignee agent instead, and answer honestly when there
+    // is no wakeable assignee (user-assigned, unassigned, or a terminated /
+    // missing assignee agent). Agent actors keep the existing behavior: they
+    // can only invoke themselves.
+    let targetAgent = agent;
+    let retryRedirect: { redirectedFromAgentId: string; issueId: string } | null = null;
+    if (req.actor.type !== "agent" && req.body.reason === "retry_failed_run") {
+      const rawIssueId = (req.body.payload as Record<string, unknown> | null | undefined)?.issueId;
+      const issueRef = typeof rawIssueId === "string" && rawIssueId.trim() ? rawIssueId.trim() : null;
+      if (issueRef) {
+        // Accept UUID or human identifier, always scoped to the agent's
+        // company (mirrors enqueueWakeup's issue lookup). Guard the UUID arm:
+        // issues.id is a Postgres uuid column and a non-UUID value would fail
+        // with a cast error before the OR is evaluated.
+        const idMatch = isUuidLike(issueRef)
+          ? or(eq(issuesTable.id, issueRef), eq(issuesTable.identifier, issueRef.toUpperCase()))
+          : eq(issuesTable.identifier, issueRef.toUpperCase());
+        const issue = await db
+          .select({
+            id: issuesTable.id,
+            assigneeAgentId: issuesTable.assigneeAgentId,
+            assigneeUserId: issuesTable.assigneeUserId,
+          })
+          .from(issuesTable)
+          .where(and(eq(issuesTable.companyId, agent.companyId), idMatch))
+          .then((rows) => rows[0] ?? null);
+        // A missing issue keeps the existing behavior: the queued-run
+        // staleness gate already cancels that run with issue_not_found.
+        if (issue && issue.assigneeAgentId !== agent.id) {
+          const respondRetrySkipped = async (message: string) => {
+            const base = await opts.skippedResponse(agent);
+            res.status(202).json({
+              ...(base && typeof base === "object" ? base : {}),
+              reason: "issue_reassigned",
+              message,
+            });
+          };
+          if (issue.assigneeAgentId) {
+            const assignee = await svc.getById(issue.assigneeAgentId);
+            if (!assignee || assignee.companyId !== agent.companyId) {
+              await respondRetrySkipped(
+                "This issue is now assigned to an agent that no longer exists; no run was started.",
+              );
+              return;
+            }
+            if (assignee.status === "terminated") {
+              await respondRetrySkipped(
+                `This issue is now assigned to ${assignee.name}, which has been terminated; no run was started.`,
+              );
+              return;
+            }
+            targetAgent = assignee;
+            retryRedirect = { redirectedFromAgentId: agent.id, issueId: issue.id };
+          } else if (issue.assigneeUserId) {
+            await respondRetrySkipped(
+              "This issue is now assigned to a user; no run was started.",
+            );
+            return;
+          } else {
+            await respondRetrySkipped(
+              "This issue is now unassigned; assign it to an agent before retrying.",
+            );
+            return;
+          }
+        }
+      }
+    }
+
+    if (targetAgent.orgChainHealth?.status === "invalid_org_chain") {
       res.status(409).json({
-        error: agent.orgChainHealth?.repairGuidance ?? "Repair this agent's reporting chain before starting runs",
+        error: targetAgent.orgChainHealth?.repairGuidance ?? "Repair this agent's reporting chain before starting runs",
       });
       return;
     }
 
-    const run = await heartbeat.wakeup(id, {
+    // Only the redirected path changes which agent is woken; every other wake
+    // keeps using the route parameter verbatim, as before.
+    const run = await heartbeat.wakeup(retryRedirect ? targetAgent.id : id, {
       source: opts.source,
       triggerDetail: req.body.triggerDetail ?? "manual",
       reason: req.body.reason ?? null,
@@ -5227,13 +5303,13 @@ export function agentRoutes(
     });
 
     if (!run) {
-      res.status(202).json(await opts.skippedResponse(agent));
+      res.status(202).json(await opts.skippedResponse(targetAgent));
       return;
     }
 
     const actor = getActorInfo(req);
     await logActivity(db, {
-      companyId: agent.companyId,
+      companyId: targetAgent.companyId,
       actorType: actor.actorType,
       actorId: actor.actorId,
       agentId: actor.agentId,
@@ -5241,7 +5317,9 @@ export function agentRoutes(
       action: "heartbeat.invoked",
       entityType: "heartbeat_run",
       entityId: run.id,
-      details: { agentId: id },
+      details: retryRedirect
+        ? { agentId: targetAgent.id, redirectedFromAgentId: retryRedirect.redirectedFromAgentId, issueId: retryRedirect.issueId }
+        : { agentId: id },
     });
     if (req.body.debug?.providerTrace === "raw") {
       await logActivity(db, {

--- a/ui/src/pages/AgentDetail.tsx
+++ b/ui/src/pages/AgentDetail.tsx
@@ -3049,6 +3049,15 @@ function RunDetail({ run: initialRun, agentRouteId, adapterType, adapterConfig }
     },
     onSuccess: (newRun) => {
       queryClient.invalidateQueries({ queryKey: queryKeys.heartbeats(run.companyId, run.agentId) });
+      // The server may redirect a retry to the issue's current assignee when
+      // the issue was reassigned after the failure, so navigate using the
+      // returned run's agent — not this page's agent — to land on the run
+      // that actually exists.
+      if (newRun.agentId !== run.agentId) {
+        queryClient.invalidateQueries({ queryKey: queryKeys.heartbeats(run.companyId, newRun.agentId) });
+        navigate(`/agents/${newRun.agentId}/runs/${newRun.id}`);
+        return;
+      }
       navigate(`/agents/${agentRouteId}/runs/${newRun.id}`);
     },
   });

--- a/ui/src/pages/AgentDetail.tsx
+++ b/ui/src/pages/AgentDetail.tsx
@@ -3384,6 +3384,15 @@ function RunDetail({ run: initialRun, agentRouteId, adapterType, adapterConfig }
     },
     onSuccess: (newRun) => {
       queryClient.invalidateQueries({ queryKey: queryKeys.heartbeats(run.companyId, run.agentId) });
+      // The server may redirect a retry to the issue's current assignee when
+      // the issue was reassigned after the failure, so navigate using the
+      // returned run's agent — not this page's agent — to land on the run
+      // that actually exists.
+      if (newRun.agentId !== run.agentId) {
+        queryClient.invalidateQueries({ queryKey: queryKeys.heartbeats(run.companyId, newRun.agentId) });
+        navigate(`/agents/${newRun.agentId}/runs/${newRun.id}`);
+        return;
+      }
       navigate(`/agents/${agentRouteId}/runs/${newRun.id}`);
     },
   });

--- a/ui/src/pages/Inbox.tsx
+++ b/ui/src/pages/Inbox.tsx
@@ -1592,7 +1592,14 @@ export function Inbox() {
     onSuccess: ({ newRun, originalRun }) => {
       queryClient.invalidateQueries({ queryKey: queryKeys.heartbeats(originalRun.companyId) });
       queryClient.invalidateQueries({ queryKey: queryKeys.heartbeats(originalRun.companyId, originalRun.agentId) });
-      navigate(`/agents/${originalRun.agentId}/runs/${newRun.id}`);
+      // The server may redirect a retry to the issue's current assignee when
+      // the issue was reassigned after the failure, so navigate using the
+      // returned run's agent — not the failed run's agent — to land on the
+      // run that actually exists.
+      if (newRun.agentId !== originalRun.agentId) {
+        queryClient.invalidateQueries({ queryKey: queryKeys.heartbeats(originalRun.companyId, newRun.agentId) });
+      }
+      navigate(`/agents/${newRun.agentId}/runs/${newRun.id}`);
     },
     onSettled: (_data, _error, run) => {
       if (!run) return;

--- a/ui/src/pages/Inbox.tsx
+++ b/ui/src/pages/Inbox.tsx
@@ -1813,7 +1813,14 @@ function StreamlinedInbox() {
     onSuccess: ({ newRun, originalRun }) => {
       queryClient.invalidateQueries({ queryKey: queryKeys.heartbeats(originalRun.companyId) });
       queryClient.invalidateQueries({ queryKey: queryKeys.heartbeats(originalRun.companyId, originalRun.agentId) });
-      navigate(`/agents/${originalRun.agentId}/runs/${newRun.id}`);
+      // The server may redirect a retry to the issue's current assignee when
+      // the issue was reassigned after the failure, so navigate using the
+      // returned run's agent — not the failed run's agent — to land on the
+      // run that actually exists.
+      if (newRun.agentId !== originalRun.agentId) {
+        queryClient.invalidateQueries({ queryKey: queryKeys.heartbeats(originalRun.companyId, newRun.agentId) });
+      }
+      navigate(`/agents/${newRun.agentId}/runs/${newRun.id}`);
     },
     onSettled: (_data, _error, run) => {
       if (!run) return;


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The heartbeat subsystem queues runs for agents and guards them with a queued-run staleness gate that cancels runs whose target issue moved on before the run could start
> - The manual Retry button on a failed run (agent run page and inbox) always wakes the failed run's agent with the original issue context, without checking who owns the issue now
> - When the issue has since been reassigned to another agent, the retry creates a run that is dead on arrival: the staleness gate cancels it with `issue_assignee_changed`, and its message ("the new owner will be woken instead") is not fulfilled in this path because `cancelQueuedRunForStaleIssue` wakes nobody
> - The operator's retry is therefore a silent no-op, repeatable forever, with no visible way to make the issue move
> - This pull request redirects `retry_failed_run` wakes to the issue's current assignee agent, and returns an honest skipped response naming the actual owner when no runnable assignee exists
> - The benefit is that clicking Retry always either moves the issue forward under its real owner or tells the operator exactly why it cannot

## Linked Issues or Issue Description

No existing issue; described inline per the bug template.

**What happened?**
On a failed heartbeat run's page (or the inbox failed-run card), clicking Retry sends a `retry_failed_run` wake to that run's agent with the run's original `issueId` payload. If the issue was reassigned to a different agent after the failure, the queued run is cancelled at claim time by `evaluateQueuedRunStaleness` with error code `issue_assignee_changed` and the message "Cancelled because issue assignee changed before the queued run could start; the new owner will be woken instead". In this manual-retry path no wake for the new owner is actually created (`cancelQueuedRunForStaleIssue` only cancels), so the retry silently does nothing, every time.

**Expected behavior**
Retrying a failed run whose issue now belongs to another agent should wake the issue's current assignee (the only agent whose run can survive the staleness gate), or clearly tell the operator that the issue is now owned by a user / unassigned / owned by a terminated agent instead of creating a doomed run.

**Reproduction**
1. Let agent A fail a run on an issue assigned to A.
2. Reassign the issue to agent B.
3. Click Retry on A's failed run: a run for A is created and immediately cancelled with `issue_assignee_changed`; no run for B appears.

Related (not duplicates; adjacent stale-assignee wake handling): #8782, #5876.

## What Changed

- `server/src/routes/agents.ts`: in `handleWakeupRoute`, for non-agent actors sending `reason: "retry_failed_run"` with an `issueId` payload, look up the issue (company-scoped, UUID-or-identifier like `enqueueWakeup`). If its current assignee is a different agent in the same company and not terminated, redirect the wake to that agent (org-chain-health 409 guard applied to the redirect target). If the issue is user-assigned, unassigned, or its assignee is terminated/missing, return the existing skipped-response shape with a message naming the actual owner instead of creating the wake. A missing issue keeps existing behavior (staleness gate handles it). The `heartbeat.invoked` activity-log entry records `redirectedFromAgentId` and `issueId` on redirect.
- `ui/src/pages/AgentDetail.tsx`, `ui/src/pages/Inbox.tsx`: retry success handlers navigate using the returned run's `agentId` (so a redirected retry lands on the new owner's run page) and invalidate the redirect target's heartbeat queries.
- `server/src/__tests__/agent-wakeup-retry-redirect-routes.test.ts`: new embedded-Postgres route tests (real router + real heartbeat service, adapter execute mocked).
- Agent self-invocation, other wake reasons, wakes without an `issueId` payload, and the staleness-gate messages in `heartbeat.ts` are all unchanged.

## Verification

- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/agent-wakeup-retry-redirect-routes.test.ts` — 7 tests: redirect to new assignee (run created for the assignee, none for the addressed agent, activity log carries `redirectedFromAgentId`), user-assigned skip, unassigned skip, terminated-assignee skip, no-issueId passthrough, other-reason passthrough, agent self-invoke passthrough. Written test-first: before the fix, the four new-behavior tests failed exactly as the bug predicts (run created for the original agent, then `claimQueuedRun: cancelled stale queued run … issue_assignee_changed`).
- Neighboring suites re-run green: `agent-permissions-routes.test.ts`, `heartbeat-stale-queue-invalidation.test.ts` (83/83 including the new file), UI `Inbox.test.tsx` + `AgentDetail` suites (25/25).
- `pnpm --filter @paperclipai/server typecheck && build`, `pnpm --filter @paperclipai/ui typecheck && build`: clean.
- Manual: with two agents and a reassigned issue, Retry on the old failed run navigates to a running run on the new assignee's page; with the issue handed to a user, Retry surfaces "This issue is now assigned to a user…" and creates no run.

## Risks

- Behavioral shift, intentionally scoped: only `retry_failed_run` wakes from non-agent actors with an `issueId` payload change behavior; timers, assignment wakes, automation, and agent self-wakes are untouched.
- The redirect target gets a wake it did not explicitly request; it passes the same staleness gate as any wake, and wake coalescing/idempotency applies as usual, so a duplicate wake collapses.
- Skipped responses reuse the existing 202 skipped shape both UIs already handle, so older clients degrade gracefully (they show the message, as today).
- No migrations, no schema changes. Low risk beyond the scoped path above.

## Model Used

Claude Fable 5 (Anthropic, model id `claude-fable-5`), extended thinking enabled, agentic tool use via Claude Code (terminal harness): repo exploration, test-first implementation, and full local verification runs.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes (no docs describe the retry flow; none needed)
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
