### PR TITLE
test(ui): cover secret creation within folders

### DIFF
--- a/ui/src/pages/Secrets.render.test.tsx
+++ b/ui/src/pages/Secrets.render.test.tsx
@@ -1699,6 +1699,122 @@ describe("Secrets folder view (PAP-14698)", () => {
     await act(async () => root.unmount());
   });
 
+  it("creates a company secret from a folder prefix and derives the key from the full name", async () => {
+    mockSecretsApi.create.mockResolvedValue(
+      makeCompanySecret({ id: "created", name: "dev/github/oauth/clientsecret/deeper" }),
+    );
+    const root = await renderAt("/?path=dev/github/oauth");
+
+    const newSecretButton = [...document.querySelectorAll("button")].find(
+      (button) => button.textContent?.trim() === "New secret",
+    ) as HTMLButtonElement;
+    await act(async () => newSecretButton.click());
+    await flushReact();
+
+    expect(document.body.textContent).toContain("dev/github/oauth/");
+    const nameInput = document.getElementById("new-secret-name") as HTMLInputElement;
+    expect(nameInput.placeholder).toBe("clientsecret");
+    expect(nameInput.value).toBe("");
+    await act(async () => setInputValue(nameInput, "clientsecret/deeper"));
+    await flushReact();
+
+    expect((document.getElementById("new-secret-key") as HTMLInputElement).value).toBe(
+      "dev-github-oauth-clientsecret-deeper",
+    );
+    await act(async () =>
+      setTextareaValue(document.getElementById("new-secret-value") as HTMLTextAreaElement, "secret-value"),
+    );
+    const createButton = [...document.querySelectorAll("button")].find(
+      (button) => button.textContent?.trim() === "Create secret",
+    ) as HTMLButtonElement;
+    await act(async () => createButton.click());
+    await flushReact();
+
+    expect(mockSecretsApi.create).toHaveBeenCalledWith(
+      "company-1",
+      expect.objectContaining({ name: "dev/github/oauth/clientsecret/deeper" }),
+    );
+
+    await act(async () => root.unmount());
+  });
+
+  it("keeps the folder prefix for Each user and exposes the full name when the chip is removed", async () => {
+    const root = await renderAt("/?path=dev/github/oauth");
+    const newSecretButton = [...document.querySelectorAll("button")].find(
+      (button) => button.textContent?.trim() === "New secret",
+    ) as HTMLButtonElement;
+    await act(async () => newSecretButton.click());
+    await flushReact();
+
+    const eachUserTab = [...document.querySelectorAll("button")].find(
+      (button) => button.textContent?.trim() === "Each user",
+    ) as HTMLButtonElement;
+    await act(async () => {
+      eachUserTab.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true }));
+      eachUserTab.dispatchEvent(new KeyboardEvent("keydown", { bubbles: true, key: "Enter" }));
+      eachUserTab.click();
+    });
+    await flushReact();
+
+    const nameInput = document.getElementById("new-secret-name") as HTMLInputElement;
+    await act(async () => setInputValue(nameInput, "personal-token"));
+    await flushReact();
+    expect((document.getElementById("new-secret-key") as HTMLInputElement).value).toBe(
+      "DEV_GITHUB_OAUTH_PERSONAL_TOKEN",
+    );
+
+    const removePrefix = document.querySelector(
+      'button[aria-label="Remove folder prefix"]',
+    ) as HTMLButtonElement;
+    await act(async () => removePrefix.click());
+    await flushReact();
+    expect((document.getElementById("new-secret-name") as HTMLInputElement).value).toBe(
+      "dev/github/oauth/personal-token",
+    );
+    expect(document.querySelector('button[aria-label="Remove folder prefix"]')).toBeNull();
+
+    await act(async () => root.unmount());
+  });
+
+  it("validates New folder inline and stages the trimmed segment in the URL-backed folder view", async () => {
+    const root = await renderAt("/?path=dev/github/oauth");
+    const newFolderButton = [...container.querySelectorAll("button")].find(
+      (button) => button.textContent?.trim() === "New folder",
+    ) as HTMLButtonElement;
+    await act(async () => newFolderButton.click());
+    await flushReact();
+
+    const folderInput = container.querySelector('input[aria-label="Folder name"]') as HTMLInputElement;
+    await act(async () => setInputValue(folderInput, "bad/name"));
+    const createFolderButton = [...container.querySelectorAll("button")].find(
+      (button) => button.textContent?.trim() === "Create folder",
+    ) as HTMLButtonElement;
+    await act(async () => createFolderButton.click());
+    await flushReact();
+    expect(container.querySelector('[role="alert"]')?.textContent).toContain(
+      "Folder name cannot contain slashes.",
+    );
+
+    await act(async () => setInputValue(folderInput, "  staged  "));
+    await flushReact();
+    await act(async () => createFolderButton.click());
+    await waitForReact(() =>
+      [...container.querySelectorAll('[aria-current="page"]')].some((node) =>
+        node.textContent?.includes("staged"),
+      ),
+    );
+
+    expect(
+      [...container.querySelectorAll('[aria-current="page"]')].some((node) =>
+        node.textContent?.includes("staged"),
+      ),
+    ).toBe(true);
+    expect(container.textContent).toContain("No secrets in this folder yet.");
+    expect(container.querySelector('input[aria-label="Folder name"]')).toBeNull();
+
+    await act(async () => root.unmount());
+  });
+
   it("Flat toggle reproduces the raw, ungrouped list", async () => {
     const root = await renderAt("/");
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The Secrets UI lets operators navigate slash-delimited secret names as folders
> - PR #9913 shipped create-in-folder behavior for company and per-user secrets
> - The production behavior is already on master, but several create-in-folder interaction paths lack retained regression coverage there
> - Without that coverage, prefix composition, derived keys, prefix removal, and staged empty folders could regress unnoticed
> - This pull request adds focused render tests without changing production behavior
> - The benefit is safer maintenance of the folder-based secrets workflow with a small, reviewable patch

## Linked Issues or Issue Description

- Refs #9913

## What Changed

- Added render coverage for creating a company secret from a folder and deriving its key from the full slash-delimited name.
- Added coverage for per-user secret prefixes and exposing the full name when the prefix chip is removed.
- Added coverage for inline folder-name validation and URL-backed staging of an empty folder.

## Verification

- `env -u PAPERCLIP_IN_WORKTREE -u PAPERCLIP_WORKTREE_NAME -u PAPERCLIP_CONFIG -u PAPERCLIP_HOME -u PAPERCLIP_INSTANCE_ID -u PAPERCLIP_CONTEXT pnpm exec vitest run ui/src/pages/Secrets.render.test.tsx` — 29 tests passed.
- `pnpm check:token-gates` — reports five existing `#9627` literals in unrelated files; this PR changes no token-gated component code and introduces no new violation.

## Risks

- Low risk: test-only change with no production, API, schema, migration, dependency, or runtime behavior changes.
- The tests exercise existing DOM interactions and may need updates if the Secrets creation UI copy or controls intentionally change.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex CLI managed coding agent with repository inspection, code execution, Git/GitHub, and Paperclip API tools. The managed harness does not expose the exact underlying model ID or context-window size.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [ ] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details — the assigned execution branch name is fixed by the task
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes — no documentation change is needed for test-only coverage
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
