### PR TITLE
Stop no-op company skill updates

### DIFF
--- a/server/src/__tests__/company-skills-service.test.ts
+++ b/server/src/__tests__/company-skills-service.test.ts
@@ -431,10 +431,16 @@ describeEmbeddedPostgres("companySkillService.list", () => {
       .set({ updatedAt: preservedUpdatedAt })
       .where(eq(companySkills.id, skillId));
 
+    const updateSpy = vi.spyOn(db, "update");
     await svc.importFromSource(companyId, skillDir);
     const stored = await svc.getById(companyId, skillId);
+    const companySkillUpdateCount = updateSpy.mock.calls
+      .filter(([table]) => table === companySkills)
+      .length;
+    updateSpy.mockRestore();
 
     expect(stored?.updatedAt.toISOString()).toBe(preservedUpdatedAt.toISOString());
+    expect(companySkillUpdateCount).toBe(0);
   });
 
   it("refreshes local-path imports with legacy null metadata fields", async () => {

--- a/server/src/services/company-skills.ts
+++ b/server/src/services/company-skills.ts
@@ -239,7 +239,6 @@ type ImportedSkillPersistValues = Pick<
 > & {
   fileInventory: Array<Record<string, unknown>>;
   metadata: Record<string, unknown>;
-  updatedAt: Date;
 };
 
 type PackageSkillConflictStrategy = "replace" | "rename" | "skip";
@@ -5580,7 +5579,6 @@ export function companySkillService(db: Db) {
         sharingScope: existing?.sharingScope ?? "company",
         installCount: existing?.installCount ?? 1,
         metadata,
-        updatedAt: new Date(),
       };
       if (existing && importedSkillPersistValuesMatchExisting(existing, values)) {
         out.push(existing);
@@ -5589,7 +5587,7 @@ export function companySkillService(db: Db) {
       const row = existing
         ? await db
           .update(companySkills)
-          .set(values)
+          .set({ ...values, updatedAt: new Date() })
           .where(eq(companySkills.id, existing.id))
           .returning()
           .then((rows) => rows[0] ?? null)


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The skills subsystem imports bundled and local skills into `company_skills` so agents can discover and use them.
> - Skill inventory refreshes may run repeatedly during normal server and workspace activity.
> - The importer already has enough persisted field data to detect unchanged skills before writing.
> - No-op `UPDATE company_skills` calls still advance `updated_at` and create unnecessary database churn.
> - This pull request makes unchanged imported skills return the existing row without writing.
> - The benefit is lower write volume during repeated inventory refreshes while preserving updates for meaningful skill payload changes.

## Linked Issues or Issue Description

Refs #3558

Bug description:
- Skill inventory refreshes can process many existing company skill rows repeatedly.
- When an imported skill has the same persisted payload as the stored row, issuing an update is unnecessary.
- Expected behavior: unchanged imported skills should not touch `company_skills.updated_at` or create update churn.
- Actual behavior before this change: the upsert payload included an update timestamp in the persistence path, making it easier for no-op refreshes to produce writes instead of preserving the existing row untouched.

## What Changed

- Changed `server/src/services/company-skills.ts` so the imported-skill comparison payload excludes `updatedAt`.
- Kept `updatedAt` assignment inside the real insert/update persistence branches only.
- Extended `server/src/__tests__/company-skills-service.test.ts` to assert a repeated unchanged local-path import preserves `updated_at` and makes zero `db.update(companySkills)` calls.

## Verification

- `env TMPDIR=/tmp pnpm exec vitest run server/src/__tests__/company-skills-service.test.ts` - passed, 44 tests.
- `pnpm exec vitest run server/src/__tests__/company-skills.test.ts` - passed, 18 tests.
- `pnpm --filter @paperclipai/server typecheck` - passed.

## Risks

Low risk.

- The changed branch only affects imported skills whose persisted fields already match the existing row.
- Meaningful payload changes still execute the existing update path and receive a fresh `updatedAt` value.
- No schema migration or data migration is included.
- Rollback is a normal git revert of commit `7429d8b9e`.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected - check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

OpenAI Codex, GPT-5.5, coding-agent environment with shell and repository tool use.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
