### PR TITLE
feat(k8s-provider): egressPolicy open-internet mode

### DIFF
--- a/packages/plugins/sandbox-providers/kubernetes/README.md
+++ b/packages/plugins/sandbox-providers/kubernetes/README.md
@@ -70,6 +70,7 @@ Common optional fields:
 | `egressAllowFqdns` | `[]` | Additional FQDNs (beyond adapter defaults like `api.anthropic.com`). |
 | `egressAllowCidrs` | `[]` | Additional CIDRs to allow egress to. |
 | `egressMode` | `"standard"` | `standard` (NetworkPolicy + CIDRs) or `cilium` (CiliumNetworkPolicy + FQDN allow-list). |
+| `egressPolicy` | `"allowlist"` | Namespace baseline posture. `allowlist` restricts egress to the configured FQDNs/CIDRs. `open-internet` additionally allows public IPv4 on TCP 443/80 with private, CGNAT, link-local (cloud IMDS), loopback, this-network, and multicast ranges excluded. Also settable via `PAPERCLIP_K8S_EGRESS_POLICY`. |
 | `runtimeClassName` | (none) | e.g. `kata-fc` for Firecracker-backed microVMs. Cluster must have the RuntimeClass installed. |
 | `serviceAccountAnnotations` | `{}` | Annotations applied to per-tenant ServiceAccount (e.g. IRSA `eks.amazonaws.com/role-arn`). |
 | `jobTtlSecondsAfterFinished` | `900` | Seconds after a Job completes before garbage-collection. |
@@ -93,6 +94,17 @@ Keep provider-level egress defaults narrow, then grant only the destinations a t
 ```
 
 The provider creates a workload-owned policy selected by the task run label, so the additional destinations do not become reachable from other concurrent agent pods. Cilium mode enforces FQDNs directly. Standard NetworkPolicy mode cannot express FQDNs, so an FQDN grant permits public IPv4 TCP 80/443 for that run while excluding private, loopback, link-local, CGNAT, and multicast ranges. Network failures that look policy-related include the grant path in stderr, and the sandbox exposes the effective policy through `PAPERCLIP_NETWORK_EGRESS_*` environment variables.
+
+#### How `egressPolicy` and task-scoped grants compose
+
+The two are different layers and Kubernetes unions them:
+
+- `egressPolicy` is the **namespace baseline**. It is written into the tenant's long-lived `paperclip-egress-allow` NetworkPolicy (or `paperclip-egress-fqdn` CiliumNetworkPolicy), selects every agent pod in the namespace, and lives for as long as the tenant does.
+- A task grant is an **additive, workload-owned policy** selected by `paperclip.io/run-id`, created per run and garbage-collected with its Job or Sandbox.
+
+The grant builder deliberately does not receive `egressPolicy`, so turning the provider baseline to `open-internet` never changes what a per-task grant itself permits: the run's reachability is the union of the two, and the grant stays a truthful record of what that specific task asked for. `PAPERCLIP_NETWORK_EGRESS_POLICY` reports the baseline (`kubernetes-default-deny` or `kubernetes-open-internet`) while `PAPERCLIP_NETWORK_EGRESS_ALLOW_*` report the task grant.
+
+With `egressPolicy: "open-internet"` the baseline already covers public TCP 443/80, so task grants for public hosts become redundant. Keep the baseline on `allowlist` if you want per-task grants to be the only path to the internet.
 
 ## What gets created in your cluster
 

--- a/packages/plugins/sandbox-providers/kubernetes/src/cilium-network-policy.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/src/cilium-network-policy.ts
@@ -1,3 +1,5 @@
+import { PRIVATE_AND_LINK_LOCAL_EXCEPT_CIDRS } from "./network-policy.js";
+
 export interface BuildCiliumNetworkPolicyInput {
   namespace: string;
   paperclipServerNamespace: string;
@@ -7,6 +9,12 @@ export interface BuildCiliumNetworkPolicyInput {
   endpointSelector?: Record<string, string>;
   includeBaseRules?: boolean;
   ownerReferences?: Record<string, unknown>[];
+  /**
+   * Provider-level NAMESPACE BASELINE posture; see the same field on
+   * `BuildNetworkPolicyInput`. Task-scoped grants leave it unset so an
+   * "open-internet" provider never widens what a per-task grant permits.
+   */
+  egressPolicy?: "allowlist" | "open-internet";
 }
 
 // Design note: no ingress rules are defined here. Paperclip-server does NOT
@@ -35,6 +43,23 @@ export function buildCiliumNetworkPolicyManifest(input: BuildCiliumNetworkPolicy
     egress.push({
       toFQDNs: input.egressAllowFqdns.map((fqdn) => ({ matchName: fqdn })),
       toPorts: [{ ports: [{ port: "443", protocol: "TCP" }] }],
+    });
+  }
+
+  if (input.egressPolicy === "open-internet") {
+    // Hardened public internet: HTTP(S) only, with private ranges,
+    // link-local metadata (cloud IMDS), loopback, CGNAT, this-network,
+    // and multicast carved out. DNS stays pinned to kube-dns above.
+    egress.push({
+      toCIDRSet: [{ cidr: "0.0.0.0/0", except: [...PRIVATE_AND_LINK_LOCAL_EXCEPT_CIDRS] }],
+      toPorts: [
+        {
+          ports: [
+            { port: "443", protocol: "TCP" },
+            { port: "80", protocol: "TCP" },
+          ],
+        },
+      ],
     });
   }
 

--- a/packages/plugins/sandbox-providers/kubernetes/src/manifest.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/src/manifest.ts
@@ -76,6 +76,12 @@ const manifest: PaperclipPluginManifestV1 = {
             enum: ["standard", "cilium"],
             description: "Network policy mode. `cilium` enables FQDN-based egress filtering via CiliumNetworkPolicy.",
           },
+          egressPolicy: {
+            type: "string",
+            enum: ["allowlist", "open-internet"],
+            description:
+              "Namespace baseline egress posture. allowlist (default): tenant egress restricted to egressAllowFqdns/egressAllowCidrs. open-internet: public internet on ports 80/443 with private ranges, link-local metadata, and CGNAT blocked. Task-scoped grants (executionWorkspaceSettings.networkEgress) remain additive per-run policies and are unaffected by this setting.",
+          },
           runtimeClassName: {
             type: "string",
             description:

--- a/packages/plugins/sandbox-providers/kubernetes/src/network-policy.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/src/network-policy.ts
@@ -17,6 +17,18 @@ export interface BuildNetworkPolicyInput {
   podSelector?: Record<string, string>;
   includeBaseRules?: boolean;
   ownerReferences?: Record<string, unknown>[];
+  /**
+   * Provider-level NAMESPACE BASELINE posture. "allowlist" (default): egress
+   * restricted to egressAllowFqdns/egressAllowCidrs (plus the public-IPv4 FQDN
+   * fallback below when applicable). "open-internet": always apply the hardened
+   * public-internet fallback regardless of FQDN/CIDR configuration.
+   *
+   * Only the tenant's baseline policy passes this. Task-scoped egress grants
+   * (see `scoped-network-egress.ts`) are ADDITIVE, run-label-selected policies
+   * that deliberately leave this unset, so switching the provider to
+   * "open-internet" never changes what a per-task grant itself permits.
+   */
+  egressPolicy?: "allowlist" | "open-internet";
 }
 
 /**
@@ -26,7 +38,7 @@ export interface BuildNetworkPolicyInput {
  * cluster loopback (127.0.0.0/8), CGNAT (100.64.0.0/10), this-network
  * (0.0.0.0/8), and multicast (224.0.0.0/4).
  */
-const PRIVATE_AND_LINK_LOCAL_EXCEPT_CIDRS = [
+export const PRIVATE_AND_LINK_LOCAL_EXCEPT_CIDRS = [
   "0.0.0.0/8",
   "10.0.0.0/8",
   "100.64.0.0/10",
@@ -36,6 +48,15 @@ const PRIVATE_AND_LINK_LOCAL_EXCEPT_CIDRS = [
   "192.168.0.0/16",
   "224.0.0.0/4",
 ];
+
+/**
+ * Value reported to the sandbox through `PAPERCLIP_NETWORK_EGRESS_POLICY`. It
+ * names the NAMESPACE BASELINE the run is governed by; task-scoped grants are
+ * reported separately through `PAPERCLIP_NETWORK_EGRESS_ALLOW_*`.
+ */
+export function baselineEgressPolicyLabel(egressPolicy?: "allowlist" | "open-internet"): string {
+  return egressPolicy === "open-internet" ? "kubernetes-open-internet" : "kubernetes-default-deny";
+}
 
 // Design note: the deny-all baseline blocks all ingress to agent pods.
 // Paperclip-server does NOT push to agent pods — the agent shim makes
@@ -108,8 +129,8 @@ export function buildNetworkPolicyManifests(input: BuildNetworkPolicyInput): Rec
         // the box for cloud LLM APIs without inadvertently exposing
         // cluster internals or link-local metadata endpoints. Operators
         // who want exact FQDN enforcement should use `egressMode: "cilium"`.
-        ...(input.egressAllowCidrs.length === 0 &&
-          (input.egressAllowFqdns?.length ?? 0) > 0
+        ...(input.egressPolicy === "open-internet" ||
+          (input.egressAllowCidrs.length === 0 && (input.egressAllowFqdns?.length ?? 0) > 0)
           ? [
               {
                 to: [

--- a/packages/plugins/sandbox-providers/kubernetes/src/plugin.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/src/plugin.ts
@@ -39,6 +39,7 @@ import {
 import { execInPod, execInPodStreaming, wrapCommandWithEnv } from "./pod-exec.js";
 import { performSyncIn, performSyncOut, type PodStreamExec } from "./file-sync.js";
 import { checkLeaseResumable, destroyLeaseResources } from "./lease-lifecycle.js";
+import { baselineEgressPolicyLabel } from "./network-policy.js";
 import {
   appendNetworkEgressDenyHint,
   createScopedNetworkEgressPolicyOrReleaseWorkload,
@@ -342,6 +343,7 @@ const plugin = definePlugin({
       paperclipServerNamespace: PAPERCLIP_SERVER_NAMESPACE,
       serviceAccountAnnotations: config.serviceAccountAnnotations,
       egressMode: config.egressMode,
+      egressPolicy: config.egressPolicy,
       egressAllowFqdns: [...adapterDefaults.allowFqdns, ...config.egressAllowFqdns],
       egressAllowCidrs: config.egressAllowCidrs,
       resourceQuota: DEFAULT_RESOURCE_QUOTA,
@@ -422,7 +424,10 @@ const plugin = definePlugin({
     // defaultEnv (non-secret base, e.g. the inference base URL) is layered first;
     // the process-env secrets named by envKeys override it.
     const adapterEnv = buildAdapterEnv(adapterDefaults);
-    adapterEnv.PAPERCLIP_NETWORK_EGRESS_POLICY = "kubernetes-default-deny";
+    // Advertise the NAMESPACE BASELINE posture the run is governed by. The
+    // task-scoped grant below is additive on top of it, so the agent needs
+    // both values to reason about what it can reach.
+    adapterEnv.PAPERCLIP_NETWORK_EGRESS_POLICY = baselineEgressPolicyLabel(config.egressPolicy);
     adapterEnv.PAPERCLIP_NETWORK_EGRESS_GRANT_PATH = NETWORK_EGRESS_GRANT_PATH;
     adapterEnv.PAPERCLIP_NETWORK_EGRESS_ALLOW_FQDNS = scopedNetworkEgress.allowFqdns.join(",");
     adapterEnv.PAPERCLIP_NETWORK_EGRESS_ALLOW_CIDRS = scopedNetworkEgress.allowCidrs.join(",");

--- a/packages/plugins/sandbox-providers/kubernetes/src/tenant-orchestrator.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/src/tenant-orchestrator.ts
@@ -8,6 +8,7 @@ export interface EnsureTenantInput {
   paperclipServerNamespace: string;
   serviceAccountAnnotations: Record<string, string>;
   egressMode: "standard" | "cilium";
+  egressPolicy?: "allowlist" | "open-internet";
   egressAllowFqdns: string[];
   egressAllowCidrs: string[];
   resourceQuota: {
@@ -212,6 +213,7 @@ async function ensureNetworkPolicies(clients: KubeClients, input: EnsureTenantIn
     paperclipServerNamespace: input.paperclipServerNamespace,
     egressAllowCidrs: input.egressAllowCidrs,
     egressAllowFqdns: input.egressAllowFqdns,
+    egressPolicy: input.egressPolicy,
   });
 
   await ensureNetworkPolicy(clients, input.namespace, denyAll);
@@ -222,6 +224,7 @@ async function ensureNetworkPolicies(clients: KubeClients, input: EnsureTenantIn
       paperclipServerNamespace: input.paperclipServerNamespace,
       egressAllowFqdns: input.egressAllowFqdns,
       egressAllowCidrs: input.egressAllowCidrs,
+      egressPolicy: input.egressPolicy,
     });
     await ensureCiliumNetworkPolicy(clients, input.namespace, cnp);
   } else {

--- a/packages/plugins/sandbox-providers/kubernetes/src/types.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/src/types.ts
@@ -19,6 +19,7 @@ export const kubernetesProviderConfigSchema = z
     egressAllowFqdns: z.array(z.string()).default([]),
     egressAllowCidrs: z.array(z.string().regex(cidrRegex, "Invalid CIDR")).default([]),
     egressMode: z.enum(["cilium", "standard"]).default("standard"),
+    egressPolicy: z.enum(["allowlist", "open-internet"]).default("allowlist"),
 
     defaultResources: z
       .object({

--- a/packages/plugins/sandbox-providers/kubernetes/test/unit/cilium-network-policy.test.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/test/unit/cilium-network-policy.test.ts
@@ -73,4 +73,37 @@ describe("buildCiliumNetworkPolicyManifest", () => {
     expect(cnp.spec.endpointSelector.matchLabels).toEqual({ "paperclip.io/run-id": "run-123" });
     expect(cnp.spec.egress).toHaveLength(1);
   });
+
+  describe("egressPolicy open-internet", () => {
+    it("emits a hardened public-internet rule on ports 443 and 80", () => {
+      const cnp: any = buildCiliumNetworkPolicyManifest({ ...baseInput, egressPolicy: "open-internet" });
+      const openRule = cnp.spec.egress.find(
+        (rule: any) => rule.toCIDRSet?.some((entry: any) => entry.cidr === "0.0.0.0/0"),
+      );
+      expect(openRule).toBeDefined();
+      const entry = openRule.toCIDRSet.find((candidate: any) => candidate.cidr === "0.0.0.0/0");
+      for (const blocked of ["10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16", "169.254.0.0/16", "100.64.0.0/10", "127.0.0.0/8"]) {
+        expect(entry.except).toContain(blocked);
+      }
+      const ports = openRule.toPorts[0].ports.map((p: any) => p.port).sort();
+      expect(ports).toEqual(["443", "80"].sort());
+    });
+
+    it("keeps kube-dns and paperclip-server rules in open-internet mode", () => {
+      const cnp: any = buildCiliumNetworkPolicyManifest({ ...baseInput, egressPolicy: "open-internet" });
+      expect(cnp.spec.egress.some((rule: any) => rule.toPorts?.[0]?.rules?.dns)).toBe(true);
+      expect(
+        cnp.spec.egress.some((rule: any) =>
+          rule.toEndpoints?.some((endpoint: any) => endpoint.matchLabels?.app === "paperclip-server"),
+        ),
+      ).toBe(true);
+    });
+
+    it("emits no public-internet rule by default (allowlist)", () => {
+      const cnp: any = buildCiliumNetworkPolicyManifest({ ...baseInput });
+      expect(
+        cnp.spec.egress.some((rule: any) => rule.toCIDRSet?.some((entry: any) => entry.cidr === "0.0.0.0/0")),
+      ).toBe(false);
+    });
+  });
 });

--- a/packages/plugins/sandbox-providers/kubernetes/test/unit/network-policy.test.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/test/unit/network-policy.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { buildNetworkPolicyManifests } from "../../src/network-policy.js";
+import { baselineEgressPolicyLabel, buildNetworkPolicyManifests } from "../../src/network-policy.js";
 
 describe("buildNetworkPolicyManifests", () => {
   const baseInput = {
@@ -108,5 +108,26 @@ describe("buildNetworkPolicyManifests", () => {
     expect(egress.spec.podSelector.matchLabels).toEqual({ "paperclip.io/run-id": "run-123" });
     expect(egress.spec.egress).toHaveLength(1);
     expect(egress.spec.egress[0].to[0].ipBlock.cidr).toBe("0.0.0.0/0");
+  });
+
+  it("reports the namespace baseline posture to the sandbox", () => {
+    expect(baselineEgressPolicyLabel(undefined)).toBe("kubernetes-default-deny");
+    expect(baselineEgressPolicyLabel("allowlist")).toBe("kubernetes-default-deny");
+    expect(baselineEgressPolicyLabel("open-internet")).toBe("kubernetes-open-internet");
+  });
+
+  it("applies the public-internet fallback whenever egressPolicy is open-internet", () => {
+    const [, egressAllow]: any[] = buildNetworkPolicyManifests({
+      namespace: "tenant-x",
+      paperclipServerNamespace: "paperclip-app",
+      egressAllowCidrs: ["203.0.113.0/24"],
+      egressAllowFqdns: [],
+      egressPolicy: "open-internet",
+    });
+    const fallback = egressAllow.spec.egress.find(
+      (rule: any) => rule.to?.[0]?.ipBlock?.cidr === "0.0.0.0/0",
+    );
+    expect(fallback).toBeDefined();
+    expect(fallback.to[0].ipBlock.except).toContain("169.254.0.0/16");
   });
 });

--- a/packages/plugins/sandbox-providers/kubernetes/test/unit/scoped-network-egress.test.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/test/unit/scoped-network-egress.test.ts
@@ -57,6 +57,39 @@ describe("scoped network egress", () => {
     expect(name).toMatch(/unique-tail-egress$/);
   });
 
+  it("never inherits the provider open-internet baseline into a cilium task grant", async () => {
+    const createNamespacedCustomObject = vi.fn().mockResolvedValue({});
+    await createScopedNetworkEgressPolicy({
+      clients: { custom: { createNamespacedCustomObject } } as never,
+      namespace: "paperclip-acme",
+      mode: "cilium",
+      runId: "run-123",
+      workloadName: "pc-workload",
+      ownerReference: { apiVersion: "batch/v1", kind: "Job", name: "pc-workload", uid: "uid-1" },
+      grant: { allowFqdns: ["github.com"], allowCidrs: [] },
+    });
+    const body: any = createNamespacedCustomObject.mock.calls[0][0].body;
+    expect(
+      body.spec.egress.some((rule: any) => rule.toCIDRSet?.some((entry: any) => entry.cidr === "0.0.0.0/0")),
+    ).toBe(false);
+    expect(body.spec.egress).toHaveLength(1);
+  });
+
+  it("keeps a standard CIDR task grant narrow regardless of provider posture", async () => {
+    const createNamespacedNetworkPolicy = vi.fn().mockResolvedValue({});
+    await createScopedNetworkEgressPolicy({
+      clients: { networking: { createNamespacedNetworkPolicy } } as never,
+      namespace: "paperclip-acme",
+      mode: "standard",
+      runId: "run-123",
+      workloadName: "pc-workload",
+      ownerReference: { apiVersion: "batch/v1", kind: "Job", name: "pc-workload", uid: "uid-1" },
+      grant: { allowFqdns: [], allowCidrs: ["203.0.113.0/24"] },
+    });
+    const body: any = createNamespacedNetworkPolicy.mock.calls[0][0].body;
+    expect(body.spec.egress).toEqual([{ to: [{ ipBlock: { cidr: "203.0.113.0/24" } }] }]);
+  });
+
   it("adds the policy and grant path to likely network denials", () => {
     expect(appendNetworkEgressDenyHint("curl: Could not resolve host: example.com", {
       allowFqdns: ["github.com"],

--- a/packages/plugins/sandbox-providers/kubernetes/test/unit/tenant-orchestrator.test.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/test/unit/tenant-orchestrator.test.ts
@@ -77,6 +77,16 @@ describe("ensureTenant", () => {
     expect((npCalls[0].body as { metadata: { name: string } }).metadata.name).toBe("paperclip-deny-all");
   });
 
+  it("threads egressPolicy=open-internet into the CiliumNetworkPolicy manifest", async () => {
+    const clients = makeMockClients();
+    await ensureTenant(clients as never, { ...baseInput, egressMode: "cilium", egressPolicy: "open-internet" });
+    const cnpCall = clients.calls.find((c) => c.kind === "CiliumNetworkPolicy");
+    expect(cnpCall).toBeDefined();
+    const cnp = cnpCall!.body as { spec: { egress: { toCIDRSet?: { cidr: string }[] }[] } };
+    const openRule = cnp.spec.egress.find((rule) => rule.toCIDRSet?.some((entry) => entry.cidr === "0.0.0.0/0"));
+    expect(openRule).toBeDefined();
+  });
+
   it("applies serviceAccountAnnotations to the ServiceAccount", async () => {
     const clients = makeMockClients();
     await ensureTenant(clients as never, {

--- a/server/src/services/environments.ts
+++ b/server/src/services/environments.ts
@@ -56,6 +56,7 @@ export interface KubernetesEnvironmentConfigInput {
   inCluster?: boolean;
   runtimeClassName?: string;
   egressMode?: "cilium" | "standard";
+  egressPolicy?: "allowlist" | "open-internet";
   egressAllowFqdns?: string[];
   egressAllowCidrs?: string[];
   namespacePrefix?: string;

--- a/server/src/services/execution-policy-bootstrap.test.ts
+++ b/server/src/services/execution-policy-bootstrap.test.ts
@@ -56,6 +56,7 @@ describe("parseExecutionPolicyBootstrapEnv", () => {
         PAPERCLIP_K8S_IN_CLUSTER: "true",
         PAPERCLIP_K8S_RUNTIME_CLASS_NAME: "gvisor",
         PAPERCLIP_K8S_EGRESS_MODE: "cilium",
+        PAPERCLIP_K8S_EGRESS_POLICY: "open-internet",
         PAPERCLIP_K8S_EGRESS_ALLOW_FQDNS: "api.anthropic.com, api.openai.com",
         PAPERCLIP_K8S_EGRESS_ALLOW_CIDRS: "10.0.0.0/8",
       }),
@@ -67,9 +68,25 @@ describe("parseExecutionPolicyBootstrapEnv", () => {
       inCluster: true,
       runtimeClassName: "gvisor",
       egressMode: "cilium",
+      egressPolicy: "open-internet",
       egressAllowFqdns: ["api.anthropic.com", "api.openai.com"],
       egressAllowCidrs: ["10.0.0.0/8"],
     });
+  });
+
+  it("defaults egressPolicy to undefined (plugin schema applies allowlist) when unset", () => {
+    const parsed = parseExecutionPolicyBootstrapEnv(
+      env({ PAPERCLIP_EXECUTION_MODE: "kubernetes" }),
+    );
+    expect(parsed?.kubernetesConfig.egressPolicy).toBeUndefined();
+  });
+
+  it("throws on an unknown egress policy", () => {
+    expect(() =>
+      parseExecutionPolicyBootstrapEnv(
+        env({ PAPERCLIP_EXECUTION_MODE: "kubernetes", PAPERCLIP_K8S_EGRESS_POLICY: "wide-open" }),
+      ),
+    ).toThrow(/PAPERCLIP_K8S_EGRESS_POLICY/);
   });
 
   it("defaults inCluster false and omits unset optional fields", () => {

--- a/server/src/services/execution-policy-bootstrap.ts
+++ b/server/src/services/execution-policy-bootstrap.ts
@@ -104,6 +104,16 @@ export function parseExecutionPolicyBootstrapEnv(
     kubernetesConfig.egressMode = egressMode;
   }
 
+  const egressPolicy = env.PAPERCLIP_K8S_EGRESS_POLICY?.trim();
+  if (egressPolicy) {
+    if (egressPolicy !== "allowlist" && egressPolicy !== "open-internet") {
+      throw new Error(
+        `PAPERCLIP_K8S_EGRESS_POLICY must be "allowlist" or "open-internet" (got "${egressPolicy}").`,
+      );
+    }
+    kubernetesConfig.egressPolicy = egressPolicy;
+  }
+
   const runtimeClassName = env.PAPERCLIP_K8S_RUNTIME_CLASS_NAME?.trim();
   if (runtimeClassName) kubernetesConfig.runtimeClassName = runtimeClassName;
 
@@ -168,6 +178,7 @@ export async function applyExecutionPolicyBootstrap(
       backend: bootstrap.kubernetesConfig.backend,
       runtimeClassName: bootstrap.kubernetesConfig.runtimeClassName,
       egressMode: bootstrap.kubernetesConfig.egressMode,
+      egressPolicy: bootstrap.kubernetesConfig.egressPolicy,
     },
     "applied forced Kubernetes execution policy",
   );


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The kubernetes sandbox provider runs each agent workspace in an isolated tenant namespace and generates a NetworkPolicy (or CiliumNetworkPolicy) that governs the sandbox's outbound network access
> - Today egress is an FQDN/CIDR allowlist: agents can only reach the hosts an operator enumerates, which is correct for locked-down deployments but impractical when agents legitimately need the open internet (arbitrary package registries, customer APIs, web fetch)
> - Operators need a way to opt a deployment into broad egress without hand-maintaining an ever-growing allowlist, while still keeping agents off cluster internals and cloud metadata
> - This pull request adds `egressPolicy: allowlist | open-internet`; `open-internet` permits public internet on TCP 443/80 while carving out private ranges, link-local metadata, CGNAT, loopback, this-network, and multicast
> - The benefit is a single opt-in switch for open egress with a hardened default-safe deny set, defaulting to the existing allowlist behavior so nothing changes unless selected

## Linked Issues or Issue Description

No existing issue. Describing in-PR following the feature template:

**Problem or motivation**
The kubernetes sandbox provider only supports allowlist egress. Deployments whose agents need the open internet must enumerate every destination FQDN/CIDR, which does not scale and breaks whenever an agent needs a host the operator did not predict. There is no built-in "open but hardened" posture.

**Proposed solution**
Add an `egressPolicy` config field (`allowlist` default, `open-internet` opt-in). In `open-internet` mode both the standard NetworkPolicy and CiliumNetworkPolicy builders emit an egress rule to `0.0.0.0/0` on TCP 443 and 80 only, with a shared except set (`10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`, `169.254.0.0/16`, `100.64.0.0/10`, `127.0.0.0/8`, `0.0.0.0/8`, `224.0.0.0/4`). DNS stays pinned to kube-dns, the paperclip-server rule and any FQDN allowlist rules remain intact. Threaded end to end from the `PAPERCLIP_K8S_EGRESS_POLICY` env var through the execution-policy bootstrap, plugin config schema, tenant orchestrator, and both builders.

**Alternatives considered**
Documenting a wildcard-heavy allowlist was rejected: NetworkPolicy cannot express FQDN wildcards and Cilium `toFQDNs` still needs enumerated names. Removing egress restrictions entirely was rejected because it would expose cluster internals and the cloud metadata endpoint. A dedicated per-tenant policy CRD was out of scope for a provider-level posture switch.

**Roadmap alignment**
Additive provider capability, opt-in, default-preserving; no overlap with planned core work.

## What Changed

- Added `egressPolicy: z.enum(["allowlist","open-internet"]).default("allowlist")` to the kubernetes provider config schema and the UI manifest schema.
- `buildCiliumNetworkPolicyManifest` and `buildNetworkPolicyManifests` emit the hardened public-internet rule (TCP 443/80, shared except set) only when `egressPolicy === "open-internet"`; the except CIDRs are a single exported constant shared by both builders.
- Threaded the field through `EnsureTenantInput` and both `ensureNetworkPolicies` builder calls, the `plugin.ts` lease-acquisition `ensureTenant` call, `PAPERCLIP_K8S_EGRESS_POLICY` parsing in `execution-policy-bootstrap.ts` (invalid values throw, matching the existing `egressMode` handling), and the `KubernetesEnvironmentConfigInput` interface.

## Verification

- `pnpm exec vitest run packages/plugins/sandbox-providers/kubernetes` — passing, including new tests: open-internet emits the `0.0.0.0/0` rule with the required excepts on 443/80, kube-dns and paperclip-server rules survive, and the default (allowlist) emits no public-internet rule.
- New `execution-policy-bootstrap` tests cover unset (undefined) and invalid (throws) `PAPERCLIP_K8S_EGRESS_POLICY`.
- `pnpm exec tsc -p server --noEmit` — clean.

## Risks

Low risk. `egressPolicy` defaults to `allowlist`; both builders gate the new rule strictly on `=== "open-internet"`, so an unset or default value produces byte-identical manifests to before and no existing deployment changes. `open-internet` is a deliberate broadening of egress and is documented as such: it is IPv4-scoped (the fallback CIDR math is IPv4, matching the pre-existing standard-mode fallback), so operators on dual-stack clusters who need IPv6 egress restrictions should keep `allowlist`. The new field is optional on every interface, so no call site breaks.

## Model Used

Claude (Anthropic), claude-fable-5, extended thinking, tool use / code execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
