### PR TITLE
Fix external UI parser worker startup in Chrome

### DIFF
--- a/ui/src/adapters/dynamic-loader.ts
+++ b/ui/src/adapters/dynamic-loader.ts
@@ -61,6 +61,7 @@ const failedLoads = new Set<string>();
 const loadPromises = new Map<string, Promise<DynamicParserModule | null>>();
 
 let resultNotifier: (() => void) | null = null;
+let resultNotificationFrame: number | null = null;
 
 export function setDynamicParserResultNotifier(fn: (() => void) | null): void {
   resultNotifier = fn;
@@ -81,7 +82,11 @@ function lineCacheKey(line: string, ts: string): string {
 }
 
 function notifyResultReady(): void {
-  resultNotifier?.();
+  if (resultNotificationFrame !== null) return;
+  resultNotificationFrame = requestAnimationFrame(() => {
+    resultNotificationFrame = null;
+    resultNotifier?.();
+  });
 }
 
 /**

--- a/ui/src/adapters/sandboxed-parser-worker.test.ts
+++ b/ui/src/adapters/sandboxed-parser-worker.test.ts
@@ -3,16 +3,44 @@ import { describe, expect, it } from "vitest";
 import { getWorkerBootstrapSource } from "./sandboxed-parser-worker";
 
 describe("sandboxed parser worker bootstrap", () => {
-  it("disables child worker and object URL escape hatches", () => {
-    const source = getWorkerBootstrapSource();
+  it("disables worker network and escape globals", () => {
+    const workerScope = {
+      Worker: () => undefined,
+      SharedWorker: () => undefined,
+      Blob: () => undefined,
+      RTCPeerConnection: () => undefined,
+      RTCDataChannel: () => undefined,
+      URL: {
+        createObjectURL: () => "blob:test",
+        revokeObjectURL: () => undefined,
+      },
+    };
 
-    expect(source).toContain("self.Worker = _undefined");
-    expect(source).toContain("self.SharedWorker = _undefined");
-    expect(source).toContain("self.Blob = _undefined");
-    expect(source).toContain("self.RTCPeerConnection = _undefined");
-    expect(source).toContain("self.RTCDataChannel = _undefined");
-    expect(source).toContain('"createObjectURL"');
-    expect(source).toContain('"revokeObjectURL"');
+    new Function("self", getWorkerBootstrapSource())(workerScope);
+
+    expect(workerScope.Worker).toBeUndefined();
+    expect(workerScope.SharedWorker).toBeUndefined();
+    expect(workerScope.Blob).toBeUndefined();
+    expect(workerScope.RTCPeerConnection).toBeUndefined();
+    expect(workerScope.RTCDataChannel).toBeUndefined();
+    expect(workerScope.URL.createObjectURL).toBeUndefined();
+    expect(workerScope.URL.revokeObjectURL).toBeUndefined();
+  });
+
+  it("disables getter-only worker globals without aborting bootstrap", () => {
+    const workerScope: Record<string, unknown> = {};
+    Object.defineProperty(workerScope, "caches", {
+      configurable: true,
+      get: () => ({ sentinel: "cache-storage" }),
+    });
+    Object.defineProperty(workerScope, "indexedDB", {
+      configurable: true,
+      get: () => ({ sentinel: "indexed-db" }),
+    });
+
+    expect(() => new Function("self", getWorkerBootstrapSource())(workerScope)).not.toThrow();
+    expect(workerScope.caches).toBeUndefined();
+    expect(workerScope.indexedDB).toBeUndefined();
   });
 
   it("evaluates parser source in strict mode", () => {

--- a/ui/src/adapters/sandboxed-parser-worker.ts
+++ b/ui/src/adapters/sandboxed-parser-worker.ts
@@ -43,25 +43,32 @@ const WORKER_BOOTSTRAP = `
 
 const _undefined = void 0;
 
+function disableGlobal(name) {
+  Object.defineProperty(self, name, {
+    value: _undefined,
+    writable: false,
+    configurable: false,
+  });
+}
+
 // Network
-self.fetch = _undefined;
-self.XMLHttpRequest = _undefined;
-self.WebSocket = _undefined;
-self.EventSource = _undefined;
-self.RTCPeerConnection = _undefined;
-self.RTCDataChannel = _undefined;
-self.Request = _undefined;
-self.Response = _undefined;
-self.Headers = _undefined;
-self.Cache = _undefined;
-self.CacheStorage = _undefined;
-self.caches = _undefined;
+for (const name of [
+  "fetch",
+  "XMLHttpRequest",
+  "WebSocket",
+  "EventSource",
+  "RTCPeerConnection",
+  "RTCDataChannel",
+  "Request",
+  "Response",
+  "Headers",
+  "Cache",
+  "CacheStorage",
+  "caches",
+]) disableGlobal(name);
 
 // Import / eval escape hatches
-self.importScripts = _undefined;
-self.Worker = _undefined;
-self.SharedWorker = _undefined;
-self.Blob = _undefined;
+for (const name of ["importScripts", "Worker", "SharedWorker", "Blob"]) disableGlobal(name);
 if (self.URL) {
   try { Object.defineProperty(self.URL, "createObjectURL", { value: _undefined, writable: false, configurable: false }); } catch {}
   try { Object.defineProperty(self.URL, "revokeObjectURL", { value: _undefined, writable: false, configurable: false }); } catch {}
@@ -71,13 +78,10 @@ if (self.URL) {
 if (self.navigator) {
   try { Object.defineProperty(self.navigator, "sendBeacon", { value: _undefined, writable: false, configurable: false }); } catch {}
 }
-
-// Service worker / broadcast channel
-self.BroadcastChannel = _undefined;
+for (const name of ["BroadcastChannel"]) disableGlobal(name);
 
 // IndexedDB (prevents persistent state exfiltration)
-self.indexedDB = _undefined;
-self.IDBFactory = _undefined;
+for (const name of ["indexedDB", "IDBFactory"]) disableGlobal(name);
 
 // ── 2. Parser state ─────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- disable Worker globals with `Object.defineProperty` so getter-only globals such as `caches` and `indexedDB` do not abort strict-mode bootstrap
- keep the sandbox fail-closed when a dangerous global cannot be overridden
- coalesce async parser result notifications to one animation frame to avoid rebuilding large transcripts once per JSONL line
- replace source-text lockdown assertions with behavioral coverage and add a getter-only regression

## Reproduction

On Paperclip 2026.720.0 in Chrome, opening a run from an external adapter leaves Nice mode on the generic stdout parser. Replaying the production Worker bootstrap reports:

```text
Uncaught TypeError: Cannot set property caches of #<WorkerGlobalScope> which has only a getter
```

After guarding only `caches`, startup fails next on getter-only `indexedDB`. Both descriptors are configurable in Chrome, so defining immutable `undefined` values preserves the intended lockdown.

## Verification

- `pnpm exec vitest run ui/src/adapters/sandboxed-parser-worker.test.ts`
- `pnpm --filter @paperclipai/ui typecheck`
- `pnpm --filter @paperclipai/ui build`
- exact Worker bootstrap exercised in Chrome against an external OMP parser: `ready`, then parsed result
- 3,577-line run reduced from raw JSONL to 26 Nice transcript entries; `toolcall_delta` raw count dropped to zero
