### PR TITLE
fix(server): suppress long-active productivity signal during scheduled monitor waits

### DIFF
--- a/server/src/__tests__/productivity-review-service.test.ts
+++ b/server/src/__tests__/productivity-review-service.test.ts
@@ -55,6 +55,8 @@ describeEmbeddedPostgres("productivity review service", () => {
     startedAt?: Date;
     parentId?: string | null;
     originKind?: string;
+    executionState?: Record<string, unknown> | null;
+    monitorNextCheckAt?: Date | null;
   }) {
     const companyId = randomUUID();
     const managerId = randomUUID();
@@ -106,6 +108,8 @@ describeEmbeddedPostgres("productivity review service", () => {
       issueNumber: 1,
       identifier: `${issuePrefix}-1`,
       startedAt: opts?.startedAt ?? createdAt,
+      executionState: opts?.executionState ?? null,
+      monitorNextCheckAt: opts?.monitorNextCheckAt ?? null,
       createdAt,
       updatedAt: createdAt,
     });
@@ -503,6 +507,100 @@ describeEmbeddedPostgres("productivity review service", () => {
     expect(review?.description).toContain("Primary trigger: `long_active_duration`");
     expect(review?.priority).toBe("medium");
     expect(hold.held).toBe(false);
+  });
+
+  it("suppresses a long-active-only review while a future scheduled monitor is pending", async () => {
+    const now = new Date("2026-04-28T12:00:00.000Z");
+    const nextCheckAt = new Date(now.getTime() + 60 * 60 * 1000);
+    const seeded = await seedAssignedIssue({
+      status: "in_progress",
+      startedAt: new Date(now.getTime() - 7 * 60 * 60 * 1000),
+      executionState: { monitor: { status: "scheduled", nextCheckAt: nextCheckAt.toISOString() } },
+      monitorNextCheckAt: nextCheckAt,
+    });
+
+    const result = await productivityReviewService(db).reconcileProductivityReviews({
+      now,
+      companyId: seeded.companyId,
+    });
+
+    expect(result.created).toBe(0);
+    expect(await listProductivityReviews(seeded.companyId)).toHaveLength(0);
+  });
+
+  it("still creates a high-churn review while a future scheduled monitor is pending", async () => {
+    const now = new Date("2026-04-28T12:00:00.000Z");
+    const nextCheckAt = new Date(now.getTime() + 60 * 60 * 1000);
+    const seeded = await seedAssignedIssue({
+      status: "in_progress",
+      startedAt: new Date(now.getTime() - 7 * 60 * 60 * 1000),
+      executionState: { monitor: { status: "scheduled", nextCheckAt: nextCheckAt.toISOString() } },
+      monitorNextCheckAt: nextCheckAt,
+    });
+    await insertRuns({
+      companyId: seeded.companyId,
+      agentId: seeded.coderId,
+      issueId: seeded.issueId,
+      count: 10,
+      now,
+      withRunComments: true,
+    });
+
+    const result = await productivityReviewService(db).reconcileProductivityReviews({
+      now,
+      companyId: seeded.companyId,
+    });
+
+    expect(result.created).toBe(1);
+    const [review] = await listProductivityReviews(seeded.companyId);
+    expect(review?.description).toContain("Primary trigger: `high_churn`");
+  });
+
+  it("still creates a no-comment-streak review while a future scheduled monitor is pending", async () => {
+    const now = new Date("2026-04-28T12:00:00.000Z");
+    const nextCheckAt = new Date(now.getTime() + 60 * 60 * 1000);
+    const seeded = await seedAssignedIssue({
+      status: "in_progress",
+      startedAt: new Date(now.getTime() - 7 * 60 * 60 * 1000),
+      executionState: { monitor: { status: "scheduled", nextCheckAt: nextCheckAt.toISOString() } },
+      monitorNextCheckAt: nextCheckAt,
+    });
+    await insertRuns({
+      companyId: seeded.companyId,
+      agentId: seeded.coderId,
+      issueId: seeded.issueId,
+      count: DEFAULT_PRODUCTIVITY_REVIEW_NO_COMMENT_STREAK_RUNS,
+      now,
+    });
+
+    const result = await productivityReviewService(db).reconcileProductivityReviews({
+      now,
+      companyId: seeded.companyId,
+    });
+
+    expect(result.created).toBe(1);
+    const [review] = await listProductivityReviews(seeded.companyId);
+    expect(review?.description).toContain("Primary trigger: `no_comment_streak`");
+  });
+
+  it("still creates a long-active review once the scheduled monitor check time has passed", async () => {
+    const now = new Date("2026-04-28T12:00:00.000Z");
+    const nextCheckAt = new Date(now.getTime() - 30 * 60 * 1000);
+    const seeded = await seedAssignedIssue({
+      status: "in_progress",
+      startedAt: new Date(now.getTime() - 7 * 60 * 60 * 1000),
+      executionState: { monitor: { status: "scheduled", nextCheckAt: nextCheckAt.toISOString() } },
+      monitorNextCheckAt: nextCheckAt,
+    });
+
+    const result = await productivityReviewService(db).reconcileProductivityReviews({
+      now,
+      companyId: seeded.companyId,
+    });
+
+    expect(result.created).toBe(1);
+    const [review] = await listProductivityReviews(seeded.companyId);
+    expect(review?.description).toContain("Primary trigger: `long_active_duration`");
   });
 
   it("creates a high-churn review even when every sampled run has a progress comment", async () => {

--- a/server/src/services/productivity-review.ts
+++ b/server/src/services/productivity-review.ts
@@ -142,6 +142,17 @@ function coerceDate(value: Date | string | null | undefined) {
   return value instanceof Date ? value : new Date(value);
 }
 
+// A future scheduled monitor means the assignee is intentionally parked waiting
+// for an external checkpoint, so a long active episode is expected rather than a
+// stall. Suppress only the long_active_duration signal while such a monitor is
+// pending; no_comment_streak and high_churn stay evaluated.
+function hasFutureScheduledMonitor(issue: IssueRow, now: Date) {
+  const monitor = (issue.executionState as { monitor?: { status?: unknown } } | null)?.monitor;
+  if (!monitor || monitor.status !== "scheduled") return false;
+  const nextCheckAt = coerceDate(issue.monitorNextCheckAt);
+  return nextCheckAt !== null && nextCheckAt.getTime() > now.getTime();
+}
+
 function buildThresholds(overrides?: Partial<ProductivityReviewThresholds>): ProductivityReviewThresholds {
   return {
     noCommentStreakRuns: readPositiveInteger(
@@ -533,7 +544,10 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
       : null;
 
     const noComment = noCommentStreak >= thresholds.noCommentStreakRuns;
-    const longActive = elapsedMs !== null && elapsedMs >= thresholds.longActiveMs;
+    const longActive =
+      elapsedMs !== null &&
+      elapsedMs >= thresholds.longActiveMs &&
+      !hasFutureScheduledMonitor(sourceIssue, now);
     const highChurn =
       runCountLastHour >= thresholds.highChurnHourly ||
       assigneeRunCommentCountLastHour >= thresholds.highChurnHourly ||


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The productivity reviewer (`server/src/services/productivity-review.ts`) watches assigned issues and opens a manager review when it detects a stall/churn pattern via three signals: `no_comment_streak`, `long_active_duration`, `high_churn`
> - `long_active_duration` fires purely on active elapsed time and ignores whether the issue is deliberately parked on a scheduled monitor waiting for an external checkpoint
> - An issue waiting on a future scheduled monitor is *expected* to stay active for a long time, so these waits surface as `long_active_duration` false positives that spam managers with reviews of healthy work
> - This pull request suppresses only the `long_active_duration` signal while the source issue's `executionState.monitor` is `scheduled` and `monitorNextCheckAt` is still in the future
> - The benefit is fewer false-positive productivity reviews for issues that are correctly waiting on a monitor, with no loss of coverage for genuine stalls (no monitor, expired monitor, or non-scheduled monitor still trigger as before), and `no_comment_streak` / `high_churn` remain fully active on the same source

## Linked Issues or Issue Description

Bug fix (no public issue filed):

- **What happened:** Issues that are intentionally parked on a future scheduled monitor (waiting for an external checkpoint) keep accruing active elapsed time and get flagged as `long_active_duration`, producing productivity-review issues for work that is healthy and simply waiting.
- **Expected behavior:** While an issue is waiting on a future scheduled monitor, the long-active signal should be suppressed; other productivity signals (no-comment streak, high churn) should continue to fire, and long-active should resume once the monitor is due or absent.
- **Steps to reproduce:** Assign an in-progress issue whose `executionState.monitor.status` is `scheduled` with `monitorNextCheckAt` in the future, let its active episode exceed the long-active threshold (default 6h), and run productivity-review reconciliation — a `long_active_duration` review is created.
- **Deployment mode:** N/A (server service logic).

Related prior work (different approaches, not duplicates): #6972 removes the `long_active_duration` trigger entirely; #5859 and #5209 snooze repeat long-active reviews after a productive close. This PR instead targets the scheduled-monitor-wait root cause without removing the signal.

## What Changed

- Added `hasFutureScheduledMonitor(issue, now)` helper in `productivity-review.ts` that returns true when `executionState.monitor.status === "scheduled"` and `monitorNextCheckAt > now`.
- Gated the `longActive` computation on `!hasFutureScheduledMonitor(...)` so only the `long_active_duration` signal is suppressed during a pending scheduled monitor. `no_comment_streak`, `high_churn`, and cost behavior are unchanged.
- Extended the `seedAssignedIssue` test helper with optional `executionState` / `monitorNextCheckAt` and added four targeted tests: long-active-only suppressed under a future scheduled monitor; high-churn still fires; no-comment-streak still fires; long-active resumes once the monitor check time has passed.

## Verification

- `npx vitest run src/__tests__/productivity-review-service.test.ts` (in `server/`) — 19 passed (15 existing + 4 new).
- `npx tsc --noEmit` (in `server/`) — no new type errors in the changed files.

## Risks

- Low risk. The change is a narrow additional guard on one signal. When there is no monitor, the monitor is not `scheduled`, or `monitorNextCheckAt` is missing/past, behavior is identical to before. `executionState` is read defensively (typed as `Record<string, unknown>`), so malformed state falls through to existing behavior.

## Model Used

- Claude (Anthropic), model `claude-opus-4-8`, extended thinking with tool use.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge
