### PR TITLE
fix(adapters): stop mis-coding codex/gemini runs from conversation stdout

### DIFF
--- a/packages/adapter-utils/src/classification.test.ts
+++ b/packages/adapter-utils/src/classification.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+import { buildErrorClassificationHaystack, stripJsonlEventLines } from "./classification.js";
+
+describe("stripJsonlEventLines", () => {
+  it("drops JSONL event lines and keeps plain-text lines", () => {
+    const stdout = [
+      JSON.stringify({ type: "thread.started", thread_id: "t-1" }),
+      JSON.stringify({
+        type: "item.completed",
+        item: { type: "agent_message", text: "We hit a 429 rate limit; try again later." },
+      }),
+      "Please visit https://example.com/login to authenticate.",
+      JSON.stringify({ type: "turn.completed", usage: { input_tokens: 1 } }),
+    ].join("\n");
+
+    expect(stripJsonlEventLines(stdout)).toBe(
+      "Please visit https://example.com/login to authenticate.",
+    );
+  });
+
+  it("keeps lines that look like JSON but do not parse", () => {
+    expect(stripJsonlEventLines('{ this is not json "rate limit"')).toBe(
+      '{ this is not json "rate limit"',
+    );
+  });
+
+  it("returns an empty string for null, undefined, and empty input", () => {
+    expect(stripJsonlEventLines(null)).toBe("");
+    expect(stripJsonlEventLines(undefined)).toBe("");
+    expect(stripJsonlEventLines("")).toBe("");
+  });
+});
+
+describe("buildErrorClassificationHaystack", () => {
+  it("joins error message, plain-text stdout, and stderr", () => {
+    const haystack = buildErrorClassificationHaystack({
+      errorMessage: "structured failure",
+      stdout: "plain diagnostic line\n",
+      stderr: "stderr line",
+    });
+    expect(haystack).toBe("structured failure\nplain diagnostic line\nstderr line");
+  });
+
+  it("never includes JSONL conversation lines from stdout", () => {
+    const haystack = buildErrorClassificationHaystack({
+      errorMessage: null,
+      stdout: [
+        JSON.stringify({
+          type: "assistant",
+          message: { content: [{ type: "text", text: "the upstream was overloaded, 429" }] },
+        }),
+        "cli: fatal error",
+      ].join("\n"),
+      stderr: "",
+    });
+    expect(haystack).toBe("cli: fatal error");
+    expect(haystack).not.toContain("429");
+  });
+
+  it("keeps error text from structured error events in stdout", () => {
+    const haystack = buildErrorClassificationHaystack({
+      stdout: [
+        JSON.stringify({ type: "error", message: "Unknown session id abc" }),
+        JSON.stringify({ type: "turn.failed", error: { message: "stream disconnected" } }),
+        JSON.stringify({ type: "system", subtype: "error", error: "auth token expired" }),
+      ].join("\n"),
+      stderr: "",
+    });
+    expect(haystack).toBe(
+      "Unknown session id abc\nstream disconnected\nauth token expired",
+    );
+  });
+
+  it("keeps error result events but drops success result events", () => {
+    const haystack = buildErrorClassificationHaystack({
+      stdout: [
+        JSON.stringify({ type: "result", subtype: "success", result: "we discussed 429 rate limits" }),
+        JSON.stringify({ type: "result", is_error: true, result: "usage limit reached" }),
+      ].join("\n"),
+      stderr: "",
+    });
+    expect(haystack).toBe("usage limit reached");
+    expect(haystack).not.toContain("429");
+  });
+
+  it("ignores non-error system events and unknown event types", () => {
+    const haystack = buildErrorClassificationHaystack({
+      stdout: [
+        JSON.stringify({ type: "system", subtype: "init", model: "rate-limit-9000" }),
+        JSON.stringify({ type: "message", role: "assistant", content: "try again later, 429" }),
+      ].join("\n"),
+      stderr: "",
+    });
+    expect(haystack).toBe("");
+  });
+
+  it("drops blank lines and trims whitespace", () => {
+    const haystack = buildErrorClassificationHaystack({
+      stdout: "  padded  \n\n\n",
+      stderr: "\n  err  \n",
+    });
+    expect(haystack).toBe("padded\nerr");
+  });
+});

--- a/packages/adapter-utils/src/classification.ts
+++ b/packages/adapter-utils/src/classification.ts
@@ -1,0 +1,115 @@
+import { asString, parseJson, parseObject } from "./server-utils.js";
+
+/**
+ * Drops JSONL event lines (stream events, structured results, and — critically
+ * — the agent conversation embedded inside them) from raw CLI stdout, keeping
+ * only plain-text lines such as CLI diagnostics and login prompts.
+ *
+ * Keyword error classifiers must never see the agent conversation: assistant
+ * text routinely discusses rate limits, auth, sessions, and retries, and
+ * matching it mis-coded successful or unrelated runs as transient/auth
+ * failures, chaining full-cost retries (LAC-2760 failure mode).
+ */
+export function stripJsonlEventLines(stdout: string | null | undefined): string {
+  if (!stdout) return "";
+  return stdout
+    .split(/\r?\n/)
+    .filter((line) => {
+      const trimmed = line.trim();
+      if (!trimmed) return false;
+      if (!trimmed.startsWith("{")) return true;
+      return parseJson(trimmed) == null;
+    })
+    .join("\n");
+}
+
+function errorTextFrom(value: unknown): string {
+  if (typeof value === "string") return value.trim();
+  if (value == null) return "";
+  const record = parseObject(value);
+  const message =
+    asString(record.message, "").trim() ||
+    asString(record.error, "").trim() ||
+    asString(record.detail, "").trim() ||
+    asString(record.code, "").trim();
+  if (message) return message;
+  try {
+    const serialized = JSON.stringify(record);
+    return serialized === "{}" ? "" : serialized;
+  } catch {
+    return "";
+  }
+}
+
+/**
+ * Extracts error text from a structured stream event, or "" for every other
+ * event shape. Only failure-shaped events (error, turn.failed, system-error,
+ * error results) contribute — conversation events (assistant/message/item
+ * text) never do, so their text stays invisible to keyword classifiers.
+ */
+function extractErrorEventText(event: Record<string, unknown>): string {
+  const type = asString(event.type, "").trim().toLowerCase();
+
+  if (type === "error") {
+    return errorTextFrom(event.error ?? event.message ?? event.detail);
+  }
+
+  if (type === "turn.failed") {
+    return errorTextFrom(event.error ?? event.message);
+  }
+
+  if (type === "system") {
+    if (asString(event.subtype, "").trim().toLowerCase() !== "error") return "";
+    return errorTextFrom(event.error ?? event.message ?? event.detail);
+  }
+
+  if (type === "result") {
+    const subtype = asString(event.subtype, "").trim().toLowerCase();
+    const status = asString(event.status, "").trim().toLowerCase();
+    const isError =
+      event.is_error === true ||
+      subtype.startsWith("error") ||
+      status === "error" ||
+      status === "failed";
+    if (!isError) return "";
+    return errorTextFrom(event.error ?? event.message ?? event.result);
+  }
+
+  return "";
+}
+
+/**
+ * Builds the haystack keyword error classifiers are allowed to scan:
+ * adapter-extracted structured error text, error text extracted from
+ * failure-shaped JSONL events, plain-text (non-JSONL) stdout, and stderr.
+ * Conversation-bearing JSONL events are dropped here, inside the builder, so
+ * the "never scan the conversation" invariant is mechanism rather than a
+ * per-call-site convention — passing raw stream stdout is safe, and structured
+ * error events stay classifiable even when the caller has no parsed
+ * errorMessage to pass.
+ */
+export function buildErrorClassificationHaystack(input: {
+  errorMessage?: string | null;
+  stdout?: string | null;
+  stderr?: string | null;
+}): string {
+  const stdoutLines: string[] = [];
+  for (const rawLine of (input.stdout ?? "").split(/\r?\n/)) {
+    const trimmed = rawLine.trim();
+    if (!trimmed) continue;
+    const event = trimmed.startsWith("{") ? parseJson(trimmed) : null;
+    if (event == null) {
+      stdoutLines.push(trimmed);
+      continue;
+    }
+    const errorText = extractErrorEventText(event);
+    if (errorText) stdoutLines.push(errorText);
+  }
+
+  return [input.errorMessage ?? "", ...stdoutLines, input.stderr ?? ""]
+    .join("\n")
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .join("\n");
+}

--- a/packages/adapter-utils/src/types.ts
+++ b/packages/adapter-utils/src/types.ts
@@ -77,6 +77,15 @@ export interface AdapterExecutionResult {
   exitCode: number | null;
   signal: string | null;
   timedOut: boolean;
+  /**
+   * Explicit success signal from the adapter's structured output. `true` is
+   * authoritative: the run is treated as successful even if the process exit
+   * code is nonzero (e.g. the CLI was SIGTERMed by terminal-result cleanup
+   * after emitting a successful result). `false`/`null`/absent are advisory
+   * only — the outcome falls back to exitCode + errorMessage inference, so a
+   * failing adapter must still set errorMessage/exitCode to signal failure.
+   */
+  succeeded?: boolean | null;
   errorMessage?: string | null;
   errorCode?: string | null;
   errorFamily?: AdapterExecutionErrorFamily | null;

--- a/packages/adapters/codex-local/src/server/execute.ts
+++ b/packages/adapters/codex-local/src/server/execute.ts
@@ -1223,8 +1223,16 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         parsedError ||
         stderrLine ||
         `Codex exited with code ${attempt.proc.exitCode ?? -1}`;
+      // A structured completed turn is authoritative success even when the
+      // process exit code is nonzero (terminal-result cleanup SIGTERMs the CLI
+      // after a successful turn), and classification runs only on actual
+      // failure. The classifiers themselves strip JSONL event lines from
+      // stdout, so the agent conversation — which routinely discusses rate
+      // limits, auth, and retries — never reaches the keyword matchers.
+      const parsedSucceeded = attempt.parsed.succeeded === true;
+      const failed = !parsedSucceeded && (attempt.proc.exitCode ?? 0) !== 0;
       const transientRetryNotBefore =
-        (attempt.proc.exitCode ?? 0) !== 0
+        failed
           ? extractCodexRetryNotBefore({
               stdout: attempt.proc.stdout,
               stderr: attempt.proc.stderr,
@@ -1232,7 +1240,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
             })
           : null;
       const authRefreshFailure =
-        (attempt.proc.exitCode ?? 0) !== 0
+        failed
           ? classifyCodexAuthRefreshFailure({
               stdout: attempt.proc.stdout,
               stderr: attempt.proc.stderr,
@@ -1240,7 +1248,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
             })
           : null;
       const providerQuota =
-        (attempt.proc.exitCode ?? 0) !== 0 &&
+        failed &&
         !authRefreshFailure &&
         isCodexProviderQuotaError({
           stdout: attempt.proc.stdout,
@@ -1248,7 +1256,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
           errorMessage: fallbackErrorMessage,
         });
       const transientUpstream =
-        (attempt.proc.exitCode ?? 0) !== 0 &&
+        failed &&
         !authRefreshFailure &&
         !providerQuota &&
         isCodexTransientUpstreamError({
@@ -1262,10 +1270,8 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         exitCode: attempt.proc.exitCode,
         signal: attempt.proc.signal,
         timedOut: false,
-        errorMessage:
-          (attempt.proc.exitCode ?? 0) === 0
-            ? null
-            : fallbackErrorMessage,
+        succeeded: parsedSucceeded,
+        errorMessage: failed ? fallbackErrorMessage : null,
         errorCode:
           authRefreshFailure
             ? authRefreshFailure
@@ -1305,7 +1311,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         sessionId &&
         !initial.proc.timedOut &&
         (initial.proc.exitCode ?? 0) !== 0 &&
-        isCodexUnknownSessionError(initial.proc.stdout, initial.rawStderr)
+        isCodexUnknownSessionError(initial.proc.stdout, initial.rawStderr, initial.parsed.errorMessage)
       ) {
         await onLog(
           "stdout",

--- a/packages/adapters/codex-local/src/server/parse.test.ts
+++ b/packages/adapters/codex-local/src/server/parse.test.ts
@@ -33,6 +33,7 @@ describe("parseCodexJsonl", () => {
       },
       usageBasis: "per_run",
       errorMessage: "resume failed",
+      succeeded: false,
     });
   });
 
@@ -67,6 +68,7 @@ describe("parseCodexJsonl", () => {
       },
       usageBasis: "per_run",
       errorMessage: null,
+      succeeded: true,
     });
   });
 });
@@ -172,5 +174,73 @@ describe("isCodexTransientUpstreamError", () => {
         ].join("\n"),
       }),
     ).toBe(false);
+  });
+});
+
+describe("classifier conversation-stdout isolation", () => {
+  const conversationStdout = [
+    JSON.stringify({ type: "thread.started", thread_id: "thread-1" }),
+    JSON.stringify({
+      type: "item.completed",
+      item: {
+        type: "agent_message",
+        text: "We're currently experiencing high demand, which may cause temporary errors. The API returned 429 too many requests; try again later. You've hit your usage limit. Session thread-1 not found earlier.",
+      },
+    }),
+    JSON.stringify({ type: "turn.completed", usage: { input_tokens: 1, cached_input_tokens: 0, output_tokens: 1 } }),
+  ].join("\n");
+
+  it("never classifies from agent conversation embedded in JSONL stdout", () => {
+    expect(isCodexTransientUpstreamError({ stdout: conversationStdout })).toBe(false);
+    expect(isCodexProviderQuotaError({ stdout: conversationStdout })).toBe(false);
+    expect(extractCodexRetryNotBefore({ stdout: conversationStdout })).toBeNull();
+    expect(isCodexUnknownSessionError(conversationStdout, "")).toBe(false);
+  });
+
+  it("still classifies plain-text stdout diagnostics", () => {
+    expect(
+      isCodexTransientUpstreamError({
+        stdout: "Error running remote compact task: We're currently experiencing high demand, which may cause temporary errors.",
+      }),
+    ).toBe(true);
+  });
+
+  it("detects unknown sessions from the structured error message", () => {
+    expect(isCodexUnknownSessionError("", "", "no rollout found for thread id thread-1")).toBe(true);
+    expect(isCodexUnknownSessionError(conversationStdout, "", null)).toBe(false);
+  });
+});
+
+describe("parseCodexJsonl succeeded", () => {
+  it("reports success when the turn completed without failure events", () => {
+    const parsed = parseCodexJsonl([
+      JSON.stringify({ type: "thread.started", thread_id: "thread-1" }),
+      JSON.stringify({ type: "item.completed", item: { type: "agent_message", text: "done" } }),
+      JSON.stringify({ type: "turn.completed", usage: { input_tokens: 1, cached_input_tokens: 0, output_tokens: 1 } }),
+    ].join("\n"));
+    expect(parsed.succeeded).toBe(true);
+  });
+
+  it("does not report success on turn.failed", () => {
+    const parsed = parseCodexJsonl([
+      JSON.stringify({ type: "thread.started", thread_id: "thread-1" }),
+      JSON.stringify({ type: "turn.failed", error: { message: "boom" } }),
+    ].join("\n"));
+    expect(parsed.succeeded).toBe(false);
+  });
+
+  it("does not report success when an error event was emitted", () => {
+    const parsed = parseCodexJsonl([
+      JSON.stringify({ type: "error", message: "stream error" }),
+      JSON.stringify({ type: "turn.completed", usage: { input_tokens: 1, cached_input_tokens: 0, output_tokens: 1 } }),
+    ].join("\n"));
+    expect(parsed.succeeded).toBe(false);
+  });
+
+  it("does not report success without a completed turn", () => {
+    const parsed = parseCodexJsonl(
+      JSON.stringify({ type: "thread.started", thread_id: "thread-1" }),
+    );
+    expect(parsed.succeeded).toBe(false);
   });
 });

--- a/packages/adapters/codex-local/src/server/parse.ts
+++ b/packages/adapters/codex-local/src/server/parse.ts
@@ -4,6 +4,7 @@ import {
   parseObject,
   parseJson,
 } from "@paperclipai/adapter-utils/server-utils";
+import { buildErrorClassificationHaystack } from "@paperclipai/adapter-utils/classification";
 
 const CODEX_TRANSIENT_UPSTREAM_RE =
   /(?:we(?:'|’)re\s+currently\s+experiencing\s+high\s+demand|temporary\s+errors|rate[-\s]?limit(?:ed)?|too\s+many\s+requests|\b429\b|server\s+overloaded|service\s+unavailable|try\s+again\s+later)/i;
@@ -31,6 +32,8 @@ export function parseCodexJsonl(stdout: string) {
   let sessionId: string | null = null;
   let finalMessage: string | null = null;
   let errorMessage: string | null = null;
+  let sawTurnCompleted = false;
+  let sawFailureEvent = false;
   const usage = {
     inputTokens: 0,
     cachedInputTokens: 0,
@@ -51,6 +54,7 @@ export function parseCodexJsonl(stdout: string) {
     }
 
     if (type === "error") {
+      sawFailureEvent = true;
       const msg = asString(event.message, "").trim();
       if (msg) errorMessage = msg;
       continue;
@@ -66,6 +70,7 @@ export function parseCodexJsonl(stdout: string) {
     }
 
     if (type === "turn.completed") {
+      sawTurnCompleted = true;
       const usageObj = parseObject(event.usage);
       usage.inputTokens = asNumber(usageObj.input_tokens, usage.inputTokens);
       usage.cachedInputTokens = asNumber(usageObj.cached_input_tokens, usage.cachedInputTokens);
@@ -74,6 +79,7 @@ export function parseCodexJsonl(stdout: string) {
     }
 
     if (type === "turn.failed") {
+      sawFailureEvent = true;
       const err = parseObject(event.error);
       const msg = asString(err.message, "").trim();
       if (msg) errorMessage = msg;
@@ -86,35 +92,23 @@ export function parseCodexJsonl(stdout: string) {
     usage,
     usageBasis: "per_run" as const,
     errorMessage,
+    // Structured success: the stream reported a completed turn and no
+    // error/turn.failed event. Authoritative when true — the process exit code
+    // may still be nonzero when terminal-result cleanup SIGTERMs the CLI after
+    // a successful turn.
+    succeeded: sawTurnCompleted && !sawFailureEvent && errorMessage == null,
   };
 }
 
-export function isCodexUnknownSessionError(stdout: string, stderr: string): boolean {
-  const haystack = `${stdout}\n${stderr}`
-    .split(/\r?\n/)
-    .map((line) => line.trim())
-    .filter(Boolean)
-    .join("\n");
+export function isCodexUnknownSessionError(
+  stdout: string,
+  stderr: string,
+  errorMessage?: string | null,
+): boolean {
+  const haystack = buildErrorClassificationHaystack({ errorMessage, stdout, stderr });
   return /unknown (session|thread)|session .* not found|thread .* not found|conversation .* not found|missing rollout path for thread|state db missing rollout path|state db returned stale rollout path|no rollout found for thread id/i.test(
     haystack,
   );
-}
-
-function buildCodexErrorHaystack(input: {
-  stdout?: string | null;
-  stderr?: string | null;
-  errorMessage?: string | null;
-}): string {
-  return [
-    input.errorMessage ?? "",
-    input.stdout ?? "",
-    input.stderr ?? "",
-  ]
-    .join("\n")
-    .split(/\r?\n/)
-    .map((line) => line.trim())
-    .filter(Boolean)
-    .join("\n");
 }
 
 export function classifyCodexAuthRefreshFailure(input: {
@@ -122,7 +116,7 @@ export function classifyCodexAuthRefreshFailure(input: {
   stderr?: string | null;
   errorMessage?: string | null;
 }): CodexAuthRefreshFailureClass | null {
-  const haystack = buildCodexErrorHaystack(input);
+  const haystack = buildErrorClassificationHaystack(input);
 
   if (CODEX_REFRESH_TOKEN_REUSED_RE.test(haystack)) return "refresh_token_reused";
   if (CODEX_REFRESH_TOKEN_EXPIRED_RE.test(haystack)) return "refresh_token_expired";
@@ -271,7 +265,7 @@ export function extractCodexRetryNotBefore(input: {
   stderr?: string | null;
   errorMessage?: string | null;
 }, now = new Date()): Date | null {
-  const haystack = buildCodexErrorHaystack(input);
+  const haystack = buildErrorClassificationHaystack(input);
   const usageLimitMatch = haystack.match(CODEX_USAGE_LIMIT_RE);
   if (!usageLimitMatch) return null;
   return parseLocalClockTime(usageLimitMatch[1] ?? "", now);
@@ -282,7 +276,7 @@ export function isCodexTransientUpstreamError(input: {
   stderr?: string | null;
   errorMessage?: string | null;
 }): boolean {
-  const haystack = buildCodexErrorHaystack(input);
+  const haystack = buildErrorClassificationHaystack(input);
 
   if (isCodexProviderQuotaError(input)) return false;
   if (!CODEX_TRANSIENT_UPSTREAM_RE.test(haystack)) return false;
@@ -296,6 +290,6 @@ export function isCodexProviderQuotaError(input: {
   stderr?: string | null;
   errorMessage?: string | null;
 }): boolean {
-  const haystack = buildCodexErrorHaystack(input);
+  const haystack = buildErrorClassificationHaystack(input);
   return CODEX_PROVIDER_QUOTA_RE.test(haystack) || extractCodexRetryNotBefore(input) != null;
 }

--- a/packages/adapters/gemini-local/src/server/execute.ts
+++ b/packages/adapters/gemini-local/src/server/execute.ts
@@ -642,12 +642,21 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     clearSessionOnMissingSession = false,
     isRetry = false,
   ): AdapterExecutionResult => {
+    // The classifiers strip JSONL event lines from stdout internally, so the
+    // agent conversation — which routinely discusses auth, rate limits, and
+    // network errors — never reaches the keyword matchers; structured error
+    // text is fed in explicitly via parsed.errorMessage/resultEvent.
     const authMeta = detectGeminiAuthRequired({
       parsed: attempt.parsed.resultEvent,
       stdout: attempt.proc.stdout,
       stderr: attempt.proc.stderr,
+      errorMessage: attempt.parsed.errorMessage,
     });
-    const networkUnavailable = isGeminiTransientNetworkError(attempt.proc.stdout, attempt.proc.stderr);
+    const networkUnavailable = isGeminiTransientNetworkError(
+      attempt.proc.stdout,
+      attempt.proc.stderr,
+      attempt.parsed.errorMessage,
+    );
 
     if (attempt.proc.timedOut) {
       return {
@@ -674,7 +683,12 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       structuredFailure ||
       stderrLine ||
       `Gemini exited with code ${attempt.proc.exitCode ?? -1}`;
-    const failed = (attempt.proc.exitCode ?? 0) !== 0;
+    // A structured non-error result event is authoritative success even when
+    // the process exit code is nonzero (terminal-result cleanup SIGTERMs the
+    // CLI after a successful result), and error classification applies only
+    // to actual failures.
+    const parsedSucceeded = attempt.parsed.succeeded === true;
+    const failed = !parsedSucceeded && (attempt.proc.exitCode ?? 0) !== 0;
     const clearSessionForTurnLimit = isGeminiTurnLimitResult(
       attempt.parsed.resultEvent,
       attempt.proc.exitCode,
@@ -710,6 +724,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       exitCode: attempt.proc.exitCode,
       signal: attempt.proc.signal,
       timedOut: false,
+      succeeded: parsedSucceeded,
       errorMessage: failed ? fallbackErrorMessage : null,
       errorCode: failed && authMeta.requiresAuth
         ? "gemini_auth_required"
@@ -740,7 +755,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       sessionId &&
       !initial.proc.timedOut &&
       (initial.proc.exitCode ?? 0) !== 0 &&
-      isGeminiSessionUnrecoverableError(initial.proc.stdout, initial.proc.stderr)
+      isGeminiSessionUnrecoverableError(initial.proc.stdout, initial.proc.stderr, initial.parsed.errorMessage)
     ) {
       await onLog(
         "stdout",

--- a/packages/adapters/gemini-local/src/server/parse.test.ts
+++ b/packages/adapters/gemini-local/src/server/parse.test.ts
@@ -213,3 +213,76 @@ describe("isGeminiTransientNetworkError", () => {
     ).toBe(false);
   });
 });
+
+describe("classifier conversation-stdout isolation", () => {
+  const conversationStdout = [
+    JSON.stringify({ type: "system", subtype: "init", session_id: "gemini-1" }),
+    JSON.stringify({
+      type: "message",
+      role: "assistant",
+      content:
+        "The user is not authenticated and login required errors appear; run gemini auth login first. I also saw ENOTFOUND oauth2.googleapis.com and a 429 quota error, plus session gemini-1 not found.",
+    }),
+    JSON.stringify({ type: "result", subtype: "success", session_id: "gemini-1", result: "ok" }),
+  ].join("\n");
+
+  it("never classifies from agent conversation embedded in JSONL stdout", () => {
+    expect(
+      detectGeminiAuthRequired({ parsed: null, stdout: conversationStdout, stderr: "" }).requiresAuth,
+    ).toBe(false);
+    expect(isGeminiTransientNetworkError(conversationStdout, "")).toBe(false);
+    expect(isGeminiSessionUnrecoverableError(conversationStdout, "")).toBe(false);
+  });
+
+  it("still detects auth failures from stderr and structured error messages", () => {
+    expect(
+      detectGeminiAuthRequired({ parsed: null, stdout: "", stderr: "Please authenticate: not logged in" })
+        .requiresAuth,
+    ).toBe(true);
+    expect(
+      detectGeminiAuthRequired({
+        parsed: null,
+        stdout: conversationStdout,
+        stderr: "",
+        errorMessage: "Authentication required. Run gemini auth login first.",
+      }).requiresAuth,
+    ).toBe(true);
+  });
+
+  it("still detects network and session errors from stderr and structured error messages", () => {
+    expect(isGeminiTransientNetworkError("", "GaxiosError: ENOTFOUND oauth2.googleapis.com")).toBe(true);
+    expect(isGeminiTransientNetworkError(conversationStdout, "", "request to sts failed: EAI_AGAIN")).toBe(true);
+    expect(isGeminiSessionUnrecoverableError("", "", "checkpoint gemini-1 not found")).toBe(true);
+  });
+});
+
+describe("parseGeminiJsonl succeeded", () => {
+  it("reports success for a non-error result event", () => {
+    const parsed = parseGeminiJsonl(
+      JSON.stringify({ type: "result", subtype: "success", session_id: "gemini-1", result: "ok" }),
+    );
+    expect(parsed.succeeded).toBe(true);
+  });
+
+  it("does not report success for an error result event", () => {
+    const parsed = parseGeminiJsonl(
+      JSON.stringify({ type: "result", subtype: "error", session_id: "gemini-1", error: "boom" }),
+    );
+    expect(parsed.succeeded).toBe(false);
+  });
+
+  it("does not report success without a result event", () => {
+    const parsed = parseGeminiJsonl(
+      JSON.stringify({ type: "message", role: "assistant", content: "hello" }),
+    );
+    expect(parsed.succeeded).toBe(false);
+  });
+
+  it("does not report success when an error event was emitted", () => {
+    const parsed = parseGeminiJsonl([
+      JSON.stringify({ type: "error", message: "stream error" }),
+      JSON.stringify({ type: "result", subtype: "success", session_id: "gemini-1", result: "ok" }),
+    ].join("\n"));
+    expect(parsed.succeeded).toBe(false);
+  });
+});

--- a/packages/adapters/gemini-local/src/server/parse.ts
+++ b/packages/adapters/gemini-local/src/server/parse.ts
@@ -1,4 +1,5 @@
 import { asNumber, asString, parseJson, parseObject } from "@paperclipai/adapter-utils/server-utils";
+import { buildErrorClassificationHaystack } from "@paperclipai/adapter-utils/classification";
 
 function collectMessageText(message: unknown): string[] {
   if (typeof message === "string") {
@@ -81,6 +82,7 @@ export function parseGeminiJsonl(stdout: string) {
   let errorMessage: string | null = null;
   let costUsd: number | null = null;
   let resultEvent: Record<string, unknown> | null = null;
+  let resultEventIsError = false;
   let question: { prompt: string; choices: Array<{ key: string; label: string; description?: string }> } | null = null;
   const usage = {
     inputTokens: 0,
@@ -152,6 +154,7 @@ export function parseGeminiJsonl(stdout: string) {
         asString(event.subtype, "").toLowerCase() === "error" ||
         status === "error" ||
         status === "failed";
+      resultEventIsError = isError;
       if (isError) {
         const text = asErrorText(event.error ?? event.message ?? event.result).trim();
         if (text) errorMessage = text;
@@ -196,27 +199,32 @@ export function parseGeminiJsonl(stdout: string) {
     errorMessage,
     resultEvent,
     question,
+    // Structured success: the stream emitted a result event that did not
+    // report an error, and no error/system-error event set an error message.
+    // Authoritative when true — the process exit code may still be nonzero
+    // when terminal-result cleanup SIGTERMs the CLI after a successful result.
+    succeeded: resultEvent != null && !resultEventIsError && errorMessage == null,
   };
 }
 
-export function isGeminiSessionUnrecoverableError(stdout: string, stderr: string): boolean {
-  const haystack = `${stdout}\n${stderr}`
-    .split(/\r?\n/)
-    .map((line) => line.trim())
-    .filter(Boolean)
-    .join("\n");
+export function isGeminiSessionUnrecoverableError(
+  stdout: string,
+  stderr: string,
+  errorMessage?: string | null,
+): boolean {
+  const haystack = buildErrorClassificationHaystack({ errorMessage, stdout, stderr });
 
   return /unknown\s+session|session\s+.*\s+not\s+found|resume\s+.*\s+not\s+found|checkpoint\s+.*\s+not\s+found|cannot\s+resume|failed\s+to\s+resume|exceeds\s+the\s+maximum\s+number\s+of\s+tokens|input\s+token\s+count\s+exceeds/i.test(
     haystack,
   );
 }
 
-export function isGeminiTransientNetworkError(stdout: string, stderr: string): boolean {
-  const haystack = `${stdout}\n${stderr}`
-    .split(/\r?\n/)
-    .map((line) => line.trim())
-    .filter(Boolean)
-    .join("\n");
+export function isGeminiTransientNetworkError(
+  stdout: string,
+  stderr: string,
+  errorMessage?: string | null,
+): boolean {
+  const haystack = buildErrorClassificationHaystack({ errorMessage, stdout, stderr });
 
   return /ENOTFOUND\s+oauth2\.googleapis\.com|ENOTFOUND\s+sts\.googleapis\.com|EAI_AGAIN|_GaxiosError.*ENOTFOUND|_UserRefreshClient.*ENOTFOUND/i.test(
     haystack,
@@ -271,15 +279,18 @@ export function detectGeminiAuthRequired(input: {
   parsed: Record<string, unknown> | null;
   stdout: string;
   stderr: string;
+  errorMessage?: string | null;
 }): { requiresAuth: boolean } {
   const errors = extractGeminiErrorMessages(input.parsed ?? {});
-  const messages = [...errors, input.stdout, input.stderr]
-    .join("\n")
-    .split(/\r?\n/)
-    .map((line) => line.trim())
-    .filter(Boolean);
+  const haystack = buildErrorClassificationHaystack({
+    errorMessage: [input.errorMessage ?? "", ...errors].join("\n"),
+    stdout: input.stdout,
+    stderr: input.stderr,
+  });
 
-  const requiresAuth = messages.some((line) => GEMINI_AUTH_REQUIRED_RE.test(line));
+  const requiresAuth = haystack
+    .split("\n")
+    .some((line) => GEMINI_AUTH_REQUIRED_RE.test(line));
   return { requiresAuth };
 }
 
@@ -287,15 +298,18 @@ export function detectGeminiQuotaExhausted(input: {
   parsed: Record<string, unknown> | null;
   stdout: string;
   stderr: string;
+  errorMessage?: string | null;
 }): { exhausted: boolean } {
   const errors = extractGeminiErrorMessages(input.parsed ?? {});
-  const messages = [...errors, input.stdout, input.stderr]
-    .join("\n")
-    .split(/\r?\n/)
-    .map((line) => line.trim())
-    .filter(Boolean);
+  const haystack = buildErrorClassificationHaystack({
+    errorMessage: [input.errorMessage ?? "", ...errors].join("\n"),
+    stdout: input.stdout,
+    stderr: input.stderr,
+  });
 
-  const exhausted = messages.some((line) => GEMINI_QUOTA_EXHAUSTED_RE.test(line));
+  const exhausted = haystack
+    .split("\n")
+    .some((line) => GEMINI_QUOTA_EXHAUSTED_RE.test(line));
   return { exhausted };
 }
 

--- a/packages/adapters/gemini-local/src/server/test.ts
+++ b/packages/adapters/gemini-local/src/server/test.ts
@@ -227,11 +227,13 @@ export async function testEnvironment(
         parsed: parsed.resultEvent,
         stdout: probe.stdout,
         stderr: probe.stderr,
+        errorMessage: parsed.errorMessage,
       });
       const quotaMeta = detectGeminiQuotaExhausted({
         parsed: parsed.resultEvent,
         stdout: probe.stdout,
         stderr: probe.stderr,
+        errorMessage: parsed.errorMessage,
       });
 
       if (quotaMeta.exhausted) {

--- a/server/src/__tests__/codex-local-execute.test.ts
+++ b/server/src/__tests__/codex-local-execute.test.ts
@@ -1461,3 +1461,119 @@ describe("codex execute", () => {
     }
   });
 });
+
+describe("codex execute classification isolation", () => {
+  async function writeStreamingCodexCommand(
+    commandPath: string,
+    options: { stdoutLines: Array<Record<string, unknown>>; exitCode?: number },
+  ): Promise<void> {
+    const script = `#!/usr/bin/env node
+for (const line of ${JSON.stringify(options.stdoutLines.map((line) => JSON.stringify(line)))}) {
+  console.log(line);
+}
+process.exit(${options.exitCode ?? 1});
+`;
+    await fs.writeFile(commandPath, script, "utf8");
+    await fs.chmod(commandPath, 0o755);
+  }
+
+  async function runCodexExecute(
+    runId: string,
+    tmpPrefix: string,
+    commandWriter: (commandPath: string) => Promise<void>,
+  ) {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), tmpPrefix));
+    const workspace = path.join(root, "workspace");
+    const commandPath = path.join(root, "codex");
+    await fs.mkdir(workspace, { recursive: true });
+    await commandWriter(commandPath);
+    const previousHome = process.env.HOME;
+    process.env.HOME = root;
+    await seedSharedCodexAuth(root);
+    try {
+      return await execute({
+        runId,
+        agent: {
+          id: "agent-1",
+          companyId: "company-1",
+          name: "Codex Coder",
+          adapterType: "codex_local",
+          adapterConfig: { engine: "cli" },
+        },
+        runtime: {
+          sessionId: null,
+          sessionParams: null,
+          sessionDisplayId: null,
+          taskKey: null,
+        },
+        config: {
+          engine: "cli",
+          command: commandPath,
+          cwd: workspace,
+          promptTemplate: "Follow the paperclip heartbeat.",
+        },
+        context: {},
+        authToken: "run-jwt-token",
+        onLog: async () => {},
+      });
+    } finally {
+      if (previousHome === undefined) delete process.env.HOME;
+      else process.env.HOME = previousHome;
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  }
+
+  it("does not classify a failed run as transient from conversation stdout alone", async () => {
+    const result = await runCodexExecute(
+      "run-codex-conversation-keywords",
+      "paperclip-codex-execute-conversation-keywords-",
+      (commandPath) =>
+        writeStreamingCodexCommand(commandPath, {
+          exitCode: 1,
+          stdoutLines: [
+            { type: "thread.started", thread_id: "codex-thread-1" },
+            {
+              type: "item.completed",
+              item: {
+                type: "agent_message",
+                text: "We're currently experiencing high demand, which may cause temporary errors. Users saw 429 too many requests and should try again later. You've hit your usage limit was the quota message.",
+              },
+            },
+            { type: "turn.failed", error: { message: "Something unrelated broke while writing the report." } },
+          ],
+        }),
+    );
+
+    expect(result.exitCode).toBe(1);
+    expect(result.succeeded ?? false).toBe(false);
+    expect(result.errorCode).not.toBe("codex_transient_upstream");
+    expect(result.errorCode).not.toBe("provider_quota");
+    expect(result.errorFamily ?? null).toBeNull();
+    expect(result.errorMessage).toContain("Something unrelated broke");
+  });
+
+  it("treats a completed turn as success even when the process exits nonzero", async () => {
+    const result = await runCodexExecute(
+      "run-codex-cleanup-kill",
+      "paperclip-codex-execute-cleanup-kill-",
+      (commandPath) =>
+        writeStreamingCodexCommand(commandPath, {
+          // Simulates terminal-result cleanup SIGTERMing the CLI after a
+          // successful turn (observed as exit 143 in prod).
+          exitCode: 143,
+          stdoutLines: [
+            { type: "thread.started", thread_id: "codex-thread-2" },
+            { type: "item.completed", item: { type: "agent_message", text: "Deployed the fix." } },
+            { type: "turn.completed", usage: { input_tokens: 1, cached_input_tokens: 0, output_tokens: 1 } },
+          ],
+        }),
+    );
+
+    expect(result.exitCode).toBe(143);
+    expect(result.succeeded).toBe(true);
+    expect(result.errorMessage).toBeNull();
+    expect(result.errorCode).toBeNull();
+    expect(result.errorFamily ?? null).toBeNull();
+    expect(result.summary).toBe("Deployed the fix.");
+  });
+});

--- a/server/src/__tests__/gemini-local-execute.test.ts
+++ b/server/src/__tests__/gemini-local-execute.test.ts
@@ -439,3 +439,110 @@ describe("gemini execute", () => {
     }
   });
 });
+
+describe("gemini execute classification isolation", () => {
+  async function runGeminiExecute(
+    runId: string,
+    tmpPrefix: string,
+    commandWriter: (commandPath: string) => Promise<void>,
+  ) {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), tmpPrefix));
+    const workspace = path.join(root, "workspace");
+    const commandPath = path.join(root, "gemini");
+    await fs.mkdir(workspace, { recursive: true });
+    await commandWriter(commandPath);
+    const previousHome = process.env.HOME;
+    process.env.HOME = root;
+    try {
+      return await execute({
+        runId,
+        agent: {
+          id: "agent-1",
+          companyId: "company-1",
+          name: "Gemini Coder",
+          adapterType: "gemini_local",
+          adapterConfig: { engine: "cli" },
+        },
+        runtime: {
+          sessionId: null,
+          sessionParams: null,
+          sessionDisplayId: null,
+          taskKey: null,
+        },
+        config: {
+          engine: "cli",
+          command: commandPath,
+          cwd: workspace,
+          model: "gemini-2.5-pro",
+          promptTemplate: "Follow the paperclip heartbeat.",
+        },
+        context: {},
+        authToken: "run-jwt-token",
+        onLog: async () => {},
+      });
+    } finally {
+      if (previousHome === undefined) delete process.env.HOME;
+      else process.env.HOME = previousHome;
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  }
+
+  it("does not mis-code a failed run whose conversation mentions auth or network errors", async () => {
+    const result = await runGeminiExecute(
+      "run-gemini-conversation-keywords",
+      "paperclip-gemini-execute-conversation-keywords-",
+      (commandPath) =>
+        writeFailingGeminiCommand(commandPath, {
+          exitCode: 1,
+          stdoutLines: [
+            { type: "system", subtype: "init", session_id: "gemini-session-2" },
+            {
+              type: "message",
+              role: "assistant",
+              content:
+                "The user is not authenticated; login required per the docs. I also saw ENOTFOUND oauth2.googleapis.com and 429 quota errors in the logs.",
+            },
+            {
+              type: "result",
+              subtype: "error",
+              session_id: "gemini-session-2",
+              status: "error",
+              error: "Something unrelated broke while writing the report.",
+            },
+          ],
+        }),
+    );
+
+    expect(result.exitCode).toBe(1);
+    expect(result.succeeded ?? false).toBe(false);
+    expect(result.errorCode).toBeNull();
+    expect(result.errorMessage).toContain("Something unrelated broke");
+  });
+
+  it("treats a structured success result as success even when the process exits nonzero", async () => {
+    const result = await runGeminiExecute(
+      "run-gemini-cleanup-kill",
+      "paperclip-gemini-execute-cleanup-kill-",
+      (commandPath) =>
+        writeFailingGeminiCommand(commandPath, {
+          // Simulates terminal-result cleanup SIGTERMing the CLI after a
+          // successful result (observed as exit 143 in prod).
+          exitCode: 143,
+          stdoutLines: [
+            { type: "system", subtype: "init", session_id: "gemini-session-3" },
+            {
+              type: "assistant",
+              message: { content: [{ type: "output_text", text: "Deployed the fix." }] },
+            },
+            { type: "result", subtype: "success", session_id: "gemini-session-3", result: "ok" },
+          ],
+        }),
+    );
+
+    expect(result.exitCode).toBe(143);
+    expect(result.succeeded).toBe(true);
+    expect(result.errorMessage).toBeNull();
+    expect(result.errorCode).toBeNull();
+    expect(result.summary).toContain("Deployed the fix.");
+  });
+});


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The heartbeat scheduler runs each agent on an interval via provider adapters and classifies every run's outcome to decide whether to retry
> - PR #9548 fixed `claude-local` mis-coding successful runs as `claude_transient_upstream`/`claude_auth_required` because keyword classifiers scanned the full stream-json stdout, including the agent's own conversation; its Risks section explicitly flagged that `codex-local` and `gemini-local` still feed full JSONL stdout into the same kind of keyword classifiers and need the equivalent restriction
> - This pull request is that follow-up: a run whose agent merely *discusses* rate limits, auth, or network errors can currently be mis-coded `codex_transient_upstream`, `gemini_auth_required`, etc., chaining full-cost `transient_failure` retries — the exact storm shape measured in #9548 (1,052 mis-coded runs in 14 days on one instance for claude-local alone)
> - The fix hoists a shared classification-haystack builder into `adapter-utils` so "never scan the conversation; classify only on failure" is mechanism rather than per-adapter convention, and both adapters now report explicit structured success
> - The benefit is that codex/gemini heartbeats can no longer be retried as transient failures because of what the agent talked about, and successful runs killed by terminal-result cleanup are not mis-recorded as failures

## Linked Issues or Issue Description

Refs #9548 (claude-local fix; names this codex/gemini follow-up in its Risks section). Refs #5553, #9288, #4488, #9294 (adjacent classification/retry-storm work linked from #9548).

**Describe the bug:** `codex-local` and `gemini-local` feed full JSONL stdout — including the agent conversation — into keyword error classifiers (`isCodexProviderQuotaError`, `isCodexTransientUpstreamError`, `classifyCodexAuthRefreshFailure`, `isGeminiProviderQuotaError`, `isGeminiAuthRequiredError`, and session/network probes). A run whose conversation mentions rate limits, `/login`, 429s, retries, etc. can be mis-coded with a transient/auth/quota error code even when the failure is unrelated — or when the run actually succeeded and only the exit code was dirtied by cleanup. Each mis-coded run schedules `scheduled_retry_reason=transient_failure` re-runs at full model cost.

**Expected behavior:** Only structured error output (failure-shaped JSONL events: `error`, `turn.failed`, system-error, error results), parsed error messages, and stderr drive classification; conversation event lines never reach the keyword matchers; classification runs only when the run actually failed; a structured completed turn / non-error result is authoritative success even when the process exit code is nonzero.

## What Changed

- `adapter-utils`: new shared `buildErrorClassificationHaystack` / `stripJsonlEventLines` (`packages/adapter-utils/src/classification.ts`). JSONL event lines are stripped *inside* the builder; error text is extracted from failure-shaped events so genuine structured errors stay classifiable while conversation events stay invisible
- `adapter-utils`: optional `succeeded?: boolean | null` on `AdapterExecutionResult` — same advisory-unless-true semantics as the field #9548 adds (identical definition; whichever PR lands second rebases trivially). Server-side consumption of the field is in #9548 and not duplicated here
- `codex-local`: quota/transient/auth-refresh/session classifiers all use the shared builder; classification is gated on actual failure (`!parsedSucceeded && exitCode !== 0`); parser reports `succeeded` on a completed turn with no error events; session-recovery probes receive the parsed structured error message
- `gemini-local`: same treatment; structured success requires a non-error result event *and* no parsed error message
- Regression tests at builder, parser, and execute level: conversation text mentioning 429/auth/rate-limits no longer classifies; structured error events still classify; cleanup-SIGTERM after structured success is not a failure

## Verification

- `npx vitest run packages/adapter-utils/src/classification.test.ts packages/adapters/codex-local/src/server/parse.test.ts packages/adapters/gemini-local/src/server/parse.test.ts` — 54 passed
- `npx vitest run packages/adapters/gemini-local/src/server/test.ts` — 19 passed
- `npx vitest run src/__tests__/codex-local-execute.test.ts src/__tests__/gemini-local-execute.test.ts` in `server` — 25 passed
- `npx tsc --noEmit` in `packages/adapter-utils`, `packages/adapters/codex-local`, `packages/adapters/gemini-local` — clean
- Execute-level regression tests were verified to fail against the pre-fix code

## Risks

- Behavioral shift: codex/gemini runs that previously (incorrectly) chained transient retries now finalize with their real outcome — intended, but dashboards keying on `codex_transient_upstream` / `gemini_*` error-code volume will show a drop
- `succeeded` is optional and advisory when `false`/absent, so no server behavior changes until #9548's server-side consumption lands; the two PRs add an identical field definition and the second one to merge needs a trivial rebase
- Structured error-event text extraction in the shared builder is intentionally conservative (only failure-shaped event types); an adapter emitting errors in a novel event shape would fall back to stderr/parsed-message classification

## Model Used

Claude Fable 5 (`claude-fable-5`), extended thinking enabled, agentic tool use via Claude Code CLI.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass