### PR TITLE
fix(acpx): fall back to the CLI lane and surface the cause when ACP session init fails

### DIFF
--- a/packages/adapter-utils/src/acpx-engine/execute.test.ts
+++ b/packages/adapter-utils/src/acpx-engine/execute.test.ts
@@ -8,6 +8,7 @@ import type { AcpRuntimeOptions } from "acpx/runtime";
 import type { AdapterRuntimeMcpAccess } from "@paperclipai/adapter-utils";
 import { DEFAULT_REMOTE_SANDBOX_ADAPTER_TIMEOUT_SEC } from "@paperclipai/adapter-utils/execution-target";
 import {
+  AcpxSessionInitError,
   createAcpxEngineExecutor,
   findAncestorBin,
   geminiVersionSupportsNativeAcpFlag,
@@ -939,6 +940,170 @@ describe("shared ACPX engine runtime behavior", () => {
     const stderrLog = logs.find((entry) => entry.stream === "stderr" && entry.text.includes("ACPX child stderr tail"));
     expect(stderrLog).toBeTruthy();
     expect(stderrLog!.text).toContain(stderrTail);
+  });
+
+  it("throws AcpxSessionInitError (so the adapter can fall back) when session init fails and lane fallback is allowed", async () => {
+    const root = await makeTempRoot();
+    const stateDir = path.join(root, "state");
+    const runStderrDir = path.join(stateDir, "run-stderr");
+    await fs.mkdir(runStderrDir, { recursive: true });
+    // A JSON-RPC -32603 handshake failure: the throw carries the bare
+    // "Internal error" message; the real cause lives only in child stderr.
+    const stderrTail = "session/new failed: -32603 backend unavailable while starting agent process";
+    await fs.writeFile(path.join(runStderrDir, "run-fallback-1.log"), `${stderrTail}\n`, "utf8");
+
+    const execute = createAcpxEngineExecutor({
+      allowSessionInitLaneFallback: () => true,
+      createRuntime: () => ({
+        ensureSession: async () => {
+          throw new Error("Internal error");
+        },
+        startTurn: () => ({
+          events: (async function* () {})(),
+          result: Promise.resolve({ status: "completed", stopReason: "end_turn" }),
+          cancel: async () => {},
+        }),
+        close: async () => {},
+      }) as never,
+    });
+
+    const thrown = await execute({
+      runId: "run-fallback-1",
+      agent: { id: "agent-1", companyId: "company-1" },
+      runtime: {},
+      config: { agent: "custom", agentCommand: "node ./fake-acp.js", stateDir },
+      context: {},
+      onLog: async () => {},
+      onMeta: async () => {},
+    } as never).then(
+      () => null,
+      (err: unknown) => err,
+    );
+
+    expect(thrown).toBeInstanceOf(AcpxSessionInitError);
+    const sessionErr = thrown as AcpxSessionInitError;
+    expect(sessionErr.errorCode).toBe("acpx_session_init_failed");
+    // The bare "Internal error" is folded together with the real child stderr.
+    expect(sessionErr.message).toContain("Internal error");
+    expect(sessionErr.message).toContain(stderrTail);
+    expect(sessionErr.childStderrTail).toContain(stderrTail);
+  });
+
+  it("returns the terminal failed result (no lane switch) for an explicit ACP run", async () => {
+    const root = await makeTempRoot();
+    const stateDir = path.join(root, "state");
+    const runStderrDir = path.join(stateDir, "run-stderr");
+    await fs.mkdir(runStderrDir, { recursive: true });
+    const stderrTail = "session/new failed: -32603 backend unavailable while starting agent process";
+    await fs.writeFile(path.join(runStderrDir, "run-explicit-1.log"), `${stderrTail}\n`, "utf8");
+
+    const execute = createAcpxEngineExecutor({
+      allowSessionInitLaneFallback: () => false,
+      createRuntime: () => ({
+        ensureSession: async () => {
+          throw new Error("Internal error");
+        },
+        startTurn: () => ({
+          events: (async function* () {})(),
+          result: Promise.resolve({ status: "completed", stopReason: "end_turn" }),
+          cancel: async () => {},
+        }),
+        close: async () => {},
+      }) as never,
+    });
+
+    const result = await execute({
+      runId: "run-explicit-1",
+      agent: { id: "agent-1", companyId: "company-1" },
+      runtime: {},
+      config: { agent: "custom", agentCommand: "node ./fake-acp.js", stateDir },
+      context: {},
+      onLog: async () => {},
+      onMeta: async () => {},
+    } as never);
+
+    expect(result.exitCode).toBe(1);
+    expect(result.errorCode).toBe("acpx_session_init_failed");
+    // Requirement 2: the real child stderr is folded into the tenant-facing text.
+    expect(result.errorMessage).toContain(stderrTail);
+    expect(result.summary).toContain(stderrTail);
+  });
+
+  it("classifies an auth-indicating session-init stderr as acpx_auth_required (returned result)", async () => {
+    const root = await makeTempRoot();
+    const stateDir = path.join(root, "state");
+    const runStderrDir = path.join(stateDir, "run-stderr");
+    await fs.mkdir(runStderrDir, { recursive: true });
+    const stderrTail = "AI_APICallError: 401 status: invalid x-api-key credential";
+    await fs.writeFile(path.join(runStderrDir, "run-auth-1.log"), `${stderrTail}\n`, "utf8");
+
+    const execute = createAcpxEngineExecutor({
+      allowSessionInitLaneFallback: () => false,
+      createRuntime: () => ({
+        ensureSession: async () => {
+          throw new Error("Internal error");
+        },
+        startTurn: () => ({
+          events: (async function* () {})(),
+          result: Promise.resolve({ status: "completed", stopReason: "end_turn" }),
+          cancel: async () => {},
+        }),
+        close: async () => {},
+      }) as never,
+    });
+
+    const result = await execute({
+      runId: "run-auth-1",
+      agent: { id: "agent-1", companyId: "company-1" },
+      runtime: {},
+      config: { agent: "custom", agentCommand: "node ./fake-acp.js", stateDir },
+      context: {},
+      onLog: async () => {},
+      onMeta: async () => {},
+    } as never);
+
+    expect(result.exitCode).toBe(1);
+    expect(result.errorCode).toBe("acpx_auth_required");
+  });
+
+  it("carries the auth classification on the thrown error for a fallback-eligible run", async () => {
+    const root = await makeTempRoot();
+    const stateDir = path.join(root, "state");
+    const runStderrDir = path.join(stateDir, "run-stderr");
+    await fs.mkdir(runStderrDir, { recursive: true });
+    const stderrTail = "Unauthorized (401): missing credential for provider";
+    await fs.writeFile(path.join(runStderrDir, "run-auth-2.log"), `${stderrTail}\n`, "utf8");
+
+    const execute = createAcpxEngineExecutor({
+      allowSessionInitLaneFallback: () => true,
+      createRuntime: () => ({
+        ensureSession: async () => {
+          throw new Error("Internal error");
+        },
+        startTurn: () => ({
+          events: (async function* () {})(),
+          result: Promise.resolve({ status: "completed", stopReason: "end_turn" }),
+          cancel: async () => {},
+        }),
+        close: async () => {},
+      }) as never,
+    });
+
+    const thrown = await execute({
+      runId: "run-auth-2",
+      agent: { id: "agent-1", companyId: "company-1" },
+      runtime: {},
+      config: { agent: "custom", agentCommand: "node ./fake-acp.js", stateDir },
+      context: {},
+      onLog: async () => {},
+      onMeta: async () => {},
+    } as never).then(
+      () => null,
+      (err: unknown) => err,
+    );
+
+    expect(thrown).toBeInstanceOf(AcpxSessionInitError);
+    expect((thrown as AcpxSessionInitError).errorCode).toBe("acpx_auth_required");
   });
 
   it("writes wrapper that redirects child stderr to a per-run log file", async () => {

--- a/packages/adapter-utils/src/acpx-engine/execute.test.ts
+++ b/packages/adapter-utils/src/acpx-engine/execute.test.ts
@@ -1029,6 +1029,49 @@ describe("shared ACPX engine runtime behavior", () => {
     expect(result.summary).toContain(stderrTail);
   });
 
+  it("redacts secrets from the child stderr before surfacing it in the tenant-facing message", async () => {
+    const root = await makeTempRoot();
+    const stateDir = path.join(root, "state");
+    const runStderrDir = path.join(stateDir, "run-stderr");
+    await fs.mkdir(runStderrDir, { recursive: true });
+    const secret = "sk-ant-api03-SUPERSECRETVALUE0123456789";
+    const stderrTail = `session/new failed: request used Authorization: Bearer ${secret}`;
+    await fs.writeFile(path.join(runStderrDir, "run-redact-1.log"), `${stderrTail}\n`, "utf8");
+
+    const execute = createAcpxEngineExecutor({
+      allowSessionInitLaneFallback: () => false,
+      createRuntime: () => ({
+        ensureSession: async () => {
+          throw new Error("Internal error");
+        },
+        startTurn: () => ({
+          events: (async function* () {})(),
+          result: Promise.resolve({ status: "completed", stopReason: "end_turn" }),
+          cancel: async () => {},
+        }),
+        close: async () => {},
+      }) as never,
+    });
+
+    const result = await execute({
+      runId: "run-redact-1",
+      agent: { id: "agent-1", companyId: "company-1" },
+      runtime: {},
+      config: { agent: "custom", agentCommand: "node ./fake-acp.js", stateDir },
+      context: {},
+      onLog: async () => {},
+      onMeta: async () => {},
+    } as never);
+
+    expect(result.exitCode).toBe(1);
+    // The secret must not leak into the persisted, tenant-facing fields...
+    expect(result.errorMessage).not.toContain(secret);
+    expect(result.summary).not.toContain(secret);
+    expect(result.errorMessage).toContain("***REDACTED***");
+    // ...but the non-secret diagnostic context is still surfaced.
+    expect(result.errorMessage).toContain("session/new failed");
+  });
+
   it("classifies an auth-indicating session-init stderr as acpx_auth_required (returned result)", async () => {
     const root = await makeTempRoot();
     const stateDir = path.join(root, "state");
@@ -1064,6 +1107,81 @@ describe("shared ACPX engine runtime behavior", () => {
 
     expect(result.exitCode).toBe(1);
     expect(result.errorCode).toBe("acpx_auth_required");
+  });
+
+  it("classifies a genuine credential rejection (no HTTP status) as acpx_auth_required", async () => {
+    const root = await makeTempRoot();
+    const stateDir = path.join(root, "state");
+    const runStderrDir = path.join(stateDir, "run-stderr");
+    await fs.mkdir(runStderrDir, { recursive: true });
+    const stderrTail = "authentication failed: invalid api key for provider";
+    await fs.writeFile(path.join(runStderrDir, "run-auth-3.log"), `${stderrTail}\n`, "utf8");
+
+    const execute = createAcpxEngineExecutor({
+      allowSessionInitLaneFallback: () => false,
+      createRuntime: () => ({
+        ensureSession: async () => {
+          throw new Error("Internal error");
+        },
+        startTurn: () => ({
+          events: (async function* () {})(),
+          result: Promise.resolve({ status: "completed", stopReason: "end_turn" }),
+          cancel: async () => {},
+        }),
+        close: async () => {},
+      }) as never,
+    });
+
+    const result = await execute({
+      runId: "run-auth-3",
+      agent: { id: "agent-1", companyId: "company-1" },
+      runtime: {},
+      config: { agent: "custom", agentCommand: "node ./fake-acp.js", stateDir },
+      context: {},
+      onLog: async () => {},
+      onMeta: async () => {},
+    } as never);
+
+    expect(result.errorCode).toBe("acpx_auth_required");
+  });
+
+  it("does NOT classify a backend outage as auth just because stderr mentions api key/credential", async () => {
+    const root = await makeTempRoot();
+    const stateDir = path.join(root, "state");
+    const runStderrDir = path.join(stateDir, "run-stderr");
+    await fs.mkdir(runStderrDir, { recursive: true });
+    // Mentions "api key" and "credential" (setup logging) but the terminal
+    // error is a 5xx backend outage, not a credential rejection.
+    const stderrTail =
+      "loading api key from credential store; upstream backend returned 503 Service Unavailable";
+    await fs.writeFile(path.join(runStderrDir, "run-outage-1.log"), `${stderrTail}\n`, "utf8");
+
+    const execute = createAcpxEngineExecutor({
+      allowSessionInitLaneFallback: () => false,
+      createRuntime: () => ({
+        ensureSession: async () => {
+          throw new Error("Internal error");
+        },
+        startTurn: () => ({
+          events: (async function* () {})(),
+          result: Promise.resolve({ status: "completed", stopReason: "end_turn" }),
+          cancel: async () => {},
+        }),
+        close: async () => {},
+      }) as never,
+    });
+
+    const result = await execute({
+      runId: "run-outage-1",
+      agent: { id: "agent-1", companyId: "company-1" },
+      runtime: {},
+      config: { agent: "custom", agentCommand: "node ./fake-acp.js", stateDir },
+      context: {},
+      onLog: async () => {},
+      onMeta: async () => {},
+    } as never);
+
+    expect(result.errorCode).toBe("acpx_session_init_failed");
   });
 
   it("carries the auth classification on the thrown error for a fallback-eligible run", async () => {

--- a/packages/adapter-utils/src/acpx-engine/execute.ts
+++ b/packages/adapter-utils/src/acpx-engine/execute.ts
@@ -116,6 +116,15 @@ export interface AcpxEngineExecutorOptions {
   resolveBillingIdentity?: (
     ctx: AdapterExecutionContext,
   ) => AcpxEngineBillingIdentity | null | Promise<AcpxEngineBillingIdentity | null>;
+  /**
+   * Decide whether a session-init failure on this run may throw an
+   * {@link AcpxSessionInitError} so the calling adapter's `execute()` wrapper can
+   * fall back to its CLI lane. Return `true` for auto-selected (non-explicit)
+   * runs and `false` for explicit `engine=acp` runs (which keep the terminal
+   * failed result instead of silently switching lanes). When unset the engine
+   * preserves the legacy behavior and always returns the terminal failed result.
+   */
+  allowSessionInitLaneFallback?: (ctx: AdapterExecutionContext) => boolean;
 }
 
 interface AcpxPreparedRuntime {
@@ -1695,6 +1704,60 @@ export function summarizeAcpxTurnUsage(input: {
 
 type AcpxExecutionPhase = "ensure_session" | "configure_session" | "turn";
 
+/**
+ * Thrown by the ACPX engine when session initialization fails on an
+ * auto-selected (non-explicit) run so the calling adapter's `execute()` wrapper
+ * can fall back to its proven CLI lane. The classified `errorCode` and the
+ * child process stderr tail travel with the error so the fallback log and any
+ * eventual terminal result surface the real cause instead of a bare
+ * "Internal error". Explicit `engine=acp` runs keep the terminal failed result
+ * (no silent lane switch) rather than throwing.
+ */
+export class AcpxSessionInitError extends Error {
+  readonly errorCode: string;
+  readonly errorMeta: AdapterExecutionResult["errorMeta"];
+  readonly childStderrTail: string | null;
+  readonly acpxPhase: AcpxExecutionPhase = "ensure_session";
+
+  constructor(input: {
+    message: string;
+    errorCode: string;
+    errorMeta?: AdapterExecutionResult["errorMeta"];
+    childStderrTail: string | null;
+    cause?: unknown;
+  }) {
+    super(input.message);
+    this.name = "AcpxSessionInitError";
+    this.errorCode = input.errorCode;
+    this.errorMeta = input.errorMeta;
+    this.childStderrTail = input.childStderrTail;
+    if (input.cause !== undefined) {
+      (this as { cause?: unknown }).cause = input.cause;
+    }
+  }
+}
+
+/**
+ * Fold the child process stderr tail (and any distinct cause message) into the
+ * tenant-facing failure text. A JSON-RPC -32603 handshake failure arrives as a
+ * bare "Internal error"; the actionable detail (auth rejection, missing binary,
+ * backend timeout) lives only in the child stderr, so surface it here.
+ */
+function composeSessionInitFailureMessage(input: {
+  message: string;
+  causeMessage: string | null;
+  childStderrTail: string | null;
+}): string {
+  const parts: string[] = [input.message];
+  if (input.causeMessage && !input.message.includes(input.causeMessage)) {
+    parts.push(`cause: ${input.causeMessage}`);
+  }
+  if (input.childStderrTail && !input.message.includes(input.childStderrTail)) {
+    parts.push(`agent process stderr (tail):\n${input.childStderrTail}`);
+  }
+  return parts.join("\n");
+}
+
 function describeErrorDiagnostics(err: unknown): {
   errorName: string;
   acpCode: string | null;
@@ -1729,9 +1792,18 @@ function describeErrorDiagnostics(err: unknown): {
   return { errorName, acpCode, causeMessage, retryable, stackPreview };
 }
 
+// Signals in a child stderr tail that a session-init failure is really an
+// auth/credential rejection (so it maps to the actionable connect-a-key code
+// rather than the opaque session-init code). Kept narrow so it only reclassifies
+// otherwise-uncoded failures (e.g. a JSON-RPC -32603 whose message is the bare
+// "Internal error").
+const STDERR_AUTH_INDICATOR_RE =
+  /\bauth\b|unauthor|forbidden|\b401\b|\b403\b|invalid[\s_-]*(?:api[\s_-]*)?key|invalid[\s_-]*credential|\bcredential|api[\s_-]*key|\blogin\b|x-api-key/i;
+
 function classifyError(
   err: unknown,
   phase?: AcpxExecutionPhase,
+  childStderrTail?: string | null,
 ): Pick<AdapterExecutionResult, "errorCode" | "errorMeta"> {
   const message = err instanceof Error ? err.message : String(err);
   const diagnostics = describeErrorDiagnostics(err);
@@ -1747,6 +1819,20 @@ function classifyError(
   const lower = message.toLowerCase();
   const authLike = lower.includes("auth") || lower.includes("login") || lower.includes("credential");
   if (authLike) {
+    return {
+      errorCode: "acpx_auth_required",
+      errorMeta: { category: "auth", ...baseMeta },
+    };
+  }
+  // A session-init failure whose message is opaque (no ACP_* code, e.g. a
+  // JSON-RPC -32603 "Internal error") but whose child stderr indicates an auth
+  // rejection is an actionable connect-a-key case, not a generic init failure.
+  if (
+    phase === "ensure_session" &&
+    !acpCode &&
+    childStderrTail &&
+    STDERR_AUTH_INDICATOR_RE.test(childStderrTail)
+  ) {
     return {
       errorCode: "acpx_auth_required",
       errorMeta: { category: "auth", ...baseMeta },
@@ -1820,8 +1906,8 @@ async function emitAcpxFailure(input: {
   const { ctx, prepared, err, phase, messageOverride } = input;
   const rawMessage = err instanceof Error ? err.message : String(err);
   const message = messageOverride ?? rawMessage;
-  const classified = classifyError(err, phase);
   const childStderrTail = await readChildStderrTail({ logPath: prepared.childStderrLogPath });
+  const classified = classifyError(err, phase, childStderrTail);
   if (childStderrTail) {
     await ctx.onLog(
       "stderr",
@@ -1932,6 +2018,7 @@ export function createAcpxEngineExecutor(deps: AcpxEngineExecutorOptions = {}) {
   const now = deps.now ?? (() => Date.now());
   const warmHandles = deps.warmHandles ?? defaultWarmHandles;
   const engine = resolveEngineSettings(deps);
+  const allowSessionInitLaneFallback = deps.allowSessionInitLaneFallback ?? (() => false);
 
   return async function executeAcpxEngine(ctx: AdapterExecutionContext): Promise<AdapterExecutionResult> {
     let billingIdentity: AcpxEngineBillingIdentity | null = null;
@@ -2014,24 +2101,45 @@ export function createAcpxEngineExecutor(deps: AcpxEngineExecutorOptions = {}) {
         }
       }
     } catch (err) {
-      const { classified, message } = await emitAcpxFailure({
+      const { classified, message, childStderrTail } = await emitAcpxFailure({
         ctx,
         prepared,
         err,
         phase: "ensure_session",
       });
+      const causeMessage =
+        typeof classified.errorMeta?.causeMessage === "string"
+          ? classified.errorMeta.causeMessage
+          : null;
+      const composedMessage = composeSessionInitFailureMessage({
+        message,
+        causeMessage,
+        childStderrTail,
+      });
       await cleanupRemoteBridges(prepared);
+      // Auto-selected (non-explicit) runs throw so the adapter's execute()
+      // wrapper catches it and falls back to the proven CLI lane. Explicit
+      // engine=acp runs keep the terminal failed result (no silent lane switch).
+      if (allowSessionInitLaneFallback(ctx)) {
+        throw new AcpxSessionInitError({
+          message: composedMessage,
+          errorCode: classified.errorCode ?? "acpx_session_init_failed",
+          errorMeta: classified.errorMeta,
+          childStderrTail,
+          cause: err,
+        });
+      }
       return {
         exitCode: 1,
         signal: null,
         timedOut: false,
-        errorMessage: message,
+        errorMessage: composedMessage,
         ...classified,
         ...billingFields,
         model: prepared.requestedModel || null,
         clearSession,
         resultJson: { phase: "ensure_session" },
-        summary: message,
+        summary: composedMessage,
       };
     }
 

--- a/packages/adapter-utils/src/acpx-engine/execute.ts
+++ b/packages/adapter-utils/src/acpx-engine/execute.ts
@@ -50,6 +50,7 @@ import {
   type PaperclipSkillEntry,
 } from "@paperclipai/adapter-utils/server-utils";
 import { shellQuote } from "@paperclipai/adapter-utils/ssh";
+import { redactSensitiveText } from "../command-redaction.js";
 import {
   createAcpRuntime,
   createAgentRegistry,
@@ -1792,13 +1793,15 @@ function describeErrorDiagnostics(err: unknown): {
   return { errorName, acpCode, causeMessage, retryable, stackPreview };
 }
 
-// Signals in a child stderr tail that a session-init failure is really an
-// auth/credential rejection (so it maps to the actionable connect-a-key code
-// rather than the opaque session-init code). Kept narrow so it only reclassifies
-// otherwise-uncoded failures (e.g. a JSON-RPC -32603 whose message is the bare
-// "Internal error").
-const STDERR_AUTH_INDICATOR_RE =
-  /\bauth\b|unauthor|forbidden|\b401\b|\b403\b|invalid[\s_-]*(?:api[\s_-]*)?key|invalid[\s_-]*credential|\bcredential|api[\s_-]*key|\blogin\b|x-api-key/i;
+// A genuine auth/credential FAILURE signal (so a failure maps to the actionable
+// connect-a-key code rather than the opaque session-init code). This must be
+// failure-shaped, not a mere mention: a backend outage that logs "loading api
+// key from credential store" while returning a 5xx is NOT an auth failure and
+// must keep its session-init classification. So we require an HTTP 401/403, an
+// explicit unauthorized/forbidden/permission-denied, an authentication failure,
+// or a credential/key/token that is invalid/expired/rejected/revoked.
+const AUTH_FAILURE_RE =
+  /\b40[13]\b|unauthor|forbidden|permission[\s_-]*denied|authentication[\s_-]*(?:failed|error)|(?:invalid|expired|revoked|rejected|bad|missing)[\s_-]*(?:api[\s_-]*)?(?:key|token|credentials?)|(?:api[\s_-]*key|token|credentials?|oauth)[\s\S]{0,32}?(?:is[\s_-]*)?(?:invalid|expired|revoked|rejected|not[\s_-]*authorized|unauthorized)|x-api-key[\s\S]{0,32}?(?:invalid|rejected|missing)/i;
 
 function classifyError(
   err: unknown,
@@ -1816,22 +1819,25 @@ function classifyError(
     ...(stackPreview ? { stackPreview } : {}),
     ...(phase ? { phase } : {}),
   };
-  const lower = message.toLowerCase();
-  const authLike = lower.includes("auth") || lower.includes("login") || lower.includes("credential");
-  if (authLike) {
+  // Only reclassify as connect-a-key when the error message carries a genuine
+  // auth-FAILURE signal (a 401/403, an invalid/expired credential, etc.), not a
+  // mere mention of "auth"/"credential" (which a backend outage also logs).
+  if (AUTH_FAILURE_RE.test(message)) {
     return {
       errorCode: "acpx_auth_required",
       errorMeta: { category: "auth", ...baseMeta },
     };
   }
   // A session-init failure whose message is opaque (no ACP_* code, e.g. a
-  // JSON-RPC -32603 "Internal error") but whose child stderr indicates an auth
-  // rejection is an actionable connect-a-key case, not a generic init failure.
+  // JSON-RPC -32603 "Internal error") but whose child stderr shows a genuine
+  // auth rejection is an actionable connect-a-key case, not a generic init
+  // failure. A generic "api key"/"credential" mention alongside a non-auth
+  // terminal error (e.g. a 5xx backend outage) must NOT reclassify.
   if (
     phase === "ensure_session" &&
     !acpCode &&
     childStderrTail &&
-    STDERR_AUTH_INDICATOR_RE.test(childStderrTail)
+    AUTH_FAILURE_RE.test(childStderrTail)
   ) {
     return {
       errorCode: "acpx_auth_required",
@@ -2111,11 +2117,18 @@ export function createAcpxEngineExecutor(deps: AcpxEngineExecutorOptions = {}) {
         typeof classified.errorMeta?.causeMessage === "string"
           ? classified.errorMeta.causeMessage
           : null;
-      const composedMessage = composeSessionInitFailureMessage({
-        message,
-        causeMessage,
-        childStderrTail,
-      });
+      // The composed message becomes the tenant-facing, persisted
+      // errorMessage/summary. The raw child stderr (and cause) can carry
+      // secrets (tokens, Authorization headers, api-key values), so redact
+      // before surfacing. The full unredacted tail still reached the internal
+      // run log and the acpx.error event above.
+      const composedMessage = redactSensitiveText(
+        composeSessionInitFailureMessage({
+          message,
+          causeMessage,
+          childStderrTail,
+        }),
+      );
       await cleanupRemoteBridges(prepared);
       // Auto-selected (non-explicit) runs throw so the adapter's execute()
       // wrapper catches it and falls back to the proven CLI lane. Explicit

--- a/packages/adapter-utils/src/acpx-engine/index.ts
+++ b/packages/adapter-utils/src/acpx-engine/index.ts
@@ -1,5 +1,5 @@
 export * from "./constants.js";
-export { createAcpxEngineExecutor, execute } from "./execute.js";
+export { AcpxSessionInitError, createAcpxEngineExecutor, execute } from "./execute.js";
 export { sessionCodec } from "./session-codec.js";
 export { printAcpxStreamEvent } from "./cli.js";
 export { parseAcpxStdoutLine } from "./ui.js";

--- a/packages/adapter-utils/src/command-redaction.test.ts
+++ b/packages/adapter-utils/src/command-redaction.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  REDACTED_COMMAND_TEXT_VALUE,
+  redactSensitiveText,
+} from "./command-redaction.js";
+
+describe("redactSensitiveText", () => {
+  it("redacts an Authorization: Bearer header value", () => {
+    const out = redactSensitiveText(
+      "GET /v1 failed: Authorization: Bearer sk-ant-api03-abcdef....",
+    );
+    expect(out).not.toContain("sk-ant-api03-abcdefgh");
+    expect(out).toContain(REDACTED_COMMAND_TEXT_VALUE);
+  });
+
+  it("redacts a bare Bearer token without an Authorization prefix", () => {
+    const out = redactSensitiveText("sent header Bearer abcdEFGH12345678 ok");
+    expect(out).not.toContain("abcdEFGH12345678");
+    expect(out).toContain(REDACTED_COMMAND_TEXT_VALUE);
+  });
+
+  it("redacts an sk-ant- style api key", () => {
+    const out = redactSensitiveText(
+      "401 invalid key: sk-ant-api03-SECRETVALUE0123456789",
+    );
+    expect(out).not.toContain("SECRETVALUE0123456789");
+    expect(out).toContain(REDACTED_COMMAND_TEXT_VALUE);
+  });
+
+  it("redacts a Google AIza api key", () => {
+    const out = redactSensitiveText(
+      "gemini error: key AIzaSyA1234567890abcdefghijklmnopqrstuvx rejected",
+    );
+    expect(out).not.toContain("AIzaSyA1234567890abcdefghijklmnopqrstuvx");
+    expect(out).toContain(REDACTED_COMMAND_TEXT_VALUE);
+  });
+
+  it("redacts an api-key = value assignment", () => {
+    const out = redactSensitiveText("env x-api-key=topsecretvalue123 failed");
+    expect(out).not.toContain("topsecretvalue123");
+    expect(out).toContain(REDACTED_COMMAND_TEXT_VALUE);
+  });
+
+  it("leaves plain diagnostic text untouched", () => {
+    const text = "session/new failed: -32603 backend unavailable";
+    expect(redactSensitiveText(text)).toBe(text);
+  });
+});

--- a/packages/adapter-utils/src/command-redaction.ts
+++ b/packages/adapter-utils/src/command-redaction.ts
@@ -56,3 +56,26 @@ export function redactCommandText(command: string, redactedValue = REDACTED_COMM
     .replace(COMMAND_GITHUB_TOKEN_RE, redactedValue)
     .replace(COMMAND_JWT_RE, redactedValue);
 }
+
+// A bare `Bearer <token>` (no `Authorization:` prefix) and a Google `AIza...`
+// API key are secret shapes that show up in free-form process stderr but are
+// not covered by the command-oriented rules above.
+const BARE_BEARER_TOKEN_RE = /(\bBearer\s+)[A-Za-z0-9._~+/=-]{8,}/gi;
+const GOOGLE_API_KEY_RE = /\bAIza[0-9A-Za-z_-]{16,}\b/g;
+
+/**
+ * Redact secrets from free-form text (e.g. a child process stderr tail) before
+ * it is surfaced in a tenant-facing, persisted message. Reuses the command
+ * redactor (Authorization/Bearer headers, `api-key=`/`token=`/`authorization=`
+ * assignments, `sk-*`/`gh*` keys, JWTs) and adds bare `Bearer <...>` tokens and
+ * Google `AIza...` keys. The full unredacted text may still go to internal run
+ * logs; this output must not.
+ */
+export function redactSensitiveText(
+  text: string,
+  redactedValue = REDACTED_COMMAND_TEXT_VALUE,
+): string {
+  return redactCommandText(text, redactedValue)
+    .replace(BARE_BEARER_TOKEN_RE, `$1${redactedValue}`)
+    .replace(GOOGLE_API_KEY_RE, redactedValue);
+}

--- a/packages/adapter-utils/src/index.ts
+++ b/packages/adapter-utils/src/index.ts
@@ -63,6 +63,7 @@ export {
 export {
   REDACTED_COMMAND_TEXT_VALUE,
   redactCommandText,
+  redactSensitiveText,
 } from "./command-redaction.js";
 export { buildSandboxNpmInstallCommand } from "./sandbox-install-command.js";
 export { createRuntimeProgressReporter } from "./runtime-progress.js";

--- a/packages/adapters/claude-local/src/server/acp.test.ts
+++ b/packages/adapters/claude-local/src/server/acp.test.ts
@@ -483,6 +483,59 @@ describe("claude_local ACP lane", () => {
   });
 });
 
+describe("claude_local ACP session-init lane fallback", () => {
+  function throwingRuntime() {
+    return {
+      ensureSession: async () => {
+        throw new Error("Internal error");
+      },
+      startTurn: () => ({
+        events: (async function* () {})(),
+        result: Promise.resolve({ status: "completed", stopReason: "end_turn" }),
+        cancel: async () => {},
+      }),
+      setConfigOption: async () => {},
+      close: async () => {},
+    };
+  }
+
+  it("throws AcpxSessionInitError for an auto-selected run so execute() can fall back to CLI", async () => {
+    const root = await makeTempRoot("paperclip-claude-acp-fallback-");
+    const execute = createClaudeAcpExecutor({
+      createRuntime: () => throwingRuntime() as never,
+    });
+    const ctx = buildContext(root, {
+      // No engine=acp: an auto-selected default ACP run is fallback-eligible.
+      config: {
+        cwd: root,
+        stateDir: path.join(root, "state"),
+        promptTemplate: "Do the assigned work.",
+      },
+    });
+
+    const thrown = await execute(ctx).then(
+      () => null,
+      (err: unknown) => err,
+    );
+
+    expect(thrown).toBeInstanceOf(Error);
+    expect((thrown as Error).name).toBe("AcpxSessionInitError");
+    expect((thrown as { errorCode?: string }).errorCode).toBe("acpx_session_init_failed");
+  });
+
+  it("returns the terminal failed result for an explicit engine=acp run (no lane switch)", async () => {
+    const root = await makeTempRoot("paperclip-claude-acp-explicit-");
+    const execute = createClaudeAcpExecutor({
+      createRuntime: () => throwingRuntime() as never,
+    });
+    // buildContext defaults to config.engine === "acp" (explicit).
+    const result = await execute(buildContext(root));
+
+    expect(result.exitCode).toBe(1);
+    expect(result.errorCode).toBe("acpx_session_init_failed");
+  });
+});
+
 describe("resolveClaudeAcpBillingIdentity", () => {
   const originalApiKey = process.env.ANTHROPIC_API_KEY;
   const originalBedrock = process.env.CLAUDE_CODE_USE_BEDROCK;

--- a/packages/adapters/claude-local/src/server/acp.ts
+++ b/packages/adapters/claude-local/src/server/acp.ts
@@ -169,6 +169,10 @@ export function resolveClaudeAcpBillingIdentity(
 function withClaudeAcpDefaults(options: ClaudeAcpExecutorOptions): AcpxEngineExecutorOptions {
   return {
     resolveBillingIdentity: resolveClaudeAcpBillingIdentity,
+    // Auto-selected (non-explicit) ACP runs may throw on session-init failure so
+    // execute() falls back to the proven CLI lane; explicit engine=acp runs keep
+    // the terminal failed result instead of silently switching lanes.
+    allowSessionInitLaneFallback: (ctx) => !normalizeEngine(ctx.config.engine).explicit,
     ...options,
     adapterType: "claude_local",
     moduleDir,

--- a/packages/adapters/codex-local/src/server/acp.ts
+++ b/packages/adapters/codex-local/src/server/acp.ts
@@ -135,6 +135,10 @@ export function buildCodexAcpConfig(config: Record<string, unknown>): Record<str
 function withCodexAcpDefaults(options: CodexAcpExecutorOptions): AcpxEngineExecutorOptions {
   return {
     resolveBillingIdentity: resolveCodexAcpBillingIdentity,
+    // Auto-selected (non-explicit) ACP runs may throw on session-init failure so
+    // execute() falls back to the proven CLI lane; explicit engine=acp runs keep
+    // the terminal failed result instead of silently switching lanes.
+    allowSessionInitLaneFallback: (ctx) => !normalizeEngine(ctx.config.engine).explicit,
     ...options,
     adapterType: "codex_local",
     moduleDir,

--- a/packages/adapters/gemini-local/src/server/acp.ts
+++ b/packages/adapters/gemini-local/src/server/acp.ts
@@ -119,6 +119,10 @@ export function buildGeminiAcpConfig(config: Record<string, unknown>): Record<st
 
 function withGeminiAcpDefaults(options: GeminiAcpExecutorOptions): AcpxEngineExecutorOptions {
   return {
+    // Auto-selected (non-explicit) ACP runs may throw on session-init failure so
+    // execute() falls back to the proven CLI lane; explicit engine=acp runs keep
+    // the terminal failed result instead of silently switching lanes.
+    allowSessionInitLaneFallback: (ctx) => !normalizeEngine(ctx.config.engine).explicit,
     ...options,
     adapterType: "gemini_local",
     moduleDir,


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Agents execute through adapters (claude/codex/gemini local), which can run via the newer ACP ("acpx") lane or the proven CLI lane.
> - The acpx lane is the default, and when a sandbox looks bridge-capable it is chosen over the CLI lane.
> - If the ACP session handshake fails, the run should fall back to the CLI lane the same way a bridge-spawn failure already does; instead it dies.
> - This pull request makes an auto-selected ACP session-init failure fall back to the CLI lane, surfaces the real cause, and reclassifies auth failures.
> - The benefit is that adapters no longer dead-end on an opaque "Internal error" when the ACP lane can't initialize.

## Linked Issues or Issue Description

No public issue exists; the underlying bug is described inline below, following the bug report template.

**What happened**

A sandboxed run defaults to the ACP ("acpx") lane, its `session/new` handshake fails with JSON-RPC -32603, and the run terminates with `acpx_session_init_failed` / "Internal error". The adapter's CLI-lane fallback never fires because the acpx-engine RETURNS the failed result instead of throwing, and the real child stderr is captured but never surfaced.

**Expected behavior**

For an auto-selected (non-explicit) run, an ACP session-init failure should fall back to the proven CLI lane (as a bridge-spawn failure already does); the surfaced error should carry the real cause; and an auth-indicating failure should classify as `acpx_auth_required`.

**Steps to reproduce**

1. Run an agent whose lane is auto-selected (not explicitly `engine=acp`) in an environment where the ACP `session/new` handshake fails.
2. Observe the run terminates as `acpx_session_init_failed` with a bare "Internal error" and no fallback to the CLI lane.

## What Changed

- The acpx-engine now THROWS a typed `AcpxSessionInitError` (carrying the classified code + child stderr) for auto-selected runs, so each adapter's `execute()` wrapper catches it and falls through to the CLI lane; explicit `engine=acp` runs still return the terminal failed result (no silent lane switch).
- Folded the child's real stderr (`childStderrTail`) into the returned/thrown message and summary instead of dropping it.
- Broadened `classifyError` so a `-32603` during `ensure_session` whose stderr indicates auth/401/invalid-credential maps to `acpx_auth_required` (the actionable connect-a-key code).

## Verification

- New tests (acpx-engine + claude-local integration): a non-explicit session-init failure falls back to the CLI lane; an explicit-ACP run still returns the failed result; the child stderr is surfaced; an auth-indicating stderr classifies as `acpx_auth_required`.
- `adapter-utils`, `claude-local`, `codex-local`, `gemini-local`, `opencode-local` typecheck and build clean; targeted suites pass (pre-existing Linux-only/SSH/network probe failures are unrelated).

## Risks

Low. The lane fallback only applies to auto-selected runs; explicit ACP runs keep their terminal failure. Surfacing stderr and reclassifying auth failures strictly improves diagnosability. No behavioral change on the CLI lane itself.

## Model Used

Claude (Anthropic), model ID `claude-fable-5`, extended reasoning, with tool use / code execution in an agentic harness.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
