### PR TITLE
fix: read local-service process cwd on macOS so live services can be adopted

### DIFF
--- a/server/src/__tests__/heartbeat-workspace-branch-containment.test.ts
+++ b/server/src/__tests__/heartbeat-workspace-branch-containment.test.ts
@@ -1,6 +1,6 @@
 import { execFile } from "node:child_process";
 import { createHash, randomUUID } from "node:crypto";
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, realpath, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
@@ -129,7 +129,9 @@ async function readGit(cwd: string, args: string[]) {
 }
 
 async function createGitRepo() {
-  const repoRoot = await mkdtemp(path.join(os.tmpdir(), "paperclip-branch-containment-repo-"));
+  // realpath: on macOS os.tmpdir() is a symlink (/tmp -> /private/tmp) and the
+  // runtime persists resolved worktree paths, so unresolved fixtures never match.
+  const repoRoot = await realpath(await mkdtemp(path.join(os.tmpdir(), "paperclip-branch-containment-repo-")));
   await runGit(repoRoot, ["init"]);
   await runGit(repoRoot, ["config", "user.email", "paperclip-test@example.com"]);
   await runGit(repoRoot, ["config", "user.name", "Paperclip Test"]);

--- a/server/src/services/local-service-supervisor.ts
+++ b/server/src/services/local-service-supervisor.ts
@@ -419,12 +419,25 @@ export async function readLocalServicePortOwner(port: number) {
 }
 
 export async function readLocalServiceProcessCwd(pid: number) {
-  if (!Number.isInteger(pid) || pid <= 0 || process.platform !== "linux") return null;
-  try {
-    return await fs.readlink(`/proc/${pid}/cwd`);
-  } catch {
-    return null;
+  if (!Number.isInteger(pid) || pid <= 0) return null;
+  if (process.platform === "linux") {
+    try {
+      return await fs.readlink(`/proc/${pid}/cwd`);
+    } catch {
+      return null;
+    }
   }
+  if (process.platform === "darwin") {
+    // No /proc on macOS; lsof -Fn prints the cwd as an "n"-prefixed field line.
+    try {
+      const { stdout } = await execFileAsync("lsof", ["-a", "-p", String(pid), "-d", "cwd", "-Fn"]);
+      const cwdLine = stdout.split("\n").find((line) => line.startsWith("n"));
+      return cwdLine ? cwdLine.slice(1) : null;
+    } catch {
+      return null;
+    }
+  }
+  return null;
 }
 
 export async function isLocalServiceProcessInWorkspace(processCwd: string, workspaceCwd: string) {


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The workspace runtime supervises long-lived shared services (dev servers, etc.) and re-adopts still-running processes after a server restart instead of killing them
> - Adoption verifies a candidate process by checking that its working directory sits inside the workspace, via `readLocalServiceProcessCwd`
> - That helper reads `/proc/<pid>/cwd`, which only exists on Linux — on macOS it returns `null`, and `adoptLocalServiceFromPortOwner` treats a null cwd as unverifiable and rejects the candidate
> - So on macOS, live shared services are never adopted after a restart; reconciliation stops them instead, and the suite's adoption test fails deterministically (`adopted: 0, stopped: 1`)
> - This pull request adds a darwin implementation using `lsof -Fn` to read the process cwd, and realpath-resolves a test fixture that assumed `/tmp` is not a symlink
> - The benefit is that macOS deployments keep their running services across restarts, and the server test suite passes on macOS

## Linked Issues or Issue Description

No existing issue found (searched for macOS / service adoption / cwd). Bug description:

- **What happened:** On macOS, `reconcilePersistedRuntimeServicesOnStartup` never adopts a live shared service — it always stops it. Three server tests fail deterministically on a macOS host: `workspace-runtime.test.ts > adopts a live auto-port shared service after runtime state is reset`, and both `heartbeat-workspace-branch-containment.test.ts` forward-divergence auto-reconcile tests.
- **Expected:** A healthy, port-owning process whose cwd is inside the workspace should be adopted, as on Linux.
- **Root cause 1 (product):** `readLocalServiceProcessCwd` in `server/src/services/local-service-supervisor.ts` returns `null` for every non-Linux platform, and the port-owner adoption path requires a non-null, workspace-contained cwd.
- **Root cause 2 (test-only):** the branch-containment fixture builds paths from `os.tmpdir()` without resolving symlinks; on macOS `/tmp -> /private/tmp`, so expected `providerRef` paths never match the realpath the runtime persists.
- **Environment:** macOS (Darwin 25.5.0), Node 22.16.0, pnpm 9.15.4.

## What Changed

- `server/src/services/local-service-supervisor.ts`: `readLocalServiceProcessCwd` now has a darwin branch that reads the process cwd via `lsof -a -p <pid> -d cwd -Fn` (no `/proc` on macOS). Linux behavior unchanged; other platforms still return `null`.
- `server/src/__tests__/heartbeat-workspace-branch-containment.test.ts`: realpath-resolve the `mkdtemp` repo fixture so path assertions are symlink-safe.

## Verification

On macOS (Darwin 25.5.0):
- `pnpm exec vitest run server/src/__tests__/workspace-runtime.test.ts` — 96/96 pass (previously 1 failure)
- `pnpm exec vitest run server/src/__tests__/heartbeat-workspace-branch-containment.test.ts` — 6/6 pass (previously 2 failures)
- Full `pnpm test:run` — 2721/2723 pass, 1 skipped (the single remaining failure is an unrelated pre-existing concurrency flake in `issue-monitor-scheduler.test.ts` that passes 7/7 in isolation)
- `tsc --noEmit` on the server package — clean

Manual: with a shared auto-port service running, wiping runtime state and re-running startup reconciliation now reports `adopted: 1, stopped: 0` on macOS.

## Risks

Low risk. The darwin branch is additive and fail-soft: any `lsof` error returns `null`, which is exactly today's behavior. Linux and Windows paths are untouched. `lsof` ships with macOS. The stricter cwd check in the port-owner adoption path now actually runs on macOS, which is the intended safety behavior rather than a behavioral risk.

## Model Used

Claude Fable 5 (Anthropic, model ID `claude-fable-5`), used via Claude Code with extended thinking and tool use (code search, test execution, git). Diagnosis, fix, and verification were model-driven; a human reviewed and approved the change.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above (none found)
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable (existing tests now exercise the darwin path; fixture made symlink-safe)
- [x] I have updated relevant documentation to reflect my changes (none applicable — internal helper)
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green (pending first CI run on this PR)
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups (pending)
- [x] I will address all Greptile and reviewer comments before requesting merge
