### PR TITLE
fix(projects): allow clearing env bindings

### DIFF
--- a/server/src/__tests__/project-routes-env.test.ts
+++ b/server/src/__tests__/project-routes-env.test.ts
@@ -206,6 +206,33 @@ describe("project env routes", () => {
     );
   });
 
+  it("allows create env null without normalizing project env bindings", async () => {
+    mockProjectService.create.mockResolvedValue(buildProject({ env: null }));
+
+    const app = await createApp();
+    const res = await request(app)
+      .post("/api/companies/company-1/projects")
+      .send({
+        name: "Project",
+        env: null,
+      });
+
+    expect([200, 201], JSON.stringify(res.body)).toContain(res.status);
+    expect(mockSecretService.normalizeEnvBindingsForPersistence).not.toHaveBeenCalled();
+    expect(mockProjectService.create).toHaveBeenCalledWith(
+      "company-1",
+      expect.objectContaining({ env: null }),
+    );
+    expect(mockLogActivity).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        details: expect.objectContaining({
+          envKeys: [],
+        }),
+      }),
+    );
+  });
+
   it("normalizes env bindings on update and avoids logging raw values", async () => {
     const normalizedEnv = {
       PLAIN_KEY: { type: "plain", value: "top-secret" },

--- a/server/src/__tests__/project-routes-env.test.ts
+++ b/server/src/__tests__/project-routes-env.test.ts
@@ -16,6 +16,7 @@ const mockProjectService = vi.hoisted(() => ({
 }));
 const mockSecretService = vi.hoisted(() => ({
   normalizeEnvBindingsForPersistence: vi.fn(),
+  syncEnvBindingsForTarget: vi.fn(),
 }));
 const mockEnvironmentService = vi.hoisted(() => ({
   getById: vi.fn(),
@@ -163,6 +164,7 @@ describe("project env routes", () => {
     mockProjectService.listWorkspaces.mockResolvedValue([]);
     mockEnvironmentService.getById.mockReset();
     mockSecretService.normalizeEnvBindingsForPersistence.mockImplementation(async (_companyId, env) => env);
+    mockSecretService.syncEnvBindingsForTarget.mockResolvedValue(undefined);
   });
 
   it("normalizes env bindings on create and logs only env keys", async () => {
@@ -226,6 +228,42 @@ describe("project env routes", () => {
         details: {
           changedKeys: ["env"],
           envKeys: ["PLAIN_KEY"],
+        },
+      }),
+    );
+  });
+
+  it("allows update env null to clear project env bindings", async () => {
+    mockProjectService.getById.mockResolvedValue(buildProject({
+      env: {
+        API_KEY: {
+          type: "secret_ref",
+          secretId: "11111111-1111-4111-8111-111111111111",
+          version: "latest",
+        },
+      },
+    }));
+    mockProjectService.update.mockResolvedValue(buildProject({ env: null }));
+
+    const app = await createApp();
+    const res = await request(app)
+      .patch("/api/projects/project-1")
+      .send({ env: null });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(mockSecretService.normalizeEnvBindingsForPersistence).not.toHaveBeenCalled();
+    expect(mockProjectService.update).toHaveBeenCalledWith("project-1", { env: null });
+    expect(mockSecretService.syncEnvBindingsForTarget).toHaveBeenCalledWith(
+      "company-1",
+      { targetType: "project", targetId: "project-1" },
+      null,
+    );
+    expect(mockLogActivity).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        details: {
+          changedKeys: ["env"],
+          envKeys: undefined,
         },
       }),
     );

--- a/server/src/routes/projects.ts
+++ b/server/src/routes/projects.ts
@@ -168,7 +168,7 @@ export function projectRoutes(db: Db) {
         ...collectProjectWorkspaceCommandPaths(workspace, "workspace"),
       ],
     );
-    if (projectData.env !== undefined) {
+    if (projectData.env !== undefined && projectData.env !== null) {
       projectData.env = await secretsSvc.normalizeEnvBindingsForPersistence(
         companyId,
         projectData.env,
@@ -233,7 +233,7 @@ export function projectRoutes(db: Db) {
     if (typeof body.archivedAt === "string") {
       body.archivedAt = new Date(body.archivedAt);
     }
-    if (body.env !== undefined) {
+    if (body.env !== undefined && body.env !== null) {
       body.env = await secretsSvc.normalizeEnvBindingsForPersistence(existing.companyId, body.env, {
         strictMode: strictSecretsMode,
         fieldPath: "env",

--- a/server/src/routes/projects.ts
+++ b/server/src/routes/projects.ts
@@ -195,7 +195,7 @@ export function projectRoutes(db: Db) {
       ],
     );
     await assertNoManagedSandboxWorkspacePath(workspace);
-    if (projectData.env !== undefined) {
+    if (projectData.env !== undefined && projectData.env !== null) {
       projectData.env = await secretsSvc.normalizeEnvBindingsForPersistence(
         companyId,
         projectData.env,
@@ -260,7 +260,7 @@ export function projectRoutes(db: Db) {
     if (typeof body.archivedAt === "string") {
       body.archivedAt = new Date(body.archivedAt);
     }
-    if (body.env !== undefined) {
+    if (body.env !== undefined && body.env !== null) {
       body.env = await secretsSvc.normalizeEnvBindingsForPersistence(existing.companyId, body.env, {
         strictMode: strictSecretsMode,
         fieldPath: "env",


### PR DESCRIPTION
## Thinking Path

> - Paperclip is a company-scoped control plane, so project settings must stay consistent with company-level env binding rules.
> - The project configuration UI already sends `env: null` when a user clears the env editor.
> - The shared validator allows `env` to be null, so the route should treat null as a valid clear action.
> - The current project route still normalizes null as if it were a binding object, which turns a clear action into a 422.
> - This pull request aligns project create/update behavior with the existing routines/pipelines pattern for clearing env.
> - The benefit is that users can clear project env values without hitting an error, while secret bindings are cleaned up correctly.

## Linked Issues or Issue Description

Fixes: #9825

## What Changed

- Skip env normalization when project `env` is `null` on create and update.
- Add a regression test that covers `PATCH /api/projects/:id` with `env: null`.
- Verify null clears bindings without logging raw secret values.

## Verification

- `PATH="/Users/xinran/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin:$PATH" pnpm --filter server exec vitest run src/__tests__/project-routes-env.test.ts`
- `git diff --check`

## Risks

- Low risk: behavior change is limited to the explicit env-clear path.
- If callers relied on the old 422, they will now see successful clears instead.

## Model Used

- OpenAI Codex (GPT-5), tool-using coding agent in the Codex desktop environment.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
