### PR TITLE
fix: advance task watchdog recovery cursor

### DIFF
--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -13,6 +13,7 @@ const recoveryActionId = "77777777-7777-4777-8777-777777777777";
 const mockIssueService = vi.hoisted(() => ({
   addComment: vi.fn(),
   assertCheckoutOwner: vi.fn(),
+  getDependencyReadiness: vi.fn(),
   create: vi.fn(),
   createChild: vi.fn(),
   decomposeAcceptedPlan: vi.fn(),
@@ -84,10 +85,16 @@ const mockIssueRecoveryActionService = vi.hoisted(() => ({
 }));
 const mockTaskWatchdogService = vi.hoisted(() => ({
   getActiveForIssue: vi.fn(async () => null),
-  revalidateMutationScope: vi.fn(async () => ({
-    allowed: true,
-    classification: { state: "stopped", stopFingerprint: "task_watchdog_stop:test" },
-  })),
+  executeSourceMutation: vi.fn(async (_scope, _request, applyMutation) => {
+    const mutation = await applyMutation({ insert: vi.fn(() => ({ values: vi.fn() })) });
+    return {
+      replayed: false,
+      value: mutation.value,
+      receipt: {
+        result: mutation.receiptResult,
+      },
+    };
+  }),
   reconcileForIssueAndAncestors: vi.fn(async () => ({
     checked: 0,
     triggered: 0,
@@ -464,10 +471,14 @@ describe("agent issue mutation checkout ownership", () => {
     });
     mockTaskWatchdogService.getActiveForIssue.mockReset();
     mockTaskWatchdogService.getActiveForIssue.mockResolvedValue(null);
-    mockTaskWatchdogService.revalidateMutationScope.mockReset();
-    mockTaskWatchdogService.revalidateMutationScope.mockResolvedValue({
-      allowed: true,
-      classification: { state: "stopped", stopFingerprint: "task_watchdog_stop:test" },
+    mockTaskWatchdogService.executeSourceMutation.mockReset();
+    mockTaskWatchdogService.executeSourceMutation.mockImplementation(async (_scope, _request, applyMutation) => {
+      const mutation = await applyMutation({ insert: vi.fn(() => ({ values: vi.fn() })) });
+      return {
+        replayed: false,
+        value: mutation.value,
+        receipt: { result: mutation.receiptResult },
+      };
     });
     mockTaskWatchdogService.reconcileForIssueAndAncestors.mockReset();
     mockTaskWatchdogService.reconcileForIssueAndAncestors.mockResolvedValue({
@@ -532,6 +543,12 @@ describe("agent issue mutation checkout ownership", () => {
     mockCompanyService.getById.mockResolvedValue({ id: companyId, issuePrefix: "PAP" });
     mockIssueService.getById.mockResolvedValue(makeIssue());
     mockIssueService.getByIdentifier.mockResolvedValue(null);
+    mockIssueService.getDependencyReadiness.mockResolvedValue({
+      unresolvedBlockerCount: 0,
+      unresolvedBlockerIssueIds: [],
+      blockerIssueIds: [],
+      isDependencyReady: true,
+    });
     mockIssueService.getComment.mockResolvedValue({
       id: "comment-1",
       issueId,
@@ -1676,18 +1693,37 @@ describe("agent issue mutation checkout ownership", () => {
       watchdogRows?: Record<string, unknown>[];
     } = {}) {
       const watchedIssueId = options.watchedIssueId ?? issueId;
+      const watchdogId = "dddddddd-dddd-4ddd-8ddd-ddddddddddde";
+      const watchdogIssueId = options.watchdogIssueId ?? watchdogReportIssueId;
       const runRows = [{
         id: watchdogRunId,
         companyId,
         agentId: peerAgentId,
-        contextSnapshot: { taskWatchdog: { watchedIssueId, stopFingerprint: "task_watchdog_stop:test" } },
+        status: "running",
+        contextSnapshot: {
+          taskWatchdog: {
+            version: 1,
+            watchdogId,
+            watchdogIssueId,
+            watchedIssueId,
+            companyId,
+            agentId: peerAgentId,
+            stopFingerprint: "task_watchdog_stop:test",
+            recoveryCursor: {
+              version: 1,
+              state: "open",
+              fingerprint: "task_watchdog_stop:test",
+              lastMutationReceipt: null,
+            },
+          },
+        },
       }];
       const watchdogRows = options.watchdogRows ?? [{
-        id: "dddddddd-dddd-4ddd-8ddd-ddddddddddde",
+        id: watchdogId,
         companyId,
         issueId: watchedIssueId,
         watchdogAgentId: peerAgentId,
-        watchdogIssueId: options.watchdogIssueId ?? watchdogReportIssueId,
+        watchdogIssueId,
         status: "active",
       }];
       const ancestryRows = [{
@@ -1751,7 +1787,24 @@ describe("agent issue mutation checkout ownership", () => {
         "Watchdog finding",
         expect.any(Object),
         expect.any(Object),
+        expect.any(Object),
       );
+    });
+
+    it("rejects a watchdog comment that also requests resume/reopen", async () => {
+      denyBaseBoundary();
+      mockIssueService.getById.mockResolvedValue(makeIssue({ status: "blocked", assigneeAgentId: ownerAgentId }));
+
+      const app = await createApp(watchdogActor(), createWatchdogDb());
+      const res = await request(app)
+        .post(`/api/issues/${issueId}/comments`)
+        .send({ body: "Need to resume", reopen: true });
+
+      expect(res.status, JSON.stringify(res.body)).toBe(409);
+      expect(res.body.error).toBe(
+        "Task-watchdog recovery status and comment must be submitted atomically through PATCH /issues/:id.",
+      );
+      expect(mockIssueService.addComment).not.toHaveBeenCalled();
     });
 
     it.each([
@@ -1770,7 +1823,11 @@ describe("agent issue mutation checkout ownership", () => {
       const res = await request(app).patch(`/api/issues/${issueId}`).send({ status });
 
       expect(res.status, JSON.stringify(res.body)).toBe(200);
-      expect(mockIssueService.update).toHaveBeenCalledWith(issueId, expect.objectContaining({ status }));
+      expect(mockIssueService.update).toHaveBeenCalledWith(
+        issueId,
+        expect.objectContaining({ status }),
+        expect.any(Object),
+      );
     });
 
     it("lets a watchdog run transition a watched issue to in_review with a live review path", async () => {
@@ -1788,20 +1845,22 @@ describe("agent issue mutation checkout ownership", () => {
       const res = await request(app).patch(`/api/issues/${issueId}`).send({ status: "in_review" });
 
       expect(res.status, JSON.stringify(res.body)).toBe(200);
-      expect(mockIssueService.update).toHaveBeenCalledWith(issueId, expect.objectContaining({ status: "in_review" }));
+      expect(mockIssueService.update).toHaveBeenCalledWith(
+        issueId,
+        expect.objectContaining({ status: "in_review" }),
+        expect.any(Object),
+      );
     });
 
     it("rejects stale watchdog source mutations when revalidation finds a live path", async () => {
       denyBaseBoundary();
       mockIssueService.getById.mockResolvedValue(makeIssue({ status: "in_progress", assigneeAgentId: ownerAgentId }));
-      mockTaskWatchdogService.revalidateMutationScope.mockResolvedValueOnce({
-        allowed: false,
-        reason:
-          "Task-watchdog review is stale because the watched subtree now has a live, waiting, already-reviewed, or not-applicable path; refresh the source state before mutating it.",
-        classification: { state: "live", liveIssueIds: [issueId] },
-      });
-
       const app = await createApp(watchdogActor(), createWatchdogDb());
+      const { conflict } = await import("../errors.js");
+      mockTaskWatchdogService.executeSourceMutation.mockRejectedValueOnce(
+        conflict("Task-watchdog review is stale because the watched subtree now has a live path."),
+      );
+
       const res = await request(app).patch(`/api/issues/${issueId}`).send({ status: "blocked" });
 
       expect(res.status, JSON.stringify(res.body)).toBe(409);
@@ -1812,14 +1871,12 @@ describe("agent issue mutation checkout ownership", () => {
     it("suppresses watchdog follow-up creation when current source revalidation is live", async () => {
       denyBaseBoundary();
       mockIssueService.getById.mockResolvedValue(makeIssue({ assigneeAgentId: ownerAgentId }));
-      mockTaskWatchdogService.revalidateMutationScope.mockResolvedValueOnce({
-        allowed: false,
-        reason:
-          "Task-watchdog review is stale because the watched subtree now has a live, waiting, already-reviewed, or not-applicable path; refresh the source state before mutating it.",
-        classification: { state: "live", liveIssueIds: [issueId] },
-      });
-
       const app = await createApp(watchdogActor(), createWatchdogDb());
+      const { conflict } = await import("../errors.js");
+      mockTaskWatchdogService.executeSourceMutation.mockRejectedValueOnce(
+        conflict("Task-watchdog review is stale because the watched subtree now has a live path."),
+      );
+
       const res = await request(app)
         .post(`/api/issues/${issueId}/children`)
         .send({ title: "Stale follow-up", status: "todo" });
@@ -1951,6 +2008,7 @@ describe("agent issue mutation checkout ownership", () => {
       expect(mockIssueService.update).toHaveBeenCalledWith(
         issueId,
         expect.objectContaining({ assigneeAgentId: peerAgentId }),
+        expect.any(Object),
       );
     });
 

--- a/server/src/__tests__/task-watchdogs-scheduler.test.ts
+++ b/server/src/__tests__/task-watchdogs-scheduler.test.ts
@@ -20,6 +20,7 @@ import {
   startEmbeddedPostgresTestDatabase,
 } from "./helpers/embedded-postgres.js";
 import { taskWatchdogService } from "../services/task-watchdogs.ts";
+import { resolveTaskWatchdogMutationScope } from "../services/task-watchdog-scope.ts";
 
 const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
 const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
@@ -164,7 +165,7 @@ describeEmbeddedPostgres("task watchdog scheduler", () => {
     const companyId = await seedCompany();
     const sourceId = await seedIssue(companyId, { identifier: "WDOG-1", status: "done" });
     const agentId = await seedAgent(companyId);
-    await seedWatchdog(companyId, sourceId, agentId);
+    const seededWatchdog = await seedWatchdog(companyId, sourceId, agentId);
     const { service, wakes } = createService();
 
     const result = await service.reconcileTaskWatchdogs({ companyId });
@@ -175,8 +176,18 @@ describeEmbeddedPostgres("task watchdog scheduler", () => {
     expect(wakes[0]?.opts?.reason).toBe("task_watchdog_stopped_subtree");
     expect(wakes[0]?.opts?.contextSnapshot).toMatchObject({
       taskWatchdog: {
+        version: 1,
+        watchdogId: seededWatchdog?.id,
         watchedIssueId: sourceId,
+        companyId,
+        agentId,
         watchedIssueIdentifier: "WDOG-1",
+        recoveryCursor: {
+          version: 1,
+          state: "open",
+          fingerprint: expect.stringMatching(/^task_watchdog_stop:/),
+          lastMutationReceipt: null,
+        },
         capabilities: {
           targetScope: {
             watchedIssueId: sourceId,
@@ -212,6 +223,9 @@ describeEmbeddedPostgres("task watchdog scheduler", () => {
 
     const [watchdog] = await db.select().from(issueWatchdogs).where(eq(issueWatchdogs.issueId, sourceId));
     expect(watchdog?.watchdogIssueId).toBe(watchdogIssues[0]?.id);
+    expect(wakes[0]?.opts?.contextSnapshot).toMatchObject({
+      taskWatchdog: { watchdogIssueId: watchdogIssues[0]?.id },
+    });
     expect(watchdog?.lastObservedFingerprint).toMatch(/^task_watchdog_stop:/);
     expect(watchdog?.triggerCount).toBe(1);
   });
@@ -490,79 +504,390 @@ describeEmbeddedPostgres("task watchdog scheduler", () => {
     expect(wakes.length).toBe(2);
   });
 
-  it("revalidates stale watchdog reviews against current source evidence before allowing mutations", async () => {
+  it("atomically advances the run cursor, then seals a compound recovery status and comment", async () => {
     const companyId = await seedCompany();
-    const sourceId = await seedIssue(companyId, { identifier: "WDOG-REVALIDATE", status: "blocked" });
     const agentId = await seedAgent(companyId);
+    const sourceId = await seedIssue(companyId, {
+      identifier: "WDOG-CURSOR",
+      status: "blocked",
+      assigneeAgentId: agentId,
+    });
     await seedWatchdog(companyId, sourceId, agentId);
-    const { service } = createService();
+    const { service, wakes } = createService();
 
     await service.reconcileTaskWatchdogs({ companyId });
-    const [watchdog] = await db.select().from(issueWatchdogs).where(eq(issueWatchdogs.issueId, sourceId));
-    const originalFingerprint = watchdog!.lastObservedFingerprint!;
-    expect(originalFingerprint).toMatch(/^task_watchdog_stop:/);
-
-    const later = new Date(Date.now() + 60_000);
-    await db.insert(issueComments).values({
-      companyId,
-      issueId: sourceId,
-      authorType: "agent",
-      body: "Fresh source evidence.",
-      updatedAt: later,
-      createdAt: later,
-    });
-    await seedIssueDocument(companyId, sourceId, new Date(later.getTime() + 1_000));
-    await seedIssueWorkProduct(companyId, sourceId, new Date(later.getTime() + 2_000));
-
-    const revalidated = await service.revalidateMutationScope({
-      kind: "watchdog",
-      watchdogId: watchdog!.id,
-      companyId,
-      watchedIssueId: sourceId,
-      stopFingerprint: originalFingerprint,
-    });
-
-    expect(revalidated.allowed).toBe(false);
-    expect(revalidated.reason).toContain("stop fingerprint changed");
-    expect(revalidated.classification?.state).toBe("stopped");
-    if (revalidated.classification?.state !== "stopped") throw new Error("Expected stopped classification");
-    expect(revalidated.classification.stopFingerprint).not.toBe(originalFingerprint);
-    expect(revalidated.classification.stoppedLeaves[0]).toMatchObject({
-      latestCommentAt: later.toISOString(),
-      latestDocumentAt: new Date(later.getTime() + 1_000).toISOString(),
-      latestWorkProductAt: new Date(later.getTime() + 2_000).toISOString(),
-    });
-  });
-
-  it("revalidates a stale watchdog review as live when the source gets a fresh run path", async () => {
-    const companyId = await seedCompany();
-    const sourceId = await seedIssue(companyId, { identifier: "WDOG-LIVE-REVALIDATE", status: "blocked" });
-    const agentId = await seedAgent(companyId);
-    await seedWatchdog(companyId, sourceId, agentId);
-    const { service } = createService();
-
-    await service.reconcileTaskWatchdogs({ companyId });
-    const [watchdog] = await db.select().from(issueWatchdogs).where(eq(issueWatchdogs.issueId, sourceId));
-    const originalFingerprint = watchdog!.lastObservedFingerprint!;
+    const contextSnapshot = wakes[0]?.opts?.contextSnapshot as Record<string, unknown>;
+    const runId = randomUUID();
     await db.insert(heartbeatRuns).values({
+      id: runId,
       companyId,
       agentId,
       status: "running",
-      invocationSource: "assignment",
-      contextSnapshot: { issueId: sourceId },
+      invocationSource: "automation",
+      contextSnapshot,
     });
+    const actor = { type: "agent", agentId, companyId, runId };
+    const initialScope = await resolveTaskWatchdogMutationScope(db, actor);
+    expect(initialScope.kind).toBe("watchdog");
+    if (initialScope.kind !== "watchdog") throw new Error("Expected watchdog scope");
 
-    const revalidated = await service.revalidateMutationScope({
-      kind: "watchdog",
-      watchdogId: watchdog!.id,
+    const first = await service.executeSourceMutation(initialScope, {
+      operationKind: "issue_comment",
+      method: "POST",
+      path: `/api/issues/${sourceId}/comments`,
+      targetIssueId: sourceId,
+      body: { body: "Cleared stale recovery evidence." },
+    }, async (tx) => {
+      const [comment] = await tx.insert(issueComments).values({
+        companyId,
+        issueId: sourceId,
+        authorAgentId: agentId,
+        authorType: "agent",
+        body: "Cleared stale recovery evidence.",
+        createdByRunId: runId,
+      }).returning();
+      await tx.update(issues).set({ updatedAt: new Date() }).where(eq(issues.id, sourceId));
+      return { value: comment, receiptResult: { commentId: comment!.id } };
+    });
+    expect(first.replayed).toBe(false);
+    expect(first.receipt.cursorState).toBe("open");
+    expect(first.receipt.newFingerprint).not.toBe(initialScope.cursorFingerprint);
+
+    const advancedScope = await resolveTaskWatchdogMutationScope(db, actor);
+    expect(advancedScope.kind).toBe("watchdog");
+    if (advancedScope.kind !== "watchdog") throw new Error("Expected advanced watchdog scope");
+    const compoundRequest = {
+      operationKind: "issue_update",
+      method: "PATCH",
+      path: `/api/issues/${sourceId}`,
+      targetIssueId: sourceId,
+      body: { status: "todo", comment: "Recovery path restored." },
+      establishesContinuationPath: true,
+    };
+    const second = await service.executeSourceMutation(advancedScope, compoundRequest, async (tx) => {
+      const [updated] = await tx.update(issues).set({ status: "todo", updatedAt: new Date() })
+        .where(eq(issues.id, sourceId)).returning();
+      const [comment] = await tx.insert(issueComments).values({
+        companyId,
+        issueId: sourceId,
+        authorAgentId: agentId,
+        authorType: "agent",
+        body: "Recovery path restored.",
+        createdByRunId: runId,
+      }).returning();
+      return {
+        value: { issue: updated, comment },
+        receiptResult: { issueId: sourceId, commentId: comment!.id },
+      };
+    });
+    expect(second.replayed).toBe(false);
+    expect(second.receipt.cursorState).toBe("sealed");
+    const [updatedSource] = await db.select().from(issues).where(eq(issues.id, sourceId));
+    expect(updatedSource?.status).toBe("todo");
+    const comments = await db.select().from(issueComments).where(eq(issueComments.issueId, sourceId));
+    expect(comments.map((comment) => comment.body)).toEqual([
+      "Cleared stale recovery evidence.",
+      "Recovery path restored.",
+    ]);
+
+    const sealedScope = await resolveTaskWatchdogMutationScope(db, actor);
+    expect(sealedScope.kind).toBe("watchdog");
+    if (sealedScope.kind !== "watchdog") throw new Error("Expected sealed watchdog scope");
+    let replayApplied = false;
+    const replay = await service.executeSourceMutation(sealedScope, compoundRequest, async () => {
+      replayApplied = true;
+      throw new Error("exact replay must not execute");
+    });
+    expect(replay.replayed).toBe(true);
+    expect(replayApplied).toBe(false);
+    expect(await db.select().from(issueComments).where(eq(issueComments.issueId, sourceId))).toHaveLength(2);
+    const mutationActivities = await db
+      .select()
+      .from(activityLog)
+      .where(and(
+        eq(activityLog.runId, runId),
+        eq(activityLog.action, "issue.task_watchdog_source_mutation_committed"),
+      ));
+    expect(mutationActivities).toHaveLength(2);
+
+    await expect(service.executeSourceMutation(sealedScope, {
+      ...compoundRequest,
+      body: { status: "blocked", comment: "A different request after sealing." },
+    }, async () => {
+      throw new Error("sealed cursor must reject a different request before applying");
+    })).rejects.toMatchObject({ status: 409 });
+    expect(await db.select().from(issueComments).where(eq(issueComments.issueId, sourceId))).toHaveLength(2);
+    expect(await db
+      .select()
+      .from(activityLog)
+      .where(and(
+        eq(activityLog.runId, runId),
+        eq(activityLog.action, "issue.task_watchdog_source_mutation_committed"),
+      ))).toHaveLength(2);
+  });
+
+  it("serializes concurrent same-run mutations so exactly one cursor claimant commits", async () => {
+    const companyId = await seedCompany();
+    const agentId = await seedAgent(companyId);
+    const sourceId = await seedIssue(companyId, { identifier: "WDOG-CURSOR-CAS", status: "blocked" });
+    await seedWatchdog(companyId, sourceId, agentId);
+    const { service, wakes } = createService();
+
+    await service.reconcileTaskWatchdogs({ companyId });
+    const runId = randomUUID();
+    await db.insert(heartbeatRuns).values({
+      id: runId,
       companyId,
-      watchedIssueId: sourceId,
-      stopFingerprint: originalFingerprint,
+      agentId,
+      status: "running",
+      invocationSource: "automation",
+      contextSnapshot: wakes[0]?.opts?.contextSnapshot as Record<string, unknown>,
+    });
+    const scope = await resolveTaskWatchdogMutationScope(db, {
+      type: "agent",
+      agentId,
+      companyId,
+      runId,
+    });
+    expect(scope.kind).toBe("watchdog");
+    if (scope.kind !== "watchdog") throw new Error("Expected watchdog scope");
+
+    const mutate = (label: string) => service.executeSourceMutation(scope, {
+      operationKind: "issue_comment",
+      method: "POST",
+      path: `/api/issues/${sourceId}/comments`,
+      targetIssueId: sourceId,
+      body: { body: label },
+    }, async (tx) => {
+      const [comment] = await tx.insert(issueComments).values({
+        companyId,
+        issueId: sourceId,
+        authorAgentId: agentId,
+        authorType: "agent",
+        body: label,
+        createdByRunId: runId,
+      }).returning();
+      return { value: comment, receiptResult: { commentId: comment!.id } };
     });
 
-    expect(revalidated.allowed).toBe(false);
-    expect(revalidated.reason).toContain("now has a live");
-    expect(revalidated.classification?.state).toBe("live");
+    const results = await Promise.allSettled([mutate("claim-a"), mutate("claim-b")]);
+    expect(results.filter((result) => result.status === "fulfilled")).toHaveLength(1);
+    const rejected = results.find((result) => result.status === "rejected");
+    expect(rejected).toMatchObject({ status: "rejected", reason: { status: 409 } });
+    expect(await db.select().from(issueComments).where(eq(issueComments.issueId, sourceId))).toHaveLength(1);
+    expect(await db
+      .select()
+      .from(activityLog)
+      .where(and(
+        eq(activityLog.runId, runId),
+        eq(activityLog.action, "issue.task_watchdog_source_mutation_committed"),
+      ))).toHaveLength(1);
+  });
+
+  it("fails closed on external fingerprint changes and reusable watchdog identity rotation", async () => {
+    const companyId = await seedCompany();
+    const agentId = await seedAgent(companyId);
+    const sourceId = await seedIssue(companyId, { identifier: "WDOG-STALE-CURSOR", status: "blocked" });
+    await seedWatchdog(companyId, sourceId, agentId);
+    const { service, wakes } = createService();
+
+    await service.reconcileTaskWatchdogs({ companyId });
+    const [watchdog] = await db.select().from(issueWatchdogs).where(eq(issueWatchdogs.issueId, sourceId));
+    const runId = randomUUID();
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId,
+      agentId,
+      status: "running",
+      invocationSource: "automation",
+      contextSnapshot: wakes[0]?.opts?.contextSnapshot as Record<string, unknown>,
+    });
+    const actor = { type: "agent", agentId, companyId, runId };
+    const scope = await resolveTaskWatchdogMutationScope(db, actor);
+    expect(scope.kind).toBe("watchdog");
+    if (scope.kind !== "watchdog") throw new Error("Expected watchdog scope");
+
+    await db.insert(issueComments).values({
+      companyId,
+      issueId: sourceId,
+      authorType: "system",
+      body: "Concurrent external evidence.",
+    });
+    let applied = false;
+    await expect(service.executeSourceMutation(scope, {
+      operationKind: "issue_update",
+      method: "PATCH",
+      path: `/api/issues/${sourceId}`,
+      targetIssueId: sourceId,
+      body: { status: "todo" },
+    }, async () => {
+      applied = true;
+      return { value: null, receiptResult: null };
+    })).rejects.toMatchObject({ status: 409 });
+    expect(applied).toBe(false);
+
+    const replacementIssueId = await seedIssue(companyId, {
+      identifier: "WDOG-ROTATED",
+      status: "todo",
+      parentId: sourceId,
+      assigneeAgentId: agentId,
+      originKind: "task_watchdog",
+    });
+    await db.update(issueWatchdogs).set({ watchdogIssueId: replacementIssueId }).where(eq(issueWatchdogs.id, watchdog!.id));
+    const rotated = await resolveTaskWatchdogMutationScope(db, actor);
+    expect(rotated).toMatchObject({
+      kind: "invalid",
+      detail: "Task-watchdog run context is not backed by an active persisted watchdog.",
+    });
+
+    const rotatedContext = structuredClone(
+      wakes[0]?.opts?.contextSnapshot as Record<string, unknown>,
+    ) as { taskWatchdog: Record<string, unknown> };
+    rotatedContext.taskWatchdog.watchdogIssueId = replacementIssueId;
+    const rotatedRunId = randomUUID();
+    await db.insert(heartbeatRuns).values({
+      id: rotatedRunId,
+      companyId,
+      agentId,
+      status: "running",
+      invocationSource: "automation",
+      contextSnapshot: rotatedContext,
+    });
+    await expect(resolveTaskWatchdogMutationScope(db, {
+      type: "agent",
+      agentId,
+      companyId,
+      runId: rotatedRunId,
+    })).resolves.toMatchObject({
+      kind: "watchdog",
+      watchdogIssueId: replacementIssueId,
+      runId: rotatedRunId,
+    });
+  });
+
+  it("rejects missing cursor identity, inactive watchdogs, and wrong actor identity", async () => {
+    const companyId = await seedCompany();
+    const agentId = await seedAgent(companyId);
+    const sourceId = await seedIssue(companyId, { identifier: "WDOG-IDENTITY", status: "blocked" });
+    await seedWatchdog(companyId, sourceId, agentId);
+    const { service, wakes } = createService();
+
+    await service.reconcileTaskWatchdogs({ companyId });
+    const completeContext = structuredClone(
+      wakes[0]?.opts?.contextSnapshot as Record<string, unknown>,
+    ) as { taskWatchdog: Record<string, unknown> };
+    const missingCursorContext = structuredClone(completeContext);
+    delete missingCursorContext.taskWatchdog.recoveryCursor;
+    const missingCursorRunId = randomUUID();
+    await db.insert(heartbeatRuns).values({
+      id: missingCursorRunId,
+      companyId,
+      agentId,
+      status: "running",
+      invocationSource: "automation",
+      contextSnapshot: missingCursorContext,
+    });
+    await expect(resolveTaskWatchdogMutationScope(db, {
+      type: "agent",
+      agentId,
+      companyId,
+      runId: missingCursorRunId,
+    })).resolves.toMatchObject({
+      kind: "invalid",
+      detail: "Task-watchdog run context is missing its immutable identity or recovery cursor.",
+    });
+
+    const validRunId = randomUUID();
+    await db.insert(heartbeatRuns).values({
+      id: validRunId,
+      companyId,
+      agentId,
+      status: "running",
+      invocationSource: "automation",
+      contextSnapshot: completeContext,
+    });
+    await expect(resolveTaskWatchdogMutationScope(db, {
+      type: "agent",
+      agentId: randomUUID(),
+      companyId,
+      runId: validRunId,
+    })).resolves.toMatchObject({
+      kind: "invalid",
+      detail: "Task-watchdog run context does not belong to this agent.",
+    });
+    await expect(resolveTaskWatchdogMutationScope(db, {
+      type: "agent",
+      agentId,
+      companyId: randomUUID(),
+      runId: validRunId,
+    })).resolves.toMatchObject({
+      kind: "invalid",
+      detail: "Task-watchdog run context does not belong to this agent.",
+    });
+
+    await db.update(issueWatchdogs).set({ status: "disabled" }).where(eq(issueWatchdogs.issueId, sourceId));
+    await expect(resolveTaskWatchdogMutationScope(db, {
+      type: "agent",
+      agentId,
+      companyId,
+      runId: validRunId,
+    })).resolves.toMatchObject({
+      kind: "invalid",
+      detail: "Task-watchdog run context is not backed by an active persisted watchdog.",
+    });
+  });
+
+  it("rolls back source writes on failure and rejects an expired run without applying", async () => {
+    const companyId = await seedCompany();
+    const agentId = await seedAgent(companyId);
+    const sourceId = await seedIssue(companyId, { identifier: "WDOG-ROLLBACK", status: "blocked" });
+    await seedWatchdog(companyId, sourceId, agentId);
+    const { service, wakes } = createService();
+
+    await service.reconcileTaskWatchdogs({ companyId });
+    const runId = randomUUID();
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId,
+      agentId,
+      status: "running",
+      invocationSource: "automation",
+      contextSnapshot: wakes[0]?.opts?.contextSnapshot as Record<string, unknown>,
+    });
+    const actor = { type: "agent", agentId, companyId, runId };
+    const scope = await resolveTaskWatchdogMutationScope(db, actor);
+    expect(scope.kind).toBe("watchdog");
+    if (scope.kind !== "watchdog") throw new Error("Expected watchdog scope");
+    const request = {
+      operationKind: "issue_comment",
+      method: "POST",
+      path: `/api/issues/${sourceId}/comments`,
+      targetIssueId: sourceId,
+      body: { body: "must roll back" },
+    };
+
+    await expect(service.executeSourceMutation(scope, request, async (tx) => {
+      await tx.insert(issueComments).values({
+        companyId,
+        issueId: sourceId,
+        authorAgentId: agentId,
+        authorType: "agent",
+        body: "must roll back",
+        createdByRunId: runId,
+      });
+      throw new Error("simulated route failure");
+    })).rejects.toThrow("simulated route failure");
+    expect(await db.select().from(issueComments).where(eq(issueComments.issueId, sourceId))).toHaveLength(0);
+
+    const unchangedScope = await resolveTaskWatchdogMutationScope(db, actor);
+    expect(unchangedScope).toMatchObject({ kind: "watchdog", cursorFingerprint: scope.cursorFingerprint });
+    await db.update(heartbeatRuns).set({ status: "failed" }).where(eq(heartbeatRuns.id, runId));
+    let expiredApplyCalled = false;
+    await expect(service.executeSourceMutation(scope, request, async () => {
+      expiredApplyCalled = true;
+      return { value: null, receiptResult: null };
+    })).rejects.toMatchObject({ status: 409 });
+    expect(expiredApplyCalled).toBe(false);
   });
 
   it("does not raise a stopped-subtree review while a freshly-created assigned issue's first run is starting", async () => {

--- a/server/src/__tests__/task-watchdogs-scheduler.test.ts
+++ b/server/src/__tests__/task-watchdogs-scheduler.test.ts
@@ -624,6 +624,76 @@ describeEmbeddedPostgres("task watchdog scheduler", () => {
         eq(activityLog.runId, runId),
         eq(activityLog.action, "issue.task_watchdog_source_mutation_committed"),
       ))).toHaveLength(2);
+
+    let changedOperationApplied = false;
+    await expect(service.executeSourceMutation(sealedScope, {
+      ...compoundRequest,
+      operationKind: "issue_comment",
+    }, async () => {
+      changedOperationApplied = true;
+      throw new Error("changed operation kind must not replay");
+    })).rejects.toMatchObject({ status: 409 });
+    expect(changedOperationApplied).toBe(false);
+  });
+
+  it("fails closed when a persisted replay receipt result is malformed", async () => {
+    const companyId = await seedCompany();
+    const agentId = await seedAgent(companyId);
+    const sourceId = await seedIssue(companyId, { identifier: "WDOG-RECEIPT", status: "blocked" });
+    await seedWatchdog(companyId, sourceId, agentId);
+    const { service, wakes } = createService();
+
+    await service.reconcileTaskWatchdogs({ companyId });
+    const runId = randomUUID();
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId,
+      agentId,
+      status: "running",
+      invocationSource: "automation",
+      contextSnapshot: wakes[0]?.opts?.contextSnapshot as Record<string, unknown>,
+    });
+    const actor = { type: "agent", agentId, companyId, runId };
+    const scope = await resolveTaskWatchdogMutationScope(db, actor);
+    expect(scope.kind).toBe("watchdog");
+    if (scope.kind !== "watchdog") throw new Error("Expected watchdog scope");
+    const request = {
+      operationKind: "issue_comment",
+      method: "POST",
+      path: `/api/issues/${sourceId}/comments`,
+      targetIssueId: sourceId,
+      body: { body: "receipt validation" },
+    };
+
+    await service.executeSourceMutation(scope, request, async (tx) => {
+      const [comment] = await tx.insert(issueComments).values({
+        companyId,
+        issueId: sourceId,
+        authorAgentId: agentId,
+        authorType: "agent",
+        body: "receipt validation",
+        createdByRunId: runId,
+      }).returning();
+      return { value: comment, receiptResult: { commentId: comment!.id } };
+    });
+
+    const [persistedRun] = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.id, runId));
+    const corruptedContext = structuredClone(persistedRun!.contextSnapshot) as {
+      taskWatchdog: { recoveryCursor: { lastMutationReceipt: Record<string, unknown> } };
+    };
+    corruptedContext.taskWatchdog.recoveryCursor.lastMutationReceipt.result = null;
+    await db.update(heartbeatRuns).set({ contextSnapshot: corruptedContext }).where(eq(heartbeatRuns.id, runId));
+
+    const corruptedScope = await resolveTaskWatchdogMutationScope(db, actor);
+    expect(corruptedScope.kind).toBe("watchdog");
+    if (corruptedScope.kind !== "watchdog") throw new Error("Expected watchdog scope");
+    let replayApplied = false;
+    await expect(service.executeSourceMutation(corruptedScope, request, async () => {
+      replayApplied = true;
+      throw new Error("malformed receipt must fail before applying");
+    })).rejects.toMatchObject({ status: 403 });
+    expect(replayApplied).toBe(false);
+    expect(await db.select().from(issueComments).where(eq(issueComments.issueId, sourceId))).toHaveLength(1);
   });
 
   it("serializes concurrent same-run mutations so exactly one cursor claimant commits", async () => {

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -334,16 +334,9 @@ function noopTaskWatchdogService(): TaskWatchdogService {
       skipped: 0,
       watchdogIssueIds: [],
     }),
-    revalidateMutationScope: async () => ({
-      allowed: true,
-      classification: {
-        state: "stopped",
-        reason: "Task watchdog service unavailable in this route context.",
-        includedIssueIds: [],
-        stopFingerprint: "task_watchdog_stop:unavailable",
-        stoppedLeaves: [],
-      },
-    }),
+    executeSourceMutation: async () => {
+      throw new Error("Task watchdog service unavailable in this route context.");
+    },
   };
 }
 
@@ -3608,28 +3601,18 @@ export function issueRoutes(
   }
 
   async function assertFreshTaskWatchdogSourceMutation(
-    res: Response,
+    _res: Response,
     scope: Awaited<ReturnType<typeof resolveTaskWatchdogMutationScope>>,
     issue: { id: string },
   ) {
     if (scope.kind !== "watchdog") return true;
     if (scope.watchdogIssueId && issue.id === scope.watchdogIssueId) return true;
 
-    const revalidated = await taskWatchdogsSvc.revalidateMutationScope(scope);
-    if (revalidated.allowed) return true;
-    res.status(409).json({
-      error: revalidated.reason,
-      details: {
-        watchedIssueId: scope.watchedIssueId,
-        watchdogId: scope.watchdogId,
-        runStopFingerprint: scope.stopFingerprint,
-        currentState: revalidated.classification?.state ?? null,
-        currentStopFingerprint: revalidated.classification && "stopFingerprint" in revalidated.classification
-          ? revalidated.classification.stopFingerprint
-          : null,
-      },
-    });
-    return false;
+    // The immutable identity is validated while resolving the scope. Source
+    // freshness is intentionally mediated inside the same transaction as the
+    // write and cursor CAS; a read-only preflight here would recreate the race
+    // this boundary is designed to close.
+    return true;
   }
 
   async function rejectTaskWatchdogConfigMutation(req: Request, res: Response) {
@@ -7015,7 +6998,7 @@ export function issueRoutes(
             discovery: watchdogProductBugFollowUp.discovery,
             sourceIssue: watchdogProductBugFollowUp.sourceIssue,
             watchdogIssue: watchdogProductBugFollowUp.watchdogIssue,
-            stopFingerprint: watchdogProductBugFollowUp.scope.stopFingerprint,
+            stopFingerprint: watchdogProductBugFollowUp.scope.initialStopFingerprint,
             runId: actor.runId,
           }),
           projectId: rawCreateBody.projectId ?? watchdogProductBugFollowUp.sourceIssue.projectId,
@@ -7062,7 +7045,7 @@ export function issueRoutes(
       executionPolicy,
     }, actor);
     let deduplicationReason: "idempotency_key" | "recent_open_title" | null = null;
-    const issue = await svc.create(companyId, {
+    const issueInput = {
       ...createBody,
       ...(taskBridgeOriginForActor(req) ?? {}),
       id: issueId,
@@ -7075,10 +7058,44 @@ export function issueRoutes(
       actorResponsibleUserId: authenticatedActorResponsibleUserId(req),
       trustExplicitResponsibleUserId: actor.actorType === "user",
       watchdogActorRunId: actor.runId,
-      onDeduplicated: (reason) => {
+      onDeduplicated: (reason: "idempotency_key" | "recent_open_title") => {
         deduplicationReason = reason;
       },
-    });
+    };
+    let issue;
+    if (watchdogProductBugFollowUp) {
+      const mutation = await taskWatchdogsSvc.executeSourceMutation(
+        watchdogProductBugFollowUp.scope,
+        {
+          operationKind: "product_bug_followup_create",
+          method: req.method,
+          path: req.originalUrl,
+          targetIssueId: watchdogProductBugFollowUp.sourceIssue.id,
+          body: req.body,
+          agentApiKeyId: actor.agentApiKeyId,
+          establishesContinuationPath: true,
+        },
+        async (tx) => {
+          const created = await svc.create(companyId, issueInput, tx as unknown as Db);
+          return {
+            value: created,
+            receiptResult: { issueId: created.id, deduplicationReason },
+          };
+        },
+      );
+      if (mutation.replayed) {
+        const receiptResult = mutation.receipt.result as { issueId?: unknown } | null;
+        const replayedIssue = typeof receiptResult?.issueId === "string"
+          ? await svc.getById(receiptResult.issueId)
+          : null;
+        if (!replayedIssue) throw new Error("Task-watchdog replay receipt product bug is missing");
+        res.status(200).json(replayedIssue);
+        return;
+      }
+      issue = mutation.value;
+    } else {
+      issue = await svc.create(companyId, issueInput);
+    }
     if (deduplicationReason) {
       const referenceSummary = await issueReferencesSvc.listIssueReferenceSummary(issue.id);
       res.status(200).json({
@@ -7119,7 +7136,7 @@ export function issueRoutes(
               sourceIssueIdentifier: watchdogProductBugFollowUp.sourceIssue.identifier,
               watchdogIssueId: watchdogProductBugFollowUp.watchdogIssue?.id ?? null,
               watchdogIssueIdentifier: watchdogProductBugFollowUp.watchdogIssue?.identifier ?? null,
-              stopFingerprint: watchdogProductBugFollowUp.scope.stopFingerprint,
+              stopFingerprint: watchdogProductBugFollowUp.scope.initialStopFingerprint,
             },
           }
           : {}),
@@ -7230,6 +7247,9 @@ export function issueRoutes(
     await assertIssueEnvironmentSelection(parent.companyId, createBody.executionWorkspaceSettings?.environmentId);
 
     const actor = getActorInfo(req);
+    const childWatchdogScope = await resolveTaskWatchdogMutationScope(db, req.actor);
+    const isWatchdogSourceChild =
+      childWatchdogScope.kind === "watchdog" && parent.id !== childWatchdogScope.watchdogIssueId;
     const serializationContext = await resolveWatchdogFollowUpSerializationContext(req, parent);
     const currentSerializedChild = serializationContext
       ? await findCurrentSerializedWatchdogChild(parent)
@@ -7246,7 +7266,7 @@ export function issueRoutes(
       projectId: createBody.projectId ?? parent.projectId ?? null,
       executionPolicy,
     }, actor);
-    const { issue, parentBlockerAdded } = await svc.createChild(parent.id, {
+    const childInput = {
       ...createBody,
       ...(taskBridgeOriginForActor(req) ?? {}),
       id: issueId,
@@ -7266,7 +7286,50 @@ export function issueRoutes(
       actorAgentId: actor.agentId,
       actorUserId: actor.actorType === "user" ? actor.actorId : null,
       watchdogActorRunId: actor.runId,
-    });
+    };
+    let childResult;
+    if (isWatchdogSourceChild) {
+      const mutation = await taskWatchdogsSvc.executeSourceMutation(
+        childWatchdogScope,
+        {
+          operationKind: "issue_child_create",
+          method: req.method,
+          path: req.originalUrl,
+          targetIssueId: parent.id,
+          body: req.body,
+          agentApiKeyId: actor.agentApiKeyId,
+          establishesContinuationPath:
+            !currentSerializedChild &&
+            (childInput.status === "todo" || childInput.status === "in_progress" || childInput.status === "in_review"),
+        },
+        async (tx) => {
+          const created = await svc.createChild(parent.id, childInput, tx as unknown as Db);
+          return {
+            value: created,
+            receiptResult: {
+              childIssueId: created.issue.id,
+              parentBlockerAdded: created.parentBlockerAdded,
+            },
+          };
+        },
+      );
+      if (mutation.replayed) {
+        const receiptResult = mutation.receipt.result as {
+          childIssueId?: unknown;
+          parentBlockerAdded?: unknown;
+        } | null;
+        const replayedIssue = typeof receiptResult?.childIssueId === "string"
+          ? await svc.getById(receiptResult.childIssueId)
+          : null;
+        if (!replayedIssue) throw new Error("Task-watchdog replay receipt child issue is missing");
+        res.status(200).json(replayedIssue);
+        return;
+      }
+      childResult = mutation.value;
+    } else {
+      childResult = await svc.createChild(parent.id, childInput);
+    }
+    const { issue, parentBlockerAdded } = childResult;
     await externalObjectsSvc.syncIssueSafely(issue.id);
 
     await logActivity(db, {
@@ -7455,13 +7518,55 @@ export function issueRoutes(
       }
     }
 
-    const result = await svc.decomposeAcceptedPlan(sourceIssue.id, {
+    const decompositionInput = {
       acceptedPlanRevisionId: req.body.acceptedPlanRevisionId,
       children: normalizedChildren,
       actorAgentId: actor.agentId,
       actorUserId: actor.actorType === "user" ? actor.actorId : null,
       actorRunId: actor.runId ?? null,
-    });
+    };
+    const decompositionWatchdogScope = await resolveTaskWatchdogMutationScope(db, req.actor);
+    const isWatchdogSourceDecomposition =
+      decompositionWatchdogScope.kind === "watchdog" &&
+      sourceIssue.id !== decompositionWatchdogScope.watchdogIssueId;
+    let result;
+    if (isWatchdogSourceDecomposition) {
+      const mutation = await taskWatchdogsSvc.executeSourceMutation(
+        decompositionWatchdogScope,
+        {
+          operationKind: "accepted_plan_decomposition",
+          method: req.method,
+          path: req.originalUrl,
+          targetIssueId: sourceIssue.id,
+          body: req.body,
+          agentApiKeyId: actor.agentApiKeyId,
+          establishesContinuationPath: normalizedChildren.some((child) =>
+            child.status === "todo" || child.status === "in_progress" || child.status === "in_review"),
+        },
+        async (tx) => {
+          const decomposed = await svc.decomposeAcceptedPlan(
+            sourceIssue.id,
+            decompositionInput,
+            tx as unknown as Db,
+          );
+          return {
+            value: decomposed,
+            receiptResult: {
+              decomposition: decomposed.decomposition,
+              childIssueIds: decomposed.childIssueIds,
+              newlyCreatedChildIssueIds: decomposed.newlyCreatedIssues.map((issue) => issue.id),
+            },
+          };
+        },
+      );
+      if (mutation.replayed) {
+        res.status(200).json(mutation.receipt.result);
+        return;
+      }
+      result = mutation.value;
+    } else {
+      result = await svc.decomposeAcceptedPlan(sourceIssue.id, decompositionInput);
+    }
 
     await logActivity(db, {
       companyId: sourceIssue.companyId,
@@ -7931,21 +8036,30 @@ export function issueRoutes(
     }
 
     let issue;
+    let atomicWatchdogComment: Awaited<ReturnType<typeof svc.addComment>> | null = null;
+    let isAtomicWatchdogMutation = false;
     try {
-      if (transition.decision && decisionId) {
-        const decision = transition.decision;
-        issue = await db.transaction(async (tx) => {
-          const updated = await svc.update(
-            id,
-            {
-              ...updateFields,
-              actorAgentId: actor.agentId ?? null,
-              actorUserId: actor.actorType === "user" ? actor.actorId : null,
-            },
-            tx,
-          );
-          if (!updated) return null;
+      const watchdogScope = await resolveTaskWatchdogMutationScope(db, req.actor);
+      const isWatchdogSourceMutation =
+        watchdogScope.kind === "watchdog" && existing.id !== watchdogScope.watchdogIssueId;
+      isAtomicWatchdogMutation = isWatchdogSourceMutation;
+      const atomicCommentSourceTrust = commentBody
+        ? await sourceTrustForActorWrite(existing, actor)
+        : null;
+      const applyUpdate = async (tx: any) => {
+        const updated = await svc.update(
+          id,
+          {
+            ...updateFields,
+            actorAgentId: actor.agentId ?? null,
+            actorUserId: actor.actorType === "user" ? actor.actorId : null,
+          },
+          tx,
+        );
+        if (!updated) return { updated: null, comment: null };
 
+        if (transition.decision && decisionId) {
+          const decision = transition.decision;
           await tx.insert(issueExecutionDecisions).values({
             id: decisionId,
             companyId: updated.companyId,
@@ -7958,9 +8072,66 @@ export function issueRoutes(
             body: decision.body,
             createdByRunId: actor.runId ?? null,
           });
+        }
 
-          return updated;
+        const insertedComment = isWatchdogSourceMutation && commentBody
+          ? await svc.addComment(id, commentBody, {
+              agentId: actor.agentId ?? undefined,
+              userId: actor.actorType === "user" ? actor.actorId : undefined,
+              runId: actor.runId,
+            }, { sourceTrust: atomicCommentSourceTrust }, tx)
+          : null;
+        return { updated, comment: insertedComment };
+      };
+
+      if (isWatchdogSourceMutation) {
+        const mutation = await taskWatchdogsSvc.executeSourceMutation(
+          watchdogScope,
+          {
+            operationKind: "issue_update",
+            method: req.method,
+            path: req.originalUrl,
+            targetIssueId: existing.id,
+            body: req.body,
+            agentApiKeyId: actor.agentApiKeyId,
+            establishesContinuationPath:
+              updateFields.status === "todo" ||
+              updateFields.status === "in_progress" ||
+              updateFields.status === "in_review",
+          },
+          async (tx) => {
+            const result = await applyUpdate(tx);
+            if (!result.updated) throw new Error("Task-watchdog mutation target disappeared inside transaction");
+            return {
+              value: result,
+              receiptResult: {
+                issueId: result.updated.id,
+                commentId: result.comment?.id ?? null,
+              },
+            };
+          },
+        );
+        if (mutation.replayed) {
+          const receiptResult = mutation.receipt.result as { issueId?: unknown; commentId?: unknown } | null;
+          issue = await svc.getById(
+            typeof receiptResult?.issueId === "string" ? receiptResult.issueId : existing.id,
+          );
+          atomicWatchdogComment = typeof receiptResult?.commentId === "string"
+            ? await svc.getComment(receiptResult.commentId)
+            : null;
+          if (commentBody && !atomicWatchdogComment) {
+            throw new Error("Task-watchdog replay receipt comment is missing");
+          }
+        } else {
+          issue = mutation.value.updated;
+          atomicWatchdogComment = mutation.value.comment;
+        }
+      } else if (transition.decision && decisionId) {
+        const result = await db.transaction(async (tx) => {
+          const applied = await applyUpdate(tx);
+          return applied.updated;
         });
+        issue = result;
       } else {
         issue = await svc.update(id, {
           ...updateFields,
@@ -8373,7 +8544,7 @@ export function issueRoutes(
     if (commentBody) {
       const commentReferenceSummaryBefore = updateReferenceSummaryAfter
         ?? await issueReferencesSvc.listIssueReferenceSummary(issue.id);
-      comment = await svc.addComment(id, commentBody, {
+      comment = isAtomicWatchdogMutation ? atomicWatchdogComment! : await svc.addComment(id, commentBody, {
         agentId: actor.agentId ?? undefined,
         userId: actor.actorType === "user" ? actor.actorId : undefined,
         runId: actor.runId,
@@ -9685,6 +9856,9 @@ export function issueRoutes(
     }
 
     const actor = getActorInfo(req);
+    const commentWatchdogScope = await resolveTaskWatchdogMutationScope(db, req.actor);
+    const isWatchdogSourceComment =
+      commentWatchdogScope.kind === "watchdog" && issue.id !== commentWatchdogScope.watchdogIssueId;
     const reopenRequested = req.body.reopen === true;
     const resumeRequested = req.body.resume === true;
     const interruptRequested = req.body.interrupt === true;
@@ -9709,11 +9883,17 @@ export function issueRoutes(
     ) {
       if (!(await assertAgentIssueMutationAllowed(req, res, issue))) return;
     }
+    const explicitMoveToTodoRequested = effectiveReopenRequested || effectiveResumeRequested === true;
+    if (isWatchdogSourceComment && explicitMoveToTodoRequested) {
+      res.status(409).json({
+        error: "Task-watchdog recovery status and comment must be submitted atomically through PATCH /issues/:id.",
+      });
+      return;
+    }
     if (effectiveResumeRequested === true && !(await assertExplicitResumeIntentAllowed(req, res, issue))) return;
     if (effectiveResumeRequested !== true && effectiveReopenRequested === true && req.actor.type === "agent") {
       if (!(await assertExplicitResumeIntentAllowed(req, res, issue))) return;
     }
-    const explicitMoveToTodoRequested = effectiveReopenRequested || effectiveResumeRequested === true;
     const scheduledRetryForHumanComment =
       shouldHumanCommentResumeInProgressScheduledRetry({
         hasComment: true,
@@ -9977,16 +10157,46 @@ export function issueRoutes(
         requestedByActorId: actor.actorId,
       });
     } else {
-      comment = await svc.addComment(id, req.body.body, {
+      const commentActor = {
         agentId: actor.agentId ?? undefined,
         userId: actor.actorType === "user" ? actor.actorId : undefined,
         runId: actor.runId,
-      }, {
+      };
+      const commentOptions = {
         authorType: req.body.authorType ?? (actor.actorType === "agent" ? "agent" : "user"),
         presentation: req.body.presentation ?? null,
         metadata: req.body.metadata ?? null,
         sourceTrust: await sourceTrustForActorWrite(currentIssue, actor),
-      });
+      };
+      if (isWatchdogSourceComment) {
+        const mutation = await taskWatchdogsSvc.executeSourceMutation(
+          commentWatchdogScope,
+          {
+            operationKind: "issue_comment",
+            method: req.method,
+            path: req.originalUrl,
+            targetIssueId: currentIssue.id,
+            body: req.body,
+            agentApiKeyId: actor.agentApiKeyId,
+          },
+          async (tx) => {
+            const inserted = await svc.addComment(id, req.body.body, commentActor, commentOptions, tx);
+            return { value: inserted, receiptResult: { commentId: inserted.id } };
+          },
+        );
+        if (mutation.replayed) {
+          const result = mutation.receipt.result as { commentId?: unknown } | null;
+          const replayedComment = typeof result?.commentId === "string"
+            ? await svc.getComment(result.commentId)
+            : null;
+          if (!replayedComment) throw new Error("Task-watchdog replay receipt comment is missing");
+          res.status(200).json(replayedComment);
+          return;
+        }
+        comment = mutation.value;
+      } else {
+        comment = await svc.addComment(id, req.body.body, commentActor, commentOptions);
+      }
     }
 
     await issueReferencesSvc.syncComment(comment.id);

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -5758,15 +5758,16 @@ export function issueService(db: Db) {
     createChild: async (
       parentIssueId: string,
       data: IssueChildCreateInput,
+      dbOrTx: Db = db,
     ) => {
-      const parent = await db
+      const parent = await dbOrTx
         .select()
         .from(issues)
         .where(eq(issues.id, parentIssueId))
         .then((rows) => rows[0] ?? null);
       if (!parent) throw notFound("Parent issue not found");
 
-      const [{ childCount }] = await db
+      const [{ childCount }] = await dbOrTx
         .select({ childCount: sql<number>`count(*)::int` })
         .from(issues)
         .where(and(eq(issues.companyId, parent.companyId), eq(issues.parentId, parent.id)));
@@ -5809,10 +5810,10 @@ export function issueService(db: Db) {
         ...(inheritStrategyOnly
           ? { skipExecutionWorkspaceInheritance: true }
           : { inheritExecutionWorkspaceFromIssueId: parent.id }),
-      });
+      }, dbOrTx);
 
       if (blockParentUntilDone) {
-        const existingBlockers = await db
+        const existingBlockers = await dbOrTx
           .select({ blockerIssueId: issueRelations.issueId })
           .from(issueRelations)
           .where(and(eq(issueRelations.companyId, parent.companyId), eq(issueRelations.relatedIssueId, parent.id), eq(issueRelations.type, "blocks")));
@@ -5821,8 +5822,9 @@ export function issueService(db: Db) {
           parent.companyId,
           [...new Set([...existingBlockers.map((row) => row.blockerIssueId), child.id])],
           { agentId: actorAgentId ?? null, userId: actorUserId ?? null },
+          dbOrTx,
         );
-        [child] = await withIssueRelationSummaries(parent.companyId, [child], db);
+        [child] = await withIssueRelationSummaries(parent.companyId, [child], dbOrTx);
       }
 
       return {
@@ -5834,8 +5836,9 @@ export function issueService(db: Db) {
     decomposeAcceptedPlan: async (
       sourceIssueId: string,
       data: AcceptedPlanDecompositionInput,
+      dbOrTx: Db = db,
     ) => {
-      const sourceIssue = await db
+      const sourceIssue = await dbOrTx
         .select({
           id: issues.id,
           companyId: issues.companyId,
@@ -5852,7 +5855,10 @@ export function issueService(db: Db) {
         children: data.children,
       });
 
-      const initialClaim = await db.transaction(async (tx) => {
+      const runTransaction = <T>(callback: (tx: Db) => Promise<T>) => dbOrTx === db
+        ? db.transaction((tx) => callback(tx as unknown as Db))
+        : callback(dbOrTx);
+      const initialClaim = await runTransaction(async (tx) => {
         await tx.execute(sql`select ${issues.id} from ${issues} where ${issues.id} = ${sourceIssue.id} for update`);
 
         const belongsToPlanDocument = await tx
@@ -5924,7 +5930,7 @@ export function issueService(db: Db) {
       const newlyCreatedIssues: Array<typeof issues.$inferSelect> = [];
 
       while (true) {
-        const step = await db.transaction(async (tx) => {
+        const step = await runTransaction(async (tx) => {
           await tx.execute(
             sql`select ${issuePlanDecompositions.id}
                 from ${issuePlanDecompositions}
@@ -6024,7 +6030,7 @@ export function issueService(db: Db) {
 
       const childIssueIds = normalizeIssuePlanDecompositionChildIds(currentClaim.childIssueIds);
       const childIssueRows = childIssueIds.length > 0
-        ? await db
+        ? await dbOrTx
             .select()
             .from(issues)
             .where(and(eq(issues.companyId, sourceIssue.companyId), inArray(issues.id, childIssueIds)))
@@ -6106,7 +6112,7 @@ export function issueService(db: Db) {
       });
     },
 
-    create: async (companyId: string, data: IssueCreateInput) => {
+    create: async (companyId: string, data: IssueCreateInput, dbOrTx: Db = db) => {
       const {
         labelIds: inputLabelIds,
         blockedByIssueIds,
@@ -6132,7 +6138,7 @@ export function issueService(db: Db) {
         throw unprocessable("Issue can only have one assignee");
       }
       if (data.assigneeAgentId) {
-        await assertAssignableAgent(db, companyId, data.assigneeAgentId, { kind: "work" });
+        await assertAssignableAgent(dbOrTx, companyId, data.assigneeAgentId, { kind: "work" });
       }
       if (data.assigneeUserId) {
         await assertAssignableUser(companyId, data.assigneeUserId);
@@ -6140,7 +6146,7 @@ export function issueService(db: Db) {
       if (data.status === "in_progress" && !data.assigneeAgentId && !data.assigneeUserId) {
         throw unprocessable("in_progress issues require an assignee");
       }
-      return db.transaction(async (tx) => {
+      const createInTransaction = async (tx: Db) => {
         const idempotencyKey = rawIdempotencyKey?.trim() || null;
         const normalizedTitle = normalizeCreateIssueTitle(issueData.title);
         if (allowDuplicate === false) {
@@ -6431,7 +6437,10 @@ export function issueService(db: Db) {
         const [enriched] = await withIssueLabels(tx, [issue]);
         const [withRelations] = await withIssueRelationSummaries(companyId, [enriched], tx);
         return withRelations;
-      });
+      };
+      return dbOrTx === db
+        ? db.transaction((tx) => createInTransaction(tx as unknown as Db))
+        : createInTransaction(dbOrTx);
     },
 
     update: async (

--- a/server/src/services/task-watchdog-scope.ts
+++ b/server/src/services/task-watchdog-scope.ts
@@ -23,11 +23,15 @@ export type TaskWatchdogMutationScope =
   | { kind: "invalid"; detail: string }
   | {
       kind: "watchdog";
+      runId: string;
+      agentId: string;
       watchdogId: string;
       companyId: string;
       watchedIssueId: string;
-      watchdogIssueId: string | null;
-      stopFingerprint: string | null;
+      watchdogIssueId: string;
+      initialStopFingerprint: string;
+      cursorFingerprint: string;
+      cursorState: "open" | "sealed";
     };
 
 function isPlainRecord(value: unknown): value is Record<string, unknown> {
@@ -43,8 +47,22 @@ function readTaskWatchdogContext(contextSnapshot: unknown) {
   const taskWatchdog = isPlainRecord(context?.taskWatchdog) ? context.taskWatchdog : null;
   if (!taskWatchdog && context?.taskWatchdog !== true) return null;
   return {
+    version: taskWatchdog?.version === 1 ? 1 : null,
+    watchdogId: readString(taskWatchdog?.watchdogId),
+    watchdogIssueId: readString(taskWatchdog?.watchdogIssueId),
     watchedIssueId: readString(taskWatchdog?.watchedIssueId) ?? readString(context?.watchedIssueId),
-    stopFingerprint: readString(taskWatchdog?.stopFingerprint) ?? readString(context?.stopFingerprint),
+    companyId: readString(taskWatchdog?.companyId),
+    agentId: readString(taskWatchdog?.agentId),
+    initialStopFingerprint: readString(taskWatchdog?.stopFingerprint) ?? readString(context?.stopFingerprint),
+    recoveryCursor: isPlainRecord(taskWatchdog?.recoveryCursor)
+      ? {
+          version: taskWatchdog.recoveryCursor.version === 1 ? 1 : null,
+          state: taskWatchdog.recoveryCursor.state === "open" || taskWatchdog.recoveryCursor.state === "sealed"
+            ? taskWatchdog.recoveryCursor.state
+            : null,
+          fingerprint: readString(taskWatchdog.recoveryCursor.fingerprint),
+        }
+      : null,
   };
 }
 
@@ -63,6 +81,7 @@ export async function resolveTaskWatchdogMutationScope(
       id: heartbeatRuns.id,
       companyId: heartbeatRuns.companyId,
       agentId: heartbeatRuns.agentId,
+      status: heartbeatRuns.status,
       contextSnapshot: heartbeatRuns.contextSnapshot,
     })
     .from(heartbeatRuns)
@@ -79,10 +98,34 @@ export async function resolveTaskWatchdogMutationScope(
     };
   }
 
-  if (!taskWatchdog.watchedIssueId) {
+  if (run.status !== "running") {
     return {
       kind: "invalid",
-      detail: "Task-watchdog run context is missing a persisted watched issue id.",
+      detail: "Task-watchdog source mutation requires its exact heartbeat run to still be running.",
+    };
+  }
+
+  if (
+    taskWatchdog.version !== 1 ||
+    !taskWatchdog.watchdogId ||
+    !taskWatchdog.watchdogIssueId ||
+    !taskWatchdog.watchedIssueId ||
+    !taskWatchdog.companyId ||
+    !taskWatchdog.agentId ||
+    !taskWatchdog.initialStopFingerprint ||
+    taskWatchdog.recoveryCursor?.version !== 1 ||
+    !taskWatchdog.recoveryCursor.state ||
+    !taskWatchdog.recoveryCursor.fingerprint
+  ) {
+    return {
+      kind: "invalid",
+      detail: "Task-watchdog run context is missing its immutable identity or recovery cursor.",
+    };
+  }
+  if (taskWatchdog.companyId !== run.companyId || taskWatchdog.agentId !== run.agentId) {
+    return {
+      kind: "invalid",
+      detail: "Task-watchdog run snapshot identity does not match the heartbeat run.",
     };
   }
 
@@ -97,14 +140,18 @@ export async function resolveTaskWatchdogMutationScope(
     })
     .from(issueWatchdogs)
     .where(and(
-      eq(issueWatchdogs.companyId, run.companyId),
-      eq(issueWatchdogs.issueId, taskWatchdog.watchedIssueId),
-      eq(issueWatchdogs.watchdogAgentId, agentId),
-      eq(issueWatchdogs.status, "active"),
+      eq(issueWatchdogs.id, taskWatchdog.watchdogId),
+      eq(issueWatchdogs.companyId, taskWatchdog.companyId),
     ))
     .then((rows) => rows[0] ?? null);
 
-  if (!watchdog) {
+  if (
+    !watchdog ||
+    watchdog.issueId !== taskWatchdog.watchedIssueId ||
+    watchdog.watchdogAgentId !== taskWatchdog.agentId ||
+    watchdog.watchdogIssueId !== taskWatchdog.watchdogIssueId ||
+    watchdog.status !== "active"
+  ) {
     return {
       kind: "invalid",
       detail: "Task-watchdog run context is not backed by an active persisted watchdog.",
@@ -113,11 +160,15 @@ export async function resolveTaskWatchdogMutationScope(
 
   return {
     kind: "watchdog",
-    watchdogId: watchdog.id,
-    companyId: watchdog.companyId,
-    watchedIssueId: watchdog.issueId,
-    watchdogIssueId: watchdog.watchdogIssueId ?? null,
-    stopFingerprint: taskWatchdog.stopFingerprint,
+    runId: run.id,
+    agentId,
+    watchdogId: taskWatchdog.watchdogId,
+    companyId: taskWatchdog.companyId,
+    watchedIssueId: taskWatchdog.watchedIssueId,
+    watchdogIssueId: taskWatchdog.watchdogIssueId,
+    initialStopFingerprint: taskWatchdog.initialStopFingerprint,
+    cursorFingerprint: taskWatchdog.recoveryCursor.fingerprint,
+    cursorState: taskWatchdog.recoveryCursor.state as "open" | "sealed",
   };
 }
 

--- a/server/src/services/task-watchdogs.ts
+++ b/server/src/services/task-watchdogs.ts
@@ -16,13 +16,14 @@ import {
   issueWorkProducts,
 } from "@paperclipai/db";
 import type { IssueWatchdog, IssueWatchdogSummary } from "@paperclipai/shared";
-import { conflict, notFound } from "../errors.js";
+import { conflict, forbidden, notFound } from "../errors.js";
 import { parseObject } from "../adapters/utils.js";
 import { logActivity } from "./activity-log.js";
 import { evaluateAgentInvokabilityFromDb } from "./agent-invokability.js";
 import { issueService } from "./issues.js";
 import { visibleIssueCondition } from "./issue-visibility.js";
 import { TASK_WATCHDOG_ORIGIN_KIND } from "./task-watchdog-scope.js";
+import type { TaskWatchdogMutationScope } from "./task-watchdog-scope.js";
 
 const TASK_WATCHDOG_STOP_FINGERPRINT_PREFIX = "task_watchdog_stop:";
 const TASK_WATCHDOG_SUBTREE_MAX_DEPTH = 100;
@@ -190,6 +191,64 @@ type TaskWatchdogWakeup = (
 export type TaskWatchdogServiceDeps = {
   enqueueWakeup?: TaskWatchdogWakeup;
 };
+
+export type TaskWatchdogSourceMutationRequest = {
+  operationKind: string;
+  method: string;
+  path: string;
+  targetIssueId: string;
+  body: unknown;
+  agentApiKeyId?: string | null;
+  establishesContinuationPath?: boolean;
+};
+
+type TaskWatchdogMutationReceipt = {
+  version: 1;
+  digest: string;
+  operationKind: string;
+  targetIssueId: string;
+  oldFingerprint: string;
+  newFingerprint: string | null;
+  cursorState: "open" | "sealed";
+  result: unknown;
+  committedAt: string;
+};
+
+function canonicalizeJson(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(canonicalizeJson);
+  if (!value || typeof value !== "object") return value;
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, entry]) => [key, canonicalizeJson(entry)]),
+  );
+}
+
+function taskWatchdogMutationDigest(input: TaskWatchdogSourceMutationRequest) {
+  return createHash("sha256")
+    .update(JSON.stringify(canonicalizeJson({
+      method: input.method.toUpperCase(),
+      path: input.path,
+      targetIssueId: input.targetIssueId,
+      body: input.body,
+    })))
+    .digest("hex");
+}
+
+function readTaskWatchdogMutationReceipt(value: unknown): TaskWatchdogMutationReceipt | null {
+  const receipt = parseObject(value);
+  if (
+    receipt.version !== 1 ||
+    typeof receipt.digest !== "string" ||
+    typeof receipt.operationKind !== "string" ||
+    typeof receipt.targetIssueId !== "string" ||
+    typeof receipt.oldFingerprint !== "string" ||
+    (receipt.newFingerprint !== null && typeof receipt.newFingerprint !== "string") ||
+    (receipt.cursorState !== "open" && receipt.cursorState !== "sealed") ||
+    typeof receipt.committedAt !== "string"
+  ) return null;
+  return receipt as TaskWatchdogMutationReceipt;
+}
 
 function normalizeInstructions(value: string | null | undefined): string | null {
   if (value == null) return null;
@@ -553,10 +612,21 @@ function watchdogWakeContext(input: {
     wakeReason: "task_watchdog_stopped_subtree",
     source: TASK_WATCHDOG_ORIGIN_KIND,
     taskWatchdog: {
+      version: 1,
+      watchdogId: input.watchdog.id,
+      watchdogIssueId: input.watchdogIssue.id,
       watchedIssueId: input.sourceIssue.id,
+      companyId: input.watchdog.companyId,
+      agentId: input.watchdog.watchdogAgentId,
       watchedIssueIdentifier: input.sourceIssue.identifier,
       watchedIssueTitle: input.sourceIssue.title,
       stopFingerprint: input.classification.stopFingerprint,
+      recoveryCursor: {
+        version: 1,
+        state: "open",
+        fingerprint: input.classification.stopFingerprint,
+        lastMutationReceipt: null,
+      },
       capabilities: {
         targetScope: {
           watchedIssueId: input.sourceIssue.id,
@@ -721,8 +791,8 @@ export async function upsertIssueWatchdogForIssue(
 export function taskWatchdogService(db: Db, deps: TaskWatchdogServiceDeps = {}) {
   const issuesSvc = issueService(db);
 
-  async function loadWatchdogSubtreeIssues(companyId: string, watchedIssueId: string) {
-    const rows = await db.execute(sql`
+  async function loadWatchdogSubtreeIssues(companyId: string, watchedIssueId: string, dbOrTx: any = db) {
+    const rows = await dbOrTx.execute(sql`
       WITH RECURSIVE watched_issues AS (
         SELECT
           id,
@@ -782,8 +852,8 @@ export function taskWatchdogService(db: Db, deps: TaskWatchdogServiceDeps = {}) 
     return (Array.isArray(rows) ? rows : []) as TaskWatchdogClassifierIssue[];
   }
 
-  async function collectClassifierInput(companyId: string, watchdog: IssueWatchdogRow) {
-    const issueRows = await loadWatchdogSubtreeIssues(companyId, watchdog.issueId);
+  async function collectClassifierInput(companyId: string, watchdog: IssueWatchdogRow, dbOrTx: any = db) {
+    const issueRows = await loadWatchdogSubtreeIssues(companyId, watchdog.issueId, dbOrTx);
     const subtreeIssueIds = issueRows.map((issue) => issue.id);
     if (subtreeIssueIds.length === 0) {
       return {
@@ -811,7 +881,7 @@ export function taskWatchdogService(db: Db, deps: TaskWatchdogServiceDeps = {}) 
       documentActivityRows,
       workProductActivityRows,
     ] = await Promise.all([
-      db
+      dbOrTx
         .select({
           companyId: heartbeatRuns.companyId,
           agentId: heartbeatRuns.agentId,
@@ -827,7 +897,7 @@ export function taskWatchdogService(db: Db, deps: TaskWatchdogServiceDeps = {}) 
             inArray(sql`${heartbeatRuns.contextSnapshot}->>'taskId'`, subtreeIssueIds),
           ),
         )),
-      db
+      dbOrTx
         .select({
           companyId: issues.companyId,
           agentId: heartbeatRuns.agentId,
@@ -842,7 +912,7 @@ export function taskWatchdogService(db: Db, deps: TaskWatchdogServiceDeps = {}) 
           visibleIssueCondition(),
           inArray(heartbeatRuns.status, [...TASK_WATCHDOG_LIVE_RUN_STATUSES]),
         )),
-      db
+      dbOrTx
         .select({
           companyId: agentWakeupRequests.companyId,
           agentId: agentWakeupRequests.agentId,
@@ -860,7 +930,7 @@ export function taskWatchdogService(db: Db, deps: TaskWatchdogServiceDeps = {}) 
             inArray(sql`${agentWakeupRequests.payload}->'_paperclipWakeContext'->>'taskId'`, subtreeIssueIds),
           ),
         )),
-      db
+      dbOrTx
         .select({
           companyId: issueRelations.companyId,
           blockerIssueId: issueRelations.issueId,
@@ -872,7 +942,7 @@ export function taskWatchdogService(db: Db, deps: TaskWatchdogServiceDeps = {}) 
           eq(issueRelations.type, "blocks"),
           inArray(issueRelations.relatedIssueId, subtreeIssueIds),
         )),
-      db
+      dbOrTx
         .select({
           companyId: issueThreadInteractions.companyId,
           issueId: issueThreadInteractions.issueId,
@@ -885,7 +955,7 @@ export function taskWatchdogService(db: Db, deps: TaskWatchdogServiceDeps = {}) 
           inArray(issueThreadInteractions.issueId, subtreeIssueIds),
           eq(issueThreadInteractions.status, "pending"),
         )),
-      db
+      dbOrTx
         .select({
           companyId: issueApprovals.companyId,
           issueId: issueApprovals.issueId,
@@ -899,7 +969,7 @@ export function taskWatchdogService(db: Db, deps: TaskWatchdogServiceDeps = {}) 
           inArray(issueApprovals.issueId, subtreeIssueIds),
           inArray(approvals.status, ["pending", "revision_requested"]),
         )),
-      db
+      dbOrTx
         .select({
           issueId: issueComments.issueId,
           latestAt: sql<Date | null>`MAX(${issueComments.updatedAt})`,
@@ -911,7 +981,7 @@ export function taskWatchdogService(db: Db, deps: TaskWatchdogServiceDeps = {}) 
           isNull(issueComments.deletedAt),
         ))
         .groupBy(issueComments.issueId),
-      db
+      dbOrTx
         .select({
           issueId: issueDocuments.issueId,
           latestAt: sql<Date | null>`MAX(${issueDocuments.updatedAt})`,
@@ -922,7 +992,7 @@ export function taskWatchdogService(db: Db, deps: TaskWatchdogServiceDeps = {}) 
           inArray(issueDocuments.issueId, subtreeIssueIds),
         ))
         .groupBy(issueDocuments.issueId),
-      db
+      dbOrTx
         .select({
           issueId: issueWorkProducts.issueId,
           latestAt: sql<Date | null>`MAX(${issueWorkProducts.updatedAt})`,
@@ -934,9 +1004,15 @@ export function taskWatchdogService(db: Db, deps: TaskWatchdogServiceDeps = {}) 
         ))
         .groupBy(issueWorkProducts.issueId),
     ]);
-    const latestCommentByIssueId = new Map(commentActivityRows.map((row) => [row.issueId, row.latestAt]));
-    const latestDocumentByIssueId = new Map(documentActivityRows.map((row) => [row.issueId, row.latestAt]));
-    const latestWorkProductByIssueId = new Map(workProductActivityRows.map((row) => [row.issueId, row.latestAt]));
+    const latestCommentByIssueId = new Map<string, Date | null>(
+      commentActivityRows.map((row: { issueId: string; latestAt: Date | null }) => [row.issueId, row.latestAt]),
+    );
+    const latestDocumentByIssueId = new Map<string, Date | null>(
+      documentActivityRows.map((row: { issueId: string; latestAt: Date | null }) => [row.issueId, row.latestAt]),
+    );
+    const latestWorkProductByIssueId = new Map<string, Date | null>(
+      workProductActivityRows.map((row: { issueId: string; latestAt: Date | null }) => [row.issueId, row.latestAt]),
+    );
 
     const evaluatedAt = new Date();
     const evaluatedAtMs = evaluatedAt.getTime();
@@ -950,7 +1026,7 @@ export function taskWatchdogService(db: Db, deps: TaskWatchdogServiceDeps = {}) 
         return createdAtMs != null && evaluatedAtMs - createdAtMs < TASK_WATCHDOG_FIRST_RUN_GRACE_MS;
       })
       .map((row) => row.id);
-    const completedRunIssueIds = await collectCompletedRunIssueIds(companyId, freshIssueIds);
+    const completedRunIssueIds = await collectCompletedRunIssueIds(companyId, freshIssueIds, dbOrTx);
 
     return {
       watchdog: summarizeIssueWatchdog(watchdog),
@@ -960,13 +1036,13 @@ export function taskWatchdogService(db: Db, deps: TaskWatchdogServiceDeps = {}) 
         latestDocumentAt: latestDocumentByIssueId.get(issue.id) ?? null,
         latestWorkProductAt: latestWorkProductByIssueId.get(issue.id) ?? null,
       })),
-      activeRuns: activeRunRows.map((row) => ({
+      activeRuns: activeRunRows.map((row: { companyId: string; agentId: string; status: string; contextSnapshot: unknown }) => ({
         companyId: row.companyId,
         agentId: row.agentId,
         status: row.status,
         issueId: issueIdFromRunContext(row.contextSnapshot),
       })).concat(activeIssueRunRows),
-      queuedWakeRequests: wakeRows.map((row) => ({
+      queuedWakeRequests: wakeRows.map((row: { companyId: string; agentId: string; status: string; payload: unknown }) => ({
         companyId: row.companyId,
         agentId: row.agentId,
         status: row.status,
@@ -984,11 +1060,11 @@ export function taskWatchdogService(db: Db, deps: TaskWatchdogServiceDeps = {}) 
   // Returns the subset of `issueIds` that already have at least one run in a
   // terminal status. Such issues have demonstrably executed, so a stopped
   // subtree is genuine and must not be masked by the pending-first-run guard.
-  async function collectCompletedRunIssueIds(companyId: string, issueIds: string[]) {
+  async function collectCompletedRunIssueIds(companyId: string, issueIds: string[], dbOrTx: any = db) {
     if (issueIds.length === 0) return [];
     const candidates = new Set(issueIds);
     const [contextRuns, executionRuns] = await Promise.all([
-      db
+      dbOrTx
         .select({ contextSnapshot: heartbeatRuns.contextSnapshot })
         .from(heartbeatRuns)
         .where(and(
@@ -999,7 +1075,7 @@ export function taskWatchdogService(db: Db, deps: TaskWatchdogServiceDeps = {}) 
             inArray(sql`${heartbeatRuns.contextSnapshot}->>'taskId'`, issueIds),
           ),
         )),
-      db
+      dbOrTx
         .select({ issueId: issues.id })
         .from(issues)
         .innerJoin(heartbeatRuns, eq(issues.executionRunId, heartbeatRuns.id))
@@ -1449,50 +1525,154 @@ export function taskWatchdogService(db: Db, deps: TaskWatchdogServiceDeps = {}) 
       ));
   }
 
-  async function revalidateMutationScope(scope: {
-    kind: "watchdog";
-    watchdogId: string;
-    companyId: string;
-    watchedIssueId: string;
-    stopFingerprint: string | null;
-  }) {
-    if (!scope.stopFingerprint) {
-      return {
-        allowed: false as const,
-        reason: "Task-watchdog run context is missing the stopped fingerprint required for mutation revalidation.",
+  async function executeSourceMutation<T>(
+    scope: Extract<TaskWatchdogMutationScope, { kind: "watchdog" }>,
+    request: TaskWatchdogSourceMutationRequest,
+    applyMutation: (tx: any) => Promise<{ value: T; receiptResult: unknown }>,
+  ): Promise<
+    | { replayed: false; value: T; receipt: TaskWatchdogMutationReceipt }
+    | { replayed: true; value: null; receipt: TaskWatchdogMutationReceipt }
+  > {
+    const digest = taskWatchdogMutationDigest(request);
+    return db.transaction(async (tx) => {
+      // Shared lock order for every watchdog source write: run cursor, active
+      // watchdog identity, then the route's target mutation.
+      const run = await tx
+        .select()
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.id, scope.runId))
+        .for("update")
+        .then((rows) => rows[0] ?? null);
+      if (!run || run.status !== "running") {
+        throw conflict("Task-watchdog source mutation requires its exact heartbeat run to still be running.");
+      }
+      if (run.companyId !== scope.companyId || run.agentId !== scope.agentId) {
+        throw forbidden("Task-watchdog run identity no longer matches this actor.");
+      }
+
+      const context = parseObject(run.contextSnapshot);
+      const taskWatchdog = parseObject(context.taskWatchdog);
+      const cursor = parseObject(taskWatchdog.recoveryCursor);
+      if (
+        taskWatchdog.version !== 1 ||
+        taskWatchdog.watchdogId !== scope.watchdogId ||
+        taskWatchdog.watchdogIssueId !== scope.watchdogIssueId ||
+        taskWatchdog.watchedIssueId !== scope.watchedIssueId ||
+        taskWatchdog.companyId !== scope.companyId ||
+        taskWatchdog.agentId !== scope.agentId ||
+        taskWatchdog.stopFingerprint !== scope.initialStopFingerprint ||
+        cursor.version !== 1 ||
+        (cursor.state !== "open" && cursor.state !== "sealed") ||
+        typeof cursor.fingerprint !== "string"
+      ) {
+        throw forbidden("Task-watchdog run snapshot identity or recovery cursor is invalid.");
+      }
+
+      const watchdog = await tx
+        .select()
+        .from(issueWatchdogs)
+        .where(eq(issueWatchdogs.id, scope.watchdogId))
+        .for("update")
+        .then((rows) => rows[0] ?? null);
+      if (
+        !watchdog ||
+        watchdog.status !== "active" ||
+        watchdog.companyId !== scope.companyId ||
+        watchdog.issueId !== scope.watchedIssueId ||
+        watchdog.watchdogAgentId !== scope.agentId ||
+        watchdog.watchdogIssueId !== scope.watchdogIssueId
+      ) {
+        throw forbidden("Task-watchdog run context is not backed by its exact active persisted watchdog identity.");
+      }
+
+      const priorReceipt = readTaskWatchdogMutationReceipt(cursor.lastMutationReceipt);
+      if (priorReceipt?.digest === digest) {
+        return { replayed: true as const, value: null, receipt: priorReceipt };
+      }
+      if (cursor.state === "sealed") {
+        throw conflict("Task-watchdog source mutation cursor is sealed because recovery already established a continuation path.");
+      }
+      if (cursor.fingerprint !== scope.cursorFingerprint) {
+        throw conflict("Task-watchdog source mutation lost the recovery cursor compare-and-swap.");
+      }
+
+      const before = classifyTaskWatchdogSubtree(await collectClassifierInput(scope.companyId, watchdog, tx));
+      if (before.state !== "stopped" || before.stopFingerprint !== cursor.fingerprint) {
+        throw conflict(
+          before.state === "stopped"
+            ? "Task-watchdog review is stale because external source evidence changed the recovery cursor fingerprint."
+            : "Task-watchdog review is stale because the watched subtree no longer has a stopped recovery path.",
+        );
+      }
+
+      const mutation = await applyMutation(tx);
+      const after = classifyTaskWatchdogSubtree(await collectClassifierInput(scope.companyId, watchdog, tx));
+      const cursorState = after.state === "stopped" && !request.establishesContinuationPath
+        ? "open" as const
+        : "sealed" as const;
+      const newFingerprint = cursorState === "open" && after.state === "stopped"
+        ? after.stopFingerprint
+        : null;
+      const receipt: TaskWatchdogMutationReceipt = {
+        version: 1,
+        digest,
+        operationKind: request.operationKind,
+        targetIssueId: request.targetIssueId,
+        oldFingerprint: cursor.fingerprint,
+        newFingerprint,
+        cursorState,
+        result: mutation.receiptResult,
+        committedAt: new Date().toISOString(),
       };
-    }
-
-    const watchdog = await db
-      .select()
-      .from(issueWatchdogs)
-      .where(and(
-        eq(issueWatchdogs.id, scope.watchdogId),
-        eq(issueWatchdogs.companyId, scope.companyId),
-        eq(issueWatchdogs.issueId, scope.watchedIssueId),
-        eq(issueWatchdogs.status, "active"),
-      ))
-      .then((rows) => rows[0] ?? null);
-    if (!watchdog) {
-      return {
-        allowed: false as const,
-        reason: "Task-watchdog run context is not backed by an active persisted watchdog.",
+      const nextContextSnapshot = {
+        ...context,
+        taskWatchdog: {
+          ...taskWatchdog,
+          recoveryCursor: {
+            version: 1,
+            state: cursorState,
+            fingerprint: newFingerprint ?? cursor.fingerprint,
+            lastMutationReceipt: receipt,
+          },
+        },
       };
-    }
+      const advanced = await tx
+        .update(heartbeatRuns)
+        .set({ contextSnapshot: nextContextSnapshot, updatedAt: new Date() })
+        .where(and(
+          eq(heartbeatRuns.id, scope.runId),
+          eq(heartbeatRuns.status, "running"),
+          eq(heartbeatRuns.contextSnapshot, run.contextSnapshot!),
+        ))
+        .returning({ id: heartbeatRuns.id });
+      if (advanced.length !== 1) {
+        throw conflict("Task-watchdog source mutation lost the recovery cursor compare-and-swap.");
+      }
 
-    const input = await collectClassifierInput(watchdog.companyId, watchdog);
-    const classification = classifyTaskWatchdogSubtree(input);
-    if (classification.state === "stopped" && classification.stopFingerprint === scope.stopFingerprint) {
-      return { allowed: true as const, classification };
-    }
+      await logActivity(tx as unknown as Db, {
+        companyId: scope.companyId,
+        actorType: "agent",
+        actorId: scope.agentId,
+        agentId: scope.agentId,
+        runId: scope.runId,
+        agentApiKeyId: request.agentApiKeyId ?? null,
+        action: "issue.task_watchdog_source_mutation_committed",
+        entityType: "issue",
+        entityId: request.targetIssueId,
+        issueId: request.targetIssueId,
+        details: {
+          watchdogId: scope.watchdogId,
+          runId: scope.runId,
+          targetIssueId: request.targetIssueId,
+          oldFingerprint: cursor.fingerprint,
+          newFingerprint,
+          cursorState,
+          operationKind: request.operationKind,
+        },
+      });
 
-    return {
-      allowed: false as const,
-      reason: classification.state === "stopped"
-        ? "Task-watchdog review is stale because the watched subtree stop fingerprint changed; refresh the source state before mutating it."
-        : "Task-watchdog review is stale because the watched subtree now has a live, waiting, already-reviewed, or not-applicable path; refresh the source state before mutating it.",
-      classification,
-    };
+      return { replayed: false as const, value: mutation.value, receipt };
+    });
   }
 
   return {
@@ -1648,6 +1828,6 @@ export function taskWatchdogService(db: Db, deps: TaskWatchdogServiceDeps = {}) 
       return result;
     },
 
-    revalidateMutationScope,
+    executeSourceMutation,
   };
 }

--- a/server/src/services/task-watchdogs.ts
+++ b/server/src/services/task-watchdogs.ts
@@ -227,6 +227,7 @@ function canonicalizeJson(value: unknown): unknown {
 function taskWatchdogMutationDigest(input: TaskWatchdogSourceMutationRequest) {
   return createHash("sha256")
     .update(JSON.stringify(canonicalizeJson({
+      operationKind: input.operationKind,
       method: input.method.toUpperCase(),
       path: input.path,
       targetIssueId: input.targetIssueId,
@@ -245,9 +246,38 @@ function readTaskWatchdogMutationReceipt(value: unknown): TaskWatchdogMutationRe
     typeof receipt.oldFingerprint !== "string" ||
     (receipt.newFingerprint !== null && typeof receipt.newFingerprint !== "string") ||
     (receipt.cursorState !== "open" && receipt.cursorState !== "sealed") ||
+    !isTaskWatchdogMutationReceiptResult(receipt.operationKind, receipt.result) ||
     typeof receipt.committedAt !== "string"
   ) return null;
   return receipt as TaskWatchdogMutationReceipt;
+}
+
+function isTaskWatchdogMutationReceiptResult(operationKind: unknown, value: unknown): boolean {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const result = value as Record<string, unknown>;
+  switch (operationKind) {
+    case "product_bug_followup_create":
+      return typeof result.issueId === "string" &&
+        (result.deduplicationReason === undefined ||
+          result.deduplicationReason === "idempotency_key" ||
+          result.deduplicationReason === "recent_open_title");
+    case "issue_child_create":
+      return typeof result.childIssueId === "string" && typeof result.parentBlockerAdded === "boolean";
+    case "accepted_plan_decomposition":
+      return !!result.decomposition &&
+        typeof result.decomposition === "object" &&
+        Array.isArray(result.childIssueIds) &&
+        result.childIssueIds.every((id) => typeof id === "string") &&
+        Array.isArray(result.newlyCreatedChildIssueIds) &&
+        result.newlyCreatedChildIssueIds.every((id) => typeof id === "string");
+    case "issue_update":
+      return typeof result.issueId === "string" &&
+        (result.commentId === null || typeof result.commentId === "string");
+    case "issue_comment":
+      return typeof result.commentId === "string";
+    default:
+      return false;
+  }
 }
 
 function normalizeInstructions(value: string | null | undefined): string | null {
@@ -1586,6 +1616,9 @@ export function taskWatchdogService(db: Db, deps: TaskWatchdogServiceDeps = {}) 
       }
 
       const priorReceipt = readTaskWatchdogMutationReceipt(cursor.lastMutationReceipt);
+      if (cursor.lastMutationReceipt !== null && !priorReceipt) {
+        throw forbidden("Task-watchdog recovery cursor contains an invalid mutation receipt.");
+      }
       if (priorReceipt?.digest === digest) {
         return { replayed: true as const, value: null, receipt: priorReceipt };
       }


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Task watchdogs diagnose stopped issue trees and may be authorized to repair a narrowly scoped source issue.
> - A watchdog run's authorization was bound only to the subtree fingerprint captured at run start.
> - Its first permitted mutation changed that fingerprint, so the same run could not make the required follow-up transition.
> - Recovery needs immutable run/watchdog identity plus a transactional cursor that advances after each authorized mutation.
> - This pull request adds that cursor, atomic mutation/audit handling, replay safety, and fail-closed validation.
> - The benefit is that one watchdog run can complete a legitimate multi-step recovery without widening its authority or permitting stale/concurrent writes.

## Linked Issues or Issue Description

Bug report:

- **Problem:** A task-watchdog run can make one permitted source mutation, change the watched subtree stop fingerprint, and then be rejected as stale when making its required follow-up transition.
- **Expected:** The authorized run advances to the new fingerprint atomically and may continue only while its immutable watchdog/run identity and cursor remain valid.
- **Actual:** Authorization continues comparing against the run-start fingerprint, permanently stranding the recovery after its first write.
- **Scope:** Server-side watchdog source-mutation authorization, persistence, replay, concurrency, and audit behavior. No schema migration or UI change.
- **Related PR search:** Searched open PRs for task-watchdog, recovery, heartbeat, and fingerprint changes. No open PR implements a run-bound transactional recovery cursor; #9432 addresses timestamp churn in fingerprint calculation and #9540 addresses workspace isolation.

## What Changed

- Persist immutable watchdog-run identity and an open/sealed recovery cursor in heartbeat-run context.
- Route watchdog-owned issue updates, comments, child creation, accepted-plan decomposition, and product-bug follow-up creation through one transactional source-mutation executor.
- Lock and validate the heartbeat run and watchdog before mutation, then advance or seal the cursor and write the audit receipt in the same transaction.
- Make exact retries idempotent while rejecting altered replay, stale cursor, wrong company/agent/watchdog identity, inactive watchdogs, and losing concurrent writers.
- Require compound status/comment recovery through the atomic issue update path instead of a standalone reopen/resume comment.
- Add focused lifecycle, replay, failure, identity-rotation, fail-closed, and concurrency regression coverage.

## Verification

- `pnpm exec vitest run server/src/__tests__/task-watchdogs-scheduler.test.ts server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts` — PASS (86 tests).
- `pnpm --filter @paperclipai/server typecheck` — PASS.
- `pnpm typecheck` — PASS across supported workspace packages.
- `pnpm build` — PASS.
- `git diff --check` — PASS.
- `pnpm test:run` — changed suites pass; repository-wide run completed with 264 passing files and 5 unrelated failing files (workspace-runtime provisioning timeouts, cursor remote-sandbox command/probe failures, and two cleanup-hook timeouts).
- The role-prescribed aliases `rtk pnpm lint`, `rtk pnpm knip`, and `rtk pnpm test --run` are unavailable/invalid in this repository (`lint` and `knip` scripts do not exist; `--run` is not a pnpm option). The repository-supported equivalents above were used.

## Risks

- **Class C:** This changes production recovery authorization and concurrency behavior.
- A cursor advanced too broadly could authorize an unrelated mutation; validation binds every write to immutable run, watchdog, source issue, company, agent, and current fingerprint identity.
- A cursor advanced separately from the source mutation could strand or over-authorize recovery; source mutation, reclassification, cursor advance/seal, receipt, and activity audit are one transaction.
- Lock order is heartbeat run, watchdog, then target mutation, and concurrent stale writers fail closed.
- No database schema or migration is involved; state is stored in the existing heartbeat-run context JSON.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI GPT-5 Codex (`gpt-5`, tool-enabled coding agent with repository editing and command execution; context-window size is not exposed by this runtime).

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [ ] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details — the assigned engineering protocol explicitly requires the issue id in the branch name
- [ ] I have run tests locally and they pass — focused changed suites pass; unrelated repository-wide failures are documented above
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes — no user-facing documentation change is required for this internal correctness fix
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green — pending first PR run
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups — pending review
- [x] I will address all Greptile and reviewer comments before requesting merge
