### PR TITLE
test(claude-local): regression coverage for real-world session-limit string

### DIFF
--- a/packages/adapters/claude-local/src/server/parse.test.ts
+++ b/packages/adapters/claude-local/src/server/parse.test.ts
@@ -87,6 +87,28 @@ describe("isClaudeTransientUpstreamError", () => {
     );
   });
 
+  it("classifies the real-world session-limit message (middle-dot separator) as provider quota and resolves the reset time", () => {
+    const now = new Date("2026-04-22T09:00:00.000Z");
+    const errorMessage = "You've hit your session limit · resets 1:40pm (Africa/Johannesburg)";
+
+    expect(isClaudeProviderQuotaError({ errorMessage })).toBe(true);
+    expect(isClaudeTransientUpstreamError({ errorMessage })).toBe(false);
+    expect(extractClaudeRetryNotBefore({ errorMessage }, now)?.toISOString()).toBe(
+      "2026-04-22T11:40:00.000Z",
+    );
+  });
+
+  it("classifies the same session-limit message with a plain hyphen separator the same way", () => {
+    const now = new Date("2026-04-22T09:00:00.000Z");
+    const errorMessage = "You've hit your session limit - resets 1:40pm (Africa/Johannesburg)";
+
+    expect(isClaudeProviderQuotaError({ errorMessage })).toBe(true);
+    expect(isClaudeTransientUpstreamError({ errorMessage })).toBe(false);
+    expect(extractClaudeRetryNotBefore({ errorMessage }, now)?.toISOString()).toBe(
+      "2026-04-22T11:40:00.000Z",
+    );
+  });
+
   it("classifies Anthropic API rate_limit_error and overloaded_error as transient", () => {
     expect(
       isClaudeTransientUpstreamError({


### PR DESCRIPTION
## Summary

Regression test only — no production-code change. The session-limit
classification fix already landed in `f12bb27b` (`CLAUDE_PROVIDER_QUOTA_RE`
session-limit alternation, `isClaudeProviderQuotaError()`, provider-quota
early-return in `isClaudeTransientUpstreamError()`, `provider_quota` routing
in `execute.ts`), but shipped with no test covering the real-world message
text, so the regex is unprotected against a future edit that silently drops
the alternation.

Adds two cases to `packages/adapters/claude-local/src/server/parse.test.ts`
asserting **classification and routing**, not regex matching, for the exact
byte-for-byte string Claude Code emits (middle-dot separator, U+00B7):

```
You've hit your session limit · resets 1:40pm (Africa/Johannesburg)
```

plus a plain-hyphen variant, since the separator glyph Claude Code emits has
varied:

```
You've hit your session limit - resets 1:40pm (Africa/Johannesburg)
```

Each case asserts all three:
- `isClaudeProviderQuotaError(...) === true`
- `isClaudeTransientUpstreamError(...) === false`
- `extractClaudeRetryNotBefore(...)` resolves to the next 13:40 in
  `Africa/Johannesburg`

Pre-fix (`2026.707.0`), this message produced `transient=false,
retryNotBefore=null`.

## Test plan

Ran the package-scoped vitest file twice, per the parent issue's smallest
verification:

- With the session-limit alternations stripped from `CLAUDE_PROVIDER_QUOTA_RE`
  and `CLAUDE_EXTRA_USAGE_RESET_RE`: **3 failed, 38 passed** — the two new
  cases fail, plus the pre-existing session-limit case at line 79.
- On clean `master` (`f12bb27b`) unmodified: **41 passed**.

```
pnpm exec vitest run src/server/parse.test.ts   # (run from packages/adapters/claude-local)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)