### PR TITLE
feat(billing): add Stripe subscription primitives

### DIFF
--- a/packages/db/src/migrations/0182_company_tiers.sql
+++ b/packages/db/src/migrations/0182_company_tiers.sql
@@ -1,0 +1,5 @@
+ALTER TABLE "companies" ADD COLUMN "tier" text NOT NULL DEFAULT 'starter';
+--> statement-breakpoint
+ALTER TABLE "companies" ADD COLUMN "tier_changed_at" timestamp with time zone;
+--> statement-breakpoint
+CREATE INDEX "companies_tier_idx" ON "companies" USING btree ("tier");

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -1261,6 +1261,13 @@
       "when": 1784231633059,
       "tag": "0181_decision_training_retention_policy",
       "breakpoints": true
+    },
+    {
+      "idx": 182,
+      "version": "7",
+      "when": 1784574300000,
+      "tag": "0182_company_tiers",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/companies.ts
+++ b/packages/db/src/schema/companies.ts
@@ -27,6 +27,8 @@ export const companies = pgTable(
     feedbackDataSharingConsentByUserId: text("feedback_data_sharing_consent_by_user_id"),
     feedbackDataSharingTermsVersion: text("feedback_data_sharing_terms_version"),
     brandColor: text("brand_color"),
+    tier: text("tier").notNull().default("starter"),
+    tierChangedAt: timestamp("tier_changed_at", { withTimezone: true }),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },

--- a/server/src/services/index.ts
+++ b/server/src/services/index.ts
@@ -80,6 +80,16 @@ export { backfillLegacyToolOAuthTokens } from "./tool-oauth-legacy-backfill.js";
 export { toolAccessPolicyService } from "./tool-access-policy.js";
 export { routineService } from "./routines.js";
 export { costService } from "./costs.js";
+export {
+  buildBillingPreview,
+  calculateOverage,
+  classifyUsageBilling,
+  createCheckoutSession,
+  createPortalSession,
+  resolveStripePriceId,
+  TIERS,
+  usageMeteringService,
+} from "./usage-metering.js";
 export { financeService } from "./finance.js";
 export { heartbeatService, resolveHeartbeatSchedulingSuppression } from "./heartbeat.js";
 export {

--- a/server/src/services/usage-metering.test.ts
+++ b/server/src/services/usage-metering.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildBillingPreview,
+  calculateOverage,
+  classifyUsageBilling,
+  createCheckoutSession,
+  createPortalSession,
+  resolveStripePriceId,
+  TIERS,
+} from "./usage-metering.js";
+
+describe("classifyUsageBilling", () => {
+  it("bills managed metered usage", () => {
+    expect(classifyUsageBilling("metered_api")).toBe("billable");
+  });
+
+  it("skips customer-paid and subscription usage", () => {
+    expect(classifyUsageBilling("subscription_included")).toBe("customer_paid");
+    expect(classifyUsageBilling("subscription_overage")).toBe("customer_paid");
+  });
+
+  it("does not silently waive unknown usage", () => {
+    expect(classifyUsageBilling("unknown")).toBe("needs_review");
+    expect(classifyUsageBilling(null)).toBe("needs_review");
+  });
+});
+
+describe("calculateOverage", () => {
+  it("multiplies the included allowance by seat count", () => {
+    expect(calculateOverage(18_000, TIERS.pro, 3)).toEqual({
+      includedAllowanceCents: 15_000,
+      actualCostCents: 18_000,
+      overageCents: 3_000,
+      overageMarkupCents: 450,
+      totalOverageCents: 3_450,
+      markupPercent: 15,
+    });
+  });
+
+  it("never charges overage below the included allowance", () => {
+    expect(calculateOverage(4_999, TIERS.pro, 1).totalOverageCents).toBe(0);
+  });
+});
+
+describe("buildBillingPreview", () => {
+  it("adds seat subscription and managed usage overage", () => {
+    expect(buildBillingPreview({ tier: "pro", seatCount: 3, actualCostCents: 18_000 })).toEqual({
+      tier: "pro",
+      seatCount: 3,
+      subscriptionCents: 6_000,
+      includedAllowanceCents: 15_000,
+      managedUsageCents: 18_000,
+      overageCents: 3_000,
+      markupCents: 450,
+      projectedInvoiceCents: 9_450,
+      usageBilling: "billable",
+    });
+  });
+
+  it("charges seats but skips usage when the customer pays the provider", () => {
+    expect(
+      buildBillingPreview({
+        tier: "team",
+        seatCount: 2,
+        actualCostCents: 90_000,
+        usageBilling: "customer_paid",
+      }),
+    ).toMatchObject({
+      subscriptionCents: 10_000,
+      includedAllowanceCents: 40_000,
+      overageCents: 0,
+      markupCents: 0,
+      projectedInvoiceCents: 10_000,
+      usageBilling: "customer_paid",
+    });
+  });
+
+  it("rejects tiers without a published seat price", () => {
+    expect(() => buildBillingPreview({ tier: "enterprise", seatCount: 1, actualCostCents: 0 }))
+      .toThrow("Tier enterprise requires custom billing configuration");
+  });
+});
+
+describe("Stripe subscription requests", () => {
+  it("resolves monthly and annual price IDs from explicit environment keys", () => {
+    expect(resolveStripePriceId("pro", "monthly", { STRIPE_PRICE_PRO_MONTHLY: "price_pro" })).toBe("price_pro");
+    expect(resolveStripePriceId("team", "annual", { STRIPE_PRICE_TEAM_ANNUAL: "price_team_annual" })).toBe("price_team_annual");
+  });
+
+  it("fails closed when a Stripe price is not configured", () => {
+    expect(() => resolveStripePriceId("pro", "monthly", {})).toThrow(
+      "Missing STRIPE_PRICE_PRO_MONTHLY",
+    );
+  });
+
+  it("creates a seat-quantity Checkout Session without exposing the secret", async () => {
+    const calls: Array<{ url: string; init?: RequestInit }> = [];
+    const fetcher = async (url: string | URL | Request, init?: RequestInit) => {
+      calls.push({ url: String(url), init });
+      return new Response(JSON.stringify({ id: "cs_test_123", url: "https://checkout.stripe.test/session" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    };
+
+    await expect(createCheckoutSession({
+      secretKey: "sk_test_secret",
+      priceId: "price_pro_monthly",
+      companyId: "company-123",
+      seatCount: 3,
+      successUrl: "https://app.test/billing?success=1",
+      cancelUrl: "https://app.test/billing?cancelled=1",
+      fetcher,
+    })).resolves.toEqual({ id: "cs_test_123", url: "https://checkout.stripe.test/session" });
+
+    expect(calls[0]?.url).toBe("https://api.stripe.com/v1/checkout/sessions");
+    expect(calls[0]?.init?.headers).toMatchObject({ Authorization: "Bearer sk_test_secret" });
+    const body = calls[0]?.init?.body as URLSearchParams;
+    expect(body.get("mode")).toBe("subscription");
+    expect(body.get("client_reference_id")).toBe("company-123");
+    expect(body.get("line_items[0][price]")).toBe("price_pro_monthly");
+    expect(body.get("line_items[0][quantity]")).toBe("3");
+  });
+
+  it("fails closed when Stripe rejects a request", async () => {
+    const fetcher = async () => new Response(JSON.stringify({ error: { message: "invalid price" } }), {
+      status: 400,
+      headers: { "content-type": "application/json" },
+    });
+    await expect(createCheckoutSession({
+      secretKey: "sk_test_secret",
+      priceId: "price_bad",
+      companyId: "company-123",
+      seatCount: 1,
+      successUrl: "https://app.test/success",
+      cancelUrl: "https://app.test/cancel",
+      fetcher,
+    })).rejects.toThrow("Stripe request failed (400): invalid price");
+  });
+
+  it("creates a customer portal session", async () => {
+    const fetcher = async (_url: string | URL | Request, init?: RequestInit) => {
+      const body = init?.body as URLSearchParams;
+      expect(body.get("customer")).toBe("cus_123");
+      expect(body.get("return_url")).toBe("https://app.test/billing");
+      return new Response(JSON.stringify({ url: "https://billing.stripe.test/session" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    };
+    await expect(createPortalSession({
+      secretKey: "sk_test_secret",
+      customerId: "cus_123",
+      returnUrl: "https://app.test/billing",
+      fetcher,
+    })).resolves.toEqual({ url: "https://billing.stripe.test/session" });
+  });
+});

--- a/server/src/services/usage-metering.ts
+++ b/server/src/services/usage-metering.ts
@@ -1,0 +1,366 @@
+import { and, eq, gte, lt, sql } from "drizzle-orm";
+import type { Db } from "@paperclipai/db";
+import { costEvents } from "@paperclipai/db";
+
+// ── Types ──────────────────────────────────────────────────────────
+
+export type UsageWindow = {
+  start: Date;
+  end: Date;
+};
+
+export type UsageSummary = {
+  companyId: string;
+  agentId: string | null;
+  totalCostCents: number;
+  totalInputTokens: number;
+  totalOutputTokens: number;
+  totalCachedInputTokens: number;
+  eventCount: number;
+  byProvider: Record<string, { costCents: number; eventCount: number }>;
+  byModel: Record<string, { costCents: number; eventCount: number }>;
+  byBillingType: Record<string, { costCents: number; eventCount: number }>;
+};
+
+export type OverageResult = {
+  includedAllowanceCents: number;
+  actualCostCents: number;
+  overageCents: number;
+  overageMarkupCents: number;
+  totalOverageCents: number;
+  markupPercent: number;
+};
+
+export type TierConfig = {
+  name: string;
+  seatPriceCents: number | null;
+  includedAllowanceCents: number;
+  overageMarkupPercent: number;
+};
+
+// ── Tier defaults (from HOL-46 pricing strategy) ──────────────────
+
+export const TIERS: Record<string, TierConfig> = {
+  free: { name: "Free", seatPriceCents: 0, includedAllowanceCents: 0, overageMarkupPercent: 0 },
+  pro: { name: "Pro", seatPriceCents: 2_000, includedAllowanceCents: 5_000, overageMarkupPercent: 15 },
+  team: { name: "Team", seatPriceCents: 5_000, includedAllowanceCents: 20_000, overageMarkupPercent: 10 },
+  enterprise: { name: "Enterprise", seatPriceCents: null, includedAllowanceCents: 0, overageMarkupPercent: 0 },
+};
+
+export type UsageBillingDisposition = "billable" | "customer_paid" | "needs_review";
+
+export function classifyUsageBilling(billingType: string | null): UsageBillingDisposition {
+  if (billingType === "metered_api") return "billable";
+  if (billingType === "subscription_included" || billingType === "subscription_overage") {
+    return "customer_paid";
+  }
+  return "needs_review";
+}
+
+export type BillingPreview = {
+  tier: string;
+  seatCount: number;
+  subscriptionCents: number;
+  includedAllowanceCents: number;
+  managedUsageCents: number;
+  overageCents: number;
+  markupCents: number;
+  projectedInvoiceCents: number;
+  usageBilling: UsageBillingDisposition;
+};
+
+export function buildBillingPreview(input: {
+  tier: string;
+  seatCount: number;
+  actualCostCents: number;
+  usageBilling?: UsageBillingDisposition;
+}): BillingPreview {
+  const tier = TIERS[input.tier];
+  if (!tier) throw new RangeError(`Unknown billing tier ${input.tier}`);
+  if (tier.seatPriceCents === null) {
+    throw new RangeError(`Tier ${input.tier} requires custom billing configuration`);
+  }
+  if (!Number.isInteger(input.seatCount) || input.seatCount < 1) {
+    throw new RangeError("seatCount must be a positive integer");
+  }
+  const usageBilling = input.usageBilling ?? "billable";
+  const managedUsageCents = usageBilling === "billable" ? input.actualCostCents : 0;
+  const overage = calculateOverage(managedUsageCents, tier, input.seatCount);
+  const subscriptionCents = tier.seatPriceCents * input.seatCount;
+  return {
+    tier: input.tier,
+    seatCount: input.seatCount,
+    subscriptionCents,
+    includedAllowanceCents: overage.includedAllowanceCents,
+    managedUsageCents,
+    overageCents: overage.overageCents,
+    markupCents: overage.overageMarkupCents,
+    projectedInvoiceCents: subscriptionCents + overage.totalOverageCents,
+    usageBilling,
+  };
+}
+
+type StripeFetch = typeof fetch;
+
+export function resolveStripePriceId(
+  tier: "pro" | "team",
+  billingCycle: "monthly" | "annual",
+  env: Record<string, string | undefined> = process.env,
+): string {
+  const key = `STRIPE_PRICE_${tier.toUpperCase()}_${billingCycle.toUpperCase()}`;
+  const priceId = env[key]?.trim();
+  if (!priceId) throw new Error(`Missing ${key}`);
+  return priceId;
+}
+
+async function postStripeForm<T>(
+  path: string,
+  secretKey: string,
+  body: URLSearchParams,
+  fetcher: StripeFetch,
+): Promise<T> {
+  const response = await fetcher(`https://api.stripe.com/v1/${path}`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${secretKey}`,
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+    body,
+  });
+  const payload = await response.json() as { error?: { message?: string } } & T;
+  if (!response.ok) {
+    throw new Error(`Stripe request failed (${response.status}): ${payload.error?.message ?? response.statusText}`);
+  }
+  return payload;
+}
+
+export function createCheckoutSession(input: {
+  secretKey: string;
+  priceId: string;
+  companyId: string;
+  seatCount: number;
+  successUrl: string;
+  cancelUrl: string;
+  customerId?: string;
+  fetcher?: StripeFetch;
+}) {
+  if (!Number.isInteger(input.seatCount) || input.seatCount < 1) {
+    throw new RangeError("seatCount must be a positive integer");
+  }
+  const body = new URLSearchParams({
+    mode: "subscription",
+    client_reference_id: input.companyId,
+    success_url: input.successUrl,
+    cancel_url: input.cancelUrl,
+    "line_items[0][price]": input.priceId,
+    "line_items[0][quantity]": String(input.seatCount),
+    "subscription_data[metadata][company_id]": input.companyId,
+  });
+  if (input.customerId) body.set("customer", input.customerId);
+  return postStripeForm<{ id: string; url: string | null }>(
+    "checkout/sessions",
+    input.secretKey,
+    body,
+    input.fetcher ?? fetch,
+  );
+}
+
+export function createPortalSession(input: {
+  secretKey: string;
+  customerId: string;
+  returnUrl: string;
+  fetcher?: StripeFetch;
+}) {
+  return postStripeForm<{ url: string }>(
+    "billing_portal/sessions",
+    input.secretKey,
+    new URLSearchParams({ customer: input.customerId, return_url: input.returnUrl }),
+    input.fetcher ?? fetch,
+  );
+}
+
+// ── Service ────────────────────────────────────────────────────────
+
+export function calculateOverage(
+  actualCostCents: number,
+  tier: TierConfig,
+  seatCount = 1,
+): OverageResult {
+  if (!Number.isInteger(seatCount) || seatCount < 1) {
+    throw new RangeError("seatCount must be a positive integer");
+  }
+  const includedAllowanceCents = tier.includedAllowanceCents * seatCount;
+  const overageCents = Math.max(0, actualCostCents - includedAllowanceCents);
+  const overageMarkupCents = Math.round(overageCents * (tier.overageMarkupPercent / 100));
+  return {
+    includedAllowanceCents,
+    actualCostCents,
+    overageCents,
+    overageMarkupCents,
+    totalOverageCents: overageCents + overageMarkupCents,
+    markupPercent: tier.overageMarkupPercent,
+  };
+}
+
+export function usageMeteringService(db: Db) {
+  /**
+   * Aggregate usage for a company (optionally scoped to an agent) over a time window.
+   */
+  async function getUsage(
+    companyId: string,
+    window: UsageWindow,
+    agentId?: string,
+  ): Promise<UsageSummary> {
+    const conditions = [
+      eq(costEvents.companyId, companyId),
+      gte(costEvents.occurredAt, window.start),
+      lt(costEvents.occurredAt, window.end),
+    ];
+    if (agentId) conditions.push(eq(costEvents.agentId, agentId));
+
+    const rows = await db
+      .select({
+        agentId: costEvents.agentId,
+        provider: costEvents.provider,
+        model: costEvents.model,
+        billingType: costEvents.billingType,
+        costCents: costEvents.costCents,
+        inputTokens: costEvents.inputTokens,
+        outputTokens: costEvents.outputTokens,
+        cachedInputTokens: costEvents.cachedInputTokens,
+      })
+      .from(costEvents)
+      .where(and(...conditions));
+
+    const summary: UsageSummary = {
+      companyId,
+      agentId: agentId ?? null,
+      totalCostCents: 0,
+      totalInputTokens: 0,
+      totalOutputTokens: 0,
+      totalCachedInputTokens: 0,
+      eventCount: rows.length,
+      byProvider: {},
+      byModel: {},
+      byBillingType: {},
+    };
+
+    for (const row of rows) {
+      summary.totalCostCents += row.costCents;
+      summary.totalInputTokens += row.inputTokens;
+      summary.totalOutputTokens += row.outputTokens;
+      summary.totalCachedInputTokens += row.cachedInputTokens;
+
+      const provider = row.provider || "unknown";
+      summary.byProvider[provider] ??= { costCents: 0, eventCount: 0 };
+      summary.byProvider[provider].costCents += row.costCents;
+      summary.byProvider[provider].eventCount++;
+
+      const model = row.model || "unknown";
+      summary.byModel[model] ??= { costCents: 0, eventCount: 0 };
+      summary.byModel[model].costCents += row.costCents;
+      summary.byModel[model].eventCount++;
+
+      const billingType = row.billingType || "unknown";
+      summary.byBillingType[billingType] ??= { costCents: 0, eventCount: 0 };
+      summary.byBillingType[billingType].costCents += row.costCents;
+      summary.byBillingType[billingType].eventCount++;
+    }
+
+    return summary;
+  }
+
+  /**
+   * Detect BYO keys: check if any cost events for this company have billingType
+   * other than "metered_api" (i.e., the user is using their own API keys).
+   * Returns true if BYO keys are detected (skip usage billing).
+   */
+  async function detectBypassBilling(
+    companyId: string,
+    window: UsageWindow,
+  ): Promise<boolean> {
+    const [row] = await db
+      .select({ count: sql<number>`count(*)::int` })
+      .from(costEvents)
+      .where(
+        and(
+          eq(costEvents.companyId, companyId),
+          gte(costEvents.occurredAt, window.start),
+          lt(costEvents.occurredAt, window.end),
+          sql`${costEvents.billingType} IS DISTINCT FROM 'metered_api'`,
+        ),
+      );
+    return (row?.count ?? 0) > 0;
+  }
+
+  /**
+   * Get per-agent usage breakdown for a company.
+   */
+  async function getPerAgentUsage(
+    companyId: string,
+    window: UsageWindow,
+  ): Promise<Map<string, UsageSummary>> {
+    const rows = await db
+      .select({
+        agentId: costEvents.agentId,
+        provider: costEvents.provider,
+        model: costEvents.model,
+        billingType: costEvents.billingType,
+        costCents: costEvents.costCents,
+        inputTokens: costEvents.inputTokens,
+        outputTokens: costEvents.outputTokens,
+        cachedInputTokens: costEvents.cachedInputTokens,
+      })
+      .from(costEvents)
+      .where(
+        and(
+          eq(costEvents.companyId, companyId),
+          gte(costEvents.occurredAt, window.start),
+          lt(costEvents.occurredAt, window.end),
+        ),
+      );
+
+    const map = new Map<string, UsageSummary>();
+    for (const row of rows) {
+      let s = map.get(row.agentId);
+      if (!s) {
+        s = {
+          companyId,
+          agentId: row.agentId,
+          totalCostCents: 0,
+          totalInputTokens: 0,
+          totalOutputTokens: 0,
+          totalCachedInputTokens: 0,
+          eventCount: 0,
+          byProvider: {},
+          byModel: {},
+          byBillingType: {},
+        };
+        map.set(row.agentId, s);
+      }
+      s.totalCostCents += row.costCents;
+      s.totalInputTokens += row.inputTokens;
+      s.totalOutputTokens += row.outputTokens;
+      s.totalCachedInputTokens += row.cachedInputTokens;
+      s.eventCount++;
+
+      const p = row.provider || "unknown";
+      s.byProvider[p] ??= { costCents: 0, eventCount: 0 };
+      s.byProvider[p].costCents += row.costCents;
+      s.byProvider[p].eventCount++;
+
+      const m = row.model || "unknown";
+      s.byModel[m] ??= { costCents: 0, eventCount: 0 };
+      s.byModel[m].costCents += row.costCents;
+      s.byModel[m].eventCount++;
+
+      const bt = row.billingType || "unknown";
+      s.byBillingType[bt] ??= { costCents: 0, eventCount: 0 };
+      s.byBillingType[bt].costCents += row.costCents;
+      s.byBillingType[bt].eventCount++;
+    }
+    return map;
+  }
+
+  return { getUsage, calculateOverage, detectBypassBilling, getPerAgentUsage };
+}


### PR DESCRIPTION
Credential-independent portion of HOL-74.

- aggregates ledger usage and per-agent breakdowns
- calculates seat-scaled allowances and overage markup
- classifies managed vs customer-paid usage fail-closed
- adds Stripe Checkout and customer portal request primitives using native fetch
- adds company tier migration

Verification:
- 13 usage-metering tests pass
- @paperclipai/server typecheck passes
- DB migration numbering/safety checks pass

Not included: live Stripe calls, webhook state sync, and invoice history. Those require Owner-provided Stripe account credentials/product price IDs and external-callback configuration.

Supersedes #9914, whose branch contained an unrelated ancestor commit.