### PR TITLE
fix(server): keep config.provider in restricted environment views

### DIFF
--- a/server/src/routes/environments-redaction.test.ts
+++ b/server/src/routes/environments-redaction.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { redactEnvironmentForRestrictedView } from "./environments.js";
+
+describe("redactEnvironmentForRestrictedView", () => {
+  const base = {
+    id: "env-1",
+    name: "Kubernetes Sandbox",
+    driver: "sandbox",
+    status: "active",
+  };
+
+  it("keeps the non-secret config.provider discriminator while dropping the rest of config", () => {
+    const redacted = redactEnvironmentForRestrictedView({
+      ...base,
+      config: {
+        provider: "kubernetes",
+        inCluster: true,
+        namespacePrefix: "paperclip-tenant-",
+        imageRegistry: "ghcr.io/example",
+      },
+      envVars: { KUBECONFIG_B64: "c2VjcmV0" },
+      metadata: { managedByPaperclip: true, managedKubernetesSandbox: true },
+    });
+
+    expect(redacted.config).toEqual({ provider: "kubernetes" });
+    expect(redacted.envVars).toEqual({});
+    expect(redacted.metadata).toBeNull();
+  });
+
+  it("returns an empty config when there is no string provider", () => {
+    expect(
+      redactEnvironmentForRestrictedView({
+        ...base,
+        config: { image: "ubuntu:24.04" },
+        metadata: null,
+      }).config,
+    ).toEqual({});
+    expect(
+      redactEnvironmentForRestrictedView({
+        ...base,
+        config: null,
+        metadata: null,
+      }).config,
+    ).toEqual({});
+    expect(
+      redactEnvironmentForRestrictedView({
+        ...base,
+        config: { provider: 42 },
+        metadata: null,
+      }).config,
+    ).toEqual({});
+  });
+
+  it("omits envVars when the input has no envVars key", () => {
+    const redacted = redactEnvironmentForRestrictedView({
+      ...base,
+      config: { provider: "kubernetes" },
+      metadata: { managedByPaperclip: true },
+    });
+    expect(Object.prototype.hasOwnProperty.call(redacted, "envVars")).toBe(false);
+  });
+});

--- a/server/src/routes/environments.ts
+++ b/server/src/routes/environments.ts
@@ -50,6 +50,28 @@ import type { PluginWorkerManager } from "../services/plugin-worker-manager.js";
 import { environmentService } from "../services/environments.js";
 import { executionWorkspaceService } from "../services/execution-workspaces.js";
 
+/**
+ * Restricted (non-instance-admin) viewers must not see environment secrets or
+ * operator configuration, but they still need to know an environment's kind:
+ * the UI resolves the managed Kubernetes sandbox via `config.provider` (see
+ * `resolveForcedKubernetesEnvironment`), so a fully-empty redacted config makes
+ * a forced-Kubernetes instance look unconfigured to every restricted viewer.
+ * Keep only the non-secret `provider` discriminator; drop everything else.
+ */
+export function redactEnvironmentForRestrictedView<T extends {
+  config: Record<string, unknown> | null;
+  envVars?: Record<string, unknown> | null;
+  metadata: Record<string, unknown> | null;
+}>(environment: T): T {
+  const provider = environment.config?.provider;
+  return {
+    ...environment,
+    config: typeof provider === "string" ? { provider } : {},
+    ...(Object.prototype.hasOwnProperty.call(environment, "envVars") ? { envVars: {} } : {}),
+    metadata: null,
+  };
+}
+
 export function environmentRoutes(
   db: Db,
   options: { pluginWorkerManager?: PluginWorkerManager } = {},
@@ -98,19 +120,6 @@ export function environmentRoutes(
   function canReadFullInstanceEnvironment(req: Request) {
     return req.actor.type === "board"
       && (req.actor.source === "local_implicit" || req.actor.isInstanceAdmin);
-  }
-
-  function redactEnvironmentForRestrictedView<T extends {
-    config: Record<string, unknown> | null;
-    envVars?: Record<string, unknown> | null;
-    metadata: Record<string, unknown> | null;
-  }>(environment: T): T {
-    return {
-      ...environment,
-      config: {},
-      ...(Object.prototype.hasOwnProperty.call(environment, "envVars") ? { envVars: {} } : {}),
-      metadata: null,
-    };
   }
 
   function presentEnvironmentForRead<T extends {


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Multi-user instances can force all agent execution onto the managed Kubernetes sandbox (`executionMode=kubernetes`), and the environments API redacts environment details for restricted (non-instance-admin) viewers so operator configuration and secrets stay private
> - The redaction strips the entire `config` object, but the UI identifies the managed Kubernetes sandbox by `config.provider === "kubernetes"` (`resolveForcedKubernetesEnvironment`)
> - Every restricted viewer on a forced-Kubernetes instance therefore sees the agent configuration page claim no managed Kubernetes environment exists, and agent creation cannot default to it, even though the environment is present and active
> - Instance admins see the unredacted view, so the regression is invisible to the operators most likely to test the flow
> - This pull request preserves only the non-secret `provider` discriminator during redaction while still stripping all other config keys, `envVars`, and `metadata`
> - The benefit is that restricted viewers on forced-Kubernetes instances get a working environment display and correct agent-creation defaults, with no change to what stays hidden

## Linked Issues or Issue Description

No public issue exists for this; inline issue description following `bug_report.yml`:

### What happened?

On an instance with `executionMode=kubernetes` and an active managed Kubernetes sandbox environment, any non-instance-admin user opening an agent's Configuration page sees the amber warning "This instance requires the Kubernetes sandbox, but no managed Kubernetes environment is available for this company yet. Configure one before creating agents; execution will not fall back to local." In agent create mode, `defaultEnvironmentId` is not defaulted to the managed environment. Root cause: `GET /companies/:companyId/environments` passes rows through `redactEnvironmentForRestrictedView`, which returns `config: {}`; the UI's `isKubernetesSandboxEnvironment` then finds no environment with `config.provider === "kubernetes"`.

### Expected behavior

The read-only environment field shows "<name> · Kubernetes sandbox", and agent create mode defaults to the managed Kubernetes environment.

### Steps to reproduce

1. Set `PAPERCLIP_EXECUTION_MODE=kubernetes` so the execution-policy bootstrap persists the forced mode and provisions the managed environment.
2. Sign in as a board user who is neither `local_implicit` nor instance admin.
3. Open any agent's Configuration page (or the create-agent form).

### Paperclip version or commit

`master` (903bd157c at time of writing).

### Deployment mode

Server deployment (multi-user instance).

## What Changed

- `server/src/routes/environments.ts`: `redactEnvironmentForRestrictedView` now preserves `config.provider` when it is a string; all other `config` keys, `envVars` values, and `metadata` are stripped exactly as before. The helper moved out of the router factory closure (it uses no closure state) and is exported for unit testing.
- `server/src/routes/environments-redaction.test.ts`: new unit tests for the redaction helper.

## Verification

- `cd server && npx vitest run src/routes/environments-redaction.test.ts` (3 tests pass; the provider-preservation assertion was written first and observed failing against the previous implementation)
- Manual: as a non-instance-admin user on a forced-Kubernetes instance, `GET /api/companies/:companyId/environments` now returns the sandbox row with `config: {"provider": "kubernetes"}` and the agent Configuration page shows the environment instead of the warning

## Risks

- Low risk. The change widens the redacted view by exactly one field, `config.provider`, which is a driver/provider discriminator (same vocabulary as the public capabilities endpoint), not a credential or operator setting. Everything previously hidden except `provider` remains hidden.

## Model Used

Claude Fable 5 (claude-fable-5, Anthropic) via Claude Code CLI, with extended thinking and tool use (code search, test execution).

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
