### PR TITLE
fix: bound the fs.stat() call in enqueueWakeup to stop pool exhaustion

### DIFF
--- a/server/src/__tests__/heartbeat-workspace-cwd-stat-timeout.test.ts
+++ b/server/src/__tests__/heartbeat-workspace-cwd-stat-timeout.test.ts
@@ -1,0 +1,279 @@
+import { execFile } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import { sql } from "drizzle-orm";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import {
+  activityLog,
+  agentRuntimeState,
+  agentTaskSessions,
+  agentWakeupRequests,
+  agents,
+  companies,
+  companySkills,
+  createDb,
+  environmentLeases,
+  environments,
+  executionWorkspaces,
+  heartbeatRunEvents,
+  heartbeatRuns,
+  issueComments,
+  issues,
+  projectWorkspaces,
+  projects,
+  workspaceOperations,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import { heartbeatService } from "../services/heartbeat.ts";
+import { instanceSettingsService } from "../services/instance-settings.ts";
+
+const HANGING_WORKSPACE_CWD = "/tmp/paperclip-hanging-workspace-cwd-test";
+
+vi.mock("node:fs/promises", async () => {
+  const actual = await vi.importActual<typeof import("node:fs/promises")>("node:fs/promises");
+  const stat: typeof actual.stat = ((path: Parameters<typeof actual.stat>[0], ...rest: unknown[]) => {
+    if (path === HANGING_WORKSPACE_CWD) {
+      return new Promise(() => {});
+    }
+    // @ts-expect-error - forwarding whatever arguments actual.stat was called with
+    return actual.stat(path, ...rest);
+  }) as typeof actual.stat;
+  return { ...actual, default: { ...actual, stat }, stat };
+});
+
+const execFileAsync = promisify(execFile);
+
+const adapterExecute = vi.hoisted(() =>
+  vi.fn(async () => ({
+    exitCode: 0,
+    signal: null,
+    timedOut: false,
+    summary: "workspace-cwd-stat-timeout test run.",
+    provider: "test",
+    model: "test-model",
+  })),
+);
+
+vi.mock("../adapters/index.js", () => ({
+  getServerAdapter: () => ({ type: "codex_local", execute: adapterExecute, supportsLocalAgentJwt: false }),
+  findActiveServerAdapter: () => ({ type: "codex_local", execute: adapterExecute, supportsLocalAgentJwt: false }),
+  listAdapterModelProfiles: async () => [],
+  runningProcesses: new Map(),
+}));
+
+type Db = ReturnType<typeof createDb>;
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping heartbeat workspace-cwd-stat-timeout tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+async function runGit(cwd: string, args: string[]) {
+  await execFileAsync("git", args, { cwd });
+}
+
+async function createGitRepo() {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), "paperclip-workspace-cwd-stat-timeout-repo-"));
+  await runGit(repoRoot, ["init"]);
+  await runGit(repoRoot, ["config", "user.email", "paperclip-test@example.com"]);
+  await runGit(repoRoot, ["config", "user.name", "Paperclip Test"]);
+  await writeFile(path.join(repoRoot, "README.md"), "workspace cwd stat timeout\n", "utf8");
+  await runGit(repoRoot, ["add", "README.md"]);
+  await runGit(repoRoot, ["commit", "-m", "initial"]);
+  return repoRoot;
+}
+
+async function waitForHeartbeatIdle(db: Db, timeoutMs = 10_000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const runs = await db.select({ status: heartbeatRuns.status }).from(heartbeatRuns);
+    if (!runs.some((run) => run.status === "queued" || run.status === "running")) {
+      await new Promise((resolve) => setTimeout(resolve, 250));
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+}
+
+async function deleteHeartbeatRowsAfterActivityLogDrains(db: Db) {
+  let lastError: unknown = null;
+  for (let attempt = 0; attempt < 10; attempt += 1) {
+    await db.delete(activityLog);
+    await db.delete(heartbeatRunEvents);
+    await db.delete(issueComments);
+    try {
+      await db.delete(heartbeatRuns);
+      await db.delete(agentWakeupRequests);
+      return;
+    } catch (error) {
+      lastError = error;
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+  }
+  throw lastError;
+}
+
+describeEmbeddedPostgres("heartbeat wakeup: session workspace cwd stat timeout", () => {
+  let db!: Db;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+  const tempRoots: string[] = [];
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-workspace-cwd-stat-timeout-");
+    db = createDb(tempDb.connectionString);
+  }, 30_000);
+
+  afterEach(async () => {
+    await waitForHeartbeatIdle(db);
+    adapterExecute.mockClear();
+    while (tempRoots.length > 0) {
+      const root = tempRoots.pop();
+      if (root) await rm(root, { recursive: true, force: true }).catch(() => undefined);
+    }
+    await db.delete(agentTaskSessions);
+    await db.delete(environmentLeases);
+    await db.delete(workspaceOperations);
+    await deleteHeartbeatRowsAfterActivityLogDrains(db);
+    await db.delete(issues);
+    await db.delete(projectWorkspaces);
+    await db.delete(projects);
+    await db.delete(agentRuntimeState);
+    await db.delete(agents);
+    await db.delete(executionWorkspaces);
+    await db.delete(environments);
+    await db.delete(companySkills);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await db.$client.end();
+    await tempDb?.cleanup();
+  }, 60_000);
+
+  async function seedWakeTarget() {
+    const repoRoot = await createGitRepo();
+    tempRoots.push(repoRoot);
+
+    const companyId = randomUUID();
+    const projectId = randomUUID();
+    const projectWorkspaceId = randomUUID();
+    const issueId = randomUUID();
+    const agentId = randomUUID();
+
+    await instanceSettingsService(db).updateExperimental({
+      enableIsolatedWorkspaces: true,
+    });
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Acme",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      status: "active",
+      defaultResponsibleUserId: "responsible-user",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    await db.insert(projects).values({
+      id: projectId,
+      companyId,
+      name: "Workspace Cwd Stat Timeout",
+      status: "active",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    await db.insert(projectWorkspaces).values({
+      id: projectWorkspaceId,
+      companyId,
+      projectId,
+      name: "Primary",
+      cwd: repoRoot,
+      isPrimary: true,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "CodexCoder",
+      role: "engineer",
+      status: "idle",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {
+        heartbeat: { wakeOnDemand: true, maxConcurrentRuns: 1 },
+      },
+      permissions: {},
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      projectId,
+      projectWorkspaceId,
+      title: "Reproduces the stalled workspace-cwd stat",
+      status: "in_progress",
+      workMode: "standard",
+      priority: "medium",
+      assigneeAgentId: agentId,
+      identifier: `PAP-${issueId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    await db.insert(agentTaskSessions).values({
+      companyId,
+      agentId,
+      adapterType: "codex_local",
+      taskKey: issueId,
+      sessionParamsJson: {
+        sessionId: "prior-session",
+        cwd: HANGING_WORKSPACE_CWD,
+        workspaceId: projectWorkspaceId,
+      },
+      sessionDisplayId: "prior-session",
+    });
+
+    return { companyId, agentId, issueId };
+  }
+
+  it(
+    "does not hang the wake (and its db.transaction) forever when the prior session's workspace cwd stat() stalls",
+    async () => {
+      const { agentId, issueId } = await seedWakeTarget();
+      const heartbeat = heartbeatService(db);
+
+      const start = Date.now();
+      await heartbeat.wakeup(agentId, {
+        source: "automation",
+        triggerDetail: "system",
+        reason: "issue_commented",
+        payload: { issueId },
+        contextSnapshot: {
+          issueId,
+          taskId: issueId,
+          wakeReason: "issue_commented",
+          skipIssueComment: true,
+        },
+      });
+      const elapsedMs = Date.now() - start;
+      expect(elapsedMs).toBeLessThan(12_000);
+
+      const stuck = await db.execute(
+        sql`select count(*)::int as count from pg_stat_activity where state = 'idle in transaction'`,
+      );
+      const row = (stuck as unknown as { count: number }[])[0];
+      expect(row?.count ?? 0).toBe(0);
+    },
+    20_000,
+  );
+});

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -312,6 +312,7 @@ const PAPERCLIP_HARNESS_CHECKOUT_KEY = "paperclipHarnessCheckedOut";
 const DETACHED_PROCESS_ERROR_CODE = "process_detached";
 const REPO_ONLY_CWD_SENTINEL = "/__paperclip_repo_only__";
 const MANAGED_WORKSPACE_GIT_CLONE_TIMEOUT_MS = 10 * 60 * 1000;
+const SESSION_WORKSPACE_CWD_STAT_TIMEOUT_MS = 5_000;
 const MAX_INLINE_WAKE_COMMENTS = 8;
 const MAX_INLINE_WAKE_COMMENT_BODY_CHARS = 4_000;
 const MAX_INLINE_WAKE_COMMENT_BODY_TOTAL_CHARS = 12_000;
@@ -7140,13 +7141,30 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     return runtimeForRun?.sessionId ?? null;
   }
 
+  const pendingSessionWorkspaceCwdStats = new Map<string, Promise<boolean>>();
+
   async function hasResolvableSessionWorkspaceCwd(sessionParams: Record<string, unknown> | null | undefined) {
     const cwd = readNonEmptyString(sessionParams?.cwd);
     if (!cwd || isUnsafeSessionWorkspaceCwd(cwd)) return false;
-    return fs
-      .stat(cwd)
-      .then((stats) => stats.isDirectory())
-      .catch(() => false);
+
+    let statPromise = pendingSessionWorkspaceCwdStats.get(cwd);
+    if (!statPromise) {
+      statPromise = fs.stat(cwd).then((stats) => stats.isDirectory()).catch(() => false);
+      statPromise.finally(() => pendingSessionWorkspaceCwdStats.delete(cwd));
+      pendingSessionWorkspaceCwdStats.set(cwd, statPromise);
+    }
+
+    let timeoutHandle: NodeJS.Timeout | undefined;
+    const timedOut = new Promise<true>((resolve) => {
+      timeoutHandle = setTimeout(() => resolve(true), SESSION_WORKSPACE_CWD_STAT_TIMEOUT_MS);
+      timeoutHandle.unref?.();
+    });
+
+    try {
+      return await Promise.race([statPromise, timedOut]);
+    } finally {
+      clearTimeout(timeoutHandle);
+    }
   }
 
   async function hasResolvablePriorSessionWorkspaceForWake(input: {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -313,6 +313,7 @@ const DETACHED_PROCESS_ERROR_CODE = "process_detached";
 const REPO_ONLY_CWD_SENTINEL = "/__paperclip_repo_only__";
 const MANAGED_WORKSPACE_GIT_CLONE_TIMEOUT_MS = 10 * 60 * 1000;
 const SESSION_WORKSPACE_CWD_STAT_TIMEOUT_MS = 5_000;
+const pendingSessionWorkspaceCwdStats = new Map<string, Promise<boolean>>();
 const MAX_INLINE_WAKE_COMMENTS = 8;
 const MAX_INLINE_WAKE_COMMENT_BODY_CHARS = 4_000;
 const MAX_INLINE_WAKE_COMMENT_BODY_TOTAL_CHARS = 12_000;
@@ -7140,8 +7141,6 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     const runtimeForRun = await getRuntimeState(agent.id);
     return runtimeForRun?.sessionId ?? null;
   }
-
-  const pendingSessionWorkspaceCwdStats = new Map<string, Promise<boolean>>();
 
   async function hasResolvableSessionWorkspaceCwd(sessionParams: Record<string, unknown> | null | undefined) {
     const cwd = readNonEmptyString(sessionParams?.cwd);


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Agents get woken up (`enqueueWakeup`) to resume or start work on an issue, and part of that decides whether a prior session's workspace can be reused
> - That resolvability check calls `fs.stat()` on a workspace path with no timeout, while the caller holds an open `db.transaction()` with a `SELECT ... FOR UPDATE` lock on the issue row
> - On a self-hosted deployment where `PAPERCLIP_HOME` sits on a degraded network volume (Longhorn/EBS/NFS), a single slow `fs.stat()` held that transaction's row lock and pooled connection open indefinitely
> - With a small pool (default `max: 10`), a handful of wakeups hitting a stalled volume exhausted the entire connection pool, hanging every unrelated request server-wide — the exact symptom in #9774
> - This pull request bounds that `fs.stat()` to a 5s timeout, dedupes concurrent stat calls against the same stalled path so repeat wakeups don't each leak a filesystem worker, and makes an ambiguous (timed-out) result fail open instead of silently blocking a runnable issue
> - The benefit is the connection pool can no longer be exhausted by one degraded workspace volume, without trading it for a new false-negative that misdiagnoses a healthy-but-slow workspace as missing

## Linked Issues or Issue Description

Fixes: #9774
Refs: #9555

Related (not duplicate): #9597 is open and adds generic `postgres.js` pool timeouts (`idle_in_transaction_session_timeout=30s`, `statement_timeout=60s`, etc.) as a defense-in-depth net for the same class of symptom. This PR fixes the specific root cause identified in #9774 directly — bounding the actual unbounded I/O call at 5s, ~6x faster than the 30s DB-level timeout in #9597, and preventing the transaction from ever reaching a stuck state rather than relying on the database to kill it after the fact. The two are complementary.

## What Changed

- Bound the unbounded `fs.stat(cwd)` call in `hasResolvableSessionWorkspaceCwd` (`server/src/services/heartbeat.ts`) to a 5s timeout via `Promise.race`, so a stalled workspace volume can no longer hold `enqueueWakeup`'s `FOR UPDATE`-locked transaction (and its pooled connection) open indefinitely.
- Added an in-flight stat dedup (keyed by `cwd`) so repeated wakeups hitting the same stalled path share one pending `fs.stat()` call instead of each leaking a separate libuv threadpool worker (Node's `fs.promises.stat()` has no cancellation), and `unref()`'d the timeout timer, matching the existing convention in `remote-http-endpoint-guard.ts`.
- On timeout, resolve to `true` (assume the workspace is resolvable) instead of `false`, so an ambiguous/slow-but-fine stat can no longer be misread by `isUnrunnableWorktreeCombo` as "workspace confirmed missing" and silently set a runnable issue to `status: "blocked"`.
- Added a regression test (`heartbeat-workspace-cwd-stat-timeout.test.ts`) that reproduces the stalled-stat scenario against a real embedded Postgres instance and asserts the wake completes quickly and leaves no `idle in transaction` connection behind.

## Verification

- `npx vitest run src/__tests__/heartbeat-workspace-cwd-stat-timeout.test.ts` — 1 passed
- Regression sweep across 6 related heartbeat test files (`heartbeat-workspace-session`, `heartbeat-process-recovery`, `execution-lock-orphan-cleanup`, `heartbeat-retry-scheduling`, `heartbeat-workspace-finalize-branch`, `heartbeat-workspace-cwd-stat-timeout`) — 248/248 passed
- `npx tsc --noEmit -p .` — clean

## Risks

- Behavioral change: `hasResolvableSessionWorkspaceCwd` now returns `true` (not `false`) when the stat times out, rather than hanging forever. This is a deliberate fail-open choice — see What Changed — but reviewers should confirm they agree an ambiguous result should default to "assume resolvable" rather than "assume missing."
- `hasResolvablePriorSessionWorkspaceForWake` can call the bounded check twice sequentially (explicit-resume-session cwd, then task-session cwd), so worst case the `FOR UPDATE` lock can still be held ~10s (2x the timeout) if both cwds sit on the same degraded volume. Still strictly bounded — no longer unbounded — but worth flagging; can parallelize if reviewers prefer.
- The same unbounded `fs.stat()` pattern still exists at two call sites in `resolveWorkspaceForRun`. Those aren't inside a `db.transaction()` (lower severity — a slow run, not a wedged pool), so left out of scope to keep this PR minimal per Path 1. Happy to follow up separately.
- Low risk otherwise: single function, no schema/migration changes, no public API changes.

## Model Used

Claude Sonnet 5 (`claude-sonnet-5`), via Claude Code — extended agentic tool use (file edits, test execution, git/gh inspection) plus a structured multi-agent review pass (10 independent subagents across correctness, reuse, simplification, efficiency, altitude, and convention angles, each candidate finding cross-checked by a separate adversarial-verification subagent) before implementing the fixes above. Standard 200K-token context window.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge