### PR TITLE
Coalesce dynamic parser transcript recomputations

### DIFF
--- a/ui/src/adapters/dynamic-loader.test.ts
+++ b/ui/src/adapters/dynamic-loader.test.ts
@@ -1,0 +1,84 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const workerFactory = vi.hoisted(() => ({
+  create: vi.fn(),
+}));
+
+vi.mock("./sandboxed-parser-worker", () => ({
+  createSandboxedWorker: workerFactory.create,
+}));
+
+import {
+  invalidateDynamicParser,
+  loadDynamicParser,
+  setDynamicParserResultNotifier,
+} from "./dynamic-loader";
+
+type FakeWorker = {
+  onmessage: ((event: MessageEvent) => void) | null;
+  onerror: ((event: ErrorEvent) => void) | null;
+  postMessage: (message: { type: string; id?: number }) => void;
+  terminate: ReturnType<typeof vi.fn>;
+};
+
+function createFakeWorker(): Worker {
+  const worker: FakeWorker = {
+    onmessage: null,
+    onerror: null,
+    postMessage(message: { type: string; id?: number }) {
+      if (message.type === "init") {
+        queueMicrotask(() => worker.onmessage?.({ data: { type: "ready" } } as MessageEvent));
+        return;
+      }
+      if (message.type === "parse") {
+        queueMicrotask(() => worker.onmessage?.({
+          data: { type: "result", id: message.id, entries: [] },
+        } as MessageEvent));
+      }
+    },
+    terminate: vi.fn(),
+  };
+  return worker as unknown as Worker;
+}
+
+describe("dynamic UI parser result notifications", () => {
+  const adapterType = "coalescing_test";
+  const animationFrames: FrameRequestCallback[] = [];
+
+  beforeEach(() => {
+    workerFactory.create.mockImplementation(createFakeWorker);
+    vi.stubGlobal("fetch", vi.fn(async () => new Response("module.exports = { parseStdoutLine: () => [] }")));
+    vi.stubGlobal("requestAnimationFrame", vi.fn((callback: FrameRequestCallback) => {
+      animationFrames.push(callback);
+      return animationFrames.length;
+    }));
+  });
+
+  afterEach(() => {
+    invalidateDynamicParser(adapterType);
+    setDynamicParserResultNotifier(null);
+    animationFrames.length = 0;
+    vi.clearAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("recomputes once per animation frame when many lines finish together", async () => {
+    const notify = vi.fn();
+    setDynamicParserResultNotifier(notify);
+    const parser = await loadDynamicParser(adapterType);
+    expect(parser).not.toBeNull();
+
+    for (let index = 0; index < 3_577; index += 1) {
+      parser?.parseStdoutLine(`line ${index}`, "2026-07-20T23:52:22Z");
+    }
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(requestAnimationFrame).toHaveBeenCalledTimes(1);
+    expect(notify).not.toHaveBeenCalled();
+
+    animationFrames[0]?.(0);
+    expect(notify).toHaveBeenCalledTimes(1);
+  });
+});

--- a/ui/src/adapters/dynamic-loader.ts
+++ b/ui/src/adapters/dynamic-loader.ts
@@ -61,6 +61,7 @@ const failedLoads = new Set<string>();
 const loadPromises = new Map<string, Promise<DynamicParserModule | null>>();
 
 let resultNotifier: (() => void) | null = null;
+let resultNotificationFrame: number | null = null;
 
 export function setDynamicParserResultNotifier(fn: (() => void) | null): void {
   resultNotifier = fn;
@@ -81,7 +82,11 @@ function lineCacheKey(line: string, ts: string): string {
 }
 
 function notifyResultReady(): void {
-  resultNotifier?.();
+  if (resultNotificationFrame !== null) return;
+  resultNotificationFrame = requestAnimationFrame(() => {
+    resultNotificationFrame = null;
+    resultNotifier?.();
+  });
 }
 
 /**


### PR DESCRIPTION
## Thinking Path

> - Paperclip renders agent run logs into human-readable transcripts in the board UI
> - External adapters parse stdout inside a sandboxed Web Worker
> - Worker parsing is asynchronous, while the transcript builder consumes cached results synchronously
> - Each completed line currently notifies the registry independently and rebuilds the complete transcript
> - Large JSONL runs therefore trigger thousands of redundant React updates and full-log reparses
> - This pull request batches completed-line notifications to one per animation frame
> - The benefit is bounded UI recomputation without changing adapter output or parser semantics

## Linked Issues or Issue Description

Refs #8806. That PR fixes the worker startup failure that exposed this downstream performance problem.

**What happened:** Once an external parser Worker is active, each parsed JSONL line calls the registry notifier. A captured OMP run contained 3,577 lines, so one burst could request 3,577 full transcript recomputations.

**Expected behavior:** Parsed line results should populate the cache immediately, while transcript recomputation should happen at most once per browser animation frame.

**Steps to reproduce:** Load an external-adapter run with thousands of JSONL stdout lines, let the Worker resolve the parse requests in one burst, and count calls to the dynamic-parser result notifier.

**Version/deployment:** Reproduced against Paperclip 2026.720.0, local `paperclipai onboard` deployment, Chrome on Fedora/WSL.

## What Changed

- Schedule dynamic parser result notification with `requestAnimationFrame`.
- Keep a single pending frame so additional Worker results reuse it.
- Add a 3,577-line regression test proving one notifier call per frame instead of one per line.

## Verification

- `pnpm exec vitest run ui/src/adapters/dynamic-loader.test.ts` — 1 passed.
- `pnpm --filter @paperclipai/ui typecheck` — passed.
- `pnpm --filter @paperclipai/ui build` — passed (existing CSS/font/chunk-size warnings only).
- Browser replay after the companion worker fix: the 3,577-line OMP run stabilized as 22 Nice transcript entries with no raw `message_update`/`toolcall_delta` rows.

## Risks

- Low risk: cached parse results are unchanged; only registry notification timing changes.
- Visible transcript updates may arrive up to one animation frame later.
- Browsers throttle animation frames in hidden tabs, but no hidden-tab render is useful; cached results render when the tab becomes visible.

> This is a tightly scoped UI performance fix. ROADMAP.md contains no overlapping planned work.

## Model Used

- `sub2api-codex/gpt-5.6-sol`, tool-assisted coding and browser execution with high-reasoning workflow; context-window size was not independently verified.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
