### PR TITLE
fix(agents): inherit company credential env on agent create and built-in provisioning

### DIFF
--- a/server/src/__tests__/agent-adapter-validation-routes.test.ts
+++ b/server/src/__tests__/agent-adapter-validation-routes.test.ts
@@ -353,6 +353,36 @@ describe("agent routes adapter validation", () => {
     });
   });
 
+  it("skips donors without secret_ref bindings so an empty-env ceo does not shadow a credentialed agent", async () => {
+    const app = await createApp({
+      agentRows: [
+        { role: "ceo", adapterConfig: { env: {} } },
+        {
+          role: "general",
+          adapterConfig: {
+            env: { MY_TOKEN: { type: "secret_ref", secretId: "22222222-2222-4222-8222-222222222222" } },
+          },
+        },
+      ],
+    });
+    const res = await requestApp(app, (baseUrl) =>
+      request(baseUrl)
+        .post("/api/companies/company-1/agents")
+        .send({
+          name: "Second Agent",
+          adapterType: "codex_local",
+          adapterConfig: {},
+        }),
+    );
+
+    expect(res.status, JSON.stringify(res.body)).toBe(201);
+    const createInput = mockAgentService.create.mock.calls.at(-1)?.[1] as Record<string, unknown>;
+    const adapterConfig = createInput.adapterConfig as Record<string, unknown>;
+    expect(adapterConfig.env).toMatchObject({
+      MY_TOKEN: { type: "secret_ref", secretId: "22222222-2222-4222-8222-222222222222", version: "latest" },
+    });
+  });
+
   it("inherits a same-adapter company agent's secret_ref env when hiring an agent", async () => {
     const app = await createApp({
       agentRows: [

--- a/server/src/__tests__/agent-adapter-validation-routes.test.ts
+++ b/server/src/__tests__/agent-adapter-validation-routes.test.ts
@@ -129,7 +129,7 @@ const externalAdapter: ServerAdapterModule = {
 
 const missingAdapterType = "missing_adapter_validation_test";
 
-async function createApp() {
+async function createApp(options: { agentRows?: Array<Record<string, unknown>> } = {}) {
   const [{ agentRoutes }, { errorHandler }] = await Promise.all([
     vi.importActual<typeof import("../routes/agents.js")>("../routes/agents.js"),
     vi.importActual<typeof import("../middleware/index.js")>("../middleware/index.js"),
@@ -147,14 +147,19 @@ async function createApp() {
     next();
   });
   const db = {
-    select: vi.fn(() => ({
+    // Field-selects (`select({...})`) are agent-row lookups; bare selects return the company row.
+    select: vi.fn((fields?: unknown) => ({
       from: vi.fn(() => ({
-        where: vi.fn(async () => [
-          {
-            id: "company-1",
-            requireBoardApprovalForNewAgents: false,
-          },
-        ]),
+        where: vi.fn(async () =>
+          fields
+            ? options.agentRows ?? []
+            : [
+                {
+                  id: "company-1",
+                  requireBoardApprovalForNewAgents: false,
+                },
+              ],
+        ),
       })),
     })),
   };
@@ -317,6 +322,65 @@ describe("agent routes adapter validation", () => {
     const env = (adapterConfig.env as Record<string, unknown> | undefined) ?? {};
     expect(env.OPENAI_API_KEY).toBeUndefined();
     expect(env.CODEX_HOME).toBeUndefined();
+  });
+
+  it("inherits a same-adapter company agent's secret_ref env when creating an agent", async () => {
+    const app = await createApp({
+      agentRows: [
+        {
+          role: "ceo",
+          adapterConfig: {
+            env: { MY_TOKEN: { type: "secret_ref", secretId: "22222222-2222-4222-8222-222222222222" } },
+          },
+        },
+      ],
+    });
+    const res = await requestApp(app, (baseUrl) =>
+      request(baseUrl)
+        .post("/api/companies/company-1/agents")
+        .send({
+          name: "Second Agent",
+          adapterType: "codex_local",
+          adapterConfig: {},
+        }),
+    );
+
+    expect(res.status, JSON.stringify(res.body)).toBe(201);
+    const createInput = mockAgentService.create.mock.calls.at(-1)?.[1] as Record<string, unknown>;
+    const adapterConfig = createInput.adapterConfig as Record<string, unknown>;
+    expect(adapterConfig.env).toMatchObject({
+      MY_TOKEN: { type: "secret_ref", secretId: "22222222-2222-4222-8222-222222222222", version: "latest" },
+    });
+  });
+
+  it("inherits a same-adapter company agent's secret_ref env when hiring an agent", async () => {
+    const app = await createApp({
+      agentRows: [
+        {
+          role: "general",
+          adapterConfig: {
+            env: { MY_TOKEN: { type: "secret_ref", secretId: "33333333-3333-4333-8333-333333333333" } },
+          },
+        },
+      ],
+    });
+    const res = await requestApp(app, (baseUrl) =>
+      request(baseUrl)
+        .post("/api/companies/company-1/agent-hires")
+        .send({
+          name: "Hired Agent",
+          role: "general",
+          adapterType: "codex_local",
+          adapterConfig: {},
+        }),
+    );
+
+    expect(res.status, JSON.stringify(res.body)).toBe(201);
+    const createInput = mockAgentService.create.mock.calls.at(-1)?.[1] as Record<string, unknown>;
+    const adapterConfig = createInput.adapterConfig as Record<string, unknown>;
+    expect(adapterConfig.env).toMatchObject({
+      MY_TOKEN: { type: "secret_ref", secretId: "33333333-3333-4333-8333-333333333333", version: "latest" },
+    });
   });
 
   it("does not re-inject CODEX_HOME or OPENAI_API_KEY when updating a keyless codex_local agent", async () => {

--- a/server/src/__tests__/agent-adapter-validation-routes.test.ts
+++ b/server/src/__tests__/agent-adapter-validation-routes.test.ts
@@ -172,7 +172,7 @@ const externalAdapter: ServerAdapterModule = {
 
 const missingAdapterType = "missing_adapter_validation_test";
 
-async function createApp() {
+async function createApp(options: { agentRows?: Array<Record<string, unknown>> } = {}) {
   const [{ agentRoutes }, { errorHandler }] = await Promise.all([
     vi.importActual<typeof import("../routes/agents.js")>("../routes/agents.js"),
     vi.importActual<typeof import("../middleware/index.js")>("../middleware/index.js"),
@@ -190,14 +190,19 @@ async function createApp() {
     next();
   });
   const db = {
-    select: vi.fn(() => ({
+    // Field-selects (`select({...})`) are agent-row lookups; bare selects return the company row.
+    select: vi.fn((fields?: unknown) => ({
       from: vi.fn(() => ({
-        where: vi.fn(async () => [
-          {
-            id: "company-1",
-            requireBoardApprovalForNewAgents: false,
-          },
-        ]),
+        where: vi.fn(async () =>
+          fields
+            ? options.agentRows ?? []
+            : [
+                {
+                  id: "company-1",
+                  requireBoardApprovalForNewAgents: false,
+                },
+              ],
+        ),
       })),
     })),
   };
@@ -373,6 +378,65 @@ describe("agent routes adapter validation", () => {
     const env = (adapterConfig.env as Record<string, unknown> | undefined) ?? {};
     expect(env.OPENAI_API_KEY).toBeUndefined();
     expect(env.CODEX_HOME).toBeUndefined();
+  });
+
+  it("inherits a same-adapter company agent's secret_ref env when creating an agent", async () => {
+    const app = await createApp({
+      agentRows: [
+        {
+          role: "ceo",
+          adapterConfig: {
+            env: { MY_TOKEN: { type: "secret_ref", secretId: "22222222-2222-4222-8222-222222222222" } },
+          },
+        },
+      ],
+    });
+    const res = await requestApp(app, (baseUrl) =>
+      request(baseUrl)
+        .post("/api/companies/company-1/agents")
+        .send({
+          name: "Second Agent",
+          adapterType: "codex_local",
+          adapterConfig: {},
+        }),
+    );
+
+    expect(res.status, JSON.stringify(res.body)).toBe(201);
+    const createInput = mockAgentService.create.mock.calls.at(-1)?.[1] as Record<string, unknown>;
+    const adapterConfig = createInput.adapterConfig as Record<string, unknown>;
+    expect(adapterConfig.env).toMatchObject({
+      MY_TOKEN: { type: "secret_ref", secretId: "22222222-2222-4222-8222-222222222222", version: "latest" },
+    });
+  });
+
+  it("inherits a same-adapter company agent's secret_ref env when hiring an agent", async () => {
+    const app = await createApp({
+      agentRows: [
+        {
+          role: "general",
+          adapterConfig: {
+            env: { MY_TOKEN: { type: "secret_ref", secretId: "33333333-3333-4333-8333-333333333333" } },
+          },
+        },
+      ],
+    });
+    const res = await requestApp(app, (baseUrl) =>
+      request(baseUrl)
+        .post("/api/companies/company-1/agent-hires")
+        .send({
+          name: "Hired Agent",
+          role: "general",
+          adapterType: "codex_local",
+          adapterConfig: {},
+        }),
+    );
+
+    expect(res.status, JSON.stringify(res.body)).toBe(201);
+    const createInput = mockAgentService.create.mock.calls.at(-1)?.[1] as Record<string, unknown>;
+    const adapterConfig = createInput.adapterConfig as Record<string, unknown>;
+    expect(adapterConfig.env).toMatchObject({
+      MY_TOKEN: { type: "secret_ref", secretId: "33333333-3333-4333-8333-333333333333", version: "latest" },
+    });
   });
 
   it("does not re-inject CODEX_HOME or OPENAI_API_KEY when updating a keyless codex_local agent", async () => {

--- a/server/src/__tests__/agent-adapter-validation-routes.test.ts
+++ b/server/src/__tests__/agent-adapter-validation-routes.test.ts
@@ -409,6 +409,36 @@ describe("agent routes adapter validation", () => {
     });
   });
 
+  it("skips donors without secret_ref bindings so an empty-env ceo does not shadow a credentialed agent", async () => {
+    const app = await createApp({
+      agentRows: [
+        { role: "ceo", adapterConfig: { env: {} } },
+        {
+          role: "general",
+          adapterConfig: {
+            env: { MY_TOKEN: { type: "secret_ref", secretId: "22222222-2222-4222-8222-222222222222" } },
+          },
+        },
+      ],
+    });
+    const res = await requestApp(app, (baseUrl) =>
+      request(baseUrl)
+        .post("/api/companies/company-1/agents")
+        .send({
+          name: "Second Agent",
+          adapterType: "codex_local",
+          adapterConfig: {},
+        }),
+    );
+
+    expect(res.status, JSON.stringify(res.body)).toBe(201);
+    const createInput = mockAgentService.create.mock.calls.at(-1)?.[1] as Record<string, unknown>;
+    const adapterConfig = createInput.adapterConfig as Record<string, unknown>;
+    expect(adapterConfig.env).toMatchObject({
+      MY_TOKEN: { type: "secret_ref", secretId: "22222222-2222-4222-8222-222222222222", version: "latest" },
+    });
+  });
+
   it("inherits a same-adapter company agent's secret_ref env when hiring an agent", async () => {
     const app = await createApp({
       agentRows: [

--- a/server/src/__tests__/agent-credential-inheritance.test.ts
+++ b/server/src/__tests__/agent-credential-inheritance.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { mergeInheritedCredentialEnv } from "../services/agent-credential-inheritance.js";
+
+describe("mergeInheritedCredentialEnv (new agents inherit the company credential)", () => {
+  const donorCred = { type: "secret_ref", secretId: "sec-1", version: "latest" };
+
+  it("inherits a donor secret_ref the new agent does not have", () => {
+    expect(mergeInheritedCredentialEnv({ CLAUDE_CODE_OAUTH_TOKEN: donorCred }, {})).toEqual({
+      CLAUDE_CODE_OAUTH_TOKEN: { type: "secret_ref", secretId: "sec-1", version: "latest" },
+    });
+  });
+
+  it("never overrides an env key the request already set (even to a different value)", () => {
+    const requested = { CLAUDE_CODE_OAUTH_TOKEN: { type: "secret_ref", secretId: "own" } };
+    expect(mergeInheritedCredentialEnv({ CLAUDE_CODE_OAUTH_TOKEN: donorCred }, requested)).toEqual(requested);
+  });
+
+  it("only inherits secret_ref bindings (ignores plain/string/non-secret env)", () => {
+    const donorEnv = {
+      CLAUDE_CODE_OAUTH_TOKEN: donorCred,
+      SOME_FLAG: "plain-value",
+      OTHER: { type: "plain", value: "x" },
+    };
+    expect(mergeInheritedCredentialEnv(donorEnv, {})).toEqual({
+      CLAUDE_CODE_OAUTH_TOKEN: { type: "secret_ref", secretId: "sec-1", version: "latest" },
+    });
+  });
+
+  it("preserves projectionClass / projectionAllowlistKey / version verbatim", () => {
+    const donorEnv = {
+      ANTHROPIC_API_KEY: {
+        type: "secret_ref",
+        secretId: "sec-2",
+        version: 3,
+        projectionClass: "class3_static_lease",
+        projectionAllowlistKey: "allow-abc",
+      },
+    };
+    expect(mergeInheritedCredentialEnv(donorEnv, {})).toEqual({
+      ANTHROPIC_API_KEY: {
+        type: "secret_ref",
+        secretId: "sec-2",
+        version: 3,
+        projectionClass: "class3_static_lease",
+        projectionAllowlistKey: "allow-abc",
+      },
+    });
+  });
+
+  it("is a no-op when the donor has no secret_ref credentials", () => {
+    expect(mergeInheritedCredentialEnv({ FLAG: "x" }, { EXISTING: { type: "secret_ref", secretId: "e" } })).toEqual({
+      EXISTING: { type: "secret_ref", secretId: "e" },
+    });
+  });
+
+  it("keeps the new agent's own env alongside inherited credentials", () => {
+    const merged = mergeInheritedCredentialEnv(
+      { CLAUDE_CODE_OAUTH_TOKEN: donorCred },
+      { MY_VAR: { type: "plain", value: "keep" } },
+    );
+    expect(merged).toEqual({
+      MY_VAR: { type: "plain", value: "keep" },
+      CLAUDE_CODE_OAUTH_TOKEN: { type: "secret_ref", secretId: "sec-1", version: "latest" },
+    });
+  });
+});

--- a/server/src/__tests__/built-in-agents.test.ts
+++ b/server/src/__tests__/built-in-agents.test.ts
@@ -13,6 +13,8 @@ import {
   builtInManagedResources,
   companies,
   companyMemberships,
+  companySecretBindings,
+  companySecrets,
   companySkillVersions,
   companySkills,
   createDb,
@@ -123,6 +125,8 @@ describeEmbeddedPostgres("built-in agents", () => {
     await db.delete(companySkills);
     await db.delete(principalPermissionGrants);
     await db.delete(companyMemberships);
+    await db.delete(companySecretBindings);
+    await db.delete(companySecrets);
     await db.delete(agentConfigRevisions);
     await db.delete(activityLog);
     await db.delete(approvals);
@@ -244,6 +248,66 @@ describeEmbeddedPostgres("built-in agents", () => {
 
     const rows = await db.select().from(agents).where(eq(agents.companyId, companyId));
     expect(rows).toHaveLength(1);
+  });
+
+  async function seedDonorAgent(companyId: string) {
+    const secretId = randomUUID();
+    await db.insert(companySecrets).values({
+      id: secretId,
+      companyId,
+      key: "claude-oauth-token",
+      name: "Claude OAuth token",
+    });
+    await db.insert(agents).values({
+      id: randomUUID(),
+      companyId,
+      name: "CEO",
+      role: "ceo",
+      status: "idle",
+      adapterType: "claude_local",
+      adapterConfig: {
+        model: "claude-sonnet-4-5",
+        env: { CLAUDE_CODE_OAUTH_TOKEN: { type: "secret_ref", secretId } },
+      },
+      runtimeConfig: {},
+      permissions: {},
+      metadata: {},
+    });
+    return secretId;
+  }
+
+  it("inherits the company credential env from a same-adapter agent on provisioning", async () => {
+    const companyId = await seedCompany({ requireApproval: false });
+    const secretId = await seedDonorAgent(companyId);
+
+    const state = await builtInAgentService(db).ensure(companyId, "summarizer");
+
+    expect(state.agent?.adapterConfig).toMatchObject({
+      model: "claude-haiku-4-5",
+      env: { CLAUDE_CODE_OAUTH_TOKEN: { type: "secret_ref", secretId, version: "latest" } },
+    });
+  });
+
+  it("inherits the company credential env on the pending-approval provisioning path", async () => {
+    const companyId = await seedCompany();
+    const secretId = await seedDonorAgent(companyId);
+
+    const result = await builtInAgentService(db).provision(companyId, "summarizer");
+
+    expect(result.state.agent?.status).toBe("pending_approval");
+    expect(result.state.agent?.adapterConfig).toMatchObject({
+      model: "claude-haiku-4-5",
+      env: { CLAUDE_CODE_OAUTH_TOKEN: { type: "secret_ref", secretId, version: "latest" } },
+    });
+  });
+
+  it("provisions a built-in agent unchanged when no same-adapter donor has a credential", async () => {
+    const companyId = await seedCompany({ requireApproval: false });
+
+    const state = await builtInAgentService(db).ensure(companyId, "summarizer");
+
+    expect(state.agent?.adapterConfig).toMatchObject({ model: "claude-haiku-4-5" });
+    expect(state.agent?.adapterConfig).not.toHaveProperty("env");
   });
 
   it("routes policy-gated built-in provisioning through a pending hire approval", async () => {

--- a/server/src/__tests__/built-in-agents.test.ts
+++ b/server/src/__tests__/built-in-agents.test.ts
@@ -13,6 +13,8 @@ import {
   builtInManagedResources,
   companies,
   companyMemberships,
+  companySecretBindings,
+  companySecrets,
   companySkillVersions,
   companySkills,
   createDb,
@@ -132,6 +134,8 @@ describeEmbeddedPostgres("built-in agents", () => {
     await db.delete(companySkills);
     await db.delete(principalPermissionGrants);
     await db.delete(companyMemberships);
+    await db.delete(companySecretBindings);
+    await db.delete(companySecrets);
     await db.delete(agentConfigRevisions);
     await db.delete(activityLog);
     await db.delete(approvals);
@@ -256,6 +260,66 @@ describeEmbeddedPostgres("built-in agents", () => {
 
     const rows = await db.select().from(agents).where(eq(agents.companyId, companyId));
     expect(rows).toHaveLength(1);
+  });
+
+  async function seedDonorAgent(companyId: string) {
+    const secretId = randomUUID();
+    await db.insert(companySecrets).values({
+      id: secretId,
+      companyId,
+      key: "claude-oauth-token",
+      name: "Claude OAuth token",
+    });
+    await db.insert(agents).values({
+      id: randomUUID(),
+      companyId,
+      name: "CEO",
+      role: "ceo",
+      status: "idle",
+      adapterType: "claude_local",
+      adapterConfig: {
+        model: "claude-sonnet-4-5",
+        env: { CLAUDE_CODE_OAUTH_TOKEN: { type: "secret_ref", secretId } },
+      },
+      runtimeConfig: {},
+      permissions: {},
+      metadata: {},
+    });
+    return secretId;
+  }
+
+  it("inherits the company credential env from a same-adapter agent on provisioning", async () => {
+    const companyId = await seedCompany({ requireApproval: false });
+    const secretId = await seedDonorAgent(companyId);
+
+    const state = await builtInAgentService(db).ensure(companyId, "summarizer");
+
+    expect(state.agent?.adapterConfig).toMatchObject({
+      model: "claude-haiku-4-5",
+      env: { CLAUDE_CODE_OAUTH_TOKEN: { type: "secret_ref", secretId, version: "latest" } },
+    });
+  });
+
+  it("inherits the company credential env on the pending-approval provisioning path", async () => {
+    const companyId = await seedCompany();
+    const secretId = await seedDonorAgent(companyId);
+
+    const result = await builtInAgentService(db).provision(companyId, "summarizer");
+
+    expect(result.state.agent?.status).toBe("pending_approval");
+    expect(result.state.agent?.adapterConfig).toMatchObject({
+      model: "claude-haiku-4-5",
+      env: { CLAUDE_CODE_OAUTH_TOKEN: { type: "secret_ref", secretId, version: "latest" } },
+    });
+  });
+
+  it("provisions a built-in agent unchanged when no same-adapter donor has a credential", async () => {
+    const companyId = await seedCompany({ requireApproval: false });
+
+    const state = await builtInAgentService(db).ensure(companyId, "summarizer");
+
+    expect(state.agent?.adapterConfig).toMatchObject({ model: "claude-haiku-4-5" });
+    expect(state.agent?.adapterConfig).not.toHaveProperty("env");
   });
 
   it("routes policy-gated built-in provisioning through a pending hire approval", async () => {

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -36,6 +36,7 @@ import {
 } from "@paperclipai/adapter-utils/server-utils";
 import { trackAgentCreated } from "@paperclipai/shared/telemetry";
 import { validate } from "../middleware/validate.js";
+import { inheritCompanyCredentialEnv } from "../services/agent-credential-inheritance.js";
 import {
   agentService,
   agentInstructionsService,
@@ -2359,7 +2360,7 @@ export function agentRoutes(
     assertNoAgentAdapterConfigMutation(req, rawHireAdapterConfig);
     assertNoAgentRuntimeConfigAdapterConfigMutation(req, hireInput.runtimeConfig);
     const hiredAgentId = randomUUID();
-    const requestedAdapterConfig = applyCodexLocalKeyIsolation(
+    let requestedAdapterConfig = applyCodexLocalKeyIsolation(
       companyId,
       hiredAgentId,
       hireInput.adapterType,
@@ -2367,6 +2368,12 @@ export function agentRoutes(
         hireInput.adapterType,
         rawHireAdapterConfig,
       ),
+    );
+    requestedAdapterConfig = await inheritCompanyCredentialEnv(
+      db,
+      companyId,
+      hireInput.adapterType,
+      requestedAdapterConfig,
     );
     const desiredSkillAssignment = await resolveDesiredSkillAssignment(
       companyId,
@@ -2554,7 +2561,7 @@ export function agentRoutes(
     assertNoAgentAdapterConfigMutation(req, rawCreateAdapterConfig);
     assertNoAgentRuntimeConfigAdapterConfigMutation(req, createInput.runtimeConfig);
     const agentId = randomUUID();
-    const requestedAdapterConfig = applyCodexLocalKeyIsolation(
+    let requestedAdapterConfig = applyCodexLocalKeyIsolation(
       companyId,
       agentId,
       createInput.adapterType,
@@ -2562,6 +2569,12 @@ export function agentRoutes(
         createInput.adapterType,
         rawCreateAdapterConfig,
       ),
+    );
+    requestedAdapterConfig = await inheritCompanyCredentialEnv(
+      db,
+      companyId,
+      createInput.adapterType,
+      requestedAdapterConfig,
     );
     const desiredSkillAssignment = await resolveDesiredSkillAssignment(
       companyId,

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -48,6 +48,7 @@ import {
 import { trackAgentCreated } from "@paperclipai/shared/telemetry";
 import { validate } from "../middleware/validate.js";
 import { agentInstructionsBundleMode } from "../services/agent-instructions.js";
+import { inheritCompanyCredentialEnv } from "../services/agent-credential-inheritance.js";
 import {
   agentService,
   agentInstructionsService,
@@ -4021,7 +4022,7 @@ export function agentRoutes(
     );
     assertNoAgentAdapterConfigMutation(req, rawHireAdapterConfig);
     const hiredAgentId = randomUUID();
-    const requestedAdapterConfig = applyCodexLocalKeyIsolation(
+    let requestedAdapterConfig = applyCodexLocalKeyIsolation(
       companyId,
       hiredAgentId,
       hireInput.adapterType,
@@ -4036,6 +4037,12 @@ export function agentRoutes(
       name: hireInput.name,
       adapterConfig: requestedAdapterConfig,
     });
+    requestedAdapterConfig = await inheritCompanyCredentialEnv(
+      db,
+      companyId,
+      hireInput.adapterType,
+      requestedAdapterConfig,
+    );
     const desiredSkillAssignment = await resolveDesiredSkillAssignment(
       companyId,
       hireInput.adapterType,
@@ -4246,7 +4253,7 @@ export function agentRoutes(
     );
     assertNoAgentAdapterConfigMutation(req, rawCreateAdapterConfig);
     const agentId = randomUUID();
-    const requestedAdapterConfig = applyCodexLocalKeyIsolation(
+    let requestedAdapterConfig = applyCodexLocalKeyIsolation(
       companyId,
       agentId,
       createInput.adapterType,
@@ -4261,6 +4268,12 @@ export function agentRoutes(
       name: createInput.name,
       adapterConfig: requestedAdapterConfig,
     });
+    requestedAdapterConfig = await inheritCompanyCredentialEnv(
+      db,
+      companyId,
+      createInput.adapterType,
+      requestedAdapterConfig,
+    );
     const desiredSkillAssignment = await resolveDesiredSkillAssignment(
       companyId,
       createInput.adapterType,

--- a/server/src/services/agent-credential-inheritance.ts
+++ b/server/src/services/agent-credential-inheritance.ts
@@ -57,7 +57,17 @@ export async function inheritCompanyCredentialEnv(
   } catch {
     return requestedAdapterConfig;
   }
-  const donors = donorRows.filter((row) => asRecord(asRecord(row.adapterConfig)?.env));
+  // A donor must have at least one secret_ref binding: an agent whose env is
+  // empty (or holds only plain/cleared values) would otherwise win the ceo
+  // preference and make inheritance a silent no-op.
+  const donors = donorRows.filter((row) => {
+    const env = asRecord(asRecord(row.adapterConfig)?.env);
+    if (!env) return false;
+    return Object.values(env).some((binding) => {
+      const parsed = asRecord(binding);
+      return parsed?.type === "secret_ref" && typeof parsed.secretId === "string";
+    });
+  });
   const donor = donors.find((row) => row.role === "ceo") ?? donors[0];
   if (!donor) return requestedAdapterConfig;
   const donorEnv = asRecord(asRecord(donor.adapterConfig)?.env) ?? {};

--- a/server/src/services/agent-credential-inheritance.ts
+++ b/server/src/services/agent-credential-inheritance.ts
@@ -1,0 +1,65 @@
+import { and, eq } from "drizzle-orm";
+import type { Db } from "@paperclipai/db";
+import { agents } from "@paperclipai/db";
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+/**
+ * Merge a donor agent's credential env bindings into a new agent's requested env,
+ * so newly created/provisioned agents inherit the company's working credential.
+ * Only `secret_ref` bindings are inherited (the shape the credential-connect flow
+ * produces), any env key the request already set is left untouched, and the donor
+ * binding's projection semantics are preserved verbatim. Pure/testable.
+ */
+export function mergeInheritedCredentialEnv(
+  donorEnv: Record<string, unknown>,
+  requestedEnv: Record<string, unknown>,
+): Record<string, unknown> {
+  const merged: Record<string, unknown> = { ...requestedEnv };
+  for (const [envKey, binding] of Object.entries(donorEnv)) {
+    const parsed = asRecord(binding);
+    if (!parsed || parsed.type !== "secret_ref" || typeof parsed.secretId !== "string") continue;
+    if (Object.prototype.hasOwnProperty.call(requestedEnv, envKey)) continue;
+    const inherited: Record<string, unknown> = {
+      type: "secret_ref",
+      secretId: parsed.secretId,
+      version: parsed.version ?? "latest",
+    };
+    if (typeof parsed.projectionClass === "string") inherited.projectionClass = parsed.projectionClass;
+    if (parsed.projectionAllowlistKey !== undefined) inherited.projectionAllowlistKey = parsed.projectionAllowlistKey;
+    merged[envKey] = inherited;
+  }
+  return merged;
+}
+
+// Inherit the company's credential env bindings onto a newly created/provisioned
+// agent so it can authenticate without the user re-connecting a key for every
+// agent. Copies each `secret_ref` env binding from an existing same-adapter
+// company agent (preferring the CEO) into the new agent's `adapterConfig.env`,
+// never overriding an env the request set explicitly. No-op when no donor agent
+// of the same adapterType has a credential (no behavior change / no regression).
+export async function inheritCompanyCredentialEnv(
+  db: Db,
+  companyId: string,
+  adapterType: string,
+  requestedAdapterConfig: Record<string, unknown>,
+): Promise<Record<string, unknown>> {
+  const requestedEnv = asRecord(requestedAdapterConfig.env) ?? {};
+  let donorRows: Array<{ role: string | null; adapterConfig: unknown }>;
+  try {
+    donorRows = await db
+      .select({ role: agents.role, adapterConfig: agents.adapterConfig })
+      .from(agents)
+      .where(and(eq(agents.companyId, companyId), eq(agents.adapterType, adapterType)));
+  } catch {
+    return requestedAdapterConfig;
+  }
+  const donors = donorRows.filter((row) => asRecord(asRecord(row.adapterConfig)?.env));
+  const donor = donors.find((row) => row.role === "ceo") ?? donors[0];
+  if (!donor) return requestedAdapterConfig;
+  const donorEnv = asRecord(asRecord(donor.adapterConfig)?.env) ?? {};
+  return { ...requestedAdapterConfig, env: mergeInheritedCredentialEnv(donorEnv, requestedEnv) };
+}

--- a/server/src/services/built-in-agents.ts
+++ b/server/src/services/built-in-agents.ts
@@ -11,6 +11,7 @@ import { syncRoutineVariablesWithTemplate } from "@paperclipai/shared";
 import type { Agent, Approval, CompanySkill, PermissionKey, Routine, RoutineTrigger, RoutineVariable } from "@paperclipai/shared";
 import { conflict, HttpError, notFound, unprocessable } from "../errors.js";
 import { logActivity } from "./activity-log.js";
+import { inheritCompanyCredentialEnv } from "./agent-credential-inheritance.js";
 import { agentInstructionsService } from "./agent-instructions.js";
 import { agentService } from "./agents.js";
 import { approvalService } from "./approvals.js";
@@ -1619,8 +1620,10 @@ export function builtInAgentService(db: Db) {
     const reportsTo = definition.defaultManager === "single_root_agent"
       ? await findSingleRootManager(companyId)
       : null;
+    const patch = definitionPatch(definition, resolvedInput);
+    patch.adapterConfig = await inheritCompanyCredentialEnv(db, companyId, patch.adapterType, patch.adapterConfig);
     const created = await agentSvc.create(companyId, {
-      ...definitionPatch(definition, resolvedInput),
+      ...patch,
       status: definition.defaultStatus ?? "idle",
       pauseReason: definition.defaultStatus === "paused"
         ? `Built-in ${definition.displayName} is disabled until explicitly configured.`
@@ -1697,8 +1700,10 @@ export function builtInAgentService(db: Db) {
     const reportsTo = definition.defaultManager === "single_root_agent"
       ? await findSingleRootManager(companyId)
       : null;
+    const pendingPatch = definitionPatch(definition, input);
+    pendingPatch.adapterConfig = await inheritCompanyCredentialEnv(db, companyId, pendingPatch.adapterType, pendingPatch.adapterConfig);
     const pending = await agentSvc.create(companyId, {
-      ...definitionPatch(definition, input),
+      ...pendingPatch,
       status: "pending_approval",
       reportsTo,
       metadata: builtInMetadata(definition),

--- a/server/src/services/built-in-agents.ts
+++ b/server/src/services/built-in-agents.ts
@@ -10,6 +10,7 @@ import { syncRoutineVariablesWithTemplate } from "@paperclipai/shared";
 import type { Agent, Approval, CompanySkill, PermissionKey, Routine, RoutineTrigger, RoutineVariable } from "@paperclipai/shared";
 import { conflict, HttpError, notFound, unprocessable } from "../errors.js";
 import { logActivity } from "./activity-log.js";
+import { inheritCompanyCredentialEnv } from "./agent-credential-inheritance.js";
 import { agentInstructionsService } from "./agent-instructions.js";
 import { agentService } from "./agents.js";
 import { approvalService } from "./approvals.js";
@@ -1655,10 +1656,12 @@ export function builtInAgentService(db: Db) {
     const reportsTo = definition.defaultManager === "single_root_agent"
       ? await findSingleRootManager(companyId)
       : null;
+    const patch = definitionPatch(definition, resolvedInput);
+    patch.adapterConfig = await inheritCompanyCredentialEnv(db, companyId, patch.adapterType, patch.adapterConfig);
     let created: Agent;
     try {
       created = await agentSvc.create(companyId, {
-        ...definitionPatch(definition, resolvedInput),
+        ...patch,
         status: definition.defaultStatus ?? "idle",
         pauseReason: definition.defaultStatus === "paused"
           ? `Built-in ${definition.displayName} is disabled until explicitly configured.`
@@ -1760,10 +1763,12 @@ export function builtInAgentService(db: Db) {
     const reportsTo = definition.defaultManager === "single_root_agent"
       ? await findSingleRootManager(companyId)
       : null;
+    const pendingPatch = definitionPatch(definition, input);
+    pendingPatch.adapterConfig = await inheritCompanyCredentialEnv(db, companyId, pendingPatch.adapterType, pendingPatch.adapterConfig);
     let pending: Agent;
     try {
       pending = await agentSvc.create(companyId, {
-        ...definitionPatch(definition, input),
+        ...pendingPatch,
         status: "pending_approval",
         reportsTo,
         metadata: builtInMetadata(definition),


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - A company's agents authenticate their model providers via adapter-config `env` bindings that reference company secrets (`secret_ref`), typically connected once for the first agent
> - Newly created agents — a hired agent, a user-created agent, or a provisioned built-in agent (Reflection Coach, Summarizer) — start with no credential bindings, even when the company already has a working credential bound to an existing same-adapter agent
> - Their first runs then fail with adapter auth errors (claude_local: `claude_auth_required` "Not logged in"), the permanent-auth-failure guard pauses them, and the user has to re-connect the same credential per agent to recover
> - Built-in agents make this sharp: they ship paused by design, and the natural "resume and try it" path lands directly on an auth failure
> - This pull request makes agent creation and built-in provisioning inherit the company's `secret_ref` credential env bindings from an existing same-adapter-type agent (preferring the CEO), never overriding anything the request set explicitly and no-op when there is no donor
> - The benefit is that new and built-in agents work out of the box in companies that already have a credential, with zero behavior change elsewhere

## Linked Issues or Issue Description

No public issue exists; inline issue description following `bug_report.yml`:

### What happened?

In a company whose existing agent has a working claude_local credential (`env.CLAUDE_CODE_OAUTH_TOKEN` as a `secret_ref` to a company secret), resuming a freshly provisioned built-in agent (Reflection Coach) produced runs failing with `claude_auth_required` ("Not logged in · Please run /login"), after which the auth-failure guard paused the agent again. The same applies to agents hired by other agents or created by users: their adapter config starts without the company's credential bindings.

### Expected behavior

A newly created or provisioned agent of the same adapter type inherits the company's credential env bindings and its runs authenticate immediately; explicit env in the create request always wins; companies with no credentialed donor agent see no change.

### Steps to reproduce

1. Create a company; connect a provider credential so an existing agent has `env.CLAUDE_CODE_OAUTH_TOKEN` (or `ANTHROPIC_API_KEY`) as a `secret_ref` binding.
2. Provision/enable a built-in agent (or hire/create a new claude_local agent) and let it run.
3. The new agent's `adapter_config.env` is empty and the run fails `claude_auth_required`.

### Paperclip version or commit

`master` (2f42a496 at time of writing).

### Deployment mode

Server deployment (any; sharpest with the Kubernetes sandbox provider where a host-side `claude login` cannot compensate).

## What Changed

- `server/src/services/agent-credential-inheritance.ts` (new): pure `mergeInheritedCredentialEnv(donorEnv, requestedEnv)` — inherits only `secret_ref` bindings, preserves projection semantics verbatim, never overrides request-set keys — plus `inheritCompanyCredentialEnv(db, companyId, adapterType, requestedAdapterConfig)` which selects a donor agent (same company + adapter type, has env; prefers role "ceo") and merges.
- `server/src/routes/agents.ts`: both create paths (`POST /companies/:companyId/agents` and `POST /companies/:companyId/agent-hires`) pass the requested adapter config through inheritance before persisting.
- `server/src/services/built-in-agents.ts`: both agent-row creation sites (the `ensure()` create path and the `provision()` pending-approval path) apply the same inheritance to the built-in's adapter config.
- Tests: `agent-credential-inheritance.test.ts` (pure function), `built-in-agents.test.ts` (+3 embedded-postgres cases: inherit via ensure, inherit via provision, no-donor unchanged), `agent-adapter-validation-routes.test.ts` (+2 supertest cases covering both routes).

## Verification

- `cd server && npx vitest run src/__tests__/agent-adapter-validation-routes.test.ts src/__tests__/agent-credential-inheritance.test.ts src/__tests__/built-in-agents.test.ts` → 48 passed
- Regression sweep over 15 related suites (built-in-agent routes, pending-approval config, secret-bindings, agent route harnesses) → 163 passed
- `pnpm run typecheck` in `server/` → clean
- Each step was test-first with the failure observed before implementing (pure-fn stub diff, missing `env` on provisioned built-in, `expected undefined to match object` on the routes).

## Risks

- Low risk. Inheritance only adds `secret_ref` env bindings when a same-adapter donor exists and the request didn't set the key; companies without donors and requests with explicit env are byte-for-byte unchanged (covered by tests). Secret access still goes through the existing company-scope validation on create (`assertSecretInCompany` path), so no cross-company secret reference becomes possible.

## Model Used

Claude Fable 5 (claude-fable-5, Anthropic) via Claude Code CLI, with extended thinking and tool use (code search, test execution); implementation executed by a Claude Fable 5 subagent under test-driven development.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
