### PR TITLE
fix(secrets): refresh sessions when a secret value changes under the same version

### DIFF
--- a/server/src/__tests__/effective-run-config-fingerprints.test.ts
+++ b/server/src/__tests__/effective-run-config-fingerprints.test.ts
@@ -199,6 +199,47 @@ describe("effective run config fingerprints", () => {
     expect(versionChanged.sessionFingerprint.fingerprint).not.toBe(v7.sessionFingerprint.fingerprint);
   });
 
+  it("changes the fingerprint when a secret value fingerprint changes under the same version", () => {
+    const manifestEntry = (valueFingerprint: string) => ({
+      configPath: "env.OPENAI_API_KEY",
+      envKey: "OPENAI_API_KEY",
+      secretId: "secret-1",
+      bindingId: "binding-1",
+      version: 7,
+      provider: "local_encrypted",
+      providerVersionRef: "provider-version-7",
+      outcome: "success" as const,
+      valueFingerprint,
+    });
+    const session = {
+      adapterConfig: { env: { OPENAI_API_KEY: "resolved-secret-value" } },
+    };
+
+    const original = createEffectiveRunConfigFingerprints({
+      session,
+      secretManifest: [manifestEntry("sha256:aaaa")],
+    });
+    // In-place re-encryption keeps the SAME version number but changes the value.
+    const reencrypted = createEffectiveRunConfigFingerprints({
+      session,
+      secretManifest: [manifestEntry("sha256:bbbb")],
+    });
+    // Identical value fingerprint must NOT cause a spurious reset.
+    const unchanged = createEffectiveRunConfigFingerprints({
+      session,
+      secretManifest: [manifestEntry("sha256:aaaa")],
+    });
+
+    expect(reencrypted.sessionFingerprint.fingerprint).not.toBe(
+      original.sessionFingerprint.fingerprint,
+    );
+    expect(unchanged.sessionFingerprint.fingerprint).toBe(
+      original.sessionFingerprint.fingerprint,
+    );
+    // The non-reversible fingerprint may be included, but never the raw value.
+    expect(original.sessionFingerprint.canonicalJson).not.toContain("resolved-secret-value");
+  });
+
   it("detects plain env value drift without storing raw values", () => {
     const base = createEffectiveRunConfigFingerprints({
       session: {

--- a/server/src/__tests__/effective-run-config-fingerprints.test.ts
+++ b/server/src/__tests__/effective-run-config-fingerprints.test.ts
@@ -240,6 +240,52 @@ describe("effective run config fingerprints", () => {
     expect(original.sessionFingerprint.canonicalJson).not.toContain("resolved-secret-value");
   });
 
+  it("changes the LEASE fingerprint when a secret value fingerprint changes under the same version", () => {
+    // The reusable-sandbox lease fingerprint carries the resolved secret manifest
+    // both as lease.secrets and as the secret manifest. An in-place re-encryption
+    // that keeps the SAME version number must still invalidate the lease so a stale
+    // sandbox is never reused with a rotated credential.
+    const leaseSecret = (valueFingerprint: string) => ({
+      configPath: "apiKey",
+      envKey: null,
+      secretId: "secret-1",
+      version: 7,
+      provider: "local_encrypted",
+      providerVersionRef: "provider-version-7",
+      valueFingerprint,
+      outcome: "success" as const,
+    });
+    const lease = (valueFingerprint: string) => ({
+      companyId: "company-1",
+      environment: { id: "env-1", driver: "sandbox" },
+      provider: "secure-plugin",
+      secrets: [leaseSecret(valueFingerprint)],
+    });
+
+    const original = createEffectiveRunConfigFingerprints({
+      lease: lease("sha256:aaaa"),
+      secretManifest: [leaseSecret("sha256:aaaa")],
+    });
+    const reencrypted = createEffectiveRunConfigFingerprints({
+      lease: lease("sha256:bbbb"),
+      secretManifest: [leaseSecret("sha256:bbbb")],
+    });
+    const unchanged = createEffectiveRunConfigFingerprints({
+      lease: lease("sha256:aaaa"),
+      secretManifest: [leaseSecret("sha256:aaaa")],
+    });
+
+    expect(reencrypted.leaseFingerprint.fingerprint).not.toBe(
+      original.leaseFingerprint.fingerprint,
+    );
+    // Identical value fingerprint must NOT cause spurious lease churn.
+    expect(unchanged.leaseFingerprint.fingerprint).toBe(
+      original.leaseFingerprint.fingerprint,
+    );
+    // The non-reversible fingerprint is included in canonical form.
+    expect(original.leaseFingerprint.canonicalJson).toContain("sha256:aaaa");
+  });
+
   it("detects plain env value drift without storing raw values", () => {
     const base = createEffectiveRunConfigFingerprints({
       session: {

--- a/server/src/__tests__/environment-runtime.test.ts
+++ b/server/src/__tests__/environment-runtime.test.ts
@@ -3,7 +3,7 @@ import { mkdtemp, rm } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import {
   buildSshEnvLabFixtureConfig,
   getSshEnvLabSupport,
@@ -1564,6 +1564,225 @@ describeEmbeddedPostgres("environmentRuntimeService", () => {
     const firstMetadata = JSON.stringify(first.lease.metadata);
     expect(firstMetadata).not.toContain("resolved-provider-key");
     expect(firstMetadata).not.toContain("rotated-provider-key");
+  });
+
+  it("does not resume released reusable plugin sandbox leases after an in-place secret value change under the same version", async () => {
+    const pluginId = randomUUID();
+    const { companyId, agentId, environment: baseEnvironment, runId } = await seedEnvironment();
+    const apiSecret = await secretService(db).create(companyId, {
+      name: `inplace-plugin-api-key-${randomUUID()}`,
+      provider: "local_encrypted",
+      value: "resolved-provider-key",
+    });
+    const providerConfig = {
+      provider: "secure-plugin",
+      template: "base",
+      apiKey: apiSecret.id,
+      timeoutMs: 1234,
+      reuseLease: true,
+    };
+    const environment = {
+      ...baseEnvironment,
+      name: "In-place Secure Plugin Sandbox",
+      driver: "sandbox",
+      config: providerConfig,
+    };
+    await secretService(db).createBinding({
+      companyId,
+      secretId: apiSecret.id,
+      targetType: "environment",
+      targetId: environment.id,
+      configPath: "apiKey",
+    });
+    await environmentService(db).update(environment.id, {
+      driver: "sandbox",
+      name: environment.name,
+      config: providerConfig,
+    });
+    await db.insert(plugins).values({
+      id: pluginId,
+      pluginKey: "acme.inplace-sandbox-provider",
+      packageName: "@acme/inplace-sandbox-provider",
+      version: "1.0.0",
+      apiVersion: 1,
+      categories: ["automation"],
+      manifestJson: {
+        id: "acme.inplace-sandbox-provider",
+        apiVersion: 1,
+        version: "1.0.0",
+        displayName: "In-place Sandbox Provider",
+        description: "Test schema-driven provider",
+        author: "Paperclip",
+        categories: ["automation"],
+        capabilities: ["environment.drivers.register"],
+        entrypoints: { worker: "dist/worker.js" },
+        environmentDrivers: [
+          {
+            driverKey: "secure-plugin",
+            kind: "sandbox_provider",
+            displayName: "Secure Sandbox",
+            supportsReusableLeases: true,
+            configSchema: {
+              type: "object",
+              properties: {
+                template: { type: "string" },
+                apiKey: { type: "string", format: "secret-ref" },
+                timeoutMs: { type: "number" },
+                reuseLease: { type: "boolean" },
+              },
+            },
+          },
+        ],
+      },
+      status: "ready",
+      installOrder: 1,
+      updatedAt: new Date(),
+    } as any);
+    const executionWorkspaceId = randomUUID();
+    const projectId = randomUUID();
+    await db.insert(projects).values({
+      id: projectId,
+      companyId,
+      name: `Workspace ${projectId.slice(0, 8)}`,
+      status: "active",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    await db.insert(executionWorkspaces).values({
+      id: executionWorkspaceId,
+      companyId,
+      projectId,
+      mode: "shared_workspace",
+      strategyType: "project_primary",
+      name: "Reusable workspace",
+      status: "active",
+      providerType: "local_fs",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    const workerManager = {
+      isRunning: vi.fn((id: string) => id === pluginId),
+      call: vi.fn(async (_pluginId: string, method: string, params: any) => {
+        if (method === "environmentAcquireLease") {
+          return {
+            providerLeaseId: `lease-${params.config.apiKey}`,
+            metadata: {
+              provider: "secure-plugin",
+              template: params.config.template,
+              apiKey: params.config.apiKey,
+              timeoutMs: params.config.timeoutMs,
+              reuseLease: true,
+              remoteCwd: "/workspace",
+            },
+          };
+        }
+        if (method === "environmentResumeLease") {
+          // If the lease fingerprint fails to detect the value change, the runtime
+          // would resume this stale sandbox. Return it so the negative assertions
+          // below fail loudly instead of falling back to acquire.
+          return {
+            providerLeaseId: params.providerLeaseId,
+            metadata: {
+              provider: "secure-plugin",
+              reuseLease: true,
+              remoteCwd: "/workspace",
+              resumed: true,
+            },
+          };
+        }
+        if (method === "environmentReleaseLease" || method === "environmentDestroyLease") {
+          return undefined;
+        }
+        throw new Error(`Unexpected plugin method: ${method}`);
+      }),
+    } as unknown as PluginWorkerManager;
+    const runtimeWithPlugin = environmentRuntimeService(db, { pluginWorkerManager: workerManager });
+
+    const first = await runtimeWithPlugin.acquireRunLease({
+      companyId,
+      environment,
+      issueId: null,
+      agentId,
+      heartbeatRunId: runId,
+      persistedExecutionWorkspace: {
+        id: executionWorkspaceId,
+        mode: "shared_workspace",
+      },
+    });
+    await runtimeWithPlugin.releaseRunLeases(runId);
+
+    // Simulate an in-place re-encryption: the credential material changes but the
+    // secret keeps the SAME version number (no rotate, latestVersion is unchanged).
+    const [versionBefore] = await db
+      .select()
+      .from(companySecretVersions)
+      .where(eq(companySecretVersions.secretId, apiSecret.id));
+    expect(versionBefore).toBeDefined();
+    const sameVersionNumber = versionBefore.version;
+    await db
+      .update(companySecretVersions)
+      .set({
+        fingerprintSha256: `sha256:in-place-${randomUUID()}`,
+        valueSha256: `sha256:in-place-${randomUUID()}`,
+      })
+      .where(
+        and(
+          eq(companySecretVersions.secretId, apiSecret.id),
+          eq(companySecretVersions.version, sameVersionNumber),
+        ),
+      );
+    const versionRowsAfter = await db
+      .select()
+      .from(companySecretVersions)
+      .where(eq(companySecretVersions.secretId, apiSecret.id));
+    // Proves the change was in place: still exactly one version, same number, and
+    // the providerVersionRef (the other lease discriminator) did not move.
+    expect(versionRowsAfter).toHaveLength(1);
+    expect(versionRowsAfter[0].version).toBe(sameVersionNumber);
+    expect(versionRowsAfter[0].providerVersionRef).toBe(versionBefore.providerVersionRef);
+
+    const nextRunId = randomUUID();
+    await db.insert(heartbeatRuns).values({
+      id: nextRunId,
+      companyId,
+      agentId,
+      invocationSource: "manual",
+      status: "running",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    const second = await runtimeWithPlugin.acquireRunLease({
+      companyId,
+      environment,
+      issueId: null,
+      agentId,
+      heartbeatRunId: nextRunId,
+      persistedExecutionWorkspace: {
+        id: executionWorkspaceId,
+        mode: "shared_workspace",
+      },
+    });
+
+    // The stale sandbox must not be resumed; it must be destroyed and replaced.
+    expect(second.lease.id).not.toBe(first.lease.id);
+    expect(workerManager.call).not.toHaveBeenCalledWith(
+      pluginId,
+      "environmentResumeLease",
+      expect.anything(),
+      expect.anything(),
+    );
+    expect(workerManager.call).toHaveBeenCalledWith(pluginId, "environmentDestroyLease", expect.objectContaining({
+      providerLeaseId: "lease-resolved-provider-key",
+    }), 31234);
+    await expect(environmentService(db).getLeaseById(first.lease.id)).resolves.toMatchObject({
+      status: "expired",
+      cleanupStatus: "success",
+      failureReason: "lease_fingerprint_mismatch",
+    });
+    // The lease metadata must never carry the raw credential value.
+    const firstMetadata = JSON.stringify(first.lease.metadata);
+    expect(firstMetadata).not.toContain("resolved-provider-key");
   });
 
   it("preserves active reusable sandbox leases held by another running run", async () => {

--- a/server/src/__tests__/environment-runtime.test.ts
+++ b/server/src/__tests__/environment-runtime.test.ts
@@ -1785,6 +1785,284 @@ describeEmbeddedPostgres("environmentRuntimeService", () => {
     expect(firstMetadata).not.toContain("resolved-provider-key");
   });
 
+  it("does not resume a legacy secret-blind reusable sandbox lease for a secret-bearing environment even on the same active run", async () => {
+    // A LEGACY lease was created before value-aware lease fingerprints existed:
+    // its metadata carries only the secret-blind runtimeFingerprint (no
+    // leaseFingerprint). On a same-run active resume, `allowLegacyRuntimeFingerprint`
+    // would normally let the runtime fallback match it. But the environment
+    // references a secret, so the fallback is blind to any in-place value change
+    // and must be refused — forcing a fresh, value-aware lease.
+    const pluginId = randomUUID();
+    const { companyId, agentId, environment: baseEnvironment, runId } = await seedEnvironment();
+    const apiSecret = await secretService(db).create(companyId, {
+      name: `legacy-plugin-api-key-${randomUUID()}`,
+      provider: "local_encrypted",
+      value: "resolved-provider-key",
+    });
+    const providerConfig = {
+      provider: "secure-plugin",
+      template: "base",
+      apiKey: apiSecret.id,
+      timeoutMs: 1234,
+      reuseLease: true,
+    };
+    const environment = {
+      ...baseEnvironment,
+      name: "Legacy Secure Plugin Sandbox",
+      driver: "sandbox",
+      config: providerConfig,
+    };
+    await secretService(db).createBinding({
+      companyId,
+      secretId: apiSecret.id,
+      targetType: "environment",
+      targetId: environment.id,
+      configPath: "apiKey",
+    });
+    await environmentService(db).update(environment.id, {
+      driver: "sandbox",
+      name: environment.name,
+      config: providerConfig,
+    });
+    await db.insert(plugins).values({
+      id: pluginId,
+      pluginKey: "acme.legacy-sandbox-provider",
+      packageName: "@acme/legacy-sandbox-provider",
+      version: "1.0.0",
+      apiVersion: 1,
+      categories: ["automation"],
+      manifestJson: {
+        id: "acme.legacy-sandbox-provider",
+        apiVersion: 1,
+        version: "1.0.0",
+        displayName: "Legacy Sandbox Provider",
+        description: "Test schema-driven provider",
+        author: "Paperclip",
+        categories: ["automation"],
+        capabilities: ["environment.drivers.register"],
+        entrypoints: { worker: "dist/worker.js" },
+        environmentDrivers: [
+          {
+            driverKey: "secure-plugin",
+            kind: "sandbox_provider",
+            displayName: "Secure Sandbox",
+            supportsReusableLeases: true,
+            configSchema: {
+              type: "object",
+              properties: {
+                template: { type: "string" },
+                apiKey: { type: "string", format: "secret-ref" },
+                timeoutMs: { type: "number" },
+                reuseLease: { type: "boolean" },
+              },
+            },
+          },
+        ],
+      },
+      status: "ready",
+      installOrder: 1,
+      updatedAt: new Date(),
+    } as any);
+    const executionWorkspaceId = randomUUID();
+    const projectId = randomUUID();
+    await db.insert(projects).values({
+      id: projectId,
+      companyId,
+      name: `Workspace ${projectId.slice(0, 8)}`,
+      status: "active",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    await db.insert(executionWorkspaces).values({
+      id: executionWorkspaceId,
+      companyId,
+      projectId,
+      mode: "shared_workspace",
+      strategyType: "project_primary",
+      name: "Reusable workspace",
+      status: "active",
+      providerType: "local_fs",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    // Seed a LEGACY reusable lease on the SAME active run: only a secret-blind
+    // runtimeFingerprint, no leaseFingerprint.
+    const legacyLease = await environmentService(db).acquireLease({
+      companyId,
+      environmentId: environment.id,
+      executionWorkspaceId,
+      heartbeatRunId: runId,
+      leasePolicy: "reuse_by_environment",
+      provider: "secure-plugin",
+      providerLeaseId: "legacy-secure-lease",
+      metadata: {
+        agentId,
+        driver: "sandbox",
+        pluginId,
+        pluginKey: "acme.legacy-sandbox-provider",
+        sandboxProviderPlugin: true,
+        provider: "secure-plugin",
+        template: "base",
+        apiKey: apiSecret.id,
+        timeoutMs: 1234,
+        reuseLease: true,
+        remoteCwd: "/workspace",
+        reusableSandboxLease: {
+          version: 1,
+          companyId,
+          environmentId: environment.id,
+          executionWorkspaceId,
+          agentId,
+          adapterType: null,
+          provider: "secure-plugin",
+          runtimeFingerprint: reusableRuntimeFingerprint({
+            provider: "secure-plugin",
+            adapterType: null,
+            config: providerConfig,
+          }),
+          remoteCwd: "/workspace",
+        },
+      },
+    });
+
+    const workerManager = {
+      isRunning: vi.fn((id: string) => id === pluginId),
+      call: vi.fn(async (_pluginId: string, method: string, params: any) => {
+        if (method === "environmentResumeLease") {
+          // If the secret gate regresses and the legacy lease is resumed, return
+          // it so the negative assertions below fail loudly.
+          return {
+            providerLeaseId: params.providerLeaseId,
+            metadata: {
+              provider: "secure-plugin",
+              reuseLease: true,
+              remoteCwd: "/workspace",
+              resumed: true,
+            },
+          };
+        }
+        if (method === "environmentAcquireLease") {
+          return {
+            providerLeaseId: `lease-${params.config.apiKey}`,
+            metadata: {
+              provider: "secure-plugin",
+              template: params.config.template,
+              apiKey: params.config.apiKey,
+              timeoutMs: params.config.timeoutMs,
+              reuseLease: true,
+              remoteCwd: "/workspace",
+            },
+          };
+        }
+        if (method === "environmentReleaseLease" || method === "environmentDestroyLease") {
+          return undefined;
+        }
+        throw new Error(`Unexpected plugin method: ${method}`);
+      }),
+    } as unknown as PluginWorkerManager;
+    const runtimeWithPlugin = environmentRuntimeService(db, { pluginWorkerManager: workerManager });
+
+    const acquired = await runtimeWithPlugin.acquireRunLease({
+      companyId,
+      environment,
+      issueId: null,
+      agentId,
+      heartbeatRunId: runId,
+      persistedExecutionWorkspace: {
+        id: executionWorkspaceId,
+        mode: "shared_workspace",
+      },
+    });
+
+    // The legacy secret-blind lease must NOT be resumed; a fresh, value-aware
+    // lease is acquired instead. The runtime resolves the secret ref before the
+    // worker call, so the fresh provider lease id reflects the resolved value.
+    expect(acquired.lease.providerLeaseId).toBe("lease-resolved-provider-key");
+    expect(acquired.lease.providerLeaseId).not.toBe("legacy-secure-lease");
+    expect(acquired.lease.id).not.toBe(legacyLease.id);
+    expect(workerManager.call).not.toHaveBeenCalledWith(
+      pluginId,
+      "environmentResumeLease",
+      expect.anything(),
+      expect.anything(),
+    );
+    // The fresh lease carries a value-aware leaseFingerprint (the whole point).
+    expect(acquired.lease.metadata?.reusableSandboxLease).toMatchObject({
+      leaseFingerprint: expect.objectContaining({
+        category: "lease",
+        fingerprint: expect.stringMatching(/^v1:sha256:[a-f0-9]{64}$/),
+      }),
+    });
+  });
+
+  it("resumes a legacy secret-blind reusable sandbox lease via the runtime fallback when the environment has no secret refs", async () => {
+    // Contrast to the secret-bearing case: with no secret refs, a legacy lease
+    // (runtimeFingerprint, no leaseFingerprint) on the same active run may still
+    // be resumed through the runtime fallback.
+    const { pluginId, companyId, agentId, environment, runId, executionWorkspaceId } =
+      await seedReusablePluginSandboxLease();
+    const workerManager = {
+      isRunning: vi.fn((id: string) => id === pluginId),
+      call: vi.fn(async (_pluginId: string, method: string, params: any) => {
+        if (method === "environmentResumeLease") {
+          return {
+            providerLeaseId: params.providerLeaseId,
+            metadata: {
+              provider: "fake-plugin",
+              reuseLease: true,
+              remoteCwd: "/workspace",
+              resumed: true,
+            },
+          };
+        }
+        if (method === "environmentAcquireLease") {
+          return {
+            providerLeaseId: "fresh-plugin-lease",
+            metadata: {
+              provider: "fake-plugin",
+              image: "fake:test",
+              timeoutMs: 1234,
+              reuseLease: true,
+              remoteCwd: "/workspace",
+            },
+          };
+        }
+        throw new Error(`Unexpected plugin method: ${method}`);
+      }),
+    } as unknown as PluginWorkerManager;
+    const runtimeWithPlugin = environmentRuntimeService(db, { pluginWorkerManager: workerManager });
+
+    const acquired = await runtimeWithPlugin.acquireRunLease({
+      companyId,
+      environment,
+      issueId: null,
+      agentId,
+      heartbeatRunId: runId,
+      persistedExecutionWorkspace: {
+        id: executionWorkspaceId,
+        mode: "shared_workspace",
+      },
+    });
+
+    // The legacy lease is resumed via the runtime fallback (no fresh acquire).
+    expect(workerManager.call).toHaveBeenCalledWith(
+      pluginId,
+      "environmentResumeLease",
+      expect.objectContaining({ providerLeaseId: "reusable-plugin-lease" }),
+      expect.anything(),
+    );
+    expect(workerManager.call).not.toHaveBeenCalledWith(
+      pluginId,
+      "environmentAcquireLease",
+      expect.anything(),
+      expect.anything(),
+    );
+    // The resumed lease keeps the legacy provider lease id (persisted as a fresh
+    // row, so the runtime lease id may differ).
+    expect(acquired.lease.providerLeaseId).toBe("reusable-plugin-lease");
+  });
+
   it("preserves active reusable sandbox leases held by another running run", async () => {
     const { pluginId, companyId, agentId, environment, executionWorkspaceId, reusableLease } =
       await seedReusablePluginSandboxLease();

--- a/server/src/__tests__/environment-runtime.test.ts
+++ b/server/src/__tests__/environment-runtime.test.ts
@@ -5699,6 +5699,7 @@ describeEmbeddedPostgres("environmentRuntimeService", () => {
 
     const workerManager = {
       isRunning: vi.fn((id: string) => id === pluginId),
+      getWorker: vi.fn(() => ({ supportedMethods: ["environmentAcquireLease", "environmentResumeLease", "environmentReleaseLease", "environmentDestroyLease"] })),
       call: vi.fn(async (_pluginId: string, method: string, params: any) => {
         if (method === "environmentAcquireLease") {
           return {
@@ -5964,6 +5965,7 @@ describeEmbeddedPostgres("environmentRuntimeService", () => {
 
     const workerManager = {
       isRunning: vi.fn((id: string) => id === pluginId),
+      getWorker: vi.fn(() => ({ supportedMethods: ["environmentAcquireLease", "environmentResumeLease", "environmentReleaseLease", "environmentDestroyLease"] })),
       call: vi.fn(async (_pluginId: string, method: string, params: any) => {
         if (method === "environmentResumeLease") {
           // If the secret gate regresses and the legacy lease is resumed, return
@@ -6040,6 +6042,7 @@ describeEmbeddedPostgres("environmentRuntimeService", () => {
       await seedReusablePluginSandboxLease();
     const workerManager = {
       isRunning: vi.fn((id: string) => id === pluginId),
+      getWorker: vi.fn(() => ({ supportedMethods: ["environmentAcquireLease", "environmentResumeLease", "environmentReleaseLease", "environmentDestroyLease"] })),
       call: vi.fn(async (_pluginId: string, method: string, params: any) => {
         if (method === "environmentResumeLease") {
           return {

--- a/server/src/__tests__/environment-runtime.test.ts
+++ b/server/src/__tests__/environment-runtime.test.ts
@@ -5821,6 +5821,284 @@ describeEmbeddedPostgres("environmentRuntimeService", () => {
     expect(firstMetadata).not.toContain("resolved-provider-key");
   });
 
+  it("does not resume a legacy secret-blind reusable sandbox lease for a secret-bearing environment even on the same active run", async () => {
+    // A LEGACY lease was created before value-aware lease fingerprints existed:
+    // its metadata carries only the secret-blind runtimeFingerprint (no
+    // leaseFingerprint). On a same-run active resume, `allowLegacyRuntimeFingerprint`
+    // would normally let the runtime fallback match it. But the environment
+    // references a secret, so the fallback is blind to any in-place value change
+    // and must be refused — forcing a fresh, value-aware lease.
+    const pluginId = randomUUID();
+    const { companyId, agentId, environment: baseEnvironment, runId } = await seedEnvironment();
+    const apiSecret = await secretService(db).create(companyId, {
+      name: `legacy-plugin-api-key-${randomUUID()}`,
+      provider: "local_encrypted",
+      value: "resolved-provider-key",
+    });
+    const providerConfig = {
+      provider: "secure-plugin",
+      template: "base",
+      apiKey: apiSecret.id,
+      timeoutMs: 1234,
+      reuseLease: true,
+    };
+    const environment = {
+      ...baseEnvironment,
+      name: "Legacy Secure Plugin Sandbox",
+      driver: "sandbox",
+      config: providerConfig,
+    };
+    await secretService(db).createBinding({
+      companyId,
+      secretId: apiSecret.id,
+      targetType: "environment",
+      targetId: environment.id,
+      configPath: "apiKey",
+    });
+    await environmentService(db).update(environment.id, {
+      driver: "sandbox",
+      name: environment.name,
+      config: providerConfig,
+    });
+    await db.insert(plugins).values({
+      id: pluginId,
+      pluginKey: "acme.legacy-sandbox-provider",
+      packageName: "@acme/legacy-sandbox-provider",
+      version: "1.0.0",
+      apiVersion: 1,
+      categories: ["automation"],
+      manifestJson: {
+        id: "acme.legacy-sandbox-provider",
+        apiVersion: 1,
+        version: "1.0.0",
+        displayName: "Legacy Sandbox Provider",
+        description: "Test schema-driven provider",
+        author: "Paperclip",
+        categories: ["automation"],
+        capabilities: ["environment.drivers.register"],
+        entrypoints: { worker: "dist/worker.js" },
+        environmentDrivers: [
+          {
+            driverKey: "secure-plugin",
+            kind: "sandbox_provider",
+            displayName: "Secure Sandbox",
+            supportsReusableLeases: true,
+            configSchema: {
+              type: "object",
+              properties: {
+                template: { type: "string" },
+                apiKey: { type: "string", format: "secret-ref" },
+                timeoutMs: { type: "number" },
+                reuseLease: { type: "boolean" },
+              },
+            },
+          },
+        ],
+      },
+      status: "ready",
+      installOrder: 1,
+      updatedAt: new Date(),
+    } as any);
+    const executionWorkspaceId = randomUUID();
+    const projectId = randomUUID();
+    await db.insert(projects).values({
+      id: projectId,
+      companyId,
+      name: `Workspace ${projectId.slice(0, 8)}`,
+      status: "active",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    await db.insert(executionWorkspaces).values({
+      id: executionWorkspaceId,
+      companyId,
+      projectId,
+      mode: "shared_workspace",
+      strategyType: "project_primary",
+      name: "Reusable workspace",
+      status: "active",
+      providerType: "local_fs",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    // Seed a LEGACY reusable lease on the SAME active run: only a secret-blind
+    // runtimeFingerprint, no leaseFingerprint.
+    const legacyLease = await environmentService(db).acquireLease({
+      companyId,
+      environmentId: environment.id,
+      executionWorkspaceId,
+      heartbeatRunId: runId,
+      leasePolicy: "reuse_by_environment",
+      provider: "secure-plugin",
+      providerLeaseId: "legacy-secure-lease",
+      metadata: {
+        agentId,
+        driver: "sandbox",
+        pluginId,
+        pluginKey: "acme.legacy-sandbox-provider",
+        sandboxProviderPlugin: true,
+        provider: "secure-plugin",
+        template: "base",
+        apiKey: apiSecret.id,
+        timeoutMs: 1234,
+        reuseLease: true,
+        remoteCwd: "/workspace",
+        reusableSandboxLease: {
+          version: 1,
+          companyId,
+          environmentId: environment.id,
+          executionWorkspaceId,
+          agentId,
+          adapterType: null,
+          provider: "secure-plugin",
+          runtimeFingerprint: reusableRuntimeFingerprint({
+            provider: "secure-plugin",
+            adapterType: null,
+            config: providerConfig,
+          }),
+          remoteCwd: "/workspace",
+        },
+      },
+    });
+
+    const workerManager = {
+      isRunning: vi.fn((id: string) => id === pluginId),
+      call: vi.fn(async (_pluginId: string, method: string, params: any) => {
+        if (method === "environmentResumeLease") {
+          // If the secret gate regresses and the legacy lease is resumed, return
+          // it so the negative assertions below fail loudly.
+          return {
+            providerLeaseId: params.providerLeaseId,
+            metadata: {
+              provider: "secure-plugin",
+              reuseLease: true,
+              remoteCwd: "/workspace",
+              resumed: true,
+            },
+          };
+        }
+        if (method === "environmentAcquireLease") {
+          return {
+            providerLeaseId: `lease-${params.config.apiKey}`,
+            metadata: {
+              provider: "secure-plugin",
+              template: params.config.template,
+              apiKey: params.config.apiKey,
+              timeoutMs: params.config.timeoutMs,
+              reuseLease: true,
+              remoteCwd: "/workspace",
+            },
+          };
+        }
+        if (method === "environmentReleaseLease" || method === "environmentDestroyLease") {
+          return undefined;
+        }
+        throw new Error(`Unexpected plugin method: ${method}`);
+      }),
+    } as unknown as PluginWorkerManager;
+    const runtimeWithPlugin = environmentRuntimeService(db, { pluginWorkerManager: workerManager });
+
+    const acquired = await runtimeWithPlugin.acquireRunLease({
+      companyId,
+      environment,
+      issueId: null,
+      agentId,
+      heartbeatRunId: runId,
+      persistedExecutionWorkspace: {
+        id: executionWorkspaceId,
+        mode: "shared_workspace",
+      },
+    });
+
+    // The legacy secret-blind lease must NOT be resumed; a fresh, value-aware
+    // lease is acquired instead. The runtime resolves the secret ref before the
+    // worker call, so the fresh provider lease id reflects the resolved value.
+    expect(acquired.lease.providerLeaseId).toBe("lease-resolved-provider-key");
+    expect(acquired.lease.providerLeaseId).not.toBe("legacy-secure-lease");
+    expect(acquired.lease.id).not.toBe(legacyLease.id);
+    expect(workerManager.call).not.toHaveBeenCalledWith(
+      pluginId,
+      "environmentResumeLease",
+      expect.anything(),
+      expect.anything(),
+    );
+    // The fresh lease carries a value-aware leaseFingerprint (the whole point).
+    expect(acquired.lease.metadata?.reusableSandboxLease).toMatchObject({
+      leaseFingerprint: expect.objectContaining({
+        category: "lease",
+        fingerprint: expect.stringMatching(/^v1:sha256:[a-f0-9]{64}$/),
+      }),
+    });
+  });
+
+  it("resumes a legacy secret-blind reusable sandbox lease via the runtime fallback when the environment has no secret refs", async () => {
+    // Contrast to the secret-bearing case: with no secret refs, a legacy lease
+    // (runtimeFingerprint, no leaseFingerprint) on the same active run may still
+    // be resumed through the runtime fallback.
+    const { pluginId, companyId, agentId, environment, runId, executionWorkspaceId } =
+      await seedReusablePluginSandboxLease();
+    const workerManager = {
+      isRunning: vi.fn((id: string) => id === pluginId),
+      call: vi.fn(async (_pluginId: string, method: string, params: any) => {
+        if (method === "environmentResumeLease") {
+          return {
+            providerLeaseId: params.providerLeaseId,
+            metadata: {
+              provider: "fake-plugin",
+              reuseLease: true,
+              remoteCwd: "/workspace",
+              resumed: true,
+            },
+          };
+        }
+        if (method === "environmentAcquireLease") {
+          return {
+            providerLeaseId: "fresh-plugin-lease",
+            metadata: {
+              provider: "fake-plugin",
+              image: "fake:test",
+              timeoutMs: 1234,
+              reuseLease: true,
+              remoteCwd: "/workspace",
+            },
+          };
+        }
+        throw new Error(`Unexpected plugin method: ${method}`);
+      }),
+    } as unknown as PluginWorkerManager;
+    const runtimeWithPlugin = environmentRuntimeService(db, { pluginWorkerManager: workerManager });
+
+    const acquired = await runtimeWithPlugin.acquireRunLease({
+      companyId,
+      environment,
+      issueId: null,
+      agentId,
+      heartbeatRunId: runId,
+      persistedExecutionWorkspace: {
+        id: executionWorkspaceId,
+        mode: "shared_workspace",
+      },
+    });
+
+    // The legacy lease is resumed via the runtime fallback (no fresh acquire).
+    expect(workerManager.call).toHaveBeenCalledWith(
+      pluginId,
+      "environmentResumeLease",
+      expect.objectContaining({ providerLeaseId: "reusable-plugin-lease" }),
+      expect.anything(),
+    );
+    expect(workerManager.call).not.toHaveBeenCalledWith(
+      pluginId,
+      "environmentAcquireLease",
+      expect.anything(),
+      expect.anything(),
+    );
+    // The resumed lease keeps the legacy provider lease id (persisted as a fresh
+    // row, so the runtime lease id may differ).
+    expect(acquired.lease.providerLeaseId).toBe("reusable-plugin-lease");
+  });
+
   it("preserves active reusable sandbox leases held by another running run", async () => {
     const { pluginId, companyId, agentId, environment, executionWorkspaceId, reusableLease } =
       await seedReusablePluginSandboxLease();

--- a/server/src/__tests__/environment-runtime.test.ts
+++ b/server/src/__tests__/environment-runtime.test.ts
@@ -3,7 +3,7 @@ import { mkdir, mkdtemp, readdir, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import {
   buildSshEnvLabFixtureConfig,
   getSshEnvLabSupport,
@@ -5600,6 +5600,225 @@ describeEmbeddedPostgres("environmentRuntimeService", () => {
     const firstMetadata = JSON.stringify(first.lease.metadata);
     expect(firstMetadata).not.toContain("resolved-provider-key");
     expect(firstMetadata).not.toContain("rotated-provider-key");
+  });
+
+  it("does not resume released reusable plugin sandbox leases after an in-place secret value change under the same version", async () => {
+    const pluginId = randomUUID();
+    const { companyId, agentId, environment: baseEnvironment, runId } = await seedEnvironment();
+    const apiSecret = await secretService(db).create(companyId, {
+      name: `inplace-plugin-api-key-${randomUUID()}`,
+      provider: "local_encrypted",
+      value: "resolved-provider-key",
+    });
+    const providerConfig = {
+      provider: "secure-plugin",
+      template: "base",
+      apiKey: apiSecret.id,
+      timeoutMs: 1234,
+      reuseLease: true,
+    };
+    const environment = {
+      ...baseEnvironment,
+      name: "In-place Secure Plugin Sandbox",
+      driver: "sandbox",
+      config: providerConfig,
+    };
+    await secretService(db).createBinding({
+      companyId,
+      secretId: apiSecret.id,
+      targetType: "environment",
+      targetId: environment.id,
+      configPath: "apiKey",
+    });
+    await environmentService(db).update(environment.id, {
+      driver: "sandbox",
+      name: environment.name,
+      config: providerConfig,
+    });
+    await db.insert(plugins).values({
+      id: pluginId,
+      pluginKey: "acme.inplace-sandbox-provider",
+      packageName: "@acme/inplace-sandbox-provider",
+      version: "1.0.0",
+      apiVersion: 1,
+      categories: ["automation"],
+      manifestJson: {
+        id: "acme.inplace-sandbox-provider",
+        apiVersion: 1,
+        version: "1.0.0",
+        displayName: "In-place Sandbox Provider",
+        description: "Test schema-driven provider",
+        author: "Paperclip",
+        categories: ["automation"],
+        capabilities: ["environment.drivers.register"],
+        entrypoints: { worker: "dist/worker.js" },
+        environmentDrivers: [
+          {
+            driverKey: "secure-plugin",
+            kind: "sandbox_provider",
+            displayName: "Secure Sandbox",
+            supportsReusableLeases: true,
+            configSchema: {
+              type: "object",
+              properties: {
+                template: { type: "string" },
+                apiKey: { type: "string", format: "secret-ref" },
+                timeoutMs: { type: "number" },
+                reuseLease: { type: "boolean" },
+              },
+            },
+          },
+        ],
+      },
+      status: "ready",
+      installOrder: 1,
+      updatedAt: new Date(),
+    } as any);
+    const executionWorkspaceId = randomUUID();
+    const projectId = randomUUID();
+    await db.insert(projects).values({
+      id: projectId,
+      companyId,
+      name: `Workspace ${projectId.slice(0, 8)}`,
+      status: "active",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    await db.insert(executionWorkspaces).values({
+      id: executionWorkspaceId,
+      companyId,
+      projectId,
+      mode: "shared_workspace",
+      strategyType: "project_primary",
+      name: "Reusable workspace",
+      status: "active",
+      providerType: "local_fs",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    const workerManager = {
+      isRunning: vi.fn((id: string) => id === pluginId),
+      call: vi.fn(async (_pluginId: string, method: string, params: any) => {
+        if (method === "environmentAcquireLease") {
+          return {
+            providerLeaseId: `lease-${params.config.apiKey}`,
+            metadata: {
+              provider: "secure-plugin",
+              template: params.config.template,
+              apiKey: params.config.apiKey,
+              timeoutMs: params.config.timeoutMs,
+              reuseLease: true,
+              remoteCwd: "/workspace",
+            },
+          };
+        }
+        if (method === "environmentResumeLease") {
+          // If the lease fingerprint fails to detect the value change, the runtime
+          // would resume this stale sandbox. Return it so the negative assertions
+          // below fail loudly instead of falling back to acquire.
+          return {
+            providerLeaseId: params.providerLeaseId,
+            metadata: {
+              provider: "secure-plugin",
+              reuseLease: true,
+              remoteCwd: "/workspace",
+              resumed: true,
+            },
+          };
+        }
+        if (method === "environmentReleaseLease" || method === "environmentDestroyLease") {
+          return undefined;
+        }
+        throw new Error(`Unexpected plugin method: ${method}`);
+      }),
+    } as unknown as PluginWorkerManager;
+    const runtimeWithPlugin = environmentRuntimeService(db, { pluginWorkerManager: workerManager });
+
+    const first = await runtimeWithPlugin.acquireRunLease({
+      companyId,
+      environment,
+      issueId: null,
+      agentId,
+      heartbeatRunId: runId,
+      persistedExecutionWorkspace: {
+        id: executionWorkspaceId,
+        mode: "shared_workspace",
+      },
+    });
+    await runtimeWithPlugin.releaseRunLeases(runId);
+
+    // Simulate an in-place re-encryption: the credential material changes but the
+    // secret keeps the SAME version number (no rotate, latestVersion is unchanged).
+    const [versionBefore] = await db
+      .select()
+      .from(companySecretVersions)
+      .where(eq(companySecretVersions.secretId, apiSecret.id));
+    expect(versionBefore).toBeDefined();
+    const sameVersionNumber = versionBefore.version;
+    await db
+      .update(companySecretVersions)
+      .set({
+        fingerprintSha256: `sha256:in-place-${randomUUID()}`,
+        valueSha256: `sha256:in-place-${randomUUID()}`,
+      })
+      .where(
+        and(
+          eq(companySecretVersions.secretId, apiSecret.id),
+          eq(companySecretVersions.version, sameVersionNumber),
+        ),
+      );
+    const versionRowsAfter = await db
+      .select()
+      .from(companySecretVersions)
+      .where(eq(companySecretVersions.secretId, apiSecret.id));
+    // Proves the change was in place: still exactly one version, same number, and
+    // the providerVersionRef (the other lease discriminator) did not move.
+    expect(versionRowsAfter).toHaveLength(1);
+    expect(versionRowsAfter[0].version).toBe(sameVersionNumber);
+    expect(versionRowsAfter[0].providerVersionRef).toBe(versionBefore.providerVersionRef);
+
+    const nextRunId = randomUUID();
+    await db.insert(heartbeatRuns).values({
+      id: nextRunId,
+      companyId,
+      agentId,
+      invocationSource: "manual",
+      status: "running",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    const second = await runtimeWithPlugin.acquireRunLease({
+      companyId,
+      environment,
+      issueId: null,
+      agentId,
+      heartbeatRunId: nextRunId,
+      persistedExecutionWorkspace: {
+        id: executionWorkspaceId,
+        mode: "shared_workspace",
+      },
+    });
+
+    // The stale sandbox must not be resumed; it must be destroyed and replaced.
+    expect(second.lease.id).not.toBe(first.lease.id);
+    expect(workerManager.call).not.toHaveBeenCalledWith(
+      pluginId,
+      "environmentResumeLease",
+      expect.anything(),
+      expect.anything(),
+    );
+    expect(workerManager.call).toHaveBeenCalledWith(pluginId, "environmentDestroyLease", expect.objectContaining({
+      providerLeaseId: "lease-resolved-provider-key",
+    }), 31234);
+    await expect(environmentService(db).getLeaseById(first.lease.id)).resolves.toMatchObject({
+      status: "expired",
+      cleanupStatus: "success",
+      failureReason: "lease_fingerprint_mismatch",
+    });
+    // The lease metadata must never carry the raw credential value.
+    const firstMetadata = JSON.stringify(first.lease.metadata);
+    expect(firstMetadata).not.toContain("resolved-provider-key");
   });
 
   it("preserves active reusable sandbox leases held by another running run", async () => {

--- a/server/src/services/effective-run-config-fingerprints.ts
+++ b/server/src/services/effective-run-config-fingerprints.ts
@@ -26,6 +26,7 @@ export interface EffectiveRunConfigSecretVersionMetadata {
   version: number | string;
   provider?: string | null;
   providerVersionRef?: string | null;
+  valueFingerprint?: string | null;
   outcome?: "success" | "failure" | null;
 }
 
@@ -141,12 +142,14 @@ function normalizeSecretManifestEntry(
   const bindingId = readString(record.bindingId);
   const provider = readString(record.provider);
   const providerVersionRef = readString(record.providerVersionRef);
+  const valueFingerprint = readString(record.valueFingerprint);
   const outcome = record.outcome === "success" || record.outcome === "failure"
     ? record.outcome
     : null;
   if (bindingId !== null) normalized.bindingId = bindingId;
   if (provider !== null) normalized.provider = provider;
   if (providerVersionRef !== null) normalized.providerVersionRef = providerVersionRef;
+  if (valueFingerprint !== null) normalized.valueFingerprint = valueFingerprint;
   if (outcome !== null) normalized.outcome = outcome;
   return normalized;
 }
@@ -177,6 +180,7 @@ function canonicalSecretMetadata(
     version: metadata.version,
     provider: metadata.provider ?? undefined,
     providerVersionRef: metadata.providerVersionRef ?? undefined,
+    valueFingerprint: metadata.valueFingerprint ?? undefined,
     outcome: metadata.outcome ?? undefined,
   });
 }

--- a/server/src/services/environment-runtime.ts
+++ b/server/src/services/environment-runtime.ts
@@ -354,6 +354,9 @@ async function buildEnvironmentSecretMetadataForLeaseFingerprint(input: {
       version: resolvedVersion,
       provider: secret.provider,
       providerVersionRef: versionRow?.providerVersionRef ?? null,
+      valueFingerprint: versionRow
+        ? versionRow.fingerprintSha256 ?? versionRow.valueSha256
+        : null,
       outcome: versionRow ? "success" : "failure",
     });
   }

--- a/server/src/services/environment-runtime.ts
+++ b/server/src/services/environment-runtime.ts
@@ -454,6 +454,7 @@ function reusableSandboxLeaseScopeMatches(input: {
   config: Record<string, unknown>;
   leaseFingerprint?: EffectiveRunConfigFingerprint | null;
   allowLegacyRuntimeFingerprint?: boolean;
+  environmentHasSecretRefs?: boolean;
 }): boolean {
   if (!input.executionWorkspaceId || !input.agentId) return false;
   const scope = input.lease.metadata?.reusableSandboxLease;
@@ -474,6 +475,12 @@ function reusableSandboxLeaseScopeMatches(input: {
     if (storedLeaseFingerprint) {
       return storedLeaseFingerprint === expectedLeaseFingerprint;
     }
+    // Legacy lease (created before value-aware lease fingerprints existed): it
+    // only carries the secret-blind runtimeFingerprint. For a secret-bearing
+    // environment we must NEVER fall through to the runtime-only match, or an
+    // in-place secret value change would be invisible and we'd serve a stale
+    // credential from the reused sandbox. Force a fresh, value-aware lease.
+    if (input.environmentHasSecretRefs) return false;
     if (!input.allowLegacyRuntimeFingerprint) return false;
   }
 
@@ -812,6 +819,13 @@ function createSandboxEnvironmentDriver(
                 lease.metadata?.agentId === input.agentId,
               )
           : [];
+        // Hoisted out of the filter: whether this environment references any
+        // secrets gates the secret-blind legacy runtime fallback below. One DB
+        // read per acquire, never per candidate lease.
+        const environmentHasSecretRefs =
+          reusableCandidateLeases.length > 0
+            ? (await collectEnvironmentSecretRefs({ db, environment: input.environment })).length > 0
+            : false;
         const reusableExistingLeases = reusableCandidateLeases.filter((lease) =>
           reusableSandboxLeaseScopeMatches({
             lease,
@@ -823,6 +837,7 @@ function createSandboxEnvironmentDriver(
             provider: parsed.config.provider,
             config: providerConfigForLease,
             leaseFingerprint,
+            environmentHasSecretRefs,
             allowLegacyRuntimeFingerprint:
               lease.status === "active" &&
               input.heartbeatRunId !== null &&
@@ -995,6 +1010,13 @@ function createSandboxEnvironmentDriver(
                 lease.metadata?.agentId === input.agentId,
               )
           : [];
+      // Hoisted out of the filter: whether this environment references any
+      // secrets gates the secret-blind legacy runtime fallback below. One DB
+      // read per acquire, never per candidate lease.
+      const environmentHasSecretRefs =
+        reusableCandidateLeases.length > 0
+          ? (await collectEnvironmentSecretRefs({ db, environment: input.environment })).length > 0
+          : false;
       const reusableExistingLeases = reusableCandidateLeases.filter((lease) =>
         reusableSandboxLeaseScopeMatches({
           lease,
@@ -1006,6 +1028,7 @@ function createSandboxEnvironmentDriver(
           provider: parsed.config.provider,
           config: providerConfigForLease,
           leaseFingerprint,
+          environmentHasSecretRefs,
           allowLegacyRuntimeFingerprint:
             lease.status === "active" &&
             input.heartbeatRunId !== null &&

--- a/server/src/services/environment-runtime.ts
+++ b/server/src/services/environment-runtime.ts
@@ -1034,6 +1034,7 @@ function reusableSandboxLeaseScopeMatches(input: {
   config: Record<string, unknown>;
   leaseFingerprint?: EffectiveRunConfigFingerprint | null;
   allowLegacyRuntimeFingerprint?: boolean;
+  environmentHasSecretRefs?: boolean;
 }): boolean {
   if (!input.executionWorkspaceId || !input.agentId) return false;
   const scope = input.lease.metadata?.reusableSandboxLease;
@@ -1054,6 +1055,12 @@ function reusableSandboxLeaseScopeMatches(input: {
     if (storedLeaseFingerprint) {
       return storedLeaseFingerprint === expectedLeaseFingerprint;
     }
+    // Legacy lease (created before value-aware lease fingerprints existed): it
+    // only carries the secret-blind runtimeFingerprint. For a secret-bearing
+    // environment we must NEVER fall through to the runtime-only match, or an
+    // in-place secret value change would be invisible and we'd serve a stale
+    // credential from the reused sandbox. Force a fresh, value-aware lease.
+    if (input.environmentHasSecretRefs) return false;
     if (!input.allowLegacyRuntimeFingerprint) return false;
   }
 
@@ -1847,6 +1854,13 @@ function createSandboxEnvironmentDriver(
                 lease.metadata?.agentId === input.agentId,
               )
           : [];
+        // Hoisted out of the filter: whether this environment references any
+        // secrets gates the secret-blind legacy runtime fallback below. One DB
+        // read per acquire, never per candidate lease.
+        const environmentHasSecretRefs =
+          reusableCandidateLeases.length > 0
+            ? (await collectEnvironmentSecretRefs({ db, environment: input.environment })).length > 0
+            : false;
         const reusableExistingLeases = reusableCandidateLeases.filter((lease) =>
           reusableSandboxLeaseScopeMatches({
             lease,
@@ -1858,6 +1872,7 @@ function createSandboxEnvironmentDriver(
             provider: parsed.config.provider,
             config: providerConfigForLease,
             leaseFingerprint,
+            environmentHasSecretRefs,
             allowLegacyRuntimeFingerprint:
               lease.status === "active" &&
               input.heartbeatRunId !== null &&
@@ -2201,6 +2216,13 @@ function createSandboxEnvironmentDriver(
                 lease.metadata?.agentId === input.agentId,
               )
           : [];
+      // Hoisted out of the filter: whether this environment references any
+      // secrets gates the secret-blind legacy runtime fallback below. One DB
+      // read per acquire, never per candidate lease.
+      const environmentHasSecretRefs =
+        reusableCandidateLeases.length > 0
+          ? (await collectEnvironmentSecretRefs({ db, environment: input.environment })).length > 0
+          : false;
       const reusableExistingLeases = reusableCandidateLeases.filter((lease) =>
         reusableSandboxLeaseScopeMatches({
           lease,
@@ -2212,6 +2234,7 @@ function createSandboxEnvironmentDriver(
           provider: parsed.config.provider,
           config: providerConfigForLease,
           leaseFingerprint,
+          environmentHasSecretRefs,
           allowLegacyRuntimeFingerprint:
             lease.status === "active" &&
             input.heartbeatRunId !== null &&

--- a/server/src/services/environment-runtime.ts
+++ b/server/src/services/environment-runtime.ts
@@ -934,6 +934,9 @@ async function buildEnvironmentSecretMetadataForLeaseFingerprint(input: {
       version: resolvedVersion,
       provider: secret.provider,
       providerVersionRef: versionRow?.providerVersionRef ?? null,
+      valueFingerprint: versionRow
+        ? versionRow.fingerprintSha256 ?? versionRow.valueSha256
+        : null,
       outcome: versionRow ? "success" : "failure",
     });
   }

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -3580,6 +3580,7 @@ function sanitizeSecretManifestForConfigFingerprint(
         : readNonEmptyString(record.version),
       provider: readNonEmptyString(record.provider),
       providerVersionRef: readNonEmptyString(record.providerVersionRef),
+      valueFingerprint: readNonEmptyString(record.valueFingerprint),
       outcome: record.outcome === "success" || record.outcome === "failure" ? record.outcome : null,
     };
   });

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -5935,6 +5935,7 @@ function sanitizeSecretManifestForConfigFingerprint(
           : readNonEmptyString(record.version),
       provider: readNonEmptyString(record.provider),
       providerVersionRef: readNonEmptyString(record.providerVersionRef),
+      valueFingerprint: readNonEmptyString(record.valueFingerprint),
       outcome:
         record.outcome === "success" || record.outcome === "failure"
           ? record.outcome

--- a/server/src/services/secrets.ts
+++ b/server/src/services/secrets.ts
@@ -434,6 +434,11 @@ export type RuntimeSecretManifestEntry = {
   version: number;
   provider: SecretProvider;
   providerVersionRef?: string | null;
+  // Non-reversible hash of the resolved secret VALUE for the version. Lets the
+  // effective-run-config fingerprint detect an in-place re-encryption that keeps
+  // the same version number but changes the underlying value, forcing a session/
+  // sandbox refresh. Never the plaintext or ciphertext material.
+  valueFingerprint?: string | null;
   outcome: "success" | "failure";
   errorCode?: string | null;
 };
@@ -1086,6 +1091,7 @@ export function secretService(db: Db) {
           version: resolvedVersion,
           provider: providerId,
           providerVersionRef: versionRow.providerVersionRef,
+          valueFingerprint: versionRow.fingerprintSha256 ?? versionRow.valueSha256,
           outcome: "success",
         },
       };

--- a/server/src/services/secrets.ts
+++ b/server/src/services/secrets.ts
@@ -681,6 +681,11 @@ export type RuntimeSecretManifestEntry = {
   version: number;
   provider: SecretProvider;
   providerVersionRef?: string | null;
+  // Non-reversible hash of the resolved secret VALUE for the version. Lets the
+  // effective-run-config fingerprint detect an in-place re-encryption that keeps
+  // the same version number but changes the underlying value, forcing a session/
+  // sandbox refresh. Never the plaintext or ciphertext material.
+  valueFingerprint?: string | null;
   outcome: "success" | "failure";
   errorCode?: string | null;
 };
@@ -1406,6 +1411,7 @@ export function secretService(db: Db | DbTransaction) {
           version: resolvedVersion,
           provider: providerId,
           providerVersionRef: versionRow.providerVersionRef,
+          valueFingerprint: versionRow.fingerprintSha256 ?? versionRow.valueSha256,
           outcome: "success",
         },
       };


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Agents run against provider credentials stored as versioned secrets; to avoid re-provisioning, the runtime reuses an agent's task session and its already-provisioned sandbox when the "effective run config fingerprint" is unchanged.
> - The secret portion of that fingerprint is derived from binding metadata (`configPath, envKey, secretId, bindingId, version, provider, providerVersionRef, outcome`) but not from the secret's actual value.
> - For the default `local_encrypted` provider, an in-place re-encryption keeps the same version number while the value changes (rotation-in-place, or repairing a corrupted credential), so the fingerprint is byte-identical and both the session AND the reusable-environment sandbox lease are reused with the stale credential — the repaired value never reaches the agent.
> - This pull request threads the version's non-reversible value hash into the secret manifest and includes it in both the session fingerprint and the sandbox-lease fingerprint.
> - The benefit is that repairing/rotating a credential in place now reliably takes effect on the next run, while unchanged values still reuse sessions and sandboxes (no spurious churn).

## Linked Issues or Issue Description

No public issue exists; the underlying bug is described inline below, following the bug report template.

**What happened**

After a secret's value was changed in place under the same version number, the agent kept authenticating with the old value. The task session and its already-provisioned sandbox were reused because the effective-run-config fingerprint (which omitted any value hash) was byte-identical before and after the change.

**Expected behavior**

A changed credential value invalidates the reused session AND the reusable-environment sandbox lease, so the corrected value is delivered on the next run; an unchanged value still reuses both with no extra churn.

**Steps to reproduce**

1. Connect a `local_encrypted` credential and run an agent so a session and sandbox are provisioned.
2. Re-encrypt the secret value in place under the same version number (rotation-in-place, or repairing a corrupted value).
3. Trigger another run and observe the stale credential is still used because the session and sandbox lease were reused.

## What Changed

- Added a non-reversible per-version `valueFingerprint` to `RuntimeSecretManifestEntry`, populated from `company_secret_versions.fingerprint_sha256` (falling back to `value_sha256`). Never the plaintext or ciphertext.
- Included `valueFingerprint` in the session effective-run-config fingerprint (`effective-run-config-fingerprints.ts` normalize + canonicalize; `heartbeat.ts` `sanitizeSecretManifestForConfigFingerprint`).
- Included `valueFingerprint` in the reusable-environment sandbox-lease fingerprint so an in-place value change also invalidates the sandbox lease (addresses the "lease fingerprint omits value change" review finding).

## Verification

- `pnpm --filter server test effective-run-config-fingerprints` — added tests assert: (1) the session fingerprint changes when only the value fingerprint changes under the same version; (2) an identical value fingerprint produces an identical fingerprint (no spurious reset); (3) the canonical JSON never contains the raw secret value; and the analogous assertions for the sandbox-lease fingerprint.
- Full affected server suite green and server typecheck clean.

## Risks

Low. The added field is an optional non-reversible hash; when absent (e.g. providers that do not set it) behavior is unchanged. Identical values keep identical fingerprints, so there is no additional session/sandbox churn. The only behavioral change is the intended one: a changed value now forces a refresh.

## Model Used

Claude (Anthropic), model ID `claude-fable-5`, extended reasoning, with tool use / code execution in an agentic harness.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
