### PR TITLE
fix(recovery): preserve intentional issue parking

### DIFF
--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -5804,6 +5804,47 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(wakeups).toHaveLength(2);
   });
 
+  it("preserves an intentionally parked todo issue after its successful checked-out run", async () => {
+    const { companyId, agentId, issueId } = await seedStrandedIssueFixture({
+      status: "in_progress",
+      runStatus: "succeeded",
+      livenessState: "advanced",
+    });
+    await db
+      .update(issues)
+      .set({
+        status: "todo",
+        checkoutRunId: null,
+        executionRunId: null,
+        startedAt: null,
+        updatedAt: new Date("2026-03-19T00:06:00.000Z"),
+      })
+      .where(eq(issues.id, issueId));
+    const heartbeat = heartbeatService(db);
+
+    const firstResult = await heartbeat.reconcileStrandedAssignedIssues();
+    const secondResult = await heartbeat.reconcileStrandedAssignedIssues();
+
+    expect(firstResult.issueIds).toEqual([]);
+    expect(secondResult.issueIds).toEqual([]);
+    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(issue).toMatchObject({
+      status: "todo",
+      assigneeAgentId: agentId,
+      checkoutRunId: null,
+      executionRunId: null,
+    });
+    const comments = await db.select().from(issueComments).where(eq(issueComments.issueId, issueId));
+    expect(comments).toHaveLength(0);
+    const actions = await db
+      .select()
+      .from(issueRecoveryActions)
+      .where(and(eq(issueRecoveryActions.companyId, companyId), eq(issueRecoveryActions.sourceIssueId, issueId)));
+    expect(actions).toHaveLength(0);
+    const runs = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.agentId, agentId));
+    expect(runs).toHaveLength(1);
+  });
+
 
   it("does not accept unmanaged local-background wait evidence as a live continuation path", async () => {
     const localWaitEvidence = {

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -3540,6 +3540,35 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         continue;
       }
 
+      // The candidate scan can overlap the heartbeat's final issue update. In
+      // particular, a successful run may deliberately park its issue back in
+      // `todo` after this evaluator observed it as `in_progress`. Re-read the
+      // lifecycle fields before applying recovery from that stale snapshot so
+      // the agent's explicit disposition wins.
+      const currentIssueLifecycle = await db
+        .select({
+          status: issues.status,
+          assigneeAgentId: issues.assigneeAgentId,
+          assigneeUserId: issues.assigneeUserId,
+          checkoutRunId: issues.checkoutRunId,
+          executionRunId: issues.executionRunId,
+        })
+        .from(issues)
+        .where(and(eq(issues.companyId, issue.companyId), eq(issues.id, issue.id)))
+        .limit(1)
+        .then((rows) => rows[0] ?? null);
+      if (
+        !currentIssueLifecycle ||
+        currentIssueLifecycle.status !== issue.status ||
+        currentIssueLifecycle.assigneeAgentId !== issue.assigneeAgentId ||
+        currentIssueLifecycle.assigneeUserId !== issue.assigneeUserId ||
+        currentIssueLifecycle.checkoutRunId !== issue.checkoutRunId ||
+        currentIssueLifecycle.executionRunId !== issue.executionRunId
+      ) {
+        result.skipped += 1;
+        continue;
+      }
+
       let latestRun = await getLatestIssueRun(issue.companyId, issue.id);
       if (latestRun?.status === "succeeded" && await hasPersistedDurableWaitPath(issue)) {
         result.skipped += 1;


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source control plane people use to manage AI agents and their work.
> - Its recovery subsystem detects assigned issues whose execution path has disappeared.
> - The evaluator scans candidates before deciding whether to dispatch, retry, or escalate them.
> - A successful heartbeat can intentionally park an issue back in `todo` while that scan still holds an older `in_progress` snapshot.
> - Acting on the stale snapshot can incorrectly block and reassign healthy parked work.
> - This pull request revalidates lifecycle ownership fields immediately before recovery classification and skips candidates that changed.
> - The benefit is that explicit agent dispositions win while genuinely orphaned `in_progress` work keeps the existing bounded recovery behavior.

## Linked Issues or Issue Description

### Pre-submission checklist

- [x] Searched open and closed issues; no duplicate was found.
- [x] Reproduced against `master` at `f12bb27bc`.
- [x] Confirmed this originates in Paperclip core lifecycle recovery, not an adapter, provider, or local configuration.

### What happened?

Continuation recovery can race a successful heartbeat's final issue update. If the heartbeat intentionally returns its checked-out issue to `todo`, the evaluator may still act on a stale `in_progress` candidate and create a recovery action, blocker comment, and reassignment.

### Expected behavior

Preserve the committed `todo` status and intended assignee without creating a recovery action or comment. Genuinely orphaned `in_progress` issues must still receive one bounded recovery intervention, and repeated evaluation must remain idempotent.

### Steps to reproduce

1. Start with an assigned issue and a scheduled heartbeat that checks it out to `in_progress`.
2. Let the heartbeat run succeed and explicitly park the issue back in `todo` with its original agent assignee.
3. Run stranded-assigned-issue reconciliation as its candidate scan overlaps the final disposition.
4. Observe recovery acting on the stale `in_progress` snapshot instead of preserving `todo`.

### Environment

- Paperclip commit: `f12bb27bc`
- Deployment mode: self-hosted server, built from source
- Installation method: pnpm workspace
- Adapter involvement: not adapter-specific (core bug)
- Database mode: external Postgres
- Access context: agent bearer API key plus system recovery evaluator
- Node.js: v26.1.0
- Operating system: Linux (Arch)

### Privacy checklist

- [x] Reviewed this description for usernames, paths, API keys, tokens, company names, and other PII.

## What Changed

- Re-read status, ownership, checkout, and execution lifecycle fields before applying stranded-work recovery.
- Skip recovery when those fields changed since the candidate scan, allowing the explicit issue disposition to win.
- Add a regression that evaluates an intentionally parked issue twice and verifies stable ownership with no recovery comment, action, or extra run.

## Verification

- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/heartbeat-process-recovery.test.ts` — passed, 92/92 tests.
- `pnpm -r typecheck` — passed across all workspace packages.
- `pnpm build` — passed across all workspace packages.
- `pnpm test:run` — broader run exposed two unrelated existing failures in `workspace-runtime.test.ts` (`adopts a live auto-port shared service after runtime state is reset` and `does not reuse a stopped auto-port service port while another process owns it`); the run was stopped after those environment/port-sensitive failures. The complete touched recovery suite is green.

## Risks

- Low risk. The guard only suppresses recovery for a candidate whose lifecycle or owner fields changed after scanning.
- A concurrent mutation that changes none of the guarded lifecycle fields is intentionally unaffected.
- No schema, migration, API, permission, or production-state changes.

> This is a focused lifecycle correctness fix and does not overlap a listed `ROADMAP.md` item. GitHub searches for `parked recovery` found no duplicate issue or PR.

## Model Used

- OpenAI GPT-5 Codex with reasoning, repository inspection, code editing, shell execution, and test tooling.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
