### PR TITLE
fix(server): soft-drain in-flight runs on shutdown instead of interrupting all

### DIFF
--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -1716,6 +1716,143 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(wakeup?.status).toBe("claimed");
   });
 
+  it("soft-drains: a run that finishes within the drain window is not interrupted", async () => {
+    const { agentId, runId } = await seedRunFixture({ agentStatus: "running" });
+    const heartbeat = heartbeatService(db);
+
+    // Simulate an in-flight run that keeps executing until, during the drain
+    // wait, it completes on its own and flips to succeeded.
+    let ticks = 0;
+    const hasInflightRuns = () => ticks < 1;
+    const sleep = vi.fn(async () => {
+      ticks += 1;
+      await db
+        .update(heartbeatRuns)
+        .set({
+          status: "succeeded",
+          finishedAt: new Date("2026-03-19T00:06:05.000Z"),
+          updatedAt: new Date("2026-03-19T00:06:05.000Z"),
+        })
+        .where(eq(heartbeatRuns.id, runId));
+    });
+
+    const result = await heartbeat.drainRunningRunsForShutdown(
+      "SIGTERM",
+      new Date("2026-03-19T00:06:00.000Z"),
+      { hasInflightRuns, sleep, drainTimeoutMs: 10_000, pollIntervalMs: 100 },
+    );
+
+    expect(sleep).toHaveBeenCalled();
+    expect(result.interrupted).toBe(0);
+    expect(result.interruptedRunIds).toEqual([]);
+
+    const runs = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.agentId, agentId));
+    // No fresh-from-scratch retry was enqueued; only the original run exists.
+    expect(runs).toHaveLength(1);
+    const run = runs[0];
+    expect(run.status).toBe("succeeded");
+    expect(run.errorCode).not.toBe("server_shutdown_interrupted");
+  });
+
+  it("soft-drains: new-run dispatch is quiesced before the drain wait begins", async () => {
+    const { runId } = await seedRunFixture({ agentStatus: "running" });
+    const heartbeat = heartbeatService(db);
+
+    // Before shutdown, scheduling is not suppressed.
+    expect((await heartbeat.resolveSchedulingSuppression()).suppressed).toBe(false);
+
+    let suppressedDuringDrain: boolean | null = null;
+    let ticks = 0;
+    const hasInflightRuns = () => ticks < 1;
+    const sleep = vi.fn(async () => {
+      ticks += 1;
+      suppressedDuringDrain = (await heartbeat.resolveSchedulingSuppression()).suppressed;
+      await db
+        .update(heartbeatRuns)
+        .set({
+          status: "succeeded",
+          finishedAt: new Date("2026-03-19T00:06:05.000Z"),
+          updatedAt: new Date("2026-03-19T00:06:05.000Z"),
+        })
+        .where(eq(heartbeatRuns.id, runId));
+    });
+
+    await heartbeat.drainRunningRunsForShutdown(
+      "SIGTERM",
+      new Date("2026-03-19T00:06:00.000Z"),
+      { hasInflightRuns, sleep, drainTimeoutMs: 10_000, pollIntervalMs: 100 },
+    );
+
+    // Dispatch was quiesced before the wait, and stays quiesced afterwards.
+    expect(suppressedDuringDrain).toBe(true);
+    expect((await heartbeat.resolveSchedulingSuppression()).suppressed).toBe(true);
+  });
+
+  it("soft-drains: a run still running at the drain deadline is interrupted and retried", async () => {
+    const { agentId, runId } = await seedRunFixture({ agentStatus: "running" });
+    const heartbeat = heartbeatService(db);
+
+    // The run never finishes on its own, so the drain must hit its deadline.
+    const hasInflightRuns = () => true;
+    const sleep = vi.fn(async () => {});
+
+    const result = await heartbeat.drainRunningRunsForShutdown(
+      "SIGTERM",
+      new Date("2026-03-19T00:06:00.000Z"),
+      { hasInflightRuns, sleep, drainTimeoutMs: 100, pollIntervalMs: 25 },
+    );
+
+    expect(result.interrupted).toBe(1);
+    expect(result.interruptedRunIds).toEqual([runId]);
+
+    const runs = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.agentId, agentId));
+    expect(runs).toHaveLength(2);
+    const interruptedRun = runs.find((row) => row.id === runId);
+    const retryRun = runs.find((row) => row.retryOfRunId === runId);
+    expect(interruptedRun).toMatchObject({
+      status: "interrupted",
+      errorCode: "server_shutdown_interrupted",
+      signal: "SIGTERM",
+    });
+    expect(retryRun).toMatchObject({ status: "queued", retryOfRunId: runId });
+  });
+
+  it("soft-drains: the wait is bounded by the drain timeout", async () => {
+    const { runId } = await seedRunFixture({ agentStatus: "running" });
+    const heartbeat = heartbeatService(db);
+
+    // Drive a fake clock so the bound is deterministic without wall-clock sleeps.
+    let fakeNow = 0;
+    const nowMs = () => fakeNow;
+    const hasInflightRuns = () => true; // never drains on its own
+    const sleep = vi.fn(async (ms: number) => {
+      fakeNow += ms;
+    });
+
+    await heartbeat.drainRunningRunsForShutdown(
+      "SIGTERM",
+      new Date("2026-03-19T00:06:00.000Z"),
+      { hasInflightRuns, sleep, nowMs, drainTimeoutMs: 100, pollIntervalMs: 25 },
+    );
+
+    // deadline=100, interval=25 => at most 4 polls before the bound is reached.
+    expect(sleep).toHaveBeenCalledTimes(4);
+
+    // The still-running run is interrupted at the deadline, never left "running".
+    const run = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, runId))
+      .then((rows) => rows[0] ?? null);
+    expect(run?.status).toBe("interrupted");
+  });
+
   it("does not enqueue duplicate restart recovery for the same interrupted run", async () => {
     const { agentId, runId, issueId, wakeupRequestId } = await seedRunFixture({
       agentStatus: "running",

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -4,7 +4,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { and, eq, or, inArray, sql } from "drizzle-orm";
-import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   activityLog,
   agents,
@@ -102,6 +102,7 @@ import {
   INTERACTION_CONTINUATION_INFRA_WAKE_REASON,
   heartbeatService,
   redactDetectedSuccessfulRunProgressSummaryForBoard,
+  resetShutdownDrainingForTests,
 } from "../services/heartbeat.ts";
 import {
   readHotRestartIntent,
@@ -303,6 +304,13 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-heartbeat-recovery-");
     db = createDb(tempDb.connectionString);
   }, 20_000);
+
+  beforeEach(() => {
+    // shutdownDraining is shared across all heartbeatService instances (module
+    // scope), so a drain test would otherwise leave dispatch suppressed for
+    // every following case. Reset it so each test starts un-quiesced.
+    resetShutdownDrainingForTests();
+  });
 
   afterEach(async () => {
     vi.clearAllMocks();
@@ -1851,6 +1859,84 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       .where(eq(heartbeatRuns.id, runId))
       .then((rows) => rows[0] ?? null);
     expect(run?.status).toBe("interrupted");
+  });
+
+  it("soft-drains: a sub-interval drain timeout never oversleeps past the deadline", async () => {
+    const { runId } = await seedRunFixture({ agentStatus: "running" });
+    const heartbeat = heartbeatService(db);
+
+    // A tiny timeout (1ms) with the real 500ms poll interval. Each wait must be
+    // capped to the remaining budget, so the total drain wait stays within the
+    // deadline instead of sleeping a full poll interval past it. Regression
+    // guard: the previous `await sleep(pollIntervalMs)` slept ~500ms for a 1ms
+    // timeout, blowing the drain+cleanup past its bound.
+    const drainTimeoutMs = 1;
+    const pollIntervalMs = 500;
+    let fakeNow = 0;
+    const nowMs = () => fakeNow;
+    const hasInflightRuns = () => true; // never drains on its own
+    const slept: number[] = [];
+    const sleep = vi.fn(async (ms: number) => {
+      slept.push(ms);
+      fakeNow += ms;
+    });
+
+    await heartbeat.drainRunningRunsForShutdown(
+      "SIGTERM",
+      new Date("2026-03-19T00:06:00.000Z"),
+      { hasInflightRuns, sleep, nowMs, drainTimeoutMs, pollIntervalMs },
+    );
+
+    // No single sleep exceeded the (tiny) remaining budget, and the total wait
+    // never ran past the deadline: waited <= deadline (well under one poll tick).
+    const totalSlept = slept.reduce((sum, ms) => sum + ms, 0);
+    expect(Math.max(0, ...slept)).toBeLessThanOrEqual(drainTimeoutMs);
+    expect(totalSlept).toBeLessThanOrEqual(drainTimeoutMs);
+
+    const run = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, runId))
+      .then((rows) => rows[0] ?? null);
+    expect(run?.status).toBe("interrupted");
+  });
+
+  it("soft-drains: a second heartbeat service instance also suppresses new-run dispatch once shutdown begins", async () => {
+    const { runId } = await seedRunFixture({ agentStatus: "running" });
+    // Two independent instances, as the server actually constructs (the drain
+    // handler on one, route/scheduler dispatch on another).
+    const drainingInstance = heartbeatService(db);
+    const otherInstance = heartbeatService(db);
+
+    // Before shutdown, neither instance suppresses new-run dispatch.
+    expect((await drainingInstance.resolveSchedulingSuppression()).suppressed).toBe(false);
+    expect((await otherInstance.resolveSchedulingSuppression()).suppressed).toBe(false);
+
+    let ticks = 0;
+    const hasInflightRuns = () => ticks < 1;
+    const sleep = vi.fn(async () => {
+      ticks += 1;
+      await db
+        .update(heartbeatRuns)
+        .set({
+          status: "succeeded",
+          finishedAt: new Date("2026-03-19T00:06:05.000Z"),
+          updatedAt: new Date("2026-03-19T00:06:05.000Z"),
+        })
+        .where(eq(heartbeatRuns.id, runId));
+    });
+
+    await drainingInstance.drainRunningRunsForShutdown(
+      "SIGTERM",
+      new Date("2026-03-19T00:06:00.000Z"),
+      { hasInflightRuns, sleep, drainTimeoutMs: 10_000, pollIntervalMs: 100 },
+    );
+
+    // The OTHER instance now observes the shared quiesce and refuses new-run
+    // dispatch, so shutdown can't be raced by a dispatch on a different instance.
+    const otherSuppression = await otherInstance.resolveSchedulingSuppression();
+    expect(otherSuppression.suppressed).toBe(true);
+    expect(otherSuppression.reason).toBe("server_shutdown");
   });
 
   it("does not enqueue duplicate restart recovery for the same interrupted run", async () => {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -5377,6 +5377,21 @@ function isTruthyRuntimeEnvValue(value: string | undefined) {
 export const SHUTDOWN_DRAIN_TIMEOUT_DEFAULT_MS = 3 * 60 * 1000;
 export const SHUTDOWN_DRAIN_POLL_INTERVAL_MS = 500;
 
+// Shared across ALL heartbeatService instances (routes and the scheduler each
+// construct their own) so that once graceful shutdown begins EVERY instance's
+// dispatch-suppression check observes the quiesce. If this lived in a single
+// service closure, a dispatch path on a different instance would keep starting
+// new runs mid-drain (only to be interrupted immediately or outlive cleanup).
+// Mirrors activeRunExecutions above, which is module-scoped for the same
+// cross-instance reason. It never resets in production (the process is exiting);
+// resetShutdownDrainingForTests() clears it between test cases.
+let shutdownDraining = false;
+
+/** Test-only: clears the shared graceful-shutdown quiesce flag between cases. */
+export function resetShutdownDrainingForTests(): void {
+  shutdownDraining = false;
+}
+
 export function resolveShutdownDrainTimeoutMs(
   env: Record<string, string | undefined> = process.env,
 ): number {
@@ -5445,9 +5460,9 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     }
     return cachedWorktreeRunExecutionOverride;
   };
-  // Set once graceful shutdown begins so the run engine stops dispatching NEW
-  // runs while in-flight runs drain. It never resets (the process is exiting).
-  let shutdownDraining = false;
+  // shutdownDraining is module-scoped (declared above) so that once graceful
+  // shutdown begins, every heartbeatService instance's suppression check below
+  // observes the quiesce, not just the instance that ran the drain.
   const getSchedulingSuppression = async () => {
     if (shutdownDraining) {
       return { suppressed: true, reason: "server_shutdown" as const };
@@ -9087,7 +9102,13 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         "soft-draining in-flight heartbeat runs before shutdown",
       );
       while (hasInflightRuns() && clock() < deadline) {
-        await sleep(pollIntervalMs);
+        // Cap each wait to the remaining budget so a sub-interval remainder can
+        // never sleep a full poll interval past the deadline. Overrunning would
+        // push the drain (plus the interrupt+retry cleanup that follows) beyond
+        // the timeout and risk a SIGKILL mid-cleanup.
+        const remainingMs = deadline - clock();
+        if (remainingMs <= 0) break;
+        await sleep(Math.min(pollIntervalMs, remainingMs));
       }
       if (hasInflightRuns()) {
         logger.warn(

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -5369,6 +5369,24 @@ function isTruthyRuntimeEnvValue(value: string | undefined) {
   return value === "true" || value === "1" || value === "yes" || value === "on";
 }
 
+// On SIGTERM (every k8s rollout of the single-replica server) we first quiesce
+// new-run dispatch and then WAIT for in-flight runs to finish on their own,
+// bounded by this timeout, before interrupting anything. Keep the default well
+// under the pod terminationGracePeriod so the wait can never be SIGKILL'd
+// mid-drain (the operator is given a matching, longer grace period).
+export const SHUTDOWN_DRAIN_TIMEOUT_DEFAULT_MS = 3 * 60 * 1000;
+export const SHUTDOWN_DRAIN_POLL_INTERVAL_MS = 500;
+
+export function resolveShutdownDrainTimeoutMs(
+  env: Record<string, string | undefined> = process.env,
+): number {
+  const raw = env.PAPERCLIP_SHUTDOWN_DRAIN_TIMEOUT_MS;
+  if (raw == null || raw.trim() === "") return SHUTDOWN_DRAIN_TIMEOUT_DEFAULT_MS;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed < 0) return SHUTDOWN_DRAIN_TIMEOUT_DEFAULT_MS;
+  return parsed;
+}
+
 export function resolveHeartbeatSchedulingSuppression(
   env: Record<string, string | undefined> = process.env,
   overrides: { allowWorktreeRunExecution?: boolean } = {},
@@ -5427,7 +5445,13 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     }
     return cachedWorktreeRunExecutionOverride;
   };
+  // Set once graceful shutdown begins so the run engine stops dispatching NEW
+  // runs while in-flight runs drain. It never resets (the process is exiting).
+  let shutdownDraining = false;
   const getSchedulingSuppression = async () => {
+    if (shutdownDraining) {
+      return { suppressed: true, reason: "server_shutdown" as const };
+    }
     const override = await resolveWorktreeRunExecutionOverride();
     return resolveHeartbeatSchedulingSuppression(runtimeEnv, {
       allowWorktreeRunExecution: override.allowed,
@@ -9021,7 +9045,60 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     };
   }
 
-  async function drainRunningRunsForShutdown(signal: "SIGINT" | "SIGTERM", now = new Date()) {
+  async function drainRunningRunsForShutdown(
+    signal: "SIGINT" | "SIGTERM",
+    now = new Date(),
+    options: {
+      /** Max time to wait for in-flight runs to finish before interrupting. */
+      drainTimeoutMs?: number;
+      /** How often to re-check for in-flight completion while waiting. */
+      pollIntervalMs?: number;
+      /** Injectable sleep (tests). Defaults to a real setTimeout. */
+      sleep?: (ms: number) => Promise<void>;
+      /** Injectable clock (tests) for the wall-clock drain bound. */
+      nowMs?: () => number;
+      /**
+       * Predicate for whether any run is still executing in THIS process.
+       * Defaults to the local in-process execution set; DB-only "running" rows
+       * with no local execution (orphans) are NOT waited for; they can never
+       * finish on their own and are interrupted immediately as before.
+       */
+      hasInflightRuns?: () => boolean;
+    } = {},
+  ) {
+    // 1. Quiesce: stop the scheduler from dispatching NEW runs. Every dispatch/
+    //    execution entrypoint gates on getSchedulingSuppression(), so flipping
+    //    this makes them all no-op for the remainder of the process lifetime.
+    shutdownDraining = true;
+
+    // 2. Soft-drain: give in-flight runs a bounded window to finish on their
+    //    own. Only runs still running at the deadline get interrupted below, so
+    //    a normal rollout no longer interrupts every in-flight run.
+    const drainTimeoutMs = options.drainTimeoutMs ?? resolveShutdownDrainTimeoutMs(runtimeEnv);
+    const pollIntervalMs = Math.max(1, options.pollIntervalMs ?? SHUTDOWN_DRAIN_POLL_INTERVAL_MS);
+    const sleep = options.sleep ?? ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
+    const clock = options.nowMs ?? (() => Date.now());
+    const hasInflightRuns = options.hasInflightRuns ?? (() => activeRunExecutions.size > 0);
+
+    if (drainTimeoutMs > 0 && hasInflightRuns()) {
+      const deadline = clock() + drainTimeoutMs;
+      logger.info(
+        { signal, drainTimeoutMs, pollIntervalMs },
+        "soft-draining in-flight heartbeat runs before shutdown",
+      );
+      while (hasInflightRuns() && clock() < deadline) {
+        await sleep(pollIntervalMs);
+      }
+      if (hasInflightRuns()) {
+        logger.warn(
+          { signal, drainTimeoutMs },
+          "soft-drain deadline reached with in-flight runs remaining; interrupting for restart recovery",
+        );
+      } else {
+        logger.info({ signal }, "in-flight heartbeat runs drained gracefully before shutdown");
+      }
+    }
+
     const activeRuns = await db
       .select({
         run: heartbeatRuns,
@@ -9073,6 +9150,14 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       });
       interrupted = await classifyAndPersistRunLiveness(interrupted, parseObject(interrupted.resultJson)) ?? interrupted;
 
+      // TODO(keep-lease-resume): ideally we would KEEP the sandbox lease here so
+      // restart recovery could reattach to the existing sandbox instead of
+      // provisioning a fresh one and losing partial work. The current retry path
+      // (enqueueProcessLossRetry) starts a brand-new run that provisions its own
+      // environment, so keeping the lease without a reattach-on-retry path would
+      // leak/double-lease the sandbox. Until the resume/reattach path exists we
+      // release the lease and retry from scratch (the safe, correct subset). The
+      // soft-drain above already makes this the rare exception, not the default.
       await releaseEnvironmentLeasesForRun({
         runId: interrupted.id,
         companyId: interrupted.companyId,


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The server drives in-flight agent runs; on a deploy/rollout the pod receives SIGTERM.
> - Today SIGTERM immediately interrupts every running run and releases its sandbox, so a routine rollout kills all in-flight work.
> - A rollout should instead let in-flight runs finish within a bounded window and only interrupt stragglers.
> - This pull request makes shutdown a soft drain: quiesce new dispatch, wait for in-flight runs, interrupt only those past the deadline.
> - The benefit is that ordinary deploys no longer interrupt active runs.

## Linked Issues or Issue Description

No public issue exists; the underlying bug is described inline below, following the bug report template.

**What happened**

On SIGTERM (every rollout of the single-replica server) the shutdown handler immediately terminates every `running` heartbeat run, marks them `server_shutdown_interrupted`, and releases their sandbox leases, so all tenants' in-flight work is interrupted at once and retried from scratch.

**Expected behavior**

A rollout should quiesce new-run dispatch and give in-flight runs a bounded window to finish on their own, interrupting (and retrying) only the runs still running at the deadline.

**Steps to reproduce**

1. Start an agent run and let it be executing.
2. Send the server SIGTERM (deploy/rollout).
3. Observe the still-early run is immediately interrupted with `server_shutdown_interrupted` instead of being allowed to finish.

## What Changed

- On SIGTERM the shutdown handler now sets a `shutdownDraining` flag that quiesces new-run dispatch.
- It then waits (polling) for in-flight local runs to finish, bounded by `PAPERCLIP_SHUTDOWN_DRAIN_TIMEOUT_MS` (default 180000ms), before interrupting anything.
- Only runs still running at the deadline are interrupted + retried as before; DB-only "running" rows are handled as before. An injectable clock/poll interval makes the drain deterministically testable.

## Verification

- New tests beside the existing drain tests: a run that finishes within the window is NOT marked `server_shutdown_interrupted`; new-run dispatch is quiesced during drain; a run still running at the deadline is interrupted+retried; the drain is bounded by the timeout.
- Server typecheck + build clean; affected suites pass.

## Risks

Low-to-moderate. Shutdown now takes up to the drain timeout when runs are in-flight, so the deployment's pod terminationGracePeriod must exceed it (handled by the operator's configurable grace). The timeout is bounded and configurable; at the deadline the previous interrupt+retry behavior is preserved. Keep-lease-resume is intentionally left as a follow-up (no reattach path yet), so stragglers still retry from a fresh sandbox as before.

## Model Used

Claude (Anthropic), model ID `claude-fable-5`, extended reasoning, with tool use / code execution in an agentic harness.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
