### PR TITLE
feat(server): declarative instance settings overrides via env

### DIFF
--- a/server/src/__tests__/feedback-service.test.ts
+++ b/server/src/__tests__/feedback-service.test.ts
@@ -519,6 +519,57 @@ describeEmbeddedPostgres("feedbackService.saveIssueVote", () => {
     });
   });
 
+  it("does not persist an env-overridden censorUsernameInLogs value on the sharing-preference write-back", async () => {
+    const { issueId, commentId } = await seedIssueWithAgentComment();
+
+    await db.insert(instanceSettings).values({
+      singletonKey: "default",
+      general: {
+        censorUsernameInLogs: true,
+        feedbackDataSharingPreference: "prompt",
+      },
+      experimental: {},
+    });
+
+    const previousOverrides = process.env.PAPERCLIP_INSTANCE_SETTINGS_OVERRIDES;
+    process.env.PAPERCLIP_INSTANCE_SETTINGS_OVERRIDES = JSON.stringify({
+      general: { censorUsernameInLogs: false },
+    });
+
+    try {
+      const result = await svc.saveIssueVote({
+        issueId,
+        targetType: "issue_comment",
+        targetId: commentId,
+        vote: "up",
+        authorUserId: "user-1",
+        allowSharing: true,
+      });
+
+      expect(result.persistedSharingPreference).toBe("allowed");
+
+      const settings = await db
+        .select()
+        .from(instanceSettings)
+        .where(eq(instanceSettings.singletonKey, "default"))
+        .then((rows) => rows[0] ?? null);
+
+      // The env override forces censorUsernameInLogs=false at read time, but
+      // the write-back must persist the raw stored value (true), never the
+      // override.
+      expect(settings?.general).toMatchObject({
+        censorUsernameInLogs: true,
+        feedbackDataSharingPreference: "allowed",
+      });
+    } finally {
+      if (previousOverrides === undefined) {
+        delete process.env.PAPERCLIP_INSTANCE_SETTINGS_OVERRIDES;
+      } else {
+        process.env.PAPERCLIP_INSTANCE_SETTINGS_OVERRIDES = previousOverrides;
+      }
+    }
+  });
+
   it("stores a trace record for document revision feedback targets", async () => {
     const { issueId, revisionId } = await seedIssueWithAgentDocument();
 

--- a/server/src/__tests__/instance-settings-service.test.ts
+++ b/server/src/__tests__/instance-settings-service.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import type { InstanceExperimentalSettings } from "@paperclipai/shared";
 import {
   applyExperimentalSettingsPatch,
+  instanceSettingsService,
   normalizeExperimentalSettings,
   resolveWorktreeRunExecutionActivationState,
   parseInstanceSettingsOverrides,
@@ -433,5 +434,51 @@ describe("stripOverriddenPatchKeys", () => {
   it("returns the patch unchanged when nothing is overridden", () => {
     const patch = { enableCases: true };
     expect(stripOverriddenPatchKeys(patch, [])).toEqual(patch);
+  });
+});
+
+function makeSettingsRow(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: "row-1",
+    singletonKey: "default",
+    defaultEnvironmentId: null,
+    general: {},
+    experimental: {},
+    visibility: {},
+    createdAt: new Date("2026-01-01T00:00:00Z"),
+    updatedAt: new Date("2026-01-01T00:00:00Z"),
+    ...overrides,
+  };
+}
+
+function makeReadOnlyDb(row: unknown) {
+  return {
+    select: () => ({ from: () => ({ where: () => Promise.resolve([row]) }) }),
+  } as never;
+}
+
+describe("instanceSettingsService with env overrides", () => {
+  it("get() returns override-merged experimental settings", async () => {
+    const svc = instanceSettingsService(makeReadOnlyDb(makeSettingsRow()), {
+      runtimeEnv: { PAPERCLIP_INSTANCE_SETTINGS_OVERRIDES: '{"experimental":{"enableApps":true}}' },
+    });
+    const settings = await svc.get();
+    expect(settings.experimental.enableApps).toBe(true);
+  });
+
+  it("getExperimental() applies overrides over stored values", async () => {
+    const svc = instanceSettingsService(
+      makeReadOnlyDb(makeSettingsRow({ experimental: { enableApps: false, enableCases: true } })),
+      { runtimeEnv: { PAPERCLIP_INSTANCE_SETTINGS_OVERRIDES: '{"experimental":{"enableApps":true}}' } },
+    );
+    const experimental = await svc.getExperimental();
+    expect(experimental.enableApps).toBe(true);
+    expect(experimental.enableCases).toBe(true);
+  });
+
+  it("getExperimental() without the env var behaves exactly as before", async () => {
+    const svc = instanceSettingsService(makeReadOnlyDb(makeSettingsRow()), { runtimeEnv: {} });
+    const experimental = await svc.getExperimental();
+    expect(experimental.enableApps).toBe(false);
   });
 });

--- a/server/src/__tests__/instance-settings-service.test.ts
+++ b/server/src/__tests__/instance-settings-service.test.ts
@@ -4,6 +4,10 @@ import {
   applyExperimentalSettingsPatch,
   normalizeExperimentalSettings,
   resolveWorktreeRunExecutionActivationState,
+  parseInstanceSettingsOverrides,
+  resolveExperimentalSettings,
+  resolveGeneralSettings,
+  stripOverriddenPatchKeys,
 } from "../services/instance-settings.js";
 
 describe("instance settings service", () => {
@@ -352,5 +356,82 @@ describe("instance settings service", () => {
     });
     expect(getExperimental).not.toHaveBeenCalled();
   });
+});
 
+describe("parseInstanceSettingsOverrides", () => {
+  it("returns empty overrides when the env var is unset or blank", () => {
+    expect(parseInstanceSettingsOverrides({})).toEqual({ general: {}, experimental: {} });
+    expect(parseInstanceSettingsOverrides({ PAPERCLIP_INSTANCE_SETTINGS_OVERRIDES: "  " })).toEqual({
+      general: {}, experimental: {},
+    });
+  });
+
+  it("parses experimental boolean overrides", () => {
+    const overrides = parseInstanceSettingsOverrides({
+      PAPERCLIP_INSTANCE_SETTINGS_OVERRIDES: '{"experimental":{"enableApps":true,"enablePipelines":true}}',
+    });
+    expect(overrides.experimental).toEqual({ enableApps: true, enablePipelines: true });
+    expect(overrides.general).toEqual({});
+  });
+
+  it("ignores invalid JSON entirely", () => {
+    expect(parseInstanceSettingsOverrides({ PAPERCLIP_INSTANCE_SETTINGS_OVERRIDES: "{nope" })).toEqual({
+      general: {}, experimental: {},
+    });
+  });
+
+  it("strips unknown keys within a section", () => {
+    const overrides = parseInstanceSettingsOverrides({
+      PAPERCLIP_INSTANCE_SETTINGS_OVERRIDES: '{"experimental":{"enableApps":true,"notAFlag":true}}',
+    });
+    expect(overrides.experimental).toEqual({ enableApps: true });
+  });
+
+  it("drops a section that fails validation", () => {
+    const overrides = parseInstanceSettingsOverrides({
+      PAPERCLIP_INSTANCE_SETTINGS_OVERRIDES: '{"experimental":{"enableApps":"yes"},"general":{"keyboardShortcuts":true}}',
+    });
+    expect(overrides.experimental).toEqual({});
+    expect(overrides.general).toEqual({ keyboardShortcuts: true });
+  });
+
+  it("strips server-managed worktree activation fields from experimental overrides", () => {
+    const overrides = parseInstanceSettingsOverrides({
+      PAPERCLIP_INSTANCE_SETTINGS_OVERRIDES:
+        '{"experimental":{"enableApps":true,"worktreeRunExecutionActivatedAt":"2026-01-01T00:00:00Z"}}',
+    });
+    expect(overrides.experimental).toEqual({ enableApps: true });
+  });
+});
+
+describe("override resolution", () => {
+  it("env overrides win over stored values", () => {
+    expect(resolveExperimentalSettings({ enableApps: false }, { enableApps: true }).enableApps).toBe(true);
+  });
+
+  it("stored values survive when not overridden", () => {
+    const resolved = resolveExperimentalSettings({ enablePipelines: true }, { enableApps: true });
+    expect(resolved.enablePipelines).toBe(true);
+    expect(resolved.enableApps).toBe(true);
+    expect(resolved.enableCases).toBe(false);
+  });
+
+  it("general overrides merge over stored general settings", () => {
+    const resolved = resolveGeneralSettings({ keyboardShortcuts: true }, { censorUsernameInLogs: true });
+    expect(resolved.keyboardShortcuts).toBe(true);
+    expect(resolved.censorUsernameInLogs).toBe(true);
+  });
+});
+
+describe("stripOverriddenPatchKeys", () => {
+  it("removes keys that are env-overridden so patches cannot persist forced values", () => {
+    expect(stripOverriddenPatchKeys({ enableApps: false, enableCases: true }, ["enableApps"])).toEqual({
+      enableCases: true,
+    });
+  });
+
+  it("returns the patch unchanged when nothing is overridden", () => {
+    const patch = { enableCases: true };
+    expect(stripOverriddenPatchKeys(patch, [])).toEqual(patch);
+  });
 });

--- a/server/src/services/feedback.ts
+++ b/server/src/services/feedback.ts
@@ -23,9 +23,7 @@ import { claudeConfigDir, parseClaudeStreamJson } from "@paperclipai/adapter-cla
 import { codexHomeDir, parseCodexJsonl } from "@paperclipai/adapter-codex-local/server";
 import { parseOpenCodeJsonl } from "@paperclipai/adapter-opencode-local/server";
 import {
-  DEFAULT_FEEDBACK_DATA_SHARING_PREFERENCE,
   DEFAULT_FEEDBACK_DATA_SHARING_TERMS_VERSION,
-  instanceGeneralSettingsSchema,
   type FeedbackTargetType,
   type FeedbackTraceBundle,
   type FeedbackTraceBundleCaptureStatus,
@@ -46,6 +44,7 @@ import {
   sha256Digest,
 } from "./feedback-redaction.js";
 import { getRunLogStore } from "./run-log-store.js";
+import { parseInstanceSettingsOverrides, resolveGeneralSettings } from "./instance-settings.js";
 
 const FEEDBACK_SCHEMA_VERSION = "paperclip-feedback-envelope-v2";
 const FEEDBACK_BUNDLE_VERSION = "paperclip-feedback-bundle-v2";
@@ -152,15 +151,6 @@ function contentTypeForPath(filePath: string) {
   if (lower.endsWith(".json")) return "application/json";
   if (lower.endsWith(".md")) return "text/markdown; charset=utf-8";
   return "text/plain; charset=utf-8";
-}
-
-function normalizeInstanceGeneralSettings(raw: unknown) {
-  const parsed = instanceGeneralSettingsSchema.safeParse(raw ?? {});
-  if (parsed.success) return parsed.data;
-  return {
-    censorUsernameInLogs: false,
-    feedbackDataSharingPreference: DEFAULT_FEEDBACK_DATA_SHARING_PREFERENCE,
-  };
 }
 
 function buildIssuePath(identifier: string | null) {
@@ -1977,8 +1967,12 @@ export function feedbackService(db: Db, options: FeedbackServiceOptions = {}) {
             })
             .then((rows) => rows[0] ?? null));
 
-        const currentGeneral = normalizeInstanceGeneralSettings(currentInstanceSettings?.general);
-        if (currentInstanceSettings && currentGeneral.feedbackDataSharingPreference === "prompt") {
+        const storedGeneral = resolveGeneralSettings(currentInstanceSettings?.general);
+        const effectiveGeneral = resolveGeneralSettings(
+          currentInstanceSettings?.general,
+          parseInstanceSettingsOverrides().general,
+        );
+        if (currentInstanceSettings && effectiveGeneral.feedbackDataSharingPreference === "prompt") {
           const nextSharingPreference = sharedWithLabs ? "allowed" : "not_allowed";
           const currentGeneralRaw = asRecord(currentInstanceSettings.general) ?? {};
           await tx
@@ -1986,7 +1980,7 @@ export function feedbackService(db: Db, options: FeedbackServiceOptions = {}) {
             .set({
               general: {
                 ...currentGeneralRaw,
-                censorUsernameInLogs: currentGeneral.censorUsernameInLogs,
+                censorUsernameInLogs: storedGeneral.censorUsernameInLogs,
                 feedbackDataSharingPreference: nextSharingPreference,
               },
               updatedAt: now,

--- a/server/src/services/instance-settings.ts
+++ b/server/src/services/instance-settings.ts
@@ -363,18 +363,23 @@ export function normalizeExperimentalSettings(raw: unknown): InstanceExperimenta
   };
 }
 
-function toInstanceSettings(row: typeof instanceSettings.$inferSelect): InstanceSettings {
+function toInstanceSettings(
+  row: typeof instanceSettings.$inferSelect,
+  overrides: InstanceSettingsOverrides = emptyOverrides(),
+): InstanceSettings {
   return {
     id: row.id,
     defaultEnvironmentId: row.defaultEnvironmentId ?? null,
-    general: normalizeGeneralSettings(row.general),
-    experimental: normalizeExperimentalSettings(row.experimental),
+    general: resolveGeneralSettings(row.general, overrides.general),
+    experimental: resolveExperimentalSettings(row.experimental, overrides.experimental),
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,
   } as InstanceSettings;
 }
 
 export function instanceSettingsService(db: Db, options: InstanceSettingsServiceOptions = {}) {
+  const overrides = parseInstanceSettingsOverrides(options.runtimeEnv ?? process.env);
+
   async function getOrCreateRow() {
     const existing = await db
       .select()
@@ -414,7 +419,7 @@ export function instanceSettingsService(db: Db, options: InstanceSettingsService
   }
 
   return {
-    get: async (): Promise<InstanceSettings> => toInstanceSettings(await getOrCreateRow()),
+    get: async (): Promise<InstanceSettings> => toInstanceSettings(await getOrCreateRow(), overrides),
 
     update: async (patch: PatchInstanceSettings): Promise<InstanceSettings> => {
       const current = await getOrCreateRow();
@@ -429,24 +434,28 @@ export function instanceSettingsService(db: Db, options: InstanceSettingsService
         })
         .where(eq(instanceSettings.id, current.id))
         .returning();
-      return toInstanceSettings(updated ?? current);
+      return toInstanceSettings(updated ?? current, overrides);
     },
 
     getGeneral: async (): Promise<InstanceGeneralSettings> => {
       const row = await getOrCreateRow();
-      return normalizeGeneralSettings(row.general);
+      return resolveGeneralSettings(row.general, overrides.general);
     },
 
     getExperimental: async (): Promise<InstanceExperimentalSettings> => {
       const row = await getOrCreateRow();
-      return normalizeExperimentalSettings(row.experimental);
+      return resolveExperimentalSettings(row.experimental, overrides.experimental);
     },
 
     updateGeneral: async (patch: PatchInstanceGeneralSettings): Promise<InstanceSettings> => {
       const current = await getOrCreateRow();
+      const effectivePatch = stripOverriddenPatchKeys(
+        patch as Record<string, unknown>,
+        Object.keys(overrides.general),
+      );
       const nextGeneral = normalizeGeneralSettings({
         ...normalizeGeneralSettings(current.general),
-        ...patch,
+        ...effectivePatch,
       });
       const now = new Date();
       const [updated] = await db
@@ -457,12 +466,16 @@ export function instanceSettingsService(db: Db, options: InstanceSettingsService
         })
         .where(eq(instanceSettings.id, current.id))
         .returning();
-      return toInstanceSettings(updated ?? current);
+      return toInstanceSettings(updated ?? current, overrides);
     },
 
     updateExperimental: async (patch: PatchInstanceExperimentalSettings): Promise<InstanceSettings> => {
       const current = await getOrCreateRow();
-      const nextExperimental = applyExperimentalSettingsPatch(current.experimental, patch, options);
+      const effectivePatch = stripOverriddenPatchKeys(
+        patch as Record<string, unknown>,
+        Object.keys(overrides.experimental),
+      ) as PatchInstanceExperimentalSettings;
+      const nextExperimental = applyExperimentalSettingsPatch(current.experimental, effectivePatch, options);
       const now = new Date();
       const [updated] = await db
         .update(instanceSettings)
@@ -472,7 +485,7 @@ export function instanceSettingsService(db: Db, options: InstanceSettingsService
         })
         .where(eq(instanceSettings.id, current.id))
         .returning();
-      return toInstanceSettings(updated ?? current);
+      return toInstanceSettings(updated ?? current, overrides);
     },
 
     listCompanyIds: async (): Promise<string[]> =>

--- a/server/src/services/instance-settings.ts
+++ b/server/src/services/instance-settings.ts
@@ -67,6 +67,105 @@ function stripServerManagedExperimentalPatchFields(
   return patchable as PatchInstanceExperimentalSettings;
 }
 
+const OVERRIDES_ENV_VAR = "PAPERCLIP_INSTANCE_SETTINGS_OVERRIDES";
+
+export interface InstanceSettingsOverrides {
+  general: Record<string, unknown>;
+  experimental: Record<string, unknown>;
+}
+
+function emptyOverrides(): InstanceSettingsOverrides {
+  return { general: {}, experimental: {} };
+}
+
+const warnedOverrideInputs = new Set<string>();
+
+function warnOverridesOnce(cacheKey: string, message: string) {
+  if (warnedOverrideInputs.has(cacheKey)) return;
+  warnedOverrideInputs.add(cacheKey);
+  console.warn(message);
+}
+
+/**
+ * Parses PAPERCLIP_INSTANCE_SETTINGS_OVERRIDES (a JSON object with optional
+ * "general" / "experimental" sections). Overridden keys win over the stored
+ * instance settings at read time, letting operators pin settings declaratively
+ * from deployment config. Invalid JSON or an invalid section is warned about
+ * once and ignored (the stored settings apply).
+ */
+export function parseInstanceSettingsOverrides(
+  env: Record<string, string | undefined> = process.env,
+): InstanceSettingsOverrides {
+  const raw = env[OVERRIDES_ENV_VAR]?.trim();
+  if (!raw) return emptyOverrides();
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    warnOverridesOnce(raw, `${OVERRIDES_ENV_VAR} is not valid JSON; ignoring overrides`);
+    return emptyOverrides();
+  }
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    warnOverridesOnce(raw, `${OVERRIDES_ENV_VAR} must be a JSON object; ignoring overrides`);
+    return emptyOverrides();
+  }
+
+  const sections = parsed as Record<string, unknown>;
+  const sectionSchemas = {
+    general: instanceGeneralSettingsSchema.partial().strip(),
+    experimental: instanceExperimentalSettingsSchema.partial().strip(),
+  } as const;
+
+  const result = emptyOverrides();
+  for (const key of ["general", "experimental"] as const) {
+    if (sections[key] === undefined) continue;
+    const sectionParsed = sectionSchemas[key].safeParse(sections[key]);
+    if (!sectionParsed.success) {
+      warnOverridesOnce(
+        `${raw}:${key}`,
+        `${OVERRIDES_ENV_VAR}.${key} failed validation; ignoring this section`,
+      );
+      continue;
+    }
+    result[key] = sectionParsed.data as Record<string, unknown>;
+  }
+  result.experimental = stripServerManagedExperimentalPatchFields(
+    result.experimental,
+  ) as Record<string, unknown>;
+  return result;
+}
+
+/**
+ * Override-aware resolution: normalize the stored value, spread the env
+ * overrides on top, and re-normalize. Nested objects (backupRetention) are
+ * overridden whole, matching the existing shallow patch semantics.
+ */
+export function resolveGeneralSettings(
+  raw: unknown,
+  overrides: Record<string, unknown> = {},
+): InstanceGeneralSettings {
+  return normalizeGeneralSettings({ ...normalizeGeneralSettings(raw), ...overrides });
+}
+
+export function resolveExperimentalSettings(
+  raw: unknown,
+  overrides: Record<string, unknown> = {},
+): InstanceExperimentalSettings {
+  return normalizeExperimentalSettings({ ...normalizeExperimentalSettings(raw), ...overrides });
+}
+
+/** Env-overridden keys are read-time-forced and must never persist via a patch. */
+export function stripOverriddenPatchKeys<T extends Record<string, unknown>>(
+  patch: T,
+  overrideKeys: string[],
+): T {
+  if (overrideKeys.length === 0) return patch;
+  const next: Record<string, unknown> = { ...patch };
+  for (const key of overrideKeys) delete next[key];
+  return next as T;
+}
+
 export function applyExperimentalSettingsPatch(
   current: unknown,
   patch: PatchInstanceExperimentalSettings | Record<string, unknown>,


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Instance behavior is governed by instance settings (general + experimental feature flags) stored as a singleton row and edited by an instance admin
> - Operators who run Paperclip through GitOps or immutable infrastructure have no declarative way to pin those settings: the only path is a human toggling them in the UI, which drifts and does not survive a database restore
> - A deployment should be able to force specific instance settings from config, the same way `PAPERCLIP_CLOUD_BILLING` / `PAPERCLIP_CLOUD_TRIAL_BANNER` already force two experimental flags today
> - This pull request adds `PAPERCLIP_INSTANCE_SETTINGS_OVERRIDES`, a JSON env var whose `general` and `experimental` sections are validated and merged over the stored settings at read time, and stripped from admin patches so a forced value never persists
> - The benefit is drift-proof, reproducible instance configuration from deployment config, with zero behavior change when the variable is unset

## Linked Issues or Issue Description

No existing issue. Describing in-PR following the feature template:

**Problem or motivation**
There is no declarative, deployment-time way to pin instance settings. Operators running under GitOps must configure experimental flags and general settings by hand in the UI; the configuration lives only in the database, drifts from source control, and is lost on a restore into a fresh database.

**Proposed solution**
Read an optional `PAPERCLIP_INSTANCE_SETTINGS_OVERRIDES` JSON env var whose `general` and `experimental` sections are validated with the existing zod schemas (partial + strip unknown keys) and merged over the stored settings at read time. Overridden keys are stripped from admin patches before write, so forced values are never persisted back to the row. Invalid JSON or an invalid section warns once and falls back to the stored settings.

**Alternatives considered**
Per-flag env vars (like the two existing `PAPERCLIP_CLOUD_*` ones) do not scale to the full settings surface and add a new variable per flag. A boot-time seed that writes the DB row was rejected because it mutates tenant state and cannot represent "forced" (a later admin edit would silently win). A read-time merge keeps the stored row untouched and makes the override authoritative for exactly as long as it is set.

**Roadmap alignment**
Small, additive operator-ergonomics improvement; no overlap with planned core feature work. Default path (variable unset) is byte-for-byte unchanged.

## What Changed

- Added `parseInstanceSettingsOverrides(env)` in `server/src/services/instance-settings.ts`: parses the JSON env var, validates the `general` and `experimental` sections (partial + strip), strips server-managed worktree-activation fields, and warns once on invalid input.
- Added `resolveGeneralSettings` / `resolveExperimentalSettings` (normalize stored value, spread overrides, re-normalize) and `stripOverriddenPatchKeys`.
- Wired overrides through every `instanceSettingsService` getter (override-merged reads) and the `updateGeneral` / `updateExperimental` writers (strip overridden keys so they never persist). Service signature unchanged; all existing call sites unaffected.
- Routed the one raw `instance_settings` read in `server/src/services/feedback.ts` through the override-aware helper for reads, while keeping the DB write-back sourced from the un-overridden stored value.

## Verification

- `pnpm exec vitest run server/src/__tests__/instance-settings-service.test.ts server/src/__tests__/instance-settings-routes.test.ts` — passing (override parse/resolve/strip, service read-merge, patch-strip, and no-env-var-unchanged cases).
- `pnpm exec vitest run server/src/__tests__ -t feedback` — passing, including a new embedded-Postgres regression test asserting an active `censorUsernameInLogs` override does not persist into the DB on a feedback write.
- `pnpm exec tsc -p server --noEmit` — clean.

## Risks

Low risk. The feature is inert unless `PAPERCLIP_INSTANCE_SETTINGS_OVERRIDES` is set: with it unset, `parseInstanceSettingsOverrides` returns empty sections and every resolve/strip helper degenerates to the prior normalization, so reads and writes are identical to before. Overridden keys are stripped from patches, so an override can never leak into persisted state. Invalid input is warned once and ignored rather than throwing.

## Model Used

Claude (Anthropic), claude-fable-5, extended thinking, tool use / code execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
