### PR TITLE
feat: adopt exact git worktrees

### DIFF
--- a/doc/DEVELOPING.md
+++ b/doc/DEVELOPING.md
@@ -531,7 +531,7 @@ For project execution worktrees, Paperclip can also run a project-defined provis
 
 ## Adopt An Existing Git Worktree As An Execution Workspace
 
-Use this control only when an operator has already created and inspected a git worktree and wants Paperclip to reuse it for exact-branch issue execution. The control is record-only: Paperclip inspects the path with read-only git commands, persists an execution workspace record, optionally binds an issue to reuse that record, and does not checkout, clean, remove, start, stop, or otherwise mutate the filesystem/git worktree.
+Use this control only when an operator has already created and inspected a git worktree and wants Paperclip to reuse it for exact-branch issue execution. The control is record-only: Paperclip inspects the path with argv-only git commands that disable repository-configured fsmonitor execution and optional Git locks/index refresh writes, persists an execution workspace record, optionally binds an issue to reuse that record, and does not checkout, clean, remove, start, stop, or otherwise mutate the filesystem/git worktree.
 
 Prerequisites:
 

--- a/doc/DEVELOPING.md
+++ b/doc/DEVELOPING.md
@@ -529,6 +529,83 @@ eval "$(pnpm paperclipai worktree env)"
 
 For project execution worktrees, Paperclip can also run a project-defined provision command after it creates or reuses an isolated git worktree. Configure this on the project's execution workspace policy (`workspaceStrategy.provisionCommand`). The command runs inside the derived worktree and receives `PAPERCLIP_WORKSPACE_*`, `PAPERCLIP_PROJECT_ID`, `PAPERCLIP_AGENT_ID`, and `PAPERCLIP_ISSUE_*` environment variables so each repo can bootstrap itself however it wants.
 
+## Adopt An Existing Git Worktree As An Execution Workspace
+
+Use this control only when an operator has already created and inspected a git worktree and wants Paperclip to reuse it for exact-branch issue execution. The control is record-only: Paperclip inspects the path with read-only git commands, persists an execution workspace record, optionally binds an issue to reuse that record, and does not checkout, clean, remove, start, stop, or otherwise mutate the filesystem/git worktree.
+
+Prerequisites:
+
+- The project and project workspace already exist in the same company.
+- The source issue is in the same company and project.
+- Optional `bindIssueId` is in the same company and project.
+- `cwd` is an existing absolute path that resolves to the worktree root.
+- `expectedBranch` is the full local branch ref, for example `refs/heads/feature/exact-adoption`.
+- `expectedHeadSha` is the exact 40-character commit SHA currently at `HEAD` and at the local branch ref.
+- `expectedUpstream` is the exact upstream reported by `git rev-parse --abbrev-ref --symbolic-full-name @{upstream}`.
+- The worktree is clean, including untracked files.
+- The local branch is not attached to another git worktree.
+
+Control:
+
+```sh
+curl -X POST "$PAPERCLIP_API_URL/api/companies/$COMPANY_ID/execution-workspaces/adopt-git-worktree" \
+  -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
+  -H "Content-Type: application/json" \
+  -H "X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID" \
+  --data '{
+    "projectId": "PROJECT_ID",
+    "projectWorkspaceId": "PROJECT_WORKSPACE_ID",
+    "sourceIssueId": "SOURCE_ISSUE_ID",
+    "bindIssueId": "OPTIONAL_BOUND_ISSUE_ID",
+    "cwd": "/absolute/path/to/worktree",
+    "expectedBranch": "refs/heads/feature/exact-adoption",
+    "expectedHeadSha": "0123456789abcdef0123456789abcdef01234567",
+    "expectedUpstream": "origin/feature/exact-adoption",
+    "expectedRepoUrl": "git@github.com:example/repo.git",
+    "name": "feature/exact-adoption"
+  }'
+```
+
+Authorization:
+
+- Authenticated non-viewer board users may adopt inside companies where they have an active membership. Agents must be same-company standard-trust principals with an explicit `execution_workspaces:adopt` grant scoped to the requested project, for example `{"projectId":"PROJECT_ID"}` or `{"projectIds":["PROJECT_ID"]}`.
+- Local trusted implicit board and instance-admin actors still follow the normal privileged development-mode behavior.
+- If `bindIssueId` is present, the actor must also pass `issue:mutate` for that issue.
+- Manage grants through the board permissions surfaces or access APIs; do not patch the database manually.
+
+Success returns `{ workspace, issue, inspection, operation }`. `workspace.metadata.adoption` contains the immutable fingerprint, expected/observed branch/SHA/upstream/repo details, canonical repo root/cwd, cleanliness counts, project/workspace/source/bound issue ids, actor, run id, and `ownsGitArtifacts: false`. Evidence is also written to:
+
+- `workspace_operations` with phase `workspace_adopt`, status `succeeded`, and `command = null`.
+- `activity_log` action `execution_workspace.adopted`.
+- If bound, `activity_log` action `issue.execution_workspace_bound`.
+- `GET /api/execution-workspaces/:id`, which includes source/bound issue summaries when available.
+- Issue heartbeat context, through the bound issue's `currentExecutionWorkspace`.
+
+Failure responses use stable redacted `reasonCode` values and do not include arbitrary git output. Common examples:
+
+```json
+{ "error": "Execution workspace adoption rejected", "reasonCode": "missing_branch" }
+{ "error": "Execution workspace adoption rejected", "reasonCode": "sha_mismatch" }
+{ "error": "Execution workspace adoption rejected", "reasonCode": "dirty_worktree" }
+{ "error": "Execution workspace adoption rejected", "reasonCode": "workspace_conflict" }
+```
+
+Retries are idempotent only when the active existing adopted record has the same immutable fingerprint. If the cwd, provider ref, or full branch ref is already registered with a different fingerprint, the control returns `409 workspace_conflict`.
+
+Rollback or disable an adopted record:
+
+```sh
+curl -X POST "$PAPERCLIP_API_URL/api/execution-workspaces/$EXECUTION_WORKSPACE_ID/rollback-adoption" \
+  -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
+  -H "Content-Type: application/json" \
+  -H "X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID" \
+  --data '{ "reason": "Operator is replacing the adopted worktree" }'
+```
+
+Rollback restores the prior issue execution workspace binding, or `null` when there was no previous binding, archives only the execution workspace record, writes `metadata.adoptionRollback`, and writes `execution_workspace.adoption_rolled_back` activity. It intentionally leaves workspace operations, activity, logs, runtime evidence, filesystem paths, git worktrees, branches, and working tree contents untouched.
+
+Operational owner: the project owner or board operator who controls the project workspace. Review adopted workspaces weekly, and immediately when an issue is reassigned, a branch is merged, or a workspace conflict appears. Treat repeated `dirty_worktree`, `branch_attached_elsewhere`, or `workspace_conflict` failures on the same project as an escalation threshold: stop adoption attempts, inspect local git state manually, then retry only with fresh exact inputs.
+
 ## App-Shipped Skills Catalog
 
 The Paperclip app ships a curated catalog of company skills out of the box. The

--- a/doc/DEVELOPING.md
+++ b/doc/DEVELOPING.md
@@ -590,7 +590,7 @@ Failure responses use stable redacted `reasonCode` values and do not include arb
 { "error": "Execution workspace adoption rejected", "reasonCode": "workspace_conflict" }
 ```
 
-Retries are idempotent only when the active existing adopted record has the same immutable fingerprint. If the cwd, provider ref, or full branch ref is already registered with a different fingerprint, the control returns `409 workspace_conflict`.
+Retries are idempotent only when the active existing adopted record has the same immutable fingerprint and bound-issue identity. Concurrent identical requests both return the same workspace; only the request that creates it returns a `workspace_adopt` operation, while the serialized retry returns `operation: null`. If the cwd, provider ref, or full branch ref is already registered with a different fingerprint or issue binding, the control returns `409 workspace_conflict`.
 
 Rollback or disable an adopted record:
 
@@ -603,6 +603,8 @@ curl -X POST "$PAPERCLIP_API_URL/api/execution-workspaces/$EXECUTION_WORKSPACE_I
 ```
 
 Rollback restores the prior issue execution workspace binding, or `null` when there was no previous binding, archives only the execution workspace record, writes `metadata.adoptionRollback`, and writes `execution_workspace.adoption_rolled_back` activity. It intentionally leaves workspace operations, activity, logs, runtime evidence, filesystem paths, git worktrees, branches, and working tree contents untouched.
+
+Rollback is single-use. Repeating the request after the adopted workspace is archived returns `409 workspace_conflict` without changing the first rollback's metadata, restored issue binding, or activity history. The same stable repeat behavior applies when the adopted workspace had no bound issue.
 
 Operational owner: the project owner or board operator who controls the project workspace. Review adopted workspaces weekly, and immediately when an issue is reassigned, a branch is merged, or a workspace conflict appears. Treat repeated `dirty_worktree`, `branch_attached_elsewhere`, or `workspace_conflict` failures on the same project as an escalation threshold: stop adoption attempts, inspect local git state manually, then retry only with fresh exact inputs.
 

--- a/doc/DEVELOPING.md
+++ b/doc/DEVELOPING.md
@@ -590,7 +590,7 @@ Failure responses use stable redacted `reasonCode` values and do not include arb
 { "error": "Execution workspace adoption rejected", "reasonCode": "workspace_conflict" }
 ```
 
-Retries are idempotent only when the active existing adopted record has the same immutable fingerprint and bound-issue identity. Concurrent identical requests both return the same workspace; only the request that creates it returns a `workspace_adopt` operation, while the serialized retry returns `operation: null`. If the cwd, provider ref, or full branch ref is already registered with a different fingerprint or issue binding, the control returns `409 workspace_conflict`.
+Retries are idempotent only when the active existing adopted record has the same immutable fingerprint and bound-issue identity. Concurrent identical requests both return the same workspace; only the request that creates it returns a `workspace_adopt` operation, while the serialized retry returns `operation: null`. Cwd/provider-ref claims remain company-wide. A full branch ref conflicts only when it is already claimed in the same project and canonical git repository; unrelated repositories/projects may adopt the same branch name. Conflicting claims return `409 workspace_conflict`.
 
 Rollback or disable an adopted record:
 

--- a/doc/DEVELOPING.md
+++ b/doc/DEVELOPING.md
@@ -606,6 +606,8 @@ Rollback restores the prior issue execution workspace binding, or `null` when th
 
 Rollback is single-use. Repeating the request after the adopted workspace is archived returns `409 workspace_conflict` without changing the first rollback's metadata, restored issue binding, or activity history. The same stable repeat behavior applies when the adopted workspace had no bound issue.
 
+Generic close/archive honors the same ownership boundary. For an adopted workspace with `metadata.ownsGitArtifacts: false`, close readiness advertises record archive only (plus runtime-service stop when applicable), and `PATCH /api/execution-workspaces/:id` with `status: "archived"` does not run workspace/project cleanup commands, teardown commands, `git worktree remove`, branch deletion, or local-directory removal. The Paperclip record archives while the operator-owned checkout remains unchanged; use the explicit single-use rollback control when issue-binding restoration is required.
+
 Operational owner: the project owner or board operator who controls the project workspace. Review adopted workspaces weekly, and immediately when an issue is reassigned, a branch is merged, or a workspace conflict appears. Treat repeated `dirty_worktree`, `branch_attached_elsewhere`, or `workspace_conflict` failures on the same project as an escalation threshold: stop adoption attempts, inspect local git state manually, then retry only with fresh exact inputs.
 
 ## App-Shipped Skills Catalog

--- a/docs/guides/board-operator/execution-workspaces-and-runtime-services.md
+++ b/docs/guides/board-operator/execution-workspaces-and-runtime-services.md
@@ -62,7 +62,7 @@ Adoption is deliberately conservative:
 
 - Authenticated non-viewer board users may adopt inside companies where they have active membership. Agent callers must be standard-trust same-company principals with an explicit `execution_workspaces:adopt` permission scoped to the target project.
 - The request must name the project, project workspace, source issue, absolute cwd, full branch ref, expected head SHA, expected upstream, and workspace name.
-- Paperclip inspects git with argv-based `git -C <cwd> ...` calls. It does not create branches, checkout refs, clean files, remove worktrees, push, pull, or otherwise mutate git during adoption.
+- Paperclip inspects git through one argv-based read-only policy that disables repository-configured fsmonitor execution and optional Git locks/index refresh writes. It does not create branches, checkout refs, clean files, remove worktrees, push, pull, or otherwise mutate git during adoption.
 - The worktree must be clean, on the exact requested `refs/heads/*` branch, at the exact requested commit, tracking the exact requested upstream, and from the expected repository.
 - The same branch cannot already be attached to another local worktree. Cwd/provider claims remain company-wide; branch/full-ref claims conflict only inside the same project and canonical git repository, so unrelated repositories/projects may use the same branch name.
 

--- a/docs/guides/board-operator/execution-workspaces-and-runtime-services.md
+++ b/docs/guides/board-operator/execution-workspaces-and-runtime-services.md
@@ -85,6 +85,18 @@ Rollback does not:
 
 Use archive/close when you intend Paperclip to perform the normal execution-workspace cleanup flow. Use adoption rollback when the adoption record or issue binding was wrong and the local filesystem/git checkout should remain untouched.
 
+### Adoption evidence, review cadence, and disable thresholds
+
+For every adoption or rollback, operators must read evidence from all of these locations:
+
+- `GET /api/execution-workspaces/:id/workspace-operations` lists the workspace's operations. For the adoption operation, read its persisted log through `GET /api/workspace-operations/:operationId/log`.
+- `GET /api/companies/:companyId/activity?entityType=execution_workspace&entityId=:id` returns the successful adoption or rollback workspace activity (`execution_workspace.adopted` or `execution_workspace.adoption_rolled_back`). Adoption validation rejections occur before a workspace exists, so read `GET /api/companies/:companyId/activity?entityType=company&entityId=:companyId` for `execution_workspace.adoption_rejected`. Rollback authorization or changed-binding conflicts return a stable HTTP `403`, `404`, or `409` without writing a rollback activity; inspect the unchanged workspace and issue readbacks instead. When an issue was bound successfully, also inspect `GET /api/issues/:issueId/activity` for `issue.execution_workspace_bound`.
+- `GET /api/execution-workspaces/:id` and `GET /api/issues/:issueId/heartbeat-context` are the two reverse readbacks. The workspace must name the bound issue and `currentExecutionWorkspace.id` must name the same workspace.
+
+The implementation author runs focused adoption and rollback checks before handoff. A non-author reviewer reviews immediately after implementation, and the CTO verifies the live route plus both reverse readbacks only after the reviewed build is running.
+
+Disable the adoption endpoint and open a high-priority Paperclip defect immediately after **one unauthorized success, one unexpected git mutation, one partial issue bind, or two unexplained HTTP 500 responses**. Keep it disabled until non-author review and CTO approval confirm the root cause and fix. Any unexpected git mutation is also a stop condition: do not retry, clean, reset, checkout, prune, or otherwise modify the affected worktree through this workflow.
+
 ## Resolved workspace logic during heartbeat runs
 
 Heartbeat still resolves a workspace for the run, but that is about code location and session continuity, not runtime-service control.

--- a/docs/guides/board-operator/execution-workspaces-and-runtime-services.md
+++ b/docs/guides/board-operator/execution-workspaces-and-runtime-services.md
@@ -64,7 +64,7 @@ Adoption is deliberately conservative:
 - The request must name the project, project workspace, source issue, absolute cwd, full branch ref, expected head SHA, expected upstream, and workspace name.
 - Paperclip inspects git with argv-based `git -C <cwd> ...` calls. It does not create branches, checkout refs, clean files, remove worktrees, push, pull, or otherwise mutate git during adoption.
 - The worktree must be clean, on the exact requested `refs/heads/*` branch, at the exact requested commit, tracking the exact requested upstream, and from the expected repository.
-- The same branch cannot already be attached to another local worktree, and the same cwd or branch cannot already be claimed by another active execution workspace.
+- The same branch cannot already be attached to another local worktree. Cwd/provider claims remain company-wide; branch/full-ref claims conflict only inside the same project and canonical git repository, so unrelated repositories/projects may use the same branch name.
 
 When adoption succeeds, Paperclip writes one execution workspace, one `workspace_adopt` operation, and activity entries in the same database transaction. If a bind issue is supplied, that issue is updated in the same transaction to `reuse_existing` and points at the adopted workspace. If the database transaction fails, the issue binding, workspace record, workspace operation, and activity entries all roll back together.
 

--- a/docs/guides/board-operator/execution-workspaces-and-runtime-services.md
+++ b/docs/guides/board-operator/execution-workspaces-and-runtime-services.md
@@ -68,11 +68,13 @@ Adoption is deliberately conservative:
 
 When adoption succeeds, Paperclip writes one execution workspace, one `workspace_adopt` operation, and activity entries in the same database transaction. If a bind issue is supplied, that issue is updated in the same transaction to `reuse_existing` and points at the adopted workspace. If the database transaction fails, the issue binding, workspace record, workspace operation, and activity entries all roll back together.
 
-The immutable adoption fingerprint is derived from the company, project, project workspace, source issue, canonical cwd, repo root, normalized repo URL, full branch ref, head SHA, and upstream. Retrying the same adoption returns the existing workspace without creating a second operation. Retrying the same exact worktree with a different issue binding is rejected as a workspace conflict.
+The immutable adoption fingerprint is derived from the company, project, project workspace, source issue, canonical cwd, repo root, normalized repo URL, full branch ref, head SHA, and upstream. Retrying the same adoption returns the existing workspace without creating a second operation, including when identical requests arrive concurrently. Retrying the same exact worktree with a different issue binding is rejected as a workspace conflict.
 
 ## Adoption rollback
 
 Rollback is also record-only. It restores the bound issue to the execution workspace binding that existed before adoption, archives the adopted workspace record with `cleanupReason: adoption_rollback`, and writes an activity entry.
+
+Rollback is single-use. Repeating rollback after the adopted workspace is archived returns `409 workspace_conflict` and leaves the original rollback metadata, issue binding, and activity history unchanged. This also applies to adopted workspaces that were not bound to an issue.
 
 Rollback does not:
 

--- a/docs/guides/board-operator/execution-workspaces-and-runtime-services.md
+++ b/docs/guides/board-operator/execution-workspaces-and-runtime-services.md
@@ -54,6 +54,37 @@ Execution workspaces are durable until a human closes them.
 - Closing an execution workspace stops its runtime services and cleans up its workspace artifacts when allowed.
 - Shared workspaces that point at the project primary checkout are treated more conservatively during cleanup than disposable isolated workspaces.
 
+## Exact-branch adoption
+
+Exact-branch adoption is the record-only path for telling Paperclip about an already-existing local git worktree. It is intended for operator workflows where the branch and checkout already exist outside Paperclip, but the control plane should track them as an execution workspace and optionally bind an issue to reuse that workspace.
+
+Adoption is deliberately conservative:
+
+- Authenticated non-viewer board users may adopt inside companies where they have active membership. Agent callers must be standard-trust same-company principals with an explicit `execution_workspaces:adopt` permission scoped to the target project.
+- The request must name the project, project workspace, source issue, absolute cwd, full branch ref, expected head SHA, expected upstream, and workspace name.
+- Paperclip inspects git with argv-based `git -C <cwd> ...` calls. It does not create branches, checkout refs, clean files, remove worktrees, push, pull, or otherwise mutate git during adoption.
+- The worktree must be clean, on the exact requested `refs/heads/*` branch, at the exact requested commit, tracking the exact requested upstream, and from the expected repository.
+- The same branch cannot already be attached to another local worktree, and the same cwd or branch cannot already be claimed by another active execution workspace.
+
+When adoption succeeds, Paperclip writes one execution workspace, one `workspace_adopt` operation, and activity entries in the same database transaction. If a bind issue is supplied, that issue is updated in the same transaction to `reuse_existing` and points at the adopted workspace. If the database transaction fails, the issue binding, workspace record, workspace operation, and activity entries all roll back together.
+
+The immutable adoption fingerprint is derived from the company, project, project workspace, source issue, canonical cwd, repo root, normalized repo URL, full branch ref, head SHA, and upstream. Retrying the same adoption returns the existing workspace without creating a second operation. Retrying the same exact worktree with a different issue binding is rejected as a workspace conflict.
+
+## Adoption rollback
+
+Rollback is also record-only. It restores the bound issue to the execution workspace binding that existed before adoption, archives the adopted workspace record with `cleanupReason: adoption_rollback`, and writes an activity entry.
+
+Rollback does not:
+
+- run cleanup commands
+- stop or start runtime services
+- remove local directories
+- remove git worktrees
+- delete or checkout branches
+- push, pull, or mutate git
+
+Use archive/close when you intend Paperclip to perform the normal execution-workspace cleanup flow. Use adoption rollback when the adoption record or issue binding was wrong and the local filesystem/git checkout should remain untouched.
+
 ## Resolved workspace logic during heartbeat runs
 
 Heartbeat still resolves a workspace for the run, but that is about code location and session continuity, not runtime-service control.

--- a/packages/db/src/migrations/0182_execution_workspace_adoption_unique_active.sql
+++ b/packages/db/src/migrations/0182_execution_workspace_adoption_unique_active.sql
@@ -8,10 +8,16 @@ CREATE UNIQUE INDEX IF NOT EXISTS execution_workspaces_active_adopted_cwd_idx
     AND COALESCE(provider_ref, cwd) IS NOT NULL;
 
 CREATE UNIQUE INDEX IF NOT EXISTS execution_workspaces_active_adopted_full_branch_idx
-  ON execution_workspaces (company_id, (metadata->>'fullBranchRef'))
+  ON execution_workspaces (
+    company_id,
+    project_id,
+    (metadata->>'repositoryIdentity'),
+    (metadata->>'fullBranchRef')
+  )
   WHERE status <> 'archived'
     AND closed_at IS NULL
     AND provider_type = 'git_worktree'
     AND strategy_type = 'git_worktree'
     AND metadata ? 'adoption'
+    AND metadata->>'repositoryIdentity' IS NOT NULL
     AND metadata->>'fullBranchRef' IS NOT NULL;

--- a/packages/db/src/migrations/0182_execution_workspace_adoption_unique_active.sql
+++ b/packages/db/src/migrations/0182_execution_workspace_adoption_unique_active.sql
@@ -1,0 +1,17 @@
+CREATE UNIQUE INDEX IF NOT EXISTS execution_workspaces_active_adopted_cwd_idx
+  ON execution_workspaces (company_id, COALESCE(provider_ref, cwd))
+  WHERE status <> 'archived'
+    AND closed_at IS NULL
+    AND provider_type = 'git_worktree'
+    AND strategy_type = 'git_worktree'
+    AND metadata ? 'adoption'
+    AND COALESCE(provider_ref, cwd) IS NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS execution_workspaces_active_adopted_full_branch_idx
+  ON execution_workspaces (company_id, (metadata->>'fullBranchRef'))
+  WHERE status <> 'archived'
+    AND closed_at IS NULL
+    AND provider_type = 'git_worktree'
+    AND strategy_type = 'git_worktree'
+    AND metadata ? 'adoption'
+    AND metadata->>'fullBranchRef' IS NOT NULL;

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -1261,6 +1261,13 @@
       "when": 1784231633059,
       "tag": "0181_decision_training_retention_policy",
       "breakpoints": true
+    },
+    {
+      "idx": 182,
+      "version": "7",
+      "when": 1784231634059,
+      "tag": "0182_execution_workspace_adoption_unique_active",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -933,6 +933,7 @@ export const PERMISSION_KEYS = [
   "tasks:assign",
   "tasks:assign_scope",
   "tasks:manage_active_checkouts",
+  "execution_workspaces:adopt",
   "pipelines:write",
   "joins:approve",
 ] as const;

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -727,6 +727,7 @@ export type {
   ExecutionWorkspaceCloseLinkedIssue,
   ExecutionWorkspaceCloseReadiness,
   ExecutionWorkspaceCloseReadinessState,
+  WorkspaceLinkedIssueSummary,
   WorkspaceOverviewItem,
   WorkspaceOverviewLinkedIssue,
   WorkspaceOverviewPrimaryService,
@@ -1326,7 +1327,13 @@ export {
   type ResourceMembershipUpdateResult,
 } from "./types/resource-memberships.js";
 
-export { workspaceRuntimeControlTargetSchema } from "./validators/execution-workspace.js";
+export {
+  adoptGitWorktreeExecutionWorkspaceSchema,
+  rollbackAdoptedExecutionWorkspaceSchema,
+  workspaceRuntimeControlTargetSchema,
+  type AdoptGitWorktreeExecutionWorkspace,
+  type RollbackAdoptedExecutionWorkspace,
+} from "./validators/execution-workspace.js";
 export {
   findWorkspaceCommandDefinition,
   listWorkspaceCommandDefinitions,

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -324,6 +324,7 @@ export type {
   ExecutionWorkspaceCloseReadinessState,
   WorkspaceOverviewItem,
   WorkspaceOverviewLinkedIssue,
+  WorkspaceLinkedIssueSummary,
   WorkspaceOverviewPrimaryService,
   WorkspaceOverviewResponse,
   ProjectWorkspaceRuntimeConfig,

--- a/packages/shared/src/types/workspace-operation.ts
+++ b/packages/shared/src/types/workspace-operation.ts
@@ -2,6 +2,7 @@ export type WorkspaceOperationPhase =
   | "worktree_prepare"
   | "workspace_config_freshness"
   | "workspace_provision"
+  | "workspace_adopt"
   | "workspace_teardown"
   | "worktree_cleanup"
   | "workspace_finalize";

--- a/packages/shared/src/types/workspace-runtime.ts
+++ b/packages/shared/src/types/workspace-runtime.ts
@@ -257,8 +257,17 @@ export interface ExecutionWorkspace {
   config: ExecutionWorkspaceConfig | null;
   metadata: Record<string, unknown> | null;
   runtimeServices?: WorkspaceRuntimeService[];
+  sourceIssue?: WorkspaceLinkedIssueSummary | null;
+  boundIssue?: WorkspaceLinkedIssueSummary | null;
   createdAt: Date;
   updatedAt: Date;
+}
+
+export interface WorkspaceLinkedIssueSummary {
+  id: string;
+  identifier: string | null;
+  title: string;
+  status: string;
 }
 
 export interface WorkspaceRuntimeService {

--- a/packages/shared/src/validators/execution-workspace.ts
+++ b/packages/shared/src/validators/execution-workspace.ts
@@ -166,6 +166,42 @@ export const reconcileExecutionWorkspaceBranchSchema = z.discriminatedUnion("mod
   }).strict(),
 ]);
 
+const safeAdoptionText = z.string()
+  .trim()
+  .min(1)
+  .max(512)
+  .refine((value) => !/[\0\r\n`$;&|<>]/.test(value), "contains unsafe shell-shaped characters");
+
+const safeAdoptionPath = z.string()
+  .trim()
+  .min(1)
+  .max(4096)
+  .refine((value) => value.startsWith("/"), "must be an absolute path")
+  .refine((value) => !/[\0\r\n`$;&|<>]/.test(value), "contains unsafe shell-shaped characters");
+
+export const adoptGitWorktreeExecutionWorkspaceSchema = z.object({
+  projectId: z.string().uuid(),
+  projectWorkspaceId: z.string().uuid(),
+  sourceIssueId: z.string().uuid(),
+  bindIssueId: z.string().uuid().optional().nullable(),
+  cwd: safeAdoptionPath,
+  expectedBranch: safeAdoptionText.refine((value) => value.startsWith("refs/heads/"), "must be a full refs/heads/* ref"),
+  expectedHeadSha: z.string().regex(/^[0-9a-f]{40}$/),
+  expectedUpstream: safeAdoptionText,
+  expectedRepoUrl: safeAdoptionText.optional().nullable(),
+  name: z.string()
+    .trim()
+    .min(1)
+    .max(160)
+    .refine((value) => !/[\0\r\n`$;&|<>]/.test(value), "contains unsafe shell-shaped characters"),
+}).strict();
+
+export const rollbackAdoptedExecutionWorkspaceSchema = z.object({
+  reason: z.string().trim().min(1).max(512).optional().nullable(),
+}).strict();
+
 export type UpdateExecutionWorkspace = z.infer<typeof updateExecutionWorkspaceSchema>;
 export type ReconcileExecutionWorkspaceBranch = z.infer<typeof reconcileExecutionWorkspaceBranchSchema>;
+export type AdoptGitWorktreeExecutionWorkspace = z.infer<typeof adoptGitWorktreeExecutionWorkspaceSchema>;
+export type RollbackAdoptedExecutionWorkspace = z.infer<typeof rollbackAdoptedExecutionWorkspaceSchema>;
 export type WorkspaceOverviewQuery = z.infer<typeof workspaceOverviewQuerySchema>;

--- a/packages/shared/src/validators/index.ts
+++ b/packages/shared/src/validators/index.ts
@@ -505,7 +505,9 @@ export {
 
 export {
   executionWorkspaceConfigSchema,
+  adoptGitWorktreeExecutionWorkspaceSchema,
   reconcileExecutionWorkspaceBranchSchema,
+  rollbackAdoptedExecutionWorkspaceSchema,
   updateExecutionWorkspaceSchema,
   workspaceOverviewQuerySchema,
   executionWorkspaceStatusSchema,
@@ -515,7 +517,9 @@ export {
   executionWorkspaceCloseLinkedIssueSchema,
   executionWorkspaceCloseReadinessSchema,
   executionWorkspaceCloseReadinessStateSchema,
+  type AdoptGitWorktreeExecutionWorkspace,
   type ReconcileExecutionWorkspaceBranch,
+  type RollbackAdoptedExecutionWorkspace,
   type UpdateExecutionWorkspace,
   type WorkspaceOverviewQuery,
 } from "./execution-workspace.js";

--- a/server/src/__tests__/authorization-service.test.ts
+++ b/server/src/__tests__/authorization-service.test.ts
@@ -794,6 +794,9 @@ describeEmbeddedPostgres("authorization service", () => {
       },
     });
 
+    await grantAgentPermission(db, company.id, actorAgent.id, "execution_workspaces:adopt", {
+      projectIds: [project.id],
+    });
     const authorization = authorizationService(db);
     const actor = { type: "agent" as const, agentId: actorAgent.id, companyId: company.id, source: "agent_key" as const };
 
@@ -821,6 +824,12 @@ describeEmbeddedPostgres("authorization service", () => {
       actor,
       action: "company_scope:read",
       resource: { type: "company", companyId: company.id },
+    })).resolves.toMatchObject({ allowed: false, reason: "deny_low_trust_boundary" });
+    await expect(authorization.decide({
+      actor,
+      action: "execution_workspaces:adopt",
+      resource: { type: "project", companyId: company.id, projectId: project.id },
+      scope: { projectId: project.id },
     })).resolves.toMatchObject({ allowed: false, reason: "deny_low_trust_boundary" });
     await expect(authorization.decide({
       actor,
@@ -1589,6 +1598,57 @@ describeEmbeddedPostgres("authorization service", () => {
       reason: "deny_scope",
     });
     expect(denied.explanation).toContain("does not cover the requested scope");
+  });
+
+  it("allows non-viewer board members and requires explicit project-scoped agent grants for exact worktree adoption", async () => {
+    const company = await createCompany(db, "WorkspaceAdoptScope");
+    const project = await createProject(db, company.id, "Allowed");
+    const otherProject = await createProject(db, company.id, "Denied");
+    const userId = await createUser(db);
+    const actorAgent = await createAgent(db, company.id);
+
+    await db.insert(companyMemberships).values({
+      companyId: company.id,
+      principalType: "user",
+      principalId: userId,
+      status: "active",
+      membershipRole: "operator",
+    });
+    await grantAgentPermission(db, company.id, actorAgent.id, "execution_workspaces:adopt", {
+      projectIds: [project.id],
+    });
+
+    const boardAllowed = await authorizationService(db).decide({
+      actor: { type: "board", userId, companyIds: [company.id], source: "session" },
+      action: "execution_workspaces:adopt",
+      resource: { type: "project", companyId: company.id, projectId: project.id },
+      scope: { projectId: project.id },
+    });
+    const agentAllowed = await authorizationService(db).decide({
+      actor: { type: "agent", agentId: actorAgent.id, companyId: company.id, source: "agent_key" },
+      action: "execution_workspaces:adopt",
+      resource: { type: "project", companyId: company.id, projectId: project.id },
+      scope: { projectId: project.id },
+    });
+    const agentDenied = await authorizationService(db).decide({
+      actor: { type: "agent", agentId: actorAgent.id, companyId: company.id, source: "agent_key" },
+      action: "execution_workspaces:adopt",
+      resource: { type: "project", companyId: company.id, projectId: otherProject.id },
+      scope: { projectId: otherProject.id },
+    });
+
+    expect(boardAllowed).toMatchObject({
+      allowed: true,
+      reason: "allow_simple_company_member",
+    });
+    expect(agentAllowed).toMatchObject({
+      allowed: true,
+      grant: { permissionKey: "execution_workspaces:adopt" },
+    });
+    expect(agentDenied).toMatchObject({
+      allowed: false,
+      reason: "deny_scope",
+    });
   });
 
   it("treats unknown grant scope metadata as unconstrained", async () => {

--- a/server/src/__tests__/authorization-service.test.ts
+++ b/server/src/__tests__/authorization-service.test.ts
@@ -1651,6 +1651,26 @@ describeEmbeddedPostgres("authorization service", () => {
     });
   });
 
+  it("fails closed when an adoption grant scope has no recognized project constraint", async () => {
+    const company = await createCompany(db, "WorkspaceAdoptUnknownScope");
+    const project = await createProject(db, company.id, "Target");
+    const actorAgent = await createAgent(db, company.id);
+    await grantAgentPermission(db, company.id, actorAgent.id, "execution_workspaces:adopt", {
+      note: "metadata is not a project constraint",
+    });
+
+    const decision = await authorizationService(db).decidePrincipalGrant({
+      companyId: company.id,
+      principalType: "agent",
+      principalId: actorAgent.id,
+      action: "execution_workspaces:adopt",
+      permissionKey: "execution_workspaces:adopt",
+      scope: { projectId: project.id },
+    });
+
+    expect(decision).toMatchObject({ allowed: false, reason: "deny_scope" });
+  });
+
   it("treats unknown grant scope metadata as unconstrained", async () => {
     const company = await createCompany(db, "UnknownScopeMetadata");
     const actorAgent = await createAgent(db, company.id);

--- a/server/src/__tests__/execution-workspaces-routes.test.ts
+++ b/server/src/__tests__/execution-workspaces-routes.test.ts
@@ -538,6 +538,203 @@ describe.sequential("execution workspace routes", () => {
     expect(mockCleanupExecutionWorkspaceArtifacts).not.toHaveBeenCalled();
   });
 
+  it("rejects ownership escalation before archive and keeps adopted cleanup record-only", async () => {
+    const existing = {
+      id: "workspace-1",
+      companyId: "company-1",
+      projectId: "11111111-1111-4111-8111-111111111111",
+      projectWorkspaceId: "22222222-2222-4222-8222-222222222222",
+      sourceIssueId: "33333333-3333-4333-8333-333333333333",
+      mode: "isolated_workspace",
+      strategyType: "git_worktree",
+      name: "Adopted workspace",
+      status: "active",
+      closedAt: null,
+      cwd: "/tmp/operator-worktree",
+      repoUrl: "ssh://git@example.com/paperclip/repo",
+      baseRef: "origin/main",
+      branchName: "feature/adopted",
+      providerType: "git_worktree",
+      providerRef: "/tmp/operator-worktree",
+      metadata: {
+        createdByRuntime: false,
+        ownsGitArtifacts: false,
+        fullBranchRef: "refs/heads/feature/adopted",
+        adoption: {
+          version: 1,
+          immutableFingerprint: "execution_workspace_adoption:v1:sha256:original",
+        },
+      },
+    };
+    mockExecutionWorkspaceService.getById.mockResolvedValue(existing);
+    mockExecutionWorkspaceService.getCloseReadiness.mockResolvedValue({
+      workspaceId: existing.id,
+      state: "ready",
+      blockingReasons: [],
+      warnings: [],
+      plannedActions: [{ kind: "archive_record", command: null }],
+    });
+    mockExecutionWorkspaceService.update.mockImplementation(async (_id, patch) => ({ ...existing, ...patch }));
+
+    const escalation = await request(createApp())
+      .patch(`/api/execution-workspaces/${existing.id}`)
+      .send({
+        metadata: {
+          ...existing.metadata,
+          ownsGitArtifacts: true,
+        },
+      });
+
+    expect(escalation.status).toBe(409);
+    expect(escalation.body).toEqual({
+      error: "Adopted execution workspace identity is immutable",
+      reasonCode: "adopted_workspace_identity_immutable",
+    });
+    expect(mockExecutionWorkspaceService.update).not.toHaveBeenCalled();
+    expect(mockDestroyReusableSandboxLeases).not.toHaveBeenCalled();
+    expect(mockStopRuntimeServicesForExecutionWorkspace).not.toHaveBeenCalled();
+    expect(mockCleanupExecutionWorkspaceArtifacts).not.toHaveBeenCalled();
+    expect(mockLogActivity).not.toHaveBeenCalled();
+
+    const archive = await request(createApp())
+      .patch(`/api/execution-workspaces/${existing.id}`)
+      .send({ status: "archived" });
+
+    expect(archive.status).toBe(200);
+    expect(mockExecutionWorkspaceService.update).toHaveBeenCalledTimes(1);
+    expect(mockCleanupExecutionWorkspaceArtifacts).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["adoption metadata removal", { metadata: null }],
+    ["adoption fingerprint rewrite", {
+      metadata: {
+        createdByRuntime: false,
+        ownsGitArtifacts: false,
+        fullBranchRef: "refs/heads/feature/adopted",
+        adoption: {
+          version: 1,
+          immutableFingerprint: "execution_workspace_adoption:v1:sha256:rewritten",
+        },
+      },
+    }],
+    ["cwd mutation", { cwd: "/tmp/other" }],
+    ["provider ref mutation", { providerRef: "/tmp/other" }],
+    ["repository mutation", { repoUrl: "ssh://git@example.com/other/repo" }],
+    ["branch mutation", { branchName: "feature/other" }],
+    ["base ref mutation", { baseRef: "origin/other" }],
+  ])("rejects adopted workspace %s without side effects", async (_label, patch) => {
+    mockExecutionWorkspaceService.getById.mockResolvedValue({
+      id: "workspace-1",
+      companyId: "company-1",
+      status: "active",
+      closedAt: null,
+      cwd: "/tmp/operator-worktree",
+      repoUrl: "ssh://git@example.com/paperclip/repo",
+      baseRef: "origin/main",
+      branchName: "feature/adopted",
+      providerRef: "/tmp/operator-worktree",
+      metadata: {
+        createdByRuntime: false,
+        ownsGitArtifacts: false,
+        fullBranchRef: "refs/heads/feature/adopted",
+        adoption: {
+          version: 1,
+          immutableFingerprint: "execution_workspace_adoption:v1:sha256:original",
+        },
+      },
+    });
+
+    const res = await request(createApp())
+      .patch("/api/execution-workspaces/workspace-1")
+      .send(patch);
+
+    expect(res.status).toBe(409);
+    expect(res.body.reasonCode).toBe("adopted_workspace_identity_immutable");
+    expect(mockExecutionWorkspaceService.update).not.toHaveBeenCalled();
+    expect(mockDestroyReusableSandboxLeases).not.toHaveBeenCalled();
+    expect(mockStopRuntimeServicesForExecutionWorkspace).not.toHaveBeenCalled();
+    expect(mockCleanupExecutionWorkspaceArtifacts).not.toHaveBeenCalled();
+    expect(mockLogActivity).not.toHaveBeenCalled();
+  });
+
+  it("preserves adopted metadata for allowlisted name and config updates", async () => {
+    const existing = {
+      id: "workspace-1",
+      companyId: "company-1",
+      status: "active",
+      closedAt: null,
+      metadata: {
+        createdByRuntime: false,
+        ownsGitArtifacts: false,
+        fullBranchRef: "refs/heads/feature/adopted",
+        adoption: {
+          version: 1,
+          immutableFingerprint: "execution_workspace_adoption:v1:sha256:original",
+        },
+      },
+    };
+    mockExecutionWorkspaceService.getById.mockResolvedValue(existing);
+    mockExecutionWorkspaceService.update.mockImplementation(async (_id, patch) => ({ ...existing, ...patch }));
+
+    const res = await request(createApp())
+      .patch(`/api/execution-workspaces/${existing.id}`)
+      .send({
+        name: "Updated label",
+        config: { provisionCommand: "pnpm install" },
+      });
+
+    expect(res.status).toBe(200);
+    expect(mockExecutionWorkspaceService.update).toHaveBeenCalledWith(existing.id, {
+      name: "Updated label",
+      metadata: expect.objectContaining({
+        ...existing.metadata,
+        config: expect.objectContaining({ provisionCommand: "pnpm install" }),
+      }),
+    });
+    expect(mockLogActivity).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps ordinary runtime-owned workspace updates valid", async () => {
+    const existing = {
+      id: "workspace-1",
+      companyId: "company-1",
+      status: "active",
+      cwd: "/tmp/runtime-worktree",
+      providerRef: "/tmp/runtime-worktree",
+      metadata: {
+        createdByRuntime: true,
+        ownsGitArtifacts: true,
+      },
+    };
+    mockExecutionWorkspaceService.getById.mockResolvedValue(existing);
+    mockExecutionWorkspaceService.update.mockImplementation(async (_id, patch) => ({ ...existing, ...patch }));
+
+    const res = await request(createApp())
+      .patch(`/api/execution-workspaces/${existing.id}`)
+      .send({
+        cwd: "/tmp/runtime-worktree-moved",
+        providerRef: "/tmp/runtime-worktree-moved",
+        metadata: {
+          createdByRuntime: true,
+          ownsGitArtifacts: true,
+          runtimeNote: "refreshed",
+        },
+      });
+
+    expect(res.status).toBe(200);
+    expect(mockExecutionWorkspaceService.update).toHaveBeenCalledWith(existing.id, {
+      cwd: "/tmp/runtime-worktree-moved",
+      providerRef: "/tmp/runtime-worktree-moved",
+      metadata: {
+        createdByRuntime: true,
+        ownsGitArtifacts: true,
+        runtimeNote: "refreshed",
+      },
+    });
+    expect(mockLogActivity).toHaveBeenCalledTimes(1);
+  });
+
   it.each([
     ["forward", { mode: "forward" }],
     ["override", { mode: "override", reason: "operator break-glass" }],

--- a/server/src/__tests__/execution-workspaces-routes.test.ts
+++ b/server/src/__tests__/execution-workspaces-routes.test.ts
@@ -10,6 +10,8 @@ const mockExecutionWorkspaceService = vi.hoisted(() => ({
   listSummaries: vi.fn(),
   getById: vi.fn(),
   getCloseReadiness: vi.fn(),
+  adoptGitWorktree: vi.fn(),
+  rollbackAdoption: vi.fn(),
   reconcileExecutionWorkspaceBranch: vi.fn(),
   update: vi.fn(),
 }));
@@ -42,14 +44,14 @@ function createApp(actor: Record<string, unknown> = {
   companyIds: ["company-1"],
   source: "session",
   isInstanceAdmin: false,
-}) {
+}, db: unknown = {}) {
   const app = express();
   app.use(express.json());
   app.use((req, _res, next) => {
     (req as any).actor = actor;
     next();
   });
-  app.use("/api", executionWorkspaceRoutes({} as any));
+  app.use("/api", executionWorkspaceRoutes(db as any));
   app.use(errorHandler);
   return app;
 }
@@ -81,6 +83,18 @@ describe.sequential("execution workspace routes", () => {
       },
     ]);
     mockExecutionWorkspaceService.getById.mockResolvedValue(null);
+    mockExecutionWorkspaceService.adoptGitWorktree.mockResolvedValue({
+      workspace: { id: "workspace-1", companyId: "company-1", projectId: "11111111-1111-4111-8111-111111111111" },
+      issue: null,
+      inspection: { status: "accepted", reasonCode: null },
+      operation: { id: "operation-1" },
+    });
+    mockExecutionWorkspaceService.rollbackAdoption.mockResolvedValue({
+      id: "workspace-1",
+      companyId: "company-1",
+      projectId: "11111111-1111-4111-8111-111111111111",
+      status: "archived",
+    });
     mockExecutionWorkspaceService.reconcileExecutionWorkspaceBranch.mockResolvedValue(null);
     mockHeartbeatService.wakeup.mockResolvedValue(null);
   });
@@ -134,6 +148,166 @@ describe.sequential("execution workspace routes", () => {
 
     expect(res.status).toBe(422);
     expect(mockExecutionWorkspaceService.listOverview).not.toHaveBeenCalled();
+  });
+
+  it("rejects adoption validation failures with redacted activity when company scope is established", async () => {
+    const res = await request(createApp())
+      .post("/api/companies/company-1/execution-workspaces/adopt-git-worktree")
+      .send({
+        projectId: "11111111-1111-4111-8111-111111111111",
+        projectWorkspaceId: "22222222-2222-4222-8222-222222222222",
+        sourceIssueId: "33333333-3333-4333-8333-333333333333",
+        cwd: "/tmp/worktree; rm -rf /",
+        expectedBranch: "refs/heads/feature/adopt",
+        expectedHeadSha: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        expectedUpstream: "origin/feature/adopt",
+        name: "feature/adopt",
+      });
+
+    expect(res.status).toBe(422);
+    expect(res.body).toMatchObject({ reasonCode: "unsafe_input" });
+    expect(mockExecutionWorkspaceService.adoptGitWorktree).not.toHaveBeenCalled();
+    expect(mockLogActivity).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
+      action: "execution_workspace.adoption_rejected",
+      entityType: "company",
+      entityId: "company-1",
+      details: { reasonCode: "unsafe_input" },
+    }));
+  });
+
+  it("allows board adoption and delegates exact validated input", async () => {
+    const body = {
+      projectId: "11111111-1111-4111-8111-111111111111",
+      projectWorkspaceId: "22222222-2222-4222-8222-222222222222",
+      sourceIssueId: "33333333-3333-4333-8333-333333333333",
+      cwd: "/tmp/worktree",
+      expectedBranch: "refs/heads/feature/adopt",
+      expectedHeadSha: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      expectedUpstream: "origin/feature/adopt",
+      expectedRepoUrl: "git@example.com:paperclip/repo.git",
+      name: "feature/adopt",
+    };
+
+    const res = await request(createApp())
+      .post("/api/companies/company-1/execution-workspaces/adopt-git-worktree")
+      .send(body);
+
+    expect(res.status).toBe(201);
+    expect(mockAccessService.decide).toHaveBeenCalledWith(expect.objectContaining({
+      action: "execution_workspaces:adopt",
+      resource: { type: "project", companyId: "company-1", projectId: body.projectId },
+      scope: { projectId: body.projectId },
+    }));
+    expect(mockExecutionWorkspaceService.adoptGitWorktree).toHaveBeenCalledWith("company-1", body, {
+      actorType: "user",
+      actorId: "local-board",
+      agentId: null,
+      runId: null,
+    });
+  });
+
+  it("requires independent issue mutation authorization when binding an adopted workspace", async () => {
+    const bindIssueId = "44444444-4444-4444-8444-444444444444";
+    const projectId = "11111111-1111-4111-8111-111111111111";
+    const db = {
+      select: vi.fn(() => ({
+        from: () => ({
+          where: () => ({
+            limit: async () => [{
+              id: bindIssueId,
+              companyId: "company-1",
+              projectId,
+              parentId: null,
+              assigneeAgentId: "other-agent",
+              assigneeUserId: null,
+              status: "todo",
+              originKind: "manual",
+              originId: null,
+            }],
+          }),
+        }),
+      })),
+    };
+
+    const body = {
+      projectId,
+      projectWorkspaceId: "22222222-2222-4222-8222-222222222222",
+      sourceIssueId: "33333333-3333-4333-8333-333333333333",
+      bindIssueId,
+      cwd: "/tmp/worktree",
+      expectedBranch: "refs/heads/feature/adopt",
+      expectedHeadSha: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      expectedUpstream: "origin/feature/adopt",
+      name: "feature/adopt",
+    };
+
+    const res = await request(createApp(undefined, db))
+      .post("/api/companies/company-1/execution-workspaces/adopt-git-worktree")
+      .send(body);
+
+    expect(res.status).toBe(201);
+    expect(mockAccessService.decide).toHaveBeenCalledWith(expect.objectContaining({
+      action: "issue:mutate",
+      resource: expect.objectContaining({
+        issueId: bindIssueId,
+        assigneeAgentId: "other-agent",
+        status: "todo",
+      }),
+    }));
+  });
+
+  it("denies agent adoption before service inspection when no project grant is available", async () => {
+    mockAccessService.decide.mockResolvedValueOnce({
+      allowed: false,
+      action: "execution_workspaces:adopt",
+      reason: "deny_missing_grant",
+      explanation: "Missing permission.",
+    });
+
+    const res = await request(createApp({
+      type: "agent",
+      agentId: "agent-1",
+      companyId: "company-1",
+      source: "agent_jwt",
+      runId: "run-1",
+    }))
+      .post("/api/companies/company-1/execution-workspaces/adopt-git-worktree")
+      .send({
+        projectId: "11111111-1111-4111-8111-111111111111",
+        projectWorkspaceId: "22222222-2222-4222-8222-222222222222",
+        sourceIssueId: "33333333-3333-4333-8333-333333333333",
+        cwd: "/tmp/worktree",
+        expectedBranch: "refs/heads/feature/adopt",
+        expectedHeadSha: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        expectedUpstream: "origin/feature/adopt",
+        name: "feature/adopt",
+      });
+
+    expect(res.status).toBe(404);
+    expect(res.body).toMatchObject({ reasonCode: "cross_scope_not_found" });
+    expect(mockExecutionWorkspaceService.adoptGitWorktree).not.toHaveBeenCalled();
+  });
+
+  it("rolls back adopted records through the record-only rollback service", async () => {
+    mockExecutionWorkspaceService.getById.mockResolvedValue({
+      id: "workspace-1",
+      companyId: "company-1",
+      projectId: "11111111-1111-4111-8111-111111111111",
+      sourceIssueId: "issue-1",
+    });
+
+    const res = await request(createApp())
+      .post("/api/execution-workspaces/workspace-1/rollback-adoption")
+      .send({ reason: "operator rollback" });
+
+    expect(res.status).toBe(200);
+    expect(mockExecutionWorkspaceService.rollbackAdoption).toHaveBeenCalledWith("workspace-1", {
+      actorType: "user",
+      actorId: "local-board",
+      agentId: null,
+      runId: null,
+    }, "operator rollback");
+    expect(mockExecutionWorkspaceService.update).not.toHaveBeenCalled();
   });
 
   it.each([

--- a/server/src/__tests__/execution-workspaces-routes.test.ts
+++ b/server/src/__tests__/execution-workspaces-routes.test.ts
@@ -362,12 +362,17 @@ describe.sequential("execution workspace routes", () => {
     expect(mockExecutionWorkspaceService.rollbackAdoption).not.toHaveBeenCalled();
   });
 
-  it("returns a stable conflict when rollback observes a changed binding", async () => {
+  it("returns a stable conflict when an unbound adopted workspace was already rolled back", async () => {
     mockExecutionWorkspaceService.getById.mockResolvedValue({
       id: "workspace-1",
       companyId: "company-1",
       projectId: "11111111-1111-4111-8111-111111111111",
-      metadata: { adoption: { boundIssueId: null } },
+      status: "archived",
+      cleanupReason: "adoption_rollback",
+      metadata: {
+        adoption: { boundIssueId: null },
+        adoptionRollback: { version: 1, reason: "first rollback" },
+      },
     });
     mockExecutionWorkspaceService.rollbackAdoption.mockRejectedValue(
       new ExecutionWorkspaceAdoptionError("workspace_conflict", 409),
@@ -382,6 +387,12 @@ describe.sequential("execution workspace routes", () => {
       error: "Execution workspace adoption rollback rejected",
       reasonCode: "workspace_conflict",
     });
+    expect(mockExecutionWorkspaceService.rollbackAdoption).toHaveBeenCalledWith("workspace-1", {
+      actorType: "user",
+      actorId: "local-board",
+      agentId: null,
+      runId: null,
+    }, "operator rollback", null, null);
   });
 
   it.each([

--- a/server/src/__tests__/execution-workspaces-routes.test.ts
+++ b/server/src/__tests__/execution-workspaces-routes.test.ts
@@ -3,6 +3,7 @@ import request from "supertest";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { errorHandler } from "../middleware/index.js";
 import { executionWorkspaceRoutes } from "../routes/execution-workspaces.js";
+import { ExecutionWorkspaceAdoptionError } from "../services/execution-workspaces.js";
 
 const mockExecutionWorkspaceService = vi.hoisted(() => ({
   list: vi.fn(),
@@ -203,7 +204,7 @@ describe.sequential("execution workspace routes", () => {
       actorId: "local-board",
       agentId: null,
       runId: null,
-    });
+    }, null);
   });
 
   it("requires independent issue mutation authorization when binding an adopted workspace", async () => {
@@ -221,6 +222,7 @@ describe.sequential("execution workspace routes", () => {
               assigneeAgentId: "other-agent",
               assigneeUserId: null,
               status: "todo",
+              executionPolicy: null,
               originKind: "manual",
               originId: null,
             }],
@@ -254,6 +256,12 @@ describe.sequential("execution workspace routes", () => {
         status: "todo",
       }),
     }));
+    expect(mockExecutionWorkspaceService.adoptGitWorktree).toHaveBeenCalledWith(
+      "company-1",
+      body,
+      expect.any(Object),
+      expect.objectContaining({ id: bindIssueId, assigneeAgentId: "other-agent", status: "todo" }),
+    );
   });
 
   it("denies agent adoption before service inspection when no project grant is available", async () => {
@@ -306,8 +314,74 @@ describe.sequential("execution workspace routes", () => {
       actorId: "local-board",
       agentId: null,
       runId: null,
-    }, "operator rollback");
+    }, "operator rollback", null, null);
     expect(mockExecutionWorkspaceService.update).not.toHaveBeenCalled();
+  });
+
+  it("requires independent issue mutation authorization before rollback", async () => {
+    const bindIssueId = "44444444-4444-4444-8444-444444444444";
+    const projectId = "11111111-1111-4111-8111-111111111111";
+    mockExecutionWorkspaceService.getById.mockResolvedValue({
+      id: "workspace-1",
+      companyId: "company-1",
+      projectId,
+      metadata: { adoption: { boundIssueId: "44444444-4444-4444-8444-444444444444" } },
+    });
+    mockAccessService.decide
+      .mockResolvedValueOnce({ allowed: true, action: "execution_workspaces:adopt", reason: "allow_test" })
+      .mockResolvedValueOnce({ allowed: false, action: "issue:mutate", reason: "deny_test" });
+    const db = {
+      select: vi.fn(() => ({
+        from: () => ({
+          where: () => ({
+            limit: async () => [{
+              id: bindIssueId,
+              parentId: null,
+              assigneeAgentId: "other-agent",
+              assigneeUserId: null,
+              status: "todo",
+              executionPolicy: null,
+              originKind: "manual",
+              originId: null,
+            }],
+          }),
+        }),
+      })),
+    };
+
+    const res = await request(createApp(undefined, db))
+      .post("/api/execution-workspaces/workspace-1/rollback-adoption")
+      .send({ reason: "operator rollback" });
+
+    expect(res.status).toBe(403);
+    expect(res.body).toMatchObject({ reasonCode: "unauthorized" });
+    expect(mockAccessService.decide).toHaveBeenLastCalledWith(expect.objectContaining({
+      action: "issue:mutate",
+      resource: expect.objectContaining({ issueId: bindIssueId }),
+    }));
+    expect(mockExecutionWorkspaceService.rollbackAdoption).not.toHaveBeenCalled();
+  });
+
+  it("returns a stable conflict when rollback observes a changed binding", async () => {
+    mockExecutionWorkspaceService.getById.mockResolvedValue({
+      id: "workspace-1",
+      companyId: "company-1",
+      projectId: "11111111-1111-4111-8111-111111111111",
+      metadata: { adoption: { boundIssueId: null } },
+    });
+    mockExecutionWorkspaceService.rollbackAdoption.mockRejectedValue(
+      new ExecutionWorkspaceAdoptionError("workspace_conflict", 409),
+    );
+
+    const res = await request(createApp())
+      .post("/api/execution-workspaces/workspace-1/rollback-adoption")
+      .send({ reason: "operator rollback" });
+
+    expect(res.status).toBe(409);
+    expect(res.body).toEqual({
+      error: "Execution workspace adoption rollback rejected",
+      reasonCode: "workspace_conflict",
+    });
   });
 
   it.each([

--- a/server/src/__tests__/execution-workspaces-routes.test.ts
+++ b/server/src/__tests__/execution-workspaces-routes.test.ts
@@ -695,6 +695,45 @@ describe.sequential("execution workspace routes", () => {
     expect(mockLogActivity).toHaveBeenCalledTimes(1);
   });
 
+  it.each([
+    ["adoption", { version: 1, immutableFingerprint: "execution_workspace_adoption:v1:sha256:forged" }],
+    ["adoptionRollback", { version: 1, reason: "forged" }],
+    ["fullBranchRef", "refs/heads/feature/forged"],
+    ["ownsGitArtifacts", true],
+    ["createdByRuntime", false],
+  ])("rejects forged server-owned %s metadata on a normal workspace before side effects", async (key, value) => {
+    const existing = {
+      id: "workspace-1",
+      companyId: "company-1",
+      status: "active",
+      metadata: { runtimeNote: "ordinary" },
+    };
+    mockExecutionWorkspaceService.getById.mockResolvedValue(existing);
+
+    const res = await request(createApp())
+      .patch(`/api/execution-workspaces/${existing.id}`)
+      .send({
+        name: "Attempted forged adoption",
+        metadata: {
+          ...existing.metadata,
+          runtimeNote: "still ordinary",
+          [key]: value,
+        },
+      });
+
+    expect(res.status).toBe(409);
+    expect(res.body).toEqual({
+      error: "Execution workspace server-owned metadata is immutable",
+      reasonCode: "execution_workspace_server_owned_metadata_immutable",
+      protectedKeys: [key],
+    });
+    expect(mockExecutionWorkspaceService.update).not.toHaveBeenCalled();
+    expect(mockDestroyReusableSandboxLeases).not.toHaveBeenCalled();
+    expect(mockStopRuntimeServicesForExecutionWorkspace).not.toHaveBeenCalled();
+    expect(mockCleanupExecutionWorkspaceArtifacts).not.toHaveBeenCalled();
+    expect(mockLogActivity).not.toHaveBeenCalled();
+  });
+
   it("keeps ordinary runtime-owned workspace updates valid", async () => {
     const existing = {
       id: "workspace-1",

--- a/server/src/__tests__/execution-workspaces-routes.test.ts
+++ b/server/src/__tests__/execution-workspaces-routes.test.ts
@@ -30,6 +30,9 @@ const mockAccessService = vi.hoisted(() => ({
   decide: vi.fn(),
 }));
 const mockLogActivity = vi.hoisted(() => vi.fn(async () => undefined));
+const mockCleanupExecutionWorkspaceArtifacts = vi.hoisted(() => vi.fn());
+const mockStopRuntimeServicesForExecutionWorkspace = vi.hoisted(() => vi.fn(async () => undefined));
+const mockDestroyReusableSandboxLeases = vi.hoisted(() => vi.fn(async () => []));
 
 vi.mock("../services/index.js", () => ({
   accessService: () => mockAccessService,
@@ -37,6 +40,22 @@ vi.mock("../services/index.js", () => ({
   heartbeatService: () => mockHeartbeatService,
   logActivity: mockLogActivity,
   workspaceOperationService: () => mockWorkspaceOperationService,
+}));
+
+vi.mock("../services/workspace-runtime.js", () => ({
+  buildWorkspaceRuntimeDesiredStatePatch: vi.fn(),
+  cleanupExecutionWorkspaceArtifacts: mockCleanupExecutionWorkspaceArtifacts,
+  ensurePersistedExecutionWorkspaceAvailable: vi.fn(),
+  listConfiguredRuntimeServiceEntries: vi.fn(),
+  runWorkspaceJobForControl: vi.fn(),
+  startRuntimeServicesForWorkspaceControl: vi.fn(),
+  stopRuntimeServicesForExecutionWorkspace: mockStopRuntimeServicesForExecutionWorkspace,
+}));
+
+vi.mock("../services/environment-runtime.js", () => ({
+  environmentRuntimeService: () => ({
+    destroyReusableSandboxLeases: mockDestroyReusableSandboxLeases,
+  }),
 }));
 
 function createApp(actor: Record<string, unknown> = {
@@ -98,6 +117,11 @@ describe.sequential("execution workspace routes", () => {
     });
     mockExecutionWorkspaceService.reconcileExecutionWorkspaceBranch.mockResolvedValue(null);
     mockHeartbeatService.wakeup.mockResolvedValue(null);
+    mockCleanupExecutionWorkspaceArtifacts.mockResolvedValue({
+      cleanedPath: "/tmp/worktree",
+      cleaned: true,
+      warnings: [],
+    });
   });
 
   it("uses summary mode for lightweight workspace lookups", async () => {
@@ -444,6 +468,74 @@ describe.sequential("execution workspace routes", () => {
       error: "Execution workspace adoption rollback rejected",
       reasonCode: "workspace_conflict",
     });
+  });
+
+  it("archives an adopted workspace record without scheduling artifact cleanup", async () => {
+    const existing = {
+      id: "workspace-1",
+      companyId: "company-1",
+      projectId: "11111111-1111-4111-8111-111111111111",
+      projectWorkspaceId: "22222222-2222-4222-8222-222222222222",
+      sourceIssueId: "33333333-3333-4333-8333-333333333333",
+      mode: "isolated_workspace",
+      strategyType: "git_worktree",
+      name: "Adopted workspace",
+      status: "active",
+      cwd: "/tmp/worktree",
+      repoUrl: "git@example.com:paperclip/repo.git",
+      baseRef: "main",
+      branchName: "feature/adopted",
+      providerType: "git_worktree",
+      providerRef: "/tmp/worktree",
+      metadata: {
+        createdByRuntime: false,
+        ownsGitArtifacts: false,
+        config: {
+          cleanupCommand: "node ./scripts/cleanup.js",
+          teardownCommand: "node ./scripts/teardown.js",
+        },
+      },
+    };
+    const archived = {
+      ...existing,
+      status: "archived",
+      closedAt: new Date(),
+    };
+    mockExecutionWorkspaceService.getById.mockResolvedValue(existing);
+    mockExecutionWorkspaceService.getCloseReadiness.mockResolvedValue({
+      workspaceId: existing.id,
+      state: "ready",
+      blockingReasons: [],
+      warnings: [],
+      plannedActions: [{
+        kind: "archive_record",
+        label: "Archive workspace record",
+        description: "Record only",
+        command: null,
+      }],
+    });
+    mockExecutionWorkspaceService.update.mockResolvedValue(archived);
+
+    const res = await request(createApp())
+      .patch(`/api/execution-workspaces/${existing.id}`)
+      .send({ status: "archived" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe("archived");
+    expect(mockExecutionWorkspaceService.update).toHaveBeenCalledWith(existing.id, expect.objectContaining({
+      status: "archived",
+      cleanupReason: null,
+    }));
+    expect(mockDestroyReusableSandboxLeases).toHaveBeenCalledWith({
+      companyId: existing.companyId,
+      executionWorkspaceId: existing.id,
+      failureReason: "execution_workspace_closed",
+    });
+    expect(mockStopRuntimeServicesForExecutionWorkspace).toHaveBeenCalledWith(expect.objectContaining({
+      executionWorkspaceId: existing.id,
+      workspaceCwd: existing.cwd,
+    }));
+    expect(mockCleanupExecutionWorkspaceArtifacts).not.toHaveBeenCalled();
   });
 
   it.each([

--- a/server/src/__tests__/execution-workspaces-routes.test.ts
+++ b/server/src/__tests__/execution-workspaces-routes.test.ts
@@ -207,6 +207,34 @@ describe.sequential("execution workspace routes", () => {
     }, null);
   });
 
+  it("returns a redacted cross-scope response when adoption source revalidation fails", async () => {
+    mockExecutionWorkspaceService.adoptGitWorktree.mockRejectedValue(
+      new ExecutionWorkspaceAdoptionError("cross_scope_not_found", 404),
+    );
+
+    const res = await request(createApp())
+      .post("/api/companies/company-1/execution-workspaces/adopt-git-worktree")
+      .send({
+        projectId: "11111111-1111-4111-8111-111111111111",
+        projectWorkspaceId: "22222222-2222-4222-8222-222222222222",
+        sourceIssueId: "33333333-3333-4333-8333-333333333333",
+        cwd: "/tmp/worktree",
+        expectedBranch: "refs/heads/feature/adopt",
+        expectedHeadSha: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        expectedUpstream: "origin/feature/adopt",
+        name: "feature/adopt",
+      });
+
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({
+      error: "Execution workspace adoption rejected",
+      reasonCode: "cross_scope_not_found",
+    });
+    expect(res.body).not.toHaveProperty("workspace");
+    expect(res.body).not.toHaveProperty("issue");
+    expect(res.body).not.toHaveProperty("inspection");
+  });
+
   it("requires independent issue mutation authorization when binding an adopted workspace", async () => {
     const bindIssueId = "44444444-4444-4444-8444-444444444444";
     const projectId = "11111111-1111-4111-8111-111111111111";
@@ -393,6 +421,29 @@ describe.sequential("execution workspace routes", () => {
       agentId: null,
       runId: null,
     }, "operator rollback", null, null);
+  });
+
+  it("returns the stable adoption error shape when rollback targets a non-adopted workspace", async () => {
+    mockExecutionWorkspaceService.getById.mockResolvedValue({
+      id: "workspace-1",
+      companyId: "company-1",
+      projectId: "11111111-1111-4111-8111-111111111111",
+      status: "active",
+      metadata: null,
+    });
+    mockExecutionWorkspaceService.rollbackAdoption.mockRejectedValue(
+      new ExecutionWorkspaceAdoptionError("workspace_conflict", 409),
+    );
+
+    const res = await request(createApp())
+      .post("/api/execution-workspaces/workspace-1/rollback-adoption")
+      .send({ reason: "operator rollback" });
+
+    expect(res.status).toBe(409);
+    expect(res.body).toEqual({
+      error: "Execution workspace adoption rollback rejected",
+      reasonCode: "workspace_conflict",
+    });
   });
 
   it.each([

--- a/server/src/__tests__/execution-workspaces-routes.test.ts
+++ b/server/src/__tests__/execution-workspaces-routes.test.ts
@@ -698,6 +698,7 @@ describe.sequential("execution workspace routes", () => {
   it.each([
     ["adoption", { version: 1, immutableFingerprint: "execution_workspace_adoption:v1:sha256:forged" }],
     ["adoptionRollback", { version: 1, reason: "forged" }],
+    ["repositoryIdentity", "/tmp/forged-git-common-dir"],
     ["fullBranchRef", "refs/heads/feature/forged"],
     ["ownsGitArtifacts", true],
     ["createdByRuntime", false],

--- a/server/src/__tests__/execution-workspaces-service.test.ts
+++ b/server/src/__tests__/execution-workspaces-service.test.ts
@@ -2977,6 +2977,46 @@ describeEmbeddedPostgres("executionWorkspaceService.getCloseReadiness", () => {
     });
   }, 20_000);
 
+  it("re-inspects git state after transaction locks before returning an idempotent retry", async () => {
+    const git = await createAdoptionGitFixture();
+    tempDirs.add(git.repoRoot);
+    tempDirs.add(git.worktreePath);
+    const scope = await seedAdoptionScope(db, {
+      repoRoot: git.repoRoot,
+      repoUrl: git.repoUrl,
+    });
+    const request = adoptionRequest({ ...git, ...scope });
+    const actor = {
+      actorType: "user" as const,
+      actorId: "local-board",
+      agentId: null,
+      runId: null,
+    };
+    const adopted = await svc.adoptGitWorktree(scope.companyId, request, actor);
+    const sideEffectsBeforeRetry = await countAdoptionSideEffects(db);
+    const retrySvc = executionWorkspaceService(db, {
+      afterAdoptionInitialInspection: async () => {
+        await fs.appendFile(path.join(git.worktreePath, "README.md"), "changed during idempotent retry\n", "utf8");
+      },
+    });
+
+    await expect(retrySvc.adoptGitWorktree(scope.companyId, request, actor)).rejects.toMatchObject({
+      reasonCode: "dirty_worktree",
+      status: 422,
+    });
+    await expect(countAdoptionSideEffects(db)).resolves.toEqual(sideEffectsBeforeRetry);
+    expect(sideEffectsBeforeRetry).toEqual({
+      workspaces: 1,
+      operations: 1,
+      activity: 2,
+    });
+    const [workspace] = await db
+      .select()
+      .from(executionWorkspaces)
+      .where(eq(executionWorkspaces.id, adopted.workspace.id));
+    expect(workspace?.status).toBe("active");
+  }, 20_000);
+
   it("rejects adoption binding when issue authorization fields change before the transaction lock", async () => {
     const git = await createAdoptionGitFixture();
     tempDirs.add(git.repoRoot);

--- a/server/src/__tests__/execution-workspaces-service.test.ts
+++ b/server/src/__tests__/execution-workspaces-service.test.ts
@@ -2579,6 +2579,65 @@ describeEmbeddedPostgres("executionWorkspaceService.getCloseReadiness", () => {
     });
   }, 20_000);
 
+  it("revalidates source issue scope after transaction locks before adoption writes", async () => {
+    const git = await createAdoptionGitFixture();
+    tempDirs.add(git.repoRoot);
+    tempDirs.add(git.worktreePath);
+    const scope = await seedAdoptionScope(db, {
+      repoRoot: git.repoRoot,
+      repoUrl: git.repoUrl,
+    });
+    const otherProjectId = randomUUID();
+    await db.insert(projects).values({
+      id: otherProjectId,
+      companyId: scope.companyId,
+      name: "Other same-company project",
+      status: "in_progress",
+    });
+    const [bindingBefore] = await db
+      .select({
+        executionWorkspaceId: issues.executionWorkspaceId,
+        executionWorkspacePreference: issues.executionWorkspacePreference,
+        executionWorkspaceSettings: issues.executionWorkspaceSettings,
+      })
+      .from(issues)
+      .where(eq(issues.id, scope.bindIssueId!));
+    const raceSvc = executionWorkspaceService(db, {
+      afterAdoptionInitialInspection: async () => {
+        await db
+          .update(issues)
+          .set({ projectId: otherProjectId })
+          .where(eq(issues.id, scope.sourceIssueId));
+      },
+    });
+
+    await expect(raceSvc.adoptGitWorktree(scope.companyId, adoptionRequest({ ...git, ...scope }), {
+      actorType: "user",
+      actorId: "local-board",
+      agentId: null,
+      runId: null,
+    })).rejects.toMatchObject({ reasonCode: "cross_scope_not_found", status: 404 });
+    await expect(countAdoptionSideEffects(db)).resolves.toEqual({
+      workspaces: 0,
+      operations: 0,
+      activity: 0,
+    });
+    const [sourceIssue] = await db
+      .select({ projectId: issues.projectId })
+      .from(issues)
+      .where(eq(issues.id, scope.sourceIssueId));
+    expect(sourceIssue?.projectId).toBe(otherProjectId);
+    const [bindingAfter] = await db
+      .select({
+        executionWorkspaceId: issues.executionWorkspaceId,
+        executionWorkspacePreference: issues.executionWorkspacePreference,
+        executionWorkspaceSettings: issues.executionWorkspaceSettings,
+      })
+      .from(issues)
+      .where(eq(issues.id, scope.bindIssueId!));
+    expect(bindingAfter).toEqual(bindingBefore);
+  }, 20_000);
+
   it("re-inspects git state after transaction locks and rejects mutation before insert", async () => {
     const git = await createAdoptionGitFixture();
     tempDirs.add(git.repoRoot);

--- a/server/src/__tests__/execution-workspaces-service.test.ts
+++ b/server/src/__tests__/execution-workspaces-service.test.ts
@@ -3045,8 +3045,8 @@ describeEmbeddedPostgres("executionWorkspaceService.getCloseReadiness", () => {
     });
   }, 20_000);
 
-  it("rejects duplicate cwd, provider ref, branch name, and full ref claims as workspace_conflict", async () => {
-    for (const duplicateField of ["cwd", "providerRef", "branchName", "fullBranchRef"] as const) {
+  it("rejects company-wide cwd/provider claims and same-project repository branch claims as workspace_conflict", async () => {
+    for (const duplicateField of ["cwd", "providerRef", "fullBranchRef"] as const) {
       await db.delete(activityLog);
       await db.delete(workspaceOperations);
       await db.delete(executionWorkspaces);
@@ -3063,6 +3063,10 @@ describeEmbeddedPostgres("executionWorkspaceService.getCloseReadiness", () => {
         repoUrl: git.repoUrl,
       });
       const canonicalWorktreePath = await fs.realpath(git.worktreePath);
+      const gitCommonDir = await readGit(git.worktreePath, ["rev-parse", "--git-common-dir"]);
+      const repositoryIdentity = await fs.realpath(
+        path.isAbsolute(gitCommonDir!) ? gitCommonDir! : path.join(git.worktreePath, gitCommonDir!),
+      );
       await db.insert(executionWorkspaces).values({
         companyId: scope.companyId,
         projectId: scope.projectId,
@@ -3075,8 +3079,10 @@ describeEmbeddedPostgres("executionWorkspaceService.getCloseReadiness", () => {
         providerType: "git_worktree",
         cwd: duplicateField === "cwd" ? canonicalWorktreePath : `/tmp/${randomUUID()}`,
         providerRef: duplicateField === "providerRef" ? canonicalWorktreePath : `/tmp/${randomUUID()}`,
-        branchName: duplicateField === "branchName" ? git.branch : `feature/${randomUUID()}`,
-        metadata: duplicateField === "fullBranchRef" ? { fullBranchRef: git.fullBranchRef } : null,
+        branchName: duplicateField === "fullBranchRef" ? git.branch : `feature/${randomUUID()}`,
+        metadata: duplicateField === "fullBranchRef"
+          ? { repositoryIdentity, fullBranchRef: git.fullBranchRef }
+          : null,
       });
 
       await expect(svc.adoptGitWorktree(scope.companyId, adoptionRequest({ ...git, ...scope }), {
@@ -3090,6 +3096,80 @@ describeEmbeddedPostgres("executionWorkspaceService.getCloseReadiness", () => {
       });
     }
   }, 60_000);
+
+  it("allows distinct repositories and projects in one company to adopt the same full branch ref", async () => {
+    const firstGit = await createAdoptionGitFixture({ repoUrl: "git@example.com:paperclip/repo-one.git" });
+    const secondGit = await createAdoptionGitFixture({ repoUrl: "git@example.com:paperclip/repo-two.git" });
+    for (const git of [firstGit, secondGit]) {
+      tempDirs.add(git.repoRoot);
+      tempDirs.add(git.worktreePath);
+    }
+    const firstScope = await seedAdoptionScope(db, {
+      bindIssueId: null,
+      repoRoot: firstGit.repoRoot,
+      repoUrl: firstGit.repoUrl,
+    });
+    const secondProjectId = randomUUID();
+    const secondProjectWorkspaceId = randomUUID();
+    const secondSourceIssueId = randomUUID();
+    await db.insert(projects).values({
+      id: secondProjectId,
+      companyId: firstScope.companyId,
+      name: "Second repository adoption",
+      status: "in_progress",
+    });
+    await db.insert(projectWorkspaces).values({
+      id: secondProjectWorkspaceId,
+      companyId: firstScope.companyId,
+      projectId: secondProjectId,
+      name: "Primary",
+      cwd: secondGit.repoRoot,
+      repoUrl: secondGit.repoUrl,
+      isPrimary: true,
+    });
+    await db.insert(issues).values({
+      id: secondSourceIssueId,
+      companyId: firstScope.companyId,
+      projectId: secondProjectId,
+      title: "Second repository source issue",
+      status: "todo",
+      priority: "medium",
+    });
+    const secondScope = {
+      ...firstScope,
+      projectId: secondProjectId,
+      projectWorkspaceId: secondProjectWorkspaceId,
+      sourceIssueId: secondSourceIssueId,
+    };
+    const actor = {
+      actorType: "user" as const,
+      actorId: "local-board",
+      agentId: null,
+      runId: null,
+    };
+
+    const first = await svc.adoptGitWorktree(
+      firstScope.companyId,
+      adoptionRequest({ ...firstGit, ...firstScope }),
+      actor,
+    );
+    const second = await svc.adoptGitWorktree(
+      firstScope.companyId,
+      adoptionRequest({ ...secondGit, ...secondScope }),
+      actor,
+    );
+
+    expect(second.workspace.id).not.toBe(first.workspace.id);
+    const active = await db
+      .select()
+      .from(executionWorkspaces)
+      .where(and(eq(executionWorkspaces.companyId, firstScope.companyId), eq(executionWorkspaces.status, "active")));
+    expect(active).toHaveLength(2);
+    expect(active.map((row) => row.metadata)).toEqual(expect.arrayContaining([
+      expect.objectContaining({ fullBranchRef: firstGit.fullBranchRef }),
+      expect.objectContaining({ fullBranchRef: secondGit.fullBranchRef }),
+    ]));
+  }, 30_000);
 
   it("serializes company-wide adoption claims across different projects", async () => {
     const git = await createAdoptionGitFixture();

--- a/server/src/__tests__/execution-workspaces-service.test.ts
+++ b/server/src/__tests__/execution-workspaces-service.test.ts
@@ -2391,6 +2391,134 @@ describeEmbeddedPostgres("executionWorkspaceService.getCloseReadiness", () => {
     });
   }, 20_000);
 
+  it("keeps operator git state and adopted ownership immutable across rejected patches and archive", async () => {
+    const git = await createAdoptionGitFixture({ branch: "feature/immutable-adoption" });
+    tempDirs.add(git.repoRoot);
+    tempDirs.add(git.worktreePath);
+    const scope = await seedAdoptionScope(db, {
+      repoRoot: git.repoRoot,
+      repoUrl: git.repoUrl,
+    });
+    const adopted = await svc.adoptGitWorktree(
+      scope.companyId,
+      adoptionRequest({ ...git, ...scope }, { bindIssueId: null }),
+      {
+        actorType: "user",
+        actorId: "local-board",
+        agentId: null,
+        runId: null,
+      },
+    );
+    const evidencePath = path.join(git.worktreePath, "operator-untracked.txt");
+    await fs.writeFile(evidencePath, "preserve me\n", "utf8");
+    const gitStateBefore = {
+      head: await readGit(git.worktreePath, ["rev-parse", "HEAD"]),
+      branch: await readGit(git.worktreePath, ["symbolic-ref", "HEAD"]),
+      upstream: await readGit(git.worktreePath, ["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}"]),
+      status: await readGit(git.worktreePath, ["status", "--porcelain=v1", "--untracked-files=all"]),
+    };
+    const app = express();
+    app.use(express.json());
+    app.use((req, _res, next) => {
+      req.actor = {
+        type: "board",
+        userId: "local-board",
+        companyIds: [scope.companyId],
+        source: "local_implicit",
+        isInstanceAdmin: false,
+      };
+      next();
+    });
+    app.use("/api", executionWorkspaceRoutes(db));
+    app.use(errorHandler);
+
+    for (const patch of [
+      {
+        metadata: {
+          ...(adopted.workspace.metadata as Record<string, unknown>),
+          ownsGitArtifacts: true,
+        },
+      },
+      { metadata: null },
+      {
+        metadata: {
+          ...(adopted.workspace.metadata as Record<string, unknown>),
+          adoption: {
+            ...((adopted.workspace.metadata as Record<string, unknown>).adoption as Record<string, unknown>),
+            immutableFingerprint: "execution_workspace_adoption:v1:sha256:rewritten",
+          },
+        },
+      },
+      {
+        cwd: `${git.worktreePath}-other`,
+        providerRef: `${git.worktreePath}-other`,
+        repoUrl: "ssh://git@example.com/other/repo",
+        branchName: "feature/other",
+        baseRef: "origin/other",
+      },
+    ]) {
+      const rejected = await supertest(app)
+        .patch(`/api/execution-workspaces/${adopted.workspace.id}`)
+        .send(patch);
+      expect(rejected.status).toBe(409);
+      expect(rejected.body.reasonCode).toBe("adopted_workspace_identity_immutable");
+    }
+
+    const archived = await supertest(app)
+      .patch(`/api/execution-workspaces/${adopted.workspace.id}`)
+      .send({ status: "archived" });
+    expect(archived.status).toBe(200);
+    expect(archived.body.status).toBe("archived");
+
+    const postArchiveEscalation = await supertest(app)
+      .patch(`/api/execution-workspaces/${adopted.workspace.id}`)
+      .send({
+        metadata: {
+          ...(adopted.workspace.metadata as Record<string, unknown>),
+          ownsGitArtifacts: true,
+        },
+      });
+    expect(postArchiveEscalation.status).toBe(409);
+    expect(postArchiveEscalation.body.reasonCode).toBe("adopted_workspace_identity_immutable");
+
+    const persisted = await svc.getById(adopted.workspace.id);
+    expect(persisted).toMatchObject({
+      status: "archived",
+      cwd: adopted.workspace.cwd,
+      providerRef: adopted.workspace.providerRef,
+      repoUrl: adopted.workspace.repoUrl,
+      branchName: git.branch,
+      baseRef: git.upstream,
+      metadata: {
+        createdByRuntime: false,
+        ownsGitArtifacts: false,
+        fullBranchRef: git.fullBranchRef,
+        adoption: {
+          immutableFingerprint: adopted.inspection.worktreeFingerprint,
+        },
+      },
+    });
+    await expect(fs.stat(evidencePath)).resolves.toBeDefined();
+    await expect(fs.stat(git.worktreePath)).resolves.toBeDefined();
+    await expect(Promise.all([
+      readGit(git.worktreePath, ["rev-parse", "HEAD"]),
+      readGit(git.worktreePath, ["symbolic-ref", "HEAD"]),
+      readGit(git.worktreePath, ["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}"]),
+      readGit(git.worktreePath, ["status", "--porcelain=v1", "--untracked-files=all"]),
+    ])).resolves.toEqual([
+      gitStateBefore.head,
+      gitStateBefore.branch,
+      gitStateBefore.upstream,
+      gitStateBefore.status,
+    ]);
+
+    const workspaceActivity = await db.select().from(activityLog).where(eq(activityLog.entityId, adopted.workspace.id));
+    expect(workspaceActivity.map((row) => row.action).sort()).toEqual([
+      "execution_workspace.adopted",
+      "execution_workspace.updated",
+    ]);
+  }, 20_000);
+
   it("serializes concurrent identical adoptions without duplicating operations or activity", async () => {
     const git = await createAdoptionGitFixture();
     tempDirs.add(git.repoRoot);

--- a/server/src/__tests__/execution-workspaces-service.test.ts
+++ b/server/src/__tests__/execution-workspaces-service.test.ts
@@ -29,6 +29,7 @@ import {
   startEmbeddedPostgresTestDatabase,
 } from "./helpers/embedded-postgres.js";
 import {
+  ExecutionWorkspaceAdoptionError,
   executionWorkspaceService,
   mergeExecutionWorkspaceConfig,
   readExecutionWorkspaceConfig,
@@ -2638,6 +2639,56 @@ describeEmbeddedPostgres("executionWorkspaceService.getCloseReadiness", () => {
     expect(bindingAfter).toEqual(bindingBefore);
   }, 20_000);
 
+  it("rejects an idempotent retry when its adopted workspace source issue moved out of project scope", async () => {
+    const git = await createAdoptionGitFixture();
+    tempDirs.add(git.repoRoot);
+    tempDirs.add(git.worktreePath);
+    const scope = await seedAdoptionScope(db, {
+      repoRoot: git.repoRoot,
+      repoUrl: git.repoUrl,
+    });
+    const request = adoptionRequest({ ...git, ...scope });
+    const actor = {
+      actorType: "user" as const,
+      actorId: "local-board",
+      agentId: null,
+      runId: null,
+    };
+    const adopted = await svc.adoptGitWorktree(scope.companyId, request, actor);
+    const sideEffectsBeforeRetry = await countAdoptionSideEffects(db);
+    const otherProjectId = randomUUID();
+    await db.insert(projects).values({
+      id: otherProjectId,
+      companyId: scope.companyId,
+      name: "Other same-company project",
+      status: "in_progress",
+    });
+    const retrySvc = executionWorkspaceService(db, {
+      afterAdoptionInitialInspection: async () => {
+        await db
+          .update(issues)
+          .set({ projectId: otherProjectId })
+          .where(eq(issues.id, scope.sourceIssueId));
+      },
+    });
+
+    await expect(retrySvc.adoptGitWorktree(scope.companyId, request, actor)).rejects.toMatchObject({
+      reasonCode: "cross_scope_not_found",
+      status: 404,
+    });
+    await expect(countAdoptionSideEffects(db)).resolves.toEqual(sideEffectsBeforeRetry);
+    expect(sideEffectsBeforeRetry).toEqual({
+      workspaces: 1,
+      operations: 1,
+      activity: 2,
+    });
+    const [workspace] = await db
+      .select()
+      .from(executionWorkspaces)
+      .where(eq(executionWorkspaces.id, adopted.workspace.id));
+    expect(workspace?.status).toBe("active");
+  }, 20_000);
+
   it("re-inspects git state after transaction locks and rejects mutation before insert", async () => {
     const git = await createAdoptionGitFixture();
     tempDirs.add(git.repoRoot);
@@ -2875,6 +2926,45 @@ describeEmbeddedPostgres("executionWorkspaceService.getCloseReadiness", () => {
     });
   }, 20_000);
 
+  it("rejects rollback of a non-adopted workspace with the stable adoption error contract", async () => {
+    const scope = await seedAdoptionScope(db, {
+      repoRoot: `/tmp/${randomUUID()}`,
+      repoUrl: "git@example.com:paperclip/repo.git",
+    });
+    const workspaceId = randomUUID();
+    await db.insert(executionWorkspaces).values({
+      id: workspaceId,
+      companyId: scope.companyId,
+      projectId: scope.projectId,
+      projectWorkspaceId: scope.projectWorkspaceId,
+      sourceIssueId: scope.sourceIssueId,
+      mode: "isolated_workspace",
+      strategyType: "git_worktree",
+      name: "ordinary workspace",
+      status: "active",
+      providerType: "git_worktree",
+      cwd: `/tmp/${randomUUID()}`,
+      branchName: "feature/ordinary",
+    });
+
+    const error = await svc.rollbackAdoption(workspaceId, {
+      actorType: "user",
+      actorId: "local-board",
+      agentId: null,
+      runId: null,
+    }, "not adopted", null, null).catch((caught: unknown) => caught);
+
+    expect(error).toBeInstanceOf(ExecutionWorkspaceAdoptionError);
+    expect(error).toMatchObject({
+      reasonCode: "workspace_conflict",
+      status: 409,
+    });
+    const [workspace] = await db.select().from(executionWorkspaces).where(eq(executionWorkspaces.id, workspaceId));
+    expect(workspace).toMatchObject({ status: "active", closedAt: null });
+    const activity = await db.select().from(activityLog).where(eq(activityLog.entityId, workspaceId));
+    expect(activity).toHaveLength(0);
+  });
+
   it("rolls back adopted records without deleting or mutating the adopted git worktree", async () => {
     const git = await createAdoptionGitFixture();
     tempDirs.add(git.repoRoot);
@@ -2995,10 +3085,10 @@ describeEmbeddedPostgres("executionWorkspaceService.getCloseReadiness", () => {
     expect(afterRepeat?.metadata).toEqual(beforeRepeat?.metadata);
     expect(afterRepeat?.updatedAt).toEqual(beforeRepeat?.updatedAt);
     expect(activityAfterRepeat).toEqual(activityBeforeRepeat);
-    expect(activityAfterRepeat.map((row) => row.action)).toEqual([
+    expect(activityAfterRepeat.map((row) => row.action).sort()).toEqual([
       "execution_workspace.adopted",
       "execution_workspace.adoption_rolled_back",
-    ]);
+    ].sort());
   }, 20_000);
 
   it("rolls back atomically when adoption fails after workspace insert but before optional issue binding", async () => {

--- a/server/src/__tests__/execution-workspaces-service.test.ts
+++ b/server/src/__tests__/execution-workspaces-service.test.ts
@@ -5,8 +5,10 @@ import os from "node:os";
 import path from "node:path";
 import { randomUUID } from "node:crypto";
 import { promisify } from "node:util";
+import express from "express";
+import supertest from "supertest";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
-import { eq, inArray, sql } from "drizzle-orm";
+import { and, eq, inArray, sql } from "drizzle-orm";
 import {
   activityLog,
   agents,
@@ -35,6 +37,9 @@ import {
   startRuntimeServicesForWorkspaceControl,
   stopRuntimeServicesForExecutionWorkspace,
 } from "../services/workspace-runtime.ts";
+import { errorHandler } from "../middleware/index.ts";
+import { executionWorkspaceRoutes } from "../routes/execution-workspaces.ts";
+import { issueRoutes } from "../routes/issues.ts";
 
 const execFileAsync = promisify(execFile);
 
@@ -290,6 +295,23 @@ async function countAdoptionSideEffects(db: ReturnType<typeof createDb>) {
     operations: operationCount?.count ?? 0,
     activity: activityCount?.count ?? 0,
   };
+}
+
+async function readIssueAuthorizationSnapshot(db: ReturnType<typeof createDb>, issueId: string) {
+  return db
+    .select({
+      id: issues.id,
+      parentId: issues.parentId,
+      assigneeAgentId: issues.assigneeAgentId,
+      assigneeUserId: issues.assigneeUserId,
+      status: issues.status,
+      executionPolicy: issues.executionPolicy,
+      originKind: issues.originKind,
+      originId: issues.originId,
+    })
+    .from(issues)
+    .where(eq(issues.id, issueId))
+    .then((rows) => rows[0] ?? null);
 }
 
 async function waitForPath(filePath: string, timeoutMs = 5_000) {
@@ -2316,6 +2338,30 @@ describeEmbeddedPostgres("executionWorkspaceService.getCloseReadiness", () => {
         identifier: "PAP-456",
       },
     });
+    const app = express();
+    app.use(express.json());
+    app.use((req, _res, next) => {
+      req.actor = {
+        type: "board",
+        userId: "local-board",
+        companyIds: [scope.companyId],
+        source: "local_implicit",
+        isInstanceAdmin: false,
+      };
+      next();
+    });
+    app.use("/api", executionWorkspaceRoutes(db));
+    app.use("/api", issueRoutes(db, {} as never));
+    app.use(errorHandler);
+    const workspaceReadback = await supertest(app).get(`/api/execution-workspaces/${first.workspace.id}`);
+    expect(workspaceReadback.status).toBe(200);
+    expect(workspaceReadback.body).toMatchObject({
+      id: first.workspace.id,
+      boundIssue: { id: scope.bindIssueId },
+    });
+    const heartbeatContext = await supertest(app).get(`/api/issues/${scope.bindIssueId}/heartbeat-context`);
+    expect(heartbeatContext.status).toBe(200);
+    expect(heartbeatContext.body.currentExecutionWorkspace).toMatchObject({ id: first.workspace.id });
     const [boundIssue] = await db.select().from(issues).where(eq(issues.id, scope.bindIssueId!));
     expect(boundIssue).toMatchObject({
       executionWorkspaceId: first.workspace.id,
@@ -2459,6 +2505,87 @@ describeEmbeddedPostgres("executionWorkspaceService.getCloseReadiness", () => {
     });
   }, 20_000);
 
+  it("fails repo identity closed when the selected project workspace cannot be inspected", async () => {
+    const git = await createAdoptionGitFixture();
+    tempDirs.add(git.repoRoot);
+    tempDirs.add(git.worktreePath);
+    const scope = await seedAdoptionScope(db, {
+      repoRoot: git.repoRoot,
+      repoUrl: git.repoUrl,
+    });
+    await db
+      .update(projectWorkspaces)
+      .set({ cwd: path.join(git.repoRoot, "missing-project-workspace") })
+      .where(eq(projectWorkspaces.id, scope.projectWorkspaceId));
+
+    await expect(svc.adoptGitWorktree(scope.companyId, adoptionRequest({ ...git, ...scope }), {
+      actorType: "user",
+      actorId: "local-board",
+      agentId: null,
+      runId: null,
+    })).rejects.toMatchObject({ reasonCode: "repo_mismatch", status: 422 });
+    await expect(countAdoptionSideEffects(db)).resolves.toEqual({
+      workspaces: 0,
+      operations: 0,
+      activity: 0,
+    });
+  }, 20_000);
+
+  it("re-inspects git state after transaction locks and rejects mutation before insert", async () => {
+    const git = await createAdoptionGitFixture();
+    tempDirs.add(git.repoRoot);
+    tempDirs.add(git.worktreePath);
+    const scope = await seedAdoptionScope(db, {
+      repoRoot: git.repoRoot,
+      repoUrl: git.repoUrl,
+    });
+    const raceSvc = executionWorkspaceService(db, {
+      afterAdoptionInitialInspection: async () => {
+        await fs.appendFile(path.join(git.worktreePath, "README.md"), "changed after initial inspection\n", "utf8");
+      },
+    });
+
+    await expect(raceSvc.adoptGitWorktree(scope.companyId, adoptionRequest({ ...git, ...scope }), {
+      actorType: "user",
+      actorId: "local-board",
+      agentId: null,
+      runId: null,
+    })).rejects.toMatchObject({ reasonCode: "dirty_worktree", status: 422 });
+    await expect(countAdoptionSideEffects(db)).resolves.toEqual({
+      workspaces: 0,
+      operations: 0,
+      activity: 0,
+    });
+  }, 20_000);
+
+  it("rejects adoption binding when issue authorization fields change before the transaction lock", async () => {
+    const git = await createAdoptionGitFixture();
+    tempDirs.add(git.repoRoot);
+    tempDirs.add(git.worktreePath);
+    const scope = await seedAdoptionScope(db, {
+      repoRoot: git.repoRoot,
+      repoUrl: git.repoUrl,
+    });
+    const authorizedBindIssue = await readIssueAuthorizationSnapshot(db, scope.bindIssueId!);
+    const raceSvc = executionWorkspaceService(db, {
+      afterAdoptionInitialInspection: async () => {
+        await db.update(issues).set({ status: "in_progress" }).where(eq(issues.id, scope.bindIssueId!));
+      },
+    });
+
+    await expect(raceSvc.adoptGitWorktree(scope.companyId, adoptionRequest({ ...git, ...scope }), {
+      actorType: "user",
+      actorId: "local-board",
+      agentId: null,
+      runId: null,
+    }, authorizedBindIssue)).rejects.toMatchObject({ reasonCode: "workspace_conflict", status: 409 });
+    await expect(countAdoptionSideEffects(db)).resolves.toEqual({
+      workspaces: 0,
+      operations: 0,
+      activity: 0,
+    });
+  }, 20_000);
+
   it("rejects duplicate cwd, provider ref, branch name, and full ref claims as workspace_conflict", async () => {
     for (const duplicateField of ["cwd", "providerRef", "branchName", "fullBranchRef"] as const) {
       await db.delete(activityLog);
@@ -2504,6 +2631,72 @@ describeEmbeddedPostgres("executionWorkspaceService.getCloseReadiness", () => {
       });
     }
   }, 60_000);
+
+  it("serializes company-wide adoption claims across different projects", async () => {
+    const git = await createAdoptionGitFixture();
+    tempDirs.add(git.repoRoot);
+    tempDirs.add(git.worktreePath);
+    const firstScope = await seedAdoptionScope(db, {
+      bindIssueId: null,
+      repoRoot: git.repoRoot,
+      repoUrl: git.repoUrl,
+    });
+    const secondProjectId = randomUUID();
+    const secondProjectWorkspaceId = randomUUID();
+    const secondSourceIssueId = randomUUID();
+    await db.insert(projects).values({
+      id: secondProjectId,
+      companyId: firstScope.companyId,
+      name: "Concurrent adoption",
+      status: "in_progress",
+    });
+    await db.insert(projectWorkspaces).values({
+      id: secondProjectWorkspaceId,
+      companyId: firstScope.companyId,
+      projectId: secondProjectId,
+      name: "Primary",
+      cwd: git.repoRoot,
+      repoUrl: git.repoUrl,
+      isPrimary: true,
+    });
+    await db.insert(issues).values({
+      id: secondSourceIssueId,
+      companyId: firstScope.companyId,
+      projectId: secondProjectId,
+      title: "Concurrent source issue",
+      status: "todo",
+      priority: "medium",
+    });
+    const secondScope = {
+      ...firstScope,
+      projectId: secondProjectId,
+      projectWorkspaceId: secondProjectWorkspaceId,
+      sourceIssueId: secondSourceIssueId,
+      bindIssueId: null,
+    };
+    const actor = {
+      actorType: "user" as const,
+      actorId: "local-board",
+      agentId: null,
+      runId: null,
+    };
+
+    const results = await Promise.allSettled([
+      svc.adoptGitWorktree(firstScope.companyId, adoptionRequest({ ...git, ...firstScope }), actor),
+      svc.adoptGitWorktree(firstScope.companyId, adoptionRequest({ ...git, ...secondScope }), actor),
+    ]);
+
+    expect(results.filter((result) => result.status === "fulfilled")).toHaveLength(1);
+    const [rejected] = results.filter((result) => result.status === "rejected");
+    expect(rejected).toMatchObject({
+      reason: expect.objectContaining({ reasonCode: "workspace_conflict", status: 409 }),
+    });
+    const active = await db
+      .select()
+      .from(executionWorkspaces)
+      .where(and(eq(executionWorkspaces.companyId, firstScope.companyId), eq(executionWorkspaces.status, "active")));
+    expect(active).toHaveLength(1);
+  }, 20_000);
 
   it("rejects cross-project and cross-company adoption identifiers before git inspection", async () => {
     const git = await createAdoptionGitFixture();
@@ -2592,12 +2785,13 @@ describeEmbeddedPostgres("executionWorkspaceService.getCloseReadiness", () => {
       agentId: null,
       runId: null,
     });
+    const authorizedBoundIssue = await readIssueAuthorizationSnapshot(db, scope.bindIssueId!);
     const rolledBack = await svc.rollbackAdoption(adopted.workspace.id, {
       actorType: "user",
       actorId: "local-board",
       agentId: null,
       runId: null,
-    }, "record-only rollback");
+    }, "record-only rollback", scope.bindIssueId, authorizedBoundIssue);
 
     expect(rolledBack).toMatchObject({
       id: adopted.workspace.id,
@@ -2796,12 +2990,58 @@ describeEmbeddedPostgres("executionWorkspaceService.getCloseReadiness", () => {
       },
     });
 
+    const authorizedBoundIssue = await readIssueAuthorizationSnapshot(db, bindIssueId);
+    expect(authorizedBoundIssue).not.toBeNull();
+    await expect(svc.rollbackAdoption(adoptedWorkspaceId, {
+      actorType: "user",
+      actorId: "local-board",
+      agentId: null,
+      runId: null,
+    }, "stale authorization", randomUUID(), authorizedBoundIssue)).rejects.toMatchObject({ reasonCode: "workspace_conflict", status: 409 });
+    const [stillAuthorizedBinding] = await db.select().from(issues).where(eq(issues.id, bindIssueId));
+    expect(stillAuthorizedBinding?.executionWorkspaceId).toBe(adoptedWorkspaceId);
+
+    await db.update(issues).set({ status: "in_progress" }).where(eq(issues.id, bindIssueId));
+    await expect(svc.rollbackAdoption(adoptedWorkspaceId, {
+      actorType: "user",
+      actorId: "local-board",
+      agentId: null,
+      runId: null,
+    }, "stale issue authorization", bindIssueId, authorizedBoundIssue)).rejects.toMatchObject({
+      reasonCode: "workspace_conflict",
+      status: 409,
+    });
+    await db.update(issues).set({ status: "todo" }).where(eq(issues.id, bindIssueId));
+
+    await db
+      .update(issues)
+      .set({ executionWorkspaceId: previousWorkspaceId })
+      .where(eq(issues.id, bindIssueId));
+    await expect(svc.rollbackAdoption(adoptedWorkspaceId, {
+      actorType: "user",
+      actorId: "local-board",
+      agentId: null,
+      runId: null,
+    }, "stale rollback", bindIssueId, authorizedBoundIssue)).rejects.toMatchObject({ reasonCode: "workspace_conflict", status: 409 });
+    const [unchangedAdoptedWorkspace] = await db
+      .select()
+      .from(executionWorkspaces)
+      .where(eq(executionWorkspaces.id, adoptedWorkspaceId));
+    const [newerBoundIssue] = await db.select().from(issues).where(eq(issues.id, bindIssueId));
+    expect(unchangedAdoptedWorkspace?.status).toBe("active");
+    expect(newerBoundIssue?.executionWorkspaceId).toBe(previousWorkspaceId);
+
+    await db
+      .update(issues)
+      .set({ executionWorkspaceId: adoptedWorkspaceId })
+      .where(eq(issues.id, bindIssueId));
+
     const result = await svc.rollbackAdoption(adoptedWorkspaceId, {
       actorType: "user",
       actorId: "local-board",
       agentId: null,
       runId: null,
-    }, "operator rollback");
+    }, "operator rollback", bindIssueId, authorizedBoundIssue);
 
     expect(result).toMatchObject({
       id: adoptedWorkspaceId,

--- a/server/src/__tests__/execution-workspaces-service.test.ts
+++ b/server/src/__tests__/execution-workspaces-service.test.ts
@@ -2390,6 +2390,54 @@ describeEmbeddedPostgres("executionWorkspaceService.getCloseReadiness", () => {
     });
   }, 20_000);
 
+  it("serializes concurrent identical adoptions without duplicating operations or activity", async () => {
+    const git = await createAdoptionGitFixture();
+    tempDirs.add(git.repoRoot);
+    tempDirs.add(git.worktreePath);
+    const scope = await seedAdoptionScope(db, {
+      repoRoot: git.repoRoot,
+      repoUrl: git.repoUrl,
+    });
+    const request = adoptionRequest({ ...git, ...scope });
+    let arrivals = 0;
+    let releaseBarrier!: () => void;
+    const barrier = new Promise<void>((resolve) => {
+      releaseBarrier = resolve;
+    });
+    const raceSvc = executionWorkspaceService(db, {
+      afterAdoptionInitialInspection: async () => {
+        arrivals += 1;
+        if (arrivals === 2) releaseBarrier();
+        await barrier;
+      },
+    });
+    const actor = {
+      actorType: "user" as const,
+      actorId: "local-board",
+      agentId: null,
+      runId: null,
+    };
+
+    const results = await Promise.all([
+      raceSvc.adoptGitWorktree(scope.companyId, request, actor),
+      raceSvc.adoptGitWorktree(scope.companyId, request, actor),
+    ]);
+
+    expect(new Set(results.map((result) => result.workspace.id))).toHaveProperty("size", 1);
+    expect(results.filter((result) => result.operation !== null)).toHaveLength(1);
+    expect(results.filter((result) => result.operation === null)).toHaveLength(1);
+    await expect(countAdoptionSideEffects(db)).resolves.toEqual({
+      workspaces: 1,
+      operations: 1,
+      activity: 2,
+    });
+    const workspaceId = results[0]!.workspace.id;
+    const workspaceActivity = await db.select().from(activityLog).where(eq(activityLog.entityId, workspaceId));
+    expect(workspaceActivity.map((row) => row.action)).toEqual(["execution_workspace.adopted"]);
+    const issueActivity = await db.select().from(activityLog).where(eq(activityLog.entityId, scope.bindIssueId!));
+    expect(issueActivity.map((row) => row.action)).toEqual(["issue.execution_workspace_bound"]);
+  }, 20_000);
+
   it.each([
     {
       name: "remote-only missing local branch",
@@ -2805,6 +2853,93 @@ describeEmbeddedPostgres("executionWorkspaceService.getCloseReadiness", () => {
     await expect(readGit(git.worktreePath, ["status", "--porcelain=v1", "--untracked-files=all"])).resolves.toBeNull();
     const operations = await db.select().from(workspaceOperations).where(eq(workspaceOperations.executionWorkspaceId, adopted.workspace.id));
     expect(operations.map((row) => row.phase)).toEqual(["workspace_adopt"]);
+    const [beforeRepeat] = await db
+      .select()
+      .from(executionWorkspaces)
+      .where(eq(executionWorkspaces.id, adopted.workspace.id));
+    const activityBeforeRepeat = await db
+      .select()
+      .from(activityLog)
+      .where(eq(activityLog.entityId, adopted.workspace.id));
+
+    await expect(svc.rollbackAdoption(adopted.workspace.id, {
+      actorType: "user",
+      actorId: "different-board-actor",
+      agentId: null,
+      runId: null,
+    }, "must not replace first rollback", scope.bindIssueId, authorizedBoundIssue)).rejects.toMatchObject({
+      reasonCode: "workspace_conflict",
+      status: 409,
+    });
+
+    const [afterRepeat] = await db
+      .select()
+      .from(executionWorkspaces)
+      .where(eq(executionWorkspaces.id, adopted.workspace.id));
+    const activityAfterRepeat = await db
+      .select()
+      .from(activityLog)
+      .where(eq(activityLog.entityId, adopted.workspace.id));
+    expect(afterRepeat?.metadata).toEqual(beforeRepeat?.metadata);
+    expect(afterRepeat?.updatedAt).toEqual(beforeRepeat?.updatedAt);
+    expect(activityAfterRepeat).toEqual(activityBeforeRepeat);
+  }, 20_000);
+
+  it("rejects repeated rollback of an unbound adopted workspace without changing metadata or activity", async () => {
+    const git = await createAdoptionGitFixture();
+    tempDirs.add(git.repoRoot);
+    tempDirs.add(git.worktreePath);
+    const scope = await seedAdoptionScope(db, {
+      bindIssueId: null,
+      repoRoot: git.repoRoot,
+      repoUrl: git.repoUrl,
+    });
+    const adopted = await svc.adoptGitWorktree(scope.companyId, adoptionRequest({ ...git, ...scope }), {
+      actorType: "user",
+      actorId: "local-board",
+      agentId: null,
+      runId: null,
+    });
+    await svc.rollbackAdoption(adopted.workspace.id, {
+      actorType: "user",
+      actorId: "local-board",
+      agentId: null,
+      runId: null,
+    }, "first rollback", null, null);
+    const [beforeRepeat] = await db
+      .select()
+      .from(executionWorkspaces)
+      .where(eq(executionWorkspaces.id, adopted.workspace.id));
+    const activityBeforeRepeat = await db
+      .select()
+      .from(activityLog)
+      .where(eq(activityLog.entityId, adopted.workspace.id));
+
+    await expect(svc.rollbackAdoption(adopted.workspace.id, {
+      actorType: "user",
+      actorId: "different-board-actor",
+      agentId: null,
+      runId: null,
+    }, "must not replace first rollback", null, null)).rejects.toMatchObject({
+      reasonCode: "workspace_conflict",
+      status: 409,
+    });
+
+    const [afterRepeat] = await db
+      .select()
+      .from(executionWorkspaces)
+      .where(eq(executionWorkspaces.id, adopted.workspace.id));
+    const activityAfterRepeat = await db
+      .select()
+      .from(activityLog)
+      .where(eq(activityLog.entityId, adopted.workspace.id));
+    expect(afterRepeat?.metadata).toEqual(beforeRepeat?.metadata);
+    expect(afterRepeat?.updatedAt).toEqual(beforeRepeat?.updatedAt);
+    expect(activityAfterRepeat).toEqual(activityBeforeRepeat);
+    expect(activityAfterRepeat.map((row) => row.action)).toEqual([
+      "execution_workspace.adopted",
+      "execution_workspace.adoption_rolled_back",
+    ]);
   }, 20_000);
 
   it("rolls back atomically when adoption fails after workspace insert but before optional issue binding", async () => {

--- a/server/src/__tests__/execution-workspaces-service.test.ts
+++ b/server/src/__tests__/execution-workspaces-service.test.ts
@@ -339,6 +339,24 @@ function stableStringifyForTest(value: unknown): string {
   return JSON.stringify(value);
 }
 
+function fingerprintAdoptionForTest(input: {
+  companyId: string;
+  projectId: string;
+  projectWorkspaceId: string;
+  sourceIssueId: string;
+  canonicalCwd: string;
+  repoRoot: string;
+  normalizedRepoUrl: string | null;
+  fullBranchRef: string;
+  headSha: string;
+  upstream: string;
+}) {
+  const digest = createHash("sha256")
+    .update(stableStringifyForTest({ version: 1, kind: "execution_workspace_adoption", ...input }))
+    .digest("hex");
+  return `execution_workspace_adoption:v1:sha256:${digest}`;
+}
+
 async function fingerprintWorkspaceBranchIncoherenceForTest(input: {
   repoRoot: string;
   worktreePath: string;
@@ -2388,6 +2406,121 @@ describeEmbeddedPostgres("executionWorkspaceService.getCloseReadiness", () => {
     })).rejects.toMatchObject({
       reasonCode: "workspace_conflict",
       status: 409,
+    });
+  }, 20_000);
+
+  it("rejects forged adoption metadata before persistence and leaves exact adoption retry unpoisoned", async () => {
+    const git = await createAdoptionGitFixture({ branch: "feature/forged-adoption-guard" });
+    tempDirs.add(git.repoRoot);
+    tempDirs.add(git.worktreePath);
+    const scope = await seedAdoptionScope(db, {
+      repoRoot: git.repoRoot,
+      repoUrl: git.repoUrl,
+    });
+    const normalWorkspaceId = randomUUID();
+    const canonicalCwd = await fs.realpath(git.worktreePath);
+    const canonicalRepoRoot = await fs.realpath(git.worktreePath);
+    const immutableFingerprint = fingerprintAdoptionForTest({
+      companyId: scope.companyId,
+      projectId: scope.projectId,
+      projectWorkspaceId: scope.projectWorkspaceId,
+      sourceIssueId: scope.sourceIssueId,
+      canonicalCwd,
+      repoRoot: canonicalRepoRoot,
+      normalizedRepoUrl: "ssh://example.com/paperclip/repo",
+      fullBranchRef: git.fullBranchRef,
+      headSha: git.headSha,
+      upstream: git.upstream,
+    });
+
+    await db.insert(executionWorkspaces).values({
+      id: normalWorkspaceId,
+      companyId: scope.companyId,
+      projectId: scope.projectId,
+      projectWorkspaceId: scope.projectWorkspaceId,
+      sourceIssueId: scope.sourceIssueId,
+      mode: "isolated_workspace",
+      strategyType: "git_worktree",
+      name: "Ordinary runtime workspace",
+      status: "active",
+      providerType: "git_worktree",
+      cwd: `/tmp/ordinary-${normalWorkspaceId}`,
+      providerRef: `/tmp/ordinary-${normalWorkspaceId}`,
+      branchName: "feature/ordinary-runtime",
+      metadata: { runtimeNote: "ordinary" },
+    });
+
+    const app = express();
+    app.use(express.json());
+    app.use((req, _res, next) => {
+      req.actor = {
+        type: "board",
+        userId: "local-board",
+        companyIds: [scope.companyId],
+        source: "local_implicit",
+        isInstanceAdmin: false,
+      };
+      next();
+    });
+    app.use("/api", executionWorkspaceRoutes(db));
+    app.use(errorHandler);
+
+    const forged = await supertest(app)
+      .patch(`/api/execution-workspaces/${normalWorkspaceId}`)
+      .send({
+        name: "Forged adopted workspace",
+        metadata: {
+          runtimeNote: "ordinary",
+          createdByRuntime: false,
+          ownsGitArtifacts: false,
+          fullBranchRef: git.fullBranchRef,
+          adoptionRollback: { version: 1, reason: "forged" },
+          adoption: {
+            version: 1,
+            immutableFingerprint,
+            boundIssueId: scope.bindIssueId,
+          },
+        },
+      });
+
+    expect(forged.status).toBe(409);
+    expect(forged.body).toEqual({
+      error: "Execution workspace server-owned metadata is immutable",
+      reasonCode: "execution_workspace_server_owned_metadata_immutable",
+      protectedKeys: [
+        "adoption",
+        "adoptionRollback",
+        "fullBranchRef",
+        "ownsGitArtifacts",
+        "createdByRuntime",
+      ],
+    });
+    const [normalReadback] = await db
+      .select()
+      .from(executionWorkspaces)
+      .where(eq(executionWorkspaces.id, normalWorkspaceId));
+    expect(normalReadback?.name).toBe("Ordinary runtime workspace");
+    expect(normalReadback?.metadata).toEqual({ runtimeNote: "ordinary" });
+    expect(await db.select().from(activityLog).where(eq(activityLog.entityId, normalWorkspaceId))).toHaveLength(0);
+
+    const adopted = await svc.adoptGitWorktree(
+      scope.companyId,
+      adoptionRequest({ ...git, ...scope }),
+      {
+        actorType: "user",
+        actorId: "local-board",
+        agentId: null,
+        runId: null,
+      },
+    );
+    expect(adopted.workspace.id).not.toBe(normalWorkspaceId);
+    expect(adopted.operation).toMatchObject({
+      phase: "workspace_adopt",
+      status: "succeeded",
+    });
+    expect((adopted.workspace.metadata as Record<string, unknown>).adoption).toMatchObject({
+      immutableFingerprint,
+      boundIssueId: scope.bindIssueId,
     });
   }, 20_000);
 

--- a/server/src/__tests__/execution-workspaces-service.test.ts
+++ b/server/src/__tests__/execution-workspaces-service.test.ts
@@ -3758,4 +3758,53 @@ describeEmbeddedPostgres("executionWorkspaceService.getCloseReadiness", () => {
       "git_branch_delete",
     ]));
   }, 20_000);
+
+  it("reports record-only close readiness for adopted operator-owned worktrees", async () => {
+    const fixture = await createAdoptionGitFixture({ branch: "feature/operator-owned-close" });
+    tempDirs.add(fixture.repoRoot);
+    tempDirs.add(fixture.worktreePath);
+    const scope = await seedAdoptionScope(db, fixture);
+    await db
+      .update(projects)
+      .set({
+        executionWorkspacePolicy: {
+          enabled: true,
+          workspaceStrategy: {
+            type: "git_worktree",
+            teardownCommand: "node ./scripts/project-teardown.js",
+          },
+        },
+      })
+      .where(eq(projects.id, scope.projectId));
+    await db
+      .update(projectWorkspaces)
+      .set({ cleanupCommand: "node ./scripts/project-cleanup.js" })
+      .where(eq(projectWorkspaces.id, scope.projectWorkspaceId));
+
+    const adopted = await svc.adoptGitWorktree(
+      scope.companyId,
+      adoptionRequest({ ...fixture, ...scope }, { bindIssueId: null }),
+      {
+        actorType: "user",
+        actorId: "board-user",
+        agentId: null,
+        runId: null,
+      },
+      null,
+    );
+
+    const readiness = await svc.getCloseReadiness(adopted.workspace.id);
+
+    expect(adopted.workspace.metadata).toMatchObject({ ownsGitArtifacts: false });
+    expect(readiness?.plannedActions).toEqual([
+      expect.objectContaining({ kind: "archive_record", command: null }),
+    ]);
+    expect(readiness?.plannedActions.map((action) => action.kind)).not.toEqual(expect.arrayContaining([
+      "cleanup_command",
+      "teardown_command",
+      "git_worktree_remove",
+      "git_branch_delete",
+      "remove_local_directory",
+    ]));
+  }, 20_000);
 });

--- a/server/src/__tests__/execution-workspaces-service.test.ts
+++ b/server/src/__tests__/execution-workspaces-service.test.ts
@@ -3017,6 +3017,77 @@ describeEmbeddedPostgres("executionWorkspaceService.getCloseReadiness", () => {
     expect(workspace?.status).toBe("active");
   }, 20_000);
 
+  it("never executes a repository-configured fsmonitor during either adoption inspection", async () => {
+    const git = await createAdoptionGitFixture({ branch: "feature/fsmonitor-safe-adoption" });
+    tempDirs.add(git.repoRoot);
+    tempDirs.add(git.worktreePath);
+    const hookPath = path.join(git.repoRoot, "fsmonitor-hook.sh");
+    const markerPath = path.join(git.repoRoot, "fsmonitor-executed.txt");
+    await fs.writeFile(
+      hookPath,
+      "#!/bin/sh\nmarker_path=\"$(dirname \"$0\")/fsmonitor-executed.txt\"\nprintf invoked > \"$marker_path\"\nprintf \"%s\\n\" \"$2\"\n",
+      "utf8",
+    );
+    await fs.chmod(hookPath, 0o755);
+    await runGit(git.worktreePath, ["config", "core.fsmonitor", hookPath]);
+    await runGit(git.worktreePath, ["config", "core.fsmonitorHookVersion", "2"]);
+    const scope = await seedAdoptionScope(db, {
+      repoRoot: git.repoRoot,
+      repoUrl: git.repoUrl,
+    });
+    let markerExistedAfterInitialInspection = false;
+    const hardenedSvc = executionWorkspaceService(db, {
+      afterAdoptionInitialInspection: async () => {
+        markerExistedAfterInitialInspection = await fs.access(markerPath).then(() => true).catch(() => false);
+      },
+    });
+
+    await expect(hardenedSvc.adoptGitWorktree(scope.companyId, adoptionRequest({ ...git, ...scope }), {
+      actorType: "user",
+      actorId: "local-board",
+      agentId: null,
+      runId: null,
+    })).resolves.toMatchObject({ inspection: { status: "accepted" } });
+
+    expect(markerExistedAfterInitialInspection).toBe(false);
+    await expect(fs.access(markerPath)).rejects.toMatchObject({ code: "ENOENT" });
+  }, 20_000);
+
+  it("leaves a stale clean index byte-for-byte unchanged after both adoption inspections", async () => {
+    const git = await createAdoptionGitFixture({ branch: "feature/index-safe-adoption" });
+    tempDirs.add(git.repoRoot);
+    tempDirs.add(git.worktreePath);
+    const scope = await seedAdoptionScope(db, {
+      repoRoot: git.repoRoot,
+      repoUrl: git.repoUrl,
+    });
+    const indexPathRaw = await readGit(git.worktreePath, ["rev-parse", "--git-path", "index"]);
+    const indexPath = path.isAbsolute(indexPathRaw!)
+      ? indexPathRaw!
+      : path.join(git.worktreePath, indexPathRaw!);
+    const indexBeforeInspection = await fs.readFile(indexPath);
+    const trackedPath = path.join(git.worktreePath, "README.md");
+    const staleMtime = new Date(Date.now() + 60_000);
+    await fs.utimes(trackedPath, staleMtime, staleMtime);
+    let indexAfterInitialInspection: Buffer | null = null;
+    const hardenedSvc = executionWorkspaceService(db, {
+      afterAdoptionInitialInspection: async () => {
+        indexAfterInitialInspection = await fs.readFile(indexPath);
+      },
+    });
+
+    await expect(hardenedSvc.adoptGitWorktree(scope.companyId, adoptionRequest({ ...git, ...scope }), {
+      actorType: "user",
+      actorId: "local-board",
+      agentId: null,
+      runId: null,
+    })).resolves.toMatchObject({ inspection: { status: "accepted" } });
+
+    expect(indexAfterInitialInspection).not.toBeNull();
+    expect(indexAfterInitialInspection!.equals(indexBeforeInspection)).toBe(true);
+    expect((await fs.readFile(indexPath)).equals(indexBeforeInspection)).toBe(true);
+  }, 20_000);
+
   it("rejects adoption binding when issue authorization fields change before the transaction lock", async () => {
     const git = await createAdoptionGitFixture();
     tempDirs.add(git.repoRoot);

--- a/server/src/__tests__/execution-workspaces-service.test.ts
+++ b/server/src/__tests__/execution-workspaces-service.test.ts
@@ -19,6 +19,7 @@ import {
   issues,
   projectWorkspaces,
   projects,
+  workspaceOperations,
   workspaceRuntimeServices,
 } from "@paperclipai/db";
 import {
@@ -159,6 +160,138 @@ async function createTempRepo() {
   return repoRoot;
 }
 
+async function createAdoptionGitFixture(options: {
+  branch?: string;
+  upstream?: string;
+  repoUrl?: string;
+  worktreeSlug?: string;
+} = {}) {
+  const branch = options.branch ?? "feature/exact";
+  const upstream = options.upstream ?? `origin/${branch}`;
+  const repoUrl = options.repoUrl ?? "git@example.com:paperclip/repo.git";
+  const repoRoot = await createTempRepo();
+  const worktreePath = path.join(path.dirname(repoRoot), `${options.worktreeSlug ?? "paperclip-adopt"}-${randomUUID()}`);
+
+  await runGit(repoRoot, ["remote", "add", "origin", repoUrl]);
+  await runGit(repoRoot, ["branch", branch]);
+  const headSha = await readGit(repoRoot, ["rev-parse", branch]);
+  await runGit(repoRoot, ["update-ref", `refs/remotes/${upstream}`, headSha!]);
+  await runGit(repoRoot, ["branch", "--set-upstream-to", upstream, branch]);
+  await runGit(repoRoot, ["worktree", "add", worktreePath, branch]);
+
+  return {
+    repoRoot,
+    worktreePath,
+    branch,
+    fullBranchRef: `refs/heads/${branch}`,
+    upstream,
+    repoUrl,
+    headSha: headSha!,
+  };
+}
+
+async function seedAdoptionScope(db: ReturnType<typeof createDb>, input: {
+  companyId?: string;
+  projectId?: string;
+  projectWorkspaceId?: string;
+  sourceIssueId?: string;
+  bindIssueId?: string | null;
+  repoRoot: string;
+  repoUrl?: string | null;
+}) {
+  const companyId = input.companyId ?? randomUUID();
+  const projectId = input.projectId ?? randomUUID();
+  const projectWorkspaceId = input.projectWorkspaceId ?? randomUUID();
+  const sourceIssueId = input.sourceIssueId ?? randomUUID();
+  const bindIssueId = input.bindIssueId === undefined ? randomUUID() : input.bindIssueId;
+
+  await db.insert(companies).values({
+    id: companyId,
+    name: "Paperclip",
+    issuePrefix: `A${companyId.replace(/-/g, "").slice(0, 5).toUpperCase()}`,
+    requireBoardApprovalForNewAgents: false,
+  });
+  await db.insert(projects).values({
+    id: projectId,
+    companyId,
+    name: "Exact branch adoption",
+    status: "in_progress",
+  });
+  await db.insert(projectWorkspaces).values({
+    id: projectWorkspaceId,
+    companyId,
+    projectId,
+    name: "Primary",
+    cwd: input.repoRoot,
+    repoUrl: input.repoUrl ?? "git@example.com:paperclip/repo.git",
+    isPrimary: true,
+  });
+
+  const issueRows = [
+    {
+      id: sourceIssueId,
+      companyId,
+      projectId,
+      title: "Source issue",
+      status: "todo",
+      priority: "medium",
+    },
+  ];
+  if (bindIssueId) {
+    issueRows.push({
+      id: bindIssueId,
+      companyId,
+      projectId,
+      title: "Bound issue",
+      status: "todo",
+      priority: "medium",
+    });
+  }
+  await db.insert(issues).values(issueRows);
+
+  return {
+    companyId,
+    projectId,
+    projectWorkspaceId,
+    sourceIssueId,
+    bindIssueId,
+  };
+}
+
+function adoptionRequest(input: Awaited<ReturnType<typeof createAdoptionGitFixture>> & Awaited<ReturnType<typeof seedAdoptionScope>>, patch: Partial<{
+  bindIssueId: string | null;
+  cwd: string;
+  expectedBranch: string;
+  expectedHeadSha: string;
+  expectedUpstream: string;
+  expectedRepoUrl: string | null;
+  name: string;
+}> = {}) {
+  return {
+    projectId: input.projectId,
+    projectWorkspaceId: input.projectWorkspaceId,
+    sourceIssueId: input.sourceIssueId,
+    bindIssueId: patch.bindIssueId === undefined ? input.bindIssueId : patch.bindIssueId,
+    cwd: patch.cwd ?? input.worktreePath,
+    expectedBranch: patch.expectedBranch ?? input.fullBranchRef,
+    expectedHeadSha: patch.expectedHeadSha ?? input.headSha,
+    expectedUpstream: patch.expectedUpstream ?? input.upstream,
+    expectedRepoUrl: patch.expectedRepoUrl === undefined ? input.repoUrl : patch.expectedRepoUrl,
+    name: patch.name ?? input.branch,
+  };
+}
+
+async function countAdoptionSideEffects(db: ReturnType<typeof createDb>) {
+  const [workspaceCount] = await db.select({ count: sql<number>`count(*)::int` }).from(executionWorkspaces);
+  const [operationCount] = await db.select({ count: sql<number>`count(*)::int` }).from(workspaceOperations);
+  const [activityCount] = await db.select({ count: sql<number>`count(*)::int` }).from(activityLog);
+  return {
+    workspaces: workspaceCount?.count ?? 0,
+    operations: operationCount?.count ?? 0,
+    activity: activityCount?.count ?? 0,
+  };
+}
+
 async function waitForPath(filePath: string, timeoutMs = 5_000) {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
@@ -229,6 +362,7 @@ describeEmbeddedPostgres("executionWorkspaceService.getCloseReadiness", () => {
 
   afterEach(async () => {
     await db.delete(workspaceRuntimeServices);
+    await db.delete(workspaceOperations);
     await db.delete(activityLog);
     await db.delete(issueRecoveryActions);
     await db.delete(issueComments);
@@ -2116,6 +2250,580 @@ describeEmbeddedPostgres("executionWorkspaceService.getCloseReadiness", () => {
     const comments = await db.select().from(issueComments).where(eq(issueComments.issueId, issueId));
     expect(comments).toHaveLength(0);
   }, 20_000);
+
+  it("adopts an exact clean git worktree idempotently and rejects rebinding the same fingerprint", async () => {
+    const git = await createAdoptionGitFixture();
+    tempDirs.add(git.repoRoot);
+    tempDirs.add(git.worktreePath);
+    const scope = await seedAdoptionScope(db, {
+      repoRoot: git.repoRoot,
+      repoUrl: git.repoUrl,
+    });
+    const otherBindIssueId = randomUUID();
+
+    await db.update(issues).set({ identifier: "PAP-456" }).where(eq(issues.id, scope.bindIssueId!));
+    await db.insert(issues).values({
+      id: otherBindIssueId,
+      companyId: scope.companyId,
+      projectId: scope.projectId,
+      title: "Other bound issue",
+      status: "todo",
+      priority: "medium",
+    });
+
+    const request = adoptionRequest({ ...git, ...scope });
+
+    const first = await svc.adoptGitWorktree(scope.companyId, request, {
+      actorType: "user",
+      actorId: "local-board",
+      agentId: null,
+      runId: null,
+    });
+    const retry = await svc.adoptGitWorktree(scope.companyId, request, {
+      actorType: "user",
+      actorId: "local-board",
+      agentId: null,
+      runId: null,
+    });
+
+    expect(first.operation).toMatchObject({
+      phase: "workspace_adopt",
+      status: "succeeded",
+      issueId: scope.bindIssueId,
+    });
+    expect(first.workspace).toMatchObject({
+      companyId: scope.companyId,
+      projectId: scope.projectId,
+      projectWorkspaceId: scope.projectWorkspaceId,
+      sourceIssueId: scope.sourceIssueId,
+      boundIssue: {
+        id: scope.bindIssueId,
+        identifier: "PAP-456",
+      },
+      status: "active",
+      providerType: "git_worktree",
+      branchName: "feature/exact",
+    });
+    expect(first.inspection.worktreeFingerprint).toMatch(/^execution_workspace_adoption:v1:sha256:/);
+    expect(retry.workspace.id).toBe(first.workspace.id);
+    expect(retry.operation).toBeNull();
+
+    const readBack = await svc.getById(first.workspace.id);
+    expect(readBack).toMatchObject({
+      id: first.workspace.id,
+      boundIssue: {
+        id: scope.bindIssueId,
+        identifier: "PAP-456",
+      },
+    });
+    const [boundIssue] = await db.select().from(issues).where(eq(issues.id, scope.bindIssueId!));
+    expect(boundIssue).toMatchObject({
+      executionWorkspaceId: first.workspace.id,
+      executionWorkspacePreference: "reuse_existing",
+    });
+    const operations = await db.select().from(workspaceOperations).where(eq(workspaceOperations.executionWorkspaceId, first.workspace.id));
+    expect(operations).toHaveLength(1);
+    const activity = await db.select().from(activityLog).where(eq(activityLog.entityId, first.workspace.id));
+    expect(activity.map((row) => row.action).sort()).toEqual([
+      "execution_workspace.adopted",
+    ]);
+    const issueActivity = await db.select().from(activityLog).where(eq(activityLog.entityId, scope.bindIssueId!));
+    expect(issueActivity.map((row) => row.action)).toEqual(["issue.execution_workspace_bound"]);
+
+    await expect(svc.adoptGitWorktree(scope.companyId, {
+      ...request,
+      bindIssueId: otherBindIssueId,
+    }, {
+      actorType: "user",
+      actorId: "local-board",
+      agentId: null,
+      runId: null,
+    })).rejects.toMatchObject({
+      reasonCode: "workspace_conflict",
+      status: 409,
+    });
+  }, 20_000);
+
+  it.each([
+    {
+      name: "remote-only missing local branch",
+      reasonCode: "missing_branch",
+      mutate: async (fixture: Awaited<ReturnType<typeof createAdoptionGitFixture>>) => {
+        await runGit(fixture.worktreePath, ["checkout", "--detach", fixture.headSha]);
+        await runGit(fixture.repoRoot, ["branch", "-D", fixture.branch]);
+      },
+    },
+    {
+      name: "detached HEAD",
+      reasonCode: "detached_head",
+      mutate: async (fixture: Awaited<ReturnType<typeof createAdoptionGitFixture>>) => {
+        await runGit(fixture.worktreePath, ["checkout", "--detach", fixture.headSha]);
+      },
+    },
+    {
+      name: "mismatched branch",
+      reasonCode: "mismatched_branch",
+      mutate: async (fixture: Awaited<ReturnType<typeof createAdoptionGitFixture>>) => {
+        await runGit(fixture.repoRoot, ["branch", "feature/other", fixture.headSha]);
+        await runGit(fixture.worktreePath, ["checkout", "feature/other"]);
+      },
+    },
+    {
+      name: "SHA mismatch",
+      reasonCode: "sha_mismatch",
+      requestPatch: { expectedHeadSha: "0000000000000000000000000000000000000000" },
+    },
+    {
+      name: "upstream mismatch",
+      reasonCode: "upstream_mismatch",
+      requestPatch: { expectedUpstream: "origin/other" },
+    },
+    {
+      name: "tracked dirtiness",
+      reasonCode: "dirty_worktree",
+      mutate: async (fixture: Awaited<ReturnType<typeof createAdoptionGitFixture>>) => {
+        await fs.appendFile(path.join(fixture.worktreePath, "README.md"), "dirty tracked work\n", "utf8");
+      },
+    },
+    {
+      name: "untracked dirtiness",
+      reasonCode: "dirty_worktree",
+      mutate: async (fixture: Awaited<ReturnType<typeof createAdoptionGitFixture>>) => {
+        await fs.writeFile(path.join(fixture.worktreePath, "untracked.txt"), "dirty untracked work\n", "utf8");
+      },
+    },
+    {
+      name: "branch attached elsewhere",
+      reasonCode: "branch_attached_elsewhere",
+      mutate: async (fixture: Awaited<ReturnType<typeof createAdoptionGitFixture>>) => {
+        const otherWorktreePath = path.join(path.dirname(fixture.repoRoot), `paperclip-adopt-attached-${randomUUID()}`);
+        tempDirs.add(otherWorktreePath);
+        await runGit(fixture.repoRoot, ["worktree", "add", "--force", otherWorktreePath, fixture.branch]);
+      },
+    },
+    {
+      name: "repo URL mismatch",
+      reasonCode: "repo_mismatch",
+      requestPatch: { expectedRepoUrl: "git@example.com:paperclip/other.git" },
+    },
+  ])("rejects adoption with stable reason code for $name", async ({ reasonCode, mutate, requestPatch }) => {
+    const git = await createAdoptionGitFixture();
+    tempDirs.add(git.repoRoot);
+    tempDirs.add(git.worktreePath);
+    const scope = await seedAdoptionScope(db, {
+      repoRoot: git.repoRoot,
+      repoUrl: git.repoUrl,
+    });
+    await mutate?.(git);
+
+    await expect(svc.adoptGitWorktree(scope.companyId, adoptionRequest({ ...git, ...scope }, requestPatch), {
+      actorType: "user",
+      actorId: "local-board",
+      agentId: null,
+      runId: null,
+    })).rejects.toMatchObject({
+      reasonCode,
+      status: 422,
+    });
+    await expect(countAdoptionSideEffects(db)).resolves.toEqual({
+      workspaces: 0,
+      operations: 0,
+      activity: 0,
+    });
+  }, 20_000);
+
+  it("rejects a cwd outside the git root as repo_mismatch", async () => {
+    const git = await createAdoptionGitFixture();
+    tempDirs.add(git.repoRoot);
+    tempDirs.add(git.worktreePath);
+    const nestedCwd = path.join(git.worktreePath, "nested");
+    await fs.mkdir(nestedCwd);
+    const scope = await seedAdoptionScope(db, {
+      repoRoot: git.repoRoot,
+      repoUrl: git.repoUrl,
+    });
+
+    await expect(svc.adoptGitWorktree(scope.companyId, adoptionRequest({ ...git, ...scope }, { cwd: nestedCwd }), {
+      actorType: "user",
+      actorId: "local-board",
+      agentId: null,
+      runId: null,
+    })).rejects.toMatchObject({
+      reasonCode: "repo_mismatch",
+      status: 422,
+    });
+    await expect(countAdoptionSideEffects(db)).resolves.toEqual({
+      workspaces: 0,
+      operations: 0,
+      activity: 0,
+    });
+  }, 20_000);
+
+  it("rejects duplicate cwd, provider ref, branch name, and full ref claims as workspace_conflict", async () => {
+    for (const duplicateField of ["cwd", "providerRef", "branchName", "fullBranchRef"] as const) {
+      await db.delete(activityLog);
+      await db.delete(workspaceOperations);
+      await db.delete(executionWorkspaces);
+      await db.delete(issues);
+      await db.delete(projectWorkspaces);
+      await db.delete(projects);
+      await db.delete(companies);
+
+      const git = await createAdoptionGitFixture({ worktreeSlug: `paperclip-adopt-${duplicateField}` });
+      tempDirs.add(git.repoRoot);
+      tempDirs.add(git.worktreePath);
+      const scope = await seedAdoptionScope(db, {
+        repoRoot: git.repoRoot,
+        repoUrl: git.repoUrl,
+      });
+      const canonicalWorktreePath = await fs.realpath(git.worktreePath);
+      await db.insert(executionWorkspaces).values({
+        companyId: scope.companyId,
+        projectId: scope.projectId,
+        projectWorkspaceId: scope.projectWorkspaceId,
+        sourceIssueId: scope.sourceIssueId,
+        mode: "isolated_workspace",
+        strategyType: "git_worktree",
+        name: `duplicate-${duplicateField}`,
+        status: "active",
+        providerType: "git_worktree",
+        cwd: duplicateField === "cwd" ? canonicalWorktreePath : `/tmp/${randomUUID()}`,
+        providerRef: duplicateField === "providerRef" ? canonicalWorktreePath : `/tmp/${randomUUID()}`,
+        branchName: duplicateField === "branchName" ? git.branch : `feature/${randomUUID()}`,
+        metadata: duplicateField === "fullBranchRef" ? { fullBranchRef: git.fullBranchRef } : null,
+      });
+
+      await expect(svc.adoptGitWorktree(scope.companyId, adoptionRequest({ ...git, ...scope }), {
+        actorType: "user",
+        actorId: "local-board",
+        agentId: null,
+        runId: null,
+      })).rejects.toMatchObject({
+        reasonCode: "workspace_conflict",
+        status: 409,
+      });
+    }
+  }, 60_000);
+
+  it("rejects cross-project and cross-company adoption identifiers before git inspection", async () => {
+    const git = await createAdoptionGitFixture();
+    tempDirs.add(git.repoRoot);
+    tempDirs.add(git.worktreePath);
+    const scope = await seedAdoptionScope(db, {
+      repoRoot: git.repoRoot,
+      repoUrl: git.repoUrl,
+    });
+    const otherProjectId = randomUUID();
+    const otherProjectWorkspaceId = randomUUID();
+    const otherProjectIssueId = randomUUID();
+    await db.insert(projects).values({
+      id: otherProjectId,
+      companyId: scope.companyId,
+      name: "Other project",
+      status: "in_progress",
+    });
+    await db.insert(projectWorkspaces).values({
+      id: otherProjectWorkspaceId,
+      companyId: scope.companyId,
+      projectId: otherProjectId,
+      name: "Other primary",
+      cwd: git.repoRoot,
+      repoUrl: git.repoUrl,
+      isPrimary: true,
+    });
+    await db.insert(issues).values({
+      id: otherProjectIssueId,
+      companyId: scope.companyId,
+      projectId: otherProjectId,
+      title: "Other project issue",
+      status: "todo",
+      priority: "medium",
+    });
+    const otherCompany = await seedAdoptionScope(db, {
+      repoRoot: git.repoRoot,
+      repoUrl: git.repoUrl,
+    });
+    const cases = [
+      { projectId: otherProjectId },
+      { projectWorkspaceId: otherProjectWorkspaceId },
+      { sourceIssueId: otherProjectIssueId },
+      { bindIssueId: otherProjectIssueId },
+      { projectId: otherCompany.projectId },
+      { projectWorkspaceId: otherCompany.projectWorkspaceId },
+      { sourceIssueId: otherCompany.sourceIssueId },
+      { bindIssueId: otherCompany.bindIssueId },
+    ];
+
+    for (const patch of cases) {
+      await expect(svc.adoptGitWorktree(scope.companyId, {
+        ...adoptionRequest({ ...git, ...scope }),
+        ...patch,
+      }, {
+        actorType: "user",
+        actorId: "local-board",
+        agentId: null,
+        runId: null,
+      })).rejects.toMatchObject({
+        reasonCode: "cross_scope_not_found",
+        status: 404,
+      });
+    }
+    await expect(countAdoptionSideEffects(db)).resolves.toEqual({
+      workspaces: 0,
+      operations: 0,
+      activity: 0,
+    });
+  }, 20_000);
+
+  it("rolls back adopted records without deleting or mutating the adopted git worktree", async () => {
+    const git = await createAdoptionGitFixture();
+    tempDirs.add(git.repoRoot);
+    tempDirs.add(git.worktreePath);
+    const scope = await seedAdoptionScope(db, {
+      repoRoot: git.repoRoot,
+      repoUrl: git.repoUrl,
+    });
+    const beforeHead = await readGit(git.worktreePath, ["rev-parse", "HEAD"]);
+    const beforeBranch = await readGit(git.worktreePath, ["symbolic-ref", "--quiet", "HEAD"]);
+
+    const adopted = await svc.adoptGitWorktree(scope.companyId, adoptionRequest({ ...git, ...scope }), {
+      actorType: "user",
+      actorId: "local-board",
+      agentId: null,
+      runId: null,
+    });
+    const rolledBack = await svc.rollbackAdoption(adopted.workspace.id, {
+      actorType: "user",
+      actorId: "local-board",
+      agentId: null,
+      runId: null,
+    }, "record-only rollback");
+
+    expect(rolledBack).toMatchObject({
+      id: adopted.workspace.id,
+      status: "archived",
+      cleanupReason: "adoption_rollback",
+      boundIssue: null,
+    });
+    await expect(fs.access(git.worktreePath)).resolves.toBeUndefined();
+    await expect(readGit(git.worktreePath, ["rev-parse", "HEAD"])).resolves.toBe(beforeHead);
+    await expect(readGit(git.worktreePath, ["symbolic-ref", "--quiet", "HEAD"])).resolves.toBe(beforeBranch);
+    await expect(readGit(git.worktreePath, ["status", "--porcelain=v1", "--untracked-files=all"])).resolves.toBeNull();
+    const operations = await db.select().from(workspaceOperations).where(eq(workspaceOperations.executionWorkspaceId, adopted.workspace.id));
+    expect(operations.map((row) => row.phase)).toEqual(["workspace_adopt"]);
+  }, 20_000);
+
+  it("rolls back atomically when adoption fails after workspace insert but before optional issue binding", async () => {
+    const git = await createAdoptionGitFixture();
+    tempDirs.add(git.repoRoot);
+    tempDirs.add(git.worktreePath);
+    const scope = await seedAdoptionScope(db, {
+      repoRoot: git.repoRoot,
+      repoUrl: git.repoUrl,
+    });
+    const previousWorkspaceId = randomUUID();
+    await db.insert(executionWorkspaces).values({
+      id: previousWorkspaceId,
+      companyId: scope.companyId,
+      projectId: scope.projectId,
+      sourceIssueId: scope.sourceIssueId,
+      mode: "isolated_workspace",
+      strategyType: "git_worktree",
+      name: "previous",
+      status: "active",
+      providerType: "git_worktree",
+      cwd: `/tmp/${randomUUID()}`,
+      branchName: "feature/previous",
+    });
+    await db.update(issues).set({
+      executionWorkspaceId: previousWorkspaceId,
+      executionWorkspacePreference: "reuse_existing",
+    }).where(eq(issues.id, scope.bindIssueId!));
+    const failingSvc = executionWorkspaceService(db, {
+      afterAdoptionWorkspaceInsert: () => {
+        throw new Error("forced adoption failure");
+      },
+    });
+
+    await expect(failingSvc.adoptGitWorktree(scope.companyId, adoptionRequest({ ...git, ...scope }), {
+      actorType: "user",
+      actorId: "local-board",
+      agentId: null,
+      runId: null,
+    })).rejects.toThrow("forced adoption failure");
+
+    const rows = await db.select().from(executionWorkspaces);
+    expect(rows.map((row) => row.id)).toEqual([previousWorkspaceId]);
+    const [boundIssue] = await db.select().from(issues).where(eq(issues.id, scope.bindIssueId!));
+    expect(boundIssue).toMatchObject({
+      executionWorkspaceId: previousWorkspaceId,
+      executionWorkspacePreference: "reuse_existing",
+    });
+    await expect(countAdoptionSideEffects(db)).resolves.toEqual({
+      workspaces: 1,
+      operations: 0,
+      activity: 0,
+    });
+  }, 20_000);
+
+  it("treats shell-shaped git inputs as argv data and does not mutate git artifacts", async () => {
+    const git = await createAdoptionGitFixture({
+      worktreeSlug: "paperclip-adopt-argv-safe;touch-should-not-run",
+    });
+    tempDirs.add(git.repoRoot);
+    tempDirs.add(git.worktreePath);
+    const scope = await seedAdoptionScope(db, {
+      repoRoot: git.repoRoot,
+      repoUrl: git.repoUrl,
+    });
+    const markerPath = path.join(path.dirname(git.repoRoot), "paperclip-adoption-shell-marker");
+    const beforeHead = await readGit(git.worktreePath, ["rev-parse", "HEAD"]);
+    const beforeStatus = await readGit(git.worktreePath, ["status", "--porcelain=v1", "--untracked-files=all"]);
+
+    await expect(svc.adoptGitWorktree(scope.companyId, adoptionRequest({ ...git, ...scope }, {
+      expectedBranch: `${git.fullBranchRef};touch ${markerPath}`,
+      name: `argv-safe;touch ${markerPath}`,
+    }), {
+      actorType: "user",
+      actorId: "local-board",
+      agentId: null,
+      runId: null,
+    })).rejects.toMatchObject({
+      reasonCode: "missing_branch",
+      status: 422,
+    });
+
+    await expect(fs.access(markerPath)).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(readGit(git.worktreePath, ["rev-parse", "HEAD"])).resolves.toBe(beforeHead);
+    await expect(readGit(git.worktreePath, ["status", "--porcelain=v1", "--untracked-files=all"])).resolves.toBe(beforeStatus);
+    await expect(countAdoptionSideEffects(db)).resolves.toEqual({
+      workspaces: 0,
+      operations: 0,
+      activity: 0,
+    });
+  }, 20_000);
+
+  it("rolls back adopted records by restoring the previous issue binding without cleanup operations", async () => {
+    const companyId = randomUUID();
+    const projectId = randomUUID();
+    const previousWorkspaceId = randomUUID();
+    const adoptedWorkspaceId = randomUUID();
+    const sourceIssueId = randomUUID();
+    const bindIssueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: "PAP",
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(projects).values({
+      id: projectId,
+      companyId,
+      name: "Rollback adoption",
+      status: "in_progress",
+    });
+    await db.insert(issues).values({
+      id: sourceIssueId,
+      companyId,
+      projectId,
+      title: "Source issue",
+      status: "todo",
+      priority: "medium",
+    });
+    await db.insert(executionWorkspaces).values([
+      {
+        id: previousWorkspaceId,
+        companyId,
+        projectId,
+        sourceIssueId,
+        mode: "isolated_workspace",
+        strategyType: "git_worktree",
+        name: "previous",
+        status: "active",
+        providerType: "git_worktree",
+        cwd: "/tmp/previous",
+        branchName: "feature/previous",
+      },
+      {
+        id: adoptedWorkspaceId,
+        companyId,
+        projectId,
+        sourceIssueId,
+        mode: "isolated_workspace",
+        strategyType: "git_worktree",
+        name: "adopted",
+        status: "active",
+        providerType: "git_worktree",
+        cwd: "/tmp/adopted",
+        branchName: "feature/adopted",
+        metadata: {
+          adoption: {
+            version: 1,
+            immutableFingerprint: "execution_workspace_adoption:v1:sha256:test",
+            boundIssueId: bindIssueId,
+            previousIssueBinding: {
+              issueId: bindIssueId,
+              executionWorkspaceId: previousWorkspaceId,
+              executionWorkspacePreference: "reuse_existing",
+              executionWorkspaceSettings: {
+                mode: "isolated_workspace",
+                workspaceStrategy: {
+                  type: "git_worktree",
+                  baseRef: "origin/feature/previous",
+                },
+              },
+            },
+          },
+        },
+      },
+    ]);
+    await db.insert(issues).values({
+      id: bindIssueId,
+      companyId,
+      projectId,
+      title: "Bound issue",
+      status: "todo",
+      priority: "medium",
+      executionWorkspaceId: adoptedWorkspaceId,
+      executionWorkspacePreference: "reuse_existing",
+      executionWorkspaceSettings: {
+        mode: "isolated_workspace",
+        workspaceStrategy: {
+          type: "git_worktree",
+          baseRef: "origin/feature/adopted",
+        },
+      },
+    });
+
+    const result = await svc.rollbackAdoption(adoptedWorkspaceId, {
+      actorType: "user",
+      actorId: "local-board",
+      agentId: null,
+      runId: null,
+    }, "operator rollback");
+
+    expect(result).toMatchObject({
+      id: adoptedWorkspaceId,
+      status: "archived",
+      cleanupReason: "adoption_rollback",
+      boundIssue: null,
+    });
+    const [boundIssue] = await db.select().from(issues).where(eq(issues.id, bindIssueId));
+    expect(boundIssue).toMatchObject({
+      executionWorkspaceId: previousWorkspaceId,
+      executionWorkspacePreference: "reuse_existing",
+    });
+    expect(boundIssue?.executionWorkspaceSettings).toMatchObject({
+      workspaceStrategy: {
+        baseRef: "origin/feature/previous",
+      },
+    });
+    const operations = await db.select().from(workspaceOperations).where(eq(workspaceOperations.executionWorkspaceId, adoptedWorkspaceId));
+    expect(operations).toHaveLength(0);
+    const activity = await db.select().from(activityLog).where(eq(activityLog.entityId, adoptedWorkspaceId));
+    expect(activity.map((row) => row.action)).toEqual(["execution_workspace.adoption_rolled_back"]);
+  });
 
   it("returns a bounded company-scoped workspace overview with service and linked issue summaries", async () => {
     const companyId = randomUUID();

--- a/server/src/__tests__/openapi-routes.test.ts
+++ b/server/src/__tests__/openapi-routes.test.ts
@@ -212,6 +212,7 @@ describe("openapi routes", () => {
         reason: { type: "string" },
       },
     });
+    expect(res.body.paths["/api/execution-workspaces/{id}/rollback-adoption"].post.responses["409"]).toBeDefined();
     expect(JSON.stringify(res.body.paths["/api/tool-gateway/tools"].get)).not.toContain("sessionToken");
     expect(JSON.stringify(res.body.paths["/api/tool-gateway/tools/call"].post)).not.toContain("sessionToken");
   });

--- a/server/src/__tests__/openapi-routes.test.ts
+++ b/server/src/__tests__/openapi-routes.test.ts
@@ -213,6 +213,7 @@ describe("openapi routes", () => {
       },
     });
     expect(res.body.paths["/api/execution-workspaces/{id}/rollback-adoption"].post.responses["409"]).toBeDefined();
+    expect(res.body.paths["/api/execution-workspaces/{id}"].patch.responses["409"]).toBeDefined();
     expect(JSON.stringify(res.body.paths["/api/tool-gateway/tools"].get)).not.toContain("sessionToken");
     expect(JSON.stringify(res.body.paths["/api/tool-gateway/tools/call"].post)).not.toContain("sessionToken");
   });

--- a/server/src/__tests__/openapi-routes.test.ts
+++ b/server/src/__tests__/openapi-routes.test.ts
@@ -189,6 +189,29 @@ describe("openapi routes", () => {
     expect(res.body.paths["/api/companies/{companyId}/folders/items/move"].post.summary).toBe(
       "Move an item into or out of a folder",
     );
+    expect(res.body.paths["/api/companies/{companyId}/execution-workspaces/adopt-git-worktree"].post.requestBody.content["application/json"].schema).toMatchObject({
+      type: "object",
+      required: expect.arrayContaining([
+        "projectId",
+        "projectWorkspaceId",
+        "sourceIssueId",
+        "cwd",
+        "expectedBranch",
+        "expectedHeadSha",
+        "expectedUpstream",
+        "name",
+      ]),
+      properties: {
+        expectedBranch: { type: "string" },
+        expectedHeadSha: { type: "string", pattern: "^[0-9a-f]{40}$" },
+      },
+    });
+    expect(res.body.paths["/api/execution-workspaces/{id}/rollback-adoption"].post.requestBody.content["application/json"].schema).toMatchObject({
+      type: "object",
+      properties: {
+        reason: { type: "string" },
+      },
+    });
     expect(JSON.stringify(res.body.paths["/api/tool-gateway/tools"].get)).not.toContain("sessionToken");
     expect(JSON.stringify(res.body.paths["/api/tool-gateway/tools/call"].post)).not.toContain("sessionToken");
   });
@@ -225,6 +248,30 @@ describe("openapi routes", () => {
     ]);
     expect(spec.paths["/api/execution-workspaces/{id}/reconcile-branch"].post["x-paperclip-authorization"]).toEqual({
       actor: "board",
+    });
+    expect(spec.paths["/api/companies/{companyId}/execution-workspaces/adopt-git-worktree"].post.security).toEqual([
+      { BoardSessionAuth: [] },
+      { BoardApiKeyAuth: [] },
+      { AgentBearerAuth: [] },
+    ]);
+    expect(spec.paths["/api/companies/{companyId}/execution-workspaces/adopt-git-worktree"].post["x-paperclip-authorization"]).toEqual({
+      actor: "board_or_agent",
+    });
+    expect(spec.paths["/api/companies/{companyId}/execution-workspaces/adopt-git-worktree"].post.requestBody.content["application/json"].schema).toMatchObject({
+      type: "object",
+      required: [
+        "projectId",
+        "projectWorkspaceId",
+        "sourceIssueId",
+        "cwd",
+        "expectedBranch",
+        "expectedHeadSha",
+        "expectedUpstream",
+        "name",
+      ],
+    });
+    expect(spec.paths["/api/execution-workspaces/{id}/rollback-adoption"].post["x-paperclip-authorization"]).toEqual({
+      actor: "board_or_agent",
     });
     expect(spec.paths["/api/companies/{companyId}/cost-events"].post.responses["201"]).toBeDefined();
     expect(spec.paths["/api/companies/{companyId}/cost-events"].post.responses["403"]).toBeDefined();

--- a/server/src/__tests__/workspace-runtime.test.ts
+++ b/server/src/__tests__/workspace-runtime.test.ts
@@ -3139,6 +3139,70 @@ describe("realizeExecutionWorkspace", () => {
     });
   });
 
+  it("preserves adopted operator-owned git artifacts and skips cleanup commands", async () => {
+    const repoRoot = await createTempRepo();
+    const branchName = "operator-owned-close";
+    const worktreePath = path.join(path.dirname(repoRoot), `paperclip-operator-owned-${randomUUID()}`);
+    const cleanupMarker = path.join(repoRoot, "cleanup-ran");
+    const teardownMarker = path.join(repoRoot, "teardown-ran");
+    const { recorder, operations } = createWorkspaceOperationRecorderDouble();
+
+    await runGit(repoRoot, ["remote", "add", "origin", repoRoot]);
+    await runGit(repoRoot, ["branch", branchName]);
+    const initialHead = await readGit(repoRoot, ["rev-parse", branchName]);
+    await runGit(repoRoot, ["update-ref", `refs/remotes/origin/${branchName}`, initialHead!]);
+    await runGit(repoRoot, ["branch", "--set-upstream-to", `origin/${branchName}`, branchName]);
+    await runGit(repoRoot, ["worktree", "add", worktreePath, branchName]);
+    await fs.writeFile(path.join(worktreePath, "README.md"), "operator edit\n", "utf8");
+    await fs.writeFile(path.join(worktreePath, "operator-untracked.txt"), "preserve me\n", "utf8");
+
+    const before = {
+      head: await readGit(worktreePath, ["rev-parse", "HEAD"]),
+      branchRef: await readGit(repoRoot, ["rev-parse", `refs/heads/${branchName}`]),
+      branch: await readGit(worktreePath, ["symbolic-ref", "--short", "HEAD"]),
+      upstream: await readGit(worktreePath, ["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}"]),
+      status: await readGit(worktreePath, ["status", "--porcelain", "--untracked-files=all"]),
+    };
+
+    const cleanup = await cleanupExecutionWorkspaceArtifacts({
+      workspace: {
+        id: "adopted-workspace-1",
+        cwd: worktreePath,
+        providerType: "git_worktree",
+        providerRef: worktreePath,
+        branchName,
+        repoUrl: repoRoot,
+        baseRef: "main",
+        projectId: "project-1",
+        projectWorkspaceId: "project-workspace-1",
+        sourceIssueId: "issue-1",
+        metadata: {
+          createdByRuntime: true,
+          ownsGitArtifacts: false,
+        },
+      },
+      projectWorkspace: {
+        cwd: repoRoot,
+        cleanupCommand: `node -e "require('node:fs').writeFileSync(${JSON.stringify(cleanupMarker)}, 'ran')"`,
+      },
+      teardownCommand: `node -e "require('node:fs').writeFileSync(${JSON.stringify(teardownMarker)}, 'ran')"`,
+      recorder,
+    });
+
+    expect(cleanup).toEqual({ cleanedPath: null, cleaned: true, warnings: [] });
+    expect(operations).toEqual([]);
+    await expect(fs.stat(worktreePath)).resolves.toBeDefined();
+    await expect(fs.stat(cleanupMarker)).rejects.toThrow();
+    await expect(fs.stat(teardownMarker)).rejects.toThrow();
+    await expect(readGit(worktreePath, ["rev-parse", "HEAD"])).resolves.toBe(before.head);
+    await expect(readGit(repoRoot, ["rev-parse", `refs/heads/${branchName}`])).resolves.toBe(before.branchRef);
+    await expect(readGit(worktreePath, ["symbolic-ref", "--short", "HEAD"])).resolves.toBe(before.branch);
+    await expect(
+      readGit(worktreePath, ["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}"]),
+    ).resolves.toBe(before.upstream);
+    await expect(readGit(worktreePath, ["status", "--porcelain", "--untracked-files=all"])).resolves.toBe(before.status);
+  });
+
   it("keeps an unmerged runtime-created branch and warns instead of force deleting it", async () => {
     const repoRoot = await createTempRepo();
 

--- a/server/src/routes/execution-workspaces.ts
+++ b/server/src/routes/execution-workspaces.ts
@@ -67,6 +67,7 @@ const ADOPTED_WORKSPACE_MUTABLE_PATCH_KEYS = new Set([
 const SERVER_OWNED_EXECUTION_WORKSPACE_METADATA_KEYS = [
   "adoption",
   "adoptionRollback",
+  "repositoryIdentity",
   "fullBranchRef",
   "ownsGitArtifacts",
   "createdByRuntime",

--- a/server/src/routes/execution-workspaces.ts
+++ b/server/src/routes/execution-workspaces.ts
@@ -37,9 +37,19 @@ import { assertCanManageExecutionWorkspaceRuntimeServices } from "./workspace-ru
 import { appendWithCap } from "../adapters/utils.js";
 import { environmentRuntimeService } from "../services/environment-runtime.js";
 import type { PluginWorkerManager } from "../services/plugin-worker-manager.js";
-import { ExecutionWorkspaceAdoptionError } from "../services/execution-workspaces.js";
+import {
+  ExecutionWorkspaceAdoptionError,
+  type ExecutionWorkspaceIssueAuthorizationSnapshot,
+} from "../services/execution-workspaces.js";
 
 const WORKSPACE_CONTROL_OUTPUT_MAX_CHARS = 256 * 1024;
+
+function adoptionBoundIssueId(metadata: Record<string, unknown> | null | undefined) {
+  const adoption = metadata?.adoption;
+  if (!adoption || typeof adoption !== "object" || Array.isArray(adoption)) return null;
+  const value = (adoption as Record<string, unknown>).boundIssueId;
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
 
 export function executionWorkspaceRoutes(db: Db, opts: { pluginWorkerManager?: PluginWorkerManager } = {}) {
   const router = Router();
@@ -157,6 +167,7 @@ export function executionWorkspaceRoutes(db: Db, opts: { pluginWorkerManager?: P
       await logAdoptionRejected(req, companyId, "unauthorized");
       return;
     }
+    let authorizedBindIssue: ExecutionWorkspaceIssueAuthorizationSnapshot | null = null;
     if (parsed.data.bindIssueId) {
       const [bindIssue] = await db
         .select({
@@ -167,6 +178,7 @@ export function executionWorkspaceRoutes(db: Db, opts: { pluginWorkerManager?: P
           assigneeAgentId: issues.assigneeAgentId,
           assigneeUserId: issues.assigneeUserId,
           status: issues.status,
+          executionPolicy: issues.executionPolicy,
           originKind: issues.originKind,
           originId: issues.originId,
         })
@@ -209,6 +221,7 @@ export function executionWorkspaceRoutes(db: Db, opts: { pluginWorkerManager?: P
         });
         return;
       }
+      authorizedBindIssue = bindIssue;
     }
     const actor = getActorInfo(req);
     try {
@@ -217,7 +230,7 @@ export function executionWorkspaceRoutes(db: Db, opts: { pluginWorkerManager?: P
         actorId: actor.actorId,
         agentId: actor.agentId,
         runId: actor.runId,
-      });
+      }, authorizedBindIssue);
       res.status(result.operation ? 201 : 200).json(result);
     } catch (error) {
       if (error instanceof ExecutionWorkspaceAdoptionError) {
@@ -702,14 +715,72 @@ export function executionWorkspaceRoutes(db: Db, opts: { pluginWorkerManager?: P
     const existing = await getAccessibleResource(req, res, svc.getById(id), "Execution workspace not found");
     if (!existing) return;
     if (!(await assertAdoptionAllowed(req, res, existing.companyId, existing.projectId))) return;
+    const boundIssueId = adoptionBoundIssueId(existing.metadata);
+    let authorizedBoundIssue: ExecutionWorkspaceIssueAuthorizationSnapshot | null = null;
+    if (boundIssueId) {
+      const [boundIssue] = await db
+        .select({
+          id: issues.id,
+          parentId: issues.parentId,
+          assigneeAgentId: issues.assigneeAgentId,
+          assigneeUserId: issues.assigneeUserId,
+          status: issues.status,
+          executionPolicy: issues.executionPolicy,
+          originKind: issues.originKind,
+          originId: issues.originId,
+        })
+        .from(issues)
+        .where(and(
+          eq(issues.id, boundIssueId),
+          eq(issues.companyId, existing.companyId),
+          eq(issues.projectId, existing.projectId),
+        ))
+        .limit(1);
+      if (!boundIssue) {
+        res.status(409).json({ error: "Adoption rollback no longer matches the bound issue", reasonCode: "workspace_conflict" });
+        return;
+      }
+      const bindDecision = await access.decide({
+        actor: req.actor,
+        action: "issue:mutate",
+        resource: {
+          type: "issue",
+          companyId: existing.companyId,
+          issueId: boundIssue.id,
+          projectId: existing.projectId,
+          parentIssueId: boundIssue.parentId,
+          assigneeAgentId: boundIssue.assigneeAgentId,
+          assigneeUserId: boundIssue.assigneeUserId,
+          status: boundIssue.status,
+          originKind: boundIssue.originKind,
+          originId: boundIssue.originId,
+        },
+      });
+      if (!bindDecision.allowed) {
+        res.status(req.actor.type === "agent" ? 404 : 403).json({
+          error: req.actor.type === "agent" ? "Execution workspace adoption target not found" : "Issue rollback is not authorized",
+          reasonCode: req.actor.type === "agent" ? "cross_scope_not_found" : "unauthorized",
+        });
+        return;
+      }
+      authorizedBoundIssue = boundIssue;
+    }
     const actor = getActorInfo(req);
-    const workspace = await svc.rollbackAdoption(id, {
-      actorType: actor.actorType,
-      actorId: actor.actorId,
-      agentId: actor.agentId,
-      runId: actor.runId,
-    }, req.body.reason ?? null);
-    res.json({ workspace });
+    try {
+      const workspace = await svc.rollbackAdoption(id, {
+        actorType: actor.actorType,
+        actorId: actor.actorId,
+        agentId: actor.agentId,
+        runId: actor.runId,
+      }, req.body.reason ?? null, boundIssueId, authorizedBoundIssue);
+      res.json({ workspace });
+    } catch (error) {
+      if (error instanceof ExecutionWorkspaceAdoptionError) {
+        res.status(error.status).json({ error: "Execution workspace adoption rollback rejected", reasonCode: error.reasonCode });
+        return;
+      }
+      throw error;
+    }
   });
 
   router.patch("/execution-workspaces/:id", validate(updateExecutionWorkspaceSchema), async (req, res) => {

--- a/server/src/routes/execution-workspaces.ts
+++ b/server/src/routes/execution-workspaces.ts
@@ -55,6 +55,23 @@ function adoptionBoundIssueId(metadata: Record<string, unknown> | null | undefin
   return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
 }
 
+const ADOPTED_WORKSPACE_MUTABLE_PATCH_KEYS = new Set([
+  "name",
+  "config",
+  "status",
+  "cleanupEligibleAt",
+  "cleanupReason",
+]);
+
+function isAdoptedWorkspace(workspace: {
+  metadata?: Record<string, unknown> | null;
+}) {
+  const adoption = workspace.metadata?.adoption;
+  return adoption !== null
+    && typeof adoption === "object"
+    && !Array.isArray(adoption);
+}
+
 export function executionWorkspaceRoutes(db: Db, opts: { pluginWorkerManager?: PluginWorkerManager } = {}) {
   const router = Router();
   const svc = executionWorkspaceService(db);
@@ -792,6 +809,16 @@ export function executionWorkspaceRoutes(db: Db, opts: { pluginWorkerManager?: P
     const existing = await getAccessibleResource(req, res, svc.getById(id), "Execution workspace not found");
     if (!existing) return;
     if (!(await assertRuntimeManageAllowed(req, res, existing.companyId))) return;
+    if (
+      isAdoptedWorkspace(existing)
+      && Object.keys(req.body).some((key) => !ADOPTED_WORKSPACE_MUTABLE_PATCH_KEYS.has(key))
+    ) {
+      res.status(409).json({
+        error: "Adopted execution workspace identity is immutable",
+        reasonCode: "adopted_workspace_identity_immutable",
+      });
+      return;
+    }
     assertNoAgentHostWorkspaceCommandMutation(
       req,
       collectExecutionWorkspaceCommandPaths({

--- a/server/src/routes/execution-workspaces.ts
+++ b/server/src/routes/execution-workspaces.ts
@@ -3,9 +3,11 @@ import { Router, type Request, type Response } from "express";
 import type { Db } from "@paperclipai/db";
 import { issues, projects, projectWorkspaces } from "@paperclipai/db";
 import {
+  adoptGitWorktreeExecutionWorkspaceSchema,
   findWorkspaceCommandDefinition,
   matchWorkspaceRuntimeServiceToCommand,
   reconcileExecutionWorkspaceBranchSchema,
+  rollbackAdoptedExecutionWorkspaceSchema,
   updateExecutionWorkspaceSchema,
   workspaceOverviewQuerySchema,
   workspaceRuntimeControlTargetSchema,
@@ -35,6 +37,7 @@ import { assertCanManageExecutionWorkspaceRuntimeServices } from "./workspace-ru
 import { appendWithCap } from "../adapters/utils.js";
 import { environmentRuntimeService } from "../services/environment-runtime.js";
 import type { PluginWorkerManager } from "../services/plugin-worker-manager.js";
+import { ExecutionWorkspaceAdoptionError } from "../services/execution-workspaces.js";
 
 const WORKSPACE_CONTROL_OUTPUT_MAX_CHARS = 256 * 1024;
 
@@ -72,6 +75,40 @@ export function executionWorkspaceRoutes(db: Db, opts: { pluginWorkerManager?: P
     return false;
   }
 
+  async function assertAdoptionAllowed(req: Request, res: Response, companyId: string, projectId: string) {
+    const decision = await access.decide({
+      actor: req.actor,
+      action: "execution_workspaces:adopt",
+      resource: { type: "project", companyId, projectId },
+      scope: { projectId },
+    });
+    if (decision.allowed) return true;
+    res.status(req.actor.type === "agent" ? 404 : 403).json({
+      error: req.actor.type === "agent" ? "Execution workspace adoption target not found" : "Execution workspace adoption is not authorized",
+      reasonCode: req.actor.type === "agent" ? "cross_scope_not_found" : "unauthorized",
+    });
+    return false;
+  }
+
+  async function logAdoptionRejected(req: Request, companyId: string, reasonCode: string) {
+    try {
+      const actor = getActorInfo(req);
+      await logActivity(db, {
+        companyId,
+        actorType: actor.actorType,
+        actorId: actor.actorId,
+        agentId: actor.agentId,
+        runId: actor.runId,
+        action: "execution_workspace.adoption_rejected",
+        entityType: "company",
+        entityId: companyId,
+        details: { reasonCode },
+      });
+    } catch {
+      // Rejection logging must not convert a safe denial into an unexpected failure.
+    }
+  }
+
   router.get("/companies/:companyId/execution-workspaces", async (req, res) => {
     const companyId = req.params.companyId as string;
     assertCompanyAccess(req, companyId);
@@ -105,6 +142,96 @@ export function executionWorkspaceRoutes(db: Db, opts: { pluginWorkerManager?: P
 
     const overview = await svc.listOverview(companyId, parsed.data);
     res.json(overview);
+  });
+
+  router.post("/companies/:companyId/execution-workspaces/adopt-git-worktree", async (req, res) => {
+    const companyId = req.params.companyId as string;
+    assertCompanyAccess(req, companyId);
+    const parsed = adoptGitWorktreeExecutionWorkspaceSchema.safeParse(req.body);
+    if (!parsed.success) {
+      await logAdoptionRejected(req, companyId, "unsafe_input");
+      res.status(422).json({ error: "Invalid execution workspace adoption request", reasonCode: "unsafe_input" });
+      return;
+    }
+    if (!(await assertAdoptionAllowed(req, res, companyId, parsed.data.projectId))) {
+      await logAdoptionRejected(req, companyId, "unauthorized");
+      return;
+    }
+    if (parsed.data.bindIssueId) {
+      const [bindIssue] = await db
+        .select({
+          id: issues.id,
+          companyId: issues.companyId,
+          projectId: issues.projectId,
+          parentId: issues.parentId,
+          assigneeAgentId: issues.assigneeAgentId,
+          assigneeUserId: issues.assigneeUserId,
+          status: issues.status,
+          originKind: issues.originKind,
+          originId: issues.originId,
+        })
+        .from(issues)
+        .where(and(
+          eq(issues.id, parsed.data.bindIssueId),
+          eq(issues.companyId, companyId),
+          eq(issues.projectId, parsed.data.projectId),
+        ))
+        .limit(1);
+      if (!bindIssue) {
+        await logAdoptionRejected(req, companyId, "cross_scope_not_found");
+        res.status(404).json({
+          error: "Execution workspace adoption target not found",
+          reasonCode: "cross_scope_not_found",
+        });
+        return;
+      }
+      const bindDecision = await access.decide({
+        actor: req.actor,
+        action: "issue:mutate",
+        resource: {
+          type: "issue",
+          companyId,
+          issueId: parsed.data.bindIssueId,
+          projectId: parsed.data.projectId,
+          parentIssueId: bindIssue.parentId,
+          assigneeAgentId: bindIssue.assigneeAgentId,
+          assigneeUserId: bindIssue.assigneeUserId,
+          status: bindIssue.status,
+          originKind: bindIssue.originKind,
+          originId: bindIssue.originId,
+        },
+      });
+      if (!bindDecision.allowed) {
+        await logAdoptionRejected(req, companyId, "unauthorized");
+        res.status(req.actor.type === "agent" ? 404 : 403).json({
+          error: req.actor.type === "agent" ? "Execution workspace adoption target not found" : "Issue binding is not authorized",
+          reasonCode: req.actor.type === "agent" ? "cross_scope_not_found" : "unauthorized",
+        });
+        return;
+      }
+    }
+    const actor = getActorInfo(req);
+    try {
+      const result = await svc.adoptGitWorktree(companyId, parsed.data, {
+        actorType: actor.actorType,
+        actorId: actor.actorId,
+        agentId: actor.agentId,
+        runId: actor.runId,
+      });
+      res.status(result.operation ? 201 : 200).json(result);
+    } catch (error) {
+      if (error instanceof ExecutionWorkspaceAdoptionError) {
+        await logAdoptionRejected(req, companyId, error.reasonCode);
+        res.status(error.status).json({
+          error: "Execution workspace adoption rejected",
+          reasonCode: error.reasonCode,
+        });
+        return;
+      }
+      await logAdoptionRejected(req, companyId, "unexpected_failure");
+      logger.warn({ err: error, companyId }, "execution workspace adoption failed unexpectedly");
+      res.status(500).json({ error: "Execution workspace adoption failed", reasonCode: "unexpected_failure" });
+    }
   });
 
   router.get("/execution-workspaces/:id", async (req, res) => {
@@ -568,6 +695,21 @@ export function executionWorkspaceRoutes(db: Db, opts: { pluginWorkerManager?: P
     }
 
     res.json(result);
+  });
+
+  router.post("/execution-workspaces/:id/rollback-adoption", validate(rollbackAdoptedExecutionWorkspaceSchema), async (req, res) => {
+    const id = req.params.id as string;
+    const existing = await getAccessibleResource(req, res, svc.getById(id), "Execution workspace not found");
+    if (!existing) return;
+    if (!(await assertAdoptionAllowed(req, res, existing.companyId, existing.projectId))) return;
+    const actor = getActorInfo(req);
+    const workspace = await svc.rollbackAdoption(id, {
+      actorType: actor.actorType,
+      actorId: actor.actorId,
+      agentId: actor.agentId,
+      runId: actor.runId,
+    }, req.body.reason ?? null);
+    res.json({ workspace });
   });
 
   router.patch("/execution-workspaces/:id", validate(updateExecutionWorkspaceSchema), async (req, res) => {

--- a/server/src/routes/execution-workspaces.ts
+++ b/server/src/routes/execution-workspaces.ts
@@ -1,3 +1,4 @@
+import { isDeepStrictEqual } from "node:util";
 import { and, eq } from "drizzle-orm";
 import { Router, type Request, type Response } from "express";
 import type { Db } from "@paperclipai/db";
@@ -62,6 +63,26 @@ const ADOPTED_WORKSPACE_MUTABLE_PATCH_KEYS = new Set([
   "cleanupEligibleAt",
   "cleanupReason",
 ]);
+
+const SERVER_OWNED_EXECUTION_WORKSPACE_METADATA_KEYS = [
+  "adoption",
+  "adoptionRollback",
+  "fullBranchRef",
+  "ownsGitArtifacts",
+  "createdByRuntime",
+] as const;
+
+function changedServerOwnedMetadataKeys(
+  existing: Record<string, unknown> | null | undefined,
+  requested: Record<string, unknown> | null,
+) {
+  const existingMetadata = existing ?? {};
+  const requestedMetadata = requested ?? {};
+  return SERVER_OWNED_EXECUTION_WORKSPACE_METADATA_KEYS.filter((key) =>
+    Object.hasOwn(existingMetadata, key) !== Object.hasOwn(requestedMetadata, key)
+    || !isDeepStrictEqual(existingMetadata[key], requestedMetadata[key]),
+  );
+}
 
 function isAdoptedWorkspace(workspace: {
   metadata?: Record<string, unknown> | null;
@@ -816,6 +837,20 @@ export function executionWorkspaceRoutes(db: Db, opts: { pluginWorkerManager?: P
       res.status(409).json({
         error: "Adopted execution workspace identity is immutable",
         reasonCode: "adopted_workspace_identity_immutable",
+      });
+      return;
+    }
+    const changedServerOwnedKeys = req.body.metadata === undefined
+      ? []
+      : changedServerOwnedMetadataKeys(
+          existing.metadata as Record<string, unknown> | null,
+          req.body.metadata as Record<string, unknown> | null,
+        );
+    if (changedServerOwnedKeys.length > 0) {
+      res.status(409).json({
+        error: "Execution workspace server-owned metadata is immutable",
+        reasonCode: "execution_workspace_server_owned_metadata_immutable",
+        protectedKeys: changedServerOwnedKeys,
       });
       return;
     }

--- a/server/src/routes/execution-workspaces.ts
+++ b/server/src/routes/execution-workspaces.ts
@@ -15,7 +15,11 @@ import {
 import type { WorkspaceRuntimeDesiredState, WorkspaceRuntimeServiceStateMap } from "@paperclipai/shared";
 import { validate } from "../middleware/validate.js";
 import { accessService, executionWorkspaceService, heartbeatService, logActivity, workspaceOperationService } from "../services/index.js";
-import { mergeExecutionWorkspaceConfig, readExecutionWorkspaceConfig } from "../services/execution-workspaces.js";
+import {
+  executionWorkspaceOwnsGitArtifacts,
+  mergeExecutionWorkspaceConfig,
+  readExecutionWorkspaceConfig,
+} from "../services/execution-workspaces.js";
 import { parseProjectExecutionWorkspacePolicy } from "../services/execution-workspace-policy.js";
 import { readProjectWorkspaceRuntimeConfig } from "../services/project-workspace-runtime-config.js";
 import {
@@ -877,50 +881,52 @@ export function executionWorkspaceRoutes(db: Db, opts: { pluginWorkerManager?: P
           executionWorkspaceId: existing.id,
           workspaceCwd: existing.cwd,
         });
-        const projectWorkspace = existing.projectWorkspaceId
-          ? await db
-              .select({
-                cwd: projectWorkspaces.cwd,
-                cleanupCommand: projectWorkspaces.cleanupCommand,
-              })
-              .from(projectWorkspaces)
-            .where(
-                and(
-                  eq(projectWorkspaces.id, existing.projectWorkspaceId),
-                  eq(projectWorkspaces.companyId, existing.companyId),
-                ),
-              )
-              .then((rows) => rows[0] ?? null)
-          : null;
-        const projectPolicy = existing.projectId
-          ? await db
-              .select({
-                executionWorkspacePolicy: projects.executionWorkspacePolicy,
-              })
-              .from(projects)
-              .where(and(eq(projects.id, existing.projectId), eq(projects.companyId, existing.companyId)))
-              .then((rows) => parseProjectExecutionWorkspacePolicy(rows[0]?.executionWorkspacePolicy))
-          : null;
-        const cleanupResult = await cleanupExecutionWorkspaceArtifacts({
-          workspace: existing,
-          projectWorkspace,
-          teardownCommand: configForCleanup?.teardownCommand ?? projectPolicy?.workspaceStrategy?.teardownCommand ?? null,
-          cleanupCommand: configForCleanup?.cleanupCommand ?? null,
-          recorder: workspaceOperationsSvc.createRecorder({
-            companyId: existing.companyId,
-            executionWorkspaceId: existing.id,
-          }),
-        });
-        cleanupWarnings = cleanupResult.warnings;
-        const cleanupPatch: Record<string, unknown> = {
-          closedAt,
-          cleanupReason: cleanupWarnings.length > 0 ? cleanupWarnings.join(" | ") : null,
-        };
-        if (!cleanupResult.cleaned) {
-          cleanupPatch.status = "cleanup_failed";
-        }
-        if (cleanupResult.warnings.length > 0 || !cleanupResult.cleaned) {
-          workspace = (await svc.update(id, cleanupPatch)) ?? workspace;
+        if (executionWorkspaceOwnsGitArtifacts(existing.metadata as Record<string, unknown> | null)) {
+          const projectWorkspace = existing.projectWorkspaceId
+            ? await db
+                .select({
+                  cwd: projectWorkspaces.cwd,
+                  cleanupCommand: projectWorkspaces.cleanupCommand,
+                })
+                .from(projectWorkspaces)
+              .where(
+                  and(
+                    eq(projectWorkspaces.id, existing.projectWorkspaceId),
+                    eq(projectWorkspaces.companyId, existing.companyId),
+                  ),
+                )
+                .then((rows) => rows[0] ?? null)
+            : null;
+          const projectPolicy = existing.projectId
+            ? await db
+                .select({
+                  executionWorkspacePolicy: projects.executionWorkspacePolicy,
+                })
+                .from(projects)
+                .where(and(eq(projects.id, existing.projectId), eq(projects.companyId, existing.companyId)))
+                .then((rows) => parseProjectExecutionWorkspacePolicy(rows[0]?.executionWorkspacePolicy))
+            : null;
+          const cleanupResult = await cleanupExecutionWorkspaceArtifacts({
+            workspace: existing,
+            projectWorkspace,
+            teardownCommand: configForCleanup?.teardownCommand ?? projectPolicy?.workspaceStrategy?.teardownCommand ?? null,
+            cleanupCommand: configForCleanup?.cleanupCommand ?? null,
+            recorder: workspaceOperationsSvc.createRecorder({
+              companyId: existing.companyId,
+              executionWorkspaceId: existing.id,
+            }),
+          });
+          cleanupWarnings = cleanupResult.warnings;
+          const cleanupPatch: Record<string, unknown> = {
+            closedAt,
+            cleanupReason: cleanupWarnings.length > 0 ? cleanupWarnings.join(" | ") : null,
+          };
+          if (!cleanupResult.cleaned) {
+            cleanupPatch.status = "cleanup_failed";
+          }
+          if (cleanupResult.warnings.length > 0 || !cleanupResult.cleaned) {
+            workspace = (await svc.update(id, cleanupPatch)) ?? workspace;
+          }
         }
       } catch (error) {
         const failureReason = error instanceof Error ? error.message : String(error);

--- a/server/src/routes/openapi.ts
+++ b/server/src/routes/openapi.ts
@@ -4328,7 +4328,7 @@ registry.registerPath({
     params: z.object({ id: z.string() }),
     body: jsonBody(rollbackAdoptedExecutionWorkspaceSchema),
   },
-  responses: { 200: r.ok(), 401: r.unauthorized, 403: r.forbidden, 422: r.unprocessable },
+  responses: { 200: r.ok(), 401: r.unauthorized, 403: r.forbidden, 409: r.conflict, 422: r.unprocessable },
 });
 
 registry.registerPath({

--- a/server/src/routes/openapi.ts
+++ b/server/src/routes/openapi.ts
@@ -4304,7 +4304,7 @@ registry.registerPath({
     params: z.object({ id: z.string() }),
     body: jsonBody(updateExecutionWorkspaceSchema),
   },
-  responses: { 200: r.ok(), 400: r.badRequest, 401: r.unauthorized },
+  responses: { 200: r.ok(), 400: r.badRequest, 401: r.unauthorized, 409: r.conflict },
 });
 
 registry.registerPath({

--- a/server/src/routes/openapi.ts
+++ b/server/src/routes/openapi.ts
@@ -83,7 +83,9 @@ import {
   // Sidebar
   upsertSidebarOrderPreferenceSchema,
   // Execution workspaces
+  adoptGitWorktreeExecutionWorkspaceSchema,
   reconcileExecutionWorkspaceBranchSchema,
+  rollbackAdoptedExecutionWorkspaceSchema,
   updateExecutionWorkspaceSchema,
   workspaceOverviewQuerySchema,
   workspaceRuntimeControlTargetSchema,
@@ -4243,6 +4245,18 @@ registry.registerPath({
 });
 
 registry.registerPath({
+  method: "post",
+  path: "/api/companies/{companyId}/execution-workspaces/adopt-git-worktree",
+  tags: ["execution-workspaces"],
+  summary: "Adopt an existing exact git worktree as an execution workspace",
+  request: {
+    params: z.object({ companyId: z.string() }),
+    body: jsonBody(adoptGitWorktreeExecutionWorkspaceSchema),
+  },
+  responses: { 200: r.ok(), 201: r.ok(), 400: r.badRequest, 401: r.unauthorized, 403: r.forbidden, 404: r.notFound, 409: r.conflict, 422: r.unprocessable },
+});
+
+registry.registerPath({
   method: "get",
   path: "/api/companies/{companyId}/workspace-overview",
   tags: ["execution-workspaces"],
@@ -4301,6 +4315,18 @@ registry.registerPath({
   request: {
     params: z.object({ id: z.string() }),
     body: jsonBody(reconcileExecutionWorkspaceBranchSchema),
+  },
+  responses: { 200: r.ok(), 401: r.unauthorized, 403: r.forbidden, 404: r.notFound, 422: r.unprocessable },
+});
+
+registry.registerPath({
+  method: "post",
+  path: "/api/execution-workspaces/{id}/rollback-adoption",
+  tags: ["execution-workspaces"],
+  summary: "Rollback an adopted execution workspace record without filesystem cleanup",
+  request: {
+    params: z.object({ id: z.string() }),
+    body: jsonBody(rollbackAdoptedExecutionWorkspaceSchema),
   },
   responses: { 200: r.ok(), 401: r.unauthorized, 403: r.forbidden, 422: r.unprocessable },
 });

--- a/server/src/services/authorization.ts
+++ b/server/src/services/authorization.ts
@@ -352,7 +352,7 @@ async function scopeAllows(
   companyId: string,
   grantScope: Record<string, unknown> | null,
   requestedScope: Record<string, unknown> | null | undefined,
-  options: { requireStructuredScope?: boolean } = {},
+  options: { requireStructuredScope?: boolean; requireProjectConstraint?: boolean } = {},
 ) {
   if (!grantScope || Object.keys(grantScope).length === 0) return !options.requireStructuredScope;
   if (!requestedScope) return false;
@@ -426,8 +426,11 @@ async function scopeAllows(
     if (!matchesSubtree) return false;
   }
 
-  // Unknown metadata keys do not constrain the grant. Recognized constraints
-  // return false above when they fail to match the requested assignment scope.
+  if (options.requireProjectConstraint && projectIds.length === 0) return false;
+
+  // Unknown metadata keys do not constrain ordinary grants. Security-sensitive
+  // callers may require a recognized constraint kind above so metadata-only
+  // scopes cannot accidentally become broad grants.
   return !constrained ? true : constrained;
 }
 
@@ -681,6 +684,7 @@ export function authorizationService(db: Db) {
         requireStructuredScope:
           input.permissionKey === "tasks:assign_scope" ||
           input.permissionKey === "execution_workspaces:adopt",
+        requireProjectConstraint: input.permissionKey === "execution_workspaces:adopt",
       }))
     ) {
       return deny({

--- a/server/src/services/authorization.ts
+++ b/server/src/services/authorization.ts
@@ -678,7 +678,9 @@ export function authorizationService(db: Db) {
 
     if (
       !(await scopeAllows(db, input.companyId, grant.scope, input.scope, {
-        requireStructuredScope: input.permissionKey === "tasks:assign_scope",
+        requireStructuredScope:
+          input.permissionKey === "tasks:assign_scope" ||
+          input.permissionKey === "execution_workspaces:adopt",
       }))
     ) {
       return deny({
@@ -929,6 +931,7 @@ export function authorizationService(db: Db) {
       input.action === "agent_config:update" ||
       input.action === "skill_config:update" ||
       input.action === "inbox:manage" ||
+      input.action === "execution_workspaces:adopt" ||
       input.action === "runtime:manage" ||
       input.action === "secrets:read"
     ) {
@@ -1572,6 +1575,23 @@ export function authorizationService(db: Db) {
           suggest: "skills:suggest-changes",
         });
       }
+      if (input.action === "execution_workspaces:adopt") {
+        const membership = await getActiveMembership(companyId, "user", input.actor.userId);
+        if (membership && membership.membershipRole !== "viewer") {
+          return allow({
+            action: input.action,
+            reason: "allow_simple_company_member",
+            explanation: "Allowed by active non-viewer board membership.",
+          });
+        }
+        return deny({
+          action: input.action,
+          reason: membership ? "deny_missing_grant" : "deny_missing_membership",
+          explanation: membership
+            ? "Viewer membership cannot adopt host execution workspaces."
+            : `user principal ${input.actor.userId} is not an active member of company ${companyId}.`,
+        });
+      }
       if (!permissionKey) {
         if (
           input.action === "agent:read" ||
@@ -1703,6 +1723,7 @@ export function authorizationService(db: Db) {
         input.action === "issue:read" ||
         input.action === "project:read" ||
         input.action === "runtime:manage" ||
+        input.action === "execution_workspaces:adopt" ||
         input.action === "secrets:read"
       ) {
         return lowTrustDecision;
@@ -1951,6 +1972,7 @@ export function authorizationService(db: Db) {
         scope: input.scope,
       });
       if (grantDecision.allowed) return grantDecision;
+      if (input.action === "execution_workspaces:adopt") return grantDecision;
     }
 
     if (

--- a/server/src/services/execution-workspaces.ts
+++ b/server/src/services/execution-workspaces.ts
@@ -2007,21 +2007,6 @@ export function executionWorkspaceService(db: Db, options: ExecutionWorkspaceSer
         },
       };
 
-      const existingRows = await db
-        .select()
-        .from(executionWorkspaces)
-        .where(and(
-          eq(executionWorkspaces.companyId, companyId),
-          ne(executionWorkspaces.status, "archived"),
-          isNull(executionWorkspaces.closedAt),
-          or(
-            eq(executionWorkspaces.cwd, inspection.canonicalCwd),
-            eq(executionWorkspaces.providerRef, inspection.canonicalCwd),
-            eq(executionWorkspaces.branchName, inspection.branchName),
-            sql`${executionWorkspaces.metadata}->>'fullBranchRef' = ${inspection.fullBranchRef}`,
-          ),
-        ))
-        .limit(20);
       const fingerprintMatches = (row: ExecutionWorkspaceRow) =>
         (row.metadata as Record<string, unknown> | null | undefined)?.adoption &&
         isRecord((row.metadata as Record<string, unknown>).adoption) &&
@@ -2030,31 +2015,6 @@ export function executionWorkspaceService(db: Db, options: ExecutionWorkspaceSer
         const adoption = (row.metadata as Record<string, unknown> | null)?.adoption;
         return isRecord(adoption) ? readNullableString(adoption.boundIssueId) : null;
       };
-      const exactExisting = existingRows.find((row) =>
-        (row.cwd === inspection.canonicalCwd || row.providerRef === inspection.canonicalCwd) &&
-        ((row.metadata as Record<string, unknown> | null)?.fullBranchRef === inspection.fullBranchRef || row.branchName === inspection.branchName)
-      );
-      if (exactExisting) {
-        if (fingerprintMatches(exactExisting)) {
-          if ((input.bindIssueId ?? null) !== adoptionBoundIssueId(exactExisting)) {
-            adoptionError("workspace_conflict", 409);
-          }
-          const existingWorkspace = await executionWorkspaceService(db).getById(exactExisting.id);
-          return {
-            workspace: existingWorkspace ?? toExecutionWorkspace(exactExisting),
-            issue: bindIssue ? {
-              id: bindIssue.id,
-              identifier: bindIssue.identifier,
-              title: bindIssue.title,
-              status: bindIssue.status,
-            } : null,
-            inspection,
-            operation: null,
-          };
-        }
-        adoptionError("workspace_conflict", 409);
-      }
-      if (existingRows.length > 0) adoptionError("workspace_conflict", 409);
 
       try {
         return await db.transaction(async (tx) => {
@@ -2373,7 +2333,7 @@ export function executionWorkspaceService(db: Db, options: ExecutionWorkspaceSer
         if (!workspace) throw notFound("Execution workspace not found");
         const metadata = (workspace.metadata as Record<string, unknown> | null) ?? {};
         const adoption = isRecord(metadata.adoption) ? metadata.adoption : null;
-        if (!adoption) throw unprocessable("Only adopted execution workspace records can be rolled back", { reasonCode: "workspace_conflict" });
+        if (!adoption) adoptionError("workspace_conflict", 409);
         const previousBinding = isRecord(adoption.previousIssueBinding) ? adoption.previousIssueBinding : null;
         const boundIssueId = readNullableString(adoption.boundIssueId);
         if (boundIssueId !== authorizedBoundIssueId) adoptionError("workspace_conflict", 409);

--- a/server/src/services/execution-workspaces.ts
+++ b/server/src/services/execution-workspaces.ts
@@ -167,6 +167,7 @@ type AdoptionInspection = {
   reasonCode: null;
   canonicalCwd: string;
   repoRoot: string;
+  repositoryIdentity: string;
   repoUrl: string | null;
   normalizedRepoUrl: string | null;
   fullBranchRef: string;
@@ -322,6 +323,7 @@ async function inspectGitWorktreeForAdoption(input: {
     reasonCode: null,
     canonicalCwd,
     repoRoot,
+    repositoryIdentity: commonReal,
     repoUrl,
     normalizedRepoUrl,
     fullBranchRef,
@@ -2067,8 +2069,11 @@ export function executionWorkspaceService(db: Db, options: ExecutionWorkspaceSer
             or(
               eq(executionWorkspaces.cwd, writeInspection.canonicalCwd),
               eq(executionWorkspaces.providerRef, writeInspection.canonicalCwd),
-              eq(executionWorkspaces.branchName, writeInspection.branchName),
-              sql`${executionWorkspaces.metadata}->>'fullBranchRef' = ${writeInspection.fullBranchRef}`,
+              and(
+                eq(executionWorkspaces.projectId, input.projectId),
+                sql`${executionWorkspaces.metadata}->>'repositoryIdentity' = ${writeInspection.repositoryIdentity}`,
+                sql`${executionWorkspaces.metadata}->>'fullBranchRef' = ${writeInspection.fullBranchRef}`,
+              ),
             ),
           ))
           .for("update")
@@ -2099,6 +2104,7 @@ export function executionWorkspaceService(db: Db, options: ExecutionWorkspaceSer
         const transactionalMetadata = {
           createdByRuntime: false,
           ownsGitArtifacts: false,
+          repositoryIdentity: writeInspection.repositoryIdentity,
           fullBranchRef: writeInspection.fullBranchRef,
           adoption: {
             version: 1,
@@ -2116,6 +2122,7 @@ export function executionWorkspaceService(db: Db, options: ExecutionWorkspaceSer
               repoUrl: writeInspection.normalizedRepoUrl,
             },
             canonicalRepoRoot: writeInspection.repoRoot,
+            canonicalGitCommonDir: writeInspection.repositoryIdentity,
             canonicalCwd: writeInspection.canonicalCwd,
             cleanliness: {
               dirtyTrackedCount: writeInspection.dirtyTrackedCount,

--- a/server/src/services/execution-workspaces.ts
+++ b/server/src/services/execution-workspaces.ts
@@ -1952,7 +1952,7 @@ export function executionWorkspaceService(db: Db, options: ExecutionWorkspaceSer
         : null;
       if (input.bindIssueId && !bindIssue) adoptionError("cross_scope_not_found", 404);
 
-      const inspection = await inspectGitWorktreeForAdoption({
+      const initialInspection = await inspectGitWorktreeForAdoption({
         companyId,
         projectId: input.projectId,
         projectWorkspaceId: input.projectWorkspaceId,
@@ -1967,58 +1967,10 @@ export function executionWorkspaceService(db: Db, options: ExecutionWorkspaceSer
       });
       await options.afterAdoptionInitialInspection?.();
 
-      const now = new Date();
-      const metadata = {
-        createdByRuntime: false,
-        ownsGitArtifacts: false,
-        fullBranchRef: inspection.fullBranchRef,
-        adoption: {
-          version: 1,
-          immutableFingerprint: inspection.worktreeFingerprint,
-          expected: {
-            branch: input.expectedBranch,
-            headSha: input.expectedHeadSha,
-            upstream: input.expectedUpstream,
-            repoUrl: normalizeRepoUrl(input.expectedRepoUrl) ?? normalizeRepoUrl(scope.projectWorkspaceRepoUrl),
-          },
-          observed: {
-            branch: inspection.fullBranchRef,
-            headSha: inspection.headSha,
-            upstream: inspection.upstream,
-            repoUrl: inspection.normalizedRepoUrl,
-          },
-          canonicalRepoRoot: inspection.repoRoot,
-          canonicalCwd: inspection.canonicalCwd,
-          cleanliness: {
-            dirtyTrackedCount: inspection.dirtyTrackedCount,
-            untrackedCount: inspection.untrackedCount,
-          },
-          projectId: input.projectId,
-          projectWorkspaceId: input.projectWorkspaceId,
-          sourceIssueId: input.sourceIssueId,
-          boundIssueId: input.bindIssueId ?? null,
-          actor: {
-            type: actor.actorType,
-            id: actor.actorId,
-            agentId: actor.agentId,
-          },
-          runId: actor.runId,
-          adoptedAt: now.toISOString(),
-          previousIssueBinding: bindIssue
-            ? {
-                issueId: bindIssue.id,
-                executionWorkspaceId: bindIssue.previousExecutionWorkspaceId ?? null,
-                executionWorkspacePreference: bindIssue.previousExecutionWorkspacePreference ?? null,
-                executionWorkspaceSettings: bindIssue.previousExecutionWorkspaceSettings ?? null,
-              }
-            : null,
-        },
-      };
-
-      const fingerprintMatches = (row: ExecutionWorkspaceRow) =>
+      const fingerprintMatches = (row: ExecutionWorkspaceRow, fingerprint: string) =>
         (row.metadata as Record<string, unknown> | null | undefined)?.adoption &&
         isRecord((row.metadata as Record<string, unknown>).adoption) &&
-        (row.metadata as { adoption: Record<string, unknown> }).adoption.immutableFingerprint === inspection.worktreeFingerprint;
+        (row.metadata as { adoption: Record<string, unknown> }).adoption.immutableFingerprint === fingerprint;
       const adoptionBoundIssueId = (row: ExecutionWorkspaceRow) => {
         const adoption = (row.metadata as Record<string, unknown> | null)?.adoption;
         return isRecord(adoption) ? readNullableString(adoption.boundIssueId) : null;
@@ -2088,44 +2040,6 @@ export function executionWorkspaceService(db: Db, options: ExecutionWorkspaceSer
           adoptionError("workspace_conflict", 409);
         }
 
-        const duplicate = await tx
-          .select()
-          .from(executionWorkspaces)
-          .where(and(
-            eq(executionWorkspaces.companyId, companyId),
-            ne(executionWorkspaces.status, "archived"),
-            isNull(executionWorkspaces.closedAt),
-            or(
-              eq(executionWorkspaces.cwd, inspection.canonicalCwd),
-              eq(executionWorkspaces.providerRef, inspection.canonicalCwd),
-              eq(executionWorkspaces.branchName, inspection.branchName),
-              sql`${executionWorkspaces.metadata}->>'fullBranchRef' = ${inspection.fullBranchRef}`,
-            ),
-          ))
-          .for("update")
-          .limit(1)
-          .then((rows) => rows[0] ?? null);
-        if (duplicate) {
-          if (
-            !fingerprintMatches(duplicate)
-            || (input.bindIssueId ?? null) !== adoptionBoundIssueId(duplicate)
-          ) {
-            adoptionError("workspace_conflict", 409);
-          }
-          const existingWorkspace = await executionWorkspaceService(txDb).getById(duplicate.id);
-          return {
-            workspace: existingWorkspace ?? toExecutionWorkspace(duplicate),
-            issue: bindIssue ? {
-              id: bindIssue.id,
-              identifier: bindIssue.identifier,
-              title: bindIssue.title,
-              status: bindIssue.status,
-            } : null,
-            inspection,
-            operation: null,
-          };
-        }
-
         const writeInspection = await inspectGitWorktreeForAdoption({
           companyId,
           projectId: input.projectId,
@@ -2139,14 +2053,85 @@ export function executionWorkspaceService(db: Db, options: ExecutionWorkspaceSer
           projectWorkspaceCwd: lockedProjectWorkspace.cwd ?? null,
           projectWorkspaceRepoUrl: lockedProjectWorkspace.repoUrl ?? null,
         });
-        if (writeInspection.worktreeFingerprint !== inspection.worktreeFingerprint) {
+        if (writeInspection.worktreeFingerprint !== initialInspection.worktreeFingerprint) {
           adoptionError("workspace_conflict", 409);
         }
 
+        const duplicate = await tx
+          .select()
+          .from(executionWorkspaces)
+          .where(and(
+            eq(executionWorkspaces.companyId, companyId),
+            ne(executionWorkspaces.status, "archived"),
+            isNull(executionWorkspaces.closedAt),
+            or(
+              eq(executionWorkspaces.cwd, writeInspection.canonicalCwd),
+              eq(executionWorkspaces.providerRef, writeInspection.canonicalCwd),
+              eq(executionWorkspaces.branchName, writeInspection.branchName),
+              sql`${executionWorkspaces.metadata}->>'fullBranchRef' = ${writeInspection.fullBranchRef}`,
+            ),
+          ))
+          .for("update")
+          .limit(1)
+          .then((rows) => rows[0] ?? null);
+        if (duplicate) {
+          if (
+            !fingerprintMatches(duplicate, writeInspection.worktreeFingerprint)
+            || (input.bindIssueId ?? null) !== adoptionBoundIssueId(duplicate)
+          ) {
+            adoptionError("workspace_conflict", 409);
+          }
+          const existingWorkspace = await executionWorkspaceService(txDb).getById(duplicate.id);
+          return {
+            workspace: existingWorkspace ?? toExecutionWorkspace(duplicate),
+            issue: bindIssue ? {
+              id: bindIssue.id,
+              identifier: bindIssue.identifier,
+              title: bindIssue.title,
+              status: bindIssue.status,
+            } : null,
+            inspection: writeInspection,
+            operation: null,
+          };
+        }
+
+        const now = new Date();
         const transactionalMetadata = {
-          ...metadata,
+          createdByRuntime: false,
+          ownsGitArtifacts: false,
+          fullBranchRef: writeInspection.fullBranchRef,
           adoption: {
-            ...metadata.adoption,
+            version: 1,
+            immutableFingerprint: writeInspection.worktreeFingerprint,
+            expected: {
+              branch: input.expectedBranch,
+              headSha: input.expectedHeadSha,
+              upstream: input.expectedUpstream,
+              repoUrl: normalizeRepoUrl(input.expectedRepoUrl) ?? normalizeRepoUrl(lockedProjectWorkspace.repoUrl),
+            },
+            observed: {
+              branch: writeInspection.fullBranchRef,
+              headSha: writeInspection.headSha,
+              upstream: writeInspection.upstream,
+              repoUrl: writeInspection.normalizedRepoUrl,
+            },
+            canonicalRepoRoot: writeInspection.repoRoot,
+            canonicalCwd: writeInspection.canonicalCwd,
+            cleanliness: {
+              dirtyTrackedCount: writeInspection.dirtyTrackedCount,
+              untrackedCount: writeInspection.untrackedCount,
+            },
+            projectId: input.projectId,
+            projectWorkspaceId: input.projectWorkspaceId,
+            sourceIssueId: input.sourceIssueId,
+            boundIssueId: input.bindIssueId ?? null,
+            actor: {
+              type: actor.actorType,
+              id: actor.actorId,
+              agentId: actor.agentId,
+            },
+            runId: actor.runId,
+            adoptedAt: now.toISOString(),
             previousIssueBinding: lockedBindIssue
               ? {
                   issueId: lockedBindIssue.id,
@@ -2169,12 +2154,12 @@ export function executionWorkspaceService(db: Db, options: ExecutionWorkspaceSer
             strategyType: "git_worktree",
             name: input.name,
             status: "active",
-            cwd: inspection.canonicalCwd,
-            repoUrl: inspection.normalizedRepoUrl,
+            cwd: writeInspection.canonicalCwd,
+            repoUrl: writeInspection.normalizedRepoUrl,
             baseRef: input.expectedUpstream,
-            branchName: inspection.branchName,
+            branchName: writeInspection.branchName,
             providerType: "git_worktree",
-            providerRef: inspection.canonicalCwd,
+            providerRef: writeInspection.canonicalCwd,
             lastUsedAt: now,
             openedAt: now,
             metadata: transactionalMetadata,
@@ -2194,11 +2179,11 @@ export function executionWorkspaceService(db: Db, options: ExecutionWorkspaceSer
             issueId: input.bindIssueId ?? input.sourceIssueId,
             phase: "workspace_adopt",
             command: null,
-            cwd: inspection.canonicalCwd,
+            cwd: writeInspection.canonicalCwd,
             status: "succeeded",
             metadata: {
               reasonCode: null,
-              fingerprint: inspection.worktreeFingerprint,
+              fingerprint: writeInspection.worktreeFingerprint,
               projectId: input.projectId,
               projectWorkspaceId: input.projectWorkspaceId,
               sourceIssueId: input.sourceIssueId,
@@ -2240,7 +2225,7 @@ export function executionWorkspaceService(db: Db, options: ExecutionWorkspaceSer
           entityId: workspaceRow.id,
           details: {
             reasonCode: null,
-            fingerprint: inspection.worktreeFingerprint,
+            fingerprint: writeInspection.worktreeFingerprint,
             projectId: input.projectId,
             projectWorkspaceId: input.projectWorkspaceId,
             sourceIssueId: input.sourceIssueId,
@@ -2284,7 +2269,7 @@ export function executionWorkspaceService(db: Db, options: ExecutionWorkspaceSer
                 status: bindIssue?.status ?? "",
               }
             : null,
-          inspection,
+          inspection: writeInspection,
           operation: operationRow ? {
             id: operationRow.id,
             companyId: operationRow.companyId,

--- a/server/src/services/execution-workspaces.ts
+++ b/server/src/services/execution-workspaces.ts
@@ -889,6 +889,10 @@ async function inspectGitCloseReadiness(workspace: ExecutionWorkspace): Promise<
   };
 }
 
+export function executionWorkspaceOwnsGitArtifacts(metadata: Record<string, unknown> | null | undefined): boolean {
+  return metadata?.ownsGitArtifacts !== false;
+}
+
 export function readExecutionWorkspaceConfig(metadata: Record<string, unknown> | null | undefined): ExecutionWorkspaceConfig | null {
   const raw = isRecord(metadata?.config) ? metadata.config : null;
   if (!raw) return null;
@@ -1688,7 +1692,9 @@ export function executionWorkspaceService(db: Db, options: ExecutionWorkspaceSer
         : null;
 
       const executionWorkspace = toExecutionWorkspace(workspace, runtimeServices);
-      const config = readExecutionWorkspaceConfig((workspace.metadata as Record<string, unknown> | null) ?? null);
+      const workspaceMetadata = (workspace.metadata as Record<string, unknown> | null) ?? null;
+      const config = readExecutionWorkspaceConfig(workspaceMetadata);
+      const ownsGitArtifacts = executionWorkspaceOwnsGitArtifacts(workspaceMetadata);
       const { git, warnings: gitWarnings } = await inspectGitCloseReadiness(executionWorkspace);
       const warnings = [...gitWarnings];
       const blockingReasons: string[] = [];
@@ -1783,36 +1789,38 @@ export function executionWorkspaceService(db: Db, options: ExecutionWorkspaceSer
         });
       }
 
-      const configuredCleanupCommands = [
-        {
-          kind: "cleanup_command" as const,
-          label: "Run workspace cleanup command",
-          description: "Workspace-specific cleanup runs before teardown.",
-          command: config?.cleanupCommand ?? null,
-        },
-        {
-          kind: "cleanup_command" as const,
-          label: "Run project workspace cleanup command",
-          description: "Project workspace cleanup runs before execution workspace teardown.",
-          command: projectWorkspace?.cleanupCommand ?? null,
-        },
-      ];
-      for (const action of configuredCleanupCommands) {
-        if (!action.command) continue;
-        plannedActions.push(action);
+      if (ownsGitArtifacts) {
+        const configuredCleanupCommands = [
+          {
+            kind: "cleanup_command" as const,
+            label: "Run workspace cleanup command",
+            description: "Workspace-specific cleanup runs before teardown.",
+            command: config?.cleanupCommand ?? null,
+          },
+          {
+            kind: "cleanup_command" as const,
+            label: "Run project workspace cleanup command",
+            description: "Project workspace cleanup runs before execution workspace teardown.",
+            command: projectWorkspace?.cleanupCommand ?? null,
+          },
+        ];
+        for (const action of configuredCleanupCommands) {
+          if (!action.command) continue;
+          plannedActions.push(action);
+        }
+
+        const teardownCommand = config?.teardownCommand ?? projectPolicy?.workspaceStrategy?.teardownCommand ?? null;
+        if (teardownCommand) {
+          plannedActions.push({
+            kind: "teardown_command",
+            label: "Run teardown command",
+            description: "Teardown runs after cleanup commands during workspace close.",
+            command: teardownCommand,
+          });
+        }
       }
 
-      const teardownCommand = config?.teardownCommand ?? projectPolicy?.workspaceStrategy?.teardownCommand ?? null;
-      if (teardownCommand) {
-        plannedActions.push({
-          kind: "teardown_command",
-          label: "Run teardown command",
-          description: "Teardown runs after cleanup commands during workspace close.",
-          command: teardownCommand,
-        });
-      }
-
-      if (executionWorkspace.providerType === "git_worktree" && workspacePath) {
+      if (ownsGitArtifacts && executionWorkspace.providerType === "git_worktree" && workspacePath) {
         plannedActions.push({
           kind: "git_worktree_remove",
           label: "Remove git worktree",
@@ -1821,7 +1829,7 @@ export function executionWorkspaceService(db: Db, options: ExecutionWorkspaceSer
         });
       }
 
-      if (git?.createdByRuntime && executionWorkspace.branchName) {
+      if (ownsGitArtifacts && git?.createdByRuntime && executionWorkspace.branchName) {
         plannedActions.push({
           kind: "git_branch_delete",
           label: "Delete runtime-created branch",
@@ -1830,7 +1838,7 @@ export function executionWorkspaceService(db: Db, options: ExecutionWorkspaceSer
         });
       }
 
-      if (executionWorkspace.providerType === "local_fs" && git?.createdByRuntime && workspacePath) {
+      if (ownsGitArtifacts && executionWorkspace.providerType === "local_fs" && git?.createdByRuntime && workspacePath) {
         const resolvedWorkspacePath = path.resolve(workspacePath);
         const resolvedProjectWorkspacePath = projectWorkspace?.cwd ? path.resolve(projectWorkspace.cwd) : null;
         const containsProjectWorkspace = resolvedProjectWorkspacePath

--- a/server/src/services/execution-workspaces.ts
+++ b/server/src/services/execution-workspaces.ts
@@ -5,8 +5,9 @@ import path from "node:path";
 import { promisify } from "node:util";
 import { and, asc, desc, eq, inArray, isNull, ne, or, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
-import { executionWorkspaces, heartbeatRuns, issueComments, issues, projects, projectWorkspaces, workspaceRuntimeServices } from "@paperclipai/db";
+import { activityLog, executionWorkspaces, heartbeatRuns, issueComments, issues, projects, projectWorkspaces, workspaceOperations, workspaceRuntimeServices } from "@paperclipai/db";
 import type {
+  AdoptGitWorktreeExecutionWorkspace,
   ExecutionWorkspace,
   ExecutionWorkspaceSummary,
   ExecutionWorkspaceCloseAction,
@@ -102,6 +103,216 @@ export type ExecutionWorkspaceGitWorktreeContention = {
     issueIdentifier: string | null;
   } | null;
 } | null;
+
+export type ExecutionWorkspaceAdoptionReasonCode =
+  | "missing_branch"
+  | "mismatched_branch"
+  | "detached_head"
+  | "sha_mismatch"
+  | "upstream_mismatch"
+  | "dirty_worktree"
+  | "branch_attached_elsewhere"
+  | "repo_mismatch"
+  | "unsafe_input"
+  | "workspace_conflict"
+  | "unauthorized"
+  | "cross_scope_not_found"
+  | "unexpected_failure";
+
+export class ExecutionWorkspaceAdoptionError extends Error {
+  reasonCode: ExecutionWorkspaceAdoptionReasonCode;
+  status: number;
+
+  constructor(reasonCode: ExecutionWorkspaceAdoptionReasonCode, status = 422) {
+    super(reasonCode);
+    this.reasonCode = reasonCode;
+    this.status = status;
+  }
+}
+
+export type ExecutionWorkspaceAdoptionActor = {
+  actorType: "agent" | "user";
+  actorId: string;
+  agentId: string | null;
+  runId: string | null;
+};
+
+type AdoptionInspection = {
+  status: "accepted";
+  reasonCode: null;
+  canonicalCwd: string;
+  repoRoot: string;
+  repoUrl: string | null;
+  normalizedRepoUrl: string | null;
+  fullBranchRef: string;
+  branchName: string;
+  headSha: string;
+  upstream: string;
+  dirtyTrackedCount: number;
+  untrackedCount: number;
+  worktreeFingerprint: string;
+};
+
+function adoptionError(reasonCode: ExecutionWorkspaceAdoptionReasonCode, status = 422): never {
+  throw new ExecutionWorkspaceAdoptionError(reasonCode, status);
+}
+
+function shortBranchName(fullRef: string) {
+  return fullRef.startsWith("refs/heads/") ? fullRef.slice("refs/heads/".length) : fullRef;
+}
+
+function normalizeRepoUrl(value: string | null | undefined) {
+  const raw = readNullableString(value);
+  if (!raw) return null;
+  let normalized = raw.trim();
+  if (normalized.endsWith("/")) normalized = normalized.slice(0, -1);
+  if (normalized.endsWith(".git")) normalized = normalized.slice(0, -4);
+  const sshMatch = normalized.match(/^git@([^:]+):(.+)$/);
+  if (sshMatch) normalized = `ssh://${sshMatch[1]}/${sshMatch[2]}`;
+  return normalized.toLowerCase();
+}
+
+function fingerprintAdoption(input: {
+  companyId: string;
+  projectId: string;
+  projectWorkspaceId: string;
+  sourceIssueId: string;
+  canonicalCwd: string;
+  repoRoot: string;
+  normalizedRepoUrl: string | null;
+  fullBranchRef: string;
+  headSha: string;
+  upstream: string;
+}) {
+  const digest = createHash("sha256")
+    .update(stableStringify({ version: 1, kind: "execution_workspace_adoption", ...input }))
+    .digest("hex");
+  return `execution_workspace_adoption:v1:sha256:${digest}`;
+}
+
+async function readGitRequired(args: string[], cwd: string, reasonCode: ExecutionWorkspaceAdoptionReasonCode) {
+  try {
+    const output = await execFileAsync("git", ["-C", cwd, ...args], { cwd });
+    return output.stdout.trim();
+  } catch {
+    adoptionError(reasonCode);
+  }
+}
+
+async function inspectGitWorktreeForAdoption(input: {
+  companyId: string;
+  projectId: string;
+  projectWorkspaceId: string;
+  sourceIssueId: string;
+  cwd: string;
+  expectedBranch: string;
+  expectedHeadSha: string;
+  expectedUpstream: string;
+  expectedRepoUrl: string | null | undefined;
+  projectWorkspaceCwd: string | null;
+  projectWorkspaceRepoUrl: string | null;
+}): Promise<AdoptionInspection> {
+  let canonicalCwd: string;
+  try {
+    canonicalCwd = await fs.realpath(input.cwd);
+  } catch {
+    adoptionError("repo_mismatch");
+  }
+  const repoRootRaw = await readGitRequired(["rev-parse", "--show-toplevel"], canonicalCwd, "repo_mismatch");
+  const repoRoot = await fs.realpath(repoRootRaw).catch(() => path.resolve(repoRootRaw));
+  if (repoRoot !== canonicalCwd) adoptionError("repo_mismatch");
+
+  if (input.projectWorkspaceCwd) {
+    const projectRoot = await fs.realpath(input.projectWorkspaceCwd).catch(() => path.resolve(input.projectWorkspaceCwd!));
+    const commonDir = await readGitRequired(["rev-parse", "--git-common-dir"], canonicalCwd, "repo_mismatch");
+    const commonReal = await fs.realpath(path.isAbsolute(commonDir) ? commonDir : path.join(canonicalCwd, commonDir))
+      .catch(() => path.resolve(canonicalCwd, commonDir));
+    const projectCommon = await readGitStdout(["rev-parse", "--git-common-dir"], projectRoot)
+      .then((value) => value ? fs.realpath(path.isAbsolute(value) ? value : path.join(projectRoot, value)) : null)
+      .catch(() => null);
+    if (projectCommon && commonReal !== projectCommon) adoptionError("repo_mismatch");
+  }
+
+  const headSha = await readGitRequired(["rev-parse", "--verify", "HEAD^{commit}"], canonicalCwd, "sha_mismatch");
+  if (headSha !== input.expectedHeadSha) adoptionError("sha_mismatch");
+  const localBranchSha = await readGitRequired(["rev-parse", "--verify", `${input.expectedBranch}^{commit}`], canonicalCwd, "missing_branch");
+  if (localBranchSha !== input.expectedHeadSha) adoptionError("missing_branch");
+
+  const fullBranchRef = await readGitRequired(["symbolic-ref", "--quiet", "HEAD"], canonicalCwd, "detached_head");
+  if (fullBranchRef !== input.expectedBranch) adoptionError("mismatched_branch");
+  const branchName = shortBranchName(fullBranchRef);
+
+  const upstream = await readGitRequired(["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}"], canonicalCwd, "upstream_mismatch");
+  if (upstream !== input.expectedUpstream) adoptionError("upstream_mismatch");
+
+  const status = await readGitRequired(["status", "--porcelain=v1", "--untracked-files=all"], canonicalCwd, "unexpected_failure");
+  let dirtyTrackedCount = 0;
+  let untrackedCount = 0;
+  for (const line of status.split(/\r?\n/)) {
+    if (!line) continue;
+    if (line.startsWith("??")) untrackedCount += 1;
+    else dirtyTrackedCount += 1;
+  }
+  if (dirtyTrackedCount > 0 || untrackedCount > 0) adoptionError("dirty_worktree");
+
+  const repoUrl = await readGitStdout(["config", "--get", "remote.origin.url"], canonicalCwd).catch(() => null);
+  const normalizedRepoUrl = normalizeRepoUrl(repoUrl);
+  const expectedRepoUrl = normalizeRepoUrl(input.expectedRepoUrl) ?? normalizeRepoUrl(input.projectWorkspaceRepoUrl);
+  if (expectedRepoUrl && normalizedRepoUrl !== expectedRepoUrl) adoptionError("repo_mismatch");
+
+  const worktreeRows = await execFileAsync("git", ["-C", canonicalCwd, "worktree", "list", "--porcelain", "-z"], { cwd: canonicalCwd })
+    .then((output) => output.stdout.split("\0").filter(Boolean))
+    .catch(() => adoptionError("unexpected_failure"));
+  let current: Record<string, string> = {};
+  const entries: Array<Record<string, string>> = [];
+  for (const row of worktreeRows) {
+    if (row.startsWith("worktree ")) {
+      if (Object.keys(current).length > 0) entries.push(current);
+      current = { worktree: row.slice("worktree ".length) };
+    } else {
+      const index = row.indexOf(" ");
+      if (index > 0) current[row.slice(0, index)] = row.slice(index + 1);
+    }
+  }
+  if (Object.keys(current).length > 0) entries.push(current);
+  const matching = entries.filter((entry) => path.resolve(entry.worktree ?? "") === canonicalCwd);
+  if (matching.length !== 1) adoptionError("repo_mismatch");
+  const attachedElsewhere = entries.some((entry) =>
+    path.resolve(entry.worktree ?? "") !== canonicalCwd &&
+    entry.branch === input.expectedBranch
+  );
+  if (attachedElsewhere) adoptionError("branch_attached_elsewhere");
+  if (matching[0]?.branch !== input.expectedBranch || matching[0]?.HEAD !== input.expectedHeadSha) {
+    adoptionError("repo_mismatch");
+  }
+
+  return {
+    status: "accepted",
+    reasonCode: null,
+    canonicalCwd,
+    repoRoot,
+    repoUrl,
+    normalizedRepoUrl,
+    fullBranchRef,
+    branchName,
+    headSha,
+    upstream,
+    dirtyTrackedCount,
+    untrackedCount,
+    worktreeFingerprint: fingerprintAdoption({
+      companyId: input.companyId,
+      projectId: input.projectId,
+      projectWorkspaceId: input.projectWorkspaceId,
+      sourceIssueId: input.sourceIssueId,
+      canonicalCwd,
+      repoRoot,
+      normalizedRepoUrl,
+      fullBranchRef,
+      headSha,
+      upstream,
+    }),
+  };
+}
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -762,6 +973,10 @@ function toRuntimeService(row: WorkspaceRuntimeServiceRow): WorkspaceRuntimeServ
 function toExecutionWorkspace(
   row: ExecutionWorkspaceRow,
   runtimeServices: WorkspaceRuntimeService[] = [],
+  linkedIssues?: {
+    sourceIssue?: ExecutionWorkspace["sourceIssue"];
+    boundIssue?: ExecutionWorkspace["boundIssue"];
+  },
 ): ExecutionWorkspace {
   return {
     id: row.id,
@@ -788,6 +1003,8 @@ function toExecutionWorkspace(
     config: readExecutionWorkspaceConfig((row.metadata as Record<string, unknown> | null) ?? null),
     metadata: (row.metadata as Record<string, unknown> | null) ?? null,
     runtimeServices,
+    sourceIssue: linkedIssues?.sourceIssue ?? null,
+    boundIssue: linkedIssues?.boundIssue ?? null,
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,
   };
@@ -902,7 +1119,11 @@ type WorkspaceOverviewIssueRow = WorkspaceOverviewLinkedIssue & {
   executionWorkspaceId: string;
 };
 
-export function executionWorkspaceService(db: Db) {
+export type ExecutionWorkspaceServiceOptions = {
+  afterAdoptionWorkspaceInsert?: (workspace: ExecutionWorkspaceRow) => void | Promise<void>;
+};
+
+export function executionWorkspaceService(db: Db, options: ExecutionWorkspaceServiceOptions = {}) {
   const recoveryActionsSvc = issueRecoveryActionService(db);
 
   function buildListConditions(
@@ -1329,9 +1550,43 @@ export function executionWorkspaceService(db: Db) {
         .then((rows) => rows[0] ?? null);
       if (!row) return null;
       const runtimeServicesByWorkspaceId = await loadEffectiveRuntimeServicesByExecutionWorkspace(db, row.companyId, [row]);
+      const linkedIssueRows = await db
+        .select({
+          id: issues.id,
+          identifier: issues.identifier,
+          title: issues.title,
+          status: issues.status,
+          executionWorkspaceId: issues.executionWorkspaceId,
+        })
+        .from(issues)
+        .where(and(
+          eq(issues.companyId, row.companyId),
+          or(
+            row.sourceIssueId ? eq(issues.id, row.sourceIssueId) : sql`false`,
+            eq(issues.executionWorkspaceId, row.id),
+          ),
+        ))
+        .orderBy(desc(issues.updatedAt), desc(issues.createdAt))
+        .limit(20);
+      const toLinkedIssue = (issue: typeof linkedIssueRows[number]) => ({
+        id: issue.id,
+        identifier: issue.identifier ?? null,
+        title: issue.title,
+        status: issue.status,
+      });
+      const sourceIssue = row.sourceIssueId
+        ? linkedIssueRows.find((issue) => issue.id === row.sourceIssueId) ?? null
+        : null;
+      const boundIssue = linkedIssueRows.find((issue) => issue.executionWorkspaceId === row.id && issue.id !== row.sourceIssueId)
+        ?? linkedIssueRows.find((issue) => issue.executionWorkspaceId === row.id)
+        ?? null;
       return toExecutionWorkspace(
         row,
         (runtimeServicesByWorkspaceId.get(row.id) ?? []).map(toRuntimeService),
+        {
+          sourceIssue: sourceIssue ? toLinkedIssue(sourceIssue) : null,
+          boundIssue: boundIssue ? toLinkedIssue(boundIssue) : null,
+        },
       );
     },
 
@@ -1603,6 +1858,430 @@ export function executionWorkspaceService(db: Db) {
         .returning()
         .then((rows) => rows[0] ?? null);
       return row ? toExecutionWorkspace(row) : null;
+    },
+
+    adoptGitWorktree: async (companyId: string, input: AdoptGitWorktreeExecutionWorkspace, actor: ExecutionWorkspaceAdoptionActor) => {
+      const scopeRows = await db
+        .select({
+          projectId: projects.id,
+          projectCompanyId: projects.companyId,
+          projectWorkspaceId: projectWorkspaces.id,
+          projectWorkspaceCompanyId: projectWorkspaces.companyId,
+          projectWorkspaceProjectId: projectWorkspaces.projectId,
+          projectWorkspaceCwd: projectWorkspaces.cwd,
+          projectWorkspaceRepoUrl: projectWorkspaces.repoUrl,
+          sourceIssueId: issues.id,
+          sourceIssueCompanyId: issues.companyId,
+          sourceIssueProjectId: issues.projectId,
+        })
+        .from(projects)
+        .innerJoin(projectWorkspaces, eq(projectWorkspaces.id, input.projectWorkspaceId))
+        .innerJoin(issues, eq(issues.id, input.sourceIssueId))
+        .where(and(
+          eq(projects.id, input.projectId),
+          eq(projects.companyId, companyId),
+          eq(projectWorkspaces.companyId, companyId),
+          eq(projectWorkspaces.projectId, input.projectId),
+          eq(issues.companyId, companyId),
+          eq(issues.projectId, input.projectId),
+        ))
+        .limit(1);
+      const scope = scopeRows[0] ?? null;
+      if (!scope) adoptionError("cross_scope_not_found", 404);
+      const bindIssue = input.bindIssueId
+        ? await db
+            .select({
+              id: issues.id,
+              companyId: issues.companyId,
+              projectId: issues.projectId,
+              previousExecutionWorkspaceId: issues.executionWorkspaceId,
+              previousExecutionWorkspacePreference: issues.executionWorkspacePreference,
+              previousExecutionWorkspaceSettings: issues.executionWorkspaceSettings,
+              identifier: issues.identifier,
+              title: issues.title,
+              status: issues.status,
+            })
+            .from(issues)
+            .where(and(eq(issues.id, input.bindIssueId), eq(issues.companyId, companyId), eq(issues.projectId, input.projectId)))
+            .then((rows) => rows[0] ?? null)
+        : null;
+      if (input.bindIssueId && !bindIssue) adoptionError("cross_scope_not_found", 404);
+
+      const inspection = await inspectGitWorktreeForAdoption({
+        companyId,
+        projectId: input.projectId,
+        projectWorkspaceId: input.projectWorkspaceId,
+        sourceIssueId: input.sourceIssueId,
+        cwd: input.cwd,
+        expectedBranch: input.expectedBranch,
+        expectedHeadSha: input.expectedHeadSha,
+        expectedUpstream: input.expectedUpstream,
+        expectedRepoUrl: input.expectedRepoUrl ?? null,
+        projectWorkspaceCwd: scope.projectWorkspaceCwd ?? null,
+        projectWorkspaceRepoUrl: scope.projectWorkspaceRepoUrl ?? null,
+      });
+
+      const now = new Date();
+      const metadata = {
+        createdByRuntime: false,
+        ownsGitArtifacts: false,
+        fullBranchRef: inspection.fullBranchRef,
+        adoption: {
+          version: 1,
+          immutableFingerprint: inspection.worktreeFingerprint,
+          expected: {
+            branch: input.expectedBranch,
+            headSha: input.expectedHeadSha,
+            upstream: input.expectedUpstream,
+            repoUrl: normalizeRepoUrl(input.expectedRepoUrl) ?? normalizeRepoUrl(scope.projectWorkspaceRepoUrl),
+          },
+          observed: {
+            branch: inspection.fullBranchRef,
+            headSha: inspection.headSha,
+            upstream: inspection.upstream,
+            repoUrl: inspection.normalizedRepoUrl,
+          },
+          canonicalRepoRoot: inspection.repoRoot,
+          canonicalCwd: inspection.canonicalCwd,
+          cleanliness: {
+            dirtyTrackedCount: inspection.dirtyTrackedCount,
+            untrackedCount: inspection.untrackedCount,
+          },
+          projectId: input.projectId,
+          projectWorkspaceId: input.projectWorkspaceId,
+          sourceIssueId: input.sourceIssueId,
+          boundIssueId: input.bindIssueId ?? null,
+          actor: {
+            type: actor.actorType,
+            id: actor.actorId,
+            agentId: actor.agentId,
+          },
+          runId: actor.runId,
+          adoptedAt: now.toISOString(),
+          previousIssueBinding: bindIssue
+            ? {
+                issueId: bindIssue.id,
+                executionWorkspaceId: bindIssue.previousExecutionWorkspaceId ?? null,
+                executionWorkspacePreference: bindIssue.previousExecutionWorkspacePreference ?? null,
+                executionWorkspaceSettings: bindIssue.previousExecutionWorkspaceSettings ?? null,
+              }
+            : null,
+        },
+      };
+
+      const existingRows = await db
+        .select()
+        .from(executionWorkspaces)
+        .where(and(
+          eq(executionWorkspaces.companyId, companyId),
+          ne(executionWorkspaces.status, "archived"),
+          isNull(executionWorkspaces.closedAt),
+          or(
+            eq(executionWorkspaces.cwd, inspection.canonicalCwd),
+            eq(executionWorkspaces.providerRef, inspection.canonicalCwd),
+            eq(executionWorkspaces.branchName, inspection.branchName),
+            sql`${executionWorkspaces.metadata}->>'fullBranchRef' = ${inspection.fullBranchRef}`,
+          ),
+        ))
+        .limit(20);
+      const fingerprintMatches = (row: ExecutionWorkspaceRow) =>
+        (row.metadata as Record<string, unknown> | null | undefined)?.adoption &&
+        isRecord((row.metadata as Record<string, unknown>).adoption) &&
+        (row.metadata as { adoption: Record<string, unknown> }).adoption.immutableFingerprint === inspection.worktreeFingerprint;
+      const adoptionBoundIssueId = (row: ExecutionWorkspaceRow) => {
+        const adoption = (row.metadata as Record<string, unknown> | null)?.adoption;
+        return isRecord(adoption) ? readNullableString(adoption.boundIssueId) : null;
+      };
+      const exactExisting = existingRows.find((row) =>
+        (row.cwd === inspection.canonicalCwd || row.providerRef === inspection.canonicalCwd) &&
+        ((row.metadata as Record<string, unknown> | null)?.fullBranchRef === inspection.fullBranchRef || row.branchName === inspection.branchName)
+      );
+      if (exactExisting) {
+        if (fingerprintMatches(exactExisting)) {
+          if ((input.bindIssueId ?? null) !== adoptionBoundIssueId(exactExisting)) {
+            adoptionError("workspace_conflict", 409);
+          }
+          const existingWorkspace = await executionWorkspaceService(db).getById(exactExisting.id);
+          return {
+            workspace: existingWorkspace ?? toExecutionWorkspace(exactExisting),
+            issue: bindIssue ? {
+              id: bindIssue.id,
+              identifier: bindIssue.identifier,
+              title: bindIssue.title,
+              status: bindIssue.status,
+            } : null,
+            inspection,
+            operation: null,
+          };
+        }
+        adoptionError("workspace_conflict", 409);
+      }
+      if (existingRows.length > 0) adoptionError("workspace_conflict", 409);
+
+      try {
+        return await db.transaction(async (tx) => {
+        const txDb = tx as unknown as Db;
+        await tx.select({ id: projects.id }).from(projects).where(eq(projects.id, input.projectId)).for("update");
+        await tx.select({ id: issues.id }).from(issues).where(eq(issues.id, input.sourceIssueId)).for("update");
+        if (input.bindIssueId) await tx.select({ id: issues.id }).from(issues).where(eq(issues.id, input.bindIssueId)).for("update");
+
+        const duplicate = await tx
+          .select()
+          .from(executionWorkspaces)
+          .where(and(
+            eq(executionWorkspaces.companyId, companyId),
+            ne(executionWorkspaces.status, "archived"),
+            isNull(executionWorkspaces.closedAt),
+            or(
+              eq(executionWorkspaces.cwd, inspection.canonicalCwd),
+              eq(executionWorkspaces.providerRef, inspection.canonicalCwd),
+              sql`${executionWorkspaces.metadata}->>'fullBranchRef' = ${inspection.fullBranchRef}`,
+            ),
+          ))
+          .for("update")
+          .limit(1)
+          .then((rows) => rows[0] ?? null);
+        if (duplicate) adoptionError(fingerprintMatches(duplicate) ? "workspace_conflict" : "workspace_conflict", 409);
+
+        const [workspaceRow] = await tx
+          .insert(executionWorkspaces)
+          .values({
+            companyId,
+            projectId: input.projectId,
+            projectWorkspaceId: input.projectWorkspaceId,
+            sourceIssueId: input.sourceIssueId,
+            mode: "isolated_workspace",
+            strategyType: "git_worktree",
+            name: input.name,
+            status: "active",
+            cwd: inspection.canonicalCwd,
+            repoUrl: inspection.normalizedRepoUrl,
+            baseRef: input.expectedUpstream,
+            branchName: inspection.branchName,
+            providerType: "git_worktree",
+            providerRef: inspection.canonicalCwd,
+            lastUsedAt: now,
+            openedAt: now,
+            metadata,
+            createdAt: now,
+            updatedAt: now,
+          })
+          .returning();
+        if (!workspaceRow) adoptionError("unexpected_failure", 500);
+        await options.afterAdoptionWorkspaceInsert?.(workspaceRow);
+
+        const [operationRow] = await tx
+          .insert(workspaceOperations)
+          .values({
+            companyId,
+            executionWorkspaceId: workspaceRow.id,
+            heartbeatRunId: actor.runId,
+            issueId: input.bindIssueId ?? input.sourceIssueId,
+            phase: "workspace_adopt",
+            command: null,
+            cwd: inspection.canonicalCwd,
+            status: "succeeded",
+            metadata: {
+              reasonCode: null,
+              fingerprint: inspection.worktreeFingerprint,
+              projectId: input.projectId,
+              projectWorkspaceId: input.projectWorkspaceId,
+              sourceIssueId: input.sourceIssueId,
+              bindIssueId: input.bindIssueId ?? null,
+            },
+            startedAt: now,
+            finishedAt: now,
+            createdAt: now,
+            updatedAt: now,
+          })
+          .returning();
+
+        if (input.bindIssueId) {
+          await tx
+            .update(issues)
+            .set({
+              executionWorkspaceId: workspaceRow.id,
+              executionWorkspacePreference: "reuse_existing",
+              executionWorkspaceSettings: {
+                mode: "isolated_workspace",
+                workspaceStrategy: {
+                  type: "git_worktree",
+                  baseRef: input.expectedUpstream,
+                },
+              },
+              updatedAt: now,
+            })
+            .where(and(eq(issues.id, input.bindIssueId), eq(issues.companyId, companyId)));
+        }
+
+        await tx.insert(activityLog).values({
+          companyId,
+          actorType: actor.actorType,
+          actorId: actor.actorId,
+          agentId: actor.agentId,
+          runId: actor.runId,
+          action: "execution_workspace.adopted",
+          entityType: "execution_workspace",
+          entityId: workspaceRow.id,
+          details: {
+            reasonCode: null,
+            fingerprint: inspection.worktreeFingerprint,
+            projectId: input.projectId,
+            projectWorkspaceId: input.projectWorkspaceId,
+            sourceIssueId: input.sourceIssueId,
+            bindIssueId: input.bindIssueId ?? null,
+          },
+          createdAt: now,
+        });
+        if (input.bindIssueId) {
+          await tx.insert(activityLog).values({
+            companyId,
+            actorType: actor.actorType,
+            actorId: actor.actorId,
+            agentId: actor.agentId,
+            runId: actor.runId,
+            action: "issue.execution_workspace_bound",
+            entityType: "issue",
+            entityId: input.bindIssueId,
+            details: {
+              executionWorkspaceId: workspaceRow.id,
+              executionWorkspacePreference: "reuse_existing",
+              executionWorkspaceSettings: {
+                mode: "isolated_workspace",
+                workspaceStrategy: {
+                  type: "git_worktree",
+                  baseRef: input.expectedUpstream,
+                },
+              },
+            },
+            createdAt: now,
+          });
+        }
+
+        const workspace = await executionWorkspaceService(txDb).getById(workspaceRow.id);
+        return {
+          workspace: workspace ?? toExecutionWorkspace(workspaceRow),
+          issue: input.bindIssueId
+            ? {
+                id: input.bindIssueId,
+                identifier: bindIssue?.identifier ?? null,
+                title: bindIssue?.title ?? "",
+                status: bindIssue?.status ?? "",
+              }
+            : null,
+          inspection,
+          operation: operationRow ? {
+            id: operationRow.id,
+            companyId: operationRow.companyId,
+            executionWorkspaceId: operationRow.executionWorkspaceId ?? null,
+            heartbeatRunId: operationRow.heartbeatRunId ?? null,
+            issueId: operationRow.issueId ?? null,
+            phase: operationRow.phase,
+            command: operationRow.command ?? null,
+            cwd: operationRow.cwd ?? null,
+            status: operationRow.status,
+            exitCode: operationRow.exitCode ?? null,
+            logStore: operationRow.logStore ?? null,
+            logRef: operationRow.logRef ?? null,
+            logBytes: operationRow.logBytes ?? null,
+            logSha256: operationRow.logSha256 ?? null,
+            logCompressed: operationRow.logCompressed,
+            stdoutExcerpt: operationRow.stdoutExcerpt ?? null,
+            stderrExcerpt: operationRow.stderrExcerpt ?? null,
+            metadata: (operationRow.metadata as Record<string, unknown> | null) ?? null,
+            startedAt: operationRow.startedAt,
+            finishedAt: operationRow.finishedAt ?? null,
+            createdAt: operationRow.createdAt,
+            updatedAt: operationRow.updatedAt,
+          } : null,
+        };
+        });
+      } catch (error) {
+        if (
+          typeof error === "object" &&
+          error !== null &&
+          "code" in error &&
+          (error as { code?: unknown }).code === "23505"
+        ) {
+          adoptionError("workspace_conflict", 409);
+        }
+        throw error;
+      }
+    },
+
+    rollbackAdoption: async (id: string, actor: ExecutionWorkspaceAdoptionActor, reason?: string | null) => {
+      const now = new Date();
+      return await db.transaction(async (tx) => {
+        const [workspace] = await tx
+          .select()
+          .from(executionWorkspaces)
+          .where(eq(executionWorkspaces.id, id))
+          .for("update");
+        if (!workspace) throw notFound("Execution workspace not found");
+        const metadata = (workspace.metadata as Record<string, unknown> | null) ?? {};
+        const adoption = isRecord(metadata.adoption) ? metadata.adoption : null;
+        if (!adoption) throw unprocessable("Only adopted execution workspace records can be rolled back", { reasonCode: "workspace_conflict" });
+        const previousBinding = isRecord(adoption.previousIssueBinding) ? adoption.previousIssueBinding : null;
+        const boundIssueId = readNullableString(adoption.boundIssueId);
+        if (boundIssueId) {
+          await tx
+            .update(issues)
+            .set({
+              executionWorkspaceId: readNullableString(previousBinding?.executionWorkspaceId),
+              executionWorkspacePreference: readNullableString(previousBinding?.executionWorkspacePreference),
+              executionWorkspaceSettings: isRecord(previousBinding?.executionWorkspaceSettings)
+                ? previousBinding.executionWorkspaceSettings
+                : null,
+              updatedAt: now,
+            })
+            .where(and(eq(issues.id, boundIssueId), eq(issues.companyId, workspace.companyId)));
+        }
+        const nextMetadata = {
+          ...metadata,
+          adoptionRollback: {
+            version: 1,
+            rolledBackAt: now.toISOString(),
+            reason: readNullableString(reason),
+            actor: {
+              type: actor.actorType,
+              id: actor.actorId,
+              agentId: actor.agentId,
+            },
+            runId: actor.runId,
+            restoredIssueId: boundIssueId,
+            restoredExecutionWorkspaceId: readNullableString(previousBinding?.executionWorkspaceId),
+          },
+        };
+        const [updated] = await tx
+          .update(executionWorkspaces)
+          .set({
+            status: "archived",
+            closedAt: now,
+            cleanupReason: "adoption_rollback",
+            metadata: nextMetadata,
+            updatedAt: now,
+          })
+          .where(eq(executionWorkspaces.id, workspace.id))
+          .returning();
+        await tx.insert(activityLog).values({
+          companyId: workspace.companyId,
+          actorType: actor.actorType,
+          actorId: actor.actorId,
+          agentId: actor.agentId,
+          runId: actor.runId,
+          action: "execution_workspace.adoption_rolled_back",
+          entityType: "execution_workspace",
+          entityId: workspace.id,
+          details: {
+            reason: readNullableString(reason),
+            boundIssueId,
+            restoredExecutionWorkspaceId: readNullableString(previousBinding?.executionWorkspaceId),
+          },
+          createdAt: now,
+        });
+        const readback = await executionWorkspaceService(tx as unknown as Db).getById(workspace.id);
+        return readback ?? toExecutionWorkspace(updated ?? workspace);
+      });
     },
 
     reconcileExecutionWorkspaceBranch: async (

--- a/server/src/services/execution-workspaces.ts
+++ b/server/src/services/execution-workspaces.ts
@@ -2073,7 +2073,16 @@ export function executionWorkspaceService(db: Db, options: ExecutionWorkspaceSer
           ))
           .for("update");
         if (!lockedProjectWorkspace) adoptionError("cross_scope_not_found", 404);
-        await tx.select({ id: issues.id }).from(issues).where(eq(issues.id, input.sourceIssueId)).for("update");
+        const [lockedSourceIssue] = await tx
+          .select({ id: issues.id })
+          .from(issues)
+          .where(and(
+            eq(issues.id, input.sourceIssueId),
+            eq(issues.companyId, companyId),
+            eq(issues.projectId, input.projectId),
+          ))
+          .for("update");
+        if (!lockedSourceIssue) adoptionError("cross_scope_not_found", 404);
         const lockedBindIssue = input.bindIssueId
           ? await tx
               .select({

--- a/server/src/services/execution-workspaces.ts
+++ b/server/src/services/execution-workspaces.ts
@@ -5,7 +5,7 @@ import path from "node:path";
 import { promisify } from "node:util";
 import { and, asc, desc, eq, inArray, isNull, ne, or, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
-import { activityLog, executionWorkspaces, heartbeatRuns, issueComments, issues, projects, projectWorkspaces, workspaceOperations, workspaceRuntimeServices } from "@paperclipai/db";
+import { activityLog, companies, executionWorkspaces, heartbeatRuns, issueComments, issues, projects, projectWorkspaces, workspaceOperations, workspaceRuntimeServices } from "@paperclipai/db";
 import type {
   AdoptGitWorktreeExecutionWorkspace,
   ExecutionWorkspace,
@@ -137,6 +137,31 @@ export type ExecutionWorkspaceAdoptionActor = {
   runId: string | null;
 };
 
+export type ExecutionWorkspaceIssueAuthorizationSnapshot = {
+  id: string;
+  parentId: string | null;
+  assigneeAgentId: string | null;
+  assigneeUserId: string | null;
+  status: string;
+  executionPolicy: unknown;
+  originKind: string | null;
+  originId: string | null;
+};
+
+function matchesIssueAuthorizationSnapshot(
+  issue: ExecutionWorkspaceIssueAuthorizationSnapshot,
+  authorized: ExecutionWorkspaceIssueAuthorizationSnapshot,
+) {
+  return issue.id === authorized.id
+    && issue.parentId === authorized.parentId
+    && issue.assigneeAgentId === authorized.assigneeAgentId
+    && issue.assigneeUserId === authorized.assigneeUserId
+    && issue.status === authorized.status
+    && stableStringify(issue.executionPolicy) === stableStringify(authorized.executionPolicy)
+    && issue.originKind === authorized.originKind
+    && issue.originId === authorized.originId;
+}
+
 type AdoptionInspection = {
   status: "accepted";
   reasonCode: null;
@@ -199,6 +224,14 @@ async function readGitRequired(args: string[], cwd: string, reasonCode: Executio
   }
 }
 
+async function realpathRequiredForAdoption(value: string, reasonCode: ExecutionWorkspaceAdoptionReasonCode) {
+  try {
+    return await fs.realpath(value);
+  } catch {
+    adoptionError(reasonCode);
+  }
+}
+
 async function inspectGitWorktreeForAdoption(input: {
   companyId: string;
   projectId: string;
@@ -212,26 +245,24 @@ async function inspectGitWorktreeForAdoption(input: {
   projectWorkspaceCwd: string | null;
   projectWorkspaceRepoUrl: string | null;
 }): Promise<AdoptionInspection> {
-  let canonicalCwd: string;
-  try {
-    canonicalCwd = await fs.realpath(input.cwd);
-  } catch {
-    adoptionError("repo_mismatch");
-  }
+  const canonicalCwd = await realpathRequiredForAdoption(input.cwd, "repo_mismatch");
   const repoRootRaw = await readGitRequired(["rev-parse", "--show-toplevel"], canonicalCwd, "repo_mismatch");
-  const repoRoot = await fs.realpath(repoRootRaw).catch(() => path.resolve(repoRootRaw));
+  const repoRoot = await realpathRequiredForAdoption(repoRootRaw, "repo_mismatch");
   if (repoRoot !== canonicalCwd) adoptionError("repo_mismatch");
 
-  if (input.projectWorkspaceCwd) {
-    const projectRoot = await fs.realpath(input.projectWorkspaceCwd).catch(() => path.resolve(input.projectWorkspaceCwd!));
-    const commonDir = await readGitRequired(["rev-parse", "--git-common-dir"], canonicalCwd, "repo_mismatch");
-    const commonReal = await fs.realpath(path.isAbsolute(commonDir) ? commonDir : path.join(canonicalCwd, commonDir))
-      .catch(() => path.resolve(canonicalCwd, commonDir));
-    const projectCommon = await readGitStdout(["rev-parse", "--git-common-dir"], projectRoot)
-      .then((value) => value ? fs.realpath(path.isAbsolute(value) ? value : path.join(projectRoot, value)) : null)
-      .catch(() => null);
-    if (projectCommon && commonReal !== projectCommon) adoptionError("repo_mismatch");
-  }
+  if (!input.projectWorkspaceCwd) adoptionError("repo_mismatch");
+  const projectRoot = await realpathRequiredForAdoption(input.projectWorkspaceCwd, "repo_mismatch");
+  const commonDir = await readGitRequired(["rev-parse", "--git-common-dir"], canonicalCwd, "repo_mismatch");
+  const commonReal = await realpathRequiredForAdoption(
+    path.isAbsolute(commonDir) ? commonDir : path.join(canonicalCwd, commonDir),
+    "repo_mismatch",
+  );
+  const projectCommonDir = await readGitRequired(["rev-parse", "--git-common-dir"], projectRoot, "repo_mismatch");
+  const projectCommon = await realpathRequiredForAdoption(
+    path.isAbsolute(projectCommonDir) ? projectCommonDir : path.join(projectRoot, projectCommonDir),
+    "repo_mismatch",
+  );
+  if (commonReal !== projectCommon) adoptionError("repo_mismatch");
 
   const headSha = await readGitRequired(["rev-parse", "--verify", "HEAD^{commit}"], canonicalCwd, "sha_mismatch");
   if (headSha !== input.expectedHeadSha) adoptionError("sha_mismatch");
@@ -1120,6 +1151,7 @@ type WorkspaceOverviewIssueRow = WorkspaceOverviewLinkedIssue & {
 };
 
 export type ExecutionWorkspaceServiceOptions = {
+  afterAdoptionInitialInspection?: () => void | Promise<void>;
   afterAdoptionWorkspaceInsert?: (workspace: ExecutionWorkspaceRow) => void | Promise<void>;
 };
 
@@ -1860,7 +1892,12 @@ export function executionWorkspaceService(db: Db, options: ExecutionWorkspaceSer
       return row ? toExecutionWorkspace(row) : null;
     },
 
-    adoptGitWorktree: async (companyId: string, input: AdoptGitWorktreeExecutionWorkspace, actor: ExecutionWorkspaceAdoptionActor) => {
+    adoptGitWorktree: async (
+      companyId: string,
+      input: AdoptGitWorktreeExecutionWorkspace,
+      actor: ExecutionWorkspaceAdoptionActor,
+      authorizedBindIssue?: ExecutionWorkspaceIssueAuthorizationSnapshot | null,
+    ) => {
       const scopeRows = await db
         .select({
           projectId: projects.id,
@@ -1920,6 +1957,7 @@ export function executionWorkspaceService(db: Db, options: ExecutionWorkspaceSer
         projectWorkspaceCwd: scope.projectWorkspaceCwd ?? null,
         projectWorkspaceRepoUrl: scope.projectWorkspaceRepoUrl ?? null,
       });
+      await options.afterAdoptionInitialInspection?.();
 
       const now = new Date();
       const metadata = {
@@ -2021,9 +2059,57 @@ export function executionWorkspaceService(db: Db, options: ExecutionWorkspaceSer
       try {
         return await db.transaction(async (tx) => {
         const txDb = tx as unknown as Db;
+        // Adoption claims are unique company-wide, so serialize adoption duplicate
+        // checks on the company rather than only on the selected project.
+        await tx.select({ id: companies.id }).from(companies).where(eq(companies.id, companyId)).for("update");
         await tx.select({ id: projects.id }).from(projects).where(eq(projects.id, input.projectId)).for("update");
+        const [lockedProjectWorkspace] = await tx
+          .select({ cwd: projectWorkspaces.cwd, repoUrl: projectWorkspaces.repoUrl })
+          .from(projectWorkspaces)
+          .where(and(
+            eq(projectWorkspaces.id, input.projectWorkspaceId),
+            eq(projectWorkspaces.companyId, companyId),
+            eq(projectWorkspaces.projectId, input.projectId),
+          ))
+          .for("update");
+        if (!lockedProjectWorkspace) adoptionError("cross_scope_not_found", 404);
         await tx.select({ id: issues.id }).from(issues).where(eq(issues.id, input.sourceIssueId)).for("update");
-        if (input.bindIssueId) await tx.select({ id: issues.id }).from(issues).where(eq(issues.id, input.bindIssueId)).for("update");
+        const lockedBindIssue = input.bindIssueId
+          ? await tx
+              .select({
+                id: issues.id,
+                parentId: issues.parentId,
+                assigneeAgentId: issues.assigneeAgentId,
+                assigneeUserId: issues.assigneeUserId,
+                status: issues.status,
+                executionPolicy: issues.executionPolicy,
+                originKind: issues.originKind,
+                originId: issues.originId,
+                executionWorkspaceId: issues.executionWorkspaceId,
+                executionWorkspacePreference: issues.executionWorkspacePreference,
+                executionWorkspaceSettings: issues.executionWorkspaceSettings,
+              })
+              .from(issues)
+              .where(and(
+                eq(issues.id, input.bindIssueId),
+                eq(issues.companyId, companyId),
+                eq(issues.projectId, input.projectId),
+              ))
+              .for("update")
+              .then((rows) => rows[0] ?? null)
+          : null;
+        if (input.bindIssueId && !lockedBindIssue) adoptionError("cross_scope_not_found", 404);
+        if (
+          authorizedBindIssue !== undefined
+          && input.bindIssueId
+          && (
+            !authorizedBindIssue
+            || !lockedBindIssue
+            || !matchesIssueAuthorizationSnapshot(lockedBindIssue, authorizedBindIssue)
+          )
+        ) {
+          adoptionError("workspace_conflict", 409);
+        }
 
         const duplicate = await tx
           .select()
@@ -2035,6 +2121,7 @@ export function executionWorkspaceService(db: Db, options: ExecutionWorkspaceSer
             or(
               eq(executionWorkspaces.cwd, inspection.canonicalCwd),
               eq(executionWorkspaces.providerRef, inspection.canonicalCwd),
+              eq(executionWorkspaces.branchName, inspection.branchName),
               sql`${executionWorkspaces.metadata}->>'fullBranchRef' = ${inspection.fullBranchRef}`,
             ),
           ))
@@ -2042,6 +2129,38 @@ export function executionWorkspaceService(db: Db, options: ExecutionWorkspaceSer
           .limit(1)
           .then((rows) => rows[0] ?? null);
         if (duplicate) adoptionError(fingerprintMatches(duplicate) ? "workspace_conflict" : "workspace_conflict", 409);
+
+        const writeInspection = await inspectGitWorktreeForAdoption({
+          companyId,
+          projectId: input.projectId,
+          projectWorkspaceId: input.projectWorkspaceId,
+          sourceIssueId: input.sourceIssueId,
+          cwd: input.cwd,
+          expectedBranch: input.expectedBranch,
+          expectedHeadSha: input.expectedHeadSha,
+          expectedUpstream: input.expectedUpstream,
+          expectedRepoUrl: input.expectedRepoUrl ?? null,
+          projectWorkspaceCwd: lockedProjectWorkspace.cwd ?? null,
+          projectWorkspaceRepoUrl: lockedProjectWorkspace.repoUrl ?? null,
+        });
+        if (writeInspection.worktreeFingerprint !== inspection.worktreeFingerprint) {
+          adoptionError("workspace_conflict", 409);
+        }
+
+        const transactionalMetadata = {
+          ...metadata,
+          adoption: {
+            ...metadata.adoption,
+            previousIssueBinding: lockedBindIssue
+              ? {
+                  issueId: lockedBindIssue.id,
+                  executionWorkspaceId: lockedBindIssue.executionWorkspaceId ?? null,
+                  executionWorkspacePreference: lockedBindIssue.executionWorkspacePreference ?? null,
+                  executionWorkspaceSettings: lockedBindIssue.executionWorkspaceSettings ?? null,
+                }
+              : null,
+          },
+        };
 
         const [workspaceRow] = await tx
           .insert(executionWorkspaces)
@@ -2062,7 +2181,7 @@ export function executionWorkspaceService(db: Db, options: ExecutionWorkspaceSer
             providerRef: inspection.canonicalCwd,
             lastUsedAt: now,
             openedAt: now,
-            metadata,
+            metadata: transactionalMetadata,
             createdAt: now,
             updatedAt: now,
           })
@@ -2209,7 +2328,13 @@ export function executionWorkspaceService(db: Db, options: ExecutionWorkspaceSer
       }
     },
 
-    rollbackAdoption: async (id: string, actor: ExecutionWorkspaceAdoptionActor, reason?: string | null) => {
+    rollbackAdoption: async (
+      id: string,
+      actor: ExecutionWorkspaceAdoptionActor,
+      reason: string | null | undefined,
+      authorizedBoundIssueId: string | null,
+      authorizedBoundIssue: ExecutionWorkspaceIssueAuthorizationSnapshot | null = null,
+    ) => {
       const now = new Date();
       return await db.transaction(async (tx) => {
         const [workspace] = await tx
@@ -2223,8 +2348,36 @@ export function executionWorkspaceService(db: Db, options: ExecutionWorkspaceSer
         if (!adoption) throw unprocessable("Only adopted execution workspace records can be rolled back", { reasonCode: "workspace_conflict" });
         const previousBinding = isRecord(adoption.previousIssueBinding) ? adoption.previousIssueBinding : null;
         const boundIssueId = readNullableString(adoption.boundIssueId);
+        if (boundIssueId !== authorizedBoundIssueId) adoptionError("workspace_conflict", 409);
         if (boundIssueId) {
-          await tx
+          const [boundIssue] = await tx
+            .select({
+              id: issues.id,
+              parentId: issues.parentId,
+              assigneeAgentId: issues.assigneeAgentId,
+              assigneeUserId: issues.assigneeUserId,
+              status: issues.status,
+              executionPolicy: issues.executionPolicy,
+              originKind: issues.originKind,
+              originId: issues.originId,
+              executionWorkspaceId: issues.executionWorkspaceId,
+            })
+            .from(issues)
+            .where(and(
+              eq(issues.id, boundIssueId),
+              eq(issues.companyId, workspace.companyId),
+              eq(issues.projectId, workspace.projectId),
+            ))
+            .for("update");
+          if (
+            !boundIssue
+            || boundIssue.executionWorkspaceId !== workspace.id
+            || !authorizedBoundIssue
+            || !matchesIssueAuthorizationSnapshot(boundIssue, authorizedBoundIssue)
+          ) {
+            adoptionError("workspace_conflict", 409);
+          }
+          const restored = await tx
             .update(issues)
             .set({
               executionWorkspaceId: readNullableString(previousBinding?.executionWorkspaceId),
@@ -2234,7 +2387,13 @@ export function executionWorkspaceService(db: Db, options: ExecutionWorkspaceSer
                 : null,
               updatedAt: now,
             })
-            .where(and(eq(issues.id, boundIssueId), eq(issues.companyId, workspace.companyId)));
+            .where(and(
+              eq(issues.id, boundIssueId),
+              eq(issues.companyId, workspace.companyId),
+              eq(issues.executionWorkspaceId, workspace.id),
+            ))
+            .returning({ id: issues.id });
+          if (restored.length !== 1) adoptionError("workspace_conflict", 409);
         }
         const nextMetadata = {
           ...metadata,

--- a/server/src/services/execution-workspaces.ts
+++ b/server/src/services/execution-workspaces.ts
@@ -218,11 +218,21 @@ function fingerprintAdoption(input: {
 
 async function readGitRequired(args: string[], cwd: string, reasonCode: ExecutionWorkspaceAdoptionReasonCode) {
   try {
-    const output = await execFileAsync("git", ["-C", cwd, ...args], { cwd });
+    const output = await runGitForAdoption(args, cwd);
     return output.stdout.trim();
   } catch {
     adoptionError(reasonCode);
   }
+}
+
+async function runGitForAdoption(args: string[], cwd: string) {
+  return await execFileAsync("git", ["-c", "core.fsmonitor=false", "-C", cwd, ...args], {
+    cwd,
+    env: {
+      ...process.env,
+      GIT_OPTIONAL_LOCKS: "0",
+    },
+  });
 }
 
 async function realpathRequiredForAdoption(value: string, reasonCode: ExecutionWorkspaceAdoptionReasonCode) {
@@ -287,12 +297,14 @@ async function inspectGitWorktreeForAdoption(input: {
   }
   if (dirtyTrackedCount > 0 || untrackedCount > 0) adoptionError("dirty_worktree");
 
-  const repoUrl = await readGitStdout(["config", "--get", "remote.origin.url"], canonicalCwd).catch(() => null);
+  const repoUrl = await runGitForAdoption(["config", "--get", "remote.origin.url"], canonicalCwd)
+    .then((output) => output.stdout.trim() || null)
+    .catch(() => null);
   const normalizedRepoUrl = normalizeRepoUrl(repoUrl);
   const expectedRepoUrl = normalizeRepoUrl(input.expectedRepoUrl) ?? normalizeRepoUrl(input.projectWorkspaceRepoUrl);
   if (expectedRepoUrl && normalizedRepoUrl !== expectedRepoUrl) adoptionError("repo_mismatch");
 
-  const worktreeRows = await execFileAsync("git", ["-C", canonicalCwd, "worktree", "list", "--porcelain", "-z"], { cwd: canonicalCwd })
+  const worktreeRows = await runGitForAdoption(["worktree", "list", "--porcelain", "-z"], canonicalCwd)
     .then((output) => output.stdout.split("\0").filter(Boolean))
     .catch(() => adoptionError("unexpected_failure"));
   let current: Record<string, string> = {};

--- a/server/src/services/execution-workspaces.ts
+++ b/server/src/services/execution-workspaces.ts
@@ -2128,7 +2128,26 @@ export function executionWorkspaceService(db: Db, options: ExecutionWorkspaceSer
           .for("update")
           .limit(1)
           .then((rows) => rows[0] ?? null);
-        if (duplicate) adoptionError(fingerprintMatches(duplicate) ? "workspace_conflict" : "workspace_conflict", 409);
+        if (duplicate) {
+          if (
+            !fingerprintMatches(duplicate)
+            || (input.bindIssueId ?? null) !== adoptionBoundIssueId(duplicate)
+          ) {
+            adoptionError("workspace_conflict", 409);
+          }
+          const existingWorkspace = await executionWorkspaceService(txDb).getById(duplicate.id);
+          return {
+            workspace: existingWorkspace ?? toExecutionWorkspace(duplicate),
+            issue: bindIssue ? {
+              id: bindIssue.id,
+              identifier: bindIssue.identifier,
+              title: bindIssue.title,
+              status: bindIssue.status,
+            } : null,
+            inspection,
+            operation: null,
+          };
+        }
 
         const writeInspection = await inspectGitWorktreeForAdoption({
           companyId,
@@ -2349,6 +2368,13 @@ export function executionWorkspaceService(db: Db, options: ExecutionWorkspaceSer
         const previousBinding = isRecord(adoption.previousIssueBinding) ? adoption.previousIssueBinding : null;
         const boundIssueId = readNullableString(adoption.boundIssueId);
         if (boundIssueId !== authorizedBoundIssueId) adoptionError("workspace_conflict", 409);
+        if (
+          workspace.status === "archived"
+          || workspace.closedAt !== null
+          || isRecord(metadata.adoptionRollback)
+        ) {
+          adoptionError("workspace_conflict", 409);
+        }
         if (boundIssueId) {
           const [boundIssue] = await tx
             .select({

--- a/server/src/services/workspace-runtime.ts
+++ b/server/src/services/workspace-runtime.ts
@@ -33,7 +33,11 @@ import {
   writeLocalServiceRegistryRecord,
 } from "./local-service-supervisor.js";
 import type { WorkspaceOperationRecorder } from "./workspace-operations.js";
-import { executionWorkspaceService, readExecutionWorkspaceConfig } from "./execution-workspaces.js";
+import {
+  executionWorkspaceOwnsGitArtifacts,
+  executionWorkspaceService,
+  readExecutionWorkspaceConfig,
+} from "./execution-workspaces.js";
 import { logActivity } from "./activity-log.js";
 import { readProjectWorkspaceRuntimeConfig } from "./project-workspace-runtime-config.js";
 
@@ -3156,6 +3160,14 @@ export async function cleanupExecutionWorkspaceArtifacts(input: {
   teardownCommand?: string | null;
   recorder?: WorkspaceOperationRecorder | null;
 }) {
+  if (!executionWorkspaceOwnsGitArtifacts(input.workspace.metadata)) {
+    return {
+      cleanedPath: null,
+      cleaned: true,
+      warnings: [],
+    };
+  }
+
   const warnings: string[] = [];
   const workspacePath = input.workspace.providerRef ?? input.workspace.cwd;
   const repoRoot = input.workspace.providerType === "git_worktree" && workspacePath


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Execution workspaces connect issue runs to concrete code locations, branches, runtime state, and continuity across heartbeats.
> - Operators can already create and reuse Paperclip-managed workspaces, but cannot safely register an exact local worktree that already exists outside the control plane.
> - Treating that workflow as ordinary workspace creation risks silently selecting the wrong ref, mutating git state, duplicating active claims, or losing audit evidence.
> - The adoption path therefore verifies the canonical checkout, exact local branch, SHA, upstream, repository, cleanliness, scope, and active claims before writing anything.
> - This pull request adds an authorized, transactionally audited, record-only adoption and rollback API with stable failure codes and readback evidence.
> - The benefit is deterministic control-plane adoption without checkout, cleanup, push, pull, branch deletion, or other git mutation.

## Linked Issues or Issue Description

No public GitHub issue currently tracks this exact feature.

**Problem**

Operators sometimes already have the exact branch worktree that an issue should use, but Paperclip has no guarded way to register that checkout as an execution workspace. Manual database edits or generic workspace creation cannot prove branch/SHA/upstream/repository identity, do not provide a dedicated authorization boundary, and do not produce complete rollback/audit evidence.

**Proposed solution**

Add a first-class exact-worktree adoption API that inspects git read-only, requires exact expected state, rejects dirty or duplicate claims with stable reason codes, writes the workspace/operation/activity/optional issue binding atomically, and supports record-only rollback that preserves local git artifacts.

**Alternatives considered**

- Recreate the checkout through the existing workspace provisioning path: rejected because it can mutate or replace an operator-owned worktree.
- Permit manual execution-workspace rows: rejected because it bypasses validation, authorization, idempotency, and audit controls.

## What Changed

- Added shared adoption request/result/reason schemas and the `execution_workspaces:adopt` permission boundary.
- Added database uniqueness guards for active adopted cwd/provider/full-ref claims.
- Added read-only exact git-worktree inspection, canonical fingerprinting, idempotent adoption, optional issue binding, operation/activity evidence, and record-only rollback.
- Added adoption and rollback routes plus OpenAPI contracts and redacted stable error responses.
- Added authorization, route, OpenAPI, real-git verification-matrix, duplicate-claim, transaction-rollback, argv-safety, readback, and rollback tests.
- Documented operator request, authorization, audit/readback, failure, review, and rollback workflows.

## Verification

- `TMPDIR="$PWD/.tmp" pnpm --filter @paperclipai/server exec vitest run src/__tests__/execution-workspaces-service.test.ts src/__tests__/authorization-service.test.ts src/__tests__/execution-workspaces-routes.test.ts src/__tests__/openapi-routes.test.ts` — 109 passed after rebasing on current `master`.
- `TMPDIR="$PWD/.tmp" pnpm --filter @paperclipai/db typecheck` — passed, including migration numbering and safety checks.
- `TMPDIR="$PWD/.tmp" pnpm --filter @paperclipai/shared typecheck` — passed.
- `TMPDIR="$PWD/.tmp" pnpm --filter @paperclipai/server typecheck` — passed.
- `TMPDIR="$PWD/.tmp" pnpm --filter @paperclipai/shared build` — passed.
- `TMPDIR="$PWD/.tmp" pnpm --filter @paperclipai/server build` — passed.
- `pnpm check:tokens` — passed.
- `git diff --check` — passed.

## Risks

- The migration adds partial unique indexes over active adopted workspaces. Adoption records do not exist before this feature, so historical-row collision risk is low; migration numbering and safety checks pass.
- Git URL normalization intentionally preserves transport distinctions after syntax normalization. Repository mismatch failures are conservative rather than permissive.
- Rollback archives only Paperclip records and restores the previous issue binding. It deliberately does not clean up or mutate local git artifacts.
- The new route exposes host filesystem inspection only to active non-viewer board members or standard-trust agents carrying an explicit project-scoped adoption grant; normal issue mutation authorization still applies when binding an issue.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

OpenAI Codex, primary model `gpt-5.6-sol`, with reasoning, repository tools, code execution, delegated Codex implementation assistance, and local test/build verification.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
