### PR TITLE
fix: prevent stale runs from reopening cancelled issues

### DIFF
--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -1592,6 +1592,43 @@ describe("agent issue mutation checkout ownership", () => {
     },
   );
 
+  it("rejects a stale owner run from resurrecting a cancelled issue", async () => {
+    mockIssueService.getById.mockResolvedValue(
+      makeIssue({
+        status: "cancelled",
+        assigneeAgentId: ownerAgentId,
+        executionRunId: null,
+        checkoutRunId: null,
+      }),
+    );
+
+    const res = await request(await createApp(ownerActor()))
+      .patch(`/api/issues/${issueId}`)
+      .send({ status: "in_progress" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(409);
+    expect(mockIssueService.assertCheckoutOwner).not.toHaveBeenCalled();
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+  });
+
+  it("preserves board authority to reopen a cancelled issue", async () => {
+    mockIssueService.getById.mockResolvedValue(
+      makeIssue({
+        status: "cancelled",
+        assigneeAgentId: ownerAgentId,
+        executionRunId: null,
+        checkoutRunId: null,
+      }),
+    );
+
+    const res = await request(await createApp(boardActor()))
+      .patch(`/api/issues/${issueId}`)
+      .send({ status: "in_progress" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(mockIssueService.update).toHaveBeenCalled();
+  });
+
   it("allows same-company agent mutations on unassigned in-progress issues", async () => {
     mockIssueService.getById.mockResolvedValue(makeIssue({ assigneeAgentId: null }));
     mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({

--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -1592,7 +1592,7 @@ describe("agent issue mutation checkout ownership", () => {
     },
   );
 
-  it("rejects a stale owner run from resurrecting a cancelled issue", async () => {
+  it.each(["todo", "in_progress"])("rejects a stale owner run from moving a cancelled issue to %s", async (status) => {
     mockIssueService.getById.mockResolvedValue(
       makeIssue({
         status: "cancelled",
@@ -1604,7 +1604,7 @@ describe("agent issue mutation checkout ownership", () => {
 
     const res = await request(await createApp(ownerActor()))
       .patch(`/api/issues/${issueId}`)
-      .send({ status: "in_progress" });
+      .send({ status });
 
     expect(res.status, JSON.stringify(res.body)).toBe(409);
     expect(mockIssueService.assertCheckoutOwner).not.toHaveBeenCalled();

--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -1631,6 +1631,25 @@ describe("agent issue mutation checkout ownership", () => {
     expect(mockIssueService.addComment).not.toHaveBeenCalled();
   });
 
+  it("rejects a stale owner run from reopening a cancelled issue", async () => {
+    mockIssueService.getById.mockResolvedValue(
+      makeIssue({
+        status: "cancelled",
+        assigneeAgentId: ownerAgentId,
+        executionRunId: null,
+        checkoutRunId: null,
+      }),
+    );
+
+    const res = await request(await createApp(ownerActor()))
+      .patch(`/api/issues/${issueId}`)
+      .send({ reopen: true });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(409);
+    expect(mockIssueService.assertCheckoutOwner).not.toHaveBeenCalled();
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+  });
+
   it("preserves board authority to reopen a cancelled issue", async () => {
     mockIssueService.getById.mockResolvedValue(
       makeIssue({

--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -1611,6 +1611,26 @@ describe("agent issue mutation checkout ownership", () => {
     expect(mockIssueService.update).not.toHaveBeenCalled();
   });
 
+  it("rejects a stale owner run from resuming a cancelled issue through a comment", async () => {
+    mockIssueService.getById.mockResolvedValue(
+      makeIssue({
+        status: "cancelled",
+        assigneeAgentId: ownerAgentId,
+        executionRunId: null,
+        checkoutRunId: null,
+      }),
+    );
+
+    const res = await request(await createApp(ownerActor()))
+      .patch(`/api/issues/${issueId}`)
+      .send({ resume: true, comment: "Resume this issue" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(409);
+    expect(mockIssueService.assertCheckoutOwner).not.toHaveBeenCalled();
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+    expect(mockIssueService.addComment).not.toHaveBeenCalled();
+  });
+
   it("preserves board authority to reopen a cancelled issue", async () => {
     mockIssueService.getById.mockResolvedValue(
       makeIssue({

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -8588,7 +8588,8 @@ export function issueRoutes(
       req.actor.type === "agent" &&
       req.actor.agentId === existing.assigneeAgentId &&
       existing.status === "cancelled" &&
-      req.body.status === "in_progress"
+      req.body.status !== undefined &&
+      req.body.status !== "cancelled"
     ) {
       res.status(409).json({ error: "Cancelled issues cannot be resumed by a stale agent run" });
       return;

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -8589,6 +8589,7 @@ export function issueRoutes(
       req.actor.agentId === existing.assigneeAgentId &&
       existing.status === "cancelled" &&
       (req.body.resume === true ||
+        req.body.reopen === true ||
         (req.body.status !== undefined && req.body.status !== "cancelled"))
     ) {
       res.status(409).json({ error: "Cancelled issues cannot be resumed by a stale agent run" });

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -8584,6 +8584,15 @@ export function issueRoutes(
     const issueMutationAuthorizationReason = req.actor.type === "agent"
       ? issueWriteAuthorizationReason(req, await decideIssueAccess(req, existing, "issue:mutate"))
       : issueWriteAuthorizationReason(req, true);
+    if (
+      req.actor.type === "agent" &&
+      req.actor.agentId === existing.assigneeAgentId &&
+      existing.status === "cancelled" &&
+      req.body.status === "in_progress"
+    ) {
+      res.status(409).json({ error: "Cancelled issues cannot be resumed by a stale agent run" });
+      return;
+    }
     if (!(await assertCheapRecoveryIssueAssigneeProfileAllowed(req, res, existing, req.body))) return;
 
     const actor = getActorInfo(req);

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -8588,8 +8588,8 @@ export function issueRoutes(
       req.actor.type === "agent" &&
       req.actor.agentId === existing.assigneeAgentId &&
       existing.status === "cancelled" &&
-      req.body.status !== undefined &&
-      req.body.status !== "cancelled"
+      (req.body.resume === true ||
+        (req.body.status !== undefined && req.body.status !== "cancelled"))
     ) {
       res.status(409).json({ error: "Cancelled issues cannot be resumed by a stale agent run" });
       return;


### PR DESCRIPTION
## Thinking Path

> - Paperclip coordinates long-running agent work through issues and execution runs
> - Cancelling an issue clears its active execution ownership and is meant to stop that work
> - A run that was already live can still send a late status update after cancellation
> - The issue mutation boundary currently trusts the same assignee whenever the issue is not `in_progress`
> - That lets the old run change a cancelled issue back to `in_progress`
> - This pull request rejects that agent-only transition while preserving board and watchdog recovery authority
> - The benefit is that cancellation remains stable even when an old run finishes late

## Linked Issues or Issue Description

- Refs #9755, specifically the cancellation-resurrection incident documented in its follow-up comment

## What Changed

- Reject an assigned agent's `cancelled` to `in_progress` status mutation with HTTP 409
- Add a regression for a stale owner run after execution and checkout ownership have been cleared
- Add an adjacent regression proving a board actor can still reopen the cancelled issue

## Verification

- `npx -y pnpm@9.15.4 exec vitest run server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts` — 68 tests passed
- `npx -y pnpm@9.15.4 --filter @paperclipai/server typecheck` — passed
- `git diff --check origin/master...HEAD` — passed

## Risks

- Low and intentionally narrow: ordinary agent actors can no longer reopen their own cancelled issues directly. Board actors retain explicit reopen authority, and task-watchdog mutations continue through their separately scoped recovery path.
- This fixes only the cancellation-resurrection facet of #9755; it does not claim to make arbitrary multi-step client operations transactional.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI GPT-5 Codex (`gpt-5`), reasoning mode with repository inspection, code execution, and local test tooling.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
