### PR TITLE
feat: add issue document artifact visibility

### DIFF
--- a/packages/db/src/migrations/0182_issue_document_artifact_visibility.sql
+++ b/packages/db/src/migrations/0182_issue_document_artifact_visibility.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "issue_documents"
+  ADD COLUMN IF NOT EXISTS "artifact_visible" boolean DEFAULT true NOT NULL;

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -1261,6 +1261,13 @@
       "when": 1784231633059,
       "tag": "0181_decision_training_retention_policy",
       "breakpoints": true
+    },
+    {
+      "idx": 182,
+      "version": "7",
+      "when": 1784515950000,
+      "tag": "0182_issue_document_artifact_visibility",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/issue_documents.ts
+++ b/packages/db/src/schema/issue_documents.ts
@@ -1,4 +1,4 @@
-import { pgTable, uuid, text, timestamp, index, uniqueIndex } from "drizzle-orm/pg-core";
+import { boolean, pgTable, uuid, text, timestamp, index, uniqueIndex } from "drizzle-orm/pg-core";
 import { companies } from "./companies.js";
 import { issues } from "./issues.js";
 import { documents } from "./documents.js";
@@ -11,6 +11,7 @@ export const issueDocuments = pgTable(
     issueId: uuid("issue_id").notNull().references(() => issues.id, { onDelete: "cascade" }),
     documentId: uuid("document_id").notNull().references(() => documents.id, { onDelete: "cascade" }),
     key: text("key").notNull(),
+    artifactVisible: boolean("artifact_visible").notNull().default(true),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },

--- a/server/src/__tests__/company-artifacts-service.test.ts
+++ b/server/src/__tests__/company-artifacts-service.test.ts
@@ -25,6 +25,7 @@ import {
 import { errorHandler } from "../middleware/index.js";
 import { companyRoutes } from "../routes/companies.js";
 import { companyArtifactsService } from "../services/company-artifacts.js";
+import { documentService } from "../services/documents.js";
 import type { StorageService } from "../storage/types.js";
 
 const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
@@ -358,6 +359,40 @@ describeEmbeddedPostgres("companyArtifactsService", () => {
     expect(result.artifacts.some((artifact) => artifact.title === "operator-screenshot.png")).toBe(false);
     expect(result.artifacts.some((artifact) => artifact.title === "comment-screenshot.png")).toBe(false);
     expect(result.artifacts.some((artifact) => artifact.issue.identifier === "OTH-1")).toBe(false);
+  });
+
+  it("hides an issue document from artifacts without deleting the document or issue link", async () => {
+    const { companyId, secondIssueId } = await seedArtifacts();
+    const documentsSvc = documentService(db) as ReturnType<typeof documentService> & {
+      setIssueDocumentArtifactVisibility: (
+        issueId: string,
+        key: string,
+        visible: boolean,
+      ) => Promise<{ changed: boolean; visible: boolean }>;
+    };
+
+    const hiddenResults = await Promise.all([
+      documentsSvc.setIssueDocumentArtifactVisibility(secondIssueId, "review", false),
+      documentsSvc.setIssueDocumentArtifactVisibility(secondIssueId, "review", false),
+    ]);
+
+    expect(hiddenResults).toEqual(expect.arrayContaining([
+      { changed: true, visible: false },
+      { changed: false, visible: false },
+    ]));
+    expect((await companyArtifactsService(db).list(companyId, { limit: 20 })).artifacts)
+      .not.toEqual(expect.arrayContaining([expect.objectContaining({ title: "Review Notes" })]));
+    expect(await documentsSvc.getIssueDocumentByKey(secondIssueId, "review")).toEqual(expect.objectContaining({
+      title: "Review Notes",
+      body: "# Review\n\nAgent-created review document with useful details.",
+    }));
+    expect(await db.select().from(issueDocuments).where(eq(issueDocuments.issueId, secondIssueId)))
+      .toHaveLength(1);
+
+    const shown = await documentsSvc.setIssueDocumentArtifactVisibility(secondIssueId, "review", true);
+    expect(shown).toEqual({ changed: true, visible: true });
+    expect((await companyArtifactsService(db).list(companyId, { limit: 20 })).artifacts)
+      .toEqual(expect.arrayContaining([expect.objectContaining({ title: "Review Notes" })]));
   });
 
   it("supports project, kind, search, and cursor filters", async () => {

--- a/server/src/__tests__/company-search-service.test.ts
+++ b/server/src/__tests__/company-search-service.test.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { sql } from "drizzle-orm";
+import { eq, sql } from "drizzle-orm";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import {
   agents,
@@ -300,6 +300,17 @@ describeEmbeddedPostgres("companySearchService", () => {
     });
     expect(result.results[0]?.snippet).toMatch(/comet tail/i);
     expect(result.countsByType).toEqual({ issue: 0, comment: 0, document: 0, artifact: 1, agent: 0, project: 0 });
+
+    await db
+      .update(issueDocuments)
+      .set({ artifactVisible: false })
+      .where(eq(issueDocuments.documentId, documentId));
+    const hidden = await svc.search(
+      companyId,
+      companySearchQuerySchema.parse({ q: "comet-tail", scope: "artifacts" }),
+    );
+    expect(hidden.results).toEqual([]);
+    expect(hidden.countsByType.artifact).toBe(0);
   });
 
   it("does not pass high-offset search fetch windows through to artifact query validation", async () => {

--- a/server/src/__tests__/issue-document-restore-routes.test.ts
+++ b/server/src/__tests__/issue-document-restore-routes.test.ts
@@ -13,6 +13,7 @@ const mockDocumentsService = vi.hoisted(() => ({
   listIssueDocuments: vi.fn(),
   listIssueDocumentRevisions: vi.fn(),
   restoreIssueDocumentRevision: vi.fn(),
+  setIssueDocumentArtifactVisibility: vi.fn(),
 }));
 
 const mockAccessService = vi.hoisted(() => ({
@@ -267,6 +268,10 @@ describe("issue document revision routes", () => {
         updatedAt: new Date("2026-03-26T12:10:00.000Z"),
       },
     });
+    mockDocumentsService.setIssueDocumentArtifactVisibility.mockResolvedValue({
+      changed: true,
+      visible: false,
+    });
     mockHeartbeatService.wakeup.mockResolvedValue(undefined);
     mockHeartbeatService.reportRunActivity.mockResolvedValue(undefined);
     mockInstanceSettingsService.get.mockResolvedValue({
@@ -346,6 +351,42 @@ describe("issue document revision routes", () => {
       title: "Plan v1",
       latestRevisionNumber: 3,
     }));
+  });
+
+  it("lets the board idempotently hide an issue document from company artifacts", async () => {
+    const res = await request(await createApp())
+      .patch(`/api/issues/${issueId}/documents/plan/artifact-visibility`)
+      .send({ visible: false });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ changed: true, visible: false });
+    expect(mockDocumentsService.setIssueDocumentArtifactVisibility).toHaveBeenCalledWith(
+      issueId,
+      "plan",
+      false,
+    );
+    expect(mockLogActivity).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        action: "issue.document_artifact_visibility_updated",
+        details: { key: "plan", visible: false, changed: true },
+      }),
+    );
+  });
+
+  it("rejects non-board artifact visibility mutations", async () => {
+    const res = await request(await createApp({
+      type: "agent",
+      agentId: "agent-1",
+      companyId,
+      runId: "run-1",
+      source: "agent_jwt",
+    }))
+      .patch(`/api/issues/${issueId}/documents/plan/artifact-visibility`)
+      .send({ visible: false });
+
+    expect(res.status).toBe(403);
+    expect(mockDocumentsService.setIssueDocumentArtifactVisibility).not.toHaveBeenCalled();
   });
 
   it("blocks cheap status-only recovery runs from restoring issue documents", async () => {

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -6352,6 +6352,49 @@ export function issueRoutes(
     },
   );
 
+  router.patch(
+    "/issues/:id/documents/:key/artifact-visibility",
+    validate(z.object({ visible: z.boolean() })),
+    async (req, res) => {
+      const id = req.params.id as string;
+      const issue = await getAccessibleResource(req, res, svc.getById(id), "Issue not found");
+      if (!issue) return;
+      if (req.actor.type !== "board") {
+        res.status(403).json({ error: "Board authentication required" });
+        return;
+      }
+      const keyParsed = issueDocumentKeySchema.safeParse(String(req.params.key ?? "").trim().toLowerCase());
+      if (!keyParsed.success) {
+        res.status(400).json({ error: "Invalid document key", details: keyParsed.error.issues });
+        return;
+      }
+
+      const result = await documentsSvc.setIssueDocumentArtifactVisibility(
+        issue.id,
+        keyParsed.data,
+        req.body.visible,
+      );
+      const actor = getActorInfo(req);
+      await logActivity(db, {
+        companyId: issue.companyId,
+        actorType: actor.actorType,
+        actorId: actor.actorId,
+        agentId: actor.agentId,
+        runId: actor.runId,
+        agentApiKeyId: actor.agentApiKeyId,
+        action: "issue.document_artifact_visibility_updated",
+        entityType: "issue",
+        entityId: issue.id,
+        details: {
+          key: keyParsed.data,
+          visible: result.visible,
+          changed: result.changed,
+        },
+      });
+      res.json(result);
+    },
+  );
+
   router.delete("/issues/:id/documents/:key", async (req, res) => {
     const id = req.params.id as string;
     const issue = await getAccessibleResource(req, res, svc.getById(id), "Issue not found");

--- a/server/src/services/company-artifacts.ts
+++ b/server/src/services/company-artifacts.ts
@@ -347,6 +347,7 @@ export function companyArtifactsService(db: Db, storage?: StorageService) {
         const documentArtifactId = sql<string>`concat('document:', ${documents.id})`;
         const documentConditions: SQL[] = [
           eq(issueDocuments.companyId, companyId),
+          eq(issueDocuments.artifactVisible, true),
           eq(documents.companyId, companyId),
           or(isNotNull(documents.createdByAgentId), isNotNull(documents.updatedByAgentId))!,
           notInArray(issueDocuments.key, [...SYSTEM_ISSUE_DOCUMENT_KEYS]),

--- a/server/src/services/company-search.ts
+++ b/server/src/services/company-search.ts
@@ -1125,6 +1125,7 @@ export function companySearchService(db: Db) {
         ];
         const documentArtifactConditions = [
           eq(issueDocuments.companyId, companyId),
+          eq(issueDocuments.artifactVisible, true),
           eq(documents.companyId, companyId),
           or(isNotNull(documents.createdByAgentId), isNotNull(documents.updatedByAgentId))!,
           notInArray(issueDocuments.key, [...SYSTEM_ISSUE_DOCUMENT_KEYS]),

--- a/server/src/services/documents.ts
+++ b/server/src/services/documents.ts
@@ -1,4 +1,4 @@
-import { and, asc, desc, eq } from "drizzle-orm";
+import { and, asc, desc, eq, ne } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import { documentRevisions, documents, issueDocuments, issues } from "@paperclipai/db";
 import { isSystemIssueDocumentKey, issueDocumentKeySchema } from "@paperclipai/shared";
@@ -45,6 +45,7 @@ export function mapIssueDocumentRow(
     companyId: string;
     issueId: string;
     key: string;
+    artifactVisible: boolean;
     title: string | null;
     format: string;
     latestBody: string;
@@ -68,6 +69,7 @@ export function mapIssueDocumentRow(
     companyId: row.companyId,
     issueId: row.issueId,
     key: row.key,
+    artifactVisible: row.artifactVisible,
     title: row.title,
     format: row.format,
     ...(includeBody ? { body: row.latestBody } : {}),
@@ -91,6 +93,7 @@ export const issueDocumentSelect = {
   companyId: documents.companyId,
   issueId: issueDocuments.issueId,
   key: issueDocuments.key,
+  artifactVisible: issueDocuments.artifactVisible,
   title: documents.title,
   format: documents.format,
   latestBody: documents.latestBody,
@@ -710,6 +713,29 @@ export function documentService(db: Db) {
           },
         };
       });
+    },
+
+    setIssueDocumentArtifactVisibility: async (issueId: string, rawKey: string, visible: boolean) => {
+      const key = normalizeDocumentKey(rawKey);
+      const changed = await db
+        .update(issueDocuments)
+        .set({ artifactVisible: visible, updatedAt: new Date() })
+        .where(and(
+          eq(issueDocuments.issueId, issueId),
+          eq(issueDocuments.key, key),
+          ne(issueDocuments.artifactVisible, visible),
+        ))
+        .returning({ id: issueDocuments.id })
+        .then((rows) => rows[0] ?? null);
+      if (changed) return { changed: true as const, visible };
+
+      const existing = await db
+        .select({ id: issueDocuments.id })
+        .from(issueDocuments)
+        .where(and(eq(issueDocuments.issueId, issueId), eq(issueDocuments.key, key)))
+        .then((rows) => rows[0] ?? null);
+      if (!existing) throw notFound("Document not found");
+      return { changed: false as const, visible };
     },
 
     deleteIssueDocument: async (issueId: string, rawKey: string) => {


### PR DESCRIPTION
## Summary
- add association-level artifact visibility with default-visible migration semantics
- add board-authenticated, idempotent hide/unhide route without deleting or detaching documents
- exclude hidden issue-document associations from company artifacts and artifact search counts

## Verification
- 38 targeted Vitest tests passed in fresh Staff Engineer review
- database and server TypeScript checks passed
- `git diff --check` passed

The change preserves archived issue-document and document reads and never mutates document content.