### PR TITLE
fix(server): cap same-root automatic retries with backoff and a park state

### DIFF
--- a/packages/db/src/migrations/0182_same_root_retry_cap.sql
+++ b/packages/db/src/migrations/0182_same_root_retry_cap.sql
@@ -1,0 +1,7 @@
+ALTER TABLE "heartbeat_runs"
+  ADD COLUMN IF NOT EXISTS "retry_root_run_id" uuid REFERENCES heartbeat_runs(id) ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS "retry_epoch" integer NOT NULL DEFAULT 0;
+
+CREATE INDEX IF NOT EXISTS heartbeat_runs_retry_root_epoch_idx
+  ON heartbeat_runs (retry_root_run_id, retry_epoch)
+  WHERE retry_root_run_id IS NOT NULL;

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -1261,6 +1261,13 @@
       "when": 1784231633059,
       "tag": "0181_decision_training_retention_policy",
       "breakpoints": true
+    },
+    {
+      "idx": 182,
+      "version": "7",
+      "when": 1784231700000,
+      "tag": "0182_same_root_retry_cap",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/heartbeat_runs.ts
+++ b/packages/db/src/schema/heartbeat_runs.ts
@@ -42,6 +42,10 @@ export const heartbeatRuns = pgTable(
     retryOfRunId: uuid("retry_of_run_id").references((): AnyPgColumn => heartbeatRuns.id, {
       onDelete: "set null",
     }),
+    retryRootRunId: uuid("retry_root_run_id").references((): AnyPgColumn => heartbeatRuns.id, {
+      onDelete: "set null",
+    }),
+    retryEpoch: integer("retry_epoch").notNull().default(0),
     processLossRetryCount: integer("process_loss_retry_count").notNull().default(0),
     scheduledRetryAt: timestamp("scheduled_retry_at", { withTimezone: true }),
     scheduledRetryAttempt: integer("scheduled_retry_attempt").notNull().default(0),

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -5214,6 +5214,98 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     const wakes = await db.select().from(agentWakeupRequests).where(eq(agentWakeupRequests.agentId, agentId));
     expect(wakes.some((row) => row.reason === "run_liveness_continuation")).toBe(false);
   });
+
+  it("bounds same-root automatic retries to four runs via the production mint, parks with owner/action, and resumes on new external input", async () => {
+    const { agentId, companyId, issueId, runId } = await seedStrandedIssueFixture({
+      status: "in_progress",
+      runStatus: "failed",
+    });
+    const heartbeat = heartbeatService(db);
+    const oldFinishedAt = new Date("2026-03-19T00:05:00.000Z");
+
+    const loadRun = async (id: string) =>
+      db.select().from(heartbeatRuns).where(eq(heartbeatRuns.id, id)).then((rows) => rows[0]!);
+    // The exact gate-source shape recovery paths pass into the production mint.
+    const gateSourceOf = (run: typeof heartbeatRuns.$inferSelect) => ({
+      id: run.id,
+      companyId: run.companyId,
+      retryRootRunId: run.retryRootRunId,
+      retryEpoch: run.retryEpoch,
+      errorCode: run.errorCode,
+      error: run.error,
+      responsibleUserId: run.responsibleUserId,
+    });
+    // Finalize a run as a past failure so the next mint sees a terminal run
+    // (no coalescing) and the issue-rewake throttle (which only counts recent
+    // terminal runs) stays out of the way.
+    const failRunInPast = async (id: string) =>
+      db
+        .update(heartbeatRuns)
+        .set({ status: "failed", errorCode: "process_lost", error: "still failing", finishedAt: oldFinishedAt, updatedAt: oldFinishedAt })
+        .where(eq(heartbeatRuns.id, id));
+    const recoveryWake = (source: ReturnType<typeof gateSourceOf>, reason: string, external = false) =>
+      heartbeat.wakeup(agentId, {
+        source: external ? "on_demand" : "automation",
+        triggerDetail: external ? "callback" : "system",
+        reason,
+        contextSnapshot: { issueId, taskId: issueId, wakeReason: reason },
+        requestedByActorType: external ? "user" : "system",
+        requestedByActorId: external ? "responsible-user" : null,
+        sameRootRetry: { source },
+      });
+
+    // Drive the real production mint (heartbeat.wakeup with sameRootRetry — the
+    // same call the stranded/source-scoped recovery paths make). Each allowed
+    // retry is scheduled with backoff and holds no slot.
+    let source = gateSourceOf(await loadRun(runId));
+    for (let attempt = 1; attempt <= 3; attempt += 1) {
+      const minted = await recoveryWake(source, "issue_assignment_recovery");
+      expect(minted?.status).toBe("scheduled_retry");
+      expect(minted?.retryRootRunId).toBe(runId);
+      expect(minted?.retryEpoch).toBe(0);
+      expect(minted?.scheduledRetryAttempt).toBe(attempt);
+      await failRunInPast(minted!.id);
+      source = gateSourceOf(await loadRun(minted!.id));
+    }
+
+    // Budget is now first run + 3 retries. Two concurrent 4th mints must both be
+    // refused — the advisory lock serializes them so neither slips a 5th run past
+    // the cap.
+    const [a, b] = await Promise.all([
+      recoveryWake(source, "issue_assignment_recovery"),
+      recoveryWake(source, "issue_assignment_recovery"),
+    ]);
+    expect(a).toBeNull();
+    expect(b).toBeNull();
+
+    const rootRuns = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(and(eq(heartbeatRuns.companyId, companyId), eq(heartbeatRuns.retryRootRunId, runId), eq(heartbeatRuns.retryEpoch, 0)));
+    expect(rootRuns).toHaveLength(3); // 3 retries + the root run = 4 automatic runs
+
+    // Park recorded with an operator-facing next owner/action; execution slot released.
+    const park = await db
+      .select()
+      .from(activityLog)
+      .where(and(eq(activityLog.entityId, issueId), eq(activityLog.action, "issue.same_root_retry_parked")));
+    expect(park.length).toBeGreaterThanOrEqual(1);
+    const parkDetails = park[0]?.details as Record<string, unknown>;
+    expect(parkDetails.status).toBe("parked");
+    expect(parkDetails.reason).toBe("root_retry_cap_exhausted");
+    expect(parkDetails.nextAction).toBeTruthy();
+    const issueAfterPark = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(issueAfterPark?.executionRunId ?? null).toBeNull();
+
+    // New external input opens a fresh retry epoch: the same root resumes with a
+    // clean budget (attempt 1 in epoch 1) through the real mint.
+    const resumed = await recoveryWake(source, "issue_commented", true);
+    expect(resumed?.status).toBe("scheduled_retry");
+    expect(resumed?.retryRootRunId).toBe(runId);
+    expect(resumed?.retryEpoch).toBe(1);
+    expect(resumed?.scheduledRetryAttempt).toBe(1);
+  });
+
   it("blocks stranded in-progress work after the continuation retry was already used", async () => {
     const { companyId, agentId, issueId, runId } = await seedStrandedIssueFixture({
       status: "in_progress",

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -2276,9 +2276,15 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       executionRunId: retryRun?.id ?? null,
     });
 
-    const comments = await db.select().from(issueComments).where(eq(issueComments.issueId, issueId));
+    // The resume-failure comment is posted after the scheduling transaction
+    // commits, so it can land a beat after the retry run row is observable.
+    // Wait for it instead of racing the post-commit insert under parallel load.
+    const comments = await waitForValue(async () => {
+      const rows = await db.select().from(issueComments).where(eq(issueComments.issueId, issueId));
+      return rows.length >= 1 ? rows : null;
+    });
     expect(comments).toHaveLength(1);
-    expect(comments[0]).toMatchObject({
+    expect(comments?.[0]).toMatchObject({
       authorType: "system",
       createdByRunId: runId,
       body: "Agent failed to resume after approval: `adapter_failed` — retrying (attempt 1/3)",
@@ -2514,9 +2520,14 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       .then((rows) => rows[0] ?? null);
     expect(retryWakeup?.reason).toBe(INTERACTION_CONTINUATION_INFRA_WAKE_REASON);
 
-    const comments = await db.select().from(issueComments).where(eq(issueComments.issueId, issueId));
+    // The resume-failure comment is posted after the scheduling transaction
+    // commits, so wait for it rather than racing the post-commit insert.
+    const comments = await waitForValue(async () => {
+      const rows = await db.select().from(issueComments).where(eq(issueComments.issueId, issueId));
+      return rows.length >= 1 ? rows : null;
+    });
     expect(comments).toHaveLength(1);
-    expect(comments[0]).toMatchObject({
+    expect(comments?.[0]).toMatchObject({
       authorType: "system",
       body: "Agent failed to resume after approval: `process_lost` — retrying (attempt 1/3)",
     });

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -1286,7 +1286,9 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       timeoutConfigured: false,
       timeoutFired: false,
     });
-    expect(["queued", "running"]).toContain(retryRun?.status);
+    // Process-loss retries are scheduled with backoff (they hold no slot) rather
+    // than started immediately, so the retry sits in `scheduled_retry`.
+    expect(retryRun?.status).toBe("scheduled_retry");
     expect(retryRun?.retryOfRunId).toBe(runId);
     expect(retryRun?.processLossRetryCount).toBe(1);
     expect(retryRun?.contextSnapshot as Record<string, unknown>).not.toHaveProperty("modelProfile");
@@ -1647,7 +1649,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       timeoutFired: false,
     });
     expect(retryRun).toMatchObject({
-      status: "queued",
+      status: "scheduled_retry",
       retryOfRunId: runId,
       processLossRetryCount: 1,
     });
@@ -1802,7 +1804,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(originalRetries).toHaveLength(1);
     const secondRetry = runs.find((row) => row.retryOfRunId === firstRetry!.id);
     expect(secondRetry).toMatchObject({
-      status: "queued",
+      status: "scheduled_retry",
       processLossRetryCount: 2,
     });
 
@@ -1880,7 +1882,8 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     });
 
     const retryRun = runs.find((row) => row.id !== runId);
-    expect(["queued", "running"]).toContain(retryRun?.status);
+    // Process-loss retries are scheduled with backoff (no slot held).
+    expect(retryRun?.status).toBe("scheduled_retry");
 
     const issue = await db
       .select()
@@ -5113,6 +5116,11 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     const heartbeat = heartbeatService(db);
 
     await heartbeat.reconcileStrandedAssignedIssues();
+    // Stranded-failure recovery is now scheduled with backoff (holds no slot);
+    // promote it past its delay and start the promoted run so the recovery run
+    // executes and is classified.
+    await heartbeat.promoteDueScheduledRetries(new Date(Date.now() + 60 * 60 * 1000));
+    await heartbeat.resumeQueuedRuns();
 
     const livenessWake = await waitForValue(async () => {
       const rows = await db.select().from(agentWakeupRequests).where(eq(agentWakeupRequests.agentId, agentId));
@@ -5188,6 +5196,11 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     const heartbeat = heartbeatService(db);
 
     await heartbeat.reconcileStrandedAssignedIssues();
+    // Stranded-failure recovery is now scheduled with backoff (holds no slot);
+    // promote it past its delay and start the promoted run so the recovery run
+    // executes and is classified.
+    await heartbeat.promoteDueScheduledRetries(new Date(Date.now() + 60 * 60 * 1000));
+    await heartbeat.resumeQueuedRuns();
 
     const retryRun = await waitForValue(async () => {
       const rows = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.agentId, agentId));

--- a/server/src/__tests__/same-root-retry-cap.test.ts
+++ b/server/src/__tests__/same-root-retry-cap.test.ts
@@ -1,0 +1,199 @@
+import { describe, expect, it } from "vitest";
+import {
+  AUTOMATIC_RETRY_LINEAGE_WAKE_REASONS,
+  SAME_ROOT_AUTOMATIC_RETRY_BACKOFF_MS,
+  SAME_ROOT_AUTOMATIC_RETRY_JITTER_RATIO,
+  SAME_ROOT_AUTOMATIC_RETRY_MAX_RETRIES,
+  SAME_ROOT_AUTOMATIC_RETRY_MAX_RUNS,
+  SAME_ROOT_AUTOMATIC_RETRY_MIN_DELAY_MS,
+  buildSameRootRetryPark,
+  computeSameRootRetryDelayMs,
+  evaluateSameRootRetry,
+  isEpochAdvancingWakeReason,
+  resolveRetryEpochForNewRun,
+  resolveRetryRootRunId,
+} from "../services/same-root-retry-cap.ts";
+
+describe("resolveRetryRootRunId", () => {
+  it("uses the source's own id when it is the first run of a lineage", () => {
+    expect(resolveRetryRootRunId({ id: "run-a", retryRootRunId: null, retryEpoch: null })).toBe("run-a");
+  });
+
+  it("propagates an existing root unchanged so fresh run ids cannot escape it", () => {
+    expect(resolveRetryRootRunId({ id: "run-b", retryRootRunId: "run-a", retryEpoch: 0 })).toBe("run-a");
+  });
+});
+
+describe("isEpochAdvancingWakeReason", () => {
+  it("keeps recovery-internal reasons on the same epoch", () => {
+    for (const reason of AUTOMATIC_RETRY_LINEAGE_WAKE_REASONS) {
+      expect(isEpochAdvancingWakeReason(reason)).toBe(false);
+    }
+  });
+
+  it("advances the epoch for new external input", () => {
+    for (const reason of [
+      "issue_commented",
+      "issue_status_changed",
+      "issue_reopened",
+      "issue_children_changed",
+      "issue_blockers_resolved",
+      "issue_comment_mentioned",
+      "issue_monitor_due",
+      "issue_assigned",
+      "manual_retry",
+    ]) {
+      expect(isEpochAdvancingWakeReason(reason)).toBe(true);
+    }
+  });
+
+  it("treats an unknown reason as new input (fail open to resume, not to loop)", () => {
+    expect(isEpochAdvancingWakeReason("some_future_reason")).toBe(true);
+  });
+
+  it("does not advance on a missing reason", () => {
+    expect(isEpochAdvancingWakeReason(null)).toBe(false);
+    expect(isEpochAdvancingWakeReason(undefined)).toBe(false);
+  });
+});
+
+describe("resolveRetryEpochForNewRun", () => {
+  const source = { id: "run-a", retryRootRunId: null, retryEpoch: 2 };
+
+  it("continues the source epoch for a recovery-internal wake", () => {
+    expect(resolveRetryEpochForNewRun({ source, wakeReason: "process_lost_retry" })).toBe(2);
+    expect(resolveRetryEpochForNewRun({ source, wakeReason: "issue_continuation_needed" })).toBe(2);
+  });
+
+  it("advances the epoch for new external input", () => {
+    expect(resolveRetryEpochForNewRun({ source, wakeReason: "issue_commented" })).toBe(3);
+  });
+
+  it("treats a missing source epoch as 0", () => {
+    const fresh = { id: "run-a", retryRootRunId: null, retryEpoch: null };
+    expect(resolveRetryEpochForNewRun({ source: fresh, wakeReason: "process_lost_retry" })).toBe(0);
+    expect(resolveRetryEpochForNewRun({ source: fresh, wakeReason: "issue_commented" })).toBe(1);
+  });
+});
+
+describe("evaluateSameRootRetry", () => {
+  it("allows the first, second, and third retry (first run + 3 = 4 total)", () => {
+    for (let priorRuns = 1; priorRuns <= SAME_ROOT_AUTOMATIC_RETRY_MAX_RETRIES; priorRuns += 1) {
+      const decision = evaluateSameRootRetry({ priorAutomaticRunCount: priorRuns });
+      expect(decision).toEqual({
+        allowed: true,
+        attempt: priorRuns,
+        maxRetries: SAME_ROOT_AUTOMATIC_RETRY_MAX_RETRIES,
+      });
+    }
+  });
+
+  it("parks the 4th retry — no 5th run for the same root/epoch", () => {
+    const decision = evaluateSameRootRetry({ priorAutomaticRunCount: SAME_ROOT_AUTOMATIC_RETRY_MAX_RUNS });
+    expect(decision).toEqual({
+      allowed: false,
+      outcome: "root_retry_cap_exhausted",
+      attempt: SAME_ROOT_AUTOMATIC_RETRY_MAX_RUNS,
+      maxRetries: SAME_ROOT_AUTOMATIC_RETRY_MAX_RETRIES,
+    });
+  });
+
+  it("stops a 144-run same-root failure chain within 4 total runs", () => {
+    // Replay of the FALA-491-class chain: a root that keeps failing and being
+    // recovered. Count the automatic runs that would actually be created.
+    let automaticRunsCreated = 1; // the first (root) run
+    for (let i = 0; i < 144; i += 1) {
+      const decision = evaluateSameRootRetry({ priorAutomaticRunCount: automaticRunsCreated });
+      if (!decision.allowed) break;
+      automaticRunsCreated += 1;
+    }
+    expect(automaticRunsCreated).toBe(SAME_ROOT_AUTOMATIC_RETRY_MAX_RUNS);
+    expect(automaticRunsCreated).toBeLessThanOrEqual(4);
+  });
+
+  it("resumes with a clean budget after the epoch advances", () => {
+    // Same root, new epoch (e.g. a human comment): the per-epoch count resets.
+    const resumed = evaluateSameRootRetry({ priorAutomaticRunCount: 1 });
+    expect(resumed.allowed).toBe(true);
+    expect(resumed.attempt).toBe(1);
+  });
+
+  it("honors a caller-supplied lower cap", () => {
+    expect(evaluateSameRootRetry({ priorAutomaticRunCount: 1, maxRetries: 0 }).allowed).toBe(false);
+    expect(evaluateSameRootRetry({ priorAutomaticRunCount: 1, maxRetries: 1 }).allowed).toBe(true);
+    expect(evaluateSameRootRetry({ priorAutomaticRunCount: 2, maxRetries: 1 }).allowed).toBe(false);
+  });
+});
+
+describe("computeSameRootRetryDelayMs", () => {
+  it("returns the ladder base delay when jitter is neutral", () => {
+    SAME_ROOT_AUTOMATIC_RETRY_BACKOFF_MS.forEach((base, index) => {
+      expect(computeSameRootRetryDelayMs(index + 1, () => 0.5)).toBe(base);
+    });
+  });
+
+  it("grows monotonically across attempts (exponential backoff)", () => {
+    const delays = SAME_ROOT_AUTOMATIC_RETRY_BACKOFF_MS.map((_base, index) =>
+      computeSameRootRetryDelayMs(index + 1, () => 0.5),
+    );
+    for (let i = 1; i < delays.length; i += 1) {
+      expect(delays[i]).toBeGreaterThan(delays[i - 1]);
+    }
+  });
+
+  it("keeps every delay inside the ±25% jitter band", () => {
+    SAME_ROOT_AUTOMATIC_RETRY_BACKOFF_MS.forEach((base, index) => {
+      const attempt = index + 1;
+      const low = computeSameRootRetryDelayMs(attempt, () => 0);
+      const high = computeSameRootRetryDelayMs(attempt, () => 1);
+      expect(low).toBe(Math.round(base * (1 - SAME_ROOT_AUTOMATIC_RETRY_JITTER_RATIO)));
+      expect(high).toBe(Math.round(base * (1 + SAME_ROOT_AUTOMATIC_RETRY_JITTER_RATIO)));
+      // random() is clamped to [0,1], so the band is a hard range.
+      for (const sample of [0, 0.1, 0.37, 0.5, 0.83, 1]) {
+        const delay = computeSameRootRetryDelayMs(attempt, () => sample);
+        expect(delay).toBeGreaterThanOrEqual(low);
+        expect(delay).toBeLessThanOrEqual(high);
+      }
+    });
+  });
+
+  it("reuses the last rung for attempts past the ladder and never returns below the floor", () => {
+    const lastBase = SAME_ROOT_AUTOMATIC_RETRY_BACKOFF_MS[SAME_ROOT_AUTOMATIC_RETRY_BACKOFF_MS.length - 1];
+    expect(computeSameRootRetryDelayMs(99, () => 0.5)).toBe(lastBase);
+    expect(computeSameRootRetryDelayMs(1, () => 0)).toBeGreaterThanOrEqual(SAME_ROOT_AUTOMATIC_RETRY_MIN_DELAY_MS);
+  });
+});
+
+describe("buildSameRootRetryPark", () => {
+  it("captures the last failure and a resumable next action for the operator", () => {
+    const park = buildSameRootRetryPark({
+      rootRunId: "run-a",
+      epoch: 0,
+      attempt: 4,
+      maxRetries: 3,
+      lastErrorCode: "adapter_failed",
+      lastErrorMessage: "Configured model is unavailable",
+      nextOwner: "user-owner",
+    });
+    expect(park.status).toBe("parked");
+    expect(park.reason).toBe("root_retry_cap_exhausted");
+    expect(park.rootRunId).toBe("run-a");
+    expect(park.nextOwner).toBe("user-owner");
+    expect(park.summary).toContain("adapter_failed");
+    expect(park.summary).toContain("Configured model is unavailable");
+    expect(park.nextAction).toMatch(/resume/i);
+  });
+
+  it("degrades gracefully when no error detail is available", () => {
+    const park = buildSameRootRetryPark({
+      rootRunId: "run-a",
+      epoch: 1,
+      attempt: 4,
+      maxRetries: 3,
+      lastErrorCode: null,
+      lastErrorMessage: null,
+      nextOwner: null,
+    });
+    expect(park.summary).toContain("unknown failure");
+  });
+});

--- a/server/src/__tests__/same-root-retry-cap.test.ts
+++ b/server/src/__tests__/same-root-retry-cap.test.ts
@@ -99,8 +99,8 @@ describe("evaluateSameRootRetry", () => {
   });
 
   it("stops a 144-run same-root failure chain within 4 total runs", () => {
-    // Replay of the FALA-491-class chain: a root that keeps failing and being
-    // recovered. Count the automatic runs that would actually be created.
+    // Replay of the runaway chain this cap targets: a root that keeps failing and
+    // being recovered. Count the automatic runs that would actually be created.
     let automaticRunsCreated = 1; // the first (root) run
     for (let i = 0; i < 144; i += 1) {
       const decision = evaluateSameRootRetry({ priorAutomaticRunCount: automaticRunsCreated });

--- a/server/src/__tests__/same-root-retry-gate.integration.test.ts
+++ b/server/src/__tests__/same-root-retry-gate.integration.test.ts
@@ -1,0 +1,198 @@
+import { randomUUID } from "node:crypto";
+import { and, count, eq } from "drizzle-orm";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { agents, companies, createDb, heartbeatRuns } from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import { enforceSameRootRetryCap } from "../services/same-root-retry-gate.ts";
+import { SAME_ROOT_AUTOMATIC_RETRY_MAX_RUNS } from "../services/same-root-retry-cap.ts";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping embedded Postgres same-root retry gate tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+// The number of retry runs that carry the root marker before the root is parked.
+// The first (root) run has a null retry_root_run_id, so it is not counted here;
+// SAME_ROOT_AUTOMATIC_RETRY_MAX_RUNS includes it (first run + retries).
+const MARKED_RETRIES = SAME_ROOT_AUTOMATIC_RETRY_MAX_RUNS - 1;
+
+describeEmbeddedPostgres("same-root retry gate (embedded postgres)", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+  let companyId!: string;
+  let agentId!: string;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-same-root-retry-gate-");
+    db = createDb(tempDb.connectionString);
+  }, 20_000);
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  beforeEach(async () => {
+    await db.delete(heartbeatRuns);
+    await db.delete(agents);
+    await db.delete(companies);
+    companyId = randomUUID();
+    agentId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+      defaultResponsibleUserId: "owner-user",
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Dev",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+  });
+
+  async function insertRun(overrides: Partial<typeof heartbeatRuns.$inferInsert> = {}) {
+    return db
+      .insert(heartbeatRuns)
+      .values({
+        companyId,
+        agentId,
+        status: "failed",
+        errorCode: "adapter_failed",
+        error: "Configured model is unavailable",
+        responsibleUserId: "owner-user",
+        ...overrides,
+      })
+      .returning()
+      .then((rows) => rows[0]!);
+  }
+
+  async function countInEpoch(rootRunId: string, epoch: number) {
+    return db
+      .select({ value: count() })
+      .from(heartbeatRuns)
+      .where(
+        and(
+          eq(heartbeatRuns.companyId, companyId),
+          eq(heartbeatRuns.retryRootRunId, rootRunId),
+          eq(heartbeatRuns.retryEpoch, epoch),
+        ),
+      )
+      .then((rows) => rows[0]?.value ?? 0);
+  }
+
+  // Replay of the FALA-491-class chain: a root that keeps failing, each failure
+  // driving another automatic retry. The gate runs in the same transaction that
+  // inserts the retry, so the count and the insert are atomic under its lock.
+  async function driveFailureChain(
+    root: typeof heartbeatRuns.$inferSelect,
+    iterations: number,
+    wakeReason = "process_lost_retry",
+  ) {
+    let source = root;
+    let automaticRunsCreated = 1; // the first (root) run
+    let lastPark: unknown = null;
+    for (let i = 0; i < iterations; i += 1) {
+      const decision = await db.transaction((tx) =>
+        enforceSameRootRetryCap(tx, { source, wakeReason, nextOwner: "owner-user" }),
+      );
+      if (!decision.allowed) {
+        lastPark = decision.park;
+        break;
+      }
+      source = await insertRun({
+        retryOfRunId: source.id,
+        retryRootRunId: decision.retryRootRunId,
+        retryEpoch: decision.retryEpoch,
+      });
+      automaticRunsCreated += 1;
+    }
+    return { automaticRunsCreated, lastPark };
+  }
+
+  it("stops a 144-run same-root failure chain within 4 total runs and parks it", async () => {
+    const root = await insertRun();
+    const { automaticRunsCreated, lastPark } = await driveFailureChain(root, 144);
+
+    expect(automaticRunsCreated).toBe(SAME_ROOT_AUTOMATIC_RETRY_MAX_RUNS);
+    expect(automaticRunsCreated).toBeLessThanOrEqual(4);
+    expect(await countInEpoch(root.id, 0)).toBe(MARKED_RETRIES);
+
+    // Exhaustion parks the root with an operator-visible failure + owner + action.
+    expect(lastPark).toMatchObject({
+      status: "parked",
+      reason: "root_retry_cap_exhausted",
+      rootRunId: root.id,
+      lastErrorCode: "adapter_failed",
+      nextOwner: "owner-user",
+    });
+    expect((lastPark as { nextAction: string }).nextAction).toMatch(/resume/i);
+  });
+
+  it("does not create a 5th run when recovery events keep repeating", async () => {
+    const root = await insertRun();
+    await driveFailureChain(root, 10, "issue_continuation_needed");
+    // Any further recovery-internal wake for the same root/epoch is refused.
+    const decision = await db.transaction((tx) =>
+      enforceSameRootRetryCap(tx, { source: root, wakeReason: "issue_assignment_recovery" }),
+    );
+    expect(decision.allowed).toBe(false);
+    expect(await countInEpoch(root.id, 0)).toBe(MARKED_RETRIES);
+  });
+
+  it("resumes with a clean budget when new external input advances the epoch", async () => {
+    const root = await insertRun();
+    await driveFailureChain(root, 144); // exhaust epoch 0
+
+    // A human comment / monitor signal on the same root is epoch-advancing.
+    const resumed = await db.transaction((tx) =>
+      enforceSameRootRetryCap(tx, { source: root, wakeReason: "issue_commented" }),
+    );
+    expect(resumed.allowed).toBe(true);
+    if (resumed.allowed) {
+      expect(resumed.retryEpoch).toBe(1);
+      expect(resumed.attempt).toBe(1);
+    }
+  });
+
+  it("enforces the cap atomically under concurrent minters (advisory lock)", async () => {
+    const root = await insertRun();
+    // Many recovery paths racing to recover the same root at once. The advisory
+    // lock must serialize count → insert so none can slip past the cap.
+    const attempts = Array.from({ length: 8 }, () =>
+      db.transaction(async (tx) => {
+        const decision = await enforceSameRootRetryCap(tx, {
+          source: root,
+          wakeReason: "process_lost_retry",
+        });
+        if (decision.allowed) {
+          await tx.insert(heartbeatRuns).values({
+            companyId,
+            agentId,
+            status: "failed",
+            retryOfRunId: root.id,
+            retryRootRunId: decision.retryRootRunId,
+            retryEpoch: decision.retryEpoch,
+          });
+        }
+        return decision.allowed;
+      }),
+    );
+    const allowed = (await Promise.all(attempts)).filter(Boolean).length;
+    expect(allowed).toBe(MARKED_RETRIES);
+    expect(await countInEpoch(root.id, 0)).toBe(MARKED_RETRIES);
+  });
+});

--- a/server/src/__tests__/same-root-retry-gate.integration.test.ts
+++ b/server/src/__tests__/same-root-retry-gate.integration.test.ts
@@ -94,7 +94,7 @@ describeEmbeddedPostgres("same-root retry gate (embedded postgres)", () => {
       .then((rows) => rows[0]?.value ?? 0);
   }
 
-  // Replay of the FALA-491-class chain: a root that keeps failing, each failure
+  // Replay of the runaway chain this cap targets: a root that keeps failing, each failure
   // driving another automatic retry. The gate runs in the same transaction that
   // inserts the retry, so the count and the insert are atomic under its lock.
   async function driveFailureChain(

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import { execFile as execFileCallback } from "node:child_process";
 import { promisify } from "node:util";
 import { createHash, randomUUID } from "node:crypto";
-import { and, asc, desc, eq, getTableColumns, gt, gte, inArray, isNull, lt, lte, notInArray, or, sql } from "drizzle-orm";
+import { and, asc, count, desc, eq, getTableColumns, gt, gte, inArray, isNull, lt, lte, notInArray, or, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import {
   AGENT_DEFAULT_MAX_CONCURRENT_RUNS,
@@ -203,6 +203,13 @@ import {
   readContinuationAttempt,
 } from "./recovery/index.js";
 import { isAutomaticRecoverySuppressedByPauseHold } from "./recovery/pause-hold-guard.js";
+import {
+  buildSameRootRetryPark,
+  computeSameRootRetryDelayMs,
+  evaluateSameRootRetry,
+  resolveRetryEpochForNewRun,
+  resolveRetryRootRunId,
+} from "./same-root-retry-cap.js";
 import {
   recoveryAssigneeAdapterOverrides,
   withRecoveryModelProfileHint,
@@ -1777,6 +1784,8 @@ const heartbeatRunListColumns = {
   lastOutputStream: heartbeatRuns.lastOutputStream,
   lastOutputBytes: heartbeatRuns.lastOutputBytes,
   retryOfRunId: heartbeatRuns.retryOfRunId,
+  retryRootRunId: heartbeatRuns.retryRootRunId,
+  retryEpoch: heartbeatRuns.retryEpoch,
   processLossRetryCount: heartbeatRuns.processLossRetryCount,
   scheduledRetryAt: heartbeatRuns.scheduledRetryAt,
   scheduledRetryAttempt: heartbeatRuns.scheduledRetryAttempt,
@@ -8651,7 +8660,47 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     }, "normal_model");
     const responsibleUserId = await resolveResponsibleUserIdForRunContext(run, retryContextSnapshot);
 
-    const queued = await db.transaction(async (tx) => {
+    const retryRootRunId = resolveRetryRootRunId(run);
+    const retryEpoch = resolveRetryEpochForNewRun({ source: run, wakeReason: "process_lost_retry" });
+
+    const priorAutomaticRunCount = await db
+      .select({ value: count() })
+      .from(heartbeatRuns)
+      .where(
+        and(
+          eq(heartbeatRuns.companyId, run.companyId),
+          eq(heartbeatRuns.retryRootRunId, retryRootRunId),
+          eq(heartbeatRuns.retryEpoch, retryEpoch),
+        ),
+      )
+      .then((rows) => rows[0]?.value ?? 0);
+
+    const capDecision = evaluateSameRootRetry({ priorAutomaticRunCount: priorAutomaticRunCount + 1 });
+    if (!capDecision.allowed) {
+      const park = buildSameRootRetryPark({
+        rootRunId: retryRootRunId,
+        epoch: retryEpoch,
+        attempt: capDecision.attempt,
+        maxRetries: capDecision.maxRetries,
+        lastErrorCode: run.errorCode ?? null,
+        lastErrorMessage: run.error ?? null,
+        nextOwner: run.responsibleUserId ?? null,
+      });
+      await appendRunEvent(run, await nextRunEventSeq(run.id), {
+        eventType: "lifecycle",
+        stream: "system",
+        level: "error",
+        message: park.summary,
+        payload: park,
+      });
+      await releaseIssueExecutionAndPromote(run);
+      return null;
+    }
+
+    const retryDelayMs = computeSameRootRetryDelayMs(capDecision.attempt);
+    const scheduledAt = new Date(now.getTime() + retryDelayMs);
+
+    const scheduled = await db.transaction(async (tx) => {
       const wakeupRequest = await tx
         .insert(agentWakeupRequests)
         .values({
@@ -8679,13 +8728,18 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           agentId: run.agentId,
           invocationSource: "automation",
           triggerDetail: "system",
-          status: "queued",
+          status: "scheduled_retry",
           wakeupRequestId: wakeupRequest.id,
           contextSnapshot: retryContextSnapshot,
           responsibleUserId,
           sessionIdBefore: sessionBefore,
           retryOfRunId: run.id,
+          retryRootRunId,
+          retryEpoch,
           processLossRetryCount: (run.processLossRetryCount ?? 0) + 1,
+          scheduledRetryAt: scheduledAt,
+          scheduledRetryAttempt: capDecision.attempt,
+          scheduledRetryReason: "process_lost_retry",
           updatedAt: now,
         })
         .returning()
@@ -8715,29 +8769,22 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       return retryRun;
     });
 
-    publishLiveEvent({
-      companyId: queued.companyId,
-      type: "heartbeat.run.queued",
-      payload: {
-        runId: queued.id,
-        agentId: queued.agentId,
-        invocationSource: queued.invocationSource,
-        triggerDetail: queued.triggerDetail,
-        wakeupRequestId: queued.wakeupRequestId,
-      },
-    });
-
-    await appendRunEvent(queued, 1, {
+    await appendRunEvent(scheduled, 1, {
       eventType: "lifecycle",
       stream: "system",
       level: "warn",
-      message: "Queued automatic retry after orphaned child process was confirmed dead",
+      message: "Scheduled automatic retry after orphaned child process was confirmed dead",
       payload: {
         retryOfRunId: run.id,
+        retryRootRunId,
+        retryEpoch,
+        attempt: capDecision.attempt,
+        scheduledAt: scheduledAt.toISOString(),
+        delayMs: retryDelayMs,
       },
     });
 
-    return queued;
+    return scheduled;
   }
 
   function toHotRestartIntentRun(input: {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -203,13 +203,8 @@ import {
   readContinuationAttempt,
 } from "./recovery/index.js";
 import { isAutomaticRecoverySuppressedByPauseHold } from "./recovery/pause-hold-guard.js";
-import {
-  buildSameRootRetryPark,
-  computeSameRootRetryDelayMs,
-  evaluateSameRootRetry,
-  resolveRetryEpochForNewRun,
-  resolveRetryRootRunId,
-} from "./same-root-retry-cap.js";
+import { computeSameRootRetryDelayMs } from "./same-root-retry-cap.js";
+import { enforceSameRootRetryCap } from "./same-root-retry-gate.js";
 import {
   recoveryAssigneeAdapterOverrides,
   withRecoveryModelProfileHint,
@@ -8660,47 +8655,22 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     }, "normal_model");
     const responsibleUserId = await resolveResponsibleUserIdForRunContext(run, retryContextSnapshot);
 
-    const retryRootRunId = resolveRetryRootRunId(run);
-    const retryEpoch = resolveRetryEpochForNewRun({ source: run, wakeReason: "process_lost_retry" });
-
-    const priorAutomaticRunCount = await db
-      .select({ value: count() })
-      .from(heartbeatRuns)
-      .where(
-        and(
-          eq(heartbeatRuns.companyId, run.companyId),
-          eq(heartbeatRuns.retryRootRunId, retryRootRunId),
-          eq(heartbeatRuns.retryEpoch, retryEpoch),
-        ),
-      )
-      .then((rows) => rows[0]?.value ?? 0);
-
-    const capDecision = evaluateSameRootRetry({ priorAutomaticRunCount: priorAutomaticRunCount + 1 });
-    if (!capDecision.allowed) {
-      const park = buildSameRootRetryPark({
-        rootRunId: retryRootRunId,
-        epoch: retryEpoch,
-        attempt: capDecision.attempt,
-        maxRetries: capDecision.maxRetries,
-        lastErrorCode: run.errorCode ?? null,
-        lastErrorMessage: run.error ?? null,
+    // Enforce the same-root retry cap atomically with the insert: the gate takes
+    // an advisory lock on (root, epoch) and counts inside this transaction, so a
+    // racing recovery path cannot also slip a run past the limit.
+    const outcome = await db.transaction(async (tx) => {
+      const gate = await enforceSameRootRetryCap(tx, {
+        source: run,
+        wakeReason: "process_lost_retry",
         nextOwner: run.responsibleUserId ?? null,
       });
-      await appendRunEvent(run, await nextRunEventSeq(run.id), {
-        eventType: "lifecycle",
-        stream: "system",
-        level: "error",
-        message: park.summary,
-        payload: park,
-      });
-      await releaseIssueExecutionAndPromote(run);
-      return null;
-    }
+      if (!gate.allowed) {
+        return { kind: "parked" as const, park: gate.park };
+      }
 
-    const retryDelayMs = computeSameRootRetryDelayMs(capDecision.attempt);
-    const scheduledAt = new Date(now.getTime() + retryDelayMs);
+      const retryDelayMs = computeSameRootRetryDelayMs(gate.attempt);
+      const scheduledAt = new Date(now.getTime() + retryDelayMs);
 
-    const scheduled = await db.transaction(async (tx) => {
       const wakeupRequest = await tx
         .insert(agentWakeupRequests)
         .values({
@@ -8734,11 +8704,11 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           responsibleUserId,
           sessionIdBefore: sessionBefore,
           retryOfRunId: run.id,
-          retryRootRunId,
-          retryEpoch,
+          retryRootRunId: gate.retryRootRunId,
+          retryEpoch: gate.retryEpoch,
           processLossRetryCount: (run.processLossRetryCount ?? 0) + 1,
           scheduledRetryAt: scheduledAt,
-          scheduledRetryAttempt: capDecision.attempt,
+          scheduledRetryAttempt: gate.attempt,
           scheduledRetryReason: "process_lost_retry",
           updatedAt: now,
         })
@@ -8766,25 +8736,46 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           .where(and(eq(issues.id, issueId), eq(issues.companyId, run.companyId), eq(issues.executionRunId, run.id)));
       }
 
-      return retryRun;
+      return {
+        kind: "scheduled" as const,
+        scheduled: retryRun,
+        attempt: gate.attempt,
+        retryRootRunId: gate.retryRootRunId,
+        retryEpoch: gate.retryEpoch,
+        scheduledAt,
+        retryDelayMs,
+      };
     });
 
-    await appendRunEvent(scheduled, 1, {
+    if (outcome.kind === "parked") {
+      const park = outcome.park;
+      await appendRunEvent(run, await nextRunEventSeq(run.id), {
+        eventType: "lifecycle",
+        stream: "system",
+        level: "error",
+        message: park.summary,
+        payload: park,
+      });
+      await releaseIssueExecutionAndPromote(run);
+      return null;
+    }
+
+    await appendRunEvent(outcome.scheduled, 1, {
       eventType: "lifecycle",
       stream: "system",
       level: "warn",
       message: "Scheduled automatic retry after orphaned child process was confirmed dead",
       payload: {
         retryOfRunId: run.id,
-        retryRootRunId,
-        retryEpoch,
-        attempt: capDecision.attempt,
-        scheduledAt: scheduledAt.toISOString(),
-        delayMs: retryDelayMs,
+        retryRootRunId: outcome.retryRootRunId,
+        retryEpoch: outcome.retryEpoch,
+        attempt: outcome.attempt,
+        scheduledAt: outcome.scheduledAt.toISOString(),
+        delayMs: outcome.retryDelayMs,
       },
     });
 
-    return scheduled;
+    return outcome.scheduled;
   }
 
   function toHotRestartIntentRun(input: {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -203,8 +203,8 @@ import {
   readContinuationAttempt,
 } from "./recovery/index.js";
 import { isAutomaticRecoverySuppressedByPauseHold } from "./recovery/pause-hold-guard.js";
-import { computeSameRootRetryDelayMs } from "./same-root-retry-cap.js";
-import { enforceSameRootRetryCap } from "./same-root-retry-gate.js";
+import { computeSameRootRetryDelayMs, type SameRootRetryPark } from "./same-root-retry-cap.js";
+import { enforceSameRootRetryCap, type SameRootRetryGateSource } from "./same-root-retry-gate.js";
 import {
   recoveryAssigneeAdapterOverrides,
   withRecoveryModelProfileHint,
@@ -2032,6 +2032,25 @@ interface WakeupOptions {
   requestedByActorType?: "user" | "agent" | "system";
   requestedByActorId?: string | null;
   contextSnapshot?: Record<string, unknown>;
+  /**
+   * When set, this wake mints an *automatic same-root retry*. The same-root cap
+   * is enforced atomically inside the mint transaction (advisory lock + count +
+   * insert under one lock), so a racing recovery path cannot slip a run past the
+   * limit. When allowed the run is inserted as `scheduled_retry` with exponential
+   * backoff + jitter — holding no concurrency slot and started only after commit
+   * by the retry-promotion loop, never immediately. When the `(root, epoch)`
+   * budget is exhausted the root is *parked*: no run is minted, the issue
+   * execution slot is released, and the last failure + next owner/action are left
+   * operator-visible. This is the single primitive every recovery mint point uses
+   * so process-loss, stranded-issue, and source-scoped recovery all apply the
+   * identical cap, backoff, and park behaviour.
+   */
+  sameRootRetry?: {
+    /** The source run being retried, used to resolve `(root, epoch)` and park detail. */
+    source: SameRootRetryGateSource;
+    /** Who should look at the parked issue next; defaults to the source's responsible user. */
+    nextOwner?: string | null;
+  };
 }
 
 type UsageTotals = {
@@ -16143,6 +16162,40 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           return { kind: "skipped" as const };
         }
 
+        // Automatic same-root retry: enforce the cap atomically with the insert.
+        // The gate takes an advisory lock on (root, epoch) and counts inside this
+        // same transaction, so a racing recovery path cannot also mint past the
+        // limit. When allowed we insert `scheduled_retry` with exponential backoff
+        // (holds no slot, promoted later — never started immediately); on
+        // exhaustion we park the root and mint nothing.
+        let sameRootRetrySchedule:
+          | {
+              scheduledAt: Date;
+              attempt: number;
+              retryRootRunId: string;
+              retryEpoch: number;
+              retryOfRunId: string;
+            }
+          | null = null;
+        if (opts.sameRootRetry) {
+          const gate = await enforceSameRootRetryCap(tx, {
+            source: opts.sameRootRetry.source,
+            wakeReason: reason,
+            nextOwner: opts.sameRootRetry.nextOwner ?? null,
+          });
+          if (!gate.allowed) {
+            return { kind: "parked" as const, park: gate.park, source: opts.sameRootRetry.source };
+          }
+          const delayMs = computeSameRootRetryDelayMs(gate.attempt);
+          sameRootRetrySchedule = {
+            scheduledAt: new Date(Date.now() + delayMs),
+            attempt: gate.attempt,
+            retryRootRunId: gate.retryRootRunId,
+            retryEpoch: gate.retryEpoch,
+            retryOfRunId: opts.sameRootRetry.source.id,
+          };
+        }
+
         const wakeupRequest = await tx
           .insert(agentWakeupRequests)
           .values({
@@ -16167,12 +16220,22 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             agentId,
             invocationSource: source,
             triggerDetail,
-            status: "queued",
+            status: sameRootRetrySchedule ? "scheduled_retry" : "queued",
             responsibleUserId: await resolveQueuedResponsibleUserId(),
             wakeupRequestId: wakeupRequest.id,
             contextSnapshot: enrichedContextSnapshot,
             sessionIdBefore: sessionBefore,
             continuationAttempt,
+            ...(sameRootRetrySchedule
+              ? {
+                  retryOfRunId: sameRootRetrySchedule.retryOfRunId,
+                  retryRootRunId: sameRootRetrySchedule.retryRootRunId,
+                  retryEpoch: sameRootRetrySchedule.retryEpoch,
+                  scheduledRetryAt: sameRootRetrySchedule.scheduledAt,
+                  scheduledRetryAttempt: sameRootRetrySchedule.attempt,
+                  scheduledRetryReason: reason,
+                }
+              : {}),
           })
           .returning()
           .then((rows) => rows[0]);
@@ -16193,12 +16256,60 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       });
 
       if (outcome.kind === "deferred" || outcome.kind === "skipped") return null;
+      if (outcome.kind === "parked") {
+        const parkSource = outcome.source;
+        await logActivity(db, {
+          companyId: parkSource.companyId,
+          actorType: "system",
+          actorId: reason ?? "same_root_retry",
+          agentId,
+          runId: parkSource.id,
+          action: "issue.same_root_retry_parked",
+          entityType: "issue",
+          entityId: issueId ?? parkSource.id,
+          details: outcome.park,
+        });
+        // Release the execution slot so the parked issue is not stuck locked on the
+        // finalized source run. suppressImmediateRecovery avoids re-triggering
+        // recovery (which would just re-park) — the root stays operator-visible.
+        const fullSourceRun = await db
+          .select()
+          .from(heartbeatRuns)
+          .where(eq(heartbeatRuns.id, parkSource.id))
+          .then((rows) => rows[0] ?? null);
+        if (fullSourceRun) {
+          await releaseIssueExecutionAndPromote(fullSourceRun, { suppressImmediateRecovery: true });
+        }
+        return null;
+      }
       if (outcome.kind === "coalesced") {
         await startNextQueuedRunForAgent(agent.id);
         return outcome.run;
       }
 
       const newRun = outcome.run;
+      if (newRun.status === "scheduled_retry") {
+        // A same-root retry scheduled with backoff: it holds no concurrency slot
+        // and is promoted by the retry loop after its delay, so we neither publish
+        // a "queued" event nor try to start it now. Surface the schedule as a run
+        // event for operator visibility.
+        await appendRunEvent(newRun, 1, {
+          eventType: "lifecycle",
+          stream: "system",
+          level: "warn",
+          message: "Scheduled automatic same-root retry with backoff",
+          payload: {
+            retryOfRunId: newRun.retryOfRunId,
+            retryRootRunId: newRun.retryRootRunId,
+            retryEpoch: newRun.retryEpoch,
+            attempt: newRun.scheduledRetryAttempt,
+            scheduledAt: newRun.scheduledRetryAt
+              ? new Date(newRun.scheduledRetryAt).toISOString()
+              : null,
+          },
+        });
+        return newRun;
+      }
       publishLiveEvent({
         companyId: newRun.companyId,
         type: "heartbeat.run.queued",

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -39,7 +39,7 @@ import { instanceSettingsService } from "../instance-settings.js";
 import { issueRecoveryActionService } from "../issue-recovery-actions.js";
 import { issueTreeControlService } from "../issue-tree-control.js";
 import { TERMINAL_HEARTBEAT_RUN_STATUSES, issueService } from "../issues.js";
-import { enforceSameRootRetryCap, type SameRootRetryGateResult } from "../same-root-retry-gate.js";
+import { type SameRootRetryGateSource } from "../same-root-retry-gate.js";
 import {
   applyIssueMonitorPolicyTransition,
   normalizeIssueExecutionPolicy,
@@ -119,6 +119,16 @@ type RecoveryWakeupOptions = {
   requestedByActorType?: "user" | "agent" | "system";
   requestedByActorId?: string | null;
   contextSnapshot?: Record<string, unknown>;
+  /**
+   * Mint an automatic same-root retry: the cap is enforced atomically inside the
+   * mint transaction and, when allowed, the run is scheduled with backoff (no
+   * slot held); on exhaustion the root is parked and nothing is minted. Mirrors
+   * the `sameRootRetry` option of the heartbeat service's `enqueueWakeup`.
+   */
+  sameRootRetry?: {
+    source: SameRootRetryGateSource;
+    nextOwner?: string | null;
+  };
 };
 
 type RecoveryWakeup = (
@@ -680,6 +690,17 @@ function buildLivenessOriginalIssueComment(finding: IssueLivenessFinding, escala
   ].join("\n");
 }
 
+/**
+ * Whether a source run is a *failure* whose automatic re-drive should count
+ * against — and be throttled by — the same-root retry cap. Re-waking a run that
+ * finished normally (e.g. a stranded review participant whose run succeeded) is
+ * legitimate progress, not a retry, so it is exempt from the cap and backoff.
+ */
+function isFailureRetrySource(run: { status: string; errorCode: string | null }): boolean {
+  if (run.errorCode != null) return true;
+  return run.status === "failed" || run.status === "timed_out";
+}
+
 export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup }) {
   const issuesSvc = issueService(db);
   const recoveryActionsSvc = issueRecoveryActionService(db);
@@ -1019,16 +1040,24 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     retryOfRunId?: string | null;
     extraContext?: Record<string, unknown>;
   }) {
-    // Consult the shared same-root cap before minting another recovery run so
-    // this path cannot bypass the limit by allocating a fresh run id. Only a
-    // lineage with a known source run is capped; a fresh dispatch (no
-    // retryOfRunId) starts its own root and is always allowed.
-    let gate: SameRootRetryGateResult | null = null;
+    // Resolve the source run so the shared same-root cap can be enforced
+    // atomically inside enqueueWakeup's mint transaction (advisory lock + count +
+    // scheduled_retry insert under one lock). This path cannot bypass the limit
+    // by allocating a fresh run id: the (root, epoch) budget, backoff scheduling,
+    // slot release, and park are all owned by the gated mint. Only a *failure*
+    // lineage with a known source run is capped: FALA #9734 is about automatic
+    // retries of a failing run, so a re-wake that continues a run which finished
+    // normally (e.g. re-enqueuing a stranded review participant whose run
+    // succeeded) is legitimate progress, not a retry, and must not be throttled
+    // or parked. A fresh dispatch (no retryOfRunId, or a missing source run)
+    // starts its own root and is always allowed.
+    let sameRootRetrySource: SameRootRetryGateSource | null = null;
     if (input.retryOfRunId) {
       const sourceRun = await db
         .select({
           id: heartbeatRuns.id,
           companyId: heartbeatRuns.companyId,
+          status: heartbeatRuns.status,
           retryRootRunId: heartbeatRuns.retryRootRunId,
           retryEpoch: heartbeatRuns.retryEpoch,
           errorCode: heartbeatRuns.errorCode,
@@ -1038,27 +1067,18 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         .from(heartbeatRuns)
         .where(eq(heartbeatRuns.id, input.retryOfRunId))
         .then((rows) => rows[0] ?? null);
-      if (sourceRun) {
-        gate = await enforceSameRootRetryCap(db, { source: sourceRun, wakeReason: input.reason });
-        if (!gate.allowed) {
-          // Exhausted: do not create another recovery run/issue/comment. Leave
-          // the last failure and next owner/action operator-visible instead.
-          await logActivity(db, {
-            companyId: sourceRun.companyId,
-            actorType: "system",
-            actorId: input.reason,
-            agentId: input.agentId,
-            runId: input.retryOfRunId,
-            action: "issue.same_root_retry_parked",
-            entityType: "issue",
-            entityId: input.issueId,
-            details: gate.park,
-          });
-          return null;
-        }
+      if (sourceRun && isFailureRetrySource(sourceRun)) {
+        const { status: _status, ...gateSource } = sourceRun;
+        sameRootRetrySource = gateSource;
       }
     }
 
+    // For the capped (failure) path, enqueueWakeup enforces the cap atomically,
+    // stamps the source-run linkage + root/epoch inside the mint, records the park
+    // itself (with slot release) on exhaustion, and returns null — nothing else is
+    // needed here. For a non-failure re-wake the run is minted normally; we still
+    // record retryOfRunId below for traceability (lineage metadata, not part of
+    // the cap, so a post-insert stamp is race-free).
     const queued = await deps.enqueueWakeup(input.agentId, {
       source: "automation",
       triggerDetail: "system",
@@ -1079,18 +1099,20 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         ...(input.retryOfRunId ? { retryOfRunId: input.retryOfRunId } : {}),
         ...(input.extraContext ?? {}),
       }, "normal_model"),
+      ...(sameRootRetrySource
+        ? {
+            sameRootRetry: {
+              source: sameRootRetrySource,
+              nextOwner: sameRootRetrySource.responsibleUserId ?? null,
+            },
+          }
+        : {}),
     });
 
-    if (queued && input.retryOfRunId) {
+    if (queued && input.retryOfRunId && !sameRootRetrySource) {
       return db
         .update(heartbeatRuns)
-        .set({
-          retryOfRunId: input.retryOfRunId,
-          // Propagate the invariant root/epoch so the next recovery on this
-          // chain counts against the same budget regardless of which path mints it.
-          ...(gate?.allowed ? { retryRootRunId: gate.retryRootRunId, retryEpoch: gate.retryEpoch } : {}),
-          updatedAt: new Date(),
-        })
+        .set({ retryOfRunId: input.retryOfRunId, updatedAt: new Date() })
         .where(eq(heartbeatRuns.id, queued.id))
         .returning()
         .then((rows) => rows[0] ?? queued);
@@ -2894,15 +2916,18 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     if (input.recoveryCause === "configuration_incomplete") return;
     if (!input.action.ownerAgentId) return;
 
-    // Same-root cap: this recovery path mints a fresh run id too, so consult the
-    // shared gate before enqueuing so a stranded root cannot loop past the limit.
-    let gate: SameRootRetryGateResult | null = null;
+    // Same-root cap: this recovery path mints a fresh run id too, so resolve the
+    // stranded source run and let enqueueWakeup enforce the shared gate atomically
+    // inside its mint transaction (backoff scheduling, slot release, and park all
+    // owned there). A stranded root therefore cannot loop past the limit.
     const strandedRunId = input.latestRun?.id ?? null;
+    let sameRootRetrySource: SameRootRetryGateSource | null = null;
     if (strandedRunId) {
       const sourceRun = await db
         .select({
           id: heartbeatRuns.id,
           companyId: heartbeatRuns.companyId,
+          status: heartbeatRuns.status,
           retryRootRunId: heartbeatRuns.retryRootRunId,
           retryEpoch: heartbeatRuns.retryEpoch,
           errorCode: heartbeatRuns.errorCode,
@@ -2912,25 +2937,9 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         .from(heartbeatRuns)
         .where(eq(heartbeatRuns.id, strandedRunId))
         .then((rows) => rows[0] ?? null);
-      if (sourceRun) {
-        gate = await enforceSameRootRetryCap(db, {
-          source: sourceRun,
-          wakeReason: "source_scoped_recovery_action",
-        });
-        if (!gate.allowed) {
-          await logActivity(db, {
-            companyId: sourceRun.companyId,
-            actorType: "system",
-            actorId: "source_scoped_recovery_action",
-            agentId: input.action.ownerAgentId,
-            runId: strandedRunId,
-            action: "issue.same_root_retry_parked",
-            entityType: "issue",
-            entityId: input.issue.id,
-            details: gate.park,
-          });
-          return;
-        }
+      if (sourceRun && isFailureRetrySource(sourceRun)) {
+        const { status: _status, ...gateSource } = sourceRun;
+        sameRootRetrySource = gateSource;
       }
     }
 
@@ -2959,16 +2968,22 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         strandedRunId,
         recoveryCause: input.recoveryCause,
       }, "status_only"),
+      ...(sameRootRetrySource
+        ? {
+            sameRootRetry: {
+              source: sameRootRetrySource,
+              nextOwner: sameRootRetrySource.responsibleUserId ?? null,
+            },
+          }
+        : {}),
     });
 
-    if (wake && strandedRunId) {
+    // Non-failure re-wakes are minted normally; record the source-run linkage for
+    // traceability (the capped path already stamps it atomically inside the mint).
+    if (wake && strandedRunId && !sameRootRetrySource) {
       await db
         .update(heartbeatRuns)
-        .set({
-          retryOfRunId: strandedRunId,
-          ...(gate?.allowed ? { retryRootRunId: gate.retryRootRunId, retryEpoch: gate.retryEpoch } : {}),
-          updatedAt: new Date(),
-        })
+        .set({ retryOfRunId: strandedRunId, updatedAt: new Date() })
         .where(eq(heartbeatRuns.id, wake.id));
     }
   }

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -1045,7 +1045,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     // scheduled_retry insert under one lock). This path cannot bypass the limit
     // by allocating a fresh run id: the (root, epoch) budget, backoff scheduling,
     // slot release, and park are all owned by the gated mint. Only a *failure*
-    // lineage with a known source run is capped: FALA #9734 is about automatic
+    // lineage with a known source run is capped: #9734 is about automatic
     // retries of a failing run, so a re-wake that continues a run which finished
     // normally (e.g. re-enqueuing a stranded review participant whose run
     // succeeded) is legitimate progress, not a retry, and must not be throttled

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -39,6 +39,7 @@ import { instanceSettingsService } from "../instance-settings.js";
 import { issueRecoveryActionService } from "../issue-recovery-actions.js";
 import { issueTreeControlService } from "../issue-tree-control.js";
 import { TERMINAL_HEARTBEAT_RUN_STATUSES, issueService } from "../issues.js";
+import { enforceSameRootRetryCap, type SameRootRetryGateResult } from "../same-root-retry-gate.js";
 import {
   applyIssueMonitorPolicyTransition,
   normalizeIssueExecutionPolicy,
@@ -1018,6 +1019,46 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     retryOfRunId?: string | null;
     extraContext?: Record<string, unknown>;
   }) {
+    // Consult the shared same-root cap before minting another recovery run so
+    // this path cannot bypass the limit by allocating a fresh run id. Only a
+    // lineage with a known source run is capped; a fresh dispatch (no
+    // retryOfRunId) starts its own root and is always allowed.
+    let gate: SameRootRetryGateResult | null = null;
+    if (input.retryOfRunId) {
+      const sourceRun = await db
+        .select({
+          id: heartbeatRuns.id,
+          companyId: heartbeatRuns.companyId,
+          retryRootRunId: heartbeatRuns.retryRootRunId,
+          retryEpoch: heartbeatRuns.retryEpoch,
+          errorCode: heartbeatRuns.errorCode,
+          error: heartbeatRuns.error,
+          responsibleUserId: heartbeatRuns.responsibleUserId,
+        })
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.id, input.retryOfRunId))
+        .then((rows) => rows[0] ?? null);
+      if (sourceRun) {
+        gate = await enforceSameRootRetryCap(db, { source: sourceRun, wakeReason: input.reason });
+        if (!gate.allowed) {
+          // Exhausted: do not create another recovery run/issue/comment. Leave
+          // the last failure and next owner/action operator-visible instead.
+          await logActivity(db, {
+            companyId: sourceRun.companyId,
+            actorType: "system",
+            actorId: input.reason,
+            agentId: input.agentId,
+            runId: input.retryOfRunId,
+            action: "issue.same_root_retry_parked",
+            entityType: "issue",
+            entityId: input.issueId,
+            details: gate.park,
+          });
+          return null;
+        }
+      }
+    }
+
     const queued = await deps.enqueueWakeup(input.agentId, {
       source: "automation",
       triggerDetail: "system",
@@ -1045,6 +1086,9 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         .update(heartbeatRuns)
         .set({
           retryOfRunId: input.retryOfRunId,
+          // Propagate the invariant root/epoch so the next recovery on this
+          // chain counts against the same budget regardless of which path mints it.
+          ...(gate?.allowed ? { retryRootRunId: gate.retryRootRunId, retryEpoch: gate.retryEpoch } : {}),
           updatedAt: new Date(),
         })
         .where(eq(heartbeatRuns.id, queued.id))
@@ -2849,7 +2893,48 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     if (input.recoveryCause === "provider_quota" && !input.action.ownerAgentId) return;
     if (input.recoveryCause === "configuration_incomplete") return;
     if (!input.action.ownerAgentId) return;
-    await deps.enqueueWakeup(input.action.ownerAgentId, {
+
+    // Same-root cap: this recovery path mints a fresh run id too, so consult the
+    // shared gate before enqueuing so a stranded root cannot loop past the limit.
+    let gate: SameRootRetryGateResult | null = null;
+    const strandedRunId = input.latestRun?.id ?? null;
+    if (strandedRunId) {
+      const sourceRun = await db
+        .select({
+          id: heartbeatRuns.id,
+          companyId: heartbeatRuns.companyId,
+          retryRootRunId: heartbeatRuns.retryRootRunId,
+          retryEpoch: heartbeatRuns.retryEpoch,
+          errorCode: heartbeatRuns.errorCode,
+          error: heartbeatRuns.error,
+          responsibleUserId: heartbeatRuns.responsibleUserId,
+        })
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.id, strandedRunId))
+        .then((rows) => rows[0] ?? null);
+      if (sourceRun) {
+        gate = await enforceSameRootRetryCap(db, {
+          source: sourceRun,
+          wakeReason: "source_scoped_recovery_action",
+        });
+        if (!gate.allowed) {
+          await logActivity(db, {
+            companyId: sourceRun.companyId,
+            actorType: "system",
+            actorId: "source_scoped_recovery_action",
+            agentId: input.action.ownerAgentId,
+            runId: strandedRunId,
+            action: "issue.same_root_retry_parked",
+            entityType: "issue",
+            entityId: input.issue.id,
+            details: gate.park,
+          });
+          return;
+        }
+      }
+    }
+
+    const wake = await deps.enqueueWakeup(input.action.ownerAgentId, {
       source: "assignment",
       triggerDetail: "system",
       reason: "source_scoped_recovery_action",
@@ -2858,7 +2943,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         issueId: input.issue.id,
         sourceIssueId: input.issue.id,
         recoveryActionId: input.action.id,
-        strandedRunId: input.latestRun?.id ?? null,
+        strandedRunId,
         recoveryCause: input.recoveryCause,
       }, "status_only"),
       requestedByActorType: "system",
@@ -2871,10 +2956,21 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         source: "issue_recovery_action",
         recoveryActionId: input.action.id,
         sourceIssueId: input.issue.id,
-        strandedRunId: input.latestRun?.id ?? null,
+        strandedRunId,
         recoveryCause: input.recoveryCause,
       }, "status_only"),
     });
+
+    if (wake && strandedRunId) {
+      await db
+        .update(heartbeatRuns)
+        .set({
+          retryOfRunId: strandedRunId,
+          ...(gate?.allowed ? { retryRootRunId: gate.retryRootRunId, retryEpoch: gate.retryEpoch } : {}),
+          updatedAt: new Date(),
+        })
+        .where(eq(heartbeatRuns.id, wake.id));
+    }
   }
 
   function readProviderQuotaRetryAt(latestRun: LatestIssueRun, now: Date) {

--- a/server/src/services/same-root-retry-cap.ts
+++ b/server/src/services/same-root-retry-cap.ts
@@ -183,7 +183,10 @@ export interface SameRootRetryParkInput {
   nextOwner: string | null;
 }
 
-export interface SameRootRetryPark {
+// A type alias (not an interface) so it stays assignable to the
+// `Record<string, unknown>` payload/details shapes the run-event and
+// activity-log sinks accept.
+export type SameRootRetryPark = {
   status: "parked";
   reason: "root_retry_cap_exhausted";
   rootRunId: string;

--- a/server/src/services/same-root-retry-cap.ts
+++ b/server/src/services/same-root-retry-cap.ts
@@ -1,0 +1,230 @@
+/**
+ * Bound automatic retries on a single invariant "retry root".
+ *
+ * Terminal-run recovery, process-loss retries, and continuation-needed wakes
+ * each re-drive a failed issue by inserting a *new* heartbeat run with a *new*
+ * run/wake id. Every one of those paths carries its own per-lineage counter
+ * (`scheduledRetryAttempt`, `processLossRetryCount`, `continuationAttempt`),
+ * so no single limiter sees the whole chain. When a run keeps dying for a
+ * reason that cannot heal itself (OOM, a permanently misconfigured adapter,
+ * an auth wall), the chain retries **forever**: each recovery mints a fresh id
+ * that resets the counter it is measured against. A single such chain has been
+ * observed producing ~150 runs / 144 consecutive failures at a ~30s median
+ * interval, monopolizing a `maxConcurrentRuns: 1` agent so every other wake
+ * starves (see paperclipai/paperclip#9734, #7535).
+ *
+ * This module defines the invariant that closes that gap: a **retry root** —
+ * the id of the first run in an automatic retry/recovery lineage, propagated
+ * unchanged through every downstream recovery run regardless of which path
+ * mints it or what fresh ids it allocates. Automatic runs sharing a root are
+ * capped at the first run plus {@link SAME_ROOT_AUTOMATIC_RETRY_MAX_RETRIES}
+ * retries. While waiting between retries the run sits in `scheduled_retry` and
+ * holds no concurrency slot; on exhaustion the root is *parked* — no further
+ * automatic run, recovery issue, or recovery comment is created, and the last
+ * failure reason plus the next owner/action are left operator-visible.
+ *
+ * A park is not permanent. Genuinely new external input — a human comment, a
+ * new issue event, an explicit operator retry, or a monitor signal — opens a
+ * new **retry epoch**: the cap is counted per `(root, epoch)`, so a fresh
+ * epoch resumes the chain with a clean budget. Recovery-internal wakes (the
+ * retry/recovery reasons this module drives) do **not** advance the epoch, so
+ * a self-referential recovery loop cannot resurrect its own budget.
+ *
+ * The functions here are pure and side-effect free; callers supply the counts
+ * and reasons they read from the database and apply the returned decisions.
+ */
+
+/** First run + this many automatic retries per `(root, epoch)`; a 4th is parked. */
+export const SAME_ROOT_AUTOMATIC_RETRY_MAX_RETRIES = 3;
+
+/** Total automatic runs allowed per `(root, epoch)`: the first run + retries. */
+export const SAME_ROOT_AUTOMATIC_RETRY_MAX_RUNS = SAME_ROOT_AUTOMATIC_RETRY_MAX_RETRIES + 1;
+
+/** Exponential backoff ladder (ms) for same-root retries 1..N, before jitter. */
+export const SAME_ROOT_AUTOMATIC_RETRY_BACKOFF_MS = [
+  2 * 60 * 1000,
+  10 * 60 * 1000,
+  30 * 60 * 1000,
+] as const;
+
+/** Symmetric jitter applied to each backoff delay: ±25%. */
+export const SAME_ROOT_AUTOMATIC_RETRY_JITTER_RATIO = 0.25;
+
+/** Floor for any computed delay so a degenerate ladder entry never busy-loops. */
+export const SAME_ROOT_AUTOMATIC_RETRY_MIN_DELAY_MS = 1_000;
+
+/**
+ * Wake reasons that continue an existing automatic retry/recovery lineage.
+ * A run woken for one of these inherits its source run's epoch, so it counts
+ * against the same `(root, epoch)` budget instead of opening a new one. Every
+ * other wake reason (human comments, status/blocker/child events, explicit
+ * retries, monitor ticks, fresh assignments) is treated as new external input
+ * and advances the epoch — see {@link isEpochAdvancingWakeReason}.
+ *
+ * Defaulting *unknown* reasons to epoch-advancing is deliberate: a stuck root
+ * that resumes one extra time is a bounded, self-correcting error, whereas a
+ * misclassified recovery reason that advances the epoch would re-open the
+ * unbounded loop this module exists to close.
+ */
+export const AUTOMATIC_RETRY_LINEAGE_WAKE_REASONS: ReadonlySet<string> = new Set([
+  "transient_failure_retry",
+  "max_turns_continuation_retry",
+  "interaction_continuation_infra_retry",
+  "execution_review_participant_recovery",
+  "process_lost_retry",
+  "issue_continuation_needed",
+  "issue_assignment_recovery",
+  "issue_graph_liveness_backstop",
+  "source_scoped_recovery_action",
+]);
+
+/**
+ * Whether a wake reason represents new external input that should open a fresh
+ * retry epoch (resuming a parked root) rather than continuing the automatic
+ * lineage. Anything not recognized as recovery-internal advances the epoch.
+ */
+export function isEpochAdvancingWakeReason(reason: string | null | undefined): boolean {
+  if (!reason) return false;
+  return !AUTOMATIC_RETRY_LINEAGE_WAKE_REASONS.has(reason);
+}
+
+export interface RetryRootLineageSource {
+  /** The source run being retried/recovered from. */
+  id: string;
+  /** Its root, if it is itself part of a lineage; null for a first run. */
+  retryRootRunId: string | null;
+  /** Its epoch, if tracked; treated as 0 when absent. */
+  retryEpoch: number | null;
+}
+
+/**
+ * The invariant root id a new automatic run inherits from its source: the
+ * source's own root, or — when the source is the first run of a lineage — the
+ * source's id. Propagating this at every mint point is what makes the cap
+ * immune to fresh run/wake ids.
+ */
+export function resolveRetryRootRunId(source: RetryRootLineageSource): string {
+  return source.retryRootRunId ?? source.id;
+}
+
+/**
+ * The epoch a new automatic run belongs to. A recovery-internal wake continues
+ * the source epoch; new external input advances it by one so the `(root,
+ * epoch)` budget resets and a parked root resumes.
+ */
+export function resolveRetryEpochForNewRun(input: {
+  source: RetryRootLineageSource;
+  wakeReason: string | null | undefined;
+}): number {
+  const sourceEpoch = input.source.retryEpoch ?? 0;
+  return isEpochAdvancingWakeReason(input.wakeReason) ? sourceEpoch + 1 : sourceEpoch;
+}
+
+export type SameRootRetryDecision =
+  | {
+      allowed: true;
+      /** 1-based index of the retry about to be scheduled within this epoch. */
+      attempt: number;
+      maxRetries: number;
+    }
+  | {
+      allowed: false;
+      outcome: "root_retry_cap_exhausted";
+      attempt: number;
+      maxRetries: number;
+    };
+
+/**
+ * Decide whether one more automatic retry may be scheduled for a `(root,
+ * epoch)`, given how many automatic runs it already holds (the first run plus
+ * any retries already created in this epoch). The next retry's 1-based index is
+ * the current count; it is allowed while that index stays within the cap.
+ */
+export function evaluateSameRootRetry(input: {
+  /** Automatic runs already persisted for this `(root, epoch)`, incl. the first. */
+  priorAutomaticRunCount: number;
+  maxRetries?: number;
+}): SameRootRetryDecision {
+  const maxRetries = Math.max(0, Math.floor(input.maxRetries ?? SAME_ROOT_AUTOMATIC_RETRY_MAX_RETRIES));
+  const attempt = Math.max(1, Math.floor(input.priorAutomaticRunCount));
+  if (attempt <= maxRetries) {
+    return { allowed: true, attempt, maxRetries };
+  }
+  return { allowed: false, outcome: "root_retry_cap_exhausted", attempt, maxRetries };
+}
+
+/**
+ * Exponential-backoff delay (with symmetric jitter) for a same-root retry.
+ * `attempt` is 1-based; attempts past the ladder reuse its last rung so a
+ * caller that raises the cap still gets a bounded, non-zero delay.
+ */
+export function computeSameRootRetryDelayMs(
+  attempt: number,
+  random: () => number = Math.random,
+): number {
+  const ladder = SAME_ROOT_AUTOMATIC_RETRY_BACKOFF_MS;
+  const index = Math.min(Math.max(1, Math.floor(attempt)), ladder.length) - 1;
+  const baseDelayMs = ladder[index];
+  const sample = Math.min(1, Math.max(0, random()));
+  const jitterMultiplier = 1 + ((sample * 2 - 1) * SAME_ROOT_AUTOMATIC_RETRY_JITTER_RATIO);
+  return Math.max(SAME_ROOT_AUTOMATIC_RETRY_MIN_DELAY_MS, Math.round(baseDelayMs * jitterMultiplier));
+}
+
+export interface SameRootRetryParkInput {
+  rootRunId: string;
+  epoch: number;
+  attempt: number;
+  maxRetries: number;
+  /** Error code of the run that exhausted the budget, if any. */
+  lastErrorCode: string | null;
+  /** Human-readable failure detail from the last run, if any. */
+  lastErrorMessage: string | null;
+  /** Who should look at the parked issue next (e.g. the responsible user/owner). */
+  nextOwner: string | null;
+}
+
+export interface SameRootRetryPark {
+  status: "parked";
+  reason: "root_retry_cap_exhausted";
+  rootRunId: string;
+  epoch: number;
+  attempt: number;
+  maxRetries: number;
+  lastErrorCode: string | null;
+  lastErrorMessage: string | null;
+  nextOwner: string | null;
+  nextAction: string;
+  /** One-line, operator-facing summary safe to surface on the issue. */
+  summary: string;
+}
+
+/**
+ * Build the operator-visible park descriptor recorded when a root exhausts its
+ * automatic-retry budget. Callers persist this (and release the agent slot)
+ * instead of minting another recovery run/issue/comment; the chain only
+ * resumes when new external input advances the epoch.
+ */
+export function buildSameRootRetryPark(input: SameRootRetryParkInput): SameRootRetryPark {
+  const lastFailure = input.lastErrorCode
+    ? `\`${input.lastErrorCode}\`${input.lastErrorMessage ? ` — ${input.lastErrorMessage}` : ""}`
+    : input.lastErrorMessage ?? "unknown failure";
+  const nextAction =
+    "Automatic retries are paused. Fix the underlying failure (or reassign/reconfigure the agent), " +
+    "then add a comment, retry explicitly, or otherwise deliver new input to resume.";
+  const summary =
+    `Automatic retry paused after ${input.maxRetries} retries for this run chain ` +
+    `(last failure: ${lastFailure}). ${nextAction}`;
+  return {
+    status: "parked",
+    reason: "root_retry_cap_exhausted",
+    rootRunId: input.rootRunId,
+    epoch: input.epoch,
+    attempt: input.attempt,
+    maxRetries: input.maxRetries,
+    lastErrorCode: input.lastErrorCode,
+    lastErrorMessage: input.lastErrorMessage,
+    nextOwner: input.nextOwner,
+    nextAction,
+    summary,
+  };
+}

--- a/server/src/services/same-root-retry-gate.ts
+++ b/server/src/services/same-root-retry-gate.ts
@@ -1,0 +1,124 @@
+/**
+ * Database-aware enforcement of the same-root automatic-retry cap.
+ *
+ * {@link ./same-root-retry-cap.ts} defines the *pure* policy — how a retry root
+ * and epoch are derived and when a `(root, epoch)` is exhausted. This module is
+ * the single side-effecting gate every automatic retry/recovery mint point
+ * calls before creating another run, so the cap is enforced identically no
+ * matter which path (process-loss retry, stranded-issue recovery,
+ * source-scoped recovery, …) mints the next run.
+ *
+ * Centralizing the count here is what closes the bypass the cap exists to stop:
+ * each recovery path used to carry its own per-lineage counter, so a fresh run
+ * id minted by a different path reset the limit and the chain retried forever
+ * (see paperclipai/paperclip#9734, #7535). Here the count is taken over the
+ * whole `(root, epoch)` regardless of which path created each run.
+ *
+ * The count and the caller's insert are made atomic with a transaction-scoped
+ * advisory lock keyed on `(root, epoch)`: two recovery paths racing to recover
+ * the same root serialize on the lock, so they cannot both read "3 runs" and
+ * both mint a 4th. Callers that mint via a direct insert should pass the same
+ * transaction they insert in; callers that mint through a higher-level wakeup
+ * primitive should gate *before* minting (an exhausted root must not create
+ * another run at all) and accept that the lock only spans the count.
+ */
+import { and, count, eq, sql } from "drizzle-orm";
+import { heartbeatRuns } from "@paperclipai/db";
+import type { Db } from "@paperclipai/db";
+import {
+  buildSameRootRetryPark,
+  evaluateSameRootRetry,
+  resolveRetryEpochForNewRun,
+  resolveRetryRootRunId,
+  type SameRootRetryPark,
+} from "./same-root-retry-cap.js";
+
+/** The subset of the source run the gate reads to derive the decision. */
+export interface SameRootRetryGateSource {
+  id: string;
+  companyId: string;
+  retryRootRunId: string | null;
+  retryEpoch: number | null;
+  /** Error code of the last failure, surfaced in the park descriptor. */
+  errorCode?: string | null;
+  /** Human-readable failure detail, surfaced in the park descriptor. */
+  error?: string | null;
+  /** Falls back to the park's next owner when none is supplied explicitly. */
+  responsibleUserId?: string | null;
+}
+
+/**
+ * Minimal executor shape shared by the top-level db handle and a transaction.
+ * Passing a transaction makes the count atomic with the caller's insert.
+ */
+export type SameRootRetryExecutor = Pick<Db, "select" | "execute">;
+
+export type SameRootRetryGateResult =
+  | {
+      allowed: true;
+      retryRootRunId: string;
+      retryEpoch: number;
+      /** 1-based index of the retry the caller may now mint. */
+      attempt: number;
+    }
+  | {
+      allowed: false;
+      retryRootRunId: string;
+      retryEpoch: number;
+      park: SameRootRetryPark;
+    };
+
+/**
+ * Decide whether another automatic run may be minted for the source run's
+ * `(root, epoch)`. Acquires a transaction advisory lock on that key, counts the
+ * automatic runs already recorded for it, and applies {@link evaluateSameRootRetry}.
+ *
+ * The first (root) run of a lineage carries a null `retryRootRunId`, so it is
+ * not matched by the count; the `+ 1` folds it back in, making the total
+ * "first run + retries" exactly as the pure policy expects.
+ */
+export async function enforceSameRootRetryCap(
+  exec: SameRootRetryExecutor,
+  input: {
+    source: SameRootRetryGateSource;
+    wakeReason: string | null | undefined;
+    nextOwner?: string | null;
+  },
+): Promise<SameRootRetryGateResult> {
+  const retryRootRunId = resolveRetryRootRunId(input.source);
+  const retryEpoch = resolveRetryEpochForNewRun({ source: input.source, wakeReason: input.wakeReason });
+
+  // Serialize concurrent minters for this (root, epoch) so the count → decide →
+  // insert window is atomic. Released automatically when the surrounding
+  // transaction ends; on the top-level handle it spans just this statement, so
+  // atomicity there relies on the caller gating before it mints.
+  await exec.execute(sql`select pg_advisory_xact_lock(hashtextextended(${`${retryRootRunId}:${retryEpoch}`}, 0))`);
+
+  const priorAutomaticRunCount = await exec
+    .select({ value: count() })
+    .from(heartbeatRuns)
+    .where(
+      and(
+        eq(heartbeatRuns.companyId, input.source.companyId),
+        eq(heartbeatRuns.retryRootRunId, retryRootRunId),
+        eq(heartbeatRuns.retryEpoch, retryEpoch),
+      ),
+    )
+    .then((rows) => rows[0]?.value ?? 0);
+
+  const decision = evaluateSameRootRetry({ priorAutomaticRunCount: priorAutomaticRunCount + 1 });
+  if (decision.allowed) {
+    return { allowed: true, retryRootRunId, retryEpoch, attempt: decision.attempt };
+  }
+
+  const park = buildSameRootRetryPark({
+    rootRunId: retryRootRunId,
+    epoch: retryEpoch,
+    attempt: decision.attempt,
+    maxRetries: decision.maxRetries,
+    lastErrorCode: input.source.errorCode ?? null,
+    lastErrorMessage: input.source.error ?? null,
+    nextOwner: input.nextOwner ?? input.source.responsibleUserId ?? null,
+  });
+  return { allowed: false, retryRootRunId, retryEpoch, park };
+}


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - When an agent run dies unexpectedly (process lost, stranded issue, review-participant recovery, source-scoped recovery), the platform automatically re-wakes it so work isn't dropped.
> - Each of those recovery paths mints a **fresh** run/wake id, and the retry cap is keyed off the immediate `retryOfRunId` lineage — so a recovery that allocates a new id resets the counter.
> - The result is unbounded automatic retries of a permanently-failing root: on a `maxConcurrentRuns: 1` agent a single failing issue can loop indefinitely (100+ runs), starving every other wake — including the wake that would cancel the loop (#9734) — and spamming recovery comments with no backoff (#7535).
> - This pull request introduces a **same-root retry cap**: a stable `(retryRootRunId, retryEpoch)` that is invariant across every automatic recovery mint, an atomic in-transaction gate that caps automatic runs at the initial run + 3 retries, exponential backoff + jitter with slot release while waiting, and a single park record (last failure reason + next owner/action) instead of repeated recovery churn.
> - The benefit is that a runaway root can no longer monopolize an agent or spam an issue, while genuine new input (human comment, issue event, explicit retry, monitor signal) still cleanly resumes work on a fresh epoch.

## Linked Issues or Issue Description

- Fixes #9734 — unbounded `process_lost_retry` monopolizes a single-slot agent.
- Refs #7535 — terminal-run recovery retries a permanently-failing adapter forever with no backoff/give-up. This PR adds the shared cap + backoff + park for the automatic recovery mint paths; the adapter-config give-up specifics remain tracked there.

## What Changed

- **`server/src/services/same-root-retry-cap.ts`** (new): pure policy module — resolves the invariant retry root, decides epoch advancement (external input advances the epoch; recovery-internal events do not), evaluates the cap (initial 1 + 3 retries = 4 automatic runs per `(root, epoch)`), computes exponential backoff + jitter, and builds the park descriptor (last failure reason + next owner/action + resume guidance).
- **`server/src/services/same-root-retry-gate.ts`** (new): shared DB gate. Under a per-`(root, epoch)` transaction advisory lock it counts the automatic runs already recorded and either allows (returning root/epoch/attempt for the caller to stamp + schedule) or parks. Count and insert happen under one lock, so concurrent recovery cannot exceed the cap.
- **`server/src/services/heartbeat.ts`**: the process-loss retry mint now runs the gate **inside** the run-insert transaction and inserts allowed retries as `scheduled_retry` with backoff (no immediate start, slot released); `enqueueWakeup` gained an optional `sameRootRetry` mint path so recovery callers get the same atomic cap, backoff, slot release, and park. Failure lineage only — a re-wake continuing a run that finished normally is progress, not a retry, and is never throttled.
- **`server/src/services/recovery/service.ts`**: stranded-issue and source-scoped recovery delegate to the gated mint instead of a top-level gate + post-insert update, sharing the atomic cap/backoff/park.
- **`packages/db`**: `heartbeat_runs` gains `retry_root_run_id` + `retry_epoch` with a partial index; migration `0182_same_root_retry_cap` (+ journal entry).
- **Tests**: policy unit tests, an embedded-Postgres integration test proving the runaway chain stops at 4 runs / recovery-only never mints a 5th / external input resumes on a clean epoch / concurrent minters are serialized by the advisory lock, and a production-mint end-to-end test in `heartbeat-process-recovery.test.ts`. Existing process-recovery/retry-scheduling contract tests updated for the `scheduled_retry` behavior; two resume-failure comment assertions deflaked (they raced a post-commit insert under parallel load).

## Verification

- `pnpm --filter @paperclipai/db check:migrations` → passes (journal/file counts aligned, safety check green).
- `pnpm exec vitest run` for `same-root-retry-cap`, `same-root-retry-gate.integration`, `heartbeat-process-recovery`, `heartbeat-retry-scheduling` → **144 passed / 0 failed** (run together, i.e. under parallel load).
- Integration test replays a 144-run same-root failure chain and asserts it stops at 4 total automatic runs; recovery-only repetition never produces a 5th; a new external-input wake resumes at epoch 1 / attempt 1; 8 concurrent minters stay within the cap.

## Risks

- Behavioral shift: automatic recovery retries are now delayed (backoff) and released from the slot while waiting instead of starting immediately, and are hard-capped at 4 per root/epoch. Genuine new input still resumes via epoch advancement, so operator-visible work is not dropped — on exhaustion the root is parked with the last failure reason and next owner/action rather than silently stopping.
- Migration adds two nullable/defaulted columns + a partial index to `heartbeat_runs` (additive, no backfill of historical rows required; existing rows get `retry_epoch` default 0 / null root and are treated as their own root).
- Concurrency correctness rests on the per-`(root, epoch)` transaction advisory lock; the integration test exercises the concurrent-minter race directly.

## Model Used

- Anthropic **Claude Opus 4.8** (`claude-opus-4-8`), extended thinking + tool use, via an autonomous coding agent. Local test/typecheck/migration verification run by the agent.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge
