### PR TITLE
fix(claude-local): close the CLI binary-swap race and bound its retry storm

### DIFF
--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -2303,6 +2303,23 @@ async function resolveCommandPath(command: string, cwd: string, env: NodeJS.Proc
   return null;
 }
 
+/**
+ * Resolve a command to its absolute path on the local host, or null when it is
+ * not on PATH. Unlike resolveCommandForLogs this never decorates the result
+ * with a remote/sandbox prefix, so the return value is safe to spawn.
+ *
+ * Callers use this to pin a command at setup time instead of re-resolving it at
+ * spawn time: a package manager that swaps the binary's symlink between those
+ * two points otherwise turns a live install into `spawn ENOENT`.
+ */
+export async function resolveLocalCommandPath(
+  command: string,
+  cwd: string,
+  env: NodeJS.ProcessEnv,
+): Promise<string | null> {
+  return resolveCommandPath(command, cwd, env);
+}
+
 export async function resolveCommandForLogs(
   command: string,
   cwd: string,

--- a/packages/adapters/claude-local/src/index.ts
+++ b/packages/adapters/claude-local/src/index.ts
@@ -5,6 +5,21 @@ export const label = "Claude Code";
 
 export const SANDBOX_INSTALL_COMMAND = "npm install -g @anthropic-ai/claude-code";
 
+/**
+ * Env applied to every claude_local run unless the agent's own adapter config
+ * sets the key explicitly.
+ *
+ * The Claude CLI's autoupdater replaces the `claude` symlink in place. A run
+ * that resolves the command while a swap is mid-flight sees the old path
+ * disappear and fails with `spawn ENOENT` / `Command not found in PATH`, which
+ * looks like a hard failure rather than the transient it is. Paperclip manages
+ * CLI installs itself (see SANDBOX_INSTALL_COMMAND), so the in-process
+ * autoupdater buys nothing and costs a race window on every run.
+ */
+export const DEFAULT_CLAUDE_LOCAL_ENV: Record<string, string> = {
+  DISABLE_AUTOUPDATER: "1",
+};
+
 export const models = [
   { id: "claude-opus-4-8", label: "Claude Opus 4.8" },
   { id: "claude-sonnet-5", label: "Claude Sonnet 5" },

--- a/packages/adapters/claude-local/src/server/execute.binary-pin.test.ts
+++ b/packages/adapters/claude-local/src/server/execute.binary-pin.test.ts
@@ -1,0 +1,117 @@
+import { chmod, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { runChildProcess, ensureCommandResolvable } = vi.hoisted(() => ({
+  runChildProcess: vi.fn(async () => ({
+    exitCode: 0,
+    signal: null,
+    timedOut: false,
+    stdout: [
+      JSON.stringify({ type: "system", subtype: "init", session_id: "s1", model: "claude-sonnet" }),
+      JSON.stringify({ type: "result", session_id: "s1", result: "ok", usage: { input_tokens: 1, cache_read_input_tokens: 0, output_tokens: 1 } }),
+    ].join("\n"),
+    stderr: "",
+    pid: 123,
+    startedAt: new Date().toISOString(),
+  })),
+  ensureCommandResolvable: vi.fn(async () => undefined),
+}));
+
+vi.mock("@paperclipai/adapter-utils/server-utils", async () => {
+  const actual = await vi.importActual<typeof import("@paperclipai/adapter-utils/server-utils")>(
+    "@paperclipai/adapter-utils/server-utils",
+  );
+  return { ...actual, ensureCommandResolvable, runChildProcess };
+});
+
+import { execute } from "./execute.js";
+
+/**
+ * The hoisted mock infers a zero-arity signature, so read its recorded args
+ * positionally: (runId, command, args, options).
+ */
+function firstSpawnCall(): { command: string; options: { env?: Record<string, string> } } {
+  const [call] = runChildProcess.mock.calls as unknown as unknown[][];
+  return { command: call?.[1] as string, options: (call?.[3] ?? {}) as { env?: Record<string, string> } };
+}
+
+/** Lay down an executable stub named `claude` and return its containing dir. */
+async function fakeClaudeBin(rootDir: string): Promise<string> {
+  const binDir = path.join(rootDir, "bin");
+  await mkdir(binDir, { recursive: true });
+  const binPath = path.join(binDir, "claude");
+  await writeFile(binPath, "#!/bin/sh\nexit 0\n", "utf8");
+  await chmod(binPath, 0o755);
+  return binDir;
+}
+
+async function runLocalExecute(rootDir: string, binDir: string, configEnv: Record<string, string> = {}) {
+  const workspaceDir = path.join(rootDir, "workspace");
+  await mkdir(workspaceDir, { recursive: true });
+  await execute({
+    runId: "run-1",
+    agent: {
+      id: "agent-1",
+      companyId: "company-1",
+      name: "Claude Coder",
+      adapterType: "claude_local",
+      adapterConfig: {},
+    },
+    runtime: { sessionId: null, sessionParams: null, sessionDisplayId: null, taskKey: null },
+    config: {
+      // The CLI lane is what owns the spawn; ACP resolves its own server binary.
+      engine: "cli",
+      command: "claude",
+      cwd: workspaceDir,
+      env: { PATH: `${binDir}:${process.env.PATH ?? ""}`, ...configEnv },
+    },
+    context: { prompt: "hi" },
+    onLog: async () => {},
+  } as unknown as Parameters<typeof execute>[0]);
+}
+
+describe.skipIf(process.platform === "win32")("claude_local binary-swap hardening", () => {
+  const cleanupDirs: string[] = [];
+
+  afterEach(async () => {
+    vi.clearAllMocks();
+    while (cleanupDirs.length > 0) {
+      const dir = cleanupDirs.pop();
+      if (!dir) continue;
+      await rm(dir, { recursive: true, force: true }).catch(() => undefined);
+    }
+  });
+
+  it("spawns the absolute binary path rather than re-resolving 'claude' at spawn time", async () => {
+    const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-claude-pin-"));
+    cleanupDirs.push(rootDir);
+    const binDir = await fakeClaudeBin(rootDir);
+
+    await runLocalExecute(rootDir, binDir);
+
+    expect(runChildProcess).toHaveBeenCalled();
+    expect(firstSpawnCall().command).toBe(path.join(binDir, "claude"));
+  });
+
+  it("applies DISABLE_AUTOUPDATER=1 by default", async () => {
+    const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-claude-autoupdate-"));
+    cleanupDirs.push(rootDir);
+    const binDir = await fakeClaudeBin(rootDir);
+
+    await runLocalExecute(rootDir, binDir);
+
+    expect(firstSpawnCall().options.env?.DISABLE_AUTOUPDATER).toBe("1");
+  });
+
+  it("lets an explicit adapter-config value override the default", async () => {
+    const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-claude-autoupdate-override-"));
+    cleanupDirs.push(rootDir);
+    const binDir = await fakeClaudeBin(rootDir);
+
+    await runLocalExecute(rootDir, binDir, { DISABLE_AUTOUPDATER: "0" });
+
+    expect(firstSpawnCall().options.env?.DISABLE_AUTOUPDATER).toBe("0");
+  });
+});

--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -38,6 +38,7 @@ import {
   ensurePathInEnv,
   isForbiddenConfigEnvKey,
   isPaperclipRuntimeEnvKey,
+  resolveLocalCommandPath,
   refreshPaperclipWorkspaceEnvForExecution,
   renderTemplate,
   renderPaperclipWakePrompt,
@@ -82,7 +83,7 @@ import { resolveClaudeDesiredSkillNames } from "./skills.js";
 import { isBedrockModelId } from "./models.js";
 import { prepareClaudePromptBundle } from "./prompt-cache.js";
 import { buildClaudeExecutionPermissionArgs } from "./permissions.js";
-import { SANDBOX_INSTALL_COMMAND } from "../index.js";
+import { DEFAULT_CLAUDE_LOCAL_ENV, SANDBOX_INSTALL_COMMAND } from "../index.js";
 import {
   createClaudeAcpExecutor,
   formatClaudeAcpFallbackMessage,
@@ -105,6 +106,8 @@ interface ClaudeExecutionInput {
 
 interface ClaudeRuntimeConfig {
   command: string;
+  /** Absolute path for local targets; the bare command for remote/sandbox ones. */
+  spawnCommand: string;
   resolvedCommand: string;
   cwd: string;
   workspaceId: string | null;
@@ -205,7 +208,10 @@ async function buildClaudeRuntimeConfig(input: ClaudeExecutionInput): Promise<Cl
   await ensureAbsoluteDirectory(cwd, { createIfMissing: true });
 
   const envConfig = parseObject(config.env);
-  const env: Record<string, string> = { ...buildPaperclipEnv(agent) };
+  // Seeded before the adapter-config env is applied below, so an agent that
+  // sets DISABLE_AUTOUPDATER explicitly still wins. This covers agents hired
+  // before the hire-time default existed.
+  const env: Record<string, string> = { ...DEFAULT_CLAUDE_LOCAL_ENV, ...buildPaperclipEnv(agent) };
   env.PAPERCLIP_RUN_ID = runId;
 
   const wakeTaskId =
@@ -327,6 +333,13 @@ async function buildClaudeRuntimeConfig(input: ClaudeExecutionInput): Promise<Cl
     timeoutSec,
   });
   const resolvedCommand = await resolveAdapterExecutionTargetCommandForLogs(command, executionTarget, cwd, runtimeEnv);
+  // Pin local runs to the absolute path we just resolved. Re-resolving at spawn
+  // time re-opens the window where the CLI's autoupdater has unlinked the old
+  // `claude` symlink and not yet linked the new one. Remote and sandbox targets
+  // resolve inside their own filesystem, so they keep the bare command.
+  const spawnCommand = executionTargetIsRemote
+    ? command
+    : (await resolveLocalCommandPath(command, cwd, runtimeEnv)) ?? command;
   const loggedEnv = buildInvocationEnvForLogs(env, {
     runtimeEnv,
     includeRuntimeKeys: ["HOME", "CLAUDE_CONFIG_DIR"],
@@ -341,6 +354,7 @@ async function buildClaudeRuntimeConfig(input: ClaudeExecutionInput): Promise<Cl
 
   return {
     command,
+    spawnCommand,
     resolvedCommand,
     cwd,
     workspaceId,
@@ -371,7 +385,7 @@ export async function runClaudeLogin(input: {
     authToken: input.authToken,
   });
 
-  const proc = await runAdapterExecutionTargetProcess(input.runId, null, runtime.command, ["login"], {
+  const proc = await runAdapterExecutionTargetProcess(input.runId, null, runtime.spawnCommand, ["login"], {
     cwd: runtime.cwd,
     env: runtime.env,
     timeoutSec: runtime.timeoutSec,
@@ -458,6 +472,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   });
   const {
     command,
+    spawnCommand,
     resolvedCommand,
     cwd,
     workspaceId,
@@ -916,7 +931,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       });
     }
 
-    const proc = await runAdapterExecutionTargetProcess(runId, runtimeExecutionTarget, command, args, {
+    const proc = await runAdapterExecutionTargetProcess(runId, runtimeExecutionTarget, spawnCommand, args, {
       cwd,
       env,
       stdin: prompt,

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -111,6 +111,7 @@ import {
   type SetupTokenSessionScope,
 } from "../services/setup-token-session.js";
 import type { DeploymentMode } from "@paperclipai/shared";
+import { DEFAULT_CLAUDE_LOCAL_ENV } from "@paperclipai/adapter-claude-local";
 import { DEFAULT_CODEX_LOCAL_BYPASS_APPROVALS_AND_SANDBOX } from "@paperclipai/adapter-codex-local";
 import {
   checkStagedCredentialReadiness,
@@ -1649,6 +1650,12 @@ export function agentRoutes(
     adapterConfig: Record<string, unknown>,
   ): Record<string, unknown> {
     const next = { ...adapterConfig };
+    if (adapterType === "claude_local") {
+      // Spread the caller's env last so an explicit value always wins, and only
+      // fill keys the caller left unset.
+      next.env = { ...DEFAULT_CLAUDE_LOCAL_ENV, ...(asRecord(next.env) ?? {}) };
+      return ensureGatewayDeviceKey(adapterType, next);
+    }
     if (adapterType === "codex_local") {
       const hasBypassFlag =
         typeof next.dangerouslyBypassApprovalsAndSandbox === "boolean" ||

--- a/server/src/services/recovery/service.missing-executable.test.ts
+++ b/server/src/services/recovery/service.missing-executable.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import { classifyContinuationFailure, isMissingExecutableFailure } from "./service.js";
+
+const run = (input: { errorCode?: string | null; error?: string | null; resultJson?: unknown }) =>
+  ({
+    errorCode: input.errorCode ?? null,
+    error: input.error ?? null,
+    resultJson: input.resultJson ?? null,
+  }) as unknown as Parameters<typeof classifyContinuationFailure>[0];
+
+describe("missing-executable continuation classification", () => {
+  it("classifies a PATH-resolution failure out of the generic transient bucket", () => {
+    // The adapter records this as the catch-all `adapter_failed`, which sits in
+    // TRANSIENT_INFRA_CONTINUATION_ERROR_CODES. Without the dedicated branch it
+    // would inherit the most retry-friendly policy we have.
+    const c = classifyContinuationFailure(
+      run({ errorCode: "adapter_failed", error: 'Command not found in PATH: "claude"' }),
+    );
+    expect(c.kind).toBe("missing_executable");
+    expect(c.maxAttempts).toBe(3);
+    expect(c.baseBackoffMs).toBeGreaterThan(0);
+  });
+
+  it("classifies a raw spawn ENOENT the same way", () => {
+    expect(
+      classifyContinuationFailure(run({ errorCode: "adapter_failed", error: "spawn claude ENOENT" }))
+        .kind,
+    ).toBe("missing_executable");
+  });
+
+  it("matches on resultJson.errorMessage when run.error is empty", () => {
+    expect(
+      classifyContinuationFailure(
+        run({
+          errorCode: "adapter_failed",
+          resultJson: { errorMessage: 'Command not found in PATH: "claude"' },
+        }),
+      ).kind,
+    ).toBe("missing_executable");
+  });
+
+  it("caps attempts below the 12 the 2026-05-20 cluster burned", () => {
+    const c = classifyContinuationFailure(
+      run({ errorCode: "adapter_failed", error: 'Command not found in PATH: "claude"' }),
+    );
+    expect(c.maxAttempts).toBeLessThan(12);
+  });
+
+  it("leaves unrelated adapter failures in the transient bucket", () => {
+    const c = classifyContinuationFailure(
+      run({ errorCode: "adapter_failed", error: "upstream returned 503" }),
+    );
+    expect(c.kind).toBe("transient_infra");
+  });
+
+  it("does not reclassify codes that are already non-retryable", () => {
+    // A paused agent whose prior error text happens to mention ENOENT must still
+    // short-circuit as non_retryable rather than earning three fresh attempts.
+    expect(
+      classifyContinuationFailure(
+        run({ errorCode: "agent_not_invokable", error: "spawn claude ENOENT" }),
+      ).kind,
+    ).toBe("non_retryable");
+  });
+
+  it("ignores prose that merely mentions a path", () => {
+    expect(isMissingExecutableFailure(run({ error: "could not find the config path" }))).toBe(false);
+    expect(isMissingExecutableFailure(run({ error: null }))).toBe(false);
+    expect(isMissingExecutableFailure(null)).toBe(false);
+  });
+});

--- a/server/src/services/recovery/service.missing-executable.test.ts
+++ b/server/src/services/recovery/service.missing-executable.test.ts
@@ -68,4 +68,63 @@ describe("missing-executable continuation classification", () => {
     expect(isMissingExecutableFailure(run({ error: null }))).toBe(false);
     expect(isMissingExecutableFailure(null)).toBe(false);
   });
+
+  it("does not match captured agent output in resultJson.stdout/stderr", () => {
+    // `resultJson` is not small metadata: the claude_local failure path stores
+    // the raw `{ stdout, stderr }` capture (up to MAX_CAPTURE_BYTES), and the
+    // CLI runs with `--output-format stream-json --verbose`, so stdout carries
+    // every `tool_result` block the agent produced. An agent that shelled out
+    // and hit its own ENOENT must not be read as OUR binary going missing.
+    expect(
+      isMissingExecutableFailure(
+        run({
+          errorCode: "adapter_failed",
+          error: "upstream returned 503",
+          resultJson: {
+            stdout:
+              '{"type":"user","message":{"content":[{"type":"tool_result","content":"spawn npm ENOENT"}]}}',
+          },
+        }),
+      ),
+    ).toBe(false);
+
+    expect(
+      isMissingExecutableFailure(
+        run({
+          errorCode: "adapter_failed",
+          resultJson: { stderr: "npm: command not found in PATH" },
+        }),
+      ),
+    ).toBe(false);
+
+    // ...and the misclassification must not leak through the classifier either.
+    expect(
+      classifyContinuationFailure(
+        run({
+          errorCode: "adapter_failed",
+          error: "upstream returned 503",
+          resultJson: { stdout: "Error: spawn npm ENOENT" },
+        }),
+      ).kind,
+    ).toBe("transient_infra");
+  });
+
+  it("still matches the named string fields the adapter actually sets", () => {
+    expect(isMissingExecutableFailure(run({ error: "spawn claude ENOENT" }))).toBe(true);
+    expect(
+      isMissingExecutableFailure(run({ resultJson: { errorMessage: "spawn claude ENOENT" } })),
+    ).toBe(true);
+    expect(
+      isMissingExecutableFailure(
+        run({ resultJson: { message: 'Command not found in PATH: "claude"' } }),
+      ),
+    ).toBe(true);
+  });
+
+  it("tolerates non-string values in the named fields", () => {
+    expect(
+      isMissingExecutableFailure(run({ resultJson: { errorMessage: 42, message: null } })),
+    ).toBe(false);
+    expect(isMissingExecutableFailure(run({ resultJson: "spawn claude ENOENT" }))).toBe(false);
+  });
 });

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -366,12 +366,26 @@ const INTERACTION_CONTINUATION_REQUEUE_MAX_ATTEMPTS = 3;
 const CONTINUATION_RECOVERY_TRANSIENT_MAX_ATTEMPTS = 3;
 const CONTINUATION_RECOVERY_DEFAULT_MAX_ATTEMPTS = 1;
 const CONTINUATION_RECOVERY_TRANSIENT_BASE_BACKOFF_MS = 60_000;
+// A binary swap window closes in seconds, so a short first backoff is enough to
+// clear the transient case. Three attempts then hands it to a human instead of
+// spending the budget the 2026-05-20 cluster burned on 12.
+const CONTINUATION_RECOVERY_MISSING_EXECUTABLE_MAX_ATTEMPTS = 3;
+const CONTINUATION_RECOVERY_MISSING_EXECUTABLE_BASE_BACKOFF_MS = 30_000;
 export const PROVIDER_QUOTA_RECOVERY_DEFAULT_BACKOFF_MS = 60 * 60 * 1000;
 
 const PROVIDER_QUOTA_ERROR_RE =
   /(?:you(?:'|’)ve hit your usage limit|usage limit(?: reached| exceeded)?|provider quota|quota (?:limit )?exceeded|model (?:is )?at capacity)/i;
 const CONFIGURATION_INCOMPLETE_ERROR_RE =
   /(?:model_not_found|model [^\n]{0,120} not found|missing (?:api )?(?:key|credentials?)|credentials? (?:are |is )?missing|no (?:api )?(?:key|credentials?) (?:was |were )?(?:found|configured|provided)|api key (?:is )?(?:not set|unavailable))/i;
+/**
+ * The adapter CLI binary could not be found or started. Usually a package
+ * manager swapping the binary's symlink mid-run, which clears on its own; when
+ * it does not, the binary is genuinely gone and an operator has to reinstall
+ * it. Either way this is not upstream flakiness, so it gets its own bounded
+ * bucket rather than sharing the generic `adapter_failed` transient one.
+ */
+const MISSING_EXECUTABLE_ERROR_RE =
+  /(?:command not found in PATH|command is not executable|spawn \S+ ENOENT|\bENOENT\b[^\n]{0,80}spawn|failed to start command)/i;
 
 export type AdapterFailureRecoveryClassification =
   | { kind: "provider_quota"; retryAt: Date; parsedResetTime: boolean }
@@ -484,16 +498,35 @@ export function classifyAdapterFailureForRecovery(
 }
 
 type ContinuationRetryClassification = {
-  kind: "transient_infra" | "non_retryable" | "default";
+  kind: "transient_infra" | "missing_executable" | "non_retryable" | "default";
   maxAttempts: number;
   baseBackoffMs: number;
   errorCode: string | null;
 };
 
+export function isMissingExecutableFailure(latestRun: LatestIssueRun): boolean {
+  if (!latestRun) return false;
+  const resultJson = parseObject(latestRun.resultJson);
+  return MISSING_EXECUTABLE_ERROR_RE.test(
+    [latestRun.error ?? "", JSON.stringify(resultJson)].join("\n"),
+  );
+}
+
 export function classifyContinuationFailure(latestRun: LatestIssueRun): ContinuationRetryClassification {
   const errorCode = readNonEmptyString(latestRun?.errorCode);
   if (errorCode && NON_RETRYABLE_CONTINUATION_ERROR_CODES.has(errorCode)) {
     return { kind: "non_retryable", maxAttempts: 0, baseBackoffMs: 0, errorCode };
+  }
+  // Checked before the transient bucket: a missing binary arrives as the
+  // catch-all `adapter_failed` code, which would otherwise land it in the most
+  // retry-friendly bucket we have.
+  if (isMissingExecutableFailure(latestRun)) {
+    return {
+      kind: "missing_executable",
+      maxAttempts: CONTINUATION_RECOVERY_MISSING_EXECUTABLE_MAX_ATTEMPTS,
+      baseBackoffMs: CONTINUATION_RECOVERY_MISSING_EXECUTABLE_BASE_BACKOFF_MS,
+      errorCode,
+    };
   }
   if (errorCode && TRANSIENT_INFRA_CONTINUATION_ERROR_CODES.has(errorCode)) {
     return {

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -506,9 +506,20 @@ type ContinuationRetryClassification = {
 
 export function isMissingExecutableFailure(latestRun: LatestIssueRun): boolean {
   if (!latestRun) return false;
+  // Scoped to the named failure-message fields, never the whole blob:
+  // `resultJson` also carries the run's raw `stdout`/`stderr` capture (up to
+  // MAX_CAPTURE_BYTES), and claude_local runs the CLI with
+  // `--output-format stream-json --verbose`, so stdout contains every
+  // `tool_result` the agent produced. Matching the serialized object would let
+  // an agent's own `spawn npm ENOENT` masquerade as our binary going missing.
+  // Mirrors the field-scoped test in heartbeat.ts's spawn-failure check.
   const resultJson = parseObject(latestRun.resultJson);
   return MISSING_EXECUTABLE_ERROR_RE.test(
-    [latestRun.error ?? "", JSON.stringify(resultJson)].join("\n"),
+    [
+      latestRun.error ?? "",
+      readNonEmptyString(resultJson.errorMessage) ?? "",
+      readNonEmptyString(resultJson.message) ?? "",
+    ].join("\n"),
   );
 }
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source control plane people use to coordinate AI-agent companies and their work.
> - Its `claude_local` adapter spawns the Claude Code CLI once per heartbeat, resolving the `claude` command from PATH.
> - The Claude CLI ships an autoupdater that replaces that binary's symlink in place, so there is a window in which the old path is unlinked and the new one is not yet linked.
> - A run that resolves the command inside that window fails with `spawn ENOENT` / `Command not found in PATH: "claude"`.
> - Those failures are recorded as the catch-all `adapter_failed` error code, which the recovery reconciler treats as ordinary upstream flakiness and retries aggressively.
> - This pull request removes the update that opens the window, removes the second resolution that re-opens it, and gives the failure family a bounded retry policy of its own.
> - The benefit is that a sub-second packaging transient stops presenting as a multi-minute run of failed heartbeats.

## Linked Issues or Issue Description

No matching public GitHub issue was found.

### What happened?

On a fleet running 37 `claude_local` agents, a background `npm install -g @anthropic-ai/claude-code` triggered by the CLI's autoupdater swapped the `claude` symlink. One agent's heartbeats failed with `Command not found in PATH: "claude"` and were retried **12 times across 4 minutes** before settling.

### Expected behavior

Paperclip already manages CLI installation itself (`SANDBOX_INSTALL_COMMAND`), so the in-process autoupdater should be off by default. A transient binary swap that does slip through should cost a small bounded number of retries and then surface for intervention.

### Steps to reproduce

1. Run a `claude_local` agent whose adapter config does **not** set `DISABLE_AUTOUPDATER`, so the Claude Code CLI's in-process autoupdater is active.
2. While a heartbeat run is resolving the `claude` command from PATH, have the autoupdater (or a concurrent `npm install -g @anthropic-ai/claude-code`) replace the `claude` symlink in place.
3. Observe the run fail with `spawn ENOENT` / `Command not found in PATH: "claude"`.
4. Watch the recovery reconciler classify it as the catch-all `adapter_failed` and retry aggressively — up to 12 attempts over ~4 minutes for a sub-second packaging transient.

### Paperclip version or commit

Reproduces on `master` at `f12bb27bc` (the base of this branch).

### Deployment mode

Self-hosted server.

### Actual behavior

The autoupdater ran by default; the command was resolved twice (once at setup, once again at spawn) so pinning never took effect; and the resulting failure landed in the most retry-friendly bucket available.

### Impact

Avoidable budget consumption, and a run of failed heartbeats that reads like a hard outage rather than the packaging transient it is.

## What Changed

**1. `DISABLE_AUTOUPDATER=1` by default for `claude_local`**

New `DEFAULT_CLAUDE_LOCAL_ENV` export, applied in two places:
- `applyCreateDefaultsByAdapterType` (hire/create/update), so it is persisted and visible in the agent's `adapterConfig`.
- `buildClaudeRuntimeConfig`, seeded *before* the adapter-config env is layered on, so agents hired before this change also get it.

An explicit `env.DISABLE_AUTOUPDATER` in adapter config wins in both paths.

**2. Absolute-path pin for the spawn**

`buildClaudeRuntimeConfig` already resolved an absolute path, but used it only for logging — the bare `"claude"` string was carried to the spawn, where `resolveSpawnTarget` resolved it a second time. That second resolution is what re-opened the race. The runtime config now carries a `spawnCommand`, resolved once via a new `resolveLocalCommandPath` helper. Remote and sandbox targets (`kind: "remote"`) resolve inside their own filesystem and keep the bare command.

**3. Bounded retry bucket for missing executables**

`spawn ENOENT` reaches the run record as `errorCode: "adapter_failed"`, which is a member of `TRANSIENT_INFRA_CONTINUATION_ERROR_CODES`. `classifyContinuationFailure` now matches the failure text first and returns a dedicated `missing_executable` classification: 3 attempts, 30s base backoff, then escalation through the existing stranded-issue path.

## Verification

- `pnpm exec vitest run packages/adapters/claude-local/ server/src/services/recovery/ server/src/__tests__/recovery-classifiers.test.ts server/src/__tests__/issue-recovery-actions.test.ts` — 163 passed.
  - 2 pre-existing failures in `test.probe.test.ts` and `execute.remote.test.ts` reproduce identically on unmodified `origin/master` (verified by stashing this branch); they are not touched by this change.
- `pnpm --filter @paperclipai/adapter-utils --filter @paperclipai/adapter-claude-local --filter @paperclipai/server typecheck` — all 3 packages Done.
- New coverage: `execute.binary-pin.test.ts` (absolute-path spawn, env default, explicit override) and `service.missing-executable.test.ts` (classification, resultJson fallback, attempt cap, non-retryable precedence, no false positives on prose).

## Risks

- The env default is applied on agent *update* as well as create, so an operator who deletes the key without setting it to an explicit value will see it reappear. Setting `DISABLE_AUTOUPDATER=0` explicitly is the supported opt-out and is covered by a test.
- Pinning the absolute path means a mid-run reinstall no longer picks up the new binary until the next run. That is the intended trade: within a single run the old inode stays valid, which is the behavior the race was breaking.
- The missing-executable regex matches on failure text. A genuinely transient upstream error whose message happens to contain `ENOENT` would get 3 attempts instead of the transient bucket's 3 — the same cap, a shorter backoff.
- Separately observed while tracing this, and **not** addressed here: the retry cap and backoff at `recovery/service.ts` are nested inside `if (didAutomaticRecoveryFail(latestRun, "issue_continuation_needed"))`, so a failure re-dispatched from any other wake reason bypasses both. That structural gap affects every error family and is the likelier reason 12 attempts fit into 4 minutes. It deserves its own PR.

## Model Used

- Anthropic Claude Opus 4.8 (`claude-opus-4-8`), using reasoning, tool use, and code execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs
- [x] I have described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links
- [x] My branch name describes the change and contains no internal ticket id
- [x] I have run tests locally
- [x] I have added tests
- [x] I have considered and documented any risks above

