### PR TITLE
feat(plugins): expose company-authorized current state

### DIFF
--- a/doc/plugins/PLUGIN_SPEC.md
+++ b/doc/plugins/PLUGIN_SPEC.md
@@ -31,6 +31,14 @@ Current limitations to keep in mind:
 - Scoped plugin API routes are JSON-only and must be declared in `apiRoutes`.
   They mount under `/api/plugins/:pluginId/api/*`; plugins cannot shadow core
   API routes.
+- Core exposes one narrow company-authorized registry read at
+  `GET /api/companies/:companyId/plugins/:pluginKey/current`. It resolves only
+  the exact key from the current `plugins` row and returns presence, lifecycle
+  status, registry identity, plugin/API versions, and `updatedAt` for a two-read
+  fingerprint. It does not expose list inventory, manifests, configuration,
+  package paths, credentials, or error text; global plugin list/detail routes
+  remain board-only. Responses use `Cache-Control: no-store` so a two-read
+  preflight cannot be satisfied by a stale HTTP cache.
 
 In practice, that means the current implementation is a good fit for local development and self-hosted persistent deployments, but not yet for multi-instance cloud plugin distribution.
 

--- a/packages/shared/src/api.ts
+++ b/packages/shared/src/api.ts
@@ -3,6 +3,7 @@ export const API_PREFIX = "/api";
 export const API = {
   health: `${API_PREFIX}/health`,
   companies: `${API_PREFIX}/companies`,
+  companyPluginCurrentState: `${API_PREFIX}/companies/:companyId/plugins/:pluginKey/current`,
   companyFolders: `${API_PREFIX}/companies/:companyId/folders`,
   companyFolder: `${API_PREFIX}/companies/:companyId/folders/:folderId`,
   companyFolderMove: `${API_PREFIX}/companies/:companyId/folders/:folderId/move`,

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1242,6 +1242,7 @@ export type {
   PluginObjectReferenceProviderDeclaration,
   PaperclipPluginManifestV1,
   PluginRecord,
+  CompanyPluginCurrentState,
   PluginDatabaseNamespaceRecord,
   PluginMigrationRecord,
   PluginStateRecord,

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -854,6 +854,7 @@ export type {
   PluginObjectReferenceProviderDeclaration,
   PaperclipPluginManifestV1,
   PluginRecord,
+  CompanyPluginCurrentState,
   PluginDatabaseNamespaceRecord,
   PluginMigrationRecord,
   PluginStateRecord,

--- a/packages/shared/src/types/plugin.ts
+++ b/packages/shared/src/types/plugin.ts
@@ -672,6 +672,30 @@ export interface PluginRecord {
   updatedAt: Date;
 }
 
+/**
+ * Minimal company-authorized view of one exact plugin registry key.
+ *
+ * This intentionally omits manifests, configuration, package locations,
+ * credentials, errors, and every form of list inventory. Consumers can compare
+ * two responses to prove the registry row did not change during a preflight.
+ */
+export interface CompanyPluginCurrentState {
+  /** Exact plugin registry key requested by the caller. */
+  pluginKey: string;
+  /** Explicitly distinguishes a missing registry row from every lifecycle status. */
+  presence: "present" | "absent";
+  /** Authoritative registry lifecycle status, or null when the key is absent. */
+  lifecycleStatus: PluginStatus | null;
+  /** Stable registry-row identity, or null when the key is absent. */
+  pluginId: string | null;
+  /** Installed plugin version, or null when the key is absent. */
+  version: string | null;
+  /** Plugin API version, or null when the key is absent. */
+  apiVersion: number | null;
+  /** Registry-row update timestamp used by two-read fingerprints. */
+  updatedAt: string | null;
+}
+
 export interface PluginDatabaseNamespaceRecord {
   id: string;
   pluginId: string;

--- a/server/src/__tests__/openapi-routes.test.ts
+++ b/server/src/__tests__/openapi-routes.test.ts
@@ -191,6 +191,27 @@ describe("openapi routes", () => {
     );
     expect(JSON.stringify(res.body.paths["/api/tool-gateway/tools"].get)).not.toContain("sessionToken");
     expect(JSON.stringify(res.body.paths["/api/tool-gateway/tools/call"].post)).not.toContain("sessionToken");
+    const pluginCurrentState = res.body.paths["/api/companies/{companyId}/plugins/{pluginKey}/current"].get;
+    expect(pluginCurrentState.summary).toBe("Get the current registry state for one plugin key");
+    expect(pluginCurrentState.responses["200"].content["application/json"].schema).toMatchObject({
+      type: "object",
+      properties: {
+        pluginKey: { type: "string" },
+        presence: { type: "string", enum: ["present", "absent"] },
+        lifecycleStatus: { type: "string", enum: expect.arrayContaining(["ready", "disabled"]), nullable: true },
+        updatedAt: { type: "string", format: "date-time", nullable: true },
+      },
+      required: expect.arrayContaining([
+        "pluginKey",
+        "presence",
+        "lifecycleStatus",
+        "pluginId",
+        "version",
+        "apiVersion",
+        "updatedAt",
+      ]),
+    });
+    expect(JSON.stringify(pluginCurrentState)).not.toMatch(/manifest|config|credential|packagePath|lastError/);
   });
 
   it("covers the mounted server routes exactly", () => {
@@ -219,6 +240,14 @@ describe("openapi routes", () => {
       actor: "board",
       instanceAdmin: true,
     });
+    expect(spec.paths["/api/companies/{companyId}/plugins/{pluginKey}/current"].get.security).toEqual([
+      { BoardSessionAuth: [] },
+      { BoardApiKeyAuth: [] },
+      { AgentBearerAuth: [] },
+    ]);
+    expect(spec.paths["/api/companies/{companyId}/plugins/{pluginKey}/current"].get[
+      "x-paperclip-authorization"
+    ]).toEqual({ actor: "board_or_agent" });
     expect(spec.paths["/api/execution-workspaces/{id}/reconcile-branch"].post.security).toEqual([
       { BoardSessionAuth: [] },
       { BoardApiKeyAuth: [] },

--- a/server/src/__tests__/plugin-routes-authz.test.ts
+++ b/server/src/__tests__/plugin-routes-authz.test.ts
@@ -135,6 +135,14 @@ function agentActor(overrides: Record<string, unknown> = {}) {
   };
 }
 
+function agentBearerActor(overrides: Record<string, unknown> = {}) {
+  return agentActor({
+    source: "agent_key",
+    keyId: "agent-key-1",
+    ...overrides,
+  });
+}
+
 function readyPlugin() {
   mockRegistry.getById.mockResolvedValue({
     id: pluginId,
@@ -143,6 +151,112 @@ function readyPlugin() {
     status: "ready",
   });
 }
+
+describe.sequential("company-scoped current plugin state authz", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("reports ready state from the authoritative registry without consulting activity history", async () => {
+    const pluginKey = "cybernative.revenue-liveness";
+    const updatedAt = new Date("2026-07-21T10:00:00.000Z");
+    mockRegistry.getByKey.mockResolvedValue({
+      id: pluginId,
+      pluginKey,
+      status: "ready",
+      version: "1.4.2",
+      apiVersion: 1,
+      updatedAt,
+    });
+    const db = {
+      select: vi.fn(() => {
+        throw new Error("current plugin state must not read activity history");
+      }),
+    };
+    const { app } = await createApp(agentBearerActor(), {}, { db });
+
+    const res = await request(app)
+      .get(`/api/companies/${companyA}/plugins/${pluginKey}/current`);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      pluginKey,
+      presence: "present",
+      lifecycleStatus: "ready",
+      pluginId,
+      version: "1.4.2",
+      apiVersion: 1,
+      updatedAt: "2026-07-21T10:00:00.000Z",
+    });
+    expect(res.headers["cache-control"]).toBe("no-store");
+    expect(mockRegistry.getByKey).toHaveBeenCalledWith(pluginKey);
+    expect(mockRegistry.getById).not.toHaveBeenCalled();
+    expect(db.select).not.toHaveBeenCalled();
+  }, 20_000);
+
+  it.each(["disabled", "installed", "uninstalled"] as const)(
+    "returns registry lifecycle status %s distinctly from active state",
+    async (status) => {
+      const pluginKey = "cybernative.revenue-liveness";
+      mockRegistry.getByKey.mockResolvedValue({
+        id: pluginId,
+        pluginKey,
+        status,
+        version: "1.4.2",
+        apiVersion: 1,
+        updatedAt: new Date("2026-07-21T10:00:00.000Z"),
+      });
+      const { app } = await createApp(agentBearerActor());
+
+      const res = await request(app)
+        .get(`/api/companies/${companyA}/plugins/${pluginKey}/current`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.presence).toBe("present");
+      expect(res.body.lifecycleStatus).toBe(status);
+    },
+    20_000,
+  );
+
+  it("returns an explicit absent result for an exact unknown key", async () => {
+    const pluginKey = "cybernative.revenue-liveness";
+    mockRegistry.getByKey.mockResolvedValue(null);
+    const { app } = await createApp(agentBearerActor());
+
+    const res = await request(app)
+      .get(`/api/companies/${companyA}/plugins/${pluginKey}/current`);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      pluginKey,
+      presence: "absent",
+      lifecycleStatus: null,
+      pluginId: null,
+      version: null,
+      apiVersion: null,
+      updatedAt: null,
+    });
+  }, 20_000);
+
+  it("denies cross-company agent reads before looking up the plugin key", async () => {
+    const { app } = await createApp(agentBearerActor());
+
+    const res = await request(app)
+      .get(`/api/companies/${companyB}/plugins/cybernative.revenue-liveness/current`);
+
+    expect(res.status).toBe(403);
+    expect(mockRegistry.getByKey).not.toHaveBeenCalled();
+  }, 20_000);
+
+  it("keeps the global plugin inventory board-only for agents", async () => {
+    const { app } = await createApp(agentBearerActor());
+
+    const res = await request(app).get("/api/plugins");
+
+    expect(res.status).toBe(403);
+    expect(mockRegistry.getByKey).not.toHaveBeenCalled();
+  }, 20_000);
+});
 
 describe.sequential("plugin install and upgrade authz", () => {
   beforeEach(() => {

--- a/server/src/__tests__/plugin-routes-authz.test.ts
+++ b/server/src/__tests__/plugin-routes-authz.test.ts
@@ -236,6 +236,7 @@ describe.sequential("company-scoped current plugin state authz", () => {
       apiVersion: null,
       updatedAt: null,
     });
+    expect(res.headers["cache-control"]).toBe("no-store");
   }, 20_000);
 
   it("denies cross-company agent reads before looking up the plugin key", async () => {

--- a/server/src/routes/openapi.ts
+++ b/server/src/routes/openapi.ts
@@ -198,6 +198,7 @@ import {
   importMcpJsonSchema,
   toolPolicyTestRequestSchema,
   createToolMcpGatewaySchema,
+  PLUGIN_STATUSES,
 } from "@paperclipai/shared";
 
 type JsonSchema = Record<string, unknown>;
@@ -4661,6 +4662,31 @@ registry.registerPath({
 });
 
 // ─── Plugins ──────────────────────────────────────────────────────────────────
+
+const companyPluginCurrentStateSchema = z.object({
+  pluginKey: z.string(),
+  presence: z.enum(["present", "absent"]),
+  lifecycleStatus: z.enum(PLUGIN_STATUSES).nullable(),
+  pluginId: z.string().nullable(),
+  version: z.string().nullable(),
+  apiVersion: z.number().int().nullable(),
+  updatedAt: z.string().datetime().nullable(),
+}).strict();
+
+registry.registerPath({
+  method: "get",
+  path: "/api/companies/{companyId}/plugins/{pluginKey}/current",
+  tags: ["plugins"],
+  summary: "Get the current registry state for one plugin key",
+  request: {
+    params: z.object({ companyId: z.string(), pluginKey: z.string() }),
+  },
+  responses: {
+    200: r.ok(companyPluginCurrentStateSchema),
+    401: r.unauthorized,
+    404: r.notFound,
+  },
+});
 
 registry.registerPath({
   method: "get",

--- a/server/src/routes/plugins.ts
+++ b/server/src/routes/plugins.ts
@@ -36,6 +36,7 @@ import {
   projects,
 } from "@paperclipai/db";
 import type {
+  CompanyPluginCurrentState,
   PluginApiRouteDeclaration,
   PluginStatus,
   PaperclipPluginManifestV1,
@@ -846,6 +847,47 @@ export function pluginRoutes(
       ? await registry.listByStatus(status)
       : await registry.listInstalled();
     res.json(plugins);
+  });
+
+  /**
+   * GET /api/companies/:companyId/plugins/:pluginKey/current
+   *
+   * Return the authoritative current registry state for one exact plugin key.
+   * Both board and agent callers must have access to the path company. This is
+   * deliberately not a list or detail endpoint: it exposes no manifest,
+   * configuration, package metadata, credentials, or error text.
+   */
+  router.get("/companies/:companyId/plugins/:pluginKey/current", async (req, res) => {
+    const { companyId, pluginKey } = req.params;
+    assertCompanyAccess(req, companyId);
+
+    // This endpoint participates in a fail-closed two-read preflight. A shared
+    // or client cache must not make two distinct reads observe the same stale
+    // registry fingerprint after the underlying lifecycle state changed.
+    res.set("Cache-Control", "no-store");
+
+    const plugin = await registry.getByKey(pluginKey);
+    const state: CompanyPluginCurrentState = plugin
+      ? {
+          pluginKey,
+          presence: "present",
+          lifecycleStatus: plugin.status,
+          pluginId: plugin.id,
+          version: plugin.version,
+          apiVersion: plugin.apiVersion,
+          updatedAt: plugin.updatedAt.toISOString(),
+        }
+      : {
+          pluginKey,
+          presence: "absent",
+          lifecycleStatus: null,
+          pluginId: null,
+          version: null,
+          apiVersion: null,
+          updatedAt: null,
+        };
+
+    res.json(state);
   });
 
   /**


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the control plane people use to operate AI-agent companies with explicit human governance.
> - Plugin lifecycle is instance-level operator state, while agent work must stay within company authorization boundaries.
> - An authenticated in-company agent can need the current state of one already-known plugin key to make a fail-closed operational decision.
> - The global plugin list and detail routes are intentionally board-only, and activity history is not an authoritative current-state source.
> - This pull request adds one exact-key, read-only, company-authorized projection of the current registry row.
> - The benefit is a least-privilege preflight primitive without exposing plugin inventory, configuration, manifests, paths, credentials, or errors.

## Linked Issues or Issue Description

**Subsystem affected**

Cross-cutting: `server/` REST API and `packages/shared` API types/constants, within the plugin system.

**Problem or motivation**

Authenticated agents cannot prove the authoritative current lifecycle state of one known plugin key without asking for board-only global inventory. Inferring current state from audit activity is unsafe because lifecycle mutation and activity persistence are not a transactional current-state read.

**Proposed solution**

Allow a company-authorized board or agent caller to read one exact plugin key and receive explicit present/absent state plus the minimal stable fields needed for a two-read fingerprint. Keep list/detail inventory board-only and make the response non-cacheable.

**Alternatives considered**

Broadening the global plugin list/detail routes would expose unnecessary instance inventory. Deriving state from activity can be stale. A board-signed snapshot adds coordination where a narrow read-only endpoint suffices.

**Roadmap alignment**

This supports the shipped plugin system and the roadmap's governed integrations/agent-control direction. It does not duplicate a listed roadmap item, add a marketplace, or expand plugin mutation authority.

**Additional context**

The change is read-only API/type/docs/tests only. It adds no database migration, plugin mutation, permission broadening, UI, secret, configuration, or telemetry change. GitHub search found no related open issue or pull request.

## What Changed

- Added `GET /api/companies/:companyId/plugins/:pluginKey/current` with company access enforced before registry lookup.
- Added a shared `CompanyPluginCurrentState` contract and API path constant.
- Returned only exact key, presence, lifecycle status, registry UUID, plugin/API versions, and `updatedAt`; omitted list inventory and sensitive plugin metadata.
- Set `Cache-Control: no-store` so two-read preflights cannot be satisfied by a stale HTTP cache.
- Added regressions for ready-without-activity, disabled/installed/uninstalled/absent states, same-company agent access, cross-company denial, no activity lookup, global-list denial, and cache policy.
- Documented the narrow endpoint and its boundary in the plugin specification.

## Verification

- `pnpm exec vitest run server/src/__tests__/plugin-routes-authz.test.ts --reporter=verbose` — 43/43 passed.
- Repeated focused suite after cache hardening — 43/43 passed.
- `pnpm -r typecheck` — all 31 workspace projects passed.
- `pnpm --filter @paperclipai/shared typecheck` — passed.
- `pnpm --filter @paperclipai/server typecheck` — passed.
- `pnpm --filter @paperclipai/shared build` — TypeScript build passed.
- `pnpm --filter @paperclipai/server build` — TypeScript compilation passed, then the existing Unix-only `mkdir`/`cp` package script stopped on Windows.
- The repository's stable test launcher cannot spawn `pnpm` from Node on this Windows host (`spawnSync pnpm ENOENT`); a shell workaround is not used because it changes argument semantics. Linux CI is the authoritative complete-suite/build gate for this draft.

## Risks

- The endpoint is an exact-key existence/status oracle for authenticated members of a company. It deliberately does not list keys or expose manifests, config, paths, credentials, or error text.
- Plugin state can change after a consumer's final read. Consumers must keep their own operation fail-closed and compare two fresh fingerprints immediately around preflight work.
- No migration or mutation path is introduced. Global plugin list/detail authorization remains unchanged and board-only.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex using GPT-5 (exact backend snapshot and context-window size are not exposed in this session), with agentic reasoning, repository inspection, tool use, code execution, and test execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge