### PR TITLE
fix(onboarding): do not restore wizard state for a company the user does not own

### DIFF
--- a/ui/src/components/OnboardingWizard.test.tsx
+++ b/ui/src/components/OnboardingWizard.test.tsx
@@ -7,8 +7,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // --- Mocks (hoisted so vi.mock factories can close over them) ----------------
 
-const ONBOARDING_STORAGE_KEY = "paperclip-onboarding-state";
-
 const mockDialog = vi.hoisted(() => ({
   onboardingOpen: true,
   onboardingOptions: {} as { initialStep?: number; companyId?: string },
@@ -110,7 +108,7 @@ vi.mock("./AsciiArtAnimation", () => ({ AsciiArtAnimation: () => null }));
 vi.mock("./FrontDoor", () => ({ FrontDoor: () => null }));
 vi.mock("./AgentCapsule", () => ({ AgentCapsule: () => null }));
 
-import { OnboardingWizard } from "./OnboardingWizard";
+import { ONBOARDING_STORAGE_KEY, OnboardingWizard } from "./OnboardingWizard";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;

--- a/ui/src/components/OnboardingWizard.test.tsx
+++ b/ui/src/components/OnboardingWizard.test.tsx
@@ -1,0 +1,262 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// --- Mocks (hoisted so vi.mock factories can close over them) ----------------
+
+const ONBOARDING_STORAGE_KEY = "paperclip-onboarding-state";
+
+const mockDialog = vi.hoisted(() => ({
+  onboardingOpen: true,
+  onboardingOptions: {} as { initialStep?: number; companyId?: string },
+  closeOnboarding: vi.fn(),
+  onboardingRouteDismissed: false,
+  setOnboardingRouteDismissed: vi.fn(),
+}));
+
+const mockCompany = vi.hoisted(() => ({
+  companies: [] as Array<{ id: string; name: string; issuePrefix: string }>,
+  setSelectedCompanyId: vi.fn(),
+  loading: false,
+}));
+
+const mockCompaniesApi = vi.hoisted(() => ({
+  create: vi.fn(),
+  update: vi.fn(),
+}));
+const mockGoalsApi = vi.hoisted(() => ({
+  create: vi.fn(),
+  list: vi.fn(async () => []),
+}));
+const mockAgentsApi = vi.hoisted(() => ({
+  adapterModels: vi.fn(async () => [] as Array<{ id: string; label: string }>),
+  testEnvironment: vi.fn(async () => ({
+    adapterType: "claude_local",
+    status: "pass" as const,
+    checks: [],
+    testedAt: new Date().toISOString(),
+  })),
+  hire: vi.fn(async () => ({ agent: { id: "agent-1" }, approval: null })),
+  instructionsBundle: vi.fn(async () => ({ entryFile: "AGENTS.md" })),
+  saveInstructionsFile: vi.fn(async () => ({})),
+}));
+const mockApprovalsApi = vi.hoisted(() => ({
+  create: vi.fn(),
+}));
+const mockIssuesApi = vi.hoisted(() => ({
+  create: vi.fn(),
+}));
+const mockProjectsApi = vi.hoisted(() => ({
+  create: vi.fn(),
+  list: vi.fn(async () => []),
+}));
+
+// The real adapter registry eagerly imports every adapter package. The
+// model/harness picker internals are out of scope here, so stub the adapter
+// layer entirely and drive it through this knob.
+const mockAdapterRegistry = vi.hoisted(() => ({
+  list: [] as Array<{ type: string }>,
+  disabled: new Set<string>(),
+}));
+
+vi.mock("@/lib/router", () => ({
+  useLocation: () => ({ pathname: "/", search: "", hash: "", state: null }),
+  useNavigate: () => vi.fn(),
+  useParams: () => ({}),
+}));
+vi.mock("../context/DialogContext", () => ({
+  useDialog: () => mockDialog,
+}));
+vi.mock("../context/CompanyContext", () => ({
+  useCompany: () => mockCompany,
+}));
+vi.mock("../api/companies", () => ({ companiesApi: mockCompaniesApi }));
+vi.mock("../api/goals", () => ({ goalsApi: mockGoalsApi }));
+vi.mock("../api/agents", () => ({ agentsApi: mockAgentsApi }));
+vi.mock("../api/approvals", () => ({ approvalsApi: mockApprovalsApi }));
+vi.mock("../api/issues", () => ({ issuesApi: mockIssuesApi }));
+vi.mock("../api/projects", () => ({ projectsApi: mockProjectsApi }));
+vi.mock("../adapters", () => ({
+  listUIAdapters: () => mockAdapterRegistry.list,
+  getUIAdapter: () => ({ buildAdapterConfig: () => ({}) }),
+}));
+vi.mock("../adapters/metadata", () => ({ isVisualAdapterChoice: () => true }));
+vi.mock("../adapters/adapter-display-registry", () => ({
+  getAdapterDisplay: (type: string) => ({
+    type,
+    recommended: false,
+    label: type,
+    description: "",
+    icon: () => null,
+  }),
+}));
+vi.mock("../adapters/use-disabled-adapters", () => ({
+  useDisabledAdaptersSync: () => mockAdapterRegistry.disabled,
+}));
+vi.mock("../adapters/use-adapter-capabilities", () => ({
+  useAdapterCapabilities: () => () => ({
+    supportsInstructionsBundle: false,
+    supportsSkills: false,
+    supportsLocalAgentJwt: false,
+    requiresMaterializedRuntimeSkills: false,
+    supportsModelProfiles: false,
+  }),
+}));
+// Animation / canvas-ish children that add nothing to the logic under test.
+vi.mock("./AsciiArtAnimation", () => ({ AsciiArtAnimation: () => null }));
+vi.mock("./FrontDoor", () => ({ FrontDoor: () => null }));
+vi.mock("./AgentCapsule", () => ({ AgentCapsule: () => null }));
+
+import { OnboardingWizard } from "./OnboardingWizard";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+async function flushReact() {
+  await act(async () => {
+    await Promise.resolve();
+    await new Promise((resolve) => window.setTimeout(resolve, 0));
+  });
+}
+
+function render() {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return { container, root, queryClient };
+}
+
+describe("OnboardingWizard restore-gate (stale localStorage across accounts)", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    mockDialog.onboardingOpen = true;
+    mockDialog.onboardingOptions = {};
+    mockDialog.onboardingRouteDismissed = false;
+    mockCompany.companies = [];
+    mockCompany.loading = false;
+    mockAdapterRegistry.list = [];
+    mockAdapterRegistry.disabled = new Set<string>();
+    mockCompaniesApi.create.mockResolvedValue({
+      id: "created",
+      name: "Created Co",
+      issuePrefix: "CRE",
+    });
+    mockCompaniesApi.update.mockResolvedValue({
+      id: "c1",
+      name: "Acme Rockets",
+      issuePrefix: "PAP",
+    });
+    mockGoalsApi.create.mockResolvedValue({ id: "goal-1" });
+    mockGoalsApi.list.mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+    vi.clearAllMocks();
+  });
+
+  it("re-syncs a restored draft once companies resolve asynchronously (companies start empty/loading)", async () => {
+    // Regression for the initializer-only restore bug: the inner wizard's
+    // ~20 useState(saved?.x ?? default) initializers only read `saved` on
+    // their very first render. useCompany() starts with companies=[] and
+    // loading=true and resolves later; if the inner component mounted before
+    // that resolution, restoreOnboardingState would see an empty companies
+    // list and the whole draft would lock to defaults forever, even after
+    // companies arrive. The fix defers mounting the inner wizard until
+    // companies settle.
+    window.localStorage.setItem(
+      ONBOARDING_STORAGE_KEY,
+      JSON.stringify({
+        step: 3,
+        companyName: "Saved Co",
+        agentName: "Ops Lead",
+        createdCompanyId: "c1",
+      }),
+    );
+    mockDialog.onboardingOptions = {};
+    mockCompany.companies = [];
+    mockCompany.loading = true;
+
+    const { container, root, queryClient } = render();
+    const renderTree = () =>
+      act(async () => {
+        root.render(
+          <QueryClientProvider client={queryClient}>
+            <OnboardingWizard />
+          </QueryClientProvider>,
+        );
+      });
+
+    await renderTree();
+    await flushReact();
+
+    // Nothing mounts yet: no premature guess, and the draft is not touched.
+    expect(container.textContent).toBe("");
+    expect(document.body.textContent).toBe("");
+    expect(window.localStorage.getItem(ONBOARDING_STORAGE_KEY)).not.toBeNull();
+
+    // Companies resolve asynchronously, owning the saved company.
+    mockCompany.companies = [{ id: "c1", name: "Saved Co", issuePrefix: "SC" }];
+    mockCompany.loading = false;
+
+    await renderTree();
+    await flushReact();
+
+    // The draft is restored once companies settle: step 3 (Create your team
+    // lead) with the saved agent name in the input, not the defaults
+    // (step 0, "Chief of staff").
+    expect(document.body.textContent).toContain("Create your team lead");
+    const nameInput = document.body.querySelector(
+      'input[placeholder="Chief of staff"]',
+    ) as HTMLInputElement | null;
+    expect(nameInput?.value).toBe("Ops Lead");
+    const currentStep = document.body.querySelector('[aria-current="step"]');
+    expect(currentStep?.getAttribute("aria-label")).toBe("Step 3");
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  it("discards a saved draft for a company the signed-in account does not own, and wipes the stale blob", async () => {
+    // The actual vulnerability this fix closes: localStorage is per-origin,
+    // not per-account, so a browser that already onboarded "company-old" for
+    // a different account hands its id straight to a brand-new session.
+    window.localStorage.setItem(
+      ONBOARDING_STORAGE_KEY,
+      JSON.stringify({
+        step: 4,
+        companyName: "Someone Else's Co",
+        createdCompanyId: "company-old",
+      }),
+    );
+    mockCompany.companies = [{ id: "company-new", name: "My Co", issuePrefix: "MC" }];
+    mockCompany.loading = false;
+
+    const { root, queryClient } = render();
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <OnboardingWizard />
+        </QueryClientProvider>,
+      );
+    });
+    await flushReact();
+
+    // Falls back to the wizard's default first step, not the stale step 4
+    // draft for a company this account does not own.
+    expect(document.body.textContent).not.toContain("Someone Else's Co");
+    // The stale blob must not linger to confuse the next onboarding attempt.
+    expect(window.localStorage.getItem(ONBOARDING_STORAGE_KEY)).toBeNull();
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+});

--- a/ui/src/components/OnboardingWizard.tsx
+++ b/ui/src/components/OnboardingWizard.tsx
@@ -82,7 +82,9 @@ function buildMissionFromQuestionnaire(q1: string, q2: string, q3: string, q4: s
   return parts.join(" ");
 }
 
-const ONBOARDING_STORAGE_KEY = "paperclip-onboarding-state";
+// Exported so tests write/read the exact key the component uses, instead of
+// duplicating the literal and silently drifting from it if it's ever renamed.
+export const ONBOARDING_STORAGE_KEY = "paperclip-onboarding-state";
 const DEFAULT_TASK_TITLE = "Hire your first engineer and create a hiring plan";
 const DEFAULT_TASK_DESCRIPTION = `You are the CEO. You set the direction for the company.
 

--- a/ui/src/components/OnboardingWizard.tsx
+++ b/ui/src/components/OnboardingWizard.tsx
@@ -31,6 +31,7 @@ import { useAdapterCapabilities } from "../adapters/use-adapter-capabilities";
 import { getAdapterDisplay } from "../adapters/adapter-display-registry";
 import { defaultCreateValues } from "./agent-config-defaults";
 import { parseOnboardingGoalInput } from "../lib/onboarding-goal";
+import { restoreOnboardingState } from "../lib/onboarding-state";
 import { composeCeoInstructions } from "../lib/ceo-instructions";
 import {
   buildOnboardingIssuePayload,
@@ -91,16 +92,62 @@ const DEFAULT_TASK_DESCRIPTION = `You are the CEO. You set the direction for the
 const INCOMPLETE_ONBOARDING_STATE_MESSAGE =
   "Onboarding state is incomplete. Please restart onboarding and try again.";
 
-function loadSavedState(): Record<string, unknown> | null {
-  try {
+/**
+ * Thin gate in front of {@link OnboardingWizardInner}. The inner component's
+ * ~20 `useState(saved?.x ?? default)` initializers only read `saved` on their
+ * very first render, so it must never mount before the restored draft is
+ * final, otherwise every field locks to its default and the draft is lost
+ * for good. restoreOnboardingState requires the SETTLED companies list (see
+ * its JSDoc), so when a saved blob exists we wait for `companiesLoading` to
+ * clear before computing `saved` and mounting the inner component at all.
+ */
+export function OnboardingWizard() {
+  const { companies, loading: companiesLoading } = useCompany();
+
+  // Parsed once (not re-parsed by the cleanup effect below) so the restored
+  // value and the "should we wipe the blob" decision always agree.
+  const rawBlob = useMemo(() => {
     const raw = localStorage.getItem(ONBOARDING_STORAGE_KEY);
-    return raw ? JSON.parse(raw) : null;
-  } catch {
+    if (!raw) return undefined;
+    try {
+      return JSON.parse(raw) as unknown;
+    } catch {
+      return null; // malformed: treated as stale below, same as before
+    }
+  }, []);
+
+  const { saved, staleStateDetected } = useMemo(() => {
+    if (rawBlob === undefined) return { saved: null, staleStateDetected: false };
+    // Companies not settled yet: restoreOnboardingState must not be called
+    // (see its CONTRACT). Not stale, just not decidable yet.
+    if (companiesLoading) return { saved: null, staleStateDetected: false };
+    if (rawBlob === null) return { saved: null, staleStateDetected: true };
+    const restored = restoreOnboardingState(rawBlob, companies);
+    return { saved: restored, staleStateDetected: restored === null };
+  }, [rawBlob, companiesLoading, companies]);
+
+  // A discarded/malformed state should not sit in storage waiting to confuse
+  // the next onboarding attempt (e.g. a different signed-in user).
+  useEffect(() => {
+    if (staleStateDetected) {
+      localStorage.removeItem(ONBOARDING_STORAGE_KEY);
+    }
+  }, [staleStateDetected]);
+
+  // A saved blob exists but companies haven't settled yet: wait rather than
+  // mount the inner wizard with a premature (and unrecoverable) guess.
+  if (rawBlob !== undefined && companiesLoading) {
     return null;
   }
+
+  return <OnboardingWizardInner saved={saved} />;
 }
 
-export function OnboardingWizard() {
+function OnboardingWizardInner({
+  saved,
+}: {
+  saved: Record<string, unknown> | null;
+}) {
   const {
     onboardingOpen,
     onboardingOptions,
@@ -137,9 +184,6 @@ export function OnboardingWizard() {
 
   const initialStep = effectiveOnboardingOptions.initialStep ?? 0;
   const existingCompanyId = effectiveOnboardingOptions.companyId;
-
-  // Restore saved state from localStorage (read once on mount)
-  const saved = useMemo(loadSavedState, []);
 
   const [step, setStep] = useState<Step>((saved?.step as Step) ?? initialStep);
   const [onboardingPath, setOnboardingPath] = useState<"create" | "grow" | null>((saved?.onboardingPath as "create" | "grow" | null) ?? null);

--- a/ui/src/lib/onboarding-state.test.ts
+++ b/ui/src/lib/onboarding-state.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { restoreOnboardingState } from "./onboarding-state";
+
+const companies = [{ id: "company-new" }];
+
+describe("restoreOnboardingState", () => {
+  it("returns null for unusable input", () => {
+    expect(restoreOnboardingState(null, companies)).toBeNull();
+    expect(restoreOnboardingState("nonsense", companies)).toBeNull();
+  });
+
+  it("discards state whose company the user does not own", () => {
+    const saved = { step: 4, companyName: "Old Co", createdCompanyId: "company-old" };
+    expect(restoreOnboardingState(saved, companies)).toBeNull();
+  });
+
+  it("keeps state for a company the user does own", () => {
+    const saved = { step: 4, companyName: "New Co", createdCompanyId: "company-new" };
+    expect(restoreOnboardingState(saved, companies)?.companyName).toBe("New Co");
+  });
+
+  it("keeps in-progress state that has no company yet", () => {
+    const saved = { step: 1, companyName: "Draft" };
+    expect(restoreOnboardingState(saved, companies)?.companyName).toBe("Draft");
+  });
+
+  it("discards a company id against an empty (settled) companies list", () => {
+    // Per the CONTRACT in the JSDoc, callers must only invoke this once
+    // companies have settled. An empty settled list legitimately means the
+    // account owns no companies, so a saved company id is discarded exactly
+    // like an unowned one.
+    const saved = { step: 4, createdCompanyId: "company-new" };
+    expect(restoreOnboardingState(saved, [])).toBeNull();
+  });
+});

--- a/ui/src/lib/onboarding-state.ts
+++ b/ui/src/lib/onboarding-state.ts
@@ -1,0 +1,31 @@
+/**
+ * localStorage is scoped per ORIGIN, not per account, so a browser that already
+ * ran onboarding will happily hand a previous company's id to a brand new
+ * session. Every downstream call then targets the wrong company: goals,
+ * agents, and issues get created there, and requests targeting the actual
+ * company fail with authorization errors.
+ *
+ * So restoring is an authorization decision, not a convenience. If the saved
+ * company is not one the signed-in user owns, the whole blob is discarded.
+ *
+ * CONTRACT: `companies` must be the caller's SETTLED companies list (its
+ * loading query/context has finished, e.g. `companiesLoading === false`).
+ * This function has no way to tell an empty-because-still-loading list apart
+ * from an empty-because-the-account-owns-nothing list, so it always treats
+ * an empty `companies` as "owns nothing" and discards a saved company id.
+ * Callers must not invoke this while companies are still loading, wait for
+ * the settled list first, or a legitimate draft gets discarded by mistake.
+ */
+export function restoreOnboardingState(
+  raw: unknown,
+  companies: Array<{ id: string }>,
+): Record<string, unknown> | null {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return null;
+
+  const saved = { ...(raw as Record<string, unknown>) };
+
+  const companyId = saved.createdCompanyId;
+  if (typeof companyId !== "string" || companyId === "") return saved;
+
+  return companies.some((c) => c.id === companyId) ? saved : null;
+}


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The onboarding wizard is the first-run flow that creates a company, hires the first agent, and connects a model, and it is designed to survive a page reload mid-flow by persisting its draft to `localStorage`.
> - `localStorage` is scoped per browser origin, not per signed-in account, so any state written there is visible to every session that later loads the same origin.
> - The wizard's restore path never checked that the `createdCompanyId` in the saved draft belonged to the account currently signed in, so a second onboarding session in the same browser (a second account, or the same account starting a second company) silently inherited a previous company's id.
> - Every wizard action taken after that point (create goal, hire agent, create issue) then targets a company the current session does not own, which fails authorization server-side or, worse, could write into a company the user has no business touching.
> - This pull request turns "restore the saved draft" into an authorization decision: the saved company id is checked against the signed-in user's own companies, and anything that fails the check is discarded and wiped from storage.
> - It also fixes a related timing bug uncovered while writing the fix: the wizard's ~20 `useState(saved?.x ?? default)` initializers only read `saved` on the very first render, so the authorization check has to run before first mount, not after, or every restored field silently locks to its default forever even once the company list resolves.
> - The benefit is that a shared or previously-used browser can no longer let one onboarding session read or act on another account's in-progress company draft.

## Linked Issues or Issue Description

No existing public issue or PR covers this (searched `gh pr list` / `gh issue list` for `onboarding localStorage company`, `onboarding wizard restore`, and related terms; found only unrelated onboarding PRs such as #9501 and #2616). Describing the issue in-PR following the bug report template:

**What happened?**
`ui/src/components/OnboardingWizard.tsx` persists its draft state, including `createdCompanyId`, to `localStorage` under the fixed key `paperclip-onboarding-state` on every field change, and restores it on mount with no check that the current signed-in user owns that company.

**Expected behavior**
A saved draft should only be restored when the signed-in user actually owns the company it references. A draft for a company the user does not own should be discarded, not silently applied.

**Steps to reproduce**
1. Sign in as user A, start onboarding, and get far enough that `createdCompanyId` is set (survives past company creation).
2. Sign out (or, on a shared/instance-local browser, sign in as user B) without ever finishing or explicitly resetting the wizard.
3. Open onboarding again in the same browser.
4. The wizard restores mid-flow with user A's `createdCompanyId` already populated, and subsequent wizard actions (hiring an agent, creating a goal, etc.) target that company on behalf of the new session.

**Paperclip version or commit**: reproducible on `master` at `f12bb27bc`.

## What Changed

- Added `ui/src/lib/onboarding-state.ts` exporting `restoreOnboardingState(raw, companies)`. It treats restoring the saved blob as an authorization decision: if the blob names a `createdCompanyId` that is not in the caller's settled companies list, the whole blob is discarded (`null`); a draft with no company id yet (early steps) passes through unchanged. The function's contract requires the caller's companies list to be settled (`companiesLoading === false`), since an empty list is ambiguous between "still loading" and "this account owns nothing."
- Split `OnboardingWizard.tsx` into a thin outer gate (`OnboardingWizard`) and `OnboardingWizardInner`. The inner component's `useState(saved?.x ?? default)` initializers only read `saved` on first render, so the gate now defers mounting the inner component until the companies list has settled whenever a saved blob exists in storage, guaranteeing the inner component's very first render sees the final, authorized value.
- A discarded or malformed blob is wiped from `localStorage` immediately via a cleanup effect, so it cannot confuse the next onboarding attempt in the same browser.
- Exported `ONBOARDING_STORAGE_KEY` from `OnboardingWizard.tsx` (previously module-private) so the test imports the real key instead of duplicating the string literal.
- Added `ui/src/lib/onboarding-state.test.ts` (unowned/owned/no-company-yet/empty-settled-list/malformed-input cases) and `ui/src/components/OnboardingWizard.test.tsx` (new file; upstream had no direct test coverage of this component before this PR) covering the async-companies-arrival timing regression and the cross-account stale-draft discard-and-wipe path.

## Verification

- `npx vitest run` from `ui/`, full suite: 3009 passed. 3 pre-existing failures are unrelated to this change and reproduce on an unmodified `master` checkout (`CaseFieldsPanel.test.tsx`, `IssueProperties.test.tsx`, `attention.test.ts`; locale/timezone-dependent formatting assertions in files this PR does not touch).
- Targeted: `npx vitest run src/lib/onboarding-state.test.ts src/components/OnboardingWizard.test.tsx src/components/OnboardingWizardVariant.test.tsx` (8/8 pass).
- `pnpm --filter @paperclipai/ui typecheck` (`tsc -b`), clean, exit 0.

## Risks

- Low risk. The change only narrows what gets restored from `localStorage`; it never widens access. Worst case for a legitimate single-account user is an unnecessary reset to step 0 if `restoreOnboardingState` were ever too strict, which the added test suite guards against (owned-company and no-company-yet drafts are proven to survive).
- The gate renders `null` for one or more frames while a saved blob exists and `companiesLoading` is still `true`, instead of mounting the wizard immediately. This is a brief, existing loading window (the company list was already being fetched before this change); the wizard was not usable during that window before either, since the old code raced the same async data with synchronous `useState` initializers and could show visibly wrong (stale-default) fields. No user-visible regression expected, but reviewers should note the wizard's very first paint can now be delayed until companies resolve when localStorage already has a draft.
- No data migration, no API or schema changes, no changes to the persisted wizard state shape.

## Model Used

Claude (Anthropic), via Claude Code CLI. Agentic tool use (file search, edit, test execution, and PR authoring tools) with extended reasoning over multiple turns; no single fixed model ID is asserted here beyond "Claude (Anthropic)" per the requesting instruction.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes (no user-facing docs are affected by this internal bug fix)
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
