### PR TITLE
fix(agents): gate host-local Claude login when execution is forced to the Kubernetes sandbox

### DIFF
--- a/server/src/__tests__/agent-claude-login-route.test.ts
+++ b/server/src/__tests__/agent-claude-login-route.test.ts
@@ -1,0 +1,133 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockAgentService = vi.hoisted(() => ({
+  getById: vi.fn(),
+}));
+
+const mockAccessService = vi.hoisted(() => ({
+  canUser: vi.fn(),
+  decide: vi.fn(),
+  hasPermission: vi.fn(),
+  getMembership: vi.fn(async () => null),
+  listPrincipalGrants: vi.fn(async () => []),
+}));
+
+const mockSecretService = vi.hoisted(() => ({
+  normalizeAdapterConfigForPersistence: vi.fn(async (_companyId: string, config: Record<string, unknown>) => config),
+  resolveAdapterConfigForRuntime: vi.fn(async (_companyId: string, config: Record<string, unknown>) => ({ config })),
+}));
+
+const mockInstanceSettingsService = vi.hoisted(() => ({
+  getGeneral: vi.fn(async () => ({ censorUsernameInLogs: false })),
+}));
+
+const mockRunClaudeLogin = vi.hoisted(() => vi.fn());
+
+vi.mock("../services/index.js", () => ({
+  agentService: () => mockAgentService,
+  agentInstructionsService: () => ({}),
+  accessService: () => mockAccessService,
+  approvalService: () => ({}),
+  builtInAgentService: () => ({ ensureCompanyDefaultAgentGrants: vi.fn() }),
+  companySkillService: () => ({
+    listRuntimeSkillEntries: vi.fn(async () => []),
+    resolveRequestedSkillKeys: vi.fn(async () => []),
+  }),
+  budgetService: () => ({}),
+  heartbeatService: () => ({
+    wakeup: vi.fn(),
+    cancelActiveForAgent: vi.fn(),
+  }),
+  ISSUE_LIST_DEFAULT_LIMIT: 50,
+  issueApprovalService: () => ({}),
+  issueRecoveryActionService: () => ({}),
+  issueService: () => ({}),
+  logActivity: vi.fn(),
+  syncInstructionsBundleConfigFromFilePath: vi.fn((_agent: unknown, config: unknown) => config),
+  workspaceOperationService: () => ({}),
+}));
+
+vi.mock("../services/secrets.js", () => ({
+  secretService: () => mockSecretService,
+}));
+
+vi.mock("../services/instance-settings.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../services/instance-settings.js")>()),
+  instanceSettingsService: () => mockInstanceSettingsService,
+}));
+
+vi.mock("@paperclipai/adapter-claude-local/server", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@paperclipai/adapter-claude-local/server")>()),
+  runClaudeLogin: mockRunClaudeLogin,
+}));
+
+async function createApp() {
+  const [{ agentRoutes }, { errorHandler }] = await Promise.all([
+    vi.importActual<typeof import("../routes/agents.js")>("../routes/agents.js"),
+    vi.importActual<typeof import("../middleware/index.js")>("../middleware/index.js"),
+  ]);
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as any).actor = {
+      type: "board",
+      userId: "local-board",
+      companyIds: ["company-1"],
+      source: "local_implicit",
+      isInstanceAdmin: false,
+    };
+    next();
+  });
+  app.use("/api", agentRoutes({} as any));
+  app.use(errorHandler);
+  return app;
+}
+
+describe("POST /agents/:id/claude-login", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAccessService.decide.mockResolvedValue({
+      allowed: true,
+      reason: "allow_explicit_grant",
+      explanation: "Allowed by test grant",
+    });
+    mockAgentService.getById.mockResolvedValue({
+      id: "33333333-3333-4333-8333-333333333333",
+      companyId: "company-1",
+      name: "Claude",
+      adapterType: "claude_local",
+      adapterConfig: {},
+    });
+    mockInstanceSettingsService.getGeneral.mockResolvedValue({ censorUsernameInLogs: false });
+    mockRunClaudeLogin.mockResolvedValue({
+      status: "url",
+      loginUrl: "https://example.invalid/login",
+    });
+  });
+
+  it("runs the host-local login when execution is unrestricted", async () => {
+    const app = await createApp();
+
+    const res = await request(app).post("/api/agents/33333333-3333-4333-8333-333333333333/claude-login").send({});
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(mockRunClaudeLogin).toHaveBeenCalledTimes(1);
+    expect(res.body).toMatchObject({ loginUrl: "https://example.invalid/login" });
+  });
+
+  it("responds 409 without spawning anything when execution is forced onto the Kubernetes sandbox", async () => {
+    mockInstanceSettingsService.getGeneral.mockResolvedValue({
+      censorUsernameInLogs: false,
+      executionMode: "kubernetes",
+    });
+    const app = await createApp();
+
+    const res = await request(app).post("/api/agents/33333333-3333-4333-8333-333333333333/claude-login").send({});
+
+    expect(res.status, JSON.stringify(res.body)).toBe(409);
+    expect(res.body.error).toMatch(/Kubernetes sandbox/);
+    expect(mockRunClaudeLogin).not.toHaveBeenCalled();
+  });
+});

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -104,6 +104,7 @@ import { recoveryService } from "../services/recovery/service.js";
 import { resolveCoreTrustPreset } from "../services/trust-preset-resolver.js";
 import { readObject } from "../lib/objects.js";
 import { listInvalidOrgChainDescendantIds } from "../services/agent-invokability.js";
+import { claudeHostLoginUnavailableReason } from "../services/execution-allowlist.js";
 import {
   AGENT_PROFILE_CHANGE_CONSENT_FIELDS,
   agentInstructionsChangeTargetKey,
@@ -3563,6 +3564,16 @@ export function agentRoutes(
     await assertBoardCanManageAgentsForCompany(req, agent.companyId);
     if (agent.adapterType !== "claude_local") {
       res.status(400).json({ error: "Login is only supported for claude_local agents" });
+      return;
+    }
+
+    // `claude login` runs on the server host; when the instance forces all
+    // execution onto the Kubernetes sandbox, sandboxed runs can never see that
+    // host-local login state, so refuse before spawning anything.
+    const { executionMode } = await instanceSettings.getGeneral();
+    const hostLoginUnavailableReason = claudeHostLoginUnavailableReason(executionMode);
+    if (hostLoginUnavailableReason) {
+      res.status(409).json({ error: hostLoginUnavailableReason });
       return;
     }
 

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -216,6 +216,7 @@ import { resolveCoreTrustPreset } from "../services/trust-preset-resolver.js";
 import { readObject } from "../lib/objects.js";
 import { listInvalidOrgChainDescendantIds } from "../services/agent-invokability.js";
 import { logger } from "../middleware/logger.js";
+import { claudeHostLoginUnavailableReason } from "../services/execution-allowlist.js";
 import {
   AGENT_PROFILE_CHANGE_CONSENT_FIELDS,
   agentInstructionsChangeTargetKey,
@@ -5389,6 +5390,16 @@ export function agentRoutes(
     await assertBoardCanManageAgentsForCompany(req, agent.companyId);
     if (agent.adapterType !== "claude_local") {
       res.status(400).json({ error: "Login is only supported for claude_local agents" });
+      return;
+    }
+
+    // `claude login` runs on the server host; when the instance forces all
+    // execution onto the Kubernetes sandbox, sandboxed runs can never see that
+    // host-local login state, so refuse before spawning anything.
+    const { executionMode } = await instanceSettings.getGeneral();
+    const hostLoginUnavailableReason = claudeHostLoginUnavailableReason(executionMode);
+    if (hostLoginUnavailableReason) {
+      res.status(409).json({ error: hostLoginUnavailableReason });
       return;
     }
 

--- a/server/src/services/execution-allowlist.test.ts
+++ b/server/src/services/execution-allowlist.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   KUBERNETES_PROVIDER_KEY,
+  claudeHostLoginUnavailableReason,
   evaluateExecutionAllowlist,
   type ExecutionEnvironmentCandidate,
 } from "./execution-allowlist.js";
@@ -82,6 +83,20 @@ describe("evaluateExecutionAllowlist", () => {
         { driver: "sandbox", provider: null },
       );
       expect(result.allowed).toBe(false);
+    });
+  });
+
+  describe("claudeHostLoginUnavailableReason", () => {
+    it("returns a human-readable reason when execution is forced onto Kubernetes", () => {
+      const reason = claudeHostLoginUnavailableReason("kubernetes");
+      expect(reason).not.toBeNull();
+      expect(reason).toMatch(/Kubernetes sandbox/);
+      expect(reason).toMatch(/credential/i);
+    });
+
+    it("returns null when host login is allowed", () => {
+      expect(claudeHostLoginUnavailableReason("any")).toBeNull();
+      expect(claudeHostLoginUnavailableReason(undefined)).toBeNull();
     });
   });
 

--- a/server/src/services/execution-allowlist.test.ts
+++ b/server/src/services/execution-allowlist.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   KUBERNETES_PROVIDER_KEY,
+  claudeHostLoginUnavailableReason,
   evaluateExecutionAllowlist,
   type ExecutionEnvironmentCandidate,
 } from "./execution-allowlist.js";
@@ -112,6 +113,20 @@ describe("evaluateExecutionAllowlist", () => {
     it("does not affect local when the mode is off", () => {
       expect(evaluateExecutionAllowlist({ managedSandboxOnly: false }, localEnv).allowed).toBe(true);
       expect(evaluateExecutionAllowlist({}, localEnv).allowed).toBe(true);
+    });
+  });
+
+  describe("claudeHostLoginUnavailableReason", () => {
+    it("returns a human-readable reason when execution is forced onto Kubernetes", () => {
+      const reason = claudeHostLoginUnavailableReason("kubernetes");
+      expect(reason).not.toBeNull();
+      expect(reason).toMatch(/Kubernetes sandbox/);
+      expect(reason).toMatch(/credential/i);
+    });
+
+    it("returns null when host login is allowed", () => {
+      expect(claudeHostLoginUnavailableReason("any")).toBeNull();
+      expect(claudeHostLoginUnavailableReason(undefined)).toBeNull();
     });
   });
 

--- a/server/src/services/execution-allowlist.ts
+++ b/server/src/services/execution-allowlist.ts
@@ -16,6 +16,8 @@
  * unit-testable.
  */
 
+import type { InstanceExecutionMode } from "@paperclipai/shared";
+
 /** Provider key (== plugin driverKey) of the first-party Kubernetes sandbox provider. */
 export const KUBERNETES_PROVIDER_KEY = "kubernetes" as const;
 
@@ -53,6 +55,26 @@ export type ExecutionAllowlistDecision =
 /** True when the policy forces all execution onto the Kubernetes sandbox. */
 export function isExecutionForcedToKubernetes(policy: ExecutionPolicy | null | undefined): boolean {
   return policy?.executionMode === "kubernetes";
+}
+
+/**
+ * Why a host-local `claude login` is unavailable under the given execution
+ * mode, or `null` when it is allowed.
+ *
+ * `claude login` runs as a process on the server host and writes login state
+ * to the host filesystem. When the instance forces all agent execution onto
+ * the Kubernetes sandbox (`executionMode === "kubernetes"`), sandboxed runs
+ * can never see that host-local state, so offering the login is a dead end.
+ */
+export function claudeHostLoginUnavailableReason(
+  executionMode: InstanceExecutionMode | undefined,
+): string | null {
+  if (executionMode !== "kubernetes") return null;
+  return (
+    "This instance runs agents in the Kubernetes sandbox; a host-local Claude " +
+    "login cannot authenticate sandboxed runs. Connect a credential in the " +
+    "agent's configuration instead."
+  );
 }
 
 /**

--- a/server/src/services/execution-allowlist.ts
+++ b/server/src/services/execution-allowlist.ts
@@ -16,6 +16,8 @@
  * unit-testable.
  */
 
+import type { InstanceExecutionMode } from "@paperclipai/shared";
+
 /** Provider key (== plugin driverKey) of the first-party Kubernetes sandbox provider. */
 export const KUBERNETES_PROVIDER_KEY = "kubernetes" as const;
 
@@ -68,6 +70,26 @@ export function isExecutionForcedToKubernetes(policy: ExecutionPolicy | null | u
 /** True when the policy refuses local (in-process/on-container) execution. */
 export function isLocalExecutionDenied(policy: ExecutionPolicy | null | undefined): boolean {
   return policy?.managedSandboxOnly === true;
+}
+
+/**
+ * Why a host-local `claude login` is unavailable under the given execution
+ * mode, or `null` when it is allowed.
+ *
+ * `claude login` runs as a process on the server host and writes login state
+ * to the host filesystem. When the instance forces all agent execution onto
+ * the Kubernetes sandbox (`executionMode === "kubernetes"`), sandboxed runs
+ * can never see that host-local state, so offering the login is a dead end.
+ */
+export function claudeHostLoginUnavailableReason(
+  executionMode: InstanceExecutionMode | undefined,
+): string | null {
+  if (executionMode !== "kubernetes") return null;
+  return (
+    "This instance runs agents in the Kubernetes sandbox; a host-local Claude " +
+    "login cannot authenticate sandboxed runs. Connect a credential in the " +
+    "agent's configuration instead."
+  );
 }
 
 /**

--- a/ui/src/lib/claude-host-login.test.ts
+++ b/ui/src/lib/claude-host-login.test.ts
@@ -1,0 +1,18 @@
+// @vitest-environment node
+
+import { describe, expect, it } from "vitest";
+import { shouldOfferClaudeHostLogin } from "./claude-host-login";
+
+describe("shouldOfferClaudeHostLogin", () => {
+  it("offers the host-local login when execution is unrestricted", () => {
+    expect(shouldOfferClaudeHostLogin("any")).toBe(true);
+  });
+
+  it("offers the host-local login when the execution mode is not loaded/absent", () => {
+    expect(shouldOfferClaudeHostLogin(undefined)).toBe(true);
+  });
+
+  it("does NOT offer the host-local login when execution is forced onto the Kubernetes sandbox", () => {
+    expect(shouldOfferClaudeHostLogin("kubernetes")).toBe(false);
+  });
+});

--- a/ui/src/lib/claude-host-login.ts
+++ b/ui/src/lib/claude-host-login.ts
@@ -1,0 +1,19 @@
+import type { InstanceExecutionMode } from "@paperclipai/shared";
+
+/**
+ * Whether the UI should offer the host-local "Login to Claude Code" action for
+ * a `claude_local` agent that failed with `claude_auth_required`.
+ *
+ * `claude login` runs as a process on the server host and writes login state
+ * to the host filesystem. When the instance execution policy forces all agent
+ * execution onto the Kubernetes sandbox (`executionMode === "kubernetes"`),
+ * sandboxed runs can never see that host-local state, so offering the login is
+ * a dead end; the server refuses it with a 409 for the same reason. Mirrors
+ * the server-side `claudeHostLoginUnavailableReason` guard. Pure so it can be
+ * unit-tested without rendering.
+ */
+export function shouldOfferClaudeHostLogin(
+  executionMode: InstanceExecutionMode | undefined,
+): boolean {
+  return executionMode !== "kubernetes";
+}

--- a/ui/src/pages/AgentDetail.tsx
+++ b/ui/src/pages/AgentDetail.tsx
@@ -24,6 +24,7 @@ import { useCompany } from "../context/CompanyContext";
 import { useToastActions } from "../context/ToastContext";
 import { useBreadcrumbs } from "../context/BreadcrumbContext";
 import { queryKeys } from "../lib/queryKeys";
+import { shouldOfferClaudeHostLogin } from "../lib/claude-host-login";
 import { AgentSkillsTab } from "./agent-skills/AgentSkillsTab";
 import { AgentConfigForm } from "../components/AgentConfigForm";
 import { PageTabBar } from "../components/PageTabBar";
@@ -2972,6 +2973,16 @@ function RunDetail({ run: initialRun, agentRouteId, adapterType, adapterConfig }
     return entry?.user?.name ?? entry?.user?.email ?? null;
   }, [run.responsibleUserId, userDirectory]);
   const responsibleDenialCode = isResponsibleUserDenialCode(run.errorCode) ? run.errorCode : null;
+  // Instance execution policy (general settings). When `executionMode` is
+  // "kubernetes" a host-local `claude login` cannot authenticate sandboxed
+  // runs, so the login button is replaced with a credential hint. Reuses the
+  // same general-settings query the rest of the UI uses.
+  const { data: generalSettings } = useQuery({
+    queryKey: queryKeys.instance.generalSettings,
+    queryFn: () => instanceSettingsApi.getGeneral(),
+    retry: false,
+  });
+  const offerClaudeHostLogin = shouldOfferClaudeHostLogin(generalSettings?.executionMode);
   const [sessionOpen, setSessionOpen] = useState(false);
   const [claudeLoginResult, setClaudeLoginResult] = useState<ClaudeLoginResult | null>(null);
 
@@ -3227,7 +3238,13 @@ function RunDetail({ run: initialRun, agentRouteId, adapterType, adapterConfig }
                 {run.errorCode && <span className="text-muted-foreground ml-1">({run.errorCode})</span>}
               </div>
             )}
-            {run.errorCode === "claude_auth_required" && adapterType === "claude_local" && (
+            {run.errorCode === "claude_auth_required" && adapterType === "claude_local" && !offerClaudeHostLogin && (
+              <p className="text-xs text-muted-foreground">
+                This instance runs agents in the Kubernetes sandbox. Connect a provider credential
+                in the agent's Configuration to fix authentication.
+              </p>
+            )}
+            {run.errorCode === "claude_auth_required" && adapterType === "claude_local" && offerClaudeHostLogin && (
               <div className="space-y-2">
                 <Button
                   variant="outline"

--- a/ui/src/pages/AgentDetail.tsx
+++ b/ui/src/pages/AgentDetail.tsx
@@ -23,6 +23,7 @@ import { useToastActions } from "../context/ToastContext";
 import { useBreadcrumbs } from "../context/BreadcrumbContext";
 import { queryKeys } from "../lib/queryKeys";
 import { copyTextToClipboard } from "../lib/clipboard";
+import { shouldOfferClaudeHostLogin } from "../lib/claude-host-login";
 import { AgentSkillsTab } from "./agent-skills/AgentSkillsTab";
 import { AgentConfigForm } from "../components/AgentConfigForm";
 import { adapterLabels, roleLabels, help } from "../components/agent-config-primitives";
@@ -3306,6 +3307,16 @@ function RunDetail({ run: initialRun, agentRouteId, adapterType, adapterConfig }
     return entry?.user?.name ?? entry?.user?.email ?? null;
   }, [run.responsibleUserId, userDirectory]);
   const responsibleDenialCode = isResponsibleUserDenialCode(run.errorCode) ? run.errorCode : null;
+  // Instance execution policy (general settings). When `executionMode` is
+  // "kubernetes" a host-local `claude login` cannot authenticate sandboxed
+  // runs, so the login button is replaced with a credential hint. Reuses the
+  // same general-settings query the rest of the UI uses.
+  const { data: generalSettings } = useQuery({
+    queryKey: queryKeys.instance.generalSettings,
+    queryFn: () => instanceSettingsApi.getGeneral(),
+    retry: false,
+  });
+  const offerClaudeHostLogin = shouldOfferClaudeHostLogin(generalSettings?.executionMode);
   const [sessionOpen, setSessionOpen] = useState(false);
   const [inspectorOpen, setInspectorOpen] = useState(false);
   const [claudeLoginResult, setClaudeLoginResult] = useState<ClaudeLoginResult | null>(null);
@@ -3613,7 +3624,13 @@ function RunDetail({ run: initialRun, agentRouteId, adapterType, adapterConfig }
                 {run.errorCode && <span className="text-muted-foreground ml-1">({run.errorCode})</span>}
               </div>
             )}
-            {run.errorCode === "claude_auth_required" && adapterType === "claude_local" && (
+            {run.errorCode === "claude_auth_required" && adapterType === "claude_local" && !offerClaudeHostLogin && (
+              <p className="text-xs text-muted-foreground">
+                This instance runs agents in the Kubernetes sandbox. Connect a provider credential
+                in the agent's Configuration to fix authentication.
+              </p>
+            )}
+            {run.errorCode === "claude_auth_required" && adapterType === "claude_local" && offerClaudeHostLogin && (
               <div className="space-y-2">
                 <Button
                   variant="outline"


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Instances can force all agent execution onto the managed Kubernetes sandbox (`executionMode=kubernetes`), while the claude_local adapter's auth-recovery flow (`POST /agents/:id/claude-login`, the "Login to Claude Code" button on a failed run) runs `claude login` as a process on the server host
> - Host-local Claude login state can never be seen by runs that execute inside the Kubernetes sandbox, so on forced-Kubernetes instances the recovery flow is a dead end: the login "succeeds" on the host and the next run still fails `claude_auth_required`
> - Users hitting an auth-failed run on such instances click the button, nothing improves, and there is no hint about the path that actually works (a provider credential in the agent's configuration)
> - This pull request gates the flow on both sides: the route responds 409 with a clear reason before spawning anything, and the run page replaces the button with a short hint under forced-Kubernetes execution
> - The benefit is that a dead-end affordance disappears exactly where it cannot work, and users are pointed at the credential path that does

## Linked Issues or Issue Description

No public issue exists; inline issue description following `bug_report.yml`:

### What happened?

On an instance with `executionMode=kubernetes`, a claude_local agent's run failed with `claude_auth_required` ("Not logged in · Please run /login"). The run page offered "Login to Claude Code"; clicking it runs `claude login` on the server host, which cannot authenticate sandboxed runs, so subsequent runs keep failing with the same error.

### Expected behavior

On forced-Kubernetes instances the host-login flow is not offered; the run page instead points at connecting a provider credential in the agent's configuration, and the API refuses the host login with an explanatory error.

### Steps to reproduce

1. Set instance general setting `executionMode` to `kubernetes` (e.g. via `PAPERCLIP_EXECUTION_MODE=kubernetes`).
2. Run a claude_local agent with no usable Claude credential so the run fails `claude_auth_required`.
3. Open the failed run and click "Login to Claude Code" (or POST `/api/agents/:id/claude-login`).

### Paperclip version or commit

`master` (2f42a496 at time of writing).

### Deployment mode

Server deployment with the Kubernetes sandbox provider.

## What Changed

- `server/src/services/execution-allowlist.ts`: new pure helper `claudeHostLoginUnavailableReason(executionMode)` next to the existing execution-policy guards; returns a reason string when `executionMode === "kubernetes"`, else null.
- `server/src/routes/agents.ts`: `POST /agents/:id/claude-login` reads instance general settings and responds `409 { error }` before resolving config or spawning the login process.
- `ui/src/lib/claude-host-login.ts` (+ test): pure `shouldOfferClaudeHostLogin(executionMode)` mirroring the `forced-kubernetes-environment.ts` helper style; stays true while settings are still loading.
- `ui/src/pages/AgentDetail.tsx`: the `claude_auth_required` block hides the login button under forced-Kubernetes execution and renders a short hint pointing at the agent configuration's provider credential instead; unrestricted instances render the original block unchanged.
- Tests: `server/src/services/execution-allowlist.test.ts` (helper), `server/src/__tests__/agent-claude-login-route.test.ts` (supertest: 409 gate + unrestricted path still spawns login), `ui/src/lib/claude-host-login.test.ts`.

## Verification

- `cd server && npx vitest run src/services/execution-allowlist.test.ts src/__tests__/agent-claude-login-route.test.ts` → 14 passed
- `cd ui && npx vitest run src/lib/claude-host-login.test.ts src/components/RunInvocationCard.test.tsx` → 4 passed
- Each test was written first and observed failing before its implementation step (helper: function missing; route: kubernetes case returned 200 instead of 409; UI helper: unresolvable import).
- Manual: on a forced-Kubernetes instance, a `claude_auth_required` run shows the hint instead of the button, and the API returns 409 with the reason.

## Risks

- Low risk. Behavior changes only when `executionMode === "kubernetes"`, where the flow was already non-functional; unrestricted and self-hosted local instances keep the exact existing button and route behavior. The UI helper defaults to offering the button while settings load, so no flicker-hiding on slow connections.

## Model Used

Claude Fable 5 (claude-fable-5, Anthropic) via Claude Code CLI, with extended thinking and tool use (code search, test execution); implementation executed by a Claude Fable 5 subagent under test-driven development.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
